### PR TITLE
USER-DPD: Neighbor refactor: replace nstencil_ssa hack

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -16,6 +16,8 @@
 /*_tally.cpp
 /*_rx.h
 /*_rx.cpp
+/*_ssa.h
+/*_ssa.cpp
 
 /kokkos.cpp
 /kokkos.h

--- a/src/USER-DPD/np_half_bin_newton_ssa.cpp
+++ b/src/USER-DPD/np_half_bin_newton_ssa.cpp
@@ -197,8 +197,9 @@ void NeighPairHalfBinNewtonSSA::build(NeighList *list)
     ibin = coord2bin(x[i]);
 
     // loop over all local atoms in other bins in "half" stencil
+    int stencil_end = aux_nstencil[0];
 
-    for (k = 0; k < nstencil; k++) {
+    for (k = 0; k < stencil_end; k++) {
       for (j = list->binhead_ssa[ibin+stencil[k]]; j >= 0; 
            j = list->bins_ssa[j]) {
 
@@ -234,7 +235,7 @@ void NeighPairHalfBinNewtonSSA::build(NeighList *list)
     // That is a significant time savings because of the "full" stencil
     // Note2: only non-pure locals can have ghosts as neighbors
 
-    if (ssaAIR[i] == 1) for (k = 0; k < nstencil_ssa; k++) {
+    if (ssaAIR[i] == 1) for (k = 0; k < nstencil; k++) {
       for (j = list->gbinhead_ssa[ibin+stencil[k]]; j >= 0; 
            j = list->bins_ssa[j]) {
 

--- a/src/neigh_pair.cpp
+++ b/src/neigh_pair.cpp
@@ -113,12 +113,13 @@ void NeighPair::copy_bin_info()
 void NeighPair::copy_stencil_info()
 {
   nstencil = ns->nstencil;
-  nstencil_ssa = ns->nstencil_ssa;
   stencil = ns->stencil;
   stencilxyz = ns->stencilxyz;
   nstencil_multi = ns->nstencil_multi;
   stencil_multi = ns->stencil_multi;
   distsq_multi = ns->distsq_multi;
+  naux_nstencil = ns->naux_nstencil;
+  aux_nstencil = ns->aux_nstencil;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/neigh_pair.h
+++ b/src/neigh_pair.h
@@ -81,12 +81,13 @@ class NeighPair : protected Pointers {
   // data from NeighStencil class
 
   int nstencil;
-  int nstencil_ssa;
   int *stencil;
   int **stencilxyz;
   int *nstencil_multi;
   int **stencil_multi;
   double **distsq_multi;
+  int naux_nstencil;
+  int *aux_nstencil;
 
   // data common to all NeighPair variants
 

--- a/src/neigh_stencil.cpp
+++ b/src/neigh_stencil.cpp
@@ -61,6 +61,8 @@ NeighStencil::NeighStencil(LAMMPS *lmp) : Pointers(lmp)
   nstencil_multi = NULL;
   stencil_multi = NULL;
   distsq_multi = NULL;
+  naux_nstencil = 0;
+  aux_nstencil = NULL;
 
   dimension = domain->dimension;
 }
@@ -72,6 +74,7 @@ NeighStencil::~NeighStencil()
   memory->destroy(stencil);
   memory->destroy(stencilxyz);
   memory->destroy(nstencil_multi);
+  memory->destroy(aux_nstencil);
 
   if (!stencil_multi) return;
 
@@ -216,6 +219,7 @@ bigint NeighStencil::memory_usage()
   if (neighstyle == BIN) {
     bytes += memory->usage(stencil,maxstencil);
     bytes += memory->usage(stencilxyz,maxstencil,3);
+    bytes += memory->usage(aux_nstencil,naux_nstencil);
   } else if (neighstyle == MULTI) {
     bytes += atom->ntypes*maxstencil_multi * sizeof(int);
     bytes += atom->ntypes*maxstencil_multi * sizeof(double);

--- a/src/neigh_stencil.h
+++ b/src/neigh_stencil.h
@@ -28,12 +28,13 @@ class NeighStencil : protected Pointers {
   bigint last_copy_bin;
 
   int nstencil;                    // # of bins in stencil
-  int nstencil_ssa;                // # of total bins in SSA stencil
   int *stencil;                    // list of bin offsets
   int **stencilxyz;                // bin offsets in xyz dims
   int *nstencil_multi;             // # bins in each type-based multi stencil
   int **stencil_multi;             // list of bin offsets in each stencil
   double **distsq_multi;           // sq distances to bins in each stencil
+  int naux_nstencil; // length of auxillary array aux_nstencil[]
+  int *aux_nstencil; // auxillary array of indexes referencing parts of stencil
 
   NeighStencil(class LAMMPS *);
   virtual ~NeighStencil();


### PR DESCRIPTION
This request addresses my comment in pull request #123 about the nstencil_ssa field being ugly and not good long term.

The new aux_nstencil[] and naux_nstencil fields allow for the SSA stencil (and others) to have a richer stencil structure.  The aux_nstencil[] values point to the end of spacial regions that the stencil covers, allowing the neighbor list to be constructed such that neighbors in particular sub-regions are grouped together.  Currently the SSA code has just one sub-region in the stencil, but I have a development branch with currently 5 sub-regions.