### PR TITLE
Add core tests to CMake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -136,6 +136,7 @@ if(BUILD_EXE)
   if(LAMMPS_MACHINE)
     set(LAMMPS_MACHINE "_${LAMMPS_MACHINE}")
   endif()
+  set(LAMMPS_BINARY lmp${LAMMPS_MACHINE})
 endif()
 
 option(BUILD_LIB "Build LAMMPS library" OFF)
@@ -208,6 +209,38 @@ option(CMAKE_VERBOSE_MAKEFILE "Verbose makefile" OFF)
 option(ENABLE_TESTING "Enable testing" OFF)
 if(ENABLE_TESTING)
   enable_testing()
+
+  if (CMAKE_VERSION VERSION_GREATER "3.10.3") # due to FetchContent
+    include(FetchContent)
+
+
+    FetchContent_Declare(lammps-testing
+      GIT_REPOSITORY https://github.com/lammps/lammps-testing.git
+      GIT_TAG master
+    )
+
+    FetchContent_GetProperties(lammps-testing)
+    if(NOT lammps-testing_POPULATED)
+      message(STATUS "Downloading tests...")
+      FetchContent_Populate(lammps-testing)
+    endif()
+    message(STATUS "Running test discovery...")
+
+    file(GLOB_RECURSE TEST_SCRIPTS ${lammps-testing_SOURCE_DIR}/tests/core/*/in.*)
+    foreach(script_path ${TEST_SCRIPTS})
+      get_filename_component(TEST_NAME ${script_path} EXT)
+      get_filename_component(SCRIPT_NAME ${script_path} NAME)
+      get_filename_component(PARENT_DIR ${script_path} DIRECTORY)
+      string(SUBSTRING ${TEST_NAME} 1 -1 TEST_NAME)
+      string(REPLACE "-" "_" TEST_NAME ${TEST_NAME})
+      string(REPLACE "+" "_" TEST_NAME ${TEST_NAME})
+      set(TEST_NAME "test_core_${TEST_NAME}_serial")
+      add_test(${TEST_NAME} ${CMAKE_BINARY_DIR}/${LAMMPS_BINARY} -in ${SCRIPT_NAME})
+      set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${PARENT_DIR})
+    endforeach()
+  else()
+    message(WARNING "Full test-suite requires CMake >= 3.11")
+  endif()
 endif(ENABLE_TESTING)
 
 set(DEFAULT_PACKAGES ASPHERE BODY CLASS2 COLLOID COMPRESS DIPOLE GRANULAR
@@ -1119,11 +1152,11 @@ if(BUILD_EXE)
     endif()
   endif()
   
-  set_target_properties(lmp PROPERTIES OUTPUT_NAME lmp${LAMMPS_MACHINE})
+  set_target_properties(lmp PROPERTIES OUTPUT_NAME ${LAMMPS_BINARY})
   install(TARGETS lmp DESTINATION ${CMAKE_INSTALL_BINDIR})
-  install(FILES ${LAMMPS_DOC_DIR}/lammps.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 RENAME lmp${LAMMPS_MACHINE}.1)
+  install(FILES ${LAMMPS_DOC_DIR}/lammps.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 RENAME ${LAMMPS_BINARY}.1)
   if(ENABLE_TESTING)
-    add_test(ShowHelp lmp${LAMMPS_MACHINE} -help)
+    add_test(ShowHelp ${LAMMPS_BINARY} -help)
   endif()
 endif()
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -209,14 +209,16 @@ option(CMAKE_VERBOSE_MAKEFILE "Verbose makefile" OFF)
 option(ENABLE_TESTING "Enable testing" OFF)
 if(ENABLE_TESTING)
   enable_testing()
+  option(LAMMPS_TESTING_SOURCE_DIR "Location of lammps-testing source directory" "")
+  option(LAMMPS_TESTING_GIT_TAG    "Git tag of lammps-testing" "master")
+  mark_as_advanced(LAMMPS_TESTING_SOURCE_DIR LAMMPS_TESTING_GIT_TAG)
 
-  if (CMAKE_VERSION VERSION_GREATER "3.10.3") # due to FetchContent
+  if (CMAKE_VERSION VERSION_GREATER "3.10.3" AND NOT LAMMPS_TESTING_SOURCE_DIR)
     include(FetchContent)
-
 
     FetchContent_Declare(lammps-testing
       GIT_REPOSITORY https://github.com/lammps/lammps-testing.git
-      GIT_TAG master
+      GIT_TAG ${LAMMPS_TESTING_GIT_TAG}
     )
 
     FetchContent_GetProperties(lammps-testing)
@@ -224,9 +226,17 @@ if(ENABLE_TESTING)
       message(STATUS "Downloading tests...")
       FetchContent_Populate(lammps-testing)
     endif()
+
+    set(LAMMPS_TESTING_SOURCE_DIR ${lammps-testing_SOURCE_DIR})
+  elseif(NOT LAMMPS_TESTING_SOURCE_DIR)
+    message(WARNING "Full test-suite requires CMake >= 3.11 or copy of\n"
+                    "https://github.com/lammps/lammps-testing in LAMMPS_TESTING_SOURCE_DIR")
+  endif()
+
+  if(EXISTS ${LAMMPS_TESTING_SOURCE_DIR})
     message(STATUS "Running test discovery...")
 
-    file(GLOB_RECURSE TEST_SCRIPTS ${lammps-testing_SOURCE_DIR}/tests/core/*/in.*)
+    file(GLOB_RECURSE TEST_SCRIPTS ${LAMMPS_TESTING_SOURCE_DIR}/tests/core/*/in.*)
     foreach(script_path ${TEST_SCRIPTS})
       get_filename_component(TEST_NAME ${script_path} EXT)
       get_filename_component(SCRIPT_NAME ${script_path} NAME)
@@ -238,8 +248,9 @@ if(ENABLE_TESTING)
       add_test(${TEST_NAME} ${CMAKE_BINARY_DIR}/${LAMMPS_BINARY} -in ${SCRIPT_NAME})
       set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${PARENT_DIR})
     endforeach()
-  else()
-    message(WARNING "Full test-suite requires CMake >= 3.11")
+    list(LENGTH TEST_SCRIPTS NUM_TESTS)
+
+    message(STATUS "Found ${NUM_TESTS} tests.")
   endif()
 endif(ENABLE_TESTING)
 


### PR DESCRIPTION
## Purpose

Add core test suite to CMake build. It downloads the https://github.com/lammps/lammps-testing repository, which contains our collections of LAMMPS tests. `core` tests should only use features that work without any other packages.

**Example:**
```bash
mkdir build
cd build
cmake -D ENABLE_TESTING=yes ../cmake
make
make test
```

## Author(s)

@rbberger

## Implementation Notes

Requires CMake 3.11 if lammps-testing repo should be fetched. By default it will get `master`, but different commits/tags can be selected by specifying `LAMMPS_TESTING_GIT_TAG`. For older CMake versions lammps-testing must be downloaded separately and its location specified using `LAMMPS_TESTING_SOURCE_DIR`.

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines


