### PR TITLE
Add extension point to write integrators in Python

### DIFF
--- a/examples/python/README.fix_python_integrate
+++ b/examples/python/README.fix_python_integrate
@@ -1,0 +1,15 @@
+This folder contains several LAMMPS input scripts and a python module
+file py_integrate.py to demonstrate the use of the fix style python/integrate.
+
+in.fix_python_integrate_melt:
+This is a version of the melt example which replaces the default NVE integrator
+with a Python implementation. Fix python/integrate is used to create an
+instance of the py_integrate.NVE class which implements the required interface.
+It demonstrates how to access LAMMPS data as numpy arrays. This gives direct
+access to memory owned by the C++ code, allows easy manipulation through numpy
+operations and avoids unnecessary copies.
+
+in.fix_python_integrate_melt_opt:
+This version of melt example uses NVE_Opt instead of NVE. While this Python
+implementation is still much slower than the native version, it shows that
+simple code transformations can lead to speedups.

--- a/examples/python/in.fix_python_integrate_melt
+++ b/examples/python/in.fix_python_integrate_melt
@@ -1,0 +1,23 @@
+# 3d Lennard-Jones melt
+
+units		lj
+atom_style	atomic
+
+lattice		fcc 0.8442
+region		box block 0 10 0 10 0 10
+create_box	1 box
+create_atoms	1 box
+mass		* 1.0
+
+velocity	all create 3.0 87287
+
+pair_style	lj/cut 2.5
+pair_coeff	1 1 1.0 1.0 2.5
+
+neighbor	0.3 bin
+neigh_modify	every 20 delay 0 check no
+
+fix		1 all python/integrate py_integrate.NVE
+
+thermo		50
+run		250

--- a/examples/python/in.fix_python_integrate_melt_opt
+++ b/examples/python/in.fix_python_integrate_melt_opt
@@ -1,0 +1,23 @@
+# 3d Lennard-Jones melt
+
+units		lj
+atom_style	atomic
+
+lattice		fcc 0.8442
+region		box block 0 10 0 10 0 10
+create_box	1 box
+create_atoms	1 box
+mass		* 1.0
+
+velocity	all create 3.0 87287
+
+pair_style	lj/cut 2.5
+pair_coeff	1 1 1.0 1.0 2.5
+
+neighbor	0.3 bin
+neigh_modify	every 20 delay 0 check no
+
+fix		1 all python/integrate py_integrate.NVE_Opt
+
+thermo		50
+run		250

--- a/examples/python/py_integrate.py
+++ b/examples/python/py_integrate.py
@@ -1,0 +1,110 @@
+from __future__ import print_function
+import lammps
+import ctypes
+import traceback
+import numpy as np
+
+class LAMMPSIntegrator(object):
+    def __init__(self, ptr):
+        self.lmp = lammps.lammps(ptr=ptr)
+
+    def init(self):
+        pass
+
+    def initial_integrate(self, vflag):
+        pass
+
+    def final_integrate(self):
+        pass
+
+    def initial_integrate_respa(self, vflag, ilevel, iloop):
+        pass
+
+    def final_integrate_respa(self, ilevel, iloop):
+        pass
+
+    def reset_dt(self):
+        pass
+
+
+class NVE(LAMMPSIntegrator):
+    """ Python implementation of fix/nve """
+    def __init__(self, ptr):
+        super(NVE, self).__init__(ptr)
+
+    def init(self):
+        dt = self.lmp.extract_global("dt", 1)
+        ftm2v = self.lmp.extract_global("ftm2v", 1)
+        self.ntypes = self.lmp.extract_global("ntypes", 0)
+        self.dtv = dt
+        self.dtf = 0.5 * dt * ftm2v
+
+    def initial_integrate(self, vflag):
+        nlocal = self.lmp.extract_global("nlocal", 0)
+        mass = self.lmp.numpy.extract_atom_darray("mass", self.ntypes+1)
+        atype = self.lmp.numpy.extract_atom_iarray("type", nlocal)
+        x = self.lmp.numpy.extract_atom_darray("x", nlocal, dim=3)
+        v = self.lmp.numpy.extract_atom_darray("v", nlocal, dim=3)
+        f = self.lmp.numpy.extract_atom_darray("f", nlocal, dim=3)
+
+        for i in range(x.shape[0]):
+            dtfm = self.dtf / mass[int(atype[i])]
+            v[i,:]+= dtfm * f[i,:]
+            x[i,:] += self.dtv * v[i,:]
+
+    def final_integrate(self):
+        nlocal = self.lmp.extract_global("nlocal", 0)
+        mass = self.lmp.numpy.extract_atom_darray("mass", self.ntypes+1)
+        atype = self.lmp.numpy.extract_atom_iarray("type", nlocal)
+        v = self.lmp.numpy.extract_atom_darray("v", nlocal, dim=3)
+        f = self.lmp.numpy.extract_atom_darray("f", nlocal, dim=3)
+
+        for i in range(v.shape[0]):
+            dtfm = self.dtf / mass[int(atype[i])]
+            v[i,:] += dtfm * f[i,:]
+
+
+class NVE_Opt(LAMMPSIntegrator):
+    """ Tuned Python implementation of fix/nve """
+    def __init__(self, ptr):
+        super(NVE_Opt, self).__init__(ptr)
+
+    def init(self):
+        dt = self.lmp.extract_global("dt", 1)
+        ftm2v = self.lmp.extract_global("ftm2v", 1)
+        self.ntypes = self.lmp.extract_global("ntypes", 0)
+        self.dtv = dt
+        self.dtf = 0.5 * dt * ftm2v
+        self.mass = self.lmp.numpy.extract_atom_darray("mass", self.ntypes+1)
+
+    def initial_integrate(self, vflag):        
+        nlocal = self.lmp.extract_global("nlocal", 0)
+        atype = self.lmp.numpy.extract_atom_iarray("type", nlocal)
+        x = self.lmp.numpy.extract_atom_darray("x", nlocal, dim=3)
+        v = self.lmp.numpy.extract_atom_darray("v", nlocal, dim=3)
+        f = self.lmp.numpy.extract_atom_darray("f", nlocal, dim=3)
+        dtf = self.dtf
+        dtv = self.dtv
+        mass = self.mass
+
+        dtfm = dtf / np.take(mass, atype)
+
+        for i in range(x.shape[0]):
+            vi = v[i,:] 
+            vi += dtfm[i] * f[i,:]
+            x[i,:] += dtv * vi
+
+    def final_integrate(self):
+        nlocal = self.lmp.extract_global("nlocal", 0)
+        mass = self.lmp.numpy.extract_atom_darray("mass", self.ntypes+1)
+        atype = self.lmp.numpy.extract_atom_iarray("type", nlocal)
+        v = self.lmp.numpy.extract_atom_darray("v", nlocal, dim=3)
+        f = self.lmp.numpy.extract_atom_darray("f", nlocal, dim=3)
+        dtf = self.dtf
+        dtv = self.dtv
+        mass = self.mass
+
+        dtfm = dtf / np.take(mass, atype)
+
+        for i in range(v.shape[0]):
+            v[i,:] += dtfm[i] * f[i,:]

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -162,8 +162,8 @@ class lammps(object):
         pythonapi.PyCObject_AsVoidPtr.argtypes = [py_object]
         self.lmp = c_void_p(pythonapi.PyCObject_AsVoidPtr(ptr))
 
-      # optional numpy support (lazy loading)
-      self._numpy = None
+    # optional numpy support (lazy loading)
+    self._numpy = None
 
   def __del__(self):
     if self.lmp and self.opened:

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -32,6 +32,13 @@ import select
 import re
 import sys
 
+def get_ctypes_int(size):
+  if size == 4:
+    return c_int32
+  elif size == 8:
+    return c_int64
+  return c_int
+
 class MPIAbortException(Exception):
   def __init__(self, message):
     self.message = message
@@ -165,6 +172,11 @@ class lammps(object):
     # optional numpy support (lazy loading)
     self._numpy = None
 
+    # set default types
+    self.c_bigint = get_ctypes_int(self.extract_setting("bigint"))
+    self.c_tagint = get_ctypes_int(self.extract_setting("tagint"))
+    self.c_imageint = get_ctypes_int(self.extract_setting("imageint"))
+
   def __del__(self):
     if self.lmp and self.opened:
       self.lib.lammps_close(self.lmp)
@@ -238,6 +250,13 @@ class lammps(object):
     else: return None
     ptr = self.lib.lammps_extract_atom(self.lmp,name)
     return ptr
+
+  # extract lammps type byte sizes
+
+  def extract_setting(self, name):
+    if name: name = name.encode()
+    self.lib.lammps_extract_atom.restype = c_int
+    return int(self.lib.lammps_extract_setting(self.lmp,name))
 
   @property
   def numpy(self):

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -858,6 +858,8 @@
 /python_compat.h
 /fix_python.cpp
 /fix_python.h
+/fix_python_integrate.cpp
+/fix_python_integrate.h
 /pair_python.cpp
 /pair_python.h
 /reader_molfile.cpp

--- a/src/PYTHON/fix_python_integrate.cpp
+++ b/src/PYTHON/fix_python_integrate.cpp
@@ -1,0 +1,247 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Richard Berger (Temple U)
+------------------------------------------------------------------------- */
+
+#include <Python.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "fix_python_integrate.h"
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "python.h"
+#include "error.h"
+#include "python_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+/* ---------------------------------------------------------------------- */
+
+FixPythonIntegrate::FixPythonIntegrate(LAMMPS *lmp, int narg, char **arg) :
+  Fix(lmp, narg, arg)
+{
+  dynamic_group_allow = 1;
+  time_integrate = 1;
+
+  python->init();
+
+  py_integrator = NULL;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  // add current directory to PYTHONPATH
+  PyObject * py_path = PySys_GetObject("path");
+  PyList_Append(py_path, PY_STRING_FROM_STRING("."));
+
+
+  // create integrator instance
+  char * full_cls_name = arg[2];
+  char * lastpos = strrchr(full_cls_name, '.');
+
+  if (lastpos == NULL) {
+    error->all(FLERR,"Python pair style requires fully qualified class name");
+  }
+
+  size_t module_name_length = strlen(full_cls_name) - strlen(lastpos);
+  size_t cls_name_length = strlen(lastpos)-1;
+
+  char * module_name = new char[module_name_length+1];
+  char * cls_name = new char[cls_name_length+1];
+  strncpy(module_name, full_cls_name, module_name_length);
+  module_name[module_name_length] = 0;
+
+  strcpy(cls_name, lastpos+1);
+
+  PyObject * pModule = PyImport_ImportModule(module_name);
+  if (!pModule) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Loading python integrator module failure");
+  }
+
+  // create LAMMPS atom type to potential file type mapping in python class
+  // by calling 'lammps_pair_style.map_coeff(name,type)'
+
+  PyObject *py_integrator_type = PyObject_GetAttrString(pModule, cls_name);
+  if (!py_integrator_type) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find integrator class in module'");
+  }
+
+  delete [] module_name;
+  delete [] cls_name;
+
+  PyObject * py_integrator_obj = PyObject_CallObject(py_integrator_type, NULL);
+  if (!py_integrator_obj) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not instantiate instance of integrator class'");
+  }
+
+  // check object interface
+  py_integrator = (void *) py_integrator_obj;
+
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixPythonIntegrate::~FixPythonIntegrate()
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  if(py_integrator) Py_DECREF((PyObject*) py_integrator);
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixPythonIntegrate::setmask()
+{
+  int mask = 0;
+  mask |= INITIAL_INTEGRATE;
+  mask |= FINAL_INTEGRATE;
+  mask |= INITIAL_INTEGRATE_RESPA;
+  mask |= FINAL_INTEGRATE_RESPA;
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPythonIntegrate::init()
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyObject *py_integrator_obj = (PyObject *) py_integrator;
+  PyObject *py_init = PyObject_GetAttrString(py_integrator_obj,"init");
+  if (!py_init) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find 'init' method'");
+  }
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(O)", ptr);
+  PyObject * result = PyEval_CallObject(py_init, arglist);
+  Py_DECREF(arglist);
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPythonIntegrate::initial_integrate(int vflag)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyObject *py_integrator_obj = (PyObject *) py_integrator;
+  PyObject *py_initial_integrate = PyObject_GetAttrString(py_integrator_obj,"initial_integrate");
+  if (!py_initial_integrate) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find 'initial_integrate' method'");
+  }
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(Oi)", ptr, vflag);
+  PyObject * result = PyEval_CallObject(py_initial_integrate, arglist);
+  Py_DECREF(arglist);
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPythonIntegrate::final_integrate()
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyObject *py_integrator_obj = (PyObject *) py_integrator;
+  PyObject *py_final_integrate = PyObject_GetAttrString(py_integrator_obj,"final_integrate");
+  if (!py_final_integrate) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find 'final_integrate' method'");
+  }
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(O)", ptr);
+  PyObject * result = PyEval_CallObject(py_final_integrate, arglist);
+  Py_DECREF(arglist);
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPythonIntegrate::initial_integrate_respa(int vflag, int ilevel, int iloop)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyObject *py_integrator_obj = (PyObject *) py_integrator;
+  PyObject *py_initial_integrate_respa = PyObject_GetAttrString(py_integrator_obj,"initial_integrate_respa");
+  if (!py_initial_integrate_respa) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find 'initial_integrate_respa' method'");
+  }
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(Oiii)", ptr, vflag, ilevel, iloop);
+  PyObject * result = PyEval_CallObject(py_initial_integrate_respa, arglist);
+  Py_DECREF(arglist);
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPythonIntegrate::final_integrate_respa(int ilevel, int iloop)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyObject *py_integrator_obj = (PyObject *) py_integrator;
+  PyObject *py_final_integrate_respa = PyObject_GetAttrString(py_integrator_obj,"final_integrate_respa");
+  if (!py_final_integrate_respa) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find 'final_integrate_respa' method'");
+  }
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(Oii)", ptr, ilevel, iloop);
+  PyObject * result = PyEval_CallObject(py_final_integrate_respa, arglist);
+  Py_DECREF(arglist);
+  PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPythonIntegrate::reset_dt()
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyObject *py_integrator_obj = (PyObject *) py_integrator;
+  PyObject *py_reset_dt = PyObject_GetAttrString(py_integrator_obj,"reset_dt");
+  if (!py_reset_dt) {
+    PyErr_Print();
+    PyErr_Clear();
+    PyGILState_Release(gstate);
+    error->all(FLERR,"Could not find 'reset_dt' method'");
+  }
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(O)", ptr);
+  PyObject * result = PyEval_CallObject(py_reset_dt, arglist);
+  Py_DECREF(arglist);
+  PyGILState_Release(gstate);
+}

--- a/src/PYTHON/fix_python_integrate.cpp
+++ b/src/PYTHON/fix_python_integrate.cpp
@@ -52,11 +52,11 @@ FixPythonIntegrate::FixPythonIntegrate(LAMMPS *lmp, int narg, char **arg) :
 
 
   // create integrator instance
-  char * full_cls_name = arg[2];
+  char * full_cls_name = arg[3];
   char * lastpos = strrchr(full_cls_name, '.');
 
   if (lastpos == NULL) {
-    error->all(FLERR,"Python pair style requires fully qualified class name");
+    error->all(FLERR,"Fix python/integrate requires fully qualified class name");
   }
 
   size_t module_name_length = strlen(full_cls_name) - strlen(lastpos);
@@ -91,7 +91,11 @@ FixPythonIntegrate::FixPythonIntegrate(LAMMPS *lmp, int narg, char **arg) :
   delete [] module_name;
   delete [] cls_name;
 
-  PyObject * py_integrator_obj = PyObject_CallObject(py_integrator_type, NULL);
+  PyObject * ptr = PY_VOID_POINTER(lmp);
+  PyObject * arglist = Py_BuildValue("(O)", ptr);
+  PyObject * py_integrator_obj = PyObject_CallObject(py_integrator_type, arglist);
+  Py_DECREF(arglist);
+
   if (!py_integrator_obj) {
     PyErr_Print();
     PyErr_Clear();
@@ -139,10 +143,7 @@ void FixPythonIntegrate::init()
     PyGILState_Release(gstate);
     error->all(FLERR,"Could not find 'init' method'");
   }
-  PyObject * ptr = PY_VOID_POINTER(lmp);
-  PyObject * arglist = Py_BuildValue("(O)", ptr);
-  PyObject * result = PyEval_CallObject(py_init, arglist);
-  Py_DECREF(arglist);
+  PyObject * result = PyEval_CallObject(py_init, NULL);
   PyGILState_Release(gstate);
 }
 
