### PR TITLE
Collected small updates and bugfixes

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -158,7 +158,7 @@ $(VENV):
 	@( \
 		virtualenv -p $(PYTHON) $(VENV); \
 		. $(VENV)/bin/activate; \
-		pip install Sphinx; \
+		pip install Sphinx==1.5.6; \
 		pip install sphinxcontrib-images; \
 		deactivate;\
 	)

--- a/doc/src/dihedral_spherical.txt
+++ b/doc/src/dihedral_spherical.txt
@@ -14,10 +14,10 @@ dihedral_style spherical :pre
 
 [Examples:]
 
-dihedral_coeff 1 1  286.1  1 124 1   1 90.0 0   1 90.0 0
-dihedral_coeff 1 3  286.1  1 114 1   1 90  0    1 90.0  0  &
-                    17.3   0 0.0 0   1 158 1    0 0.0   0  &
-                    15.1   0 0.0 0   0 0.0 0    1 167.3 1   :pre
+dihedral_coeff 1 1  286.1  1 124  1    1 90.0 0    1 90.0 0
+dihedral_coeff 1 3  69.3   1 93.9 1    1 90   0    1 90   0  &
+                    49.1   0 0.00 0    1 74.4 1    0 0.00 0  &
+                    25.2   0 0.00 0    0 0.00 0    1 48.1 1
 
 [Description:]
 
@@ -35,13 +35,14 @@ the dihedral interaction even if it requires adding additional terms to
 the expansion (as was done in the second example).  A careful choice of
 parameters can prevent singularities that occur with traditional
 force-fields whenever theta1 or theta2 approach 0 or 180 degrees.
+
 The last example above corresponds to an interaction with a single energy
-minima located at phi=114, theta1=158, theta2=167.3 degrees, and it remains
+minima located near phi=93.9, theta1=74.4, theta2=48.1 degrees, and it remains
 numerically stable at all angles (phi, theta1, theta2). In this example,
-the coefficients 17.3, and 15.1 can be physically interpreted as the
+the coefficients 49.1, and 25.2 can be physically interpreted as the
 harmonic spring constants for theta1 and theta2 around their minima.
-The coefficient 286.1 is the harmonic spring constant for phi after
-division by sin(158)*sin(167.3) (the minima positions for theta1 and theta2).
+The coefficient 69.3 is the harmonic spring constant for phi after
+division by sin(74.4)*sin(48.1) (the minima positions for theta1 and theta2).
 
 The following coefficients must be defined for each dihedral type via the
 "dihedral_coeff"_dihedral_coeff.html command as in the example above, or in

--- a/doc/src/pair_gauss.txt
+++ b/doc/src/pair_gauss.txt
@@ -128,7 +128,7 @@ The B parameter is converted to a distance (sigma), before mixing
 afterwards (using B=sigma^2).
 Negative A values are converted to positive A values (using abs(A))
 before mixing, and converted back after mixing
-(by multiplying by sign(Ai)*sign(Aj)).
+(by multiplying by min(sign(Ai),sign(Aj))).
 This way, if either particle is repulsive (if Ai<0 or Aj<0),
 then the default interaction between both particles will be repulsive.
 

--- a/doc/src/pair_meam_spline.txt
+++ b/doc/src/pair_meam_spline.txt
@@ -33,7 +33,7 @@ atoms J, I, and K centered on atom I. The five functions Phi, U, rho,
 f, and g are represented by cubic splines.
 
 The {meam/spline} style also supports a new style multicomponent
-modified embedded-atom method (MEAM) potential "(Zhang)"_#Zhang1, where
+modified embedded-atom method (MEAM) potential "(Zhang)"_#Zhang4, where
 the total energy E is given by
 
 :c,image(Eqs/pair_meam_spline_multicomponent.jpg)
@@ -164,5 +164,5 @@ for more info.
 Kress, Modelling Simulation Materials Science Engineering, 8, 825
 (2000).
 
-:link(Zhang1)
+:link(Zhang4)
 [(Zhang)] Zhang and Trinkle, Computational Materials Science, 124, 204-210 (2016).

--- a/doc/src/rerun.txt
+++ b/doc/src/rerun.txt
@@ -15,7 +15,7 @@ rerun file1 file2 ... keyword args ... :pre
 file1,file2,... = dump file(s) to read :ulb,l
 one or more keywords may be appended, keyword {dump} must appear and be last :l
 keyword = {first} or {last} or {every} or {skip} or {start} or {stop} or {dump}
- {first} args = Nfirts
+ {first} args = Nfirst
    Nfirst = dump timestep to start on
  {last} args = Nlast
    Nlast = dumptimestep to stop on

--- a/doc/src/velocity.txt
+++ b/doc/src/velocity.txt
@@ -61,7 +61,7 @@ keyword/value parameters.  Not all options are used by each style.
 Each option has a default as listed below.
 
 The {create} style generates an ensemble of velocities using a random
-number generator with the specified seed as the specified temperature.
+number generator with the specified seed at the specified temperature.
 
 The {set} style sets the velocities of all atoms in the group to the
 specified values.  If any component is specified as NULL, then it is

--- a/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
+++ b/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
@@ -393,10 +393,10 @@ void PairLJCharmmfswCoulCharmmfsh::write_restart(FILE *fp)
     for (j = i; j <= atom->ntypes; j++) {
       fwrite(&setflag[i][j],sizeof(int),1,fp);
       if (setflag[i][j]) {
-	fwrite(&epsilon[i][j],sizeof(double),1,fp);
-	fwrite(&sigma[i][j],sizeof(double),1,fp);
-	fwrite(&eps14[i][j],sizeof(double),1,fp);
-	fwrite(&sigma14[i][j],sizeof(double),1,fp);
+        fwrite(&epsilon[i][j],sizeof(double),1,fp);
+        fwrite(&sigma[i][j],sizeof(double),1,fp);
+        fwrite(&eps14[i][j],sizeof(double),1,fp);
+        fwrite(&sigma14[i][j],sizeof(double),1,fp);
       }
     }
 }


### PR DESCRIPTION
This PR contains the following changes:
- two small doc corrections from Andrew Jewett for pair style `gauss` and dihedral style `spherical`
- correct type reported in #486 
- fix a duplicate reference issue in pair meam/spline docs
- small fix from richard berger to html and ebook generation. we need to prohibit sphinx from updating to version 1.6.x which is breaking one of the extensions we use.