### PR TITLE
Refactor ring communication to no longer require static class variables

### DIFF
--- a/src/RIGID/fix_rigid_small.h
+++ b/src/RIGID/fix_rigid_small.h
@@ -31,10 +31,6 @@ class FixRigidSmall : public Fix {
   friend class ComputeRigidLocal;
 
  public:
-  // static variable for ring communication callback to access class data
-
-  static FixRigidSmall *frsptr;
-
   FixRigidSmall(class LAMMPS *, int, char **);
   virtual ~FixRigidSmall();
   virtual int setmask();
@@ -199,9 +195,9 @@ class FixRigidSmall : public Fix {
 
   // callback functions for ring communication
 
-  static void ring_bbox(int, char *);
-  static void ring_nearest(int, char *);
-  static void ring_farthest(int, char *);
+  static void ring_bbox(int, char *, void *);
+  static void ring_nearest(int, char *, void *);
+  static void ring_farthest(int, char *, void *);
 
   // debug
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -39,10 +39,6 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace MathConst;
 
-// allocate space for static class variable
-
-FixShake *FixShake::fsptr;
-
 #define BIG 1.0e20
 #define MASSDELTA 0.1
 
@@ -844,8 +840,7 @@ void FixShake::find_clusters()
 
   // cycle buffer around ring of procs back to self
 
-  fsptr = this;
-  comm->ring(size,sizeof(tagint),buf,1,ring_bonds,buf);
+  comm->ring(size,sizeof(tagint),buf,1,ring_bonds,buf,(void *)this);
 
   // store partner info returned to me
 
@@ -970,8 +965,7 @@ void FixShake::find_clusters()
 
   // cycle buffer around ring of procs back to self
 
-  fsptr = this;
-  comm->ring(size,sizeof(tagint),buf,2,ring_nshake,buf);
+  comm->ring(size,sizeof(tagint),buf,2,ring_nshake,buf,(void *)this);
 
   // store partner info returned to me
   
@@ -1123,8 +1117,7 @@ void FixShake::find_clusters()
 
   // cycle buffer around ring of procs back to self
 
-  fsptr = this;
-  comm->ring(size,sizeof(tagint),buf,3,ring_shake,NULL);
+  comm->ring(size,sizeof(tagint),buf,3,ring_shake,NULL,(void *)this);
 
   memory->destroy(buf);
 
@@ -1211,8 +1204,9 @@ void FixShake::find_clusters()
      search for bond with 1st atom and fill in bondtype
 ------------------------------------------------------------------------- */
 
-void FixShake::ring_bonds(int ndatum, char *cbuf)
+void FixShake::ring_bonds(int ndatum, char *cbuf, void *ptr)
 {
+  FixShake *fsptr = (FixShake *)ptr;
   Atom *atom = fsptr->atom;
   double *rmass = atom->rmass;
   double *mass = atom->mass;
@@ -1248,8 +1242,9 @@ void FixShake::ring_bonds(int ndatum, char *cbuf)
    if I own partner, fill in nshake value
 ------------------------------------------------------------------------- */
 
-void FixShake::ring_nshake(int ndatum, char *cbuf)
+void FixShake::ring_nshake(int ndatum, char *cbuf, void *ptr)
 {
+  FixShake *fsptr = (FixShake *)ptr;
   Atom *atom = fsptr->atom;
   int nlocal = atom->nlocal;
 
@@ -1269,8 +1264,9 @@ void FixShake::ring_nshake(int ndatum, char *cbuf)
    if I own partner, fill in nshake value
 ------------------------------------------------------------------------- */
 
-void FixShake::ring_shake(int ndatum, char *cbuf)
+void FixShake::ring_shake(int ndatum, char *cbuf, void *ptr)
 {
+  FixShake *fsptr = (FixShake *)ptr;
   Atom *atom = fsptr->atom;
   int nlocal = atom->nlocal;
 

--- a/src/RIGID/fix_shake.h
+++ b/src/RIGID/fix_shake.h
@@ -134,10 +134,9 @@ class FixShake : public Fix {
   // static variable for ring communication callback to access class data
   // callback functions for ring communication
 
-  static FixShake *fsptr;
-  static void ring_bonds(int, char *);
-  static void ring_nshake(int, char *);
-  static void ring_shake(int, char *);
+  static void ring_bonds(int, char *, void *);
+  static void ring_nshake(int, char *, void *);
+  static void ring_shake(int, char *, void *);
 };
 
 }

--- a/src/USER-DRUDE/fix_drude.cpp
+++ b/src/USER-DRUDE/fix_drude.cpp
@@ -28,8 +28,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-FixDrude *FixDrude::sptr = NULL;
-
 /* ---------------------------------------------------------------------- */
 
 FixDrude::FixDrude(LAMMPS *lmp, int narg, char **arg) :
@@ -111,7 +109,6 @@ void FixDrude::build_drudeid(){
   std::vector<tagint> core_drude_vec;
   partner_set = new std::set<tagint>[nlocal]; // Temporary sets of bond partner tags
 
-  sptr = this;
   if (atom->molecular == 1)
   {
     // Build list of my atoms' bond partners
@@ -149,7 +146,7 @@ void FixDrude::build_drudeid(){
   // Loop on procs to fill my atoms' sets of bond partners
   comm->ring(core_drude_vec.size(), sizeof(tagint),
              (char *) core_drude_vec.data(),
-             4, ring_build_partner, NULL, 1);
+             4, ring_build_partner, NULL, (void *)this, 1);
 
   // Build the list of my Drudes' tags
   // The only bond partners of a Drude particle is its core,
@@ -165,7 +162,7 @@ void FixDrude::build_drudeid(){
   // so that each core finds its Drude.
   comm->ring(drude_vec.size(), sizeof(tagint),
              (char *) drude_vec.data(),
-             3, ring_search_drudeid, NULL, 1);
+             3, ring_search_drudeid, NULL, (void *)this, 1);
   delete [] partner_set;
 }
 
@@ -174,14 +171,15 @@ void FixDrude::build_drudeid(){
  * Look in my cores' bond partner tags if there is a Drude tag.
  * If so fill this core's dureid.
 ------------------------------------------------------------------------- */
-void FixDrude::ring_search_drudeid(int size, char *cbuf){
+void FixDrude::ring_search_drudeid(int size, char *cbuf, void *ptr){
   // Search for the drude partner of my cores
-  Atom *atom = sptr->atom;
+  FixDrude *fdptr = (FixDrude *) ptr;
+  Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int *type = atom->type;
-  std::set<tagint> *partner_set = sptr->partner_set;
-  tagint *drudeid = sptr->drudeid;
-  int *drudetype = sptr->drudetype;
+  std::set<tagint> *partner_set = fdptr->partner_set;
+  tagint *drudeid = fdptr->drudeid;
+  int *drudetype = fdptr->drudetype;
 
   tagint *first = (tagint *) cbuf;
   tagint *last = first + size;
@@ -203,11 +201,12 @@ void FixDrude::ring_search_drudeid(int size, char *cbuf){
  * buffer contains bond partners. Look for my atoms and add their partner's
  * tag in its set of bond partners.
 ------------------------------------------------------------------------- */
-void FixDrude::ring_build_partner(int size, char *cbuf){
+void FixDrude::ring_build_partner(int size, char *cbuf, void *ptr){
   // Add partners from incoming list
-  Atom *atom = sptr->atom;
+  FixDrude *fdptr = (FixDrude *) ptr;
+  Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
-  std::set<tagint> *partner_set = sptr->partner_set;
+  std::set<tagint> *partner_set = fdptr->partner_set;
   tagint *it = (tagint *) cbuf;
   tagint *last = it + size;
 
@@ -338,11 +337,11 @@ void FixDrude::rebuild_special(){
   // Remove Drude particles from the special lists of each proc
   comm->ring(drude_vec.size(), sizeof(tagint),
              (char *) drude_vec.data(),
-             9, ring_remove_drude, NULL, 1);
+             9, ring_remove_drude, NULL, (void *)this, 1);
   // Add back Drude particles in the lists just after their core
   comm->ring(core_drude_vec.size(), sizeof(tagint),
              (char *) core_drude_vec.data(),
-             10, ring_add_drude, NULL, 1);
+             10, ring_add_drude, NULL, (void *)this, 1);
 
   // Check size of special list
   nspecmax_loc = 0;
@@ -373,16 +372,17 @@ void FixDrude::rebuild_special(){
   // Copy core's list into their drude list
   comm->ring(core_special_vec.size(), sizeof(tagint),
              (char *) core_special_vec.data(),
-             11, ring_copy_drude, NULL, 1);
+             11, ring_copy_drude, NULL, (void *)this, 1);
 }
 
 /* ----------------------------------------------------------------------
  * When receive buffer, build a set of drude tags, look into my atoms'
  * special list if some tags are drude particles. If so, remove it.
 ------------------------------------------------------------------------- */
-void FixDrude::ring_remove_drude(int size, char *cbuf){
+void FixDrude::ring_remove_drude(int size, char *cbuf, void *ptr){
   // Remove all drude particles from special list
-  Atom *atom = sptr->atom;
+  FixDrude *fdptr = (FixDrude *) ptr;
+  Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int **nspecial = atom->nspecial;
   tagint **special = atom->special;
@@ -390,7 +390,7 @@ void FixDrude::ring_remove_drude(int size, char *cbuf){
   tagint *first = (tagint *) cbuf;
   tagint *last = first + size;
   std::set<tagint> drude_set(first, last);
-  int *drudetype = sptr->drudetype;
+  int *drudetype = fdptr->drudetype;
 
   for (int i=0; i<nlocal; i++) {
     if (drudetype[type[i]] == DRUDE_TYPE) continue;
@@ -415,16 +415,17 @@ void FixDrude::ring_remove_drude(int size, char *cbuf){
  * Loop on my atoms' special list to find core tags. Insert their Drude
  * particle if they have one.
 ------------------------------------------------------------------------- */
-void FixDrude::ring_add_drude(int size, char *cbuf){
+void FixDrude::ring_add_drude(int size, char *cbuf, void *ptr){
   // Assume special array size is big enough
   // Add all particle just after their core in the special list
-  Atom *atom = sptr->atom;
+  FixDrude *fdptr = (FixDrude *) ptr;
+  Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int **nspecial = atom->nspecial;
   tagint **special = atom->special;
   int *type = atom->type;
-  tagint *drudeid = sptr->drudeid;
-  int *drudetype = sptr->drudetype;
+  tagint *drudeid = fdptr->drudeid;
+  int *drudetype = fdptr->drudetype;
 
   tagint *first = (tagint *) cbuf;
   tagint *last = first + size;
@@ -471,15 +472,16 @@ void FixDrude::ring_add_drude(int size, char *cbuf){
  * in the buffer. Loop on my Drude particles and copy their special
  * info from that of their core if the latter is found in the map.
 ------------------------------------------------------------------------- */
-void FixDrude::ring_copy_drude(int size, char *cbuf){
+void FixDrude::ring_copy_drude(int size, char *cbuf, void *ptr){
   // Copy special list of drude from its core (except itself)
-  Atom *atom = sptr->atom;
+  FixDrude *fdptr = (FixDrude *) ptr;
+  Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int **nspecial = atom->nspecial;
   tagint **special = atom->special;
   int *type = atom->type;
-  tagint *drudeid = sptr->drudeid;
-  int *drudetype = sptr->drudetype;
+  tagint *drudeid = fdptr->drudeid;
+  int *drudetype = fdptr->drudetype;
 
   tagint *first = (tagint *) cbuf;
   tagint *last = first + size;

--- a/src/USER-DRUDE/fix_drude.h
+++ b/src/USER-DRUDE/fix_drude.h
@@ -50,16 +50,15 @@ class FixDrude : public Fix {
 
 private:
   int rebuildflag;
-  static FixDrude *sptr;
   std::set<tagint> * partner_set;
 
   void build_drudeid();
-  static void ring_search_drudeid(int size, char *cbuf);
-  static void ring_build_partner(int size, char *cbuf);
+  static void ring_search_drudeid(int size, char *cbuf, void *ptr);
+  static void ring_build_partner(int size, char *cbuf, void *ptr);
   void rebuild_special();
-  static void ring_remove_drude(int size, char *cbuf);
-  static void ring_add_drude(int size, char *cbuf);
-  static void ring_copy_drude(int size, char *cbuf);
+  static void ring_remove_drude(int size, char *cbuf, void *ptr);
+  static void ring_add_drude(int size, char *cbuf, void *ptr);
+  static void ring_copy_drude(int size, char *cbuf, void *ptr);
 };
 
 }

--- a/src/USER-MISC/fix_filter_corotate.h
+++ b/src/USER-MISC/fix_filter_corotate.h
@@ -120,13 +120,11 @@ namespace LAMMPS_NS
     int bondtype_findset(int, tagint, tagint, int);
     int angletype_findset(int, tagint, tagint, int);
 
-    // static variable for ring communication callback to access class data
     // callback functions for ring communication
 
-    static FixFilterCorotate *fsptr;
-    static void ring_bonds(int, char *);
-    static void ring_nshake(int, char *);
-    static void ring_shake(int, char *);
+    static void ring_bonds(int, char *, void *);
+    static void ring_nshake(int, char *, void *);
+    static void ring_shake(int, char *, void *);
 
     int sgn(double val) {
       return (0 < val) - (val < 0);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -678,10 +678,12 @@ int Comm::binary(double value, int n, double *vec)
      using original inbuf, which may have been updated
    for non-NULL outbuf, final updated inbuf is copied to it
      ok to specify outbuf = inbuf
+   the ptr argument is a pointer to the instance of calling class
 ------------------------------------------------------------------------- */
 
 void Comm::ring(int n, int nper, void *inbuf, int messtag,
-                void (*callback)(int, char *), void *outbuf, int self)
+                void (*callback)(int, char *, void *),
+                void *outbuf, void *ptr, int self)
 {
   MPI_Request request;
   MPI_Status status;
@@ -712,7 +714,7 @@ void Comm::ring(int n, int nper, void *inbuf, int messtag,
       MPI_Get_count(&status,MPI_CHAR,&nbytes);
       memcpy(buf,bufcopy,nbytes);
     }
-    if (self || loop < nprocs-1) callback(nbytes/nper,buf);
+    if (self || loop < nprocs-1) callback(nbytes/nper,buf,ptr);
   }
 
   if (outbuf) memcpy(outbuf,buf,nbytes);

--- a/src/comm.h
+++ b/src/comm.h
@@ -105,8 +105,8 @@ class Comm : protected Pointers {
 
   // non-virtual functions common to all Comm styles
 
-  void ring(int, int, void *, int, void (*)(int, char *),
-            void *, int self = 1);
+  void ring(int, int, void *, int, void (*)(int, char *, void *),
+            void *, void *, int self = 1);
   int read_lines_from_file(FILE *, int, int, char *);
   int read_lines_from_file_universe(FILE *, int, int, char *);
 

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -49,10 +49,6 @@ enum{LIMITMAX,LIMITEXACT};
 #define IDMAX 1024*1024
 #define INVOKED_PERATOM 8
 
-// allocate space for static class variable
-
-ComputeChunkAtom *ComputeChunkAtom::cptr;
-
 /* ---------------------------------------------------------------------- */
 
 ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
@@ -1088,8 +1084,7 @@ void ComputeChunkAtom::compress_chunk_ids()
     memory->destroy(listall);
 
   } else {
-    cptr = this;
-    comm->ring(n,sizeof(int),list,1,idring,NULL,0);
+    comm->ring(n,sizeof(int),list,1,idring,NULL,(void *)this,0);
   }
 
   memory->destroy(list);
@@ -1121,8 +1116,9 @@ void ComputeChunkAtom::compress_chunk_ids()
    hash ends up storing all unique IDs across all procs
 ------------------------------------------------------------------------- */
 
-void ComputeChunkAtom::idring(int n, char *cbuf)
+void ComputeChunkAtom::idring(int n, char *cbuf, void *ptr)
 {
+  ComputeChunkAtom *cptr = (ComputeChunkAtom *)ptr;
   tagint *list = (tagint *) cbuf;
   std::map<tagint,int> *hash = cptr->hash;
   for (int i = 0; i < n; i++) (*hash)[list[i]] = 0;

--- a/src/compute_chunk_atom.h
+++ b/src/compute_chunk_atom.h
@@ -107,11 +107,9 @@ class ComputeChunkAtom : public Compute {
   int *exclude;              // 1 if atom is not assigned to any chunk
   std::map<tagint,int> *hash;   // store original chunks IDs before compression
 
-  // static variable for ring communication callback to access class data
-  // callback functions for ring communication
+  // callback function for ring communication
 
-  static ComputeChunkAtom *cptr;
-  static void idring(int, char *);
+  static void idring(int, char *, void *);
 
   void assign_chunk_ids();
   void compress_chunk_ids();

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -33,10 +33,6 @@
 
 using namespace LAMMPS_NS;
 
-// allocate space for static class variable
-
-DeleteAtoms *DeleteAtoms::cptr;
-
 /* ---------------------------------------------------------------------- */
 
 DeleteAtoms::DeleteAtoms(LAMMPS *lmp) : Pointers(lmp) {}
@@ -464,8 +460,7 @@ void DeleteAtoms::delete_bond()
   for (int i = 0; i < nlocal; i++)
     if (dlist[i]) list[n++] = tag[i];
 
-  cptr = this;
-  comm->ring(n,sizeof(tagint),list,1,bondring,NULL);
+  comm->ring(n,sizeof(tagint),list,1,bondring,NULL,(void *)this);
 
   delete hash;
   memory->destroy(list);
@@ -503,8 +498,7 @@ void DeleteAtoms::delete_molecule()
   std::map<tagint,int>::iterator pos;
   for (pos = hash->begin(); pos != hash->end(); ++pos) list[n++] = pos->first;
 
-  cptr = this;
-  comm->ring(n,sizeof(tagint),list,1,molring,NULL);
+  comm->ring(n,sizeof(tagint),list,1,molring,NULL,(void *)this);
 
   delete hash;
   memory->destroy(list);
@@ -576,37 +570,38 @@ void DeleteAtoms::recount_topology()
    callback from comm->ring() in delete_bond()
 ------------------------------------------------------------------------- */
 
-void DeleteAtoms::bondring(int nbuf, char *cbuf)
+void DeleteAtoms::bondring(int nbuf, char *cbuf, void *ptr)
 {
+  DeleteAtoms *daptr = (DeleteAtoms *) ptr;
   tagint *list = (tagint *) cbuf;
-  std::map<tagint,int> *hash = cptr->hash;
+  std::map<tagint,int> *hash = daptr->hash;
 
-  int *num_bond = cptr->atom->num_bond;
-  int *num_angle = cptr->atom->num_angle;
-  int *num_dihedral = cptr->atom->num_dihedral;
-  int *num_improper = cptr->atom->num_improper;
+  int *num_bond = daptr->atom->num_bond;
+  int *num_angle = daptr->atom->num_angle;
+  int *num_dihedral = daptr->atom->num_dihedral;
+  int *num_improper = daptr->atom->num_improper;
 
-  int **bond_type = cptr->atom->bond_type;
-  tagint **bond_atom = cptr->atom->bond_atom;
+  int **bond_type = daptr->atom->bond_type;
+  tagint **bond_atom = daptr->atom->bond_atom;
 
-  int **angle_type = cptr->atom->angle_type;
-  tagint **angle_atom1 = cptr->atom->angle_atom1;
-  tagint **angle_atom2 = cptr->atom->angle_atom2;
-  tagint **angle_atom3 = cptr->atom->angle_atom3;
+  int **angle_type = daptr->atom->angle_type;
+  tagint **angle_atom1 = daptr->atom->angle_atom1;
+  tagint **angle_atom2 = daptr->atom->angle_atom2;
+  tagint **angle_atom3 = daptr->atom->angle_atom3;
 
-  int **dihedral_type = cptr->atom->dihedral_type;
-  tagint **dihedral_atom1 = cptr->atom->dihedral_atom1;
-  tagint **dihedral_atom2 = cptr->atom->dihedral_atom2;
-  tagint **dihedral_atom3 = cptr->atom->dihedral_atom3;
-  tagint **dihedral_atom4 = cptr->atom->dihedral_atom4;
+  int **dihedral_type = daptr->atom->dihedral_type;
+  tagint **dihedral_atom1 = daptr->atom->dihedral_atom1;
+  tagint **dihedral_atom2 = daptr->atom->dihedral_atom2;
+  tagint **dihedral_atom3 = daptr->atom->dihedral_atom3;
+  tagint **dihedral_atom4 = daptr->atom->dihedral_atom4;
 
-  int **improper_type = cptr->atom->improper_type;
-  tagint **improper_atom1 = cptr->atom->improper_atom1;
-  tagint **improper_atom2 = cptr->atom->improper_atom2;
-  tagint **improper_atom3 = cptr->atom->improper_atom3;
-  tagint **improper_atom4 = cptr->atom->improper_atom4;
+  int **improper_type = daptr->atom->improper_type;
+  tagint **improper_atom1 = daptr->atom->improper_atom1;
+  tagint **improper_atom2 = daptr->atom->improper_atom2;
+  tagint **improper_atom3 = daptr->atom->improper_atom3;
+  tagint **improper_atom4 = daptr->atom->improper_atom4;
 
-  int nlocal = cptr->atom->nlocal;
+  int nlocal = daptr->atom->nlocal;
 
   // cbuf = list of N deleted atom IDs from other proc, put them in hash
 
@@ -692,13 +687,14 @@ void DeleteAtoms::bondring(int nbuf, char *cbuf)
    callback from comm->ring() in delete_molecule()
 ------------------------------------------------------------------------- */
 
-void DeleteAtoms::molring(int n, char *cbuf)
+void DeleteAtoms::molring(int n, char *cbuf, void *ptr)
 {
+  DeleteAtoms *daptr = (DeleteAtoms *)ptr;
   tagint *list = (tagint *) cbuf;
-  int *dlist = cptr->dlist;
-  std::map<tagint,int> *hash = cptr->hash;
-  int nlocal = cptr->atom->nlocal;
-  tagint *molecule = cptr->atom->molecule;
+  int *dlist = daptr->dlist;
+  std::map<tagint,int> *hash = daptr->hash;
+  int nlocal = daptr->atom->nlocal;
+  tagint *molecule = daptr->atom->molecule;
 
   // cbuf = list of N molecule IDs from other proc, put them in hash
 

--- a/src/delete_atoms.h
+++ b/src/delete_atoms.h
@@ -49,12 +49,10 @@ class DeleteAtoms : protected Pointers {
     return j >> SBBITS & 3;
   }
 
-  // static variable for ring communication callback to access class data
   // callback functions for ring communication
 
-  static DeleteAtoms *cptr;
-  static void bondring(int, char *);
-  static void molring(int, char *);
+  static void bondring(int, char *, void *);
+  static void molring(int, char *, void *);
 };
 
 }

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -45,10 +45,6 @@ enum{LT,LE,GT,GE,EQ,NEQ,BETWEEN};
 
 #define BIG 1.0e20
 
-// allocate space for static class variable
-
-Group *Group::cptr;
-
 /* ----------------------------------------------------------------------
    initialize group memory
 ------------------------------------------------------------------------- */
@@ -654,9 +650,8 @@ void Group::add_molecules(int igroup, int bit)
   std::map<tagint,int>::iterator pos;
   for (pos = hash->begin(); pos != hash->end(); ++pos) list[n++] = pos->first;
 
-  cptr = this;
   molbit = bit;
-  comm->ring(n,sizeof(tagint),list,1,molring,NULL);
+  comm->ring(n,sizeof(tagint),list,1,molring,NULL,(void *)this);
 
   delete hash;
   memory->destroy(list);
@@ -669,14 +664,15 @@ void Group::add_molecules(int igroup, int bit)
      add atom to group flagged by molbit
 ------------------------------------------------------------------------- */
 
-void Group::molring(int n, char *cbuf)
+void Group::molring(int n, char *cbuf, void *ptr)
 {
+  Group *gptr = (Group *) ptr;
   tagint *list = (tagint *) cbuf;
-  std::map<tagint,int> *hash = cptr->hash;
-  int nlocal = cptr->atom->nlocal;
-  tagint *molecule = cptr->atom->molecule;
-  int *mask = cptr->atom->mask;
-  int molbit = cptr->molbit;
+  std::map<tagint,int> *hash = gptr->hash;
+  int nlocal = gptr->atom->nlocal;
+  tagint *molecule = gptr->atom->molecule;
+  int *mask = gptr->atom->mask;
+  int molbit = gptr->molbit;
 
   hash->clear();
   for (int i = 0; i < n; i++) (*hash)[list[i]] = 1;

--- a/src/group.h
+++ b/src/group.h
@@ -70,11 +70,9 @@ class Group : protected Pointers {
   int find_unused();
   void add_molecules(int, int);
 
-  // static variable for ring communication callback to access class data
   // callback functions for ring communication
 
-  static Group *cptr;
-  static void molring(int, char *);
+  static void molring(int, char *, void *);
   int molbit;
 };
 

--- a/src/special.h
+++ b/src/special.h
@@ -39,18 +39,16 @@ class Special : protected Pointers {
   void combine();
   void fix_alteration();
 
-  // static variable for ring communication callback to access class data
   // callback functions for ring communication
 
-  static Special *sptr;
-  static void ring_one(int, char *);
-  static void ring_two(int, char *);
-  static void ring_three(int, char *);
-  static void ring_four(int, char *);
-  static void ring_five(int, char *);
-  static void ring_six(int, char *);
-  static void ring_seven(int, char *);
-  static void ring_eight(int, char *);
+  static void ring_one(int, char *, void *);
+  static void ring_two(int, char *, void *);
+  static void ring_three(int, char *, void *);
+  static void ring_four(int, char *, void *);
+  static void ring_five(int, char *, void *);
+  static void ring_six(int, char *, void *);
+  static void ring_seven(int, char *, void *);
+  static void ring_eight(int, char *, void *);
 };
 
 }


### PR DESCRIPTION
This implements the proposed change from march 2017 to pass a third argument (void *ptr) to the callback functions for ring communication, which allows to remove static class member variables as `this` is now passed along from the third argument.

Together with #530 LAMMPS is now very close to support concurrent instances in the same address space (on separate MPI communicators).

The changes have been tested successfully in parallel on a selection of the example inputs and with the medium regression tests.