### PR TITLE
add coul/wolf/cs and born/coul/wolf/cs pair styles for CORESHELL package

### DIFF
--- a/doc/src/pair_cs.txt
+++ b/doc/src/pair_cs.txt
@@ -9,12 +9,13 @@
 pair_style born/coul/long/cs command :h3
 pair_style buck/coul/long/cs command :h3
 pair_style born/coul/dsf/cs command :h3
+pair_style born/coul/wolf/cs command :h3
 
 [Syntax:]
 
 pair_style style args :pre
 
-style = {born/coul/long/cs} or {buck/coul/long/cs} or {born/coul/dsf/cs}
+style = {born/coul/long/cs} or {buck/coul/long/cs} or {born/coul/dsf/cs} or {born/coul/wolf/cs}
 args = list of arguments for a particular style :ul
   {born/coul/long/cs} args = cutoff (cutoff2)
     cutoff = global cutoff for non-Coulombic (and Coulombic if only 1 arg) (distance units)
@@ -26,6 +27,10 @@ args = list of arguments for a particular style :ul
     alpha = damping parameter (inverse distance units)
     cutoff = global cutoff for non-Coulombic (and Coulombic if only 1 arg) (distance units)
     cutoff2 = global cutoff for Coulombic (distance units) :pre
+  {born/coul/wolf/cs} args = alpha cutoff (cutoff2)
+    alpha = damping parameter (inverse distance units)
+    cutoff = global cutoff for Buckingham (and Coulombic if only 1 arg) (distance units)
+    cutoff2 = global cutoff for Coulombic (optional) (distance units)
 
 [Examples:]
 
@@ -38,6 +43,10 @@ pair_coeff * * 100.0 1.5 200.0
 pair_coeff 1 1 100.0 1.5 200.0 9.0 :pre
 
 pair_style born/coul/dsf/cs 0.1 10.0 12.0
+pair_coeff * *   0.0 1.00 0.00 0.00 0.00
+pair_coeff 1 1 480.0 0.25 0.00 1.05 0.50 :pre
+
+pair_style born/coul/wolf/cs 0.25 10.0 12.0
 pair_coeff * *   0.0 1.00 0.00 0.00 0.00
 pair_coeff 1 1 480.0 0.25 0.00 1.05 0.50 :pre
 
@@ -73,9 +82,17 @@ the core and shell, epsilon is the dielectric constant and r_min is the
 minimal distance.
 
 The pair style {born/coul/dsf/cs} is identical to the
-"pair_style born/coul/dsf"_pair_born.html style, which uses the
+"pair_style born/coul/dsf"_pair_born.html style, which uses
 the damped shifted force model as in "coul/dsf"_pair_coul.html
 to compute the Coulomb contribution. This approach does not require
+a long-range solver, thus the only correction is the addition of a
+minimal distance to avoid the possible r = 0.0 case for a
+core/shell pair.
+
+The pair style {born/coul/wolf/cs} is identical to the
+"pair_style born/coul/wolf"_pair_born.html style, which uses
+the Wolf summation as in "coul/wolf"_pair_coul.html to compute
+the Coulomb contribution. This approach does not require
 a long-range solver, thus the only correction is the addition of a
 minimal distance to avoid the possible r = 0.0 case for a
 core/shell pair.

--- a/examples/coreshell/in.coreshell.wolf
+++ b/examples/coreshell/in.coreshell.wolf
@@ -1,0 +1,71 @@
+# Testsystem for core-shell model compared to Mitchel and Finchham
+# Shamelessly copied from in.coreshell.dsf but this script uses Wolf summation.
+
+# ------------------------ INITIALIZATION ----------------------------
+
+units 		metal
+dimension	3
+boundary	p	p	p
+atom_style	full
+
+# ----------------------- ATOM DEFINITION ----------------------------
+
+fix csinfo all property/atom i_CSID
+read_data data.coreshell fix csinfo NULL CS-Info
+
+group cores type 1 2
+group shells type 3 4
+
+neighbor 2.0 bin
+comm_modify vel yes
+
+# ------------------------ FORCE FIELDS ------------------------------
+
+pair_style   born/coul/wolf/cs 0.1 20.0 20.0    # A, rho, sigma=0, C, D 
+pair_coeff   * *      0.0 1.000   0.00  0.00   0.00
+pair_coeff   3 3    487.0 0.23768 0.00  1.05   0.50 #Na-Na
+pair_coeff   3 4 145134.0 0.23768 0.00  6.99   8.70 #Na-Cl
+pair_coeff   4 4 405774.0 0.23768 0.00 72.40 145.40 #Cl-Cl
+
+bond_style harmonic
+bond_coeff 1 63.014 0.0
+bond_coeff 2 25.724 0.0
+
+# ------------------------ Equilibration Run -------------------------------
+
+reset_timestep 0
+
+thermo 50
+thermo_style custom step etotal pe ke temp press &
+             epair evdwl ecoul elong ebond fnorm fmax vol
+
+compute CSequ all temp/cs cores shells 
+
+# output via chunk method
+
+#compute prop all property/atom i_CSID
+#compute cs_chunk all chunk/atom c_prop
+#compute cstherm all temp/chunk cs_chunk temp internal com yes cdof 3.0
+#fix ave_chunk all ave/time 100 1 100 c_cstherm file chunk.dump mode vector 
+
+thermo_modify temp CSequ
+
+# velocity bias option
+
+velocity all create 1427 134 dist gaussian mom yes rot no bias yes temp CSequ
+velocity all scale 1427 temp CSequ
+
+fix thermoberendsen all temp/berendsen 1427 1427 0.4
+fix nve all nve
+fix_modify thermoberendsen temp CSequ
+
+# 2 fmsec timestep
+
+timestep 0.002
+run 500
+
+unfix thermoberendsen
+
+# ------------------------ Dynamic Run -------------------------------
+
+run 1000

--- a/examples/coreshell/log.22Sep17.coreshell.wolf.g++.1
+++ b/examples/coreshell/log.22Sep17.coreshell.wolf.g++.1
@@ -1,0 +1,190 @@
+LAMMPS (22 Sep 2017)
+# Testsystem for core-shell model compared to Mitchel and Finchham
+# Shamelessly copied from in.coreshell.dsf but this script uses Wolf summation.
+
+# ------------------------ INITIALIZATION ----------------------------
+
+units 		metal
+dimension	3
+boundary	p	p	p
+atom_style	full
+
+# ----------------------- ATOM DEFINITION ----------------------------
+
+fix csinfo all property/atom i_CSID
+read_data data.coreshell fix csinfo NULL CS-Info
+  orthogonal box = (0 0 0) to (24.096 24.096 24.096)
+  1 by 1 by 1 MPI processor grid
+  reading atoms ...
+  432 atoms
+  scanning bonds ...
+  1 = max bonds/atom
+  reading bonds ...
+  216 bonds
+  1 = max # of 1-2 neighbors
+  0 = max # of 1-3 neighbors
+  0 = max # of 1-4 neighbors
+  1 = max # of special neighbors
+
+group cores type 1 2
+216 atoms in group cores
+group shells type 3 4
+216 atoms in group shells
+
+neighbor 2.0 bin
+comm_modify vel yes
+
+# ------------------------ FORCE FIELDS ------------------------------
+
+pair_style   born/coul/wolf/cs 0.1 20.0 20.0    # A, rho, sigma=0, C, D
+pair_coeff   * *      0.0 1.000   0.00  0.00   0.00
+pair_coeff   3 3    487.0 0.23768 0.00  1.05   0.50 #Na-Na
+pair_coeff   3 4 145134.0 0.23768 0.00  6.99   8.70 #Na-Cl
+pair_coeff   4 4 405774.0 0.23768 0.00 72.40 145.40 #Cl-Cl
+
+bond_style harmonic
+bond_coeff 1 63.014 0.0
+bond_coeff 2 25.724 0.0
+
+# ------------------------ Equilibration Run -------------------------------
+
+reset_timestep 0
+
+thermo 50
+thermo_style custom step etotal pe ke temp press              epair evdwl ecoul elong ebond fnorm fmax vol
+
+compute CSequ all temp/cs cores shells
+
+# output via chunk method
+
+#compute prop all property/atom i_CSID
+#compute cs_chunk all chunk/atom c_prop
+#compute cstherm all temp/chunk cs_chunk temp internal com yes cdof 3.0
+#fix ave_chunk all ave/time 100 1 100 c_cstherm file chunk.dump mode vector
+
+thermo_modify temp CSequ
+
+# velocity bias option
+
+velocity all create 1427 134 dist gaussian mom yes rot no bias yes temp CSequ
+Neighbor list info ...
+  update every 1 steps, delay 10 steps, check yes
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 22
+  ghost atom cutoff = 22
+  binsize = 11, bins = 3 3 3
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair born/coul/wolf/cs, perpetual
+      attributes: half, newton on
+      pair build: half/bin/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+velocity all scale 1427 temp CSequ
+
+fix thermoberendsen all temp/berendsen 1427 1427 0.4
+fix nve all nve
+fix_modify thermoberendsen temp CSequ
+
+# 2 fmsec timestep
+
+timestep 0.002
+run 500
+Per MPI rank memory allocation (min/avg/max) = 8.59 | 8.59 | 8.59 Mbytes
+Step TotEng PotEng KinEng Temp Press E_pair E_vdwl E_coul E_long E_bond Fnorm Fmax Volume 
+       0   -637.41039   -677.06805    39.657659         1427   -21302.622   -677.06805    1.6320365   -678.70009            0            0 1.2935454e-14 3.3306691e-15      13990.5 
+      50   -635.62711   -667.67134    32.044236    1153.0465   -4533.0717   -669.45724     37.76997   -707.22721            0    1.7858939    9.6844521    2.2001656      13990.5 
+     100   -632.76337   -662.83035    30.066977    1081.8989   -3492.8736   -664.98454    39.197093   -704.18164            0    2.1541967    11.063962    2.1543406      13990.5 
+     150   -630.82538   -663.70056    32.875182    1182.9464   -74.330324   -666.12202    46.263665   -712.38569            0    2.4214607    11.739683    2.7558416      13990.5 
+     200    -629.1541   -664.54637     35.39227    1273.5187   -1707.5508   -666.87772    41.796197   -708.67391            0    2.3313445    10.594804    3.0025376      13990.5 
+     250   -627.86587   -662.60879    34.742918    1250.1531   -1258.7537   -665.21416    43.017024   -708.23118            0    2.6053655    10.576999    1.8400986      13990.5 
+     300   -627.10755   -664.12897    37.021419    1332.1403   -1891.3466   -666.39618    40.769593   -707.16577            0    2.2672094     9.412943    1.2434258      13990.5 
+     350   -626.27558   -665.04303    38.767448    1394.9676   -1436.8514   -667.47081    41.854746   -709.32556            0    2.4277827    10.304721     1.977594      13990.5 
+     400   -625.55098   -661.86388    36.312896    1306.6455   -331.92076    -664.4632    44.426542   -708.88975            0     2.599325    11.081635    2.1734468      13990.5 
+     450   -624.88626   -661.07359    36.187328    1302.1272    -2325.834    -663.6031    39.662697   -703.26579            0    2.5295037    9.9810051    1.3068929      13990.5 
+     500   -623.87093   -660.24145    36.370525    1308.7192    410.85324   -662.86944    45.869201   -708.73864            0    2.6279856    10.592785    1.8162326      13990.5 
+Loop time of 11.7065 on 1 procs for 500 steps with 432 atoms
+
+Performance: 7.381 ns/day, 3.252 hours/ns, 42.711 timesteps/s
+100.0% CPU use with 1 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 11.535     | 11.535     | 11.535     |   0.0 | 98.54
+Bond    | 0.001443   | 0.001443   | 0.001443   |   0.0 |  0.01
+Neigh   | 0.10952    | 0.10952    | 0.10952    |   0.0 |  0.94
+Comm    | 0.048796   | 0.048796   | 0.048796   |   0.0 |  0.42
+Output  | 0.00038695 | 0.00038695 | 0.00038695 |   0.0 |  0.00
+Modify  | 0.0067511  | 0.0067511  | 0.0067511  |   0.0 |  0.06
+Other   |            | 0.004243   |            |       |  0.04
+
+Nlocal:    432 ave 432 max 432 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:    9328 ave 9328 max 9328 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:    297280 ave 297280 max 297280 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 297280
+Ave neighs/atom = 688.148
+Ave special neighs/atom = 1
+Neighbor list builds = 21
+Dangerous builds = 0
+
+unfix thermoberendsen
+
+# ------------------------ Dynamic Run -------------------------------
+
+run 1000
+Per MPI rank memory allocation (min/avg/max) = 8.59 | 8.59 | 8.59 Mbytes
+Step TotEng PotEng KinEng Temp Press E_pair E_vdwl E_coul E_long E_bond Fnorm Fmax Volume 
+     500   -623.87093   -660.24145    36.370525    1308.7192    410.85324   -662.86944    45.869201   -708.73864            0    2.6279856    10.592785    1.8162326      13990.5 
+     550   -623.95762   -659.99899    36.041371    1296.8752   -442.62446   -662.68699    44.004419   -706.69141            0    2.6879934    10.936057    1.7358509      13990.5 
+     600   -624.04214   -661.21748    37.175332    1337.6785    47.615854   -663.76133    45.009742   -708.77107            0    2.5438549    11.431366    2.1185464      13990.5 
+     650   -623.98279   -661.85255     37.86976    1362.6661   -1708.3823   -664.31138    40.933446   -705.24482            0    2.4588298    9.7960191    1.4159904      13990.5 
+     700   -624.02941   -661.57484     37.54543    1350.9958   -124.09512   -663.95322    44.666402   -708.61962            0    2.3783801    10.518712    2.0854584      13990.5 
+     750   -624.03935   -661.11619    37.076837    1334.1344   -1163.2721   -663.82553      42.1219   -705.94743            0    2.7093404    10.634859    1.9381654      13990.5 
+     800   -623.98709   -659.43647     35.44938    1275.5737   -285.65702   -662.23782    44.650233   -706.88805            0    2.8013482     11.83459    3.4506407      13990.5 
+     850   -623.96081   -661.77923    37.818422    1360.8188   -814.33212   -664.38161    42.860208   -707.24181            0    2.6023728    10.766451    2.9211132      13990.5 
+     900   -623.96136   -662.98419    39.022831     1404.157    308.13105   -665.65877    45.053188   -710.71195            0    2.6745786    11.028799    1.8494322      13990.5 
+     950   -623.91048   -660.63828      36.7278     1321.575   -445.31526   -663.79806     43.94833   -707.74639            0    3.1597729    11.852051    1.8238458      13990.5 
+    1000   -623.90541   -661.03474    37.129332    1336.0233    522.57958   -663.50212    45.863261   -709.36538            0    2.4673781    10.949291    1.8614095      13990.5 
+    1050   -624.01134   -660.99076    36.979422    1330.6291   -1710.2829   -663.67762    41.056102   -704.73372            0    2.6868521     10.86533    2.2154165      13990.5 
+    1100   -624.02639   -660.86661    36.840225    1325.6204    1151.0236    -663.5066    47.207185   -710.71378            0    2.6399847    11.298044    1.8900703      13990.5 
+    1150   -624.04418   -661.29819    37.254006    1340.5094    161.09847   -663.73735    45.222561   -708.95991            0    2.4391651    11.261119    2.2245673      13990.5 
+    1200   -624.08628   -662.39932    38.313043    1378.6168   -1405.0927   -664.93121    41.728112   -706.65933            0    2.5318927    10.458041    2.1153159      13990.5 
+    1250   -624.03036   -661.25661    37.226248    1339.5106    63.407721   -663.72719    45.086961   -708.81415            0    2.4705832    11.766021    2.2297809      13990.5 
+    1300   -623.97475   -661.55998    37.585229    1352.4278   -763.66781   -663.80645    42.870244    -706.6767            0    2.2464703    10.098322    1.7614596      13990.5 
+    1350   -623.93123   -660.30786    36.376631    1308.9389   -2389.8052   -663.04725    39.749029   -702.79628            0    2.7393936    10.879364    2.6622521      13990.5 
+    1400   -623.86468   -658.44644    34.581765    1244.3543    2262.7586   -660.95368     50.10608   -711.05976            0    2.5072434    11.528291    1.7861906      13990.5 
+    1450   -623.85494   -661.47216    37.617217    1353.5789   -1435.0174   -664.13587    41.701767   -705.83764            0    2.6637191    11.297444    2.0038345      13990.5 
+    1500   -623.79928   -659.70124    35.901959    1291.8588   -198.39562   -662.57415    44.358482   -706.93263            0     2.872907    11.075746    2.2821286      13990.5 
+Loop time of 23.4119 on 1 procs for 1000 steps with 432 atoms
+
+Performance: 7.381 ns/day, 3.252 hours/ns, 42.713 timesteps/s
+99.9% CPU use with 1 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 23.069     | 23.069     | 23.069     |   0.0 | 98.54
+Bond    | 0.0029275  | 0.0029275  | 0.0029275  |   0.0 |  0.01
+Neigh   | 0.22821    | 0.22821    | 0.22821    |   0.0 |  0.97
+Comm    | 0.097941   | 0.097941   | 0.097941   |   0.0 |  0.42
+Output  | 0.00074033 | 0.00074033 | 0.00074033 |   0.0 |  0.00
+Modify  | 0.0042015  | 0.0042015  | 0.0042015  |   0.0 |  0.02
+Other   |            | 0.00865    |            |       |  0.04
+
+Nlocal:    432 ave 432 max 432 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:    9388 ave 9388 max 9388 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:    297212 ave 297212 max 297212 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 297212
+Ave neighs/atom = 687.991
+Ave special neighs/atom = 1
+Neighbor list builds = 45
+Dangerous builds = 0
+Total wall time: 0:00:35

--- a/examples/coreshell/log.22Sep17.coreshell.wolf.g++.4
+++ b/examples/coreshell/log.22Sep17.coreshell.wolf.g++.4
@@ -1,0 +1,190 @@
+LAMMPS (22 Sep 2017)
+# Testsystem for core-shell model compared to Mitchel and Finchham
+# Shamelessly copied from in.coreshell.dsf but this script uses Wolf summation.
+
+# ------------------------ INITIALIZATION ----------------------------
+
+units 		metal
+dimension	3
+boundary	p	p	p
+atom_style	full
+
+# ----------------------- ATOM DEFINITION ----------------------------
+
+fix csinfo all property/atom i_CSID
+read_data data.coreshell fix csinfo NULL CS-Info
+  orthogonal box = (0 0 0) to (24.096 24.096 24.096)
+  1 by 2 by 2 MPI processor grid
+  reading atoms ...
+  432 atoms
+  scanning bonds ...
+  1 = max bonds/atom
+  reading bonds ...
+  216 bonds
+  1 = max # of 1-2 neighbors
+  0 = max # of 1-3 neighbors
+  0 = max # of 1-4 neighbors
+  1 = max # of special neighbors
+
+group cores type 1 2
+216 atoms in group cores
+group shells type 3 4
+216 atoms in group shells
+
+neighbor 2.0 bin
+comm_modify vel yes
+
+# ------------------------ FORCE FIELDS ------------------------------
+
+pair_style   born/coul/wolf/cs 0.1 20.0 20.0    # A, rho, sigma=0, C, D
+pair_coeff   * *      0.0 1.000   0.00  0.00   0.00
+pair_coeff   3 3    487.0 0.23768 0.00  1.05   0.50 #Na-Na
+pair_coeff   3 4 145134.0 0.23768 0.00  6.99   8.70 #Na-Cl
+pair_coeff   4 4 405774.0 0.23768 0.00 72.40 145.40 #Cl-Cl
+
+bond_style harmonic
+bond_coeff 1 63.014 0.0
+bond_coeff 2 25.724 0.0
+
+# ------------------------ Equilibration Run -------------------------------
+
+reset_timestep 0
+
+thermo 50
+thermo_style custom step etotal pe ke temp press              epair evdwl ecoul elong ebond fnorm fmax vol
+
+compute CSequ all temp/cs cores shells
+
+# output via chunk method
+
+#compute prop all property/atom i_CSID
+#compute cs_chunk all chunk/atom c_prop
+#compute cstherm all temp/chunk cs_chunk temp internal com yes cdof 3.0
+#fix ave_chunk all ave/time 100 1 100 c_cstherm file chunk.dump mode vector
+
+thermo_modify temp CSequ
+
+# velocity bias option
+
+velocity all create 1427 134 dist gaussian mom yes rot no bias yes temp CSequ
+Neighbor list info ...
+  update every 1 steps, delay 10 steps, check yes
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 22
+  ghost atom cutoff = 22
+  binsize = 11, bins = 3 3 3
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair born/coul/wolf/cs, perpetual
+      attributes: half, newton on
+      pair build: half/bin/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+velocity all scale 1427 temp CSequ
+
+fix thermoberendsen all temp/berendsen 1427 1427 0.4
+fix nve all nve
+fix_modify thermoberendsen temp CSequ
+
+# 2 fmsec timestep
+
+timestep 0.002
+run 500
+Per MPI rank memory allocation (min/avg/max) = 6.881 | 6.881 | 6.881 Mbytes
+Step TotEng PotEng KinEng Temp Press E_pair E_vdwl E_coul E_long E_bond Fnorm Fmax Volume 
+       0   -637.41039   -677.06805    39.657659         1427   -21302.622   -677.06805    1.6320365   -678.70009            0            0 1.3530839e-14 3.6429193e-15      13990.5 
+      50   -635.62704   -667.67108    32.044047    1153.0397   -4532.6842   -669.45828    37.771018    -707.2293            0     1.787201    9.6848095    2.2028349      13990.5 
+     100   -632.76343   -662.83014    30.066711    1081.8893   -3493.0827   -664.98212    39.195967   -704.17809            0     2.151977    11.060773    2.1578583      13990.5 
+     150   -630.82533   -663.70172    32.876385    1182.9897   -75.706974   -666.12608    46.261038   -712.38712            0    2.4243598    11.746728    2.7663319      13990.5 
+     200   -629.15463   -664.55009    35.395466    1273.6337   -1707.9185   -666.88117    41.794868   -708.67604            0     2.331082    10.596229    3.0031523      13990.5 
+     250   -627.86625   -662.60876    34.742511    1250.1384   -1263.5726     -665.214    43.005742   -708.21974            0    2.6052329    10.572641     1.841604      13990.5 
+     300   -627.10829   -664.12159    37.013298    1331.8481   -1884.8587   -666.39136    40.786141    -707.1775            0    2.2697693    9.4160685    1.2472271      13990.5 
+     350    -626.2729   -665.01858    38.745682    1394.1844   -1433.1302   -667.44315    41.864785   -709.30793            0    2.4245625    10.312641    1.9815612      13990.5 
+     400   -625.54274   -661.84438    36.301638    1306.2404   -355.45544    -664.4483    44.370671   -708.81897            0    2.6039276    11.076154    2.1819703      13990.5 
+     450   -624.88802   -661.12299    36.234964    1303.8413   -2356.6101    -663.6463     39.57847   -703.22477            0     2.523314    9.8995886    1.3113549      13990.5 
+     500   -623.86344   -660.20235    36.338906    1307.5814    462.72862    -662.8515    45.983055   -708.83455            0    2.6491489    10.523732    1.6709561      13990.5 
+Loop time of 4.63313 on 4 procs for 500 steps with 432 atoms
+
+Performance: 18.648 ns/day, 1.287 hours/ns, 107.919 timesteps/s
+99.4% CPU use with 4 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 2.8133     | 3.5934     | 4.4255     |  36.3 | 77.56
+Bond    | 0.00042245 | 0.00050305 | 0.00059825 |   0.0 |  0.01
+Neigh   | 0.0411     | 0.041561   | 0.04202    |   0.2 |  0.90
+Comm    | 0.15622    | 0.9884     | 1.7686     |  69.2 | 21.33
+Output  | 0.00028311 | 0.00031345 | 0.00040011 |   0.0 |  0.01
+Modify  | 0.0039899  | 0.00403    | 0.0040654  |   0.0 |  0.09
+Other   |            | 0.004911   |            |       |  0.11
+
+Nlocal:    108 ave 112 max 106 min
+Histogram: 2 0 0 1 0 0 0 0 0 1
+Nghost:    6531.75 ave 6611 max 6460 min
+Histogram: 1 0 0 1 0 1 0 0 0 1
+Neighs:    74316.2 ave 75641 max 72780 min
+Histogram: 1 0 0 1 0 0 0 0 1 1
+
+Total # of neighbors = 297265
+Ave neighs/atom = 688.113
+Ave special neighs/atom = 1
+Neighbor list builds = 21
+Dangerous builds = 0
+
+unfix thermoberendsen
+
+# ------------------------ Dynamic Run -------------------------------
+
+run 1000
+Per MPI rank memory allocation (min/avg/max) = 6.884 | 7.01 | 7.138 Mbytes
+Step TotEng PotEng KinEng Temp Press E_pair E_vdwl E_coul E_long E_bond Fnorm Fmax Volume 
+     500   -623.86344   -660.20235    36.338906    1307.5814    462.72862    -662.8515    45.983055   -708.83455            0    2.6491489    10.523732    1.6709561      13990.5 
+     550   -623.95339   -660.07946    36.126069    1299.9229   -362.67288    -662.8047    44.180832   -706.98553            0     2.725239     11.07199    2.0461377      13990.5 
+     600   -624.04508   -661.27298    37.227902    1339.5701    110.39823   -663.90927    45.166569   -709.07584            0    2.6362911    11.747923    2.1846828      13990.5 
+     650    -623.9608   -661.50573    37.544934    1350.9779   -1594.4701   -663.91531    41.226571   -705.14188            0    2.4095736    10.022027    1.6264014      13990.5 
+     700   -624.00658   -663.55636    39.549777    1423.1181    -588.9804   -665.88666    43.124023   -709.01068            0    2.3302979     9.924587    2.1027837      13990.5 
+     750   -623.99813   -659.97695    35.978816    1294.6243    -364.1415   -662.75959    43.973556   -706.73315            0     2.782646    11.487832    1.8799695      13990.5 
+     800   -624.01235   -661.04908    37.036728    1332.6911   -85.655852   -663.49204    44.570117   -708.06215            0    2.4429547    11.213149    1.6792926      13990.5 
+     850   -624.02581   -659.39933    35.373519     1272.844   -1090.9179   -662.11969    42.375064   -704.49476            0    2.7203673    11.214629    2.2907474      13990.5 
+     900   -624.09244   -663.33386    39.241421    1412.0225    303.76207   -666.00593    45.332458   -711.33839            0    2.6720667    11.897188    2.0599033      13990.5 
+     950   -624.04544   -661.11578    37.070341    1333.9007    1637.6438   -663.61305     48.65892   -712.27197            0      2.49727    12.343774     2.429225      13990.5 
+    1000   -623.95457   -661.51816    37.563586    1351.6491   -851.77182   -663.83594    42.813468   -706.64941            0     2.317782    10.251422    1.6922864      13990.5 
+    1050   -623.98731   -662.01988    38.032562    1368.5242   -2123.9075   -664.72609    39.917382   -704.64348            0     2.706218     9.600838    1.7365559      13990.5 
+    1100    -623.9653   -659.32023    35.354929    1272.1751   -436.90576   -662.14454    44.057776   -706.20232            0    2.8243167    11.267546    2.6807602      13990.5 
+    1150   -624.02273   -665.13902    41.116293     1479.486   -128.13268    -667.4769    44.013761   -711.49066            0    2.3378768    10.406604    1.5102324      13990.5 
+    1200   -623.97328   -663.08042    39.107135    1407.1905   -539.63284   -665.67946    43.319308   -708.99877            0     2.599042    10.632657    1.4608707      13990.5 
+    1250   -623.92529   -661.81902    37.893723    1363.5284    1708.0621   -664.63624    48.396874   -713.03311            0    2.8172251    11.369352    1.8836979      13990.5 
+    1300   -623.99283   -662.19734    38.204509    1374.7114   -820.77291   -664.34556    42.656202   -707.00176            0    2.1482151    10.186898    1.7081329      13990.5 
+    1350   -623.99798   -658.70752    34.709535    1248.9519    776.28486   -662.01647    46.925412   -708.94188            0    3.3089536    12.457581    2.5027978      13990.5 
+    1400   -623.96941   -662.15959    38.190183    1374.1959    880.21756   -664.90452    46.628183    -711.5327            0    2.7449282    11.918894    3.0466188      13990.5 
+    1450   -623.95068   -662.25435    38.303671    1378.2795   -391.56711    -664.7631    43.644066   -708.40716            0    2.5087493    10.465803    1.8744864      13990.5 
+    1500   -624.00637   -661.48756    37.481185     1348.684    430.69453   -664.32151    45.704366   -710.02587            0    2.8339501    11.650821    2.0752813      13990.5 
+Loop time of 6.7003 on 4 procs for 1000 steps with 432 atoms
+
+Performance: 25.790 ns/day, 0.931 hours/ns, 149.247 timesteps/s
+99.1% CPU use with 4 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 5.9613     | 6.0752     | 6.2064     |   4.1 | 90.67
+Bond    | 0.00087095 | 0.00088993 | 0.00091671 |   0.0 |  0.01
+Neigh   | 0.06494    | 0.064964   | 0.064987   |   0.0 |  0.97
+Comm    | 0.41743    | 0.54863    | 0.6626     |  13.8 |  8.19
+Output  | 0.00053867 | 0.00059268 | 0.00074867 |   0.0 |  0.01
+Modify  | 0.0013288  | 0.0013592  | 0.0013841  |   0.1 |  0.02
+Other   |            | 0.008613   |            |       |  0.13
+
+Nlocal:    108 ave 116 max 102 min
+Histogram: 2 0 0 0 0 0 0 1 0 1
+Nghost:    6504.5 ave 6624 max 6380 min
+Histogram: 1 1 0 0 0 0 0 0 1 1
+Neighs:    74267 ave 79230 max 70993 min
+Histogram: 2 0 0 0 0 1 0 0 0 1
+
+Total # of neighbors = 297068
+Ave neighs/atom = 687.657
+Ave special neighs/atom = 1
+Neighbor list builds = 45
+Dangerous builds = 0
+Total wall time: 0:00:11

