### PR TITLE
avoid makefile failure, if LAMMPS has not been configured yet

### DIFF
--- a/lib/colvars/Makefile.common
+++ b/lib/colvars/Makefile.common
@@ -1,12 +1,12 @@
 # Shared -*- makefile -*- for multiple architectures
 
-# Detect settings from PYTHON package (if defined)
-sinclude ../../src/Makefile.package.settings
-ifeq ($(python_SYSINC),)
-COLVARS_PYTHON_INCFLAGS =
-else
-COLVARS_PYTHON_INCFLAGS = -DCOLVARS_PYTHON $(python_SYSINC)
-endif
+# # Detect settings from PYTHON package (if defined)
+# sinclude ../../src/Makefile.package.settings
+# ifeq ($(python_SYSINC),)
+# COLVARS_PYTHON_INCFLAGS =
+# else
+# COLVARS_PYTHON_INCFLAGS = -DCOLVARS_PYTHON $(python_SYSINC)
+# endif
 
 # Detect debug settings
 ifeq ($(COLVARS_DEBUG),)

--- a/lib/colvars/Makefile.common
+++ b/lib/colvars/Makefile.common
@@ -1,7 +1,7 @@
 # Shared -*- makefile -*- for multiple architectures
 
 # Detect settings from PYTHON package (if defined)
-include ../../src/Makefile.package.settings
+sinclude ../../src/Makefile.package.settings
 ifeq ($(python_SYSINC),)
 COLVARS_PYTHON_INCFLAGS =
 else

--- a/lib/colvars/Makefile.g++
+++ b/lib/colvars/Makefile.g++
@@ -11,11 +11,11 @@ AR =		ar
 ARFLAGS =	-rscv
 SHELL =		/bin/sh
 
-include Makefile.common
-
 .PHONY: default clean
 
 default: $(COLVARS_LIB) Makefile.lammps
+
+include Makefile.common
 
 clean:
 	-rm -f $(COLVARS_OBJS) $(COLVARS_LIB)

--- a/lib/colvars/Makefile.mingw32-cross
+++ b/lib/colvars/Makefile.mingw32-cross
@@ -14,11 +14,11 @@ AR =		i686-w64-mingw32-ar
 ARFLAGS =	-rscv
 SHELL =		/bin/sh
 
-include Makefile.common
-
 .PHONY: default clean
 
 default: $(COLVARS_OBJ_DIR) $(COLVARS_LIB) Makefile.lammps
+
+include Makefile.common
 
 $(COLVARS_OBJ_DIR):
 	mkdir $(COLVARS_OBJ_DIR)

--- a/lib/colvars/Makefile.mingw64-cross
+++ b/lib/colvars/Makefile.mingw64-cross
@@ -14,11 +14,11 @@ AR =		x86_64-w64-mingw32-ar
 ARFLAGS =	-rscv
 SHELL =		/bin/sh
 
-include Makefile.common
-
 .PHONY: default clean
 
 default: $(COLVARS_OBJ_DIR) $(COLVARS_LIB) Makefile.lammps
+
+include Makefile.common
 
 $(COLVARS_OBJ_DIR):
 	mkdir $(COLVARS_OBJ_DIR)

--- a/lib/colvars/README
+++ b/lib/colvars/README
@@ -18,13 +18,17 @@ For a brief description see:
 This directory has source files to build a library that LAMMPS
 links against when using the USER-COLVARS package.
 
-This library must be built with a C++ compiler, *before* LAMMPS is built, so
-that LAMMPS can link against it.  You can use the provided Makefile.* files or
-create your own, specific to your compiler and system.  For example:
+This library must be built with a C++ compiler, *before* LAMMPS is built and
+*after* packages are configured, so that LAMMPS can link against it.
+You can use the provided Makefile.* files or create your own, specific to your
+compiler and system.  For example:
 
+  cd src
+  make yes-user-colvars
+  cd ../lib/colvars
   make -f Makefile.g++
 
-will use the GNU C++ compiler and is a good template to start.
+where Makefile.g++ uses the GNU C++ compiler and is a good template to start.
 
 **Optional**: if you use the Install.py script provided in this folder, you
 can give the machine name as the '-m' argument.  This can be the suffix of one


### PR DESCRIPTION
quick fix for patch release. closes #587
