### PR TITLE
Limit IPython autocomplete to known commands and properties

### DIFF
--- a/python/lammps.py
+++ b/python/lammps.py
@@ -861,6 +861,19 @@ class PyLammps(object):
     """ needed for Python2 compatibility, since print is a reserved keyword """
     return self.__getattr__("print")(s)
 
+  def __dir__(self):
+    return ['angle_coeff', 'angle_style', 'atom_modify', 'atom_style', 'atom_style',
+    'bond_coeff', 'bond_style', 'boundary', 'change_box', 'communicate', 'compute',
+    'create_atoms', 'create_box', 'delete_atoms', 'delete_bonds', 'dielectric',
+    'dihedral_coeff', 'dihedral_style', 'dimension', 'dump', 'fix', 'fix_modify',
+    'group', 'improper_coeff', 'improper_style', 'include', 'kspace_modify',
+    'kspace_style', 'lattice', 'mass', 'minimize', 'min_style', 'neighbor',
+    'neigh_modify', 'newton', 'nthreads', 'pair_coeff', 'pair_modify',
+    'pair_style', 'processors', 'read', 'read_data', 'read_restart', 'region',
+    'replicate', 'reset_timestep', 'restart', 'run', 'run_style', 'thermo',
+    'thermo_modify', 'thermo_style', 'timestep', 'undump', 'unfix', 'units',
+    'variable', 'velocity', 'write_restart']
+
   def __getattr__(self, name):
     def handler(*args, **kwargs):
       cmd_args = [name] + [str(x) for x in args]


### PR DESCRIPTION
## Purpose

This fixes a bug reported by Gideon Simpson via Email. IPython crashes when trying to autocomplete (TAB) from a PyLammps or IPyLammps instance. Besides preventing the issue, it extends the autocompletion with a list of callable LAMMPS commands, hopefully making it more useful.

## Author(s)

Richard Berger (Temple U)

## Implementation Notes

IPython was using and executing methods returned from `__getattr__` to figure out the available callables and making assumptions about it being in a TTY. By implementing `__dir__` we prevent that situation and also add a useful feature by listing all available LAMMPS commands.

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
