### PR TITLE
Static analysis fixes

### DIFF
--- a/src/fix_halt.h
+++ b/src/fix_halt.h
@@ -36,7 +36,7 @@ class FixHalt : public Fix {
 
  private:
   int attribute,operation,eflag,ivar;
-  double attvalue,value;
+  double value;
   char *idvar;
 
   double bondmax();

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -486,7 +486,7 @@ void Region::set_velocity()
     else v[0] = v[1] = v[2] = 0.0;
     prev[0] = dx;
     prev[1] = dy;
-    prev[2] = dz;    
+    prev[2] = dz;
   }
 
   if (rotateflag) {
@@ -546,13 +546,13 @@ void Region::velocity_contact(double *vwall, double *x, int ic)
 
 void Region::length_restart_string(int &n)
 {
-  n += sizeof(int) + strlen(id)+1 + 
+  n += sizeof(int) + strlen(id)+1 +
     sizeof(int) + strlen(style)+1 + sizeof(int) +
     size_restart*sizeof(double);
 }
 
 /* ----------------------------------------------------------------------
-   region writes its current style, id, number of sub-regions 
+   region writes its current style, id, number of sub-regions
      and position/angle
    needed by fix/wall/gran/region to compute velocity by differencing scheme
 ------------------------------------------------------------------------- */
@@ -564,10 +564,10 @@ void Region::write_restart(FILE *fp)
   fwrite(&sizeid, sizeof(int), 1, fp);
   fwrite(id, 1, sizeid, fp);
   fwrite(&sizestyle, sizeof(int), 1, fp);
-  fwrite(style, 1, sizestyle, fp);  
+  fwrite(style, 1, sizestyle, fp);
   fwrite(&nregion,sizeof(int),1,fp);
 
-  fwrite(prev, sizeof(double), size_restart, fp);  
+  fwrite(prev, sizeof(double), size_restart, fp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -578,34 +578,21 @@ void Region::write_restart(FILE *fp)
 
 int Region::restart(char *buf, int &n)
 {
-  int sizeid = buf[n];
+  int size = *((int *)(buf+n));
   n += sizeof(int);
-  char *restart_id = new char[sizeid];
-  for (int i = 0; i < sizeid; i++)
-    restart_id[i] = buf[n++];    
-  if (strcmp(restart_id,id) != 0) return 0;
+  if ((size <= 0) || (strcmp(buf+n,id) != 0)) return 0;
+  n += size;
 
-  int sizestyle = buf[n];
+  size = *((int *)(buf+n));
   n += sizeof(int);
-  char *restart_style = new char[sizestyle];
-  for (int i = 0; i < sizestyle; i++)
-    restart_style[i] = buf[n++];  
-  if (strcmp(restart_style,style) != 0) return 0;    
+  if ((size <= 0) || (strcmp(buf+n,style) != 0)) return 0;
+  n += size;
 
-  int restart_nreg = buf[n];
+  int restart_nreg = *((int *)(buf+n));
   n += sizeof(int);
   if (restart_nreg != nregion) return 0;
 
-  char *rlist = new char[size_restart*sizeof(double)];  
-  for (int i = 0; i < size_restart*sizeof(double); i++)
-    rlist[i] = buf[n++]; 
-  for (int i = 0; i < size_restart; i++){
-    prev[i] = ((double *)rlist)[i];
-  }
-  
-  delete [] rlist;
-  delete [] restart_id;
-  delete [] restart_style;
+  memcpy(prev,buf+n,size_restart*sizeof(double));
   return 1;
 }
 

--- a/src/region.h
+++ b/src/region.h
@@ -60,7 +60,7 @@ class Region : protected Pointers {
   double omega[3];	      // angular velocity
   double rprev;               // speed of time-dependent radius, if applicable
   double xcenter[3];          // translated/rotated center of cylinder/sphere (only used if varshape)
-  double prev[5];             // stores displacement (X3), angle and if 
+  double prev[5];             // stores displacement (X3), angle and if
                               //  necessary, region variable size (e.g. radius)
                               //  at previous time step
   int vel_timestep;           // store timestep at which set_velocity was called

--- a/src/region_block.cpp
+++ b/src/region_block.cpp
@@ -344,7 +344,7 @@ int RegBlock::surface_exterior(double *x, double cutoff)
   store closest point in xc,yc,zc
 --------------------------------------------------------------------------*/
 
-double RegBlock::find_closest_point(int i, double *x, 
+double RegBlock::find_closest_point(int i, double *x,
                                     double &xc, double &yc, double &zc)
 {
   double dot,d2,d2min;
@@ -372,7 +372,7 @@ double RegBlock::find_closest_point(int i, double *x,
 
   } else {
     point_on_line_segment(corners[i][0],corners[i][1],x,p);
-    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) + 
+    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) +
       (p[2]-x[2])*(p[2]-x[2]);
     if (d2 < d2min) {
       d2min = d2;
@@ -382,7 +382,7 @@ double RegBlock::find_closest_point(int i, double *x,
     }
 
     point_on_line_segment(corners[i][1],corners[i][2],x,p);
-    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) + 
+    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) +
       (p[2]-x[2])*(p[2]-x[2]);
     if (d2 < d2min) {
       d2min = d2;
@@ -392,7 +392,7 @@ double RegBlock::find_closest_point(int i, double *x,
     }
 
     point_on_line_segment(corners[i][2],corners[i][3],x,p);
-    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) + 
+    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) +
       (p[2]-x[2])*(p[2]-x[2]);
     if (d2 < d2min) {
       d2min = d2;
@@ -402,7 +402,7 @@ double RegBlock::find_closest_point(int i, double *x,
     }
 
     point_on_line_segment(corners[i][3],corners[i][4],x,p);
-    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) + 
+    d2 = (p[0]-x[0])*(p[0]-x[0]) + (p[1]-x[1])*(p[1]-x[1]) +
       (p[2]-x[2])*(p[2]-x[2]);
     if (d2 < d2min) {
       d2min = d2;

--- a/src/region_cone.cpp
+++ b/src/region_cone.cpp
@@ -416,7 +416,7 @@ int RegCone::surface_exterior(double *x, double cutoff)
     // x is far enough from cone that there is no contact
     // x is interior to cone
 
-    if (r >= maxradius+cutoff || x[0] <= lo-cutoff || x[0] >= hi+cutoff) 
+    if (r >= maxradius+cutoff || x[0] <= lo-cutoff || x[0] >= hi+cutoff)
       return 0;
     if (r < currentradius && x[0] > lo && x[0] < hi) return 0;
 

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -36,7 +36,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
 
   // check open face settings
 
-  if (openflag && (open_faces[2] || open_faces[3] || 
+  if (openflag && (open_faces[2] || open_faces[3] ||
                    open_faces[4] || open_faces[5]))
     error->all(FLERR,"Invalid region cylinder open setting");
 
@@ -691,16 +691,16 @@ void RegCylinder::variable_check()
 
 
 /* ----------------------------------------------------------------------
-   Set values needed to calculate velocity due to shape changes. 
+   Set values needed to calculate velocity due to shape changes.
    These values do not depend on the contact, so this function is
    called once per timestep by fix/wall/gran/region.
-   
+
 ------------------------------------------------------------------------- */
 
 void RegCylinder::set_velocity_shape()
 {
   if (axis == 'x'){
-    xcenter[0] = 0; 
+    xcenter[0] = 0;
     xcenter[1] = c1;
     xcenter[2] = c2;
   }
@@ -715,15 +715,15 @@ void RegCylinder::set_velocity_shape()
     xcenter[2] = 0;
   }
   forward_transform(xcenter[0], xcenter[1], xcenter[2]);
-  if (update->ntimestep > 0) rprev = prev[4];  
+  if (update->ntimestep > 0) rprev = prev[4];
   else rprev = radius;
-  prev[4] = radius;     
+  prev[4] = radius;
 }
 
 
 
 /* ----------------------------------------------------------------------
-   add velocity due to shape change to wall velocity 
+   add velocity due to shape change to wall velocity
 ------------------------------------------------------------------------- */
 
 void RegCylinder::velocity_contact_shape(double *vwall, double *xc)
@@ -746,7 +746,7 @@ void RegCylinder::velocity_contact_shape(double *vwall, double *xc)
   }
   vwall[0] += delx/update->dt;
   vwall[1] += dely/update->dt;
-  vwall[2] += delz/update->dt;     
+  vwall[2] += delz/update->dt;
   //printf ("R is %g, prev %g, velocity of wall at %g %g %g is %g %g %g\n",radius,rprev,xc[0],xc[1],xc[2],vwall[0],vwall[1],vwall[2]);
 }
 

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -323,30 +323,23 @@ void RegIntersect::write_restart(FILE *fp)
 
 int RegIntersect::restart(char *buf, int& n)
 {
-  int sizeid = buf[n];
+  int size = *((int *)(buf+n));
   n += sizeof(int);
-  char *restart_id = new char[sizeid];
-  for (int i = 0; i < sizeid; i++)
-    restart_id[i] = buf[n++];    
-  if (strcmp(restart_id,id) != 0) return 0;
+  if ((size <= 0) || (strcmp(buf+n,id) != 0)) return 0;
+  n += size;
 
-  int sizestyle = buf[n];
+  size = *((int *)(buf+n));
   n += sizeof(int);
+  if ((size <= 0) || (strcmp(buf+n,style) != 0)) return 0;
+  n += size;
 
-  char *restart_style = new char[sizestyle];
-  for (int i = 0; i < sizestyle; i++)
-    restart_style[i] = buf[n++];  
-  if (strcmp(restart_style,style) != 0) return 0;    
-
-  int restart_nreg = buf[n];
+  int restart_nreg = *((int *)(buf+n));
   n += sizeof(int);
   if (restart_nreg != nregion) return 0;
 
-  for (int ilist = 0; ilist < nregion; ilist++){
-    if (!domain->regions[list[ilist]]->restart(buf, n)){
-      return 0;
-    }
-  }
+  for (int ilist = 0; ilist < nregion; ilist++)
+    if (!domain->regions[list[ilist]]->restart(buf, n)) return 0;
+
   return 1; 
 }
 

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -43,7 +43,7 @@ RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
     idsub[nregion] = new char[m];
     strcpy(idsub[nregion],arg[iarg+3]);
     iregion = domain->find_region(idsub[nregion]);
-    if (iregion == -1) 
+    if (iregion == -1)
       error->all(FLERR,"Region intersect region ID does not exist");
     list[nregion++] = iregion;
   }
@@ -124,7 +124,7 @@ void RegIntersect::init()
   int iregion;
   for (int ilist = 0; ilist < nregion; ilist++) {
     iregion = domain->find_region(idsub[ilist]);
-    if (iregion == -1) 
+    if (iregion == -1)
       error->all(FLERR,"Region union region ID does not exist");
     list[ilist] = iregion;
   }
@@ -290,7 +290,7 @@ void RegIntersect::set_velocity()
 
 void RegIntersect::length_restart_string(int& n)
 {
-  n += sizeof(int) + strlen(id)+1 + 
+  n += sizeof(int) + strlen(id)+1 +
     sizeof(int) + strlen(style)+1 + sizeof(int);
   for (int ilist = 0; ilist < nregion; ilist++)
     domain->regions[list[ilist]]->length_restart_string(n);
@@ -308,7 +308,7 @@ void RegIntersect::write_restart(FILE *fp)
   fwrite(&sizeid, sizeof(int), 1, fp);
   fwrite(id, 1, sizeid, fp);
   fwrite(&sizestyle, sizeof(int), 1, fp);
-  fwrite(style, 1, sizestyle, fp);  
+  fwrite(style, 1, sizestyle, fp);
   fwrite(&nregion,sizeof(int),1,fp);
 
   for (int ilist = 0; ilist < nregion; ilist++){
@@ -340,7 +340,7 @@ int RegIntersect::restart(char *buf, int& n)
   for (int ilist = 0; ilist < nregion; ilist++)
     if (!domain->regions[list[ilist]]->restart(buf, n)) return 0;
 
-  return 1; 
+  return 1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/region_sphere.cpp
+++ b/src/region_sphere.cpp
@@ -188,10 +188,10 @@ void RegSphere::variable_check()
 
 
 /* ----------------------------------------------------------------------
-   Set values needed to calculate velocity due to shape changes. 
+   Set values needed to calculate velocity due to shape changes.
    These values do not depend on the contact, so this function is
    called once per timestep by fix/wall/gran/region.
-   
+
 ------------------------------------------------------------------------- */
 
 void RegSphere::set_velocity_shape()
@@ -200,27 +200,27 @@ void RegSphere::set_velocity_shape()
   xcenter[1] = yc;
   xcenter[2] = zc;
   forward_transform(xcenter[0], xcenter[1], xcenter[2]);
-  if (update->ntimestep > 0) rprev = prev[4];  
+  if (update->ntimestep > 0) rprev = prev[4];
   else rprev = radius;
-  prev[4] = radius;     
+  prev[4] = radius;
 }
 
 
 
 /* ----------------------------------------------------------------------
-   add velocity due to shape change to wall velocity 
+   add velocity due to shape change to wall velocity
 ------------------------------------------------------------------------- */
 
 void RegSphere::velocity_contact_shape(double *vwall, double *xc)
 {
   double delx, dely, delz; // Displacement of contact point in x,y,z
- 
+
   delx = (xc[0] - xcenter[0])*(1 - rprev/radius);
   dely = (xc[1] - xcenter[1])*(1 - rprev/radius);
   delz = (xc[2] - xcenter[2])*(1 - rprev/radius);
 
   vwall[0] += delx/update->dt;
   vwall[1] += dely/update->dt;
-  vwall[2] += delz/update->dt;     
+  vwall[2] += delz/update->dt;
 }
 

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -315,27 +315,23 @@ void RegUnion::write_restart(FILE *fp)
 
 int RegUnion::restart(char *buf, int &n)
 {
-  int sizeid = buf[n];
+  int size = *((int *)(buf+n));
   n += sizeof(int);
-  char *restart_id = new char[sizeid];
-  for (int i = 0; i < sizeid; i++)
-    restart_id[i] = buf[n++];    
-  if (strcmp(restart_id,id) != 0) return 0;
+  if ((size <= 0) || (strcmp(buf+n,id) != 0)) return 0;
+  n += size;
 
-  int sizestyle = buf[n];
+  size = *((int *)(buf+n));
   n += sizeof(int);
-  char *restart_style = new char[sizestyle];
-  for (int i = 0; i < sizestyle; i++)
-    restart_style[i] = buf[n++];  
-  if (strcmp(restart_style,style) != 0) return 0;    
+  if ((size <= 0) || (strcmp(buf+n,style) != 0)) return 0;
+  n += size;
 
-  int restart_nreg = buf[n];
+  int restart_nreg = *((int *)(buf+n));
   n += sizeof(int);
   if (restart_nreg != nregion) return 0;
 
-  for (int ilist = 0; ilist < nregion; ilist++){
+  for (int ilist = 0; ilist < nregion; ilist++)
     if (!domain->regions[list[ilist]]->restart(buf, n)) return 0;
-  }
+
   return 1;
 }
 

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -44,7 +44,7 @@ RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg)
     idsub[nregion] = new char[m];
     strcpy(idsub[nregion],arg[iarg+3]);
     iregion = domain->find_region(idsub[nregion]);
-    if (iregion == -1) 
+    if (iregion == -1)
       error->all(FLERR,"Region union region ID does not exist");
     list[nregion++] = iregion;
   }
