### PR TITLE
Enhance Kokkos communication logic

### DIFF
--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -379,8 +379,8 @@ void CommKokkos::exchange()
     if(!exchange_comm_classic) {
       static int print = 1;
       if(print && comm->me==0) {
-        error->warning(FLERR,"Fixes cannot send data in Kokkos communication, "
-		       "switching to classic communication");
+        error->warning(FLERR,"Fixes cannot yet send data in Kokkos communication, "
+                      "switching to classic communication");
       }
       print = 0;
       exchange_comm_classic = true;
@@ -620,6 +620,19 @@ void CommKokkos::exchange_device()
 
 void CommKokkos::borders()
 {
+  if (!exchange_comm_classic) {
+    static int print = 1;
+
+    if (style != SINGLE || bordergroup || ghost_velocity) {
+      if (print && comm->me==0) {
+        error->warning(FLERR,"Required border comm not yet implemented in Kokkos communication, "
+                      "switching to classic communication");
+      }
+      print = 0;
+      exchange_comm_classic = true;
+    }
+  }
+  
   if (!exchange_comm_classic) {
     if (exchange_comm_on_host) borders_device<LMPHostType>();
     else borders_device<LMPDeviceType>();

--- a/src/KOKKOS/comm_kokkos.h
+++ b/src/KOKKOS/comm_kokkos.h
@@ -82,9 +82,14 @@ E: Ghost velocity forward comm not yet implemented with Kokkos
 
 This is a current restriction.
 
-W: Fixes cannot send data in Kokkos communication, switching to classic communication
+W: Fixes cannot yet send data in Kokkos communication, switching to classic communication
 
-This is current restriction with Kokkos.
+This is a current restriction with Kokkos.
+
+W: Required border comm not yet implemented in Kokkos communication, switching to classic communication
+
+There are various limitations in the communication options supported
+by Kokkos.
 
 E: Required border comm not yet implemented with Kokkos
 


### PR DESCRIPTION
Make Kokkos comm give warning and switch to classic comm instead of erroring out if required border comm isn't implemented.