### PR TITLE
Avoid unnecessary sorting in print_columns

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -44,7 +44,7 @@
 #include "error.h"
 
 #include <ctime>
-#include <vector>
+#include <map>
 #include <string>
 #include <algorithm>
 
@@ -117,7 +117,8 @@ static const char bstyles[] = "pfsm";
 using namespace LAMMPS_NS;
 using namespace std;
 
-static void print_columns(FILE* fp, vector<string> & styles);
+template<typename ValueType>
+static void print_columns(FILE* fp, map<string, ValueType> * styles);
 
 /* ---------------------------------------------------------------------- */
 
@@ -686,196 +687,98 @@ void Info::available_styles(FILE * out, int flags)
 void Info::atom_styles(FILE * out)
 {
   fprintf(out, "\nAtom styles:\n");
-
-  vector<string> styles;
-
-  for(Atom::AtomVecCreatorMap::iterator it = atom->avec_map->begin(); it != atom->avec_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, atom->avec_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::integrate_styles(FILE * out)
 {
   fprintf(out, "\nIntegrate styles:\n");
-
-  vector<string> styles;
-
-  for(Update::IntegrateCreatorMap::iterator it = update->integrate_map->begin(); it != update->integrate_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, update->integrate_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::minimize_styles(FILE * out)
 {
   fprintf(out, "\nMinimize styles:\n");
-
-  vector<string> styles;
-
-  for(Update::MinimizeCreatorMap::iterator it = update->minimize_map->begin(); it != update->minimize_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, update->minimize_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::pair_styles(FILE * out)
 {
   fprintf(out, "\nPair styles:\n");
-
-  vector<string> styles;
-
-  for(Force::PairCreatorMap::iterator it = force->pair_map->begin(); it != force->pair_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, force->pair_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::bond_styles(FILE * out)
 {
   fprintf(out, "\nBond styles:\n");
-
-  vector<string> styles;
-
-  for(Force::BondCreatorMap::iterator it = force->bond_map->begin(); it != force->bond_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, force->bond_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::angle_styles(FILE * out)
 {
   fprintf(out, "\nAngle styles:\n");
-
-  vector<string> styles;
-
-  for(Force::AngleCreatorMap::iterator it = force->angle_map->begin(); it != force->angle_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, force->angle_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::dihedral_styles(FILE * out)
 {
   fprintf(out, "\nDihedral styles:\n");
-
-  vector<string> styles;
-
-  for(Force::DihedralCreatorMap::iterator it = force->dihedral_map->begin(); it != force->dihedral_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, force->dihedral_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::improper_styles(FILE * out)
 {
   fprintf(out, "\nImproper styles:\n");
-
-  vector<string> styles;
-
-  for(Force::ImproperCreatorMap::iterator it = force->improper_map->begin(); it != force->improper_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, force->improper_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::kspace_styles(FILE * out)
 {
   fprintf(out, "\nKSpace styles:\n");
-
-  vector<string> styles;
-
-  for(Force::KSpaceCreatorMap::iterator it = force->kspace_map->begin(); it != force->kspace_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, force->kspace_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::fix_styles(FILE * out)
 {
   fprintf(out, "\nFix styles:\n");
-
-  vector<string> styles;
-
-  for(Modify::FixCreatorMap::iterator it = modify->fix_map->begin(); it != modify->fix_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, modify->fix_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::compute_styles(FILE * out)
 {
   fprintf(out, "\nCompute styles:\n");
-
-  vector<string> styles;
-
-  for(Modify::ComputeCreatorMap::iterator it = modify->compute_map->begin(); it != modify->compute_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, modify->compute_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::region_styles(FILE * out)
 {
   fprintf(out, "\nRegion styles:\n");
-
-  vector<string> styles;
-
-  for(Domain::RegionCreatorMap::iterator it = domain->region_map->begin(); it != domain->region_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, domain->region_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::dump_styles(FILE * out)
 {
   fprintf(out, "\nDump styles:\n");
-
-  vector<string> styles;
-
-  for(Output::DumpCreatorMap::iterator it = output->dump_map->begin(); it != output->dump_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, output->dump_map);
   fprintf(out, "\n\n\n");
 }
 
 void Info::command_styles(FILE * out)
 {
   fprintf(out, "\nCommand styles (add-on input script commands):\n");
-
-  vector<string> styles;
-
-  for(Input::CommandCreatorMap::iterator it = input->command_map->begin(); it != input->command_map->end(); ++it) {
-    styles.push_back(it->first);
-  }
-
-  print_columns(out, styles);
+  print_columns(out, input->command_map);
   fprintf(out, "\n\n\n");
 }
 
@@ -1110,41 +1013,42 @@ bool Info::is_defined(const char *category, const char *name)
   return false;
 }
 
-static void print_columns(FILE* fp, vector<string> & styles)
+template<typename ValueType>
+static void print_columns(FILE* fp, map<string, ValueType> * styles)
 {
-  if (styles.size() == 0) {
+  if (styles->empty()) {
     fprintf(fp, "\nNone");
     return;
   }
 
-  std::sort(styles.begin(), styles.end());
-
+  // std::map keys are already sorted
   int pos = 80;
-  for (int i = 0; i < styles.size(); ++i) {
+  for(typename map<string, ValueType>::iterator it = styles->begin(); it != styles->end(); ++it) {
+    const string & style_name = it->first;
 
     // skip "secret" styles
-    if (isupper(styles[i][0])) continue;
+    if (isupper(style_name[0])) continue;
 
-    int len = styles[i].length();
+    int len = style_name.length();
     if (pos + len > 80) {
       fprintf(fp,"\n");
       pos = 0;
     }
 
     if (len < 16) {
-      fprintf(fp,"%-16s",styles[i].c_str());
+      fprintf(fp,"%-16s", style_name.c_str());
       pos += 16;
     } else if (len < 32) {
-      fprintf(fp,"%-32s",styles[i].c_str());
+      fprintf(fp,"%-32s", style_name.c_str());
       pos += 32;
     } else if (len < 48) {
-      fprintf(fp,"%-48s",styles[i].c_str());
+      fprintf(fp,"%-48s", style_name.c_str());
       pos += 48;
     } else if (len < 64) {
-      fprintf(fp,"%-64s",styles[i].c_str());
+      fprintf(fp,"%-64s", style_name.c_str());
       pos += 64;
     } else {
-      fprintf(fp,"%-80s",styles[i].c_str());
+      fprintf(fp,"%-80s", style_name.c_str());
       pos += 80;
     }
   }


### PR DESCRIPTION
## Purpose

Simplify info command code.

## Author(s)

@rbberger

## Backward Compatibility

yes. Identical output with `lmp -h`. Even produces a marginally smaller binary.

## Implementation Notes

std::map is a sorted associative container. We don't need to first copy it into a vector and sort that one.
`print_columns` has been refactored as a template function and makes use of this property.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

