### PR TITLE
include support for 'extra/XXX/per/atom' info in restart files

### DIFF
--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -62,7 +62,9 @@ enum{VERSION,SMALLINT,TAGINT,BIGINT,
      MULTIPROC,MPIIO,PROCSPERFILE,PERPROC,
      IMAGEINT,BOUNDMIN,TIMESTEP,
      ATOM_ID,ATOM_MAP_STYLE,ATOM_MAP_USER,ATOM_SORTFREQ,ATOM_SORTBIN,
-     COMM_MODE,COMM_CUTOFF,COMM_VEL,NO_PAIR};
+     COMM_MODE,COMM_CUTOFF,COMM_VEL,NO_PAIR,
+     EXTRA_BOND_PER_ATOM,EXTRA_ANGLE_PER_ATOM,EXTRA_DIHEDRAL_PER_ATOM,
+     EXTRA_IMPROPER_PER_ATOM,EXTRA_SPECIAL_PER_ATOM};
 
 #define LB_FACTOR 1.1
 
@@ -913,6 +915,17 @@ void ReadRestart::header(int incompatible)
       comm->cutghostuser = read_double();
     } else if (flag == COMM_VEL) {
       comm->ghost_velocity = read_int();
+
+    } else if (flag == EXTRA_BOND_PER_ATOM) {
+      atom->extra_bond_per_atom = read_int();
+    } else if (flag == EXTRA_ANGLE_PER_ATOM) {
+      atom->extra_angle_per_atom = read_int();
+    } else if (flag == EXTRA_DIHEDRAL_PER_ATOM) {
+      atom->extra_dihedral_per_atom = read_int();
+    } else if (flag == EXTRA_IMPROPER_PER_ATOM) {
+      atom->extra_improper_per_atom = read_int();
+    } else if (flag == EXTRA_SPECIAL_PER_ATOM) {
+      force->special_extra = read_int();
 
     } else error->all(FLERR,"Invalid flag in header section of restart file");
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -61,7 +61,9 @@ enum{VERSION,SMALLINT,TAGINT,BIGINT,
      MULTIPROC,MPIIO,PROCSPERFILE,PERPROC,
      IMAGEINT,BOUNDMIN,TIMESTEP,
      ATOM_ID,ATOM_MAP_STYLE,ATOM_MAP_USER,ATOM_SORTFREQ,ATOM_SORTBIN,
-     COMM_MODE,COMM_CUTOFF,COMM_VEL,NO_PAIR};
+     COMM_MODE,COMM_CUTOFF,COMM_VEL,NO_PAIR,
+     EXTRA_BOND_PER_ATOM,EXTRA_ANGLE_PER_ATOM,EXTRA_DIHEDRAL_PER_ATOM,
+     EXTRA_IMPROPER_PER_ATOM,EXTRA_SPECIAL_PER_ATOM};
 
 /* ---------------------------------------------------------------------- */
 
@@ -526,6 +528,12 @@ void WriteRestart::header()
   write_int(COMM_MODE,comm->mode);
   write_double(COMM_CUTOFF,comm->cutghostuser);
   write_int(COMM_VEL,comm->ghost_velocity);
+
+  write_int(EXTRA_BOND_PER_ATOM,atom->extra_bond_per_atom);
+  write_int(EXTRA_ANGLE_PER_ATOM,atom->extra_angle_per_atom);
+  write_int(EXTRA_DIHEDRAL_PER_ATOM,atom->extra_dihedral_per_atom);
+  write_int(EXTRA_IMPROPER_PER_ATOM,atom->extra_improper_per_atom);
+  write_int(EXTRA_SPECIAL_PER_ATOM,force->special_extra);
 
   // -1 flag signals end of header
 


### PR DESCRIPTION
## Purpose

when restarting simulations that will form bonds via fix bond/create or fix bond/react, sometimes extra space for future bonds, angles, etc. will have to be reserved. when starting initially, that is possible via keywords to create_box and read_data. however, upon reading a restart, this information is not preserved. The change in this pull request add support to record these settings in restart files and read them back.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

Reading older restarts without these new settings is unaffected, but - of course - the various "extra" settings are not available.

## Implementation Notes

New elements were added at the end of the enumerator and the end of the read/write section for maximum compatibility.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [n/a] Suitable new documentation files and/or updates to the existing docs are included
- [n/a] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines


