### PR TITLE
compressed output via gzip for some ReaxFF fixes

### DIFF
--- a/doc/src/fix_reax_bonds.txt
+++ b/doc/src/fix_reax_bonds.txt
@@ -36,6 +36,10 @@ please see the "fix reaxc/c/species"_fix_reaxc_species.html command.
 
 The format of the output file should be self-explanatory.
 
+If the filename ends with ".gz", the output file is written in gzipped
+format.  A gzipped dump file will be about 3x smaller than the text
+version, but will also take longer to write.
+
 :line
 
 [Restart, fix_modify, output, run start/stop, minimize info:]
@@ -84,6 +88,9 @@ reax/c"_pair_reaxc.html be invoked.  This fix is part of the
 USER-REAXC package.  It is only enabled if LAMMPS was built with that
 package.  See the "Making LAMMPS"_Section_start.html#start_3 section
 for more info.
+
+To write gzipped bond files, you must compile LAMMPS with the
+-DLAMMPS_GZIP option.
 
 [Related commands:]
 

--- a/doc/src/fix_reaxc_species.txt
+++ b/doc/src/fix_reaxc_species.txt
@@ -52,6 +52,10 @@ number of molecules of each species.  In this context, "species" means
 a unique molecule.  The chemical formula of each species is given in
 the first line.
 
+If the filename ends with ".gz", the output file is written in gzipped
+format.  A gzipped dump file will be about 3x smaller than the text version,
+but will also take longer to write.
+
 Optional keyword {cutoff} can be assigned to change the minimum
 bond-order values used in identifying chemical bonds between pairs of
 atoms.  Bond-order cutoffs should be carefully chosen, as bond-order
@@ -163,6 +167,9 @@ reax/c"_pair_reaxc.html be invoked.  This fix is part of the
 USER-REAXC package.  It is only enabled if LAMMPS was built with that
 package.  See the "Making LAMMPS"_Section_start.html#start_3 section
 for more info.
+
+To write gzipped species files, you must compile LAMMPS with the
+-DLAMMPS_GZIP option.
 
 It should be possible to extend it to other reactive pair_styles (such as
 "rebo"_pair_airebo.html, "airebo"_pair_airebo.html,

--- a/src/REAX/fix_reax_bonds.cpp
+++ b/src/REAX/fix_reax_bonds.cpp
@@ -49,7 +49,21 @@ FixReaxBonds::FixReaxBonds(LAMMPS *lmp, int narg, char **arg) :
   if (nevery < 1) error->all(FLERR,"Illegal fix reax/bonds command");
 
   if (me == 0) {
-    fp = fopen(arg[4],"w");
+    char *suffix = strrchr(arg[4],'.');
+    if (suffix && strcmp(suffix,".gz") == 0) {
+#ifdef LAMMPS_GZIP
+      char gzip[128];
+      sprintf(gzip,"gzip -6 > %s",arg[4]);
+#ifdef _WIN32
+      fp = _popen(gzip,"wb");
+#else
+      fp = popen(gzip,"w");
+#endif
+#else
+      error->one(FLERR,"Cannot open gzipped file");
+#endif
+    } else fp = fopen(arg[4],"w");
+
     if (fp == NULL) {
       char str[128];
       sprintf(str,"Cannot open fix reax/bonds file %s",arg[4]);

--- a/src/USER-REAXC/fix_reaxc_bonds.cpp
+++ b/src/USER-REAXC/fix_reaxc_bonds.cpp
@@ -58,7 +58,21 @@ FixReaxCBonds::FixReaxCBonds(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,"Illegal fix reax/c/bonds command");
 
   if (me == 0) {
-    fp = fopen(arg[4],"w");
+    char *suffix = strrchr(arg[4],'.');
+    if (suffix && strcmp(suffix,".gz") == 0) {
+#ifdef LAMMPS_GZIP
+      char gzip[128];
+      sprintf(gzip,"gzip -6 > %s",arg[4]);
+#ifdef _WIN32
+      fp = _popen(gzip,"wb");
+#else
+      fp = popen(gzip,"w");
+#endif
+#else
+      error->one(FLERR,"Cannot open gzipped file");
+#endif
+    } else fp = fopen(arg[4],"w");
+
     if (fp == NULL) {
       char str[128];
       sprintf(str,"Cannot open fix reax/c/bonds file %s",arg[4]);

--- a/src/USER-REAXC/fix_reaxc_species.cpp
+++ b/src/USER-REAXC/fix_reaxc_species.cpp
@@ -110,7 +110,21 @@ FixReaxCSpecies::FixReaxCSpecies(LAMMPS *lmp, int narg, char **arg) :
   strcpy(tmparg[2],arg[5]);
 
   if (me == 0) {
-    fp = fopen(arg[6],"w");
+    char *suffix = strrchr(arg[6],'.');
+    if (suffix && strcmp(suffix,".gz") == 0) {
+#ifdef LAMMPS_GZIP
+      char gzip[128];
+      sprintf(gzip,"gzip -6 > %s",arg[6]);
+#ifdef _WIN32
+      fp = _popen(gzip,"wb");
+#else
+      fp = popen(gzip,"w");
+#endif
+#else
+      error->one(FLERR,"Cannot open gzipped file");
+#endif
+    } else fp = fopen(arg[6],"w");
+
     if (fp == NULL) {
       char str[128];
       sprintf(str,"Cannot open fix reax/c/species file %s",arg[6]);


### PR DESCRIPTION
in response to a [feature request on lammps-users](https://sourceforge.net/p/lammps/mailman/lammps-users/thread/CAN-konDnUdA1bFL%3DRs1K_b4M6za9rtGHykZmdR%2BE0da%3Dt4jKHQ%40mail.gmail.com/#msg35828362) this PR adds support for writing output from `fix reax/bonds`, `fix reax/c/bonds` and `fix reax/c/species` to gzip compressed files via piping the output through gzip. updated documentation accordingly and mention requirement to set `-DLAMMPS_GZIP` at compile time. this does **not** implement the requested one-file-per-timestep option.