### PR TITLE
Fix bug where fix/compute style names were not correctly set with suffixes

### DIFF
--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -424,7 +424,7 @@ void PairGranHookeHistory::init_style()
     fixarg[1] = (char *) "all";
     fixarg[2] = (char *) "SHEAR_HISTORY";
     fixarg[3] = dnumstr;
-    modify->add_fix(4,fixarg,1);
+    modify->add_fix(4,fixarg);
     delete [] fixarg;
     fix_history = (FixShearHistory *) modify->fix[modify->nfix-1];
     fix_history->pair = this;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1478,7 +1478,7 @@ void Input::comm_style()
 
 void Input::compute()
 {
-  modify->add_compute(narg,arg,1);
+  modify->add_compute(narg,arg);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1556,7 +1556,7 @@ void Input::dump_modify()
 
 void Input::fix()
 {
-  modify->add_fix(narg,arg,1);
+  modify->add_fix(narg,arg);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -819,20 +819,26 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
 
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
-      char estyle[256];
+      int n = strlen(arg[2])+strlen(lmp->suffix)+2;
+      char *estyle = new char[n];
       sprintf(estyle,"%s/%s",arg[2],lmp->suffix);
       if (fix_map->find(estyle) != fix_map->end()) {
         FixCreator fix_creator = (*fix_map)[estyle];
         fix[ifix] = fix_creator(lmp,narg,arg);
-      }
+        delete[] fix[ifix]->style;
+        fix[ifix]->style = estyle;
+      } else delete[] estyle;
     }
     if (fix[ifix] == NULL && lmp->suffix2) {
-      char estyle[256];
+      int n = strlen(arg[2])+strlen(lmp->suffix2)+2;
+      char *estyle = new char[n];
       sprintf(estyle,"%s/%s",arg[2],lmp->suffix2);
       if (fix_map->find(estyle) != fix_map->end()) {
         FixCreator fix_creator = (*fix_map)[estyle];
         fix[ifix] = fix_creator(lmp,narg,arg);
-      }
+        delete[] fix[ifix]->style;
+        fix[ifix]->style = estyle;
+      } else delete[] estyle;
     }
   }
 
@@ -1018,20 +1024,26 @@ void Modify::add_compute(int narg, char **arg, int trysuffix)
 
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
-      char estyle[256];
+      int n = strlen(arg[2])+strlen(lmp->suffix)+2;
+      char *estyle = new char[n];
       sprintf(estyle,"%s/%s",arg[2],lmp->suffix);
       if (compute_map->find(estyle) != compute_map->end()) {
         ComputeCreator compute_creator = (*compute_map)[estyle];
         compute[ncompute] = compute_creator(lmp,narg,arg);
-      }
+        delete[] compute[ncompute]->style;
+        compute[ncompute]->style = estyle;
+      } else delete[] estyle;
     }
     if (compute[ncompute] == NULL && lmp->suffix2) {
-      char estyle[256];
+      int n = strlen(arg[2])+strlen(lmp->suffix2)+2;
+      char *estyle = new char[n];
       sprintf(estyle,"%s/%s",arg[2],lmp->suffix2);
       if (compute_map->find(estyle) != compute_map->end()) {
         ComputeCreator compute_creator = (*compute_map)[estyle];
         compute[ncompute] = compute_creator(lmp,narg,arg);
-      }
+        delete[] compute[ncompute]->style;
+        compute[ncompute]->style = estyle;
+      } else delete[] estyle;
     }
   }
 

--- a/src/modify.h
+++ b/src/modify.h
@@ -92,14 +92,14 @@ class Modify : protected Pointers {
   virtual int min_dof();
   virtual int min_reset_ref();
 
-  void add_fix(int, char **, int trysuffix=0);
+  void add_fix(int, char **, int trysuffix=1);
   void modify_fix(int, char **);
   void delete_fix(const char *);
   int find_fix(const char *);
   int find_fix_by_style(const char *);
   int check_package(const char *);
 
-  void add_compute(int, char **, int trysuffix=0);
+  void add_compute(int, char **, int trysuffix=1);
   void modify_compute(int, char **);
   void delete_compute(const char *);
   int find_compute(const char *);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -49,18 +49,18 @@ Output::Output(LAMMPS *lmp) : Pointers(lmp)
   newarg[0] = (char *) "thermo_temp";
   newarg[1] = (char *) "all";
   newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg,1);
+  modify->add_compute(3,newarg);
 
   newarg[0] = (char *) "thermo_press";
   newarg[1] = (char *) "all";
   newarg[2] = (char *) "pressure";
   newarg[3] = (char *) "thermo_temp";
-  modify->add_compute(4,newarg,1);
+  modify->add_compute(4,newarg);
 
   newarg[0] = (char *) "thermo_pe";
   newarg[1] = (char *) "all";
   newarg[2] = (char *) "pe";
-  modify->add_compute(3,newarg,1);
+  modify->add_compute(3,newarg);
 
   delete [] newarg;
 


### PR DESCRIPTION
This pull request addresses an issue, where style names for fixes and computes are not properly recorded to include the suffix when created with suffixes enabled. Instead the style name would be that of the non-suffix version.

Also, the default behavior is changed to be consistent with other style creation setups, i.e. the suffix is now always tried by default unless explicitly set to not use it. This will likely need some careful testing to determine, whether something breaks, that was written in expectation of the previous behavior, e.g. in KOKKOS.