### PR TITLE
fix the problem with COM, gyration, inertia ... calculation over a chunk computes with PBC.

### DIFF
--- a/src/compute_angmom_chunk.cpp
+++ b/src/compute_angmom_chunk.cpp
@@ -27,7 +27,8 @@ using namespace LAMMPS_NS;
 
 ComputeAngmomChunk::ComputeAngmomChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
-  idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), angmom(NULL), angmomall(NULL)
+  idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), angmom(NULL), angmomall(NULL),
+  origin(NULL)                  //added by A.Vorontsov
 {
   if (narg != 4) error->all(FLERR,"Illegal compute angmom/chunk command");
 
@@ -63,6 +64,7 @@ ComputeAngmomChunk::~ComputeAngmomChunk()
   memory->destroy(comall);
   memory->destroy(angmom);
   memory->destroy(angmomall);
+  memory->destroy(origin);          //added by A.Vorontsov
 }
 
 /* ---------------------------------------------------------------------- */
@@ -117,6 +119,23 @@ void ComputeAngmomChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
+//----------- added by A.Vorontsov ----------------------------------------------------------------------
+  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
+    if (mask[i] & groupbit) {                // added by A.Vorontsov
+      index = ichunk[i]-1;                   // added by A.Vorontsov
+      if (index < 0) continue;               // added by A.Vorontsov
+      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
+      com[index][0] = unwrap[0];             // added by A.Vorontsov
+      com[index][1] = unwrap[1];             // added by A.Vorontsov
+      com[index][2] = unwrap[2];             // added by A.Vorontsov
+    }                                        // added by A.Vorontsov
+
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+
+  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
+    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
+//--------------------------------------------------------------------------------------------------------
+
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
       index = ichunk[i]-1;
@@ -124,6 +143,11 @@ void ComputeAngmomChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
+      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
+      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
+      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
       com[index][1] += unwrap[1] * massone;
@@ -138,8 +162,12 @@ void ComputeAngmomChunk::compute_array()
       comall[i][0] /= masstotal[i];
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
+
+      comall[i][0] += origin[i][0];             // added by A.Vorontsov
+      comall[i][1] += origin[i][1];             // added by A.Vorontsov
+      comall[i][2] += origin[i][2];             // added by A.Vorontsov
     }
-  }
+  }    
 
   // compute angmom for each chunk
 
@@ -153,6 +181,7 @@ void ComputeAngmomChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
+      domain->minimum_image(dx,dy,dz);             // added by A.Vorontsov 
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       angmom[index][0] += massone * (dy*v[i][2] - dz*v[i][1]);
@@ -232,6 +261,7 @@ void ComputeAngmomChunk::allocate()
   memory->destroy(comall);
   memory->destroy(angmom);
   memory->destroy(angmomall);
+  memory->destroy(origin);             //added by A.Vorontsov
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"angmom/chunk:massproc");
   memory->create(masstotal,maxchunk,"angmom/chunk:masstotal");
@@ -239,6 +269,7 @@ void ComputeAngmomChunk::allocate()
   memory->create(comall,maxchunk,3,"angmom/chunk:comall");
   memory->create(angmom,maxchunk,3,"angmom/chunk:angmom");
   memory->create(angmomall,maxchunk,3,"angmom/chunk:angmomall");
+  memory->create(origin,maxchunk,3,"angmom/chunk:origin");         //added by A.Vorontsov
   array = angmomall;
 }
 
@@ -251,5 +282,6 @@ double ComputeAngmomChunk::memory_usage()
   double bytes = (bigint) maxchunk * 2 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
+  bytes += (bigint) maxchunk * 3 * sizeof(double);          //added by A.Vorontsov
   return bytes;
 }

--- a/src/compute_angmom_chunk.cpp
+++ b/src/compute_angmom_chunk.cpp
@@ -28,7 +28,7 @@ using namespace LAMMPS_NS;
 ComputeAngmomChunk::ComputeAngmomChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), angmom(NULL), angmomall(NULL),
-  origin(NULL)                  //added by A.Vorontsov
+  origin(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute angmom/chunk command");
 
@@ -64,7 +64,7 @@ ComputeAngmomChunk::~ComputeAngmomChunk()
   memory->destroy(comall);
   memory->destroy(angmom);
   memory->destroy(angmomall);
-  memory->destroy(origin);          //added by A.Vorontsov
+  memory->destroy(origin);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -119,22 +119,20 @@ void ComputeAngmomChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-//----------- added by A.Vorontsov ----------------------------------------------------------------------
-  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
-    if (mask[i] & groupbit) {                // added by A.Vorontsov
-      index = ichunk[i]-1;                   // added by A.Vorontsov
-      if (index < 0) continue;               // added by A.Vorontsov
-      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
-      com[index][0] = unwrap[0];             // added by A.Vorontsov
-      com[index][1] = unwrap[1];             // added by A.Vorontsov
-      com[index][2] = unwrap[2];             // added by A.Vorontsov
-    }                                        // added by A.Vorontsov
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      index = ichunk[i]-1;
+      if (index < 0) continue;
+      domain->unmap(x[i],image[i],unwrap);
+      com[index][0] = unwrap[0];
+      com[index][1] = unwrap[1];
+      com[index][2] = unwrap[2];
+    }
 
-  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);
 
-  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
-    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
-//--------------------------------------------------------------------------------------------------------
+  for (int i = 0; i < nchunk; i++)
+    com[i][0] = com[i][1] = com[i][2] = 0.0;
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
@@ -143,10 +141,10 @@ void ComputeAngmomChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
-      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+      unwrap[0] -= origin[index][0];
+      unwrap[1] -= origin[index][1];
+      unwrap[2] -= origin[index][2];
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);
 
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
@@ -163,11 +161,11 @@ void ComputeAngmomChunk::compute_array()
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
 
-      comall[i][0] += origin[i][0];             // added by A.Vorontsov
-      comall[i][1] += origin[i][1];             // added by A.Vorontsov
-      comall[i][2] += origin[i][2];             // added by A.Vorontsov
+      comall[i][0] += origin[i][0];
+      comall[i][1] += origin[i][1];
+      comall[i][2] += origin[i][2];
     }
-  }    
+  }
 
   // compute angmom for each chunk
 
@@ -181,7 +179,7 @@ void ComputeAngmomChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
-      domain->minimum_image(dx,dy,dz);             // added by A.Vorontsov 
+      domain->minimum_image(dx,dy,dz);
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       angmom[index][0] += massone * (dy*v[i][2] - dz*v[i][1]);
@@ -261,7 +259,7 @@ void ComputeAngmomChunk::allocate()
   memory->destroy(comall);
   memory->destroy(angmom);
   memory->destroy(angmomall);
-  memory->destroy(origin);             //added by A.Vorontsov
+  memory->destroy(origin);
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"angmom/chunk:massproc");
   memory->create(masstotal,maxchunk,"angmom/chunk:masstotal");
@@ -269,7 +267,7 @@ void ComputeAngmomChunk::allocate()
   memory->create(comall,maxchunk,3,"angmom/chunk:comall");
   memory->create(angmom,maxchunk,3,"angmom/chunk:angmom");
   memory->create(angmomall,maxchunk,3,"angmom/chunk:angmomall");
-  memory->create(origin,maxchunk,3,"angmom/chunk:origin");         //added by A.Vorontsov
+  memory->create(origin,maxchunk,3,"angmom/chunk:origin");
   array = angmomall;
 }
 
@@ -282,6 +280,6 @@ double ComputeAngmomChunk::memory_usage()
   double bytes = (bigint) maxchunk * 2 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
-  bytes += (bigint) maxchunk * 3 * sizeof(double);          //added by A.Vorontsov
+  bytes += (bigint) maxchunk * 3 * sizeof(double);
   return bytes;
 }

--- a/src/compute_angmom_chunk.h
+++ b/src/compute_angmom_chunk.h
@@ -47,7 +47,7 @@ class ComputeAngmomChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **angmom,**angmomall;
-  double **origin;                   //added by A.Vorontsov
+  double **origin;
 
   void allocate();
 };

--- a/src/compute_angmom_chunk.h
+++ b/src/compute_angmom_chunk.h
@@ -47,6 +47,7 @@ class ComputeAngmomChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **angmom,**angmomall;
+  double **origin;                   //added by A.Vorontsov
 
   void allocate();
 };

--- a/src/compute_com_chunk.cpp
+++ b/src/compute_com_chunk.cpp
@@ -30,7 +30,7 @@ enum{ONCE,NFREQ,EVERY};
 ComputeCOMChunk::ComputeCOMChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), masstotal(NULL), massproc(NULL), com(NULL), comall(NULL),
-  origin(NULL)          // added by A.Vorontsov
+  origin(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute com/chunk command");
 
@@ -66,7 +66,7 @@ ComputeCOMChunk::~ComputeCOMChunk()
   memory->destroy(masstotal);
   memory->destroy(com);
   memory->destroy(comall);
-  memory->destroy(origin);       // added by A.Vorontsov
+  memory->destroy(origin);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -132,22 +132,20 @@ void ComputeCOMChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-//----------- added by A.Vorontsov ----------------------------------------------------------------------
-  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
-    if (mask[i] & groupbit) {                // added by A.Vorontsov
-      index = ichunk[i]-1;                   // added by A.Vorontsov
-      if (index < 0) continue;               // added by A.Vorontsov
-      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
-      com[index][0] = unwrap[0];             // added by A.Vorontsov
-      com[index][1] = unwrap[1];             // added by A.Vorontsov
-      com[index][2] = unwrap[2];             // added by A.Vorontsov
-    }                                        // added by A.Vorontsov
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      index = ichunk[i]-1;
+      if (index < 0) continue;
+      domain->unmap(x[i],image[i],unwrap);
+      com[index][0] = unwrap[0];
+      com[index][1] = unwrap[1];
+      com[index][2] = unwrap[2];
+    }
 
-  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);
 
-  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
-    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
-//--------------------------------------------------------------------------------------------------------
+  for (int i = 0; i < nchunk; i++)
+    com[i][0] = com[i][1] = com[i][2] = 0.0;
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
@@ -157,10 +155,10 @@ void ComputeCOMChunk::compute_array()
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
 
-      unwrap[0] -= origin[index][0];                          // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                          // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                          // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);   // added by A.Vorontsov
+      unwrap[0] -= origin[index][0];
+      unwrap[1] -= origin[index][1];
+      unwrap[2] -= origin[index][2];
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);
 
       com[index][0] += unwrap[0] * massone;
       com[index][1] += unwrap[1] * massone;
@@ -178,9 +176,9 @@ void ComputeCOMChunk::compute_array()
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
 
-      comall[i][0] += origin[i][0];             // added by A.Vorontsov
-      comall[i][1] += origin[i][1];             // added by A.Vorontsov
-      comall[i][2] += origin[i][2];             // added by A.Vorontsov
+      comall[i][0] += origin[i][0];
+      comall[i][1] += origin[i][1];
+      comall[i][2] += origin[i][2];
 
     } else comall[i][0] = comall[i][1] = comall[i][2] = 0.0;
   }
@@ -252,13 +250,13 @@ void ComputeCOMChunk::allocate()
   memory->destroy(masstotal);
   memory->destroy(com);
   memory->destroy(comall);
-  memory->destroy(origin);                                // added by A.Vorontsov
+  memory->destroy(origin);
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"com/chunk:massproc");
   memory->create(masstotal,maxchunk,"com/chunk:masstotal");
   memory->create(com,maxchunk,3,"com/chunk:com");
   memory->create(comall,maxchunk,3,"com/chunk:comall");
-  memory->create(origin,maxchunk,3,"com/chunk:origin");   // added by A.Vorontsov
+  memory->create(origin,maxchunk,3,"com/chunk:origin");
   array = comall;
 }
 
@@ -270,6 +268,6 @@ double ComputeCOMChunk::memory_usage()
 {
   double bytes = (bigint) maxchunk * 2 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
-  bytes += (bigint) maxchunk * 3 * sizeof(double);          // added by A.Vorontsov
+  bytes += (bigint) maxchunk * 3 * sizeof(double);
   return bytes;
 }

--- a/src/compute_com_chunk.cpp
+++ b/src/compute_com_chunk.cpp
@@ -156,15 +156,16 @@ void ComputeCOMChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
-      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
 
-      massproc[index] += massone;
+      unwrap[0] -= origin[index][0];                          // added by A.Vorontsov
+      unwrap[1] -= origin[index][1];                          // added by A.Vorontsov
+      unwrap[2] -= origin[index][2];                          // added by A.Vorontsov
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);   // added by A.Vorontsov
+
       com[index][0] += unwrap[0] * massone;
       com[index][1] += unwrap[1] * massone;
       com[index][2] += unwrap[2] * massone;
