### PR TITLE
Fixes a memory leak when using OpenCL

### DIFF
--- a/lib/gpu/geryon/ocl_timer.h
+++ b/lib/gpu/geryon/ocl_timer.h
@@ -49,8 +49,6 @@ class UCL_Timer {
   inline void clear() {
     if (_initialized) {
       CL_DESTRUCT_CALL(clReleaseCommandQueue(_cq));
-      clReleaseEvent(start_event);
-      clReleaseEvent(stop_event);
       _initialized=false;
       _total_time=0.0;
     }
@@ -107,6 +105,8 @@ class UCL_Timer {
     CL_SAFE_CALL(clGetEventProfilingInfo(start_event,
                                          CL_PROFILING_COMMAND_END,
                                          sizeof(cl_ulong), &tstart, NULL));
+    clReleaseEvent(start_event);
+    clReleaseEvent(stop_event);
     return (tend-tstart)*t_factor;
   }
 


### PR DESCRIPTION
## Purpose

The GPU package uses OpenCL events for measuring time. These have to be
released to free up memory. I also removed the `clReleaseEvent()` calls in the
clear() method because in some cases they don't exist yet and I couldn't
find a way to check for a valid event (`clRetainEvent` didn't work). This
at least fixes the massive leak during simulations.

See issue #1006

Running the melt example:
```bash
valgrind --tool=massif lmp -in in.melt -pk gpu 1 device generic -sf gpu
```

Before fix:
![before](https://user-images.githubusercontent.com/2828630/42912439-64b368de-8abd-11e8-832e-aeea6b8b5fbb.png)

After fix:
![after](https://user-images.githubusercontent.com/2828630/42912445-6989184a-8abd-11e8-949a-cd93aacd58c7.png)

## Author(s)

@rbberger

## Backward Compatibility

Yes

## Implementation Notes

Couldn't find a way to make the clear() function work, since I would have to check if a `cl_event` is valid. `clRetainEvent` crashed on my system with a segfault.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
