### PR TITLE
TACC/P&G DPD optimization

### DIFF
--- a/src/KSPACE/pair_coul_long.cpp
+++ b/src/KSPACE/pair_coul_long.cpp
@@ -70,6 +70,9 @@ PairCoulLong::~PairCoulLong()
 
 void PairCoulLong::compute(int eflag, int vflag)
 {
+
+  if(cut_coulsq == 0.0) return;
+
   int i,j,ii,jj,inum,jnum,itable,itype,jtype;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
   double fraction,table;

--- a/src/MAKE/MACHINES/Makefile.stampede
+++ b/src/MAKE/MACHINES/Makefile.stampede
@@ -5,15 +5,19 @@ SHELL = /bin/sh
 # ---------------------------------------------------------------------
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
+#
+
+TACC_MKL_LIB = $(MKLROOT)/lib/intel64
+TACC_MKL_INC = $(MKLROOT)/include
 
 CC =		mpicc -openmp -DLMP_INTEL_OFFLOAD -DLAMMPS_MEMALIGN=64
 MIC_OPT =       -offload-option,mic,compiler,"-fp-model fast=2 -mGLOB_default_function_attrs=\"gather_scatter_loop_unroll=4\""
-CCFLAGS =	-O3 -xAVX -fno-alias -ansi-alias -restrict -override-limits $(MIC_OPT)
+CCFLAGS =	-O3 -xhost -fp-model precise -restrict -DVSL_RNG  $(MIC_OPT)
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicc -openmp
-LINKFLAGS =	-O3 -xAVX
+LINKFLAGS =	-O3 -xhost
 LIB =           
 SIZE =		size
 
@@ -29,7 +33,7 @@ SHLIBFLAGS =	-shared
 # LAMMPS ifdef settings
 # see possible settings in Section 2.2 (step 4) of manual
 
-LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_JPEG
+LMP_INC =	-DLAMMPS_GZIP
 
 # MPI library
 # see discussion in Section 2.2 (step 5) of manual
@@ -51,9 +55,10 @@ MPI_LIB =
 # PATH = path for FFT library
 # LIB = name of FFT library
 
-FFT_INC =      -DFFT_MKL -DFFT_SINGLE -I$(TACC_MKL_INC)
+FFT_INC =      -DFFT_MKL  -I$(TACC_MKL_INC)
 FFT_PATH = 
-FFT_LIB =	-L$(TACC_MKL_LIB) -lmkl_intel_ilp64 -lmkl_intel_thread -lmkl_core
+#FFT_LIB =	-L$(TACC_MKL_LIB) -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core
+FFT_LIB =	-L$(TACC_MKL_LIB) -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -lm
 
 # JPEG and/or PNG library
 # see discussion in Section 2.2 (step 7) of manual
@@ -73,11 +78,9 @@ JPG_LIB =	-ljpeg
 include	Makefile.package.settings
 include	Makefile.package
 
-EXTRA_INC = $(LMP_INC) $(PKG_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC) $(PKG_SYSINC)
-EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
-EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB)
-EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
-EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
+EXTRA_INC =  $(LMP_INC) $(PKG_INC)  $(MPI_INC)  $(FFT_INC)  $(JPG_INC)  $(PKG_SYSINC)
+EXTRA_PATH =            $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB =             $(PKG_LIB)  $(MPI_LIB)  $(FFT_LIB)  $(JPG_LIB)  $(PKG_SYSLIB)
 
 # Path to src files
 
@@ -86,28 +89,28 @@ vpath %.h ..
 
 # Link target
 
-$(EXE):	$(OBJ) $(EXTRA_LINK_DEPENDS)
+$(EXE):	$(OBJ)
 	$(LINK) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(EXTRA_LIB) $(LIB) -o $(EXE)
 	$(SIZE) $(EXE)
 
 # Library targets
 
-lib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+lib:	$(OBJ)
 	$(ARCHIVE) $(ARFLAGS) $(EXE) $(OBJ)
 
-shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(SHLIBFLAGS) $(EXTRA_PATH) -o $(EXE) \
         $(OBJ) $(EXTRA_LIB) $(LIB)
 
 # Compilation rules
 
-%.o:%.cpp $(EXTRA_CPP_DEPENDS)
+%.o:%.cpp
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
-%.d:%.cpp $(EXTRA_CPP_DEPENDS)
+%.d:%.cpp
 	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
 
-%.o:%.cu $(EXTRA_CPP_DEPENDS)
+%.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 # Individual dependencies

--- a/src/pair_dpd.h
+++ b/src/pair_dpd.h
@@ -22,6 +22,11 @@ PairStyle(dpd,PairDPD)
 
 #include "pair.h"
 
+#ifdef VSL_RNG
+#include "mkl_vsl.h"
+#define LEN_R_LIST	(512)
+#endif
+
 namespace LAMMPS_NS {
 
 class PairDPD : public Pair {
@@ -48,6 +53,11 @@ class PairDPD : public Pair {
   double **a0,**gamma;
   double **sigma;
   class RanMars *random;
+#ifdef VSL_RNG
+  VSLStreamStatePtr stream;
+  int r_count;
+  double r_list[LEN_R_LIST];
+#endif
 
   void allocate();
 };


### PR DESCRIPTION
Use Intel Vector RNG in pair_dpd, return if cut_coulsq == 0.0 in pair_coul_long compute, new stampede Makefile.  ~10% faster for Vector RNG, and 27% faster for special case cut_coulsq=0.0.  (Compiler Define used to turn on vector random number generator.)  P&G: Peter Kroenig, TACC: Lei Huang & Kent Milfeld.