### PR TITLE
More fixes to conform with C++ standards as indicated by Clang

### DIFF
--- a/src/USER-INTEL/intel_buffers.cpp
+++ b/src/USER-INTEL/intel_buffers.cpp
@@ -642,6 +642,6 @@ double IntelBuffers<flt_t, acc_t>::memory_usage(const int nthreads)
 
 /* ---------------------------------------------------------------------- */
 
-template class IntelBuffers<float,float>;
-template class IntelBuffers<float,double>;
-template class IntelBuffers<double,double>;
+template class LAMMPS_NS::IntelBuffers<float,float>;
+template class LAMMPS_NS::IntelBuffers<float,double>;
+template class LAMMPS_NS::IntelBuffers<double,double>;

--- a/src/USER-MESO/fix_edpd_source.cpp
+++ b/src/USER-MESO/fix_edpd_source.cpp
@@ -112,7 +112,7 @@ void FixEDPDSource::post_force(int vflag)
         drx = x[i][0] - center[0];
         dry = x[i][1] - center[1];
         drz = x[i][2] - center[2];
-        if(abs(drx) <= 0.5*dLx && abs(dry) <= 0.5*dLy && abs(drz) <= 0.5*dLz)
+        if(fabs(drx) <= 0.5*dLx && fabs(dry) <= 0.5*dLy && fabs(drz) <= 0.5*dLz)
           edpd_flux[i] += value*edpd_cv[i];
       }
     }

--- a/src/USER-MESO/fix_tdpd_source.cpp
+++ b/src/USER-MESO/fix_tdpd_source.cpp
@@ -112,7 +112,7 @@ void FixTDPDSource::post_force(int vflag)
         drx = x[i][0] - center[0];
         dry = x[i][1] - center[1];
         drz = x[i][2] - center[2];
-        if(abs(drx) <= 0.5*dLx && abs(dry) <= 0.5*dLy && abs(drz) <= 0.5*dLz)
+        if(fabs(drx) <= 0.5*dLx && fabs(dry) <= 0.5*dLy && fabs(drz) <= 0.5*dLz)
           cc_flux[i][cc_index-1] += value;
       }
     }


### PR DESCRIPTION
## Purpose

Increase C++ standard conformance of the code, but addressing issues that got past GNU C++ but were flagged by Clang. 

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes

## Implementation Notes

The following changes are included:
- fix a namespace issues when instantiating `IntelBuffers` for different precision settings in USER-INTEL package
- fix ambiguous use of `abs()` in USER-MESO package 

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- n/a Suitable new documentation files and/or updates to the existing docs are included
- n/a One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

