### PR TITLE
improve memory usage reporting in info and output class

### DIFF
--- a/doc/src/info.txt
+++ b/doc/src/info.txt
@@ -12,7 +12,7 @@ info command :h3
 
 info args :pre
 
-args = one or more of the following keywords: {out}, {all}, {system}, {communication}, {computes}, {dumps}, {fixes}, {groups}, {regions}, {variables}, {styles}, {time}, or {configuration}
+args = one or more of the following keywords: {out}, {all}, {system}, {memory}, {communication}, {computes}, {dumps}, {fixes}, {groups}, {regions}, {variables}, {styles}, {time}, or {configuration}
      {out} values = {screen}, {log}, {append} filename, {overwrite} filename
      {styles} values = {all}, {angle}, {atom}, {bond}, {compute}, {command}, {dump}, {dihedral}, {fix}, {improper}, {integrate}, {kspace}, {minimize}, {pair}, {region} :ul
 
@@ -39,6 +39,17 @@ to one target. By default this is the screen, if it is active. The
 to that file, which is either appended to or overwritten, respectively.
 
 The {all} flag activates printing all categories listed below.
+
+The {configuration} category prints some information about the
+LAMMPS version as well as architecture and OS it is run on.
+
+The {memory} category prints some information about the current
+memory allocation of MPI rank 0 (this the amount of dynamically
+allocated memory reported by LAMMPS classes). Where supported,
+also some OS specific information about the size of the reserved
+memory pool size (this is where malloc() and the new operator
+request memory from) and the maximum resident set size is reported
+(this is the maximum amount of physical memory occupied so far).
 
 The {system} category prints a general system overview listing.  This
 includes the unit style, atom style, number of atoms, bonds, angles,
@@ -92,11 +103,6 @@ region :ul
 
 The {time} category prints the accumulated CPU and wall time for the
 process that writes output (usually MPI rank 0).
-
-The {configuration} command prints some information about the LAMMPS
-version and architecture and OS it is run on. Where supported, also
-information about the memory consumption provided by the OS is
-reported.
 
 [Restrictions:] none
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -653,6 +653,8 @@
 /pair_hbond_dreiding_lj.h
 /pair_hbond_dreiding_morse.cpp
 /pair_hbond_dreiding_morse.h
+/pair_kolmogorov_crespi_z.cpp
+/pair_kolmogorov_crespi_z.h
 /pair_lcbop.cpp
 /pair_lcbop.h
 /pair_line_lj.cpp

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -72,31 +72,32 @@ enum {COMPUTES=1<<0,
       REGIONS=1<<4,
       CONFIG=1<<5,
       TIME=1<<6,
-      VARIABLES=1<<7,
-      SYSTEM=1<<8,
-      COMM=1<<9,
-      ATOM_STYLES=1<<10,
-      INTEGRATE_STYLES=1<<11,
-      MINIMIZE_STYLES=1<<12,
-      PAIR_STYLES=1<<13,
-      BOND_STYLES=1<<14,
-      ANGLE_STYLES=1<<15,
-      DIHEDRAL_STYLES=1<<16,
-      IMPROPER_STYLES=1<<17,
-      KSPACE_STYLES=1<<18,
-      FIX_STYLES=1<<19,
-      COMPUTE_STYLES=1<<20,
-      REGION_STYLES=1<<21,
-      DUMP_STYLES=1<<22,
-      COMMAND_STYLES=1<<23,
+      MEMORY=1<<7,
+      VARIABLES=1<<8,
+      SYSTEM=1<<9,
+      COMM=1<<10,
+      ATOM_STYLES=1<<11,
+      INTEGRATE_STYLES=1<<12,
+      MINIMIZE_STYLES=1<<13,
+      PAIR_STYLES=1<<14,
+      BOND_STYLES=1<<15,
+      ANGLE_STYLES=1<<16,
+      DIHEDRAL_STYLES=1<<17,
+      IMPROPER_STYLES=1<<18,
+      KSPACE_STYLES=1<<19,
+      FIX_STYLES=1<<20,
+      COMPUTE_STYLES=1<<21,
+      REGION_STYLES=1<<22,
+      DUMP_STYLES=1<<23,
+      COMMAND_STYLES=1<<24,
       ALL=~0};
 
-static const int STYLES = ATOM_STYLES | INTEGRATE_STYLES | MINIMIZE_STYLES | PAIR_STYLES | BOND_STYLES | \
-                         ANGLE_STYLES | DIHEDRAL_STYLES | IMPROPER_STYLES | KSPACE_STYLES | FIX_STYLES | \
-                         COMPUTE_STYLES | REGION_STYLES | DUMP_STYLES | COMMAND_STYLES;
-
+static const int STYLES = ATOM_STYLES | INTEGRATE_STYLES | MINIMIZE_STYLES
+                        | PAIR_STYLES | BOND_STYLES | ANGLE_STYLES
+                        | DIHEDRAL_STYLES | IMPROPER_STYLES | KSPACE_STYLES
+                        | FIX_STYLES | COMPUTE_STYLES | REGION_STYLES
+                        | DUMP_STYLES | COMMAND_STYLES;
 }
-
 
 static const char *varstyles[] = {
   "index", "loop", "world", "universe", "uloop", "string", "getenv",
@@ -173,6 +174,9 @@ void Info::command(int narg, char **arg)
       ++idx;
     } else if (strncmp(arg[idx],"time",3) == 0) {
       flags |= TIME;
+      ++idx;
+    } else if (strncmp(arg[idx],"memory",3) == 0) {
+      flags |= MEMORY;
       ++idx;
     } else if (strncmp(arg[idx],"variables",3) == 0) {
       flags |= VARIABLES;
@@ -293,27 +297,42 @@ void Info::command(int narg, char **arg)
     fprintf(out,"\nOS information: %s %s on %s\n",
             ut.sysname, ut.release, ut.machine);
 #endif
+  }
+  
+  if (flags & MEMORY) {
 
-    fprintf(out,"\nMemory allocation information (MPI rank 0)\n");
+    fprintf(out,"\nMemory allocation information (MPI rank 0):\n\n");
+
+    bigint bytes = 0;
+    bytes += atom->memory_usage();
+    bytes += neighbor->memory_usage();
+    bytes += comm->memory_usage();
+    bytes += update->memory_usage();
+    bytes += force->memory_usage();
+    bytes += modify->memory_usage();
+    for (int i = 0; i < output->ndump; i++)
+      bytes += output->dump[i]->memory_usage();
+    double mbytes = bytes/1024.0/1024.0;
+    fprintf(out,"Total dynamically allocated memory: %.4g Mbyte\n",mbytes);
 
 #if defined(_WIN32)
     HANDLE phandle = GetCurrentProcess();
     PROCESS_MEMORY_COUNTERS_EX pmc;
     GetProcessMemoryInfo(phandle,(PROCESS_MEMORY_COUNTERS *)&pmc,sizeof(pmc));
-    fprintf(out,"Non-shared memory use: %.3g Mbyte\n",
+    fprintf(out,"Non-shared memory use: %.4g Mbyte\n",
             (double)pmc.PrivateUsage/1048576.0);
-    fprintf(out,"Maximum working set size: %.3g Mbyte\n",
+    fprintf(out,"Maximum working set size: %.4g Mbyte\n",
             (double)pmc.PeakWorkingSetSize/1048576.0);
 #else
 #if defined(__linux)
     struct mallinfo mi;
     mi = mallinfo();
-    fprintf(out,"Total dynamically allocated memory: %.3g Mbyte\n",
-            (double)mi.uordblks/1048576.0);
+    fprintf(out,"Current reserved memory pool size: %.4g Mbyte\n",
+            (double)mi.uordblks/1048576.0+(double)mi.hblkhd/1048576.0);
 #endif
     struct rusage ru;
     if (getrusage(RUSAGE_SELF, &ru) == 0) {
-      fprintf(out,"Maximum resident set size: %.3g Mbyte\n",
+      fprintf(out,"Maximum resident set size: %.4g Mbyte\n",
               (double)ru.ru_maxrss/1024.0);
     }
 #endif


### PR DESCRIPTION
This changes the memory report output from
`Memory usage per processor = 14.8928 Mbytes`
to
`Per MPI rank memory allocation (min/avg/max) = 15.62 | 15.83 | 16.03 Mbytes`
This hopefully helps to avoid misunderstandings and shows memory use imbalances in parallel runs. 

This also adds a `memory` keyword to the `info` command and removes the memory outputs from the 'config' keyword. On Linux machines, three different properties are shown:
```
Memory allocation information (MPI rank 0):

Total dynamically allocated memory: 15.63 Mbyte
Current reserved memory pool size: 22.18 Mbyte
Maximum resident set size: 31.98 Mbyte
```
