### PR TITLE
New "coeffs" keyword added to "info" command

### DIFF
--- a/doc/src/info.txt
+++ b/doc/src/info.txt
@@ -12,7 +12,7 @@ info command :h3
 
 info args :pre
 
-args = one or more of the following keywords: {out}, {all}, {system}, {memory}, {communication}, {computes}, {dumps}, {fixes}, {groups}, {regions}, {variables}, {styles}, {time}, or {configuration}
+args = one or more of the following keywords: {out}, {all}, {system}, {memory}, {communication}, {computes}, {dumps}, {fixes}, {groups}, {regions}, {variables}, {coeffs}, {styles}, {time}, or {configuration}
      {out} values = {screen}, {log}, {append} filename, {overwrite} filename
      {styles} values = {all}, {angle}, {atom}, {bond}, {compute}, {command}, {dump}, {dihedral}, {fix}, {improper}, {integrate}, {kspace}, {minimize}, {pair}, {region} :ul
 
@@ -80,6 +80,11 @@ selected.
 The {variables} category prints a list of all currently defined
 variables, their names, styles, definition and last computed value, if
 available.
+
+The {coeffs} category prints a list for each defined force style
+(pair, bond, angle, dihedral, improper) indicating which of the
+corresponding coefficients have been set. This can be very helpful
+to debug error messages like "All pair coeffs are not set".
 
 The {styles} category prints the list of styles available in the
 current LAMMPS binary. It supports one of the following options

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -28,6 +28,10 @@
 #include "force.h"
 #include "pair.h"
 #include "pair_hybrid.h"
+#include "bond.h"
+#include "angle.h"
+#include "dihedral.h"
+#include "improper.h"
 #include "group.h"
 #include "input.h"
 #include "modify.h"
@@ -75,20 +79,21 @@ enum {COMPUTES=1<<0,
       VARIABLES=1<<8,
       SYSTEM=1<<9,
       COMM=1<<10,
-      ATOM_STYLES=1<<11,
-      INTEGRATE_STYLES=1<<12,
-      MINIMIZE_STYLES=1<<13,
-      PAIR_STYLES=1<<14,
-      BOND_STYLES=1<<15,
-      ANGLE_STYLES=1<<16,
-      DIHEDRAL_STYLES=1<<17,
-      IMPROPER_STYLES=1<<18,
-      KSPACE_STYLES=1<<19,
-      FIX_STYLES=1<<20,
-      COMPUTE_STYLES=1<<21,
-      REGION_STYLES=1<<22,
-      DUMP_STYLES=1<<23,
-      COMMAND_STYLES=1<<24,
+      COEFFS=1<<11,
+      ATOM_STYLES=1<<12,
+      INTEGRATE_STYLES=1<<13,
+      MINIMIZE_STYLES=1<<14,
+      PAIR_STYLES=1<<15,
+      BOND_STYLES=1<<16,
+      ANGLE_STYLES=1<<17,
+      DIHEDRAL_STYLES=1<<18,
+      IMPROPER_STYLES=1<<19,
+      KSPACE_STYLES=1<<20,
+      FIX_STYLES=1<<21,
+      COMPUTE_STYLES=1<<22,
+      REGION_STYLES=1<<23,
+      DUMP_STYLES=1<<24,
+      COMMAND_STYLES=1<<25,
       ALL=~0};
 
 static const int STYLES = ATOM_STYLES | INTEGRATE_STYLES | MINIMIZE_STYLES
@@ -182,6 +187,9 @@ void Info::command(int narg, char **arg)
       ++idx;
     } else if (strncmp(arg[idx],"system",3) == 0) {
       flags |= SYSTEM;
+      ++idx;
+    } else if (strncmp(arg[idx],"coeffs",3) == 0) {
+      flags |= COEFFS;
       ++idx;
     } else if (strncmp(arg[idx],"styles",3) == 0) {
       if (idx+1 < narg) {
@@ -437,6 +445,69 @@ void Info::command(int narg, char **arg)
                   domain->xy, domain->xz, domain->yz);
     } else {
       fputs("\nBox has not yet been created\n",out);
+    }
+  }
+
+  if (domain->box_exist && (flags & COEFFS)) {
+    Pair *pair=force->pair;
+
+    fprintf(out,"\nCoeff information:\n");
+    if (pair) {
+      fprintf(out,"Pair Coeffs:\n");
+      for (int i=1; i <= atom->ntypes; ++i)
+        for (int j=i; j <= atom->ntypes; ++j) {
+          fprintf(out,"%3d %3d :",i,j);
+          if (pair->allocated && pair->setflag[i][j]) fputs(" is set\n",out);
+          else fputs (" is not set\n",out);
+        }
+    }
+    if (force->bond) {
+      Bond *bond=force->bond;
+
+      if (bond) {
+        fprintf(out,"Bond Coeffs:\n");
+        for (int i=1; i <= atom->nbondtypes; ++i) {
+          fprintf(out,"%3d :",i);
+          if (bond->allocated && bond->setflag[i]) fputs(" is set\n",out);
+          else fputs (" is not set\n",out);
+        }
+      }
+    }
+    if (force->angle) {
+      Angle *angle=force->angle;
+
+      if (angle) {
+        fprintf(out,"Angle Coeffs:\n");
+        for (int i=1; i <= atom->nangletypes; ++i) {
+          fprintf(out,"%3d :",i);
+          if (angle->allocated && angle->setflag[i]) fputs(" is set\n",out);
+          else fputs (" is not set\n",out);
+        }
+      }
+    }
+    if (force->dihedral) {
+      Dihedral *dihedral=force->dihedral;
+
+      if (dihedral) {
+        fprintf(out,"Dihedral Coeffs:\n");
+        for (int i=1; i <= atom->ndihedraltypes; ++i) {
+          fprintf(out,"%3d :",i);
+          if (dihedral->allocated && dihedral->setflag[i]) fputs(" is set\n",out);
+          else fputs (" is not set\n",out);
+        }
+      }
+    }
+    if (force->improper) {
+      Improper *b=force->improper;
+
+      if (b) {
+        fprintf(out,"Improper Coeffs:\n");
+        for (int i=1; i <= atom->nimpropertypes; ++i) {
+          fprintf(out,"%3d :",i);
+          if (b->allocated && b->setflag[i]) fputs(" is set\n",out);
+          else fputs (" is not set\n",out);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds a `coeffs` keyword to the `info` command.

## Purpose

This feature can help to pinpoint which coefficients exactly are unset when LAMMPS errors out with messages like "Not all pair coeffs are set", which seems to stump a lot of LAMMPS users. Example output for a faulty input would be:
```
Coeff information:
Pair Coeffs:
  1   1 : is not set
  1   2 : is set
  1   3 : is not set
  2   2 : is set
  2   3 : is set
  3   3 : is set
Bond Coeffs:
  1 : is not set
  2 : is set
```

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

Fully backward compatible

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines

