### PR TITLE
Make USER-PTM compile with MinGW64 for Windows

### DIFF
--- a/src/USER-PTM/ptm_neighbour_ordering.cpp
+++ b/src/USER-PTM/ptm_neighbour_ordering.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include "ptm_constants.h"
 #include "ptm_voronoi_cell.h"
+#include "ptm_neighbour_ordering.h"
 
 
 namespace ptm {

--- a/src/USER-PTM/ptm_neighbour_ordering.h
+++ b/src/USER-PTM/ptm_neighbour_ordering.h
@@ -1,6 +1,8 @@
 #ifndef PTM_NEIGHBOUR_ORDERING_H
 #define PTM_NEIGHBOUR_ORDERING_H
 
+#include <inttypes.h>
+
 namespace ptm {
 
 int calculate_neighbour_ordering(void* voronoi_handle, int num_points, const double (*_points)[3], int8_t* ordering);

--- a/src/USER-PTM/ptm_polar.cpp
+++ b/src/USER-PTM/ptm_polar.cpp
@@ -89,6 +89,7 @@
 #include <algorithm>
 #include <string.h>
 #include "ptm_quat.h"
+#include "ptm_polar.h"
 
 
 namespace ptm {

--- a/src/USER-PTM/ptm_polar.h
+++ b/src/USER-PTM/ptm_polar.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 namespace ptm {
 

--- a/src/library.h
+++ b/src/library.h
@@ -17,6 +17,7 @@
 */
 
 #include <mpi.h>
+#include <inttypes.h>  /* for int64_t */
 
 /* ifdefs allow this file to be included in a C program */
 


### PR DESCRIPTION
## Purpose

Explicitly include headers declaring fixed width integer types to recover compiling LAMMPS for Windows using MinGW64.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

n/a

## Implementation Notes

This mainly is done by including `inttypes.h`, or including the header that includes it.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete

## Further Information, Files, and Links