+      if (massneed) massproc[index] += massone;
     }
 
   MPI_Allreduce(&com[0][0],&comall[0][0],3*nchunk,MPI_DOUBLE,MPI_SUM,world);
@@ -180,7 +181,8 @@ void ComputeCOMChunk::compute_array()
       comall[i][0] += origin[i][0];             // added by A.Vorontsov
       comall[i][1] += origin[i][1];             // added by A.Vorontsov
       comall[i][2] += origin[i][2];             // added by A.Vorontsov
-    }
+
+    } else comall[i][0] = comall[i][1] = comall[i][2] = 0.0;
   }
 }
 

--- a/src/compute_com_chunk.h
+++ b/src/compute_com_chunk.h
@@ -50,7 +50,7 @@ class ComputeCOMChunk : public Compute {
 
   double *massproc;
   double **com,**comall;
-  double **origin;           // added by A.Vorontsov
+  double **origin;
 
   void allocate();
 };

--- a/src/compute_com_chunk.h
+++ b/src/compute_com_chunk.h
@@ -50,6 +50,7 @@ class ComputeCOMChunk : public Compute {
 
   double *massproc;
   double **com,**comall;
+  double **origin;           // added by A.Vorontsov
 
   void allocate();
 };

--- a/src/compute_gyration_chunk.cpp
+++ b/src/compute_gyration_chunk.cpp
@@ -29,8 +29,7 @@ using namespace LAMMPS_NS;
 ComputeGyrationChunk::ComputeGyrationChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), 
-  rg(NULL), rgall(NULL), rgt(NULL), rgtall(NULL),
-  origin(NULL)          //added by A.Vorontsov
+  rg(NULL), rgall(NULL), rgt(NULL), rgtall(NULL), origin(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute gyration/chunk command");
 
@@ -86,7 +85,7 @@ ComputeGyrationChunk::~ComputeGyrationChunk()
   memory->destroy(rgall);
   memory->destroy(rgt);
   memory->destroy(rgtall);
-  memory->destroy(origin);      //added by A.Vorontsov
+  memory->destroy(origin);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -135,7 +134,7 @@ void ComputeGyrationChunk::compute_vector()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
-      domain->minimum_image(dx,dy,dz);                 // added by A.Vorontsov
+      domain->minimum_image(dx,dy,dz);
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       rg[index] += (dx*dx + dy*dy + dz*dz) * massone;
@@ -180,7 +179,7 @@ void ComputeGyrationChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
-      domain->minimum_image(dx,dy,dz);             // added by A.Vorontsov
+      domain->minimum_image(dx,dy,dz);
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       rgt[index][0] += dx*dx * massone;
@@ -242,22 +241,20 @@ void ComputeGyrationChunk::com_chunk()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-//----------- added by A.Vorontsov ----------------------------------------------------------------------
-  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
-    if (mask[i] & groupbit) {                // added by A.Vorontsov
-      index = ichunk[i]-1;                   // added by A.Vorontsov
-      if (index < 0) continue;               // added by A.Vorontsov
-      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
-      com[index][0] = unwrap[0];             // added by A.Vorontsov
-      com[index][1] = unwrap[1];             // added by A.Vorontsov
-      com[index][2] = unwrap[2];             // added by A.Vorontsov
-    }                                        // added by A.Vorontsov
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      index = ichunk[i]-1;
+      if (index < 0) continue;
+      domain->unmap(x[i],image[i],unwrap);
+      com[index][0] = unwrap[0];
+      com[index][1] = unwrap[1];
+      com[index][2] = unwrap[2];
+    }
 
-  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);
 
-  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
-    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
-//--------------------------------------------------------------------------------------------------------
+  for (int i = 0; i < nchunk; i++)
+    com[i][0] = com[i][1] = com[i][2] = 0.0;
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
@@ -266,10 +263,10 @@ void ComputeGyrationChunk::com_chunk()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
-      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+      unwrap[0] -= origin[index][0];
+      unwrap[1] -= origin[index][1];
+      unwrap[2] -= origin[index][2];
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);
 
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
@@ -286,9 +283,9 @@ void ComputeGyrationChunk::com_chunk()
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
 
-      comall[i][0] += origin[i][0];             // added by A.Vorontsov
-      comall[i][1] += origin[i][1];             // added by A.Vorontsov
-      comall[i][2] += origin[i][2];             // added by A.Vorontsov
+      comall[i][0] += origin[i][0];
+      comall[i][1] += origin[i][1];
+      comall[i][2] += origin[i][2];
     }
   }
 }
@@ -363,13 +360,13 @@ void ComputeGyrationChunk::allocate()
   memory->destroy(rgall);
   memory->destroy(rgt);
   memory->destroy(rgtall);
-  memory->destroy(origin);                                          // added by A.Vorontsov
+  memory->destroy(origin);
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"gyration/chunk:massproc");
   memory->create(masstotal,maxchunk,"gyration/chunk:masstotal");
   memory->create(com,maxchunk,3,"gyration/chunk:com");
   memory->create(comall,maxchunk,3,"gyration/chunk:comall");
