### PR TITLE
Fixed sign error on mu for semigrand variant

### DIFF
--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -377,7 +377,7 @@ int FixAtomSwap::attempt_semi_grand()
   int success = 0;
   if (i >= 0)
     if (random_unequal->uniform() <
-      exp(-beta*(energy_after - energy_before
+      exp(beta*(energy_before - energy_after
             + mu[jtype] - mu[itype]))) success = 1;
 
   int success_all = 0;


### PR DESCRIPTION
## Purpose

Fix obvious sign error on chemical potential (mu) used in semigrand variant of fix atom/swap. Fixes #1139 

## Author(s)

@sinamoeini and @athomps

## Backward Compatibility

As explained in #1139 , this will change behavior substantially relative to old code. Old behavior can be recovered by changing sign of mu values in input script.  

## Implementation Notes

n/a

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links



