### PR TITLE
Fix GPU sync bugs

### DIFF
--- a/src/KOKKOS/angle_charmm_kokkos.cpp
+++ b/src/KOKKOS/angle_charmm_kokkos.cpp
@@ -84,9 +84,6 @@ void AngleCharmmKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     }
   }
 
-  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
-  else atomKK->modified(execution_space,F_MASK);
-
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();
   neighborKK->k_anglelist.template sync<DeviceType>();

--- a/src/KOKKOS/bond_fene_kokkos.cpp
+++ b/src/KOKKOS/bond_fene_kokkos.cpp
@@ -85,13 +85,10 @@ void BondFENEKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     d_vatom = k_vatom.d_view;
   }
 
-  atomKK->sync(execution_space,datamask_read);
   k_k.template sync<DeviceType>();
   k_r0.template sync<DeviceType>();
   k_epsilon.template sync<DeviceType>();
   k_sigma.template sync<DeviceType>();
-  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
-  else atomKK->modified(execution_space,F_MASK);
 
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();

--- a/src/KOKKOS/dihedral_charmm_kokkos.cpp
+++ b/src/KOKKOS/dihedral_charmm_kokkos.cpp
@@ -98,11 +98,6 @@ void DihedralCharmmKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     }
   }
 
-
-  //atomKK->sync(execution_space,datamask_read);
-  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
-  else atomKK->modified(execution_space,F_MASK);
-
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();
   q = atomKK->k_q.view<DeviceType>();

--- a/src/KOKKOS/dihedral_opls_kokkos.cpp
+++ b/src/KOKKOS/dihedral_opls_kokkos.cpp
@@ -85,13 +85,10 @@ void DihedralOPLSKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     d_vatom = k_vatom.d_view;
   }
 
-  atomKK->sync(execution_space,datamask_read);
   k_k1.template sync<DeviceType>();
   k_k2.template sync<DeviceType>();
   k_k3.template sync<DeviceType>();
   k_k4.template sync<DeviceType>();
-  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
-  else atomKK->modified(execution_space,F_MASK);
 
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -646,10 +646,7 @@ void PPPMKokkos<DeviceType>::compute(int eflag, int vflag)
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();
   q = atomKK->k_q.view<DeviceType>();
- 
-  atomKK->sync(execution_space,datamask_read);
-  atomKK->modified(execution_space,datamask_modify);
- 
+
   //nlocal = atomKK->nlocal;
   //nall = atomKK->nlocal + atomKK->nghost;
   //newton_pair = force->newton_pair;


### PR DESCRIPTION
the Kokkos implementations of `dihedral_opls` and `pppm` were calling `sync` and `modified` themselves, which breaks @crtrott 's optimization that separately calculates forces on the host and device. this commit removes those calls and lets the datamask system work in its mysterious ways.