### PR TITLE
Fix skip with ghost issue

### DIFF
--- a/src/USER-OMP/npair_skip_omp.h
+++ b/src/USER-OMP/npair_skip_omp.h
@@ -18,7 +18,8 @@
 
 NPairStyle(skip/omp,
            NPairSkip,
-           NP_SKIP | NP_HALF | NP_FULL | NP_NSQ | NP_BIN | NP_MULTI |
+           NP_SKIP | NP_HALF | NP_FULL | NP_HALFFULL |
+           NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_OMP)
 
 NPairStyle(skip/half/respa/omp,

--- a/src/USER-OMP/npair_skip_omp.h
+++ b/src/USER-OMP/npair_skip_omp.h
@@ -45,6 +45,12 @@ NPairStyle(skip/size/off2on/oneside/omp,
            NP_NSQ | NP_BIN | NP_MULTI | NP_NEWTON | NP_NEWTOFF |
            NP_ORTHO | NP_TRI | NP_OMP)
 
+NPairStyle(skip/ghost/omp,
+           NPairSkip,
+           NP_SKIP | NP_HALF | NP_FULL | NP_HALFFULL |
+           NP_NSQ | NP_BIN | NP_MULTI |
+           NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_OMP | NP_GHOST)
+
 #endif
 
 /* ERROR/WARNING messages:

--- a/src/npair_skip.h
+++ b/src/npair_skip.h
@@ -16,8 +16,14 @@
 NPairStyle(skip,
            NPairSkip,
            NP_SKIP | NP_HALF | NP_FULL | NP_HALFFULL |
-           NP_NSQ | NP_BIN | NP_MULTI | 
+           NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI)
+
+NPairStyle(skip/ghost,
+           NPairSkip,
+           NP_SKIP | NP_HALF | NP_FULL | NP_HALFFULL |
+           NP_NSQ | NP_BIN | NP_MULTI |
+           NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_GHOST)
 
 #else
 


### PR DESCRIPTION
This pull request corrects two problems with the input deck and problem reported here: https://sourceforge.net/p/lammps/mailman/lammps-users/thread/1909172481.2131119.1485208835320%40mail.yahoo.com/#msg35621936

- skip list build settings in USER-OMP were missing the `NP_HALFFULL` flag
- skip list builds were not flagged as compatible with `NP_GHOST` for regular and USER-OMP

due to the way how the tests for compatible build methods are performed, in both cases new/updated definitions were provided, that refer to the existing styles.