### PR TITLE
USER-DPD another zero compute optimization

### DIFF
--- a/src/USER-DPD/pair_dpd_fdt.cpp
+++ b/src/USER-DPD/pair_dpd_fdt.cpp
@@ -43,6 +43,7 @@ using namespace LAMMPS_NS;
 PairDPDfdt::PairDPDfdt(LAMMPS *lmp) : Pair(lmp)
 {
   random = NULL;
+  splitFDT_flag = false;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-DPD/pair_dpd_fdt.h
+++ b/src/USER-DPD/pair_dpd_fdt.h
@@ -50,6 +50,7 @@ class PairDPDfdt : public Pair {
   double cut_global;
   int seed;
   bool splitFDT_flag;
+  bool a0_is_zero;
 
   void allocate();
 


### PR DESCRIPTION
This is basically the same as PR #344 applied to pair_dpd_fdt, also yielding a roughly 10% speedup in affected test cases.