### PR TITLE
Bugfix for correct resetting of previously set cutoffs to various Pair::settings() functions

### DIFF
--- a/src/ASPHERE/pair_gayberne.cpp
+++ b/src/ASPHERE/pair_gayberne.cpp
@@ -281,7 +281,7 @@ void PairGayBerne::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/ASPHERE/pair_line_lj.cpp
+++ b/src/ASPHERE/pair_line_lj.cpp
@@ -355,7 +355,7 @@ void PairLineLJ::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/ASPHERE/pair_resquared.cpp
+++ b/src/ASPHERE/pair_resquared.cpp
@@ -253,7 +253,7 @@ void PairRESquared::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/ASPHERE/pair_tri_lj.cpp
+++ b/src/ASPHERE/pair_tri_lj.cpp
@@ -426,7 +426,7 @@ void PairTriLJ::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/BODY/pair_body.cpp
+++ b/src/BODY/pair_body.cpp
@@ -372,7 +372,7 @@ void PairBody::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/CLASS2/pair_lj_class2.cpp
+++ b/src/CLASS2/pair_lj_class2.cpp
@@ -174,7 +174,7 @@ void PairLJClass2::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/CLASS2/pair_lj_class2_coul_cut.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_cut.cpp
@@ -202,7 +202,7 @@ void PairLJClass2CoulCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_lj[i][j] = cut_lj_global;
           cut_coul[i][j] = cut_coul_global;

