### PR TITLE
Fixed deprecated CUDA Driver feature.

### DIFF
--- a/lib/gpu/Makefile.lammps.standard
+++ b/lib/gpu/Makefile.lammps.standard
@@ -2,4 +2,4 @@
 
 gpu_SYSINC =
 gpu_SYSLIB = -lcudart -lcuda
-gpu_SYSPATH = -L/usr/local/cuda/lib64
+gpu_SYSPATH = -L$(CUDA_HOME)/lib64

--- a/lib/gpu/geryon/nvd_device.h
+++ b/lib/gpu/geryon/nvd_device.h
@@ -229,7 +229,11 @@ class UCL_Device {
   /// Returns false if accelerator cannot be shared by multiple processes
   /** If it cannot be determined, true is returned **/
   inline bool sharing_supported(const int i)
+#if CUDA_VERSION >= 8000
+    { return (_properties[i].computeMode == CU_COMPUTEMODE_EXCLUSIVE_PROCESS); }
+#else
     { return (_properties[i].computeMode == CU_COMPUTEMODE_DEFAULT); }
+#endif
 
   /// True if splitting device into equal subdevices supported
   inline bool fission_equal()
@@ -432,7 +436,11 @@ void UCL_Device::print_all(std::ostream &out) {
     out << "  Compute mode:                                  ";
     if (_properties[i].computeMode == CU_COMPUTEMODE_DEFAULT)
       out << "Default\n"; // multiple threads can use device
+#if CUDA_VERSION >= 8000
+    else if (_properties[i].computeMode == CU_COMPUTEMODE_EXCLUSIVE_PROCESS)
+#else
     else if (_properties[i].computeMode == CU_COMPUTEMODE_EXCLUSIVE)
+#endif
       out << "Exclusive\n"; // only thread can use device
     else if (_properties[i].computeMode == CU_COMPUTEMODE_PROHIBITED)
       out << "Prohibited\n"; // no thread can use device


### PR DESCRIPTION
- Thread-exclusive mode was deprecated in 7.5, this change changed nvd_device.h
to use process-exclusive mode instead.
- Additionally, changed lib/gpu/Makefile.lammps.standard to not use a direct
path, but rather use the commonly-used CUDA_HOME variable, which should work
better on machines where environment modules are used.