### PR TITLE
Resolve neighbor list request conflict with USER-INTEL and USER-OMP

### DIFF
--- a/src/USER-INTEL/fix_intel.cpp
+++ b/src/USER-INTEL/fix_intel.cpp
@@ -532,8 +532,13 @@ void FixIntel::check_neighbor_intel()
       _offload_noghost = 0;
     }
     #endif
+
+    // avoid flagging a neighbor list as both USER-INTEL and USER-OMP
+    if (neighbor->requests[i]->intel)
+      neighbor->requests[i]->omp = 0;
+
     if (neighbor->requests[i]->skip)
-      error->all(FLERR, "Cannot yet use hybrid styles with Intel package.");
+      error->all(FLERR, "Hybrid styles with Intel package are unsupported.");
   }
 }
 

--- a/src/USER-OMP/fix_omp.cpp
+++ b/src/USER-OMP/fix_omp.cpp
@@ -318,8 +318,11 @@ void FixOMP::set_neighbor_omp()
   const int neigh_omp = _neighbor ? 1 : 0;
   const int nrequest = neighbor->nrequest;
 
+  // flag *all* neighbor list requests as USER-OMP threaded,
+  // but skip lists already flagged as USER-INTEL threaded
   for (int i = 0; i < nrequest; ++i)
-    neighbor->requests[i]->omp = neigh_omp;
+    if (! neighbor->requests[i]->intel)
+      neighbor->requests[i]->omp = neigh_omp;
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
## Purpose

Avoid setting both the intel and omp flag in a neighbor list request, when both USER-OMP and USER-INTEL pair styles are used in a hybrid pair styles. closes #1140 

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

yes.

## Implementation Notes

When using the USER-OMP package (and the package omp command) all neighbor list requests are flagged to use the multi-threaded versions from the USER-OMP package, even if not multi-threaded.
However, when using both, USER-INTEL and USER-OMP styles, the neighbor list requests contain both flags, which are mutually exclusive. thus a suitable neighbor list build style cannot be found.
This changes the neighbor list request processing/checking code in both, fix omp and fix intel, to avoid this situation and the resulting crash.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

