### PR TITLE
Apply modifications to MEAM & MEAM/C as found by Kyung-Han Kang

### DIFF
--- a/lib/meam/meam_setup_done.F
+++ b/lib/meam/meam_setup_done.F
@@ -232,7 +232,8 @@ c     pairs, but need to include NN2 contributions to those pairs as
 c     well.
               if (lattce_meam(a,b).eq.'b1'.or.
      $             lattce_meam(a,b).eq.'b2'.or.
-     $             lattce_meam(a,b).eq.'l12') then
+     $             lattce_meam(a,b).eq.'l12'.or.
+     $             lattce_meam(a,b).eq.'dia') then
                 rarat = r*arat
 
 c               phi_aa
@@ -262,7 +263,8 @@ c               phi_bb
                 endif
 
                 if (lattce_meam(a,b).eq.'b1'.
-     $               or.lattce_meam(a,b).eq.'b2') then
+     $               or.lattce_meam(a,b).eq.'b2'.
+     $               or.lattce_meam(a,b).eq.'dia') then
 c     Add contributions to the B1 or B2 potential
                   call get_Zij(Z1,lattce_meam(a,b))
                   call get_Zij2(Z2,arat,scrn,lattce_meam(a,b),
@@ -720,9 +722,9 @@ c neighbor screening function for lattice type "latt"
         a = sqrt(2.d0)
         numscr = 4
       else if (latt.eq.'dia') then
-        Zij2 = 0
+        Zij2 = 12
         a = sqrt(8.d0/3.d0)
-        numscr = 4
+        numscr = 1
         if (cmin.lt.0.500001) then
 c          call error('can not do 2NN MEAM for dia')
         endif

--- a/src/USER-MEAMC/meam_funcs.cpp
+++ b/src/USER-MEAMC/meam_funcs.cpp
@@ -277,9 +277,9 @@ MEAM::get_Zij2(const lattice_t latt, const double cmin, const double cmax, doubl
     break;
 
   case DIA:
-    Zij2 = 0;
+    Zij2 = 12;
     a = sqrt(8.0 / 3.0);
-    numscr = 4;
+    numscr = 1;
     if (cmin < 0.500001) {
         //          call error('can not do 2NN MEAM for dia')
     }

--- a/src/USER-MEAMC/meam_setup_done.cpp
+++ b/src/USER-MEAMC/meam_setup_done.cpp
@@ -213,14 +213,12 @@ MEAM::compute_pair_meam(void)
           Z2 = get_Zij2(this->lattce_meam[a][b], this->Cmin_meam[a][a][b],
                    this->Cmax_meam[a][a][b], arat, scrn);
 
-          //     The B1, B2,  and L12 cases with NN2 have a trick to them; we
-          //     need to
-          //     compute the contributions from second nearest neighbors, like
-          //     a-a
+          //     The B1, B2,  and L12 cases with NN2 have a trick to them; we need to
+          //     compute the contributions from second nearest neighbors, like a-a
           //     pairs, but need to include NN2 contributions to those pairs as
           //     well.
           if (this->lattce_meam[a][b] == B1 || this->lattce_meam[a][b] == B2 ||
-              this->lattce_meam[a][b] == L12) {
+              this->lattce_meam[a][b] == L12 || this->lattce_meam[a][b] == DIA) {
             rarat = r * arat;
 
             //               phi_aa
@@ -247,7 +245,8 @@ MEAM::compute_pair_meam(void)
               }
             }
 
-            if (this->lattce_meam[a][b] == B1 || this->lattce_meam[a][b] == B2) {
+            if (this->lattce_meam[a][b] == B1 || this->lattce_meam[a][b] == B2 ||
+                this->lattce_meam[a][b] == DIA) {
               //     Add contributions to the B1 or B2 potential
               Z1 = get_Zij(this->lattce_meam[a][b]);
               Z2 = get_Zij2(this->lattce_meam[a][b], this->Cmin_meam[a][a][b],


### PR DESCRIPTION
## Purpose

According to [this document](http://cmse.postech.ac.kr/lammps/22036), the Fortran implementation of MEAM in LAMMPS has a bug concerning 'dia' reference structures. This results in a difference in results between LAMMPS and KISSMD.  Consequently, my USER-MEAMC translation has the same issue.
I just found this by accident, I don't think it has been discussed before?

The folks at Postech provide a modified version of the then-current code, which I have applied to both the Fortran and C++ implementations. I would think their workgroup has some authority on what should be correct.

## Author(s)

Patch by Kyung-Han Kang, CMSE Lab., Pohang University of Science and Technology
Applied by Sebastian Hütter (OvGU)

## Backward Compatibility
The SiC example in examples/meam/in.meam is not affected by this specific issue and produces the exact same results. If someone has more complete regression tests available, that'd be good.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
