### PR TITLE
neighbor_kokkos.cpp: Don't call grow() on neighbor lists that are copies

### DIFF
--- a/src/KOKKOS/neighbor_kokkos.cpp
+++ b/src/KOKKOS/neighbor_kokkos.cpp
@@ -306,7 +306,7 @@ void NeighborKokkos::build_kokkos(int topoflag)
   atomKK->sync(Host,ALL_MASK);
   for (i = 0; i < npair_perpetual; i++) {
     m = plist[i];
-    lists[m]->grow(nlocal,nall);
+    if (!lists[m]->copy) lists[m]->grow(nlocal,nall);
     neigh_pair[m]->build_setup();
     neigh_pair[m]->build(lists[m]);
   }


### PR DESCRIPTION
This corresponds to a bugfix from commit 9161bd98 on neighbor.cpp
I think the only side-effect of the bug in this case is wasted memory.

Stan, please check that I didn't miss anything else from the 9161bd98 bugfix that should have been propagated into the KOKKOS directory.