### PR TITLE
Fixes for srp example

### DIFF
--- a/examples/USER/misc/srp/in.srp
+++ b/examples/USER/misc/srp/in.srp
@@ -15,6 +15,7 @@ bond_style      harmonic
 bond_coeff      * 225.0 0.85
 
 comm_modify vel yes
+comm_modify cutoff 3.6
 
 # must use pair hybrid, since srp bond particles
 # do not interact with other atoms types

--- a/src/USER-MISC/fix_srp.cpp
+++ b/src/USER-MISC/fix_srp.cpp
@@ -67,7 +67,7 @@ FixSRP::FixSRP(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
 
   // zero
   for (int i = 0; i < atom->nmax; i++)
-    for (int m = 0; m < 3; m++)
+    for (int m = 0; m < 2; m++)
       array[i][m] = 0.0;
 }
 
@@ -170,7 +170,7 @@ void FixSRP::setup_pre_force(int zz)
     xold[i][2] = x[i][2];
     tagold[i]=tag[i];
     dlist[i] = (type[i] == bptype) ? 1 : 0;
-    for (n = 0; n < 3; n++)
+    for (n = 0; n < 2; n++)
       array[i][n] = 0.0;
   }
 

--- a/src/USER-MISC/fix_srp.cpp
+++ b/src/USER-MISC/fix_srp.cpp
@@ -264,14 +264,11 @@ void FixSRP::setup_pre_force(int zz)
   if (cutghostmin > comm->cutghost[2])
     cutghostmin = comm->cutghost[2];
 
-  // reset cutghost if needed
+  // stop if cutghost is insufficient
   if (cutneighmax_srp > cutghostmin){
-    if(comm->me == 0){
-      sprintf(str, "Extending ghost comm cutoff. New %f, old %f.", cutneighmax_srp, cutghostmin);
-      error->message(FLERR,str);
-    }
-    // cutghost updated by comm->setup
-    comm->cutghostuser = cutneighmax_srp;
+    sprintf(str, "Communication cutoff too small for fix srp. "
+            "Need %f, current %f.", cutneighmax_srp, cutghostmin);
+    error->all(FLERR,str);
   }
 
   // assign tags for new atoms, update map

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -714,6 +714,8 @@ void Neighbor::init_pair()
       if (requests[i]->kokkos_host != requests[j]->kokkos_host) continue;
 
       if (requests[i]->ssa != requests[j]->ssa) continue;
+      // newton 2 and newton 0 both are newton off
+      if ((requests[i]->newton & 2) != (requests[j]->newton & 2)) continue;
 
       if (requests[i]->half && requests[j]->pair && 
           !requests[j]->skip && requests[j]->half && !requests[j]->copy)

--- a/src/npair.cpp
+++ b/src/npair.cpp
@@ -24,7 +24,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-NPair::NPair(LAMMPS *lmp) : Pointers(lmp)
+NPair::NPair(LAMMPS *lmp)
+  : Pointers(lmp), nb(NULL), ns(NULL), bins(NULL), stencil(NULL)
 {
   last_build = -1;
   last_copy_bin_setup = last_copy_bin = last_copy_stencil = -1;
@@ -130,11 +131,11 @@ void NPair::build_setup()
     copy_bin_setup_info();
     last_copy_bin_setup = update->ntimestep;
   }
-  if (nb && last_copy_bin < nb->last_bin_memory) {
+  if (nb && ((last_copy_bin < nb->last_bin_memory) || (bins != nb->bins))) {
     copy_bin_info();
     last_copy_bin = update->ntimestep;
   }
-  if (ns && last_copy_stencil < ns->last_create) {
+  if (ns && ((last_copy_stencil < ns->last_create) || (stencil != ns->stencil))) {
     copy_stencil_info();
     last_copy_stencil = update->ntimestep;
   }


### PR DESCRIPTION
This adds several changes fixing problems exposed by running the example for fix srp and a bug report for compute rdf reported on lammps-users
- out-of-bound accesses when clearing the result array
- the neighbor list build was operating on outdated pointers
- we cannot copy a neighbor list with different newton settings, since a request with newton == 2 can request a list with newton_pair off when newton_pair is on.

The second fix seems to affect other problem reports as well, e.g. it fixes #316 
As indicated in the comments, there may be a more general way to address the issue in Npair, however, this PR may serve as a temporary workaround.