### PR TITLE
Add python support features

### DIFF
--- a/doc/src/Section_python.txt
+++ b/doc/src/Section_python.txt
@@ -155,7 +155,8 @@ commands.
 See the "python"_python.html doc page and the "variable"_variable.html
 doc page for its python-style variables for more info, including
 examples of Python code you can write for both pure Python operations
-and callbacks to LAMMPS.
+and callbacks to LAMMPS. See "fix python"_fix_python.html to learn about
+possibilities to execute Python code during each time step.
 
 To run pure Python code from LAMMPS, you only need to build LAMMPS
 with the PYTHON package installed:

--- a/doc/src/fix_python.txt
+++ b/doc/src/fix_python.txt
@@ -17,7 +17,7 @@ python = style name of this fix command :l
 N = execute every N steps :l
 callback = {post_force} or {end_of_step} :l
   {post_force} = callback after force computations on atoms every N time steps
-  {end_of_step} = callback after each N time steps :pre
+  {end_of_step} = callback after every N time steps :pre
 :ule
 
 [Examples:]

--- a/doc/src/fix_python.txt
+++ b/doc/src/fix_python.txt
@@ -10,13 +10,14 @@ fix python command :h3
 
 [Syntax:]
 
-fix ID group-ID python callback function_name :pre
+fix ID group-ID python N callback function_name :pre
 
 ID, group-ID are ignored by this fix :ulb,l
 python = style name of this fix command :l
+N = execute every N steps :l
 callback = {post_force} or {end_of_step} :l
-  {post_force} = callback after force computations on atoms
-  {end_of_step} = callback after each time step :pre
+  {post_force} = callback after force computations on atoms every N time steps
+  {end_of_step} = callback after each N time steps :pre
 :ule
 
 [Examples:]
