### PR TITLE
Removed triclinic restrictions on slab ewald/pppm.

### DIFF
--- a/doc/src/kspace_modify.txt
+++ b/doc/src/kspace_modify.txt
@@ -163,11 +163,12 @@ The {slab} keyword allows an Ewald or PPPM solver to be used for a
 systems that are periodic in x,y but non-periodic in z - a
 "boundary"_boundary.html setting of "boundary p p f".  This is done by
 treating the system as if it were periodic in z, but inserting empty
-volume between atom slabs and removing dipole inter-slab interactions
-so that slab-slab interactions are effectively turned off.  The
+volume between atom slabs and removing dipolar interactions between
+images so that slab-slab interactions are effectively turned off.  The
 volfactor value sets the ratio of the extended dimension in z divided
-by the actual dimension in z.  The recommended value is 3.0.  A larger
-value is inefficient; a smaller value introduces unwanted slab-slab
+by the actual dimension in z.  The recommended value is 3.  A larger
+value is inefficient, while a z-length smaller than three times
+the largest box length introduces unwanted slab-slab
 interactions.  The use of fixed boundaries in z means that the user
 must prevent particle migration beyond the initial z-bounds, typically
 by providing a wall-style fix.  The methodology behind the {slab}
@@ -179,9 +180,8 @@ in lieu of the volfactor.  This turns off all kspace forces in the z
 direction.  The {nozforce} option is not supported by MSM. For MSM,
 any combination of periodic, non-periodic, or shrink-wrapped
 boundaries can be set using "boundary"_boundary.html (the slab
-approximation in not needed).  The {slab} keyword is not currently
-supported by Ewald or PPPM when using a triclinic simulation cell. The
-slab correction has also been extended to point dipole interactions
+approximation in not needed).
+The slab correction has also been extended to point dipole interactions
 "(Klapp)"_#Klapp in "kspace_style"_kspace_style.html {ewald/disp}.
 
 NOTE: If you wish to apply an electric field in the Z-direction, in
@@ -316,7 +316,7 @@ split = 0, tol = 1.0e-6, and disp/auto = no.
 Adam Hilger, NY (1989).
 
 :link(Yeh)
-[(Yeh)] Yeh and Berkowitz, J Chem Phys, 111, 3155 (1999).
+[(Yeh)] Yeh and Berkowitz, J Chem Phys, 111, 3155 (1999); see also Ballenegger, J Chem Phys, 140, 161102 (2014).
 
 :link(Ballenegger)
 [(Ballenegger)] Ballenegger, Arnold, Cerda, J Chem Phys, 131, 094107

--- a/src/KSPACE/ewald.cpp
+++ b/src/KSPACE/ewald.cpp
@@ -105,9 +105,6 @@ void Ewald::init()
     if (domain->xperiodic != 1 || domain->yperiodic != 1 ||
         domain->boundary[2][0] != 1 || domain->boundary[2][1] != 1)
       error->all(FLERR,"Incorrect boundaries with slab Ewald");
-    if (domain->triclinic)
-      error->all(FLERR,"Cannot (yet) use Ewald with triclinic box "
-                 "and slab correction");
   }
 
   // extract short-range Coulombic cutoff from pair style

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -188,9 +188,6 @@ void PPPM::init()
   if (domain->triclinic && differentiation_flag == 1)
     error->all(FLERR,"Cannot (yet) use PPPM with triclinic box "
                "and kspace_modify diff ad");
-  if (domain->triclinic && slabflag)
-    error->all(FLERR,"Cannot (yet) use PPPM with triclinic box and "
-               "slab correction");
   if (domain->dimension == 2) error->all(FLERR,
                                          "Cannot use PPPM with 2d simulation");
   if (comm->style != 0)
@@ -745,13 +742,14 @@ void PPPM::compute(int eflag, int vflag)
     }
   }
 
+  // convert atoms back from lamda to box coords
+
+  if (triclinic) domain->lamda2x(atom->nlocal);
+
   // 2d slab correction
 
   if (slabflag == 1) slabcorr();
 
-  // convert atoms back from lamda to box coords
-
-  if (triclinic) domain->lamda2x(atom->nlocal);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -498,7 +498,7 @@ void KSpace::modify_params(int narg, char **arg)
       } else {
         slabflag = 1;
         slab_volfactor = force->numeric(FLERR,arg[iarg+1]);
-        if (slab_volfactor <= 1.0)
+        if (slab_volfactor < 1.0)
           error->all(FLERR,"Bad kspace_modify slab parameter");
         if (slab_volfactor < 2.0 && comm->me == 0)
           error->warning(FLERR,"Kspace_modify slab param < 2.0 may "


### PR DESCRIPTION
Since the slab correction applies specifically to the z-direction, it is not influenced by tilt.  I have confirmed the correction by calculating it manually for a system with 2 charges (+1 at 0,0,1.5 and -1 at 0.0,-1.5).  The files are attached:

[ewtest.zip](https://github.com/lammps/lammps/files/835435/ewtest.zip)

Four cases are tested -- an orthogonal and a triclinic box with and without the slab correction.
Although changing the box tilt alters the energies and forces, the correction term is identical for both, as it should be.
