### PR TITLE
Fixed proper deletion of fixes if fix is NULL

### DIFF
--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -110,7 +110,7 @@ Modify::~Modify()
   // delete all fixes
   // do it via delete_fix() so callbacks in Atom are also updated correctly
 
-  while (nfix) delete_fix(fix[0]->id);
+  while (nfix) delete_fix(0);
   memory->sfree(fix);
   memory->destroy(fmask);
 
@@ -944,7 +944,13 @@ void Modify::delete_fix(const char *id)
 {
   int ifix = find_fix(id);
   if (ifix < 0) error->all(FLERR,"Could not find fix ID to delete");
-  delete fix[ifix];
+  delete_fix(ifix);
+}
+
+void Modify::delete_fix(int ifix)
+{
+  if(fix[ifix])
+    delete fix[ifix];
   atom->update_callback(ifix);
 
   // move other Fixes and fmask down in list one slot

--- a/src/modify.h
+++ b/src/modify.h
@@ -95,6 +95,7 @@ class Modify : protected Pointers {
   void add_fix(int, char **, int trysuffix=1);
   void modify_fix(int, char **);
   void delete_fix(const char *);
+  void delete_fix(int);
   int find_fix(const char *);
   int find_fix_by_style(const char *);
   int check_package(const char *);


### PR DESCRIPTION
## Purpose

Prevent null pointer access on a deleted fix in destructor of Modify.

If two fix commands with same type and same ID is called, but second command is invalid, deallocation of Modify tries to access fix[0]->id where fix[0] has been NULL'ed before.
Example of such commans:
```
fix nvt all nvt temp 1.0 1.0 1.0
fix nvt all nvt temp 1.0 1.0 1.0 1.0
```

## Author(s)

Anders Hafreager

## Implementation Notes

If the above commands are used, the first fix is [deleted](https://github.com/lammps/lammps/blob/master/src/modify.cpp#L804) and [NULL'ed](https://github.com/lammps/lammps/blob/master/src/modify.cpp#L805). When the new fix then [is created](https://github.com/lammps/lammps/blob/master/src/modify.cpp#L847), it will throw an exception while `fix[ifix]` still is NULL.

If the Modify object is deleted later, the destructor tries to [delete fix](https://github.com/lammps/lammps/blob/master/src/modify.cpp#L113) with identifier `fix[0]->id` where `fix[0]` is NULL. 

This is solved by for instance adding a `delete_fix` function also accepting an `int ifix` so we don't need to access the identifier.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

This appeared as a problem in Atomify where I had a similar issue as the example above.


