### PR TITLE
Handle class2 force field parameters correctly in write_coeff

### DIFF
--- a/src/write_coeff.cpp
+++ b/src/write_coeff.cpp
@@ -27,6 +27,8 @@
 
 using namespace LAMMPS_NS;
 
+enum {REGULAR_MODE, CLASS2_MODE};
+
 /* ----------------------------------------------------------------------
    called as write_coeff command in input script
 ------------------------------------------------------------------------- */
@@ -50,6 +52,7 @@ void WriteCoeff::command(int narg, char **arg)
   if (comm->me == 0) {
     char str[256], coeff[256];
     FILE *one = fopen(file,"wb+");
+
     if (one == NULL) {
       snprintf(str,256,"Cannot open coeff file %s",file);
       error->one(FLERR,str);
@@ -91,17 +94,78 @@ void WriteCoeff::command(int narg, char **arg)
     }
     fprintf(two,"# LAMMPS coeff file via write_coeff, version %s\n",
             universe->version);
+
     while(1) {
+      int coeff_mode = REGULAR_MODE;
       if (fgets(str,256,one) == NULL) break;
+
+      // some coeffs need special treatment
+      if (strstr(str,"class2") != NULL) {
+        if (strstr(str,"angle_style") != NULL)
+          coeff_mode = CLASS2_MODE;
+        else if (strstr(str,"dihedral_style") != NULL)
+          coeff_mode = CLASS2_MODE;
+        else if (strstr(str,"improper_style") != NULL)
+          coeff_mode = CLASS2_MODE;
+      }
+
+      const char *section = (const char *)"";
       fputs(str,two);      // style
       fgets(str,256,one);  // coeff
       n = strlen(str);
       strcpy(coeff,str);
       coeff[n-1] = '\0';
       fgets(str,256,one);
+
       while (strcmp(str,"end\n") != 0) {
-        fprintf(two,"%s %s",coeff,str);
-        fgets(str,256,one);
+
+        if (coeff_mode == REGULAR_MODE) {
+
+          fprintf(two,"%s %s",coeff,str);
+          fgets(str,256,one);
+
+        } else if (coeff_mode == CLASS2_MODE) {
+
+          // class2 angles, dihedrals, and impropers can have
+          // multiple sections and thus need special treatment
+
+          if (strcmp(str,"\n") == 0) {
+
+            // all but the the last section end with an empty line.
+            // skip it and read and parse the next section title
+
+            fgets(str,256,one);
+
+            if (strcmp(str,"BondBond Coeffs\n") == 0)
+              section = (const char *)"bb";
+            else if (strcmp(str,"BondAngle Coeffs\n") ==0)
+              section = (const char *)"ba";
+            else if (strcmp(str,"MiddleBondTorsion Coeffs\n") == 0)
+              section = (const char *)"mbt";
+            else if (strcmp(str,"EndBondTorsion Coeffs\n") == 0)
+              section = (const char *)"ebt";
+            else if (strcmp(str,"AngleTorsion Coeffs\n") == 0)
+              section = (const char *)"at";
+            else if (strcmp(str,"AngleAngleTorsion Coeffs\n") == 0)
+              section = (const char *)"aat";
+            else if (strcmp(str,"BondBond13 Coeffs\n") == 0)
+              section = (const char *)"bb13";
+            else if (strcmp(str,"AngleAngle Coeffs\n") == 0)
+              section = (const char *)"aa";
+
+            fgets(str,256,one);   // gobble up one more empty line
+            fgets(str,256,one);
+          }
+
+          // parse type number and skip over it
+          int type = atoi(str);
+          char *p = str;
+          while ((*p != '\0') && (*p == ' ')) ++p;
+          while ((*p != '\0') && isdigit(*p)) ++p;
+
+          fprintf(two,"%s %d %s %s",coeff,type,section,p);
+          fgets(str,256,one);
+        }
       }
       fputc('\n',two);
     }


### PR DESCRIPTION
## Purpose

The write_coeff command needs to include special cases, to correctly transform the sections for class2 style angles, dihedrals and impropers.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

yes. write_coeff was not producing correct output for angles, dihedrals, and impropers. now it is.

## Implementation Notes

This code is rather fragile, because it depends on specifics how the coeffs sections of data files are written, but since this is handled internally by processing a temporary file, it still is safe for as long as it is kept consistent with how the corresponding coeff sections in data files are written.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [n/a] Suitable new documentation files and/or updates to the existing docs are included
- [n/a] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines


