### PR TITLE
2 small bug fixes to load balancing

### DIFF
--- a/doc/src/run_style.txt
+++ b/doc/src/run_style.txt
@@ -173,11 +173,17 @@ have their force go ramped to 0.0 so the overlap with the next regime
 compute forces for all pairs from 5.0 outward, with those from 5.0 to
 6.0 having their value ramped in an inverse manner.
 
-Only some pair potentials support the use of the {inner} and {middle}
-and {outer} keywords.  If not, only the {pair} keyword can be used
-with that pair style, meaning all pairwise forces are computed at the
-same rRESPA level.  See the doc pages for individual pair styles for
-details.i
+Note that you can use {inner} and {outer} without using {middle} to
+split the pairwise computations into two portions instead of three.
+Unless you are using a very long pairwise cutoff, a 2-way split is
+often faster than a 3-way split, since it avoids too much duplicate
+computation of pairwise interactions near the intermediate cutoffs.
+
+Also note that only a few pair potentials support the use of the
+{inner} and {middle} and {outer} keywords.  If not, only the {pair}
+keyword can be used with that pair style, meaning all pairwise forces
+are computed at the same rRESPA level.  See the doc pages for
+individual pair styles for details.
 
 Another option for using pair potentials with rRESPA is with the
 {hybrid} keyword, which requires the use of the "pair_style hybrid or

--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -350,13 +350,13 @@ void Balance::command(int narg, char **arg)
   domain->set_local_box();
 
   // move particles to new processors via irregular()
+  // set disable = 0, so weights migrate with atoms for imbfinal calculation
 
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
   Irregular *irregular = new Irregular(lmp);
   if (wtflag) fixstore->disable = 0;
   if (style == BISECTION) irregular->migrate_atoms(1,1,rcb->sendproc);
   else irregular->migrate_atoms(1);
-  if (wtflag) fixstore->disable = 1;
   delete irregular;
   if (domain->triclinic) domain->lamda2x(atom->nlocal);
 
@@ -377,9 +377,11 @@ void Balance::command(int narg, char **arg)
   }
 
   // imbfinal = final imbalance
+  // set disable = 1, so weights no longer migrate with atoms
 
   double maxfinal;
   double imbfinal = imbalance_factor(maxfinal);
+  if (wtflag) fixstore->disable = 1;
 
   // stats output
 
@@ -539,6 +541,8 @@ void Balance::weight_storage(char *prefix)
     modify->add_fix(6,fixargs);
     fixstore = (FixStore *) modify->fix[modify->nfix-1];
   } else fixstore = (FixStore *) modify->fix[ifix];
+
+  // do not carry weights with atoms during normal atom migration
 
   fixstore->disable = 1;
 

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -114,6 +114,7 @@ FixBalance::FixBalance(LAMMPS *lmp, int narg, char **arg) :
 
   if (nevery) force_reneighbor = 1;
   lastbalance = -1;
+  next_reneighbor = -1;
 
   // compute initial outputs
 
@@ -248,6 +249,10 @@ void FixBalance::pre_neighbor()
   if (!pending) return;
   imbfinal = balance->imbalance_factor(maxloadperproc);
   pending = 0;
+
+  // set disable = 1, so weights no longer migrate with atoms
+
+  if (wtflag) balance->fixstore->disable = 1;
 }
 
 /* ----------------------------------------------------------------------
@@ -275,21 +280,23 @@ void FixBalance::rebalance()
 
   // reset proc sub-domains
   // check and warn if any proc's subbox is smaller than neigh skin
-  //   since may lead to lost atoms in exchange()
+  //   since may lead to lost atoms in comm->exchange()
 
   if (domain->triclinic) domain->set_lamda_box();
   domain->set_local_box();
   domain->subbox_too_small_check(neighbor->skin);
 
   // move atoms to new processors via irregular()
-  // only needed if migrate_check() says an atom moves to far
+  // for non-RCB only needed if migrate_check() says an atom moves too far
   // else allow caller's comm->exchange() to do it
+  // set disable = 0, so weights migrate with atoms
+  //   important to delay disable = 1 until after pre_neighbor imbfinal calc
+  //   b/c atoms may migrate again in comm->exchange()
 
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
   if (wtflag) balance->fixstore->disable = 0;
   if (lbstyle == BISECTION) irregular->migrate_atoms(0,1,sendproc);
   else if (irregular->migrate_check()) irregular->migrate_atoms();
-  if (wtflag) balance->fixstore->disable = 1;
   if (domain->triclinic) domain->lamda2x(atom->nlocal);
 
   // invoke KSpace setup_grid() to adjust to new proc sub-domains

--- a/src/fix_store.cpp
+++ b/src/fix_store.cpp
@@ -154,8 +154,6 @@ void FixStore::reset_global(int nrow_caller, int ncol_caller)
   if (vecflag) memory->create(vstore,nrow,"fix/store:vstore");
   else memory->create(astore,nrow,ncol,"fix/store:astore");
   memory->create(rbuf,nrow*ncol+2,"fix/store:rbuf");
-
- // printf("AAA HOW GET HERE\n");
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Two small bug fixes to load balancing.  One for an uninitialized variable.  The
other for turning off weight migration too soon before the final
imbalance factor was computed.  Both could lead to valgrind issues
with unitialized memory being accessed or even a hang for the first one.

Thanks to Jon Bollinger (Sandia) for sending a test script to debug with.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


