### PR TITLE
Re-allow commands after an exception was caught inside a run.

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -16,6 +16,7 @@
 #include <cstring>
 #include "error.h"
 #include "universe.h"
+#include "update.h"
 #include "output.h"
 #include "input.h"
 
@@ -69,6 +70,10 @@ void Error::universe_all(const char *file, int line, const char *str)
   if (universe->ulogfile) fclose(universe->ulogfile);
 
 #ifdef LAMMPS_EXCEPTIONS
+
+  // allow commands if an exception was caught in a run
+  update->whichflag = 0;
+
   char msg[100];
   sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
   throw LAMMPSException(msg);
@@ -90,6 +95,10 @@ void Error::universe_one(const char *file, int line, const char *str)
             universe->me,str,truncpath(file),line);
 
 #ifdef LAMMPS_EXCEPTIONS
+
+  // allow commands if an exception was caught in a run
+  update->whichflag = 0;
+
   char msg[100];
   sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
   throw LAMMPSAbortException(msg, universe->uworld);
@@ -137,6 +146,10 @@ void Error::all(const char *file, int line, const char *str)
   }
 
 #ifdef LAMMPS_EXCEPTIONS
+
+  // allow commands if an exception was caught in a run
+  update->whichflag = 0;
+
   char msg[100];
   sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
 
@@ -183,6 +196,10 @@ void Error::one(const char *file, int line, const char *str)
               universe->me,str,truncpath(file),line);
 
 #ifdef LAMMPS_EXCEPTIONS
+
+  // allow commands if an exception was caught in a run
+  update->whichflag = 0;
+
   char msg[100];
   sprintf(msg, "ERROR on proc %d: %s (%s:%d)\n", me, str, file, line);
   throw LAMMPSAbortException(msg, world);


### PR DESCRIPTION
## Purpose

This PR lifts a restriction where when using the library interface it became impossible to recover the calculation via issuing a `clear` command and starting over. 

After an exception "all bets are off", i.e. the user should be allowed to do anything to recover.
Through setting `Update::whichflag` to 0, the guard against running commands during a run is removed.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

Yes, indeed it lifts an incompatibility when the library interface was protected to issue LAMMPS commands from inside a run in a specific (and valid!) case.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
