### PR TITLE
Implemented pair style vashishta in GPU package

### DIFF
--- a/doc/src/Section_errors.txt
+++ b/doc/src/Section_errors.txt
@@ -8890,6 +8890,14 @@ This is a requirement to use this potential. :dd
 
 See the newton command.  This is a restriction to use this potential. :dd
 
+{Pair style vashishta/gpu requires atom IDs} :dt
+
+This is a requirement to use this potential. :dd
+
+{Pair style vashishta/gpu requires newton pair off} :dt
+
+See the newton command.  This is a restriction to use this potential. :dd
+
 {Pair style tersoff/gpu requires atom IDs} :dt
 
 This is a requirement to use the tersoff/gpu potential. :dd

--- a/doc/src/pair_vashishta.txt
+++ b/doc/src/pair_vashishta.txt
@@ -7,6 +7,7 @@
 :line
 
 pair_style vashishta command :h3
+pair_style vashishta/gpu command :h3
 pair_style vashishta/omp command :h3
 pair_style vashishta/kk command :h3
 pair_style vashishta/table command :h3

--- a/lib/gpu/Makefile.linux.mixed
+++ b/lib/gpu/Makefile.linux.mixed
@@ -8,7 +8,6 @@
 EXTRAMAKE = Makefile.lammps.standard
 
 CUDA_HOME = /usr/local/cuda
-CUDA_HOME = /home/projects/openmpi/1.8.1/intel/13.1.SP1.106/cuda/6.0.37
 NVCC = nvcc
 
 # Kepler CUDA

--- a/lib/gpu/Nvidia.makefile
+++ b/lib/gpu/Nvidia.makefile
@@ -63,6 +63,7 @@ OBJS = $(OBJ_DIR)/lal_atom.o $(OBJ_DIR)/lal_ans.o \
        $(OBJ_DIR)/lal_lj_coul_debye.o $(OBJ_DIR)/lal_lj_coul_debye_ext.o \
        $(OBJ_DIR)/lal_coul_dsf.o $(OBJ_DIR)/lal_coul_dsf_ext.o \
        $(OBJ_DIR)/lal_sw.o $(OBJ_DIR)/lal_sw_ext.o \
+       $(OBJ_DIR)/lal_vashishta.o $(OBJ_DIR)/lal_vashishta_ext.o \
        $(OBJ_DIR)/lal_beck.o $(OBJ_DIR)/lal_beck_ext.o \
        $(OBJ_DIR)/lal_mie.o $(OBJ_DIR)/lal_mie_ext.o \
        $(OBJ_DIR)/lal_soft.o $(OBJ_DIR)/lal_soft_ext.o \
@@ -117,6 +118,7 @@ CBNS = $(OBJ_DIR)/device.cubin $(OBJ_DIR)/device_cubin.h \
        $(OBJ_DIR)/lj_coul_debye.cubin $(OBJ_DIR)/lj_coul_debye_cubin.h \
        $(OBJ_DIR)/coul_dsf.cubin $(OBJ_DIR)/coul_dsf_cubin.h \
        $(OBJ_DIR)/sw.cubin $(OBJ_DIR)/sw_cubin.h \
+       $(OBJ_DIR)/vashishta.cubin $(OBJ_DIR)/vashishta_cubin.h \
        $(OBJ_DIR)/beck.cubin $(OBJ_DIR)/beck_cubin.h \
        $(OBJ_DIR)/mie.cubin $(OBJ_DIR)/mie_cubin.h \
        $(OBJ_DIR)/soft.cubin $(OBJ_DIR)/soft_cubin.h \
@@ -612,6 +614,18 @@ $(OBJ_DIR)/lal_coul_dsf.o: $(ALL_H) lal_coul_dsf.h lal_coul_dsf.cpp $(OBJ_DIR)/c
 
 $(OBJ_DIR)/lal_coul_dsf_ext.o: $(ALL_H) lal_coul_dsf.h lal_coul_dsf_ext.cpp lal_base_charge.h
 	$(CUDR) -o $@ -c lal_coul_dsf_ext.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/vashishta.cubin: lal_vashishta.cu lal_precision.h lal_preprocessor.h
+	$(CUDA) --cubin -DNV_KERNEL -o $@ lal_vashishta.cu
+
+$(OBJ_DIR)/vashishta_cubin.h: $(OBJ_DIR)/vashishta.cubin $(OBJ_DIR)/vashishta.cubin
+	$(BIN2C) -c -n vashishta $(OBJ_DIR)/vashishta.cubin > $(OBJ_DIR)/vashishta_cubin.h
+
+$(OBJ_DIR)/lal_vashishta.o: $(ALL_H) lal_vashishta.h lal_vashishta.cpp $(OBJ_DIR)/vashishta_cubin.h $(OBJ_DIR)/lal_base_three.o
+	$(CUDR) -o $@ -c lal_vashishta.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_vashishta_ext.o: $(ALL_H) lal_vashishta.h lal_vashishta_ext.cpp lal_base_three.h
+	$(CUDR) -o $@ -c lal_vashishta_ext.cpp -I$(OBJ_DIR)
 
 $(OBJ_DIR)/sw.cubin: lal_sw.cu lal_precision.h lal_preprocessor.h
 	$(CUDA) --cubin -DNV_KERNEL -o $@ lal_sw.cu

--- a/lib/gpu/Opencl.makefile
+++ b/lib/gpu/Opencl.makefile
@@ -52,6 +52,7 @@ OBJS = $(OBJ_DIR)/lal_atom.o $(OBJ_DIR)/lal_answer.o \
        $(OBJ_DIR)/lal_lj_coul_debye.o $(OBJ_DIR)/lal_lj_coul_debye_ext.o \
        $(OBJ_DIR)/lal_coul_dsf.o $(OBJ_DIR)/lal_coul_dsf_ext.o \
        $(OBJ_DIR)/lal_sw.o $(OBJ_DIR)/lal_sw_ext.o \
+       $(OBJ_DIR)/lal_vashishta.o $(OBJ_DIR)/lal_vashishta_ext.o \
        $(OBJ_DIR)/lal_beck.o $(OBJ_DIR)/lal_beck_ext.o \
        $(OBJ_DIR)/lal_mie.o $(OBJ_DIR)/lal_mie_ext.o \
        $(OBJ_DIR)/lal_soft.o $(OBJ_DIR)/lal_soft_ext.o \
@@ -92,7 +93,7 @@ KERS = $(OBJ_DIR)/device_cl.h $(OBJ_DIR)/atom_cl.h \
        $(OBJ_DIR)/tersoff_cl.h $(OBJ_DIR)/tersoff_zbl_cl.h \
        $(OBJ_DIR)/tersoff_mod_cl.h $(OBJ_DIR)/coul_cl.h \
        $(OBJ_DIR)/coul_debye_cl.h $(OBJ_DIR)/zbl_cl.h \
-       $(OBJ_DIR)/lj_cubic_cl.h
+       $(OBJ_DIR)/lj_cubic_cl.h $(OBJ_DIR)/vashishta_cl.h
 
 
 OCL_EXECS = $(BIN_DIR)/ocl_get_devices
@@ -449,6 +450,15 @@ $(OBJ_DIR)/lal_sw.o: $(ALL_H) lal_sw.h lal_sw.cpp  $(OBJ_DIR)/sw_cl.h $(OBJ_DIR)
 
 $(OBJ_DIR)/lal_sw_ext.o: $(ALL_H) lal_sw.h lal_sw_ext.cpp lal_base_three.h
 	$(OCL) -o $@ -c lal_sw_ext.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/vashishta_cl.h: lal_vashishta.cu $(PRE1_H)
+	$(BSH) ./geryon/file_to_cstr.sh vashishta $(PRE1_H) lal_vashishta.cu $(OBJ_DIR)/vashishta_cl.h;
+
+$(OBJ_DIR)/lal_vashishta.o: $(ALL_H) lal_vashishta.h lal_vashishta.cpp  $(OBJ_DIR)/vashishta_cl.h $(OBJ_DIR)/vashishta_cl.h $(OBJ_DIR)/lal_base_three.o
+	$(OCL) -o $@ -c lal_vashishta.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_vashishta_ext.o: $(ALL_H) lal_vashishta.h lal_vashishta_ext.cpp lal_base_three.h
+	$(OCL) -o $@ -c lal_vashishta_ext.cpp -I$(OBJ_DIR)
 
 $(OBJ_DIR)/beck_cl.h: lal_beck.cu $(PRE1_H)
 	$(BSH) ./geryon/file_to_cstr.sh beck $(PRE1_H) lal_beck.cu $(OBJ_DIR)/beck_cl.h;

