### PR TITLE
Consistent checking of Tersoff potential parameters

### DIFF
--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -507,14 +507,20 @@ void PairTersoff::read_file(char *file)
 
     params[nparams].powermint = int(params[nparams].powerm);
 
-    if (params[nparams].c < 0.0 || params[nparams].d < 0.0 ||
-        params[nparams].powern < 0.0 || params[nparams].beta < 0.0 ||
-        params[nparams].lam2 < 0.0 || params[nparams].bigb < 0.0 ||
-        params[nparams].bigr < 0.0 ||params[nparams].bigd < 0.0 ||
+    if (params[nparams].c < 0.0 ||
+        params[nparams].d < 0.0 ||
+        params[nparams].powern < 0.0 ||
+        params[nparams].beta < 0.0 ||
+        params[nparams].lam2 < 0.0 ||
+        params[nparams].bigb < 0.0 ||
+        params[nparams].bigr < 0.0 ||
+        params[nparams].bigd < 0.0 ||
         params[nparams].bigd > params[nparams].bigr ||
-        params[nparams].lam1 < 0.0 || params[nparams].biga < 0.0 ||
+        params[nparams].lam1 < 0.0 ||
+        params[nparams].biga < 0.0 ||
         params[nparams].powerm - params[nparams].powermint != 0.0 ||
-        (params[nparams].powermint != 3 && params[nparams].powermint != 1) ||
+        (params[nparams].powermint != 3 &&
+         params[nparams].powermint != 1) ||
         params[nparams].gamma < 0.0)
       error->all(FLERR,"Illegal Tersoff parameter");
 

--- a/src/MANYBODY/pair_tersoff_mod.cpp
+++ b/src/MANYBODY/pair_tersoff_mod.cpp
@@ -162,19 +162,23 @@ void PairTersoffMOD::read_file(char *file)
     params[nparams].c4 = atof(words[18]);
     params[nparams].c5 = atof(words[19]);
 
-    // currently only allow m exponent of 1
+    // currently only allow m exponent of 1 or 3
 
     params[nparams].powermint = int(params[nparams].powerm);
 
-    if (
-	params[nparams].lam3 < 0.0 || params[nparams].powern < 0.0 ||
-	params[nparams].beta < 0.0 || params[nparams].lam2 < 0.0 ||
-	params[nparams].bigb < 0.0 || params[nparams].bigr < 0.0 ||
-	params[nparams].bigd < 0.0 ||
-                               params[nparams].bigd > params[nparams].bigr ||
-	params[nparams].lam3 < 0.0 || params[nparams].biga < 0.0 ||
-	params[nparams].powerm - params[nparams].powermint != 0.0 ||
-    (params[nparams].powermint != 3 && params[nparams].powermint != 1))
+    if (params[nparams].powern < 0.0 ||
+        params[nparams].beta < 0.0 ||
+        params[nparams].lam2 < 0.0 ||
+        params[nparams].bigb < 0.0 ||
+        params[nparams].bigr < 0.0 ||
+        params[nparams].bigd < 0.0 ||
+        params[nparams].bigd > params[nparams].bigr ||
+        params[nparams].lam1 < 0.0 ||
+        params[nparams].biga < 0.0 ||
+        params[nparams].powerm - params[nparams].powermint != 0.0 ||
+        (params[nparams].powermint != 3 &&
+         params[nparams].powermint != 1)
+        )
       error->all(FLERR,"Illegal Tersoff parameter");
 
     nparams++;

--- a/src/MANYBODY/pair_tersoff_mod_c.cpp
+++ b/src/MANYBODY/pair_tersoff_mod_c.cpp
@@ -158,19 +158,24 @@ void PairTersoffMODC::read_file(char *file)
     params[nparams].c5 = atof(words[19]);
     params[nparams].c0 = atof(words[20]);
 
-    // currently only allow m exponent of 1
+    // currently only allow m exponent of 1 or 3
 
     params[nparams].powermint = int(params[nparams].powerm);
 
     if (
-	params[nparams].lam3 < 0.0 || params[nparams].powern < 0.0 ||
-	params[nparams].beta < 0.0 || params[nparams].lam2 < 0.0 ||
-	params[nparams].bigb < 0.0 || params[nparams].bigr < 0.0 ||
-	params[nparams].bigd < 0.0 ||
-                               params[nparams].bigd > params[nparams].bigr ||
-	params[nparams].lam3 < 0.0 || params[nparams].biga < 0.0 ||
-	params[nparams].powerm - params[nparams].powermint != 0.0 ||
-    (params[nparams].powermint != 3 && params[nparams].powermint != 1))
+      params[nparams].powern < 0.0 ||
+      params[nparams].beta < 0.0 ||
+      params[nparams].lam2 < 0.0 ||
+      params[nparams].bigb < 0.0 ||
+      params[nparams].bigr < 0.0 ||
+      params[nparams].bigd < 0.0 ||
+      params[nparams].bigd > params[nparams].bigr ||
+      params[nparams].lam1 < 0.0 ||
+      params[nparams].biga < 0.0 ||
+      params[nparams].powerm - params[nparams].powermint != 0.0 ||
+      (params[nparams].powermint != 3 &&
+       params[nparams].powermint != 1)
+      )
       error->all(FLERR,"Illegal Tersoff parameter");
 
     nparams++;

