### PR TITLE
Fixes various compilation issues

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -678,7 +678,8 @@ if(PKG_USER-OMP)
     set(USER-OMP_SOURCES ${USER-OMP_SOURCES_DIR}/thr_data.cpp
                          ${USER-OMP_SOURCES_DIR}/thr_omp.cpp
                          ${USER-OMP_SOURCES_DIR}/fix_nh_omp.cpp
-                         ${USER-OMP_SOURCES_DIR}/fix_nh_sphere_omp.cpp)
+                         ${USER-OMP_SOURCES_DIR}/fix_nh_sphere_omp.cpp
+                         ${USER-OMP_SOURCES_DIR}/domain_omp.cpp)
     add_definitions(-DLMP_USER_OMP)
     set_property(GLOBAL PROPERTY "OMP_SOURCES" "${USER-OMP_SOURCES}")
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -679,6 +679,7 @@ if(PKG_USER-OMP)
                          ${USER-OMP_SOURCES_DIR}/thr_omp.cpp
                          ${USER-OMP_SOURCES_DIR}/fix_nh_omp.cpp
                          ${USER-OMP_SOURCES_DIR}/fix_nh_sphere_omp.cpp)
+    add_definitions(-DLMP_USER_OMP)
     set_property(GLOBAL PROPERTY "OMP_SOURCES" "${USER-OMP_SOURCES}")
 
     # detects styles which have USER-OMP version

