### PR TITLE
Colvars 2016-10-05

### DIFF
--- a/lib/colvars/colvarbias_abf.cpp
+++ b/lib/colvars/colvarbias_abf.cpp
@@ -242,13 +242,7 @@ int colvarbias_abf::update()
       for (size_t i = 0; i < colvars.size(); i++) {
         // get total forces (lagging by 1 timestep) from colvars
         // and subtract previous ABF force
-        system_force[i] = colvars[i]->total_force().real_value
-                        - colvar_forces[i].real_value;
-//         if (cvm::debug())
-//           cvm::log("ABF System force calc: cv " + cvm::to_str(i) +
-//                   " fs " + cvm::to_str(system_force[i]) +
-//                   " = ft " + cvm::to_str(colvars[i]->total_force().real_value) +
-//                   " - fa " + cvm::to_str(colvar_forces[i].real_value));
+        update_system_force(i);
       }
       gradients->acc_force(force_bin, system_force);
     }
@@ -260,8 +254,7 @@ int colvarbias_abf::update()
         for (size_t i = 0; i < colvars.size(); i++) {
           // If we are outside the range of xi, the force has not been obtained above
           // the function is just an accessor, so cheap to call again anyway
-          system_force[i] = colvars[i]->total_force().real_value
-                          - colvar_forces[i].real_value;
+          update_system_force(i);
         }
         z_gradients->acc_force(z_bin, system_force);
       }

--- a/lib/colvars/colvarbias_abf.h
+++ b/lib/colvars/colvarbias_abf.h
@@ -62,6 +62,23 @@ private:
   /// n-dim grid contining CZAR estimator of "real" free energy gradients
   colvar_grid_gradient  *czar_gradients;
 
+  inline int update_system_force(size_t i)
+  {
+    if (colvars[i]->is_enabled(f_cv_subtract_applied_force)) {
+      // this colvar is already subtracting the ABF force
+      system_force[i] = colvars[i]->total_force().real_value;
+    } else {
+      system_force[i] = colvars[i]->total_force().real_value
+        - colvar_forces[i].real_value;
+    }
+    if (cvm::debug())
+      cvm::log("ABF System force calc: cv " + cvm::to_str(i) +
+               " fs " + cvm::to_str(system_force[i]) +
+               " = ft " + cvm::to_str(colvars[i]->total_force().real_value) +
+               " - fa " + cvm::to_str(colvar_forces[i].real_value));
+    return COLVARS_OK;
+  }
+
   // shared ABF
   bool     shared_on;
   size_t   shared_freq;

--- a/lib/colvars/colvarmodule.cpp
+++ b/lib/colvars/colvarmodule.cpp
@@ -942,6 +942,8 @@ int colvarmodule::setup_output()
 
 std::istream & colvarmodule::read_restart(std::istream &is)
 {
+  bool warn_total_forces = false;
+
   {
     // read global restart information
     std::string restart_conf;
@@ -958,6 +960,12 @@ std::istream & colvarmodule::read_restart(std::istream &is)
                         colvarparse::parse_silent);
       if (restart_version.size() && (restart_version != std::string(COLVARS_VERSION))) {
         cvm::log("This state file was generated with version "+restart_version+"\n");
+      }
+      if ((restart_version.size() == 0) || (restart_version.compare(std::string(COLVARS_VERSION)) < 0)) {
+        // check for total force change
+        if (proxy->total_forces_enabled()) {
+          warn_total_forces = true;
+        }
       }
     }
     is.clear();
@@ -987,6 +995,73 @@ std::istream & colvarmodule::read_restart(std::istream &is)
     }
   }
   cvm::decrease_depth();