@@ -118,7 +118,7 @@ void RegUnion::init()
   int iregion;
   for (int ilist = 0; ilist < nregion; ilist++) {
     iregion = domain->find_region(idsub[ilist]);
-    if (iregion == -1) 
+    if (iregion == -1)
       error->all(FLERR,"Region union region ID does not exist");
     list[ilist] = iregion;
   }
@@ -171,7 +171,7 @@ int RegUnion::surface_interior(double *x, double cutoff)
       for (jlist = 0; jlist < nregion; jlist++) {
         if (jlist == ilist) continue;
         jregion = list[jlist];
-        if (regions[jregion]->match(xs,ys,zs) && 
+        if (regions[jregion]->match(xs,ys,zs) &&
             !regions[jregion]->openflag) break;
       }
       if (jlist == nregion) {
@@ -284,7 +284,7 @@ void RegUnion::set_velocity()
 
 void RegUnion::length_restart_string(int& n)
 {
-  n += sizeof(int) + strlen(id)+1 + 
+  n += sizeof(int) + strlen(id)+1 +
     sizeof(int) + strlen(style)+1 + sizeof(int);
   for (int ilist = 0; ilist < nregion; ilist++)
     domain->regions[list[ilist]]->length_restart_string(n);
@@ -302,10 +302,10 @@ void RegUnion::write_restart(FILE *fp)
   fwrite(&sizeid, sizeof(int), 1, fp);
   fwrite(id, 1, sizeid, fp);
   fwrite(&sizestyle, sizeof(int), 1, fp);
-  fwrite(style, 1, sizestyle, fp);  
+  fwrite(style, 1, sizestyle, fp);
   fwrite(&nregion,sizeof(int),1,fp);
   for (int ilist = 0; ilist < nregion; ilist++)
-    domain->regions[list[ilist]]->write_restart(fp);  
+    domain->regions[list[ilist]]->write_restart(fp);
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
This addresses issues detected by static code analysis on recently changed code.
- remove unused class member in fix halt, which was shadowed by a local variable
- refactor, correct and simplify handling restart checks related to regions in combination with fix wall/gran/region. the original code had memory leaks, was more complex, and was making copies without need.