### PR TITLE
Extend compute pair to handle multiple instances of a sub-style in pair style hybrid

### DIFF
--- a/doc/src/compute_pair.txt
+++ b/doc/src/compute_pair.txt
@@ -18,7 +18,7 @@ pstyle = style name of a pair style that calculates additional values :l
 zero or more keyword/value pairs may be appended :l
 keyword = {evalue} or {nsub}
   {evalue} arg = {epair} or {evdwl} or {ecoul}
-  {nsub} n = use {n}-th instance of a sub-style in a pair_style hybrid or hybrid/overlay command :pre
+  {nsub} n = use the {n}-th instance of a sub-style in a pair_style hybrid or hybrid/overlay command :pre
 :ule
 
 [Examples:]
@@ -39,14 +39,15 @@ NOTE: The group specified for this command is [ignored].
 The specified {pstyle} must be a pair style used in your simulation
 either by itself or as a sub-style in a "pair_style hybrid or
 hybrid/overlay"_pair_hybrid.html command. If the sub-style is
-used more than once, additional keyword {nsub} has to be specified in
-order to choose a single instance.
+used more than once, an additional keyword {nsub} has to be
+specified in order to choose which instance of the sub-style will
+be used by the compute.
 
 NOTE: The {nsub} keyword should be used only if the sub-style occurs
 multiple times. Its value must be an integer from 1 to M, where M is
 the number of times the sub-style is listed in the "pair_style hybrid
 or hybrid/overlay"_pair_hybrid.html" command. If the pair style is
-used once, {nsub} must remain zero.
+used only once, {nsub} must remain zero.
 
 The {evalue} setting is optional.  All
 pair styles tally a potential energy {epair} which may be broken into

--- a/doc/src/compute_pair.txt
+++ b/doc/src/compute_pair.txt
@@ -10,17 +10,22 @@ compute pair command :h3
 
 [Syntax:]
 
-compute ID group-ID pair pstyle evalue :pre
+compute ID group-ID pair pstyle keyword value :pre
 
-ID, group-ID are documented in "compute"_compute.html command
-pair = style name of this compute command
-pstyle = style name of a pair style that calculates additional values
-evalue = {epair} or {evdwl} or {ecoul} or blank (optional setting) :ul
+ID, group-ID are documented in "compute"_compute.html command :ulb,l
+pair = style name of this compute command :l
+pstyle = style name of a pair style that calculates additional values :l
+zero or more keyword/value pairs may be appended :l
+keyword = {evalue} or {nsub}
+  {evalue} arg = {epair} or {evdwl} or {ecoul}
+  {nsub} n = use {n}-th instance of a sub-style in a pair_style hybrid or hybrid/overlay command :pre
+:ule
 
 [Examples:]
 
 compute 1 all pair gauss
-compute 1 all pair lj/cut/coul/cut ecoul
+compute 1 all pair lj/cut/coul/cut evalue ecoul
+compute 1 all pair tersoff nsub 2
 compute 1 all pair reax :pre
 
 [Description:]
@@ -33,15 +38,23 @@ NOTE: The group specified for this command is [ignored].
 
 The specified {pstyle} must be a pair style used in your simulation
 either by itself or as a sub-style in a "pair_style hybrid or
-hybrid/overlay"_pair_hybrid.html command.
+hybrid/overlay"_pair_hybrid.html command. If the sub-style is
+used more than once, additional keyword {nsub} has to be specified in
+order to choose a single instance.
 
-The {evalue} setting is optional; it may be left off the command.  All
+NOTE: The {nsub} keyword should be used only if the sub-style occurs
+multiple times. Its value must be an integer from 1 to M, where M is
+the number of times the sub-style is listed in the "pair_style hybrid
+or hybrid/overlay"_pair_hybrid.html" command. If the pair style is
+used once, {nsub} must remain zero.
+
+The {evalue} setting is optional.  All
 pair styles tally a potential energy {epair} which may be broken into
 two parts: {evdwl} and {ecoul} such that {epair} = {evdwl} + {ecoul}.
 If the pair style calculates Coulombic interactions, their energy will
 be tallied in {ecoul}.  Everything else (whether it is a Lennard-Jones
 style van der Waals interaction or not) is tallied in {evdwl}.  If
-{evalue} is specified as {epair} or left out, then {epair} is stored
+{evalue} is specified as {epair}, then {epair} is stored
 as a global scalar by this compute.  This is useful when using
 "pair_style hybrid"_pair_hybrid.html if you want to know the portion
 of the total energy contributed by one sub-style.  If {evalue} is
@@ -82,4 +95,4 @@ the doc page for the pair style for details.
 
 [Default:]
 
-The default for {evalue} is {epair}.
+The keyword defaults are {evalue} = {epair}, nsub = 0.

--- a/doc/src/compute_pair.txt
+++ b/doc/src/compute_pair.txt
@@ -10,22 +10,20 @@ compute pair command :h3
 
 [Syntax:]
 
-compute ID group-ID pair pstyle keyword value :pre
+compute ID group-ID pair pstyle \[nstyle\] \[evalue\]  :pre
 
 ID, group-ID are documented in "compute"_compute.html command :ulb,l
 pair = style name of this compute command :l
 pstyle = style name of a pair style that calculates additional values :l
-zero or more keyword/value pairs may be appended :l
-keyword = {evalue} or {nsub}
-  {evalue} arg = {epair} or {evdwl} or {ecoul}
-  {nsub} n = use the {n}-th instance of a sub-style in a pair_style hybrid or hybrid/overlay command :pre
+nsub = {n}-instance of a substyle, if a pair style is used multiple times in a hybrid style :l
+{evalue} = {epair} or {evdwl} or {ecoul} or blank (optional) :l
 :ule
 
 [Examples:]
 
 compute 1 all pair gauss