@@ -35,14 +36,14 @@ def end_of_step_callback(lammps_ptr):
     # access LAMMPS state using Python interface
 """ :pre
 
-fix pf  all python post_force post_force_callback
-fix eos all python end_of_step end_of_step_callback :pre
+fix pf  all python 50 post_force post_force_callback
+fix eos all python 50 end_of_step end_of_step_callback :pre
 
 [Description:]
 
 This fix allows you to call a Python function during a simulation run.
 The callback is either executed after forces have been applied to atoms
-or at the end of each time step.
+or at the end of every N time steps.
 
 Callback functions must be declared in the global scope of the
 active Python interpreter. This can either be done by defining it

--- a/doc/src/fix_python.txt
+++ b/doc/src/fix_python.txt
@@ -1,0 +1,75 @@
+"LAMMPS WWW Site"_lws - "LAMMPS Documentation"_ld - "LAMMPS Commands"_lc :c
+
+:link(lws,http://lammps.sandia.gov)
+:link(ld,Manual.html)
+:link(lc,Section_commands.html#comm)
+
+:line
+
+fix python command :h3
+
+[Syntax:]
+
+fix ID group-ID python callback function_name :pre
+
+ID, group-ID are ignored by this fix :ulb,l
+python = style name of this fix command :l
+callback = {post_force} or {end_of_step} :l
+  {post_force} = callback after force computations on atoms
+  {end_of_step} = callback after each time step :pre
+:ule
+
+[Examples:]
+
+python post_force_callback here """
+from lammps import lammps :pre
+
+def post_force_callback(lammps_ptr, vflag):
+    lmp = lammps(ptr=lammps_ptr)
+    # access LAMMPS state using Python interface
+""" :pre
+
+python end_of_step_callback here """
+def end_of_step_callback(lammps_ptr):
+    lmp = lammps(ptr=lammps_ptr)
+    # access LAMMPS state using Python interface
+""" :pre
+
+fix pf  all python post_force post_force_callback
+fix eos all python end_of_step end_of_step_callback :pre
+
+[Description:]
+
+This fix allows you to call a Python function during a simulation run.
+The callback is either executed after forces have been applied to atoms
+or at the end of each time step.
+
+Callback functions must be declared in the global scope of the
+active Python interpreter. This can either be done by defining it
+inline using the python command or by importing functions from other
+Python modules. If LAMMPS is driven using the library interface from
+Python, functions defined in the driving Python interpreter can also
+be executed.
+
+Each callback is given a pointer object as first argument. This can be
+used to initialize an instance of the lammps Python interface, which
+gives access to the LAMMPS state from Python.
+
+IMPORTANT NOTE: While you can access the state of LAMMPS via library functions
+from these callbacks, trying to execute input script commands will in the best
+case not work or in the worst case result in undefined behavior.
+
+[Restrictions:]
+
+This fix is part of the PYTHON package.  It is only enabled if
+LAMMPS was built with that package.  See the "Making
+LAMMPS"_Section_start.html#start_3 section for more info.
+
+Building LAMMPS with the PYTHON package will link LAMMPS with the
+Python library on your system.  Settings to enable this are in the
+lib/python/Makefile.lammps file.  See the lib/python/README file for
+information on those settings.
+
+[Related commands:]
+
+"python command"_python.html

--- a/doc/src/fixes.txt
+++ b/doc/src/fixes.txt
@@ -111,6 +111,7 @@ Fixes :h1
    fix_press_berendsen
    fix_print
    fix_property_atom
+   fix_python
    fix_qbmsst
    fix_qeq
    fix_qeq_comb

--- a/doc/src/python.txt
+++ b/doc/src/python.txt
@@ -405,6 +405,9 @@ or other variables may have hidden side effects as well.  In these
 cases, LAMMPS has no simple way to check that something illogical is
 being attempted.
 
+The same applies to Python functions called during a simulation run at
+each time step using "fix python"_fix_python.html.
+
 :line
 
 If you run Python code directly on your workstation, either
@@ -490,6 +493,6 @@ different source files, problems may occur.
 
 [Related commands:]
 
-"shell"_shell.html, "variable"_variable.html
+"shell"_shell.html, "variable"_variable.html, "fix python"_fix_python.html
 
 [Default:] none

--- a/doc/src/python.txt
+++ b/doc/src/python.txt
@@ -14,7 +14,7 @@ python func keyword args ... :pre
 
 func = name of Python function :ulb,l
 one or more keyword/args pairs must be appended :l
-keyword = {invoke} or {input} or {return} or {format} or {length} or {file} or {here} or {exists}
+keyword = {invoke} or {input} or {return} or {format} or {length} or {file} or {here} or {exists} or {source}
   {invoke} arg = none = invoke the previously defined Python function
   {input} args = N i1 i2 ... iN
     N = # of inputs to function
@@ -36,7 +36,12 @@ keyword = {invoke} or {input} or {return} or {format} or {length} or {file} or {
   {here} arg = inline
     inline = one or more lines of Python code which defines func
              must be a single argument, typically enclosed between triple quotes
-  {exists} arg = none = Python code has been loaded by previous python command :pre
+  {exists} arg = none = Python code has been loaded by previous python command
+  {source} arg = {filename} or {inline}
+    filename = file of Python code which will be executed immediately
+    inline = one or more lines of Python code which will be executed immediately
+             must be a single argument, typically enclosed between triple quotes
+:pre
 :ule
 
 [Examples:]
@@ -67,7 +72,8 @@ def loop(lmpptr,N,cut0):
 
 [Description:]
 
-Define a Python function or execute a previously defined function.
+Define a Python function or execute a previously defined function or
+execute some arbitrary python code.
 Arguments, including LAMMPS variables, can be passed to the function
 from the LAMMPS input script and a value returned by the Python
 function to a LAMMPS variable.  The Python code for the function can
@@ -102,7 +108,8 @@ command.
 
 The {func} setting specifies the name of the Python function.  The
 code for the function is defined using the {file} or {here} keywords
-as explained below.
+as explained below. In case of the {source} keyword, the name of
+the function is ignored.
 
 If the {invoke} keyword is used, no other keywords can be used, and a
 previous python command must have defined the Python function
@@ -110,6 +117,13 @@ referenced by this command.  This invokes the Python function with the
 previously defined arguments and return value processed as explained
 below.  You can invoke the function as many times as you wish in your
 input script.
+
+If the {source} keyword is used, no other keywords can be used.
+The argument can be a filename or a string with python commands,
+either on a single line enclosed in quotes, or as multiple lines
+enclosed in triple quotes. These python commands will be passed
+to the python interpreter and executed immediately without registering
+a python function for future execution.
 
 The {input} keyword defines how many arguments {N} the Python function
 expects.  If it takes no arguments, then the {input} keyword should

--- a/examples/python/in.fix_python
+++ b/examples/python/in.fix_python
@@ -1,0 +1,50 @@
+# 3d Lennard-Jones melt
+
+units		lj
+atom_style	atomic
+
+lattice		fcc 0.8442
+region		box block 0 10 0 10 0 10
+create_box	1 box
+create_atoms	1 box
+mass		1 1.0
+
+velocity	all create 3.0 87287
+
+pair_style	lj/cut 2.5
+pair_coeff	1 1 1.0 1.0 2.5
+
+neighbor	0.3 bin
+neigh_modify	every 20 delay 0 check no
+
+python         end_of_step_callback here """
+from __future__ import print_function
+from lammps import lammps
+
+def end_of_step_callback(lmp):
+  L = lammps(ptr=lmp)
+  t = L.extract_global("ntimestep", 0)
+  print("### END OF STEP ###", t)
+
+def post_force_callback(lmp, v):
+  L = lammps(ptr=lmp)
+  t = L.extract_global("ntimestep", 0)
+  print("### POST_FORCE ###", t)
+"""
+
+fix		1 all nve
+fix     2 all python end_of_step end_of_step_callback
+fix     3 all python post_force post_force_callback
+
+#dump		id all atom 50 dump.melt
+
+#dump		2 all image 25 image.*.jpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 25 movie.mpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+thermo		50
+run		250

--- a/examples/python/in.fix_python
+++ b/examples/python/in.fix_python
@@ -33,8 +33,8 @@ def post_force_callback(lmp, v):
 """
 
 fix		1 all nve
