### PR TITLE
Initialized pointers in src folder

### DIFF
--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -51,7 +51,10 @@ enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 /* ---------------------------------------------------------------------- */
 
-CommBrick::CommBrick(LAMMPS *lmp) : Comm(lmp)
+CommBrick::CommBrick(LAMMPS *lmp) : Comm(lmp),
+  sendnum(NULL), recvnum(NULL), sendproc(NULL), recvproc(NULL), size_forward_recv(NULL),
+  size_reverse_send(NULL), size_reverse_recv(NULL), slablo(NULL), slabhi(NULL), multilo(NULL), multihi(NULL),
+  cutghostmulti(NULL), pbc_flag(NULL), pbc(NULL), firstrecv(NULL), sendlist(NULL), maxsendlist(NULL), buf_send(NULL), buf_recv(NULL)
 {
   style = 0;
   layout = LAYOUT_UNIFORM;

--- a/src/dump_cfg.cpp
+++ b/src/dump_cfg.cpp
@@ -42,7 +42,7 @@ enum{INT,DOUBLE,STRING,BIGINT};   // same as in DumpCustom
 /* ---------------------------------------------------------------------- */
 
 DumpCFG::DumpCFG(LAMMPS *lmp, int narg, char **arg) :
-  DumpCustom(lmp, narg, arg)
+  DumpCustom(lmp, narg, arg), auxname(NULL)
 {
   multifile_override = 0;
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -54,7 +54,12 @@ enum{INT,DOUBLE,STRING,BIGINT};    // same as in DumpCFG
 /* ---------------------------------------------------------------------- */
 
 DumpCustom::DumpCustom(LAMMPS *lmp, int narg, char **arg) :
-  Dump(lmp, narg, arg)
+  Dump(lmp, narg, arg),
+  idregion(NULL), thresh_array(NULL), thresh_op(NULL), thresh_value(NULL), thresh_last(NULL),
+  thresh_fix(NULL), thresh_fixID(NULL), thresh_first(NULL), earg(NULL), vtype(NULL), vformat(NULL),
+  columns(NULL), choose(NULL), dchoose(NULL), clist(NULL), field2index(NULL), argindex(NULL),
+  id_compute(NULL), compute(NULL), id_fix(NULL), fix(NULL), id_variable(NULL), variable(NULL),
+  vbuf(NULL), id_custom(NULL), flag_custom(NULL), typenames(NULL), pack_choice(NULL)
 {
   if (narg == 5) error->all(FLERR,"No dump custom arguments specified");
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -55,10 +55,11 @@ enum{INT,DOUBLE,STRING,BIGINT};    // same as in DumpCFG
 
 DumpCustom::DumpCustom(LAMMPS *lmp, int narg, char **arg) :
   Dump(lmp, narg, arg),
-  idregion(NULL), thresh_array(NULL), thresh_op(NULL), thresh_value(NULL), thresh_last(NULL),
-  thresh_fix(NULL), thresh_fixID(NULL), thresh_first(NULL), earg(NULL), vtype(NULL), vformat(NULL),
-  columns(NULL), choose(NULL), dchoose(NULL), clist(NULL), field2index(NULL), argindex(NULL),
-  id_compute(NULL), compute(NULL), id_fix(NULL), fix(NULL), id_variable(NULL), variable(NULL),
+  idregion(NULL), thresh_array(NULL), thresh_op(NULL), thresh_value(NULL),
+  thresh_last(NULL), thresh_fix(NULL), thresh_fixID(NULL), thresh_first(NULL),
+  earg(NULL), vtype(NULL), vformat(NULL), columns(NULL), choose(NULL),
+  dchoose(NULL), clist(NULL), field2index(NULL), argindex(NULL), id_compute(NULL),
+  compute(NULL), id_fix(NULL), fix(NULL), id_variable(NULL), variable(NULL),
   vbuf(NULL), id_custom(NULL), flag_custom(NULL), typenames(NULL), pack_choice(NULL)
 {
   if (narg == 5) error->all(FLERR,"No dump custom arguments specified");

--- a/src/dump_dcd.cpp
+++ b/src/dump_dcd.cpp
@@ -52,7 +52,8 @@ static inline void fwrite_int32(FILE* fd, uint32_t i)
 
 /* ---------------------------------------------------------------------- */
 
-DumpDCD::DumpDCD(LAMMPS *lmp, int narg, char **arg) : Dump(lmp, narg, arg)
+DumpDCD::DumpDCD(LAMMPS *lmp, int narg, char **arg) : Dump(lmp, narg, arg),
+  coords(NULL)
 {
   if (narg != 5) error->all(FLERR,"Illegal dump dcd command");
   if (binary || compressed || multifile || multiproc)

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -49,7 +49,9 @@ enum{NO,YES};
 /* ---------------------------------------------------------------------- */
 
 DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
-  DumpCustom(lmp, narg, arg)
+  DumpCustom(lmp, narg, arg), phistr(NULL), czstr(NULL), upzstr(NULL), perspstr(NULL), 
+  bdiamtype(NULL), bcolortype(NULL), avec_line(NULL), avec_tri(NULL), avec_body(NULL), 
+  fixptr(NULL), image(NULL), chooseghost(NULL), bufcopy(NULL)
 {
   if (binary || multiproc) error->all(FLERR,"Invalid dump image filename");
 

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -49,9 +49,12 @@ enum{NO,YES};
 /* ---------------------------------------------------------------------- */
 
 DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
-  DumpCustom(lmp, narg, arg), phistr(NULL), czstr(NULL), upzstr(NULL), perspstr(NULL), 
-  bdiamtype(NULL), bcolortype(NULL), avec_line(NULL), avec_tri(NULL), avec_body(NULL), 
-  fixptr(NULL), image(NULL), chooseghost(NULL), bufcopy(NULL)
+  DumpCustom(lmp, narg, arg), thetastr(NULL), phistr(NULL), cxstr(NULL), 
+  cystr(NULL), czstr(NULL), upxstr(NULL), upystr(NULL), upzstr(NULL), 
+  zoomstr(NULL), perspstr(NULL), diamtype(NULL), diamelement(NULL), 
+  bdiamtype(NULL), colortype(NULL), colorelement(NULL), bcolortype(NULL), 
+  avec_line(NULL), avec_tri(NULL), avec_body(NULL), fixptr(NULL), image(NULL), 
+  chooseghost(NULL), bufcopy(NULL)
 {
   if (binary || multiproc) error->all(FLERR,"Invalid dump image filename");
 

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -37,7 +37,10 @@ enum{INT,DOUBLE};
 /* ---------------------------------------------------------------------- */
 
 DumpLocal::DumpLocal(LAMMPS *lmp, int narg, char **arg) :
-  Dump(lmp, narg, arg)
+  Dump(lmp, narg, arg),
+  label(NULL), vtype(NULL), vformat(NULL), columns(NULL), field2index(NULL), 
+  argindex(NULL), id_compute(NULL), compute(NULL), id_fix(NULL), fix(NULL), 
+  pack_choice(NULL)
 {
   if (narg == 5) error->all(FLERR,"No dump local arguments specified");
 

--- a/src/dump_xyz.cpp
+++ b/src/dump_xyz.cpp
@@ -26,7 +26,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DumpXYZ::DumpXYZ(LAMMPS *lmp, int narg, char **arg) : Dump(lmp, narg, arg)
+DumpXYZ::DumpXYZ(LAMMPS *lmp, int narg, char **arg) : Dump(lmp, narg, arg),
+  typenames(NULL)
 {
   if (narg != 5) error->all(FLERR,"Illegal dump xyz command");
   if (binary || multiproc) error->all(FLERR,"Invalid dump xyz filename");

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -32,7 +32,8 @@ int Fix::instance_total = 0;
 /* ---------------------------------------------------------------------- */
 
 Fix::Fix(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp),
-id(NULL), style(NULL), eatom(NULL), vatom(NULL)
+id(NULL), style(NULL), extlist(NULL), vector_atom(NULL), array_atom(NULL),
+vector_local(NULL), array_local(NULL), eatom(NULL), vatom(NULL)
 {
   instance_me = instance_total++;
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -37,7 +37,16 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 Molecule::Molecule(LAMMPS *lmp, int narg, char **arg, int &index) :
-  Pointers(lmp)
+  Pointers(lmp), id(NULL), x(NULL), type(NULL), q(NULL), radius(NULL),
+  rmass(NULL), num_bond(NULL), bond_type(NULL), bond_atom(NULL),
+  num_angle(NULL), angle_type(NULL), angle_atom1(NULL), angle_atom2(NULL),
+  angle_atom3(NULL), num_dihedral(NULL), dihedral_type(NULL), dihedral_atom1(NULL),
+  dihedral_atom2(NULL), dihedral_atom3(NULL), dihedral_atom4(NULL), num_improper(NULL),
+  improper_type(NULL), improper_atom1(NULL), improper_atom2(NULL),
+  improper_atom3(NULL), improper_atom4(NULL), nspecial(NULL), special(NULL),
+  shake_flag(NULL), shake_atom(NULL), shake_type(NULL), avec_body(NULL), ibodyparams(NULL),
+  dbodyparams(NULL), dx(NULL), dxcom(NULL), dxbody(NULL), quat_external(NULL),
+  fp(NULL), count(NULL)
 {
   me = comm->me;
 

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -31,15 +31,12 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairHybrid::PairHybrid(LAMMPS *lmp) : Pair(lmp)
+PairHybrid::PairHybrid(LAMMPS *lmp) : Pair(lmp),
+  styles(NULL), keywords(NULL), multiple(NULL), nmap(NULL),
+  map(NULL), special_lj(NULL), special_coul(NULL)
 {
   nstyles = 0;
-  styles = NULL;
-  keywords = NULL;
-  multiple = NULL;
-  special_lj = NULL;
-  special_coul = NULL;
-
+  
   outerflag = 0;
   respaflag = 0;
 

--- a/src/random_mars.cpp
+++ b/src/random_mars.cpp
@@ -22,7 +22,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-RanMars::RanMars(LAMMPS *lmp, int seed) : Pointers(lmp)
+RanMars::RanMars(LAMMPS *lmp, int seed) : Pointers(lmp),
+  u(NULL)
 {
   int ij,kl,i,j,k,l,ii,jj,m;
   double s,t;

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -28,7 +28,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-Region::Region(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
+Region::Region(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp),
+  id(NULL), style(NULL), contact(NULL), list(NULL), xstr(NULL), ystr(NULL), zstr(NULL), tstr(NULL)
 {
   int n = strlen(arg[0]) + 1;
   id = new char[n];

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -30,7 +30,7 @@ enum{CONSTANT,VARIABLE};
 /* ---------------------------------------------------------------------- */
 
 RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
-  Region(lmp, narg, arg)
+  Region(lmp, narg, arg), rstr(NULL)
 {
   options(narg-8,&arg[8]);
 

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -23,8 +23,10 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
-  Region(lmp, narg, arg)
+  Region(lmp, narg, arg), idsub(NULL)
 {
+  nregion = 0;
+  
   if (narg < 5) error->all(FLERR,"Illegal region command");
   int n = force->inumeric(FLERR,arg[2]);
   if (n < 2) error->all(FLERR,"Illegal region command");

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -24,8 +24,10 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg)
+RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg),
+  idsub(NULL)
 {
+  nregion = 0;
   if (narg < 5) error->all(FLERR,"Illegal region command");
   int n = force->inumeric(FLERR,arg[2]);
   if (n < 2) error->all(FLERR,"Illegal region command");

--- a/src/respa.cpp
+++ b/src/respa.cpp
@@ -44,8 +44,10 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-Respa::Respa(LAMMPS *lmp, int narg, char **arg) : Integrate(lmp, narg, arg)
+Respa::Respa(LAMMPS *lmp, int narg, char **arg) : Integrate(lmp, narg, arg),
+step(NULL), loop(NULL), hybrid_level(NULL), hybrid_compute(NULL), newton(NULL), fix_respa(NULL)
 {
+  nhybrid_styles = 0;
   if (narg < 1) error->all(FLERR,"Illegal run_style respa command");
 
   nlevels = force->inumeric(FLERR,arg[0]);


### PR DESCRIPTION
This PR finalizes NULLing of pointers in all potentially dangerous files in src folder (make no-all).

Fixes first part of https://github.com/lammps/lammps/issues/143.