### PR TITLE
Collected small fixes

### DIFF
--- a/doc/src/fix_qeq.txt
+++ b/doc/src/fix_qeq.txt
@@ -90,9 +90,14 @@ file specified by {qfile}.  The file has the following format
 ...
 Ntype chi eta gamma zeta qcore :pre
 
-There is one line per atom type with the following parameters.
+There have to be parameters given for every atom type. Wildcard entries
+are possible using the same syntax as elsewhere in LAMMPS
+(i.e., n*m, n*, *m, *). Later entries will overwrite previous ones.
+Empty lines or any text following the pound sign (#) are ignored.
+Each line starts with the atom type followed by five parameters.
 Only a subset of the parameters is used by each QEq style as described
-below, thus the others can be set to 0.0 if desired.
+below, thus the others can be set to 0.0 if desired, but all five
+entries per line are required.
 
 {chi} = electronegativity in energy units
 {eta} = self-Coulomb potential in energy units

--- a/doc/src/fix_wall_ees.txt
+++ b/doc/src/fix_wall_ees.txt
@@ -50,17 +50,17 @@ fix ees_cube all wall/region/ees myCube 1.0 1.0 2.5 :pre
 Fix {wall/ees} bounds the simulation domain on one or more of its
 faces with a flat wall that interacts with the ellipsoidal atoms in the
 group by generating a force on the atom in a direction perpendicular to
-the wall and a torque parallel with the wall.  The energy of
+the wall and a torque parallel with the wall.  The energy of
 wall-particle interactions E is given by:
 
 :c,image(Eqs/fix_wall_ees.jpg)
 
 Introduced by Babadi and Ejtehadi in "(Babadi)"_#BabadiEjtehadi. Here,
 {r} is the distance from the particle to the wall at position {coord},
-and Rc is the {cutoff} distance at which the  particle and wall no
-longer interact. Also,  sigma_n is the distance between center of
-ellipsoid and the nearest point of its surface to the wall  The energy
-of the wall (see the image below).
+and Rc is the {cutoff} distance at which the particle and wall no
+longer interact. Also, sigma_n is the distance between center of
+ellipsoid and the nearest point of its surface to the wall. The energy
+of the wall is:
 
 :c,image(JPG/fix_wall_ees_image.jpg)
 
@@ -68,21 +68,22 @@ Details of using this command and specifications are the same as
 fix/wall command. You can also find an example in USER/ees/ under
 examples/ directory.
 
-The prefactor {epsilon} can be thought of as an
-effective Hamaker constant with energy units for the strength of the
-ellipsoid-wall interaction.  More specifically, the {epsilon} pre-factor
-= 8 * pi^2 * rho_wall * rho_ellipsoid * epsilon
-* sigma_a * sigma_b * sigma_c, where epsilon is the LJ parameters for
-the constituent LJ particles and sigma_a, sigma_b, and sigma_c are radii
-of ellipsoidal particles. Rho_wall and rho_ellipsoid are the number
+The prefactor {epsilon} can be thought of as an
+effective Hamaker constant with energy units for the strength of the
+ellipsoid-wall interaction.  More specifically, the {epsilon} pre-factor
+= 8 * pi^2 * rho_wall * rho_ellipsoid * epsilon
+* sigma_a * sigma_b * sigma_c, where epsilon is the LJ parameters for
+the constituent LJ particles and sigma_a, sigma_b, and sigma_c are radii
+of ellipsoidal particles. Rho_wall and rho_ellipsoid are the number
 density of the constituent particles, in the wall and ellipsoid
 respectively, in units of 1/volume.
 
 NOTE: You must insure that r is always bigger than sigma_n for
-all particles in the group, or LAMMPS will generate an error.  This
+all particles in the group, or LAMMPS will generate an error.  This
 means you cannot start your simulation with particles touching the wall
-position {coord} (r = sigma_n) or with particles penetrating the wall (0 =< r < sigma_n) or with particles on the wrong side of the
-wall (r < 0). 
+position {coord} (r = sigma_n) or with particles penetrating the wall
+(0 =< r < sigma_n) or with particles on the wrong side of the
+wall (r < 0).
 
 
 Fix {wall/region/ees} treats the surface of the geometric region defined
@@ -93,7 +94,7 @@ Other details of this command are the same as for the "fix
 wall/region"_fix_wall_region.html command.  One may also find an example
 of using this fix in the examples/USER/misc/ees/ directory.
 
-[Restrictions:] 
+[Restrictions:]
 
 This fix is part of the USER-MISC package.  It is only enabled if
 LAMMPS was built with that package.  See the "Making

--- a/doc/src/lammps.book
+++ b/doc/src/lammps.book
@@ -21,6 +21,7 @@ Section_python.html
 Section_errors.html
 Section_history.html
 
+tutorial_bash_on_windows.html
 tutorial_drude.html
 tutorial_github.html
 tutorial_pylammps.html

--- a/lib/gpu/Install.py
+++ b/lib/gpu/Install.py
@@ -9,8 +9,8 @@ import sys,os,subprocess
 # help message
 
 help = """
-Syntax from src dir: make lib-gpu args="-m machine -h hdir -a arch -p precision -e esuffix -m -o osuffix"
-Syntax from lib dir: python Install.py -m machine -h hdir -a arch -p precision -e esuffix -m -o osuffix
+Syntax from src dir: make lib-gpu args="-m machine -h hdir -a arch -p precision -e esuffix -b -o osuffix"
+Syntax from lib dir: python Install.py -m machine -h hdir -a arch -p precision -e esuffix -b -o osuffix
 
 specify one or more options, order does not matter
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -57,6 +57,7 @@
 /intel_buffers.cpp
 /intel_buffers.h
 /intel_intrinsics.h
+/intel_intrinsics_airebo.h
 /intel_preprocess.h
 /intel_simd.h
 

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -747,18 +747,26 @@ void FixQEq::read_file(char *file)
     nwords = atom->count_words(line);
     if (nwords == 0) continue;
 
-    // words = ptrs to all words in line
+    // must have 6 parameters per line.
 
-    nwords = 0;
-    words[nwords++] = strtok(line," \t\n\r\f");
-    while ((words[nwords++] = strtok(NULL," \t\n\r\f"))) continue;
+    if (nwords < 6)
+      error->all(FLERR,"Invalid fix qeq parameter file");
 
-    itype = atoi(words[0]);
-    chi[itype]   = atof(words[1]);
-    eta[itype]   = atof(words[2]);
-    gamma[itype] = atof(words[3]);
-    zeta[itype]  = atof(words[4]);
-    zcore[itype] = atof(words[5]);
+
+    // words = ptrs to first 6 words in line
+
+    for (n=0, words[n] = strtok(line," \t\n\r\f");
+         n < 6;
+         words[++n] = strtok(NULL," \t\n\r\f"));
+
+    itype = force->inumeric(FLERR,words[0]);
+    if ((itype < 1) || (itype > atom->ntypes))
+      error->all(FLERR,"Invalid fix qeq parameter file");
+    chi[itype]   = force->numeric(FLERR,words[1]);
+    eta[itype]   = force->numeric(FLERR,words[2]);
+    gamma[itype] = force->numeric(FLERR,words[3]);
+    zeta[itype]  = force->numeric(FLERR,words[4]);
+    zcore[itype] = force->numeric(FLERR,words[5]);
   }
   delete [] words;
 }

--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -70,6 +70,9 @@ const int THIS_IS_A_BIGINT   = -4;
 
 #define NCERR(x) ncerr(x, NULL, __LINE__)
 #define NCERRX(x, descr) ncerr(x, descr, __LINE__)
+#if !defined(NC_64BIT_DATA)
+#define NC_64BIT_DATA NC_64BIT_OFFSET
+#endif
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-NETCDF/dump_netcdf_mpiio.cpp
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.cpp
@@ -70,6 +70,9 @@ const int THIS_IS_A_BIGINT   = -4;
 
 #define NCERR(x) ncerr(x, NULL, __LINE__)
 #define NCERRX(x, descr) ncerr(x, descr, __LINE__)
+#if !defined(NC_64BIT_DATA)
+#define NC_64BIT_DATA NC_64BIT_OFFSET
+#endif
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1219,7 +1219,7 @@ void Molecule::shakeflag_read(char *line)
 
 void Molecule::shakeatom_read(char *line)
 {
-  int tmp, nmatch, nwant;
+  int tmp, nmatch=0, nwant=0;
   for (int i = 0; i < natoms; i++) {
     readline(line);
     if (shake_flag[i] == 1) {
@@ -1262,7 +1262,7 @@ void Molecule::shakeatom_read(char *line)
 
 void Molecule::shaketype_read(char *line)
 {
-  int tmp,nmatch,nwant;
+  int tmp, nmatch=0, nwant=0;
   for (int i = 0; i < natoms; i++) {
     readline(line);
     if (shake_flag[i] == 1) {


### PR DESCRIPTION
## Purpose

This pull request combines multiple small changes and bugfixes

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

The updated fix qeq now accepts valid files (according to the docs), that were previously rejected, and extends the format by ignoring extra words, not requiring a fixed number of lines, supporting wildcards for atom types, and correctly checking if all types have parameters set.

## Implementation Notes

Here is a list of individual changes:
- refactoring of the parameter file reader for all fix qeq styles in the QEQ package
- remove non-ASCII (blank) characters from a doc file
- avoid uninitialized local variable access in molecule command
- update some administrative files for recent additions
- compatibility macro for NetCDF as bundled with RHEL/CentOS 7.x
- correct typo in embedded help for GPU lib Install.py file

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
