### PR TITLE
Allow cross-compiling from linux to windows with cmake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -138,8 +138,11 @@ set_property(CACHE LAMMPS_SIZE_LIMIT PROPERTY STRINGS LAMMPS_SMALLBIG LAMMPS_BIG
 add_definitions(-D${LAMMPS_SIZE_LIMIT})
 set(LAMMPS_API_DEFINES "${LAMMPS_API_DEFINES} -D${LAMMPS_SIZE_LIMIT}")
 
-set(LAMMPS_MEMALIGN "64" CACHE STRING "enables the use of the posix_memalign() call instead of malloc() when large chunks or memory are allocated by LAMMPS")
-add_definitions(-DLAMMPS_MEMALIGN=${LAMMPS_MEMALIGN})
+# posix_memalign is not available on Windows
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+  set(LAMMPS_MEMALIGN "64" CACHE STRING "enables the use of the posix_memalign() call instead of malloc() when large chunks or memory are allocated by LAMMPS")
+  add_definitions(-DLAMMPS_MEMALIGN=${LAMMPS_MEMALIGN})
+endif()
 
 option(LAMMPS_EXCEPTIONS "enable the use of C++ exceptions for error messages (useful for library interface)" OFF)
 if(LAMMPS_EXCEPTIONS)
@@ -467,6 +470,11 @@ if(PKG_COMPRESS)
   list(APPEND LAMMPS_LINK_LIBS ${ZLIB_LIBRARIES})
 endif()
 
+# the windows version of LAMMPS requires a couple extra libraries
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+  list(APPEND LAMMPS_LINK_LIBS -lwsock32 -lpsapi)
+endif()
+
 ########################################################################
 # Basic system tests (standard libraries, headers, functions, types)   #
 ########################################################################
@@ -625,6 +633,10 @@ if(PKG_USER-OMP)
     get_property(USER-OMP_SOURCES GLOBAL PROPERTY OMP_SOURCES)
 
     # manually add package dependent source files from USER-OMP that do not provide styles
+
+    if(PKG_ASPHERE)
+      list(APPEND USER-OMP_SOURCES ${USER-OMP_SOURCES_DIR}/fix_nh_asphere_omp.cpp)
+    endif()
 
     if(PKG_RIGID)
       list(APPEND USER-OMP_SOURCES ${USER-OMP_SOURCES_DIR}/fix_rigid_nh_omp.cpp)


### PR DESCRIPTION
## Purpose

A few small modifications to CMake configurations, that allow cross-compiling from Linux to Windows using the Fedora MingGW toolchain and `mingw32-cmake` or `mingw64-cmake`.

In addition one more package dependency issue has been resolved (for ASPHERE vs. USER-OMP)

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

n/a

## Implementation Notes

Linking on windows requires a couple more libraries, so they need to be added explicitly for windows targets. Also `posix_memalign()` is not available, so that feature will have to be skipped.

No support for MPI yet, as this requires a custom thirdparty set of headers and binaries.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

