### PR TITLE
Collected small changes

### DIFF
--- a/doc/src/fix_rigid.txt
+++ b/doc/src/fix_rigid.txt
@@ -212,8 +212,9 @@ pour"_fix_pour.html.
 For bodystyle {single} the entire fix group of atoms is treated as one
 rigid body.  This option is only allowed for the {rigid} styles.
 
-For bodystyle {molecule}, each set of atoms in the fix group with a
-different molecule ID is treated as a rigid body.  This option is
+For bodystyle {molecule}, atoms are grouped into rigid bodies by their
+respective molecule IDs: each set of atoms in the fix group with the
+same molecule ID is treated as a different rigid body.  This option is
 allowed for both the {rigid} and {rigid/small} styles.  Note that
 atoms with a molecule ID = 0 will be treated as a single rigid body.
 For a system with atomic solvent (typically this is atoms with

--- a/examples/README
+++ b/examples/README
@@ -37,9 +37,8 @@ produce dump snapshots of the running simulation in any of 3 formats.
 
 If you uncomment the dump command in the input script, a text dump
 file will be produced, which can be animated by various visualization
-programs (see http://lammps.sandia.gov/viz.html) such as VMD or
-AtomEye.  It can also be animated using the xmovie tool described in
-the Additional Tools section of the LAMMPS documentation.
+programs (see http://lammps.sandia.gov/viz.html) such as Ovito, VMD,
+or AtomEye.
 
 If you uncomment the dump image command in the input script, and
 assuming you have built LAMMPS with a JPG library, JPG snapshot images

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -95,6 +95,11 @@ PPPM::PPPM(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
 
+  nfft_both = 0;
+  nxhi_in = nxlo_in = nxhi_out = nxlo_out = 0;
+  nyhi_in = nylo_in = nyhi_out = nylo_out = 0;
+  nzhi_in = nzlo_in = nzhi_out = nzlo_out = 0;
+
   density_brick = vdx_brick = vdy_brick = vdz_brick = NULL;
   density_fft = NULL;
   u_brick = NULL;

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -121,6 +121,13 @@ PPPMDisp::PPPMDisp(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
 
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
+  nfft_both = nfft_both_6 = 0;
+  nxhi_in = nxlo_in = nxhi_out = nxlo_out = 0;
+  nyhi_in = nylo_in = nyhi_out = nylo_out = 0;
+  nzhi_in = nzlo_in = nzhi_out = nzlo_out = 0;
+  nxhi_in_6 = nxlo_in_6 = nxhi_out_6 = nxlo_out_6 = 0;
+  nyhi_in_6 = nylo_in_6 = nyhi_out_6 = nylo_out_6 = 0;
+  nzhi_in_6 = nzlo_in_6 = nzhi_out_6 = nzlo_out_6 = 0;
 
   csumflag = 0;
   B = NULL;

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -949,7 +949,7 @@ void FixRigid::enforce2d()
     angmom[ibody][1] = 0.0;
     omega[ibody][0] = 0.0;
     omega[ibody][1] = 0.0;
-    if (langflag) {
+    if (langflag && langextra) {
       langextra[ibody][2] = 0.0;
       langextra[ibody][3] = 0.0;
       langextra[ibody][4] = 0.0;

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -786,7 +786,7 @@ void FixRigidSmall::enforce2d()
     b->angmom[1] = 0.0;
     b->omega[0] = 0.0;
     b->omega[1] = 0.0;
-    if (langflag) {
+    if (langflag && langextra) {
       langextra[ibody][2] = 0.0;
       langextra[ibody][3] = 0.0;
       langextra[ibody][4] = 0.0;

--- a/src/USER-OMP/fix_nphug_omp.cpp
+++ b/src/USER-OMP/fix_nphug_omp.cpp
@@ -157,7 +157,7 @@ FixNPHugOMP::FixNPHugOMP(LAMMPS *lmp, int narg, char **arg) :
 
   // create a new compute potential energy compute
 
-  n = strlen(id) + 3;
+  n = strlen(id) + 4;
   id_pe = new char[n];
   strcpy(id_pe,id);
   strcat(id_pe,"_pe");

--- a/src/USER-OMP/fix_qeq_comb_omp.cpp
+++ b/src/USER-OMP/fix_qeq_comb_omp.cpp
@@ -70,17 +70,6 @@ void FixQEQCombOMP::init()
 
   ngroup = group->count(igroup);
   if (ngroup == 0) error->all(FLERR,"Fix qeq/comb group has no atoms");
-
-  // determine status of neighbor flag of the omp package command
-  int ifix = modify->find_fix("package_omp");
-  int use_omp = 0;
-  if (ifix >=0) {
-     FixOMP * fix = static_cast<FixOMP *>(lmp->modify->fix[ifix]);
-     if (fix->get_neighbor()) use_omp = 1;
-  }
-
-  int irequest = neighbor->request(this,instance_me);
-  neighbor->requests[irequest]->omp = use_omp;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-REAXC/reaxc_allocate.cpp
+++ b/src/USER-REAXC/reaxc_allocate.cpp
@@ -196,11 +196,10 @@ void DeAllocate_Workspace( control_params *control, storage *workspace )
 
   /* reductions */
 #ifdef LMP_USER_OMP
-  if(workspace->CdDeltaReduction) sfree( workspace->CdDeltaReduction, "cddelta_reduce" );
-  if(workspace->forceReduction) sfree( workspace->forceReduction, "f_reduce" );
-  if(workspace->valence_angle_atom_myoffset) sfree( workspace->valence_angle_atom_myoffset, "valence_angle_atom_myoffset");
-
-  if (control->virial && workspace->my_ext_pressReduction) sfree( workspace->my_ext_pressReduction, "ext_press_reduce");
+  if (workspace->CdDeltaReduction) sfree( workspace->CdDeltaReduction, "cddelta_reduce" );
+  if (workspace->forceReduction) sfree( workspace->forceReduction, "f_reduce" );
+  if (workspace->valence_angle_atom_myoffset) sfree( workspace->valence_angle_atom_myoffset, "valence_angle_atom_myoffset");
+  if (workspace->my_ext_pressReduction) sfree( workspace->my_ext_pressReduction, "ext_press_reduce");
 #endif
 }
 
@@ -307,9 +306,7 @@ int Allocate_Workspace( reax_system *system, control_params *control,
 					       "forceReduction", comm);
 
   workspace->valence_angle_atom_myoffset = (int *) scalloc(sizeof(int), total_cap, "valence_angle_atom_myoffset", comm);
-
-  if (control->virial)
-    workspace->my_ext_pressReduction = (rvec *) calloc(sizeof(rvec), control->nthreads);
+  workspace->my_ext_pressReduction = (rvec *) calloc(sizeof(rvec), control->nthreads);
 #endif
 
   return SUCCESS;

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -124,6 +124,7 @@ void CommBrick::init_buffers()
   maxrecv = BUFMIN;
   memory->create(buf_recv,maxrecv,"comm:buf_recv");
 
+  nswap = 0;
   maxswap = 6;
   allocate_swap(maxswap);
 

--- a/src/fix_enforce2d.cpp
+++ b/src/fix_enforce2d.cpp
@@ -66,12 +66,21 @@ void FixEnforce2D::init()
     if (modify->fix[i]->enforce2d_flag) nfixlist++;
 
   if (nfixlist) {
+    int myindex = -1;
     delete [] flist;
     flist = new Fix*[nfixlist];
     nfixlist = 0;
     for (int i = 0; i < modify->nfix; i++) {
-      if (modify->fix[i]->enforce2d_flag) 
-        flist[nfixlist++] = modify->fix[i];
+      if (modify->fix[i]->enforce2d_flag) {
+        if (myindex < 0)
+          flist[nfixlist++] = modify->fix[i];
+        else {
+          char msg[256];
+          sprintf(msg,"Fix enforce2d must be defined after fix %s",modify->fix[i]->style);
+          error->all(FLERR,msg);
+        }
+      }
+      if (modify->fix[i] == this) myindex = i;
     }
   }
 }


### PR DESCRIPTION
## Purpose

This PR combines multiple small changes that don't warrant a single PR of their own

## Author(s)

@akohlmey

## Backward Compatibility

n/a

## Implementation Notes

The following changes are included:
- reformulate the definition of body style `molecule` for rigid fixes to be more explicit
- remove reference to xmovie from `examples/README`. together with PR #572, this should purge the final references to xmovie from the distribution
- updates to fix `rigid`, fix `rigid/small` and fix `enforce2d`, so that 2d simulations using the `langevin` option will not segfault and operate correctly. fix `enforce2d` must be defined after the rigid fixes
- fix small unitialized data issue with associated memory leak in USER-OMP support in USER-REAXC
- fix possible uninitialized data issue in `pppm` and `pppm/disp` spotted by valgrind
- remove useless and incorrect neighbor list request from fix `qeq/comb/omp` spotted by GCC's undefine behavior sanitizer
- fix for off-by-one allocation bug in fix `nphug/omp`

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

n/a

