### PR TITLE
added old tangent to fix_neb for AGNI potential

### DIFF
--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -425,11 +425,11 @@ void FixNEB::min_post_force(int vflag)
             tangent[i][0] = vmax*delxn + vmin*delxp;
             tangent[i][1] = vmax*delyn + vmin*delyp;
             tangent[i][2] = vmax*delzn + vmin*delzp;
-          } else if(vnext < vprev) {
+          } else if (vnext < vprev) {
             tangent[i][0] = vmin*delxn + vmax*delxp;
             tangent[i][1] = vmin*delyn + vmax*delyp;
             tangent[i][2] = vmin*delzn + vmax*delzp;
-          } else { //AGNI "old-tangent" method
+          } else { // vnext == vprev, e.g. for potentials that do not compute an energy
             tangent[i][0] = delxn + delxp;
             tangent[i][1] = delyn + delyp;
             tangent[i][2] = delzn + delzp;

--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -425,10 +425,14 @@ void FixNEB::min_post_force(int vflag)
             tangent[i][0] = vmax*delxn + vmin*delxp;
             tangent[i][1] = vmax*delyn + vmin*delyp;
             tangent[i][2] = vmax*delzn + vmin*delzp;
-          } else {
+          } else if(vnext < vprev) {
             tangent[i][0] = vmin*delxn + vmax*delxp;
             tangent[i][1] = vmin*delyn + vmax*delyp;
             tangent[i][2] = vmin*delzn + vmax*delzp;
+          } else { //AGNI "old-tangent" method
+            tangent[i][0] = delxn + delxp;
+            tangent[i][1] = delyn + delyp;
+            tangent[i][2] = delzn + delzp;
           }
         }
 


### PR DESCRIPTION
## Purpose
Implemented the old-tangent definition for nudged elastic band in src/Replica/fix_neb.cpp. The machine learning potential, AGNI, cannot predict energies, only forces. Therefore, the current implementation of NEB, which uses the image's potential terms to update spring and true force is not compatible.

## Author(s)

James Chapman

Georgia Institute of Technology, Department of Materials Science and Engineering 

## Backward Compatibility

Probably yes, as pair styles that can predict energy work fine (tested on Al_mishin.eam : eam/alloy).

## Implementation Notes
 I have simply added a conditional statement, that checks to see if neither of the required conditions for new tangent calculation have been met (potential term check), and if they have not (meaning all potential terms are zero), perform the old tangent calculation . 

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


