### PR TITLE
Changed the check on initial and final temperature to <= 0 for both.

### DIFF
--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -133,7 +133,7 @@ FixNH::FixNH(LAMMPS *lmp, int narg, char **arg) :
       t_target = t_start;
       t_stop = force->numeric(FLERR,arg[iarg+2]);
       t_period = force->numeric(FLERR,arg[iarg+3]);
-      if (t_start < 0.0 || t_stop <= 0.0)
+      if (t_start <= 0.0 || t_stop <= 0.0)
         error->all(FLERR,
                    "Target temperature for fix nvt/npt/nph cannot be 0.0");
       iarg += 4;


### PR DESCRIPTION
This change should fix issue #435 , unless there is a conceptual reason to allow an initial temp of 0.
This PR closes #435