### PR TITLE
Move enums that have to be consistent across files into a class

### DIFF
--- a/src/COLLOID/pair_lubricate.cpp
+++ b/src/COLLOID/pair_lubricate.cpp
@@ -43,10 +43,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-// same as fix_deform.cpp
-
-enum{NO_REMAP,X_REMAP,V_REMAP};
-
 // same as fix_wall.cpp
 
 enum{EDGE,CONSTANT,VARIABLE};
@@ -570,7 +566,7 @@ void PairLubricate::init_style()
   for (int i = 0; i < modify->nfix; i++){
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
       shearing = flagdeform = 1;
-      if (((FixDeform *) modify->fix[i])->remapflag != V_REMAP)
+      if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using pair lubricate with inconsistent "
                    "fix deform remap option");
     }

--- a/src/COLLOID/pair_lubricate_poly.cpp
+++ b/src/COLLOID/pair_lubricate_poly.cpp
@@ -44,11 +44,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-// same as fix_deform.cpp
-
-enum{NO_REMAP,X_REMAP,V_REMAP};
-
-
 // same as fix_wall.cpp
 
 enum{EDGE,CONSTANT,VARIABLE};
@@ -474,7 +469,7 @@ void PairLubricatePoly::init_style()
   for (int i = 0; i < modify->nfix; i++){
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
       shearing = flagdeform = 1;
-      if (((FixDeform *) modify->fix[i])->remapflag != V_REMAP)
+      if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using pair lubricate with inconsistent "
                    "fix deform remap option");
     }
@@ -550,7 +545,7 @@ void PairLubricatePoly::init_style()
   for (int i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
       shearing = 1;
-      if (((FixDeform *) modify->fix[i])->remapflag != V_REMAP)
+      if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using pair lubricate/poly with inconsistent "
                    "fix deform remap option");
     }

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -39,7 +39,6 @@ using namespace MathConst;
 
 enum{ATOM,MOLECULE};
 enum{ONE,RANGE,POLY};
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 #define EPSILON 0.001
 #define SMALL 1.0e-10
