### PR TITLE
Safer Makefiles for Colvars

### DIFF
--- a/lib/colvars/Makefile.common
+++ b/lib/colvars/Makefile.common
@@ -1,12 +1,12 @@
 # Shared -*- makefile -*- for multiple architectures
 
-# Detect settings from PYTHON package (if defined)
-include ../../src/Makefile.package.settings
-ifeq ($(python_SYSINC),)
-COLVARS_PYTHON_INCFLAGS =
-else
-COLVARS_PYTHON_INCFLAGS = -DCOLVARS_PYTHON $(python_SYSINC)
-endif
+# # Detect settings from PYTHON package (if defined)
+# sinclude ../../src/Makefile.package.settings
+# ifeq ($(python_SYSINC),)
+# COLVARS_PYTHON_INCFLAGS =
+# else
+# COLVARS_PYTHON_INCFLAGS = -DCOLVARS_PYTHON $(python_SYSINC)
+# endif
 
 # Detect debug settings
 ifeq ($(COLVARS_DEBUG),)

--- a/lib/colvars/Makefile.g++
+++ b/lib/colvars/Makefile.g++
@@ -11,11 +11,11 @@ AR =		ar
 ARFLAGS =	-rscv
 SHELL =		/bin/sh
 
-include Makefile.common
-
 .PHONY: default clean
 
 default: $(COLVARS_LIB) Makefile.lammps
+
+include Makefile.common
 
 clean:
 	-rm -f $(COLVARS_OBJS) $(COLVARS_LIB)

--- a/lib/colvars/Makefile.mingw32-cross
+++ b/lib/colvars/Makefile.mingw32-cross
@@ -14,11 +14,11 @@ AR =		i686-w64-mingw32-ar
 ARFLAGS =	-rscv
 SHELL =		/bin/sh
 
-include Makefile.common
-
 .PHONY: default clean
 
 default: $(COLVARS_OBJ_DIR) $(COLVARS_LIB) Makefile.lammps
+
+include Makefile.common
 
 $(COLVARS_OBJ_DIR):
 	mkdir $(COLVARS_OBJ_DIR)

--- a/lib/colvars/Makefile.mingw64-cross
+++ b/lib/colvars/Makefile.mingw64-cross
@@ -14,11 +14,11 @@ AR =		x86_64-w64-mingw32-ar
 ARFLAGS =	-rscv
 SHELL =		/bin/sh
 
-include Makefile.common
-
 .PHONY: default clean
 
 default: $(COLVARS_OBJ_DIR) $(COLVARS_LIB) Makefile.lammps
+
+include Makefile.common
 
 $(COLVARS_OBJ_DIR):
 	mkdir $(COLVARS_OBJ_DIR)


### PR DESCRIPTION
## Purpose

Disable inclusion of `Makefile.lammps` from other packages and rearranged order of targets.

## Author(s)

@giacomofiorin

## Backward Compatibility

Compatible.

## Implementation Notes

Changes to Makefiles, commented out a few statements (but incorporates already a fix from @akohlmey that wasn't merged yet).

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

https://github.com/colvars/colvars


