### PR TITLE
Doc and example fixes

### DIFF
--- a/doc/src/pair_python.txt
+++ b/doc/src/pair_python.txt
@@ -107,15 +107,15 @@ class LJCutMelt(LAMMPSPairPotential):
         # set coeffs: 48*eps*sig**12, 24*eps*sig**6,
         #              4*eps*sig**12,  4*eps*sig**6
         self.units = 'lj'
-        self.coeff = {'lj'  : {'lj'  : (48.0,24.0,4.0,4.0)}}
+        self.coeff = \{'lj'  : \{'lj'  : (48.0,24.0,4.0,4.0)\}\}
 :pre
 
 The class also has to provide two methods for the computation of the
 potential energy and forces, which have be named {compute_force},
 and {compute_energy}, which both take 3 numerical arguments:
 
-  rsq   = the square of the distance between a pair of atoms (float) :li
-  itype = the (numerical) type of the first atom :li
+  rsq   = the square of the distance between a pair of atoms (float) :l
+  itype = the (numerical) type of the first atom :l
   jtype = the (numerical) type of the second atom :ul
 
 This functions need to compute the force and the energy, respectively,

--- a/examples/ASPHERE/poly/in.poly
+++ b/examples/ASPHERE/poly/in.poly
@@ -62,6 +62,7 @@ pair_coeff	3 3 1.0 1.5
 pair_coeff	1 4 0.0 1.0 0.5
 pair_coeff	2 4 0.0 1.0 1.0
 pair_coeff	3 4 0.0 1.0 0.75
+pair_coeff	4 4 0.0 1.0 0.0
 
 delete_atoms	overlap 1.0 small big
 

--- a/examples/ASPHERE/poly/in.poly.mp
+++ b/examples/ASPHERE/poly/in.poly.mp
@@ -62,6 +62,7 @@ pair_coeff	3 3 1.0 1.5
 pair_coeff	1 4 0.0 1.0 0.5
 pair_coeff	2 4 0.0 1.0 1.0
 pair_coeff	3 4 0.0 1.0 0.75
+pair_coeff	4 4 0.0 1.0 0.0
 
 delete_atoms	overlap 1.0 small big
 


### PR DESCRIPTION
This PR fixes an issue with the pair style `python` docs that prevents building the pdf version of the manual. It also cleans up some formatting issues in the same doc file. Finally, it corrects two example inputs that assumed a buggy behavior of `Pair::settings()`, which was addressed in PR #485.