### PR TITLE
USER-DPD: propagate a minor performance bugfix throughout the DPDE code

### DIFF
--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -157,7 +157,6 @@ void FixShardlowKokkos<DeviceType>::init()
   k_pairDPDE->k_cutsq.template sync<DeviceType>();
   d_cutsq = k_pairDPDE->k_cutsq.template view<DeviceType>();
 
-  const double boltz2 = 2.0*force->boltz;
   for (int i = 1; i <= ntypes; i++) {
     for (int j = i; j <= ntypes; j++) {
       F_FLOAT cutone = k_pairDPDE->cut[i][j];
@@ -165,7 +164,7 @@ void FixShardlowKokkos<DeviceType>::init()
       else k_params.h_view(i,j).cutinv = FLT_MAX;
       k_params.h_view(i,j).halfsigma = 0.5*k_pairDPDE->sigma[i][j];
       k_params.h_view(i,j).kappa = k_pairDPDE->kappa[i][j];
-      k_params.h_view(i,j).alpha = sqrt(boltz2*k_pairDPDE->kappa[i][j]);
+      k_params.h_view(i,j).alpha = k_pairDPDE->alpha[i][j];
 
       k_params.h_view(j,i) = k_params.h_view(i,j);
 

--- a/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
+++ b/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
@@ -591,7 +591,7 @@ void PairDPDfdtEnergyKokkos<DeviceType>::operator()(TagPairDPDfdtEnergyComputeNo
       // Compute uCond
       randnum = rand_gen.normal();
       kappa_ij = STACKPARAMS?m_params[itype][jtype].kappa:params(itype,jtype).kappa;
-      alpha_ij = sqrt(2.0*boltz*kappa_ij);
+      alpha_ij = STACKPARAMS?m_params[itype][jtype].alpha:params(itype,jtype).alpha;
       randPair = alpha_ij*wr*randnum*dtinvsqrt;
 
       uTmp = kappa_ij*(1.0/dpdTheta[i] - 1.0/dpdTheta[j])*wd;
@@ -676,6 +676,7 @@ double PairDPDfdtEnergyKokkos<DeviceType>::init_one(int i, int j)
   k_params.h_view(i,j).a0 = a0[i][j];
   k_params.h_view(i,j).sigma = sigma[i][j];
   k_params.h_view(i,j).kappa = kappa[i][j];
+  k_params.h_view(i,j).alpha = alpha[i][j];
   k_params.h_view(j,i) = k_params.h_view(i,j);
   if(i<MAX_TYPES_STACKPARAMS+1 && j<MAX_TYPES_STACKPARAMS+1) {
     m_params[i][j] = m_params[j][i] = k_params.h_view(i,j);

--- a/src/KOKKOS/pair_dpd_fdt_energy_kokkos.h
+++ b/src/KOKKOS/pair_dpd_fdt_energy_kokkos.h
@@ -88,10 +88,10 @@ class PairDPDfdtEnergyKokkos : public PairDPDfdtEnergy {
 
   struct params_dpd {
     KOKKOS_INLINE_FUNCTION
-    params_dpd(){cut=0;a0=0;sigma=0;kappa=0;};
+    params_dpd(){cut=0;a0=0;sigma=0;kappa=0;alpha=0;};
     KOKKOS_INLINE_FUNCTION
-    params_dpd(int i){cut=0;a0=0;sigma=0;kappa=0;};
-    F_FLOAT cut,a0,sigma,kappa;
+    params_dpd(int i){cut=0;a0=0;sigma=0;kappa=0;alpha=0;};
+    F_FLOAT cut,a0,sigma,kappa,alpha;
   };
 
   DAT::tdual_efloat_1d k_duCond,k_duMech;

--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -354,9 +354,8 @@ void FixShardlow::ssa_update_dpde(
   double *uMech = atom->uMech;
   double *dpdTheta = atom->dpdTheta;
 
-  double *cut_i, *cut2_i, *sigma_i, *kappa_i;
+  double *cut_i, *cut2_i, *sigma_i, *kappa_i, *alpha_i;
   double theta_ij_inv, theta_i_inv;
-  const double boltz2 = 2.0*force->boltz;
   const double boltz_inv = 1.0/force->boltz;
   const double ftm2v = force->ftm2v;
 
@@ -389,6 +388,7 @@ while (ct-- > 0) {
   cut_i  = pairDPDE->cut[itype];
   sigma_i = pairDPDE->sigma[itype];
   kappa_i = pairDPDE->kappa[itype];
+  alpha_i = pairDPDE->alpha[itype];
   theta_i_inv = 1.0/dpdTheta[i];
   const double mass_i = (rmass) ? rmass[i] : mass[itype];
   const double massinv_i = 1.0 / mass_i;
@@ -448,7 +448,7 @@ while (ct-- > 0) {
 
       // Compute uCond
       double kappa_ij = kappa_i[jtype];
-      double alpha_ij = sqrt(boltz2*kappa_ij);
+      double alpha_ij = alpha_i[jtype];
       double del_uCond = alpha_ij*wr*dtsqrt * es_normal(RNGstate);
 
       del_uCond += kappa_ij*(theta_i_inv - theta_j_inv)*wdt;

--- a/src/USER-DPD/pair_dpd_fdt_energy.h
+++ b/src/USER-DPD/pair_dpd_fdt_energy.h
@@ -43,7 +43,7 @@ class PairDPDfdtEnergy : public Pair {
 
   double **cut;
   double **a0;
-  double **sigma,**kappa;
+  double **sigma,**kappa,**alpha;
   double *duCond,*duMech;
 
   int seed;


### PR DESCRIPTION
## Purpose

The fix_shardlow_kokkos.cpp code had already factored out a redundant
sqrt() calculation in the innermost loop of ssa_update_dpde().  This
changeset propagates an equivalent optimization to:
  fix_shardlow.cpp
  pair_dpd_fdt_energy.cpp
  pair_dpd_fdt_energy_kokkos.cpp

## Author(s)

Tim Mattox (Engility)

## Backward Compatibility

No Backward Compatibility issues.

## Implementation Notes

The alpha_ij variable was really just an [itype][jtype] lookup parameter,
replacing a sqrt() and two multiplies per interacting particle pair
by a cached memory read.  Even if there isn't much time savings, the
code is now consistent across the various versions.
It passed our suite of regression tests for USER-DPD.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [X] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links
N/A


