### PR TITLE
Small bugfixes for Pair Snap

### DIFF
--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -1529,11 +1529,11 @@ void PairSNAP::coeff(int narg, char **arg)
       sna[tid]->grow_rij(nmax);
   }
 
-  if (comm->me == 0)
-    if (ncoeff != sna[0]->ncoeff) {
+  if (ncoeff != sna[0]->ncoeff) {
+    if (comm->me == 0)
       printf("ncoeff = %d snancoeff = %d \n",ncoeff,sna[0]->ncoeff);
-      error->all(FLERR,"Incorrect SNAP parameter file");
-    }
+    error->all(FLERR,"Incorrect SNAP parameter file");
+  }
 
   // Calculate maximum cutoff for all elements
 

--- a/src/SNAP/pair_snap.h
+++ b/src/SNAP/pair_snap.h
@@ -37,8 +37,11 @@ public:
   virtual double init_one(int, int);
   virtual double memory_usage();
 
+  double rcutfac, quadraticflag; // declared public to workaround gcc 4.9
+  int ncoeff;                    //  compiler bug, manifest in KOKKOS package
+
 protected:
-  int ncoeff, ncoeffq, ncoeffall;
+  int ncoeffq, ncoeffall;
   double **bvec, ***dbvec;
   class SNA** sna;
   int nmax;
@@ -97,8 +100,8 @@ protected:
   double *wjelem;               // elements weights
   double **coeffelem;           // element bispectrum coefficients
   int *map;                     // mapping from atom types to elements
-  int twojmax, diagonalstyle, switchflag, bzeroflag, quadraticflag;
-  double rcutfac, rfac0, rmin0, wj1, wj2;
+  int twojmax, diagonalstyle, switchflag, bzeroflag;
+  double rfac0, rmin0, wj1, wj2;
   int rcutfacflag, twojmaxflag; // flags for required parameters
 };
 


### PR DESCRIPTION
## Purpose
Small fixes for pair snap: 
- Restore workaround for compiler bug in pair_snap.h that shows up with the KOKKOS package
- Fix possible MPI deadlock in pair_snap when error-ing out

## Author(s)
Stan Moore (Sandia)

## Backward Compatibility
No issues
