### PR TITLE
remove the misleading "(which it is by default)" from several doc files

### DIFF
--- a/doc/src/angle_charmm.txt
+++ b/doc/src/angle_charmm.txt
@@ -74,7 +74,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/angle_cosine.txt
+++ b/doc/src/angle_cosine.txt
@@ -61,7 +61,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/angle_cosine_delta.txt
+++ b/doc/src/angle_cosine_delta.txt
@@ -66,7 +66,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/angle_cosine_periodic.txt
+++ b/doc/src/angle_cosine_periodic.txt
@@ -74,7 +74,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/angle_cosine_squared.txt
+++ b/doc/src/angle_cosine_squared.txt
@@ -66,7 +66,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/angle_harmonic.txt
+++ b/doc/src/angle_harmonic.txt
@@ -65,11 +65,11 @@ more instructions on how to use the accelerated styles effectively.
 
 :line
 
-[Restrictions:] none
+[Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
-LAMMPS"_Section_start.html#start_3 section for more info on packages.
+MOLECULE package.  See the "Making LAMMPS"_Section_start.html#start_3
+section for more info on packages.
 
 [Related commands:]
 

--- a/doc/src/angle_hybrid.txt
+++ b/doc/src/angle_hybrid.txt
@@ -76,7 +76,7 @@ for specific angle types.
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 Unlike other angle styles, the hybrid angle style does not store angle

--- a/doc/src/angle_table.txt
+++ b/doc/src/angle_table.txt
@@ -147,7 +147,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/bond_fene.txt
+++ b/doc/src/bond_fene.txt
@@ -70,7 +70,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 You typically should specify "special_bonds fene"_special_bonds.html

--- a/doc/src/bond_fene_expand.txt
+++ b/doc/src/bond_fene_expand.txt
@@ -73,7 +73,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 You typically should specify "special_bonds fene"_special_bonds.html

--- a/doc/src/bond_harmonic.txt
+++ b/doc/src/bond_harmonic.txt
@@ -65,7 +65,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/bond_hybrid.txt
+++ b/doc/src/bond_hybrid.txt
@@ -59,7 +59,7 @@ bond types.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 Unlike other bond styles, the hybrid bond style does not store bond

--- a/doc/src/bond_morse.txt
+++ b/doc/src/bond_morse.txt
@@ -64,7 +64,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/bond_nonlinear.txt
+++ b/doc/src/bond_nonlinear.txt
@@ -64,7 +64,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/bond_quartic.txt
+++ b/doc/src/bond_quartic.txt
@@ -99,7 +99,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 The {quartic} style requires that "special_bonds"_special_bonds.html

--- a/doc/src/bond_table.txt
+++ b/doc/src/bond_table.txt
@@ -144,7 +144,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/dihedral_charmm.txt
+++ b/doc/src/dihedral_charmm.txt
@@ -109,7 +109,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/dihedral_harmonic.txt
+++ b/doc/src/dihedral_harmonic.txt
@@ -76,7 +76,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/dihedral_helix.txt
+++ b/doc/src/dihedral_helix.txt
@@ -69,7 +69,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/dihedral_hybrid.txt
+++ b/doc/src/dihedral_hybrid.txt
@@ -77,7 +77,7 @@ for specific dihedral types.
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 Unlike other dihedral styles, the hybrid dihedral style does not store

--- a/doc/src/dihedral_multi_harmonic.txt
+++ b/doc/src/dihedral_multi_harmonic.txt
@@ -63,7 +63,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/dihedral_opls.txt
+++ b/doc/src/dihedral_opls.txt
@@ -71,7 +71,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/fix_cmap.txt
+++ b/doc/src/fix_cmap.txt
@@ -113,7 +113,7 @@ quantity being minimized), you MUST enable the
 [Restrictions:]
 
 This fix can only be used if LAMMPS was built with the MOLECULE
-package (which it is by default).  See the "Making
+package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/improper_cvff.txt
+++ b/doc/src/improper_cvff.txt
@@ -77,7 +77,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This improper style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/improper_harmonic.txt
+++ b/doc/src/improper_harmonic.txt
@@ -81,7 +81,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This improper style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/improper_hybrid.txt
+++ b/doc/src/improper_hybrid.txt
@@ -55,7 +55,7 @@ types.
 [Restrictions:]
 
 This improper style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 Unlike other improper styles, the hybrid improper style does not store

