### PR TITLE
USER-DPD: bugfix for AtomVecDPD::unpack_restart() and the Kokkos version

### DIFF
--- a/src/KOKKOS/atom_vec_dpd_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.cpp
@@ -158,6 +158,7 @@ void AtomVecDPDKokkos::copy(int i, int j, int delflag)
 {
   sync(Host,X_MASK | V_MASK | TAG_MASK | TYPE_MASK |
             MASK_MASK | IMAGE_MASK | DPDTHETA_MASK |
+            UCG_MASK | UCGNEW_MASK |
             UCOND_MASK | UMECH_MASK | UCHEM_MASK | DVECTOR_MASK);
 
   h_tag[j] = h_tag[i];
@@ -183,6 +184,7 @@ void AtomVecDPDKokkos::copy(int i, int j, int delflag)
 
   modified(Host,X_MASK | V_MASK | TAG_MASK | TYPE_MASK |
                 MASK_MASK | IMAGE_MASK | DPDTHETA_MASK |
+                UCG_MASK | UCGNEW_MASK |
                 UCOND_MASK | UMECH_MASK | UCHEM_MASK | DVECTOR_MASK);
 }
 
@@ -1029,7 +1031,7 @@ int AtomVecDPDKokkos::pack_comm_hybrid(int n, int *list, double *buf)
   int i,j,m;
 
   sync(Host,DPDTHETA_MASK | UCOND_MASK |
-            UMECH_MASK | UCHEM_MASK | UCG_MASK | UCGNEW_MASK);
+            UMECH_MASK | UCHEM_MASK);
 
   m = 0;
   for (i = 0; i < n; i++) {
@@ -1234,7 +1236,7 @@ int AtomVecDPDKokkos::unpack_comm_hybrid(int n, int first, double *buf)
   }
 
   modified(Host,DPDTHETA_MASK | UCOND_MASK |
-                UMECH_MASK | UCHEM_MASK | UCG_MASK | UCGNEW_MASK);
+                UMECH_MASK | UCHEM_MASK );
 
   return m;
 }
@@ -1645,6 +1647,8 @@ int AtomVecDPDKokkos::unpack_restart(double *buf)
   h_uCond[nlocal] = buf[m++];
   h_uMech[nlocal] = buf[m++];
   h_uChem[nlocal] = buf[m++];
+  h_uCG[nlocal] = 0.0;
+  h_uCGnew[nlocal] = 0.0;
 
   double **extra = atom->extra;
   if (atom->nextra_store) {
@@ -1654,6 +1658,7 @@ int AtomVecDPDKokkos::unpack_restart(double *buf)
 
   modified(Host,X_MASK | V_MASK | TAG_MASK | TYPE_MASK |
                 MASK_MASK | IMAGE_MASK | DPDTHETA_MASK |
+                UCG_MASK | UCGNEW_MASK |
                 UCOND_MASK | UMECH_MASK | UCHEM_MASK | DVECTOR_MASK);
 
   atom->nlocal++;

--- a/src/USER-DPD/atom_vec_dpd.cpp
+++ b/src/USER-DPD/atom_vec_dpd.cpp
@@ -757,6 +757,8 @@ int AtomVecDPD::unpack_restart(double *buf)
   uCond[nlocal] = buf[m++];
   uMech[nlocal] = buf[m++];
   uChem[nlocal] = buf[m++];
+  uCG[nlocal] = 0.0;
+  uCGnew[nlocal] = 0.0;
 
   double **extra = atom->extra;
   if (atom->nextra_store) {


### PR DESCRIPTION
USER-DPD bugfix for a crash when using restart or replicate when reactions are turned on.

## Purpose

Fixes a crash when using the python interface on a 2nd LAMMPS invocation
when using the restart (or replicate) commands, because of garbage
in the uCG and uCGnew arrays leftover from the previous LAMMPS invocation.
Also, cleaned up UCG_MASK and UCGNEW_MASK usage in atom_vec_dpd_kokkos.cpp

## Author(s)

Tim Mattox (Engility)

## Backward Compatibility

no change

## Implementation Notes

When using the restart or replicate command with DPD-RX, the uCG and uCGnew arrays were not guaranteed to be initialized to zero.  This corrects that mistake, as well as cleans up the modify and sync flags for those two arrays in the Kokkos code as well.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

The issue was exposed when invoking LAMMPS a second time via the python interface.


