### PR TITLE
Remove "if" inside goes-at-least-once loop in RanMars/RanPark::gaussian()

### DIFF
--- a/src/random_mars.cpp
+++ b/src/random_mars.cpp
@@ -97,13 +97,11 @@ double RanMars::gaussian()
   double first,v1,v2,rsq,fac;
 
   if (!save) {
-    int again = 1;
-    while (again) {
+    do {
       v1 = 2.0*uniform()-1.0;
       v2 = 2.0*uniform()-1.0;
       rsq = v1*v1 + v2*v2;
-      if (rsq < 1.0 && rsq != 0.0) again = 0;
-    }
+    } while ((rsq >= 1.0) || (rsq == 0.0));
     fac = sqrt(-2.0*log(rsq)/rsq);
     second = v1*fac;
     first = v2*fac;

--- a/src/random_park.cpp
+++ b/src/random_park.cpp
@@ -57,13 +57,11 @@ double RanPark::gaussian()
   double first,v1,v2,rsq,fac;
 
   if (!save) {
-    int again = 1;
-    while (again) {
+    do {
       v1 = 2.0*uniform()-1.0;
       v2 = 2.0*uniform()-1.0;
       rsq = v1*v1 + v2*v2;
-      if (rsq < 1.0 && rsq != 0.0) again = 0;
-    }
+    } while ((rsq >= 1.0) || (rsq == 0.0));
     fac = sqrt(-2.0*log(rsq)/rsq);
     second = v1*fac;
     first = v2*fac;


### PR DESCRIPTION
Remove "if" inside goes-at-least-once loop in RanMars/RanPark::gaussian()
Most compilers probably already do this optimization, but it shouldn't hurt.