-  memory->create(origin,maxchunk,3,"gyration/chunk:origin");        // added by A.Vorontsov
+  memory->create(origin,maxchunk,3,"gyration/chunk:origin");
   if (tensor) {
     memory->create(rgt,maxchunk,6,"gyration/chunk:rgt");
     memory->create(rgtall,maxchunk,6,"gyration/chunk:rgtall");
@@ -389,7 +386,7 @@ double ComputeGyrationChunk::memory_usage()
 {
   double bytes = (bigint) maxchunk * 2 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
-  bytes += (bigint) maxchunk * 3 * sizeof(double);                 // added by A.Vorontsov
+  bytes += (bigint) maxchunk * 3 * sizeof(double);
   if (tensor) bytes += (bigint) maxchunk * 2*6 * sizeof(double);
   else bytes += (bigint) maxchunk * 2 * sizeof(double);
   return bytes;

--- a/src/compute_gyration_chunk.h
+++ b/src/compute_gyration_chunk.h
@@ -51,7 +51,7 @@ class ComputeGyrationChunk : public Compute {
   double **com,**comall;
   double *rg,*rgall;
   double **rgt,**rgtall;
-  double **origin;            //added by A.Vorontsov
+  double **origin;
 
   void com_chunk();
   void allocate();

--- a/src/compute_gyration_chunk.h
+++ b/src/compute_gyration_chunk.h
@@ -51,6 +51,7 @@ class ComputeGyrationChunk : public Compute {
   double **com,**comall;
   double *rg,*rgall;
   double **rgt,**rgtall;
+  double **origin;            //added by A.Vorontsov
 
   void com_chunk();
   void allocate();

--- a/src/compute_inertia_chunk.cpp
+++ b/src/compute_inertia_chunk.cpp
@@ -28,7 +28,8 @@ using namespace LAMMPS_NS;
 ComputeInertiaChunk::ComputeInertiaChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL),
-  inertia(NULL), inertiaall(NULL)
+  inertia(NULL), inertiaall(NULL),
+  origin(NULL)                // added by A.Vorontsov
 {
   if (narg != 4) error->all(FLERR,"Illegal compute inertia/chunk command");
 
@@ -64,6 +65,7 @@ ComputeInertiaChunk::~ComputeInertiaChunk()
   memory->destroy(comall);
   memory->destroy(inertia);
   memory->destroy(inertiaall);
+  memory->destroy(origin);              //added by A. Vorontsov
 }
 
 /* ---------------------------------------------------------------------- */
@@ -118,6 +120,23 @@ void ComputeInertiaChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
+//----------- added by A.Vorontsov ----------------------------------------------------------------------
+  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
+    if (mask[i] & groupbit) {                // added by A.Vorontsov
+      index = ichunk[i]-1;                   // added by A.Vorontsov
+      if (index < 0) continue;               // added by A.Vorontsov
+      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
+      com[index][0] = unwrap[0];             // added by A.Vorontsov
+      com[index][1] = unwrap[1];             // added by A.Vorontsov
+      com[index][2] = unwrap[2];             // added by A.Vorontsov
+    }                                        // added by A.Vorontsov
+
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+
+  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
+    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
+//--------------------------------------------------------------------------------------------------------
+
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
       index = ichunk[i]-1;
@@ -125,6 +144,11 @@ void ComputeInertiaChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
+      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
+      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
+      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
       com[index][1] += unwrap[1] * massone;
@@ -139,6 +163,10 @@ void ComputeInertiaChunk::compute_array()
       comall[i][0] /= masstotal[i];
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
+
+      comall[i][0] += origin[i][0];             // added by A.Vorontsov
+      comall[i][1] += origin[i][1];             // added by A.Vorontsov
+      comall[i][2] += origin[i][2];             // added by A.Vorontsov
     }
   }
 
@@ -154,6 +182,7 @@ void ComputeInertiaChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
+      domain->minimum_image(dx,dy,dz);                  // added by A.Vorontsov
       inertia[index][0] += massone * (dy*dy + dz*dz);
       inertia[index][1] += massone * (dx*dx + dz*dz);
       inertia[index][2] += massone * (dx*dx + dy*dy);
@@ -235,6 +264,7 @@ void ComputeInertiaChunk::allocate()
   memory->destroy(comall);
   memory->destroy(inertia);
   memory->destroy(inertiaall);
+  memory->destroy(origin);                  // added by A.Vorontsov
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"inertia/chunk:massproc");
   memory->create(masstotal,maxchunk,"inertia/chunk:masstotal");
@@ -242,6 +272,7 @@ void ComputeInertiaChunk::allocate()
   memory->create(comall,maxchunk,3,"inertia/chunk:comall");
   memory->create(inertia,maxchunk,6,"inertia/chunk:inertia");
   memory->create(inertiaall,maxchunk,6,"inertia/chunk:inertiaall");
+  memory->create(origin,maxchunk,3,"inertia/chunk:origin");      // added by A.Vorontsov
   array = inertiaall;
 }
 
@@ -254,5 +285,6 @@ double ComputeInertiaChunk::memory_usage()
   double bytes = (bigint) maxchunk * 2 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
   bytes += (bigint) maxchunk * 2*6 * sizeof(double);
+  bytes += (bigint) maxchunk * 3 * sizeof(double);           //added by A.Vorontsov
   return bytes;
 }

--- a/src/compute_inertia_chunk.cpp
+++ b/src/compute_inertia_chunk.cpp
@@ -28,8 +28,7 @@ using namespace LAMMPS_NS;
 ComputeInertiaChunk::ComputeInertiaChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL),
-  inertia(NULL), inertiaall(NULL),
-  origin(NULL)                // added by A.Vorontsov
+  inertia(NULL), inertiaall(NULL), origin(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute inertia/chunk command");
 
@@ -65,7 +64,7 @@ ComputeInertiaChunk::~ComputeInertiaChunk()
   memory->destroy(comall);
   memory->destroy(inertia);
   memory->destroy(inertiaall);
-  memory->destroy(origin);              //added by A. Vorontsov
+  memory->destroy(origin);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -120,22 +119,20 @@ void ComputeInertiaChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-//----------- added by A.Vorontsov ----------------------------------------------------------------------
-  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
-    if (mask[i] & groupbit) {                // added by A.Vorontsov
-      index = ichunk[i]-1;                   // added by A.Vorontsov
-      if (index < 0) continue;               // added by A.Vorontsov
-      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
-      com[index][0] = unwrap[0];             // added by A.Vorontsov
-      com[index][1] = unwrap[1];             // added by A.Vorontsov
-      com[index][2] = unwrap[2];             // added by A.Vorontsov
-    }                                        // added by A.Vorontsov
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      index = ichunk[i]-1;
+      if (index < 0) continue;
+      domain->unmap(x[i],image[i],unwrap);
+      com[index][0] = unwrap[0];
+      com[index][1] = unwrap[1];
+      com[index][2] = unwrap[2];
+    }
 
-  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);
 
-  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
-    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
-//--------------------------------------------------------------------------------------------------------
+  for (int i = 0; i < nchunk; i++)
+    com[i][0] = com[i][1] = com[i][2] = 0.0;
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
@@ -144,10 +141,10 @@ void ComputeInertiaChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
-      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+      unwrap[0] -= origin[index][0];
+      unwrap[1] -= origin[index][1];
+      unwrap[2] -= origin[index][2];
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);
 
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
@@ -164,9 +161,9 @@ void ComputeInertiaChunk::compute_array()
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
 
-      comall[i][0] += origin[i][0];             // added by A.Vorontsov
-      comall[i][1] += origin[i][1];             // added by A.Vorontsov
-      comall[i][2] += origin[i][2];             // added by A.Vorontsov
+      comall[i][0] += origin[i][0];
+      comall[i][1] += origin[i][1];
+      comall[i][2] += origin[i][2];
     }
   }
 
@@ -182,7 +179,7 @@ void ComputeInertiaChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
-      domain->minimum_image(dx,dy,dz);                  // added by A.Vorontsov
+      domain->minimum_image(dx,dy,dz);
       inertia[index][0] += massone * (dy*dy + dz*dz);
       inertia[index][1] += massone * (dx*dx + dz*dz);
       inertia[index][2] += massone * (dx*dx + dy*dy);
@@ -264,7 +261,7 @@ void ComputeInertiaChunk::allocate()
   memory->destroy(comall);
   memory->destroy(inertia);
   memory->destroy(inertiaall);
-  memory->destroy(origin);                  // added by A.Vorontsov
+  memory->destroy(origin);
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"inertia/chunk:massproc");
   memory->create(masstotal,maxchunk,"inertia/chunk:masstotal");
@@ -272,7 +269,7 @@ void ComputeInertiaChunk::allocate()
   memory->create(comall,maxchunk,3,"inertia/chunk:comall");
   memory->create(inertia,maxchunk,6,"inertia/chunk:inertia");
   memory->create(inertiaall,maxchunk,6,"inertia/chunk:inertiaall");
-  memory->create(origin,maxchunk,3,"inertia/chunk:origin");      // added by A.Vorontsov
+  memory->create(origin,maxchunk,3,"inertia/chunk:origin");
   array = inertiaall;
 }
 
@@ -285,6 +282,6 @@ double ComputeInertiaChunk::memory_usage()
   double bytes = (bigint) maxchunk * 2 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
   bytes += (bigint) maxchunk * 2*6 * sizeof(double);
-  bytes += (bigint) maxchunk * 3 * sizeof(double);           //added by A.Vorontsov
+  bytes += (bigint) maxchunk * 3 * sizeof(double);
   return bytes;
 }

--- a/src/compute_inertia_chunk.h
+++ b/src/compute_inertia_chunk.h
@@ -47,6 +47,7 @@ class ComputeInertiaChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **inertia,**inertiaall;
+  double **origin;                // added by A.Vorontsov
 
   void allocate();
 };

--- a/src/compute_inertia_chunk.h
+++ b/src/compute_inertia_chunk.h
@@ -47,7 +47,7 @@ class ComputeInertiaChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **inertia,**inertiaall;
-  double **origin;                // added by A.Vorontsov
+  double **origin;
 
   void allocate();
 };

--- a/src/compute_msd_chunk.cpp
+++ b/src/compute_msd_chunk.cpp
@@ -29,7 +29,8 @@ using namespace LAMMPS_NS;
 
 ComputeMSDChunk::ComputeMSDChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
-  idchunk(NULL), id_fix(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), msd(NULL)
+  idchunk(NULL), id_fix(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), msd(NULL),
+  origin(NULL)             //added by A.Vorontsov
 {
   if (narg != 4) error->all(FLERR,"Illegal compute msd/chunk command");
 
@@ -87,6 +88,7 @@ ComputeMSDChunk::~ComputeMSDChunk()
   memory->destroy(com);
   memory->destroy(comall);
   memory->destroy(msd);
+  memory->destroy(origin);              //added by A.Vorontsov
 }
 
 /* ---------------------------------------------------------------------- */
@@ -181,6 +183,23 @@ void ComputeMSDChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
+//----------- added by A.Vorontsov ----------------------------------------------------------------------
+  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
+    if (mask[i] & groupbit) {                // added by A.Vorontsov
+      index = ichunk[i]-1;                   // added by A.Vorontsov
+      if (index < 0) continue;               // added by A.Vorontsov
+      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
+      com[index][0] = unwrap[0];             // added by A.Vorontsov
+      com[index][1] = unwrap[1];             // added by A.Vorontsov
+      com[index][2] = unwrap[2];             // added by A.Vorontsov
+    }                                        // added by A.Vorontsov
+
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+
+  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
+    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
+//--------------------------------------------------------------------------------------------------------
+
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
       index = ichunk[i]-1;
@@ -188,6 +207,11 @@ void ComputeMSDChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
+      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
+      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
+      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
       com[index][1] += unwrap[1] * massone;
@@ -202,6 +226,10 @@ void ComputeMSDChunk::compute_array()
       comall[i][0] /= masstotal[i];
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
+
+      comall[i][0] += origin[i][0];             // added by A.Vorontsov
+      comall[i][1] += origin[i][1];             // added by A.Vorontsov
+      comall[i][2] += origin[i][2];             // added by A.Vorontsov
     }
   }
 
@@ -217,6 +245,10 @@ void ComputeMSDChunk::compute_array()
     dx = comall[i][0] - cominit[i][0];
     dy = comall[i][1] - cominit[i][1];
     dz = comall[i][2] - cominit[i][2];
+
+//???? could it be: msd > box_size/2 ?
+    domain->minimum_image(dx,dy,dz);   // added by A.Vorontsov.
+
     msd[i][0] = dx*dx;
     msd[i][1] = dy*dy;
     msd[i][2] = dz*dz;
@@ -291,6 +323,7 @@ void ComputeMSDChunk::allocate()
   memory->create(com,nchunk,3,"msd/chunk:com");
   memory->create(comall,nchunk,3,"msd/chunk:comall");
   memory->create(msd,nchunk,4,"msd/chunk:msd");
+  memory->create(origin,nchunk,3,"msd/chunk:origin");          //added by A.Vorontsov
   array = msd;
 }
 
@@ -303,5 +336,6 @@ double ComputeMSDChunk::memory_usage()
   double bytes = (bigint) nchunk * 2 * sizeof(double);
   bytes += (bigint) nchunk * 2*3 * sizeof(double);
   bytes += (bigint) nchunk * 4 * sizeof(double);
+  bytes += (bigint) nchunk * 3 * sizeof(double);              //added by A.Vorontov
   return bytes;
 }

--- a/src/compute_msd_chunk.cpp
+++ b/src/compute_msd_chunk.cpp
@@ -30,7 +30,7 @@ using namespace LAMMPS_NS;
 ComputeMSDChunk::ComputeMSDChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), id_fix(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), msd(NULL),