--- a/src/MANYBODY/pair_tersoff_zbl.cpp
+++ b/src/MANYBODY/pair_tersoff_zbl.cpp
@@ -184,19 +184,25 @@ void PairTersoffZBL::read_file(char *file)
 
     params[nparams].powermint = int(params[nparams].powerm);
 
-    if (
-        params[nparams].lam3 < 0.0 || params[nparams].c < 0.0 ||
-        params[nparams].d < 0.0 || params[nparams].powern < 0.0 ||
-        params[nparams].beta < 0.0 || params[nparams].lam2 < 0.0 ||
-        params[nparams].bigb < 0.0 || params[nparams].bigr < 0.0 ||
+    if (params[nparams].c < 0.0 ||
+        params[nparams].d < 0.0 ||
+        params[nparams].powern < 0.0 ||
+        params[nparams].beta < 0.0 ||
+        params[nparams].lam2 < 0.0 ||
+        params[nparams].bigb < 0.0 ||
+        params[nparams].bigr < 0.0 ||
         params[nparams].bigd < 0.0 ||
         params[nparams].bigd > params[nparams].bigr ||
-        params[nparams].lam3 < 0.0 || params[nparams].biga < 0.0 ||
+        params[nparams].lam1 < 0.0 ||
+        params[nparams].biga < 0.0 ||
         params[nparams].powerm - params[nparams].powermint != 0.0 ||
-        (params[nparams].powermint != 3 && params[nparams].powermint != 1) ||
+        (params[nparams].powermint != 3 &&
+         params[nparams].powermint != 1) ||
         params[nparams].gamma < 0.0 ||
-        params[nparams].Z_i < 1.0 || params[nparams].Z_j < 1.0 ||
-        params[nparams].ZBLcut < 0.0 || params[nparams].ZBLexpscale < 0.0)
+        params[nparams].Z_i < 1.0 ||
+        params[nparams].Z_j < 1.0 ||
+        params[nparams].ZBLcut < 0.0 ||
+        params[nparams].ZBLexpscale < 0.0)
       error->all(FLERR,"Illegal Tersoff parameter");
 
     nparams++;

--- a/src/USER-MISC/pair_tersoff_table.cpp
+++ b/src/USER-MISC/pair_tersoff_table.cpp
@@ -939,8 +939,10 @@ void PairTersoffTable::read_file(char *file)
     params[nparams].beta = atof(words[10]);
     params[nparams].lam2 = atof(words[11]);
     params[nparams].bigb = atof(words[12]);
+
     // current implementation is based on functional form
     // of tersoff_2 as reported in the reference paper
+
     double bigr = atof(words[13]);
     double bigd = atof(words[14]);
     params[nparams].cutoffR = bigr - bigd;
