### PR TITLE
add single options to create_bonds command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,11 @@ _Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in 
 
 ## Implementation Notes
 
-_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features, if any, in LAMMPS are affected_
+_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_
+
+## Backward Compatibility
+
+_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_
 
 ## Post Submission Checklist
 

--- a/doc/src/create_bonds.txt
+++ b/doc/src/create_bonds.txt
@@ -10,53 +10,93 @@ create_bonds command :h3
 
 [Syntax:]
 
-create_bonds group-ID group2-ID btype rmin rmax :pre
+create_bonds style args ... keyword value ... :pre
 
-group-ID = ID of first group
-group2-ID = ID of second group, bonds will be between atoms in the 2 groups
-btype = bond type of created bonds
-rmin = minimum distance between pair of atoms to bond together
-rmax = minimum distance between pair of atoms to bond together :ul
+style = {many} or {single/bond} or {single/angle} or {single/dihedral} :ule,l
+  {many} args = group-ID group2-ID btype rmin rmax
+    group-ID = ID of first group
+    group2-ID = ID of second group, bonds will be between atoms in the 2 groups
+    btype = bond type of created bonds
+    rmin = minimum distance between pair of atoms to bond together
+    rmax = minimum distance between pair of atoms to bond together
+  {single/bond} args = btype batom1 batom2
+    btype = bond type of new bond
+    batom1,batom2 = atom IDs for two atoms in bond
+  {single/angle} args = atype aatom1 aatom2 aatom3
+    atype = bond type of new angle
+    aatom1,aatom2,aatom3 = atom IDs for three atoms in angle
+  {single/dihedral} args = dtype datom1 datom2 datom3 datom4
+    dtype = bond type of new dihedral
+    datom1,datom2,datom3,datom4 = atom IDs for four atoms in dihedral :pre
+zero or more keyword/value pairs may be appended :l
+keyword = {special} :l
+  {special} value = {yes} or {no} :pre
+:ule
 
 [Examples:]
 
-create_bonds all all 1 1.0 1.2
-create_bonds surf solvent 3 2.0 2.4 :pre
+create_bonds many all all 1 1.0 1.2
+create_bonds many surf solvent 3 2.0 2.4
+create_bond single/bond 1 1 2
+create_bond single/angle 5 52 98 107 special no :pre
 
 [Description:]
 
-Create bonds between pairs of atoms that meet specified distance
-criteria.  The bond interactions can then be computed during a
-simulation by the bond potential defined by the
-"bond_style"_bond_style.html and "bond_coeff"_bond_coeff.html
-commands.  This command is useful for adding bonds to a system,
-e.g. between nearest neighbors in a lattice of atoms, without having
-to enumerate all the bonds in the data file read by the
-"read_data"_read_data.html command.
+Create bonds between pairs of atoms that meet a specified distance
+criteria.  Or create a single bond, angle, or dihedral between 2, 3,
+or 4 specified atoms.
 
-Note that the flexibility of this command is limited.  It can be used
-several times to create different types of bond at different
-distances.  But it cannot typically create all the bonds that would
-normally be defined in a complex system of molecules.  Also note that
-this command does not add any 3-body or 4-body interactions which,
-depending on your model, may be induced by added bonds,
-e.g. "angle"_angle_style.html, "dihedral"_dihedral_style.html, or
-"improper"_improper_style.html interactions.
+The new bond (angle, diehdral) interactions will then be computed
+during a simulation by the bond (angle, dihedral) potential defined by
+the "bond_style"_bond_style.html, "bond_coeff"_bond_coeff.html,
+"angle_style"_angle_style.html, "angle_coeff"_angle_coeff.html,
+"dihedral_style"_dihedral_style.html,
+"dihedral_coeff"_dihedral_coeff.html commands.
 
