### PR TITLE
recover running USER-DPD with USER-OMP and suffixes

### DIFF
--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -184,12 +184,12 @@ void FixShardlow::setup(int vflag)
   bool fixShardlow = false;
 
   for (int i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"nvt") == 0 || strcmp(modify->fix[i]->style,"npt") == 0)
+    if (strncmp(modify->fix[i]->style,"nvt",3) == 0 || strncmp(modify->fix[i]->style,"npt",3) == 0)
       error->all(FLERR,"Cannot use constant temperature integration routines with DPD.");
 
   for (int i = 0; i < modify->nfix; i++){
     if (strcmp(modify->fix[i]->style,"shardlow") == 0) fixShardlow = true;
-    if (strcmp(modify->fix[i]->style,"nve") == 0 || (strcmp(modify->fix[i]->style,"nph") == 0)){
+    if (strncmp(modify->fix[i]->style,"nve",3) == 0 || (strncmp(modify->fix[i]->style,"nph",3) == 0)){
       if(fixShardlow) break;
       else error->all(FLERR,"The deterministic integrator must follow fix shardlow in the input file.");
     }


### PR DESCRIPTION
this PR restores heuristics for checking against integrators that broke after PR #499 was merged so that you can run with -sf omp again. this should be generalized, but this change will revover the previous behavior.