### PR TITLE
Fixes #995: Added tail correction to fix gcmc

### DIFF
--- a/doc/src/fix_gcmc.txt
+++ b/doc/src/fix_gcmc.txt
@@ -349,7 +349,7 @@ in the context of NVT dynamics.
 NOTE: If the density of the cell is initially very small or zero, and
 increases to a much larger density after a period of equilibration,
 then certain quantities that are only calculated once at the start
-(kspace parameters, tail corrections) may no longer be accurate.  The
+(kspace parameters) may no longer be accurate.  The
 solution is to start a new simulation after the equilibrium density
 has been reached.
 

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -1589,6 +1589,7 @@ void FixGCMC::attempt_atomic_deletion_full()
     }
   }
   if (force->kspace) force->kspace->qsum_qsq();
+  if (force->pair->tail_flag) force->pair->reinit();
   double energy_after = energy_full();
 
   if (random_equal->uniform() <
@@ -1607,6 +1608,7 @@ void FixGCMC::attempt_atomic_deletion_full()
       if (q_flag) atom->q[i] = q_tmp;
     }
     if (force->kspace) force->kspace->qsum_qsq();
+    if (force->pair->tail_flag) force->pair->reinit();
     energy_stored = energy_before;
   }
   update_gas_atoms_list();
@@ -1700,6 +1702,7 @@ void FixGCMC::attempt_atomic_insertion_full()
   comm->borders();
   if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
   if (force->kspace) force->kspace->qsum_qsq();
+  if (force->pair->tail_flag) force->pair->reinit();
   double energy_after = energy_full();
 
   if (energy_after < MAXENERGYTEST &&
@@ -1712,6 +1715,7 @@ void FixGCMC::attempt_atomic_insertion_full()
     atom->natoms--;
     if (proc_flag) atom->nlocal--;
     if (force->kspace) force->kspace->qsum_qsq();
+    if (force->pair->tail_flag) force->pair->reinit();
     energy_stored = energy_before;
   }
   update_gas_atoms_list();
@@ -1949,6 +1953,7 @@ void FixGCMC::attempt_molecule_deletion_full()
     }
   }
   if (force->kspace) force->kspace->qsum_qsq();
+  if (force->pair->tail_flag) force->pair->reinit();
   double energy_after = energy_full();
 
   // energy_before corrected by energy_intra
@@ -1981,6 +1986,7 @@ void FixGCMC::attempt_molecule_deletion_full()
       }
     }
     if (force->kspace) force->kspace->qsum_qsq();
+    if (force->pair->tail_flag) force->pair->reinit();
   }
   update_gas_atoms_list();
   delete[] tmpmask;
@@ -2151,6 +2157,7 @@ void FixGCMC::attempt_molecule_insertion_full()
   comm->borders();
   if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
   if (force->kspace) force->kspace->qsum_qsq();
+  if (force->pair->tail_flag) force->pair->reinit();
   double energy_after = energy_full();
 
   // energy_after corrected by energy_intra
@@ -2181,6 +2188,7 @@ void FixGCMC::attempt_molecule_insertion_full()
       } else i++;
     }
     if (force->kspace) force->kspace->qsum_qsq();
+    if (force->pair->tail_flag) force->pair->reinit();
   }
   update_gas_atoms_list();
 }


### PR DESCRIPTION
## Purpose

Adds the tail corrections to the `fix gcmc` during insertions and deletions

## Author(s)

Marshall McDonnell (Oak Ridge National Laboratory)

## Backward Compatibility

This will not change the inputs. Yet, the results from previous computations will most likely change. 

## Implementation Notes

Following the "Steps to Reproduce" in Issue #995, adding the necessary lines for testing and using the input script provided there, the output is now:

```
tail before -4845.920013 tail after -4923.764872
```

Thus, the tail correction is changing due to changes in density. Also, the `energy_after` for this insertion was compared to the current version of LAMMPS (29 Jun 2018) without these changes. The energies were in fact different exactly by the difference in the tail corrections above.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included *N/A*
- [x] One or more example input decks are included *N/A*
- [x] The source code follows the LAMMPS formatting guidelines 