-All created bonds will be between pairs of atoms I,J where I is in one
-of the two specified groups, and J is in the other.  The two groups
-can be the same, e.g. group "all".  The created bonds will be of bond
-type {btype}, where {btype} must be a value between 1 and the number
-of bond types defined.  This maximum value is set by the "bond types"
-field in the header of the data file read by the
-"read_data"_read_data.html command, or via the optional "bond/types"
-argument of the "create_box"_create_box.html command.
+The {many} style is useful for adding bonds to a system, e.g. between
+nearest neighbors in a lattice of atoms, without having to enumerate
+all the bonds in the data file read by the "read_data"_read_data.html
+command.
+
+The {single} styles are useful for adding bonds, angles, dihedrals
+to a system incrementally, then continuing a simulation.
+
+Note that this command does not auto-create any angle or dihedral
+interactions when a bond is added.  Nor does it auto-create any bonds
+when an angle or dihedral is added.  Or auto-create any angles when a
+dihedral is added.  Thus the flexibility of this command is limited.
+It can be used several times to create different types of bond at
+different distances.  But it cannot typically auto-create all the
+bonds or angles or dihedral that would normally be defined in a data
+file for a complex system of molecules.
+
+NOTE: If the system has no bonds (angles, dihedrals) to begin with, or
+if more bonds per atom are being added than currently exist, then you
+must insure that the number of bond types and the maximum number of
+bonds per atom are set to large enough values.  And similarly for
+angles and dihedrals.  Otherwise an error may occur when too many
+bonds (angles, dihedrals) are added to an atom.  If the
+"read_data"_read_data.html command is used to define the system, these
+parameters can be set via the "bond types" and "extra bond per atom"
+fields in the header section of the data file.  If the
+"create_box"_create_box.html command is used to define the system,
+these 2 parameters can be set via its optional "bond/types" and
+"extra/bond/per/atom" arguments.  And similarly for angles and
+dihedrals.  See the doc pages for these 2 commands for details.
+
+:line
+
+The {many} style will create bonds between pairs of atoms I,J where I
+is in one of the two specified groups, and J is in the other.  The two
+groups can be the same, e.g. group "all".  The created bonds will be
+of bond type {btype}, where {btype} must be a value between 1 and the
+number of bond types defined. 
 
 For a bond to be created, an I,J pair of atoms must be a distance D
 apart such that {rmin} <= D <= {rmax}.
 
-The following settings must have been made in an input
-script before this command is used:
+The following settings must have been made in an input script before
+this style is used:
 
 special_bonds weight for 1-2 interactions must be 0.0
 a "pair_style"_pair_style.html must be defined
@@ -69,8 +109,8 @@ cannot appear in the neighbor list, to avoid creation of duplicate
 bonds.  The neighbor list for all atom type pairs must also extend to
 a distance that encompasses the {rmax} for new bonds to create.
 
-An additional requirement is that your system must be ready to perform
-a simulation.  This means, for example, that all
+An additional requirement for this style is that your system must be
+ready to perform a simulation.  This means, for example, that all
 "pair_style"_pair_style.html coefficients be set via the
 "pair_coeff"_pair_coeff.html command.  A "bond_style"_bond_style.html
 command and all bond coefficients must also be set, even if no bonds
@@ -83,17 +123,58 @@ executes, e.g. if you wish to use long-range Coulombic interactions
 via the "kspace_style"_kspace_style.html command for your subsequent
 simulation.
 
