### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/KOKKOS/fix_qeq_reax_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.cpp
@@ -214,8 +214,6 @@ void FixQEqReaxKokkos<DeviceType>::pre_force(int vflag)
 
   copymode = 1;
 
-  int teamsize = TEAMSIZE;
-
   // allocate
   allocate_array();
 
@@ -281,7 +279,6 @@ void FixQEqReaxKokkos<DeviceType>::num_neigh_item(int ii, int &maxneigh) const
 template<class DeviceType>
 void FixQEqReaxKokkos<DeviceType>::allocate_matrix()
 {
-  int i,ii,m;
   const int inum = list->inum;
 
   nmax = atom->nmax;
@@ -369,7 +366,7 @@ KOKKOS_INLINE_FUNCTION
 void FixQEqReaxKokkos<DeviceType>::compute_h_item(int ii, int &m_fill, const bool &final) const
 {
   const int i = d_ilist[ii];
-  int j,jj,jtype,flag;
+  int j,jj,jtype;
 
   if (mask[i] & groupbit) {
 
@@ -471,7 +468,6 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve1()
 // b = b_s, x = s;
 {
   const int inum = list->inum;
-  const int ignum = inum + list->gnum;
   F_FLOAT tmp, sig_old, b_norm;
 
   const int teamsize = TEAMSIZE;
@@ -602,7 +598,6 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve2()
 // b = b_t, x = t;
 {
   const int inum = list->inum;
-  const int ignum = inum + list->gnum;
   F_FLOAT tmp, sig_old, b_norm;
 
   const int teamsize = TEAMSIZE;

--- a/src/KOKKOS/pair_reaxc_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxc_kokkos.cpp
@@ -3894,7 +3894,7 @@ void *PairReaxCKokkos<DeviceType>::extract(const char *str, int &dim)
 ------------------------------------------------------------------------- */
 
 template<class DeviceType>
-void PairReaxCKokkos<DeviceType>::ev_setup(int eflag, int vflag)
+void PairReaxCKokkos<DeviceType>::ev_setup(int eflag, int vflag, int)
 {
   int i;
 

--- a/src/KOKKOS/pair_reaxc_kokkos.h
+++ b/src/KOKKOS/pair_reaxc_kokkos.h
@@ -135,7 +135,7 @@ class PairReaxCKokkos : public PairReaxC {
   PairReaxCKokkos(class LAMMPS *);
   virtual ~PairReaxCKokkos();
 
-  void ev_setup(int, int);
+  void ev_setup(int, int, int alloc = 1);
   void compute(int, int);
   void *extract(const char *, int &);
   void init_style();

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -472,7 +472,6 @@ void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeFullB<NEIGHFLAG,EVFLAG
 
   F_FLOAT delr1[3],delr2[3],fj[3],fk[3];
   F_FLOAT evdwl = 0.0;
-  F_FLOAT fpair = 0.0;
 
   const int i = d_ilist[ii];
 

--- a/src/KOKKOS/pair_sw_kokkos.h
+++ b/src/KOKKOS/pair_sw_kokkos.h
@@ -112,9 +112,15 @@ class PairSWKokkos : public PairSW {
   t_param_1d d_params;
 
   virtual void setup_params();
+
+  KOKKOS_INLINE_FUNCTION
   void twobody(const Param&, const F_FLOAT&, F_FLOAT&, const int&, F_FLOAT&) const;
+
+  KOKKOS_INLINE_FUNCTION
   void threebody(const Param&, const Param&, const Param&, const F_FLOAT&, const F_FLOAT&, F_FLOAT *, F_FLOAT *,
                  F_FLOAT *, F_FLOAT *, const int&, F_FLOAT&) const;
+
+  KOKKOS_INLINE_FUNCTION
   void threebodyj(const Param&, const Param&, const Param&, const F_FLOAT&, const F_FLOAT&, F_FLOAT *, F_FLOAT *,
                  F_FLOAT *) const;
 

--- a/src/KOKKOS/pair_tersoff_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_kokkos.h
@@ -153,8 +153,10 @@ class PairTersoffKokkos : public PairTersoff {
   int sbmask(const int& j) const;
 
   struct params_ters{
+    KOKKOS_INLINE_FUNCTION
     params_ters(){powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
 	    	  bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;};
+    KOKKOS_INLINE_FUNCTION
     params_ters(int i){powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
 	    	  bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;};
     F_FLOAT powerm, gamma, lam3, c, d, h, powern, beta, lam2, bigb, bigr,

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.h
@@ -102,8 +102,8 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
 
   KOKKOS_INLINE_FUNCTION
   double bondorder(const int &i, const int &j, const int &k,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
 
   KOKKOS_INLINE_FUNCTION
   double ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
@@ -113,21 +113,21 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
 
   KOKKOS_INLINE_FUNCTION
   void ters_dthb(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-	      F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+        F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   void ters_dthbj(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-	      F_FLOAT *fj, F_FLOAT *fk) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+        F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   void ters_dthbk(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-	      F_FLOAT *fk) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+        F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   double vec3_dot(const F_FLOAT x[3], const double y[3]) const {
@@ -153,12 +153,14 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
   int sbmask(const int& j) const;
 
   struct params_ters{
+    KOKKOS_INLINE_FUNCTION
     params_ters(){powerm=0;lam3=0;h=0;powern=0;beta=0;lam2=0;bigb=0;bigr=0;bigd=0;
-	    lam1=0;biga=0;powern_del=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;c5=0;ca1=0;ca4=0;};
+      lam1=0;biga=0;powern_del=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;c5=0;ca1=0;ca4=0;};
+    KOKKOS_INLINE_FUNCTION
     params_ters(int i){powerm=0;lam3=0;h=0;powern=0;beta=0;lam2=0;bigb=0;bigr=0;bigd=0;
-	    lam1=0;biga=0;powern_del=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;c5=0;ca1=0;ca4=0;};
+      lam1=0;biga=0;powern_del=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;c5=0;ca1=0;ca4=0;};
     F_FLOAT powerm, lam3, h, powern, beta, lam2, bigb, bigr, bigd,
-	    lam1, biga, powern_del, cutsq, c1, c2, c3, c4, c5, ca1, ca4;
+      lam1, biga, powern_del, cutsq, c1, c2, c3, c4, c5, ca1, ca4;
   };
 
   template<int NEIGHFLAG>
@@ -170,11 +172,11 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void v_tally3(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-		F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
+    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
 
   KOKKOS_INLINE_FUNCTION
   void v_tally3_atom(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-		F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
+    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
 
   void allocate();
   void setup_params();

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.h
@@ -101,8 +101,8 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
 
   KOKKOS_INLINE_FUNCTION
   double bondorder(const int &i, const int &j, const int &k,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
 
   KOKKOS_INLINE_FUNCTION
   double ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
@@ -112,21 +112,21 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
 
   KOKKOS_INLINE_FUNCTION
   void ters_dthb(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-	      F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+        F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   void ters_dthbj(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-	      F_FLOAT *fj, F_FLOAT *fk) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+        F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   void ters_dthbk(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-	      const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-	      const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-	      F_FLOAT *fk) const;
+        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+        F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   double vec3_dot(const F_FLOAT x[3], const double y[3]) const {
@@ -152,12 +152,14 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
   int sbmask(const int& j) const;
 
   struct params_ters{
+    KOKKOS_INLINE_FUNCTION
     params_ters(){powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
-	    	  bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;Z_i=0;Z_j=0;ZBLcut=0;ZBLexpscale=0;};
+          bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;Z_i=0;Z_j=0;ZBLcut=0;ZBLexpscale=0;};
+    KOKKOS_INLINE_FUNCTION
     params_ters(int i){powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
-	    	  bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;Z_i=0;Z_j=0;ZBLcut=0;ZBLexpscale=0;};
+          bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;Z_i=0;Z_j=0;ZBLcut=0;ZBLexpscale=0;};
     F_FLOAT powerm, gamma, lam3, c, d, h, powern, beta, lam2, bigb, bigr,
-	    bigd, lam1, biga, cutsq, c1, c2, c3, c4, Z_i, Z_j, ZBLcut, ZBLexpscale;
+      bigd, lam1, biga, cutsq, c1, c2, c3, c4, Z_i, Z_j, ZBLcut, ZBLexpscale;
   };
 
   template<int NEIGHFLAG>
@@ -169,11 +171,11 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void v_tally3(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-		F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
+    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
 
   KOKKOS_INLINE_FUNCTION
   void v_tally3_atom(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-		F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
+    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
 
   void allocate();
   void setup_params();

--- a/src/KOKKOS/pair_vashishta_kokkos.cpp
+++ b/src/KOKKOS/pair_vashishta_kokkos.cpp
@@ -477,7 +477,6 @@ void PairVashishtaKokkos<DeviceType>::operator()(TagPairVashishtaComputeFullB<NE
 
   F_FLOAT delr1[3],delr2[3],fj[3],fk[3];
   F_FLOAT evdwl = 0.0;
-  F_FLOAT fpair = 0.0;
 
   const int i = d_ilist[ii];
 
@@ -735,9 +734,9 @@ void PairVashishtaKokkos<DeviceType>::threebodyj(const Param& paramij, const Par
                        const F_FLOAT& rsq1, const F_FLOAT& rsq2, F_FLOAT *delr1, F_FLOAT *delr2, F_FLOAT *fj) const
 {
   F_FLOAT r1,rinvsq1,rainv1,gsrainv1,gsrainvsq1,expgsrainv1;
-  F_FLOAT r2,rinvsq2,rainv2,gsrainv2,gsrainvsq2,expgsrainv2;
-  F_FLOAT rinv12,cs,delcs,delcssq,facexp,facrad,frad1,frad2,pcsinv,pcsinvsq,pcs;
-  F_FLOAT facang,facang12,csfacang,csfac1,csfac2;
+  F_FLOAT r2,rainv2,gsrainv2,expgsrainv2;
+  F_FLOAT rinv12,cs,delcs,delcssq,facexp,facrad,frad1,pcsinv,pcsinvsq,pcs;
+  F_FLOAT facang,facang12,csfacang,csfac1;
 
   r1 = sqrt(rsq1);
   rinvsq1 = 1.0/rsq1;
@@ -747,10 +746,8 @@ void PairVashishtaKokkos<DeviceType>::threebodyj(const Param& paramij, const Par
   expgsrainv1 = exp(gsrainv1);
 
   r2 = sqrt(rsq2);
-  rinvsq2 = 1.0/rsq2;
   rainv2 = 1.0/(r2 - paramik.r0);
   gsrainv2 = paramik.gamma * rainv2;
-  gsrainvsq2 = gsrainv2*rainv2/r2;
   expgsrainv2 = exp(gsrainv2);
 
   rinv12 = 1.0/(r1*r2);
@@ -765,7 +762,6 @@ void PairVashishtaKokkos<DeviceType>::threebodyj(const Param& paramij, const Par
 
   facrad = paramijk.bigb * facexp * pcs;
   frad1 = facrad*gsrainvsq1;
-  frad2 = facrad*gsrainvsq2;
   facang = paramijk.big2b * facexp * delcs/pcsinvsq;
   facang12 = rinv12*facang;
   csfacang = cs*facang;

--- a/src/KOKKOS/pair_vashishta_kokkos.h
+++ b/src/KOKKOS/pair_vashishta_kokkos.h
@@ -112,9 +112,15 @@ class PairVashishtaKokkos : public PairVashishta {
   t_param_1d d_params;
 
   virtual void setup_params();
+
+  KOKKOS_INLINE_FUNCTION
   void twobody(const Param&, const F_FLOAT&, F_FLOAT&, const int&, F_FLOAT&) const;
+
+  KOKKOS_INLINE_FUNCTION
   void threebody(const Param&, const Param&, const Param&, const F_FLOAT&, const F_FLOAT&, F_FLOAT *, F_FLOAT *,
                  F_FLOAT *, F_FLOAT *, const int&, F_FLOAT&) const;
+
+  KOKKOS_INLINE_FUNCTION
   void threebodyj(const Param&, const Param&, const Param&, const F_FLOAT&, const F_FLOAT&, F_FLOAT *, F_FLOAT *,
                  F_FLOAT *) const;
 

--- a/src/USER-DPD/random_external_state.h
+++ b/src/USER-DPD/random_external_state.h
@@ -66,12 +66,6 @@
 #include <math.h>
 #include "accelerator_kokkos.h"
 
-#ifdef LMP_KOKKOS
-#define RND_INLINE KOKKOS_INLINE_FUNCTION
-#else
-#define RND_INLINE inline
-#endif
-
 
 /// \file random_external_state.h
 /// \brief Pseudorandom number generators
@@ -88,7 +82,7 @@ namespace random_external_state {
   enum {MAX_URAND = 0xffffffffU};
   enum {MAX_URAND64 = 0xffffffffffffffffULL-1};
 
-  RND_INLINE
+  LAMMPS_INLINE
   uint32_t es_urand(es_RNG_t &state_) {
     state_ ^= state_ >> 12;
     state_ ^= state_ << 25;
@@ -99,7 +93,7 @@ namespace random_external_state {
     return static_cast<uint32_t>(tmp&MAX_URAND);
   }
 
-  RND_INLINE
+  LAMMPS_INLINE
   uint64_t es_urand64(es_RNG_t &state_) {
     state_ ^= state_ >> 12;
     state_ ^= state_ << 25;
@@ -107,18 +101,18 @@ namespace random_external_state {
     return (state_ * 2685821657736338717ULL) - 1;
   }
 
-  RND_INLINE
+  LAMMPS_INLINE
   int es_rand(es_RNG_t &state_) {
     return static_cast<int>(es_urand(state_)/2);
   }
 
-  RND_INLINE
+  LAMMPS_INLINE
   double es_drand(es_RNG_t &state_) {
     return 1.0 * es_urand64(state_)/MAX_URAND64;
   }
 
   //Marsaglia polar method for drawing a standard normal distributed random number
-  RND_INLINE
+  LAMMPS_INLINE
   double es_normal(es_RNG_t &state_) {
     double S, U;
     do {
@@ -129,7 +123,7 @@ namespace random_external_state {
     return U*sqrt(-2.0*log(S)/S);
   }
 
-  RND_INLINE
+  LAMMPS_INLINE
   double es_normalPair(es_RNG_t &state_, double &second) {
     double S, U, V;
     do {
@@ -145,7 +139,7 @@ namespace random_external_state {
   // Use es_init() to init a serial RNG, that is then
   // used to generate the initial state of your k parallel
   // RNGs with k calls to genNextParallelState()
-  RND_INLINE
+  LAMMPS_INLINE
   void es_init(es_RNG_t &serial_state, uint64_t seed) {
     if(seed==0) seed = uint64_t(1318319);
     serial_state = seed;
@@ -154,7 +148,7 @@ namespace random_external_state {
 
   // Call genNextParallelState() once for each RNG to generate
   // the initial state for that RNG.
-  RND_INLINE
+  LAMMPS_INLINE
   void es_genNextParallelState(es_RNG_t &serial_state, es_RNG_t &new_state) {
     int n1 = es_rand(serial_state);
     int n2 = es_rand(serial_state);

--- a/src/USER-REAXC/reaxc_allocate.cpp
+++ b/src/USER-REAXC/reaxc_allocate.cpp
@@ -327,14 +327,14 @@ static void Reallocate_Neighbor_List( reax_list *far_nbrs, int n,
 static int Reallocate_HBonds_List( reax_system *system, reax_list *hbonds,
                                    MPI_Comm comm )
 {
-  int i, id, total_hbonds;
+  int i, total_hbonds;
 
   int mincap = system->mincap;
   double saferzone = system->saferzone;
 
   total_hbonds = 0;
   for( i = 0; i < system->n; ++i )
-    if( (id = system->my_atoms[i].Hindex) >= 0 ) {
+    if( (system->my_atoms[i].Hindex) >= 0 ) {
       total_hbonds += system->my_atoms[i].num_hbonds;
     }
   total_hbonds = (int)(MAX( total_hbonds*saferzone, mincap*MIN_HBONDS ));

--- a/src/USER-REAXC/reaxc_forces.cpp
+++ b/src/USER-REAXC/reaxc_forces.cpp
@@ -178,7 +178,7 @@ void Init_Forces_noQEq( reax_system *system, control_params *control,
   int i, j, pj;
   int start_i, end_i;
   int type_i, type_j;
-  int btop_i, btop_j, num_bonds, num_hbonds;
+  int btop_i, num_bonds, num_hbonds;
   int ihb, jhb, ihb_top, jhb_top;
   int local, flag, renbr;
   double cutoff;
@@ -200,7 +200,7 @@ void Init_Forces_noQEq( reax_system *system, control_params *control,
 
   num_bonds = 0;
   num_hbonds = 0;
-  btop_i = btop_j = 0;
+  btop_i = 0;
   renbr = (data->step-data->prev_steps) % control->reneighbor == 0;
 
   for( i = 0; i < system->N; ++i ) {

--- a/src/USER-REAXC/reaxc_types.h
+++ b/src/USER-REAXC/reaxc_types.h
@@ -37,6 +37,7 @@
 #include <string.h>
 #include "sys/time.h"
 #include <time.h>
+#include "accelerator_kokkos.h"
 
 #if defined LMP_USER_OMP
 #define OMP_TIMING 1
@@ -830,6 +831,10 @@ struct LR_data
   double e_vdW, CEvd;
   double e_ele, CEclmb;
 
+  LAMMPS_INLINE
+  LR_data() {}
+
+  LAMMPS_INLINE
   void operator = (const LR_data& rhs) {
     H      = rhs.H;
     e_vdW  = rhs.e_vdW;
@@ -837,6 +842,7 @@ struct LR_data
     e_ele  = rhs.e_ele;
     CEclmb = rhs.CEclmb;
   }
+  LAMMPS_INLINE
   void operator = (const LR_data& rhs) volatile {
     H      = rhs.H;
     e_vdW  = rhs.e_vdW;
@@ -850,12 +856,18 @@ struct LR_data
 struct cubic_spline_coef
 {
   double a, b, c, d;
+
+  LAMMPS_INLINE
+  cubic_spline_coef() {}
+
+  LAMMPS_INLINE
   void operator = (const cubic_spline_coef& rhs) {
     a = rhs.a;
     b = rhs.b;
     c = rhs.c;
     d = rhs.d;
   }
+  LAMMPS_INLINE
   void operator = (const cubic_spline_coef& rhs) volatile {
     a = rhs.a;
     b = rhs.b;

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -28,6 +28,8 @@
 #include "memory_kokkos.h"
 #include "modify_kokkos.h"
 
+#define LAMMPS_INLINE KOKKOS_INLINE_FUNCTION
+
 #else
 
 // dummy interface to KOKKOS
@@ -40,6 +42,8 @@
 #include "neighbor.h"
 #include "memory.h"
 #include "modify.h"
+
+#define LAMMPS_INLINE inline
 
 namespace LAMMPS_NS {
 

--- a/src/math_special.cpp
+++ b/src/math_special.cpp
@@ -541,7 +541,8 @@ double MathSpecial::fm_exp(double x)
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return exp2_x86(FM_DOUBLE_LOG2OFE * x);
 #endif
-#endif
+#else
     return ::exp(x);
+#endif
 }
 

--- a/src/pair_lj_cut_coul_wolf.cpp
+++ b/src/pair_lj_cut_coul_wolf.cpp
@@ -275,8 +275,7 @@ void PairLJCutCoulWolf::init_style()
 
   // request regular or rRESPA neighbor list
 
-  int irequest;
-  irequest = neighbor->request(this,instance_me);
+  neighbor->request(this,instance_me);
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
## Purpose
Fix many compiler warnings, mostly in the KOKKOS package, but in a few other files as well.

## Author(s)
Stan Moore

## Backward Compatibility
No issues.
