### PR TITLE
Fix the tail correction with pair_nm

### DIFF
--- a/src/MISC/pair_nm_cut.cpp
+++ b/src/MISC/pair_nm_cut.cpp
@@ -15,10 +15,10 @@
    Contributing Author: Julien Devemy (ICCF)
 ------------------------------------------------------------------------- */
 
-#include <cmath>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "pair_nm_cut.h"
 #include "atom.h"
 #include "comm.h"
@@ -282,10 +282,12 @@ double PairNMCut::init_one(int i, int j)
     double rrr1 = pow(r0[i][j],nn[i][j])*(1-nn[i][j]);
     double rrr2 = pow(r0[i][j],mm[i][j])*(1-mm[i][j]);
 
-    etail_ij = 2.0*MY_PI*all[0]*all[1]*e0nm[i][j] *
-      (rr1*pow(cut[i][j],p1)-rr2*pow(cut[i][j],p2));
-    ptail_ij = 2.0*MY_PI*all[0]*all[1]*e0nm[i][j] *
-      nn[i][j]*mm[i][j]*(rrr1*pow(cut[i][j],p1)-rrr2*pow(cut[i][j],p2));
+    double cut3 = cut[i][j]*cut[i][j]*cut[i][j];
+    ptail_ij = 2.*MY_PI/3.*all[0]*all[1]*e0nm[i][j]*nm[i][j]*cut3 *
+      (pow(r0[i][j]/cut[i][j],nn[i][j])/(nn[i][j]-3) - pow(r0[i][j]/cut[i][j],mm[i][j])/(mm[i][j]-3));
+    etail_ij = 2.*MY_PI*all[0]*all[1]*e0nm[i][j]*cut3 *
+      (mm[i][j]*pow(r0[i][j]/cut[i][j],nn[i][j])/(nn[i][j]-3) - nn[i][j]*pow(r0[i][j]/cut[i][j],mm[i][j])/(mm[i][j]-3));
+
   }
 
   return cut[i][j];

--- a/src/MISC/pair_nm_cut.cpp
+++ b/src/MISC/pair_nm_cut.cpp
@@ -15,10 +15,10 @@
    Contributing Author: Julien Devemy (ICCF)
 ------------------------------------------------------------------------- */
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include "pair_nm_cut.h"
 #include "atom.h"
 #include "comm.h"

--- a/src/MISC/pair_nm_cut_coul_cut.cpp
+++ b/src/MISC/pair_nm_cut_coul_cut.cpp
@@ -15,10 +15,10 @@
    Contributing Author: Julien Devemy (ICCF)
 ------------------------------------------------------------------------- */
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include "pair_nm_cut_coul_cut.h"
 #include "atom.h"
 #include "comm.h"

--- a/src/MISC/pair_nm_cut_coul_cut.cpp
+++ b/src/MISC/pair_nm_cut_coul_cut.cpp
@@ -15,10 +15,10 @@
    Contributing Author: Julien Devemy (ICCF)
 ------------------------------------------------------------------------- */
 
-#include <cmath>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "pair_nm_cut_coul_cut.h"
 #include "atom.h"
 #include "comm.h"
@@ -332,10 +332,11 @@ double PairNMCutCoulCut::init_one(int i, int j)
     double rrr1 = pow(r0[i][j],nn[i][j])*(1-nn[i][j]);
     double rrr2 = pow(r0[i][j],mm[i][j])*(1-mm[i][j]);
 
-    etail_ij = 2.0*MY_PI*all[0]*all[1]*e0nm[i][j] *
-      (rr1*pow(cut_lj[i][j],p1)-rr2*pow(cut_lj[i][j],p2));
-    ptail_ij = 2.0*MY_PI*all[0]*all[1]*e0nm[i][j] *
-      nn[i][j]*mm[i][j]*(rrr1*pow(cut_lj[i][j],p1)-rrr2*pow(cut_lj[i][j],p2));
+    double cut_lj3 = cut_lj[i][j]*cut_lj[i][j]*cut_lj[i][j];
+    ptail_ij = 2.*MY_PI/3.*all[0]*all[1]*e0nm[i][j]*nm[i][j]*cut_lj3 *
+      (pow(r0[i][j]/cut_lj[i][j],nn[i][j])/(nn[i][j]-3) - pow(r0[i][j]/cut_lj[i][j],mm[i][j])/(mm[i][j]-3));
+    etail_ij = 2.*MY_PI*all[0]*all[1]*e0nm[i][j]*cut_lj3 *
+      (mm[i][j]*pow(r0[i][j]/cut_lj[i][j],nn[i][j])/(nn[i][j]-3) - nn[i][j]*pow(r0[i][j]/cut_lj[i][j],mm[i][j])/(mm[i][j]-3));
 
   }
 

--- a/src/MISC/pair_nm_cut_coul_long.cpp
+++ b/src/MISC/pair_nm_cut_coul_long.cpp
@@ -15,10 +15,10 @@
    Contributing Author: Julien Devemy (ICCF)
 ------------------------------------------------------------------------- */
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include "pair_nm_cut_coul_long.h"
 #include "atom.h"
 #include "comm.h"

--- a/src/MISC/pair_nm_cut_coul_long.cpp
+++ b/src/MISC/pair_nm_cut_coul_long.cpp
@@ -15,10 +15,10 @@
    Contributing Author: Julien Devemy (ICCF)
 ------------------------------------------------------------------------- */
 
-#include <cmath>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "pair_nm_cut_coul_long.h"
 #include "atom.h"
 #include "comm.h"
@@ -379,10 +379,12 @@ double PairNMCutCoulLong::init_one(int i, int j)
     double rrr1 = pow(r0[i][j],nn[i][j])*(1-nn[i][j]);
     double rrr2 = pow(r0[i][j],mm[i][j])*(1-mm[i][j]);
 
-    etail_ij = 2.0*MY_PI*all[0]*all[1]*e0nm[i][j] *
-      (rr1*pow(cut_lj[i][j],p1)-rr2*pow(cut_lj[i][j],p2));
-    ptail_ij = 2.0*MY_PI*all[0]*all[1]*e0nm[i][j]*nn[i][j]*mm[i][j] *
-      (rrr1*pow(cut_lj[i][j],p1)-rrr2*pow(cut_lj[i][j],p2));
+    double cut_lj3 = cut_lj[i][j]*cut_lj[i][j]*cut_lj[i][j];
+    ptail_ij = 2.*MY_PI/3.*all[0]*all[1]*e0nm[i][j]*nm[i][j]*cut_lj3 *
+      (pow(r0[i][j]/cut_lj[i][j],nn[i][j])/(nn[i][j]-3) - pow(r0[i][j]/cut_lj[i][j],mm[i][j])/(mm[i][j]-3));
+    etail_ij = 2.*MY_PI*all[0]*all[1]*e0nm[i][j]*cut_lj3 *
+      (mm[i][j]*pow(r0[i][j]/cut_lj[i][j],nn[i][j])/(nn[i][j]-3) - nn[i][j]*pow(r0[i][j]/cut_lj[i][j],mm[i][j])/(mm[i][j]-3));
+
   }
 
   return cut;


### PR DESCRIPTION

[test_bug_tail_nm.tar.gz](https://github.com/lammps/lammps/files/2102196/test_bug_tail_nm.tar.gz)

## Purpose

The computation of the tail variables (`etail_ij` and `ptail_ij`) in _pair_nm_* was bugged.

You can use the attached test which compare pair_nm and pair_lj : with the bugged code and tail yes, the thermo output are different.

With the modified code, the thermo outputs are the same, which is the normal behavior.

## Author(s)

Julien Devemy, Alain Dequidt



