### PR TITLE
Reduce namespace pollution for VORONOI package

### DIFF
--- a/src/VORONOI/compute_voronoi_atom.cpp
+++ b/src/VORONOI/compute_voronoi_atom.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstring>
 #include <cstdlib>
+#include "voro++.hh"
 #include "compute_voronoi_atom.h"
 #include "atom.h"
 #include "group.h"

--- a/src/VORONOI/compute_voronoi_atom.h
+++ b/src/VORONOI/compute_voronoi_atom.h
@@ -21,7 +21,12 @@ ComputeStyle(voronoi/atom,ComputeVoronoi)
 #define LMP_COMPUTE_VORONOI_H
 
 #include "compute.h"
-#include "voro++.hh"
+
+namespace voro {
+  class container;
+  class container_poly;
+  class voronoicell_neighbor;
+}
 
 namespace LAMMPS_NS {
 


### PR DESCRIPTION
## Purpose

use forward declarations in compute `voronoi/atom` for better namespace hygiene and to avoid having the voro++.hh header to be included globally.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

No change in functionality.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
