### PR TITLE
Bug fix for merge sort

### DIFF
--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -46,13 +46,6 @@
 #define PRId64 "ld"
 #endif
 
-// favor qsort over mergesort for stable release
-// TODO: to be removed after stable release
-
-#ifndef LMP_QSORT
-#define LMP_QSORT
-#endif
-
 namespace LAMMPS_NS {
 
 // enum used for KOKKOS host/device flags

--- a/src/mergesort.h
+++ b/src/mergesort.h
@@ -98,7 +98,7 @@ static void merge_sort(int *index, int num, void *ptr,
 
     int *tmp = dest; dest = hold; hold = tmp;
 
-    // merge from hold array to destiation array
+    // merge from hold array to destination array
 
     for (i=0; i < num-1; i += 2*chunk) {
       j = i + 2*chunk;
@@ -107,6 +107,10 @@ static void merge_sort(int *index, int num, void *ptr,
       if (m > num) m=num;
       do_merge(dest,hold,i,m,m,j,ptr,comp);
     }
+
+    // copy all indices not handled by the chunked merge sort loop
+
+    for ( ; i < num ; i++ ) dest[i] = hold[i];
     chunk *= 2;
   }
 


### PR DESCRIPTION
## Purpose

This applies the bugfix for merge sort from issue #1163 by @jtfrey and re-enables using merge sort over quick sort (and thus avoiding static class members and improving performance again).
Closes #1163 

## Author(s)

Jeffrey Frey

## Backward Compatibility

yes.

## Implementation Notes

Detailed discussion is at #1163 

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

