### PR TITLE
Collected small changes and bug fixes for the next patch release

### DIFF
--- a/doc/src/compute_displace_atom.txt
+++ b/doc/src/compute_displace_atom.txt
@@ -15,7 +15,7 @@ compute ID group-ID displace/atom :pre
 ID, group-ID are documented in "compute"_compute.html command :ulb,l
 displace/atom = style name of this compute command :l
 zero or more keyword/arg pairs may be appended :l
-keyword = {refresh} :
+keyword = {refresh} :l
   {replace} arg = name of per-atom variable :pre
 
 :ule

--- a/doc/src/fix_reax_bonds.txt
+++ b/doc/src/fix_reax_bonds.txt
@@ -34,6 +34,8 @@ written to {filename} on timesteps that are multiples of {Nevery},
 including timestep 0.  For time-averaged chemical species analysis,
 please see the "fix reaxc/c/species"_fix_reaxc_species.html command.
 
+The specified group-ID is ignored by this fix.
+
 The format of the output file should be reasonably self-explanatory.
 The meaning of the column header abbreviations is as follows:
 

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -384,9 +384,14 @@ class lammps(object):
       ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
       return ptr
     if type == 2:
-      self.lib.lammps_extract_compute.restype = POINTER(POINTER(c_double))
-      ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
-      return ptr
+      if style == 0:
+        self.lib.lammps_extract_compute.restype = POINTER(c_int)
+        ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
+        return ptr[0]
+      else:
+        self.lib.lammps_extract_compute.restype = POINTER(POINTER(c_double))
+        ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
+        return ptr
     return None
 
   # extract fix info

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -5,7 +5,7 @@
 #
 #   Copyright (2003) Sandia Corporation.  Under the terms of Contract
 #   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-#   certain rights in this software.  This software is distributed under 
+#   certain rights in this software.  This software is distributed under
 #   the GNU General Public License.
 #
 #   See the README file in the top-level LAMMPS directory.
@@ -37,7 +37,7 @@ def get_ctypes_int(size):
     return c_int32
   elif size == 8:
     return c_int64
-  return c_int 
+  return c_int
 
 class MPIAbortException(Exception):
   def __init__(self, message):
@@ -47,7 +47,7 @@ class MPIAbortException(Exception):
     return repr(self.message)
 
 class lammps(object):
-  
+
   # detect if Python is using version of mpi4py that can pass a communicator
 
   has_mpi4py = False
@@ -71,7 +71,7 @@ class lammps(object):
 
     # if a pointer to a LAMMPS object is handed in,
     # all symbols should already be available
-    
+
     try:
       if ptr: self.lib = CDLL("",RTLD_GLOBAL)
     except:
@@ -84,7 +84,7 @@ class lammps(object):
     #   so that LD_LIBRARY_PATH does not need to be set for regular install
     # fall back to loading with a relative path,
     #   typically requires LD_LIBRARY_PATH to be set appropriately
-      
+
     if not self.lib:
       try:
         if not name: self.lib = CDLL(join(modpath,"liblammps.so"),RTLD_GLOBAL)
