### PR TITLE
Added error if gcmc is used with molecules on more than one processor

### DIFF
--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -714,6 +714,12 @@ void FixGCMC::init()
     }
   }
 
+  // Current implementation is broken using
+  // full_flag on molecules on more than one processor.
+  // Print error if this is the current mode
+  if (full_flag && (exchmode == EXCHMOL || movemode == MOVEMOL) && comm->nprocs > 1)
+    error->all(FLERR,"fix gcmc does currently not support full_energy option with molecules on more than 1 MPI process.");
+
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

As been reported in #467, and also on the mailing list, LAMMPS is broken with `fix gcmc` using molecule on more than one MPI process. With this PR, LAMMPS detects this and throws an error instead of letting the user run a potentially non-crashing, but invalid state.

We should probably also update the docs?

## Author(s)
Anders Hafreager, University of Oslo

## Backward Compatibility

Any simulation using the above conditions will stop working

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
