### PR TITLE
Added OMP-enabled pair_morse_smooth_linear

### DIFF
--- a/doc/pair_morse.txt
+++ b/doc/pair_morse.txt
@@ -12,6 +12,7 @@ pair_style morse/gpu command :h3
 pair_style morse/omp command :h3
 pair_style morse/opt command :h3
 pair_style morse/smooth/linear command :h3
+pair_style morse/smooth/linear/omp command :h3
 
 [Syntax:]
 

--- a/src/USER-OMP/pair_morse_smooth_linear_omp.cpp
+++ b/src/USER-OMP/pair_morse_smooth_linear_omp.cpp
@@ -1,0 +1,169 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Stefan Paquay (Eindhoven University of Technology)
+   Most code stolen from pair_morse_omp.cpp
+------------------------------------------------------------------------- */
+
+#include <math.h>
+#include "pair_morse_smooth_linear_omp.h"
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+
+#include "suffix.h"
+using namespace LAMMPS_NS;
+
+
+/* ---------------------------------------------------------------------- */
+
+PairMorseSmoothLinearOMP::PairMorseSmoothLinearOMP(LAMMPS *lmp) :
+  PairMorseSmoothLinear(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+
+
+/* ---------------------------------------------------------------------- */
+
+void PairMorseSmoothLinearOMP::compute(int eflag, int vflag)
+{
+  if (eflag || vflag) {
+    ev_setup(eflag,vflag);
+  } else evflag = vflag_fdotr = 0;
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel default(none) shared(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairMorseSmoothLinearOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair,fpartial;
+  double rsq,r,dr,dexp,factor_lj;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = 0.0;
+
+  const dbl3_t * _noalias const x = (dbl3_t *) atom->x[0];
+  dbl3_t * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int * _noalias const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * _noalias const special_lj = force->special_lj;
+  double fxtmp,fytmp,fztmp;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+
+    i = ilist[ii];
+    xtmp = x[i].x;
+    ytmp = x[i].y;
+    ztmp = x[i].z;
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+    fxtmp=fytmp=fztmp=0.0;
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j].x;
+      dely = ytmp - x[j].y;
+      delz = ztmp - x[j].z;
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        r = sqrt(rsq);
+        dr = r - r0[itype][jtype];
+        dexp = exp(-alpha[itype][jtype] * dr);
+
+        fpartial = morse1[itype][jtype] * (dexp*dexp - dexp) / r;
+        fpair = factor_lj * ( fpartial - der_at_cutoff[itype][jtype] / r);
+
+        fxtmp += delx*fpair;
+        fytmp += dely*fpair;
+        fztmp += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j].x -= delx*fpair;
+          f[j].y -= dely*fpair;
+          f[j].z -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          evdwl = d0[itype][jtype] * (dexp*dexp - 2.0*dexp) -
+	          offset[itype][jtype];
+          evdwl += ( r - cut[itype][jtype] ) * der_at_cutoff[itype][jtype];
+          evdwl *= factor_lj;
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,0.0,fpair,delx,dely,delz,thr);
+      }
+    }
+    f[i].x += fxtmp;
+    f[i].y += fytmp;
+    f[i].z += fztmp;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairMorseSmoothLinearOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairMorseSmoothLinear::memory_usage();
+
+  return bytes;
+}

--- a/src/USER-OMP/pair_morse_smooth_linear_omp.h
+++ b/src/USER-OMP/pair_morse_smooth_linear_omp.h
@@ -1,0 +1,65 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+  -------------------------------------------------------------------------
+  Contributed by Stefan Paquay @ Eindhoven University of Technology
+  Most code stolen from pair_morse_omp.h
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(morse/smooth/linear/omp,PairMorseSmoothLinearOMP)
+
+#else
+
+#ifndef LMP_PAIR_MORSE_SMOOTH_LINEAR_OMP_H
+#define LMP_PAIR_MORSE_SMOOTH_LINEAR_OMP_H
+
+#include "pair_morse_smooth_linear.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairMorseSmoothLinearOMP : public PairMorseSmoothLinear, public ThrOMP {
+ public:
+  PairMorseSmoothLinearOMP(class LAMMPS *);
+
+  virtual void compute(int, int);
+  virtual double memory_usage();
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval( int ifrom, int ito, ThrData * const thr );
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Incorrect args for pair coefficients
+
+Self-explanatory.  Check the input script or data file.
+
+E: All pair coeffs are not set
+
+All pair coefficients must be set in the data file or by the
+pair_coeff command before running a simulation.
+
+*/


### PR DESCRIPTION
I copy-pasted pretty much everything from pair_morse_omp.{cpp,h}, copy-pasted the force formula, done. It produces similar thermo (same up until a few hundred time steps) as pair_morse_smooth_linear, runs about twice as fast on my i7.

I also added an entry to the documentation of pair_morse.txt. I am just not sure if this belongs in USER-MISC or USER-OMP.