### PR TITLE
Make default argument for virtual method Neighbor::build() explicit

### DIFF
--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -119,7 +119,7 @@ void VerletKokkos::setup(int flag)
 
   atomKK->modified(Host,ALL_MASK);
 
-  neighbor->build();
+  neighbor->build(1);
   neighbor->ncalls = 0;
 
   // compute all forces
@@ -222,7 +222,7 @@ void VerletKokkos::setup_minimal(int flag)
 
     atomKK->modified(Host,ALL_MASK);
 
-    neighbor->build();
+    neighbor->build(1);
     neighbor->ncalls = 0;
   }
 
@@ -378,7 +378,7 @@ void VerletKokkos::run(int n)
         modify->pre_neighbor();
         timer->stamp(Timer::MODIFY);
       }
-      neighbor->build();
+      neighbor->build(1);
       timer->stamp(Timer::NEIGH);
     }
 

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -316,7 +316,7 @@ void FixAtomSwap::pre_exchange()
   comm->borders();
   if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
   if (modify->n_pre_neighbor) modify->pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
 
   energy_stored = energy_full();
 
@@ -366,7 +366,7 @@ int FixAtomSwap::attempt_semi_grand()
     comm->borders();
     if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
     if (modify->n_pre_neighbor) modify->pre_neighbor();
-    neighbor->build();
+    neighbor->build(1);
   } else {
     comm->forward_comm_fix(this);
   }
@@ -408,7 +408,7 @@ int FixAtomSwap::attempt_semi_grand()
       comm->borders();
       if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
       if (modify->n_pre_neighbor) modify->pre_neighbor();
-      neighbor->build();
+      neighbor->build(1);
     } else {
       comm->forward_comm_fix(this);
     }
@@ -447,7 +447,7 @@ int FixAtomSwap::attempt_swap()
     comm->borders();
     if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
     if (modify->n_pre_neighbor) modify->pre_neighbor();
-    neighbor->build();
+    neighbor->build(1);
   } else {
     comm->forward_comm_fix(this);
   }
@@ -489,7 +489,7 @@ int FixAtomSwap::attempt_swap()
       comm->borders();
       if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
       if (modify->n_pre_neighbor) modify->pre_neighbor();
-      neighbor->build();
+      neighbor->build(1);
     } else {
       comm->forward_comm_fix(this);
     }

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -2250,7 +2250,7 @@ double FixGCMC::energy_full()
   comm->borders();
   if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
   if (modify->n_pre_neighbor) modify->pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
   int eflag = 1;
   int vflag = 0;
 

--- a/src/REPLICA/verlet_split.cpp
+++ b/src/REPLICA/verlet_split.cpp
@@ -344,7 +344,7 @@ void VerletSplit::run(int n)
         if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
         timer->stamp(Timer::COMM);
         if (n_pre_neighbor) modify->pre_neighbor();
-        neighbor->build();
+        neighbor->build(1);
         timer->stamp(Timer::NEIGH);
       }
     }

--- a/src/USER-INTEL/verlet_lrt_intel.cpp
+++ b/src/USER-INTEL/verlet_lrt_intel.cpp
@@ -142,7 +142,7 @@ void VerletLRTIntel::setup(int flag)
   domain->image_check();
   domain->box_too_small_check();
   modify->setup_pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
   neighbor->ncalls = 0;
 
   // compute all forces
@@ -276,7 +276,7 @@ void VerletLRTIntel::run(int n)
         modify->pre_neighbor();
         timer->stamp(Timer::MODIFY);
       }
-      neighbor->build();
+      neighbor->build(1);
       timer->stamp(Timer::NEIGH);
     }
 

--- a/src/USER-MISC/fix_srp.cpp
+++ b/src/USER-MISC/fix_srp.cpp
@@ -304,7 +304,7 @@ void FixSRP::setup_pre_force(int zz)
   domain->image_check();
   domain->box_too_small_check();
   modify->setup_pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
   neighbor->ncalls = 0;
 
   // new atom counts

--- a/src/USER-OMP/respa_omp.cpp
+++ b/src/USER-OMP/respa_omp.cpp
@@ -107,7 +107,7 @@ void RespaOMP::setup()
   domain->image_check();
   domain->box_too_small_check();
   modify->setup_pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
   modify->setup_post_neighbor();
   neighbor->ncalls = 0;
 
@@ -200,7 +200,7 @@ void RespaOMP::setup_minimal(int flag)
     domain->image_check();
     domain->box_too_small_check();
     modify->setup_pre_neighbor();
-    neighbor->build();
+    neighbor->build(1);
     modify->setup_post_neighbor();
     neighbor->ncalls = 0;
   }
@@ -311,7 +311,7 @@ void RespaOMP::recurse(int ilevel)
           modify->pre_neighbor();
           timer->stamp(Timer::MODIFY);
         }
-        neighbor->build();
+        neighbor->build(1);
         timer->stamp(Timer::NEIGH);
         if (modify->n_post_neighbor) {
           modify->post_neighbor();

--- a/src/USER-UEF/fix_nh_uef.cpp
+++ b/src/USER-UEF/fix_nh_uef.cpp
@@ -734,7 +734,7 @@ void FixNHUef::end_of_step()
     comm->borders();
     domain->lamda2x(atom->nlocal+atom->nghost);
     timer->stamp(Timer::COMM);
-    neighbor->build();
+    neighbor->build(1);
     timer->stamp(Timer::NEIGH);
   }
 }
@@ -754,7 +754,7 @@ void FixNHUef::post_run()
   comm->borders();
   domain->lamda2x(atom->nlocal+atom->nghost);
   timer->stamp(Timer::COMM);
-  neighbor->build();
+  neighbor->build(1);
   timer->stamp(Timer::NEIGH);
 }
 

--- a/src/create_bonds.cpp
+++ b/src/create_bonds.cpp
@@ -209,7 +209,7 @@ void CreateBonds::many()
   comm->exchange();
   comm->borders();
   if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-  neighbor->build();
+  neighbor->build(1);
 
   // build neighbor list this command needs based on earlier request
 

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -311,7 +311,7 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
   comm->exchange();
   comm->borders();
   if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-  neighbor->build();
+  neighbor->build(1);
 
   // build neighbor list this command needs based on earlier request
 

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -245,7 +245,7 @@ void Min::setup(int flag)
   domain->image_check();
   domain->box_too_small_check();
   modify->setup_pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
   modify->setup_post_neighbor();
   neighbor->ncalls = 0;
 
@@ -345,7 +345,7 @@ void Min::setup_minimal(int flag)
     domain->image_check();
     domain->box_too_small_check();
     modify->setup_pre_neighbor();
-    neighbor->build();
+    neighbor->build(1);
     modify->setup_post_neighbor();
     neighbor->ncalls = 0;
   }
@@ -508,7 +508,7 @@ double Min::energy_force(int resetflag)
       modify->min_pre_neighbor();
       timer->stamp(Timer::MODIFY);
     }
-    neighbor->build();
+    neighbor->build(1);
     timer->stamp(Timer::NEIGH);
     if (modify->n_min_post_neighbor) {
       modify->min_post_neighbor();

--- a/src/neighbor.h
+++ b/src/neighbor.h
@@ -111,7 +111,7 @@ class Neighbor : protected Pointers {
   int decide();                     // decide whether to build or not
   virtual int check_distance();     // check max distance moved since last build
   void setup_bins();                // setup bins based on box and cutoff
-  virtual void build(int topoflag=1);  // build all perpetual neighbor lists
+  virtual void build(int);          // build all perpetual neighbor lists
   virtual void build_topology();    // pairwise topology neighbor lists
   void build_one(class NeighList *list, int preflag=0);
                                     // create a one-time pairwise neigh list

--- a/src/respa.cpp
+++ b/src/respa.cpp
@@ -441,7 +441,7 @@ void Respa::setup(int flag)
   domain->image_check();
   domain->box_too_small_check();
   modify->setup_pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
   modify->setup_post_neighbor();
   neighbor->ncalls = 0;
 
@@ -517,7 +517,7 @@ void Respa::setup_minimal(int flag)
     domain->image_check();
     domain->box_too_small_check();
     modify->setup_pre_neighbor();
-    neighbor->build();
+    neighbor->build(1);
     modify->setup_post_neighbor();
     neighbor->ncalls = 0;
   }
@@ -668,7 +668,7 @@ void Respa::recurse(int ilevel)
           modify->pre_neighbor();
           timer->stamp(Timer::MODIFY);
         }
-        neighbor->build();
+        neighbor->build(1);
         timer->stamp(Timer::NEIGH);
         if (modify->n_post_neighbor) {
           modify->post_neighbor();

--- a/src/verlet.cpp
+++ b/src/verlet.cpp
@@ -120,7 +120,7 @@ void Verlet::setup(int flag)
   domain->image_check();
   domain->box_too_small_check();
   modify->setup_pre_neighbor();
-  neighbor->build();
+  neighbor->build(1);
   modify->setup_post_neighbor();
   neighbor->ncalls = 0;
 
@@ -182,7 +182,7 @@ void Verlet::setup_minimal(int flag)
     domain->image_check();
     domain->box_too_small_check();
     modify->setup_pre_neighbor();
-    neighbor->build();
+    neighbor->build(1);
     modify->setup_post_neighbor();
     neighbor->ncalls = 0;
   }
@@ -284,7 +284,7 @@ void Verlet::run(int n)
         modify->pre_neighbor();
         timer->stamp(Timer::MODIFY);
       }
-      neighbor->build();
+      neighbor->build(1);
       timer->stamp(Timer::NEIGH);
       if (n_post_neighbor) {
         modify->post_neighbor();


### PR DESCRIPTION
## Purpose

This is similar to PR #812 and should help avoid unexpected overloading of methods in derived classes and thus detect possible bugs at compile time. Unlike for the case in #812, there doesn't seem to be a derived class with an unwanted overload currently. So this is a preventive change.

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

No user interface changes. All calls to neighbor->build() need to have an explicit argument now (default 1).

## Implementation Notes

see PR #812 



