### PR TITLE
Replace OS provided XDR support with bundled code

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -170,13 +170,6 @@ if(ENABLE_KSPACE)
   endif()
 endif()
 
-if(ENABLE_MISC)
-  option(LAMMPS_XDR "include XDR compatibility files for doing particle dumps in XTC format" OFF)
-  if(LAMMPS_XDR)
-    add_definitions(-DLAMMPS_XDR) # for liblammps
-  endif()
-endif()
-
 if(ENABLE_MSCG OR ENABLE_USER-ATC OR ENABLE_USER-AWPMD OR ENABLE_USER-QUIP OR ENABLE_LATTE)
   find_package(LAPACK)
   if(NOT LAPACK_FOUND)

--- a/doc/src/Section_start.txt
+++ b/doc/src/Section_start.txt
@@ -259,7 +259,6 @@ within the LAMMPS code.  The options that are currently recognized are:
 -DLAMMPS_PNG
 -DLAMMPS_FFMPEG
 -DLAMMPS_MEMALIGN
--DLAMMPS_XDR
 -DLAMMPS_SMALLBIG
 -DLAMMPS_BIGBIG
 -DLAMMPS_SMALLSMALL
@@ -307,11 +306,6 @@ vector instructions of modern CPUS, since dynamically allocated memory
 has to be aligned on larger than default byte boundaries (e.g. 16
 bytes instead of 8 bytes on x86 type platforms) for optimal
 performance.
-
-If you use -DLAMMPS_XDR, the build will include XDR compatibility
-files for doing particle dumps in XTC format.  This is only necessary
-if your platform does have its own XDR files available.  See the
-Restrictions section of the "dump"_dump.html command for details.
 
 Use at most one of the -DLAMMPS_SMALLBIG, -DLAMMPS_BIGBIG,
 -DLAMMPS_SMALLSMALL settings.  The default is -DLAMMPS_SMALLBIG. These

--- a/doc/src/dump.txt
+++ b/doc/src/dump.txt
@@ -649,20 +649,7 @@ LAMMPS"_Section_start.html#start_3 section for more info.
 
 The {xtc} style is part of the MISC package.  It is only enabled if
 LAMMPS was built with that package.  See the "Making
-LAMMPS"_Section_start.html#start_3 section for more info.  This is
-because some machines may not support the low-level XDR data format
-that XTC files are written with, which will result in a compile-time
-error when a low-level include file is not found.  Putting this style
-in a package makes it easy to exclude from a LAMMPS build for those
-machines.  However, the MISC package also includes two compatibility
-header files and associated functions, which should be a suitable
-substitute on machines that do not have the appropriate native header
-files.  This option can be invoked at build time by adding
--DLAMMPS_XDR to the CCFLAGS variable in the appropriate low-level
-Makefile, e.g. src/MAKE/Makefile.foo.  This compatibility mode has
-been tested successfully on Cray XT3/XT4/XT5 and IBM BlueGene/L
-machines and should also work on IBM BG/P, and Windows XP/Vista/7
-machines.
+LAMMPS"_Section_start.html#start_3 section for more info.
 
 [Related commands:]
 

--- a/src/MISC/dump_xtc.h
+++ b/src/MISC/dump_xtc.h
@@ -21,13 +21,7 @@ DumpStyle(xtc,DumpXTC)
 #define LMP_DUMP_XTC_H
 
 #include "dump.h"
-
-#ifdef LAMMPS_XDR
 #include "xdr_compat.h"
-#else
-#include "rpc/rpc.h"
-#include "rpc/xdr.h"
-#endif
 
 namespace LAMMPS_NS {
 

--- a/src/MISC/xdr_compat.cpp
+++ b/src/MISC/xdr_compat.cpp
@@ -1,5 +1,3 @@
-#ifdef LAMMPS_XDR
-
 #include <stdlib.h>
 #include <limits.h>
 #include <string.h>
@@ -714,9 +712,3 @@ xdrstdio_putuint32 (XDR *xdrs, xdr_uint32_t *ip)
 }
 #endif
 
-#else
-/* satisfy compilers that do not like to compile empty files. */
-static void i_am_a_dummy_subroutine(void) {
-  return;
-}
-#endif


### PR DESCRIPTION
## Purpose

Dump xtc requires XDR data structures and functions for platform neutral binary encoding. These are part of Sun RPC, which is declared obsolete. In anticipation of Linux distributions moving support for XDR from libc to external libraries, we now always use the bundled compatibility code, which has been tested successfully on all current major architectures. This eliminates the need for the compilation option `-DLAMMPS_XDR` and closes #790

## Author(s)

Axel Kohlmeyer (ICTP) 

## Backward Compatibility

Full, for as long as xdr_compat.cpp can be compiled correctly. 

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines


