### PR TITLE
provide an accessor for names of LAMMPS variables

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1079,3 +1079,10 @@ bool Info::has_exceptions() const {
   return false;
 #endif
 }
+
+/* ---------------------------------------------------------------------- */
+
+char **Info::get_variable_names(int &num) {
+    num = input->variable->nvar;
+    return input->variable->names;
+}

--- a/src/info.h
+++ b/src/info.h
@@ -39,6 +39,8 @@ class Info : protected Pointers {
   bool has_ffmpeg_support() const;
   bool has_exceptions() const;
 
+  char **get_variable_names(int &num);
+
 private:
   void available_styles(FILE * out, int flags);
 


### PR DESCRIPTION
In response to a request by @andeplane 
This closes #223 