### PR TITLE
Add missing pair_eam_cd to .gitignore

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -729,6 +729,8 @@
 /pair_eam.h
 /pair_eam_alloy.cpp
 /pair_eam_alloy.h
+/pair_eam_cd.cpp
+/pair_eam_cd.h
 /pair_eam_fs.cpp
 /pair_eam_fs.h
 /pair_edip.cpp


### PR DESCRIPTION
## Purpose
Add missing pair_eam_cd to .gitignore

## Author(s)
Stan Moore (Sandia)
