### PR TITLE
Replace deprecated CUDA functions calls in GPU package

### DIFF
--- a/lib/gpu/lal_preprocessor.h
+++ b/lib/gpu/lal_preprocessor.h
@@ -119,6 +119,8 @@
 #define BLOCK_ELLIPSE 128
 #define MAX_SHARED_TYPES 11
 
+#if (__CUDACC_VER_MAJOR__ < 9)
+
 #ifdef _SINGLE_SINGLE
 #define shfl_xor __shfl_xor
 #else
@@ -130,6 +132,25 @@ ucl_inline double shfl_xor(double var, int laneMask, int width) {
   tmp.y = __shfl_xor(tmp.y,laneMask,width);
   return __hiloint2double(tmp.x,tmp.y);
 }
+#endif
+
+#else
+
+#ifdef _SINGLE_SINGLE
+ucl_inline double shfl_xor(double var, int laneMask, int width) {
+  return __shfl_xor_sync(0xffffffff, var, laneMask, width);
+}
+#else
+ucl_inline double shfl_xor(double var, int laneMask, int width) {
+  int2 tmp;
+  tmp.x = __double2hiint(var);
+  tmp.y = __double2loint(var);
+  tmp.x = __shfl_xor_sync(0xffffffff,tmp.x,laneMask,width);
+  tmp.y = __shfl_xor_sync(0xffffffff,tmp.y,laneMask,width);
+  return __hiloint2double(tmp.x,tmp.y);
+}
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
## Purpose
 Fixes issue #1035 by removing usage of deprecated CUDA functions
- `__shfl_xor(...)` -> `__shfl_xor_sync(0xffffffff, ...)`. the new function supports selecting the participating threads within the warp using a mask. to retain the old function we simply have to pass the full mask.
- Several CUDA Driver Interface functions are deprecated and have been removed with `cuDeviceGetAttribute` calls.
- also simplified some of the GPU code

## Author(s)

@rbberger

## Backward Compatibility
still needs more testing to be sure

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

