### PR TITLE
cmake: print flag summary

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -555,7 +555,6 @@ message(STATUS "<<< Build configuration >>>
        Type         ${CMAKE_CXX_COMPILER_ID}
    C++ Flags        ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BTYPE}}")
 get_property(LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
-list(FIND LANGUAGES "Fortran" FORTRAN_ENABLED)
 if(LANGUAGES MATCHES ".*Fortran.*")
   message(STATUS "Fortran Compiler ${CMAKE_Fortran_COMPILER} 
            Type     ${CMAKE_Fortran_COMPILER_ID}
@@ -564,9 +563,9 @@ endif()
 message(STATUS "Linker flags:
    Executable      ${CMAKE_EXE_LINKER_FLAGS}")
 if(BUILD_SHARED_LIBS)
-  message(STATUS "Shared          ${CMAKE_SHARED_LINKER_FLAGS}")
+  message(STATUS "Shared libries  ${CMAKE_SHARED_LINKER_FLAGS}")
 else()
-  message(STATUS "Static          ${CMAKE_STATIC_LINKER_FLAGS}")
+  message(STATUS "Static libries  ${CMAKE_STATIC_LINKER_FLAGS}")
 endif()
 message(STATUS "Link libraries: ${LAMMPS_LINK_LIBS}")
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -545,3 +545,28 @@ foreach(PKG ${DEFAULT_PACKAGES} ${OTHER_PACKAGES} ${ACCEL_PACKAGES})
     message(STATUS "Building package: ${PKG}")
   endif()
 endforeach()
+
+string(TOUPPER "${CMAKE_BUILD_TYPE}" BTYPE)
+message(STATUS "<<< Build configuration >>>
+   Build type       ${CMAKE_BUILD_TYPE}
+   Install path     ${CMAKE_INSTALL_PREFIX}
+   Compilers and Flags:
+   C++ Compiler     ${CMAKE_CXX_COMPILER}
+       Type         ${CMAKE_CXX_COMPILER_ID}
+   C++ Flags        ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BTYPE}}")
+get_property(LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+list(FIND LANGUAGES "Fortran" FORTRAN_ENABLED)
+if(LANGUAGES MATCHES ".*Fortran.*")
+  message(STATUS "Fortran Compiler ${CMAKE_Fortran_COMPILER} 
+           Type     ${CMAKE_Fortran_COMPILER_ID}
+   Fortran Flags    ${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${BTYPE}}")
+endif()
+message(STATUS "Linker flags:
+   Executable      ${CMAKE_EXE_LINKER_FLAGS}")
+if(BUILD_SHARED_LIBS)
+  message(STATUS "Shared          ${CMAKE_SHARED_LINKER_FLAGS}")
+else()
+  message(STATUS "Static          ${CMAKE_STATIC_LINKER_FLAGS}")
+endif()
+message(STATUS "Link libraries: ${LAMMPS_LINK_LIBS}")
+


### PR DESCRIPTION
## Purpose

Print a summary of all flags used CMake and libraries linked in.
Part of #616 

## Author(s)

@junghans

## Backward Compatibility

N/A

## Implementation Notes

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included