### PR TITLE
DLM code from master

### DIFF
--- a/doc/src/fix_nh.txt
+++ b/doc/src/fix_nh.txt
@@ -56,7 +56,8 @@ keyword = {temp} or {iso} or {aniso} or {tri} or {x} or {y} or {z} or {xy} or {y
   {flip} value = {yes} or {no} = allow or disallow box flips when it becomes highly skewed
   {fixedpoint} values = x y z
     x,y,z = perform barostat dilation/contraction around this point (distance units)
-  {update} value = {dipole} update dipole orientation (only for sphere variants) :pre
+  {update} value = {dipole} update dipole orientation (only for sphere variants) 
+  {dlm} use Dullweber-Leimkuhler-McLachlan integrator to update the dipole orientation :pre
 
 :ule
 
@@ -334,6 +335,8 @@ during the time integration.  This option should be used for models
 where a dipole moment is assigned to finite-size particles,
 e.g. spheroids via use of the "atom_style hybrid sphere
 dipole"_atom_style.html command.
+
+Instead of the default integrator used when the {update dipole} keyword/value pair is present, adding the {dlm} keyword enables the Dullweber-Leimkuhler-McLachlan integration scheme "(Dullweber)"_#nh-Dullweber for the dipole orientation.  This integrator is symplectic and time-reversible, giving better energy conservation and allows slightly longer timesteps at only a small additional computational cost. The {dlm} keyword may only be used together with {update dipole}.
 
 :line
 
@@ -638,3 +641,6 @@ Martyna, J Phys A: Math Gen, 39, 5629 (2006).
 
 :link(nh-Shinoda)
 [(Shinoda)] Shinoda, Shiga, and Mikami, Phys Rev B, 69, 134103 (2004).
+
+:link(nh-Dullweber)
+[(Dullweber)] Dullweber, Leimkuhler and McLachlan, J Chem Phys, 107, 5840 (1997).

--- a/doc/src/fix_nve_sphere.txt
+++ b/doc/src/fix_nve_sphere.txt
@@ -47,7 +47,7 @@ where a dipole moment is assigned to finite-size particles,
 e.g. spheroids via use of the "atom_style hybrid sphere
 dipole"_atom_style.html command.
 
-Instead of the default integrator used when the {update dipole} keyword/value pair is present, adding the {dlm} keyword enables the Dullweber-Leimkuhler-McLachlan integration scheme for the dipole orientation.  This integrator is symplectic and time-reversible, giving better energy conservation and allows slightly longer timesteps at only a small additional computational cost. The {dlm} keyword may only be used together with {update dipole}.
+Instead of the default integrator used when the {update dipole} keyword/value pair is present, adding the {dlm} keyword enables the Dullweber-Leimkuhler-McLachlan integration scheme "(Dullweber)"_#nve-Dullweber for the dipole orientation.  This integrator is symplectic and time-reversible, giving better energy conservation and allows slightly longer timesteps at only a small additional computational cost. The {dlm} keyword may only be used together with {update dipole}.
 
 :line
 
@@ -100,3 +100,8 @@ be point particles.
 "fix nve"_fix_nve.html, "fix nve/asphere"_fix_nve_asphere.html
 
 [Default:] none
+
+:line
+
+:link(nve-Dullweber)
+[(Dullweber)] Dullweber, Leimkuhler and McLachlan, J Chem Phys, 107, 5840 (1997).

--- a/doc/src/fix_nve_sphere.txt
+++ b/doc/src/fix_nve_sphere.txt
@@ -19,12 +19,16 @@ zero or more keyword/value pairs may be appended :l
 keyword = {update} :l
   {update} value = {dipole}
     dipole = update orientation of dipole moment during integration :pre
+keyword = {dlm} :l
+  {dlm} 
+   use Dullweber-Leimkuhler-McLachlan integrator to update the dipole orientation :pre
 :ule
 
 [Examples:]
 
 fix 1 all nve/sphere
-fix 1 all nve/sphere update dipole :pre
+fix 1 all nve/sphere update dipole
+fix 1 all nve/sphere update dipole dlm :pre
 
 [Description:]
 
@@ -42,6 +46,8 @@ during the time integration.  This option should be used for models
 where a dipole moment is assigned to finite-size particles,
 e.g. spheroids via use of the "atom_style hybrid sphere
 dipole"_atom_style.html command.
+
+Instead of the default integrator used when the {update dipole} keyword/value pair is present, adding the {dlm} keyword enables the Dullweber-Leimkuhler-McLachlan integration scheme for the dipole orientation.  This integrator is symplectic and time-reversible, giving better energy conservation and allows slightly longer timesteps at only a small additional computational cost. The {dlm} keyword may only be used together with {update dipole}.
 
 :line
 

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -79,6 +79,7 @@ FixNH::FixNH(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
   etap_mass_flag = 0;
   flipflag = 1;
   dipole_flag = 0;
+  dlm_flag = 0;
 
   tcomputeflag = 0;
   pcomputeflag = 0;
@@ -332,6 +333,9 @@ FixNH::FixNH(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
       if (strcmp(arg[iarg+1],"dipole") == 0) dipole_flag = 1;
       else error->all(FLERR,"Illegal fix nvt/npt/nph command");
       iarg += 2;
+    } else if (strcmp(arg[iarg],"dlm") == 0) {
+      dlm_flag = 1;
+      iarg += 1;
     } else if (strcmp(arg[iarg],"fixedpoint") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal fix nvt/npt/nph command");
       fixedpoint[0] = force->numeric(FLERR,arg[iarg+1]);
@@ -434,6 +438,9 @@ FixNH::FixNH(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
     if (!atom->mu_flag)
       error->all(FLERR,"Using update dipole flag requires atom attribute mu");
   }
+  
+  if (dlm_flag && !dipole_flag)
+    error->all(FLERR,"The dlm flag must be used with update dipole");
 
   if ((tstat_flag && t_period <= 0.0) ||
       (p_flag[0] && p_period[0] <= 0.0) ||

--- a/src/fix_nh.h
+++ b/src/fix_nh.h
@@ -111,6 +111,7 @@ class FixNH : public Fix {
   int omega_mass_flag;             // 1 if omega_mass updated, 0 if not.
   int etap_mass_flag;              // 1 if etap_mass updated, 0 if not.
   int dipole_flag;                 // 1 if dipole is updated, 0 if not.
+  int dlm_flag;                    // 1 if using the DLM rotational integrator, 0 if not
 
   int scaleyz;                     // 1 if yz scaled with lz
   int scalexz;                     // 1 if xz scaled with lz
@@ -219,6 +220,10 @@ Self-explanatory.
 
 E: Using update dipole flag requires atom attribute mu
 
+Self-explanatory.
+ 
+E: The dlm flag must be used with update dipole
+ 
 Self-explanatory.
 
 E: Fix nvt/npt/nph damping parameters must be > 0.0

--- a/src/fix_nh_sphere.cpp
+++ b/src/fix_nh_sphere.cpp
@@ -21,9 +21,13 @@
 #include "atom_vec.h"
 #include "group.h"
 #include "error.h"
+#include "force.h"
+#include "math_vector.h"
+#include "math_extra.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
+using namespace MathExtra;
 
 #define INERTIA 0.4          // moment of inertia prefactor for sphere
 
@@ -102,28 +106,133 @@ void FixNHSphere::nve_x()
   FixNH::nve_x();
 
   // update mu for dipoles
-  // d_mu/dt = omega cross mu
-  // renormalize mu to dipole length
-
+  
   if (dipole_flag) {
-    double msq,scale,g[3];
     double **mu = atom->mu;
     double **omega = atom->omega;
     int *mask = atom->mask;
     int nlocal = atom->nlocal;
-
-    for (int i = 0; i < nlocal; i++)
-      if (mask[i] & groupbit)
-        if (mu[i][3] > 0.0) {
-          g[0] = mu[i][0] + dtv * (omega[i][1]*mu[i][2]-omega[i][2]*mu[i][1]);
-          g[1] = mu[i][1] + dtv * (omega[i][2]*mu[i][0]-omega[i][0]*mu[i][2]);
-          g[2] = mu[i][2] + dtv * (omega[i][0]*mu[i][1]-omega[i][1]*mu[i][0]);
-          msq = g[0]*g[0] + g[1]*g[1] + g[2]*g[2];
-          scale = mu[i][3]/sqrt(msq);
-          mu[i][0] = g[0]*scale;
-          mu[i][1] = g[1]*scale;
-          mu[i][2] = g[2]*scale;
+    if (dlm_flag == 0){
+      // d_mu/dt = omega cross mu
+      // renormalize mu to dipole length
+      double msq,scale,g[3];
+      
+      for (int i = 0; i < nlocal; i++)
+        if (mask[i] & groupbit)
+          if (mu[i][3] > 0.0) {
+            g[0] = mu[i][0] + dtv * (omega[i][1]*mu[i][2]-omega[i][2]*mu[i][1]);
+            g[1] = mu[i][1] + dtv * (omega[i][2]*mu[i][0]-omega[i][0]*mu[i][2]);
+            g[2] = mu[i][2] + dtv * (omega[i][0]*mu[i][1]-omega[i][1]*mu[i][0]);
+            msq = g[0]*g[0] + g[1]*g[1] + g[2]*g[2];
+            scale = mu[i][3]/sqrt(msq);
+            mu[i][0] = g[0]*scale;
+            mu[i][1] = g[1]*scale;
+            mu[i][2] = g[2]*scale;
+          }
+    }else{
+      // Integrate orientation following Dullweber-Leimkuhler-Maclachlan scheme
+      vector w, w_temp, a;
+      matrix Q, Q_temp, R;
+      double scale,s2,c,inv_len_mu;
+      
+      for (int i = 0; i < nlocal; i++) {
+        if (mask[i] & groupbit && mu[i][3] > 0.0) {
+          
+          // Construct Q from dipole:
+          // Q is the rotation matrix from space frame to body frame
+          // i.e. v_b = Q.v_s
+          
+          // Define mu to lie along the z axis in the body frame
+          // We take the unit dipole to avoid getting a scaling matrix
+          inv_len_mu = 1.0/mu[i][3];
+          a[0] = mu[i][0]*inv_len_mu;
+          a[1] = mu[i][1]*inv_len_mu;
+          a[2] = mu[i][2]*inv_len_mu;
+          
+          // v = a x [0 0 1] - cross product of mu in space and body frames
+          // s = |v|
+          // c = a.[0 0 1] = a[2]
+          // vx = [ 0    -v[2]  v[1]
+          //        v[2]  0    -v[0]
+          //       -v[1]  v[0]  0    ]
+          // then
+          // Q = I + vx + vx^2 * (1-c)/s^2
+          
+          s2 = a[0]*a[0] + a[1]*a[1];
+          if (s2 != 0.0){ // i.e. the vectors are not parallel
+            scale = (1.0 - a[2])/s2;
+            
+            Q[0][0] = 1.0 - scale*a[0]*a[0]; Q[0][1] = -scale*a[0]*a[1];      Q[0][2] = -a[0];
+            Q[1][0] = -scale*a[0]*a[1];      Q[1][1] = 1.0 - scale*a[1]*a[1]; Q[1][2] = -a[1];
+            Q[2][0] = a[0];                  Q[2][1] = a[1];                  Q[2][2] = 1.0 - scale*(a[0]*a[0] + a[1]*a[1]);
+          }else{ // if parallel then we just have I or -I
+            Q[0][0] = 1.0/a[2];  Q[0][1] = 0.0;       Q[0][2] = 0.0;
+            Q[1][0] = 0.0;       Q[1][1] = 1.0/a[2];  Q[1][2] = 0.0;
+            Q[2][0] = 0.0;       Q[2][1] = 0.0;       Q[2][2] = 1.0/a[2];
+          }
+          
+          // Local copy of this particle's angular velocity (in space frame)
+          w[0] = omega[i][0]; w[1] = omega[i][1]; w[2] = omega[i][2];
+          
+          // Transform omega into body frame: w_temp= Q.w
+          matvec(Q,w,w_temp);
+          
+          // Construct rotation R1
+          BuildRxMatrix(R, dtf/force->ftm2v*w_temp[0]);
+          
+          // Apply R1 to w: w = R.w_temp
+          matvec(R,w_temp,w);
+          
+          // Apply R1 to Q: Q_temp = R^T.Q
+          transpose_times3(R,Q,Q_temp);
+          
+          // Construct rotation R2
+          BuildRyMatrix(R, dtf/force->ftm2v*w[1]);
+          
+          // Apply R2 to w: w_temp = R.w
+          matvec(R,w,w_temp);
+          
+          // Apply R2 to Q: Q = R^T.Q_temp
+          transpose_times3(R,Q_temp,Q);
+          
+          // Construct rotation R3
+          BuildRzMatrix(R, 2.0*dtf/force->ftm2v*w_temp[2]);
+          
+          // Apply R3 to w: w = R.w_temp
+          matvec(R,w_temp,w);
+          
+          // Apply R3 to Q: Q_temp = R^T.Q
+          transpose_times3(R,Q,Q_temp);
+          
+          // Construct rotation R4
+          BuildRyMatrix(R, dtf/force->ftm2v*w[1]);
+          
+          // Apply R4 to w: w_temp = R.w
+          matvec(R,w,w_temp);
+          
+          // Apply R4 to Q: Q = R^T.Q_temp
+          transpose_times3(R,Q_temp,Q);
+          
+          // Construct rotation R5
+          BuildRxMatrix(R, dtf/force->ftm2v*w_temp[0]);
+          
+          // Apply R5 to w: w = R.w_temp
+          matvec(R,w_temp,w);
+          
+          // Apply R5 to Q: Q_temp = R^T.Q
+          transpose_times3(R,Q,Q_temp);
+          
+          // Transform w back into space frame w_temp = Q^T.w
+          transpose_matvec(Q_temp,w,w_temp);
+          omega[i][0] = w_temp[0]; omega[i][1] = w_temp[1]; omega[i][2] = w_temp[2];
+          
+          // Set dipole according to updated Q: mu = Q^T.[0 0 1] * |mu|
+          mu[i][0] = Q_temp[2][0] * mu[i][3];
+          mu[i][1] = Q_temp[2][1] * mu[i][3];
+          mu[i][2] = Q_temp[2][2] * mu[i][3];
         }
+      }
+    }
   }
 }
 

--- a/src/fix_nve_sphere.cpp
+++ b/src/fix_nve_sphere.cpp
@@ -21,13 +21,17 @@
 #include "respa.h"
 #include "force.h"
 #include "error.h"
+#include "math_vector.h"
+#include "math_extra.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
+using namespace MathExtra;
 
 #define INERTIA 0.4          // moment of inertia prefactor for sphere
 
 enum{NONE,DIPOLE};
+enum{NODLM,DLM};
 
 /* ---------------------------------------------------------------------- */
 
@@ -41,6 +45,7 @@ FixNVESphere::FixNVESphere(LAMMPS *lmp, int narg, char **arg) :
   // process extra keywords
 
   extra = NONE;
+  dlm = NODLM;
 
   int iarg = 3;
   while (iarg < narg) {
@@ -49,6 +54,9 @@ FixNVESphere::FixNVESphere(LAMMPS *lmp, int narg, char **arg) :
       if (strcmp(arg[iarg+1],"dipole") == 0) extra = DIPOLE;
       else error->all(FLERR,"Illegal fix nve/sphere command");
       iarg += 2;
+    } else if (strcmp(arg[iarg],"dlm") == 0) {
+      dlm = DLM;
+      iarg += 1;
     } else error->all(FLERR,"Illegal fix nve/sphere command");
   }
 
@@ -57,7 +65,9 @@ FixNVESphere::FixNVESphere(LAMMPS *lmp, int narg, char **arg) :
   if (!atom->sphere_flag)
     error->all(FLERR,"Fix nve/sphere requires atom style sphere");
   if (extra == DIPOLE && !atom->mu_flag)
-    error->all(FLERR,"Fix nve/sphere dipole requires atom attribute mu");
+    error->all(FLERR,"Fix nve/sphere update dipole requires atom attribute mu");
+  if (dlm == DLM && extra != DIPOLE)
+    error->all(FLERR,"Fix nve/sphere dlm must be used with update dipole");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -83,8 +93,10 @@ void FixNVESphere::init()
 
 void FixNVESphere::initial_integrate(int vflag)
 {
-  double dtfm,dtirotate,msq,scale;
+  double dtfm,dtirotate,msq,scale,s2,c,inv_len_mu;
   double g[3];
+  vector w, w_temp, a;
+  matrix Q, Q_temp, R;
 
   double **x = atom->x;
   double **v = atom->v;
@@ -120,25 +132,127 @@ void FixNVESphere::initial_integrate(int vflag)
       omega[i][2] += dtirotate * torque[i][2];
     }
   }
-
+  
   // update mu for dipoles
-  // d_mu/dt = omega cross mu
-  // renormalize mu to dipole length
+  
 
   if (extra == DIPOLE) {
     double **mu = atom->mu;
-    for (int i = 0; i < nlocal; i++)
-      if (mask[i] & groupbit)
-        if (mu[i][3] > 0.0) {
-          g[0] = mu[i][0] + dtv * (omega[i][1]*mu[i][2]-omega[i][2]*mu[i][1]);
-          g[1] = mu[i][1] + dtv * (omega[i][2]*mu[i][0]-omega[i][0]*mu[i][2]);
-          g[2] = mu[i][2] + dtv * (omega[i][0]*mu[i][1]-omega[i][1]*mu[i][0]);
-          msq = g[0]*g[0] + g[1]*g[1] + g[2]*g[2];
-          scale = mu[i][3]/sqrt(msq);
-          mu[i][0] = g[0]*scale;
-          mu[i][1] = g[1]*scale;
-          mu[i][2] = g[2]*scale;
+    if (dlm == NODLM) {
+      // d_mu/dt = omega cross mu
+      // renormalize mu to dipole length
+      for (int i = 0; i < nlocal; i++)
+        if (mask[i] & groupbit)
+          if (mu[i][3] > 0.0) {
+            g[0] = mu[i][0] + dtv * (omega[i][1]*mu[i][2]-omega[i][2]*mu[i][1]);
+            g[1] = mu[i][1] + dtv * (omega[i][2]*mu[i][0]-omega[i][0]*mu[i][2]);
+            g[2] = mu[i][2] + dtv * (omega[i][0]*mu[i][1]-omega[i][1]*mu[i][0]);
+            msq = g[0]*g[0] + g[1]*g[1] + g[2]*g[2];
+            scale = mu[i][3]/sqrt(msq);
+            mu[i][0] = g[0]*scale;
+            mu[i][1] = g[1]*scale;
+            mu[i][2] = g[2]*scale;
+          }
+    }else{
+      // Integrate orientation following Dullweber-Leimkuhler-Maclachlan scheme
+      for (int i = 0; i < nlocal; i++) {
+        if (mask[i] & groupbit && mu[i][3] > 0.0) {
+          
+          // Construct Q from dipole:
+          // Q is the rotation matrix from space frame to body frame
+          // i.e. v_b = Q.v_s
+          
+          // Define mu to lie along the z axis in the body frame
+          // We take the unit dipole to avoid getting a scaling matrix
+          inv_len_mu = 1.0/mu[i][3];
+          a[0] = mu[i][0]*inv_len_mu;
+          a[1] = mu[i][1]*inv_len_mu;
+          a[2] = mu[i][2]*inv_len_mu;
+          
+          // v = a x [0 0 1] - cross product of mu in space and body frames
+          // s = |v|
+          // c = a.[0 0 1] = a[2]
+          // vx = [ 0    -v[2]  v[1]
+          //        v[2]  0    -v[0]
+          //       -v[1]  v[0]  0    ]
+          // then
+          // Q = I + vx + vx^2 * (1-c)/s^2
+          
+          s2 = a[0]*a[0] + a[1]*a[1];
+          if (s2 != 0.0){ // i.e. the vectors are not parallel
+            scale = (1.0 - a[2])/s2;
+            
+            Q[0][0] = 1.0 - scale*a[0]*a[0]; Q[0][1] = -scale*a[0]*a[1];      Q[0][2] = -a[0];
+            Q[1][0] = -scale*a[0]*a[1];      Q[1][1] = 1.0 - scale*a[1]*a[1]; Q[1][2] = -a[1];
+            Q[2][0] = a[0];                  Q[2][1] = a[1];                  Q[2][2] = 1.0 - scale*(a[0]*a[0] + a[1]*a[1]);
+          }else{ // if parallel then we just have I or -I
+            Q[0][0] = 1.0/a[2];  Q[0][1] = 0.0;       Q[0][2] = 0.0;
+            Q[1][0] = 0.0;       Q[1][1] = 1.0/a[2];  Q[1][2] = 0.0;
+            Q[2][0] = 0.0;       Q[2][1] = 0.0;       Q[2][2] = 1.0/a[2];
+          }
+          
+          // Local copy of this particle's angular velocity (in space frame)
+          w[0] = omega[i][0]; w[1] = omega[i][1]; w[2] = omega[i][2];
+          
+          // Transform omega into body frame: w_temp= Q.w
+          matvec(Q,w,w_temp);
+          
+          // Construct rotation R1
+          BuildRxMatrix(R, dtf/force->ftm2v*w_temp[0]);
+          
+          // Apply R1 to w: w = R.w_temp
+          matvec(R,w_temp,w);
+          
+          // Apply R1 to Q: Q_temp = R^T.Q
+          transpose_times3(R,Q,Q_temp);
+          
+          // Construct rotation R2
+          BuildRyMatrix(R, dtf/force->ftm2v*w[1]);
+          
+          // Apply R2 to w: w_temp = R.w
+          matvec(R,w,w_temp);
+          
+          // Apply R2 to Q: Q = R^T.Q_temp
+          transpose_times3(R,Q_temp,Q);
+          
+          // Construct rotation R3
+          BuildRzMatrix(R, 2.0*dtf/force->ftm2v*w_temp[2]);
+          
+          // Apply R3 to w: w = R.w_temp
+          matvec(R,w_temp,w);
+          
+          // Apply R3 to Q: Q_temp = R^T.Q
+          transpose_times3(R,Q,Q_temp);
+          
+          // Construct rotation R4
+          BuildRyMatrix(R, dtf/force->ftm2v*w[1]);
+          
+          // Apply R4 to w: w_temp = R.w
+          matvec(R,w,w_temp);
+          
+          // Apply R4 to Q: Q = R^T.Q_temp
+          transpose_times3(R,Q_temp,Q);
+          
+          // Construct rotation R5
+          BuildRxMatrix(R, dtf/force->ftm2v*w_temp[0]);
+          
+          // Apply R5 to w: w = R.w_temp
+          matvec(R,w_temp,w);
+          
+          // Apply R5 to Q: Q_temp = R^T.Q
+          transpose_times3(R,Q,Q_temp);
+          
+          // Transform w back into space frame w_temp = Q^T.w
+          transpose_matvec(Q_temp,w,w_temp);
+          omega[i][0] = w_temp[0]; omega[i][1] = w_temp[1]; omega[i][2] = w_temp[2];
+          
+          // Set dipole according to updated Q: mu = Q^T.[0 0 1] * |mu|
+          mu[i][0] = Q_temp[2][0] * mu[i][3];
+          mu[i][1] = Q_temp[2][1] * mu[i][3];
+          mu[i][2] = Q_temp[2][2] * mu[i][3];
         }
+      }
+    }
   }
 }
 
@@ -165,6 +279,7 @@ void FixNVESphere::final_integrate()
   // update v,omega for all particles
   // d_omega/dt = torque / inertia
 
+  double rke = 0.0;
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
       dtfm = dtf / rmass[i];
@@ -176,5 +291,7 @@ void FixNVESphere::final_integrate()
       omega[i][0] += dtirotate * torque[i][0];
       omega[i][1] += dtirotate * torque[i][1];
       omega[i][2] += dtirotate * torque[i][2];
+      rke += (omega[i][0]*omega[i][0] + omega[i][1]*omega[i][1] + omega[i][2]*omega[i][2])*radius[i]*radius[i]*rmass[i];
     }
+  
 }

--- a/src/fix_nve_sphere.h
+++ b/src/fix_nve_sphere.h
@@ -34,6 +34,7 @@ class FixNVESphere : public FixNVE {
 
  protected:
   int extra;
+  int dlm;
 };
 
 }
@@ -53,12 +54,17 @@ E: Fix nve/sphere requires atom style sphere
 
 Self-explanatory.
 
-E: Fix nve/sphere dipole requires atom attribute mu
+E: Fix nve/sphere update dipole requires atom attribute mu
 
 An atom style with this attribute is needed.
 
 E: Fix nve/sphere requires extended particles
 
 This fix can only be used for particles of a finite size.
+ 
+E: Fix nve/sphere dlm must be used with update dipole
+ 
+The DLM algorithm can only be used in conjunction with update dipole.
+
 
 */

--- a/src/math_extra.cpp
+++ b/src/math_extra.cpp
@@ -607,6 +607,51 @@ void inertia_triangle(double *idiag, double *quat, double mass,
   inertia[5] = tensor[0][1];
 }
 
+/* ----------------------------------------------------------------------
+ Build rotation matrix for a small angle rotation around the X axis
+ ------------------------------------------------------------------------- */
+
+void BuildRxMatrix(double R[3][3], const double angle)
+{
+  const double angleSq = angle * angle;
+  const double cosAngle = (1.0 - angleSq * 0.25) / (1.0 + angleSq * 0.25);
+  const double sinAngle = angle / (1.0 + angleSq * 0.25);
+  
+  R[0][0] = 1.0;  R[0][1] = 0.0;       R[0][2] = 0.0;
+  R[1][0] = 0.0;  R[1][1] = cosAngle;  R[1][2] = -sinAngle;
+  R[2][0] = 0.0;  R[2][1] = sinAngle;  R[2][2] = cosAngle;
+}
+
+/* ----------------------------------------------------------------------
+ Build rotation matrix for a small angle rotation around the Y axis
+ ------------------------------------------------------------------------- */
+
+void BuildRyMatrix(double R[3][3], const double angle)
+{
+  const double angleSq = angle * angle;
+  const double cosAngle = (1.0 - angleSq * 0.25) / (1.0 + angleSq * 0.25);
+  const double sinAngle = angle / (1.0 + angleSq * 0.25);
+  
+  R[0][0] = cosAngle;   R[0][1] = 0.0;  R[0][2] = sinAngle;
+  R[1][0] = 0.0;        R[1][1] = 1.0;  R[1][2] = 0.0;
+  R[2][0] = -sinAngle;  R[2][1] = 0.0;  R[2][2] = cosAngle;
+}
+
+/* ----------------------------------------------------------------------
+ Build rotation matrix for a small angle rotation around the Y axis
+ ------------------------------------------------------------------------- */
+
+void BuildRzMatrix(double R[3][3], const double angle)
+{
+  const double angleSq = angle * angle;
+  const double cosAngle = (1.0 - angleSq * 0.25) / (1.0 + angleSq * 0.25);
+  const double sinAngle = angle / (1.0 + angleSq * 0.25);
+  
+  R[0][0] = cosAngle;  R[0][1] = -sinAngle;  R[0][2] = 0.0;
+  R[1][0] = sinAngle;  R[1][1] = cosAngle;   R[1][2] = 0.0;
+  R[2][0] = 0.0;       R[2][1] = 0.0;        R[2][2] = 1.0;
+}
+
 /* ---------------------------------------------------------------------- */
 
 }

--- a/src/math_extra.h
+++ b/src/math_extra.h
@@ -111,6 +111,10 @@ namespace MathExtra {
   inline void rotation_generator_x(const double m[3][3], double ans[3][3]);
   inline void rotation_generator_y(const double m[3][3], double ans[3][3]);
   inline void rotation_generator_z(const double m[3][3], double ans[3][3]);
+  
+  void BuildRxMatrix(double R[3][3], const double angle);
+  void BuildRyMatrix(double R[3][3], const double angle);
+  void BuildRzMatrix(double R[3][3], const double angle);
 
   // moment of inertia operations
 


### PR DESCRIPTION
This branch introduces the Dullweber-Leimkuhler McLachlan (DLM) integrator (see http://dx.doi.org/10.1063/1.474310) into fix_nve_sphere and fix_nh_sphere.  The existing behaviour is kept as the default, to use the new integrator add the keyword 'dlm' to the fix command.  Some convenience functions shared between the two implementations are added to math_extra.

In our tests, DLM provides better energy conservation and small drift / longer timesteps than the currently implemented rotational integrator in LAMMPS.