+
+  if (warn_total_forces) {
+    cvm::log(cvm::line_marker);
+    cvm::log("WARNING:\n");
+    std::string const warning("### CHANGES IN THE DEFINITION OF SYSTEM FORCES (NOW TOTAL FORCES)\n\
+\n\
+Starting from the version 2016-08-10 of the Colvars module, \n\
+the role of system forces has been replaced by total forces.\n\
+\n\
+These include *all* forces acting on a collective variable, whether they\n\
+come from the force field potential or from external terms\n\
+(e.g. restraints), including forces applied by Colvars itself.\n\
+\n\
+In NAMD, forces applied by Colvars, IMD, SMD, TMD, symmetry\n\
+restraints and tclForces are now all counted in the total force.\n\
+\n\
+In LAMMPS, forces applied by Colvars itself are now counted in the total\n\
+force (all forces from other fixes were being counted already).\n\
+\n\
+\n\
+### WHEN IS THIS CHANGE RELEVANT\n\
+\n\
+This change affects results *only* when (1) outputSystemForce is\n\
+requested or (2) the ABF bias is used.  All other usage cases are\n\
+*unaffected* (colvar restraints, metadynamics, etc).\n\
+\n\
+When system forces are reported (flag: outputSystemForce), their values\n\
+in the output may change, but the physical trajectory is never affected.\n\
+The physical results of ABF calculations may be affected in some cases.\n\
+\n\
+\n\
+### CHANGES TO ABF CALCULATIONS\n\
+\n\
+Compared to previous Colvars versions, the ABF method will now attempt\n\
+to cancel external forces (for example, boundary walls) and it may be\n\
+not possible to resume through a state file a simulation that was\n\
+performed with a previous version.\n\
+\n\
+There are three possible scenarios:\n\
+\n\
+1. No external forces are applied to the atoms used by ABF: results are\n\
+unchanged.\n\
+\n\
+2. Some of the atoms used by ABF experience external forces, but these\n\
+forces are not applied directly to the variables used by ABF\n\
+(e.g. another colvar that uses the same atoms, tclForces, etc): in this\n\
+case, we recommend beginning a new simulation.\n\
+\n\
+3. External forces are applied to one or more of the colvars used by\n\
+ABF, but no other forces are applied to their atoms: you may use the\n\
+subtractAppliedForce keyword inside the corresponding colvars to\n\
+continue the previous simulation.\n\n");
+    cvm::log(warning);
+    cvm::log(cvm::line_marker);
+
+    // update this ahead of time in this special case
+    output_prefix = proxy->output_prefix();
+    cvm::log("All output files will now be saved with the prefix \""+output_prefix+".tmp.*\".\n");
+    output_prefix = output_prefix+".tmp";
+    write_output_files();
+    cvm::log(cvm::line_marker);
+    cvm::log("Please review the important warning above. After that, you may rename:\n\
+\""+output_prefix+".tmp.colvars.state\"\n\
+to:\n\
+\""+output_prefix+".colvars.state\"\n");
+    cvm::error("Exiting with error until issue is addressed.\n", FATAL_ERROR);
+  }
 
   return is;
 }

--- a/lib/colvars/colvarmodule.h
+++ b/lib/colvars/colvarmodule.h
@@ -4,7 +4,7 @@
 #define COLVARMODULE_H
 
 #ifndef COLVARS_VERSION
-#define COLVARS_VERSION "2016-09-30"
+#define COLVARS_VERSION "2016-10-05"
 #endif
 
 #ifndef COLVARS_DEBUG

--- a/lib/colvars/colvarproxy.h
+++ b/lib/colvars/colvarproxy.h
@@ -303,6 +303,14 @@ public:
                  COLVARS_NOT_IMPLEMENTED);
   }
 
+  /// Are total forces being used?
+  virtual bool total_forces_enabled() const
+  {
+    cvm::error("Error: total forces are currently not implemented.\n",
+               COLVARS_NOT_IMPLEMENTED);
+    return false;
+  }
+
   /// \brief Get the PBC-aware distance vector between two positions
   virtual cvm::rvector position_distance(cvm::atom_pos const &pos1,
                                          cvm::atom_pos const &pos2) = 0;

--- a/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -299,9 +299,9 @@ void colvarproxy_lammps::error(std::string const &message)
 void colvarproxy_lammps::fatal_error(std::string const &message)
 {
   log(message);
-  if (!cvm::debug())
-    log("If this error message is unclear, try recompiling the "
-         "colvars library and LAMMPS with -DCOLVARS_DEBUG.\n");
+  // if (!cvm::debug())
+  //   log("If this error message is unclear, try recompiling the "
+  //        "colvars library and LAMMPS with -DCOLVARS_DEBUG.\n");
 
   _lmp->error->one(FLERR,
                    "Fatal error in the collective variables module.\n");

--- a/src/USER-COLVARS/colvarproxy_lammps.h
+++ b/src/USER-COLVARS/colvarproxy_lammps.h
@@ -21,7 +21,7 @@
 #endif
 
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2016-04-08"
+#define COLVARPROXY_VERSION "2016-10-05"
 #endif
 
 /* struct for packed data communication of coordinates and forces. */
@@ -86,7 +86,7 @@ class colvarproxy_lammps : public colvarproxy {
   // methods for lammps to move data or trigger actions in the proxy
  public:
   void set_temperature(double t) { t_target = t; };
-  bool need_total_forces() const { return  total_force_requested; };
+  bool total_forces_enabled() const { return  total_force_requested; };
   bool want_exit() const { return do_exit; };
 
   // perform colvars computation. returns biasing energy

--- a/src/USER-COLVARS/fix_colvars.cpp
+++ b/src/USER-COLVARS/fix_colvars.cpp
@@ -766,7 +766,7 @@ void FixColvars::post_force(int vflag)
   // call our workhorse and retrieve additional information.
   if (me == 0) {
     energy = proxy->compute();
-    store_forces = proxy->need_total_forces();
+    store_forces = proxy->total_forces_enabled();
   }
   ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This pull request contains two updates, shown as separate commits:

1. When total forces are requested (typically, ABF calculations) in a continuation job and an older version of Colvars is detected in the state file, Colvars will call `_lmp->error->one()` to make users aware that the total force does not always coincide with the system force. This error condition is also triggered in NAMD. Although in LAMMPS the risk of errors is much smaller, there are several usage cases where the user must decide whether to continue a simulation across versions, and possibly enable a compatibility flag for a subset of those cases.

2. Make ABF aware of the above compatibility flag.

Further details:
https://github.com/colvars/colvars/blob/master/README-totalforce.md