### PR TITLE
Changes to intel Makefiles to make use of MKL consistent.

### DIFF
--- a/src/MAKE/OPTIONS/Makefile.intel_cpu
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu
@@ -15,8 +15,8 @@ SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpiicpc
-LINKFLAGS =	-qopenmp $(OPTFLAGS)
-LIB =           -ltbbmalloc
+LINKFLAGS =	-qopenmp $(OPTFLAGS) -L$(MKLROOT)/lib/intel64/
+LIB =           -ltbbmalloc -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
 SIZE =		size
 
 ARCHIVE =	ar
@@ -55,8 +55,7 @@ MPI_LIB =
 
 FFT_INC =       -DFFT_MKL -DFFT_SINGLE
 FFT_PATH = 
-FFT_LIB =       -L$(MKLROOT)/lib/intel64/ -lmkl_intel_ilp64 \
-                -lmkl_sequential -lmkl_core	
+FFT_LIB =       	
 
 # JPEG and/or PNG library
 # see discussion in Section 2.2 (step 7) of manual

--- a/src/MAKE/OPTIONS/Makefile.intel_cpu_intelmpi
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu_intelmpi
@@ -15,8 +15,8 @@ SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpiicpc
-LINKFLAGS =	-qopenmp $(OPTFLAGS)
-LIB =           -ltbbmalloc
+LINKFLAGS =	-qopenmp $(OPTFLAGS) -L$(MKLROOT)/lib/intel64/
+LIB =           -ltbbmalloc -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core	
 SIZE =		size
 
 ARCHIVE =	ar
@@ -55,8 +55,7 @@ MPI_LIB =
 
 FFT_INC =       -DFFT_MKL -DFFT_SINGLE
 FFT_PATH = 
-FFT_LIB =       -L$(MKLROOT)/lib/intel64/ -lmkl_intel_ilp64 \
-                -lmkl_sequential -lmkl_core	
+FFT_LIB =
 
 # JPEG and/or PNG library
 # see discussion in Section 2.2 (step 7) of manual

--- a/src/MAKE/OPTIONS/Makefile.intel_cpu_mpich
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu_mpich
@@ -15,8 +15,8 @@ SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx -cxx=icc
-LINKFLAGS =	-qopenmp $(OPTFLAGS)
-LIB =           -ltbbmalloc
+LINKFLAGS =	-qopenmp $(OPTFLAGS) -L$(MKLROOT)/lib/intel64/
+LIB =           -ltbbmalloc -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
 SIZE =		size
 
 ARCHIVE =	ar
@@ -53,7 +53,7 @@ MPI_LIB =	-lmpich -lmpl -lpthread
 # PATH = path for FFT library
 # LIB = name of FFT library
 
-FFT_INC =       
+FFT_INC =       -DFFT_MKL -DFFT_SINGLE
 FFT_PATH = 
 FFT_LIB =       
 

--- a/src/MAKE/OPTIONS/Makefile.intel_cpu_openmpi
+++ b/src/MAKE/OPTIONS/Makefile.intel_cpu_openmpi
@@ -16,8 +16,8 @@ SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-qopenmp $(OPTFLAGS)
-LIB =           -ltbbmalloc
+LINKFLAGS =	-qopenmp $(OPTFLAGS) -L$(MKLROOT)/lib/intel64/
+LIB =           -ltbbmalloc -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
 SIZE =		size
 
 ARCHIVE =	ar
@@ -54,7 +54,7 @@ MPI_LIB =
 # PATH = path for FFT library
 # LIB = name of FFT library
 
-FFT_INC =       
+FFT_INC =      -DFFT_MKL -DFFT_SINGLE 
 FFT_PATH = 
 FFT_LIB =       
 


### PR DESCRIPTION
## Purpose

In response to Issue #1144, changing the intel Makefiles in src/MAKE/OPTIONS to be consistent in use of MKL. MKL is used for random number gen in addition to FFT. Link params for MKL moved up from the FFT lines and Makefile.intel* are consistent in use of MKL.

## Author(s)

Mike Brown, Intel

## Backward Compatibility

Makefile.intel_cpu_openmpi now uses MKL for FFT. The others already did.

## Implementation Notes

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x ] The feature or features in this pull request is complete
- [x ] Suitable new documentation files and/or updates to the existing docs are included
- [x ] One or more example input decks are included
- [x ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

