### PR TITLE
add a needed ifort flag for LAMMPS/LATTE link

### DIFF
--- a/lib/latte/Makefile.lammps.ifort
+++ b/lib/latte/Makefile.lammps.ifort
@@ -6,7 +6,7 @@ latte_SYSINC =
 latte_SYSLIB = ../../lib/latte/filelink.o \
                -llatte -lifport -lifcore -lsvml -lompstub -limf \
                -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core \
-               -lmkl_intel_thread -lpthread -openmp -O0
+               -lmkl_intel_thread -lpthread -openmp
 latte_SYSPATH = -openmp -L${MKLROOT}/lib/intel64 -lmkl_lapack95_lp64 \
                 -L/opt/intel/composer_xe_2013_sp1.2.144/compiler/lib/intel64
 

--- a/lib/latte/Makefile.lammps.ifort
+++ b/lib/latte/Makefile.lammps.ifort
@@ -4,9 +4,9 @@
 
 latte_SYSINC = 
 latte_SYSLIB = ../../lib/latte/filelink.o \
-               -llatte -lifcore -lsvml -lompstub -limf -lmkl_intel_lp64 \
-               -lmkl_intel_thread -lmkl_core -lmkl_intel_thread -lpthread \
-               -openmp -O0
+               -llatte -lifport -lifcore -lsvml -lompstub -limf \
+               -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core \
+               -lmkl_intel_thread -lpthread -openmp -O0
 latte_SYSPATH = -openmp -L${MKLROOT}/lib/intel64 -lmkl_lapack95_lp64 \
                 -L/opt/intel/composer_xe_2013_sp1.2.144/compiler/lib/intel64
 


### PR DESCRIPTION
## Purpose

Add a library needed to link LAMPS with LATTE for ifort compiled.
Mentioned by Christian Negre on mail list.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


