### PR TITLE
fix cmake build for USER-H5MD

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -819,7 +819,7 @@ foreach(SIMPLE_LIB REAX MEAM POEMS USER-ATC USER-AWPMD USER-COLVARS USER-H5MD
     if(PKG_LIB STREQUAL awpmd)
       target_include_directories(awpmd PUBLIC ${LAMMPS_LIB_SOURCE_DIR}/awpmd/systems/interact ${LAMMPS_LIB_SOURCE_DIR}/awpmd/ivutils/include)
     elseif(PKG_LIB STREQUAL h5md)
-      target_include_directories(h5md PUBLIC ${LAMMPS_LIB_SOURCE_DIR}/h5md/include)
+      target_include_directories(h5md PUBLIC ${LAMMPS_LIB_SOURCE_DIR}/h5md/include ${HDF5_INCLUDE_DIRS})
     elseif(PKG_LIB STREQUAL colvars)
       target_compile_options(colvars PRIVATE -DLEPTON)
       target_include_directories(colvars PRIVATE ${LAMMPS_LIB_SOURCE_DIR}/colvars/lepton/include)
@@ -842,6 +842,7 @@ if(PKG_USER-H5MD)
   find_package(HDF5 REQUIRED)
   target_link_libraries(h5md ${HDF5_LIBRARIES})
   target_include_directories(h5md PRIVATE ${HDF5_INCLUDE_DIRS})
+  include_directories(${HDF5_INCLUDE_DIRS})
 endif()
 
 


### PR DESCRIPTION
The hdf5 includes were needed as well for building the dump.

## Purpose

Fix failing builds of the extension `USER-H5MD` for the cmake build system.

## Author(s)

Pierre de Buyl, KU Leuven

## Backward Compatibility

There is no issue of compatibility. The pull request addresses a missing item in the cmake build process.

## Implementation Notes

I added `${HDF5_INCLUDE_DIRS}` using `include_directories`.


## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
