### PR TITLE
Adds a -thermo cli option for dumping thermo data to a separate file

### DIFF
--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -1307,6 +1307,7 @@ letter abbreviation can be used:
 -i or -in
 -k or -kokkos
 -l or -log
+-t or -thermo
 -nc or -nocite
 -pk or -package
 -p or -partition
@@ -1464,6 +1465,12 @@ file.N.  For both one-partition and multi-partition mode, if the
 specified file is "none", then no log files are created.  Using a
 "log"_log.html command in the input script will override this setting.
 Option -plog will override the name of the partition log files file.N.
+
+-thermo file :pre
+
+Specify a file for LAMMPS to write thermo output into. If the switch is
+not used, LAMMPS does not create any file. If this switch is used,
+LAMMPS writes to the specified file.
 
 -nocite :pre
 

--- a/doc/thermo_log.txt
+++ b/doc/thermo_log.txt
@@ -1,0 +1,46 @@
+"LAMMPS WWW Site"_lws - "LAMMPS Documentation"_ld - "LAMMPS Commands"_lc :c
+
+:link(lws,http://lammps.sandia.gov)
+:link(ld,Manual.html)
+:link(lc,Section_commands.html#comm)
+
+:line
+
+thermo_log command :h3
+
+[Syntax:]
+
+thermo_log file keyword :pre
+
+file = name of new thermofile
+keyword = {append} if output should be appended to thermofile (optional) :ul
+
+[Examples:]
+
+thermo_log thermo.dat
+thermo_log thermo.dat append :pre
+
+[Description:]
+
+This command closes the current LAMMPS thermo log file, opens a new
+file with the specified name, and begins logging information to it.
+If the specified file name is {none}, then no new log file is opened.
+If the optional keyword {append} is specified, then output will be
+appended to an existing log file, instead of overwriting it.
+
+If multiple processor partitions are being used, the file name should
+be a variable, so that different processors do not attempt to write to
+the same thermo log file.
+
+By default no thermo log file is created during a LAMMPS run.  The
+name of the initial thermo log file can also be set by the command-line
+switch -thermo.  See "Section_start 6"_Section_start.html#start_7 for
+details.
+
+[Restrictions:] none
+
+[Related commands:] none
+
+[Default:]
+
+No thermo log file is created.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -685,6 +685,7 @@ int Input::execute_command()
   else if (!strcmp(command,"thermo")) thermo();
   else if (!strcmp(command,"thermo_modify")) thermo_modify();
   else if (!strcmp(command,"thermo_style")) thermo_style();
+  else if (!strcmp(command,"thermo_log")) thermo_log();
   else if (!strcmp(command,"timestep")) timestep();
   else if (!strcmp(command,"timers")) timers();
   else if (!strcmp(command,"uncompute")) uncompute();
@@ -971,6 +972,34 @@ void Input::log()
       }
     }
     if (universe->nworlds == 1) universe->ulogfile = logfile;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Input::thermo_log()
+{
+  if (narg > 2) error->all(FLERR,"Illegal thermo_log command");
+
+  int appendflag = 0;
+  if (narg == 2) {
+    if (strcmp(arg[1],"append") == 0) appendflag = 1;
+    else error->all(FLERR,"Illegal thermo_log command");
+  }
+
+  if (me == 0) {
+    if (thermofile) fclose(thermofile);
+    if (strcmp(arg[0],"none") == 0) thermofile = NULL;
+    else {
+      if (appendflag) thermofile = fopen(arg[0],"a");
+      else thermofile = fopen(arg[0],"w");
+      if (thermofile == NULL) {
+        char str[128];
+        sprintf(str,"Cannot open thermo log file %s",arg[0]);
+        error->one(FLERR,str);
+      }
+    }
+    if (universe->nworlds == 1) universe->uthermofile = thermofile;
   }
 }
 

--- a/src/input.h
+++ b/src/input.h
@@ -125,6 +125,7 @@ class Input : protected Pointers {
   void thermo();
   void thermo_modify();
   void thermo_style();
+  void thermo_log();
   void timestep();
   void timers();
   void uncompute();

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -41,6 +41,7 @@ class LAMMPS {
   FILE *infile;                  // infile
   FILE *screen;                  // screen output
   FILE *logfile;                 // logfile
+  FILE *thermofile;              // file for thermo output
 
   double initclock;              // wall clock at instantiation
 

--- a/src/pointers.h
+++ b/src/pointers.h
@@ -56,6 +56,7 @@ class Pointers {
     infile(ptr->infile),
     screen(ptr->screen),
     logfile(ptr->logfile),
+    thermofile(ptr->thermofile),
     atomKK(ptr->atomKK) {}
   virtual ~Pointers() {}
 
@@ -81,6 +82,7 @@ class Pointers {
   FILE *&infile;
   FILE *&screen;
   FILE *&logfile;
+  FILE *&thermofile;
 
   class AtomKokkos *&atomKK;
 };

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -210,7 +210,7 @@ void Thermo::init()
   // add '/n' every 3 values if lineflag = MULTILINE
   // add trailing '/n' to last value
 
-  char *ptr;
+  char *ptr = NULL;
   for (i = 0; i < nfield; i++) {
     format[i][0] = '\0';
     if (lineflag == MULTILINE && i % 3 == 0) strcat(format[i],"\n");
@@ -294,6 +294,7 @@ void Thermo::header()
   if (me == 0) {
     if (screen) fprintf(screen,"%s",line);
     if (logfile) fprintf(logfile,"%s",line);
+    if (thermofile) fprintf(thermofile,"%s",line);
   }
 }
 
@@ -363,6 +364,10 @@ void Thermo::compute(int flag)
     if (logfile) {
       fprintf(logfile,"%s",line);
       if (flushflag) fflush(logfile);
+    }
+    if (thermofile) {
+      fprintf(thermofile,"%s",line);
+      if (flushflag) fflush(thermofile);
     }
   }
 }

--- a/src/universe.cpp
+++ b/src/universe.cpp
@@ -39,6 +39,7 @@ Universe::Universe(LAMMPS *lmp, MPI_Comm communicator) : Pointers(lmp)
 
   uscreen = stdout;
   ulogfile = NULL;
+  uthermofile = NULL;
 
   existflag = 0;
   nworlds = 0;

--- a/src/universe.h
+++ b/src/universe.h
@@ -28,6 +28,7 @@ class Universe : protected Pointers {
 
   FILE *uscreen;          // universe screen output
   FILE *ulogfile;         // universe logfile
+  FILE *uthermofile;      // universe thermofile
 
   int existflag;          // 1 if universe exists due to -partition flag
   int nworlds;            // # of worlds in universe


### PR DESCRIPTION
For regression testing it is often useful to directly dump thermo data to a file instead of trying to parse the log file or manually adding fix print commands. The thermo option allows to specify a filename where thermo lines are dumped to. Nothing brand new, just more convenient.