### PR TITLE
add "atomonly" optimized neighbor list build styles to USER-OMP

### DIFF
--- a/src/USER-OMP/npair_full_bin_atomonly_omp.cpp
+++ b/src/USER-OMP/npair_full_bin_atomonly_omp.cpp
@@ -1,0 +1,106 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "npair_full_bin_atomonly_omp.h"
+#include "npair_omp.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "atom.h"
+#include "atom_vec.h"
+#include "domain.h"
+#include "my_page.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+using namespace NeighConst;
+
+/* ---------------------------------------------------------------------- */
+
+NPairFullBinAtomonlyOmp::NPairFullBinAtomonlyOmp(LAMMPS *lmp) : NPair(lmp) {}
+
+/* ----------------------------------------------------------------------
+   binned neighbor list construction for all neighbors
+   every neighbor pair appears in list of both atoms i and j
+------------------------------------------------------------------------- */
+
+void NPairFullBinAtomonlyOmp::build(NeighList *list)
+{
+  const int nlocal = (includegroup) ? atom->nfirst : atom->nlocal;
+
+  NPAIR_OMP_INIT;
+#if defined(_OPENMP)
+#pragma omp parallel default(none) shared(list)
+#endif
+  NPAIR_OMP_SETUP(nlocal);
+
+  int i,j,k,n,itype,jtype,ibin;
+  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
+  int *neighptr;
+
+  double **x = atom->x;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  tagint *molecule = atom->molecule;
+
+  int *ilist = list->ilist;
+  int *numneigh = list->numneigh;
+  int **firstneigh = list->firstneigh;
+
+  // each thread has its own page allocator
+  MyPage<int> &ipage = list->ipage[tid];
+  ipage.reset();
+
+  // loop over owned atoms, storing neighbors
+
+  for (i = ifrom; i < ito; i++) {
+
+    n = 0;
+    neighptr = ipage.vget();
+
+    itype = type[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+
+    // loop over all atoms in surrounding bins in stencil including self
+    // skip i = j
+
+    ibin = atom2bin[i];
+
+    for (k = 0; k < nstencil; k++) {
+      for (j = binhead[ibin+stencil[k]]; j >= 0; j = bins[j]) {
+        if (i == j) continue;
+
+        jtype = type[j];
+        if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+
+        delx = xtmp - x[j][0];
+        dely = ytmp - x[j][1];
+        delz = ztmp - x[j][2];
+        rsq = delx*delx + dely*dely + delz*delz;
+
+        if (rsq <= cutneighsq[itype][jtype]) neighptr[n++] = j;
+      }
+    }
+
+    ilist[i] = i;
+    firstneigh[i] = neighptr;
+    numneigh[i] = n;
+    ipage.vgot(n);
+    if (ipage.status())
+      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+  }
+  NPAIR_OMP_CLOSE;
+  list->inum = nlocal;
+  list->gnum = 0;
+}

--- a/src/USER-OMP/npair_full_bin_atomonly_omp.h
+++ b/src/USER-OMP/npair_full_bin_atomonly_omp.h
@@ -1,0 +1,44 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef NPAIR_CLASS
+
+NPairStyle(full/bin/atomonly/omp,
+           NPairFullBinAtomonlyOmp,
+           NP_FULL | NP_BIN | NP_ATOMONLY | NP_OMP |
+           NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI)
+
+#else
+
+#ifndef LMP_NPAIR_FULL_BIN_ATOMONLY_OMP_H
+#define LMP_NPAIR_FULL_BIN_ATOMONLY_OMP_H
+
+#include "npair.h"
+
+namespace LAMMPS_NS {
+
+class NPairFullBinAtomonlyOmp : public NPair {
+ public:
+  NPairFullBinAtomonlyOmp(class LAMMPS *);
+  ~NPairFullBinAtomonlyOmp() {}
+  void build(class NeighList *);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+*/

--- a/src/USER-OMP/npair_half_bin_atomonly_newton_omp.cpp
+++ b/src/USER-OMP/npair_half_bin_atomonly_newton_omp.cpp
@@ -1,0 +1,126 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "npair_half_bin_atomonly_newton_omp.h"
+#include "npair_omp.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "atom.h"
+#include "atom_vec.h"
+#include "molecule.h"
+#include "domain.h"
+#include "my_page.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+NPairHalfBinAtomonlyNewtonOmp::NPairHalfBinAtomonlyNewtonOmp(LAMMPS *lmp) : NPair(lmp) {}
+
+/* ----------------------------------------------------------------------
+   binned neighbor list construction with full Newton's 3rd law
+   each owned atom i checks its own bin and other bins in Newton stencil
+   every pair stored exactly once by some processor
+------------------------------------------------------------------------- */
+
+void NPairHalfBinAtomonlyNewtonOmp::build(NeighList *list)
+{
+  const int nlocal = (includegroup) ? atom->nfirst : atom->nlocal;
+
+  NPAIR_OMP_INIT;
+#if defined(_OPENMP)
+#pragma omp parallel default(none) shared(list)
+#endif
+  NPAIR_OMP_SETUP(nlocal);
+
+  int i,j,k,n,itype,jtype,ibin;
+  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
+  int *neighptr;
+
+  // loop over each atom, storing neighbors
+
+  double **x = atom->x;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  tagint *molecule = atom->molecule;
+
+  int *ilist = list->ilist;
+  int *numneigh = list->numneigh;
+  int **firstneigh = list->firstneigh;
+
+  // each thread has its own page allocator
+  MyPage<int> &ipage = list->ipage[tid];
+  ipage.reset();
+
+  for (i = ifrom; i < ito; i++) {
+
+    n = 0;
+    neighptr = ipage.vget();
+
+    itype = type[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+
+    // loop over rest of atoms in i's bin, ghosts are at end of linked list
+    // if j is owned atom, store it, since j is beyond i in linked list
+    // if j is ghost, only store if j coords are "above and to the right" of i
+
+    for (j = bins[i]; j >= 0; j = bins[j]) {
+      if (j >= nlocal) {
+        if (x[j][2] < ztmp) continue;
+        if (x[j][2] == ztmp) {
+          if (x[j][1] < ytmp) continue;
+          if (x[j][1] == ytmp && x[j][0] < xtmp) continue;
+        }
+      }
+
+      jtype = type[j];
+      if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq <= cutneighsq[itype][jtype]) neighptr[n++] = j;
+    }
+
+    // loop over all atoms in other bins in stencil, store every pair
+
+    ibin = atom2bin[i];
+    for (k = 0; k < nstencil; k++) {
+      for (j = binhead[ibin+stencil[k]]; j >= 0; j = bins[j]) {
+        jtype = type[j];
+        if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+
+        delx = xtmp - x[j][0];
+        dely = ytmp - x[j][1];
+        delz = ztmp - x[j][2];
+        rsq = delx*delx + dely*dely + delz*delz;
+
+        if (rsq <= cutneighsq[itype][jtype]) neighptr[n++] = j;
+      }
+    }
+
+    ilist[i] = i;
+    firstneigh[i] = neighptr;
+    numneigh[i] = n;
+    ipage.vgot(n);
+    if (ipage.status())
+      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+  }
+  NPAIR_OMP_CLOSE;
+  list->inum = nlocal;
+}

--- a/src/USER-OMP/npair_half_bin_atomonly_newton_omp.h
+++ b/src/USER-OMP/npair_half_bin_atomonly_newton_omp.h
@@ -1,0 +1,43 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef NPAIR_CLASS
+
+NPairStyle(half/bin/atomonly/newton/omp,
+           NPairHalfBinAtomonlyNewtonOmp,
+           NP_HALF | NP_BIN | NP_ATOMONLY | NP_NEWTON | NP_OMP | NP_ORTHO)
+
+#else
+
+#ifndef LMP_NPAIR_HALF_BIN_ATOMONLY_NEWTON_OMP_H
+#define LMP_NPAIR_HALF_BIN_ATOMONLY_NEWTON_OMP_H
+
+#include "npair.h"
+
+namespace LAMMPS_NS {
+
+class NPairHalfBinAtomonlyNewtonOmp : public NPair {
+ public:
+  NPairHalfBinAtomonlyNewtonOmp(class LAMMPS *);
+  ~NPairHalfBinAtomonlyNewtonOmp() {}
+  void build(class NeighList *);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+*/


### PR DESCRIPTION
USER-OMP was missing the `half/bin/atomonly/newton/omp` and `full/bin/atomonly/omp` npair styles.
this PR implements them.