### PR TITLE
Updated molfile plugin header files from VMD 1.9.3

### DIFF
--- a/src/USER-MOLFILE/README
+++ b/src/USER-MOLFILE/README
@@ -28,8 +28,7 @@ taken from.  These header files can be found inside the VMD
 installation tree under: "plugins/include".
 
 For convenience, this package includes a set of header files that is
-compatible with VMD 1.9 and 1.9.1 (the current version in June 2012)
-and should be compilable with VMD versions back to about version 1.8.4
+compatible with VMD 1.9.3 (the current version in April 2017).
 
 The person who created this package is Axel Kohlmeyer at Temple U
 (akohlmey at gmail.com).  Contact him directly if you have questions.

--- a/src/USER-MOLFILE/molfile_plugin.h
+++ b/src/USER-MOLFILE/molfile_plugin.h
@@ -11,14 +11,14 @@
  *
  *      $RCSfile: molfile_plugin.h,v $
  *      $Author: johns $       $Locker:  $             $State: Exp $
- *      $Revision: 1.103 $       $Date: 2011/03/05 03:56:11 $
+ *      $Revision: 1.108 $       $Date: 2016/02/26 03:17:01 $
  *
  ***************************************************************************/
 
-/** @file
+/** @file 
  * API for C extensions to define a way to load structure, coordinate,
- * trajectory, and volumetric data files
- */
+ * trajectory, and volumetric data files  
+ */ 
 
 #ifndef MOL_FILE_PLUGIN_H
 #define MOL_FILE_PLUGIN_H
@@ -60,6 +60,21 @@ typedef ssize_t molfile_ssize_t;      /**< for frame counts */
 #define MOLFILE_MAXWAVEPERTS     25   /**< maximum number of wavefunctions
                                        *   per timestep */
 
+/**
+ * Hard-coded direct-I/O page size constants for use by both VMD
+ * and the plugins that want to use direct, unbuffered I/O for high
+ * performance with SSDs etc.  We use two constants to define the 
+ * range of hardware page sizes that we can support, so that we can 
+ * add support for larger 8KB or 16KB page sizes in the future 
+ * as they become more prevalent in high-end storage systems.
+ *
+ * At present, VMD uses a hard-coded 4KB page size to reduce memory
+ * fragmentation, but these constants will make it easier to enable the
+ * use of larger page sizes in the future if it becomes necessary.
+ */
+#define MOLFILE_DIRECTIO_MIN_BLOCK_SIZE 4096
+#define MOLFILE_DIRECTIO_MAX_BLOCK_SIZE 4096
+
 
 /**
  * File level comments, origin information, and annotations.
@@ -74,16 +89,16 @@ typedef struct {
 } molfile_metadata_t;
 
 
-/*
- * Struct for specifying atoms in a molecular structure.  The first
- * six components are required, the rest are optional and their presence is
+/* 
+ * Struct for specifying atoms in a molecular structure.  The first 
+ * six components are required, the rest are optional and their presence is 
  * indicating by setting the corresponding bit in optsflag.  When omitted,
- * the application (for read_structure) or plugin (for write_structure)
- * must be able to supply default values if the missing parameters are
+ * the application (for read_structure) or plugin (for write_structure) 
+ * must be able to supply default values if the missing parameters are 
  * part of its internal data structure.
  * Note that it is not possible to specify coordinates with this structure.
- * This is intentional; all coordinate I/O is done with the read_timestep and
- * write_timestep functions.
+ * This is intentional; all coordinate I/O is done with the read_timestep and 
+ * write_timestep functions. 
  */
 
 /**
@@ -96,8 +111,17 @@ typedef struct {
   char resname[8];    /**< required residue name string          */
   int resid;          /**< required integer residue ID           */
   char segid[8];      /**< required segment name string, or ""   */
+#if 0 && vmdplugin_ABIVERSION > 17
+  /* The new PDB file formats allows for much larger structures, */
+  /* which can therefore require longer chain ID strings.  The   */
+  /* new PDBx/mmCIF file formats do not have length limits on    */
+  /* fields, so PDB chains could be arbitrarily long strings     */
+  /* in such files.  At present, we know we need at least 3-char */
+  /* chains for existing PDBx/mmCIF files.                       */
+  char chain[4];      /**< required chain name, or ""            */
+#else
   char chain[2];      /**< required chain name, or ""            */
-
+#endif
   /* rest are optional; use optflags to specify what's present   */
   char altloc[2];     /**< optional PDB alternate location code  */
   char insertion[2];  /**< optional PDB insertion code           */
@@ -107,6 +131,23 @@ typedef struct {
   float charge;       /**< optional charge value                 */
   float radius;       /**< optional radius value                 */
   int atomicnumber;   /**< optional element atomic number        */
+
+#if 0
+  char complex[16];
+  char assembly[16];
+  int qmregion;
+  int qmregionlink;
+  int qmlayer;
+  int qmlayerlink;
+  int qmfrag;
+  int qmfraglink;
+  string qmecp;
+  int qmadapt;
+  int qmect;          /**< boolean */
+  int qmparam;
+  int autoparam;
+#endif
+
 #if defined(DESRES_CTNUMBER)
   int ctnumber;       /**< mae ct block, 0-based, including meta */
 #endif
@@ -128,7 +169,7 @@ typedef struct {
 #define MOLFILE_CTNUMBER      0x0200 /**< ctnumber provided */
 #endif
 #define MOLFILE_BADOPTIONS    0xFFFFFFFF /**< Detect badly behaved plugins */
-
+                              
 /*@}*/
 
 /*@{*/
@@ -140,38 +181,32 @@ typedef struct {
 #define MOLFILE_QMTS_SCFITER       0x0002
 /*@}*/
 
-#if vmdplugin_ABIVERSION > 10
 typedef struct molfile_timestep_metadata {
   unsigned int count;                  /**< total # timesteps; -1 if unknown */
   unsigned int avg_bytes_per_timestep; /** bytes per timestep                */
   int has_velocities;                  /**< if timesteps have velocities     */
 } molfile_timestep_metadata_t;
-#endif
 
 /*
  * Per-timestep atom coordinates and periodic cell information
- */
+ */ 
 typedef struct {
   float *coords;        /**< coordinates of all atoms, arranged xyzxyzxyz   */
-#if vmdplugin_ABIVERSION > 10
   float *velocities;    /**< space for velocities of all atoms; same layout */
                         /**< NULL unless has_velocities is set              */
-#endif
 
-  /*@{*/
+  /*@{*/   
   /**
    * Unit cell specification of the form A, B, C, alpha, beta, gamma.
    * notes: A, B, C are side lengths of the unit cell
    * alpha = angle between b and c
    *  beta = angle between a and c
    * gamma = angle between a and b
-   */
-  float A, B, C, alpha, beta, gamma;
-  /*@}*/
+   */ 
+  float A, B, C, alpha, beta, gamma; 
+  /*@}*/   
 
-#if vmdplugin_ABIVERSION > 10
   double physical_time; /**< physical time point associated with this frame */
-#endif
 
 #if defined(DESRES_READ_TIMESTEP2)
   /* HACK to support generic trajectory information */
@@ -188,7 +223,7 @@ typedef struct {
 
 /**
  * Metadata for volumetric datasets, read initially and used for subsequent
- * memory allocations and file loading.
+ * memory allocations and file loading.  
  */
 typedef struct {
   char dataname[256];   /**< name of volumetric data set                    */
@@ -198,29 +233,48 @@ typedef struct {
    * x/y/z axis:
    * These the three cell sides, providing both direction and length
    * (not unit vectors) for the x, y, and z axes.  In the simplest
-   * case, these would be <size,0,0> <0,size,0> and <0,0,size) for
+   * case, these would be <size,0,0> <0,size,0> and <0,0,size) for 
    * an orthogonal cubic volume set.  For other cell shapes these
    * axes can be oriented non-orthogonally, and the parallelpiped
    * may have different side lengths, not just a cube/rhombus.
    */
-  float xaxis[3];       /**< direction (and length) for X axis              */
+  float xaxis[3];       /**< direction (and length) for X axis              */ 
   float yaxis[3];       /**< direction (and length) for Y axis              */
   float zaxis[3];       /**< direction (and length) for Z axis              */
 
   /*
-   * x/y/z size:
+   * x/y/z size: 
    * Number of grid cells along each axis.  This is _not_ the
    * physical size of the box, this is the number of voxels in each
-   * direction, independent of the shape of the volume set.
+   * direction, independent of the shape of the volume set. 
    */
-  int xsize;            /**< number of grid cells along the X axis          */
-  int ysize;            /**< number of grid cells along the Y axis          */
-  int zsize;            /**< number of grid cells along the Z axis          */
+  int xsize;            /**< number of grid cells along the X axis           */
+  int ysize;            /**< number of grid cells along the Y axis           */
+  int zsize;            /**< number of grid cells along the Z axis           */
 
-  int has_color;        /**< flag indicating presence of voxel color data   */
+#if vmdplugin_ABIVERSION > 16
+  int has_scalar;       /**< flag indicating presence of scalar volume       */
+  int has_gradient;     /**< flag indicating presence of vector volume       */
+  int has_variance;     /**< flag indicating presence of variance map        */
+#endif
+  int has_color;        /**< flag indicating presence of voxel color data    */
 } molfile_volumetric_t;
 
 
+#if vmdplugin_ABIVERSION > 16
+/**
+ * Volumetric dataset read/write structure with both flag/parameter sets
+ * and VMD-allocated pointers for fields to be used by the plugin.
+ */
+typedef struct {
+  int setidx;           /**< volumetric dataset index to load/save */
+  float *scalar;        /**< scalar density/potential field data   */
+  float *gradient;      /**< gradient vector field                 */
+  float *variance;      /**< variance map indicating signal/noise  */
+  float *rgb3f;         /**< RGB floating point color texture map  */
+  unsigned char *rgb3u; /**< RGB unsigned byte color texture map   */
+} molfile_volumetric_readwrite_t;
+#endif
 
 
 /**************************************************************
@@ -230,9 +284,6 @@ typedef struct {
  ****                                                      ****
  **************************************************************
  **************************************************************/
-
-#if vmdplugin_ABIVERSION > 9
-
 
 /* macros for the convergence status of a QM calculation. */
 #define MOLFILE_QMSTATUS_UNKNOWN       -1 /* don't know yet */
@@ -297,10 +348,10 @@ typedef struct {
 
 /**
  * QM run info. Parameters that stay unchanged during a single file.
- */
+ */ 
 typedef struct {
   int nproc;             /**< number of processors used. */
-  int memory;            /**< amount of memory used in Mbyte. */
+  int memory;            /**< amount of memory used in Mbyte. */ 
   int runtype;           /**< flag indicating the calculation method. */
   int scftype;           /**< SCF type: RHF, UHF, ROHF, GVB or MCSCF wfn. */
   int status;            /**< indicates wether SCF and geometry optimization
@@ -333,9 +384,9 @@ typedef struct {
                              *   array size = 2*num_basis_funcs
                              *   The basis must NOT be normalized. */
   int *atomic_number;       /**< atomic numbers (chem. element) of atoms in basis set */
-  int *angular_momentum;    /**< 3 ints per wave function coefficient do describe the
+  int *angular_momentum;    /**< 3 ints per wave function coefficient do describe the 
                              *   cartesian components of the angular momentum.
-                             *   E.g. S={0 0 0}, Px={1 0 0}, Dxy={1 1 0}, or Fyyz={0 2 1}.
+                             *   E.g. S={0 0 0}, Px={1 0 0}, Dxy={1 1 0}, or Fyyz={0 2 1}. 
                              */
   int *shell_types;         /**< type for each shell in basis */
 } molfile_qm_basis_t;
@@ -409,9 +460,9 @@ enum molfile_qm_wavefunc_type {
   MOLFILE_WAVE_MCSCFNAT, MOLFILE_WAVE_MCSCFOPT,
   MOLFILE_WAVE_CINATUR,
   MOLFILE_WAVE_PIPEK,  MOLFILE_WAVE_BOYS, MOLFILE_WAVE_RUEDEN,
-  MOLFILE_WAVE_NAO,    MOLFILE_WAVE_PNAO, MOLFILE_WAVE_NHO,
-  MOLFILE_WAVE_PNHO,   MOLFILE_WAVE_NBO,  MOLFILE_WAVE_PNBO,
-  MOLFILE_WAVE_PNLMO,  MOLFILE_WAVE_NLMO, MOLFILE_WAVE_MOAO,
+  MOLFILE_WAVE_NAO,    MOLFILE_WAVE_PNAO, MOLFILE_WAVE_NHO, 
+  MOLFILE_WAVE_PNHO,   MOLFILE_WAVE_NBO,  MOLFILE_WAVE_PNBO, 
+  MOLFILE_WAVE_PNLMO,  MOLFILE_WAVE_NLMO, MOLFILE_WAVE_MOAO, 
   MOLFILE_WAVE_NATO,   MOLFILE_WAVE_UNKNOWN
 };
 
@@ -442,7 +493,7 @@ typedef struct molfile_qm_timestep_metadata {
   int has_orben_per_wavef[MOLFILE_MAXWAVEPERTS]; /**< orbital energy flags */
   int has_occup_per_wavef[MOLFILE_MAXWAVEPERTS]; /**< orbital occupancy flags */
   int num_wavef ;                      /**< # wavefunctions in this ts     */
-  int wavef_size;                      /**< size of one wavefunction
+  int wavef_size;                      /**< size of one wavefunction 
                                         *   (# of gaussian basis fctns)    */
   int num_charge_sets;                 /**< # of charge values per atom */
 } molfile_qm_timestep_metadata_t;
@@ -485,8 +536,6 @@ typedef struct {
 } molfile_qm_timestep_t;
 
 
-#endif
-
 /**************************************************************
  **************************************************************/
 
@@ -498,14 +547,14 @@ typedef struct {
  *  from graphics file reader plugins.
  */
 enum molfile_graphics_type {
-  MOLFILE_POINT,  MOLFILE_TRIANGLE, MOLFILE_TRINORM, MOLFILE_NORMS,
-  MOLFILE_LINE,   MOLFILE_CYLINDER, MOLFILE_CAPCYL,  MOLFILE_CONE,
+  MOLFILE_POINT,  MOLFILE_TRIANGLE, MOLFILE_TRINORM, MOLFILE_NORMS, 
+  MOLFILE_LINE,   MOLFILE_CYLINDER, MOLFILE_CAPCYL,  MOLFILE_CONE,    
   MOLFILE_SPHERE, MOLFILE_TEXT,     MOLFILE_COLOR,   MOLFILE_TRICOLOR
 };
 
 /**
  *  Individual graphics object/element data
- */
+ */ 
 typedef struct {
   int type;             /* One of molfile_graphics_type */
   int style;            /* A general style parameter    */
@@ -521,13 +570,13 @@ typedef struct {
 type        data                                     style       size
 ----        ----                                     -----       ----
 point       x, y, z                                              pixel size
-triangle    x1,y1,z1,x2,y2,z2,x3,y3,z3
-trinorm     x1,y1,z1,x2,y2,z2,x3,y3,z3
+triangle    x1,y1,z1,x2,y2,z2,x3,y3,z3                 
+trinorm     x1,y1,z1,x2,y2,z2,x3,y3,z3                 
             the next array element must be NORMS
-tricolor    x1,y1,z1,x2,y2,z2,x3,y3,z3
+tricolor    x1,y1,z1,x2,y2,z2,x3,y3,z3                 
             the next array elements must be NORMS
             the following element must be COLOR, with three RGB triples
-norms       x1,y1,z1,x2,y2,z2,x3,y3,z3
+norms       x1,y1,z1,x2,y2,z2,x3,y3,z3                 
 line        x1,y1,z1,x2,y2,z2                        0=solid     pixel width
                                                      1=stippled
 cylinder    x1,y1,z1,x2,y2,z2                        resolution  radius
@@ -541,41 +590,41 @@ color       r, g, b
 /**
  * Main file reader API.  Any function in this struct may be NULL
  * if not implemented by the plugin; the application checks this to determine
- * what functionality is present in the plugin.
- */
+ * what functionality is present in the plugin. 
+ */ 
 typedef struct {
   /**
-   * Required header
+   * Required header 
    */
   vmdplugin_HEAD
 
   /**
-   * Filename extension for this file type.  May be NULL if no filename
+   * Filename extension for this file type.  May be NULL if no filename 
    * extension exists and/or is known.  For file types that match several
    * common extensions, list them in a comma separated list such as:
    *  "pdb,ent,foo,bar,baz,ban"
    * The comma separated list will be expanded when filename extension matching
    * is performed.  If multiple plugins solicit the same filename extensions,
-   * the one that lists the extension earliest in its list is selected. In the
+   * the one that lists the extension earliest in its list is selected. In the 
    * case of a "tie", the first one tried/checked "wins".
    */
   const char *filename_extension;
 
   /**
    * Try to open the file for reading.  Return an opaque handle, or NULL on
-   * failure. Set the number of atoms; if the number of atoms cannot be
-   * determined, set natoms to MOLFILE_NUMATOMS_UNKNOWN.
+   * failure. Set the number of atoms; if the number of atoms cannot be 
+   * determined, set natoms to MOLFILE_NUMATOMS_UNKNOWN. 
    * Filetype should be the name under which this plugin was registered;
    * this is provided so that plugins can provide the same function pointer
    * to handle multiple file types.
    */
-  void *(* open_file_read)(const char *filepath, const char *filetype,
+  void *(* open_file_read)(const char *filepath, const char *filetype, 
       int *natoms);
-
+  
   /**
    * Read molecular structure from the given file handle.  atoms is allocated
    * by the caller and points to space for natoms.
-   * On success, place atom information in the passed-in pointer.
+   * On success, place atom information in the passed-in pointer.  
    * optflags specifies which optional fields in the atoms will be set by
    * the plugin.
    */
@@ -587,15 +636,15 @@ typedef struct {
    * Each unique bond should be specified only once, so file formats that list
    * bonds twice will need post-processing before the results are returned to
    * the caller.
-   * If the plugin provides bond information, but the file loaded doesn't
+   * If the plugin provides bond information, but the file loaded doesn't 
    * actually contain any bond info, the nbonds parameter should be
    * set to 0 and from/to should be set to NULL to indicate that no bond
    * information was actually present, and automatic bond search should be
-   * performed.
+   * performed.  
    *
    * If the plugin provides bond order information, the bondorder array
    * will contain the bond order for each from/to pair.  If not, the bondorder
-   * pointer should be set to NULL, in which case the caller will provide a
+   * pointer should be set to NULL, in which case the caller will provide a 
    * default bond order value of 1.0.
    *
    * If the plugin provides bond type information, the bondtype array
@@ -606,27 +655,23 @@ typedef struct {
    * and consistency checking.
    *
    * These arrays must be freed by the plugin in the close_file_read function.
-   * This function can be called only after read_structure().
-   * Return MOLFILE_SUCCESS if no errors occur.
+   * This function can be called only after read_structure().  
+   * Return MOLFILE_SUCCESS if no errors occur. 
    */
-#if vmdplugin_ABIVERSION > 14
-  int (*read_bonds)(void *, int *nbonds, int **from, int **to, float **bondorder,
+  int (*read_bonds)(void *, int *nbonds, int **from, int **to, float **bondorder, 
                     int **bondtype, int *nbondtypes, char ***bondtypename);
-#else
-  int (*read_bonds)(void *, int *nbonds, int **from, int **to, float **bondorder);
-#endif
 
   /**
-   * XXX this function will be augmented and possibly superceded by a
+   * XXX this function will be augmented and possibly superceded by a 
    *     new QM-capable version named read_timestep(), when finished.
    *
-   * Read the next timestep from the file.  Return MOLFILE_SUCCESS, or
-   * MOLFILE_EOF on EOF.  If the molfile_timestep_t argument is NULL, then
-   * the frame should be skipped.  Otherwise, the application must prepare
-   * molfile_timestep_t by allocating space in coords for the corresponding
-   * number of coordinates.
-   * The natoms parameter exists because some coordinate file formats
-   * (like CRD) cannot determine for themselves how many atoms are in a
+   * Read the next timestep from the file.  Return MOLFILE_SUCCESS, or 
+   * MOLFILE_EOF on EOF.  If the molfile_timestep_t argument is NULL, then 
+   * the frame should be skipped.  Otherwise, the application must prepare 
+   * molfile_timestep_t by allocating space in coords for the corresponding 
+   * number of coordinates.  
+   * The natoms parameter exists because some coordinate file formats 
+   * (like CRD) cannot determine for themselves how many atoms are in a 
    * timestep; the app must therefore obtain this information elsewhere
    * and provide it to the plugin.
    */
@@ -636,16 +681,16 @@ typedef struct {
    * Close the file and release all data.  The handle cannot be reused.
    */
   void (* close_file_read)(void *);
-
+   
   /**
    * Open a coordinate file for writing using the given header information.
    * Return an opaque handle, or NULL on failure.  The application must
-   * specify the number of atoms to be written.
+   * specify the number of atoms to be written. 
    * filetype should be the name under which this plugin was registered.
    */
-  void *(* open_file_write)(const char *filepath, const char *filetype,
+  void *(* open_file_write)(const char *filepath, const char *filetype, 
       int natoms);
-
+  
   /**
    * Write structure information.  Return success.
    */
@@ -653,12 +698,12 @@ typedef struct {
 
   /**
    * Write a timestep to the coordinate file.  Return MOLFILE_SUCCESS if no
-   * errors occur.  If the file contains structure information in each
-   * timestep (like a multi-entry PDB), it will have to cache the information
+   * errors occur.  If the file contains structure information in each 
+   * timestep (like a multi-entry PDB), it will have to cache the information 
    * from the initial calls from write_structure.
    */
   int (* write_timestep)(void *, const molfile_timestep_t *);
-
+  
   /**
    * Close the file and release all data.  The handle cannot be reused.
    */
@@ -671,24 +716,27 @@ typedef struct {
    * the plugin and should be freed by close_file_read().  The application
    * may call this function any number of times.
    */
-  int (* read_volumetric_metadata)(void *, int *nsets,
+  int (* read_volumetric_metadata)(void *, int *nsets, 
         molfile_volumetric_t **metadata);
 
-  /**
-   * Read the specified volumetric data set into the space pointed to by
-   * datablock.  The set is specified with a zero-based index.  The space
+  /** 
+   * Read the specified volumetric data set into the space pointed to by 
+   * datablock.  The set is specified with a zero-based index.  The space 
    * allocated for the datablock must be equal to
-   * xsize * ysize * zsize.  No space will be allocated for colorblock
+   * xsize * ysize * zsize.  No space will be allocated for colorblock 
    * unless has_color is nonzero; in that case, colorblock should be
    * filled in with three RGB floats per datapoint.
    */
-  int (* read_volumetric_data)(void *, int set, float *datablock,
+  int (* read_volumetric_data)(void *, int set, float *datablock, 
         float *colorblock);
+#if vmdplugin_ABIVERSION > 16
+  int (* read_volumetric_data_ex)(void *, molfile_volumetric_readwrite_t *v);
+#endif
 
   /**
    * Read raw graphics data stored in this file.   Return the number of data
-   * elements and the data itself as an array of molfile_graphics_t in the
-   * pointer provided by the application.  The plugin is responsible for
+   * elements and the data itself as an array of molfile_graphics_t in the 
+   * pointer provided by the application.  The plugin is responsible for 
    * freeing the data when the file is closed.
    */
   int (* read_rawgraphics)(void *, int *nelem, const molfile_graphics_t **data);
@@ -698,19 +746,19 @@ typedef struct {
    * came from, what the accession code for the database is, textual remarks
    * and other notes pertaining to the contained structure/trajectory/volume
    * and anything else that's informative at the whole file level.
-   */
+   */ 
   int (* read_molecule_metadata)(void *, molfile_metadata_t **metadata);
-
+  
   /**
    * Write bond information for the molecule.  The arrays from
    * and to point to the (one-based) indices of bonded atoms.
-   * Each unique bond will be specified only once by the caller.
-   * File formats that list bonds twice will need to emit both the
+   * Each unique bond will be specified only once by the caller. 
+   * File formats that list bonds twice will need to emit both the 
    * from/to and to/from versions of each.
-   * This function must be called before write_structure().
+   * This function must be called before write_structure().  
    *
    * Like the read_bonds() routine, the bondorder pointer is set to NULL
-   * if the caller doesn't have such information, in which case the
+   * if the caller doesn't have such information, in which case the 
    * plugin should assume a bond order of 1.0 if the file format requires
    * bond order information.
    *
@@ -721,76 +769,47 @@ typedef struct {
    * scheme is different from the index numbers.
    * if the pointers are set to NULL, then this information is not available.
    * bondtypenames can only be used of bondtypes is also given.
-   * Return MOLFILE_SUCCESS if no errors occur.
+   * Return MOLFILE_SUCCESS if no errors occur. 
    */
-#if vmdplugin_ABIVERSION > 14
-  int (* write_bonds)(void *, int nbonds, int *from, int *to, float *bondorder,
+  int (* write_bonds)(void *, int nbonds, int *from, int *to, float *bondorder, 
                      int *bondtype, int nbondtypes, char **bondtypename);
-#else
-  int (* write_bonds)(void *, int nbonds, int *from, int *to, float *bondorder);
-#endif
 
-#if vmdplugin_ABIVERSION > 9
   /**
-   * Write the specified volumetric data set into the space pointed to by
+   * Write the specified volumetric data set into the space pointed to by 
    * datablock.  The * allocated for the datablock must be equal to
-   * xsize * ysize * zsize.  No space will be allocated for colorblock
+   * xsize * ysize * zsize.  No space will be allocated for colorblock 
    * unless has_color is nonzero; in that case, colorblock should be
    * filled in with three RGB floats per datapoint.
    */
   int (* write_volumetric_data)(void *, molfile_volumetric_t *metadata,
                                 float *datablock, float *colorblock);
+#if vmdplugin_ABIVERSION > 16
+  int (* write_volumetric_data_ex)(void *, molfile_volumetric_t *metadata,
+                                   molfile_volumetric_readwrite_t *v);
+#endif
 
-#if vmdplugin_ABIVERSION > 15
-  /**
+  /** 
    * Read in Angles, Dihedrals, Impropers, and Cross Terms and optionally types.
-   * (Cross terms pertain to the CHARMM/NAMD CMAP feature)
+   * (Cross terms pertain to the CHARMM/NAMD CMAP feature) 
    */
   int (* read_angles)(void *handle, int *numangles, int **angles, int **angletypes,
                       int *numangletypes, char ***angletypenames, int *numdihedrals,
                       int **dihedrals, int **dihedraltypes, int *numdihedraltypes,
-                      char ***dihedraltypenames, int *numimpropers, int **impropers,
+                      char ***dihedraltypenames, int *numimpropers, int **impropers,        
                       int **impropertypes, int *numimpropertypes, char ***impropertypenames,
                       int *numcterms, int **cterms, int *ctermcols, int *ctermrows);
 
-  /**
+  /** 
    * Write out Angles, Dihedrals, Impropers, and Cross Terms
-   * (Cross terms pertain to the CHARMM/NAMD CMAP feature)
+   * (Cross terms pertain to the CHARMM/NAMD CMAP feature) 
    */
   int (* write_angles)(void *handle, int numangles, const int *angles, const int *angletypes,
                        int numangletypes, const char **angletypenames, int numdihedrals,
                        const int *dihedrals, const int *dihedraltypes, int numdihedraltypes,
-                       const char **dihedraltypenames, int numimpropers,
+                       const char **dihedraltypenames, int numimpropers, 
                        const int *impropers, const int *impropertypes, int numimpropertypes,
-                       const char **impropertypenames, int numcterms,  const int *cterms,
+                       const char **impropertypenames, int numcterms,  const int *cterms, 
                        int ctermcols, int ctermrows);
-#else
-  /**
-   * Read in Angles, Dihedrals, Impropers, and Cross Terms
-   * Forces are in Kcal/mol
-   * (Cross terms pertain to the CHARMM/NAMD CMAP feature, forces are given
-   *  as a 2-D matrix)
-   */
-  int (* read_angles)(void *,
-                int *numangles,    int **angles,    double **angleforces,
-                int *numdihedrals, int **dihedrals, double **dihedralforces,
-                int *numimpropers, int **impropers, double **improperforces,
-                int *numcterms,    int **cterms,
-                int *ctermcols,    int *ctermrows,  double **ctermforces);
-
-  /**
-   * Write out Angles, Dihedrals, Impropers, and Cross Terms
-   * Forces are in Kcal/mol
-   * (Cross terms pertain to the CHARMM/NAMD CMAP feature, forces are given
-   *  as a 2-D matrix)
-   */
-  int (* write_angles)(void *,
-        int numangles,    const int *angles,    const double *angleforces,
-        int numdihedrals, const int *dihedrals, const double *dihedralforces,
-        int numimpropers, const int *impropers, const double *improperforces,
-        int numcterms,   const int *cterms,
-        int ctermcols, int ctermrows, const double *ctermforces);
-#endif
 
 
   /**
@@ -798,7 +817,7 @@ typedef struct {
    * QM datasets in this file.
    *
    * The metadata are the sizes of the QM related data structure
-   * arrays that will be populated by the plugin when
+   * arrays that will be populated by the plugin when 
    * read_qm_rundata() is called. Since the allocation of these
    * arrays is done by VMD rather than the plugin, VMD needs to
    * know the sizes beforehand. Consequently read_qm_metadata()
@@ -811,7 +830,7 @@ typedef struct {
    * Read timestep independent QM data.
    *
    * Typical data that are defined only once per trajectory are
-   * general info about the calculation (such as the used method),
+   * general info about the calculation (such as the used method), 
    * the basis set and normal modes.
    * The data structures to be populated must have been allocated
    * before by VMD according to sizes obtained through
@@ -821,32 +840,27 @@ typedef struct {
 
 
   /**
-   * Read the next timestep from the file.  Return MOLFILE_SUCCESS, or
+   * Read the next timestep from the file.  Return MOLFILE_SUCCESS, or 
    * MOLFILE_EOF on EOF.  If the molfile_timestep_t or molfile_qm_metadata_t
-   * arguments are NULL, then the coordinate or qm data should be skipped.
-   * Otherwise, the application must prepare molfile_timestep_t and
-   * molfile_qm_timestep_t by allocating space for the corresponding
+   * arguments are NULL, then the coordinate or qm data should be skipped.  
+   * Otherwise, the application must prepare molfile_timestep_t and 
+   * molfile_qm_timestep_t by allocating space for the corresponding 
    * number of coordinates, orbital wavefunction coefficients, etc.
-   * Since it is common for users to want to load only the final timestep
+   * Since it is common for users to want to load only the final timestep 
    * data from a QM run, the application may provide any combination of
-   * valid, or NULL pointers for the molfile_timestep_t and
+   * valid, or NULL pointers for the molfile_timestep_t and 
    * molfile_qm_timestep_t parameters, depending on what information the
    * user is interested in.
-   * The natoms and qm metadata parameters exist because some file formats
-   * cannot determine for themselves how many atoms etc are in a
+   * The natoms and qm metadata parameters exist because some file formats 
+   * cannot determine for themselves how many atoms etc are in a 
    * timestep; the app must therefore obtain this information elsewhere
    * and provide it to the plugin.
    */
   int (* read_timestep)(void *, int natoms, molfile_timestep_t *,
                         molfile_qm_metadata_t *, molfile_qm_timestep_t *);
-#endif
 
-#if vmdplugin_ABIVERSION > 10
   int (* read_timestep_metadata)(void *, molfile_timestep_metadata_t *);
-#endif
-#if vmdplugin_ABIVERSION > 11
   int (* read_qm_timestep_metadata)(void *, molfile_qm_timestep_metadata_t *);
-#endif
 
 #if defined(DESRES_READ_TIMESTEP2)
   /**
@@ -864,7 +878,6 @@ typedef struct {
                                   double * times );
 #endif
 
-#if vmdplugin_ABIVERSION > 13
   /**
    *  Console output, READ-ONLY function pointer.
    *  Function pointer that plugins can use for printing to the host
@@ -883,7 +896,6 @@ typedef struct {
    *      application-provided services
    */
   int (* cons_fputs)(const int, const char*);
-#endif
 
 } molfile_plugin_t;
 

--- a/src/USER-MOLFILE/vmdplugin.h
+++ b/src/USER-MOLFILE/vmdplugin.h
@@ -11,26 +11,26 @@
  *
  *      $RCSfile: vmdplugin.h,v $
  *      $Author: johns $       $Locker:  $             $State: Exp $
- *      $Revision: 1.32 $       $Date: 2009/02/24 05:12:35 $
+ *      $Revision: 1.33 $       $Date: 2015/10/29 05:10:54 $
  *
  ***************************************************************************/
 
 /** @file
  * This header must be included by every VMD plugin library.  It defines the
- * API for every plugin so that VMD can organize the plugins it finds.
+ * API for every plugin so that VMD can organize the plugins it finds.  
  */
 
 #ifndef VMD_PLUGIN_H
 #define VMD_PLUGIN_H
 
 
-/*
+/* 
  * Preprocessor tricks to make it easier for us to redefine the names of
  * functions when building static plugins.
  */
 #if !defined(VMDPLUGIN)
-/**
-  * macro defining VMDPLUGIN if it hasn't already been set to the name of
+/** 
+  * macro defining VMDPLUGIN if it hasn't already been set to the name of 
   * a static plugin that is being compiled.  This is the catch-all case.
   */
 #define VMDPLUGIN vmdplugin
@@ -38,11 +38,11 @@
 /** concatenation macro, joins args x and y together as a single string */
 #define xcat(x, y) cat(x, y)
 /** concatenation macro, joins args x and y together as a single string */
-#define cat(x, y) x ## y
+#define cat(x, y) x ## y 
 
 /*
- *  macros to correctly define plugin function names depending on whether
- *  the plugin is being compiled for static linkage or dynamic loading.
+ *  macros to correctly define plugin function names depending on whether 
+ *  the plugin is being compiled for static linkage or dynamic loading. 
  *  When compiled for static linkage, each plugin needs to have unique
  *  function names for all of its entry points.  When compiled for dynamic
  *  loading, the plugins must name their entry points consistently so that
@@ -59,13 +59,13 @@
 
 
 /** "WIN32" is defined on both WIN32 and WIN64 platforms... */
-#if (defined(WIN32))
+#if (defined(WIN32)) 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #if !defined(STATIC_PLUGIN)
 #if defined(VMDPLUGIN_EXPORTS)
-/**
+/** 
  *  Only define DllMain for plugins, not in VMD or in statically linked plugins
  *  VMDPLUGIN_EXPORTS is only defined when compiling dynamically loaded plugins
  */
@@ -86,7 +86,7 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 #endif /* ! STATIC_PLUGIN */
 #else
 /** If we're not compiling on Windows, then this macro is defined empty */
-#define VMDPLUGIN_API
+#define VMDPLUGIN_API 
 #endif
 
 /** define plugin linkage correctly for both C and C++ based plugins */
@@ -96,13 +96,13 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 #define VMDPLUGIN_EXTERN extern VMDPLUGIN_API
 #endif  /* __cplusplus */
 
-/*
- * Plugin API functions start here
+/* 
+ * Plugin API functions start here 
  */
 
 
-/**
- * Init routine: called the first time the library is loaded by the
+/** 
+ * Init routine: called the first time the library is loaded by the 
  * application and before any other API functions are referenced.
  * Return 0 on success.
  */
@@ -110,15 +110,15 @@ VMDPLUGIN_EXTERN int VMDPLUGIN_init(void);
 
 /**
  * Macro for creating a struct header used in all plugin structures.
- *
- * This header should be placed at the top of every plugin API definition
+ * 
+ * This header should be placed at the top of every plugin API definition 
  * so that it can be treated as a subtype of the base plugin type.
  *
  * abiversion: Defines the ABI for the base plugin type (not for other plugins)
  * type: A string descriptor of the plugin type.
  * name: A name for the plugin.
  * author: A string identifier, possibly including newlines.
- * Major and minor version.
+ * Major and minor version.  
  * is_reentrant: Whether this library can be run concurrently with itself.
  */
 #define vmdplugin_HEAD \
@@ -129,12 +129,12 @@ VMDPLUGIN_EXTERN int VMDPLUGIN_init(void);
   const char *author; \
   int majorv; \
   int minorv; \
-  int is_reentrant;
+  int is_reentrant; 
 
-/**
+/** 
   * Typedef for generic plugin header, individual plugins can
-  * make their own structures as long as the header info remains
-  * the same as the generic plugin header, most easily done by
+  * make their own structures as long as the header info remains 
+  * the same as the generic plugin header, most easily done by 
   * using the vmdplugin_HEAD macro.
   */
 typedef struct {
@@ -144,7 +144,7 @@ typedef struct {
 /**
  * Use this macro to initialize the abiversion member of each plugin
  */
-#define vmdplugin_ABIVERSION  16
+#define vmdplugin_ABIVERSION  17
 
 /*@{*/
 /** Use this macro to indicate a plugin's thread-safety at registration time */
@@ -158,7 +158,7 @@ typedef struct {
 #define VMDPLUGIN_ERROR       -1
 /*@}*/
 
-/**
+/** 
  * Function pointer typedef for register callback functions
  */
 typedef int (*vmdplugin_register_cb)(void *, vmdplugin_t *);
@@ -175,16 +175,16 @@ typedef int (*vmdplugin_register_cb)(void *, vmdplugin_t *);
 VMDPLUGIN_EXTERN int VMDPLUGIN_register(void *, vmdplugin_register_cb);
 
 /**
- * Allow the library to register Tcl extensions.
+ * Allow the library to register Tcl extensions.  
  * This API is optional; if found by dlopen, it will be called after first
- * calling init and register.
+ * calling init and register.  
  */
-VMDPLUGIN_EXTERN int VMDPLUGIN_register_tcl(void *, void *tcl_interp,
+VMDPLUGIN_EXTERN int VMDPLUGIN_register_tcl(void *, void *tcl_interp, 
     vmdplugin_register_cb);
 
 /**
- * The Fini method is called when the application will no longer use
- * any plugins in the library.
+ * The Fini method is called when the application will no longer use 
+ * any plugins in the library.  
  */
 VMDPLUGIN_EXTERN int VMDPLUGIN_fini(void);
 


### PR DESCRIPTION
The molfile plugin header files (vmdplugin.h and molfile_plugin.h) from VMD 1.9.3 (current version in April 2017).  The previous versions included in the src/USER-MOLFILE folder were compatible with VMD 1.9.1 (version current in June 2012).  I have compiled the 31Mar17 version of LAMMPS with these new header files from VMD 1.9.3 and have been able to successfully use the molfile plugin.