### PR TITLE
Make default argument for pure method Integrate::setup() explicit

### DIFF
--- a/src/KOKKOS/verlet_kokkos.h
+++ b/src/KOKKOS/verlet_kokkos.h
@@ -31,7 +31,7 @@ class VerletKokkos : public Verlet {
  public:
   VerletKokkos(class LAMMPS *, int, char **);
   ~VerletKokkos() {}
-  void setup(int flag=1);
+  void setup(int);
   void setup_minimal(int);
   void run(int);
 

--- a/src/REPLICA/prd.cpp
+++ b/src/REPLICA/prd.cpp
@@ -293,7 +293,7 @@ void PRD::command(int narg, char **arg)
 
   update->whichflag = 1;
   lmp->init();
-  update->integrate->setup();
+  update->integrate->setup(1);
 
   if (temp_flag == 0) {
     if (universe->iworld == 0) temp_dephase = temperature->compute_scalar();
@@ -390,7 +390,7 @@ void PRD::command(int narg, char **arg)
 
     update->whichflag = 1;
     lmp->init();
-    update->integrate->setup();
+    update->integrate->setup(1);
 
     timer->barrier_start();
 
@@ -545,7 +545,7 @@ void PRD::dynamics(int nsteps, double &time_category)
   update->nsteps = nsteps;
 
   lmp->init();
-  update->integrate->setup();
+  update->integrate->setup(1);
   // this may be needed if don't do full init
   //modify->addstep_compute_all(update->ntimestep);
   bigint ncalls = neighbor->ncalls;

--- a/src/REPLICA/tad.cpp
+++ b/src/REPLICA/tad.cpp
@@ -264,7 +264,7 @@ void TAD::command(int narg, char **arg)
 
   update->whichflag = 1;
   lmp->init();
-  update->integrate->setup();
+  update->integrate->setup(1);
 
   // main loop: look for events until out of time
   // (1) dynamics, store state, quench, check event, restore state
@@ -342,7 +342,7 @@ void TAD::command(int narg, char **arg)
 
       update->whichflag = 1;
       lmp->init();
-      update->integrate->setup();
+      update->integrate->setup(1);
 
     // write restart file of hot coords
 
@@ -448,7 +448,7 @@ void TAD::dynamics()
   update->nsteps = t_event;
 
   lmp->init();
-  update->integrate->setup();
+  update->integrate->setup(1);
   // this may be needed if don't do full init
   //modify->addstep_compute_all(update->ntimestep);
   int ncalls = neighbor->ncalls;

--- a/src/REPLICA/temper.cpp
+++ b/src/REPLICA/temper.cpp
@@ -212,7 +212,7 @@ void Temper::command(int narg, char **arg)
   if (me_universe == 0 && universe->uscreen)
     fprintf(universe->uscreen,"Setting up tempering ...\n");
 
-  update->integrate->setup();
+  update->integrate->setup(1);
 
   if (me_universe == 0) {
     if (universe->uscreen) {

--- a/src/REPLICA/verlet_split.cpp
+++ b/src/REPLICA/verlet_split.cpp
@@ -239,13 +239,13 @@ void VerletSplit::init()
    servant partition only sets up KSpace calculation
 ------------------------------------------------------------------------- */
 
-void VerletSplit::setup()
+void VerletSplit::setup(int flag)
 {
   if (comm->me == 0 && screen)
     fprintf(screen,"Setting up Verlet/split run ...\n");
 
   if (!master) force->kspace->setup();
-  else Verlet::setup();
+  else Verlet::setup(flag);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/REPLICA/verlet_split.h
+++ b/src/REPLICA/verlet_split.h
@@ -29,7 +29,7 @@ class VerletSplit : public Verlet {
   VerletSplit(class LAMMPS *, int, char **);
   ~VerletSplit();
   void init();
-  void setup();
+  void setup(int);
   void setup_minimal(int);
   void run(int);
   bigint memory_usage();

--- a/src/USER-INTEL/verlet_lrt_intel.h
+++ b/src/USER-INTEL/verlet_lrt_intel.h
@@ -41,7 +41,7 @@ class VerletLRTIntel : public Verlet {
   VerletLRTIntel(class LAMMPS *, int, char **);
   virtual ~VerletLRTIntel();
   virtual void init();
-  virtual void setup(int flag = 1);
+  virtual void setup(int flag);
   virtual void run(int);
 
  protected:

--- a/src/USER-MISC/temper_grem.cpp
+++ b/src/USER-MISC/temper_grem.cpp
@@ -214,7 +214,7 @@ void TemperGrem::command(int narg, char **arg)
   if (me_universe == 0 && universe->uscreen)
     fprintf(universe->uscreen,"Setting up tempering ...\n");
 
-  update->integrate->setup();
+  update->integrate->setup(1);
 
   if (me_universe == 0) {
     if (universe->uscreen) {

--- a/src/USER-MISC/temper_npt.cpp
+++ b/src/USER-MISC/temper_npt.cpp
@@ -190,7 +190,7 @@ void TemperNPT::command(int narg, char **arg)
   if (me_universe == 0 && universe->uscreen)
     fprintf(universe->uscreen,"Setting up tempering ...\n");
 
-  update->integrate->setup();
+  update->integrate->setup(1);
 
   if (me_universe == 0) {
     if (universe->uscreen) {

--- a/src/USER-OMP/respa_omp.cpp
+++ b/src/USER-OMP/respa_omp.cpp
@@ -67,24 +67,26 @@ void RespaOMP::init()
    setup before run
 ------------------------------------------------------------------------- */
 
-void RespaOMP::setup()
+void RespaOMP::setup(int flag)
 {
   if (comm->me == 0 && screen) {
     fprintf(screen,"Setting up r-RESPA/omp run ...\n");
-    fprintf(screen,"  Unit style    : %s\n", update->unit_style);
-    fprintf(screen,"  Current step  : " BIGINT_FORMAT "\n", update->ntimestep);
-    fprintf(screen,"  Time steps    :");
-    for (int ilevel=0; ilevel < nlevels; ++ilevel)
-      fprintf(screen," %d:%g",ilevel+1, step[ilevel]);
-    fprintf(screen,"\n  r-RESPA fixes :");
-    for (int l=0; l < modify->n_post_force_respa; ++l) {
-      Fix *f = modify->fix[modify->list_post_force_respa[l]];
-      if (f->respa_level >= 0)
-        fprintf(screen," %d:%s[%s]",
-                MIN(f->respa_level+1,nlevels),f->style,f->id);
+    if (flag) {
+      fprintf(screen,"  Unit style    : %s\n", update->unit_style);
+      fprintf(screen,"  Current step  : " BIGINT_FORMAT "\n", update->ntimestep);
+      fprintf(screen,"  Time steps    :");
+      for (int ilevel=0; ilevel < nlevels; ++ilevel)
+        fprintf(screen," %d:%g",ilevel+1, step[ilevel]);
+      fprintf(screen,"\n  r-RESPA fixes :");
+      for (int l=0; l < modify->n_post_force_respa; ++l) {
+        Fix *f = modify->fix[modify->list_post_force_respa[l]];
+        if (f->respa_level >= 0)
+          fprintf(screen," %d:%s[%s]",
+                  MIN(f->respa_level+1,nlevels),f->style,f->id);
+      }
+      fprintf(screen,"\n");
+      timer->print_timeout(screen);
     }
-    fprintf(screen,"\n");
-    timer->print_timeout(screen);
   }
 
   update->setupflag = 1;

--- a/src/USER-OMP/respa_omp.h
+++ b/src/USER-OMP/respa_omp.h
@@ -30,7 +30,7 @@ class RespaOMP : public Respa, public ThrOMP {
   RespaOMP(class LAMMPS *, int, char **);
   virtual ~RespaOMP() {}
   virtual void init();
-  virtual void setup();
+  virtual void setup(int);
   virtual void setup_minimal(int);
 
  protected:

--- a/src/integrate.h
+++ b/src/integrate.h
@@ -23,7 +23,7 @@ class Integrate : protected Pointers {
   Integrate(class LAMMPS *, int, char **);
   virtual ~Integrate();
   virtual void init();
-  virtual void setup(int flag=1) = 0;
+  virtual void setup(int flag) = 0;
   virtual void setup_minimal(int) = 0;
   virtual void run(int) = 0;
   virtual void cleanup() {}

--- a/src/respa.h
+++ b/src/respa.h
@@ -48,7 +48,7 @@ class Respa : public Integrate {
   Respa(class LAMMPS *, int, char **);
   virtual ~Respa();
   virtual void init();
-  virtual void setup(int flag=1);
+  virtual void setup(int);
   virtual void setup_minimal(int);
   virtual void run(int);
   virtual void cleanup();

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -175,7 +175,7 @@ void Run::command(int narg, char **arg)
 
     if (preflag || update->first_update == 0) {
       lmp->init();
-      update->integrate->setup();
+      update->integrate->setup(1);
     } else output->setup(0);
 
     timer->init();
@@ -216,7 +216,7 @@ void Run::command(int narg, char **arg)
 
       if (preflag || iter == 0) {
         lmp->init();
-        update->integrate->setup();
+        update->integrate->setup(1);
       } else output->setup(0);
 
       timer->init();

--- a/src/verlet.h
+++ b/src/verlet.h
@@ -29,7 +29,7 @@ class Verlet : public Integrate {
   Verlet(class LAMMPS *, int, char **);
   virtual ~Verlet() {}
   virtual void init();
-  virtual void setup(int flag=1);
+  virtual void setup(int flag);
   virtual void setup_minimal(int);
   virtual void run(int);
   void cleanup();


### PR DESCRIPTION
## Purpose

Using default arguments in polymorph methods may lead to unexpected and unwanted overloading and thus hiding of methods in derived classes. This is for the `Integrate::setup()` method which results in setup becoming an unexpected overload in`VerletSplit` and `RespaOMP`, which may explain reports of verlet/split being broken.

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

no user visible change, but internally, all code must now use integrate->setup(0) or integrate->setup(1), with the latter implemented current behavior.

## Implementation Notes

All instances of integrate->setup() were replaced with integrate->setup(1) to result in the same behavior as with the default argument flag=1.
## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


