### PR TITLE
Correct handling of triclinic box support in pppm/tip4p and pppm/tip4p/omp

### DIFF
--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -186,6 +186,10 @@ void PPPM::init()
   // error check
 
   triclinic_check();
+
+  if (triclinic != domain->triclinic)
+    error->all(FLERR,"Must redefine kspace_style after changing to triclinic box");
+
   if (domain->triclinic && differentiation_flag == 1)
     error->all(FLERR,"Cannot (yet) use PPPM with triclinic box "
                "and kspace_modify diff ad");

--- a/src/KSPACE/pppm_tip4p.cpp
+++ b/src/KSPACE/pppm_tip4p.cpp
@@ -332,9 +332,9 @@ void PPPMTIP4P::fieldforce_ad()
 
     const double qfactor = qqrd2e * scale;
 
-    s1 = x[i][0]*hx_inv;
-    s2 = x[i][1]*hy_inv;
-    s3 = x[i][2]*hz_inv;
+    s1 = xi[0]*hx_inv;
+    s2 = xi[1]*hy_inv;
+    s3 = xi[2]*hz_inv;
     sf = sf_coeff[0]*sin(2*MY_PI*s1);
     sf += sf_coeff[1]*sin(4*MY_PI*s1);
     sf *= 2.0*q[i]*q[i];

--- a/src/KSPACE/pppm_tip4p.h
+++ b/src/KSPACE/pppm_tip4p.h
@@ -39,7 +39,6 @@ class PPPMTIP4P : public PPPM {
 
  private:
   void find_M(int, int &, int &, double *);
-  void find_M_triclinic(int, int, int, double *);
 };
 
 }


### PR DESCRIPTION
Kspace style `pppm/tip4p` breaks when changing the box from orthogonal to triclinic, even without setting a tilt factor. I have tracked this down to the `PPPMTIP4P::find_M()` function (e.g. with setting the offset of point M to 0.0 the results are consistent with using a non-tip4p pair style and kspace style).
The problem lies in finding the closest image. While local atoms at this point are in lambda coordinates, ghost atoms are not, thus calling `Domain::closest_image()` fails. I've thus implemented a custom variant directly into `find_M()` which also eliminates the need for `find_M_triclinic()`. This change is now also ported to kspace style `pppm/tip4p/omp`.

To avoid memory corruption resulting from different memory layout for orthogonal versus triclinic boxes, a check is added, requiring to reissue a new `kspace_style` command after `change_box all triclinic`, if the style was already defined before.
