### PR TITLE
Allow the user at build time to override default KOKKOS_DEVICES and K…

### DIFF
--- a/src/MAKE/OPTIONS/Makefile.kokkos_cuda_mpi
+++ b/src/MAKE/OPTIONS/Makefile.kokkos_cuda_mpi
@@ -22,8 +22,8 @@ SIZE =		size
 ARCHIVE =	ar
 ARFLAGS =	-rc
 SHLIBFLAGS =	-shared
-KOKKOS_DEVICES = Cuda, OpenMP
-KOKKOS_ARCH =   Kepler35
+KOKKOS_DEVICES ?= Cuda, OpenMP
+KOKKOS_ARCH ?=   Kepler35
 
 # ---------------------------------------------------------------------
 # LAMMPS-specific settings, all OPTIONAL


### PR DESCRIPTION
…OKKOS_ARCH env vars.

## Purpose

This allows the user to explicitly override the KOKKOS_DEVICES and KOKKOS_ARCH env vars when running `make kokkos_cuda_openmpi`, as in `KOKKOS_DEVICES=Cuda KOKKOS_ARCH=Pascal61 make kokkos_cuda_openmpi`.  Previously, changing the architecture required altering the Makefiles.

## Author(s)

Brennon Brimhall, Fulton Supercomputing Laboratory, Brigham Young University

## Backward Compatibility

Fully backwards compatible.

## Implementation Notes

See diff.  It's pretty self-explanatory.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [X] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

None needed.