### PR TITLE
Output individual energies in fix restrain

### DIFF
--- a/doc/src/fix_restrain.txt
+++ b/doc/src/fix_restrain.txt
@@ -187,10 +187,16 @@ added forces to be included in the total potential energy of the
 system (the quantity being minimized), you MUST enable the
 "fix_modify"_fix_modify.html {energy} option for this fix.
 
-This fix computes a global scalar, which can be accessed by various
-"output commands"_Section_howto.html#howto_15.  The scalar is the
-potential energy for all the restraints as discussed above. The scalar
-value calculated by this fix is "extensive".
+This fix computes a global scalar and vector of length 3, which can be 
+accessed by various "output commands"_Section_howto.html#howto_15.  The 
+scalar is the potential energy for all the restraints as discussed above.
+The vector values are the following global quantities:
+
+1 = bond energy
+2 = angle energy
+3 = dihedral energy :ul
+
+The scalar and vector values calculated by this fix are "extensive".
 
 No parameter of this fix can be used with the {start/stop} keywords of
 the "run"_run.html command.

--- a/doc/src/fix_restrain.txt
+++ b/doc/src/fix_restrain.txt
@@ -187,10 +187,11 @@ added forces to be included in the total potential energy of the
 system (the quantity being minimized), you MUST enable the
 "fix_modify"_fix_modify.html {energy} option for this fix.
 
-This fix computes a global scalar and vector of length 3, which can be 
-accessed by various "output commands"_Section_howto.html#howto_15.  The 
-scalar is the potential energy for all the restraints as discussed above.
-The vector values are the following global quantities:
+This fix computes a global scalar and a global vector of length 3, which
+can be accessed by various "output commands"_Section_howto.html#howto_15.
+The scalar is the total potential energy for {all} the restraints as
+discussed above. The vector values are the sum of contributions to the
+following individual categories:
 
 1 = bond energy
 2 = angle energy

--- a/src/fix_restrain.cpp
+++ b/src/fix_restrain.cpp
@@ -279,7 +279,7 @@ void FixRestrain::restrain_bond(int m)
   else fbond = 0.0;
 
   ebond += rk*dr;
-  energy += ebond;
+  energy += rk*dr;
 
   // apply force to each of 2 atoms
 
@@ -387,7 +387,7 @@ void FixRestrain::restrain_angle(int m)
   tk = k * dtheta;
 
   eangle += tk*dtheta;
-  energy += eangle;
+  energy += tk*dtheta;
 
   a = -2.0 * tk * s;
   a11 = a*c / rsq1;
@@ -568,7 +568,7 @@ void FixRestrain::restrain_dihedral(int m)
   p += 1.0;
 
   edihed += k * p;
-  energy += edihed;
+  energy += k * p;
 
   fg = vb1x*vb2xm + vb1y*vb2ym + vb1z*vb2zm;
   hg = vb3x*vb2xm + vb3y*vb2ym + vb3z*vb2zm;

--- a/src/fix_restrain.cpp
+++ b/src/fix_restrain.cpp
@@ -652,8 +652,16 @@ double FixRestrain::compute_scalar()
 
 double FixRestrain::compute_vector(int n)
 {
-  if (n == 0) return ebond;
-  if (n == 1) return eangle;
-  if (n == 2) return edihed;
-  return 0.0;
+  if (n == 0) {
+    MPI_Allreduce(&ebond,&ebond_all,1,MPI_DOUBLE,MPI_SUM,world);
+    return ebond_all;
+  } else if (n == 1) {
+    MPI_Allreduce(&eangle,&eangle_all,1,MPI_DOUBLE,MPI_SUM,world);
+    return eangle_all;
+  } else if (n == 2) { 
+    MPI_Allreduce(&edihed,&edihed_all,1,MPI_DOUBLE,MPI_SUM,world);
+    return edihed_all;
+  } else {
+    return 0.0;
+  }
 }

--- a/src/fix_restrain.h
+++ b/src/fix_restrain.h
@@ -36,6 +36,7 @@ class FixRestrain : public Fix {
   void post_force_respa(int, int, int);
   void min_post_force(int);
   double compute_scalar();
+  double compute_vector(int);
 
  private:
   int ilevel_respa;
@@ -46,6 +47,7 @@ class FixRestrain : public Fix {
   double *kstart,*kstop,*target;
   double *cos_target,*sin_target;
   double energy,energy_all;
+  double ebond,eangle,edihed;
 
   void restrain_bond(int);
   void restrain_angle(int);

--- a/src/fix_restrain.h
+++ b/src/fix_restrain.h
@@ -47,7 +47,9 @@ class FixRestrain : public Fix {
   double *kstart,*kstop,*target;
   double *cos_target,*sin_target;
   double energy,energy_all;
-  double ebond,eangle,edihed;
+  double ebond,ebond_all;
+  double eangle,eangle_all;
+  double edihed,edihed_all;
 
   void restrain_bond(int);
   void restrain_angle(int);


### PR DESCRIPTION
## Purpose

Individual energies for bond, angle or dihedral interactions defined in fix restrain can be now accessed through a global vector .

## Author(s)

Robert Meißner

## Backward Compatibility

Yes

## Implementation Notes

added three new variables for bond, angle and dihedral energy and a compute_vector() method.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

