### PR TITLE
Collected small cleanups, fixes, and enhancements

### DIFF
--- a/doc/src/read_data.txt
+++ b/doc/src/read_data.txt
@@ -15,10 +15,11 @@ read_data file keyword args ... :pre
 file = name of data file to read in :ulb,l
 zero or more keyword/arg pairs may be appended :l
 keyword = {add} or {offset} or {shift} or {extra/atom/types} or {extra/bond/types} or {extra/angle/types} or {extra/dihedral/types} or {extra/improper/types} or {extra/bond/per/atom} or {extra/angle/per/atom} or {extra/dihedral/per/atom} or {extra/improper/per/atom} or {group} or {nocoeff} or {fix} :l
-  {add} arg = {append} or {Nstart} or {merge}
-    append = add new atoms with IDs appended to current IDs
-    Nstart = add new atoms with IDs starting with Nstart
-    merge = add new atoms with their IDs unchanged
+  {add} arg = {append} or {IDoffset} or {IDoffset MOLoffset} or {merge}
+    append = add new atoms with atom IDs appended to current IDs
+    IDoffset = add new atoms with atom IDs having IDoffset added
+    MOLoffset = add new atoms with molecule IDs having MOLoffset added (only when molecule IDs are enabled)
+    merge = add new atoms with their atom IDs (and molecule IDs) unchanged
   {offset} args = toff boff aoff doff ioff
     toff = offset to add to atom types
     boff = offset to add to bond types
@@ -120,20 +121,26 @@ boundary, then the atoms may become far apart if the box size grows.
 This will separate the atoms in the bond, which can lead to "lost"
 bond atoms or bad dynamics.
 
-The three choices for the {add} argument affect how the IDs of atoms
-in the data file are treated.  If {append} is specified, atoms in the
-data file are added to the current system, with their atom IDs reset
-so that an atomID = M in the data file becomes atomID = N+M, where N
-is the largest atom ID in the current system.  This rule is applied to
-all occurrences of atom IDs in the data file, e.g. in the Velocity or
-Bonds section.  If {Nstart} is specified, then {Nstart} is a numeric
-value is given, e.g. 1000, so that an atomID = M in the data file
-becomes atomID = 1000+M.  If {merge} is specified, the data file atoms
+The three choices for the {add} argument affect how the atom IDs and
+molecule IDs of atoms in the data file are treated.  If {append} is
+specified, atoms in the data file are added to the current system,
+with their atom IDs reset so that an atomID = M in the data file
+becomes atomID = N+M, where N is the largest atom ID in the current
+system.  This rule is applied to all occurrences of atom IDs in the
+data file, e.g. in the Velocity or Bonds section. This is also done
+for molecule IDs, if the atom style does support molecule IDs or
+they are enabled via fix property/atom. If {IDoffset} is specified,
+then {IDoffset} is a numeric value is given, e.g. 1000, so that an
+atomID = M in the data file becomes atomID = 1000+M. For systems
+with enabled molecule IDs, another numerical argument {MOLoffset}
+is required representing the equivalent offset for molecule IDs.
+If {merge} is specified, the data file atoms
 are added to the current system without changing their IDs.  They are
 assumed to merge (without duplication) with the currently defined
 atoms.  It is up to you to insure there are no multiply defined atom
 IDs, as LAMMPS only performs an incomplete check that this is the case
-by insuring the resulting max atomID >= the number of atoms.
+by insuring the resulting max atomID >= the number of atoms. For
+molecule IDs, there is no check done at all.
 
 The {offset} and {shift} keywords can only be used if the {add}
 keyword is also specified.

--- a/src/CLASS2/pair_lj_class2_coul_long.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_long.cpp
@@ -66,6 +66,7 @@ PairLJClass2CoulLong::~PairLJClass2CoulLong()
       memory->destroy(offset);
     }
   }
+  if (ftable) free_tables();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-MISC/pair_edip_multi.cpp
+++ b/src/USER-MISC/pair_edip_multi.cpp
@@ -364,7 +364,7 @@ void PairEDIPMulti::edip_fc(double r, Param *param, double &f, double &fdr)
   double c = param->cutoffC;
   double alpha = param->alpha;
   double x;
-  double v1, v2, v3;
+  double v1, v2;
 
   if(r < c + 1E-6)
   {

--- a/src/USER-OMP/pair_lj_long_tip4p_long_omp.cpp
+++ b/src/USER-OMP/pair_lj_long_tip4p_long_omp.cpp
@@ -1700,6 +1700,7 @@ void PairLJLongTIP4PLongOMP::eval_outer(int iifrom, int iito, ThrData * const th
     jnum = numneigh[i];
     offseti = offset[itype];
     lj1i = lj1[itype]; lj2i = lj2[itype]; lj3i = lj3[itype]; lj4i = lj4[itype];
+    fxtmp = fytmp = fztmp = 0.0;
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -822,8 +822,8 @@ void Atom::deallocate_topology()
    call style-specific routine to parse line
 ------------------------------------------------------------------------- */
 
-void Atom::data_atoms(int n, char *buf, tagint id_offset, int type_offset,
-                      int shiftflag, double *shift)
+void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
+                      int type_offset, int shiftflag, double *shift)
 {
   int m,xptr,iptr;
   imageint imagedata;
@@ -948,6 +948,7 @@ void Atom::data_atoms(int n, char *buf, tagint id_offset, int type_offset,
         coord[2] >= sublo[2] && coord[2] < subhi[2]) {
       avec->data_atom(xdata,imagedata,values);
       if (id_offset) tag[nlocal-1] += id_offset;
+      if (mol_offset) molecule[nlocal-1] += mol_offset;
       if (type_offset) {
         type[nlocal-1] += type_offset;
         if (type[nlocal-1] > ntypes)

--- a/src/atom.h
+++ b/src/atom.h
@@ -229,7 +229,7 @@ class Atom : protected Pointers {
 
   void deallocate_topology();
 
-  void data_atoms(int, char *, tagint, int, int, double *);
+  void data_atoms(int, char *, tagint, tagint, int, int, double *);
   void data_vels(int, char *, tagint);
   void data_bonds(int, char *, int *, tagint, int);
   void data_angles(int, char *, int *, tagint, int);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -696,10 +696,15 @@ void Comm::ring(int n, int nper, void *inbuf, int messtag,
 
   if (maxbytes == 0) return;
 
+  // sanity check 1
+
+  if ((nbytes > 0) && inbuf == NULL)
+    error->one(FLERR,"Cannot put data on ring from NULL pointer");
+
   char *buf,*bufcopy;
   memory->create(buf,maxbytes,"comm:buf");
   memory->create(bufcopy,maxbytes,"comm:bufcopy");
-  memcpy(buf,inbuf,nbytes);
+  if (nbytes && inbuf) memcpy(buf,inbuf,nbytes);
 
   int next = me + 1;
   int prev = me - 1;
@@ -712,12 +717,17 @@ void Comm::ring(int n, int nper, void *inbuf, int messtag,
       MPI_Send(buf,nbytes,MPI_CHAR,next,messtag,world);
       MPI_Wait(&request,&status);
       MPI_Get_count(&status,MPI_CHAR,&nbytes);
-      memcpy(buf,bufcopy,nbytes);
+      if (nbytes) memcpy(buf,bufcopy,nbytes);
     }
     if (self || loop < nprocs-1) callback(nbytes/nper,buf,ptr);
   }
 
-  if (outbuf) memcpy(outbuf,buf,nbytes);
+  // sanity check 2
+
+  if ((nbytes > 0) && outbuf == NULL)
+    error->one(FLERR,"Cannot put data from ring to NULL pointer");
+
+  if (nbytes && outbuf) memcpy(outbuf,buf,nbytes);
 
   memory->destroy(buf);
   memory->destroy(bufcopy);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -696,7 +696,7 @@ void Comm::ring(int n, int nper, void *inbuf, int messtag,
 
   if (maxbytes == 0) return;
 
-  // sanity check 1
+  // sanity check
 
   if ((nbytes > 0) && inbuf == NULL)
     error->one(FLERR,"Cannot put data on ring from NULL pointer");
@@ -721,11 +721,6 @@ void Comm::ring(int n, int nper, void *inbuf, int messtag,
     }
     if (self || loop < nprocs-1) callback(nbytes/nper,buf,ptr);
   }
-
-  // sanity check 2
-
-  if ((nbytes > 0) && outbuf == NULL)
-    error->one(FLERR,"Cannot put data from ring to NULL pointer");
 
   if (nbytes && outbuf) memcpy(outbuf,buf,nbytes);
 

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -1809,13 +1809,13 @@ void ComputeChunkAtom::atom2binsphere()
     }
     yremap = x[i][1];
     if (periodicity[1]) {
-      if (xremap < boxlo[1]) yremap += prd[1];
-      if (xremap >= boxhi[1]) yremap -= prd[1];
+      if (yremap < boxlo[1]) yremap += prd[1];
+      if (yremap >= boxhi[1]) yremap -= prd[1];
     }
     zremap = x[i][2];
     if (periodicity[2]) {
-      if (xremap < boxlo[2]) zremap += prd[2];
-      if (xremap >= boxhi[2]) zremap -= prd[2];
+      if (zremap < boxlo[2]) zremap += prd[2];
+      if (zremap >= boxhi[2]) zremap -= prd[2];
     }
 
     dx = xremap - sorigin[0];

--- a/src/fix_wall_harmonic.cpp
+++ b/src/fix_wall_harmonic.cpp
@@ -22,7 +22,10 @@ using namespace FixConst;
 /* ---------------------------------------------------------------------- */
 
 FixWallHarmonic::FixWallHarmonic(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg) {}
+  FixWall(lmp, narg, arg)
+{
+  dynamic_group_allow = 1;
+}
 
 /* ----------------------------------------------------------------------
    interaction of all particles in group with a wall

--- a/src/fix_wall_lj1043.cpp
+++ b/src/fix_wall_lj1043.cpp
@@ -26,7 +26,10 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 FixWallLJ1043::FixWallLJ1043(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg) {}
+  FixWall(lmp, narg, arg)
+{
+  dynamic_group_allow = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/fix_wall_lj126.cpp
+++ b/src/fix_wall_lj126.cpp
@@ -22,7 +22,10 @@ using namespace FixConst;
 /* ---------------------------------------------------------------------- */
 
 FixWallLJ126::FixWallLJ126(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg) {}
+  FixWall(lmp, narg, arg)
+{
+  dynamic_group_allow = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/fix_wall_lj93.cpp
+++ b/src/fix_wall_lj93.cpp
@@ -22,7 +22,10 @@ using namespace FixConst;
 /* ---------------------------------------------------------------------- */
 
 FixWallLJ93::FixWallLJ93(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg) {}
+  FixWall(lmp, narg, arg)
+{
+  dynamic_group_allow = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/fix_wall_reflect.cpp
+++ b/src/fix_wall_reflect.cpp
@@ -39,6 +39,8 @@ FixWallReflect::FixWallReflect(LAMMPS *lmp, int narg, char **arg) :
 {
   if (narg < 4) error->all(FLERR,"Illegal fix wall/reflect command");
 
+  dynamic_group_allow = 1;
+
   // parse args
 
   nwall = 0;

--- a/src/fix_wall_region.cpp
+++ b/src/fix_wall_region.cpp
@@ -67,6 +67,8 @@ FixWallRegion::FixWallRegion(LAMMPS *lmp, int narg, char **arg) :
   else if (strcmp(arg[4],"harmonic") == 0) style = HARMONIC;
   else error->all(FLERR,"Illegal fix wall/region command");
 
+  if (style != COLLOID) dynamic_group_allow = 1;
+
   epsilon = force->numeric(FLERR,arg[5]);
   sigma = force->numeric(FLERR,arg[6]);
   cutoff = force->numeric(FLERR,arg[7]);

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -285,7 +285,6 @@ void lammps_commands_string(void *ptr, char *str)
   BEGIN_CAPTURE
   {
     if (lmp->update->whichflag != 0) {
-      delete [] copy;
       lmp->error->all(FLERR,"Library error: issuing LAMMPS command during run");
     }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -276,13 +276,6 @@ void lammps_commands_string(void *ptr, char *str)
 {
   LAMMPS *lmp = (LAMMPS *) ptr;
 
-  BEGIN_CAPTURE
-  {
-    if (lmp->update->whichflag != 0)
-      lmp->error->all(FLERR,"Library error: issuing LAMMPS command during run");
-  }
-  END_CAPTURE
-
   // make copy of str so can strtok() it
 
   int n = strlen(str) + 1;
@@ -291,6 +284,11 @@ void lammps_commands_string(void *ptr, char *str)
 
   BEGIN_CAPTURE
   {
+    if (lmp->update->whichflag != 0) {
+      delete [] copy;
+      lmp->error->all(FLERR,"Library error: issuing LAMMPS command during run");
+    }
+
     char *ptr = copy;
     for (int i=0; i < n-1; ++i) {
 

--- a/src/read_data.h
+++ b/src/read_data.h
@@ -39,7 +39,7 @@ class ReadData : protected Pointers {
   int narg,maxarg;
   char argoffset1[8],argoffset2[8];
 
-  bigint id_offset;
+  bigint id_offset, mol_offset;
 
   int nlocal_previous;
   bigint natoms;


### PR DESCRIPTION
## Purpose

Collection of a variety of small enhancements, or fixes and cleanups to address issues discovered during testing for stable release.

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

Reading data files with `read_data add` on systems with molecule IDs (via atom style or fix property/atom) now two numeric offsets are required: the first for the atom ID offset, the second correspondingly for the molecule ID offset.

## Implementation Notes

The individual changes contained in this pull request are:
- a bugfix for the library interface, so it can be compiled (again) with exceptions enabled. Closes #818 
- remove dead code and uninitialized variables detected by clang
- support offsets for molecule IDs in `read_data add` following the similar logic as for atom IDs. suggested by felipe perez in https://sourceforge.net/p/lammps/mailman/message/36236631/
- add sanity checks on ring communication. don't call memcpy to copy zero bytes. error out on illegal combinations for `nbytes` and `inbuf` or `outbuf`.
- allow dynamic groups for standard wall fixes acting on point particles.
- bugfix for spherical chunks in `compute chunk/atom` reported by @poppik in issue #820. Closes #820

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
