### PR TITLE
Collected bugfixes and updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,3 +43,14 @@ src/USER-MISC/*_grem.*              @dstelter92
 
 # tools
 tools/msi2lmp/*       @akohlmey
+
+# cmake
+cmake/*               @junghans @rbberger
+
+# python
+python/*              @rbberger
+
+# docs
+doc/utils/*/*         @rbberger
+doc/Makefile          @rbberger
+doc/README            @rbberger

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,6 +9,7 @@ TXT2RST       = $(VENV)/bin/txt2rst
 ANCHORCHECK   = $(VENV)/bin/doc_anchor_check
 
 PYTHON        = $(shell which python3)
+VIRTUALENV     = virtualenv
 HAS_PYTHON3    = NO
 HAS_VIRTUALENV = NO
 
@@ -16,7 +17,13 @@ ifeq ($(shell which python3 >/dev/null 2>&1; echo $$?), 0)
 HAS_PYTHON3 = YES
 endif
 
+ifeq ($(shell which virtualenv-3 >/dev/null 2>&1; echo $$?), 0)
+VIRTUALENV     = virtualenv-3
+HAS_VIRTUALENV = YES
+endif
+
 ifeq ($(shell which virtualenv >/dev/null 2>&1; echo $$?), 0)
+VIRTUALENV     = virtualenv
 HAS_VIRTUALENV = YES
 endif
 
@@ -158,7 +165,7 @@ $(VENV):
 	@if [ "$(HAS_PYTHON3)" == "NO" ] ; then echo "Python3 was not found! Please check README.md for further instructions" 1>&2; exit 1; fi
 	@if [ "$(HAS_VIRTUALENV)" == "NO" ] ; then echo "virtualenv was not found! Please check README.md for further instructions" 1>&2; exit 1; fi
 	@( \
-		virtualenv -p $(PYTHON) $(VENV); \
+		$(VIRTUALENV) -p $(PYTHON) $(VENV); \
 		. $(VENV)/bin/activate; \
 		pip install Sphinx; \
 		pip install sphinxcontrib-images; \

--- a/doc/src/Section_errors.txt
+++ b/doc/src/Section_errors.txt
@@ -803,6 +803,13 @@ lo value must be less than the hi value for all 3 dimensions. :dd
 The box command cannot be used after a read_data, read_restart, or
 create_box command. :dd
 
+{BUG: restartinfo=1 but no restart support in pair style} :dt
+
+The pair style has a bug, where it does not support reading
+and writing information to a restart file, but does not set
+the member variable restartinfo to 0 as required in that case. :dd
+
+
 {CPU neighbor lists must be used for ellipsoid/sphere mix.} :dt
 
 When using Gay-Berne or RE-squared pair styles with both ellipsoidal and

--- a/doc/src/create_bonds.txt
+++ b/doc/src/create_bonds.txt
@@ -37,8 +37,8 @@ keyword = {special} :l
 
 create_bonds many all all 1 1.0 1.2
 create_bonds many surf solvent 3 2.0 2.4
-create_bond single/bond 1 1 2
-create_bond single/angle 5 52 98 107 special no :pre
+create_bonds single/bond 1 1 2
+create_bonds single/angle 5 52 98 107 special no :pre
 
 [Description:]
 

--- a/doc/src/fix_adapt.txt
+++ b/doc/src/fix_adapt.txt
@@ -205,6 +205,14 @@ a bond coefficient over time, very similar to how the {pair} keyword
 operates. The only difference is that now a bond coefficient for a
 given bond type is adapted.
 
+A wild-card asterisk can be used in place of or in conjunction with
+the bond type argument to set the coefficients for multiple bond types.
+This takes the form "*" or "*n" or "n*" or "m*n".  If N = the number of
+atom types, then an asterisk with no numeric values means all types
+from 1 to N.  A leading asterisk means all types from 1 to n (inclusive).
+A trailing asterisk means all types from n to N (inclusive).  A middle
+asterisk means all types from m to n (inclusive).
+
 Currently {bond} does not support bond_style hybrid nor bond_style
 hybrid/overlay as bond styles. The only bonds that currently are
 working with fix_adapt are

--- a/doc/src/molecule.txt
+++ b/doc/src/molecule.txt
@@ -98,19 +98,20 @@ molecule (header keyword = inertia).
 NOTE: The molecule command can be used to define molecules with bonds,
 angles, dihedrals, imporopers, or special bond lists of neighbors
 within a molecular topology, so that you can later add the molecules
-to your simulation, via one or more of the commands listed above.  If
-such molecules do not already exist when LAMMPS creates the simulation
-box, via the "create_box"_create_box.html or
-"read_data"_read_data.html command, when you later add them you may
-overflow the pre-allocated data structures which store molecular
-topology information with each atom, and an error will be generated.
-Both the "create_box"_create_box.html command and the data files read
-by the "read_data"_read_data.html command have "extra" options which
+to your simulation, via one or more of the commands listed above.
+Since this topology-related information requires that suitable storage
+is reserved when LAMMPS creates the simulation box (e.g. when using
+the "create_box"_create_box.html command or the
+"read_data"_read_data.html command) suitable space has to be reserved
+so you do not overflow those pre-allocated data structures when adding
+molecules later.  Both the "create_box"_create_box.html command and
+the "read_data"_read_data.html command have "extra" options which
 insure space is allocated for storing topology info for molecules that
 are added later.
 
-The format of an individual molecule file is similar to the data file
-read by the "read_data"_read_data.html commands, and is as follows.
+The format of an individual molecule file is similar but
+(not identical) to the data file read by the "read_data"_read_data.html
+commands, and is as follows.
 
 A molecule file has a header and a body.  The header appears first.
 The first line of the header is always skipped; it typically contains

--- a/doc/src/molecule.txt
+++ b/doc/src/molecule.txt
@@ -456,7 +456,11 @@ of SHAKE clusters.
 
 :line
 
-[Restrictions:] none
+[Restrictions:]
+
+This command must come after the simulation box is define by a
+"read_data"_read_data.html, "read_restart"_read_restart.html, or
+"create_box"_create_box.html command.
 
 [Related commands:]
 

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -40,6 +40,7 @@ using namespace LAMMPS_NS;
 PairQUIP::PairQUIP(LAMMPS *lmp) : Pair(lmp)
 {
    single_enable = 0;
+   restartinfo = 0;
    one_coeff = 1;
    no_virial_fdotr_compute = 1;
    manybody_flag = 1;

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -28,7 +28,7 @@ static const char *truncpath(const char *path)
    if (path) {
      int len = strlen(path);
      for (int i = len-4; i > 0; --i) {
-	if (strncmp("src/",path+i,4) == 0)
+        if (strncmp("src/",path+i,4) == 0)
           return path+i;
      }
    }

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -118,7 +118,7 @@ nadapt(0), id_fix_diam(NULL), id_fix_chg(NULL), adapt(NULL)
       adapt[nadapt].bparam = new char[n];
       adapt[nadapt].bond = NULL;
       strcpy(adapt[nadapt].bparam,arg[iarg+2]);
-      force->bounds(FLERR,arg[iarg+3],atom->ntypes,
+      force->bounds(FLERR,arg[iarg+3],atom->nbondtypes,
                     adapt[nadapt].ilo,adapt[nadapt].ihi);
       if (strstr(arg[iarg+4],"v_") == arg[iarg+4]) {
         n = strlen(&arg[iarg+4][2]) + 1;

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -52,6 +52,9 @@ Molecule::Molecule(LAMMPS *lmp, int narg, char **arg, int &index) :
 
   if (index >= narg) error->all(FLERR,"Illegal molecule command");
 
+  if (domain->box_exist == 0)
+    error->all(FLERR,"Molecule command before simulation box is defined");
+
   int n = strlen(arg[0]) + 1;
   id = new char[n];
   strcpy(id,arg[0]);

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -684,7 +684,7 @@ void Molecule::types(char *line)
   }
 
   for (int i = 0; i < natoms; i++)
-    if (type[i] <= 0)
+    if (type[i] <= 0 || type[i] > atom->ntypes)
       error->all(FLERR,"Invalid atom type in molecule file");
 
   for (int i = 0; i < natoms; i++)
@@ -771,10 +771,10 @@ void Molecule::bonds(int flag, char *line)
       error->all(FLERR,"Invalid Bonds section in molecule file");
     itype += boffset;
 
-    if (atom1 <= 0 || atom1 > natoms ||
-        atom2 <= 0 || atom2 > natoms)
+    if ((atom1 <= 0) || (atom1 > natoms) ||
+        (atom2 <= 0) || (atom2 > natoms) || (atom1 == atom2))
       error->one(FLERR,"Invalid atom ID in Bonds section of molecule file");
-    if (itype <= 0)
+    if (itype <= 0 || itype > atom->nbondtypes)
       error->one(FLERR,"Invalid bond type in Bonds section of molecule file");
 
     if (flag) {
@@ -829,11 +829,12 @@ void Molecule::angles(int flag, char *line)
       error->all(FLERR,"Invalid Angles section in molecule file");
     itype += aoffset;
 
-    if (atom1 <= 0 || atom1 > natoms ||
-        atom2 <= 0 || atom2 > natoms ||
-        atom3 <= 0 || atom3 > natoms)
+    if ((atom1 <= 0) || (atom1 > natoms) ||
+        (atom2 <= 0) || (atom2 > natoms) ||
+        (atom3 <= 0) || (atom3 > natoms) ||
+        (atom1 == atom2) || (atom1 == atom3) || (atom2 == atom3))
       error->one(FLERR,"Invalid atom ID in Angles section of molecule file");
-    if (itype <= 0)
+    if (itype <= 0 || itype > atom->nangletypes)
       error->one(FLERR,"Invalid angle type in Angles section of molecule file");
 
     if (flag) {
@@ -902,13 +903,15 @@ void Molecule::dihedrals(int flag, char *line)
       error->all(FLERR,"Invalid Dihedrals section in molecule file");
     itype += doffset;
 
-    if (atom1 <= 0 || atom1 > natoms ||
-        atom2 <= 0 || atom2 > natoms ||
-        atom3 <= 0 || atom3 > natoms ||
-        atom4 <= 0 || atom4 > natoms)
+    if ((atom1 <= 0) || (atom1 > natoms) ||
+        (atom2 <= 0) || (atom2 > natoms) ||
+        (atom3 <= 0) || (atom3 > natoms) ||
+        (atom4 <= 0) || (atom4 > natoms) ||
+        (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
+        (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
       error->one(FLERR,
                  "Invalid atom ID in dihedrals section of molecule file");
-    if (itype <= 0)
+    if (itype <= 0 || itype > atom->ndihedraltypes)
       error->one(FLERR,
                  "Invalid dihedral type in dihedrals section of molecule file");
 
@@ -989,13 +992,15 @@ void Molecule::impropers(int flag, char *line)
       error->all(FLERR,"Invalid Impropers section in molecule file");
     itype += ioffset;
 
-    if (atom1 <= 0 || atom1 > natoms ||
-        atom2 <= 0 || atom2 > natoms ||
-        atom3 <= 0 || atom3 > natoms ||
-        atom4 <= 0 || atom4 > natoms)
+    if ((atom1 <= 0) || (atom1 > natoms) ||
+        (atom2 <= 0) || (atom2 > natoms) ||
+        (atom3 <= 0) || (atom3 > natoms) ||
+        (atom4 <= 0) || (atom4 > natoms) ||
+        (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
+        (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
       error->one(FLERR,
                  "Invalid atom ID in impropers section of molecule file");
-    if (itype <= 0)
+    if (itype <= 0 || itype > atom->nimpropertypes)
       error->one(FLERR,
                  "Invalid improper type in impropers section of molecule file");
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -695,13 +695,15 @@ void Pair::compute_dummy(int eflag, int vflag)
 /* ---------------------------------------------------------------------- */
 void Pair::read_restart(FILE *)
 {
-  error->all(FLERR,"BUG: restartinfo=1 but no restart support in pair style");
+  if (comm->me == 0)
+    error->warning(FLERR,"BUG: restartinfo=1 but no restart support in pair style");
 }
 
 /* ---------------------------------------------------------------------- */
 void Pair::write_restart(FILE *)
 {
-  error->all(FLERR,"BUG: restartinfo=1 but no restart support in pair style");
+  if (comm->me == 0)
+    error->warning(FLERR,"BUG: restartinfo=1 but no restart support in pair style");
 }
 
 /* -------------------------------------------------------------------

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -698,6 +698,12 @@ void Pair::read_restart(FILE *)
   error->all(FLERR,"BUG: restartinfo=1 but no restart support in pair style");
 }
 
+/* ---------------------------------------------------------------------- */
+void Pair::write_restart(FILE *)
+{
+  error->all(FLERR,"BUG: restartinfo=1 but no restart support in pair style");
+}
+
 /* -------------------------------------------------------------------
    register a callback to a compute, so it can compute and accumulate
    additional properties during the pair computation from within

--- a/src/pair.h
+++ b/src/pair.h
@@ -157,7 +157,7 @@ class Pair : protected Pointers {
   virtual void free_tables();
   virtual void free_disp_tables();
 
-  virtual void write_restart(FILE *) {}
+  virtual void write_restart(FILE *);
   virtual void read_restart(FILE *);
   virtual void write_restart_settings(FILE *) {}
   virtual void read_restart_settings(FILE *) {}
@@ -303,7 +303,9 @@ No kspace style is defined.
 
 E: BUG: restartinfo=1 but no restart support in pair style
 
-UNDOCUMENTED
+The pair style has a bug, where it does not support reading
+and writing information to a restart file, but does not set
+the member variable restartinfo to 0 as required in that case.
 
 E: Cannot yet use compute tally with Kokkos
 


### PR DESCRIPTION
## Purpose

The PR combines multiple bugfixes and updates including other pull requests that are trivial or need additional updates. This closes #931 and #932

## Author(s)

Jake Gissinger, Axel Kohlmeyer

## Backward Compatibility

The molecule command now is only allowed **after** the simulation box has been defined. Otherwise, the testing of the input for consistency would not be possible. The benefit from these checks outweighs the benefit from issuing the molecule command early in the input. any command using the molecule definitions (e.g. create_atoms) has to come after the definition of the simulation box, anyway.

## Implementation Notes

Individual contained changes are:
- PR #931 
- PR #932 
- bugfix for pair style `quip`, which does not set restartinfo to 0 as required for pair styles that do not write information to restarts
- copy `restartinfo` check from `Pair::read_restart()` to `Pair::write_restart()` as suggested by Noam Bernstein. Also make those checks print warnings instead of erroring out.
- update Makefile in `doc` to support machines where the only installed virtualenv is called `virtualenv-3` to distinguish it from the python 2.x variant called `virtualenv`. 
- .github/CODEOWNERS updates
- fix for typos in docs

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines


