### PR TITLE
reaxff corrected bond order bugfix

### DIFF
--- a/src/KOKKOS/pair_reaxc_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxc_kokkos.cpp
@@ -2073,11 +2073,11 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBondOrder2, const int &ii) 
       d_C1dbo(i,j_index) = 1.0;
       d_C2dbo(i,j_index) = 0.0;
       d_C3dbo(i,j_index) = 0.0;
-      d_C1dbopi(i,j_index) = d_BO_pi(i,j_index);
+      d_C1dbopi(i,j_index) = 1.0;
       d_C2dbopi(i,j_index) = 0.0;
       d_C3dbopi(i,j_index) = 0.0;
       d_C4dbopi(i,j_index) = 0.0;
-      d_C1dbopi2(i,j_index) = d_BO_pi(i,j_index);
+      d_C1dbopi2(i,j_index) = 1.0;
       d_C2dbopi2(i,j_index) = 0.0;
       d_C3dbopi2(i,j_index) = 0.0;
       d_C4dbopi2(i,j_index) = 0.0;

--- a/src/USER-OMP/reaxc_bond_orders_omp.cpp
+++ b/src/USER-OMP/reaxc_bond_orders_omp.cpp
@@ -497,12 +497,12 @@ void BOOMP( reax_system *system, control_params *control, simulation_data *data,
 	    bo_ij->C2dbo = 0.000000;
 	    bo_ij->C3dbo = 0.000000;
 	
-	    bo_ij->C1dbopi = bo_ij->BO_pi;
+	    bo_ij->C1dbopi = 1.000000;
 	    bo_ij->C2dbopi = 0.000000;
 	    bo_ij->C3dbopi = 0.000000;
 	    bo_ij->C4dbopi = 0.000000;
 	
-	    bo_ij->C1dbopi2 = bo_ij->BO_pi2;
+	    bo_ij->C1dbopi2 = 1.000000;
 	    bo_ij->C2dbopi2 = 0.000000;
 	    bo_ij->C3dbopi2 = 0.000000;
 	    bo_ij->C4dbopi2 = 0.000000;

--- a/src/USER-REAXC/reaxc_bond_orders.cpp
+++ b/src/USER-REAXC/reaxc_bond_orders.cpp
@@ -418,12 +418,12 @@ void BO( reax_system *system, control_params *control, simulation_data *data,
           bo_ij->C2dbo = 0.000000;
           bo_ij->C3dbo = 0.000000;
 
-          bo_ij->C1dbopi = bo_ij->BO_pi;
+          bo_ij->C1dbopi = 1.000000;
           bo_ij->C2dbopi = 0.000000;
           bo_ij->C3dbopi = 0.000000;
           bo_ij->C4dbopi = 0.000000;
 
-          bo_ij->C1dbopi2 = bo_ij->BO_pi2;
+          bo_ij->C1dbopi2 = 1.000000;
           bo_ij->C2dbopi2 = 0.000000;
           bo_ij->C3dbopi2 = 0.000000;
           bo_ij->C4dbopi2 = 0.000000;


### PR DESCRIPTION
This pull request implements the bugfix described below for USER-REAXC and USER-OMP. From looking at the sources, it appears that KOKKOS does not seem to be affected by this.

axel.

Tomáš Trnka trnka@scm.com via lists.sourceforge.net 
8:24 AM (3 hours ago)
to lammps-users, puremd 
Hello everyone,

I've been investigating differences in forces/pressures between LAMMPS
USER-REAXC and our SCM-ReaxFF code, originally reported by Dundar Yilmaz:
http://lammps.sandia.gov/threads/msg74519.html

The source of the differences is a major bug in USER-REAXC, going all the way
back to the initial commit in 2010. I'm thus CCing the PuReMD team as I suspect
that PuReMD might also be affected.

The bug is in BO(), which contains a separate fast path for bonds without bond
order correction. For such bonds, the pi-BO derivative terms are calculated
incorrectly.
```
if( twbp->ovc < 0.001 && twbp->v13cor < 0.001 ) {
…
bo_ij->C1dbopi = bo_ij->BO_pi;
bo_ij->C1dbopi2 = bo_ij->BO_pi2;
…
}
```
C1dbopi should be equal to one, as it is the product of the f1, f4, and f5
terms, all of them being equal to 1 for bonds without the corrections. The
general code in BO() gets this right, it's just the special case that's broken.
I can only speculate how this bug came to be, but it's probably related to the
fact that the other part of the derivative contribution is confusingly called
"dln_BOp_pi", although it's not "ln" at all (it's already multiplied by the BO).

The end result is that for bonds that are mostly sigma (BO_pi ~ 0), the pi-BO
derivative contribution is essentially missing due to the extra multiplication
by the tiny BO_pi. This amounts to errors in forces that are comparable in
magnitude to the force itself.

For example, using Dundar's 1080-atom BaTiO3 test system, these are the
(single-point, 0 K) pressures with varying box size:
```
# L Pxx Pyy Pzz Pyz Pxz Pxy

# LAMMPS
24.06 -5630.5324 -5630.5324 -5630.5324 2.2893807e-07 2.2891492e-07 2.2891093e-07
34.06 1473.4922 1473.4922 1473.4922 -33.6732 -33.6732 -33.6732
44.06 680.68832 680.68832 680.68832 -15.555532 -15.555532 -15.555532
54.06 368.51372 368.51372 368.51372 -8.4215147 -8.4215147 -8.4215147
64.06 221.47309 221.47309 221.47309 -5.061247 -5.061247 -5.061247
84.06 98.019756 98.019756 98.019756 -2.2400111 -2.2400111 -2.2400111
```
```
# LAMMPS-fixed
24.06 2517.9749 2517.9749 2517.9749 2.289367e-07 2.2891946e-07 2.2888915e-07
34.06 3898.5103 3898.5103 3898.5103 -33.6732 -33.6732 -33.6732
44.06 1800.9395 1800.9395 1800.9395 -15.555532 -15.555532 -15.555532
54.06 974.99971 974.99971 974.99971 -8.4215147 -8.4215147 -8.4215147
64.06 585.96518 585.96518 585.96518 -5.061247 -5.061247 -5.061247
84.06 259.33698 259.33698 259.33698 -2.2400111 -2.2400111 -2.2400111
```
```
# SCM-ReaxFF
24.06 2517.9657 2517.9657 2517.9657 5.03584e-08 5.0401035e-08 5.0245074e-08
34.06 3898.4737 3898.4737 3898.4737 -33.673288 -33.673288 -33.673288
44.06 1800.9227 1800.9227 1800.9227 -15.555572 -15.555572 -15.555572
54.06 974.99058 974.99058 974.99058 -8.4215365 -8.4215365 -8.4215364
64.06 585.95969 585.95969 585.95969 -5.06126 -5.0612601 -5.0612601
84.06 259.33455 259.33455 259.33455 -2.2400169 -2.2400169 -2.2400169
```
You can see that fixing the two affected lines using the following trivial
patch makes LAMMPS results match SCM-ReaxFF perfectly. (They also match the
forces/pressures calculated by numerical differentiation of the energy.
Unfortunately, I don't know how to do such a numerical test in LAMMPS easily.)

I also suspect that the KOKKOS and OpenMP implementations of ReaxFF are
affected as well, but I've never used those so hopefully someone else can
take care of fixing them.

Best regards,

Tomáš Trnka
Software for Chemistry & Materials B.V.
De Boelelaan 1083
1081 HV Amsterdam, The Netherlands
https://www.scm.com

```
diff --git a/src/USER-REAXC/reaxc_bond_orders.cpp b/src/USER-REAXC/reaxc_bond_orders.cpp
index 04cedf18a..468164a2c 100644
--- a/src/USER-REAXC/reaxc_bond_orders.cpp
+++ b/src/USER-REAXC/reaxc_bond_orders.cpp
@@ -418,12 +418,12 @@ void BO( reax_system *system, control_params *control, simulation_data *data,
           bo_ij->C2dbo = 0.000000;
           bo_ij->C3dbo = 0.000000;

-          bo_ij->C1dbopi = bo_ij->BO_pi;
+          bo_ij->C1dbopi = 1.000000;
           bo_ij->C2dbopi = 0.000000;
           bo_ij->C3dbopi = 0.000000;
           bo_ij->C4dbopi = 0.000000;

-          bo_ij->C1dbopi2 = bo_ij->BO_pi2;
+          bo_ij->C1dbopi2 = 1.000000;
           bo_ij->C2dbopi2 = 0.000000;
           bo_ij->C3dbopi2 = 0.000000;
           bo_ij->C4dbopi2 = 0.000000;
```



