### PR TITLE
Use OpenCL 2.x API in GPU package when supported

### DIFF
--- a/lib/gpu/geryon/ocl_device.h
+++ b/lib/gpu/geryon/ocl_device.h
@@ -140,8 +140,13 @@ class UCL_Device {
   inline void push_command_queue() {
     cl_int errorv;
     _cq.push_back(cl_command_queue());
-    _cq.back()=clCreateCommandQueue(_context,_cl_device,
-                                    CL_QUEUE_PROFILING_ENABLE,&errorv);
+
+#ifdef CL_VERSION_2_0
+    cl_queue_properties props[] = {CL_QUEUE_PROPERTIES, CL_QUEUE_PROFILING_ENABLE, 0};
+    _cq.back()=clCreateCommandQueueWithProperties(_context, _cl_device, props, &errorv);
+#else
+    _cq.back()=clCreateCommandQueue(_context, _cl_device, CL_QUEUE_PROFILING_ENABLE, &errorv);
+#endif
     if (errorv!=CL_SUCCESS) {
       std::cerr << "Could not create command queue on device: " << name()
                 << std::endl;


### PR DESCRIPTION
## Purpose
Compiling the GPU library with OpenCL creates a lot of warnings because the `clCreateCommandQueue` function is deprecated in OpenCL 2.x. Instead `clCreateCommandQueueWithProperties` should be used. This PR checks if the OpenCL header supports OpenCL 2.x and changes the API call.

## Author(s)
Richard Berger (Temple U)

## Backward Compatibility
Continues to use OpenCL 1.x API if headers do not have 2.x support

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines