### PR TITLE
bugfix for irregular::create_atom and create_data

### DIFF
--- a/src/STUBS/mpi.c
+++ b/src/STUBS/mpi.c
@@ -190,6 +190,13 @@ int MPI_Type_size(MPI_Datatype datatype, int *size)
 
 /* ---------------------------------------------------------------------- */
 
+int MPI_Request_free(MPI_Request *request)
+{
+  return 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
 int MPI_Send(const void *buf, int count, MPI_Datatype datatype,
              int dest, int tag, MPI_Comm comm)
 {

--- a/src/STUBS/mpi.h
+++ b/src/STUBS/mpi.h
@@ -89,6 +89,7 @@ int MPI_Finalize();
 double MPI_Wtime();
 
 int MPI_Type_size(int, int *);
+int MPI_Request_free(MPI_Request *request);
 
 int MPI_Send(const void *buf, int count, MPI_Datatype datatype,
              int dest, int tag, MPI_Comm comm);

--- a/src/irregular.cpp
+++ b/src/irregular.cpp
@@ -297,11 +297,9 @@ int Irregular::create_atom(int n, int *sizes, int *proclist, int sortflag)
 
   // setup for collective comm
   // work1 = 1 for procs I send a message to, not including self
-  // work2 = 1 for all procs, used for ReduceScatter
 
   for (i = 0; i < nprocs; i++) {
     work1[i] = 0;
-    work2[i] = 1;
   }
   for (i = 0; i < n; i++) work1[proclist[i]] = 1;
   work1[me] = 0;
@@ -318,7 +316,7 @@ int Irregular::create_atom(int n, int *sizes, int *proclist, int sortflag)
   MPI_Allreduce(work1,work2,nprocs,MPI_INT,MPI_SUM,world);
   nrecv_proc = work2[me];
 #else
-  MPI_Reduce_scatter(work1,&nrecv_proc,work2,MPI_INT,MPI_SUM,world);
+  MPI_Reduce_scatter_block(work1,&nrecv_proc,1,MPI_INT,MPI_SUM,world);
 #endif
 #endif
 
@@ -545,11 +543,9 @@ int Irregular::create_data(int n, int *proclist, int sortflag)
 
   // setup for collective comm
   // work1 = 1 for procs I send a message to, not including self
-  // work2 = 1 for all procs, used for ReduceScatter
 
   for (i = 0; i < nprocs; i++) {
     work1[i] = 0;
-    work2[i] = 1;
   }
   for (i = 0; i < n; i++) work1[proclist[i]] = 1;
   work1[me] = 0;
@@ -566,7 +562,7 @@ int Irregular::create_data(int n, int *proclist, int sortflag)
   MPI_Allreduce(work1,work2,nprocs,MPI_INT,MPI_SUM,world);
   nrecv_proc = work2[me];
 #else
-  MPI_Reduce_scatter(work1,&nrecv_proc,work2,MPI_INT,MPI_SUM,world);
+  MPI_Reduce_scatter_block(work1,&nrecv_proc,1,MPI_INT,MPI_SUM,world);
 #endif
 #endif
 

--- a/src/irregular.cpp
+++ b/src/irregular.cpp
@@ -395,7 +395,9 @@ int Irregular::create_atom(int n, int *sizes, int *proclist, int sortflag)
 
   sendmax_proc = 0;
   for (i = 0; i < nsend_proc; i++) {
-    MPI_Send(&length_send[i],1,MPI_INT,proc_send[i],0,world);
+    MPI_Request tmpReq; // Use non-blocking send to avoid possible deadlock
+    MPI_Isend(&length_send[i],1,MPI_INT,proc_send[i],0,world,&tmpReq);
+    MPI_Request_free(&tmpReq); // the MPI_Barrier below marks completion
     sendmax_proc = MAX(sendmax_proc,length_send[i]);
   }
 
@@ -641,7 +643,9 @@ int Irregular::create_data(int n, int *proclist, int sortflag)
 
   sendmax_proc = 0;
   for (i = 0; i < nsend_proc; i++) {
-    MPI_Send(&num_send[i],1,MPI_INT,proc_send[i],0,world);
+    MPI_Request tmpReq; // Use non-blocking send to avoid possible deadlock
+    MPI_Isend(&num_send[i],1,MPI_INT,proc_send[i],0,world,&tmpReq);
+    MPI_Request_free(&tmpReq); // the MPI_Barrier below marks completion
     sendmax_proc = MAX(sendmax_proc,num_send[i]);
   }
 

--- a/src/irregular.cpp
+++ b/src/irregular.cpp
@@ -297,9 +297,11 @@ int Irregular::create_atom(int n, int *sizes, int *proclist, int sortflag)
 
   // setup for collective comm
   // work1 = 1 for procs I send a message to, not including self
+  // work2 = 1 for all procs, used for ReduceScatter
 
   for (i = 0; i < nprocs; i++) {
     work1[i] = 0;
+    work2[i] = 1;
   }
   for (i = 0; i < n; i++) work1[proclist[i]] = 1;
   work1[me] = 0;
@@ -316,7 +318,7 @@ int Irregular::create_atom(int n, int *sizes, int *proclist, int sortflag)
   MPI_Allreduce(work1,work2,nprocs,MPI_INT,MPI_SUM,world);
   nrecv_proc = work2[me];
 #else
-  MPI_Reduce_scatter_block(work1,&nrecv_proc,1,MPI_INT,MPI_SUM,world);
+  MPI_Reduce_scatter(work1,&nrecv_proc,work2,MPI_INT,MPI_SUM,world);
 #endif
 #endif
 
@@ -543,9 +545,11 @@ int Irregular::create_data(int n, int *proclist, int sortflag)
 
   // setup for collective comm
   // work1 = 1 for procs I send a message to, not including self
+  // work2 = 1 for all procs, used for ReduceScatter
 
   for (i = 0; i < nprocs; i++) {
     work1[i] = 0;
+    work2[i] = 1;
   }
   for (i = 0; i < n; i++) work1[proclist[i]] = 1;
   work1[me] = 0;
@@ -562,7 +566,7 @@ int Irregular::create_data(int n, int *proclist, int sortflag)
   MPI_Allreduce(work1,work2,nprocs,MPI_INT,MPI_SUM,world);
   nrecv_proc = work2[me];
 #else
-  MPI_Reduce_scatter_block(work1,&nrecv_proc,1,MPI_INT,MPI_SUM,world);
+  MPI_Reduce_scatter(work1,&nrecv_proc,work2,MPI_INT,MPI_SUM,world);
 #endif
 #endif
 


### PR DESCRIPTION
When doing an arbitrarily large number of unmatched blocking MPI sends before doing the receives, it is possible to deadlock.  Prevent this possible deadlock by converting the sends to non-blocking sends.

Also change the MPI_Reduce_scatter to the simpler MPI_Reduce_scatter_block function that has each MPI rank receive the same amount of data (one element in this case), rather than an individually specified amount, which in this case was being specified via an array of ones.