### PR TITLE
Bugfix for checking image flags

### DIFF
--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -772,7 +772,7 @@ void Domain::image_check()
       delz = unwrap[i][2] - unwrap[k][2];
 
       if (xperiodic && delx > xprd_half) flag = 1;
-      if (xperiodic && dely > yprd_half) flag = 1;
+      if (yperiodic && dely > yprd_half) flag = 1;
       if (dimension == 3 && zperiodic && delz > zprd_half) flag = 1;
       if (!xperiodic && delx > xprd) flag = 1;
       if (!yperiodic && dely > yprd) flag = 1;


### PR DESCRIPTION
## Purpose

I found a bug at line 775 in src/domain.cpp.

I think `if (xperiodic && dely > yprd_half) flag = 1;` should be `if (yperiodic && dely > yprd_half) flag = 1;` so that a check of image flags works correctly when the simulation box is not periodic in x but periodic in y.

## Author(s)

Takayuki Kobayashi

## Backward Compatibility

N/A

## Implementation Notes

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

