### PR TITLE
Include list of installed packages in help and info output

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -798,6 +798,20 @@ GenerateStyleHeaders(${LAMMPS_STYLE_HEADERS_DIR})
 include_directories(${LAMMPS_SOURCE_DIR})
 include_directories(${LAMMPS_STYLE_HEADERS_DIR})
 
+######################################
+# Generate lmpinstalledpkgs.h
+######################################
+set(temp "const char * LAMMPS_NS::LAMMPS::installed_packages[] =  {\n")
+foreach(PKG ${DEFAULT_PACKAGES} ${ACCEL_PACKAGES} ${OTHER_PACKAGES})
+    if(PKG_${PKG})
+        set(temp "${temp}  \"${PKG}\",\n")
+    endif()
+endforeach()
+set(temp "${temp}  NULL\n};\n\n")
+message(STATUS "Generating lmpinstalledpkgs.h...")
+file(WRITE "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h.tmp" "${temp}" )
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h.tmp" "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h")
+
 ###########################################
 # Actually add executable and lib to build
 ############################################

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -801,13 +801,14 @@ include_directories(${LAMMPS_STYLE_HEADERS_DIR})
 ######################################
 # Generate lmpinstalledpkgs.h
 ######################################
-set(temp "const char * LAMMPS_NS::LAMMPS::installed_packages[] =  {\n")
+set(temp "#ifndef LMP_INSTALLED_PKGS_H\n#define LMP_INSTALLED_PKGS_H\n")
+set(temp "${temp}const char * LAMMPS_NS::LAMMPS::installed_packages[] =  {\n")
 foreach(PKG ${DEFAULT_PACKAGES} ${ACCEL_PACKAGES} ${OTHER_PACKAGES})
     if(PKG_${PKG})
         set(temp "${temp}  \"${PKG}\",\n")
     endif()
 endforeach()
-set(temp "${temp}  NULL\n};\n\n")
+set(temp "${temp}  NULL\n};\n#endif\n\n")
 message(STATUS "Generating lmpinstalledpkgs.h...")
 file(WRITE "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h.tmp" "${temp}" )
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h.tmp" "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h")

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -209,6 +209,7 @@ class lammps(object):
     self.c_bigint = get_ctypes_int(self.extract_setting("bigint"))
     self.c_tagint = get_ctypes_int(self.extract_setting("tagint"))
     self.c_imageint = get_ctypes_int(self.extract_setting("imageint"))
+    self._installed_packages = None
 
   # shut-down LAMMPS instance
 
@@ -562,13 +563,36 @@ class lammps(object):
                                  shrinkexceed)
 
   @property
-  def uses_exceptions(self):
+  def has_exceptions(self):
     """ Return whether the LAMMPS shared library was compiled with C++ exceptions handling enabled """
-    try:
-      if self.lib.lammps_has_error:
-        return True
-    except(AttributeError):
-      return False
+    return self.lib.lammps_config_has_exceptions() != 0
+
+  @property
+  def has_gzip_support(self):
+    return self.lib.lammps_config_has_gzip_support() != 0
+
+  @property
+  def has_png_support(self):
+    return self.lib.lammps_config_has_png_support() != 0
+
+  @property
+  def has_jpeg_support(self):
+    return self.lib.lammps_config_has_jpeg_support() != 0
+
+  @property
+  def has_ffmpeg_support(self):
+    return self.lib.lammps_config_has_ffmpeg_support() != 0
+
+  @property
+  def installed_packages(self):
+    if self._installed_packages is None:
+      self._installed_packages = []
+      npackages = self.lib.lammps_config_package_count()
+      sb = create_string_buffer(100)
+      for idx in range(npackages):
+        self.lib.lammps_config_package_name(idx, sb, 100)
+        self._installed_packages.append(sb.value.decode())
+    return self._installed_packages
 
 # -------------------------------------------------------------------------
 # -------------------------------------------------------------------------

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -5,6 +5,7 @@
 /lmp_*
 
 /style_*.h
+/lmpcompiledate.h
 
 /*_gpu.h
 /*_gpu.cpp

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -5,7 +5,6 @@
 /lmp_*
 
 /style_*.h
-/lmpcompiledate.h
 /lmpinstalledpkgs.h
 
 /*_gpu.h

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -6,6 +6,7 @@
 
 /style_*.h
 /lmpcompiledate.h
+/lmpinstalledpkgs.h
 
 /*_gpu.h
 /*_gpu.cpp

--- a/src/Make.sh
+++ b/src/Make.sh
@@ -1,7 +1,6 @@
 # Make.sh = update Makefile.lib, Makefile.shlib, Makefile.list 
 #           or style_*.h files
 # Syntax: sh Make.sh style
-#         sh Make.sh date
 #         sh Make.sh Makefile.lib
 #         sh Make.sh Makefile.shlib
 #         sh Make.sh Makefile.list
@@ -55,10 +54,6 @@ style () {
     rm -f style_$3.tmp
   fi
 }
-
-if (test $1 = "date") then
-  echo "static const char lammps_compile_date[] = \"`date`\";" > lmpcompiledate.h
-fi
 
 # create individual style files
 # called by "make machine"

--- a/src/Make.sh
+++ b/src/Make.sh
@@ -1,6 +1,7 @@
 # Make.sh = update Makefile.lib, Makefile.shlib, Makefile.list 
 #           or style_*.h files
 # Syntax: sh Make.sh style
+#         sh Make.sh date
 #         sh Make.sh Makefile.lib
 #         sh Make.sh Makefile.shlib
 #         sh Make.sh Makefile.list
@@ -54,6 +55,10 @@ style () {
     rm -f style_$3.tmp
   fi
 }
+
+if (test $1 = "date") then
+  echo "static const char lammps_compile_date[] = \"`date`\";" > lmpcompiledate.h
+fi
 
 # create individual style files
 # called by "make machine"

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ OBJDIR =   Obj_$@
 OBJSHDIR = Obj_shared_$@
 
 SRC =	$(wildcard *.cpp)
-INC =	$(wildcard *.h)
+INC =	$(filter-out lmpinstalledpkgs.h,$(wildcard *.h))
 OBJ = 	$(SRC:.cpp=.o)
 
 SRCLIB = $(filter-out main.cpp,$(SRC))
@@ -150,6 +150,18 @@ help:
 	  for file in $$files; do head -1 $$file; done
 	@echo ''
 
+
+lmpinstalledpkgs.h: $(SRC) $(INC)
+	@echo 'Gathering installed package information (may take a little while)'
+	@echo 'static const char lammps_installed_packages[] = ' > lmpinstalledpkgs.tmp
+	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
+             [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package/"/' >> lmpinstalledpkgs.tmp || :; done
+	@echo ';' >> lmpinstalledpkgs.tmp
+	@if [ -f lmpinstalledpkgs.h ]; \
+          then test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
+	        mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp ; \
+        else mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h ; fi
+
 # Build LAMMPS in one of 4 modes
 # exe =   exe with static compile in Obj_machine (default)
 # shexe = exe with shared compile in Obj_shared_machine
@@ -163,17 +175,7 @@ help:
 	  -f MAKE/MACHINES/Makefile.$@ -o -f MAKE/MINE/Makefile.$@
 	@if [ ! -d $(objdir) ]; then mkdir $(objdir); fi
 	@$(SHELL) Make.sh style
-	@$(SHELL) Make.sh date
-	@echo 'Gathering installed package information'
-	@echo 'static const char lammps_installed_packages[] = ' > lmpinstalledpkgs.tmp
-	@for p in $(PACKAGEUC) $(PACKUSERUC); do echo -n '.'; info=$$($(SHELL) Package.sh $$p installed); \
-             [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package/"/' >> lmpinstalledpkgs.tmp || :; done
-	@echo ';' >> lmpinstalledpkgs.tmp
-	@echo
-	@if [ -f lmpinstalledpkgs.h ]; \
-          then test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
-	        mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp ; \
-        else mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h ; fi
+	@$(MAKE) $(MFLAGS) lmpinstalledpkgs.h
 	@echo 'Compiling LAMMPS for machine $@'
 	@if [ -f MAKE/MACHINES/Makefile.$@ ]; \
 	  then cp MAKE/MACHINES/Makefile.$@ $(objdir)/Makefile; fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -169,8 +169,10 @@ help:
 	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
              [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package/"/' >> lmpinstalledpkgs.tmp || :; done
 	@echo ';' >> lmpinstalledpkgs.tmp
-	@test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
-	       mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp
+	@if [ -f lmpinstalledpkgs.h ]; \
+          then test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
+	        mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp ; \
+        else mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h ; fi
 	@if [ -f MAKE/MACHINES/Makefile.$@ ]; \
 	  then cp MAKE/MACHINES/Makefile.$@ $(objdir)/Makefile; fi
 	@if [ -f MAKE/OPTIONS/Makefile.$@ ]; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,8 +153,8 @@ help:
 
 lmpinstalledpkgs.h: $(SRC) $(INC)
 	@echo 'Gathering installed package information (may take a little while)'
-	@echo '#ifndef LMP_INSTALLED_PKGS' >  lmpinstalledpkgs.tmp
-	@echo '#define LMP_INSTALLED_PKGS' >> lmpinstalledpkgs.tmp
+	@echo '#ifndef LMP_INSTALLED_PKGS_H' >  lmpinstalledpkgs.tmp
+	@echo '#define LMP_INSTALLED_PKGS_H' >> lmpinstalledpkgs.tmp
 	@echo 'const char * LAMMPS_NS::LAMMPS::installed_packages[] = {' >> lmpinstalledpkgs.tmp
 	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
              [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package \(.*\)"/"\1",/' >> lmpinstalledpkgs.tmp || :; done

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,7 +153,7 @@ help:
 
 lmpinstalledpkgs.h: $(SRC) $(INC)
 	@echo 'Gathering installed package information (may take a little while)'
-	@echo 'static const char lammps_installed_packages[] = ' > lmpinstalledpkgs.tmp
+	@echo 'static const char lammps_installed_packages[] = " "' > lmpinstalledpkgs.tmp
 	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
              [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package/"/' >> lmpinstalledpkgs.tmp || :; done
 	@echo ';' >> lmpinstalledpkgs.tmp

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,10 +153,13 @@ help:
 
 lmpinstalledpkgs.h: $(SRC) $(INC)
 	@echo 'Gathering installed package information (may take a little while)'
-	@echo 'const char * LAMMPS_NS::LAMMPS::installed_packages[] = {' > lmpinstalledpkgs.tmp
+	@echo '#ifndef LMP_INSTALLED_PKGS' >  lmpinstalledpkgs.tmp
+	@echo '#define LMP_INSTALLED_PKGS' >> lmpinstalledpkgs.tmp
+	@echo 'const char * LAMMPS_NS::LAMMPS::installed_packages[] = {' >> lmpinstalledpkgs.tmp
 	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
              [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package \(.*\)"/"\1",/' >> lmpinstalledpkgs.tmp || :; done
 	@echo ' NULL };' >> lmpinstalledpkgs.tmp
+	@echo '#endif' >> lmpinstalledpkgs.tmp
 	@if [ -f lmpinstalledpkgs.h ]; \
           then test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
 	        mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp ; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,7 +153,7 @@ help:
 
 lmpinstalledpkgs.h: $(SRC) $(INC)
 	@echo 'Gathering installed package information (may take a little while)'
-	@echo 'static const char * lammps_installed_packages[] = {' > lmpinstalledpkgs.tmp
+	@echo 'const char * LAMMPS_NS::LAMMPS::installed_packages[] = {' > lmpinstalledpkgs.tmp
 	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
              [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package \(.*\)"/"\1",/' >> lmpinstalledpkgs.tmp || :; done
 	@echo ' NULL };' >> lmpinstalledpkgs.tmp

--- a/src/Makefile
+++ b/src/Makefile
@@ -163,6 +163,7 @@ help:
 	  -f MAKE/MACHINES/Makefile.$@ -o -f MAKE/MINE/Makefile.$@
 	@if [ ! -d $(objdir) ]; then mkdir $(objdir); fi
 	@$(SHELL) Make.sh style
+	@$(SHELL) Make.sh date
 	@if [ -f MAKE/MACHINES/Makefile.$@ ]; \
 	  then cp MAKE/MACHINES/Makefile.$@ $(objdir)/Makefile; fi
 	@if [ -f MAKE/OPTIONS/Makefile.$@ ]; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -164,6 +164,13 @@ help:
 	@if [ ! -d $(objdir) ]; then mkdir $(objdir); fi
 	@$(SHELL) Make.sh style
 	@$(SHELL) Make.sh date
+	@echo 'Gathering installed package information'
+	@echo 'static const char lammps_installed_packages[] = ' > lmpinstalledpkgs.tmp
+	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
+             [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package/"/' >> lmpinstalledpkgs.tmp || :; done
+	@echo ';' >> lmpinstalledpkgs.tmp
+	@test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
+	       mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp
 	@if [ -f MAKE/MACHINES/Makefile.$@ ]; \
 	  then cp MAKE/MACHINES/Makefile.$@ $(objdir)/Makefile; fi
 	@if [ -f MAKE/OPTIONS/Makefile.$@ ]; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,10 +153,10 @@ help:
 
 lmpinstalledpkgs.h: $(SRC) $(INC)
 	@echo 'Gathering installed package information (may take a little while)'
-	@echo 'static const char lammps_installed_packages[] = " "' > lmpinstalledpkgs.tmp
+	@echo 'static const char * lammps_installed_packages[] = {' > lmpinstalledpkgs.tmp
 	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
-             [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package/"/' >> lmpinstalledpkgs.tmp || :; done
-	@echo ';' >> lmpinstalledpkgs.tmp
+             [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package \(.*\)"/"\1",/' >> lmpinstalledpkgs.tmp || :; done
+	@echo ' NULL };' >> lmpinstalledpkgs.tmp
 	@if [ -f lmpinstalledpkgs.h ]; \
           then test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
 	        mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp ; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -166,13 +166,15 @@ help:
 	@$(SHELL) Make.sh date
 	@echo 'Gathering installed package information'
 	@echo 'static const char lammps_installed_packages[] = ' > lmpinstalledpkgs.tmp
-	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
+	@for p in $(PACKAGEUC) $(PACKUSERUC); do echo -n '.'; info=$$($(SHELL) Package.sh $$p installed); \
              [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package/"/' >> lmpinstalledpkgs.tmp || :; done
 	@echo ';' >> lmpinstalledpkgs.tmp
+	@echo
 	@if [ -f lmpinstalledpkgs.h ]; \
           then test "`diff --brief lmpinstalledpkgs.tmp lmpinstalledpkgs.h`" != "" && \
 	        mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h || rm lmpinstalledpkgs.tmp ; \
         else mv lmpinstalledpkgs.tmp lmpinstalledpkgs.h ; fi
+	@echo 'Compiling LAMMPS for machine $@'
 	@if [ -f MAKE/MACHINES/Makefile.$@ ]; \
 	  then cp MAKE/MACHINES/Makefile.$@ $(objdir)/Makefile; fi
 	@if [ -f MAKE/OPTIONS/Makefile.$@ ]; \

--- a/src/Purge.list
+++ b/src/Purge.list
@@ -18,6 +18,7 @@ style_neigh_pair.h
 style_neigh_stencil.h
 # other auto-generated files
 lmpcompiledate.h
+lmpinstalledpkgs.h
 # deleted on 4 April 2018
 pair_kim_version.h
 # deleted on 15 December 2017

--- a/src/Purge.list
+++ b/src/Purge.list
@@ -16,8 +16,11 @@ style_region.h
 style_neigh_bin.h
 style_neigh_pair.h
 style_neigh_stencil.h
+style_nbin.h
+style_npair.h
+style_nstencil.h
+style_ntopo.h
 # other auto-generated files
-lmpcompiledate.h
 lmpinstalledpkgs.h
 # deleted on 4 April 2018
 pair_kim_version.h

--- a/src/Purge.list
+++ b/src/Purge.list
@@ -16,6 +16,8 @@ style_region.h
 style_neigh_bin.h
 style_neigh_pair.h
 style_neigh_stencil.h
+# other auto-generated files
+lmpcompiledate.h
 # deleted on 4 April 2018
 pair_kim_version.h
 # deleted on 15 December 2017

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -259,14 +259,27 @@ void Info::command(int narg, char **arg)
   fprintf(out,"Printed on %s\n",ctime(&now));
 
   if (flags & CONFIG) {
-
-    fprintf(out,"\nLAMMPS version: %s / %s\n",
+    fprintf(out,"\nLAMMPS version: %s / %s\n\n",
             universe->version, universe->num_ver);
-    lmp->print_config(out);
     fprintf(out,"sizeof(smallint): %3d-bit\n",(int)sizeof(smallint)*8);
     fprintf(out,"sizeof(imageint): %3d-bit\n",(int)sizeof(imageint)*8);
     fprintf(out,"sizeof(tagint):   %3d-bit\n",(int)sizeof(tagint)*8);
     fprintf(out,"sizeof(bigint):   %3d-bit\n",(int)sizeof(bigint)*8);
+
+    const char *pkg;
+    int ncword, ncline = 0;
+
+    fputs("\nInstalled packages:\n\n",out);
+    for (int i = 0; NULL != (pkg = lmp->installed_packages[i]); ++i) {
+      ncword = strlen(pkg);
+      if (ncline + ncword > 78) {
+        ncline = 0;
+        fputs("\n",out);
+      }
+      fprintf(out,"%s ",pkg);
+      ncline += ncword + 1;
+    }
+    fputs("\n",out);
 
 #if defined(_WIN32)
     DWORD fullversion,majorv,minorv,buildv=0;

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -262,6 +262,7 @@ void Info::command(int narg, char **arg)
 
     fprintf(out,"\nLAMMPS version: %s / %s\n",
             universe->version, universe->num_ver);
+    lmp->print_config(out);
     fprintf(out,"sizeof(smallint): %3d-bit\n",(int)sizeof(smallint)*8);
     fprintf(out,"sizeof(imageint): %3d-bit\n",(int)sizeof(imageint)*8);
     fprintf(out,"sizeof(tagint):   %3d-bit\n",(int)sizeof(tagint)*8);

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -266,6 +266,13 @@ void Info::command(int narg, char **arg)
     fprintf(out,"sizeof(tagint):   %3d-bit\n",(int)sizeof(tagint)*8);
     fprintf(out,"sizeof(bigint):   %3d-bit\n",(int)sizeof(bigint)*8);
 
+    fputs("\nActive compile time flags:\n\n",out);
+    if (has_gzip_support()) fputs("-DLAMMPS_GZIP\n",out);
+    if (has_png_support()) fputs("-DLAMMPS_PNG\n",out);
+    if (has_jpeg_support()) fputs("-DLAMMPS_JPEG\n",out);
+    if (has_ffmpeg_support()) fputs("-DLAMMPS_FFMPEG\n",out);
+    if (has_exceptions()) fputs("-DLAMMPS_EXCEPTIONS\n",out);
+
     const char *pkg;
     int ncword, ncline = 0;
 

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1190,6 +1190,15 @@ bool Info::has_exceptions() {
 #endif
 }
 
+bool Info::has_package(const char * package_name) {
+  for(int i = 0; LAMMPS::installed_packages[i] != NULL; ++i) {
+    if(strcmp(package_name, LAMMPS::installed_packages[i]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /* ---------------------------------------------------------------------- */
 
 char **Info::get_variable_names(int &num) {

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1143,7 +1143,7 @@ static void print_columns(FILE* fp, vector<string> & styles)
   }
 }
 
-bool Info::has_gzip_support() const {
+bool Info::has_gzip_support() {
 #ifdef LAMMPS_GZIP
   return true;
 #else
@@ -1151,7 +1151,7 @@ bool Info::has_gzip_support() const {
 #endif
 }
 
-bool Info::has_png_support() const {
+bool Info::has_png_support() {
 #ifdef LAMMPS_PNG
   return true;
 #else
@@ -1159,7 +1159,7 @@ bool Info::has_png_support() const {
 #endif
 }
 
-bool Info::has_jpeg_support() const {
+bool Info::has_jpeg_support() {
 #ifdef LAMMPS_JPEG
   return true;
 #else
@@ -1167,7 +1167,7 @@ bool Info::has_jpeg_support() const {
 #endif
 }
 
-bool Info::has_ffmpeg_support() const {
+bool Info::has_ffmpeg_support() {
 #ifdef LAMMPS_FFMPEG
   return true;
 #else
@@ -1175,7 +1175,7 @@ bool Info::has_ffmpeg_support() const {
 #endif
 }
 
-bool Info::has_exceptions() const {
+bool Info::has_exceptions() {
 #ifdef LAMMPS_EXCEPTIONS
   return true;
 #else

--- a/src/info.h
+++ b/src/info.h
@@ -33,11 +33,11 @@ class Info : protected Pointers {
   bool is_defined(const char *, const char *);
   bool is_available(const char *, const char *);
 
-  bool has_gzip_support() const;
-  bool has_png_support() const;
-  bool has_jpeg_support() const;
-  bool has_ffmpeg_support() const;
-  bool has_exceptions() const;
+  static bool has_gzip_support();
+  static bool has_png_support();
+  static bool has_jpeg_support();
+  static bool has_ffmpeg_support();
+  static bool has_exceptions();
 
   char **get_variable_names(int &num);
 

--- a/src/info.h
+++ b/src/info.h
@@ -38,6 +38,7 @@ class Info : protected Pointers {
   static bool has_jpeg_support();
   static bool has_ffmpeg_support();
   static bool has_exceptions();
+  static bool has_package(const char * package_name);
 
   char **get_variable_names(int &num);
 

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -978,9 +978,25 @@ void print_style(FILE *fp, const char *str, int &pos)
   }
 }
 
+#define lmp_str(s) #s
+#define lmp_xstr(s) lmp_str(s)
+
 static const char lammps_config_options[]
 = "LAMMPS compile time settings:\n\n"
-  "Integer sizes setting:    "
+  "MPI library setting:       "
+#if defined(MPI_STUBS)
+  "Serial version using STUBS"
+#elif defined(MPICH_VERSION)
+  "Parallel version using MPICH " MPICH_VERSION
+#elif defined(OPEN_MPI)
+  "Parallel version using OpenMPI "
+  lmp_xstr(OMPI_MAJOR_VERSION) "."
+  lmp_xstr(OMPI_MINOR_VERSION) "."
+  lmp_xstr(OMPI_RELEASE_VERSION)
+#else
+ "Parallel version using unknown MPI library"
+#endif
+  "\nInteger sizes setting:    "
 #if defined(LAMMPS_SMALLSMALL)
   " -DLAMMPS_SMALLSMALL"
 #elif defined(LAMMPS_SMALLBIG)
@@ -1019,8 +1035,6 @@ static const char lammps_config_options[]
 #endif
   "\nMemory alignment:         "
 #if defined(LAMMPS_MEMALIGN)
-#define lmp_str(s) #s
-#define lmp_xstr(s) lmp_str(s)
   " -DLAMMPS_MEMALIGN=" lmp_xstr(LAMMPS_MEMALIGN)
 #else
   " (default)"

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -990,6 +990,7 @@ void LAMMPS::print_config(FILE *fp)
   if (Info::has_png_support()) fputs("-DLAMMPS_PNG\n",fp);
   if (Info::has_jpeg_support()) fputs("-DLAMMPS_JPEG\n",fp);
   if (Info::has_ffmpeg_support()) fputs("-DLAMMPS_FFMPEG\n",fp);
+  if (Info::has_exceptions()) fputs("-DLAMMPS_EXCEPTIONS\n",fp);
 
   fputs("\nInstalled packages:\n\n",fp);
   for (int i = 0; NULL != (pkg = installed_packages[i]); ++i) {

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -51,6 +51,8 @@
 #include "version.h"
 #include "error.h"
 
+#include "lmpinstalledpkgs.h"
+
 using namespace LAMMPS_NS;
 
 static void print_style(FILE *fp, const char *str, int &pos);
@@ -977,8 +979,6 @@ void print_style(FILE *fp, const char *str, int &pos)
     pos += 80;
   }
 }
-
-#include "lmpinstalledpkgs.h"
 
 void LAMMPS::print_config(FILE *fp)
 {

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -31,6 +31,7 @@
 #include "style_region.h"
 #include "universe.h"
 #include "input.h"
+#include "info.h"
 #include "atom.h"
 #include "update.h"
 #include "neighbor.h"
@@ -823,6 +824,8 @@ void LAMMPS::help()
           "-var varname value          : set index style variable (-v)\n\n",
           exename);
 
+
+  print_config(fp);
   fprintf(fp,"List of style options included in this LAMMPS executable\n\n");
 
   int pos = 80;
@@ -973,4 +976,65 @@ void print_style(FILE *fp, const char *str, int &pos)
     fprintf(fp,"%-80s",str);
     pos += 80;
   }
+}
+
+static const char lammps_config_options[]
+= "LAMMPS compile time settings:\n"
+  "Integer sizes setting:    "
+#if defined(LAMMPS_SMALLSMALL)
+  " -DLAMMPS_SMALLSMALL"
+#elif defined(LAMMPS_SMALLBIG)
+  " -DLAMMPS_SMALLBIG"
+#elif defined(LAMMPS_BIGBIG)
+  " -DLAMMPS_BIGBIG"
+#else
+  " (unkown)"
+#endif
+  "\nExternal commands support:"
+#if defined(LAMMPS_GZIP)
+  " -DLAMMPS_GZIP"
+#endif
+#if defined(LAMMPS_FFMPEG)
+  " -DLAMMPS_FFMPEG"
+#endif
+  "\nImage library support:    "
+#if defined(LAMMPS_JPEG)
+  " -DLAMMPS_JPEG"
+#endif
+#if defined(LAMMPS_PNG)
+  " -DLAMMPS_PNG"
+#endif
+  "\nFFT library support:      "
+#if defined(FFT_SINGLE)
+  " -DFFT_SINGLE"
+#endif
+#if defined(FFT_FFTW) || defined(FFT_FFTW3)
+  " -DFFT_FFTW3"
+#elif defined(FFT_FFTW2)
+  " -DFFT_FFTW2"
+#elif defined(FFT_MKL)
+  " -DFFT_MKL"
+#else
+  " -DFFT_KISSFFT"
+#endif
+  "\nMemory alignment:         "
+#if defined(LAMMPS_MEMALIGN)
+#define lmp_str(s) #s
+#define lmp_xstr(s) lmp_str(s)
+  " -DLAMMPS_MEMALIGN=" lmp_xstr(LAMMPS_MEMALIGN)
+#else
+  " (default)"
+#endif
+
+  "\nException support:        "
+#if defined(LAMMPS_EXCEPTIONS)
+  " -DLAMMPS_EXCEPTIONS\n"
+#else
+  " (not enabled)\n"
+#endif
+  "\n";
+
+void LAMMPS::print_config(FILE *fp)
+{
+  fputs(lammps_config_options,fp);
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -826,7 +826,7 @@ void LAMMPS::help()
 
 
   print_config(fp);
-  fprintf(fp,"List of style options included in this LAMMPS executable\n\n");
+  fprintf(fp,"List of individual style options included in this LAMMPS executable\n\n");
 
   int pos = 80;
   fprintf(fp,"* Atom styles:\n");
@@ -1060,6 +1060,19 @@ static const char lammps_config_options[]
 
 void LAMMPS::print_config(FILE *fp)
 {
+  const char *pkg;
+  int ncword, ncline = 0;
+
   fputs(lammps_config_options,fp);
-  fprintf(fp,"Installed packages:%s\n\n",lammps_installed_packages);
+  fputs("Installed packages:\n\n",fp);
+  for (int i = 0; NULL != (pkg = lammps_installed_packages[i]); ++i) {
+    ncword = strlen(pkg);
+    if (ncline + ncword > 78) {
+      ncline = 0;
+      fputs("\n",fp);
+    }
+    fprintf(fp,"%s ",pkg);
+    ncline += ncword + 1;
+  }
+  fputs("\n\n",fp);
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -978,84 +978,6 @@ void print_style(FILE *fp, const char *str, int &pos)
   }
 }
 
-#define lmp_str(s) #s
-#define lmp_xstr(s) lmp_str(s)
-
-static const char lammps_config_options[]
-= "LAMMPS compile time settings:\n\n"
-  "MPI library setting         : "
-#if defined(MPI_STUBS)
-  "Serial version using STUBS"
-#elif defined(MPICH_VERSION)
-  "Parallel version using MPICH " MPICH_VERSION
-#elif defined(OPEN_MPI)
-  "Parallel version using OpenMPI "
-  lmp_xstr(OMPI_MAJOR_VERSION) "."
-  lmp_xstr(OMPI_MINOR_VERSION) "."
-  lmp_xstr(OMPI_RELEASE_VERSION)
-#else
- "Parallel version using unknown MPI library"
-#endif
-  "\nInteger sizes setting       : "
-#if defined(LAMMPS_SMALLSMALL)
-  "-DLAMMPS_SMALLSMALL"
-#elif defined(LAMMPS_SMALLBIG)
-  "-DLAMMPS_SMALLBIG"
-#elif defined(LAMMPS_BIGBIG)
-  "-DLAMMPS_BIGBIG"
-#else
-  "(unkown)"
-#endif
-  "\nExternal commands support   :"
-#if defined(LAMMPS_GZIP)
-  " -DLAMMPS_GZIP"
-#endif
-#if defined(LAMMPS_FFMPEG)
-  " -DLAMMPS_FFMPEG"
-#endif
-  "\nImage library support       :"
-#if defined(LAMMPS_JPEG)
-  " -DLAMMPS_JPEG"
-#endif
-#if defined(LAMMPS_PNG)
-  " -DLAMMPS_PNG"
-#endif
-  "\nFFT library support         :"
-#if defined(FFT_SINGLE)
-  " -DFFT_SINGLE"
-#endif
-#if defined(FFT_FFTW) || defined(FFT_FFTW3)
-  " -DFFT_FFTW3"
-#elif defined(FFT_FFTW2)
-  " -DFFT_FFTW2"
-#elif defined(FFT_MKL)
-  " -DFFT_MKL"
-#else
-  " -DFFT_KISSFFT"
-#endif
-  "\n3d-FFT data packing         :"
-#if defined(PACK_POINTER)
-  " -DPACK_POINTER"
-#elif defined(PACK_MEMCPY)
-  " -DPACK_MEMCPY"
-#else
-  " -DPACK_ARRAY"
-#endif
-  "\nMemory alignment            :"
-#if defined(LAMMPS_MEMALIGN)
-  " -DLAMMPS_MEMALIGN=" lmp_xstr(LAMMPS_MEMALIGN)
-#else
-  " (default)"
-#endif
-
-  "\nException support           :"
-#if defined(LAMMPS_EXCEPTIONS)
-  " -DLAMMPS_EXCEPTIONS\n"
-#else
-  " (not enabled)\n"
-#endif
-  "\n";
-
 #include "lmpinstalledpkgs.h"
 
 void LAMMPS::print_config(FILE *fp)
@@ -1063,9 +985,8 @@ void LAMMPS::print_config(FILE *fp)
   const char *pkg;
   int ncword, ncline = 0;
 
-  fputs(lammps_config_options,fp);
   fputs("Installed packages:\n\n",fp);
-  for (int i = 0; NULL != (pkg = lammps_installed_packages[i]); ++i) {
+  for (int i = 0; NULL != (pkg = installed_packages[i]); ++i) {
     ncword = strlen(pkg);
     if (ncline + ncword > 78) {
       ncline = 0;

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -1035,9 +1035,11 @@ static const char lammps_config_options[]
   "\n";
 
 #include "lmpcompiledate.h"
+#include "lmpinstalledpkgs.h"
 
 void LAMMPS::print_config(FILE *fp)
 {
   fprintf(fp,"LAMMPS compiled on: %s\n\n",lammps_compile_date);
   fputs(lammps_config_options,fp);
+  fprintf(fp,"Installed packages:%s\n\n",lammps_installed_packages);
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -1033,6 +1033,14 @@ static const char lammps_config_options[]
 #else
   " -DFFT_KISSFFT"
 #endif
+  "\n3d-FFT data packing         :"
+#if defined(PACK_POINTER)
+  " -DPACK_POINTER"
+#elif defined(PACK_MEMCPY)
+  " -DPACK_MEMCPY"
+#else
+  " -DPACK_ARRAY"
+#endif
   "\nMemory alignment            :"
 #if defined(LAMMPS_MEMALIGN)
   " -DLAMMPS_MEMALIGN=" lmp_xstr(LAMMPS_MEMALIGN)

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -978,8 +978,10 @@ void print_style(FILE *fp, const char *str, int &pos)
   }
 }
 
+#include "lmpcompiledate.h"
+
 static const char lammps_config_options[]
-= "LAMMPS compile time settings:\n"
+= "LAMMPS compile time settings:\n\n"
   "Integer sizes setting:    "
 #if defined(LAMMPS_SMALLSMALL)
   " -DLAMMPS_SMALLSMALL"
@@ -1037,4 +1039,5 @@ static const char lammps_config_options[]
 void LAMMPS::print_config(FILE *fp)
 {
   fputs(lammps_config_options,fp);
+  fprintf(fp,"LAMMPS compiled on: %s\n",lammps_compile_date); 
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -983,7 +983,7 @@ void print_style(FILE *fp, const char *str, int &pos)
 
 static const char lammps_config_options[]
 = "LAMMPS compile time settings:\n\n"
-  "MPI library setting:       "
+  "MPI library setting         : "
 #if defined(MPI_STUBS)
   "Serial version using STUBS"
 #elif defined(MPICH_VERSION)
@@ -996,31 +996,31 @@ static const char lammps_config_options[]
 #else
  "Parallel version using unknown MPI library"
 #endif
-  "\nInteger sizes setting:    "
+  "\nInteger sizes setting       : "
 #if defined(LAMMPS_SMALLSMALL)
-  " -DLAMMPS_SMALLSMALL"
+  "-DLAMMPS_SMALLSMALL"
 #elif defined(LAMMPS_SMALLBIG)
-  " -DLAMMPS_SMALLBIG"
+  "-DLAMMPS_SMALLBIG"
 #elif defined(LAMMPS_BIGBIG)
-  " -DLAMMPS_BIGBIG"
+  "-DLAMMPS_BIGBIG"
 #else
-  " (unkown)"
+  "(unkown)"
 #endif
-  "\nExternal commands support:"
+  "\nExternal commands support   :"
 #if defined(LAMMPS_GZIP)
   " -DLAMMPS_GZIP"
 #endif
 #if defined(LAMMPS_FFMPEG)
   " -DLAMMPS_FFMPEG"
 #endif
-  "\nImage library support:    "
+  "\nImage library support       :"
 #if defined(LAMMPS_JPEG)
   " -DLAMMPS_JPEG"
 #endif
 #if defined(LAMMPS_PNG)
   " -DLAMMPS_PNG"
 #endif
-  "\nFFT library support:      "
+  "\nFFT library support         :"
 #if defined(FFT_SINGLE)
   " -DFFT_SINGLE"
 #endif
@@ -1033,14 +1033,14 @@ static const char lammps_config_options[]
 #else
   " -DFFT_KISSFFT"
 #endif
-  "\nMemory alignment:         "
+  "\nMemory alignment            :"
 #if defined(LAMMPS_MEMALIGN)
   " -DLAMMPS_MEMALIGN=" lmp_xstr(LAMMPS_MEMALIGN)
 #else
   " (default)"
 #endif
 
-  "\nException support:        "
+  "\nException support           :"
 #if defined(LAMMPS_EXCEPTIONS)
   " -DLAMMPS_EXCEPTIONS\n"
 #else
@@ -1048,12 +1048,10 @@ static const char lammps_config_options[]
 #endif
   "\n";
 
-#include "lmpcompiledate.h"
 #include "lmpinstalledpkgs.h"
 
 void LAMMPS::print_config(FILE *fp)
 {
-  fprintf(fp,"LAMMPS compiled on: %s\n\n",lammps_compile_date);
   fputs(lammps_config_options,fp);
   fprintf(fp,"Installed packages:%s\n\n",lammps_installed_packages);
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -978,8 +978,6 @@ void print_style(FILE *fp, const char *str, int &pos)
   }
 }
 
-#include "lmpcompiledate.h"
-
 static const char lammps_config_options[]
 = "LAMMPS compile time settings:\n\n"
   "Integer sizes setting:    "
@@ -1036,8 +1034,10 @@ static const char lammps_config_options[]
 #endif
   "\n";
 
+#include "lmpcompiledate.h"
+
 void LAMMPS::print_config(FILE *fp)
 {
+  fprintf(fp,"LAMMPS compiled on: %s\n\n",lammps_compile_date);
   fputs(lammps_config_options,fp);
-  fprintf(fp,"LAMMPS compiled on: %s\n",lammps_compile_date); 
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -985,7 +985,13 @@ void LAMMPS::print_config(FILE *fp)
   const char *pkg;
   int ncword, ncline = 0;
 
-  fputs("Installed packages:\n\n",fp);
+  fputs("Active compile time flags:\n\n",fp);
+  if (Info::has_gzip_support()) fputs("-DLAMMPS_GZIP\n",fp);
+  if (Info::has_png_support()) fputs("-DLAMMPS_PNG\n",fp);
+  if (Info::has_jpeg_support()) fputs("-DLAMMPS_JPEG\n",fp);
+  if (Info::has_ffmpeg_support()) fputs("-DLAMMPS_FFMPEG\n",fp);
+
+  fputs("\nInstalled packages:\n\n",fp);
   for (int i = 0; NULL != (pkg = installed_packages[i]); ++i) {
     ncword = strlen(pkg);
     if (ncline + ncword > 78) {

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -65,6 +65,7 @@ class LAMMPS {
   void post_create();
   void init();
   void destroy();
+  void print_config(FILE *);    // print compile time settings
 
  private:
   void help();

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -59,6 +59,8 @@ class LAMMPS {
 
   class CiteMe *citeme;          // citation info
 
+  static const char * installed_packages[];
+
   LAMMPS(int, char **, MPI_Comm);
   ~LAMMPS();
   void create();

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -38,6 +38,7 @@
 #include "memory.h"
 #include "error.h"
 #include "force.h"
+#include "info.h"
 
 using namespace LAMMPS_NS;
 
@@ -1520,6 +1521,56 @@ void lammps_create_atoms(void *ptr, int n, tagint *id, int *type,
     }
   }
   END_CAPTURE
+}
+
+// ----------------------------------------------------------------------
+// library API functions for accessing LAMMPS configuration
+// ----------------------------------------------------------------------
+
+int lammps_config_has_package(char * package_name) {
+  return Info::has_package(package_name);
+}
+
+int lammps_config_package_count() {
+  int i = 0;
+  while(LAMMPS::installed_packages[i] != NULL) {
+    ++i;
+  }
+  return i;
+}
+
+int lammps_config_package_name(int index, char * buffer, int max_size) {
+  int i = 0;
+  while(LAMMPS::installed_packages[i] != NULL && i < index) {
+    ++i;
+  }
+
+  if(LAMMPS::installed_packages[i] != NULL) {
+    strncpy(buffer, LAMMPS::installed_packages[i], max_size);
+    return true;
+  }
+
+  return false;
+}
+
+int lammps_config_has_gzip_support() {
+  return Info::has_gzip_support();
+}
+
+int lammps_config_has_png_support() {
+  return Info::has_png_support();
+}
+
+int lammps_config_has_jpeg_support() {
+  return Info::has_jpeg_support();
+}
+
+int lammps_config_has_ffmpeg_support() {
+  return Info::has_ffmpeg_support();
+}
+
+int lammps_config_has_exceptions() {
+  return Info::has_exceptions();
 }
 
 // ----------------------------------------------------------------------

--- a/src/library.h
+++ b/src/library.h
@@ -55,6 +55,15 @@ void lammps_gather_atoms_subset(void *, char *, int, int, int, int *, void *);
 void lammps_scatter_atoms(void *, char *, int, int, void *);
 void lammps_scatter_atoms_subset(void *, char *, int, int, int, int *, void *);
 
+int lammps_config_has_package(char * package_name);
+int lammps_config_package_count();
+int lammps_config_package_name(int index, char * buffer, int max_size);
+int lammps_config_has_gzip_support();
+int lammps_config_has_png_support();
+int lammps_config_has_jpeg_support();
+int lammps_config_has_ffmpeg_support();
+int lammps_config_has_exceptions();
+
 // lammps_create_atoms() takes tagint and imageint as args
 // ifdef insures they are compatible with rest of LAMMPS
 // caller must match to how LAMMPS library is built


### PR DESCRIPTION
## Purpose

This adds a function `LAMMPS::print_config()` and a list `LAMMPS::installed_packages[]` that is supposed to report various compile time settings for the executable to output them them with with the `-help` flag or when using the `info config` command.

Update 2018-06-21: The inclusion of compile time options (like `-DLAMMPS_BIGBIG`) is better done together with the creation of the `lmpconfig.h` header and adding `make config` to the conventional make system. So the scope of this PR is reduced of providing and outputting the list of packages and flags, that are already supported inside the `Info` class.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

likely. this changes the `info config` command output, which may affect PyLAMMPS.

## Implementation Notes

This is providing support for both, cmake and conventional make.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

Example output of `./lmp_machine -h`:
```txt
Large-scale Atomic/Molecular Massively Parallel Simulator - 11 May 2018

Usage example: ./lmp -var t 300 -echo screen -in in.alloy

List of command line options supported by this LAMMPS executable:

-echo none/screen/log/both  : echoing of input script (-e)
-help                       : print this help message (-h)
-in filename                : read input from file, not stdin (-i)
-kokkos on/off ...          : turn KOKKOS mode on or off (-k)
-log none/filename          : where to send log output (-l)
-nocite                     : disable writing log.cite file (-nc)
-package style ...          : invoke package command (-pk)
-partition size1 size2 ...  : assign partition sizes (-p)
-plog basename              : basename for partition logs (-pl)
-pscreen basename           : basename for partition screens (-ps)
-restart rfile dfile ...    : convert restart to data file (-r)
-reorder topology-specs     : processor reordering (-r)
-screen none/filename       : where to send screen output (-sc)
-suffix gpu/intel/opt/omp   : style suffix to apply (-sf)
-var varname value          : set index style variable (-v)

Active compile time flags:

-DLAMMPS_GZIP
-DLAMMPS_PNG
-DLAMMPS_JPEG
-DLAMMPS_FFMPEG

Installed packages:

ASPHERE BODY CLASS2 COLLOID COMPRESS CORESHELL DIPOLE GRANULAR KSPACE MANYBODY 
MC MISC MOLECULE PERI QEQ REPLICA RIGID SHOCK SNAP SRD OPT VORONOI POEMS 
USER-CGDNA USER-MESO USER-CGSDK USER-COLVARS USER-DIFFRACTION USER-DPD 
USER-DRUDE USER-FEP USER-MANIFOLD USER-MEAMC USER-MISC USER-MOFFF USER-MOLFILE 
USER-PHONON USER-REAXC USER-SMD USER-SPH USER-TALLY USER-UEF 

List of individual style options included in this LAMMPS executable

* Atom styles:

atomic          body            charge          ellipsoid       hybrid          
line            sphere          tri             dipole          angle           
bond            full            molecular       template        peri            
edpd            mdpd            tdpd            dpd             smd             
meso 
[...]
```

Example output of `info config`:
```txt
$ ./lmp
LAMMPS (11 May 2018)
  using 1 OpenMP thread(s) per MPI task
info config

Info-Info-Info-Info-Info-Info-Info-Info-Info-Info-Info
Printed on Fri Jun 22 08:25:49 2018


LAMMPS version: 11 May 2018 / 20180511

sizeof(smallint):  32-bit
sizeof(imageint):  32-bit
sizeof(tagint):    32-bit
sizeof(bigint):    64-bit

Active compile time flags:

-DLAMMPS_GZIP
-DLAMMPS_PNG
-DLAMMPS_JPEG
-DLAMMPS_FFMPEG

Installed packages:

ASPHERE BODY CLASS2 COLLOID COMPRESS CORESHELL DIPOLE GRANULAR KSPACE MANYBODY 
MC MISC MOLECULE PERI QEQ REPLICA RIGID SHOCK SNAP SRD OPT VORONOI POEMS 
USER-CGDNA USER-MESO USER-CGSDK USER-COLVARS USER-DIFFRACTION USER-DPD 
USER-DRUDE USER-FEP USER-MANIFOLD USER-MEAMC USER-MISC USER-MOFFF USER-MOLFILE 
USER-PHONON USER-REAXC USER-SMD USER-SPH USER-TALLY USER-UEF 

OS information: Linux 4.16.16-300.fc28.x86_64 on x86_64

Info-Info-Info-Info-Info-Info-Info-Info-Info-Info-Info

Total wall time: 0:00:10
```
