### PR TITLE
Added warning to discourage use of group all and fixed some segfault …

### DIFF
--- a/doc/src/fix_gcmc.txt
+++ b/doc/src/fix_gcmc.txt
@@ -95,14 +95,20 @@ which will result in roughly one MC move per atom or molecule
 per MC cycle.
 
 All inserted particles are always added to two groups: the default
-group "all" and the fix group specified in the fix command (which can
-also be "all"). In addition, particles are also added to any groups
+group "all" and the fix group specified in the fix command.
+In addition, particles are also added to any groups
 specified by the {group} and {grouptype} keywords.  If inserted
 particles are individual atoms, they are assigned the atom type given
 by the type argument.  If they are molecules, the type argument has no
 effect and must be set to zero. Instead, the type of each atom in the
 inserted molecule is specified in the file read by the
 "molecule"_molecule.html command.
+
+NOTE: Care should be taken to apply fix gcmc only to
+a group that contains only those atoms and molecules
+that you wish to manipulate using Monte Carlo.
+Hence it is generally not a good idea to specify
+the default group "all" in the fix command, although it is allowed.
 
 This fix cannot be used to perform GCMC insertions of gas atoms or
 molecules other than the exchanged type, but GCMC deletions,

--- a/examples/gcmc/in.gcmc.co2
+++ b/examples/gcmc/in.gcmc.co2
@@ -58,21 +58,21 @@ timestep        1.0
 
 # rigid constraints with thermostat 
 
-fix             myrigidnvt all rigid/nvt/small molecule temp ${temp} ${temp} 100 mol co2mol
+fix             myrigidnvt co2 rigid/nvt/small molecule temp ${temp} ${temp} 100 mol co2mol
 fix_modify	myrigidnvt dynamic/dof no
 
 # gcmc
 
 variable        tfac equal 5.0/3.0 # (3 trans + 2 rot)/(3 trans)
-fix             mygcmc all gcmc 100 100 0 0 54341 ${temp} ${mu} ${disp} mol &
+fix             mygcmc co2 gcmc 100 100 0 0 54341 ${temp} ${mu} ${disp} mol &
                 co2mol tfac_insert ${tfac} group co2 rigid myrigidnvt
 
 # atom counts
 
 variable 	carbon atom "type==1"
 variable        oxygen atom "type==2"
-group 		carbon dynamic all var carbon
-group 	        oxygen dynamic all var oxygen
+group 		carbon dynamic co2 var carbon
+group 	        oxygen dynamic co2 var oxygen
 variable        nC equal count(carbon)
 variable        nO equal count(oxygen)
 

--- a/examples/gcmc/in.gcmc.lj
+++ b/examples/gcmc/in.gcmc.lj
@@ -29,14 +29,18 @@ create_box	1 box
 pair_coeff	* * 1.0 1.0
 mass		* 1.0
 
+# we recommend setting up a dedicated group for gcmc
+
+group		gcmcgroup type 1
+
 # gcmc
 
-fix             mygcmc all gcmc 1 100 100 1 29494 ${temp} ${mu} ${disp}
+fix             mygcmc gcmcgroup gcmc 1 100 100 1 29494 ${temp} ${mu} ${disp}
 
 # atom count
 
 variable 	type1 atom "type==1"
-group 		type1 dynamic all var type1
+group 		type1 dynamic gcmcgroup var type1
 variable        n1 equal count(type1)
 
 # averaging

--- a/src/MC/fix_gcmc.h
+++ b/src/MC/fix_gcmc.h
@@ -57,7 +57,8 @@ class FixGCMC : public Fix {
   double memory_usage();
   void write_restart(FILE *);
   void restart(char *);
-
+  void grow_molecule_arrays(int);
+  
  private:
   int molecule_group,molecule_group_bit;
   int molecule_group_inversebit;
@@ -78,7 +79,7 @@ class FixGCMC : public Fix {
   bool full_flag;           // true if doing full system energy calculations
 
   int natoms_per_molecule;  // number of atoms in each inserted molecule
-  int nmaxmolcoords;        // number of atoms allocated for molcoords
+  int nmaxmolatoms;         // number of atoms allocated for molecule arrays
 
   int groupbitall;          // group bitmask for inserted atoms
   int ngroups;              // number of group-ids for inserted atoms
@@ -114,6 +115,8 @@ class FixGCMC : public Fix {
   int *local_gas_list;
   double **cutsq;
   double **molcoords;
+  double *molq;
+  imageint *molimage;
   imageint imagezero;
   double overlap_cutoffsq; // square distance cutoff for overlap 
   int overlap_flag;
@@ -223,6 +226,12 @@ W: Energy of old configuration in fix gcmc is > MAXENERGYTEST.
 
 This probably means that a pair of atoms are closer than the 
 overlap cutoff distance for keyword overlap_cutoff.
+
+W: Fix gcmc is being applied to the default group all
+
+This is allowed, but it will result in Monte Carlo moves
+being performed on all the atoms in the system, which is
+often not what is intended.
 
 E: Invalid atom type in fix gcmc command
 


### PR DESCRIPTION
…cases

## Purpose

Handling cases where user specified group all. Now issues a warning and also avoids
segfaults when molecules are bigger than the molecule insertion template.

## Author(s)

Aidan Thompson, Anders Hafreager

## Backward Compatibility

No issues in numeric output from examples. 

## Implementation Notes

This (unintentionally applying gcmc to the group all) seems to be a common mistake by users. I will change both the examples/gcmc examples to follow Anders' suggestion and add a note on the doc page and a WARNING to the code.
 
At the same time, there might be cases where the user wishes to delete a charged molecule other than the exchange molecule (why?), in which case the segfault is a bug. I will fix that too. I also found another similar issue with image flags array for molecule rotation.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links