--- a/doc/src/improper_umbrella.txt
+++ b/doc/src/improper_umbrella.txt
@@ -74,7 +74,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This improper style can only be used if LAMMPS was built with the
-MOLECULE package (which it is by default).  See the "Making
+MOLECULE package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/pair_adp.txt
+++ b/doc/src/pair_adp.txt
@@ -168,7 +168,7 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 This pair style is part of the MANYBODY package.  It is only enabled
-if LAMMPS was built with that package (which it is by default).
+if LAMMPS was built with that package.
 
 [Related commands:]
 

--- a/doc/src/pair_airebo.txt
+++ b/doc/src/pair_airebo.txt
@@ -203,9 +203,8 @@ These pair styles can only be used via the {pair} keyword of the
 [Restrictions:]
 
 These pair styles are part of the MANYBODY package.  They are only
-enabled if LAMMPS was built with that package (which it is by
-default).  See the "Making LAMMPS"_Section_start.html#start_3 section
-for more info.
+enabled if LAMMPS was built with that package.  See the
+"Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 These pair potentials require the "newton"_newton.html setting to be
 "on" for pair interactions.

--- a/doc/src/pair_bop.txt
+++ b/doc/src/pair_bop.txt
@@ -382,7 +382,7 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 These pair styles are part of the MANYBODY package.  They are only
-enabled if LAMMPS was built with that package (which it is by default).
+enabled if LAMMPS was built with that package.
 See the "Making LAMMPS"_Section_start.html#start_3 section for more
 info.
 

--- a/doc/src/pair_born.txt
+++ b/doc/src/pair_born.txt
@@ -174,9 +174,8 @@ respa"_run_style.html command.  They do not support the {inner},
 [Restrictions:]
 
 The {born/coul/long} style is part of the KSPACE package.  It is only
-enabled if LAMMPS was built with that package (which it is by
-default).  See the "Making LAMMPS"_Section_start.html#start_3 section
-for more info.
+enabled if LAMMPS was built with that package.  See the
+"Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 

--- a/doc/src/pair_buck.txt
+++ b/doc/src/pair_buck.txt
@@ -186,9 +186,8 @@ respa"_run_style.html command.  They do not support the {inner},
 
 The {buck/coul/long} style is part of the KSPACE package.  The
 {buck/coul/long/cs} style is part of the CORESHELL package.  They are
-only enabled if LAMMPS was built with that package (which it is by
-default).  See the "Making LAMMPS"_Section_start.html#start_3 section
-for more info.
+only enabled if LAMMPS was built with that package.  See the
+"Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 

--- a/doc/src/pair_comb.txt
+++ b/doc/src/pair_comb.txt
@@ -156,7 +156,7 @@ These pair styles can only be used via the {pair} keyword of the
 [Restrictions:]
 
 These pair styles are part of the MANYBODY package.  It is only enabled
-if LAMMPS was built with that package (which it is by default).  See
+if LAMMPS was built with that package.  See
 the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 These pair styles requires the "newton"_newton.html setting to be "on"

--- a/doc/src/pair_coul.txt
+++ b/doc/src/pair_coul.txt
@@ -313,9 +313,8 @@ This pair style can only be used via the {pair} keyword of the
 
 The {coul/long}, {coul/msm} and {tip4p/long} styles are part of the
 KSPACE package.  The {coul/long/cs} style is part of the CORESHELL
-package.  They are only enabled if LAMMPS was built with that package
-(which it is by default).  See the "Making
-LAMMPS"_Section_start.html#start_3 section for more info.
+package.  They are only enabled if LAMMPS was built with that package.
+See the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 

--- a/doc/src/pair_eam.txt
+++ b/doc/src/pair_eam.txt
@@ -412,9 +412,8 @@ The eam pair styles can only be used via the {pair} keyword of the
 [Restrictions:]
 
 All of these styles except the {eam/cd} style are part of the MANYBODY
