### PR TITLE
corrections to pair style morse/smooth/linear

### DIFF
--- a/src/USER-MISC/pair_morse_smooth_linear.cpp
+++ b/src/USER-MISC/pair_morse_smooth_linear.cpp
@@ -104,7 +104,7 @@ void PairMorseSmoothLinear::compute(int eflag, int vflag)
         dexp = exp(-alpha[itype][jtype] * dr);
 
         fpartial = morse1[itype][jtype] * (dexp*dexp - dexp) / r;
-        fpair = factor_lj * ( fpartial - der_at_cutoff[itype][jtype] / r);
+        fpair = factor_lj * ( fpartial + der_at_cutoff[itype][jtype] / r);
 
         f[i][0] += delx*fpair;
         f[i][1] += dely*fpair;
@@ -118,7 +118,7 @@ void PairMorseSmoothLinear::compute(int eflag, int vflag)
         if (eflag) {
           evdwl = d0[itype][jtype] * (dexp*dexp - 2.0*dexp) -
             offset[itype][jtype];
-          evdwl += ( r - cut[itype][jtype] ) * der_at_cutoff[itype][jtype];
+          evdwl -= ( r - cut[itype][jtype] ) * der_at_cutoff[itype][jtype];
           evdwl *= factor_lj;
         }
 
@@ -349,10 +349,11 @@ double PairMorseSmoothLinear::single(int i, int j, int itype, int jtype, double 
   r = sqrt(rsq);
   dr = r - r0[itype][jtype];
   dexp = exp(-alpha[itype][jtype] * dr);
-  fforce = factor_lj * morse1[itype][jtype] * (dexp*dexp - dexp) / r;
+  fforce = factor_lj * (morse1[itype][jtype] * (dexp*dexp - dexp)
+                        + der_at_cutoff[itype][jtype]) / r;
 
   phi = d0[itype][jtype] * (dexp*dexp - 2.0*dexp) - offset[itype][jtype];
-  dr = cut[itype][jtype] - r0[itype][jtype];
+  dr = cut[itype][jtype] - r;
   phi += dr * der_at_cutoff[itype][jtype];
 
   return factor_lj*phi;


### PR DESCRIPTION
This PR contains bugfixes reported by David R. Heine:
```
We are looking at the pair_morse_smooth_linear potential and found that there
are a few typos that prevent the potential from being continuous at the cutoff.
Here is a corrected version and a sample input script to highlight the
discontinuity in the original version. 
```
Example script to highlight the issue:
```bash
units           metal
lattice         fcc 0.8442
region          box block 0 10 0 10 0 10
create_box      2 box
create_atoms    1 single 0 0 0
create_atoms    2 single 5 5 5
variable  cutoff equal 3
pair_style      morse/smooth/linear ${cutoff}
pair_coeff     1 1    0.042395  1.379316  3.618701
pair_coeff     1 2    0.340554  2.006700  2.100000
pair_coeff     2 2    0.000000 1.000000 1.000000
mass 1 15.9994
mass 2 28.0855
run 0
pair_write  1 2 100000 r 1.2 8.0 pair.txt doublecheck 0 0
pair_write  1 2 100000 r $(v_cutoff-0.002) $(v_cutoff+0.002) zoom-in.txt doublecheck 0 0
```
Plot the 2nd and 3rd or 4th column in pair.txt or zoom-in.txt to see the energy and force VS distance.