### PR TITLE
docs: Fix sneaky unicode character

### DIFF
--- a/doc/src/Developer/developer.tex
+++ b/doc/src/Developer/developer.tex
@@ -476,7 +476,7 @@ is the name of the class. This code allows LAMMPS to find your fix
 when it parses input script. In addition, your fix header must be
 included in the file "style\_fix.h". In case if you use LAMMPS make,
 this file is generated automatically - all files starting with prefix
-fix\_ are included, so call your header the same way. Otherwise, don’t
+fix\_ are included, so call your header the same way. Otherwise, don't
 forget to add your include into "style\_fix.h".
 
 Let's write a simple fix which will print average velocity at the end


### PR DESCRIPTION
## Purpose

Fixes the `pdf` target of the `Makefile`.

## Author(s)

Rohit Goswami <rohit.goswami@aol.com>

There really doesn't need to be any attribution for this.

## Backward Compatibility

Totally compatible. Fixes a bug.

## Implementation Notes

N/A

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
N/A
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

I'm surprised no-one noticed this before.