-fix     2 all python end_of_step end_of_step_callback
-fix     3 all python post_force post_force_callback
+fix     2 all python 50 end_of_step end_of_step_callback
+fix     3 all python 50 post_force post_force_callback
 
 #dump		id all atom 50 dump.melt
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -850,6 +850,8 @@
 /prd.h
 /python_impl.cpp
 /python_impl.h
+/fix_python.cpp
+/fix_python.h
 /reader_molfile.cpp
 /reader_molfile.h
 /reaxc_allocate.cpp

--- a/src/PYTHON/fix_python.cpp
+++ b/src/PYTHON/fix_python.cpp
@@ -1,0 +1,106 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <stdio.h>
+#include <string.h>
+#include "fix_python.h"
+#include "atom.h"
+#include "force.h"
+#include "update.h"
+#include "respa.h"
+#include "error.h"
+#include "python.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+// Wrap API changes between Python 2 and 3 using macros
+#if PY_MAJOR_VERSION == 2
+#define PY_VOID_POINTER(X) PyCObject_FromVoidPtr((void *) X, NULL)
+#elif PY_MAJOR_VERSION == 3
+#define PY_VOID_POINTER(X) PyCapsule_New((void *) X, NULL, NULL)
+#endif
+
+/* ---------------------------------------------------------------------- */
+
+FixPython::FixPython(LAMMPS *lmp, int narg, char **arg) :
+  Fix(lmp, narg, arg)
+{
+  if (narg != 5) error->all(FLERR,"Illegal fix python command");
+
+  // ensure Python interpreter is initialized
+  python->init();
+
+  if (strcmp(arg[3],"post_force") == 0) {
+    selected_callback = POST_FORCE;
+  } else if (strcmp(arg[3],"end_of_step") == 0) {
+    selected_callback = END_OF_STEP;
+  }
+
+  // get Python function
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  PyObject * pyMain = PyImport_AddModule("__main__");
+
+  if (!pyMain) {
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not initialize embedded Python");
+  }
+
+  char * fname = arg[4];
+  pFunc = PyObject_GetAttrString(pyMain, fname);
+
+  if (!pFunc) {
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find Python function");
+  }
+
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixPython::setmask()
+{
+  return selected_callback;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPython::end_of_step()
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(O)", ptr);
+
+  PyObject * result = PyEval_CallObject(pFunc, arglist);
+  Py_DECREF(arglist);
+
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPython::post_force(int vflag)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(Oi)", ptr, vflag);
+
+  PyObject * result = PyEval_CallObject(pFunc, arglist);
+  Py_DECREF(arglist);
+
+  PyGILState_Release(gstate);
+}

--- a/src/PYTHON/fix_python.h
+++ b/src/PYTHON/fix_python.h
@@ -1,0 +1,54 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(python,FixPython)
+
+#else
+
+#ifndef LMP_FIX_PYTHON_H
+#define LMP_FIX_PYTHON_H
+
+#include "fix.h"
+#include <Python.h>
+
+namespace LAMMPS_NS {
+
+class FixPython : public Fix {
+ public:
+  FixPython(class LAMMPS *, int, char **);
+  virtual ~FixPython() {}
+  int setmask();
+  virtual void end_of_step();
+  virtual void post_force(int);
+
+ private:
+  PyObject * pFunc;
+  int selected_callback;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+*/

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -119,6 +119,32 @@ void PythonImpl::command(int narg, char **arg)
     return;
   }
 
+  // if source is only keyword, execute the python code
+
+  if (narg == 3 && strcmp(arg[1],"source") == 0) {
+
+    PyGILState_STATE gstate = PyGILState_Ensure();
+
+    // if argument string is file, open it
+    // otherwise process string as python code
+
+    int err = 0;
+    FILE *fp = fopen(arg[2],"r");
+
+    if (fp == NULL)
+      err = PyRun_SimpleString(arg[2]);
+    else
+      err = PyRun_SimpleFile(fp,arg[2]);
+
+    if (err) {
+      PyGILState_Release(gstate);
+      error->all(FLERR,"Could not process Python source command");
+    }
+    if (fp) fclose(fp);
+    PyGILState_Release(gstate);
+    return;
+  }
+
   // parse optional args, invoke is not allowed in this mode
 
   ninput = noutput = 0;

--- a/src/PYTHON/python_impl.h
+++ b/src/PYTHON/python_impl.h
@@ -29,6 +29,8 @@ class PythonImpl : protected Pointers, public PythonInterface {
   int find(char *);
   int variable_match(char *, char *, int);
   char *long_string(int);
+  int execute_string(char *);
+  int execute_file(char *);
 
  private:
   int ninput,noutput,length_longstr;

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -97,3 +97,19 @@ char * Python::long_string(int ifunc)
   init();
   return impl->long_string(ifunc);
 }
+
+/* ------------------------------------------------------------------ */
+
+int Python::execute_string(char *cmd)
+{
+  init();
+  return impl->execute_string(cmd);
+}
+
+/* ------------------------------------------------------------------ */
+
+int Python::execute_file(char *fname)
+{
+  init();
+  return impl->execute_file(fname);
+}

--- a/src/python.h
+++ b/src/python.h
@@ -26,6 +26,8 @@ public:
   virtual int find(char *) = 0;
   virtual int variable_match(char *, char *, int) = 0;
   virtual char * long_string(int ifunc) = 0;
+  virtual int execute_string(char *) = 0;
+  virtual int execute_file(char *) = 0;
 };
 
 class Python : protected Pointers {
@@ -38,6 +40,8 @@ public:
   int find(char *);
   int variable_match(char *, char *, int);
   char * long_string(int ifunc);
+  int execute_string(char *);
+  int execute_file(char *);
 
   bool is_enabled() const;
   void init();


### PR DESCRIPTION
This pull request implements all 4 features from issue #454 
- an API in the python class to execute arbitrary python code provided as a string
- an API in the python class to execute arbitrary python code provided in a file
- an additional keyword `source` for the python command, that will take either a file or a string (single or multi-line) and execute it as python code.
- a new `fix python` allowing to execute Python code every N time steps during a simulation run

The purpose for all of these is to allow executing arbitrary python code outside of functions, e.g. loading a python module globally (for example the lammps python module). Examples
```bash
# multi-line inline example
python NULL source """
print ("test1 for here")
print ("test2 for here")
"""
# reading from a file
python NULL source test.py
# single line inline example
python xxx source "print('test single'); print('test2 single')"
```
and finally executing arbitrary python code during simulation steps using `fix python` to either monitor the progression of the simulation or making adjustments like applying an additional force during the `post_force` event.

EDIT: changes by @rbberger to include `fix python`
This closes #454 