### PR TITLE
reorder operations in init() to fix a bug with compute chunk/atom del…

### DIFF
--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -165,7 +165,40 @@ void Modify::init()
 
   restart_deallocate(1);
 
+  // init each compute
+  // set invoked_scalar,vector,etc to -1 to force new run to re-compute them
+  // add initial timestep to all computes that store invocation times
+  //   since any of them may be invoked by initial thermo
+  // do not clear out invocation times stored within a compute,
+  //   b/c some may be holdovers from previous run, like for ave fixes
+
+  for (i = 0; i < ncompute; i++) {
+    compute[i]->init();
+    compute[i]->invoked_scalar = -1;
+    compute[i]->invoked_vector = -1;
+    compute[i]->invoked_array = -1;
+    compute[i]->invoked_peratom = -1;
+    compute[i]->invoked_local = -1;
+  }
+  addstep_compute_all(update->ntimestep);
+
+  // init each fix
+  // should not need to come before compute init
+  //   used to b/c temperature computes called fix->dof() in their init,
+  //   and fix rigid required its own init before its dof() could be called,
+  //   but computes now do their DOF in setup()
+
+  for (i = 0; i < nfix; i++) fix[i]->init();
+
+  // set global flag if any fix has its restart_pbc flag set
+
+  restart_pbc_any = 0;
+  for (i = 0; i < nfix; i++)
+    if (fix[i]->restart_pbc) restart_pbc_any = 1;
+
   // create lists of fixes to call at each stage of run
+  // needs to happen after init() of computes
+  //   b/c a compute::init() can delete a fix, e.g. compute chunk/atom
 
   list_init(INITIAL_INTEGRATE,n_initial_integrate,list_initial_integrate);
   list_init(POST_INTEGRATE,n_post_integrate,list_post_integrate);
@@ -199,40 +232,9 @@ void Modify::init()
   list_init(MIN_POST_FORCE,n_min_post_force,list_min_post_force);
   list_init(MIN_ENERGY,n_min_energy,list_min_energy);
 
-  // init each fix
-  // not sure if now needs to come before compute init
-  // used to b/c temperature computes called fix->dof() in their init,
-  // and fix rigid required its own init before its dof() could be called,
-  // but computes now do their DOF in setup()
-
-  for (i = 0; i < nfix; i++) fix[i]->init();
-
-  // set global flag if any fix has its restart_pbc flag set
-
-  restart_pbc_any = 0;
-  for (i = 0; i < nfix; i++)
-    if (fix[i]->restart_pbc) restart_pbc_any = 1;
-
   // create list of computes that store invocation times
 
   list_init_compute();
-
-  // init each compute
-  // set invoked_scalar,vector,etc to -1 to force new run to re-compute them
-  // add initial timestep to all computes that store invocation times
-  //   since any of them may be invoked by initial thermo
-  // do not clear out invocation times stored within a compute,
-  //   b/c some may be holdovers from previous run, like for ave fixes
-
-  for (i = 0; i < ncompute; i++) {
-    compute[i]->init();
-    compute[i]->invoked_scalar = -1;
-    compute[i]->invoked_vector = -1;
-    compute[i]->invoked_array = -1;
-    compute[i]->invoked_peratom = -1;
-    compute[i]->invoked_local = -1;
-  }
-  addstep_compute_all(update->ntimestep);
 
   // error if any fix or compute is using a dynamic group when not allowed
 
@@ -248,7 +250,8 @@ void Modify::init()
     if (!compute[i]->dynamic_group_allow &&
         group->dynamic[compute[i]->igroup]) {
       char str[128];
-      snprintf(str,128,"Compute %s does not allow use of dynamic group",fix[i]->id);
+      snprintf(str,128,"Compute %s does not allow use of dynamic group",
+               fix[i]->id);
       error->all(FLERR,str);
     }
 


### PR DESCRIPTION
…eting a fix

## Purpose

Reorder operations in Modify::init().  This is to fix a bug reported by Laurent Joly on the mail list,
where compute chunk/atom deleted a fix in its init(), making the lists of per-timestep fix invocations bogus.  This puts the init() calls for computes and fixes before the creation of those lists.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


