### PR TITLE
Update error.cpp

### DIFF
--- a/tools/pymol_asphere/src/error.cpp
+++ b/tools/pymol_asphere/src/error.cpp
@@ -13,7 +13,8 @@
 
 #include "error.h"
 #include <cstring>
- 
+#include <cstdlib>
+
 Notice::Notice() {
 	nullout=new ostream(NULL);
 	noteout=&cout;


### PR DESCRIPTION
When compiling with g++ (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18) an error occurs: 
error.cpp: In member function ‘void Error::generate_error(unsigned int, std::string, std::string)’:
error.cpp:146: error: ‘exit’ was not declared in this scope
The fix is to include the #include <cstdlib> where the exit() function is decleared in the error.cpp file

## Purpose

_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request. If this addresses an open GitHub Issue, mention the issue number, e.g. with `fixes #221` or `closes #135`, so that issue will be automatically closed when the pull request is merged_

## Author(s)

_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


