### PR TITLE
Add missing source file for KOKKOS with KSPACE

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -731,6 +731,11 @@ if(PKG_KOKKOS)
                          ${KOKKOS_PKG_SOURCES_DIR}/npair_kokkos.cpp
                          ${KOKKOS_PKG_SOURCES_DIR}/domain_kokkos.cpp
                          ${KOKKOS_PKG_SOURCES_DIR}/modify_kokkos.cpp)
+
+  if(PKG_KSPACE)
+    list(APPEND KOKKOS_PKG_SOURCES ${KOKKOS_PKG_SOURCES_DIR}/gridcomm_kokkos.cpp)
+  endif()
+
   set_property(GLOBAL PROPERTY "KOKKOS_PKG_SOURCES" "${KOKKOS_PKG_SOURCES}")
 
   # detects styles which have KOKKOS version


### PR DESCRIPTION
## Purpose

When building LAMMPS and KOKKOS with CMake there is a file missing if KSPACE is enabled.

## Author(s)

@rbberger

