### PR TITLE
Add support for inline format strings to immediate variable substitution

### DIFF
--- a/doc/src/Section_commands.txt
+++ b/doc/src/Section_commands.txt
@@ -129,6 +129,15 @@ region 1 block $((xlo+xhi)/2+sqrt(v_area)) 2 INF INF EDGE EDGE :pre
 
 so that you do not have to define (or discard) a temporary variable X.
 
+Additionally, the "immediate" expression may be followed by a colon,
+followed by a C-style format string, e.g. "%f" or "%.10g", which must be
+appropriate for formatting a double-precision floating-point value. The
+format string will be used to output the result of the variable evaluation,
+so you do not have to define a temporary "format-style variable"_variable.html.
+This may be used for formatting print output:
+
+print "Final energy per atom: $(pe/atoms:%10.3f) eV/atom" :pre
+
 Note that neither the curly-bracket or immediate form of variables can
 contain nested $ characters for other variables to substitute for.
 Thus you cannot do this:

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -516,7 +516,14 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
         if (var[i] == '\0') error->one(FLERR,"Invalid immediate variable");
         var[i] = '\0';
         beyond = ptr + strlen(var) + 3;
-        sprintf(immediate,"%.20g",variable->compute_equal(var));
+        // check if an inline format specifier was given
+        char fmtstr[64] = "%.20g";
+        char *fmtflag;
+        if ((fmtflag=strrchr(var, ':')) && (fmtflag[1]=='%')) {
+          strncpy(fmtstr,&fmtflag[1],sizeof(fmtstr)-1);
+          *fmtflag='\0';
+        }
+        sprintf(immediate,fmtstr,variable->compute_equal(var));
         value = immediate;
 
         // single character variable name, e.g. $a


### PR DESCRIPTION
## Purpose

This PR extends `$(immediate)`-variable evaluation to support format specifiers. Effectively, this eliminates the need for `format` style variables in some (most?) cases.

Example:
```
variable            peatom equal pe/atoms
variable            spea format peatom %10.3f
print "Final energy per atom: ${spea} eV/atom"
```
Can be shortened to:
```
print "Final energy per atom: $(pe/atoms:%10.3f) eV/atom"
```
## Author(s)

Sebastian Hütter (OvGU)

## Backward Compatibility

The splitter character ':' was not a valid character in an equal-style variable before, and the ":%" sequence does not look like it will ever be one. Only `$()` is modified, expression evaluation itself is unchanged. No issues are expected.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