--- a/src/CORESHELL/Install.sh
+++ b/src/CORESHELL/Install.sh
@@ -30,13 +30,19 @@ action () {
 
 action compute_temp_cs.cpp
 action compute_temp_cs.h
-action pair_born_coul_long_cs.cpp pair_born_coul_long.cpp
-action pair_born_coul_dsf_cs.cpp pair_born_coul_dsf.cpp
-action pair_buck_coul_long_cs.cpp pair_buck_coul_long.cpp
-action pair_born_coul_long_cs.h pair_born_coul_long.h
-action pair_born_coul_dsf_cs.h pair_born_coul_dsf.h
-action pair_buck_coul_long_cs.h pair_buck_coul_long.h
-action pair_coul_long_cs.cpp pair_coul_long.cpp
-action pair_coul_long_cs.h pair_coul_long.h
+
+action pair_born_coul_long_cs.cpp   pair_born_coul_long.cpp
+action pair_born_coul_dsf_cs.cpp    pair_born_coul_dsf.cpp
+action pair_buck_coul_long_cs.cpp   pair_buck_coul_long.cpp
+action pair_born_coul_long_cs.h     pair_born_coul_long.h
+action pair_born_coul_dsf_cs.h      pair_born_coul_dsf.h
+action pair_buck_coul_long_cs.h     pair_buck_coul_long.h
+action pair_coul_long_cs.cpp        pair_coul_long.cpp
+action pair_coul_long_cs.h          pair_coul_long.h
 action pair_lj_cut_coul_long_cs.cpp pair_lj_cut_coul_long.cpp
-action pair_lj_cut_coul_long_cs.h pair_lj_cut_coul_long.h
+action pair_lj_cut_coul_long_cs.h   pair_lj_cut_coul_long.h
+
+action pair_born_coul_wolf_cs.cpp   pair_born_coul_wolf.cpp
+action pair_born_coul_wolf_cs.h     pair_born_coul_wolf.h
+action pair_coul_wolf_cs.cpp        pair_coul_wolf.cpp
+action pair_coul_wolf_cs.h          pair_coul_wolf.h

--- a/src/CORESHELL/pair_born_coul_wolf_cs.cpp
+++ b/src/CORESHELL/pair_born_coul_wolf_cs.cpp
@@ -70,8 +70,7 @@ void PairBornCoulWolfCS::compute(int eflag, int vflag)
 
   e_self = v_sh = 0.0;
   e_shift = erfc(alf*cut_coul)/cut_coul;
-  f_shift = -(e_shift+ 2.0*alf/MY_PIS * exp(-alf*alf*cut_coul*cut_coul)) /
-    cut_coul;
+  f_shift = -(e_shift+ 2.0*alf/MY_PIS * exp(-alf*alf*cut_coul*cut_coul)) / cut_coul;
 
   inum = list->inum;
   ilist = list->ilist;
@@ -107,9 +106,9 @@ void PairBornCoulWolfCS::compute(int eflag, int vflag)
       jtype = type[j];
 
       if (rsq < cutsq[itype][jtype]) {
-	rsq += EPSILON;
-	// Add EPISLON for case: r = 0; Interaction must be removed
-	// by special bond
+		rsq += EPSILON;
+		// Add EPISLON for case: r = 0; Interaction must be removed
+		// by special bond
         r2inv = 1.0/rsq;
 
         if (rsq < cut_coulsq) {

--- a/src/CORESHELL/pair_born_coul_wolf_cs.cpp
+++ b/src/CORESHELL/pair_born_coul_wolf_cs.cpp
@@ -1,0 +1,170 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "pair_born_coul_wolf_cs.h"
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "math_const.h"
+#include "math_special.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+using namespace MathSpecial;
+
+#define EPSILON 1.0e-20
+
+/* ---------------------------------------------------------------------- */
+
+PairBornCoulWolfCS::PairBornCoulWolfCS(LAMMPS *lmp) : PairBornCoulWolf(lmp)
+{
+  single_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairBornCoulWolfCS::compute(int eflag, int vflag)
+{
+  int i,j,ii,jj,inum,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double rsq,r2inv,r6inv,forcecoul,forceborn,factor_coul,factor_lj;
+  double prefactor;
+  double r,rexp;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  double erfcc,erfcd,v_sh,dvdrr,e_self,e_shift,f_shift,qisq;
+
+  evdwl = ecoul = 0.0;
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = vflag_fdotr = 0;
+
+  double **x = atom->x;
+  double **f = atom->f;
+  double *q = atom->q;
+  int *type = atom->type;
+  int nlocal = atom->nlocal;
+  double *special_coul = force->special_coul;
+  double *special_lj = force->special_lj;
+  int newton_pair = force->newton_pair;
+  double qqrd2e = force->qqrd2e;
+
+  // self and shifted coulombic energy
+
+  e_self = v_sh = 0.0;
+  e_shift = erfc(alf*cut_coul)/cut_coul;
+  f_shift = -(e_shift+ 2.0*alf/MY_PIS * exp(-alf*alf*cut_coul*cut_coul)) /
+    cut_coul;
+
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    qisq = qtmp*qtmp;
+    e_self = -(e_shift/2.0 + alf/MY_PIS) * qisq*qqrd2e;
+    if (eflag) ev_tally(i,i,nlocal,0,0.0,e_self,0.0,0.0,0.0,0.0);
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+	rsq += EPSILON;
+	// Add EPISLON for case: r = 0; Interaction must be removed
+	// by special bond
+        r2inv = 1.0/rsq;
+
+        if (rsq < cut_coulsq) {
+          r = sqrt(rsq);
+          prefactor = qqrd2e*qtmp*q[j]/r;
+          erfcc = erfc(alf*r);
+          erfcd = exp(-alf*alf*r*r);
+          v_sh = (erfcc - e_shift*r) * prefactor;
+          dvdrr = (erfcc/rsq + 2.0*alf/MY_PIS * erfcd/r) + f_shift;
+          forcecoul = dvdrr*rsq*prefactor;
+          if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r6inv = r2inv*r2inv*r2inv;
+          r = sqrt(rsq);
+          rexp = exp((sigma[itype][jtype]-r)*rhoinv[itype][jtype]);
+          forceborn = born1[itype][jtype]*r*rexp - born2[itype][jtype]*r6inv
+            + born3[itype][jtype]*r2inv*r6inv;
+        } else forceborn = 0.0;
+
+        fpair = (forcecoul + factor_lj*forceborn) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (newton_pair || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (eflag) {
+          if (rsq < cut_coulsq) {
+            ecoul = v_sh;
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = a[itype][jtype]*rexp - c[itype][jtype]*r6inv +
+              d[itype][jtype]*r6inv*r2inv - offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (evflag) ev_tally(i,j,nlocal,newton_pair,
+                             evdwl,ecoul,fpair,delx,dely,delz);
+      }
+    }
+  }
+
+  if (vflag_fdotr) virial_fdotr_compute();
+}
+
+/*
+Using erfc and expmsq provided by math_special.h
+
+See: http://lammps.sandia.gov/threads/msg61934.html
+*/

--- a/src/CORESHELL/pair_born_coul_wolf_cs.h
+++ b/src/CORESHELL/pair_born_coul_wolf_cs.h
@@ -1,0 +1,60 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(born/coul/wolf/cs,PairBornCoulWolfCS)
+
+#else
+
+#ifndef LMP_PAIR_BORN_COUL_WOLF_CS_H
+#define LMP_PAIR_BORN_COUL_WOLF_CS_H
+
+#include "pair_born_coul_wolf.h"
+
+namespace LAMMPS_NS {
+
+class PairBornCoulWolfCS : public PairBornCoulWolf {
+ public:
+  PairBornCoulWolfCS(class LAMMPS *);
+  virtual void compute(int, int);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Incorrect args for pair coefficients
+
+Self-explanatory.  Check the input script or data file.
+
+E: All pair coeffs are not set
+
+All pair coefficients must be set in the data file or by the
+pair_coeff command before running a simulation.
+
+E: Pair style born/coul/wolf/cs requires atom attribute q
+
+An atom style that defines this attribute must be used.
+
+
+*/

--- a/src/CORESHELL/pair_coul_wolf_cs.cpp
+++ b/src/CORESHELL/pair_coul_wolf_cs.cpp
@@ -1,0 +1,145 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "pair_coul_wolf_cs.h"
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+#include "neigh_list.h"
+#include "math_const.h"
+#include "math_special.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+using namespace MathSpecial;
+
+#define EPSILON 1.0e-20
+
+/* ---------------------------------------------------------------------- */
+
+PairCoulWolfCS::PairCoulWolfCS(LAMMPS *lmp) : PairCoulWolf( lmp )
+{
+   single_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairCoulWolfCS::compute(int eflag, int vflag)
+{
+  int i,j,ii,jj,inum,jnum;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
+  double rsq,forcecoul,factor_coul;
+  double prefactor;
+  double r;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  double erfcc,erfcd,v_sh,dvdrr,e_self,e_shift,f_shift,qisq;
+
+  ecoul = 0.0;
+  if (eflag || vflag) ev_setup(eflag,vflag);
+  else evflag = vflag_fdotr = 0;
+
+  double **x = atom->x;
+  double **f = atom->f;
+  double *q = atom->q;
+  int nlocal = atom->nlocal;
+  double *special_coul = force->special_coul;
+  int newton_pair = force->newton_pair;
+  double qqrd2e = force->qqrd2e;
+
+  // self and shifted coulombic energy
+
+  e_self = v_sh = 0.0;
+  e_shift = erfc(alf*cut_coul)/cut_coul;
+  f_shift = -(e_shift+ 2.0*alf/MY_PIS * exp(-alf*alf*cut_coul*cut_coul)) /
+    cut_coul;
+
+  inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = 0; ii < inum; ii++) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    qisq = qtmp*qtmp;
+    e_self = -(e_shift/2.0 + alf/MY_PIS) * qisq*qqrd2e;
+    if (evflag) ev_tally(i,i,nlocal,0,0.0,e_self,0.0,0.0,0.0,0.0);
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq < cut_coulsq) {
+	rsq += EPSILON;
+	// Add EPISLON for case: r = 0; Interaction must be removed
+	// by special bond
+	r = sqrt(rsq);
+	prefactor = qqrd2e*qtmp*q[j]/r;
+	erfcc = erfc(alf*r);
+	erfcd = exp(-alf*alf*r*r);
+	v_sh = (erfcc - e_shift*r) * prefactor;
+	dvdrr = (erfcc/rsq + 2.0*alf/MY_PIS * erfcd/r) + f_shift;
+	forcecoul = dvdrr*rsq*prefactor;
+	if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+	fpair = forcecoul / rsq;
+
+	f[i][0] += delx*fpair;
+	f[i][1] += dely*fpair;
+	f[i][2] += delz*fpair;
+	if (newton_pair || j < nlocal) {
+	  f[j][0] -= delx*fpair;
+	  f[j][1] -= dely*fpair;
+	  f[j][2] -= delz*fpair;
+	}
+
+	if (eflag) {
+	  ecoul = v_sh;
+	  if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+	} else ecoul = 0.0;
+
+	if (evflag) ev_tally(i,j,nlocal,newton_pair,
+			     0.0,ecoul,fpair,delx,dely,delz);
+      }
+    }
+  }
+
+  if (vflag_fdotr) virial_fdotr_compute();
+}
+
+/* NOTES
+Using erfc and expmsq provided by math_special.h
+
+See: http://lammps.sandia.gov/threads/msg61934.html
+*/

--- a/src/CORESHELL/pair_coul_wolf_cs.h
+++ b/src/CORESHELL/pair_coul_wolf_cs.h
@@ -1,0 +1,54 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(coul/wolf/cs,PairCoulWolfCS)
+
+#else
+
+#ifndef LMP_PAIR_COUL_WOLF_CS_H_
+#define LMP_PAIR_COUL_WOLF_CS_H_
+
+#include "pair_coul_wolf.h"
+
+namespace LAMMPS_NS {
+
+class PairCoulWolfCS : public PairCoulWolf {
+ public:
+  PairCoulWolfCS( class LAMMPS *);
+  virtual void compute( int, int);
+};
+
+}
+
+#endif
+#endif /* LMP_PAIR_COUL_WOLF_CS_H_ */
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Incorrect args for pair coefficients
+
+Self-explanatory.  Check the input script or data file.
+
+E: Pair coul/wolf/cs requires atom attribute q
+
+The atom style defined does not have this attribute.
+
+*/


### PR DESCRIPTION
## Purpose

This pull request adds the following pair styles in the CORESHELL package. 
`coul/wolf/cs`
`born/coul/wolf/cs`

This PR could be related to #371.

## Author(s)

Vishal Boddu

## Backward Compatibility

Yes.

## Implementation Notes

The new pair styles are written based on `coul/wolf` and `coul/long/cs` pair styles.

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines