### PR TITLE
Fix airebo/morse

### DIFF
--- a/src/MANYBODY/pair_airebo_morse.cpp
+++ b/src/MANYBODY/pair_airebo_morse.cpp
@@ -27,7 +27,7 @@ PairAIREBOMorse::PairAIREBOMorse(LAMMPS *lmp) : PairAIREBO(lmp) {}
 
 void PairAIREBOMorse::settings(int narg, char **arg)
 {
-  PairAIREBO::settings(narg, arg);
+  PairAIREBO::settings(narg,arg);
 
   morseflag = 1;
 }

--- a/src/USER-OMP/pair_airebo_morse_omp.cpp
+++ b/src/USER-OMP/pair_airebo_morse_omp.cpp
@@ -27,14 +27,7 @@ PairAIREBOMorseOMP::PairAIREBOMorseOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp) {}
 
 void PairAIREBOMorseOMP::settings(int narg, char **arg)
 {
-  if (narg != 1 && narg != 3) error->all(FLERR,"Illegal pair_style command");
-
-  cutlj = force->numeric(FLERR,arg[0]);
-
-  if (narg == 3) {
-    ljflag = force->inumeric(FLERR,arg[1]);
-    torflag = force->inumeric(FLERR,arg[2]);
-  }
+  PairAIREBOOMP::settings(narg,arg);
 
   morseflag = 1;
 }


### PR DESCRIPTION
Introduced in b3d2fb91, PCCf_2_0 does not get initialized in ::settings
in PairAIREBOMorse. Future proof by calling super-class.