### PR TITLE
Added double quotes to a word in Section_tools.txt file

### DIFF
--- a/doc/src/Section_tools.txt
+++ b/doc/src/Section_tools.txt
@@ -177,7 +177,7 @@ doxygen tool :h4,link(doxygen)
 
 The tools/doxygen directory contains a shell script called
 doxygen.sh which can generate a call graph and API lists using
-the Doxygen_http://doxygen.org software.
+the "Doxygen"_http://doxygen.org software.
 
 See the included README file for details.
 


### PR DESCRIPTION
Added double quotes to a word in Section_tools.txt file in order to activate Sphinx hyperlink.

## Purpose

Small syntactic correction.

## Author(s)

Nandor Tamaskovics numericalfreedom AT googlemail.com

## Backward Compatibility

Full

## Implementation Notes

Documentation change only.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [X] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

No additional files.
