### PR TITLE
Refactor PDF Manual Structure

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,7 +21,7 @@ HAS_VIRTUALENV = YES
 endif
 
 SPHINXEXTRA = -j $(shell $(PYTHON) -c 'import multiprocessing;print(multiprocessing.cpu_count())')
-SOURCES=$(filter-out src/lammps_commands.txt src/lammps_tutorials.txt,$(wildcard src/*.txt))
+SOURCES=$(filter-out $(wildcard src/lammps_commands*.txt) src/lammps_support.txt src/lammps_tutorials.txt,$(wildcard src/*.txt))
 OBJECTS=$(SOURCES:src/%.txt=$(RSTDIR)/%.rst)
 
 .PHONY: help clean-all clean epub html pdf old venv spelling anchor_check

--- a/doc/src/Manual.txt
+++ b/doc/src/Manual.txt
@@ -18,12 +18,10 @@
 
 :line
 
-<H1></H1>
+LAMMPS Documentation :c,h1
+16 Mar 2018 version :c,h2
 
-LAMMPS Documentation :c,h3
-16 Mar 2018 version :c,h4
-
-Version info: :h4
+Version info: :h3
 
 The LAMMPS "version" is the date when it was released, such as 1 May
 2010. LAMMPS is updated continuously.  Whenever we fix a bug or add a

--- a/doc/src/Section_accelerate.txt
+++ b/doc/src/Section_accelerate.txt
@@ -8,7 +8,7 @@ Section"_Section_howto.html :c
 
 :line
 
-5. Accelerating LAMMPS performance :h3
+5. Accelerating LAMMPS performance :h2
 
 This section describes various methods for improving LAMMPS
 performance for different classes of problems running on different
@@ -41,7 +41,7 @@ compute nodes, on different hardware platforms.
 :line
 :line
 
-5.1 Measuring performance :h4,link(acc_1)
+5.1 Measuring performance :h3,link(acc_1)
 
 Before trying to make your simulation run faster, you should
 understand how it currently performs and where the bottlenecks are.
@@ -89,7 +89,7 @@ LAMMPS, to obtain synchronized timings.
 
 :line
 
-5.2 General strategies :h4,link(acc_2)
+5.2 General strategies :h3,link(acc_2)
 
 NOTE: this section 5.2 is still a work in progress
 
@@ -141,7 +141,7 @@ when using a barostat.
 
 :line
 
-5.3 Packages with optimized styles :h4,link(acc_3)
+5.3 Packages with optimized styles :h3,link(acc_3)
 
 Accelerated versions of various "pair_style"_pair_style.html,
 "fixes"_fix.html, "computes"_compute.html, and other commands have
@@ -325,7 +325,7 @@ restrictions :ul
 
 :line
 
-5.4 Comparison of various accelerator packages :h4,link(acc_4)
+5.4 Comparison of various accelerator packages :h3,link(acc_4)
 
 NOTE: this section still needs to be re-worked with additional KOKKOS
 and USER-INTEL information.

--- a/doc/src/Section_commands.txt
+++ b/doc/src/Section_commands.txt
@@ -6,7 +6,7 @@
 
 :line
 
-3. Commands :h3
+3. Commands :h2
 
 This section describes how a LAMMPS input script is formatted and the
 input script commands used to define a LAMMPS simulation.
@@ -190,7 +190,7 @@ allowed, but that should be sufficient for most use cases.
 
 :line
 
-3.3 Input script structure :h4,link(cmd_3)
+3.3 Input script structure :h3,link(cmd_3)
 
 This section describes the structure of a typical LAMMPS input script.
 The "examples" directory in the LAMMPS distribution contains many
@@ -414,7 +414,7 @@ Input script control:
 
 :line
 
-3.5 Individual commands :h4,link(cmd_5),link(comm)
+3.5 Individual commands :h3,link(cmd_5),link(comm)
 
 This section lists all LAMMPS commands alphabetically, with a separate
 listing below of styles within certain commands.  The "previous
@@ -537,7 +537,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Fix styles :h4
+Fix styles :h3
 
 See the "fix"_fix.html command for one-line descriptions of each style
 or click on the style itself for a full description.  Some of the
@@ -751,7 +751,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Compute styles :h4
+Compute styles :h3
 
 See the "compute"_compute.html command for one-line descriptions of
 each style or click on the style itself for a full description.  Some
@@ -894,7 +894,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Pair_style potentials :h4
+Pair_style potentials :h3
 
 See the "pair_style"_pair_style.html command for an overview of pair
 potentials.  Click on the style itself for a full description.  Many
@@ -1107,7 +1107,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Bond_style potentials :h4
+Bond_style potentials :h3
 
 See the "bond_style"_bond_style.html command for an overview of bond
 potentials.  Click on the style itself for a full description.  Some
@@ -1141,7 +1141,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Angle_style potentials :h4
+Angle_style potentials :h3
 
 See the "angle_style"_angle_style.html command for an overview of
 angle potentials.  Click on the style itself for a full description.
@@ -1177,7 +1177,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Dihedral_style potentials :h4
+Dihedral_style potentials :h3
 
 See the "dihedral_style"_dihedral_style.html command for an overview
 of dihedral potentials.  Click on the style itself for a full
@@ -1211,7 +1211,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Improper_style potentials :h4
+Improper_style potentials :h3
 
 See the "improper_style"_improper_style.html command for an overview
 of improper potentials.  Click on the style itself for a full
@@ -1240,7 +1240,7 @@ package"_Section_start.html#start_3.
 
 :line
 
-Kspace solvers :h4
+Kspace solvers :h3
 
 See the "kspace_style"_kspace_style.html command for an overview of
 Kspace solvers.  Click on the style itself for a full description.

--- a/doc/src/Section_errors.txt
+++ b/doc/src/Section_errors.txt
@@ -8,7 +8,7 @@ Section"_Section_history.html :c
 
 :line
 
-12. Errors :h3
+12. Errors :h2
 
 This section describes the errors you can encounter when using LAMMPS,
 either conceptually, or as printed out by the program.
@@ -167,7 +167,7 @@ As a last resort, you can send an email directly to the
 
 :line
 
-12.3 Error & warning messages :h4,link(err_3)
+12.3 Error & warning messages :h3,link(err_3)
 
 These are two alphabetic lists of the "ERROR"_#error and
 "WARNING"_#warn messages LAMMPS prints out and the reason why.  If the
@@ -186,7 +186,7 @@ packages"_Section_start.html#start_3 are not listed here.  If such an
 error occurs and is not self-explanatory, you'll need to look in the
 source code or contact the author of the package.
 
-Errors: :h4,link(error)
+Errors: :h3,link(error)
 
 :dlb
 
@@ -11037,7 +11037,7 @@ Self-explanatory. :dd
 
 :dle
 
-Warnings: :h4,link(warn)
+Warnings: :h3,link(warn)
 
 :dlb
 

--- a/doc/src/Section_example.txt
+++ b/doc/src/Section_example.txt
@@ -6,7 +6,7 @@
 
 :line
 
-7. Example problems :h3
+7. Example problems :h2
 
 The LAMMPS distribution includes an examples sub-directory with many
 sample problems.  Many are 2d models that run quickly are are
@@ -46,7 +46,7 @@ Lists of both kinds of directories are given below.
 
 :line
 
-Lowercase directories :h4
+Lowercase directories :h3
 
 accelerate: run with various acceleration options (OpenMP, GPU, Phi)
 airebo:   polyethylene with AIREBO potential
@@ -122,7 +122,7 @@ browser.
 
 :line
 
-Uppercase directories :h4
+Uppercase directories :h3
 
 ASPHERE: various aspherical particle models, using ellipsoids, rigid bodies, line/triangle particles, etc
 COUPLE: examples of how to use LAMMPS as a library

--- a/doc/src/Section_history.txt
+++ b/doc/src/Section_history.txt
@@ -8,7 +8,7 @@ Section"_Manual.html :c
 
 :line
 
-13. Future and history :h3
+13. Future and history :h2
 
 This section lists features we plan to add to LAMMPS, features of
 previous versions of LAMMPS, and features of other parallel molecular
@@ -20,7 +20,7 @@ dynamics codes our group has distributed.
 :line
 :line
 
-13.1 Coming attractions :h4,link(hist_1)
+13.1 Coming attractions :h3,link(hist_1)
 
 As of summer 2016 we are using the "LAMMPS project issue tracker
 on GitHub"_https://github.com/lammps/lammps/issues for keeping
@@ -46,7 +46,7 @@ if you want to have your suggestion added to the list.
 
 :line
 
-13.2 Past versions :h4,link(hist_2)
+13.2 Past versions :h3,link(hist_2)
 
 LAMMPS development began in the mid 1990s under a cooperative research
 & development agreement (CRADA) between two DOE labs (Sandia and LLNL)

--- a/doc/src/Section_howto.txt
+++ b/doc/src/Section_howto.txt
@@ -6,7 +6,7 @@
 
 :line
 
-6. How-to discussions :h3
+6. How-to discussions :h2
 
 This section describes how to perform common tasks using LAMMPS.
 
@@ -1058,7 +1058,7 @@ Example input scripts for these kinds of models are in the body,
 colloid, dipole, ellipse, line, peri, pour, and tri directories of the
 "examples directory"_Section_example.html in the LAMMPS distribution.
 
-Atom styles :h5
+Atom styles :h4
 
 There are several "atom styles"_atom_style.html that allow for
 definition of finite-size particles: sphere, dipole, ellipsoid, line,
@@ -1140,7 +1140,7 @@ ellipses.  This means they have the same moment of inertia as the 3d
 object.  When temperature is computed, the correct degrees of freedom
 are used for rotation in a 2d versus 3d system.
 
-Pair potentials :h5
+Pair potentials :h4
 
 When a system with finite-size particles is defined, the particles
 will only rotate and experience torque if the force field computes
@@ -1168,7 +1168,7 @@ Brownian and lubrication potentials are used with spherical particles.
 The line, tri, and body potentials are used with line segment,
 triangular, and body particles respectively.
 
-Time integration :h5
+Time integration :h4
 
 There are several fixes that perform time integration on finite-size
 spherical particles, meaning the integrators update the rotational
@@ -1204,7 +1204,7 @@ Note that for mixtures of point and finite-size particles, these
 integration fixes can only be used with "groups"_group.html which
 contain finite-size particles.
 
-Computes, thermodynamics, and dump output :h5
+Computes, thermodynamics, and dump output :h4
 
 There are several computes that calculate the temperature or
 rotational energy of spherical or ellipsoidal particles:
@@ -1236,7 +1236,7 @@ angular momentum, the quaternion, the torque, the end-point and
 corner-point coordinates (for line and tri particles), and
 sub-particle attributes of body particles.
 
-Rigid bodies composed of finite-size particles :h5
+Rigid bodies composed of finite-size particles :h4
 
 The "fix rigid"_fix_rigid.html command treats a collection of
 particles as a rigid body, computes its inertia tensor, sums the total
@@ -1319,7 +1319,7 @@ to output and the kind of data they operate on and produce:
 "Variables that generate values to output"_#variable
 "Summary table of output options and data flow between commands"_#table :ul
 
-Global/per-atom/local data :h5,link(global)
+Global/per-atom/local data :h4,link(global)
 
 Various output-related commands work with three different styles of
 data: global, per-atom, or local.  A global datum is one or more
@@ -1329,7 +1329,7 @@ atom.  Local datums are calculated by each processor based on the
 atoms it owns, but there may be zero or more per atom, e.g. a list of
 bond distances.
 
-Scalar/vector/array data :h5,link(scalar)
+Scalar/vector/array data :h4,link(scalar)
 
 Global, per-atom, and local datums can each come in three kinds: a
 single scalar value, a vector of values, or a 2d array of values.  The
@@ -1352,7 +1352,7 @@ the dimension twice (array -> scalar).  Thus a command that uses
 scalar values as input can typically also process elements of a vector
 or array.
 
-Thermodynamic output :h5,link(thermo)
+Thermodynamic output :h4,link(thermo)
 
 The frequency and format of thermodynamic output is set by the
 "thermo"_thermo.html, "thermo_style"_thermo_style.html, and
@@ -1377,7 +1377,7 @@ intensive values; you can include a division by "natoms" in the
 formula if desired, to make an extensive calculation produce an
 intensive result.
 
-Dump file output :h5,link(dump)
+Dump file output :h4,link(dump)
 
 Dump file output is specified by the "dump"_dump.html and
 "dump_modify"_dump_modify.html commands.  There are several
@@ -1401,7 +1401,7 @@ provides the values to be output.  In each case, the compute or fix
 must generate local values for input to the "dump local"_dump.html
 command.
 
-Fixes that write output files :h5,link(fixoutput)
+Fixes that write output files :h4,link(fixoutput)
 
 Several fixes take various quantities as input and can write output
 files: "fix ave/time"_fix_ave_time.html, "fix
@@ -1455,7 +1455,7 @@ values for a specific atom.  Thus the "fix print"_fix_print.html
 command is a means to output a wide variety of quantities separate
 from normal thermodynamic or dump file output.
 
-Computes that process output quantities :h5,link(computeoutput)
+Computes that process output quantities :h4,link(computeoutput)
 
 The "compute reduce"_compute_reduce.html and "compute
 reduce/region"_compute_reduce.html commands take one or more per-atom
@@ -1481,7 +1481,7 @@ info, etc) and stores the values in a local vector or array.  These
 are produced as output values which can be used as input to other
 output commands.
 
-Fixes that process output quantities :h5,link(fixprocoutput)
+Fixes that process output quantities :h4,link(fixprocoutput)
 
 The "fix vector"_fix_vector.html command can create global vectors as
 output from global scalars as input, accumulating them one element at
@@ -1503,7 +1503,7 @@ including per-atom quantities calculated by a "compute"_compute.html,
 by a "fix"_fix.html, or by an atom-style "variable"_variable.html.
 The output of this fix can be used as input to other output commands.
 
-Computes that generate values to output :h5,link(compute)
+Computes that generate values to output :h4,link(compute)
 
 Every "compute"_compute.html in LAMMPS produces either global or
 per-atom or local values.  The values can be scalars or vectors or
@@ -1513,7 +1513,7 @@ describes what it produces.  Computes that produce per-atom or local
 values have the word "atom" or "local" in their style name.  Computes
 without the word "atom" or "local" produce global values.
 
-Fixes that generate values to output :h5,link(fix)
+Fixes that generate values to output :h4,link(fix)
 
 Some "fixes"_fix.html in LAMMPS produces either global or per-atom or
 local values which can be accessed by other commands.  The values can
@@ -1522,7 +1522,7 @@ using the other commands described in this section.  The doc page for
 each fix command tells whether it produces any output quantities and
 describes them.
 
-Variables that generate values to output :h5,link(variable)
+Variables that generate values to output :h4,link(variable)
 
 "Variables"_variable.html defined in an input script can store one or
 more strings.  But equal-style, vector-style, and atom-style or
@@ -1534,7 +1534,7 @@ computes, fixes, and other variables.  The values generated by
 variables can be used as input to and thus output by the other
 commands described in this section.
 
-Summary table of output options and data flow between commands :h5,link(table)
+Summary table of output options and data flow between commands :h4,link(table)
 
 This table summarizes the various commands that can be used for
 generating output from LAMMPS.  Each command produces output data of
@@ -2264,7 +2264,7 @@ Here, each of the 3 kinds of chunk-related commands is briefly
 overviewed.  Then some examples are given of how to compute different
 properties with chunk commands.
 
-Compute chunk/atom command: :h5
+Compute chunk/atom command: :h4
 
 This compute can assign atoms to chunks of various styles.  Only atoms
 in the specified group and optional specified region are assigned to a
@@ -2303,7 +2303,7 @@ do this.  You can also define a "per-atom variable"_variable.html in
 the input script that uses a formula to generate a chunk ID for each
 atom.
 
-Fix ave/chunk command: :h5
+Fix ave/chunk command: :h4
 
 This fix takes the ID of a "compute
 chunk/atom"_compute_chunk_atom.html command as input.  For each chunk,
@@ -2320,7 +2320,7 @@ values to be time-averaged in various ways, and output to a file.  The
 fix produces a global array as output with one row of values per
 chunk.
 
-Compute */chunk commands: :h5
+Compute */chunk commands: :h4
 
 Currently the following computes operate on chunks of atoms to produce
 per-chunk values.
@@ -2365,7 +2365,7 @@ variables"_variable.html, like sum() and max().  E.g. to find the
 largest cluster or fastest diffusing molecule. :l
 :ule
 
-Example calculations with chunks :h5
+Example calculations with chunks :h4
 
 Here are examples using chunk commands to calculate various
 properties:

--- a/doc/src/Section_intro.txt
+++ b/doc/src/Section_intro.txt
@@ -6,7 +6,7 @@
 
 :line
 
-1. Introduction :h3
+1. Introduction :h2
 
 This section provides an overview of what LAMMPS can and can't do,
 describes what it means for LAMMPS to be an open-source code, and
@@ -97,7 +97,7 @@ favorite interatomic potential, boundary condition, or atom type, see
 "Section 10"_Section_modify.html, which describes how you can add
 it to LAMMPS.
 
-General features :h5
+General features :h4
 
   runs on a single processor or in parallel
   distributed-memory message-passing parallelism (MPI)
@@ -114,7 +114,7 @@ General features :h5
   build as library, invoke LAMMPS thru library interface or provided Python wrapper
   couple with other codes: LAMMPS calls other code, other code calls LAMMPS, umbrella code calls both :ul
 
-Particle and model types :h5
+Particle and model types :h4
 ("atom style"_atom_style.html command)
 
   atoms
@@ -130,7 +130,7 @@ Particle and model types :h5
   rigid collections of particles
   hybrid combinations of these :ul
 
-Force fields :h5
+Force fields :h4
 ("pair style"_pair_style.html, "bond style"_bond_style.html,
 "angle style"_angle_style.html, "dihedral style"_dihedral_style.html,
 "improper style"_improper_style.html, "kspace style"_kspace_style.html
@@ -169,7 +169,7 @@ commands)
     potentials can be used in one simulation
   overlaid potentials: superposition of multiple pair potentials :ul
 
-Atom creation :h5
+Atom creation :h4
 ("read_data"_read_data.html, "lattice"_lattice.html,
 "create_atoms"_create_atoms.html, "delete_atoms"_delete_atoms.html,
 "displace_atoms"_displace_atoms.html, "replicate"_replicate.html commands)
@@ -180,7 +180,7 @@ Atom creation :h5
   replicate existing atoms multiple times
   displace atoms :ul
 
-Ensembles, constraints, and boundary conditions :h5
+Ensembles, constraints, and boundary conditions :h4
 ("fix"_fix.html command)
 
   2d or 3d systems
@@ -198,7 +198,7 @@ Ensembles, constraints, and boundary conditions :h5
   non-equilibrium molecular dynamics (NEMD)
   variety of additional boundary conditions and constraints :ul
 
-Integrators :h5
+Integrators :h4
 ("run"_run.html, "run_style"_run_style.html, "minimize"_minimize.html commands)
 
   velocity-Verlet integrator
@@ -208,11 +208,11 @@ Integrators :h5
   rRESPA hierarchical timestepping
   rerun command for post-processing of dump files :ul
 
-Diagnostics :h5
+Diagnostics :h4
 
   see the various flavors of the "fix"_fix.html and "compute"_compute.html commands :ul
 
-Output :h5
+Output :h4
 ("dump"_dump.html, "restart"_restart.html commands)
 
   log file of thermodynamic info
@@ -225,14 +225,14 @@ Output :h5
   time averaging of system-wide quantities
   atom snapshots in native, XYZ, XTC, DCD, CFG formats :ul
 
-Multi-replica models :h5
+Multi-replica models :h4
 
 "nudged elastic band"_neb.html
 "parallel replica dynamics"_prd.html
 "temperature accelerated dynamics"_tad.html
 "parallel tempering"_temper.html
 
-Pre- and post-processing :h5
+Pre- and post-processing :h4
 
 Various pre- and post-processing serial tools are packaged
 with LAMMPS; see these "doc pages"_Section_tools.html. :ulb,l
@@ -247,7 +247,7 @@ Pizza.py WWW site"_pizza. :l
 :link(pizza,http://www.sandia.gov/~sjplimp/pizza.html)
 :link(python,http://www.python.org)
 
-Specialized features :h5
+Specialized features :h4
 
 LAMMPS can be built with optional packages which implement a variety
 of additional capabilities.  An overview of all the packages is "given
@@ -468,7 +468,7 @@ encouraged. :l
 
 :line
 
-1.5 Acknowledgments and citations :h4,link(intro_5)
+1.5 Acknowledgments and citations :h3,link(intro_5)
 
 LAMMPS development has been funded by the "US Department of
 Energy"_doe (DOE), through its CRADA, LDRD, ASCI, and Genomes-to-Life

--- a/doc/src/Section_modify.txt
+++ b/doc/src/Section_modify.txt
@@ -8,7 +8,7 @@ Section"_Section_python.html :c
 
 :line
 
-10. Modifying & extending LAMMPS :h3
+10. Modifying & extending LAMMPS :h2
 
 This section describes how to customize LAMMPS by modifying
 and extending its source code.

--- a/doc/src/Section_packages.txt
+++ b/doc/src/Section_packages.txt
@@ -8,7 +8,7 @@ Section"_Section_accelerate.html :c
 
 :line
 
-4. Packages :h3
+4. Packages :h2
 
 This section gives an overview of the optional packages that extend
 LAMMPS functionality with instructions on how to build LAMMPS with

--- a/doc/src/Section_perf.txt
+++ b/doc/src/Section_perf.txt
@@ -6,7 +6,7 @@
 
 :line
 
-8. Performance & scalability :h3
+8. Performance & scalability :h2
 
 Current LAMMPS performance is discussed on the Benchmarks page of the
 "LAMMPS WWW Site"_lws where CPU timings and parallel efficiencies are

--- a/doc/src/Section_python.txt
+++ b/doc/src/Section_python.txt
@@ -6,7 +6,7 @@
 
 :line
 
-11. Python interface to LAMMPS :h3
+11. Python interface to LAMMPS :h2
 
 LAMMPS can work together with Python in three ways.  First, Python can
 wrap LAMMPS through the "LAMMPS library
@@ -443,7 +443,7 @@ If an error occurs, carefully go thru the steps in "Section
 library and about insuring Python can find the necessary two files
 it needs.
 
-[Test LAMMPS and Python in serial:] :h5
+[Test LAMMPS and Python in serial:] :h4
 
 To run a LAMMPS test in serial, type these lines into Python
 interactively from the bench directory:
@@ -462,7 +462,7 @@ typed something like:
 
 lmp_g++ -in in.lj :pre
 
-[Test LAMMPS and Python in parallel:] :h5
+[Test LAMMPS and Python in parallel:] :h4
 
 To run LAMMPS in parallel, assuming you have installed the
 "PyPar"_https://github.com/daleroberts/pypar package as discussed
@@ -510,7 +510,7 @@ described in the PyPar documentation.  The last line of your Python
 script should be pypar.finalize(), to insure MPI is shut down
 correctly.
 
-[Running Python scripts:] :h5
+[Running Python scripts:] :h4
 
 Note that any Python script (not just for LAMMPS) can be invoked in
 one of several ways:

--- a/doc/src/Section_start.txt
+++ b/doc/src/Section_start.txt
@@ -6,7 +6,7 @@
 
 :line
 
-2. Getting Started :h3
+2. Getting Started :h2
 
 This section describes how to build and run LAMMPS, for both new and
 experienced users.
@@ -22,7 +22,7 @@ experienced users.
 
 :line
 
-2.1 What's in the LAMMPS distribution :h4,link(start_1)
+2.1 What's in the LAMMPS distribution :h3,link(start_1)
 
 When you download a LAMMPS tarball you will need to unzip and untar
 the downloaded file with the following commands, after placing the
@@ -64,7 +64,7 @@ launch a LAMMPS Windows executable on a Windows box.
 
 :line
 
-2.2 Making LAMMPS :h4,link(start_2)
+2.2 Making LAMMPS :h3,link(start_2)
 
 This section has the following sub-sections:
 
@@ -77,7 +77,7 @@ This section has the following sub-sections:
 
 :line
 
-Read this first :h5,link(start_2_1)
+Read this first :h4,link(start_2_1)
 
 If you want to avoid building LAMMPS yourself, read the preceding
 section about options available for downloading and installing
@@ -148,9 +148,9 @@ include it in the LAMMPS distribution.
 
 :line
 
-Steps to build a LAMMPS executable :h5,link(start_2_2)
+Steps to build a LAMMPS executable :h4,link(start_2_2)
 
-Step 0 :h6
+Step 0 :h5
 
 The src directory contains the C++ source and header files for LAMMPS.
 It also contains a top-level Makefile and a MAKE sub-directory with
@@ -198,7 +198,7 @@ Note that by default only a few of LAMMPS optional packages are
 installed.  To build LAMMPS with optional packages, see "this
 section"_#start_3 below.
 
-Step 1 :h6
+Step 1 :h5
 
 If Step 0 did not work, you will need to create a low-level Makefile
 for your machine, like Makefile.foo.  You should make a copy of an
@@ -209,13 +209,13 @@ the first line, the "compiler/linker settings" section, and the
 file in src/MAKE/MINE and it will not be altered by any future LAMMPS
 updates.
 
-Step 2 :h6
+Step 2 :h5
 
 Change the first line of Makefile.foo to list the word "foo" after the
 "#", and whatever other options it will set.  This is the line you
 will see if you just type "make".
 
-Step 3 :h6
+Step 3 :h5
 
 The "compiler/linker settings" section lists compiler and linker
 settings for your C++ compiler, including optimization flags.  You can
@@ -244,7 +244,7 @@ first time on a new platform, a long list of *.d files will be printed
 out rapidly.  This is not an error; it is the Makefile doing its
 normal creation of dependencies.
 
-Step 4 :h6
+Step 4 :h5
 
 The "system-specific settings" section has several parts.  Note that
 if you change any -D setting in this section, you should do a full
@@ -345,7 +345,7 @@ platforms.  The -DPACK_ARRAY setting is the default.  See the
 "kspace_style"_kspace_style.html command for info about PPPM.  See
 Step 6 below for info about building LAMMPS with an FFT library.
 
-Step 5 :h6
+Step 5 :h5
 
 The 3 MPI variables are used to specify an MPI library to build LAMMPS
 with.  Note that you do not need to set these if you use the MPI
@@ -401,7 +401,7 @@ Note that the ANSI-standard function clock() rolls over after an hour
 or so, and is therefore insufficient for timing long LAMMPS
 simulations.
 
-Step 6 :h6
+Step 6 :h5
 
 The 3 FFT variables allow you to specify an FFT library which LAMMPS
 uses (for performing 1d FFTs) when running the particle-particle
@@ -482,7 +482,7 @@ double-precision library (libdfftw.a and not the default libfftw.a),
 then you can specify -DFFT_SIZE (and not -DFFT_SINGLE), and specify
 -ldfftw to use double-precision FFTs.
 
-Step 7 :h6
+Step 7 :h5
 
 The 3 JPG variables allow you to specify a JPEG and/or PNG library
 which LAMMPS uses when writing out JPEG or PNG files via the "dump
@@ -505,13 +505,13 @@ find it.
 As before, if these header and library files are in the usual place on
 your machine, you may not need to set these variables.
 
-Step 8 :h6
+Step 8 :h5
 
 Note that by default only a few of LAMMPS optional packages are
 installed.  To build LAMMPS with optional packages, see "this
 section"_#start_3 below, before proceeding to Step 9.
 
-Step 9 :h6
+Step 9 :h5
 
 That's it.  Once you have a correct Makefile.foo, and you have
 pre-built any other needed libraries (e.g. MPI, FFT, etc) all you need
@@ -530,7 +530,7 @@ You should get the executable lmp_foo when the build is complete.
 
 :line
 
-Errors that can occur when making LAMMPS :h5 :link(start_2_3)
+Errors that can occur when making LAMMPS :h4 :link(start_2_3)
 
 If an error occurs when building LAMMPS, the compiler or linker will
 state very explicitly what the problem is.  The error message should
@@ -567,21 +567,21 @@ above in Step 4.
 
 :line
 
-Additional build tips :h5,link(start_2_4)
+Additional build tips :h4,link(start_2_4)
 
-Building LAMMPS for multiple platforms. :h6
+Building LAMMPS for multiple platforms. :h5
 
 You can make LAMMPS for multiple platforms from the same src
 directory.  Each target creates its own object sub-directory called
 Obj_target where it stores the system-specific *.o files.
 
-Cleaning up. :h6
+Cleaning up. :h5
 
 Typing "make clean-all" or "make clean-machine" will delete *.o object
 files created when LAMMPS is built, for either all builds or for a
 particular machine.
 
-Changing the LAMMPS size limits via -DLAMMPS_SMALLBIG or -DLAMMPS_BIGBIG or -DLAMMPS_SMALLSMALL :h6
+Changing the LAMMPS size limits via -DLAMMPS_SMALLBIG or -DLAMMPS_BIGBIG or -DLAMMPS_SMALLSMALL :h5
 
 As explained above, any of these 3 settings can be specified on the
 LMP_INC line in your low-level src/MAKE/Makefile.foo.
@@ -631,14 +631,14 @@ neighbor lists and would run very slowly in terms of CPU secs/timestep.
 
 :line
 
-Building for a Mac :h5,link(start_2_5)
+Building for a Mac :h4,link(start_2_5)
 
 OS X is a derivative of BSD Unix, so it should just work.  See the
 src/MAKE/MACHINES/Makefile.mac and Makefile.mac_mpi files.
 
 :line
 
-Building for Windows :h5,link(start_2_6)
+Building for Windows :h4,link(start_2_6)
 
 If you want to build a Windows version of LAMMPS, you can build it
 yourself, but it may require some effort. LAMMPS expects a Unix-like
@@ -678,7 +678,7 @@ examples, but no source code.
 
 :line
 
-2.3 Making LAMMPS with optional packages :h4,link(start_3)
+2.3 Making LAMMPS with optional packages :h3,link(start_3)
 
 This section has the following sub-sections:
 
@@ -688,7 +688,7 @@ This section has the following sub-sections:
 
 :line
 
-Package basics: :h5,link(start_3_1)
+Package basics: :h4,link(start_3_1)
 
 The source code for LAMMPS is structured as a set of core files which
 are always included, plus optional packages.  Packages are groups of
@@ -719,7 +719,7 @@ known to your executable, and immediately exit.
 
 :line
 
-Including/excluding packages :h5,link(start_3_2)
+Including/excluding packages :h4,link(start_3_2)
 
 To use (or not use) a package you must install it (or un-install it)
 before building LAMMPS.  From the src directory, this is as simple as:
@@ -823,7 +823,7 @@ options.
 
 :line
 
-Packages that require extra libraries :h5,link(start_3_3)
+Packages that require extra libraries :h4,link(start_3_3)
 
 A few of the standard and user packages require extra libraries.  See
 "Section 4"_Section_packages.html for two tables of packages which
@@ -925,7 +925,7 @@ Makefile.opt :ul
 
 :line
 
-2.4 Building LAMMPS as a library :h4,link(start_4)
+2.4 Building LAMMPS as a library :h3,link(start_4)
 
 LAMMPS can be built as either a static or shared library, which can
 then be called from another application or a scripting language.  See
@@ -933,7 +933,7 @@ then be called from another application or a scripting language.  See
 LAMMPS to other codes.  See "this section"_Section_python.html for
 more info on wrapping and running LAMMPS from Python.
 
-Static library :h5
+Static library :h4
 
 To build LAMMPS as a static library (*.a file on Linux), type
 
@@ -947,7 +947,7 @@ will create the file liblammps_foo.a which another application can
 link to.  It will also create a soft link liblammps.a, which will
 point to the most recently built static library.
 
-Shared library :h5
+Shared library :h4
 
 To build LAMMPS as a shared library (*.so file on Linux), which can be
 dynamically loaded, e.g. from Python, type
@@ -1004,7 +1004,7 @@ You may need to use "sudo make install" in place of the last line if
 you do not have write privileges for /usr/local/lib.  The end result
 should be the file /usr/local/lib/libmpich.so.
 
-[Additional requirement for using a shared library:] :h5
+[Additional requirement for using a shared library:] :h4
 
 The operating system finds shared libraries to load at run-time using
 the environment variable LD_LIBRARY_PATH.  So you may wish to copy the
@@ -1019,7 +1019,7 @@ For the csh or tcsh shells, you would add something like this to your
 
 setenv LD_LIBRARY_PATH $\{LD_LIBRARY_PATH\}:/home/sjplimp/lammps/src :pre
 
-Calling the LAMMPS library :h5
+Calling the LAMMPS library :h4
 
 Either flavor of library (static or shared) allows one or more LAMMPS
 objects to be instantiated from the calling program.
@@ -1047,7 +1047,7 @@ interface and how to extend it for your needs.
 
 :line
 
-2.5 Running LAMMPS :h4,link(start_5)
+2.5 Running LAMMPS :h3,link(start_5)
 
 By default, LAMMPS runs by reading commands from standard input.  Thus
 if you run the LAMMPS executable by itself, e.g.
@@ -1193,7 +1193,7 @@ more processors or setup a smaller problem.
 
 :line
 
-2.6 Command-line options :h4,link(start_6)
+2.6 Command-line options :h3,link(start_6)
 
 At run time, LAMMPS recognizes several optional command-line switches
 which may be used in any order.  Either the full word or a one-or-two
@@ -1623,7 +1623,7 @@ negative numeric value.  It is OK if the first value1 starts with a
 
 :line
 
-2.7 LAMMPS screen output :h4,link(start_7)
+2.7 LAMMPS screen output :h3,link(start_7)
 
 As LAMMPS reads an input script, it prints information to both the
 screen and a log file about significant actions it takes to setup a
@@ -1779,7 +1779,7 @@ communication, roughly 75% in the example above.
 
 :line
 
-2.8 Tips for users of previous LAMMPS versions :h4,link(start_8)
+2.8 Tips for users of previous LAMMPS versions :h3,link(start_8)
 
 The current C++ began with a complete rewrite of LAMMPS 2001, which
 was written in F90.  Features of earlier versions of LAMMPS are listed

--- a/doc/src/Section_tools.txt
+++ b/doc/src/Section_tools.txt
@@ -8,7 +8,7 @@ Section"_Section_modify.html :c
 
 :line
 
-9. Additional tools :h3
+9. Additional tools :h2
 
 LAMMPS is designed to be a computational kernel for performing
 molecular dynamics computations.  Additional pre- and post-processing
@@ -75,7 +75,7 @@ own sub-directories with their own Makefiles and/or README files.
 
 :line
 
-amber2lmp tool :h4,link(amber)
+amber2lmp tool :h3,link(amber)
 
 The amber2lmp sub-directory contains two Python scripts for converting
 files back-and-forth between the AMBER MD code and LAMMPS.  See the
@@ -90,7 +90,7 @@ necessary modifications yourself.
 
 :line
 
-binary2txt tool :h4,link(binary)
+binary2txt tool :h3,link(binary)
 
 The file binary2txt.cpp converts one or more binary LAMMPS dump file
 into ASCII text files.  The syntax for running the tool is
@@ -103,7 +103,7 @@ since binary files are not compatible across all platforms.
 
 :line
 
-ch2lmp tool :h4,link(charmm)
+ch2lmp tool :h3,link(charmm)
 
 The ch2lmp sub-directory contains tools for converting files
 back-and-forth between the CHARMM MD code and LAMMPS.
@@ -128,7 +128,7 @@ Chris Lorenz (chris.lorenz at kcl.ac.uk), King's College London.
 
 :line
 
-chain tool :h4,link(chain)
+chain tool :h3,link(chain)
 
 The file chain.f creates a LAMMPS data file containing bead-spring
 polymer chains and/or monomer solvent atoms.  It uses a text file
@@ -145,7 +145,7 @@ system for the "chain benchmark"_Section_perf.html.
 
 :line
 
-colvars tools :h4,link(colvars)
+colvars tools :h3,link(colvars)
 
 The colvars directory contains a collection of tools for postprocessing
 data produced by the colvars collective variable library.
@@ -167,7 +167,7 @@ gmail.com) at ICTP, Italy.
 
 :line
 
-createatoms tool :h4,link(createatoms)
+createatoms tool :h3,link(createatoms)
 
 The tools/createatoms directory contains a Fortran program called
 createAtoms.f which can generate a variety of interesting crystal
@@ -180,7 +180,7 @@ The tool is authored by Xiaowang Zhou (Sandia), xzhou at sandia.gov.
 
 :line
 
-doxygen tool :h4,link(doxygen)
+doxygen tool :h3,link(doxygen)
 
 The tools/doxygen directory contains a shell script called
 doxygen.sh which can generate a call graph and API lists using
@@ -192,7 +192,7 @@ The tool is authored by Nandor Tamaskovics, numericalfreedom at googlemail.com.
 
 :line
 
-drude tool :h4,link(drude)
+drude tool :h3,link(drude)
 
 The tools/drude directory contains a Python script called
 polarizer.py which can add Drude oscillators to a LAMMPS
@@ -205,7 +205,7 @@ at univ-bpclermont.fr, alain.dequidt at univ-bpclermont.fr
 
 :line
 
-eam database tool :h4,link(eamdb)
+eam database tool :h3,link(eamdb)
 
 The tools/eam_database directory contains a Fortran program that will
 generate EAM alloy setfl potential files for any combination of 16
@@ -221,7 +221,7 @@ X. W. Zhou, R. A. Johnson, and H. N. G. Wadley, Phys. Rev. B, 69,
 
 :line
 
-eam generate tool :h4,link(eamgn)
+eam generate tool :h3,link(eamgn)
 
 The tools/eam_generate directory contains several one-file C programs
 that convert an analytic formula into a tabulated "embedded atom
@@ -234,7 +234,7 @@ The source files and potentials were provided by Gerolf Ziegenhain
 
 :line
 
-eff tool :h4,link(eff)
+eff tool :h3,link(eff)
 
 The tools/eff directory contains various scripts for generating
 structures and post-processing output for simulations using the
@@ -245,7 +245,7 @@ These tools were provided by Andres Jaramillo-Botero at CalTech
 
 :line
 
-emacs tool :h4,link(emacs)
+emacs tool :h3,link(emacs)
 
 The tools/emacs directory contains a Lips add-on file for Emacs that
 enables a lammps-mode for editing of input scripts when using Emacs,
@@ -256,7 +256,7 @@ These tools were provided by Aidan Thompson at Sandia
 
 :line
 
-fep tool :h4,link(fep)
+fep tool :h3,link(fep)
 
 The tools/fep directory contains Python scripts useful for
 post-processing results from performing free-energy perturbation
@@ -269,7 +269,7 @@ See README file in the tools/fep directory.
 
 :line
 
-i-pi tool :h4,link(ipi)
+i-pi tool :h3,link(ipi)
 
 The tools/i-pi directory contains a version of the i-PI package, with
 all the LAMMPS-unrelated files removed.  It is provided so that it can
@@ -286,7 +286,7 @@ calculations with LAMMPS.
 
 :line
 
-ipp tool :h4,link(ipp)
+ipp tool :h3,link(ipp)
 
 The tools/ipp directory contains a Perl script ipp which can be used
 to facilitate the creation of a complicated file (say, a lammps input
@@ -300,7 +300,7 @@ tools/createatoms tool's input file.
 
 :line
 
-kate tool :h4,link(kate)
+kate tool :h3,link(kate)
 
 The file in the tools/kate directory is an add-on to the Kate editor
 in the KDE suite that allow syntax highlighting of LAMMPS input
@@ -311,7 +311,7 @@ The file was provided by Alessandro Luigi Sellerio
 
 :line
 
-lmp2arc tool :h4,link(arc)
+lmp2arc tool :h3,link(arc)
 
 The lmp2arc sub-directory contains a tool for converting LAMMPS output
 files to the format for Accelrys' Insight MD code (formerly
@@ -327,7 +327,7 @@ Greathouse at Sandia (jagreat at sandia.gov).
 
 :line
 
-lmp2cfg tool :h4,link(cfg)
+lmp2cfg tool :h3,link(cfg)
 
 The lmp2cfg sub-directory contains a tool for converting LAMMPS output
 files into a series of *.cfg files which can be read into the
@@ -338,7 +338,7 @@ This tool was written by Ara Kooser at Sandia (askoose at sandia.gov).
 
 :line
 
-matlab tool :h4,link(matlab)
+matlab tool :h3,link(matlab)
 
 The matlab sub-directory contains several "MATLAB"_matlabhome scripts for
 post-processing LAMMPS output.  The scripts include readers for log
@@ -356,7 +356,7 @@ These scripts were written by Arun Subramaniyan at Purdue Univ
 
 :line
 
-micelle2d tool :h4,link(micelle)
+micelle2d tool :h3,link(micelle)
 
 The file micelle2d.f creates a LAMMPS data file containing short lipid
 chains in a monomer solution.  It uses a text file containing lipid
@@ -373,7 +373,7 @@ definition file.  This tool was used to create the system for the
 
 :line
 
-moltemplate tool :h4,link(moltemplate)
+moltemplate tool :h3,link(moltemplate)
 
 The moltemplate sub-directory contains a Python-based tool for
 building molecular systems based on a text-file description, and
@@ -387,7 +387,7 @@ supports it.  It has its own WWW page at
 
 :line
 
-msi2lmp tool :h4,link(msi)
+msi2lmp tool :h3,link(msi)
 
 The msi2lmp sub-directory contains a tool for creating LAMMPS template
 input and data files from BIOVIA's Materias Studio files (formerly Accelrys'
@@ -404,7 +404,7 @@ See the README file in the tools/msi2lmp folder for more information.
 
 :line
 
-phonon tool :h4,link(phonon)
+phonon tool :h3,link(phonon)
 
 The phonon sub-directory contains a post-processing tool useful for
 analyzing the output of the "fix phonon"_fix_phonon.html command in
@@ -419,7 +419,7 @@ University.
 
 :line
 
-polybond tool :h4,link(polybond)
+polybond tool :h3,link(polybond)
 
 The polybond sub-directory contains a Python-based tool useful for
 performing "programmable polymer bonding".  The Python file
@@ -433,7 +433,7 @@ This tool was written by Zachary Kraus at Georgia Tech.
 
 :line
 
-pymol_asphere tool :h4,link(pymol)
+pymol_asphere tool :h3,link(pymol)
 
 The pymol_asphere sub-directory contains a tool for converting a
 LAMMPS dump file that contains orientation info for ellipsoidal
@@ -451,7 +451,7 @@ This tool was written by Mike Brown at Sandia.
 
 :line
 
-python tool :h4,link(pythontools)
+python tool :h3,link(pythontools)
 
 The python sub-directory contains several Python scripts
 that perform common LAMMPS post-processing tasks, such as:
@@ -467,7 +467,7 @@ README for more info on Pizza.py and how to use these scripts.
 
 :line
 
-reax tool :h4,link(reax_tool)
+reax tool :h3,link(reax_tool)
 
 The reax sub-directory contains stand-alond codes that can
 post-process the output of the "fix reax/bonds"_fix_reax_bonds.html
@@ -478,7 +478,7 @@ These tools were written by Aidan Thompson at Sandia.
 
 :line
 
-smd tool :h4,link(smd)
+smd tool :h3,link(smd)
 
 The smd sub-directory contains a C++ file dump2vtk_tris.cpp and
 Makefile which can be compiled and used to convert triangle output
@@ -494,7 +494,7 @@ Ernst Mach Institute in Germany (georg.ganzenmueller at emi.fhg.de).
 
 :line
 
-vim tool :h4,link(vim)
+vim tool :h3,link(vim)
 
 The files in the tools/vim directory are add-ons to the VIM editor
 that allow easier editing of LAMMPS input scripts.  See the README.txt
@@ -505,7 +505,7 @@ ziegenhain.com)
 
 :line
 
-xmgrace tool :h4,link(xmgrace)
+xmgrace tool :h3,link(xmgrace)
 
 The files in the tools/xmgrace directory can be used to plot the
 thermodynamic data in LAMMPS log files via the xmgrace plotting

--- a/doc/src/body.txt
+++ b/doc/src/body.txt
@@ -6,7 +6,7 @@
 
 :line
 
-Body particles :h1
+Body particles :h2
 
 [Overview:]
 

--- a/doc/src/lammps.book
+++ b/doc/src/lammps.book
@@ -26,34 +26,26 @@ tutorial_drude.html
 tutorial_github.html
 tutorial_pylammps.html
 
+lammps_support.html
 body.html
 manifolds.html
 
 lammps_commands.html
-angle_coeff.html
-angle_style.html
 atom_modify.html
 atom_style.html
 balance.html
-bond_coeff.html
-bond_style.html
-bond_write.html
 boundary.html
 box.html
 change_box.html
 clear.html
 comm_modify.html
 comm_style.html
-compute.html
-compute_modify.html
 create_atoms.html
 create_bonds.html
 create_box.html
 delete_atoms.html
 delete_bonds.html
 dielectric.html
-dihedral_coeff.html
-dihedral_style.html
 dimension.html
 displace_atoms.html
 dump.html
@@ -65,18 +57,12 @@ dump_netcdf.html
 dump_vtk.html
 dump_cfg_uef.html
 echo.html
-fix.html
-fix_modify.html
 group.html
 group2ndx.html
 if.html
-improper_coeff.html
-improper_style.html
 include.html
 info.html
 jump.html
-kspace_modify.html
-kspace_style.html
 label.html
 lattice.html
 log.html
@@ -91,10 +77,6 @@ neighbor.html
 newton.html
 next.html
 package.html
-pair_coeff.html
-pair_modify.html
-pair_style.html
-pair_write.html
 partition.html
 prd.html
 print.html
@@ -135,6 +117,9 @@ write_data.html
 write_dump.html
 write_restart.html
 
+lammps_commands_fix.html
+fix.html
+fix_modify.html
 fix_adapt.html
 fix_adapt_fep.html
 fix_addforce.html
@@ -300,6 +285,9 @@ fix_wall_reflect.html
 fix_wall_region.html
 fix_wall_srd.html
 
+lammps_commands_compute.html
+compute.html
+compute_modify.html
 compute_ackland_atom.html
 compute_angle.html
 compute_angle_local.html
@@ -418,6 +406,11 @@ compute_vcm_chunk.html
 compute_voronoi_atom.html
 compute_xrd.html
 
+lammps_commands_pair.html
+pair_style.html
+pair_coeff.html
+pair_modify.html
+pair_write.html
 pair_adp.html
 pair_agni.html
 pair_airebo.html
@@ -523,6 +516,10 @@ pair_yukawa_colloid.html
 pair_zbl.html
 pair_zero.html
 
+lammps_commands_bond.html
+bond_style.html
+bond_coeff.html
+bond_write.html
 bond_class2.html
 bond_fene.html
 bond_fene_expand.html
@@ -539,6 +536,9 @@ bond_quartic.html
 bond_table.html
 bond_zero.html
 
+lammps_commands_angle.html
+angle_style.html
+angle_coeff.html
 angle_charmm.html
 angle_class2.html
 angle_cosine.html
@@ -559,6 +559,9 @@ angle_sdk.html
 angle_table.html
 angle_zero.html
 
+lammps_commands_dihedral.html
+dihedral_style.html
+dihedral_coeff.html
 dihedral_charmm.html
 dihedral_class2.html
 dihedral_cosine_shift_exp.html
@@ -575,6 +578,9 @@ dihedral_spherical.html
 dihedral_table.html
 dihedral_zero.html
 
+lammps_commands_improper.html
+improper_style.html
+improper_coeff.html
 improper_class2.html
 improper_cossq.html
 improper_cvff.html
@@ -588,6 +594,11 @@ improper_ring.html
 improper_umbrella.html
 improper_zero.html
 
+lammps_commands_kspace.html
+kspace_style.html
+kspace_modify.html
+
+lammps_commands_atc.html
 fix_atc.html
 USER/atc/man_add_molecule.html
 USER/atc/man_add_species.html

--- a/doc/src/lammps_commands.txt
+++ b/doc/src/lammps_commands.txt
@@ -8,3 +8,5 @@ command categories like compute styles or pair styles and so on.
 
 The documentation for the USER-ATC package fix_modify commands
 follow at the very end of this manual.
+
+General Commands :h2

--- a/doc/src/lammps_commands_angle.txt
+++ b/doc/src/lammps_commands_angle.txt
@@ -1,0 +1,2 @@
+
+Angle Style Commands :h2

--- a/doc/src/lammps_commands_atc.txt
+++ b/doc/src/lammps_commands_atc.txt
@@ -1,0 +1,2 @@
+
+AtC Commands :h2

--- a/doc/src/lammps_commands_bond.txt
+++ b/doc/src/lammps_commands_bond.txt
@@ -1,0 +1,2 @@
+
+Bond Style Commands :h2

--- a/doc/src/lammps_commands_compute.txt
+++ b/doc/src/lammps_commands_compute.txt
@@ -1,0 +1,2 @@
+
+Compute Commands :h2

--- a/doc/src/lammps_commands_dihedral.txt
+++ b/doc/src/lammps_commands_dihedral.txt
@@ -1,0 +1,2 @@
+
+Dihedral Style Commands :h2

--- a/doc/src/lammps_commands_fix.txt
+++ b/doc/src/lammps_commands_fix.txt
@@ -1,0 +1,2 @@
+
+Fix Commands :h2

--- a/doc/src/lammps_commands_improper.txt
+++ b/doc/src/lammps_commands_improper.txt
@@ -1,0 +1,2 @@
+
+Improper Style Commands :h2

--- a/doc/src/lammps_commands_kspace.txt
+++ b/doc/src/lammps_commands_kspace.txt
@@ -1,0 +1,2 @@
+
+Kspace Style Commands :h2

--- a/doc/src/lammps_commands_pair.txt
+++ b/doc/src/lammps_commands_pair.txt
@@ -1,0 +1,2 @@
+
+Pair Style Commands :h2

--- a/doc/src/lammps_support.txt
+++ b/doc/src/lammps_support.txt
@@ -1,0 +1,7 @@
+
+Supporting Information :h1
+
+This section of the manual contains supporting information that
+is not documenting individual commands but general concepts and
+supporting information about entities like body particles or
+manifolds.

--- a/doc/src/manifolds.txt
+++ b/doc/src/manifolds.txt
@@ -6,7 +6,7 @@
 
 :line
 
-Manifolds (surfaces) :h1
+Manifolds (surfaces) :h2
 
 [Overview:]
 


### PR DESCRIPTION
## Purpose

This pull request refactors headline levels and inserts some pdf-only doc files in order to have a more structured PDF TOC. There should be no impact to the html manual version, at least that is the intention.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines

