### PR TITLE
Fixes a bug when attempting to restart a reaction DPD calculation.

### DIFF
--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -44,6 +44,7 @@ FixRX::FixRX(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg)
 {
   if (narg < 6 || narg > 7) error->all(FLERR,"Illegal fix rx command");
+  restart_peratom = 1;
   nevery = 1;
 
   nreactions = maxparam = 0;


### PR DESCRIPTION
After this 1-liner fix, our tests show that the calculation can be exactly restarted for reaction DPD and it's corresponding pair styles.  Patch from my colleague Jim Larentzos.