### PR TITLE
Variable style 'string' substitutes variables in definition

### DIFF
--- a/doc/src/variable.txt
+++ b/doc/src/variable.txt
@@ -296,10 +296,11 @@ list of runs (e.g. 1000) without having to list N strings in the input
 script.
 
 For the {string} style, a single string is assigned to the variable.
-The only difference between this and using the {index} style with a
-single string is that a variable with {string} style can be redefined.
-E.g. by another command later in the input script, or if the script is
-read again in a loop.
+Two differences between this this and using the {index} style exist:
+a variable with {string} style can be redefined, e.g. by another command later
+in the input script, or if the script is read again in a loop. The other
+difference is that {string} performs variable substitution even if the
+string parameter is quoted.
 
 For the {format} style, an equal-style variable is specified along
 with a C-style format string, e.g. "%f" or "%.10g", which must be

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -284,12 +284,21 @@ void Variable::set(int narg, char **arg)
 
   } else if (strcmp(arg[1],"string") == 0) {
     if (narg != 3) error->all(FLERR,"Illegal variable command");
+
+    int maxcopy = strlen(arg[2]) + 1;
+    int maxwork = maxcopy;
+    char *scopy = new char[maxcopy];
+    char *work = new char[maxwork];
+    strcpy(scopy,arg[2]);
+    input->substitute(scopy,work,maxcopy,maxwork,1);
+    delete [] work;
+
     int ivar = find(arg[0]);
     if (ivar >= 0) {
       if (style[ivar] != STRING)
         error->all(FLERR,"Cannot redefine variable as a different style");
       delete [] data[ivar][0];
-      copy(1,&arg[2],data[ivar]);
+      copy(1,&scopy,data[ivar]);
       replaceflag = 1;
     } else {
       if (nvar == maxvar) grow();
@@ -298,8 +307,9 @@ void Variable::set(int narg, char **arg)
       which[nvar] = 0;
       pad[nvar] = 0;
       data[nvar] = new char*[num[nvar]];
-      copy(1,&arg[2],data[nvar]);
+      copy(1,&scopy,data[nvar]);
     }
+    delete [] scopy;
 
   // GETENV
   // remove pre-existing var if also style GETENV (allows it to be reset)

--- a/src/variable.h
+++ b/src/variable.h
@@ -16,6 +16,7 @@
 
 #include <cstdlib>
 #include "pointers.h"
+#include "input.h"
 
 namespace LAMMPS_NS {
 


### PR DESCRIPTION
## Purpose

As discussed on lammps-users, this PR modifies variable style "string" to also do variable expansion at definition time when the value is quoted.

Example:
```
variable bar index 123
variable baz index abc

variable foo1 string ${bar}_${baz}
variable foo2 string "${bar} ${baz}" 

print ${foo1}
print "${foo2}"
```
Expands to:
```
print ${foo1}
print 123_abc
123_abc
print "${foo2}"
123 abc
```
## Author(s)

Sebastian Hütter (OvGU)

## Backward Compatibility

This does change existing interpretation of `variable string`. However, I don't see any existing use case that might be influenced by this: since it was previously not possible to do anything useful with substitution variables in string-style variables, I suspect there shouldn't be any code that gets broken.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines
