### PR TITLE
Refactor kspace base class to have a settings() method

### DIFF
--- a/examples/USER/scafacos/in.scafacos
+++ b/examples/USER/scafacos/in.scafacos
@@ -1,7 +1,7 @@
 # Point dipoles in a 2d box
 
 units		lj
-atom_style  full	
+atom_style  charge	
 
 read_data data.NaCl
 
@@ -29,7 +29,7 @@ pair_coeff	* *
 #fix		2 all scafacos p3m tolerance field 0.001
 
 kspace_style    scafacos p3m 0.001
-kspace_style    scafacos tolerance field 
+#kspace_style    scafacos tolerance field 
 
 timestep	0.005
 thermo          10

--- a/src/GPU/pppm_gpu.cpp
+++ b/src/GPU/pppm_gpu.cpp
@@ -89,10 +89,8 @@ void PPPM_GPU_API(forces)(double **f);
 
 /* ---------------------------------------------------------------------- */
 
-PPPMGPU::PPPMGPU(LAMMPS *lmp, int narg, char **arg) : PPPM(lmp, narg, arg)
+PPPMGPU::PPPMGPU(LAMMPS *lmp) : PPPM(lmp)
 {
-  if (narg != 1) error->all(FLERR,"Illegal kspace_style pppm/gpu command");
-
   triclinic_support = 0;
   density_brick_gpu = vd_brick = NULL;
   kspace_split = false;

--- a/src/GPU/pppm_gpu.h
+++ b/src/GPU/pppm_gpu.h
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class PPPMGPU : public PPPM {
  public:
-  PPPMGPU(class LAMMPS *, int, char **);
+  PPPMGPU(class LAMMPS *);
   virtual ~PPPMGPU();
   void init();
   void setup();

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -64,10 +64,8 @@ enum{FORWARD_IK,FORWARD_IK_PERATOM};
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-PPPMKokkos<DeviceType>::PPPMKokkos(LAMMPS *lmp, int narg, char **arg) : PPPM(lmp, narg, arg)
+PPPMKokkos<DeviceType>::PPPMKokkos(LAMMPS *lmp) : PPPM(lmp)
 {
-  if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm command");
-
   atomKK = (AtomKokkos *) atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
   datamask_read = X_MASK | F_MASK | TYPE_MASK | Q_MASK;
@@ -76,8 +74,6 @@ PPPMKokkos<DeviceType>::PPPMKokkos(LAMMPS *lmp, int narg, char **arg) : PPPM(lmp
   pppmflag = 1;
   group_group_enable = 0;
   triclinic_support = 0;
-
-  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 
   nfactors = 3;
   //factors = new int[nfactors];
@@ -146,6 +142,13 @@ PPPMKokkos<DeviceType>::PPPMKokkos(LAMMPS *lmp, int narg, char **arg) : PPPM(lmp
   acons(7,6) = 4887769399.0 / 37838389248.0;
 
   k_flag = DAT::tdual_int_scalar("PPPM:flag");
+}
+
+template<class DeviceType>
+void PPPMKokkos<DeviceType>::settings(int narg, char **arg)
+{
+  if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm/kk command");
+  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -92,11 +92,12 @@ class PPPMKokkos : public PPPM, public KokkosBase {
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
 
-  PPPMKokkos(class LAMMPS *, int, char **);
+  PPPMKokkos(class LAMMPS *);
   virtual ~PPPMKokkos();
   virtual void init();
   virtual void setup();
   void setup_grid();
+  virtual void settings(int, char **);
   virtual void compute(int, int);
   virtual int timing_1d(int, double &);
   virtual int timing_3d(int, double &);

--- a/src/KSPACE/ewald.cpp
+++ b/src/KSPACE/ewald.cpp
@@ -40,7 +40,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-Ewald::Ewald(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
+Ewald::Ewald(LAMMPS *lmp) : KSpace(lmp),
   kxvecs(NULL), kyvecs(NULL), kzvecs(NULL), ug(NULL), eg(NULL), vg(NULL),
   ek(NULL), sfacrl(NULL), sfacim(NULL), sfacrl_all(NULL), sfacim_all(NULL),
   cs(NULL), sn(NULL), sfacrl_A(NULL), sfacim_A(NULL), sfacrl_A_all(NULL),
@@ -49,12 +49,10 @@ Ewald::Ewald(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
 {
   group_allocate_flag = 0;
   kmax_created = 0;
-  if (narg != 1) error->all(FLERR,"Illegal kspace_style ewald command");
-
   ewaldflag = 1;
   group_group_enable = 1;
 
-  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
+  accuracy_relative = 0.0;
 
   kmax = 0;
   kxvecs = kyvecs = kzvecs = NULL;
@@ -68,6 +66,13 @@ Ewald::Ewald(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
 
   kcount = 0;
 }
+
+void Ewald::settings(int narg, char **arg)
+{
+  if (narg != 1) error->all(FLERR,"Illegal kspace_style ewald command");
+
+  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
+}  
 
 /* ----------------------------------------------------------------------
    free all memory

--- a/src/KSPACE/ewald.h
+++ b/src/KSPACE/ewald.h
@@ -26,10 +26,11 @@ namespace LAMMPS_NS {
 
 class Ewald : public KSpace {
  public:
-  Ewald(class LAMMPS *, int, char **);
+  Ewald(class LAMMPS *);
   virtual ~Ewald();
   void init();
   void setup();
+  virtual void settings(int, char **);
   virtual void compute(int, int);
   double memory_usage();
 

--- a/src/KSPACE/ewald_disp.cpp
+++ b/src/KSPACE/ewald_disp.cpp
@@ -43,14 +43,11 @@ using namespace MathSpecial;
 
 /* ---------------------------------------------------------------------- */
 
-EwaldDisp::EwaldDisp(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
+EwaldDisp::EwaldDisp(LAMMPS *lmp) : KSpace(lmp),
   kenergy(NULL), kvirial(NULL), energy_self_peratom(NULL), virial_self_peratom(NULL),
   ekr_local(NULL), hvec(NULL), kvec(NULL), B(NULL), cek_local(NULL), cek_global(NULL)
 {
-  if (narg!=1) error->all(FLERR,"Illegal kspace_style ewald/n command");
-
   ewaldflag = dispersionflag = dipoleflag = 1;
-  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 
   memset(function, 0, EWALD_NFUNCS*sizeof(int));
   kenergy = kvirial = NULL;
@@ -67,6 +64,13 @@ EwaldDisp::EwaldDisp(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg)
   b2 = 0;
   M2 = 0;
 }
+
+void EwaldDisp::settings(int narg, char **arg)
+{
+  if (narg!=1) error->all(FLERR,"Illegal kspace_style ewald/n command");
+  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
+}
+
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/ewald_disp.h
+++ b/src/KSPACE/ewald_disp.h
@@ -36,10 +36,11 @@ typedef struct kvector { long x, y, z; } kvector;
 
 class EwaldDisp : public KSpace {
  public:
-  EwaldDisp(class LAMMPS *, int, char **);
+  EwaldDisp(class LAMMPS *);
   ~EwaldDisp();
   void init();
   void setup();
+  void settings(int, char **);
   void compute(int, int);
   double memory_usage() {return bytes;}
 

--- a/src/KSPACE/fix_tune_kspace.cpp
+++ b/src/KSPACE/fix_tune_kspace.cpp
@@ -273,7 +273,8 @@ void FixTuneKspace::update_kspace_style(char *new_kspace_style,
 
   // delete old kspace style and create new one
 
-  force->create_kspace(narg,arg,1);
+  force->create_kspace(arg[0],1);
+  force->kspace->settings(narg-1,&arg[1]);
   force->kspace->differentiation_flag = old_differentiation_flag;
   force->kspace->slabflag = old_slabflag;
   force->kspace->slab_volfactor = old_slab_volfactor;

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -111,13 +111,13 @@ MSM::MSM(LAMMPS *lmp) : KSpace(lmp),
   order = 10;
 }
 
+/* ---------------------------------------------------------------------- */
 
 void MSM::settings(int narg, char **arg)
 {
   if (narg < 1) error->all(FLERR,"Illegal kspace_style msm command");
   accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 }
-
 
 /* ----------------------------------------------------------------------
    free all memory

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -44,7 +44,7 @@ enum{REVERSE_RHO,REVERSE_AD,REVERSE_AD_PERATOM};
 enum{FORWARD_RHO,FORWARD_AD,FORWARD_AD_PERATOM};
 /* ---------------------------------------------------------------------- */
 
-MSM::MSM(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
+MSM::MSM(LAMMPS *lmp) : KSpace(lmp),
   factors(NULL), delxinv(NULL), delyinv(NULL), delzinv(NULL), nx_msm(NULL),
   ny_msm(NULL), nz_msm(NULL), nxlo_in(NULL), nylo_in(NULL), nzlo_in(NULL),
   nxhi_in(NULL), nyhi_in(NULL), nzhi_in(NULL), nxlo_out(NULL), nylo_out(NULL),
@@ -58,11 +58,7 @@ MSM::MSM(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
   phi1d(NULL), dphi1d(NULL), procneigh_levels(NULL), cg(NULL), cg_peratom(NULL),
   cg_all(NULL), cg_peratom_all(NULL), part2grid(NULL), boxlo(NULL)
 {
-  if (narg < 1) error->all(FLERR,"Illegal kspace_style msm command");
-
   msmflag = 1;
-
-  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 
   nfactors = 1;
   factors = new int[nfactors];
@@ -114,6 +110,14 @@ MSM::MSM(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
 
   order = 10;
 }
+
+
+void MSM::settings(int narg, char **arg)
+{
+  if (narg < 1) error->all(FLERR,"Illegal kspace_style msm command");
+  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
+}
+
 
 /* ----------------------------------------------------------------------
    free all memory

--- a/src/KSPACE/msm.h
+++ b/src/KSPACE/msm.h
@@ -29,10 +29,11 @@ namespace LAMMPS_NS {
 
 class MSM : public KSpace {
  public:
-  MSM(class LAMMPS *, int, char **);
+  MSM(class LAMMPS *);
   virtual ~MSM();
   void init();
   void setup();
+  virtual void settings(int, char **);
   virtual void compute(int, int);
 
  protected:

--- a/src/KSPACE/msm_cg.cpp
+++ b/src/KSPACE/msm_cg.cpp
@@ -42,18 +42,27 @@ enum{FORWARD_RHO,FORWARD_AD,FORWARD_AD_PERATOM};
 
 /* ---------------------------------------------------------------------- */
 
-MSMCG::MSMCG(LAMMPS *lmp, int narg, char **arg) : MSM(lmp, narg, arg),
+MSMCG::MSMCG(LAMMPS *lmp) : MSM(lmp),
   is_charged(NULL)
+{
+  triclinic_support = 0;
+
+  num_charged = -1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void MSMCG::settings(int narg, char **arg)
 {
   if ((narg < 1) || (narg > 2))
     error->all(FLERR,"Illegal kspace_style msm/cg command");
 
-  triclinic_support = 0;
+  // first argument is processed in parent class
+
+  MSM::settings(narg,arg);
 
   if (narg == 2) smallq = fabs(force->numeric(FLERR,arg[1]));
   else smallq = SMALLQ;
-
-  num_charged = -1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/msm_cg.h
+++ b/src/KSPACE/msm_cg.h
@@ -26,8 +26,9 @@ namespace LAMMPS_NS {
 
 class MSMCG : public MSM {
  public:
-  MSMCG(class LAMMPS *, int, char **);
+  MSMCG(class LAMMPS *);
   virtual ~MSMCG();
+  virtual void settings(int, char **);
   virtual void compute(int, int);
   virtual double memory_usage();
 

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -64,7 +64,7 @@ enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
 
 /* ---------------------------------------------------------------------- */
 
-PPPM::PPPM(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
+PPPM::PPPM(LAMMPS *lmp) : KSpace(lmp),
   factors(NULL), density_brick(NULL), vdx_brick(NULL), vdy_brick(NULL), vdz_brick(NULL),
   u_brick(NULL), v0_brick(NULL), v1_brick(NULL), v2_brick(NULL), v3_brick(NULL),
   v4_brick(NULL), v5_brick(NULL), greensfn(NULL), vg(NULL), fkx(NULL), fky(NULL),
@@ -78,13 +78,9 @@ PPPM::PPPM(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
   peratom_allocate_flag = 0;
   group_allocate_flag = 0;
 
-  if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm command");
-
   pppmflag = 1;
   group_group_enable = 1;
   triclinic = domain->triclinic;
-
-  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 
   nfactors = 3;
   factors = new int[nfactors];
@@ -159,6 +155,14 @@ PPPM::PPPM(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
   acons[7][4] = 25091609.0 / 1560084480.0;
   acons[7][5] = 1755948832039.0 / 36229939200000.0;
   acons[7][6] = 4887769399.0 / 37838389248.0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PPPM::settings(int narg, char **arg)
+{
+  if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm command");
+  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/pppm.h
+++ b/src/KSPACE/pppm.h
@@ -37,8 +37,9 @@ namespace LAMMPS_NS {
 
 class PPPM : public KSpace {
  public:
-  PPPM(class LAMMPS *, int, char **);
+  PPPM(class LAMMPS *);
   virtual ~PPPM();
+  virtual void settings(int, char **);
   virtual void init();
   virtual void setup();
   void setup_grid();

--- a/src/KSPACE/pppm_cg.cpp
+++ b/src/KSPACE/pppm_cg.cpp
@@ -48,17 +48,26 @@ enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
 
 /* ---------------------------------------------------------------------- */
 
-PPPMCG::PPPMCG(LAMMPS *lmp, int narg, char **arg) : PPPM(lmp, narg, arg),
+PPPMCG::PPPMCG(LAMMPS *lmp) : PPPM(lmp),
   is_charged(NULL)
+{
+  num_charged = -1;
+  group_group_enable = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PPPMCG::settings(int narg, char **arg)
 {
   if ((narg < 1) || (narg > 2))
     error->all(FLERR,"Illegal kspace_style pppm/cg command");
 
+  // first argument is processed in parent class
+
+  PPPM::settings(narg,arg);
+
   if (narg == 2) smallq = fabs(force->numeric(FLERR,arg[1]));
   else smallq = SMALLQ;
-
-  num_charged = -1;
-  group_group_enable = 1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/pppm_cg.h
+++ b/src/KSPACE/pppm_cg.h
@@ -26,8 +26,9 @@ namespace LAMMPS_NS {
 
 class PPPMCG : public PPPM {
  public:
-  PPPMCG(class LAMMPS *, int, char **);
+  PPPMCG(class LAMMPS *);
   virtual ~PPPMCG();
+  virtual void settings(int, char **);
   virtual void compute(int, int);
   virtual double memory_usage();
 

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -63,7 +63,7 @@ enum{FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM,
 
 /* ---------------------------------------------------------------------- */
 
-PPPMDisp::PPPMDisp(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
+PPPMDisp::PPPMDisp(LAMMPS *lmp) : KSpace(lmp),
   factors(NULL), csumi(NULL), cii(NULL), B(NULL), density_brick(NULL), vdx_brick(NULL),
   vdy_brick(NULL), vdz_brick(NULL), density_fft(NULL), u_brick(NULL), v0_brick(NULL),
   v1_brick(NULL), v2_brick(NULL), v3_brick(NULL), v4_brick(NULL), v5_brick(NULL),
@@ -106,11 +106,8 @@ PPPMDisp::PPPMDisp(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
    fft2_6(NULL), remap(NULL), remap_6(NULL), cg(NULL), cg_peratom(NULL), cg_6(NULL),
    cg_peratom_6(NULL), part2grid(NULL), part2grid_6(NULL), boxlo(NULL)
 {
-  if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm/disp command");
-
   triclinic_support = 0;
   pppmflag = dispersionflag = 1;
-  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 
   nfactors = 3;
   factors = new int[nfactors];
@@ -223,6 +220,14 @@ PPPMDisp::PPPMDisp(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg),
   cg_peratom_6 = NULL;
 
   memset(function, 0, EWALD_FUNCS*sizeof(int));
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PPPMDisp::settings(int narg, char **arg)
+{
+  if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm/disp command");
+  accuracy_relative = fabs(force->numeric(FLERR,arg[0]));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/pppm_disp.h
+++ b/src/KSPACE/pppm_disp.h
@@ -41,11 +41,12 @@ namespace LAMMPS_NS {
 
 class PPPMDisp : public KSpace {
  public:
-  PPPMDisp(class LAMMPS *, int, char **);
+  PPPMDisp(class LAMMPS *);
   virtual ~PPPMDisp();
   virtual void init();
   virtual void setup();
   void setup_grid();
+  virtual void settings(int, char **);
   virtual void compute(int, int);
   virtual int timing_1d(int, double &);
   virtual int timing_3d(int, double &);

--- a/src/KSPACE/pppm_disp_tip4p.cpp
+++ b/src/KSPACE/pppm_disp_tip4p.cpp
@@ -41,8 +41,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-PPPMDispTIP4P::PPPMDispTIP4P(LAMMPS *lmp, int narg, char **arg) :
-  PPPMDisp(lmp, narg, arg)
+PPPMDispTIP4P::PPPMDispTIP4P(LAMMPS *lmp) : PPPMDisp(lmp)
 {
   triclinic_support = 0;
   tip4pflag = 1;

--- a/src/KSPACE/pppm_disp_tip4p.h
+++ b/src/KSPACE/pppm_disp_tip4p.h
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class PPPMDispTIP4P : public PPPMDisp {
  public:
-  PPPMDispTIP4P(class LAMMPS *, int, char **);
+  PPPMDispTIP4P(class LAMMPS *);
   virtual ~PPPMDispTIP4P () {};
   void init();
 

--- a/src/KSPACE/pppm_stagger.cpp
+++ b/src/KSPACE/pppm_stagger.cpp
@@ -51,11 +51,10 @@ enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
 
 /* ---------------------------------------------------------------------- */
 
-PPPMStagger::PPPMStagger(LAMMPS *lmp, int narg, char **arg) :
-  PPPM(lmp, narg, arg),
+PPPMStagger::PPPMStagger(LAMMPS *lmp) :
+  PPPM(lmp),
   gf_b2(NULL)
 {
-  if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm/stagger command");
   stagger_flag = 1;
   group_group_enable = 0;
 

--- a/src/KSPACE/pppm_stagger.h
+++ b/src/KSPACE/pppm_stagger.h
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class PPPMStagger : public PPPM {
  public:
-  PPPMStagger(class LAMMPS *, int, char **);
+  PPPMStagger(class LAMMPS *);
   virtual ~PPPMStagger();
   virtual void init();
   virtual void compute(int, int);

--- a/src/KSPACE/pppm_tip4p.cpp
+++ b/src/KSPACE/pppm_tip4p.cpp
@@ -39,8 +39,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-PPPMTIP4P::PPPMTIP4P(LAMMPS *lmp, int narg, char **arg) :
-  PPPM(lmp, narg, arg)
+PPPMTIP4P::PPPMTIP4P(LAMMPS *lmp) : PPPM(lmp)
 {
   triclinic_support = 1;
   tip4pflag = 1;

--- a/src/KSPACE/pppm_tip4p.h
+++ b/src/KSPACE/pppm_tip4p.h
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class PPPMTIP4P : public PPPM {
  public:
-  PPPMTIP4P(class LAMMPS *, int, char **);
+  PPPMTIP4P(class LAMMPS *);
   virtual ~PPPMTIP4P () {};
   void init();
 

--- a/src/USER-OMP/ewald_omp.cpp
+++ b/src/USER-OMP/ewald_omp.cpp
@@ -34,8 +34,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-EwaldOMP::EwaldOMP(LAMMPS *lmp, int narg, char **arg)
-  : Ewald(lmp, narg, arg), ThrOMP(lmp, THR_KSPACE)
+EwaldOMP::EwaldOMP(LAMMPS *lmp) : Ewald(lmp), ThrOMP(lmp, THR_KSPACE)
 {
   triclinic_support = 0;
   suffix_flag |= Suffix::OMP;

--- a/src/USER-OMP/ewald_omp.h
+++ b/src/USER-OMP/ewald_omp.h
@@ -27,7 +27,7 @@ namespace LAMMPS_NS {
 
   class EwaldOMP : public Ewald, public ThrOMP {
  public:
-  EwaldOMP(class LAMMPS *, int, char **);
+  EwaldOMP(class LAMMPS *);
   virtual ~EwaldOMP() { };
   virtual void allocate();
   virtual void compute(int, int);

--- a/src/USER-OMP/msm_cg_omp.cpp
+++ b/src/USER-OMP/msm_cg_omp.cpp
@@ -44,18 +44,25 @@ enum{FORWARD_RHO,FORWARD_AD,FORWARD_AD_PERATOM};
 
 /* ---------------------------------------------------------------------- */
 
-MSMCGOMP::MSMCGOMP(LAMMPS *lmp, int narg, char **arg) : MSMOMP(lmp, narg, arg),
+MSMCGOMP::MSMCGOMP(LAMMPS *lmp) : MSMOMP(lmp),
   is_charged(NULL)
+{
+  triclinic_support = 0;
+
+  num_charged = -1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void MSMCGOMP::settings(int narg, char **arg)
 {
   if ((narg < 1) || (narg > 2))
     error->all(FLERR,"Illegal kspace_style msm/cg/omp command");
 
-  triclinic_support = 0;
+  MSMOMP::settings(narg,arg);
 
   if (narg == 2) smallq = fabs(force->numeric(FLERR,arg[1]));
   else smallq = SMALLQ;
-
-  num_charged = -1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-OMP/msm_cg_omp.h
+++ b/src/USER-OMP/msm_cg_omp.h
@@ -26,8 +26,9 @@ namespace LAMMPS_NS {
 
 class MSMCGOMP : public MSMOMP {
  public:
-  MSMCGOMP(class LAMMPS *, int, char **);
+  MSMCGOMP(class LAMMPS *);
   virtual ~MSMCGOMP();
+  virtual void settings(int, char **);
   virtual void compute(int, int);
   virtual double memory_usage();
 

--- a/src/USER-OMP/msm_omp.cpp
+++ b/src/USER-OMP/msm_omp.cpp
@@ -35,8 +35,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-MSMOMP::MSMOMP(LAMMPS *lmp, int narg, char **arg) :
-  MSM(lmp, narg, arg), ThrOMP(lmp, THR_KSPACE)
+MSMOMP::MSMOMP(LAMMPS *lmp) : MSM(lmp), ThrOMP(lmp, THR_KSPACE)
 {
   triclinic_support = 0;
   suffix_flag |= Suffix::OMP;

--- a/src/USER-OMP/msm_omp.h
+++ b/src/USER-OMP/msm_omp.h
@@ -27,7 +27,7 @@ namespace LAMMPS_NS {
 
   class MSMOMP : public MSM, public ThrOMP {
  public:
-  MSMOMP(class LAMMPS *, int, char **);
+  MSMOMP(class LAMMPS *);
   virtual ~MSMOMP () {};
 
  protected:

--- a/src/USER-OMP/pppm_cg_omp.cpp
+++ b/src/USER-OMP/pppm_cg_omp.cpp
@@ -46,8 +46,7 @@ using namespace MathSpecial;
 
 /* ---------------------------------------------------------------------- */
 
-PPPMCGOMP::PPPMCGOMP(LAMMPS *lmp, int narg, char **arg) :
-  PPPMCG(lmp, narg, arg), ThrOMP(lmp, THR_KSPACE)
+PPPMCGOMP::PPPMCGOMP(LAMMPS *lmp) : PPPMCG(lmp), ThrOMP(lmp, THR_KSPACE)
 {
   triclinic_support = 0;
   suffix_flag |= Suffix::OMP;

--- a/src/USER-OMP/pppm_cg_omp.h
+++ b/src/USER-OMP/pppm_cg_omp.h
@@ -27,7 +27,7 @@ namespace LAMMPS_NS {
 
 class PPPMCGOMP : public PPPMCG, public ThrOMP {
  public:
-  PPPMCGOMP(class LAMMPS *, int, char **);
+  PPPMCGOMP(class LAMMPS *);
   virtual ~PPPMCGOMP ();
   virtual void compute(int, int);
 

--- a/src/USER-OMP/pppm_disp_omp.cpp
+++ b/src/USER-OMP/pppm_disp_omp.cpp
@@ -43,8 +43,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-PPPMDispOMP::PPPMDispOMP(LAMMPS *lmp, int narg, char **arg) :
-  PPPMDisp(lmp, narg, arg), ThrOMP(lmp, THR_KSPACE)
+PPPMDispOMP::PPPMDispOMP(LAMMPS *lmp) : PPPMDisp(lmp), ThrOMP(lmp, THR_KSPACE)
 {
   triclinic_support = 0;
   suffix_flag |= Suffix::OMP;

--- a/src/USER-OMP/pppm_disp_omp.h
+++ b/src/USER-OMP/pppm_disp_omp.h
@@ -27,7 +27,7 @@ namespace LAMMPS_NS {
 
   class PPPMDispOMP : public PPPMDisp, public ThrOMP {
  public:
-  PPPMDispOMP(class LAMMPS *, int, char **);
+  PPPMDispOMP(class LAMMPS *);
   virtual ~PPPMDispOMP ();
   virtual void compute(int, int);
 

--- a/src/USER-OMP/pppm_disp_tip4p_omp.cpp
+++ b/src/USER-OMP/pppm_disp_tip4p_omp.cpp
@@ -43,8 +43,8 @@ using namespace MathSpecial;
 
 /* ---------------------------------------------------------------------- */
 
-PPPMDispTIP4POMP::PPPMDispTIP4POMP(LAMMPS *lmp, int narg, char **arg) :
-  PPPMDispTIP4P(lmp, narg, arg), ThrOMP(lmp, THR_KSPACE)
+PPPMDispTIP4POMP::PPPMDispTIP4POMP(LAMMPS *lmp) :
+  PPPMDispTIP4P(lmp), ThrOMP(lmp, THR_KSPACE)
 {
   triclinic_support = 0;
   tip4pflag = 1;

--- a/src/USER-OMP/pppm_disp_tip4p_omp.h
+++ b/src/USER-OMP/pppm_disp_tip4p_omp.h
@@ -27,7 +27,7 @@ namespace LAMMPS_NS {
 
   class PPPMDispTIP4POMP : public PPPMDispTIP4P, public ThrOMP {
  public:
-  PPPMDispTIP4POMP(class LAMMPS *, int, char **);
+  PPPMDispTIP4POMP(class LAMMPS *);
   virtual ~PPPMDispTIP4POMP ();
 
  protected:

--- a/src/USER-OMP/pppm_omp.cpp
+++ b/src/USER-OMP/pppm_omp.cpp
@@ -43,8 +43,7 @@ using namespace MathSpecial;
 
 /* ---------------------------------------------------------------------- */
 
-PPPMOMP::PPPMOMP(LAMMPS *lmp, int narg, char **arg) :
-  PPPM(lmp, narg, arg), ThrOMP(lmp, THR_KSPACE)
+PPPMOMP::PPPMOMP(LAMMPS *lmp) : PPPM(lmp), ThrOMP(lmp, THR_KSPACE)
 {
   triclinic_support = 0;
   suffix_flag |= Suffix::OMP;

--- a/src/USER-OMP/pppm_omp.h
+++ b/src/USER-OMP/pppm_omp.h
@@ -27,7 +27,7 @@ namespace LAMMPS_NS {
 
 class PPPMOMP : public PPPM, public ThrOMP {
  public:
-  PPPMOMP(class LAMMPS *, int, char **);
+  PPPMOMP(class LAMMPS *);
   virtual ~PPPMOMP ();
   virtual void compute(int, int);
 

--- a/src/USER-OMP/pppm_tip4p_omp.cpp
+++ b/src/USER-OMP/pppm_tip4p_omp.cpp
@@ -44,8 +44,8 @@ using namespace MathSpecial;
 
 /* ---------------------------------------------------------------------- */
 
-PPPMTIP4POMP::PPPMTIP4POMP(LAMMPS *lmp, int narg, char **arg) :
-  PPPMTIP4P(lmp, narg, arg), ThrOMP(lmp, THR_KSPACE)
+PPPMTIP4POMP::PPPMTIP4POMP(LAMMPS *lmp) :
+  PPPMTIP4P(lmp), ThrOMP(lmp, THR_KSPACE)
 {
   triclinic_support = 1;
   suffix_flag |= Suffix::OMP;

--- a/src/USER-OMP/pppm_tip4p_omp.h
+++ b/src/USER-OMP/pppm_tip4p_omp.h
@@ -27,7 +27,7 @@ namespace LAMMPS_NS {
 
 class PPPMTIP4POMP : public PPPMTIP4P, public ThrOMP {
  public:
-  PPPMTIP4POMP(class LAMMPS *, int, char **);
+  PPPMTIP4POMP(class LAMMPS *);
   virtual ~PPPMTIP4POMP ();
   virtual void compute(int, int);
 

--- a/src/USER-SCAFACOS/scafacos.cpp
+++ b/src/USER-SCAFACOS/scafacos.cpp
@@ -36,7 +36,21 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-Scafacos::Scafacos(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg)
+Scafacos::Scafacos(LAMMPS *lmp) : KSpace(lmp)
+{
+  me = comm->me;
+  initialized = 0;
+
+  maxatom = 0;
+  xpbc = NULL;
+  epot = NULL;
+  efield = NULL;
+  fcs = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Scafacos::settings(int narg, char **arg)
 {
   if (narg != 2) error->all(FLERR,"Illegal scafacos command");
 
@@ -48,35 +62,18 @@ Scafacos::Scafacos(LAMMPS *lmp, int narg, char **arg) : KSpace(lmp, narg, arg)
   // optional ScaFaCoS library setting defaults
   // choose the correct default tolerance type for chosen method
   // throw an error if a not yet supported solver is chosen
-  if (strcmp(method,"fmm") == 0)
-  {
+  if (strcmp(method,"fmm") == 0) {
     tolerance_type = FCS_TOLERANCE_TYPE_ENERGY;
     fmm_tuning_flag = 0;
-  }
-  else if (strcmp(method,"p3m") == 0 || 
-           strcmp(method,"p2nfft") == 0 || 
-           strcmp(method,"ewald") == 0)
-  {
+  } else if (strcmp(method,"p3m") == 0 || 
+             strcmp(method,"p2nfft") == 0 || 
+             strcmp(method,"ewald") == 0) {
     tolerance_type = FCS_TOLERANCE_TYPE_FIELD;    
-  }
-  else if (strcmp(method,"direct") == 0)
-  {
-    // direct summation has no tolerance type
-  }
-  else
-  {
+  } else if (strcmp(method,"direct") == 0) {
+    ; // direct summation has no tolerance type
+  } else {
     error->all(FLERR,"Unsupported ScaFaCoS method");
   }
-
-  // initializations
-
-  me = comm->me;
-  initialized = 0;
-
-  maxatom = 0;
-  xpbc = NULL;
-  epot = NULL;
-  efield = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-SCAFACOS/scafacos.h
+++ b/src/USER-SCAFACOS/scafacos.h
@@ -27,10 +27,11 @@ namespace LAMMPS_NS {
 
 class Scafacos : public KSpace {
  public:
-  Scafacos(class LAMMPS *, int, char **);
+  Scafacos(class LAMMPS *);
   ~Scafacos();
   void init();
   void setup() {}
+  void settings(int, char **);
   void compute(int, int);
   int modify_param(int, char **);
   double memory_usage();

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -665,14 +665,14 @@ Improper *Force::improper_match(const char *style)
    new kspace style
 ------------------------------------------------------------------------- */
 
-void Force::create_kspace(int narg, char **arg, int trysuffix)
+void Force::create_kspace(const char *style, int trysuffix)
 {
   delete [] kspace_style;
   if (kspace) delete kspace;
 
   int sflag;
-  kspace = new_kspace(narg,arg,trysuffix,sflag);
-  store_style(kspace_style,arg[0],sflag);
+  kspace = new_kspace(style,trysuffix,sflag);
+  store_style(kspace_style,style,sflag);
 
   if (comm->style == 1 && !kspace_match("ewald",0))
     error->all(FLERR,
@@ -683,39 +683,39 @@ void Force::create_kspace(int narg, char **arg, int trysuffix)
    generate a kspace class
 ------------------------------------------------------------------------- */
 
-KSpace *Force::new_kspace(int narg, char **arg, int trysuffix, int &sflag)
+KSpace *Force::new_kspace(const char *style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
       char estyle[256];
-      sprintf(estyle,"%s/%s",arg[0],lmp->suffix);
+      sprintf(estyle,"%s/%s",style,lmp->suffix);
       if (kspace_map->find(estyle) != kspace_map->end()) {
         KSpaceCreator kspace_creator = (*kspace_map)[estyle];
-        return kspace_creator(lmp, narg-1, &arg[1]);
+        return kspace_creator(lmp);
       }
     }
 
     if (lmp->suffix2) {
       sflag = 1;
       char estyle[256];
-      sprintf(estyle,"%s/%s",arg[0],lmp->suffix2);
+      sprintf(estyle,"%s/%s",style,lmp->suffix2);
       if (kspace_map->find(estyle) != kspace_map->end()) {
         KSpaceCreator kspace_creator = (*kspace_map)[estyle];
-        return kspace_creator(lmp, narg-1, &arg[1]);
+        return kspace_creator(lmp);
       }
     }
   }
 
   sflag = 0;
-  if (strcmp(arg[0],"none") == 0) return NULL;
-  if (kspace_map->find(arg[0]) != kspace_map->end()) {
-    KSpaceCreator kspace_creator = (*kspace_map)[arg[0]];
-    return kspace_creator(lmp, narg-1, &arg[1]);
+  if (strcmp(style,"none") == 0) return NULL;
+  if (kspace_map->find(style) != kspace_map->end()) {
+    KSpaceCreator kspace_creator = (*kspace_map)[style];
+    return kspace_creator(lmp);
   }
 
   char str[128];
-  sprintf(str,"Unknown kspace style %s",arg[0]);
+  sprintf(str,"Unknown kspace style %s",style);
   error->all(FLERR,str);
 
   return NULL;
@@ -726,9 +726,9 @@ KSpace *Force::new_kspace(int narg, char **arg, int trysuffix, int &sflag)
 ------------------------------------------------------------------------- */
 
 template <typename T>
-KSpace *Force::kspace_creator(LAMMPS *lmp, int narg, char ** arg)
+KSpace *Force::kspace_creator(LAMMPS *lmp)
 {
-  return new T(lmp, narg, arg);
+  return new T(lmp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/force.h
+++ b/src/force.h
@@ -72,7 +72,7 @@ class Force : protected Pointers {
   typedef Angle *(*AngleCreator)(LAMMPS *);
   typedef Dihedral *(*DihedralCreator)(LAMMPS *);
   typedef Improper *(*ImproperCreator)(LAMMPS *);
-  typedef KSpace *(*KSpaceCreator)(LAMMPS *,int,char**);
+  typedef KSpace *(*KSpaceCreator)(LAMMPS *);
 
   typedef std::map<std::string,PairCreator> PairCreatorMap;
   typedef std::map<std::string,BondCreator> BondCreatorMap;
@@ -123,8 +123,8 @@ class Force : protected Pointers {
   class Improper *new_improper(const char *, int, int &);
   class Improper *improper_match(const char *);
 
-  void create_kspace(int, char **, int);
-  class KSpace *new_kspace(int, char **, int, int &);
+  void create_kspace(const char *, int);
+  class KSpace *new_kspace(const char *, int, int &);
   class KSpace *kspace_match(const char *, int);
 
   void store_style(char *&, const char *, int);
@@ -148,7 +148,7 @@ class Force : protected Pointers {
   template <typename T> static Angle *angle_creator(LAMMPS *);
   template <typename T> static Dihedral *dihedral_creator(LAMMPS *);
   template <typename T> static Improper *improper_creator(LAMMPS *);
-  template <typename T> static KSpace *kspace_creator(LAMMPS *, int, char **);
+  template <typename T> static KSpace *kspace_creator(LAMMPS *);
 };
 
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1633,7 +1633,8 @@ void Input::kspace_modify()
 
 void Input::kspace_style()
 {
-  force->create_kspace(narg,arg,1);
+  force->create_kspace(arg[0],1);
+  if (force->kspace) force->kspace->settings(narg-1,&arg[1]);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -30,7 +30,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-KSpace::KSpace(LAMMPS *lmp, int /*narg*/, char **/*arg*/) : Pointers(lmp)
+KSpace::KSpace(LAMMPS *lmp) : Pointers(lmp)
 {
   order_allocated = 0;
   energy = 0.0;

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -133,7 +133,7 @@ class KSpace : protected Pointers {
 
 /* ----------------------------------------------------------------------
    compute gamma for MSM and pair styles
-   see Eq 4 from Parallel Computing 35 (2009) 164177
+   see Eq 4 from Parallel Computing 35 (2009) 164-177
 ------------------------------------------------------------------------- */
 
   double gamma(const double &rho) const

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -92,7 +92,7 @@ class KSpace : protected Pointers {
 
   double splittol;                // tolerance for when to truncate splitting
 
-  KSpace(class LAMMPS *, int, char **);
+  KSpace(class LAMMPS *);
   virtual ~KSpace();
   void triclinic_check();
   void modify_params(int, char **);
@@ -112,6 +112,7 @@ class KSpace : protected Pointers {
 
   // general child-class methods
 
+  virtual void settings(int, char **) {};
   virtual void init() = 0;
   virtual void setup() = 0;
   virtual void setup_grid() {};

--- a/src/kspace_deprecated.cpp
+++ b/src/kspace_deprecated.cpp
@@ -17,7 +17,6 @@
 
 #include <cstring>
 #include "kspace_deprecated.h"
-#include "kspace_hybrid.h"
 #include "comm.h"
 #include "force.h"
 #include "error.h"
@@ -36,14 +35,14 @@ static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
 
 /* ---------------------------------------------------------------------- */
 
-void KspaceDeprecated::settings(int, char **)
+void KSpaceDeprecated::settings(int, char **)
 {
   const char *my_style = force->kspace_style;
 
   if (strcmp(my_style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nKspace style 'DEPRECATED' is a dummy style\n\n",0);
+    writemsg(lmp,"\nKSpace style 'DEPRECATED' is a dummy style\n\n",0);
 
   }
-}  
+}
 
 

--- a/src/kspace_deprecated.cpp
+++ b/src/kspace_deprecated.cpp
@@ -1,0 +1,49 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include "kspace_deprecated.h"
+#include "kspace_hybrid.h"
+#include "comm.h"
+#include "force.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
+{
+  if (lmp->comm->me == 0) {
+    if (lmp->screen) fputs(msg,lmp->screen);
+    if (lmp->logfile) fputs(msg,lmp->logfile);
+  }
+  if (abend)
+    lmp->error->all(FLERR,"This kspace style is no longer available");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void KspaceDeprecated::settings(int, char **)
+{
+  const char *my_style = force->kspace_style;
+
+  if (strcmp(my_style,"DEPRECATED") == 0) {
+    writemsg(lmp,"\nKspace style 'DEPRECATED' is a dummy style\n\n",0);
+
+  }
+}  
+
+

--- a/src/kspace_deprecated.h
+++ b/src/kspace_deprecated.h
@@ -13,7 +13,7 @@
 
 #ifdef KSPACE_CLASS
 
-KspaceStyle(DEPRECATED,KspaceDeprecated)
+KSpaceStyle(DEPRECATED,KSpaceDeprecated)
 
 #else
 
@@ -24,12 +24,13 @@ KspaceStyle(DEPRECATED,KspaceDeprecated)
 
 namespace LAMMPS_NS {
 
-class KspaceDeprecated : public Kspace {
+class KSpaceDeprecated : public KSpace {
  public:
-  KspaceDeprecated(class LAMMPS *lmp) : Kspace(lmp) {}
-  virtual ~KspaceDeprecated() {}
+  KSpaceDeprecated(class LAMMPS *lmp) : KSpace(lmp) {}
+  virtual ~KSpaceDeprecated() {}
 
   virtual void init() {}
+  virtual void settings(int, char**);
   virtual void setup() {}
   virtual void compute(int, int) {}
 };

--- a/src/kspace_deprecated.h
+++ b/src/kspace_deprecated.h
@@ -1,0 +1,44 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef KSPACE_CLASS
+
+KspaceStyle(DEPRECATED,KspaceDeprecated)
+
+#else
+
+#ifndef LMP_KSPACE_DEPRECATED_H
+#define LMP_KSPACE_DEPRECATED_H
+
+#include "kspace.h"
+
+namespace LAMMPS_NS {
+
+class KspaceDeprecated : public Kspace {
+ public:
+  KspaceDeprecated(class LAMMPS *lmp) : Kspace(lmp) {}
+  virtual ~KspaceDeprecated() {}
+
+  virtual void init() {}
+  virtual void setup() {}
+  virtual void compute(int, int) {}
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+*/


### PR DESCRIPTION
## Purpose

All force computing base classes except Kspace were instantiated with a constructor followed by a call to a `settings()` method, where the former only receives the style name and the latter parses all following arguments. This pull request refactors `kspace.h` and `kspace.cpp` to follow the same scheme and implements the necessary changes for all derived classes. This improves consistency and allows to add kspace to the deprecated style implementations in #1148

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes. no change in functionality or behavior is expected. if observed, it would be a bug.

## Implementation Notes

this also fixes a couple of minor bugs in USER-SCAFACOS and adds the "DEPRECATED" kspace style.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

