### PR TITLE
Bugfix in the fix_ipi initialization - prevents multiple open_socket calls

### DIFF
--- a/src/USER-MISC/fix_ipi.cpp
+++ b/src/USER-MISC/fix_ipi.cpp
@@ -219,6 +219,9 @@ FixIPI::FixIPI(LAMMPS *lmp, int narg, char **arg) :
 
   // create instance of Irregular class
   irregular = new Irregular(lmp);
+  
+  // yet, we have not assigned a socket
+  socketflag = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -248,9 +251,12 @@ int FixIPI::setmask()
 void FixIPI::init()
 {
   //only opens socket on master process
-  if (master) open_socket(ipisock, inet, port, host, error);
-  else ipisock=0;
+  if (master) {
+	if (!socketflag) open_socket(ipisock, inet, port, host, error);
+  } else ipisock=0;
   //! should check for success in socket opening -- but the current open_socket routine dies brutally if unsuccessful
+  // tell lammps we have assigned a socket
+  socketflag = 1;
 
   // asks for evaluation of PE at first step
   modify->compute[modify->find_compute("thermo_pe")]->invoked_scalar = -1;

--- a/src/USER-MISC/fix_ipi.h
+++ b/src/USER-MISC/fix_ipi.h
@@ -35,7 +35,7 @@ class FixIPI : public Fix {
 
  protected:
   char *host; int port; int inet, master, hasdata;
-  int ipisock, me; double *buffer; long bsize;
+  int ipisock, me, socketflag; double *buffer; long bsize;
   int kspace_flag;
   int reset_flag;
 


### PR DESCRIPTION
This is a minimal change to include a flag that signals that the socket has already been open
and a connection established. This avoids a crash when one uses multiple run commands in a
LAMMPS input that includes a fix ipi.