### PR TITLE
Dynamic group and normalization support for compute rdf

### DIFF
--- a/doc/src/compute_rdf.txt
+++ b/doc/src/compute_rdf.txt
@@ -180,9 +180,18 @@ will register an arbitrarily large spike at whatever distance they
 happen to be at, and zero everywhere else.  Coord(r) will show a step
 change from zero to one at the location of the spike in g(r).
 
+NOTE: compute rdf can handle dynamic groups and systems where atoms
+are added or removed, but this causes that certain normalization
+parameters need to be recomputed in every step and include collective
+communication operations. This will reduce performance and limit
+parallel efficiency and scaling. For systems, where only the type
+of atoms changes (e.g. when using "fix atom/swap"_fix_atom_swap.html),
+you need to explicitly request the dynamic normalization updates
+via "compute_modify dynamic yes"_compute_modify.html
+
 [Related commands:]
 
-"fix ave/time"_fix_ave_time.html
+"fix ave/time"_fix_ave_time.html, "compute_modify"_compute_modify.html
 
 [Default:]
 

--- a/src/compute_rdf.h
+++ b/src/compute_rdf.h
@@ -51,6 +51,8 @@ class ComputeRDF : public Compute {
   int *duplicates;
 
   class NeighList *list; // half neighbor list
+  void init_norm();
+  bigint natoms_old;
 };
 
 }


### PR DESCRIPTION

## Purpose
This PR implements support for computing g(r)s for systems with dynamic groups or atoms being deposited or removed or atom types being changed. This closes #183 

## Author(s)

@akohlmey

## Backward Compatibility

Existing functionality is unchanged and should not see a negative performance impact.

## Implementation Notes

The computation of certain pre-factors for normalization and correcting for finite size and double counting is moved to its own function `ComputeRDF::init_norm()`, which is called during `ComputeRDF::init()` (to retain the original behavior) but also, when `Compute::dynamic` is non-zero during `ComputeRDF::compute_array()`. The the dynamic flag defaults to 0 but will be changed under three conditions: a) the compute group is flagged as dynamic, b) the value of `Atom::natoms` changes or c) if the command `compute_modify <compute id> dynamic yes` is issued.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
