### PR TITLE
bugfix for eam/alloy/omp and eam/fs/omp

### DIFF
--- a/src/USER-OMP/pair_eam_alloy_omp.cpp
+++ b/src/USER-OMP/pair_eam_alloy_omp.cpp
@@ -101,6 +101,7 @@ void PairEAMAlloyOMP::coeff(int narg, char **arg)
         if (i == j) atom->set_mass(i,setfl->mass[map[i]]);
         count++;
       }
+      scale[i][j] = 1.0;
     }
   }
 

--- a/src/USER-OMP/pair_eam_fs_omp.cpp
+++ b/src/USER-OMP/pair_eam_fs_omp.cpp
@@ -101,6 +101,7 @@ void PairEAMFSOMP::coeff(int narg, char **arg)
         if (i == j) atom->set_mass(i,fs->mass[map[i]]);
         count++;
       }
+      scale[i][j] = 1.0;
     }
   }
 


### PR DESCRIPTION
correct the bug discovered by stan due to uninitialized scale factors for eam/alloy/omp and eam/fs/omp