### PR TITLE
Print error if pair_write does not get correct number of arguments

### DIFF
--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -1534,7 +1534,7 @@ void Pair::virial_fdotr_compute()
 
 void Pair::write_file(int narg, char **arg)
 {
-  if (narg < 8) error->all(FLERR,"Illegal pair_write command");
+  if (narg != 8 && narg != 10) error->all(FLERR,"Illegal pair_write command");
   if (single_enable == 0)
     error->all(FLERR,"Pair style does not support pair_write");
 


### PR DESCRIPTION
Fixes issue #397 