### PR TITLE
restore lost KIM doc section in Section packages

### DIFF
--- a/doc/src/Section_commands.txt
+++ b/doc/src/Section_commands.txt
@@ -734,8 +734,8 @@ package"_Section_start.html#start_3.
 "smd/wall/surface"_fix_smd_wall_surface.html,
 "temp/rescale/eff"_fix_temp_rescale_eff.html,
 "ti/spring"_fix_ti_spring.html,
-"ttm/mod"_fix_ttm.html
-"wall/ees"_fix_wall_ees.html
+"ttm/mod"_fix_ttm.html,
+"wall/ees"_fix_wall_ees.html,
 "wall/region/ees"_fix_wall_ees.html :tb(c=6,ea=c)
 
 :line

--- a/doc/src/Section_packages.txt
+++ b/doc/src/Section_packages.txt
@@ -492,14 +492,38 @@ Minnesota).
 
 [Install or un-install:]
 
-Using this package requires the KIM library and its models
-(interatomic potentials) to be downloaded and installed on your
-system.  The library can be downloaded and built in lib/kim or
-elsewhere on your system.  Details of the download, build, and install
-process for KIM are given in the lib/kim/README file.
+Before building LAMMPS with this package, you must first download and
+build the KIM library and include the KIM models that you want to
+use. You can do this manually if you prefer; follow the instructions
+in lib/kim/README.  You can also do it in one step from the lammps/src
+dir, using a command like these, which simply invoke the
+lib/kim/Install.py script with the specified args.
 
-Once that process is complete, you can then install/un-install the
-package and build LAMMPS in the usual manner:
+make lib-kim                    # print help message
+make lib-kim args="-b . none"   # install KIM API lib with only example models
+make lib-kim args="-b . Glue_Ercolessi_Adams_Al__MO_324507536345_001"  # ditto plus one model
+make lib-kim args="-b . OpenKIM"   # install KIM API lib with all models
+make lib-kim args="-a EAM_Dynamo_Ackland_W__MO_141627196590_002"       # add one model or model driver :pre
+
+Note that in LAMMPS lingo, a KIM model driver is a pair style
+(e.g. EAM or Tersoff).  A KIM model is a pair style for a particular
+element or alloy and set of parameters, e.g. EAM for Cu with a
+specific EAM potential file.  Also note that installing the KIM API
+library with all its models, may take around 30 min to build.  Of
+course you only need to do that once.
+
+See the list of KIM model drivers here:
+https://openkim.org/kim-items/model-drivers/alphabetical
+
+See the list of all KIM models here:
+https://openkim.org/kim-items/models/by-model-drivers
+
+See the list of example KIM models included by default here:
+https://openkim.org/kim-api in the "What is in the KIM API source
+package?" section
+
+You can then install/un-install the package and build LAMMPS in the
+usual manner:
 
 make yes-kim
 make machine :pre

--- a/src/SHOCK/fix_msst.cpp
+++ b/src/SHOCK/fix_msst.cpp
@@ -939,7 +939,7 @@ int FixMSST::modify_param(int narg, char **arg)
 
 double FixMSST::compute_scalar()
 {
-  // compute new pressure and volume.
+  // compute new pressure and volume
 
   temperature->compute_vector();
   pressure->compute_vector();
@@ -958,10 +958,9 @@ double FixMSST::compute_scalar()
   energy -= p0 * ( v0 - volume ) / nktv2p;
 
   // subtract off precomputed TS_int integral value
+  // TS_int = 0 for non DFTB calculations
 
-  if (dftb) { // TS_int == 0 for non DFTB calculations
-    energy -= TS_int;
-  }
+  if (dftb) energy -= TS_int;
 
   return energy;
 }
@@ -987,7 +986,7 @@ double FixMSST::compute_vector(int n)
 
 /* ----------------------------------------------------------------------
    Computes the deviation of the current point
-   from the Hugoniot in Kelvin for the MSST.
+   from the Hugoniot in Kelvin for the MSST
 ------------------------------------------------------------------------- */
 
 double FixMSST::compute_hugoniot()
@@ -1012,7 +1011,7 @@ double FixMSST::compute_hugoniot()
 
 /* ----------------------------------------------------------------------
    Computes the deviation of the current point from the Rayleigh
-   in pressure units for the MSST.
+   in pressure units for the MSST
 ------------------------------------------------------------------------- */
 
 double FixMSST::compute_rayleigh()
@@ -1108,4 +1107,3 @@ double FixMSST::memory_usage()
   double bytes = 3*atom->nmax * sizeof(double);
   return bytes;
 }
-

--- a/src/SHOCK/fix_msst.h
+++ b/src/SHOCK/fix_msst.h
@@ -41,56 +41,56 @@ class FixMSST : public Fix {
   double memory_usage();
 
  private:
-  double dtv,dtf,dthalf;           // Full and half step sizes
+  double dtv,dtf,dthalf;           // full and half step sizes
   double boltz,nktv2p, mvv2e;      // Boltzmann factor and unit conversions
-  double total_mass;               // Mass of the computational cell
+  double total_mass;               // mass of the computational cell
 
-  double omega[3];                 // Time derivative of the volume
+  double omega[3];                 // time derivative of the volume
   double p_current[3],dilation[3];
-  double qmass;                    // Effective cell mass
-  double mu;                       // Effective cell viscosity
-  double tscale;                   // Converts thermal energy to compressive
+  double qmass;                    // effective cell mass
+  double mu;                       // effective cell viscosity
+  double tscale;                   // converts thermal energy to compressive
                                    // strain ke at simulation start
   int dftb;                        // flag for use with DFTB+
 
-  double velocity_sum;             // Sum of the velocities squared
-  double damping;                  // Damping function for TS force term at
+  double velocity_sum;             // sum of the velocities squared
+  double damping;                  // damping function for TS force term at
                                    //   small volume difference (v0 - vol)
-  double T0S0;                     // Initial TS term for DFTB+ simulations
+  double T0S0;                     // initial TS term for DFTB+ simulations
   double S_elec,S_elec_1,S_elec_2; // time history of electron entropy
                                    //   for DFTB+ simulaitons
   double TS_dot;                   // time derivative of TS term for
                                    //   DFTB+ simulations
 
-  double **old_velocity;           // Saved velocities
+  double **old_velocity;           // saved velocities
 
   int kspace_flag;                 // 1 if KSpace invoked, 0 if not
   int nrigid;                      // number of rigid fixes
   int *rfix;                       // indices of rigid fixes
 
-  char *id_temp,*id_press;         // Strings with identifiers of
+  char *id_temp,*id_press;         // strings with identifiers of
   char *id_pe;                     // created computes
 
-  class Compute *temperature;      // Computes created to evaluate
+  class Compute *temperature;      // computes created to evaluate
   class Compute *pressure;         // thermodynamic quantities
   class Compute *pe;
-  int tflag,pflag,vsflag,peflag;   // Flags to keep track of computes that
+  int tflag,pflag,vsflag,peflag;   // flags to keep track of computes that
                                    // were created
 
   // shock initial conditions
 
-  double e0;                       // Initial energy
-  double v0;                       // Initial volume
-  double p0;                       // Initial pressure
-  double velocity;                 // Velocity of the shock
+  double e0;                       // initial energy
+  double v0;                       // initial volume
+  double p0;                       // initial pressure
+  double velocity;                 // velocity of the shock
   double lagrangian_position;      // Lagrangian location of computational cell
-  int direction;                   // Direction of shock
-  int p0_set;                      // Is pressure set
-  int v0_set;                      // Is volume set
-  int e0_set;                      // Is energy set
-  double TS_int;                   // Needed for conserved quantity
+  int direction;                   // direction of shock
+  int p0_set;                      // is pressure set
+  int v0_set;                      // is volume set
+  int e0_set;                      // is energy set
+  double TS_int;                   // needed for conserved quantity
                                    //   with thermal electronic excitations
-  double beta;                     // Energy conservation scaling factor
+  double beta;                     // energy conservation scaling factor
 
   int maxold;                      // allocated size of old_velocity
   class FixExternal *fix_external; // ptr to fix external


### PR DESCRIPTION
## Purpose

somehow some package doc info for the new KIM Install,py got lost

## Author(s)

Steve Plimpton

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


