### PR TITLE
Move when and where the SSA AIR number is calulated and stored (used by USER-DPD).

### DIFF
--- a/src/USER-DPD/atom_vec_dpd.h
+++ b/src/USER-DPD/atom_vec_dpd.h
@@ -60,12 +60,15 @@ class AtomVecDPD : public AtomVec {
   bigint memory_usage();
   double *uCond,*uMech,*uChem,*uCG,*uCGnew,*rho,*dpdTheta;
   double *duCond,*duMech,*duChem;
+  int *ssaAIR; // Shardlow Splitting Algorithm Active Interaction Region number
 
  protected:
   tagint *tag;
   int *type,*mask;
   imageint *image;
   double **x,**v,**f;
+
+  int coord2ssaAIR(double *);  // map atom coord to an AIR number
 };
 
 }

--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -113,7 +113,6 @@ int FixShardlow::setmask()
 {
   int mask = 0;
   mask |= INITIAL_INTEGRATE;
-  mask |= PRE_NEIGHBOR;
   return mask;
 }
 
@@ -180,6 +179,7 @@ void FixShardlow::initial_integrate(int vflag)
   int newton_pair = force->newton_pair;
   double randPair;
 
+  int *ssaAIR = atom->ssaAIR;
   double *uCond = atom->uCond;
   double *uMech = atom->uMech;
   double *duCond = atom->duCond;
@@ -263,7 +263,7 @@ void FixShardlow::initial_integrate(int vflag)
       for (jj = 0; jj < jnum; jj++) {
 	j = jlist[jj];
 	j &= NEIGHMASK;
-	if (neighbor->ssa_airnum[j] != idir) continue;
+	if (ssaAIR[j] != idir) continue;
 	jtype = type[j];
 	
 	delx = xtmp - x[j][0];
@@ -455,20 +455,6 @@ void FixShardlow::initial_integrate(int vflag)
     delete dvSSA[ii];
   }
   delete [] dvSSA;
-}
-
-/* ----------------------------------------------------------------------
- *    assign owned and ghost atoms their ssa active interaction region numbers
-------------------------------------------------------------------------- */
-
-void FixShardlow::setup_pre_neighbor()
-{
-  neighbor->assign_ssa_airnums();
-}
-
-void FixShardlow::pre_neighbor()
-{
-  neighbor->assign_ssa_airnums();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-DPD/fix_shardlow.h
+++ b/src/USER-DPD/fix_shardlow.h
@@ -34,9 +34,6 @@ class FixShardlow : public Fix {
   virtual void setup_pre_force(int);
   virtual void initial_integrate(int);
 
-  void setup_pre_neighbor();
-  void pre_neighbor();
-
  protected:
   int pack_reverse_comm(int, int, double *);
   void unpack_reverse_comm(int, int *, double *);

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -96,6 +96,7 @@ Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
   uCond = uMech = uChem = uCG = uCGnew = NULL;
   duCond = duMech = duChem = NULL;
   dpdTheta = NULL;
+  ssaAIR = NULL;
 
   // USER-SMD
 
@@ -287,6 +288,7 @@ Atom::~Atom()
   memory->destroy(duCond);
   memory->destroy(duMech);
   memory->destroy(duChem);
+  memory->destroy(ssaAIR);
 
   memory->destroy(nspecial);
   memory->destroy(special);

--- a/src/atom.h
+++ b/src/atom.h
@@ -91,6 +91,7 @@ class Atom : protected Pointers {
   double *duCond,*duMech,*duChem;
   double *dpdTheta;
   int nspecies_dpd;
+  int *ssaAIR; // Shardlow Splitting Algorithm Active Interaction Region number
 
   // molecular info
 

--- a/src/neigh_shardlow.cpp
+++ b/src/neigh_shardlow.cpp
@@ -31,93 +31,6 @@
 using namespace LAMMPS_NS;
 
 /* ----------------------------------------------------------------------
-   convert atom coords into the ssa active interaction region number
-------------------------------------------------------------------------- */
-
-int Neighbor::coord2ssa_airnum(double *x)
-{
-  int ix, iy, iz;
-
-  ix = iy = iz = 0;
-  if (x[2] < domain->sublo[2]) iz = -1;
-  if (x[2] > domain->subhi[2]) iz = 1;
-  if (x[1] < domain->sublo[1]) iy = -1;
-  if (x[1] > domain->subhi[1]) iy = 1;
-  if (x[0] < domain->sublo[0]) ix = -1;
-  if (x[0] > domain->subhi[0]) ix = 1;
-
-  if(iz < 0) return 0;
-
-  if(iz == 0){
-    if( iy<0 ) return 0; // bottom left/middle/right
-    if( (iy==0) && (ix<0)  ) return 0; // left atoms
-    if( (iy==0) && (ix==0) ) return 1; // Locally owned atoms
-    if( (iy==0) && (ix>0)  ) return 3; // Right atoms
-    if( (iy>0)  && (ix==0) ) return 2; // Top-middle atoms
-    if( (iy>0)  && (ix!=0) ) return 4; // Top-right and top-left atoms
-  } else if(iz > 0) {
-    if((ix==0) && (iy==0)) return 5; // Back atoms
-    if((ix==0) && (iy!=0)) return 6; // Top-back and bottom-back atoms
-    if((ix!=0) && (iy==0)) return 7; // Left-back and right-back atoms
-    if((ix!=0) && (iy!=0)) return 8; // Back corner atoms
-  }
-
-  return 0;
-}
-
-/* ----------------------------------------------------------------------
- *    assign owned and ghost atoms their ssa active interaction region numbers
- *    Called in the pre_neighbor and setup_pre_neighbor fix stages
-------------------------------------------------------------------------- */
-
-void Neighbor::assign_ssa_airnums()
-{
-  int i,ibin;
-  double **x = atom->x;
-  int *mask = atom->mask;
-  int nlocal = atom->nlocal;
-  int nall = nlocal + atom->nghost;
-
-  if (nall > len_ssa_airnum) {
-    len_ssa_airnum = nall;
-    memory->destroy(ssa_airnum);
-    memory->create(ssa_airnum,len_ssa_airnum,"ssa_airnum");
-  }
-
-  // bin in reverse order so linked list will be in forward order
-
-  if (includegroup) {
-    int bitmask = group->bitmask[includegroup];
-    for (i = nall-1; i >= nlocal; i--) {
-      if (mask[i] & bitmask) {
-        ibin = coord2ssa_airnum(x[i]);
-      } else {
-        ibin = 0;
-      }
-      ssa_airnum[i] = ibin;
-    }
-    // All the local excluded atoms are in the zero airnum
-    ibin = 0;
-    for (i = atom->nlocal-1; i >= atom->nfirst; i--) {
-      ssa_airnum[i] = ibin;
-    }
-  } else {
-    for (i = nall-1; i >= nlocal; i--) {
-      ibin = coord2ssa_airnum(x[i]);
-      ssa_airnum[i] = ibin;
-    }
-  }
-
-  // All the local included atoms are in the same airnum (#1)
-  if (i >= 0) {
-    ibin = coord2ssa_airnum(x[i]);
-    do {
-      ssa_airnum[i] = ibin;
-    } while (--i >= 0);
-  }
-}
-
-/* ----------------------------------------------------------------------
    routines to create a stencil = list of bin offsets
    stencil = bins whose closest corner to central bin is within cutoff
    sx,sy,sz = bin bounds = furthest the stencil could possibly extend
@@ -207,6 +120,7 @@ void Neighbor::half_from_full_newton_ssa(NeighList *list)
   int *neighptr,*jlist;
 
   int nlocal = atom->nlocal;
+  int *ssaAIR = atom->ssaAIR;
 
   int *ilist = list->ilist;
   int *numneigh = list->numneigh;
@@ -240,7 +154,7 @@ void Neighbor::half_from_full_newton_ssa(NeighList *list)
       if (j < nlocal) {
         if (i > j) continue;
       } else {
-        if (ssa_airnum[j] <= 0) continue;
+        if (ssaAIR[j] <= 0) continue;
       }
       neighptr[n++] = joriginal;
     }
@@ -279,6 +193,7 @@ void Neighbor::half_bin_newton_ssa(NeighList *list)
   int **nspecial = atom->nspecial;
   int nlocal = atom->nlocal;
   int nall = nlocal + atom->nghost;
+  int *ssaAIR = atom->ssaAIR;
 
   int *molindex = atom->molindex;
   int *molatom = atom->molatom;
@@ -325,7 +240,7 @@ void Neighbor::half_bin_newton_ssa(NeighList *list)
   if (includegroup) {
     int bitmask = group->bitmask[includegroup];
     for (i = nall-1; i >= nlocal; i--) {
-      if (ssa_airnum[i] <= 0) continue; // skip ghost atoms not in AIR
+      if (ssaAIR[i] <= 0) continue; // skip ghost atoms not in AIR
       if (mask[i] & bitmask) {
         ibin = coord2bin(x[i]);
         bins_ssa[i] = gbinhead_ssa[ibin];
@@ -335,7 +250,7 @@ void Neighbor::half_bin_newton_ssa(NeighList *list)
     nlocal = atom->nfirst; // This is important for the code that follows!
   } else {
     for (i = nall-1; i >= nlocal; i--) {
-      if (ssa_airnum[i] <= 0) continue; // skip ghost atoms not in AIR
+      if (ssaAIR[i] <= 0) continue; // skip ghost atoms not in AIR
       ibin = coord2bin(x[i]);
       bins_ssa[i] = gbinhead_ssa[ibin];
       gbinhead_ssa[ibin] = i;

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -106,8 +106,6 @@ Neighbor::Neighbor(LAMMPS *lmp) : Pointers(lmp)
 
   // USER-DPD SSA AIR binning
 
-  len_ssa_airnum = 0;
-  ssa_airnum = NULL;
   maxbin_ssa = 0;
   bins_ssa = NULL;
   binhead_ssa = NULL;
@@ -189,7 +187,6 @@ Neighbor::~Neighbor()
   memory->destroy(gbinhead_ssa);
   memory->destroy(binhead_ssa);
   memory->destroy(bins_ssa);
-  memory->destroy(ssa_airnum);
 
   memory->destroy(ex1_type);
   memory->destroy(ex2_type);
@@ -2224,8 +2221,6 @@ bigint Neighbor::memory_usage()
     bytes += memory->usage(binhead_ssa,maxhead_ssa);
     bytes += memory->usage(gbinhead_ssa,maxhead_ssa);
   }
-
-  bytes += memory->usage(ssa_airnum,len_ssa_airnum);
 
   for (int i = 0; i < nrequest; i++)
     if (lists[i]) bytes += lists[i]->memory_usage();

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -104,7 +104,7 @@ Neighbor::Neighbor(LAMMPS *lmp) : Pointers(lmp)
   maxbin = 0;
   bins = NULL;
 
-  // SSA AIR binning
+  // USER-DPD SSA AIR binning
 
   len_ssa_airnum = 0;
   ssa_airnum = NULL;
@@ -390,6 +390,15 @@ void Neighbor::init()
     maxbin = maxhead = 0;
     binhead = NULL;
     bins = NULL;
+
+    // for USER-DPD Shardlow Splitting Algorithm (SSA)
+    memory->destroy(bins_ssa);
+    memory->destroy(binhead_ssa);
+    memory->destroy(gbinhead_ssa);
+    maxbin_ssa = maxhead_ssa = 0;
+    bins_ssa = NULL;
+    binhead_ssa = NULL;
+    gbinhead_ssa = NULL;
   }
 
   // 1st time allocation of xhold and bins
@@ -2211,6 +2220,9 @@ bigint Neighbor::memory_usage()
   if (style != NSQ) {
     bytes += memory->usage(bins,maxbin);
     bytes += memory->usage(binhead,maxhead);
+    bytes += memory->usage(bins_ssa,maxbin_ssa);
+    bytes += memory->usage(binhead_ssa,maxhead_ssa);
+    bytes += memory->usage(gbinhead_ssa,maxhead_ssa);
   }
 
   bytes += memory->usage(ssa_airnum,len_ssa_airnum);

--- a/src/neighbor.h
+++ b/src/neighbor.h
@@ -71,10 +71,6 @@ class Neighbor : protected Pointers {
 
   int cluster_check;               // 1 if check bond/angle/etc satisfies minimg
 
-  // USER-DPD package
-
-  int *ssa_airnum;              // AIR number of each atom for SSA in USER-DPD
-
   // methods
 
   Neighbor(class LAMMPS *);
@@ -94,10 +90,6 @@ class Neighbor : protected Pointers {
   bigint memory_usage();
   int exclude_setting();
   void exclusion_group_group_delete(int, int);  // rm a group-group exclusion
-
-  // USER-DPD package
-
-  void assign_ssa_airnums();       // set ssa_airnum values
 
  protected:
   int me,nprocs;
@@ -184,7 +176,6 @@ class Neighbor : protected Pointers {
 
   // USER-DPD package
 
-  int len_ssa_airnum;        // length of ssa_airnum array
   int *bins_ssa;             // ptr to next atom in each bin used by SSA
   int maxbin_ssa;            // size of bins array used by SSA
   int *binhead_ssa;          // ptr to 1st atom in each bin used by SSA
@@ -328,8 +319,6 @@ class Neighbor : protected Pointers {
   void improper_partial();            // exclude certain impropers
 
   // SSA neighboring for USER-DPD
-
-  int coord2ssa_airnum(double *);  // map atom coord to an AIR number
 
   void half_bin_newton_ssa(NeighList *);
   void half_from_full_newton_ssa(class NeighList *);


### PR DESCRIPTION
Background: The USER-DPD package needs support in the core code for calculating and storing the Shardlow Splitting Algorithm's (SSA) Active Interaction Region (AIR) number for each atom.
Our initial implementation did this calculation in the neighbor code, and initiated it with a pre_neighbor hook in the fix_shardlow.

This pull request moves and consolidates this work into the atom and atom_vec_dpd code, so that this SSA AIR calculation is invoked during the pack/unpack border() and exchange() hooks.  This simplifies the code, and allows us to rebuild the neighbor list infrequently when using USER-DPD.