### PR TITLE
USER-DPD: Process each Active Interaction Region directly, saving time.

### DIFF
--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -108,9 +108,7 @@ FixShardlow::FixShardlow(LAMMPS *lmp, int narg, char **arg) :
   // Setup the ssaAIR array
   atom->ssaAIR = NULL;
   grow_arrays(atom->nmax);
-  for (int i = 0; i < atom->nlocal; i++) {
-    atom->ssaAIR[i] = 1; /* coord2ssaAIR(x[i]) */
-  }
+  memset(atom->ssaAIR, 0, sizeof(int)*atom->nlocal);
 
   // Setup callbacks for maintaining atom->ssaAIR[]
   atom->add_callback(0); // grow (aka exchange)
@@ -137,7 +135,36 @@ int FixShardlow::setmask()
 {
   int mask = 0;
   mask |= INITIAL_INTEGRATE;
+  mask |= PRE_EXCHANGE | MIN_PRE_EXCHANGE;
   return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixShardlow::pre_exchange()
+{
+  memset(atom->ssaAIR, 0, sizeof(int)*atom->nlocal);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixShardlow::setup_pre_exchange()
+{
+  memset(atom->ssaAIR, 0, sizeof(int)*atom->nlocal);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixShardlow::min_pre_exchange()
+{
+  memset(atom->ssaAIR, 0, sizeof(int)*atom->nlocal);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixShardlow::min_setup_pre_exchange()
+{
+  memset(atom->ssaAIR, 0, sizeof(int)*atom->nlocal);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -244,7 +271,11 @@ void FixShardlow::do_ssaAIR_for(
   for (jj = 0; jj < jnum; jj++) {
     j = jlist[jj];
     j &= NEIGHMASK;
-    if (ssaAIR[j] != airnum) continue;
+    if (airnum == 1) {
+      if (ssaAIR[j] > 1) continue;
+    } else {
+      if (ssaAIR[j] != airnum) continue;
+    }
     jtype = type[j];
 
     delx = xtmp - x[j][0];
@@ -554,11 +585,11 @@ int FixShardlow::coord2ssaAIR(double *x)
   if (x[0] >= domain->subhi[0]) ix = 1;
 
   if(iz < 0){
-    return 0;
+    return -1;
   } else if(iz == 0){
-    if( iy<0 ) return 0; // bottom left/middle/right
-    if( (iy==0) && (ix<0)  ) return 0; // left atoms
-    if( (iy==0) && (ix==0) ) return 1; // Locally owned atoms
+    if( iy<0 ) return -1; // bottom left/middle/right
+    if( (iy==0) && (ix<0)  ) return -1; // left atoms
+    if( (iy==0) && (ix==0) ) return 0; // Locally owned atoms
     if( (iy==0) && (ix>0)  ) return 3; // Right atoms
     if( (iy>0)  && (ix==0) ) return 2; // Top-middle atoms
     if( (iy>0)  && (ix!=0) ) return 4; // Top-right and top-left atoms
@@ -569,7 +600,7 @@ int FixShardlow::coord2ssaAIR(double *x)
     if((ix!=0) && (iy!=0)) return 8; // Back corner atoms
   }
 
-  return 0;
+  return -2;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -586,7 +617,16 @@ void FixShardlow::copy_arrays(int i, int j, int delflag)
 
 void FixShardlow::set_arrays(int i)
 {
-  atom->ssaAIR[i] = 1; /* coord2ssaAIR(x[i]) */
+  atom->ssaAIR[i] = 0; /* coord2ssaAIR(x[i]) */
+}
+
+int FixShardlow::pack_border(int n, int *list, double *buf)
+{
+  for (int i = 0; i < n; i++) {
+    int j = list[i];
+    if (atom->ssaAIR[j] == 0) atom->ssaAIR[j] = 1; // not purely local anymore
+  }
+  return 0;
 }
 
 int FixShardlow::unpack_border(int n, int first, double *buf)
@@ -600,13 +640,13 @@ int FixShardlow::unpack_border(int n, int first, double *buf)
 
 int FixShardlow::unpack_exchange(int i, double *buf)
 {
-  atom->ssaAIR[i] = 1; /* coord2ssaAIR(x[i]) */
+  atom->ssaAIR[i] = 0; /* coord2ssaAIR(x[i]) */
   return 0;
 }
 
 void FixShardlow::unpack_restart(int i, int nth)
 {
-  atom->ssaAIR[i] = 1; /* coord2ssaAIR(x[i]) */
+  atom->ssaAIR[i] = 0; /* coord2ssaAIR(x[i]) */
 }
 
 double FixShardlow::memory_usage()

--- a/src/USER-DPD/fix_shardlow.h
+++ b/src/USER-DPD/fix_shardlow.h
@@ -31,6 +31,10 @@ class FixShardlow : public Fix {
   int setmask();
   virtual void setup(int);
   virtual void initial_integrate(int);
+  void setup_pre_exchange();
+  void pre_exchange();
+  void min_setup_pre_exchange();
+  void min_pre_exchange();
 
   void grow_arrays(int);
   void copy_arrays(int, int, int);
@@ -38,7 +42,7 @@ class FixShardlow : public Fix {
 
   void reset_dt();
 
-//  int pack_border(int, int *, double *);
+  int pack_border(int, int *, double *);
   int unpack_border(int, int, double *);
   int unpack_exchange(int, double *);
   void unpack_restart(int, int);

--- a/src/USER-DPD/fix_shardlow.h
+++ b/src/USER-DPD/fix_shardlow.h
@@ -63,7 +63,7 @@ class FixShardlow : public Fix {
   double dtsqrt; // = sqrt(update->dt);
 
   int coord2ssaAIR(double *);  // map atom coord to an AIR number
-  void do_ssaAIR_for(int, int, int, int *, class RanMars *);
+  void ssa_update(int, int *, int, class RanMars *);
 
 
 };

--- a/src/neigh_list.cpp
+++ b/src/neigh_list.cpp
@@ -58,6 +58,7 @@ NeighList::NeighList(LAMMPS *lmp) :
   listskip = NULL;
 
   // USER-DPD package
+  ndxAIR_ssa = NULL;
   maxbin_ssa = 0;
   bins_ssa = NULL;
   maxhead_ssa = 0;
@@ -96,6 +97,7 @@ NeighList::~NeighList()
 
   if (maxstencil) memory->destroy(stencil);
   if (ghostflag) memory->destroy(stencilxyz);
+  if (ndxAIR_ssa) memory->sfree(ndxAIR_ssa);
   if (maxbin_ssa) memory->destroy(bins_ssa);
   if (maxhead_ssa) {
     memory->destroy(binhead_ssa);
@@ -161,6 +163,11 @@ void NeighList::grow(int nmax)
   if (dnum)
     firstdouble = (double **) memory->smalloc(maxatoms*sizeof(double *),
                                               "neighlist:firstdouble");
+  if (ssaflag) {
+    if (ndxAIR_ssa) memory->sfree(ndxAIR_ssa);
+    ndxAIR_ssa = (uint16_t (*)[8]) memory->smalloc(sizeof(uint16_t)*8*maxatoms,
+      "neighlist:ndxAIR_ssa");
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -242,6 +249,7 @@ void NeighList::print_attributes()
   printf("  %d = grow flag\n",growflag);
   printf("  %d = stencil flag\n",stencilflag);
   printf("  %d = ghost flag\n",ghostflag);
+  printf("  %d = ssa flag\n",ssaflag);
   printf("\n");
   printf("  %d = pair\n",rq->pair);
   printf("  %d = fix\n",rq->fix);
@@ -303,6 +311,7 @@ bigint NeighList::memory_usage()
 
   if (maxstencil) bytes += memory->usage(stencil,maxstencil);
   if (ghostflag) bytes += memory->usage(stencilxyz,maxstencil,3);
+  if (ndxAIR_ssa) bytes += sizeof(uint16_t) * 8 * maxatoms;
   if (maxbin_ssa) bytes += memory->usage(bins_ssa,maxbin_ssa);
   if (maxhead_ssa) {
     bytes += memory->usage(binhead_ssa,maxhead_ssa);

--- a/src/neigh_list.h
+++ b/src/neigh_list.h
@@ -67,6 +67,8 @@ class NeighList : protected Pointers {
 
   // USER-DPD package and Shardlow Splitting Algorithm (SSA) support
 
+  int ssaflag;               // 1 if the list has the ndxAIR_ssa array
+  uint16_t (*ndxAIR_ssa)[8]; // for each atom, last neighbor index of each AIR
   int *bins_ssa;             // index of next atom in each bin
   int maxbin_ssa;            // size of bins_ssa array
   int *binhead_ssa;          // index of 1st local atom in each bin

--- a/src/neigh_shardlow.cpp
+++ b/src/neigh_shardlow.cpp
@@ -347,7 +347,8 @@ void Neighbor::half_bin_newton_ssa(NeighList *list)
     // loop over AIR ghost atoms in all bins in "full" stencil
     // Note: the non-AIR ghost atoms have already been filtered out
     // That is a significant time savings because of the "full" stencil
-    for (k = 0; k < maxstencil; k++) {
+    // Note2: only non-pure locals can have ghosts as neighbors
+    if (ssaAIR[i] == 1) for (k = 0; k < maxstencil; k++) {
       if (stencil[k] > mbins) break; /* Check if ghost stencil bins are exhausted */
       for (j = list->gbinhead_ssa[ibin+stencil[k]]; j >= 0; j = list->bins_ssa[j]) {
 

--- a/src/neigh_shardlow.cpp
+++ b/src/neigh_shardlow.cpp
@@ -154,7 +154,7 @@ void Neighbor::half_from_full_newton_ssa(NeighList *list)
       if (j < nlocal) {
         if (i > j) continue;
       } else {
-        if (ssaAIR[j] <= 0) continue;
+        if (ssaAIR[j] < 2) continue; // skip ghost atoms not in AIR
       }
       neighptr[n++] = joriginal;
     }
@@ -241,7 +241,7 @@ void Neighbor::half_bin_newton_ssa(NeighList *list)
     if (includegroup) {
       int bitmask = group->bitmask[includegroup];
       for (i = nall-1; i >= nlocal; i--) {
-        if (ssaAIR[i] <= 0) continue; // skip ghost atoms not in AIR
+        if (ssaAIR[i] < 2) continue; // skip ghost atoms not in AIR
         if (mask[i] & bitmask) {
           ibin = coord2bin(x[i]);
           list->bins_ssa[i] = list->gbinhead_ssa[ibin];
@@ -251,7 +251,7 @@ void Neighbor::half_bin_newton_ssa(NeighList *list)
       nlocal = atom->nfirst; // This is important for the code that follows!
     } else {
       for (i = nall-1; i >= nlocal; i--) {
-        if (ssaAIR[i] <= 0) continue; // skip ghost atoms not in AIR
+        if (ssaAIR[i] < 2) continue; // skip ghost atoms not in AIR
         ibin = coord2bin(x[i]);
         list->bins_ssa[i] = list->gbinhead_ssa[ibin];
         list->gbinhead_ssa[ibin] = i;

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -703,6 +703,9 @@ void Neighbor::init()
         lists[i]->ghostflag = 0;
         if (requests[i]->ghost) lists[i]->ghostflag = 1;
         if (requests[i]->ghost && !requests[i]->occasional) anyghostlist = 1;
+
+        lists[i]->ssaflag = 0;
+        if (requests[i]->ssa) lists[i]->ssaflag = 1;
       } else init_list_flags1_kokkos(i);
     }
 


### PR DESCRIPTION
This series of commits saves a few % on Shardlow Update runtime for non-reactive scenarios, by adding an auxiliary data structure to the Neighbor List that tracks the index where each Active Interaction Region (AIR) starts within each atom's list of neighbors.  The data structure is only instantiated for lists with the ssaflag set.
The AIR for local atoms is also split into two values: 0 and 1, where 0 is for purely local atoms that have no ghost(ly) neighbors, and 1 for local atoms that might have some ghosts as neighbors.