### PR TITLE
Info command extensions

### DIFF
--- a/src/atom.h
+++ b/src/atom.h
@@ -15,6 +15,8 @@
 #define LMP_ATOM_H
 
 #include "pointers.h"
+#include <map>
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -209,6 +211,12 @@ class Atom : protected Pointers {
 
   int *sametag;      // sametag[I] = next atom with same ID, -1 if no more
 
+  // AtomVec factory types and map
+
+  typedef AtomVec *(*AtomVecCreator)(LAMMPS *);
+  typedef std::map<std::string,AtomVecCreator> AtomVecCreatorMap;
+  AtomVecCreatorMap *avec_map;
+
   // functions
 
   Atom(class LAMMPS *);
@@ -334,6 +342,9 @@ class Atom : protected Pointers {
 
   void setup_sort_bins();
   int next_prime(int);
+
+ private:
+  template <typename T> static AtomVec *avec_creator(LAMMPS *);
 };
 
 }

--- a/src/domain.h
+++ b/src/domain.h
@@ -16,6 +16,8 @@
 
 #include <math.h>
 #include "pointers.h"
+#include <map>
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -92,6 +94,10 @@ class Domain : protected Pointers {
 
   int copymode;
 
+  typedef Region *(*RegionCreator)(LAMMPS *,int,char**);
+  typedef std::map<std::string,RegionCreator> RegionCreatorMap;
+  RegionCreatorMap *region_map;
+
   Domain(class LAMMPS *);
   virtual ~Domain();
   virtual void init();
@@ -151,6 +157,9 @@ class Domain : protected Pointers {
 
  protected:
   double small[3];                  // fractions of box lengths
+
+ private:
+  template <typename T> static Region *region_creator(LAMMPS *,int,char**);
 };
 
 }

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -78,7 +78,7 @@ Force::Force(LAMMPS *lmp) : Pointers(lmp)
 
   // fill pair map with pair styles listed in style_pair.h
 
-  pair_map = new std::map<std::string,PairCreator>();
+  pair_map = new PairCreatorMap();
 
 #define PAIR_CLASS
 #define PairStyle(key,Class) \

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -163,6 +163,7 @@ Force::~Force()
   delete angle_map;
   delete dihedral_map;
   delete improper_map;
+  delete kspace_map;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/force.h
+++ b/src/force.h
@@ -82,6 +82,11 @@ class Force : protected Pointers {
 
   class KSpace *kspace;
   char *kspace_style;
+
+  typedef KSpace *(*KSpaceCreator)(LAMMPS *,int,char**);
+  typedef std::map<std::string,KSpaceCreator> KSpaceCreatorMap;
+  KSpaceCreatorMap *kspace_map;
+
                              // index [0] is not used in these arrays
   double special_lj[4];      // 1-2, 1-3, 1-4 prefactors for LJ
   double special_coul[4];    // 1-2, 1-3, 1-4 prefactors for Coulombics
@@ -142,6 +147,7 @@ class Force : protected Pointers {
   template <typename T> static Angle *angle_creator(LAMMPS *);
   template <typename T> static Dihedral *dihedral_creator(LAMMPS *);
   template <typename T> static Improper *improper_creator(LAMMPS *);
+  template <typename T> static KSpace *kspace_creator(LAMMPS *, int, char **);
 };
 
 }

--- a/src/force.h
+++ b/src/force.h
@@ -49,7 +49,8 @@ class Force : protected Pointers {
   char *pair_style;
 
   typedef Pair *(*PairCreator)(LAMMPS *);
-  std::map<std::string,PairCreator> *pair_map;
+  typedef std::map<std::string,PairCreator> PairCreatorMap;
+  PairCreatorMap *pair_map;
 
   class Bond *bond;
   char *bond_style;

--- a/src/force.h
+++ b/src/force.h
@@ -62,6 +62,10 @@ class Force : protected Pointers {
   class Angle *angle;
   char *angle_style;
 
+  typedef Angle *(*AngleCreator)(LAMMPS *);
+  typedef std::map<std::string,AngleCreator> AngleCreatorMap;
+  AngleCreatorMap *angle_map;
+
   class Dihedral *dihedral;
   char *dihedral_style;
 
@@ -127,6 +131,7 @@ class Force : protected Pointers {
  private:
   template <typename T> static Pair *pair_creator(LAMMPS *);
   template <typename T> static Bond *bond_creator(LAMMPS *);
+  template <typename T> static Angle *angle_creator(LAMMPS *);
 };
 
 }

--- a/src/force.h
+++ b/src/force.h
@@ -69,6 +69,10 @@ class Force : protected Pointers {
   class Dihedral *dihedral;
   char *dihedral_style;
 
+  typedef Dihedral *(*DihedralCreator)(LAMMPS *);
+  typedef std::map<std::string,DihedralCreator> DihedralCreatorMap;
+  DihedralCreatorMap *dihedral_map;
+
   class Improper *improper;
   char *improper_style;
 
@@ -132,6 +136,7 @@ class Force : protected Pointers {
   template <typename T> static Pair *pair_creator(LAMMPS *);
   template <typename T> static Bond *bond_creator(LAMMPS *);
   template <typename T> static Angle *angle_creator(LAMMPS *);
+  template <typename T> static Dihedral *dihedral_creator(LAMMPS *);
 };
 
 }

--- a/src/force.h
+++ b/src/force.h
@@ -48,43 +48,40 @@ class Force : protected Pointers {
   class Pair *pair;
   char *pair_style;
 
-  typedef Pair *(*PairCreator)(LAMMPS *);
-  typedef std::map<std::string,PairCreator> PairCreatorMap;
-  PairCreatorMap *pair_map;
-
   class Bond *bond;
   char *bond_style;
-
-  typedef Bond *(*BondCreator)(LAMMPS *);
-  typedef std::map<std::string,BondCreator> BondCreatorMap;
-  BondCreatorMap *bond_map;
 
   class Angle *angle;
   char *angle_style;
 
-  typedef Angle *(*AngleCreator)(LAMMPS *);
-  typedef std::map<std::string,AngleCreator> AngleCreatorMap;
-  AngleCreatorMap *angle_map;
-
   class Dihedral *dihedral;
   char *dihedral_style;
-
-  typedef Dihedral *(*DihedralCreator)(LAMMPS *);
-  typedef std::map<std::string,DihedralCreator> DihedralCreatorMap;
-  DihedralCreatorMap *dihedral_map;
 
   class Improper *improper;
   char *improper_style;
 
-  typedef Improper *(*ImproperCreator)(LAMMPS *);
-  typedef std::map<std::string,ImproperCreator> ImproperCreatorMap;
-  ImproperCreatorMap *improper_map;
-
   class KSpace *kspace;
   char *kspace_style;
 
+  typedef Pair *(*PairCreator)(LAMMPS *);
+  typedef Bond *(*BondCreator)(LAMMPS *);
+  typedef Angle *(*AngleCreator)(LAMMPS *);
+  typedef Dihedral *(*DihedralCreator)(LAMMPS *);
+  typedef Improper *(*ImproperCreator)(LAMMPS *);
   typedef KSpace *(*KSpaceCreator)(LAMMPS *,int,char**);
+
+  typedef std::map<std::string,PairCreator> PairCreatorMap;
+  typedef std::map<std::string,BondCreator> BondCreatorMap;
+  typedef std::map<std::string,AngleCreator> AngleCreatorMap;
+  typedef std::map<std::string,DihedralCreator> DihedralCreatorMap;
+  typedef std::map<std::string,ImproperCreator> ImproperCreatorMap;
   typedef std::map<std::string,KSpaceCreator> KSpaceCreatorMap;
+
+  PairCreatorMap *pair_map;
+  BondCreatorMap *bond_map;
+  AngleCreatorMap *angle_map;
+  DihedralCreatorMap *dihedral_map;
+  ImproperCreatorMap *improper_map;
   KSpaceCreatorMap *kspace_map;
 
                              // index [0] is not used in these arrays

--- a/src/force.h
+++ b/src/force.h
@@ -76,6 +76,10 @@ class Force : protected Pointers {
   class Improper *improper;
   char *improper_style;
 
+  typedef Improper *(*ImproperCreator)(LAMMPS *);
+  typedef std::map<std::string,ImproperCreator> ImproperCreatorMap;
+  ImproperCreatorMap *improper_map;
+
   class KSpace *kspace;
   char *kspace_style;
                              // index [0] is not used in these arrays
@@ -137,6 +141,7 @@ class Force : protected Pointers {
   template <typename T> static Bond *bond_creator(LAMMPS *);
   template <typename T> static Angle *angle_creator(LAMMPS *);
   template <typename T> static Dihedral *dihedral_creator(LAMMPS *);
+  template <typename T> static Improper *improper_creator(LAMMPS *);
 };
 
 }

--- a/src/force.h
+++ b/src/force.h
@@ -55,6 +55,10 @@ class Force : protected Pointers {
   class Bond *bond;
   char *bond_style;
 
+  typedef Bond *(*BondCreator)(LAMMPS *);
+  typedef std::map<std::string,BondCreator> BondCreatorMap;
+  BondCreatorMap *bond_map;
+
   class Angle *angle;
   char *angle_style;
 
@@ -122,6 +126,7 @@ class Force : protected Pointers {
 
  private:
   template <typename T> static Pair *pair_creator(LAMMPS *);
+  template <typename T> static Bond *bond_creator(LAMMPS *);
 };
 
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -737,10 +737,9 @@ void Info::command_styles(FILE * out)
   fprintf(out, "\nCommand styles (add-on input script commands):\n");
 
   vector<string> styles;
-#define COMMAND_CLASS
-#define CommandStyle(key,Class) styles.push_back(#key);
-#include "style_command.h"
-#undef COMMAND_CLASS
+  for(Input::CommandCreatorMap::iterator it = input->command_map->begin(); it != input->command_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -663,10 +663,11 @@ void Info::improper_styles(FILE * out)
   fprintf(out, "\nImproper styles:\n");
 
   vector<string> styles;
-#define IMPROPER_CLASS
-#define ImproperStyle(key,Class) styles.push_back(#key);
-#include "style_improper.h"
-#undef IMPROPER_CLASS
+
+  for(Force::ImproperCreatorMap::iterator it = force->improper_map->begin(); it != force->improper_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -635,10 +635,11 @@ void Info::angle_styles(FILE * out)
   fprintf(out, "\nAngle styles:\n");
 
   vector<string> styles;
-#define ANGLE_CLASS
-#define AngleStyle(key,Class) styles.push_back(#key);
-#include "style_angle.h"
-#undef ANGLE_CLASS
+
+  for(Force::AngleCreatorMap::iterator it = force->angle_map->begin(); it != force->angle_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -568,10 +568,11 @@ void Info::atom_styles(FILE * out)
   fprintf(out, "\nAtom styles:\n");
 
   vector<string> styles;
-#define ATOM_CLASS
-#define AtomStyle(key,Class) styles.push_back(#key);
-#include "style_atom.h"
-#undef ATOM_CLASS
+
+  for(Atom::AtomVecCreatorMap::iterator it = atom->avec_map->begin(); it != atom->avec_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -621,10 +621,11 @@ void Info::bond_styles(FILE * out)
   fprintf(out, "\nBond styles:\n");
 
   vector<string> styles;
-#define BOND_CLASS
-#define BondStyle(key,Class) styles.push_back(#key);
-#include "style_bond.h"
-#undef BOND_CLASS
+
+  for(Force::BondCreatorMap::iterator it = force->bond_map->begin(); it != force->bond_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -582,10 +582,11 @@ void Info::integrate_styles(FILE * out)
   fprintf(out, "\nIntegrate styles:\n");
 
   vector<string> styles;
-#define INTEGRATE_CLASS
-#define IntegrateStyle(key,Class) styles.push_back(#key);
-#include "style_integrate.h"
-#undef INTEGRATE_CLASS
+
+  for(Update::IntegrateCreatorMap::iterator it = update->integrate_map->begin(); it != update->integrate_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -649,10 +649,11 @@ void Info::dihedral_styles(FILE * out)
   fprintf(out, "\nDihedral styles:\n");
 
   vector<string> styles;
-#define DIHEDRAL_CLASS
-#define DihedralStyle(key,Class) styles.push_back(#key);
-#include "style_dihedral.h"
-#undef DIHEDRAL_CLASS
+
+  for(Force::DihedralCreatorMap::iterator it = force->dihedral_map->begin(); it != force->dihedral_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -677,10 +677,11 @@ void Info::kspace_styles(FILE * out)
   fprintf(out, "\nKSpace styles:\n");
 
   vector<string> styles;
-#define KSPACE_CLASS
-#define KSpaceStyle(key,Class) styles.push_back(#key);
-#include "style_kspace.h"
-#undef KSPACE_CLASS
+
+  for(Force::KSpaceCreatorMap::iterator it = force->kspace_map->begin(); it != force->kspace_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -596,10 +596,11 @@ void Info::minimize_styles(FILE * out)
   fprintf(out, "\nMinimize styles:\n");
 
   vector<string> styles;
-#define MINIMIZE_CLASS
-#define MinimizeStyle(key,Class) styles.push_back(#key);
-#include "style_minimize.h"
-#undef MINIMIZE_CLASS
+
+  for(Update::MinimizeCreatorMap::iterator it = update->minimize_map->begin(); it != update->minimize_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -150,48 +150,6 @@ void Info::command(int narg, char **arg)
       if ((out != screen) && (out != logfile)) fclose(out);
       out = fopen(arg[idx+2],"w");
       idx += 3;
-    } else if (strncmp(arg[idx],"atom_styles",3) == 0) {
-      flags |= ATOM_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"integrate_styles",3) == 0) {
-      flags |= INTEGRATE_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"minimize_styles",3) == 0) {
-      flags |= MINIMIZE_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"pair_styles",3) == 0) {
-      flags |= PAIR_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"bond_styles",3) == 0) {
-      flags |= BOND_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"angle_styles",3) == 0) {
-      flags |= ANGLE_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"dihedral_styles",3) == 0) {
-      flags |= DIHEDRAL_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"improper_styles",3) == 0) {
-      flags |= IMPROPER_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"kspace_styles",3) == 0) {
-      flags |= KSPACE_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"fix_styles",3) == 0) {
-      flags |= FIX_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"compute_styles",5) == 0) {
-      flags |= COMPUTE_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"region_styles",3) == 0) {
-      flags |= REGION_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"dump_styles",3) == 0) {
-      flags |= DUMP_STYLES;
-      ++idx;
-    } else if (strncmp(arg[idx],"command_styles",5) == 0) {
-      flags |= COMMAND_STYLES;
-      ++idx;
     } else if (strncmp(arg[idx],"communication",5) == 0) {
       flags |= COMM;
       ++idx;
@@ -223,8 +181,60 @@ void Info::command(int narg, char **arg)
       flags |= SYSTEM;
       ++idx;
     } else if (strncmp(arg[idx],"styles",3) == 0) {
-      flags |= STYLES;
-      ++idx;
+      if (idx+1 < narg) {
+        ++idx;
+        if (strncmp(arg[idx],"all",3) == 0) {
+          flags |= STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"atom",3) == 0) {
+          flags |= ATOM_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"integrate",3) == 0) {
+          flags |= INTEGRATE_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"minimize",3) == 0) {
+          flags |= MINIMIZE_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"pair",3) == 0) {
+          flags |= PAIR_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"bond",3) == 0) {
+          flags |= BOND_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"angle",3) == 0) {
+          flags |= ANGLE_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"dihedral",3) == 0) {
+          flags |= DIHEDRAL_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"improper",3) == 0) {
+          flags |= IMPROPER_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"kspace",3) == 0) {
+          flags |= KSPACE_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"fix",3) == 0) {
+          flags |= FIX_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"compute",4) == 0) {
+          flags |= COMPUTE_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"region",3) == 0) {
+          flags |= REGION_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"dump",3) == 0) {
+          flags |= DUMP_STYLES;
+          ++idx;
+        } else if (strncmp(arg[idx],"command",4) == 0) {
+          flags |= COMMAND_STYLES;
+          ++idx;
+        } else {
+          flags |= STYLES;
+        }
+      } else {
+        flags |= STYLES;
+        ++idx;
+      }
     } else {
       error->warning(FLERR,"Ignoring unknown or incorrect info command flag");
       ++idx;

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -685,10 +685,11 @@ void Info::fix_styles(FILE * out)
   fprintf(out, "\nFix styles:\n");
 
   vector<string> styles;
-#define FIX_CLASS
-#define FixStyle(key,Class) styles.push_back(#key);
-#include "style_fix.h"
-#undef FIX_CLASS
+
+  for(Modify::FixCreatorMap::iterator it = modify->fix_map->begin(); it != modify->fix_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }
@@ -698,10 +699,11 @@ void Info::compute_styles(FILE * out)
   fprintf(out, "\nCompute styles:\n");
 
   vector<string> styles;
-#define COMPUTE_CLASS
-#define ComputeStyle(key,Class) styles.push_back(#key);
-#include "style_compute.h"
-#undef COMPUTE_CLASS
+
+  for(Modify::ComputeCreatorMap::iterator it = modify->compute_map->begin(); it != modify->compute_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }
@@ -737,9 +739,11 @@ void Info::command_styles(FILE * out)
   fprintf(out, "\nCommand styles (add-on input script commands):\n");
 
   vector<string> styles;
+
   for(Input::CommandCreatorMap::iterator it = input->command_map->begin(); it != input->command_map->end(); ++it) {
     styles.push_back(it->first);
   }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -735,10 +735,11 @@ void Info::dump_styles(FILE * out)
   fprintf(out, "\nDump styles:\n");
 
   vector<string> styles;
-#define DUMP_CLASS
-#define DumpStyle(key,Class) styles.push_back(#key);
-#include "style_dump.h"
-#undef DUMP_CLASS
+
+  for(Output::DumpCreatorMap::iterator it = output->dump_map->begin(); it != output->dump_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -722,10 +722,11 @@ void Info::region_styles(FILE * out)
   fprintf(out, "\nRegion styles:\n");
 
   vector<string> styles;
-#define REGION_CLASS
-#define RegionStyle(key,Class) styles.push_back(#key);
-#include "style_region.h"
-#undef REGION_CLASS
+
+  for(Domain::RegionCreatorMap::iterator it = domain->region_map->begin(); it != domain->region_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1,4 +1,5 @@
 /* ----------------------------------------------------------------------
+  fputs
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    http://lammps.sandia.gov, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
@@ -12,7 +13,8 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Contributing author:  Axel Kohlmeyer (Temple U)
+   Contributing authors:  Axel Kohlmeyer (Temple U),
+                          Richard Berger (Temple U)
 ------------------------------------------------------------------------- */
 
 #include <string.h>
@@ -39,6 +41,9 @@
 #include "error.h"
 
 #include <time.h>
+#include <vector>
+#include <string>
+#include <algorithm>
 
 #ifdef _WIN32
 #define PSAPI_VERSION=1
@@ -70,8 +75,28 @@ enum {COMPUTES=1<<0,
       VARIABLES=1<<7,
       SYSTEM=1<<8,
       COMM=1<<9,
+      ATOM_STYLES=1<<10,
+      INTEGRATE_STYLES=1<<11,
+      MINIMIZE_STYLES=1<<12,
+      PAIR_STYLES=1<<13,
+      BOND_STYLES=1<<14,
+      ANGLE_STYLES=1<<15,
+      DIHEDRAL_STYLES=1<<16,
+      IMPROPER_STYLES=1<<17,
+      KSPACE_STYLES=1<<18,
+      FIX_STYLES=1<<19,
+      COMPUTE_STYLES=1<<20,
+      REGION_STYLES=1<<21,
+      DUMP_STYLES=1<<22,
+      COMMAND_STYLES=1<<23,
       ALL=~0};
+
+static const int STYLES = ATOM_STYLES | INTEGRATE_STYLES | MINIMIZE_STYLES | PAIR_STYLES | BOND_STYLES | \
+                         ANGLE_STYLES | DIHEDRAL_STYLES | IMPROPER_STYLES | KSPACE_STYLES | FIX_STYLES | \
+                         COMPUTE_STYLES | REGION_STYLES | DUMP_STYLES | COMMAND_STYLES;
+
 }
+
 
 static const char *varstyles[] = {
   "index", "loop", "world", "universe", "uloop", "string", "getenv",
@@ -85,6 +110,9 @@ static const char *commlayout[] = { "uniform", "nonuniform", "irregular" };
 static const char bstyles[] = "pfsm";
 
 using namespace LAMMPS_NS;
+using namespace std;
+
+static void print_columns(FILE* fp, vector<string> & styles);
 
 /* ---------------------------------------------------------------------- */
 
@@ -122,16 +150,58 @@ void Info::command(int narg, char **arg)
       if ((out != screen) && (out != logfile)) fclose(out);
       out = fopen(arg[idx+2],"w");
       idx += 3;
-    } else if (strncmp(arg[idx],"communication",4) == 0) {
+    } else if (strncmp(arg[idx],"atom_styles",3) == 0) {
+      flags |= ATOM_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"integrate_styles",3) == 0) {
+      flags |= INTEGRATE_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"minimize_styles",3) == 0) {
+      flags |= MINIMIZE_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"pair_styles",3) == 0) {
+      flags |= PAIR_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"bond_styles",3) == 0) {
+      flags |= BOND_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"angle_styles",3) == 0) {
+      flags |= ANGLE_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"dihedral_styles",3) == 0) {
+      flags |= DIHEDRAL_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"improper_styles",3) == 0) {
+      flags |= IMPROPER_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"kspace_styles",3) == 0) {
+      flags |= KSPACE_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"fix_styles",3) == 0) {
+      flags |= FIX_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"compute_styles",5) == 0) {
+      flags |= COMPUTE_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"region_styles",3) == 0) {
+      flags |= REGION_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"dump_styles",3) == 0) {
+      flags |= DUMP_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"command_styles",5) == 0) {
+      flags |= COMMAND_STYLES;
+      ++idx;
+    } else if (strncmp(arg[idx],"communication",5) == 0) {
       flags |= COMM;
       ++idx;
-    } else if (strncmp(arg[idx],"computes",4) == 0) {
+    } else if (strncmp(arg[idx],"computes",5) == 0) {
       flags |= COMPUTES;
       ++idx;
-    } else if (strncmp(arg[idx],"dumps",3) == 0) {
+    } else if (strncmp(arg[idx],"dumps",5) == 0) {
       flags |= DUMPS;
       ++idx;
-    } else if (strncmp(arg[idx],"fixes",3) == 0) {
+    } else if (strncmp(arg[idx],"fixes",5) == 0) {
       flags |= FIXES;
       ++idx;
     } else if (strncmp(arg[idx],"groups",3) == 0) {
@@ -151,6 +221,9 @@ void Info::command(int narg, char **arg)
       ++idx;
     } else if (strncmp(arg[idx],"system",3) == 0) {
       flags |= SYSTEM;
+      ++idx;
+    } else if (strncmp(arg[idx],"styles",3) == 0) {
+      flags |= STYLES;
       ++idx;
     } else {
       error->warning(FLERR,"Ignoring unknown or incorrect info command flag");
@@ -457,12 +530,221 @@ void Info::command(int narg, char **arg)
             cpuh,cpum,cpus,wallh,wallm,walls);
   }
 
+  if (flags & STYLES) {
+    available_styles(out, flags);
+  }
+
   fputs("\nInfo-Info-Info-Info-Info-Info-Info-Info-Info-Info-Info\n\n",out);
 
   // close output file pointer if opened locally thus forcing a hard sync.
   if ((out != screen) && (out != logfile))
     fclose(out);
 }
+
+
+void Info::available_styles(FILE * out, int flags)
+{
+
+  fprintf(out,"\nStyles information:\n");
+
+  if(flags & ATOM_STYLES)      atom_styles(out);
+  if(flags & INTEGRATE_STYLES) integrate_styles(out);
+  if(flags & MINIMIZE_STYLES)  minimize_styles(out);
+  if(flags & PAIR_STYLES)      pair_styles(out);
+  if(flags & BOND_STYLES)      bond_styles(out);
+  if(flags & ANGLE_STYLES)     angle_styles(out);
+  if(flags & DIHEDRAL_STYLES)  dihedral_styles(out);
+  if(flags & IMPROPER_STYLES)  improper_styles(out);
+  if(flags & KSPACE_STYLES)    kspace_styles(out);
+  if(flags & FIX_STYLES)       fix_styles(out);
+  if(flags & COMPUTE_STYLES)   compute_styles(out);
+  if(flags & REGION_STYLES)    region_styles(out);
+  if(flags & DUMP_STYLES)      dump_styles(out);
+  if(flags & COMMAND_STYLES)   command_styles(out);
+}
+
+void Info::atom_styles(FILE * out)
+{
+  fprintf(out, "\nAtom styles:\n");
+
+  vector<string> styles;
+#define ATOM_CLASS
+#define AtomStyle(key,Class) styles.push_back(#key);
+#include "style_atom.h"
+#undef ATOM_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::integrate_styles(FILE * out)
+{
+  fprintf(out, "\nIntegrate styles:\n");
+
+  vector<string> styles;
+#define INTEGRATE_CLASS
+#define IntegrateStyle(key,Class) styles.push_back(#key);
+#include "style_integrate.h"
+#undef INTEGRATE_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::minimize_styles(FILE * out)
+{
+  fprintf(out, "\nMinimize styles:\n");
+
+  vector<string> styles;
+#define MINIMIZE_CLASS
+#define MinimizeStyle(key,Class) styles.push_back(#key);
+#include "style_minimize.h"
+#undef MINIMIZE_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::pair_styles(FILE * out)
+{
+  fprintf(out, "\nPair styles:\n");
+
+  vector<string> styles;
+#define PAIR_CLASS
+#define PairStyle(key,Class) styles.push_back(#key);
+#include "style_pair.h"
+#undef PAIR_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::bond_styles(FILE * out)
+{
+  fprintf(out, "\nBond styles:\n");
+
+  vector<string> styles;
+#define BOND_CLASS
+#define BondStyle(key,Class) styles.push_back(#key);
+#include "style_bond.h"
+#undef BOND_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::angle_styles(FILE * out)
+{
+  fprintf(out, "\nAngle styles:\n");
+
+  vector<string> styles;
+#define ANGLE_CLASS
+#define AngleStyle(key,Class) styles.push_back(#key);
+#include "style_angle.h"
+#undef ANGLE_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::dihedral_styles(FILE * out)
+{
+  fprintf(out, "\nDihedral styles:\n");
+
+  vector<string> styles;
+#define DIHEDRAL_CLASS
+#define DihedralStyle(key,Class) styles.push_back(#key);
+#include "style_dihedral.h"
+#undef DIHEDRAL_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::improper_styles(FILE * out)
+{
+  fprintf(out, "\nImproper styles:\n");
+
+  vector<string> styles;
+#define IMPROPER_CLASS
+#define ImproperStyle(key,Class) styles.push_back(#key);
+#include "style_improper.h"
+#undef IMPROPER_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::kspace_styles(FILE * out)
+{
+  fprintf(out, "\nKSpace styles:\n");
+
+  vector<string> styles;
+#define KSPACE_CLASS
+#define KSpaceStyle(key,Class) styles.push_back(#key);
+#include "style_kspace.h"
+#undef KSPACE_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::fix_styles(FILE * out)
+{
+  fprintf(out, "\nFix styles:\n");
+
+  vector<string> styles;
+#define FIX_CLASS
+#define FixStyle(key,Class) styles.push_back(#key);
+#include "style_fix.h"
+#undef FIX_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::compute_styles(FILE * out)
+{
+  fprintf(out, "\nCompute styles:\n");
+
+  vector<string> styles;
+#define COMPUTE_CLASS
+#define ComputeStyle(key,Class) styles.push_back(#key);
+#include "style_compute.h"
+#undef COMPUTE_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::region_styles(FILE * out)
+{
+  fprintf(out, "\nRegion styles:\n");
+
+  vector<string> styles;
+#define REGION_CLASS
+#define RegionStyle(key,Class) styles.push_back(#key);
+#include "style_region.h"
+#undef REGION_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::dump_styles(FILE * out)
+{
+  fprintf(out, "\nDump styles:\n");
+
+  vector<string> styles;
+#define DUMP_CLASS
+#define DumpStyle(key,Class) styles.push_back(#key);
+#include "style_dump.h"
+#undef DUMP_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
+void Info::command_styles(FILE * out)
+{
+  fprintf(out, "\nCommand styles (add-on input script commands):\n");
+
+  vector<string> styles;
+#define COMMAND_CLASS
+#define CommandStyle(key,Class) styles.push_back(#key);
+#include "style_command.h"
+#undef COMMAND_CLASS
+  print_columns(out, styles);
+  fprintf(out, "\n\n\n");
+}
+
 
 /* ---------------------------------------------------------------------- */
 
@@ -680,4 +962,44 @@ bool Info::is_defined(const char *category, const char *name)
   } else error->all(FLERR,"Unknown category for info is_defined()");
 
   return false;
+}
+
+static void print_columns(FILE* fp, vector<string> & styles)
+{
+  if (styles.size() == 0) {
+    fprintf(fp, "\nNone");
+    return;
+  }
+
+  std::sort(styles.begin(), styles.end());
+
+  int pos = 80;
+  for (int i = 0; i < styles.size(); ++i) {
+
+    // skip "secret" styles
+    if (isupper(styles[i][0])) continue;
+
+    int len = styles[i].length();
+    if (pos + len > 80) {
+      fprintf(fp,"\n");
+      pos = 0;
+    }
+
+    if (len < 16) {
+      fprintf(fp,"%-16s",styles[i].c_str());
+      pos += 16;
+    } else if (len < 32) {
+      fprintf(fp,"%-32s",styles[i].c_str());
+      pos += 32;
+    } else if (len < 48) {
+      fprintf(fp,"%-48s",styles[i].c_str());
+      pos += 48;
+    } else if (len < 64) {
+      fprintf(fp,"%-64s",styles[i].c_str());
+      pos += 64;
+    } else {
+      fprintf(fp,"%-80s",styles[i].c_str());
+      pos += 80;
+    }
+  }
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -607,10 +607,11 @@ void Info::pair_styles(FILE * out)
   fprintf(out, "\nPair styles:\n");
 
   vector<string> styles;
-#define PAIR_CLASS
-#define PairStyle(key,Class) styles.push_back(#key);
-#include "style_pair.h"
-#undef PAIR_CLASS
+
+  for(Force::PairCreatorMap::iterator it = force->pair_map->begin(); it != force->pair_map->end(); ++it) {
+    styles.push_back(it->first);
+  }
+
   print_columns(out, styles);
   fprintf(out, "\n\n\n");
 }

--- a/src/info.h
+++ b/src/info.h
@@ -32,6 +32,24 @@ class Info : protected Pointers {
   bool is_active(const char *, const char *);
   bool is_defined(const char *, const char *);
   bool is_available(const char *, const char *);
+
+private:
+  void available_styles(FILE * out, int flags);
+
+  void atom_styles(FILE * out);
+  void integrate_styles(FILE * out);
+  void minimize_styles(FILE * out);
+  void pair_styles(FILE * out);
+  void bond_styles(FILE * out);
+  void angle_styles(FILE * out);
+  void dihedral_styles(FILE * out);
+  void improper_styles(FILE * out);
+  void kspace_styles(FILE * out);
+  void fix_styles(FILE * out);
+  void compute_styles(FILE * out);
+  void region_styles(FILE * out);
+  void dump_styles(FILE * out);
+  void command_styles(FILE * out);
 };
 
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -93,7 +93,7 @@ Input::Input(LAMMPS *lmp, int argc, char **argv) : Pointers(lmp)
 
   // fill map with commands listed in style_command.h
 
-  command_map = new std::map<std::string,CommandCreator>();
+  command_map = new CommandCreatorMap();
 
 #define COMMAND_CLASS
 #define CommandStyle(key,Class) \

--- a/src/input.h
+++ b/src/input.h
@@ -53,10 +53,12 @@ class Input : protected Pointers {
 
   FILE **infiles;              // list of open input files
 
- protected:
+ public:
   typedef void (*CommandCreator)(LAMMPS *, int, char **);
-  std::map<std::string,CommandCreator> *command_map;
+  typedef std::map<std::string,CommandCreator> CommandCreatorMap;
+  CommandCreatorMap *command_map;
 
+ protected:
   template <typename T> static void command_creator(LAMMPS *, int, char **);
 
  private:

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -28,8 +28,6 @@
 #include "memory.h"
 #include "error.h"
 
-#include <map>
-
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
@@ -80,7 +78,7 @@ Modify::Modify(LAMMPS *lmp) : Pointers(lmp)
 
   // fill map with fixes listed in style_fix.h
 
-  fix_map = new std::map<std::string,FixCreator>();
+  fix_map = new FixCreatorMap();
 
 #define FIX_CLASS
 #define FixStyle(key,Class) \
@@ -91,7 +89,7 @@ Modify::Modify(LAMMPS *lmp) : Pointers(lmp)
 
   // fill map with computes listed in style_compute.h
 
-  compute_map = new std::map<std::string,ComputeCreator>();
+  compute_map = new ComputeCreatorMap();
 
 #define COMPUTE_CLASS
 #define ComputeStyle(key,Class) \

--- a/src/modify.h
+++ b/src/modify.h
@@ -149,13 +149,16 @@ class Modify : protected Pointers {
   void list_init_dofflag(int &, int *&);
   void list_init_compute();
 
- protected:
+ public:
   typedef Compute *(*ComputeCreator)(LAMMPS *, int, char **);
-  std::map<std::string,ComputeCreator> *compute_map;
+  typedef std::map<std::string,ComputeCreator> ComputeCreatorMap;
+  ComputeCreatorMap *compute_map;
 
   typedef Fix *(*FixCreator)(LAMMPS *, int, char **);
-  std::map<std::string,FixCreator> *fix_map;
+  typedef std::map<std::string,FixCreator> FixCreatorMap;
+  FixCreatorMap *fix_map;
 
+ protected:
   template <typename T> static Compute *compute_creator(LAMMPS *, int, char **);
   template <typename T> static Fix *fix_creator(LAMMPS *, int, char **);
 };

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -94,6 +94,15 @@ Output::Output(LAMMPS *lmp) : Pointers(lmp)
   restart1 = restart2a = restart2b = NULL;
   var_restart_single = var_restart_double = NULL;
   restart = NULL;
+
+  dump_map = new DumpCreatorMap();
+
+#define DUMP_CLASS
+#define DumpStyle(key,Class) \
+  (*dump_map)[#key] = &dump_creator<Class>;
+#include "style_dump.h"
+#undef DumpStyle
+#undef DUMP_CLASS
 }
 
 /* ----------------------------------------------------------------------
@@ -120,6 +129,8 @@ Output::~Output()
   delete [] var_restart_single;
   delete [] var_restart_double;
   delete restart;
+
+  delete dump_map;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -576,14 +587,10 @@ void Output::add_dump(int narg, char **arg)
 
   // create the Dump
 
-  if (0) return;         // dummy line to enable else-if macro expansion
-
-#define DUMP_CLASS
-#define DumpStyle(key,Class) \
-  else if (strcmp(arg[2],#key) == 0) dump[ndump] = new Class(lmp,narg,arg);
-#include "style_dump.h"
-#undef DUMP_CLASS
-
+  if (dump_map->find(arg[2]) != dump_map->end()) {
+    DumpCreator dump_creator = (*dump_map)[arg[2]];
+    dump[ndump] = dump_creator(lmp, narg, arg);
+  }
   else error->all(FLERR,"Unknown dump style");
 
   every_dump[ndump] = force->inumeric(FLERR,arg[3]);
@@ -591,6 +598,16 @@ void Output::add_dump(int narg, char **arg)
   last_dump[ndump] = -1;
   var_dump[ndump] = NULL;
   ndump++;
+}
+
+/* ----------------------------------------------------------------------
+   one instance per dump style in style_dump.h
+------------------------------------------------------------------------- */
+
+template <typename T>
+Dump *Output::dump_creator(LAMMPS *lmp, int narg, char ** arg)
+{
+  return new T(lmp, narg, arg);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/output.h
+++ b/src/output.h
@@ -15,6 +15,8 @@
 #define LMP_OUTPUT_H
 
 #include "pointers.h"
+#include <map>
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -57,6 +59,11 @@ class Output : protected Pointers {
   char *restart2a,*restart2b;  // names of double restart files
   class WriteRestart *restart; // class for writing restart files
 
+
+  typedef Dump *(*DumpCreator)(LAMMPS *,int,char**);
+  typedef std::map<std::string,DumpCreator> DumpCreatorMap;
+  DumpCreatorMap *dump_map;
+
   Output(class LAMMPS *);
   ~Output();
   void init();
@@ -75,6 +82,9 @@ class Output : protected Pointers {
   void create_restart(int, char **); // create Restart and restart files
 
   void memory_usage();               // print out memory usage
+
+ private:
+  template <typename T> static Dump *dump_creator(LAMMPS *, int, char **);
 };
 
 }

--- a/src/update.h
+++ b/src/update.h
@@ -15,6 +15,8 @@
 #define LMP_UPDATE_H
 
 #include "pointers.h"
+#include <map>
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -49,6 +51,10 @@ class Update : protected Pointers {
   int rng_style;                  // default style for pRNGs
   int rng_seed;                   // global seed for pRNGs
 
+  typedef Integrate *(*IntegrateCreator)(LAMMPS *,int,char**);
+  typedef std::map<std::string,IntegrateCreator> IntegrateCreatorMap;
+  IntegrateCreatorMap *integrate_map;
+
   Update(class LAMMPS *);
   ~Update();
   void init();
@@ -64,6 +70,7 @@ class Update : protected Pointers {
  private:
   void new_integrate(char *, int, char **, int, int &);
 
+  template <typename T> static Integrate *integrate_creator(LAMMPS *, int, char **);
 };
 
 }

--- a/src/update.h
+++ b/src/update.h
@@ -52,8 +52,13 @@ class Update : protected Pointers {
   int rng_seed;                   // global seed for pRNGs
 
   typedef Integrate *(*IntegrateCreator)(LAMMPS *,int,char**);
+  typedef Min *(*MinimizeCreator)(LAMMPS *);
+
   typedef std::map<std::string,IntegrateCreator> IntegrateCreatorMap;
+  typedef std::map<std::string,MinimizeCreator> MinimizeCreatorMap;
+
   IntegrateCreatorMap *integrate_map;
+  MinimizeCreatorMap *minimize_map;
 
   Update(class LAMMPS *);
   ~Update();
@@ -71,6 +76,7 @@ class Update : protected Pointers {
   void new_integrate(char *, int, char **, int, int &);
 
   template <typename T> static Integrate *integrate_creator(LAMMPS *, int, char **);
+  template <typename T> static Min *minimize_creator(LAMMPS *);
 };
 
 }


### PR DESCRIPTION
This PR extends the `info` command with options to output a list of all available styles in LAMMPS. This is useful for external tools, such as the Python interface to query the capabilities of the LAMMPS executable/library.

## Usage
```shell
# prints out all styles
info styles

# prints out only styles of selected class
info styles [all|atom|bond|dihedral|improper|fix|compute|region|dump|command]
```

## Implementation notes
While implementing this feature I also unified the creation of all styles using the factory pattern which we have started to use for Pair, Compute, etc. While for some style types this is a bit of an overkill, my main argument to apply it is to unify the styles creation across the entire code base. This also is a milestone for the proposed plugin interface we were talking about.