### PR TITLE
Fixed bugs with tersoff/gpu potentials used in pair hybrid

### DIFF
--- a/lib/gpu/lal_tersoff.cpp
+++ b/lib/gpu/lal_tersoff.cpp
@@ -269,7 +269,7 @@ void TersoffT::compute(const int f_ago, const int nlocal, const int nall,
   else
     _eflag=0;
 
-  int ainum=nall;
+  int ainum=nlist;
   int nbor_pitch=this->nbor->nbor_pitch();
   int BX=this->block_pair();
   int GX=static_cast<int>(ceil(static_cast<double>(ainum)/
@@ -279,7 +279,7 @@ void TersoffT::compute(const int f_ago, const int nlocal, const int nall,
   this->k_zeta.run(&this->atom->x, &ts1, &ts2, &ts3, &ts4, &ts5, &cutsq,
                    &map, &elem2param, &_nelements, &_nparams, &_zetaij,
                    &this->nbor->dev_nbor, &this->_nbor_data->begin(),
-                   &_eflag, &nall, &ainum, &nbor_pitch, &this->_threads_per_atom);
+                   &_eflag, &ainum, &nbor_pitch, &this->_threads_per_atom);
 
   int evatom=0;
   if (eatom || vatom)
@@ -364,7 +364,7 @@ int ** TersoffT::compute(const int ago, const int inum_full,
   this->k_zeta.run(&this->atom->x, &ts1, &ts2, &ts3, &ts4, &ts5, &cutsq,
                    &map, &elem2param, &_nelements, &_nparams, &_zetaij,
                    &this->nbor->dev_nbor, &this->_nbor_data->begin(),
-                   &_eflag, &nall, &ainum, &nbor_pitch, &this->_threads_per_atom);
+                   &_eflag, &ainum, &nbor_pitch, &this->_threads_per_atom);
 
   int evatom=0;
   if (eatom || vatom)

--- a/lib/gpu/lal_tersoff.cu
+++ b/lib/gpu/lal_tersoff.cu
@@ -184,7 +184,7 @@ __kernel void k_tersoff_zeta(const __global numtyp4 *restrict x_,
                              __global acctyp4 * zetaij,
                              const __global int * dev_nbor,
                              const __global int * dev_packed,
-                             const int eflag, const int nall, const int inum,
+                             const int eflag, const int inum,
                              const int nbor_pitch, const int t_per_atom) {
   __local int tpa_sq,n_stride;
   tpa_sq = fast_mul(t_per_atom,t_per_atom);
@@ -210,7 +210,7 @@ __kernel void k_tersoff_zeta(const __global numtyp4 *restrict x_,
 
   __syncthreads();
 
-  if (ii<nall) {
+  if (ii<inum) {
     int nbor_j, nbor_end;
     int i, numj;
 
@@ -815,7 +815,7 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
 __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
                                         const __global numtyp4 *restrict ts1_in,
                                         const __global numtyp4 *restrict ts2_in,
-                                              const __global numtyp4 *restrict ts4_in,
+                                        const __global numtyp4 *restrict ts4_in,
                                         const __global numtyp *restrict cutsq,
                                         const __global int *restrict map,
                                         const __global int *restrict elem2param,
@@ -974,7 +974,7 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
 
         numtyp delr2[3];
         delr2[0] = kx.x-jx.x;
-              delr2[1] = kx.y-jx.y;
+        delr2[1] = kx.y-jx.y;
         delr2[2] = kx.z-jx.z;
         numtyp rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
 

--- a/lib/gpu/lal_tersoff_mod.cpp
+++ b/lib/gpu/lal_tersoff_mod.cpp
@@ -269,7 +269,7 @@ void TersoffMT::compute(const int f_ago, const int nlocal, const int nall,
   else
     _eflag=0;
 
-  int ainum=nall;
+  int ainum=nlist;
   int nbor_pitch=this->nbor->nbor_pitch();
   int BX=this->block_pair();
   int GX=static_cast<int>(ceil(static_cast<double>(ainum)/
@@ -279,7 +279,7 @@ void TersoffMT::compute(const int f_ago, const int nlocal, const int nall,
   this->k_zeta.run(&this->atom->x, &ts1, &ts2, &ts3, &ts4, &ts5, &cutsq,
                    &map, &elem2param, &_nelements, &_nparams, &_zetaij,
                    &this->nbor->dev_nbor, &this->_nbor_data->begin(),
-                   &_eflag, &nall, &ainum, &nbor_pitch, &this->_threads_per_atom);
+                   &_eflag, &ainum, &nbor_pitch, &this->_threads_per_atom);
 
   int evatom=0;
   if (eatom || vatom)
@@ -364,7 +364,7 @@ int ** TersoffMT::compute(const int ago, const int inum_full,
   this->k_zeta.run(&this->atom->x, &ts1, &ts2, &ts3, &ts4, &ts5, &cutsq,
                    &map, &elem2param, &_nelements, &_nparams, &_zetaij,
                    &this->nbor->dev_nbor, &this->_nbor_data->begin(),
-                   &_eflag, &nall, &ainum, &nbor_pitch, &this->_threads_per_atom);
+                   &_eflag, &ainum, &nbor_pitch, &this->_threads_per_atom);
 
   int evatom=0;
   if (eatom || vatom)

--- a/lib/gpu/lal_tersoff_mod.cu
+++ b/lib/gpu/lal_tersoff_mod.cu
@@ -184,7 +184,7 @@ __kernel void k_tersoff_mod_zeta(const __global numtyp4 *restrict x_,
                              __global acctyp4 * zetaij,
                              const __global int * dev_nbor,
                              const __global int * dev_packed,
-                             const int eflag, const int nall, const int inum,
+                             const int eflag, const int inum,
                              const int nbor_pitch, const int t_per_atom) {
   __local int tpa_sq,n_stride;
   tpa_sq = fast_mul(t_per_atom,t_per_atom);
@@ -210,7 +210,7 @@ __kernel void k_tersoff_mod_zeta(const __global numtyp4 *restrict x_,
 
   __syncthreads();
 
-  if (ii<nall) {
+  if (ii<inum) {
     int nbor_j, nbor_end;
     int i, numj;
 
@@ -831,8 +831,8 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
 __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
                                         const __global numtyp4 *restrict ts1_in,
                                         const __global numtyp4 *restrict ts2_in,
-                                              const __global numtyp4 *restrict ts4_in,
-                                              const __global numtyp4 *restrict ts5_in,
+                                        const __global numtyp4 *restrict ts4_in,
+                                        const __global numtyp4 *restrict ts5_in,
                                         const __global numtyp *restrict cutsq,
                                         const __global int *restrict map,
                                         const __global int *restrict elem2param,
@@ -993,7 +993,7 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
 
         numtyp delr2[3];
         delr2[0] = kx.x-jx.x;
-              delr2[1] = kx.y-jx.y;
+        delr2[1] = kx.y-jx.y;
         delr2[2] = kx.z-jx.z;
         numtyp rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
 

--- a/lib/gpu/lal_tersoff_zbl.cpp
+++ b/lib/gpu/lal_tersoff_zbl.cpp
@@ -294,7 +294,7 @@ void TersoffZT::compute(const int f_ago, const int nlocal, const int nall,
   else
     _eflag=0;
 
-  int ainum=nall;
+  int ainum=nlist;
   int nbor_pitch=this->nbor->nbor_pitch();
   int BX=this->block_pair();
   int GX=static_cast<int>(ceil(static_cast<double>(ainum)/
@@ -304,7 +304,7 @@ void TersoffZT::compute(const int f_ago, const int nlocal, const int nall,
   this->k_zeta.run(&this->atom->x, &ts1, &ts2, &ts3, &ts4, &ts5, &ts6, &cutsq,
                    &map, &elem2param, &_nelements, &_nparams, &_zetaij,
                    &this->nbor->dev_nbor, &this->_nbor_data->begin(),
-                   &_eflag, &nall, &ainum, &nbor_pitch, &this->_threads_per_atom);
+                   &_eflag, &ainum, &nbor_pitch, &this->_threads_per_atom);
 
   int evatom=0;
   if (eatom || vatom)
@@ -389,7 +389,7 @@ int ** TersoffZT::compute(const int ago, const int inum_full,
   this->k_zeta.run(&this->atom->x, &ts1, &ts2, &ts3, &ts4, &ts5, &ts6, &cutsq,
                    &map, &elem2param, &_nelements, &_nparams, &_zetaij,
                    &this->nbor->dev_nbor, &this->_nbor_data->begin(),
-                   &_eflag, &nall, &ainum, &nbor_pitch, &this->_threads_per_atom);
+                   &_eflag, &ainum, &nbor_pitch, &this->_threads_per_atom);
 
   int evatom=0;
   if (eatom || vatom)

--- a/lib/gpu/lal_tersoff_zbl.cu
+++ b/lib/gpu/lal_tersoff_zbl.cu
@@ -188,7 +188,7 @@ __kernel void k_tersoff_zbl_zeta(const __global numtyp4 *restrict x_,
                              __global acctyp4 * zetaij,
                              const __global int * dev_nbor,
                              const __global int * dev_packed,
-                             const int eflag, const int nall, const int inum,
+                             const int eflag, const int inum,
                              const int nbor_pitch, const int t_per_atom) {
   __local int tpa_sq,n_stride;
   tpa_sq = fast_mul(t_per_atom,t_per_atom);
@@ -216,7 +216,7 @@ __kernel void k_tersoff_zbl_zeta(const __global numtyp4 *restrict x_,
 
   __syncthreads();
 
-  if (ii<nall) {
+  if (ii<inum) {
     int nbor_j, nbor_end;
     int i, numj;
 
@@ -835,7 +835,7 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
 __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
                                         const __global numtyp4 *restrict ts1_in,
                                         const __global numtyp4 *restrict ts2_in,
-                                              const __global numtyp4 *restrict ts4_in,
+                                        const __global numtyp4 *restrict ts4_in,
                                         const __global numtyp *restrict cutsq,
                                         const __global int *restrict map,
                                         const __global int *restrict elem2param,
@@ -994,7 +994,7 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
 
         numtyp delr2[3];
         delr2[0] = kx.x-jx.x;
-              delr2[1] = kx.y-jx.y;
+        delr2[1] = kx.y-jx.y;
         delr2[2] = kx.z-jx.z;
         numtyp rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
 


### PR DESCRIPTION
This contains bugfixes to tersoff/gpu, tersoff/zbl/gpu and tersoff/mod/gpu when used as a sub-style in pair hybrid.