@@ -159,8 +160,7 @@ void FixPythonIntegrate::initial_integrate(int vflag)
     PyGILState_Release(gstate);
     error->all(FLERR,"Could not find 'initial_integrate' method'");
   }
-  PyObject * ptr = PY_VOID_POINTER(lmp);
-  PyObject * arglist = Py_BuildValue("(Oi)", ptr, vflag);
+  PyObject * arglist = Py_BuildValue("(i)", vflag);
   PyObject * result = PyEval_CallObject(py_initial_integrate, arglist);
   Py_DECREF(arglist);
   PyGILState_Release(gstate);
@@ -179,10 +179,7 @@ void FixPythonIntegrate::final_integrate()
     PyGILState_Release(gstate);
     error->all(FLERR,"Could not find 'final_integrate' method'");
   }
-  PyObject * ptr = PY_VOID_POINTER(lmp);
-  PyObject * arglist = Py_BuildValue("(O)", ptr);
-  PyObject * result = PyEval_CallObject(py_final_integrate, arglist);
-  Py_DECREF(arglist);
+  PyObject * result = PyEval_CallObject(py_final_integrate, NULL);
   PyGILState_Release(gstate);
 }
 
@@ -199,8 +196,7 @@ void FixPythonIntegrate::initial_integrate_respa(int vflag, int ilevel, int iloo
     PyGILState_Release(gstate);
     error->all(FLERR,"Could not find 'initial_integrate_respa' method'");
   }
-  PyObject * ptr = PY_VOID_POINTER(lmp);
-  PyObject * arglist = Py_BuildValue("(Oiii)", ptr, vflag, ilevel, iloop);
+  PyObject * arglist = Py_BuildValue("(iii)", vflag, ilevel, iloop);
   PyObject * result = PyEval_CallObject(py_initial_integrate_respa, arglist);
   Py_DECREF(arglist);
   PyGILState_Release(gstate);
@@ -219,8 +215,7 @@ void FixPythonIntegrate::final_integrate_respa(int ilevel, int iloop)
     PyGILState_Release(gstate);
     error->all(FLERR,"Could not find 'final_integrate_respa' method'");
   }
-  PyObject * ptr = PY_VOID_POINTER(lmp);
-  PyObject * arglist = Py_BuildValue("(Oii)", ptr, ilevel, iloop);
+  PyObject * arglist = Py_BuildValue("(ii)", ilevel, iloop);
   PyObject * result = PyEval_CallObject(py_final_integrate_respa, arglist);
   Py_DECREF(arglist);
   PyGILState_Release(gstate);
@@ -239,9 +234,6 @@ void FixPythonIntegrate::reset_dt()
     PyGILState_Release(gstate);
     error->all(FLERR,"Could not find 'reset_dt' method'");
   }
-  PyObject * ptr = PY_VOID_POINTER(lmp);
-  PyObject * arglist = Py_BuildValue("(O)", ptr);
-  PyObject * result = PyEval_CallObject(py_reset_dt, arglist);
-  Py_DECREF(arglist);
+  PyObject * result = PyEval_CallObject(py_reset_dt, NULL);
   PyGILState_Release(gstate);
 }

