### PR TITLE
Bug fix for Kspace refactoring in USER-INTEL package

### DIFF
--- a/src/USER-INTEL/pppm_disp_intel.cpp
+++ b/src/USER-INTEL/pppm_disp_intel.cpp
@@ -59,8 +59,7 @@ enum{FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM,
 
 /* ---------------------------------------------------------------------- */
 
-PPPMDispIntel::PPPMDispIntel(LAMMPS *lmp, int narg, char **arg) :
-  PPPMDisp(lmp, narg, arg)
+PPPMDispIntel::PPPMDispIntel(LAMMPS *lmp) : PPPMDisp(lmp)
 {
   suffix_flag |= Suffix::INTEL;
 
@@ -97,12 +96,9 @@ PPPMDispIntel::~PPPMDispIntel()
   memory->destroy(drho6_lookup);
 }
 
-
-
 /* ----------------------------------------------------------------------
    called once before run
 ------------------------------------------------------------------------- */
-
 
 void PPPMDispIntel::init()
 {

--- a/src/USER-INTEL/pppm_disp_intel.h
+++ b/src/USER-INTEL/pppm_disp_intel.h
@@ -31,7 +31,7 @@ namespace LAMMPS_NS {
 
   class PPPMDispIntel : public PPPMDisp {
   public:
-    PPPMDispIntel(class LAMMPS *, int, char **);
+    PPPMDispIntel(class LAMMPS *);
     virtual ~PPPMDispIntel();
     virtual void init();
     virtual void compute(int, int);

--- a/src/USER-INTEL/pppm_intel.cpp
+++ b/src/USER-INTEL/pppm_intel.cpp
@@ -57,7 +57,7 @@ enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
 
 /* ---------------------------------------------------------------------- */
 
-PPPMIntel::PPPMIntel(LAMMPS *lmp, int narg, char **arg) : PPPM(lmp, narg, arg)
+PPPMIntel::PPPMIntel(LAMMPS *lmp) : PPPM(lmp)
 {
   suffix_flag |= Suffix::INTEL;
 

--- a/src/USER-INTEL/pppm_intel.h
+++ b/src/USER-INTEL/pppm_intel.h
@@ -34,7 +34,7 @@ namespace LAMMPS_NS {
 
 class PPPMIntel : public PPPM {
  public:
-  PPPMIntel(class LAMMPS *, int, char **);
+  PPPMIntel(class LAMMPS *);
   virtual ~PPPMIntel();
   virtual void init();
   virtual void compute(int, int);


### PR DESCRIPTION
## Purpose

This fixes the bug reported in issue #1173 (and second similar one). Online the corresponding calling sequences need to be updates, since the argument parsing, where is now in `settings()` is deferred to the parent classes for the affected USER-INTEL kspace styles. With this change USER-INTEL compiles again. closes #1173 

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

Yes.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
