### PR TITLE
make no-lib should also remove MPIIO and USER-LB packages

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,8 +55,8 @@ PACKUSER = user-atc user-awpmd user-cg-cmm user-colvars \
 	   user-quip user-reaxc user-smd user-smtbq user-sph user-tally \
 	   user-vtk
 
-PACKLIB = compress gpu kim kokkos meam poems python reax voronoi \
-	  user-atc user-awpmd user-colvars user-h5md user-molfile \
+PACKLIB = compress gpu kim kokkos meam mpiio poems python reax voronoi \
+	  user-atc user-awpmd user-colvars user-h5md user-lb user-molfile \
 	  user-qmmm user-quip user-vtk
 
 PACKALL = $(PACKAGE) $(PACKUSER)


### PR DESCRIPTION
the MPIIO and USER-LB packages depend on MPI-I/O library. While this is bundled with MPI-2 conforming packages, there is no MPI-I/O support in STUBS. Thus:
```
make yes-all
make no-lib
make serial
```
will fail. This patch corrects for it.
