### PR TITLE
Avoid more buffer overflows due to using snprintf() on fixed size buffers

### DIFF
--- a/src/GPU/pair_eam_alloy_gpu.cpp
+++ b/src/GPU/pair_eam_alloy_gpu.cpp
@@ -364,7 +364,7 @@ void PairEAMAlloyGPU::read_file(char *filename)
     fptr = fopen(filename,"r");
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/GPU/pair_eam_fs_gpu.cpp
+++ b/src/GPU/pair_eam_fs_gpu.cpp
@@ -364,7 +364,7 @@ void PairEAMFSGPU::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/GRANULAR/fix_wall_gran_region.cpp
+++ b/src/GRANULAR/fix_wall_gran_region.cpp
@@ -113,16 +113,16 @@ void FixWallGranRegion::init()
       strcmp(region_style,region->style) != 0 ||
       nregion != region->nregion) {
     char str[256];
-    sprintf(str,"Region properties for region %s changed between runs, "
-            "resetting its motion",idregion);
+    snprintf(str,256,"Region properties for region %s changed between runs, "
+             "resetting its motion",idregion);
     error->warning(FLERR,str);
     region->reset_vel();
   }
 
   if (motion_resetflag){
     char str[256];
-    sprintf(str,"Region properties for region %s are inconsistent "
-            "with restart file, resetting its motion",idregion);
+    snprintf(str,256,"Region properties for region %s are inconsistent "
+             "with restart file, resetting its motion",idregion);
     error->warning(FLERR,str);
     region->reset_vel();
   }

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -992,7 +992,7 @@ void PairEAMAlloyKokkos<DeviceType>::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/KOKKOS/pair_eam_fs_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_fs_kokkos.cpp
@@ -992,7 +992,7 @@ void PairEAMFSKokkos<DeviceType>::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/KOKKOS/pair_exp6_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_exp6_rx_kokkos.cpp
@@ -1725,7 +1725,7 @@ void PairExp6rxKokkos<DeviceType>::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open exp6/rx potential file %s",file);
+      snprintf(str,128,"Cannot open exp6/rx potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/fix_qeq_comb.cpp
+++ b/src/MANYBODY/fix_qeq_comb.cpp
@@ -67,7 +67,7 @@ FixQEQComb::FixQEQComb(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg),
         fp = fopen(arg[iarg+1],"w");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix qeq/comb file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open fix qeq/comb file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -551,7 +551,7 @@ void PairADP::read_file(char *filename)
     fp = force->open_potential(filename);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open ADP potential file %s",filename);
+      snprintf(str,128,"Cannot open ADP potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -3373,9 +3373,9 @@ void PairAIREBO::read_file(char *filename)
     if (fp == NULL) {
       char str[128];
       if (morseflag)
-        sprintf(str,"Cannot open AIREBO-M potential file %s",filename);
+        snprintf(str,128,"Cannot open AIREBO-M potential file %s",filename);
       else
-        sprintf(str,"Cannot open AIREBO potential file %s",filename);
+        snprintf(str,128,"Cannot open AIREBO potential file %s",filename);
       error->one(FLERR,str);
     }
 

--- a/src/MANYBODY/pair_bop.cpp
+++ b/src/MANYBODY/pair_bop.cpp
@@ -4976,7 +4976,7 @@ void PairBOP::read_table(char *filename)
     FILE *fp = force->open_potential(filename);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open BOP potential file %s",filename);
+      snprintf(str,128,"Cannot open BOP potential file %s",filename);
       error->one(FLERR,str);
     }
     fgets(s,MAXLINE,fp);  // skip first comment line
@@ -5079,7 +5079,7 @@ void PairBOP::read_table(char *filename)
     FILE *fp = force->open_potential(filename);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open BOP potential file %s",filename);
+      snprintf(str,128,"Cannot open BOP potential file %s",filename);
       error->one(FLERR,str);
     }
     fgets(s,MAXLINE,fp);  // skip first comment line

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -597,7 +597,7 @@ void PairComb::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open COMB potential file %s",file);
+      snprintf(str,128,"Cannot open COMB potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -320,11 +320,7 @@ void PairComb3::read_lib()
 
   if (comm->me == 0) {
     FILE *fp = force->open_potential("lib.comb3");
-    if (fp == NULL) {
-      char str[128];
-      sprintf(str,"Cannot open COMB3 lib.comb3 file");
-      error->one(FLERR,str);
-    }
+    if (fp == NULL) error->one(FLERR,"Cannot open COMB3 lib.comb3 file");
 
     // read and store at the same time
     fgets(s,MAXLIB,fp);
@@ -607,7 +603,7 @@ void PairComb3::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open COMB3 potential file %s",file);
+      snprintf(str,128,"Cannot open COMB3 potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -460,7 +460,7 @@ void PairEAM::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_eam_alloy.cpp
+++ b/src/MANYBODY/pair_eam_alloy.cpp
@@ -127,7 +127,7 @@ void PairEAMAlloy::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_eam_cd.cpp
+++ b/src/MANYBODY/pair_eam_cd.cpp
@@ -504,7 +504,7 @@ void PairEAMCD::read_h_coeff(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s", filename);
+      snprintf(str,128,"Cannot open EAM potential file %s", filename);
       error->one(FLERR,str);
     }
 

--- a/src/MANYBODY/pair_eam_fs.cpp
+++ b/src/MANYBODY/pair_eam_fs.cpp
@@ -127,7 +127,7 @@ void PairEAMFS::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_eim.cpp
+++ b/src/MANYBODY/pair_eim.cpp
@@ -461,7 +461,7 @@ void PairEIM::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EIM potential file %s",filename);
+      snprintf(str,128,"Cannot open EIM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_gw.cpp
+++ b/src/MANYBODY/pair_gw.cpp
@@ -381,7 +381,7 @@ void PairGW::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open GW potential file %s",file);
+      snprintf(str,128,"Cannot open GW potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_gw_zbl.cpp
+++ b/src/MANYBODY/pair_gw_zbl.cpp
@@ -77,7 +77,7 @@ void PairGWZBL::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open GW potential file %s",file);
+      snprintf(str,128,"Cannot open GW potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_lcbop.cpp
+++ b/src/MANYBODY/pair_lcbop.cpp
@@ -978,7 +978,7 @@ void PairLCBOP::read_file(char *filename)
     FILE *fp = force->open_potential(filename);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open LCBOP potential file %s",filename);
+      snprintf(str,128,"Cannot open LCBOP potential file %s",filename);
       error->one(FLERR,str);
     }
 

--- a/src/MANYBODY/pair_nb3b_harmonic.cpp
+++ b/src/MANYBODY/pair_nb3b_harmonic.cpp
@@ -299,7 +299,7 @@ void PairNb3bHarmonic::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open nb3b/harmonic potential file %s",file);
+      snprintf(str,128,"Cannot open nb3b/harmonic potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_polymorphic.cpp
+++ b/src/MANYBODY/pair_polymorphic.cpp
@@ -573,7 +573,7 @@ void PairPolymorphic::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open polymorphic potential file %s",file);
+      snprintf(str,128,"Cannot open polymorphic potential file %s",file);
       error->one(FLERR,str);
     }
     // move past comments to first data line

--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -363,7 +363,7 @@ void PairSW::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Stillinger-Weber potential file %s",file);
+      snprintf(str,128,"Cannot open Stillinger-Weber potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -404,7 +404,7 @@ void PairTersoff::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Tersoff potential file %s",file);
+      snprintf(str,128,"Cannot open Tersoff potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_tersoff_mod.cpp
+++ b/src/MANYBODY/pair_tersoff_mod.cpp
@@ -60,7 +60,7 @@ void PairTersoffMOD::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Tersoff potential file %s",file);
+      snprintf(str,128,"Cannot open Tersoff potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_tersoff_mod_c.cpp
+++ b/src/MANYBODY/pair_tersoff_mod_c.cpp
@@ -55,7 +55,7 @@ void PairTersoffMODC::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Tersoff potential file %s",file);
+      snprintf(str,128,"Cannot open Tersoff potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_tersoff_zbl.cpp
+++ b/src/MANYBODY/pair_tersoff_zbl.cpp
@@ -77,7 +77,7 @@ void PairTersoffZBL::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Tersoff potential file %s",file);
+      snprintf(str,128,"Cannot open Tersoff potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -369,7 +369,7 @@ void PairVashishta::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Vashishta potential file %s",file);
+      snprintf(str,128,"Cannot open Vashishta potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -464,7 +464,7 @@ void PairMEAM::read_files(char *globalfile, char *userfile)
     fp = force->open_potential(globalfile);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open MEAM potential file %s",globalfile);
+      snprintf(str,128,"Cannot open MEAM potential file %s",globalfile);
       error->one(FLERR,str);
     }
   }
@@ -645,7 +645,7 @@ void PairMEAM::read_files(char *globalfile, char *userfile)
     fp = force->open_potential(userfile);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open MEAM potential file %s",userfile);
+      snprintf(str,128,"Cannot open MEAM potential file %s",userfile);
       error->one(FLERR,str);
     }
   }
@@ -694,8 +694,8 @@ void PairMEAM::read_files(char *globalfile, char *userfile)
       if (strcmp(params[0],keywords[which]) == 0) break;
     if (which == nkeywords) {
       char str[128];
-      sprintf(str,"Keyword %s in MEAM parameter file not recognized",
-              params[0]);
+      snprintf(str,128,"Keyword %s in MEAM parameter file not recognized",
+               params[0]);
       error->all(FLERR,str);
     }
     nindex = nparams - 2;

--- a/src/MISC/fix_ttm.cpp
+++ b/src/MISC/fix_ttm.cpp
@@ -71,7 +71,7 @@ FixTTM::FixTTM(LAMMPS *lmp, int narg, char **arg) :
   fpr = fopen(arg[13],"r");
   if (fpr == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",arg[13]);
+    snprintf(str,128,"Cannot open file %s",arg[13]);
     error->one(FLERR,str);
   }
 
@@ -84,7 +84,7 @@ FixTTM::FixTTM(LAMMPS *lmp, int narg, char **arg) :
       fp = fopen(arg[15],"w");
       if (fp == NULL) {
         char str[128];
-        sprintf(str,"Cannot open fix ttm file %s",arg[15]);
+        snprintf(str,128,"Cannot open fix ttm file %s",arg[15]);
         error->one(FLERR,str);
       }
     }

--- a/src/MOLECULE/angle_table.cpp
+++ b/src/MOLECULE/angle_table.cpp
@@ -369,7 +369,7 @@ void AngleTable::read_table(Table *tb, char *file, char *keyword)
   FILE *fp = force->open_potential(file);
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -298,7 +298,7 @@ void BondTable::read_table(Table *tb, char *file, char *keyword)
   FILE *fp = force->open_potential(file);
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -644,7 +644,7 @@ void FixCMAP::read_grid_map(char *cmapfile)
     fp = force->open_potential(cmapfile);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix cmap file %s",cmapfile);
+      snprintf(str,128,"Cannot open fix cmap file %s",cmapfile);
       error->one(FLERR,str);
     }
   }
@@ -1076,7 +1076,7 @@ void FixCMAP::read_data_section(char *keyword, int n, char *buf,
 
   if (nwords != 7) {
     char str[128];
-    sprintf(str,"Incorrect %s format in data file",keyword);
+    snprintf(str,128,"Incorrect %s format in data file",keyword);
     error->all(FLERR,str);
   }
 

--- a/src/POEMS/fix_poems.cpp
+++ b/src/POEMS/fix_poems.cpp
@@ -369,7 +369,7 @@ void FixPOEMS::init()
       if (pflag && (modify->fmask[i] & POST_FORCE) && 
           !modify->fix[i]->rigid_flag) {
         char str[128];
-        sprintf(str,"Fix %s alters forces after fix poems",modify->fix[i]->id);
+        snprintf(str,128,"Fix %s alters forces after fix poems",modify->fix[i]->id);
         error->warning(FLERR,str);
       }
     }
@@ -961,7 +961,7 @@ void FixPOEMS::readfile(char *file)
     fp = fopen(file,"r");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix poems file %s",file);
+      snprintf(str,128,"Cannot open fix poems file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -715,7 +715,7 @@ void FixQEq::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix qeq parameter file %s",file);
+      snprintf(str,128,"Cannot open fix qeq parameter file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/REAX/fix_reax_bonds.cpp
+++ b/src/REAX/fix_reax_bonds.cpp
@@ -53,7 +53,7 @@ FixReaxBonds::FixReaxBonds(LAMMPS *lmp, int narg, char **arg) :
     if (suffix && strcmp(suffix,".gz") == 0) {
 #ifdef LAMMPS_GZIP
       char gzip[128];
-      sprintf(gzip,"gzip -6 > %s",arg[4]);
+      snprintf(gzip128,,"gzip -6 > %s",arg[4]);
 #ifdef _WIN32
       fp = _popen(gzip,"wb");
 #else
@@ -66,7 +66,7 @@ FixReaxBonds::FixReaxBonds(LAMMPS *lmp, int narg, char **arg) :
 
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix reax/bonds file %s",arg[4]);
+      snprintf(str,128,"Cannot open fix reax/bonds file %s",arg[4]);
       error->one(FLERR,str);
     }
   }
@@ -222,11 +222,8 @@ void FixReaxBonds::OutputReaxBonds(bigint ntimestep, FILE *fp)
         numbonds = nint(buf[j+2]);
         fprintf(fp," %d %d %d",nint(buf[j]),nint(buf[j+1]),numbonds);
         j += 3;
-        if (numbonds > nsbmax_most) {
-          char str[128];
-          sprintf(str,"Fix reax/bonds numbonds > nsbmax_most");
-          error->one(FLERR,str);
-        }
+        if (numbonds > nsbmax_most)
+          error->one(FLERR,"Fix reax/bonds numbonds > nsbmax_most");
 
         // print connection table
 

--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -549,7 +549,7 @@ void NEB::open(char *file)
   else {
 #ifdef LAMMPS_GZIP
     char gunzip[128];
-    snprintf(gunz128,ip,"gzip -c -d %s",file);
+    snprintf(gunzip,128,"gzip -c -d %s",file);
 
 #ifdef _WIN32
     fp = _popen(gunzip,"rb");

--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -549,7 +549,7 @@ void NEB::open(char *file)
   else {
 #ifdef LAMMPS_GZIP
     char gunzip[128];
-    sprintf(gunzip,"gzip -c -d %s",file);
+    snprintf(gunz128,ip,"gzip -c -d %s",file);
 
 #ifdef _WIN32
     fp = _popen(gunzip,"rb");
@@ -564,7 +564,7 @@ void NEB::open(char *file)
 
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 }

--- a/src/REPLICA/tad.cpp
+++ b/src/REPLICA/tad.cpp
@@ -712,10 +712,7 @@ void TAD::perform_neb(int ievent)
   args[0] = (char *) "neb";
   args[1] = (char *) "all";
   args[2] = (char *) "neb";
-  char str[128];
-  args[3] = str;
-  double kspring = 1.0;
-  sprintf(args[3],"%f",kspring);
+  args[3] = (char *) "1.0";
   modify->add_fix(narg2,args);
   fix_neb = (Fix *) modify->fix[modify->nfix-1];
   delete [] args;

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -730,7 +730,7 @@ void FixRigid::init()
       if (rflag && (modify->fmask[i] & POST_FORCE) && 
           !modify->fix[i]->rigid_flag) {
         char str[128];
-        sprintf(str,"Fix %s alters forces after fix rigid",modify->fix[i]->id);
+        snprintf(str,128,"Fix %s alters forces after fix rigid",modify->fix[i]->id);
         error->warning(FLERR,str);
       }
     }
@@ -2271,7 +2271,7 @@ void FixRigid::readfile(int which, double *vec,
     fp = fopen(infile,"r");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix rigid infile %s",infile);
+      snprintf(str,128,"Cannot open fix rigid infile %s",infile);
       error->one(FLERR,str);
     }
 
@@ -2380,11 +2380,11 @@ void FixRigid::write_restart_file(char *file)
   if (me) return;
 
   char outfile[128];
-  sprintf(outfile,"%s.rigid",file);
+  snprintf(outfile,128,"%s.rigid",file);
   FILE *fp = fopen(outfile,"w");
   if (fp == NULL) {
     char str[192];
-    sprintf(str,"Cannot open fix rigid restart file %s",outfile);
+    snprintf(str,192,"Cannot open fix rigid restart file %s",outfile);
     error->one(FLERR,str);
   }
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -569,7 +569,7 @@ void FixRigidSmall::init()
       if (rflag && (modify->fmask[i] & POST_FORCE) && 
           !modify->fix[i]->rigid_flag) {
         char str[128];
-        sprintf(str,"Fix %s alters forces after fix rigid",modify->fix[i]->id);
+        snprintf(str,128,"Fix %s alters forces after fix rigid",modify->fix[i]->id);
         error->warning(FLERR,str);
       }
     }
@@ -2482,7 +2482,7 @@ void FixRigidSmall::readfile(int which, double **array, int *inbody)
     fp = fopen(infile,"r");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix rigid/small infile %s",infile);
+      snprintf(str,128,"Cannot open fix rigid/small infile %s",infile);
       error->one(FLERR,str);
     }
 
