### PR TITLE
revised reax ff parameters for water

### DIFF
--- a/ffield.reax.O_H_X
+++ b/ffield.reax.O_H_X
@@ -1,0 +1,83 @@
+DATE: 2018-02-22 CITATION: Zhang & van Duin J. Phys. Chem. B 121 (2017) 6021–6032 
+ 39 ! Number of general parameters
+ 50.0000 !Overcoordination parameter
+ 9.5469 !Overcoordination parameter
+ 26.5405 !Valency angle conjugation parameter
+ 1.7224 !Triple bond stabilisation parameter
+ 6.8702 !Triple bond stabilisation parameter
+ 60.4850 !C2-correction
+ 1.0588 !Undercoordination parameter
+ 4.6000 !Triple bond stabilisation parameter
+ 12.1176 !Undercoordination parameter
+ 13.3056 !Undercoordination parameter
+ -70.5044 !Triple bond stabilization energy
+ 0.0000 !Lower Taper-radius
+ 10.0000 !Upper Taper-radius
+ 2.8793 !Not used
+ 33.8667 !Valency undercoordination
+ 6.0891 !Valency angle/lone pair parameter
+ 1.0563 !Valency angle
+ 2.0384 !Valency angle parameter
+ 6.1431 !Not used
+ 6.9290 !Double bond/angle parameter
+ 0.3989 !Double bond/angle parameter: overcoord
+ 3.9954 !Double bond/angle parameter: overcoord
+ -2.4837 !Not used
+ 5.7796 !Torsion/BO parameter
+ 10.0000 !Torsion overcoordination
+ 1.9487 !Torsion overcoordination
+ -1.2327 !Conjugation 0 (not used)
+ 2.1645 !Conjugation
+ 1.5591 !vdWaals shielding
+ 0.1000 !Cutoff for bond order (*100)
+ 2.1365 !Valency angle conjugation parameter
+ 0.6991 !Overcoordination parameter
+ 50.0000 !Overcoordination parameter
+ 1.8512 !Valency/lone pair parameter
+ 0.5000 !Not used
+ 20.0000 !Not used
+ 5.0000 !Molecular energy (not used)
+ 0.0000 !Molecular energy (not used)
+ 2.6962 !Valency angle conjugation parameter
+ 3 ! Nr of atoms; cov.r; valency;a.m;Rvdw;Evdw;gammaEEM;cov.r2;#
+ 	alfa;gammavdW;valency;Eunder;Eover;chiEEM;etaEEM;n.u.
+ 	cov r3;Elp;Heat inc.;n.u.;n.u.;n.u.;n.u.
+ 	ov/un;val1;n.u.;val3,vval4
+ H 	0.8930 1.0000 1.0080 1.3550 0.0930 0.8203 -0.1000 1.0000
+ 	8.2180 33.2894 1.0000 0.0000 121.1250 3.7248 9.6093 1.0000
+ 	-0.1000 0.0000 61.6606 3.0408 2.4197 0.0003 1.0698 0.0000
+ 	-19.4571 4.2733 1.0338 1.0000 2.8793 0.0000 0.0000 0.0000
+ O 	1.2450 2.0000 15.9990 2.3808 0.1038 1.0950 1.0548 6.0000
+ 	9.7942 11.7301 4.0000 37.5000 116.0768 8.5000 8.3134 2.0000
+ 	0.9049 0.1000 59.0626 3.5357 0.6653 0.0021 0.9745 0.0000
+ 	-3.6039 2.7952 1.0493 4.0000 2.9225 0.0000 0.0000 0.0000
+ X 	-0.1000 2.0000 1.0080 2.0000 0.0000 1.0000 -0.1000 6.0000
+ 	10.0000 2.5000 4.0000 0.0000 0.0000 8.5000 1.5000 0.0000
+ 	-0.1000 0.0000 -2.3700 8.7410 13.3640 0.6690 0.9745 0.0000
+ 	-11.0000 2.7466 1.0338 2.0000 2.8793 0.0000 0.0000 0.0000
+ 3 ! Nr of bonds; Edis1;LPpen;n.u.;pbe1;pbo5;13corr;pbo6
+ 	pbe2;pbo3;pbo4;n.u.;pbo1;pbo2;ovcorr
+ 1 1 153.3934 0.0000 0.0000 -0.4600 0.0000 1.0000 6.0000 0.7300
+       6.2500 1.0000 0.0000 1.0000 -0.0790 6.0552 0.0000 0.0000
+ 2 2 142.2858 145.0000 50.8293 0.2506 -0.1000 1.0000 29.7503 0.6051
+       0.3451 -0.1055 9.0000 1.0000 -0.1225 5.5000 1.0000 0.0000
+ 1 2 167.2086 0.0000 0.0000 -0.5770 0.0000 1.0000 6.0000 0.6019
+       1.1413 1.0000 0.0000 0.0000 -0.0924 4.2778 0.0000 0.0000
+ 1 ! Nr of off-diagonal terms; Ediss;Ro;gamma;rsigma;rpi;rpi2
+ 1 2 0.0320 1.2896 10.9108 0.9215 -1.0000 -1.0000
+ 6 ! Nr of angles;at1;at2;at3;Thetao,o;ka;kb;pv1;pv2
+ 1 1 1 0.0000 27.9213 5.8635 0.0000 0.0000 0.0000 1.0400
+ 2 2 2 80.7324 30.4554 0.9953 0.0000 1.6310 50.0000 1.0783
+ 1 2 2 75.6935 50.0000 2.0000 0.0000 1.0000 0.0000 1.1680
+ 1 2 1 85.1864 8.5843 2.2985 0.0000 2.9142 0.0000 2.0521
+ 2 1 2 0.0000 11.8475 2.7571 0.0000 0.0000 0.0000 2.9000
+ 1 1 2 0.0000 6.4269 2.8500 0.0000 0.0000 0.0000 1.0772
+ 6 ! Nr of torsions;at1;at2;at3;at4;;V1;V2;V3;V2(BO);vconj;n.u;n
+ 1 2 2 1 2.5000 -4.0000 0.9000 -2.5000 -1.0000 0.0000 0.0000
+ 1 2 2 2 0.8302 -4.0000 -0.7763 -2.5000 -1.0000 0.0000 0.0000
+ 2 2 2 2 -2.5000 -4.0000 1.0000 -2.5000 -1.0000 0.0000 0.0000
+ 0 1 1 0 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000
+ 0 1 2 0 0.0000 0.1000 0.0200 -2.5415 0.0000 0.0000 0.0000
+ 0 2 2 0 0.5511 25.4150 1.1330 -5.1903 -1.0000 0.0000 0.0000
+ 1 ! Nr of hydrogen bonds;at1;at2;at3;Rhb;Dehb;vhb1
+ 2 1 2 2.1653 -3.6983 1.7831 17.0964 


### PR DESCRIPTION
a set of new parameters from van Duin group for water (https://pubs.acs.org/doi/abs/10.1021/acs.jpcb.7b02548). The file is taken from the supporting information. The new set predicts the proper water density.