--- a/src/CLASS2/pair_lj_class2_coul_long.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_long.cpp
@@ -240,7 +240,7 @@ void PairLJClass2CoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/COLLOID/pair_brownian.cpp
+++ b/src/COLLOID/pair_brownian.cpp
@@ -403,7 +403,7 @@ void PairBrownian::settings(int narg, char **arg)
 
   if (allocated) {
     for (int i = 1; i <= atom->ntypes; i++)
-      for (int j = i+1; j <= atom->ntypes; j++)
+      for (int j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/COLLOID/pair_colloid.cpp
+++ b/src/COLLOID/pair_colloid.cpp
@@ -256,7 +256,7 @@ void PairColloid::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/COLLOID/pair_lubricate.cpp
+++ b/src/COLLOID/pair_lubricate.cpp
@@ -489,7 +489,7 @@ void PairLubricate::settings(int narg, char **arg)
 
   if (allocated) {
     for (int i = 1; i <= atom->ntypes; i++)
-      for (int j = i+1; j <= atom->ntypes; j++)
+      for (int j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/COLLOID/pair_lubricateU.cpp
+++ b/src/COLLOID/pair_lubricateU.cpp
@@ -1707,7 +1707,7 @@ void PairLubricateU::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/COLLOID/pair_lubricateU_poly.cpp
+++ b/src/COLLOID/pair_lubricateU_poly.cpp
@@ -1104,7 +1104,7 @@ void PairLubricateUPoly::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/DIPOLE/pair_lj_cut_dipole_cut.cpp
+++ b/src/DIPOLE/pair_lj_cut_dipole_cut.cpp
@@ -307,7 +307,7 @@ void PairLJCutDipoleCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_lj[i][j] = cut_lj_global;
           cut_coul[i][j] = cut_coul_global;

--- a/src/DIPOLE/pair_lj_cut_dipole_long.cpp
+++ b/src/DIPOLE/pair_lj_cut_dipole_long.cpp
@@ -140,174 +140,174 @@ void PairLJCutDipoleLong::compute(int eflag, int vflag)
       jtype = type[j];
 
       if (rsq < cutsq[itype][jtype]) {
-	r2inv = 1.0/rsq;
-	rinv = sqrt(r2inv);
+        r2inv = 1.0/rsq;
+        rinv = sqrt(r2inv);
 
-	if (rsq < cut_coulsq) {
-	  r = sqrt(rsq);
-	  grij = g_ewald * r;
-	  expm2 = exp(-grij*grij);
-	  t = 1.0 / (1.0 + EWALD_P*grij);
-	  erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
+        if (rsq < cut_coulsq) {
+          r = sqrt(rsq);
+          grij = g_ewald * r;
+          expm2 = exp(-grij*grij);
+          t = 1.0 / (1.0 + EWALD_P*grij);
+          erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
 
-	  pdotp = mu[i][0]*mu[j][0] + mu[i][1]*mu[j][1] + mu[i][2]*mu[j][2];
-	  pidotr = mu[i][0]*delx + mu[i][1]*dely + mu[i][2]*delz;
-	  pjdotr = mu[j][0]*delx + mu[j][1]*dely + mu[j][2]*delz;
+          pdotp = mu[i][0]*mu[j][0] + mu[i][1]*mu[j][1] + mu[i][2]*mu[j][2];
+          pidotr = mu[i][0]*delx + mu[i][1]*dely + mu[i][2]*delz;
+          pjdotr = mu[j][0]*delx + mu[j][1]*dely + mu[j][2]*delz;
 
-	  g0 = qtmp*q[j];
-	  g1 = qtmp*pjdotr - q[j]*pidotr + pdotp;
-	  g2 = -pidotr*pjdotr;
+          g0 = qtmp*q[j];
+          g1 = qtmp*pjdotr - q[j]*pidotr + pdotp;
+          g2 = -pidotr*pjdotr;
 
-	  if (factor_coul > 0.0) {
-	    b0 = erfc * rinv;
-	    b1 = (b0 + pre1*expm2) * r2inv;
-	    b2 = (3.0*b1 + pre2*expm2) * r2inv;
-	    b3 = (5.0*b2 + pre3*expm2) * r2inv;
+          if (factor_coul > 0.0) {
+            b0 = erfc * rinv;
+            b1 = (b0 + pre1*expm2) * r2inv;
+            b2 = (3.0*b1 + pre2*expm2) * r2inv;
+            b3 = (5.0*b2 + pre3*expm2) * r2inv;
 
-	    g0b1_g1b2_g2b3 = g0*b1 + g1*b2 + g2*b3;
-	    fdx = delx * g0b1_g1b2_g2b3 -
-	      b1 * (qtmp*mu[j][0] - q[j]*mu[i][0]) +
-	      b2 * (pjdotr*mu[i][0] + pidotr*mu[j][0]);
-	    fdy = dely * g0b1_g1b2_g2b3 -
-	      b1 * (qtmp*mu[j][1] - q[j]*mu[i][1]) +
-	      b2 * (pjdotr*mu[i][1] + pidotr*mu[j][1]);
-	    fdz = delz * g0b1_g1b2_g2b3 -
-	      b1 * (qtmp*mu[j][2] - q[j]*mu[i][2]) +
-	      b2 * (pjdotr*mu[i][2] + pidotr*mu[j][2]);
+            g0b1_g1b2_g2b3 = g0*b1 + g1*b2 + g2*b3;
+            fdx = delx * g0b1_g1b2_g2b3 -
+              b1 * (qtmp*mu[j][0] - q[j]*mu[i][0]) +
+              b2 * (pjdotr*mu[i][0] + pidotr*mu[j][0]);
+            fdy = dely * g0b1_g1b2_g2b3 -
+              b1 * (qtmp*mu[j][1] - q[j]*mu[i][1]) +
+              b2 * (pjdotr*mu[i][1] + pidotr*mu[j][1]);
+            fdz = delz * g0b1_g1b2_g2b3 -
+              b1 * (qtmp*mu[j][2] - q[j]*mu[i][2]) +
+              b2 * (pjdotr*mu[i][2] + pidotr*mu[j][2]);
 
-	    zdix = delx * (q[j]*b1 + b2*pjdotr) - b1*mu[j][0];
-	    zdiy = dely * (q[j]*b1 + b2*pjdotr) - b1*mu[j][1];
-	    zdiz = delz * (q[j]*b1 + b2*pjdotr) - b1*mu[j][2];
-	    zdjx = delx * (-qtmp*b1 + b2*pidotr) - b1*mu[i][0];
-	    zdjy = dely * (-qtmp*b1 + b2*pidotr) - b1*mu[i][1];
-	    zdjz = delz * (-qtmp*b1 + b2*pidotr) - b1*mu[i][2];
+            zdix = delx * (q[j]*b1 + b2*pjdotr) - b1*mu[j][0];
+            zdiy = dely * (q[j]*b1 + b2*pjdotr) - b1*mu[j][1];
+            zdiz = delz * (q[j]*b1 + b2*pjdotr) - b1*mu[j][2];
+            zdjx = delx * (-qtmp*b1 + b2*pidotr) - b1*mu[i][0];
+            zdjy = dely * (-qtmp*b1 + b2*pidotr) - b1*mu[i][1];
+            zdjz = delz * (-qtmp*b1 + b2*pidotr) - b1*mu[i][2];
 
-	    if (factor_coul < 1.0) {
-	      fdx *= factor_coul;
-	      fdy *= factor_coul;
-	      fdz *= factor_coul;
-	      zdix *= factor_coul;
-	      zdiy *= factor_coul;
-	      zdiz *= factor_coul;
-	      zdjx *= factor_coul;
-	      zdjy *= factor_coul;
-	      zdjz *= factor_coul;
-	    }
-	  } else {
-	    fdx = fdy = fdz = 0.0;
-	    zdix = zdiy = zdiz = 0.0;
-	    zdjx = zdjy = zdjz = 0.0;
-	  }
+            if (factor_coul < 1.0) {
+              fdx *= factor_coul;
+              fdy *= factor_coul;
+              fdz *= factor_coul;
+              zdix *= factor_coul;
+              zdiy *= factor_coul;
+              zdiz *= factor_coul;
+              zdjx *= factor_coul;
+              zdjy *= factor_coul;
+              zdjz *= factor_coul;
+            }
+          } else {
+            fdx = fdy = fdz = 0.0;
+            zdix = zdiy = zdiz = 0.0;
+            zdjx = zdjy = zdjz = 0.0;
+          }
 
-	  if (factor_coul < 1.0) {
-	    d0 = (erfc - 1.0) * rinv;
-	    d1 = (d0 + pre1*expm2) * r2inv;
-	    d2 = (3.0*d1 + pre2*expm2) * r2inv;
-	    d3 = (5.0*d2 + pre3*expm2) * r2inv;
+          if (factor_coul < 1.0) {
+            d0 = (erfc - 1.0) * rinv;
+            d1 = (d0 + pre1*expm2) * r2inv;
+            d2 = (3.0*d1 + pre2*expm2) * r2inv;
+            d3 = (5.0*d2 + pre3*expm2) * r2inv;
 
-	    g0d1_g1d2_g2d3 = g0*d1 + g1*d2 + g2*d3;
-	    fax = delx * g0d1_g1d2_g2d3 -
-	      d1 * (qtmp*mu[j][0] - q[j]*mu[i][0]) +
-	      d2 * (pjdotr*mu[i][0] + pidotr*mu[j][0]);
-	    fay = dely * g0d1_g1d2_g2d3 -
-	      d1 * (qtmp*mu[j][1] - q[j]*mu[i][1]) +
-	      d2 * (pjdotr*mu[i][1] + pidotr*mu[j][1]);
-	    faz = delz * g0d1_g1d2_g2d3 -
-	      d1 * (qtmp*mu[j][2] - q[j]*mu[i][2]) +
-	      d2 * (pjdotr*mu[i][2] + pidotr*mu[j][2]);
+            g0d1_g1d2_g2d3 = g0*d1 + g1*d2 + g2*d3;
+            fax = delx * g0d1_g1d2_g2d3 -
+              d1 * (qtmp*mu[j][0] - q[j]*mu[i][0]) +
+              d2 * (pjdotr*mu[i][0] + pidotr*mu[j][0]);
+            fay = dely * g0d1_g1d2_g2d3 -
+              d1 * (qtmp*mu[j][1] - q[j]*mu[i][1]) +
+              d2 * (pjdotr*mu[i][1] + pidotr*mu[j][1]);
+            faz = delz * g0d1_g1d2_g2d3 -
+              d1 * (qtmp*mu[j][2] - q[j]*mu[i][2]) +
+              d2 * (pjdotr*mu[i][2] + pidotr*mu[j][2]);
 
-	    zaix = delx * (q[j]*d1 + d2*pjdotr) - d1*mu[j][0];
-	    zaiy = dely * (q[j]*d1 + d2*pjdotr) - d1*mu[j][1];
-	    zaiz = delz * (q[j]*d1 + d2*pjdotr) - d1*mu[j][2];
-	    zajx = delx * (-qtmp*d1 + d2*pidotr) - d1*mu[i][0];
-	    zajy = dely * (-qtmp*d1 + d2*pidotr) - d1*mu[i][1];
-	    zajz = delz * (-qtmp*d1 + d2*pidotr) - d1*mu[i][2];
+            zaix = delx * (q[j]*d1 + d2*pjdotr) - d1*mu[j][0];
+            zaiy = dely * (q[j]*d1 + d2*pjdotr) - d1*mu[j][1];
+            zaiz = delz * (q[j]*d1 + d2*pjdotr) - d1*mu[j][2];
+            zajx = delx * (-qtmp*d1 + d2*pidotr) - d1*mu[i][0];
+            zajy = dely * (-qtmp*d1 + d2*pidotr) - d1*mu[i][1];
+            zajz = delz * (-qtmp*d1 + d2*pidotr) - d1*mu[i][2];
 
-	    if (factor_coul > 0.0) {
-	      facm1 = 1.0 - factor_coul;
-	      fax *= facm1;
-	      fay *= facm1;
-	      faz *= facm1;
-	      zaix *= facm1;
-	      zaiy *= facm1;
-	      zaiz *= facm1;
-	      zajx *= facm1;
-	      zajy *= facm1;
-	      zajz *= facm1;
-	    }
-	  } else {
-	    fax = fay = faz = 0.0;
-	    zaix = zaiy = zaiz = 0.0;
-	    zajx = zajy = zajz = 0.0;
-	  }
+            if (factor_coul > 0.0) {
+              facm1 = 1.0 - factor_coul;
+              fax *= facm1;
+              fay *= facm1;
+              faz *= facm1;
+              zaix *= facm1;
+              zaiy *= facm1;
+              zaiz *= facm1;
+              zajx *= facm1;
+              zajy *= facm1;
+              zajz *= facm1;
+            }
+          } else {
+            fax = fay = faz = 0.0;
+            zaix = zaiy = zaiz = 0.0;
+            zajx = zajy = zajz = 0.0;
+          }
 
-	  forcecoulx = fdx + fax;
-	  forcecouly = fdy + fay;
-	  forcecoulz = fdz + faz;
+          forcecoulx = fdx + fax;
+          forcecouly = fdy + fay;
+          forcecoulz = fdz + faz;
 
-	  tixcoul = mu[i][1]*(zdiz + zaiz) - mu[i][2]*(zdiy + zaiy);
-	  tiycoul = mu[i][2]*(zdix + zaix) - mu[i][0]*(zdiz + zaiz);
-	  tizcoul = mu[i][0]*(zdiy + zaiy) - mu[i][1]*(zdix + zaix);
-	  tjxcoul = mu[j][1]*(zdjz + zajz) - mu[j][2]*(zdjy + zajy);
-	  tjycoul = mu[j][2]*(zdjx + zajx) - mu[j][0]*(zdjz + zajz);
-	  tjzcoul = mu[j][0]*(zdjy + zajy) - mu[j][1]*(zdjx + zajx);
+          tixcoul = mu[i][1]*(zdiz + zaiz) - mu[i][2]*(zdiy + zaiy);
+          tiycoul = mu[i][2]*(zdix + zaix) - mu[i][0]*(zdiz + zaiz);
+          tizcoul = mu[i][0]*(zdiy + zaiy) - mu[i][1]*(zdix + zaix);
+          tjxcoul = mu[j][1]*(zdjz + zajz) - mu[j][2]*(zdjy + zajy);
+          tjycoul = mu[j][2]*(zdjx + zajx) - mu[j][0]*(zdjz + zajz);
+          tjzcoul = mu[j][0]*(zdjy + zajy) - mu[j][1]*(zdjx + zajx);
 
-	} else {
-	  forcecoulx = forcecouly = forcecoulz = 0.0;
-	  tixcoul = tiycoul = tizcoul = 0.0;
-	  tjxcoul = tjycoul = tjzcoul = 0.0;
-	}
-
-	// LJ interaction
-
-	if (rsq < cut_ljsq[itype][jtype]) {
-	  r6inv = r2inv*r2inv*r2inv;
-	  forcelj = r6inv * (lj1[itype][jtype]*r6inv - lj2[itype][jtype]);
-	  fforce = factor_lj * forcelj*r2inv;
-	} else fforce = 0.0;
-
-	// total force
-
-	fx = qqrd2e*forcecoulx + delx*fforce;
-	fy = qqrd2e*forcecouly + dely*fforce;
-	fz = qqrd2e*forcecoulz + delz*fforce;
-
-	// force & torque accumulation
-
-	f[i][0] += fx;
-	f[i][1] += fy;
-	f[i][2] += fz;
-	torque[i][0] += qqrd2e*tixcoul;
-	torque[i][1] += qqrd2e*tiycoul;
-	torque[i][2] += qqrd2e*tizcoul;
-
-	if (newton_pair || j < nlocal) {
-	  f[j][0] -= fx;
-	  f[j][1] -= fy;
-	  f[j][2] -= fz;
-	  torque[j][0] += qqrd2e*tjxcoul;
-	  torque[j][1] += qqrd2e*tjycoul;
-	  torque[j][2] += qqrd2e*tjzcoul;
-	}
-
-	if (eflag) {
-	  if (rsq < cut_coulsq && factor_coul > 0.0) {
-	    ecoul = qqrd2e*(b0*g0 + b1*g1 + b2*g2);
-	    if (factor_coul < 1.0) {
-              ecoul *= factor_coul;
-	      ecoul += (1-factor_coul) * qqrd2e * (d0*g0 + d1*g1 + d2*g2);
+        } else {
+          forcecoulx = forcecouly = forcecoulz = 0.0;
+          tixcoul = tiycoul = tizcoul = 0.0;
+          tjxcoul = tjycoul = tjzcoul = 0.0;
         }
-	  } else ecoul = 0.0;
 
-	  if (rsq < cut_ljsq[itype][jtype]) {
-	    evdwl = r6inv*(lj3[itype][jtype]*r6inv-lj4[itype][jtype]) -
-	      offset[itype][jtype];
-	    evdwl *= factor_lj;
-	  } else evdwl = 0.0;
-	}
+        // LJ interaction
 
-	if (evflag) ev_tally_xyz(i,j,nlocal,newton_pair,
-				 evdwl,ecoul,fx,fy,fz,delx,dely,delz);
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r6inv = r2inv*r2inv*r2inv;
+          forcelj = r6inv * (lj1[itype][jtype]*r6inv - lj2[itype][jtype]);
+          fforce = factor_lj * forcelj*r2inv;
+        } else fforce = 0.0;
+
+        // total force
+
+        fx = qqrd2e*forcecoulx + delx*fforce;
+        fy = qqrd2e*forcecouly + dely*fforce;
+        fz = qqrd2e*forcecoulz + delz*fforce;
+
+        // force & torque accumulation
+
+        f[i][0] += fx;
+        f[i][1] += fy;
+        f[i][2] += fz;
+        torque[i][0] += qqrd2e*tixcoul;
+        torque[i][1] += qqrd2e*tiycoul;
+        torque[i][2] += qqrd2e*tizcoul;
+
+        if (newton_pair || j < nlocal) {
+          f[j][0] -= fx;
+          f[j][1] -= fy;
+          f[j][2] -= fz;
+          torque[j][0] += qqrd2e*tjxcoul;
+          torque[j][1] += qqrd2e*tjycoul;
+          torque[j][2] += qqrd2e*tjzcoul;
+        }
+
+        if (eflag) {
+          if (rsq < cut_coulsq && factor_coul > 0.0) {
+            ecoul = qqrd2e*(b0*g0 + b1*g1 + b2*g2);
+            if (factor_coul < 1.0) {
+              ecoul *= factor_coul;
+              ecoul += (1-factor_coul) * qqrd2e * (d0*g0 + d1*g1 + d2*g2);
+            }
+          } else ecoul = 0.0;
+
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = r6inv*(lj3[itype][jtype]*r6inv-lj4[itype][jtype]) -
+              offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (evflag) ev_tally_xyz(i,j,nlocal,newton_pair,
+                                 evdwl,ecoul,fx,fy,fz,delx,dely,delz);
       }
     }
   }
@@ -360,8 +360,8 @@ void PairLJCutDipoleLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-	if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
+      for (j = i; j <= atom->ntypes; j++)
+        if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }
 
@@ -407,7 +407,7 @@ double PairLJCutDipoleLong::init_one(int i, int j)
 {
   if (setflag[i][j] == 0) {
     epsilon[i][j] = mix_energy(epsilon[i][i],epsilon[j][j],
-			       sigma[i][i],sigma[j][j]);
+                               sigma[i][i],sigma[j][j]);
     sigma[i][j] = mix_distance(sigma[i][i],sigma[j][j]);
     cut_lj[i][j] = mix_distance(cut_lj[i][i],cut_lj[j][j]);
   }
@@ -472,9 +472,9 @@ void PairLJCutDipoleLong::write_restart(FILE *fp)
     for (j = i; j <= atom->ntypes; j++) {
       fwrite(&setflag[i][j],sizeof(int),1,fp);
       if (setflag[i][j]) {
-	fwrite(&epsilon[i][j],sizeof(double),1,fp);
-	fwrite(&sigma[i][j],sizeof(double),1,fp);
-	fwrite(&cut_lj[i][j],sizeof(double),1,fp);
+        fwrite(&epsilon[i][j],sizeof(double),1,fp);
+        fwrite(&sigma[i][j],sizeof(double),1,fp);
+        fwrite(&cut_lj[i][j],sizeof(double),1,fp);
       }
     }
 }
@@ -496,14 +496,14 @@ void PairLJCutDipoleLong::read_restart(FILE *fp)
       if (me == 0) fread(&setflag[i][j],sizeof(int),1,fp);
       MPI_Bcast(&setflag[i][j],1,MPI_INT,0,world);
       if (setflag[i][j]) {
-	if (me == 0) {
-	  fread(&epsilon[i][j],sizeof(double),1,fp);
-	  fread(&sigma[i][j],sizeof(double),1,fp);
-	  fread(&cut_lj[i][j],sizeof(double),1,fp);
-	}
-	MPI_Bcast(&epsilon[i][j],1,MPI_DOUBLE,0,world);
-	MPI_Bcast(&sigma[i][j],1,MPI_DOUBLE,0,world);
-	MPI_Bcast(&cut_lj[i][j],1,MPI_DOUBLE,0,world);
+        if (me == 0) {
+          fread(&epsilon[i][j],sizeof(double),1,fp);
+          fread(&sigma[i][j],sizeof(double),1,fp);
+          fread(&cut_lj[i][j],sizeof(double),1,fp);
+        }
+        MPI_Bcast(&epsilon[i][j],1,MPI_DOUBLE,0,world);
+        MPI_Bcast(&sigma[i][j],1,MPI_DOUBLE,0,world);
+        MPI_Bcast(&cut_lj[i][j],1,MPI_DOUBLE,0,world);
       }
     }
 }