@@ -110,15 +110,15 @@ class lammps(object):
     self.lib.lammps_gather_atoms.argtypes = \
       [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_gather_atoms.restype = None
-    
+
     self.lib.lammps_gather_atoms_concat.argtypes = \
       [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_gather_atoms_concat.restype = None
-    
+
     self.lib.lammps_gather_atoms_subset.argtypes = \
       [c_void_p,c_char_p,c_int,c_int,c_int,POINTER(c_int),c_void_p]
     self.lib.lammps_gather_atoms_subset.restype = None
-    
+
     self.lib.lammps_scatter_atoms.argtypes = \
       [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_scatter_atoms.restype = None
@@ -137,7 +137,7 @@ class lammps(object):
     #   just convert it to ctypes ptr and store in self.lmp
 
     if not ptr:
-      
+
       # with mpi4py v2, can pass MPI communicator to LAMMPS
       # need to adjust for type of MPI communicator object
       # allow for int (like MPICH) or void* (like OpenMPI)
@@ -211,7 +211,7 @@ class lammps(object):
     self.c_imageint = get_ctypes_int(self.extract_setting("imageint"))
 
   # shut-down LAMMPS instance
-  
+
   def __del__(self):
     if self.lmp and self.opened:
       self.lib.lammps_close(self.lmp)
@@ -230,7 +230,7 @@ class lammps(object):
     self.lib.lammps_file(self.lmp,file)
 
   # send a single command
-    
+
   def command(self,cmd):
     if cmd: cmd = cmd.encode()
     self.lib.lammps_command(self.lmp,cmd)
@@ -250,13 +250,13 @@ class lammps(object):
     cmds = [x.encode() for x in cmdlist if type(x) is str]
     args = (c_char_p * len(cmdlist))(*cmds)
     self.lib.lammps_commands_list(self.lmp,len(cmdlist),args)
-    
+
   # send a string of commands
 
   def commands_string(self,multicmd):
     if type(multicmd) is str: multicmd = multicmd.encode()
     self.lib.lammps_commands_string(self.lmp,c_char_p(multicmd))
-    
+
   # extract lammps type byte sizes
 
   def extract_setting(self, name):
@@ -265,7 +265,7 @@ class lammps(object):
     return int(self.lib.lammps_extract_setting(self.lmp,name))
 
   # extract global info
-    
+
   def extract_global(self,name,type):
     if name: name = name.encode()
     if type == 0:
@@ -277,7 +277,7 @@ class lammps(object):
     return ptr[0]
 
   # extract global info
-    
+
   def extract_box(self):
     boxlo = (3*c_double)()
     boxhi = (3*c_double)()
@@ -286,11 +286,11 @@ class lammps(object):
     xz = c_double()
     periodicity = (3*c_int)()
     box_change = c_int()
-    
+
     self.lib.lammps_extract_box(self.lmp,boxlo,boxhi,
                                 byref(xy),byref(yz),byref(xz),
                                 periodicity,byref(box_change))
-    
+
     boxlo = boxlo[:3]
     boxhi = boxhi[:3]
     xy = xy.value
@@ -298,9 +298,9 @@ class lammps(object):
     xz = xz.value
     periodicity = periodicity[:3]
     box_change = box_change.value
-    
+
     return boxlo,boxhi,xy,yz,xz,periodicity,box_change
-    
+
   # extract per-atom info
   # NOTE: need to insure are converting to/from correct Python type
   #   e.g. for Python list or NumPy or ctypes
@@ -318,7 +318,7 @@ class lammps(object):
     else: return None
     ptr = self.lib.lammps_extract_atom(self.lmp,name)
     return ptr
-    
+
   @property
   def numpy(self):
     if not self._numpy:
@@ -371,7 +371,7 @@ class lammps(object):
     return self._numpy
 
   # extract compute info
-  
+
   def extract_compute(self,id,style,type):
     if id: id = id.encode()
     if type == 0:
@@ -466,7 +466,7 @@ class lammps(object):
     cboxlo = (3*c_double)(*boxlo)
     cboxhi = (3*c_double)(*boxhi)
     self.lib.lammps_reset_box(self.lmp,cboxlo,cboxhi,xy,yz,xz)
-    
+
   # return vector of atom properties gathered across procs
   # 3 variants to match src/library.cpp
   # name = atom property recognized by LAMMPS in atom->extract()
@@ -475,7 +475,7 @@ class lammps(object):
   # returned data is a 1d vector - doc how it is ordered?
   # NOTE: need to insure are converting to/from correct Python type
   #   e.g. for Python list or NumPy or ctypes
-  
+
   def gather_atoms(self,name,type,count):
     if name: name = name.encode()
     natoms = self.lib.lammps_get_natoms(self.lmp)
@@ -487,7 +487,7 @@ class lammps(object):
       self.lib.lammps_gather_atoms(self.lmp,name,type,count,data)
     else: return None
     return data
-    
+
   def gather_atoms_concat(self,name,type,count):
     if name: name = name.encode()
     natoms = self.lib.lammps_get_natoms(self.lmp)
@@ -519,7 +519,7 @@ class lammps(object):
   # assume data is of correct type and length, as created by gather_atoms()
   # NOTE: need to insure are converting to/from correct Python type
   #   e.g. for Python list or NumPy or ctypes
-  
+
   def scatter_atoms(self,name,type,count,data):
     if name: name = name.encode()
     self.lib.lammps_scatter_atoms(self.lmp,name,type,count,data)

--- a/src/MOLECULE/angle_cosine_squared.cpp
+++ b/src/MOLECULE/angle_cosine_squared.cpp
@@ -34,7 +34,11 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-AngleCosineSquared::AngleCosineSquared(LAMMPS *lmp) : Angle(lmp) {}
+AngleCosineSquared::AngleCosineSquared(LAMMPS *lmp) : Angle(lmp)
+{
+  k = NULL;
+  theta0 = NULL;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MOLECULE/angle_harmonic.cpp
+++ b/src/MOLECULE/angle_harmonic.cpp
@@ -30,7 +30,11 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-AngleHarmonic::AngleHarmonic(LAMMPS *lmp) : Angle(lmp) {}
+AngleHarmonic::AngleHarmonic(LAMMPS *lmp) : Angle(lmp)
+{
+  k = NULL;
+  theta0 = NULL;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MOLECULE/dihedral_helix.cpp
+++ b/src/MOLECULE/dihedral_helix.cpp
@@ -332,3 +332,13 @@ void DihedralHelix::read_restart(FILE *fp)
 
   for (int i = 1; i <= atom->ndihedraltypes; i++) setflag[i] = 1;
 }
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void DihedralHelix::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->ndihedraltypes; i++)
+    fprintf(fp,"%d %g %g %g\n",i,aphi[i],bphi[i],cphi[i]);
+}

--- a/src/MOLECULE/dihedral_helix.h
+++ b/src/MOLECULE/dihedral_helix.h
@@ -33,6 +33,7 @@ class DihedralHelix : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  protected:
   double *aphi,*bphi,*cphi;

--- a/src/MOLECULE/dihedral_multi_harmonic.cpp
+++ b/src/MOLECULE/dihedral_multi_harmonic.cpp
@@ -331,3 +331,13 @@ void DihedralMultiHarmonic::read_restart(FILE *fp)
 
   for (int i = 1; i <= atom->ndihedraltypes; i++) setflag[i] = 1;
 }
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void DihedralMultiHarmonic::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->ndihedraltypes; i++)
+    fprintf(fp,"%d %g %g %g %g %g\n",i,a1[i],a2[i],a3[i],a4[i],a5[i]);
+}

