### PR TITLE
USER-DPD: a variety of small but important bugfixes

### DIFF
--- a/src/USER-DPD/atom_vec_dpd.cpp
+++ b/src/USER-DPD/atom_vec_dpd.cpp
@@ -488,8 +488,6 @@ int AtomVecDPD::pack_comm_hybrid(int n, int *list, double *buf)
     buf[m++] = uCond[j];
     buf[m++] = uMech[j];
     buf[m++] = uChem[j];
-    buf[m++] = uCG[j];
-    buf[m++] = uCGnew[j];
   }
   return m;
 }
@@ -589,8 +587,6 @@ int AtomVecDPD::unpack_comm_hybrid(int n, int first, double *buf)
     uCond[i] = buf[m++];
     uMech[i] = buf[m++];
     uChem[i] = buf[m++];
-    uCG[i] = buf[m++];
-    uCGnew[i] = buf[m++];
   }
   return m;
 }

--- a/src/USER-DPD/pair_multi_lucy_rx.cpp
+++ b/src/USER-DPD/pair_multi_lucy_rx.cpp
@@ -923,15 +923,15 @@ void PairMultiLucyRX::computeLocalDensity()
           rho_i += factor;
           if (newton_pair || j < nlocal)
             rho[j] += factor;
-        } else if (rsq < cutsq[itype][jtype]) {
-          const double rcut = sqrt(cutsq[itype][jtype]);
-          const double tmpFactor = 1.0-sqrt(rsq)/rcut;
-          const double tmpFactor4 = tmpFactor*tmpFactor*tmpFactor*tmpFactor;
-          const double factor = (84.0/(5.0*pi*rcut*rcut*rcut))*(1.0+3.0*sqrt(rsq)/(2.0*rcut))*tmpFactor4;
-          rho_i += factor;
-          if (newton_pair || j < nlocal)
-            rho[j] += factor;
         }
+      } else if (rsq < cutsq[itype][jtype]) {
+        const double rcut = sqrt(cutsq[itype][jtype]);
+        const double tmpFactor = 1.0-sqrt(rsq)/rcut;
+        const double tmpFactor4 = tmpFactor*tmpFactor*tmpFactor*tmpFactor;
+        const double factor = (84.0/(5.0*pi*rcut*rcut*rcut))*(1.0+3.0*sqrt(rsq)/(2.0*rcut))*tmpFactor4;
+        rho_i += factor;
+        if (newton_pair || j < nlocal)
+          rho[j] += factor;
       }
     }
 

--- a/src/USER-DPD/pair_multi_lucy_rx.cpp
+++ b/src/USER-DPD/pair_multi_lucy_rx.cpp
@@ -385,11 +385,11 @@ void PairMultiLucyRX::coeff(int narg, char **arg)
 
   nspecies = atom->nspecies_dpd;
   int n;
-  n = strlen(arg[3]) + 1;
+  n = strlen(arg[4]) + 1;
   site1 = new char[n];
   strcpy(site1,arg[4]);
 
-  n = strlen(arg[4]) + 1;
+  n = strlen(arg[5]) + 1;
   site2 = new char[n];
   strcpy(site2,arg[5]);
 

--- a/src/USER-DPD/pair_table_rx.cpp
+++ b/src/USER-DPD/pair_table_rx.cpp
@@ -351,7 +351,7 @@ void PairTableRX::coeff(int narg, char **arg)
   nspecies = atom->nspecies_dpd;
   if(nspecies==0) error->all(FLERR,"There are no rx species specified.");
   int n;
-  n = strlen(arg[3]) + 1;
+  n = strlen(arg[4]) + 1;
   site1 = new char[n];
   strcpy(site1,arg[4]);
 
@@ -362,7 +362,7 @@ void PairTableRX::coeff(int narg, char **arg)
   if (ispecies == nspecies && strcmp(site1,"1fluid") != 0)
     error->all(FLERR,"Site1 name not recognized in pair coefficients");
 
-  n = strlen(arg[4]) + 1;
+  n = strlen(arg[5]) + 1;
   site2 = new char[n];
   strcpy(site2,arg[5]);
 


### PR DESCRIPTION
String length off-by-one errors in PairTableRX::coeff and PairMultiLucyRX::coeff.
Communication length errors in AtomVecDPD::*comm_hybrid.
Misplaced closing bracket in PairMultiLucyRX::computeLocalDensity causing important code to be skipped if there were multiple particle types.