### PR TITLE
Sanity check on created/read-in bonds/angles/dihedrals/impropers

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1031,8 +1031,8 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
     }
     itype += type_offset;
 
-    if (atom1 <= 0 || atom1 > map_tag_max ||
-        atom2 <= 0 || atom2 > map_tag_max)
+    if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+        (atom2 <= 0) || (atom2 > map_tag_max) || (atom1 == atom2))
       error->one(FLERR,"Invalid atom ID in Bonds section of data file");
     if (itype <= 0 || itype > nbondtypes)
       error->one(FLERR,"Invalid bond type in Bonds section of data file");
@@ -1085,9 +1085,10 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
     }
     itype += type_offset;
 
-    if (atom1 <= 0 || atom1 > map_tag_max ||
-        atom2 <= 0 || atom2 > map_tag_max ||
-        atom3 <= 0 || atom3 > map_tag_max)
+    if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+        (atom2 <= 0) || (atom2 > map_tag_max) ||
+        (atom3 <= 0) || (atom3 > map_tag_max) ||
+        (atom1 == atom2) || (atom1 == atom3) || (atom2 == atom3))
       error->one(FLERR,"Invalid atom ID in Angles section of data file");
     if (itype <= 0 || itype > nangletypes)
       error->one(FLERR,"Invalid angle type in Angles section of data file");
@@ -1156,10 +1157,12 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
     }
     itype += type_offset;
 
-    if (atom1 <= 0 || atom1 > map_tag_max ||
-        atom2 <= 0 || atom2 > map_tag_max ||
-        atom3 <= 0 || atom3 > map_tag_max ||
-        atom4 <= 0 || atom4 > map_tag_max)
+    if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+        (atom2 <= 0) || (atom2 > map_tag_max) ||
+        (atom3 <= 0) || (atom3 > map_tag_max) ||
+        (atom4 <= 0) || (atom4 > map_tag_max) ||
+        (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
+        (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
       error->one(FLERR,"Invalid atom ID in Dihedrals section of data file");
     if (itype <= 0 || itype > ndihedraltypes)
       error->one(FLERR,
@@ -1243,10 +1246,12 @@ void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
     }
     itype += type_offset;
 
-    if (atom1 <= 0 || atom1 > map_tag_max ||
-        atom2 <= 0 || atom2 > map_tag_max ||
-        atom3 <= 0 || atom3 > map_tag_max ||
-        atom4 <= 0 || atom4 > map_tag_max)
+    if ((atom1 <= 0) || (atom1 > map_tag_max) ||
+        (atom2 <= 0) || (atom2 > map_tag_max) ||
+        (atom3 <= 0) || (atom3 > map_tag_max) ||
+        (atom4 <= 0) || (atom4 > map_tag_max) ||
+        (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
+        (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
       error->one(FLERR,"Invalid atom ID in Impropers section of data file");
     if (itype <= 0 || itype > nimpropertypes)
       error->one(FLERR,

--- a/src/create_bonds.cpp
+++ b/src/create_bonds.cpp
@@ -75,6 +75,8 @@ void CreateBonds::command(int narg, char **arg)
     btype = force->inumeric(FLERR,arg[1]);
     batom1 = force->tnumeric(FLERR,arg[2]);
     batom2 = force->tnumeric(FLERR,arg[3]);
+    if (batom1 == batom2)
+      error->all(FLERR,"Illegal create_bonds command");
     iarg = 4;
   } else if (strcmp(arg[0],"single/angle") == 0) {
     style = SANGLE;
@@ -83,6 +85,8 @@ void CreateBonds::command(int narg, char **arg)
     aatom1 = force->tnumeric(FLERR,arg[2]);
     aatom2 = force->tnumeric(FLERR,arg[3]);
     aatom3 = force->tnumeric(FLERR,arg[4]);
+    if ((aatom1 == aatom2) || (aatom1 == aatom3) || (aatom2 == aatom3))
+      error->all(FLERR,"Illegal create_bonds command");
     iarg = 5;
   } else if (strcmp(arg[0],"single/dihedral") == 0) {
     style = SDIHEDRAL;
@@ -92,6 +96,9 @@ void CreateBonds::command(int narg, char **arg)
     datom2 = force->tnumeric(FLERR,arg[3]);
     datom3 = force->tnumeric(FLERR,arg[4]);
     datom4 = force->tnumeric(FLERR,arg[5]);
+    if ((datom1 == datom2) || (datom1 == datom3) || (datom1 == datom4) ||
+        (datom2 == datom3) || (datom2 == datom4) || (datom3 == datom4))
+      error->all(FLERR,"Illegal create_bonds command");
     iarg = 6;
   } else error->all(FLERR,"Illegal create_bonds command");
 


### PR DESCRIPTION
## Purpose

When bonds, angles, dihedrals, or impropers are defined with tuples of non-unique atom IDs, LAMMPS should detect and disallow them. Currently LAMMPS usually exits with a cryptic "inconsistent bond count" error message.

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

compatible. should error out on incorrect inputs, that previously may have been accepted.

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines
