### PR TITLE
liblammps.pc: add some more documentation

### DIFF
--- a/cmake/pkgconfig/liblammps.pc.in
+++ b/cmake/pkgconfig/liblammps.pc.in
@@ -1,8 +1,28 @@
 # pkg-config file for lammps
 # https://people.freedesktop.org/~dbn/pkg-config-guide.html
-# Usage: cc `pkg-config --cflags --libs liblammps` -o myapp myapp.c
-# after you added @CMAKE_INSTALL_FULL_LIBDIR@/pkg-config to PKG_CONFIG_PATH,
+
+# Add the directory where lammps.pc got installed to your PKG_CONFIG_PATH
 # e.g. export PKG_CONFIG_PATH=@CMAKE_INSTALL_FULL_LIBDIR@/pkgconfig
+
+# Use this on commandline with:
+# c++ `pkg-config --cflags --libs lammps` -o myapp myapp.cpp
+
+# Use this in a Makefile:
+# myapp: myapp.cpp
+# 	$(CC) `pkg-config --cflags --libs lammps` -o $@ $<
+
+# Use this in autotools:
+# configure.ac:
+# PKG_CHECK_MODULES([LAMMPS], [lammps])
+# Makefile.am:
+# myapp_CFLAGS = $(LAMMPS_CFLAGS)
+# myapp_LDADD = $(LAMMPS_LIBS)
+
+# Use this in CMake:
+# CMakeLists.txt:
+# find_package(PkgConfig)
+# pkg_check_modules(LAMMPS IMPORTED_TARGET lammps)
+# target_link_libraries(<lib> PkgConfig::LAMMPS)
 
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@


### PR DESCRIPTION
## Purpose

Add some documentation to pkg-config file.

## Author(s)

@junghans


## Backward Compatibility

Yes

## Implementation Notes

To-Do:
- [ ] Add this documentation somewhere
- [ ] Have the make-based build system install lammps.pc as well

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- `N/A` One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

https://people.freedesktop.org/~dbn/pkg-config-guide.html
