### PR TITLE
modifications to correctly print modified dihedrals, impropers

### DIFF
--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -274,7 +274,7 @@ void AtomVec::write_angle(FILE *fp, int n, tagint **buf, int index)
    pack dihedral info for data file
 ------------------------------------------------------------------------- */
 
-void AtomVec::pack_dihedral(tagint **buf)
+int AtomVec::pack_dihedral(tagint **buf)
 {
   tagint *tag = atom->tag;
   int *num_dihedral = atom->num_dihedral;
@@ -291,25 +291,31 @@ void AtomVec::pack_dihedral(tagint **buf)
   if (newton_bond) {
     for (i = 0; i < nlocal; i++)
       for (j = 0; j < num_dihedral[i]; j++) {
-        buf[m][0] = MAX(dihedral_type[i][j],-dihedral_type[i][j]);
-        buf[m][1] = dihedral_atom1[i][j];
-        buf[m][2] = dihedral_atom2[i][j];
-        buf[m][3] = dihedral_atom3[i][j];
-        buf[m][4] = dihedral_atom4[i][j];
+      	if (buf) {
+          buf[m][0] = MAX(dihedral_type[i][j],-dihedral_type[i][j]);
+          buf[m][1] = dihedral_atom1[i][j];
+          buf[m][2] = dihedral_atom2[i][j];
+          buf[m][3] = dihedral_atom3[i][j];
+          buf[m][4] = dihedral_atom4[i][j];
+        }
         m++;
       }
   } else {
     for (i = 0; i < nlocal; i++)
       for (j = 0; j < num_dihedral[i]; j++)
         if (tag[i] == dihedral_atom2[i][j]) {
-          buf[m][0] = MAX(dihedral_type[i][j],-dihedral_type[i][j]);
-          buf[m][1] = dihedral_atom1[i][j];
-          buf[m][2] = dihedral_atom2[i][j];
-          buf[m][3] = dihedral_atom3[i][j];
-          buf[m][4] = dihedral_atom4[i][j];
+          if (buf) {
+            buf[m][0] = MAX(dihedral_type[i][j],-dihedral_type[i][j]);
+            buf[m][1] = dihedral_atom1[i][j];
+            buf[m][2] = dihedral_atom2[i][j];
+            buf[m][3] = dihedral_atom3[i][j];
+            buf[m][4] = dihedral_atom4[i][j];
+          }
           m++;
         }
   }
+
+  return m;
 }
 
 /* ----------------------------------------------------------------------
@@ -330,7 +336,7 @@ void AtomVec::write_dihedral(FILE *fp, int n, tagint **buf, int index)
    pack improper info for data file
 ------------------------------------------------------------------------- */
 
-void AtomVec::pack_improper(tagint **buf)
+int AtomVec::pack_improper(tagint **buf)
 {
   tagint *tag = atom->tag;
   int *num_improper = atom->num_improper;
@@ -347,25 +353,31 @@ void AtomVec::pack_improper(tagint **buf)
   if (newton_bond) {
     for (i = 0; i < nlocal; i++)
       for (j = 0; j < num_improper[i]; j++) {
-        buf[m][0] = MAX(improper_type[i][j],-improper_type[i][j]);
-        buf[m][1] = improper_atom1[i][j];
-        buf[m][2] = improper_atom2[i][j];
-        buf[m][3] = improper_atom3[i][j];
-        buf[m][4] = improper_atom4[i][j];
+        if (buf) {
+          buf[m][0] = MAX(improper_type[i][j],-improper_type[i][j]);
+          buf[m][1] = improper_atom1[i][j];
+          buf[m][2] = improper_atom2[i][j];
+          buf[m][3] = improper_atom3[i][j];
+          buf[m][4] = improper_atom4[i][j];
+        }
         m++;
       }
   } else {
     for (i = 0; i < nlocal; i++)
       for (j = 0; j < num_improper[i]; j++)
         if (tag[i] == improper_atom2[i][j]) {
-          buf[m][0] = MAX(improper_type[i][j],-improper_type[i][j]);
-          buf[m][1] = improper_atom1[i][j];
-          buf[m][2] = improper_atom2[i][j];
-          buf[m][3] = improper_atom3[i][j];
-          buf[m][4] = improper_atom4[i][j];
+          if (buf) {
+            buf[m][0] = MAX(improper_type[i][j],-improper_type[i][j]);
+            buf[m][1] = improper_atom1[i][j];
+            buf[m][2] = improper_atom2[i][j];
+            buf[m][3] = improper_atom3[i][j];
+            buf[m][4] = improper_atom4[i][j];
+          }
           m++;
         }
   }
+
+  return m;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -291,7 +291,7 @@ int AtomVec::pack_dihedral(tagint **buf)
   if (newton_bond) {
     for (i = 0; i < nlocal; i++)
       for (j = 0; j < num_dihedral[i]; j++) {
-      	if (buf) {
+        if (buf) {
           buf[m][0] = MAX(dihedral_type[i][j],-dihedral_type[i][j]);
           buf[m][1] = dihedral_atom1[i][j];
           buf[m][2] = dihedral_atom2[i][j];

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -107,9 +107,9 @@ class AtomVec : protected Pointers {
   void write_bond(FILE *, int, tagint **, int);
   int pack_angle(tagint **);
   void write_angle(FILE *, int, tagint **, int);
-  void pack_dihedral(tagint **);
+  int pack_dihedral(tagint **);
   void write_dihedral(FILE *, int, tagint **, int);
-  void pack_improper(tagint **);
+  int pack_improper(tagint **);
   void write_improper(FILE *, int, tagint **, int);
 
   virtual int property_atom(char *) {return -1;}

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -152,8 +152,8 @@ void WriteData::write(char *file)
   if (natoms != atom->natoms && output->thermo->lostflag == ERROR)
     error->all(FLERR,"Atom count is inconsistent, cannot write data file");
 
-  // sum up bond,angle counts
-  // may be different than atom->nbonds,nangles if broken/turned-off
+  // sum up bond,angle,dihedral,improper counts
+  // may be different than atom->nbonds,nangles, etc. if broken/turned-off
 
   if (atom->molecular == 1 && (atom->nbonds || atom->nbondtypes)) {
     nbonds_local = atom->avec->pack_bond(NULL);
@@ -162,6 +162,16 @@ void WriteData::write(char *file)
   if (atom->molecular == 1 && (atom->nangles || atom->nangletypes)) {
     nangles_local = atom->avec->pack_angle(NULL);
     MPI_Allreduce(&nangles_local,&nangles,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  }
+
+  if (atom->molecular == 1 && (atom->ndihedrals || atom->ndihedraltypes)) {
+    ndihedrals_local = atom->avec->pack_dihedral(NULL);
+    MPI_Allreduce(&ndihedrals_local,&ndihedrals,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  }
+
+  if (atom->molecular == 1 && (atom->nimpropers || atom->nimpropertypes)) {
+    nimpropers_local = atom->avec->pack_improper(NULL);
+    MPI_Allreduce(&nimpropers_local,&nimpropers,1,MPI_LMP_BIGINT,MPI_SUM,world);
   }
 
   // open data file

--- a/src/write_data.h
+++ b/src/write_data.h
@@ -38,6 +38,8 @@ class WriteData : protected Pointers {
   FILE *fp;
   bigint nbonds_local,nbonds;
   bigint nangles_local,nangles;
+  bigint ndihedrals_local,ndihedrals;
+  bigint nimpropers_local,nimpropers;
 
   void header();
   void type_arrays();


### PR DESCRIPTION
## Purpose

Modifications needed to correctly print out new/changed dihedrals, impropers when the simulation modifies topology. For example, probably needed when using the current 'dtype' and 'itype' options in fix bond/create.

## Author(s)

Jacob Gissinger

## Backward Compatibility

Backward Compatible

## Implementation Notes

modified to match current implementation of bonds/angles

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included [none]
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


