### PR TITLE
Fix broken charge history in fix qeq/reax/kk

### DIFF
--- a/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
@@ -255,6 +255,7 @@ int AtomVecHybridKokkos::pack_comm_kokkos(const int &n, const DAT::tdual_int_2d 
                      const int &pbc_flag, const int pbc[])
 {
   error->all(FLERR,"AtomVecHybridKokkos doesn't yet support threaded comm");
+  return 0;
 }
 void AtomVecHybridKokkos::unpack_comm_kokkos(const int &n, const int &nfirst,
                         const DAT::tdual_xfloat_2d &buf)
@@ -266,12 +267,14 @@ int AtomVecHybridKokkos::pack_comm_self(const int &n, const DAT::tdual_int_2d &l
                    const int &pbc_flag, const int pbc[])
 {
   error->all(FLERR,"AtomVecHybridKokkos doesn't yet support threaded comm");
+  return 0;
 }
 int AtomVecHybridKokkos::pack_border_kokkos(int n, DAT::tdual_int_2d k_sendlist,
                        DAT::tdual_xfloat_2d buf,int iswap,
                        int pbc_flag, int *pbc, ExecutionSpace space)
 {
   error->all(FLERR,"AtomVecHybridKokkos doesn't yet support threaded comm");
+  return 0;
 }
 void AtomVecHybridKokkos::unpack_border_kokkos(const int &n, const int &nfirst,
                           const DAT::tdual_xfloat_2d &buf,
@@ -286,12 +289,14 @@ int AtomVecHybridKokkos::pack_exchange_kokkos(const int &nsend,DAT::tdual_xfloat
                          X_FLOAT lo, X_FLOAT hi)
 {
   error->all(FLERR,"AtomVecHybridKokkos doesn't yet support threaded comm");
+  return 0;
 }
 int AtomVecHybridKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf, int nrecv,
                            int nlocal, int dim, X_FLOAT lo, X_FLOAT hi,
                            ExecutionSpace space)
 {
   error->all(FLERR,"AtomVecHybridKokkos doesn't yet support threaded comm");
+  return 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/fix_qeq_reax_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.cpp
@@ -392,19 +392,19 @@ void FixQEqReaxKokkos<DeviceType>::compute_h_item(int ii, int &m_fill, const boo
       const X_FLOAT delz = x(j,2) - ztmp;
 
       if (neighflag != FULL) {
+        // skip half of the interactions
         const tagint jtag = tag(j);
-        flag = 0;
-        if (j < nlocal) flag = 1;
-        else if (itag < jtag) flag = 1;
-        else if (itag == jtag) {
-          if (delz > SMALL) flag = 1;
-          else if (fabs(delz) < SMALL) {
-            if (dely > SMALL) flag = 1;
-            else if (fabs(dely) < SMALL && delx > SMALL)
-              flag = 1;
+        if (j >= nlocal) {
+          if (itag > jtag) {
+            if ((itag+jtag) % 2 == 0) continue;
+          } else if (itag < jtag) {
+            if ((itag+jtag) % 2 == 1) continue;
+          } else {
+            if (x(j,2) < ztmp) continue;
+            if (x(j,2) == ztmp && x(j,1)  < ytmp) continue;
+            if (x(j,2) == ztmp && x(j,1) == ytmp && x(j,0) < xtmp) continue;
           }
         }
-        if (!flag) continue;
       }
 
       const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;

--- a/src/KOKKOS/fix_qeq_reax_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.cpp
@@ -64,6 +64,10 @@ FixQEqReaxKokkos(LAMMPS *lmp, int narg, char **arg) :
   nmax = nmax = m_cap = 0;
   allocated_flag = 0;
   nprev = 4;
+
+  memory->destroy(s_hist);
+  memory->destroy(t_hist);
+  grow_arrays(atom->nmax);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/fix_qeq_reax_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.h
@@ -57,7 +57,7 @@ class FixQEqReaxKokkos : public FixQEqReax {
   void compute_h_item(int, int &, const bool &) const;
 
   KOKKOS_INLINE_FUNCTION
-  void mat_vec_item(int) const;
+  void matvec_item(int) const;
 
   KOKKOS_INLINE_FUNCTION
   void sparse12_item(int) const;
@@ -145,7 +145,7 @@ class FixQEqReaxKokkos : public FixQEqReax {
   void unpack_reverse_comm(int, int *, double *);
   double memory_usage();
 
- protected:
+ private:
   int inum;
   int allocated_flag;
 
@@ -210,6 +210,10 @@ class FixQEqReaxKokkos : public FixQEqReax {
   typename AT::t_int_2d d_sendlist;
   typename AT::t_xfloat_1d_um v_buf;
 
+  void grow_arrays(int);
+  void copy_arrays(int, int, int);
+  int pack_exchange(int, double *);
+  int unpack_exchange(int, double *);
 };
 
 template <class DeviceType>
@@ -235,7 +239,7 @@ struct FixQEqReaxKokkosMatVecFunctor  {
   };
   KOKKOS_INLINE_FUNCTION
   void operator()(const int ii) const {
-    c.mat_vec_item(ii);
+    c.matvec_item(ii);
   }
 };
 

--- a/src/USER-REAXC/fix_qeq_reax.h
+++ b/src/USER-REAXC/fix_qeq_reax.h
@@ -122,15 +122,15 @@ class FixQEqReax : public Fix {
   //int GMRES(double*,double*);
   virtual void sparse_matvec(sparse_matrix*,double*,double*);
 
-  int pack_forward_comm(int, int *, double *, int, int *);
-  void unpack_forward_comm(int, int, double *);
-  int pack_reverse_comm(int, int, double *);
-  void unpack_reverse_comm(int, int *, double *);
-  double memory_usage();
-  void grow_arrays(int);
-  void copy_arrays(int, int, int);
-  int pack_exchange(int, double *);
-  int unpack_exchange(int, double *);
+  virtual int pack_forward_comm(int, int *, double *, int, int *);
+  virtual void unpack_forward_comm(int, int, double *);
+  virtual int pack_reverse_comm(int, int, double *);
+  virtual void unpack_reverse_comm(int, int *, double *);
+  virtual double memory_usage();
+  virtual void grow_arrays(int);
+  virtual void copy_arrays(int, int, int);
+  virtual int pack_exchange(int, double *);
+  virtual int unpack_exchange(int, double *);
 
   virtual double parallel_norm( double*, int );
   virtual double parallel_dot( double*, double*, int );


### PR DESCRIPTION
## Purpose

The charge history in `fix qeq/reax/kk` wasn't being properly exchanged between processors, which led to a degraded convergence rate and required more iterations for the Kokkos version.

## Author(s)

Stan Moore

## Backward Compatibility

No issues