### PR TITLE
convert bigint values for bonds/angles/dihedrals/impropers to doubles

### DIFF
--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -1385,11 +1385,6 @@ int Thermo::evaluate_keyword(char *word, double *answer)
   else if (strcmp(word,"ylat") == 0) compute_ylat();
   else if (strcmp(word,"zlat") == 0) compute_zlat();
 
-  else if (strcmp(word,"bonds") == 0) compute_bonds();
-  else if (strcmp(word,"angles") == 0) compute_angles();
-  else if (strcmp(word,"dihedrals") == 0) compute_dihedrals();
-  else if (strcmp(word,"impropers") == 0) compute_impropers();
-
   else if (strcmp(word,"pxx") == 0) {
     if (!pressure)
       error->all(FLERR,"Thermo keyword in variable requires "

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -1145,6 +1145,22 @@ int Thermo::evaluate_keyword(char *word, double *answer)
     compute_atoms();
     dvalue = bivalue;
 
+  } else if (strcmp(word,"bonds") == 0) {
+    compute_bonds();
+    dvalue = bivalue;
+
+  } else if (strcmp(word,"angles") == 0) {
+    compute_angles();
+    dvalue = bivalue;
+
+  } else if (strcmp(word,"dihedrals") == 0) {
+    compute_dihedrals();
+    dvalue = bivalue;
+
+  } else if (strcmp(word,"impropers") == 0) {
+    compute_impropers();
+    dvalue = bivalue;
+
   } else if (strcmp(word,"temp") == 0) {
     if (!temperature)
       error->all(FLERR,"Thermo keyword in variable requires "


### PR DESCRIPTION
This fixes the bug reported on lammps-users by Kurt Sjoblom (Drexel).
When evaluating thermo keywords in variable expressions, their value needs
to be converted into a double by assigning `dvalue` to `bivalue`. This wasn't done
for the keywords `bonds`, `angles`, `dihedrals`, and `impropers`.