### PR TITLE
Make the USER-ATC package depend on MANYBODY

### DIFF
--- a/src/USER-ATC/Install.sh
+++ b/src/USER-ATC/Install.sh
@@ -26,6 +26,16 @@ action () {
   fi
 }
 
+# ATC library has a reference to PairEAM, so we must
+# require the MANYBODY package to be installed.
+
+if (test $1 = 1) then
+  if (test ! -e ../pair_eam.cpp) then
+    echo "Must install MANYBODY package with USER-ATC"
+    exit 1
+  fi
+fi
+
 # all package files with no dependencies
 
 for file in *.cpp *.h; do


### PR DESCRIPTION
## Purpose

This modifies src/USER-ATC/Install.sh to add a dependency on PairEAM/MANYBODY for the installing USER-ATC package. In case pair_eam.cpp is not present, the install script aborts after printing a message asking to install the MANYBODY package.

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

n/a
