### PR TITLE
Correct small bugs found by static code analysis

### DIFF
--- a/src/POEMS/fix_poems.cpp
+++ b/src/POEMS/fix_poems.cpp
@@ -369,7 +369,7 @@ void FixPOEMS::init()
       if (pflag && (modify->fmask[i] & POST_FORCE) && 
           !modify->fix[i]->rigid_flag) {
         char str[128];
-        sprintf(str,"Fix %d alters forces after fix poems",modify->fix[i]->id);
+        sprintf(str,"Fix %s alters forces after fix poems",modify->fix[i]->id);
         error->warning(FLERR,str);
       }
     }

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -730,7 +730,7 @@ void FixRigid::init()
       if (rflag && (modify->fmask[i] & POST_FORCE) && 
           !modify->fix[i]->rigid_flag) {
         char str[128];
-        sprintf(str,"Fix %d alters forces after fix rigid",modify->fix[i]->id);
+        sprintf(str,"Fix %s alters forces after fix rigid",modify->fix[i]->id);
         error->warning(FLERR,str);
       }
     }

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -569,7 +569,7 @@ void FixRigidSmall::init()
       if (rflag && (modify->fmask[i] & POST_FORCE) && 
           !modify->fix[i]->rigid_flag) {
         char str[128];
-        sprintf(str,"Fix %d alters forces after fix rigid",modify->fix[i]->id);
+        sprintf(str,"Fix %s alters forces after fix rigid",modify->fix[i]->id);
         error->warning(FLERR,str);
       }
     }

--- a/src/USER-MISC/fix_bond_react.cpp
+++ b/src/USER-MISC/fix_bond_react.cpp
@@ -1155,6 +1155,8 @@ void FixBondReact::make_a_guess()
   for (int i = 0; i < atom->ntypes; i++) {
     if (mol_ntypes[i] != lcl_ntypes[i]) {
       status = GUESSFAIL;
+      delete [] mol_ntypes;
+      delete [] lcl_ntypes;
       return;
     }
   }


### PR DESCRIPTION
- in fix rigid, rigid/small, and poems, a string argument was
  incorrectly assigned to a %d format
- plug two small memory leaks in fix bond/react

## Author(s)

Axel Kohlmeyrer (Temple U)

