### PR TITLE
correct the logic for checking if fix is right

### DIFF
--- a/src/USER-MISC/temper_npt.cpp
+++ b/src/USER-MISC/temper_npt.cpp
@@ -101,9 +101,9 @@ void TemperNPT::command(int narg, char **arg)
   // change the volume. This currently only applies to fix npt and
   // fix rigid/npt variants
 
-  if ((strncmp(modify->fix[whichfix]->style,"npt",3) == 0)
-      || (strncmp(modify->fix[whichfix]->style,"rigid/npt",9) == 0))
-    error->universe_all(FLERR,"Tempering temperature fix is not supported");
+  if ((strncmp(modify->fix[whichfix]->style,"npt",3) != 0)
+      && (strncmp(modify->fix[whichfix]->style,"rigid/npt",9) != 0))
+    error->universe_all(FLERR,"Tempering temperature and pressure fix is not supported");
 
   // setup for long tempering run
 


### PR DESCRIPTION
The previous version didn't use the correct logic for comparing fix styles, this version should appropriately check the acceptable fix styles for temper_npt

## Purpose

temper_npt needs to check that the fix style uses some kind of npt, currently the code had ((strncmp(modify->fix[whichfix]->style,"npt",3) == 0)
      || (strncmp(modify->fix[whichfix]->style,"rigid/npt",9) == 0))
    error->universe_all(FLERR,"Tempering temperature fix is not supported");

This was incorrect logic as strncmp returns zero if the strings match. It should be corrected so that if the fix style doesn't match  npt* and also the fix style doesn't match rigid/npt*, only then is the fix not supported. Also temper_npt requires the fix to specify temperature and pressure so I added pressure to the error output statement.

## Author(s)

Christopher Walker, ccwalker@ncsu.edu, and Amulya Pervaje, akpervaj@ncsu.edu

## Backward Compatibility

Previously, this temper_npt.cpp would not work as intended. It should work now.

## Implementation Notes

In the original submission,  the correct logic was used but the number of fixes was limited. This will be broad while allowing for original functionality

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
no change to documentation
- [ ] One or more example input decks are included
same example can be used
- [ ] The source code follows the LAMMPS formatting guidelines


## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_
