### PR TITLE
Implement dummy classes for deprecated and removed styles

### DIFF
--- a/src/angle_deprecated.cpp
+++ b/src/angle_deprecated.cpp
@@ -1,0 +1,57 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "angle_deprecated.h"
+#include "angle_hybrid.h"
+#include "comm.h"
+#include "force.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This angle style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void AngleDeprecated::settings(int, char **)
+{
+  const char *my_style = force->angle_style;
+
+  // hybrid substyles are created in AngleHybrid::settings(), so when this is
+  // called, our style was just added at the end of the list of substyles
+
+  if (strncmp(my_style,"hybrid",6) == 0) {
+    AngleHybrid *hybrid = (AngleHybrid *)force->angle;
+    my_style = hybrid->keywords[hybrid->nstyles];
+  }
+
+  if (strcmp(my_style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nAngle style 'DEPRECATED' is a dummy style\n\n",0);
+
+  }
+}  
+
+

--- a/src/angle_deprecated.h
+++ b/src/angle_deprecated.h
@@ -11,28 +11,31 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef PAIR_CLASS
+#ifdef ANGLE_CLASS
 
-PairStyle(DEPRECATED,PairDeprecated)
+AngleStyle(DEPRECATED,AngleDeprecated)
 
 #else
 
-#ifndef LMP_PAIR_DEPRECATED_H
-#define LMP_PAIR_DEPRECATED_H
+#ifndef LMP_ANGLE_DEPRECATED_H
+#define LMP_ANGLE_DEPRECATED_H
 
-#include "pair.h"
+#include "angle.h"
 
 namespace LAMMPS_NS {
 
-class PairDeprecated : public Pair {
+class AngleDeprecated : public Angle {
  public:
-  PairDeprecated(class LAMMPS *lmp) : Pair(lmp) {}
-  virtual ~PairDeprecated() {}
+  AngleDeprecated(class LAMMPS *lmp) : Angle(lmp) {}
+  virtual ~AngleDeprecated() {}
 
   virtual void compute(int, int) {}
   virtual void settings(int, char **);
   virtual void coeff(int, char **) {}
-
+  virtual double equilibrium_angle(int) { return 0.0; }
+  virtual void write_restart(FILE *) {}
+  virtual void read_restart(FILE *) {}
+  virtual double single(int, int, int, int) { return 0.0; }
 };
 
 }

--- a/src/bond_deprecated.cpp
+++ b/src/bond_deprecated.cpp
@@ -1,0 +1,57 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "bond_deprecated.h"
+#include "bond_hybrid.h"
+#include "comm.h"
+#include "force.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This bond style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondDeprecated::settings(int, char **)
+{
+  const char *my_style = force->bond_style;
+
+  // hybrid substyles are created in BondHybrid::settings(), so when this is
+  // called, our style was just added at the end of the list of substyles
+
+  if (strncmp(my_style,"hybrid",6) == 0) {
+    BondHybrid *hybrid = (BondHybrid *)force->bond;
+    my_style = hybrid->keywords[hybrid->nstyles];
+  }
+
+  if (strcmp(my_style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nBond style 'DEPRECATED' is a dummy style\n\n",0);
+
+  }
+}  
+
+

--- a/src/bond_deprecated.h
+++ b/src/bond_deprecated.h
@@ -11,28 +11,31 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef PAIR_CLASS
+#ifdef BOND_CLASS
 
-PairStyle(DEPRECATED,PairDeprecated)
+BondStyle(DEPRECATED,BondDeprecated)
 
 #else
 
-#ifndef LMP_PAIR_DEPRECATED_H
-#define LMP_PAIR_DEPRECATED_H
+#ifndef LMP_BOND_DEPRECATED_H
+#define LMP_BOND_DEPRECATED_H
 
-#include "pair.h"
+#include "bond.h"
 
 namespace LAMMPS_NS {
 
-class PairDeprecated : public Pair {
+class BondDeprecated : public Bond {
  public:
-  PairDeprecated(class LAMMPS *lmp) : Pair(lmp) {}
-  virtual ~PairDeprecated() {}
+  BondDeprecated(class LAMMPS *lmp) : Bond(lmp) {}
+  virtual ~BondDeprecated() {}
 
   virtual void compute(int, int) {}
   virtual void settings(int, char **);
   virtual void coeff(int, char **) {}
-
+  virtual double equilibrium_distance(int) { return 0.0; }
+  virtual void write_restart(FILE *) {}
+  virtual void read_restart(FILE *) {}
+  virtual double single(int, double, int, int, double &) { return 0.0; }
 };
 
 }

--- a/src/compute_deprecated.cpp
+++ b/src/compute_deprecated.cpp
@@ -1,0 +1,39 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "compute_deprecated.h"
+#include "comm.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This compute style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeDeprecated::ComputeDeprecated(LAMMPS *lmp, int narg, char **arg) :
+  Compute(lmp, narg, arg)
+{
+  if (strcmp(style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nCompute style 'DEPRECATED' is a dummy style\n\n",0);
+  }
+}

--- a/src/compute_deprecated.h
+++ b/src/compute_deprecated.h
@@ -1,0 +1,47 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+
+// list all deprecated and removed compute styles here
+
+ComputeStyle(DEPRECATED,ComputeDeprecated)
+
+#else
+
+#ifndef LMP_COMPUTE_DEPRECATED_H
+#define LMP_COMPUTE_DEPRECATED_H
+
+#include "compute.h"
+
+namespace LAMMPS_NS {
+
+class ComputeDeprecated : public Compute {
+ public:
+  ComputeDeprecated(class LAMMPS *, int, char **);
+  ~ComputeDeprecated() {}
+  void init() {}
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: This compute command has been removed from LAMMPS
+
+UNDOCUMENTED
+
+*/

--- a/src/deprecated.cpp
+++ b/src/deprecated.cpp
@@ -38,11 +38,8 @@ static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
 
 void Deprecated::command(int narg, char **arg)
 {
-  if (strcmp(input->command,"deprecated") == 0) {
-    writemsg(lmp,"\nCommand 'deprecated' is a dummy command\n\n",0);
+  if (strcmp(input->command,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nCommand 'DEPRECATED' is a dummy command\n\n",0);
 
-  } else if (strcmp(input->command,"XXX") == 0) {
-    writemsg(lmp, "\nCommand 'XXX' has been removed from LAMMPS "
-             "after the\n## XXX 20## stable release.\n\n");
   }
 }

--- a/src/deprecated.cpp
+++ b/src/deprecated.cpp
@@ -12,15 +12,15 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Contributing author: Axel Kohlmeyer (Temple U)
+   Contributing authors:  Axel Kohlmeyer (Temple U),
 ------------------------------------------------------------------------- */
 
 #include <cstring>
-#include "pair_deprecated.h"
-#include "pair_hybrid.h"
+#include "deprecated.h"
 #include "comm.h"
 #include "force.h"
 #include "error.h"
+#include "input.h"
 
 using namespace LAMMPS_NS;
 
@@ -31,31 +31,18 @@ static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
     if (lmp->logfile) fputs(msg,lmp->logfile);
   }
   if (abend)
-    lmp->error->all(FLERR,"This pair_style is no longer available");
+    lmp->error->all(FLERR,"This command is no longer available");
 }
-
 
 /* ---------------------------------------------------------------------- */
 
-void PairDeprecated::settings(int, char **)
+void Deprecated::command(int narg, char **arg)
 {
-  const char *my_style = force->pair_style;
+  if (strcmp(input->command,"deprecated") == 0) {
+    writemsg(lmp,"\nCommand 'deprecated' is a dummy command\n\n",0);
 
-  // hybrid substyles are created in PairHybrid::settings(), so when this is
-  // called, our style was just added at the end of the list of substyles
-  if (strncmp(my_style,"hybrid",6) == 0) {
-    PairHybrid *hybrid = (PairHybrid *)force->pair;
-    my_style = hybrid->keywords[hybrid->nstyles];
+  } else if (strcmp(input->command,"XXX") == 0) {
+    writemsg(lmp, "\nCommand 'XXX' has been removed from LAMMPS "
+             "after the\n## XXX 20## stable release.\n\n");
   }
-
-  if (strcmp(my_style,"deprecated") == 0) {
-    writemsg(lmp,"\nPair style 'deprecated' is a dummy pair style\n\n",0);
-
-  } else if (strcmp(my_style,"reax") == 0) {
-    writemsg(lmp, "\nPair style 'reax' has been removed from LAMMPS "
-             "after the\n## November 2018 stable release. Its "
-             "functionality has\nbeen superseded by pair style 'reax/c'.\n\n");
-  }
-}  
-
-
+}

--- a/src/deprecated.h
+++ b/src/deprecated.h
@@ -1,0 +1,70 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMMAND_CLASS
+
+CommandStyle(deprecated,Deprecated)
+CommandStyle(XXX,Deprecated)
+
+#else
+
+#ifndef LMP_DEPRECATED_H
+#define LMP_DEPRECATED_H
+
+#include "pointers.h"
+
+namespace LAMMPS_NS {
+
+class Deprecated : protected Pointers {
+ public:
+  Deprecated(class LAMMPS *lmp) : Pointers(lmp) {};
+  void command(int, char **);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+W: Ignoring unknown or incorrect info command flag
+
+Self-explanatory.  An unknown argument was given to the info command.
+Compare your input with the documentation.
+
+E: Unknown name for info package category
+
+Self-explanatory.
+
+E: Unknown name for info newton category
+
+Self-explanatory.
+
+E: Unknown name for info pair category
+
+Self-explanatory.
+
+E: Unknown category for info is_active()
+
+Self-explanatory.
+
+E: Unknown category for info is_available()
+
+Self-explanatory.
+
+E: Unknown category for info is_defined()
+
+Self-explanatory.
+
+*/

--- a/src/deprecated.h
+++ b/src/deprecated.h
@@ -13,8 +13,7 @@
 
 #ifdef COMMAND_CLASS
 
-CommandStyle(deprecated,Deprecated)
-CommandStyle(XXX,Deprecated)
+CommandStyle(DEPRECATED,Deprecated)
 
 #else
 

--- a/src/dihedral_deprecated.cpp
+++ b/src/dihedral_deprecated.cpp
@@ -1,0 +1,57 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "dihedral_deprecated.h"
+#include "dihedral_hybrid.h"
+#include "comm.h"
+#include "force.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This dihedral style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DihedralDeprecated::settings(int, char **)
+{
+  const char *my_style = force->dihedral_style;
+
+  // hybrid substyles are created in DihedralHybrid::settings(), so when this is
+  // called, our style was just added at the end of the list of substyles
+
+  if (strncmp(my_style,"hybrid",6) == 0) {
+    DihedralHybrid *hybrid = (DihedralHybrid *)force->dihedral;
+    my_style = hybrid->keywords[hybrid->nstyles];
+  }
+
+  if (strcmp(my_style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nDihedral style 'DEPRECATED' is a dummy style\n\n",0);
+
+  }
+}  
+
+

--- a/src/dihedral_deprecated.h
+++ b/src/dihedral_deprecated.h
@@ -11,28 +11,29 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef PAIR_CLASS
+#ifdef DIHEDRAL_CLASS
 
-PairStyle(DEPRECATED,PairDeprecated)
+DihedralStyle(DEPRECATED,DihedralDeprecated)
 
 #else
 
-#ifndef LMP_PAIR_DEPRECATED_H
-#define LMP_PAIR_DEPRECATED_H
+#ifndef LMP_DIHEDRAL_DEPRECATED_H
+#define LMP_DIHEDRAL_DEPRECATED_H
 
-#include "pair.h"
+#include "dihedral.h"
 
 namespace LAMMPS_NS {
 
-class PairDeprecated : public Pair {
+class DihedralDeprecated : public Dihedral {
  public:
-  PairDeprecated(class LAMMPS *lmp) : Pair(lmp) {}
-  virtual ~PairDeprecated() {}
+  DihedralDeprecated(class LAMMPS *lmp) : Dihedral(lmp) {}
+  virtual ~DihedralDeprecated() {}
 
   virtual void compute(int, int) {}
   virtual void settings(int, char **);
   virtual void coeff(int, char **) {}
-
+  virtual void write_restart(FILE *) {}
+  virtual void read_restart(FILE *) {}
 };
 
 }

--- a/src/dump_deprecated.cpp
+++ b/src/dump_deprecated.cpp
@@ -1,0 +1,40 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "dump_deprecated.h"
+#include "comm.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This dump style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+DumpDeprecated::DumpDeprecated(LAMMPS *lmp, int narg, char **arg) :
+  Dump(lmp, narg, arg)
+{
+  if (strcmp(style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nDump style 'DEPRECATED' is a dummy style\n\n",0);
+
+  }
+}

--- a/src/dump_deprecated.h
+++ b/src/dump_deprecated.h
@@ -1,0 +1,50 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef DUMP_CLASS
+
+// list all deprecated and removed dump styles here
+
+DumpStyle(DEPRECATED,DumpDeprecated)
+
+#else
+
+#ifndef LMP_DUMP_DEPRECATED_H
+#define LMP_DUMP_DEPRECATED_H
+
+#include "dump.h"
+
+namespace LAMMPS_NS {
+
+class DumpDeprecated : public Dump {
+ public:
+  DumpDeprecated(class LAMMPS *, int, char **);
+  ~DumpDeprecated() {}
+  virtual void init_style() {}
+  virtual void write_header(bigint) {}
+  virtual void pack(tagint *) {}
+  virtual void write_data(int, double *) {}
+ };
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: This dump style has been removed from LAMMPS
+
+UNDOCUMENTED
+
+*/

--- a/src/fix_deprecated.cpp
+++ b/src/fix_deprecated.cpp
@@ -18,35 +18,33 @@
 
 using namespace LAMMPS_NS;
 
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This fix style is no longer available");
+}
+
 /* ---------------------------------------------------------------------- */
 
 FixDeprecated::FixDeprecated(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg)
 {
-  if (strcmp(style,"deprecated") == 0) {
-    const char *message = "\n"
-    "NOTE: The fix style 'deprecated' is a dummy fix style that was added to\n"
-    "LAMMPS in order to print suitable error messages for deleted features.\n\n";
+  if (strcmp(style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nFix style 'DEPRECATED' is a dummy style\n\n",0);
 
-    if (comm->me == 0) {
-      if (screen) fputs(message,screen);
-      if (logfile) fputs(message,logfile);
-    }
+  } else if (strncmp(style,"ave/spatial",11) == 0) {
+    writemsg(lmp,"\nFix styles 'ave/spatial' and 'ave/spatial/sphere' have "
+             "been replaced\nby the more general fix ave/chunk and compute "
+             "chunk/atom commands.\nAll ave/spatial and ave/spatial/sphere "
+             "functionality is available in these\nnew commands. These "
+             "ave/spatial keywords & options are part of fix ave/chunk:\n"
+             "  Nevery, Nrepeat, Nfreq, input values, norm, ave, file, "
+             "overwrite, title123\nThese ave/spatial keywords & options for "
+             "binning are part of compute chunk/atom:\n  dim, origin, delta,"
+             " region, bound, discard, units\n\n");
   }
-  if (strncmp(style,"ave/spatial",11) == 0) {
-    const char *message = "\n"
-    "NOTE: The fix styles 'ave/spatial' and 'ave/spatial/sphere' have been replaced\n"
-    "by the more general fix ave/chunk and compute chunk/atom commands.\n"
-    "All ave/spatial and ave/spatial/sphere functionality is available in these\n"
-    "new commands. These ave/spatial keywords & options are part of fix ave/chunk:\n"
-    "  Nevery, Nrepeat, Nfreq, input values, norm, ave, file, overwrite, title123\n"
-    "These ave/spatial keywords & options for binning are part of compute chunk/atom:\n"
-    "  dim, origin, delta, region, bound, discard, units\n\n";
-
-    if (comm->me == 0) {
-      if (screen) fputs(message,screen);
-      if (logfile) fputs(message,logfile);
-    }
-  }
-  error->all(FLERR,"This fix command has been removed from LAMMPS");
 }

--- a/src/fix_deprecated.h
+++ b/src/fix_deprecated.h
@@ -15,7 +15,7 @@
 
 // list all deprecated and removed fix styles here
 
-FixStyle(deprecated,FixDeprecated)
+FixStyle(DEPRECATED,FixDeprecated)
 FixStyle(ave/spatial,FixDeprecated)
 FixStyle(ave/spatial/sphere,FixDeprecated)
 

--- a/src/fix_deprecated.h
+++ b/src/fix_deprecated.h
@@ -15,6 +15,7 @@
 
 // list all deprecated and removed fix styles here
 
+FixStyle(deprecated,FixDeprecated)
 FixStyle(ave/spatial,FixDeprecated)
 FixStyle(ave/spatial/sphere,FixDeprecated)
 

--- a/src/improper_deprecated.cpp
+++ b/src/improper_deprecated.cpp
@@ -1,0 +1,57 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "improper_deprecated.h"
+#include "improper_hybrid.h"
+#include "comm.h"
+#include "force.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This improper style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ImproperDeprecated::settings(int, char **)
+{
+  const char *my_style = force->improper_style;
+
+  // hybrid substyles are created in ImproperHybrid::settings(), so when this is
+  // called, our style was just added at the end of the list of substyles
+
+  if (strncmp(my_style,"hybrid",6) == 0) {
+    ImproperHybrid *hybrid = (ImproperHybrid *)force->improper;
+    my_style = hybrid->keywords[hybrid->nstyles];
+  }
+
+  if (strcmp(my_style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nImproper style 'DEPRECATED' is a dummy style\n\n",0);
+
+  }
+}  
+
+

--- a/src/improper_deprecated.h
+++ b/src/improper_deprecated.h
@@ -11,28 +11,29 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef PAIR_CLASS
+#ifdef IMPROPER_CLASS
 
-PairStyle(DEPRECATED,PairDeprecated)
+ImproperStyle(DEPRECATED,ImproperDeprecated)
 
 #else
 
-#ifndef LMP_PAIR_DEPRECATED_H
-#define LMP_PAIR_DEPRECATED_H
+#ifndef LMP_IMPROPER_DEPRECATED_H
+#define LMP_IMPROPER_DEPRECATED_H
 
-#include "pair.h"
+#include "improper.h"
 
 namespace LAMMPS_NS {
 
-class PairDeprecated : public Pair {
+class ImproperDeprecated : public Improper {
  public:
-  PairDeprecated(class LAMMPS *lmp) : Pair(lmp) {}
-  virtual ~PairDeprecated() {}
+  ImproperDeprecated(class LAMMPS *lmp) : Improper(lmp) {}
+  virtual ~ImproperDeprecated() {}
 
   virtual void compute(int, int) {}
   virtual void settings(int, char **);
   virtual void coeff(int, char **) {}
-
+  virtual void write_restart(FILE *) {}
+  virtual void read_restart(FILE *) {}
 };
 
 }

--- a/src/input.h
+++ b/src/input.h
@@ -24,6 +24,8 @@ namespace LAMMPS_NS {
 class Input : protected Pointers {
   friend class Info;
   friend class Error;
+  friend class Deprecated;
+
  public:
   int narg;                    // # of command args
   char **arg;                  // parsed args for command
@@ -38,9 +40,11 @@ class Input : protected Pointers {
                                  // substitute for variables in a string
   int expand_args(int, char **, int, char **&);  // expand args due to wildcard
 
+ protected:
+  char *command;               // ptr to current command
+
  private:
   int me;                      // proc ID
-  char *command;               // ptr to current command
   int maxarg;                  // max # of args in arg
   char *line,*copy,*work;      // input line & copy and work string
   int maxline,maxcopy,maxwork; // max lengths of char strings

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -785,16 +785,17 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
   //   but can't think of better way
   // too late if instantiate fix, then check flag set in fix constructor,
   //   since some fixes access domain settings in their constructor
-  // MUST change NEXCEPT above when add new fix to this list
+  // NULL must be last entry in this list
 
-  const char *exceptions[NEXCEPT] =
-    {"GPU","OMP","INTEL","property/atom","cmap","cmap3","rx"};
+  const char *exceptions[] =
+    {"GPU", "OMP", "INTEL", "property/atom", "cmap", "cmap3", "rx",
+     "deprecated", NULL};
 
   if (domain->box_exist == 0) {
     int m;
-    for (m = 0; m < NEXCEPT; m++)
+    for (m = 0; exceptions[m] != NULL; m++)
       if (strcmp(arg[2],exceptions[m]) == 0) break;
-    if (m == NEXCEPT)
+    if (exceptions[m] == NULL)
       error->all(FLERR,"Fix command before simulation box is defined");
   }
 

--- a/src/pair_deprecated.cpp
+++ b/src/pair_deprecated.cpp
@@ -31,9 +31,8 @@ static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
     if (lmp->logfile) fputs(msg,lmp->logfile);
   }
   if (abend)
-    lmp->error->all(FLERR,"This pair_style is no longer available");
+    lmp->error->all(FLERR,"This pair style is no longer available");
 }
-
 
 /* ---------------------------------------------------------------------- */
 
@@ -43,18 +42,15 @@ void PairDeprecated::settings(int, char **)
 
   // hybrid substyles are created in PairHybrid::settings(), so when this is
   // called, our style was just added at the end of the list of substyles
+
   if (strncmp(my_style,"hybrid",6) == 0) {
     PairHybrid *hybrid = (PairHybrid *)force->pair;
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 
-  if (strcmp(my_style,"deprecated") == 0) {
-    writemsg(lmp,"\nPair style 'deprecated' is a dummy pair style\n\n",0);
+  if (strcmp(my_style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nPair style 'DEPRECATED' is a dummy style\n\n",0);
 
-  } else if (strcmp(my_style,"reax") == 0) {
-    writemsg(lmp, "\nPair style 'reax' has been removed from LAMMPS "
-             "after the\n## November 2018 stable release. Its "
-             "functionality has\nbeen superseded by pair style 'reax/c'.\n\n");
   }
 }  
 

--- a/src/pair_deprecated.cpp
+++ b/src/pair_deprecated.cpp
@@ -53,8 +53,7 @@ void PairDeprecated::settings(int, char **)
   } else if (strcmp(my_style,"reax") == 0) {
     writemsg(lmp, "\nPair style 'reax' has been removed from LAMMPS "
              "after the\n## November 2018 stable release. Its "
-             "functionality has long before\nbeen superseded by pair "
-             "styles 'reax/c' and 'reax/c/kk'\n\n");
+             "functionality has\nbeen superseded by pair style 'reax/c'.\n\n");
   }
 }  
 

--- a/src/pair_deprecated.cpp
+++ b/src/pair_deprecated.cpp
@@ -11,21 +11,25 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#include <cstring>
-#include "fix_deprecated.h"
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "pair_deprecated.h"
+#include "pair_hybrid.h"
 #include "comm.h"
+#include "force.h"
 #include "error.h"
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-FixDeprecated::FixDeprecated(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg)
+PairDeprecated::PairDeprecated(LAMMPS *lmp) : Pair(lmp)
 {
-  if (strcmp(style,"deprecated") == 0) {
+  if (strcmp(force->pair_style,"deprecated") == 0) {
     const char *message = "\n"
-    "NOTE: The fix style 'deprecated' is a dummy fix style that was added to\n"
+    "NOTE: The pair style 'deprecated' is a dummy fix style that was added to\n"
     "LAMMPS in order to print suitable error messages for deleted features.\n\n";
 
     if (comm->me == 0) {
@@ -33,20 +37,17 @@ FixDeprecated::FixDeprecated(LAMMPS *lmp, int narg, char **arg) :
       if (logfile) fputs(message,logfile);
     }
   }
-  if (strncmp(style,"ave/spatial",11) == 0) {
+  if (strncmp(force->pair_style,"reax",11) == 0) {
     const char *message = "\n"
-    "NOTE: The fix styles 'ave/spatial' and 'ave/spatial/sphere' have been replaced\n"
-    "by the more general fix ave/chunk and compute chunk/atom commands.\n"
-    "All ave/spatial and ave/spatial/sphere functionality is available in these\n"
-    "new commands. These ave/spatial keywords & options are part of fix ave/chunk:\n"
-    "  Nevery, Nrepeat, Nfreq, input values, norm, ave, file, overwrite, title123\n"
-    "These ave/spatial keywords & options for binning are part of compute chunk/atom:\n"
-    "  dim, origin, delta, region, bound, discard, units\n\n";
+    "NOTE: The pair style 'reax' has been removed from LAMMPS after the\n"
+    "## November 2018 stable release. Its functionality has long before\n"
+    "been superseded by pair styles 'reax/c' and 'reax/c/kk'\n\n";
 
     if (comm->me == 0) {
       if (screen) fputs(message,screen);
       if (logfile) fputs(message,logfile);
     }
   }
-  error->all(FLERR,"This fix command has been removed from LAMMPS");
+  error->all(FLERR,"This pair_style command has been removed from LAMMPS");
 }
+

--- a/src/pair_deprecated.h
+++ b/src/pair_deprecated.h
@@ -13,7 +13,7 @@
 
 #ifdef PAIR_CLASS
 
-PairStyle(deprecated,PairDeprecated)
+PairStyle(DEPRECATED,PairDeprecated)
 
 #else
 

--- a/src/pair_deprecated.h
+++ b/src/pair_deprecated.h
@@ -1,0 +1,84 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+
+PairStyle(deprecated,PairDeprecated)
+
+#else
+
+#ifndef LMP_PAIR_DEPRECATED_H
+#define LMP_PAIR_DEPRECATED_H
+
+#include "pair.h"
+
+namespace LAMMPS_NS {
+
+class PairDeprecated : public Pair {
+ public:
+  PairDeprecated(class LAMMPS *);
+  virtual ~PairDeprecated() {};
+
+  virtual void compute(int, int) {};
+  virtual void settings(int, char **) {};
+  virtual void coeff(int, char **) {};
+
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Not all pairs processed in pair_style list
+
+Not all interacting pairs for which coefficients were found. This can be intentional
+and then you need to set the 'nocheck' option. If not, it usually means that the
+communication cutoff is too small. This can be ameliorated by either increasing
+the cutoff in the pair_style command or the communication cutoff.
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Cannot open pair list file
+
+Self-explanatory.  The file with the list of pairs cannot be open for reading.
+Check the path and permissions.
+
+E: Incorrectly formatted ...
+
+Self-explanatory.  The content of the pair list file does not match the documented
+format. Please re-read the documentation and carefully compare it to your file.
+
+E: Unknown pair list potential style
+
+Self-explanatory.  You requested a potential type that is not yet implemented or have a typo.
+
+E: Incorrect args for pair coefficients
+
+Self-explanatory.  Check the input script or data file.
+
+E: Pair style list requires atom IDs
+
+Self-explanatory.  The pairs in the list are identified via atom IDs, so they need to be present.
+
+E: Pair style list requires an atom map
+
+Self-explanatory.  Atoms are looked up via an atom map. Create one using the atom_style map command.
+
+*/

--- a/src/pair_deprecated.h
+++ b/src/pair_deprecated.h
@@ -26,12 +26,12 @@ namespace LAMMPS_NS {
 
 class PairDeprecated : public Pair {
  public:
-  PairDeprecated(class LAMMPS *);
-  virtual ~PairDeprecated() {};
+  PairDeprecated(class LAMMPS *lmp) : Pair(lmp) {}
+  virtual ~PairDeprecated() {}
 
-  virtual void compute(int, int) {};
-  virtual void settings(int, char **) {};
-  virtual void coeff(int, char **) {};
+  virtual void compute(int, int) {}
+  virtual void settings(int, char **);
+  virtual void coeff(int, char **) {}
 
 };
 

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -281,7 +281,7 @@ void PairHybrid::settings(int narg, char **arg)
   iarg = 0;
   nstyles = 0;
   while (iarg < narg) {
-    if (strcmp(arg[iarg],"hybrid") == 0)
+    if (strncmp(arg[iarg],"hybrid",6) == 0)
       error->all(FLERR,"Pair style hybrid cannot have hybrid as an argument");
     if (strcmp(arg[iarg],"none") == 0)
       error->all(FLERR,"Pair style hybrid cannot have none as an argument");

--- a/src/pair_hybrid.h
+++ b/src/pair_hybrid.h
@@ -32,6 +32,7 @@ class PairHybrid : public Pair {
   friend class Force;
   friend class Respa;
   friend class Info;
+  friend class PairDeprecated;
  public:
   PairHybrid(class LAMMPS *);
   virtual ~PairHybrid();

--- a/src/region_deprecated.cpp
+++ b/src/region_deprecated.cpp
@@ -1,0 +1,40 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "region_deprecated.h"
+#include "comm.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This region style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegionDeprecated::RegionDeprecated(LAMMPS *lmp, int narg, char **arg) :
+  Region(lmp, narg, arg)
+{
+  if (strcmp(style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nRegion style 'DEPRECATED' is a dummy style\n\n",0);
+
+  }
+}

--- a/src/region_deprecated.h
+++ b/src/region_deprecated.h
@@ -1,0 +1,50 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef REGION_CLASS
+
+// list all deprecated and removed region styles here
+
+RegionStyle(DEPRECATED,RegionDeprecated)
+
+#else
+
+#ifndef LMP_REGION_DEPRECATED_H
+#define LMP_REGION_DEPRECATED_H
+
+#include "region.h"
+
+namespace LAMMPS_NS {
+
+class RegionDeprecated : public Region {
+ public:
+  RegionDeprecated(class LAMMPS *, int, char **);
+  ~RegionDeprecated() {}
+  virtual void init() {}
+  virtual int inside(double, double, double) { return 0; }
+  virtual int surface_interior(double *, double) { return 0; }
+  virtual int surface_exterior(double *, double) { return 0; }
+ };
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: This region command has been removed from LAMMPS
+
+UNDOCUMENTED
+
+*/


### PR DESCRIPTION
## Purpose

Implement a set of "dummy" classes for the purpose of providing meaningful error messages for people when commands/features have been removed from LAMMPS. This is to have a different kind of error than the non-descript "unknown XXX style", which would usually be caused by not including a specific package for compilation. 

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

n/a

## Implementation Notes

This is in preparation of removing pair styles `reax` and `meam` and their corresponding packages and related styles. It has been expanded to other styles, so removal of almost any feature is covered. command, compute, fix, pair, bond, angle, dihedral, improper, dump, region. notable exception is kspace because it is lacking a "settings()" function and the name of the style is not accessible in the constructor. we may want to change this for consistency with pair/bond/angle/dihedral/improper styles.

The equivalent kspace class is in PR #1165 which contains the necessary refactoring of all kspace classes.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
