### PR TITLE
tools/Makefile: remove remains of data2xmovie

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,7 +5,7 @@
 #
 
 all:
-	$(MAKE) binary2txt chain micelle2d data2xmovie
+	$(MAKE) binary2txt chain micelle2d
 
 binary2txt:	binary2txt.o
 	g++ -g binary2txt.o -o binary2txt
@@ -16,14 +16,11 @@ chain:	chain.o
 micelle2d:	micelle2d.o
 	ifort micelle2d.o -o micelle2d
 
-data2xmovie:	data2xmovie.o
-	g++ -g data2xmovie.o -o data2xmovie
-
 thermo_extract:	thermo_extract.o
 	gcc -g thermo_extract.o -o thermo_extract
 
 clean:
-	rm binary2txt chain micelle2d data2xmovie
+	rm binary2txt chain micelle2d
 	rm thermo_extract
 	rm *.o
 


### PR DESCRIPTION
## Purpose

tools/Makefile: remove remains of data2xmovie, which was removed in e110d6961a48017274256e23d15530974aec55ff

## Author(s)

Christoph Junghans (LANL)

## Backward Compatibility

N/A

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines



