### PR TITLE
Silence  USER-CGSD warnings

### DIFF
--- a/src/USER-CGSDK/lj_sdk_common.h
+++ b/src/USER-CGSDK/lj_sdk_common.h
@@ -27,6 +27,7 @@ namespace LJSDKParms {
   // LJ type flags. list of supported LJ exponent combinations
   enum {LJ_NOT_SET=0, LJ9_6, LJ12_4, LJ12_6, NUM_LJ_TYPES};
 
+#if defined(LMP_NEED_FIND_SDK_LJ_TYPE)
   static int find_lj_type(const char *label,
                           const char * const * const list) {
     for (int i=0; i < NUM_LJ_TYPES; ++i)
@@ -34,6 +35,7 @@ namespace LJSDKParms {
 
     return LJ_NOT_SET;
   }
+#endif
 
   static const char * const lj_type_list[] = {"none", "lj9_6", "lj12_4", "lj12_6"};
   static const double lj_prefact[] = {0.0, 6.75,  2.59807621135332, 4.0};

--- a/src/USER-CGSDK/lj_sdk_common.h
+++ b/src/USER-CGSDK/lj_sdk_common.h
@@ -27,7 +27,7 @@ namespace LJSDKParms {
   // LJ type flags. list of supported LJ exponent combinations
   enum {LJ_NOT_SET=0, LJ9_6, LJ12_4, LJ12_6, NUM_LJ_TYPES};
 
-#if defined(LMP_NEED_FIND_SDK_LJ_TYPE)
+#if defined(LMP_NEED_SDK_FIND_LJ_TYPE)
   static int find_lj_type(const char *label,
                           const char * const * const list) {
     for (int i=0; i < NUM_LJ_TYPES; ++i)

--- a/src/USER-CGSDK/pair_lj_sdk.cpp
+++ b/src/USER-CGSDK/pair_lj_sdk.cpp
@@ -33,7 +33,7 @@
 #include "memory.h"
 #include "error.h"
 
-#define LMP_NEED_FIND_SDK_LJ_TYPE 1
+#define LMP_NEED_SDK_FIND_LJ_TYPE 1
 #include "lj_sdk_common.h"
 
 using namespace LAMMPS_NS;

--- a/src/USER-CGSDK/pair_lj_sdk.cpp
+++ b/src/USER-CGSDK/pair_lj_sdk.cpp
@@ -33,6 +33,7 @@
 #include "memory.h"
 #include "error.h"
 
+#define LMP_NEED_FIND_SDK_LJ_TYPE 1
 #include "lj_sdk_common.h"
 
 using namespace LAMMPS_NS;

--- a/src/USER-CGSDK/pair_lj_sdk_coul_long.cpp
+++ b/src/USER-CGSDK/pair_lj_sdk_coul_long.cpp
@@ -34,6 +34,7 @@
 #include "memory.h"
 #include "error.h"
 
+#define LMP_NEED_FIND_SDK_LJ_TYPE 1
 #include "lj_sdk_common.h"
 
 using namespace LAMMPS_NS;

--- a/src/USER-CGSDK/pair_lj_sdk_coul_long.cpp
+++ b/src/USER-CGSDK/pair_lj_sdk_coul_long.cpp
@@ -34,7 +34,7 @@
 #include "memory.h"
 #include "error.h"
 
-#define LMP_NEED_FIND_SDK_LJ_TYPE 1
+#define LMP_NEED_SDK_FIND_LJ_TYPE 1
 #include "lj_sdk_common.h"
 
 using namespace LAMMPS_NS;


### PR DESCRIPTION
## Purpose

This silences an annoying warning about an unused static function in a header shared across all USER-SDK styles.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes.

## Implementation Notes

`#define LMP_NEED_SDK_FIND_LJ_TYPE 1` is now required to be set before including `lj_sdk_common.h` in case the (static/inlined) function `LJSDKParams::find_lj_type()` is required.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines



