### PR TITLE
Detect, warn about, and optionally enforce new 'pair_style' command after 'read_restart'

### DIFF
--- a/doc/src/Section_errors.txt
+++ b/doc/src/Section_errors.txt
@@ -7718,6 +7718,12 @@ The region keyword must be specified with this fix. :dd
 
 Self-explanatory. :dd
 
+{Must specify 'pair_style' command after 'read_restart' for pair style ...} :dt
+
+The pair style does not support reading from restart files and thus
+the 'pair_style' and 'pair_coeff' commands have to be issues again
+with the same settings as in the previous input. :dd
+
 {Must specify at least 2 types in fix atom/swap command} :dt
 
 Self-explanatory. :dd
@@ -11731,6 +11737,13 @@ The restart file value will override the setting in the input script. :dd
 {Restart file used different newton pair setting, using input script value} :dt
 
 The input script value will override the setting in the restart file. :dd
+
+{Restarting a pair style without restart support. May need to specify 'pair_style' command again} :dt
+
+This warning indicates that you have read a restart file with a pair
+style that has no support for reading from and writing to restart
+files. In most cases this requires issuing the same 'pair_style' and
+'pair_coeff' commands with the same settings as in the previous input. :dd
 
 {Restrain problem: %d %ld %d %d %d %d} :dt
 

--- a/src/BODY/pair_body.cpp
+++ b/src/BODY/pair_body.cpp
@@ -365,11 +365,6 @@ void PairBody::settings(int narg, char **arg)
 {
   if (narg != 1) error->all(FLERR,"Illegal pair_style command");
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   cut_global = force->numeric(FLERR,arg[0]);
 
   // reset cutoffs that have been explicitly set

--- a/src/BODY/pair_body.cpp
+++ b/src/BODY/pair_body.cpp
@@ -365,6 +365,11 @@ void PairBody::settings(int narg, char **arg)
 {
   if (narg != 1) error->all(FLERR,"Illegal pair_style command");
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   cut_global = force->numeric(FLERR,arg[0]);
 
   // reset cutoffs that have been explicitly set
@@ -422,6 +427,10 @@ void PairBody::init_style()
   if (strcmp(avec->bptr->style,"nparticle") != 0)
     error->all(FLERR,"Pair body requires body style nparticle");
   bptr = (BodyNparticle *) avec->bptr;
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style body");
 
   neighbor->request(this,instance_me);
 }

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -268,11 +268,6 @@ void PairKIM::settings(int narg, char **arg)
    ++settings_call_count;
    init_style_call_count = 0;
 
-   // Pair::settings() is only called after a pair_style command.
-   // this means that after a restart we are now fully initialized.
-
-   did_dummy_restart = 0;
-
    if (narg < 2) error->all(FLERR,"Illegal pair_style command");
    // arg[0] is the virial handling option: "LAMMPSvirial" or "KIMvirial"
    // arg[1] is the KIM Model name

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -268,6 +268,11 @@ void PairKIM::settings(int narg, char **arg)
    ++settings_call_count;
    init_style_call_count = 0;
 
+   // Pair::settings() is only called after a pair_style command.
+   // this means that after a restart we are now fully initialized.
+
+   did_dummy_restart = 0;
+
    if (narg < 2) error->all(FLERR,"Illegal pair_style command");
    // arg[0] is the virial handling option: "LAMMPSvirial" or "KIMvirial"
    // arg[1] is the KIM Model name
@@ -404,6 +409,10 @@ void PairKIM::init_style()
 {
    // This is called for each "run ...", "minimize ...", etc. read from input
    ++init_style_call_count;
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style KIM");
 
    if (domain->dimension != 3)
       error->all(FLERR,"PairKIM only works with 3D problems");

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -427,6 +427,11 @@ void PairADP::allocate()
 void PairADP::settings(int narg, char **arg)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -509,6 +514,10 @@ void PairADP::coeff(int narg, char **arg)
 
 void PairADP::init_style()
 {
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style ADP");
+
   // convert read-in file(s) to arrays and spline them
 
   file2array();

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -427,11 +427,6 @@ void PairADP::allocate()
 void PairADP::settings(int narg, char **arg)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -155,6 +155,11 @@ void PairAIREBO::settings(int narg, char **arg)
   if (narg != 1 && narg != 3 && narg != 4)
     error->all(FLERR,"Illegal pair_style command");
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   cutlj = force->numeric(FLERR,arg[0]);
 
   if (narg >= 3) {
@@ -238,6 +243,9 @@ void PairAIREBO::init_style()
     error->all(FLERR,"Pair style AIREBO requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style AIREBO requires newton pair on");
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style AIREBO");
 
   // need a full neighbor list, including neighbors of ghosts
 
@@ -2084,7 +2092,7 @@ double PairAIREBO::bondorder(int i, int j, double rij[3],
 
 /* ----------------------------------------------------------------------
    Bij* function
-------------------------------------------------------------------------- 
+-------------------------------------------------------------------------
 
 This function calculates S(t_b(b_ij*)) as specified in the AIREBO paper.
 To do so, it needs to compute b_ij*, i.e. the bondorder given that the
@@ -2290,7 +2298,7 @@ double PairAIREBO::bondorderLJ(int i, int j, double rij_mod[3], double rijmag_mo
         cos321 = MAX(cos321,-1.0);
         sin321 = sqrt(1.0 - cos321*cos321);
         if ((sin321 > TOL) && (r21mag > TOL)) { // XXX was sin321 != 0.0
-          w21 = Sp(r21mag,rcmin[itype][ktype],rcmaxp[itype][ktype],dw21); 
+          w21 = Sp(r21mag,rcmin[itype][ktype],rcmaxp[itype][ktype],dw21);
           tspjik = Sp2(cos321,thmin,thmax,dtsjik);
 
           REBO_neighs_j = REBO_firstneigh[j];
@@ -2470,7 +2478,7 @@ double PairAIREBO::bondorderLJ(int i, int j, double rij_mod[3], double rijmag_mo
           (rijmag*rjlmag);
         cosijl = MIN(cosijl,1.0);
         cosijl = MAX(cosijl,-1.0);
-        
+
         dcosijldri[0] = (-rjl[0]/(rijmag*rjlmag)) -
           (cosijl*rij[0]/(rijmag*rijmag));
         dcosijldri[1] = (-rjl[1]/(rijmag*rjlmag)) -
@@ -2500,7 +2508,7 @@ double PairAIREBO::bondorderLJ(int i, int j, double rij_mod[3], double rijmag_mo
         fl[0] = -tmp2*dcosijldrl[0];
         fl[1] = -tmp2*dcosijldrl[1];
         fl[2] = -tmp2*dcosijldrl[2];
-  
+
         tmp2 = VA*.5*(tmp*wjl*g*exp(lamdaijl)*4.0*kronecker(jtype,1));
         fj[0] += tmp2*(rjl[0]/rjlmag);
         fj[1] += tmp2*(rjl[1]/rjlmag);

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -155,11 +155,6 @@ void PairAIREBO::settings(int narg, char **arg)
   if (narg != 1 && narg != 3 && narg != 4)
     error->all(FLERR,"Illegal pair_style command");
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   cutlj = force->numeric(FLERR,arg[0]);
 
   if (narg >= 3) {

--- a/src/MANYBODY/pair_bop.cpp
+++ b/src/MANYBODY/pair_bop.cpp
@@ -549,6 +549,11 @@ void PairBOP::settings(int narg, char **arg)
 {
   otfly = 1;
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   int iarg = 0;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"save") == 0) {
@@ -641,6 +646,10 @@ void PairBOP::init_style()
     error->all(FLERR,"Pair style BOP requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style BOP requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style BOP");
 
   // check that user sets comm->cutghostuser to 3x the max BOP cutoff
 

--- a/src/MANYBODY/pair_bop.cpp
+++ b/src/MANYBODY/pair_bop.cpp
@@ -549,11 +549,6 @@ void PairBOP::settings(int narg, char **arg)
 {
   otfly = 1;
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   int iarg = 0;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"save") == 0) {

--- a/src/MANYBODY/pair_gw.cpp
+++ b/src/MANYBODY/pair_gw.cpp
@@ -260,6 +260,11 @@ void PairGW::allocate()
 void PairGW::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -344,6 +349,10 @@ void PairGW::init_style()
     error->all(FLERR,"Pair style GW requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style GW requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style GW");
 
   // need a full neighbor list
 

--- a/src/MANYBODY/pair_gw.cpp
+++ b/src/MANYBODY/pair_gw.cpp
@@ -260,11 +260,6 @@ void PairGW::allocate()
 void PairGW::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_lcbop.cpp
+++ b/src/MANYBODY/pair_lcbop.cpp
@@ -121,11 +121,6 @@ void PairLCBOP::allocate()
 
 void PairLCBOP::settings(int narg, char **arg) {
   if( narg != 0 ) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_lcbop.cpp
+++ b/src/MANYBODY/pair_lcbop.cpp
@@ -121,6 +121,11 @@ void PairLCBOP::allocate()
 
 void PairLCBOP::settings(int narg, char **arg) {
   if( narg != 0 ) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -185,6 +190,10 @@ void PairLCBOP::init_style()
     error->all(FLERR,"Pair style LCBOP requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style LCBOP requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style LCBOP");
 
   // need a full neighbor list, including neighbors of ghosts
 

--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -242,11 +242,6 @@ void PairSW::allocate()
 void PairSW::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -242,6 +242,11 @@ void PairSW::allocate()
 void PairSW::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -326,6 +331,10 @@ void PairSW::init_style()
     error->all(FLERR,"Pair style Stillinger-Weber requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style Stillinger-Weber requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style Stillinger-Weber");
 
   // need a full neighbor list
 

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -283,6 +283,11 @@ void PairTersoff::allocate()
 void PairTersoff::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -367,6 +372,10 @@ void PairTersoff::init_style()
     error->all(FLERR,"Pair style Tersoff requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style Tersoff requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style Tersoff");
 
   // need a full neighbor list
 

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -283,11 +283,6 @@ void PairTersoff::allocate()
 void PairTersoff::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -248,11 +248,6 @@ void PairVashishta::allocate()
 void PairVashishta::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -248,6 +248,11 @@ void PairVashishta::allocate()
 void PairVashishta::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -332,6 +337,10 @@ void PairVashishta::init_style()
     error->all(FLERR,"Pair style Vashishta requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style Vashishta requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style Vashishta");
 
   // need a full neighbor list
 

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -328,11 +328,6 @@ void PairMEAM::allocate()
 void PairMEAM::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -328,6 +328,11 @@ void PairMEAM::allocate()
 void PairMEAM::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -416,6 +421,10 @@ void PairMEAM::init_style()
 {
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style MEAM requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style MEAM");
 
   // need full and half neighbor list
 

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -233,6 +233,11 @@ void PairPython::settings(int narg, char **arg)
   if (narg != 1)
     error->all(FLERR,"Illegal pair_style command");
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   cut_global = force->numeric(FLERR,arg[0]);
 }
 
@@ -388,6 +393,17 @@ void PairPython::coeff(int narg, char **arg)
   }
   Py_DECREF(py_map_args);
   PyGILState_Release(gstate);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairPython::init_style()
+{
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style python");
+
+  neighbor->request(this,instance_me);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -25,6 +25,7 @@
 #include "force.h"
 #include "memory.h"
 #include "update.h"
+#include "neighbor.h"
 #include "neigh_list.h"
 #include "python.h"
 #include "error.h"

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -233,11 +233,6 @@ void PairPython::settings(int narg, char **arg)
   if (narg != 1)
     error->all(FLERR,"Illegal pair_style command");
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   cut_global = force->numeric(FLERR,arg[0]);
 }
 

--- a/src/PYTHON/pair_python.h
+++ b/src/PYTHON/pair_python.h
@@ -39,10 +39,11 @@ class PairPython : public Pair {
   PairPython(class LAMMPS *);
   virtual ~PairPython();
   virtual void compute(int, int);
-  void settings(int, char **);
-  void coeff(int, char **);
-  double init_one(int, int);
-  double single(int, int, int, int, double, double, double, double &);
+  virtual void settings(int, char **);
+  virtual void coeff(int, char **);
+  virtual void init_style();
+  virtual double init_one(int, int);
+  virtual double single(int, int, int, int, double, double, double, double &);
 
  protected:
   double cut_global;

--- a/src/REAX/pair_reax.cpp
+++ b/src/REAX/pair_reax.cpp
@@ -490,6 +490,11 @@ void PairREAX::settings(int narg, char **arg)
 {
   if (narg != 0 && narg !=4) error->all(FLERR,"Illegal pair_style command");
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   if (narg == 4) {
     hbcut = force->numeric(FLERR,arg[0]);
     ihbnew = static_cast<int> (force->numeric(FLERR,arg[1]));
@@ -565,6 +570,10 @@ void PairREAX::init_style()
     error->all(FLERR,"Pair style reax requires atom attribute q");
   if (strcmp(update->unit_style,"real") != 0 && comm->me == 0)
     error->warning(FLERR,"Not using real units with pair reax");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style reax");
 
   int irequest = neighbor->request(this,instance_me);
   neighbor->requests[irequest]->newton = 2;

--- a/src/REAX/pair_reax.cpp
+++ b/src/REAX/pair_reax.cpp
@@ -490,11 +490,6 @@ void PairREAX::settings(int narg, char **arg)
 {
   if (narg != 0 && narg !=4) error->all(FLERR,"Illegal pair_style command");
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   if (narg == 4) {
     hbcut = force->numeric(FLERR,arg[0]);
     ihbnew = static_cast<int> (force->numeric(FLERR,arg[1]));

--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -1317,11 +1317,6 @@ void PairSNAP::settings(int narg, char **arg)
   do_load_balance = 0;
   use_optimized = 1;
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   // optional arguments
 
   for (int i=0; i < narg; i++) {

--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -1317,6 +1317,11 @@ void PairSNAP::settings(int narg, char **arg)
   do_load_balance = 0;
   use_optimized = 1;
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   // optional arguments
 
   for (int i=0; i < narg; i++) {
@@ -1542,6 +1547,10 @@ void PairSNAP::init_style()
 {
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style SNAP requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style SNAP");
 
   // need a full neighbor list
 

--- a/src/USER-MEAMC/pair_meamc.cpp
+++ b/src/USER-MEAMC/pair_meamc.cpp
@@ -198,11 +198,6 @@ void PairMEAMC::allocate()
 void PairMEAMC::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-MEAMC/pair_meamc.cpp
+++ b/src/USER-MEAMC/pair_meamc.cpp
@@ -198,6 +198,11 @@ void PairMEAMC::allocate()
 void PairMEAMC::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -285,7 +290,11 @@ void PairMEAMC::coeff(int narg, char **arg)
 void PairMEAMC::init_style()
 {
   if (force->newton_pair == 0)
-    error->all(FLERR,"Pair style MEAM requires newton pair on");
+    error->all(FLERR,"Pair style MEAM/C requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style MEAM/C");
 
   // need full and half neighbor list
 

--- a/src/USER-MISC/pair_agni.cpp
+++ b/src/USER-MISC/pair_agni.cpp
@@ -249,6 +249,11 @@ void PairAGNI::allocate()
 void PairAGNI::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -329,6 +334,10 @@ void PairAGNI::coeff(int narg, char **arg)
 
 void PairAGNI::init_style()
 {
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style AGNI");
+
   // need a full neighbor list
 
   int irequest = neighbor->request(this,instance_me);

--- a/src/USER-MISC/pair_agni.cpp
+++ b/src/USER-MISC/pair_agni.cpp
@@ -249,11 +249,6 @@ void PairAGNI::allocate()
 void PairAGNI::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-MISC/pair_edip.cpp
+++ b/src/USER-MISC/pair_edip.cpp
@@ -624,11 +624,6 @@ void PairEDIP::allocate()
 void PairEDIP::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-MISC/pair_edip.cpp
+++ b/src/USER-MISC/pair_edip.cpp
@@ -624,6 +624,11 @@ void PairEDIP::allocate()
 void PairEDIP::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -840,6 +845,10 @@ void PairEDIP::init_style()
 {
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style edip requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style edip");
 
   // need a full neighbor list
 

--- a/src/USER-MISC/pair_list.cpp
+++ b/src/USER-MISC/pair_list.cpp
@@ -207,6 +207,11 @@ void PairList::settings(int narg, char **arg)
   if (narg < 2)
     error->all(FLERR,"Illegal pair_style command");
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   cut_global = force->numeric(FLERR,arg[1]);
   if (narg > 2) {
     if (strcmp(arg[2],"nocheck") == 0) check_flag = 0;
@@ -374,6 +379,10 @@ void PairList::init_style()
 
   if (atom->map_style == 0)
     error->all(FLERR,"Pair style list requires an atom map");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style list");
 
   if (offset_flag) {
     for (int n=0; n < npairs; ++n) {

--- a/src/USER-MISC/pair_list.cpp
+++ b/src/USER-MISC/pair_list.cpp
@@ -207,11 +207,6 @@ void PairList::settings(int narg, char **arg)
   if (narg < 2)
     error->all(FLERR,"Illegal pair_style command");
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   cut_global = force->numeric(FLERR,arg[1]);
   if (narg > 2) {
     if (strcmp(arg[2],"nocheck") == 0) check_flag = 0;

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -214,12 +214,6 @@ void PairQUIP::compute(int eflag, int vflag)
 void PairQUIP::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   if (strcmp(force->pair_style,"hybrid") == 0)
     error->all(FLERR,"Pair style quip is only compatible with hybrid/overlay");
 

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -214,6 +214,12 @@ void PairQUIP::compute(int eflag, int vflag)
 void PairQUIP::settings(int narg, char **arg)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   if (strcmp(force->pair_style,"hybrid") == 0)
     error->all(FLERR,"Pair style quip is only compatible with hybrid/overlay");
 
@@ -302,6 +308,10 @@ void PairQUIP::init_style()
 
   if (force->newton_pair != 1)
     error->all(FLERR,"Pair style quip requires newton pair on");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style quip");
 
   // Initialise neighbour list
   int irequest_full = neighbor->request(this);

--- a/src/USER-REAXC/pair_reaxc.cpp
+++ b/src/USER-REAXC/pair_reaxc.cpp
@@ -198,6 +198,11 @@ void PairReaxC::settings(int narg, char **arg)
 {
   if (narg < 1) error->all(FLERR,"Illegal pair_style command");
 
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
+
   // read name of control file or use default controls
 
   if (strcmp(arg[0],"NULL") == 0) {
@@ -356,6 +361,10 @@ void PairReaxC::init_style( )
 {
   if (!atom->q_flag)
     error->all(FLERR,"Pair style reax/c requires atom attribute q");
+
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style reax/c");
 
   // firstwarn = 1;
 

--- a/src/USER-REAXC/pair_reaxc.cpp
+++ b/src/USER-REAXC/pair_reaxc.cpp
@@ -198,11 +198,6 @@ void PairReaxC::settings(int narg, char **arg)
 {
   if (narg < 1) error->all(FLERR,"Illegal pair_style command");
 
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
-
   // read name of control file or use default controls
 
   if (strcmp(arg[0],"NULL") == 0) {

--- a/src/USER-SMTBQ/pair_smtbq.cpp
+++ b/src/USER-SMTBQ/pair_smtbq.cpp
@@ -245,6 +245,11 @@ void PairSMTBQ::allocate()
 void PairSMTBQ::settings(int narg, char **arg)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
+
+  // Pair::settings() is only called after a pair_style command.
+  // this means that after a restart we are now fully initialized.
+
+  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -354,6 +359,9 @@ void PairSMTBQ::init_style()
   if (!atom->q_flag)
     error->all(FLERR,"Pair style SMTBQ requires atom attribute q");
 
+  if (did_dummy_restart)
+    error->all(FLERR,"Must specify 'pair_style' command after "
+               "'read_restart' for pair style SMTBQ");
 
   // need a full neighbor list
 

--- a/src/USER-SMTBQ/pair_smtbq.cpp
+++ b/src/USER-SMTBQ/pair_smtbq.cpp
@@ -245,11 +245,6 @@ void PairSMTBQ::allocate()
 void PairSMTBQ::settings(int narg, char **arg)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
-
-  // Pair::settings() is only called after a pair_style command.
-  // this means that after a restart we are now fully initialized.
-
-  did_dummy_restart = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1798,6 +1798,9 @@ void Input::pair_style()
     }
     if (match) {
       force->pair->settings(narg-1,&arg[1]);
+      // reset flag that triggers a warning when restarting a pair style
+      // without restart functions and not re-issuing the pair_style command
+      force->pair->did_dummy_restart = 0;
       return;
     }
   }

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -66,6 +66,7 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   no_virial_fdotr_compute = 0;
   writedata = 0;
   ghostneigh = 0;
+  did_dummy_restart = 0;
 
   nextra = 0;
   pvector = NULL;
@@ -231,6 +232,15 @@ void Pair::init()
 
   init_style();
 
+  // print a warning (but only once), if we have read a restart for a pair
+  // style without read_restart() and have not created a new instance.
+
+  if (did_dummy_restart && (comm->me == 0)) {
+    did_dummy_restart = 0;
+    error->warning(FLERR,"Restarting a pair style without restart support. "
+                   "May need to specify 'pair_style' command again.");
+  }
+
   // call init_one() for each I,J
   // set cutsq for each I,J, used to neighbor
   // cutforce = max of all I,J cutoffs
@@ -304,6 +314,17 @@ void Pair::init_style()
 void Pair::init_list(int which, NeighList *ptr)
 {
   list = ptr;
+}
+
+/* ----------------------------------------------------------------------
+   trigger a warning message in Pair::init() when reading a restart
+   file for a pair style without restart support and without a new
+   pair_style command after the restart has been read.
+------------------------------------------------------------------------- */
+
+void Pair::read_restart(FILE *)
+{
+  did_dummy_restart = 1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/pair.h
+++ b/src/pair.h
@@ -55,6 +55,7 @@ class Pair : protected Pointers {
   int writedata;                 // 1 if writes coeffs to data file
   int ghostneigh;                // 1 if pair style needs neighbors of ghosts
   double **cutghost;             // cutoff for each ghost pair
+  int did_dummy_restart;         // 1 if restarted using dummy restart method
 
   int ewaldflag;                 // 1 if compatible with Ewald solver
   int pppmflag;                  // 1 if compatible with PPPM solver
@@ -161,7 +162,7 @@ class Pair : protected Pointers {
   virtual void free_disp_tables();
 
   virtual void write_restart(FILE *) {}
-  virtual void read_restart(FILE *) {}
+  virtual void read_restart(FILE *);
   virtual void write_restart_settings(FILE *) {}
   virtual void read_restart_settings(FILE *) {}
   virtual void write_data(FILE *) {}
@@ -294,6 +295,13 @@ W: Using a manybody potential with bonds/angles/dihedrals and special_bond exclu
 This is likely not what you want to do.  The exclusion settings will
 eliminate neighbors in the neighbor list, which the manybody potential
 needs to calculated its terms correctly.
+
+W: Restarting a pair style without restart support. May need to specify 'pair_style' command again.
+
+This warning indicates that you have read a restart file with a pair
+style that has no support for reading from and writing to restart
+files. In most cases this requires issuing the same 'pair_style' and
+'pair_coeff' commands with the same settings as in the previous input.
 
 E: All pair coeffs are not set
 


### PR DESCRIPTION
## Purpose

Several pair styles in LAMMPS do not support reading their state from binary restart files. In these cases it it required to re-issue the `pair_style` and `pair_coeff` commands **after** the `read_restart` command.
This PR provides an infrastructure to detect this and issue a generic warning  (in `Pair::init()`), but individual pair styles can also implement an error exit (in `Pair*::init_style()`) in case the `did_dummy_restart` variable has not been reset before (in `Pair*::settings()`, which is only called when a `pair_style` command is issued. This hard exit has been implemented for a number of pair styles, that explicitly state in their respective documentation, that the `pair_style` must be re-issued after a restart.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

This change is fully backward compatible for correct inputs. For incorrect inputs the result is either a generic (one time) warning or an error message and stop. The latter happens only for pair styles that are documented and confirmed to require re-issuing the `pair_style` command and have been adapted as needed.

## Implementation Notes

The detection of whether restarts are supported or not is done via the member variable `Pair::did_dummy_restart`, which is set to 1 in the virtual function `Pair::read_restart()`. If a pair style does support restarts, it will override this function and `did_dummy_restart` will remain at its default value of 0. If it value is 1 inside of `Pair::init()` a general warning is printed. However, individual pair styles can test for it in `Pair*::init_style()` and do a hard exit. `did_dummy_restart` is reset to 0 for all pair styles in either the `Pair` constructor or in `Input::pair_style()`.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

N/A