-package.  They are only enabled if LAMMPS was built with that package
-(which it is by default).  See the "Making
-LAMMPS"_Section_start.html#start_3 section for more info.
+package.  They are only enabled if LAMMPS was built with that package.
+See the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 The {eam/cd} style is part of the USER-MISC package and also requires
 the MANYBODY package.  It is only enabled if LAMMPS was built with

--- a/doc/src/pair_eim.txt
+++ b/doc/src/pair_eim.txt
@@ -159,7 +159,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This style is part of the MANYBODY package.  It is only enabled if
-LAMMPS was built with that package (which it is by default).
+LAMMPS was built with that package.
 
 [Related commands:]
 

--- a/doc/src/pair_lcbop.txt
+++ b/doc/src/pair_lcbop.txt
@@ -72,7 +72,7 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 This pair styles is part of the MANYBODY package.  It is only enabled
-if LAMMPS was built with that package (which it is by default).  See
+if LAMMPS was built with that package.  See
 the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 This pair potential requires the "newton"_newton.html setting to be

--- a/doc/src/pair_nb3b_harmonic.txt
+++ b/doc/src/pair_nb3b_harmonic.txt
@@ -113,7 +113,7 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 This pair style can only be used if LAMMPS was built with the MANYBODY
-package (which it is by default).  See the "Making
+package.  See the "Making
 LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 [Related commands:]

--- a/doc/src/pair_polymorphic.txt
+++ b/doc/src/pair_polymorphic.txt
@@ -191,7 +191,7 @@ input script. If using read_data, atomic masses must be defined in the
 atomic structure data file.
 
 This pair style is part of the MANYBODY package. It is only enabled if
-LAMMPS was built with that package (which it is by default). See the
+LAMMPS was built with that package. See the
 "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 This pair potential requires the "newtion"_newton.html setting to be

--- a/doc/src/pair_sw.txt
+++ b/doc/src/pair_sw.txt
@@ -192,7 +192,7 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 This pair style is part of the MANYBODY package.  It is only enabled
-if LAMMPS was built with that package (which it is by default).  See
+if LAMMPS was built with that package.  See
 the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 This pair style requires the "newton"_newton.html setting to be "on"

--- a/doc/src/pair_tersoff.txt
+++ b/doc/src/pair_tersoff.txt
@@ -222,7 +222,7 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 This pair style is part of the MANYBODY package.  It is only enabled
-if LAMMPS was built with that package (which it is by default).  See
+if LAMMPS was built with that package.  See
 the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 This pair style requires the "newton"_newton.html setting to be "on"

--- a/doc/src/pair_tersoff_mod.txt
+++ b/doc/src/pair_tersoff_mod.txt
@@ -156,7 +156,7 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 This pair style is part of the MANYBODY package.  It is only enabled
-if LAMMPS was built with that package (which it is by default).  See
+if LAMMPS was built with that package.  See
 the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 This pair style requires the "newton"_newton.html setting to be "on"

--- a/doc/src/pair_tersoff_zbl.txt
+++ b/doc/src/pair_tersoff_zbl.txt
@@ -232,7 +232,7 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 This pair style is part of the MANYBODY package.  It is only enabled
-if LAMMPS was built with that package (which it is by default).  See
+if LAMMPS was built with that package.  See
 the "Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 This pair style requires the "newton"_newton.html setting to be "on"

--- a/doc/src/pair_vashishta.txt
+++ b/doc/src/pair_vashishta.txt
@@ -212,9 +212,8 @@ This pair style can only be used via the {pair} keyword of the
 [Restrictions:]
 
 These pair style are part of the MANYBODY package.  They is only
-enabled if LAMMPS was built with that package (which it is by
-default).  See the "Making LAMMPS"_Section_start.html#start_3 section
-for more info.
+enabled if LAMMPS was built with that package.  See the
+"Making LAMMPS"_Section_start.html#start_3 section for more info.
 
 These pair styles requires the "newton"_newton.html setting to be "on"
 for pair interactions.


### PR DESCRIPTION
This statement is only (mostly) true for people that download LAMMPS tarballs.
Rather than explaining the difference, it is better to just not mention this at all.

if anything, it would be better to refer to a paragraph somewhere explaining how to check for availability of styles in executables (via -help/-h) and in the source folder via `make ps`.