-compute 1 all pair lj/cut/coul/cut evalue ecoul
-compute 1 all pair tersoff nsub 2
+compute 1 all pair lj/cut/coul/cut ecoul
+compute 1 all pair tersoff 2 epair
 compute 1 all pair reax :pre
 
 [Description:]
@@ -39,15 +37,10 @@ NOTE: The group specified for this command is [ignored].
 The specified {pstyle} must be a pair style used in your simulation
 either by itself or as a sub-style in a "pair_style hybrid or
 hybrid/overlay"_pair_hybrid.html command. If the sub-style is
-used more than once, an additional keyword {nsub} has to be
-specified in order to choose which instance of the sub-style will
-be used by the compute.
-
-NOTE: The {nsub} keyword should be used only if the sub-style occurs
-multiple times. Its value must be an integer from 1 to M, where M is
-the number of times the sub-style is listed in the "pair_style hybrid
-or hybrid/overlay"_pair_hybrid.html" command. If the pair style is
-used only once, {nsub} must remain zero.
+used more than once, an additional number {nsub} has to be specified
+in order to choose which instance of the sub-style will be used by
+the compute. Not specifying the number in this case will cause the
+compute to fail.
 
 The {evalue} setting is optional.  All
 pair styles tally a potential energy {epair} which may be broken into
@@ -55,7 +48,7 @@ two parts: {evdwl} and {ecoul} such that {epair} = {evdwl} + {ecoul}.
 If the pair style calculates Coulombic interactions, their energy will
 be tallied in {ecoul}.  Everything else (whether it is a Lennard-Jones
 style van der Waals interaction or not) is tallied in {evdwl}.  If
-{evalue} is specified as {epair}, then {epair} is stored
+{evalue} is blank or specified as {epair}, then {epair} is stored
 as a global scalar by this compute.  This is useful when using
 "pair_style hybrid"_pair_hybrid.html if you want to know the portion
 of the total energy contributed by one sub-style.  If {evalue} is

--- a/src/compute_pair.cpp
+++ b/src/compute_pair.cpp
@@ -44,7 +44,7 @@ ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
 
   int iarg = 4;
   nsub = 0;
-  evalue = NPAIR;
+  evalue = EPAIR;
 
   if (narg > iarg) {
     if (isdigit(arg[iarg][0])) {

--- a/src/compute_pair.cpp
+++ b/src/compute_pair.cpp
@@ -13,6 +13,7 @@
 
 #include <mpi.h>
 #include <cstring>
+#include <cctype>
 #include "compute_pair.h"
 #include "update.h"
 #include "force.h"
@@ -43,23 +44,24 @@ ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
 
   int iarg = 4;
   nsub = 0;
+  evalue = NPAIR;
 
-  while (iarg < narg) {
-    if (strcmp(arg[iarg],"evalue") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal compute pair command");
-      if (strcmp(arg[iarg+1],"epair") == 0) evalue = EPAIR;
-      else if (strcmp(arg[iarg+1],"evdwl") == 0) evalue = EVDWL;
-      else if (strcmp(arg[iarg+1],"ecoul") == 0) evalue = ECOUL;
-      else error->all(FLERR, "Unrecognized energy type");
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"nsub") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal compute pair command");
-      nsub = force->inumeric(FLERR,arg[iarg+1]);
-      iarg += 2;
-    } else error->all(FLERR,"Illegal compute pair command");
-    
+  if (narg > iarg) {
+    if (isdigit(arg[iarg][0])) {
+      nsub = force->inumeric(FLERR,arg[iarg]);
+      ++iarg;
+      if (nsub <= 0)
+        error->all(FLERR,"Illegal compute pair command");
+    }
   }
-  
+
+  if  (narg > iarg) {
+    if (strcmp(arg[iarg],"epair") == 0) evalue = EPAIR;
+    else if (strcmp(arg[iarg],"evdwl") == 0) evalue = EVDWL;
+    else if (strcmp(arg[iarg],"ecoul") == 0) evalue = ECOUL;
+    else error->all(FLERR, "Illegal compute pair command");
+    ++iarg;
+  }
 
   // check if pair style with and without suffix exists
 

--- a/src/compute_pair.h
+++ b/src/compute_pair.h
@@ -33,7 +33,7 @@ class ComputePair : public Compute {
   void compute_vector();
 
  private:
-  int evalue,npair;
+  int evalue,npair,nsub;
   char *pstyle;
   class Pair *pair;
   double *one;


### PR DESCRIPTION
## Purpose

I'd like to contribute a tweak for compute pair, which makes possible to use it with sub-styles specified multiple times in a pair style hybrid or hybrid/overlay command. Additionally, this PR adds a check for `evalue` which restricts it to `epair`, `ecoul` or `evdwl`. Currently, any value can be used and LAMMPS won't complain.

## Author(s)

Michal Kanski (Jagiellonian University)

## Backward Compatibility

It shouldn't break backward compatibility

## Implementation Notes

I introduced additional keyword "nsub" which allows a user to choose which instance of a sub-style will be used in the compute. The type of energy for the compute (epair/ecoul/evdwl) is now specified with help of another keyword called "evalue". No other features of LAMMPS are affected.

Instead of using "nsub" and "evalue" keywords, we just check whether the keyword following the pair style is numeric and then it is considered the sub-style number when using multiple styles of the same kind. The error, if an unknown keyword is added is retained.

A simple test script is attached. It checks if the sum of partial energies is equal to total potential energy.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


[test_script.txt](https://github.com/lammps/lammps/files/2451896/test_script.txt)
