### PR TITLE
add mixing support for pair styles gauss and gauss/cut

### DIFF
--- a/doc/src/pair_gauss.txt
+++ b/doc/src/pair_gauss.txt
@@ -106,8 +106,31 @@ more instructions on how to use the accelerated styles effectively.
 
 [Mixing, shift, table, tail correction, restart, rRESPA info]:
 
-These pair styles do not support mixing. Thus, coefficients for all
-I,J pairs must be specified explicitly.
+For atom type pairs I,J and I != J, the A, B, H, sigma_h, r_mh
+parameters, and the cutoff distance for these pair styles can be mixed:
+A (energy units)
+sqrt(1/B) (distance units, see below)
+H (energy units)
+sigma_h (distance units)
+r_mh (distance units)
+cutoff (distance units):ul
+
+The default mix value is {geometric}.
+Only {arithmetic} and {geometric} mix values are supported.
+See the "pair_modify" command for details.
+
+The A and H parameters are mixed using the same rules normally
+used to mix the "epsilon" parameter in a Lennard Jones interaction.
+The sigma_h, r_mh, and the cutoff distance are mixed using the same
+rules used to mix the "sigma" parameter in a Lennard Jones interaction.
+The B parameter is converted to a distance (sigma), before mixing
+(using sigma=B^-0.5), and converted back to a coefficient
+afterwards (using B=sigma^2).
+Negative A values are converted to positive A values (using abs(A))
+before mixing, and converted back after mixing
+(by multiplying by sign(Ai)*sign(Aj)).
+This way, if either particle is repulsive (if Ai<0 or Aj<0),
+then the default interaction between both particles will be repulsive.
 
 The {gauss} style does not support the "pair_modify"_pair_modify.html
 shift option. There is no effect due to the Gaussian well beyond the

--- a/src/USER-MISC/pair_gauss_cut.h
+++ b/src/USER-MISC/pair_gauss_cut.h
@@ -42,6 +42,8 @@ class PairGaussCut : public Pair {
   virtual void read_restart(FILE *);
   virtual void write_restart_settings(FILE *);
   virtual void read_restart_settings(FILE *);
+  virtual void write_data(FILE *fp);
+  virtual void write_data_all(FILE *fp);
 
   virtual double memory_usage();
 

--- a/src/pair_gauss.h
+++ b/src/pair_gauss.h
@@ -36,6 +36,8 @@ class PairGauss : public Pair {
   void read_restart(FILE *);
   void write_restart_settings(FILE *);
   void read_restart_settings(FILE *);
+  void write_data(FILE *fp);
+  void write_data_all(FILE *fp);
   double single(int, int, int, int, double, double, double, double &);
   void *extract(const char *, int &);
 


### PR DESCRIPTION
This is contributed code from andrew jewett as posted on lammps-users.
In addition, i've added support for write_data/write_coeffs for both styles to simplify debugging of mixing.