### PR TITLE
make PRD code compatible with -DLAMMPS_BIGBIG

### DIFF
--- a/src/REPLICA/prd.cpp
+++ b/src/REPLICA/prd.cpp
@@ -795,7 +795,7 @@ void PRD::replicate(int ireplica)
 
   if (cmode == SINGLE_PROC_DIRECT) {
     MPI_Bcast(atom->x[0],3*atom->nlocal,MPI_DOUBLE,ireplica,comm_replica);
-    MPI_Bcast(atom->image,atom->nlocal,MPI_INT,ireplica,comm_replica);
+    MPI_Bcast(atom->image,atom->nlocal,MPI_LMP_IMAGEINT,ireplica,comm_replica);
     return;
   }
 
@@ -815,9 +815,9 @@ void PRD::replicate(int ireplica)
       memcpy(imageall,image,nlocal*sizeof(imageint));
     }
 
-    MPI_Bcast(tagall,natoms,MPI_INT,ireplica,comm_replica);
+    MPI_Bcast(tagall,natoms,MPI_LMP_TAGINT,ireplica,comm_replica);
     MPI_Bcast(xall[0],3*natoms,MPI_DOUBLE,ireplica,comm_replica);
-    MPI_Bcast(imageall,natoms,MPI_INT,ireplica,comm_replica);
+    MPI_Bcast(imageall,natoms,MPI_LMP_IMAGEINT,ireplica,comm_replica);
 
     for (i = 0; i < nlocal; i++) {
       m = atom->map(tagall[i]);
@@ -844,8 +844,8 @@ void PRD::replicate(int ireplica)
       displacements[i+1] = displacements[i] + counts[i];
     MPI_Gatherv(atom->tag,atom->nlocal,MPI_LMP_TAGINT,
                 tagall,counts,displacements,MPI_LMP_TAGINT,0,world);
-    MPI_Gatherv(atom->image,atom->nlocal,MPI_LMP_TAGINT,
-                imageall,counts,displacements,MPI_LMP_TAGINT,0,world);
+    MPI_Gatherv(atom->image,atom->nlocal,MPI_LMP_IMAGEINT,
+                imageall,counts,displacements,MPI_LMP_IMAGEINT,0,world);
     for (i = 0; i < nprocs; i++) counts[i] *= 3;
     for (i = 0; i < nprocs-1; i++)
       displacements[i+1] = displacements[i] + counts[i];
@@ -854,13 +854,13 @@ void PRD::replicate(int ireplica)
   }
   
   if (me == 0) {
-    MPI_Bcast(tagall,natoms,MPI_INT,ireplica,comm_replica);
-    MPI_Bcast(imageall,natoms,MPI_INT,ireplica,comm_replica);
+    MPI_Bcast(tagall,natoms,MPI_LMP_TAGINT,ireplica,comm_replica);
+    MPI_Bcast(imageall,natoms,MPI_LMP_IMAGEINT,ireplica,comm_replica);
     MPI_Bcast(xall[0],3*natoms,MPI_DOUBLE,ireplica,comm_replica);
   }
   
-  MPI_Bcast(tagall,natoms,MPI_INT,0,world);
-  MPI_Bcast(imageall,natoms,MPI_INT,0,world);
+  MPI_Bcast(tagall,natoms,MPI_LMP_TAGINT,0,world);
+  MPI_Bcast(imageall,natoms,MPI_LMP_IMAGEINT,0,world);
   MPI_Bcast(xall[0],3*natoms,MPI_DOUBLE,0,world);
   
   double **x = atom->x;

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -89,6 +89,7 @@ typedef int64_t bigint;
 #define MAXBIGINT INT64_MAX
 
 #define MPI_LMP_TAGINT MPI_INT
+#define MPI_LMP_IMAGEINT MPI_INT
 #define MPI_LMP_BIGINT MPI_LL
 
 #define TAGINT_FORMAT "%d"
@@ -120,6 +121,7 @@ typedef int64_t bigint;
 #define MAXBIGINT INT64_MAX
 
 #define MPI_LMP_TAGINT MPI_LL
+#define MPI_LMP_IMAGEINT MPI_LL
 #define MPI_LMP_BIGINT MPI_LL
 
 #define TAGINT_FORMAT "%" PRId64
@@ -150,6 +152,7 @@ typedef int bigint;
 #define MAXBIGINT INT_MAX
 
 #define MPI_LMP_TAGINT MPI_INT
+#define MPI_LMP_IMAGEINT MPI_INT
 #define MPI_LMP_BIGINT MPI_INT
 
 #define TAGINT_FORMAT "%d"


### PR DESCRIPTION
this changes inconsistent use of MPI_INT for 64-bit integer data types like imageint and tagint.
for that purpose a new define MPI_LMP_IMAGEINT is added.

this closes #227 