### PR TITLE
Implement workaround for NVCC incompatibilities with OpenMP directives

### DIFF
--- a/src/USER-OMP/pair_comb_omp.cpp
+++ b/src/USER-OMP/pair_comb_omp.cpp
@@ -484,7 +484,7 @@ double PairCombOMP::yasu_char(double *qf_fix, int &igroup)
 
         qfo_field(&params[iparam_ij],rsq1,iq,jq,fqji,fqjj);
         fqi   += jq * fqij + fqji;
-#if defined(_OPENMP)
+#if defined(_OPENMP) && !defined(__NVCC__)
 #pragma omp atomic
 #endif
         qf[j] += (iq * fqij + fqjj);
@@ -511,13 +511,13 @@ double PairCombOMP::yasu_char(double *qf_fix, int &igroup)
 
         qfo_short(&params[iparam_ij],i,nj,rsq1,iq,jq,fqij,fqjj);
         fqi += fqij;
-#if defined(_OPENMP)
+#if defined(_OPENMP) && !defined(__NVCC__)
 #pragma omp atomic
 #endif
         qf[j] += fqjj;
       }
 
-#if defined(_OPENMP)
+#if defined(_OPENMP) && !defined(__NVCC__)
 #pragma omp atomic
 #endif
       qf[i] += fqi;

--- a/src/USER-OMP/reaxc_torsion_angles_omp.cpp
+++ b/src/USER-OMP/reaxc_torsion_angles_omp.cpp
@@ -69,8 +69,10 @@ void Torsion_AnglesOMP( reax_system *system, control_params *control,
   double total_Econ = 0;
   int  nthreads = control->nthreads;
 
+#if defined(_OPENMP)
 #pragma omp parallel default(shared) reduction(+: total_Etor, total_Econ)
- {
+#endif
+  {
   int i, j, k, l, pi, pj, pk, pl, pij, plk;
   int type_i, type_j, type_k, type_l;
   int start_j, end_j;
@@ -125,7 +127,9 @@ void Torsion_AnglesOMP( reax_system *system, control_params *control,
                                     system->N, system->pair_ptr->eatom,
                                     system->pair_ptr->vatom, thr);
 
+#if defined(_OPENMP)
 #pragma omp for schedule(static)
+#endif
   for (j = 0; j < system->N; ++j) {
     start_j = Start_Index(j, bonds);
     end_j = End_Index(j, bonds);
@@ -137,7 +141,9 @@ void Torsion_AnglesOMP( reax_system *system, control_params *control,
     }
   }
 
+#if defined(_OPENMP)
 #pragma omp for schedule(dynamic,50)
+#endif
   for (j = 0; j < natoms; ++j) {
     type_j = system->my_atoms[j].type;
     Delta_j = workspace->Delta_boc[j];


### PR DESCRIPTION
When compiling KOKKOS enabled LAMMPS with CUDA support and OpenMP enabled, compilation fails on several valid OpenMP constructs in the USER-OMP package due to nvcc not being able to correctly parse certain combinations of OpenMP constructs (multiple atomics, barrier/master). Those NVCC compilations on non-KOKKOS files are not really needed and should produce no output, but the current build setup requires it and simplifies compiling of KOKKOS enabled LAMMPS significantly.

To avoid the NVCC issues, the conflicting compiler directives are wrapped in an `#if defined(_OPENMP) && !defined(__NVCC__)` `#endif` bracket and compilation will succeed, since NVCC no longer sees the offending directives.

This closes #535