### PR TITLE
Protect from divide by zero in mpi_timings() when printing results.

### DIFF
--- a/src/finish.cpp
+++ b/src/finish.cpp
@@ -912,7 +912,7 @@ void mpi_timings(const char *label, Timer *t, enum Timer::ttype tt,
   time_cpu = tmp/nprocs*100.0;
 
   // % variance from the average as measure of load imbalance
-  if ((time_sq/time - time) > 1.0e-10)
+  if ((time > 0.0) && ((time_sq/time - time) > 1.0e-10))
     time_sq = sqrt(time_sq/time - time)*100.0;
   else
     time_sq = 0.0;
@@ -964,7 +964,7 @@ void omp_times(FixOMP *fix, const char *label, enum Timer::ttype which,
   time_std /= nthreads;
   time_total /= nthreads;
 
-  if ((time_std/time_avg -time_avg) > 1.0e-10)
+  if ((time_avg > 0.0) && ((time_std/time_avg -time_avg) > 1.0e-10))
     time_std = sqrt(time_std/time_avg - time_avg)*100.0;
   else
     time_std = 0.0;


### PR DESCRIPTION
We had some test cases where the neighbor list was never rebuilt after its initial build.
Thus, the wall time reported by Timer::NEIGH was exactly zero, and when Finish::end()
tried to report on the Neighbor timing breakdown, a divide by zero would occur.