### PR TITLE
Fix discrepancies between fix_nh and papers

### DIFF
--- a/src/KOKKOS/fix_nh_kokkos.cpp
+++ b/src/KOKKOS/fix_nh_kokkos.cpp
@@ -148,7 +148,7 @@ void FixNHKokkos<DeviceType>::setup(int vflag)
 
   if (pstat_flag) {
     double kt = boltz * t_target;
-    double nkt = atom->natoms * kt;
+    double nkt = (atom->natoms + 1) * kt;
 
     for (int i = 0; i < 3; i++)
       if (p_flag[i])

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -798,7 +798,7 @@ void FixNH::setup(int vflag)
 
   if (pstat_flag) {
     double kt = boltz * t_target;
-    double nkt = atom->natoms * kt;
+    double nkt = (atom->natoms + 1) * kt;
 
     for (int i = 0; i < 3; i++)
       if (p_flag[i])
@@ -1826,7 +1826,7 @@ void FixNH::nhc_press_integrate()
   // Update masses, to preserve initial freq, if flag set
 
   if (omega_mass_flag) {
-    double nkt = atom->natoms * kt;
+    double nkt = (atom->natoms + 1) * kt;
     for (int i = 0; i < 3; i++)
       if (p_flag[i])
         omega_mass[i] = nkt/(p_freq[i]*p_freq[i]);


### PR DESCRIPTION
## Purpose

This addresses two places where the Nosé-Hoover-like barostats deviate from relevant literature.

The mass of the barostat fictitious DoFs should be proportional to (N+1)kT according to all relevant papers. Of course, the difference in the resulting relaxation times is negligible for anything bigger than a couple of atoms.

Additionally, each degree of freedom of the cell should be thermostatted to a kinetic energy of kT, but fix_nh thermostats the sum of their kinetic energies to kT. This makes the temperature of the cell DoFs just a fraction of the requested temperature, depending on the number of barostatted dimensions. I guess that someone might have originally planned to implement this correctly and then it just somehow did not get finished, judging from the "lkt_press" variables that weren't really used for anything.

## Author(s)

Tomáš Trnka, Software for Chemistry & Materials B.V.

## Backward Compatibility

No changes to the input, but results will be somewhat different due to the different temperature of barostat DoFs.

## Implementation Notes

Tested against our MD code (following the MTTK paper) using ReaxFF and a set of small systems. These two commits make our results agree to within numerical precision.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
