### PR TITLE
Set peratom_freq in fix ave/chunk

### DIFF
--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -63,6 +63,7 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
   strcpy(idchunk,arg[6]);
 
   global_freq = nfreq;
+  peratom_freq = nfreq;
   no_change_box = 1;
 
   // expand args if any have wildcard character "*"


### PR DESCRIPTION
## Purpose

Fix `ave/chunk` constructor did not copy `nfreq` into super class `peratom_freq`. Compute `global/atom` will then test 
[`if (update->ntimestep % modify->fix[value2index[m]]->peratom_freq)`](https://github.com/lammps/lammps/blob/master/src/compute_global_atom.cpp#L487)
which results in division by zero / arithmetic error if the fix is `ave/chunk`.

This PR fixes this issue.

## Author(s)

Anders Hafreager, Anders Johansson, University of Oslo

## Implementation Notes

Copy `nfreq` into `peratom_freq` in constructor.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