@@ -2597,11 +2597,11 @@ void FixRigidSmall::write_restart_file(char *file)
 
   if (me == 0) {
     char outfile[128];
-    sprintf(outfile,"%s.rigid",file);
+    snprintf(outfile,128,"%s.rigid",file);
     fp = fopen(outfile,"w");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix rigid restart file %s",outfile);
+      snprintf(str,128,"Cannot open fix rigid restart file %s",outfile);
       error->one(FLERR,str);
     }
 

--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -1591,7 +1591,7 @@ void PairSNAP::read_files(char *coefffilename, char *paramfilename)
     fpcoeff = force->open_potential(coefffilename);
     if (fpcoeff == NULL) {
       char str[128];
-      sprintf(str,"Cannot open SNAP coefficient file %s",coefffilename);
+      snprintf(str,128,"Cannot open SNAP coefficient file %s",coefffilename);
       error->one(FLERR,str);
     }
   }
@@ -1757,7 +1757,7 @@ void PairSNAP::read_files(char *coefffilename, char *paramfilename)
     fpparam = force->open_potential(paramfilename);
     if (fpparam == NULL) {
       char str[128];
-      sprintf(str,"Cannot open SNAP parameter file %s",paramfilename);
+      snprintf(str,128,"Cannot open SNAP parameter file %s",paramfilename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-BOCS/fix_bocs.cpp
+++ b/src/USER-BOCS/fix_bocs.cpp
@@ -207,12 +207,11 @@ FixBocs::FixBocs(LAMMPS *lmp, int narg, char **arg) :
         p_basis_type = 2;
         spline_length = read_F_table( arg[iarg+1], p_basis_type );
         iarg += 2;
-      }  else
-      {
-         char * errmsg = (char *) calloc(150,sizeof(char));
-         sprintf(errmsg,"CG basis type %s is not recognized\nSupported "
-             "basis types: analytic linear_spline cubic_spline",arg[iarg]);
-         error->all(FLERR,errmsg);
+      }  else {
+        char errmsg[256];
+        snprintf(errmsg,256,"CG basis type %s is not recognized\nSupported "
+                 "basis types: analytic linear_spline cubic_spline",arg[iarg]);
+        error->all(FLERR,errmsg);
       } // END NJD MRD
     } else if (strcmp(arg[iarg],"tchain") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix bocs command");
@@ -243,9 +242,9 @@ FixBocs::FixBocs(LAMMPS *lmp, int narg, char **arg) :
       if (nc_pchain < 0) error->all(FLERR,"Illegal fix bocs command");
       iarg += 2;
     } else {
-      char * errmsg = (char *) calloc(80,sizeof(char));
-      sprintf(errmsg,"Illegal fix bocs command: unrecognized keyword %s"
-                                                             ,arg[iarg]);
+      char errmsg[128];
+      snprintf(errmsg,128,"Illegal fix bocs command: unrecognized keyword %s"
+               ,arg[iarg]);
       error->all(FLERR,errmsg);
     }
   }
@@ -641,20 +640,16 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
     {
       data[i] = (double *) calloc(n_entries,sizeof(double));
     }
-  }
-  else
-  {
-    char * errmsg = (char *) calloc(50,sizeof(char));
-    sprintf(errmsg,"Unable to open file: %s\n",filename);
+  } else {
+    char errmsg[128];
+    snprintf(errmsg,128,"Unable to open file: %s\n",filename);
     error->all(FLERR,errmsg);
   }
 
   n_entries = 0;
   fpi = fopen(filename,"r");
-  if (fpi)
-  {
-    while( fgets(line,199,fpi))
-    {
+  if (fpi) {
+    while( fgets(line,199,fpi)) {
       ++n_entries;
       test_sscanf = sscanf(line," %f , %f ",&f1, &f2);
       if (test_sscanf == 2)
@@ -668,11 +663,9 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
                  "line %d of file %s\n\tline: %s",n_entries,filename,line);
       }
     }
-  }
-  else
-  {
-    char * errmsg = (char *) calloc(50,sizeof(char));
-    sprintf(errmsg,"Unable to open file: %s\n",filename);
+  } else {
+    char errmsg[128];
+    snprintf(errmsg,128,"Unable to open file: %s\n",filename);
     error->all(FLERR,errmsg);
   }
   fclose(fpi);

--- a/src/USER-DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/USER-DIFFRACTION/fix_saed_vtk.cpp
@@ -424,12 +424,12 @@ void FixSAEDVTK::invoke_vector(bigint ntimestep)
       fclose(fp);
 
       char nName [128];
