### PR TITLE
Avoid checking region when not specified

### DIFF
--- a/src/fix_heat.cpp
+++ b/src/fix_heat.cpp
@@ -127,7 +127,7 @@ void FixHeat::init()
   }
 
   // check for rigid bodies in region (done here for performance reasons)
-  if (modify->check_rigid_region_overlap(groupbit,domain->regions[iregion]))
+  if (iregion >= 0 && modify->check_rigid_region_overlap(groupbit,domain->regions[iregion]))
     error->warning(FLERR,"Cannot apply fix heat to atoms in rigid bodies");
 
   // cannot have 0 atoms in group


### PR DESCRIPTION
## Purpose

Avoid accessing region with index -1 when region is not specified in `fix heat`.

## Author(s)

Anders Hafreager

## Implementation Notes

When the optional `region` keyword was not used in `fix heat`, `iregion` was -1 and used to access `domain->regions[iregion]`. Test for `iregion >= 0` first.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

