### PR TITLE
txt2rst external link fix

### DIFF
--- a/doc/src/fix_wall_gran_region.txt
+++ b/doc/src/fix_wall_gran_region.txt
@@ -42,7 +42,7 @@ Here are snapshots of example models using this command.
 Corresponding input scripts can be found in examples/granregion.
 Click on the images to see a bigger picture.  Movies of these
 simulations are "here on the Movies
-page"_http://lammps.sandia.gov/movies.html#granregion.html of the
+page"_http://lammps.sandia.gov/movies.html#granregion of the
 LAMMPS web site.
 
 :image(JPG/gran_funnel_small.jpg,JPG/gran_funnel.png)

--- a/doc/utils/converters/lammpsdoc/txt2rst.py
+++ b/doc/utils/converters/lammpsdoc/txt2rst.py
@@ -104,7 +104,7 @@ class RSTMarkup(Markup):
 
         anchor_pos = href.find('#')
 
-        if anchor_pos >= 0:
+        if anchor_pos >= 0 and not href.startswith('http'):
             href = href[anchor_pos+1:]
             return ":ref:`%s <%s>`" % (content, href)
 

--- a/doc/utils/converters/tests/test_txt2rst.py
+++ b/doc/utils/converters/tests/test_txt2rst.py
@@ -424,6 +424,11 @@ class TestSpecialCommands(unittest.TestCase):
                          "one \n\n"
                          "a :ref:`link <name>` to above\n\n", s)
 
+    def test_external_anchor_link(self):
+        s = self.txt2rst.convert('some text "containing a\n'
+                                 'link"_http://lammps.sandia.gov/movies.html#granregion with an anchor')
+        self.assertEqual('some text `containing a link <http://lammps.sandia.gov/movies.html#granregion>`_ with an anchor\n\n', s)
+
     def test_define_link_alias(self):
         s = self.txt2rst.convert("one :link(alias,value)\n"
                                  "\"test\"_alias\n")


### PR DESCRIPTION
External links with anchors did not pass through correctly during the txt2rst conversion. This PR fixes that issue.