### PR TITLE
collected small updates and bugfixes

### DIFF
--- a/doc/src/kspace_modify.txt
+++ b/doc/src/kspace_modify.txt
@@ -290,9 +290,10 @@ to be specified using the {gewald/disp}, {mesh/disp},
 {force/disp/real} or {force/disp/kspace} keywords, or
 the code will stop with an error message. When this option is set to
 {yes}, the error message will not appear and the simulation will start.
-For a typical application, using the automatic parameter generation will provide
-simulations that are either inaccurate or slow. Using this option is thus not
-recommended. For guidelines on how to obtain good parameters, see the "How-To"_Section_howto.html#howto_23 discussion.
+For a typical application, using the automatic parameter generation
+will provide simulations that are either inaccurate or slow. Using this
+option is thus not recommended. For guidelines on how to obtain good
+parameters, see the "How-To"_Section_howto.html#howto_24 discussion.
 
 [Restrictions:] none
 

--- a/src/ASPHERE/compute_temp_asphere.cpp
+++ b/src/ASPHERE/compute_temp_asphere.cpp
@@ -73,6 +73,11 @@ ComputeTempAsphere::ComputeTempAsphere(LAMMPS *lmp, int narg, char **arg) :
     } else error->all(FLERR,"Illegal compute temp/asphere command");
   }
 
+  // when computing only the rotational temperature,
+  // do not remove DOFs for translation as set by default
+
+  if (mode == ROTATE) extra_dof = 0;
+
   vector = new double[6];
 
 }

--- a/src/COMPRESS/Install.sh
+++ b/src/COMPRESS/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/Install.sh
+++ b/src/Install.sh
@@ -33,5 +33,5 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done

--- a/src/KIM/Install.sh
+++ b/src/KIM/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/MEAM/Install.sh
+++ b/src/MEAM/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/MPIIO/Install.sh
+++ b/src/MPIIO/Install.sh
@@ -36,7 +36,7 @@ touch ../write_restart.cpp
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package to include/exclude LMP_MPIIO setting

--- a/src/MSCG/Install.sh
+++ b/src/MSCG/Install.sh
@@ -25,7 +25,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/POEMS/Install.sh
+++ b/src/POEMS/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/PYTHON/Install.sh
+++ b/src/PYTHON/Install.sh
@@ -35,7 +35,7 @@ touch ../variable.cpp
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/REAX/Install.sh
+++ b/src/REAX/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-ATC/Install.sh
+++ b/src/USER-ATC/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-AWPMD/Install.sh
+++ b/src/USER-AWPMD/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-COLVARS/Install.sh
+++ b/src/USER-COLVARS/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-H5MD/Install.sh
+++ b/src/USER-H5MD/Install.sh
@@ -27,7 +27,7 @@ action () {
 }
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-MISC/Install.sh
+++ b/src/USER-MISC/Install.sh
@@ -35,6 +35,6 @@ for file in *.cpp *.h; do
   elif (test $file = "pair_cdeam.h") then
     action pair_cdeam.h pair_eam_alloy.cpp
   else
-    action $file
+    test -f ${file} && action $file
   fi
 done

--- a/src/USER-MOLFILE/Install.sh
+++ b/src/USER-MOLFILE/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-NC-DUMP/Install.sh
+++ b/src/USER-NC-DUMP/Install.sh
@@ -27,7 +27,7 @@ action () {
 }
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-QMMM/Install.sh
+++ b/src/USER-QMMM/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-QUIP/Install.sh
+++ b/src/USER-QUIP/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-SMD/Install.sh
+++ b/src/USER-SMD/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/USER-VTK/Install.sh
+++ b/src/USER-VTK/Install.sh
@@ -27,7 +27,7 @@ action () {
 }
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/VORONOI/Install.sh
+++ b/src/VORONOI/Install.sh
@@ -29,7 +29,7 @@ action () {
 # all package files with no dependencies
 
 for file in *.cpp *.h; do
-  action $file
+  test -f ${file} && action $file
 done
 
 # edit 2 Makefile.package files to include/exclude package info

--- a/src/compute_temp_sphere.cpp
+++ b/src/compute_temp_sphere.cpp
@@ -67,6 +67,11 @@ ComputeTempSphere::ComputeTempSphere(LAMMPS *lmp, int narg, char **arg) :
     } else error->all(FLERR,"Illegal compute temp/sphere command");
   }
 
+  // when computing only the rotational temperature,
+  // do not remove DOFs for translation as set by default
+
+  if (mode == ROTATE) extra_dof = 0;
+
   vector = new double[6];
 
   // error checks

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -205,14 +205,18 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
   for (int i = 0; i < nvalues; i++) {
     if (which[i] == X || which[i] == V || which[i] == F) kindflag = PERATOM;
     else if (which[i] == COMPUTE) {
-      Compute *compute = modify->compute[modify->find_compute(ids[i])];
+      int c_id = modify->find_compute(ids[i]);
+      if (c_id < 0) error->all(FLERR,"Fix ave/histo input is invalid compute");
+      Compute *compute = modify->compute[c_id];
       if (compute->scalar_flag || compute->vector_flag || compute->array_flag)
         kindflag = GLOBAL;
       else if (compute->peratom_flag) kindflag = PERATOM;
       else if (compute->local_flag) kindflag = LOCAL;
       else error->all(FLERR,"Fix ave/histo input is invalid compute");
     } else if (which[i] == FIX) {
-      Fix *fix = modify->fix[modify->find_fix(ids[i])];
+      int f_id = modify->find_fix(ids[i]);
+      if (f_id < 0) error->all(FLERR,"Fix ave/histo input is invalid fix");
+      Fix *fix = modify->fix[f_id];
       if (fix->scalar_flag || fix->vector_flag || fix->array_flag)
         kindflag = GLOBAL;
       else if (fix->peratom_flag) kindflag = PERATOM;
@@ -220,6 +224,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
       else error->all(FLERR,"Fix ave/histo input is invalid fix");
     } else if (which[i] == VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
+      if (ivariable < 0) error->all(FLERR,"Fix ave/histo input is invalid variable");
       if (input->variable->equalstyle(ivariable)) kindflag = GLOBAL;
       else if (input->variable->atomstyle(ivariable)) kindflag = PERATOM;
       else error->all(FLERR,"Fix ave/histo input is invalid variable");


### PR DESCRIPTION
This pull request contains the following changes:
- protect fix ave/histo from segfaulting on non-existing computes, fixes or variables (there were checks, but not for the first encounter of the items). this closes #441
- address the issue, that uninstalling an empty package will delete all source files in `src/`
- computes `temp/sphere` and `temp/asphere` should reset `extra_dof` to `0` when only the rotational temperature is requested (`mode == ROTATE`). the default value for extra_dof assumes translation is included