### PR TITLE
allow for mpi4py version 2 or 3 in Python wrapper

### DIFF
--- a/python/examples/simple.py
+++ b/python/examples/simple.py
@@ -88,8 +88,6 @@ lmp.command("run 10");
 
 # uncomment if running in parallel via Pypar
 #print("Proc %d out of %d procs has" % (me,nprocs), lmp)
-#pypar.finalize()
 
 # uncomment if running in parallel via mpi4py
-#print "Proc %d out of %d procs has" % (me,nprocs), lmp
-#MPI.Finalize()
+#print("Proc %d out of %d procs has" % (me,nprocs), lmp)

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -46,17 +46,15 @@ class MPIAbortException(Exception):
   def __str__(self):
     return repr(self.message)
 
-
 class lammps(object):
   
   # detect if Python is using version of mpi4py that can pass a communicator
 
-  has_mpi4py_v2 = False
+  has_mpi4py = False
   try:
     from mpi4py import MPI
     from mpi4py import __version__ as mpi4py_version
-    if mpi4py_version.split('.')[0] == '2':
-      has_mpi4py_v2 = True
+    if mpi4py_version.split('.')[0] in ['2','3']: has_mpi4py = True
   except:
     pass
 
@@ -111,7 +109,9 @@ class lammps(object):
       # need to adjust for type of MPI communicator object
       # allow for int (like MPICH) or void* (like OpenMPI)
 
-      if lammps.has_mpi4py_v2 and comm != None:
+      if comm:
+	if not lammps.has_mpi4py:
+          raise Exception('Python mpi4py version is not 2 or 3')
         if lammps.MPI._sizeof(lammps.MPI.Comm) == sizeof(c_int):
           MPI_Comm = c_int
         else:


### PR DESCRIPTION
## Purpose

Enable Python wrapper lammps.py to use mpi4py version 2 or 3.

## Author(s)

Patch from Noam Bernstein, slightly modified by Steve.

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


