### PR TITLE
Dynamic groups for respa

### DIFF
--- a/src/REPLICA/prd.cpp
+++ b/src/REPLICA/prd.cpp
@@ -783,8 +783,6 @@ void PRD::log_event()
 
 void PRD::replicate(int ireplica)
 {
-  int nreplica = universe->nworlds;
-  int nprocs_universe = universe->nprocs;
   int i,m;
 
   // -----------------------------------------------------

--- a/src/fix_group.cpp
+++ b/src/fix_group.cpp
@@ -21,6 +21,7 @@
 #include "domain.h"
 #include "region.h"
 #include "modify.h"
+#include "respa.h"
 #include "input.h"
 #include "variable.h"
 #include "memory.h"
@@ -95,6 +96,7 @@ int FixGroup::setmask()
 {
   int mask = 0;
   mask |= POST_INTEGRATE;
+  mask |= POST_INTEGRATE_RESPA;
   return mask;
 }
 
@@ -107,6 +109,9 @@ void FixGroup::init()
 
   if (group->dynamic[igroup])
     error->all(FLERR,"Group dynamic parent group cannot be dynamic");
+
+  if (strstr(update->integrate_style,"respa"))
+    nlevels_respa = ((Respa *) update->integrate)->nlevels;
 
   // set current indices for region and variable
 
@@ -165,6 +170,13 @@ void FixGroup::post_integrate()
   // only assign atoms to group on steps that are multiples of nevery
 
   if (update->ntimestep % nevery == 0) set_group();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixGroup::post_integrate_respa(int ilevel, int iloop)
+{
+  if (ilevel == nlevels_respa-1) post_integrate();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix_group.h
+++ b/src/fix_group.h
@@ -32,6 +32,7 @@ class FixGroup : public Fix {
   void init();
   void setup(int);
   void post_integrate();
+  void post_integrate_respa(int,int);
 
  private:
   int gbit,gbitinverse;
@@ -39,6 +40,8 @@ class FixGroup : public Fix {
   int iregion,ivar;
   char *idregion,*idvar;
   class Region *region;
+
+  int nlevels_respa;
 
   void set_group();
 };


### PR DESCRIPTION
This pull request implements the Fix::post_integrate_respa() method for FixGroup, so that dynamic groups will also be updated with run_style respa in addition to run_style verlet.