### PR TITLE
Bug fix for unexpected case where a Intel bonded style is specified but there are no types

### DIFF
--- a/src/USER-INTEL/angle_charmm_intel.cpp
+++ b/src/USER-INTEL/angle_charmm_intel.cpp
@@ -336,7 +336,7 @@ void AngleCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->nangletypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].theta0 = theta0[i];
     fc.fc[i].k_ub = k_ub[i];

--- a/src/USER-INTEL/angle_harmonic_intel.cpp
+++ b/src/USER-INTEL/angle_harmonic_intel.cpp
@@ -318,7 +318,7 @@ void AngleHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->nangletypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].theta0 = theta0[i];
   }

--- a/src/USER-INTEL/bond_fene_intel.cpp
+++ b/src/USER-INTEL/bond_fene_intel.cpp
@@ -295,7 +295,7 @@ void BondFENEIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->nbondtypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].ir0sq = 1.0 / (r0[i] * r0[i]);
     fc.fc[i].sigma = sigma[i];

--- a/src/USER-INTEL/bond_harmonic_intel.cpp
+++ b/src/USER-INTEL/bond_harmonic_intel.cpp
@@ -266,7 +266,7 @@ void BondHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->nbondtypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].r0 = r0[i];
   }

--- a/src/USER-INTEL/dihedral_charmm_intel.cpp
+++ b/src/USER-INTEL/dihedral_charmm_intel.cpp
@@ -942,8 +942,8 @@ void DihedralCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
   buffers->set_ntypes(tp1);
 
   if (weightflag) {
-    for (int i = 0; i < tp1; i++) {
-      for (int j = 0; j < tp1; j++) {
+    for (int i = 1; i < tp1; i++) {
+      for (int j = 1; j < tp1; j++) {
         fc.ljp[i][j].lj1 = lj14_1[i][j];
         fc.ljp[i][j].lj2 = lj14_2[i][j];
         fc.ljp[i][j].lj3 = lj14_3[i][j];
@@ -952,7 +952,7 @@ void DihedralCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
     }
   }
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.bp[i].multiplicity = multiplicity[i];
     fc.bp[i].cos_shift = cos_shift[i];
     fc.bp[i].sin_shift = sin_shift[i];

--- a/src/USER-INTEL/dihedral_harmonic_intel.cpp
+++ b/src/USER-INTEL/dihedral_harmonic_intel.cpp
@@ -400,7 +400,7 @@ void DihedralHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.bp[i].multiplicity = multiplicity[i];
     fc.bp[i].cos_shift = cos_shift[i];
     fc.bp[i].sin_shift = sin_shift[i];

--- a/src/USER-INTEL/dihedral_opls_intel.cpp
+++ b/src/USER-INTEL/dihedral_opls_intel.cpp
@@ -427,7 +427,7 @@ void DihedralOPLSIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.bp[i].k1 = k1[i];
     fc.bp[i].k2 = k2[i];
     fc.bp[i].k3 = k3[i];

--- a/src/USER-INTEL/improper_cvff_intel.cpp
+++ b/src/USER-INTEL/improper_cvff_intel.cpp
@@ -433,7 +433,7 @@ void ImproperCvffIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->nimpropertypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].sign = sign[i];
     fc.fc[i].multiplicity = multiplicity[i];

--- a/src/USER-INTEL/improper_harmonic_intel.cpp
+++ b/src/USER-INTEL/improper_harmonic_intel.cpp
@@ -389,7 +389,7 @@ void ImproperHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
   const int bp1 = atom->nimpropertypes + 1;
   fc.set_ntypes(bp1,memory);
 
-  for (int i = 0; i < bp1; i++) {
+  for (int i = 1; i < bp1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].chi = chi[i];
   }

--- a/src/USER-INTEL/intel_preprocess.h
+++ b/src/USER-INTEL/intel_preprocess.h
@@ -211,16 +211,23 @@ enum {TIME_PACK, TIME_HOST_NEIGHBOR, TIME_HOST_PAIR, TIME_OFFLOAD_NEIGHBOR,
                            datasize);                           \
   }
 
-#define IP_PRE_omp_range_id_vec(ifrom, ito, tid, inum,          \
-                                nthreads, vecsize)              \
+#define IP_PRE_omp_range_vec(ifrom, ito, tid, inum, nthreads,	\
+                             vecsize)				\
   {                                                             \
-    tid = omp_get_thread_num();                                 \
     int idelta = static_cast<int>(ceil(static_cast<float>(inum) \
                                        /vecsize/nthreads));     \
     idelta *= vecsize;                                          \
     ifrom = tid*idelta;                                         \
     ito = ifrom + idelta;                                       \
     if (ito > inum) ito = inum;                                 \
+  }
+
+#define IP_PRE_omp_range_id_vec(ifrom, ito, tid, inum,          \
+                                nthreads, vecsize)              \
+  {                                                             \
+    tid = omp_get_thread_num();                                 \
+    IP_PRE_omp_range_vec(ifrom, ito, tid, inum, nthreads,	\
+			 vecsize);				\
   }
 
 #define IP_PRE_omp_stride_id_vec(ifrom, ip, ito, tid, inum,     \
@@ -235,13 +242,12 @@ enum {TIME_PACK, TIME_HOST_NEIGHBOR, TIME_HOST_PAIR, TIME_OFFLOAD_NEIGHBOR,
       int nd = nthr / INTEL_HTHREADS;                           \
       int td = tid / INTEL_HTHREADS;                            \
       int tm = tid % INTEL_HTHREADS;                            \
-      IP_PRE_omp_range_id_vec(ifrom, ito, td, inum, nd,         \
-        vecsize);                                               \
+      IP_PRE_omp_range_vec(ifrom, ito, td, inum, nd, vecsize);	\
       ifrom += tm * vecsize;                                    \
       ip = INTEL_HTHREADS * vecsize;                            \
     } else {                                                    \
-      IP_PRE_omp_range_id_vec(ifrom, ito, tid, inum, nthr,      \
-                              vecsize);                         \
+      IP_PRE_omp_range_vec(ifrom, ito, tid, inum, nthr,		\
+			   vecsize);				\
       ip = vecsize;                                             \
     }                                                           \
   }

--- a/src/USER-INTEL/pair_buck_coul_cut_intel.cpp
+++ b/src/USER-INTEL/pair_buck_coul_cut_intel.cpp
@@ -458,8 +458,8 @@ void PairBuckCoulCutIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       fc.c_cut[i][j].cutsq = cutsq[i][j];
       fc.c_cut[i][j].cut_ljsq = cut_ljsq[i][j];
       fc.c_cut[i][j].cut_coulsq = cut_coulsq[i][j];

--- a/src/USER-INTEL/pair_buck_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_buck_coul_long_intel.cpp
@@ -545,8 +545,8 @@ void PairBuckCoulLongIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       if (cutsq[i][j] < cut_ljsq[i][j])
         error->all(FLERR,
          "Intel variant of lj/buck/coul/long expects lj cutoff<=coulombic");

--- a/src/USER-INTEL/pair_buck_intel.cpp
+++ b/src/USER-INTEL/pair_buck_intel.cpp
@@ -413,8 +413,8 @@ void PairBuckIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       fc.c_force[i][j].buck1 = buck1[i][j];
       fc.c_force[i][j].buck2 = buck2[i][j];
       fc.c_force[i][j].rhoinv = rhoinv[i][j];

--- a/src/USER-INTEL/pair_dpd_intel.cpp
+++ b/src/USER-INTEL/pair_dpd_intel.cpp
@@ -531,8 +531,8 @@ void PairDPDIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       fc.param[i][j].a0 = a0[i][j];
       fc.param[i][j].gamma = gamma[i][j];
       fc.param[i][j].sigma = sigma[i][j];

--- a/src/USER-INTEL/pair_gayberne_intel.cpp
+++ b/src/USER-INTEL/pair_gayberne_intel.cpp
@@ -938,8 +938,8 @@ void PairGayBerneIntel::pack_force_const(ForceConst<flt_t> &fc,
   fc.upsilon = upsilon;
   fc.mu = mu;
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       fc.ijc[i][j].lj1 = lj1[i][j];
       fc.ijc[i][j].lj2 = lj2[i][j];
       fc.ijc[i][j].cutsq = cutsq[i][j];

--- a/src/USER-INTEL/pair_lj_charmm_coul_charmm_intel.cpp
+++ b/src/USER-INTEL/pair_lj_charmm_coul_charmm_intel.cpp
@@ -521,8 +521,8 @@ void PairLJCharmmCoulCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       fc.lj[i][j].x = lj1[i][j];
       fc.lj[i][j].y = lj2[i][j];
       fc.lj[i][j].z = lj3[i][j];

--- a/src/USER-INTEL/pair_lj_charmm_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_lj_charmm_coul_long_intel.cpp
@@ -586,8 +586,8 @@ void PairLJCharmmCoulLongIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       fc.lj[i][j].x = lj1[i][j];
       fc.lj[i][j].y = lj2[i][j];
       fc.lj[i][j].z = lj3[i][j];

--- a/src/USER-INTEL/pair_lj_cut_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_lj_cut_coul_long_intel.cpp
@@ -544,8 +544,8 @@ void PairLJCutCoulLongIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       if (cutsq[i][j] < cut_ljsq[i][j])
         error->all(FLERR,
          "Intel variant of lj/cut/coul/long expects lj cutoff<=coulombic");

--- a/src/USER-INTEL/pair_lj_cut_intel.cpp
+++ b/src/USER-INTEL/pair_lj_cut_intel.cpp
@@ -437,8 +437,8 @@ void PairLJCutIntel::pack_force_const(ForceConst<flt_t> &fc,
     fc.special_lj[0] = 1.0;
   }
 
-  for (int i = 0; i < tp1; i++) {
-    for (int j = 0; j < tp1; j++) {
+  for (int i = 1; i < tp1; i++) {
+    for (int j = 1; j < tp1; j++) {
       fc.ljc12o[i][j].lj1 = lj1[i][j];
       fc.ljc12o[i][j].lj2 = lj2[i][j];
       fc.lj34[i][j].lj3 = lj3[i][j];


### PR DESCRIPTION
When there are no types for bond/angle/dihedral/improper, no allocation is performed and the Intel styles would erroneously try to access 0 indices into type arrays in parent classes.

## Author(s)

Mike Brown (Intel)

## Backward Compatibility

N/A

## Implementation Notes

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

