### PR TITLE
Added optimized vashishta potential.

### DIFF
--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -76,6 +76,11 @@ PairVashishta::~PairVashishta()
   memory->destroy(params);
   memory->destroy(elem2param);
 
+  memory->destroy(forceTable);
+  memory->destroy(potentialTable);
+  memory->destroy(neigh3BodyCount);
+  memory->destroy(neigh3Body);
+
   if (allocated) {
     memory->destroy(setflag);
     memory->destroy(cutsq);

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -95,14 +95,22 @@ void PairVashishta::modify_params(int narg, char **arg)
   while (iarg < narg) {
     if (strcmp(arg[iarg],"table") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal pair_modify command");
+
       nTablebits = force->inumeric(FLERR,arg[iarg+1]);
-      if (nTablebits > sizeof(float)*CHAR_BIT)
+      if (nTablebits > sizeof(float)*CHAR_BIT) {
         error->all(FLERR,"Too many total bits for bitmapped lookup table");
-      if(nTablebits != 0) 
+      }
+
+      if(nTablebits == 0) {
+        useTable = false;
+      } else {
         useTable = true;
+      }
+
       iarg += 2;
     } else if (strcmp(arg[iarg],"tabinner") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal pair_modify command");
+      
       tabinner = force->numeric(FLERR,arg[iarg+1]);
       iarg += 2;
     }

--- a/src/MANYBODY/pair_vashishta.h
+++ b/src/MANYBODY/pair_vashishta.h
@@ -53,6 +53,10 @@ class PairVashishta : public Pair {
   double ***forceTable;          // Table containing the forces
   double ***potentialTable;      // Table containing the potential energies
 
+  int neigh3BodyMax;            // Max size of short neighborlist
+  int *neigh3BodyCount;         // Number of neighbors in short range 3 particle forces neighbor list
+  int **neigh3Body;             // Neighborlist for short range 3 particle forces
+
   double cutmax;                // max cutoff for all elements
   int nelements;                // # of unique elements
   char **elements;              // names of unique elements
@@ -66,6 +70,7 @@ class PairVashishta : public Pair {
   void read_file(char *);
   void setup_params();
   void createTable();
+  void validateNeigh3Body();
   void twobody(Param *, double, double &, int, double &, bool);
   void threebody(Param *, Param *, Param *, double, double, double *, double *,
                  double *, double *, int, double &);

--- a/src/MANYBODY/pair_vashishta.h
+++ b/src/MANYBODY/pair_vashishta.h
@@ -46,8 +46,9 @@ class PairVashishta : public Pair {
     double lam1rc,lam4rc,vrcc2,vrcc3,vrc,dvrc,c0;
     int ielement,jelement,kelement;
   };
+
   bool useTable;
-  int tableSize;
+  int nTablebits;
   double deltaR2;
   double oneOverDeltaR2;
   double ***forceTable;          // Table containing the forces
@@ -62,6 +63,7 @@ class PairVashishta : public Pair {
   char **elements;              // names of unique elements
   int ***elem2param;            // mapping from element triplets to parameters
   int *map;                     // mapping from atom types to elements
+  char estr[128];               // Char array to store error message with sprintf (i.e. twobody table)
   int nparams;                  // # of stored parameter sets
   int maxparam;                 // max # of parameter sets
   Param *params;                // parameter set for an I-J-K interaction
@@ -71,7 +73,7 @@ class PairVashishta : public Pair {
   void setup_params();
   void createTable();
   void validateNeigh3Body();
-  void twobody(Param *, double, double &, int, double &, bool);
+  void twobody(Param *, double, double &, int, double &, bool tabulated = false);
   void threebody(Param *, Param *, Param *, double, double, double *, double *,
                  double *, double *, int, double &);
 };

--- a/src/MANYBODY/pair_vashishta.h
+++ b/src/MANYBODY/pair_vashishta.h
@@ -28,6 +28,7 @@ class PairVashishta : public Pair {
  public:
   PairVashishta(class LAMMPS *);
   virtual ~PairVashishta();
+  virtual void modify_params(int, char **);
   virtual void compute(int, int);
   void settings(int, char **);
   void coeff(int, char **);
@@ -45,6 +46,12 @@ class PairVashishta : public Pair {
     double lam1rc,lam4rc,vrcc2,vrcc3,vrc,dvrc,c0;
     int ielement,jelement,kelement;
   };
+  bool useTable;
+  int tableSize;
+  double deltaR2;
+  double oneOverDeltaR2;
+  double ***forceTable;          // Table containing the forces
+  double ***potentialTable;      // Table containing the potential energies
 
   double cutmax;                // max cutoff for all elements
   int nelements;                // # of unique elements
@@ -58,7 +65,8 @@ class PairVashishta : public Pair {
   virtual void allocate();
   void read_file(char *);
   void setup_params();
-  void twobody(Param *, double, double &, int, double &);
+  void createTable();
+  void twobody(Param *, double, double &, int, double &, bool);
   void threebody(Param *, Param *, Param *, double, double, double *, double *,
                  double *, double *, int, double &);
 };

--- a/src/USER-OMP/pair_vashishta_omp.cpp
+++ b/src/USER-OMP/pair_vashishta_omp.cpp
@@ -36,6 +36,8 @@ PairVashishtaOMP::PairVashishtaOMP(LAMMPS *lmp) :
 
 void PairVashishtaOMP::compute(int eflag, int vflag)
 {
+  validateNeigh3Body();
+
   if (eflag || vflag) {
     ev_setup(eflag,vflag);
   } else evflag = vflag_fdotr = 0;
@@ -105,6 +107,8 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
     ztmp = x[i].z;
     fxtmp = fytmp = fztmp = 0.0;
 
+    neigh3BodyCount[i] = 0;
+    
     // two-body interactions, skip half of them
 
     jlist = firstneigh[i];
@@ -114,6 +118,21 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
       j = jlist[jj];
       j &= NEIGHMASK;
       jtag = tag[j];
+      jtype = map[type[j]];
+
+      delx = xtmp - x[j].x;
+      dely = ytmp - x[j].y;
+      delz = ztmp - x[j].z;
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      ijparam = elem2param[itype][jtype][jtype];
+
+      if (rsq <= params[ijparam].cutsq2) {
+          neigh3Body[i][neigh3BodyCount[i]] = j;
+          neigh3BodyCount[i]++;
+      }
+
+      if (rsq >= params[ijparam].cutsq) continue;
 
       if (itag > jtag) {
         if ((itag+jtag) % 2 == 0) continue;
@@ -124,16 +143,6 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
         if (x[j].z == ztmp && x[j].y < ytmp) continue;
         if (x[j].z == ztmp && x[j].y == ytmp && x[j].x < xtmp) continue;
       }
-
-      jtype = map[type[j]];
-
-      delx = xtmp - x[j].x;
-      dely = ytmp - x[j].y;
-      delz = ztmp - x[j].z;
-      rsq = delx*delx + dely*dely + delz*delz;
-
-      ijparam = elem2param[itype][jtype][jtype];
-      if (rsq >= params[ijparam].cutsq) continue;
 
       twobody(&params[ijparam],rsq,fpair,EFLAG,evdwl, useTable);
 
@@ -148,6 +157,8 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
                                evdwl,0.0,fpair,delx,dely,delz,thr);
     }
 
+    jlist = neigh3Body[i];
+    jnum = neigh3BodyCount[i];
     jnumm1 = jnum - 1;
 
     for (jj = 0; jj < jnumm1; jj++) {

--- a/src/USER-OMP/pair_vashishta_omp.cpp
+++ b/src/USER-OMP/pair_vashishta_omp.cpp
@@ -135,7 +135,7 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
       ijparam = elem2param[itype][jtype][jtype];
       if (rsq >= params[ijparam].cutsq) continue;
 
-      twobody(&params[ijparam],rsq,fpair,EFLAG,evdwl);
+      twobody(&params[ijparam],rsq,fpair,EFLAG,evdwl, useTable);
 
       fxtmp += delx*fpair;
       fytmp += dely*fpair;


### PR DESCRIPTION
As discussed today, an optimized vashishta implementation with 2 optimizations. Both optimizations increases performance by a total factor 3.

1) tabulated 2-body forces. Simulation time (in.sio2 with 10k timesteps) went from 155.8 secs to 80.51 secs. See attached .zip-file for output. 
2) building a new short range 3-body neighbor list when looping through 2-body neighborlist. Since 3-body cutoff is 2.6Å and 2-body is 10Å for SiO2, we can skip many 3-body triplets that are out of cutoff. Simulation time went from 80.51 secs to 51.71 secs.

I also added a pair_modify table yes/no [tableSize] command. USER-OMP version is also updated. 

[vashishta_benchmark.zip](https://github.com/lammps/lammps/files/421704/vashishta_benchmark.zip)
