### PR TITLE
fix topology parsing

### DIFF
--- a/tools/ch2lmp/charmm2lammps.pl
+++ b/tools/ch2lmp/charmm2lammps.pl
@@ -795,8 +795,7 @@
         $masses{$tmp[1]}        = $tmp[3];
         $max_id                 = $tmp[1] if ($max_id<$tmp[1]);
       } elsif ($read&&($tmp[0] eq "ATOM")) {
-        # $names{$tmp[1]} = $tmp[4] if ($read&&($tmp[0] eq "MASS"));
-        #last if ($read&&!scalar(@tmp));                   # quit reading
+        # quit reading when hitting the "ATOM" section
         last;
       }
     }

--- a/tools/ch2lmp/charmm2lammps.pl
+++ b/tools/ch2lmp/charmm2lammps.pl
@@ -794,9 +794,11 @@
         $ids{$tmp[1]}           = $tmp[2];
         $masses{$tmp[1]}        = $tmp[3];
         $max_id                 = $tmp[1] if ($max_id<$tmp[1]);
+      } elsif ($read&&($tmp[0] eq "ATOM")) {
+        # $names{$tmp[1]} = $tmp[4] if ($read&&($tmp[0] eq "MASS"));
+        #last if ($read&&!scalar(@tmp));                   # quit reading
+        last;
       }
-      # $names{$tmp[1]} = $tmp[4] if ($read&&($tmp[0] eq "MASS"));
-      last if ($read&&!scalar(@tmp));                   # quit reading
     }
     AddMass(HT, 1.00800);
     AddMass(OT, 15.99940);


### PR DESCRIPTION
## Purpose

CHARMM topology files sometimes contain spaces between MASS declarations. charmm2lammps omits all the MASS declarations that appear after a line with just a CR. This PR fix this issue (not reported in the issue list).

## Author(s)

Diego Ugarte

## Backward Compatibility

It is backward compatible.

## Implementation Notes

I just added an elsif statement that makes the reading process to not stop if a line with a CR is found, but when a line with an ATOM statement is found.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [X] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links