--- a/src/DIPOLE/pair_lj_long_dipole_long.cpp
+++ b/src/DIPOLE/pair_lj_long_dipole_long.cpp
@@ -102,8 +102,8 @@ void PairLJLongDipoleLong::settings(int narg, char **arg)
   if (allocated) {					// reset explicit cuts
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-	if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
+      for (j = i; j <= atom->ntypes; j++)
+        if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }
 
@@ -343,9 +343,9 @@ void PairLJLongDipoleLong::write_restart(FILE *fp)
     for (j = i; j <= atom->ntypes; j++) {
       fwrite(&setflag[i][j],sizeof(int),1,fp);
       if (setflag[i][j]) {
-	fwrite(&epsilon_read[i][j],sizeof(double),1,fp);
-	fwrite(&sigma_read[i][j],sizeof(double),1,fp);
-	fwrite(&cut_lj_read[i][j],sizeof(double),1,fp);
+        fwrite(&epsilon_read[i][j],sizeof(double),1,fp);
+        fwrite(&sigma_read[i][j],sizeof(double),1,fp);
+        fwrite(&cut_lj_read[i][j],sizeof(double),1,fp);
       }
     }
 }
@@ -367,14 +367,14 @@ void PairLJLongDipoleLong::read_restart(FILE *fp)
       if (me == 0) fread(&setflag[i][j],sizeof(int),1,fp);
       MPI_Bcast(&setflag[i][j],1,MPI_INT,0,world);
       if (setflag[i][j]) {
-	if (me == 0) {
-	  fread(&epsilon_read[i][j],sizeof(double),1,fp);
-	  fread(&sigma_read[i][j],sizeof(double),1,fp);
-	  fread(&cut_lj_read[i][j],sizeof(double),1,fp);
-	}
-	MPI_Bcast(&epsilon_read[i][j],1,MPI_DOUBLE,0,world);
-	MPI_Bcast(&sigma_read[i][j],1,MPI_DOUBLE,0,world);
-	MPI_Bcast(&cut_lj_read[i][j],1,MPI_DOUBLE,0,world);
+        if (me == 0) {
+          fread(&epsilon_read[i][j],sizeof(double),1,fp);
+          fread(&sigma_read[i][j],sizeof(double),1,fp);
+          fread(&cut_lj_read[i][j],sizeof(double),1,fp);
+        }
+        MPI_Bcast(&epsilon_read[i][j],1,MPI_DOUBLE,0,world);
+        MPI_Bcast(&sigma_read[i][j],1,MPI_DOUBLE,0,world);
+        MPI_Bcast(&cut_lj_read[i][j],1,MPI_DOUBLE,0,world);
       }
     }
 }

