### PR TITLE
lje_gpu_reinit: added missing return code

### DIFF
--- a/lib/gpu/lal_lj_expand_ext.cpp
+++ b/lib/gpu/lal_lj_expand_ext.cpp
@@ -110,6 +110,7 @@ int lje_gpu_reinit(const int ntypes, double **cutsq, double **host_lj1,
                    offset, shift);
     LJEMF.device->gpu_barrier();
   }
+  return 0;
 }
 
 void lje_gpu_clear() {


### PR DESCRIPTION
Found by [OpenSuse build bot](https://github.com/lammps/lammps/files/1442779/_log.txt).
