### PR TITLE
Link correction to the doxygen website in Section_tools.txt

### DIFF
--- a/doc/src/Section_tools.txt
+++ b/doc/src/Section_tools.txt
@@ -182,9 +182,11 @@ The tool is authored by Xiaowang Zhou (Sandia), xzhou at sandia.gov.
 
 doxygen tool :h4,link(doxygen)
 
+:link(doxygenwebsite,http://doxygen.org)
+
 The tools/doxygen directory contains a shell script called
 doxygen.sh which can generate a call graph and API lists using
-the "Doxygen"_http://doxygen.org software.
+the "Doxygen"_doxygenwebsite software.
 
 See the included README file for details.
 


### PR DESCRIPTION
Link correction to the doxygen website in Section_tools.txt, as SphinX does not like immediate URLs as link text complaining with red warning

## Purpose

Small error correction, now no red warning when "make html" is launched in the doc directory

## Author(s)

Nandor Tamaskovics, numericalfreedom AT googlemail.com

## Backward Compatibility

Full

## Implementation Notes

No computation results affected

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [X] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [X] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

No further information.