--- a/lib/gpu/lal_vashishta.cpp
+++ b/lib/gpu/lal_vashishta.cpp
@@ -1,0 +1,283 @@
+/***************************************************************************
+                                vashishta.cpp
+                             -------------------
+                            Anders Hafreager (UiO)
+
+  Class for acceleration of the vashishta pair style.
+
+ __________________________________________________________________________
+    This file is part of the LAMMPS Accelerator Library (LAMMPS_AL)
+ __________________________________________________________________________
+
+    begin                : Mon June 12, 2017
+    email                : andershaf@gmail.com
+ ***************************************************************************/
+
+#if defined(USE_OPENCL)
+#include "vashishta_cl.h"
+#elif defined(USE_CUDART)
+const char *vashishta=0;
+#else
+#include "vashishta_cubin.h"
+#endif
+
+#include "lal_vashishta.h"
+#include <cassert>
+using namespace LAMMPS_AL;
+#define VashishtaT Vashishta<numtyp, acctyp>
+
+extern Device<PRECISION,ACC_PRECISION> device;
+
+template <class numtyp, class acctyp>
+VashishtaT::Vashishta() : BaseThree<numtyp,acctyp>(), _allocated(false) {
+}
+
+template <class numtyp, class acctyp>
+VashishtaT::~Vashishta() {
+  clear();
+}
+
+template <class numtyp, class acctyp>
+int VashishtaT::bytes_per_atom(const int max_nbors) const {
+  return this->bytes_per_atom_atomic(max_nbors);
+}
+
+template <class numtyp, class acctyp>
+int VashishtaT::init(const int ntypes, const int nlocal, const int nall, const int max_nbors,
+           const double cell_size, const double gpu_split, FILE *_screen,
+           int* host_map, const int nelements, int*** host_elem2param, const int nparams,
+           const double* cutsq, const double* r0,
+           const double* gamma, const double* eta,
+           const double* lam1inv, const double* lam4inv,
+           const double* zizj, const double* mbigd,
+           const double* dvrc, const double* big6w, 
+           const double* heta, const double* bigh,
+           const double* bigw, const double* c0,
+           const double* costheta, const double* bigb,
+           const double* big2b, const double* bigc)
+{
+  int success;
+  success=this->init_three(nlocal,nall,max_nbors,0,cell_size,gpu_split,
+                           _screen,vashishta,"k_vashishta","k_vashishta_three_center",
+                           "k_vashishta_three_end");
+  if (success!=0)
+    return success;
+
+  // If atom type constants fit in shared memory use fast kernel
+  int lj_types=ntypes;
+  shared_types=false;
+  int max_shared_types=this->device->max_shared_types();
+  if (lj_types<=max_shared_types && this->_block_size>=max_shared_types) {
+    lj_types=max_shared_types;
+    shared_types=true;
+  }
+  _lj_types=lj_types;
+
+  _nparams = nparams;
+  _nelements = nelements;
+
+  UCL_H_Vec<numtyp4> dview(nparams,*(this->ucl_device),
+                             UCL_WRITE_ONLY);
+
+  for (int i=0; i<nparams; i++) {
+    dview[i].x=(numtyp)0;
+    dview[i].y=(numtyp)0;
+    dview[i].z=(numtyp)0;
+    dview[i].w=(numtyp)0;
+  }
+
+  // pack coefficients into arrays
+  param1.alloc(nparams,*(this->ucl_device),UCL_READ_ONLY);
+
+  for (int i=0; i<nparams; i++) {
+    dview[i].x=static_cast<numtyp>(eta[i]);
+    dview[i].y=static_cast<numtyp>(lam1inv[i]);
+    dview[i].z=static_cast<numtyp>(lam4inv[i]);
+    dview[i].w=static_cast<numtyp>(zizj[i]);
+  }
+
+  ucl_copy(param1,dview,false);
+  param1_tex.get_texture(*(this->pair_program),"param1_tex");
+  param1_tex.bind_float(param1,4);
+
+  param2.alloc(nparams,*(this->ucl_device),UCL_READ_ONLY);
+
+  for (int i=0; i<nparams; i++) {
+    dview[i].x=static_cast<numtyp>(mbigd[i]);
+    dview[i].y=static_cast<numtyp>(dvrc[i]);
+    dview[i].z=static_cast<numtyp>(big6w[i]);
+    dview[i].w=static_cast<numtyp>(heta[i]);
+  }
+
+  ucl_copy(param2,dview,false);
+  param2_tex.get_texture(*(this->pair_program),"param2_tex");
+  param2_tex.bind_float(param2,4);
+
+  param3.alloc(nparams,*(this->ucl_device),UCL_READ_ONLY);
+
+  for (int i=0; i<nparams; i++) {
+    dview[i].x=static_cast<numtyp>(bigh[i]);
+    dview[i].y=static_cast<numtyp>(bigw[i]);
+    dview[i].z=static_cast<numtyp>(dvrc[i]);
+    dview[i].w=static_cast<numtyp>(c0[i]);
+  }
+
+  ucl_copy(param3,dview,false);
+  param3_tex.get_texture(*(this->pair_program),"param3_tex");
+  param3_tex.bind_float(param3,4);
+
+  param4.alloc(nparams,*(this->ucl_device),UCL_READ_ONLY);
+
+  for (int i=0; i<nparams; i++) {
+    double r0sq = r0[i]*r0[i]-1e-4; // TODO: should we have the 1e-4?
+
+    dview[i].x=static_cast<numtyp>(r0sq);
+    dview[i].y=static_cast<numtyp>(gamma[i]);
+    dview[i].z=static_cast<numtyp>(cutsq[i]);
+    dview[i].w=static_cast<numtyp>(r0[i]);
+  }
+
+  ucl_copy(param4,dview,false);
+  param4_tex.get_texture(*(this->pair_program),"param4_tex");
+  param4_tex.bind_float(param4,4);
+
+  param5.alloc(nparams,*(this->ucl_device),UCL_READ_ONLY);
+
+  for (int i=0; i<nparams; i++) {
+    dview[i].x=static_cast<numtyp>(bigc[i]);
+    dview[i].y=static_cast<numtyp>(costheta[i]);
+    dview[i].z=static_cast<numtyp>(bigb[i]);
+    dview[i].w=static_cast<numtyp>(big2b[i]);
+  }
+
+  ucl_copy(param5,dview,false);
+  param5_tex.get_texture(*(this->pair_program),"param5_tex");
+  param5_tex.bind_float(param5,4);
+
+  UCL_H_Vec<int> dview_elem2param(nelements*nelements*nelements,
+                           *(this->ucl_device), UCL_WRITE_ONLY);
+
+  elem2param.alloc(nelements*nelements*nelements,*(this->ucl_device),
+                   UCL_READ_ONLY);
+
+  for (int i = 0; i < nelements; i++)
+    for (int j = 0; j < nelements; j++)
+      for (int k = 0; k < nelements; k++) {
+         int idx = i*nelements*nelements+j*nelements+k;
+         dview_elem2param[idx] = host_elem2param[i][j][k];
+      }
+
+  ucl_copy(elem2param,dview_elem2param,false);
+
+  UCL_H_Vec<int> dview_map(lj_types, *(this->ucl_device), UCL_WRITE_ONLY);
+  for (int i = 0; i < ntypes; i++)
+    dview_map[i] = host_map[i];
+
+  map.alloc(lj_types,*(this->ucl_device), UCL_READ_ONLY);
+  ucl_copy(map,dview_map,false);
+
+  _allocated=true;
+  this->_max_bytes=param1.row_bytes()+param2.row_bytes()+param3.row_bytes()+param4.row_bytes()+param5.row_bytes()+
+    map.row_bytes()+elem2param.row_bytes();
+  return 0;
+}
+
+template <class numtyp, class acctyp>
+void VashishtaT::clear() {
+  if (!_allocated)
+    return;
+  _allocated=false;
+
+  param1.clear();
+  param2.clear();
+  param3.clear();
+  param4.clear();
+  param5.clear();
+  map.clear();
+  elem2param.clear();
+  this->clear_atomic();
+}
+
+template <class numtyp, class acctyp>
+double VashishtaT::host_memory_usage() const {
+  return this->host_memory_usage_atomic()+sizeof(Vashishta<numtyp,acctyp>);
+}
+
+#define KTHREADS this->_threads_per_atom
+#define JTHREADS this->_threads_per_atom
+// ---------------------------------------------------------------------------
+// Calculate energies, forces, and torques
+// ---------------------------------------------------------------------------
+template <class numtyp, class acctyp>
+void VashishtaT::loop(const bool _eflag, const bool _vflag, const int evatom) {
+  // Compute the block size and grid size to keep all cores busy
+  int BX=this->block_pair();
+  int eflag, vflag;
+  if (_eflag)
+    eflag=1;
+  else
+    eflag=0;
+
+  if (_vflag)
+    vflag=1;
+  else
+    vflag=0;
+
+  int GX=static_cast<int>(ceil(static_cast<double>(this->ans->inum())/
+                               (BX/this->_threads_per_atom)));
+
+  // this->_nbor_data == nbor->dev_packed for gpu_nbor == 0 and tpa > 1
+  // this->_nbor_data == nbor->dev_nbor for gpu_nbor == 1 or tpa == 1
+  int ainum=this->ans->inum();
+  int nbor_pitch=this->nbor->nbor_pitch();
+  this->time_pair.start();
+
+  this->k_pair.set_size(GX,BX);
+  this->k_pair.run(&this->atom->x, &param1, &param2, &param3, &param4, &param5,
+                   &map, &elem2param, &_nelements,
+                   &this->nbor->dev_nbor, &this->_nbor_data->begin(),
+                   &this->ans->force, &this->ans->engv,
+                   &eflag, &vflag, &ainum, &nbor_pitch,
+                   &this->_threads_per_atom);
+
+  BX=this->block_size();
+  GX=static_cast<int>(ceil(static_cast<double>(this->ans->inum())/
+                           (BX/(KTHREADS*JTHREADS))));
+  
+  this->k_three_center.set_size(GX,BX);
+  this->k_three_center.run(&this->atom->x, &param1, &param2, &param3, &param4, &param5,
+                           &map, &elem2param, &_nelements,
+                           &this->nbor->dev_nbor, &this->_nbor_data->begin(),
+                           &this->ans->force, &this->ans->engv, &eflag, &vflag, &ainum,
+                           &nbor_pitch, &this->_threads_per_atom, &evatom);
+  Answer<numtyp,acctyp> *end_ans;
+  #ifdef THREE_CONCURRENT
+  end_ans=this->ans2;
+  #else
+  end_ans=this->ans;
+  #endif
+  if (evatom!=0) {
+    
+    this->k_three_end_vatom.set_size(GX,BX);
+    this->k_three_end_vatom.run(&this->atom->x, &param1, &param2, &param3, &param4, &param5,
+                          &map, &elem2param, &_nelements,
+                          &this->nbor->dev_nbor, &this->_nbor_data->begin(),
+                          &this->nbor->dev_acc,
+                          &end_ans->force, &end_ans->engv, &eflag, &vflag, &ainum,
+                          &nbor_pitch, &this->_threads_per_atom, &this->_gpu_nbor);
+  } else {
+    
+    this->k_three_end.set_size(GX,BX);
+    this->k_three_end.run(&this->atom->x, &param1, &param2, &param3, &param4, &param5,
+                          &map, &elem2param, &_nelements,
+                          &this->nbor->dev_nbor, &this->_nbor_data->begin(),
+                          &this->nbor->dev_acc,
+                          &end_ans->force, &end_ans->engv, &eflag, &vflag, &ainum,
+                          &nbor_pitch, &this->_threads_per_atom, &this->_gpu_nbor);
+  }
+
+  this->time_pair.stop();
+}
+
+template class Vashishta<PRECISION,ACC_PRECISION>;
+

--- a/lib/gpu/lal_vashishta.cu
+++ b/lib/gpu/lal_vashishta.cu
@@ -1,0 +1,744 @@
+// **************************************************************************
+//                                 vashishta.cu
+//                             -------------------
+//                           Anders Hafreager (UiO)
+//
+//  Device code for acceleration of the vashishta pair style
+//
+// __________________________________________________________________________
+//    This file is part of the LAMMPS Accelerator Library (LAMMPS_AL)
+// __________________________________________________________________________
+//
+//    begin                : Mon June 12, 2017
+//    email                : andershaf@gmail.com
+// ***************************************************************************/
+
+#ifdef NV_KERNEL
+#include "lal_aux_fun1.h"
+
+#ifndef _DOUBLE_DOUBLE
+texture<float4> pos_tex;
+texture<float4> param1_tex;
+texture<float4> param2_tex;
+texture<float4> param3_tex;
+texture<float4> param4_tex;
+texture<float4> param5_tex;
+#else
+texture<int4,1> pos_tex;
+texture<int4> param1_tex;
+texture<int4> param2_tex;
+texture<int4> param3_tex;
+texture<int4> param4_tex;
+texture<int4> param5_tex;
+#endif
+
+#else
+#define pos_tex x_
+#define param1_tex param1
+#define param2_tex param2
+#define param3_tex param3
+#define param3_tex param4
+#define param3_tex param5
+#endif
+
+#define THIRD (numtyp)0.66666666666666666667
+
+//#define THREE_CONCURRENT
+
+#if (ARCH < 300)
+
+#define store_answers_p(f, energy, virial, ii, inum, tid, t_per_atom, offset, \
+                      eflag, vflag, ans, engv)                              \
+  if (t_per_atom>1) {                                                       \
+    __local acctyp red_acc[6][BLOCK_ELLIPSE];                               \
+    red_acc[0][tid]=f.x;                                                    \
+    red_acc[1][tid]=f.y;                                                    \
+    red_acc[2][tid]=f.z;                                                    \
+    red_acc[3][tid]=energy;                                                 \
+    for (unsigned int s=t_per_atom/2; s>0; s>>=1) {                         \
+      if (offset < s) {                                                     \
+        for (int r=0; r<4; r++)                                             \
+          red_acc[r][tid] += red_acc[r][tid+s];                             \
+      }                                                                     \
+    }                                                                       \
+    f.x=red_acc[0][tid];                                                    \
+    f.y=red_acc[1][tid];                                                    \
+    f.z=red_acc[2][tid];                                                    \
+    energy=red_acc[3][tid];                                                 \
+    if (vflag>0) {                                                          \
+      for (int r=0; r<6; r++)                                               \
+        red_acc[r][tid]=virial[r];                                          \
+      for (unsigned int s=t_per_atom/2; s>0; s>>=1) {                       \
+        if (offset < s) {                                                   \
+          for (int r=0; r<6; r++)                                           \
+            red_acc[r][tid] += red_acc[r][tid+s];                           \
+        }                                                                   \
+      }                                                                     \
+      for (int r=0; r<6; r++)                                               \
+        virial[r]=red_acc[r][tid];                                          \
+    }                                                                       \
+  }                                                                         \
+  if (offset==0) {                                                          \
+    int ei=ii;                                                              \
+    if (eflag>0) {                                                          \
+      engv[ei]+=energy*(acctyp)0.5;                                         \
+      ei+=inum;                                                             \
+    }                                                                       \
+    if (vflag>0) {                                                          \
+      for (int i=0; i<6; i++) {                                             \
+        engv[ei]+=virial[i]*(acctyp)0.5;                                    \
+        ei+=inum;                                                           \
+      }                                                                     \
+    }                                                                       \
+    acctyp4 old=ans[ii];                                                    \
+    old.x+=f.x;                                                             \
+    old.y+=f.y;                                                             \
+    old.z+=f.z;                                                             \
+    ans[ii]=old;                                                            \
+  }
+
+#else
+
+#define store_answers_p(f, energy, virial, ii, inum, tid, t_per_atom, offset, \
+                      eflag, vflag, ans, engv)                              \
+  if (t_per_atom>1) {                                                       \
+    for (unsigned int s=t_per_atom/2; s>0; s>>=1) {                         \
+        f.x += shfl_xor(f.x, s, t_per_atom);                                \
+        f.y += shfl_xor(f.y, s, t_per_atom);                                \
+        f.z += shfl_xor(f.z, s, t_per_atom);                                \
+        energy += shfl_xor(energy, s, t_per_atom);                          \
+    }                                                                       \
+    if (vflag>0) {                                                          \
+      for (unsigned int s=t_per_atom/2; s>0; s>>=1) {                       \
+          for (int r=0; r<6; r++)                                           \
+            virial[r] += shfl_xor(virial[r], s, t_per_atom);                \
+      }                                                                     \
+    }                                                                       \
+  }                                                                         \
+  if (offset==0) {                                                          \
+    int ei=ii;                                                              \
+    if (eflag>0) {                                                          \
+      engv[ei]+=energy*(acctyp)0.5;                                         \
+      ei+=inum;                                                             \
+    }                                                                       \
+    if (vflag>0) {                                                          \
+      for (int i=0; i<6; i++) {                                             \
+        engv[ei]+=virial[i]*(acctyp)0.5;                                    \
+        ei+=inum;                                                           \
+      }                                                                     \
+    }                                                                       \
+    acctyp4 old=ans[ii];                                                    \
+    old.x+=f.x;                                                             \
+    old.y+=f.y;                                                             \
+    old.z+=f.z;                                                             \
+    ans[ii]=old;                                                            \
+  }
+
+#endif
+
+
+__kernel void k_vashishta(const __global numtyp4 *restrict x_,
+                   const __global numtyp4 *restrict param1,
+                   const __global numtyp4 *restrict param2,
+                   const __global numtyp4 *restrict param3,
+                   const __global numtyp4 *restrict param4,
+                   const __global numtyp4 *restrict param5,
+                   const __global int *restrict map,
+                   const __global int *restrict elem2param,
+                   const int nelements,
+                   const __global int * dev_nbor,
+                   const __global int * dev_packed,
+                   __global acctyp4 *restrict ans,
+                   __global acctyp *restrict engv,
+                   const int eflag, const int vflag, const int inum,
+                   const int nbor_pitch, const int t_per_atom) {
+  __local int n_stride;
+  int tid, ii, offset;
+  atom_info(t_per_atom,ii,tid,offset);
+
+  acctyp energy=(acctyp)0;
+  acctyp4 f;
+  f.x=(acctyp)0; f.y=(acctyp)0; f.z=(acctyp)0;
+  acctyp virial[6];
+  for (int i=0; i<6; i++)
+    virial[i]=(acctyp)0;
+
+  __syncthreads();
+
+  if (ii<inum) {
+    int nbor, nbor_end;
+    int i, numj;
+    nbor_info(dev_nbor,dev_packed,nbor_pitch,t_per_atom,ii,offset,i,numj,
+              n_stride,nbor_end,nbor);
+
+    numtyp4 ix; fetch4(ix,i,pos_tex); //x_[i];
+    int itype=ix.w;
+    itype=map[itype];
+
+    for ( ; nbor<nbor_end; nbor+=n_stride) {
+
+      int j=dev_packed[nbor];
+      j &= NEIGHMASK;
+
+      numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
+      int jtype=jx.w;
+      jtype=map[jtype];
+
+      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
+
+      // Compute r12
+      numtyp delx = ix.x-jx.x;
+      numtyp dely = ix.y-jx.y;
+      numtyp delz = ix.z-jx.z;
+      numtyp rsq = delx*delx+dely*dely+delz*delz;
+
+      if (rsq<param4[ijparam].z) { // cutsq = param4[ijparam].z
+        numtyp4 param1_ijparam; fetch4(param1_ijparam,ijparam,param1_tex);
+        numtyp param1_eta=param1_ijparam.x;
+        numtyp param1_lam1inv=param1_ijparam.y;
+        numtyp param1_lam4inv=param1_ijparam.z;
+        numtyp param1_zizj=param1_ijparam.w;
+
+        numtyp4 param2_ijparam; fetch4(param2_ijparam,ijparam,param2_tex);
+        numtyp param2_mbigd=param2_ijparam.x;
+        numtyp param2_dvrc =param2_ijparam.y;
+        numtyp param2_big6w=param2_ijparam.z;
+        numtyp param2_heta =param2_ijparam.w;
+
+        numtyp4 param3_ijparam; fetch4(param3_ijparam,ijparam,param3_tex);
+        numtyp param3_bigh=param3_ijparam.x;
+        numtyp param3_bigw=param3_ijparam.y;
+        numtyp param3_dvrc=param3_ijparam.z;
+        numtyp param3_c0  =param3_ijparam.w;
+
+        numtyp r=sqrt(rsq);
+        numtyp rinvsq=1.0/rsq;
+        numtyp r4inv = rinvsq*rinvsq;
+        numtyp r6inv = rinvsq*r4inv;
+
+        numtyp reta = pow(r,-param1_eta);
+        numtyp lam1r = r*param1_lam1inv;
+        numtyp lam4r = r*param1_lam4inv;
+        numtyp vc2 = param1_zizj * exp(-lam1r)/r;
+        numtyp vc3 = param2_mbigd * r4inv*exp(-lam4r);
+
+        numtyp force = (param2_dvrc*r
+            - (4.0*vc3 + lam4r*vc3+param2_big6w*r6inv
+               - param2_heta*reta - vc2 - lam1r*vc2)
+            ) * rinvsq;
+
+        f.x+=delx*force;
+        f.y+=dely*force;
+        f.z+=delz*force;
+        if (eflag>0)
+          energy += (param3_bigh*reta+vc2-vc3-param3_bigw*r6inv-r*param3_dvrc+param3_c0);
+          
+        if (vflag>0) {
+          virial[0] += delx*delx*force;
+          virial[1] += dely*dely*force;
+          virial[2] += delz*delz*force;
+          virial[3] += delx*dely*force;
+          virial[4] += delx*delz*force;
+          virial[5] += dely*delz*force;
+        }
+      }
+    } // for nbor
+
+    store_answers(f,energy,virial,ii,inum,tid,t_per_atom,offset,eflag,vflag,
+                  ans,engv);
+  } // if ii
+
+}
+
+#define threebody(delr1x, delr1y, delr1z, eflag, energy)                     \
+{                                                                            \
+  numtyp r1 = ucl_sqrt(rsq1);                                                \
+  numtyp rinvsq1 = ucl_recip(rsq1);                                          \
+  numtyp rainv1 = ucl_recip(r1 - param_r0_ij);                               \
+  numtyp gsrainv1 = param_gamma_ij * rainv1;                                    \
+  numtyp gsrainvsq1 = gsrainv1*rainv1/r1;                                    \
+  numtyp expgsrainv1 = ucl_exp(gsrainv1);                                    \
+                                                                             \
+  numtyp r2 = ucl_sqrt(rsq2);                                                \
+  numtyp rinvsq2 = ucl_recip(rsq2);                                          \
+  numtyp rainv2 = ucl_recip(r2 - param_r0_ik);                               \
+  numtyp gsrainv2 = param_gamma_ik * rainv2;                                    \
+  numtyp gsrainvsq2 = gsrainv2*rainv2/r2;                                    \
+  numtyp expgsrainv2 = ucl_exp(gsrainv2);                                    \
+                                                                             \
+  numtyp rinv12 = ucl_recip(r1*r2);                                          \
+  numtyp cs = (delr1x*delr2x + delr1y*delr2y + delr1z*delr2z) * rinv12;      \
+  numtyp delcs = cs - param_costheta_ijk;                                       \
+  numtyp delcssq = delcs*delcs;                                              \
+  numtyp pcsinv = param_bigc_ijk*delcssq+1.0;                                   \
+  numtyp pcsinvsq = pcsinv*pcsinv;                                           \
+  numtyp pcs = delcssq/pcsinv;                                               \
+                                                                             \
+  numtyp facexp = expgsrainv1*expgsrainv2;                                   \
+                                                                             \
+  numtyp facrad = param_bigb_ijk * facexp*pcs;                                  \
+  numtyp frad1 = facrad*gsrainvsq1;                                          \
+  numtyp frad2 = facrad*gsrainvsq2;                                          \
+  numtyp facang = param_big2b_ijk * facexp*delcs/pcsinvsq;                      \
+  numtyp facang12 = rinv12*facang;                                           \
+  numtyp csfacang = cs*facang;                                               \
+  numtyp csfac1 = rinvsq1*csfacang;                                          \
+                                                                             \
+  fjx = delr1x*(frad1+csfac1)-delr2x*facang12;                               \
+  fjy = delr1y*(frad1+csfac1)-delr2y*facang12;                               \
+  fjz = delr1z*(frad1+csfac1)-delr2z*facang12;                               \
+                                                                             \
+  numtyp csfac2 = rinvsq2*csfacang;                                          \
+                                                                             \
+  fkx = delr2x*(frad2+csfac2)-delr1x*facang12;                               \
+  fky = delr2y*(frad2+csfac2)-delr1y*facang12;                               \
+  fkz = delr2z*(frad2+csfac2)-delr1z*facang12;                               \
+                                                                             \
+  if (eflag>0)                                                               \
+    energy+=facrad;                                                          \
+  if (vflag>0) {                                                             \
+    virial[0] += delr1x*fjx + delr2x*fkx;                                    \
+    virial[1] += delr1y*fjy + delr2y*fky;                                    \
+    virial[2] += delr1z*fjz + delr2z*fkz;                                    \
+    virial[3] += delr1x*fjy + delr2x*fky;                                    \
+    virial[4] += delr1x*fjz + delr2x*fkz;                                    \
+    virial[5] += delr1y*fjz + delr2y*fkz;                                    \
+  }                                                                          \
+}
+
+#define threebody_half(delr1x, delr1y, delr1z)                               \
+{                                                                            \
+  numtyp r1 = ucl_sqrt(rsq1);                                                \
+  numtyp rinvsq1 = ucl_recip(rsq1);                                          \
+  numtyp rainv1 = ucl_recip(r1 - param_r0_ij);                               \
+  numtyp gsrainv1 = param_gamma_ij * rainv1;                                    \
+  numtyp gsrainvsq1 = gsrainv1*rainv1/r1;                                    \
+  numtyp expgsrainv1 = ucl_exp(gsrainv1);                                    \
+                                                                             \
+  numtyp r2 = ucl_sqrt(rsq2);                                                \
+  numtyp rainv2 = ucl_recip(r2 - param_r0_ik);                               \
+  numtyp gsrainv2 = param_gamma_ik * rainv2;                                    \
+  numtyp expgsrainv2 = ucl_exp(gsrainv2);                                    \
+                                                                             \
+  numtyp rinv12 = ucl_recip(r1*r2);                                          \
+  numtyp cs = (delr1x*delr2x + delr1y*delr2y + delr1z*delr2z) * rinv12;      \
+  numtyp delcs = cs - param_costheta_ijk;                                       \
+  numtyp delcssq = delcs*delcs;                                              \
+  numtyp pcsinv = param_bigc_ijk*delcssq+1.0;                                   \
+  numtyp pcsinvsq = pcsinv*pcsinv;                                           \
+  numtyp pcs = delcssq/pcsinv;                                               \
+                                                                             \
+  numtyp facexp = expgsrainv1*expgsrainv2;                                   \
+                                                                             \
+  numtyp facrad = param_bigb_ijk * facexp*pcs;                                  \
+  numtyp frad1 = facrad*gsrainvsq1;                                          \
+  numtyp facang = param_big2b_ijk * facexp*delcs/pcsinvsq;                      \
+  numtyp facang12 = rinv12*facang;                                           \
+  numtyp csfacang = cs*facang;                                               \
+  numtyp csfac1 = rinvsq1*csfacang;                                          \
+                                                                             \
+  fjx = delr1x*(frad1+csfac1)-delr2x*facang12;                               \
+  fjy = delr1y*(frad1+csfac1)-delr2y*facang12;                               \
+  fjz = delr1z*(frad1+csfac1)-delr2z*facang12;                               \
+}
+
+__kernel void k_vashishta_three_center(const __global numtyp4 *restrict x_,
+                                const __global numtyp4 *restrict param1,
+                                const __global numtyp4 *restrict param2,
+                                const __global numtyp4 *restrict param3,
+                                const __global numtyp4 *restrict param4,
+                                const __global numtyp4 *restrict param5,
+                                const __global int *restrict map,
+                                const __global int *restrict elem2param,
+                                const int nelements,
+                                const __global int * dev_nbor,
+                                const __global int * dev_packed,
+                                __global acctyp4 *restrict ans,
+                                __global acctyp *restrict engv,
+                                const int eflag, const int vflag,
+                                const int inum,  const int nbor_pitch,
+                                const int t_per_atom, const int evatom) {
+  __local int tpa_sq, n_stride;
+  tpa_sq=fast_mul(t_per_atom,t_per_atom);
+  numtyp param_gamma_ij, param_r0sq_ij, param_r0_ij, param_gamma_ik, param_r0sq_ik, param_r0_ik;
+  numtyp param_costheta_ijk, param_bigc_ijk, param_bigb_ijk, param_big2b_ijk;
+
+  int tid, ii, offset;
+  atom_info(tpa_sq,ii,tid,offset);
+
+  acctyp energy=(acctyp)0;
+  acctyp4 f;
+  f.x=(acctyp)0; f.y=(acctyp)0; f.z=(acctyp)0;
+  acctyp virial[6];
+  for (int i=0; i<6; i++)
+    virial[i]=(acctyp)0;
+
+  __syncthreads();
+
+  if (ii<inum) {
+    int i, numj, nbor_j, nbor_end;
+
+    int offset_j=offset/t_per_atom;
+    nbor_info(dev_nbor,dev_packed,nbor_pitch,t_per_atom,ii,offset_j,i,numj,
+              n_stride,nbor_end,nbor_j);
+    int offset_k=tid & (t_per_atom-1);
+
+    numtyp4 ix; fetch4(ix,i,pos_tex); //x_[i];
+    int itype=ix.w;
+    itype=map[itype];
+
+    for ( ; nbor_j<nbor_end; nbor_j+=n_stride) {
+
+      int j=dev_packed[nbor_j];
+      j &= NEIGHMASK;
+
+      numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
+      int jtype=jx.w;
+      jtype=map[jtype];
+
+      // Compute r12
+      numtyp delr1x = jx.x-ix.x;
+      numtyp delr1y = jx.y-ix.y;
+      numtyp delr1z = jx.z-ix.z;
+      numtyp rsq1 = delr1x*delr1x+delr1y*delr1y+delr1z*delr1z;
+
+      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
+      
+      numtyp4 param4_ijparam; fetch4(param4_ijparam,ijparam,param4_tex);
+      param_r0sq_ij=param4_ijparam.x;
+      if (rsq1 > param_r0sq_ij) continue;
+      param_gamma_ij=param4_ijparam.y;
+      param_r0_ij=param4_ijparam.w;
+      
+      int nbor_k=nbor_j-offset_j+offset_k;
+      if (nbor_k<=nbor_j)
+        nbor_k+=n_stride;
+
+      for ( ; nbor_k<nbor_end; nbor_k+=n_stride) {
+        int k=dev_packed[nbor_k];
+        k &= NEIGHMASK;
+
+        numtyp4 kx; fetch4(kx,k,pos_tex);
+        int ktype=kx.w;
+        ktype=map[ktype];
+        int ikparam=elem2param[itype*nelements*nelements+ktype*nelements+ktype];
+        numtyp4 param4_ikparam; fetch4(param4_ikparam,ikparam,param4_tex);
+
+        numtyp delr2x = kx.x-ix.x;
+        numtyp delr2y = kx.y-ix.y;
+        numtyp delr2z = kx.z-ix.z;
+        numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
+
+        param_r0sq_ik=param4_ikparam.x;
+        if (rsq2 < param_r0sq_ik) {
+          param_gamma_ik=param4_ikparam.y;
+          param_r0_ik=param4_ikparam.w;
+
+          int ijkparam=elem2param[itype*nelements*nelements+jtype*nelements+ktype];
+          numtyp4 param5_ijkparam; fetch4(param5_ijkparam,ijkparam,param5_tex);
+          param_bigc_ijk=param5_ijkparam.x;
+          param_bigb_ijk=param5_ijkparam.z;
+          param_big2b_ijk=param5_ijkparam.w;
+          param_costheta_ijk=param5_ijkparam.y;
+
+          numtyp fjx, fjy, fjz, fkx, fky, fkz;
+          threebody(delr1x,delr1y,delr1z,eflag,energy);
+
+          f.x -= fjx + fkx;
+          f.y -= fjy + fky;
+          f.z -= fjz + fkz;
+        }
+      }
+    } // for nbor
+
+    numtyp pre;
+    if (evatom==1)
+      pre=THIRD;
+    else
+      pre=(numtyp)2.0;
+    energy*=pre;
+    for (int i=0; i<6; i++)
+      virial[i]*=pre;
+
+    store_answers_p(f,energy,virial,ii,inum,tid,tpa_sq,offset,
+                    eflag,vflag,ans,engv);
+
+  } // if ii
+}
+
+__kernel void k_vashishta_three_end(const __global numtyp4 *restrict x_,
+                             const __global numtyp4 *restrict param1,
+                             const __global numtyp4 *restrict param2,
+                             const __global numtyp4 *restrict param3,
+                             const __global numtyp4 *restrict param4,
+                             const __global numtyp4 *restrict param5,
+                             const __global int *restrict map,
+                             const __global int *restrict elem2param,
+                             const int nelements,
+                             const __global int * dev_nbor,
+                             const __global int * dev_packed,
+                             const __global int * dev_acc,
+                             __global acctyp4 *restrict ans,
+                             __global acctyp *restrict engv,
+                             const int eflag, const int vflag,
+                             const int inum,  const int nbor_pitch,
+                             const int t_per_atom, const int gpu_nbor) {
+  __local int tpa_sq, n_stride;
+  tpa_sq=fast_mul(t_per_atom,t_per_atom);
+  numtyp param_gamma_ij, param_r0sq_ij, param_r0_ij, param_gamma_ik, param_r0sq_ik, param_r0_ik;
+  numtyp param_costheta_ijk, param_bigc_ijk, param_bigb_ijk, param_big2b_ijk;
+
+  int tid, ii, offset;
+  atom_info(tpa_sq,ii,tid,offset);
+
+  acctyp energy=(acctyp)0;
+  acctyp4 f;
+  f.x=(acctyp)0; f.y=(acctyp)0; f.z=(acctyp)0;
+  acctyp virial[6];
+  for (int i=0; i<6; i++)
+    virial[i]=(acctyp)0;
+
+  __syncthreads();
+
+  if (ii<inum) {
+    int i, numj, nbor_j, nbor_end, k_end;
+
+    int offset_j=offset/t_per_atom;
+    nbor_info(dev_nbor,dev_packed,nbor_pitch,t_per_atom,ii,offset_j,i,numj,
+              n_stride,nbor_end,nbor_j);
+    int offset_k=tid & (t_per_atom-1);
+
+    numtyp4 ix; fetch4(ix,i,pos_tex); //x_[i];
+    int itype=ix.w;
+    itype=map[itype];
+
+    for ( ; nbor_j<nbor_end; nbor_j+=n_stride) {
+      int j=dev_packed[nbor_j];
+      j &= NEIGHMASK;
+
+      numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
+      int jtype=jx.w;
+      jtype=map[jtype];
+
+      // Compute r12
+      numtyp delr1x = ix.x-jx.x;
+      numtyp delr1y = ix.y-jx.y;
+      numtyp delr1z = ix.z-jx.z;
+      numtyp rsq1 = delr1x*delr1x+delr1y*delr1y+delr1z*delr1z;
+
+      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
+      numtyp4 param4_ijparam; fetch4(param4_ijparam,ijparam,param4_tex);
+      param_r0sq_ij = param4_ijparam.x;
+      if (rsq1 > param_r0sq_ij) continue;
+
+      param_gamma_ij=param4_ijparam.y;
+      param_r0_ij = param4_ijparam.w;
+      
+      int nbor_k,numk;
+      if (dev_nbor==dev_packed) {
+        if (gpu_nbor) nbor_k=j+nbor_pitch;
+        else nbor_k=dev_acc[j]+nbor_pitch;
+        numk=dev_nbor[nbor_k];
+        nbor_k+=nbor_pitch+fast_mul(j,t_per_atom-1);
+        k_end=nbor_k+fast_mul(numk/t_per_atom,n_stride)+(numk & (t_per_atom-1));
+        nbor_k+=offset_k;
+      } else {
+        nbor_k=dev_acc[j]+nbor_pitch;
+        numk=dev_nbor[nbor_k];
+        nbor_k+=nbor_pitch;
+        nbor_k=dev_nbor[nbor_k];
+        k_end=nbor_k+numk;
+        nbor_k+=offset_k;
+      }
+
+      for ( ; nbor_k<k_end; nbor_k+=n_stride) {
+        int k=dev_packed[nbor_k];
+        k &= NEIGHMASK;
+
+        if (k == i) continue;
+
+        numtyp4 kx; fetch4(kx,k,pos_tex);
+        int ktype=kx.w;
+        ktype=map[ktype];
+        int ikparam=elem2param[jtype*nelements*nelements+ktype*nelements+ktype]; //jk
+
+        numtyp delr2x = kx.x - jx.x;
+        numtyp delr2y = kx.y - jx.y;
+        numtyp delr2z = kx.z - jx.z;
+        numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
+        numtyp4 param4_ikparam; fetch4(param4_ikparam,ikparam,param4_tex);
+        param_r0sq_ik=param4_ikparam.x;
+
+        if (rsq2 < param_r0sq_ik) {
+          param_gamma_ik=param4_ikparam.y;
+          param_r0_ik=param4_ikparam.w;
+          
+          int ijkparam=elem2param[jtype*nelements*nelements+itype*nelements+ktype]; //jik
+          numtyp4 param5_ijkparam; fetch4(param5_ijkparam,ijkparam,param5_tex);
+          param_bigc_ijk=param5_ijkparam.x;
+          param_costheta_ijk=param5_ijkparam.y;
+          param_bigb_ijk=param5_ijkparam.z;
+          param_big2b_ijk=param5_ijkparam.w;
+          
+          numtyp fjx, fjy, fjz;
+          //if (evatom==0) {
+            threebody_half(delr1x,delr1y,delr1z);
+          //} else {
+          //  numtyp fkx, fky, fkz;
+          //  threebody(delr1x,delr1y,delr1z,eflag,energy);
+          //}
+
+          f.x += fjx;
+          f.y += fjy;
+          f.z += fjz;
+        }
+      }
+
+    } // for nbor
+    #ifdef THREE_CONCURRENT
+    store_answers(f,energy,virial,ii,inum,tid,tpa_sq,offset,
+                  eflag,vflag,ans,engv);
+    #else
+    store_answers_p(f,energy,virial,ii,inum,tid,tpa_sq,offset,
+                    eflag,vflag,ans,engv);
+    #endif
+  } // if ii
+}
+
+__kernel void k_vashishta_three_end_vatom(const __global numtyp4 *restrict x_,
+                             const __global numtyp4 *restrict param1,
+                             const __global numtyp4 *restrict param2,
+                             const __global numtyp4 *restrict param3,
+                             const __global numtyp4 *restrict param4,
+                             const __global numtyp4 *restrict param5,
+                             const __global int *restrict map,
+                             const __global int *restrict elem2param,
+                             const int nelements,
+                             const __global int * dev_nbor,
+                             const __global int * dev_packed,
+                             const __global int * dev_acc,
+                             __global acctyp4 *restrict ans,
+                             __global acctyp *restrict engv,
+                             const int eflag, const int vflag,
+                             const int inum,  const int nbor_pitch,
+                             const int t_per_atom, const int gpu_nbor) {
+  __local int tpa_sq, n_stride;
+  tpa_sq=fast_mul(t_per_atom,t_per_atom);
+  numtyp param_gamma_ij, param_r0sq_ij, param_r0_ij, param_gamma_ik, param_r0sq_ik, param_r0_ik;
+  numtyp param_costheta_ijk, param_bigc_ijk, param_bigb_ijk, param_big2b_ijk;
+
+  int tid, ii, offset;
+  atom_info(tpa_sq,ii,tid,offset);
+
+  acctyp energy=(acctyp)0;
+  acctyp4 f;
+  f.x=(acctyp)0; f.y=(acctyp)0; f.z=(acctyp)0;
+  acctyp virial[6];
+  for (int i=0; i<6; i++)
+    virial[i]=(acctyp)0;
+
+  __syncthreads();
+
+  if (ii<inum) {
+    int i, numj, nbor_j, nbor_end, k_end;
+
+    int offset_j=offset/t_per_atom;
+    nbor_info(dev_nbor,dev_packed,nbor_pitch,t_per_atom,ii,offset_j,i,numj,
+              n_stride,nbor_end,nbor_j);
+    int offset_k=tid & (t_per_atom-1);
+
+    numtyp4 ix; fetch4(ix,i,pos_tex); //x_[i];
+    int itype=ix.w;
+    itype=map[itype];
+
+    for ( ; nbor_j<nbor_end; nbor_j+=n_stride) {
+      int j=dev_packed[nbor_j];
+      j &= NEIGHMASK;
+
+      numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
+      int jtype=jx.w;
+      jtype=map[jtype];
+
+      // Compute r12
+      numtyp delr1x = ix.x-jx.x;
+      numtyp delr1y = ix.y-jx.y;
+      numtyp delr1z = ix.z-jx.z;
+      numtyp rsq1 = delr1x*delr1x+delr1y*delr1y+delr1z*delr1z;
+
+      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
+      numtyp4 param4_ijparam; fetch4(param4_ijparam,ijparam,param4_tex);
+      param_r0sq_ij=param4_ijparam.x;
+      if (rsq1 > param_r0sq_ij) continue;
+
+      param_gamma_ij=param4_ijparam.y;
+      param_r0_ij=param4_ijparam.w;
+      
+      int nbor_k,numk;
+      if (dev_nbor==dev_packed) {
+        if (gpu_nbor) nbor_k=j+nbor_pitch;
+        else nbor_k=dev_acc[j]+nbor_pitch;
+        numk=dev_nbor[nbor_k];
+        nbor_k+=nbor_pitch+fast_mul(j,t_per_atom-1);
+        k_end=nbor_k+fast_mul(numk/t_per_atom,n_stride)+(numk & (t_per_atom-1));
+        nbor_k+=offset_k;
+      } else {
+        nbor_k=dev_acc[j]+nbor_pitch;
+        numk=dev_nbor[nbor_k];
+        nbor_k+=nbor_pitch;
+        nbor_k=dev_nbor[nbor_k];
+        k_end=nbor_k+numk;
+        nbor_k+=offset_k;
+      }
+
+      for ( ; nbor_k<k_end; nbor_k+=n_stride) {
+        int k=dev_packed[nbor_k];
+        k &= NEIGHMASK;
+
+        if (k == i) continue;
+
+        numtyp4 kx; fetch4(kx,k,pos_tex);
+        int ktype=kx.w;
+        ktype=map[ktype];
+        int ikparam=elem2param[jtype*nelements*nelements+ktype*nelements+ktype]; // jk
+        numtyp4 param4_ikparam; fetch4(param4_ikparam,ikparam,param4_tex);
+
+        numtyp delr2x = kx.x - jx.x;
+        numtyp delr2y = kx.y - jx.y;
+        numtyp delr2z = kx.z - jx.z;
+        numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
+        param_r0sq_ik=param4_ikparam.x;
+
+        if (rsq2 < param_r0sq_ik) {
+          param_gamma_ik=param4_ikparam.y;
+          param_r0_ik=param4_ikparam.w;
+
+          int ijkparam=elem2param[jtype*nelements*nelements+itype*nelements+ktype]; // jik
+          numtyp4 param5_ijkparam; fetch4(param5_ijkparam,ijkparam,param5_tex);
+          param_bigc_ijk=param5_ijkparam.x;
+          param_costheta_ijk=param5_ijkparam.y;
+          param_bigb_ijk=param5_ijkparam.z;
+          param_big2b_ijk=param5_ijkparam.w;
+          
+          numtyp fjx, fjy, fjz, fkx, fky, fkz;
+          threebody(delr1x,delr1y,delr1z,eflag,energy);
+
+          f.x += fjx;
+          f.y += fjy;
+          f.z += fjz;
+        }
+      }
+
+    } // for nbor
+    energy*=THIRD;
+    for (int i=0; i<6; i++)
+      virial[i]*=THIRD;
+    #ifdef THREE_CONCURRENT
+    store_answers(f,energy,virial,ii,inum,tid,tpa_sq,offset,
+                  eflag,vflag,ans,engv);
+    #else
+    store_answers_p(f,energy,virial,ii,inum,tid,tpa_sq,offset,
+                    eflag,vflag,ans,engv);
+    #endif
+  } // if ii
+}
+

--- a/lib/gpu/lal_vashishta.cu
+++ b/lib/gpu/lal_vashishta.cu
@@ -37,8 +37,8 @@ texture<int4> param5_tex;
 #define param1_tex param1
 #define param2_tex param2
 #define param3_tex param3
-#define param3_tex param4
-#define param3_tex param5
+#define param4_tex param4
+#define param5_tex param5
 #endif
 
 #define THIRD (numtyp)0.66666666666666666667

--- a/lib/gpu/lal_vashishta.h
+++ b/lib/gpu/lal_vashishta.h
@@ -1,0 +1,97 @@
+/***************************************************************************
+                                vashishta.h
+                             -------------------
+                            Anders Hafreager (UiO9)
+
+  Class for acceleration of the vashishta pair style.
+
+ __________________________________________________________________________
+    This file is part of the LAMMPS Accelerator Library (LAMMPS_AL)
+ __________________________________________________________________________
+
+    begin                : Mon June 12, 2017
+    email                : andershaf@gmail.com
+ ***************************************************************************/
+
+#ifndef LAL_VASHISHTA_H
+#define LAL_VASHISHTA_H
+
+#include "lal_base_three.h"
+
+namespace LAMMPS_AL {
+
+template <class numtyp, class acctyp>
+class Vashishta : public BaseThree<numtyp, acctyp> {
+ public:
+  Vashishta();
+  ~Vashishta();
+
+  /// Clear any previous data and set up for a new LAMMPS run
+  /** \param max_nbors initial number of rows in the neighbor matrix
+    * \param cell_size cutoff + skin
+    * \param gpu_split fraction of particles handled by device
+    *
+    * Returns:
+    * -  0 if successfull
+    * - -1 if fix gpu not found
+    * - -3 if there is an out of memory error
+    * - -4 if the GPU library was not compiled for GPU
+    * - -5 Double precision is not supported on card **/
+  int init(const int ntypes, const int nlocal, const int nall, const int max_nbors,
+           const double cell_size, const double gpu_split, FILE *screen,
+           int* host_map, const int nelements, int*** host_elem2param, const int nparams,
+           const double* cutsq, const double* r0, 
+           const double* gamma, const double* eta,
+           const double* lam1inv, const double* lam4inv,
+           const double* zizj, const double* mbigd,
+           const double* dvrc, const double* big6w, 
+           const double* heta, const double* bigh,
+           const double* bigw, const double* c0,
+           const double* costheta, const double* bigb,
+           const double* big2b, const double* bigc);
+
+  /// Clear all host and device data
+  /** \note This is called at the beginning of the init() routine **/
+  void clear();
+
+  /// Returns memory usage on device per atom
+  int bytes_per_atom(const int max_nbors) const;
+
+  /// Total host memory used by library for pair style
+  double host_memory_usage() const;
+
+  // --------------------------- TYPE DATA --------------------------
+
+  /// If atom type constants fit in shared memory, use fast kernels
+  bool shared_types;
+
+  /// Number of atom types
+  int _lj_types;
+
+  /// param1.x = eta, param1.y = lam1inv, param1.z = lam4inv, param1.w = zizj
+  UCL_D_Vec<numtyp4> param1;
+  /// param2.x = mbigd, param2.y = dvrc, param2.z = big6w, param2.w = heta
+  UCL_D_Vec<numtyp4> param2;
+  /// param3.x = bigh, param3.y = bigw, param3.z = dvrc, param3.w = c0
+  UCL_D_Vec<numtyp4> param3;
+  /// param4.x = r0sq, param4.y = gamma, param4.z = cutsq, param4.w = r0
+  UCL_D_Vec<numtyp4> param4;
+  /// param5.x = bigc, param5.y = costheta, param5.z = bigb, param5.w = big2b
+  UCL_D_Vec<numtyp4> param5;
+
+  UCL_D_Vec<int> elem2param;
+  UCL_D_Vec<int> map;
+  int _nparams,_nelements;
+
+  UCL_Texture param1_tex, param2_tex, param3_tex, param4_tex, param5_tex;
+
+ private:
+  bool _allocated;
+  void loop(const bool _eflag, const bool _vflag, const int evatom);
+
+};
+
+}
+
+#endif
+

--- a/lib/gpu/lal_vashishta_ext.cpp
+++ b/lib/gpu/lal_vashishta_ext.cpp
@@ -18,10 +18,6 @@
 #include <math.h>
 
 #include "lal_vashishta.h"
-#include <iostream>
-using namespace std;
-
-using namespace std;
 using namespace LAMMPS_AL;
 
 static Vashishta<PRECISION,ACC_PRECISION> VashishtaMF;
@@ -103,7 +99,6 @@ int vashishta_gpu_init(const int ntypes, const int inum, const int nall, const i
   if (init_ok==0)
     VashishtaMF.estimate_gpu_overhead();
 
-  cout << "Seems like this was ok!" << endl;
   return init_ok;
 }
 

--- a/lib/gpu/lal_vashishta_ext.cpp
+++ b/lib/gpu/lal_vashishta_ext.cpp
@@ -1,0 +1,139 @@
+/***************************************************************************
+                              vashishta_ext.cpp
+                             -------------------
+                            Anders Hafreager (UiO)
+
+  Class for acceleration of the vashishta pair style.
+
+ __________________________________________________________________________
+    This file is part of the LAMMPS Accelerator Library (LAMMPS_AL)
+ __________________________________________________________________________
+
+    begin                : Mon June 12, 2017
+    email                : andershaf@gmail.com
+ ***************************************************************************/
+
+#include <iostream>
+#include <cassert>
+#include <math.h>
+
+#include "lal_vashishta.h"
+#include <iostream>
+using namespace std;
+
+using namespace std;
+using namespace LAMMPS_AL;
+
+static Vashishta<PRECISION,ACC_PRECISION> VashishtaMF;
+
+// ---------------------------------------------------------------------------
+// Allocate memory on host and device and copy constants to device
+// ---------------------------------------------------------------------------
+int vashishta_gpu_init(const int ntypes, const int inum, const int nall, const int max_nbors,
+                const double cell_size, int &gpu_mode, FILE *screen,
+                int* host_map, const int nelements, int*** host_elem2param, const int nparams,
+                const double* cutsq, const double* r0,
+                const double* gamma, const double* eta,
+                const double* lam1inv, const double* lam4inv,
+                const double* zizj, const double* mbigd,
+                const double* dvrc, const double* big6w, 
+                const double* heta, const double* bigh,
+                const double* bigw, const double* c0,
+                const double* costheta, const double* bigb,
+                const double* big2b, const double* bigc) {
+  VashishtaMF.clear();
+  gpu_mode=VashishtaMF.device->gpu_mode();
+  double gpu_split=VashishtaMF.device->particle_split();
+  int first_gpu=VashishtaMF.device->first_device();
+  int last_gpu=VashishtaMF.device->last_device();
+  int world_me=VashishtaMF.device->world_me();
+  int gpu_rank=VashishtaMF.device->gpu_rank();
+  int procs_per_gpu=VashishtaMF.device->procs_per_gpu();
+
+  // disable host/device split for now
+  if (gpu_split != 1.0)
+    return -8;
+
+  VashishtaMF.device->init_message(screen,"vashishta/gpu",first_gpu,last_gpu);
+
+  bool message=false;
+  if (VashishtaMF.device->replica_me()==0 && screen)
+    message=true;
+
+  if (message) {
+    fprintf(screen,"Initializing Device and compiling on process 0...");
+    fflush(screen);
+  }
+
+  int init_ok=0;
+  if (world_me==0)
+    init_ok=VashishtaMF.init(ntypes, inum, nall, 500, cell_size, gpu_split, screen,
+                      host_map, nelements, host_elem2param, nparams,
+                      cutsq, r0, gamma, eta, lam1inv, 
+                      lam4inv, zizj, mbigd, dvrc, big6w, heta, bigh, bigw, 
+                      c0, costheta, bigb, big2b, bigc);
+
+  VashishtaMF.device->world_barrier();
+  if (message)
+    fprintf(screen,"Done.\n");
+
+  for (int i=0; i<procs_per_gpu; i++) {
+    if (message) {
+      if (last_gpu-first_gpu==0)
+        fprintf(screen,"Initializing Device %d on core %d...",first_gpu,i);
+      else
+        fprintf(screen,"Initializing Devices %d-%d on core %d...",first_gpu,
+                last_gpu,i);
+      fflush(screen);
+    }
+    if (gpu_rank==i && world_me!=0)
+      init_ok=VashishtaMF.init(ntypes, inum, nall, 500, cell_size, gpu_split, screen,
+                        host_map, nelements, host_elem2param, nparams,
+                        cutsq, r0, gamma, eta, lam1inv, 
+                        lam4inv, zizj, mbigd, dvrc, big6w, heta, bigh, bigw, 
+                        c0, costheta, bigb, big2b, bigc);
+
+    VashishtaMF.device->gpu_barrier();
+    if (message)
+      fprintf(screen,"Done.\n");
+  }
+  if (message)
+    fprintf(screen,"\n");
+
+  if (init_ok==0)
+    VashishtaMF.estimate_gpu_overhead();
+
+  cout << "Seems like this was ok!" << endl;
+  return init_ok;
+}
+
+void vashishta_gpu_clear() {
+  VashishtaMF.clear();
+}
+
+int ** vashishta_gpu_compute_n(const int ago, const int inum_full,
+                        const int nall, double **host_x, int *host_type,
+                        double *sublo, double *subhi, tagint *tag, int **nspecial,
+                        tagint **special, const bool eflag, const bool vflag,
+                        const bool eatom, const bool vatom, int &host_start,
+                        int **ilist, int **jnum, const double cpu_time,
+                        bool &success) {
+  return VashishtaMF.compute(ago, inum_full, nall, host_x, host_type, sublo,
+                       subhi, tag, nspecial, special, eflag, vflag, eatom,
+                       vatom, host_start, ilist, jnum, cpu_time, success);
+}
+
+void vashishta_gpu_compute(const int ago, const int nlocal, const int nall,
+                    const int nlist, double **host_x, int *host_type,
+                    int *ilist, int *numj, int **firstneigh, const bool eflag,
+                    const bool vflag, const bool eatom, const bool vatom,
+                    int &host_start, const double cpu_time, bool &success) {
+  VashishtaMF.compute(ago,nlocal,nall,nlist,host_x,host_type,ilist,numj,
+               firstneigh,eflag,vflag,eatom,vatom,host_start,cpu_time,success);
+}
+
+double vashishta_gpu_bytes() {
+  return VashishtaMF.host_memory_usage();
+}
+
+

--- a/src/GPU/Install.sh
+++ b/src/GPU/Install.sh
@@ -113,6 +113,8 @@ action pair_soft_gpu.cpp
 action pair_soft_gpu.h
 action pair_sw_gpu.cpp pair_sw.cpp
 action pair_sw_gpu.h pair_sw.h
+action pair_vashishta_gpu.cpp pair_vashishta.cpp
+action pair_vashishta_gpu.h pair_vashishta.h
 action pair_table_gpu.cpp pair_table.cpp
 action pair_table_gpu.h pair_table.cpp
 action pair_tersoff_gpu.cpp pair_tersoff.cpp

--- a/src/GPU/pair_vashishta_gpu.cpp
+++ b/src/GPU/pair_vashishta_gpu.cpp
@@ -1,0 +1,258 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Anders Hafreager (UiO)
+------------------------------------------------------------------------- */
+#include <limits>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "pair_vashishta_gpu.h"
+#include "atom.h"
+#include "neighbor.h"
+#include "neigh_request.h"
+#include "force.h"
+#include "comm.h"
+#include "memory.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "memory.h"
+#include "error.h"
+#include "domain.h"
+#include "gpu_extra.h"
+
+using namespace LAMMPS_NS;
+
+// External functions from cuda library for atom decomposition
+
+int vashishta_gpu_init(const int ntypes, const int inum, const int nall, const int max_nbors,
+                const double cell_size, int &gpu_mode, FILE *screen,
+                int* host_map, const int nelements, int*** host_elem2param, const int nparams,
+                const double* cutsq, const double* r0,
+                const double* gamma, const double* eta,
+                const double* lam1inv, const double* lam4inv,
+                const double* zizj, const double* mbigd,
+                const double* dvrc, const double* big6w, 
+                const double* heta, const double* bigh,
+                const double* bigw, const double* c0,
+                const double* costheta, const double* bigb,
+                const double* big2b, const double* bigc);
+void vashishta_gpu_clear();
+int ** vashishta_gpu_compute_n(const int ago, const int inum,
+                        const int nall, double **host_x, int *host_type,
+                        double *sublo, double *subhi, tagint *tag, int **nspecial,
+                        tagint **special, const bool eflag, const bool vflag,
+                        const bool eatom, const bool vatom, int &host_start,
+                        int **ilist, int **jnum,
+                        const double cpu_time, bool &success);
+void vashishta_gpu_compute(const int ago, const int nloc, const int nall, const int ln,
+                    double **host_x, int *host_type, int *ilist, int *numj,
+                    int **firstneigh, const bool eflag, const bool vflag,
+                    const bool eatom, const bool vatom, int &host_start,
+                    const double cpu_time, bool &success);
+double vashishta_gpu_bytes();
+extern double lmp_gpu_forces(double **f, double **tor, double *eatom,
+                             double **vatom, double *virial, double &ecoul);
+
+/* ---------------------------------------------------------------------- */
+
+PairVashishtaGPU::PairVashishtaGPU(LAMMPS *lmp) : PairVashishta(lmp), gpu_mode(GPU_FORCE)
+{
+  cpu_time = 0.0;
+  reinitflag = 0;
+  gpu_allocated = false;
+  GPU_EXTRA::gpu_ready(lmp->modify, lmp->error);
+
+  cutghost = NULL;
+  ghostneigh = 1;
+}
+
+/* ----------------------------------------------------------------------
+   check if allocated, since class can be destructed when incomplete
+------------------------------------------------------------------------- */
+
+PairVashishtaGPU::~PairVashishtaGPU()
+{
+  vashishta_gpu_clear();
+  if (allocated)
+    memory->destroy(cutghost);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairVashishtaGPU::compute(int eflag, int vflag)
+{
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = vflag_fdotr = 0;
+
+  int nall = atom->nlocal + atom->nghost;
+  int inum, host_start;
+
+  bool success = true;
+  int *ilist, *numneigh, **firstneigh;
+  if (gpu_mode != GPU_FORCE) {
+    inum = atom->nlocal;
+    firstneigh = vashishta_gpu_compute_n(neighbor->ago, inum, nall,
+                                   atom->x, atom->type, domain->sublo,
+                                   domain->subhi, atom->tag, atom->nspecial,
+                                   atom->special, eflag, vflag, eflag_atom,
+                                   vflag_atom, host_start,
+                                   &ilist, &numneigh, cpu_time, success);
+  } else {
+    inum = list->inum;
+    ilist = list->ilist;
+    numneigh = list->numneigh;
+    firstneigh = list->firstneigh;
+
+    vashishta_gpu_compute(neighbor->ago, inum, nall, inum+list->gnum,
+                   atom->x, atom->type, ilist, numneigh, firstneigh, eflag,
+                   vflag, eflag_atom, vflag_atom, host_start, cpu_time,
+                   success);
+  }
+  if (!success)
+    error->one(FLERR,"Insufficient memory on accelerator");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairVashishtaGPU::allocate()
+{
+  if(!allocated) {
+    PairVashishta::allocate();
+  }
+  int n = atom->ntypes;
+  
+  memory->create(cutghost,n+1,n+1,"pair:cutghost");
+  gpu_allocated = true;
+}
+
+/* ----------------------------------------------------------------------
+   init specific to this pair style
+------------------------------------------------------------------------- */
+
+void PairVashishtaGPU::init_style()
+{
+  double cell_size = cutmax + neighbor->skin;
+
+  if (atom->tag_enable == 0)
+    error->all(FLERR,"Pair style vashishta/gpu requires atom IDs");
+  if (force->newton_pair != 0)
+    error->all(FLERR,"Pair style vashishta/gpu requires newton pair off");
+
+  double *cutsq, *r0, *r0eps, *gamma, *eta;
+  double *lam1inv, *lam4inv, *zizj, *mbigd;
+  double *dvrc, *big6w, *heta, *bigh;
+  double *bigw, *c0, *costheta, *bigb;
+  double *big2b, *bigc;
+
+  cutsq = r0 = gamma = eta = NULL;
+  lam1inv = lam4inv = zizj = mbigd = NULL;
+  dvrc = big6w = heta = bigh = NULL;
+  bigw = c0 = costheta = bigb = NULL;
+  big2b = bigc = NULL;
+  
+  memory->create(cutsq,nparams,"pair:cutsq");
+  memory->create(r0,nparams,"pair:r0");
+  memory->create(gamma,nparams,"pair:gamma");
+  memory->create(eta,nparams,"pair:eta");
+  memory->create(lam1inv,nparams,"pair:lam1inv");
+  memory->create(lam4inv,nparams,"pair:lam4inv");
+  memory->create(zizj,nparams,"pair:zizj");
+  memory->create(mbigd,nparams,"pair:mbigd");
+  memory->create(dvrc,nparams,"pair:dvrc");
+  memory->create(big6w,nparams,"pair:big6w");
+  memory->create(heta,nparams,"pair:heta");
+  memory->create(bigh,nparams,"pair:bigh");
+  memory->create(bigw,nparams,"pair:bigw");
+  memory->create(c0,nparams,"pair:c0");
+  memory->create(costheta,nparams,"pair:costheta");
+  memory->create(bigb,nparams,"pair:bigb");
+  memory->create(big2b,nparams,"pair:big2b");
+  memory->create(bigc,nparams,"pair:bigc");
+
+  for (int i = 0; i < nparams; i++) {
+    cutsq[i] = params[i].cutsq;
+    r0[i] = params[i].r0;
+    gamma[i] = params[i].gamma;
+    eta[i] = params[i].eta;
+    lam1inv[i] = params[i].lam1inv;
+    lam4inv[i] = params[i].lam4inv;
+    zizj[i] = params[i].zizj;
+    mbigd[i] = params[i].mbigd;
+    dvrc[i] = params[i].dvrc;
+    big6w[i] = params[i].big6w;
+    heta[i] = params[i].heta;
+    bigh[i] = params[i].bigh;
+    bigw[i] = params[i].bigw;
+    c0[i] = params[i].c0;
+    costheta[i] = params[i].costheta;
+    bigb[i] = params[i].bigb;
+    big2b[i] = params[i].big2b;
+    bigc[i] = params[i].bigc;
+  }
+  int success = vashishta_gpu_init(atom->ntypes+1, atom->nlocal, atom->nlocal+atom->nghost, 500,
+                            cell_size, gpu_mode, screen, map, nelements,
+                            elem2param, nparams, cutsq, r0, gamma, eta, lam1inv, 
+                            lam4inv, zizj, mbigd, dvrc, big6w, heta, bigh, bigw, 
+                            c0, costheta, bigb, big2b, bigc);
+  memory->destroy(cutsq);
+  memory->destroy(r0);
+  memory->destroy(gamma);
+  memory->destroy(eta);
+  memory->destroy(lam1inv);
+  memory->destroy(lam4inv);
+  memory->destroy(zizj);
+  memory->destroy(mbigd);
+  memory->destroy(dvrc);
+  memory->destroy(big6w);
+  memory->destroy(heta);
+  memory->destroy(bigh);
+  memory->destroy(bigw);
+  memory->destroy(c0);
+  memory->destroy(costheta);
+  memory->destroy(bigb);
+  memory->destroy(big2b);
+  memory->destroy(bigc);
+
+  GPU_EXTRA::check_flag(success,error,world);
+
+  if (gpu_mode == GPU_FORCE) {
+    int irequest = neighbor->request(this,instance_me);
+    neighbor->requests[irequest]->half = 0;
+    neighbor->requests[irequest]->full = 1;
+    neighbor->requests[irequest]->ghost = 1;
+  }
+
+  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin) )
+    comm->cutghostuser=2.0*cutmax + neighbor->skin;
+
+}
+
+/* ----------------------------------------------------------------------
+   init for one type pair i,j and corresponding j,i
+------------------------------------------------------------------------- */
+
+double PairVashishtaGPU::init_one(int i, int j)
+{
+  if(!gpu_allocated) {
+    allocate();
+  }
+  if (setflag[i][j] == 0) error->all(FLERR,"All pair coeffs are not set");
+  cutghost[i][j] = cutmax;
+  cutghost[j][i] = cutmax;
+
+  return cutmax;
+}
+

--- a/src/GPU/pair_vashishta_gpu.h
+++ b/src/GPU/pair_vashishta_gpu.h
@@ -1,0 +1,69 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(vashishta/gpu,PairVashishtaGPU)
+
+#else
+
+#ifndef LMP_PAIR_VASHISHTA_GPU_H
+#define LMP_PAIR_VASHISHTA_GPU_H
+
+#include "pair_vashishta.h"
+
+namespace LAMMPS_NS {
+
+class PairVashishtaGPU : public PairVashishta {
+ public:
+  PairVashishtaGPU(class LAMMPS *);
+  ~PairVashishtaGPU();
+  void compute(int, int);
+  double init_one(int, int);
+  void init_style();
+
+ enum { GPU_FORCE, GPU_NEIGH, GPU_HYB_NEIGH };
+
+ protected:
+  void allocate();
+  int gpu_allocated;
+  int gpu_mode;
+  double cpu_time;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Insufficient memory on accelerator
+
+There is insufficient memory on one of the devices specified for the gpu
+package
+
+E: Pair style vashishta/gpu requires atom IDs
+
+This is a requirement to use this potential.
+
+E: Pair style vashishta/gpu requires newton pair off
+
+See the newton command.  This is a restriction to use this potential.
+
+E: All pair coeffs are not set
+
+All pair coefficients must be set in the data file or by the
+pair_coeff command before running a simulation.
+
+*/


### PR DESCRIPTION
#This PR implements the vashishta potential in the GPU package. 

- [x] NVidia
- [x] OpenCL
- [x] Documentation

A benchmark to compare implementation to CPU implementation is attached.
CUDA    DOUBLE_DOUBLE: identical output as CPU.
OpenCL DOUBLE_DOUBLE: identical output as CPU.

Mixed precision gives as follows:
**CPU**
```
Step Temp E_pair E_mol TotEng Press 
       0         2000   -50721.159            0   -48653.255    26956.023 
      10     692.5957   -49362.196            0   -48646.086    87755.757 
      20    898.27209   -49578.123            0   -48649.353    51766.322 
      30    697.14427   -49368.833            0    -48648.02    63971.301 
      40    1083.7883    -49769.89            0   -48649.305     48580.22 
      50    886.83642   -49565.326            0   -48648.379    71573.265 
      60    1123.3123   -49810.646            0   -48649.195    55667.479 
      70    950.01702   -49630.575            0   -48648.303    67439.925 
      80    1034.2977   -49718.656            0   -48649.242    55082.703 
      90    866.05594   -49543.685            0   -48648.224     67679.99 
     100    1098.3142   -49784.984            0    -48649.38    52808.022 
Loop time of 7.29486 on 1 procs for 100 steps with 8000 atoms

Performance: 1.184 ns/day, 20.264 hours/ns, 13.708 timesteps/s
```

**GPU (mixed, CUDA P100):**
```
Step Temp E_pair E_mol TotEng Press 
       0         2000   -50721.145            0   -48653.241    26954.764 
      10    692.59554   -49362.166            0   -48646.055    87755.669 
      20    898.27203   -49578.092            0   -48649.322    51766.222 
      30    697.14389   -49368.802            0   -48647.989    63971.228 
      40    1083.7885    -49769.86            0   -48649.274    48580.104 
      50    886.83622   -49565.295            0   -48648.349    71573.175 
      60     1123.312   -49810.615            0   -48649.165    55667.373 
      70    950.01712   -49630.545            0   -48648.272    67439.796 
      80    1034.2976   -49718.625            0   -48649.211    55082.599 
      90    866.05589   -49543.654            0   -48648.194    67679.901 
     100    1098.3139   -49784.953            0   -48649.349    52807.944 
Loop time of 0.293018 on 1 procs for 100 steps with 8000 atoms
Performance: 29.486 ns/day, 0.814 hours/ns, 341.276 timesteps/s
```

**GPU (mixed, OpenCL P100):**
```
Step Temp E_pair E_mol TotEng Press 
       0         2000   -50721.126            0   -48653.222    26955.401 
      10    692.59561   -49362.162            0   -48646.051    87755.883 
      20    898.27195   -49578.088            0   -48649.318    51766.456 
      30    697.14419   -49368.799            0   -48647.985    63971.427 
      40    1083.7882   -49769.855            0    -48649.27    48580.346 
      50    886.83626    -49565.29            0   -48648.344    71573.409 
      60    1123.3122   -49810.611            0    -48649.16    55667.637 
      70    950.01703   -49630.539            0   -48648.267    67440.079 
      80    1034.2975   -49718.621            0   -48649.207    55082.834 
      90    866.05582   -49543.649            0   -48648.189    67680.113 
     100    1098.3142   -49784.949            0   -48649.345    52808.163 
Loop time of 0.276476 on 1 procs for 100 steps with 8000 atoms
Performance: 31.250 ns/day, 0.768 hours/ns, 361.695 timesteps/s
``` 

[vashishta_sic.tar.gz](https://github.com/lammps/lammps/files/1074024/vashishta_sic.tar.gz)
