### PR TITLE
Kokkos vs gpu direct

### DIFF
--- a/doc/src/Speed_kokkos.txt
+++ b/doc/src/Speed_kokkos.txt
@@ -102,12 +102,9 @@ the case, especially when using pre-compiled MPI libraries provided by
 a Linux distribution. This is not a problem when using only a single
 GPU and a single MPI rank on a desktop. When running with multiple
 MPI ranks, you may see segmentation faults without GPU-direct support.
-Many of those can be avoided by adding the flags '-pk kokkos comm no'
-to the LAMMPS command line or using "package kokkos comm on"_package.html
-in the input file, however for some KOKKOS enabled styles like 
-"EAM"_pair_eam.html or "PPPM"_kspace_style.html, this is not the case
-and a GPU-direct enabled MPI library is REQUIRED.
-
+These can be avoided by adding the flags '-pk kokkos comm no gpu/direct no'
+to the LAMMPS command line or using "package kokkos comm no gpu/direct no"_package.html
+in the input file.
 
 Use a C++11 compatible compiler and set KOKKOS_ARCH variable in
 /src/MAKE/OPTIONS/Makefile.kokkos_cuda_mpi for both GPU and CPU as

--- a/doc/src/Speed_kokkos.txt
+++ b/doc/src/Speed_kokkos.txt
@@ -96,6 +96,19 @@ software version 7.5 or later must be installed on your system. See
 the discussion for the "GPU package"_Speed_gpu.html for details of how
 to check and do this.
 
+NOTE: Kokkos with CUDA currently implicitly assumes, that the MPI
+library is CUDA-aware and has support for GPU-direct. This is not always
+the case, especially when using pre-compiled MPI libraries provided by
+a Linux distribution. This is not a problem when using only a single
+GPU and a single MPI rank on a desktop. When running with multiple
+MPI ranks, you may see segmentation faults without GPU-direct support.
+Many of those can be avoided by adding the flags '-pk kokkos comm no'
+to the LAMMPS command line or using "package kokkos comm on"_package.html
+in the input file, however for some KOKKOS enabled styles like 
+"EAM"_pair_eam.html or "PPPM"_kspace_style.html, this is not the case
+and a GPU-direct enabled MPI library is REQUIRED.
+
+
 Use a C++11 compatible compiler and set KOKKOS_ARCH variable in
 /src/MAKE/OPTIONS/Makefile.kokkos_cuda_mpi for both GPU and CPU as
 described above.  Then do the following:
@@ -262,9 +275,12 @@ the # of physical GPUs on the node.  You can assign multiple MPI tasks
 to the same GPU with the KOKKOS package, but this is usually only
 faster if significant portions of the input script have not been
 ported to use Kokkos. Using CUDA MPS is recommended in this
-scenario. As above for multi-core CPUs (and no GPU), if N is the
-number of physical cores/node, then the number of MPI tasks/node
-should not exceed N.
+scenario. Using a CUDA-aware MPI library with support for GPU-direct
+is highly recommended and for some KOKKOS-enabled styles even required.
+Most GPU-direct use can be avoided by using "-pk kokkos comm no".
+As above for multi-core CPUs (and no GPU), if N is the number of
+physical cores/node, then the number of MPI tasks/node should not
+exceed N.
 
 -k on g Ng :pre
 

--- a/doc/src/Speed_kokkos.txt
+++ b/doc/src/Speed_kokkos.txt
@@ -102,8 +102,8 @@ the case, especially when using pre-compiled MPI libraries provided by
 a Linux distribution. This is not a problem when using only a single
 GPU and a single MPI rank on a desktop. When running with multiple
 MPI ranks, you may see segmentation faults without GPU-direct support.
-These can be avoided by adding the flags '-pk kokkos comm no gpu/direct no'
-to the LAMMPS command line or using "package kokkos comm no gpu/direct no"_package.html
+These can be avoided by adding the flags '-pk kokkos gpu/direct no'
+to the LAMMPS command line or using "package kokkos gpu/direct no"_package.html
 in the input file.
 
 Use a C++11 compatible compiler and set KOKKOS_ARCH variable in
@@ -273,8 +273,7 @@ to the same GPU with the KOKKOS package, but this is usually only
 faster if significant portions of the input script have not been
 ported to use Kokkos. Using CUDA MPS is recommended in this
 scenario. Using a CUDA-aware MPI library with support for GPU-direct
