### PR TITLE
Wrong length of the box in the z-direction

### DIFF
--- a/tools/msi2lmp/src/ReadCarFile.c
+++ b/tools/msi2lmp/src/ReadCarFile.c
@@ -285,6 +285,11 @@ void ReadCarFile(void)
       box[2][0] =  B * cos_gamma; /* This is xy SLTM */
       box[2][1] =  C * cos_beta;  /* This is xz SLTM */
       box[2][2] =  C*(cos_alpha-cos_gamma*cos_beta)/sin_gamma; /* This is yz SLTM */
+       
+      // quick fix 
+      box[0][2] = -0.5*sqrt(sq_c - box[2][1]*box[2][1] - box[2][2]*box[2][2]) + center[2] + shift[2]; // low_z
+      box[1][2] =  0.5*sqrt(sq_c - box[2][1]*box[2][1] - box[2][2]*box[2][2]) + center[2] + shift[2]; // high_z
+
     }
   }
 


### PR DESCRIPTION
I am trying to convert a *car file to LAMMPS data file. The fifth line of the car file reads:
PBC   29.4000   32.4000  172.0000   48.5000   77.0000   63.5000 (P1)
The box dimensions that I get using the tool is 
   -14.700000000    14.700000000 xlo xhi
   -14.497936658    14.497936658 ylo yhi
   -83.634474945    83.634474945 zlo zhi
    14.456809145    38.691581347   108.059935409 xy xz yz
Using the relationships in section 6.12 it is expected that the length of the simulation box in the z-direction would be 128.1015687. Moreover, the initial dimension in the car file (a, b, c) cannot be recovered from these values. When I apply the patch I can recover the initial values.

## Purpose

_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request. If this addresses an open GitHub Issue, mention the issue number, e.g. with `fixes #221` or `closes #135`, so that issue will be automatically closed when the pull request is merged_

## Author(s)

_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


