### PR TITLE
better rRESPA doc page, also a new Makefile.theta

### DIFF
--- a/doc/src/run_style.txt
+++ b/doc/src/run_style.txt
@@ -138,13 +138,19 @@ iterations of level 1 for a single iteration of level 2, N2 is the
 iterations of level 2 per iteration of level 3, etc.  N-1 looping
 parameters must be specified.
 
-The "timestep"_timestep.html command sets the timestep for the
-outermost rRESPA level.  Thus if the example command above for a
-4-level rRESPA had an outer timestep of 4.0 fmsec, the inner timestep
-would be 8x smaller or 0.5 fmsec.  All other LAMMPS commands that
-specify number of timesteps (e.g. "neigh_modify"_neigh_modify.html
-parameters, "dump"_dump.html every N timesteps, etc) refer to the
-outermost timesteps.
+Thus with a 4-level respa setting of "2 2 2" for the 3 loop factors,
+you could choose to have bond interactions computed 8x per large
+timestep, angle interactions computed 4x, pair interactions computed
+2x, and long-range interactions once per large timestep.
+
+The "timestep"_timestep.html command sets the large timestep for the
+outermost rRESPA level.  Thus if the 3 loop factors are "2 2 2" for
+4-level rRESPA, and the outer timestep is set to 4.0 fmsec, then the
+inner timestep would be 8x smaller or 0.5 fmsec.  All other LAMMPS
+commands that specify number of timesteps (e.g. "thermo"_thermo.html
+for thermo output every N steps, "neigh_modify
+delay/every"_neigh_modify.html parameters, "dump"_dump.html every N
+steps, etc) refer to the outermost timesteps.
 
 The rRESPA keywords enable you to specify at what level of the
 hierarchy various forces will be computed.  If not specified, the
@@ -238,12 +244,24 @@ roughly a 1.5 fold speedup over the {verlet} style with SHAKE and a
 
 For non-biomolecular simulations, the {respa} style can be
 advantageous if there is a clear separation of time scales - fast and
-slow modes in the simulation.  Even a LJ system can benefit from
-rRESPA if the interactions are divided by the inner, middle and outer
-keywords.  A 2-fold or more speedup can be obtained while maintaining
-good energy conservation.  In real units, for a pure LJ fluid at
-liquid density, with a sigma of 3.0 angstroms, and epsilon of 0.1
-Kcal/mol, the following settings seem to work well:
+slow modes in the simulation.  For example, a system of slowly-moving
+charged polymer chains could be setup as follows:
+
+timestep 4.0
+run_style respa 2 8 :pre
+
+This is two-level rRESPA with an 8x difference between the short and
+long timesteps.  The bonds, angles, dihedrals will be computed every
+0.5 fs (assuming real units), while the pair and kspace interactions
+will be computed once every 4 fs.  These are the default settings for
+each kind of interaction, so no additional keywords are necessary.
+
+Even a LJ system can benefit from rRESPA if the interactions are
+divided by the inner, middle and outer keywords.  A 2-fold or more
+speedup can be obtained while maintaining good energy conservation.
+In real units, for a pure LJ fluid at liquid density, with a sigma of
+3.0 angstroms, and epsilon of 0.1 Kcal/mol, the following settings
+seem to work well:
 
 timestep  36.0
 run_style respa 3 3 4 inner 1 3.0 4.0 middle 2 6.0 7.0 outer 3 :pre
@@ -271,9 +289,9 @@ more instructions on how to use the accelerated styles effectively.
 [Restrictions:]
 
 The {verlet/split} style can only be used if LAMMPS was built with the
-REPLICA package. Correspondingly the {respa/omp} style is available only
-if the USER-OMP package was included. See the "Making LAMMPS"_Section_start.html#start_3
-section for more info on packages.
+REPLICA package. Correspondingly the {respa/omp} style is available
+only if the USER-OMP package was included. See the "Making
+LAMMPS"_Section_start.html#start_3 section for more info on packages.
 
 Whenever using rRESPA, the user should experiment with trade-offs in
 speed and accuracy for their system, and verify that they are
@@ -286,6 +304,17 @@ conserving energy to adequate precision.
 [Default:]
 
 run_style verlet :pre
+
+For run_style respa, the default assignment of interactions
+to rRESPA levels is as follows:
+
+bond forces = level 1 (innermost loop)
+angle forces = same level as bond forces
+dihedral forces = same level as angle forces
+improper forces = same level as dihedral forces
+pair forces = leven N (outermost level)
+kspace forces = same level as pair forces
+inner, middle, outer forces = no default :ul
 
 :line
 

