### PR TITLE
Warn more loudly about REAX and MEAM going away soon

### DIFF
--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -48,8 +48,8 @@ static const char *keywords[] = {
 PairMEAM::PairMEAM(LAMMPS *lmp) : Pair(lmp)
 {
   if (comm->me == 0)
-    error->warning(FLERR,"The pair_style meam command is unsupported. "
-                   "Please use pair_style meam/c instead");
+    error->warning(FLERR,"THE pair_style meam COMMAND IS OBSOLETE AND "
+                   "WILL BE REMOVED VERY SOON. PLEASE USE meam/c");
 
   single_enable = 0;
   restartinfo = 0;

--- a/src/REAX/pair_reax.cpp
+++ b/src/REAX/pair_reax.cpp
@@ -46,8 +46,8 @@ using namespace LAMMPS_NS;
 PairREAX::PairREAX(LAMMPS *lmp) : Pair(lmp)
 {
   if (comm->me == 0)
-    error->warning(FLERR,"The pair_style reax command is unsupported. "
-                   "Please switch to pair_style reax/c instead");
+    error->warning(FLERR,"THE pair_style reax COMMAND IS OBSOLETE AND "
+                   "WILL BE REMOVED VERY SOON. PLEASE USE reax/c");
 
   single_enable = 0;
   restartinfo = 0;


### PR DESCRIPTION
## Purpose

As discussed with @athomps we will more warn more loudly about the REAX and MEAM packages going away. They will be removed after the next stable release planned for mid-late November.

## Author(s)

Axel Kohlmeyer

## Backward Compatibility

yes.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete

