### PR TITLE
Dihedral generation bugfix for msi2lmp

### DIFF
--- a/tools/msi2lmp/src/MakeLists.c
+++ b/tools/msi2lmp/src/MakeLists.c
@@ -363,7 +363,7 @@ int count_dihedrals()
               if (i != k) {
                 for (ll=0; ll < atoms[k].no_connect; ll++) {
                   l = atoms[k].conn_no[ll];
-                  if (l != j) n++;
+                  if ((l != j) && (i != l)) n++
                 }
               }
             }
@@ -391,7 +391,7 @@ void build_dihedrals_list()
               if (i != k) {
                 for (ll=0; ll < atoms[k].no_connect; ll++) {
                   l = atoms[k].conn_no[ll];
-                  if (l != j) {
+                  if ((l != j) && (i != l)) {
                     dihedrals[n  ].type = 0;
                     dihedrals[n  ].members[0] = i;
                     dihedrals[n  ].members[1] = j;

--- a/tools/msi2lmp/src/msi2lmp.c
+++ b/tools/msi2lmp/src/msi2lmp.c
@@ -2,6 +2,8 @@
 *
 *  msi2lmp.exe
 *
+*   v3.9.9 AK- Teach msi2lmp to not generate dihedrals with identical 1-4 atoms
+*
 *   v3.9.8 AK- Improved whitespace handling in parsing topology and force
 *              field files to avoid bogus warnings about type name truncation
 *

--- a/tools/msi2lmp/src/msi2lmp.h
+++ b/tools/msi2lmp/src/msi2lmp.h
@@ -36,7 +36,7 @@
 
 # include <stdio.h>
 
-#define MSI2LMP_VERSION "v3.9.8 / 06 Oct 2016"
+#define MSI2LMP_VERSION "v3.9.9 / 05 Nov 2018"
 
 #define PI_180  0.01745329251994329576
 


### PR DESCRIPTION
## Purpose

Do not generate illegal dihedrals, e.g. from 3-membered rings. msi2lmp walks the list of connections to build angle and dihedrals. But that creates illegal dihedrals for 3-membered rings. This modification will skip those.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

n/a

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

