### PR TITLE
Workaround issue in pair_snap_kokkos

### DIFF
--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -188,7 +188,7 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   int team_size_max = Kokkos::TeamPolicy<DeviceType>::team_size_max(*this);
   int vector_length = 8;
 #ifdef KOKKOS_ENABLE_CUDA
-  int team_size = 20;//max_neighs;
+  int team_size = 32;//max_neighs;
   if (team_size*vector_length > team_size_max)
     team_size = team_size_max/vector_length;
 #else

--- a/src/SNAP/pair_snap.h
+++ b/src/SNAP/pair_snap.h
@@ -37,8 +37,11 @@ public:
   virtual double init_one(int, int);
   virtual double memory_usage();
 
+  double rcutfac, quadraticflag; // declared public to workaround gcc 4.9
+  int ncoeff;                    //  compiler bug, manifest in KOKKOS package
+
 protected:
-  int ncoeff, ncoeffq, ncoeffall;
+  int ncoeffq, ncoeffall;
   double **bvec, ***dbvec;
   class SNA** sna;
   int nmax;
@@ -97,8 +100,8 @@ protected:
   double *wjelem;               // elements weights
   double **coeffelem;           // element bispectrum coefficients
   int *map;                     // mapping from atom types to elements
-  int twojmax, diagonalstyle, switchflag, bzeroflag, quadraticflag;
-  double rcutfac, rfac0, rmin0, wj1, wj2;
+  int twojmax, diagonalstyle, switchflag, bzeroflag;
+  double rfac0, rmin0, wj1, wj2;
   int rcutfacflag, twojmaxflag; // flags for required parameters
 };
 


### PR DESCRIPTION
## Purpose
We are seeing runtime crashes in Kokkos SNAP when running on GPUs. It is unknown whether the root cause is in LAMMPS, Kokkos, or CUDA. So far debugging efforts have been fruitless. This is a workaround that lets the code run.

Also add workaround for a bug in gcc v4.9.3 that doesn't allow lambda capture of protected variables.

## Author(s)
Stan Moore

## Backward Compatibility
No issues.
