### PR TITLE
print the last input line, when error->all() is called

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -17,6 +17,7 @@
 #include "error.h"
 #include "universe.h"
 #include "output.h"
+#include "input.h"
 
 using namespace LAMMPS_NS;
 
@@ -107,11 +108,18 @@ void Error::all(const char *file, int line, const char *str)
   MPI_Barrier(world);
 
   int me;
+  const char *lastcmd = (const char*)"(unknown)";
+
   MPI_Comm_rank(world,&me);
 
   if (me == 0) {
-    if (screen) fprintf(screen,"ERROR: %s (%s:%d)\n",str,file,line);
-    if (logfile) fprintf(logfile,"ERROR: %s (%s:%d)\n",str,file,line);
+    if (input && input->line) lastcmd = input->line;
+    if (screen) fprintf(screen,"ERROR: %s (%s:%d)\n"
+		        "Last command: %s\n",
+                        str,file,line,lastcmd);
+    if (logfile) fprintf(logfile,"ERROR: %s (%s:%d)\n"
+		         "Last command: %s\n",
+                         str,file,line,lastcmd);
   }
 
 #ifdef LAMMPS_EXCEPTIONS

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -350,15 +350,15 @@ void Input::parse()
     }
     if (quoteflag == 0) {
       if (strstr(ptr,"\"\"\"") == ptr) {
-	quoteflag = 3;
-	ptr += 2;
+        quoteflag = 3;
+        ptr += 2;
       }
       else if (*ptr == '"') quoteflag = 2;
       else if (*ptr == '\'') quoteflag = 1;
     } else {
       if (quoteflag == 3 && strstr(ptr,"\"\"\"") == ptr) {
-	quoteflag = 0;
-	ptr += 2;
+        quoteflag = 0;
+        ptr += 2;
       }
       else if (quoteflag == 2 && *ptr == '"') quoteflag = 0;
       else if (quoteflag == 1 && *ptr == '\'') quoteflag = 0;

--- a/src/input.h
+++ b/src/input.h
@@ -23,6 +23,7 @@ namespace LAMMPS_NS {
 
 class Input : protected Pointers {
   friend class Info;
+  friend class Error;
  public:
   int narg;                    // # of command args
   char **arg;                  // parsed args for command


### PR DESCRIPTION
this should help tracking down input file errors for many
common cases without having to repeat the run with -echo screen
and avoid having to explain how to use that feature all the time

this also provides a straightforward way to have better error location tracking for tools like atomify as discussed in #295 without having to make complex changes to the LAMMPS parser. Thus this PR closes #295.