### PR TITLE
Enable use of fix halt for minimizations

### DIFF
--- a/doc/src/fix_halt.txt
+++ b/doc/src/fix_halt.txt
@@ -135,8 +135,7 @@ files"_restart.html.  None of the "fix_modify"_fix_modify.html options
 are relevant to this fix.  No global or per-atom quantities are stored
 by this fix for access by various "output commands"_Howto_output.html.
 No parameter of this fix can be used with the {start/stop} keywords of
-the "run"_run.html command.  This fix is not invoked during "energy
-minimization"_minimize.html.
+the "run"_run.html command.
 
 [Restrictions:] none
 

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -119,6 +119,7 @@ int FixHalt::setmask()
   int mask = 0;
   mask |= END_OF_STEP;
   mask |= POST_RUN;
+  mask |= MIN_POST_FORCE;
   return mask;
 }
 
@@ -138,14 +139,17 @@ void FixHalt::init()
   // settings used by TLIMIT
 
   nextstep = (update->ntimestep/nevery)*nevery + nevery;
+  thisstep = -1;
   tratio = 0.5;
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixHalt::min_step(double, double *)
+void FixHalt::min_post_force(int /* vflag */)
 {
+  if (update->ntimestep == thisstep) return;
   if ((update->ntimestep % nevery) == 0) end_of_step();
+  thisstep = update->ntimestep;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -143,6 +143,13 @@ void FixHalt::init()
 
 /* ---------------------------------------------------------------------- */
 
+void FixHalt::min_step(double, double *)
+{
+  if ((update->ntimestep % nevery) == 0) end_of_step();
+}
+
+/* ---------------------------------------------------------------------- */
+
 void FixHalt::end_of_step()
 {
   // variable evaluation may invoke computes so wrap with clear/add

--- a/src/fix_halt.h
+++ b/src/fix_halt.h
@@ -32,6 +32,7 @@ class FixHalt : public Fix {
   int setmask();
   void init();
   void end_of_step();
+  void min_step(double, double *);
   void post_run();
 
  private:

--- a/src/fix_halt.h
+++ b/src/fix_halt.h
@@ -32,12 +32,12 @@ class FixHalt : public Fix {
   int setmask();
   void init();
   void end_of_step();
-  void min_step(double, double *);
+  void min_post_force(int);
   void post_run();
 
  private:
   int attribute,operation,eflag,msgflag,ivar;
-  bigint nextstep;
+  bigint nextstep,thisstep;
   double value,tratio;
   char *idvar;
 


### PR DESCRIPTION
## Purpose

Fix halt can now also be used with minimizations

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

n/a

## Implementation Notes

Since minimization has no equivalent to `Fix::end_of_step()`, we use `Fix::min_post_force()` and use a check, that this function is called only once per (outer) minimization step.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The source code follows the LAMMPS formatting guidelines


