### PR TITLE
Refactor Dump and Irregular classes to remove static class members

### DIFF
--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -80,7 +80,7 @@ Dump::Dump(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   buffer_flag = 0;
   padflag = 0;
   pbcflag = 0;
-  
+
   maxbuf = maxids = maxsort = maxproc = 0;
   buf = bufsort = NULL;
   ids = idsort = NULL;
@@ -166,13 +166,13 @@ Dump::~Dump()
   delete irregular;
 
   memory->destroy(sbuf);
-  
+
   if (pbcflag) {
     memory->destroy(xpbc);
     memory->destroy(vpbc);
     memory->destroy(imagepbc);
   }
-  
+
   if (multiproc) MPI_Comm_free(&clustercomm);
 
   // XTC style sets fp to NULL since it closes file in its destructor
@@ -273,7 +273,7 @@ void Dump::init()
   }
 
   // preallocation for PBC copies if requested
-  
+
   if (pbcflag && atom->nlocal > maxpbc) pbc_allocate();
 }
 
@@ -386,7 +386,7 @@ void Dump::write()
     atom->image = imagepbc;
     domain->pbc();
   }
-  
+
   // pack my data into buf
   // if sorting on IDs also request ID list from pack()
   // sort buf as needed
@@ -717,7 +717,8 @@ void Dump::sort()
    compare two atom IDs
    called via merge_sort() in sort() method
 ------------------------------------------------------------------------- */
-int Dump::idcompare(const int i, const int j, void *ptr) {
+int Dump::idcompare(const int i, const int j, void *ptr)
+{
   tagint *idsort = ((Dump *)ptr)->idsort;
   if (idsort[i] < idsort[j]) return -1;
   else if (idsort[i] > idsort[j]) return 1;
@@ -730,7 +731,8 @@ int Dump::idcompare(const int i, const int j, void *ptr) {
    sort in ASCENDing order
 ------------------------------------------------------------------------- */
 
-int Dump::bufcompare(const int i, const int j, void *ptr) {
+int Dump::bufcompare(const int i, const int j, void *ptr)
+{
   Dump *dptr = (Dump *) ptr;
   double *bufsort     = dptr->bufsort;
   const int size_one  = dptr->size_one;
@@ -738,7 +740,7 @@ int Dump::bufcompare(const int i, const int j, void *ptr) {
 
   const int ii=i*size_one + sortcolm1;
   const int jj=j*size_one + sortcolm1;
-        
+
   if (bufsort[ii] < bufsort[jj]) return -1;
   else if (bufsort[ii] > bufsort[jj]) return 1;
   else return 0;
@@ -749,7 +751,8 @@ int Dump::bufcompare(const int i, const int j, void *ptr) {
    sort in DESCENDing order
 ------------------------------------------------------------------------- */
 
-int Dump::bufcompare_reverse(const int i, const int j, void *ptr) {
+int Dump::bufcompare_reverse(const int i, const int j, void *ptr)
+{
   Dump *dptr = (Dump *) ptr;
   double *bufsort     = dptr->bufsort;
   const int size_one  = dptr->size_one;
@@ -757,7 +760,7 @@ int Dump::bufcompare_reverse(const int i, const int j, void *ptr) {
 
   const int ii=i*size_one + sortcolm1;
   const int jj=j*size_one + sortcolm1;
-        
+
   if (bufsort[ii] < bufsort[jj]) return 1;
   else if (bufsort[ii] > bufsort[jj]) return -1;
   else return 0;

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -30,9 +30,7 @@
 
 using namespace LAMMPS_NS;
 
-// allocate space for static class variable
-
-Dump *Dump::dumpptr;
+#include "mergesort.h"
 
 #define BIG 1.0e20
 #define EPSILON 1.0e-6
@@ -690,11 +688,10 @@ void Dump::sort()
   }
 
   if (!reorderflag) {
-    dumpptr = this;
     for (i = 0; i < nme; i++) index[i] = i;
-    if (sortcol == 0) qsort(index,nme,sizeof(int),idcompare);
-    else if (sortorder == ASCEND) qsort(index,nme,sizeof(int),bufcompare);
-    else qsort(index,nme,sizeof(int),bufcompare_reverse);
+    if (sortcol==0) merge_sort(index,nme,(void *)this,idcompare);
+    else if (sortorder==ASCEND) merge_sort(index,nme,(void *)this,bufcompare);
+    else merge_sort(index,nme,(void *)this,bufcompare_reverse);
   }
 
   // reset buf size and maxbuf to largest of any post-sort nme values
@@ -718,62 +715,52 @@ void Dump::sort()
 
 /* ----------------------------------------------------------------------
    compare two atom IDs
-   called via qsort() in sort() method
-   is a static method so access data via dumpptr
+   called via merge_sort() in sort() method
 ------------------------------------------------------------------------- */
-
-int Dump::idcompare(const void *pi, const void *pj)
-{
-  tagint *idsort = dumpptr->idsort;
-
-  int i = *((int *) pi);
-  int j = *((int *) pj);
-
+int Dump::idcompare(const int i, const int j, void *ptr) {
+  tagint *idsort = ((Dump *)ptr)->idsort;
   if (idsort[i] < idsort[j]) return -1;
-  if (idsort[i] > idsort[j]) return 1;
-  return 0;
+  else if (idsort[i] > idsort[j]) return 1;
+  else return 0;
 }
 
 /* ----------------------------------------------------------------------
    compare two buffer values with size_one stride
-   called via qsort() in sort() method
-   is a static method so access data via dumpptr
+   called via merge_sort() in sort() method
    sort in ASCENDing order
 ------------------------------------------------------------------------- */
 
-int Dump::bufcompare(const void *pi, const void *pj)
-{
-  double *bufsort = dumpptr->bufsort;
-  int size_one = dumpptr->size_one;
-  int sortcolm1 = dumpptr->sortcolm1;
+int Dump::bufcompare(const int i, const int j, void *ptr) {
+  Dump *dptr = (Dump *) ptr;
+  double *bufsort     = dptr->bufsort;
+  const int size_one  = dptr->size_one;
+  const int sortcolm1 = dptr->sortcolm1;
 
-  int i = *((int *) pi)*size_one + sortcolm1;
-  int j = *((int *) pj)*size_one + sortcolm1;
-
-  if (bufsort[i] < bufsort[j]) return -1;
-  if (bufsort[i] > bufsort[j]) return 1;
-  return 0;
+  const int ii=i*size_one + sortcolm1;
+  const int jj=j*size_one + sortcolm1;
+        
+  if (bufsort[ii] < bufsort[jj]) return -1;
+  else if (bufsort[ii] > bufsort[jj]) return 1;
+  else return 0;
 }
-
 /* ----------------------------------------------------------------------
    compare two buffer values with size_one stride
-   called via qsort() in sort() method
-   is a static method so access data via dumpptr
+   called via merge_sort() in sort() method
    sort in DESCENDing order
 ------------------------------------------------------------------------- */
 
-int Dump::bufcompare_reverse(const void *pi, const void *pj)
-{
-  double *bufsort = dumpptr->bufsort;
-  int size_one = dumpptr->size_one;
-  int sortcolm1 = dumpptr->sortcolm1;
+int Dump::bufcompare_reverse(const int i, const int j, void *ptr) {
+  Dump *dptr = (Dump *) ptr;
+  double *bufsort     = dptr->bufsort;
+  const int size_one  = dptr->size_one;
+  const int sortcolm1 = dptr->sortcolm1;
 
-  int i = *((int *) pi)*size_one + sortcolm1;
-  int j = *((int *) pj)*size_one + sortcolm1;
-
-  if (bufsort[i] > bufsort[j]) return -1;
-  if (bufsort[i] < bufsort[j]) return 1;
-  return 0;
+  const int ii=i*size_one + sortcolm1;
+  const int jj=j*size_one + sortcolm1;
+        
+  if (bufsort[ii] < bufsort[jj]) return 1;
+  else if (bufsort[ii] > bufsort[jj]) return -1;
+  else return 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/dump.h
+++ b/src/dump.h
@@ -128,7 +128,7 @@ class Dump : protected Pointers {
   virtual int convert_string(int, double *) {return 0;}
   virtual void write_data(int, double *) = 0;
   void pbc_allocate();
-    
+
   void sort();
   static int idcompare(const int, const int, void *);
   static int bufcompare(const int, const int, void *);

--- a/src/dump.h
+++ b/src/dump.h
@@ -33,6 +33,11 @@ class Dump : protected Pointers {
   int comm_forward;          // size of forward communication (0 if none)
   int comm_reverse;          // size of reverse communication (0 if none)
 
+#if defined(LMP_USE_LIBC_QSORT)
+  // static variable across all Dump objects
+  static Dump *dumpptr;         // holds a ptr to Dump currently being used
+#endif
+
   Dump(class LAMMPS *, int, char **);
   virtual ~Dump();
   void init();
@@ -130,9 +135,15 @@ class Dump : protected Pointers {
   void pbc_allocate();
 
   void sort();
+#if defined(LMP_USE_LIBC_QSORT)
+  static int idcompare(const void *, const void *);
+  static int bufcompare(const void *, const void *);
+  static int bufcompare_reverse(const void *, const void *);
+#else
   static int idcompare(const int, const int, void *);
   static int bufcompare(const int, const int, void *);
   static int bufcompare_reverse(const int, const int, void *);
+#endif
 };
 
 }

--- a/src/dump.h
+++ b/src/dump.h
@@ -33,10 +33,6 @@ class Dump : protected Pointers {
   int comm_forward;          // size of forward communication (0 if none)
   int comm_reverse;          // size of reverse communication (0 if none)
 
-  // static variable across all Dump objects
-
-  static Dump *dumpptr;         // holds a ptr to Dump currently being used
-
   Dump(class LAMMPS *, int, char **);
   virtual ~Dump();
   void init();
@@ -134,9 +130,9 @@ class Dump : protected Pointers {
   void pbc_allocate();
     
   void sort();
-  static int idcompare(const void *, const void *);
-  static int bufcompare(const void *, const void *);
-  static int bufcompare_reverse(const void *, const void *);
+  static int idcompare(const int, const int, void *);
+  static int bufcompare(const int, const int, void *);
+  static int bufcompare_reverse(const int, const int, void *);
 };
 
 }

--- a/src/irregular.h
+++ b/src/irregular.h
@@ -21,10 +21,6 @@ namespace LAMMPS_NS {
 class Irregular : protected Pointers {
  public:
 
-  // static variable across all Irregular objects, for qsort callback
-
-  static int *proc_recv_copy;
-
   Irregular(class LAMMPS *);
   ~Irregular();
   void migrate_atoms(int sortflag = 0, int preassign = 0,

--- a/src/irregular.h
+++ b/src/irregular.h
@@ -21,6 +21,12 @@ namespace LAMMPS_NS {
 class Irregular : protected Pointers {
  public:
 
+#if defined(LMP_USE_LIBC_QSORT)
+  // static variable across all Irregular objects, for qsort callback
+
+  static int *proc_recv_copy;
+#endif
+
   Irregular(class LAMMPS *);
   ~Irregular();
   void migrate_atoms(int sortflag = 0, int preassign = 0,

--- a/src/mergesort.h
+++ b/src/mergesort.h
@@ -14,13 +14,35 @@
 #ifndef LMP_MERGESORT
 #define LMP_MERGESORT
 
-/* ---------------------------------------------------------------------- */
+#include <string.h>
 
-// custom upward merge sort implementation which allows to pass a custom
-// pointer to the comparison function for access to class instances.
-// this avoids having to use global variables.
+// custom hybrid upward merge sort implementation with support to pass
+// an opaque pointer to the comparison function, e.g. for access to
+// class members. this avoids having to use global variables.
+// for improved performance, we employ an in-place insertion sort on
+// chunks of up to 32 elements and switch to merge sort from then on.
 
-// part 1. merge two sublists.
+// part 1. insertion sort for pre-sorting of small chunks
+
+static void insertion_sort(int *index, int num, void *ptr,
+                           int (*comp)(int, int, void*))
+{
+  if (num < 2) return;
+  for (int i=1; i < num; ++i) {
+    int tmp = index[i];
+    for (int j=i-1; j >= 0; --j) {
+      if ((*comp)(index[j],tmp,ptr) > 0) {
+        index[j+1] = index[j];
+      } else {
+        index[j+1] = tmp;
+        break;
+      }
+      if (j == 0) index[0] = tmp;
+    }
+  }
+}
+
+// part 2. merge two sublists
 
 static void do_merge(int *idx, int *buf, int llo, int lhi, int rlo, int rhi,
                      void *ptr, int (*comp)(int, int, void *))
@@ -34,34 +56,65 @@ static void do_merge(int *idx, int *buf, int llo, int lhi, int rlo, int rhi,
     else idx[i++] = buf[r++];
   }
     
-  while(l < lhi) idx[i++] = buf[l++];
-  while(r < rhi) idx[i++] = buf[r++];
+  while (l < lhi) idx[i++] = buf[l++];
+  while (r < rhi) idx[i++] = buf[r++];
 }
 
-// part 2: loop over sublists doubling in size with each iteration
+// part 3: loop over sublists doubling in size with each iteration.
+//         pre-sort sublists with insertion sort for better performance.
 
 static void merge_sort(int *index, int num, void *ptr,
                        int (*comp)(int, int, void *))
 {
   if (num < 2) return;
 
-  int *hold = new int[num];
-  int i,j,k,m;
+  int chunk,i,j;
 
-  i = 1;
-  while (i < num) {
-    memcpy(hold,index,sizeof(int)*num);
-    for (j=0; j < num-1; j += 2*i) {
-      k = j + 2*i;
-      if (k > num) k=num;
-      m = j+i;
-      if (m > num) m=num;
-      do_merge(index,hold,j,m,m,k,ptr,comp);
-    }
-    i *= 2;
+  // do insertion sort on chunks of up to 32 elements
+
+  chunk = 32;
+  for (i=0; i < num; i += chunk) {
+    j = (i+chunk > num) ? num-i : chunk;
+    insertion_sort(index+i,j,ptr,comp);
   }
 
-  delete[] hold;
+  // already done?
+
+  if (chunk >= num) return;
+
+  // continue with merge sort on the pre-sorted chunks.
+  // we need an extra buffer for temporary storage and two
+  // pointers to operate on, so we can swap the pointers
+  // rather than copying to the hold buffer in each pass
+
+  int *buf = new int[num];
+  int *dest = index;
+  int *hold = buf;
+
+  while (chunk < num) {
+    int m;
+
+    // swap hold and destination buffer
+
+    int *tmp = dest; dest = hold; hold = tmp;
+
+    // merge from hold array to destiation array
+
+    for (i=0; i < num-1; i += 2*chunk) {
+      j = i + 2*chunk;
+      if (j > num) j=num;
+      m = i+chunk;
+      if (m > num) m=num;
+      do_merge(dest,hold,i,m,m,j,ptr,comp);
+    }
+    chunk *= 2;
+  }
+
+  // if the final sorted data is in buf, copy back to index
+
+  if (dest == buf) memcpy(index,buf,sizeof(int)*num);
+
+  delete[] buf;
 }
 
 #endif

--- a/src/mergesort.h
+++ b/src/mergesort.h
@@ -1,0 +1,67 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifndef LMP_MERGESORT
+#define LMP_MERGESORT
+
+/* ---------------------------------------------------------------------- */
+
+// custom upward merge sort implementation which allows to pass a custom
+// pointer to the comparison function for access to class instances.
+// this avoids having to use global variables.
+
+// part 1. merge two sublists.
+
+static void do_merge(int *idx, int *buf, int llo, int lhi, int rlo, int rhi,
+                     void *ptr, int (*comp)(int, int, void *))
+{
+  int i = llo;
+  int l = llo;
+  int r = rlo;
+  while ((l < lhi) && (r < rhi)) {
+    if ((*comp)(buf[l],buf[r],ptr) < 0)
+      idx[i++] = buf[l++];
+    else idx[i++] = buf[r++];
+  }
+    
+  while(l < lhi) idx[i++] = buf[l++];
+  while(r < rhi) idx[i++] = buf[r++];
+}
+
+// part 2: loop over sublists doubling in size with each iteration
+
+static void merge_sort(int *index, int num, void *ptr,
+                       int (*comp)(int, int, void *))
+{
+  if (num < 2) return;
+
+  int *hold = new int[num];
+  int i,j,k,m;
+
+  i = 1;
+  while (i < num) {
+    memcpy(hold,index,sizeof(int)*num);
+    for (j=0; j < num-1; j += 2*i) {
+      k = j + 2*i;
+      if (k > num) k=num;
+      m = j+i;
+      if (m > num) m=num;
+      do_merge(index,hold,j,m,m,k,ptr,comp);
+    }
+    i *= 2;
+  }
+
+  delete[] hold;
+}
+
+#endif

--- a/src/mergesort.h
+++ b/src/mergesort.h
@@ -22,13 +22,6 @@
 // for improved performance, we employ an in-place insertion sort on
 // chunks of up to 64 elements and switch to merge sort from then on.
 
-// compile with -DLMP_USE_MERGE_SORT to switch to a plain merge sort
-
-#if !defined(LMP_USE_MERGE_SORT) && !defined(LMP_USE_HYBRID_SORT)
-#define LMP_USE_HYBRID_SORT
-#endif
-
-#if defined(LMP_USE_HYBRID_SORT)
 // part 1. insertion sort for pre-sorting of small chunks
 
 static void insertion_sort(int *index, int num, void *ptr,
@@ -48,7 +41,6 @@ static void insertion_sort(int *index, int num, void *ptr,
     }
   }
 }
-#endif
 
 // part 2. merge two sublists
 
@@ -78,8 +70,6 @@ static void merge_sort(int *index, int num, void *ptr,
 
   int chunk,i,j;
 
-#if defined(LMP_USE_HYBRID_SORT)
-
   // do insertion sort on chunks of up to 64 elements
 
   chunk = 64;
@@ -91,10 +81,6 @@ static void merge_sort(int *index, int num, void *ptr,
   // already done?
 
   if (chunk >= num) return;
-
-#else
-  chunk = 1;
-#endif
 
   // continue with merge sort on the pre-sorted chunks.
   // we need an extra buffer for temporary storage and two


### PR DESCRIPTION
This pull request replaces code in `Dump` and `Irregular` that requires static class members, i.e. global variables in order to pass information to the comparison function use by `qsort()` from the C-library.
Instead we use now a customized merge sort, with comparison functions that accept a void pointer
that is passed through the merge sort function call.

With these changes and the changes in #528 , we are very close to being able to safely use multiple LAMMPS instances concurrently (on separate MPI communicators, that is).

**Update**: Performance tuning of the merge sort function. The the index array is now pre-sorted in 64 element chunks with an insertion sort and copies between the merge passes have been replaced with swapping pointers.