### PR TITLE
Fixed bugs with pppm/gpu when used with compute group/group

### DIFF
--- a/src/GPU/pppm_gpu.h
+++ b/src/GPU/pppm_gpu.h
@@ -35,13 +35,15 @@ class PPPMGPU : public PPPM {
   int timing_3d(int, double &);
   double memory_usage();
 
+  virtual void compute_group_group(int, int, int);
+
  protected:
   FFT_SCALAR ***density_brick_gpu, ***vd_brick;
   bool kspace_split, im_real_space;
   int old_nlocal;
   double poisson_time;
 
-  void brick2fft();
+  void brick2fft_gpu();
   virtual void poisson_ik();
 
   void pack_forward(int, FFT_SCALAR *, int, int *);


### PR DESCRIPTION
This PR is to address a recent issue reported in:

https://sourceforge.net/p/lammps/mailman/message/35654263/

The input deck that reproduces the issue is provided in the user's first email.

The issue was tracked down to that pppm/gpu does not support compute_group_group(). This PR implements the function compute_group_group() for pppm/gpu. (An alternative is to enforce users to use pppm only on the CPU if they want compute group/group.) 

Axel, please review the changes I've made to the PPPMGPU class. Feel free to make improvements and corrections to them. Thanks!

