### PR TITLE
USER-INTEL: Adding compiler flag and small fix to tersoff/intel for 2…

### DIFF
--- a/src/MAKE/OPTIONS/Makefile.intel_cpu
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu
@@ -8,6 +8,7 @@ SHELL = /bin/sh
 
 CC =		mpiicpc 
 OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits
+                -qopt-zmm-usage=high
 CCFLAGS =	-qopenmp -qno-offload -fno-alias -ansi-alias -restrict \
                 -DLMP_INTEL_USELRT -DLMP_USE_MKL_RNG $(OPTFLAGS)
 SHFLAGS =	-fPIC

--- a/src/MAKE/OPTIONS/Makefile.intel_cpu_intelmpi
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu_intelmpi
@@ -8,6 +8,7 @@ SHELL = /bin/sh
 
 CC =		mpiicpc 
 OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits
+                -qopt-zmm-usage=high
 CCFLAGS =	-qopenmp -qno-offload -fno-alias -ansi-alias -restrict \
                 -DLMP_INTEL_USELRT -DLMP_USE_MKL_RNG $(OPTFLAGS)
 SHFLAGS =	-fPIC

--- a/src/MAKE/OPTIONS/Makefile.intel_cpu_mpich
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu_mpich
@@ -7,7 +7,8 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx -cxx=icc
-OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits
+OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits \
+                -qopt-zmm-usage=high
 CCFLAGS =	-qopenmp -qno-offload -fno-alias -ansi-alias -restrict \
                 -DLMP_INTEL_USELRT -DLMP_USE_MKL_RNG $(OPTFLAGS)
 SHFLAGS =	-fPIC

--- a/src/MAKE/OPTIONS/Makefile.intel_cpu_openmpi
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu_openmpi
@@ -8,7 +8,8 @@ SHELL = /bin/sh
 
 export OMPI_CXX = icc
 CC =		mpicxx
-OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits
+OPTFLAGS =      -xHost -O2 -fp-model fast=2 -no-prec-div -qoverride-limits \
+                -qopt-zmm-usage=high
 CCFLAGS =	-qopenmp -qno-offload -fno-alias -ansi-alias -restrict \
                 -DLMP_INTEL_USELRT -DLMP_USE_MKL_RNG $(OPTFLAGS)
 SHFLAGS =	-fPIC

--- a/src/USER-INTEL/pair_tersoff_intel.cpp
+++ b/src/USER-INTEL/pair_tersoff_intel.cpp
@@ -1372,7 +1372,7 @@ void IntelKernelTersoff<flt_t,acc_t,mic, pack_i>::attractive_vector(
   fvec vrij_hatx = vrijinv * vdijx;
   fvec vrij_haty = vrijinv * vdijy;
   fvec vrij_hatz = vrijinv * vdijz;
-  fvec rikinv = invsqrt(rsq2);
+  fvec rikinv = v::invsqrt(rsq2);
   fvec rik_hatx = rikinv * dikx;
   fvec rik_haty = rikinv * diky;
   fvec rik_hatz = rikinv * dikz;


### PR DESCRIPTION
…018u1 compilers.

## Purpose

Adding a flag to intel_cpu* Makefiles using the Intel compiler to prefer 512-bit AVX512 + a small fix in tersoff/intel to compile without errors on 2018 update 1 compilers.

## Author(s)

Mike Brown (Intel)

## Backward Compatibility

no

## Implementation Notes

N/A

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

N/A

