### PR TITLE
Avoid more buffer overflows through sprintf with long file names and exceptions

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -75,7 +75,7 @@ void Error::universe_all(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
+  snprintf(msg,100,"ERROR: %s (%s:%d)\n", str, file, line);
   throw LAMMPSException(msg);
 #else
   MPI_Finalize();
@@ -100,7 +100,7 @@ void Error::universe_one(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
+  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, file, line);
   throw LAMMPSAbortException(msg, universe->uworld);
 #else
   MPI_Abort(universe->uworld,1);
@@ -151,7 +151,7 @@ void Error::all(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR: %s (%s:%d)\n", str, file, line);
+  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, file, line);
 
   if (universe->nworlds > 1) {
     throw LAMMPSAbortException(msg, universe->uworld);
@@ -201,7 +201,7 @@ void Error::one(const char *file, int line, const char *str)
   update->whichflag = 0;
 
   char msg[100];
-  sprintf(msg, "ERROR on proc %d: %s (%s:%d)\n", me, str, file, line);
+  sprintf(msg, 100, "ERROR on proc %d: %s (%s:%d)\n", me, str, file, line);
   throw LAMMPSAbortException(msg, world);
 #else
   MPI_Abort(world,1);


### PR DESCRIPTION
## Purpose

This pull request addresses additional issues where text of unchecked length is copied with sprintf() into a fixed size buffer and thus can cause a segfault or worse through a buffer overflow.

## Author(s)

Axel Kohlmeyer and the Indonesia LAMMPS Tutorial Participants

## Backward Compatibility

Yes,

## Implementation Notes

We used to avoid snprintf() because it is not portable to windows, but this has changed with Visual C++ 2015.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [n/a ] Suitable new documentation files and/or updates to the existing docs are included
- [n/a] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
