### PR TITLE
turn remap hint off by default; activate with 'kspace_modify remap/du…

### DIFF
--- a/doc/src/kspace_modify.txt
+++ b/doc/src/kspace_modify.txt
@@ -13,7 +13,7 @@ kspace_modify command :h3
 kspace_modify keyword value ... :pre
 
 one or more keyword/value pairs may be listed :ulb,l
-keyword = {mesh} or {order} or {order/disp} or {mix/disp} or {overlap} or {minorder} or {force} or {gewald} or {gewald/disp} or {slab} or (nozforce} or {compute} or {cutoff/adjust} or {fftbench} or {collective} or {diff} or {kmax/ewald} or {force/disp/real} or {force/disp/kspace} or {splittol} or {disp/auto}:l
+keyword = {mesh} or {order} or {order/disp} or {mix/disp} or {overlap} or {minorder} or {force} or {gewald} or {gewald/disp} or {slab} or (nozforce} or {compute} or {cutoff/adjust} or {fftbench} or {collective} or {remap/dup} or {diff} or {kmax/ewald} or {force/disp/real} or {force/disp/kspace} or {splittol} or {disp/auto}:l
   {mesh} value = x y z
     x,y,z = grid size in each dimension for long-range Coulombics
   {mesh/disp} value = x y z
@@ -40,6 +40,7 @@ keyword = {mesh} or {order} or {order/disp} or {mix/disp} or {overlap} or {minor
   {pressure/scalar} value = {yes} or {no}
   {fftbench} value = {yes} or {no}
   {collective} value = {yes} or {no}
+  {remap/dup} value = {yes} or {no}
   {diff} value = {ad} or {ik} = 2 or 4 FFTs for PPPM in smoothed or non-smoothed mode
   {kmax/ewald} value = kx ky kz
     kx,ky,kz = number of Ewald sum kspace vectors in each dimension
@@ -231,6 +232,13 @@ default, except on IBM BlueGene machines.  If this option is set to
 This is faster on IBM BlueGene machines, and may also be faster on
 other machines if they have an efficient implementation of MPI
 collective operations and adequate hardware.
+
+The {remap/dup} keyword applies only to PPPM.  It is set to {no} by
+default.  If this option is set to {yes}, LAMMPS will duplicate the
+MPI communicator in the final remap plan for 3d-FFT operations. In the
+final plan, this is much faster on a large number of MPI ranks than
+iteratively generating the list of all participating MPI ranks, which
+in this case is all MPI ranks in communicator.
 
 The {diff} keyword specifies the differentiation scheme used by the
 PPPM method to compute forces on particles given electrostatic

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -839,7 +839,7 @@ void PPPM::allocate()
   remap = new Remap(lmp,world,
                     nxlo_in,nxhi_in,nylo_in,nyhi_in,nzlo_in,nzhi_in,
                     nxlo_fft,nxhi_fft,nylo_fft,nyhi_fft,nzlo_fft,nzhi_fft,
-                    1,0,0,FFT_PRECISION,collective_flag,1);
+                    1,0,0,FFT_PRECISION,collective_flag,remapdup_flag);
 
   // create ghost grid object for rho and electric field communication
 

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -57,6 +57,10 @@ KSpace::KSpace(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   collective_flag = 0;
 #endif
 
+  // default is to iteratively generate list of participating MPI ranks
+
+  remapdup_flag = 0;
+
   kewaldflag = 0;
 
   order_6 = 5;
@@ -521,6 +525,12 @@ void KSpace::modify_params(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal kspace_modify command");
       if (strcmp(arg[iarg+1],"yes") == 0) collective_flag = 1;
       else if (strcmp(arg[iarg+1],"no") == 0) collective_flag = 0;
+      else error->all(FLERR,"Illegal kspace_modify command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"remap/dup") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal kspace_modify command");
+      if (strcmp(arg[iarg+1],"yes") == 0) remapdup_flag = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) remapdup_flag = 0;
       else error->all(FLERR,"Illegal kspace_modify command");
       iarg += 2;
     } else if (strcmp(arg[iarg],"diff") == 0) {

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -89,6 +89,7 @@ class KSpace : protected Pointers {
   int compute_flag;               // 0 if skip compute()
   int fftbench;                   // 0 if skip FFT timing
   int collective_flag;            // 1 if use MPI collectives for FFT/remap
+  int remapdup_flag;              // 1 if hint to duplicate MPI comm
   int stagger_flag;               // 1 if using staggered PPPM grids
 
   double splittol;                // tolerance for when to truncate splitting


### PR DESCRIPTION
Contribution to PR 713 for branch comm-nprocs-opt: set default to off for hint to duplicate MPI communicator in final remap plan. The hint can be turned on by user via 'kspace_modify remap/dup yes'.
