### PR TITLE
Kokkos version of class2 bond, angle, dihedral, and improper from Ray Shan

### DIFF
--- a/doc/src/angle_class2.txt
+++ b/doc/src/angle_class2.txt
@@ -8,6 +8,7 @@
 
 angle_style class2 command :h3
 angle_style class2/omp command :h3
+angle_style class2/kk command :h3
 
 [Syntax:]
 

--- a/doc/src/bond_class2.txt
+++ b/doc/src/bond_class2.txt
@@ -8,6 +8,7 @@
 
 bond_style class2 command :h3
 bond_style class2/omp command :h3
+bond_style class2/kk command :h3
 
 [Syntax:]
 

--- a/doc/src/dihedral_class2.txt
+++ b/doc/src/dihedral_class2.txt
@@ -8,6 +8,7 @@
 
 dihedral_style class2 command :h3
 dihedral_style class2/omp command :h3
+dihedral_style class2/kk command :h3
 
 [Syntax:]
 

--- a/doc/src/improper_class2.txt
+++ b/doc/src/improper_class2.txt
@@ -8,6 +8,7 @@
 
 improper_style class2 command :h3
 improper_style class2/omp command :h3
+improper_style class2/kk command :h3
 
 [Syntax:]
 

--- a/src/CLASS2/angle_class2.cpp
+++ b/src/CLASS2/angle_class2.cpp
@@ -41,6 +41,8 @@ AngleClass2::AngleClass2(LAMMPS *lmp) : Angle(lmp) {}
 
 AngleClass2::~AngleClass2()
 {
+  if (copymode) return;
+
   if (allocated) {
     memory->destroy(setflag);
     memory->destroy(setflag_a);

--- a/src/CLASS2/bond_class2.cpp
+++ b/src/CLASS2/bond_class2.cpp
@@ -36,6 +36,8 @@ BondClass2::BondClass2(LAMMPS *lmp) : Bond(lmp) {}
 
 BondClass2::~BondClass2()
 {
+  if (copymode) return;
+
   if (allocated) {
     memory->destroy(setflag);
     memory->destroy(r0);

--- a/src/CLASS2/dihedral_class2.cpp
+++ b/src/CLASS2/dihedral_class2.cpp
@@ -46,6 +46,8 @@ DihedralClass2::DihedralClass2(LAMMPS *lmp) : Dihedral(lmp)
 
 DihedralClass2::~DihedralClass2()
 {
+  if (copymode) return;
+
   if (allocated) {
     memory->destroy(setflag);
     memory->destroy(setflag_d);

--- a/src/CLASS2/improper_class2.cpp
+++ b/src/CLASS2/improper_class2.cpp
@@ -45,6 +45,8 @@ ImproperClass2::ImproperClass2(LAMMPS *lmp) : Improper(lmp)
 
 ImproperClass2::~ImproperClass2()
 {
+  if (copymode) return;
+
   if (allocated) {
     memory->destroy(setflag);
     memory->destroy(setflag_i);

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -35,6 +35,8 @@ touch ../memory.h
 
 action angle_charmm_kokkos.cpp angle_charmm.cpp 
 action angle_charmm_kokkos.h angle_charmm.h
+action angle_class2_kokkos.cpp angle_class2.cpp 
+action angle_class2_kokkos.h angle_class2.h
 action angle_harmonic_kokkos.cpp angle_harmonic.cpp 
 action angle_harmonic_kokkos.h angle_harmonic.h 
 action atom_kokkos.cpp
@@ -53,6 +55,8 @@ action atom_vec_kokkos.cpp
 action atom_vec_kokkos.h
 action atom_vec_molecular_kokkos.cpp atom_vec_molecular.cpp
 action atom_vec_molecular_kokkos.h atom_vec_molecular.h
+action bond_class2_kokkos.cpp bond_class2.cpp 
+action bond_class2_kokkos.h bond_class2.h
 action bond_fene_kokkos.cpp bond_fene.cpp
 action bond_fene_kokkos.h bond_fene.h
 action bond_harmonic_kokkos.cpp bond_harmonic.cpp
@@ -65,6 +69,8 @@ action compute_temp_kokkos.cpp
 action compute_temp_kokkos.h
 action dihedral_charmm_kokkos.cpp dihedral_charmm.cpp
 action dihedral_charmm_kokkos.h dihedral_charmm.h
+action dihedral_class2_kokkos.cpp dihedral_class2.cpp 
+action dihedral_class2_kokkos.h dihedral_class2.h
 action dihedral_opls_kokkos.cpp dihedral_opls.cpp
 action dihedral_opls_kokkos.h dihedral_opls.h
 action domain_kokkos.cpp
@@ -97,6 +103,8 @@ action fix_wall_reflect_kokkos.cpp
 action fix_wall_reflect_kokkos.h
 action gridcomm_kokkos.cpp gridcomm.cpp
 action gridcomm_kokkos.h gridcomm.h
+action improper_class2_kokkos.cpp improper_class2.cpp 
+action improper_class2_kokkos.h improper_class2.h
 action improper_harmonic_kokkos.cpp improper_harmonic.cpp
 action improper_harmonic_kokkos.h improper_harmonic.h
 action kokkos.cpp

--- a/src/KOKKOS/angle_class2_kokkos.cpp
+++ b/src/KOKKOS/angle_class2_kokkos.cpp
@@ -1,0 +1,526 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Ray Shan (Materials Design)
+------------------------------------------------------------------------- */
+
+#include <math.h>
+#include <stdlib.h>
+#include "angle_class2_kokkos.h"
+#include "atom_kokkos.h"
+#include "neighbor_kokkos.h"
+#include "domain.h"
+#include "comm.h"
+#include "force.h"
+#include "math_const.h"
+#include "memory.h"
+#include "error.h"
+#include "atom_masks.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+#define SMALL 0.001
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+AngleClass2Kokkos<DeviceType>::AngleClass2Kokkos(LAMMPS *lmp) : AngleClass2(lmp)
+{
+  atomKK = (AtomKokkos *) atom;
+  neighborKK = (NeighborKokkos *) neighbor;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | F_MASK | ENERGY_MASK | VIRIAL_MASK;
+  datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+AngleClass2Kokkos<DeviceType>::~AngleClass2Kokkos()
+{
+  if (!copymode) {
+    memory->destroy_kokkos(k_eatom,eatom);
+    memory->destroy_kokkos(k_vatom,vatom);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void AngleClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  eflag = eflag_in;
+  vflag = vflag_in;
+
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = 0;
+
+  // reallocate per-atom arrays if necessary
+
+  if (eflag_atom) {
+    memory->destroy_kokkos(k_eatom,eatom);
+    memory->create_kokkos(k_eatom,eatom,maxeatom,"angle:eatom");
+    d_eatom = k_eatom.template view<DeviceType>();
+  }
+  if (vflag_atom) {
+    memory->destroy_kokkos(k_vatom,vatom);
+    memory->create_kokkos(k_vatom,vatom,maxvatom,6,"angle:vatom");
+    d_vatom = k_vatom.template view<DeviceType>();
+  }
+
+  //atomKK->sync(execution_space,datamask_read);
+  //if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  //else atomKK->modified(execution_space,F_MASK);
+  
+  k_theta0.template sync<DeviceType>();
+  k_k2.template sync<DeviceType>();
+  k_k3.template sync<DeviceType>();
+  k_k4.template sync<DeviceType>();
+  k_bb_k.template sync<DeviceType>();
+  k_bb_r1.template sync<DeviceType>();
+  k_bb_r2.template sync<DeviceType>();
+  k_ba_k1.template sync<DeviceType>();
+  k_ba_k2.template sync<DeviceType>();
+  k_ba_r1.template sync<DeviceType>();
+  k_ba_r2.template sync<DeviceType>();
+  k_setflag.template sync<DeviceType>();
+  k_setflag_a.template sync<DeviceType>();
+  k_setflag_bb.template sync<DeviceType>();
+  k_setflag_ba.template sync<DeviceType>();
+
+  x = atomKK->k_x.template view<DeviceType>();
+  f = atomKK->k_f.template view<DeviceType>();
+  neighborKK->k_anglelist.template sync<DeviceType>();
+  anglelist = neighborKK->k_anglelist.template view<DeviceType>();
+  int nanglelist = neighborKK->nanglelist;
+  nlocal = atom->nlocal;
+  newton_bond = force->newton_bond;
+
+  copymode = 1;
+
+  // loop over neighbors of my atoms
+
+  EV_FLOAT ev;
+
+  if (evflag) {
+    if (newton_bond) {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagAngleClass2Compute<1,1> >(0,nanglelist),*this,ev);
+    } else {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagAngleClass2Compute<0,1> >(0,nanglelist),*this,ev);
+    }
+  } else {
+    if (newton_bond) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagAngleClass2Compute<1,0> >(0,nanglelist),*this);
+    } else {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagAngleClass2Compute<0,0> >(0,nanglelist),*this);
+    }
+  }
+
+  if (eflag_global) energy += ev.evdwl;
+  if (vflag_global) {
+    virial[0] += ev.v[0];
+    virial[1] += ev.v[1];
+    virial[2] += ev.v[2];
+    virial[3] += ev.v[3];
+    virial[4] += ev.v[4];
+    virial[5] += ev.v[5];
+  }
+
+  if (eflag_atom) {
+    k_eatom.template modify<DeviceType>();
+    k_eatom.template sync<LMPHostType>();
+  }
+
+  if (vflag_atom) {
+    k_vatom.template modify<DeviceType>();
+    k_vatom.template sync<LMPHostType>();
+  }
+
+  copymode = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void AngleClass2Kokkos<DeviceType>::operator()(TagAngleClass2Compute<NEWTON_BOND,EVFLAG>, const int &n, EV_FLOAT& ev) const {
+
+  // The f array is atomic
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > a_f = f;
+
+  const int i1 = anglelist(n,0);
+  const int i2 = anglelist(n,1);
+  const int i3 = anglelist(n,2);
+  const int type = anglelist(n,3);
+
+  // 1st bond
+
+  const F_FLOAT delx1 = x(i1,0) - x(i2,0);
+  const F_FLOAT dely1 = x(i1,1) - x(i2,1);
+  const F_FLOAT delz1 = x(i1,2) - x(i2,2);
+
+  const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
+  const F_FLOAT r1 = sqrt(rsq1);
+
+  // 2nd bond
+
+  const F_FLOAT delx2 = x(i3,0) - x(i2,0);
+  const F_FLOAT dely2 = x(i3,1) - x(i2,1);
+  const F_FLOAT delz2 = x(i3,2) - x(i2,2);
+
+  const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
+  const F_FLOAT r2 = sqrt(rsq2);
+
+  // angle (cos and sin)
+
+  F_FLOAT c = delx1*delx2 + dely1*dely2 + delz1*delz2;
+  c /= r1*r2;
+
+  if (c > 1.0) c = 1.0;
+  if (c < -1.0) c = -1.0;
+
+  F_FLOAT s = sqrt(1.0 - c*c);
+  if (s < SMALL) s = SMALL;
+  s = 1.0/s;
+
+  // force & energy for angle term
+
+  const F_FLOAT dtheta = acos(c) - d_theta0[type];
+  const F_FLOAT dtheta2 = dtheta*dtheta;
+  const F_FLOAT dtheta3 = dtheta2*dtheta;
+  const F_FLOAT dtheta4 = dtheta3*dtheta;
+
+  const F_FLOAT de_angle = 2.0*d_k2[type]*dtheta + 3.0*d_k3[type]*dtheta2 + 4.0*d_k4[type]*dtheta3;
+
+  const F_FLOAT a = -de_angle*s;
+  const F_FLOAT a11 = a*c / rsq1;
+  const F_FLOAT a12 = -a / (r1*r2);
+  const F_FLOAT a22 = a*c / rsq2;
+
+  F_FLOAT f1[3],f3[3];
+  f1[0] = a11*delx1 + a12*delx2;
+  f1[1] = a11*dely1 + a12*dely2;
+  f1[2] = a11*delz1 + a12*delz2;
+  f3[0] = a22*delx2 + a12*delx1;
+  f3[1] = a22*dely2 + a12*dely1;
+  f3[2] = a22*delz2 + a12*delz1;
+
+  F_FLOAT eangle = 0.0;
+  if (eflag) eangle = d_k2[type]*dtheta2 + d_k3[type]*dtheta3 + d_k4[type]*dtheta4;
+
+  // force & energy for bond-bond term
+ 
+  const F_FLOAT dr1 = r1 - d_bb_r1[type];
+  const F_FLOAT dr2 = r2 - d_bb_r2[type];
+  const F_FLOAT tk1 = d_bb_k[type] * dr1;
+  const F_FLOAT tk2 = d_bb_k[type] * dr2;
+
+  f1[0] -= delx1*tk2/r1;
+  f1[1] -= dely1*tk2/r1;
+  f1[2] -= delz1*tk2/r1;
+
+  f3[0] -= delx2*tk1/r2;
+  f3[1] -= dely2*tk1/r2;
+  f3[2] -= delz2*tk1/r2;
+
+  if (eflag) eangle += d_bb_k[type]*dr1*dr2;
+
+  // force & energy for bond-angle term
+
+  const F_FLOAT aa1 = s * dr1 * d_ba_k1[type];
+  const F_FLOAT aa2 = s * dr2 * d_ba_k2[type];
+
+  F_FLOAT aa11 = aa1 * c / rsq1;
+  F_FLOAT aa12 = -aa1 / (r1 * r2);
+  F_FLOAT aa21 = aa2 * c / rsq1;
+  F_FLOAT aa22 = -aa2 / (r1 * r2);
+
+  const F_FLOAT vx11 = (aa11 * delx1) + (aa12 * delx2);
+  const F_FLOAT vx12 = (aa21 * delx1) + (aa22 * delx2);
+  const F_FLOAT vy11 = (aa11 * dely1) + (aa12 * dely2);
+  const F_FLOAT vy12 = (aa21 * dely1) + (aa22 * dely2);
+  const F_FLOAT vz11 = (aa11 * delz1) + (aa12 * delz2);
+  const F_FLOAT vz12 = (aa21 * delz1) + (aa22 * delz2);
+
+  aa11 = aa1 * c / rsq2;
+  aa21 = aa2 * c / rsq2;
+
+  const F_FLOAT vx21 = (aa11 * delx2) + (aa12 * delx1);
+  const F_FLOAT vx22 = (aa21 * delx2) + (aa22 * delx1);
+  const F_FLOAT vy21 = (aa11 * dely2) + (aa12 * dely1);
+  const F_FLOAT vy22 = (aa21 * dely2) + (aa22 * dely1);
+  const F_FLOAT vz21 = (aa11 * delz2) + (aa12 * delz1);
+  const F_FLOAT vz22 = (aa21 * delz2) + (aa22 * delz1);
+
+  const F_FLOAT b1 = d_ba_k1[type] * dtheta / r1;
+  const F_FLOAT b2 = d_ba_k2[type] * dtheta / r2;
+
+  f1[0] -= vx11 + b1*delx1 + vx12;
+  f1[1] -= vy11 + b1*dely1 + vy12;
+  f1[2] -= vz11 + b1*delz1 + vz12;
+
+  f3[0] -= vx21 + b2*delx2 + vx22;
+  f3[1] -= vy21 + b2*dely2 + vy22;
+  f3[2] -= vz21 + b2*delz2 + vz22;
+
+  if (eflag) eangle += d_ba_k1[type]*dr1*dtheta + d_ba_k2[type]*dr2*dtheta;
+
+  // apply force to each of 3 atoms
+
+  if (NEWTON_BOND || i1 < nlocal) {
+    a_f(i1,0) += f1[0];
+    a_f(i1,1) += f1[1];
+    a_f(i1,2) += f1[2];
+  }
+
+  if (NEWTON_BOND || i2 < nlocal) {
+    a_f(i2,0) -= f1[0] + f3[0];
+    a_f(i2,1) -= f1[1] + f3[1];
+    a_f(i2,2) -= f1[2] + f3[2];
+  }
+
+  if (NEWTON_BOND || i3 < nlocal) {
+    a_f(i3,0) += f3[0];
+    a_f(i3,1) += f3[1];
+    a_f(i3,2) += f3[2];
+  }
+
+  if (EVFLAG) ev_tally(ev,i1,i2,i3,eangle,f1,f3,
+                       delx1,dely1,delz1,delx2,dely2,delz2);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void AngleClass2Kokkos<DeviceType>::operator()(TagAngleClass2Compute<NEWTON_BOND,EVFLAG>, const int &n) const {
+  EV_FLOAT ev;
+  this->template operator()<NEWTON_BOND,EVFLAG>(TagAngleClass2Compute<NEWTON_BOND,EVFLAG>(), n, ev);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void AngleClass2Kokkos<DeviceType>::allocate()
+{
+  AngleClass2::allocate();
+
+}
+
+/* ----------------------------------------------------------------------
+   set coeffs for one or more types
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void AngleClass2Kokkos<DeviceType>::coeff(int narg, char **arg)
+{
+  AngleClass2::coeff(narg, arg);
+
+  int n = atom->nangletypes;
+  k_k2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::k2",n+1);
+  k_k3 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::k3",n+1);
+  k_k4 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::k4",n+1);
+  k_bb_k = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::bb_k",n+1);
+  k_bb_r1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::bb_r1",n+1);
+  k_bb_r2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::bb_r2",n+1);
+  k_ba_k1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::ba_k1",n+1);
+  k_ba_k2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::ba_k2",n+1);
+  k_ba_r1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::ba_r1",n+1);
+  k_ba_r2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::ba_r2",n+1);
+  k_setflag = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag",n+1);
+  k_setflag_a = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_a",n+1);
+  k_setflag_bb = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_bb",n+1);
+  k_setflag_ba = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_ba",n+1);
+  k_theta0 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::theta0",n+1);
+
+  d_k2 = k_k2.template view<DeviceType>();
+  d_k3 = k_k3.template view<DeviceType>();
+  d_k4 = k_k4.template view<DeviceType>();
+  d_bb_k = k_bb_k.template view<DeviceType>();
+  d_bb_r1 = k_bb_r1.template view<DeviceType>();
+  d_bb_r2 = k_bb_r2.template view<DeviceType>();
+  d_ba_k1 = k_ba_k1.template view<DeviceType>();
+  d_ba_k2 = k_ba_k2.template view<DeviceType>();
+  d_ba_r1 = k_ba_r1.template view<DeviceType>();
+  d_ba_r2 = k_ba_r2.template view<DeviceType>();
+  d_ba_r2 = k_ba_r2.template view<DeviceType>();
+  d_setflag = k_setflag.template view<DeviceType>();
+  d_setflag_a = k_setflag_a.template view<DeviceType>();
+  d_setflag_bb = k_setflag_bb.template view<DeviceType>();
+  d_setflag_ba = k_setflag_ba.template view<DeviceType>();
+  d_theta0 = k_theta0.template view<DeviceType>();
+
+  //int n = atom->nangletypes;
+  for (int i = 1; i <= n; i++) {
+    k_k2.h_view[i] = k2[i];
+    k_k3.h_view[i] = k3[i];
+    k_k4.h_view[i] = k4[i];
+    k_bb_k.h_view[i] = bb_k[i];
+    k_bb_r1.h_view[i] = bb_r1[i];
+    k_bb_r2.h_view[i] = bb_r2[i];
+    k_ba_k1.h_view[i] = ba_k1[i];
+    k_ba_k2.h_view[i] = ba_k2[i];
+    k_ba_r1.h_view[i] = ba_r1[i];
+    k_ba_r2.h_view[i] = ba_r2[i];
+    k_setflag.h_view[i] = setflag[i];
+    k_setflag_a.h_view[i] = setflag_a[i];
+    k_setflag_bb.h_view[i] = setflag_bb[i];
+    k_setflag_ba.h_view[i] = setflag_ba[i];
+    k_theta0.h_view[i] = theta0[i];
+  }
+
+  k_k2.template modify<LMPHostType>();
+  k_k3.template modify<LMPHostType>();
+  k_k4.template modify<LMPHostType>();
+  k_bb_k.template modify<LMPHostType>();
+  k_bb_r1.template modify<LMPHostType>();
+  k_bb_r2.template modify<LMPHostType>();
+  k_ba_k1.template modify<LMPHostType>();
+  k_ba_k2.template modify<LMPHostType>();
+  k_ba_r1.template modify<LMPHostType>();
+  k_ba_r2.template modify<LMPHostType>();
+  k_setflag.template modify<LMPHostType>();
+  k_setflag_a.template modify<LMPHostType>();
+  k_setflag_bb.template modify<LMPHostType>();
+  k_setflag_ba.template modify<LMPHostType>();
+  k_theta0.template modify<LMPHostType>();
+}
+
+/* ----------------------------------------------------------------------
+   tally energy and virial into global and per-atom accumulators
+   virial = r1F1 + r2F2 + r3F3 = (r1-r2) F1 + (r3-r2) F3 = del1*f1 + del2*f3
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+//template<int NEWTON_BOND>
+KOKKOS_INLINE_FUNCTION
+void AngleClass2Kokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int i, const int j, const int k,
+                     F_FLOAT &eangle, F_FLOAT *f1, F_FLOAT *f3,
+                     const F_FLOAT &delx1, const F_FLOAT &dely1, const F_FLOAT &delz1,
+                     const F_FLOAT &delx2, const F_FLOAT &dely2, const F_FLOAT &delz2) const
+{
+  E_FLOAT eanglethird;
+  F_FLOAT v[6];
+
+  // The eatom and vatom arrays are atomic
+  Kokkos::View<E_FLOAT*, typename DAT::t_efloat_1d::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_eatom = k_eatom.template view<DeviceType>();
+  Kokkos::View<F_FLOAT*[6], typename DAT::t_virial_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_vatom = k_vatom.template view<DeviceType>();
+
+  if (eflag_either) {
+    if (eflag_global) {
+      if (newton_bond) ev.evdwl += eangle;
+      else {
+        eanglethird = THIRD*eangle;
+
+        if (i < nlocal) ev.evdwl += eanglethird;
+        if (j < nlocal) ev.evdwl += eanglethird;
+        if (k < nlocal) ev.evdwl += eanglethird;
+      }
+    }
+    if (eflag_atom) {
+      eanglethird = THIRD*eangle;
+
+      if (newton_bond || i < nlocal) v_eatom[i] += eanglethird;
+      if (newton_bond || j < nlocal) v_eatom[j] += eanglethird;
+      if (newton_bond || k < nlocal) v_eatom[k] += eanglethird;
+    }
+  }
+
+  if (vflag_either) {
+    v[0] = delx1*f1[0] + delx2*f3[0];
+    v[1] = dely1*f1[1] + dely2*f3[1];
+    v[2] = delz1*f1[2] + delz2*f3[2];
+    v[3] = delx1*f1[1] + delx2*f3[1];
+    v[4] = delx1*f1[2] + delx2*f3[2];
+    v[5] = dely1*f1[2] + dely2*f3[2];
+
+    if (vflag_global) {
+      if (newton_bond) {
+        ev.v[0] += v[0];
+        ev.v[1] += v[1];
+        ev.v[2] += v[2];
+        ev.v[3] += v[3];
+        ev.v[4] += v[4];
+        ev.v[5] += v[5];
+      } else {
+        if (i < nlocal) {
+          ev.v[0] += THIRD*v[0];
+          ev.v[1] += THIRD*v[1];
+          ev.v[2] += THIRD*v[2];
+          ev.v[3] += THIRD*v[3];
+          ev.v[4] += THIRD*v[4];
+          ev.v[5] += THIRD*v[5];
+        }
+        if (j < nlocal) {
+          ev.v[0] += THIRD*v[0];
+          ev.v[1] += THIRD*v[1];
+          ev.v[2] += THIRD*v[2];
+          ev.v[3] += THIRD*v[3];
+          ev.v[4] += THIRD*v[4];
+          ev.v[5] += THIRD*v[5];
+        }
+        if (k < nlocal) {
+          ev.v[0] += THIRD*v[0];
+
+          ev.v[1] += THIRD*v[1];
+          ev.v[2] += THIRD*v[2];
+          ev.v[3] += THIRD*v[3];
+          ev.v[4] += THIRD*v[4];
+          ev.v[5] += THIRD*v[5];
+        }
+      }
+    }
+
+    if (vflag_atom) {
+      if (newton_bond || i < nlocal) {
+        v_vatom(i,0) += THIRD*v[0];
+        v_vatom(i,1) += THIRD*v[1];
+        v_vatom(i,2) += THIRD*v[2];
+        v_vatom(i,3) += THIRD*v[3];
+        v_vatom(i,4) += THIRD*v[4];
+        v_vatom(i,5) += THIRD*v[5];
+      }
+      if (newton_bond || j < nlocal) {
+        v_vatom(j,0) += THIRD*v[0];
+        v_vatom(j,1) += THIRD*v[1];
+        v_vatom(j,2) += THIRD*v[2];
+        v_vatom(j,3) += THIRD*v[3];
+        v_vatom(j,4) += THIRD*v[4];
+        v_vatom(j,5) += THIRD*v[5];
+      }
+      if (newton_bond || k < nlocal) {
+        v_vatom(k,0) += THIRD*v[0];
+        v_vatom(k,1) += THIRD*v[1];
+        v_vatom(k,2) += THIRD*v[2];
+        v_vatom(k,3) += THIRD*v[3];
+        v_vatom(k,4) += THIRD*v[4];
+        v_vatom(k,5) += THIRD*v[5];
+
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+namespace LAMMPS_NS {
+template class AngleClass2Kokkos<LMPDeviceType>;
+#ifdef KOKKOS_HAVE_CUDA
+template class AngleClass2Kokkos<LMPHostType>;
+#endif
+}
+

--- a/src/KOKKOS/angle_class2_kokkos.h
+++ b/src/KOKKOS/angle_class2_kokkos.h
@@ -35,6 +35,7 @@ class AngleClass2Kokkos : public AngleClass2 {
 
  public:
   typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
   typedef EV_FLOAT value_type;
 
   AngleClass2Kokkos(class LAMMPS *);
@@ -61,29 +62,29 @@ class AngleClass2Kokkos : public AngleClass2 {
 
   class NeighborKokkos *neighborKK;
 
-  typename ArrayTypes<DeviceType>::t_x_array_randomread x;
-  typename ArrayTypes<DeviceType>::t_f_array f;
-  typename ArrayTypes<DeviceType>::t_int_2d anglelist;
+  typename AT::t_x_array_randomread x;
+  typename AT::t_f_array f;
+  typename AT::t_int_2d anglelist;
 
-  typename ArrayTypes<DeviceType>::tdual_efloat_1d k_eatom;
-  typename ArrayTypes<DeviceType>::tdual_virial_array k_vatom;
-  typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
-  typename ArrayTypes<DeviceType>::t_virial_array d_vatom;
+  typename AT::tdual_efloat_1d k_eatom;
+  typename AT::tdual_virial_array k_vatom;
+  typename AT::t_efloat_1d d_eatom;
+  typename AT::t_virial_array d_vatom;
 
   int nlocal,newton_bond;
   int eflag,vflag;
 
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_theta0;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_k2, k_k3, k_k4;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_bb_k, k_bb_r1, k_bb_r2;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_ba_k1, k_ba_k2, k_ba_r1, k_ba_r2;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag, k_setflag_a, k_setflag_bb, k_setflag_ba;
+  typename AT::tdual_ffloat_1d k_theta0;
+  typename AT::tdual_ffloat_1d k_k2, k_k3, k_k4;
+  typename AT::tdual_ffloat_1d k_bb_k, k_bb_r1, k_bb_r2;
+  typename AT::tdual_ffloat_1d k_ba_k1, k_ba_k2, k_ba_r1, k_ba_r2;
+  typename AT::tdual_ffloat_1d k_setflag, k_setflag_a, k_setflag_bb, k_setflag_ba;
 
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_theta0;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_k2, d_k3, d_k4;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_bb_k, d_bb_r1, d_bb_r2;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_ba_k1, d_ba_k2, d_ba_r1, d_ba_r2;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag, d_setflag_a, d_setflag_bb, d_setflag_ba;
+  typename AT::t_ffloat_1d d_theta0;
+  typename AT::t_ffloat_1d d_k2, d_k3, d_k4;
+  typename AT::t_ffloat_1d d_bb_k, d_bb_r1, d_bb_r2;
+  typename AT::t_ffloat_1d d_ba_k1, d_ba_k2, d_ba_r1, d_ba_r2;
+  typename AT::t_ffloat_1d d_setflag, d_setflag_a, d_setflag_bb, d_setflag_ba;
 
   virtual void allocate();
 };

--- a/src/KOKKOS/angle_class2_kokkos.h
+++ b/src/KOKKOS/angle_class2_kokkos.h
@@ -1,0 +1,98 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef ANGLE_CLASS
+
+AngleStyle(class2/kk,AngleClass2Kokkos<LMPDeviceType>)
+AngleStyle(class2/kk/device,AngleClass2Kokkos<LMPDeviceType>)
+AngleStyle(class2/kk/host,AngleClass2Kokkos<LMPHostType>)
+
+#else
+
+#ifndef LMP_ANGLE_CLASS2_KOKKOS_H
+#define LMP_ANGLE_CLASS2_KOKKOS_H
+
+#include "angle_class2.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template<int NEWTON_BOND, int EVFLAG>
+struct TagAngleClass2Compute{};
+
+template<class DeviceType>
+class AngleClass2Kokkos : public AngleClass2 {
+
+ public:
+  typedef DeviceType device_type;
+  typedef EV_FLOAT value_type;
+
+  AngleClass2Kokkos(class LAMMPS *);
+  virtual ~AngleClass2Kokkos();
+  virtual void compute(int, int);
+  virtual void coeff(int, char **);
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagAngleClass2Compute<NEWTON_BOND,EVFLAG>, const int&, EV_FLOAT&) const;
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagAngleClass2Compute<NEWTON_BOND,EVFLAG>, const int&) const;
+
+  //template<int NEWTON_BOND>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally(EV_FLOAT &ev, const int i, const int j, const int k,
+                     F_FLOAT &eangle, F_FLOAT *f1, F_FLOAT *f3,
+                     const F_FLOAT &delx1, const F_FLOAT &dely1, const F_FLOAT &delz1,
+                     const F_FLOAT &delx2, const F_FLOAT &dely2, const F_FLOAT &delz2) const;
+
+ protected:
+
+  class NeighborKokkos *neighborKK;
+
+  typename ArrayTypes<DeviceType>::t_x_array_randomread x;
+  typename ArrayTypes<DeviceType>::t_f_array f;
+  typename ArrayTypes<DeviceType>::t_int_2d anglelist;
+
+  typename ArrayTypes<DeviceType>::tdual_efloat_1d k_eatom;
+  typename ArrayTypes<DeviceType>::tdual_virial_array k_vatom;
+  typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
+  typename ArrayTypes<DeviceType>::t_virial_array d_vatom;
+
+  int nlocal,newton_bond;
+  int eflag,vflag;
+
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_theta0;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_k2, k_k3, k_k4;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_bb_k, k_bb_r1, k_bb_r2;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_ba_k1, k_ba_k2, k_ba_r1, k_ba_r2;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag, k_setflag_a, k_setflag_bb, k_setflag_ba;
+
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_theta0;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_k2, d_k3, d_k4;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_bb_k, d_bb_r1, d_bb_r2;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_ba_k1, d_ba_k2, d_ba_r1, d_ba_r2;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag, d_setflag_a, d_setflag_bb, d_setflag_ba;
+
+  virtual void allocate();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+*/

--- a/src/KOKKOS/bond_class2_kokkos.cpp
+++ b/src/KOKKOS/bond_class2_kokkos.cpp
@@ -66,18 +66,18 @@ void BondClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   // reallocate per-atom arrays if necessary
 
   if (eflag_atom) {
-    if(k_eatom.dimension_0()<maxeatom) {
+    //if(k_eatom.dimension_0()<maxeatom) { // won't work without adding zero functor
       memory->destroy_kokkos(k_eatom,eatom);
       memory->create_kokkos(k_eatom,eatom,maxeatom,"improper:eatom");
-      d_eatom = k_eatom.d_view;
-    }
+      d_eatom = k_eatom.template view<DeviceType>();
+    //}
   }
   if (vflag_atom) {
-    if(k_vatom.dimension_0()<maxvatom) {
+    //if(k_vatom.dimension_0()<maxvatom) { // won't work without adding zero functor
       memory->destroy_kokkos(k_vatom,vatom);
       memory->create_kokkos(k_vatom,vatom,maxvatom,6,"improper:vatom");
-      d_vatom = k_vatom.d_view;
-    }
+      d_vatom = k_vatom.template view<DeviceType>();
+    //}
   }
 
 //  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);

--- a/src/KOKKOS/bond_class2_kokkos.cpp
+++ b/src/KOKKOS/bond_class2_kokkos.cpp
@@ -1,0 +1,338 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Ray Shan (Materials Design)
+------------------------------------------------------------------------- */
+
+#include <math.h>
+#include <stdlib.h>
+#include "bond_class2_kokkos.h"
+#include "atom_kokkos.h"
+#include "neighbor_kokkos.h"
+#include "domain.h"
+#include "comm.h"
+#include "force.h"
+#include "memory.h"
+#include "error.h"
+#include "atom_masks.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+BondClass2Kokkos<DeviceType>::BondClass2Kokkos(LAMMPS *lmp) : BondClass2(lmp)
+{
+  atomKK = (AtomKokkos *) atom;
+  neighborKK = (NeighborKokkos *) neighbor;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | F_MASK | ENERGY_MASK | VIRIAL_MASK;
+  datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+BondClass2Kokkos<DeviceType>::~BondClass2Kokkos()
+{
+  if (!copymode) {
+    memory->destroy_kokkos(k_eatom,eatom);
+    memory->destroy_kokkos(k_vatom,vatom);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void BondClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  eflag = eflag_in;
+  vflag = vflag_in;
+
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = 0;
+
+  // reallocate per-atom arrays if necessary
+
+  if (eflag_atom) {
+    if(k_eatom.dimension_0()<maxeatom) {
+      memory->destroy_kokkos(k_eatom,eatom);
+      memory->create_kokkos(k_eatom,eatom,maxeatom,"improper:eatom");
+      d_eatom = k_eatom.d_view;
+    }
+  }
+  if (vflag_atom) {
+    if(k_vatom.dimension_0()<maxvatom) {
+      memory->destroy_kokkos(k_vatom,vatom);
+      memory->create_kokkos(k_vatom,vatom,maxvatom,6,"improper:vatom");
+      d_vatom = k_vatom.d_view;
+    }
+  }
+
+//  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+//  else atomKK->modified(execution_space,F_MASK);
+
+  x = atomKK->k_x.template view<DeviceType>();
+  f = atomKK->k_f.template view<DeviceType>();
+  neighborKK->k_bondlist.template sync<DeviceType>();
+  bondlist = neighborKK->k_bondlist.template view<DeviceType>();
+  int nbondlist = neighborKK->nbondlist;
+  nlocal = atom->nlocal;
+  newton_bond = force->newton_bond;
+
+  copymode = 1;
+
+  // loop over neighbors of my atoms
+
+  EV_FLOAT ev;
+
+  if (evflag) {
+    if (newton_bond) {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagBondClass2Compute<1,1> >(0,nbondlist),*this,ev);
+    } else {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagBondClass2Compute<0,1> >(0,nbondlist),*this,ev);
+    }
+  } else {
+    if (newton_bond) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagBondClass2Compute<1,0> >(0,nbondlist),*this);
+    } else {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagBondClass2Compute<0,0> >(0,nbondlist),*this);
+    }
+  }
+  //DeviceType::fence();
+
+  if (eflag_global) energy += ev.evdwl;
+  if (vflag_global) {
+    virial[0] += ev.v[0];
+    virial[1] += ev.v[1];
+    virial[2] += ev.v[2];
+    virial[3] += ev.v[3];
+    virial[4] += ev.v[4];
+    virial[5] += ev.v[5];
+  }
+
+  if (eflag_atom) {
+    k_eatom.template modify<DeviceType>();
+    k_eatom.template sync<LMPHostType>();
+  }
+
+  if (vflag_atom) {
+    k_vatom.template modify<DeviceType>();
+    k_vatom.template sync<LMPHostType>();
+  }
+
+  copymode = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void BondClass2Kokkos<DeviceType>::operator()(TagBondClass2Compute<NEWTON_BOND,EVFLAG>, const int &n, EV_FLOAT& ev) const {
+
+  const int i1 = bondlist(n,0);
+  const int i2 = bondlist(n,1);
+  const int type = bondlist(n,2);
+
+  const F_FLOAT delx = x(i1,0) - x(i2,0);
+  const F_FLOAT dely = x(i1,1) - x(i2,1);
+  const F_FLOAT delz = x(i1,2) - x(i2,2);
+
+  const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
+  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT dr = r - d_r0[type];
+  const F_FLOAT dr2 = dr*dr;
+  const F_FLOAT dr3 = dr2*dr;
+  const F_FLOAT dr4 = dr3*dr;
+
+  // force & energy
+
+  F_FLOAT ebond, fbond, de_bond;
+
+  de_bond = 2.0*d_k2[type]*dr + 3.0*d_k3[type]*dr2 + 4.0*d_k4[type]*dr3;
+  if (r > 0.0) fbond = -de_bond/r;
+  else fbond = 0.0;
+
+  if (eflag) ebond = d_k2[type]*dr2 + d_k3[type]*dr3 + d_k4[type]*dr4;
+
+  // apply force to each of 2 atoms
+
+  if (NEWTON_BOND || i1 < nlocal) {
+    f(i1,0) += delx*fbond;
+    f(i1,1) += dely*fbond;
+    f(i1,2) += delz*fbond;
+  }
+
+  if (NEWTON_BOND || i2 < nlocal) {
+    f(i2,0) -= delx*fbond;
+    f(i2,1) -= dely*fbond;
+    f(i2,2) -= delz*fbond;
+  }
+
+  if (EVFLAG) ev_tally(ev,i1,i2,ebond,fbond,delx,dely,delz);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void BondClass2Kokkos<DeviceType>::operator()(TagBondClass2Compute<NEWTON_BOND,EVFLAG>, const int &n) const {
+  EV_FLOAT ev;
+  this->template operator()<NEWTON_BOND,EVFLAG>(TagBondClass2Compute<NEWTON_BOND,EVFLAG>(), n, ev);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void BondClass2Kokkos<DeviceType>::allocate()
+{
+  BondClass2::allocate();
+}
+
+/* ----------------------------------------------------------------------
+   set coeffs for one type
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void BondClass2Kokkos<DeviceType>::coeff(int narg, char **arg)
+{
+  BondClass2::coeff(narg, arg);
+
+  int n = atom->nbondtypes;
+  Kokkos::DualView<F_FLOAT*,DeviceType> k_k2("BondClass2::k2",n+1);
+  Kokkos::DualView<F_FLOAT*,DeviceType> k_k3("BondClass2::k3",n+1);
+  Kokkos::DualView<F_FLOAT*,DeviceType> k_k4("BondClass2::k4",n+1);
+  Kokkos::DualView<F_FLOAT*,DeviceType> k_r0("BondClass2::r0",n+1);
+
+  d_k2 = k_k2.template view<DeviceType>();
+  d_k3 = k_k3.template view<DeviceType>();
+  d_k4 = k_k4.template view<DeviceType>();
+  d_r0 = k_r0.template view<DeviceType>();
+
+  for (int i = 1; i <= n; i++) {
+    k_k2.h_view[i] = k2[i];
+    k_k3.h_view[i] = k3[i];
+    k_k4.h_view[i] = k4[i];
+    k_r0.h_view[i] = r0[i];
+  }
+
+  k_k2.template modify<LMPHostType>();
+  k_k2.template sync<DeviceType>();
+  k_k3.template modify<LMPHostType>();
+  k_k3.template sync<DeviceType>();
+  k_k4.template modify<LMPHostType>();
+  k_k4.template sync<DeviceType>();
+  k_r0.template modify<LMPHostType>();
+  k_r0.template sync<DeviceType>();
+
+}
+
+/* ----------------------------------------------------------------------
+   tally energy and virial into global and per-atom accumulators
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+//template<int NEWTON_BOND>
+KOKKOS_INLINE_FUNCTION
+void BondClass2Kokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const int &j,
+      const F_FLOAT &ebond, const F_FLOAT &fbond, const F_FLOAT &delx,
+                const F_FLOAT &dely, const F_FLOAT &delz) const
+{
+  E_FLOAT ebondhalf;
+  F_FLOAT v[6];
+
+  if (eflag_either) {
+    if (eflag_global) {
+      if (newton_bond) ev.evdwl += ebond;
+      else {
+        ebondhalf = 0.5*ebond;
+        if (i < nlocal) ev.evdwl += ebondhalf;
+        if (j < nlocal) ev.evdwl += ebondhalf;
+      }
+    }
+    if (eflag_atom) {
+      ebondhalf = 0.5*ebond;
+      if (newton_bond || i < nlocal) d_eatom[i] += ebondhalf;
+      if (newton_bond || j < nlocal) d_eatom[j] += ebondhalf;
+    }
+  }
+
+  if (vflag_either) {
+    v[0] = delx*delx*fbond;
+    v[1] = dely*dely*fbond;
+    v[2] = delz*delz*fbond;
+    v[3] = delx*dely*fbond;
+    v[4] = delx*delz*fbond;
+    v[5] = dely*delz*fbond;
+
+    if (vflag_global) {
+      if (newton_bond) {
+        ev.v[0] += v[0];
+        ev.v[1] += v[1];
+        ev.v[2] += v[2];
+        ev.v[3] += v[3];
+        ev.v[4] += v[4];
+        ev.v[5] += v[5];
+      } else {
+        if (i < nlocal) {
+          ev.v[0] += 0.5*v[0];
+          ev.v[1] += 0.5*v[1];
+          ev.v[2] += 0.5*v[2];
+          ev.v[3] += 0.5*v[3];
+          ev.v[4] += 0.5*v[4];
+          ev.v[5] += 0.5*v[5];
+        }
+        if (j < nlocal) {
+          ev.v[0] += 0.5*v[0];
+          ev.v[1] += 0.5*v[1];
+          ev.v[2] += 0.5*v[2];
+          ev.v[3] += 0.5*v[3];
+          ev.v[4] += 0.5*v[4];
+          ev.v[5] += 0.5*v[5];
+        }
+      }
+    }
+
+    if (vflag_atom) {
+      if (newton_bond || i < nlocal) {
+        d_vatom(i,0) += 0.5*v[0];
+        d_vatom(i,1) += 0.5*v[1];
+        d_vatom(i,2) += 0.5*v[2];
+        d_vatom(i,3) += 0.5*v[3];
+        d_vatom(i,4) += 0.5*v[4];
+        d_vatom(i,5) += 0.5*v[5];
+      }
+      if (newton_bond || j < nlocal) {
+        d_vatom(j,0) += 0.5*v[0];
+        d_vatom(j,1) += 0.5*v[1];
+        d_vatom(j,2) += 0.5*v[2];
+        d_vatom(j,3) += 0.5*v[3];
+        d_vatom(j,4) += 0.5*v[4];
+        d_vatom(j,5) += 0.5*v[5];
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+namespace LAMMPS_NS {
+template class BondClass2Kokkos<LMPDeviceType>;
+#ifdef KOKKOS_HAVE_CUDA
+template class BondClass2Kokkos<LMPHostType>;
+#endif
+}
+

--- a/src/KOKKOS/bond_class2_kokkos.h
+++ b/src/KOKKOS/bond_class2_kokkos.h
@@ -35,6 +35,7 @@ class BondClass2Kokkos : public BondClass2 {
 
  public:
   typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
   typedef EV_FLOAT value_type;
 
   BondClass2Kokkos(class LAMMPS *);
@@ -60,7 +61,6 @@ class BondClass2Kokkos : public BondClass2 {
 
   class NeighborKokkos *neighborKK;
 
-  typedef ArrayTypes<DeviceType> AT;
   typename AT::t_x_array_randomread x;
   typename Kokkos::View<double*[3],typename AT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic> > f;
   typename AT::t_int_2d bondlist;

--- a/src/KOKKOS/bond_class2_kokkos.h
+++ b/src/KOKKOS/bond_class2_kokkos.h
@@ -1,0 +1,89 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef BOND_CLASS
+
+BondStyle(class2/kk,BondClass2Kokkos<LMPDeviceType>)
+BondStyle(class2/kk/device,BondClass2Kokkos<LMPDeviceType>)
+BondStyle(class2/kk/host,BondClass2Kokkos<LMPHostType>)
+
+#else
+
+#ifndef LMP_BOND_CLASS2_KOKKOS_H
+#define LMP_BOND_CLASS2_KOKKOS_H
+
+#include "bond_class2.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template<int NEWTON_BOND, int EVFLAG>
+struct TagBondClass2Compute{};
+
+template<class DeviceType>
+class BondClass2Kokkos : public BondClass2 {
+
+ public:
+  typedef DeviceType device_type;
+  typedef EV_FLOAT value_type;
+
+  BondClass2Kokkos(class LAMMPS *);
+  virtual ~BondClass2Kokkos();
+  virtual void compute(int, int);
+  virtual void coeff(int, char **);
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagBondClass2Compute<NEWTON_BOND,EVFLAG>, const int&, EV_FLOAT&) const;
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagBondClass2Compute<NEWTON_BOND,EVFLAG>, const int&) const;
+
+  //template<int NEWTON_BOND>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally(EV_FLOAT &ev, const int &i, const int &j,
+      const F_FLOAT &ebond, const F_FLOAT &fbond, const F_FLOAT &delx,
+                  const F_FLOAT &dely, const F_FLOAT &delz) const;
+
+ protected:
+
+  class NeighborKokkos *neighborKK;
+
+  typedef ArrayTypes<DeviceType> AT;
+  typename AT::t_x_array_randomread x;
+  typename Kokkos::View<double*[3],typename AT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic> > f;
+  typename AT::t_int_2d bondlist;
+
+  Kokkos::DualView<E_FLOAT*,Kokkos::LayoutRight,DeviceType> k_eatom;
+  Kokkos::DualView<F_FLOAT*[6],Kokkos::LayoutRight,DeviceType> k_vatom;
+  Kokkos::View<E_FLOAT*,Kokkos::LayoutRight,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic> > d_eatom;
+  Kokkos::View<F_FLOAT*[6],Kokkos::LayoutRight,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic> > d_vatom;
+
+  int nlocal,newton_bond;
+  int eflag,vflag;
+
+  typename AT::t_ffloat_1d d_k2, d_k3, d_k4;
+  typename AT::t_ffloat_1d d_r0;
+
+  virtual void allocate();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+*/

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -77,15 +77,15 @@ void DihedralClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   if (eflag_atom) {
     memory->destroy_kokkos(k_eatom,eatom);
     memory->create_kokkos(k_eatom,eatom,maxeatom,"dihedral:eatom");
-    d_eatom = k_eatom.d_view;
+    d_eatom = k_eatom.template view<DeviceType>();
   }
   if (vflag_atom) {
     memory->destroy_kokkos(k_vatom,vatom);
     memory->create_kokkos(k_vatom,vatom,maxvatom,6,"dihedral:vatom");
-    d_vatom = k_vatom.d_view;
+    d_vatom = k_vatom.template view<DeviceType>();
   }
 
-  atomKK->sync(execution_space,datamask_read);
+  //atomKK->sync(execution_space,datamask_read);
   k_k1.template sync<DeviceType>();
   k_k2.template sync<DeviceType>(); 
   k_k3.template sync<DeviceType>();
@@ -125,8 +125,8 @@ void DihedralClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_setflag_aat.template sync<DeviceType>(); 
   k_setflag_bb13t.template sync<DeviceType>();
 
-  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
-  else atomKK->modified(execution_space,F_MASK);
+  //if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  //else atomKK->modified(execution_space,F_MASK);
 
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -1,0 +1,965 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Ray Shan (Materials Design)
+------------------------------------------------------------------------- */
+
+#include <math.h>
+#include <stdlib.h>
+#include "dihedral_class2_kokkos.h"
+#include "atom_kokkos.h"
+#include "comm.h"
+#include "neighbor_kokkos.h"
+#include "domain.h"
+#include "force.h"
+#include "update.h"
+#include "memory.h"
+#include "error.h"
+#include "atom_masks.h"
+
+using namespace LAMMPS_NS;
+
+#define TOLERANCE 0.05
+#define SMALL     0.001
+#define SMALLER   0.00001
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+DihedralClass2Kokkos<DeviceType>::DihedralClass2Kokkos(LAMMPS *lmp) : DihedralClass2(lmp)
+{
+  atomKK = (AtomKokkos *) atom;
+  neighborKK = (NeighborKokkos *) neighbor;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | F_MASK | Q_MASK | ENERGY_MASK | VIRIAL_MASK;
+  datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+
+  k_warning_flag = DAT::tdual_int_scalar("Dihedral:warning_flag");
+  d_warning_flag = k_warning_flag.view<DeviceType>();
+  h_warning_flag = k_warning_flag.h_view;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+DihedralClass2Kokkos<DeviceType>::~DihedralClass2Kokkos()
+{
+  if (!copymode) {
+    memory->destroy_kokkos(k_eatom,eatom);
+    memory->destroy_kokkos(k_vatom,vatom);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void DihedralClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  eflag = eflag_in;
+  vflag = vflag_in;
+
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = 0;
+
+  // reallocate per-atom arrays if necessary
+
+  if (eflag_atom) {
+    memory->destroy_kokkos(k_eatom,eatom);
+    memory->create_kokkos(k_eatom,eatom,maxeatom,"dihedral:eatom");
+    d_eatom = k_eatom.d_view;
+  }
+  if (vflag_atom) {
+    memory->destroy_kokkos(k_vatom,vatom);
+    memory->create_kokkos(k_vatom,vatom,maxvatom,6,"dihedral:vatom");
+    d_vatom = k_vatom.d_view;
+  }
+
+  atomKK->sync(execution_space,datamask_read);
+  k_k1.template sync<DeviceType>();
+  k_k2.template sync<DeviceType>(); 
+  k_k3.template sync<DeviceType>();
+  k_phi1.template sync<DeviceType>();
+  k_phi2.template sync<DeviceType>();
+  k_phi3.template sync<DeviceType>();
+  k_mbt_f1.template sync<DeviceType>();
+  k_mbt_f2.template sync<DeviceType>();
+  k_mbt_f3.template sync<DeviceType>();
+  k_mbt_r0.template sync<DeviceType>(); 
+  k_ebt_f1_1.template sync<DeviceType>();
+  k_ebt_f2_1.template sync<DeviceType>();
+  k_ebt_f3_1.template sync<DeviceType>();
+  k_ebt_r0_1.template sync<DeviceType>();
+  k_ebt_f1_2.template sync<DeviceType>();
+  k_ebt_f2_2.template sync<DeviceType>();
+  k_ebt_f3_2.template sync<DeviceType>();
+  k_ebt_r0_2.template sync<DeviceType>();
+  k_at_f1_1.template sync<DeviceType>();
+  k_at_f2_1.template sync<DeviceType>();
+  k_at_f3_1.template sync<DeviceType>();
+  k_at_f1_2.template sync<DeviceType>();
+  k_at_f2_2.template sync<DeviceType>(); 
+  k_at_f3_2.template sync<DeviceType>(); 
+  k_at_theta0_1.template sync<DeviceType>();
+  k_at_theta0_2.template sync<DeviceType>();
+  k_aat_k.template sync<DeviceType>();
+  k_aat_theta0_1.template sync<DeviceType>();
+  k_aat_theta0_2.template sync<DeviceType>();
+  k_bb13t_k.template sync<DeviceType>(); 
+  k_bb13t_r10.template sync<DeviceType>();
+  k_bb13t_r30.template sync<DeviceType>(); 
+  k_setflag_d.template sync<DeviceType>(); 
+  k_setflag_mbt.template sync<DeviceType>();
+  k_setflag_ebt.template sync<DeviceType>();
+  k_setflag_at.template sync<DeviceType>(); 
+  k_setflag_aat.template sync<DeviceType>(); 
+  k_setflag_bb13t.template sync<DeviceType>();
+
+  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  else atomKK->modified(execution_space,F_MASK);
+
+  x = atomKK->k_x.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  neighborKK->k_dihedrallist.template sync<DeviceType>();
+  dihedrallist = neighborKK->k_dihedrallist.view<DeviceType>();
+  int ndihedrallist = neighborKK->ndihedrallist;
+  nlocal = atom->nlocal;
+  newton_bond = force->newton_bond;
+
+  h_warning_flag() = 0;
+  k_warning_flag.template modify<LMPHostType>();
+  k_warning_flag.template sync<DeviceType>();
+
+  copymode = 1;
+
+  // loop over neighbors of my atoms
+
+  EV_FLOAT ev;
+
+  if (evflag) {
+    if (newton_bond) {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagDihedralClass2Compute<1,1> >(0,ndihedrallist),*this,ev);
+    } else {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagDihedralClass2Compute<0,1> >(0,ndihedrallist),*this,ev);
+    }
+  } else {
+    if (newton_bond) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagDihedralClass2Compute<1,0> >(0,ndihedrallist),*this);
+    } else {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagDihedralClass2Compute<0,0> >(0,ndihedrallist),*this);
+    }
+  }
+  DeviceType::fence();
+
+  // error check
+
+  k_warning_flag.template modify<DeviceType>();
+  k_warning_flag.template sync<LMPHostType>();
+  if (h_warning_flag())
+    error->warning(FLERR,"Dihedral problem",0);
+
+  if (eflag_global) energy += ev.evdwl;
+  if (vflag_global) {
+    virial[0] += ev.v[0];
+    virial[1] += ev.v[1];
+    virial[2] += ev.v[2];
+    virial[3] += ev.v[3];
+    virial[4] += ev.v[4];
+    virial[5] += ev.v[5];
+  }
+
+  if (eflag_atom) {
+    k_eatom.template modify<DeviceType>();
+    k_eatom.template sync<LMPHostType>();
+  }
+
+  if (vflag_atom) {
+    k_vatom.template modify<DeviceType>();
+    k_vatom.template sync<LMPHostType>();
+  }
+
+  copymode = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTON_BOND,EVFLAG>, const int &n, EV_FLOAT& ev) const {
+
+  // The f array is atomic
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > a_f = f;
+
+  const int i1 = dihedrallist(n,0);
+  const int i2 = dihedrallist(n,1);
+  const int i3 = dihedrallist(n,2);
+  const int i4 = dihedrallist(n,3);
+  const int type = dihedrallist(n,4);
+
+  // 1st bond
+
+  const F_FLOAT vb1x = x(i1,0) - x(i2,0);
+  const F_FLOAT vb1y = x(i1,1) - x(i2,1);
+  const F_FLOAT vb1z = x(i1,2) - x(i2,2);
+
+  // 2nd bond
+
+  const F_FLOAT vb2x = x(i3,0) - x(i2,0);
+  const F_FLOAT vb2y = x(i3,1) - x(i2,1);
+  const F_FLOAT vb2z = x(i3,2) - x(i2,2);
+
+  const F_FLOAT vb2xm = -vb2x;
+  const F_FLOAT vb2ym = -vb2y;
+  const F_FLOAT vb2zm = -vb2z;
+
+  // 3rd bond
+
+  const F_FLOAT vb3x = x(i4,0) - x(i3,0);
+  const F_FLOAT vb3y = x(i4,1) - x(i3,1);
+  const F_FLOAT vb3z = x(i4,2) - x(i3,2);
+
+  // distance: c0 calculation
+ 
+  const F_FLOAT r1mag2 = vb1x*vb1x + vb1y*vb1y + vb1z*vb1z;
+  const F_FLOAT r1 = sqrt(r1mag2);
+  const F_FLOAT r2mag2 = vb2x*vb2x + vb2y*vb2y + vb2z*vb2z;
+  const F_FLOAT r2 = sqrt(r2mag2);
+  const F_FLOAT r3mag2 = vb3x*vb3x + vb3y*vb3y + vb3z*vb3z;
+  const F_FLOAT r3 = sqrt(r3mag2);
+
+  const F_FLOAT sb1 = 1.0/r1mag2;
+  const F_FLOAT rb1 = 1.0/r1;
+  const F_FLOAT sb2 = 1.0/r2mag2;
+  const F_FLOAT rb2 = 1.0/r2;
+  const F_FLOAT sb3 = 1.0/r3mag2;
+  const F_FLOAT rb3 = 1.0/r3;
+
+  const F_FLOAT c0 = (vb1x*vb3x + vb1y*vb3y + vb1z*vb3z) * rb1*rb3;
+
+  // 1st and 2nd angle
+ 
+  const F_FLOAT r12c1 = rb1*rb2;
+  const F_FLOAT r12c2 = rb2*rb3;
+  const F_FLOAT costh12 = (vb1x*vb2x + vb1y*vb2y + vb1z*vb2z) * r12c1;
+  const F_FLOAT costh13 = c0;
+  const F_FLOAT costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
+
+  // cos and sin of 2 angles and final c
+
+  F_FLOAT sin2 = MAX(1.0 - costh12*costh12,0.0);
+  F_FLOAT sc1 = sqrt(sin2);
+  if (sc1 < SMALL) sc1 = SMALL;
+  sc1 = 1.0/sc1;
+
+  sin2 = MAX(1.0 - costh23*costh23,0.0);
+  F_FLOAT sc2 = sqrt(sin2);
+  if (sc2 < SMALL) sc2 = SMALL;
+  sc2 = 1.0/sc2;
+
+  const F_FLOAT s1 = sc1 * sc1;
+  const F_FLOAT s2 = sc2 * sc2;
+  const F_FLOAT s12 = sc1 * sc2;
+  F_FLOAT c = (c0 + costh12*costh23) * s12;
+
+  // error check
+
+  if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
+    Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+
+  if (c > 1.0) c = 1.0;
+  if (c < -1.0) c = -1.0;
+  const F_FLOAT cosphi = c;
+  F_FLOAT phi = acos(c);
+
+  F_FLOAT sinphi = sqrt(1.0 - c*c);
+  sinphi = MAX(sinphi,SMALL);
+
+  // n123 = vb1 x vb2
+
+  const F_FLOAT n123x = vb1y*vb2z - vb1z*vb2y;
+  const F_FLOAT n123y = vb1z*vb2x - vb1x*vb2z;
+  const F_FLOAT n123z = vb1x*vb2y - vb1y*vb2x;
+  const F_FLOAT n123_dot_vb3 = n123x*vb3x + n123y*vb3y + n123z*vb3z;
+  if (n123_dot_vb3 > 0.0) {
+    phi = -phi;
+    sinphi = -sinphi;
+  }
+
+  const F_FLOAT a11 = -c*sb1*s1;
+  const F_FLOAT a22 = sb2 * (2.0*costh13*s12 - c*(s1+s2));
+  const F_FLOAT a33 = -c*sb3*s2;
+  const F_FLOAT a12 = r12c1 * (costh12*c*s1 + costh23*s12);
+  const F_FLOAT a13 = rb1*rb3*s12;
+  const F_FLOAT a23 = r12c2 * (-costh23*c*s2 - costh12*s12);
+
+  const F_FLOAT sx1  = a11*vb1x + a12*vb2x + a13*vb3x;
+  const F_FLOAT sx2  = a12*vb1x + a22*vb2x + a23*vb3x;
+  const F_FLOAT sx12 = a13*vb1x + a23*vb2x + a33*vb3x;
+  const F_FLOAT sy1  = a11*vb1y + a12*vb2y + a13*vb3y;
+  const F_FLOAT sy2  = a12*vb1y + a22*vb2y + a23*vb3y;
+  const F_FLOAT sy12 = a13*vb1y + a23*vb2y + a33*vb3y;
+  const F_FLOAT sz1  = a11*vb1z + a12*vb2z + a13*vb3z;
+  const F_FLOAT sz2  = a12*vb1z + a22*vb2z + a23*vb3z;
+  const F_FLOAT sz12 = a13*vb1z + a23*vb2z + a33*vb3z;
+
+  // set up d(cos(phi))/d(r) and dphi/dr arrays
+
+  F_FLOAT dcosphidr[4][3], dphidr[4][3];
+
+  dcosphidr[0][0] = -sx1;
+  dcosphidr[0][1] = -sy1;
+  dcosphidr[0][2] = -sz1;
+  dcosphidr[1][0] = sx2 + sx1;
+  dcosphidr[1][1] = sy2 + sy1;
+  dcosphidr[1][2] = sz2 + sz1;
+  dcosphidr[2][0] = sx12 - sx2;
+  dcosphidr[2][1] = sy12 - sy2;
+  dcosphidr[2][2] = sz12 - sz2;
+  dcosphidr[3][0] = -sx12;
+  dcosphidr[3][1] = -sy12;
+  dcosphidr[3][2] = -sz12;
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      dphidr[i][j] = -dcosphidr[i][j] / sinphi;
+
+  // energy
+
+  F_FLOAT edihedral = 0.0;
+
+  const F_FLOAT dphi1 = phi - d_phi1[type];
+  const F_FLOAT dphi2 = 2.0*phi - d_phi2[type];
+  const F_FLOAT dphi3 = 3.0*phi - d_phi3[type];
+
+  if (eflag) edihedral = d_k1[type]*(1.0 - cos(dphi1)) +
+                 	 d_k2[type]*(1.0 - cos(dphi2)) +
+                 	 d_k3[type]*(1.0 - cos(dphi3));
+
+  const F_FLOAT de_dihedral = d_k1[type]*sin(dphi1) + 2.0*d_k2[type]*sin(dphi2) +
+      3.0*d_k3[type]*sin(dphi3);
+
+  // torsion forces on all 4 atoms
+
+  F_FLOAT dbonddr[3][4][3], fabcd[4][3];
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      fabcd[i][j] = de_dihedral*dphidr[i][j];
+
+  // set up d(bond)/d(r) array
+  // dbonddr(i,j,k) = bond i, atom j, coordinate k
+
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 4; j++)
+      for (int k = 0; k < 3; k++)
+        dbonddr[i][j][k] = 0.0;
+
+  // bond1
+
+  dbonddr[0][0][0] = vb1x / r1;
+  dbonddr[0][0][1] = vb1y / r1;
+  dbonddr[0][0][2] = vb1z / r1;
+  dbonddr[0][1][0] = -vb1x / r1;
+  dbonddr[0][1][1] = -vb1y / r1;
+  dbonddr[0][1][2] = -vb1z / r1;
+
+  // bond2
+
+  dbonddr[1][1][0] = vb2x / r2;
+  dbonddr[1][1][1] = vb2y / r2;
+  dbonddr[1][1][2] = vb2z / r2;
+  dbonddr[1][2][0] = -vb2x / r2;
+  dbonddr[1][2][1] = -vb2y / r2;
+  dbonddr[1][2][2] = -vb2z / r2;
+
+  // bond3
+
+  dbonddr[2][2][0] = vb3x / r3;
+  dbonddr[2][2][1] = vb3y / r3;
+  dbonddr[2][2][2] = vb3z / r3;
+  dbonddr[2][3][0] = -vb3x / r3;
+  dbonddr[2][3][1] = -vb3y / r3;
+  dbonddr[2][3][2] = -vb3z / r3;
+
+  // set up d(theta)/d(r) array
+  // dthetadr(i,j,k) = angle i, atom j, coordinate k
+  
+  F_FLOAT dthetadr[2][4][3];
+
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 4; j++)
+      for (int k = 0; k < 3; k++)
+        dthetadr[i][j][k] = 0.0;
+
+  const F_FLOAT t1 = costh12 / r1mag2;
+  const F_FLOAT t2 = costh23 / r2mag2;
+  const F_FLOAT t3 = costh12 / r2mag2;
+  const F_FLOAT t4 = costh23 / r3mag2;
+
+  // angle12
+
+  dthetadr[0][0][0] = sc1 * ((t1 * vb1x) - (vb2x * r12c1));
+  dthetadr[0][0][1] = sc1 * ((t1 * vb1y) - (vb2y * r12c1));
+  dthetadr[0][0][2] = sc1 * ((t1 * vb1z) - (vb2z * r12c1));
+
+  dthetadr[0][1][0] = sc1 * ((-t1 * vb1x) + (vb2x * r12c1) +
+                             (-t3 * vb2x) + (vb1x * r12c1));
+  dthetadr[0][1][1] = sc1 * ((-t1 * vb1y) + (vb2y * r12c1) +
+                 (-t3 * vb2y) + (vb1y * r12c1));
+  dthetadr[0][1][2] = sc1 * ((-t1 * vb1z) + (vb2z * r12c1) +
+                             (-t3 * vb2z) + (vb1z * r12c1));
+
+  dthetadr[0][2][0] = sc1 * ((t3 * vb2x) - (vb1x * r12c1));
+  dthetadr[0][2][1] = sc1 * ((t3 * vb2y) - (vb1y * r12c1));
+  dthetadr[0][2][2] = sc1 * ((t3 * vb2z) - (vb1z * r12c1));
+
+  // angle23
+
+  dthetadr[1][1][0] = sc2 * ((t2 * vb2x) + (vb3x * r12c2));
+  dthetadr[1][1][1] = sc2 * ((t2 * vb2y) + (vb3y * r12c2));
+  dthetadr[1][1][2] = sc2 * ((t2 * vb2z) + (vb3z * r12c2));
+
+  dthetadr[1][2][0] = sc2 * ((-t2 * vb2x) - (vb3x * r12c2) +
+                 	      (t4 * vb3x) + (vb2x * r12c2));
+  dthetadr[1][2][1] = sc2 * ((-t2 * vb2y) - (vb3y * r12c2) +
+                 	      (t4 * vb3y) + (vb2y * r12c2));
+  dthetadr[1][2][2] = sc2 * ((-t2 * vb2z) - (vb3z * r12c2) +
+                 	      (t4 * vb3z) + (vb2z * r12c2));
+
+  dthetadr[1][3][0] = -sc2 * ((t4 * vb3x) + (vb2x * r12c2));
+  dthetadr[1][3][1] = -sc2 * ((t4 * vb3y) + (vb2y * r12c2));
+  dthetadr[1][3][2] = -sc2 * ((t4 * vb3z) + (vb2z * r12c2));
+
+  // mid-bond/torsion coupling
+  // energy on bond2 (middle bond)
+
+  F_FLOAT cos2phi = cos(2.0*phi);
+  F_FLOAT cos3phi = cos(3.0*phi);
+
+  F_FLOAT bt1 = d_mbt_f1[type] * cosphi;
+  F_FLOAT bt2 = d_mbt_f2[type] * cos2phi;
+  F_FLOAT bt3 = d_mbt_f3[type] * cos3phi;
+  F_FLOAT sumbte = bt1 + bt2 + bt3;
+  F_FLOAT db = r2 - d_mbt_r0[type];
+  if (eflag) edihedral += db * sumbte;
+
+  // force on bond2
+
+  bt1 = -d_mbt_f1[type] * sinphi;
+  bt2 = -2.0 * d_mbt_f2[type] * sin(2.0*phi);
+  bt3 = -3.0 * d_mbt_f3[type] * sin(3.0*phi);
+  F_FLOAT sumbtf = bt1 + bt2 + bt3;
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      fabcd[i][j] += db*sumbtf*dphidr[i][j] + sumbte*dbonddr[1][i][j];
+
+  // end-bond/torsion coupling
+  // energy on bond1 (first bond)
+
+  bt1 = d_ebt_f1_1[type] * cosphi;
+  bt2 = d_ebt_f2_1[type] * cos2phi;
+  bt3 = d_ebt_f3_1[type] * cos3phi;
+  sumbte = bt1 + bt2 + bt3;
+
+  db = r1 - d_ebt_r0_1[type];
+  if (eflag) edihedral += db * (bt1+bt2+bt3);
+
+  // force on bond1
+
+  bt1 = d_ebt_f1_1[type] * sinphi;
+  bt2 = 2.0 * d_ebt_f2_1[type] * sin(2.0*phi);
+  bt3 = 3.0 * d_ebt_f3_1[type] * sin(3.0*phi);
+  sumbtf = bt1 + bt2 + bt3;
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      fabcd[i][j] -= db*sumbtf*dphidr[i][j] + sumbte*dbonddr[0][i][j];
+
+  // end-bond/torsion coupling
+  // energy on bond3 (last bond)
+
+  bt1 = d_ebt_f1_2[type] * cosphi;
+  bt2 = d_ebt_f2_2[type] * cos2phi;
+  bt3 = d_ebt_f3_2[type] * cos3phi;
+  sumbte = bt1 + bt2 + bt3;
+
+  db = r3 - d_ebt_r0_2[type];
+  if (eflag) edihedral += db * (bt1+bt2+bt3);
+
+  // force on bond3
+
+  bt1 = -d_ebt_f1_2[type] * sinphi;
+  bt2 = -2.0 * d_ebt_f2_2[type] * sin(2.0*phi);
+  bt3 = -3.0 * d_ebt_f3_2[type] * sin(3.0*phi);
+  sumbtf = bt1 + bt2 + bt3;
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      fabcd[i][j] += db*sumbtf*dphidr[i][j] + sumbte*dbonddr[2][i][j];
+
+  // angle/torsion coupling
+  // energy on angle1
+
+  F_FLOAT at1 = d_at_f1_1[type] * cosphi;
+  F_FLOAT at2 = d_at_f2_1[type] * cos2phi;
+  F_FLOAT at3 = d_at_f3_1[type] * cos3phi;
+  sumbte = at1 + at2 + at3;
+
+  F_FLOAT da = acos(costh12) - d_at_theta0_1[type];
+  if (eflag) edihedral += da * (at1+at2+at3);
+
+  // force on angle1
+
+  bt1 = d_at_f1_1[type] * sinphi;
+  bt2 = 2.0 * d_at_f2_1[type] * sin(2.0*phi);
+  bt3 = 3.0 * d_at_f3_1[type] * sin(3.0*phi);
+  sumbtf = bt1 + bt2 + bt3;
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      fabcd[i][j] -= da*sumbtf*dphidr[i][j] + sumbte*dthetadr[0][i][j];
+
+  // energy on angle2
+
+  at1 = d_at_f1_2[type] * cosphi;
+  at2 = d_at_f2_2[type] * cos2phi;
+  at3 = d_at_f3_2[type] * cos3phi;
+  sumbte = at1 + at2 + at3;
+
+  da = acos(costh23) - d_at_theta0_2[type];
+  if (eflag) edihedral += da * (at1+at2+at3);
+
+  // force on angle2
+
+  bt1 = -d_at_f1_2[type] * sinphi;
+  bt2 = -2.0 * d_at_f2_2[type] * sin(2.0*phi);
+  bt3 = -3.0 * d_at_f3_2[type] * sin(3.0*phi);
+  sumbtf = bt1 + bt2 + bt3;
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      fabcd[i][j] += da*sumbtf*dphidr[i][j] + sumbte*dthetadr[1][i][j];
+
+  // angle/angle/torsion coupling
+
+  const F_FLOAT da1 = acos(costh12) - d_aat_theta0_1[type];
+  const F_FLOAT da2 = acos(costh23) - d_aat_theta0_2[type];
+
+  if (eflag) edihedral += d_aat_k[type]*da1*da2*cosphi;
+
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      fabcd[i][j] -= d_aat_k[type] *
+        (cosphi * (da2*dthetadr[0][i][j] - da1*dthetadr[1][i][j]) +
+         sinphi * da1*da2*dphidr[i][j]);
+
+  // bond1/bond3 coupling
+
+  if (fabs(d_bb13t_k[type]) > SMALL) {
+
+    const F_FLOAT r1_0 = d_bb13t_r10[type];
+    const F_FLOAT r3_0 = d_bb13t_r30[type];
+    const F_FLOAT dr1 = r1 - r1_0;
+    const F_FLOAT dr2 = r3 - r3_0;
+    const F_FLOAT tk1 = -d_bb13t_k[type] * dr1 / r3;
+    const F_FLOAT tk2 = -d_bb13t_k[type] * dr2 / r1;
+
+    if (eflag) edihedral += d_bb13t_k[type]*dr1*dr2;
+
+    fabcd[0][0] += tk2 * vb1x;
+    fabcd[0][1] += tk2 * vb1y;
+    fabcd[0][2] += tk2 * vb1z;
+
+    fabcd[1][0] -= tk2 * vb1x;
+    fabcd[1][1] -= tk2 * vb1y;
+    fabcd[1][2] -= tk2 * vb1z;
+
+    fabcd[2][0] -= tk1 * vb3x;
+    fabcd[2][1] -= tk1 * vb3y;
+    fabcd[2][2] -= tk1 * vb3z;
+
+    fabcd[3][0] += tk1 * vb3x;
+    fabcd[3][1] += tk1 * vb3y;
+    fabcd[3][2] += tk1 * vb3z;
+  }
+ 
+  F_FLOAT f1[3],f2[3],f3[3],f4[3];
+  
+  for (int i = 0; i < 3; i++) {
+    f1[i] = fabcd[0][i];
+    f2[i] = fabcd[1][i];
+    f3[i] = fabcd[2][i];
+    f4[i] = fabcd[3][i];
+  }
+
+  // apply force to each of 4 atoms
+
+  if (NEWTON_BOND || i1 < nlocal) {
+    a_f(i1,0) += f1[0];
+    a_f(i1,1) += f1[1];
+    a_f(i1,2) += f1[2];
+  }
+
+  if (NEWTON_BOND || i2 < nlocal) {
+    a_f(i2,0) += f2[0];
+    a_f(i2,1) += f2[1];
+    a_f(i2,2) += f2[2];
+  }
+
+  if (NEWTON_BOND || i3 < nlocal) {
+    a_f(i3,0) += f3[0];
+    a_f(i3,1) += f3[1];
+    a_f(i3,2) += f3[2];
+  }
+
+  if (NEWTON_BOND || i4 < nlocal) {
+    a_f(i4,0) += f4[0];
+    a_f(i4,1) += f4[1];
+    a_f(i4,2) += f4[2];
+  }
+
+  if (EVFLAG)
+    ev_tally(ev,i1,i2,i3,i4,edihedral,f1,f3,f4,
+             vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTON_BOND,EVFLAG>, const int &n) const {
+  EV_FLOAT ev;
+  this->template operator()<NEWTON_BOND,EVFLAG>(TagDihedralClass2Compute<NEWTON_BOND,EVFLAG>(), n, ev);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void DihedralClass2Kokkos<DeviceType>::allocate()
+{
+  DihedralClass2::allocate();
+}
+
+/* ----------------------------------------------------------------------
+   set coeffs for one type
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void DihedralClass2Kokkos<DeviceType>::coeff(int narg, char **arg)
+{
+  DihedralClass2::coeff(narg, arg);
+
+  int n = atom->ndihedraltypes;
+  k_k1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::k1",n+1);
+  k_k2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::k2",n+1);
+  k_k3 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::k3",n+1);
+  k_phi1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::phi1",n+1);
+  k_phi2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::phi2",n+1);
+  k_phi3 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::phi3",n+1);
+  k_mbt_f1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::mbt_f1",n+1);
+  k_mbt_f2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::mbt_f2",n+1);
+  k_mbt_f3 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::mbt_f3",n+1);
+  k_mbt_r0 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::mbt_r0",n+1);
+  k_ebt_f1_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_f1_1",n+1);
+  k_ebt_f2_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_f2_1",n+1);
+  k_ebt_f3_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_f3_1",n+1);
+  k_ebt_r0_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_r0_1",n+1);
+  k_ebt_f1_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_f1_2",n+1);
+  k_ebt_f2_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_f2_2",n+1);
+  k_ebt_f3_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_f3_2",n+1);
+  k_ebt_r0_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::ebt_r0_2",n+1);
+  k_at_f1_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_f1_1",n+1);
+  k_at_f2_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_f2_1",n+1);
+  k_at_f3_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_f3_1",n+1);
+  k_at_f1_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_f1_2",n+1);
+  k_at_f2_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_f2_2",n+1);
+  k_at_f3_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_f3_2",n+1);
+  k_at_theta0_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_theta0_1",n+1);
+  k_at_theta0_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::at_theta0_2",n+1);
+  k_aat_k = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::aat_k",n+1);
+  k_aat_theta0_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::aat_theta0_1",n+1);
+  k_aat_theta0_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::aat_theta0_2",n+1);
+  k_bb13t_k = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::bb13t_k",n+1);
+  k_bb13t_r10 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::bb13t_r10",n+1);
+  k_bb13t_r30 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("DihedralClass2::bb13t_r30",n+1);
+  k_setflag_d = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_d",n+1);
+  k_setflag_mbt = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_mbt",n+1);
+  k_setflag_ebt = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_ebt",n+1);
+  k_setflag_at = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_at",n+1);
+  k_setflag_aat = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_aat",n+1);
+  k_setflag_bb13t = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("AngleClass2::setflag_bb13t",n+1);
+
+  d_k1 = k_k1.template view<DeviceType>();
+  d_k2 = k_k2.template view<DeviceType>();
+  d_k3 = k_k3.template view<DeviceType>();
+  d_phi1 = k_phi1.template view<DeviceType>();
+  d_phi2 = k_phi2.template view<DeviceType>();
+  d_phi3 = k_phi3.template view<DeviceType>();
+  d_mbt_f1 = k_mbt_f1.template view<DeviceType>();
+  d_mbt_f2 = k_mbt_f2.template view<DeviceType>();
+  d_mbt_f3 = k_mbt_f3.template view<DeviceType>();
+  d_mbt_r0 = k_mbt_r0.template view<DeviceType>();
+  d_ebt_f1_1 = k_ebt_f1_1.template view<DeviceType>();
+  d_ebt_f2_1 = k_ebt_f2_1.template view<DeviceType>();
+  d_ebt_f3_1 = k_ebt_f3_1.template view<DeviceType>();
+  d_ebt_r0_1 = k_ebt_r0_1.template view<DeviceType>();
+  d_ebt_f1_2 = k_ebt_f1_2.template view<DeviceType>();
+  d_ebt_f2_2 = k_ebt_f2_2.template view<DeviceType>();
+  d_ebt_f3_2 = k_ebt_f3_2.template view<DeviceType>();
+  d_ebt_r0_2 = k_ebt_r0_2.template view<DeviceType>();
+  d_at_f1_1 = k_at_f1_1.template view<DeviceType>();
+  d_at_f2_1 = k_at_f2_1.template view<DeviceType>();
+  d_at_f3_1 = k_at_f3_1.template view<DeviceType>();
+  d_at_f1_2 = k_at_f1_2.template view<DeviceType>();
+  d_at_f2_2 = k_at_f2_2.template view<DeviceType>();
+  d_at_f3_2 = k_at_f3_2.template view<DeviceType>();
+  d_at_theta0_1 = k_at_theta0_1.template view<DeviceType>();
+  d_at_theta0_2 = k_at_theta0_2.template view<DeviceType>();
+  d_aat_k = k_aat_k.template view<DeviceType>();
+  d_aat_theta0_1 = k_aat_theta0_1.template view<DeviceType>();
+  d_aat_theta0_2 = k_aat_theta0_2.template view<DeviceType>();
+  d_bb13t_k = k_bb13t_k.template view<DeviceType>();
+  d_bb13t_r10 = k_bb13t_r10.template view<DeviceType>();
+  d_bb13t_r30 = k_bb13t_r30.template view<DeviceType>();
+  d_setflag_d = k_setflag_d.template view<DeviceType>();
+  d_setflag_mbt = k_setflag_mbt.template view<DeviceType>();
+  d_setflag_ebt = k_setflag_ebt.template view<DeviceType>();
+  d_setflag_at = k_setflag_at.template view<DeviceType>();
+  d_setflag_aat = k_setflag_aat.template view<DeviceType>();
+  d_setflag_bb13t = k_setflag_bb13t.template view<DeviceType>();
+
+  for (int i = 1; i <= n; i++) {
+    k_k1.h_view[i] = k1[i];
+    k_k2.h_view[i] = k2[i];
+    k_k3.h_view[i] = k3[i];
+    k_phi1.h_view[i] = phi1[i];
+    k_phi2.h_view[i] = phi2[i];
+    k_phi3.h_view[i] = phi3[i];
+    k_mbt_f1.h_view[i] = mbt_f1[i];
+    k_mbt_f2.h_view[i] = mbt_f2[i];
+    k_mbt_f3.h_view[i] = mbt_f3[i];
+    k_mbt_r0.h_view[i] = mbt_r0[i];
+    k_ebt_f1_1.h_view[i] = ebt_f1_1[i];
+    k_ebt_f2_1.h_view[i] = ebt_f2_1[i];
+    k_ebt_f3_1.h_view[i] = ebt_f3_1[i];
+    k_ebt_r0_1.h_view[i] = ebt_r0_1[i];
+    k_ebt_f1_2.h_view[i] = ebt_f1_2[i];
+    k_ebt_f2_2.h_view[i] = ebt_f2_2[i];
+    k_ebt_f3_2.h_view[i] = ebt_f3_2[i];
+    k_ebt_r0_2.h_view[i] = ebt_r0_2[i];
+    k_at_f1_1.h_view[i] = at_f1_1[i];
+    k_at_f2_1.h_view[i] = at_f2_1[i];
+    k_at_f3_1.h_view[i] = at_f3_1[i];
+    k_at_f1_2.h_view[i] = at_f1_2[i];
+    k_at_f2_2.h_view[i] = at_f2_2[i];
+    k_at_f3_2.h_view[i] = at_f3_2[i];
+    k_at_theta0_1.h_view[i] = at_theta0_1[i];
+    k_at_theta0_2.h_view[i] = at_theta0_2[i];
+    k_aat_k.h_view[i] = aat_k[i];
+    k_aat_theta0_1.h_view[i] = aat_theta0_1[i];
+    k_aat_theta0_2.h_view[i] = aat_theta0_2[i];
+    k_bb13t_k.h_view[i] = bb13t_k[i];
+    k_bb13t_r10.h_view[i] = bb13t_r10[i];
+    k_bb13t_r30.h_view[i] = bb13t_r30[i];
+    k_setflag_d.h_view[i] = setflag_d[i];
+    k_setflag_mbt.h_view[i] = setflag_mbt[i];
+    k_setflag_ebt.h_view[i] = setflag_ebt[i];
+    k_setflag_at.h_view[i] = setflag_at[i];
+    k_setflag_aat.h_view[i] = setflag_aat[i];
+    k_setflag_bb13t.h_view[i] = setflag_bb13t[i];
+  }
+
+  k_k1.template modify<LMPHostType>(); 
+  k_k2.template modify<LMPHostType>(); 
+  k_k3.template modify<LMPHostType>();
+  k_phi1.template modify<LMPHostType>();
+  k_phi2.template modify<LMPHostType>();
+  k_phi3.template modify<LMPHostType>();
+  k_mbt_f1.template modify<LMPHostType>();
+  k_mbt_f2.template modify<LMPHostType>();
+  k_mbt_f3.template modify<LMPHostType>();
+  k_mbt_r0.template modify<LMPHostType>(); 
+  k_ebt_f1_1.template modify<LMPHostType>();
+  k_ebt_f2_1.template modify<LMPHostType>();
+  k_ebt_f3_1.template modify<LMPHostType>();
+  k_ebt_r0_1.template modify<LMPHostType>();
+  k_ebt_f1_2.template modify<LMPHostType>();
+  k_ebt_f2_2.template modify<LMPHostType>();
+  k_ebt_f3_2.template modify<LMPHostType>();
+  k_ebt_r0_2.template modify<LMPHostType>();
+  k_at_f1_1.template modify<LMPHostType>();
+  k_at_f2_1.template modify<LMPHostType>();
+  k_at_f3_1.template modify<LMPHostType>();
+  k_at_f1_2.template modify<LMPHostType>();
+  k_at_f2_2.template modify<LMPHostType>(); 
+  k_at_f3_2.template modify<LMPHostType>(); 
+  k_at_theta0_1.template modify<LMPHostType>();
+  k_at_theta0_2.template modify<LMPHostType>();
+  k_aat_k.template modify<LMPHostType>();
+  k_aat_theta0_1.template modify<LMPHostType>();
+  k_aat_theta0_2.template modify<LMPHostType>();
+  k_bb13t_k.template modify<LMPHostType>(); 
+  k_bb13t_r10.template modify<LMPHostType>();
+  k_bb13t_r30.template modify<LMPHostType>(); 
+  k_setflag_d.template modify<LMPHostType>(); 
+  k_setflag_mbt.template modify<LMPHostType>();
+  k_setflag_ebt.template modify<LMPHostType>();
+  k_setflag_at.template modify<LMPHostType>(); 
+  k_setflag_aat.template modify<LMPHostType>(); 
+  k_setflag_bb13t.template modify<LMPHostType>();
+}
+
+/* ----------------------------------------------------------------------
+   tally energy and virial into global and per-atom accumulators
+   virial = r1F1 + r2F2 + r3F3 + r4F4 = (r1-r2) F1 + (r3-r2) F3 + (r4-r2) F4
+          = (r1-r2) F1 + (r3-r2) F3 + (r4-r3 + r3-r2) F4
+          = vb1*f1 + vb2*f3 + (vb3+vb2)*f4
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+//template<int NEWTON_BOND>
+KOKKOS_INLINE_FUNCTION
+void DihedralClass2Kokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int i1, const int i2, const int i3, const int i4,
+                        F_FLOAT &edihedral, F_FLOAT *f1, F_FLOAT *f3, F_FLOAT *f4,
+                        const F_FLOAT &vb1x, const F_FLOAT &vb1y, const F_FLOAT &vb1z,
+                        const F_FLOAT &vb2x, const F_FLOAT &vb2y, const F_FLOAT &vb2z,
+                        const F_FLOAT &vb3x, const F_FLOAT &vb3y, const F_FLOAT &vb3z) const
+{
+  E_FLOAT edihedralquarter;
+  F_FLOAT v[6];
+
+  // The eatom and vatom arrays are atomic
+  Kokkos::View<E_FLOAT*, typename DAT::t_efloat_1d::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_eatom = k_eatom.view<DeviceType>();
+  Kokkos::View<F_FLOAT*[6], typename DAT::t_virial_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_vatom = k_vatom.view<DeviceType>();
+
+  if (eflag_either) {
+    if (eflag_global) {
+      if (newton_bond) ev.evdwl += edihedral;
+      else {
+        edihedralquarter = 0.25*edihedral;
+        if (i1 < nlocal) ev.evdwl += edihedralquarter;
+        if (i2 < nlocal) ev.evdwl += edihedralquarter;
+        if (i3 < nlocal) ev.evdwl += edihedralquarter;
+        if (i4 < nlocal) ev.evdwl += edihedralquarter;
+      }
+    }
+    if (eflag_atom) {
+      edihedralquarter = 0.25*edihedral;
+      if (newton_bond || i1 < nlocal) v_eatom[i1] += edihedralquarter;
+      if (newton_bond || i2 < nlocal) v_eatom[i2] += edihedralquarter;
+      if (newton_bond || i3 < nlocal) v_eatom[i3] += edihedralquarter;
+      if (newton_bond || i4 < nlocal) v_eatom[i4] += edihedralquarter;
+    }
+  }
+
+  if (vflag_either) {
+    v[0] = vb1x*f1[0] + vb2x*f3[0] + (vb3x+vb2x)*f4[0];
+    v[1] = vb1y*f1[1] + vb2y*f3[1] + (vb3y+vb2y)*f4[1];
+    v[2] = vb1z*f1[2] + vb2z*f3[2] + (vb3z+vb2z)*f4[2];
+    v[3] = vb1x*f1[1] + vb2x*f3[1] + (vb3x+vb2x)*f4[1];
+    v[4] = vb1x*f1[2] + vb2x*f3[2] + (vb3x+vb2x)*f4[2];
+    v[5] = vb1y*f1[2] + vb2y*f3[2] + (vb3y+vb2y)*f4[2];
+
+    if (vflag_global) {
+      if (newton_bond) {
+        ev.v[0] += v[0];
+        ev.v[1] += v[1];
+        ev.v[2] += v[2];
+        ev.v[3] += v[3];
+        ev.v[4] += v[4];
+        ev.v[5] += v[5];
+      } else {
+        if (i1 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i2 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i3 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i4 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+      }
+    }
+
+    if (vflag_atom) {
+      if (newton_bond || i1 < nlocal) {
+        v_vatom(i1,0) += 0.25*v[0];
+        v_vatom(i1,1) += 0.25*v[1];
+        v_vatom(i1,2) += 0.25*v[2];
+        v_vatom(i1,3) += 0.25*v[3];
+        v_vatom(i1,4) += 0.25*v[4];
+        v_vatom(i1,5) += 0.25*v[5];
+      }
+      if (newton_bond || i2 < nlocal) {
+        v_vatom(i2,0) += 0.25*v[0];
+        v_vatom(i2,1) += 0.25*v[1];
+        v_vatom(i2,2) += 0.25*v[2];
+        v_vatom(i2,3) += 0.25*v[3];
+        v_vatom(i2,4) += 0.25*v[4];
+        v_vatom(i2,5) += 0.25*v[5];
+      }
+      if (newton_bond || i3 < nlocal) {
+        v_vatom(i3,0) += 0.25*v[0];
+        v_vatom(i3,1) += 0.25*v[1];
+        v_vatom(i3,2) += 0.25*v[2];
+        v_vatom(i3,3) += 0.25*v[3];
+        v_vatom(i3,4) += 0.25*v[4];
+        v_vatom(i3,5) += 0.25*v[5];
+      }
+      if (newton_bond || i4 < nlocal) {
+        v_vatom(i4,0) += 0.25*v[0];
+        v_vatom(i4,1) += 0.25*v[1];
+        v_vatom(i4,2) += 0.25*v[2];
+        v_vatom(i4,3) += 0.25*v[3];
+        v_vatom(i4,4) += 0.25*v[4];
+        v_vatom(i4,5) += 0.25*v[5];
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+namespace LAMMPS_NS {
+template class DihedralClass2Kokkos<LMPDeviceType>;
+#ifdef KOKKOS_HAVE_CUDA
+template class DihedralClass2Kokkos<LMPHostType>;
+#endif
+}
+

--- a/src/KOKKOS/dihedral_class2_kokkos.h
+++ b/src/KOKKOS/dihedral_class2_kokkos.h
@@ -68,8 +68,8 @@ class DihedralClass2Kokkos : public DihedralClass2 {
 
   DAT::tdual_efloat_1d k_eatom;
   DAT::tdual_virial_array k_vatom;
-  DAT::t_efloat_1d d_eatom;
-  DAT::t_virial_array d_vatom;
+  typename AT::t_efloat_1d d_eatom;
+  typename AT::t_virial_array d_vatom;
 
   int nlocal,newton_bond;
   int eflag,vflag;
@@ -78,29 +78,29 @@ class DihedralClass2Kokkos : public DihedralClass2 {
   typename AT::t_int_scalar d_warning_flag;
   HAT::t_int_scalar h_warning_flag;
 
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_k2, k_k3, k_k1;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_phi1, k_phi2, k_phi3;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_mbt_f1, k_mbt_f2, k_mbt_f3, k_mbt_r0;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_ebt_f1_1, k_ebt_f2_1, k_ebt_f3_1, k_ebt_r0_1;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_ebt_f1_2, k_ebt_f2_2, k_ebt_f3_2, k_ebt_r0_2;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_at_f1_1, k_at_f2_1, k_at_f3_1, k_at_theta0_1;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_at_f1_2, k_at_f2_2, k_at_f3_2, k_at_theta0_2;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_aat_k, k_aat_theta0_1, k_aat_theta0_2;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_bb13t_k, k_bb13t_r10, k_bb13t_r30;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag_d, k_setflag_mbt, k_setflag_ebt;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag_at, k_setflag_aat, k_setflag_bb13t;
+  typename AT::tdual_ffloat_1d k_k2, k_k3, k_k1;
+  typename AT::tdual_ffloat_1d k_phi1, k_phi2, k_phi3;
+  typename AT::tdual_ffloat_1d k_mbt_f1, k_mbt_f2, k_mbt_f3, k_mbt_r0;
+  typename AT::tdual_ffloat_1d k_ebt_f1_1, k_ebt_f2_1, k_ebt_f3_1, k_ebt_r0_1;
+  typename AT::tdual_ffloat_1d k_ebt_f1_2, k_ebt_f2_2, k_ebt_f3_2, k_ebt_r0_2;
+  typename AT::tdual_ffloat_1d k_at_f1_1, k_at_f2_1, k_at_f3_1, k_at_theta0_1;
+  typename AT::tdual_ffloat_1d k_at_f1_2, k_at_f2_2, k_at_f3_2, k_at_theta0_2;
+  typename AT::tdual_ffloat_1d k_aat_k, k_aat_theta0_1, k_aat_theta0_2;
+  typename AT::tdual_ffloat_1d k_bb13t_k, k_bb13t_r10, k_bb13t_r30;
+  typename AT::tdual_ffloat_1d k_setflag_d, k_setflag_mbt, k_setflag_ebt;
+  typename AT::tdual_ffloat_1d k_setflag_at, k_setflag_aat, k_setflag_bb13t;
 
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_k2, d_k3, d_k1;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_phi1, d_phi2, d_phi3;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_mbt_f1, d_mbt_f2, d_mbt_f3, d_mbt_r0;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_ebt_f1_1, d_ebt_f2_1, d_ebt_f3_1, d_ebt_r0_1;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_ebt_f1_2, d_ebt_f2_2, d_ebt_f3_2, d_ebt_r0_2;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_at_f1_1, d_at_f2_1, d_at_f3_1, d_at_theta0_1;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_at_f1_2, d_at_f2_2, d_at_f3_2, d_at_theta0_2;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_aat_k, d_aat_theta0_1, d_aat_theta0_2;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_bb13t_k, d_bb13t_r10, d_bb13t_r30;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag_d, d_setflag_mbt, d_setflag_ebt;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag_at, d_setflag_aat, d_setflag_bb13t;
+  typename AT::t_ffloat_1d d_k2, d_k3, d_k1;
+  typename AT::t_ffloat_1d d_phi1, d_phi2, d_phi3;
+  typename AT::t_ffloat_1d d_mbt_f1, d_mbt_f2, d_mbt_f3, d_mbt_r0;
+  typename AT::t_ffloat_1d d_ebt_f1_1, d_ebt_f2_1, d_ebt_f3_1, d_ebt_r0_1;
+  typename AT::t_ffloat_1d d_ebt_f1_2, d_ebt_f2_2, d_ebt_f3_2, d_ebt_r0_2;
+  typename AT::t_ffloat_1d d_at_f1_1, d_at_f2_1, d_at_f3_1, d_at_theta0_1;
+  typename AT::t_ffloat_1d d_at_f1_2, d_at_f2_2, d_at_f3_2, d_at_theta0_2;
+  typename AT::t_ffloat_1d d_aat_k, d_aat_theta0_1, d_aat_theta0_2;
+  typename AT::t_ffloat_1d d_bb13t_k, d_bb13t_r10, d_bb13t_r30;
+  typename AT::t_ffloat_1d d_setflag_d, d_setflag_mbt, d_setflag_ebt;
+  typename AT::t_ffloat_1d d_setflag_at, d_setflag_aat, d_setflag_bb13t;
 
   virtual void allocate();
 };

--- a/src/KOKKOS/dihedral_class2_kokkos.h
+++ b/src/KOKKOS/dihedral_class2_kokkos.h
@@ -1,0 +1,120 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef DIHEDRAL_CLASS
+
+DihedralStyle(class2/kk,DihedralClass2Kokkos<LMPDeviceType>)
+DihedralStyle(class2/kk/device,DihedralClass2Kokkos<LMPDeviceType>)
+DihedralStyle(class2/kk/host,DihedralClass2Kokkos<LMPHostType>)
+
+#else
+
+#ifndef LMP_DIHEDRAL_CLASS2_KOKKOS_H
+#define LMP_DIHEDRAL_CLASS2_KOKKOS_H
+
+#include "dihedral_class2.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template<int NEWTON_BOND, int EVFLAG>
+struct TagDihedralClass2Compute{};
+
+template<class DeviceType>
+class DihedralClass2Kokkos : public DihedralClass2 {
+ public:
+  typedef DeviceType device_type;
+  typedef EV_FLOAT value_type;
+  typedef ArrayTypes<DeviceType> AT;
+
+  DihedralClass2Kokkos(class LAMMPS *);
+  virtual ~DihedralClass2Kokkos();
+  virtual void compute(int, int);
+  virtual void coeff(int, char **);
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagDihedralClass2Compute<NEWTON_BOND,EVFLAG>, const int&, EV_FLOAT&) const;
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagDihedralClass2Compute<NEWTON_BOND,EVFLAG>, const int&) const;
+
+  //template<int NEWTON_BOND>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally(EV_FLOAT &ev, const int i1, const int i2, const int i3, const int i4,
+                          F_FLOAT &edihedral, F_FLOAT *f1, F_FLOAT *f3, F_FLOAT *f4,
+                          const F_FLOAT &vb1x, const F_FLOAT &vb1y, const F_FLOAT &vb1z,
+                          const F_FLOAT &vb2x, const F_FLOAT &vb2y, const F_FLOAT &vb2z,
+                          const F_FLOAT &vb3x, const F_FLOAT &vb3y, const F_FLOAT &vb3z) const;
+
+ protected:
+
+  class NeighborKokkos *neighborKK;
+
+  typename AT::t_x_array_randomread x;
+  typename AT::t_f_array f;
+  typename AT::t_int_2d dihedrallist;
+
+  DAT::tdual_efloat_1d k_eatom;
+  DAT::tdual_virial_array k_vatom;
+  DAT::t_efloat_1d d_eatom;
+  DAT::t_virial_array d_vatom;
+
+  int nlocal,newton_bond;
+  int eflag,vflag;
+
+  DAT::tdual_int_scalar k_warning_flag;
+  typename AT::t_int_scalar d_warning_flag;
+  HAT::t_int_scalar h_warning_flag;
+
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_k2, k_k3, k_k1;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_phi1, k_phi2, k_phi3;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_mbt_f1, k_mbt_f2, k_mbt_f3, k_mbt_r0;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_ebt_f1_1, k_ebt_f2_1, k_ebt_f3_1, k_ebt_r0_1;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_ebt_f1_2, k_ebt_f2_2, k_ebt_f3_2, k_ebt_r0_2;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_at_f1_1, k_at_f2_1, k_at_f3_1, k_at_theta0_1;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_at_f1_2, k_at_f2_2, k_at_f3_2, k_at_theta0_2;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_aat_k, k_aat_theta0_1, k_aat_theta0_2;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_bb13t_k, k_bb13t_r10, k_bb13t_r30;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag_d, k_setflag_mbt, k_setflag_ebt;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag_at, k_setflag_aat, k_setflag_bb13t;
+
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_k2, d_k3, d_k1;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_phi1, d_phi2, d_phi3;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_mbt_f1, d_mbt_f2, d_mbt_f3, d_mbt_r0;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_ebt_f1_1, d_ebt_f2_1, d_ebt_f3_1, d_ebt_r0_1;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_ebt_f1_2, d_ebt_f2_2, d_ebt_f3_2, d_ebt_r0_2;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_at_f1_1, d_at_f2_1, d_at_f3_1, d_at_theta0_1;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_at_f1_2, d_at_f2_2, d_at_f3_2, d_at_theta0_2;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_aat_k, d_aat_theta0_1, d_aat_theta0_2;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_bb13t_k, d_bb13t_r10, d_bb13t_r30;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag_d, d_setflag_mbt, d_setflag_ebt;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag_at, d_setflag_aat, d_setflag_bb13t;
+
+  virtual void allocate();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+W: Dihedral problem
+
+Conformation of the 4 listed dihedral atoms is extreme; you may want
+to check your simulation geometry.
+
+*/

--- a/src/KOKKOS/improper_class2_kokkos.cpp
+++ b/src/KOKKOS/improper_class2_kokkos.cpp
@@ -1,0 +1,1082 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Ray Shan (Materials Design)
+------------------------------------------------------------------------- */
+
+#include <mpi.h>
+#include <math.h>
+#include <stdlib.h>
+#include "improper_class2_kokkos.h"
+#include "atom_kokkos.h"
+#include "comm.h"
+#include "neighbor_kokkos.h"
+#include "domain.h"
+#include "force.h"
+#include "update.h"
+#include "math_const.h"
+#include "memory.h"
+#include "error.h"
+#include "atom_masks.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+#define TOLERANCE 0.05
+#define SMALL     0.001
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+ImproperClass2Kokkos<DeviceType>::ImproperClass2Kokkos(LAMMPS *lmp) : ImproperClass2(lmp)
+{
+  atomKK = (AtomKokkos *) atom;
+  neighborKK = (NeighborKokkos *) neighbor;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | F_MASK | ENERGY_MASK | VIRIAL_MASK;
+  datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+
+  k_warning_flag = DAT::tdual_int_scalar("Dihedral:warning_flag");
+  d_warning_flag = k_warning_flag.view<DeviceType>();
+  h_warning_flag = k_warning_flag.h_view;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+ImproperClass2Kokkos<DeviceType>::~ImproperClass2Kokkos()
+{
+  if (!copymode) {
+    memory->destroy_kokkos(k_eatom,eatom);
+    memory->destroy_kokkos(k_vatom,vatom);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void ImproperClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  eflag = eflag_in;
+  vflag = vflag_in;
+
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = 0;
+
+  // reallocate per-atom arrays if necessary
+
+  if (eflag_atom) {
+    if(k_eatom.dimension_0()<maxeatom) {
+      memory->destroy_kokkos(k_eatom,eatom);
+      memory->create_kokkos(k_eatom,eatom,maxeatom,"improper:eatom");
+      d_eatom = k_eatom.d_view;
+    }
+  }
+  if (vflag_atom) {
+    if(k_vatom.dimension_0()<maxvatom) {
+      memory->destroy_kokkos(k_vatom,vatom);
+      memory->create_kokkos(k_vatom,vatom,maxvatom,6,"improper:vatom");
+      d_vatom = k_vatom.d_view;
+    }
+  }
+
+  atomKK->sync(execution_space,datamask_read);
+  k_k0.template sync<DeviceType>();
+  k_chi0.template sync<DeviceType>();
+  k_aa_k1.template sync<DeviceType>();
+  k_aa_k2.template sync<DeviceType>();
+  k_aa_k3.template sync<DeviceType>();
+  k_aa_theta0_1.template sync<DeviceType>();
+  k_aa_theta0_2.template sync<DeviceType>();
+  k_aa_theta0_3 .template sync<DeviceType>();
+  k_setflag.template sync<DeviceType>();
+  k_setflag_i.template sync<DeviceType>();
+  k_setflag_aa.template sync<DeviceType>();
+
+  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  else atomKK->modified(execution_space,F_MASK);
+
+  x = atomKK->k_x.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  neighborKK->k_improperlist.template sync<DeviceType>();
+  improperlist = neighborKK->k_improperlist.view<DeviceType>();
+  int nimproperlist = neighborKK->nimproperlist;
+  nlocal = atom->nlocal;
+  newton_bond = force->newton_bond;
+
+  h_warning_flag() = 0;
+  k_warning_flag.template modify<LMPHostType>();
+  k_warning_flag.template sync<DeviceType>();
+
+  copymode = 1;
+
+  // loop over neighbors of my atoms
+
+  EV_FLOAT ev;
+
+  // Improper energy/force
+
+  if (evflag) {
+    if (newton_bond) {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagImproperClass2Compute<1,1> >(0,nimproperlist),*this,ev);
+    } else {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagImproperClass2Compute<0,1> >(0,nimproperlist),*this,ev);
+    }
+  } else {
+    if (newton_bond) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagImproperClass2Compute<1,0> >(0,nimproperlist),*this);
+    } else {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagImproperClass2Compute<0,0> >(0,nimproperlist),*this);
+    }
+  }
+  DeviceType::fence();
+  if (eflag_global) energy += ev.evdwl;
+
+  // error check
+
+  k_warning_flag.template modify<DeviceType>();
+  k_warning_flag.template sync<LMPHostType>();
+  if (h_warning_flag())
+    error->warning(FLERR,"Improper problem",0);
+
+  // Angle-Angle energy/force
+
+  if (evflag) {
+    if (newton_bond) {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagImproperClass2AngleAngle<1,1> >(0,nimproperlist),*this,ev);
+    } else {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagImproperClass2AngleAngle<0,1> >(0,nimproperlist),*this,ev);
+    }
+  } else {
+    if (newton_bond) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagImproperClass2AngleAngle<1,0> >(0,nimproperlist),*this);
+    } else {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagImproperClass2AngleAngle<0,0> >(0,nimproperlist),*this);
+    }
+  }
+  DeviceType::fence();
+  if (eflag_global) energy += ev.evdwl;
+
+  if (vflag_global) {
+    virial[0] += ev.v[0];
+    virial[1] += ev.v[1];
+    virial[2] += ev.v[2];
+    virial[3] += ev.v[3];
+    virial[4] += ev.v[4];
+    virial[5] += ev.v[5];
+  }
+
+  if (eflag_atom) {
+    k_eatom.template modify<DeviceType>();
+    k_eatom.template sync<LMPHostType>();
+  }
+
+  if (vflag_atom) {
+    k_vatom.template modify<DeviceType>();
+    k_vatom.template sync<LMPHostType>();
+  }
+
+  copymode = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTON_BOND,EVFLAG>, const int &n, EV_FLOAT& ev) const {
+
+  // The f array is atomic
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > a_f = f;
+
+  int i, j, k;
+  F_FLOAT delr[3][3],rmag[3],rinvmag[3],rmag2[3];
+  F_FLOAT theta[3],costheta[3],sintheta[3];
+  F_FLOAT cossqtheta[3],sinsqtheta[3],invstheta[3];
+  F_FLOAT rABxrCB[3],rDBxrAB[3],rCBxrDB[3];
+  F_FLOAT ddelr[3][4],dr[3][4][3],dinvr[3][4][3];
+  F_FLOAT dthetadr[3][4][3],dinvsth[3][4][3];
+  F_FLOAT dinv3r[4][3],dinvs3r[3][4][3];
+  F_FLOAT drCBxrDB[3],rCBxdrDB[3],drDBxrAB[3],rDBxdrAB[3];
+  F_FLOAT drABxrCB[3],rABxdrCB[3];
+  F_FLOAT dot1,dot2,dd[3];
+  F_FLOAT fdot[3][4][3],ftmp,invs3r[3],inv3r;
+  F_FLOAT drAB[3][4][3],drCB[3][4][3],drDB[3][4][3];
+  F_FLOAT dchi[3][4][3],dtotalchi[4][3];
+  F_FLOAT fabcd[4][3];
+
+  F_FLOAT t,tt1,tt3,sc1;
+  F_FLOAT dotCBDBAB,dotDBABCB,dotABCBDB;
+  F_FLOAT schiABCD,chiABCD,schiCBDA,chiCBDA,schiDBAC,chiDBAC;
+  F_FLOAT chi,deltachi,d2chi,cossin2;
+  F_FLOAT eimproper;
+
+  const int i1 = improperlist(n,0);
+  const int i2 = improperlist(n,1);
+  const int i3 = improperlist(n,2);
+  const int i4 = improperlist(n,3);
+  const int type = improperlist(n,4);
+
+  if (d_k0[type] != 0.0) {
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++)
+        for (k = 0; k < 3; k++) {
+          dthetadr[i][j][k] = 0.0;
+          drAB[i][j][k] = 0.0;
+          drCB[i][j][k] = 0.0;
+          drDB[i][j][k] = 0.0;
+        }
+
+    // difference vectors
+
+    delr[0][0] = x(i1,0) - x(i2,0);
+    delr[0][1] = x(i1,1) - x(i2,1);
+    delr[0][2] = x(i1,2) - x(i2,2);
+
+    delr[1][0] = x(i3,0) - x(i2,0);
+    delr[1][1] = x(i3,1) - x(i2,1);
+    delr[1][2] = x(i3,2) - x(i2,2);
+
+    delr[2][0] = x(i4,0) - x(i2,0);
+    delr[2][1] = x(i4,1) - x(i2,1);
+    delr[2][2] = x(i4,2) - x(i2,2);
+
+    // bond lengths and associated values
+    
+    for (i = 0; i < 3; i++) {
+      rmag2[i] = delr[i][0]*delr[i][0] + delr[i][1]*delr[i][1] + delr[i][2]*delr[i][2];
+      rmag[i] = sqrt(rmag2[i]);
+      rinvmag[i] = 1.0/rmag[i];
+    }
+
+    // angle ABC, CBD, ABD
+
+    costheta[0] = (delr[0][0]*delr[1][0] + delr[0][1]*delr[1][1] +
+                   delr[0][2]*delr[1][2]) / (rmag[0]*rmag[1]);
+    costheta[1] = (delr[1][0]*delr[2][0] + delr[1][1]*delr[2][1] +
+                   delr[1][2]*delr[2][2]) / (rmag[1]*rmag[2]);
+    costheta[2] = (delr[0][0]*delr[2][0] + delr[0][1]*delr[2][1] +
+                   delr[0][2]*delr[2][2]) / (rmag[0]*rmag[2]);
+
+    // sin and cos of improper
+
+    F_FLOAT s1 = 1.0 - costheta[1]*costheta[1];
+    if (s1 < SMALL) s1 = SMALL;
+    s1 = 1.0 / s1;
+
+    F_FLOAT s2 = 1.0 - costheta[2]*costheta[2];
+    if (s2 < SMALL) s2 = SMALL;
+    s2 = 1.0 / s2;
+
+    F_FLOAT s12 = sqrt(s1*s2);
+    F_FLOAT c = (costheta[1]*costheta[2] + costheta[0]) * s12;
+
+    // error check
+
+    /*
+    if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
+      Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+    */
+    if ((costheta[0] == -1.0 || costheta[1] == -1.0 || costheta[2] == -1.0) && !d_warning_flag())
+      Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+
+    F_FLOAT s = sqrt(1.0 - c*c);
+    if (s < SMALL) s = SMALL;
+
+    for (i = 0; i < 3; i++) {
+      if (costheta[i] > 1.0)  costheta[i] = 1.0;
+      if (costheta[i] < -1.0) costheta[i] = -1.0;
+      theta[i] = acos(costheta[i]);
+      cossqtheta[i] = costheta[i]*costheta[i];
+      sintheta[i] = sin(theta[i]);
+      invstheta[i] = 1.0/sintheta[i];
+      sinsqtheta[i] = sintheta[i]*sintheta[i];
+    }
+
+    // cross & dot products
+
+    //cross(delr[0],delr[1],rABxrCB);
+    rABxrCB[0] = delr[0][1]*delr[1][2] - delr[0][2]*delr[1][1];
+    rABxrCB[1] = delr[0][2]*delr[1][0] - delr[0][0]*delr[1][2];
+    rABxrCB[2] = delr[0][0]*delr[1][1] - delr[0][1]*delr[1][0];
+
+    //cross(delr[2],delr[0],rDBxrAB);
+    rDBxrAB[0] = delr[2][1]*delr[0][2] - delr[2][2]*delr[0][1];
+    rDBxrAB[1] = delr[2][2]*delr[0][0] - delr[2][0]*delr[0][2];
+    rDBxrAB[2] = delr[2][0]*delr[0][1] - delr[2][1]*delr[0][0];
+
+    //cross(delr[1],delr[2],rCBxrDB);
+    rCBxrDB[0] = delr[1][1]*delr[2][2] - delr[1][2]*delr[2][1];
+    rCBxrDB[1] = delr[1][2]*delr[2][0] - delr[1][0]*delr[2][2];
+    rCBxrDB[2] = delr[1][0]*delr[2][1] - delr[1][1]*delr[2][0];
+
+    //dotCBDBAB = dot(rCBxrDB,delr[0]);
+    dotCBDBAB = rCBxrDB[0]*delr[0][0] + rCBxrDB[1]*delr[0][1] + rCBxrDB[2]*delr[0][2];
+
+    //dotDBABCB = dot(rDBxrAB,delr[1]);
+    dotDBABCB = rDBxrAB[0]*delr[1][0] + rDBxrAB[1]*delr[1][1] + rDBxrAB[2]*delr[1][2];
+
+    //dotABCBDB = dot(rABxrCB,delr[2]);
+    dotABCBDB = rABxrCB[0]*delr[2][0] + rABxrCB[1]*delr[2][1] + rABxrCB[2]*delr[2][2];
+
+    t = rmag[0] * rmag[1] * rmag[2];
+    inv3r = 1.0/t;
+    invs3r[0] = invstheta[1] * inv3r;
+    invs3r[1] = invstheta[2] * inv3r;
+    invs3r[2] = invstheta[0] * inv3r;
+
+    // chi ABCD, CBDA, DBAC: final chi is average of three
+
+    schiABCD = dotCBDBAB * invs3r[0];
+    chiABCD = asin(schiABCD);
+    schiCBDA = dotDBABCB * invs3r[1];
+    chiCBDA = asin(schiCBDA);
+    schiDBAC = dotABCBDB * invs3r[2];
+    chiDBAC = asin(schiDBAC);
+
+    chi = (chiABCD + chiCBDA + chiDBAC) / 3.0;
+    deltachi = chi - d_chi0[type];
+    d2chi = deltachi * deltachi;
+
+    // energy
+
+    if (eflag) eimproper = d_k0[type]*d2chi;
+
+    // forces
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++)
+        ddelr[i][j] = 0.0;
+
+    ddelr[0][0] = 1.0;
+    ddelr[0][1] = -1.0;
+    ddelr[1][1] = -1.0;
+    ddelr[1][2] = 1.0;
+    ddelr[2][1] = -1.0;
+    ddelr[2][3] = 1.0;
+
+    // compute d(|r|)/dr and d(1/|r|)/dr for each direction, bond and atom
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++)
+        for (k = 0; k < 3; k++) {
+          dr[i][j][k] = delr[i][k] * ddelr[i][j] / rmag[i];
+          dinvr[i][j][k] = -dr[i][j][k] / rmag2[i];
+        }
+
+    // compute d(1 / (|r_AB| * |r_CB| * |r_DB|) / dr
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        dinv3r[i][j] = rinvmag[1] * (rinvmag[2] * dinvr[0][i][j] +
+                                     rinvmag[0] * dinvr[2][i][j]) +
+          rinvmag[2] * rinvmag[0] * dinvr[1][i][j];
+
+    // compute d(theta)/d(r) for 3 angles
+    // angleABC
+
+    tt1 = costheta[0] / rmag2[0];
+    tt3 = costheta[0] / rmag2[1];
+    sc1 = 1.0 / sqrt(1.0 - cossqtheta[0]);
+
+    dthetadr[0][0][0] = sc1 * ((tt1 * delr[0][0]) -
+                               (delr[1][0] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][0][1] = sc1 * ((tt1 * delr[0][1]) -
+                               (delr[1][1] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][0][2] = sc1 * ((tt1 * delr[0][2]) -
+                               (delr[1][2] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][1][0] = -sc1 * ((tt1 * delr[0][0]) -
+                                (delr[1][0] * rinvmag[0] * rinvmag[1]) +
+                                (tt3 * delr[1][0]) -
+                                (delr[0][0] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][1][1] = -sc1 * ((tt1 * delr[0][1]) -
+                                (delr[1][1] * rinvmag[0] * rinvmag[1]) +
+                                (tt3 * delr[1][1]) -
+                                (delr[0][1] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][1][2] = -sc1 * ((tt1 * delr[0][2]) -
+                                (delr[1][2] * rinvmag[0] * rinvmag[1]) +
+                                (tt3 * delr[1][2]) -
+                                (delr[0][2] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][2][0] = sc1 * ((tt3 * delr[1][0]) -
+                               (delr[0][0] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][2][1] = sc1 * ((tt3 * delr[1][1]) -
+                               (delr[0][1] * rinvmag[0] * rinvmag[1]));
+    dthetadr[0][2][2] = sc1 * ((tt3 * delr[1][2]) -
+                               (delr[0][2] * rinvmag[0] * rinvmag[1]));
+
+
+    // angleCBD
+
+    tt1 = costheta[1] / rmag2[1];
+    tt3 = costheta[1] / rmag2[2];
+    sc1 = 1.0 / sqrt(1.0 - cossqtheta[1]);
+
+    dthetadr[1][2][0] = sc1 * ((tt1 * delr[1][0]) -
+                               (delr[2][0] * rinvmag[1] * rinvmag[2]));
+    dthetadr[1][2][1] = sc1 * ((tt1 * delr[1][1]) -
+                               (delr[2][1] * rinvmag[1] * rinvmag[2]));
+    dthetadr[1][2][2] = sc1 * ((tt1 * delr[1][2]) -
+                               (delr[2][2] * rinvmag[1] * rinvmag[2]));
+    dthetadr[1][1][0] = -sc1 * ((tt1 * delr[1][0]) -
+                                (delr[2][0] * rinvmag[1] * rinvmag[2]) +
+                                (tt3 * delr[2][0]) -
+                                (delr[1][0] * rinvmag[2] * rinvmag[1]));
+    dthetadr[1][1][1] = -sc1 * ((tt1 * delr[1][1]) -
+                                (delr[2][1] * rinvmag[1] * rinvmag[2]) +
+                                (tt3 * delr[2][1]) -
+                                (delr[1][1] * rinvmag[2] * rinvmag[1]));
+    dthetadr[1][1][2] = -sc1 * ((tt1 * delr[1][2]) -
+                                (delr[2][2] * rinvmag[1] * rinvmag[2]) +
+                                (tt3 * delr[2][2]) -
+                                (delr[1][2] * rinvmag[2] * rinvmag[1]));
+    dthetadr[1][3][0] = sc1 * ((tt3 * delr[2][0]) -
+                               (delr[1][0] * rinvmag[2] * rinvmag[1]));
+    dthetadr[1][3][1] = sc1 * ((tt3 * delr[2][1]) -
+                               (delr[1][1] * rinvmag[2] * rinvmag[1]));
+    dthetadr[1][3][2] = sc1 * ((tt3 * delr[2][2]) -
+                               (delr[1][2] * rinvmag[2] * rinvmag[1]));
+
+    // angleABD
+
+    tt1 = costheta[2] / rmag2[0];
+    tt3 = costheta[2] / rmag2[2];
+    sc1 = 1.0 / sqrt(1.0 - cossqtheta[2]);
+
+    dthetadr[2][0][0] = sc1 * ((tt1 * delr[0][0]) -
+                               (delr[2][0] * rinvmag[0] * rinvmag[2]));
+    dthetadr[2][0][1] = sc1 * ((tt1 * delr[0][1]) -
+                               (delr[2][1] * rinvmag[0] * rinvmag[2]));
+    dthetadr[2][0][2] = sc1 * ((tt1 * delr[0][2]) -
+                               (delr[2][2] * rinvmag[0] * rinvmag[2]));
+    dthetadr[2][1][0] = -sc1 * ((tt1 * delr[0][0]) -
+                                (delr[2][0] * rinvmag[0] * rinvmag[2]) +
+                                (tt3 * delr[2][0]) -
+                                (delr[0][0] * rinvmag[2] * rinvmag[0]));
+    dthetadr[2][1][1] = -sc1 * ((tt1 * delr[0][1]) -
+                                (delr[2][1] * rinvmag[0] * rinvmag[2]) +
+                                (tt3 * delr[2][1]) -
+                                (delr[0][1] * rinvmag[2] * rinvmag[0]));
+    dthetadr[2][1][2] = -sc1 * ((tt1 * delr[0][2]) -
+                                (delr[2][2] * rinvmag[0] * rinvmag[2]) +
+                                (tt3 * delr[2][2]) -
+                                (delr[0][2] * rinvmag[2] * rinvmag[0]));
+    dthetadr[2][3][0] = sc1 * ((tt3 * delr[2][0]) -
+                               (delr[0][0] * rinvmag[2] * rinvmag[0]));
+    dthetadr[2][3][1] = sc1 * ((tt3 * delr[2][1]) -
+                               (delr[0][1] * rinvmag[2] * rinvmag[0]));
+    dthetadr[2][3][2] = sc1 * ((tt3 * delr[2][2]) -
+                               (delr[0][2] * rinvmag[2] * rinvmag[0]));
+
+    // compute d( 1 / sin(theta))/dr
+    // i = angle, j = atom, k = direction
+
+    for (i = 0; i < 3; i++) {
+      cossin2 = -costheta[i] / sinsqtheta[i];
+      for (j = 0; j < 4; j++)
+        for (k = 0; k < 3; k++)
+          dinvsth[i][j][k] = cossin2 * dthetadr[i][j][k];
+    }
+
+    // compute d(1 / sin(theta) * |r_AB| * |r_CB| * |r_DB|)/dr
+    // i = angle, j = atom
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++) {
+        dinvs3r[0][i][j] = (invstheta[1] * dinv3r[i][j]) +
+          (inv3r * dinvsth[1][i][j]);
+        dinvs3r[1][i][j] = (invstheta[2] * dinv3r[i][j]) +
+          (inv3r * dinvsth[2][i][j]);
+        dinvs3r[2][i][j] = (invstheta[0] * dinv3r[i][j]) +
+          (inv3r * dinvsth[0][i][j]);
+      }
+
+    // drCB(i,j,k), etc
+    // i = vector X'/Y'/Z', j = atom A/B/C/D, k = direction X/Y/Z
+
+    for (i = 0; i < 3; i++) {
+      drCB[i][1][i] = -1.0;
+      drAB[i][1][i] = -1.0;
+      drDB[i][1][i] = -1.0;
+      drDB[i][3][i] = 1.0;
+      drCB[i][2][i] = 1.0;
+      drAB[i][0][i] = 1.0;
+    }
+
+    // d((r_CB x r_DB) dot r_AB)
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++) {
+        //cross(delr[1],drDB[i][j],rCBxdrDB);
+        rCBxdrDB[0] = delr[1][1]*drDB[i][j][2] - delr[1][2]*drDB[i][j][1];
+        rCBxdrDB[1] = delr[1][2]*drDB[i][j][0] - delr[1][0]*drDB[i][j][2];
+        rCBxdrDB[2] = delr[1][0]*drDB[i][j][1] - delr[1][1]*drDB[i][j][0];
+
+        //cross(drCB[i][j],delr[2],drCBxrDB);
+        drCBxrDB[0] = drCB[i][j][1]*delr[2][2] - drCB[i][j][2]*delr[2][1];
+        drCBxrDB[1] = drCB[i][j][2]*delr[2][0] - drCB[i][j][0]*delr[2][2];
+        drCBxrDB[2] = drCB[i][j][0]*delr[2][1] - drCB[i][j][1]*delr[2][0];
+
+        for (k = 0; k < 3; k++) dd[k] = rCBxdrDB[k] + drCBxrDB[k];
+        //dot1 = dot(dd,delr[0]);
+        dot1 = dd[0]*delr[0][0] + dd[1]*delr[0][1] + dd[2]*delr[0][2];
+
+        //dot2 = dot(rCBxrDB,drAB[i][j]);
+        dot2 = rCBxrDB[0]*drAB[i][j][0] + rCBxrDB[1]*drAB[i][j][1] + rCBxrDB[2]*drAB[i][j][2];
+
+        fdot[0][j][i] = dot1 + dot2;
+      }
+
+    // d((r_DB x r_AB) dot r_CB)
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++) {
+        //cross(delr[2],drAB[i][j],rDBxdrAB);
+        rDBxdrAB[0] = delr[2][1]*drAB[i][j][2] - delr[2][2]*drAB[i][j][1];
+        rDBxdrAB[1] = delr[2][2]*drAB[i][j][0] - delr[2][0]*drAB[i][j][2];
+        rDBxdrAB[2] = delr[2][0]*drAB[i][j][1] - delr[2][1]*drAB[i][j][0];
+
+        //cross(drDB[i][j],delr[0],drDBxrAB);
+        drDBxrAB[0] = drDB[i][j][1]*delr[0][2] - drDB[i][j][2]*delr[0][1];
+        drDBxrAB[1] = drDB[i][j][2]*delr[0][0] - drDB[i][j][0]*delr[0][2];
+        drDBxrAB[2] = drDB[i][j][0]*delr[0][1] - drDB[i][j][1]*delr[0][0];
+
+        for (k = 0; k < 3; k++) dd[k] = rDBxdrAB[k] + drDBxrAB[k];
+
+        //dot1 = dot(dd,delr[1]);
+        dot1 = dd[0]*delr[1][0] + dd[1]*delr[1][1] + dd[2]*delr[1][2];
+
+        //dot2 = dot(rDBxrAB,drCB[i][j]);
+        dot2 = rDBxrAB[0]*drCB[i][j][0] + rDBxrAB[1]*drCB[i][j][1] + rDBxrAB[2]*drCB[i][j][2];
+
+        fdot[1][j][i] = dot1 + dot2;
+      }
+
+    // d((r_AB x r_CB) dot r_DB)
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++) {
+        //cross(delr[0],drCB[i][j],rABxdrCB);
+        rABxdrCB[0] = delr[0][1]*drCB[i][j][2] - delr[0][2]*drCB[i][j][1];
+        rABxdrCB[1] = delr[0][2]*drCB[i][j][0] - delr[0][0]*drCB[i][j][2];
+        rABxdrCB[2] = delr[0][0]*drCB[i][j][1] - delr[0][1]*drCB[i][j][0];
+
+        //cross(drAB[i][j],delr[1],drABxrCB);
+        drABxrCB[0] = drAB[i][j][1]*delr[1][2] - drAB[i][j][2]*delr[1][1];
+        drABxrCB[1] = drAB[i][j][2]*delr[1][0] - drAB[i][j][0]*delr[1][2];
+        drABxrCB[2] = drAB[i][j][0]*delr[1][1] - drAB[i][j][1]*delr[1][0];
+
+        for (k = 0; k < 3; k++) dd[k] = rABxdrCB[k] + drABxrCB[k];
+
+        //dot1 = dot(dd,delr[2]);
+        dot1 = dd[0]*delr[2][0] + dd[1]*delr[2][1] + dd[2]*delr[2][2];
+
+        //dot2 = dot(rABxrCB,drDB[i][j]);
+        dot2 = rABxrCB[0]*drDB[i][j][0] +rABxrCB[1]*drDB[i][j][1] +rABxrCB[2]*drDB[i][j][2];
+
+        fdot[2][j][i] = dot1 + dot2;
+      }
+
+    // force on each atom
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++) {
+        ftmp = (fdot[0][i][j] * invs3r[0]) + (dinvs3r[0][i][j] * dotCBDBAB);
+        dchi[0][i][j] = ftmp / cos(chiABCD);
+        ftmp = (fdot[1][i][j] * invs3r[1]) + (dinvs3r[1][i][j] * dotDBABCB);
+        dchi[1][i][j] = ftmp / cos(chiCBDA);
+        ftmp = (fdot[2][i][j] * invs3r[2]) + (dinvs3r[2][i][j] * dotABCBDB);
+        dchi[2][i][j] = ftmp / cos(chiDBAC);
+        dtotalchi[i][j] = (dchi[0][i][j]+dchi[1][i][j]+dchi[2][i][j]) / 3.0;
+      }
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] = -2.0*d_k0[type] * deltachi*dtotalchi[i][j];
+
+    // apply force to each of 4 atoms
+
+    F_FLOAT f1[3],f2[3],f3[3],f4[3];
+
+    for (i = 0; i < 3; i++) {
+      f1[i] = fabcd[0][i];
+      f2[i] = fabcd[1][i];
+      f3[i] = fabcd[2][i];
+      f4[i] = fabcd[3][i];
+    }
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      a_f(i1,0) += f1[0];
+      a_f(i1,1) += f1[1];
+      a_f(i1,2) += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      a_f(i2,0) += f2[0];
+      a_f(i2,1) += f2[1];
+      a_f(i2,2) += f2[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      a_f(i3,0) += f3[0];
+      a_f(i3,1) += f3[1];
+      a_f(i3,2) += f3[2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      a_f(i4,0) += f4[0];
+      a_f(i4,1) += f4[1];
+      a_f(i4,2) += f4[2];
+    }
+
+    if (EVFLAG)
+      ev_tally(ev,i1,i2,i3,i4,eimproper,f1,f3,f4,
+               delr[0][0], delr[0][1], delr[0][2],
+               delr[1][0], delr[1][1], delr[1][2],
+               delr[2][0]- delr[1][0], delr[2][1]-delr[1][1], delr[2][2]-delr[1][2]);
+  }
+
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTON_BOND,EVFLAG>, const int &n) const {
+  EV_FLOAT ev;
+  this->template operator()<NEWTON_BOND,EVFLAG>(TagImproperClass2Compute<NEWTON_BOND,EVFLAG>(), n, ev);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2AngleAngle<NEWTON_BOND,EVFLAG>, const int &n, EV_FLOAT& ev) const {
+
+  // The f array is atomic
+  Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > a_f = f;
+
+  int i,j,k;
+  F_FLOAT eimproper;
+  F_FLOAT delxAB,delyAB,delzAB,rABmag2,rAB;
+  F_FLOAT delxBC,delyBC,delzBC,rBCmag2,rBC;
+  F_FLOAT delxBD,delyBD,delzBD,rBDmag2,rBD;
+  F_FLOAT costhABC,thetaABC,costhABD;
+  F_FLOAT thetaABD,costhCBD,thetaCBD,dthABC,dthCBD,dthABD;
+  F_FLOAT sc1,t1,t3,r12;
+  F_FLOAT dthetadr[3][4][3],fabcd[4][3];
+
+  const int i1 = improperlist(n,0);
+  const int i2 = improperlist(n,1);
+  const int i3 = improperlist(n,2);
+  const int i4 = improperlist(n,3);
+  const int type = improperlist(n,4);
+
+  if ((d_aa_k1[type] != 0.0) || (d_aa_k2[type] != 0.0) || (d_aa_k3[type] != 0.0)) {
+
+    // difference vectors
+
+    delxAB = x(i1,0) - x(i2,0);
+    delyAB = x(i1,1) - x(i2,1);
+    delzAB = x(i1,2) - x(i2,2);
+
+    delxBC = x(i3,0) - x(i2,0);
+    delyBC = x(i3,1) - x(i2,1);
+    delzBC = x(i3,2) - x(i2,2);
+
+    delxBD = x(i4,0) - x(i2,0);
+    delyBD = x(i4,1) - x(i2,1);
+    delzBD = x(i4,2) - x(i2,2);
+
+    // bond lengths
+
+    rABmag2 = delxAB*delxAB + delyAB*delyAB + delzAB*delzAB;
+    rAB = sqrt(rABmag2);
+    rBCmag2 = delxBC*delxBC + delyBC*delyBC + delzBC*delzBC;
+    rBC = sqrt(rBCmag2);
+    rBDmag2 = delxBD*delxBD + delyBD*delyBD + delzBD*delzBD;
+    rBD = sqrt(rBDmag2);
+
+    // angle ABC, ABD, CBD
+
+    costhABC = (delxAB*delxBC + delyAB*delyBC + delzAB*delzBC) / (rAB * rBC);
+    if (costhABC > 1.0)  costhABC = 1.0;
+    if (costhABC < -1.0) costhABC = -1.0;
+    thetaABC = acos(costhABC);
+
+    costhABD = (delxAB*delxBD + delyAB*delyBD + delzAB*delzBD) / (rAB * rBD);
+    if (costhABD > 1.0)  costhABD = 1.0;
+    if (costhABD < -1.0) costhABD = -1.0;
+    thetaABD = acos(costhABD);
+
+    costhCBD = (delxBC*delxBD + delyBC*delyBD + delzBC*delzBD) /(rBC * rBD);
+    if (costhCBD > 1.0)  costhCBD = 1.0;
+    if (costhCBD < -1.0) costhCBD = -1.0;
+    thetaCBD = acos(costhCBD);
+
+    dthABC = thetaABC - d_aa_theta0_1[type];
+    dthABD = thetaABD - d_aa_theta0_2[type];
+    dthCBD = thetaCBD - d_aa_theta0_3[type];
+
+    // energy
+
+    if (eflag) eimproper = d_aa_k2[type] * dthABC * dthABD +
+                 d_aa_k1[type] * dthABC * dthCBD +
+                 d_aa_k3[type] * dthABD * dthCBD;
+
+    // d(theta)/d(r) array
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++)
+        for (k = 0; k < 3; k++)
+          dthetadr[i][j][k] = 0.0;
+
+    // angle ABC
+
+    sc1 = sqrt(1.0/(1.0 - costhABC*costhABC));
+    t1 = costhABC / rABmag2;
+    t3 = costhABC / rBCmag2;
+    r12 = 1.0 / (rAB * rBC);
+
+    dthetadr[0][0][0] = sc1 * ((t1 * delxAB) - (delxBC * r12));
+    dthetadr[0][0][1] = sc1 * ((t1 * delyAB) - (delyBC * r12));
+    dthetadr[0][0][2] = sc1 * ((t1 * delzAB) - (delzBC * r12));
+    dthetadr[0][1][0] = sc1 * ((-t1 * delxAB) + (delxBC * r12) +
+                               (-t3 * delxBC) + (delxAB * r12));
+    dthetadr[0][1][1] = sc1 * ((-t1 * delyAB) + (delyBC * r12) +
+                               (-t3 * delyBC) + (delyAB * r12));
+    dthetadr[0][1][2] = sc1 * ((-t1 * delzAB) + (delzBC * r12) +
+                               (-t3 * delzBC) + (delzAB * r12));
+    dthetadr[0][2][0] = sc1 * ((t3 * delxBC) - (delxAB * r12));
+    dthetadr[0][2][1] = sc1 * ((t3 * delyBC) - (delyAB * r12));
+    dthetadr[0][2][2] = sc1 * ((t3 * delzBC) - (delzAB * r12));
+
+    // angle CBD
+
+    sc1 = sqrt(1.0/(1.0 - costhCBD*costhCBD));
+    t1 = costhCBD / rBCmag2;
+    t3 = costhCBD / rBDmag2;
+    r12 = 1.0 / (rBC * rBD);
+
+    dthetadr[1][2][0] = sc1 * ((t1 * delxBC) - (delxBD * r12));
+    dthetadr[1][2][1] = sc1 * ((t1 * delyBC) - (delyBD * r12));
+    dthetadr[1][2][2] = sc1 * ((t1 * delzBC) - (delzBD * r12));
+    dthetadr[1][1][0] = sc1 * ((-t1 * delxBC) + (delxBD * r12) +
+                               (-t3 * delxBD) + (delxBC * r12));
+    dthetadr[1][1][1] = sc1 * ((-t1 * delyBC) + (delyBD * r12) +
+                               (-t3 * delyBD) + (delyBC * r12));
+    dthetadr[1][1][2] = sc1 * ((-t1 * delzBC) + (delzBD * r12) +
+                               (-t3 * delzBD) + (delzBC * r12));
+    dthetadr[1][3][0] = sc1 * ((t3 * delxBD) - (delxBC * r12));
+    dthetadr[1][3][1] = sc1 * ((t3 * delyBD) - (delyBC * r12));
+    dthetadr[1][3][2] = sc1 * ((t3 * delzBD) - (delzBC * r12));
+
+    // angle ABD
+
+    sc1 = sqrt(1.0/(1.0 - costhABD*costhABD));
+    t1 = costhABD / rABmag2;
+    t3 = costhABD / rBDmag2;
+    r12 = 1.0 / (rAB * rBD);
+
+    dthetadr[2][0][0] = sc1 * ((t1 * delxAB) - (delxBD * r12));
+    dthetadr[2][0][1] = sc1 * ((t1 * delyAB) - (delyBD * r12));
+    dthetadr[2][0][2] = sc1 * ((t1 * delzAB) - (delzBD * r12));
+    dthetadr[2][1][0] = sc1 * ((-t1 * delxAB) + (delxBD * r12) +
+                               (-t3 * delxBD) + (delxAB * r12));
+    dthetadr[2][1][1] = sc1 * ((-t1 * delyAB) + (delyBD * r12) +
+                               (-t3 * delyBD) + (delyAB * r12));
+    dthetadr[2][1][2] = sc1 * ((-t1 * delzAB) + (delzBD * r12) +
+                               (-t3 * delzBD) + (delzAB * r12));
+    dthetadr[2][3][0] = sc1 * ((t3 * delxBD) - (delxAB * r12));
+    dthetadr[2][3][1] = sc1 * ((t3 * delyBD) - (delyAB * r12));
+    dthetadr[2][3][2] = sc1 * ((t3 * delzBD) - (delzAB * r12));
+
+    // angleangle forces
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] = -
+          ((d_aa_k1[type] * (dthABC*dthetadr[1][i][j] + dthCBD*dthetadr[0][i][j])) +
+           (d_aa_k2[type] * (dthABC*dthetadr[2][i][j] + dthABD*dthetadr[0][i][j])) +
+           (d_aa_k3[type] * (dthABD*dthetadr[1][i][j] + dthCBD*dthetadr[2][i][j])));
+
+    // apply force to each of 4 atoms
+
+    F_FLOAT f1[3],f2[3],f3[3],f4[3];
+
+    for (i = 0; i < 3; i++) {
+      f1[i] = fabcd[0][i];
+      f2[i] = fabcd[1][i];
+      f3[i] = fabcd[2][i];
+      f4[i] = fabcd[3][i];
+    }
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      a_f(i1,0) += f1[0];
+      a_f(i1,1) += f1[1];
+      a_f(i1,2) += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      a_f(i2,0) += f2[0];
+      a_f(i2,1) += f2[1];
+      a_f(i2,2) += f2[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      a_f(i3,0) += f3[0];
+      a_f(i3,1) += f3[1];
+      a_f(i3,2) += f3[2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      a_f(i4,0) += f4[0];
+      a_f(i4,1) += f4[1];
+      a_f(i4,2) += f4[2];
+    }
+
+    if (EVFLAG)
+      ev_tally(ev,i1,i2,i3,i4,eimproper,
+               fabcd[0],fabcd[2],fabcd[3],
+               delxAB,delyAB,delzAB,delxBC,delyBC,delzBC,
+               delxBD-delxBC,delyBD-delyBC,delzBD-delzBC);
+  }
+
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2AngleAngle<NEWTON_BOND,EVFLAG>, const int &n) const {
+  EV_FLOAT ev;
+  this->template operator()<NEWTON_BOND,EVFLAG>(TagImproperClass2AngleAngle<NEWTON_BOND,EVFLAG>(), n, ev);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void ImproperClass2Kokkos<DeviceType>::allocate()
+{
+  ImproperClass2::allocate();
+}
+
+/* ----------------------------------------------------------------------
+   set coeffs for one type
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void ImproperClass2Kokkos<DeviceType>::coeff(int narg, char **arg)
+{
+  ImproperClass2::coeff(narg, arg);
+
+  int n = atom->nimpropertypes;
+  k_k0 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::k0",n+1);
+  k_chi0 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::chi0",n+1);
+  k_aa_k1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::aa_k1",n+1);
+  k_aa_k2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::aa_k2",n+1);
+  k_aa_k3 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::aa_k3",n+1);
+  k_aa_theta0_1 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::aa_theta0_1",n+1);
+  k_aa_theta0_2 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::aa_theta0_2",n+1);
+  k_aa_theta0_3 = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::aa_theta0_3",n+1);
+  k_setflag = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::setflag",n+1);
+  k_setflag_i = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::setflag_i",n+1);
+  k_setflag_aa = typename ArrayTypes<DeviceType>::tdual_ffloat_1d("ImproperClass2::setflag_aa",n+1);
+
+  d_k0 = k_k0.template view<DeviceType>();
+  d_chi0 = k_chi0.template view<DeviceType>();
+  d_aa_k1 = k_aa_k1.template view<DeviceType>();
+  d_aa_k2 = k_aa_k2.template view<DeviceType>();
+  d_aa_k3 = k_aa_k3.template view<DeviceType>();
+  d_aa_theta0_1 = k_aa_theta0_1.template view<DeviceType>();
+  d_aa_theta0_2 = k_aa_theta0_2.template view<DeviceType>();
+  d_aa_theta0_3 = k_aa_theta0_3.template view<DeviceType>();
+  d_setflag = k_setflag.template view<DeviceType>();
+  d_setflag_i = k_setflag_i.template view<DeviceType>();
+  d_setflag_aa = k_setflag_aa.template view<DeviceType>();
+
+  for (int i = 1; i <= n; i++) {
+    k_k0.h_view[i] = k0[i];
+    k_chi0.h_view[i] = chi0[i];
+    k_aa_k1.h_view[i] = aa_k1[i];
+    k_aa_k2.h_view[i] = aa_k2[i];
+    k_aa_k3.h_view[i] = aa_k3[i];
+    k_aa_theta0_1.h_view[i] = aa_theta0_1[i];
+    k_aa_theta0_2.h_view[i] = aa_theta0_2[i];
+    k_aa_theta0_3.h_view[i] = aa_theta0_3[i];
+    k_setflag.h_view[i] = setflag[i];
+    k_setflag_i.h_view[i] = setflag_i[i];
+    k_setflag_aa.h_view[i] = setflag_aa[i];
+  }
+
+  k_k0.template modify<LMPHostType>();
+  k_chi0.template modify<LMPHostType>();
+  k_aa_k1.template modify<LMPHostType>();
+  k_aa_k2.template modify<LMPHostType>();
+  k_aa_k3.template modify<LMPHostType>();
+  k_aa_theta0_1.template modify<LMPHostType>();
+  k_aa_theta0_2.template modify<LMPHostType>();
+  k_aa_theta0_3 .template modify<LMPHostType>();
+  k_setflag.template modify<LMPHostType>();
+  k_setflag_i.template modify<LMPHostType>();
+  k_setflag_aa.template modify<LMPHostType>();
+}
+
+/* ----------------------------------------------------------------------
+   tally energy and virial into global and per-atom accumulators
+   virial = r1F1 + r2F2 + r3F3 + r4F4 = (r1-r2) F1 + (r3-r2) F3 + (r4-r2) F4
+          = (r1-r2) F1 + (r3-r2) F3 + (r4-r3 + r3-r2) F4
+          = vb1*f1 + vb2*f3 + (vb3+vb2)*f4
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+//template<int NEWTON_BOND>
+KOKKOS_INLINE_FUNCTION
+void ImproperClass2Kokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int i1, const int i2, const int i3, const int i4,
+                        F_FLOAT &eimproper, F_FLOAT *f1, F_FLOAT *f3, F_FLOAT *f4,
+                        const F_FLOAT &vb1x, const F_FLOAT &vb1y, const F_FLOAT &vb1z,
+                        const F_FLOAT &vb2x, const F_FLOAT &vb2y, const F_FLOAT &vb2z,
+                        const F_FLOAT &vb3x, const F_FLOAT &vb3y, const F_FLOAT &vb3z) const
+{
+  E_FLOAT eimproperquarter;
+  F_FLOAT v[6];
+
+  // The eatom and vatom arrays are atomic
+  Kokkos::View<E_FLOAT*, typename DAT::t_efloat_1d::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_eatom = k_eatom.view<DeviceType>();
+  Kokkos::View<F_FLOAT*[6], typename DAT::t_virial_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_vatom = k_vatom.view<DeviceType>();
+
+  if (eflag_either) {
+    if (eflag_global) {
+      if (newton_bond) ev.evdwl += eimproper;
+      else {
+        eimproperquarter = 0.25*eimproper;
+        if (i1 < nlocal) ev.evdwl += eimproperquarter;
+        if (i2 < nlocal) ev.evdwl += eimproperquarter;
+        if (i3 < nlocal) ev.evdwl += eimproperquarter;
+        if (i4 < nlocal) ev.evdwl += eimproperquarter;
+      }
+    }
+    if (eflag_atom) {
+      eimproperquarter = 0.25*eimproper;
+      if (newton_bond || i1 < nlocal) v_eatom[i1] += eimproperquarter;
+      if (newton_bond || i2 < nlocal) v_eatom[i2] += eimproperquarter;
+      if (newton_bond || i3 < nlocal) v_eatom[i3] += eimproperquarter;
+      if (newton_bond || i4 < nlocal) v_eatom[i4] += eimproperquarter;
+    }
+  }
+
+  if (vflag_either) {
+    v[0] = vb1x*f1[0] + vb2x*f3[0] + (vb3x+vb2x)*f4[0];
+    v[1] = vb1y*f1[1] + vb2y*f3[1] + (vb3y+vb2y)*f4[1];
+    v[2] = vb1z*f1[2] + vb2z*f3[2] + (vb3z+vb2z)*f4[2];
+    v[3] = vb1x*f1[1] + vb2x*f3[1] + (vb3x+vb2x)*f4[1];
+    v[4] = vb1x*f1[2] + vb2x*f3[2] + (vb3x+vb2x)*f4[2];
+    v[5] = vb1y*f1[2] + vb2y*f3[2] + (vb3y+vb2y)*f4[2];
+
+    if (vflag_global) {
+      if (newton_bond) {
+        ev.v[0] += v[0];
+        ev.v[1] += v[1];
+        ev.v[2] += v[2];
+        ev.v[3] += v[3];
+        ev.v[4] += v[4];
+        ev.v[5] += v[5];
+      } else {
+        if (i1 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i2 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i3 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i4 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+      }
+    }
+
+    if (vflag_atom) {
+      if (newton_bond || i1 < nlocal) {
+        v_vatom(i1,0) += 0.25*v[0];
+        v_vatom(i1,1) += 0.25*v[1];
+        v_vatom(i1,2) += 0.25*v[2];
+        v_vatom(i1,3) += 0.25*v[3];
+        v_vatom(i1,4) += 0.25*v[4];
+        v_vatom(i1,5) += 0.25*v[5];
+      }
+      if (newton_bond || i2 < nlocal) {
+        v_vatom(i2,0) += 0.25*v[0];
+        v_vatom(i2,1) += 0.25*v[1];
+        v_vatom(i2,2) += 0.25*v[2];
+        v_vatom(i2,3) += 0.25*v[3];
+        v_vatom(i2,4) += 0.25*v[4];
+        v_vatom(i2,5) += 0.25*v[5];
+      }
+      if (newton_bond || i3 < nlocal) {
+        v_vatom(i3,0) += 0.25*v[0];
+        v_vatom(i3,1) += 0.25*v[1];
+        v_vatom(i3,2) += 0.25*v[2];
+        v_vatom(i3,3) += 0.25*v[3];
+        v_vatom(i3,4) += 0.25*v[4];
+        v_vatom(i3,5) += 0.25*v[5];
+      }
+      if (newton_bond || i4 < nlocal) {
+        v_vatom(i4,0) += 0.25*v[0];
+        v_vatom(i4,1) += 0.25*v[1];
+        v_vatom(i4,2) += 0.25*v[2];
+        v_vatom(i4,3) += 0.25*v[3];
+        v_vatom(i4,4) += 0.25*v[4];
+        v_vatom(i4,5) += 0.25*v[5];
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+namespace LAMMPS_NS {
+template class ImproperClass2Kokkos<LMPDeviceType>;
+#ifdef KOKKOS_HAVE_CUDA
+template class ImproperClass2Kokkos<LMPHostType>;
+#endif
+}
+

--- a/src/KOKKOS/improper_class2_kokkos.cpp
+++ b/src/KOKKOS/improper_class2_kokkos.cpp
@@ -77,21 +77,21 @@ void ImproperClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   // reallocate per-atom arrays if necessary
 
   if (eflag_atom) {
-    if(k_eatom.dimension_0()<maxeatom) {
+    //if(k_eatom.dimension_0()<maxeatom) { // won't work without adding zero functor
       memory->destroy_kokkos(k_eatom,eatom);
       memory->create_kokkos(k_eatom,eatom,maxeatom,"improper:eatom");
-      d_eatom = k_eatom.d_view;
-    }
+      d_eatom = k_eatom.template view<DeviceType>();
+    //}
   }
   if (vflag_atom) {
-    if(k_vatom.dimension_0()<maxvatom) {
+    //if(k_vatom.dimension_0()<maxvatom) { // won't work without adding zero functor
       memory->destroy_kokkos(k_vatom,vatom);
       memory->create_kokkos(k_vatom,vatom,maxvatom,6,"improper:vatom");
-      d_vatom = k_vatom.d_view;
-    }
+      d_vatom = k_vatom.template view<DeviceType>();
+    //}
   }
 
-  atomKK->sync(execution_space,datamask_read);
+  //atomKK->sync(execution_space,datamask_read);
   k_k0.template sync<DeviceType>();
   k_chi0.template sync<DeviceType>();
   k_aa_k1.template sync<DeviceType>();
@@ -104,8 +104,8 @@ void ImproperClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_setflag_i.template sync<DeviceType>();
   k_setflag_aa.template sync<DeviceType>();
 
-  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
-  else atomKK->modified(execution_space,F_MASK);
+  //if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  //else atomKK->modified(execution_space,F_MASK);
 
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();

--- a/src/KOKKOS/improper_class2_kokkos.h
+++ b/src/KOKKOS/improper_class2_kokkos.h
@@ -79,8 +79,8 @@ class ImproperClass2Kokkos : public ImproperClass2 {
 
   DAT::tdual_efloat_1d k_eatom;
   DAT::tdual_virial_array k_vatom;
-  DAT::t_efloat_1d d_eatom;
-  DAT::t_virial_array d_vatom;
+  typename AT::t_efloat_1d d_eatom;
+  typename AT::t_virial_array d_vatom;
 
   int nlocal,newton_bond;
   int eflag,vflag;
@@ -89,13 +89,13 @@ class ImproperClass2Kokkos : public ImproperClass2 {
   typename AT::t_int_scalar d_warning_flag;
   HAT::t_int_scalar h_warning_flag;
 
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_k0,k_chi0;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_aa_k1,k_aa_k2,k_aa_k3,k_aa_theta0_1,k_aa_theta0_2,k_aa_theta0_3;
-  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag_i,k_setflag_aa,k_setflag;
+  typename AT::tdual_ffloat_1d k_k0,k_chi0;
+  typename AT::tdual_ffloat_1d k_aa_k1,k_aa_k2,k_aa_k3,k_aa_theta0_1,k_aa_theta0_2,k_aa_theta0_3;
+  typename AT::tdual_ffloat_1d k_setflag_i,k_setflag_aa,k_setflag;
 
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_k0,d_chi0;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_aa_k1,d_aa_k2,d_aa_k3,d_aa_theta0_1,d_aa_theta0_2,d_aa_theta0_3;
-  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag_i,d_setflag_aa,d_setflag;
+  typename AT::t_ffloat_1d d_k0,d_chi0;
+  typename AT::t_ffloat_1d d_aa_k1,d_aa_k2,d_aa_k3,d_aa_theta0_1,d_aa_theta0_2,d_aa_theta0_3;
+  typename AT::t_ffloat_1d d_setflag_i,d_setflag_aa,d_setflag;
 
   virtual void allocate();
 };

--- a/src/KOKKOS/improper_class2_kokkos.h
+++ b/src/KOKKOS/improper_class2_kokkos.h
@@ -1,0 +1,115 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef IMPROPER_CLASS
+
+ImproperStyle(class2/kk,ImproperClass2Kokkos<LMPDeviceType>)
+ImproperStyle(class2/kk/device,ImproperClass2Kokkos<LMPDeviceType>)
+ImproperStyle(class2/kk/host,ImproperClass2Kokkos<LMPHostType>)
+
+#else
+
+#ifndef LMP_IMPROPER_CLASS2_KOKKOS_H
+#define LMP_IMPROPER_CLASS2_KOKKOS_H
+
+#include "improper_class2.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template<int NEWTON_BOND, int EVFLAG>
+struct TagImproperClass2Compute{};
+
+template<int NEWTON_BOND, int EVFLAG>
+struct TagImproperClass2AngleAngle{};
+
+template<class DeviceType>
+class ImproperClass2Kokkos : public ImproperClass2 {
+ public:
+  typedef DeviceType device_type;
+  typedef EV_FLOAT value_type;
+  typedef ArrayTypes<DeviceType> AT;
+
+  ImproperClass2Kokkos(class LAMMPS *);
+  virtual ~ImproperClass2Kokkos();
+  virtual void compute(int, int);
+  virtual void coeff(int, char **);
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagImproperClass2Compute<NEWTON_BOND,EVFLAG>, const int&, EV_FLOAT&) const;
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagImproperClass2Compute<NEWTON_BOND,EVFLAG>, const int&) const;
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagImproperClass2AngleAngle<NEWTON_BOND,EVFLAG>, const int&, EV_FLOAT&) const;
+
+  template<int NEWTON_BOND, int EVFLAG>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagImproperClass2AngleAngle<NEWTON_BOND,EVFLAG>, const int&) const;
+
+  //template<int NEWTON_BOND>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally(EV_FLOAT &ev, const int i1, const int i2, const int i3, const int i4,
+                          F_FLOAT &eimproper, F_FLOAT *f1, F_FLOAT *f3, F_FLOAT *f4,
+                          const F_FLOAT &vb1x, const F_FLOAT &vb1y, const F_FLOAT &vb1z,
+                          const F_FLOAT &vb2x, const F_FLOAT &vb2y, const F_FLOAT &vb2z,
+                          const F_FLOAT &vb3x, const F_FLOAT &vb3y, const F_FLOAT &vb3z) const;
+
+ protected:
+
+  class NeighborKokkos *neighborKK;
+
+  typename AT::t_x_array_randomread x;
+  typename Kokkos::View<double*[3],typename AT::t_f_array::array_layout,DeviceType,Kokkos::MemoryTraits<Kokkos::Atomic> > f;
+  typename AT::t_int_2d improperlist;
+
+  DAT::tdual_efloat_1d k_eatom;
+  DAT::tdual_virial_array k_vatom;
+  DAT::t_efloat_1d d_eatom;
+  DAT::t_virial_array d_vatom;
+
+  int nlocal,newton_bond;
+  int eflag,vflag;
+
+  DAT::tdual_int_scalar k_warning_flag;
+  typename AT::t_int_scalar d_warning_flag;
+  HAT::t_int_scalar h_warning_flag;
+
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_k0,k_chi0;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_aa_k1,k_aa_k2,k_aa_k3,k_aa_theta0_1,k_aa_theta0_2,k_aa_theta0_3;
+  typename ArrayTypes<DeviceType>::tdual_ffloat_1d k_setflag_i,k_setflag_aa,k_setflag;
+
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_k0,d_chi0;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_aa_k1,d_aa_k2,d_aa_k3,d_aa_theta0_1,d_aa_theta0_2,d_aa_theta0_3;
+  typename ArrayTypes<DeviceType>::t_ffloat_1d d_setflag_i,d_setflag_aa,d_setflag;
+
+  virtual void allocate();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+W: Dihedral problem
+
+Conformation of the 4 listed dihedral atoms is extreme; you may want
+to check your simulation geometry.
+
+*/


### PR DESCRIPTION
From Ray Shan (Materials Design), @RayMaterialsDesign : "I have ported bond, angle, dihedral, and improper class2 styles to Kokkos ... useful for polymer force fields such as COMPASS and PCFF/PCFF+.  On one K40 GPU card, the bonded interactions are ~5.9 times faster than one Intel Xeon 3.0 GHz core for a ~100,000 atom system."