### PR TITLE
add restartinfo=0 to manbody file it was missing from

### DIFF
--- a/doc/src/pair_meam.txt
+++ b/doc/src/pair_meam.txt
@@ -77,7 +77,7 @@ See the "pair_coeff"_pair_coeff.html doc page for alternate ways
 to specify the path for the potential files.
 
 As an example, the potentials/library.meam file has generic MEAM
-settings for a variety of elements.  The potentials/sic.meam file has
+settings for a variety of elements.  The potentials/SiC.meam file has
 specific parameter settings for a Si and C alloy system.  If your
 LAMMPS simulation has 4 atoms types and you want the 1st 3 to be Si,
 and the 4th to be C, you would use the following pair_coeff command:
@@ -104,6 +104,15 @@ If a mapping value is specified as NULL, the mapping is not performed.
 This can be used when a {meam} potential is used as part of the
 {hybrid} pair style.  The NULL values are placeholders for atom types
 that will be used with other potentials.
+
+NOTE: If the 2nd filename is NULL, the element names between the two
+filenames can appear in any order, e.g. "Si C" or "C Si" in the
+example above.  However, if the 2nd filename is not NULL (as in the
+example above), it contains settings that are Fortran-indexed for the
+elements that preceed it.  Thus you need to insure you list the
+elements between the filenames in an order consistent with how the
+values in the 2nd filename are indexed.  See details below on the
+syntax for settings in the 2nd file.
 
 The MEAM library file provided with LAMMPS has the name
 potentials/library.meam.  It is the "meamf" file used by other MD
@@ -170,8 +179,9 @@ selected starting from 1. Thus for the example given below
 
 pair_coeff * * library.meam Si C sic.meam Si Si Si C :pre
 
-an index of 1 would refer to Si and an index of 2 to C. The recognized
-keywords for the parameter file are as follows:
+an index of 1 would refer to Si and an index of 2 to C. 
+
+The recognized keywords for the parameter file are as follows:
 
 Ec, alpha, rho0, delta, lattce, attrac, repuls, nn2, Cmin, Cmax, rc, delr,
 augt1, gsmooth_factor, re

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -52,6 +52,7 @@ using namespace MathSpecial;
 PairAIREBO::PairAIREBO(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
+  restartinfo = 0;
   one_coeff = 1;
   ghostneigh = 1;
   ljflag = torflag = 1;

--- a/src/MANYBODY/pair_bop.cpp
+++ b/src/MANYBODY/pair_bop.cpp
@@ -61,6 +61,7 @@ using namespace LAMMPS_NS;
 PairBOP::PairBOP(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
+  restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
   ghostneigh = 1;

--- a/src/MANYBODY/pair_lcbop.cpp
+++ b/src/MANYBODY/pair_lcbop.cpp
@@ -44,8 +44,10 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-PairLCBOP::PairLCBOP(LAMMPS *lmp) : Pair(lmp) {
+PairLCBOP::PairLCBOP(LAMMPS *lmp) : Pair(lmp)
+{
   single_enable = 0;
+  restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
   ghostneigh = 1;

--- a/src/MANYBODY/pair_nb3b_harmonic.cpp
+++ b/src/MANYBODY/pair_nb3b_harmonic.cpp
@@ -44,6 +44,7 @@ using namespace LAMMPS_NS;
 PairNb3bHarmonic::PairNb3bHarmonic(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
+  restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
 

--- a/src/MANYBODY/pair_polymorphic.cpp
+++ b/src/MANYBODY/pair_polymorphic.cpp
@@ -43,6 +43,7 @@ using namespace MathConst;
 PairPolymorphic::PairPolymorphic(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
+  restartinfo = 0;
   one_coeff = 1;
 
   nelements = 0;

--- a/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
@@ -43,6 +43,7 @@ using namespace LAMMPS_NS;
 PairKolmogorovCrespiZ::PairKolmogorovCrespiZ(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
+  restartinfo = 0;
 
   // initialize element to parameter maps
   nelements = 0;

--- a/src/USER-MISC/pair_list.cpp
+++ b/src/USER-MISC/pair_list.cpp
@@ -54,6 +54,7 @@ typedef struct { double x,y,z; } dbl3_t;
 PairList::PairList(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
+  restartinfo = 0;
   respa_enable = 0;
   cut_global = 0.0;
   style = NULL;

--- a/src/USER-MISC/pair_tersoff_table.cpp
+++ b/src/USER-MISC/pair_tersoff_table.cpp
@@ -55,6 +55,7 @@ using namespace LAMMPS_NS;
 PairTersoffTable::PairTersoffTable(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
+  restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
 


### PR DESCRIPTION
## Purpose

Add a restartinfo=0 flag to several manybody pair styles that were missing it.  This insures
no info about the pair style is written to a restart file, consistent with the doc pages for each pair
style.  The user thus needs to include new pair style/coeff commands in a restart script
after reading the restart file.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