--- a/src/MOLECULE/dihedral_multi_harmonic.h
+++ b/src/MOLECULE/dihedral_multi_harmonic.h
@@ -33,6 +33,7 @@ class DihedralMultiHarmonic : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  protected:
   double *a1,*a2,*a3,*a4,*a5;

--- a/src/USER-MISC/angle_cosine_shift.cpp
+++ b/src/USER-MISC/angle_cosine_shift.cpp
@@ -34,7 +34,10 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-AngleCosineShift::AngleCosineShift(LAMMPS *lmp) : Angle(lmp) {}
+AngleCosineShift::AngleCosineShift(LAMMPS *lmp) : Angle(lmp)
+{
+  kcost = NULL;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/angle_cosine_shift_exp.cpp
+++ b/src/USER-MISC/angle_cosine_shift_exp.cpp
@@ -34,7 +34,16 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-AngleCosineShiftExp::AngleCosineShiftExp(LAMMPS *lmp) : Angle(lmp) {}
+AngleCosineShiftExp::AngleCosineShiftExp(LAMMPS *lmp) : Angle(lmp)
+{
+  doExpansion = NULL;
+  umin = NULL;
+  a = NULL;
+  opt1 = NULL;
+  theta0 = NULL;
+  sint = NULL;
+  cost = NULL;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/angle_dipole.cpp
+++ b/src/USER-MISC/angle_dipole.cpp
@@ -32,7 +32,11 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-AngleDipole::AngleDipole(LAMMPS *lmp) : Angle(lmp) {}
+AngleDipole::AngleDipole(LAMMPS *lmp) : Angle(lmp)
+{
+  k = NULL;
+  gamma0 = NULL;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/angle_fourier.cpp
+++ b/src/USER-MISC/angle_fourier.cpp
@@ -35,7 +35,13 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-AngleFourier::AngleFourier(LAMMPS *lmp) : Angle(lmp) {}
+AngleFourier::AngleFourier(LAMMPS *lmp) : Angle(lmp)
+{
+  k = NULL;
+  C0 = NULL;
+  C1 = NULL;
+  C2 = NULL;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/angle_fourier_simple.cpp
+++ b/src/USER-MISC/angle_fourier_simple.cpp
@@ -35,7 +35,12 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-AngleFourierSimple::AngleFourierSimple(LAMMPS *lmp) : Angle(lmp) {}
+AngleFourierSimple::AngleFourierSimple(LAMMPS *lmp) : Angle(lmp)
+{
+  k = NULL;
+  C = NULL;
+  N = NULL;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/dihedral_cosine_shift_exp.cpp
+++ b/src/USER-MISC/dihedral_cosine_shift_exp.cpp
@@ -26,6 +26,7 @@
 #include "force.h"
 #include "update.h"
 #include "memory.h"
+#include "math_const.h"
 #include "error.h"
 
 using namespace LAMMPS_NS;
@@ -285,9 +286,9 @@ void DihedralCosineShiftExp::coeff(int narg, char **arg)
     doExpansion[i]=(fabs(a_)<0.001);
     umin[i]  = umin_;
     a[i]     = a_;
-    cost[i]  = cos(theta0_*3.14159265/180);
-    sint[i]  = sin(theta0_*3.14159265/180);
-    theta[i] = theta0_*3.14159265/180;
+    cost[i]  = cos(theta0_*MathConst::MY_PI/180.0);
+    sint[i]  = sin(theta0_*MathConst::MY_PI/180.0);
+    theta[i] = theta0_*MathConst::MY_PI/180.0;
 
     if (!doExpansion[i]) opt1[i]=umin_/(exp(a_)-1);
 
@@ -337,4 +338,15 @@ void DihedralCosineShiftExp::read_restart(FILE *fp)
     doExpansion[i]=(fabs(a[i])<0.01);
     if (!doExpansion[i]) opt1[i]=umin[i]/(exp(a[i])-1);
   }
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void DihedralCosineShiftExp::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->ndihedraltypes; i++)
+    fprintf(fp,"%d %g %g %g\n",i,umin[i],
+            theta[i]*180.0/MathConst::MY_PI,a[i]);
 }

--- a/src/USER-MISC/dihedral_cosine_shift_exp.h
+++ b/src/USER-MISC/dihedral_cosine_shift_exp.h
@@ -33,6 +33,7 @@ class DihedralCosineShiftExp : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  protected:
   bool *doExpansion;

--- a/src/USER-MISC/dihedral_quadratic.cpp
+++ b/src/USER-MISC/dihedral_quadratic.cpp
@@ -333,3 +333,12 @@ void DihedralQuadratic::read_restart(FILE *fp)
   for (int i = 1; i <= atom->ndihedraltypes; i++) setflag[i] = 1;
 }
 
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void DihedralQuadratic::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->ndihedraltypes; i++)
+    fprintf(fp,"%d %g %g \n",i,k[i],phi0[i]*180.0/MY_PI);
+}

