### PR TITLE
The sna*/atom computes were not destroying SNA objects. Fixed.

### DIFF
--- a/src/SNAP/compute_sna_atom.cpp
+++ b/src/SNAP/compute_sna_atom.cpp
@@ -115,7 +115,8 @@ ComputeSNAAtom::ComputeSNAAtom(LAMMPS *lmp, int narg, char **arg) :
     } else error->all(FLERR,"Illegal compute sna/atom command");
   }
 
-  snaptr = new SNA*[comm->nthreads];
+  nthreads = comm->nthreads;
+  snaptr = new SNA*[nthreads];
 #if defined(_OPENMP)
 #pragma omp parallel default(none) shared(lmp,rfac0,twojmax,rmin0,switchflag,bzeroflag)
 #endif
@@ -146,6 +147,8 @@ ComputeSNAAtom::~ComputeSNAAtom()
   memory->destroy(radelem);
   memory->destroy(wjelem);
   memory->destroy(cutsq);
+  for (int tid = 0; tid<nthreads; tid++)
+    delete snaptr[tid];
   delete [] snaptr;
 }
 

--- a/src/SNAP/compute_sna_atom.h
+++ b/src/SNAP/compute_sna_atom.h
@@ -45,6 +45,7 @@ class ComputeSNAAtom : public Compute {
   class SNA** snaptr;
   double cutmax;
   int quadraticflag;
+  int nthreads;
 };
 
 }

--- a/src/SNAP/compute_snad_atom.cpp
+++ b/src/SNAP/compute_snad_atom.cpp
@@ -148,6 +148,8 @@ ComputeSNADAtom::~ComputeSNADAtom()
   memory->destroy(radelem);
   memory->destroy(wjelem);
   memory->destroy(cutsq);
+  for (int tid = 0; tid<nthreads; tid++)
+    delete snaptr[tid];
   delete [] snaptr;
 }
 

--- a/src/SNAP/compute_snad_atom.h
+++ b/src/SNAP/compute_snad_atom.h
@@ -47,6 +47,7 @@ class ComputeSNADAtom : public Compute {
   class SNA** snaptr;
   double cutmax;
   int quadraticflag;
+  int nthreads;
 };
 
 }

--- a/src/SNAP/compute_snav_atom.cpp
+++ b/src/SNAP/compute_snav_atom.cpp
@@ -142,6 +142,9 @@ ComputeSNAVAtom::~ComputeSNAVAtom()
   memory->destroy(radelem);
   memory->destroy(wjelem);
   memory->destroy(cutsq);
+
+  for (int tid = 0; tid<nthreads; tid++)
+    delete snaptr[tid];
   delete [] snaptr;
 }
 

--- a/src/SNAP/compute_snav_atom.h
+++ b/src/SNAP/compute_snav_atom.h
@@ -46,6 +46,7 @@ class ComputeSNAVAtom : public Compute {
   double *wjelem;
   class SNA** snaptr;
   int quadraticflag;
+  int nthreads;
 };
 
 }


### PR DESCRIPTION
## Purpose

This fixes a memory leak related to threading, but occurs even without threading. The sna*/atom computes were not destroying the SNA objects they created. Added a loop over elements of SNA* snaptr, deleting each one.

## Author(s)

SNL

## Backward Compatibility

Fully backward compatible.

## Implementation Notes

None

## Post Submission Checklist

No change in functionality.

## Further Information, Files, and Links



