### PR TITLE
added comm duplicate hint for final remap of pppm

### DIFF
--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -839,7 +839,7 @@ void PPPM::allocate()
   remap = new Remap(lmp,world,
                     nxlo_in,nxhi_in,nylo_in,nyhi_in,nzlo_in,nzhi_in,
                     nxlo_fft,nxhi_fft,nylo_fft,nyhi_fft,nzlo_fft,nzhi_fft,
-                    1,0,0,FFT_PRECISION,collective_flag);
+                    1,0,0,FFT_PRECISION,collective_flag,1);
 
   // create ghost grid object for rho and electric field communication
 

--- a/src/KSPACE/remap.h
+++ b/src/KSPACE/remap.h
@@ -64,7 +64,8 @@ void remap_3d(FFT_SCALAR *, FFT_SCALAR *, FFT_SCALAR *, struct remap_plan_3d *);
 struct remap_plan_3d *remap_3d_create_plan(MPI_Comm,
                                            int, int, int, int, int, int,
                                            int, int, int, int, int, int,
-                                           int, int, int, int, int);
+                                           int, int, int, int, int, 
+					   int hint_comm_dup = 0);
 void remap_3d_destroy_plan(struct remap_plan_3d *);
 int remap_3d_collide(struct extent_3d *,
                      struct extent_3d *, struct extent_3d *);

--- a/src/KSPACE/remap_wrap.cpp
+++ b/src/KSPACE/remap_wrap.cpp
@@ -25,12 +25,14 @@ Remap::Remap(LAMMPS *lmp, MPI_Comm comm,
              int out_ilo, int out_ihi, int out_jlo, int out_jhi,
              int out_klo, int out_khi,
              int nqty, int permute, int memory,
-             int precision, int usecollective) : Pointers(lmp)
+             int precision, int usecollective,
+	     int hint_comm_dup) : Pointers(lmp)
 {
   plan = remap_3d_create_plan(comm,
                               in_ilo,in_ihi,in_jlo,in_jhi,in_klo,in_khi,
                               out_ilo,out_ihi,out_jlo,out_jhi,out_klo,out_khi,
-                              nqty,permute,memory,precision,usecollective);
+                              nqty,permute,memory,precision,usecollective,
+			      hint_comm_dup);
   if (plan == NULL) error->one(FLERR,"Could not create 3d remap plan");
 }
 

--- a/src/KSPACE/remap_wrap.h
+++ b/src/KSPACE/remap_wrap.h
@@ -22,7 +22,8 @@ namespace LAMMPS_NS {
 class Remap : protected Pointers {
  public:
   Remap(class LAMMPS *, MPI_Comm,int,int,int,int,int,int,
-        int,int,int,int,int,int,int,int,int,int,int);
+        int,int,int,int,int,int,int,int,int,int,int,
+	int hint_comm_dup = 0);
   ~Remap();
   void perform(FFT_SCALAR *, FFT_SCALAR *, FFT_SCALAR *);
 


### PR DESCRIPTION
Contribution to PR 713 for branch comm-nprocs-opt: added remap hint to duplicate communicator mentioned in original mailing list posting.

Needs thorough testing and support added to other pppm styles (pppm/disp and pppm/kokkos).