### PR TITLE
Restore USER-DPD to a working state after the neighbor list refactoring.

### DIFF
--- a/src/USER-DPD/np_half_bin_newton_ssa.h
+++ b/src/USER-DPD/np_half_bin_newton_ssa.h
@@ -13,7 +13,7 @@
 
 #ifdef NEIGH_PAIR_CLASS
 
-NeighPairStyle(NEIGH_PAIR_HALF_BIN_NEWTON_SSA,NeighPairHalfBinNewtonSsa)
+NeighPairStyle(NEIGH_PAIR_HALF_BIN_NEWTON_SSA,NeighPairHalfBinNewtonSSA)
 
 #else
 
@@ -24,10 +24,10 @@ NeighPairStyle(NEIGH_PAIR_HALF_BIN_NEWTON_SSA,NeighPairHalfBinNewtonSsa)
 
 namespace LAMMPS_NS {
 
-class NeighPairHalfBinNewtonSsa : public NeighPair {
+class NeighPairHalfBinNewtonSSA : public NeighPair {
  public:
-  NeighPairHalfBinNewtonSsa(class LAMMPS *);
-  ~NeighPairHalfBinNewtonSsa() {}
+  NeighPairHalfBinNewtonSSA(class LAMMPS *);
+  ~NeighPairHalfBinNewtonSSA() {}
   void build(class NeighList *);
 };
 

--- a/src/USER-DPD/np_half_from_full_newton_ssa.cpp
+++ b/src/USER-DPD/np_half_from_full_newton_ssa.cpp
@@ -32,7 +32,7 @@ using namespace LAMMPS_NS;
 // prototype for non-class function
 
 static int *ssaAIRptr;
-int cmp_ssaAIR(const void *, const void *);
+static int cmp_ssaAIR(const void *, const void *);
 
 /* ---------------------------------------------------------------------- */
 
@@ -122,7 +122,7 @@ void NeighPairHalfFromFullNewtonSSA::build(NeighList *list)
    accesses static class member ssaAIRptr, set before call to qsort()
 ------------------------------------------------------------------------- */
 
-int cmp_ssaAIR(const void *iptr, const void *jptr)
+static int cmp_ssaAIR(const void *iptr, const void *jptr)
 {
   int i = *((int *) iptr);
   int j = *((int *) jptr);

--- a/src/USER-DPD/ns_half_bin_2d_ssa.cpp
+++ b/src/USER-DPD/ns_half_bin_2d_ssa.cpp
@@ -35,19 +35,21 @@ NeighStencilHalfBin2dSSA::NeighStencilHalfBin2dSSA(LAMMPS *lmp) :
    for half list with newton on:
      stencil is bins to the "upper right" of central bin
      stencil does not include self
+   Additionally, includes the bins beyond nstencil that are needed
+   to locate all the Active Interaction Region (AIR) ghosts for SSA
 ------------------------------------------------------------------------- */
 
 void NeighStencilHalfBin2dSSA::create()
 {
-  int i,j;
-
-  nstencil = 0;
+  int i,j,pos = 0;
 
   for (j = 0; j <= sy; j++)
     for (i = -sx; i <= sx; i++)
       if (j > 0 || (j == 0 && i > 0))
         if (bin_distance(i,j,0) < cutneighmaxsq)
-          stencil[nstencil++] = j*mbinx + i;
+          stencil[pos++] = j*mbinx + i;
+
+  nstencil = pos; // record where normal half stencil ends
 
   // include additional bins for AIR ghosts only
 
@@ -55,12 +57,8 @@ void NeighStencilHalfBin2dSSA::create()
     for (i = -sx; i <= sx; i++) {
       if (j == 0 && i > 0) continue;
       if (bin_distance(i,j,0) < cutneighmaxsq)
-        stencil[nstencil++] = j*mbinx + i;
+        stencil[pos++] = j*mbinx + i;
     }
 
-  // NOTE to Tim: not sure why you need to pad the stencil?
-
-  while (nstencil < maxstencil) {
-    stencil[nstencil++] = INT_MAX;
-  }
+  nstencil_ssa = pos; // record where full stencil ends
 }

--- a/src/neigh_pair.cpp
+++ b/src/neigh_pair.cpp
@@ -113,6 +113,7 @@ void NeighPair::copy_bin_info()
 void NeighPair::copy_stencil_info()
 {
   nstencil = ns->nstencil;
+  nstencil_ssa = ns->nstencil_ssa;
   stencil = ns->stencil;
   stencilxyz = ns->stencilxyz;
   nstencil_multi = ns->nstencil_multi;

--- a/src/neigh_pair.h
+++ b/src/neigh_pair.h
@@ -81,6 +81,7 @@ class NeighPair : protected Pointers {
   // data from NeighStencil class
 
   int nstencil;
+  int nstencil_ssa;
   int *stencil;
   int **stencilxyz;
   int *nstencil_multi;

--- a/src/neigh_stencil.h
+++ b/src/neigh_stencil.h
@@ -28,6 +28,7 @@ class NeighStencil : protected Pointers {
   bigint last_copy_bin;
 
   int nstencil;                    // # of bins in stencil
+  int nstencil_ssa;                // # of total bins in SSA stencil
   int *stencil;                    // list of bin offsets
   int **stencilxyz;                // bin offsets in xyz dims
   int *nstencil_multi;             // # bins in each type-based multi stencil


### PR DESCRIPTION
Still need to move SSA binning stuff from np_half_bin_newton_ssa.cpp to a NeighBinShardlow class.
Note: I added "int nstencil_ssa" to record my auxiliary stencil length, which is ugly,
and won't be good long term.

I will need more fine detail about the SSA stencil in the near future, since I will be processing it in phases in prep for kokkos parallelism.  Specifically, I will need a 5 (possibly 9) element array of indexes into the stencil:
uint16 nstencil_ssa_ndx[5];

So, how to get that info from out of ns_half_bin_[23]d_ssa.* into both np_half_bin_newton_ssa.cpp and fix_shardlow.cpp will be a problem to be solved in the near future.

Anyway, this pull request makes the USER-DPD code function again, and it passes all my tests.