### PR TITLE
Tiny update to fix latte for checking library version

### DIFF
--- a/src/LATTE/fix_latte.cpp
+++ b/src/LATTE/fix_latte.cpp
@@ -39,6 +39,7 @@ extern "C" {
              double *, double *, double *, double *,
              double *, double *, double *, int*,
              double *, double *, double *, double *, bool *);
+  int latte_abiversion();
 }
 
 #define INVOKED_PERATOM 8
@@ -53,6 +54,9 @@ FixLatte::FixLatte(LAMMPS *lmp, int narg, char **arg) :
 
   if (comm->nprocs != 1)
     error->all(FLERR,"Fix latte currently runs only in serial");
+
+  if (20180207 != latte_abiversion())
+    error->all(FLERR,"LAMMPS is linked against incompatible LATTE library");
 
   if (narg != 4) error->all(FLERR,"Illegal fix latte command");
 


### PR DESCRIPTION
## Purpose

The LATTE folks just added a feature, that allows to query the ABI version of the library (currently 20180207, i.e. the date of the last change of the ABI). This PR adds a check for that to `fix latte`,
so that it will abort, when an incompatible change is required. The LAMMPS interface and the LATTE library interface must be at the same ABI and changed at the same time in the future.
This can be particularly problematic when only one of the two codes is updated, and particularly when somebody compiled/installed LATTE as a shared library.

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

It compiles/links with the current LATTE library as retrieved via lib/latte/Install.py today.

## Implementation Notes


## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

here is the merged pull request at the LATTE github site
https://github.com/lanl/LATTE/pull/24