### PR TITLE
Added README and Makefile.lammps variants to lib/vtk

### DIFF
--- a/lib/vtk/Makefile.lammps.arch_vtk6
+++ b/lib/vtk/Makefile.lammps.arch_vtk6
@@ -1,0 +1,4 @@
+# Settings that the LAMMPS build will import when this package library is used
+vtk_SYSINC = -I/usr/include/vtk
+vtk_SYSLIB = -lvtkCommonCore -lvtkIOCore -lvtkIOXML -lvtkIOParallelXML -lvtkIOLegacy -lvtkCommonDataModel
+vtk_SYSPATH =

--- a/lib/vtk/Makefile.lammps.centos6_vtk5
+++ b/lib/vtk/Makefile.lammps.centos6_vtk5
@@ -1,0 +1,16 @@
+# Settings that the LAMMPS build will import when this package library is used
+#
+# CentOS 6 installation of VTK5 library:
+# --------------------------------------
+#
+# Install the EPEL repository:
+#
+# $ sudo yum install epel-release
+#
+# Install VTK5 from the EPEL repository:
+#
+# $ sudo yum install vtk-devel
+#
+vtk_SYSINC = -I/usr/include/vtk
+vtk_SYSLIB = -lvtkCommon -lvtkFiltering -lvtkIO
+vtk_SYSPATH = -L/usr/lib64/vtk

--- a/lib/vtk/Makefile.lammps.centos7_vtk6
+++ b/lib/vtk/Makefile.lammps.centos7_vtk6
@@ -1,0 +1,16 @@
+# Settings that the LAMMPS build will import when this package library is used
+#
+# CentOS 7 installation of VTK6 library:
+# --------------------------------------
+#
+# Install the EPEL repository:
+#
+# $ sudo yum install epel-release
+#
+# Install VTK6 from the EPEL repository:
+#
+# $ sudo yum install vtk-devel
+#
+vtk_SYSINC = -I/usr/include/vtk
+vtk_SYSLIB = -lvtkCommonCore -lvtkIOCore -lvtkIOXML -lvtkIOLegacy -lvtkCommonDataModel
+vtk_SYSPATH = -L/usr/lib64/vtk

--- a/lib/vtk/Makefile.lammps.ubuntu14.04_vtk5
+++ b/lib/vtk/Makefile.lammps.ubuntu14.04_vtk5
@@ -1,0 +1,12 @@
+# Settings that the LAMMPS build will import when this package library is used
+#
+# Ubuntu 14.04 installation of VTK5 library:
+# ------------------------------------------
+#
+# Execute the following installation command:
+#
+# $ sudo apt-get install libvtk5-dev
+#
+vtk_SYSINC = -I/usr/include/vtk-5.8
+vtk_SYSLIB = -lvtkCommon -lvtkFiltering -lvtkIO
+vtk_SYSPATH =

--- a/lib/vtk/Makefile.lammps.ubuntu14.04_vtk6
+++ b/lib/vtk/Makefile.lammps.ubuntu14.04_vtk6
@@ -1,0 +1,12 @@
+# Settings that the LAMMPS build will import when this package library is used
+#
+# Ubuntu 14.04 installation of VTK6 library:
+# ------------------------------------------
+#
+# Execute the following installation command:
+#
+# $ sudo apt-get install libvtk6-dev
+#
+vtk_SYSINC = -I/usr/include/vtk-6.0
+vtk_SYSLIB = -lvtkCommonCore-6.0 -lvtkIOCore-6.0 -lvtkIOXML-6.0 -lvtkIOLegacy-6.0 -lvtkCommonDataModel-6.0
+vtk_SYSPATH =

--- a/lib/vtk/README
+++ b/lib/vtk/README
@@ -1,0 +1,28 @@
+The Makefile.lammps file in this directory is used when building LAMMPS with
+its USER-VTK package installed.  The file has several settings needed to
+compile and link LAMMPS with the VTK library.  You should choose a
+Makefile.lammps.* file compatible with your system and your version of VTK, and
+copy it to Makefile.lammps before building LAMMPS itself.  You may need to edit
+one of the provided files to match your system.
+
+If you create a new Makefile.lammps file suitable for some version of VTK on
+some system, that is not a match to one of the provided Makefile.lammps.*
+files, you can send it to the developers, and we can include it in the
+distribution for others to use.
+
+To illustrate, these are example settings from the
+Makefile.lammps.ubuntu14.04_vtk6 file:
+
+vtk_SYSINC = -I/usr/include/vtk-6.0
+vtk_SYSLIB = -lvtkCommonCore-6.0 -lvtkIOCore-6.0 -lvtkIOXML-6.0 -lvtkIOLegacy-6.0 -lvtkCommonDataModel-6.0
+vtk_SYSPATH =
+
+vtk_SYSINC refers to the include directory of the installed VTK library
+
+vtk_SYSLIB refers to the libraries needed to link to from an application
+(LAMMPS in this case) to "embed" VTK in the application. VTK consists of
+multiple shared libraries which are needed when using the USER-VTK package.
+
+vtk_SYSPATH = refers to the path (e.g. -L/usr/local/lib) where the VTK library
+can be found.  You may not need this setting if the path is already included in
+your LD_LIBRARY_PATH environment variable.

--- a/src/USER-VTK/README
+++ b/src/USER-VTK/README
@@ -15,7 +15,3 @@ Computing. This is an effort to integrate it back to LAMMPS.
 
 The person who created this package is Richard Berger at JKU
 (richard.berger@jku.at). Contact him directly if you have questions.
-
----------------------------------
-
-Version: <not-released-yet>


### PR DESCRIPTION
This includes examples and documentation of how to install VTK on Ubuntu, CentOS and Arch.