-      sprintf(nName,"%s.%d.vtk",filename,nOutput);
+      snprintf(nName,128,"%s.%d.vtk",filename,nOutput);
       fp = fopen(nName,"w");
 
       if (fp == NULL) {
         char str[128];
-        sprintf(str,"Cannot open fix saed/vtk file %s",nName);
+        snprintf(str,128,"Cannot open fix saed/vtk file %s",nName);
         error->one(FLERR,str);
       }
     }
@@ -550,13 +550,13 @@ void FixSAEDVTK::options(int narg, char **arg)
          filename = new char[n];
          strcpy(filename,arg[iarg+1]);
 
-        char nName [128];
-         sprintf(nName,"%s.%d.vtk",filename,nOutput);
+         char nName [128];
+         snprintf(nName,128,"%s.%d.vtk",filename,nOutput);
          fp = fopen(nName,"w");
 
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix saed/vtk file %s",nName);
+          snprintf(str,128,"Cannot open fix saed/vtk file %s",nName);
           error->one(FLERR,str);
         }
       }

--- a/src/USER-DPD/fix_eos_table.cpp
+++ b/src/USER-DPD/fix_eos_table.cpp
@@ -200,7 +200,7 @@ void FixEOStable::read_table(Table *tb, Table *tb2, char *file, char *keyword)
   FILE *fp = force->open_potential(file);
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/USER-DPD/fix_eos_table_rx.cpp
+++ b/src/USER-DPD/fix_eos_table_rx.cpp
@@ -309,7 +309,7 @@ void FixEOStableRX::read_file(char *file)
     fp = fopen(file,"r");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open eos table/rx potential file %s",file);
+      snprintf(str,128,"Cannot open eos table/rx potential file %s",file);
       error->one(FLERR,str);
     }
   }
@@ -419,7 +419,7 @@ void FixEOStableRX::read_table(Table *tb, Table *tb2, char *file, char *keyword)
   FILE *fp = fopen(file,"r");
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -272,7 +272,7 @@ void FixRX::post_constructor()
     fp = force->open_potential(kineticsFile);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open rx file %s",kineticsFile);
+      snprintf(str,128,"Cannot open rx file %s",kineticsFile);
       error->one(FLERR,str);
     }
   }
@@ -859,7 +859,7 @@ void FixRX::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open rx file %s",file);
+      snprintf(str,128,"Cannot open rx file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-DPD/pair_exp6_rx.cpp
+++ b/src/USER-DPD/pair_exp6_rx.cpp
@@ -730,7 +730,7 @@ void PairExp6rx::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open exp6/rx potential file %s",file);
+      snprintf(str,128,"Cannot open exp6/rx potential file %s",file);
       error->one(FLERR,str);
     }
   }
@@ -841,7 +841,7 @@ void PairExp6rx::read_file2(char *file)
     fp = fopen(file,"r");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open polynomial file %s",file);
+      snprintf(str,128,"Cannot open polynomial file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-DPD/pair_multi_lucy.cpp
+++ b/src/USER-DPD/pair_multi_lucy.cpp
@@ -350,7 +350,7 @@ void PairMultiLucy::read_table(Table *tb, char *file, char *keyword)
   FILE *fp = fopen(file,"r");
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/USER-DPD/pair_multi_lucy_rx.cpp
+++ b/src/USER-DPD/pair_multi_lucy_rx.cpp
@@ -495,7 +495,7 @@ void PairMultiLucyRX::read_table(Table *tb, char *file, char *keyword)
   FILE *fp = force->open_potential(file);
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/USER-INTEL/pair_eam_alloy_intel.cpp
+++ b/src/USER-INTEL/pair_eam_alloy_intel.cpp
@@ -126,7 +126,7 @@ void PairEAMAlloyIntel::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-INTEL/pair_eam_fs_intel.cpp
+++ b/src/USER-INTEL/pair_eam_fs_intel.cpp
@@ -126,7 +126,7 @@ void PairEAMFSIntel::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MEAMC/pair_meamc.cpp
+++ b/src/USER-MEAMC/pair_meamc.cpp
@@ -328,7 +328,7 @@ void PairMEAMC::read_files(char *globalfile, char *userfile)
     fp = force->open_potential(globalfile);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open MEAM potential file %s",globalfile);
+      snprintf(str,128,"Cannot open MEAM potential file %s",globalfile);
       error->one(FLERR,str);
     }
   }
@@ -509,7 +509,7 @@ void PairMEAMC::read_files(char *globalfile, char *userfile)
     fp = force->open_potential(userfile);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open MEAM potential file %s",userfile);
+      snprintf(str,128,"Cannot open MEAM potential file %s",userfile);
       error->one(FLERR,str);
     }
   }
@@ -558,8 +558,8 @@ void PairMEAMC::read_files(char *globalfile, char *userfile)
       if (strcmp(params[0],keywords[which]) == 0) break;
     if (which == nkeywords) {
       char str[128];
-      sprintf(str,"Keyword %s in MEAM parameter file not recognized",
-              params[0]);
+      snprintf(str,128,"Keyword %s in MEAM parameter file not recognized",
+               params[0]);
       error->all(FLERR,str);
     }
     nindex = nparams - 2;

--- a/src/USER-MISC/fix_ave_correlate_long.cpp
+++ b/src/USER-MISC/fix_ave_correlate_long.cpp
@@ -165,7 +165,7 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS * lmp, int narg, char **arg):
         fp = fopen(arg[iarg+1],"w");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix ave/correlate/long file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open fix ave/correlate/long file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/USER-MISC/fix_bond_react.cpp
+++ b/src/USER-MISC/fix_bond_react.cpp
@@ -2529,7 +2529,7 @@ void FixBondReact::open(char *file)
   fp = fopen(file,"r");
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open superimpose file %s",file);
+    snprintf(str,128,"Cannot open superimpose file %s",file);
     error->one(FLERR,str);
   }
 }

--- a/src/USER-MISC/fix_gle.cpp
+++ b/src/USER-MISC/fix_gle.cpp
@@ -232,7 +232,7 @@ FixGLE::FixGLE(LAMMPS *lmp, int narg, char **arg) :
     fgle = force->open_potential(fname);
     if (fgle == NULL) {
       char str[128];
-      sprintf(str,"Cannot open A-matrix file %s",fname);
+      snprintf(str,128,"Cannot open A-matrix file %s",fname);
       error->one(FLERR,str);
     }
     if (screen) fprintf(screen,"Reading A-matrix from %s\n", fname);
@@ -302,7 +302,7 @@ FixGLE::FixGLE(LAMMPS *lmp, int narg, char **arg) :
       fgle = force->open_potential(fname);
       if (fgle == NULL) {
         char str[128];
-        sprintf(str,"Cannot open C-matrix file %s",fname);
+        snprintf(str,128,"Cannot open C-matrix file %s",fname);
         error->one(FLERR,str);
       }
       if (screen)

--- a/src/USER-MISC/fix_ttm_mod.cpp
+++ b/src/USER-MISC/fix_ttm_mod.cpp
@@ -86,7 +86,7 @@ FixTTMMod::FixTTMMod(LAMMPS *lmp, int narg, char **arg) :
   FILE *fpr_2 = force->open_potential(arg[4]);
   if (fpr_2 == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",arg[4]);
+    snprintf(str,128,"Cannot open file %s",arg[4]);
     error->all(FLERR,str);
   }
 
@@ -99,7 +99,7 @@ FixTTMMod::FixTTMMod(LAMMPS *lmp, int narg, char **arg) :
   FILE *fpr = force->open_potential(arg[8]);
   if (fpr == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",arg[8]);
+    snprintf(str,128,"Cannot open file %s",arg[8]);
     error->all(FLERR,str);
   }
 
@@ -111,7 +111,7 @@ FixTTMMod::FixTTMMod(LAMMPS *lmp, int narg, char **arg) :
       fp = fopen(arg[10],"w");
       if (fp == NULL) {
         char str[128];
-        sprintf(str,"Cannot open fix ttm/mod file %s",arg[10]);
+        snprintf(str,128,"Cannot open fix ttm/mod file %s",arg[10]);
         error->one(FLERR,str);
       }
     }

--- a/src/USER-MISC/pair_agni.cpp
+++ b/src/USER-MISC/pair_agni.cpp
@@ -363,7 +363,7 @@ void PairAGNI::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open AGNI potential file %s",file);
+      snprintf(str,128,"Cannot open AGNI potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MISC/pair_edip.cpp
+++ b/src/USER-MISC/pair_edip.cpp
@@ -877,7 +877,7 @@ void PairEDIP::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EDIP potential file %s",file);
+      snprintf(str,128,"Cannot open EDIP potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MISC/pair_edip_multi.cpp
+++ b/src/USER-MISC/pair_edip_multi.cpp
@@ -644,7 +644,7 @@ void PairEDIPMulti::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EDIP potential file %s",file);
+      snprintf(str,128,"Cannot open EDIP potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MISC/pair_extep.cpp
+++ b/src/USER-MISC/pair_extep.cpp
@@ -591,7 +591,7 @@ void PairExTeP::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open ExTeP potential file %s",file);
+      snprintf(str,128,"Cannot open ExTeP potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MISC/pair_ilp_graphene_hbn.cpp
+++ b/src/USER-MISC/pair_ilp_graphene_hbn.cpp
@@ -880,7 +880,7 @@ void PairILPGrapheneHBN::read_file(char *filename)
     fp = force->open_potential(filename);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open ILP potential file %s",filename);
+      snprintf(str,128,"Cannot open ILP potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
@@ -885,7 +885,7 @@ void PairKolmogorovCrespiFull::read_file(char *filename)
     fp = force->open_potential(filename);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open KC potential file %s",filename);
+      snprintf(str,128,"Cannot open KC potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
@@ -315,7 +315,7 @@ void PairKolmogorovCrespiZ::read_file(char *filename)
     fp = force->open_potential(filename);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open KC potential file %s",filename);
+      snprintf(str,128,"Cannot open KC potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MISC/pair_meam_spline.cpp
+++ b/src/USER-MISC/pair_meam_spline.cpp
@@ -439,7 +439,7 @@ void PairMEAMSpline::read_file(const char* filename)
     FILE *fp = force->open_potential(filename);
     if(fp == NULL) {
       char str[1024];
-      sprintf(str,"Cannot open spline MEAM potential file %s", filename);
+      snprintf(str,128,"Cannot open spline MEAM potential file %s", filename);
       error->one(FLERR,str);
     }
 

--- a/src/USER-MISC/pair_meam_sw_spline.cpp
+++ b/src/USER-MISC/pair_meam_sw_spline.cpp
@@ -466,7 +466,7 @@ void PairMEAMSWSpline::read_file(const char* filename)
     FILE *fp = force->open_potential(filename);
     if(fp == NULL) {
       char str[1024];
-      snprintf(str,128,"Cannot open spline MEAM potential file %s", filename);
+      snprintf(str,1024,"Cannot open spline MEAM potential file %s", filename);
       error->one(FLERR,str);
     }
 

--- a/src/USER-MISC/pair_meam_sw_spline.cpp
+++ b/src/USER-MISC/pair_meam_sw_spline.cpp
@@ -462,64 +462,64 @@ void PairMEAMSWSpline::coeff(int narg, char **arg)
 
 void PairMEAMSWSpline::read_file(const char* filename)
 {
-        if(comm->me == 0) {
-                FILE *fp = force->open_potential(filename);
-                if(fp == NULL) {
-                        char str[1024];
-                        sprintf(str,"Cannot open spline MEAM potential file %s", filename);
-                        error->one(FLERR,str);
-                }
+  if(comm->me == 0) {
+    FILE *fp = force->open_potential(filename);
+    if(fp == NULL) {
+      char str[1024];
+      snprintf(str,128,"Cannot open spline MEAM potential file %s", filename);
+      error->one(FLERR,str);
+    }
 
-                // Skip first line of file.
-                char line[MAXLINE];
-                fgets(line, MAXLINE, fp);
+    // Skip first line of file.
+    char line[MAXLINE];
+    fgets(line, MAXLINE, fp);
 
-                // Parse spline functions.
-                phi.parse(fp, error);
-                F.parse(fp, error);
-                G.parse(fp, error);
-                rho.parse(fp, error);
-                U.parse(fp, error);
-                f.parse(fp, error);
-                g.parse(fp, error);
+    // Parse spline functions.
+    phi.parse(fp, error);
+    F.parse(fp, error);
+    G.parse(fp, error);
+    rho.parse(fp, error);
+    U.parse(fp, error);
+    f.parse(fp, error);
+    g.parse(fp, error);
 
-                fclose(fp);
-        }
+    fclose(fp);
+  }
 
-        // Transfer spline functions from master processor to all other processors.
-        phi.communicate(world, comm->me);
-        rho.communicate(world, comm->me);
-        f.communicate(world, comm->me);
-        U.communicate(world, comm->me);
-        g.communicate(world, comm->me);
-        F.communicate(world, comm->me);
-        G.communicate(world, comm->me);
+  // Transfer spline functions from master processor to all other processors.
+  phi.communicate(world, comm->me);
+  rho.communicate(world, comm->me);
+  f.communicate(world, comm->me);
+  U.communicate(world, comm->me);
+  g.communicate(world, comm->me);
+  F.communicate(world, comm->me);
+  G.communicate(world, comm->me);
 
-        // Calculate 'zero-point energy' of single atom in vacuum.
-        zero_atom_energy = U.eval(0.0);
+  // Calculate 'zero-point energy' of single atom in vacuum.
+  zero_atom_energy = U.eval(0.0);
 
-        // Determine maximum cutoff radius of all relevant spline functions.
-        cutoff = 0.0;
-        if(phi.cutoff() > cutoff) cutoff = phi.cutoff();
-        if(rho.cutoff() > cutoff) cutoff = rho.cutoff();
-        if(f.cutoff() > cutoff) cutoff = f.cutoff();
-        if(F.cutoff() > cutoff) cutoff = F.cutoff();
+  // Determine maximum cutoff radius of all relevant spline functions.
+  cutoff = 0.0;
+  if(phi.cutoff() > cutoff) cutoff = phi.cutoff();
+  if(rho.cutoff() > cutoff) cutoff = rho.cutoff();
+  if(f.cutoff() > cutoff) cutoff = f.cutoff();
+  if(F.cutoff() > cutoff) cutoff = F.cutoff();
 
-        // Set LAMMPS pair interaction flags.
-        for(int i = 1; i <= atom->ntypes; i++) {
-                for(int j = 1; j <= atom->ntypes; j++) {
-                        setflag[i][j] = 1;
-                        cutsq[i][j] = cutoff;
-                }
-        }
+  // Set LAMMPS pair interaction flags.
+  for(int i = 1; i <= atom->ntypes; i++) {
+    for(int j = 1; j <= atom->ntypes; j++) {
+      setflag[i][j] = 1;
+      cutsq[i][j] = cutoff;
+    }
+  }
 
-        // phi.writeGnuplot("phi.gp", "Phi(r)");
-        // rho.writeGnuplot("rho.gp", "Rho(r)");
-        // f.writeGnuplot("f.gp", "f(r)");
-        // U.writeGnuplot("U.gp", "U(rho)");
-        // g.writeGnuplot("g.gp", "g(x)");
-        // F.writeGnuplot("F.gp", "F(r)");
-        // G.writeGnuplot("G.gp", "G(x)");
+  // phi.writeGnuplot("phi.gp", "Phi(r)");
+  // rho.writeGnuplot("rho.gp", "Rho(r)");
+  // f.writeGnuplot("f.gp", "f(r)");
+  // U.writeGnuplot("U.gp", "U(rho)");
+  // g.writeGnuplot("g.gp", "g(x)");
+  // F.writeGnuplot("F.gp", "F(r)");
+  // G.writeGnuplot("G.gp", "G(x)");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-MISC/pair_tersoff_table.cpp
+++ b/src/USER-MISC/pair_tersoff_table.cpp
@@ -845,7 +845,7 @@ void PairTersoffTable::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Tersoff potential file %s",file);
+      snprintf(str,128,"Cannot open Tersoff potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-MOLFILE/reader_molfile.cpp
+++ b/src/USER-MOLFILE/reader_molfile.cpp
@@ -113,12 +113,12 @@ void ReaderMolfile::open_file(const char *file)
   rv = mf->open(file,&natoms);
 
   if (rv != MFI::E_NONE) {
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,1024,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 
   if (natoms < 1) {
-    sprintf(str,"No atoms in file %s",file);
+    snprintf(str,1024,"No atoms in file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/USER-OMP/pair_eam_alloy_omp.cpp
+++ b/src/USER-OMP/pair_eam_alloy_omp.cpp
@@ -126,7 +126,7 @@ void PairEAMAlloyOMP::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-OMP/pair_eam_fs_omp.cpp
+++ b/src/USER-OMP/pair_eam_fs_omp.cpp
@@ -126,7 +126,7 @@ void PairEAMFSOMP::read_file(char *filename)
     fptr = force->open_potential(filename);
     if (fptr == NULL) {
       char str[128];
-      sprintf(str,"Cannot open EAM potential file %s",filename);
+      snprintf(str,128,"Cannot open EAM potential file %s",filename);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-OMP/pair_tersoff_zbl_omp.cpp
+++ b/src/USER-OMP/pair_tersoff_zbl_omp.cpp
@@ -97,7 +97,7 @@ void PairTersoffZBLOMP::read_file(char *file)
     fp = force->open_potential(file);
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open Tersoff potential file %s",file);
+      snprintf(str,128,"Cannot open Tersoff potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-REAXC/fix_reaxc_bonds.cpp
+++ b/src/USER-REAXC/fix_reaxc_bonds.cpp
@@ -62,7 +62,7 @@ FixReaxCBonds::FixReaxCBonds(LAMMPS *lmp, int narg, char **arg) :
     if (suffix && strcmp(suffix,".gz") == 0) {
 #ifdef LAMMPS_GZIP
       char gzip[128];
-      sprintf(gzip,"gzip -6 > %s",arg[4]);
+      snprintf(gzip,128,"gzip -6 > %s",arg[4]);
 #ifdef _WIN32
       fp = _popen(gzip,"wb");
 #else
@@ -75,7 +75,7 @@ FixReaxCBonds::FixReaxCBonds(LAMMPS *lmp, int narg, char **arg) :
 
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix reax/c/bonds file %s",arg[4]);
+      snprintf(str,128,"Cannot open fix reax/c/bonds file %s",arg[4]);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-REAXC/fix_reaxc_species.cpp
+++ b/src/USER-REAXC/fix_reaxc_species.cpp
@@ -98,9 +98,7 @@ FixReaxCSpecies::FixReaxCSpecies(LAMMPS *lmp, int narg, char **arg) :
   }
 
   if (me == 0 && rene_flag) {
-    char str[128];
-    sprintf(str,"Resetting reneighboring criteria for fix reax/c/species");
-    error->warning(FLERR,str);
+    error->warning(FLERR,"Resetting reneighboring criteria for fix reax/c/species");
   }
 
   tmparg = NULL;
@@ -127,7 +125,7 @@ FixReaxCSpecies::FixReaxCSpecies(LAMMPS *lmp, int narg, char **arg) :
 
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open fix reax/c/species file %s",arg[6]);
+      snprintf(str,128,"Cannot open fix reax/c/species file %s",arg[6]);
       error->one(FLERR,str);
     }
   }

--- a/src/USER-REAXC/pair_reaxc.cpp
+++ b/src/USER-REAXC/pair_reaxc.cpp
@@ -301,7 +301,7 @@ void PairReaxC::coeff( int nargs, char **args )
     Read_Force_Field(fp, &(system->reax_param), control);
   else {
       char str[128];
-      sprintf(str,"Cannot open ReaxFF potential file %s",file);
+      snprintf(str,128,"Cannot open ReaxFF potential file %s",file);
       error->all(FLERR,str);
   }
 

--- a/src/USER-SMD/fix_smd_integrate_tlsph.cpp
+++ b/src/USER-SMD/fix_smd_integrate_tlsph.cpp
@@ -86,7 +86,7 @@ FixSMDIntegrateTlsph::FixSMDIntegrateTlsph(LAMMPS *lmp, int narg, char **arg) :
                         }
                 } else {
                         char msg[128];
-                        sprintf(msg, "Illegal keyword for smd/integrate_tlsph: %s\n", arg[iarg]);
+                        snprintf(msg,128, "Illegal keyword for smd/integrate_tlsph: %s\n", arg[iarg]);
                         error->all(FLERR, msg);
                 }
 

--- a/src/USER-SMD/fix_smd_integrate_ulsph.cpp
+++ b/src/USER-SMD/fix_smd_integrate_ulsph.cpp
@@ -119,7 +119,7 @@ FixSMDIntegrateUlsph::FixSMDIntegrateUlsph(LAMMPS *lmp, int narg, char **arg) :
                         }
                 } else {
                         char msg[128];
-                        sprintf(msg, "Illegal keyword for smd/integrate_ulsph: %s\n", arg[iarg]);
+                        snprintf(msg,128, "Illegal keyword for smd/integrate_ulsph: %s\n", arg[iarg]);
                         error->all(FLERR, msg);
                 }
 

--- a/src/USER-SMD/fix_smd_move_triangulated_surface.cpp
+++ b/src/USER-SMD/fix_smd_move_triangulated_surface.cpp
@@ -200,7 +200,7 @@ FixSMDMoveTriSurf::FixSMDMoveTriSurf(LAMMPS *lmp, int narg, char **arg) :
 
                 } else {
                         char msg[128];
-                        sprintf(msg, "Illegal keyword for fix smd/move_tri_surf: %s\n", arg[iarg]);
+                        snprintf(msg,128, "Illegal keyword for fix smd/move_tri_surf: %s\n", arg[iarg]);
                         error->all(FLERR, msg);
                 }
 

--- a/src/USER-SMD/fix_smd_wall_surface.cpp
+++ b/src/USER-SMD/fix_smd_wall_surface.cpp
@@ -223,62 +223,59 @@ int FixSMDWallSurface::count_words(const char *line) {
 
 void FixSMDWallSurface::read_triangles(int pass) {
 
-        double coord[3];
+  double coord[3];
 
-        int nlocal_previous = atom->nlocal;
-        int ilocal = nlocal_previous;
-        int m;
-        int me;
+  int nlocal_previous = atom->nlocal;
+  int ilocal = nlocal_previous;
+  int m;
+  int me;
 
-        bigint natoms_previous = atom->natoms;
-        Vector3d *vert;
-        vert = new Vector3d[3];
-        Vector3d normal, center;
+  bigint natoms_previous = atom->natoms;
+  Vector3d *vert;
+  vert = new Vector3d[3];
+  Vector3d normal, center;
 
-        FILE *fp = fopen(filename, "r");
-        if (fp == NULL) {
-                char str[128];
-                sprintf(str, "Cannot open file %s", filename);
-                error->one(FLERR, str);
-        }
+  FILE *fp = fopen(filename, "r");
+  if (fp == NULL) {
+    char str[128];
+    snprintf(str,128, "Cannot open file %s", filename);
+    error->one(FLERR, str);
+  }
 
-        MPI_Comm_rank(world, &me);
-        if (me == 0) {
-                if (screen) {
-                        if (pass == 0) {
-                                printf("\n>>========>>========>>========>>========>>========>>========>>========>>========\n");
-                                fprintf(screen, "  scanning triangle pairs ...\n");
-                        } else {
-                                fprintf(screen, "  reading triangle pairs ...\n");
-                        }
-                }
-                if (logfile) {
-                        if (pass == 0) {
-                                fprintf(logfile, "  scanning triangle pairs ...\n");
-                        } else {
-                                fprintf(logfile, "  reading triangle pairs ...\n");
-                        }
-                }
-        }
+  MPI_Comm_rank(world, &me);
+  if (me == 0) {
+    if (screen) {
+      if (pass == 0) {
+        printf("\n>>========>>========>>========>>========>>========>>========>>========>>========\n");
+        fprintf(screen, "  scanning triangle pairs ...\n");
+      } else {
+        fprintf(screen, "  reading triangle pairs ...\n");
+      }
+    }
+    if (logfile) {
+      if (pass == 0) {
+        fprintf(logfile, "  scanning triangle pairs ...\n");
+      } else {
+        fprintf(logfile, "  reading triangle pairs ...\n");
+      }
+    }
+  }
 
-        char str[128];
-        char line[256];
-        char *retpointer;
-        char **values;
-        int nwords;
+  char line[256];
+  char *retpointer;
+  char **values;
+  int nwords;
 
-        // read STL solid name
-        retpointer = fgets(line, sizeof(line), fp);
-        if (retpointer == NULL) {
-                sprintf(str, "error reading number of triangle pairs");
-                error->one(FLERR, str);
-        }
+  // read STL solid name
+  retpointer = fgets(line, sizeof(line), fp);
+  if (retpointer == NULL) {
+    error->one(FLERR,"error reading number of triangle pairs");
+  }
 
-        nwords = count_words(line);
-        if (nwords < 1) {
-                sprintf(str, "first line of file is incorrect");
-                error->one(FLERR, str);
-        }
+  nwords = count_words(line);
+  if (nwords < 1) {
+    error->one(FLERR,"first line of file is incorrect");
+  }
 
 //      values = new char*[nwords];
 //      values[0] = strtok(line, " \t\n\r\f");
@@ -295,211 +292,203 @@ void FixSMDWallSurface::read_triangles(int pass) {
 //              cout << "STL file contains solid body with name: " << values[1] << endl;
 //      }
 
-        // iterate over STL facets util end of body is reached
+  // iterate over STL facets util end of body is reached
 
-        while (fgets(line, sizeof(line), fp)) { // read a line, should be the facet line
+  while (fgets(line, sizeof(line), fp)) { // read a line, should be the facet line
 
-                // evaluate facet line
-                nwords = count_words(line);
-                if (nwords != 5) {
-                        //sprintf(str, "found end solid line");
-                        //error->message(FLERR, str);
-                        break;
-                } else {
-                        // should be facet line
-                }
+    // evaluate facet line
+    nwords = count_words(line);
+    if (nwords != 5) {
+      //sprintf(str, "found end solid line");
+      //error->message(FLERR, str);
+      break;
+    } else {
+      // should be facet line
+    }
 
-                values = new char*[nwords];
-                values[0] = strtok(line, " \t\n\r\f");
-                if (values[0] == NULL)
-                        error->all(FLERR, "Incorrect atom format in data file");
-                for (m = 1; m < nwords; m++) {
-                        values[m] = strtok(NULL, " \t\n\r\f");
-                        if (values[m] == NULL)
-                                error->all(FLERR, "Incorrect atom format in data file");
-                }
+    values = new char*[nwords];
+    values[0] = strtok(line, " \t\n\r\f");
+    if (values[0] == NULL)
+      error->all(FLERR, "Incorrect atom format in data file");
+    for (m = 1; m < nwords; m++) {
+      values[m] = strtok(NULL, " \t\n\r\f");
+      if (values[m] == NULL)
+        error->all(FLERR, "Incorrect atom format in data file");
+    }
 
-                normal << force->numeric(FLERR, values[2]), force->numeric(FLERR, values[3]), force->numeric(FLERR, values[4]);
-                //cout << "normal is " << normal << endl;
+    normal << force->numeric(FLERR, values[2]), force->numeric(FLERR, values[3]), force->numeric(FLERR, values[4]);
+    //cout << "normal is " << normal << endl;
 
-                delete[] values;
+    delete[] values;
 
-                // read outer loop line
-                retpointer = fgets(line, sizeof(line), fp);
-                if (retpointer == NULL) {
-                        sprintf(str, "error reading outer loop");
-                        error->one(FLERR, str);
-                }
+    // read outer loop line
+    retpointer = fgets(line, sizeof(line), fp);
+    if (retpointer == NULL) {
+      error->one(FLERR, "error reading outer loop");
+    }
 
-                nwords = count_words(line);
-                if (nwords != 2) {
-                        sprintf(str, "error reading outer loop");
-                        error->one(FLERR, str);
-                }
+    nwords = count_words(line);
+    if (nwords != 2) {
+      error->one(FLERR,"error reading outer loop");
+    }
 
-                // read vertex lines
+    // read vertex lines
 
-                for (int k = 0; k < 3; k++) {
-                        retpointer = fgets(line, sizeof(line), fp);
-                        if (retpointer == NULL) {
-                                sprintf(str, "error reading vertex line");
-                                error->one(FLERR, str);
-                        }
+    for (int k = 0; k < 3; k++) {
+      retpointer = fgets(line, sizeof(line), fp);
+      if (retpointer == NULL) {
+        error->one(FLERR,"error reading vertex line");
+      }
 
-                        nwords = count_words(line);
-                        if (nwords != 4) {
-                                sprintf(str, "error reading vertex line");
-                                error->one(FLERR, str);
-                        }
+      nwords = count_words(line);
+      if (nwords != 4) {
+        error->one(FLERR,"error reading vertex line");
+      }
 
-                        values = new char*[nwords];
-                        values[0] = strtok(line, " \t\n\r\f");
-                        if (values[0] == NULL)
-                                error->all(FLERR, "Incorrect vertex line");
-                        for (m = 1; m < nwords; m++) {
-                                values[m] = strtok(NULL, " \t\n\r\f");
-                                if (values[m] == NULL)
-                                        error->all(FLERR, "Incorrect vertex line");
-                        }
+      values = new char*[nwords];
+      values[0] = strtok(line, " \t\n\r\f");
+      if (values[0] == NULL)
+        error->all(FLERR,"Incorrect vertex line");
+      for (m = 1; m < nwords; m++) {
+        values[m] = strtok(NULL, " \t\n\r\f");
+        if (values[m] == NULL)
+          error->all(FLERR, "Incorrect vertex line");
+      }
 
-                        vert[k] << force->numeric(FLERR, values[1]), force->numeric(FLERR, values[2]), force->numeric(FLERR, values[3]);
-                        //cout << "vertex is " << vert[k] << endl;
-                        //printf("%s %s %s\n", values[1], values[2], values[3]);
-                        delete[] values;
-                        //exit(1);
+      vert[k] << force->numeric(FLERR, values[1]), force->numeric(FLERR, values[2]), force->numeric(FLERR, values[3]);
+      //cout << "vertex is " << vert[k] << endl;
+      //printf("%s %s %s\n", values[1], values[2], values[3]);
+      delete[] values;
+      //exit(1);
 
-                }
+    }
 
-                // read end loop line
-                retpointer = fgets(line, sizeof(line), fp);
-                if (retpointer == NULL) {
-                        sprintf(str, "error reading endloop");
-                        error->one(FLERR, str);
-                }
+    // read end loop line
+    retpointer = fgets(line, sizeof(line), fp);
+    if (retpointer == NULL) {
+      error->one(FLERR, "error reading endloop");
+    }
 
-                nwords = count_words(line);
-                if (nwords != 1) {
-                        sprintf(str, "error reading endloop");
-                        error->one(FLERR, str);
-                }
+    nwords = count_words(line);
+    if (nwords != 1) {
+      error->one(FLERR,"error reading endloop");
+    }
 
-                // read end facet line
-                retpointer = fgets(line, sizeof(line), fp);
-                if (retpointer == NULL) {
-                        sprintf(str, "error reading endfacet");
-                        error->one(FLERR, str);
-                }
+    // read end facet line
+    retpointer = fgets(line, sizeof(line), fp);
+    if (retpointer == NULL) {
+      error->one(FLERR,"error reading endfacet");
+    }
 
-                nwords = count_words(line);
-                if (nwords != 1) {
-                        sprintf(str, "error reading endfacet");
-                        error->one(FLERR, str);
-                }
+    nwords = count_words(line);
+    if (nwords != 1) {
+      error->one(FLERR,"error reading endfacet");
+    }
 
-                // now we have a normal and three vertices ... proceed with adding triangle
+    // now we have a normal and three vertices ... proceed with adding triangle
 
-                center = (vert[0] + vert[1] + vert[2]) / 3.0;
+    center = (vert[0] + vert[1] + vert[2]) / 3.0;
 
-                //      cout << "center is " << center << endl;
+    //      cout << "center is " << center << endl;
 
-                double r1 = (center - vert[0]).norm();
-                double r2 = (center - vert[1]).norm();
-                double r3 = (center - vert[2]).norm();
-                double r = MAX(r1, r2);
-                r = MAX(r, r3);
+    double r1 = (center - vert[0]).norm();
+    double r2 = (center - vert[1]).norm();
+    double r3 = (center - vert[2]).norm();
+    double r = MAX(r1, r2);
+    r = MAX(r, r3);
 
-                /*
-                 * if atom/molecule is in my subbox, create it
-                 * ... use x0 to hold triangle normal.
-                 * ... use smd_data_9 to hold the three vertices
-                 * ... use x to hold triangle center
-                 * ... radius is the mmaximal distance from triangle center to all vertices
-                 */
+    /*
+     * if atom/molecule is in my subbox, create it
+     * ... use x0 to hold triangle normal.
+     * ... use smd_data_9 to hold the three vertices
+     * ... use x to hold triangle center
+     * ... radius is the mmaximal distance from triangle center to all vertices
+     */
 
-                //      printf("coord: %f %f %f\n", coord[0], coord[1], coord[2]);
-                //      printf("sublo: %f %f %f\n", sublo[0], sublo[1], sublo[2]);
-                //      printf("subhi: %f %f %f\n", subhi[0], subhi[1], subhi[2]);
-                //printf("ilocal = %d\n", ilocal);
-                if (center(0) >= sublo[0] && center(0) < subhi[0] && center(1) >= sublo[1] && center(1) < subhi[1] && center(2) >= sublo[2]
-                                && center(2) < subhi[2]) {
-                        //printf("******* KERATIN nlocal=%d ***\n", nlocal);
-                        coord[0] = center(0);
-                        coord[1] = center(1);
-                        coord[2] = center(2);
-                        atom->avec->create_atom(wall_particle_type, coord);
+    //      printf("coord: %f %f %f\n", coord[0], coord[1], coord[2]);
+    //      printf("sublo: %f %f %f\n", sublo[0], sublo[1], sublo[2]);
+    //      printf("subhi: %f %f %f\n", subhi[0], subhi[1], subhi[2]);
+    //printf("ilocal = %d\n", ilocal);
+    if (center(0) >= sublo[0] && center(0) < subhi[0] && center(1) >= sublo[1] && center(1) < subhi[1] && center(2) >= sublo[2]
+        && center(2) < subhi[2]) {
+      //printf("******* KERATIN nlocal=%d ***\n", nlocal);
+      coord[0] = center(0);
+      coord[1] = center(1);
+      coord[2] = center(2);
+      atom->avec->create_atom(wall_particle_type, coord);
 
-                        /*
-                         * need to initialize pointers to atom vec arrays here, because they could have changed
-                         * due to calling grow() in create_atoms() above;
-                         */
+      /*
+       * need to initialize pointers to atom vec arrays here, because they could have changed
+       * due to calling grow() in create_atoms() above;
+       */
 
-                        tagint *mol = atom->molecule;
-                        int *type = atom->type;
-                        double *radius = atom->radius;
-                        double *contact_radius = atom->contact_radius;
-                        double **smd_data_9 = atom->smd_data_9;
-                        double **x0 = atom->x0;
+      tagint *mol = atom->molecule;
+      int *type = atom->type;
+      double *radius = atom->radius;
+      double *contact_radius = atom->contact_radius;
+      double **smd_data_9 = atom->smd_data_9;
+      double **x0 = atom->x0;
 
-                        radius[ilocal] = r; //ilocal;
-                        contact_radius[ilocal] = r; //ilocal;
-                        mol[ilocal] = wall_molecule_id;
-                        type[ilocal] = wall_particle_type;
-                        x0[ilocal][0] = normal(0);
-                        x0[ilocal][1] = normal(1);
-                        x0[ilocal][2] = normal(2);
-                        smd_data_9[ilocal][0] = vert[0](0);
-                        smd_data_9[ilocal][1] = vert[0](1);
-                        smd_data_9[ilocal][2] = vert[0](2);
-                        smd_data_9[ilocal][3] = vert[1](0);
-                        smd_data_9[ilocal][4] = vert[1](1);
-                        smd_data_9[ilocal][5] = vert[1](2);
-                        smd_data_9[ilocal][6] = vert[2](0);
-                        smd_data_9[ilocal][7] = vert[2](1);
-                        smd_data_9[ilocal][8] = vert[2](2);
+      radius[ilocal] = r; //ilocal;
+      contact_radius[ilocal] = r; //ilocal;
+      mol[ilocal] = wall_molecule_id;
+      type[ilocal] = wall_particle_type;
+      x0[ilocal][0] = normal(0);
+      x0[ilocal][1] = normal(1);
+      x0[ilocal][2] = normal(2);
+      smd_data_9[ilocal][0] = vert[0](0);
+      smd_data_9[ilocal][1] = vert[0](1);
+      smd_data_9[ilocal][2] = vert[0](2);
+      smd_data_9[ilocal][3] = vert[1](0);
+      smd_data_9[ilocal][4] = vert[1](1);
+      smd_data_9[ilocal][5] = vert[1](2);
+      smd_data_9[ilocal][6] = vert[2](0);
+      smd_data_9[ilocal][7] = vert[2](1);
+      smd_data_9[ilocal][8] = vert[2](2);
 
-                        ilocal++;
-                }
+      ilocal++;
+    }
 
-        }
+  }
 
 // set new total # of atoms and error check
 
-        bigint nblocal = atom->nlocal;
-        MPI_Allreduce(&nblocal, &atom->natoms, 1, MPI_LMP_BIGINT, MPI_SUM, world);
-        if (atom->natoms < 0 || atom->natoms >= MAXBIGINT)
-                error->all(FLERR, "Too many total atoms");
+  bigint nblocal = atom->nlocal;
+  MPI_Allreduce(&nblocal, &atom->natoms, 1, MPI_LMP_BIGINT, MPI_SUM, world);
+  if (atom->natoms < 0 || atom->natoms >= MAXBIGINT)
+    error->all(FLERR, "Too many total atoms");
 
 // add IDs for newly created atoms
 // check that atom IDs are valid
 
-        if (atom->tag_enable)
-                atom->tag_extend();
-        atom->tag_check();
+  if (atom->tag_enable)
+    atom->tag_extend();
+  atom->tag_check();
 
 // create global mapping of atoms
 // zero nghost in case are adding new atoms to existing atoms
 
-        if (atom->map_style) {
-                atom->nghost = 0;
-                atom->map_init();
-                atom->map_set();
-        }
+  if (atom->map_style) {
+    atom->nghost = 0;
+    atom->map_init();
+    atom->map_set();
+  }
 
 // print status
-        if (comm->me == 0) {
-                if (screen) {
-                        printf("... fix smd/wall_surface finished reading triangulated surface\n");
-                        fprintf(screen, "fix smd/wall_surface created " BIGINT_FORMAT " atoms\n", atom->natoms - natoms_previous);
-                        printf(">>========>>========>>========>>========>>========>>========>>========>>========\n");
-                }
-                if (logfile) {
-                        fprintf(logfile, "... fix smd/wall_surface finished reading triangulated surface\n");
-                        fprintf(logfile, "fix smd/wall_surface created " BIGINT_FORMAT " atoms\n", atom->natoms - natoms_previous);
-                        fprintf(logfile, ">>========>>========>>========>>========>>========>>========>>========>>========\n");
-                }
-        }
+  if (comm->me == 0) {
+    if (screen) {
+      printf("... fix smd/wall_surface finished reading triangulated surface\n");
+      fprintf(screen, "fix smd/wall_surface created " BIGINT_FORMAT " atoms\n", atom->natoms - natoms_previous);
+      printf(">>========>>========>>========>>========>>========>>========>>========>>========\n");
+    }
+    if (logfile) {
+      fprintf(logfile, "... fix smd/wall_surface finished reading triangulated surface\n");
+      fprintf(logfile, "fix smd/wall_surface created " BIGINT_FORMAT " atoms\n", atom->natoms - natoms_previous);
+      fprintf(logfile, ">>========>>========>>========>>========>>========>>========>>========>>========\n");
+    }
+  }
 
-        delete[] vert;
-        fclose(fp);
+  delete[] vert;
+  fclose(fp);
 }
 

--- a/src/USER-SMD/pair_smd_tlsph.cpp
+++ b/src/USER-SMD/pair_smd_tlsph.cpp
@@ -1684,8 +1684,8 @@ void PairTlsph::coeff(int narg, char **arg) {
                 } // end energy release rate failure criterion
 
                 else {
-                        sprintf(str, "unknown *KEYWORD: %s", arg[ioffset]);
-                        error->all(FLERR, str);
+                  snprintf(str,128,"unknown *KEYWORD: %s", arg[ioffset]);
+                  error->all(FLERR, str);
                 }
 
         }

--- a/src/USER-SMD/pair_smd_ulsph.cpp
+++ b/src/USER-SMD/pair_smd_ulsph.cpp
@@ -1331,8 +1331,8 @@ void PairULSPH::coeff(int narg, char **arg) {
                         } // end *ARTIFICIAL_STRESS
 
                         else {
-                                sprintf(str, "unknown *KEYWORD: %s", arg[ioffset]);
-                                error->all(FLERR, str);
+                          snprintf(str,128, "unknown *KEYWORD: %s", arg[ioffset]);
+                          error->all(FLERR, str);
                         }
 
                 }

--- a/src/USER-SMTBQ/pair_smtbq.cpp
+++ b/src/USER-SMTBQ/pair_smtbq.cpp
@@ -399,7 +399,7 @@ void PairSMTBQ::read_file(char *file)
   fp = force->open_potential(file);
   if ( fp  == NULL ) {
     char str[128];
-    sprintf(str,"Cannot open SMTBQ potential file %s",file);
+    snprintf(str,128,"Cannot open SMTBQ potential file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/USER-UEF/dump_cfg_uef.cpp
+++ b/src/USER-UEF/dump_cfg_uef.cpp
@@ -90,9 +90,7 @@ void DumpCFGUef::write_header(bigint n)
   if (atom->peri_flag) scale = atom->pdscale;
   else if (unwrapflag == 1) scale = UNWRAPEXPAND;
 
-  char str[64];
-  sprintf(str,"Number of particles = %s\n",BIGINT_FORMAT);
-  fprintf(fp,str,n);
+  fprintf(fp,"Number of particles = " BIGINT_FORMAT "\n",n);
   fprintf(fp,"A = %g Angstrom (basic length-scale)\n",scale);
   // in box[][] columns are cell edges
   // in H0, rows are cell edges

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -225,7 +225,7 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
         fp = fopen(arg[iarg+1],"w");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix ave/chunk file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open fix ave/chunk file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/fix_ave_correlate.cpp
+++ b/src/fix_ave_correlate.cpp
@@ -149,7 +149,7 @@ FixAveCorrelate::FixAveCorrelate(LAMMPS * lmp, int narg, char **arg):
         fp = fopen(arg[iarg+1],"w");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix ave/correlate file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open fix ave/correlate file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -937,7 +937,7 @@ void FixAveHisto::options(int iarg, int narg, char **arg)
         fp = fopen(arg[iarg+1],"w");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix ave/histo file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open fix ave/histo file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -1042,7 +1042,7 @@ void FixAveTime::options(int iarg, int narg, char **arg)
         fp = fopen(arg[iarg+1],"w");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix ave/time file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open fix ave/time file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/fix_enforce2d.cpp
+++ b/src/fix_enforce2d.cpp
@@ -78,7 +78,7 @@ void FixEnforce2D::init()
           flist[nfixlist++] = modify->fix[i];
         else {
           char msg[256];
-          sprintf(msg,"Fix enforce2d must be defined after fix %s",modify->fix[i]->style);
+          snprintf(msg,256,"Fix enforce2d must be defined after fix %s",modify->fix[i]->style);
           error->all(FLERR,msg);
         }
       }

--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -60,7 +60,7 @@ FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
         else fp = fopen(arg[iarg+1],"a");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open fix print file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open fix print file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -224,7 +224,7 @@ void FixPropertyAtom::read_data_section(char *keyword, int n, char *buf,
 
   if (nwords != nvalue+1) {
     char str[128];
-    sprintf(str,"Incorrect %s format in data file",keyword);
+    snprintf(str,128,"Incorrect %s format in data file",keyword);
     error->all(FLERR,str);
   }
 
@@ -242,7 +242,7 @@ void FixPropertyAtom::read_data_section(char *keyword, int n, char *buf,
     values[0] = strtok(buf," \t\n\r\f");
     if (values[0] == NULL) {
       char str[128];
-      sprintf(str,"Too few lines in %s section of data file",keyword);
+      snprintf(str,128,"Too few lines in %s section of data file",keyword);
       error->one(FLERR,str);
     }
     int format_ok = 1;
@@ -252,14 +252,14 @@ void FixPropertyAtom::read_data_section(char *keyword, int n, char *buf,
     }
     if (!format_ok) {
       char str[128];
-      sprintf(str,"Incorrect %s format in data file",keyword);
+      snprintf(str,128,"Incorrect %s format in data file",keyword);
       error->all(FLERR,str);
     }
 
     itag = ATOTAGINT(values[0]) + id_offset;
     if (itag <= 0 || itag > map_tag_max) {
       char str[128];
-      sprintf(str,"Invalid atom ID in %s section of data file",keyword);
+      snprintf(str,128,"Invalid atom ID in %s section of data file",keyword);
       error->one(FLERR,str);
     }
 

--- a/src/fix_tmd.cpp
+++ b/src/fix_tmd.cpp
@@ -75,7 +75,7 @@ nfileevery(0), fp(NULL), xf(NULL), xold(NULL)
       fp = fopen(arg[6],"w");
       if (fp == NULL) {
         char str[128];
-        sprintf(str,"Cannot open fix tmd file %s",arg[6]);
+        snprintf(str,128,"Cannot open fix tmd file %s",arg[6]);
         error->one(FLERR,str);
       }
       fprintf(fp,"%s %s\n","# Step rho_target rho_old gamma_back",
@@ -523,7 +523,7 @@ void FixTMD::open(char *file)
   else {
 #ifdef LAMMPS_GZIP
     char gunzip[128];
-    sprintf(gunzip,"gzip -c -d %s",file);
+    snprintf(gunzip,128,"gzip -c -d %s",file);
 
 #ifdef _WIN32
     fp = _popen(gunzip,"rb");
@@ -538,7 +538,7 @@ void FixTMD::open(char *file)
 
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 }

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -182,8 +182,8 @@ void Force::init()
   if (pair_restart) {
     if (!pair) {
       char msg[128];
-      sprintf(msg,"Must re-specify non-restarted pair style (%s) "
-              "after read_restart", pair_restart);
+      snprintf(msg,128,"Must re-specify non-restarted pair style (%s) "
+               "after read_restart", pair_restart);
       error->all(FLERR,msg);
     }
   }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -267,7 +267,7 @@ void Input::file(const char *filename)
     infile = fopen(filename,"r");
     if (infile == NULL) {
       char str[128];
-      sprintf(str,"Cannot open input script %s",filename);
+      snprintf(str,128,"Cannot open input script %s",filename);
       error->one(FLERR,str);
     }
     infiles[0] = infile;
@@ -526,7 +526,7 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
           *fmtflag='\0';
         }
 
-        sprintf(immediate,fmtstr,variable->compute_equal(var));
+        snprintf(immediate,256,fmtstr,variable->compute_equal(var));
         value = immediate;
 
       // single character variable name, e.g. $a
@@ -541,7 +541,7 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
 
       if (value == NULL) {
         char str[128];
-        sprintf(str,"Substitution for illegal variable %s",var);
+        snprintf(str,128,"Substitution for illegal variable %s",var);
         error->one(FLERR,str);
       }
       // check if storage in str2 needs to be expanded
@@ -1047,7 +1047,7 @@ void Input::include()
     infile = fopen(arg[0],"r");
     if (infile == NULL) {
       char str[128];
-      sprintf(str,"Cannot open input script %s",arg[0]);
+      snprintf(str,128,"Cannot open input script %s",arg[0]);
       error->one(FLERR,str);
     }
     infiles[nfile++] = infile;
@@ -1072,7 +1072,7 @@ void Input::jump()
       infile = fopen(arg[0],"r");
       if (infile == NULL) {
         char str[128];
-        sprintf(str,"Cannot open input script %s",arg[0]);
+        snprintf(str,128,"Cannot open input script %s",arg[0]);
         error->one(FLERR,str);
       }
       infiles[nfile-1] = infile;
@@ -1117,7 +1117,7 @@ void Input::log()
 
       if (logfile == NULL) {
         char str[128];
-        sprintf(str,"Cannot open logfile %s",arg[0]);
+        snprintf(str,128,"Cannot open logfile %s",arg[0]);
         error->one(FLERR,str);
       }
     }
@@ -1196,7 +1196,7 @@ void Input::print()
         else fp = fopen(arg[iarg+1],"a");
         if (fp == NULL) {
           char str[128];
-          sprintf(str,"Cannot open print file %s",arg[iarg+1]);
+          snprintf(str,128,"Cannot open print file %s",arg[iarg+1]);
           error->one(FLERR,str);
         }
       }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -385,7 +385,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator)
       else infile = fopen(arg[inflag],"r");
       if (infile == NULL) {
         char str[128];
-        sprintf(str,"Cannot open input script %s",arg[inflag]);
+        snprintf(str,128,"Cannot open input script %s",arg[inflag]);
         error->one(FLERR,str);
       }
     }
@@ -416,7 +416,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator)
          screen = NULL;
        else {
          char str[128];
-         sprintf(str,"%s.%d",arg[screenflag],universe->iworld);
+         snprintf(str,128,"%s.%d",arg[screenflag],universe->iworld);
          screen = fopen(str,"w");
          if (screen == NULL) error->one(FLERR,"Cannot open screen file");
        }
@@ -424,7 +424,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator)
         screen = NULL;
       else {
         char str[128];
-        sprintf(str,"%s.%d",arg[partscreenflag],universe->iworld);
+        snprintf(str,128,"%s.%d",arg[partscreenflag],universe->iworld);
         screen = fopen(str,"w");
         if (screen == NULL) error->one(FLERR,"Cannot open screen file");
       } else screen = NULL;
@@ -440,7 +440,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator)
          logfile = NULL;
        else {
          char str[128];
-         sprintf(str,"%s.%d",arg[logflag],universe->iworld);
+         snprintf(str,128,"%s.%d",arg[logflag],universe->iworld);
          logfile = fopen(str,"w");
          if (logfile == NULL) error->one(FLERR,"Cannot open logfile");
        }
@@ -448,7 +448,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator)
         logfile = NULL;
       else {
         char str[128];
-        sprintf(str,"%s.%d",arg[partlogflag],universe->iworld);
+        snprintf(str,128,"%s.%d",arg[partlogflag],universe->iworld);
         logfile = fopen(str,"w");
         if (logfile == NULL) error->one(FLERR,"Cannot open logfile");
       } else logfile = NULL;
@@ -457,7 +457,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator)
       infile = fopen(arg[inflag],"r");
       if (infile == NULL) {
         char str[128];
-        sprintf(str,"Cannot open input script %s",arg[inflag]);
+        snprintf(str,128,"Cannot open input script %s",arg[inflag]);
         error->one(FLERR,str);
       }
     } else infile = NULL;
@@ -579,10 +579,10 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator)
 
   if (restartflag) {
     char cmd[128];
-    sprintf(cmd,"read_restart %s\n",rfile);
+    snprintf(cmd,128,"read_restart %s\n",rfile);
     if (restartremapflag) strcat(cmd," remap\n");
     input->one(cmd);
-    sprintf(cmd,"write_data %s",dfile);
+    snprintf(cmd,128,"write_data %s",dfile);
     for (iarg = wdfirst; iarg < wdlast; iarg++)
       sprintf(&cmd[strlen(cmd)]," %s",arg[iarg]);
     strcat(cmd," noinit\n");

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -121,6 +121,7 @@ void Memory::sfree(void *ptr)
 void Memory::fail(const char *name)
 {
   char str[128];
-  sprintf(str,"Cannot create/grow a vector/array of pointers for %s",name);
+  snprintf(str,128,
+           "Cannot create/grow a vector/array of pointers for %s",name);
   error->one(FLERR,str);
 }

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -239,7 +239,8 @@ void Modify::init()
   for (i = 0; i < nfix; i++)
     if (!fix[i]->dynamic_group_allow && group->dynamic[fix[i]->igroup]) {
       char str[128];
-      sprintf(str,"Fix %s does not allow use of dynamic group",fix[i]->id);
+      snprintf(str,128,
+               "Fix %s does not allow use of dynamic group",fix[i]->id);
       error->all(FLERR,str);
     }
 
@@ -247,7 +248,7 @@ void Modify::init()
     if (!compute[i]->dynamic_group_allow &&
         group->dynamic[compute[i]->igroup]) {
       char str[128];
-      sprintf(str,"Compute %s does not allow use of dynamic group",fix[i]->id);
+      snprintf(str,128,"Compute %s does not allow use of dynamic group",fix[i]->id);
       error->all(FLERR,str);
     }
 
@@ -889,7 +890,7 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
 
   if (fix[ifix] == NULL) {
     char str[128];
-    sprintf(str,"Unknown fix style %s",arg[2]);
+    snprintf(str,128,"Unknown fix style %s",arg[2]);
     error->all(FLERR,str);
   }
 
@@ -1191,7 +1192,7 @@ void Modify::add_compute(int narg, char **arg, int trysuffix)
 
   if (compute[ncompute] == NULL) {
     char str[128];
-    sprintf(str,"Unknown compute style %s",arg[2]);
+    snprintf(str,128,"Unknown compute style %s",arg[2]);
     error->all(FLERR,str);
   }
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1632,7 +1632,7 @@ void Molecule::open(char *file)
   fp = fopen(file,"r");
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open molecule file %s",file);
+    snprintf(str,128,"Cannot open molecule file %s",file);
     error->one(FLERR,str);
   }
 }

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -1408,7 +1408,6 @@ void Neighbor::init_topology()
 void Neighbor::print_pairwise_info()
 {
   int i,m;
-  char str[256];
   NeighRequest *rq;
   FILE *out;
 
@@ -1457,18 +1456,17 @@ void Neighbor::print_pairwise_info()
         rq = requests[i];
         if (rq->pair) {
           char *pname = force->pair_match_ptr((Pair *) rq->requestor);
-          sprintf(str,"  (%d) pair %s",i+1,pname);
+          fprintf(out,"  (%d) pair %s",i+1,pname);
         } else if (rq->fix) {
-          sprintf(str,"  (%d) fix %s",i+1,((Fix *) rq->requestor)->style);
+          fprintf(out,"  (%d) fix %s",i+1,((Fix *) rq->requestor)->style);
         } else if (rq->compute) {
-          sprintf(str,"  (%d) compute %s",i+1,
+          fprintf(out,"  (%d) compute %s",i+1,
                   ((Compute *) rq->requestor)->style);
         } else if (rq->command) {
-          sprintf(str,"  (%d) command %s",i+1,rq->command_style);
+          fprintf(out,"  (%d) command %s",i+1,rq->command_style);
         } else if (rq->neigh) {
-          sprintf(str,"  (%d) neighbor class addition",i+1);
+          fprintf(out,"  (%d) neighbor class addition",i+1);
         }
-        fprintf(out,"%s",str);
 
         if (rq->occasional) fprintf(out,", occasional");
         else fprintf(out,", perpetual");

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -1408,7 +1408,7 @@ void Neighbor::init_topology()
 void Neighbor::print_pairwise_info()
 {
   int i,m;
-  char str[128];
+  char str[256];
   NeighRequest *rq;
   FILE *out;
 

--- a/src/pair_coul_streitz.cpp
+++ b/src/pair_coul_streitz.cpp
@@ -258,7 +258,7 @@ void PairCoulStreitz::read_file(char *file)
     fp = fopen(file,"r");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open coul/streitz potential file %s",file);
+      snprintf(str,128,"Cannot open coul/streitz potential file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/pair_table.cpp
+++ b/src/pair_table.cpp
@@ -362,7 +362,7 @@ void PairTable::read_table(Table *tb, char *file, char *keyword)
   FILE *fp = force->open_potential(file);
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -706,7 +706,7 @@ void ReadData::command(int narg, char **arg)
 
       } else {
         char str[128];
-        sprintf(str,"Unknown identifier in data file: %s",keyword);
+        snprintf(str,128,"Unknown identifier in data file: %s",keyword);
         error->all(FLERR,str);
       }
 
@@ -1919,7 +1919,7 @@ void ReadData::open(char *file)
   else {
 #ifdef LAMMPS_GZIP
     char gunzip[128];
-    sprintf(gunzip,"gzip -c -d %s",file);
+    snprintf(gunzip,128,"gzip -c -d %s",file);
 
 #ifdef _WIN32
     fp = _popen(gunzip,"rb");
@@ -1934,7 +1934,7 @@ void ReadData::open(char *file)
 
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 }

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -138,7 +138,7 @@ void ReadRestart::command(int narg, char **arg)
     fp = fopen(hfile,"rb");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open restart file %s",hfile);
+      snprintf(str,128,"Cannot open restart file %s",hfile);
       error->one(FLERR,str);
     }
     if (multiproc) delete [] hfile;
@@ -297,7 +297,7 @@ void ReadRestart::command(int narg, char **arg)
       fp = fopen(procfile,"rb");
       if (fp == NULL) {
         char str[128];
-        sprintf(str,"Cannot open restart file %s",procfile);
+        snprintf(str,128,"Cannot open restart file %s",procfile);
         error->one(FLERR,str);
       }
 
@@ -369,7 +369,7 @@ void ReadRestart::command(int narg, char **arg)
       fp = fopen(procfile,"rb");
       if (fp == NULL) {
         char str[128];
-        sprintf(str,"Cannot open restart file %s",procfile);
+        snprintf(str,128,"Cannot open restart file %s",procfile);
         error->one(FLERR,str);
       }
       delete [] procfile;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -41,7 +41,7 @@ void Reader::open_file(const char *file)
   else {
 #ifdef LAMMPS_GZIP
     char gunzip[1024];
-    sprintf(gunzip,"gzip -c -d %s",file);
+    snprintf(gunzip,1024,"gzip -c -d %s",file);
 
 #ifdef _WIN32
     fp = _popen(gunzip,"rb");
@@ -56,7 +56,7 @@ void Reader::open_file(const char *file)
 
   if (fp == NULL) {
     char str[128];
-    sprintf(str,"Cannot open file %s",file);
+    snprintf(str,128,"Cannot open file %s",file);
     error->one(FLERR,str);
   }
 }

--- a/src/universe.cpp
+++ b/src/universe.cpp
@@ -204,7 +204,7 @@ void Universe::add_world(char *str)
 
     if (!valid) {
       char msg[128];
-      sprintf(msg,"Invalid partition string '%s'",str);
+      snprintf(msg,128,"Invalid partition string '%s'",str);
       error->universe_all(FLERR,msg);
     }
   } else nper = nprocs;
@@ -269,7 +269,7 @@ char *date2num(const char *version)
     year = atoi(version);
   }
 
