### PR TITLE
fix USER-OMP bug on per-atom data with hybrid styles

### DIFF
--- a/src/USER-OMP/thr_omp.cpp
+++ b/src/USER-OMP/thr_omp.cpp
@@ -170,9 +170,8 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
   switch (thr_style) {
 
   case THR_PAIR: {
-    Pair * const pair = lmp->force->pair;
 
-    if (pair->vflag_fdotr) {
+    if (lmp->force->pair->vflag_fdotr) {
 
       // this is a non-hybrid pair style. compute per thread fdotr
       if (fix->last_pair_hybrid == NULL) {
@@ -192,6 +191,8 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
     }
 
     if (evflag) {
+      Pair * const pair = (Pair *)style;
+
 #if defined(_OPENMP)
 #pragma omp critical
 #endif


### PR DESCRIPTION
This PR addresses a long-standing known issue in USER-OMP, where per-atom data was not correctly reduced across the per-thread storage in sub-styles or hybrid pair styles.

Turns out, the code was reduced the storage of the hybrid style itself but not of the individual sub-styles.
for global data it worked in the past, since the per-thread storage is kept in ThrData so the code in ThrOMP would just directly tally it into the accumulator in PairHybrid and PairHybrid would just add zeroes from the substyles, but per-atom storage is in Pair, so this needed to be done differently.

Closes #360