### PR TITLE
Fix bond create updated

### DIFF
--- a/doc/src/fix_bond_create.txt
+++ b/doc/src/fix_bond_create.txt
@@ -41,7 +41,10 @@ keyword = {iparam} or {jparam} or {prob} or {atype} or {dtype} or {itype} :l
 
 fix 5 all bond/create 10 1 2 0.8 1
 fix 5 all bond/create 1 3 3 0.8 1 prob 0.5 85784 iparam 2 3
-fix 5 all bond/create 1 3 3 0.8 1 prob 0.5 85784 iparam 2 3 atype 1 dtype 2 :pre
+
+varialbe  ang_type string "1 2 1 1 2 1 2 2 3 3 1 3 1 3 1 4 2 1 3 5 * * * 6"
+variable dtype_type string "1 2 1 2 1 * * * * 2"
+fix 5 all bond/create 1 3 3 0.8 1 prob 0.5 85784 iparam 2 3 atype ang_type dtype dtype_type :pre
 
 [Description:]
 
@@ -52,7 +55,10 @@ context, a bond means an interaction between a pair of atoms computed
 by the "bond_style"_bond_style.html command.  Once the bond is created
 it will be permanently in place.  Optionally, the creation of a bond
 can also create angle, dihedral, and improper interactions that bond
-is part of.  See the discussion of the {atype}, {dtype}, and {itype}
+is part of.  Type of angle, proper/improper dihedrals can be specified with 
+an number, or with a "angle_type", "dihedral_type", or "improper_type" class 
+which determines types of newly created angles, dihedrals based on the type of 
+atoms in the angle or dihedral. See the discussion of the {atype}, {dtype}, and {itype}
 keywords below.
 
 This is different than a "pairwise"_pair_style.html bond-order
@@ -127,7 +133,10 @@ interactions inferred by the creation of a bond will create new angles
 of type {angletype}, with parameters assigned by the corresponding
 "angle_coeff"_angle_coeff.html command.  Likewise, the {dtype} and
 {itype} keywords will create new dihedrals and impropers of type
-{dihedraltype} and {impropertype}.
+{dihedraltype} and {impropertype}. Type of angles, proper/improper dihedrals created
+due to fomation of the bond can be specified with an number, or with a "angle_type", 
+"dihedral_type", or "improper_type" variable which determines types of 
+newly created angles, dihedrals based on the type of atoms in the angle or dihedral.
 
 NOTE: To create a new bond, the internal LAMMPS data structures that
 store this information must have space for it.  When LAMMPS is
@@ -167,8 +176,8 @@ be potentially turned off or weighted by the 1-3 weighting specified
 by the "special_bonds"_special_bonds.html command.  This is the case
 even if the "angle yes" option was used with that command.  The same
 is true for 3rd neighbors (1-4 interactions), the {dtype} keyword, and
-the "dihedral yes" option used with the
-"special_bonds"_special_bonds.html command.
+the "dihedral yes" option used with the "special_bonds"_special_bonds.html 
+command.
 
 Note that even if your simulation starts with no bonds, you must
 define a "bond_style"_bond_style.html and use the
@@ -208,7 +217,7 @@ created bonds (and angles, dihedrals, impropers).
 
 No information about this fix is written to "binary restart
 files"_restart.html.  None of the "fix_modify"_fix_modify.html options
-are relevant to this fix.
+are relevant to this fix. 
 
 This fix computes two statistics which it stores in a global vector of
 length 2, which can be accessed by various "output

--- a/doc/src/fix_bond_create.txt
+++ b/doc/src/fix_bond_create.txt
@@ -42,8 +42,8 @@ keyword = {iparam} or {jparam} or {prob} or {atype} or {dtype} or {itype} :l
 fix 5 all bond/create 10 1 2 0.8 1
 fix 5 all bond/create 1 3 3 0.8 1 prob 0.5 85784 iparam 2 3
 
-varialbe  ang_type string "1 2 1 1 2 1 2 2 3 3 1 3 1 3 1 4 2 1 3 5 * * * 6"
-variable dtype_type string "1 2 1 2 1 * * * * 2"
+varialbe  ang_type string "1 2 1 1 ; 2 1 2 2 ; 3 3 1 3 ; 1 3 1 4 ; 2 1 3 5 ; * * * 6"
+variable dtype_type string "1 2 1 2 1 , * * * * 2"
 fix 5 all bond/create 1 3 3 0.8 1 prob 0.5 85784 iparam 2 3 atype ang_type dtype dtype_type :pre
 
 [Description:]

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -1,21 +1,21 @@
 /* ----------------------------------------------------------------------
-   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   http://lammps.sandia.gov, Sandia National Laboratories
-   Steve Plimpton, sjplimp@sandia.gov
+ LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+ http://lammps.sandia.gov, Sandia National Laboratories
+ Steve Plimpton, sjplimp@sandia.gov
 
-   Copyright (2003) Sandia Corporation.  Under the terms of Contract
-   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-   certain rights in this software.  This software is distributed under
-   the GNU General Public License.
+ Copyright (2003) Sandia Corporation.  Under the terms of Contract
+ DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+ certain rights in this software.  This software is distributed under
+ the GNU General Public License.
 
-   See the README file in the top-level LAMMPS directory.
-------------------------------------------------------------------------- */
+ See the README file in the top-level LAMMPS directory.
+ ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Assigning different types for angle, dihedral, and
-   improper dihedral angles added to the code:
-   Contributing author: Amin Aramoon (Johns Hopkins U)
-------------------------------------------------------------------------- */
+ Assigning different types for angle, dihedral, and
+ improper dihedral angles added to the code:
+ Contributing author: Amin Aramoon (Johns Hopkins U)
+ ------------------------------------------------------------------------- */
 
 #include <math.h>
 #include <mpi.h>
@@ -37,6 +37,7 @@
 #include "error.h"
 #include "variable.h"
 #include "input.h"
+#include "citeme.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -44,1486 +45,1615 @@ using namespace FixConst;
 #define BIG 1.0e20
 #define DELTA 16
 
+static const char cite_crosslinking[] =
+		"cross linking command:\n\n"
+				"@Article{Aramoon16,\n"
+				" author =  {A. Aramoon, T. D. Breitzman, C. F. Woodward, and J. A. El-Awady},\n"
+				" title =   {A Coarse-Grained Molecular Dynamics Study of the Curing and Properties of Highly Cross-Linked Epoxy Polymers},\n"
+				" journal = {J.~Phys.~Chem.B},\n"
+				" year =    2016,\n"
+				" doi =  10.1021/acs.jpcb.6b03809 \n"
+				"}\n\n";
+
 /* ---------------------------------------------------------------------- */
 
 FixBondCreate::FixBondCreate(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg)
-{
-  if (narg < 8) error->all(FLERR,"Illegal fix bond/create command");
+		Fix(lmp, narg, arg) {
+	if (narg < 8)
+		error->all(FLERR, "Illegal fix bond/create command");
 
-  MPI_Comm_rank(world,&me);
+	MPI_Comm_rank(world, &me);
 
-  nevery = force->inumeric(FLERR,arg[3]);
-  if (nevery <= 0) error->all(FLERR,"Illegal fix bond/create command");
+	nevery = force->inumeric(FLERR, arg[3]);
+	if (nevery <= 0)
+		error->all(FLERR, "Illegal fix bond/create command");
 
-  force_reneighbor = 1;
-  next_reneighbor = -1;
-  vector_flag = 1;
-  size_vector = 2;
-  global_freq = 1;
-  extvector = 0;
+	force_reneighbor = 1;
+	next_reneighbor = -1;
+	vector_flag = 1;
+	size_vector = 2;
+	global_freq = 1;
+	extvector = 0;
 
-  iatomtype = force->inumeric(FLERR,arg[4]);
-  jatomtype = force->inumeric(FLERR,arg[5]);
-  double cutoff = force->numeric(FLERR,arg[6]);
-  btype = force->inumeric(FLERR,arg[7]);
+	iatomtype = force->inumeric(FLERR, arg[4]);
+	jatomtype = force->inumeric(FLERR, arg[5]);
+	double cutoff = force->numeric(FLERR, arg[6]);
+	btype = force->inumeric(FLERR, arg[7]);
 
-  if (iatomtype < 1 || iatomtype > atom->ntypes ||
-      jatomtype < 1 || jatomtype > atom->ntypes)
-    error->all(FLERR,"Invalid atom type in fix bond/create command");
-  if (cutoff < 0.0) error->all(FLERR,"Illegal fix bond/create command");
-  if (btype < 1 || btype > atom->nbondtypes)
-    error->all(FLERR,"Invalid bond type in fix bond/create command");
+	if (iatomtype < 1 || iatomtype > atom->ntypes || jatomtype < 1
+			|| jatomtype > atom->ntypes)
+		error->all(FLERR, "Invalid atom type in fix bond/create command");
+	if (cutoff < 0.0)
+		error->all(FLERR, "Illegal fix bond/create command");
+	if (btype < 1 || btype > atom->nbondtypes)
+		error->all(FLERR, "Invalid bond type in fix bond/create command");
 
-  cutsq = cutoff*cutoff;
+	cutsq = cutoff * cutoff;
 
-  // optional keywords
+	// optional keywords
 
-  imaxbond = 0;
-  inewtype = iatomtype;
-  jmaxbond = 0;
-  jnewtype = jatomtype;
-  fraction = 1.0;
-  int seed = 12345;
-  atype = dtype = itype = 0;
+	imaxbond = 0;
+	inewtype = iatomtype;
+	jmaxbond = 0;
+	jnewtype = jatomtype;
+	fraction = 1.0;
+	int seed = 12345;
+	atype = dtype = itype = 0;
 
-  angle_detector = NULL;
-  dihedral_detector = NULL;
-  improper_detector = NULL;
+	angle_detector = NULL;
+	dihedral_detector = NULL;
+	improper_detector = NULL;
 
-  int iarg = 8;
-  while (iarg < narg) {
-    if (strcmp(arg[iarg],"iparam") == 0) {
-      if (iarg+3 > narg) error->all(FLERR,"Illegal fix bond/create command");
-      imaxbond = force->inumeric(FLERR,arg[iarg+1]);
-      inewtype = force->inumeric(FLERR,arg[iarg+2]);
-      if (imaxbond < 0) error->all(FLERR,"Illegal fix bond/create command");
-      if (inewtype < 1 || inewtype > atom->ntypes)
-        error->all(FLERR,"Invalid atom type in fix bond/create command");
-      iarg += 3;
-    } else if (strcmp(arg[iarg],"jparam") == 0) {
-      if (iarg+3 > narg) error->all(FLERR,"Illegal fix bond/create command");
-      jmaxbond = force->inumeric(FLERR,arg[iarg+1]);
-      jnewtype = force->inumeric(FLERR,arg[iarg+2]);
-      if (jmaxbond < 0) error->all(FLERR,"Illegal fix bond/create command");
-      if (jnewtype < 1 || jnewtype > atom->ntypes)
-        error->all(FLERR,"Invalid atom type in fix bond/create command");
-      iarg += 3;
-    } else if (strcmp(arg[iarg],"prob") == 0) {
-      if (iarg+3 > narg) error->all(FLERR,"Illegal fix bond/create command");
-      fraction = force->numeric(FLERR,arg[iarg+1]);
-      seed = force->inumeric(FLERR,arg[iarg+2]);
-      if (fraction < 0.0 || fraction > 1.0)
-        error->all(FLERR,"Illegal fix bond/create command");
-      if (seed <= 0) error->all(FLERR,"Illegal fix bond/create command");
-      iarg += 3;
-    } else if (strcmp(arg[iarg],"atype") == 0) {
-    	if (iarg + 2 > narg) error->all(FLERR, "Illegal fix bond/create command");
-    	if (isalpha(arg[iarg + 1][0])) {
-    		char* syntax = input->variable->retrieve(arg[iarg + 1]);
-    		angle_detector = new TypeDetector();
-    		bool sucess = angle_detector->init(syntax, 1);
-    		if (!sucess) error->all(FLERR, "Illegal fix bond/create command");
-    	} else {
-    		atype = force->inumeric(FLERR, arg[iarg + 1]);
-    		if (atype < 0)
-    		error->all(FLERR, "Illegal fix bond/create command");
-    	}
-    	iarg += 2;
-    } else if (strcmp(arg[iarg],"dtype") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix bond/create command");
-      if (isalpha(arg[iarg + 1][0])) {
-          char* syntax = input->variable->retrieve(arg[iarg + 1]);
-          dihedral_detector = new TypeDetector();
-          bool sucess = dihedral_detector->init(syntax, 2);
-          if (!sucess) error->all(FLERR, "Illegal fix bond/create command");
-      }
-      else {
-    	  dtype = force->inumeric(FLERR, arg[iarg + 1]);
-          if (dtype < 0) error->all(FLERR, "Illegal fix bond/create command");
-      }
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"itype") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix bond/create command");
-      if (isalpha(arg[iarg + 1][0])) {
-    	  char* syntax = input->variable->retrieve(arg[iarg + 1]);
-          improper_detector = new TypeDetector();
-          bool sucess = improper_detector->init(syntax, 3);
-          if (!sucess) error->all(FLERR, "Illegal fix bond/create command");
-      }
-      else {
-    	  itype = force->inumeric(FLERR, arg[iarg + 1]);
-          if (itype < 0) error->all(FLERR, "Illegal fix bond/create command");
-      }
-      iarg += 2;
-    } else error->all(FLERR,"Illegal fix bond/create command");
-  }
+	int iarg = 8;
+	while (iarg < narg) {
+		if (strcmp(arg[iarg], "iparam") == 0) {
+			if (iarg + 3 > narg)
+				error->all(FLERR, "Illegal fix bond/create command");
+			imaxbond = force->inumeric(FLERR, arg[iarg + 1]);
+			inewtype = force->inumeric(FLERR, arg[iarg + 2]);
+			if (imaxbond < 0)
+				error->all(FLERR, "Illegal fix bond/create command");
+			if (inewtype < 1 || inewtype > atom->ntypes)
+				error->all(FLERR,
+						"Invalid atom type in fix bond/create command");
+			iarg += 3;
+		} else if (strcmp(arg[iarg], "jparam") == 0) {
+			if (iarg + 3 > narg)
+				error->all(FLERR, "Illegal fix bond/create command");
+			jmaxbond = force->inumeric(FLERR, arg[iarg + 1]);
+			jnewtype = force->inumeric(FLERR, arg[iarg + 2]);
+			if (jmaxbond < 0)
+				error->all(FLERR, "Illegal fix bond/create command");
+			if (jnewtype < 1 || jnewtype > atom->ntypes)
+				error->all(FLERR,
+						"Invalid atom type in fix bond/create command");
+			iarg += 3;
+		} else if (strcmp(arg[iarg], "prob") == 0) {
+			if (iarg + 3 > narg)
+				error->all(FLERR, "Illegal fix bond/create command");
+			fraction = force->numeric(FLERR, arg[iarg + 1]);
+			seed = force->inumeric(FLERR, arg[iarg + 2]);
+			if (fraction < 0.0 || fraction > 1.0)
+				error->all(FLERR, "Illegal fix bond/create command");
+			if (seed <= 0)
+				error->all(FLERR, "Illegal fix bond/create command");
+			iarg += 3;
+		} else if (strcmp(arg[iarg], "atype") == 0) {
+			if (iarg + 2 > narg)
+				error->all(FLERR, "Illegal fix bond/create command");
+			if (isalpha(arg[iarg + 1][0])) {
+				char* syntax = input->variable->retrieve(arg[iarg + 1]);
+				angle_detector = new TypeDetector();
+				bool sucess = angle_detector->init(syntax, 1);
+				if (!sucess)
+					error->all(FLERR, "Illegal fix bond/create command");
+			} else {
+				atype = force->inumeric(FLERR, arg[iarg + 1]);
+				if (atype < 0)
+					error->all(FLERR, "Illegal fix bond/create command");
+			}
+			iarg += 2;
+		} else if (strcmp(arg[iarg], "dtype") == 0) {
+			if (iarg + 2 > narg)
+				error->all(FLERR, "Illegal fix bond/create command");
+			if (isalpha(arg[iarg + 1][0])) {
+				char* syntax = input->variable->retrieve(arg[iarg + 1]);
+				dihedral_detector = new TypeDetector();
+				bool sucess = dihedral_detector->init(syntax, 2);
+				if (!sucess)
+					error->all(FLERR, "Illegal fix bond/create command");
+			} else {
+				dtype = force->inumeric(FLERR, arg[iarg + 1]);
+				if (dtype < 0)
+					error->all(FLERR, "Illegal fix bond/create command");
+			}
+			iarg += 2;
+		} else if (strcmp(arg[iarg], "itype") == 0) {
+			if (iarg + 2 > narg)
+				error->all(FLERR, "Illegal fix bond/create command");
+			if (isalpha(arg[iarg + 1][0])) {
+				char* syntax = input->variable->retrieve(arg[iarg + 1]);
+				improper_detector = new TypeDetector();
+				bool sucess = improper_detector->init(syntax, 3);
+				if (!sucess)
+					error->all(FLERR, "Illegal fix bond/create command");
+			} else {
+				itype = force->inumeric(FLERR, arg[iarg + 1]);
+				if (itype < 0)
+					error->all(FLERR, "Illegal fix bond/create command");
+			}
+			iarg += 2;
+		} else
+			error->all(FLERR, "Illegal fix bond/create command");
+	}
 
-  // error check
+	// error check
 
-  if (atom->molecular != 1)
-    error->all(FLERR,"Cannot use fix bond/create with non-molecular systems");
-  if (iatomtype == jatomtype &&
-      ((imaxbond != jmaxbond) || (inewtype != jnewtype)))
-    error->all(FLERR,
-               "Inconsistent iparam/jparam values in fix bond/create command");
+	if (atom->molecular != 1)
+		error->all(FLERR,
+				"Cannot use fix bond/create with non-molecular systems");
+	if (iatomtype == jatomtype
+			&& ((imaxbond != jmaxbond) || (inewtype != jnewtype)))
+		error->all(FLERR,
+				"Inconsistent iparam/jparam values in fix bond/create command");
 
-  // initialize Marsaglia RNG with processor-unique seed
+	// initialize Marsaglia RNG with processor-unique seed
 
-  random = new RanMars(lmp,seed + me);
+	random = new RanMars(lmp, seed + me);
 
-  // perform initial allocation of atom-based arrays
-  // register with Atom class
-  // bondcount values will be initialized in setup()
+	// perform initial allocation of atom-based arrays
+	// register with Atom class
+	// bondcount values will be initialized in setup()
 
-  bondcount = NULL;
-  grow_arrays(atom->nmax);
-  atom->add_callback(0);
-  countflag = 0;
+	bondcount = NULL;
+	grow_arrays(atom->nmax);
+	atom->add_callback(0);
+	countflag = 0;
 
-  // set comm sizes needed by this fix
-  // forward is big due to comm of broken bonds and 1-2 neighbors
+	// set comm sizes needed by this fix
+	// forward is big due to comm of broken bonds and 1-2 neighbors
 
-  comm_forward = MAX(2,2+atom->maxspecial);
-  comm_reverse = 2;
+	comm_forward = MAX(2, 2 + atom->maxspecial);
+	comm_reverse = 2;
 
-  // allocate arrays local to this fix
+	// allocate arrays local to this fix
 
-  nmax = 0;
-  partner = finalpartner = NULL;
-  distsq = NULL;
+	nmax = 0;
+	partner = finalpartner = NULL;
+	distsq = NULL;
 
-  maxcreate = 0;
-  created = NULL;
+	maxcreate = 0;
+	created = NULL;
 
-  // copy = special list for one atom
-  // size = ms^2 + ms is sufficient
-  // b/c in rebuild_special_one() neighs of all 1-2s are added,
-  //   then a dedup(), then neighs of all 1-3s are added, then final dedup()
-  // this means intermediate size cannot exceed ms^2 + ms
+	// copy = special list for one atom
+	// size = ms^2 + ms is sufficient
+	// b/c in rebuild_special_one() neighs of all 1-2s are added,
+	//   then a dedup(), then neighs of all 1-3s are added, then final dedup()
+	// this means intermediate size cannot exceed ms^2 + ms
 
-  int maxspecial = atom->maxspecial;
-  copy = new tagint[maxspecial*maxspecial + maxspecial];
+	int maxspecial = atom->maxspecial;
+	copy = new tagint[maxspecial * maxspecial + maxspecial];
 
-  // zero out stats
+	// zero out stats
 
-  createcount = 0;
-  createcounttotal = 0;
+	createcount = 0;
+	createcounttotal = 0;
+
+	if ((angle_detector || dihedral_detector || improper_detector)
+			&& lmp->citeme) {
+		lmp->citeme->add(cite_crosslinking);
+	}
+
 }
 
 /* ---------------------------------------------------------------------- */
 
-FixBondCreate::~FixBondCreate()
-{
-  // unregister callbacks to this fix from Atom class
+FixBondCreate::~FixBondCreate() {
+	// unregister callbacks to this fix from Atom class
 
-  atom->delete_callback(id,0);
+	atom->delete_callback(id, 0);
 
-  delete random;
+	delete random;
 
-  // delete locally stored arrays
+	// delete locally stored arrays
 
-  memory->destroy(bondcount);
-  memory->destroy(partner);
-  memory->destroy(finalpartner);
-  memory->destroy(distsq);
-  memory->destroy(created);
-  delete [] copy;
+	memory->destroy(bondcount);
+	memory->destroy(partner);
+	memory->destroy(finalpartner);
+	memory->destroy(distsq);
+	memory->destroy(created);
+	delete[] copy;
 }
 
 /* ---------------------------------------------------------------------- */
 
-int FixBondCreate::setmask()
-{
-  int mask = 0;
-  mask |= POST_INTEGRATE;
-  mask |= POST_INTEGRATE_RESPA;
-  return mask;
+int FixBondCreate::setmask() {
+	int mask = 0;
+	mask |= POST_INTEGRATE;
+	mask |= POST_INTEGRATE_RESPA;
+	return mask;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::init()
-{
-  if (strstr(update->integrate_style,"respa"))
-    nlevels_respa = ((Respa *) update->integrate)->nlevels;
+void FixBondCreate::init() {
+	if (strstr(update->integrate_style, "respa"))
+		nlevels_respa = ((Respa *) update->integrate)->nlevels;
 
-  // check cutoff for iatomtype,jatomtype
+	// check cutoff for iatomtype,jatomtype
 
-  if (force->pair == NULL || cutsq > force->pair->cutsq[iatomtype][jatomtype])
-    error->all(FLERR,"Fix bond/create cutoff is longer than pairwise cutoff");
+	if (force->pair == NULL || cutsq > force->pair->cutsq[iatomtype][jatomtype])
+		error->all(FLERR,
+				"Fix bond/create cutoff is longer than pairwise cutoff");
 
-  // enable angle/dihedral/improper creation if atype/dtype/itype
-  //   option was used and a force field has been specified
+	// enable angle/dihedral/improper creation if atype/dtype/itype
+	//   option was used and a force field has been specified
 
-  if ((atype || angle_detector != NULL) && force->angle) {
-  		angleflag = 1;
-  		angledynflag = (angle_detector != NULL);
-  		atype = (angledynflag) ? angle_detector->get_num_types() : atype;
-  		if (atype > atom->nangletypes)
-  			error->all(FLERR, "Fix bond/create angle type is invalid");
-  } else angleflag = 0;
+	if ((atype || angle_detector != NULL) && force->angle) {
+		angleflag = 1;
+		angledynflag = (angle_detector != NULL);
+		atype = (angledynflag) ? angle_detector->get_num_types() : atype;
+		if (atype > atom->nangletypes)
+			error->all(FLERR, "Fix bond/create angle type is invalid");
+	} else
+		angleflag = 0;
 
-  if ((dtype || dihedral_detector != NULL) && force->dihedral) {
-  		dihedralflag = 1;
-  		dihedraldynflag = (dihedral_detector != NULL);
-  		dtype = (dihedraldynflag) ? dihedral_detector->get_num_types() : dtype;
-  		if (dtype > atom->ndihedraltypes)
-  			error->all(FLERR, "Fix bond/create dihedral type is invalid");
-  } else dihedralflag = 0;
+	if ((dtype || dihedral_detector != NULL) && force->dihedral) {
+		dihedralflag = 1;
+		dihedraldynflag = (dihedral_detector != NULL);
+		dtype = (dihedraldynflag) ? dihedral_detector->get_num_types() : dtype;
+		if (dtype > atom->ndihedraltypes)
+			error->all(FLERR, "Fix bond/create dihedral type is invalid");
+	} else
+		dihedralflag = 0;
 
-  if ((itype || improper_detector != NULL) && force->improper) {
-  		improperflag = 1;
-  		improperdynflag = (improper_detector != NULL);
-  		itype = (improperdynflag) ? improper_detector->get_num_types() : itype;
-  		if (itype > atom->nimpropertypes)
-  			error->all(FLERR, "Fix bond/create improper type is invalid");}
-  else improperflag = 0;
+	if ((itype || improper_detector != NULL) && force->improper) {
+		improperflag = 1;
+		improperdynflag = (improper_detector != NULL);
+		itype = (improperdynflag) ? improper_detector->get_num_types() : itype;
+		if (itype > atom->nimpropertypes)
+			error->all(FLERR, "Fix bond/create improper type is invalid");
+	} else
+		improperflag = 0;
 
+	if (force->improper) {
+		if (force->improper_match("class2") || force->improper_match("ring"))
+			error->all(FLERR, "Cannot yet use fix bond/create with this "
+					"improper style");
+	}
 
-  if (force->improper) {
-    if (force->improper_match("class2") || force->improper_match("ring"))
-      error->all(FLERR,"Cannot yet use fix bond/create with this "
-                 "improper style");
-  }
+	// need a half neighbor list, built every Nevery steps
 
-  // need a half neighbor list, built every Nevery steps
+	int irequest = neighbor->request(this, instance_me);
+	neighbor->requests[irequest]->pair = 0;
+	neighbor->requests[irequest]->fix = 1;
+	neighbor->requests[irequest]->occasional = 1;
 
-  int irequest = neighbor->request(this,instance_me);
-  neighbor->requests[irequest]->pair = 0;
-  neighbor->requests[irequest]->fix = 1;
-  neighbor->requests[irequest]->occasional = 1;
-
-  lastcheck = -1;
+	lastcheck = -1;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::init_list(int id, NeighList *ptr)
-{
-  list = ptr;
+void FixBondCreate::init_list(int id, NeighList *ptr) {
+	list = ptr;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::setup(int vflag)
-{
-  int i,j,m;
+void FixBondCreate::setup(int vflag) {
+	int i, j, m;
 
-  // compute initial bondcount if this is first run
-  // can't do this earlier, in constructor or init, b/c need ghost info
+	// compute initial bondcount if this is first run
+	// can't do this earlier, in constructor or init, b/c need ghost info
 
-  if (countflag) return;
-  countflag = 1;
+	if (countflag)
+		return;
+	countflag = 1;
 
-  // count bonds stored with each bond I own
-  // if newton bond is not set, just increment count on atom I
-  // if newton bond is set, also increment count on atom J even if ghost
-  // bondcount is long enough to tally ghost atom counts
+	// count bonds stored with each bond I own
+	// if newton bond is not set, just increment count on atom I
+	// if newton bond is set, also increment count on atom J even if ghost
+	// bondcount is long enough to tally ghost atom counts
 
-  int *num_bond = atom->num_bond;
-  int **bond_type = atom->bond_type;
-  tagint **bond_atom = atom->bond_atom;
-  int nlocal = atom->nlocal;
-  int nghost = atom->nghost;
-  int nall = nlocal + nghost;
-  int newton_bond = force->newton_bond;
+	int *num_bond = atom->num_bond;
+	int **bond_type = atom->bond_type;
+	tagint **bond_atom = atom->bond_atom;
+	int nlocal = atom->nlocal;
+	int nghost = atom->nghost;
+	int nall = nlocal + nghost;
+	int newton_bond = force->newton_bond;
 
-  for (i = 0; i < nall; i++) bondcount[i] = 0;
+	for (i = 0; i < nall; i++)
+		bondcount[i] = 0;
 
-  for (i = 0; i < nlocal; i++)
-    for (j = 0; j < num_bond[i]; j++) {
-      if (bond_type[i][j] == btype) {
-        bondcount[i]++;
-        if (newton_bond) {
-          m = atom->map(bond_atom[i][j]);
-          if (m < 0)
-            error->one(FLERR,"Fix bond/create needs ghost atoms "
-                       "from further away");
-          bondcount[m]++;
-        }
-      }
-    }
+	for (i = 0; i < nlocal; i++)
+		for (j = 0; j < num_bond[i]; j++) {
+			if (bond_type[i][j] == btype) {
+				bondcount[i]++;
+				if (newton_bond) {
+					m = atom->map(bond_atom[i][j]);
+					if (m < 0)
+						error->one(FLERR, "Fix bond/create needs ghost atoms "
+								"from further away");
+					bondcount[m]++;
+				}
+			}
+		}
 
-  // if newton_bond is set, need to sum bondcount
+	// if newton_bond is set, need to sum bondcount
 
-  commflag = 1;
-  if (newton_bond) comm->reverse_comm_fix(this,1);
+	commflag = 1;
+	if (newton_bond)
+		comm->reverse_comm_fix(this, 1);
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::post_integrate()
-{
-  int i,j,k,m,n,ii,jj,inum,jnum,itype,jtype,n1,n2,n3,possible;
-  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
-  int *ilist,*jlist,*numneigh,**firstneigh;
-  tagint *slist;
+void FixBondCreate::post_integrate() {
+	int i, j, k, m, n, ii, jj, inum, jnum, itype, jtype, n1, n2, n3, possible;
+	double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
+	int *ilist, *jlist, *numneigh, **firstneigh;
+	tagint *slist;
 
-  if (update->ntimestep % nevery) return;
+	if (update->ntimestep % nevery)
+		return;
 
-  // check that all procs have needed ghost atoms within ghost cutoff
-  // only if neighbor list has changed since last check
-  // needs to be <= test b/c neighbor list could have been re-built in
-  //   same timestep as last post_integrate() call, but afterwards
-  // NOTE: no longer think is needed, due to error tests on atom->map()
-  // NOTE: if delete, can also delete lastcheck and check_ghosts()
+	// check that all procs have needed ghost atoms within ghost cutoff
+	// only if neighbor list has changed since last check
+	// needs to be <= test b/c neighbor list could have been re-built in
+	//   same timestep as last post_integrate() call, but afterwards
+	// NOTE: no longer think is needed, due to error tests on atom->map()
+	// NOTE: if delete, can also delete lastcheck and check_ghosts()
 
-  //if (lastcheck <= neighbor->lastcall) check_ghosts();
+	//if (lastcheck <= neighbor->lastcall) check_ghosts();
 
-  // acquire updated ghost atom positions
-  // necessary b/c are calling this after integrate, but before Verlet comm
+	// acquire updated ghost atom positions
+	// necessary b/c are calling this after integrate, but before Verlet comm
 
-  comm->forward_comm();
+	comm->forward_comm();
 
-  // forward comm of bondcount, so ghosts have it
+	// forward comm of bondcount, so ghosts have it
 
-  commflag = 1;
-  comm->forward_comm_fix(this,1);
+	commflag = 1;
+	comm->forward_comm_fix(this, 1);
 
-  // resize bond partner list and initialize it
-  // probability array overlays distsq array
-  // needs to be atom->nmax in length
+	// resize bond partner list and initialize it
+	// probability array overlays distsq array
+	// needs to be atom->nmax in length
 
-  if (atom->nmax > nmax) {
-    memory->destroy(partner);
-    memory->destroy(finalpartner);
-    memory->destroy(distsq);
-    nmax = atom->nmax;
-    memory->create(partner,nmax,"bond/create:partner");
-    memory->create(finalpartner,nmax,"bond/create:finalpartner");
-    memory->create(distsq,nmax,"bond/create:distsq");
-    probability = distsq;
-  }
+	if (atom->nmax > nmax) {
+		memory->destroy(partner);
+		memory->destroy(finalpartner);
+		memory->destroy(distsq);
+		nmax = atom->nmax;
+		memory->create(partner, nmax, "bond/create:partner");
+		memory->create(finalpartner, nmax, "bond/create:finalpartner");
+		memory->create(distsq, nmax, "bond/create:distsq");
+		probability = distsq;
+	}
 
-  int nlocal = atom->nlocal;
-  int nall = atom->nlocal + atom->nghost;
+	int nlocal = atom->nlocal;
+	int nall = atom->nlocal + atom->nghost;
 
-  for (i = 0; i < nall; i++) {
-    partner[i] = 0;
-    finalpartner[i] = 0;
-    distsq[i] = BIG;
-  }
+	for (i = 0; i < nall; i++) {
+		partner[i] = 0;
+		finalpartner[i] = 0;
+		distsq[i] = BIG;
+	}
 
-  // loop over neighbors of my atoms
-  // each atom sets one closest eligible partner atom ID to bond with
+	// loop over neighbors of my atoms
+	// each atom sets one closest eligible partner atom ID to bond with
 
-  double **x = atom->x;
-  tagint *tag = atom->tag;
-  tagint **bond_atom = atom->bond_atom;
-  int *num_bond = atom->num_bond;
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
-  int *mask = atom->mask;
-  int *type = atom->type;
+	double **x = atom->x;
+	tagint *tag = atom->tag;
+	tagint **bond_atom = atom->bond_atom;
+	int *num_bond = atom->num_bond;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
+	int *mask = atom->mask;
+	int *type = atom->type;
 
-  neighbor->build_one(list,1);
-  inum = list->inum;
-  ilist = list->ilist;
-  numneigh = list->numneigh;
-  firstneigh = list->firstneigh;
+	neighbor->build_one(list, 1);
+	inum = list->inum;
+	ilist = list->ilist;
+	numneigh = list->numneigh;
+	firstneigh = list->firstneigh;
 
-  for (ii = 0; ii < inum; ii++) {
-    i = ilist[ii];
-    if (!(mask[i] & groupbit)) continue;
-    itype = type[i];
-    xtmp = x[i][0];
-    ytmp = x[i][1];
-    ztmp = x[i][2];
-    jlist = firstneigh[i];
-    jnum = numneigh[i];
+	for (ii = 0; ii < inum; ii++) {
+		i = ilist[ii];
+		if (!(mask[i] & groupbit))
+			continue;
+		itype = type[i];
+		xtmp = x[i][0];
+		ytmp = x[i][1];
+		ztmp = x[i][2];
+		jlist = firstneigh[i];
+		jnum = numneigh[i];
 
-    for (jj = 0; jj < jnum; jj++) {
-      j = jlist[jj];
-      j &= NEIGHMASK;
-      if (!(mask[j] & groupbit)) continue;
-      jtype = type[j];
+		for (jj = 0; jj < jnum; jj++) {
+			j = jlist[jj];
+			j &= NEIGHMASK;
+			if (!(mask[j] & groupbit))
+				continue;
+			jtype = type[j];
 
-      possible = 0;
-      if (itype == iatomtype && jtype == jatomtype) {
-        if ((imaxbond == 0 || bondcount[i] < imaxbond) &&
-            (jmaxbond == 0 || bondcount[j] < jmaxbond))
-          possible = 1;
-      } else if (itype == jatomtype && jtype == iatomtype) {
-        if ((jmaxbond == 0 || bondcount[i] < jmaxbond) &&
-            (imaxbond == 0 || bondcount[j] < imaxbond))
-          possible = 1;
-      }
-      if (!possible) continue;
+			possible = 0;
+			if (itype == iatomtype && jtype == jatomtype) {
+				if ((imaxbond == 0 || bondcount[i] < imaxbond)
+						&& (jmaxbond == 0 || bondcount[j] < jmaxbond))
+					possible = 1;
+			} else if (itype == jatomtype && jtype == iatomtype) {
+				if ((jmaxbond == 0 || bondcount[i] < jmaxbond)
+						&& (imaxbond == 0 || bondcount[j] < imaxbond))
+					possible = 1;
+			}
+			if (!possible)
+				continue;
 
-      // do not allow a duplicate bond to be created
-      // check 1-2 neighbors of atom I
+			// do not allow a duplicate bond to be created
+			// check 1-2 neighbors of atom I
 
-      for (k = 0; k < nspecial[i][0]; k++)
-        if (special[i][k] == tag[j]) possible = 0;
-      if (!possible) continue;
+			for (k = 0; k < nspecial[i][0]; k++)
+				if (special[i][k] == tag[j])
+					possible = 0;
+			if (!possible)
+				continue;
 
-      delx = xtmp - x[j][0];
-      dely = ytmp - x[j][1];
-      delz = ztmp - x[j][2];
-      rsq = delx*delx + dely*dely + delz*delz;
-      if (rsq >= cutsq) continue;
+			delx = xtmp - x[j][0];
+			dely = ytmp - x[j][1];
+			delz = ztmp - x[j][2];
+			rsq = delx * delx + dely * dely + delz * delz;
+			if (rsq >= cutsq)
+				continue;
 
-      if (rsq < distsq[i]) {
-        partner[i] = tag[j];
-        distsq[i] = rsq;
-      }
-      if (rsq < distsq[j]) {
-        partner[j] = tag[i];
-        distsq[j] = rsq;
-      }
-    }
-  }
+			if (rsq < distsq[i]) {
+				partner[i] = tag[j];
+				distsq[i] = rsq;
+			}
+			if (rsq < distsq[j]) {
+				partner[j] = tag[i];
+				distsq[j] = rsq;
+			}
+		}
+	}
 
-  // reverse comm of distsq and partner
-  // not needed if newton_pair off since I,J pair was seen by both procs
+	// reverse comm of distsq and partner
+	// not needed if newton_pair off since I,J pair was seen by both procs
 
-  commflag = 2;
-  if (force->newton_pair) comm->reverse_comm_fix(this);
+	commflag = 2;
+	if (force->newton_pair)
+		comm->reverse_comm_fix(this);
 
-  // each atom now knows its winning partner
-  // for prob check, generate random value for each atom with a bond partner
-  // forward comm of partner and random value, so ghosts have it
+	// each atom now knows its winning partner
+	// for prob check, generate random value for each atom with a bond partner
+	// forward comm of partner and random value, so ghosts have it
 
-  if (fraction < 1.0) {
-    for (i = 0; i < nlocal; i++)
-      if (partner[i]) probability[i] = random->uniform();
-  }
+	if (fraction < 1.0) {
+		for (i = 0; i < nlocal; i++)
+			if (partner[i])
+				probability[i] = random->uniform();
+	}
 
-  commflag = 2;
-  comm->forward_comm_fix(this,2);
+	commflag = 2;
+	comm->forward_comm_fix(this, 2);
 
-  // create bonds for atoms I own
-  // only if both atoms list each other as winning bond partner
-  //   and probability constraint is satisfied
-  // if other atom is owned by another proc, it should do same thing
+	// create bonds for atoms I own
+	// only if both atoms list each other as winning bond partner
+	//   and probability constraint is satisfied
+	// if other atom is owned by another proc, it should do same thing
 
-  int **bond_type = atom->bond_type;
-  int newton_bond = force->newton_bond;
+	int **bond_type = atom->bond_type;
+	int newton_bond = force->newton_bond;
 
-  ncreate = 0;
-  for (i = 0; i < nlocal; i++) {
-    if (partner[i] == 0) continue;
-    j = atom->map(partner[i]);
-    if (partner[j] != tag[i]) continue;
+	ncreate = 0;
+	for (i = 0; i < nlocal; i++) {
+		if (partner[i] == 0)
+			continue;
+		j = atom->map(partner[i]);
+		if (partner[j] != tag[i])
+			continue;
 
-    // apply probability constraint using RN for atom with smallest ID
+		// apply probability constraint using RN for atom with smallest ID
 
-    if (fraction < 1.0) {
-      if (tag[i] < tag[j]) {
-        if (probability[i] >= fraction) continue;
-      } else {
-        if (probability[j] >= fraction) continue;
-      }
-    }
+		if (fraction < 1.0) {
+			if (tag[i] < tag[j]) {
+				if (probability[i] >= fraction)
+					continue;
+			} else {
+				if (probability[j] >= fraction)
+					continue;
+			}
+		}
 
-    // if newton_bond is set, only store with I or J
-    // if not newton_bond, store bond with both I and J
-    // atom J will also do this consistently, whatever proc it is on
+		// if newton_bond is set, only store with I or J
+		// if not newton_bond, store bond with both I and J
+		// atom J will also do this consistently, whatever proc it is on
 
-    if (!newton_bond || tag[i] < tag[j]) {
-      if (num_bond[i] == atom->bond_per_atom)
-        error->one(FLERR,"New bond exceeded bonds per atom in fix bond/create");
-      bond_type[i][num_bond[i]] = btype;
-      bond_atom[i][num_bond[i]] = tag[j];
-      num_bond[i]++;
-    }
+		if (!newton_bond || tag[i] < tag[j]) {
+			if (num_bond[i] == atom->bond_per_atom)
+				error->one(FLERR,
+						"New bond exceeded bonds per atom in fix bond/create");
+			bond_type[i][num_bond[i]] = btype;
+			bond_atom[i][num_bond[i]] = tag[j];
+			num_bond[i]++;
+		}
 
-    // add a 1-2 neighbor to special bond list for atom I
-    // atom J will also do this, whatever proc it is on
-    // need to first remove tag[j] from later in list if it appears
-    // prevents list from overflowing, will be rebuilt in rebuild_special_one()
+		// add a 1-2 neighbor to special bond list for atom I
+		// atom J will also do this, whatever proc it is on
+		// need to first remove tag[j] from later in list if it appears
+		// prevents list from overflowing, will be rebuilt in rebuild_special_one()
 
-    slist = special[i];
-    n1 = nspecial[i][0];
-    n2 = nspecial[i][1];
-    n3 = nspecial[i][2];
-    for (m = n1; m < n3; m++)
-      if (slist[m] == tag[j]) break;
-    if (m < n3) {
-      for (n = m; n < n3-1; n++) slist[n] = slist[n+1];
-      n3--;
-      if (m < n2) n2--;
-    }
-    if (n3 == atom->maxspecial)
-      error->one(FLERR,
-                 "New bond exceeded special list size in fix bond/create");
-    for (m = n3; m > n1; m--) slist[m] = slist[m-1];
-    slist[n1] = tag[j];
-    nspecial[i][0] = n1+1;
-    nspecial[i][1] = n2+1;
-    nspecial[i][2] = n3+1;
+		slist = special[i];
+		n1 = nspecial[i][0];
+		n2 = nspecial[i][1];
+		n3 = nspecial[i][2];
+		for (m = n1; m < n3; m++)
+			if (slist[m] == tag[j])
+				break;
+		if (m < n3) {
+			for (n = m; n < n3 - 1; n++)
+				slist[n] = slist[n + 1];
+			n3--;
+			if (m < n2)
+				n2--;
+		}
+		if (n3 == atom->maxspecial)
+			error->one(FLERR,
+					"New bond exceeded special list size in fix bond/create");
+		for (m = n3; m > n1; m--)
+			slist[m] = slist[m - 1];
+		slist[n1] = tag[j];
+		nspecial[i][0] = n1 + 1;
+		nspecial[i][1] = n2 + 1;
+		nspecial[i][2] = n3 + 1;
 
-    // increment bondcount, convert atom to new type if limit reached
-    // atom J will also do this, whatever proc it is on
+		// increment bondcount, convert atom to new type if limit reached
+		// atom J will also do this, whatever proc it is on
 
-    bondcount[i]++;
-    if (type[i] == iatomtype) {
-      if (bondcount[i] == imaxbond) type[i] = inewtype;
-    } else {
-      if (bondcount[i] == jmaxbond) type[i] = jnewtype;
-    }
+		bondcount[i]++;
+		if (type[i] == iatomtype) {
+			if (bondcount[i] == imaxbond)
+				type[i] = inewtype;
+		} else {
+			if (bondcount[i] == jmaxbond)
+				type[i] = jnewtype;
+		}
 
-    // store final created bond partners and count the created bond once
+		// store final created bond partners and count the created bond once
 
-    finalpartner[i] = tag[j];
-    finalpartner[j] = tag[i];
-    if (tag[i] < tag[j]) ncreate++;
-  }
+		finalpartner[i] = tag[j];
+		finalpartner[j] = tag[i];
+		if (tag[i] < tag[j])
+			ncreate++;
+	}
 
-  // tally stats
+	// tally stats
 
-  MPI_Allreduce(&ncreate,&createcount,1,MPI_INT,MPI_SUM,world);
-  createcounttotal += createcount;
-  atom->nbonds += createcount;
+	MPI_Allreduce(&ncreate, &createcount, 1, MPI_INT, MPI_SUM, world);
+	createcounttotal += createcount;
+	atom->nbonds += createcount;
 
-  // trigger reneighboring if any bonds were formed
-  // this insures neigh lists will immediately reflect the topology changes
-  // done if any bonds created
+	// trigger reneighboring if any bonds were formed
+	// this insures neigh lists will immediately reflect the topology changes
+	// done if any bonds created
 
-  if (createcount) next_reneighbor = update->ntimestep;
-  if (!createcount) return;
+	if (createcount)
+		next_reneighbor = update->ntimestep;
+	if (!createcount)
+		return;
 
-  // communicate final partner and 1-2 special neighbors
-  // 1-2 neighs already reflect created bonds
+	// communicate final partner and 1-2 special neighbors
+	// 1-2 neighs already reflect created bonds
 
-  commflag = 3;
-  comm->forward_comm_fix(this);
+	commflag = 3;
+	comm->forward_comm_fix(this);
 
-  // create list of broken bonds that influence my owned atoms
-  //   even if between owned-ghost or ghost-ghost atoms
-  // finalpartner is now set for owned and ghost atoms so loop over nall
-  // OK if duplicates in broken list due to ghosts duplicating owned atoms
-  // check J < 0 to insure a broken bond to unknown atom is included
-  //   i.e. a bond partner outside of cutoff length
+	// create list of broken bonds that influence my owned atoms
+	//   even if between owned-ghost or ghost-ghost atoms
+	// finalpartner is now set for owned and ghost atoms so loop over nall
+	// OK if duplicates in broken list due to ghosts duplicating owned atoms
+	// check J < 0 to insure a broken bond to unknown atom is included
+	//   i.e. a bond partner outside of cutoff length
 
-  ncreate = 0;
-  for (i = 0; i < nall; i++) {
-    if (finalpartner[i] == 0) continue;
-    j = atom->map(finalpartner[i]);
-    if (j < 0 || tag[i] < tag[j]) {
-      if (ncreate == maxcreate) {
-        maxcreate += DELTA;
-        memory->grow(created,maxcreate,2,"bond/create:created");
-      }
-      created[ncreate][0] = tag[i];
-      created[ncreate][1] = finalpartner[i];
-      ncreate++;
-    }
-  }
+	ncreate = 0;
+	for (i = 0; i < nall; i++) {
+		if (finalpartner[i] == 0)
+			continue;
+		j = atom->map(finalpartner[i]);
+		if (j < 0 || tag[i] < tag[j]) {
+			if (ncreate == maxcreate) {
+				maxcreate += DELTA;
+				memory->grow(created, maxcreate, 2, "bond/create:created");
+			}
+			created[ncreate][0] = tag[i];
+			created[ncreate][1] = finalpartner[i];
+			ncreate++;
+		}
+	}
 
-  // update special neigh lists of all atoms affected by any created bond
-  // also add angles/dihedrals/impropers induced by created bonds
+	// update special neigh lists of all atoms affected by any created bond
+	// also add angles/dihedrals/impropers induced by created bonds
 
-  update_topology();
+	update_topology();
 
-  // DEBUG
-  //print_bb();
+	// DEBUG
+	//print_bb();
 }
 
 /* ----------------------------------------------------------------------
-   insure all atoms 2 hops away from owned atoms are in ghost list
-   this allows dihedral 1-2-3-4 to be properly created
-     and special list of 1 to be properly updated
-   if I own atom 1, but not 2,3,4, and bond 3-4 is added
-     then 2,3 will be ghosts and 3 will store 4 as its finalpartner
-------------------------------------------------------------------------- */
+ insure all atoms 2 hops away from owned atoms are in ghost list
+ this allows dihedral 1-2-3-4 to be properly created
+ and special list of 1 to be properly updated
+ if I own atom 1, but not 2,3,4, and bond 3-4 is added
+ then 2,3 will be ghosts and 3 will store 4 as its finalpartner
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::check_ghosts()
-{
-  int i,j,n;
-  tagint *slist;
+void FixBondCreate::check_ghosts() {
+	int i, j, n;
+	tagint *slist;
 
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
-  int nlocal = atom->nlocal;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
+	int nlocal = atom->nlocal;
 
-  int flag = 0;
-  for (i = 0; i < nlocal; i++) {
-    slist = special[i];
-    n = nspecial[i][1];
-    for (j = 0; j < n; j++)
-      if (atom->map(slist[j]) < 0) flag = 1;
-  }
+	int flag = 0;
+	for (i = 0; i < nlocal; i++) {
+		slist = special[i];
+		n = nspecial[i][1];
+		for (j = 0; j < n; j++)
+			if (atom->map(slist[j]) < 0)
+				flag = 1;
+	}
 
-  int flagall;
-  MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
-  if (flagall)
-    error->all(FLERR,"Fix bond/create needs ghost atoms from further away");
-  lastcheck = update->ntimestep;
+	int flagall;
+	MPI_Allreduce(&flag, &flagall, 1, MPI_INT, MPI_SUM, world);
+	if (flagall)
+		error->all(FLERR,
+				"Fix bond/create needs ghost atoms from further away");
+	lastcheck = update->ntimestep;
 }
 
 /* ----------------------------------------------------------------------
-   double loop over my atoms and created bonds
-   influenced = 1 if atom's topology is affected by any created bond
-     yes if is one of 2 atoms in bond
-     yes if either atom ID appears in as 1-2 or 1-3 in atom's special list
-     else no
-   if influenced by any created bond:
-     rebuild the atom's special list of 1-2,1-3,1-4 neighs
-     check for angles/dihedrals/impropers to create due modified special list
-------------------------------------------------------------------------- */
+ double loop over my atoms and created bonds
+ influenced = 1 if atom's topology is affected by any created bond
+ yes if is one of 2 atoms in bond
+ yes if either atom ID appears in as 1-2 or 1-3 in atom's special list
+ else no
+ if influenced by any created bond:
+ rebuild the atom's special list of 1-2,1-3,1-4 neighs
+ check for angles/dihedrals/impropers to create due modified special list
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::update_topology()
-{
-  int i,j,k,n,influence,influenced;
-  tagint id1,id2;
-  tagint *slist;
+void FixBondCreate::update_topology() {
+	int i, j, k, n, influence, influenced;
+	tagint id1, id2;
+	tagint *slist;
 
-  tagint *tag = atom->tag;
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
-  int nlocal = atom->nlocal;
+	tagint *tag = atom->tag;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
+	int nlocal = atom->nlocal;
 
-  nangles = 0;
-  ndihedrals = 0;
-  nimpropers = 0;
-  overflow = 0;
+	nangles = 0;
+	ndihedrals = 0;
+	nimpropers = 0;
+	overflow = 0;
 
-  //printf("NCREATE %d: ",ncreate);
-  //for (i = 0; i < ncreate; i++)
-  //  printf(" %d %d,",created[i][0],created[i][1]);
-  //printf("\n");
+	//printf("NCREATE %d: ",ncreate);
+	//for (i = 0; i < ncreate; i++)
+	//  printf(" %d %d,",created[i][0],created[i][1]);
+	//printf("\n");
 
-  for (i = 0; i < nlocal; i++) {
-    influenced = 0;
-    slist = special[i];
+	for (i = 0; i < nlocal; i++) {
+		influenced = 0;
+		slist = special[i];
 
-    for (j = 0; j < ncreate; j++) {
-      id1 = created[j][0];
-      id2 = created[j][1];
+		for (j = 0; j < ncreate; j++) {
+			id1 = created[j][0];
+			id2 = created[j][1];
 
-      influence = 0;
-      if (tag[i] == id1 || tag[i] == id2) influence = 1;
-      else {
-        n = nspecial[i][1];
-        for (k = 0; k < n; k++)
-          if (slist[k] == id1 || slist[k] == id2) {
-            influence = 1;
-            break;
-          }
-      }
-      if (!influence) continue;
-      influenced = 1;
-    }
+			influence = 0;
+			if (tag[i] == id1 || tag[i] == id2)
+				influence = 1;
+			else {
+				n = nspecial[i][1];
+				for (k = 0; k < n; k++)
+					if (slist[k] == id1 || slist[k] == id2) {
+						influence = 1;
+						break;
+					}
+			}
+			if (!influence)
+				continue;
+			influenced = 1;
+		}
 
-    // rebuild_special_one() first, since used by create_angles, etc
+		// rebuild_special_one() first, since used by create_angles, etc
 
-    if (influenced) {
-      rebuild_special_one(i);
-      if (angleflag) create_angles(i);
-      if (dihedralflag) create_dihedrals(i);
-      if (improperflag) create_impropers(i);
-    }
-  }
+		if (influenced) {
+			rebuild_special_one(i);
+			if (angleflag)
+				create_angles(i);
+			if (dihedralflag)
+				create_dihedrals(i);
+			if (improperflag)
+				create_impropers(i);
+		}
+	}
 
-  int overflowall;
-  MPI_Allreduce(&overflow,&overflowall,1,MPI_INT,MPI_SUM,world);
-  if (overflowall) error->all(FLERR,"Fix bond/create induced too many "
-                              "angles/dihedrals/impropers per atom");
+	int overflowall;
+	MPI_Allreduce(&overflow, &overflowall, 1, MPI_INT, MPI_SUM, world);
+	if (overflowall)
+		error->all(FLERR, "Fix bond/create induced too many "
+				"angles/dihedrals/impropers per atom");
 
-  int newton_bond = force->newton_bond;
+	int newton_bond = force->newton_bond;
 
-  int all;
-  if (angleflag) {
-    MPI_Allreduce(&nangles,&all,1,MPI_INT,MPI_SUM,world);
-    if (!newton_bond) all /= 3;
-    atom->nangles += all;
-  }
-  if (dihedralflag) {
-    MPI_Allreduce(&ndihedrals,&all,1,MPI_INT,MPI_SUM,world);
-    if (!newton_bond) all /= 4;
-    atom->ndihedrals += all;
-  }
-  if (improperflag) {
-    MPI_Allreduce(&nimpropers,&all,1,MPI_INT,MPI_SUM,world);
-    if (!newton_bond) all /= 4;
-    atom->nimpropers += all;
-  }
+	int all;
+	if (angleflag) {
+		MPI_Allreduce(&nangles, &all, 1, MPI_INT, MPI_SUM, world);
+		if (!newton_bond)
+			all /= 3;
+		atom->nangles += all;
+	}
+	if (dihedralflag) {
+		MPI_Allreduce(&ndihedrals, &all, 1, MPI_INT, MPI_SUM, world);
+		if (!newton_bond)
+			all /= 4;
+		atom->ndihedrals += all;
+	}
+	if (improperflag) {
+		MPI_Allreduce(&nimpropers, &all, 1, MPI_INT, MPI_SUM, world);
+		if (!newton_bond)
+			all /= 4;
+		atom->nimpropers += all;
+	}
 }
 
 /* ----------------------------------------------------------------------
-   re-build special list of atom M
-   does not affect 1-2 neighs (already include effects of new bond)
-   affects 1-3 and 1-4 neighs due to other atom's augmented 1-2 neighs
-------------------------------------------------------------------------- */
+ re-build special list of atom M
+ does not affect 1-2 neighs (already include effects of new bond)
+ affects 1-3 and 1-4 neighs due to other atom's augmented 1-2 neighs
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::rebuild_special_one(int m)
-{
-  int i,j,n,n1,cn1,cn2,cn3;
-  tagint *slist;
+void FixBondCreate::rebuild_special_one(int m) {
+	int i, j, n, n1, cn1, cn2, cn3;
+	tagint *slist;
 
-  tagint *tag = atom->tag;
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
+	tagint *tag = atom->tag;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
 
-  // existing 1-2 neighs of atom M
+	// existing 1-2 neighs of atom M
 
-  slist = special[m];
-  n1 = nspecial[m][0];
-  cn1 = 0;
-  for (i = 0; i < n1; i++)
-    copy[cn1++] = slist[i];
+	slist = special[m];
+	n1 = nspecial[m][0];
+	cn1 = 0;
+	for (i = 0; i < n1; i++)
+		copy[cn1++] = slist[i];
 
-  // new 1-3 neighs of atom M, based on 1-2 neighs of 1-2 neighs
-  // exclude self
-  // remove duplicates after adding all possible 1-3 neighs
+	// new 1-3 neighs of atom M, based on 1-2 neighs of 1-2 neighs
+	// exclude self
+	// remove duplicates after adding all possible 1-3 neighs
 
-  cn2 = cn1;
-  for (i = 0; i < cn1; i++) {
-    n = atom->map(copy[i]);
-    if (n < 0)
-      error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-    slist = special[n];
-    n1 = nspecial[n][0];
-    for (j = 0; j < n1; j++)
-      if (slist[j] != tag[m]) copy[cn2++] = slist[j];
-  }
+	cn2 = cn1;
+	for (i = 0; i < cn1; i++) {
+		n = atom->map(copy[i]);
+		if (n < 0)
+			error->one(FLERR,
+					"Fix bond/create needs ghost atoms from further away");
+		slist = special[n];
+		n1 = nspecial[n][0];
+		for (j = 0; j < n1; j++)
+			if (slist[j] != tag[m])
+				copy[cn2++] = slist[j];
+	}
 
-  cn2 = dedup(cn1,cn2,copy);
-  if (cn2 > atom->maxspecial)
-    error->one(FLERR,"Special list size exceeded in fix bond/create");
+	cn2 = dedup(cn1, cn2, copy);
+	if (cn2 > atom->maxspecial)
+		error->one(FLERR, "Special list size exceeded in fix bond/create");
 
-  // new 1-4 neighs of atom M, based on 1-2 neighs of 1-3 neighs
-  // exclude self
-  // remove duplicates after adding all possible 1-4 neighs
+	// new 1-4 neighs of atom M, based on 1-2 neighs of 1-3 neighs
+	// exclude self
+	// remove duplicates after adding all possible 1-4 neighs
 
-  cn3 = cn2;
-  for (i = cn1; i < cn2; i++) {
-    n = atom->map(copy[i]);
-    if (n < 0)
-      error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-    slist = special[n];
-    n1 = nspecial[n][0];
-    for (j = 0; j < n1; j++)
-      if (slist[j] != tag[m]) copy[cn3++] = slist[j];
-  }
+	cn3 = cn2;
+	for (i = cn1; i < cn2; i++) {
+		n = atom->map(copy[i]);
+		if (n < 0)
+			error->one(FLERR,
+					"Fix bond/create needs ghost atoms from further away");
+		slist = special[n];
+		n1 = nspecial[n][0];
+		for (j = 0; j < n1; j++)
+			if (slist[j] != tag[m])
+				copy[cn3++] = slist[j];
+	}
 
-  cn3 = dedup(cn2,cn3,copy);
-  if (cn3 > atom->maxspecial)
-    error->one(FLERR,"Special list size exceeded in fix bond/create");
+	cn3 = dedup(cn2, cn3, copy);
+	if (cn3 > atom->maxspecial)
+		error->one(FLERR, "Special list size exceeded in fix bond/create");
 
-  // store new special list with atom M
+	// store new special list with atom M
 
-  nspecial[m][0] = cn1;
-  nspecial[m][1] = cn2;
-  nspecial[m][2] = cn3;
-  memcpy(special[m],copy,cn3*sizeof(int));
+	nspecial[m][0] = cn1;
+	nspecial[m][1] = cn2;
+	nspecial[m][2] = cn3;
+	memcpy(special[m], copy, cn3 * sizeof(int));
 }
 
 /* ----------------------------------------------------------------------
-   create any angles owned by atom M induced by newly created bonds
-   walk special list to find all possible angles to create
-   only add an angle if a new bond is one of its 2 bonds (I-J,J-K)
-   for newton_bond on, atom M is central atom
-   for newton_bond off, atom M is any of 3 atoms in angle
-------------------------------------------------------------------------- */
+ create any angles owned by atom M induced by newly created bonds
+ walk special list to find all possible angles to create
+ only add an angle if a new bond is one of its 2 bonds (I-J,J-K)
+ for newton_bond on, atom M is central atom
+ for newton_bond off, atom M is any of 3 atoms in angle
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::create_angles(int m)
-{
-  int i,j,n,i2local,n1,n2;
-  tagint i1,i2,i3;
-  tagint *s1list,*s2list;
+void FixBondCreate::create_angles(int m) {
+	int i, j, n, i2local, n1, n2;
+	tagint i1, i2, i3;
+	tagint *s1list, *s2list;
 
-  tagint *tag = atom->tag;
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
+	tagint *tag = atom->tag;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
 
-  int *type;
-  int *ang_type;
-  if (angledynflag) {
-	  type = atom->type;
-	  ang_type = new int[3];
-  }
+	int *type;
+	int *ang_type;
+	if (angledynflag) {
+		type = atom->type;
+		ang_type = new int[3];
+	}
 
-  int num_angle = atom->num_angle[m];
-  int *angle_type = atom->angle_type[m];
-  tagint *angle_atom1 = atom->angle_atom1[m];
-  tagint *angle_atom2 = atom->angle_atom2[m];
-  tagint *angle_atom3 = atom->angle_atom3[m];
+	int num_angle = atom->num_angle[m];
+	int *angle_type = atom->angle_type[m];
+	tagint *angle_atom1 = atom->angle_atom1[m];
+	tagint *angle_atom2 = atom->angle_atom2[m];
+	tagint *angle_atom3 = atom->angle_atom3[m];
 
-  // atom M is central atom in angle
-  // double loop over 1-2 neighs
-  // avoid double counting by 2nd loop as j = i+1,N not j = 1,N
-  // consider all angles, only add if:
-  //   a new bond is in the angle and atom types match
+	// atom M is central atom in angle
+	// double loop over 1-2 neighs
+	// avoid double counting by 2nd loop as j = i+1,N not j = 1,N
+	// consider all angles, only add if:
+	//   a new bond is in the angle and atom types match
 
-  i2 = tag[m];
-  n2 = nspecial[m][0];
-  s2list = special[m];
+	i2 = tag[m];
+	n2 = nspecial[m][0];
+	s2list = special[m];
 
-  for (i = 0; i < n2; i++) {
-    i1 = s2list[i];
-    for (j = i+1; j < n2; j++) {
-      i3 = s2list[j];
+	for (i = 0; i < n2; i++) {
+		i1 = s2list[i];
+		for (j = i + 1; j < n2; j++) {
+			i3 = s2list[j];
 
-      // angle = i1-i2-i3
+			// angle = i1-i2-i3
 
-      for (n = 0; n < ncreate; n++) {
-        if (created[n][0] == i1 && created[n][1] == i2) break;
-        if (created[n][0] == i2 && created[n][1] == i1) break;
-        if (created[n][0] == i2 && created[n][1] == i3) break;
-        if (created[n][0] == i3 && created[n][1] == i2) break;
-      }
-      if (n == ncreate) continue;
+			for (n = 0; n < ncreate; n++) {
+				if (created[n][0] == i1 && created[n][1] == i2)
+					break;
+				if (created[n][0] == i2 && created[n][1] == i1)
+					break;
+				if (created[n][0] == i2 && created[n][1] == i3)
+					break;
+				if (created[n][0] == i3 && created[n][1] == i2)
+					break;
+			}
+			if (n == ncreate)
+				continue;
 
-      if (angledynflag) {
-    	  ang_type[0] = type[atom->map(i1)];
-    	  ang_type[1] = type[atom->map(i2)];
-    	  ang_type[2] = type[atom->map(i3)];
-    	  angle_detector->get(ang_type, atype);
-      }
+			if (angledynflag) {
+				ang_type[0] = type[atom->map(i1)];
+				ang_type[1] = type[atom->map(i2)];
+				ang_type[2] = type[atom->map(i3)];
+				angle_detector->get(ang_type, atype);
+			}
 
-      // NOTE: this is place to check atom types of i1,i2,i3
+			// NOTE: this is place to check atom types of i1,i2,i3
 
-      if (num_angle < atom->angle_per_atom) {
-        angle_type[num_angle] = atype;
-        angle_atom1[num_angle] = i1;
-        angle_atom2[num_angle] = i2;
-        angle_atom3[num_angle] = i3;
-        num_angle++;
-        nangles++;
-      } else overflow = 1;
-    }
-  }
+			if (num_angle < atom->angle_per_atom) {
+				angle_type[num_angle] = atype;
+				angle_atom1[num_angle] = i1;
+				angle_atom2[num_angle] = i2;
+				angle_atom3[num_angle] = i3;
+				num_angle++;
+				nangles++;
+			} else
+				overflow = 1;
+		}
+	}
 
-  atom->num_angle[m] = num_angle;
-  if (force->newton_bond) return;
+	atom->num_angle[m] = num_angle;
+	if (force->newton_bond)
+		return;
 
-  // for newton_bond off, also consider atom M as atom 1 in angle
+	// for newton_bond off, also consider atom M as atom 1 in angle
 
-  i1 = tag[m];
-  n1 = nspecial[m][0];
-  s1list = special[m];
+	i1 = tag[m];
+	n1 = nspecial[m][0];
+	s1list = special[m];
 
-  for (i = 0; i < n1; i++) {
-    i2 = s1list[i];
-    i2local = atom->map(i2);
-    if (i2local < 0)
-      error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-    s2list = special[i2local];
-    n2 = nspecial[i2local][0];
+	for (i = 0; i < n1; i++) {
+		i2 = s1list[i];
+		i2local = atom->map(i2);
+		if (i2local < 0)
+			error->one(FLERR,
+					"Fix bond/create needs ghost atoms from further away");
+		s2list = special[i2local];
+		n2 = nspecial[i2local][0];
 
-    for (j = 0; j < n2; j++) {
-      i3 = s2list[j];
-      if (i3 == i1) continue;
+		for (j = 0; j < n2; j++) {
+			i3 = s2list[j];
+			if (i3 == i1)
+				continue;
 
-      // angle = i1-i2-i3
+			// angle = i1-i2-i3
 
-      for (n = 0; n < ncreate; n++) {
-        if (created[n][0] == i1 && created[n][1] == i2) break;
-        if (created[n][0] == i2 && created[n][1] == i1) break;
-        if (created[n][0] == i2 && created[n][1] == i3) break;
-        if (created[n][0] == i3 && created[n][1] == i2) break;
-      }
-      if (n == ncreate) continue;
+			for (n = 0; n < ncreate; n++) {
+				if (created[n][0] == i1 && created[n][1] == i2)
+					break;
+				if (created[n][0] == i2 && created[n][1] == i1)
+					break;
+				if (created[n][0] == i2 && created[n][1] == i3)
+					break;
+				if (created[n][0] == i3 && created[n][1] == i2)
+					break;
+			}
+			if (n == ncreate)
+				continue;
 
-      // NOTE: this is place to check atom types of i1,i2,i3
+			// NOTE: this is place to check atom types of i1,i2,i3
 
-      if (num_angle < atom->angle_per_atom) {
-        angle_type[num_angle] = atype;
-        angle_atom1[num_angle] = i1;
-        angle_atom2[num_angle] = i2;
-        angle_atom3[num_angle] = i3;
-        num_angle++;
-        nangles++;
-      } else overflow = 1;
-    }
-  }
+			if (num_angle < atom->angle_per_atom) {
+				angle_type[num_angle] = atype;
+				angle_atom1[num_angle] = i1;
+				angle_atom2[num_angle] = i2;
+				angle_atom3[num_angle] = i3;
+				num_angle++;
+				nangles++;
+			} else
+				overflow = 1;
+		}
+	}
 
-  atom->num_angle[m] = num_angle;
+	atom->num_angle[m] = num_angle;
 }
 
 /* ----------------------------------------------------------------------
-   create any dihedrals owned by atom M induced by newly created bonds
-   walk special list to find all possible dihedrals to create
-   only add a dihedral if a new bond is one of its 3 bonds (I-J,J-K,K-L)
-   for newton_bond on, atom M is central atom
-   for newton_bond off, atom M is any of 4 atoms in dihedral
-------------------------------------------------------------------------- */
+ create any dihedrals owned by atom M induced by newly created bonds
+ walk special list to find all possible dihedrals to create
+ only add a dihedral if a new bond is one of its 3 bonds (I-J,J-K,K-L)
+ for newton_bond on, atom M is central atom
+ for newton_bond off, atom M is any of 4 atoms in dihedral
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::create_dihedrals(int m)
-{
-  int i,j,k,n,i1local,i2local,i3local,n1,n2,n3;
-  tagint i1,i2,i3,i4;
-  tagint *s1list,*s2list,*s3list;
+void FixBondCreate::create_dihedrals(int m) {
+	int i, j, k, n, i1local, i2local, i3local, n1, n2, n3;
+	tagint i1, i2, i3, i4;
+	tagint *s1list, *s2list, *s3list;
 
-  tagint *tag = atom->tag;
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
+	tagint *tag = atom->tag;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
 
-  int *type;
-  int *dih_type;
-  if (dihedraldynflag) {
-	  type = atom->type;
-	  dih_type = new int[4];
-  }
+	int *type;
+	int *dih_type;
+	if (dihedraldynflag) {
+		type = atom->type;
+		dih_type = new int[4];
+	}
 
-  int num_dihedral = atom->num_dihedral[m];
-  int *dihedral_type = atom->dihedral_type[m];
-  tagint *dihedral_atom1 = atom->dihedral_atom1[m];
-  tagint *dihedral_atom2 = atom->dihedral_atom2[m];
-  tagint *dihedral_atom3 = atom->dihedral_atom3[m];
-  tagint *dihedral_atom4 = atom->dihedral_atom4[m];
+	int num_dihedral = atom->num_dihedral[m];
+	int *dihedral_type = atom->dihedral_type[m];
+	tagint *dihedral_atom1 = atom->dihedral_atom1[m];
+	tagint *dihedral_atom2 = atom->dihedral_atom2[m];
+	tagint *dihedral_atom3 = atom->dihedral_atom3[m];
+	tagint *dihedral_atom4 = atom->dihedral_atom4[m];
 
-  // atom M is 2nd atom in dihedral
-  // double loop over 1-2 neighs
-  // two triple loops: one over neighs at each end of triplet
-  // avoid double counting by 2nd loop as j = i+1,N not j = 1,N
-  // avoid double counting due to another atom being 2nd atom in same dihedral
-  //   by requiring ID of 2nd atom < ID of 3rd atom
-  //   don't do this if newton bond off since want to double count
-  // consider all dihedrals, only add if:
-  //   a new bond is in the dihedral and atom types match
+	// atom M is 2nd atom in dihedral
+	// double loop over 1-2 neighs
+	// two triple loops: one over neighs at each end of triplet
+	// avoid double counting by 2nd loop as j = i+1,N not j = 1,N
+	// avoid double counting due to another atom being 2nd atom in same dihedral
+	//   by requiring ID of 2nd atom < ID of 3rd atom
+	//   don't do this if newton bond off since want to double count
+	// consider all dihedrals, only add if:
+	//   a new bond is in the dihedral and atom types match
 
-  i2 = tag[m];
-  n2 = nspecial[m][0];
-  s2list = special[m];
+	i2 = tag[m];
+	n2 = nspecial[m][0];
+	s2list = special[m];
 
-  for (i = 0; i < n2; i++) {
-    i1 = s2list[i];
+	for (i = 0; i < n2; i++) {
+		i1 = s2list[i];
 
-    for (j = i+1; j < n2; j++) {
-      i3 = s2list[j];
-      if (force->newton_bond && i2 > i3) continue;
-      i3local = atom->map(i3);
-      if (i3local < 0)
-        error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-      s3list = special[i3local];
-      n3 = nspecial[i3local][0];
+		for (j = i + 1; j < n2; j++) {
+			i3 = s2list[j];
+			if (force->newton_bond && i2 > i3)
+				continue;
+			i3local = atom->map(i3);
+			if (i3local < 0)
+				error->one(FLERR,
+						"Fix bond/create needs ghost atoms from further away");
+			s3list = special[i3local];
+			n3 = nspecial[i3local][0];
 
-      for (k = 0; k < n3; k++) {
-        i4 = s3list[k];
-        if (i4 == i1 || i4 == i2 || i4 == i3) continue;
+			for (k = 0; k < n3; k++) {
+				i4 = s3list[k];
+				if (i4 == i1 || i4 == i2 || i4 == i3)
+					continue;
 
-        // dihedral = i1-i2-i3-i4
+				// dihedral = i1-i2-i3-i4
 
-        for (n = 0; n < ncreate; n++) {
-          if (created[n][0] == i1 && created[n][1] == i2) break;
-          if (created[n][0] == i2 && created[n][1] == i1) break;
-          if (created[n][0] == i2 && created[n][1] == i3) break;
-          if (created[n][0] == i3 && created[n][1] == i2) break;
-          if (created[n][0] == i3 && created[n][1] == i4) break;
-          if (created[n][0] == i4 && created[n][1] == i3) break;
-        }
-        if (n < ncreate) {
+				for (n = 0; n < ncreate; n++) {
+					if (created[n][0] == i1 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i1)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i3)
+						break;
+					if (created[n][0] == i3 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i3 && created[n][1] == i4)
+						break;
+					if (created[n][0] == i4 && created[n][1] == i3)
+						break;
+				}
+				if (n < ncreate) {
 
-        	if (dihedraldynflag) {
-        		dih_type[0] = type[atom->map(i1)];
-        		dih_type[1] = type[atom->map(i2)];
-        		dih_type[2] = type[atom->map(i3)];
-        		dih_type[3] = type[atom->map(i4)];
-        		dihedral_detector->get(dih_type, dtype);
-        	}
+					if (dihedraldynflag) {
+						dih_type[0] = type[atom->map(i1)];
+						dih_type[1] = type[atom->map(i2)];
+						dih_type[2] = type[atom->map(i3)];
+						dih_type[3] = type[atom->map(i4)];
+						dihedral_detector->get(dih_type, dtype);
+					}
 
-          // NOTE: this is place to check atom types of i3,i2,i1,i4
-          if (num_dihedral < atom->dihedral_per_atom) {
-            dihedral_type[num_dihedral] = dtype;
-            dihedral_atom1[num_dihedral] = i1;
-            dihedral_atom2[num_dihedral] = i2;
-            dihedral_atom3[num_dihedral] = i3;
-            dihedral_atom4[num_dihedral] = i4;
-            num_dihedral++;
-            ndihedrals++;
-          } else overflow = 1;
-        }
-      }
-    }
-  }
+					// NOTE: this is place to check atom types of i3,i2,i1,i4
+					if (num_dihedral < atom->dihedral_per_atom) {
+						dihedral_type[num_dihedral] = dtype;
+						dihedral_atom1[num_dihedral] = i1;
+						dihedral_atom2[num_dihedral] = i2;
+						dihedral_atom3[num_dihedral] = i3;
+						dihedral_atom4[num_dihedral] = i4;
+						num_dihedral++;
+						ndihedrals++;
+					} else
+						overflow = 1;
+				}
+			}
+		}
+	}
 
-  for (i = 0; i < n2; i++) {
-    i1 = s2list[i];
-    if (force->newton_bond && i2 > i1) continue;
-    i1local = atom->map(i1);
-    if (i1local < 0)
-      error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-    s3list = special[i1local];
-    n3 = nspecial[i1local][0];
+	for (i = 0; i < n2; i++) {
+		i1 = s2list[i];
+		if (force->newton_bond && i2 > i1)
+			continue;
+		i1local = atom->map(i1);
+		if (i1local < 0)
+			error->one(FLERR,
+					"Fix bond/create needs ghost atoms from further away");
+		s3list = special[i1local];
+		n3 = nspecial[i1local][0];
 
-    for (j = i+1; j < n2; j++) {
-      i3 = s2list[j];
+		for (j = i + 1; j < n2; j++) {
+			i3 = s2list[j];
 
-      for (k = 0; k < n3; k++) {
-        i4 = s3list[k];
-        if (i4 == i1 || i4 == i2 || i4 == i3) continue;
+			for (k = 0; k < n3; k++) {
+				i4 = s3list[k];
+				if (i4 == i1 || i4 == i2 || i4 == i3)
+					continue;
 
-        // dihedral = i3-i2-i1-i4
+				// dihedral = i3-i2-i1-i4
 
-        for (n = 0; n < ncreate; n++) {
-          if (created[n][0] == i3 && created[n][1] == i2) break;
-          if (created[n][0] == i2 && created[n][1] == i3) break;
-          if (created[n][0] == i2 && created[n][1] == i1) break;
-          if (created[n][0] == i1 && created[n][1] == i2) break;
-          if (created[n][0] == i1 && created[n][1] == i4) break;
-          if (created[n][0] == i4 && created[n][1] == i1) break;
-        }
-        if (n < ncreate) {
-          // NOTE: this is place to check atom types of i3,i2,i1,i4
-          if (num_dihedral < atom->dihedral_per_atom) {
-            dihedral_type[num_dihedral] = dtype;
-            dihedral_atom1[num_dihedral] = i3;
-            dihedral_atom2[num_dihedral] = i2;
-            dihedral_atom3[num_dihedral] = i1;
-            dihedral_atom4[num_dihedral] = i4;
-            num_dihedral++;
-            ndihedrals++;
-          } else overflow = 1;
-        }
-      }
-    }
-  }
+				for (n = 0; n < ncreate; n++) {
+					if (created[n][0] == i3 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i3)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i1)
+						break;
+					if (created[n][0] == i1 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i1 && created[n][1] == i4)
+						break;
+					if (created[n][0] == i4 && created[n][1] == i1)
+						break;
+				}
+				if (n < ncreate) {
+					// NOTE: this is place to check atom types of i3,i2,i1,i4
+					if (num_dihedral < atom->dihedral_per_atom) {
+						dihedral_type[num_dihedral] = dtype;
+						dihedral_atom1[num_dihedral] = i3;
+						dihedral_atom2[num_dihedral] = i2;
+						dihedral_atom3[num_dihedral] = i1;
+						dihedral_atom4[num_dihedral] = i4;
+						num_dihedral++;
+						ndihedrals++;
+					} else
+						overflow = 1;
+				}
+			}
+		}
+	}
 
-  atom->num_dihedral[m] = num_dihedral;
-  if (force->newton_bond) return;
+	atom->num_dihedral[m] = num_dihedral;
+	if (force->newton_bond)
+		return;
 
-  // for newton_bond off, also consider atom M as atom 1 in dihedral
+	// for newton_bond off, also consider atom M as atom 1 in dihedral
 
-  i1 = tag[m];
-  n1 = nspecial[m][0];
-  s1list = special[m];
+	i1 = tag[m];
+	n1 = nspecial[m][0];
+	s1list = special[m];
 
-  for (i = 0; i < n1; i++) {
-    i2 = s1list[i];
-    i2local = atom->map(i2);
-    if (i2local < 0)
-      error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-    s2list = special[i2local];
-    n2 = nspecial[i2local][0];
+	for (i = 0; i < n1; i++) {
+		i2 = s1list[i];
+		i2local = atom->map(i2);
+		if (i2local < 0)
+			error->one(FLERR,
+					"Fix bond/create needs ghost atoms from further away");
+		s2list = special[i2local];
+		n2 = nspecial[i2local][0];
 
-    for (j = 0; j < n2; j++) {
-      i3 = s2list[j];
-      if (i3 == i1) continue;
-      i3local = atom->map(i3);
-      if (i3local < 0)
-        error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-      s3list = special[i3local];
-      n3 = nspecial[i3local][0];
+		for (j = 0; j < n2; j++) {
+			i3 = s2list[j];
+			if (i3 == i1)
+				continue;
+			i3local = atom->map(i3);
+			if (i3local < 0)
+				error->one(FLERR,
+						"Fix bond/create needs ghost atoms from further away");
+			s3list = special[i3local];
+			n3 = nspecial[i3local][0];
 
-      for (k = 0; k < n3; k++) {
-        i4 = s3list[k];
-        if (i4 == i1 || i4 == i2 || i4 == i3) continue;
+			for (k = 0; k < n3; k++) {
+				i4 = s3list[k];
+				if (i4 == i1 || i4 == i2 || i4 == i3)
+					continue;
 
-        // dihedral = i1-i2-i3-i4
+				// dihedral = i1-i2-i3-i4
 
-        for (n = 0; n < ncreate; n++) {
-          if (created[n][0] == i1 && created[n][1] == i2) break;
-          if (created[n][0] == i2 && created[n][1] == i1) break;
-          if (created[n][0] == i2 && created[n][1] == i3) break;
-          if (created[n][0] == i3 && created[n][1] == i2) break;
-          if (created[n][0] == i3 && created[n][1] == i4) break;
-          if (created[n][0] == i4 && created[n][1] == i3) break;
-        }
-        if (n < ncreate) {
-          // NOTE: this is place to check atom types of i3,i2,i1,i4
-          if (num_dihedral < atom->dihedral_per_atom) {
-            dihedral_type[num_dihedral] = dtype;
-            dihedral_atom1[num_dihedral] = i1;
-            dihedral_atom2[num_dihedral] = i2;
-            dihedral_atom3[num_dihedral] = i3;
-            dihedral_atom4[num_dihedral] = i4;
-            num_dihedral++;
-            ndihedrals++;
-          } else overflow = 1;
-        }
-      }
-    }
-  }
+				for (n = 0; n < ncreate; n++) {
+					if (created[n][0] == i1 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i1)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i3)
+						break;
+					if (created[n][0] == i3 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i3 && created[n][1] == i4)
+						break;
+					if (created[n][0] == i4 && created[n][1] == i3)
+						break;
+				}
+				if (n < ncreate) {
+					// NOTE: this is place to check atom types of i3,i2,i1,i4
+					if (num_dihedral < atom->dihedral_per_atom) {
+						dihedral_type[num_dihedral] = dtype;
+						dihedral_atom1[num_dihedral] = i1;
+						dihedral_atom2[num_dihedral] = i2;
+						dihedral_atom3[num_dihedral] = i3;
+						dihedral_atom4[num_dihedral] = i4;
+						num_dihedral++;
+						ndihedrals++;
+					} else
+						overflow = 1;
+				}
+			}
+		}
+	}
 }
 
 /* ----------------------------------------------------------------------
-   create any impropers owned by atom M induced by newly created bonds
-   walk special list to find all possible impropers to create
-   only add an improper if a new bond is one of its 3 bonds (I-J,I-K,I-L)
-   for newton_bond on, atom M is central atom
-   for newton_bond off, atom M is any of 4 atoms in improper
-------------------------------------------------------------------------- */
+ create any impropers owned by atom M induced by newly created bonds
+ walk special list to find all possible impropers to create
+ only add an improper if a new bond is one of its 3 bonds (I-J,I-K,I-L)
+ for newton_bond on, atom M is central atom
+ for newton_bond off, atom M is any of 4 atoms in improper
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::create_impropers(int m)
-{
-  int i,j,k,n,i1local,n1,n2;
-  tagint i1,i2,i3,i4;
-  tagint *s1list,*s2list;
+void FixBondCreate::create_impropers(int m) {
+	int i, j, k, n, i1local, n1, n2;
+	tagint i1, i2, i3, i4;
+	tagint *s1list, *s2list;
 
-  tagint *tag = atom->tag;
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
+	tagint *tag = atom->tag;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
 
-  int num_improper = atom->num_improper[m];
-  int *improper_type = atom->improper_type[m];
-  tagint *improper_atom1 = atom->improper_atom1[m];
-  tagint *improper_atom2 = atom->improper_atom2[m];
-  tagint *improper_atom3 = atom->improper_atom3[m];
-  tagint *improper_atom4 = atom->improper_atom4[m];
+	int num_improper = atom->num_improper[m];
+	int *improper_type = atom->improper_type[m];
+	tagint *improper_atom1 = atom->improper_atom1[m];
+	tagint *improper_atom2 = atom->improper_atom2[m];
+	tagint *improper_atom3 = atom->improper_atom3[m];
+	tagint *improper_atom4 = atom->improper_atom4[m];
 
-  int *type;
-  int *imp_type;
-  if (improperdynflag) {
-	  type = atom->type;
-	  imp_type = new int[4];
-  }
-  // atom M is central atom in improper
-  // triple loop over 1-2 neighs
-  // avoid double counting by 2nd loop as j = i+1,N not j = 1,N
-  // consider all impropers, only add if:
-  //   a new bond is in the improper and atom types match
+	int *type;
+	int *imp_type;
+	if (improperdynflag) {
+		type = atom->type;
+		imp_type = new int[4];
+	}
+	// atom M is central atom in improper
+	// triple loop over 1-2 neighs
+	// avoid double counting by 2nd loop as j = i+1,N not j = 1,N
+	// consider all impropers, only add if:
+	//   a new bond is in the improper and atom types match
 
-  i1 = tag[m];
-  n1 = nspecial[m][0];
-  s1list = special[m];
+	i1 = tag[m];
+	n1 = nspecial[m][0];
+	s1list = special[m];
 
-  for (i = 0; i < n1; i++) {
-    i2 = s1list[i];
-    for (j = i+1; j < n1; j++) {
-      i3 = s1list[j];
-      for (k = j+1; k < n1; k++) {
-        i4 = s1list[k];
+	for (i = 0; i < n1; i++) {
+		i2 = s1list[i];
+		for (j = i + 1; j < n1; j++) {
+			i3 = s1list[j];
+			for (k = j + 1; k < n1; k++) {
+				i4 = s1list[k];
 
-        // improper = i1-i2-i3-i4
+				// improper = i1-i2-i3-i4
 
-        for (n = 0; n < ncreate; n++) {
-          if (created[n][0] == i1 && created[n][1] == i2) break;
-          if (created[n][0] == i2 && created[n][1] == i1) break;
-          if (created[n][0] == i1 && created[n][1] == i3) break;
-          if (created[n][0] == i3 && created[n][1] == i1) break;
-          if (created[n][0] == i1 && created[n][1] == i4) break;
-          if (created[n][0] == i4 && created[n][1] == i1) break;
-        }
-        if (n == ncreate) continue;
+				for (n = 0; n < ncreate; n++) {
+					if (created[n][0] == i1 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i1)
+						break;
+					if (created[n][0] == i1 && created[n][1] == i3)
+						break;
+					if (created[n][0] == i3 && created[n][1] == i1)
+						break;
+					if (created[n][0] == i1 && created[n][1] == i4)
+						break;
+					if (created[n][0] == i4 && created[n][1] == i1)
+						break;
+				}
+				if (n == ncreate)
+					continue;
 
-        if (improperdynflag) {
-        	imp_type[0] = type[atom->map(i1)];
-        	imp_type[1] = type[atom->map(i2)];
-        	imp_type[2] = type[atom->map(i3)];
-        	imp_type[3] = type[atom->map(i4)];
-        	improper_detector->get(imp_type, itype);
-        }
+				if (improperdynflag) {
+					imp_type[0] = type[atom->map(i1)];
+					imp_type[1] = type[atom->map(i2)];
+					imp_type[2] = type[atom->map(i3)];
+					imp_type[3] = type[atom->map(i4)];
+					improper_detector->get(imp_type, itype);
+				}
 
-        if (num_improper < atom->improper_per_atom) {
-          improper_type[num_improper] = itype;
-          improper_atom1[num_improper] = i1;
-          improper_atom2[num_improper] = i2;
-          improper_atom3[num_improper] = i3;
-          improper_atom4[num_improper] = i4;
-          num_improper++;
-          nimpropers++;
-        } else overflow = 1;
-      }
-    }
-  }
+				if (num_improper < atom->improper_per_atom) {
+					improper_type[num_improper] = itype;
+					improper_atom1[num_improper] = i1;
+					improper_atom2[num_improper] = i2;
+					improper_atom3[num_improper] = i3;
+					improper_atom4[num_improper] = i4;
+					num_improper++;
+					nimpropers++;
+				} else
+					overflow = 1;
+			}
+		}
+	}
 
-  atom->num_improper[m] = num_improper;
-  if (force->newton_bond) return;
+	atom->num_improper[m] = num_improper;
+	if (force->newton_bond)
+		return;
 
-  // for newton_bond off, also consider atom M as atom 2 in improper
+	// for newton_bond off, also consider atom M as atom 2 in improper
 
-  i2 = tag[m];
-  n2 = nspecial[m][0];
-  s2list = special[m];
+	i2 = tag[m];
+	n2 = nspecial[m][0];
+	s2list = special[m];
 
-  for (i = 0; i < n2; i++) {
-    i1 = s2list[i];
-    i1local = atom->map(i1);
-    if (i1local < 0)
-      error->one(FLERR,"Fix bond/create needs ghost atoms from further away");
-    s1list = special[i1local];
-    n1 = nspecial[i1local][0];
+	for (i = 0; i < n2; i++) {
+		i1 = s2list[i];
+		i1local = atom->map(i1);
+		if (i1local < 0)
+			error->one(FLERR,
+					"Fix bond/create needs ghost atoms from further away");
+		s1list = special[i1local];
+		n1 = nspecial[i1local][0];
 
-    for (j = 0; j < n1; j++) {
-      i3 = s1list[j];
-      if (i3 == i1 || i3 == i2) continue;
+		for (j = 0; j < n1; j++) {
+			i3 = s1list[j];
+			if (i3 == i1 || i3 == i2)
+				continue;
 
-      for (k = j+1; k < n1; k++) {
-        i4 = s1list[k];
-        if (i4 == i1 || i4 == i2) continue;
+			for (k = j + 1; k < n1; k++) {
+				i4 = s1list[k];
+				if (i4 == i1 || i4 == i2)
+					continue;
 
-        // improper = i1-i2-i3-i4
+				// improper = i1-i2-i3-i4
 
-        for (n = 0; n < ncreate; n++) {
-          if (created[n][0] == i1 && created[n][1] == i2) break;
-          if (created[n][0] == i2 && created[n][1] == i1) break;
-          if (created[n][0] == i1 && created[n][1] == i3) break;
-          if (created[n][0] == i3 && created[n][1] == i1) break;
-          if (created[n][0] == i1 && created[n][1] == i4) break;
-          if (created[n][0] == i4 && created[n][1] == i1) break;
-        }
-        if (n < ncreate) {
-          // NOTE: this is place to check atom types of i3,i2,i1,i4
-          if (num_improper < atom->improper_per_atom) {
-            improper_type[num_improper] = itype;
-            improper_atom1[num_improper] = i1;
-            improper_atom2[num_improper] = i2;
-            improper_atom3[num_improper] = i3;
-            improper_atom4[num_improper] = i4;
-            num_improper++;
-            nimpropers++;
-          } else overflow = 1;
-        }
-      }
-    }
-  }
+				for (n = 0; n < ncreate; n++) {
+					if (created[n][0] == i1 && created[n][1] == i2)
+						break;
+					if (created[n][0] == i2 && created[n][1] == i1)
+						break;
+					if (created[n][0] == i1 && created[n][1] == i3)
+						break;
+					if (created[n][0] == i3 && created[n][1] == i1)
+						break;
+					if (created[n][0] == i1 && created[n][1] == i4)
+						break;
+					if (created[n][0] == i4 && created[n][1] == i1)
+						break;
+				}
+				if (n < ncreate) {
+					// NOTE: this is place to check atom types of i3,i2,i1,i4
+					if (num_improper < atom->improper_per_atom) {
+						improper_type[num_improper] = itype;
+						improper_atom1[num_improper] = i1;
+						improper_atom2[num_improper] = i2;
+						improper_atom3[num_improper] = i3;
+						improper_atom4[num_improper] = i4;
+						num_improper++;
+						nimpropers++;
+					} else
+						overflow = 1;
+				}
+			}
+		}
+	}
 }
 
 /* ----------------------------------------------------------------------
-   remove all ID duplicates in copy from Nstart:Nstop-1
-   compare to all previous values in copy
-   return N decremented by any discarded duplicates
-------------------------------------------------------------------------- */
+ remove all ID duplicates in copy from Nstart:Nstop-1
+ compare to all previous values in copy
+ return N decremented by any discarded duplicates
+ ------------------------------------------------------------------------- */
 
-int FixBondCreate::dedup(int nstart, int nstop, tagint *copy)
-{
-  int i;
+int FixBondCreate::dedup(int nstart, int nstop, tagint *copy) {
+	int i;
 
-  int m = nstart;
-  while (m < nstop) {
-    for (i = 0; i < m; i++)
-      if (copy[i] == copy[m]) {
-        copy[m] = copy[nstop-1];
-        nstop--;
-        break;
-      }
-    if (i == m) m++;
-  }
+	int m = nstart;
+	while (m < nstop) {
+		for (i = 0; i < m; i++)
+			if (copy[i] == copy[m]) {
+				copy[m] = copy[nstop - 1];
+				nstop--;
+				break;
+			}
+		if (i == m)
+			m++;
+	}
 
-  return nstop;
+	return nstop;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::post_integrate_respa(int ilevel, int iloop)
-{
-  if (ilevel == nlevels_respa-1) post_integrate();
+void FixBondCreate::post_integrate_respa(int ilevel, int iloop) {
+	if (ilevel == nlevels_respa - 1)
+		post_integrate();
 }
 
 /* ---------------------------------------------------------------------- */
 
 int FixBondCreate::pack_forward_comm(int n, int *list, double *buf,
-                                     int pbc_flag, int *pbc)
-{
-  int i,j,k,m,ns;
+		int pbc_flag, int *pbc) {
+	int i, j, k, m, ns;
 
-  m = 0;
+	m = 0;
 
-  if (commflag == 1) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = ubuf(bondcount[j]).d;
-    }
-    return m;
-  }
+	if (commflag == 1) {
+		for (i = 0; i < n; i++) {
+			j = list[i];
+			buf[m++] = ubuf(bondcount[j]).d;
+		}
+		return m;
+	}
 
-  if (commflag == 2) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = ubuf(partner[j]).d;
-      buf[m++] = probability[j];
-    }
-    return m;
-  }
+	if (commflag == 2) {
+		for (i = 0; i < n; i++) {
+			j = list[i];
+			buf[m++] = ubuf(partner[j]).d;
+			buf[m++] = probability[j];
+		}
+		return m;
+	}
 
-  int **nspecial = atom->nspecial;
-  tagint **special = atom->special;
+	int **nspecial = atom->nspecial;
+	tagint **special = atom->special;
 
-  m = 0;
-  for (i = 0; i < n; i++) {
-    j = list[i];
-    buf[m++] = ubuf(finalpartner[j]).d;
-    ns = nspecial[j][0];
-    buf[m++] = ubuf(ns).d;
-    for (k = 0; k < ns; k++)
-      buf[m++] = ubuf(special[j][k]).d;
-  }
-  return m;
+	m = 0;
+	for (i = 0; i < n; i++) {
+		j = list[i];
+		buf[m++] = ubuf(finalpartner[j]).d;
+		ns = nspecial[j][0];
+		buf[m++] = ubuf(ns).d;
+		for (k = 0; k < ns; k++)
+			buf[m++] = ubuf(special[j][k]).d;
+	}
+	return m;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::unpack_forward_comm(int n, int first, double *buf)
-{
-  int i,j,m,ns,last;
+void FixBondCreate::unpack_forward_comm(int n, int first, double *buf) {
+	int i, j, m, ns, last;
 
-  m = 0;
-  last = first + n;
+	m = 0;
+	last = first + n;
 
-  if (commflag == 1) {
-    for (i = first; i < last; i++)
-      bondcount[i] = (int) ubuf(buf[m++]).i;
+	if (commflag == 1) {
+		for (i = first; i < last; i++)
+			bondcount[i] = (int) ubuf(buf[m++]).i;
 
-  } else if (commflag == 2) {
-    for (i = first; i < last; i++) {
-      partner[i] = (tagint) ubuf(buf[m++]).i;
-      probability[i] = buf[m++];
-    }
+	} else if (commflag == 2) {
+		for (i = first; i < last; i++) {
+			partner[i] = (tagint) ubuf(buf[m++]).i;
+			probability[i] = buf[m++];
+		}
 
-  } else {
-    int **nspecial = atom->nspecial;
-    tagint **special = atom->special;
+	} else {
+		int **nspecial = atom->nspecial;
+		tagint **special = atom->special;
 
-    m = 0;
-    last = first + n;
-    for (i = first; i < last; i++) {
-      finalpartner[i] = (tagint) ubuf(buf[m++]).i;
-      ns = (int) ubuf(buf[m++]).i;
-      nspecial[i][0] = ns;
-      for (j = 0; j < ns; j++)
-        special[i][j] = (tagint) ubuf(buf[m++]).i;
-    }
-  }
+		m = 0;
+		last = first + n;
+		for (i = first; i < last; i++) {
+			finalpartner[i] = (tagint) ubuf(buf[m++]).i;
+			ns = (int) ubuf(buf[m++]).i;
+			nspecial[i][0] = ns;
+			for (j = 0; j < ns; j++)
+				special[i][j] = (tagint) ubuf(buf[m++]).i;
+		}
+	}
 }
 
 /* ---------------------------------------------------------------------- */
 
-int FixBondCreate::pack_reverse_comm(int n, int first, double *buf)
-{
-  int i,m,last;
+int FixBondCreate::pack_reverse_comm(int n, int first, double *buf) {
+	int i, m, last;
 
-  m = 0;
-  last = first + n;
+	m = 0;
+	last = first + n;
 
-  if (commflag == 1) {
-    for (i = first; i < last; i++)
-      buf[m++] = ubuf(bondcount[i]).d;
-    return m;
-  }
+	if (commflag == 1) {
+		for (i = first; i < last; i++)
+			buf[m++] = ubuf(bondcount[i]).d;
+		return m;
+	}
 
-  for (i = first; i < last; i++) {
-    buf[m++] = ubuf(partner[i]).d;
-    buf[m++] = distsq[i];
-  }
-  return m;
+	for (i = first; i < last; i++) {
+		buf[m++] = ubuf(partner[i]).d;
+		buf[m++] = distsq[i];
+	}
+	return m;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::unpack_reverse_comm(int n, int *list, double *buf)
-{
-  int i,j,m;
+void FixBondCreate::unpack_reverse_comm(int n, int *list, double *buf) {
+	int i, j, m;
 
-  m = 0;
+	m = 0;
 
-  if (commflag == 1) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      bondcount[j] += (int) ubuf(buf[m++]).i;
-    }
+	if (commflag == 1) {
+		for (i = 0; i < n; i++) {
+			j = list[i];
+			bondcount[j] += (int) ubuf(buf[m++]).i;
+		}
 
-  } else {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      if (buf[m+1] < distsq[j]) {
-        partner[j] = (tagint) ubuf(buf[m++]).i;
-        distsq[j] = buf[m++];
-      } else m += 2;
-    }
-  }
+	} else {
+		for (i = 0; i < n; i++) {
+			j = list[i];
+			if (buf[m + 1] < distsq[j]) {
+				partner[j] = (tagint) ubuf(buf[m++]).i;
+				distsq[j] = buf[m++];
+			} else
+				m += 2;
+		}
+	}
 }
 
 /* ----------------------------------------------------------------------
-   allocate local atom-based arrays
-------------------------------------------------------------------------- */
+ allocate local atom-based arrays
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::grow_arrays(int nmax)
-{
-  memory->grow(bondcount,nmax,"bond/create:bondcount");
+void FixBondCreate::grow_arrays(int nmax) {
+	memory->grow(bondcount, nmax, "bond/create:bondcount");
 }
 
 /* ----------------------------------------------------------------------
-   copy values within local atom-based arrays
-------------------------------------------------------------------------- */
+ copy values within local atom-based arrays
+ ------------------------------------------------------------------------- */
 
-void FixBondCreate::copy_arrays(int i, int j, int delflag)
-{
-  bondcount[j] = bondcount[i];
+void FixBondCreate::copy_arrays(int i, int j, int delflag) {
+	bondcount[j] = bondcount[i];
 }
 
 /* ----------------------------------------------------------------------
-   pack values in local atom-based arrays for exchange with another proc
-------------------------------------------------------------------------- */
+ pack values in local atom-based arrays for exchange with another proc
+ ------------------------------------------------------------------------- */
 
-int FixBondCreate::pack_exchange(int i, double *buf)
-{
-  buf[0] = bondcount[i];
-  return 1;
+int FixBondCreate::pack_exchange(int i, double *buf) {
+	buf[0] = bondcount[i];
+	return 1;
 }
 
 /* ----------------------------------------------------------------------
-   unpack values in local atom-based arrays from exchange with another proc
-------------------------------------------------------------------------- */
+ unpack values in local atom-based arrays from exchange with another proc
+ ------------------------------------------------------------------------- */
 
-int FixBondCreate::unpack_exchange(int nlocal, double *buf)
-{
-  bondcount[nlocal] = static_cast<int> (buf[0]);
-  return 1;
+int FixBondCreate::unpack_exchange(int nlocal, double *buf) {
+	bondcount[nlocal] = static_cast<int>(buf[0]);
+	return 1;
 }
 
 /* ---------------------------------------------------------------------- */
 
-double FixBondCreate::compute_vector(int n)
-{
-  if (n == 0) return (double) createcount;
-  return (double) createcounttotal;
+double FixBondCreate::compute_vector(int n) {
+	if (n == 0)
+		return (double) createcount;
+	return (double) createcounttotal;
 }
 
 /* ----------------------------------------------------------------------
-   memory usage of local atom-based arrays
-------------------------------------------------------------------------- */
+ memory usage of local atom-based arrays
+ ------------------------------------------------------------------------- */
 
-double FixBondCreate::memory_usage()
-{
-  int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);
-  bytes = 2*nmax * sizeof(tagint);
-  bytes += nmax * sizeof(double);
-  return bytes;
+double FixBondCreate::memory_usage() {
+	int nmax = atom->nmax;
+	double bytes = nmax * sizeof(int);
+	bytes = 2 * nmax * sizeof(tagint);
+	bytes += nmax * sizeof(double);
+	return bytes;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::print_bb()
-{
-  for (int i = 0; i < atom->nlocal; i++) {
-    printf("TAG " TAGINT_FORMAT ": %d nbonds: ",atom->tag[i],atom->num_bond[i]);
-    for (int j = 0; j < atom->num_bond[i]; j++) {
-      printf(" " TAGINT_FORMAT,atom->bond_atom[i][j]);
-    }
-    printf("\n");
-    printf("TAG " TAGINT_FORMAT ": %d nangles: ",atom->tag[i],atom->num_angle[i]);
-    for (int j = 0; j < atom->num_angle[i]; j++) {
-      printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT ",",
-             atom->angle_atom1[i][j], atom->angle_atom2[i][j],
-             atom->angle_atom3[i][j]);
-    }
-    printf("\n");
-    printf("TAG " TAGINT_FORMAT ": %d ndihedrals: ",atom->tag[i],atom->num_dihedral[i]);
-    for (int j = 0; j < atom->num_dihedral[i]; j++) {
-      printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT " "
-             TAGINT_FORMAT ",", atom->dihedral_atom1[i][j],
-	     atom->dihedral_atom2[i][j],atom->dihedral_atom3[i][j],
-	     atom->dihedral_atom4[i][j]);
-    }
-    printf("\n");
-    printf("TAG " TAGINT_FORMAT ": %d nimpropers: ",atom->tag[i],atom->num_improper[i]);
-    for (int j = 0; j < atom->num_improper[i]; j++) {
-      printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT " "
-             TAGINT_FORMAT ",",atom->improper_atom1[i][j],
-	     atom->improper_atom2[i][j],atom->improper_atom3[i][j],
-	     atom->improper_atom4[i][j]);
-    }
-    printf("\n");
-    printf("TAG " TAGINT_FORMAT ": %d %d %d nspecial: ",atom->tag[i],
-	   atom->nspecial[i][0],atom->nspecial[i][1],atom->nspecial[i][2]);
-    for (int j = 0; j < atom->nspecial[i][2]; j++) {
-      printf(" " TAGINT_FORMAT,atom->special[i][j]);
-    }
-    printf("\n");
-  }
+void FixBondCreate::print_bb() {
+	for (int i = 0; i < atom->nlocal; i++) {
+		printf("TAG " TAGINT_FORMAT ": %d nbonds: ", atom->tag[i],
+				atom->num_bond[i]);
+		for (int j = 0; j < atom->num_bond[i]; j++) {
+			printf(" " TAGINT_FORMAT, atom->bond_atom[i][j]);
+		}
+		printf("\n");
+		printf("TAG " TAGINT_FORMAT ": %d nangles: ", atom->tag[i],
+				atom->num_angle[i]);
+		for (int j = 0; j < atom->num_angle[i]; j++) {
+			printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT ",",
+					atom->angle_atom1[i][j], atom->angle_atom2[i][j],
+					atom->angle_atom3[i][j]);
+		}
+		printf("\n");
+		printf("TAG " TAGINT_FORMAT ": %d ndihedrals: ", atom->tag[i],
+				atom->num_dihedral[i]);
+		for (int j = 0; j < atom->num_dihedral[i]; j++) {
+			printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT " "
+			TAGINT_FORMAT ",", atom->dihedral_atom1[i][j],
+					atom->dihedral_atom2[i][j], atom->dihedral_atom3[i][j],
+					atom->dihedral_atom4[i][j]);
+		}
+		printf("\n");
+		printf("TAG " TAGINT_FORMAT ": %d nimpropers: ", atom->tag[i],
+				atom->num_improper[i]);
+		for (int j = 0; j < atom->num_improper[i]; j++) {
+			printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT " "
+			TAGINT_FORMAT ",", atom->improper_atom1[i][j],
+					atom->improper_atom2[i][j], atom->improper_atom3[i][j],
+					atom->improper_atom4[i][j]);
+		}
+		printf("\n");
+		printf("TAG " TAGINT_FORMAT ": %d %d %d nspecial: ", atom->tag[i],
+				atom->nspecial[i][0], atom->nspecial[i][1],
+				atom->nspecial[i][2]);
+		for (int j = 0; j < atom->nspecial[i][2]; j++) {
+			printf(" " TAGINT_FORMAT, atom->special[i][j]);
+		}
+		printf("\n");
+	}
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::print_copy(const char *str, tagint m,
-                              int n1, int n2, int n3, int *v)
-{
-  printf("%s " TAGINT_FORMAT ": %d %d %d nspecial: ",str,m,n1,n2,n3);
-  for (int j = 0; j < n3; j++) printf(" %d",v[j]);
+void FixBondCreate::print_copy(const char *str, tagint m, int n1, int n2,
+		int n3, int *v) {
+	printf("%s " TAGINT_FORMAT ": %d %d %d nspecial: ", str, m, n1, n2, n3);
+	for (int j = 0; j < n3; j++)
+		printf(" %d", v[j]);
 	printf("\n");
 }

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -11,6 +11,12 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Assigning different types for angle, dihedral, and
+   improper dihedral angles added to the code:
+   Contributing author: Amin Aramoon (Johns Hopkins U)
+------------------------------------------------------------------------- */
+
 #include <math.h>
 #include <mpi.h>
 #include <string.h>

--- a/src/MC/fix_bond_create.h
+++ b/src/MC/fix_bond_create.h
@@ -11,6 +11,12 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Assigning different types for angle, dihedral, and
+   improper dihedral angles added to the code:
+   Contributing author: Amin Aramoon (Johns Hopkins U)
+------------------------------------------------------------------------- */
+
 #ifdef FIX_CLASS
 
 FixStyle(bond/create,FixBondCreate)

--- a/src/MC/fix_bond_create.h
+++ b/src/MC/fix_bond_create.h
@@ -21,6 +21,7 @@ FixStyle(bond/create,FixBondCreate)
 #define LMP_FIX_BOND_CREATE_H
 
 #include "fix.h"
+#include "type_detector.h"
 
 namespace LAMMPS_NS {
 
@@ -57,6 +58,9 @@ class FixBondCreate : public Fix {
   int angleflag,dihedralflag,improperflag;
   int overflow;
   tagint lastcheck;
+
+  int angledynflag, dihedraldynflag, improperdynflag; // set whether the types are specified on the go
+  TypeDetector *angle_detector, *dihedral_detector, *improper_detector;
 
   int *bondcount;
   int createcount,createcounttotal;

--- a/src/MC/type_detector.h
+++ b/src/MC/type_detector.h
@@ -154,7 +154,7 @@ private:
 	}
 
 	void tokentize(char* &dup, std::vector<char*> & v) {
-		const char delim[] = { ' ', ',' };
+		const char delim[] = { ' ', ',', ';' };
 		char *token = strtok(dup, delim);
 		while (token != NULL) {
 			v.push_back(token);

--- a/src/MC/type_detector.h
+++ b/src/MC/type_detector.h
@@ -1,9 +1,19 @@
-/*
- * type_detector.h
- *
- *  Created on: Aug 12, 2016
- *      Author: amin
- */
+/* ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Author: Amin Aramoon (Johns Hopkins U) aaramoo1@jhu.edu
+------------------------------------------------------------------------- */
 
 #ifndef LMP_TYPE_DETECTOR_H_
 #define LMP_TYPE_DETECTOR_H_

--- a/src/MC/type_detector.h
+++ b/src/MC/type_detector.h
@@ -1,0 +1,158 @@
+/*
+ * type_detector.h
+ *
+ *  Created on: Aug 12, 2016
+ *      Author: amin
+ */
+
+#ifndef LMP_TYPE_DETECTOR_H_
+#define LMP_TYPE_DETECTOR_H_
+
+#include <stdlib.h>
+#include <vector>
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+#include "pointers.h"
+
+class TypeDetector {
+
+	struct Entity {
+		int *ID; // * -> -1
+		int value;
+		int level;
+
+		Entity() {
+			ID = NULL;
+			value = -1;
+			level = 0;
+		}
+
+		virtual ~Entity() {
+			delete[] ID;
+		}
+	};
+
+public:
+	int type; // 0=bond, 1=angle, 2=dihedral, 3=improper
+	int length;
+
+	TypeDetector() {
+	}
+
+	virtual ~TypeDetector() {
+		values.empty();
+	}
+
+	bool init(const char* input, int style) {
+		std::vector<char*> args;
+		char* s = new char[128];
+		strcpy(s, input);
+		tokentize(s, args);
+		int len = args.size();
+		type = style;
+		if (type == 0)
+			length = 2;
+		else if (type == 1)
+			length = 3;
+		else if (type == 2)
+			length = 4;
+		else if (type == 3)
+			length = 4;
+
+		int ntype = len / (length + 1);
+		int *t = new int[len];
+		int val = 0;
+		int iarg = 0;
+		for (int num = 0; num < ntype; num++) {
+			for (int i = 0; i < length; i++) {
+				if (strcmp(args[iarg], "*") == 0)
+					t[i] = 0;
+				else
+					t[i] = atoi(args[iarg]);
+				iarg++;
+			}
+			val = atoi(args[iarg++]);
+			this->set(t, val);
+		}
+		return true;
+	}
+
+	bool get(int *&t1, int &answer) {
+		for (std::vector<Entity *>::iterator it = values.begin();
+				it != values.end(); it++) {
+			if (equals((*it), t1)) {
+				answer = (*it)->value;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	int get_num_types() {
+		int max = 0;
+		for (std::vector<Entity *>::iterator it = values.begin();
+				it != values.end(); it++) {
+			if ((*it)->value > max) {
+				max = (*it)->value;
+			}
+		}
+		return max;
+	}
+
+private:
+
+	void set(int *t1, int value) {
+		int i, p = 0;
+		for (i = 0; i < length; ++i)
+			p += (t1[i] == 0) ? 1 : 0;
+		std::vector<Entity *>::iterator it = values.begin();
+		bool equal = false;
+		while (it != values.end()) {
+			Entity *e = (*it);
+			if (equals(e, t1) && e->level == p) {
+				equal = true;
+				break;
+			} else if (e->level > p) {
+				break;
+			}
+			it++;
+		}
+		if (equal)
+			(*it)->value = value;
+		else {
+			Entity *ne = new Entity();
+			ne->ID = new int[length];
+			for (int i = 0; i < length; ++i)
+				ne->ID[i] = t1[i];
+			ne->value = value;
+			ne->level = p;
+			values.insert(it, ne);
+		}
+	}
+
+	int equals(Entity *&e, int *&id) {
+		int *ID = e->ID;
+		int res = 1, res_rev = 1;
+		for (int i = 0; i < length; ++i) {
+			res *= (ID[i] == id[i] || ID[i] == 0) ? 1 : 0;
+			res_rev *= (ID[i] == id[length - i - 1] || ID[i] == 0) ? 1 : 0;
+		}
+		if (res == 1 || res_rev == 1)
+			return 1;
+		return 0;
+	}
+
+	void tokentize(char* &dup, std::vector<char*> & v) {
+		const char delim[] = { ' ', ',' };
+		char *token = strtok(dup, delim);
+		while (token != NULL) {
+			v.push_back(token);
+			token = strtok(NULL, delim);
+		}
+	}
+
+	std::vector<Entity*> values;
+};
+
+#endif /* SRC_TYPE_DETECTOR_H_ */


### PR DESCRIPTION
this is a pull request for fix_bond_create with updated feature.

The old version applies a static angle, dihedral or improper dihedral style to the newly created angle, and dihedral angles. with this update, user can define different types of angles, and dihedral angles to assign to new coordinates based on the types of atoms forming the coordinate.

This class is fully backward compatible, and utilizes a new class "type_detector" which can decide the type of new created coordinates.

the doc for fix_bond_create is also updated.

usage:

variable id string "1 2 3 1, 2 1 3 2"  // states that if angle is formed by atoms with types <1-2-3> => 1, and <2-1-3> =>2

fix  1 all bond/create 10 1 3 10 1 iparam 2 1 jparam 3 3 atype id dtype 4

