### PR TITLE
Setting lattice to NULL before creating

### DIFF
--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1697,6 +1697,7 @@ int Domain::ownatom(int id, double *x, imageint *image, int shrinkexceed)
 void Domain::set_lattice(int narg, char **arg)
 {
   if (lattice) delete lattice;
+  lattice = NULL;
   lattice = new Lattice(lmp,narg,arg);
 }
 


### PR DESCRIPTION
If an illegal lattice command is given, LAMMPS may delete a deleted pointer unless NULL'ed before creating new lattice.