--- a/src/PYTHON/fix_python_integrate.h
+++ b/src/PYTHON/fix_python_integrate.h
@@ -1,0 +1,67 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+
+   Pair zero is a dummy pair interaction useful for requiring a
+   force cutoff distance in the absense of pair-interactions or
+   with hybrid/overlay if a larger force cutoff distance is required.
+
+   This can be used in conjunction with bond/create to create bonds
+   that are longer than the cutoff of a given force field, or to
+   calculate radial distribution functions for models without
+   pair interactions.
+
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(python/integrate,FixPythonIntegrate)
+
+#else
+
+#ifndef LMP_FIX_PYTHON_INTEGRATE_H
+#define LMP_FIX_PYTHON_INTEGRATE_H
+
+#include "fix.h"
+
+namespace LAMMPS_NS {
+
+class FixPythonIntegrate : public Fix {
+ public:
+  FixPythonIntegrate(LAMMPS *lmp, int narg, char **arg);
+  virtual ~FixPythonIntegrate();
+
+  int setmask();
+  virtual void init();
+  virtual void initial_integrate(int);
+  virtual void final_integrate();
+  virtual void initial_integrate_respa(int, int, int);
+  virtual void final_integrate_respa(int, int);
+  virtual void reset_dt();
+
+ protected:
+  void * py_integrator;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+*/

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -37,6 +37,7 @@
 #include "comm.h"
 #include "memory.h"
 #include "error.h"
+#include "force.h"
 
 using namespace LAMMPS_NS;
 
@@ -370,6 +371,7 @@ void *lammps_extract_global(void *ptr, char *name)
   if (strcmp(name,"nlocal") == 0) return (void *) &lmp->atom->nlocal;
   if (strcmp(name,"nghost") == 0) return (void *) &lmp->atom->nghost;
   if (strcmp(name,"nmax") == 0) return (void *) &lmp->atom->nmax;
+  if (strcmp(name,"ntypes") == 0) return (void *) &lmp->atom->ntypes;
   if (strcmp(name,"ntimestep") == 0) return (void *) &lmp->update->ntimestep;
 
   if (strcmp(name,"units") == 0) return (void *) lmp->update->unit_style;
@@ -383,6 +385,28 @@ void *lammps_extract_global(void *ptr, char *name)
 
   if (strcmp(name,"atime") == 0) return (void *) &lmp->update->atime;
   if (strcmp(name,"atimestep") == 0) return (void *) &lmp->update->atimestep;
+
+  // global constants defined by units
+
+  if (strcmp(name,"boltz") == 0) return (void *) &lmp->force->boltz;
+  if (strcmp(name,"hplanck") == 0) return (void *) &lmp->force->hplanck;
+  if (strcmp(name,"mvv2e") == 0) return (void *) &lmp->force->mvv2e;
+  if (strcmp(name,"ftm2v") == 0) return (void *) &lmp->force->ftm2v;
+  if (strcmp(name,"mv2d") == 0) return (void *) &lmp->force->mv2d;
+  if (strcmp(name,"nktv2p") == 0) return (void *) &lmp->force->nktv2p;
+  if (strcmp(name,"qqr2e") == 0) return (void *) &lmp->force->qqr2e;
+  if (strcmp(name,"qe2f") == 0) return (void *) &lmp->force->qe2f;
+  if (strcmp(name,"vxmu2f") == 0) return (void *) &lmp->force->vxmu2f;
+  if (strcmp(name,"xxt2kmu") == 0) return (void *) &lmp->force->xxt2kmu;
+  if (strcmp(name,"dielectric") == 0) return (void *) &lmp->force->dielectric;
+  if (strcmp(name,"qqrd2e") == 0) return (void *) &lmp->force->qqrd2e;
+  if (strcmp(name,"e_mass") == 0) return (void *) &lmp->force->e_mass;
+  if (strcmp(name,"hhmrr2e") == 0) return (void *) &lmp->force->hhmrr2e;
+  if (strcmp(name,"mvh2r") == 0) return (void *) &lmp->force->mvh2r;
+
+  if (strcmp(name,"angstrom") == 0) return (void *) &lmp->force->angstrom;
+  if (strcmp(name,"femtosecond") == 0) return (void *) &lmp->force->femtosecond;
+  if (strcmp(name,"qelectron") == 0) return (void *) &lmp->force->qelectron;
 
   return NULL;
 }


### PR DESCRIPTION
## Purpose

This is a feature requested during the MD Workshop at Temple. It demonstrates how to implement a LAMMPS integrator class in Python. It also showcases how `numpy` arrays can be used to directly manipulate the LAMMPS state.

## Author(s)

Richard Berger (Temple University)

## Implementation Notes

* a LAMMPS pointer is passed to the constructor of the integrator class. It uses it to instantiate a `lammps` instance to gain access to internal data. As we move forward to enable other extension points, this is the kind of class layout I would like to follow. Comments?
* Changes to the library interface: added access to constants defined by units
* Numpy functions are isolated by grouping them into a helper object. This is only loaded when it is accessed, which avoids a hard dependency
* The current implementation does not honor group selections. While I have an idea how to proceed with this, I didn't want to add it yet to keep it simple.

## Post Submission Checklist

- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines


