### PR TITLE
Manybody short neighbor list

### DIFF
--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -52,8 +52,7 @@ PairSW::PairSW(LAMMPS *lmp) : Pair(lmp)
   elem2param = NULL;
   map = NULL;
 
-  sizeshort = 10;
-  numshort = 0;
+  maxshort = 10;
   neighshort = NULL;
 }
 
@@ -122,7 +121,7 @@ void PairSW::compute(int eflag, int vflag)
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
-    numshort = 0;
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
@@ -135,9 +134,9 @@ void PairSW::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > sizeshort) {
-          sizeshort += sizeshort/2;
-          memory->grow(neighshort,sizeshort,"pair:neighshort");
+        if (numshort > maxshort) {
+          maxshort += maxshort/2;
+          memory->grow(neighshort,maxshort,"pair:neighshort");
         }
       }
 
@@ -223,7 +222,7 @@ void PairSW::allocate()
 
   memory->create(setflag,n+1,n+1,"pair:setflag");
   memory->create(cutsq,n+1,n+1,"pair:cutsq");
-  memory->create(neighshort,sizeshort,"pair:neighshort");
+  memory->create(neighshort,maxshort,"pair:neighshort");
   map = new int[n+1];
 }
 

--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -100,7 +100,6 @@ void PairSW::compute(int eflag, int vflag)
   int *type = atom->type;
   int nlocal = atom->nlocal;
   int newton_pair = force->newton_pair;
-  const double cutshortsq = cutmax*cutmax;
 
   inum = list->inum;
   ilist = list->ilist;
@@ -132,7 +131,11 @@ void PairSW::compute(int eflag, int vflag)
       delz = ztmp - x[j][2];
       rsq = delx*delx + dely*dely + delz*delz;
 
-      if (rsq < cutshortsq) {
+      jtype = map[type[j]];
+      ijparam = elem2param[itype][jtype][jtype];
+      if (rsq >= params[ijparam].cutsq) {
+        continue;
+      } else {
         neighshort[numshort++] = j;
         if (numshort >= maxshort) {
           maxshort += maxshort/2;
@@ -151,9 +154,6 @@ void PairSW::compute(int eflag, int vflag)
         if (x[j][2] == ztmp && x[j][1] == ytmp && x[j][0] < xtmp) continue;
       }
 
-      jtype = map[type[j]];
-      ijparam = elem2param[itype][jtype][jtype];
-      if (rsq >= params[ijparam].cutsq) continue;
 
       twobody(&params[ijparam],rsq,fpair,eflag,evdwl);
 
@@ -178,7 +178,6 @@ void PairSW::compute(int eflag, int vflag)
       delr1[1] = x[j][1] - ytmp;
       delr1[2] = x[j][2] - ztmp;
       rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
-      if (rsq1 >= params[ijparam].cutsq) continue;
 
       for (kk = jj+1; kk < numshort; kk++) {
         k = neighshort[kk];
@@ -190,7 +189,6 @@ void PairSW::compute(int eflag, int vflag)
         delr2[1] = x[k][1] - ytmp;
         delr2[2] = x[k][2] - ztmp;
         rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
-        if (rsq2 >= params[ikparam].cutsq) continue;
 
         threebody(&params[ijparam],&params[ikparam],&params[ijkparam],
                   rsq1,rsq2,delr1,delr2,fj,fk,eflag,evdwl);

--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -134,7 +134,7 @@ void PairSW::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > maxshort) {
+        if (numshort >= maxshort) {
           maxshort += maxshort/2;
           memory->grow(neighshort,maxshort,"pair:neighshort");
         }

--- a/src/MANYBODY/pair_sw.h
+++ b/src/MANYBODY/pair_sw.h
@@ -55,6 +55,9 @@ class PairSW : public Pair {
   int nparams;                  // # of stored parameter sets
   int maxparam;                 // max # of parameter sets
   Param *params;                // parameter set for an I-J-K interaction
+  int sizeshort;                // size of short neighbor list array
+  int numshort;                 // current count of neighbors in short list
+  int *neighshort;              // short neighbor list array
 
   virtual void allocate();
   void read_file(char *);

--- a/src/MANYBODY/pair_sw.h
+++ b/src/MANYBODY/pair_sw.h
@@ -55,8 +55,7 @@ class PairSW : public Pair {
   int nparams;                  // # of stored parameter sets
   int maxparam;                 // max # of parameter sets
   Param *params;                // parameter set for an I-J-K interaction
-  int sizeshort;                // size of short neighbor list array
-  int numshort;                 // current count of neighbors in short list
+  int maxshort;                 // size of short neighbor list array
   int *neighshort;              // short neighbor list array
 
   virtual void allocate();

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -53,8 +53,7 @@ PairTersoff::PairTersoff(LAMMPS *lmp) : Pair(lmp)
   elem2param = NULL;
   map = NULL;
 
-  sizeshort = 10;
-  numshort = 0;
+  maxshort = 10;
   neighshort = NULL;
 }
 
@@ -124,7 +123,7 @@ void PairTersoff::compute(int eflag, int vflag)
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
-    numshort = 0;
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
@@ -137,9 +136,9 @@ void PairTersoff::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > sizeshort) {
-          sizeshort += sizeshort/2;
-          memory->grow(neighshort,sizeshort,"pair:neighshort");
+        if (numshort > maxshort) {
+          maxshort += maxshort/2;
+          memory->grow(neighshort,maxshort,"pair:neighshort");
         }
       }
 
@@ -262,7 +261,7 @@ void PairTersoff::allocate()
 
   memory->create(setflag,n+1,n+1,"pair:setflag");
   memory->create(cutsq,n+1,n+1,"pair:cutsq");
-  memory->create(neighshort,sizeshort,"pair:neighshort");
+  memory->create(neighshort,maxshort,"pair:neighshort");
   map = new int[n+1];
 }
 

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -109,6 +109,8 @@ void PairTersoff::compute(int eflag, int vflag)
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
 
+  double fxtmp,fytmp,fztmp;
+
   // loop over full neighbor list of my atoms
 
   for (ii = 0; ii < inum; ii++) {
@@ -118,6 +120,7 @@ void PairTersoff::compute(int eflag, int vflag)
     xtmp = x[i][0];
     ytmp = x[i][1];
     ztmp = x[i][2];
+    fxtmp = fytmp = fztmp = 0.0;
 
     // two-body interactions, skip half of them
 
@@ -155,13 +158,13 @@ void PairTersoff::compute(int eflag, int vflag)
 
       jtype = map[type[j]];
       iparam_ij = elem2param[itype][jtype][jtype];
-      if (rsq > params[iparam_ij].cutsq) continue;
+      if (rsq >= params[iparam_ij].cutsq) continue;
 
       repulsive(&params[iparam_ij],rsq,fpair,eflag,evdwl);
 
-      f[i][0] += delx*fpair;
-      f[i][1] += dely*fpair;
-      f[i][2] += delz*fpair;
+      fxtmp += delx*fpair;
+      fytmp += dely*fpair;
+      fztmp += delz*fpair;
       f[j][0] -= delx*fpair;
       f[j][1] -= dely*fpair;
       f[j][2] -= delz*fpair;
@@ -172,6 +175,7 @@ void PairTersoff::compute(int eflag, int vflag)
 
     // three-body interactions
     // skip immediately if I-J is not within cutoff
+    double fjxtmp,fjytmp,fjztmp;
 
     for (jj = 0; jj < numshort; jj++) {
       j = neighshort[jj];
@@ -182,10 +186,11 @@ void PairTersoff::compute(int eflag, int vflag)
       delr1[1] = x[j][1] - ytmp;
       delr1[2] = x[j][2] - ztmp;
       rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
-      if (rsq1 > params[iparam_ij].cutsq) continue;
+      if (rsq1 >= params[iparam_ij].cutsq) continue;
 
       // accumulate bondorder zeta for each i-j interaction via loop over k
 
+      fjxtmp = fjytmp = fjztmp = 0.0;
       zeta_ij = 0.0;
 
       for (kk = 0; kk < numshort; kk++) {
@@ -198,7 +203,7 @@ void PairTersoff::compute(int eflag, int vflag)
         delr2[1] = x[k][1] - ytmp;
         delr2[2] = x[k][2] - ztmp;
         rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
-        if (rsq2 > params[iparam_ijk].cutsq) continue;
+        if (rsq2 >= params[iparam_ijk].cutsq) continue;
 
         zeta_ij += zeta(&params[iparam_ijk],rsq1,rsq2,delr1,delr2);
       }
@@ -207,12 +212,12 @@ void PairTersoff::compute(int eflag, int vflag)
 
       force_zeta(&params[iparam_ij],rsq1,zeta_ij,fpair,prefactor,eflag,evdwl);
 
-      f[i][0] += delr1[0]*fpair;
-      f[i][1] += delr1[1]*fpair;
-      f[i][2] += delr1[2]*fpair;
-      f[j][0] -= delr1[0]*fpair;
-      f[j][1] -= delr1[1]*fpair;
-      f[j][2] -= delr1[2]*fpair;
+      fxtmp += delr1[0]*fpair;
+      fytmp += delr1[1]*fpair;
+      fztmp += delr1[2]*fpair;
+      fjxtmp -= delr1[0]*fpair;
+      fjytmp -= delr1[1]*fpair;
+      fjztmp -= delr1[2]*fpair;
 
       if (evflag) ev_tally(i,j,nlocal,newton_pair,
                            evdwl,0.0,-fpair,-delr1[0],-delr1[1],-delr1[2]);
@@ -229,24 +234,30 @@ void PairTersoff::compute(int eflag, int vflag)
         delr2[1] = x[k][1] - ytmp;
         delr2[2] = x[k][2] - ztmp;
         rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
-        if (rsq2 > params[iparam_ijk].cutsq) continue;
+        if (rsq2 >= params[iparam_ijk].cutsq) continue;
 
         attractive(&params[iparam_ijk],prefactor,
                    rsq1,rsq2,delr1,delr2,fi,fj,fk);
 
-        f[i][0] += fi[0];
-        f[i][1] += fi[1];
-        f[i][2] += fi[2];
-        f[j][0] += fj[0];
-        f[j][1] += fj[1];
-        f[j][2] += fj[2];
+        fxtmp += fi[0];
+        fytmp += fi[1];
+        fztmp += fi[2];
+        fjxtmp += fj[0];
+        fjytmp += fj[1];
+        fjztmp += fj[2];
         f[k][0] += fk[0];
         f[k][1] += fk[1];
         f[k][2] += fk[2];
 
         if (vflag_atom) v_tally3(i,j,k,fj,fk,delr1,delr2);
       }
+      f[j][0] += fjxtmp;
+      f[j][1] += fjytmp;
+      f[j][2] += fjztmp;
     }
+    f[i][0] += fxtmp;
+    f[i][1] += fytmp;
+    f[i][2] += fztmp;
   }
 
   if (vflag_fdotr) virial_fdotr_compute();

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -136,7 +136,7 @@ void PairTersoff::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > maxshort) {
+        if (numshort >= maxshort) {
           maxshort += maxshort/2;
           memory->grow(neighshort,maxshort,"pair:neighshort");
         }

--- a/src/MANYBODY/pair_tersoff.h
+++ b/src/MANYBODY/pair_tersoff.h
@@ -59,8 +59,7 @@ class PairTersoff : public Pair {
   int nelements;                // # of unique elements
   int nparams;                  // # of stored parameter sets
   int maxparam;                 // max # of parameter sets
-  int sizeshort;                // size of short neighbor list array
-  int numshort;                 // current count of neighbors in short list
+  int maxshort;                 // size of short neighbor list array
   int *neighshort;              // short neighbor list array
 
   virtual void allocate();

--- a/src/MANYBODY/pair_tersoff.h
+++ b/src/MANYBODY/pair_tersoff.h
@@ -59,6 +59,9 @@ class PairTersoff : public Pair {
   int nelements;                // # of unique elements
   int nparams;                  // # of stored parameter sets
   int maxparam;                 // max # of parameter sets
+  int sizeshort;                // size of short neighbor list array
+  int numshort;                 // current count of neighbors in short list
+  int *neighshort;              // short neighbor list array
 
   virtual void allocate();
   virtual void read_file(char *);

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -134,7 +134,7 @@ void PairVashishta::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > maxshort) {
+        if (numshort >= maxshort) {
           maxshort += maxshort/2;
           memory->grow(neighshort,maxshort,"pair:neighshort");
         }

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -107,6 +107,8 @@ void PairVashishta::compute(int eflag, int vflag)
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
 
+  double fxtmp,fytmp,fztmp;
+
   // loop over full neighbor list of my atoms
 
   for (ii = 0; ii < inum; ii++) {
@@ -116,6 +118,7 @@ void PairVashishta::compute(int eflag, int vflag)
     xtmp = x[i][0];
     ytmp = x[i][1];
     ztmp = x[i][2];
+    fxtmp = fytmp = fztmp = 0.0;
 
     // two-body interactions, skip half of them
 
@@ -157,9 +160,9 @@ void PairVashishta::compute(int eflag, int vflag)
 
       twobody(&params[ijparam],rsq,fpair,eflag,evdwl);
 
-      f[i][0] += delx*fpair;
-      f[i][1] += dely*fpair;
-      f[i][2] += delz*fpair;
+      fxtmp += delx*fpair;
+      fytmp += dely*fpair;
+      fztmp += delz*fpair;
       f[j][0] -= delx*fpair;
       f[j][1] -= dely*fpair;
       f[j][2] -= delz*fpair;
@@ -180,6 +183,9 @@ void PairVashishta::compute(int eflag, int vflag)
       rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
       if (rsq1 >= params[ijparam].cutsq2) continue;
 
+      double fjxtmp,fjytmp,fjztmp;
+      fjxtmp = fjytmp = fjztmp = 0.0;
+
       for (kk = jj+1; kk < numshort; kk++) {
         k = neighshort[kk];
         ktype = map[type[k]];
@@ -195,19 +201,25 @@ void PairVashishta::compute(int eflag, int vflag)
         threebody(&params[ijparam],&params[ikparam],&params[ijkparam],
                   rsq1,rsq2,delr1,delr2,fj,fk,eflag,evdwl);
 
-        f[i][0] -= fj[0] + fk[0];
-        f[i][1] -= fj[1] + fk[1];
-        f[i][2] -= fj[2] + fk[2];
-        f[j][0] += fj[0];
-        f[j][1] += fj[1];
-        f[j][2] += fj[2];
+        fxtmp -= fj[0] + fk[0];
+        fytmp -= fj[1] + fk[1];
+        fztmp -= fj[2] + fk[2];
+        fjxtmp += fj[0];
+        fjytmp += fj[1];
+        fjztmp += fj[2];
         f[k][0] += fk[0];
         f[k][1] += fk[1];
         f[k][2] += fk[2];
 
         if (evflag) ev_tally3(i,j,k,evdwl,0.0,fj,fk,delr1,delr2);
       }
+      f[j][0] += fjxtmp;
+      f[j][1] += fjytmp;
+      f[j][2] += fjztmp;
     }
+    f[i][0] += fxtmp;
+    f[i][1] += fytmp;
+    f[i][2] += fztmp;
   }
 
   if (vflag_fdotr) virial_fdotr_compute();

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -54,8 +54,7 @@ PairVashishta::PairVashishta(LAMMPS *lmp) : Pair(lmp)
   map = NULL;
 
   r0max = 0.0;
-  sizeshort = 10;
-  numshort = 0;
+  maxshort = 10;
   neighshort = NULL;
 }
 
@@ -122,7 +121,7 @@ void PairVashishta::compute(int eflag, int vflag)
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
-    numshort = 0;
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
@@ -135,9 +134,9 @@ void PairVashishta::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > sizeshort) {
-          sizeshort += sizeshort/2;
-          memory->grow(neighshort,sizeshort,"pair:neighshort");
+        if (numshort > maxshort) {
+          maxshort += maxshort/2;
+          memory->grow(neighshort,maxshort,"pair:neighshort");
         }
       }
 