@@ -948,15 +950,17 @@ void PairTersoffTable::read_file(char *file)
     params[nparams].lam1 = atof(words[15]);
     params[nparams].biga = atof(words[16]);
 
-    // currently only allow m exponent of 1 or 3
-    params[nparams].powermint = int(params[nparams].powerm);
-
-    if (params[nparams].c < 0.0 || params[nparams].d < 0.0 ||
-        params[nparams].powern < 0.0 || params[nparams].beta < 0.0 ||
-        params[nparams].lam2 < 0.0 || params[nparams].bigb < 0.0 ||
-        params[nparams].cutoffR < 0.0 ||params[nparams].cutoffS < 0.0 ||
+    if (params[nparams].c < 0.0 ||
+        params[nparams].d < 0.0 ||
+        params[nparams].powern < 0.0 ||
+        params[nparams].beta < 0.0 ||
+        params[nparams].lam2 < 0.0 ||
+        params[nparams].bigb < 0.0 ||
+        params[nparams].cutoffR < 0.0 ||
+        params[nparams].cutoffS < 0.0 ||
         params[nparams].cutoffR > params[nparams].cutoffS ||
-        params[nparams].lam1 < 0.0 || params[nparams].biga < 0.0
+        params[nparams].lam1 < 0.0 ||
+        params[nparams].biga < 0.0
     ) error->all(FLERR,"Illegal Tersoff parameter");
 
     // only tersoff_2 parametrization is implemented

--- a/src/USER-OMP/pair_tersoff_zbl_omp.cpp
+++ b/src/USER-OMP/pair_tersoff_zbl_omp.cpp
@@ -205,18 +205,24 @@ void PairTersoffZBLOMP::read_file(char *file)
     params[nparams].powermint = int(params[nparams].powerm);
 
     if (
-        params[nparams].lam3 < 0.0 || params[nparams].c < 0.0 ||
-        params[nparams].d < 0.0 || params[nparams].powern < 0.0 ||
-        params[nparams].beta < 0.0 || params[nparams].lam2 < 0.0 ||
-        params[nparams].bigb < 0.0 || params[nparams].bigr < 0.0 ||
+        params[nparams].c < 0.0 ||
+        params[nparams].d < 0.0 ||
+        params[nparams].powern < 0.0 ||
+        params[nparams].beta < 0.0 ||
+        params[nparams].lam2 < 0.0 ||
+        params[nparams].bigb < 0.0 ||
+        params[nparams].bigr < 0.0 ||
         params[nparams].bigd < 0.0 ||
         params[nparams].bigd > params[nparams].bigr ||
-        params[nparams].lam3 < 0.0 || params[nparams].biga < 0.0 ||
+        params[nparams].biga < 0.0 ||
         params[nparams].powerm - params[nparams].powermint != 0.0 ||
-        (params[nparams].powermint != 3 && params[nparams].powermint != 1) ||
+        (params[nparams].powermint != 3 &&
+         params[nparams].powermint != 1) ||
         params[nparams].gamma < 0.0 ||
-        params[nparams].Z_i < 1.0 || params[nparams].Z_j < 1.0 ||
-        params[nparams].ZBLcut < 0.0 || params[nparams].ZBLexpscale < 0.0)
+        params[nparams].Z_i < 1.0 ||
+        params[nparams].Z_j < 1.0 ||
+        params[nparams].ZBLcut < 0.0 ||
+        params[nparams].ZBLexpscale < 0.0)
       error->all(FLERR,"Illegal Tersoff parameter");
 
     nparams++;


### PR DESCRIPTION

## Purpose

LAMMPS contains several Tersoff pair style variants. After reading the potential file, some consistency checks are performed on the parameters. However, there were some bugfixes for those check in the original Tersoff pair style that were not propagated to the variants and thus those would throw errors where they should not.

Also the readability of the code for that consistency check is improved.

## Author(s)

Aidan Thompson (SNL), Axel Kohlmeyer (ICTP)

## Backward Compatibility

Some correct inputs that failed with older LAMMPS using `tersoff/zbl` or `tersoff/mod` and alike should work now.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

