### PR TITLE
Add make package-installed command

### DIFF
--- a/doc/src/Section_start.txt
+++ b/doc/src/Section_start.txt
@@ -803,6 +803,10 @@ currently installed. For those that are installed, it will list any
 files that are different in the src directory and package
 sub-directory.
 
+Typing "make package-installed" or "make pi" will list which packages are
+currently installed, without listing the status of packages that are not
+installed.
+
 Typing "make package-update" or "make pu" will overwrite src files
 with files from the package sub-directories if the package is
 installed.  It should be used after a patch has been applied, since

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,6 +100,7 @@ help:
 	@echo ''
 	@echo 'make package                 list available packages and their dependencies'
 	@echo 'make package-status (ps)     status of all packages'
+	@echo 'make package-installed (pi)  list of installed packages'
 	@echo 'make yes-package             install a single pgk in src dir'
 	@echo 'make no-package              remove a single pkg from src dir'
 	@echo 'make yes-all                 install all pgks in src dir'
@@ -260,6 +261,7 @@ package:
 	@echo 'make package                 list available packages'
 	@echo 'make package                 list available packages'
 	@echo 'make package-status (ps)     status of all packages'
+	@echo 'make package-installed (pi)  list of installed packages'
 	@echo 'make yes-package             install a single pgk in src dir'
 	@echo 'make no-package              remove a single pkg from src dir'
 	@echo 'make yes-all                 install all pgks in src dir'
@@ -354,6 +356,7 @@ lib-%:
 	fi; touch main.cpp
 
 # status = list src files that differ from package files
+# installed = list of installed packages
 # update = replace src files with newer package files
 # overwrite = overwrite package files with newer src files
 # diff = show differences between src and package files
@@ -363,6 +366,10 @@ package-status ps:
 	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p status; done
 	@echo ''
 	@for p in $(PACKUSERUC); do $(SHELL) Package.sh $$p status; done
+
+package-installed pi:
+	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p installed; done
+	@for p in $(PACKUSERUC); do $(SHELL) Package.sh $$p installed; done
 
 package-update pu: purge
 	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p update; done

--- a/src/Package.sh
+++ b/src/Package.sh
@@ -34,6 +34,13 @@ if (test $2 = "status") then
     echo "Installed  NO: package $1"
   fi
 
+# installed, list only if installed
+
+elif (test $2 = "installed") then
+  if (test $installed = 1) then
+    echo "Installed YES: package $1"
+  fi
+
 # update, only if installed
 # perform a re-install, but only if the package is already installed
 


### PR DESCRIPTION
## Purpose
Add a new command `make package-installed`, aka `make pi`, which only lists which packages are installed. The currently available `make package-status` command lists the status of all packages, whether they are installed or not. Typically only a handful of packages are installed at a time, so it is hard to find the "YES" in a sea of "NOs". Sample output:

```
$ make package-installed
Installed YES: package KOKKOS
Installed YES: package USER-REAXC
```

## Author(s)
Stan Moore (Sandia)

## Backward Compatibility
No issues