### PR TITLE
USER-DPD: bugfix in unpack_comm_hybrid(); now works with atom_style hybrid

### DIFF
--- a/src/USER-DPD/atom_vec_dpd.cpp
+++ b/src/USER-DPD/atom_vec_dpd.cpp
@@ -589,6 +589,8 @@ int AtomVecDPD::unpack_comm_hybrid(int n, int first, double *buf)
     uCond[i] = buf[m++];
     uMech[i] = buf[m++];
     uChem[i] = buf[m++];
+    uCG[i] = buf[m++];
+    uCGnew[i] = buf[m++];
   }
   return m;
 }


### PR DESCRIPTION
We got around to testing USER-DPD with atom_style hybrid and found we had missed two fields in unpack_comm_hybrid(), which this patch fixes.