--- a/src/KOKKOS/pair_coul_debye_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_debye_kokkos.cpp
@@ -241,7 +241,7 @@ void PairCoulDebyeKokkos<DeviceType>::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 

--- a/src/KSPACE/pair_born_coul_long.cpp
+++ b/src/KSPACE/pair_born_coul_long.cpp
@@ -250,7 +250,7 @@ void PairBornCoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/KSPACE/pair_buck_coul_long.cpp
+++ b/src/KSPACE/pair_buck_coul_long.cpp
@@ -240,7 +240,7 @@ void PairBuckCoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/KSPACE/pair_buck_long_coul_long.cpp
+++ b/src/KSPACE/pair_buck_long_coul_long.cpp
@@ -104,7 +104,7 @@ void PairBuckLongCoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_buck[i][j] = cut_buck_global;
   }
 }

--- a/src/KSPACE/pair_lj_cut_coul_long.cpp
+++ b/src/KSPACE/pair_lj_cut_coul_long.cpp
@@ -608,7 +608,7 @@ void PairLJCutCoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/KSPACE/pair_lj_cut_tip4p_long.cpp
+++ b/src/KSPACE/pair_lj_cut_tip4p_long.cpp
@@ -450,7 +450,7 @@ void PairLJCutTIP4PLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/KSPACE/pair_lj_long_coul_long.cpp
+++ b/src/KSPACE/pair_lj_long_coul_long.cpp
@@ -103,7 +103,7 @@ void PairLJLongCoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/KSPACE/pair_lj_long_tip4p_long.cpp
+++ b/src/KSPACE/pair_lj_long_tip4p_long.cpp
@@ -1439,8 +1439,8 @@ void PairLJLongTIP4PLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-	if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
+      for (j = i; j <= atom->ntypes; j++)
+        if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }
 

