### PR TITLE
Modified USER-QUIP interface to pass lammps atom IDs

### DIFF
--- a/doc/src/pair_quip.txt
+++ b/doc/src/pair_quip.txt
@@ -80,6 +80,14 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 QUIP potentials are parametrized in electron-volts and Angstroms and
 therefore should be used with LAMMPS metal "units"_units.html.
 
+QUIP potentials are generally not designed to work with the scaling
+factors set by the "special_bonds"_special_bonds.html command.  The
+recommended setting in molecular systems is to include all
+interactions, i.e. to use {special_bonds lj 1.0 1.0 1.0}.  The only
+exception to this rule is if you know that your QUIP potential needs
+to exclude bonded, 1-3, or 1-4 interactions and does not already do
+this exclusion within QUIP.
+
 [Related commands:]
 
 "pair_coeff"_pair_coeff.html

--- a/doc/src/pair_quip.txt
+++ b/doc/src/pair_quip.txt
@@ -83,10 +83,18 @@ therefore should be used with LAMMPS metal "units"_units.html.
 QUIP potentials are generally not designed to work with the scaling
 factors set by the "special_bonds"_special_bonds.html command.  The
 recommended setting in molecular systems is to include all
-interactions, i.e. to use {special_bonds lj 1.0 1.0 1.0}.  The only
-exception to this rule is if you know that your QUIP potential needs
-to exclude bonded, 1-3, or 1-4 interactions and does not already do
-this exclusion within QUIP.
+interactions, i.e. to use {special_bonds lj/coul 1.0 1.0 1.0}. Scaling
+factors > 0.0 will be ignored and treated as 1.0. The only exception
+to this rule is if you know that your QUIP potential needs to exclude
+bonded, 1-3, or 1-4 interactions and does not already do this exclusion
+within QUIP. Then a factor 0.0 needs to be used which will remove such
+pairs from the neighbor list. This needs to be very carefully tested,
+because it may remove pairs from the neighbor list that are still
+required.
+
+Pair style {quip} cannot be used with pair style {hybrid}, only
+with {hybrid/overlay} and only the {quip} substyle is applied to
+all atom types.
 
 [Related commands:]
 

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -255,11 +255,11 @@ void PairQUIP::coeff(int narg, char **arg)
       error->all(FLERR,"Incorrect args for pair coefficients");
 
    n_quip_file = strlen(arg[2]);
-   quip_file = new char[n_quip_file];
+   quip_file = new char[n_quip_file+1];
    strcpy(quip_file,arg[2]);
 
    n_quip_string = strlen(arg[3]);
-   quip_string = new char[n_quip_string];
+   quip_string = new char[n_quip_string+1];
    strcpy(quip_string,arg[3]);
 
    for (int i = 4; i < narg; i++) {

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -124,12 +124,23 @@ void PairQUIP::compute(int eflag, int vflag)
   lattice[7] = domain->yz;
   lattice[8] = domain->zprd;
 
+#if defined(LAMMPS_BIGBIG)
+  error->all(FLERR,"Pair style quip does not support -DLAMMPS_BIGBIG");
+  // quip_lammps_longint_wrapper(
+  // (&nlocal,&nghost,atomic_numbers,tag,
+  //   &inum,&sum_num_neigh,ilist,
+  //   quip_num_neigh,quip_neigh,lattice,
+  //   quip_potential,&n_quip_potential,&x[0][0],
+  //   &quip_energy,quip_local_e,quip_virial,quip_local_virial,quip_force);
+#else
   quip_lammps_wrapper
     (&nlocal,&nghost,atomic_numbers,tag,
      &inum,&sum_num_neigh,ilist,
      quip_num_neigh,quip_neigh,lattice,
      quip_potential,&n_quip_potential,&x[0][0],
      &quip_energy,quip_local_e,quip_virial,quip_local_virial,quip_force);
+#endif
+
   iquip = 0;
   for (ii = 0; ii < ntotal; ii++) {
      for( jj = 0; jj < 3; jj++ ) {

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -42,6 +42,7 @@ PairQUIP::PairQUIP(LAMMPS *lmp) : Pair(lmp)
    single_enable = 0;
    one_coeff = 1;
    no_virial_fdotr_compute = 1;
+   manybody_flag = 1;
 }
 
 PairQUIP::~PairQUIP()
@@ -99,7 +100,7 @@ void PairQUIP::compute(int eflag, int vflag)
     jnum = numneigh[i];
 
     for (jj = 0; jj < jnum; jj++) {
-       quip_neigh[iquip] = jlist[jj]+1;
+       quip_neigh[iquip] = (jlist[jj] & NEIGHMASK) + 1;
        iquip++;
     }
   }
@@ -131,7 +132,7 @@ void PairQUIP::compute(int eflag, int vflag)
     tmptag[ii] = tag[ii];
     if (tag[ii] > MAXSMALLINT) tmplarge=1;
   }
-  MPI_Allreduce(&tmplarge,&toolarge,1,MPI_INT,MPI_MAX,comm);
+  MPI_Allreduce(&tmplarge,&toolarge,1,MPI_INT,MPI_MAX,world);
   if (toolarge > 0)
     error->all(FLERR,"Pair style quip does not support 64-bit atom IDs");
 
@@ -213,7 +214,7 @@ void PairQUIP::compute(int eflag, int vflag)
 void PairQUIP::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-  if (strncmp(force->pair->style,"hybrid",6) == 0)
+  if (strncmp(force->pair_style,"hybrid",6) == 0)
     error->all(FLERR,"Pair style quip is not compatible with hybrid styles");
 }
 

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -214,8 +214,14 @@ void PairQUIP::compute(int eflag, int vflag)
 void PairQUIP::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-  if (strncmp(force->pair_style,"hybrid",6) == 0)
-    error->all(FLERR,"Pair style quip is not compatible with hybrid styles");
+  if (strcmp(force->pair_style,"hybrid") == 0)
+    error->all(FLERR,"Pair style quip is only compatible with hybrid/overlay");
+
+  // check if linked to the correct QUIP library API version
+  // as of 2017-07-19 this is API_VERSION 1
+  if (quip_lammps_api_version() != 1)
+    error->all(FLERR,"QUIP LAMMPS wrapper API version is not compatible "
+        "with this version of LAMMPS");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -66,6 +66,7 @@ void PairQUIP::compute(int eflag, int vflag)
   int nghost = atom->nghost;
   int ntotal = nlocal + nghost;
   int *type = atom->type;
+  tagint *tag = atom->tag;
 
   double **x = atom->x;
   double **f = atom->f;
@@ -124,7 +125,7 @@ void PairQUIP::compute(int eflag, int vflag)
   lattice[8] = domain->zprd;
 
   quip_lammps_wrapper
-    (&nlocal,&nghost,atomic_numbers,
+    (&nlocal,&nghost,atomic_numbers,tag,
      &inum,&sum_num_neigh,ilist,
      quip_num_neigh,quip_neigh,lattice,
      quip_potential,&n_quip_potential,&x[0][0],

--- a/src/USER-QUIP/pair_quip.h
+++ b/src/USER-QUIP/pair_quip.h
@@ -24,12 +24,13 @@ PairStyle(quip,PairQUIP)
 
 extern "C"
 {
-   void quip_lammps_wrapper(int*, int*, int*, int*,
+  int quip_lammps_api_version();
+  void quip_lammps_wrapper(int*, int*, int*, int*,
       int*, int*, int*,
       int*, int*, double*,
       int*, int*, double*,
       double*, double*, double*, double*, double*);
-   void quip_lammps_potential_initialise(int*, int*, double*, char*, int*, char*, int*);
+  void quip_lammps_potential_initialise(int*, int*, double*, char*, int*, char*, int*);
 }
 
 namespace LAMMPS_NS {

--- a/src/USER-QUIP/pair_quip.h
+++ b/src/USER-QUIP/pair_quip.h
@@ -24,7 +24,7 @@ PairStyle(quip,PairQUIP)
 
 extern "C"
 {
-   void quip_lammps_wrapper(int*, int*, int*,
+   void quip_lammps_wrapper(int*, int*, int*, int*,
       int*, int*, int*,
       int*, int*, double*,
       int*, int*, double*,

--- a/src/USER-QUIP/pair_quip.h
+++ b/src/USER-QUIP/pair_quip.h
@@ -29,11 +29,6 @@ extern "C"
       int*, int*, double*,
       int*, int*, double*,
       double*, double*, double*, double*, double*);
-   // void quip_lammps_longint_wrapper(int*, int*, int*, int64_t*,
-   //   int*, int*, int*,
-   //   int*, int*, double*,
-   //   int*, int*, double*,
-   //   double*, double*, double*, double*, double*);
    void quip_lammps_potential_initialise(int*, int*, double*, char*, int*, char*, int*);
 }
 

--- a/src/USER-QUIP/pair_quip.h
+++ b/src/USER-QUIP/pair_quip.h
@@ -29,6 +29,11 @@ extern "C"
       int*, int*, double*,
       int*, int*, double*,
       double*, double*, double*, double*, double*);
+   // void quip_lammps_longint_wrapper(int*, int*, int*, int64_t*,
+   //   int*, int*, int*,
+   //   int*, int*, double*,
+   //   int*, int*, double*,
+   //   double*, double*, double*, double*, double*);
    void quip_lammps_potential_initialise(int*, int*, double*, char*, int*, char*, int*);
 }
 


### PR DESCRIPTION
## Purpose

Modify the interface from lammps to quip so that quip gets lammps atom IDs.  This is necessary because some of the potentials in quip need to distinguish atoms in a way that is consistent between frames of a simulation.

## Author(s)

Max Veit (University of Cambridge)

## Backward Compatibility

The input format remains unchanged.  However, as the interface signature does change, this version must be used with the [branch lmpidces](https://github.com/libAtoms/QUIP/tree/lmpidces) of QUIP until that branch can be merged (once this pull request is accepted).

## Implementation Notes

The only change is to take the Atom field `tag` and add it to the list of parameters passed in the wrapper function `quip_lammps_wrapper()`.  This change has been verified to pass the correct atom IDs in both serial and MPI mode, and QUIP has been able to use these (read-only) with no problems.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included (none necessary)
- [ ] One or more example input decks are included (already included)
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

N/A