--- a/src/BODY/fix_wall_body_polyhedron.cpp
+++ b/src/BODY/fix_wall_body_polyhedron.cpp
@@ -693,7 +693,7 @@ int FixWallBodyPolyhedron::compute_distance_to_wall(int ibody, int edge_index,
 ------------------------------------------------------------------------- */
 
 void FixWallBodyPolyhedron::contact_forces(int ibody,
-  double j_a, double *xi, double */*xj*/, double delx, double dely, double delz,
+  double j_a, double *xi, double * /*xj*/, double delx, double dely, double delz,
   double fx, double fy, double fz, double** x, double** v, double** angmom,
   double** f, double** torque, double* vwall)
 {

--- a/src/COLLOID/pair_lubricate.cpp
+++ b/src/COLLOID/pair_lubricate.cpp
@@ -749,7 +749,7 @@ void PairLubricate::read_restart_settings(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 int PairLubricate::pack_forward_comm(int n, int *list, double *buf,
-                                     int /*pbc_flag*/, int */*pbc*/)
+                                     int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/COLLOID/pair_lubricateU.cpp
+++ b/src/COLLOID/pair_lubricateU.cpp
@@ -2010,7 +2010,7 @@ void PairLubricateU::copy_uo_vec(int inum, double **f, double **torque,
 /* ---------------------------------------------------------------------- */
 
 int PairLubricateU::pack_forward_comm(int n, int *list, double *buf,
-                                      int /*pbc_flag*/, int */*pbc*/)
+                                      int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -746,7 +746,7 @@ double PairGranHookeHistory::single(int i, int j, int /*itype*/, int /*jtype*/,
 /* ---------------------------------------------------------------------- */
 
 int PairGranHookeHistory::pack_forward_comm(int n, int *list, double *buf,
-                                            int /*pbc_flag*/, int */*pbc*/)
+                                            int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/LATTE/fix_latte.cpp
+++ b/src/LATTE/fix_latte.cpp
@@ -189,7 +189,7 @@ void FixLatte::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixLatte::init_list(int /*id*/, NeighList */*ptr*/)
+void FixLatte::init_list(int /*id*/, NeighList * /*ptr*/)
 {
   // list = ptr;
 }

--- a/src/MANYBODY/fix_qeq_comb.cpp
+++ b/src/MANYBODY/fix_qeq_comb.cpp
@@ -293,7 +293,7 @@ double FixQEQComb::memory_usage()
 /* ---------------------------------------------------------------------- */
 
 int FixQEQComb::pack_forward_comm(int n, int *list, double *buf,
-                                  int /*pbc_flag*/, int */*pbc*/)
+                                  int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -935,7 +935,7 @@ void PairADP::grab(FILE *fp, int n, double *list)
 /* ---------------------------------------------------------------------- */
 
 int PairADP::pack_forward_comm(int n, int *list, double *buf,
-                               int /*pbc_flag*/, int */*pbc*/)
+                               int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -2002,7 +2002,7 @@ void PairComb::Over_cor(Param *param, double rsq1, int NCoi,
 /* ---------------------------------------------------------------------- */
 
 int PairComb::pack_forward_comm(int n, int *list, double *buf,
-                                int /*pbc_flag*/, int */*pbc*/)
+                                int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -2109,7 +2109,7 @@ void PairComb3::coord(Param *param, double r, int i,
 
 void PairComb3::cntri_int(int tri_flag, double xval, double yval,
                 double zval, int ixmin, int iymin, int izmin, double &vval,
-                double &dvalx, double &dvaly, double &dvalz, Param */*param*/)
+                double &dvalx, double &dvaly, double &dvalz, Param * /*param*/)
 {
   double x;
   vval = 0.0; dvalx = 0.0; dvaly = 0.0; dvalz = 0.0;
@@ -3863,7 +3863,7 @@ double PairComb3::switching_d(double rr)
 /* ---------------------------------------------------------------------- */
 
 int PairComb3::pack_forward_comm(int n, int *list, double *buf,
-                                 int /*pbc_flag*/, int */*pbc*/)
+                                 int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -829,7 +829,7 @@ double PairEAM::single(int i, int j, int itype, int jtype,
 /* ---------------------------------------------------------------------- */
 
 int PairEAM::pack_forward_comm(int n, int *list, double *buf,
-                               int /*pbc_flag*/, int */*pbc*/)
+                               int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_eam_cd.cpp
+++ b/src/MANYBODY/pair_eam_cd.cpp
@@ -539,7 +539,7 @@ void PairEAMCD::read_h_coeff(char *filename)
 /* ---------------------------------------------------------------------- */
 
 int PairEAMCD::pack_forward_comm(int n, int *list, double *buf,
-                                 int /*pbc_flag*/, int */*pbc*/)
+                                 int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_eim.cpp
+++ b/src/MANYBODY/pair_eim.cpp
@@ -1087,7 +1087,7 @@ double PairEIM::funccoul(int i, int j, double r)
 /* ---------------------------------------------------------------------- */
 
 int PairEIM::pack_forward_comm(int n, int *list, double *buf,
-                               int /*pbc_flag*/, int */*pbc*/)
+                               int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MANYBODY/pair_nb3b_harmonic.cpp
+++ b/src/MANYBODY/pair_nb3b_harmonic.cpp
@@ -454,7 +454,7 @@ void PairNb3bHarmonic::setup_params()
 /* ---------------------------------------------------------------------- */
 
 
-void PairNb3bHarmonic::threebody(Param */*paramij*/, Param */*paramik*/,
+void PairNb3bHarmonic::threebody(Param * /*paramij*/, Param * /*paramik*/,
                                  Param *paramijk,
                                  double rsq1, double rsq2,
                                  double *delr1, double *delr2,

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -695,7 +695,7 @@ void FixAtomSwap::update_swap_atoms_list()
 
 /* ---------------------------------------------------------------------- */
 
-int FixAtomSwap::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
+int FixAtomSwap::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/MC/fix_bond_break.cpp
+++ b/src/MC/fix_bond_break.cpp
@@ -701,7 +701,7 @@ void FixBondBreak::post_integrate_respa(int ilevel, int /*iloop*/)
 /* ---------------------------------------------------------------------- */
 
 int FixBondBreak::pack_forward_comm(int n, int *list, double *buf,
-                                    int /*pbc_flag*/, int */*pbc*/)
+                                    int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,k,m,ns;
 

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -1214,7 +1214,7 @@ void FixBondCreate::post_integrate_respa(int ilevel, int /*iloop*/)
 /* ---------------------------------------------------------------------- */
 
 int FixBondCreate::pack_forward_comm(int n, int *list, double *buf,
-                                     int /*pbc_flag*/, int */*pbc*/)
+                                     int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,k,m,ns;
 

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -734,7 +734,7 @@ void PairMEAM::read_files(char *globalfile, char *userfile)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAM::pack_forward_comm(int n, int *list, double *buf,
-                                int /*pbc_flag*/, int */*pbc*/)
+                                int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,k,m;
 

--- a/src/MISC/fix_orient_bcc.cpp
+++ b/src/MISC/fix_orient_bcc.cpp
@@ -488,7 +488,7 @@ double FixOrientBCC::compute_scalar()
 /* ---------------------------------------------------------------------- */
 
 int FixOrientBCC::pack_forward_comm(int n, int *list, double *buf,
-                                    int /*pbc_flag*/, int */*pbc*/)
+                                    int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,k,num;
   tagint id;

--- a/src/MISC/fix_orient_fcc.cpp
+++ b/src/MISC/fix_orient_fcc.cpp
@@ -486,7 +486,7 @@ double FixOrientFCC::compute_scalar()
 /* ---------------------------------------------------------------------- */
 
 int FixOrientFCC::pack_forward_comm(int n, int *list, double *buf,
-                                    int /*pbc_flag*/, int */*pbc*/)
+                                    int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,k,num;
   tagint id;

--- a/src/MISC/xdr_compat.cpp
+++ b/src/MISC/xdr_compat.cpp
@@ -650,7 +650,7 @@ xdrstdio_setpos (XDR *xdrs, unsigned int pos)
 }
 
 static xdr_int32_t *
-xdrstdio_inline (XDR */*xdrs*/, int /*len*/)
+xdrstdio_inline (XDR * /*xdrs*/, int /*len*/)
 {
   /*
    * Must do some work to implement this: must insure

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -1163,7 +1163,7 @@ void FixCMAP::read_data_section(char *keyword, int n, char *buf,
 
 /* ---------------------------------------------------------------------- */
 
-bigint FixCMAP::read_data_skip_lines(char */*keyword*/)
+bigint FixCMAP::read_data_skip_lines(char * /*keyword*/)
 {
   return ncmap;
 }

--- a/src/PERI/fix_peri_neigh.cpp
+++ b/src/PERI/fix_peri_neigh.cpp
@@ -514,7 +514,7 @@ int FixPeriNeigh::unpack_exchange(int nlocal, double *buf)
 /* ---------------------------------------------------------------------- */
 
 int FixPeriNeigh::pack_forward_comm(int n, int *list, double *buf,
-                                    int /*pbc_flag*/, int */*pbc*/)
+                                    int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -799,7 +799,7 @@ double PairPeriEPS::compute_DeviatoricForceStateNorm(int i)
 ---------------------------------------------------------------------- */
 
 int PairPeriEPS::pack_forward_comm(int n, int *list, double *buf,
-                                   int /*pbc_flag*/, int */*pbc*/)
+                                   int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/PERI/pair_peri_lps.cpp
+++ b/src/PERI/pair_peri_lps.cpp
@@ -631,7 +631,7 @@ void PairPeriLPS::compute_dilatation()
  ---------------------------------------------------------------------- */
 
 int PairPeriLPS::pack_forward_comm(int n, int *list, double *buf,
-                                   int /*pbc_flag*/, int */*pbc*/)
+                                   int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/PERI/pair_peri_ves.cpp
+++ b/src/PERI/pair_peri_ves.cpp
@@ -697,7 +697,7 @@ void PairPeriVES::compute_dilatation()
 ---------------------------------------------------------------------- */
 
 int PairPeriVES::pack_forward_comm(int n, int *list, double *buf,
-                                   int /*pbc_flag*/, int */*pbc*/)
+                                   int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -471,7 +471,7 @@ void FixQEq::calculate_Q()
 /* ---------------------------------------------------------------------- */
 
 int FixQEq::pack_forward_comm(int n, int *list, double *buf,
-                          int /*pbc_flag*/, int */*pbc*/)
+                          int /*pbc_flag*/, int * /*pbc*/)
 {
   int m;
 

--- a/src/QEQ/fix_qeq_dynamic.cpp
+++ b/src/QEQ/fix_qeq_dynamic.cpp
@@ -247,7 +247,7 @@ double FixQEqDynamic::compute_eneg()
 /* ---------------------------------------------------------------------- */
 
 int FixQEqDynamic::pack_forward_comm(int n, int *list, double *buf,
-                          int /*pbc_flag*/, int */*pbc*/)
+                          int /*pbc_flag*/, int * /*pbc*/)
 {
   int m=0;
 

--- a/src/QEQ/fix_qeq_fire.cpp
+++ b/src/QEQ/fix_qeq_fire.cpp
@@ -311,7 +311,7 @@ double FixQEqFire::compute_eneg()
 /* ---------------------------------------------------------------------- */
 
 int FixQEqFire::pack_forward_comm(int n, int *list, double *buf,
-                          int /*pbc_flag*/, int */*pbc*/)
+                          int /*pbc_flag*/, int * /*pbc*/)
 {
   int m = 0;
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -2999,7 +2999,7 @@ int FixRigidSmall::unpack_exchange(int nlocal, double *buf)
 ------------------------------------------------------------------------- */
 
 int FixRigidSmall::pack_forward_comm(int n, int *list, double *buf,
-                                     int /*pbc_flag*/, int */*pbc*/)
+                                     int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j;
   double *xcm,*vcm,*quat,*omega,*ex_space,*ey_space,*ez_space,*conjqm;

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -2528,7 +2528,7 @@ void FixShake::update_arrays(int i, int atom_offset)
 ------------------------------------------------------------------------- */
 
 void FixShake::set_molecule(int nlocalprev, tagint tagprev, int imol,
-                            double */*xgeom*/, double */*vcm*/, double */*quat*/)
+                            double * /*xgeom*/, double * /*vcm*/, double * /*quat*/)
 {
   int m,flag;
 

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -2168,8 +2168,8 @@ void FixSRD::collision_ellipsoid_inexact(double *xs, double *xb,
    norm = surface normal of collision pt at time of collision
 ------------------------------------------------------------------------- */
 
-double FixSRD::collision_line_exact(double */*xs*/, double */*xb*/,
-                                    double */*vs*/, double */*vb*/, Big */*big*/,
+double FixSRD::collision_line_exact(double * /*xs*/, double * /*xb*/,
+                                    double * /*vs*/, double * /*vb*/, Big * /*big*/,
                                     double dt_step,
                                     double *xscoll, double *xbcoll,
                                     double *norm)
@@ -2197,8 +2197,8 @@ double FixSRD::collision_line_exact(double */*xs*/, double */*xb*/,
    norm = surface normal of collision pt at time of collision
 ------------------------------------------------------------------------- */
 
-double FixSRD::collision_tri_exact(double */*xs*/, double */*xb*/,
-                                   double */*vs*/, double */*vb*/, Big */*big*/,
+double FixSRD::collision_tri_exact(double * /*xs*/, double * /*xb*/,
+                                   double * /*vs*/, double * /*vb*/, Big * /*big*/,
                                    double dt_step,
                                    double *xscoll, double *xbcoll,
                                    double *norm)

--- a/src/USER-DPD/fix_eos_table_rx.cpp
+++ b/src/USER-DPD/fix_eos_table_rx.cpp
@@ -803,7 +803,7 @@ void FixEOStableRX::temperature_lookup(int id, double ui, double &thetai)
 
 /* ---------------------------------------------------------------------- */
 
-int FixEOStableRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
+int FixEOStableRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/)
 {
   int ii,jj,m;
   double *uChem = atom->uChem;

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -1885,7 +1885,7 @@ void FixRX::computeLocalTemperature()
 
 /* ---------------------------------------------------------------------- */
 
-int FixRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
+int FixRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/)
 {
   int ii,jj,m;
   double tmp;

--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -646,7 +646,7 @@ fprintf(stdout, "\n%6d %6d,%6d %6d: "
 
 /* ---------------------------------------------------------------------- */
 
-int FixShardlow::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
+int FixShardlow::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/)
 {
   int ii,jj,m;
   double **v  = atom->v;

--- a/src/USER-DPD/pair_multi_lucy.cpp
+++ b/src/USER-DPD/pair_multi_lucy.cpp
@@ -781,7 +781,7 @@ void PairMultiLucy::computeLocalDensity()
 }
 /* ---------------------------------------------------------------------- */
 
-int PairMultiLucy::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
+int PairMultiLucy::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
   double *rho = atom->rho;

--- a/src/USER-DPD/pair_multi_lucy_rx.cpp
+++ b/src/USER-DPD/pair_multi_lucy_rx.cpp
@@ -1019,7 +1019,7 @@ void PairMultiLucyRX::getMixingWeights(int id, double &mixWtSite1old, double &mi
 
 /* ---------------------------------------------------------------------- */
 
-int PairMultiLucyRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
+int PairMultiLucyRX::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
   double *rho = atom->rho;

--- a/src/USER-INTEL/angle_charmm_intel.cpp
+++ b/src/USER-INTEL/angle_charmm_intel.cpp
@@ -332,7 +332,7 @@ void AngleCharmmIntel::init_style()
 
 template <class flt_t, class acc_t>
 void AngleCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                        IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                        IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->nangletypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/angle_harmonic_intel.cpp
+++ b/src/USER-INTEL/angle_harmonic_intel.cpp
@@ -314,7 +314,7 @@ void AngleHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void AngleHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                        IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                        IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->nangletypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/bond_fene_intel.cpp
+++ b/src/USER-INTEL/bond_fene_intel.cpp
@@ -291,7 +291,7 @@ void BondFENEIntel::init_style()
 
 template <class flt_t, class acc_t>
 void BondFENEIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                         IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                         IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->nbondtypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/bond_harmonic_intel.cpp
+++ b/src/USER-INTEL/bond_harmonic_intel.cpp
@@ -262,7 +262,7 @@ void BondHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void BondHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                         IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                         IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->nbondtypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/dihedral_fourier_intel.cpp
+++ b/src/USER-INTEL/dihedral_fourier_intel.cpp
@@ -401,7 +401,7 @@ void DihedralFourierIntel::init_style()
 
 template <class flt_t, class acc_t>
 void DihedralFourierIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                            IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                            IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1, setflag, nterms, memory);

--- a/src/USER-INTEL/dihedral_harmonic_intel.cpp
+++ b/src/USER-INTEL/dihedral_harmonic_intel.cpp
@@ -396,7 +396,7 @@ void DihedralHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void DihedralHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                             IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/dihedral_opls_intel.cpp
+++ b/src/USER-INTEL/dihedral_opls_intel.cpp
@@ -416,7 +416,7 @@ void DihedralOPLSIntel::init_style()
 
 template <class flt_t, class acc_t>
 void DihedralOPLSIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                             IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->ndihedraltypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/improper_cvff_intel.cpp
+++ b/src/USER-INTEL/improper_cvff_intel.cpp
@@ -428,7 +428,7 @@ void ImproperCvffIntel::init_style()
 
 template <class flt_t, class acc_t>
 void ImproperCvffIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                             IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->nimpropertypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/improper_harmonic_intel.cpp
+++ b/src/USER-INTEL/improper_harmonic_intel.cpp
@@ -384,7 +384,7 @@ void ImproperHarmonicIntel::init_style()
 
 template <class flt_t, class acc_t>
 void ImproperHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
-                                             IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                             IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   const int bp1 = atom->nimpropertypes + 1;
   fc.set_ntypes(bp1,memory);

--- a/src/USER-INTEL/intel_buffers.cpp
+++ b/src/USER-INTEL/intel_buffers.cpp
@@ -310,7 +310,7 @@ void IntelBuffers<flt_t, acc_t>::free_nbor_list()
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t, class acc_t>
-void IntelBuffers<flt_t, acc_t>::_grow_nbor_list(NeighList */*list*/,
+void IntelBuffers<flt_t, acc_t>::_grow_nbor_list(NeighList * /*list*/,
                                                  const int nlocal,
                                                  const int nthreads,
                                                  const int /*offload_end*/,

--- a/src/USER-INTEL/intel_buffers.h
+++ b/src/USER-INTEL/intel_buffers.h
@@ -135,8 +135,8 @@ class IntelBuffers {
 
   void set_ntypes(const int ntypes, const int use_ghost_cut = 0);
 
-  inline int * firstneigh(const NeighList */*list*/) { return _list_alloc; }
-  inline int * cnumneigh(const NeighList */*list*/) { return _cnumneigh; }
+  inline int * firstneigh(const NeighList * /*list*/) { return _list_alloc; }
+  inline int * cnumneigh(const NeighList * /*list*/) { return _cnumneigh; }
   inline int * get_atombin() { return _atombin; }
   inline int * get_binpacked() { return _binpacked; }
 

--- a/src/USER-INTEL/pair_eam_intel.cpp
+++ b/src/USER-INTEL/pair_eam_intel.cpp
@@ -784,7 +784,7 @@ void PairEAMIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
 /* ---------------------------------------------------------------------- */
 
 int PairEAMIntel::pack_forward_comm(int n, int *list, double *buf,
-                                    int /*pbc_flag*/, int */*pbc*/)
+                                    int /*pbc_flag*/, int * /*pbc*/)
 {
   if (fix->precision() == FixIntel::PREC_MODE_DOUBLE)
     return pack_forward_comm(n, list, buf, fp);

--- a/src/USER-INTEL/pppm_disp_intel.cpp
+++ b/src/USER-INTEL/pppm_disp_intel.cpp
@@ -723,7 +723,7 @@ void PPPMDispIntel::particle_map(double delx, double dely, double delz,
                                  double sft, int** p2g, int nup, int nlow,
                                  int nxlo, int nylo, int nzlo,
                                  int nxhi, int nyhi, int nzhi,
-                                 IntelBuffers<flt_t,acc_t> */*buffers*/)
+                                 IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   int nlocal = atom->nlocal;
   int nthr = comm->nthreads;
@@ -790,7 +790,7 @@ void PPPMDispIntel::particle_map(double delx, double dely, double delz,
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_c(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::make_rho_c(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   // clear 3d density array
 
@@ -940,7 +940,7 @@ void PPPMDispIntel::make_rho_c(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_g(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::make_rho_g(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   // clear 3d density array
 
@@ -1091,7 +1091,7 @@ void PPPMDispIntel::make_rho_g(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_a(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::make_rho_a(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   // clear 3d density array
 
@@ -1225,7 +1225,7 @@ void PPPMDispIntel::make_rho_a(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::make_rho_none(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::make_rho_none(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   FFT_SCALAR * _noalias global_density = &(density_brick_none[0][nzlo_out_6][nylo_out_6][nxlo_out_6]);
@@ -1373,7 +1373,7 @@ void PPPMDispIntel::make_rho_none(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_c_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_c_ik(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -1520,7 +1520,7 @@ void PPPMDispIntel::fieldforce_c_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_c_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_c_ad(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -1725,7 +1725,7 @@ void PPPMDispIntel::fieldforce_c_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_g_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_g_ik(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -1869,7 +1869,7 @@ void PPPMDispIntel::fieldforce_g_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_g_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_g_ad(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2069,7 +2069,7 @@ void PPPMDispIntel::fieldforce_g_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_a_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_a_ik(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2282,7 +2282,7 @@ void PPPMDispIntel::fieldforce_a_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_a_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_a_ad(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2594,7 +2594,7 @@ void PPPMDispIntel::fieldforce_a_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_none_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_none_ik(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
 
   // loop over my charges, interpolate electric field from nearby grid points
@@ -2755,7 +2755,7 @@ void PPPMDispIntel::fieldforce_none_ik(IntelBuffers<flt_t,acc_t> */*buffers*/)
 ------------------------------------------------------------------------- */
 
 template<class flt_t, class acc_t, int use_table>
-void PPPMDispIntel::fieldforce_none_ad(IntelBuffers<flt_t,acc_t> */*buffers*/)
+void PPPMDispIntel::fieldforce_none_ad(IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
   // loop over my charges, interpolate electric field from nearby grid points
   // (nx,ny,nz) = global coords of grid pt to "lower left" of charge

--- a/src/USER-MANIFOLD/manifold_plane.cpp
+++ b/src/USER-MANIFOLD/manifold_plane.cpp
@@ -16,7 +16,7 @@ double manifold_plane::g( const double *x )
 }
 
 
-void manifold_plane::n( const double */*x*/, double *n )
+void manifold_plane::n( const double * /*x*/, double *n )
 {
   n[0] = params[0];
   n[1] = params[1];

--- a/src/USER-MANIFOLD/manifold_thylakoid.cpp
+++ b/src/USER-MANIFOLD/manifold_thylakoid.cpp
@@ -117,7 +117,7 @@ void   manifold_thylakoid::n( const double *x, double *n )
   }
 }
 
-thyla_part *manifold_thylakoid::get_thyla_part( const double *x, int */*err_flag*/, std::size_t *idx )
+thyla_part *manifold_thylakoid::get_thyla_part( const double *x, int * /*err_flag*/, std::size_t *idx )
 {
 
   for( std::size_t i = 0; i < parts.size(); ++i ){

--- a/src/USER-MEAMC/pair_meamc.cpp
+++ b/src/USER-MEAMC/pair_meamc.cpp
@@ -598,7 +598,7 @@ void PairMEAMC::read_files(char *globalfile, char *userfile)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAMC::pack_forward_comm(int n, int *list, double *buf,
-                                int /*pbc_flag*/, int */*pbc*/)
+                                int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,k,m;
 

--- a/src/USER-MESO/pair_mdpd_rhosum.cpp
+++ b/src/USER-MESO/pair_mdpd_rhosum.cpp
@@ -246,7 +246,7 @@ double PairMDPDRhoSum::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/
 /* ---------------------------------------------------------------------- */
 
 int PairMDPDRhoSum::pack_forward_comm(int n, int *list, double *buf,
-                                     int /*pbc_flag*/, int */*pbc*/) {
+                                     int /*pbc_flag*/, int * /*pbc*/) {
   int i, j, m;
   double *rho = atom->rho;
 

--- a/src/USER-MISC/fix_bond_react.cpp
+++ b/src/USER-MISC/fix_bond_react.cpp
@@ -2628,7 +2628,7 @@ void FixBondReact::post_integrate_respa(int ilevel, int /*iloop*/)
 /* ---------------------------------------------------------------------- */
 
 int FixBondReact::pack_forward_comm(int n, int *list, double *buf,
-                                    int /*pbc_flag*/, int */*pbc*/)
+                                    int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,k,m,ns;
 

--- a/src/USER-MISC/fix_filter_corotate.cpp
+++ b/src/USER-MISC/fix_filter_corotate.cpp
@@ -1699,7 +1699,7 @@ void FixFilterCorotate::general_cluster(int index, int index_in_list)
 }
 
 int FixFilterCorotate::pack_forward_comm(int n, int *list, double *buf,
-                                         int /*pbc_flag*/, int */*pbc*/)
+                                         int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
   double**f = atom->f;

--- a/src/USER-MISC/fix_pimd.cpp
+++ b/src/USER-MISC/fix_pimd.cpp
@@ -686,7 +686,7 @@ void FixPIMD::comm_exec(double **ptr)
 /* ---------------------------------------------------------------------- */
 
 int FixPIMD::pack_forward_comm(int n, int *list, double *buf,
-                             int /*pbc_flag*/, int */*pbc*/)
+                             int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/USER-MISC/pair_ilp_graphene_hbn.cpp
+++ b/src/USER-MISC/pair_ilp_graphene_hbn.cpp
@@ -1047,7 +1047,7 @@ double PairILPGrapheneHBN::single(int /*i*/, int /*j*/, int itype, int jtype, do
 /* ---------------------------------------------------------------------- */
 
 int PairILPGrapheneHBN::pack_forward_comm(int n, int *list, double *buf,
-                               int /*pbc_flag*/, int */*pbc*/)
+                               int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m,id,ip,l;
 

--- a/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
@@ -1050,7 +1050,7 @@ double PairKolmogorovCrespiFull::single(int /*i*/, int /*j*/, int itype, int jty
 /* ---------------------------------------------------------------------- */
 
 int PairKolmogorovCrespiFull::pack_forward_comm(int n, int *list, double *buf,
-                               int /*pbc_flag*/, int */*pbc*/)
+                               int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m,l,ip,id;
 

--- a/src/USER-MISC/pair_meam_spline.cpp
+++ b/src/USER-MISC/pair_meam_spline.cpp
@@ -600,7 +600,7 @@ double PairMEAMSpline::init_one(int /*i*/, int /*j*/)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAMSpline::pack_forward_comm(int n, int *list, double *buf,
-                                      int /*pbc_flag*/, int */*pbc*/)
+                                      int /*pbc_flag*/, int * /*pbc*/)
 {
   int* list_iter = list;
   int* list_iter_end = list + n;
@@ -618,14 +618,14 @@ void PairMEAMSpline::unpack_forward_comm(int n, int first, double *buf)
 
 /* ---------------------------------------------------------------------- */
 
-int PairMEAMSpline::pack_reverse_comm(int /*n*/, int /*first*/, double */*buf*/)
+int PairMEAMSpline::pack_reverse_comm(int /*n*/, int /*first*/, double * /*buf*/)
 {
   return 0;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void PairMEAMSpline::unpack_reverse_comm(int /*n*/, int */*list*/, double */*buf*/)
+void PairMEAMSpline::unpack_reverse_comm(int /*n*/, int * /*list*/, double * /*buf*/)
 {
 }
 

--- a/src/USER-MISC/pair_meam_sw_spline.cpp
+++ b/src/USER-MISC/pair_meam_sw_spline.cpp
@@ -560,7 +560,7 @@ double PairMEAMSWSpline::init_one(int /*i*/, int /*j*/)
 /* ---------------------------------------------------------------------- */
 
 int PairMEAMSWSpline::pack_forward_comm(int n, int *list, double *buf,
-                                        int /*pbc_flag*/, int */*pbc*/)
+                                        int /*pbc_flag*/, int * /*pbc*/)
 {
         int* list_iter = list;
         int* list_iter_end = list + n;
@@ -578,14 +578,14 @@ void PairMEAMSWSpline::unpack_forward_comm(int n, int first, double *buf)
 
 /* ---------------------------------------------------------------------- */
 
-int PairMEAMSWSpline::pack_reverse_comm(int /*n*/, int /*first*/, double */*buf*/)
+int PairMEAMSWSpline::pack_reverse_comm(int /*n*/, int /*first*/, double * /*buf*/)
 {
         return 0;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void PairMEAMSWSpline::unpack_reverse_comm(int /*n*/, int */*list*/, double */*buf*/)
+void PairMEAMSWSpline::unpack_reverse_comm(int /*n*/, int * /*list*/, double * /*buf*/)
 {
 }
 

--- a/src/USER-REAXC/fix_qeq_reax.cpp
+++ b/src/USER-REAXC/fix_qeq_reax.cpp
@@ -833,7 +833,7 @@ void FixQEqReax::calculate_Q()
 /* ---------------------------------------------------------------------- */
 
 int FixQEqReax::pack_forward_comm(int n, int *list, double *buf,
-                                  int /*pbc_flag*/, int */*pbc*/)
+                                  int /*pbc_flag*/, int * /*pbc*/)
 {
   int m;
 

--- a/src/USER-REAXC/fix_reaxc.cpp
+++ b/src/USER-REAXC/fix_reaxc.cpp
@@ -136,7 +136,7 @@ int FixReaxC::unpack_exchange(int nlocal, double *buf)
 /* ---------------------------------------------------------------------- */
 
 int FixReaxC::pack_forward_comm(int n, int *list, double *buf,
-                                int /*pbc_flag*/, int */*pbc*/)
+                                int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/USER-REAXC/fix_reaxc_bonds.cpp
+++ b/src/USER-REAXC/fix_reaxc_bonds.cpp
@@ -137,7 +137,7 @@ void FixReaxCBonds::end_of_step()
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCBonds::Output_ReaxC_Bonds(bigint /*ntimestep*/, FILE */*fp*/)
+void FixReaxCBonds::Output_ReaxC_Bonds(bigint /*ntimestep*/, FILE * /*fp*/)
 
 {
   int i, j;
@@ -185,7 +185,7 @@ void FixReaxCBonds::Output_ReaxC_Bonds(bigint /*ntimestep*/, FILE */*fp*/)
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCBonds::FindBond(struct _reax_list */*lists*/, int &numbonds)
+void FixReaxCBonds::FindBond(struct _reax_list * /*lists*/, int &numbonds)
 {
   int *ilist, i, ii, inum;
   int j, pj, nj;

--- a/src/USER-REAXC/fix_reaxc_species.cpp
+++ b/src/USER-REAXC/fix_reaxc_species.cpp
@@ -442,7 +442,7 @@ void FixReaxCSpecies::post_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixReaxCSpecies::Output_ReaxC_Bonds(bigint ntimestep, FILE */*fp*/)
+void FixReaxCSpecies::Output_ReaxC_Bonds(bigint ntimestep, FILE * /*fp*/)
 
 {
   int Nmole, Nspec;
@@ -946,7 +946,7 @@ int FixReaxCSpecies::nint(const double &r)
 /* ---------------------------------------------------------------------- */
 
 int FixReaxCSpecies::pack_forward_comm(int n, int *list, double *buf,
-                                       int /*pbc_flag*/, int */*pbc*/)
+                                       int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/USER-REAXC/reaxc_allocate.cpp
+++ b/src/USER-REAXC/reaxc_allocate.cpp
@@ -39,8 +39,8 @@
    important: we cannot know the exact number of atoms that will fall into a
    process's box throughout the whole simulation. therefore
    we need to make upper bound estimates for various data structures */
-int PreAllocate_Space( reax_system *system, control_params */*control*/,
-                       storage */*workspace*/, MPI_Comm comm )
+int PreAllocate_Space( reax_system *system, control_params * /*control*/,
+                       storage * workspace, MPI_Comm comm )
 {
   int mincap = system->mincap;
   double safezone = system->safezone;
@@ -60,6 +60,8 @@ int PreAllocate_Space( reax_system *system, control_params */*control*/,
   workspace->forceReduction = NULL;
   workspace->valence_angle_atom_myoffset = NULL;
   workspace->my_ext_pressReduction = NULL;
+#else
+  LMP_UNUSED_PARAM(workspace);
 #endif
 
   return SUCCESS;
@@ -69,7 +71,7 @@ int PreAllocate_Space( reax_system *system, control_params */*control*/,
 /*************       system        *************/
 
 int Allocate_System( reax_system *system, int /*local_cap*/, int total_cap,
-                     char */*msg*/ )
+                     char * /*msg*/ )
 {
   system->my_atoms = (reax_atom*)
     realloc( system->my_atoms, total_cap*sizeof(reax_atom) );
@@ -116,7 +118,7 @@ void DeAllocate_System( reax_system *system )
 
 
 /*************       workspace        *************/
-void DeAllocate_Workspace( control_params */*control*/, storage *workspace )
+void DeAllocate_Workspace( control_params * /*control*/, storage *workspace )
 {
   int i;
 
@@ -204,9 +206,9 @@ void DeAllocate_Workspace( control_params */*control*/, storage *workspace )
 }
 
 
-int Allocate_Workspace( reax_system */*system*/, control_params */*control*/,
+int Allocate_Workspace( reax_system * /*system*/, control_params * control,
                         storage *workspace, int local_cap, int total_cap,
-                        MPI_Comm comm, char */*msg*/ )
+                        MPI_Comm comm, char * /*msg*/ )
 {
   int i, total_real, total_rvec, local_rvec;
 
@@ -307,6 +309,8 @@ int Allocate_Workspace( reax_system */*system*/, control_params */*control*/,
 
   workspace->valence_angle_atom_myoffset = (int *) scalloc(sizeof(int), total_cap, "valence_angle_atom_myoffset", comm);
   workspace->my_ext_pressReduction = (rvec *) calloc(sizeof(rvec), control->nthreads);
+#else
+  LMP_UNUSED_PARAM(control);
 #endif
 
   return SUCCESS;

--- a/src/USER-REAXC/reaxc_bond_orders.cpp
+++ b/src/USER-REAXC/reaxc_bond_orders.cpp
@@ -359,8 +359,8 @@ int BOp( storage *workspace, reax_list *bonds, double bo_cut,
 }
 
 
-void BO( reax_system *system, control_params */*control*/, simulation_data */*data*/,
-         storage *workspace, reax_list **lists, output_controls */*out_control*/ )
+void BO( reax_system *system, control_params * /*control*/, simulation_data * /*data*/,
+         storage *workspace, reax_list **lists, output_controls * /*out_control*/ )
 {
   int i, j, pj, type_i, type_j;
   int start_i, end_i, sym_index;

--- a/src/USER-REAXC/reaxc_bonds.cpp
+++ b/src/USER-REAXC/reaxc_bonds.cpp
@@ -31,9 +31,9 @@
 #include "reaxc_tool_box.h"
 #include "reaxc_vector.h"
 
-void Bonds( reax_system *system, control_params */*control*/,
+void Bonds( reax_system *system, control_params * /*control*/,
             simulation_data *data, storage *workspace, reax_list **lists,
-            output_controls */*out_control*/ )
+            output_controls * /*out_control*/ )
 {
   int i, j, pj, natoms;
   int start_i, end_i;

--- a/src/USER-REAXC/reaxc_forces.cpp
+++ b/src/USER-REAXC/reaxc_forces.cpp
@@ -41,9 +41,9 @@
 
 interaction_function Interaction_Functions[NUM_INTRS];
 
-void Dummy_Interaction( reax_system */*system*/, control_params */*control*/,
-                        simulation_data */*data*/, storage */*workspace*/,
-                        reax_list **/*lists*/, output_controls */*out_control*/ )
+void Dummy_Interaction( reax_system * /*system*/, control_params * /*control*/,
+                        simulation_data * /*data*/, storage * /*workspace*/,
+                        reax_list **/*lists*/, output_controls * /*out_control*/ )
 {
 }
 
@@ -98,7 +98,7 @@ void Compute_NonBonded_Forces( reax_system *system, control_params *control,
 
 void Compute_Total_Force( reax_system *system, control_params *control,
                           simulation_data *data, storage *workspace,
-                          reax_list **lists, mpi_datatypes */*mpi_data*/ )
+                          reax_list **lists, mpi_datatypes * /*mpi_data*/ )
 {
   int i, pj;
   reax_list *bonds = (*lists) + BONDS;
@@ -114,7 +114,7 @@ void Compute_Total_Force( reax_system *system, control_params *control,
 
 }
 
-void Validate_Lists( reax_system *system, storage */*workspace*/, reax_list **lists,
+void Validate_Lists( reax_system *system, storage * /*workspace*/, reax_list **lists,
                      int step, int /*n*/, int N, int numH, MPI_Comm comm )
 {
   int i, comp, Hindex;
@@ -173,7 +173,7 @@ void Validate_Lists( reax_system *system, storage */*workspace*/, reax_list **li
 
 void Init_Forces_noQEq( reax_system *system, control_params *control,
                         simulation_data *data, storage *workspace,
-                        reax_list **lists, output_controls */*out_control*/,
+                        reax_list **lists, output_controls * /*out_control*/,
                         MPI_Comm comm ) {
   int i, j, pj;
   int start_i, end_i;

--- a/src/USER-REAXC/reaxc_hydrogen_bonds.cpp
+++ b/src/USER-REAXC/reaxc_hydrogen_bonds.cpp
@@ -33,7 +33,7 @@
 
 void Hydrogen_Bonds( reax_system *system, control_params *control,
                      simulation_data *data, storage *workspace,
-                     reax_list **lists, output_controls */*out_control*/ )
+                     reax_list **lists, output_controls * /*out_control*/ )
 {
   int  i, j, k, pi, pk;
   int  type_i, type_j, type_k;

--- a/src/USER-REAXC/reaxc_init_md.cpp
+++ b/src/USER-REAXC/reaxc_init_md.cpp
@@ -36,7 +36,7 @@
 #include "reaxc_tool_box.h"
 #include "reaxc_vector.h"
 
-int Init_System( reax_system *system, control_params *control, char */*msg*/ )
+int Init_System( reax_system *system, control_params *control, char * /*msg*/ )
 {
   int i;
   reax_atom *atom;
@@ -66,7 +66,7 @@ int Init_System( reax_system *system, control_params *control, char */*msg*/ )
 
 
 int Init_Simulation_Data( reax_system *system, control_params *control,
-                          simulation_data *data, char */*msg*/ )
+                          simulation_data *data, char * /*msg*/ )
 {
   Reset_Simulation_Data( data, control->virial );
 
@@ -139,8 +139,8 @@ int Init_Workspace( reax_system *system, control_params *control,
 
 
 /************** setup communication data structures  **************/
-int Init_MPI_Datatypes( reax_system *system, storage */*workspace*/,
-                        mpi_datatypes *mpi_data, MPI_Comm comm, char */*msg*/ )
+int Init_MPI_Datatypes( reax_system *system, storage * /*workspace*/,
+                        mpi_datatypes *mpi_data, MPI_Comm comm, char * /*msg*/ )
 {
 
   /* setup the world */
@@ -151,8 +151,8 @@ int Init_MPI_Datatypes( reax_system *system, storage */*workspace*/,
 }
 
 int  Init_Lists( reax_system *system, control_params *control,
-                 simulation_data */*data*/, storage */*workspace*/, reax_list **lists,
-                 mpi_datatypes *mpi_data, char */*msg*/ )
+                 simulation_data * /*data*/, storage * /*workspace*/, reax_list **lists,
+                 mpi_datatypes *mpi_data, char * /*msg*/ )
 {
   int i, total_hbonds, total_bonds, bond_cap, num_3body, cap_3body, Htop;
   int *hb_top, *bond_top;

--- a/src/USER-REAXC/reaxc_io_tools.cpp
+++ b/src/USER-REAXC/reaxc_io_tools.cpp
@@ -88,7 +88,7 @@ int Init_Output_Files( reax_system *system, control_params *control,
 
 /************************ close output files ************************/
 int Close_Output_Files( reax_system *system, control_params *control,
-                        output_controls *out_control, mpi_datatypes */*mpi_data*/ )
+                        output_controls *out_control, mpi_datatypes * /*mpi_data*/ )
 {
   if( out_control->write_steps > 0 )
     End_Traj( system->my_rank, out_control );

--- a/src/USER-REAXC/reaxc_lookup.cpp
+++ b/src/USER-REAXC/reaxc_lookup.cpp
@@ -151,7 +151,7 @@ void Complete_Cubic_Spline( const double *h, const double *f, double v0, double 
 
 
 int Init_Lookup_Tables( reax_system *system, control_params *control,
-                        storage *workspace, mpi_datatypes *mpi_data, char */*msg*/ )
+                        storage *workspace, mpi_datatypes *mpi_data, char * /*msg*/ )
 {
   int i, j, r;
   int num_atom_types;

--- a/src/USER-REAXC/reaxc_multi_body.cpp
+++ b/src/USER-REAXC/reaxc_multi_body.cpp
@@ -32,7 +32,7 @@
 
 void Atom_Energy( reax_system *system, control_params *control,
                   simulation_data *data, storage *workspace, reax_list **lists,
-                  output_controls */*out_control*/ )
+                  output_controls * /*out_control*/ )
 {
   int i, j, pj, type_i, type_j;
   double Delta_lpcorr, dfvl;

--- a/src/USER-REAXC/reaxc_nonbonded.cpp
+++ b/src/USER-REAXC/reaxc_nonbonded.cpp
@@ -33,7 +33,7 @@
 
 void vdW_Coulomb_Energy( reax_system *system, control_params *control,
                          simulation_data *data, storage *workspace,
-                         reax_list **lists, output_controls */*out_control*/ )
+                         reax_list **lists, output_controls * /*out_control*/ )
 {
   int i, j, pj, natoms;
   int start_i, end_i, flag;
@@ -206,7 +206,7 @@ void vdW_Coulomb_Energy( reax_system *system, control_params *control,
 void Tabulated_vdW_Coulomb_Energy( reax_system *system,control_params *control,
                                    simulation_data *data, storage *workspace,
                                    reax_list **lists,
-                                   output_controls */*out_control*/ )
+                                   output_controls * /*out_control*/ )
 {
   int i, j, pj, r, natoms;
   int type_i, type_j, tmin, tmax;

--- a/src/USER-REAXC/reaxc_torsion_angles.cpp
+++ b/src/USER-REAXC/reaxc_torsion_angles.cpp
@@ -41,7 +41,7 @@ double Calculate_Omega( rvec dvec_ij, double r_ij,
                       three_body_interaction_data *p_jkl,
                       rvec dcos_omega_di, rvec dcos_omega_dj,
                       rvec dcos_omega_dk, rvec dcos_omega_dl,
-                      output_controls */*out_control*/ )
+                      output_controls * /*out_control*/ )
 {
   double unnorm_cos_omega, unnorm_sin_omega, omega;
   double sin_ijk, cos_ijk, sin_jkl, cos_jkl;

--- a/src/USER-REAXC/reaxc_traj.cpp
+++ b/src/USER-REAXC/reaxc_traj.cpp
@@ -48,7 +48,7 @@ int Reallocate_Output_Buffer( output_controls *out_control, int req_space,
 }
 
 
-void Write_Skip_Line( output_controls *out_control, mpi_datatypes */*mpi_data*/,
+void Write_Skip_Line( output_controls *out_control, mpi_datatypes * /*mpi_data*/,
                       int my_rank, int skip, int num_section )
 {
   if( my_rank == MASTER_NODE )
@@ -259,7 +259,7 @@ int Write_Header( reax_system *system, control_params *control,
 }
 
 
-int Write_Init_Desc( reax_system *system, control_params */*control*/,
+int Write_Init_Desc( reax_system *system, control_params * /*control*/,
                      output_controls *out_control, mpi_datatypes *mpi_data )
 {
   int i, me, np, cnt, buffer_len, buffer_req;
@@ -482,7 +482,7 @@ int Write_Frame_Header( reax_system *system, control_params *control,
 
 
 
-int Write_Atoms( reax_system *system, control_params */*control*/,
+int Write_Atoms( reax_system *system, control_params * /*control*/,
                  output_controls *out_control, mpi_datatypes *mpi_data )
 {
   int i, me, np, line_len, buffer_len, buffer_req, cnt;

--- a/src/USER-REAXC/reaxc_valence_angles.cpp
+++ b/src/USER-REAXC/reaxc_valence_angles.cpp
@@ -76,7 +76,7 @@ void Calculate_dCos_Theta( rvec dvec_ji, double d_ji, rvec dvec_jk, double d_jk,
 
 void Valence_Angles( reax_system *system, control_params *control,
                      simulation_data *data, storage *workspace,
-                     reax_list **lists, output_controls */*out_control*/ )
+                     reax_list **lists, output_controls * /*out_control*/ )
 {
   int i, j, pi, k, pk, t;
   int type_i, type_j, type_k;

--- a/src/USER-SMD/atom_vec_smd.cpp
+++ b/src/USER-SMD/atom_vec_smd.cpp
@@ -208,7 +208,7 @@ void AtomVecSMD::copy(int i, int j, int delflag) {
 
 /* ---------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_comm(int /*n*/, int */*list*/, double */*buf*/, int /*pbc_flag*/, int */*pbc*/) {
+int AtomVecSMD::pack_comm(int /*n*/, int * /*list*/, double * /*buf*/, int /*pbc_flag*/, int * /*pbc*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
         return -1;
 }
@@ -333,7 +333,7 @@ int AtomVecSMD::pack_comm_hybrid(int n, int *list, double *buf) {
 
 /* ---------------------------------------------------------------------- */
 
-void AtomVecSMD::unpack_comm(int /*n*/, int /*first*/, double */*buf*/) {
+void AtomVecSMD::unpack_comm(int /*n*/, int /*first*/, double * /*buf*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
 }
 
@@ -441,7 +441,7 @@ int AtomVecSMD::unpack_reverse_hybrid(int n, int *list, double *buf) {
 
 /* ---------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_border(int /*n*/, int */*list*/, double */*buf*/, int /*pbc_flag*/, int */*pbc*/) {
+int AtomVecSMD::pack_border(int /*n*/, int * /*list*/, double * /*buf*/, int /*pbc_flag*/, int * /*pbc*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
         return -1;
 }
@@ -633,7 +633,7 @@ int AtomVecSMD::pack_border_hybrid(int n, int *list, double *buf) {
 
 /* ---------------------------------------------------------------------- */
 
-void AtomVecSMD::unpack_border(int /*n*/, int /*first*/, double */*buf*/) {
+void AtomVecSMD::unpack_border(int /*n*/, int /*first*/, double * /*buf*/) {
         error->one(FLERR, "atom vec tlsph can only be used with ghost velocities turned on");
 }
 
@@ -1158,7 +1158,7 @@ void AtomVecSMD::pack_data(double **buf) {
  pack hybrid atom info for data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_data_hybrid(int /*i*/, double */*buf*/) {
+int AtomVecSMD::pack_data_hybrid(int /*i*/, double * /*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return -1;
 }
@@ -1180,7 +1180,7 @@ void AtomVecSMD::write_data(FILE *fp, int n, double **buf) {
  write hybrid atom info to data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::write_data_hybrid(FILE */*fp*/, double */*buf*/) {
+int AtomVecSMD::write_data_hybrid(FILE * /*fp*/, double * /*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return -1;
 }
@@ -1203,7 +1203,7 @@ void AtomVecSMD::pack_vel(double **buf) {
  pack hybrid velocity info for data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::pack_vel_hybrid(int /*i*/, double */*buf*/) {
+int AtomVecSMD::pack_vel_hybrid(int /*i*/, double * /*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return 0;
 }
@@ -1222,7 +1222,7 @@ void AtomVecSMD::write_vel(FILE *fp, int n, double **buf) {
  write hybrid velocity info to data file
  ------------------------------------------------------------------------- */
 
-int AtomVecSMD::write_vel_hybrid(FILE */*fp*/, double */*buf*/) {
+int AtomVecSMD::write_vel_hybrid(FILE * /*fp*/, double * /*buf*/) {
         error->one(FLERR, "hybrid atom style functionality not yet implemented for atom style smd");
         return 3;
 }

--- a/src/USER-SMD/fix_smd_move_triangulated_surface.cpp
+++ b/src/USER-SMD/fix_smd_move_triangulated_surface.cpp
@@ -461,7 +461,7 @@ void FixSMDMoveTriSurf::reset_dt() {
 
 /* ---------------------------------------------------------------------- */
 
-int FixSMDMoveTriSurf::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
+int FixSMDMoveTriSurf::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/) {
         int i, j, m;
         double **x0 = atom->x0;
         double **smd_data_9 = atom->smd_data_9;

--- a/src/USER-SMD/fix_smd_tlsph_reference_configuration.cpp
+++ b/src/USER-SMD/fix_smd_tlsph_reference_configuration.cpp
@@ -512,7 +512,7 @@ int FixSMD_TLSPH_ReferenceConfiguration::size_restart(int nlocal) {
 
 /* ---------------------------------------------------------------------- */
 
-int FixSMD_TLSPH_ReferenceConfiguration::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
+int FixSMD_TLSPH_ReferenceConfiguration::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/) {
         int i, j, m;
         double *radius = atom->radius;
         double *vfrac = atom->vfrac;

--- a/src/USER-SMD/pair_smd_tlsph.cpp
+++ b/src/USER-SMD/pair_smd_tlsph.cpp
@@ -1839,7 +1839,7 @@ void *PairTlsph::extract(const char *str, int &/*i*/) {
 
 /* ---------------------------------------------------------------------- */
 
-int PairTlsph::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
+int PairTlsph::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/) {
         int i, j, m;
         tagint *mol = atom->molecule;
         double *damage = atom->damage;

--- a/src/USER-SMD/pair_smd_ulsph.cpp
+++ b/src/USER-SMD/pair_smd_ulsph.cpp
@@ -1487,7 +1487,7 @@ double PairULSPH::memory_usage() {
 
 /* ---------------------------------------------------------------------- */
 
-int PairULSPH::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/) {
+int PairULSPH::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/) {
         double *vfrac = atom->vfrac;
         double *eff_plastic_strain = atom->eff_plastic_strain;
         int i, j, m;

--- a/src/USER-SMTBQ/pair_smtbq.cpp
+++ b/src/USER-SMTBQ/pair_smtbq.cpp
@@ -3334,7 +3334,7 @@ void PairSMTBQ::groupQEqAllParallel_QEq()
 
 /* ---------------------------------------------------------------------- */
 
-void PairSMTBQ::Init_charge(int */*nQEq*/, int */*nQEqa*/, int */*nQEqc*/)
+void PairSMTBQ::Init_charge(int * /*nQEq*/, int * /*nQEqa*/, int * /*nQEqc*/)
 {
   int ii,i,gp,itype;
   int *ilist,test[nteam],init[nteam];
@@ -3391,7 +3391,7 @@ void PairSMTBQ::Init_charge(int */*nQEq*/, int */*nQEqa*/, int */*nQEqc*/)
  *                        COMMUNICATION
  * ---------------------------------------------------------------------- */
 
-int PairSMTBQ::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int */*pbc*/)
+int PairSMTBQ::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j,m;
 

--- a/src/USER-SPH/pair_sph_rhosum.cpp
+++ b/src/USER-SPH/pair_sph_rhosum.cpp
@@ -288,7 +288,7 @@ double PairSPHRhoSum::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/,
 /* ---------------------------------------------------------------------- */
 
 int PairSPHRhoSum::pack_forward_comm(int n, int *list, double *buf,
-                                     int /*pbc_flag*/, int */*pbc*/) {
+                                     int /*pbc_flag*/, int * /*pbc*/) {
   int i, j, m;
   double *rho = atom->rho;
 

--- a/src/accelerator_omp.h
+++ b/src/accelerator_omp.h
@@ -17,47 +17,6 @@
 
 // true interface to USER-OMP
 
-// this part is used inside the neighbor.h header file to
-// add functions to the Neighbor class definition
-
-#ifdef LMP_INSIDE_NEIGHBOR_H
-
-  void half_nsq_no_newton_omp(class NeighList *);
-  void half_nsq_no_newton_ghost_omp(class NeighList *);
-  void half_nsq_newton_omp(class NeighList *);
-
-  void half_bin_no_newton_omp(class NeighList *);
-  void half_bin_no_newton_ghost_omp(class NeighList *);
-  void half_bin_newton_omp(class NeighList *);
-  void half_bin_newton_tri_omp(class NeighList *);
-
-  void half_multi_no_newton_omp(class NeighList *);
-  void half_multi_newton_omp(class NeighList *);
-  void half_multi_newton_tri_omp(class NeighList *);
-
-  void full_nsq_omp(class NeighList *);
-  void full_nsq_ghost_omp(class NeighList *);
-  void full_bin_omp(class NeighList *);
-  void full_bin_ghost_omp(class NeighList *);
-  void full_multi_omp(class NeighList *);
-
-  void half_from_full_no_newton_omp(class NeighList *);
-  void half_from_full_newton_omp(class NeighList *);
-
-  void granular_nsq_no_newton_omp(class NeighList *);
-  void granular_nsq_newton_omp(class NeighList *);
-  void granular_bin_no_newton_omp(class NeighList *);
-  void granular_bin_newton_omp(class NeighList *);
-  void granular_bin_newton_tri_omp(class NeighList *);
-
-  void respa_nsq_no_newton_omp(class NeighList *);
-  void respa_nsq_newton_omp(class NeighList *);
-  void respa_bin_no_newton_omp(class NeighList *);
-  void respa_bin_newton_omp(class NeighList *);
-  void respa_bin_newton_tri_omp(class NeighList *);
-
-#else /* !LMP_INSIDE_NEIGHBOR_H */
-
 // provide a DomainOMP class with some overrides for Domain
 #include "domain.h"
 
@@ -68,8 +27,8 @@ namespace LAMMPS_NS {
 
 class DomainOMP : public Domain {
  public:
-  DomainOMP(class LAMMPS *lmp) : Domain(lmp) {};
-  virtual ~DomainOMP() {};
+  DomainOMP(class LAMMPS *lmp) : Domain(lmp) {}
+  virtual ~DomainOMP() {}
 
   // multi-threaded versions
   virtual void pbc();
@@ -81,48 +40,5 @@ class DomainOMP : public Domain {
 }
 
 #endif /* LMP_DOMAIN_OMP_H */
-#endif /* !LMP_INSIDE_NEIGHBOR_H */
-
-#else /* !LMP_USER_OMP */
-
-// dummy interface to USER-OMP
-// needed for compiling when USER-OMP is not installed
-
-#ifdef LMP_INSIDE_NEIGHBOR_H
-
-  void half_nsq_no_newton_omp(class NeighList *) {}
-  void half_nsq_no_newton_ghost_omp(class NeighList *) {}
-  void half_nsq_newton_omp(class NeighList *) {}
-
-  void half_bin_no_newton_omp(class NeighList *) {}
-  void half_bin_no_newton_ghost_omp(class NeighList *) {}
-  void half_bin_newton_omp(class NeighList *) {}
-  void half_bin_newton_tri_omp(class NeighList *) {}
-
-  void half_multi_no_newton_omp(class NeighList *) {}
-  void half_multi_newton_omp(class NeighList *) {}
-  void half_multi_newton_tri_omp(class NeighList *) {}
-
-  void full_nsq_omp(class NeighList *) {}
-  void full_nsq_ghost_omp(class NeighList *) {}
-  void full_bin_omp(class NeighList *) {}
-  void full_bin_ghost_omp(class NeighList *) {}
-  void full_multi_omp(class NeighList *) {}
-
-  void half_from_full_no_newton_omp(class NeighList *) {}
-  void half_from_full_newton_omp(class NeighList *) {}
-
-  void granular_nsq_no_newton_omp(class NeighList *) {}
-  void granular_nsq_newton_omp(class NeighList *) {}
-  void granular_bin_no_newton_omp(class NeighList *) {}
-  void granular_bin_newton_omp(class NeighList *) {}
-  void granular_bin_newton_tri_omp(class NeighList *) {}
-
-  void respa_nsq_no_newton_omp(class NeighList *) {}
-  void respa_nsq_newton_omp(class NeighList *) {}
-  void respa_bin_no_newton_omp(class NeighList *) {}
-  void respa_bin_newton_omp(class NeighList *) {}
-  void respa_bin_newton_tri_omp(class NeighList *) {}
-#endif
 
 #endif /* !LMP_USER_OMP */

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -292,7 +292,7 @@ void FixPropertyAtom::read_data_section(char *keyword, int n, char *buf,
    return # of lines in section of data file labeled by keyword
 ------------------------------------------------------------------------- */
 
-bigint FixPropertyAtom::read_data_skip_lines(char */*keyword*/)
+bigint FixPropertyAtom::read_data_skip_lines(char * /*keyword*/)
 {
   return atom->natoms;
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -992,7 +992,6 @@ void Image::compute_SSAO()
 
 void Image::write_JPG(FILE *fp)
 {
-  (void)(fp); // suppress unused parameter warning
 #ifdef LAMMPS_JPEG
   struct jpeg_compress_struct cinfo;
   struct jpeg_error_mgr jerr;
@@ -1018,6 +1017,8 @@ void Image::write_JPG(FILE *fp)
 
   jpeg_finish_compress(&cinfo);
   jpeg_destroy_compress(&cinfo);
+#else
+  LMP_UNUSED_PARAM(fp);
 #endif
 }
 
@@ -1025,7 +1026,6 @@ void Image::write_JPG(FILE *fp)
 
 void Image::write_PNG(FILE *fp)
 {
-  (void)(fp); // suppress unused parameter warning
 #ifdef LAMMPS_PNG
   png_structp png_ptr;
   png_infop info_ptr;
@@ -1076,6 +1076,8 @@ void Image::write_PNG(FILE *fp)
 
   png_destroy_write_struct(&png_ptr, &info_ptr);
   delete[] row_pointers;
+#else
+  LMP_UNUSED_PARAM(fp);
 #endif
 }
 

--- a/src/improper_zero.cpp
+++ b/src/improper_zero.cpp
@@ -99,13 +99,13 @@ void ImproperZero::coeff(int narg, char **arg)
    proc 0 writes out coeffs to restart file
 ------------------------------------------------------------------------- */
 
-void ImproperZero::write_restart(FILE */*fp*/) {}
+void ImproperZero::write_restart(FILE * /*fp*/) {}
 
 /* ----------------------------------------------------------------------
    proc 0 reads coeffs from restart file, bcasts them
 ------------------------------------------------------------------------- */
 
-void ImproperZero::read_restart(FILE */*fp*/)
+void ImproperZero::read_restart(FILE * /*fp*/)
 {
   allocate();
   for (int i = 1; i <= atom->nimpropertypes; i++) setflag[i] = 1;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -336,7 +336,7 @@ void lammps_free(void *ptr)
    customize by adding names
 ------------------------------------------------------------------------- */
 
-int lammps_extract_setting(void */*ptr*/, char *name)
+int lammps_extract_setting(void * /*ptr*/, char *name)
 {
   if (strcmp(name,"bigint") == 0) return sizeof(bigint);
   if (strcmp(name,"tagint") == 0) return sizeof(tagint);

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -213,6 +213,8 @@ typedef int bigint;
 #include "lmpwindows.h"
 #endif
 
-#define LMP_UNUSED_PARAM(x) (void)x
+// suppress unused parameter warning
+
+#define LMP_UNUSED_PARAM(x) (void)(x)
 
 #endif

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -213,4 +213,6 @@ typedef int bigint;
 #include "lmpwindows.h"
 #endif
 
+#define LMP_UNUSED_PARAM(x) (void)x
+
 #endif

--- a/src/rcb.cpp
+++ b/src/rcb.cpp
@@ -1108,7 +1108,7 @@ void RCB::compute_old(int dimension, int n, double **x, double *wt,
    merge of each component of an RCB bounding box
 ------------------------------------------------------------------------- */
 
-void box_merge(void *in, void *inout, int */*len*/, MPI_Datatype */*dptr*/)
+void box_merge(void *in, void *inout, int * /*len*/, MPI_Datatype * /*dptr*/)
 
 {
   RCB::BBox *box1 = (RCB::BBox *) in;
@@ -1138,7 +1138,7 @@ void box_merge(void *in, void *inout, int */*len*/, MPI_Datatype */*dptr*/)
                                   all procs must get same proclo,prochi
 ------------------------------------------------------------------------- */
 
-void median_merge(void *in, void *inout, int */*len*/, MPI_Datatype */*dptr*/)
+void median_merge(void *in, void *inout, int * /*len*/, MPI_Datatype * /*dptr*/)
 
 {
   RCB::Median *med1 = (RCB::Median *) in;


### PR DESCRIPTION
## Purpose
- fixes a compilation issue introduced by #1077, due to conditional compilation such as `-DLMP_USER_OMP`
- add missing `LMP_USER_OMP` definition to CMake build which was exposed by fixing this
- add missing `domain_omp.cpp`
- cleans up `accelerator_omp.h`
- add additional space to avoid code highlighting issues

closes #1076 

## Author(s)

@rbberger

## Backward Compatibility

yes

## Implementation Notes

Added `LMP_UNUSED_PARAM` macro to create empty statements to suppress unused parameter warnings and documenting that case at the same time.

**Usage:**
```cpp
#ifdef LMP_USER_OMP
   // only code path using variable x
#else
  LMP_UNUSED_PARAM(x);
#endif
```

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines


