### PR TITLE
use CHARMM energy conversion factor with new CHARMM pair styles

### DIFF
--- a/doc/src/kspace_modify.txt
+++ b/doc/src/kspace_modify.txt
@@ -219,10 +219,10 @@ instead of using the virial equation. This option cannot be used to access
 individual components of the pressure tensor, to compute per-atom virial,
 or with suffix kspace/pair styles of MSM, like OMP or GPU.
 
-The {fftbench} keyword applies only to PPPM. It is on by default. If
-this option is turned off, LAMMPS will not take the time at the end
-of a run to give FFT benchmark timings, and will finish a few seconds
-faster than it would if this option were on.
+The {fftbench} keyword applies only to PPPM. It is off by default. If
+this option is turned on, LAMMPS will perform a short FFT benchmark
+computation and report its timings, and will thus finish a some seconds
+later than it would if this option were off.
 
 The {collective} keyword applies only to PPPM.  It is set to {no} by
 default, except on IBM BlueGene machines.  If this option is set to
@@ -306,7 +306,7 @@ parameters, see the "How-To"_Section_howto.html#howto_24 discussion.
 The option defaults are mesh = mesh/disp = 0 0 0, order = order/disp =
 5 (PPPM), order = 10 (MSM), minorder = 2, overlap = yes, force = -1.0,
 gewald = gewald/disp = 0.0, slab = 1.0, compute = yes, cutoff/adjust =
-yes (MSM), pressure/scalar = yes (MSM), fftbench = yes (PPPM), diff = ik
+yes (MSM), pressure/scalar = yes (MSM), fftbench = no (PPPM), diff = ik
 (PPPM), mix/disp = pair, force/disp/real = -1.0, force/disp/kspace = -1.0,
 split = 0, tol = 1.0e-6, and disp/auto = no. For pppm/intel, order =
 order/disp = 7.

--- a/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
@@ -65,8 +65,12 @@ PairLJCharmmfswCoulLong::PairLJCharmmfswCoulLong(LAMMPS *lmp) : Pair(lmp)
 
   // switch qqr2e from LAMMPS value to CHARMM value
 
-  if (strcmp(update->unit_style,"real") == 0)
+  if (strcmp(update->unit_style,"real") == 0) {
+    if ((comm->me == 0) && (force->qqr2e != force->qqr2e_charmm_real))
+      error->message(FLERR,"Switching to CHARMM coulomb energy"
+                     " conversion constant");
     force->qqr2e = force->qqr2e_charmm_real;
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -96,8 +100,12 @@ PairLJCharmmfswCoulLong::~PairLJCharmmfswCoulLong()
 
   // switch qqr2e back from CHARMM value to LAMMPS value
 
-  if (strcmp(update->unit_style,"real") == 0)
+  if (update && strcmp(update->unit_style,"real") == 0) {
+    if ((comm->me == 0) && (force->qqr2e == force->qqr2e_charmm_real))
+      error->message(FLERR,"Restoring original LAMMPS coulomb energy"
+                     " conversion constant");
     force->qqr2e = force->qqr2e_lammps_real;
+  }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
@@ -25,6 +25,7 @@
 #include <string.h>
 #include "pair_lj_charmmfsw_coul_long.h"
 #include "atom.h"
+#include "update.h"
 #include "comm.h"
 #include "force.h"
 #include "kspace.h"
@@ -61,6 +62,11 @@ PairLJCharmmfswCoulLong::PairLJCharmmfswCoulLong(LAMMPS *lmp) : Pair(lmp)
   // short-range/long-range flag accessed by DihedralCharmmfsw
 
   dihedflag = 1;
+
+  // switch qqr2e from LAMMPS value to CHARMM value
+
+  if (strcmp(update->unit_style,"real") == 0)
+    force->qqr2e = force->qqr2e_charmm_real;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -87,6 +93,11 @@ PairLJCharmmfswCoulLong::~PairLJCharmmfswCoulLong()
     }
     if (ftable) free_tables();
   }
+
+  // switch qqr2e back from CHARMM value to LAMMPS value
+
+  if (strcmp(update->unit_style,"real") == 0)
+    force->qqr2e = force->qqr2e_lammps_real;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
+++ b/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
@@ -50,8 +50,12 @@ PairLJCharmmfswCoulCharmmfsh::PairLJCharmmfswCoulCharmmfsh(LAMMPS *lmp) :
 
   // switch qqr2e from LAMMPS value to CHARMM value
 
-  if (strcmp(update->unit_style,"real") == 0)
+  if (strcmp(update->unit_style,"real") == 0) {
+    if ((comm->me == 0) && (force->qqr2e != force->qqr2e_charmm_real))
+      error->message(FLERR,"Switching to CHARMM coulomb energy"
+                     " conversion constant");
     force->qqr2e = force->qqr2e_charmm_real;
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -80,8 +84,12 @@ PairLJCharmmfswCoulCharmmfsh::~PairLJCharmmfswCoulCharmmfsh()
 
   // switch qqr2e back from CHARMM value to LAMMPS value
 
-  if (strcmp(update->unit_style,"real") == 0)
+  if (update && strcmp(update->unit_style,"real") == 0) {
+    if ((comm->me == 0) && (force->qqr2e == force->qqr2e_charmm_real))
+      error->message(FLERR,"Restoring original LAMMPS coulomb energy"
+                     " conversion constant");
     force->qqr2e = force->qqr2e_lammps_real;
+  }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
+++ b/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
@@ -25,6 +25,7 @@
 #include <string.h>
 #include "pair_lj_charmmfsw_coul_charmmfsh.h"
 #include "atom.h"
+#include "update.h"
 #include "comm.h"
 #include "force.h"
 #include "neighbor.h"
@@ -46,6 +47,11 @@ PairLJCharmmfswCoulCharmmfsh::PairLJCharmmfswCoulCharmmfsh(LAMMPS *lmp) :
   // short-range/long-range flag accessed by DihedralCharmmfsw
 
   dihedflag = 0;
+
+  // switch qqr2e from LAMMPS value to CHARMM value
+
+  if (strcmp(update->unit_style,"real") == 0)
+    force->qqr2e = force->qqr2e_charmm_real;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -71,6 +77,11 @@ PairLJCharmmfswCoulCharmmfsh::~PairLJCharmmfswCoulCharmmfsh()
       memory->destroy(lj14_4);
     }
   }
+
+  // switch qqr2e back from CHARMM value to LAMMPS value
+
+  if (strcmp(update->unit_style,"real") == 0)
+    force->qqr2e = force->qqr2e_lammps_real;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -53,6 +53,8 @@ Force::Force(LAMMPS *lmp) : Pointers(lmp)
   special_extra = 0;
 
   dielectric = 1.0;
+  qqr2e_lammps_real = 332.06371;          // these constants are toggled
+  qqr2e_charmm_real = 332.0716;           // by new CHARMM pair styles
 
   pair = NULL;
   bond = NULL;

--- a/src/force.h
+++ b/src/force.h
@@ -43,6 +43,9 @@ class Force : protected Pointers {
   double femtosecond;                // 1 femtosecond in native units
   double qelectron;                  // 1 electron charge abs() in native units
 
+  double qqr2e_lammps_real;          // different versions of this constant
+  double qqr2e_charmm_real;          // used by new CHARMM pair styles
+
   int newton,newton_pair,newton_bond;   // Newton's 3rd law settings
 
   class Pair *pair;

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -165,8 +165,8 @@ void Min::init()
 
   if (neigh_every != 1 || neigh_delay != 0 || neigh_dist_check != 1) {
     if (comm->me == 0)
-      error->warning(FLERR,
-                     "Resetting reneighboring criteria during minimization");
+      error->warning(FLERR, "Using 'neigh_modify every 1 delay 0 check"
+                     " yes' setting during minimization");
   }
 
   neighbor->every = 1;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -154,7 +154,7 @@ void Update::set_units(const char *style)
     force->ftm2v = 1.0 / 48.88821291 / 48.88821291;
     force->mv2d = 1.0 / 0.602214129;
     force->nktv2p = 68568.415;
-    force->qqr2e = 332.06371;
+    force->qqr2e = 332.06371;     // see also force->qqr2d_lammps_real
     force->qe2f = 23.060549;
     force->vxmu2f = 1.4393264316e4;
     force->xxt2kmu = 0.1;


### PR DESCRIPTION
In addition to the CHARMM related changes, this PR includes an updated message for the temporary neighbor settings reset and and update of the `kspace_modify` docs to reflect the current state of the `fftbench` keyword.