-NOTE: If the system has no bonds to begin with, or if more bonds per
-atom are being added than currently exist, then you must insure that
-the number of bond types and the maximum number of bonds per atom are
-set to large enough values.  Otherwise an error may occur when too
-many bonds are added to an atom.  If the "read_data"_read_data.html
-command is used to define the system, these 2 parameters can be set
-via the "bond types" and "extra bond per atom" fields in the header
-section of the data file.  If the "create_box"_create_box.html command
-is used to define the system, these 2 parameters can be set via its
-optional "bond/types" and "extra/bond/per/atom" arguments.  See the
-doc pages for the 2 commands for details.
+:line
+
+The {single/bond} style creates a signle bond of type {btype} between
+two atoms with IDs {batom1} and {batom2}.  {Btype} must be a value
+between 1 and the number of bond types defined.
+
+The {single/angle} style creates a single angle of type {atype}
+between three atoms with IDs {aatom1}, {aatom2}, and {aatom3}.  The
+ordering of the atoms is the same as in the {Angles} section of a data
+file read by the "read_data"_read_data command.  I.e. the 3 atoms are
+ordered linearly within the angle; the central atom is {aatom2}.
+{Atype} must be a value between 1 and the number of angle types
+defined.
+
+The {single/dihedral} style creates a signle dihedral of type {btype}
+between two atoms with IDs {batom1} and {batom2}.  The ordering of the
+atoms is the same as in the {Dihedrals} section of a data file read by
+the "read_data"_read_data command.  I.e. the 4 atoms are ordered
+linearly within the dihedral.  {Dtype} must be a value between 1 and
+the number of dihedral types defined.
+
+:line
+
+The keyword {special} controls whether an internal list of special
+bonds is created after one or more bonds, or a single angle or
+dihedral is added to the system.
+
+The default value is {yes}.  A value of {no} cannot be used
+with the {many} style.
+
+This is an expensive operation since the bond topology for the system
+must be walked to find all 1-2, 1-3, 1-4 interactions to store in an
+internal list, which is used when pairwise interactions are weighted;
+see the "special_bonds"_special_bonds.html command for details.
+
+Thus if you are adding a few bonds or a large list of angles all at
+the same time, by using this command repeatedly, it is more efficient
+to only trigger the internal list to be created once, after the last
+bond (or angle, or dihedral) is added:
+
+create_bonds single/bond 5 52 98 special no
+create_bonds single/bond  5 73 74 special no
+...
+create_bonds single/bond 5 17 386 special no
+create_bonds single/bond 4 112 183 special yes :pre
+
+Note that you MUST insure the internal list is re-built after the last
+bond (angle, dihedral) is added, before performing a simulation.
+Otherwise pairwise interactions will not be properly excluded or
+weighted.  LAMMPS does NOT check that you have done this correctly.
+
+:line
 
 [Restrictions:]
 
@@ -105,4 +186,6 @@ molecule template files via the "molecule"_molecule.html and
 
 "create_atoms"_create_atoms.html, "delete_bonds"_delete_bonds.html
 
-[Default:] none
+[Default:]
+
+The keyword default is special = yes.

--- a/doc/src/create_bonds.txt
+++ b/doc/src/create_bonds.txt
@@ -46,7 +46,7 @@ Create bonds between pairs of atoms that meet a specified distance
 criteria.  Or create a single bond, angle, or dihedral between 2, 3,
 or 4 specified atoms.
 
-The new bond (angle, diehdral) interactions will then be computed
+The new bond (angle, dihedral) interactions will then be computed
 during a simulation by the bond (angle, dihedral) potential defined by
 the "bond_style"_bond_style.html, "bond_coeff"_bond_coeff.html,
 "angle_style"_angle_style.html, "angle_coeff"_angle_coeff.html,
@@ -125,7 +125,7 @@ simulation.
 
 :line
 
-The {single/bond} style creates a signle bond of type {btype} between
+The {single/bond} style creates a single bond of type {btype} between
 two atoms with IDs {batom1} and {batom2}.  {Btype} must be a value
 between 1 and the number of bond types defined.
 
@@ -137,7 +137,7 @@ ordered linearly within the angle; the central atom is {aatom2}.
 {Atype} must be a value between 1 and the number of angle types
 defined.
 
-The {single/dihedral} style creates a signle dihedral of type {btype}
+The {single/dihedral} style creates a single dihedral of type {btype}
 between two atoms with IDs {batom1} and {batom2}.  The ordering of the
 atoms is the same as in the {Dihedrals} section of a data file read by
 the "read_data"_read_data command.  I.e. the 4 atoms are ordered

--- a/src/create_bonds.h
+++ b/src/create_bonds.h
@@ -30,9 +30,15 @@ class CreateBonds : protected Pointers {
   void command(int, char **);
 
  private:
-  inline int sbmask(int j) const {
-    return j >> SBBITS & 3;
-  }
+  int igroup,group1bit,group2bit;
+  int btype,atype,dtype;
+  tagint batom1,batom2,aatom1,aatom2,aatom3,datom1,datom2,datom3,datom4;
+  double rmin,rmax;
+
+  void many();
+  void single_bond();
+  void single_angle();
+  void single_dihedral();
 };
 
 }


### PR DESCRIPTION
## Purpose

Incorporate code sent by Mike Salerno (NRL) to allow creation of single bonds, angles,
dihedrals from the input script.  Old behavior of create_bonds is now the "many" option.

## Implementation Notes

Changes the syntax of old create_bonds ... to create_bonds many ...

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

N/A

