### PR TITLE
Various small fixes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -193,6 +193,8 @@ if(PKG_MEAM OR PKG_USER-H5MD OR PKG_USER-QMMM OR PKG_USER-SCAFACOS)
   enable_language(C)
 endif()
 
+include_directories(${LAMMPS_SOURCE_DIR})
+
 # do MPI detection after language activation, if MPI for these language is required
 find_package(MPI QUIET)
 option(BUILD_MPI "Build MPI version" ${MPI_FOUND})
@@ -1166,7 +1168,6 @@ set(LAMMPS_STYLE_HEADERS_DIR ${CMAKE_CURRENT_BINARY_DIR}/styles)
 
 GenerateStyleHeaders(${LAMMPS_STYLE_HEADERS_DIR})
 
-include_directories(${LAMMPS_SOURCE_DIR})
 include_directories(${LAMMPS_STYLE_HEADERS_DIR})
 
 ######################################

--- a/lib/latte/Install.py
+++ b/lib/latte/Install.py
@@ -78,7 +78,6 @@ def geturl(url,fname):
 
   if which('curl') != None:
     cmd = 'curl -L -o "%s" %s' % (fname,url)
-    print(cmd)
     try:
       subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
       success = True
@@ -87,7 +86,6 @@ def geturl(url,fname):
 
   if not success and which('wget') != None:
     cmd = 'wget -O "%s" %s' % (fname,url)
-    print(cmd)
     try:
       subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
       success = True

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -1477,8 +1477,10 @@ void CommBrick::free_multi()
 
 void *CommBrick::extract(const char *str, int &dim)
 {
+  dim = 0;
   if (strcmp(str,"localsendlist") == 0) {
     int i, iswap, isend;
+    dim = 1;
     if (!localsendlist)
       memory->create(localsendlist,atom->nlocal,"comm:localsendlist");
     else

--- a/src/compute_adf.cpp
+++ b/src/compute_adf.cpp
@@ -46,14 +46,17 @@ enum{DEGREE, RADIAN, COSINE};
 ComputeADF::ComputeADF(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   ilo(NULL), ihi(NULL), jlo(NULL), jhi(NULL), klo(NULL), khi(NULL), 
-  iatomcount(NULL), iatomcountall(NULL), 
   hist(NULL), histall(NULL),
-  iatomflag(NULL), 
-  jatomflag(NULL), rcutinnerj(NULL), rcutouterj(NULL), 
-  katomflag(NULL), rcutinnerk(NULL), rcutouterk(NULL),
-  list(NULL), maxjatom(NULL), numjatom(NULL), neighjatom(NULL),
-  maxkatom(NULL), numkatom(NULL), neighkatom(NULL), 
-  maxjkatom(NULL), numjkatom(NULL), neighjkatom(NULL), bothjkatom(NULL)
+  rcutinnerj(NULL), rcutinnerk(NULL),
+  rcutouterj(NULL), rcutouterk(NULL),
+  list(NULL),
+  iatomcount(NULL), iatomcountall(NULL), iatomflag(NULL),
+  maxjatom(NULL), maxkatom(NULL),
+  numjatom(NULL), numkatom(NULL),
+  neighjatom(NULL),neighkatom(NULL), 
+  jatomflag(NULL), katomflag(NULL),
+  maxjkatom(NULL), numjkatom(NULL),
+  neighjkatom(NULL), bothjkatom(NULL), delrjkatom(NULL)
 {
   int nargsperadf = 7;
 
@@ -358,9 +361,9 @@ void ComputeADF::init_list(int /*id*/, NeighList *ptr)
 void ComputeADF::compute_array()
 {
   int i,j,k,m,ii,jj,jatom,katom,jk,jjj,kkk;
-  int inum,jnum,itype,jtype,ibin,ihisto;
+  int inum,jnum,itype,jtype,ibin;
   double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
-  int *ilist,*jlist,*klist,*numneigh,**firstneigh;
+  int *ilist,*jlist,*numneigh,**firstneigh;
   double factor_lj,factor_coul;
   double delr1[3],delr2[3],rinv1,rinv2,rinv12,cs,theta;
 
@@ -394,11 +397,9 @@ void ComputeADF::compute_array()
   double **x = atom->x;
   int *type = atom->type;
   int *mask = atom->mask;
-  int nlocal = atom->nlocal;
 
   double *special_coul = force->special_coul;
   double *special_lj = force->special_lj;
-  int newton_pair = force->newton_pair;
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];

--- a/src/compute_adf.cpp
+++ b/src/compute_adf.cpp
@@ -51,7 +51,7 @@ ComputeADF::ComputeADF(LAMMPS *lmp, int narg, char **arg) :
   iatomflag(NULL), 
   jatomflag(NULL), rcutinnerj(NULL), rcutouterj(NULL), 
   katomflag(NULL), rcutinnerk(NULL), rcutouterk(NULL),
-  maxjatom(NULL), numjatom(NULL), neighjatom(NULL), 
+  list(NULL), maxjatom(NULL), numjatom(NULL), neighjatom(NULL),
   maxkatom(NULL), numkatom(NULL), neighkatom(NULL), 
   maxjkatom(NULL), numjkatom(NULL), neighjkatom(NULL), bothjkatom(NULL)
 {

--- a/src/compute_angle_local.cpp
+++ b/src/compute_angle_local.cpp
@@ -38,7 +38,7 @@ enum{THETA,ENG,VARIABLE};
 
 ComputeAngleLocal::ComputeAngleLocal(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
-  bstyle(NULL), vstr(NULL), vvar(NULL), tstr(NULL), vlocal(NULL), alocal(NULL)
+  bstyle(NULL), vvar(NULL), tstr(NULL), vstr(NULL), vlocal(NULL), alocal(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute angle/local command");
 

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -39,7 +39,7 @@ enum{DIST,VELVIB,OMEGA,ENGTRANS,ENGVIB,ENGROT,ENGPOT,FORCE,VARIABLE};
 
 ComputeBondLocal::ComputeBondLocal(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
-  bstyle(NULL), vstr(NULL), vvar(NULL), dstr(NULL), vlocal(NULL), alocal(NULL)
+  bstyle(NULL), vvar(NULL), dstr(NULL), vstr(NULL), vlocal(NULL), alocal(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute bond/local command");
 

--- a/src/compute_dihedral_local.cpp
+++ b/src/compute_dihedral_local.cpp
@@ -40,7 +40,7 @@ enum{PHI,VARIABLE};
 
 ComputeDihedralLocal::ComputeDihedralLocal(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
-  bstyle(NULL), vstr(NULL), vvar(NULL), pstr(NULL), vlocal(NULL), alocal(NULL)
+  bstyle(NULL), vvar(NULL), pstr(NULL), vstr(NULL), vlocal(NULL), alocal(NULL)
 {
   if (narg < 4) error->all(FLERR,"Illegal compute dihedral/local command");
 

--- a/src/deprecated.cpp
+++ b/src/deprecated.cpp
@@ -36,7 +36,7 @@ static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
 
 /* ---------------------------------------------------------------------- */
 
-void Deprecated::command(int narg, char **arg)
+void Deprecated::command(int /* narg */, char ** /* arg */)
 {
   if (strcmp(input->command,"DEPRECATED") == 0) {
     writemsg(lmp,"\nCommand 'DEPRECATED' is a dummy command\n\n",0);


### PR DESCRIPTION
## Purpose

Collection of mostly cosmetic changes that reduces compiler warnings and ensures initialization of data.
Includes a fix for CMake build on systems where header files with identical names to LAMMPS header files are in include folders picked up through supporting libraries like PNG or JPEG. closes #1187 

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

