### PR TITLE
Collected bugfixes and updates for the next patch release

### DIFF
--- a/doc/src/Section_packages.txt
+++ b/doc/src/Section_packages.txt
@@ -732,7 +732,7 @@ make lib-latte args="-b -m gfortran"    # download and build in lib/latte and
 :pre
 
 Note that 3 symbolic (soft) links, "includelink" and "liblink" and
-"filelink", are created in lib/latte to point into the LATTE home dir.
+"filelink.o", are created in lib/latte to point into the LATTE home dir.
 When LAMMPS builds in src it will use these links.  You should 
 also check that the Makefile.lammps file you create is apporpriate
 for the compiler you use on your system to build LATTE.

--- a/doc/src/fix_neb.txt
+++ b/doc/src/fix_neb.txt
@@ -138,17 +138,17 @@ By default, no additional forces act on the first and last replicas
 during the NEB relaxation, so these replicas simply relax toward their
 respective local minima.  By using the key word {end}, additional
 forces can be applied to the first and/or last replicas, to enable
-them to relax toward a MEP while constraining their energy.
+them to relax toward a MEP while constraining their energy E to the
+target energy ETarget.
 
-The interatomic force Fi for the specified replica becomes:
+If ETarget>E, the interatomic force Fi for the specified replica becomes:
 
 Fi = -Grad(V) + (Grad(V) dot T' + (E-ETarget)*Kspring3) T',  {when} Grad(V) dot T' < 0
 Fi = -Grad(V) + (Grad(V) dot T' + (ETarget- E)*Kspring3) T', {when} Grad(V) dot T' > 0
 :pre
 
-where E is the current energy of the replica and ETarget is the target
-energy.  The "spring" constant on the difference in energies is the
-specified {Kspring3} value.
+The "spring" constant on the difference in energies is the specified
+{Kspring3} value.
 
 When {estyle} is specified as {first}, the force is applied to the
 first replica.  When {estyle} is specified as {last}, the force is
@@ -183,10 +183,9 @@ After converging a NEB calculation using an {estyle} of
 have a larger energy than the first replica. If this is not the case,
 the path is probably not a MEP.
 
-Finally, note that if the last replica converges toward a local
-minimum which has a larger energy than the energy of the first
-replica, a NEB calculation using an {estyle} of {last/efirst} or
-{last/efirst/middle} cannot reach final convergence.
+Finally, note that the last replica may never reach the target energy
+if it is stuck in a local minima which has a larger energy than the
+target energy.
 
 [Restart, fix_modify, output, run start/stop, minimize info:]
 

--- a/doc/src/fix_property_atom.txt
+++ b/doc/src/fix_property_atom.txt
@@ -155,7 +155,7 @@ these commands could be used:
 
 fix prop all property/atom mol
 variable cluster atom ((id-1)/10)+1
-set id * mol v_cluster :pre
+set atom * mol v_cluster :pre
 
 The "atom-style variable"_variable.html will create values for atoms
 with IDs 31,32,33,...40 that are 4.0,4.1,4.2,...,4.9.  When the

--- a/examples/python/funcs.py
+++ b/examples/python/funcs.py
@@ -8,17 +8,21 @@ def loop(N,cut0,thresh,lmpptr):
   from lammps import lammps
   lmp = lammps(ptr=lmpptr)
   natoms = lmp.get_natoms()
-  
-  for i in range(N):
-    cut = cut0 + i*0.1
 
-    lmp.set_variable("cut",cut)                 # set a variable in LAMMPS
+  try:
+    for i in range(N):
+      cut = cut0 + i*0.1
 
-    lmp.command("pair_style lj/cut ${cut}")     # LAMMPS command
-    #lmp.command("pair_style lj/cut %d" % cut)  # LAMMPS command option
+      lmp.set_variable("cut",cut)                 # set a variable in LAMMPS
 
-    lmp.command("pair_coeff * * 1.0 1.0")       # ditto
-    lmp.command("run 10")                       # ditto
-    pe = lmp.extract_compute("thermo_pe",0,0)   # extract total PE from LAMMPS
-    print("PE",pe/natoms,thresh)
-    if pe/natoms < thresh: return
+      lmp.command("pair_style lj/cut ${cut}")     # LAMMPS command
+      #lmp.command("pair_style lj/cut %d" % cut)  # LAMMPS command option
+
+      lmp.command("pair_coeff * * 1.0 1.0")       # ditto
+      lmp.command("run 10")                       # ditto
+      pe = lmp.extract_compute("thermo_pe",0,0)   # extract total PE from LAMMPS
+      print("PE",pe/natoms,thresh)
+      if pe/natoms < thresh: return
+  except Exception as e:
+    print("LOOP error:", e)
+

--- a/examples/python/in.python
+++ b/examples/python/in.python
@@ -28,6 +28,7 @@ python          simple here """
 from __future__ import print_function
 
 def simple():
+  foo = 0
   print("Inside simple function")
   try:
     foo += 1

--- a/lib/latte/README
+++ b/lib/latte/README
@@ -28,14 +28,15 @@ Instructions:
    and finally, build the code via the make command
    % make
 
-3. Create three soft links in this dir (lib/latte)
+3. Create three symbolic links in this dir (lib/latte)
    E.g if you built LATTE in this dir:
       % ln -s ./LATTE-master/src includelink
       % ln -s ./LATTE-master liblink
-      % ln -s ./LATTE-master/src/latte_c_bind.o filelink
+      % ln -s ./LATTE-master/src/latte_c_bind.o filelink.o
 
 4. Choose a Makefile.lammps.* file appropriate for your compiler
-   (GNU gfortran or Intel ifort) and copy it to Makefile.lammps.
+   (GNU gfortran with external BLAS, GNU gfortran with local liblinalg,
+   or Intel ifort with MKL) and copy it to Makefile.lammps.
    Note that you may need to edit Makefile.lammps for paths
    and compiler options appropriate to your system.
 
@@ -49,7 +50,7 @@ with the LATTE package installed:
 % make g++ (or whatever target you wish)
 
 Note that if you download and unpack a new LAMMPS tarball, the
-"includelink" and "liblink" and "filelink" files will be lost and you
-will need to re-create them (step 3).  If you built LATTE in this
-directory (as opposed to somewhere else on your system), you will also
-need to repeat steps 1,2,4.
+"includelink" and "liblink" and "filelink.o" symbolic links will be
+lost and you will need to re-create them (step 3).  If you built LATTE
+in this directory (as opposed to somewhere else on your system), you
+will also need to repeat steps 1,2,4.

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -969,6 +969,8 @@ void PPPMKokkos<DeviceType>::set_grid_global()
   if (!gewaldflag) {
     if (accuracy <= 0.0)
       error->all(FLERR,"KSpace accuracy must be > 0");
+    if (q2 == 0.0)
+      error->all(FLERR,"Must use 'kspace_modify gewald' for uncharged system");
     g_ewald = accuracy*sqrt(natoms*cutoff*xprd*yprd*zprd) / (2.0*q2);
     if (g_ewald >= 1.0) g_ewald = (1.35 - 0.15*log(accuracy))/cutoff;
     else g_ewald = sqrt(-log(g_ewald)) / cutoff;
@@ -1179,6 +1181,7 @@ double PPPMKokkos<DeviceType>::final_accuracy()
   double yprd = domain->yprd;
   double zprd = domain->zprd;
   bigint natoms = atomKK->natoms;
+  if (natoms == 0) natoms = 1; // avoid division by zero
 
   double df_kspace = compute_df_kspace();
   double q2_over_sqrt = q2 / sqrt(natoms*cutoff*xprd*yprd*zprd);

--- a/src/KSPACE/ewald.cpp
+++ b/src/KSPACE/ewald.cpp
@@ -154,6 +154,8 @@ void Ewald::init()
   if (!gewaldflag) {
     if (accuracy <= 0.0)
       error->all(FLERR,"KSpace accuracy must be > 0");
+    if (q2 == 0.0)
+      error->all(FLERR,"Must use 'kspace_modify gewald' for uncharged system");
     g_ewald = accuracy*sqrt(natoms*cutoff*xprd*yprd*zprd) / (2.0*q2);
     if (g_ewald >= 1.0) g_ewald = (1.35 - 0.15*log(accuracy))/cutoff;
     else g_ewald = sqrt(-log(g_ewald)) / cutoff;
@@ -340,6 +342,7 @@ void Ewald::setup()
 
 double Ewald::rms(int km, double prd, bigint natoms, double q2)
 {
+  if (natoms == 0) natoms = 1;   // avoid division by zero
   double value = 2.0*q2*g_ewald/prd *
     sqrt(1.0/(MY_PI*km*natoms)) *
     exp(-MY_PI*MY_PI*km*km/(g_ewald*g_ewald*prd*prd));

--- a/src/KSPACE/ewald_disp.cpp
+++ b/src/KSPACE/ewald_disp.cpp
@@ -193,6 +193,10 @@ void EwaldDisp::init()
 
   if (!gewaldflag) {
     if (function[0]) {
+      if (accuracy <= 0.0)
+        error->all(FLERR,"KSpace accuracy must be > 0");
+      if (q2 == 0.0)
+        error->all(FLERR,"Must use 'kspace_modify gewald' for uncharged system");
       g_ewald = accuracy*sqrt(natoms*(*cutoff)*shape_det(domain->h)) / (2.0*q2);
       if (g_ewald >= 1.0) g_ewald = (1.35 - 0.15*log(accuracy))/(*cutoff);
       else g_ewald = sqrt(-log(g_ewald)) / (*cutoff);
@@ -298,6 +302,7 @@ double EwaldDisp::rms(int km, double prd, bigint natoms,
                       double q2, double b2, double M2)
 {
   double value = 0.0;
+  if (natoms == 0) natoms = 1; // avoid division by zero
 
   // Coulombic
 

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -1268,6 +1268,7 @@ double PPPM::compute_qopt()
 double PPPM::estimate_ik_error(double h, double prd, bigint natoms)
 {
   double sum = 0.0;
+  if (natoms == 0) return 0.0;
   for (int m = 0; m < order; m++)
     sum += acons[order][m] * pow(h*g_ewald,2.0*m);
   double value = q2 * pow(h*g_ewald,(double)order) *

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -1004,6 +1004,8 @@ void PPPM::set_grid_global()
   if (!gewaldflag) {
     if (accuracy <= 0.0)
       error->all(FLERR,"KSpace accuracy must be > 0");
+    if (q2 == 0.0)
+      error->all(FLERR,"Must use kspace_modify gewald for uncharged system");
     g_ewald = accuracy*sqrt(natoms*cutoff*xprd*yprd*zprd) / (2.0*q2);
     if (g_ewald >= 1.0) g_ewald = (1.35 - 0.15*log(accuracy))/cutoff;
     else g_ewald = sqrt(-log(g_ewald)) / cutoff;
@@ -1346,6 +1348,7 @@ double PPPM::final_accuracy()
   double yprd = domain->yprd;
   double zprd = domain->zprd;
   bigint natoms = atom->natoms;
+  if (natoms == 0) natoms = 1; // avoid division by zero
 
   double df_kspace = compute_df_kspace();
   double q2_over_sqrt = q2 / sqrt(natoms*cutoff*xprd*yprd*zprd);

--- a/src/LATTE/README
+++ b/src/LATTE/README
@@ -17,7 +17,7 @@ Once you have successfully built LAMMPS with this package and the
 LATTE library you can test it using an input file from the examples
 latte dir, e.g.
 
-lmp_serial < lammps/examples/latte/in.latte.water
+lmp_serial -in lammps/examples/latte/in.latte.water
 
 This pair style was written in collaboration with the LATTE
 developers.

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,12 +17,12 @@ SHLINK = liblammps.so
 OBJDIR =   Obj_$@
 OBJSHDIR = Obj_shared_$@
 
-SRC =	$(filter-out library.cpp,$(wildcard *.cpp))
-INC =	$(filter-out library.h,$(wildcard *.h))
+SRC =	$(wildcard *.cpp)
+INC =	$(wildcard *.h)
 OBJ = 	$(SRC:.cpp=.o)
 
-SRCLIB = $(filter-out main.cpp,$(SRC)) library.cpp
-OBJLIB = $(filter-out main.o,$(OBJ)) library.o
+SRCLIB = $(filter-out main.cpp,$(SRC))
+OBJLIB = $(filter-out main.o,$(OBJ))
 
 # Command-line options for mode: exe (default), shexe, lib, shlib
 
@@ -176,7 +176,7 @@ help:
 	  then cp Makefile.package.settings.empty Makefile.package.settings; fi
 	@cp Makefile.package Makefile.package.settings $(objdir)
 	@cd $(objdir); rm -f .depend; \
-	$(MAKE) $(MFLAGS) "SRC = $(SRC) library.cpp" "INC = $(INC) library.h" depend || :
+	$(MAKE) $(MFLAGS) "SRC = $(SRC)" "INC = $(INC)" depend || :
 ifeq ($(mode),exe)
 	@cd $(objdir); \
 	$(MAKE) $(MFLAGS) "OBJ = $(OBJ)" "INC = $(INC)" "SHFLAGS =" \

--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -94,26 +94,26 @@ FixNEB::FixNEB(LAMMPS *lmp, int narg, char **arg) :
       if (iarg+3 > narg) error->all(FLERR,"Illegal fix neb command");
       if (strcmp(arg[iarg+1],"first") == 0) {
         FreeEndIni = true;
-	kspringIni = force->numeric(FLERR,arg[iarg+2]);
+        kspringIni = force->numeric(FLERR,arg[iarg+2]);
       } else if (strcmp(arg[iarg+1],"last") == 0) {
         FreeEndFinal = true;
         FinalAndInterWithRespToEIni = false;
         FreeEndFinalWithRespToEIni = false;
-	kspringFinal = force->numeric(FLERR,arg[iarg+2]);
+        kspringFinal = force->numeric(FLERR,arg[iarg+2]);
       } else if (strcmp(arg[iarg+1],"last/efirst") == 0) {
         FreeEndFinal = false;
         FinalAndInterWithRespToEIni = false;
         FreeEndFinalWithRespToEIni = true;
-	kspringFinal = force->numeric(FLERR,arg[iarg+2]);
+        kspringFinal = force->numeric(FLERR,arg[iarg+2]);
       } else if (strcmp(arg[iarg+1],"last/efirst/middle") == 0) {
         FreeEndFinal = false;
         FinalAndInterWithRespToEIni = true;
         FreeEndFinalWithRespToEIni = true;
-	kspringFinal = force->numeric(FLERR,arg[iarg+2]);
+        kspringFinal = force->numeric(FLERR,arg[iarg+2]);
       } else error->all(FLERR,"Illegal fix neb command");
 
       iarg += 3;
-    
+
     } else error->all(FLERR,"Illegal fix neb command");
   }
 
@@ -298,12 +298,14 @@ void FixNEB::min_post_force(int vflag)
   if (ireplica == 0) vIni=veng;
 
   if (FreeEndFinalWithRespToEIni) {
-    if (me == 0) {
+    if (cmode == SINGLE_PROC_DIRECT || cmode == SINGLE_PROC_MAP) {
       int procFirst;
       procFirst=universe->root_proc[0];
       MPI_Bcast(&vIni,1,MPI_DOUBLE,procFirst,uworld);
-    }
-    if (cmode == MULTI_PROC) {
+    }else {
+      if (me == 0)
+        MPI_Bcast(&vIni,1,MPI_DOUBLE,0,rootworld);
+
       MPI_Bcast(&vIni,1,MPI_DOUBLE,0,world);
     }
   }
@@ -313,8 +315,8 @@ void FixNEB::min_post_force(int vflag)
     //    if (me == 0 )
       if (update->ntimestep == 0) {
         EIniIni = veng;
-	//	if (cmode == MULTI_PROC)
-	// MPI_Bcast(&EIniIni,1,MPI_DOUBLE,0,world);
+        //      if (cmode == MULTI_PROC)
+        // MPI_Bcast(&EIniIni,1,MPI_DOUBLE,0,world);
       }
       }*/
 
@@ -360,7 +362,7 @@ void FixNEB::min_post_force(int vflag)
           tangent[i][2]=delzp;
           tlen += tangent[i][0]*tangent[i][0] +
             tangent[i][1]*tangent[i][1] + tangent[i][2]*tangent[i][2];
-          dot += f[i][0]*tangent[i][0] + f[i][1]*tangent[i][1] + 
+          dot += f[i][0]*tangent[i][0] + f[i][1]*tangent[i][1] +
             f[i][2]*tangent[i][2];
         }
       }
@@ -383,9 +385,9 @@ void FixNEB::min_post_force(int vflag)
           tangent[i][0]=delxn;
           tangent[i][1]=delyn;
           tangent[i][2]=delzn;
-          tlen += tangent[i][0]*tangent[i][0] + 
+          tlen += tangent[i][0]*tangent[i][0] +
             tangent[i][1]*tangent[i][1] + tangent[i][2]*tangent[i][2];
-          dot += f[i][0]*tangent[i][0] + f[i][1]*tangent[i][1] + 
+          dot += f[i][0]*tangent[i][0] + f[i][1]*tangent[i][1] +
             f[i][2]*tangent[i][2];
         }
       }
@@ -431,15 +433,15 @@ void FixNEB::min_post_force(int vflag)
         }
 
         nlen += delxn*delxn + delyn*delyn + delzn*delzn;
-        tlen += tangent[i][0]*tangent[i][0] + 
+        tlen += tangent[i][0]*tangent[i][0] +
           tangent[i][1]*tangent[i][1] + tangent[i][2]*tangent[i][2];
         gradlen += f[i][0]*f[i][0] + f[i][1]*f[i][1] + f[i][2]*f[i][2];
         dotpath += delxp*delxn + delyp*delyn + delzp*delzn;
-        dottangrad += tangent[i][0]*f[i][0] + 
+        dottangrad += tangent[i][0]*f[i][0] +
           tangent[i][1]*f[i][1] + tangent[i][2]*f[i][2];
-        gradnextlen += fnext[i][0]*fnext[i][0] + 
+        gradnextlen += fnext[i][0]*fnext[i][0] +
           fnext[i][1]*fnext[i][1] +fnext[i][2] * fnext[i][2];
-        dotgrad += f[i][0]*fnext[i][0] + f[i][1]*fnext[i][1] + 
+        dotgrad += f[i][0]*fnext[i][0] + f[i][1]*fnext[i][1] +
           f[i][2]*fnext[i][2];
 
         springF[i][0] = kspringPerp*(delxn-delxp);
@@ -514,9 +516,10 @@ void FixNEB::min_post_force(int vflag)
       MPI_Allreduce(&dot,&dotall,1,MPI_DOUBLE,MPI_SUM,world);
       dot=dotall/tlen;
 
-      if (dot<0) prefactor = -dot - kspringFinal*(veng-EFinalIni);
-      else prefactor = -dot + kspringFinal*(veng-EFinalIni);
-
+      if (veng<EFinalIni) {
+        if (dot<0) prefactor = -dot - kspringFinal*(veng-EFinalIni);
+        else prefactor = -dot + kspringFinal*(veng-EFinalIni);
+      }
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
           f[i][0] += prefactor *tangent[i][0];
@@ -531,10 +534,10 @@ void FixNEB::min_post_force(int vflag)
       double dotall;
       MPI_Allreduce(&dot,&dotall,1,MPI_DOUBLE,MPI_SUM,world);
       dot=dotall/tlen;
-
-      if (dot<0) prefactor = -dot - kspringFinal*(veng-vIni);
-      else prefactor = -dot + kspringFinal*(veng-vIni);
-
+      if (veng<vIni) {
+        if (dot<0) prefactor = -dot - kspringFinal*(veng-vIni);
+        else prefactor = -dot + kspringFinal*(veng-vIni);
+      }
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
           f[i][0] += prefactor *tangent[i][0];
@@ -589,7 +592,7 @@ void FixNEB::min_post_force(int vflag)
 
   for (int i = 0; i < nlocal; i++) {
     if (mask[i] & groupbit) {
-      dot += f[i][0]*tangent[i][0] + f[i][1]*tangent[i][1] + 
+      dot += f[i][0]*tangent[i][0] + f[i][1]*tangent[i][1] +
         f[i][2]*tangent[i][2];
       dotSpringTangent += springF[i][0]*tangent[i][0] +
         springF[i][1]*tangent[i][1] + springF[i][2]*tangent[i][2];}
@@ -625,11 +628,11 @@ void FixNEB::min_post_force(int vflag)
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      f[i][0] += prefactor*tangent[i][0] + 
+      f[i][0] += prefactor*tangent[i][0] +
         AngularContr*(springF[i][0] - dotSpringTangent*tangent[i][0]);
-      f[i][1] += prefactor*tangent[i][1] + 
+      f[i][1] += prefactor*tangent[i][1] +
         AngularContr*(springF[i][1] - dotSpringTangent*tangent[i][1]);
-      f[i][2] += prefactor*tangent[i][2] + 
+      f[i][2] += prefactor*tangent[i][2] +
         AngularContr*(springF[i][2] - dotSpringTangent*tangent[i][2]);
     }
 }

--- a/src/USER-INTEL/fix_intel.cpp
+++ b/src/USER-INTEL/fix_intel.cpp
@@ -34,6 +34,10 @@
 #include <stdio.h>
 #include <math.h>
 
+#ifdef LAMMPS_BIGBIG
+#error "The USER-INTEL package is not compatible with -DLAMMPS_BIGBIG"
+#endif
+
 #ifdef _LMP_INTEL_OFFLOAD
 #ifndef INTEL_OFFLOAD_NOAFFINITY
 #include <unistd.h>

--- a/src/USER-INTEL/pair_airebo_intel.cpp
+++ b/src/USER-INTEL/pair_airebo_intel.cpp
@@ -2165,9 +2165,7 @@ template<typename flt_t, typename acc_t>
 void ref_lennard_jones_single_atom(KernelArgsAIREBOT<flt_t,acc_t> * ka, int i,
 				   int morseflag) {
   AtomAIREBOT<flt_t> * x = ka->x;
-  tagint * tag = ka->tag;
   int jj;
-  tagint itag = tag[i];
   int * neighs = ka->neigh_lmp.entries + ka->neigh_lmp.offset[i];
   int jnum = ka->neigh_lmp.num_half[i];
   for (jj = 0; jj < jnum; jj++) {
@@ -3640,7 +3638,6 @@ static void aut_frebo_batch_of_kind(KernelArgsAIREBOT<flt_t,acc_t> * ka,
 				    int * i_buf, int * j_buf) {
  { // jump-scope for exceed_limits
   AtomAIREBOT<flt_t> * x = ka->x;
-  tagint * tag = ka->tag;
   int * map = ka->map;
   ResultForceT<acc_t> * result_f = ka->result_f;
   flt_t rcminij = ka->params.rcmin[itype][jtype];
@@ -4490,7 +4487,6 @@ exceed_limits:
 template<int MORSEFLAG>
 static void aut_lennard_jones(KernelArgsAIREBOT<flt_t,acc_t> * ka) {
   AtomAIREBOT<flt_t> * x = ka->x;
-  tagint * tag = ka->tag;
   int * map = ka->map;
   ResultForceT<acc_t> * result_f = ka->result_f;
   ivec c_i1 = ivec::set1(1);
@@ -4521,7 +4517,6 @@ static void aut_lennard_jones(KernelArgsAIREBOT<flt_t,acc_t> * ka) {
   int num_bo[2][2] = {0};
 
   for (int i = ka->frebo_from_atom; i < ka->frebo_to_atom; i++) {
-    ivec itag_bc = ivec::set1(tag[i]);
     int itype = map[x[i].w];
     fvec x_i = fvec::set1(x[i].x);
     fvec y_i = fvec::set1(x[i].y);

--- a/src/USER-INTEL/pair_airebo_intel.cpp
+++ b/src/USER-INTEL/pair_airebo_intel.cpp
@@ -127,7 +127,7 @@ struct KernelArgsAIREBOT {
   struct NeighListAIREBO neigh_rebo;
   PairAIREBOIntelParam<flt_t,acc_t> params;
   struct AtomAIREBOT<flt_t> * x; /* num_all */
-  int * tag; /* num_all */
+  tagint * tag; /* num_all */
   flt_t * nC, * nH; /* num_all */
   int * map; /* num_types+1 */
   struct ResultForceT<acc_t> * result_f; /* num_all */
@@ -399,7 +399,7 @@ void PairAIREBOIntel::eval(
   const int * _noalias const numneigh = list->numneigh;
   const int * _noalias const cnumneigh = buffers->cnumneigh(list);
   const int * _noalias const firstneigh = buffers->firstneigh(list);
-  int * const tag = atom->tag;
+  tagint * const tag = atom->tag;
 
   const int ntypes = atom->ntypes + 1;
   const int eatom = this->eflag_atom;
@@ -1912,10 +1912,10 @@ template<typename flt_t, typename acc_t>
 void ref_torsion(KernelArgsAIREBOT<flt_t,acc_t> * ka) {
   AtomAIREBOT<flt_t> * x = ka->x;
   int * map = ka->map;
-  int * tag = ka->tag;
+  tagint * tag = ka->tag;
   for (int ii = ka->frebo_from_atom; ii < ka->frebo_to_atom; ii++) {
     int i = ii;
-    int itag = tag[i];
+    tagint itag = tag[i];
     int itype = map[x[i].w];
     if (itype != 0) continue;
     flt_t xtmp = x[i].x;
@@ -1925,7 +1925,7 @@ void ref_torsion(KernelArgsAIREBOT<flt_t,acc_t> * ka) {
     int jnum = ka->neigh_rebo.num[i];
     for (int jj = 0; jj < jnum; jj++) {
       int j = REBO_neighs_i[jj];
-      int jtag = tag[j];
+      tagint jtag = tag[j];
 
       if (itag > jtag) {
         if (((itag+jtag) & 1) == 0) continue;
@@ -2039,9 +2039,9 @@ void ref_frebo_single_interaction(KernelArgsAIREBOT<flt_t,acc_t> * ka, int i,
 template<typename flt_t, typename acc_t>
 inline void ref_frebo_single_atom(KernelArgsAIREBOT<flt_t,acc_t> * ka, int i) {
   AtomAIREBOT<flt_t> * x = ka->x;
-  int * tag = ka->tag;
+  tagint * tag = ka->tag;
   int jj;
-  int itag = tag[i];
+  tagint itag = tag[i];
   flt_t x_i = x[i].x;
   flt_t y_i = x[i].y;
   flt_t z_i = x[i].z;
@@ -2049,7 +2049,7 @@ inline void ref_frebo_single_atom(KernelArgsAIREBOT<flt_t,acc_t> * ka, int i) {
   int jnum = ka->neigh_rebo.num[i];
   for (jj = 0; jj < jnum; jj++) {
     int j = neighs[jj];
-    int jtag = tag[j];
+    tagint jtag = tag[j];
     if (itag > jtag) {
       if (((itag + jtag) & 1) == 0)
         continue;
@@ -2165,9 +2165,9 @@ template<typename flt_t, typename acc_t>
 void ref_lennard_jones_single_atom(KernelArgsAIREBOT<flt_t,acc_t> * ka, int i,
 				   int morseflag) {
   AtomAIREBOT<flt_t> * x = ka->x;
-  int * tag = ka->tag;
+  tagint * tag = ka->tag;
   int jj;
-  int itag = tag[i];
+  tagint itag = tag[i];
   int * neighs = ka->neigh_lmp.entries + ka->neigh_lmp.offset[i];
   int jnum = ka->neigh_lmp.num_half[i];
   for (jj = 0; jj < jnum; jj++) {
@@ -3640,7 +3640,7 @@ static void aut_frebo_batch_of_kind(KernelArgsAIREBOT<flt_t,acc_t> * ka,
 				    int * i_buf, int * j_buf) {
  { // jump-scope for exceed_limits
   AtomAIREBOT<flt_t> * x = ka->x;
-  int * tag = ka->tag;
+  tagint * tag = ka->tag;
   int * map = ka->map;
   ResultForceT<acc_t> * result_f = ka->result_f;
   flt_t rcminij = ka->params.rcmin[itype][jtype];
@@ -3847,13 +3847,13 @@ exceed_limits:
 */
 static void aut_frebo(KernelArgsAIREBOT<flt_t,acc_t> * ka, int torflag) {
   AtomAIREBOT<flt_t> * _noalias x = ka->x;
-  int * _noalias tag = ka->tag;
+  tagint * _noalias tag = ka->tag;
   int * _noalias map = ka->map;
   int i_buf[2][2][fvec::VL];
   int j_buf[2][2][fvec::VL];
   int n_buf[2][2] = {0};
   for (int i = ka->frebo_from_atom; i < ka->frebo_to_atom; i++) {
-    int itag = tag[i];
+    tagint itag = tag[i];
     int itype = map[x[i].w];
     flt_t x_i = x[i].x;
     flt_t y_i = x[i].y;
@@ -3862,7 +3862,7 @@ static void aut_frebo(KernelArgsAIREBOT<flt_t,acc_t> * ka, int torflag) {
     int jnum = ka->neigh_rebo.num[i];
     for (int jj = 0; jj < jnum; jj++) {
       int j = neighs[jj];
-      int jtag = tag[j];
+      tagint jtag = tag[j];
       if (itag > jtag) {
         if (((itag + jtag) & 1) == 0)
           continue;
@@ -4490,7 +4490,7 @@ exceed_limits:
 template<int MORSEFLAG>
 static void aut_lennard_jones(KernelArgsAIREBOT<flt_t,acc_t> * ka) {
   AtomAIREBOT<flt_t> * x = ka->x;
-  int * tag = ka->tag;
+  tagint * tag = ka->tag;
   int * map = ka->map;
   ResultForceT<acc_t> * result_f = ka->result_f;
   ivec c_i1 = ivec::set1(1);

--- a/src/USER-OMP/fix_neigh_history_omp.cpp
+++ b/src/USER-OMP/fix_neigh_history_omp.cpp
@@ -98,7 +98,7 @@ void FixNeighHistoryOMP::pre_exchange_onesided()
     // nlocal can be larger if other fixes added atoms at this pre_exchange()
 
     // clear per-thread paged data structures
-    
+
     MyPage <tagint> &ipg = ipage_atom[tid];
     MyPage <double> &dpg = dpage_atom[tid];
     ipg.reset();
@@ -540,8 +540,8 @@ void FixNeighHistoryOMP::post_neighbor()
     int *allflags;
     double *allvalues;
 
-    MyPage <tagint> &ipg = ipage_atom[tid];
-    MyPage <double> &dpg = dpage_atom[tid];
+    MyPage <int> &ipg = ipage_neigh[tid];
+    MyPage <double> &dpg = dpage_neigh[tid];
     ipg.reset();
     dpg.reset();
 

--- a/src/USER-SMD/atom_vec_smd.cpp
+++ b/src/USER-SMD/atom_vec_smd.cpp
@@ -1099,7 +1099,7 @@ void AtomVecSMD::data_atom(double *coord, imageint imagetmp, char **values) {
  ------------------------------------------------------------------------- */
 
 int AtomVecSMD::data_atom_hybrid(int nlocal, char **values) {
-	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style tlsph");
+	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
 	return -1;
 }
 
@@ -1121,7 +1121,7 @@ void AtomVecSMD::data_vel(int m, char **values) {
  ------------------------------------------------------------------------- */
 
 int AtomVecSMD::data_vel_hybrid(int m, char **values) {
-	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style tlsph");
+	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
 	return 0;
 }
 
@@ -1159,7 +1159,7 @@ void AtomVecSMD::pack_data(double **buf) {
  ------------------------------------------------------------------------- */
 
 int AtomVecSMD::pack_data_hybrid(int i, double *buf) {
-	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style tlsph");
+	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
 	return -1;
 }
 
@@ -1181,7 +1181,7 @@ void AtomVecSMD::write_data(FILE *fp, int n, double **buf) {
  ------------------------------------------------------------------------- */
 
 int AtomVecSMD::write_data_hybrid(FILE *fp, double *buf) {
-	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style tlsph");
+	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
 	return -1;
 }
 
@@ -1204,7 +1204,7 @@ void AtomVecSMD::pack_vel(double **buf) {
  ------------------------------------------------------------------------- */
 
 int AtomVecSMD::pack_vel_hybrid(int i, double *buf) {
-	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style tlsph");
+	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
 	return 0;
 }
 
@@ -1223,7 +1223,7 @@ void AtomVecSMD::write_vel(FILE *fp, int n, double **buf) {
  ------------------------------------------------------------------------- */
 
 int AtomVecSMD::write_vel_hybrid(FILE *fp, double *buf) {
-	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style tlsph");
+	error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
 	return 3;
 }
 

--- a/src/USER-SMD/atom_vec_smd.cpp
+++ b/src/USER-SMD/atom_vec_smd.cpp
@@ -1215,8 +1215,7 @@ int AtomVecSMD::pack_vel_hybrid(int i, double *buf) {
 void AtomVecSMD::write_vel(FILE *fp, int n, double **buf) {
 	for (int i = 0; i < n; i++)
 		fprintf(fp, TAGINT_FORMAT
-		" %-1.16e %-1.16e %-1.16e %-1.16e %-1.16e %-1.16e\n", (tagint) ubuf(buf[i][0]).i, buf[i][1], buf[i][2], buf[i][3],
-				buf[i][4], buf[i][5], buf[i][6]);
+		" %-1.16e %-1.16e %-1.16e\n", (tagint) ubuf(buf[i][0]).i, buf[i][1], buf[i][2], buf[i][3]);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/create_bonds.cpp
+++ b/src/create_bonds.cpp
@@ -306,6 +306,10 @@ void CreateBonds::many()
               nadd_bonds,atom->nbonds);
     }
   }
+  // trigger clearing the list of available neighbor list requests
+  // and a full rebuild of them during the next run setup.
+  // otherwise the request from this command may linger around.
+  neighbor->init();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/create_bonds.cpp
+++ b/src/create_bonds.cpp
@@ -342,6 +342,7 @@ void CreateBonds::single_bond()
     bond_atom[m][num_bond[m]] = batom2;
     num_bond[m]++;
   }
+  ++atom->nbonds;
 
   if (force->newton_bond) return;
 
@@ -389,6 +390,7 @@ void CreateBonds::single_angle()
     angle_atom3[m][num_angle[m]] = aatom3;
     num_angle[m]++;
   }
+  ++atom->nangles;
 
   if (force->newton_bond) return;
 
@@ -452,6 +454,7 @@ void CreateBonds::single_dihedral()
     dihedral_atom4[m][num_dihedral[m]] = datom4;
     num_dihedral[m]++;
   }
+  ++atom->ndihedrals;
 
   if (force->newton_bond) return;
 

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -407,6 +407,10 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
       break;
     }
   }
+  // trigger clearing the list of available neighbor list requests
+  // and a full rebuild of them during the next run setup.
+  // otherwise the request from this command may linger around.
+  neighbor->init();
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

This pull request combines accumulated small bugfixes and updates

## Author(s)

Axel Kohlmeyer (Temple U)
Emile Maras (CEA, France)
Dr. Alban de Vaucorbeil, Monash University, Clayton, VIC, Australia
Stefan Paquay, (Brandeis U)

## Backward Compatibility

N/A

## Implementation Notes

- address a compilation issue for fix `neigh/history/omp` with `-DLAMMPS_BIGBIG`
- ditto for pair style `airebo/intel`, however, there are still fundamental issues leading to "data slicing" in `USER-INTEL`, so that compilation will now error out in compiling `fix_intel.cpp` with `-DLAMMPS_BIGBIG` defined; similar to `fix atc` from `USER-ATC`.
- bugfix/update for NEB from Emile Maras (see git log for details)
- bugfixes for `write_data` output with atom style `smd`. taken from PR #745 plus additional changes. this closes #745.
- documentation bugfix for `fix property/atom`
- add call to `neighbor->init()` at the end of methods in `delete_atoms` and `create_bonds` that request a neighbor list. thus will clear all neighbor list requests and thus avoid having the per-comment neighbor list being considered for re-use in the next run command.
- consistently refer to `filelink.o` in LATTE related docs and README files.
- avoid multiple cases of division by zero when using Ewald or PPPM on an empty or uncharged system. require using `kspace_modify gewald` in those cases as the estimator will fail.
- correctly tally added bonds/angles/dihedrals into global counters with `create_bonds single/*`, so that data files have correct headers. fixes bug reported by bernard rousseau on lammps-users: https://sourceforge.net/p/lammps/mailman/message/36180184/

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines




  
  
  
  