### PR TITLE
turn on -DLAMMPS_MEMALIGN=64 automatically when USER-INTEL is installed

### DIFF
--- a/src/MAKE/OPTIONS/Makefile.icc_mpich
+++ b/src/MAKE/OPTIONS/Makefile.icc_mpich
@@ -7,7 +7,7 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx -cxx=icc
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -restrict
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 

--- a/src/MAKE/OPTIONS/Makefile.icc_mpich_link
+++ b/src/MAKE/OPTIONS/Makefile.icc_mpich_link
@@ -7,7 +7,7 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		icc
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -restrict
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 

--- a/src/MAKE/OPTIONS/Makefile.icc_openmpi
+++ b/src/MAKE/OPTIONS/Makefile.icc_openmpi
@@ -8,7 +8,7 @@ SHELL = /bin/sh
 
 export OMPI_CXX = icc
 CC =		mpicxx
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -restrict
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 

--- a/src/MAKE/OPTIONS/Makefile.icc_openmpi_link
+++ b/src/MAKE/OPTIONS/Makefile.icc_openmpi_link
@@ -7,7 +7,7 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		icc
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -restrict
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 

--- a/src/MAKE/OPTIONS/Makefile.icc_serial
+++ b/src/MAKE/OPTIONS/Makefile.icc_serial
@@ -7,7 +7,7 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		icc
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -restrict
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 

--- a/src/USER-INTEL/intel_preprocess.h
+++ b/src/USER-INTEL/intel_preprocess.h
@@ -28,12 +28,10 @@
 #ifndef LMP_INTEL_PREPROCESS_H
 #define LMP_INTEL_PREPROCESS_H
 
-#ifndef LAMMPS_MEMALIGN
-#error Please set -DLAMMPS_MEMALIGN=64 in CCFLAGS for your LAMMPS makefile.
-#else
-#if (LAMMPS_MEMALIGN != 64)
-#error Please set -DLAMMPS_MEMALIGN=64 in CCFLAGS for your LAMMPS makefile.
-#endif
+// LAMMPS_MEMALIGN is set to 64 by default for -DLMP_USER_INTEL
+// so we only need to error out in case of a different alignment
+#if LAMMPS_MEMALIGN && (LAMMPS_MEMALIGN != 64)
+#error Please set -DLAMMPS_MEMALIGN=64 in CCFLAGS of your LAMMPS makefile for USER-INTEL package
 #endif
 
 #if defined(_OPENMP)

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -22,6 +22,10 @@
 #include "tbb/scalable_allocator.h"
 #endif
 
+#if defined(LMP_USER_INTEL) && !defined(LAMMPS_MEMALIGN)
+#define LAMMPS_MEMALIGN 64
+#endif
+
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */

--- a/src/my_page.h
+++ b/src/my_page.h
@@ -48,6 +48,10 @@ methods:
 #ifndef LAMMPS_MY_PAGE_H
 #define LAMMPS_MY_PAGE_H
 
+#if defined(LMP_USER_INTEL) && !defined(LAMMPS_MEMALIGN)
+#define LAMMPS_MEMALIGN 64
+#endif
+
 #include <stdlib.h>
 namespace LAMMPS_NS {
 


### PR DESCRIPTION
This PR will simplify compiling the USER-INTEL package, tweaking the code in memory.cpp and my_page.h to default to `-DLAMMPS_MEMALIGN=64` in case it is not set in the makefile.
This will avoid aborted compilations for `make mpi` and `make serial` that do not set it.

It does not really change the resulting executable, it only avoids, that the user has to edit a makefile.
N.b: it will still abort, in case `-DLAMMPS_MEMALIGN` is set to a value _different_ from 64 as required by USER-INTEL.

The PR also contains a change to add `-restrict` to CCFLAGS for all makefiles intended for use with Intel compilers. This will avoid compiler errors for files using the _noalias macro.
