### PR TITLE
bug fix for compute cluster/atom when computing values used to update…

### DIFF
--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -31,6 +31,8 @@
 
 using namespace LAMMPS_NS;
 
+enum{CLUSTER,MASK,COORDS};
+
 /* ---------------------------------------------------------------------- */
 
 ComputeClusterAtom::ComputeClusterAtom(LAMMPS *lmp, int narg, char **arg) :
@@ -44,7 +46,7 @@ ComputeClusterAtom::ComputeClusterAtom(LAMMPS *lmp, int narg, char **arg) :
 
   peratom_flag = 1;
   size_peratom_cols = 0;
-  comm_forward = 1;
+  comm_forward = 3;
 
   nmax = 0;
 }
@@ -122,10 +124,19 @@ void ComputeClusterAtom::compute_peratom()
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
 
+  // if update->post_integrate set:
+  // a dynamic group in FixGroup is invoking a variable with this compute
+  // thus ghost atom coords need to be up-to-date after initial_integrate()
+
+  if (update->post_integrate) {
+    commflag = COORDS;
+    comm->forward_comm_compute(this);
+  }
+
   // if group is dynamic, insure ghost atom masks are current
 
   if (group->dynamic[igroup]) {
-    commflag = 0;
+    commflag = MASK;
     comm->forward_comm_compute(this);
   }
 
@@ -147,7 +158,7 @@ void ComputeClusterAtom::compute_peratom()
   // iterate until no changes in my atoms
   // then check if any proc made changes
 
-  commflag = 1;
+  commflag = CLUSTER;
   double **x = atom->x;
 
   int change,done,anychange;
@@ -203,16 +214,24 @@ int ComputeClusterAtom::pack_forward_comm(int n, int *list, double *buf,
   int i,j,m;
 
   m = 0;
-  if (commflag) {
+  if (commflag == CLUSTER) {
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = clusterID[j];
     }
-  } else {
+  } else if (commflag == MASK) {
     int *mask = atom->mask;
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = ubuf(mask[j]).d;
+    }
+  } else if (commflag == COORDS) {
+    double **x = atom->x;
+    for (i = 0; i < n; i++) {
+      j = list[i];
+      buf[m++] = x[j][0];
+      buf[m++] = x[j][1];
+      buf[m++] = x[j][2];
     }
   }
 
@@ -227,11 +246,18 @@ void ComputeClusterAtom::unpack_forward_comm(int n, int first, double *buf)
 
   m = 0;
   last = first + n;
-  if (commflag)
+  if (commflag == CLUSTER) {
     for (i = first; i < last; i++) clusterID[i] = buf[m++];
-  else {
+  } else if (commflag == MASK) {
     int *mask = atom->mask;
     for (i = first; i < last; i++) mask[i] = (int) ubuf(buf[m++]).i;
+  } else if (commflag == COORDS) {
+    double **x = atom->x;
+    for (i = first; i < last; i++) {
+      x[i][0] = buf[m++];
+      x[i][1] = buf[m++];
+      x[i][2] = buf[m++];
+    }
   }
 }
 

--- a/src/fix_group.cpp
+++ b/src/fix_group.cpp
@@ -204,17 +204,22 @@ void FixGroup::set_group()
   int nlocal = atom->nlocal;
 
   // invoke atom-style variable if defined
+  // set post_integrate flag to 1, then unset after
+  // this is for any compute to check if it needs to 
+  //   operate differently due to invocation this early in timestep
+  // e.g. perform ghost comm update due to atoms having just moved
 
   double *var = NULL;
   int *ivector = NULL;
   double *dvector = NULL;
 
-
   if (varflag) {
+    update->post_integrate = 1;
     modify->clearstep_compute();
     memory->create(var,nlocal,"fix/group:varvalue");
     input->variable->compute_atom(ivar,igroup,var,1,0);
     modify->addstep_compute(update->ntimestep + nevery);
+    update->post_integrate = 0;
   }
 
   // invoke per-atom property if defined

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -46,10 +46,10 @@ Update::Update(LAMMPS *lmp) : Pointers(lmp)
   whichflag = 0;
   firststep = laststep = 0;
   beginstep = endstep = 0;
-  setupflag = 0;
-  multireplica = 0;
-
   restrict_output = 0;
+  setupflag = 0;
+  post_integrate = 0;
+  multireplica = 0;
 
   eflag_global = vflag_global = -1;
 

--- a/src/update.h
+++ b/src/update.h
@@ -35,6 +35,7 @@ class Update : protected Pointers {
   int max_eval;                   // max force evaluations for minimizer
   int restrict_output;            // 1 if output should not write dump/restart
   int setupflag;                  // set when setup() is computing forces
+  int post_integrate;             // 1 if now at post_integrate() in timestep
   int multireplica;               // 1 if min across replicas, else 0
 
   bigint eflag_global,eflag_atom;  // timestep global/peratom eng is tallied on


### PR DESCRIPTION
… a dynamic group

## Purpose

Fix a bug in compute cluster/atom when it is used (in a per-atom variable) to update a dynamic group via being called by FixGroup at the post_integrate() point of a timestep.  This requires cluster/atom to have accurate ghost atom coords, which it normally would not at this point in the timestep.  This should fix reported issue #998.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


