### PR TITLE
USER-DPD Bugfix: reset_dt() is not called when I thought it should be called.

### DIFF
--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -169,13 +169,6 @@ void FixShardlow::min_setup_pre_exchange()
 
 /* ---------------------------------------------------------------------- */
 
-void FixShardlow::reset_dt()
-{
-  dtsqrt = sqrt(update->dt);
-}
-
-/* ---------------------------------------------------------------------- */
-
 void FixShardlow::setup(int vflag)
 {
   bool fixShardlow = false;
@@ -451,6 +444,8 @@ void FixShardlow::initial_integrate(int vflag)
   }
   inum = list->inum;
   ilist = list->ilist;
+
+  dtsqrt = sqrt(update->dt);
 
   //Loop over all 14 directions (8 stages)
   for (airnum = 1; airnum <=8; airnum++){

--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -114,8 +114,6 @@ FixShardlow::FixShardlow(LAMMPS *lmp, int narg, char **arg) :
   atom->add_callback(0); // grow (aka exchange)
   atom->add_callback(1); // restart
   atom->add_callback(2); // border
-
-  reset_dt();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-DPD/fix_shardlow.h
+++ b/src/USER-DPD/fix_shardlow.h
@@ -40,8 +40,6 @@ class FixShardlow : public Fix {
   void copy_arrays(int, int, int);
   void set_arrays(int);
 
-  void reset_dt();
-
   int pack_border(int, int *, double *);
   int unpack_border(int, int, double *);
   int unpack_exchange(int, double *);


### PR DESCRIPTION
Move the calculation of dtsqrt inside FixShardlow::initial_integrate() where it is needed.

This corrects a serious bug discovered with a new ARL-internal USER-DPD test case.