### PR TITLE
Pair zero update

### DIFF
--- a/src/pair_zero.cpp
+++ b/src/pair_zero.cpp
@@ -68,7 +68,7 @@ void PairZero::allocate()
   memory->create(setflag,n+1,n+1,"pair:setflag");
   for (int i = 1; i <= n; i++)
     for (int j = i; j <= n; j++)
-      setflag[i][j] = 1;
+      setflag[i][j] = 0;
 
   memory->create(cutsq,n+1,n+1,"pair:cutsq");
   memory->create(cut,n+1,n+1,"pair:cut");
@@ -121,6 +121,7 @@ void PairZero::coeff(int narg, char **arg)
   for (int i = ilo; i <= ihi; i++) {
     for (int j = MAX(jlo,i); j <= jhi; j++) {
       cut[i][j] = cut_one;
+      setflag[i][j] = 1;
       count++;
     }
   }

--- a/src/pair_zero.cpp
+++ b/src/pair_zero.cpp
@@ -30,7 +30,10 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairZero::PairZero(LAMMPS *lmp) : Pair(lmp), coeffflag(1) {}
+PairZero::PairZero(LAMMPS *lmp) : Pair(lmp) {
+  coeffflag=1;
+  writedata=1;
+}
 
 /* ---------------------------------------------------------------------- */
 
@@ -204,4 +207,26 @@ void PairZero::read_restart_settings(FILE *fp)
   MPI_Bcast(&cut_global,1,MPI_DOUBLE,0,world);
   MPI_Bcast(&coeffflag,1,MPI_INT,0,world);
 }
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void PairZero::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->ntypes; i++)
+    fprintf(fp,"%d\n",i);
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes all pairs to data file
+------------------------------------------------------------------------- */
+
+void PairZero::write_data_all(FILE *fp)
+{
+  for (int i = 1; i <= atom->ntypes; i++)
+    for (int j = i; j <= atom->ntypes; j++)
+      fprintf(fp,"%d %d %g\n",i,j,cut[i][j]);
+}
+
 

--- a/src/pair_zero.cpp
+++ b/src/pair_zero.cpp
@@ -88,10 +88,12 @@ void PairZero::settings(int narg, char **arg)
 
   // reset cutoffs that have been explicitly set
 
-  int i,j;
-  for (i = 1; i <= atom->ntypes; i++)
-    for (j = i+1; j <= atom->ntypes; j++)
-         cut[i][j] = cut_global;
+  if (allocated) {
+    int i,j;
+    for (i = 1; i <= atom->ntypes; i++)
+      for (j = i+1; j <= atom->ntypes; j++)
+        cut[i][j] = cut_global;
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/pair_zero.h
+++ b/src/pair_zero.h
@@ -46,6 +46,8 @@ class PairZero : public Pair {
   void read_restart(FILE *);
   void write_restart_settings(FILE *);
   void read_restart_settings(FILE *);
+  void write_data(FILE *);
+  void write_data_all(FILE *);
 
  protected:
   double cut_global;


### PR DESCRIPTION
This change will fix an issue with pair style zero where using
```
pair_coeff * * 10.0
```
would cause a segfault due to the global reset is not protected against "allocated" being true. This is fixed in commit  5c16aa0.

Also it adds support for writing coefficients (i.e. cutoffs) to data files. see commit 4a51187

Finally, the behavior with respect to setting coefficients is made consistent with other pair styles by initializing setflag to 0 and then assigning setflag[i][j] as coefficients are set. Fixed in commit f627a42