### PR TITLE
Fix to allow suffix and pair hybrid to work together with USER-INTEL.

### DIFF
--- a/src/USER-INTEL/fix_intel.h
+++ b/src/USER-INTEL/fix_intel.h
@@ -101,7 +101,7 @@ class FixIntel : public Fix {
   IntelBuffers<double,double> *_double_buffers;
 
   int _precision_mode, _nthreads, _nbor_pack_width, _three_body_neighbor;
-  int _pair_hybrid_flag;
+  int _pair_intel_count, _pair_hybrid_flag;
   // These should be removed in subsequent update w/ simpler hybrid arch
   int _pair_hybrid_zero, _hybrid_nonpair, _zero_master;
   


### PR DESCRIPTION
## Purpose

Previously, using suffix commands for intel with hybrid{/overlay} pair styles along with bond/kspace could result in a runtime error message "Intel styles for ... require intel pair style". This commit fixes the issue - correct checking for use of USER-INTEL styles in hybrid lists.

## Author(s)

Mike Brown, Intel

## Backward Compatibility

## Implementation Notes

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x ] The feature or features in this pull request is complete
- [x ] Suitable new documentation files and/or updates to the existing docs are included
- [x ] One or more example input decks are included
- [x ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links


