### PR TITLE
Fixed a bug with equal-style variables as manifold params.

### DIFF
--- a/src/USER-MANIFOLD/fix_manifoldforce.cpp
+++ b/src/USER-MANIFOLD/fix_manifoldforce.cpp
@@ -84,8 +84,8 @@ FixManifoldForce::FixManifoldForce(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,msg);
   }
 
-  *(ptr_m->get_params()) = new double[nvars];
-  if( ptr_m->get_params() == NULL ){
+  ptr_m->params = new double[nvars];
+  if( ptr_m->params == NULL ){
     error->all(FLERR,"Parameter pointer was NULL!");
   }
 
@@ -94,7 +94,7 @@ FixManifoldForce::FixManifoldForce(LAMMPS *lmp, int narg, char **arg) :
   // and sets the values of those arguments that were _not_
   // equal style vars (so that they are not overwritten each time step).
 
-  double *params = *(ptr_m->get_params());
+  double *params = ptr_m->params;
   for( int i = 0; i < nvars; ++i ){
     if( was_var( arg[i+4] ) )
       error->all(FLERR,"Equal-style variables not allowed with fix manifoldforce");

--- a/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
+++ b/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
@@ -110,9 +110,6 @@ FixNVEManifoldRattle::FixNVEManifoldRattle( LAMMPS *lmp, int &narg, char **arg,
   tstyle = new int[nvars];
   is_var = new int[nvars];
 
-  fprintf(screen,"Succesfully created a manifold of type %s with %d params.\n",
-          ptr_m->id(), nvars);
-
   if( !tstrs || !tvars || !tstyle || !is_var ){
     error->all(FLERR, "Error creating manifold arg arrays");
   }
@@ -121,7 +118,6 @@ FixNVEManifoldRattle::FixNVEManifoldRattle( LAMMPS *lmp, int &narg, char **arg,
   for( int i = 0; i < nvars; ++i ){
     int len = 0, offset = 0;
     if( was_var( arg[i+6] ) ){
-      fprintf(screen,"arg %d (%s) was var\n",i+6, arg[i+6]);
       len = strlen(arg[i+6]) - 1; // -1 because -2 for v_, +1 for \0.
       is_var[i] = 1;
       offset = 2;
@@ -141,7 +137,6 @@ FixNVEManifoldRattle::FixNVEManifoldRattle( LAMMPS *lmp, int &narg, char **arg,
     // If param i was variable type, it will be set later...
     ptr_m->params[i] = is_var[i] ? 0.0 : force->numeric( FLERR, arg[i+6] );
   }
-  fprintf(screen,"Calling post_param_init().\n");
   ptr_m->post_param_init();
 
 
@@ -267,8 +262,7 @@ void FixNVEManifoldRattle::init()
 
 void FixNVEManifoldRattle::update_var_params()
 {
-  fprintf(screen,"In update_var_params().\n");
-  
+ 
   if( nevery > 0 ){
     stats.x_iters = 0;
     stats.v_iters = 0;
@@ -278,11 +272,9 @@ void FixNVEManifoldRattle::update_var_params()
   }
 
   double *ptr_params = ptr_m->params;
-  fprintf(screen,"Setting values of params.\n");
   
   for( int i = 0; i < nvars; ++i ){
     if( is_var[i] ){
-      fprintf(screen,"%d was a var.\n", i);
       tvars[i] = input->variable->find(tstrs[i]);
       if( tvars[i] < 0 ){
         error->all(FLERR,
@@ -291,7 +283,6 @@ void FixNVEManifoldRattle::update_var_params()
       if( input->variable->equalstyle(tvars[i]) ){
         tstyle[i] = EQUAL;
         double new_val = input->variable->compute_equal(tvars[i]);
-        fprintf( stdout, "New value of var %d is now %f\n", i+1, new_val );
         
         ptr_params[i] = new_val;
       }else{

--- a/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
+++ b/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
@@ -110,6 +110,9 @@ FixNVEManifoldRattle::FixNVEManifoldRattle( LAMMPS *lmp, int &narg, char **arg,
   tstyle = new int[nvars];
   is_var = new int[nvars];
 
+  fprintf(screen,"Succesfully created a manifold of type %s with %d params.\n",
+          ptr_m->id(), nvars);
+
   if( !tstrs || !tvars || !tstyle || !is_var ){
     error->all(FLERR, "Error creating manifold arg arrays");
   }
@@ -118,6 +121,7 @@ FixNVEManifoldRattle::FixNVEManifoldRattle( LAMMPS *lmp, int &narg, char **arg,
   for( int i = 0; i < nvars; ++i ){
     int len = 0, offset = 0;
     if( was_var( arg[i+6] ) ){
+      fprintf(screen,"arg %d (%s) was var\n",i+6, arg[i+6]);
       len = strlen(arg[i+6]) - 1; // -1 because -2 for v_, +1 for \0.
       is_var[i] = 1;
       offset = 2;
@@ -131,12 +135,13 @@ FixNVEManifoldRattle::FixNVEManifoldRattle( LAMMPS *lmp, int &narg, char **arg,
     strcpy( tstrs[i], arg[i+6] + offset );
   }
 
-  *ptr_m->get_params() = new double[nvars];
-  if( !(*ptr_m->get_params()) ) error->all(FLERR,"Failed to allocate params!");
+  ptr_m->params = new double[nvars];
+  if( !ptr_m->params ) error->all(FLERR,"Failed to allocate params!");
   for( int i = 0; i < nvars; ++i ){
     // If param i was variable type, it will be set later...
-    (*ptr_m->get_params())[i] = is_var[i] ? 0.0 : force->numeric( FLERR, arg[i+6] );
+    ptr_m->params[i] = is_var[i] ? 0.0 : force->numeric( FLERR, arg[i+6] );
   }
+  fprintf(screen,"Calling post_param_init().\n");
   ptr_m->post_param_init();
 
 
@@ -262,6 +267,8 @@ void FixNVEManifoldRattle::init()
 
 void FixNVEManifoldRattle::update_var_params()
 {
+  fprintf(screen,"In update_var_params().\n");
+  
   if( nevery > 0 ){
     stats.x_iters = 0;
     stats.v_iters = 0;
@@ -270,9 +277,12 @@ void FixNVEManifoldRattle::update_var_params()
     stats.v_iters_per_atom = 0.0;
   }
 
-  double **ptr_params = ptr_m->get_params();
+  double *ptr_params = ptr_m->params;
+  fprintf(screen,"Setting values of params.\n");
+  
   for( int i = 0; i < nvars; ++i ){
     if( is_var[i] ){
+      fprintf(screen,"%d was a var.\n", i);
       tvars[i] = input->variable->find(tstrs[i]);
       if( tvars[i] < 0 ){
         error->all(FLERR,
@@ -281,8 +291,9 @@ void FixNVEManifoldRattle::update_var_params()
       if( input->variable->equalstyle(tvars[i]) ){
         tstyle[i] = EQUAL;
         double new_val = input->variable->compute_equal(tvars[i]);
-        // fprintf( stdout, "New value of var %d is now %f\n", i+1, new_val );
-        *(ptr_params[i]) = new_val;
+        fprintf( stdout, "New value of var %d is now %f\n", i+1, new_val );
+        
+        ptr_params[i] = new_val;
       }else{
         error->all(FLERR,
                    "Variable for fix nve/manifold/rattle is invalid style");

--- a/src/USER-MANIFOLD/manifold.h
+++ b/src/USER-MANIFOLD/manifold.h
@@ -63,12 +63,12 @@ namespace user_manifold {
 
     virtual void set_atom_id( tagint a_id ){}
     virtual int nparams() = 0;
-    double **get_params(){ return &params; };
+    // double *get_params(){ return params; };
 
     // Overload if any initialization depends on params:
     virtual void post_param_init(){}
     virtual void checkup(){} // Some diagnostics...
-   protected:
+
     double *params;
   };
 


### PR DESCRIPTION
This fixes a bug that causes a segfault when using equal-style variables for parameters other than the first. It was caused by a misunderstanding of pointers that is now fixed.