### PR TITLE
More consistent and transparent handling for force styles with restarts

### DIFF
--- a/src/force.cpp
+++ b/src/force.cpp
@@ -78,6 +78,8 @@ Force::Force(LAMMPS *lmp) : Pointers(lmp)
   kspace_style = new char[n];
   strcpy(kspace_style,str);
 
+  pair_restart = NULL;
+
   // fill pair map with pair styles listed in style_pair.h
 
   pair_map = new PairCreatorMap();
@@ -146,6 +148,8 @@ Force::~Force()
   delete [] improper_style;
   delete [] kspace_style;
 
+  delete [] pair_restart;
+
   if (pair) delete pair;
   if (bond) delete bond;
   if (angle) delete angle;
@@ -197,8 +201,10 @@ void Force::create_pair(const char *style, int trysuffix)
 {
   delete [] pair_style;
   if (pair) delete pair;
+  if (pair_restart) delete [] pair_restart;
   pair_style = NULL;
   pair = NULL;
+  pair_restart = NULL;
 
   int sflag;
   pair = new_pair(style,trysuffix,sflag);

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -178,6 +178,16 @@ void Force::init()
 {
   qqrd2e = qqr2e/dielectric;
 
+  // check if pair style must be specified after restart
+  if (pair_restart) {
+    if (!pair) {
+      char msg[128];
+      sprintf(msg,"Must re-specify non-restarted pair style (%s) "
+              "after read_restart", pair_restart);
+      error->all(FLERR,msg);
+    }
+  }
+
   if (kspace) kspace->init();         // kspace must come before pair
   if (pair) pair->init();             // so g_ewald is defined
   if (bond) bond->init();

--- a/src/force.h
+++ b/src/force.h
@@ -50,6 +50,7 @@ class Force : protected Pointers {
 
   class Pair *pair;
   char *pair_style;
+  char *pair_restart;
 
   class Bond *bond;
   char *bond_style;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -692,6 +692,12 @@ void Pair::compute_dummy(int eflag, int vflag)
   else evflag = 0;
 }
 
+/* ---------------------------------------------------------------------- */
+void Pair::read_restart(FILE *)
+{
+  error->all(FLERR,"BUG: restartinfo=1 but no restart support in pair style");
+}
+
 /* -------------------------------------------------------------------
    register a callback to a compute, so it can compute and accumulate
    additional properties during the pair computation from within

--- a/src/pair.h
+++ b/src/pair.h
@@ -156,7 +156,7 @@ class Pair : protected Pointers {
   virtual void free_disp_tables();
 
   virtual void write_restart(FILE *) {}
-  virtual void read_restart(FILE *) {}
+  virtual void read_restart(FILE *);
   virtual void write_restart_settings(FILE *) {}
   virtual void read_restart_settings(FILE *) {}
   virtual void write_data(FILE *) {}

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -948,13 +948,13 @@ void ReadRestart::force_fields()
       style = read_string();
       force->create_pair(style,1);
       delete [] style;
-      force->pair->read_restart(fp);
       if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restored pair style %s from "
+        if (screen) fprintf(screen,"  restoring pair style %s from "
                             "restart\n", force->pair_style);
-        if (logfile) fprintf(logfile,"  restored pair style %s from "
+        if (logfile) fprintf(logfile,"  restoring pair style %s from "
                              "restart\n", force->pair_style);
       }
+      force->pair->read_restart(fp);
 
     } else if (flag == NO_PAIR) {
       style = read_string();
@@ -971,49 +971,49 @@ void ReadRestart::force_fields()
       style = read_string();
       force->create_bond(style,1);
       delete [] style;
-      force->bond->read_restart(fp);
       if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restored bond style %s from "
+        if (screen) fprintf(screen,"  restoring bond style %s from "
                             "restart\n", force->bond_style);
-        if (logfile) fprintf(logfile,"  restored bond style %s from "
+        if (logfile) fprintf(logfile,"  restoring bond style %s from "
                              "restart\n", force->bond_style);
       }
+      force->bond->read_restart(fp);
 
     } else if (flag == ANGLE) {
       style = read_string();
       force->create_angle(style,1);
       delete [] style;
-      force->angle->read_restart(fp);
       if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restored angle style %s from "
+        if (screen) fprintf(screen,"  restoring angle style %s from "
                             "restart\n", force->angle_style);
-        if (logfile) fprintf(logfile,"  restored angle style %s from "
+        if (logfile) fprintf(logfile,"  restoring angle style %s from "
                              "restart\n", force->angle_style);
       }
+      force->angle->read_restart(fp);
 
     } else if (flag == DIHEDRAL) {
       style = read_string();
       force->create_dihedral(style,1);
       delete [] style;
-      force->dihedral->read_restart(fp);
       if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restored dihedral style %s from "
+        if (screen) fprintf(screen,"  restoring dihedral style %s from "
                             "restart\n", force->dihedral_style);
-        if (logfile) fprintf(logfile,"  restored dihedral style %s from "
+        if (logfile) fprintf(logfile,"  restoring dihedral style %s from "
                              "restart\n", force->dihedral_style);
       }
+      force->dihedral->read_restart(fp);
 
     } else if (flag == IMPROPER) {
       style = read_string();
       force->create_improper(style,1);
       delete [] style;
-      force->improper->read_restart(fp);
       if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restored improper style %s from "
+        if (screen) fprintf(screen,"  restoring improper style %s from "
                             "restart\n", force->improper_style);
-        if (logfile) fprintf(logfile,"  restored improper style %s from "
+        if (logfile) fprintf(logfile,"  restoring improper style %s from "
                              "restart\n", force->improper_style);
       }
+      force->improper->read_restart(fp);
 
     } else error->all(FLERR,
                       "Invalid flag in force field section of restart file");

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -62,7 +62,7 @@ enum{VERSION,SMALLINT,TAGINT,BIGINT,
      MULTIPROC,MPIIO,PROCSPERFILE,PERPROC,
      IMAGEINT,BOUNDMIN,TIMESTEP,
      ATOM_ID,ATOM_MAP_STYLE,ATOM_MAP_USER,ATOM_SORTFREQ,ATOM_SORTBIN,
-     COMM_MODE,COMM_CUTOFF,COMM_VEL};
+     COMM_MODE,COMM_CUTOFF,COMM_VEL,NO_PAIR};
 
 #define LB_FACTOR 1.1
 
@@ -949,30 +949,71 @@ void ReadRestart::force_fields()
       force->create_pair(style,1);
       delete [] style;
       force->pair->read_restart(fp);
+      if (comm->me ==0) {
+        if (screen) fprintf(screen,"  restored pair style %s from "
+                            "restart\n", force->pair_style);
+        if (logfile) fprintf(logfile,"  restored pair style %s from "
+                             "restart\n", force->pair_style);
+      }
+
+    } else if (flag == NO_PAIR) {
+      style = read_string();
+      if (comm->me ==0) {
+        if (screen) fprintf(screen,"  pair style %s stores no "
+                            "restart info\n", style);
+        if (logfile) fprintf(logfile,"  pair style %s stores no "
+                             "restart info\n", style);
+      }
+      force->create_pair("none",0);
+      force->pair_restart = style;
 
     } else if (flag == BOND) {
       style = read_string();
       force->create_bond(style,1);
       delete [] style;
       force->bond->read_restart(fp);
+      if (comm->me ==0) {
+        if (screen) fprintf(screen,"  restored bond style %s from "
+                            "restart\n", force->bond_style);
+        if (logfile) fprintf(logfile,"  restored bond style %s from "
+                             "restart\n", force->bond_style);
+      }
 
     } else if (flag == ANGLE) {
       style = read_string();
       force->create_angle(style,1);
       delete [] style;
       force->angle->read_restart(fp);
+      if (comm->me ==0) {
+        if (screen) fprintf(screen,"  restored angle style %s from "
+                            "restart\n", force->angle_style);
+        if (logfile) fprintf(logfile,"  restored angle style %s from "
+                             "restart\n", force->angle_style);
+      }
 
     } else if (flag == DIHEDRAL) {
       style = read_string();
       force->create_dihedral(style,1);
       delete [] style;
       force->dihedral->read_restart(fp);
+      if (comm->me ==0) {
+        if (screen) fprintf(screen,"  restored dihedral style %s from "
+                            "restart\n", force->dihedral_style);
+        if (logfile) fprintf(logfile,"  restored dihedral style %s from "
+                             "restart\n", force->dihedral_style);
+      }
 
     } else if (flag == IMPROPER) {
       style = read_string();
       force->create_improper(style,1);
       delete [] style;
       force->improper->read_restart(fp);
+      if (comm->me ==0) {
+        if (screen) fprintf(screen,"  restored improper style %s from "
+                            "restart\n", force->improper_style);
+        if (logfile) fprintf(logfile,"  restored improper style %s from "
+                             "restart\n", force->improper_style);
+      }
 
     } else error->all(FLERR,
                       "Invalid flag in force field section of restart file");

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -832,6 +832,12 @@ void ReadRestart::header(int incompatible)
       for (int i = 0; i < nargcopy; i++)
         argcopy[i] = read_string();
       atom->create_avec(style,nargcopy,argcopy,1);
+      if (comm->me ==0) {
+        if (screen) fprintf(screen,"  restoring atom style %s from "
+                            "restart\n", style);
+        if (logfile) fprintf(logfile,"  restoring atom style %s from "
+                             "restart\n", style);
+      }
       for (int i = 0; i < nargcopy; i++) delete [] argcopy[i];
       delete [] argcopy;
       delete [] style;

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -61,7 +61,7 @@ enum{VERSION,SMALLINT,TAGINT,BIGINT,
      MULTIPROC,MPIIO,PROCSPERFILE,PERPROC,
      IMAGEINT,BOUNDMIN,TIMESTEP,
      ATOM_ID,ATOM_MAP_STYLE,ATOM_MAP_USER,ATOM_SORTFREQ,ATOM_SORTBIN,
-     COMM_MODE,COMM_CUTOFF,COMM_VEL};
+     COMM_MODE,COMM_CUTOFF,COMM_VEL,NO_PAIR};
 
 enum{IGNORE,WARN,ERROR};                    // same as thermo.cpp
 
@@ -555,9 +555,13 @@ void WriteRestart::type_arrays()
 
 void WriteRestart::force_fields()
 {
-  if (force->pair && force->pair->restartinfo) {
-    write_string(PAIR,force->pair_style);
-    force->pair->write_restart(fp);
+  if (force->pair) {
+    if (force->pair->restartinfo) {
+      write_string(PAIR,force->pair_style);
+      force->pair->write_restart(fp);
+    } else {
+      write_string(NO_PAIR,force->pair_style);
+    }
   }
   if (atom->avec->bonds_allow && force->bond) {
     write_string(BOND,force->bond_style);


### PR DESCRIPTION
## Purpose

When reading a restart file there is very little feedback given. The behavior can be surprising and leads to a cryptic error message when restarting a pair style that does not support writing information to a restart. This pull request implements the following changes:
- when a pair style does not store restart information, the name of the pair style is still recorded in a new (force field) section (`NO_PAIR`)
- when restarting from such a restart file, and **not** having issued a new `pair_style` command, an error message is printed during `Force::init()` and LAMMPS aborts
- when restoring force field styles from a restart, the names of the styles are printed to screen and logfile
- when a pair style does not implement the `read_restart()` method, but advertises it via `restartinfo == 1`, an error message reporting this as a bug is printed and LAMMPS aborts
- for consistency, also a message about the restored atom style is printed

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes, the old behavior is retained when reading restart files written before the changes in this PR, except for buggy pair styles without restart support that have `restartinfo == 1`. Those would have to (temporarily) re-implement read_restart() to work around the error. The only difference is that `NO_PAIR` now explicitly deletes the current pair style for consistency. The documentation explicitly states to re-issue `pair_style` and `pair_coeff` **after** `read_restart`, so this is not in conflict with the docs.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links



