### PR TITLE
Fix compile warnings when building with pedantic flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.o
 *.so
+*.lo
 *.cu_o
 *.ptx
 *_ptx.h
@@ -32,6 +33,7 @@ log.cite
 .Trashes
 ehthumbs.db
 Thumbs.db
+.clang-format
 
 #cmake
 /build*

--- a/src/ASPHERE/fix_nve_asphere.cpp
+++ b/src/ASPHERE/fix_nve_asphere.cpp
@@ -62,7 +62,7 @@ void FixNVEAsphere::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEAsphere::initial_integrate(int vflag)
+void FixNVEAsphere::initial_integrate(int /*vflag*/)
 {
   double dtfm;
   double inertia[3],omega[3];

--- a/src/ASPHERE/fix_nve_asphere_noforce.cpp
+++ b/src/ASPHERE/fix_nve_asphere_noforce.cpp
@@ -64,7 +64,7 @@ void FixNVEAsphereNoforce::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEAsphereNoforce::initial_integrate(int vflag)
+void FixNVEAsphereNoforce::initial_integrate(int /*vflag*/)
 {
   AtomVecEllipsoid::Bonus *bonus;
   if (avec) bonus = avec->bonus;

--- a/src/ASPHERE/fix_nve_line.cpp
+++ b/src/ASPHERE/fix_nve_line.cpp
@@ -81,7 +81,7 @@ void FixNVELine::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVELine::initial_integrate(int vflag)
+void FixNVELine::initial_integrate(int /*vflag*/)
 {
   double dtfm,dtirotate,length,theta;
 

--- a/src/ASPHERE/fix_nve_tri.cpp
+++ b/src/ASPHERE/fix_nve_tri.cpp
@@ -75,7 +75,7 @@ void FixNVETri::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVETri::initial_integrate(int vflag)
+void FixNVETri::initial_integrate(int /*vflag*/)
 {
   double dtfm;
   double omega[3];

--- a/src/BODY/body_nparticle.cpp
+++ b/src/BODY/body_nparticle.cpp
@@ -195,7 +195,7 @@ void BodyNparticle::data_body(int ibonus, int ninteger, int ndouble,
    called by Molecule class which needs single body size
 ------------------------------------------------------------------------- */
 
-double BodyNparticle::radius_body(int ninteger, int ndouble,
+double BodyNparticle::radius_body(int /*ninteger*/, int ndouble,
                                   int *ifile, double *dfile)
 {
   int nsub = ifile[0];
@@ -258,7 +258,7 @@ void BodyNparticle::output(int ibonus, int m, double *values)
 
 /* ---------------------------------------------------------------------- */
 
-int BodyNparticle::image(int ibonus, double flag1, double flag2,
+int BodyNparticle::image(int ibonus, double flag1, double /*flag2*/,
                          int *&ivec, double **&darray)
 {
   double p[3][3];

--- a/src/BODY/body_rounded_polygon.cpp
+++ b/src/BODY/body_rounded_polygon.cpp
@@ -323,7 +323,7 @@ void BodyRoundedPolygon::data_body(int ibonus, int ninteger, int ndouble,
    called by Molecule class which needs single body size
 ------------------------------------------------------------------------- */
 
-double BodyRoundedPolygon::radius_body(int ninteger, int ndouble,
+double BodyRoundedPolygon::radius_body(int /*ninteger*/, int ndouble,
 				       int *ifile, double *dfile)
 {
   int nsub = ifile[0];
@@ -392,7 +392,7 @@ void BodyRoundedPolygon::output(int ibonus, int m, double *values)
 
 /* ---------------------------------------------------------------------- */
 
-int BodyRoundedPolygon::image(int ibonus, double flag1, double flag2,
+int BodyRoundedPolygon::image(int ibonus, double flag1, double /*flag2*/,
                               int *&ivec, double **&darray)
 {
   int j;

--- a/src/BODY/body_rounded_polyhedron.cpp
+++ b/src/BODY/body_rounded_polyhedron.cpp
@@ -381,7 +381,7 @@ void BodyRoundedPolyhedron::data_body(int ibonus, int ninteger, int ndouble,
    called by Molecule class which needs single body size
 ------------------------------------------------------------------------- */
 
-double BodyRoundedPolyhedron::radius_body(int ninteger, int ndouble,
+double BodyRoundedPolyhedron::radius_body(int /*ninteger*/, int ndouble,
 				       int *ifile, double *dfile)
 {
   int nsub = ifile[0];
@@ -460,7 +460,7 @@ void BodyRoundedPolyhedron::output(int ibonus, int m, double *values)
 
 /* ---------------------------------------------------------------------- */
 
-int BodyRoundedPolyhedron::image(int ibonus, double flag1, double flag2,
+int BodyRoundedPolyhedron::image(int ibonus, double flag1, double /*flag2*/,
                               int *&ivec, double **&darray)
 {
   int j, nelements;

--- a/src/BODY/body_rounded_polyhedron.cpp
+++ b/src/BODY/body_rounded_polyhedron.cpp
@@ -96,7 +96,7 @@ int BodyRoundedPolyhedron::nedges(AtomVecBody::Bonus *bonus)
 {
   int nvertices = bonus->ivalue[0];
   int nedges = bonus->ivalue[1];
-  int nfaces = bonus->ivalue[2];
+  //int nfaces = bonus->ivalue[2];
   if (nvertices == 1) return 0;
   else if (nvertices == 2) return 1;
   return nedges; //(nvertices+nfaces-2); // Euler's polyon formula: V-E+F=2
@@ -463,7 +463,7 @@ void BodyRoundedPolyhedron::output(int ibonus, int m, double *values)
 int BodyRoundedPolyhedron::image(int ibonus, double flag1, double /*flag2*/,
                               int *&ivec, double **&darray)
 {
-  int j, nelements;
+  int nelements;
   double p[3][3];
   double *x, rrad;
 
@@ -488,7 +488,7 @@ int BodyRoundedPolyhedron::image(int ibonus, double flag1, double /*flag2*/,
 
     nelements = nvertices;
   } else {
-    int nfaces = bonus->ivalue[2];
+    //int nfaces = bonus->ivalue[2];
     int nedges = bonus->ivalue[1]; //nvertices + nfaces - 2;
     if (nvertices == 2) nedges = 1; // special case: rods
     double* edge_ends = &bonus->dvalue[3*nvertices];

--- a/src/BODY/fix_nve_body.cpp
+++ b/src/BODY/fix_nve_body.cpp
@@ -54,7 +54,7 @@ void FixNVEBody::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEBody::initial_integrate(int vflag)
+void FixNVEBody::initial_integrate(int /*vflag*/)
 {
   double dtfm;
   double omega[3];

--- a/src/BODY/fix_wall_body_polygon.cpp
+++ b/src/BODY/fix_wall_body_polygon.cpp
@@ -204,7 +204,7 @@ void FixWallBodyPolygon::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallBodyPolygon::post_force(int vflag)
+void FixWallBodyPolygon::post_force(int /*vflag*/)
 {
   double vwall[3],dx,dy,dz,del1,del2,delxy,delr,rsq,eradi,rradi,wall_pos;
   int i,ni,npi,ifirst,nei,iefirst,side;
@@ -475,7 +475,7 @@ void FixWallBodyPolygon::body2space(int i)
 
 int FixWallBodyPolygon::vertex_against_wall(int i, double wall_pos,
                 double** x, double** f, double** torque, int side,
-                Contact* contact_list, int &num_contacts, double* facc)
+                Contact* contact_list, int &num_contacts, double* /*facc*/)
 {
   int ni, npi, ifirst, interact;
   double xpi[3], xpj[3], dist, eradi, rradi;

--- a/src/BODY/fix_wall_body_polygon.cpp
+++ b/src/BODY/fix_wall_body_polygon.cpp
@@ -310,9 +310,6 @@ void FixWallBodyPolygon::post_force(int /*vflag*/)
       rsq = dx*dx + dy*dy + dz*dz;
       if (rsq > radius[i]*radius[i]) continue;
 
-      double r = sqrt(rsq);
-      double rsqinv = 1.0 / rsq;
-
       if (dnum[i] == 0) body2space(i);
       npi = dnum[i];
       ifirst = dfirst[i];
@@ -478,9 +475,8 @@ int FixWallBodyPolygon::vertex_against_wall(int i, double wall_pos,
                 Contact* contact_list, int &num_contacts, double* /*facc*/)
 {
   int ni, npi, ifirst, interact;
-  double xpi[3], xpj[3], dist, eradi, rradi;
-  double fx, fy, fz, rx, ry, rz;
-  int nlocal = atom->nlocal;
+  double xpi[3], eradi, rradi;
+  double fx, fy, fz;
 
   npi = dnum[i];
   ifirst = dfirst[i];
@@ -499,9 +495,9 @@ int FixWallBodyPolygon::vertex_against_wall(int i, double wall_pos,
     xpi[1] = x[i][1] + discrete[ifirst+ni][1];
     xpi[2] = x[i][2] + discrete[ifirst+ni][2];
 
-    int mode, contact, p2vertex;
-    double d, R, hi[3], t, delx, dely, delz, fpair, shift;
-    double xj[3], rij;
+    int mode, contact;
+    double d, R, hi[3], delx, dely, delz, fpair;
+    double rij;
 
     // compute the distance from the vertex xpi to the wall
 
@@ -671,7 +667,7 @@ void FixWallBodyPolygon::contact_forces(Contact& contact, double j_a,
                       double** x, double** v, double** angmom, double** f,
                       double** torque, double* vwall, double* facc)
 {
-  int ibody,ibonus,ifirst, jefirst, ni;
+  int ibody,ibonus,ifirst, ni;
   double fx,fy,fz,delx,dely,delz,rsq,rsqinv;
   double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
   double fn[3],ft[3],vi[3];

--- a/src/BODY/fix_wall_body_polyhedron.cpp
+++ b/src/BODY/fix_wall_body_polyhedron.cpp
@@ -213,7 +213,7 @@ void FixWallBodyPolyhedron::setup(int vflag)
 
 void FixWallBodyPolyhedron::post_force(int /*vflag*/)
 {
-  double vwall[3],dx,dy,dz,del1,del2,delxy,delr,rsq,eradi,rradi,wall_pos;
+  double vwall[3],dx,dy,dz,del1,del2,rsq,eradi,rradi,wall_pos;
   int i,ni,npi,ifirst,nei,iefirst,nfi,iffirst,side;
   double facc[3];
 
@@ -325,9 +325,6 @@ void FixWallBodyPolyhedron::post_force(int /*vflag*/)
       rsq = dx*dx + dy*dy + dz*dz;
       if (rsq > radius[i]*radius[i]) continue;
 
-      double r = sqrt(rsq);
-      double rsqinv = 1.0 / rsq;
-
       if (dnum[i] == 0) body2space(i);
       npi = dnum[i];
       ifirst = dfirst[i];
@@ -359,8 +356,7 @@ void FixWallBodyPolyhedron::post_force(int /*vflag*/)
         edge[iefirst+ni][5] = 0;
       }
 
-      int interact, num_contacts, done;
-      double delta_a, delta_ua, j_a;
+      int interact, num_contacts;
       Contact contact_list[MAX_CONTACTS];
 
       num_contacts = 0;
@@ -550,7 +546,6 @@ int FixWallBodyPolyhedron::edge_against_wall(int i, double wall_pos,
 {
   int ni, nei, mode, contact;
   double rradi;
-  int nlocal = atom->nlocal;
 
   nei = ednum[i];
   rradi = rounded_radius[i];
@@ -702,10 +697,10 @@ void FixWallBodyPolyhedron::contact_forces(int ibody,
   double fx, double fy, double fz, double** x, double** v, double** angmom,
   double** f, double** torque, double* vwall)
 {
-  int ibonus,jbonus;
+  int ibonus;
   double fxt,fyt,fzt,rsq,rsqinv;
   double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
-  double fn[3],ft[3],vi[3],vj[3];
+  double fn[3],ft[3],vi[3];
   double *quat, *inertia;
   AtomVecBody::Bonus *bonus;
 
@@ -787,7 +782,7 @@ void FixWallBodyPolyhedron::contact_forces(Contact& contact, double j_a,
                       double** x, double** v, double** angmom, double** f,
                       double** torque, double* vwall, double* facc)
 {
-  int ibody,ibonus,ifirst, jefirst, ni;
+  int ibody,ibonus,ifirst,ni;
   double fx,fy,fz,delx,dely,delz,rsq,rsqinv;
   double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
   double fn[3],ft[3],vi[3];

--- a/src/BODY/fix_wall_body_polyhedron.cpp
+++ b/src/BODY/fix_wall_body_polyhedron.cpp
@@ -211,7 +211,7 @@ void FixWallBodyPolyhedron::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallBodyPolyhedron::post_force(int vflag)
+void FixWallBodyPolyhedron::post_force(int /*vflag*/)
 {
   double vwall[3],dx,dy,dz,del1,del2,delxy,delr,rsq,eradi,rradi,wall_pos;
   int i,ni,npi,ifirst,nei,iefirst,nfi,iffirst,side;
@@ -485,7 +485,7 @@ void FixWallBodyPolyhedron::body2space(int i)
 ---------------------------------------------------------------------- */
 
 int FixWallBodyPolyhedron::sphere_against_wall(int i, double wall_pos,
-     int side, double* vwall, double** x, double** v, double** f,
+     int /*side*/, double* vwall, double** x, double** v, double** f,
      double** angmom, double** torque)
 {
   int mode;
@@ -545,8 +545,8 @@ int FixWallBodyPolyhedron::sphere_against_wall(int i, double wall_pos,
 ---------------------------------------------------------------------- */
 
 int FixWallBodyPolyhedron::edge_against_wall(int i, double wall_pos,
-     int side, double* vwall, double** x, double** f, double** torque,
-     Contact* contact_list, int &num_contacts, double* facc)
+     int side, double* vwall, double** x, double** /*f*/, double** /*torque*/,
+     Contact* /*contact_list*/, int &/*num_contacts*/, double* /*facc*/)
 {
   int ni, nei, mode, contact;
   double rradi;
@@ -584,7 +584,7 @@ int FixWallBodyPolyhedron::edge_against_wall(int i, double wall_pos,
 
 int FixWallBodyPolyhedron::compute_distance_to_wall(int ibody, int edge_index,
                         double *xmi, double rounded_radius_i, double wall_pos, 
-                        int side, double* vwall, int &contact)
+                        int /*side*/, double* vwall, int &contact)
 {
   int mode,ifirst,iefirst,npi1,npi2;
   double d1,d2,xpi1[3],xpi2[3],hi[3];
@@ -698,7 +698,7 @@ int FixWallBodyPolyhedron::compute_distance_to_wall(int ibody, int edge_index,
 ------------------------------------------------------------------------- */
 
 void FixWallBodyPolyhedron::contact_forces(int ibody,
-  double j_a, double *xi, double *xj, double delx, double dely, double delz,
+  double j_a, double *xi, double */*xj*/, double delx, double dely, double delz,
   double fx, double fy, double fz, double** x, double** v, double** angmom,
   double** f, double** torque, double* vwall)
 {

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -105,10 +105,9 @@ void PairBodyRoundedPolygon::compute(int eflag, int vflag)
   int i,j,ii,jj,inum,jnum,itype,jtype;
   int ni,nj,npi,npj,ifirst,jfirst;
   int nei,nej,iefirst,jefirst;
-  double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fx,fy,fz;
+  double xtmp,ytmp,ztmp,delx,dely,delz,evdwl;
   double rsq,rsqinv,r,radi,radj,eradi,eradj,rradi,rradj,k_nij,k_naij;
-  double xi[3],xj[3],fi[3],fj[3],ti[3],tj[3],facc[3];
-  double *dxi,*dxj;
+  double xi[3],xj[3],facc[3];
   int *ilist,*jlist,*numneigh,**firstneigh;
 
   evdwl = 0.0;
@@ -709,9 +708,8 @@ int PairBodyRoundedPolygon::vertex_against_edge(int i, int j,
   int ni, npi, ifirst, nei, iefirst;
   int nj, npj, jfirst, nej, jefirst;
   double xpi[3], xpj[3], dist, eradi, eradj, rradi, rradj;
-  double fx, fy, fz, rx, ry, rz, energy;
+  double fx, fy, fz, energy;
   int interact;
-  int nlocal = atom->nlocal;
 
   npi = dnum[i];
   ifirst = dfirst[i];
@@ -758,7 +756,7 @@ int PairBodyRoundedPolygon::vertex_against_edge(int i, int j,
 
     int mode, contact, p2vertex;
     double d, R, hi[3], t, delx, dely, delz, fpair, shift;
-    double xj[3], rij;
+    double rij;
 
     // loop through body j's edges
 
@@ -781,6 +779,7 @@ int PairBodyRoundedPolygon::vertex_against_edge(int i, int j,
         if (mode == VERTEXI) p2vertex = edge[jefirst+nj][0];
         else if (mode == VERTEXJ) p2vertex = edge[jefirst+nj][1];
 
+        // double xj[3];
         // p2.body2space(p2vertex, xj);
         xpj[0] = x[j][0] + discrete[jfirst+p2vertex][0];
         xpj[1] = x[j][1] + discrete[jfirst+p2vertex][1];

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -598,7 +598,7 @@ void PairBodyRoundedPolygon::body2space(int i)
 
 void PairBodyRoundedPolygon::sphere_against_sphere(int i, int j,
                        double delx, double dely, double delz, double rsq,
-                       double k_n, double k_na, double** x, double** v,
+                       double k_n, double k_na, double** /*x*/, double** v,
                        double** f, int evflag)
 {
   double eradi,eradj,rradi,rradj;
@@ -1166,7 +1166,7 @@ int PairBodyRoundedPolygon::compute_distance_to_vertex(int ibody,
 
 void PairBodyRoundedPolygon::contact_forces(Contact& contact, double j_a,
                        double** x, double** v, double** angmom, double** f,
-                       double** torque, double &evdwl, double* facc)
+                       double** torque, double &/*evdwl*/, double* facc)
 {
   int ibody,jbody,ibonus,jbonus,ifirst,jefirst,ni,nj;
   double fx,fy,fz,delx,dely,delz,rsq,rsqinv;

--- a/src/BODY/pair_body_rounded_polyhedron.cpp
+++ b/src/BODY/pair_body_rounded_polyhedron.cpp
@@ -603,7 +603,7 @@ void PairBodyRoundedPolyhedron::sphere_against_sphere(int ibody, int jbody,
 {
   double rradi,rradj,contact_dist;
   double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
-  double rij,rsqinv,R,fx,fy,fz,fn[3],ft[3],fpair,shift,energy;
+  double rij,rsqinv,R,fx,fy,fz,fn[3],ft[3],fpair,energy;
   int nlocal = atom->nlocal;
   int newton_pair = force->newton_pair;
 
@@ -685,7 +685,7 @@ void PairBodyRoundedPolyhedron::sphere_against_edge(int ibody, int jbody,
 {
   int ni,nei,ifirst,iefirst,npi1,npi2,ibonus;
   double xi1[3],xi2[3],vti[3],h[3],fn[3],ft[3],d,t;
-  double delx,dely,delz,rsq,rij,rsqinv,R,fx,fy,fz,fpair,shift,energy;
+  double delx,dely,delz,rsq,rij,rsqinv,R,fx,fy,fz,fpair,energy;
   double rradi,rradj,contact_dist;
   double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
   double *quat, *inertia;
@@ -835,7 +835,7 @@ void PairBodyRoundedPolyhedron::sphere_against_face(int ibody, int jbody,
 {
   int ni,nfi,inside,ifirst,iffirst,npi1,npi2,npi3,ibonus,tmp;
   double xi1[3],xi2[3],xi3[3],ui[3],vi[3],vti[3],n[3],h[3],fn[3],ft[3],d;
-  double delx,dely,delz,rsq,rij,rsqinv,R,fx,fy,fz,fpair,shift,energy;
+  double delx,dely,delz,rsq,rij,rsqinv,R,fx,fy,fz,fpair,energy;
   double rradi,rradj,contact_dist;
   double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
   double *quat, *inertia;
@@ -988,7 +988,7 @@ int PairBodyRoundedPolyhedron::edge_against_edge(int ibody, int jbody,
   int itype, int jtype, double** x, Contact* contact_list, int &num_contacts,
   double &evdwl, double* facc)
 {
-  int ni,nei,nj,nej,contact,interact;
+  int ni,nei,nj,nej,interact;
   double rradi,rradj,energy;
 
   nei = ednum[ibody];
@@ -1045,7 +1045,7 @@ int PairBodyRoundedPolyhedron::edge_against_face(int ibody, int jbody,
   int itype, int jtype, double** x, Contact* contact_list, int &num_contacts,
   double &evdwl, double* facc)
 {
-  int ni,nei,nj,nfj,contact,interact;
+  int ni,nei,nj,nfj,interact;
   double rradi,rradj,energy;
 
   nei = ednum[ibody];
@@ -1118,7 +1118,7 @@ int PairBodyRoundedPolyhedron::interaction_edge_to_edge(int ibody,
   int ifirst,iefirst,jfirst,jefirst,npi1,npi2,npj1,npj2,interact;
   double xi1[3],xi2[3],xpj1[3],xpj2[3];
   double r,t1,t2,h1[3],h2[3];
-  double contact_dist, shift;
+  double contact_dist;
 
   double** x = atom->x;
   double** v = atom->v;
@@ -1314,7 +1314,7 @@ int PairBodyRoundedPolyhedron::interaction_face_to_edge(int ibody,
 
   // determine the intersection of the edge to the face
 
-  double hi1[3], hi2[3], d1, d2, contact_dist, shift;
+  double hi1[3], hi2[3], d1, d2, contact_dist;
   int inside1 = 0;
   int inside2 = 0;
 
@@ -2345,9 +2345,8 @@ void PairBodyRoundedPolyhedron::find_unique_contacts(Contact* contact_list,
 void PairBodyRoundedPolyhedron::sanity_check()
 {
 
-  double x1[3],x2[3],x3[3],x4[3],h_a[3],h_b[3],d_a,d_b,u[3],v[3],n[3];
+  double x1[3],x2[3],x3[3],x4[3],h_a[3],h_b[3],d_a,d_b;
   double a[3],b[3],t_a,t_b;
-  int inside_a, inside_b;
 
   x1[0] = 0; x1[1] = 3; x1[2] = 0;
   x2[0] = 3; x2[1] = 0; x2[2] = 0;
@@ -2364,9 +2363,11 @@ void PairBodyRoundedPolyhedron::sanity_check()
     h_a[0], h_a[1], h_a[2], h_b[0], h_b[1], h_b[2], t_a, t_b, d_a, d_b);
 */
 /*
+  int inside_a, inside_b;
   int mode = edge_face_intersect(x1, x2, x3, a, b, h_a, h_b, d_a, d_b,
                                  inside_a, inside_b);
 
+  double u[3],v[3],n[3];
   MathExtra::sub3(x2, x1, u);
   MathExtra::sub3(x3, x1, v);
   MathExtra::cross3(u, v, n);

--- a/src/CLASS2/bond_class2.cpp
+++ b/src/CLASS2/bond_class2.cpp
@@ -209,7 +209,7 @@ void BondClass2::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondClass2::single(int type, double rsq, int i, int j, double &fforce)
+double BondClass2::single(int type, double rsq, int /*i*/, int /*j*/, double &fforce)
 {
   double r = sqrt(rsq);
   double dr = r - r0[type];

--- a/src/CLASS2/improper_class2.cpp
+++ b/src/CLASS2/improper_class2.cpp
@@ -633,7 +633,7 @@ void ImproperClass2::read_restart(FILE *fp)
    angle-angle interactions within improper
 ------------------------------------------------------------------------- */
 
-void ImproperClass2::angleangle(int eflag, int vflag)
+void ImproperClass2::angleangle(int eflag, int /*vflag*/)
 {
   int i1,i2,i3,i4,i,j,k,n,type;
   double eimproper;

--- a/src/CLASS2/pair_lj_class2.cpp
+++ b/src/CLASS2/pair_lj_class2.cpp
@@ -377,8 +377,8 @@ void PairLJClass2::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJClass2::single(int i, int j, int itype, int jtype, double rsq,
-                            double factor_coul, double factor_lj,
+double PairLJClass2::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                            double /*factor_coul*/, double factor_lj,
                             double &fforce)
 {
   double r2inv,rinv,r3inv,r6inv,forcelj,philj;

--- a/src/COLLOID/pair_colloid.cpp
+++ b/src/COLLOID/pair_colloid.cpp
@@ -469,8 +469,8 @@ void PairColloid::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairColloid::single(int i, int j, int itype, int jtype, double rsq,
-                           double factor_coul, double factor_lj,
+double PairColloid::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                           double /*factor_coul*/, double factor_lj,
                            double &fforce)
 {
   double K[9],h[4],g[4];

--- a/src/COLLOID/pair_lubricate.cpp
+++ b/src/COLLOID/pair_lubricate.cpp
@@ -749,7 +749,7 @@ void PairLubricate::read_restart_settings(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 int PairLubricate::pack_forward_comm(int n, int *list, double *buf,
-                                     int pbc_flag, int *pbc)
+                                     int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 
@@ -797,7 +797,7 @@ void PairLubricate::unpack_forward_comm(int n, int first, double *buf)
    if type pair setting, return -2 if no type pairs are set
 ------------------------------------------------------------------------- */
 
-int PairLubricate::pre_adapt(char *name, int ilo, int ihi, int jlo, int jhi)
+int PairLubricate::pre_adapt(char *name, int /*ilo*/, int /*ihi*/, int /*jlo*/, int /*jhi*/)
 {
   if (strcmp(name,"mu") == 0) return 0;
   return -1;
@@ -809,7 +809,7 @@ int PairLubricate::pre_adapt(char *name, int ilo, int ihi, int jlo, int jhi)
    if type pair setting, set I-J and J-I coeffs
 ------------------------------------------------------------------------- */
 
-void PairLubricate::adapt(int which, int ilo, int ihi, int jlo, int jhi,
+void PairLubricate::adapt(int /*which*/, int /*ilo*/, int /*ihi*/, int /*jlo*/, int /*jhi*/,
                           double value)
 {
   mu = value;

--- a/src/COLLOID/pair_lubricateU.cpp
+++ b/src/COLLOID/pair_lubricateU.cpp
@@ -2010,7 +2010,7 @@ void PairLubricateU::copy_uo_vec(int inum, double **f, double **torque,
 /* ---------------------------------------------------------------------- */
 
 int PairLubricateU::pack_forward_comm(int n, int *list, double *buf,
-                                      int pbc_flag, int *pbc)
+                                      int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/COLLOID/pair_yukawa_colloid.cpp
+++ b/src/COLLOID/pair_yukawa_colloid.cpp
@@ -160,9 +160,9 @@ double PairYukawaColloid::init_one(int i, int j)
 
 /* ---------------------------------------------------------------------- */
 
-double PairYukawaColloid::single(int i, int j, int itype, int jtype,
+double PairYukawaColloid::single(int /*i*/, int /*j*/, int itype, int jtype,
                                  double rsq,
-                                 double factor_coul, double factor_lj,
+                                 double /*factor_coul*/, double factor_lj,
                                  double &fforce)
 {
   double r,rinv,screening,forceyukawa,phi;

--- a/src/GRANULAR/fix_freeze.cpp
+++ b/src/GRANULAR/fix_freeze.cpp
@@ -83,7 +83,7 @@ void FixFreeze::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixFreeze::post_force(int vflag)
+void FixFreeze::post_force(int /*vflag*/)
 {
   double **f = atom->f;
   double **torque = atom->torque;
@@ -110,7 +110,7 @@ void FixFreeze::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixFreeze::post_force_respa(int vflag, int ilevel, int iloop)
+void FixFreeze::post_force_respa(int vflag, int /*ilevel*/, int /*iloop*/)
 {
   post_force(vflag);
 }

--- a/src/GRANULAR/fix_wall_gran.cpp
+++ b/src/GRANULAR/fix_wall_gran.cpp
@@ -302,7 +302,7 @@ void FixWallGran::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallGran::post_force(int vflag)
+void FixWallGran::post_force(int /*vflag*/)
 {
   int i,j;
   double dx,dy,dz,del1,del2,delxy,delr,rsq,rwall,meff;
@@ -446,7 +446,7 @@ void FixWallGran::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallGran::post_force_respa(int vflag, int ilevel, int iloop)
+void FixWallGran::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }
@@ -1041,7 +1041,7 @@ void FixWallGran::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixWallGran::copy_arrays(int i, int j, int delflag)
+void FixWallGran::copy_arrays(int i, int j, int /*delflag*/)
 {
   if (history)
     for (int m = 0; m < sheardim; m++)
@@ -1136,7 +1136,7 @@ int FixWallGran::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixWallGran::size_restart(int nlocal)
+int FixWallGran::size_restart(int /*nlocal*/)
 {
   if (!history) return 0;
   return 1 + sheardim;

--- a/src/GRANULAR/fix_wall_gran_region.cpp
+++ b/src/GRANULAR/fix_wall_gran_region.cpp
@@ -130,7 +130,7 @@ void FixWallGranRegion::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallGranRegion::post_force(int vflag)
+void FixWallGranRegion::post_force(int /*vflag*/)
 {
   int i,m,nc,iwall;
   double dx,dy,dz,rsq,meff;
@@ -347,7 +347,7 @@ void FixWallGranRegion::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixWallGranRegion::copy_arrays(int i, int j, int delflag)
+void FixWallGranRegion::copy_arrays(int i, int j, int /*delflag*/)
 {
   int m,n,iwall;
 

--- a/src/GRANULAR/pair_gran_hertz_history.cpp
+++ b/src/GRANULAR/pair_gran_hertz_history.cpp
@@ -306,9 +306,9 @@ void PairGranHertzHistory::settings(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-double PairGranHertzHistory::single(int i, int j, int itype, int jtype,
+double PairGranHertzHistory::single(int i, int j, int /*itype*/, int /*jtype*/,
                                     double rsq,
-                                    double factor_coul, double factor_lj,
+                                    double /*factor_coul*/, double /*factor_lj*/,
                                     double &fforce)
 {
   double radi,radj,radsum;

--- a/src/GRANULAR/pair_gran_hooke.cpp
+++ b/src/GRANULAR/pair_gran_hooke.cpp
@@ -219,8 +219,8 @@ void PairGranHooke::compute(int eflag, int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-double PairGranHooke::single(int i, int j, int itype, int jtype, double rsq,
-                             double factor_coul, double factor_lj,
+double PairGranHooke::single(int i, int j, int /*itype*/, int /*jtype*/, double rsq,
+                             double /*factor_coul*/, double /*factor_lj*/,
                              double &fforce)
 {
   double radi,radj,radsum,r,rinv,rsqinv;

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -587,9 +587,9 @@ void PairGranHookeHistory::reset_dt()
 
 /* ---------------------------------------------------------------------- */
 
-double PairGranHookeHistory::single(int i, int j, int itype, int jtype,
+double PairGranHookeHistory::single(int i, int j, int /*itype*/, int /*jtype*/,
                                     double rsq,
-                                    double factor_coul, double factor_lj,
+                                    double /*factor_coul*/, double /*factor_lj*/,
                                     double &fforce)
 {
   double radi,radj,radsum;
@@ -746,7 +746,7 @@ double PairGranHookeHistory::single(int i, int j, int itype, int jtype,
 /* ---------------------------------------------------------------------- */
 
 int PairGranHookeHistory::pack_forward_comm(int n, int *list, double *buf,
-                                            int pbc_flag, int *pbc)
+                                            int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/KSPACE/pair_coul_long.cpp
+++ b/src/KSPACE/pair_coul_long.cpp
@@ -338,9 +338,9 @@ void PairCoulLong::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairCoulLong::single(int i, int j, int itype, int jtype,
+double PairCoulLong::single(int i, int j, int /*itype*/, int /*jtype*/,
                             double rsq,
-                            double factor_coul, double factor_lj,
+                            double factor_coul, double /*factor_lj*/,
                             double &fforce)
 {
   double r2inv,r,grij,expm2,t,erfc,prefactor;

--- a/src/KSPACE/pair_coul_msm.cpp
+++ b/src/KSPACE/pair_coul_msm.cpp
@@ -169,9 +169,9 @@ void PairCoulMSM::compute(int eflag, int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-double PairCoulMSM::single(int i, int j, int itype, int jtype,
+double PairCoulMSM::single(int i, int j, int /*itype*/, int /*jtype*/,
                             double rsq,
-                            double factor_coul, double factor_lj,
+                            double factor_coul, double /*factor_lj*/,
                             double &fforce)
 {
   double r2inv,r,egamma,fgamma,prefactor;

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -8052,7 +8052,7 @@ void PPPMDisp::compute_rho_coeff(FFT_SCALAR **coeff , FFT_SCALAR **dcoeff,
    extended to non-neutral systems (J. Chem. Phys. 131, 094107).
 ------------------------------------------------------------------------- */
 
-void PPPMDisp::slabcorr(int eflag)
+void PPPMDisp::slabcorr(int /*eflag*/)
 {
   // compute local contribution to global dipole moment
 

--- a/src/KSPACE/remap.cpp
+++ b/src/KSPACE/remap.cpp
@@ -234,7 +234,7 @@ struct remap_plan_3d *remap_3d_create_plan(
   int in_klo, int in_khi,
   int out_ilo, int out_ihi, int out_jlo, int out_jhi,
   int out_klo, int out_khi,
-  int nqty, int permute, int memory, int precision, int usecollective)
+  int nqty, int permute, int memory, int /*precision*/, int usecollective)
 
 {
 

--- a/src/LATTE/fix_latte.cpp
+++ b/src/LATTE/fix_latte.cpp
@@ -189,7 +189,7 @@ void FixLatte::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixLatte::init_list(int id, NeighList *ptr)
+void FixLatte::init_list(int /*id*/, NeighList */*ptr*/)
 {
   // list = ptr;
 }
@@ -223,13 +223,13 @@ void FixLatte::setup_pre_reverse(int eflag, int vflag)
    integrate electronic degrees of freedom
 ------------------------------------------------------------------------- */
 
-void FixLatte::initial_integrate(int vflag) {}
+void FixLatte::initial_integrate(int /*vflag*/) {}
 
 /* ----------------------------------------------------------------------
    store eflag, so can use it in post_force to tally per-atom energies
 ------------------------------------------------------------------------- */
 
-void FixLatte::pre_reverse(int eflag, int vflag)
+void FixLatte::pre_reverse(int eflag, int /*vflag*/)
 {
   eflag_caller = eflag;
 }

--- a/src/MANYBODY/fix_qeq_comb.cpp
+++ b/src/MANYBODY/fix_qeq_comb.cpp
@@ -159,7 +159,7 @@ void FixQEQComb::min_post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEQComb::post_force(int vflag)
+void FixQEQComb::post_force(int /*vflag*/)
 {
   int i,ii,iloop,loopmax,inum,*ilist;
   double heatpq,qmass,dtq,dtq2;
@@ -276,7 +276,7 @@ void FixQEQComb::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEQComb::post_force_respa(int vflag, int ilevel, int iloop)
+void FixQEQComb::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }
@@ -293,7 +293,7 @@ double FixQEQComb::memory_usage()
 /* ---------------------------------------------------------------------- */
 
 int FixQEQComb::pack_forward_comm(int n, int *list, double *buf,
-                                  int pbc_flag, int *pbc)
+                                  int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -424,7 +424,7 @@ void PairADP::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairADP::settings(int narg, char **arg)
+void PairADP::settings(int narg, char **/*arg*/)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -521,7 +521,7 @@ void PairADP::init_style()
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairADP::init_one(int i, int j)
+double PairADP::init_one(int /*i*/, int /*j*/)
 {
   // single global cutoff = max of cut from all files read in
   // for funcfl could be multiple files
@@ -935,7 +935,7 @@ void PairADP::grab(FILE *fp, int n, double *list)
 /* ---------------------------------------------------------------------- */
 
 int PairADP::pack_forward_comm(int n, int *list, double *buf,
-                               int pbc_flag, int *pbc)
+                               int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -425,7 +425,7 @@ void PairAIREBO::REBO_neigh()
    REBO forces and energy
 ------------------------------------------------------------------------- */
 
-void PairAIREBO::FREBO(int eflag, int vflag)
+void PairAIREBO::FREBO(int eflag, int /*vflag*/)
 {
   int i,j,k,m,ii,inum,itype,jtype;
   tagint itag,jtag;
@@ -524,7 +524,7 @@ void PairAIREBO::FREBO(int eflag, int vflag)
    find 3- and 4-step paths between atoms I,J via REBO neighbor lists
 ------------------------------------------------------------------------- */
 
-void PairAIREBO::FLJ(int eflag, int vflag)
+void PairAIREBO::FLJ(int eflag, int /*vflag*/)
 {
   int i,j,k,m,ii,jj,kk,mm,inum,jnum,itype,jtype,ktype,mtype;
   int atomi,atomj,atomk,atomm;
@@ -893,7 +893,7 @@ void PairAIREBO::FLJ(int eflag, int vflag)
    torsional forces and energy
 ------------------------------------------------------------------------- */
 
-void PairAIREBO::TORSION(int eflag, int vflag)
+void PairAIREBO::TORSION(int eflag, int /*vflag*/)
 {
   int i,j,k,l,ii,inum;
   tagint itag,jtag;
@@ -2116,7 +2116,7 @@ but of the vector r_ij.
 
 */
 
-double PairAIREBO::bondorderLJ(int i, int j, double rij_mod[3], double rijmag_mod,
+double PairAIREBO::bondorderLJ(int i, int j, double /*rij_mod*/[3], double rijmag_mod,
                                double VA, double rij[3], double rijmag,
                                double **f, int vflag_atom)
 {

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -432,7 +432,7 @@ void PairComb::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairComb::settings(int narg, char **arg)
+void PairComb::settings(int narg, char **/*arg*/)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -1542,7 +1542,7 @@ void PairComb::potal_calc(double &calc1, double &calc2, double &calc3)
 
 void PairComb::tri_point(double rsq, int &mr1, int &mr2,
                          int &mr3, double &sr1, double &sr2,
-                         double &sr3, int &itype)
+                         double &sr3, int &/*itype*/)
 {
  double r, rin, dr, dd, rr1, rridr, rridr2;
 
@@ -1572,7 +1572,7 @@ void PairComb::tri_point(double rsq, int &mr1, int &mr2,
 void PairComb::direct(int inty, int mr1, int mr2, int mr3, double rsq,
                       double sr1, double sr2, double sr3,
                       double iq, double jq,
-                      double potal, double fac11, double fac11e,
+                      double /*potal*/, double fac11, double fac11e,
                       double &pot_tmp, double &pot_d)
 {
  double r,erfcc,fafbn1,potij,sme2,esucon;
@@ -2002,7 +2002,7 @@ void PairComb::Over_cor(Param *param, double rsq1, int NCoi,
 /* ---------------------------------------------------------------------- */
 
 int PairComb::pack_forward_comm(int n, int *list, double *buf,
-                                int pbc_flag, int *pbc)
+                                int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -1569,7 +1569,7 @@ void PairComb3::compute(int eflag, int vflag)
 /* ---------------------------------------------------------------------- */
 
 void PairComb3::repulsive(Param *parami, Param *paramj, double rsq,
-        double &fforce,int eflag, double &eng, double iq, double jq)
+        double &fforce,int /*eflag*/, double &eng, double iq, double jq)
 {
   double r,tmp_fc,tmp_fc_d,Di,Dj;
   double caj,vrcs,fvrcs;
@@ -1614,7 +1614,7 @@ void PairComb3::repulsive(Param *parami, Param *paramj, double rsq,
 /* ---------------------------------------------------------------------- */
 
 double PairComb3::zeta(Param *parami, Param *paramj, double rsqij,
-        double rsqik, double *delrij, double *delrik, int i, double xcn)
+        double rsqik, double *delrij, double *delrik, int /*i*/, double xcn)
 {
   double rij,rik,costheta,arg,ex_delr,rlm3;
 
@@ -1661,7 +1661,7 @@ void PairComb3::selfp6p(Param *parami, Param *paramj, double rsq,
 /* ---------------------------------------------------------------------- */
 
 double PairComb3::ep6p(Param *paramj, Param *paramk, double rsqij, double rsqik,
-                     double *delrij, double *delrik , double &zet_add)
+                     double *delrij, double *delrik , double &/*zet_add*/)
 {
   double comtt;
   double pplp0 = paramj->p6p0;
@@ -2109,7 +2109,7 @@ void PairComb3::coord(Param *param, double r, int i,
 
 void PairComb3::cntri_int(int tri_flag, double xval, double yval,
                 double zval, int ixmin, int iymin, int izmin, double &vval,
-                double &dvalx, double &dvaly, double &dvalz, Param *param)
+                double &dvalx, double &dvaly, double &dvalz, Param */*param*/)
 {
   double x;
   vval = 0.0; dvalx = 0.0; dvaly = 0.0; dvalz = 0.0;
@@ -2254,7 +2254,7 @@ void PairComb3::comb_gijk_d(double costheta, Param *param, double nco_tmp,
 void PairComb3::attractive(Param *parami, Param *paramj , Param *paramk, double prefac_ij1,
         double prefac_ij2, double prefac_ij3, double prefac_ij4,
         double prefac_ij5, double rsqij, double rsqik, double *delrij,
-        double *delrik, double *fi, double *fj,double *fk, int i, double xcn)
+        double *delrik, double *fi, double *fj,double *fk, int /*i*/, double xcn)
 {
   double rij_hat[3],rik_hat[3];
   double rij,rijinv,rik,rikinv;
@@ -2867,7 +2867,7 @@ void PairComb3::field(Param *parami, Param *paramj, double rsq, double iq,
 
 /* ---------------------------------------------------------------------- */
 
-double PairComb3::rad_init(double rsq2,Param *param,int i,
+double PairComb3::rad_init(double rsq2,Param *param,int /*i*/,
                 double &radtot, double cnconj)
 {
   double r, fc1k, radcut;
@@ -2882,7 +2882,7 @@ double PairComb3::rad_init(double rsq2,Param *param,int i,
 /* ---------------------------------------------------------------------- */
 
 void PairComb3::rad_calc(double r, Param *parami, Param *paramj,
-        double kconjug, double lconjug, int i, int j, double xcn, double ycn)
+        double kconjug, double lconjug, int /*i*/, int /*j*/, double xcn, double ycn)
 {
   int ixmin, iymin, izmin;
   int radindx;
@@ -3061,7 +3061,7 @@ double PairComb3::bbtor1(int torindx, Param *paramk, Param *paraml,
 /* ---------------------------------------------------------------------- */
 
 void PairComb3::tor_calc(double r, Param *parami, Param *paramj,
-        double kconjug, double lconjug, int i, int j, double xcn, double ycn)
+        double kconjug, double lconjug, int /*i*/, int /*j*/, double xcn, double ycn)
 {
   int ixmin, iymin, izmin;
   double vtor, dtorx, dtory, dtorz;
@@ -3589,7 +3589,7 @@ void PairComb3::qfo_dipole(double fac11, int mr1, int mr2, int mr3,
 
 void PairComb3::qfo_short(Param *parami, Param *paramj, double rsq,
         double iq, double jq, double &fqij, double &fqji,
-        int i, int j, int nj)
+        int i, int /*j*/, int nj)
 {
   double r, tmp_fc;
   double Di, Dj, dDi, dDj, Bsi, Bsj, dBsi, dBsj;
@@ -3863,7 +3863,7 @@ double PairComb3::switching_d(double rr)
 /* ---------------------------------------------------------------------- */
 
 int PairComb3::pack_forward_comm(int n, int *list, double *buf,
-                                 int pbc_flag, int *pbc)
+                                 int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -347,7 +347,7 @@ void PairEAM::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairEAM::settings(int narg, char **arg)
+void PairEAM::settings(int narg, char **/*arg*/)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -795,7 +795,7 @@ void PairEAM::grab(FILE *fptr, int n, double *list)
 /* ---------------------------------------------------------------------- */
 
 double PairEAM::single(int i, int j, int itype, int jtype,
-                       double rsq, double factor_coul, double factor_lj,
+                       double rsq, double /*factor_coul*/, double /*factor_lj*/,
                        double &fforce)
 {
   int m;
@@ -829,7 +829,7 @@ double PairEAM::single(int i, int j, int itype, int jtype,
 /* ---------------------------------------------------------------------- */
 
 int PairEAM::pack_forward_comm(int n, int *list, double *buf,
-                               int pbc_flag, int *pbc)
+                               int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_eam_cd.cpp
+++ b/src/MANYBODY/pair_eam_cd.cpp
@@ -539,7 +539,7 @@ void PairEAMCD::read_h_coeff(char *filename)
 /* ---------------------------------------------------------------------- */
 
 int PairEAMCD::pack_forward_comm(int n, int *list, double *buf,
-                                 int pbc_flag, int *pbc)
+                                 int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_eim.cpp
+++ b/src/MANYBODY/pair_eim.cpp
@@ -342,7 +342,7 @@ void PairEIM::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairEIM::settings(int narg, char **arg)
+void PairEIM::settings(int narg, char **/*arg*/)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -850,7 +850,7 @@ void PairEIM::array2spline()
 /* ---------------------------------------------------------------------- */
 
 void PairEIM::interpolate(int n, double delta, double *f,
-                          double **spline, double origin)
+                          double **spline, double /*origin*/)
 {
   for (int m = 1; m <= n; m++) spline[m][6] = f[m];
 
@@ -1087,7 +1087,7 @@ double PairEIM::funccoul(int i, int j, double r)
 /* ---------------------------------------------------------------------- */
 
 int PairEIM::pack_forward_comm(int n, int *list, double *buf,
-                               int pbc_flag, int *pbc)
+                               int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_gw.cpp
+++ b/src/MANYBODY/pair_gw.cpp
@@ -257,7 +257,7 @@ void PairGW::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairGW::settings(int narg, char **arg)
+void PairGW::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/MANYBODY/pair_lcbop.cpp
+++ b/src/MANYBODY/pair_lcbop.cpp
@@ -121,7 +121,7 @@ void PairLCBOP::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairLCBOP::settings(int narg, char **arg) {
+void PairLCBOP::settings(int narg, char **/*arg*/) {
   if( narg != 0 ) error->all(FLERR,"Illegal pair_style command");
 }
 
@@ -353,7 +353,7 @@ void PairLCBOP::SR_neigh()
   Short range forces and energy
 ------------------------------------------------------------------------- */
 
-void PairLCBOP::FSR(int eflag, int vflag)
+void PairLCBOP::FSR(int eflag, int /*vflag*/)
 {
   int i,j,jj,ii,inum;
   tagint itag,jtag;
@@ -449,7 +449,7 @@ void PairLCBOP::FSR(int eflag, int vflag)
    compute long range forces and energy
 ------------------------------------------------------------------------- */
 
-void PairLCBOP::FLR(int eflag, int vflag)
+void PairLCBOP::FLR(int eflag, int /*vflag*/)
 {
   int i,j,jj,ii;
   tagint itag,jtag;

--- a/src/MANYBODY/pair_nb3b_harmonic.cpp
+++ b/src/MANYBODY/pair_nb3b_harmonic.cpp
@@ -174,7 +174,7 @@ void PairNb3bHarmonic::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairNb3bHarmonic::settings(int narg, char **arg)
+void PairNb3bHarmonic::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -454,7 +454,7 @@ void PairNb3bHarmonic::setup_params()
 /* ---------------------------------------------------------------------- */
 
 
-void PairNb3bHarmonic::threebody(Param *paramij, Param *paramik,
+void PairNb3bHarmonic::threebody(Param */*paramij*/, Param */*paramik*/,
                                  Param *paramijk,
                                  double rsq1, double rsq2,
                                  double *delr1, double *delr2,

--- a/src/MANYBODY/pair_polymorphic.cpp
+++ b/src/MANYBODY/pair_polymorphic.cpp
@@ -450,7 +450,7 @@ void PairPolymorphic::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairPolymorphic::settings(int narg, char **arg)
+void PairPolymorphic::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/MANYBODY/pair_rebo.cpp
+++ b/src/MANYBODY/pair_rebo.cpp
@@ -24,7 +24,7 @@ PairREBO::PairREBO(LAMMPS *lmp) : PairAIREBO(lmp) {}
    global settings
 ------------------------------------------------------------------------- */
 
-void PairREBO::settings(int narg, char **arg)
+void PairREBO::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -239,7 +239,7 @@ void PairSW::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairSW::settings(int narg, char **arg)
+void PairSW::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -280,7 +280,7 @@ void PairTersoff::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairTersoff::settings(int narg, char **arg)
+void PairTersoff::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -245,7 +245,7 @@ void PairVashishta::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairVashishta::settings(int narg, char **arg)
+void PairVashishta::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -695,7 +695,7 @@ void FixAtomSwap::update_swap_atoms_list()
 
 /* ---------------------------------------------------------------------- */
 
-int FixAtomSwap::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc)
+int FixAtomSwap::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/MC/fix_bond_break.cpp
+++ b/src/MC/fix_bond_break.cpp
@@ -693,7 +693,7 @@ int FixBondBreak::dedup(int nstart, int nstop, tagint *copy)
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondBreak::post_integrate_respa(int ilevel, int iloop)
+void FixBondBreak::post_integrate_respa(int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_integrate();
 }
@@ -701,7 +701,7 @@ void FixBondBreak::post_integrate_respa(int ilevel, int iloop)
 /* ---------------------------------------------------------------------- */
 
 int FixBondBreak::pack_forward_comm(int n, int *list, double *buf,
-                                    int pbc_flag, int *pbc)
+                                    int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,k,m,ns;
 

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -258,14 +258,14 @@ void FixBondCreate::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::init_list(int id, NeighList *ptr)
+void FixBondCreate::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::setup(int vflag)
+void FixBondCreate::setup(int /*vflag*/)
 {
   int i,j,m;
 
@@ -1206,7 +1206,7 @@ int FixBondCreate::dedup(int nstart, int nstop, tagint *copy)
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondCreate::post_integrate_respa(int ilevel, int iloop)
+void FixBondCreate::post_integrate_respa(int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_integrate();
 }
@@ -1214,7 +1214,7 @@ void FixBondCreate::post_integrate_respa(int ilevel, int iloop)
 /* ---------------------------------------------------------------------- */
 
 int FixBondCreate::pack_forward_comm(int n, int *list, double *buf,
-                                     int pbc_flag, int *pbc)
+                                     int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,k,m,ns;
 
@@ -1347,7 +1347,7 @@ void FixBondCreate::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixBondCreate::copy_arrays(int i, int j, int delflag)
+void FixBondCreate::copy_arrays(int i, int j, int /*delflag*/)
 {
   bondcount[j] = bondcount[i];
 }

--- a/src/MC/fix_bond_swap.cpp
+++ b/src/MC/fix_bond_swap.cpp
@@ -182,7 +182,7 @@ void FixBondSwap::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondSwap::init_list(int id, NeighList *ptr)
+void FixBondSwap::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/MC/fix_tfmc.cpp
+++ b/src/MC/fix_tfmc.cpp
@@ -158,7 +158,7 @@ void FixTFMC::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixTFMC::initial_integrate(int vflag)
+void FixTFMC::initial_integrate(int /*vflag*/)
 {
   double boltz = force->boltz;
   double **x = atom->x;

--- a/src/MC/pair_dsmc.cpp
+++ b/src/MC/pair_dsmc.cpp
@@ -65,7 +65,7 @@ PairDSMC::~PairDSMC()
 
 /* ---------------------------------------------------------------------- */
 
-void PairDSMC::compute(int eflag, int vflag)
+void PairDSMC::compute(int /*eflag*/, int /*vflag*/)
 {
   double **x = atom->x;
   double *mass = atom->mass;
@@ -405,7 +405,7 @@ void PairDSMC::read_restart_settings(FILE *fp)
   the next nrezero timesteps
 -------------------------------------------------------------------------*/
 
-void PairDSMC::recompute_V_sigma_max(int icell)
+void PairDSMC::recompute_V_sigma_max(int /*icell*/)
 {
   int i,j,k;
   double Vsigma_max = 0;
@@ -459,7 +459,7 @@ double PairDSMC::V_sigma(int i, int j)
   generate new velocities for collided particles
 -------------------------------------------------------------------------*/
 
-void PairDSMC::scatter_random(int i, int j, int icell)
+void PairDSMC::scatter_random(int i, int j, int /*icell*/)
 {
   double mag_delv,cos_phi,cos_squared,r,theta;
   double delv[3],vcm[3];

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -325,7 +325,7 @@ void PairMEAM::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairMEAM::settings(int narg, char **arg)
+void PairMEAM::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -448,7 +448,7 @@ void PairMEAM::init_list(int id, NeighList *ptr)
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairMEAM::init_one(int i, int j)
+double PairMEAM::init_one(int /*i*/, int /*j*/)
 {
   return cutmax;
 }
@@ -734,7 +734,7 @@ void PairMEAM::read_files(char *globalfile, char *userfile)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAM::pack_forward_comm(int n, int *list, double *buf,
-                                int pbc_flag, int *pbc)
+                                int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,k,m;
 

--- a/src/MISC/fix_efield.cpp
+++ b/src/MISC/fix_efield.cpp
@@ -412,7 +412,7 @@ void FixEfield::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixEfield::post_force_respa(int vflag, int ilevel, int iloop)
+void FixEfield::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/MISC/fix_gld.cpp
+++ b/src/MISC/fix_gld.cpp
@@ -217,7 +217,7 @@ void FixGLD::init()
    First half of a timestep (V^{n} -> V^{n+1/2}; X^{n} -> X^{n+1})
 ------------------------------------------------------------------------- */
 
-void FixGLD::initial_integrate(int vflag)
+void FixGLD::initial_integrate(int /*vflag*/)
 {
   double dtfm;
   double ftm2v = force->ftm2v;
@@ -444,7 +444,7 @@ void FixGLD::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixGLD::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixGLD::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * (force->ftm2v);
@@ -458,7 +458,7 @@ void FixGLD::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGLD::final_integrate_respa(int ilevel, int iloop)
+void FixGLD::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtf = 0.5 * step_respa[ilevel] * (force->ftm2v);
   final_integrate();
@@ -507,7 +507,7 @@ void FixGLD::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixGLD::copy_arrays(int i, int j, int delflag)
+void FixGLD::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int k = 0; k < 3*prony_terms; k++) {
     s_gld[j][k] = s_gld[i][k];
@@ -588,7 +588,7 @@ void FixGLD::unpack_restart(int nlocal, int nth)
    fixes on a given processor.
 ------------------------------------------------------------------------- */
 
-int FixGLD::size_restart(int nlocal)
+int FixGLD::size_restart(int /*nlocal*/)
 {
   return 3*prony_terms+1;
 }

--- a/src/MISC/fix_orient_bcc.cpp
+++ b/src/MISC/fix_orient_bcc.cpp
@@ -230,7 +230,7 @@ void FixOrientBCC::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixOrientBCC::init_list(int id, NeighList *ptr)
+void FixOrientBCC::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -250,7 +250,7 @@ void FixOrientBCC::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixOrientBCC::post_force(int vflag)
+void FixOrientBCC::post_force(int /*vflag*/)
 {
   int i,j,k,ii,jj,inum,jnum,m,n,nn,nsort;
   tagint id_self;
@@ -471,7 +471,7 @@ void FixOrientBCC::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixOrientBCC::post_force_respa(int vflag, int ilevel, int iloop)
+void FixOrientBCC::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }
@@ -488,7 +488,7 @@ double FixOrientBCC::compute_scalar()
 /* ---------------------------------------------------------------------- */
 
 int FixOrientBCC::pack_forward_comm(int n, int *list, double *buf,
-                                    int pbc_flag, int *pbc)
+                                    int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,k,num;
   tagint id;

--- a/src/MISC/fix_orient_fcc.cpp
+++ b/src/MISC/fix_orient_fcc.cpp
@@ -228,7 +228,7 @@ void FixOrientFCC::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixOrientFCC::init_list(int id, NeighList *ptr)
+void FixOrientFCC::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -248,7 +248,7 @@ void FixOrientFCC::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixOrientFCC::post_force(int vflag)
+void FixOrientFCC::post_force(int /*vflag*/)
 {
   int i,j,k,ii,jj,inum,jnum,m,n,nn,nsort;
   tagint id_self;
@@ -469,7 +469,7 @@ void FixOrientFCC::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixOrientFCC::post_force_respa(int vflag, int ilevel, int iloop)
+void FixOrientFCC::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }
@@ -486,7 +486,7 @@ double FixOrientFCC::compute_scalar()
 /* ---------------------------------------------------------------------- */
 
 int FixOrientFCC::pack_forward_comm(int n, int *list, double *buf,
-                                    int pbc_flag, int *pbc)
+                                    int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,k,num;
   tagint id;

--- a/src/MISC/fix_ttm.cpp
+++ b/src/MISC/fix_ttm.cpp
@@ -235,7 +235,7 @@ void FixTTM::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTM::post_force(int vflag)
+void FixTTM::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double **v = atom->v;
@@ -287,7 +287,7 @@ void FixTTM::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTM::post_force_setup(int vflag)
+void FixTTM::post_force_setup(int /*vflag*/)
 {
   double **f = atom->f;
   int *mask = atom->mask;
@@ -306,14 +306,14 @@ void FixTTM::post_force_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTM::post_force_respa(int vflag, int ilevel, int iloop)
+void FixTTM::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTM::post_force_respa_setup(int vflag, int ilevel, int iloop)
+void FixTTM::post_force_respa_setup(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force_setup(vflag);
 }
@@ -685,7 +685,7 @@ int FixTTM::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixTTM::size_restart(int nlocal)
+int FixTTM::size_restart(int /*nlocal*/)
 {
   return 4;
 }

--- a/src/MISC/pair_nm_cut.cpp
+++ b/src/MISC/pair_nm_cut.cpp
@@ -401,8 +401,8 @@ void PairNMCut::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairNMCut::single(int i, int j, int itype, int jtype,
-                      double rsq, double factor_coul, double factor_lj,
+double PairNMCut::single(int /*i*/, int /*j*/, int itype, int jtype,
+                      double rsq, double /*factor_coul*/, double factor_lj,
                       double &fforce)
 {
   double r2inv,r,forcenm,phinm;

--- a/src/MISC/xdr_compat.cpp
+++ b/src/MISC/xdr_compat.cpp
@@ -650,7 +650,7 @@ xdrstdio_setpos (XDR *xdrs, unsigned int pos)
 }
 
 static xdr_int32_t *
-xdrstdio_inline (XDR *xdrs, int len)
+xdrstdio_inline (XDR */*xdrs*/, int /*len*/)
 {
   /*
    * Must do some work to implement this: must insure

--- a/src/MOLECULE/angle_cosine.cpp
+++ b/src/MOLECULE/angle_cosine.cpp
@@ -172,7 +172,7 @@ void AngleCosine::coeff(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-double AngleCosine::equilibrium_angle(int i)
+double AngleCosine::equilibrium_angle(int /*i*/)
 {
   return MY_PI;
 }

--- a/src/MOLECULE/angle_cosine_periodic.cpp
+++ b/src/MOLECULE/angle_cosine_periodic.cpp
@@ -222,7 +222,7 @@ void AngleCosinePeriodic::coeff(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-double AngleCosinePeriodic::equilibrium_angle(int i)
+double AngleCosinePeriodic::equilibrium_angle(int /*i*/)
 {
   return MY_PI;
 }

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -242,7 +242,7 @@ void BondFENE::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondFENE::single(int type, double rsq, int i, int j,
+double BondFENE::single(int type, double rsq, int /*i*/, int /*j*/,
                         double &fforce)
 {
   double r0sq = r0[type] * r0[type];

--- a/src/MOLECULE/bond_fene_expand.cpp
+++ b/src/MOLECULE/bond_fene_expand.cpp
@@ -253,7 +253,7 @@ void BondFENEExpand::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondFENEExpand::single(int type, double rsq, int i, int j,
+double BondFENEExpand::single(int type, double rsq, int /*i*/, int /*j*/,
                         double &fforce)
 {
   double r = sqrt(rsq);

--- a/src/MOLECULE/bond_gromos.cpp
+++ b/src/MOLECULE/bond_gromos.cpp
@@ -190,7 +190,7 @@ void BondGromos::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondGromos::single(int type, double rsq, int i, int j,
+double BondGromos::single(int type, double rsq, int /*i*/, int /*j*/,
                         double &fforce)
 {
   double dr = rsq - r0[type]*r0[type];

--- a/src/MOLECULE/bond_harmonic.cpp
+++ b/src/MOLECULE/bond_harmonic.cpp
@@ -190,7 +190,7 @@ void BondHarmonic::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondHarmonic::single(int type, double rsq, int i, int j,
+double BondHarmonic::single(int type, double rsq, int /*i*/, int /*j*/,
                         double &fforce)
 {
   double r = sqrt(rsq);

--- a/src/MOLECULE/bond_morse.cpp
+++ b/src/MOLECULE/bond_morse.cpp
@@ -196,7 +196,7 @@ void BondMorse::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondMorse::single(int type, double rsq, int i, int j,
+double BondMorse::single(int type, double rsq, int /*i*/, int /*j*/,
                          double &fforce)
 {
   double r = sqrt(rsq);

--- a/src/MOLECULE/bond_nonlinear.cpp
+++ b/src/MOLECULE/bond_nonlinear.cpp
@@ -191,7 +191,7 @@ void BondNonlinear::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondNonlinear::single(int type, double rsq, int i, int j,
+double BondNonlinear::single(int type, double rsq, int /*i*/, int /*j*/,
                              double &fforce)
 {
   double r = sqrt(rsq);

--- a/src/MOLECULE/bond_quartic.cpp
+++ b/src/MOLECULE/bond_quartic.cpp
@@ -251,7 +251,7 @@ void BondQuartic::init_style()
    return an equilbrium bond length
 ------------------------------------------------------------------------- */
 
-double BondQuartic::equilibrium_distance(int i)
+double BondQuartic::equilibrium_distance(int /*i*/)
 {
   return 0.97;
 }

--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -244,7 +244,7 @@ void BondTable::read_restart(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondTable::single(int type, double rsq, int i, int j,
+double BondTable::single(int type, double rsq, int /*i*/, int /*j*/,
                          double &fforce)
 {
   double r = sqrt(rsq);

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -295,7 +295,7 @@ void FixCMAP::pre_neighbor()
    store eflag, so can use it in post_force to tally per-atom energies
 ------------------------------------------------------------------------- */
 
-void FixCMAP::pre_reverse(int eflag, int vflag)
+void FixCMAP::pre_reverse(int eflag, int /*vflag*/)
 {
   eflag_caller = eflag;
 }
@@ -604,7 +604,7 @@ void FixCMAP::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixCMAP::post_force_respa(int vflag, int ilevel, int iloop)
+void FixCMAP::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }
@@ -1163,7 +1163,7 @@ void FixCMAP::read_data_section(char *keyword, int n, char *buf,
 
 /* ---------------------------------------------------------------------- */
 
-bigint FixCMAP::read_data_skip_lines(char *keyword)
+bigint FixCMAP::read_data_skip_lines(char */*keyword*/)
 {
   return ncmap;
 }
@@ -1173,7 +1173,7 @@ bigint FixCMAP::read_data_skip_lines(char *keyword)
    only called by proc 0
 ------------------------------------------------------------------------- */
 
-void FixCMAP::write_data_header(FILE *fp, int mth)
+void FixCMAP::write_data_header(FILE *fp, int /*mth*/)
 {
   fprintf(fp,BIGINT_FORMAT " cmap crossterms\n",ncmap);
 }
@@ -1186,7 +1186,7 @@ void FixCMAP::write_data_header(FILE *fp, int mth)
    ny = columns = type + 5 atom IDs
 ------------------------------------------------------------------------- */
 
-void FixCMAP::write_data_section_size(int mth, int &nx, int &ny)
+void FixCMAP::write_data_section_size(int /*mth*/, int &nx, int &ny)
 {
   int i,m;
 
@@ -1206,7 +1206,7 @@ void FixCMAP::write_data_section_size(int mth, int &nx, int &ny)
    buf allocated by caller as owned crossterms by 6
 ------------------------------------------------------------------------- */
 
-void FixCMAP::write_data_section_pack(int mth, double **buf)
+void FixCMAP::write_data_section_pack(int /*mth*/, double **buf)
 {
   int i,m;
 
@@ -1237,7 +1237,7 @@ void FixCMAP::write_data_section_pack(int mth, double **buf)
    only called by proc 0
 ------------------------------------------------------------------------- */
 
-void FixCMAP::write_data_section_keyword(int mth, FILE *fp)
+void FixCMAP::write_data_section_keyword(int /*mth*/, FILE *fp)
 {
   fprintf(fp,"\nCMAP\n\n");
 }
@@ -1249,7 +1249,7 @@ void FixCMAP::write_data_section_keyword(int mth, FILE *fp)
    only called by proc 0
 ------------------------------------------------------------------------- */
 
-void FixCMAP::write_data_section(int mth, FILE *fp,
+void FixCMAP::write_data_section(int /*mth*/, FILE *fp,
                                   int n, double **buf, int index)
 {
   for (int i = 0; i < n; i++)
@@ -1383,7 +1383,7 @@ void FixCMAP::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixCMAP::copy_arrays(int i, int j, int delflag)
+void FixCMAP::copy_arrays(int i, int j, int /*delflag*/)
 {
   num_crossterm[j] = num_crossterm[i];
 

--- a/src/MOLECULE/pair_hbond_dreiding_lj.cpp
+++ b/src/MOLECULE/pair_hbond_dreiding_lj.cpp
@@ -468,7 +468,7 @@ double PairHbondDreidingLJ::init_one(int i, int j)
 
 double PairHbondDreidingLJ::single(int i, int j, int itype, int jtype,
                                    double rsq,
-                                   double factor_coul, double factor_lj,
+                                   double /*factor_coul*/, double /*factor_lj*/,
                                    double &fforce)
 {
   int k,kk,ktype,knum,m;

--- a/src/MOLECULE/pair_hbond_dreiding_morse.cpp
+++ b/src/MOLECULE/pair_hbond_dreiding_morse.cpp
@@ -371,7 +371,7 @@ void PairHbondDreidingMorse::init_style()
 
 double PairHbondDreidingMorse::single(int i, int j, int itype, int jtype,
                                      double rsq,
-                                     double factor_coul, double factor_lj,
+                                     double /*factor_coul*/, double /*factor_lj*/,
                                      double &fforce)
 {
   int k,kk,ktype,knum,m;

--- a/src/MOLECULE/pair_tip4p_cut.cpp
+++ b/src/MOLECULE/pair_tip4p_cut.cpp
@@ -443,7 +443,7 @@ void PairTIP4PCut::init_style()
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairTIP4PCut::init_one(int i, int j)
+double PairTIP4PCut::init_one(int /*i*/, int /*j*/)
 {
   // include TIP4P qdist in full cutoff, qdist = 0.0 if not TIP4P
 

--- a/src/PERI/fix_peri_neigh.cpp
+++ b/src/PERI/fix_peri_neigh.cpp
@@ -140,7 +140,7 @@ void FixPeriNeigh::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixPeriNeigh::init_list(int id, NeighList *ptr)
+void FixPeriNeigh::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -159,7 +159,7 @@ void FixPeriNeigh::min_setup(int vflag)
    must be done in setup (not init) since fix init comes before neigh init
 ------------------------------------------------------------------------- */
 
-void FixPeriNeigh::setup(int vflag)
+void FixPeriNeigh::setup(int /*vflag*/)
 {
   int i,j,ii,jj,itype,jtype,inum,jnum;
   double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
@@ -441,7 +441,7 @@ void FixPeriNeigh::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixPeriNeigh::copy_arrays(int i, int j, int delflag)
+void FixPeriNeigh::copy_arrays(int i, int j, int /*delflag*/)
 {
   npartner[j] = npartner[i];
   for (int m = 0; m < npartner[j]; m++) {
@@ -514,7 +514,7 @@ int FixPeriNeigh::unpack_exchange(int nlocal, double *buf)
 /* ---------------------------------------------------------------------- */
 
 int FixPeriNeigh::pack_forward_comm(int n, int *list, double *buf,
-                                    int pbc_flag, int *pbc)
+                                    int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -434,7 +434,7 @@ void PairPeriEPS::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairPeriEPS::settings(int narg, char **arg)
+void PairPeriEPS::settings(int narg, char **/*arg*/)
 {
   if (narg) error->all(FLERR,"Illegal pair_style command");
 }
@@ -799,7 +799,7 @@ double PairPeriEPS::compute_DeviatoricForceStateNorm(int i)
 ---------------------------------------------------------------------- */
 
 int PairPeriEPS::pack_forward_comm(int n, int *list, double *buf,
-                                   int pbc_flag, int *pbc)
+                                   int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/PERI/pair_peri_lps.cpp
+++ b/src/PERI/pair_peri_lps.cpp
@@ -364,7 +364,7 @@ void PairPeriLPS::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairPeriLPS::settings(int narg, char **arg)
+void PairPeriLPS::settings(int narg, char **/*arg*/)
 {
   if (narg) error->all(FLERR,"Illegal pair_style command");
 }
@@ -631,7 +631,7 @@ void PairPeriLPS::compute_dilatation()
  ---------------------------------------------------------------------- */
 
 int PairPeriLPS::pack_forward_comm(int n, int *list, double *buf,
-                                   int pbc_flag, int *pbc)
+                                   int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/PERI/pair_peri_pmb.cpp
+++ b/src/PERI/pair_peri_pmb.cpp
@@ -297,7 +297,7 @@ void PairPeriPMB::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairPeriPMB::settings(int narg, char **arg)
+void PairPeriPMB::settings(int narg, char **/*arg*/)
 {
   if (narg) error->all(FLERR,"Illegal pair_style command");
 }
@@ -441,7 +441,7 @@ void PairPeriPMB::read_restart(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double PairPeriPMB::single(int i, int j, int itype, int jtype, double rsq,
-                           double factor_coul, double factor_lj,
+                           double /*factor_coul*/, double /*factor_lj*/,
                            double &fforce)
 {
   double delx0,dely0,delz0,rsq0;

--- a/src/PERI/pair_peri_ves.cpp
+++ b/src/PERI/pair_peri_ves.cpp
@@ -411,7 +411,7 @@ void PairPeriVES::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairPeriVES::settings(int narg, char **arg)
+void PairPeriVES::settings(int narg, char **/*arg*/)
 {
   if (narg) error->all(FLERR,"Illegal pair_style command");
 }
@@ -697,7 +697,7 @@ void PairPeriVES::compute_dilatation()
 ---------------------------------------------------------------------- */
 
 int PairPeriVES::pack_forward_comm(int n, int *list, double *buf,
-                                   int pbc_flag, int *pbc)
+                                   int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -274,7 +274,7 @@ void FixQEq::reallocate_matrix()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEq::init_list(int id, NeighList *ptr)
+void FixQEq::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -329,7 +329,7 @@ void FixQEq::init_storage()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEq::pre_force_respa(int vflag, int ilevel, int iloop)
+void FixQEq::pre_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) pre_force(vflag);
 }
@@ -471,7 +471,7 @@ void FixQEq::calculate_Q()
 /* ---------------------------------------------------------------------- */
 
 int FixQEq::pack_forward_comm(int n, int *list, double *buf,
-                          int pbc_flag, int *pbc)
+                          int /*pbc_flag*/, int */*pbc*/)
 {
   int m;
 
@@ -552,7 +552,7 @@ void FixQEq::grow_arrays(int nmax)
    copy values within fictitious charge arrays
 ------------------------------------------------------------------------- */
 
-void FixQEq::copy_arrays(int i, int j, int delflag)
+void FixQEq::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < nprev; m++) {
     s_hist[j][m] = s_hist[i][m];

--- a/src/QEQ/fix_qeq_dynamic.cpp
+++ b/src/QEQ/fix_qeq_dynamic.cpp
@@ -88,7 +88,7 @@ void FixQEqDynamic::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqDynamic::pre_force(int vflag)
+void FixQEqDynamic::pre_force(int /*vflag*/)
 {
   int i,ii,iloop,inum,*ilist;
   double qmass,dtq2;
@@ -247,7 +247,7 @@ double FixQEqDynamic::compute_eneg()
 /* ---------------------------------------------------------------------- */
 
 int FixQEqDynamic::pack_forward_comm(int n, int *list, double *buf,
-                          int pbc_flag, int *pbc)
+                          int /*pbc_flag*/, int */*pbc*/)
 {
   int m=0;
 

--- a/src/QEQ/fix_qeq_fire.cpp
+++ b/src/QEQ/fix_qeq_fire.cpp
@@ -104,7 +104,7 @@ void FixQEqFire::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqFire::pre_force(int vflag)
+void FixQEqFire::pre_force(int /*vflag*/)
 {
   int inum, *ilist;
   int i,ii,iloop;
@@ -311,7 +311,7 @@ double FixQEqFire::compute_eneg()
 /* ---------------------------------------------------------------------- */
 
 int FixQEqFire::pack_forward_comm(int n, int *list, double *buf,
-                          int pbc_flag, int *pbc)
+                          int /*pbc_flag*/, int */*pbc*/)
 {
   int m = 0;
 

--- a/src/QEQ/fix_qeq_point.cpp
+++ b/src/QEQ/fix_qeq_point.cpp
@@ -67,7 +67,7 @@ void FixQEqPoint::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqPoint::pre_force(int vflag)
+void FixQEqPoint::pre_force(int /*vflag*/)
 {
   if (update->ntimestep % nevery) return;
 

--- a/src/QEQ/fix_qeq_shielded.cpp
+++ b/src/QEQ/fix_qeq_shielded.cpp
@@ -111,7 +111,7 @@ void FixQEqShielded::init_shielding()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqShielded::pre_force(int vflag)
+void FixQEqShielded::pre_force(int /*vflag*/)
 {
   if (update->ntimestep % nevery) return;
 

--- a/src/QEQ/fix_qeq_slater.cpp
+++ b/src/QEQ/fix_qeq_slater.cpp
@@ -107,7 +107,7 @@ void FixQEqSlater::extract_streitz()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqSlater::pre_force(int vflag)
+void FixQEqSlater::pre_force(int /*vflag*/)
 {
   if (update->ntimestep % nevery) return;
 

--- a/src/REPLICA/fix_event.cpp
+++ b/src/REPLICA/fix_event.cpp
@@ -241,7 +241,7 @@ void FixEvent::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixEvent::copy_arrays(int i, int j, int delflag)
+void FixEvent::copy_arrays(int i, int j, int /*delflag*/)
 {
   xevent[j][0] = xevent[i][0];
   xevent[j][1] = xevent[i][1];

--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -270,7 +270,7 @@ void FixNEB::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixNEB::min_post_force(int vflag)
+void FixNEB::min_post_force(int /*vflag*/)
 {
   double vprev,vnext;
   double delxp,delyp,delzp,delxn,delyn,delzn;

--- a/src/RIGID/fix_rattle.cpp
+++ b/src/RIGID/fix_rattle.cpp
@@ -185,7 +185,7 @@ void FixRattle::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRattle::post_force_respa(int vflag, int ilevel, int iloop)
+void FixRattle::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   // remember vflag for the coordinate correction in this->final_integrate
 
@@ -625,7 +625,7 @@ void FixRattle::update_v_half_nocons()
 
 /* ---------------------------------------------------------------------- */
 
-void FixRattle::update_v_half_nocons_respa(int ilevel)
+void FixRattle::update_v_half_nocons_respa(int /*ilevel*/)
 {
   // carry out unconstrained velocity update
 

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -1096,7 +1096,7 @@ void FixRigid::compute_forces_and_torques()
 
 /* ---------------------------------------------------------------------- */
 
-void FixRigid::post_force(int vflag)
+void FixRigid::post_force(int /*vflag*/)
 {
   if (langflag) apply_langevin_thermostat();
   if (earlyflag) compute_forces_and_torques();
@@ -1141,7 +1141,7 @@ void FixRigid::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixRigid::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixRigid::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
@@ -1153,7 +1153,7 @@ void FixRigid::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRigid::final_integrate_respa(int ilevel, int iloop)
+void FixRigid::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
   final_integrate();
@@ -2478,7 +2478,7 @@ void FixRigid::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixRigid::copy_arrays(int i, int j, int delflag)
+void FixRigid::copy_arrays(int i, int j, int /*delflag*/)
 {
   body[j] = body[i];
   xcmimage[j] = xcmimage[i];

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -1030,7 +1030,6 @@ void FixRigid::enforce2d()
 void FixRigid::compute_forces_and_torques()
 {
   int i,ibody;
-  double dtfm;
 
   // sum over atoms to get force and torque on rigid body
 

--- a/src/RIGID/fix_rigid_nh.cpp
+++ b/src/RIGID/fix_rigid_nh.cpp
@@ -591,9 +591,9 @@ void FixRigidNH::initial_integrate(int vflag)
 
 void FixRigidNH::final_integrate()
 {
-  int i,ibody;
+  int ibody;
   double tmp,scale_t[3],scale_r;
-  double dtfm,xy,xz,yz;
+  double dtfm;
   double mbody[3],tbody[3],fquat[4];
 
   double dtf2 = dtf * 2.0;

--- a/src/RIGID/fix_rigid_nh_small.cpp
+++ b/src/RIGID/fix_rigid_nh_small.cpp
@@ -618,7 +618,7 @@ void FixRigidNHSmall::initial_integrate(int vflag)
 
 void FixRigidNHSmall::final_integrate()
 {
-  int i,ibody;
+  int ibody;
   double tmp,scale_t[3],scale_r;
   double dtfm;
   double mbody[3],tbody[3],fquat[4];

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -867,7 +867,7 @@ void FixRigidSmall::enforce2d()
 
 /* ---------------------------------------------------------------------- */
 
-void FixRigidSmall::post_force(int vflag)
+void FixRigidSmall::post_force(int /*vflag*/)
 {
   if (langflag) apply_langevin_thermostat();
   if (earlyflag) compute_forces_and_torques();
@@ -1004,7 +1004,7 @@ void FixRigidSmall::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixRigidSmall::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixRigidSmall::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
@@ -1016,7 +1016,7 @@ void FixRigidSmall::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRigidSmall::final_integrate_respa(int ilevel, int iloop)
+void FixRigidSmall::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
   final_integrate();
@@ -2999,7 +2999,7 @@ int FixRigidSmall::unpack_exchange(int nlocal, double *buf)
 ------------------------------------------------------------------------- */
 
 int FixRigidSmall::pack_forward_comm(int n, int *list, double *buf,
-                                     int pbc_flag, int *pbc)
+                                     int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j;
   double *xcm,*vcm,*quat,*omega,*ex_space,*ey_space,*ez_space,*conjqm;

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -2451,7 +2451,7 @@ void FixShake::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixShake::copy_arrays(int i, int j, int delflag)
+void FixShake::copy_arrays(int i, int j, int /*delflag*/)
 {
   int flag = shake_flag[j] = shake_flag[i];
   if (flag == 1) {
@@ -2528,7 +2528,7 @@ void FixShake::update_arrays(int i, int atom_offset)
 ------------------------------------------------------------------------- */
 
 void FixShake::set_molecule(int nlocalprev, tagint tagprev, int imol,
-                            double *xgeom, double *vcm, double *quat)
+                            double */*xgeom*/, double */*vcm*/, double */*quat*/)
 {
   int m,flag;
 

--- a/src/SHOCK/fix_append_atoms.cpp
+++ b/src/SHOCK/fix_append_atoms.cpp
@@ -231,7 +231,7 @@ int FixAppendAtoms::setmask()
 
 /* ---------------------------------------------------------------------- */
 
-void FixAppendAtoms::initial_integrate(int vflag)
+void FixAppendAtoms::initial_integrate(int /*vflag*/)
 {
   if (update->ntimestep % freq == 0) next_reneighbor = update->ntimestep;
 }
@@ -331,7 +331,7 @@ int FixAppendAtoms::get_spatial()
 
 /* ---------------------------------------------------------------------- */
 
-void FixAppendAtoms::post_force(int vflag)
+void FixAppendAtoms::post_force(int /*vflag*/)
 {
   double **f = atom->f;
   double **v = atom->v;

--- a/src/SHOCK/fix_msst.cpp
+++ b/src/SHOCK/fix_msst.cpp
@@ -357,7 +357,7 @@ void FixMSST::init()
    compute T,P before integrator starts
 ------------------------------------------------------------------------- */
 
-void FixMSST::setup(int vflag)
+void FixMSST::setup(int /*vflag*/)
 {
   lagrangian_position = 0.0;
 
@@ -442,7 +442,7 @@ void FixMSST::setup(int vflag)
    1st half of Verlet update
 ------------------------------------------------------------------------- */
 
-void FixMSST::initial_integrate(int vflag)
+void FixMSST::initial_integrate(int /*vflag*/)
 {
   int i,k;
   double p_msst;                       // MSST driving pressure

--- a/src/SHOCK/fix_wall_piston.cpp
+++ b/src/SHOCK/fix_wall_piston.cpp
@@ -171,7 +171,7 @@ int FixWallPiston::setmask()
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallPiston::initial_integrate(int vflag)
+void FixWallPiston::initial_integrate(int /*vflag*/)
 {
   next_reneighbor = update->ntimestep;
 }

--- a/src/SNAP/compute_sna_atom.cpp
+++ b/src/SNAP/compute_sna_atom.cpp
@@ -184,7 +184,7 @@ void ComputeSNAAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeSNAAtom::init_list(int id, NeighList *ptr)
+void ComputeSNAAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/SNAP/compute_snad_atom.cpp
+++ b/src/SNAP/compute_snad_atom.cpp
@@ -186,7 +186,7 @@ void ComputeSNADAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeSNADAtom::init_list(int id, NeighList *ptr)
+void ComputeSNADAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/SNAP/compute_snav_atom.cpp
+++ b/src/SNAP/compute_snav_atom.cpp
@@ -181,7 +181,7 @@ void ComputeSNAVAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeSNAVAtom::init_list(int id, NeighList *ptr)
+void ComputeSNAVAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/SNAP/compute_snav_atom.h
+++ b/src/SNAP/compute_snav_atom.h
@@ -45,7 +45,6 @@ class ComputeSNAVAtom : public Compute {
   double *radelem;
   double *wjelem;
   class SNA** snaptr;
-  double cutmax;
   int quadraticflag;
 };
 

--- a/src/SNAP/sna.cpp
+++ b/src/SNAP/sna.cpp
@@ -1231,7 +1231,7 @@ void SNA::compute_uarray(double x, double y, double z,
 }
 
 void SNA::compute_uarray_omp(double x, double y, double z,
-                             double z0, double r, int sub_threads)
+                             double z0, double r, int /*sub_threads*/)
 {
   double r0inv;
   double a_r, b_r, a_i, b_i;

--- a/src/SPIN/atom_vec_spin.cpp
+++ b/src/SPIN/atom_vec_spin.cpp
@@ -943,7 +943,7 @@ bigint AtomVecSpin::memory_usage()
   return bytes;
 }
 
-void AtomVecSpin::force_clear(int n, size_t nbytes)
+void AtomVecSpin::force_clear(int /*n*/, size_t nbytes)
 {
   memset(&atom->f[0][0],0,3*nbytes);
   memset(&atom->fm[0][0],0,3*nbytes);

--- a/src/SPIN/compute_spin.h
+++ b/src/SPIN/compute_spin.h
@@ -33,7 +33,6 @@ class ComputeSpin : public Compute {
 
  private:
   double kb,hbar;
-  int usecenter;
 
   void allocate();
 };

--- a/src/SPIN/fix_langevin_spin.cpp
+++ b/src/SPIN/fix_langevin_spin.cpp
@@ -192,7 +192,7 @@ void FixLangevinSpin::add_temperature(double fmi[3])
 
 /* ---------------------------------------------------------------------- */
 
-void FixLangevinSpin::post_force_respa(int vflag, int ilevel, int iloop)
+void FixLangevinSpin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }

--- a/src/SPIN/fix_nve_spin.cpp
+++ b/src/SPIN/fix_nve_spin.cpp
@@ -258,7 +258,7 @@ void FixNVESpin::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVESpin::initial_integrate(int vflag)
+void FixNVESpin::initial_integrate(int /*vflag*/)
 {
   double dtfm;
 	

--- a/src/SPIN/fix_precession_spin.cpp
+++ b/src/SPIN/fix_precession_spin.cpp
@@ -169,7 +169,7 @@ void FixPrecessionSpin::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixPrecessionSpin::post_force(int vflag)
+void FixPrecessionSpin::post_force(int /*vflag*/)
 {
   // update mag field with time (potential improvement)
 
@@ -245,7 +245,7 @@ void FixPrecessionSpin::compute_anisotropy(double spi[3], double fmi[3])
 
 /* ---------------------------------------------------------------------- */
 
-void FixPrecessionSpin::post_force_respa(int vflag, int ilevel, int iloop)
+void FixPrecessionSpin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/SPIN/pair_spin.cpp
+++ b/src/SPIN/pair_spin.cpp
@@ -63,7 +63,7 @@ PairSpin::~PairSpin() {}
    global settings
 ------------------------------------------------------------------------- */
 
-void PairSpin::settings(int narg, char **arg)
+void PairSpin::settings(int narg, char **/*arg*/)
 {
   if (narg < 1 || narg > 2)
     error->all(FLERR,"Incorrect number of args in pair_style pair/spin command");

--- a/src/SPIN/pair_spin_dmi.cpp
+++ b/src/SPIN/pair_spin_dmi.cpp
@@ -414,7 +414,7 @@ void PairSpinDmi::compute_dmi(int i, int j, double eij[3], double fmi[3], double
    compute the mechanical force due to the dmi interaction between atom i and atom j
 ------------------------------------------------------------------------- */
 
-void PairSpinDmi::compute_dmi_mech(int i, int j, double rsq, double eij[3], 
+void PairSpinDmi::compute_dmi_mech(int i, int j, double rsq, double /*eij*/[3], 
     double fi[3],  double spi[3], double spj[3])
 {
   int *type = atom->type;

--- a/src/SPIN/pair_spin_magelec.cpp
+++ b/src/SPIN/pair_spin_magelec.cpp
@@ -380,7 +380,7 @@ void PairSpinMagelec::compute_single_pair(int ii, double fmi[3])
 
 /* ---------------------------------------------------------------------- */
 
-void PairSpinMagelec::compute_magelec(int i, int j, double rsq, double eij[3], double fmi[3], double spj[3])
+void PairSpinMagelec::compute_magelec(int i, int j, double /*rsq*/, double eij[3], double fmi[3], double spj[3])
 {
   int *type = atom->type;
   int itype, jtype;

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -440,7 +440,7 @@ void FixSRD::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixSRD::setup(int vflag)
+void FixSRD::setup(int /*vflag*/)
 {
   setup_bounds();
 
@@ -703,7 +703,7 @@ void FixSRD::pre_neighbor()
    when collision occurs, change x,v of SRD, force,torque of BIG particle
 ------------------------------------------------------------------------- */
 
-void FixSRD::post_force(int vflag)
+void FixSRD::post_force(int /*vflag*/)
 {
   int i,m,ix,iy,iz;
 
@@ -2168,8 +2168,8 @@ void FixSRD::collision_ellipsoid_inexact(double *xs, double *xb,
    norm = surface normal of collision pt at time of collision
 ------------------------------------------------------------------------- */
 
-double FixSRD::collision_line_exact(double *xs, double *xb,
-                                    double *vs, double *vb, Big *big,
+double FixSRD::collision_line_exact(double */*xs*/, double */*xb*/,
+                                    double */*vs*/, double */*vb*/, Big */*big*/,
                                     double dt_step,
                                     double *xscoll, double *xbcoll,
                                     double *norm)
@@ -2197,8 +2197,8 @@ double FixSRD::collision_line_exact(double *xs, double *xb,
    norm = surface normal of collision pt at time of collision
 ------------------------------------------------------------------------- */
 
-double FixSRD::collision_tri_exact(double *xs, double *xb,
-                                   double *vs, double *vb, Big *big,
+double FixSRD::collision_tri_exact(double */*xs*/, double */*xb*/,
+                                   double */*vs*/, double */*vb*/, Big */*big*/,
                                    double dt_step,
                                    double *xscoll, double *xbcoll,
                                    double *norm)

--- a/src/USER-BOCS/fix_bocs.cpp
+++ b/src/USER-BOCS/fix_bocs.cpp
@@ -625,11 +625,9 @@ void FixBocs::init()
 // NJD MRD 2 functions
 int FixBocs::read_F_table( char *filename, int p_basis_type )
 {
-  char separator = ',';
   FILE *fpi;
   int N_columns = 2, n_entries = 0, i;
   float f1, f2;
-  double n1, n2;
   int test_sscanf;
   double **data = (double **) calloc(N_columns,sizeof(double *));
   char * line = (char *) calloc(200,sizeof(char));

--- a/src/USER-BOCS/fix_bocs.cpp
+++ b/src/USER-BOCS/fix_bocs.cpp
@@ -790,7 +790,7 @@ void FixBocs::build_cubic_splines( double **data )
    compute T,P before integrator starts
 ------------------------------------------------------------------------- */
 
-void FixBocs::setup(int vflag)
+void FixBocs::setup(int /*vflag*/)
 {
   // tdof needed by compute_temp_target()
 
@@ -875,7 +875,7 @@ void FixBocs::setup(int vflag)
    1st half of Verlet update
 ------------------------------------------------------------------------- */
 
-void FixBocs::initial_integrate(int vflag)
+void FixBocs::initial_integrate(int /*vflag*/)
 {
   // update eta_press_dot
 
@@ -970,7 +970,7 @@ void FixBocs::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixBocs::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixBocs::initial_integrate_respa(int /*vflag*/, int ilevel, int /*iloop*/)
 {
   // set timesteps by level
 
@@ -1039,7 +1039,7 @@ void FixBocs::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixBocs::final_integrate_respa(int ilevel, int iloop)
+void FixBocs::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   // set timesteps by level
 

--- a/src/USER-CGDNA/bond_oxdna_fene.cpp
+++ b/src/USER-CGDNA/bond_oxdna_fene.cpp
@@ -56,7 +56,7 @@ BondOxdnaFene::~BondOxdnaFene()
     compute vector COM-sugar-phosphate backbone interaction site in oxDNA
 ------------------------------------------------------------------------- */
 void BondOxdnaFene::compute_interaction_sites(double e1[3],
-  double e2[3], double r[3])
+  double /*e2*/[3], double r[3])
 {
   double d_cs=-0.4;
 
@@ -316,7 +316,7 @@ void BondOxdnaFene::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondOxdnaFene::single(int type, double rsq, int i, int j,
+double BondOxdnaFene::single(int type, double rsq, int /*i*/, int /*j*/,
                         double &fforce)
 {
   double r = sqrt(rsq);

--- a/src/USER-CGDNA/fix_nve_dot.cpp
+++ b/src/USER-CGDNA/fix_nve_dot.cpp
@@ -62,7 +62,7 @@ void FixNVEDot::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEDot::initial_integrate(int vflag)
+void FixNVEDot::initial_integrate(int /*vflag*/)
 {
   double *shape,*quat;
   double fquat[4],conjqm[4],inertia[3];

--- a/src/USER-CGDNA/fix_nve_dotc_langevin.cpp
+++ b/src/USER-CGDNA/fix_nve_dotc_langevin.cpp
@@ -127,7 +127,7 @@ void FixNVEDotcLangevin::compute_target()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEDotcLangevin::initial_integrate(int vflag)
+void FixNVEDotcLangevin::initial_integrate(int /*vflag*/)
 {
   double *shape,*quat;
   double fquat[4],conjqm[4],inertia[3];

--- a/src/USER-CGDNA/pair_oxdna2_coaxstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna2_coaxstk.cpp
@@ -542,7 +542,7 @@ void PairOxdna2Coaxstk::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairOxdna2Coaxstk::settings(int narg, char **arg)
+void PairOxdna2Coaxstk::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-CGDNA/pair_oxdna2_dh.cpp
+++ b/src/USER-CGDNA/pair_oxdna2_dh.cpp
@@ -264,7 +264,7 @@ void PairOxdna2Dh::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairOxdna2Dh::settings(int narg, char **arg)
+void PairOxdna2Dh::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/USER-CGDNA/pair_oxdna_coaxstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_coaxstk.cpp
@@ -666,7 +666,7 @@ void PairOxdnaCoaxstk::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairOxdnaCoaxstk::settings(int narg, char **arg)
+void PairOxdnaCoaxstk::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-CGDNA/pair_oxdna_excv.cpp
+++ b/src/USER-CGDNA/pair_oxdna_excv.cpp
@@ -92,7 +92,7 @@ PairOxdnaExcv::~PairOxdnaExcv()
     compute vector COM-excluded volume interaction sites in oxDNA
 ------------------------------------------------------------------------- */
 void PairOxdnaExcv::compute_interaction_sites(double e1[3],
-  double e2[3], double rs[3], double rb[3])
+  double /*e2*/[3], double rs[3], double rb[3])
 {
   double d_cs=-0.4, d_cb=+0.4;
 
@@ -441,7 +441,7 @@ void PairOxdnaExcv::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairOxdnaExcv::settings(int narg, char **arg)
+void PairOxdnaExcv::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-CGDNA/pair_oxdna_hbond.cpp
+++ b/src/USER-CGDNA/pair_oxdna_hbond.cpp
@@ -601,7 +601,7 @@ void PairOxdnaHbond::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairOxdnaHbond::settings(int narg, char **arg)
+void PairOxdnaHbond::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-CGDNA/pair_oxdna_stk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_stk.cpp
@@ -647,7 +647,7 @@ void PairOxdnaStk::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairOxdnaStk::settings(int narg, char **arg)
+void PairOxdnaStk::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-CGDNA/pair_oxdna_xstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_xstk.cpp
@@ -611,7 +611,7 @@ void PairOxdnaXstk::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairOxdnaXstk::settings(int narg, char **arg)
+void PairOxdnaXstk::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/USER-DIFFRACTION/fix_saed_vtk.cpp
@@ -325,7 +325,7 @@ void FixSAEDVTK::init()
    only does something if nvalid = current timestep
 ------------------------------------------------------------------------- */
 
-void FixSAEDVTK::setup(int vflag)
+void FixSAEDVTK::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/USER-DPD/fix_dpd_energy.cpp
+++ b/src/USER-DPD/fix_dpd_energy.cpp
@@ -57,7 +57,7 @@ int FixDPDenergy::setmask()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixDPDenergy::initial_integrate(int vflag)
+void FixDPDenergy::initial_integrate(int /*vflag*/)
 {
   int nlocal = atom->nlocal;
   if (igroup == atom->firstgroup) nlocal = atom->nfirst;

--- a/src/USER-DPD/fix_eos_table_rx.cpp
+++ b/src/USER-DPD/fix_eos_table_rx.cpp
@@ -178,7 +178,7 @@ int FixEOStableRX::setmask()
 
 /* ---------------------------------------------------------------------- */
 
-void FixEOStableRX::setup(int vflag)
+void FixEOStableRX::setup(int /*vflag*/)
 {
   int nlocal = atom->nlocal;
   int *mask = atom->mask;
@@ -803,7 +803,7 @@ void FixEOStableRX::temperature_lookup(int id, double ui, double &thetai)
 
 /* ---------------------------------------------------------------------- */
 
-int FixEOStableRX::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc)
+int FixEOStableRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
 {
   int ii,jj,m;
   double *uChem = atom->uChem;

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -729,7 +729,7 @@ void FixRX::setup_pre_force(int /*vflag*/)
 
 void FixRX::pre_force(int /*vflag*/)
 {
-  TimerType timer_start = getTimeStamp();
+  //TimerType timer_start = getTimeStamp();
 
   int nlocal = atom->nlocal;
   int nghost = atom->nghost;
@@ -808,7 +808,7 @@ void FixRX::pre_force(int /*vflag*/)
   comm->forward_comm_fix(this);
   if(localTempFlag) delete [] dpdThetaLocal;
 
-  TimerType timer_stop = getTimeStamp();
+  //TimerType timer_stop = getTimeStamp();
 
   double time_ODE = getElapsedTime(timer_localTemperature, timer_ODE);
 

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -668,7 +668,7 @@ void FixRX::init_list(int, class NeighList* ptr)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRX::setup_pre_force(int vflag)
+void FixRX::setup_pre_force(int /*vflag*/)
 {
   int nlocal = atom->nlocal;
   int nghost = atom->nghost;
@@ -727,7 +727,7 @@ void FixRX::setup_pre_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRX::pre_force(int vflag)
+void FixRX::pre_force(int /*vflag*/)
 {
   TimerType timer_start = getTimeStamp();
 
@@ -1191,7 +1191,7 @@ void FixRX::rkf45_step (const int neq, const double h, double y[], double y_out[
    return;
 }
 
-int FixRX::rkf45_h0 (const int neq, const double t, const double t_stop,
+int FixRX::rkf45_h0 (const int neq, const double t, const double /*t_stop*/,
                      const double hmin, const double hmax,
                      double& h0, double y[], double rwk[], void* v_params)
 {
@@ -1668,7 +1668,7 @@ int FixRX::rhs(double t, const double *y, double *dydt, void *params)
 
 /* ---------------------------------------------------------------------- */
 
-int FixRX::rhs_dense(double t, const double *y, double *dydt, void *params)
+int FixRX::rhs_dense(double /*t*/, const double *y, double *dydt, void *params)
 {
   UserRHSData *userData = (UserRHSData *) params;
 
@@ -1702,7 +1702,7 @@ int FixRX::rhs_dense(double t, const double *y, double *dydt, void *params)
 
 /* ---------------------------------------------------------------------- */
 
-int FixRX::rhs_sparse(double t, const double *y, double *dydt, void *v_params) const
+int FixRX::rhs_sparse(double /*t*/, const double *y, double *dydt, void *v_params) const
 {
    UserRHSData *userData = (UserRHSData *) v_params;
 
@@ -1885,7 +1885,7 @@ void FixRX::computeLocalTemperature()
 
 /* ---------------------------------------------------------------------- */
 
-int FixRX::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc)
+int FixRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
 {
   int ii,jj,m;
   double tmp;

--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -145,14 +145,14 @@ void FixShardlow::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixShardlow::init_list(int id, NeighList *ptr)
+void FixShardlow::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixShardlow::setup(int vflag)
+void FixShardlow::setup(int /*vflag*/)
 {
   bool fixShardlow = false;
 
@@ -527,7 +527,7 @@ while (ct-- > 0) {
   rand_state[id] = RNGstate;
 }
 
-void FixShardlow::initial_integrate(int vflag)
+void FixShardlow::initial_integrate(int /*vflag*/)
 {
   int ii;
 
@@ -646,7 +646,7 @@ fprintf(stdout, "\n%6d %6d,%6d %6d: "
 
 /* ---------------------------------------------------------------------- */
 
-int FixShardlow::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc)
+int FixShardlow::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
 {
   int ii,jj,m;
   double **v  = atom->v;

--- a/src/USER-DPD/pair_dpd_fdt.cpp
+++ b/src/USER-DPD/pair_dpd_fdt.cpp
@@ -433,8 +433,8 @@ void PairDPDfdt::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairDPDfdt::single(int i, int j, int itype, int jtype, double rsq,
-                       double factor_coul, double factor_dpd, double &fforce)
+double PairDPDfdt::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                       double /*factor_coul*/, double factor_dpd, double &fforce)
 {
   double r,rinv,wr,wd,phi;
 

--- a/src/USER-DPD/pair_dpd_fdt_energy.cpp
+++ b/src/USER-DPD/pair_dpd_fdt_energy.cpp
@@ -534,8 +534,8 @@ void PairDPDfdtEnergy::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairDPDfdtEnergy::single(int i, int j, int itype, int jtype, double rsq,
-                       double factor_coul, double factor_dpd, double &fforce)
+double PairDPDfdtEnergy::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                       double /*factor_coul*/, double factor_dpd, double &fforce)
 {
   double r,rinv,wr,wd,phi;
 

--- a/src/USER-DPD/pair_multi_lucy.cpp
+++ b/src/USER-DPD/pair_multi_lucy.cpp
@@ -781,7 +781,7 @@ void PairMultiLucy::computeLocalDensity()
 }
 /* ---------------------------------------------------------------------- */
 
-int PairMultiLucy::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc)
+int PairMultiLucy::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
   double *rho = atom->rho;

--- a/src/USER-DPD/pair_multi_lucy_rx.cpp
+++ b/src/USER-DPD/pair_multi_lucy_rx.cpp
@@ -1019,7 +1019,7 @@ void PairMultiLucyRX::getMixingWeights(int id, double &mixWtSite1old, double &mi
 
 /* ---------------------------------------------------------------------- */
 
-int PairMultiLucyRX::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc)
+int PairMultiLucyRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
   double *rho = atom->rho;

--- a/src/USER-DPD/pair_table_rx.cpp
+++ b/src/USER-DPD/pair_table_rx.cpp
@@ -439,7 +439,7 @@ void PairTableRX::coeff(int narg, char **arg)
 /* ---------------------------------------------------------------------- */
 
 double PairTableRX::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   int itable;

--- a/src/USER-DRUDE/fix_drude.cpp
+++ b/src/USER-DRUDE/fix_drude.cpp
@@ -235,7 +235,7 @@ void FixDrude::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixDrude::copy_arrays(int i, int j, int delflag)
+void FixDrude::copy_arrays(int i, int j, int /*delflag*/)
 {
     drudeid[j] = drudeid[i];
 }

--- a/src/USER-DRUDE/fix_langevin_drude.cpp
+++ b/src/USER-DRUDE/fix_langevin_drude.cpp
@@ -157,7 +157,7 @@ void FixLangevinDrude::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixLangevinDrude::setup(int vflag)
+void FixLangevinDrude::setup(int /*vflag*/)
 {
   if (!strstr(update->integrate_style,"verlet"))
     error->all(FLERR,"RESPA style not compatible with fix langevin/drude");

--- a/src/USER-DRUDE/pair_thole.cpp
+++ b/src/USER-DRUDE/pair_thole.cpp
@@ -363,7 +363,7 @@ void PairThole::read_restart_settings(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double PairThole::single(int i, int j, int itype, int jtype,
-                         double rsq, double factor_coul, double factor_lj,
+                         double rsq, double factor_coul, double /*factor_lj*/,
                          double &fforce)
 {
   double r2inv,rinv,r,phicoul;

--- a/src/USER-EFF/compute_temp_deform_eff.cpp
+++ b/src/USER-EFF/compute_temp_deform_eff.cpp
@@ -290,7 +290,7 @@ void ComputeTempDeformEff::remove_bias_all()
    assume remove_bias() was previously called
 ------------------------------------------------------------------------- */
 
-void ComputeTempDeformEff::restore_bias(int i, double *v)
+void ComputeTempDeformEff::restore_bias(int /*i*/, double *v)
 {
   v[0] += vbias[0];
   v[1] += vbias[1];

--- a/src/USER-EFF/compute_temp_region_eff.cpp
+++ b/src/USER-EFF/compute_temp_region_eff.cpp
@@ -263,7 +263,7 @@ void ComputeTempRegionEff::remove_bias_all()
    assume remove_bias() was previously called
 ------------------------------------------------------------------------- */
 
-void ComputeTempRegionEff::restore_bias(int i, double *v)
+void ComputeTempRegionEff::restore_bias(int /*i*/, double *v)
 {
   v[0] += vbias[0];
   v[1] += vbias[1];

--- a/src/USER-EFF/fix_langevin_eff.cpp
+++ b/src/USER-EFF/fix_langevin_eff.cpp
@@ -63,7 +63,7 @@ FixLangevinEff::~FixLangevinEff()
 
 /* ---------------------------------------------------------------------- */
 
-void FixLangevinEff::post_force(int vflag)
+void FixLangevinEff::post_force(int /*vflag*/)
 {
   if (tallyflag) post_force_tally();
   else post_force_no_tally();

--- a/src/USER-EFF/fix_nve_eff.cpp
+++ b/src/USER-EFF/fix_nve_eff.cpp
@@ -68,7 +68,7 @@ void FixNVEEff::init()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixNVEEff::initial_integrate(int vflag)
+void FixNVEEff::initial_integrate(int /*vflag*/)
 {
   double dtfm;
 
@@ -145,7 +145,7 @@ void FixNVEEff::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEEff::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixNVEEff::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
@@ -159,7 +159,7 @@ void FixNVEEff::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEEff::final_integrate_respa(int ilevel, int iloop)
+void FixNVEEff::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
   final_integrate();

--- a/src/USER-EFF/pair_eff_cut.cpp
+++ b/src/USER-EFF/pair_eff_cut.cpp
@@ -1009,7 +1009,7 @@ void PairEffCut::read_restart_settings(FILE *fp)
    these arrays are stored locally by pair style
 ------------------------------------------------------------------------- */
 
-void PairEffCut::min_xf_pointers(int ignore, double **xextra, double **fextra)
+void PairEffCut::min_xf_pointers(int /*ignore*/, double **xextra, double **fextra)
 {
   // grow arrays if necessary
   // need to be atom->nmax in length
@@ -1031,7 +1031,7 @@ void PairEffCut::min_xf_pointers(int ignore, double **xextra, double **fextra)
    calculate and store in min_eradius and min_erforce
 ------------------------------------------------------------------------- */
 
-void PairEffCut::min_xf_get(int ignore)
+void PairEffCut::min_xf_get(int /*ignore*/)
 {
   double *eradius = atom->eradius;
   double *erforce = atom->erforce;
@@ -1050,7 +1050,7 @@ void PairEffCut::min_xf_get(int ignore)
    propagate the change back to eradius
 ------------------------------------------------------------------------- */
 
-void PairEffCut::min_x_set(int ignore)
+void PairEffCut::min_x_set(int /*ignore*/)
 {
   double *eradius = atom->eradius;
   int *spin = atom->spin;

--- a/src/USER-FEP/fix_adapt_fep.cpp
+++ b/src/USER-FEP/fix_adapt_fep.cpp
@@ -387,7 +387,7 @@ void FixAdaptFEP::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixAdaptFEP::setup_pre_force(int vflag)
+void FixAdaptFEP::setup_pre_force(int /*vflag*/)
 {
   change_settings();
 }
@@ -402,7 +402,7 @@ void FixAdaptFEP::setup_pre_force_respa(int vflag, int ilevel)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAdaptFEP::pre_force(int vflag)
+void FixAdaptFEP::pre_force(int /*vflag*/)
 {
   if (nevery == 0) return;
 

--- a/src/USER-FEP/pair_coul_cut_soft.cpp
+++ b/src/USER-FEP/pair_coul_cut_soft.cpp
@@ -347,7 +347,7 @@ void PairCoulCutSoft::write_data_all(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double PairCoulCutSoft::single(int i, int j, int itype, int jtype,
-                           double rsq, double factor_coul, double factor_lj,
+                           double rsq, double factor_coul, double /*factor_lj*/,
                            double &fforce)
 {
   double forcecoul,phicoul;

--- a/src/USER-FEP/pair_coul_long_soft.cpp
+++ b/src/USER-FEP/pair_coul_long_soft.cpp
@@ -348,7 +348,7 @@ void PairCoulLongSoft::read_restart_settings(FILE *fp)
 
 double PairCoulLongSoft::single(int i, int j, int itype, int jtype,
                             double rsq,
-                            double factor_coul, double factor_lj,
+                            double factor_coul, double /*factor_lj*/,
                             double &fforce)
 {
   double r,grij,expm2,t,erfc,prefactor;

--- a/src/USER-FEP/pair_lj_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_soft.cpp
@@ -735,8 +735,8 @@ void PairLJCutSoft::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJCutSoft::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairLJCutSoft::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double forcelj,philj;

--- a/src/USER-FEP/pair_morse_soft.cpp
+++ b/src/USER-FEP/pair_morse_soft.cpp
@@ -360,8 +360,8 @@ void PairMorseSoft::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairMorseSoft::single(int i, int j, int itype, int jtype, double rsq,
-                             double factor_coul, double factor_lj,
+double PairMorseSoft::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                             double /*factor_coul*/, double factor_lj,
                              double &fforce)
 {
   double r, dr, dexp, dexp2, dexp3, phi;

--- a/src/USER-INTEL/angle_charmm_intel.cpp
+++ b/src/USER-INTEL/angle_charmm_intel.cpp
@@ -332,7 +332,7 @@ void AngleCharmmIntel::init_style()
 
 template <class flt_t, class acc_t>
 void AngleCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                        IntelBuffers<flt_t,acc_t> *buffers)
+                                        IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->nangletypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/angle_harmonic_intel.cpp
+++ b/src/USER-INTEL/angle_harmonic_intel.cpp
@@ -314,7 +314,7 @@ void AngleHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void AngleHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                        IntelBuffers<flt_t,acc_t> *buffers)
+                                        IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->nangletypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/bond_fene_intel.cpp
+++ b/src/USER-INTEL/bond_fene_intel.cpp
@@ -291,7 +291,7 @@ void BondFENEIntel::init_style()
 
 template <class flt_t, class acc_t>
 void BondFENEIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                         IntelBuffers<flt_t,acc_t> *buffers)
+                                         IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->nbondtypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/bond_harmonic_intel.cpp
+++ b/src/USER-INTEL/bond_harmonic_intel.cpp
@@ -262,7 +262,7 @@ void BondHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void BondHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                         IntelBuffers<flt_t,acc_t> *buffers)
+                                         IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->nbondtypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/dihedral_fourier_intel.cpp
+++ b/src/USER-INTEL/dihedral_fourier_intel.cpp
@@ -401,7 +401,7 @@ void DihedralFourierIntel::init_style()
 
 template <class flt_t, class acc_t>
 void DihedralFourierIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                            IntelBuffers<flt_t,acc_t> *buffers)
+                                            IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1, setflag, nterms, memory);

--- a/src/USER-INTEL/dihedral_harmonic_intel.cpp
+++ b/src/USER-INTEL/dihedral_harmonic_intel.cpp
@@ -396,7 +396,7 @@ void DihedralHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void DihedralHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> *buffers)
+                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/dihedral_opls_intel.cpp
+++ b/src/USER-INTEL/dihedral_opls_intel.cpp
@@ -416,7 +416,7 @@ void DihedralOPLSIntel::init_style()
 
 template <class flt_t, class acc_t>
 void DihedralOPLSIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> *buffers)
+                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/fix_intel.cpp
+++ b/src/USER-INTEL/fix_intel.cpp
@@ -724,11 +724,13 @@ void FixIntel::add_oresults(const ft * _noalias const f_in,
   lmp_ft * _noalias const f = (lmp_ft *) lmp->atom->f[0] + out_offset;
   if (atom->torque) {
     if (f_in[1].w)
+    {
       if (f_in[1].w == 1)
         error->all(FLERR,"Bad matrix inversion in mldivide3");
       else
         error->all(FLERR,
                    "Sphere particles not yet supported for gayberne/intel");
+    }
   }
 
   int packthreads;

--- a/src/USER-INTEL/fix_intel.cpp
+++ b/src/USER-INTEL/fix_intel.cpp
@@ -349,7 +349,7 @@ void FixIntel::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixIntel::setup(int vflag)
+void FixIntel::setup(int /*vflag*/)
 {
   if (neighbor->style != Neighbor::BIN)
     error->all(FLERR,
@@ -539,7 +539,7 @@ void FixIntel::check_neighbor_intel()
 
 /* ---------------------------------------------------------------------- */
 
-void FixIntel::pre_reverse(int eflag, int vflag)
+void FixIntel::pre_reverse(int /*eflag*/, int /*vflag*/)
 {
   if (_force_array_m != 0) {
     if (_need_reduce) {
@@ -652,7 +652,7 @@ template <class ft, class acc_t>
 void FixIntel::add_results(const ft * _noalias const f_in,
                            const acc_t * _noalias const ev_global,
                            const int eatom, const int vatom,
-                           const int offload) {
+                           const int /*offload*/) {
   start_watch(TIME_PACK);
   int f_length;
   #ifdef _LMP_INTEL_OFFLOAD
@@ -719,7 +719,7 @@ void FixIntel::add_results(const ft * _noalias const f_in,
 template <class ft, class acc_t>
 void FixIntel::add_oresults(const ft * _noalias const f_in,
                             const acc_t * _noalias const ev_global,
-                            const int eatom, const int vatom,
+                            const int eatom, const int /*vatom*/,
                             const int out_offset, const int nall) {
   lmp_ft * _noalias const f = (lmp_ft *) lmp->atom->f[0] + out_offset;
   if (atom->torque) {

--- a/src/USER-INTEL/fix_intel.h
+++ b/src/USER-INTEL/fix_intel.h
@@ -74,7 +74,7 @@ class FixIntel : public Fix {
   inline int nbor_pack_width() const { return _nbor_pack_width; }
   inline void nbor_pack_width(const int w) { _nbor_pack_width = w; }
   inline int three_body_neighbor() { return _three_body_neighbor; }
-  inline void three_body_neighbor(const int i) { _three_body_neighbor = 1; }
+  inline void three_body_neighbor(const int /*i*/) { _three_body_neighbor = 1; }
 
   inline int need_zero(const int tid) {
     if (_need_reduce == 0 && tid > 0) return 1;
@@ -159,8 +159,8 @@ class FixIntel : public Fix {
   inline int host_start_neighbor() { return 0; }
   inline int host_start_pair() { return 0; }
   inline void zero_timers() {}
-  inline void start_watch(const int which) {}
-  inline double stop_watch(const int which) { return 0.0; }
+  inline void start_watch(const int /*which*/) {}
+  inline double stop_watch(const int /*which*/) { return 0.0; }
   double * off_watch_pair() { return NULL; }
   double * off_watch_neighbor() { return NULL; }
   inline void balance_stamp() {}
@@ -238,7 +238,7 @@ class FixIntel : public Fix {
 
 /* ---------------------------------------------------------------------- */
 
-void FixIntel::get_buffern(const int offload, int &nlocal, int &nall,
+void FixIntel::get_buffern(const int /*offload*/, int &nlocal, int &nall,
                            int &minlocal) {
   #ifdef _LMP_INTEL_OFFLOAD
   if (_separate_buffers) {
@@ -273,7 +273,7 @@ void FixIntel::get_buffern(const int offload, int &nlocal, int &nall,
 /* ---------------------------------------------------------------------- */
 
 void FixIntel::add_result_array(IntelBuffers<double,double>::vec3_acc_t *f_in,
-                                double *ev_in, const int offload,
+                                double *ev_in, const int /*offload*/,
                                 const int eatom, const int vatom,
                                 const int rflag) {
   #ifdef _LMP_INTEL_OFFLOAD
@@ -301,7 +301,7 @@ void FixIntel::add_result_array(IntelBuffers<double,double>::vec3_acc_t *f_in,
 /* ---------------------------------------------------------------------- */
 
 void FixIntel::add_result_array(IntelBuffers<float,double>::vec3_acc_t *f_in,
-                                double *ev_in, const int offload,
+                                double *ev_in, const int /*offload*/,
                                 const int eatom, const int vatom,
                                 const int rflag) {
   #ifdef _LMP_INTEL_OFFLOAD
@@ -329,7 +329,7 @@ void FixIntel::add_result_array(IntelBuffers<float,double>::vec3_acc_t *f_in,
 /* ---------------------------------------------------------------------- */
 
 void FixIntel::add_result_array(IntelBuffers<float,float>::vec3_acc_t *f_in,
-                                float *ev_in, const int offload,
+                                float *ev_in, const int /*offload*/,
                                 const int eatom, const int vatom,
                                 const int rflag) {
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/USER-INTEL/fix_nh_intel.cpp
+++ b/src/USER-INTEL/fix_nh_intel.cpp
@@ -464,7 +464,6 @@ void FixNHIntel::nve_x()
 {
   double * _noalias const x = atom->x[0];
   double * _noalias const v = atom->v[0];
-  const double * _noalias const f = atom->f[0];
 
   // x update by full step only for atoms in group
 

--- a/src/USER-INTEL/fix_nve_asphere_intel.cpp
+++ b/src/USER-INTEL/fix_nve_asphere_intel.cpp
@@ -81,10 +81,6 @@ void FixNVEAsphereIntel::setup(int vflag)
 
 void FixNVEAsphereIntel::initial_integrate(int /*vflag*/)
 {
-  double dtfm;
-  double inertia[3],omega[3];
-  double *shape,*quat;
-
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
   int *ellipsoid = atom->ellipsoid;
   double * _noalias const x = atom->x[0];
@@ -94,7 +90,6 @@ void FixNVEAsphereIntel::initial_integrate(int /*vflag*/)
 
   double **angmom = atom->angmom;
   double **torque = atom->torque;
-  double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
   if (igroup == atom->firstgroup) nlocal = atom->nfirst;
 
@@ -142,8 +137,6 @@ void FixNVEAsphereIntel::initial_integrate(int /*vflag*/)
 void FixNVEAsphereIntel::final_integrate()
 {
   if (neighbor->ago == 0) reset_dt();
-
-  double dtfm;
 
   double * _noalias const v = atom->v[0];
   const double * _noalias const f = atom->f[0];

--- a/src/USER-INTEL/fix_nve_asphere_intel.cpp
+++ b/src/USER-INTEL/fix_nve_asphere_intel.cpp
@@ -79,7 +79,7 @@ void FixNVEAsphereIntel::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVEAsphereIntel::initial_integrate(int vflag)
+void FixNVEAsphereIntel::initial_integrate(int /*vflag*/)
 {
   double dtfm;
   double inertia[3],omega[3];

--- a/src/USER-INTEL/fix_nve_intel.cpp
+++ b/src/USER-INTEL/fix_nve_intel.cpp
@@ -56,7 +56,7 @@ void FixNVEIntel::setup(int vflag)
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixNVEIntel::initial_integrate(int vflag)
+void FixNVEIntel::initial_integrate(int /*vflag*/)
 {
   // update v and x of atoms in group
 

--- a/src/USER-INTEL/improper_cvff_intel.cpp
+++ b/src/USER-INTEL/improper_cvff_intel.cpp
@@ -428,7 +428,7 @@ void ImproperCvffIntel::init_style()
 
 template <class flt_t, class acc_t>
 void ImproperCvffIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> *buffers)
+                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->nimpropertypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/improper_harmonic_intel.cpp
+++ b/src/USER-INTEL/improper_harmonic_intel.cpp
@@ -384,7 +384,7 @@ void ImproperHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void ImproperHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> *buffers)
+                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   const int bp1 = atom->nimpropertypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/intel_buffers.cpp
+++ b/src/USER-INTEL/intel_buffers.cpp
@@ -109,7 +109,7 @@ void IntelBuffers<flt_t, acc_t>::free_buffers()
 template <class flt_t, class acc_t>
 void IntelBuffers<flt_t, acc_t>::_grow(const int nall, const int nlocal,
                                        const int nthreads,
-                                       const int offload_end)
+                                       const int /*offload_end*/)
 {
   free_buffers();
   _buf_size = static_cast<double>(nall) * 1.1 + 1;
@@ -200,7 +200,7 @@ void IntelBuffers<flt_t, acc_t>::free_nmax()
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t, class acc_t>
-void IntelBuffers<flt_t, acc_t>::_grow_nmax(const int offload_end)
+void IntelBuffers<flt_t, acc_t>::_grow_nmax(const int /*offload_end*/)
 {
   #ifdef _LMP_INTEL_OFFLOAD
   free_nmax();
@@ -264,7 +264,7 @@ void IntelBuffers<flt_t, acc_t>::free_list_local()
 
 template <class flt_t, class acc_t>
 void IntelBuffers<flt_t, acc_t>::_grow_list_local(NeighList *list,
-                                                  const int offload_end)
+                                                  const int /*offload_end*/)
 {
   free_list_local();
   int size = list->get_maxlocal();
@@ -310,10 +310,10 @@ void IntelBuffers<flt_t, acc_t>::free_nbor_list()
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t, class acc_t>
-void IntelBuffers<flt_t, acc_t>::_grow_nbor_list(NeighList *list,
+void IntelBuffers<flt_t, acc_t>::_grow_nbor_list(NeighList */*list*/,
                                                  const int nlocal,
                                                  const int nthreads,
-                                                 const int offload_end,
+                                                 const int /*offload_end*/,
                                                  const int pack_width)
 {
   free_nbor_list();
@@ -382,7 +382,7 @@ void IntelBuffers<flt_t, acc_t>::free_ccache()
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t, class acc_t>
-void IntelBuffers<flt_t, acc_t>::grow_ccache(const int off_flag,
+void IntelBuffers<flt_t, acc_t>::grow_ccache(const int /*off_flag*/,
         const int nthreads,
         const int width)
 {
@@ -481,7 +481,7 @@ void IntelBuffers<flt_t, acc_t>::free_ncache()
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t, class acc_t>
-void IntelBuffers<flt_t, acc_t>::grow_ncache(const int off_flag,
+void IntelBuffers<flt_t, acc_t>::grow_ncache(const int /*off_flag*/,
                                              const int nthreads)
 {
   const int nsize = get_max_nbors() * 3;

--- a/src/USER-INTEL/intel_buffers.h
+++ b/src/USER-INTEL/intel_buffers.h
@@ -135,24 +135,24 @@ class IntelBuffers {
 
   void set_ntypes(const int ntypes, const int use_ghost_cut = 0);
 
-  inline int * firstneigh(const NeighList *list) { return _list_alloc; }
-  inline int * cnumneigh(const NeighList *list) { return _cnumneigh; }
+  inline int * firstneigh(const NeighList */*list*/) { return _list_alloc; }
+  inline int * cnumneigh(const NeighList */*list*/) { return _cnumneigh; }
   inline int * get_atombin() { return _atombin; }
   inline int * get_binpacked() { return _binpacked; }
 
-  inline atom_t * get_x(const int offload = 1) {
+  inline atom_t * get_x(const int /*offload*/ = 1) {
     #ifdef _LMP_INTEL_OFFLOAD
     if (_separate_buffers && offload == 0) return _host_x;
     #endif
     return _x;
   }
-  inline flt_t * get_q(const int offload = 1) {
+  inline flt_t * get_q(const int /*offload*/ = 1) {
     #ifdef _LMP_INTEL_OFFLOAD
     if (_separate_buffers && offload == 0) return _host_q;
     #endif
     return _q;
   }
-  inline quat_t * get_quat(const int offload = 1) {
+  inline quat_t * get_quat(const int /*offload*/ = 1) {
     #ifdef _LMP_INTEL_OFFLOAD
     if (_separate_buffers && offload == 0) return _host_quat;
     #endif

--- a/src/USER-INTEL/intel_intrinsics_airebo.h
+++ b/src/USER-INTEL/intel_intrinsics_airebo.h
@@ -2243,7 +2243,7 @@ public:
   FVEC_BINOP(*, mul)
   FVEC_BINOP(/, div)
 
-  VEC_INLINE static void gather_prefetch0(const ivec &idx, const void * mem) {}
+  VEC_INLINE static void gather_prefetch0(const ivec & /*idx*/, const void * /*mem*/) {}
 };
 
 class avec {

--- a/src/USER-INTEL/intel_intrinsics_airebo.h
+++ b/src/USER-INTEL/intel_intrinsics_airebo.h
@@ -2057,8 +2057,8 @@ public:
   }
 
   VEC_INLINE static ivec set(
-      int i15, int i14, int i13, int i12, int i11, int i10, int i9, int i8,
-      int i7, int i6, int i5, int i4, int i3, int i2, int i1, int i0
+      int /*i15*/, int /*i14*/, int /*i13*/, int /*i12*/, int /*i11*/, int /*i10*/, int /*i9*/, int /*i8*/,
+      int /*i7*/, int /*i6*/, int /*i5*/, int /*i4*/, int /*i3*/, int /*i2*/, int /*i1*/, int i0
   ) {
     return i0;
   }

--- a/src/USER-INTEL/nbin_intel.cpp
+++ b/src/USER-INTEL/nbin_intel.cpp
@@ -192,14 +192,9 @@ void NBinIntel::bin_atoms(IntelBuffers<flt_t,acc_t> * buffers) {
 
   // ---------- Bin Atoms -------------
   _fix->start_watch(TIME_HOST_NEIGHBOR);
-  const ATOM_T * _noalias const x = buffers->get_x();
+  //const ATOM_T * _noalias const x = buffers->get_x();
   int * _noalias const atombin = this->_atombin;
   int * _noalias const binpacked = this->_binpacked;
-
-
-  const double sboxlo0 = bboxlo[0] + mbinxlo/bininvx;
-  const double sboxlo1 = bboxlo[1] + mbinylo/bininvy;
-  const double sboxlo2 = bboxlo[2] + mbinzlo/bininvz;
 
   int i, ibin;
 

--- a/src/USER-INTEL/npair_full_bin_ghost_intel.cpp
+++ b/src/USER-INTEL/npair_full_bin_ghost_intel.cpp
@@ -106,7 +106,7 @@ void NPairFullBinGhostIntel::fbi(NeighList * list,
 /* ---------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int need_ic>
-void NPairFullBinGhostIntel::fbi(const int offload, NeighList * list,
+void NPairFullBinGhostIntel::fbi(const int /*offload*/, NeighList * list,
                                  IntelBuffers<flt_t,acc_t> * buffers,
                                  const int pstart, const int pend) {
   if (pend-pstart == 0) return;

--- a/src/USER-INTEL/npair_full_bin_ghost_intel.cpp
+++ b/src/USER-INTEL/npair_full_bin_ghost_intel.cpp
@@ -115,7 +115,6 @@ void NPairFullBinGhostIntel::fbi(const int /*offload*/, NeighList * list,
   int nall_t = nall;
   const int aend = nall;
 
-  const int pack_width = _fix->nbor_pack_width();
   const ATOM_T * _noalias const x = buffers->get_x();
   int * _noalias const firstneigh = buffers->firstneigh(list);
   const int e_nall = nall_t;
@@ -155,9 +154,6 @@ void NPairFullBinGhostIntel::fbi(const int /*offload*/, NeighList * list,
   tagint * const molecule = atom->molecule;
   #endif
 
-  int *molindex = atom->molindex;
-  int *molatom = atom->molatom;
-  Molecule **onemols = atom->avec->onemols;
   int moltemplate;
   if (molecular == 2) moltemplate = 1;
   else moltemplate = 0;
@@ -167,8 +163,8 @@ void NPairFullBinGhostIntel::fbi(const int /*offload*/, NeighList * list,
 
   int tnum;
   int *overflow;
-  double *timer_compute;
   #ifdef _LMP_INTEL_OFFLOAD
+  double *timer_compute;
   if (offload) {
     timer_compute = _fix->off_watch_neighbor();
     tnum = buffers->get_off_threads();
@@ -311,7 +307,7 @@ void NPairFullBinGhostIntel::fbi(const int /*offload*/, NeighList * list,
       int * _noalias const ttag = ncachetag + toffs;
 
       // loop over all atoms in other bins in stencil, store every pair
-      int istart, icount, ncount, oldbin = -9999999, lane, max_chunk;
+      int ncount, oldbin = -9999999;
       for (int i = ifrom; i < ito; i++) {
         const flt_t xtmp = x[i].x;
         const flt_t ytmp = x[i].y;

--- a/src/USER-INTEL/npair_intel.cpp
+++ b/src/USER-INTEL/npair_intel.cpp
@@ -109,8 +109,8 @@ void NPairIntel::bin_newton(const int /*offload*/, NeighList *list,
 
   int tnum;
   int *overflow;
-  double *timer_compute;
   #ifdef _LMP_INTEL_OFFLOAD
+  double *timer_compute;
   if (offload) {
     timer_compute = _fix->off_watch_neighbor();
     tnum = buffers->get_off_threads();
@@ -265,8 +265,9 @@ void NPairIntel::bin_newton(const int /*offload*/, NeighList *list,
       int * _noalias itjtype;
 
       // loop over all atoms in other bins in stencil, store every pair
-      int istart, icount, ncount, oldbin = -9999999, lane, max_chunk;
+      int istart, icount, ncount, oldbin = -9999999;
       #ifdef LMP_INTEL_3BODY_FAST
+      int lane, max_chunk;
       if (THREE) {
         lane = 0;
         max_chunk = 0;
@@ -579,7 +580,6 @@ void NPairIntel::bin_newton(const int /*offload*/, NeighList *list,
 
         int ns;
         if (THREE) {
-          int alln = n;
           ns = n - pack_offset;
           atombin[i] = ns;
           ns += n2 - pack_offset - maxnbors;

--- a/src/USER-INTEL/npair_intel.cpp
+++ b/src/USER-INTEL/npair_intel.cpp
@@ -54,10 +54,10 @@ NPairIntel::~NPairIntel() {
 
 template <class flt_t, class acc_t, int offload_noghost, int need_ic,
           int FULL, int TRI, int THREE>
-void NPairIntel::bin_newton(const int offload, NeighList *list,
+void NPairIntel::bin_newton(const int /*offload*/, NeighList *list,
                             IntelBuffers<flt_t,acc_t> *buffers,
                             const int astart, const int aend,
-                            const int offload_end) {
+                            const int /*offload_end*/) {
 
   if (aend-astart == 0) return;
 

--- a/src/USER-INTEL/pair_airebo_intel.cpp
+++ b/src/USER-INTEL/pair_airebo_intel.cpp
@@ -2200,7 +2200,7 @@ typedef typename intr_types<flt_t, acc_t>::bvec bvec;
 VEC_INLINE inline
 static void aut_loadatoms_vec(
     AtomAIREBOT<flt_t> * atoms, ivec j_vec,
-    fvec *x, fvec * y, fvec * z, bvec * type_mask, int * map, ivec map_i,
+    fvec *x, fvec * y, fvec * z, bvec * type_mask, int * /*map*/, ivec map_i,
     ivec c_1
 ) {
   const ivec c_4 = ivec::set1(4);
@@ -2413,7 +2413,7 @@ static fvec aut_eval_poly_lin_pd_2(int n, flt_t * vals, ivec idx, fvec x,
 }
 
 static fvec aut_mask_gSpline_pd_2(KernelArgsAIREBOT<flt_t,acc_t> * ka,
-                                  bvec active_mask, int itype, fvec cosjik,
+                                  bvec /*active_mask*/, int itype, fvec cosjik,
                                   fvec Nij, fvec *dgdc, fvec *dgdN) {
   int i;
   flt_t * gDom = NULL;
@@ -2835,7 +2835,7 @@ static void aut_frebo_data_writeback(
 static void aut_frebo_N_spline_force(
      KernelArgsAIREBOT<flt_t,acc_t> * _noalias ka,
      struct aut_frebo_data * _noalias data, int itype, int jtype, ivec vi,
-     ivec vj, fvec VA, fvec dN, fvec dNconj, fvec Nconj) {
+     ivec /*vj*/, fvec VA, fvec dN, fvec dNconj, fvec Nconj) {
   ivec c_i1 = ivec::set1(1);
   fvec c_2 = fvec::set1(2);
   fvec c_TOL = fvec::set1(TOL);
@@ -2999,8 +2999,8 @@ static fvec aut_frebo_sum_omega(
     KernelArgsAIREBOT<flt_t,acc_t> * _noalias ka,
     struct aut_frebo_data * _noalias i_data,
     struct aut_frebo_data * _noalias j_data,
-    int itype, int jtype,
-    ivec vi, ivec vj,
+    int /*itype*/, int /*jtype*/,
+    ivec /*vi*/, ivec /*vj*/,
     fvec r23x, fvec r23y, fvec r23z, fvec r23mag,
     fvec VA, fvec fij[3]
 ) {
@@ -3284,7 +3284,7 @@ static void aut_torsion_vec(
     KernelArgsAIREBOT<flt_t,acc_t> * ka,
     struct aut_frebo_data * i_data,
     struct aut_frebo_data * j_data,
-    ivec i, ivec j, fvec wij, fvec dwij
+    ivec /*i*/, ivec /*j*/, fvec wij, fvec dwij
 ) {
   AtomAIREBOT<flt_t> * x = ka->x;
   int * map = ka->map;
@@ -4134,7 +4134,7 @@ exceed_limits:
 /*
  * Attempt to look up an element in the hash-map.
  */
-static fvec aut_airebo_lj_tap_test_path(KernelArgsAIREBOT<flt_t,acc_t> * ka,
+static fvec aut_airebo_lj_tap_test_path(KernelArgsAIREBOT<flt_t,acc_t> * /*ka*/,
   struct aut_airebo_lj_test_path_result_data * test_path_result,
   bvec need_search, ivec i_bc, ivec j,
   LennardJonesPathAIREBOT<flt_t> path[fvec::VL]

--- a/src/USER-INTEL/pair_eam_intel.cpp
+++ b/src/USER-INTEL/pair_eam_intel.cpp
@@ -784,7 +784,7 @@ void PairEAMIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
 /* ---------------------------------------------------------------------- */
 
 int PairEAMIntel::pack_forward_comm(int n, int *list, double *buf,
-                                    int pbc_flag, int *pbc)
+                                    int /*pbc_flag*/, int */*pbc*/)
 {
   if (fix->precision() == FixIntel::PREC_MODE_DOUBLE)
     return pack_forward_comm(n, list, buf, fp);

--- a/src/USER-INTEL/pair_rebo_intel.cpp
+++ b/src/USER-INTEL/pair_rebo_intel.cpp
@@ -28,7 +28,7 @@ PairREBOIntel::PairREBOIntel(LAMMPS *lmp) : PairAIREBOIntel(lmp) {}
    global settings
 ------------------------------------------------------------------------- */
 
-void PairREBOIntel::settings(int narg, char **arg)
+void PairREBOIntel::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-INTEL/pair_sw_intel.cpp
+++ b/src/USER-INTEL/pair_sw_intel.cpp
@@ -173,7 +173,7 @@ template <int SPQ,int ONETYPE,int EFLAG,class flt_t,class acc_t>
 void PairSWIntel::eval(const int offload, const int vflag,
                        IntelBuffers<flt_t,acc_t> *buffers,
                        const ForceConst<flt_t> &fc, const int astart,
-                       const int aend, const int pad_width)
+                       const int aend, const int /*pad_width*/)
 {
   const int inum = aend - astart;
   if (inum == 0) return;

--- a/src/USER-INTEL/pppm_disp_intel.cpp
+++ b/src/USER-INTEL/pppm_disp_intel.cpp
@@ -723,7 +723,7 @@ void PPPMDispIntel::particle_map(double delx, double dely, double delz,
                                  double sft, int** p2g, int nup, int nlow,
                                  int nxlo, int nylo, int nzlo,
                                  int nxhi, int nyhi, int nzhi,
-                                 IntelBuffers<flt_t,acc_t> *buffers)
+                                 IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   int nlocal = atom->nlocal;
   int nthr = comm->nthreads;
@@ -790,7 +790,7 @@ void PPPMDispIntel::particle_map(double delx, double dely, double delz,
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_c(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::make_rho_c(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   // clear 3d density array
 
@@ -940,7 +940,7 @@ void PPPMDispIntel::make_rho_c(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_g(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::make_rho_g(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   // clear 3d density array
 
@@ -1091,7 +1091,7 @@ void PPPMDispIntel::make_rho_g(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_a(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::make_rho_a(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   // clear 3d density array
 
@@ -1225,7 +1225,7 @@ void PPPMDispIntel::make_rho_a(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_none(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::make_rho_none(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   FFT_SCALAR * _noalias global_density = &(density_brick_none[0][nzlo_out_6][nylo_out_6][nxlo_out_6]);
@@ -1373,7 +1373,7 @@ void PPPMDispIntel::make_rho_none(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_c_ik(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_c_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -1520,7 +1520,7 @@ void PPPMDispIntel::fieldforce_c_ik(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_c_ad(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_c_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -1725,7 +1725,7 @@ void PPPMDispIntel::fieldforce_c_ad(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_g_ik(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_g_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -1869,7 +1869,7 @@ void PPPMDispIntel::fieldforce_g_ik(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_g_ad(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_g_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2069,7 +2069,7 @@ void PPPMDispIntel::fieldforce_g_ad(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_a_ik(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_a_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2282,7 +2282,7 @@ void PPPMDispIntel::fieldforce_a_ik(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_a_ad(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_a_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2594,7 +2594,7 @@ void PPPMDispIntel::fieldforce_a_ad(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_none_ik(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_none_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2755,7 +2755,7 @@ void PPPMDispIntel::fieldforce_none_ik(IntelBuffers<flt_t,acc_t> *buffers)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_none_ad(IntelBuffers<flt_t,acc_t> *buffers)
+void PPPMDispIntel::fieldforce_none_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
 {
   // loop over my charges, interpolate electric field from nearby grid points
   // (nx,ny,nz) = global coords of grid pt to "lower left" of charge

--- a/src/USER-INTEL/pppm_intel.cpp
+++ b/src/USER-INTEL/pppm_intel.cpp
@@ -255,7 +255,7 @@ void PPPMIntel::compute_first(int eflag, int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void PPPMIntel::compute_second(int eflag, int vflag)
+void PPPMIntel::compute_second(int /*eflag*/, int /*vflag*/)
 {
   int i,j;
 

--- a/src/USER-LB/fix_lb_fluid.cpp
+++ b/src/USER-LB/fix_lb_fluid.cpp
@@ -646,7 +646,7 @@ void FixLbFluid::init(void)
 
 }
 
-void FixLbFluid::setup(int vflag)
+void FixLbFluid::setup(int /*vflag*/)
 {
   //--------------------------------------------------------------------------
   // Need to calculate the force on the fluid for a restart run.
@@ -655,7 +655,7 @@ void FixLbFluid::setup(int vflag)
     calc_fluidforce();
 }
 
-void FixLbFluid::initial_integrate(int vflag)
+void FixLbFluid::initial_integrate(int /*vflag*/)
 {
   //--------------------------------------------------------------------------
   // Print a header labelling any output printed to the screen.
@@ -711,7 +711,7 @@ void FixLbFluid::initial_integrate(int vflag)
     streamout();
 
 }
-void FixLbFluid::post_force(int vflag)
+void FixLbFluid::post_force(int /*vflag*/)
 {
   if(fixviscouslb==1)
     calc_fluidforce();
@@ -741,7 +741,7 @@ void FixLbFluid::grow_arrays(int nmax)
 //==========================================================================
 //   copy values within local atom-based array
 //==========================================================================
-void FixLbFluid::copy_arrays(int i, int j, int delflag)
+void FixLbFluid::copy_arrays(int i, int j, int /*delflag*/)
 {
   hydroF[j][0] = hydroF[i][0];
   hydroF[j][1] = hydroF[i][1];

--- a/src/USER-LB/fix_lb_pc.cpp
+++ b/src/USER-LB/fix_lb_pc.cpp
@@ -118,7 +118,7 @@ void FixLbPC::init()
 }
 
 /* ---------------------------------------------------------------------- */
-void FixLbPC::initial_integrate(int vflag) {
+void FixLbPC::initial_integrate(int /*vflag*/) {
 
   double dtfm;
 
@@ -285,7 +285,7 @@ void FixLbPC::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixLbPC::copy_arrays(int i, int j, int delflag)
+void FixLbPC::copy_arrays(int i, int j, int /*delflag*/)
 {
 
   force_old[j][0] = force_old[i][0];

--- a/src/USER-LB/fix_lb_rigid_pc_sphere.cpp
+++ b/src/USER-LB/fix_lb_rigid_pc_sphere.cpp
@@ -1454,7 +1454,7 @@ void FixLbRigidPCSphere::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixLbRigidPCSphere::copy_arrays(int i, int j, int delflag)
+void FixLbRigidPCSphere::copy_arrays(int i, int j, int /*delflag*/)
 {
   body[j] = body[i];
   up[j][0] = up[i][0];

--- a/src/USER-LB/fix_lb_viscous.cpp
+++ b/src/USER-LB/fix_lb_viscous.cpp
@@ -109,7 +109,7 @@ void FixLbViscous::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixLbViscous::post_force(int vflag)
+void FixLbViscous::post_force(int /*vflag*/)
 {
   // apply drag force to atoms in group
   // direction is opposed to velocity vector
@@ -132,7 +132,7 @@ void FixLbViscous::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixLbViscous::post_force_respa(int vflag, int ilevel, int iloop)
+void FixLbViscous::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }

--- a/src/USER-MANIFOLD/fix_manifoldforce.cpp
+++ b/src/USER-MANIFOLD/fix_manifoldforce.cpp
@@ -149,7 +149,7 @@ void FixManifoldForce::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixManifoldForce::post_force(int vflag)
+void FixManifoldForce::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double **f = atom->f;
@@ -177,7 +177,7 @@ void FixManifoldForce::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixManifoldForce::post_force_respa(int vflag, int ilevel, int iloop)
+void FixManifoldForce::post_force_respa(int vflag, int /*ilevel*/, int /*iloop*/)
 {
   post_force(vflag);
 }

--- a/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
+++ b/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
@@ -307,7 +307,7 @@ void FixNVEManifoldRattle::update_var_params()
 
 /* -----------------------------------------------------------------------------
    ---------------------------------------------------------------------------*/
-int FixNVEManifoldRattle::dof(int igroup)
+int FixNVEManifoldRattle::dof(int /*igroup*/)
 {
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
@@ -348,7 +348,7 @@ double FixNVEManifoldRattle::memory_usage()
 
 /* -----------------------------------------------------------------------------
    ---------------------------------------------------------------------------*/
-void FixNVEManifoldRattle::initial_integrate(int vflag)
+void FixNVEManifoldRattle::initial_integrate(int /*vflag*/)
 {
   update_var_params();
   nve_x_rattle(igroup, groupbit);

--- a/src/USER-MANIFOLD/fix_nvt_manifold_rattle.cpp
+++ b/src/USER-MANIFOLD/fix_nvt_manifold_rattle.cpp
@@ -229,7 +229,7 @@ void FixNVTManifoldRattle::init()
 
 
 
-void FixNVTManifoldRattle::setup(int vflag)
+void FixNVTManifoldRattle::setup(int /*vflag*/)
 {
   compute_temp_target();
 
@@ -371,7 +371,7 @@ void FixNVTManifoldRattle::nh_v_temp()
 
 
 // Most of this logic is based on fix_nh:
-void FixNVTManifoldRattle::initial_integrate(int vflag)
+void FixNVTManifoldRattle::initial_integrate(int /*vflag*/)
 {
 
   update_var_params();

--- a/src/USER-MANIFOLD/manifold.h
+++ b/src/USER-MANIFOLD/manifold.h
@@ -61,7 +61,7 @@ namespace user_manifold {
 
     virtual const char *id() = 0;
 
-    virtual void set_atom_id( tagint a_id ){}
+    virtual void set_atom_id( tagint /*a_id*/ ){}
     virtual int nparams() = 0;
     // double *get_params(){ return params; };
 

--- a/src/USER-MANIFOLD/manifold_cylinder.cpp
+++ b/src/USER-MANIFOLD/manifold_cylinder.cpp
@@ -5,8 +5,8 @@ using namespace LAMMPS_NS;
 using namespace user_manifold;
 
 
-manifold_cylinder::manifold_cylinder( LAMMPS *lmp, int argc,
-                                      char **argv ) : manifold(lmp)
+manifold_cylinder::manifold_cylinder( LAMMPS *lmp, int /*argc*/,
+                                      char **/*argv*/ ) : manifold(lmp)
 {}
 
 

--- a/src/USER-MANIFOLD/manifold_cylinder_dent.cpp
+++ b/src/USER-MANIFOLD/manifold_cylinder_dent.cpp
@@ -8,8 +8,8 @@ using namespace LAMMPS_NS;
 
 using namespace user_manifold;
 
-manifold_cylinder_dent::manifold_cylinder_dent( LAMMPS *lmp, int argc,
-                                                char **argv ) : manifold(lmp)
+manifold_cylinder_dent::manifold_cylinder_dent( LAMMPS *lmp, int /*argc*/,
+                                                char **/*argv*/ ) : manifold(lmp)
 {}
 
 

--- a/src/USER-MANIFOLD/manifold_dumbbell.cpp
+++ b/src/USER-MANIFOLD/manifold_dumbbell.cpp
@@ -6,7 +6,7 @@ using namespace LAMMPS_NS;
 
 using namespace user_manifold;
 
-manifold_dumbbell::manifold_dumbbell( LAMMPS *lmp, int argc, char **argv ) : manifold(lmp)
+manifold_dumbbell::manifold_dumbbell( LAMMPS *lmp, int /*argc*/, char **/*argv*/ ) : manifold(lmp)
 {}
 
 

--- a/src/USER-MANIFOLD/manifold_ellipsoid.cpp
+++ b/src/USER-MANIFOLD/manifold_ellipsoid.cpp
@@ -4,7 +4,7 @@ using namespace LAMMPS_NS;
 
 using namespace user_manifold;
 
-manifold_ellipsoid::manifold_ellipsoid( LAMMPS *lmp, int narg, char **argv ) : manifold(lmp)
+manifold_ellipsoid::manifold_ellipsoid( LAMMPS *lmp, int /*narg*/, char **/*argv*/ ) : manifold(lmp)
 {}
 
 

--- a/src/USER-MANIFOLD/manifold_gaussian_bump.cpp
+++ b/src/USER-MANIFOLD/manifold_gaussian_bump.cpp
@@ -25,7 +25,6 @@ public:
 
   cubic_hermite( double x0, double x1, double y0, double y1,
                  double yp0, double yp1, LAMMPS_NS::Error *err ) :
-    x0(x0), x1(x1), y0(y0), y1(y1), yp0(yp0), yp1(yp1),
     a(  2*x0 + 2 - 2*x1 ),
     b( -3*x0 - 3 + 3*x1 ),
     c( 1.0 ),
@@ -34,6 +33,7 @@ public:
     u( -3*y0 + 3*y1 - 2*yp0 - yp1  ),
     v(  yp0  ),
     w(  y0 ),
+    x0(x0), x1(x1), y0(y0), y1(y1), yp0(yp0), yp1(yp1),
     err(err)
   {
     test();

--- a/src/USER-MANIFOLD/manifold_gaussian_bump.cpp
+++ b/src/USER-MANIFOLD/manifold_gaussian_bump.cpp
@@ -133,7 +133,7 @@ public:
 
 // Manifold itself:
 manifold_gaussian_bump::manifold_gaussian_bump(class LAMMPS* lmp,
-                                               int narg, char **arg)
+                                               int /*narg*/, char **/*arg*/)
         : manifold(lmp), lut_z(NULL), lut_zp(NULL) {}
 
 

--- a/src/USER-MANIFOLD/manifold_plane.cpp
+++ b/src/USER-MANIFOLD/manifold_plane.cpp
@@ -4,7 +4,7 @@ using namespace LAMMPS_NS;
 
 using namespace user_manifold;
 
-manifold_plane::manifold_plane( LAMMPS *lmp, int argc, char **argv ) :
+manifold_plane::manifold_plane( LAMMPS *lmp, int /*argc*/, char **/*argv*/ ) :
   manifold(lmp)
 {}
 
@@ -16,7 +16,7 @@ double manifold_plane::g( const double *x )
 }
 
 
-void manifold_plane::n( const double *x, double *n )
+void manifold_plane::n( const double */*x*/, double *n )
 {
   n[0] = params[0];
   n[1] = params[1];

--- a/src/USER-MANIFOLD/manifold_plane_wiggle.cpp
+++ b/src/USER-MANIFOLD/manifold_plane_wiggle.cpp
@@ -5,7 +5,7 @@
 using namespace LAMMPS_NS;
 using namespace user_manifold;
 
-manifold_plane_wiggle::manifold_plane_wiggle( LAMMPS *lmp, int argc, char **argv ) :
+manifold_plane_wiggle::manifold_plane_wiggle( LAMMPS *lmp, int /*argc*/, char **/*argv*/ ) :
   manifold(lmp)
 {}
 

--- a/src/USER-MANIFOLD/manifold_sphere.h
+++ b/src/USER-MANIFOLD/manifold_sphere.h
@@ -40,7 +40,7 @@ namespace user_manifold {
       nn[2] = 2*x[2];
     }
 
-    virtual void   H( double *x, double h[3][3] )
+    virtual void   H( double * /*x*/, double h[3][3] )
     {
       h[0][1] = h[0][2] = h[1][0] = h[1][2] = h[2][0] = h[2][1] = 0.0;
       h[0][0] = h[1][1] = h[2][2] = 2.0;

--- a/src/USER-MANIFOLD/manifold_spine.cpp
+++ b/src/USER-MANIFOLD/manifold_spine.cpp
@@ -8,7 +8,7 @@ using namespace user_manifold;
 
 
 
-manifold_spine::manifold_spine( LAMMPS *lmp, int argc, char **argv )
+manifold_spine::manifold_spine( LAMMPS *lmp, int /*argc*/, char **/*argv*/ )
   : manifold(lmp)
 {
   power = 4;

--- a/src/USER-MANIFOLD/manifold_thylakoid.cpp
+++ b/src/USER-MANIFOLD/manifold_thylakoid.cpp
@@ -12,7 +12,7 @@ using namespace LAMMPS_NS;
 using namespace user_manifold;
 
 
-manifold_thylakoid::manifold_thylakoid( LAMMPS *lmp, int narg, char ** arg)
+manifold_thylakoid::manifold_thylakoid( LAMMPS *lmp, int /*narg*/, char ** /*arg*/)
   : manifold(lmp)
 {
   // You can NOT depend on proper construction of the domains in
@@ -117,7 +117,7 @@ void   manifold_thylakoid::n( const double *x, double *n )
   }
 }
 
-thyla_part *manifold_thylakoid::get_thyla_part( const double *x, int *err_flag, std::size_t *idx )
+thyla_part *manifold_thylakoid::get_thyla_part( const double *x, int */*err_flag*/, std::size_t *idx )
 {
 
   for( std::size_t i = 0; i < parts.size(); ++i ){

--- a/src/USER-MANIFOLD/manifold_torus.cpp
+++ b/src/USER-MANIFOLD/manifold_torus.cpp
@@ -6,7 +6,7 @@ using namespace LAMMPS_NS;
 using namespace user_manifold;
 
 
-manifold_torus::manifold_torus( LAMMPS *lmp, int argc, char **argv ) : manifold(lmp)
+manifold_torus::manifold_torus( LAMMPS *lmp, int /*argc*/, char **/*argv*/ ) : manifold(lmp)
 {}
 
 

--- a/src/USER-MEAMC/meam_dens_final.cpp
+++ b/src/USER-MEAMC/meam_dens_final.cpp
@@ -5,7 +5,7 @@ using namespace LAMMPS_NS;
 
 void
 MEAM::meam_dens_final(int nlocal, int eflag_either, int eflag_global, int eflag_atom, double* eng_vdwl,
-                      double* eatom, int ntype, int* type, int* fmap, int& errorflag)
+                      double* eatom, int /*ntype*/, int* type, int* fmap, int& errorflag)
 {
   int i, elti;
   int m;

--- a/src/USER-MEAMC/meam_dens_init.cpp
+++ b/src/USER-MEAMC/meam_dens_init.cpp
@@ -93,7 +93,7 @@ MEAM::meam_dens_init(int i, int ntype, int* type, int* fmap, double** x,
 
 void
 MEAM::getscreen(int i, double* scrfcn, double* dscrfcn, double* fcpair, double** x, int numneigh,
-                int* firstneigh, int numneigh_full, int* firstneigh_full, int ntype, int* type, int* fmap)
+                int* firstneigh, int numneigh_full, int* firstneigh_full, int /*ntype*/, int* type, int* fmap)
 {
   int jn, j, kn, k;
   int elti, eltj, eltk;
@@ -256,7 +256,7 @@ MEAM::getscreen(int i, double* scrfcn, double* dscrfcn, double* fcpair, double**
 // ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 void
-MEAM::calc_rho1(int i, int ntype, int* type, int* fmap, double** x, int numneigh, int* firstneigh,
+MEAM::calc_rho1(int i, int /*ntype*/, int* type, int* fmap, double** x, int numneigh, int* firstneigh,
                 double* scrfcn, double* fcpair)
 {
   int jn, j, m, n, p, elti, eltj;

--- a/src/USER-MEAMC/meam_force.cpp
+++ b/src/USER-MEAMC/meam_force.cpp
@@ -7,7 +7,7 @@ using namespace LAMMPS_NS;
 
 void
 MEAM::meam_force(int i, int eflag_either, int eflag_global, int eflag_atom, int vflag_atom, double* eng_vdwl,
-                 double* eatom, int ntype, int* type, int* fmap, double** x, int numneigh, int* firstneigh,
+                 double* eatom, int /*ntype*/, int* type, int* fmap, double** x, int numneigh, int* firstneigh,
                  int numneigh_full, int* firstneigh_full, int fnoffset, double** f, double** vatom)
 {
   int j, jn, k, kn, kk, m, n, p, q;

--- a/src/USER-MEAMC/meam_setup_global.cpp
+++ b/src/USER-MEAMC/meam_setup_global.cpp
@@ -3,7 +3,7 @@
 using namespace LAMMPS_NS;
 
 void
-MEAM::meam_setup_global(int nelt, lattice_t* lat, double* z, int* ielement, double* atwt, double* alpha,
+MEAM::meam_setup_global(int nelt, lattice_t* lat, double* z, int* ielement, double* /*atwt*/, double* alpha,
                         double* b0, double* b1, double* b2, double* b3, double* alat, double* esub,
                         double* asub, double* t0, double* t1, double* t2, double* t3, double* rozero,
                         int* ibar)

--- a/src/USER-MEAMC/pair_meamc.cpp
+++ b/src/USER-MEAMC/pair_meamc.cpp
@@ -195,7 +195,7 @@ void PairMEAMC::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairMEAMC::settings(int narg, char **arg)
+void PairMEAMC::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -312,7 +312,7 @@ void PairMEAMC::init_list(int id, NeighList *ptr)
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairMEAMC::init_one(int i, int j)
+double PairMEAMC::init_one(int /*i*/, int /*j*/)
 {
   return cutmax;
 }
@@ -598,7 +598,7 @@ void PairMEAMC::read_files(char *globalfile, char *userfile)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAMC::pack_forward_comm(int n, int *list, double *buf,
-                                int pbc_flag, int *pbc)
+                                int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,k,m;
 

--- a/src/USER-MESO/fix_edpd_source.cpp
+++ b/src/USER-MESO/fix_edpd_source.cpp
@@ -87,7 +87,7 @@ void FixEDPDSource::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixEDPDSource::post_force(int vflag)
+void FixEDPDSource::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double *edpd_flux = atom->edpd_flux;

--- a/src/USER-MESO/fix_mvv_dpd.cpp
+++ b/src/USER-MESO/fix_mvv_dpd.cpp
@@ -72,7 +72,7 @@ void FixMvvDPD::init()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixMvvDPD::initial_integrate(int vflag)
+void FixMvvDPD::initial_integrate(int /*vflag*/)
 {
   double dtfm;
   double **x = atom->x;

--- a/src/USER-MESO/fix_mvv_edpd.cpp
+++ b/src/USER-MESO/fix_mvv_edpd.cpp
@@ -78,7 +78,7 @@ void FixMvvEDPD::init()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixMvvEDPD::initial_integrate(int vflag)
+void FixMvvEDPD::initial_integrate(int /*vflag*/)
 {
   double dtfm,dtT;
   // update v and x and cc of atoms in group

--- a/src/USER-MESO/fix_mvv_tdpd.cpp
+++ b/src/USER-MESO/fix_mvv_tdpd.cpp
@@ -76,7 +76,7 @@ void FixMvvTDPD::init()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixMvvTDPD::initial_integrate(int vflag)
+void FixMvvTDPD::initial_integrate(int /*vflag*/)
 {
   double dtfm;
   // update v and x and cc of atoms in group

--- a/src/USER-MESO/fix_tdpd_source.cpp
+++ b/src/USER-MESO/fix_tdpd_source.cpp
@@ -88,7 +88,7 @@ void FixTDPDSource::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixTDPDSource::post_force(int vflag)
+void FixTDPDSource::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double **cc_flux = atom->cc_flux;

--- a/src/USER-MESO/pair_edpd.cpp
+++ b/src/USER-MESO/pair_edpd.cpp
@@ -530,7 +530,7 @@ void PairEDPD::read_restart_settings(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double PairEDPD::single(int i, int j, int itype, int jtype, double rsq,
-                       double factor_coul, double factor_dpd, double &fforce)
+                       double /*factor_coul*/, double factor_dpd, double &fforce)
 {
   double r,rinv,wc,phi;
   double *T = atom->edpd_temp;

--- a/src/USER-MESO/pair_mdpd_rhosum.cpp
+++ b/src/USER-MESO/pair_mdpd_rhosum.cpp
@@ -186,7 +186,7 @@ void PairMDPDRhoSum::allocate() {
  global settings
  ------------------------------------------------------------------------- */
 
-void PairMDPDRhoSum::settings(int narg, char **arg) {
+void PairMDPDRhoSum::settings(int narg, char **/*arg*/) {
   if (narg != 0)
     error->all(FLERR,"Illegal number of setting arguments for pair_style mdpd/rhosum");
 }
@@ -236,8 +236,8 @@ double PairMDPDRhoSum::init_one(int i, int j) {
 
 /* ---------------------------------------------------------------------- */
 
-double PairMDPDRhoSum::single(int i, int j, int itype, int jtype, double rsq,
-    double factor_coul, double factor_lj, double &fforce) {
+double PairMDPDRhoSum::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/, double /*rsq*/,
+    double /*factor_coul*/, double /*factor_lj*/, double &fforce) {
   fforce = 0.0;
 
   return 0.0;
@@ -246,7 +246,7 @@ double PairMDPDRhoSum::single(int i, int j, int itype, int jtype, double rsq,
 /* ---------------------------------------------------------------------- */
 
 int PairMDPDRhoSum::pack_forward_comm(int n, int *list, double *buf,
-                                     int pbc_flag, int *pbc) {
+                                     int /*pbc_flag*/, int */*pbc*/) {
   int i, j, m;
   double *rho = atom->rho;
 

--- a/src/USER-MESO/pair_tdpd.cpp
+++ b/src/USER-MESO/pair_tdpd.cpp
@@ -465,8 +465,8 @@ void PairTDPD::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairTDPD::single(int i, int j, int itype, int jtype, double rsq,
-                       double factor_coul, double factor_dpd, double &fforce)
+double PairTDPD::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                       double /*factor_coul*/, double factor_dpd, double &fforce)
 {
   double r,rinv,wc,phi;
 

--- a/src/USER-MGPT/mgpt_linalg.cpp
+++ b/src/USER-MGPT/mgpt_linalg.cpp
@@ -81,8 +81,8 @@
 #define const
 #endif
 static void transprod_generic(const double * restrict A,
-			      const double * restrict B,
-			      double * restrict C) {
+                              const double * restrict B,
+                              double * restrict C) {
   const int lda = 8,n = mgpt_linalg::matrix_size;
   int i,j,k;
   double s;
@@ -90,15 +90,15 @@ static void transprod_generic(const double * restrict A,
     for(j = 0; j<n; j++) {
       s = 0.0;
       for(k = 1; k<=n; k++)
-	s = s + A[i*lda+k]*B[j*lda+k];
+        s = s + A[i*lda+k]*B[j*lda+k];
       C[i*lda+(j+1)] = s;
     }
 }
 
 static void transtrace3_generic(const double * restrict A,
-				const double * restrict B0,double * restrict tout0,
-				const double * restrict B1,double * restrict tout1,
-				const double * restrict B2,double * restrict tout2) {
+                                const double * restrict B0,double * restrict tout0,
+                                const double * restrict B1,double * restrict tout1,
+                                const double * restrict B2,double * restrict tout2) {
   const int lda = 8,n = mgpt_linalg::matrix_size;
   double t0 = 0.0,t1 = 0.0,t2 = 0.0;
   int i,j;
@@ -116,16 +116,16 @@ static void transtrace3_generic(const double * restrict A,
   *tout2 = t2;
 }
 
-static void transprod_error(const double * restrict A,
-			    const double * restrict B,
-			    double * restrict C) {
+static void transprod_error(const double * restrict /*A*/,
+                            const double * restrict /*B*/,
+                            double * restrict /*C*/) {
   printf("Linear algebra subroutines not initialized (transprod).\n");
   exit(1);
 }
-static void transtrace3_error(const double * restrict A,
-			      const double * restrict B0,double * restrict tout0,
-			      const double * restrict B1,double * restrict tout1,
-			      const double * restrict B2,double * restrict tout2) {
+static void transtrace3_error(const double * restrict /*A*/,
+                              const double * restrict /*B0*/,double * restrict /*tout0*/,
+                              const double * restrict /*B1*/,double * restrict /*tout1*/,
+                              const double * restrict /*B2*/,double * restrict /*tout2*/) {
   printf("Linear algebra subroutines not initialized (transtrace3).\n");
   exit(1);
 }

--- a/src/USER-MGPT/pair_mgpt.cpp
+++ b/src/USER-MGPT/pair_mgpt.cpp
@@ -79,7 +79,7 @@ static double gettime(int x = 0) {
     return 0.0;
 }
 #else
-static double gettime(int x = 0) { return 0.0; }
+static double gettime(int /*x*/ = 0) { return 0.0; }
 #endif
 
 
@@ -1805,7 +1805,7 @@ void PairMGPT::allocate()
 /* ----------------------------------------------------------------------
    global settings
 ------------------------------------------------------------------------- */
-void PairMGPT::settings(int narg, char **arg)
+void PairMGPT::settings(int narg, char **/*arg*/)
 {
   if(narg != 0) error->all(__FILE__,__LINE__,"Illegal pair_style command");
 }
@@ -2025,7 +2025,7 @@ void PairMGPT::init_list(int id, NeighList *ptr)
 /* ----------------------------------------------------------------------
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
-double PairMGPT::init_one(int i, int j)
+double PairMGPT::init_one(int /*i*/, int /*j*/)
 {
 	return cutoff;
 }

--- a/src/USER-MISC/angle_dipole.cpp
+++ b/src/USER-MISC/angle_dipole.cpp
@@ -229,7 +229,7 @@ void AngleDipole::write_data(FILE *fp)
    used by ComputeAngleLocal
 ------------------------------------------------------------------------- */
 
-double AngleDipole::single(int type, int iRef, int iDip, int iDummy)
+double AngleDipole::single(int type, int iRef, int iDip, int /*iDummy*/)
 {
   double **x = atom->x; // position vector
   double **mu = atom->mu; // point-dipole components and moment magnitude

--- a/src/USER-MISC/bond_harmonic_shift.cpp
+++ b/src/USER-MISC/bond_harmonic_shift.cpp
@@ -203,7 +203,7 @@ void BondHarmonicShift::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondHarmonicShift::single(int type, double rsq, int i, int j,
+double BondHarmonicShift::single(int type, double rsq, int /*i*/, int /*j*/,
                                  double &fforce)
 {
   double r = sqrt(rsq);

--- a/src/USER-MISC/bond_harmonic_shift_cut.cpp
+++ b/src/USER-MISC/bond_harmonic_shift_cut.cpp
@@ -205,7 +205,7 @@ void BondHarmonicShiftCut::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondHarmonicShiftCut::single(int type, double rsq, int i, int j,
+double BondHarmonicShiftCut::single(int type, double rsq, int /*i*/, int /*j*/,
                                     double &fforce)
 {
   fforce = 0.0;

--- a/src/USER-MISC/compute_ackland_atom.cpp
+++ b/src/USER-MISC/compute_ackland_atom.cpp
@@ -105,7 +105,7 @@ void ComputeAcklandAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeAcklandAtom::init_list(int id, NeighList *ptr)
+void ComputeAcklandAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/USER-MISC/compute_basal_atom.cpp
+++ b/src/USER-MISC/compute_basal_atom.cpp
@@ -85,7 +85,7 @@ void ComputeBasalAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeBasalAtom::init_list(int id, NeighList *ptr)
+void ComputeBasalAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/USER-MISC/compute_cnp_atom.cpp
+++ b/src/USER-MISC/compute_cnp_atom.cpp
@@ -121,7 +121,7 @@ void ComputeCNPAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeCNPAtom::init_list(int id, NeighList *ptr)
+void ComputeCNPAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/USER-MISC/compute_entropy_atom.cpp
+++ b/src/USER-MISC/compute_entropy_atom.cpp
@@ -151,7 +151,7 @@ void ComputeEntropyAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeEntropyAtom::init_list(int id, NeighList *ptr)
+void ComputeEntropyAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/USER-MISC/fix_addtorque.cpp
+++ b/src/USER-MISC/fix_addtorque.cpp
@@ -164,7 +164,7 @@ void FixAddTorque::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAddTorque::post_force(int vflag)
+void FixAddTorque::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double **f = atom->f;
@@ -252,7 +252,7 @@ void FixAddTorque::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAddTorque::post_force_respa(int vflag, int ilevel, int iloop)
+void FixAddTorque::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/USER-MISC/fix_ave_correlate_long.cpp
+++ b/src/USER-MISC/fix_ave_correlate_long.cpp
@@ -412,7 +412,7 @@ void FixAveCorrelateLong::init()
    only does something if nvalid = current timestep
 ------------------------------------------------------------------------- */
 
-void FixAveCorrelateLong::setup(int vflag)
+void FixAveCorrelateLong::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/USER-MISC/fix_bond_react.cpp
+++ b/src/USER-MISC/fix_bond_react.cpp
@@ -588,7 +588,7 @@ void FixBondReact::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondReact::init_list(int id, NeighList *ptr)
+void FixBondReact::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -2621,7 +2621,7 @@ double FixBondReact::compute_vector(int n)
 
 /* ---------------------------------------------------------------------- */
 
-void FixBondReact::post_integrate_respa(int ilevel, int iloop)
+void FixBondReact::post_integrate_respa(int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_integrate();
 }
@@ -2629,7 +2629,7 @@ void FixBondReact::post_integrate_respa(int ilevel, int iloop)
 /* ---------------------------------------------------------------------- */
 
 int FixBondReact::pack_forward_comm(int n, int *list, double *buf,
-                                    int pbc_flag, int *pbc)
+                                    int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,k,m,ns;
 

--- a/src/USER-MISC/fix_bond_react.cpp
+++ b/src/USER-MISC/fix_bond_react.cpp
@@ -1558,7 +1558,6 @@ void FixBondReact::find_landlocked_atoms(int myrxn)
   // would someone want to change an angle type but not bond or atom types? (etc.) ...hopefully not yet
   for (int i = 0; i < twomol->natoms; i++) {
     if (landlocked_atoms[i][myrxn] == 0) {
-      int twomol_atomi = i+1;
       for (int j = 0; j < twomol->num_bond[i]; j++) {
         int twomol_atomj = twomol->bond_atom[i][j];
         if (landlocked_atoms[twomol_atomj-1][myrxn] == 0) {

--- a/src/USER-MISC/fix_filter_corotate.cpp
+++ b/src/USER-MISC/fix_filter_corotate.cpp
@@ -705,7 +705,7 @@ double FixFilterCorotate::compute_array(int,int)
   return 1;
 }
 
-void FixFilterCorotate::pre_force_respa(int vflag, int ilevel, int iloop)
+void FixFilterCorotate::pre_force_respa(int /*vflag*/, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1)
   {
@@ -717,7 +717,7 @@ void FixFilterCorotate::pre_force_respa(int vflag, int ilevel, int iloop)
   }
 }
 
-void FixFilterCorotate::post_force_respa(int vflag, int ilevel, int iloop)
+void FixFilterCorotate::post_force_respa(int /*vflag*/, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1)
   {
@@ -1699,7 +1699,7 @@ void FixFilterCorotate::general_cluster(int index, int index_in_list)
 }
 
 int FixFilterCorotate::pack_forward_comm(int n, int *list, double *buf,
-                                         int pbc_flag, int *pbc)
+                                         int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
   double**f = atom->f;
@@ -1839,7 +1839,7 @@ double FixFilterCorotate::memory_usage()
  *  copy values within local atom-based arrays
  * ------------------------------------------------------------------------- */
 
-void FixFilterCorotate::copy_arrays(int i, int j, int delflag)
+void FixFilterCorotate::copy_arrays(int i, int j, int /*delflag*/)
 {
   int flag = shake_flag[j] = shake_flag[i];
   if (flag == 1) {

--- a/src/USER-MISC/fix_flow_gauss.cpp
+++ b/src/USER-MISC/fix_flow_gauss.cpp
@@ -155,7 +155,7 @@ void FixFlowGauss::setup(int vflag)
 /* ----------------------------------------------------------------------
    this is where Gaussian dynamics constraint is applied
    ------------------------------------------------------------------------- */
-void FixFlowGauss::post_force(int vflag)
+void FixFlowGauss::post_force(int /*vflag*/)
 {
   double **f   = atom->f;
   double **v   = atom->v;
@@ -222,7 +222,7 @@ void FixFlowGauss::post_force(int vflag)
 
 }
 
-void FixFlowGauss::post_force_respa(int vflag, int ilevel, int iloop)
+void FixFlowGauss::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/USER-MISC/fix_gle.cpp
+++ b/src/USER-MISC/fix_gle.cpp
@@ -582,7 +582,7 @@ void FixGLE::gle_integrate()
   energy += deltae*0.5*force->mvv2e;
 }
 
-void FixGLE::initial_integrate(int vflag)
+void FixGLE::initial_integrate(int /*vflag*/)
 {
   double dtfm;
 
@@ -685,7 +685,7 @@ void FixGLE::final_integrate()
 }
 /* ---------------------------------------------------------------------- */
 
-void FixGLE::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixGLE::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
@@ -699,7 +699,7 @@ void FixGLE::initial_integrate_respa(int vflag, int ilevel, int iloop)
   else { final_integrate();}
 }
 
-void FixGLE::final_integrate_respa(int ilevel, int iloop)
+void FixGLE::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
@@ -793,7 +793,7 @@ void FixGLE::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixGLE::copy_arrays(int i, int j, int delflag)
+void FixGLE::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int k = 0; k < 3*ns; k++) gle_s[j][k] = gle_s[i][k];
 }
@@ -868,7 +868,7 @@ void FixGLE::unpack_restart(int nlocal, int nth)
    fixes on a given processor.
 ------------------------------------------------------------------------- */
 
-int FixGLE::size_restart(int nlocal)
+int FixGLE::size_restart(int /*nlocal*/)
 {
   return 3*ns+1;
 }

--- a/src/USER-MISC/fix_grem.cpp
+++ b/src/USER-MISC/fix_grem.cpp
@@ -256,7 +256,7 @@ void FixGrem::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGrem::post_force(int vflag)
+void FixGrem::post_force(int /*vflag*/)
 {
   double **f = atom->f;
   int *mask = atom->mask;

--- a/src/USER-MISC/fix_imd.cpp
+++ b/src/USER-MISC/fix_imd.cpp
@@ -811,7 +811,7 @@ void FixIMD::ioworker()
 /* ---------------------------------------------------------------------- */
 /* Main IMD protocol handler:
  * Send coodinates, energies, and add IMD forces to atoms. */
-void FixIMD::post_force(int vflag)
+void FixIMD::post_force(int /*vflag*/)
 {
   /* check for reconnect */
   if (imd_inactive) {
@@ -1153,7 +1153,7 @@ void FixIMD::post_force(int vflag)
 }
 
 /* ---------------------------------------------------------------------- */
-void FixIMD::post_force_respa(int vflag, int ilevel, int iloop)
+void FixIMD::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   /* only process IMD on the outmost RESPA level. */
   if (ilevel == nlevels_respa-1) post_force(vflag);

--- a/src/USER-MISC/fix_ipi.cpp
+++ b/src/USER-MISC/fix_ipi.cpp
@@ -269,7 +269,7 @@ void FixIPI::init()
   neighbor->every = 1;
 }
 
-void FixIPI::initial_integrate(int vflag)
+void FixIPI::initial_integrate(int /*vflag*/)
 {
   /* This is called at the beginning of the integration loop,
    * and will be used to read positions from the socket. Then,

--- a/src/USER-MISC/fix_nvk.cpp
+++ b/src/USER-MISC/fix_nvk.cpp
@@ -94,7 +94,7 @@ void FixNVK::init()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixNVK::initial_integrate(int vflag)
+void FixNVK::initial_integrate(int /*vflag*/)
 {
   double sm;
   double a,b,sqtb,s,sdot;
@@ -190,7 +190,7 @@ void FixNVK::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVK::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixNVK::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel];
@@ -204,7 +204,7 @@ void FixNVK::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVK::final_integrate_respa(int ilevel, int iloop)
+void FixNVK::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtf = 0.5 * step_respa[ilevel];
   final_integrate();

--- a/src/USER-MISC/fix_pimd.cpp
+++ b/src/USER-MISC/fix_pimd.cpp
@@ -214,7 +214,7 @@ void FixPIMD::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixPIMD::initial_integrate(int vflag)
+void FixPIMD::initial_integrate(int /*vflag*/)
 {
   nhc_update_v();
   nhc_update_x();
@@ -229,7 +229,7 @@ void FixPIMD::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixPIMD::post_force(int flag)
+void FixPIMD::post_force(int /*flag*/)
 {
   for(int i=0; i<atom->nlocal; i++) for(int j=0; j<3; j++) atom->f[i][j] /= np;
 
@@ -686,7 +686,7 @@ void FixPIMD::comm_exec(double **ptr)
 /* ---------------------------------------------------------------------- */
 
 int FixPIMD::pack_forward_comm(int n, int *list, double *buf,
-                             int pbc_flag, int *pbc)
+                             int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 
@@ -744,7 +744,7 @@ void FixPIMD::grow_arrays(int nmax)
 
 /* ---------------------------------------------------------------------- */
 
-void FixPIMD::copy_arrays(int i, int j, int delflag)
+void FixPIMD::copy_arrays(int i, int j, int /*delflag*/)
 {
   int i_pos = i*3;
   int j_pos = j*3;
@@ -832,7 +832,7 @@ int FixPIMD::maxsize_restart()
 
 /* ---------------------------------------------------------------------- */
 
-int FixPIMD::size_restart(int nlocal)
+int FixPIMD::size_restart(int /*nlocal*/)
 {
   return size_peratom_cols+1;
 }

--- a/src/USER-MISC/fix_rhok.cpp
+++ b/src/USER-MISC/fix_rhok.cpp
@@ -144,7 +144,7 @@ FixRhok::min_setup( int inVFlag )
 
 // Modify the forces calculated in the main force loop of ordinary MD
 void
-FixRhok::post_force( int inVFlag )
+FixRhok::post_force( int /*inVFlag*/ )
 {
   double **x = atom->x;
   double **f = atom->f;
@@ -206,7 +206,7 @@ FixRhok::post_force( int inVFlag )
 
 // Forces in RESPA loop
 void
-FixRhok::post_force_respa( int inVFlag, int inILevel, int inILoop )
+FixRhok::post_force_respa( int inVFlag, int inILevel, int /*inILoop*/ )
 {
   if( inILevel == mNLevelsRESPA - 1 )
     post_force( inVFlag );

--- a/src/USER-MISC/fix_smd.cpp
+++ b/src/USER-MISC/fix_smd.cpp
@@ -461,7 +461,7 @@ void FixSMD::restart(char *buf)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSMD::post_force_respa(int vflag, int ilevel, int iloop)
+void FixSMD::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/USER-MISC/fix_srp.cpp
+++ b/src/USER-MISC/fix_srp.cpp
@@ -145,7 +145,7 @@ void FixSRP::init()
    insert bond particles
 ------------------------------------------------------------------------- */
 
-void FixSRP::setup_pre_force(int zz)
+void FixSRP::setup_pre_force(int /*zz*/)
 {
   double **x = atom->x;
   double **xold;
@@ -394,7 +394,7 @@ void FixSRP::grow_arrays(int nmax)
    called when move to new proc
 ------------------------------------------------------------------------- */
 
-void FixSRP::copy_arrays(int i, int j, int delflag)
+void FixSRP::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < 2; m++)
     array[j][m] = array[i][m];
@@ -589,7 +589,7 @@ int FixSRP::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixSRP::size_restart(int nlocal)
+int FixSRP::size_restart(int /*nlocal*/)
 {
   return 3;
 }
@@ -632,7 +632,7 @@ void FixSRP::restart(char *buf)
    pair srp sets the bond type in this fix
 ------------------------------------------------------------------------- */
 
-int FixSRP::modify_param(int narg, char **arg)
+int FixSRP::modify_param(int /*narg*/, char **arg)
 {
   if (strcmp(arg[0],"btype") == 0) {
     btype = atoi(arg[1]);

--- a/src/USER-MISC/fix_ti_spring.cpp
+++ b/src/USER-MISC/fix_ti_spring.cpp
@@ -167,7 +167,7 @@ void FixTISpring::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTISpring::post_force(int vflag)
+void FixTISpring::post_force(int /*vflag*/)
 {
   // do not calculate forces during equilibration
   if ((update->ntimestep - t0) < t_equil) return;
@@ -200,7 +200,7 @@ void FixTISpring::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTISpring::post_force_respa(int vflag, int ilevel, int iloop)
+void FixTISpring::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }
@@ -214,7 +214,7 @@ void FixTISpring::min_post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTISpring::initial_integrate(int vflag)
+void FixTISpring::initial_integrate(int /*vflag*/)
 {
   // Update the coupling parameter value if needed
   if ((update->ntimestep - t0) < t_equil) return;
@@ -278,7 +278,7 @@ void FixTISpring::grow_arrays(int nmax)
      copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixTISpring::copy_arrays(int i, int j, int delflag)
+void FixTISpring::copy_arrays(int i, int j, int /*delflag*/)
 {
   xoriginal[j][0] = xoriginal[i][0];
   xoriginal[j][1] = xoriginal[i][1];
@@ -354,7 +354,7 @@ int FixTISpring::maxsize_restart()
      size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixTISpring::size_restart(int nlocal)
+int FixTISpring::size_restart(int /*nlocal*/)
 {
   return 4;
 }

--- a/src/USER-MISC/fix_ttm_mod.cpp
+++ b/src/USER-MISC/fix_ttm_mod.cpp
@@ -357,7 +357,7 @@ void FixTTMMod::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTMMod::post_force(int vflag)
+void FixTTMMod::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double **v = atom->v;
@@ -451,7 +451,7 @@ void FixTTMMod::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTMMod::post_force_setup(int vflag)
+void FixTTMMod::post_force_setup(int /*vflag*/)
 {
   double **f = atom->f;
   int *mask = atom->mask;
@@ -468,14 +468,14 @@ void FixTTMMod::post_force_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTMMod::post_force_respa(int vflag, int ilevel, int iloop)
+void FixTTMMod::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixTTMMod::post_force_respa_setup(int vflag, int ilevel, int iloop)
+void FixTTMMod::post_force_respa_setup(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force_setup(vflag);
 }
@@ -916,7 +916,7 @@ int FixTTMMod::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixTTMMod::size_restart(int nlocal)
+int FixTTMMod::size_restart(int /*nlocal*/)
 {
   return 4;
 }

--- a/src/USER-MISC/fix_wall_region_ees.cpp
+++ b/src/USER-MISC/fix_wall_region_ees.cpp
@@ -149,7 +149,7 @@ void FixWallRegionEES::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallRegionEES::post_force(int vflag)
+void FixWallRegionEES::post_force(int /*vflag*/)
 {
   //sth is needed here, but I dont know what
   //that is calculation of sn
@@ -246,7 +246,7 @@ void FixWallRegionEES::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallRegionEES::post_force_respa(int vflag, int ilevel, int iloop)
+void FixWallRegionEES::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }

--- a/src/USER-MISC/pair_agni.cpp
+++ b/src/USER-MISC/pair_agni.cpp
@@ -246,7 +246,7 @@ void PairAGNI::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairAGNI::settings(int narg, char **arg)
+void PairAGNI::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/USER-MISC/pair_buck_mdf.cpp
+++ b/src/USER-MISC/pair_buck_mdf.cpp
@@ -391,8 +391,8 @@ void PairBuckMDF::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairBuckMDF::single(int i, int j, int itype, int jtype,
-                        double rsq, double factor_coul, double factor_lj,
+double PairBuckMDF::single(int /*i*/, int /*j*/, int itype, int jtype,
+                        double rsq, double /*factor_coul*/, double factor_lj,
                         double &fforce)
 {
   double r2inv,r6inv,r,rexp,forcebuck,phibuck;

--- a/src/USER-MISC/pair_coul_diel.cpp
+++ b/src/USER-MISC/pair_coul_diel.cpp
@@ -326,7 +326,7 @@ void PairCoulDiel::read_restart_settings(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double PairCoulDiel::single(int i, int j, int itype, int jtype,
-                           double rsq, double factor_coul, double factor_lj,
+                           double rsq, double factor_coul, double /*factor_lj*/,
                            double &fforce)
 {
   double r, rarg,forcedielec,phidielec;

--- a/src/USER-MISC/pair_coul_shield.cpp
+++ b/src/USER-MISC/pair_coul_shield.cpp
@@ -341,7 +341,7 @@ void PairCoulShield::read_restart_settings(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double PairCoulShield::single(int i, int j, int itype, int jtype,
-                           double rsq, double factor_coul, double factor_lj,
+                           double rsq, double factor_coul, double /*factor_lj*/,
                            double &fforce)
 {
   double r, rarg,Vc,fvc,forcecoul,phishieldec;

--- a/src/USER-MISC/pair_edip.cpp
+++ b/src/USER-MISC/pair_edip.cpp
@@ -621,7 +621,7 @@ void PairEDIP::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairEDIP::settings(int narg, char **arg)
+void PairEDIP::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/USER-MISC/pair_edip_multi.cpp
+++ b/src/USER-MISC/pair_edip_multi.cpp
@@ -516,7 +516,7 @@ void PairEDIPMulti::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairEDIPMulti::settings(int narg, char **arg)
+void PairEDIPMulti::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/USER-MISC/pair_extep.cpp
+++ b/src/USER-MISC/pair_extep.cpp
@@ -442,7 +442,7 @@ void PairExTeP::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairExTeP::settings(int narg, char **arg)
+void PairExTeP::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/USER-MISC/pair_gauss_cut.cpp
+++ b/src/USER-MISC/pair_gauss_cut.cpp
@@ -374,8 +374,8 @@ void PairGaussCut::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairGaussCut::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairGaussCut::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double r, rexp,ugauss,phigauss;

--- a/src/USER-MISC/pair_ilp_graphene_hbn.cpp
+++ b/src/USER-MISC/pair_ilp_graphene_hbn.cpp
@@ -1010,8 +1010,8 @@ void PairILPGrapheneHBN::read_file(char *filename)
 
 /* ---------------------------------------------------------------------- */
 
-double PairILPGrapheneHBN::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairILPGrapheneHBN::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double r,r2inv,r6inv,r8inv,forcelj,philj,fpair;
@@ -1047,7 +1047,7 @@ double PairILPGrapheneHBN::single(int i, int j, int itype, int jtype, double rsq
 /* ---------------------------------------------------------------------- */
 
 int PairILPGrapheneHBN::pack_forward_comm(int n, int *list, double *buf,
-                               int pbc_flag, int *pbc)
+                               int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m,id,ip,l;
 

--- a/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
@@ -1015,8 +1015,8 @@ void PairKolmogorovCrespiFull::read_file(char *filename)
 
 /* ---------------------------------------------------------------------- */
 
-double PairKolmogorovCrespiFull::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairKolmogorovCrespiFull::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double r,r2inv,r6inv,r8inv,forcelj,philj;
@@ -1050,7 +1050,7 @@ double PairKolmogorovCrespiFull::single(int i, int j, int itype, int jtype, doub
 /* ---------------------------------------------------------------------- */
 
 int PairKolmogorovCrespiFull::pack_forward_comm(int n, int *list, double *buf,
-                               int pbc_flag, int *pbc)
+                               int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m,l,ip,id;
 

--- a/src/USER-MISC/pair_lennard_mdf.cpp
+++ b/src/USER-MISC/pair_lennard_mdf.cpp
@@ -352,9 +352,9 @@ void PairLJ_AB_MDF::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJ_AB_MDF::single(int i, int j, int itype, int jtype,
+double PairLJ_AB_MDF::single(int /*i*/, int /*j*/, int itype, int jtype,
                              double rsq,
-                             double factor_coul, double factor_lj,
+                             double /*factor_coul*/, double factor_lj,
                              double &fforce)
 {
   double r2inv,r6inv,forcelj,philj;

--- a/src/USER-MISC/pair_lj_mdf.cpp
+++ b/src/USER-MISC/pair_lj_mdf.cpp
@@ -352,9 +352,9 @@ void PairLJMDF::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJMDF::single(int i, int j, int itype, int jtype,
+double PairLJMDF::single(int /*i*/, int /*j*/, int itype, int jtype,
                              double rsq,
-                             double factor_coul, double factor_lj,
+                             double /*factor_coul*/, double factor_lj,
                              double &fforce)
 {
   double r2inv,r6inv,forcelj,philj;

--- a/src/USER-MISC/pair_meam_spline.cpp
+++ b/src/USER-MISC/pair_meam_spline.cpp
@@ -360,7 +360,7 @@ void PairMEAMSpline::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairMEAMSpline::settings(int narg, char **arg)
+void PairMEAMSpline::settings(int narg, char **/*arg*/)
 {
   if(narg != 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -592,7 +592,7 @@ void PairMEAMSpline::init_list(int id, NeighList *ptr)
 /* ----------------------------------------------------------------------
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
-double PairMEAMSpline::init_one(int i, int j)
+double PairMEAMSpline::init_one(int /*i*/, int /*j*/)
 {
   return cutoff;
 }
@@ -600,7 +600,7 @@ double PairMEAMSpline::init_one(int i, int j)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAMSpline::pack_forward_comm(int n, int *list, double *buf,
-                                      int pbc_flag, int *pbc)
+                                      int /*pbc_flag*/, int */*pbc*/)
 {
   int* list_iter = list;
   int* list_iter_end = list + n;
@@ -618,14 +618,14 @@ void PairMEAMSpline::unpack_forward_comm(int n, int first, double *buf)
 
 /* ---------------------------------------------------------------------- */
 
-int PairMEAMSpline::pack_reverse_comm(int n, int first, double *buf)
+int PairMEAMSpline::pack_reverse_comm(int /*n*/, int /*first*/, double */*buf*/)
 {
   return 0;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void PairMEAMSpline::unpack_reverse_comm(int n, int *list, double *buf)
+void PairMEAMSpline::unpack_reverse_comm(int /*n*/, int */*list*/, double */*buf*/)
 {
 }
 

--- a/src/USER-MISC/pair_meam_sw_spline.cpp
+++ b/src/USER-MISC/pair_meam_sw_spline.cpp
@@ -372,7 +372,7 @@ void PairMEAMSWSpline::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairMEAMSWSpline::settings(int narg, char **arg)
+void PairMEAMSWSpline::settings(int narg, char **/*arg*/)
 {
   if(narg != 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -552,7 +552,7 @@ void PairMEAMSWSpline::init_list(int id, NeighList *ptr)
 /* ----------------------------------------------------------------------
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
-double PairMEAMSWSpline::init_one(int i, int j)
+double PairMEAMSWSpline::init_one(int /*i*/, int /*j*/)
 {
         return cutoff;
 }
@@ -560,7 +560,7 @@ double PairMEAMSWSpline::init_one(int i, int j)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAMSWSpline::pack_forward_comm(int n, int *list, double *buf,
-                                        int pbc_flag, int *pbc)
+                                        int /*pbc_flag*/, int */*pbc*/)
 {
         int* list_iter = list;
         int* list_iter_end = list + n;
@@ -578,14 +578,14 @@ void PairMEAMSWSpline::unpack_forward_comm(int n, int first, double *buf)
 
 /* ---------------------------------------------------------------------- */
 
-int PairMEAMSWSpline::pack_reverse_comm(int n, int first, double *buf)
+int PairMEAMSWSpline::pack_reverse_comm(int /*n*/, int /*first*/, double */*buf*/)
 {
         return 0;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void PairMEAMSWSpline::unpack_reverse_comm(int n, int *list, double *buf)
+void PairMEAMSWSpline::unpack_reverse_comm(int /*n*/, int */*list*/, double */*buf*/)
 {
 }
 

--- a/src/USER-MISC/pair_momb.cpp
+++ b/src/USER-MISC/pair_momb.cpp
@@ -365,8 +365,8 @@ void PairMomb::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairMomb::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairMomb::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double r,dr,dexp,phi,r2inv,r6inv,ddexp,invexp;

--- a/src/USER-MISC/pair_morse_smooth_linear.cpp
+++ b/src/USER-MISC/pair_morse_smooth_linear.cpp
@@ -337,8 +337,8 @@ void PairMorseSmoothLinear::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairMorseSmoothLinear::single(int i, int j, int itype, int jtype, double rsq,
-                                     double factor_coul, double factor_lj,
+double PairMorseSmoothLinear::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                                     double /*factor_coul*/, double factor_lj,
                                      double &fforce)
 {
   double r,dr,dexp,phi;

--- a/src/USER-MISC/pair_tersoff_table.cpp
+++ b/src/USER-MISC/pair_tersoff_table.cpp
@@ -719,7 +719,7 @@ void PairTersoffTable::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairTersoffTable::settings(int narg, char **arg)
+void PairTersoffTable::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 }

--- a/src/USER-MOFFF/angle_cosine_buck6d.cpp
+++ b/src/USER-MOFFF/angle_cosine_buck6d.cpp
@@ -56,7 +56,7 @@ AngleCosineBuck6d::~AngleCosineBuck6d()
 
 void AngleCosineBuck6d::compute(int eflag, int vflag)
 {
-  int i,i1,i2,i3,n,type,itype,jtype;
+  int i1,i2,i3,n,type,itype,jtype;
   double delx1,dely1,delz1,delx2,dely2,delz2;
   double eangle,f1[3],f3[3];
   double rsq1,rsq2,r1,r2,c,s,a,a11,a12,a22;

--- a/src/USER-MOFFF/angle_cosine_buck6d.cpp
+++ b/src/USER-MOFFF/angle_cosine_buck6d.cpp
@@ -309,7 +309,7 @@ void AngleCosineBuck6d::init_style()
 
 /* ---------------------------------------------------------------------- */
 
-double AngleCosineBuck6d::equilibrium_angle(int i)
+double AngleCosineBuck6d::equilibrium_angle(int /*i*/)
 {
   return MY_PI;
 }

--- a/src/USER-MOFFF/improper_inversion_harmonic.cpp
+++ b/src/USER-MOFFF/improper_inversion_harmonic.cpp
@@ -139,7 +139,6 @@ void ImproperInversionHarmonic::invang(const int &i1,const int &i2,
   double upx,upy,upz,upn,rup,umx,umy,umz,umn,rum,wwr;
   double rucb,rudb,rvcb,rvdb,rupupn,rumumn;
 
-  double **x = atom->x;
   double **f = atom->f;
   int nlocal = atom->nlocal;
   int newton_bond = force->newton_bond;
@@ -242,7 +241,7 @@ void ImproperInversionHarmonic::invang(const int &i1,const int &i2,
     f[i4][2] += f4[2];
   }
 
-  double rb1x, rb1y, rb1z, rb2x, rb2y, rb2z, rb3x, rb3y, rb3z;
+  double rb3x, rb3y, rb3z;
   if (evflag)
 
     rb3x = vb1x - vb2x;
@@ -253,7 +252,7 @@ void ImproperInversionHarmonic::invang(const int &i1,const int &i2,
              vb3x,vb3y,vb3z,
              vb2x,vb2y,vb2z,
              rb3x,rb3y,rb3z);
- }
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-PHONON/fix_phonon.cpp
+++ b/src/USER-PHONON/fix_phonon.cpp
@@ -299,7 +299,7 @@ void FixPhonon::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixPhonon::setup(int flag)
+void FixPhonon::setup(int /*flag*/)
 {
   // initialize accumulating variables
   for (int i = 0; i < sysdim; ++i) TempSum[i] = 0.;

--- a/src/USER-QTB/fix_qbmsst.cpp
+++ b/src/USER-QTB/fix_qbmsst.cpp
@@ -424,7 +424,7 @@ void FixQBMSST::init()
 /* ----------------------------------------------------------------------
    compute T,P before integrator starts
 ------------------------------------------------------------------------- */
-void FixQBMSST::setup(int vflag)
+void FixQBMSST::setup(int /*vflag*/)
 {
   lagrangian_position = 0.0;
 
@@ -507,7 +507,7 @@ void FixQBMSST::setup(int vflag)
 /* ----------------------------------------------------------------------
    1st half of Verlet update
 ------------------------------------------------------------------------- */
-void FixQBMSST::initial_integrate(int vflag)
+void FixQBMSST::initial_integrate(int /*vflag*/)
 {
   int sd;
   sd = direction;
@@ -1157,7 +1157,7 @@ void FixQBMSST::grow_arrays(int nmax)
 /* ----------------------------------------------------------------------
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
-void FixQBMSST::copy_arrays(int i, int j, int delflag)
+void FixQBMSST::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < 2*N_f; m++) {
     random_array_0[j][m] = random_array_0[i][m];

--- a/src/USER-QTB/fix_qtb.cpp
+++ b/src/USER-QTB/fix_qtb.cpp
@@ -239,7 +239,7 @@ void FixQTB::setup(int vflag)
 /* ----------------------------------------------------------------------
    post_force
 ------------------------------------------------------------------------- */
-void FixQTB::post_force(int vflag)
+void FixQTB::post_force(int /*vflag*/)
 {
   double gamma1,gamma3;
 
@@ -334,7 +334,7 @@ void FixQTB::post_force(int vflag)
 /* ----------------------------------------------------------------------
    post_force_respa
 ------------------------------------------------------------------------- */
-void FixQTB::post_force_respa(int vflag, int ilevel, int iloop)
+void FixQTB::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }
@@ -392,7 +392,7 @@ void FixQTB::grow_arrays(int nmax)
 /* ----------------------------------------------------------------------
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
-void FixQTB::copy_arrays(int i, int j, int delflag)
+void FixQTB::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < 2*N_f; m++) {
     random_array_0[j][m] = random_array_0[i][m];

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -212,7 +212,7 @@ void PairQUIP::compute(int eflag, int vflag)
    global settings
 ------------------------------------------------------------------------- */
 
-void PairQUIP::settings(int narg, char **arg)
+void PairQUIP::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
   if (strcmp(force->pair_style,"hybrid") == 0)
@@ -315,7 +315,7 @@ void PairQUIP::init_style()
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairQUIP::init_one(int i, int j)
+double PairQUIP::init_one(int /*i*/, int /*j*/)
 {
   return cutoff;
 }

--- a/src/USER-REAXC/fix_qeq_reax.cpp
+++ b/src/USER-REAXC/fix_qeq_reax.cpp
@@ -381,7 +381,7 @@ void FixQEqReax::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqReax::init_list(int id, NeighList *ptr)
+void FixQEqReax::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -485,7 +485,7 @@ void FixQEqReax::init_storage()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqReax::pre_force(int vflag)
+void FixQEqReax::pre_force(int /*vflag*/)
 {
   double t_start, t_end;
 
@@ -518,7 +518,7 @@ void FixQEqReax::pre_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqReax::pre_force_respa(int vflag, int ilevel, int iloop)
+void FixQEqReax::pre_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) pre_force(vflag);
 }
@@ -833,7 +833,7 @@ void FixQEqReax::calculate_Q()
 /* ---------------------------------------------------------------------- */
 
 int FixQEqReax::pack_forward_comm(int n, int *list, double *buf,
-                                  int pbc_flag, int *pbc)
+                                  int /*pbc_flag*/, int */*pbc*/)
 {
   int m;
 
@@ -952,7 +952,7 @@ void FixQEqReax::grow_arrays(int nmax)
    copy values within fictitious charge arrays
 ------------------------------------------------------------------------- */
 
-void FixQEqReax::copy_arrays(int i, int j, int delflag)
+void FixQEqReax::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < nprev; m++) {
     s_hist[j][m] = s_hist[i][m];

--- a/src/USER-REAXC/fix_reaxc.cpp
+++ b/src/USER-REAXC/fix_reaxc.cpp
@@ -105,7 +105,7 @@ void FixReaxC::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixReaxC::copy_arrays(int i, int j, int delflag)
+void FixReaxC::copy_arrays(int i, int j, int /*delflag*/)
 {
   num_bonds[j] = num_bonds[i];
   num_hbonds[j] = num_hbonds[i];
@@ -136,7 +136,7 @@ int FixReaxC::unpack_exchange(int nlocal, double *buf)
 /* ---------------------------------------------------------------------- */
 
 int FixReaxC::pack_forward_comm(int n, int *list, double *buf,
-                                int pbc_flag, int *pbc)
+                                int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/USER-REAXC/fix_reaxc_bonds.cpp
+++ b/src/USER-REAXC/fix_reaxc_bonds.cpp
@@ -112,7 +112,7 @@ int FixReaxCBonds::setmask()
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCBonds::setup(int vflag)
+void FixReaxCBonds::setup(int /*vflag*/)
 {
   end_of_step();
 }
@@ -137,7 +137,7 @@ void FixReaxCBonds::end_of_step()
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCBonds::Output_ReaxC_Bonds(bigint ntimestep, FILE *fp)
+void FixReaxCBonds::Output_ReaxC_Bonds(bigint /*ntimestep*/, FILE */*fp*/)
 
 {
   int i, j;
@@ -185,7 +185,7 @@ void FixReaxCBonds::Output_ReaxC_Bonds(bigint ntimestep, FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCBonds::FindBond(struct _reax_list *lists, int &numbonds)
+void FixReaxCBonds::FindBond(struct _reax_list */*lists*/, int &numbonds)
 {
   int *ilist, i, ii, inum;
   int j, pj, nj;

--- a/src/USER-REAXC/fix_reaxc_species.cpp
+++ b/src/USER-REAXC/fix_reaxc_species.cpp
@@ -281,7 +281,7 @@ int FixReaxCSpecies::setmask()
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCSpecies::setup(int vflag)
+void FixReaxCSpecies::setup(int /*vflag*/)
 {
   ntotal = static_cast<int> (atom->natoms);
   if (Name == NULL)
@@ -427,7 +427,7 @@ void FixReaxCSpecies::create_fix()
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCSpecies::init_list(int id, NeighList *ptr)
+void FixReaxCSpecies::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -442,7 +442,7 @@ void FixReaxCSpecies::post_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCSpecies::Output_ReaxC_Bonds(bigint ntimestep, FILE *fp)
+void FixReaxCSpecies::Output_ReaxC_Bonds(bigint ntimestep, FILE */*fp*/)
 
 {
   int Nmole, Nspec;
@@ -946,7 +946,7 @@ int FixReaxCSpecies::nint(const double &r)
 /* ---------------------------------------------------------------------- */
 
 int FixReaxCSpecies::pack_forward_comm(int n, int *list, double *buf,
-                                       int pbc_flag, int *pbc)
+                                       int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/USER-REAXC/pair_reaxc.cpp
+++ b/src/USER-REAXC/pair_reaxc.cpp
@@ -751,7 +751,7 @@ int PairReaxC::write_reax_lists()
 
 /* ---------------------------------------------------------------------- */
 
-void PairReaxC::read_reax_forces(int vflag)
+void PairReaxC::read_reax_forces(int /*vflag*/)
 {
   for( int i = 0; i < system->N; ++i ) {
     system->my_atoms[i].f[0] = workspace->f[i][0];

--- a/src/USER-REAXC/reaxc_allocate.cpp
+++ b/src/USER-REAXC/reaxc_allocate.cpp
@@ -39,8 +39,8 @@
    important: we cannot know the exact number of atoms that will fall into a
    process's box throughout the whole simulation. therefore
    we need to make upper bound estimates for various data structures */
-int PreAllocate_Space( reax_system *system, control_params *control,
-                       storage *workspace, MPI_Comm comm )
+int PreAllocate_Space( reax_system *system, control_params */*control*/,
+                       storage */*workspace*/, MPI_Comm comm )
 {
   int mincap = system->mincap;
   double safezone = system->safezone;
@@ -68,8 +68,8 @@ int PreAllocate_Space( reax_system *system, control_params *control,
 
 /*************       system        *************/
 
-int Allocate_System( reax_system *system, int local_cap, int total_cap,
-                     char *msg )
+int Allocate_System( reax_system *system, int /*local_cap*/, int total_cap,
+                     char */*msg*/ )
 {
   system->my_atoms = (reax_atom*)
     realloc( system->my_atoms, total_cap*sizeof(reax_atom) );
@@ -116,7 +116,7 @@ void DeAllocate_System( reax_system *system )
 
 
 /*************       workspace        *************/
-void DeAllocate_Workspace( control_params *control, storage *workspace )
+void DeAllocate_Workspace( control_params */*control*/, storage *workspace )
 {
   int i;
 
@@ -204,9 +204,9 @@ void DeAllocate_Workspace( control_params *control, storage *workspace )
 }
 
 
-int Allocate_Workspace( reax_system *system, control_params *control,
+int Allocate_Workspace( reax_system */*system*/, control_params */*control*/,
                         storage *workspace, int local_cap, int total_cap,
-                        MPI_Comm comm, char *msg )
+                        MPI_Comm comm, char */*msg*/ )
 {
   int i, total_real, total_rvec, local_rvec;
 

--- a/src/USER-REAXC/reaxc_bond_orders.cpp
+++ b/src/USER-REAXC/reaxc_bond_orders.cpp
@@ -359,8 +359,8 @@ int BOp( storage *workspace, reax_list *bonds, double bo_cut,
 }
 
 
-void BO( reax_system *system, control_params *control, simulation_data *data,
-         storage *workspace, reax_list **lists, output_controls *out_control )
+void BO( reax_system *system, control_params */*control*/, simulation_data */*data*/,
+         storage *workspace, reax_list **lists, output_controls */*out_control*/ )
 {
   int i, j, pj, type_i, type_j;
   int start_i, end_i, sym_index;

--- a/src/USER-REAXC/reaxc_bonds.cpp
+++ b/src/USER-REAXC/reaxc_bonds.cpp
@@ -31,9 +31,9 @@
 #include "reaxc_tool_box.h"
 #include "reaxc_vector.h"
 
-void Bonds( reax_system *system, control_params *control,
+void Bonds( reax_system *system, control_params */*control*/,
             simulation_data *data, storage *workspace, reax_list **lists,
-            output_controls *out_control )
+            output_controls */*out_control*/ )
 {
   int i, j, pj, natoms;
   int start_i, end_i;

--- a/src/USER-REAXC/reaxc_forces.cpp
+++ b/src/USER-REAXC/reaxc_forces.cpp
@@ -41,9 +41,9 @@
 
 interaction_function Interaction_Functions[NUM_INTRS];
 
-void Dummy_Interaction( reax_system *system, control_params *control,
-                        simulation_data *data, storage *workspace,
-                        reax_list **lists, output_controls *out_control )
+void Dummy_Interaction( reax_system */*system*/, control_params */*control*/,
+                        simulation_data */*data*/, storage */*workspace*/,
+                        reax_list **/*lists*/, output_controls */*out_control*/ )
 {
 }
 
@@ -68,7 +68,7 @@ void Init_Force_Functions( control_params *control )
 void Compute_Bonded_Forces( reax_system *system, control_params *control,
                             simulation_data *data, storage *workspace,
                             reax_list **lists, output_controls *out_control,
-                            MPI_Comm comm )
+                            MPI_Comm /*comm*/ )
 {
   int i;
 
@@ -83,7 +83,7 @@ void Compute_Bonded_Forces( reax_system *system, control_params *control,
 void Compute_NonBonded_Forces( reax_system *system, control_params *control,
                                simulation_data *data, storage *workspace,
                                reax_list **lists, output_controls *out_control,
-                               MPI_Comm comm )
+                               MPI_Comm /*comm*/ )
 {
 
   /* van der Waals and Coulomb interactions */
@@ -98,7 +98,7 @@ void Compute_NonBonded_Forces( reax_system *system, control_params *control,
 
 void Compute_Total_Force( reax_system *system, control_params *control,
                           simulation_data *data, storage *workspace,
-                          reax_list **lists, mpi_datatypes *mpi_data )
+                          reax_list **lists, mpi_datatypes */*mpi_data*/ )
 {
   int i, pj;
   reax_list *bonds = (*lists) + BONDS;
@@ -114,8 +114,8 @@ void Compute_Total_Force( reax_system *system, control_params *control,
 
 }
 
-void Validate_Lists( reax_system *system, storage *workspace, reax_list **lists,
-                     int step, int n, int N, int numH, MPI_Comm comm )
+void Validate_Lists( reax_system *system, storage */*workspace*/, reax_list **lists,
+                     int step, int /*n*/, int N, int numH, MPI_Comm comm )
 {
   int i, comp, Hindex;
   reax_list *bonds, *hbonds;
@@ -173,7 +173,7 @@ void Validate_Lists( reax_system *system, storage *workspace, reax_list **lists,
 
 void Init_Forces_noQEq( reax_system *system, control_params *control,
                         simulation_data *data, storage *workspace,
-                        reax_list **lists, output_controls *out_control,
+                        reax_list **lists, output_controls */*out_control*/,
                         MPI_Comm comm ) {
   int i, j, pj;
   int start_i, end_i;
@@ -317,7 +317,7 @@ void Init_Forces_noQEq( reax_system *system, control_params *control,
 
 void Estimate_Storages( reax_system *system, control_params *control,
                         reax_list **lists, int *Htop, int *hb_top,
-                        int *bond_top, int *num_3body, MPI_Comm comm )
+                        int *bond_top, int *num_3body, MPI_Comm /*comm*/ )
 {
   int i, j, pj;
   int start_i, end_i;

--- a/src/USER-REAXC/reaxc_hydrogen_bonds.cpp
+++ b/src/USER-REAXC/reaxc_hydrogen_bonds.cpp
@@ -33,7 +33,7 @@
 
 void Hydrogen_Bonds( reax_system *system, control_params *control,
                      simulation_data *data, storage *workspace,
-                     reax_list **lists, output_controls *out_control )
+                     reax_list **lists, output_controls */*out_control*/ )
 {
   int  i, j, k, pi, pk;
   int  type_i, type_j, type_k;

--- a/src/USER-REAXC/reaxc_init_md.cpp
+++ b/src/USER-REAXC/reaxc_init_md.cpp
@@ -36,7 +36,7 @@
 #include "reaxc_tool_box.h"
 #include "reaxc_vector.h"
 
-int Init_System( reax_system *system, control_params *control, char *msg )
+int Init_System( reax_system *system, control_params *control, char */*msg*/ )
 {
   int i;
   reax_atom *atom;
@@ -66,7 +66,7 @@ int Init_System( reax_system *system, control_params *control, char *msg )
 
 
 int Init_Simulation_Data( reax_system *system, control_params *control,
-                          simulation_data *data, char *msg )
+                          simulation_data *data, char */*msg*/ )
 {
   Reset_Simulation_Data( data, control->virial );
 
@@ -139,8 +139,8 @@ int Init_Workspace( reax_system *system, control_params *control,
 
 
 /************** setup communication data structures  **************/
-int Init_MPI_Datatypes( reax_system *system, storage *workspace,
-                        mpi_datatypes *mpi_data, MPI_Comm comm, char *msg )
+int Init_MPI_Datatypes( reax_system *system, storage */*workspace*/,
+                        mpi_datatypes *mpi_data, MPI_Comm comm, char */*msg*/ )
 {
 
   /* setup the world */
@@ -151,8 +151,8 @@ int Init_MPI_Datatypes( reax_system *system, storage *workspace,
 }
 
 int  Init_Lists( reax_system *system, control_params *control,
-                 simulation_data *data, storage *workspace, reax_list **lists,
-                 mpi_datatypes *mpi_data, char *msg )
+                 simulation_data */*data*/, storage */*workspace*/, reax_list **lists,
+                 mpi_datatypes *mpi_data, char */*msg*/ )
 {
   int i, total_hbonds, total_bonds, bond_cap, num_3body, cap_3body, Htop;
   int *hb_top, *bond_top;

--- a/src/USER-REAXC/reaxc_io_tools.cpp
+++ b/src/USER-REAXC/reaxc_io_tools.cpp
@@ -88,7 +88,7 @@ int Init_Output_Files( reax_system *system, control_params *control,
 
 /************************ close output files ************************/
 int Close_Output_Files( reax_system *system, control_params *control,
-                        output_controls *out_control, mpi_datatypes *mpi_data )
+                        output_controls *out_control, mpi_datatypes */*mpi_data*/ )
 {
   if( out_control->write_steps > 0 )
     End_Traj( system->my_rank, out_control );

--- a/src/USER-REAXC/reaxc_lookup.cpp
+++ b/src/USER-REAXC/reaxc_lookup.cpp
@@ -151,7 +151,7 @@ void Complete_Cubic_Spline( const double *h, const double *f, double v0, double 
 
 
 int Init_Lookup_Tables( reax_system *system, control_params *control,
-                        storage *workspace, mpi_datatypes *mpi_data, char *msg )
+                        storage *workspace, mpi_datatypes *mpi_data, char */*msg*/ )
 {
   int i, j, r;
   int num_atom_types;

--- a/src/USER-REAXC/reaxc_multi_body.cpp
+++ b/src/USER-REAXC/reaxc_multi_body.cpp
@@ -32,7 +32,7 @@
 
 void Atom_Energy( reax_system *system, control_params *control,
                   simulation_data *data, storage *workspace, reax_list **lists,
-                  output_controls *out_control )
+                  output_controls */*out_control*/ )
 {
   int i, j, pj, type_i, type_j;
   double Delta_lpcorr, dfvl;

--- a/src/USER-REAXC/reaxc_nonbonded.cpp
+++ b/src/USER-REAXC/reaxc_nonbonded.cpp
@@ -33,7 +33,7 @@
 
 void vdW_Coulomb_Energy( reax_system *system, control_params *control,
                          simulation_data *data, storage *workspace,
-                         reax_list **lists, output_controls *out_control )
+                         reax_list **lists, output_controls */*out_control*/ )
 {
   int i, j, pj, natoms;
   int start_i, end_i, flag;
@@ -206,7 +206,7 @@ void vdW_Coulomb_Energy( reax_system *system, control_params *control,
 void Tabulated_vdW_Coulomb_Energy( reax_system *system,control_params *control,
                                    simulation_data *data, storage *workspace,
                                    reax_list **lists,
-                                   output_controls *out_control )
+                                   output_controls */*out_control*/ )
 {
   int i, j, pj, r, natoms;
   int type_i, type_j, tmin, tmax;

--- a/src/USER-REAXC/reaxc_reset_tools.cpp
+++ b/src/USER-REAXC/reaxc_reset_tools.cpp
@@ -87,7 +87,7 @@ void Reset_Pressures( simulation_data *data )
 }
 
 
-void Reset_Simulation_Data( simulation_data* data, int virial )
+void Reset_Simulation_Data( simulation_data* data, int /*virial*/ )
 {
   Reset_Energies( &data->my_en );
   Reset_Energies( &data->sys_en );

--- a/src/USER-REAXC/reaxc_torsion_angles.cpp
+++ b/src/USER-REAXC/reaxc_torsion_angles.cpp
@@ -41,7 +41,7 @@ double Calculate_Omega( rvec dvec_ij, double r_ij,
                       three_body_interaction_data *p_jkl,
                       rvec dcos_omega_di, rvec dcos_omega_dj,
                       rvec dcos_omega_dk, rvec dcos_omega_dl,
-                      output_controls *out_control )
+                      output_controls */*out_control*/ )
 {
   double unnorm_cos_omega, unnorm_sin_omega, omega;
   double sin_ijk, cos_ijk, sin_jkl, cos_jkl;

--- a/src/USER-REAXC/reaxc_traj.cpp
+++ b/src/USER-REAXC/reaxc_traj.cpp
@@ -48,7 +48,7 @@ int Reallocate_Output_Buffer( output_controls *out_control, int req_space,
 }
 
 
-void Write_Skip_Line( output_controls *out_control, mpi_datatypes *mpi_data,
+void Write_Skip_Line( output_controls *out_control, mpi_datatypes */*mpi_data*/,
                       int my_rank, int skip, int num_section )
 {
   if( my_rank == MASTER_NODE )
@@ -259,7 +259,7 @@ int Write_Header( reax_system *system, control_params *control,
 }
 
 
-int Write_Init_Desc( reax_system *system, control_params *control,
+int Write_Init_Desc( reax_system *system, control_params */*control*/,
                      output_controls *out_control, mpi_datatypes *mpi_data )
 {
   int i, me, np, cnt, buffer_len, buffer_req;
@@ -482,7 +482,7 @@ int Write_Frame_Header( reax_system *system, control_params *control,
 
 
 
-int Write_Atoms( reax_system *system, control_params *control,
+int Write_Atoms( reax_system *system, control_params */*control*/,
                  output_controls *out_control, mpi_datatypes *mpi_data )
 {
   int i, me, np, line_len, buffer_len, buffer_req, cnt;

--- a/src/USER-REAXC/reaxc_valence_angles.cpp
+++ b/src/USER-REAXC/reaxc_valence_angles.cpp
@@ -76,7 +76,7 @@ void Calculate_dCos_Theta( rvec dvec_ji, double d_ji, rvec dvec_jk, double d_jk,
 
 void Valence_Angles( reax_system *system, control_params *control,
                      simulation_data *data, storage *workspace,
-                     reax_list **lists, output_controls *out_control )
+                     reax_list **lists, output_controls */*out_control*/ )
 {
   int i, j, pi, k, pk, t;
   int type_i, type_j, type_k;

--- a/src/USER-SMD/atom_vec_smd.cpp
+++ b/src/USER-SMD/atom_vec_smd.cpp
@@ -208,7 +208,7 @@ void AtomVecSMD::copy(int i, int j, int delflag) {
 
 /* ---------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_comm(int n, int *list, double *buf, int pbc_flag, int *pbc) {
+int AtomVecSMD::pack_comm(int /*n*/, int */*list*/, double */*buf*/, int /*pbc_flag*/, int */*pbc*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
         return -1;
 }
@@ -333,7 +333,7 @@ int AtomVecSMD::pack_comm_hybrid(int n, int *list, double *buf) {
 
 /* ---------------------------------------------------------------------- */
 
-void AtomVecSMD::unpack_comm(int n, int first, double *buf) {
+void AtomVecSMD::unpack_comm(int /*n*/, int /*first*/, double */*buf*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
 }
 
@@ -441,7 +441,7 @@ int AtomVecSMD::unpack_reverse_hybrid(int n, int *list, double *buf) {
 
 /* ---------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_border(int n, int *list, double *buf, int pbc_flag, int *pbc) {
+int AtomVecSMD::pack_border(int /*n*/, int */*list*/, double */*buf*/, int /*pbc_flag*/, int */*pbc*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
         return -1;
 }
@@ -633,7 +633,7 @@ int AtomVecSMD::pack_border_hybrid(int n, int *list, double *buf) {
 
 /* ---------------------------------------------------------------------- */
 
-void AtomVecSMD::unpack_border(int n, int first, double *buf) {
+void AtomVecSMD::unpack_border(int /*n*/, int /*first*/, double */*buf*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
 }
 
@@ -1098,7 +1098,7 @@ void AtomVecSMD::data_atom(double *coord, imageint imagetmp, char **values) {
  initialize other atom quantities for this sub-style
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::data_atom_hybrid(int nlocal, char **values) {
+int AtomVecSMD::data_atom_hybrid(int /*nlocal*/, char **/*values*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return -1;
 }
@@ -1120,7 +1120,7 @@ void AtomVecSMD::data_vel(int m, char **values) {
  unpack hybrid quantities from one line in Velocities section of data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::data_vel_hybrid(int m, char **values) {
+int AtomVecSMD::data_vel_hybrid(int /*m*/, char **/*values*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return 0;
 }
@@ -1158,7 +1158,7 @@ void AtomVecSMD::pack_data(double **buf) {
  pack hybrid atom info for data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_data_hybrid(int i, double *buf) {
+int AtomVecSMD::pack_data_hybrid(int /*i*/, double */*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return -1;
 }
@@ -1180,7 +1180,7 @@ void AtomVecSMD::write_data(FILE *fp, int n, double **buf) {
  write hybrid atom info to data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::write_data_hybrid(FILE *fp, double *buf) {
+int AtomVecSMD::write_data_hybrid(FILE */*fp*/, double */*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return -1;
 }
@@ -1203,7 +1203,7 @@ void AtomVecSMD::pack_vel(double **buf) {
  pack hybrid velocity info for data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_vel_hybrid(int i, double *buf) {
+int AtomVecSMD::pack_vel_hybrid(int /*i*/, double */*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return 0;
 }
@@ -1222,7 +1222,7 @@ void AtomVecSMD::write_vel(FILE *fp, int n, double **buf) {
  write hybrid velocity info to data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::write_vel_hybrid(FILE *fp, double *buf) {
+int AtomVecSMD::write_vel_hybrid(FILE */*fp*/, double */*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return 3;
 }

--- a/src/USER-SMD/fix_smd_adjust_dt.cpp
+++ b/src/USER-SMD/fix_smd_adjust_dt.cpp
@@ -86,13 +86,13 @@ void FixSMDTlsphDtReset::init() {
 
 /* ---------------------------------------------------------------------- */
 
-void FixSMDTlsphDtReset::setup(int vflag) {
+void FixSMDTlsphDtReset::setup(int /*vflag*/) {
         end_of_step();
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixSMDTlsphDtReset::initial_integrate(int vflag) {
+void FixSMDTlsphDtReset::initial_integrate(int /*vflag*/) {
 
         //printf("in adjust_dt: dt = %20.10f\n", update->dt);
 

--- a/src/USER-SMD/fix_smd_integrate_tlsph.cpp
+++ b/src/USER-SMD/fix_smd_integrate_tlsph.cpp
@@ -125,7 +125,7 @@ void FixSMDIntegrateTlsph::init() {
 /* ----------------------------------------------------------------------
  ------------------------------------------------------------------------- */
 
-void FixSMDIntegrateTlsph::initial_integrate(int vflag) {
+void FixSMDIntegrateTlsph::initial_integrate(int /*vflag*/) {
         double dtfm, vsq, scale;
 
         // update v and x of atoms in group

--- a/src/USER-SMD/fix_smd_integrate_ulsph.cpp
+++ b/src/USER-SMD/fix_smd_integrate_ulsph.cpp
@@ -158,7 +158,7 @@ void FixSMDIntegrateUlsph::init() {
  allow for both per-type and per-atom mass
  ------------------------------------------------------------------------- */
 
-void FixSMDIntegrateUlsph::initial_integrate(int vflag) {
+void FixSMDIntegrateUlsph::initial_integrate(int /*vflag*/) {
         double **x = atom->x;
         double **v = atom->v;
         double **f = atom->f;

--- a/src/USER-SMD/fix_smd_move_triangulated_surface.cpp
+++ b/src/USER-SMD/fix_smd_move_triangulated_surface.cpp
@@ -248,7 +248,7 @@ void FixSMDMoveTriSurf::init() {
 /* ----------------------------------------------------------------------
  ------------------------------------------------------------------------- */
 
-void FixSMDMoveTriSurf::initial_integrate(int vflag) {
+void FixSMDMoveTriSurf::initial_integrate(int /*vflag*/) {
         double **x = atom->x;
         double **x0 = atom->x0;
         double **v = atom->v;
@@ -461,7 +461,7 @@ void FixSMDMoveTriSurf::reset_dt() {
 
 /* ---------------------------------------------------------------------- */
 
-int FixSMDMoveTriSurf::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc) {
+int FixSMDMoveTriSurf::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
         int i, j, m;
         double **x0 = atom->x0;
         double **smd_data_9 = atom->smd_data_9;

--- a/src/USER-SMD/fix_smd_setvel.cpp
+++ b/src/USER-SMD/fix_smd_setvel.cpp
@@ -231,7 +231,7 @@ void FixSMDSetVel::min_setup(int vflag) {
 /* ---------------------------------------------------------------------- */
 
 //void FixSMDSetVel::initial_integrate(int vflag) {
-void FixSMDSetVel::post_force(int vflag) {
+void FixSMDSetVel::post_force(int /*vflag*/) {
         double **x = atom->x;
         double **f = atom->f;
         double **v = atom->v;

--- a/src/USER-SMD/fix_smd_setvel.h
+++ b/src/USER-SMD/fix_smd_setvel.h
@@ -56,7 +56,6 @@ class FixSMDSetVel : public Fix {
   int xvar,yvar,zvar,xstyle,ystyle,zstyle;
   double foriginal[3],foriginal_all[3];
   int force_flag;
-  int nlevels_respa;
 
   int maxatom;
   double **sforce;

--- a/src/USER-SMD/fix_smd_tlsph_reference_configuration.cpp
+++ b/src/USER-SMD/fix_smd_tlsph_reference_configuration.cpp
@@ -199,7 +199,7 @@ void FixSMD_TLSPH_ReferenceConfiguration::pre_exchange() {
  so can be migrated or stored with atoms
  ------------------------------------------------------------------------- */
 
-void FixSMD_TLSPH_ReferenceConfiguration::setup(int vflag) {
+void FixSMD_TLSPH_ReferenceConfiguration::setup(int /*vflag*/) {
         int i, j, ii, jj, n, inum, jnum;
         int *ilist, *jlist, *numneigh, **firstneigh;
         double r, h, wf, wfd;
@@ -386,7 +386,7 @@ void FixSMD_TLSPH_ReferenceConfiguration::grow_arrays(int nmax) {
  copy values within local atom-based arrays
  ------------------------------------------------------------------------- */
 
-void FixSMD_TLSPH_ReferenceConfiguration::copy_arrays(int i, int j, int delflag) {
+void FixSMD_TLSPH_ReferenceConfiguration::copy_arrays(int i, int j, int /*delflag*/) {
         npartner[j] = npartner[i];
         for (int m = 0; m < npartner[j]; m++) {
                 partner[j][m] = partner[i][m];
@@ -470,7 +470,7 @@ int FixSMD_TLSPH_ReferenceConfiguration::pack_restart(int i, double *buf) {
  unpack values from atom->extra array to restart the fix
  ------------------------------------------------------------------------- */
 
-void FixSMD_TLSPH_ReferenceConfiguration::unpack_restart(int nlocal, int nth) {
+void FixSMD_TLSPH_ReferenceConfiguration::unpack_restart(int /*nlocal*/, int /*nth*/) {
 // ipage = NULL if being called from granular pair style init()
 
 // skip to Nth set of extra values
@@ -512,7 +512,7 @@ int FixSMD_TLSPH_ReferenceConfiguration::size_restart(int nlocal) {
 
 /* ---------------------------------------------------------------------- */
 
-int FixSMD_TLSPH_ReferenceConfiguration::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc) {
+int FixSMD_TLSPH_ReferenceConfiguration::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
         int i, j, m;
         double *radius = atom->radius;
         double *vfrac = atom->vfrac;

--- a/src/USER-SMD/fix_smd_tlsph_reference_configuration.cpp
+++ b/src/USER-SMD/fix_smd_tlsph_reference_configuration.cpp
@@ -149,7 +149,7 @@ void FixSMD_TLSPH_ReferenceConfiguration::pre_exchange() {
 
         if (updateFlag > 0) {
                 if (comm->me == 0) {
-                        printf("**** updating ref config at step: %ld\n", update->ntimestep);
+                        printf("**** updating ref config at step: " BIGINT_FORMAT "\n", update->ntimestep);
                 }
 
                 for (i = 0; i < nlocal; i++) {

--- a/src/USER-SMD/fix_smd_wall_surface.cpp
+++ b/src/USER-SMD/fix_smd_wall_surface.cpp
@@ -110,7 +110,7 @@ void FixSMDWallSurface::min_setup(int vflag) {
  must be done in setup (not init) since fix init comes before neigh init
  ------------------------------------------------------------------------- */
 
-void FixSMDWallSurface::setup(int vflag) {
+void FixSMDWallSurface::setup(int /*vflag*/) {
 
         if (!first)
                 return;

--- a/src/USER-SMD/pair_smd_hertz.cpp
+++ b/src/USER-SMD/pair_smd_hertz.cpp
@@ -373,7 +373,7 @@ double PairHertz::memory_usage() {
         return 0.0;
 }
 
-void *PairHertz::extract(const char *str, int &i) {
+void *PairHertz::extract(const char *str, int &/*i*/) {
         //printf("in PairTriSurf::extract\n");
         if (strcmp(str, "smd/hertz/stable_time_increment_ptr") == 0) {
                 return (void *) &stable_time_increment;

--- a/src/USER-SMD/pair_smd_tlsph.cpp
+++ b/src/USER-SMD/pair_smd_tlsph.cpp
@@ -1802,7 +1802,7 @@ double PairTlsph::memory_usage() {
  extract method to provide access to this class' data structures
  ------------------------------------------------------------------------- */
 
-void *PairTlsph::extract(const char *str, int &i) {
+void *PairTlsph::extract(const char *str, int &/*i*/) {
 //printf("in PairTlsph::extract\n");
         if (strcmp(str, "smd/tlsph/Fincr_ptr") == 0) {
                 return (void *) Fincr;
@@ -1839,7 +1839,7 @@ void *PairTlsph::extract(const char *str, int &i) {
 
 /* ---------------------------------------------------------------------- */
 
-int PairTlsph::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc) {
+int PairTlsph::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
         int i, j, m;
         tagint *mol = atom->molecule;
         double *damage = atom->damage;
@@ -1928,7 +1928,7 @@ void PairTlsph::unpack_forward_comm(int n, int first, double *buf) {
  ------------------------------------------------------------------------- */
 
 void PairTlsph::effective_longitudinal_modulus(const int itype, const double dt, const double d_iso, const double p_rate,
-                const Matrix3d d_dev, const Matrix3d sigma_dev_rate, const double damage, double &K_eff, double &mu_eff, double &M_eff) {
+                const Matrix3d d_dev, const Matrix3d sigma_dev_rate, const double /*damage*/, double &K_eff, double &mu_eff, double &M_eff) {
         double M0; // initial longitudinal modulus
         double shear_rate_sq;
 
@@ -2094,7 +2094,7 @@ void PairTlsph::ComputeStressDeviator(const int i, const Matrix3d sigmaInitial_d
 /* ----------------------------------------------------------------------
  Compute damage. Called from AssembleStress().
  ------------------------------------------------------------------------- */
-void PairTlsph::ComputeDamage(const int i, const Matrix3d strain, const Matrix3d stress, Matrix3d &stress_damaged) {
+void PairTlsph::ComputeDamage(const int i, const Matrix3d strain, const Matrix3d stress, Matrix3d &/*stress_damaged*/) {
         double *eff_plastic_strain = atom->eff_plastic_strain;
         double *eff_plastic_strain_rate = atom->eff_plastic_strain_rate;
         double *radius = atom->radius;

--- a/src/USER-SMD/pair_smd_triangulated_surface.cpp
+++ b/src/USER-SMD/pair_smd_triangulated_surface.cpp
@@ -834,7 +834,7 @@ double PairTriSurf::clamp(const double a, const double min, const double max) {
         }
 }
 
-void *PairTriSurf::extract(const char *str, int &i) {
+void *PairTriSurf::extract(const char *str, int &/*i*/) {
         //printf("in PairTriSurf::extract\n");
         if (strcmp(str, "smd/tri_surface/stable_time_increment_ptr") == 0) {
                 return (void *) &stable_time_increment;

--- a/src/USER-SMD/pair_smd_ulsph.cpp
+++ b/src/USER-SMD/pair_smd_ulsph.cpp
@@ -1487,7 +1487,7 @@ double PairULSPH::memory_usage() {
 
 /* ---------------------------------------------------------------------- */
 
-int PairULSPH::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc) {
+int PairULSPH::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
         double *vfrac = atom->vfrac;
         double *eff_plastic_strain = atom->eff_plastic_strain;
         int i, j, m;
@@ -1562,7 +1562,7 @@ void PairULSPH::unpack_forward_comm(int n, int first, double *buf) {
  * EXTRACT
  */
 
-void *PairULSPH::extract(const char *str, int &i) {
+void *PairULSPH::extract(const char *str, int &/*i*/) {
 //printf("in extract\n");
         if (strcmp(str, "smd/ulsph/smoothVel_ptr") == 0) {
                 return (void *) smoothVel;

--- a/src/USER-SMD/smd_material_models.cpp
+++ b/src/USER-SMD/smd_material_models.cpp
@@ -97,7 +97,7 @@ void ShockEOS(double rho, double rho0, double e, double e0, double c0, double S,
  final pressure pFinal
 
  ------------------------------------------------------------------------- */
-void polynomialEOS(double rho, double rho0, double e, double C0, double C1, double C2, double C3, double C4, double C5, double C6,
+void polynomialEOS(double rho, double rho0, double /*e*/, double C0, double C1, double C2, double C3, double /*C4*/, double /*C5*/, double /*C6*/,
                 double pInitial, double dt, double &pFinal, double &p_rate) {
 
         double mu = rho / rho0 - 1.0;
@@ -307,7 +307,7 @@ void LinearPlasticStrength(const double G, const double yieldStress, const Matri
  output:  sigmaFinal_dev, sigmaFinal_dev_rate__: final stress deviator and its rate.
  ------------------------------------------------------------------------- */
 void JohnsonCookStrength(const double G, const double cp, const double espec, const double A, const double B, const double a,
-                const double C, const double epdot0, const double T0, const double Tmelt, const double M, const double dt, const double ep,
+                const double C, const double epdot0, const double T0, const double Tmelt, const double /*M*/, const double dt, const double ep,
                 const double epdot, const Matrix3d sigmaInitial_dev, const Matrix3d d_dev, Matrix3d &sigmaFinal_dev__,
                 Matrix3d &sigma_dev_rate__, double &plastic_strain_increment) {
 

--- a/src/USER-SMTBQ/pair_smtbq.cpp
+++ b/src/USER-SMTBQ/pair_smtbq.cpp
@@ -242,7 +242,7 @@ void PairSMTBQ::allocate()
    global settings
    ------------------------------------------------------------------------- */
 
-void PairSMTBQ::settings(int narg, char **arg)
+void PairSMTBQ::settings(int narg, char **/*arg*/)
 {
   if (narg > 0) error->all(FLERR,"Illegal pair_style command");
 }
@@ -1592,7 +1592,7 @@ void PairSMTBQ::tabqeq()
 /* ---------------------------------------------------------------------*/
 
 void PairSMTBQ::potqeq(int i, int j, double qi, double qj, double rsq,
-                       double &fforce, int eflag, double &eng)
+                       double &fforce, int /*eflag*/, double &eng)
 {
 
   /* ===================================================================
@@ -1840,7 +1840,7 @@ void PairSMTBQ::pot_ES2 (int i, int j, double rsq, double &pot)
    -------------------------------------------------------------------- */
 
 void PairSMTBQ::rep_OO(Intparam *intparam, double rsq, double &fforce,
-                       int eflag, double &eng)
+                       int /*eflag*/, double &eng)
 {
   double r,tmp_exp,tmp;
   double A = intparam->abuck ;
@@ -1858,7 +1858,7 @@ void PairSMTBQ::rep_OO(Intparam *intparam, double rsq, double &fforce,
 
 
 void PairSMTBQ::Attr_OO(Intparam *intparam, double rsq, double &fforce,
-                        int eflag, double &eng)
+                        int /*eflag*/, double &eng)
 {
   double r,tmp_exp;
   double aOO = intparam->aOO ;
@@ -1980,8 +1980,8 @@ void PairSMTBQ::tabsm()
 
 /* -------------------------------------------------------------- */
 
-void PairSMTBQ::repulsive(Intparam *intparam, double rsq, int i, int j,
-                          double &fforce, int eflag, double &eng)
+void PairSMTBQ::repulsive(Intparam *intparam, double rsq, int /*i*/, int /*j*/,
+                          double &fforce, int /*eflag*/, double &eng)
 {
 
   /* ================================================
@@ -2031,7 +2031,7 @@ void PairSMTBQ::repulsive(Intparam *intparam, double rsq, int i, int j,
 
 
 void PairSMTBQ::attractive(Intparam *intparam, double rsq,
-                           int eflag, int i, double iq, int j, double jq)
+                           int /*eflag*/, int i, double /*iq*/, int /*j*/, double /*jq*/)
 {
   int itype,l;
   double r,t1,t2,xi,sds;
@@ -3334,7 +3334,7 @@ void PairSMTBQ::groupQEqAllParallel_QEq()
 
 /* ---------------------------------------------------------------------- */
 
-void PairSMTBQ::Init_charge(int *nQEq, int *nQEqa, int *nQEqc)
+void PairSMTBQ::Init_charge(int */*nQEq*/, int */*nQEqa*/, int */*nQEqc*/)
 {
   int ii,i,gp,itype;
   int *ilist,test[nteam],init[nteam];
@@ -3391,7 +3391,7 @@ void PairSMTBQ::Init_charge(int *nQEq, int *nQEqa, int *nQEqc)
  *                        COMMUNICATION
  * ---------------------------------------------------------------------- */
 
-int PairSMTBQ::pack_forward_comm(int n, int *list, double *buf, int pbc_flag, int *pbc)
+int PairSMTBQ::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
 {
   int i,j,m;
 

--- a/src/USER-SPH/fix_meso.cpp
+++ b/src/USER-SPH/fix_meso.cpp
@@ -64,7 +64,7 @@ void FixMeso::init() {
   dtf = 0.5 * update->dt * force->ftm2v;
 }
 
-void FixMeso::setup_pre_force(int vflag)
+void FixMeso::setup_pre_force(int /*vflag*/)
 {
   // set vest equal to v
   double **v = atom->v;
@@ -87,7 +87,7 @@ void FixMeso::setup_pre_force(int vflag)
  allow for both per-type and per-atom mass
  ------------------------------------------------------------------------- */
 
-void FixMeso::initial_integrate(int vflag) {
+void FixMeso::initial_integrate(int /*vflag*/) {
   // update v and x and rho and e of atoms in group
 
   double **x = atom->x;

--- a/src/USER-SPH/fix_meso_stationary.cpp
+++ b/src/USER-SPH/fix_meso_stationary.cpp
@@ -67,7 +67,7 @@ void FixMesoStationary::init() {
  allow for both per-type and per-atom mass
  ------------------------------------------------------------------------- */
 
-void FixMesoStationary::initial_integrate(int vflag) {
+void FixMesoStationary::initial_integrate(int /*vflag*/) {
 
   double *rho = atom->rho;
   double *drho = atom->drho;

--- a/src/USER-SPH/pair_sph_heatconduction.cpp
+++ b/src/USER-SPH/pair_sph_heatconduction.cpp
@@ -155,7 +155,7 @@ void PairSPHHeatConduction::allocate() {
  global settings
  ------------------------------------------------------------------------- */
 
-void PairSPHHeatConduction::settings(int narg, char **arg) {
+void PairSPHHeatConduction::settings(int narg, char **/*arg*/) {
   if (narg != 0)
     error->all(FLERR,
         "Illegal number of setting arguments for pair_style sph/heatconduction");
@@ -211,8 +211,8 @@ double PairSPHHeatConduction::init_one(int i, int j) {
 
 /* ---------------------------------------------------------------------- */
 
-double PairSPHHeatConduction::single(int i, int j, int itype, int jtype,
-    double rsq, double factor_coul, double factor_lj, double &fforce) {
+double PairSPHHeatConduction::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/,
+    double /*rsq*/, double /*factor_coul*/, double /*factor_lj*/, double &fforce) {
   fforce = 0.0;
 
   return 0.0;

--- a/src/USER-SPH/pair_sph_idealgas.cpp
+++ b/src/USER-SPH/pair_sph_idealgas.cpp
@@ -197,7 +197,7 @@ void PairSPHIdealGas::allocate() {
  global settings
  ------------------------------------------------------------------------- */
 
-void PairSPHIdealGas::settings(int narg, char **arg) {
+void PairSPHIdealGas::settings(int narg, char **/*arg*/) {
   if (narg != 0)
     error->all(FLERR,
         "Illegal number of setting arguments for pair_style sph/idealgas");
@@ -252,8 +252,8 @@ double PairSPHIdealGas::init_one(int i, int j) {
 
 /* ---------------------------------------------------------------------- */
 
-double PairSPHIdealGas::single(int i, int j, int itype, int jtype,
-    double rsq, double factor_coul, double factor_lj, double &fforce) {
+double PairSPHIdealGas::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/,
+    double /*rsq*/, double /*factor_coul*/, double /*factor_lj*/, double &fforce) {
   fforce = 0.0;
 
   return 0.0;

--- a/src/USER-SPH/pair_sph_lj.cpp
+++ b/src/USER-SPH/pair_sph_lj.cpp
@@ -204,7 +204,7 @@ void PairSPHLJ::allocate() {
  global settings
  ------------------------------------------------------------------------- */
 
-void PairSPHLJ::settings(int narg, char **arg) {
+void PairSPHLJ::settings(int narg, char **/*arg*/) {
   if (narg != 0)
     error->all(FLERR,
         "Illegal number of setting arguments for pair_style sph/lj");
@@ -261,8 +261,8 @@ double PairSPHLJ::init_one(int i, int j) {
 
 /* ---------------------------------------------------------------------- */
 
-double PairSPHLJ::single(int i, int j, int itype, int jtype,
-    double rsq, double factor_coul, double factor_lj, double &fforce) {
+double PairSPHLJ::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/,
+    double /*rsq*/, double /*factor_coul*/, double /*factor_lj*/, double &fforce) {
   fforce = 0.0;
 
   return 0.0;

--- a/src/USER-SPH/pair_sph_rhosum.cpp
+++ b/src/USER-SPH/pair_sph_rhosum.cpp
@@ -278,8 +278,8 @@ double PairSPHRhoSum::init_one(int i, int j) {
 
 /* ---------------------------------------------------------------------- */
 
-double PairSPHRhoSum::single(int i, int j, int itype, int jtype, double rsq,
-    double factor_coul, double factor_lj, double &fforce) {
+double PairSPHRhoSum::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/, double /*rsq*/,
+    double /*factor_coul*/, double /*factor_lj*/, double &fforce) {
   fforce = 0.0;
 
   return 0.0;
@@ -288,7 +288,7 @@ double PairSPHRhoSum::single(int i, int j, int itype, int jtype, double rsq,
 /* ---------------------------------------------------------------------- */
 
 int PairSPHRhoSum::pack_forward_comm(int n, int *list, double *buf,
-                                     int pbc_flag, int *pbc) {
+                                     int /*pbc_flag*/, int */*pbc*/) {
   int i, j, m;
   double *rho = atom->rho;
 

--- a/src/USER-SPH/pair_sph_taitwater.cpp
+++ b/src/USER-SPH/pair_sph_taitwater.cpp
@@ -225,7 +225,7 @@ void PairSPHTaitwater::allocate() {
  global settings
  ------------------------------------------------------------------------- */
 
-void PairSPHTaitwater::settings(int narg, char **arg) {
+void PairSPHTaitwater::settings(int narg, char **/*arg*/) {
   if (narg != 0)
     error->all(FLERR,
         "Illegal number of setting arguments for pair_style sph/taitwater");
@@ -293,8 +293,8 @@ double PairSPHTaitwater::init_one(int i, int j) {
 
 /* ---------------------------------------------------------------------- */
 
-double PairSPHTaitwater::single(int i, int j, int itype, int jtype,
-    double rsq, double factor_coul, double factor_lj, double &fforce) {
+double PairSPHTaitwater::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/,
+    double /*rsq*/, double /*factor_coul*/, double /*factor_lj*/, double &fforce) {
   fforce = 0.0;
 
   return 0.0;

--- a/src/USER-SPH/pair_sph_taitwater_morris.cpp
+++ b/src/USER-SPH/pair_sph_taitwater_morris.cpp
@@ -225,7 +225,7 @@ void PairSPHTaitwaterMorris::allocate() {
  global settings
  ------------------------------------------------------------------------- */
 
-void PairSPHTaitwaterMorris::settings(int narg, char **arg) {
+void PairSPHTaitwaterMorris::settings(int narg, char **/*arg*/) {
   if (narg != 0)
     error->all(FLERR,
         "Illegal number of setting arguments for pair_style sph/taitwater/morris");
@@ -289,8 +289,8 @@ double PairSPHTaitwaterMorris::init_one(int i, int j) {
 
 /* ---------------------------------------------------------------------- */
 
-double PairSPHTaitwaterMorris::single(int i, int j, int itype, int jtype,
-    double rsq, double factor_coul, double factor_lj, double &fforce) {
+double PairSPHTaitwaterMorris::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/,
+    double /*rsq*/, double /*factor_coul*/, double /*factor_lj*/, double &fforce) {
   fforce = 0.0;
 
   return 0.0;

--- a/src/USER-UEF/fix_nh_uef.cpp
+++ b/src/USER-UEF/fix_nh_uef.cpp
@@ -348,7 +348,7 @@ void FixNHUef::final_integrate()
  * at outer level: call this->final_integrate()
  * at other levels: rotate -> 2nd verlet step -> rotate back
  * ---------------------------------------------------------------------- */
-void FixNHUef::final_integrate_respa(int ilevel, int iloop)
+void FixNHUef::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   // set timesteps by level
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -66,8 +66,8 @@ class AtomKokkos : public Atom {
   tagint **k_special;
   AtomKokkos(class LAMMPS *lmp) : Atom(lmp) {}
   ~AtomKokkos() {}
-  void sync(const ExecutionSpace space, unsigned int mask) {}
-  void modified(const ExecutionSpace space, unsigned int mask) {}
+  void sync(const ExecutionSpace /*space*/, unsigned int /*mask*/) {}
+  void modified(const ExecutionSpace /*space*/, unsigned int /*mask*/) {}
 };
 
 class CommKokkos : public CommBrick {

--- a/src/angle_zero.cpp
+++ b/src/angle_zero.cpp
@@ -148,7 +148,7 @@ void AngleZero::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double AngleZero::single(int type, int i1, int i2, int i3)
+double AngleZero::single(int /*type*/, int /*i1*/, int /*i2*/, int /*i3*/)
 {
   return 0.0;
 }

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -99,7 +99,7 @@ Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
   // SPIN package
 
   sp = fm = NULL;
-  
+
   // USER-DPD
 
   uCond = uMech = uChem = uCG = uCGnew = NULL;
@@ -1516,7 +1516,7 @@ void Atom::set_mass(const char *file, int line, int itype, double value)
    called from reading of input script
 ------------------------------------------------------------------------- */
 
-void Atom::set_mass(const char *file, int line, int narg, char **arg)
+void Atom::set_mass(const char *file, int line, int /*narg*/, char **arg)
 {
   if (mass == NULL) error->all(file,line,"Cannot set mass for this atom style");
 

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -66,7 +66,7 @@ void AtomVec::store_args(int narg, char **arg)
    no additional args by default
 ------------------------------------------------------------------------- */
 
-void AtomVec::process_args(int narg, char **arg)
+void AtomVec::process_args(int narg, char ** /*arg*/)
 {
   if (narg) error->all(FLERR,"Invalid atom_style command");
 }

--- a/src/atom_vec_body.cpp
+++ b/src/atom_vec_body.cpp
@@ -82,6 +82,9 @@ AtomVecBody::~AtomVecBody()
 
 void AtomVecBody::process_args(int narg, char **arg)
 {
+  // suppress unused parameter warning dependent on style_body.h
+  (void)(arg);
+
   if (narg < 1) error->all(FLERR,"Invalid atom_style body command");
 
   if (0) bptr = NULL;

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -21,7 +21,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-Body::Body(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
+Body::Body(LAMMPS *lmp, int /*narg*/, char **arg) : Pointers(lmp)
 {
   int n = strlen(arg[0]) + 1;
   style = new char[n];

--- a/src/bond_zero.cpp
+++ b/src/bond_zero.cpp
@@ -149,8 +149,8 @@ void BondZero::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondZero::single(int type, double rsq, int i, int j,
-                        double &fforce)
+double BondZero::single(int /*type*/, double /*rsq*/, int /*i*/, int /*j*/,
+                        double & /*fforce*/)
 {
   return 0.0;
 }

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -88,7 +88,7 @@ CommBrick::~CommBrick()
 //           The call to Comm::copy_arrays() then converts the shallow copy
 //           into a deep copy of the class with the new layout.
 
-CommBrick::CommBrick(LAMMPS *lmp, Comm *oldcomm) : Comm(*oldcomm)
+CommBrick::CommBrick(LAMMPS * /*lmp*/, Comm *oldcomm) : Comm(*oldcomm)
 {
   if (oldcomm->layout == Comm::LAYOUT_TILED)
     error->all(FLERR,"Cannot change to comm_style brick from tiled layout");
@@ -457,7 +457,7 @@ int CommBrick::updown(int dim, int dir, int loc,
    other per-atom attributes may also be sent via pack/unpack routines
 ------------------------------------------------------------------------- */
 
-void CommBrick::forward_comm(int dummy)
+void CommBrick::forward_comm(int /*dummy*/)
 {
   int n;
   MPI_Request request;

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -55,7 +55,7 @@ CommTiled::CommTiled(LAMMPS *lmp) : Comm(lmp)
 //           The call to Comm::copy_arrays() then converts the shallow copy
 //           into a deep copy of the class with the new layout.
 
-CommTiled::CommTiled(LAMMPS *lmp, Comm *oldcomm) : Comm(*oldcomm)
+CommTiled::CommTiled(LAMMPS * /*lmp*/, Comm *oldcomm) : Comm(*oldcomm)
 {
   style = 1;
   layout = oldcomm->layout;
@@ -438,7 +438,7 @@ void CommTiled::setup()
    other per-atom attributes may also be sent via pack/unpack routines
 ------------------------------------------------------------------------- */
 
-void CommTiled::forward_comm(int dummy)
+void CommTiled::forward_comm(int /*dummy*/)
 {
   int i,irecv,n,nsend,nrecv;
   AtomVec *avec = atom->avec;
@@ -1164,7 +1164,7 @@ void CommTiled::reverse_comm_fix(Fix *fix, int size)
    NOTE: how to setup one big buf recv with correct offsets ??
 ------------------------------------------------------------------------- */
 
-void CommTiled::reverse_comm_fix_variable(Fix *fix)
+void CommTiled::reverse_comm_fix_variable(Fix * /*fix*/)
 {
   error->all(FLERR,"Reverse comm fix variable not yet supported by CommTiled");
 }
@@ -1428,7 +1428,7 @@ void CommTiled::forward_comm_array(int nsize, double **array)
    NOTE: this method is currently not used
 ------------------------------------------------------------------------- */
 
-int CommTiled::exchange_variable(int n, double *inbuf, double *&outbuf)
+int CommTiled::exchange_variable(int n, double * /*inbuf*/, double *& /*outbuf*/)
 {
   int nrecv = n;
   return nrecv;
@@ -1509,7 +1509,7 @@ void CommTiled::box_drop_brick(int idim, double *lo, double *hi, int &indexme)
    no need to split lo/hi box as recurse b/c OK if box extends outside RCB box
 ------------------------------------------------------------------------- */
 
-void CommTiled::box_drop_tiled(int idim, double *lo, double *hi, int &indexme)
+void CommTiled::box_drop_tiled(int /*idim*/, double *lo, double *hi, int &indexme)
 {
   box_drop_tiled_recurse(lo,hi,0,nprocs-1,indexme);
 }
@@ -1601,7 +1601,7 @@ void CommTiled::box_other_brick(int idim, int idir,
    return other box owned by proc as lo/hi corner pts
 ------------------------------------------------------------------------- */
 
-void CommTiled::box_other_tiled(int idim, int idir,
+void CommTiled::box_other_tiled(int /*idim*/, int /*idir*/,
                                 int proc, double *lo, double *hi)
 {
   double (*split)[2] = rcbinfo[proc].mysplit;

--- a/src/compute_aggregate_atom.cpp
+++ b/src/compute_aggregate_atom.cpp
@@ -98,7 +98,7 @@ void ComputeAggregateAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeAggregateAtom::init_list(int id, NeighList *ptr)
+void ComputeAggregateAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -231,7 +231,7 @@ void ComputeAggregateAtom::compute_peratom()
 /* ---------------------------------------------------------------------- */
 
 int ComputeAggregateAtom::pack_forward_comm(int n, int *list, double *buf,
-                                          int pbc_flag, int *pbc)
+                                          int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -337,7 +337,7 @@ int ComputeBondLocal::compute_bonds(int flag)
 /* ---------------------------------------------------------------------- */
 
 int ComputeBondLocal::pack_forward_comm(int n, int *list, double *buf,
-                                        int pbc_flag, int *pbc)
+                                        int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/compute_centro_atom.cpp
+++ b/src/compute_centro_atom.cpp
@@ -110,7 +110,7 @@ void ComputeCentroAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeCentroAtom::init_list(int id, NeighList *ptr)
+void ComputeCentroAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -89,7 +89,7 @@ void ComputeClusterAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeClusterAtom::init_list(int id, NeighList *ptr)
+void ComputeClusterAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -209,7 +209,7 @@ void ComputeClusterAtom::compute_peratom()
 /* ---------------------------------------------------------------------- */
 
 int ComputeClusterAtom::pack_forward_comm(int n, int *list, double *buf,
-                                          int pbc_flag, int *pbc)
+                                          int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/compute_cna_atom.cpp
+++ b/src/compute_cna_atom.cpp
@@ -100,7 +100,7 @@ void ComputeCNAAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeCNAAtom::init_list(int id, NeighList *ptr)
+void ComputeCNAAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_contact_atom.cpp
+++ b/src/compute_contact_atom.cpp
@@ -80,7 +80,7 @@ void ComputeContactAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeContactAtom::init_list(int id, NeighList *ptr)
+void ComputeContactAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -153,7 +153,7 @@ void ComputeCoordAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeCoordAtom::init_list(int id, NeighList *ptr)
+void ComputeCoordAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -311,7 +311,7 @@ void ComputeCoordAtom::compute_peratom()
 /* ---------------------------------------------------------------------- */
 
 int ComputeCoordAtom::pack_forward_comm(int n, int *list, double *buf,
-                                        int pbc_flag, int *pbc)
+                                        int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,m=0,j;
   for (i = 0; i < n; ++i) {

--- a/src/compute_fragment_atom.cpp
+++ b/src/compute_fragment_atom.cpp
@@ -159,7 +159,7 @@ void ComputeFragmentAtom::compute_peratom()
 /* ---------------------------------------------------------------------- */
 
 int ComputeFragmentAtom::pack_forward_comm(int n, int *list, double *buf,
-                                          int pbc_flag, int *pbc)
+                                          int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/compute_group_group.cpp
+++ b/src/compute_group_group.cpp
@@ -173,7 +173,7 @@ void ComputeGroupGroup::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeGroupGroup::init_list(int id, NeighList *ptr)
+void ComputeGroupGroup::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_hexorder_atom.cpp
+++ b/src/compute_hexorder_atom.cpp
@@ -129,7 +129,7 @@ void ComputeHexOrderAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeHexOrderAtom::init_list(int id, NeighList *ptr)
+void ComputeHexOrderAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_orientorder_atom.cpp
+++ b/src/compute_orientorder_atom.cpp
@@ -187,7 +187,7 @@ void ComputeOrientOrderAtom::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeOrientOrderAtom::init_list(int id, NeighList *ptr)
+void ComputeOrientOrderAtom::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }
@@ -542,4 +542,3 @@ double ComputeOrientOrderAtom::associated_legendre(int l, int m, double x)
 
   return p;
 }
-

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -139,7 +139,7 @@ void ComputePairLocal::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputePairLocal::init_list(int id, NeighList *ptr)
+void ComputePairLocal::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_property_local.cpp
+++ b/src/compute_property_local.cpp
@@ -308,7 +308,7 @@ void ComputePropertyLocal::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputePropertyLocal::init_list(int id, NeighList *ptr)
+void ComputePropertyLocal::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_rdf.cpp
+++ b/src/compute_rdf.cpp
@@ -213,7 +213,7 @@ void ComputeRDF::init()
 
 /* ---------------------------------------------------------------------- */
 
-void ComputeRDF::init_list(int id, NeighList *ptr)
+void ComputeRDF::init_list(int /*id*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/compute_temp_com.cpp
+++ b/src/compute_temp_com.cpp
@@ -163,7 +163,7 @@ void ComputeTempCOM::compute_vector()
    remove velocity bias from atom I to leave thermal velocity
 ------------------------------------------------------------------------- */
 
-void ComputeTempCOM::remove_bias(int i, double *v)
+void ComputeTempCOM::remove_bias(int /*i*/, double *v)
 {
   v[0] -= vbias[0];
   v[1] -= vbias[1];
@@ -204,7 +204,7 @@ void ComputeTempCOM::remove_bias_all()
    assume remove_bias() was previously called
 ------------------------------------------------------------------------- */
 
-void ComputeTempCOM::restore_bias(int i, double *v)
+void ComputeTempCOM::restore_bias(int /*i*/, double *v)
 {
   v[0] += vbias[0];
   v[1] += vbias[1];

--- a/src/compute_temp_deform.cpp
+++ b/src/compute_temp_deform.cpp
@@ -277,7 +277,7 @@ void ComputeTempDeform::remove_bias_all()
    assume remove_bias() was previously called
 ------------------------------------------------------------------------- */
 
-void ComputeTempDeform::restore_bias(int i, double *v)
+void ComputeTempDeform::restore_bias(int /*i*/, double *v)
 {
   v[0] += vbias[0];
   v[1] += vbias[1];
@@ -289,7 +289,7 @@ void ComputeTempDeform::restore_bias(int i, double *v)
    assume remove_bias_thr() was previously called with the same buffer b
 ------------------------------------------------------------------------- */
 
-void ComputeTempDeform::restore_bias_thr(int i, double *v, double *b)
+void ComputeTempDeform::restore_bias_thr(int /*i*/, double *v, double *b)
 {
   v[0] += b[0];
   v[1] += b[1];

--- a/src/compute_temp_partial.cpp
+++ b/src/compute_temp_partial.cpp
@@ -90,7 +90,7 @@ void ComputeTempPartial::dof_compute()
 
 /* ---------------------------------------------------------------------- */
 
-int ComputeTempPartial::dof_remove(int i)
+int ComputeTempPartial::dof_remove(int /*i*/)
 {
   int nper = xflag+yflag+zflag;
   return (domain->dimension - nper);
@@ -169,7 +169,7 @@ void ComputeTempPartial::compute_vector()
    remove velocity bias from atom I to leave thermal velocity
 ------------------------------------------------------------------------- */
 
-void ComputeTempPartial::remove_bias(int i, double *v)
+void ComputeTempPartial::remove_bias(int /*i*/, double *v)
 {
   if (!xflag) {
     vbias[0] = v[0];
@@ -189,7 +189,7 @@ void ComputeTempPartial::remove_bias(int i, double *v)
    remove velocity bias from atom I to leave thermal velocity
 ------------------------------------------------------------------------- */
 
-void ComputeTempPartial::remove_bias_thr(int i, double *v, double *b)
+void ComputeTempPartial::remove_bias_thr(int /*i*/, double *v, double *b)
 {
   if (!xflag) {
     b[0] = v[0];
@@ -275,7 +275,7 @@ void ComputeTempPartial::reapply_bias_all()
    assume remove_bias() was previously called
 ------------------------------------------------------------------------- */
 
-void ComputeTempPartial::restore_bias(int i, double *v)
+void ComputeTempPartial::restore_bias(int /*i*/, double *v)
 {
   if (!xflag) v[0] += vbias[0];
   if (!yflag) v[1] += vbias[1];
@@ -287,7 +287,7 @@ void ComputeTempPartial::restore_bias(int i, double *v)
    assume remove_bias_thr() was previously called with the same buffer b
 ------------------------------------------------------------------------- */
 
-void ComputeTempPartial::restore_bias_thr(int i, double *v, double *b)
+void ComputeTempPartial::restore_bias_thr(int /*i*/, double *v, double *b)
 {
   if (!xflag) v[0] += b[0];
   if (!yflag) v[1] += b[1];

--- a/src/compute_temp_ramp.cpp
+++ b/src/compute_temp_ramp.cpp
@@ -279,7 +279,7 @@ void ComputeTempRamp::remove_bias_all()
    assume remove_bias() was previously called
 ------------------------------------------------------------------------- */
 
-void ComputeTempRamp::restore_bias(int i, double *v)
+void ComputeTempRamp::restore_bias(int /*i*/, double *v)
 {
   v[v_dim] += vbias[v_dim];
 }
@@ -289,7 +289,7 @@ void ComputeTempRamp::restore_bias(int i, double *v)
    assume remove_bias_thr() was previously called with the same buffer b
 ------------------------------------------------------------------------- */
 
-void ComputeTempRamp::restore_bias_thr(int i, double *v, double *b)
+void ComputeTempRamp::restore_bias_thr(int /*i*/, double *v, double *b)
 {
   v[v_dim] += b[v_dim];
 }

--- a/src/compute_temp_region.cpp
+++ b/src/compute_temp_region.cpp
@@ -253,7 +253,7 @@ void ComputeTempRegion::remove_bias_all()
    assume remove_bias() was previously called
 ------------------------------------------------------------------------- */
 
-void ComputeTempRegion::restore_bias(int i, double *v)
+void ComputeTempRegion::restore_bias(int /*i*/, double *v)
 {
   v[0] += vbias[0];
   v[1] += vbias[1];
@@ -265,7 +265,7 @@ void ComputeTempRegion::restore_bias(int i, double *v)
    assume remove_bias_thr() was previously called with the same buffer b
 ------------------------------------------------------------------------- */
 
-void ComputeTempRegion::restore_bias_thr(int i, double *v, double *b)
+void ComputeTempRegion::restore_bias_thr(int /*i*/, double *v, double *b)
 {
   v[0] += b[0];
   v[1] += b[1];

--- a/src/dihedral_zero.cpp
+++ b/src/dihedral_zero.cpp
@@ -99,13 +99,13 @@ void DihedralZero::coeff(int narg, char **arg)
    proc 0 writes out coeffs to restart file
 ------------------------------------------------------------------------- */
 
-void DihedralZero::write_restart(FILE *fp) {}
+void DihedralZero::write_restart(FILE * /*fp*/) {}
 
 /* ----------------------------------------------------------------------
    proc 0 reads coeffs from restart file, bcasts them
 ------------------------------------------------------------------------- */
 
-void DihedralZero::read_restart(FILE *fp)
+void DihedralZero::read_restart(FILE * /*fp*/)
 {
   allocate();
   for (int i = 1; i <= atom->ndihedraltypes; i++) setflag[i] = 1;
@@ -119,4 +119,3 @@ void DihedralZero::write_data(FILE *fp) {
   for (int i = 1; i <= atom->ndihedraltypes; i++)
     fprintf(fp,"%d\n",i);
 }
-

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1618,7 +1618,7 @@ void Domain::image_flip(int m, int n, int p)
    called from create_atoms() in library.cpp
 ------------------------------------------------------------------------- */
 
-int Domain::ownatom(int id, double *x, imageint *image, int shrinkexceed)
+int Domain::ownatom(int /*id*/, double *x, imageint *image, int shrinkexceed)
 {
   double lamda[3];
   double *coord,*blo,*bhi,*slo,*shi;

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -45,7 +45,7 @@ enum{ASCEND,DESCEND};
 
 /* ---------------------------------------------------------------------- */
 
-Dump::Dump(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
+Dump::Dump(LAMMPS *lmp, int /*narg*/, char **arg) : Pointers(lmp)
 {
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -1023,12 +1023,12 @@ int DumpCustom::count()
       } else if (thresh_op[ithresh] == XOR) {
         if (lastflag) {
           for (i = 0; i < nlocal; i++, ptr += nstride)
-            if (choose[i] && (*ptr == 0.0 && values[i] == 0.0) ||
+            if ((choose[i] && *ptr == 0.0 && values[i] == 0.0) ||
                 (*ptr != 0.0 && values[i] != 0.0))
               choose[i] = 0;
         } else {
           for (i = 0; i < nlocal; i++, ptr += nstride)
-            if (choose[i] && (*ptr == 0.0 && value == 0.0) ||
+            if ((choose[i] && *ptr == 0.0 && value == 0.0) ||
                 (*ptr != 0.0 && value != 0.0))
               choose[i] = 0;
         }

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -1193,7 +1193,7 @@ void DumpImage::create_image()
 /* ---------------------------------------------------------------------- */
 
 int DumpImage::pack_forward_comm(int n, int *list, double *buf,
-                                 int pbc_flag, int *pbc)
+                                 int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -326,7 +326,7 @@ int DumpLocal::count()
 
 /* ---------------------------------------------------------------------- */
 
-void DumpLocal::pack(tagint *dummy)
+void DumpLocal::pack(tagint * /*dummy*/)
 {
   for (int n = 0; n < size_one; n++) (this->*pack_choice[n])(n);
 }

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -31,7 +31,7 @@ int Fix::instance_total = 0;
 
 /* ---------------------------------------------------------------------- */
 
-Fix::Fix(LAMMPS *lmp, int narg, char **arg) :
+Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   Pointers(lmp),
   id(NULL), style(NULL), extlist(NULL), vector_atom(NULL), array_atom(NULL),
   vector_local(NULL), array_local(NULL), eatom(NULL), vatom(NULL)

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -476,7 +476,7 @@ void FixAdapt::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixAdapt::setup_pre_force(int vflag)
+void FixAdapt::setup_pre_force(int /*vflag*/)
 {
   change_settings();
 }
@@ -491,7 +491,7 @@ void FixAdapt::setup_pre_force_respa(int vflag, int ilevel)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAdapt::pre_force(int vflag)
+void FixAdapt::pre_force(int /*vflag*/)
 {
   if (nevery == 0) return;
   if (update->ntimestep % nevery) return;

--- a/src/fix_addforce.cpp
+++ b/src/fix_addforce.cpp
@@ -361,7 +361,7 @@ void FixAddForce::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAddForce::post_force_respa(int vflag, int ilevel, int iloop)
+void FixAddForce::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_ave_atom.cpp
+++ b/src/fix_ave_atom.cpp
@@ -283,7 +283,7 @@ void FixAveAtom::init()
    only does something if nvalid = current timestep
 ------------------------------------------------------------------------- */
 
-void FixAveAtom::setup(int vflag)
+void FixAveAtom::setup(int /*vflag*/)
 {
   end_of_step();
 }
@@ -432,7 +432,7 @@ void FixAveAtom::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixAveAtom::copy_arrays(int i, int j, int delflag)
+void FixAveAtom::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < nvalues; m++)
     array[j][m] = array[i][m];

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -557,7 +557,7 @@ void FixAveChunk::init()
      that nchunk may not track it
 ------------------------------------------------------------------------- */
 
-void FixAveChunk::setup(int vflag)
+void FixAveChunk::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/fix_ave_correlate.cpp
+++ b/src/fix_ave_correlate.cpp
@@ -404,7 +404,7 @@ void FixAveCorrelate::init()
    only does something if nvalid = current timestep
 ------------------------------------------------------------------------- */
 
-void FixAveCorrelate::setup(int vflag)
+void FixAveCorrelate::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -559,7 +559,7 @@ void FixAveHisto::init()
    only does something if nvalid = current timestep
 ------------------------------------------------------------------------- */
 
-void FixAveHisto::setup(int vflag)
+void FixAveHisto::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -529,7 +529,7 @@ void FixAveTime::init()
    only does something if nvalid = current timestep
 ------------------------------------------------------------------------- */
 
-void FixAveTime::setup(int vflag)
+void FixAveTime::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/fix_aveforce.cpp
+++ b/src/fix_aveforce.cpp
@@ -194,7 +194,7 @@ void FixAveForce::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAveForce::post_force(int vflag)
+void FixAveForce::post_force(int /*vflag*/)
 {
   // update region if necessary
 
@@ -259,7 +259,7 @@ void FixAveForce::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAveForce::post_force_respa(int vflag, int ilevel, int iloop)
+void FixAveForce::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   // ave + extra force on selected RESPA level
   // just ave on all other levels

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -160,7 +160,7 @@ void FixBalance::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixBalance::setup(int vflag)
+void FixBalance::setup(int /*vflag*/)
 {
   // compute final imbalance factor if setup_pre_exchange() invoked balancer
   // this is called at end of run setup, before output

--- a/src/fix_drag.cpp
+++ b/src/fix_drag.cpp
@@ -90,7 +90,7 @@ void FixDrag::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixDrag::post_force(int vflag)
+void FixDrag::post_force(int /*vflag*/)
 {
   // apply drag force to atoms in group of magnitude f_mag
   // apply in direction (r-r0) if atom is further than delta away
@@ -132,7 +132,7 @@ void FixDrag::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixDrag::post_force_respa(int vflag, int ilevel, int iloop)
+void FixDrag::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_dt_reset.cpp
+++ b/src/fix_dt_reset.cpp
@@ -129,7 +129,7 @@ void FixDtReset::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixDtReset::setup(int vflag)
+void FixDtReset::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/fix_enforce2d.cpp
+++ b/src/fix_enforce2d.cpp
@@ -112,7 +112,7 @@ void FixEnforce2D::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixEnforce2D::post_force(int vflag)
+void FixEnforce2D::post_force(int /*vflag*/)
 {
   double **v = atom->v;
   double **f = atom->f;
@@ -164,7 +164,7 @@ void FixEnforce2D::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixEnforce2D::post_force_respa(int vflag, int ilevel, int iloop)
+void FixEnforce2D::post_force_respa(int vflag, int /*ilevel*/, int /*iloop*/)
 {
   post_force(vflag);
 }

--- a/src/fix_external.cpp
+++ b/src/fix_external.cpp
@@ -129,7 +129,7 @@ void FixExternal::min_setup(int vflag)
    store eflag, so can use it in post_force to tally per-atom energies
 ------------------------------------------------------------------------- */
 
-void FixExternal::pre_reverse(int eflag, int vflag)
+void FixExternal::pre_reverse(int eflag, int /*vflag*/)
 {
   eflag_caller = eflag;
 }
@@ -305,7 +305,7 @@ void FixExternal::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixExternal::copy_arrays(int i, int j, int delflag)
+void FixExternal::copy_arrays(int i, int j, int /*delflag*/)
 {
   fexternal[j][0] = fexternal[i][0];
   fexternal[j][1] = fexternal[i][1];

--- a/src/fix_gravity.cpp
+++ b/src/fix_gravity.cpp
@@ -247,7 +247,7 @@ void FixGravity::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGravity::post_force(int vflag)
+void FixGravity::post_force(int /*vflag*/)
 {
   // update gravity due to variables
 
@@ -300,7 +300,7 @@ void FixGravity::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGravity::post_force_respa(int vflag, int ilevel, int iloop)
+void FixGravity::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_group.cpp
+++ b/src/fix_group.cpp
@@ -176,7 +176,7 @@ void FixGroup::init()
    assign atoms to group
 ------------------------------------------------------------------------- */
 
-void FixGroup::setup(int vflag)
+void FixGroup::setup(int /*vflag*/)
 {
   set_group();
 }
@@ -192,7 +192,7 @@ void FixGroup::post_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixGroup::post_integrate_respa(int ilevel, int iloop)
+void FixGroup::post_integrate_respa(int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_integrate();
 }
@@ -259,7 +259,7 @@ void FixGroup::set_group()
 
 /* ---------------------------------------------------------------------- */
 
-void *FixGroup::extract(const char *str, int &unused)
+void *FixGroup::extract(const char *str, int &/*unused*/)
 {
   if (strcmp(str,"property") == 0 && propflag) return (void *) idprop;
   if (strcmp(str,"variable") == 0 && varflag) return (void *) idvar;

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -184,7 +184,7 @@ void FixHalt::end_of_step()
   // print message with ID of fix halt in case multiple instances
 
   char str[128];
-  sprintf(str,"Fix halt %s condition met on step %ld with value %g",
+  sprintf(str,"Fix halt %s condition met on step " BIGINT_FORMAT " with value %g",
           id,update->ntimestep,attvalue);
 
   if (eflag == HARD) {

--- a/src/fix_indent.cpp
+++ b/src/fix_indent.cpp
@@ -182,7 +182,7 @@ void FixIndent::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixIndent::post_force(int vflag)
+void FixIndent::post_force(int /*vflag*/)
 {
   // indenter values, 0 = energy, 1-3 = force components
   // wrap variable evaluations with clear/add
@@ -357,7 +357,7 @@ void FixIndent::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixIndent::post_force_respa(int vflag, int ilevel, int iloop)
+void FixIndent::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -298,7 +298,7 @@ void FixLangevin::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixLangevin::post_force(int vflag)
+void FixLangevin::post_force(int /*vflag*/)
 {
   double *rmass = atom->rmass;
 
@@ -441,7 +441,7 @@ void FixLangevin::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixLangevin::post_force_respa(int vflag, int ilevel, int iloop)
+void FixLangevin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }
@@ -896,7 +896,7 @@ void FixLangevin::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixLangevin::copy_arrays(int i, int j, int delflag)
+void FixLangevin::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < nvalues; m++)
     franprev[j][m] = franprev[i][m];

--- a/src/fix_lineforce.cpp
+++ b/src/fix_lineforce.cpp
@@ -80,7 +80,7 @@ void FixLineForce::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixLineForce::post_force(int vflag)
+void FixLineForce::post_force(int /*vflag*/)
 {
   double **f = atom->f;
   int *mask = atom->mask;
@@ -98,7 +98,7 @@ void FixLineForce::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixLineForce::post_force_respa(int vflag, int ilevel, int iloop)
+void FixLineForce::post_force_respa(int vflag, int /*ilevel*/, int /*iloop*/)
 {
   post_force(vflag);
 }

--- a/src/fix_minimize.cpp
+++ b/src/fix_minimize.cpp
@@ -184,7 +184,7 @@ void FixMinimize::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixMinimize::copy_arrays(int i, int j, int delflag)
+void FixMinimize::copy_arrays(int i, int j, int /*delflag*/)
 {
   int m,iper,nper,ni,nj;
 

--- a/src/fix_move.cpp
+++ b/src/fix_move.cpp
@@ -453,7 +453,7 @@ void FixMove::init()
    set x,v of particles
 ------------------------------------------------------------------------- */
 
-void FixMove::initial_integrate(int vflag)
+void FixMove::initial_integrate(int /*vflag*/)
 {
   int flag;
   double ddotr,dx,dy,dz;
@@ -945,7 +945,7 @@ void FixMove::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixMove::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixMove::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   // outermost level - update v and x
   // all other levels - nothing
@@ -955,7 +955,7 @@ void FixMove::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixMove::final_integrate_respa(int ilevel, int iloop)
+void FixMove::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) final_integrate();
 }
@@ -1019,7 +1019,7 @@ void FixMove::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixMove::copy_arrays(int i, int j, int delflag)
+void FixMove::copy_arrays(int i, int j, int /*delflag*/)
 {
   xoriginal[j][0] = xoriginal[i][0];
   xoriginal[j][1] = xoriginal[i][1];
@@ -1238,7 +1238,7 @@ int FixMove::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixMove::size_restart(int nlocal)
+int FixMove::size_restart(int /*nlocal*/)
 {
   return nrestart;
 }

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -35,7 +35,7 @@ enum{DEFAULT,NPARTNER,PERPARTNER}; // also set in fix neigh/history/omp
 
 FixNeighHistory::FixNeighHistory(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg),
-  npartner(NULL), partner(NULL), valuepartner(NULL), pair(NULL),
+  pair(NULL), npartner(NULL), partner(NULL), valuepartner(NULL),
   ipage_atom(NULL), dpage_atom(NULL), ipage_neigh(NULL), dpage_neigh(NULL)
 {
   if (narg != 4) error->all(FLERR,"Illegal fix NEIGH_HISTORY command");

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -686,7 +686,7 @@ void FixNeighHistory::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixNeighHistory::copy_arrays(int i, int j, int delflag)
+void FixNeighHistory::copy_arrays(int i, int j, int /*delflag*/)
 {
   // just copy pointers for partner and valuepartner
   // b/c can't overwrite chunk allocation inside ipage_atom,dpage_atom

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -742,7 +742,7 @@ void FixNH::init()
    compute T,P before integrator starts
 ------------------------------------------------------------------------- */
 
-void FixNH::setup(int vflag)
+void FixNH::setup(int /*vflag*/)
 {
   // tdof needed by compute_temp_target()
 
@@ -827,7 +827,7 @@ void FixNH::setup(int vflag)
    1st half of Verlet update
 ------------------------------------------------------------------------- */
 
-void FixNH::initial_integrate(int vflag)
+void FixNH::initial_integrate(int /*vflag*/)
 {
   // update eta_press_dot
 
@@ -922,7 +922,7 @@ void FixNH::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNH::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixNH::initial_integrate_respa(int /*vflag*/, int ilevel, int /*iloop*/)
 {
   // set timesteps by level
 
@@ -991,7 +991,7 @@ void FixNH::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixNH::final_integrate_respa(int ilevel, int iloop)
+void FixNH::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   // set timesteps by level
 

--- a/src/fix_nve.cpp
+++ b/src/fix_nve.cpp
@@ -62,7 +62,7 @@ void FixNVE::init()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixNVE::initial_integrate(int vflag)
+void FixNVE::initial_integrate(int /*vflag*/)
 {
   double dtfm;
 
@@ -143,7 +143,7 @@ void FixNVE::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVE::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixNVE::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
@@ -157,7 +157,7 @@ void FixNVE::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVE::final_integrate_respa(int ilevel, int iloop)
+void FixNVE::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
   final_integrate();

--- a/src/fix_nve_limit.cpp
+++ b/src/fix_nve_limit.cpp
@@ -83,7 +83,7 @@ void FixNVELimit::init()
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixNVELimit::initial_integrate(int vflag)
+void FixNVELimit::initial_integrate(int /*vflag*/)
 {
   double dtfm,vsq,scale;
 
@@ -202,7 +202,7 @@ void FixNVELimit::final_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVELimit::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixNVELimit::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   dtv = step_respa[ilevel];
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
@@ -213,7 +213,7 @@ void FixNVELimit::initial_integrate_respa(int vflag, int ilevel, int iloop)
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVELimit::final_integrate_respa(int ilevel, int iloop)
+void FixNVELimit::final_integrate_respa(int ilevel, int /*iloop*/)
 {
   dtf = 0.5 * step_respa[ilevel] * force->ftm2v;
   final_integrate();

--- a/src/fix_nve_noforce.cpp
+++ b/src/fix_nve_noforce.cpp
@@ -54,7 +54,7 @@ void FixNVENoforce::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVENoforce::initial_integrate(int vflag)
+void FixNVENoforce::initial_integrate(int /*vflag*/)
 {
   double **x = atom->x;
   double **v = atom->v;

--- a/src/fix_nve_sphere.cpp
+++ b/src/fix_nve_sphere.cpp
@@ -97,7 +97,7 @@ void FixNVESphere::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVESphere::initial_integrate(int vflag)
+void FixNVESphere::initial_integrate(int /*vflag*/)
 {
   double dtfm,dtirotate,msq,scale,s2,inv_len_mu;
   double g[3];

--- a/src/fix_planeforce.cpp
+++ b/src/fix_planeforce.cpp
@@ -80,7 +80,7 @@ void FixPlaneForce::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixPlaneForce::post_force(int vflag)
+void FixPlaneForce::post_force(int /*vflag*/)
 {
   double **f = atom->f;
   int *mask = atom->mask;
@@ -98,7 +98,7 @@ void FixPlaneForce::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixPlaneForce::post_force_respa(int vflag, int ilevel, int iloop)
+void FixPlaneForce::post_force_respa(int vflag, int /*ilevel*/, int /*iloop*/)
 {
   post_force(vflag);
 }

--- a/src/fix_press_berendsen.cpp
+++ b/src/fix_press_berendsen.cpp
@@ -334,7 +334,7 @@ void FixPressBerendsen::init()
    compute T,P before integrator starts
 ------------------------------------------------------------------------- */
 
-void FixPressBerendsen::setup(int vflag)
+void FixPressBerendsen::setup(int /*vflag*/)
 {
   // trigger virial computation on next timestep
 

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -292,7 +292,7 @@ void FixPropertyAtom::read_data_section(char *keyword, int n, char *buf,
    return # of lines in section of data file labeled by keyword
 ------------------------------------------------------------------------- */
 
-bigint FixPropertyAtom::read_data_skip_lines(char *keyword)
+bigint FixPropertyAtom::read_data_skip_lines(char */*keyword*/)
 {
   return atom->natoms;
 }
@@ -304,7 +304,7 @@ bigint FixPropertyAtom::read_data_skip_lines(char *keyword)
    ny = columns = tag + nvalues
 ------------------------------------------------------------------------- */
 
-void FixPropertyAtom::write_data_section_size(int mth, int &nx, int &ny)
+void FixPropertyAtom::write_data_section_size(int /*mth*/, int &nx, int &ny)
 {
   nx = atom->nlocal;
   ny = nvalue + 1;
@@ -315,7 +315,7 @@ void FixPropertyAtom::write_data_section_size(int mth, int &nx, int &ny)
    buf allocated by caller as Nlocal by Nvalues+1
 ------------------------------------------------------------------------- */
 
-void FixPropertyAtom::write_data_section_pack(int mth, double **buf)
+void FixPropertyAtom::write_data_section_pack(int /*mth*/, double **buf)
 {
   int i;
 
@@ -354,7 +354,7 @@ void FixPropertyAtom::write_data_section_pack(int mth, double **buf)
    only called by proc 0
 ------------------------------------------------------------------------- */
 
-void FixPropertyAtom::write_data_section_keyword(int mth, FILE *fp)
+void FixPropertyAtom::write_data_section_keyword(int /*mth*/, FILE *fp)
 {
   if (nvalue == 1 && style[0] == MOLECULE) fprintf(fp,"\nMolecules\n\n");
   else if (nvalue == 1 && style[0] == CHARGE) fprintf(fp,"\nCharges\n\n");
@@ -368,8 +368,8 @@ void FixPropertyAtom::write_data_section_keyword(int mth, FILE *fp)
    only called by proc 0
 ------------------------------------------------------------------------- */
 
-void FixPropertyAtom::write_data_section(int mth, FILE *fp,
-                                         int n, double **buf, int index)
+void FixPropertyAtom::write_data_section(int /*mth*/, FILE *fp,
+                                         int n, double **buf, int /*index*/)
 {
   int m;
 
@@ -443,7 +443,7 @@ void FixPropertyAtom::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixPropertyAtom::copy_arrays(int i, int j, int delflag)
+void FixPropertyAtom::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < nvalue; m++) {
     if (style[m] == MOLECULE)
@@ -644,7 +644,7 @@ int FixPropertyAtom::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixPropertyAtom::size_restart(int nlocal)
+int FixPropertyAtom::size_restart(int /*nlocal*/)
 {
   return nvalue+1;
 }

--- a/src/fix_read_restart.cpp
+++ b/src/fix_read_restart.cpp
@@ -96,7 +96,7 @@ void FixReadRestart::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixReadRestart::copy_arrays(int i, int j, int delflag)
+void FixReadRestart::copy_arrays(int i, int j, int /*delflag*/)
 {
   count[j] = count[i];
   for (int m = 0; m < count[i]; m++) extra[j][m] = extra[i][m];

--- a/src/fix_recenter.cpp
+++ b/src/fix_recenter.cpp
@@ -149,7 +149,7 @@ void FixRecenter::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixRecenter::initial_integrate(int vflag)
+void FixRecenter::initial_integrate(int /*vflag*/)
 {
   // target COM
   // bounding box around domain works for both orthogonal and triclinic
@@ -211,7 +211,7 @@ void FixRecenter::initial_integrate(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRecenter::initial_integrate_respa(int vflag, int ilevel, int iloop)
+void FixRecenter::initial_integrate_respa(int vflag, int ilevel, int /*iloop*/)
 {
   // outermost level - operate recenter
   // all other levels - nothing

--- a/src/fix_respa.cpp
+++ b/src/fix_respa.cpp
@@ -93,7 +93,7 @@ void FixRespa::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixRespa::copy_arrays(int i, int j, int delflag)
+void FixRespa::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int k = 0; k < nlevels; k++) {
     f_level[j][k][0] = f_level[i][k][0];

--- a/src/fix_restrain.cpp
+++ b/src/fix_restrain.cpp
@@ -188,7 +188,7 @@ void FixRestrain::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRestrain::post_force(int vflag)
+void FixRestrain::post_force(int /*vflag*/)
 {
   energy = 0.0;
   
@@ -204,7 +204,7 @@ void FixRestrain::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixRestrain::post_force_respa(int vflag, int ilevel, int iloop)
+void FixRestrain::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_setforce.cpp
+++ b/src/fix_setforce.cpp
@@ -219,7 +219,7 @@ void FixSetForce::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSetForce::post_force(int vflag)
+void FixSetForce::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double **f = atom->f;
@@ -293,7 +293,7 @@ void FixSetForce::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSetForce::post_force_respa(int vflag, int ilevel, int iloop)
+void FixSetForce::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   // set force to desired value on requested level, 0.0 on other levels
 

--- a/src/fix_spring.cpp
+++ b/src/fix_spring.cpp
@@ -159,7 +159,7 @@ void FixSpring::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpring::post_force(int vflag)
+void FixSpring::post_force(int /*vflag*/)
 {
   if (styleflag == TETHER) spring_tether();
   else spring_couple();
@@ -335,7 +335,7 @@ void FixSpring::spring_couple()
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpring::post_force_respa(int vflag, int ilevel, int iloop)
+void FixSpring::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_spring_chunk.cpp
+++ b/src/fix_spring_chunk.cpp
@@ -144,7 +144,7 @@ void FixSpringChunk::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpringChunk::post_force(int vflag)
+void FixSpringChunk::post_force(int /*vflag*/)
 {
   int i,m;
   double dx,dy,dz,r;
@@ -231,7 +231,7 @@ void FixSpringChunk::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpringChunk::post_force_respa(int vflag, int ilevel, int iloop)
+void FixSpringChunk::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_spring_rg.cpp
+++ b/src/fix_spring_rg.cpp
@@ -95,7 +95,7 @@ void FixSpringRG::setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpringRG::post_force(int vflag)
+void FixSpringRG::post_force(int /*vflag*/)
 {
   // compute current Rg and center-of-mass
 
@@ -142,7 +142,7 @@ void FixSpringRG::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpringRG::post_force_respa(int vflag, int ilevel, int iloop)
+void FixSpringRG::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_spring_self.cpp
+++ b/src/fix_spring_self.cpp
@@ -148,7 +148,7 @@ void FixSpringSelf::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpringSelf::post_force(int vflag)
+void FixSpringSelf::post_force(int /*vflag*/)
 {
   double **x = atom->x;
   double **f = atom->f;
@@ -181,7 +181,7 @@ void FixSpringSelf::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixSpringSelf::post_force_respa(int vflag, int ilevel, int iloop)
+void FixSpringSelf::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }
@@ -227,7 +227,7 @@ void FixSpringSelf::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixSpringSelf::copy_arrays(int i, int j, int delflag)
+void FixSpringSelf::copy_arrays(int i, int j, int /*delflag*/)
 {
   xoriginal[j][0] = xoriginal[i][0];
   xoriginal[j][1] = xoriginal[i][1];
@@ -303,7 +303,7 @@ int FixSpringSelf::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixSpringSelf::size_restart(int nlocal)
+int FixSpringSelf::size_restart(int /*nlocal*/)
 {
   return 4;
 }

--- a/src/fix_store.cpp
+++ b/src/fix_store.cpp
@@ -229,7 +229,7 @@ void FixStore::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixStore::copy_arrays(int i, int j, int delflag)
+void FixStore::copy_arrays(int i, int j, int /*delflag*/)
 {
   if (disable) return;
 
@@ -324,7 +324,7 @@ int FixStore::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixStore::size_restart(int nlocal)
+int FixStore::size_restart(int /*nlocal*/)
 {
   if (disable) return 1;
   return nvalues+1;

--- a/src/fix_store_force.cpp
+++ b/src/fix_store_force.cpp
@@ -95,7 +95,7 @@ void FixStoreForce::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixStoreForce::post_force(int vflag)
+void FixStoreForce::post_force(int /*vflag*/)
 {
   if (atom->nmax > nmax) {
     nmax = atom->nmax;
@@ -118,7 +118,7 @@ void FixStoreForce::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixStoreForce::post_force_respa(int vflag, int ilevel, int iloop)
+void FixStoreForce::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }

--- a/src/fix_store_state.cpp
+++ b/src/fix_store_state.cpp
@@ -446,7 +446,7 @@ void FixStoreState::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixStoreState::setup(int vflag)
+void FixStoreState::setup(int /*vflag*/)
 {
   // if first invocation, store current values for compute, fix, variable
 
@@ -580,7 +580,7 @@ void FixStoreState::grow_arrays(int nmax)
    copy values within local atom-based array
 ------------------------------------------------------------------------- */
 
-void FixStoreState::copy_arrays(int i, int j, int delflag)
+void FixStoreState::copy_arrays(int i, int j, int /*delflag*/)
 {
   for (int m = 0; m < nvalues; m++) values[j][m] = values[i][m];
 }
@@ -646,7 +646,7 @@ int FixStoreState::maxsize_restart()
    size of atom nlocal's restart data
 ------------------------------------------------------------------------- */
 
-int FixStoreState::size_restart(int nlocal)
+int FixStoreState::size_restart(int /*nlocal*/)
 {
   return nvalues+1;
 }

--- a/src/fix_tmd.cpp
+++ b/src/fix_tmd.cpp
@@ -170,7 +170,7 @@ void FixTMD::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixTMD::initial_integrate(int vflag)
+void FixTMD::initial_integrate(int /*vflag*/)
 {
   double a,b,c,d,e;
   double dx,dy,dz,dxkt,dykt,dzkt;
@@ -335,7 +335,7 @@ void FixTMD::grow_arrays(int nmax)
    copy values within local atom-based arrays
 ------------------------------------------------------------------------- */
 
-void FixTMD::copy_arrays(int i, int j, int delflag)
+void FixTMD::copy_arrays(int i, int j, int /*delflag*/)
 {
   xf[j][0] = xf[i][0];
   xf[j][1] = xf[i][1];

--- a/src/fix_vector.cpp
+++ b/src/fix_vector.cpp
@@ -239,7 +239,7 @@ void FixVector::init()
    only does something if nvalid = current timestep
 ------------------------------------------------------------------------- */
 
-void FixVector::setup(int vflag)
+void FixVector::setup(int /*vflag*/)
 {
   end_of_step();
 }

--- a/src/fix_viscous.cpp
+++ b/src/fix_viscous.cpp
@@ -109,7 +109,7 @@ void FixViscous::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixViscous::post_force(int vflag)
+void FixViscous::post_force(int /*vflag*/)
 {
   // apply drag force to atoms in group
   // direction is opposed to velocity vector
@@ -134,7 +134,7 @@ void FixViscous::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixViscous::post_force_respa(int vflag, int ilevel, int iloop)
+void FixViscous::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_wall.cpp
+++ b/src/fix_wall.cpp
@@ -343,7 +343,7 @@ void FixWall::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWall::post_force_respa(int vflag, int ilevel, int iloop)
+void FixWall::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/fix_wall_region.cpp
+++ b/src/fix_wall_region.cpp
@@ -287,7 +287,7 @@ void FixWallRegion::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallRegion::post_force_respa(int vflag, int ilevel, int iloop)
+void FixWallRegion::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -629,7 +629,7 @@ int Group::find_unused()
    do not include molID = 0
 ------------------------------------------------------------------------- */
 
-void Group::add_molecules(int igroup, int bit)
+void Group::add_molecules(int /*igroup*/, int bit)
 {
   // hash = unique molecule IDs of atoms already in group
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -990,8 +990,9 @@ void Image::compute_SSAO()
 
 /* ---------------------------------------------------------------------- */
 
-void Image::write_JPG(FILE */*fp*/)
+void Image::write_JPG(FILE *fp)
 {
+  (void)(fp); // suppress unused parameter warning
 #ifdef LAMMPS_JPEG
   struct jpeg_compress_struct cinfo;
   struct jpeg_error_mgr jerr;
@@ -1022,8 +1023,9 @@ void Image::write_JPG(FILE */*fp*/)
 
 /* ---------------------------------------------------------------------- */
 
-void Image::write_PNG(FILE */*fp*/)
+void Image::write_PNG(FILE *fp)
 {
+  (void)(fp); // suppress unused parameter warning
 #ifdef LAMMPS_PNG
   png_structp png_ptr;
   png_infop info_ptr;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -990,7 +990,7 @@ void Image::compute_SSAO()
 
 /* ---------------------------------------------------------------------- */
 
-void Image::write_JPG(FILE *fp)
+void Image::write_JPG(FILE */*fp*/)
 {
 #ifdef LAMMPS_JPEG
   struct jpeg_compress_struct cinfo;
@@ -1022,7 +1022,7 @@ void Image::write_JPG(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-void Image::write_PNG(FILE *fp)
+void Image::write_PNG(FILE */*fp*/)
 {
 #ifdef LAMMPS_PNG
   png_structp png_ptr;

--- a/src/imbalance_var.cpp
+++ b/src/imbalance_var.cpp
@@ -52,7 +52,7 @@ int ImbalanceVar::options(int narg, char **arg)
 
 /* -------------------------------------------------------------------- */
 
-void ImbalanceVar::init(int flag)
+void ImbalanceVar::init(int /*flag*/)
 {
   id = input->variable->find(name);
   if (id < 0) {

--- a/src/improper_zero.cpp
+++ b/src/improper_zero.cpp
@@ -99,13 +99,13 @@ void ImproperZero::coeff(int narg, char **arg)
    proc 0 writes out coeffs to restart file
 ------------------------------------------------------------------------- */
 
-void ImproperZero::write_restart(FILE *fp) {}
+void ImproperZero::write_restart(FILE */*fp*/) {}
 
 /* ----------------------------------------------------------------------
    proc 0 reads coeffs from restart file, bcasts them
 ------------------------------------------------------------------------- */
 
-void ImproperZero::read_restart(FILE *fp)
+void ImproperZero::read_restart(FILE */*fp*/)
 {
   allocate();
   for (int i = 1; i <= atom->nimpropertypes; i++) setflag[i] = 1;

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -24,7 +24,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-Integrate::Integrate(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
+Integrate::Integrate(LAMMPS *lmp, int /*narg*/, char **/*arg*/) : Pointers(lmp)
 {
   elist_global = elist_atom = NULL;
   vlist_global = vlist_atom = NULL;

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -30,7 +30,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-KSpace::KSpace(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
+KSpace::KSpace(LAMMPS *lmp, int /*narg*/, char **/*arg*/) : Pointers(lmp)
 {
   order_allocated = 0;
   energy = 0.0;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1515,7 +1515,7 @@ void lammps_create_atoms(void *ptr, int n, tagint *id, int *type,
     if (lmp->atom->natoms != natoms_prev + n) {
       char str[128];
       sprintf(str,"Library warning in lammps_create_atoms, "
-              "invalid total atoms %ld %ld",lmp->atom->natoms,natoms_prev+n);
+              "invalid total atoms " BIGINT_FORMAT " %lld",lmp->atom->natoms,natoms_prev+n);
       if (lmp->comm->me == 0)
         lmp->error->warning(FLERR,str);
     }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -336,7 +336,7 @@ void lammps_free(void *ptr)
    customize by adding names
 ------------------------------------------------------------------------- */
 
-int lammps_extract_setting(void *ptr, char *name)
+int lammps_extract_setting(void */*ptr*/, char *name)
 {
   if (strcmp(name,"bigint") == 0) return sizeof(bigint);
   if (strcmp(name,"tagint") == 0) return sizeof(tagint);

--- a/src/math_extra.cpp
+++ b/src/math_extra.cpp
@@ -590,7 +590,7 @@ void inertia_triangle(double *v0, double *v1, double *v2,
    return symmetric inertia tensor as 6-vector in Voigt notation
 ------------------------------------------------------------------------- */
 
-void inertia_triangle(double *idiag, double *quat, double mass,
+void inertia_triangle(double *idiag, double *quat, double /*mass*/,
                       double *inertia)
 {
   double p[3][3],ptrans[3][3],itemp[3][3],tensor[3][3];

--- a/src/memory.h
+++ b/src/memory.h
@@ -50,7 +50,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE **create(TYPE **&array, int n, const char *name)
+  TYPE **create(TYPE **& /*array*/, int /*n*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -68,7 +68,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE **grow(TYPE **&array, int n, const char *name)
+  TYPE **grow(TYPE **& /*array*/, int /*n*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -96,7 +96,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE **create1d_offset(TYPE **&array, int nlo, int nhi, const char *name)
+  TYPE **create1d_offset(TYPE **& /*array*/, int /*nlo*/, int /*nhi*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -131,7 +131,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ***create(TYPE ***&array, int n1, int n2, const char *name)
+  TYPE ***create(TYPE ***& /*array*/, int /*n1*/, int /*n2*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -158,7 +158,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ***grow(TYPE ***&array, int n1, int n2, const char *name)
+  TYPE ***grow(TYPE ***& /*array*/, int /*n1*/, int /*n2*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -198,7 +198,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ***create_ragged(TYPE ***&array, int n1, int *n2, const char *name)
+  TYPE ***create_ragged(TYPE ***& /*array*/, int /*n1*/, int * /*n2*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -217,7 +217,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ***create2d_offset(TYPE ***&array, int n1, int n2lo, int n2hi,
+  TYPE ***create2d_offset(TYPE ***& /*array*/, int /*n1*/, int /*n2lo*/, int /*n2hi*/,
                           const char *name) {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -262,7 +262,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ****create(TYPE ****&array, int n1, int n2, int n3, const char *name)
+  TYPE ****create(TYPE ****& /*array*/, int /*n1*/, int /*n2*/, int /*n3*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -297,7 +297,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ****grow(TYPE ****&array, int n1, int n2, int n3, const char *name)
+  TYPE ****grow(TYPE ****& /*array*/, int /*n1*/, int /*n2*/, int /*n3*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -330,8 +330,8 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ****create3d_offset(TYPE ****&array, int n1lo, int n1hi,
-                           int n2, int n3, const char *name)
+  TYPE ****create3d_offset(TYPE ****& /*array*/, int /*n1lo*/, int /*n1hi*/,
+                           int /*n2*/, int /*n3*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------
@@ -374,8 +374,8 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ****create3d_offset(TYPE ****&array, int n1lo, int n1hi,
-                           int n2lo, int n2hi, int n3lo, int n3hi,
+  TYPE ****create3d_offset(TYPE ****& /*array*/, int /*n1lo*/, int /*n1hi*/,
+                           int /*n2lo*/, int /*n2hi*/, int /*n3lo*/, int /*n3hi*/,
                            const char *name)
   {fail(name); return NULL;}
 
@@ -432,7 +432,7 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE *****create(TYPE *****&array, int n1, int n2, int n3, int n4,
+  TYPE *****create(TYPE *****& /*array*/, int /*n1*/, int /*n2*/, int /*n3*/, int /*n4*/,
                    const char *name)
   {fail(name); return NULL;}
 
@@ -478,8 +478,8 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ****create4d_offset(TYPE *****&array, int n1, int n2lo, int n2hi,
-                           int n3lo, int n3hi, int n4lo, int n4hi,
+  TYPE ****create4d_offset(TYPE *****& /*array*/, int /*n1*/, int /*n2lo*/, int /*n2hi*/,
+                           int /*n3lo*/, int /*n3hi*/, int /*n4lo*/, int /*n4hi*/,
                            const char *name)
   {fail(name); return NULL;}
 
@@ -546,8 +546,8 @@ class Memory : protected Pointers {
   }
 
   template <typename TYPE>
-  TYPE ******create(TYPE ******&array, int n1, int n2, int n3, int n4,
-                    int n5, const char *name)
+  TYPE ******create(TYPE ******& /*array*/, int /*n1*/, int /*n2*/, int /*n3*/, int /*n4*/,
+                    int /*n5*/, const char *name)
   {fail(name); return NULL;}
 
 /* ----------------------------------------------------------------------

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -2193,7 +2193,7 @@ void Neighbor::set(int narg, char **arg)
    ditto for lastcall and last_setup_bins
 ------------------------------------------------------------------------- */
 
-void Neighbor::reset_timestep(bigint ntimestep)
+void Neighbor::reset_timestep(bigint /*ntimestep*/)
 {
   for (int i = 0; i < nbin; i++)
     neigh_bin[i]->last_bin = -1;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -301,7 +301,7 @@ void Pair::init_style()
    specific pair style can override this function
 ------------------------------------------------------------------------- */
 
-void Pair::init_list(int which, NeighList *ptr)
+void Pair::init_list(int /*which*/, NeighList *ptr)
 {
   list = ptr;
 }

--- a/src/pair_beck.cpp
+++ b/src/pair_beck.cpp
@@ -327,9 +327,9 @@ void PairBeck::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairBeck::single(int i, int j, int itype, int jtype,
+double PairBeck::single(int /*i*/, int /*j*/, int itype, int jtype,
                                   double rsq,
-                                  double factor_coul, double factor_lj,
+                                  double /*factor_coul*/, double factor_lj,
                                   double &fforce)
 {
   double phi_beck,r,rinv;

--- a/src/pair_born.cpp
+++ b/src/pair_born.cpp
@@ -407,8 +407,8 @@ void PairBorn::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairBorn::single(int i, int j, int itype, int jtype,
-                        double rsq, double factor_coul, double factor_lj,
+double PairBorn::single(int /*i*/, int /*j*/, int itype, int jtype,
+                        double rsq, double /*factor_coul*/, double factor_lj,
                         double &fforce)
 {
   double r2inv,r6inv,r,rexp,forceborn,phiborn;

--- a/src/pair_buck.cpp
+++ b/src/pair_buck.cpp
@@ -380,8 +380,8 @@ void PairBuck::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairBuck::single(int i, int j, int itype, int jtype,
-                        double rsq, double factor_coul, double factor_lj,
+double PairBuck::single(int /*i*/, int /*j*/, int itype, int jtype,
+                        double rsq, double /*factor_coul*/, double factor_lj,
                         double &fforce)
 {
   double r2inv,r6inv,r,rexp,forcebuck,phibuck;

--- a/src/pair_coul_cut.cpp
+++ b/src/pair_coul_cut.cpp
@@ -284,8 +284,8 @@ void PairCoulCut::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairCoulCut::single(int i, int j, int itype, int jtype,
-                           double rsq, double factor_coul, double factor_lj,
+double PairCoulCut::single(int i, int j, int /*itype*/, int /*jtype*/,
+                           double rsq, double factor_coul, double /*factor_lj*/,
                            double &fforce)
 {
   double r2inv,rinv,forcecoul,phicoul;

--- a/src/pair_coul_debye.cpp
+++ b/src/pair_coul_debye.cpp
@@ -163,8 +163,8 @@ void PairCoulDebye::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairCoulDebye::single(int i, int j, int itype, int jtype,
-                           double rsq, double factor_coul, double factor_lj,
+double PairCoulDebye::single(int i, int j, int /*itype*/, int /*jtype*/,
+                           double rsq, double factor_coul, double /*factor_lj*/,
                            double &fforce)
 {
   double r2inv,r,rinv,forcecoul,phicoul,screening;

--- a/src/pair_coul_dsf.cpp
+++ b/src/pair_coul_dsf.cpp
@@ -221,7 +221,7 @@ void PairCoulDSF::init_style()
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairCoulDSF::init_one(int i, int j)
+double PairCoulDSF::init_one(int /*i*/, int /*j*/)
 {
   return cut_coul;
 }
@@ -291,8 +291,8 @@ void PairCoulDSF::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairCoulDSF::single(int i, int j, int itype, int jtype, double rsq,
-                           double factor_coul, double factor_lj,
+double PairCoulDSF::single(int i, int j, int /*itype*/, int /*jtype*/, double rsq,
+                           double factor_coul, double /*factor_lj*/,
                            double &fforce)
 {
   double r2inv,r,erfcc,erfcd,prefactor,t;

--- a/src/pair_coul_wolf.cpp
+++ b/src/pair_coul_wolf.cpp
@@ -219,7 +219,7 @@ void PairCoulWolf::init_style()
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairCoulWolf::init_one(int i, int j)
+double PairCoulWolf::init_one(int /*i*/, int /*j*/)
 {
   return cut_coul;
 }
@@ -290,8 +290,8 @@ void PairCoulWolf::read_restart_settings(FILE *fp)
    only the pair part is calculated here
 ------------------------------------------------------------------------- */
 
-double PairCoulWolf::single(int i, int j, int itype, int jtype, double rsq,
-                            double factor_coul, double factor_lj,
+double PairCoulWolf::single(int i, int j, int /*itype*/, int /*jtype*/, double rsq,
+                            double factor_coul, double /*factor_lj*/,
                             double &fforce)
 {
   double r,prefactor;

--- a/src/pair_dpd.cpp
+++ b/src/pair_dpd.cpp
@@ -390,8 +390,8 @@ void PairDPD::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairDPD::single(int i, int j, int itype, int jtype, double rsq,
-                       double factor_coul, double factor_dpd, double &fforce)
+double PairDPD::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                       double /*factor_coul*/, double factor_dpd, double &fforce)
 {
   double r,rinv,wd,phi;
 

--- a/src/pair_gauss.cpp
+++ b/src/pair_gauss.cpp
@@ -347,8 +347,8 @@ void PairGauss::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairGauss::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairGauss::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double /*factor_lj*/,
                          double &fforce)
 {
   double philj =

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -844,7 +844,7 @@ void PairHybrid::modify_params(int narg, char **arg)
    store a local per pair style override for special_lj and special_coul
 ------------------------------------------------------------------------- */
 
-void PairHybrid::modify_special(int m, int narg, char **arg)
+void PairHybrid::modify_special(int m, int /*narg*/, char **arg)
 {
   double special[4];
   int i;

--- a/src/pair_lj96_cut.cpp
+++ b/src/pair_lj96_cut.cpp
@@ -678,8 +678,8 @@ void PairLJ96Cut::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJ96Cut::single(int i, int j, int itype, int jtype, double rsq,
-                           double factor_coul, double factor_lj,
+double PairLJ96Cut::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                           double /*factor_coul*/, double factor_lj,
                            double &fforce)
 {
   double r2inv,r3inv,r6inv,forcelj,philj;

--- a/src/pair_lj_cubic.cpp
+++ b/src/pair_lj_cubic.cpp
@@ -175,7 +175,7 @@ void PairLJCubic::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairLJCubic::settings(int narg, char **arg)
+void PairLJCubic::settings(int narg, char **/*arg*/)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 
@@ -321,9 +321,9 @@ void PairLJCubic::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJCubic::single(int i, int j, int itype, int jtype,
+double PairLJCubic::single(int /*i*/, int /*j*/, int itype, int jtype,
                              double rsq,
-                             double factor_coul, double factor_lj,
+                             double /*factor_coul*/, double factor_lj,
                              double &fforce)
 {
   double r2inv,r6inv,forcelj,philj;

--- a/src/pair_lj_cut.cpp
+++ b/src/pair_lj_cut.cpp
@@ -672,8 +672,8 @@ void PairLJCut::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJCut::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairLJCut::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double r2inv,r6inv,forcelj,philj;

--- a/src/pair_lj_expand.cpp
+++ b/src/pair_lj_expand.cpp
@@ -396,8 +396,8 @@ void PairLJExpand::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJExpand::single(int i, int j, int itype, int jtype, double rsq,
-                            double factor_coul, double factor_lj,
+double PairLJExpand::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                            double /*factor_coul*/, double factor_lj,
                             double &fforce)
 {
   double r,rshift,rshiftsq,r2inv,r6inv,forcelj,philj;

--- a/src/pair_lj_gromacs.cpp
+++ b/src/pair_lj_gromacs.cpp
@@ -414,9 +414,9 @@ void PairLJGromacs::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJGromacs::single(int i, int j, int itype, int jtype,
+double PairLJGromacs::single(int /*i*/, int /*j*/, int itype, int jtype,
                              double rsq,
-                             double factor_coul, double factor_lj,
+                             double /*factor_coul*/, double factor_lj,
                              double &fforce)
 {
   double r2inv,r6inv,forcelj,philj;

--- a/src/pair_lj_smooth.cpp
+++ b/src/pair_lj_smooth.cpp
@@ -425,8 +425,8 @@ void PairLJSmooth::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJSmooth::single(int i, int j, int itype, int jtype, double rsq,
-                            double factor_coul, double factor_lj,
+double PairLJSmooth::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                            double /*factor_coul*/, double factor_lj,
                             double &fforce)
 {
   double r2inv,r6inv,forcelj,philj,r,t,tsq,fskin;

--- a/src/pair_lj_smooth_linear.cpp
+++ b/src/pair_lj_smooth_linear.cpp
@@ -326,9 +326,9 @@ void PairLJSmoothLinear::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairLJSmoothLinear::single(int i, int j, int itype, int jtype,
+double PairLJSmoothLinear::single(int /*i*/, int /*j*/, int itype, int jtype,
                                   double rsq,
-                                  double factor_coul, double factor_lj,
+                                  double /*factor_coul*/, double factor_lj,
                                   double &fforce)
 {
   double r2inv,r6inv,forcelj,philj,r,rinv;

--- a/src/pair_mie_cut.cpp
+++ b/src/pair_mie_cut.cpp
@@ -682,8 +682,8 @@ void PairMIECut::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairMIECut::single(int i, int j, int itype, int jtype, double rsq,
-                           double factor_coul, double factor_mie,
+double PairMIECut::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                           double /*factor_coul*/, double factor_mie,
                            double &fforce)
 {
   double r2inv,rgamR,rgamA,forcemie,phimie;

--- a/src/pair_morse.cpp
+++ b/src/pair_morse.cpp
@@ -334,8 +334,8 @@ void PairMorse::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairMorse::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairMorse::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double r,dr,dexp,phi;

--- a/src/pair_soft.cpp
+++ b/src/pair_soft.cpp
@@ -307,8 +307,8 @@ void PairSoft::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairSoft::single(int i, int j, int itype, int jtype, double rsq,
-                        double factor_coul, double factor_lj,
+double PairSoft::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                        double /*factor_coul*/, double factor_lj,
                         double &fforce)
 {
   double r,arg,philj;

--- a/src/pair_table.cpp
+++ b/src/pair_table.cpp
@@ -993,8 +993,8 @@ void PairTable::read_restart_settings(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairTable::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairTable::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   int itable;

--- a/src/pair_ufm.cpp
+++ b/src/pair_ufm.cpp
@@ -353,8 +353,8 @@ void PairUFM::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairUFM::single(int i, int j, int itype, int jtype, double rsq,
-                         double factor_coul, double factor_lj,
+double PairUFM::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*factor_coul*/, double factor_lj,
                          double &fforce)
 {
   double expuf,phiuf;

--- a/src/pair_yukawa.cpp
+++ b/src/pair_yukawa.cpp
@@ -319,8 +319,8 @@ void PairYukawa::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairYukawa::single(int i, int j, int itype, int jtype, double rsq,
-                          double factor_coul, double factor_lj,
+double PairYukawa::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                          double /*factor_coul*/, double factor_lj,
                           double &fforce)
 {
   double r2inv,r,rinv,screening,forceyukawa,phi;

--- a/src/pair_zbl.cpp
+++ b/src/pair_zbl.cpp
@@ -267,8 +267,8 @@ double PairZBL::init_one(int i, int j)
 
 /* ---------------------------------------------------------------------- */
 
-double PairZBL::single(int i, int j, int itype, int jtype, double rsq,
-                         double dummy1, double dummy2,
+double PairZBL::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                         double /*dummy1*/, double /*dummy2*/,
                          double &fforce)
 {
   double phi,r,t,eswitch,fswitch;

--- a/src/rcb.cpp
+++ b/src/rcb.cpp
@@ -1108,7 +1108,7 @@ void RCB::compute_old(int dimension, int n, double **x, double *wt,
    merge of each component of an RCB bounding box
 ------------------------------------------------------------------------- */
 
-void box_merge(void *in, void *inout, int *len, MPI_Datatype *dptr)
+void box_merge(void *in, void *inout, int */*len*/, MPI_Datatype */*dptr*/)
 
 {
   RCB::BBox *box1 = (RCB::BBox *) in;
@@ -1138,7 +1138,7 @@ void box_merge(void *in, void *inout, int *len, MPI_Datatype *dptr)
                                   all procs must get same proclo,prochi
 ------------------------------------------------------------------------- */
 
-void median_merge(void *in, void *inout, int *len, MPI_Datatype *dptr)
+void median_merge(void *in, void *inout, int */*len*/, MPI_Datatype */*dptr*/)
 
 {
   RCB::Median *med1 = (RCB::Median *) in;

--- a/src/reader_xyz.cpp
+++ b/src/reader_xyz.cpp
@@ -117,9 +117,9 @@ void ReaderXYZ::skip()
    only called by proc 0
 ------------------------------------------------------------------------- */
 
-bigint ReaderXYZ::read_header(double box[3][3], int &triclinic,
+bigint ReaderXYZ::read_header(double /*box*/[3][3], int &triclinic,
                               int fieldinfo, int nfield,
-                              int *fieldtype, char **fieldlabel,
+                              int *fieldtype, char **/*fieldlabel*/,
                               int scaleflag, int wrapflag, int &fieldflag,
                               int &xflag, int &yflag, int &zflag)
 {

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -28,7 +28,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-Region::Region(LAMMPS *lmp, int narg, char **arg) :
+Region::Region(LAMMPS *lmp, int /*narg*/, char **arg) :
   Pointers(lmp),
   id(NULL), style(NULL), contact(NULL), list(NULL),
   xstr(NULL), ystr(NULL), zstr(NULL), tstr(NULL)

--- a/src/reset_ids.cpp
+++ b/src/reset_ids.cpp
@@ -28,7 +28,7 @@ ResetIDs::ResetIDs(LAMMPS *lmp) : Pointers(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 
-void ResetIDs::command(int narg, char **arg)
+void ResetIDs::command(int narg, char **/*arg*/)
 {
   if (domain->box_exist == 0)
     error->all(FLERR,"Reset_ids command before simulation box is defined");

--- a/src/respa.cpp
+++ b/src/respa.cpp
@@ -774,7 +774,7 @@ void Respa::recurse(int ilevel)
    clear other arrays as needed
 ------------------------------------------------------------------------- */
 
-void Respa::force_clear(int newtonflag)
+void Respa::force_clear(int /*newtonflag*/)
 {
   if (external_force_clear) return;
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -733,7 +733,7 @@ int Variable::find(char *name)
    called when atom is created
 ------------------------------------------------------------------------- */
 
-void Variable::set_arrays(int i)
+void Variable::set_arrays(int /*i*/)
 {
   for (int i = 0; i < nvar; i++)
     if (reader[i] && style[i] == ATOMFILE)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3733,7 +3733,7 @@ int Variable::group_function(char *word, char *contents, Tree **tree,
 
   if (strcmp(word,"count") == 0) {
     if (narg == 1) value = group->count(igroup);
-    else if (narg == 2) 
+    else if (narg == 2)
       value = group->count(igroup,region_function(args[1],ivar));
     else print_var_error(FLERR,"Invalid group function in variable formula",ivar);
 
@@ -3744,7 +3744,7 @@ int Variable::group_function(char *word, char *contents, Tree **tree,
 
   } else if (strcmp(word,"charge") == 0) {
     if (narg == 1) value = group->charge(igroup);
-    else if (narg == 2) 
+    else if (narg == 2)
       value = group->charge(igroup,region_function(args[1],ivar));
     else print_var_error(FLERR,"Invalid group function in variable formula",ivar);
 
@@ -3795,7 +3795,7 @@ int Variable::group_function(char *word, char *contents, Tree **tree,
   } else if (strcmp(word,"bound") == 0) {
     double minmax[6];
     if (narg == 2) group->bounds(igroup,minmax);
-    else if (narg == 3) 
+    else if (narg == 3)
       group->bounds(igroup,minmax,region_function(args[2],ivar));
     else print_var_error(FLERR,"Invalid group function in variable formula",ivar);
     if (strcmp(args[1],"xmin") == 0) value = minmax[0];
@@ -3959,7 +3959,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
                                double *argstack, int &nargstack, int ivar)
 {
   bigint sx,sxx;
-  double value,xvalue,sy,sxy;
+  double value,sy,sxy;
 
   // word not a match to any special function
 
@@ -4055,7 +4055,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
       } else index = 0;
 
       int ifix = modify->find_fix(&args[0][2]);
-      if (ifix < 0) 
+      if (ifix < 0)
         print_var_error(FLERR,"Invalid fix ID in variable formula",ivar);
       fix = modify->fix[ifix];
       if (index == 0 && fix->vector_flag) {

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -410,7 +410,7 @@ void Velocity::create(double t_desired, int seed)
 
 /* ---------------------------------------------------------------------- */
 
-void Velocity::set(int narg, char **arg)
+void Velocity::set(int /*narg*/, char **arg)
 {
   int xstyle,ystyle,zstyle,varflag;
   double vx,vy,vz;
@@ -579,7 +579,7 @@ void Velocity::set(int narg, char **arg)
    rescale velocities of a group after computing its temperature
 ------------------------------------------------------------------------- */
 
-void Velocity::scale(int narg, char **arg)
+void Velocity::scale(int /*narg*/, char **arg)
 {
   double t_desired = force->numeric(FLERR,arg[0]);
 
@@ -628,7 +628,7 @@ void Velocity::scale(int narg, char **arg)
    apply a ramped set of velocities
 ------------------------------------------------------------------------- */
 
-void Velocity::ramp(int narg, char **arg)
+void Velocity::ramp(int /*narg*/, char **arg)
 {
   // set scale factors
 
@@ -705,7 +705,7 @@ void Velocity::ramp(int narg, char **arg)
    zero linear or angular momentum of a group
 ------------------------------------------------------------------------- */
 
-void Velocity::zero(int narg, char **arg)
+void Velocity::zero(int /*narg*/, char **arg)
 {
   if (strcmp(arg[0],"linear") == 0) {
     if (rfix < 0) zero_momentum();


### PR DESCRIPTION
## Purpose

Cleans up the code to build without warnings when specifying pedantic warnings (such as unused variables, wrong initializer list order, potentially mislieading bracketing around logic operators etc.)

**This PR is not complete, but before I sink too much time into it I'd like some quick feedback on whether these changes are welcome or not**

## Author(s)

Daniel Schwen (INL)

## Backward Compatibility

There should not me any functional changes in this PR. It should be backward compatible.

## Implementation Notes

Unused function parameters were `/*param*/` commented out. The names are thus still in the source for self-documentation purposes, but the unused parameter warnings get squashed. Some brackets within chained `&&` terms were shifted to squash logic warnings.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