@@ -154,7 +153,7 @@ void PairVashishta::compute(int eflag, int vflag)
 
       jtype = map[type[j]];
       ijparam = elem2param[itype][jtype][jtype];
-      if (rsq > params[ijparam].cutsq) continue;
+      if (rsq >= params[ijparam].cutsq) continue;
 
       twobody(&params[ijparam],rsq,fpair,eflag,evdwl);
 
@@ -206,7 +205,7 @@ void PairVashishta::compute(int eflag, int vflag)
         f[k][1] += fk[1];
         f[k][2] += fk[2];
 
-	if (evflag) ev_tally3(i,j,k,evdwl,0.0,fj,fk,delr1,delr2);
+        if (evflag) ev_tally3(i,j,k,evdwl,0.0,fj,fk,delr1,delr2);
       }
     }
   }
@@ -223,7 +222,7 @@ void PairVashishta::allocate()
 
   memory->create(setflag,n+1,n+1,"pair:setflag");
   memory->create(cutsq,n+1,n+1,"pair:cutsq");
-  memory->create(neighshort,sizeshort,"pair:neighshort");
+  memory->create(neighshort,maxshort,"pair:neighshort");
 
   map = new int[n+1];
 }

--- a/src/MANYBODY/pair_vashishta.h
+++ b/src/MANYBODY/pair_vashishta.h
@@ -1,4 +1,4 @@
-/* ----------------------------------------------------------------------
+/* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    http://lammps.sandia.gov, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
@@ -54,6 +54,10 @@ class PairVashishta : public Pair {
   int nparams;                  // # of stored parameter sets
   int maxparam;                 // max # of parameter sets
   Param *params;                // parameter set for an I-J-K interaction
+  double r0max;                 // largest value of r0
+  int sizeshort;                // size of short neighbor list array
+  int numshort;                 // current count of neighbors in short list
+  int *neighshort;              // short neighbor list array
 
   void allocate();
   void read_file(char *);

--- a/src/MANYBODY/pair_vashishta.h
+++ b/src/MANYBODY/pair_vashishta.h
@@ -55,8 +55,7 @@ class PairVashishta : public Pair {
   int maxparam;                 // max # of parameter sets
   Param *params;                // parameter set for an I-J-K interaction
   double r0max;                 // largest value of r0
-  int sizeshort;                // size of short neighbor list array
-  int numshort;                 // current count of neighbors in short list
+  int maxshort;                 // size of short neighbor list array
   int *neighshort;              // short neighbor list array
 
   void allocate();

--- a/src/MANYBODY/pair_vashishta_table.cpp
+++ b/src/MANYBODY/pair_vashishta_table.cpp
@@ -107,7 +107,7 @@ void PairVashishtaTable::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > maxshort) {
+        if (numshort >= maxshort) {
           maxshort += maxshort/2;
           memory->grow(neighshort,maxshort,"pair:neighshort");
         }

--- a/src/MANYBODY/pair_vashishta_table.cpp
+++ b/src/MANYBODY/pair_vashishta_table.cpp
@@ -94,7 +94,7 @@ void PairVashishtaTable::compute(int eflag, int vflag)
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
-    numshort = 0;
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
@@ -107,9 +107,9 @@ void PairVashishtaTable::compute(int eflag, int vflag)
 
       if (rsq < cutshortsq) {
         neighshort[numshort++] = j;
-        if (numshort > sizeshort) {
-          sizeshort += sizeshort/2;
-          memory->grow(neighshort,sizeshort,"pair:neighshort");
+        if (numshort > maxshort) {
+          maxshort += maxshort/2;
+          memory->grow(neighshort,maxshort,"pair:neighshort");
         }
       }
 

--- a/src/MANYBODY/pair_vashishta_table.cpp
+++ b/src/MANYBODY/pair_vashishta_table.cpp
@@ -80,6 +80,8 @@ void PairVashishtaTable::compute(int eflag, int vflag)
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
 
+  double fxtmp,fytmp,fztmp;
+
   // loop over full neighbor list of my atoms
 
   for (ii = 0; ii < inum; ii++) {
@@ -89,6 +91,7 @@ void PairVashishtaTable::compute(int eflag, int vflag)
     xtmp = x[i][0];
     ytmp = x[i][1];
     ztmp = x[i][2];
+    fxtmp = fytmp = fztmp = 0.0;
 
     // two-body interactions, skip half of them
 
@@ -126,13 +129,13 @@ void PairVashishtaTable::compute(int eflag, int vflag)
 
       jtype = map[type[j]];
       ijparam = elem2param[itype][jtype][jtype];
-      if (rsq > params[ijparam].cutsq) continue;
+      if (rsq >= params[ijparam].cutsq) continue;
 
       twobody_table(params[ijparam],rsq,fpair,eflag,evdwl);
 
-      f[i][0] += delx*fpair;
-      f[i][1] += dely*fpair;
-      f[i][2] += delz*fpair;
+      fxtmp += delx*fpair;
+      fytmp += dely*fpair;
+      fztmp += delz*fpair;
       f[j][0] -= delx*fpair;
       f[j][1] -= dely*fpair;
       f[j][2] -= delz*fpair;
@@ -153,6 +156,9 @@ void PairVashishtaTable::compute(int eflag, int vflag)
       rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
       if (rsq1 >= params[ijparam].cutsq2) continue;
 
+      double fjxtmp,fjytmp,fjztmp;
+      fjxtmp = fjytmp = fjztmp = 0.0;
+
       for (kk = jj+1; kk < numshort; kk++) {
         k = neighshort[kk];
         ktype = map[type[k]];
@@ -168,19 +174,25 @@ void PairVashishtaTable::compute(int eflag, int vflag)
         threebody(&params[ijparam],&params[ikparam],&params[ijkparam],
                   rsq1,rsq2,delr1,delr2,fj,fk,eflag,evdwl);
 
-        f[i][0] -= fj[0] + fk[0];
-        f[i][1] -= fj[1] + fk[1];
-        f[i][2] -= fj[2] + fk[2];
-        f[j][0] += fj[0];
-        f[j][1] += fj[1];
-        f[j][2] += fj[2];
+        fxtmp -= fj[0] + fk[0];
+        fytmp -= fj[1] + fk[1];
+        fztmp -= fj[2] + fk[2];
+        fjxtmp += fj[0];
+        fjytmp += fj[1];
+        fjztmp += fj[2];
         f[k][0] += fk[0];
         f[k][1] += fk[1];
         f[k][2] += fk[2];
 
         if (evflag) ev_tally3(i,j,k,evdwl,0.0,fj,fk,delr1,delr2);
       }
+      f[j][0] += fjxtmp;
+      f[j][1] += fjytmp;
+      f[j][2] += fjztmp;
     }
+    f[i][0] += fxtmp;
+    f[i][1] += fytmp;
+    f[i][2] += fztmp;
   }
 
   if (vflag_fdotr) virial_fdotr_compute();

--- a/src/MANYBODY/pair_vashishta_table.h
+++ b/src/MANYBODY/pair_vashishta_table.h
@@ -39,11 +39,6 @@ class PairVashishtaTable : public PairVashishta {
   double ***forceTable;         // table of forces per element pair
   double ***potentialTable;     // table of potential energies
 
-  int neigh3BodyMax;            // max size of short neighborlist
-  int *neigh3BodyCount;         // # of neighbors in short range 
-                                // 3 particle forces neighbor list
-  int **neigh3Body;             // neighlist for short range 3 particle forces
-
   void twobody_table(const Param &, double, double &, int, double &);
   void setup_params();
   void create_tables();

--- a/src/USER-OMP/pair_sw_omp.cpp
+++ b/src/USER-OMP/pair_sw_omp.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "force.h"
+#include "memory.h"
 #include "neighbor.h"
 #include "neigh_list.h"
 
@@ -71,13 +72,13 @@ void PairSWOMP::compute(int eflag, int vflag)
 template <int EVFLAG, int EFLAG>
 void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
 {
-  int i,j,k,ii,jj,kk,jnum,jnumm1;
+  int i,j,k,ii,jj,kk,jnum,jnumm1,maxshort_thr;
   tagint itag,jtag;
   int itype,jtype,ktype,ijparam,ikparam,ijkparam;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,rsq1,rsq2;
   double delr1[3],delr2[3],fj[3],fk[3];
-  int *ilist,*jlist,*numneigh,**firstneigh;
+  int *ilist,*jlist,*numneigh,**firstneigh,*neighshort_thr;
 
   evdwl = 0.0;
 
@@ -86,10 +87,13 @@ void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
   const tagint * _noalias const tag = atom->tag;
   const int * _noalias const type = atom->type;
   const int nlocal = atom->nlocal;
+  const double cutshortsq = cutmax*cutmax;
 
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
+  maxshort_thr = maxshort;
+  memory->create(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
 
   double fxtmp,fytmp,fztmp;
 
@@ -109,12 +113,26 @@ void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
       j &= NEIGHMASK;
-      jtag = tag[j];
 
+      delx = xtmp - x[j].x;
+      dely = ytmp - x[j].y;
+      delz = ztmp - x[j].z;
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq < cutshortsq) {
+        neighshort_thr[numshort++] = j;
+        if (numshort > maxshort_thr) {
+          maxshort_thr += maxshort_thr/2;
+          memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
+        }
+      }
+
+      jtag = tag[j];
       if (itag > jtag) {
         if ((itag+jtag) % 2 == 0) continue;
       } else if (itag < jtag) {
@@ -126,12 +144,6 @@ void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
       }
 
       jtype = map[type[j]];
-
-      delx = xtmp - x[j].x;
-      dely = ytmp - x[j].y;
-      delz = ztmp - x[j].z;
-      rsq = delx*delx + dely*dely + delz*delz;
-
       ijparam = elem2param[itype][jtype][jtype];
       if (rsq >= params[ijparam].cutsq) continue;
 
@@ -148,11 +160,10 @@ void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
                                evdwl,0.0,fpair,delx,dely,delz,thr);
     }
 
-    jnumm1 = jnum - 1;
+    jnumm1 = numshort - 1;
 
     for (jj = 0; jj < jnumm1; jj++) {
-      j = jlist[jj];
-      j &= NEIGHMASK;
+      j = neighshort_thr[jj];
       jtype = map[type[j]];
       ijparam = elem2param[itype][jtype][jtype];
       delr1[0] = x[j].x - xtmp;
@@ -164,9 +175,8 @@ void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
       double fjxtmp,fjytmp,fjztmp;
       fjxtmp = fjytmp = fjztmp = 0.0;
 
-      for (kk = jj+1; kk < jnum; kk++) {
-        k = jlist[kk];
-        k &= NEIGHMASK;
+      for (kk = jj+1; kk < numshort; kk++) {
+        k = neighshort_thr[kk];
         ktype = map[type[k]];
         ikparam = elem2param[itype][ktype][ktype];
         ijkparam = elem2param[itype][jtype][ktype];
@@ -200,6 +210,7 @@ void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
     f[i].y += fytmp;
     f[i].z += fztmp;
   }
+  memory->destroy(neighshort_thr);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-OMP/pair_sw_omp.cpp
+++ b/src/USER-OMP/pair_sw_omp.cpp
@@ -126,7 +126,7 @@ void PairSWOMP::eval(int iifrom, int iito, ThrData * const thr)
 
       if (rsq < cutshortsq) {
         neighshort_thr[numshort++] = j;
-        if (numshort > maxshort_thr) {
+        if (numshort >= maxshort_thr) {
           maxshort_thr += maxshort_thr/2;
           memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
         }

--- a/src/USER-OMP/pair_tersoff_omp.cpp
+++ b/src/USER-OMP/pair_tersoff_omp.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "force.h"
+#include "memory.h"
 #include "neighbor.h"
 #include "neigh_list.h"
 
@@ -73,14 +74,14 @@ void PairTersoffOMP::compute(int eflag, int vflag)
 template <int EVFLAG, int EFLAG, int VFLAG_ATOM>
 void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
 {
-  int i,j,k,ii,jj,kk,jnum;
+  int i,j,k,ii,jj,kk,jnum,maxshort_thr;
   tagint itag,jtag;
   int itype,jtype,ktype,iparam_ij,iparam_ijk;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,rsq1,rsq2;
   double delr1[3],delr2[3],fi[3],fj[3],fk[3];
   double zeta_ij,prefactor;
-  int *ilist,*jlist,*numneigh,**firstneigh;
+  int *ilist,*jlist,*numneigh,**firstneigh,*neighshort_thr;
 
   evdwl = 0.0;
 
@@ -89,10 +90,13 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
   const tagint * _noalias const tag = atom->tag;
   const int * _noalias const type = atom->type;
   const int nlocal = atom->nlocal;
+  const double cutshortsq = cutmax*cutmax;
 
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
+  maxshort_thr = maxshort;
+  memory->create(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
 
   double fxtmp,fytmp,fztmp;
 
@@ -112,12 +116,26 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
       j &= NEIGHMASK;
-      jtag = tag[j];
 
+      delx = xtmp - x[j].x;
+      dely = ytmp - x[j].y;
+      delz = ztmp - x[j].z;
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq < cutshortsq) {
+        neighshort_thr[numshort++] = j;
+        if (numshort > maxshort_thr) {
+          maxshort_thr += maxshort_thr/2;
+          memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
+        }
+      }
+
+      jtag = tag[j];
       if (itag > jtag) {
         if ((itag+jtag) % 2 == 0) continue;
       } else if (itag < jtag) {
@@ -129,14 +147,8 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
       }
 
       jtype = map[type[j]];
-
-      delx = xtmp - x[j].x;
-      dely = ytmp - x[j].y;
-      delz = ztmp - x[j].z;
-      rsq = delx*delx + dely*dely + delz*delz;
-
       iparam_ij = elem2param[itype][jtype][jtype];
-      if (rsq > params[iparam_ij].cutsq) continue;
+      if (rsq >= params[iparam_ij].cutsq) continue;
 
       repulsive(&params[iparam_ij],rsq,fpair,EFLAG,evdwl);
 
@@ -155,9 +167,8 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
     // skip immediately if I-J is not within cutoff
     double fjxtmp,fjytmp,fjztmp;
 
-    for (jj = 0; jj < jnum; jj++) {
-      j = jlist[jj];
-      j &= NEIGHMASK;
+    for (jj = 0; jj < numshort; jj++) {
+      j = neighshort_thr[jj];
       jtype = map[type[j]];
       iparam_ij = elem2param[itype][jtype][jtype];
 
@@ -165,17 +176,16 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
       delr1[1] = x[j].y - ytmp;
       delr1[2] = x[j].z - ztmp;
       rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
-      if (rsq1 > params[iparam_ij].cutsq) continue;
+      if (rsq1 >= params[iparam_ij].cutsq) continue;
 
       // accumulate bondorder zeta for each i-j interaction via loop over k
 
       fjxtmp = fjytmp = fjztmp = 0.0;
       zeta_ij = 0.0;
 
-      for (kk = 0; kk < jnum; kk++) {
+      for (kk = 0; kk < numshort; kk++) {
         if (jj == kk) continue;
-        k = jlist[kk];
-        k &= NEIGHMASK;
+        k = neighshort_thr[kk];
         ktype = map[type[k]];
         iparam_ijk = elem2param[itype][jtype][ktype];
 
@@ -183,7 +193,7 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
         delr2[1] = x[k].y - ytmp;
         delr2[2] = x[k].z - ztmp;
         rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
-        if (rsq2 > params[iparam_ijk].cutsq) continue;
+        if (rsq2 >= params[iparam_ijk].cutsq) continue;
 
         zeta_ij += zeta(&params[iparam_ijk],rsq1,rsq2,delr1,delr2);
       }
@@ -204,10 +214,9 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
 
       // attractive term via loop over k
 
-      for (kk = 0; kk < jnum; kk++) {
+      for (kk = 0; kk < numshort; kk++) {
         if (jj == kk) continue;
-        k = jlist[kk];
-        k &= NEIGHMASK;
+        k = neighshort_thr[kk];
         ktype = map[type[k]];
         iparam_ijk = elem2param[itype][jtype][ktype];
 
@@ -215,7 +224,7 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
         delr2[1] = x[k].y - ytmp;
         delr2[2] = x[k].z - ztmp;
         rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
-        if (rsq2 > params[iparam_ijk].cutsq) continue;
+        if (rsq2 >= params[iparam_ijk].cutsq) continue;
 
         attractive(&params[iparam_ijk],prefactor,
                    rsq1,rsq2,delr1,delr2,fi,fj,fk);
@@ -240,6 +249,7 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
     f[i].y += fytmp;
     f[i].z += fztmp;
   }
+  memory->destroy(neighshort_thr);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-OMP/pair_tersoff_omp.cpp
+++ b/src/USER-OMP/pair_tersoff_omp.cpp
@@ -129,7 +129,7 @@ void PairTersoffOMP::eval(int iifrom, int iito, ThrData * const thr)
 
       if (rsq < cutshortsq) {
         neighshort_thr[numshort++] = j;
-        if (numshort > maxshort_thr) {
+        if (numshort >= maxshort_thr) {
           maxshort_thr += maxshort_thr/2;
           memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
         }

--- a/src/USER-OMP/pair_vashishta_omp.cpp
+++ b/src/USER-OMP/pair_vashishta_omp.cpp
@@ -126,7 +126,7 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
 
       if (rsq < cutshortsq) {
         neighshort_thr[numshort++] = j;
-        if (numshort > maxshort_thr) {
+        if (numshort >= maxshort_thr) {
           maxshort_thr += maxshort_thr/2;
           memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
         }

--- a/src/USER-OMP/pair_vashishta_omp.cpp
+++ b/src/USER-OMP/pair_vashishta_omp.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "force.h"
+#include "memory.h"
 #include "neighbor.h"
 #include "neigh_list.h"
 
@@ -71,13 +72,13 @@ void PairVashishtaOMP::compute(int eflag, int vflag)
 template <int EVFLAG, int EFLAG>
 void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
 {
-  int i,j,k,ii,jj,kk,jnum,jnumm1;
+  int i,j,k,ii,jj,kk,jnum,jnumm1,maxshort_thr;
   tagint itag,jtag;
   int itype,jtype,ktype,ijparam,ikparam,ijkparam;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,rsq1,rsq2;
   double delr1[3],delr2[3],fj[3],fk[3];
-  int *ilist,*jlist,*numneigh,**firstneigh;
+  int *ilist,*jlist,*numneigh,**firstneigh,*neighshort_thr;
 
   evdwl = 0.0;
 
@@ -86,10 +87,13 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
   const tagint * _noalias const tag = atom->tag;
   const int * _noalias const type = atom->type;
   const int nlocal = atom->nlocal;
+  const double cutshortsq = r0max*r0max;
 
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
+  maxshort_thr = maxshort;
+  memory->create(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
 
   double fxtmp,fytmp,fztmp;
 
@@ -109,12 +113,26 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
       j &= NEIGHMASK;
-      jtag = tag[j];
 
+      delx = xtmp - x[j].x;
+      dely = ytmp - x[j].y;
+      delz = ztmp - x[j].z;
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq < cutshortsq) {
+        neighshort_thr[numshort++] = j;
+        if (numshort > maxshort_thr) {
+          maxshort_thr += maxshort_thr/2;
+          memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
+        }
+      }
+
+      jtag = tag[j];
       if (itag > jtag) {
         if ((itag+jtag) % 2 == 0) continue;
       } else if (itag < jtag) {
@@ -126,12 +144,6 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
       }
 
       jtype = map[type[j]];
-
-      delx = xtmp - x[j].x;
-      dely = ytmp - x[j].y;
-      delz = ztmp - x[j].z;
-      rsq = delx*delx + dely*dely + delz*delz;
-
       ijparam = elem2param[itype][jtype][jtype];
       if (rsq >= params[ijparam].cutsq) continue;
 
@@ -148,11 +160,10 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
                                evdwl,0.0,fpair,delx,dely,delz,thr);
     }
 
-    jnumm1 = jnum - 1;
+    jnumm1 = numshort - 1;
 
     for (jj = 0; jj < jnumm1; jj++) {
-      j = jlist[jj];
-      j &= NEIGHMASK;
+      j = neighshort_thr[jj];
       jtype = map[type[j]];
       ijparam = elem2param[itype][jtype][jtype];
       delr1[0] = x[j].x - xtmp;
@@ -164,9 +175,8 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
       double fjxtmp,fjytmp,fjztmp;
       fjxtmp = fjytmp = fjztmp = 0.0;
 
-      for (kk = jj+1; kk < jnum; kk++) {
-        k = jlist[kk];
-        k &= NEIGHMASK;
+      for (kk = jj+1; kk < numshort; kk++) {
+        k = neighshort_thr[kk];
         ktype = map[type[k]];
         ikparam = elem2param[itype][ktype][ktype];
         ijkparam = elem2param[itype][jtype][ktype];
@@ -200,6 +210,7 @@ void PairVashishtaOMP::eval(int iifrom, int iito, ThrData * const thr)
     f[i].y += fytmp;
     f[i].z += fztmp;
   }
+  memory->destroy(neighshort_thr);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-OMP/pair_vashishta_table_omp.cpp
+++ b/src/USER-OMP/pair_vashishta_table_omp.cpp
@@ -126,7 +126,7 @@ void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
 
       if (rsq < cutshortsq) {
         neighshort_thr[numshort++] = j;
-        if (numshort > maxshort_thr) {
+        if (numshort >= maxshort_thr) {
           maxshort_thr += maxshort_thr/2;
           memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
         }

--- a/src/USER-OMP/pair_vashishta_table_omp.cpp
+++ b/src/USER-OMP/pair_vashishta_table_omp.cpp
@@ -41,20 +41,6 @@ void PairVashishtaTableOMP::compute(int eflag, int vflag)
     ev_setup(eflag,vflag);
   } else evflag = vflag_fdotr = 0;
 
-  // reallocate 3-body neighbor list if necessary
-  // NOTE: using 1000 is inefficient
-  //       could make this a LAMMPS paged neighbor list
-
-  if (atom->nlocal > neigh3BodyMax) {
-    neigh3BodyMax = atom->nmax;
-    memory->destroy(neigh3BodyCount);
-    memory->destroy(neigh3Body);
-    memory->create(neigh3BodyCount,neigh3BodyMax,
-                   "pair:vashishta:neigh3BodyCount");
-    memory->create(neigh3Body,neigh3BodyMax,1000,
-                   "pair:vashishta:neigh3Body");
-  }
-
   const int nall = atom->nlocal + atom->nghost;
   const int nthreads = comm->nthreads;
   const int inum = list->inum;
@@ -86,13 +72,13 @@ void PairVashishtaTableOMP::compute(int eflag, int vflag)
 template <int EVFLAG, int EFLAG>
 void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
 {
-  int i,j,k,ii,jj,kk,jnum,jnumm1;
+  int i,j,k,ii,jj,kk,jnum,jnumm1,maxshort_thr;
   tagint itag,jtag;
   int itype,jtype,ktype,ijparam,ikparam,ijkparam;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,rsq1,rsq2;
   double delr1[3],delr2[3],fj[3],fk[3];
-  int *ilist,*jlist,*numneigh,**firstneigh;
+  int *ilist,*jlist,*numneigh,**firstneigh,*neighshort_thr;
 
   evdwl = 0.0;
 
@@ -101,13 +87,16 @@ void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
   const tagint * _noalias const tag = atom->tag;
   const int * _noalias const type = atom->type;
   const int nlocal = atom->nlocal;
+  const double cutshortsq = r0max*r0max;
 
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
+  maxshort_thr = maxshort;
+  memory->create(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
 
   double fxtmp,fytmp,fztmp;
-  
+
   // loop over full neighbor list of my atoms
 
   for (ii = iifrom; ii < iito; ++ii) {
@@ -120,35 +109,30 @@ void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
     ztmp = x[i].z;
     fxtmp = fytmp = fztmp = 0.0;
 
-    // reset the 3-body neighbor list
-
-    neigh3BodyCount[i] = 0;
-
     // two-body interactions, skip half of them
 
     jlist = firstneigh[i];
     jnum = numneigh[i];
+    int numshort = 0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
       j &= NEIGHMASK;
-      jtag = tag[j];
-
-      jtype = map[type[j]];
 
       delx = xtmp - x[j].x;
       dely = ytmp - x[j].y;
       delz = ztmp - x[j].z;
       rsq = delx*delx + dely*dely + delz*delz;
-      ijparam = elem2param[itype][jtype][jtype];
 
-      if (rsq <= params[ijparam].cutsq2) {
-        neigh3Body[i][neigh3BodyCount[i]] = j;
-        neigh3BodyCount[i]++;
+      if (rsq < cutshortsq) {
+        neighshort_thr[numshort++] = j;
+        if (numshort > maxshort_thr) {
+          maxshort_thr += maxshort_thr/2;
+          memory->grow(neighshort_thr,maxshort_thr,"pair_thr:neighshort_thr");
+        }
       }
 
-      if (rsq >= params[ijparam].cutsq) continue;
-
+      jtag = tag[j];
       if (itag > jtag) {
         if ((itag+jtag) % 2 == 0) continue;
       } else if (itag < jtag) {
@@ -158,6 +142,10 @@ void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
         if (x[j].z == ztmp && x[j].y < ytmp) continue;
         if (x[j].z == ztmp && x[j].y == ytmp && x[j].x < xtmp) continue;
       }
+
+      jtype = map[type[j]];
+      ijparam = elem2param[itype][jtype][jtype];
+      if (rsq >= params[ijparam].cutsq) continue;
 
       twobody_table(params[ijparam],rsq,fpair,EFLAG,evdwl);
 
@@ -172,13 +160,10 @@ void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
                                evdwl,0.0,fpair,delx,dely,delz,thr);
     }
 
-    jlist = neigh3Body[i];
-    jnum = neigh3BodyCount[i];
-    jnumm1 = jnum - 1;
+    jnumm1 = numshort - 1;
 
     for (jj = 0; jj < jnumm1; jj++) {
-      j = jlist[jj];
-      j &= NEIGHMASK;
+      j = neighshort_thr[jj];
       jtype = map[type[j]];
       ijparam = elem2param[itype][jtype][jtype];
       delr1[0] = x[j].x - xtmp;
@@ -190,9 +175,8 @@ void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
       double fjxtmp,fjytmp,fjztmp;
       fjxtmp = fjytmp = fjztmp = 0.0;
 
-      for (kk = jj+1; kk < jnum; kk++) {
-        k = jlist[kk];
-        k &= NEIGHMASK;
+      for (kk = jj+1; kk < numshort; kk++) {
+        k = neighshort_thr[kk];
         ktype = map[type[k]];
         ikparam = elem2param[itype][ktype][ktype];
         ijkparam = elem2param[itype][jtype][ktype];
@@ -226,6 +210,7 @@ void PairVashishtaTableOMP::eval(int iifrom, int iito, ThrData * const thr)
     f[i].y += fytmp;
     f[i].z += fztmp;
   }
+  memory->destroy(neighshort_thr);
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
this implements short neighbor lists for the following manybody pair styles:
- sw, sw/omp
- tersoff, tersoff/omp  (and variants like /mod or /zbl, which use the some compute method)
- vashishta, vashishta/table, vashishta/omp, vashishta/table/omp

this closes #179 and fixes #180
