### PR TITLE
Collected small fixes

### DIFF
--- a/doc/src/compute_bond_local.txt
+++ b/doc/src/compute_bond_local.txt
@@ -51,12 +51,12 @@ relative to the center of mass (COM) velocity of the 2 atoms in the
 bond.
 
 The value {engvib} is the vibrational kinetic energy of the two atoms
-in the bond, which is simply 1/2 m1 v1^2 + 1/2 m1 v2^2, where v1 and
+in the bond, which is simply 1/2 m1 v1^2 + 1/2 m2 v2^2, where v1 and
 v2 are the magnitude of the velocity of the 2 atoms along the bond
 direction, after the COM velocity has been subtracted from each.
 
 The value {engrot} is the rotationsl kinetic energy of the two atoms
-in the bond, which is simply 1/2 m1 v1^2 + 1/2 m1 v2^2, where v1 and
+in the bond, which is simply 1/2 m1 v1^2 + 1/2 m2 v2^2, where v1 and
 v2 are the magnitude of the velocity of the 2 atoms perpendicular to
 the bond direction, after the COM velocity has been subtracted from
 each.
@@ -67,7 +67,7 @@ Vcm^2 where Vcm = magnitude of the velocity of the COM.
 
 Note that these 3 kinetic energy terms are simply a partitioning of
 the summed kinetic energy of the 2 atoms themselves.  I.e. total KE =
-1/2 m1 v1^2 + 1/2 m2 v3^2 = engvib + engrot + engtrans, where v1,v2
+1/2 m1 v1^2 + 1/2 m2 v2^2 = engvib + engrot + engtrans, where v1,v2
 are the magnitude of the velocities of the 2 atoms, without any
 adjustment for the COM velocity.
 

--- a/doc/src/fix_gcmc.txt
+++ b/doc/src/fix_gcmc.txt
@@ -21,7 +21,7 @@ type = atom type for inserted atoms (must be 0 if mol keyword used) :l
 seed = random # seed (positive integer) :l
 T = temperature of the ideal gas reservoir (temperature units) :l
 mu = chemical potential of the ideal gas reservoir (energy units) :l
-translate = maximum Monte Carlo translation distance (length units) :l
+displace = maximum Monte Carlo translation distance (length units) :l
 zero or more keyword/value pairs may be appended to args :l
 keyword = {mol}, {region}, {maxangle}, {pressure}, {fugacity_coeff}, {full_energy}, {charge}, {group}, {grouptype}, {intra_energy}, or {tfac_insert}
   {mol} value = template-ID

--- a/src/finish.cpp
+++ b/src/finish.cpp
@@ -158,25 +158,24 @@ void Finish::end(int flag)
 
       // CPU use on MPI tasks and OpenMP threads
 
-#ifdef LMP_USER_OMP
-      const char fmt2[] =
-        "%.1f%% CPU use with %d MPI tasks x %d OpenMP threads\n";
-      if (screen) fprintf(screen,fmt2,cpu_loop,nprocs,nthreads);
-      if (logfile) fprintf(logfile,fmt2,cpu_loop,nprocs,nthreads);
-#else
       if (lmp->kokkos) {
         const char fmt2[] =
           "%.1f%% CPU use with %d MPI tasks x %d OpenMP threads\n";
         if (screen) fprintf(screen,fmt2,cpu_loop,nprocs,lmp->kokkos->num_threads);
         if (logfile) fprintf(logfile,fmt2,cpu_loop,nprocs,lmp->kokkos->num_threads);
       } else {
+#if defined(_OPENMP)
+        const char fmt2[] =
+        "%.1f%% CPU use with %d MPI tasks x %d OpenMP threads\n";
+        if (screen) fprintf(screen,fmt2,cpu_loop,nprocs,nthreads);
+        if (logfile) fprintf(logfile,fmt2,cpu_loop,nprocs,nthreads);
+#else
         const char fmt2[] =
           "%.1f%% CPU use with %d MPI tasks x no OpenMP threads\n";
         if (screen) fprintf(screen,fmt2,cpu_loop,nprocs);
         if (logfile) fprintf(logfile,fmt2,cpu_loop,nprocs);
-      }
 #endif
-
+      }
     }
   }
 


### PR DESCRIPTION
This refactors the %CPU/OpenMP thread line in finish.cpp to be consistent with KOKKOS, USER-OMP and other code that uses OpenMP directly.

It also includes and thus closes #297 and #296