-  char *ver = new char[10];
+  char *ver = new char[64];
   sprintf(ver,"%04d%02d%02d", year % 10000, month, day % 100);
 
   return ver;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -528,7 +528,7 @@ void Variable::set(int narg, char **arg)
   for (int i = 0; i < n-1; i++)
     if (!isalnum(names[nvar][i]) && names[nvar][i] != '_') {
       char errmsg[128];
-      sprintf(errmsg,"Variable name '%s' must have only alphanumeric "
+      snprintf(errmsg,128,"Variable name '%s' must have only alphanumeric "
               "characters or underscore",names[nvar]);
       error->all(FLERR,errmsg);
     }
@@ -586,7 +586,7 @@ int Variable::next(int narg, char **arg)
     ivar = find(arg[iarg]);
     if (ivar < 0) {
       char errmsg[128];
-      sprintf(errmsg,"Invalid variable '%s' in next command",arg[iarg]);
+      snprintf(errmsg,128,"Invalid variable '%s' in next command",arg[iarg]);
       error->all(FLERR,errmsg);
     }
     if (style[ivar] == ULOOP && style[find(arg[0])] == UNIVERSE) continue;
@@ -886,7 +886,7 @@ char *Variable::retrieve(char *name)
     int ifunc = python->variable_match(data[ivar][0],name,0);
     if (ifunc < 0) {
       char errmsg[128];
-      sprintf(errmsg,"Python variable '%s' does not match Python function",name);
+      snprintf(errmsg,128,"Python variable '%s' does not match Python function",name);
       error->all(FLERR,errmsg);
     }
     python->invoke_function(ifunc,data[ivar][1]);
@@ -1597,7 +1597,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
         int ifix = modify->find_fix(word+2);
         if (ifix < 0) {
           char msg[128];
-          sprintf(msg,"Invalid fix ID '%s' in variable formula",word+2);
+          snprintf(msg,128,"Invalid fix ID '%s' in variable formula",word+2);
           print_var_error(FLERR,msg,ivar);
         }
         Fix *fix = modify->fix[ifix];
@@ -2032,8 +2032,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
                                     argstack,nargstack,ivar));
           else {
             char msg[128];
-            sprintf(msg,"Invalid math/group/special function '%s()'"
-                    "in variable formula", word);
+            snprintf(msg,128,"Invalid math/group/special function '%s()'"
+                     "in variable formula", word);
             print_var_error(FLERR,msg,ivar);
           }
           delete [] contents;
@@ -2092,7 +2092,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           int flag = output->thermo->evaluate_keyword(word,&value1);
           if (flag) {
             char msg[128];
-            sprintf(msg,"Invalid thermo keyword '%s' in variable formula",word);
+            snprintf(msg,128,"Invalid thermo keyword '%s' in variable formula",word);
             print_var_error(FLERR,msg,ivar);
           }
           if (tree) {
@@ -4013,7 +4013,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
       int icompute = modify->find_compute(&args[0][2]);
       if (icompute < 0) {
         char msg[128];
-        sprintf(msg,"Invalid compute ID '%s' in variable formula",word+2);
+        snprintf(msg,128,"Invalid compute ID '%s' in variable formula",word+2);
         print_var_error(FLERR,msg,ivar);
       }
       compute = modify->compute[icompute];
@@ -4656,7 +4656,7 @@ void Variable::print_var_error(const char *srcfile, int lineno,
   if ((ivar >= 0) && (ivar < nvar)) {
     char msg[128];
 
-    sprintf(msg,"Variable %s: %s",names[ivar],errmsg);
+    snprintf(msg,128,"Variable %s: %s",names[ivar],errmsg);
     error->all(srcfile,lineno,msg);
   } else error->all(srcfile,lineno,errmsg);
 }
@@ -4944,7 +4944,7 @@ VarReader::VarReader(LAMMPS *lmp, char *name, char *file, int flag) :
     fp = fopen(file,"r");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open file variable file %s",file);
+      snprintf(str,128,"Cannot open file variable file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/write_coeff.cpp
+++ b/src/write_coeff.cpp
@@ -51,7 +51,7 @@ void WriteCoeff::command(int narg, char **arg)
     char str[256], coeff[256];
     FILE *one = fopen(file,"wb+");
     if (one == NULL) {
-          sprintf(str,"Cannot open coeff file %s",file);
+      snprintf(str,256,"Cannot open coeff file %s",file);
       error->one(FLERR,str);
     }
 
@@ -86,7 +86,7 @@ void WriteCoeff::command(int narg, char **arg)
 
     FILE *two = fopen(file+4,"w");
     if (two == NULL) {
-      sprintf(str,"Cannot open coeff file %s",file+4);
+      snprintf(str,256,"Cannot open coeff file %s",file+4);
       error->one(FLERR,str);
     }
     fprintf(two,"# LAMMPS coeff file via write_coeff, version %s\n",

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -183,7 +183,7 @@ void WriteData::write(char *file)
     fp = fopen(file,"w");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open data file %s",file);
+      snprintf(str,128,"Cannot open data file %s",file);
       error->one(FLERR,str);
     }
   }

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -269,7 +269,7 @@ void WriteRestart::write(char *file)
     fp = fopen(hfile,"wb");
     if (fp == NULL) {
       char str[128];
-      sprintf(str,"Cannot open restart file %s",hfile);
+      snprintf(str,128,"Cannot open restart file %s",hfile);
       error->one(FLERR,str);
     }
     if (multiproc) delete [] hfile;
@@ -334,7 +334,7 @@ void WriteRestart::write(char *file)
       fp = fopen(multiname,"wb");
       if (fp == NULL) {
         char str[128];
-        sprintf(str,"Cannot open restart file %s",multiname);
+        snprintf(str,128,"Cannot open restart file %s",multiname);
         error->one(FLERR,str);
       }
       write_int(PROCSPERFILE,nclusterprocs);


### PR DESCRIPTION

## Purpose

This pull request addresses more issues like in #1105 through using snprintf() when printing unchecked strings to fixed size buffers.

## Author(s)

Indonesia LAMMPS Tutorial 2018

## Backward Compatibility

Yes. 

## Implementation Notes

We used to avoid snprintf() because it was not portable to Windows, but since VC++ has this since the 2015 version, it is less of a problem now.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

