### PR TITLE
favor qsort over mergesort for stable release

### DIFF
--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -46,6 +46,13 @@
 #define PRId64 "ld"
 #endif
 
+// favor qsort over mergesort for stable release
+// TODO: to be removed after stable release
+
+#ifndef LMP_QSORT
+#define LMP_QSORT
+#endif
+
 namespace LAMMPS_NS {
 
 // enum used for KOKKOS host/device flags


### PR DESCRIPTION
## Purpose

For stable release, we should favor qsort over mergesort. There is a bug in mergesort we'll have to track down after the stable release is out. See discussion on mailing list:
https://sourceforge.net/p/lammps/mailman/message/36383759/

## Author(s)

@rbberger

## Backward Compatibility
Yes

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

