### PR TITLE
Small bugfixes

### DIFF
--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -585,17 +585,26 @@ double BondTable::splint(double *xa, double *ya, double *y2a, int n, double x)
 
 /* ----------------------------------------------------------------------
    calculate potential u and force f at distance x
-   insure x is between bond min/max
+   insure x is between bond min/max, exit with error if not
 ------------------------------------------------------------------------- */
 
 void BondTable::uf_lookup(int type, double x, double &u, double &f)
 {
   int itable;
   double fraction,a,b;
+  char estr[128];
 
   Table *tb = &tables[tabindex[type]];
-  x = MAX(x,tb->lo);
-  x = MIN(x,tb->hi);
+  if (x < tb->lo) {
+    sprintf(estr,"Bond length < table inner cutoff: "
+            "type %d length %g",type,x);
+    error->one(FLERR,estr);
+  }
+  if (x > tb->hi) {
+    sprintf(estr,"Bond length > table outer cutoff: "
+            "type %d length %g",type,x);
+    error->one(FLERR,estr);
+  }
 
   if (tabstyle == LINEAR) {
     itable = static_cast<int> ((x - tb->lo) * tb->invdelta);

--- a/src/create_box.cpp
+++ b/src/create_box.cpp
@@ -159,6 +159,7 @@ void CreateBox::command(int narg, char **arg)
     } else if (strcmp(arg[iarg],"extra/special/per/atom") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal create_box command");
       force->special_extra = force->inumeric(FLERR,arg[iarg+1]);
+      atom->maxspecial += force->special_extra;
       iarg += 2;
     } else error->all(FLERR,"Illegal create_box command");
   }

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -595,6 +595,10 @@ void Molecule::read(int flag)
   // set maxspecial on first pass, so allocate() has a size
 
   if (bondflag && specialflag == 0) {
+    if (domain->box_exist == 0)
+      error->all(FLERR,"Cannot auto-generate special bonds before "
+                       "simulation box is defined");
+
     maxspecial = atom->maxspecial;
     if (flag) {
       special_generate();


### PR DESCRIPTION
Various small bugfixes and enhancements:
- better handle extra auto-generated exclusions for molecule file. error when used before box is defined (as discussed on lammps-users)
- exit with an error message instead of using an inconsistent/bad force (and worse energy) when outside the tabulated range in bond style table (as discussed on lammps-users)