### PR TITLE
Make .d files dependent on source files as well

### DIFF
--- a/src/MAKE/MACHINES/Makefile.beacon
+++ b/src/MAKE/MACHINES/Makefile.beacon
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.bgl
+++ b/src/MAKE/MACHINES/Makefile.bgl
@@ -110,7 +110,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.bgq
+++ b/src/MAKE/MACHINES/Makefile.bgq
@@ -45,7 +45,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.chama
+++ b/src/MAKE/MACHINES/Makefile.chama
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.cygwin
+++ b/src/MAKE/MACHINES/Makefile.cygwin
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.glory
+++ b/src/MAKE/MACHINES/Makefile.glory
@@ -121,7 +121,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.jaguar
+++ b/src/MAKE/MACHINES/Makefile.jaguar
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.mac
+++ b/src/MAKE/MACHINES/Makefile.mac
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.mac_mpi
+++ b/src/MAKE/MACHINES/Makefile.mac_mpi
@@ -107,7 +107,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.mingw32-cross
+++ b/src/MAKE/MACHINES/Makefile.mingw32-cross
@@ -109,7 +109,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.mingw32-cross-mpi
+++ b/src/MAKE/MACHINES/Makefile.mingw32-cross-mpi
@@ -109,7 +109,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.mingw64-cross
+++ b/src/MAKE/MACHINES/Makefile.mingw64-cross
@@ -109,7 +109,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.mingw64-cross-mpi
+++ b/src/MAKE/MACHINES/Makefile.mingw64-cross-mpi
@@ -109,7 +109,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.myrinet
+++ b/src/MAKE/MACHINES/Makefile.myrinet
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.power
+++ b/src/MAKE/MACHINES/Makefile.power
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.redsky
+++ b/src/MAKE/MACHINES/Makefile.redsky
@@ -124,7 +124,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.serial
+++ b/src/MAKE/MACHINES/Makefile.serial
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.stampede
+++ b/src/MAKE/MACHINES/Makefile.stampede
@@ -103,7 +103,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.storm
+++ b/src/MAKE/MACHINES/Makefile.storm
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.tacc
+++ b/src/MAKE/MACHINES/Makefile.tacc
@@ -107,7 +107,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.ubuntu
+++ b/src/MAKE/MACHINES/Makefile.ubuntu
@@ -108,7 +108,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.ubuntu_simple
+++ b/src/MAKE/MACHINES/Makefile.ubuntu_simple
@@ -107,7 +107,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.xe6
+++ b/src/MAKE/MACHINES/Makefile.xe6
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.xt3
+++ b/src/MAKE/MACHINES/Makefile.xt3
@@ -106,7 +106,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MACHINES/Makefile.xt5
+++ b/src/MAKE/MACHINES/Makefile.xt5
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.clang
+++ b/src/MAKE/MINE/Makefile.clang
@@ -102,7 +102,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.g++
+++ b/src/MAKE/MINE/Makefile.g++
@@ -100,7 +100,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.intel
+++ b/src/MAKE/MINE/Makefile.intel
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.openmpi-big
+++ b/src/MAKE/MINE/Makefile.openmpi-big
@@ -98,7 +98,8 @@ lib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 # Individual dependencies
 

--- a/src/MAKE/MINE/Makefile.openmpi-clang
+++ b/src/MAKE/MINE/Makefile.openmpi-clang
@@ -99,7 +99,8 @@ lib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 # Individual dependencies
 

--- a/src/MAKE/MINE/Makefile.openmpi-intel
+++ b/src/MAKE/MINE/Makefile.openmpi-intel
@@ -106,7 +106,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.openmpi-omp
+++ b/src/MAKE/MINE/Makefile.openmpi-omp
@@ -110,7 +110,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.openmpi-omp-intel
+++ b/src/MAKE/MINE/Makefile.openmpi-omp-intel
@@ -106,7 +106,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.openmpi-single
+++ b/src/MAKE/MINE/Makefile.openmpi-single
@@ -101,7 +101,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.openmpi-small
+++ b/src/MAKE/MINE/Makefile.openmpi-small
@@ -106,7 +106,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/MINE/Makefile.serial-clang
+++ b/src/MAKE/MINE/Makefile.serial-clang
@@ -100,7 +100,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 # Individual dependencies
 

--- a/src/MAKE/MINE/Makefile.serial-intel
+++ b/src/MAKE/MINE/Makefile.serial-intel
@@ -103,7 +103,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/Makefile.mpi
+++ b/src/MAKE/Makefile.mpi
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/Makefile.serial
+++ b/src/MAKE/Makefile.serial
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.fftw
+++ b/src/MAKE/OPTIONS/Makefile.fftw
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.intel_cpu
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu
@@ -107,7 +107,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.intel_knl
+++ b/src/MAKE/OPTIONS/Makefile.intel_knl
@@ -104,7 +104,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.intel_phi
+++ b/src/MAKE/OPTIONS/Makefile.intel_phi
@@ -107,7 +107,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.jpeg
+++ b/src/MAKE/OPTIONS/Makefile.jpeg
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.knl
+++ b/src/MAKE/OPTIONS/Makefile.knl
@@ -105,7 +105,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.kokkos_cuda
+++ b/src/MAKE/OPTIONS/Makefile.kokkos_cuda
@@ -109,7 +109,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.kokkos_omp
+++ b/src/MAKE/OPTIONS/Makefile.kokkos_omp
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.kokkos_phi
+++ b/src/MAKE/OPTIONS/Makefile.kokkos_phi
@@ -106,7 +106,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.mpi_fastmgpt
+++ b/src/MAKE/OPTIONS/Makefile.mpi_fastmgpt
@@ -102,7 +102,8 @@ shlib:	$(OBJ)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.mpich_g++
+++ b/src/MAKE/OPTIONS/Makefile.mpich_g++
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.mpich_icc
+++ b/src/MAKE/OPTIONS/Makefile.mpich_icc
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.mpich_native_g++
+++ b/src/MAKE/OPTIONS/Makefile.mpich_native_g++
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.mpich_native_icc
+++ b/src/MAKE/OPTIONS/Makefile.mpich_native_icc
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.omp
+++ b/src/MAKE/OPTIONS/Makefile.omp
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.ompi_g++
+++ b/src/MAKE/OPTIONS/Makefile.ompi_g++
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.ompi_icc
+++ b/src/MAKE/OPTIONS/Makefile.ompi_icc
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.ompi_native_g++
+++ b/src/MAKE/OPTIONS/Makefile.ompi_native_g++
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.ompi_native_icc
+++ b/src/MAKE/OPTIONS/Makefile.ompi_native_icc
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.opt
+++ b/src/MAKE/OPTIONS/Makefile.opt
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.pgi
+++ b/src/MAKE/OPTIONS/Makefile.pgi
@@ -105,7 +105,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.png
+++ b/src/MAKE/OPTIONS/Makefile.png
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<

--- a/src/MAKE/OPTIONS/Makefile.serial_icc
+++ b/src/MAKE/OPTIONS/Makefile.serial_icc
@@ -104,7 +104,8 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
 
 %.d:%.cpp $(EXTRA_CPP_DEPENDS)
-	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+	{ $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< || kill $$$$; } | \
+	  sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' > $@
 
 %.o:%.cu $(EXTRA_CPP_DEPENDS)
 	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<


### PR DESCRIPTION
This way make detects if the dependencies need to be recalculated (the *.d* rebuilt) and does so.  The failure case this closes is building, then editing a source to add a header, then building, then editing the header, and then building.  The last build won't rebuild as dependencies are based on the first build.

The code is basically a rip off of what is given in the make info documentation.