### PR TITLE
Fix some valgrind errors

### DIFF
--- a/src/QEQ/fix_qeq_slater.cpp
+++ b/src/QEQ/fix_qeq_slater.cpp
@@ -90,14 +90,6 @@ void FixQEqSlater::init()
 
 void FixQEqSlater::extract_streitz()
 {
-  int ntypes = atom->ntypes;
-
-  memory->create(chi,ntypes+1,"qeq:chi");
-  memory->create(eta,ntypes+1,"qeq:eta");
-  memory->create(gamma,ntypes+1,"qeq:gamma");
-  memory->create(zeta,ntypes+1,"qeq:zeta");
-  memory->create(zcore,ntypes+1,"qeq:zcore");
-
   Pair *pair = force->pair_match("coul/streitz",1);
   if (pair == NULL) error->all(FLERR,"No pair coul/streitz for fix qeq/slater");
   int tmp;

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -151,6 +151,7 @@ void Velocity::init_external(const char *extgroup)
   rotation_flag = 0;
   loop_flag = ALL;
   scale_flag = 1;
+  bias_flag = 0;
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
Fixes the following errors found during Jenkins runs:
* [prd example: Conditional jump or move depends on uninitialised value(s)
](https://ci.lammps.org/job/coverage/job/mpich-cov-examples-fedora/9/valgrindResult/pid=37296,0x0/)
* [streitz.ewald example: Memory Leaks (definitely lost)](https://ci.lammps.org/job/coverage/job/mpich-cov-examples-fedora/9/valgrindResult/pid=37452,0x1/)