### PR TITLE
Fixed pbc wrapping in case of spherical bins

### DIFF
--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -1804,18 +1804,18 @@ void ComputeChunkAtom::atom2binsphere()
 
     xremap = x[i][0];
     if (periodicity[0]) {
-      if (xremap < boxlo[0]) xremap += prd[0];
-      if (xremap >= boxhi[0]) xremap -= prd[0];
+      while (xremap < boxlo[0]) {xremap += prd[0];}
+      while (xremap >= boxhi[0]) {xremap -= prd[0];}
     }
     yremap = x[i][1];
     if (periodicity[1]) {
-      if (yremap < boxlo[1]) yremap += prd[1];
-      if (yremap >= boxhi[1]) yremap -= prd[1];
+      while (yremap < boxlo[1]) {yremap += prd[1];}
+      while (yremap >= boxhi[1]) {yremap -= prd[1];}
     }
     zremap = x[i][2];
     if (periodicity[2]) {
-      if (zremap < boxlo[2]) zremap += prd[2];
-      if (zremap >= boxhi[2]) zremap -= prd[2];
+      while (zremap < boxlo[2]) {zremap += prd[2];}
+      while (zremap >= boxhi[2]) {zremap -= prd[2];}
     }
 
     dx = xremap - sorigin[0];
@@ -1829,19 +1829,19 @@ void ComputeChunkAtom::atom2binsphere()
 
     if (pbcflag) {
       if (periodicity[0]) {
-        if (fabs(dx) > prd_half[0]) {
+        while (fabs(dx) > prd_half[0]) {
           if (dx < 0.0) dx += prd[0];
           else dx -= prd[0];
         }
       }
       if (periodicity[1]) {
-        if (fabs(dy) > prd_half[1]) {
+        while (fabs(dy) > prd_half[1]) {
           if (dy < 0.0) dy += prd[1];
           else dy -= prd[1];
         }
       }
       if (periodicity[2]) {
-        if (fabs(dz) > prd_half[2]) {
+        while (fabs(dz) > prd_half[2]) {
           if (dz < 0.0) dz += prd[2];
           else dz -= prd[2];
         }


### PR DESCRIPTION
## Purpose

A fix for 'compute chunk/atom bin/sphere' in case when atom or sphere center coordinates are more than one image away from the original cell. 

## Author(s)

Pavel Strashnov, INEOS RAS

## Backward Compatibility

Yes

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


