### PR TITLE
Avoid buffer overflow during errors with long filenames

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -75,7 +75,7 @@ void Error::universe_all(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
+  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, truncpath(file), line);
   throw LAMMPSException(msg);
 #else
   MPI_Finalize();
@@ -100,7 +100,7 @@ void Error::universe_one(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
+  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, truncpath(file), line);
   throw LAMMPSAbortException(msg, universe->uworld);
 #else
   MPI_Abort(universe->uworld,1);
@@ -151,7 +151,7 @@ void Error::all(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
+  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, truncpath(file), line);
 
   if (universe->nworlds > 1) {
     throw LAMMPSAbortException(msg, universe->uworld);
@@ -201,7 +201,7 @@ void Error::one(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR on proc %d: %s (%s:%d)\n", me, str, file, line);
+  snprintf(msg, 100, "ERROR on proc %d: %s (%s:%d)\n", me, str, truncpath(file), line);
   throw LAMMPSAbortException(msg, world);
 #else
   MPI_Abort(world,1);


### PR DESCRIPTION
## Purpose

Fixes issue #1104 

## Author(s)

@rbberger

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines


