### PR TITLE
fix triclinic rounding bug for lib interface as well

### DIFF
--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1623,8 +1623,14 @@ int Domain::ownatom(int /*id*/, double *x, imageint *image, int shrinkexceed)
   if (image) remap(x,*image);
   else remap(x);
 
+  // if triclinic, convert to lamda coords (0-1)
+  // for periodic dims, resulting coord must satisfy 0.0 <= coord < 1.0
+
   if (triclinic) {
     x2lamda(x,lamda);
+    if (xperiodic && (lamda[0] < 0.0 || lamda[0] >= 1.0)) lamda[0] = 0.0;
+    if (yperiodic && (lamda[1] < 0.0 || lamda[1] >= 1.0)) lamda[1] = 0.0;
+    if (zperiodic && (lamda[2] < 0.0 || lamda[2] >= 1.0)) lamda[2] = 0.0;
     coord = lamda;
   } else coord = x;
 


### PR DESCRIPTION
## Purpose

Fix same create atom triclinic periodic bug as in #1161, but now when invoked
via the lib interace and its create_atoms() method.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


