### PR TITLE
Update pair_smd_tlsph.cpp

### DIFF
--- a/src/USER-SMD/pair_smd_tlsph.cpp
+++ b/src/USER-SMD/pair_smd_tlsph.cpp
@@ -1066,7 +1066,7 @@ void PairTlsph::coeff(int narg, char **arg) {
 	Lookup[HEAT_CAPACITY][itype] = force->numeric(FLERR, arg[ioffset + 7]);
 
 	Lookup[LAME_LAMBDA][itype] = Lookup[YOUNGS_MODULUS][itype] * Lookup[POISSON_RATIO][itype]
-			/ ((1.0 + Lookup[POISSON_RATIO][itype] * (1.0 - 2.0 * Lookup[POISSON_RATIO][itype])));
+			/ ((1.0 + Lookup[POISSON_RATIO][itype]) * (1.0 - 2.0 * Lookup[POISSON_RATIO][itype]));
 	Lookup[SHEAR_MODULUS][itype] = Lookup[YOUNGS_MODULUS][itype] / (2.0 * (1.0 + Lookup[POISSON_RATIO][itype]));
 	Lookup[M_MODULUS][itype] = Lookup[LAME_LAMBDA][itype] + 2.0 * Lookup[SHEAR_MODULUS][itype];
 	Lookup[SIGNAL_VELOCITY][itype] = sqrt(


### PR DESCRIPTION
Correction of a typo in the computation of LAME_LAMBDA.

## Purpose

This is a bugfix that fixes the way the variable LAME_LAMBDA is calculated. The variable LAME_LAMBDA corresponds to the Lame parameter called lambda. This parameter should be equal to E/((1+nu)*(1-2*nu)) where E is the Young's modulus and nu the Poisson's ratio of the material. However, it was calculated as E/((1+nu*(1-2*nu))).

## Author(s)

Dr. Alban de Vaucorbeil, Monash University, Clayton, VIC, Australia

## Backward Compatibility

No problem

## Implementation Notes

The correctness of the fix was checked by matching the output of LAME_LAMBDA from the log file with its hand calculated value.



