### PR TITLE
Remove unneeded restart_peratom flags in USER-DPD package

### DIFF
--- a/src/USER-DPD/fix_eos_cv.cpp
+++ b/src/USER-DPD/fix_eos_cv.cpp
@@ -34,7 +34,6 @@ FixEOScv::FixEOScv(LAMMPS *lmp, int narg, char **arg) :
   cvEOS = force->numeric(FLERR,arg[3]);
   if(cvEOS <= 0.0) error->all(FLERR,"EOS cv must be > 0.0");
 
-  restart_peratom = 1;
   nevery = 1;
 
   if (atom->dpd_flag != 1)

--- a/src/USER-DPD/fix_eos_table.cpp
+++ b/src/USER-DPD/fix_eos_table.cpp
@@ -34,7 +34,6 @@ FixEOStable::FixEOStable(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg), ntables(0), tables(NULL)
 {
   if (narg != 7) error->all(FLERR,"Illegal fix eos/table command");
-  restart_peratom = 1;
   nevery = 1;
 
   if (strcmp(arg[3],"linear") == 0) tabstyle = LINEAR;

--- a/src/USER-DPD/fix_eos_table_rx.cpp
+++ b/src/USER-DPD/fix_eos_table_rx.cpp
@@ -44,7 +44,6 @@ FixEOStableRX::FixEOStableRX(LAMMPS *lmp, int narg, char **arg) :
   tables2(NULL), dHf(NULL), eosSpecies(NULL)
 {
   if (narg != 8 && narg != 10) error->all(FLERR,"Illegal fix eos/table/rx command");
-  restart_peratom = 1;
   nevery = 1;
 
   rx_flag = false;


### PR DESCRIPTION
This prevents a memory issue reported by Valgrind.