--- a/src/MAKE/MACHINES/Makefile.theta
+++ b/src/MAKE/MACHINES/Makefile.theta
@@ -1,0 +1,133 @@
+# knl = Flags for Knights Landing Xeon Phi Processor,Intel Compiler/MPI,MKL FFT
+# module load perftools-base perftools
+# make theta -j 8
+# pat_build -g mpi -u ./lmp_theta
+
+SHELL = /bin/sh
+
+# ---------------------------------------------------------------------
+# compiler/linker settings
+# specify flags and libraries needed for your compiler
+
+CC =        CC -mkl
+#OPTFLAGS =       -O0
+OPTFLAGS =      -xMIC-AVX512 -O3 -fp-model fast=2 -no-prec-div -qoverride-limits
+CCFLAGS =   -g -qopenmp -DLAMMPS_MEMALIGN=64 -qno-offload \
+                -fno-alias -ansi-alias -restrict $(OPTFLAGS)
+#CCFLAGS +=      -DLMP_INTEL_NO_TBB
+#CCFLAGS +=      -DLAMMPS_BIGBIG
+#CCFLAGS +=      -D_USE_PAPI
+#CCFLAGS +=      -D_USE_CRAYPAT_API
+SHFLAGS =   -fPIC
+DEPFLAGS =  -M
+
+LINK =      $(CC)
+LINKFLAGS = -g -qopenmp $(OPTFLAGS)
+LINKFLAGS += -dynamic
+LIB =
+#LIB +=           -L${TBBROOT}/lib/intel64/gcc4.7 -ltbbmalloc
+LIB +=           -ltbbmalloc
+#LIB +=          /soft/debuggers/forge-7.0-2017-02-16/lib/64/libdmallocthcxx.a -zmuldefs
+SIZE =      size
+
+ARCHIVE =   ar
+ARFLAGS =   -rc
+SHLIBFLAGS =    -shared
+
+# ---------------------------------------------------------------------
+# LAMMPS-specific settings, all OPTIONAL
+# specify settings for LAMMPS features you will use
+# if you change any -D setting, do full re-compile after "make clean"
+
+# LAMMPS ifdef settings
+# see possible settings in Section 2.2 (step 4) of manual
+
+LMP_INC =   -DLAMMPS_GZIP #-DLAMMPS_JPEG
+
+# MPI library
+# see discussion in Section 2.2 (step 5) of manual
+# MPI wrapper compiler/linker can provide this info
+# can point to dummy MPI library in src/STUBS as in Makefile.serial
+# use -D MPICH and OMPI settings in INC to avoid C++ lib conflicts
+# INC = path for mpi.h, MPI compiler settings
+# PATH = path for MPI library
+# LIB = name of MPI library
+
+MPI_INC =       -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1
+MPI_PATH =
+MPI_LIB =
+
+# FFT library
+# see discussion in Section 2.2 (step 6) of manaul
+# can be left blank to use provided KISS FFT library
+# INC = -DFFT setting, e.g. -DFFT_FFTW, FFT compiler settings
+# PATH = path for FFT library
+# LIB = name of FFT library
+
+FFT_INC =       -DFFT_MKL -DFFT_SINGLE
+FFT_PATH =
+FFT_LIB =       -L$(MKLROOT)/lib/intel64/ -Wl,--start-group -lmkl_intel_ilp64 \
+                -lmkl_intel_thread -lmkl_core -Wl,--end-group
+
+# JPEG and/or PNG library
+# see discussion in Section 2.2 (step 7) of manual
+# only needed if -DLAMMPS_JPEG or -DLAMMPS_PNG listed with LMP_INC
+# INC = path(s) for jpeglib.h and/or png.h
+# PATH = path(s) for JPEG library and/or PNG library
+# LIB = name(s) of JPEG library and/or PNG library
+
+JPG_INC =
+JPG_PATH =
+JPG_LIB =
+
+# ---------------------------------------------------------------------
+# build rules and dependencies
+# do not edit this section
+
+include Makefile.package.settings
+include Makefile.package
+
+EXTRA_INC = $(LMP_INC) $(PKG_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+
+# Path to src files
+
+vpath %.cpp ..
+vpath %.h ..
+
+# Link target
+
+$(EXE): $(OBJ)
+    $(LINK) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(EXTRA_LIB) $(LIB) -o $(EXE)
+    $(SIZE) $(EXE)
+
+# Library targets
+
+lib:    $(OBJ)
+    $(ARCHIVE) $(ARFLAGS) $(EXE) $(OBJ)
+
+shlib:  $(OBJ)
+    $(CC) $(CCFLAGS) $(SHFLAGS) $(SHLIBFLAGS) $(EXTRA_PATH) -o $(EXE) \
+        $(OBJ) $(EXTRA_LIB) $(LIB)
+
+# Compilation rules
+
+%.o:%.cpp
+    $(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+%.d:%.cpp
+    $(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+
+%.o:%.cu
+    $(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+# Individual dependencies
+
+depend : fastdep.exe $(SRC)
+    @./fastdep.exe $(EXTRA_INC) -- $^ > .depend || exit 1
+
+fastdep.exe: ../DEPEND/fastdep.c
+    icc -O -o $@ $<
+
+sinclude .depend


### PR DESCRIPTION
## Purpose

More explanation of rRESPA options on the run_style doc page.  Also a new
Makefile.theta for the ALCF Theta machine from the ALCF folks.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


