### PR TITLE
lammps_extract_global to handle nbonds and time

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -149,8 +149,10 @@ void *lammps_extract_global(void *ptr, char *name)
   if (strcmp(name,"xz") == 0) return (void *) &lmp->domain->xz;
   if (strcmp(name,"yz") == 0) return (void *) &lmp->domain->yz;
   if (strcmp(name,"natoms") == 0) return (void *) &lmp->atom->natoms;
+  if (strcmp(name,"nbonds") == 0) return (void *) &lmp->neighbor->nbondlist;
   if (strcmp(name,"nlocal") == 0) return (void *) &lmp->atom->nlocal;
   if (strcmp(name,"ntimestep") == 0) return (void *) &lmp->update->ntimestep;
+  if (strcmp(name,"time") == 0) return (void *) &lmp->update->atime;
 
   return NULL;
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -22,6 +22,7 @@
 #include "universe.h"
 #include "input.h"
 #include "atom.h"
+#include "neighbor.h"
 #include "domain.h"
 #include "update.h"
 #include "group.h"


### PR DESCRIPTION
Added two new quantities to be retreived from the lammps_extract_global function: the number of bonds and the dimensionful simulation time (as opposed to the number of time steps).