### PR TITLE
.travis.yml: move to container-based intrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,23 @@
 language: cpp
 
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - ccache
+      - gfortran
+      - openmpi-bin
+      - libopenmpi-dev
+      - libfftw3-dev
+      - libjpeg-dev
+      - libpng12-dev
+      - python-dev
+      - libblas-dev
+      - liblapack-dev
+      - libhdf5-serial-dev
+      - hdf5-tools
+
 notifications:
   email:
     recipients:
@@ -10,10 +28,6 @@ notifications:
 compiler:
   - gcc
   - clang
-
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y gfortran mpi-default-bin mpi-default-dev libfftw3-dev libjpeg-dev libpng12-dev python-dev libblas-dev liblapack-dev libhdf5-serial-dev hdf5-tools
 
 env:
   - MACH=shlib LMPFLAGS="-sf off" LMP_INC="-I../../src/STUBS -DFFT_KISSFFT -DLAMMPS_GZIP -DLAMMPS_PNG -DLAMMPS_JPEG" JPG_LIB="-L../../src/STUBS/ -lmpi_stubs -ljpeg -lpng -lz"
@@ -44,3 +58,7 @@ script:
   - test "$MACH" = shlib || make -C src test-${MACH} MPICMD="${MPICMD}" CC="${COMP}" LINK="${COMP}" LMP_INC="${LMP_INC}" JPG_LIB="${JPG_LIB}" TAG="${TAG}-$CC" LMPFLAGS="${LMPFLAGS}"
   - if [ "$MACH" = shlib ] ; then  make -C src mode=shlib serial MACH=serial MPICMD="${MPICMD}" CC="${COMP}" LINK="${COMP}" LMP_INC="${LMP_INC}" JPG_LIB="${JPG_LIB}" TAG="${TAG}-$CC" LMPFLAGS="${LMPFLAGS}" && make -C test python MACH=serial MPICMD="${MPICMD}" CC="${COMP}" LINK="${COMP}" LMP_INC="${LMP_INC}" JPG_LIB="${JPG_LIB}" TAG="${TAG}-$CC" LMPFLAGS="${LMPFLAGS}" || exit 1 ; fi
   - if [ "$MACH" != shlib ] ; then make -C src mode=lib ${MACH} MPICMD="${MPICMD}" CC="${COMP}" LINK="${COMP}" LMP_INC="${LMP_INC}" JPG_LIB="${JPG_LIB}" TAG="${TAG}-$CC" LMPFLAGS="${LMPFLAGS}" && make -C test couple MACH="${MACH}" MPICMD="${MPICMD}" CC="${COMP}" LINK="${COMP}" LMP_INC="${LMP_INC}" JPG_LIB="${JPG_LIB}" TAG="${TAG}-$CC" LMPFLAGS="${LMPFLAGS}" || exit 1 ; fi
+
+cache:
+  directories:
+    - $HOME/.ccache


### PR DESCRIPTION
Container-based infrastructure see:
https://docs.travis-ci.com/user/workers/container-based-infrastructure/

In short:

- start up faster
- allow the use of caches for public repositories
- disallow the use of sudo, setuid and setgid executables

It currently breaks because on one of mpi tests takes too long (or didn't output anything for 10mins).