-is highly recommended and for some KOKKOS-enabled styles even required.
-Most GPU-direct use can be avoided by using "-pk kokkos comm no".
+is highly recommended. GPU-direct use can be avoided by using "-pk kokkos gpu/direct no".
 As above for multi-core CPUs (and no GPU), if N is the number of
 physical cores/node, then the number of MPI tasks/node should not
 exceed N.

--- a/doc/src/Speed_kokkos.txt
+++ b/doc/src/Speed_kokkos.txt
@@ -102,9 +102,9 @@ the case, especially when using pre-compiled MPI libraries provided by
 a Linux distribution. This is not a problem when using only a single
 GPU and a single MPI rank on a desktop. When running with multiple
 MPI ranks, you may see segmentation faults without GPU-direct support.
-These can be avoided by adding the flags '-pk kokkos gpu/direct no'
-to the LAMMPS command line or using "package kokkos gpu/direct no"_package.html
-in the input file.
+These can be avoided by adding the flags '-pk kokkos gpu/direct off'
+to the LAMMPS command line or by using the command
+"package kokkos gpu/direct off"_package.html in the input file.
 
 Use a C++11 compatible compiler and set KOKKOS_ARCH variable in
 /src/MAKE/OPTIONS/Makefile.kokkos_cuda_mpi for both GPU and CPU as

--- a/doc/src/package.txt
+++ b/doc/src/package.txt
@@ -507,10 +507,10 @@ typically faster to let the host handle communication, by using the
 {host} value.  Using {host} instead of {no} will enable use of
 multiple threads to pack/unpack communicated data.
 
-The {gpu/direct} keyword chooses whether GPU-direct will be used. When 
-this keyword is set to {on}, buffers in GPU memory are passed directly 
-through MPI send/receive calls. This reduces overhead of first copying 
-the data to the host CPU. However GPU-direct is not supported on all 
+The {gpu/direct} keyword chooses whether GPU-direct will be used. When
+this keyword is set to {on}, buffers in GPU memory are passed directly
+through MPI send/receive calls. This reduces overhead of first copying
+the data to the host CPU. However GPU-direct is not supported on all
 systems, which can lead to segmentation faults and would require
 using a value of {off}. When the {gpu/direct} keyword is set to {off}
 while any of the {comm} keywords are set to {device}, the value for the
@@ -622,12 +622,12 @@ is used.  If it is not used, you must invoke the package intel
 command in your input script or or via the "-pk intel" "command-line
 switch"_Section_start.html#start_6.
 
-For the KOKKOS package, the option defaults neigh = full, neigh/qeq = 
-full, newton = off, binsize = 0.0, and comm = device, gpu/direct = on. 
-These settings are made automatically by the required "-k on" 
-"command-line switch"_Section_start.html#start_6. You can change them bu 
-using the package kokkos command in your input script or via the "-pk 
-kokkos" "command-line switch"_Section_start.html#start_6. 
+For the KOKKOS package, the option defaults neigh = full, neigh/qeq =
+full, newton = off, binsize = 0.0, and comm = device, gpu/direct = on.
+These settings are made automatically by the required "-k on"
+"command-line switch"_Section_start.html#start_6. You can change them by
+using the package kokkos command in your input script or via the "-pk
+kokkos" "command-line switch"_Section_start.html#start_6.
 
 For the OMP package, the default is Nthreads = 0 and the option
 defaults are neigh = yes.  These settings are made automatically if

--- a/doc/src/package.txt
+++ b/doc/src/package.txt
@@ -512,9 +512,12 @@ this keyword is set to {on}, buffers in GPU memory are passed directly
 through MPI send/receive calls. This reduces overhead of first copying
 the data to the host CPU. However GPU-direct is not supported on all
 systems, which can lead to segmentation faults and would require
-using a value of {off}. When the {gpu/direct} keyword is set to {off}
-while any of the {comm} keywords are set to {device}, the value for the
-{comm} keywords will be automatically changed to {host}.
+using a value of {off}. If LAMMPS can safely detect that GPU-direct is
+not available (currently only possible with OpenMPI v2.0.0 or later),
+then the {gpu/direct} keyword is automatically set to {off} by default.
+When the {gpu/direct} keyword is set to {off} while any of the {comm}
+keywords are set to {device}, the value for these {comm} keywords will
+be automatically changed to {host}.
 
 :line
 
@@ -624,6 +627,8 @@ switch"_Section_start.html#start_6.
 
 For the KOKKOS package, the option defaults neigh = full, neigh/qeq =
 full, newton = off, binsize = 0.0, and comm = device, gpu/direct = on.
+When LAMMPS can safely detect, that GPU-direct is not available, the
+default value of gpu/direct becomes "off".
 These settings are made automatically by the required "-k on"
 "command-line switch"_Section_start.html#start_6. You can change them by
 using the package kokkos command in your input script or via the "-pk

--- a/doc/src/package.txt
+++ b/doc/src/package.txt
@@ -489,10 +489,9 @@ packing/unpacking operation.
 
 The optimal choice for these keywords depends on the input script and
 the hardware used.  The {no} value is useful for verifying that the
-Kokkos-based {host} and {device} values are working correctly.  The {no}
-value should also be used, in case of using an MPI library that does
-not support GPU-direct. It may also be the fastest choice when using
-Kokkos styles in MPI-only mode (i.e. with a thread count of 1).
+Kokkos-based {host} and {device} values are working correctly. 
+It may also be the fastest choice when using Kokkos styles in
+MPI-only mode (i.e. with a thread count of 1).
 
 When running on CPUs or Xeon Phi, the {host} and {device} values work
 identically.  When using GPUs, the {device} value will typically be
@@ -513,7 +512,9 @@ this keyword is set to {on}, buffers in GPU memory are passed directly
 through MPI send/receive calls. This reduces overhead of first copying 
 the data to the host CPU. However GPU-direct is not supported on all 
 systems, which can lead to segmentation faults and would require
-using a value of {off}. 
+using a value of {off}. When the {gpu/direct} keyword is set to {off}
+while any of the {comm} keywords are set to {device}, the value for the
+{comm} keywords will be automatically changed to {host}.
 
 :line
 

--- a/doc/src/package.txt
+++ b/doc/src/package.txt
@@ -84,6 +84,9 @@ args = arguments specific to the style :l
         no = perform communication pack/unpack in non-KOKKOS mode
         host = perform pack/unpack on host (e.g. with OpenMP threading)
         device = perform pack/unpack on device (e.g. on GPU)
+      {gpu/direct} = {off} or {on}
+        off = do not use GPU-direct
+        on = use GPU-direct (default)
   {omp} args = Nthreads keyword value ...
     Nthread = # of OpenMP threads to associate with each MPI process
     zero or more keyword/value pairs may be appended
@@ -505,6 +508,13 @@ typically faster to let the host handle communication, by using the
 {host} value.  Using {host} instead of {no} will enable use of
 multiple threads to pack/unpack communicated data.
 
+The {gpu/direct} keyword chooses whether GPU-direct will be used. When 
+this keyword is set to {on}, buffers in GPU memory are passed directly 
+through MPI send/receive calls. This reduces overhead of first copying 
+the data to the host CPU. However GPU-direct is not supported on all 
+systems, which can lead to segmentation faults and would require
+using a value of {off}. 
+
 :line
 
 The {omp} style invokes settings associated with the use of the
@@ -611,12 +621,12 @@ is used.  If it is not used, you must invoke the package intel
 command in your input script or or via the "-pk intel" "command-line
 switch"_Section_start.html#start_6.
 
-For the KOKKOS package, the option defaults neigh = full,
-neigh/qeq = full, newton = off, binsize = 0.0, and comm = device.
-These settings are made automatically by the required "-k on" "command-line
-switch"_Section_start.html#start_6.  You can change them bu using the
-package kokkos command in your input script or via the "-pk kokkos"
-"command-line switch"_Section_start.html#start_6.
+For the KOKKOS package, the option defaults neigh = full, neigh/qeq = 
+full, newton = off, binsize = 0.0, and comm = device, gpu/direct = on. 
+These settings are made automatically by the required "-k on" 
+"command-line switch"_Section_start.html#start_6. You can change them bu 
+using the package kokkos command in your input script or via the "-pk 
+kokkos" "command-line switch"_Section_start.html#start_6. 
 
 For the OMP package, the default is Nthreads = 0 and the option
 defaults are neigh = yes.  These settings are made automatically if

--- a/doc/src/package.txt
+++ b/doc/src/package.txt
@@ -480,15 +480,16 @@ The value options for all 3 keywords are {no} or {host} or {device}.
 A value of {no} means to use the standard non-KOKKOS method of
 packing/unpacking data for the communication.  A value of {host} means
 to use the host, typically a multi-core CPU, and perform the
-packing/unpacking in parallel with threads.  A value of {device} means
-to use the device, typically a GPU, to perform the packing/unpacking
-operation.
+packing/unpacking in parallel with threads.  A value of {device}
+means to use the device, typically a GPU, to perform the
+packing/unpacking operation.
 
 The optimal choice for these keywords depends on the input script and
 the hardware used.  The {no} value is useful for verifying that the
-Kokkos-based {host} and {device} values are working correctly.  It may
-also be the fastest choice when using Kokkos styles in MPI-only mode
-(i.e. with a thread count of 1).
+Kokkos-based {host} and {device} values are working correctly.  The {no}
+value should also be used, in case of using an MPI library that does
+not support GPU-direct. It may also be the fastest choice when using
+Kokkos styles in MPI-only mode (i.e. with a thread count of 1).
 
 When running on CPUs or Xeon Phi, the {host} and {device} values work
 identically.  When using GPUs, the {device} value will typically be

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -406,7 +406,7 @@ void CommKokkos::forward_comm_pair_device(Pair *pair)
     if (sendproc[iswap] != me) {
       double* buf_send_pair;
       double* buf_recv_pair;
-      if (lmp->kokkos->gpu_direct) {
+      if (lmp->kokkos->gpu_direct_flag) {
         buf_send_pair = k_buf_send_pair.view<DeviceType>().data();
         buf_recv_pair = k_buf_recv_pair.view<DeviceType>().data();
       } else {
@@ -424,7 +424,7 @@ void CommKokkos::forward_comm_pair_device(Pair *pair)
         MPI_Send(buf_send_pair,n,MPI_DOUBLE,sendproc[iswap],0,world);
       if (recvnum[iswap]) MPI_Wait(&request,MPI_STATUS_IGNORE);
 
-      if (!lmp->kokkos->gpu_direct) {
+      if (!lmp->kokkos->gpu_direct_flag) {
         k_buf_recv_pair.modify<LMPHostType>();
         k_buf_recv_pair.sync<DeviceType>();
       }

--- a/src/KOKKOS/gridcomm_kokkos.cpp
+++ b/src/KOKKOS/gridcomm_kokkos.cpp
@@ -529,7 +529,7 @@ void GridCommKokkos<DeviceType>::forward_comm(KSpace *kspace, int which)
     if (swap[m].sendproc != me) {
       FFT_SCALAR* buf1;
       FFT_SCALAR* buf2;
-      if (lmp->kokkos->gpu_direct) {
+      if (lmp->kokkos->gpu_direct_flag) {
         buf1 = k_buf1.view<DeviceType>().data();
         buf2 = k_buf2.view<DeviceType>().data();
       } else {
@@ -545,7 +545,7 @@ void GridCommKokkos<DeviceType>::forward_comm(KSpace *kspace, int which)
                swap[m].sendproc,0,gridcomm);
       MPI_Wait(&request,MPI_STATUS_IGNORE);
 
-      if (!lmp->kokkos->gpu_direct) {
+      if (!lmp->kokkos->gpu_direct_flag) {
         k_buf2.modify<LMPHostType>();
         k_buf2.sync<DeviceType>();
       }
@@ -579,7 +579,7 @@ void GridCommKokkos<DeviceType>::reverse_comm(KSpace *kspace, int which)
     if (swap[m].recvproc != me) {
       FFT_SCALAR* buf1;
       FFT_SCALAR* buf2;
-      if (lmp->kokkos->gpu_direct) {
+      if (lmp->kokkos->gpu_direct_flag) {
         buf1 = k_buf1.view<DeviceType>().data();
         buf2 = k_buf2.view<DeviceType>().data();
       } else {
@@ -595,7 +595,7 @@ void GridCommKokkos<DeviceType>::reverse_comm(KSpace *kspace, int which)
                swap[m].recvproc,0,gridcomm);
       MPI_Wait(&request,MPI_STATUS_IGNORE);
 
-      if (!lmp->kokkos->gpu_direct) {
+      if (!lmp->kokkos->gpu_direct_flag) {
         k_buf2.modify<LMPHostType>();
         k_buf2.sync<DeviceType>();
       }

--- a/src/KOKKOS/gridcomm_kokkos.cpp
+++ b/src/KOKKOS/gridcomm_kokkos.cpp
@@ -527,8 +527,8 @@ void GridCommKokkos<DeviceType>::forward_comm(KSpace *kspace, int which)
     DeviceType::fence();
 
     if (swap[m].sendproc != me) {
-      MPI_FFT_SCALAR* buf1;
-      MPI_FFT_SCALAR* buf2;
+      FFT_SCALAR* buf1;
+      FFT_SCALAR* buf2;
       if (lmp->kokkos->gpu_direct) {
         buf1 = k_buf1.view<DeviceType>().data();
         buf2 = k_buf2.view<DeviceType>().data();
@@ -577,8 +577,8 @@ void GridCommKokkos<DeviceType>::reverse_comm(KSpace *kspace, int which)
     DeviceType::fence();
 
     if (swap[m].recvproc != me) {
-      MPI_FFT_SCALAR* buf1;
-      MPI_FFT_SCALAR* buf2;
+      FFT_SCALAR* buf1;
+      FFT_SCALAR* buf2;
       if (lmp->kokkos->gpu_direct) {
         buf1 = k_buf1.view<DeviceType>().data();
         buf2 = k_buf2.view<DeviceType>().data();

--- a/src/KOKKOS/gridcomm_kokkos.cpp
+++ b/src/KOKKOS/gridcomm_kokkos.cpp
@@ -18,6 +18,7 @@
 #include "memory_kokkos.h"
 #include "error.h"
 #include "kokkos_base.h"
+#include "kokkos.h"
 
 using namespace LAMMPS_NS;
 
@@ -526,11 +527,28 @@ void GridCommKokkos<DeviceType>::forward_comm(KSpace *kspace, int which)
     DeviceType::fence();
 
     if (swap[m].sendproc != me) {
-      MPI_Irecv(k_buf2.view<DeviceType>().data(),nforward*swap[m].nunpack,MPI_FFT_SCALAR,
+      MPI_FFT_SCALAR* buf1;
+      MPI_FFT_SCALAR* buf2;
+      if (lmp->kokkos->gpu_direct) {
+        buf1 = k_buf1.view<DeviceType>().data();
+        buf2 = k_buf2.view<DeviceType>().data();
+      } else {
+        k_buf1.modify<DeviceType>();
+        k_buf1.sync<LMPHostType>();
+        buf1 = k_buf1.h_view.data();
+        buf2 = k_buf2.h_view.data();
+      }
+
+      MPI_Irecv(buf2,nforward*swap[m].nunpack,MPI_FFT_SCALAR,
                 swap[m].recvproc,0,gridcomm,&request);
-      MPI_Send(k_buf1.view<DeviceType>().data(),nforward*swap[m].npack,MPI_FFT_SCALAR,
+      MPI_Send(buf1,nforward*swap[m].npack,MPI_FFT_SCALAR,
                swap[m].sendproc,0,gridcomm);
       MPI_Wait(&request,MPI_STATUS_IGNORE);
+
+      if (!lmp->kokkos->gpu_direct) {
+        k_buf2.modify<LMPHostType>();
+        k_buf2.sync<DeviceType>();
+      }
     }
 
     kspaceKKBase->unpack_forward_kspace_kokkos(which,k_buf2,swap[m].nunpack,k_unpacklist,m);
@@ -559,11 +577,28 @@ void GridCommKokkos<DeviceType>::reverse_comm(KSpace *kspace, int which)
     DeviceType::fence();
 
     if (swap[m].recvproc != me) {
-      MPI_Irecv(k_buf2.view<DeviceType>().data(),nreverse*swap[m].npack,MPI_FFT_SCALAR,
+      MPI_FFT_SCALAR* buf1;
+      MPI_FFT_SCALAR* buf2;
+      if (lmp->kokkos->gpu_direct) {
+        buf1 = k_buf1.view<DeviceType>().data();
+        buf2 = k_buf2.view<DeviceType>().data();
+      } else {
+        k_buf1.modify<DeviceType>();
+        k_buf1.sync<LMPHostType>();
+        buf1 = k_buf1.h_view.data();
+        buf2 = k_buf2.h_view.data();
+      }
+
+      MPI_Irecv(buf2,nreverse*swap[m].npack,MPI_FFT_SCALAR,
                 swap[m].sendproc,0,gridcomm,&request);
-      MPI_Send(k_buf1.view<DeviceType>().data(),nreverse*swap[m].nunpack,MPI_FFT_SCALAR,
+      MPI_Send(buf1,nreverse*swap[m].nunpack,MPI_FFT_SCALAR,
                swap[m].recvproc,0,gridcomm);
       MPI_Wait(&request,MPI_STATUS_IGNORE);
+
+      if (!lmp->kokkos->gpu_direct) {
+        k_buf2.modify<LMPHostType>();
+        k_buf2.sync<DeviceType>();
+      }
     }
 
     kspaceKKBase->unpack_reverse_kspace_kokkos(which,k_buf2,swap[m].npack,k_packlist,m);

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -106,8 +106,8 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   // initialize Kokkos
 
   if (me == 0) {
-    if (screen) fprintf(screen,"  using %d GPU(s)\n",ngpu);
-    if (logfile) fprintf(logfile,"  using %d GPU(s)\n",ngpu);
+    if (screen) fprintf(screen,"  will use up to %d GPU(s) per node\n",ngpu);
+    if (logfile) fprintf(logfile,"  will use up to %d GPU(s) per node\n",ngpu);
   }
 
 #ifdef KOKKOS_HAVE_CUDA

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -156,16 +156,16 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
     } else if (-1 == have_gpu_direct() ) {
       error->warning(FLERR,"Kokkos with CUDA assumes GPU-direct is available,"
                      " but cannot determine if this is the case\n         try"
-                     " '-pk kokkos gpu/direct no' when getting segmentation faults");
+                     " '-pk kokkos gpu/direct off' when getting segmentation faults");
     } else if ( 0 == have_gpu_direct() ) {
       error->warning(FLERR,"GPU-direct is NOT available, but some parts of "
                      "Kokkos with CUDA require it by default\n         try"
-                     " '-pk kokkos gpu/direct no' when getting segmentation faults");
+                     " '-pk kokkos gpu/direct off' when getting segmentation faults");
     } else {
       ; // should never get here
     }
   }
-    
+
 #endif
 
   Kokkos::InitArguments args;
@@ -310,7 +310,7 @@ void KokkosLMP::accelerator(int narg, char **arg)
     } else error->all(FLERR,"Illegal package kokkos command");
   }
 
-  // if "gpu/direct no" and "comm device", change to "comm host"
+  // if "gpu/direct off" and "comm device", change to "comm host"
 
   if (!gpu_direct) {
    if (exchange_comm_classic == 0 && exchange_comm_on_host == 0)

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -156,11 +156,11 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
     } else if (-1 == have_gpu_direct() ) {
       error->warning(FLERR,"Kokkos with CUDA assumes GPU-direct is available,"
                      " but cannot determine if this is the case\n         try"
-                     " '-pk kokkos comm no' when getting segmentation faults");
+                     " '-pk kokkos comm no gpu/direct no' when getting segmentation faults");
     } else if ( 0 == have_gpu_direct() ) {
       error->warning(FLERR,"GPU-direct is NOT available, but some parts of "
                      "Kokkos with CUDA require it\n         try"
-                     " '-pk kokkos comm no' when getting segmentation faults");
+                     " '-pk kokkos comm no gpu/direct no' when getting segmentation faults");
     } else {
       ; // should never get here
     }
@@ -186,6 +186,7 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   exchange_comm_on_host = 0;
   forward_comm_on_host = 0;
   reverse_comm_on_host = 0;
+  gpu_direct = 0;
 
 #ifdef KILL_KOKKOS_ON_SIGSEGV
   signal(SIGSEGV, my_signal_handler);
@@ -216,6 +217,7 @@ void KokkosLMP::accelerator(int narg, char **arg)
   double binsize = 0.0;
   exchange_comm_classic = forward_comm_classic = reverse_comm_classic = 0;
   exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 0;
+  gpu_direct = 1;
 
   int iarg = 0;
   while (iarg < narg) {
@@ -298,6 +300,12 @@ void KokkosLMP::accelerator(int narg, char **arg)
         reverse_comm_classic = 0;
         reverse_comm_on_host = 0;
       } else error->all(FLERR,"Illegal package kokkos command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"gpu/direct") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
+      if (strcmp(arg[iarg+1],"off") == 0) gpu_direct = 0;
+      else if (strcmp(arg[iarg+1],"on") == 0) gpu_direct = 1;
+      else error->all(FLERR,"Illegal package kokkos command");
       iarg += 2;
     } else error->all(FLERR,"Illegal package kokkos command");
   }

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -159,7 +159,7 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
                      " '-pk kokkos gpu/direct no' when getting segmentation faults");
     } else if ( 0 == have_gpu_direct() ) {
       error->warning(FLERR,"GPU-direct is NOT available, but some parts of "
-                     "Kokkos with CUDA require it\n         try"
+                     "Kokkos with CUDA require it by default\n         try"
                      " '-pk kokkos gpu/direct no' when getting segmentation faults");
     } else {
       ; // should never get here

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -156,11 +156,11 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
     } else if (-1 == have_gpu_direct() ) {
       error->warning(FLERR,"Kokkos with CUDA assumes GPU-direct is available,"
                      " but cannot determine if this is the case\n         try"
-                     " '-pk kokkos comm no gpu/direct no' when getting segmentation faults");
+                     " '-pk kokkos gpu/direct no' when getting segmentation faults");
     } else if ( 0 == have_gpu_direct() ) {
       error->warning(FLERR,"GPU-direct is NOT available, but some parts of "
                      "Kokkos with CUDA require it\n         try"
-                     " '-pk kokkos comm no gpu/direct no' when getting segmentation faults");
+                     " '-pk kokkos gpu/direct no' when getting segmentation faults");
     } else {
       ; // should never get here
     }
@@ -186,7 +186,7 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   exchange_comm_on_host = 0;
   forward_comm_on_host = 0;
   reverse_comm_on_host = 0;
-  gpu_direct = 0;
+  gpu_direct = 1;
 
 #ifdef KILL_KOKKOS_ON_SIGSEGV
   signal(SIGSEGV, my_signal_handler);
@@ -308,6 +308,17 @@ void KokkosLMP::accelerator(int narg, char **arg)
       else error->all(FLERR,"Illegal package kokkos command");
       iarg += 2;
     } else error->all(FLERR,"Illegal package kokkos command");
+  }
+
+  // if "gpu/direct no" and "comm device", change to "comm host"
+
+  if (!gpu_direct) {
+   if (exchange_comm_classic == 0 && exchange_comm_on_host == 0)
+     exchange_comm_on_host = 1;
+   if (forward_comm_classic == 0 && forward_comm_on_host == 0)
+     forward_comm_on_host = 1;
+   if (reverse_comm_classic == 0 && reverse_comm_on_host == 0)
+     reverse_comm_on_host = 1;
   }
 
   // set newton flags

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -204,6 +204,7 @@ void KokkosLMP::accelerator(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
       if (strcmp(arg[iarg+1],"no") == 0) {
         exchange_comm_classic = forward_comm_classic = reverse_comm_classic = 1;
+        exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 0;
       } else if (strcmp(arg[iarg+1],"host") == 0) {
         exchange_comm_classic = forward_comm_classic = reverse_comm_classic = 0;
         exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 1;

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -34,6 +34,7 @@ class KokkosLMP : protected Pointers {
   int num_threads,ngpu;
   int numa;
   int auto_sync;
+  int gpu_direct;
 
   KokkosLMP(class LAMMPS *, int, char **);
   ~KokkosLMP();

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -34,7 +34,7 @@ class KokkosLMP : protected Pointers {
   int num_threads,ngpu;
   int numa;
   int auto_sync;
-  int gpu_direct;
+  int gpu_direct_flag;
 
   KokkosLMP(class LAMMPS *, int, char **);
   ~KokkosLMP();


### PR DESCRIPTION
## Purpose

Add some code to try and detect whether GPU-direct support is available in the MPI library and add some warning messages in case this is relevant. Some related minor output tweaks and documentation updates.

## Author(s)

Axel Kohlmeyer (ICTP) and Stan Moore (SNL)

## Backward Compatibility

yes, only extra warnings and a new package flag are added. New custom code only added for supported MPI implementations.

## Implementation Notes

This provides a small local wrapper function `have_gpu_direct()` which will return either -1, 0, 1. -1 means "cannot detect GPU-direct", 0 means "no GPU-direct support", 1 means "full GPU-direct support". default for unsupported cases is -1. Only code for known cases added. At the moment, only OpenMPI > 2.0.0 is supported to do a runtime check via a OpenMPI specific API.
Additional wrappers for other MPI libraries are welcome.


## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines

