### PR TITLE
USER/diffraction: change ave/histo to ave/histo/weight

### DIFF
--- a/examples/USER/diffraction/BulkNi.in
+++ b/examples/USER/diffraction/BulkNi.in
@@ -20,7 +20,7 @@ compute         XRD all xrd  1.541838 Ni 2Theta 40 80 c 2 2 2 LP 1 echo
 compute         SAED all saed 0.0251  Ni Kmax 0.85 Zone 1 0 0 c 0.025 0.025 0.025  &
                 dR_Ewald 0.05 echo manual
 
-fix             1 all ave/histo 1 1 1 40 80 200 c_XRD[1] c_XRD[2] &
+fix             1 all ave/histo/weight 1 1 1 40 80 200 c_XRD[1] c_XRD[2] &
                 mode vector file $A.hist.xrd
 
 fix             2 all saed/vtk 1 1 1 c_SAED file $A_001.saed 


### PR DESCRIPTION
## Purpose

The example ``examples/USER/diffraction/BulkNi.in`` was not changed when ``fix ave/histo`` was changed.

The documentation of ``compute xrd`` is updated, only the example was not working anymore. 
(wrong results)

