### PR TITLE
Fix such that package USER-MISC can compile using icpc

### DIFF
--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -193,7 +193,7 @@ typedef int bigint;
 // declaration to lift aliasing restrictions
 
 #if defined(__INTEL_COMPILER)
-#define _noalias restrict
+#define _noalias __restrict
 #elif defined(__GNUC__)
 #define _noalias __restrict
 #else


### PR DESCRIPTION
Using the 'restrict' directive does not compile with 'icpc' as it is a C directive and not a C++ one. 
It seems the compiler specific '__restrict' does the job.

This fixes #971.