### PR TITLE
LICENSE: update address of Free Software Foundation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ GNU GENERAL PUBLIC LICENSE
 Version 2, June 1991 
 
 Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
-59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 Everyone is permitted to copy and distribute verbatim copies of this
 license document, but changing it is not allowed.


### PR DESCRIPTION
## Purpose

OpenSuse's rpmlint told me:
```
The Free Software Foundation address in this file seems to be outdated or
misspelled.  Ask upstream to update the address, or if this is a license file,
possibly the entire file with a new copy available from the FSF.
```

## Author(s)

@junghans

## Backward Compatibility

Yes

## Implementation Notes

N/A

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

New address found here: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html


