### PR TITLE
Using correct ndegree instead of nnn

### DIFF
--- a/src/compute_hexorder_atom.cpp
+++ b/src/compute_hexorder_atom.cpp
@@ -248,7 +248,7 @@ inline void ComputeHexOrderAtom::calc_qn_complex(double delx, double dely, doubl
   double x = delx*rinv;
   double y = dely*rinv;
   std::complex<double> z(x, y);
-  std::complex<double> zn = pow(z, nnn);
+  std::complex<double> zn = pow(z, ndegree);
   u = real(zn);
   v = imag(zn);
 }
@@ -259,9 +259,9 @@ inline void ComputeHexOrderAtom::calc_qn_complex(double delx, double dely, doubl
 inline void ComputeHexOrderAtom::calc_qn_trig(double delx, double dely, double &u, double &v) {
   double ntheta;
   if(fabs(delx) <= MY_EPSILON) {
-    if(dely > 0.0) ntheta = nnn * MY_PI / 2.0;
-    else ntheta = nnn * 3.0 * MY_PI / 2.0;
-  } else ntheta = nnn * atan(dely / delx);
+    if(dely > 0.0) ntheta = ndegree * MY_PI / 2.0;
+    else ntheta = ndegree * 3.0 * MY_PI / 2.0;
+  } else ntheta = ndegree * atan(dely / delx);
   u = cos(ntheta);
   v = sin(ntheta);
 }


### PR DESCRIPTION
I'm working on a 2d material and was going to use compute hexorder/atom to measure the order parameter. I'm adding a feature where you can use voronoi neighbors instead of the nearest `nnn` neighbors. When I looked through the code, it the exponent `ndegree` is not used and `nnn` is wrongly used in [line 251](https://github.com/lammps/lammps/blob/master/src/compute_hexorder_atom.cpp#L251) and [lines 262-264](https://github.com/lammps/lammps/blob/master/src/compute_hexorder_atom.cpp#L262).