-  origin(NULL)             //added by A.Vorontsov
+  origin(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute msd/chunk command");
 
@@ -88,7 +88,7 @@ ComputeMSDChunk::~ComputeMSDChunk()
   memory->destroy(com);
   memory->destroy(comall);
   memory->destroy(msd);
-  memory->destroy(origin);              //added by A.Vorontsov
+  memory->destroy(origin);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -183,22 +183,20 @@ void ComputeMSDChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-//----------- added by A.Vorontsov ----------------------------------------------------------------------
-  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
-    if (mask[i] & groupbit) {                // added by A.Vorontsov
-      index = ichunk[i]-1;                   // added by A.Vorontsov
-      if (index < 0) continue;               // added by A.Vorontsov
-      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
-      com[index][0] = unwrap[0];             // added by A.Vorontsov
-      com[index][1] = unwrap[1];             // added by A.Vorontsov
-      com[index][2] = unwrap[2];             // added by A.Vorontsov
-    }                                        // added by A.Vorontsov
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      index = ichunk[i]-1;
+      if (index < 0) continue;
+      domain->unmap(x[i],image[i],unwrap);
+      com[index][0] = unwrap[0];
+      com[index][1] = unwrap[1];
+      com[index][2] = unwrap[2];
+    }
 
-  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);
 
-  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
-    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
-//--------------------------------------------------------------------------------------------------------
+  for (int i = 0; i < nchunk; i++)
+    com[i][0] = com[i][1] = com[i][2] = 0.0;
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
@@ -207,10 +205,10 @@ void ComputeMSDChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
-      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+      unwrap[0] -= origin[index][0];
+      unwrap[1] -= origin[index][1];
+      unwrap[2] -= origin[index][2];
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);
 
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
@@ -227,9 +225,9 @@ void ComputeMSDChunk::compute_array()
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
 
-      comall[i][0] += origin[i][0];             // added by A.Vorontsov
-      comall[i][1] += origin[i][1];             // added by A.Vorontsov
-      comall[i][2] += origin[i][2];             // added by A.Vorontsov
+      comall[i][0] += origin[i][0];
+      comall[i][1] += origin[i][1];
+      comall[i][2] += origin[i][2];
     }
   }
 
@@ -247,7 +245,7 @@ void ComputeMSDChunk::compute_array()
     dz = comall[i][2] - cominit[i][2];
 
 //???? could it be: msd > box_size/2 ?
-    domain->minimum_image(dx,dy,dz);   // added by A.Vorontsov.
+    domain->minimum_image(dx,dy,dz);
 
     msd[i][0] = dx*dx;
     msd[i][1] = dy*dy;
@@ -323,7 +321,7 @@ void ComputeMSDChunk::allocate()
   memory->create(com,nchunk,3,"msd/chunk:com");
   memory->create(comall,nchunk,3,"msd/chunk:comall");
   memory->create(msd,nchunk,4,"msd/chunk:msd");
-  memory->create(origin,nchunk,3,"msd/chunk:origin");          //added by A.Vorontsov
+  memory->create(origin,nchunk,3,"msd/chunk:origin");
   array = msd;
 }
 
@@ -336,6 +334,6 @@ double ComputeMSDChunk::memory_usage()
   double bytes = (bigint) nchunk * 2 * sizeof(double);
   bytes += (bigint) nchunk * 2*3 * sizeof(double);
   bytes += (bigint) nchunk * 4 * sizeof(double);
-  bytes += (bigint) nchunk * 3 * sizeof(double);              //added by A.Vorontov
+  bytes += (bigint) nchunk * 3 * sizeof(double);
   return bytes;
 }

--- a/src/compute_msd_chunk.h
+++ b/src/compute_msd_chunk.h
@@ -51,6 +51,7 @@ class ComputeMSDChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **msd;
+  double **origin;        //added by A.Vorontsov
 
   void allocate();
 };

--- a/src/compute_msd_chunk.h
+++ b/src/compute_msd_chunk.h
@@ -51,7 +51,7 @@ class ComputeMSDChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **msd;
-  double **origin;        //added by A.Vorontsov
+  double **origin;
 
   void allocate();
 };

--- a/src/compute_omega_chunk.cpp
+++ b/src/compute_omega_chunk.cpp
@@ -32,7 +32,7 @@ ComputeOmegaChunk::ComputeOmegaChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL),massproc(NULL),masstotal(NULL),com(NULL),comall(NULL),
   inertia(NULL),inertiaall(NULL),angmom(NULL),angmomall(NULL),omega(NULL),
-  origin(NULL)          // added by A.Vorontsov
+  origin(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute omega/chunk command");
 
@@ -71,7 +71,7 @@ ComputeOmegaChunk::~ComputeOmegaChunk()
   memory->destroy(inertia);
   memory->destroy(inertiaall);
   memory->destroy(omega);
-  memory->destroy(origin);                   //added by A.Vorontsov
+  memory->destroy(origin);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -128,22 +128,20 @@ void ComputeOmegaChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-//----------- added by A.Vorontsov ----------------------------------------------------------------------
-  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
-    if (mask[i] & groupbit) {                // added by A.Vorontsov
-      index = ichunk[i]-1;                   // added by A.Vorontsov
-      if (index < 0) continue;               // added by A.Vorontsov
-      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
-      com[index][0] = unwrap[0];             // added by A.Vorontsov
-      com[index][1] = unwrap[1];             // added by A.Vorontsov
-      com[index][2] = unwrap[2];             // added by A.Vorontsov
-    }                                        // added by A.Vorontsov
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      index = ichunk[i]-1;
+      if (index < 0) continue;
+      domain->unmap(x[i],image[i],unwrap);
+      com[index][0] = unwrap[0];
+      com[index][1] = unwrap[1];
+      com[index][2] = unwrap[2];
+    }
 
-  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);
 
-  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
-    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
-//--------------------------------------------------------------------------------------------------------
+  for (int i = 0; i < nchunk; i++)
+    com[i][0] = com[i][1] = com[i][2] = 0.0;
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
@@ -152,10 +150,10 @@ void ComputeOmegaChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
-      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+      unwrap[0] -= origin[index][0];
+      unwrap[1] -= origin[index][1];
+      unwrap[2] -= origin[index][2];
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);
 
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
@@ -172,9 +170,9 @@ void ComputeOmegaChunk::compute_array()
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
 
-      comall[i][0] += origin[i][0];             // added by A.Vorontsov
-      comall[i][1] += origin[i][1];             // added by A.Vorontsov
-      comall[i][2] += origin[i][2];             // added by A.Vorontsov
+      comall[i][0] += origin[i][0];
+      comall[i][1] += origin[i][1];
+      comall[i][2] += origin[i][2];
     }
   }
 
@@ -190,7 +188,7 @@ void ComputeOmegaChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
-      domain->minimum_image(dx,dy,dz);             // added by A.Vorontsov.
+      domain->minimum_image(dx,dy,dz);
       inertia[index][0] += massone * (dy*dy + dz*dz);
       inertia[index][1] += massone * (dx*dx + dz*dz);
       inertia[index][2] += massone * (dx*dx + dy*dy);
@@ -214,7 +212,7 @@ void ComputeOmegaChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
-      domain->minimum_image(dx,dy,dz);             // added by A.Vorontsov.
+      domain->minimum_image(dx,dy,dz);
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       angmom[index][0] += massone * (dy*v[i][2] - dz*v[i][1]);
@@ -390,7 +388,7 @@ void ComputeOmegaChunk::allocate()
   memory->destroy(angmom);
   memory->destroy(angmomall);
   memory->destroy(omega);
-  memory->destroy(origin);                              //added by A.Vorontsov
+  memory->destroy(origin);
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"omega/chunk:massproc");
   memory->create(masstotal,maxchunk,"omega/chunk:masstotal");
@@ -401,7 +399,7 @@ void ComputeOmegaChunk::allocate()
   memory->create(angmom,maxchunk,3,"omega/chunk:angmom");
   memory->create(angmomall,maxchunk,3,"omega/chunk:angmomall");
   memory->create(omega,maxchunk,3,"omega/chunk:omega");
-  memory->create(origin,maxchunk,3,"omega/chunk:origin"); //added by A.Vorontsov
+  memory->create(origin,maxchunk,3,"omega/chunk:origin");
   array = omega;
 }
 
@@ -416,6 +414,6 @@ double ComputeOmegaChunk::memory_usage()
   bytes += (bigint) maxchunk * 2*6 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
   bytes += (bigint) maxchunk * 3 * sizeof(double);
-  bytes += (bigint) maxchunk * 3 * sizeof(double);       //added by A.Vorontsov
+  bytes += (bigint) maxchunk * 3 * sizeof(double);
   return bytes;
 }

--- a/src/compute_omega_chunk.h
+++ b/src/compute_omega_chunk.h
@@ -49,7 +49,7 @@ class ComputeOmegaChunk : public Compute {
   double **inertia,**inertiaall;
   double **angmom,**angmomall;
   double **omega;
-  double **origin;          //added by A.Vorontsov
+  double **origin;
 
   void allocate();
 };

--- a/src/compute_omega_chunk.h
+++ b/src/compute_omega_chunk.h
@@ -49,6 +49,7 @@ class ComputeOmegaChunk : public Compute {
   double **inertia,**inertiaall;
   double **angmom,**angmomall;
   double **omega;
+  double **origin;          //added by A.Vorontsov
 
   void allocate();
 };

--- a/src/compute_torque_chunk.cpp
+++ b/src/compute_torque_chunk.cpp
@@ -28,7 +28,7 @@ using namespace LAMMPS_NS;
 ComputeTorqueChunk::ComputeTorqueChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), massproc(NULL), masstotal(NULL), com(NULL), comall(NULL), torque(NULL), torqueall(NULL),
-  origin(NULL)      //added by A.Vorontsov
+  origin(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal compute torque/chunk command");
 
@@ -64,7 +64,7 @@ ComputeTorqueChunk::~ComputeTorqueChunk()
   memory->destroy(comall);
   memory->destroy(torque);
   memory->destroy(torqueall);
-  memory->destroy(origin);           //added by A.Vorontsov
+  memory->destroy(origin);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -119,22 +119,20 @@ void ComputeTorqueChunk::compute_array()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-//----------- added by A.Vorontsov ----------------------------------------------------------------------
-  for (int i = 0; i < nlocal; i++)           // added by A.Vorontsov
-    if (mask[i] & groupbit) {                // added by A.Vorontsov
-      index = ichunk[i]-1;                   // added by A.Vorontsov
-      if (index < 0) continue;               // added by A.Vorontsov
-      domain->unmap(x[i],image[i],unwrap);   // added by A.Vorontsov
-      com[index][0] = unwrap[0];             // added by A.Vorontsov
-      com[index][1] = unwrap[1];             // added by A.Vorontsov
-      com[index][2] = unwrap[2];             // added by A.Vorontsov
-    }                                        // added by A.Vorontsov
+  for (int i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      index = ichunk[i]-1;
+      if (index < 0) continue;
+      domain->unmap(x[i],image[i],unwrap);
+      com[index][0] = unwrap[0];
+      com[index][1] = unwrap[1];
+      com[index][2] = unwrap[2];
+    }
 
-  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);  // added by A.Vorontsov
+  MPI_Allreduce(&com[0][0],&origin[0][0],3*nchunk,MPI_DOUBLE,MPI_MIN,world);
 
-  for (int i = 0; i < nchunk; i++)              // added by A.Vorontsov
-    com[i][0] = com[i][1] = com[i][2] = 0.0;    // added by A.Vorontsov
-//--------------------------------------------------------------------------------------------------------
+  for (int i = 0; i < nchunk; i++)
+    com[i][0] = com[i][1] = com[i][2] = 0.0;
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
@@ -143,10 +141,10 @@ void ComputeTorqueChunk::compute_array()
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
       domain->unmap(x[i],image[i],unwrap);
-      unwrap[0] -= origin[index][0];                        // added by A.Vorontsov
-      unwrap[1] -= origin[index][1];                        // added by A.Vorontsov
-      unwrap[2] -= origin[index][2];                        // added by A.Vorontsov
-      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]); // added by A.Vorontsov
+      unwrap[0] -= origin[index][0];
+      unwrap[1] -= origin[index][1];
+      unwrap[2] -= origin[index][2];
+      domain->minimum_image(unwrap[0],unwrap[1],unwrap[2]);
 
       massproc[index] += massone;
       com[index][0] += unwrap[0] * massone;
@@ -163,9 +161,9 @@ void ComputeTorqueChunk::compute_array()
       comall[i][1] /= masstotal[i];
       comall[i][2] /= masstotal[i];
 
-      comall[i][0] += origin[i][0];             // added by A.Vorontsov
-      comall[i][1] += origin[i][1];             // added by A.Vorontsov
-      comall[i][2] += origin[i][2];             // added by A.Vorontsov
+      comall[i][0] += origin[i][0];
+      comall[i][1] += origin[i][1];
+      comall[i][2] += origin[i][2];
     }
   }
 
@@ -181,7 +179,7 @@ void ComputeTorqueChunk::compute_array()
       dx = unwrap[0] - comall[index][0];
       dy = unwrap[1] - comall[index][1];
       dz = unwrap[2] - comall[index][2];
-      domain->minimum_image(dx,dy,dz);             // added by A.Vorontsov
+      domain->minimum_image(dx,dy,dz);
       torque[index][0] += dy*f[i][2] - dz*f[i][1];
       torque[index][1] += dz*f[i][0] - dx*f[i][2];
       torque[index][2] += dx*f[i][1] - dy*f[i][0];
@@ -259,7 +257,7 @@ void ComputeTorqueChunk::allocate()
   memory->destroy(comall);
   memory->destroy(torque);
   memory->destroy(torqueall);
-  memory->destroy(origin);              //added by A.Vorontsov
+  memory->destroy(origin);
   maxchunk = nchunk;
   memory->create(massproc,maxchunk,"torque/chunk:massproc");
   memory->create(masstotal,maxchunk,"torque/chunk:masstotal");
@@ -267,7 +265,7 @@ void ComputeTorqueChunk::allocate()
   memory->create(comall,maxchunk,3,"torque/chunk:comall");
   memory->create(torque,maxchunk,3,"torque/chunk:torque");
   memory->create(torqueall,maxchunk,3,"torque/chunk:torqueall");
-  memory->create(origin,maxchunk,3,"torque/chunk:origin");    //added by A.Vorontsov
+  memory->create(origin,maxchunk,3,"torque/chunk:origin");
   array = torqueall;
 }
 
@@ -280,6 +278,6 @@ double ComputeTorqueChunk::memory_usage()
   double bytes = (bigint) maxchunk * 2 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
   bytes += (bigint) maxchunk * 2*3 * sizeof(double);
-  bytes += (bigint) maxchunk * 3 * sizeof(double);    //added by A.Vorontsov
+  bytes += (bigint) maxchunk * 3 * sizeof(double);
   return bytes;
 }

--- a/src/compute_torque_chunk.h
+++ b/src/compute_torque_chunk.h
@@ -47,6 +47,7 @@ class ComputeTorqueChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **torque,**torqueall;
+  double **origin;              //added by A.Vorontsov
 
   void allocate();
 };

--- a/src/compute_torque_chunk.h
+++ b/src/compute_torque_chunk.h
@@ -47,7 +47,7 @@ class ComputeTorqueChunk : public Compute {
   double *massproc,*masstotal;
   double **com,**comall;
   double **torque,**torqueall;
-  double **origin;              //added by A.Vorontsov
+  double **origin;
 
   void allocate();
 };


### PR DESCRIPTION
I fixed the problem with COM calculation over a chunk computes with PBC.
Problem appeared when chunk crossed the boundary.
Solution is shifting origin close to chunk atoms, making calculation and shifting it back.
Also in gyration, inertia, omega, torque calculation one have to take nearest to COM copy of atoms.

I don't understand how you chose origin in compute_dipole_chunk, so i didn't correct it. But correction  is have to be done. 

## Purpose

I think distance with PBC should be calculated to the nearest image of atom. It is natural for molecules and clusters.

## Author(s)

Alexander Vorontsov, South Ural State University, Chelyabinsk, Russia

## Backward Compatibility

I made minor changes in existing files, so everything should be OK. 

## Implementation Notes

I've add  'origin' array, that takes MIN coordinates x_min, y_min, z_min of atoms of a chunk. COM calculation was performed with  nearest to origin images of atoms. After COM calculations origin shifted back.

In gyration, inertia, omega, torque calculation distance from atom to COM is calculated for nearest to COM copy of it.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

Simple test 
-------input_file------
...
boundary   p p p
region  reg block 0. 50. 0. 50. 0. 50.
create_box 1 reg
create_atoms 1 single 0 0 0
create_atoms 1 single 49 49 49
................
compute  clust_old all cluster/atom 8.0
compute chunk1 all chunk/atom c_clust_old
compute size all property/chunk chunk1 count
compute size_chunk all global/atom c_chunk1 c_size
compute com all com/chunk chunk1
compute com_chunk all global/atom c_chunk1 c_com[ * ]
compute gyr all gyration/chunk chunk1
compute gyr_chunk all global/atom c_chunk1 c_gyr
...
dump   clust_dump all custom 50 dump.txt id x y z c_clust_old c_size_chunk c_com_chunk[ * ] c_gyr_chunk[ * ]

run 0

--------- new result --------
ITEM: TIMESTEP
0
ITEM: NUMBER OF ATOMS
2
ITEM: BOX BOUNDS pp pp pp
0.0000000000000000e+00 5.0000000000000000e+01
0.0000000000000000e+00 5.0000000000000000e+01
0.0000000000000000e+00 5.0000000000000000e+01
ITEM: ATOMS id x y z c_clust_old c_size_chunk c_com_chunk[1] c_com_chunk[2] c_com_chunk[3] c_gyr_chunk[*]
     1      0    0.00000    0.00000    1.00000      2   49.50000   49.50000   49.50000    0.86603
     2     49   49.00000   49.00000    1.00000      2   49.50000   49.50000   49.50000    0.86603

-------  old  result --------------------
ITEM: TIMESTEP
0
ITEM: NUMBER OF ATOMS
2
ITEM: BOX BOUNDS pp pp pp
0.0000000000000000e+00 5.0000000000000000e+01
0.0000000000000000e+00 5.0000000000000000e+01
0.0000000000000000e+00 5.0000000000000000e+01
ITEM: ATOMS id x y z c_clust_old c_size_chunk c_com_chunk[1] c_com_chunk[2] c_com_chunk[3] c_gyr_chunk[*].
     1      0    0.00000    0.00000    1.00000      2   24.50000   24.50000   24.50000   42.43524.
     2     49   49.00000   49.00000    1.00000      2   24.50000   24.50000   24.50000   42.43524.