### PR TITLE
Rename files for pair style eam/cd/omp in USER-OMP

### DIFF
--- a/src/Purge.list
+++ b/src/Purge.list
@@ -24,6 +24,9 @@ style_nstencil.h
 style_ntopo.h
 # other auto-generated files
 lmpinstalledpkgs.h
+# renamed on 6 September 2018
+pair_cdeam_omp.h
+pair_cdeam_omp.cpp
 # renamed on 31 July 2018
 pair_cdeam.h
 pair_cdeam.cpp

--- a/src/USER-OMP/pair_eam_cd_omp.cpp
+++ b/src/USER-OMP/pair_eam_cd_omp.cpp
@@ -15,7 +15,7 @@
 #include <cmath>
 #include <cstring>
 
-#include "pair_cdeam_omp.h"
+#include "pair_eam_cd_omp.h"
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
@@ -44,8 +44,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairCDEAMOMP::PairCDEAMOMP(LAMMPS *lmp, int _cdeamVersion) :
-  PairEAM(lmp), PairCDEAM(lmp,_cdeamVersion), ThrOMP(lmp, THR_PAIR)
+PairEAMCDOMP::PairEAMCDOMP(LAMMPS *lmp, int _cdeamVersion) :
+  PairEAM(lmp), PairEAMCD(lmp,_cdeamVersion), ThrOMP(lmp, THR_PAIR)
 {
   suffix_flag |= Suffix::OMP;
   respa_enable = 0;
@@ -53,7 +53,7 @@ PairCDEAMOMP::PairCDEAMOMP(LAMMPS *lmp, int _cdeamVersion) :
 
 /* ---------------------------------------------------------------------- */
 
-void PairCDEAMOMP::compute(int eflag, int vflag)
+void PairEAMCDOMP::compute(int eflag, int vflag)
 {
   if (eflag || vflag) {
     ev_setup(eflag,vflag);
@@ -143,7 +143,7 @@ void PairCDEAMOMP::compute(int eflag, int vflag)
 }
 
 template <int EVFLAG, int EFLAG, int NEWTON_PAIR, int CDEAMVERSION>
-void PairCDEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
+void PairEAMCDOMP::eval(int iifrom, int iito, ThrData * const thr)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
@@ -534,10 +534,10 @@ void PairCDEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
 
 /* ---------------------------------------------------------------------- */
 
-double PairCDEAMOMP::memory_usage()
+double PairEAMCDOMP::memory_usage()
 {
   double bytes = memory_usage_thr();
-  bytes += PairCDEAM::memory_usage();
+  bytes += PairEAMCD::memory_usage();
 
   return bytes;
 }

--- a/src/USER-OMP/pair_eam_cd_omp.h
+++ b/src/USER-OMP/pair_eam_cd_omp.h
@@ -17,23 +17,23 @@
 
 #ifdef PAIR_CLASS
 
-PairStyle(eam/cd/omp,PairCDEAM_OneSiteOMP)
-PairStyle(eam/cd/old/omp,PairCDEAM_TwoSiteOMP)
+PairStyle(eam/cd/omp,PairEAMCD_OneSiteOMP)
+PairStyle(eam/cd/old/omp,PairEAMCD_TwoSiteOMP)
 
 #else
 
-#ifndef LMP_PAIR_CDEAM_OMP_H
-#define LMP_PAIR_CDEAM_OMP_H
+#ifndef LMP_PAIR_EAM_CD_OMP_H
+#define LMP_PAIR_EAM_CD_OMP_H
 
-#include "pair_cdeam.h"
+#include "pair_eam_cd.h"
 #include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class PairCDEAMOMP : public PairCDEAM, public ThrOMP {
+class PairEAMCDOMP : public PairEAMCD, public ThrOMP {
 
  public:
-  PairCDEAMOMP(class LAMMPS *, int);
+  PairEAMCDOMP(class LAMMPS *, int);
 
   virtual void compute(int, int);
   virtual double memory_usage();
@@ -44,19 +44,19 @@ class PairCDEAMOMP : public PairCDEAM, public ThrOMP {
 };
 
   /// The one-site concentration formulation of CD-EAM.
-  class PairCDEAM_OneSiteOMP : public PairCDEAMOMP
+  class PairEAMCD_OneSiteOMP : public PairEAMCDOMP
   {
   public:
     /// Constructor.
-    PairCDEAM_OneSiteOMP(class LAMMPS* lmp) : PairEAM(lmp), PairCDEAMOMP(lmp, 1) {}
+    PairEAMCD_OneSiteOMP(class LAMMPS* lmp) : PairEAM(lmp), PairEAMCDOMP(lmp, 1) {}
   };
 
   /// The two-site concentration formulation of CD-EAM.
-  class PairCDEAM_TwoSiteOMP : public PairCDEAMOMP
+  class PairEAMCD_TwoSiteOMP : public PairEAMCDOMP
   {
   public:
     /// Constructor.
-    PairCDEAM_TwoSiteOMP(class LAMMPS* lmp) : PairEAM(lmp), PairCDEAMOMP(lmp, 2) {}
+    PairEAMCD_TwoSiteOMP(class LAMMPS* lmp) : PairEAM(lmp), PairEAMCDOMP(lmp, 2) {}
   };
 
 }


### PR DESCRIPTION
## Purpose

Pair style `eam/cd` was recently move from USER-MISC to MANYBODY and in the process the internal class names and file names changed. The same change was not done for USER-OMP and thus, the eam/cd/omp variants were no longer installed. This PR corrects the oversight.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

Yes, unexpected incompatibility is removed.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


