### PR TITLE
Transverse DPD (pair_style dpd/tstat/trans)

### DIFF
--- a/src/pair_dpd_tstat_trans.cpp
+++ b/src/pair_dpd_tstat_trans.cpp
@@ -1,0 +1,368 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "math.h"
+#include "pair_dpd_tstat_trans.h"
+#include "atom.h"
+#include "update.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "comm.h"
+#include "random_mars.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+#define EPSILON 1.0e-10
+
+/* ---------------------------------------------------------------------- */
+
+PairDPDTstatTrans::PairDPDTstatTrans(LAMMPS *lmp) : PairDPD(lmp)
+{
+  single_enable = 0;
+  writedata = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::compute(int eflag, int vflag)
+{
+  int i,j,ii,jj,inum,jnum,itype,jtype;
+  double xtmp,ytmp,ztmp,delx,dely,delz,fpair;
+  double vxtmp,vytmp,vztmp,delvx,delvy,delvz;
+  double rsq,r,rinv,dot,wd,randnum,factor_dpd;
+  int k,l;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = vflag_fdotr = 0;
+
+  // adjust sigma if target T is changing
+
+  if (t_start != t_stop) {
+    double delta = update->ntimestep - update->beginstep;
+    if (delta != 0.0) delta /= update->endstep - update->beginstep;
+    temperature = t_start + delta * (t_stop-t_start);
+    double boltz = force->boltz;
+    for (i = 1; i <= atom->ntypes; i++)
+      for (j = i; j <= atom->ntypes; j++)
+        sigma[i][j] = sigma[j][i] = sqrt(2.0*boltz*temperature*gamma[i][j]);
+        tsigma[i][j] = tsigma[j][i] = sqrt(2.0*boltz*temperature*tgamma[i][j]);
+  }
+
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  int *type = atom->type;
+  int nlocal = atom->nlocal;
+  double *special_lj = force->special_lj;
+  int newton_pair = force->newton_pair;
+  double dtinvsqrt = 1.0/sqrt(update->dt);
+
+ double P_times_dist_sqr[3][3]={{0,0,0},{0,0,0},{0,0,0}},noise_vec[3];
+ double f_D[3],f_R[3];
+ double deld[3];
+ double delvel[3];
+ double tmpx, tmpy, tmpz;
+
+  
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    vxtmp = v[i][0];
+    vytmp = v[i][1];
+    vztmp = v[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_dpd = special_lj[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+
+	  
+      if (rsq < cutsq[itype][jtype]) {
+        r = sqrt(rsq);
+  P_times_dist_sqr[0][0]=rsq;
+  P_times_dist_sqr[1][1]=rsq;
+  P_times_dist_sqr[2][2]=rsq;
+        if (r < EPSILON) continue;     // r can be 0.0 in DPD systems
+        rinv = 1.0/r;
+        delvx = vxtmp - v[j][0];
+        delvy = vytmp - v[j][1];
+        delvz = vztmp - v[j][2];
+        dot = delx*delvx + dely*delvy + delz*delvz;
+        wd = 1.0 - r/cut[itype][jtype];
+        randnum = random->gaussian();
+		
+for (k=0;k<3;k++){
+        //noise vector
+        noise_vec[k]=randnum;
+		// deldistance
+		deld[0]=delx;
+		deld[1]=dely;
+		deld[2]=delz;
+		delvel[0]=delvx;
+		delvel[1]=delvy;
+		delvel[2]=delvz;                
+		//Damping force
+        f_D[k]=0;
+        //Random force
+        f_R[k]=0;
+        // Projection Matrix0
+		for (l=0;l<3;l++){
+          P_times_dist_sqr[k][l]-=deld[k]*deld[l];
+        }
+      }
+ for (k=0;k<3;k++){
+        for (l=0;l<3;l++){
+          f_D[k]+=P_times_dist_sqr[k][l]*delvel[l];
+          f_R[k]+=P_times_dist_sqr[k][l]*noise_vec[l];
+		  f_D[k]*=-tgamma[itype][jtype]*wd*wd;
+          f_R[k]*=tsigma[itype][jtype]*wd*dtinvsqrt*rinv;
+        
+		}
+ }
+
+        tmpx=(f_D[0]+f_R[0]);
+		tmpx*=factor_dpd*rinv;
+		tmpy=(f_D[1]+f_R[1]);
+		tmpy*=factor_dpd*rinv;
+		tmpz=(f_D[2]+f_R[2]);
+		tmpz*=factor_dpd*rinv;
+        f[i][0] += tmpx;
+		f[i][1] += tmpy;
+		f[i][2] += tmpz;
+		if (newton_pair || j < nlocal) {
+		f[j][0] -= tmpx;
+		f[j][1] -= tmpy;
+		f[j][2] -= tmpz;
+		}
+    	
+        // drag force = -gamma * wd^2 * (delx dot delv) / r
+        // random force = sigma * wd * rnd * dtinvsqrt;
+
+        fpair = -gamma[itype][jtype]*wd*wd*dot*rinv;
+        fpair += sigma[itype][jtype]*wd*randnum*dtinvsqrt;
+        fpair *= factor_dpd*rinv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (newton_pair || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+fpair+=sqrt(tmpx*tmpx+tmpy*tmpy+tmpz*tmpz);
+        if (evflag) ev_tally(i,j,nlocal,newton_pair,
+                             0.0,0.0,fpair,delx,dely,delz);
+      }
+    }
+  }
+
+  if (vflag_fdotr) virial_fdotr_compute();
+}
+
+/* ----------------------------------------------------------------------
+   global settings
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::settings(int narg, char **arg)
+{
+  if (narg != 4) error->all(FLERR,"Illegal pair_style command");
+
+  t_start = force->numeric(FLERR,arg[0]);
+  t_stop = force->numeric(FLERR,arg[1]);
+  cut_global = force->numeric(FLERR,arg[2]);
+  seed = force->inumeric(FLERR,arg[3]);
+
+  temperature = t_start;
+
+  // initialize Marsaglia RNG with processor-unique seed
+
+  if (seed <= 0) error->all(FLERR,"Illegal pair_style command");
+  delete random;
+  random = new RanMars(lmp,seed + comm->me);
+
+  // reset cutoffs that have been explicitly set
+
+  if (allocated) {
+    int i,j;
+    for (i = 1; i <= atom->ntypes; i++)
+      for (j = i+1; j <= atom->ntypes; j++)
+        if (setflag[i][j]) cut[i][j] = cut_global;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   set coeffs for one or more type pairs
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::coeff(int narg, char **arg)
+{
+  if (narg < 3 || narg > 5) 
+    error->all(FLERR,"Incorrect args for pair coefficients");
+  if (!allocated) allocate();
+
+  int ilo,ihi,jlo,jhi;
+  force->bounds(arg[0],atom->ntypes,ilo,ihi);
+  force->bounds(arg[1],atom->ntypes,jlo,jhi);
+
+  double a0_one = 0.0;
+  double gamma_one = force->numeric(FLERR,arg[2]);
+  double gamma_two = force->numeric(FLERR,arg[3]);
+  double cut_one = cut_global;
+  if (narg == 5) cut_one = force->numeric(FLERR,arg[4]);
+  int count = 0;
+  for (int i = ilo; i <= ihi; i++) {
+    for (int j = MAX(jlo,i); j <= jhi; j++) {
+      a0[i][j] = a0_one;
+      gamma[i][j] = gamma_one;
+	  tgamma[i][j] = gamma_two;
+      cut[i][j] = cut_one;
+      setflag[i][j] = 1;
+      count++;
+    }
+  }
+
+  if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to restart file
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::write_restart(FILE *fp)
+{
+  write_restart_settings(fp);
+
+  int i,j;
+  for (i = 1; i <= atom->ntypes; i++)
+    for (j = i; j <= atom->ntypes; j++) {
+      fwrite(&setflag[i][j],sizeof(int),1,fp);
+      if (setflag[i][j]) {
+        fwrite(&gamma[i][j],sizeof(double),1,fp);
+		fwrite(&tgamma[i][j],sizeof(double),1,fp);
+        fwrite(&cut[i][j],sizeof(double),1,fp);
+      }
+    }
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 reads from restart file, bcasts
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::read_restart(FILE *fp)
+{
+  read_restart_settings(fp);
+
+  allocate();
+
+  int i,j;
+  int me = comm->me;
+  for (i = 1; i <= atom->ntypes; i++)
+    for (j = i; j <= atom->ntypes; j++) {
+      if (me == 0) fread(&setflag[i][j],sizeof(int),1,fp);
+      MPI_Bcast(&setflag[i][j],1,MPI_INT,0,world);
+      if (setflag[i][j]) {
+        if (me == 0) {
+          fread(&gamma[i][j],sizeof(double),1,fp);
+		  fread(&tgamma[i][j],sizeof(double),1,fp);
+          fread(&cut[i][j],sizeof(double),1,fp);
+        }
+        MPI_Bcast(&gamma[i][j],1,MPI_DOUBLE,0,world);
+		MPI_Bcast(&tgamma[i][j],1,MPI_DOUBLE,0,world);
+        MPI_Bcast(&cut[i][j],1,MPI_DOUBLE,0,world);
+      }
+    }
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to restart file
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::write_restart_settings(FILE *fp)
+{
+  fwrite(&t_start,sizeof(double),1,fp);
+  fwrite(&t_stop,sizeof(double),1,fp);
+  fwrite(&cut_global,sizeof(double),1,fp);
+  fwrite(&seed,sizeof(int),1,fp);
+  fwrite(&mix_flag,sizeof(int),1,fp);
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 reads from restart file, bcasts
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::read_restart_settings(FILE *fp)
+{
+  if (comm->me == 0) {
+    fread(&t_start,sizeof(double),1,fp);
+    fread(&t_stop,sizeof(double),1,fp);
+    fread(&cut_global,sizeof(double),1,fp);
+    fread(&seed,sizeof(int),1,fp);
+    fread(&mix_flag,sizeof(int),1,fp);
+  }
+  MPI_Bcast(&t_start,1,MPI_DOUBLE,0,world);
+  MPI_Bcast(&t_stop,1,MPI_DOUBLE,0,world);
+  MPI_Bcast(&cut_global,1,MPI_DOUBLE,0,world);
+  MPI_Bcast(&seed,1,MPI_INT,0,world);
+  MPI_Bcast(&mix_flag,1,MPI_INT,0,world);
+
+  temperature = t_start;
+
+  // initialize Marsaglia RNG with processor-unique seed
+  // same seed that pair_style command initially specified
+
+  if (random) delete random;
+  random = new RanMars(lmp,seed + comm->me);
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->ntypes; i++)
+    fprintf(fp,"%d %g %g\n",i,gamma[i][i],tgamma[i][i]);
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes all pairs to data file
+------------------------------------------------------------------------- */
+
+void PairDPDTstatTrans::write_data_all(FILE *fp)
+{
+  for (int i = 1; i <= atom->ntypes; i++)
+    for (int j = i; j <= atom->ntypes; j++)
+      fprintf(fp,"%d %d %g %g %g\n",i,j,gamma[i][j],tgamma[i][i],cut[i][j]);
+}

--- a/src/pair_dpd_tstat_trans.h
+++ b/src/pair_dpd_tstat_trans.h
@@ -1,0 +1,59 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(dpd/tstat/trans,PairDPDTstatTrans)
+
+#else
+
+#ifndef LMP_PAIR_DPD_TSTAT_TRANS_H
+#define LMP_PAIR_DPD_TSTAT_TRANS_H
+
+#include "pair_dpd.h"
+
+namespace LAMMPS_NS {
+
+class PairDPDTstatTrans : public PairDPD {
+ public:
+  PairDPDTstatTrans(class LAMMPS *);
+  ~PairDPDTstatTrans() {}
+  void compute(int, int);
+  void settings(int, char **);
+  void coeff(int, char **);
+  void write_restart(FILE *);
+  void read_restart(FILE *);
+  void write_restart_settings(FILE *);
+  void read_restart_settings(FILE *);
+  void write_data(FILE *);
+  void write_data_all(FILE *);
+
+ protected:
+  double t_start,t_stop;
+  double **tgamma;
+  double **tsigma;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+E: Illegal ... command
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+E: Incorrect args for pair coefficients
+Self-explanatory.  Check the input script or data file.
+*/


### PR DESCRIPTION
Here's my attempt to implement the transverse DPD method (Junghans et al. Soft matter, 4, 156-161, 2008) to the DPD thermostat in LAMMPS (in similar form to pair_style dpd/tstat, found here). The original publication implemented this approach in ESPResSo (found here, labelled under TRANS_DPD). I am a complete beginner in C++ so I tried my best to implement what I saw in the ESPResSo source code into the pair_dpd_tstat.cpp file.

I tried to compile LAMMPS with these files and it compiled OK. Simulations involving coarse-grained polymers ran OK with transverse DPD thermostat as a standalone pair_style, but as soon as I try to use pair_hybrid (mainly to add conservative forces), I get segmentation faults.

I suspect something unphysical is happening. One thing I didn't understand is the scaling of the drag force in dpd/tstat by 1/r (line 172 and 174), which wasn't in the LAMMPS manual. I just implemented the same 1/r approach to the ESPResSo code - perhaps that could be a factor. Also if I understand it correctly, the transverse DPD method uses a vector for the fpair (f_D and f_R in the code), so to add that back to the ev_tally fpair I just got the magnitude of the fpair vector from the transverse DPD and added it to the scalar fpair in dpd/tstat - could be another thing I am not doing correctly.

In any case, I think this is a very important feature that will help reproduce dynamics more accurately than the standard DPD, as also noted by Groot et al. in Phys. Rev. E 78, 051403, 2008 and Brennan et al. in J. Phys. Chem. Lett., 5 (12), 2144–2149, 2014. I'd appreciate feedback on the source code & and will write up a proper documentation once I get it working.

Jake