### PR TITLE
Add src directory to PreventInSourceBuilds checks

### DIFF
--- a/cmake/Modules/PreventInSourceBuilds.cmake
+++ b/cmake/Modules/PreventInSourceBuilds.cmake
@@ -5,10 +5,11 @@ function(prevent_in_source_builds)
   # make sure the user doesn't play dirty with symlinks
   get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
   get_filename_component(srcdir2 "${CMAKE_SOURCE_DIR}/.." REALPATH)
+  get_filename_component(srcdir3 "${CMAKE_SOURCE_DIR}/../src" REALPATH)
   get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
 
   # disallow in-source builds
-  if("${srcdir}" STREQUAL "${bindir}" OR "${srcdir2}" STREQUAL "${bindir}")
+  if("${srcdir}" STREQUAL "${bindir}" OR "${srcdir2}" STREQUAL "${bindir}" OR "${srcdir3}" STREQUAL "${bindir}")
     message(FATAL_ERROR "\
 
 CMake must not to be run in the source directory. \


### PR DESCRIPTION
## Purpose

Adds an additional check to the cmake module `PreventInSourceBuilds` to avoid in-source builds started from the `src/` directory.

together with #1136 this closes #1134

## Author(s)

@rbberger



## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines


