### PR TITLE
Fix bug in FixPropertyAtom

### DIFF
--- a/src/KOKKOS/fix_property_atom_kokkos.cpp
+++ b/src/KOKKOS/fix_property_atom_kokkos.cpp
@@ -31,6 +31,7 @@ FixPropertyAtomKokkos::FixPropertyAtomKokkos(LAMMPS *lmp, int narg, char **arg) 
   FixPropertyAtom(lmp, narg, arg)
 {
   atomKK = (AtomKokkos *) atom;
+  grow_arrays(atom->nmax);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -134,6 +134,8 @@ FixPropertyAtom::FixPropertyAtom(LAMMPS *lmp, int narg, char **arg) :
   // register with Atom class
 
   nmax_old = 0;
+  if (!lmp->kokkos)
+    grow_arrays(atom->nmax);
   atom->add_callback(0);
   atom->add_callback(1);
   if (border) atom->add_callback(2);
@@ -189,8 +191,6 @@ int FixPropertyAtom::setmask()
 
 void FixPropertyAtom::init()
 {
-  grow_arrays(atom->nmax);
-
   // error if atom style has changed since fix was defined
   // don't allow this b/c user could change to style that defines molecule,q
 


### PR DESCRIPTION
## Purpose
Fixes #759. This code is tricky because a child function (`FixProperyAtomKokkos::grow_arrays`) cannot be called inside the constructor of the base class (`FixProperyAtom`).

## Author(s)
Stan Moore

## Backward Compatibility
No issues