### PR TITLE
Bugfix for effective plastic strain rate calculation

### DIFF
--- a/src/USER-SMD/pair_smd_tlsph.cpp
+++ b/src/USER-SMD/pair_smd_tlsph.cpp
@@ -775,9 +775,9 @@ void PairTlsph::AssembleStress() {
 
 				// compute a characteristic time over which to average the plastic strain
 				double tav = 1000 * radius[i] / (Lookup[SIGNAL_VELOCITY][itype]);
-				eff_plastic_strain_rate[i] -= eff_plastic_strain_rate[i] / tav;
-				eff_plastic_strain_rate[i] += (plastic_strain_increment / dt) / tav;
-				eff_plastic_strain_rate[i] = MAX(0.0, eff_plastic_strain_rate[i]);
+				eff_plastic_strain_rate[i] -= eff_plastic_strain_rate[i] * dt / tav;
+                                eff_plastic_strain_rate[i] += plastic_strain_increment / tav;
+                                eff_plastic_strain_rate[i] = MAX(0.0, eff_plastic_strain_rate[i]);
 
 				/*
 				 *  assemble total stress from pressure and deviatoric stress


### PR DESCRIPTION
## Purpose

The calculation of the effective plastic strain rate was supposed to follow the averaging scheme similar to that of a 1st order filter. i.e.
dEav/dt + Eav/tav = E/tav
where E, and Eav are the noisy variable, and the averaged (filtered) variable, respectively, and tav a time constant. 
In the case of the effective plastic strain rate, this equation yields:
(eff_plastic_strain_rate(current_step) - eff_plastic_strain_rate(previous_step))/dt + eff_plastic_strain_rate(previous_step)/tav = plastic_strain_rate_increment * 1/tav
 
where eff_plastic_strain_rate(current_step) and  eff_plastic_strain_rate(previous_step) are the effective plastic strain rate evaluated respectively at the current step, and the previous step, plastic_strain_rate_increment, the plastic strain rate increment, equal to:
plastic_strain_increment/dt.

Therefore, we should obtain:
eff_plastic_strain_rate(current_step) = eff_plastic_strain_rate(previous_step) - eff_plastic_strain_rate(previous_step)*dt/tav + plastic_strain_increment/tav.

The changes proposed here reflect this equation.

## Author(s)

Dr. Alban de Vaucorbeil, Monash University, Clayton, VIC, Australia

## Backward Compatibility

No problem

## Implementation Notes

It was observed that the proposed change fixes data that was noisy in space and time.