### PR TITLE
Fix property atom doc update

### DIFF
--- a/doc/src/fix_property_atom.txt
+++ b/doc/src/fix_property_atom.txt
@@ -111,7 +111,7 @@ need to communicate their new values to/from ghost atoms, an operation
 that can be invoked from within a "pair style"_pair_style.html or
 "fix"_fix.html or "compute"_compute.html that you write.
 
-NOTE: If this fix is defined _after_ the simulation box is created,
+NOTE: If this fix is defined [after] the simulation box is created,
 a 'run 0' command should be issued to properly initialize the storage
 created by this fix.
 

--- a/doc/src/fix_property_atom.txt
+++ b/doc/src/fix_property_atom.txt
@@ -111,6 +111,10 @@ need to communicate their new values to/from ghost atoms, an operation
 that can be invoked from within a "pair style"_pair_style.html or
 "fix"_fix.html or "compute"_compute.html that you write.
 
+NOTE: If this fix is defined _after_ the simulation box is created,
+a 'run 0' command should be issued to properly initialize the storage
+created by this fix.
+
 :line
 
 This fix is one of a small number that can be defined in an input
@@ -155,7 +159,7 @@ these commands could be used:
 
 fix prop all property/atom mol
 variable cluster atom ((id-1)/10)+1
-set id * mol v_cluster :pre
+set atom * mol v_cluster :pre
 
 The "atom-style variable"_variable.html will create values for atoms
 with IDs 31,32,33,...40 that are 4.0,4.1,4.2,...,4.9.  When the


### PR DESCRIPTION
## Purpose

This PR corrects the example set command in the fix property/atom docs and adds a note that explicitly states that a 'run 0' should be issued if the simulation box is already created.

## Author(s)

Stefan Paquay @ Brandeis University

## Backward Compatibility

Changes no code, only updates documentation to the currently working syntax.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [X] Suitable new documentation files and/or updates to the existing docs are included
- NA One or more example input decks are included
- NA The source code follows the LAMMPS formatting guidelines