--- a/src/MC/pair_dsmc.cpp
+++ b/src/MC/pair_dsmc.cpp
@@ -230,7 +230,7 @@ void PairDSMC::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/MISC/pair_nm_cut.cpp
+++ b/src/MISC/pair_nm_cut.cpp
@@ -187,7 +187,7 @@ void PairNMCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/MISC/pair_nm_cut_coul_cut.cpp
+++ b/src/MISC/pair_nm_cut_coul_cut.cpp
@@ -213,7 +213,7 @@ void PairNMCutCoulCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_lj[i][j] = cut_lj_global;
           cut_coul[i][j] = cut_coul_global;

--- a/src/MISC/pair_nm_cut_coul_long.cpp
+++ b/src/MISC/pair_nm_cut_coul_long.cpp
@@ -255,7 +255,7 @@ void PairNMCutCoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/MOLECULE/pair_lj_cut_tip4p_cut.cpp
+++ b/src/MOLECULE/pair_lj_cut_tip4p_cut.cpp
@@ -441,7 +441,7 @@ void PairLJCutTIP4PCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }
@@ -596,7 +596,7 @@ void PairLJCutTIP4PCut::write_restart(FILE *fp)
   for (i = 1; i <= atom->ntypes; i++) {
     for (j = i; j <= atom->ntypes; j++) {
       fwrite(&setflag[i][j],sizeof(int),1,fp);
-      if (setflag[i][j]){
+      if (setflag[i][j]) {
         fwrite(&epsilon[i][j],sizeof(double),1,fp);
         fwrite(&sigma[i][j],sizeof(double),1,fp);
         fwrite(&cut_lj[i][j],sizeof(double),1,fp);

--- a/src/USER-AWPMD/pair_awpmd_cut.cpp
+++ b/src/USER-AWPMD/pair_awpmd_cut.cpp
@@ -454,16 +454,6 @@ void PairAWPMDCut::settings(int narg, char **arg){
     else if(!strcmp(arg[i],"flex_press"))
       flexible_pressure_flag = 1;
   }
-
-
-  // reset cutoffs that have been explicitly set
-  /*
-  if (allocated) {
-    int i,j;
-    for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-        if (setflag[i][j]) cut[i][j] = cut_global;
-  }*/
 }
 
 /* ----------------------------------------------------------------------
@@ -489,7 +479,7 @@ void PairAWPMDCut::coeff(int narg, char **arg)
   else{
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 

--- a/src/USER-CGSDK/pair_lj_sdk.cpp
+++ b/src/USER-CGSDK/pair_lj_sdk.cpp
@@ -248,7 +248,7 @@ void PairLJSDK::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-CGSDK/pair_lj_sdk_coul_long.cpp
+++ b/src/USER-CGSDK/pair_lj_sdk_coul_long.cpp
@@ -308,7 +308,7 @@ void PairLJSDKCoulLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/USER-DPD/pair_dpd_fdt.cpp
+++ b/src/USER-DPD/pair_dpd_fdt.cpp
@@ -267,7 +267,7 @@ void PairDPDfdt::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-DPD/pair_dpd_fdt_energy.cpp
+++ b/src/USER-DPD/pair_dpd_fdt_energy.cpp
@@ -351,7 +351,7 @@ void PairDPDfdtEnergy::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-DPD/pair_exp6_rx.cpp
+++ b/src/USER-DPD/pair_exp6_rx.cpp
@@ -562,7 +562,7 @@ void PairExp6rx::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 

--- a/src/USER-DRUDE/pair_lj_cut_thole_long.cpp
+++ b/src/USER-DRUDE/pair_lj_cut_thole_long.cpp
@@ -295,11 +295,11 @@ void PairLJCutTholeLong::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-          if (setflag[i][j]) {
-              thole[i][j] = thole_global;
-              cut_lj[i][j] = cut_lj_global;
-          }
+      for (j = i; j <= atom->ntypes; j++)
+        if (setflag[i][j]) {
+          thole[i][j] = thole_global;
+          cut_lj[i][j] = cut_lj_global;
+        }
   }
 }
 

--- a/src/USER-DRUDE/pair_thole.cpp
+++ b/src/USER-DRUDE/pair_thole.cpp
@@ -199,11 +199,11 @@ void PairThole::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-          if (setflag[i][j]) {
-              thole[i][j] = thole_global;
-              cut[i][j] = cut_global;
-          }
+      for (j = i; j <= atom->ntypes; j++)
+        if (setflag[i][j]) {
+          thole[i][j] = thole_global;
+          cut[i][j] = cut_global;
+        }
   }
 }
 

--- a/src/USER-EFF/pair_eff_cut.cpp
+++ b/src/USER-EFF/pair_eff_cut.cpp
@@ -846,7 +846,7 @@ void PairEffCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-FEP/pair_coul_cut_soft.cpp
+++ b/src/USER-FEP/pair_coul_cut_soft.cpp
@@ -168,7 +168,7 @@ void PairCoulCutSoft::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-FEP/pair_lj_cut_coul_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_coul_cut_soft.cpp
@@ -211,7 +211,7 @@ void PairLJCutCoulCutSoft::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_lj[i][j] = cut_lj_global;
           cut_coul[i][j] = cut_coul_global;

--- a/src/USER-FEP/pair_lj_cut_coul_long_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_coul_long_soft.cpp
@@ -582,7 +582,7 @@ void PairLJCutCoulLongSoft::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/USER-FEP/pair_lj_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_soft.cpp
@@ -462,7 +462,7 @@ void PairLJCutSoft::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-FEP/pair_lj_cut_tip4p_long_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_tip4p_long_soft.cpp
@@ -436,7 +436,7 @@ void PairLJCutTIP4PLongSoft::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/USER-FEP/pair_morse_soft.cpp
+++ b/src/USER-FEP/pair_morse_soft.cpp
@@ -222,7 +222,7 @@ void PairMorseSoft::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_buck_mdf.cpp
+++ b/src/USER-MISC/pair_buck_mdf.cpp
@@ -197,7 +197,7 @@ void PairBuckMDF::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_coul_diel.cpp
+++ b/src/USER-MISC/pair_coul_diel.cpp
@@ -168,7 +168,7 @@ void PairCoulDiel::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_gauss_cut.cpp
+++ b/src/USER-MISC/pair_gauss_cut.cpp
@@ -175,7 +175,7 @@ void PairGaussCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
@@ -209,7 +209,7 @@ void PairKolmogorovCrespiZ::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_lennard_mdf.cpp
+++ b/src/USER-MISC/pair_lennard_mdf.cpp
@@ -197,7 +197,7 @@ void PairLJ_AB_MDF::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/USER-MISC/pair_lj_mdf.cpp
+++ b/src/USER-MISC/pair_lj_mdf.cpp
@@ -197,7 +197,7 @@ void PairLJMDF::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/USER-MISC/pair_lj_sf.cpp
+++ b/src/USER-MISC/pair_lj_sf.cpp
@@ -181,7 +181,7 @@ void PairLJShiftedForce::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_lj_sf_dipole_sf.cpp
+++ b/src/USER-MISC/pair_lj_sf_dipole_sf.cpp
@@ -342,7 +342,7 @@ void PairLJSFDipoleSF::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_lj[i][j] = cut_lj_global;
           cut_coul[i][j] = cut_coul_global;

--- a/src/USER-MISC/pair_momb.cpp
+++ b/src/USER-MISC/pair_momb.cpp
@@ -199,7 +199,7 @@ void PairMomb::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_morse_smooth_linear.cpp
+++ b/src/USER-MISC/pair_morse_smooth_linear.cpp
@@ -171,7 +171,7 @@ void PairMorseSmoothLinear::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/USER-MISC/pair_srp.cpp
+++ b/src/USER-MISC/pair_srp.cpp
@@ -408,7 +408,7 @@ void PairSRP::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= bptype; i++)
-      for (j = i+1; j <= bptype; j++)
+      for (j = i; j <= bptype; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_beck.cpp
+++ b/src/pair_beck.cpp
@@ -181,10 +181,8 @@ void PairBeck::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-        if (setflag[i][j]) {
-          cut[i][j] = cut_global;
-        }
+      for (j = i; j <= atom->ntypes; j++)
+        if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }
 

--- a/src/pair_born.cpp
+++ b/src/pair_born.cpp
@@ -185,7 +185,7 @@ void PairBorn::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_born_coul_dsf.cpp
+++ b/src/pair_born_coul_dsf.cpp
@@ -226,9 +226,8 @@ void PairBornCoulDSF::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-        if (setflag[i][j])
-          cut_lj[i][j] = cut_lj_global;
+      for (j = i; j <= atom->ntypes; j++)
+        if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }
 

--- a/src/pair_born_coul_wolf.cpp
+++ b/src/pair_born_coul_wolf.cpp
@@ -229,7 +229,7 @@ void PairBornCoulWolf::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut_lj[i][j] = cut_lj_global;
   }
 }

--- a/src/pair_buck.cpp
+++ b/src/pair_buck.cpp
@@ -176,7 +176,7 @@ void PairBuck::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_buck_coul_cut.cpp
+++ b/src/pair_buck_coul_cut.cpp
@@ -205,7 +205,7 @@ void PairBuckCoulCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_lj[i][j] = cut_lj_global;
           cut_coul[i][j] = cut_coul_global;

--- a/src/pair_coul_cut.cpp
+++ b/src/pair_coul_cut.cpp
@@ -155,7 +155,7 @@ void PairCoulCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_coul_debye.cpp
+++ b/src/pair_coul_debye.cpp
@@ -126,7 +126,7 @@ void PairCoulDebye::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_dpd.cpp
+++ b/src/pair_dpd.cpp
@@ -207,7 +207,7 @@ void PairDPD::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_dpd_tstat.cpp
+++ b/src/pair_dpd_tstat.cpp
@@ -159,7 +159,7 @@ void PairDPDTstat::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_gauss.cpp
+++ b/src/pair_gauss.cpp
@@ -173,7 +173,7 @@ void PairGauss::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_lj96_cut.cpp
+++ b/src/pair_lj96_cut.cpp
@@ -442,7 +442,7 @@ void PairLJ96Cut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_lj_cubic.cpp
+++ b/src/pair_lj_cubic.cpp
@@ -179,14 +179,8 @@ void PairLJCubic::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 
-  // reset cutoffs that have been explicitly set
-
-  if (allocated) {
-    int i,j;
-    for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
-        if (setflag[i][j]) cut[i][j] = 0.0;
-  }
+  // NOTE: lj/cubic has no global cutoff. instead the cutoff is
+  // inferred from the lj parameters. so we must not reset cutoffs here.
 }
 
 /* ----------------------------------------------------------------------

--- a/src/pair_lj_cut.cpp
+++ b/src/pair_lj_cut.cpp
@@ -436,7 +436,7 @@ void PairLJCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_lj_cut_coul_cut.cpp
+++ b/src/pair_lj_cut_coul_cut.cpp
@@ -198,7 +198,7 @@ void PairLJCutCoulCut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_lj[i][j] = cut_lj_global;
           cut_coul[i][j] = cut_coul_global;

--- a/src/pair_lj_cut_coul_dsf.cpp
+++ b/src/pair_lj_cut_coul_dsf.cpp
@@ -224,7 +224,7 @@ void PairLJCutCoulDSF::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j])
           cut_lj[i][j] = cut_lj_global;
   }

--- a/src/pair_lj_expand.cpp
+++ b/src/pair_lj_expand.cpp
@@ -179,7 +179,7 @@ void PairLJExpand::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_lj_gromacs.cpp
+++ b/src/pair_lj_gromacs.cpp
@@ -204,7 +204,7 @@ void PairLJGromacs::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/pair_lj_smooth.cpp
+++ b/src/pair_lj_smooth.cpp
@@ -206,7 +206,7 @@ void PairLJSmooth::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) {
           cut_inner[i][j] = cut_inner_global;
           cut[i][j] = cut_global;

--- a/src/pair_lj_smooth_linear.cpp
+++ b/src/pair_lj_smooth_linear.cpp
@@ -175,7 +175,7 @@ void PairLJSmoothLinear::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j])
           cut[i][j] = cut_global;
   }

--- a/src/pair_mie_cut.cpp
+++ b/src/pair_mie_cut.cpp
@@ -447,7 +447,7 @@ void PairMIECut::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_morse.cpp
+++ b/src/pair_morse.cpp
@@ -165,7 +165,7 @@ void PairMorse::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_soft.cpp
+++ b/src/pair_soft.cpp
@@ -158,7 +158,7 @@ void PairSoft::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }

--- a/src/pair_yukawa.cpp
+++ b/src/pair_yukawa.cpp
@@ -162,7 +162,7 @@ void PairYukawa::settings(int narg, char **arg)
   if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
-      for (j = i+1; j <= atom->ntypes; j++)
+      for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
   }
 }


### PR DESCRIPTION
This was reported by frank uhlig on lammps-users for lj/cut, but applies to many more pair styles.
Those pair styles have a piece of code like the following in their `PairXXX::settings()` function:
```c++
  if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
       for (j = i+1; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
```
However, this does not result in the behavior documented for the `pair_style` command:
_Typically, the global cutoff value can be overridden for a specific pair of atom types by the pair_coeff command. The pair style settings (including global cutoffs) can be changed by a subsequent pair_style command using the same style. This will reset the cutoffs for all atom type pairs, including those previously set explicitly by a pair_coeff command. The exceptions to this are that pair_style table and hybrid settings cannot be reset. A new pair_style command for these styles will wipe out all previously specified pair_coeff values._
Instead this code has to be changed to:
```c++
  if (allocated) {
     int i,j;
     for (i = 1; i <= atom->ntypes; i++)
       for (j = i; j <= atom->ntypes; j++)
         if (setflag[i][j]) cut[i][j] = cut_global;
```
So far, this bug has been found in 79 pair styles.
