### PR TITLE
Dumping to multiple files failed with an error message complaining about a missing 'append yes' option.

### DIFF
--- a/doc/src/dump.txt
+++ b/doc/src/dump.txt
@@ -45,7 +45,7 @@ args = list of arguments for a particular style :l
   {xyz/gz} args = none
   {xyz/mpiio} args = none :pre
 
-{custom} or {custom/gz} or {custom/mpiio} args = list of atom attributes :l
+{custom} or {custom/gz} or {custom/mpiio} or {netcdf} or {netcdf/mpiio} args = list of atom attributes :l
     possible attributes = id, mol, proc, procp1, type, element, mass,
                           x, y, z, xs, ys, zs, xu, yu, zu,
                           xsu, ysu, zsu, ix, iy, iz,

--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -343,7 +343,7 @@ void DumpNetCDF::openfile()
       if (framei <= 0) framei = nframes+framei+1;
       if (framei < 1)  framei = 1;
     } else {
-      if (framei != 0)
+      if (framei != 0 && !multifile)
         error->all(FLERR,"at keyword requires use of 'append yes'");
 
       int dims[NC_MAX_VAR_DIMS];

--- a/src/USER-NETCDF/dump_netcdf_mpiio.cpp
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.cpp
@@ -342,7 +342,7 @@ void DumpNetCDFMPIIO::openfile()
     if (framei <= 0) framei = nframes+framei+1;
     if (framei < 1)  framei = 1;
   } else {
-    if (framei != 0)
+    if (framei != 0 && !multifile)
       error->all(FLERR,"at keyword requires use of 'append yes'");
 
     int dims[NC_MAX_VAR_DIMS];


### PR DESCRIPTION
## Purpose

Dumping to multiple files failed with an error message complaining about a missing 'append yes' option. This is an issue introduced and discussed with pull request #673.

For more information see discussion here:

https://github.com/lammps/lammps/pull/673

I also added netcdf and netcdf/mpiio to the list of dump styles supporting atom attributes in the documentation for 'dump'.

## Author(s)

Lars Pastewka, University of Freiburg

## Backward Compatibility

Does not break compatibility.