@@ -609,7 +608,7 @@ void FixPour::pre_exchange()
           newcoord[1] >= sublo[1] && newcoord[1] < subhi[1] &&
           newcoord[2] >= sublo[2] && newcoord[2] < subhi[2]) flag = 1;
       else if (dimension == 3 && newcoord[2] >= domain->boxhi[2]) {
-        if (comm->layout != LAYOUT_TILED) {
+        if (comm->layout != Comm::LAYOUT_TILED) {
           if (comm->myloc[2] == comm->procgrid[2]-1 &&
               newcoord[0] >= sublo[0] && newcoord[0] < subhi[0] &&
               newcoord[1] >= sublo[1] && newcoord[1] < subhi[1]) flag = 1;
@@ -619,7 +618,7 @@ void FixPour::pre_exchange()
               newcoord[1] >= sublo[1] && newcoord[1] < subhi[1]) flag = 1;
         }
       } else if (dimension == 2 && newcoord[1] >= domain->boxhi[1]) {
-        if (comm->layout != LAYOUT_TILED) {
+        if (comm->layout != Comm::LAYOUT_TILED) {
           if (comm->myloc[1] == comm->procgrid[1]-1 &&
               newcoord[0] >= sublo[0] && newcoord[0] < subhi[0]) flag = 1;
         } else {

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -36,8 +36,6 @@ using namespace LAMMPS_NS;
 #define BUFMIN 10000
 #define BUFEXTRA 1000
 
-enum{SINGLE,MULTI};
-
 /* ----------------------------------------------------------------------
    setup MPI and allocate buffer space
 ------------------------------------------------------------------------- */
@@ -709,7 +707,7 @@ void CommKokkos::borders()
   if (!exchange_comm_classic) {
     static int print = 1;
 
-    if (style != SINGLE || bordergroup || ghost_velocity) {
+    if (style != Comm::SINGLE || bordergroup || ghost_velocity) {
       if (print && comm->me==0) {
         error->warning(FLERR,"Required border comm not yet implemented in Kokkos communication, "
                       "switching to classic communication");
@@ -817,7 +815,7 @@ void CommKokkos::borders_device() {
       // store sent atom indices in list for use in future timesteps
 
       x = atom->x;
-      if (style == SINGLE) {
+      if (style == Comm::SINGLE) {
         lo = slablo[iswap];
         hi = slabhi[iswap];
       } else {
@@ -846,7 +844,7 @@ void CommKokkos::borders_device() {
 
       if (sendflag) {
         if (!bordergroup || ineed >= 2) {
-          if (style == SINGLE) {
+          if (style == Comm::SINGLE) {
             k_total_send.h_view() = 0;
             k_total_send.template modify<LMPHostType>();
             k_total_send.template sync<LMPDeviceType>();
@@ -894,7 +892,7 @@ void CommKokkos::borders_device() {
         } else {
           error->all(FLERR,"Required border comm not yet "
                      "implemented with Kokkos");
-          if (style == SINGLE) {
+          if (style == Comm::SINGLE) {
             ngroup = atom->nfirst;
             for (i = 0; i < ngroup; i++)
               if (x[i][dim] >= lo && x[i][dim] <= hi) {
@@ -1099,7 +1097,7 @@ void CommKokkos::grow_swap(int n)
 {
   free_swap();
   allocate_swap(n);
-  if (style == MULTI) {
+  if (style == Comm::MULTI) {
     free_multi();
     allocate_multi(n);
   }

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -39,8 +39,6 @@ using namespace LAMMPS_NS;
 
 #define DELTA_PROCS 16
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 /* ---------------------------------------------------------------------- */
 
 CommTiledKokkos::CommTiledKokkos(LAMMPS *lmp) : CommTiled(lmp)

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -39,7 +39,6 @@ using namespace LAMMPS_NS;
 
 #define DELTA_PROCS 16
 
-enum{SINGLE,MULTI};               // same as in Comm
 enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/fix_deform_kokkos.cpp
+++ b/src/KOKKOS/fix_deform_kokkos.cpp
@@ -41,10 +41,6 @@ using namespace MathConst;
 enum{NONE,FINAL,DELTA,SCALE,VEL,ERATE,TRATE,VOLUME,WIGGLE,VARIABLE};
 enum{ONE_FROM_ONE,ONE_FROM_TWO,TWO_FROM_ONE};
 
-// same as domain.cpp, fix_nvt_sllod.cpp, compute_temp_deform.cpp
-
-enum{NO_REMAP,X_REMAP,V_REMAP};
-
 /* ---------------------------------------------------------------------- */
 
 FixDeformKokkos::FixDeformKokkos(LAMMPS *lmp, int narg, char **arg) : FixDeform(lmp, narg, arg)
@@ -315,7 +311,7 @@ void FixDeformKokkos::end_of_step()
 
   // convert atoms and rigid bodies to lamda coords
 
-  if (remapflag == X_REMAP) {
+  if (remapflag == Domain::X_REMAP) {
     int nlocal = atom->nlocal;
 
     domainKK->x2lamda(nlocal);
@@ -355,7 +351,7 @@ void FixDeformKokkos::end_of_step()
 
   // convert atoms and rigid bodies back to box coords
 
-  if (remapflag == X_REMAP) {
+  if (remapflag == Domain::X_REMAP) {
     int nlocal = atom->nlocal;
 
     domainKK->lamda2x(nlocal);

--- a/src/KOKKOS/nbin_kokkos.cpp
+++ b/src/KOKKOS/nbin_kokkos.cpp
@@ -23,8 +23,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{NSQ,BIN,MULTI};       // also in Neighbor
-
 #define SMALL 1.0e-6
 #define CUT2BIN_RATIO 100
 

--- a/src/KOKKOS/neigh_bond_kokkos.cpp
+++ b/src/KOKKOS/neigh_bond_kokkos.cpp
@@ -37,8 +37,6 @@ using namespace LAMMPS_NS;
 #define BONDDELTA 10000
 #define LB_FACTOR 1.5
 
-enum{IGNORE,WARN,ERROR};           // same as thermo.cpp
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
@@ -288,7 +286,7 @@ void NeighBondKokkos<DeviceType>::bond_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Bond atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -296,7 +294,7 @@ void NeighBondKokkos<DeviceType>::bond_all()
   }
 
   if (neighbor->cluster_check) bond_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -317,7 +315,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondBondAll, const int &i, 
     int atom1 = map_array(bond_atom(i,m));
     if (atom1 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);
@@ -383,7 +381,7 @@ void NeighBondKokkos<DeviceType>::bond_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Bond atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -391,7 +389,7 @@ void NeighBondKokkos<DeviceType>::bond_partial()
   }
 
   if (neighbor->cluster_check) bond_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -413,7 +411,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondBondPartial, const int 
     int atom1 = map_array(bond_atom(i,m));
     if (atom1 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);
@@ -505,7 +503,7 @@ void NeighBondKokkos<DeviceType>::angle_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Angle atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -513,7 +511,7 @@ void NeighBondKokkos<DeviceType>::angle_all()
   }
 
   if (neighbor->cluster_check) angle_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -536,7 +534,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondAngleAll, const int &i,
     int atom3 = map_array(angle_atom3(i,m));
     if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);
@@ -607,7 +605,7 @@ void NeighBondKokkos<DeviceType>::angle_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Angle atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -615,7 +613,7 @@ void NeighBondKokkos<DeviceType>::angle_partial()
   }
 
   if (neighbor->cluster_check) angle_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -639,7 +637,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondAnglePartial, const int
     int atom3 = map_array(angle_atom3(i,m));
     if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);
@@ -749,7 +747,7 @@ void NeighBondKokkos<DeviceType>::dihedral_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Dihedral atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -757,7 +755,7 @@ void NeighBondKokkos<DeviceType>::dihedral_all()
   }
 
   if (neighbor->cluster_check) dihedral_check(neighbor->ndihedrallist,v_dihedrallist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -781,7 +779,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondDihedralAll, const int 
     int atom4 = map_array(dihedral_atom4(i,m));
     if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);
@@ -856,7 +854,7 @@ void NeighBondKokkos<DeviceType>::dihedral_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Dihedral atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -864,7 +862,7 @@ void NeighBondKokkos<DeviceType>::dihedral_partial()
   }
 
   if (neighbor->cluster_check) dihedral_check(neighbor->ndihedrallist,v_dihedrallist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -889,7 +887,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondDihedralPartial, const 
     int atom4 = map_array(dihedral_atom4(i,m));
     if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);
@@ -1020,7 +1018,7 @@ void NeighBondKokkos<DeviceType>::improper_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Improper atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -1028,7 +1026,7 @@ void NeighBondKokkos<DeviceType>::improper_all()
   }
 
   if (neighbor->cluster_check) dihedral_check(neighbor->nimproperlist,v_improperlist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -1052,7 +1050,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondImproperAll, const int 
     int atom4 = map_array(improper_atom4(i,m));
     if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);
@@ -1127,7 +1125,7 @@ void NeighBondKokkos<DeviceType>::improper_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == ERROR) {
+  if (nmissing && lostbond == Thermo::ERROR) {
     char str[128];
     sprintf(str,"Improper atoms missing on proc %d at step " BIGINT_FORMAT,
             me,update->ntimestep);
@@ -1135,7 +1133,7 @@ void NeighBondKokkos<DeviceType>::improper_partial()
   }
 
   if (neighbor->cluster_check) dihedral_check(neighbor->nimproperlist,v_improperlist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
@@ -1160,7 +1158,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondImproperPartial, const 
     int atom4 = map_array(improper_atom4(i,m));
     if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
       nmissing++;
-      if (lostbond == ERROR) return;
+      if (lostbond == Thermo::ERROR) return;
       continue;
     }
     atom1 = closest_image(i,atom1);

--- a/src/KOKKOS/neigh_list_kokkos.cpp
+++ b/src/KOKKOS/neigh_list_kokkos.cpp
@@ -17,8 +17,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{NSQ,BIN,MULTI};
-
 /* ---------------------------------------------------------------------- */
 
 template<class Device>

--- a/src/KOKKOS/neighbor_kokkos.cpp
+++ b/src/KOKKOS/neighbor_kokkos.cpp
@@ -33,8 +33,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{NSQ,BIN,MULTI};     // also in neigh_list.cpp
-
 /* ---------------------------------------------------------------------- */
 
 NeighborKokkos::NeighborKokkos(LAMMPS *lmp) : Neighbor(lmp),
@@ -98,7 +96,7 @@ void NeighborKokkos::init_cutneighsq_kokkos(int n)
 
 void NeighborKokkos::create_kokkos_list(int i)
 {
-  if (style != BIN)
+  if (style != Neighbor::BIN)
     error->all(FLERR,"KOKKOS package only supports 'bin' neighbor lists");
 
   if (requests[i]->kokkos_device) {
@@ -300,7 +298,7 @@ void NeighborKokkos::build_kokkos(int topoflag)
   // if bin then, atoms may have moved outside of proc domain & bin extent,
   //   leading to errors or even a crash
 
-  if (style != NSQ) {
+  if (style != Neighbor::NSQ) {
     for (int i = 0; i < nbin; i++) {
       neigh_bin[i]->bin_atoms_setup(nall);
       neigh_bin[i]->bin_atoms();

--- a/src/KSPACE/ewald_disp.cpp
+++ b/src/KSPACE/ewald_disp.cpp
@@ -39,8 +39,6 @@ using namespace MathSpecial;
 
 #define SMALL 0.00001
 
-enum{GEOMETRIC,ARITHMETIC,SIXTHPOWER};   // same as in pair.h
-
 //#define DEBUG
 
 /* ---------------------------------------------------------------------- */
@@ -116,7 +114,7 @@ void EwaldDisp::init()
   if (!(ptr||cutoff))
     error->all(FLERR,"KSpace style is incompatible with Pair style");
   int ewald_order = ptr ? *((int *) ptr) : 1<<1;
-  int ewald_mix = ptr ? *((int *) pair->extract("ewald_mix",tmp)) : GEOMETRIC;
+  int ewald_mix = ptr ? *((int *) pair->extract("ewald_mix",tmp)) : Pair::GEOMETRIC;
   memset(function, 0, EWALD_NFUNCS*sizeof(int));
   for (int i=0; i<=EWALD_NORDER; ++i)                        // transcribe order
     if (ewald_order&(1<<i)) {                                // from pair_style
@@ -127,8 +125,8 @@ void EwaldDisp::init()
         case 3:
           k = 3; break;
         case 6:
-          if (ewald_mix==GEOMETRIC) { k = 1; break; }
-          else if (ewald_mix==ARITHMETIC) { k = 2; break; }
+          if (ewald_mix==Pair::GEOMETRIC) { k = 1; break; }
+          else if (ewald_mix==Pair::ARITHMETIC) { k = 2; break; }
           error->all(FLERR,
                      "Unsupported mixing rule in kspace_style ewald/disp");
         default:

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -46,7 +46,6 @@ using namespace MathConst;
 #define LARGE 10000.0
 #define EPS_HOC 1.0e-7
 
-enum{GEOMETRIC,ARITHMETIC,SIXTHPOWER};
 enum{REVERSE_RHO, REVERSE_RHO_G, REVERSE_RHO_A, REVERSE_RHO_NONE};
 enum{FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM,
      FORWARD_IK_G, FORWARD_AD_G, FORWARD_IK_PERATOM_G, FORWARD_AD_PERATOM_G,
@@ -304,7 +303,7 @@ void PPPMDisp::init()
   // check out which types of potentials will have to be calculated
 
   int ewald_order = ptr ? *((int *) ptr) : 1<<1;
-  int ewald_mix = ptr ? *((int *) pair->extract("ewald_mix",tmp)) : GEOMETRIC;
+  int ewald_mix = ptr ? *((int *) pair->extract("ewald_mix",tmp)) : Pair::GEOMETRIC;
   memset(function, 0, EWALD_FUNCS*sizeof(int));
   for (int i=0; i<=EWALD_MAXORDER; ++i)                 // transcribe order
     if (ewald_order&(1<<i)) {                           // from pair_style
@@ -314,9 +313,9 @@ void PPPMDisp::init()
         case 1:
           k = 0; break;
         case 6:
-          if ((ewald_mix==GEOMETRIC || ewald_mix==SIXTHPOWER ||
+          if ((ewald_mix==Pair::GEOMETRIC || ewald_mix==Pair::SIXTHPOWER ||
                mixflag == 1) && mixflag!= 2) { k = 1; break; }
-          else if (ewald_mix==ARITHMETIC && mixflag!=2) { k = 2; break; }
+          else if (ewald_mix==Pair::ARITHMETIC && mixflag!=2) { k = 2; break; }
           else if (mixflag == 2) { k = 3; break; }
         default:
           sprintf(str, "Unsupported order in kspace_style "

--- a/src/MISC/fix_deposit.cpp
+++ b/src/MISC/fix_deposit.cpp
@@ -37,7 +37,6 @@ using namespace FixConst;
 using namespace MathConst;
 
 enum{ATOM,MOLECULE};
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 enum{DIST_UNIFORM,DIST_GAUSSIAN};
 
 #define EPSILON 1.0e6
@@ -506,7 +505,7 @@ void FixDeposit::pre_exchange()
           newcoord[1] >= sublo[1] && newcoord[1] < subhi[1] &&
           newcoord[2] >= sublo[2] && newcoord[2] < subhi[2]) flag = 1;
       else if (dimension == 3 && newcoord[2] >= domain->boxhi[2]) {
-        if (comm->layout != LAYOUT_TILED) {
+        if (comm->layout != Comm::LAYOUT_TILED) {
           if (comm->myloc[2] == comm->procgrid[2]-1 &&
               newcoord[0] >= sublo[0] && newcoord[0] < subhi[0] &&
               newcoord[1] >= sublo[1] && newcoord[1] < subhi[1]) flag = 1;
@@ -516,7 +515,7 @@ void FixDeposit::pre_exchange()
               newcoord[1] >= sublo[1] && newcoord[1] < subhi[1]) flag = 1;
         }
       } else if (dimension == 2 && newcoord[1] >= domain->boxhi[1]) {
-        if (comm->layout != LAYOUT_TILED) {
+        if (comm->layout != Comm::LAYOUT_TILED) {
           if (comm->myloc[1] == comm->procgrid[1]-1 &&
               newcoord[0] >= sublo[0] && newcoord[0] < subhi[0]) flag = 1;
         } else {

--- a/src/MPIIO/dump_cfg_mpiio.cpp
+++ b/src/MPIIO/dump_cfg_mpiio.cpp
@@ -47,8 +47,6 @@ using namespace LAMMPS_NS;
 #define DUMP_BUF_CHUNK_SIZE 16384
 #define DUMP_BUF_INCREMENT_SIZE 4096
 
-enum{INT,DOUBLE,STRING,BIGINT};   // same as in DumpCustom
-
 #define UNWRAPEXPAND 10.0
 #define ONEFIELD 32
 #define DELTA 1048576
@@ -377,13 +375,13 @@ int DumpCFGMPIIO::convert_string_omp(int n, double *mybuf)
             } else if (j == 1) {
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),"%s \n",typenames[(int) mybuf[bufOffset[tid]+m]]);
             } else if (j >= 2) {
-            if (vtype[j] == INT)
+            if (vtype[j] == Dump::INT)
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],static_cast<int> (mybuf[bufOffset[tid]+m]));
-            else if (vtype[j] == DOUBLE)
+            else if (vtype[j] == Dump::DOUBLE)
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],mybuf[bufOffset[tid]+m]);
-            else if (vtype[j] == STRING)
+            else if (vtype[j] == Dump::STRING)
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],typenames[(int) mybuf[bufOffset[tid]+m]]);
-            else if (vtype[j] == BIGINT)
+            else if (vtype[j] == Dump::BIGINT)
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],static_cast<bigint> (mybuf[bufOffset[tid]+m]));
           }
           m++;
@@ -410,18 +408,18 @@ int DumpCFGMPIIO::convert_string_omp(int n, double *mybuf)
           //offset += sprintf(&sbuf[offset],vformat[j],unwrap_coord);
             mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],unwrap_coord);
           } else if (j >= 5 ) {
-            if (vtype[j] == INT)
+            if (vtype[j] == Dump::INT)
             //offset +=
             //  sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],static_cast<int> (mybuf[bufOffset[tid]+m]));
-            else if (vtype[j] == DOUBLE)
+            else if (vtype[j] == Dump::DOUBLE)
             // offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],mybuf[bufOffset[tid]+m]);
-            else if (vtype[j] == STRING)
+            else if (vtype[j] == Dump::STRING)
             // offset +=
             //  sprintf(&sbuf[offset],vformat[j],typenames[(int) mybuf[m]]);
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],typenames[(int) mybuf[bufOffset[tid]+m]]);
-            else if (vtype[j] == BIGINT)
+            else if (vtype[j] == Dump::BIGINT)
             // offset +=
             //  sprintf(&sbuf[offset],vformat[j],static_cast<bigint> (mybuf[m]));
               mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],static_cast<bigint> (mybuf[bufOffset[tid]+m]));

--- a/src/MPIIO/dump_custom_mpiio.cpp
+++ b/src/MPIIO/dump_custom_mpiio.cpp
@@ -53,7 +53,6 @@ enum{ID,MOL,TYPE,ELEMENT,MASS,
      TQX,TQY,TQZ,SPIN,ERADIUS,ERVEL,ERFORCE,
      COMPUTE,FIX,VARIABLE};
 enum{LT,LE,GT,GE,EQ,NEQ};
-enum{INT,DOUBLE,STRING,BIGINT};    // same as in DumpCustom
 
 /* ---------------------------------------------------------------------- */
 
@@ -246,13 +245,13 @@ void DumpCustomMPIIO::init_style()
     if (format_column_user[i]) {
       vformat[i] = new char[strlen(format_column_user[i]) + 2];
       strcpy(vformat[i],format_column_user[i]);
-    } else if (vtype[i] == INT && format_int_user) {
+    } else if (vtype[i] == Dump::INT && format_int_user) {
       vformat[i] = new char[strlen(format_int_user) + 2];
       strcpy(vformat[i],format_int_user);
-    } else if (vtype[i] == DOUBLE && format_float_user) {
+    } else if (vtype[i] == Dump::DOUBLE && format_float_user) {
       vformat[i] = new char[strlen(format_float_user) + 2];
       strcpy(vformat[i],format_float_user);
-    } else if (vtype[i] == BIGINT && format_bigint_user) {
+    } else if (vtype[i] == Dump::BIGINT && format_bigint_user) {
       vformat[i] = new char[strlen(format_bigint_user) + 2];
       strcpy(vformat[i],format_bigint_user);
     } else {
@@ -618,11 +617,11 @@ int DumpCustomMPIIO::convert_string_omp(int n, double *mybuf)
         }
         for (int j = 0; j < size_one; j++) {
 
-          if (vtype[j] == INT)
+          if (vtype[j] == Dump::INT)
             mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],static_cast<int> (mybuf[bufOffset[tid]+m]));
-          else if (vtype[j] == DOUBLE)
+          else if (vtype[j] == Dump::DOUBLE)
             mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],mybuf[bufOffset[tid]+m]);
-          else if (vtype[j] == STRING)
+          else if (vtype[j] == Dump::STRING)
             mpifhStringCountPerThread[tid] += sprintf(&(mpifh_buffer_line_per_thread[tid][mpifhStringCountPerThread[tid]]),vformat[j],typenames[(int) mybuf[bufOffset[tid]+m]]);
           m ++;
         }

--- a/src/MPIIO/dump_xyz_mpiio.cpp
+++ b/src/MPIIO/dump_xyz_mpiio.cpp
@@ -53,7 +53,6 @@ enum{ID,MOL,TYPE,ELEMENT,MASS,
      TQX,TQY,TQZ,SPIN,ERADIUS,ERVEL,ERFORCE,
      COMPUTE,FIX,VARIABLE};
 enum{LT,LE,GT,GE,EQ,NEQ};
-enum{INT,DOUBLE,STRING};    // same as in DumpCFG
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/SHOCK/fix_append_atoms.cpp
+++ b/src/SHOCK/fix_append_atoms.cpp
@@ -29,8 +29,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 #define BIG      1.0e30
 #define EPSILON  1.0e-6
 
@@ -417,7 +415,7 @@ void FixAppendAtoms::pre_exchange()
     if (spatflag==1) if (get_spatial()==0) return;
 
     int addflag = 0;
-    if (comm->layout != LAYOUT_TILED) {
+    if (comm->layout != Comm::LAYOUT_TILED) {
       if (comm->myloc[2] == comm->procgrid[2]-1) addflag = 1;
     } else {
       if (comm->mysplit[2][1] == 1.0) addflag = 1;

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -52,8 +52,6 @@ enum{BIG_MOVE,SRD_MOVE,SRD_ROTATE};
 enum{CUBIC_ERROR,CUBIC_WARN};
 enum{SHIFT_NO,SHIFT_YES,SHIFT_POSSIBLE};
 
-enum{NO_REMAP,X_REMAP,V_REMAP};                   // same as fix_deform.cpp
-
 #define EINERTIA 0.2          // moment of inertia prefactor for ellipsoid
 
 #define ATOMPERBIN 30
@@ -384,7 +382,7 @@ void FixSRD::init()
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
       deformflag = 1;
       FixDeform *deform = (FixDeform *) modify->fix[i];
-      if (deform->box_change_shape && deform->remapflag != V_REMAP)
+      if (deform->box_change_shape && deform->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix srd with inconsistent "
                    "fix deform remap option");
     }

--- a/src/USER-EFF/compute_temp_deform_eff.cpp
+++ b/src/USER-EFF/compute_temp_deform_eff.cpp
@@ -35,8 +35,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{NO_REMAP,X_REMAP,V_REMAP};                   // same as fix_deform.cpp
-
 /* ---------------------------------------------------------------------- */
 
 ComputeTempDeformEff::ComputeTempDeformEff(LAMMPS *lmp, int narg, char **arg) :
@@ -76,7 +74,7 @@ void ComputeTempDeformEff::init()
   int i;
   for (i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
-      if (((FixDeform *) modify->fix[i])->remapflag == X_REMAP &&
+      if (((FixDeform *) modify->fix[i])->remapflag == Domain::X_REMAP &&
           comm->me == 0)
         error->warning(FLERR,"Using compute temp/deform/eff with inconsistent "
                        "fix deform remap option");

--- a/src/USER-EFF/fix_nvt_sllod_eff.cpp
+++ b/src/USER-EFF/fix_nvt_sllod_eff.cpp
@@ -27,8 +27,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{NO_REMAP,X_REMAP,V_REMAP};                   // same as fix_deform.cpp
-
 /* ---------------------------------------------------------------------- */
 
 FixNVTSllodEff::FixNVTSllodEff(LAMMPS *lmp, int narg, char **arg) :
@@ -78,7 +76,7 @@ void FixNVTSllodEff::init()
   int i;
   for (i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
-      if (((FixDeform *) modify->fix[i])->remapflag != V_REMAP)
+      if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod/eff with inconsistent fix deform "
                    "remap option");
       break;

--- a/src/USER-INTEL/fix_intel.cpp
+++ b/src/USER-INTEL/fix_intel.cpp
@@ -55,8 +55,6 @@ using namespace FixConst;
 #endif
 #endif
 
-enum{NSQ,BIN,MULTI};
-
 /* ---------------------------------------------------------------------- */
 
 FixIntel::FixIntel(LAMMPS *lmp, int narg, char **arg) :  Fix(lmp, narg, arg)
@@ -353,7 +351,7 @@ void FixIntel::init()
 
 void FixIntel::setup(int vflag)
 {
-  if (neighbor->style != BIN)
+  if (neighbor->style != Neighbor::BIN)
     error->all(FLERR,
             "Currently, neighbor style BIN must be used with Intel package.");
   if (neighbor->exclude_setting() != 0)

--- a/src/USER-INTEL/fix_nvt_sllod_intel.cpp
+++ b/src/USER-INTEL/fix_nvt_sllod_intel.cpp
@@ -27,8 +27,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{NO_REMAP,X_REMAP,V_REMAP};                   // same as fix_deform.cpp
-
 /* ---------------------------------------------------------------------- */
 
 FixNVTSllodIntel::FixNVTSllodIntel(LAMMPS *lmp, int narg, char **arg) :
@@ -79,7 +77,7 @@ void FixNVTSllodIntel::init()
   int i;
   for (i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
-      if (((FixDeform *) modify->fix[i])->remapflag != V_REMAP)
+      if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod with inconsistent fix deform "
                    "remap option");
       break;

--- a/src/USER-OMP/fix_nvt_sllod_omp.cpp
+++ b/src/USER-OMP/fix_nvt_sllod_omp.cpp
@@ -31,8 +31,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{NO_REMAP,X_REMAP,V_REMAP};                   // same as fix_deform.cpp
-
 typedef struct { double x,y,z; } dbl3_t;
 
 /* ---------------------------------------------------------------------- */
@@ -85,7 +83,7 @@ void FixNVTSllodOMP::init()
   int i;
   for (i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
-      if (((FixDeform *) modify->fix[i])->remapflag != V_REMAP)
+      if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod/omp with inconsistent fix "
                    "deform remap option");
       break;

--- a/src/USER-OMP/pair_lubricate_omp.cpp
+++ b/src/USER-OMP/pair_lubricate_omp.cpp
@@ -32,10 +32,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-// same as fix_deform.cpp
-
-enum{NO_REMAP,X_REMAP,V_REMAP};
-
 // same as fix_wall.cpp
 
 enum{EDGE,CONSTANT,VARIABLE};

--- a/src/USER-OMP/pair_lubricate_poly_omp.cpp
+++ b/src/USER-OMP/pair_lubricate_poly_omp.cpp
@@ -32,11 +32,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-// same as fix_deform.cpp
-
-enum{NO_REMAP,X_REMAP,V_REMAP};
-
-
 // same as fix_wall.cpp
 
 enum{EDGE,CONSTANT,VARIABLE};

--- a/src/USER-SMD/fix_smd_wall_surface.cpp
+++ b/src/USER-SMD/fix_smd_wall_surface.cpp
@@ -40,10 +40,6 @@ using namespace Eigen;
 using namespace std;
 #define DELTA 16384
 #define EPSILON 1.0e-6
-enum {
-        LAYOUT_UNIFORM, LAYOUT_NONUNIFORM, LAYOUT_TILED
-};
-// several files
 
 /* ---------------------------------------------------------------------- */
 
@@ -151,7 +147,7 @@ void FixSMDWallSurface::setup(int vflag) {
                 subhi[2] = domain->subhi_lamda[2];
         }
 
-        if (comm->layout != LAYOUT_TILED) {
+        if (comm->layout != Comm::LAYOUT_TILED) {
                 if (domain->xperiodic) {
                         if (comm->myloc[0] == 0)
                                 sublo[0] -= epsilon[0];

--- a/src/USER-UEF/dump_cfg_uef.cpp
+++ b/src/USER-UEF/dump_cfg_uef.cpp
@@ -30,8 +30,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{INT,DOUBLE,STRING,BIGINT};   // same as in DumpCustom
-
 #define UNWRAPEXPAND 10.0
 #define ONEFIELD 32
 #define DELTA 1048576

--- a/src/USER-VTK/dump_vtk.cpp
+++ b/src/USER-VTK/dump_vtk.cpp
@@ -87,7 +87,6 @@ enum{X,Y,Z, // required for vtk, must come first
      VARIABLE,COMPUTE,FIX,INAME,DNAME,
      ATTRIBUTES}; // must come last
 enum{LT,LE,GT,GE,EQ,NEQ};
-enum{INT,DOUBLE,STRING,BIGINT};    // same as in DumpCFG
 enum{VTK,VTP,VTU,PVTP,PVTU}; // file formats
 
 #define INVOKED_PERATOM 8
@@ -1091,7 +1090,7 @@ void DumpVTK::buf2arrays(int n, double *mybuf)
       vtkAbstractArray *paa = it->second;
       if (it->second->GetNumberOfComponents() == 3) {
         switch (vtype[it->first]) {
-          case INT:
+          case Dump::INT:
             {
               int iv3[3] = { static_cast<int>(mybuf[iatom*size_one+j  ]),
                              static_cast<int>(mybuf[iatom*size_one+j+1]),
@@ -1100,7 +1099,7 @@ void DumpVTK::buf2arrays(int n, double *mybuf)
               pia->InsertNextTupleValue(iv3);
               break;
             }
-          case DOUBLE:
+          case Dump::DOUBLE:
             {
               vtkDoubleArray *pda = static_cast<vtkDoubleArray*>(paa);
               pda->InsertNextTupleValue(&mybuf[iatom*size_one+j]);
@@ -1110,19 +1109,19 @@ void DumpVTK::buf2arrays(int n, double *mybuf)
         j+=3;
       } else {
         switch (vtype[it->first]) {
-          case INT:
+          case Dump::INT:
             {
               vtkIntArray *pia = static_cast<vtkIntArray*>(paa);
               pia->InsertNextValue(mybuf[iatom*size_one+j]);
               break;
             }
-          case DOUBLE:
+          case Dump::DOUBLE:
             {
               vtkDoubleArray *pda = static_cast<vtkDoubleArray*>(paa);
               pda->InsertNextValue(mybuf[iatom*size_one+j]);
               break;
             }
-          case STRING:
+          case Dump::STRING:
             {
               vtkStringArray *psa = static_cast<vtkStringArray*>(paa);
               psa->InsertNextValue(typenames[static_cast<int>(mybuf[iatom*size_one+j])]);
@@ -1482,13 +1481,13 @@ void DumpVTK::reset_vtk_data_containers()
   ++it; ++it; ++it;
   for (; it!=vtype.end(); ++it) {
     switch(vtype[it->first]) {
-      case INT:
+      case Dump::INT:
         myarrays[it->first] = vtkSmartPointer<vtkIntArray>::New();
         break;
-      case DOUBLE:
+      case Dump::DOUBLE:
         myarrays[it->first] = vtkSmartPointer<vtkDoubleArray>::New();
         break;
-      case STRING:
+      case Dump::STRING:
         myarrays[it->first] = vtkSmartPointer<vtkStringArray>::New();
         break;
     }
@@ -1509,13 +1508,13 @@ int DumpVTK::parse_fields(int narg, char **arg)
 {
 
   pack_choice[X] = &DumpVTK::pack_x;
-  vtype[X] = DOUBLE;
+  vtype[X] = Dump::DOUBLE;
   name[X] = "x";
   pack_choice[Y] = &DumpVTK::pack_y;
-  vtype[Y] = DOUBLE;
+  vtype[Y] = Dump::DOUBLE;
   name[Y] = "y";
   pack_choice[Z] = &DumpVTK::pack_z;
-  vtype[Z] = DOUBLE;
+  vtype[Z] = Dump::DOUBLE;
   name[Z] = "z";
 
   // customize by adding to if statement
@@ -1525,33 +1524,33 @@ int DumpVTK::parse_fields(int narg, char **arg)
 
     if (strcmp(arg[iarg],"id") == 0) {
       pack_choice[ID] = &DumpVTK::pack_id;
-      vtype[ID] = INT;
+      vtype[ID] = Dump::INT;
       name[ID] = arg[iarg];
     } else if (strcmp(arg[iarg],"mol") == 0) {
       if (!atom->molecule_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[MOL] = &DumpVTK::pack_molecule;
-      vtype[MOL] = INT;
+      vtype[MOL] = Dump::INT;
       name[MOL] = arg[iarg];
     } else if (strcmp(arg[iarg],"proc") == 0) {
       pack_choice[PROC] = &DumpVTK::pack_proc;
-      vtype[PROC] = INT;
+      vtype[PROC] = Dump::INT;
       name[PROC] = arg[iarg];
     } else if (strcmp(arg[iarg],"procp1") == 0) {
       pack_choice[PROCP1] = &DumpVTK::pack_procp1;
-      vtype[PROCP1] = INT;
+      vtype[PROCP1] = Dump::INT;
       name[PROCP1] = arg[iarg];
     } else if (strcmp(arg[iarg],"type") == 0) {
       pack_choice[TYPE] = &DumpVTK::pack_type;
-      vtype[TYPE] = INT;
+      vtype[TYPE] = Dump::INT;
       name[TYPE] =arg[iarg];
     } else if (strcmp(arg[iarg],"element") == 0) {
       pack_choice[ELEMENT] = &DumpVTK::pack_type;
-      vtype[ELEMENT] = STRING;
+      vtype[ELEMENT] = Dump::STRING;
       name[ELEMENT] = arg[iarg];
     } else if (strcmp(arg[iarg],"mass") == 0) {
       pack_choice[MASS] = &DumpVTK::pack_mass;
-      vtype[MASS] = DOUBLE;
+      vtype[MASS] = Dump::DOUBLE;
       name[MASS] = arg[iarg];
 
     } else if (strcmp(arg[iarg],"x") == 0) {
@@ -1563,181 +1562,181 @@ int DumpVTK::parse_fields(int narg, char **arg)
     } else if (strcmp(arg[iarg],"xs") == 0) {
       if (domain->triclinic) pack_choice[XS] = &DumpVTK::pack_xs_triclinic;
       else pack_choice[XS] = &DumpVTK::pack_xs;
-      vtype[XS] = DOUBLE;
+      vtype[XS] = Dump::DOUBLE;
       name[XS] = arg[iarg];
     } else if (strcmp(arg[iarg],"ys") == 0) {
       if (domain->triclinic) pack_choice[YS] = &DumpVTK::pack_ys_triclinic;
       else pack_choice[YS] = &DumpVTK::pack_ys;
-      vtype[YS] = DOUBLE;
+      vtype[YS] = Dump::DOUBLE;
       name[YS] = arg[iarg];
     } else if (strcmp(arg[iarg],"zs") == 0) {
       if (domain->triclinic) pack_choice[ZS] = &DumpVTK::pack_zs_triclinic;
       else pack_choice[ZS] = &DumpVTK::pack_zs;
-      vtype[ZS] = DOUBLE;
+      vtype[ZS] = Dump::DOUBLE;
       name[ZS] = arg[iarg];
     } else if (strcmp(arg[iarg],"xu") == 0) {
       if (domain->triclinic) pack_choice[XU] = &DumpVTK::pack_xu_triclinic;
       else pack_choice[XU] = &DumpVTK::pack_xu;
-      vtype[XU] = DOUBLE;
+      vtype[XU] = Dump::DOUBLE;
       name[XU] = arg[iarg];
     } else if (strcmp(arg[iarg],"yu") == 0) {
       if (domain->triclinic) pack_choice[YU] = &DumpVTK::pack_yu_triclinic;
       else pack_choice[YU] = &DumpVTK::pack_yu;
-      vtype[YU] = DOUBLE;
+      vtype[YU] = Dump::DOUBLE;
       name[YU] = arg[iarg];
     } else if (strcmp(arg[iarg],"zu") == 0) {
       if (domain->triclinic) pack_choice[ZU] = &DumpVTK::pack_zu_triclinic;
       else pack_choice[ZU] = &DumpVTK::pack_zu;
-      vtype[ZU] = DOUBLE;
+      vtype[ZU] = Dump::DOUBLE;
       name[ZU] = arg[iarg];
     } else if (strcmp(arg[iarg],"xsu") == 0) {
       if (domain->triclinic) pack_choice[XSU] = &DumpVTK::pack_xsu_triclinic;
       else pack_choice[XSU] = &DumpVTK::pack_xsu;
-      vtype[XSU] = DOUBLE;
+      vtype[XSU] = Dump::DOUBLE;
       name[XSU] = arg[iarg];
     } else if (strcmp(arg[iarg],"ysu") == 0) {
       if (domain->triclinic) pack_choice[YSU] = &DumpVTK::pack_ysu_triclinic;
       else pack_choice[YSU] = &DumpVTK::pack_ysu;
-      vtype[YSU] = DOUBLE;
+      vtype[YSU] = Dump::DOUBLE;
       name[YSU] = arg[iarg];
     } else if (strcmp(arg[iarg],"zsu") == 0) {
       if (domain->triclinic) pack_choice[ZSU] = &DumpVTK::pack_zsu_triclinic;
       else pack_choice[ZSU] = &DumpVTK::pack_zsu;
-      vtype[ZSU] = DOUBLE;
+      vtype[ZSU] = Dump::DOUBLE;
       name[ZSU] = arg[iarg];
     } else if (strcmp(arg[iarg],"ix") == 0) {
       pack_choice[IX] = &DumpVTK::pack_ix;
-      vtype[IX] = INT;
+      vtype[IX] = Dump::INT;
       name[IX] = arg[iarg];
     } else if (strcmp(arg[iarg],"iy") == 0) {
       pack_choice[IY] = &DumpVTK::pack_iy;
-      vtype[IY] = INT;
+      vtype[IY] = Dump::INT;
       name[IY] = arg[iarg];
     } else if (strcmp(arg[iarg],"iz") == 0) {
       pack_choice[IZ] = &DumpVTK::pack_iz;
-      vtype[IZ] = INT;
+      vtype[IZ] = Dump::INT;
       name[IZ] = arg[iarg];
 
     } else if (strcmp(arg[iarg],"vx") == 0) {
       pack_choice[VX] = &DumpVTK::pack_vx;
-      vtype[VX] = DOUBLE;
+      vtype[VX] = Dump::DOUBLE;
       name[VX] = arg[iarg];
     } else if (strcmp(arg[iarg],"vy") == 0) {
       pack_choice[VY] = &DumpVTK::pack_vy;
-      vtype[VY] = DOUBLE;
+      vtype[VY] = Dump::DOUBLE;
       name[VY] = arg[iarg];
     } else if (strcmp(arg[iarg],"vz") == 0) {
       pack_choice[VZ] = &DumpVTK::pack_vz;
-      vtype[VZ] = DOUBLE;
+      vtype[VZ] = Dump::DOUBLE;
       name[VZ] = arg[iarg];
     } else if (strcmp(arg[iarg],"fx") == 0) {
       pack_choice[FX] = &DumpVTK::pack_fx;
-      vtype[FX] = DOUBLE;
+      vtype[FX] = Dump::DOUBLE;
       name[FX] = arg[iarg];
     } else if (strcmp(arg[iarg],"fy") == 0) {
       pack_choice[FY] = &DumpVTK::pack_fy;
-      vtype[FY] = DOUBLE;
+      vtype[FY] = Dump::DOUBLE;
       name[FY] = arg[iarg];
     } else if (strcmp(arg[iarg],"fz") == 0) {
       pack_choice[FZ] = &DumpVTK::pack_fz;
-      vtype[FZ] = DOUBLE;
+      vtype[FZ] = Dump::DOUBLE;
       name[FZ] = arg[iarg];
     } else if (strcmp(arg[iarg],"q") == 0) {
       if (!atom->q_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[Q] = &DumpVTK::pack_q;
-      vtype[Q] = DOUBLE;
+      vtype[Q] = Dump::DOUBLE;
       name[Q] = arg[iarg];
     } else if (strcmp(arg[iarg],"mux") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[MUX] = &DumpVTK::pack_mux;
-      vtype[MUX] = DOUBLE;
+      vtype[MUX] = Dump::DOUBLE;
       name[MUX] = arg[iarg];
     } else if (strcmp(arg[iarg],"muy") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[MUY] = &DumpVTK::pack_muy;
-      vtype[MUY] = DOUBLE;
+      vtype[MUY] = Dump::DOUBLE;
       name[MUY] = arg[iarg];
     } else if (strcmp(arg[iarg],"muz") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[MUZ] = &DumpVTK::pack_muz;
-      vtype[MUZ] = DOUBLE;
+      vtype[MUZ] = Dump::DOUBLE;
       name[MUZ] = arg[iarg];
     } else if (strcmp(arg[iarg],"mu") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[MU] = &DumpVTK::pack_mu;
-      vtype[MU] = DOUBLE;
+      vtype[MU] = Dump::DOUBLE;
       name[MU] = arg[iarg];
 
     } else if (strcmp(arg[iarg],"radius") == 0) {
       if (!atom->radius_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[RADIUS] = &DumpVTK::pack_radius;
-      vtype[RADIUS] = DOUBLE;
+      vtype[RADIUS] = Dump::DOUBLE;
       name[RADIUS] = arg[iarg];
     } else if (strcmp(arg[iarg],"diameter") == 0) {
       if (!atom->radius_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[DIAMETER] = &DumpVTK::pack_diameter;
-      vtype[DIAMETER] = DOUBLE;
+      vtype[DIAMETER] = Dump::DOUBLE;
       name[DIAMETER] = arg[iarg];
     } else if (strcmp(arg[iarg],"omegax") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[OMEGAX] = &DumpVTK::pack_omegax;
-      vtype[OMEGAX] = DOUBLE;
+      vtype[OMEGAX] = Dump::DOUBLE;
       name[OMEGAX] = arg[iarg];
     } else if (strcmp(arg[iarg],"omegay") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[OMEGAY] = &DumpVTK::pack_omegay;
-      vtype[OMEGAY] = DOUBLE;
+      vtype[OMEGAY] = Dump::DOUBLE;
       name[OMEGAY] = arg[iarg];
     } else if (strcmp(arg[iarg],"omegaz") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[OMEGAZ] = &DumpVTK::pack_omegaz;
-      vtype[OMEGAZ] = DOUBLE;
+      vtype[OMEGAZ] = Dump::DOUBLE;
       name[OMEGAZ] = arg[iarg];
     } else if (strcmp(arg[iarg],"angmomx") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[ANGMOMX] = &DumpVTK::pack_angmomx;
-      vtype[ANGMOMX] = DOUBLE;
+      vtype[ANGMOMX] = Dump::DOUBLE;
       name[ANGMOMX] = arg[iarg];
     } else if (strcmp(arg[iarg],"angmomy") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[ANGMOMY] = &DumpVTK::pack_angmomy;
-      vtype[ANGMOMY] = DOUBLE;
+      vtype[ANGMOMY] = Dump::DOUBLE;
       name[ANGMOMY] = arg[iarg];
     } else if (strcmp(arg[iarg],"angmomz") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[ANGMOMZ] = &DumpVTK::pack_angmomz;
-      vtype[ANGMOMZ] = DOUBLE;
+      vtype[ANGMOMZ] = Dump::DOUBLE;
       name[ANGMOMZ] = arg[iarg];
     } else if (strcmp(arg[iarg],"tqx") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[TQX] = &DumpVTK::pack_tqx;
-      vtype[TQX] = DOUBLE;
+      vtype[TQX] = Dump::DOUBLE;
       name[TQX] = arg[iarg];
     } else if (strcmp(arg[iarg],"tqy") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[TQY] = &DumpVTK::pack_tqy;
-      vtype[TQY] = DOUBLE;
+      vtype[TQY] = Dump::DOUBLE;
       name[TQY] = arg[iarg];
     } else if (strcmp(arg[iarg],"tqz") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[TQZ] = &DumpVTK::pack_tqz;
-      vtype[TQZ] = DOUBLE;
+      vtype[TQZ] = Dump::DOUBLE;
       name[TQZ] = arg[iarg];
 
     // compute value = c_ID
@@ -1745,7 +1744,7 @@ int DumpVTK::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"c_",2) == 0) {
       pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_compute;
-      vtype[ATTRIBUTES+i] = DOUBLE;
+      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1782,7 +1781,7 @@ int DumpVTK::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"f_",2) == 0) {
       pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_fix;
-      vtype[ATTRIBUTES+i] = DOUBLE;
+      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1816,7 +1815,7 @@ int DumpVTK::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"v_",2) == 0) {
       pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_variable;
-      vtype[ATTRIBUTES+i] = DOUBLE;
+      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1837,7 +1836,7 @@ int DumpVTK::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"d_",2) == 0) {
       pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_custom;
-      vtype[ATTRIBUTES+i] = DOUBLE;
+      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1860,7 +1859,7 @@ int DumpVTK::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"i_",2) == 0) {
       pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_custom;
-      vtype[ATTRIBUTES+i] = INT;
+      vtype[ATTRIBUTES+i] = Dump::INT;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -51,8 +51,6 @@ using namespace MathConst;
 #define DELTA_MEMSTR 1024
 #define EPSILON 1.0e-6
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 /* ---------------------------------------------------------------------- */
 
 Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
@@ -866,7 +864,7 @@ void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
     sublo[2] = domain->sublo_lamda[2]; subhi[2] = domain->subhi_lamda[2];
   }
 
-  if (comm->layout != LAYOUT_TILED) {
+  if (comm->layout != Comm::LAYOUT_TILED) {
     if (domain->xperiodic) {
       if (comm->myloc[0] == 0) sublo[0] -= epsilon[0];
       if (comm->myloc[0] == comm->procgrid[0]-1) subhi[0] += epsilon[0];

--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -48,8 +48,6 @@ using namespace LAMMPS_NS;
 enum{XYZ,SHIFT,BISECTION};
 enum{NONE,UNIFORM,USER};
 enum{X,Y,Z};
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 /* ---------------------------------------------------------------------- */
 
 Balance::Balance(LAMMPS *lmp) : Pointers(lmp)
@@ -281,7 +279,7 @@ void Balance::command(int narg, char **arg)
   // no load-balance if imbalance doesn't exceed threshold
   // unless switching from tiled to non tiled layout, then force rebalance
 
-  if (comm->layout == LAYOUT_TILED && style != BISECTION) {
+  if (comm->layout == Comm::LAYOUT_TILED && style != BISECTION) {
   } else if (imbinit < thresh) return;
 
   // debug output of initial state
@@ -296,16 +294,16 @@ void Balance::command(int narg, char **arg)
   // style XYZ = explicit setting of cutting planes of logical 3d grid
 
   if (style == XYZ) {
-    if (comm->layout == LAYOUT_UNIFORM) {
+    if (comm->layout == Comm::LAYOUT_UNIFORM) {
       if (xflag == USER || yflag == USER || zflag == USER)
-        comm->layout = LAYOUT_NONUNIFORM;
-    } else if (comm->layout == LAYOUT_NONUNIFORM) {
+        comm->layout = Comm::LAYOUT_NONUNIFORM;
+    } else if (comm->layout == Comm::LAYOUT_NONUNIFORM) {
       if (xflag == UNIFORM && yflag == UNIFORM && zflag == UNIFORM)
-        comm->layout = LAYOUT_UNIFORM;
-    } else if (comm->layout == LAYOUT_TILED) {
+        comm->layout = Comm::LAYOUT_UNIFORM;
+    } else if (comm->layout == Comm::LAYOUT_TILED) {
       if (xflag == UNIFORM && yflag == UNIFORM && zflag == UNIFORM)
-        comm->layout = LAYOUT_UNIFORM;
-      else comm->layout = LAYOUT_NONUNIFORM;
+        comm->layout = Comm::LAYOUT_UNIFORM;
+      else comm->layout = Comm::LAYOUT_NONUNIFORM;
     }
 
     if (xflag == UNIFORM) {
@@ -333,7 +331,7 @@ void Balance::command(int narg, char **arg)
   // style SHIFT = adjust cutting planes of logical 3d grid
 
   if (style == SHIFT) {
-    comm->layout = LAYOUT_NONUNIFORM;
+    comm->layout = Comm::LAYOUT_NONUNIFORM;
     shift_setup_static(bstr);
     niter = shift();
   }
@@ -341,7 +339,7 @@ void Balance::command(int narg, char **arg)
   // style BISECTION = recursive coordinate bisectioning
 
   if (style == BISECTION) {
-    comm->layout = LAYOUT_TILED;
+    comm->layout = Comm::LAYOUT_TILED;
     bisection(1);
   }
 
@@ -745,7 +743,7 @@ void Balance::shift_setup_static(char *str)
   // if current layout is TILED, set initial uniform splits in Comm
   // this gives starting point to subsequent shift balancing
 
-  if (comm->layout == LAYOUT_TILED) {
+  if (comm->layout == Comm::LAYOUT_TILED) {
     int *procgrid = comm->procgrid;
     double *xsplit = comm->xsplit;
     double *ysplit = comm->ysplit;

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -42,7 +42,6 @@ using namespace LAMMPS_NS;
 
 enum{ONELEVEL,TWOLEVEL,NUMA,CUSTOM};
 enum{CART,CARTREORDER,XYZ};
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 /* ---------------------------------------------------------------------- */
 
@@ -605,7 +604,7 @@ int Comm::coord2proc(double *x, int &igx, int &igy, int &igz)
 
   triclinic = domain->triclinic;
 
-  if (layout == LAYOUT_UNIFORM) {
+  if (layout == Comm::LAYOUT_UNIFORM) {
     if (triclinic == 0) {
       igx = static_cast<int> (procgrid[0] * (x[0]-boxlo[0]) / prd[0]);
       igy = static_cast<int> (procgrid[1] * (x[1]-boxlo[1]) / prd[1]);
@@ -616,7 +615,7 @@ int Comm::coord2proc(double *x, int &igx, int &igy, int &igz)
       igz = static_cast<int> (procgrid[2] * x[2]);
     }
 
-  } else if (layout == LAYOUT_NONUNIFORM) {
+  } else if (layout == Comm::LAYOUT_NONUNIFORM) {
     if (triclinic == 0) {
       igx = binary((x[0]-boxlo[0])/prd[0],procgrid[0],xsplit);
       igy = binary((x[1]-boxlo[1])/prd[1],procgrid[1],ysplit);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -40,8 +40,6 @@ using namespace LAMMPS_NS;
 
 #define BUFMIN 1000             // also in comm styles
 
-enum{SINGLE,MULTI};             // same as in Comm sub-styles
-enum{MULTIPLE};                   // same as in ProcMap
 enum{ONELEVEL,TWOLEVEL,NUMA,CUSTOM};
 enum{CART,CARTREORDER,XYZ};
 enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
@@ -244,14 +242,14 @@ void Comm::modify_params(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal comm_modify command");
       if (strcmp(arg[iarg+1],"single") == 0) {
         // need to reset cutghostuser when switching comm mode
-        if (mode == MULTI) cutghostuser = 0.0;
+        if (mode == Comm::MULTI) cutghostuser = 0.0;
         memory->destroy(cutusermulti);
         cutusermulti = NULL;
-        mode = SINGLE;
+        mode = Comm::SINGLE;
       } else if (strcmp(arg[iarg+1],"multi") == 0) {
         // need to reset cutghostuser when switching comm mode
-        if (mode == SINGLE) cutghostuser = 0.0;
-        mode = MULTI;
+        if (mode == Comm::SINGLE) cutghostuser = 0.0;
+        mode = Comm::MULTI;
       } else error->all(FLERR,"Illegal comm_modify command");
       iarg += 2;
     } else if (strcmp(arg[iarg],"group") == 0) {
@@ -265,7 +263,7 @@ void Comm::modify_params(int narg, char **arg)
       iarg += 2;
     } else if (strcmp(arg[iarg],"cutoff") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal comm_modify command");
-      if (mode == MULTI)
+      if (mode == Comm::MULTI)
         error->all(FLERR,
                    "Use cutoff/multi keyword to set cutoff in multi mode");
       cutghostuser = force->numeric(FLERR,arg[iarg+1]);
@@ -275,7 +273,7 @@ void Comm::modify_params(int narg, char **arg)
     } else if (strcmp(arg[iarg],"cutoff/multi") == 0) {
       int i,nlo,nhi;
       double cut;
-      if (mode == SINGLE)
+      if (mode == Comm::SINGLE)
         error->all(FLERR,"Use cutoff keyword to set cutoff in single mode");
       if (domain->box_exist == 0)
         error->all(FLERR,
@@ -415,7 +413,7 @@ void Comm::set_processors(int narg, char **arg)
       if (strcmp(arg[iarg+3],"multiple") == 0) {
         if (universe->iworld == irecv-1) {
           otherflag = 1;
-          other_style = MULTIPLE;
+          other_style = Comm::MULTIPLE;
         }
       } else error->all(FLERR,"Illegal processors command");
       iarg += 4;

--- a/src/comm.h
+++ b/src/comm.h
@@ -25,6 +25,7 @@ class Comm : protected Pointers {
                  // LAYOUT_NONUNIFORM = logical bricks, but diff sizes via LB
                  // LAYOUT_TILED = general tiling, due to RCB LB
   int mode;      // 0 = single cutoff, 1 = multi-type cutoff
+  enum{SINGLE,MULTI};
 
   int me,nprocs;                    // proc info
   int ghost_velocity;               // 1 if ghost atoms have velocity, 0 if not
@@ -132,6 +133,7 @@ class Comm : protected Pointers {
 
   int otherflag;                    // 1 if this partition dependent on another
   int other_style;                  // style of dependency
+  enum{MULTIPLE};
   int other_procgrid[3];            // proc layout of another partition
   int other_coregrid[3];            // core layout of another partition
   int ncores;                       // # of cores per node

--- a/src/comm.h
+++ b/src/comm.h
@@ -133,12 +133,13 @@ class Comm : protected Pointers {
 
   int otherflag;                    // 1 if this partition dependent on another
   int other_style;                  // style of dependency
-  enum{MULTIPLE};
   int other_procgrid[3];            // proc layout of another partition
   int other_coregrid[3];            // core layout of another partition
   int ncores;                       // # of cores per node
   int coregrid[3];                  // 3d grid of cores within a node
   int user_coregrid[3];             // user request for cores in each dim
+ public:
+  enum{MULTIPLE};
 };
 
 }

--- a/src/comm.h
+++ b/src/comm.h
@@ -24,6 +24,7 @@ class Comm : protected Pointers {
   int layout;    // LAYOUT_UNIFORM = equal-sized bricks
                  // LAYOUT_NONUNIFORM = logical bricks, but diff sizes via LB
                  // LAYOUT_TILED = general tiling, due to RCB LB
+  enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};
   int mode;      // 0 = single cutoff, 1 = multi-type cutoff
   enum{SINGLE,MULTI};
 

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -46,8 +46,6 @@ using namespace LAMMPS_NS;
 #define BUFEXTRA 1000
 #define BIG 1.0e20
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 /* ---------------------------------------------------------------------- */
 
 CommBrick::CommBrick(LAMMPS *lmp) :
@@ -60,7 +58,7 @@ CommBrick::CommBrick(LAMMPS *lmp) :
   sendlist(NULL), maxsendlist(NULL), buf_send(NULL), buf_recv(NULL)
 {
   style = 0;
-  layout = LAYOUT_UNIFORM;
+  layout = Comm::LAYOUT_UNIFORM;
   pbc_flag = NULL;
   init_buffers();
 }
@@ -92,7 +90,7 @@ CommBrick::~CommBrick()
 
 CommBrick::CommBrick(LAMMPS *lmp, Comm *oldcomm) : Comm(*oldcomm)
 {
-  if (oldcomm->layout == LAYOUT_TILED)
+  if (oldcomm->layout == Comm::LAYOUT_TILED)
     error->all(FLERR,"Cannot change to comm_style brick from tiled layout");
 
   style = 0;
@@ -239,7 +237,7 @@ void CommBrick::setup()
   int *periodicity = domain->periodicity;
   int left,right;
 
-  if (layout == LAYOUT_UNIFORM) {
+  if (layout == Comm::LAYOUT_UNIFORM) {
     maxneed[0] = static_cast<int> (cutghost[0] * procgrid[0] / prd[0]) + 1;
     maxneed[1] = static_cast<int> (cutghost[1] * procgrid[1] / prd[1]) + 1;
     maxneed[2] = static_cast<int> (cutghost[2] * procgrid[2] / prd[2]) + 1;

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -38,7 +38,6 @@ using namespace LAMMPS_NS;
 
 #define DELTA_PROCS 16
 
-enum{SINGLE,MULTI};               // same as in Comm
 enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 /* ---------------------------------------------------------------------- */
@@ -115,7 +114,7 @@ void CommTiled::init()
 
   if (triclinic)
     error->all(FLERR,"Cannot yet use comm_style tiled with triclinic box");
-  if (mode == MULTI)
+  if (mode == Comm::MULTI)
     error->all(FLERR,"Cannot yet use comm_style tiled with multi-mode comm");
 }
 

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -38,14 +38,12 @@ using namespace LAMMPS_NS;
 
 #define DELTA_PROCS 16
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 /* ---------------------------------------------------------------------- */
 
 CommTiled::CommTiled(LAMMPS *lmp) : Comm(lmp)
 {
   style = 1;
-  layout = LAYOUT_UNIFORM;
+  layout = Comm::LAYOUT_UNIFORM;
   pbc_flag = NULL;
   init_buffers();
 }
@@ -140,7 +138,7 @@ void CommTiled::setup()
 
   // set function pointers
 
-  if (layout != LAYOUT_TILED) {
+  if (layout != Comm::LAYOUT_TILED) {
     box_drop = &CommTiled::box_drop_brick;
     box_other = &CommTiled::box_other_brick;
     box_touch = &CommTiled::box_touch_brick;
@@ -154,7 +152,7 @@ void CommTiled::setup()
 
   // if RCB decomp exists and just changed, gather needed global RCB info
 
-  if (layout == LAYOUT_TILED) coord2proc_setup();
+  if (layout == Comm::LAYOUT_TILED) coord2proc_setup();
 
   // set cutoff for comm forward and comm reverse
   // check that cutoff < any periodic box length
@@ -1806,7 +1804,7 @@ void CommTiled::coord2proc_setup()
 
 int CommTiled::coord2proc(double *x, int &igx, int &igy, int &igz)
 {
-  if (layout != LAYOUT_TILED) return Comm::coord2proc(x,igx,igy,igz);
+  if (layout != Comm::LAYOUT_TILED) return Comm::coord2proc(x,igx,igy,igz);
   return point_drop_tiled_recurse(x,0,nprocs-1);
 }
 

--- a/src/compute_temp_deform.cpp
+++ b/src/compute_temp_deform.cpp
@@ -32,8 +32,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{NO_REMAP,X_REMAP,V_REMAP};                   // same as fix_deform.cpp
-
 /* ---------------------------------------------------------------------- */
 
 ComputeTempDeform::ComputeTempDeform(LAMMPS *lmp, int narg, char **arg) :
@@ -71,7 +69,7 @@ void ComputeTempDeform::init()
 
   for (i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
-      if (((FixDeform *) modify->fix[i])->remapflag == X_REMAP &&
+      if (((FixDeform *) modify->fix[i])->remapflag == Domain::X_REMAP &&
           comm->me == 0)
         error->warning(FLERR,"Using compute temp/deform with inconsistent "
                        "fix deform remap option");

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -44,7 +44,6 @@ using namespace MathConst;
 
 enum{BOX,REGION,SINGLE,RANDOM};
 enum{ATOM,MOLECULE};
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 /* ---------------------------------------------------------------------- */
 
@@ -314,7 +313,7 @@ void CreateAtoms::command(int narg, char **arg)
   }
 
   if (style == BOX || style == REGION) {
-    if (comm->layout != LAYOUT_TILED) {
+    if (comm->layout != Comm::LAYOUT_TILED) {
       if (domain->xperiodic) {
         if (comm->myloc[0] == 0) sublo[0] -= epsilon[0];
         if (comm->myloc[0] == comm->procgrid[0]-1) subhi[0] -= 2.0*epsilon[0];

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -44,8 +44,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 #define BIG   1.0e20
 #define SMALL 1.0e-4
 #define DELTAREGION 4
@@ -274,7 +272,7 @@ void Domain::set_global_box()
 
 void Domain::set_lamda_box()
 {
-  if (comm->layout != LAYOUT_TILED) {
+  if (comm->layout != Comm::LAYOUT_TILED) {
     int *myloc = comm->myloc;
     double *xsplit = comm->xsplit;
     double *ysplit = comm->ysplit;
@@ -311,7 +309,7 @@ void Domain::set_local_box()
 {
   if (triclinic) return;
 
-  if (comm->layout != LAYOUT_TILED) {
+  if (comm->layout != Comm::LAYOUT_TILED) {
     int *myloc = comm->myloc;
     int *procgrid = comm->procgrid;
     double *xsplit = comm->xsplit;

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -44,7 +44,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-enum{NO_REMAP,X_REMAP,V_REMAP};    // same as fix_deform.cpp
 enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 #define BIG   1.0e20
@@ -154,7 +153,7 @@ void Domain::init()
   for (int i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
       deform_flag = 1;
-      if (((FixDeform *) modify->fix[i])->remapflag == V_REMAP) {
+      if (((FixDeform *) modify->fix[i])->remapflag == Domain::V_REMAP) {
         deform_vremap = 1;
         deform_groupbit = modify->fix[i]->groupbit;
       }

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -45,7 +45,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 enum{NO_REMAP,X_REMAP,V_REMAP};    // same as fix_deform.cpp
-enum{IGNORE,WARN,ERROR};           // same as thermo.cpp
 enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 #define BIG   1.0e20
@@ -762,7 +761,7 @@ void Domain::image_check()
 
       if (k == -1) {
         nmissing++;
-        if (lostbond == ERROR)
+        if (lostbond == Thermo::ERROR)
           error->one(FLERR,"Bond atom missing in image check");
         continue;
       }
@@ -785,7 +784,7 @@ void Domain::image_check()
   if (flagall && comm->me == 0)
     error->warning(FLERR,"Inconsistent image flags");
 
-  if (lostbond == WARN) {
+  if (lostbond == Thermo::WARN) {
     int all;
     MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
     if (all && comm->me == 0)
@@ -861,7 +860,7 @@ void Domain::box_too_small_check()
 
       if (k == -1) {
         nmissing++;
-        if (lostbond == ERROR)
+        if (lostbond == Thermo::ERROR)
           error->one(FLERR,"Bond atom missing in box size check");
         continue;
       }
@@ -875,7 +874,7 @@ void Domain::box_too_small_check()
     }
   }
 
-  if (lostbond == WARN) {
+  if (lostbond == Thermo::WARN) {
     int all;
     MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
     if (all && comm->me == 0)

--- a/src/domain.h
+++ b/src/domain.h
@@ -93,6 +93,7 @@ class Domain : protected Pointers {
   class Region **regions;                  // list of defined Regions
 
   int copymode;
+  enum{NO_REMAP,X_REMAP,V_REMAP};
 
   typedef Region *(*RegionCreator)(LAMMPS *,int,char**);
   typedef std::map<std::string,RegionCreator> RegionCreatorMap;

--- a/src/dump.h
+++ b/src/dump.h
@@ -94,6 +94,7 @@ class Dump : protected Pointers {
   char *format_int_user;
   char *format_bigint_user;
   char **format_column_user;
+  enum{INT,DOUBLE,STRING,BIGINT};
 
   FILE *fp;                  // file to write dump to
   int size_one;              // # of quantities for one atom

--- a/src/dump_cfg.cpp
+++ b/src/dump_cfg.cpp
@@ -33,8 +33,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{INT,DOUBLE,STRING,BIGINT};   // same as in DumpCustom
-
 #define UNWRAPEXPAND 10.0
 #define ONEFIELD 32
 #define DELTA 1048576
@@ -181,15 +179,15 @@ int DumpCFG::convert_string(int n, double *mybuf)
         } else if (j == 1) {
           offset += sprintf(&sbuf[offset],"%s \n",typenames[(int) mybuf[m]]);
         } else if (j >= 2) {
-          if (vtype[j] == INT)
+          if (vtype[j] == Dump::INT)
             offset +=
               sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
-          else if (vtype[j] == DOUBLE)
+          else if (vtype[j] == Dump::DOUBLE)
             offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
-          else if (vtype[j] == STRING)
+          else if (vtype[j] == Dump::STRING)
             offset +=
               sprintf(&sbuf[offset],vformat[j],typenames[(int) mybuf[m]]);
-          else if (vtype[j] == BIGINT)
+          else if (vtype[j] == Dump::BIGINT)
             offset +=
               sprintf(&sbuf[offset],vformat[j],static_cast<bigint> (mybuf[m]));
         }
@@ -216,15 +214,15 @@ int DumpCFG::convert_string(int n, double *mybuf)
           unwrap_coord = (mybuf[m] - 0.5)/UNWRAPEXPAND + 0.5;
           offset += sprintf(&sbuf[offset],vformat[j],unwrap_coord);
         } else if (j >= 5 ) {
-          if (vtype[j] == INT)
+          if (vtype[j] == Dump::INT)
             offset +=
               sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
-          else if (vtype[j] == DOUBLE)
+          else if (vtype[j] == Dump::DOUBLE)
             offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
-          else if (vtype[j] == STRING)
+          else if (vtype[j] == Dump::STRING)
             offset +=
               sprintf(&sbuf[offset],vformat[j],typenames[(int) mybuf[m]]);
-          else if (vtype[j] == BIGINT)
+          else if (vtype[j] == Dump::BIGINT)
             offset +=
               sprintf(&sbuf[offset],vformat[j],static_cast<bigint> (mybuf[m]));
         }
@@ -266,13 +264,13 @@ void DumpCFG::write_lines(int n, double *mybuf)
         } else if (j == 1) {
           fprintf(fp,"%s \n",typenames[(int) mybuf[m]]);
         } else if (j >= 2) {
-          if (vtype[j] == INT)
+          if (vtype[j] == Dump::INT)
             fprintf(fp,vformat[j],static_cast<int> (mybuf[m]));
-          else if (vtype[j] == DOUBLE)
+          else if (vtype[j] == Dump::DOUBLE)
             fprintf(fp,vformat[j],mybuf[m]);
-          else if (vtype[j] == STRING)
+          else if (vtype[j] == Dump::STRING)
             fprintf(fp,vformat[j],typenames[(int) mybuf[m]]);
-          else if (vtype[j] == BIGINT)
+          else if (vtype[j] == Dump::BIGINT)
             fprintf(fp,vformat[j],static_cast<bigint> (mybuf[m]));
         }
         m++;
@@ -292,13 +290,13 @@ void DumpCFG::write_lines(int n, double *mybuf)
           unwrap_coord = (mybuf[m] - 0.5)/UNWRAPEXPAND + 0.5;
           fprintf(fp,vformat[j],unwrap_coord);
         } else if (j >= 5 ) {
-          if (vtype[j] == INT)
+          if (vtype[j] == Dump::INT)
             fprintf(fp,vformat[j],static_cast<int> (mybuf[m]));
-          else if (vtype[j] == DOUBLE)
+          else if (vtype[j] == Dump::DOUBLE)
             fprintf(fp,vformat[j],mybuf[m]);
-          else if (vtype[j] == STRING)
+          else if (vtype[j] == Dump::STRING)
             fprintf(fp,vformat[j],typenames[(int) mybuf[m]]);
-          else if (vtype[j] == BIGINT)
+          else if (vtype[j] == Dump::BIGINT)
             fprintf(fp,vformat[j],static_cast<bigint> (mybuf[m]));
         }
         m++;

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -45,7 +45,6 @@ enum{ID,MOL,PROC,PROCP1,TYPE,ELEMENT,MASS,
      TQX,TQY,TQZ,
      COMPUTE,FIX,VARIABLE,INAME,DNAME};
 enum{LT,LE,GT,GE,EQ,NEQ,XOR};
-enum{INT,DOUBLE,STRING,BIGINT};    // same as in DumpCFG
 
 #define INVOKED_PERATOM 8
 #define ONEFIELD 32
@@ -165,10 +164,10 @@ DumpCustom::DumpCustom(LAMMPS *lmp, int narg, char **arg) :
   format_default[0] = '\0';
 
   for (int i = 0; i < size_one; i++) {
-    if (vtype[i] == INT) strcat(format_default,"%d ");
-    else if (vtype[i] == DOUBLE) strcat(format_default,"%g ");
-    else if (vtype[i] == STRING) strcat(format_default,"%s ");
-    else if (vtype[i] == BIGINT) strcat(format_default,BIGINT_FORMAT " ");
+    if (vtype[i] == Dump::INT) strcat(format_default,"%d ");
+    else if (vtype[i] == Dump::DOUBLE) strcat(format_default,"%g ");
+    else if (vtype[i] == Dump::STRING) strcat(format_default,"%s ");
+    else if (vtype[i] == Dump::BIGINT) strcat(format_default,BIGINT_FORMAT " ");
     vformat[i] = NULL;
   }
 
@@ -288,13 +287,13 @@ void DumpCustom::init_style()
     if (format_column_user[i]) {
       vformat[i] = new char[strlen(format_column_user[i]) + 2];
       strcpy(vformat[i],format_column_user[i]);
-    } else if (vtype[i] == INT && format_int_user) {
+    } else if (vtype[i] == Dump::INT && format_int_user) {
       vformat[i] = new char[strlen(format_int_user) + 2];
       strcpy(vformat[i],format_int_user);
-    } else if (vtype[i] == DOUBLE && format_float_user) {
+    } else if (vtype[i] == Dump::DOUBLE && format_float_user) {
       vformat[i] = new char[strlen(format_float_user) + 2];
       strcpy(vformat[i],format_float_user);
-    } else if (vtype[i] == BIGINT && format_bigint_user) {
+    } else if (vtype[i] == Dump::BIGINT && format_bigint_user) {
       vformat[i] = new char[strlen(format_bigint_user) + 2];
       strcpy(vformat[i],format_bigint_user);
     } else {
@@ -1088,13 +1087,13 @@ int DumpCustom::convert_string(int n, double *mybuf)
     }
 
     for (j = 0; j < size_one; j++) {
-      if (vtype[j] == INT)
+      if (vtype[j] == Dump::INT)
         offset += sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
-      else if (vtype[j] == DOUBLE)
+      else if (vtype[j] == Dump::DOUBLE)
         offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
-      else if (vtype[j] == STRING)
+      else if (vtype[j] == Dump::STRING)
         offset += sprintf(&sbuf[offset],vformat[j],typenames[(int) mybuf[m]]);
-      else if (vtype[j] == BIGINT)
+      else if (vtype[j] == Dump::BIGINT)
         offset += sprintf(&sbuf[offset],vformat[j],
                           static_cast<bigint> (mybuf[m]));
       m++;
@@ -1137,11 +1136,11 @@ void DumpCustom::write_lines(int n, double *mybuf)
   int m = 0;
   for (i = 0; i < n; i++) {
     for (j = 0; j < size_one; j++) {
-      if (vtype[j] == INT) fprintf(fp,vformat[j],static_cast<int> (mybuf[m]));
-      else if (vtype[j] == DOUBLE) fprintf(fp,vformat[j],mybuf[m]);
-      else if (vtype[j] == STRING)
+      if (vtype[j] == Dump::INT) fprintf(fp,vformat[j],static_cast<int> (mybuf[m]));
+      else if (vtype[j] == Dump::DOUBLE) fprintf(fp,vformat[j],mybuf[m]);
+      else if (vtype[j] == Dump::STRING)
         fprintf(fp,vformat[j],typenames[(int) mybuf[m]]);
-      else if (vtype[j] == BIGINT)
+      else if (vtype[j] == Dump::BIGINT)
         fprintf(fp,vformat[j],static_cast<bigint> (mybuf[m]));
       m++;
     }
@@ -1161,192 +1160,192 @@ int DumpCustom::parse_fields(int narg, char **arg)
 
     if (strcmp(arg[iarg],"id") == 0) {
       pack_choice[i] = &DumpCustom::pack_id;
-      if (sizeof(tagint) == sizeof(smallint)) vtype[i] = INT;
-      else vtype[i] = BIGINT;
+      if (sizeof(tagint) == sizeof(smallint)) vtype[i] = Dump::INT;
+      else vtype[i] = Dump::BIGINT;
     } else if (strcmp(arg[iarg],"mol") == 0) {
       if (!atom->molecule_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_molecule;
-      if (sizeof(tagint) == sizeof(smallint)) vtype[i] = INT;
-      else vtype[i] = BIGINT;
+      if (sizeof(tagint) == sizeof(smallint)) vtype[i] = Dump::INT;
+      else vtype[i] = Dump::BIGINT;
     } else if (strcmp(arg[iarg],"proc") == 0) {
       pack_choice[i] = &DumpCustom::pack_proc;
-      vtype[i] = INT;
+      vtype[i] = Dump::INT;
     } else if (strcmp(arg[iarg],"procp1") == 0) {
       pack_choice[i] = &DumpCustom::pack_procp1;
-      vtype[i] = INT;
+      vtype[i] = Dump::INT;
     } else if (strcmp(arg[iarg],"type") == 0) {
       pack_choice[i] = &DumpCustom::pack_type;
-      vtype[i] = INT;
+      vtype[i] = Dump::INT;
     } else if (strcmp(arg[iarg],"element") == 0) {
       pack_choice[i] = &DumpCustom::pack_type;
-      vtype[i] = STRING;
+      vtype[i] = Dump::STRING;
     } else if (strcmp(arg[iarg],"mass") == 0) {
       pack_choice[i] = &DumpCustom::pack_mass;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
     } else if (strcmp(arg[iarg],"x") == 0) {
       pack_choice[i] = &DumpCustom::pack_x;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"y") == 0) {
       pack_choice[i] = &DumpCustom::pack_y;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"z") == 0) {
       pack_choice[i] = &DumpCustom::pack_z;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"xs") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_xs_triclinic;
       else pack_choice[i] = &DumpCustom::pack_xs;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"ys") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_ys_triclinic;
       else pack_choice[i] = &DumpCustom::pack_ys;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"zs") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_zs_triclinic;
       else pack_choice[i] = &DumpCustom::pack_zs;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"xu") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_xu_triclinic;
       else pack_choice[i] = &DumpCustom::pack_xu;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"yu") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_yu_triclinic;
       else pack_choice[i] = &DumpCustom::pack_yu;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"zu") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_zu_triclinic;
       else pack_choice[i] = &DumpCustom::pack_zu;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"xsu") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_xsu_triclinic;
       else pack_choice[i] = &DumpCustom::pack_xsu;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"ysu") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_ysu_triclinic;
       else pack_choice[i] = &DumpCustom::pack_ysu;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"zsu") == 0) {
       if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_zsu_triclinic;
       else pack_choice[i] = &DumpCustom::pack_zsu;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"ix") == 0) {
       pack_choice[i] = &DumpCustom::pack_ix;
-      vtype[i] = INT;
+      vtype[i] = Dump::INT;
     } else if (strcmp(arg[iarg],"iy") == 0) {
       pack_choice[i] = &DumpCustom::pack_iy;
-      vtype[i] = INT;
+      vtype[i] = Dump::INT;
     } else if (strcmp(arg[iarg],"iz") == 0) {
       pack_choice[i] = &DumpCustom::pack_iz;
-      vtype[i] = INT;
+      vtype[i] = Dump::INT;
 
     } else if (strcmp(arg[iarg],"vx") == 0) {
       pack_choice[i] = &DumpCustom::pack_vx;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"vy") == 0) {
       pack_choice[i] = &DumpCustom::pack_vy;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"vz") == 0) {
       pack_choice[i] = &DumpCustom::pack_vz;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"fx") == 0) {
       pack_choice[i] = &DumpCustom::pack_fx;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"fy") == 0) {
       pack_choice[i] = &DumpCustom::pack_fy;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"fz") == 0) {
       pack_choice[i] = &DumpCustom::pack_fz;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
     } else if (strcmp(arg[iarg],"q") == 0) {
       if (!atom->q_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_q;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"mux") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_mux;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"muy") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_muy;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"muz") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_muz;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"mu") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_mu;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
     } else if (strcmp(arg[iarg],"radius") == 0) {
       if (!atom->radius_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_radius;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"diameter") == 0) {
       if (!atom->radius_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_diameter;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"omegax") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_omegax;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"omegay") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_omegay;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"omegaz") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_omegaz;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"angmomx") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_angmomx;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"angmomy") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_angmomy;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"angmomz") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_angmomz;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"tqx") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_tqx;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"tqy") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_tqy;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"tqz") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
       pack_choice[i] = &DumpCustom::pack_tqz;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
     // compute value = c_ID
     // if no trailing [], then arg is set to 0, else arg is int between []
 
     } else if (strncmp(arg[iarg],"c_",2) == 0) {
       pack_choice[i] = &DumpCustom::pack_compute;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1382,7 +1381,7 @@ int DumpCustom::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"f_",2) == 0) {
       pack_choice[i] = &DumpCustom::pack_fix;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1415,7 +1414,7 @@ int DumpCustom::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"v_",2) == 0) {
       pack_choice[i] = &DumpCustom::pack_variable;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1435,7 +1434,7 @@ int DumpCustom::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"d_",2) == 0) {
       pack_choice[i] = &DumpCustom::pack_custom;
-      vtype[i] = DOUBLE;
+      vtype[i] = Dump::DOUBLE;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];
@@ -1457,7 +1456,7 @@ int DumpCustom::parse_fields(int narg, char **arg)
 
     } else if (strncmp(arg[iarg],"i_",2) == 0) {
       pack_choice[i] = &DumpCustom::pack_custom;
-      vtype[i] = INT;
+      vtype[i] = Dump::INT;
 
       int n = strlen(arg[iarg]);
       char *suffix = new char[n];

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -33,7 +33,6 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 
 enum{SHIFT,BISECTION};
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
 
 /* ---------------------------------------------------------------------- */
 
@@ -264,10 +263,10 @@ void FixBalance::rebalance()
   int *sendproc;
   if (lbstyle == SHIFT) {
     itercount = balance->shift();
-    comm->layout = LAYOUT_NONUNIFORM;
+    comm->layout = Comm::LAYOUT_NONUNIFORM;
   } else if (lbstyle == BISECTION) {
     sendproc = balance->bisection();
-    comm->layout = LAYOUT_TILED;
+    comm->layout = Comm::LAYOUT_TILED;
   }
 
   // output of new decomposition

--- a/src/fix_deform.cpp
+++ b/src/fix_deform.cpp
@@ -40,10 +40,6 @@ using namespace MathConst;
 enum{NONE=0,FINAL,DELTA,SCALE,VEL,ERATE,TRATE,VOLUME,WIGGLE,VARIABLE};
 enum{ONE_FROM_ONE,ONE_FROM_TWO,TWO_FROM_ONE};
 
-// same as domain.cpp, fix_nvt_sllod.cpp, compute_temp_deform.cpp
-
-enum{NO_REMAP,X_REMAP,V_REMAP};
-
 /* ---------------------------------------------------------------------- */
 
 FixDeform::FixDeform(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg),
@@ -208,7 +204,7 @@ rfix(NULL), irregular(NULL), set(NULL)
   // no x remap effectively moves atoms within box, so set restart_pbc
 
   options(narg-iarg,&arg[iarg]);
-  if (remapflag != X_REMAP) restart_pbc = 1;
+  if (remapflag != Domain::X_REMAP) restart_pbc = 1;
 
   // setup dimflags used by other classes to check for volume-change conflicts
 
@@ -890,7 +886,7 @@ void FixDeform::end_of_step()
 
   // convert atoms and rigid bodies to lamda coords
 
-  if (remapflag == X_REMAP) {
+  if (remapflag == Domain::X_REMAP) {
     double **x = atom->x;
     int *mask = atom->mask;
     int nlocal = atom->nlocal;
@@ -930,7 +926,7 @@ void FixDeform::end_of_step()
 
   // convert atoms and rigid bodies back to box coords
 
-  if (remapflag == X_REMAP) {
+  if (remapflag == Domain::X_REMAP) {
     double **x = atom->x;
     int *mask = atom->mask;
     int nlocal = atom->nlocal;
@@ -992,7 +988,7 @@ void FixDeform::options(int narg, char **arg)
 {
   if (narg < 0) error->all(FLERR,"Illegal fix deform command");
 
-  remapflag = X_REMAP;
+  remapflag = Domain::X_REMAP;
   scaleflag = 1;
   flipflag = 1;
 
@@ -1000,9 +996,9 @@ void FixDeform::options(int narg, char **arg)
   while (iarg < narg) {
     if (strcmp(arg[iarg],"remap") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix deform command");
-      if (strcmp(arg[iarg+1],"x") == 0) remapflag = X_REMAP;
-      else if (strcmp(arg[iarg+1],"v") == 0) remapflag = V_REMAP;
-      else if (strcmp(arg[iarg+1],"none") == 0) remapflag = NO_REMAP;
+      if (strcmp(arg[iarg+1],"x") == 0) remapflag = Domain::X_REMAP;
+      else if (strcmp(arg[iarg+1],"v") == 0) remapflag = Domain::V_REMAP;
+      else if (strcmp(arg[iarg+1],"none") == 0) remapflag = Domain::NO_REMAP;
       else error->all(FLERR,"Illegal fix deform command");
       iarg += 2;
     } else if (strcmp(arg[iarg],"units") == 0) {

--- a/src/fix_nvt_sllod.cpp
+++ b/src/fix_nvt_sllod.cpp
@@ -31,8 +31,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{NO_REMAP,X_REMAP,V_REMAP};                   // same as fix_deform.cpp
-
 /* ---------------------------------------------------------------------- */
 
 FixNVTSllod::FixNVTSllod(LAMMPS *lmp, int narg, char **arg) :
@@ -83,7 +81,7 @@ void FixNVTSllod::init()
   int i;
   for (i = 0; i < modify->nfix; i++)
     if (strcmp(modify->fix[i]->style,"deform") == 0) {
-      if (((FixDeform *) modify->fix[i])->remapflag != V_REMAP)
+      if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod with inconsistent fix deform "
                    "remap option");
       break;

--- a/src/irregular.cpp
+++ b/src/irregular.cpp
@@ -34,8 +34,6 @@ static int compare_standalone(const void *, const void *);
 static int compare_standalone(const int, const int, void *);
 #endif
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 #define BUFFACTOR 1.5
 #define BUFMIN 1000
 #define BUFEXTRA 1000
@@ -222,7 +220,7 @@ int Irregular::migrate_check()
   // migrate required if comm layout is tiled
   // cannot use myloc[] logic below
 
-  if (comm->layout == LAYOUT_TILED) return 1;
+  if (comm->layout == Comm::LAYOUT_TILED) return 1;
 
   // subbox bounds for orthogonal or triclinic box
 

--- a/src/nbin_standard.cpp
+++ b/src/nbin_standard.cpp
@@ -22,8 +22,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{NSQ,BIN,MULTI};       // also in Neighbor
-
 #define SMALL 1.0e-6
 #define CUT2BIN_RATIO 100
 
@@ -94,7 +92,7 @@ void NBinStandard::setup_bins(int style)
 
   double binsize_optimal;
   if (binsizeflag) binsize_optimal = binsize_user;
-  else if (style == BIN) binsize_optimal = 0.5*cutneighmax;
+  else if (style == Neighbor::BIN) binsize_optimal = 0.5*cutneighmax;
   else binsize_optimal = 0.5*cutneighmin;
   if (binsize_optimal == 0.0) binsize_optimal = bbox[0];
   double binsizeinv = 1.0/binsize_optimal;

--- a/src/neigh_list.cpp
+++ b/src/neigh_list.cpp
@@ -26,8 +26,6 @@ using namespace LAMMPS_NS;
 
 #define PGDELTA 1
 
-enum{NSQ,BIN,MULTI};     // also in Neighbor
-
 /* ---------------------------------------------------------------------- */
 
 NeighList::NeighList(LAMMPS *lmp) : Pointers(lmp)

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -57,7 +57,6 @@ using namespace NeighConst;
 
 #define BIG 1.0e20
 
-enum{NSQ,BIN,MULTI};     // also in NBin, NeighList, NStencil
 enum{NONE,ALL,PARTIAL,TEMPLATE};
 
 static const char cite_neigh_multi[] =
@@ -85,7 +84,7 @@ pairclass(NULL), pairnames(NULL), pairmasks(NULL)
 
   firsttime = 1;
 
-  style = BIN;
+  style = Neighbor::BIN;
   every = 1;
   delay = 10;
   dist_check = 1;
@@ -651,7 +650,7 @@ int Neighbor::init_pair()
   //     at time of binning when neighbor lists are rebuilt,
   //     similar to what vanilla Nbin::coord2atom() does now in atom2bin
 
-  if (style == BIN) {
+  if (style == Neighbor::BIN) {
     for (i = 0; i < nrequest; i++)
       if (requests[i]->occasional && requests[i]->ghost)
         error->all(FLERR,"Cannot request an occasional binned neighbor list "
@@ -1420,7 +1419,7 @@ void Neighbor::print_pairwise_info()
   bbox[1] =  bboxhi[1]-bboxlo[1];
   bbox[2] =  bboxhi[2]-bboxlo[2];
   if (binsizeflag) binsize = binsize_user;
-  else if (style == BIN) binsize = 0.5*cutneighmax;
+  else if (style == Neighbor::BIN) binsize = 0.5*cutneighmax;
   else binsize = 0.5*cutneighmin;
   if (binsize == 0.0) binsize = bbox[0];
 
@@ -1445,7 +1444,7 @@ void Neighbor::print_pairwise_info()
               oneatom, pgsize);
       fprintf(out,"  master list distance cutoff = %g\n",cutneighmax);
       fprintf(out,"  ghost atom cutoff = %g\n",cutghost);
-      if (style != NSQ)
+      if (style != Neighbor::NSQ)
         fprintf(out,"  binsize = %g, bins = %g %g %g\n",binsize,
                 ceil(bbox[0]/binsize), ceil(bbox[1]/binsize),
                 ceil(bbox[2]/binsize));
@@ -1595,7 +1594,7 @@ int Neighbor::choose_bin(NeighRequest *rq)
 {
   // no binning needed
 
-  if (style == NSQ) return 0;
+  if (style == Neighbor::NSQ) return 0;
   if (rq->skip || rq->copy || rq->halffull) return 0;
 
   // use request settings to match exactly one NBin class mask
@@ -1635,7 +1634,7 @@ int Neighbor::choose_stencil(NeighRequest *rq)
 {
   // no stencil creation needed
 
-  if (style == NSQ) return 0;
+  if (style == Neighbor::NSQ) return 0;
   if (rq->skip || rq->copy || rq->halffull) return 0;
 
   // convert newton request to newtflag = on or off
@@ -1686,9 +1685,9 @@ int Neighbor::choose_stencil(NeighRequest *rq)
 
     // neighbor style is BIN or MULTI and must match
 
-    if (style == BIN) {
+    if (style == Neighbor::BIN) {
       if (!(mask & NS_BIN)) continue;
-    } else if (style == MULTI) {
+    } else if (style == Neighbor::MULTI) {
       if (!(mask & NS_MULTI)) continue;
     }
 
@@ -1817,11 +1816,11 @@ int Neighbor::choose_pair(NeighRequest *rq)
 
     // neighbor style is one of NSQ,BIN,MULTI and must match
 
-    if (style == NSQ) {
+    if (style == Neighbor::NSQ) {
       if (!(mask & NP_NSQ)) continue;
-    } else if (style == BIN) {
+    } else if (style == Neighbor::BIN) {
       if (!(mask & NP_BIN)) continue;
-    } else if (style == MULTI) {
+    } else if (style == Neighbor::MULTI) {
       if (!(mask & NP_MULTI)) continue;
     }
 
@@ -2063,7 +2062,7 @@ void Neighbor::build(int topoflag)
   // if bin then, atoms may have moved outside of proc domain & bin extent,
   //   leading to errors or even a crash
 
-  if (style != NSQ) {
+  if (style != Neighbor::NSQ) {
     for (int i = 0; i < nbin; i++) {
       neigh_bin[i]->bin_atoms_setup(nall);
       neigh_bin[i]->bin_atoms();
@@ -2180,12 +2179,12 @@ void Neighbor::set(int narg, char **arg)
   skin = force->numeric(FLERR,arg[0]);
   if (skin < 0.0) error->all(FLERR,"Illegal neighbor command");
 
-  if (strcmp(arg[1],"nsq") == 0) style = NSQ;
-  else if (strcmp(arg[1],"bin") == 0) style = BIN;
-  else if (strcmp(arg[1],"multi") == 0) style = MULTI;
+  if (strcmp(arg[1],"nsq") == 0) style = Neighbor::NSQ;
+  else if (strcmp(arg[1],"bin") == 0) style = Neighbor::BIN;
+  else if (strcmp(arg[1],"multi") == 0) style = Neighbor::MULTI;
   else error->all(FLERR,"Illegal neighbor command");
 
-  if (style == MULTI && lmp->citeme) lmp->citeme->add(cite_neigh_multi);
+  if (style == Neighbor::MULTI && lmp->citeme) lmp->citeme->add(cite_neigh_multi);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/neighbor.h
+++ b/src/neighbor.h
@@ -21,6 +21,7 @@ namespace LAMMPS_NS {
 
 class Neighbor : protected Pointers {
  public:
+  enum{NSQ,BIN,MULTI};
   int style;                       // 0,1,2 = nsq, bin, multi
   int every;                       // build every this many steps
   int delay;                       // delay build for this many steps

--- a/src/nstencil.cpp
+++ b/src/nstencil.cpp
@@ -22,8 +22,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{NSQ,BIN,MULTI};     // also in Neighbor
-
 /* ----------------------------------------------------------------------
    NStencil classes
    each has method to create a stencil = list of bin offsets
@@ -161,7 +159,7 @@ void NStencil::create_setup()
   // reallocate stencil structs if necessary
   // for BIN and MULTI styles
 
-  if (neighstyle == BIN) {
+  if (neighstyle == Neighbor::BIN) {
     if (smax > maxstencil) {
       maxstencil = smax;
       memory->destroy(stencil);
@@ -227,10 +225,10 @@ double NStencil::bin_distance(int i, int j, int k)
 bigint NStencil::memory_usage()
 {
   bigint bytes = 0;
-  if (neighstyle == BIN) {
+  if (neighstyle == Neighbor::BIN) {
     bytes += memory->usage(stencil,maxstencil);
     bytes += memory->usage(stencilxyz,maxstencil,3);
-  } else if (neighstyle == MULTI) {
+  } else if (neighstyle == Neighbor::MULTI) {
     bytes += atom->ntypes*maxstencil_multi * sizeof(int);
     bytes += atom->ntypes*maxstencil_multi * sizeof(double);
   }

--- a/src/ntopo.h
+++ b/src/ntopo.h
@@ -31,8 +31,6 @@ class NTopo : protected Pointers {
   bigint memory_usage();
 
  protected:
-  enum{IGNORE,WARN,ERROR};       // same as thermo.cpp
-
   int me,nprocs;
   int maxbond,maxangle,maxdihedral,maximproper;
   int cluster_check;             // copy from Neighbor

--- a/src/ntopo_angle_all.cpp
+++ b/src/ntopo_angle_all.cpp
@@ -58,7 +58,7 @@ void NTopoAngleAll::build()
       atom3 = atom->map(angle_atom3[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Angle atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT
@@ -86,7 +86,7 @@ void NTopoAngleAll::build()
     }
 
   if (cluster_check) angle_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_angle_partial.cpp
+++ b/src/ntopo_angle_partial.cpp
@@ -59,7 +59,7 @@ void NTopoAnglePartial::build()
       atom3 = atom->map(angle_atom3[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Angle atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT
@@ -87,7 +87,7 @@ void NTopoAnglePartial::build()
     }
 
   if (cluster_check) angle_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_angle_template.cpp
+++ b/src/ntopo_angle_template.cpp
@@ -76,7 +76,7 @@ void NTopoAngleTemplate::build()
       atom3 = atom->map(angle_atom3[iatom][m]+tagprev);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Angle atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT
@@ -106,7 +106,7 @@ void NTopoAngleTemplate::build()
   }
 
   if (cluster_check) angle_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_bond_all.cpp
+++ b/src/ntopo_bond_all.cpp
@@ -55,7 +55,7 @@ void NTopoBondAll::build()
       atom1 = atom->map(bond_atom[i][m]);
       if (atom1 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Bond atoms " TAGINT_FORMAT " " TAGINT_FORMAT
                   " missing on proc %d at step " BIGINT_FORMAT,
@@ -78,7 +78,7 @@ void NTopoBondAll::build()
     }
 
   if (cluster_check) bond_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_bond_partial.cpp
+++ b/src/ntopo_bond_partial.cpp
@@ -56,7 +56,7 @@ void NTopoBondPartial::build()
       atom1 = atom->map(bond_atom[i][m]);
       if (atom1 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Bond atoms " TAGINT_FORMAT " " TAGINT_FORMAT
                   " missing on proc %d at step " BIGINT_FORMAT,
@@ -79,7 +79,7 @@ void NTopoBondPartial::build()
     }
 
   if (cluster_check) bond_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_bond_template.cpp
+++ b/src/ntopo_bond_template.cpp
@@ -72,7 +72,7 @@ void NTopoBondTemplate::build()
       atom1 = atom->map(bond_atom[iatom][m]+tagprev);
       if (atom1 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Bond atoms " TAGINT_FORMAT " " TAGINT_FORMAT
                   " missing on proc %d at step " BIGINT_FORMAT,
@@ -96,7 +96,7 @@ void NTopoBondTemplate::build()
   }
 
   if (cluster_check) bond_check();
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_dihedral_all.cpp
+++ b/src/ntopo_dihedral_all.cpp
@@ -60,7 +60,7 @@ void NTopoDihedralAll::build()
       atom4 = atom->map(dihedral_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Dihedral atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " "
@@ -93,7 +93,7 @@ void NTopoDihedralAll::build()
     }
 
   if (cluster_check) dihedral_check(ndihedrallist,dihedrallist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_dihedral_partial.cpp
+++ b/src/ntopo_dihedral_partial.cpp
@@ -62,7 +62,7 @@ void NTopoDihedralPartial::build()
       atom4 = atom->map(dihedral_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Dihedral atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " "
@@ -95,7 +95,7 @@ void NTopoDihedralPartial::build()
     }
 
   if (cluster_check) dihedral_check(ndihedrallist,dihedrallist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_dihedral_template.cpp
+++ b/src/ntopo_dihedral_template.cpp
@@ -78,7 +78,7 @@ void NTopoDihedralTemplate::build()
       atom4 = atom->map(dihedral_atom4[iatom][m]+tagprev);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Dihedral atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " "
@@ -114,7 +114,7 @@ void NTopoDihedralTemplate::build()
   }
 
   if (cluster_check) dihedral_check(ndihedrallist,dihedrallist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_improper_all.cpp
+++ b/src/ntopo_improper_all.cpp
@@ -60,7 +60,7 @@ void NTopoImproperAll::build()
       atom4 = atom->map(improper_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Improper atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " "
@@ -93,7 +93,7 @@ void NTopoImproperAll::build()
     }
 
   if (cluster_check) dihedral_check(nimproperlist,improperlist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_improper_partial.cpp
+++ b/src/ntopo_improper_partial.cpp
@@ -62,7 +62,7 @@ void NTopoImproperPartial::build()
       atom4 = atom->map(improper_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Improper atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " "
@@ -95,7 +95,7 @@ void NTopoImproperPartial::build()
     }
 
   if (cluster_check) dihedral_check(nimproperlist,improperlist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/ntopo_improper_template.cpp
+++ b/src/ntopo_improper_template.cpp
@@ -78,7 +78,7 @@ void NTopoImproperTemplate::build()
       atom4 = atom->map(improper_atom4[iatom][m]+tagprev);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == ERROR) {
+        if (lostbond == Thermo::ERROR) {
           char str[128];
           sprintf(str,"Improper atoms "
                   TAGINT_FORMAT " " TAGINT_FORMAT " "
@@ -114,7 +114,7 @@ void NTopoImproperTemplate::build()
   }
 
   if (cluster_check) dihedral_check(nimproperlist,improperlist);
-  if (lostbond == IGNORE) return;
+  if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);

--- a/src/pair.h
+++ b/src/pair.h
@@ -96,6 +96,8 @@ class Pair : protected Pointers {
                                  //       public so external driver can check
   int compute_flag;              // 0 if skip compute()
 
+  enum{GEOMETRIC,ARITHMETIC,SIXTHPOWER};   // mixing options
+
   // KOKKOS host/device flag and data masks
 
   ExecutionSpace execution_space;
@@ -190,8 +192,6 @@ class Pair : protected Pointers {
 
  protected:
   int instance_me;        // which Pair class instantiation I am
-
-  enum{GEOMETRIC,ARITHMETIC,SIXTHPOWER};   // mixing options
 
   int special_lj[4];           // copied from force->special_lj for Kokkos
 

--- a/src/procmap.cpp
+++ b/src/procmap.cpp
@@ -29,8 +29,6 @@ using namespace LAMMPS_NS;
 
 #define MAXLINE 128
 
-enum{MULTIPLE};                   // same as in Comm
-
 /* ---------------------------------------------------------------------- */
 
 ProcMap::ProcMap(LAMMPS *lmp) : Pointers(lmp) {}
@@ -811,7 +809,7 @@ int ProcMap::cull_other(int n, int **factors, int m,
 {
   int i = 0;
   while (i < n) {
-    if (other_style == MULTIPLE) {
+    if (other_style == Comm::MULTIPLE) {
       int flag = 0;
       if ((other_procgrid[0]/other_coregrid[0]) % factors[i][0]) flag = 1;
       if ((other_procgrid[1]/other_coregrid[1]) % factors[i][1]) flag = 1;

--- a/src/procmap.cpp
+++ b/src/procmap.cpp
@@ -17,6 +17,7 @@
 
 #include "procmap.h"
 #include "universe.h"
+#include "comm.h"
 #include "domain.h"
 #include "math_extra.h"
 #include "memory.h"

--- a/src/replicate.cpp
+++ b/src/replicate.cpp
@@ -30,8 +30,6 @@ using namespace LAMMPS_NS;
 #define LB_FACTOR 1.1
 #define EPSILON   1.0e-6
 
-enum{LAYOUT_UNIFORM,LAYOUT_NONUNIFORM,LAYOUT_TILED};    // several files
-
 /* ---------------------------------------------------------------------- */
 
 Replicate::Replicate(LAMMPS *lmp) : Pointers(lmp) {}
@@ -267,7 +265,7 @@ void Replicate::command(int narg, char **arg)
     sublo[2] = domain->sublo_lamda[2]; subhi[2] = domain->subhi_lamda[2];
   }
 
-  if (comm->layout != LAYOUT_TILED) {
+  if (comm->layout != Comm::LAYOUT_TILED) {
     if (domain->xperiodic) {
       if (comm->myloc[0] == 0) sublo[0] -= epsilon[0];
       if (comm->myloc[0] == comm->procgrid[0]-1) subhi[0] += epsilon[0];

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -72,7 +72,6 @@ using namespace MathConst;
 #define ONE "step temp epair emol etotal press"
 #define MULTI "etotal ke temp pe ebond eangle edihed eimp evdwl ecoul elong press"
 
-enum{IGNORE,WARN,ERROR};           // same as several files
 enum{ONELINE,MULTILINE};
 enum{INT,FLOAT,BIGINT};
 enum{SCALAR,VECTOR,ARRAY};
@@ -98,7 +97,7 @@ Thermo::Thermo(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   modified = 0;
   normuserflag = 0;
   lineflag = ONELINE;
-  lostflag = lostbond = ERROR;
+  lostflag = lostbond = Thermo::ERROR;
   lostbefore = 0;
   flushflag = 0;
 
@@ -427,14 +426,14 @@ bigint Thermo::lost_check()
   if (ntotal == atom->natoms) return ntotal;
 
   // if not checking or already warned, just return
-  if (lostflag == IGNORE) return ntotal;
-  if (lostflag == WARN && lostbefore == 1) {
+  if (lostflag == Thermo::IGNORE) return ntotal;
+  if (lostflag == Thermo::WARN && lostbefore == 1) {
     return ntotal;
   }
 
   // error message
 
-  if (lostflag == ERROR) {
+  if (lostflag == Thermo::ERROR) {
     char str[64];
     sprintf(str,
             "Lost atoms: original " BIGINT_FORMAT " current " BIGINT_FORMAT,
@@ -536,17 +535,17 @@ void Thermo::modify_params(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"lost") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal thermo_modify command");
-      if (strcmp(arg[iarg+1],"ignore") == 0) lostflag = IGNORE;
-      else if (strcmp(arg[iarg+1],"warn") == 0) lostflag = WARN;
-      else if (strcmp(arg[iarg+1],"error") == 0) lostflag = ERROR;
+      if (strcmp(arg[iarg+1],"ignore") == 0) lostflag = Thermo::IGNORE;
+      else if (strcmp(arg[iarg+1],"warn") == 0) lostflag = Thermo::WARN;
+      else if (strcmp(arg[iarg+1],"error") == 0) lostflag = Thermo::ERROR;
       else error->all(FLERR,"Illegal thermo_modify command");
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"lost/bond") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal thermo_modify command");
-      if (strcmp(arg[iarg+1],"ignore") == 0) lostbond = IGNORE;
-      else if (strcmp(arg[iarg+1],"warn") == 0) lostbond = WARN;
-      else if (strcmp(arg[iarg+1],"error") == 0) lostbond = ERROR;
+      if (strcmp(arg[iarg+1],"ignore") == 0) lostbond = Thermo::IGNORE;
+      else if (strcmp(arg[iarg+1],"warn") == 0) lostbond = Thermo::WARN;
+      else if (strcmp(arg[iarg+1],"error") == 0) lostbond = Thermo::ERROR;
       else error->all(FLERR,"Illegal thermo_modify command");
       iarg += 2;
 

--- a/src/thermo.h
+++ b/src/thermo.h
@@ -33,6 +33,8 @@ class Thermo : protected Pointers {
   int lostflag;          // IGNORE,WARN,ERROR
   int lostbond;          // ditto for atoms in bonds
 
+  enum {IGNORE,WARN,ERROR};
+
   Thermo(class LAMMPS *, int, char **);
   ~Thermo();
   void init();

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -36,7 +36,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{IGNORE,WARN,ERROR};                    // same as thermo.cpp
 enum{II,IJ};
 
 /* ---------------------------------------------------------------------- */
@@ -153,7 +152,7 @@ void WriteData::write(char *file)
   bigint nblocal = atom->nlocal;
   bigint natoms;
   MPI_Allreduce(&nblocal,&natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
-  if (natoms != atom->natoms && output->thermo->lostflag == ERROR)
+  if (natoms != atom->natoms && output->thermo->lostflag == Thermo::ERROR)
     error->all(FLERR,"Atom count is inconsistent, cannot write data file");
 
   // sum up bond,angle,dihedral,improper counts

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -63,8 +63,6 @@ enum{VERSION,SMALLINT,TAGINT,BIGINT,
      ATOM_ID,ATOM_MAP_STYLE,ATOM_MAP_USER,ATOM_SORTFREQ,ATOM_SORTBIN,
      COMM_MODE,COMM_CUTOFF,COMM_VEL,NO_PAIR};
 
-enum{IGNORE,WARN,ERROR};                    // same as thermo.cpp
-
 /* ---------------------------------------------------------------------- */
 
 WriteRestart::WriteRestart(LAMMPS *lmp) : Pointers(lmp)
@@ -252,7 +250,7 @@ void WriteRestart::write(char *file)
 
   bigint nblocal = atom->nlocal;
   MPI_Allreduce(&nblocal,&natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
-  if (natoms != atom->natoms && output->thermo->lostflag == ERROR)
+  if (natoms != atom->natoms && output->thermo->lostflag == Thermo::ERROR)
     error->all(FLERR,"Atom count is inconsistent, cannot write restart file");
 
   // open single restart file or base file for multiproc case


### PR DESCRIPTION
## Purpose

This pull request implements what is suggested in issue #325 
Enums, that have to be kept consistent across multiple files are defined inside one class and then the namespace of the class is used to make them unique and avoid clashes.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

no change in runtime behavior. source outside the git repo, that uses these constants should be adapted but will continue to compile and function for as long as the enums are kept consistent.

## Implementation Notes

This move 9 enums into base class header files.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- n/a Suitable new documentation files and/or updates to the existing docs are included
- n/a One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

