### PR TITLE
Correction of lammps_gather_atoms and lammps_scatter_atoms

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -417,8 +417,11 @@ void lammps_gather_atoms(void *ptr, char *name,
   int flag = 0;
   if (lmp->atom->tag_enable == 0 || lmp->atom->tag_consecutive() == 0) flag = 1;
   if (lmp->atom->natoms > MAXSMALLINT) flag = 1;
-  if (flag && lmp->comm->me == 0) {
-    lmp->error->warning(FLERR,"Library error in lammps_gather_atoms");
+  /// check if error exists, then exit on all procs
+  if (flag) {
+    if (lmp->comm->me == 0) {
+       lmp->error->warning(FLERR,"Library error in lammps_gather_atoms");
+    }
     return;
   }
 
@@ -506,10 +509,16 @@ void lammps_scatter_atoms(void *ptr, char *name,
   if (lmp->atom->tag_enable == 0 || lmp->atom->tag_consecutive() == 0) flag = 1;
   if (lmp->atom->natoms > MAXSMALLINT) flag = 1;
   if (lmp->atom->map_style == 0) flag = 1;
-  if (flag && lmp->comm->me == 0) {
-    lmp->error->warning(FLERR,"Library error in lammps_scatter_atoms");
+  
+  /// check if error exists, then exit on all procs
+  if (flag) {
+    if (lmp->comm->me == 0) {
+       lmp->error->warning(FLERR,"Library error in lammps_scatter_atoms");
+    }
     return;
   }
+
+
 
   int natoms = static_cast<int> (lmp->atom->natoms);
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -411,12 +411,11 @@ void lammps_gather_atoms(void *ptr, char *name,
                          int type, int count, void *data)
 {
   LAMMPS *lmp = (LAMMPS *) ptr;
-
   // error if tags are not defined or not consecutive
-
   int flag = 0;
   if (lmp->atom->tag_enable == 0 || lmp->atom->tag_consecutive() == 0) flag = 1;
   if (lmp->atom->natoms > MAXSMALLINT) flag = 1;
+
   /// check if error exists, then exit on all procs
   if (flag) {
     if (lmp->comm->me == 0) {
@@ -502,9 +501,7 @@ void lammps_scatter_atoms(void *ptr, char *name,
                           int type, int count, void *data)
 {
   LAMMPS *lmp = (LAMMPS *) ptr;
-
   // error if tags are not defined or not consecutive or no atom map
-
   int flag = 0;
   if (lmp->atom->tag_enable == 0 || lmp->atom->tag_consecutive() == 0) flag = 1;
   if (lmp->atom->natoms > MAXSMALLINT) flag = 1;
@@ -517,8 +514,6 @@ void lammps_scatter_atoms(void *ptr, char *name,
     }
     return;
   }
-
-
 
   int natoms = static_cast<int> (lmp->atom->natoms);
 


### PR DESCRIPTION
When an error is detected (i.e. flag is set) an error message should be printed only on rank 0,
and all ranks should return (as suggested by @akohlmey).