--- a/src/USER-MISC/dihedral_quadratic.h
+++ b/src/USER-MISC/dihedral_quadratic.h
@@ -33,6 +33,7 @@ class DihedralQuadratic : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  protected:
   double *k,*phi0;

--- a/src/USER-MISC/improper_cossq.cpp
+++ b/src/USER-MISC/improper_cossq.cpp
@@ -312,3 +312,13 @@ void ImproperCossq::read_restart(FILE *fp)
 
   for (int i = 1; i <= atom->nimpropertypes; i++) setflag[i] = 1;
 }
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void ImproperCossq::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->nimpropertypes; i++)
+    fprintf(fp,"%d %g %g\n",i,k[i],chi[i]/MY_PI*180.0);
+}

--- a/src/USER-MISC/improper_cossq.h
+++ b/src/USER-MISC/improper_cossq.h
@@ -33,6 +33,7 @@ class ImproperCossq : public Improper {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  protected:
   double *k, *chi;

--- a/src/USER-MISC/improper_distance.cpp
+++ b/src/USER-MISC/improper_distance.cpp
@@ -223,7 +223,6 @@ void ImproperDistance::coeff(int narg, char **arg)
   int count = 0;
   for (int i = ilo; i <= ihi; i++) {
     k[i] = k_one;
-    //chi[i] = chi_one/180.0 * PI;
     chi[i] = chi_one;
     setflag[i] = 1;
     count++;
@@ -258,4 +257,14 @@ void ImproperDistance::read_restart(FILE *fp)
   MPI_Bcast(&chi[1],atom->nimpropertypes,MPI_DOUBLE,0,world);
 
   for (int i = 1; i <= atom->nimpropertypes; i++) setflag[i] = 1;
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void ImproperDistance::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->nimpropertypes; i++)
+    fprintf(fp,"%d %g %g\n",i,k[i],chi[i]);
 }

--- a/src/USER-MISC/improper_distance.h
+++ b/src/USER-MISC/improper_distance.h
@@ -33,6 +33,7 @@ class ImproperDistance : public Improper {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  private:
   double *k,*chi;

--- a/src/USER-MISC/improper_fourier.cpp
+++ b/src/USER-MISC/improper_fourier.cpp
@@ -343,3 +343,13 @@ void ImproperFourier::read_restart(FILE *fp)
 
   for (int i = 1; i <= atom->nimpropertypes; i++) setflag[i] = 1;
 }
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void ImproperFourier::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->nimpropertypes; i++)
+    fprintf(fp,"%d %g %g %g %g %d\n",i,k[i],C0[i],C1[i],C2[i],all[i]);
+}

--- a/src/USER-MISC/improper_fourier.h
+++ b/src/USER-MISC/improper_fourier.h
@@ -33,6 +33,7 @@ class ImproperFourier : public Improper {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  protected:
   double *k, *C0, *C1, *C2;

--- a/src/USER-MISC/improper_ring.cpp
+++ b/src/USER-MISC/improper_ring.cpp
@@ -337,3 +337,13 @@ void ImproperRing::read_restart(FILE *fp)
 
   for (int i = 1; i <= atom->nimpropertypes; i++) setflag[i] = 1;
 }
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to data file
+------------------------------------------------------------------------- */
+
+void ImproperRing::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->nimpropertypes; i++)
+    fprintf(fp,"%d %g %g\n",i,k[i],acos(chi[i])/MY_PI*180.0);
+}

--- a/src/USER-MISC/improper_ring.h
+++ b/src/USER-MISC/improper_ring.h
@@ -33,6 +33,7 @@ class ImproperRing : public Improper {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_data(FILE *);
 
  protected:
   double *k,*chi;

--- a/src/USER-MISC/pair_coul_shield.cpp
+++ b/src/USER-MISC/pair_coul_shield.cpp
@@ -231,6 +231,8 @@ void PairCoulShield::init_style()
 {
   if (!atom->q_flag)
     error->all(FLERR,"Pair style coul/shield requires atom attribute q");
+  if (!atom->molecule_flag)
+    error->all(FLERR,"Pair style coul/shield requires atom attribute molecule");
 
   neighbor->request(this,instance_me);
 }

--- a/src/USER-MISC/pair_ilp_graphene_hbn.cpp
+++ b/src/USER-MISC/pair_ilp_graphene_hbn.cpp
@@ -636,7 +636,9 @@ void PairILPGrapheneHBN::calc_normal()
 void PairILPGrapheneHBN::init_style()
 {
   if (force->newton_pair == 0)
-    error->all(FLERR,"Pair style ILP requires newton pair on");
+    error->all(FLERR,"Pair style ilp/graphene/hbn requires newton pair on");
+  if (!atom->molecule_flag)
+    error->all(FLERR,"Pair style ilp/graphene/hbn requires atom attribute molecule");
 
   // need a full neighbor list, including neighbors of ghosts
 

--- a/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
@@ -640,7 +640,9 @@ void PairKolmogorovCrespiFull::calc_normal()
 void PairKolmogorovCrespiFull::init_style()
 {
   if (force->newton_pair == 0)
-    error->all(FLERR,"Pair style KC requires newton pair on");
+    error->all(FLERR,"Pair style kolmolgorov/crespi/full requires newton pair on");
+  if (!atom->molecule_flag)
+    error->all(FLERR,"Pair style kolmolgorov/crespi/full requires atom attribute molecule");
 
   // need a full neighbor list, including neighbors of ghosts
 

--- a/src/fix_restrain.cpp
+++ b/src/fix_restrain.cpp
@@ -261,7 +261,7 @@ void FixRestrain::restrain_bond(int m)
   if (r > 0.0) fbond = -2.0*rk/r;
   else fbond = 0.0;
 
-  energy = rk*dr;
+  energy += rk*dr;
 
   // apply force to each of 2 atoms
 
@@ -368,7 +368,7 @@ void FixRestrain::restrain_angle(int m)
   dtheta = acos(c) - target[m];
   tk = k * dtheta;
 
-  energy = tk*dtheta;
+  energy += tk*dtheta;
 
   a = -2.0 * tk * s;
   a11 = a*c / rsq1;
@@ -549,7 +549,7 @@ void FixRestrain::restrain_dihedral(int m)
   df1 *= -mult;
   p += 1.0;
 
-  energy = k * p;
+  energy += k * p;
 
   fg = vb1x*vb2xm + vb1y*vb2ym + vb1z*vb2zm;
   hg = vb3x*vb2xm + vb3y*vb2ym + vb3z*vb2zm;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -480,10 +480,13 @@ void *lammps_extract_atom(void *ptr, char *name)
      compute's internal data structure for the entity
      caller should cast it to (double *) for a scalar or vector
      caller should cast it to (double **) for an array
-   for per-atom or local data, returns a pointer to the
+   for per-atom or local vector/array data, returns a pointer to the
      compute's internal data structure for the entity
      caller should cast it to (double *) for a vector
      caller should cast it to (double **) for an array
+   for local data, accessing scalar data for the compute (type = 0),
+   returns a pointer that should be cast to (int *) which points to
+   an int with the number of local rows, i.e. the length of the local array.
    returns a void pointer to the compute's internal data structure
      for the entity which the caller can cast to the proper data type
    returns a NULL if id is not recognized or style/type not supported
@@ -541,6 +544,11 @@ void *lammps_extract_compute(void *ptr, char *id, int style, int type)
 
     if (style == 2) {
       if (!compute->local_flag) return NULL;
+      if (type == 0) {
+        if (compute->invoked_local != lmp->update->ntimestep)
+          compute->compute_local();
+        return (void *) &compute->size_local_rows;
+      }
       if (type == 1) {
         if (compute->invoked_local != lmp->update->ntimestep)
           compute->compute_local();

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -39,6 +39,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <cmath>
 
 // grrr - IBM Power6 does not provide this def in their system header files
 
@@ -200,7 +201,7 @@ typedef int bigint;
 #define _noalias
 #endif
 
-#define ISFINITE(x) isfinite(x)
+#define ISFINITE(x) std::isfinite(x)
 
 // settings to enable LAMMPS to build under Windows
 

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -39,7 +39,6 @@
 #include <limits.h>
 #include <stdint.h>
 #include <inttypes.h>
-#include <cmath>
 
 // grrr - IBM Power6 does not provide this def in their system header files
 
@@ -201,7 +200,7 @@ typedef int bigint;
 #define _noalias
 #endif
 
-#define ISFINITE(x) std::isfinite(x)
+#define ISFINITE(x) isfinite(x)
 
 // settings to enable LAMMPS to build under Windows
 


### PR DESCRIPTION
## Purpose

The PR collects multiple small changes, bugfixes and improvements for the next patch

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes

## Implementation Notes

The following individual changes are included:
- add a check to pair styles `coul/shield`, `ilp/graphene/hbn`, and `kolmolgorov/crespi/full` to require molecule IDs in order to avoid a segfault later in the code. This is to counter incorrect use of those styles as seen here: https://sourceforge.net/p/lammps/mailman/message/36298339/
- add `write_data()` support for 4 more dihedral styles and thus completing the set
- add `write_data()` support to 4 more improper styles and thus completing the set and all bonded styles
- using `type == 2` and `style == 0`, i.e "local scalar" now will be supported with `lammps_extract_compute()` in the library (and python) interface. it returns the number of "local rows", i.e. the "length" of the local vector or array as an `int *` (or c_int), which is otherwise not accessible from the library (python) interface.
- bugfix to fix restrain by Robert Meißner (Helmholtz-Zentrum Geesthacht) posted to lammps-users
- initialize pointers to zero in angle style constructors. closes issues detected by coverity scan
- document that `fix reax/c/bonds` and `fix reax/bonds` ignore the group-ID.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

