### PR TITLE
Tersoff GPU kernel dead code removal

### DIFF
--- a/lib/gpu/lal_tersoff.cu
+++ b/lib/gpu/lal_tersoff.cu
@@ -11,7 +11,7 @@
 //
 //       begin                : Thu April 17, 2014
 //       email                : ndactrung@gmail.com
-// ***************************************************************************/
+// **************************************************************************
 
 #ifdef NV_KERNEL
 #include "lal_tersoff_extra.h"
@@ -572,7 +572,6 @@ __kernel void k_tersoff_three_center(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -760,7 +759,6 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -815,21 +813,10 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
-        ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
-      }
 
-      //int iix = (ijnum - offset_kf - 2*nbor_pitch) / n_stride;
-      //int idx = iix*n_stride + j*t_per_atom + offset_kf;
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               j, ijnum, offset_kf, idx);
       acctyp4 zeta_ji = zetaij[idx]; // fetch(zeta_ji,idx,zeta_tex);
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
@@ -1005,7 +992,6 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -1060,21 +1046,10 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
-        ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
-      }
 
-      //int iix = (ijnum - offset_kf - 2*nbor_pitch) / n_stride;
-      //int idx = iix*n_stride + j*t_per_atom + offset_kf;
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               j, ijnum, offset_kf, idx);
       acctyp4 zeta_ji = zetaij[idx]; //  fetch(zeta_ji,idx,zeta_tex);
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;

--- a/lib/gpu/lal_tersoff.cu
+++ b/lib/gpu/lal_tersoff.cu
@@ -719,8 +719,6 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[2*BLOCK_PAIR];
-
   __syncthreads();
 
   if (ii<inum) {
@@ -792,15 +790,13 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
       int nbork_start = nbor_k;
 
       // look up for zeta_ji: find i in the j's neighbor list
-      int m = tid / t_per_atom;
+
       int ijnum = -1;
       for ( ; nbor_k<k_end; nbor_k+=n_stride) {
         int k=nbor_mem[nbor_k];
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[2*m+0] = ijnum;
-          red_acc[2*m+1] = offset_k;
           break;
         }
       }
@@ -949,8 +945,6 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[2*BLOCK_PAIR];
-
   __syncthreads();
 
   if (ii<inum) {
@@ -1022,15 +1016,13 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
       int nbork_start = nbor_k;
 
       // look up for zeta_ji
-      int m = tid / t_per_atom;
+
       int ijnum = -1;
       for ( ; nbor_k<k_end; nbor_k+=n_stride) {
         int k=nbor_mem[nbor_k];
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[2*m+0] = ijnum;
-          red_acc[2*m+1] = offset_k;
           break;
         }
       }

--- a/lib/gpu/lal_tersoff.cu
+++ b/lib/gpu/lal_tersoff.cu
@@ -339,13 +339,13 @@ __kernel void k_tersoff_zeta(const __global numtyp4 *restrict x_,
 
         if (rsq2 > cutsq[ijkparam]) continue;
 
-        numtyp4 ts1_ijkparam = ts1[ijkparam]; //fetch4(ts1_ijkparam,ijkparam,ts1_tex);
+        numtyp4 ts1_ijkparam = ts1[ijkparam];
         numtyp ijkparam_lam3 = ts1_ijkparam.z;
         numtyp ijkparam_powermint = ts1_ijkparam.w;
-        numtyp4 ts2_ijkparam = ts2[ijkparam]; //fetch4(ts2_ijkparam,ijkparam,ts2_tex);
+        numtyp4 ts2_ijkparam = ts2[ijkparam];
         numtyp ijkparam_bigr = ts2_ijkparam.z;
         numtyp ijkparam_bigd = ts2_ijkparam.w;
-        numtyp4 ts4_ijkparam = ts4[ijkparam]; //fetch4(ts4_ijkparam,ijkparam,ts4_tex);
+        numtyp4 ts4_ijkparam = ts4[ijkparam];
         numtyp ijkparam_c = ts4_ijkparam.x;
         numtyp ijkparam_d = ts4_ijkparam.y;
         numtyp ijkparam_h = ts4_ijkparam.z;
@@ -355,27 +355,24 @@ __kernel void k_tersoff_zeta(const __global numtyp4 *restrict x_,
                   rsq1, rsq2, delr1, delr2);
       }
 
-      //int jj = (nbor_j-offset_j-2*nbor_pitch)/n_stride;
-      //int idx = jj*n_stride + i*t_per_atom + offset_j;
       //idx to zetaij is shifted by n_stride relative to nbor_j in dev_short_nbor
       int idx = nbor_j;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               i, nbor_j, offset_j, idx);
+
       acc_zeta(z, tid, t_per_atom, offset_k);
 
-      numtyp4 ts1_ijparam = ts1[ijparam]; //fetch4(ts1_ijparam,ijparam,ts1_tex);
+      numtyp4 ts1_ijparam = ts1[ijparam];
       numtyp ijparam_lam2 = ts1_ijparam.y;
-      numtyp4 ts2_ijparam = ts2[ijparam]; //fetch4(ts2_ijparam,ijparam,ts2_tex);
+      numtyp4 ts2_ijparam = ts2[ijparam];
       numtyp ijparam_bigb = ts2_ijparam.y;
       numtyp ijparam_bigr = ts2_ijparam.z;
       numtyp ijparam_bigd = ts2_ijparam.w;
-      numtyp4 ts3_ijparam = ts3[ijparam]; //fetch4(ts3_ijparam,ijparam,ts3_tex);
+      numtyp4 ts3_ijparam = ts3[ijparam];
       numtyp ijparam_c1 = ts3_ijparam.x;
       numtyp ijparam_c2 = ts3_ijparam.y;
       numtyp ijparam_c3 = ts3_ijparam.z;
       numtyp ijparam_c4 = ts3_ijparam.w;
-      numtyp4 ts5_ijparam = ts5[ijparam]; //fetch4(ts5_ijparam,ijparam,ts5_tex);
+      numtyp4 ts5_ijparam = ts5[ijparam];
       numtyp ijparam_beta = ts5_ijparam.x;
       numtyp ijparam_powern = ts5_ijparam.y;
 
@@ -585,14 +582,11 @@ __kernel void k_tersoff_three_center(const __global numtyp4 *restrict x_,
 
       // look up for zeta_ij
 
-      //int jj = (nbor_j-offset_j-2*nbor_pitch) / n_stride;
-      //int idx = jj*n_stride + i*t_per_atom + offset_j;
       //idx to zetaij is shifted by n_stride relative to nbor_j in dev_short_nbor
       int idx = nbor_j;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               i, nbor_j, offset_j, idx);
-      acctyp4 zeta_ij = zetaij[idx]; // fetch(zeta_ij,idx,zeta_tex);
+
+      acctyp4 zeta_ij = zetaij[idx];
       numtyp force = zeta_ij.x*tpainv;
       numtyp prefactor = zeta_ij.y;
       f.x += delr1[0]*force;
@@ -641,13 +635,13 @@ __kernel void k_tersoff_three_center(const __global numtyp4 *restrict x_,
         numtyp r2inv = ucl_rsqrt(rsq2);
 
         numtyp fi[3], fj[3], fk[3];
-        numtyp4 ts1_ijkparam = ts1[ijkparam]; //fetch4(ts1_ijkparam,ijkparam,ts1_tex);
+        numtyp4 ts1_ijkparam = ts1[ijkparam];
         lam3 = ts1_ijkparam.z;
         powermint = ts1_ijkparam.w;
-        numtyp4 ts2_ijkparam = ts2[ijkparam]; //fetch4(ts2_ijkparam,ijkparam,ts2_tex);
+        numtyp4 ts2_ijkparam = ts2[ijkparam];
         bigr = ts2_ijkparam.z;
         bigd = ts2_ijkparam.w;
-        numtyp4 ts4_ijkparam = ts4[ijkparam]; //fetch4(ts4_ijkparam,ijkparam,ts4_tex);
+        numtyp4 ts4_ijkparam = ts4[ijkparam];
         c = ts4_ijkparam.x;
         d = ts4_ijkparam.y;
         h = ts4_ijkparam.z;
@@ -817,7 +811,7 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-      acctyp4 zeta_ji = zetaij[idx]; // fetch(zeta_ji,idx,zeta_tex);
+      acctyp4 zeta_ji = zetaij[idx];
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
       f.x += delr1[0]*force;
@@ -861,13 +855,13 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
         numtyp4 ts1_param, ts2_param, ts4_param;
         numtyp fi[3];
 
-        ts1_param = ts1[jikparam]; //fetch4(ts1_jikparam,jikparam,ts1_tex);
+        ts1_param = ts1[jikparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jikparam]; //fetch4(ts2_jikparam,jikparam,ts2_tex);
+        ts2_param = ts2[jikparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jikparam]; //fetch4(ts4_jikparam,jikparam,ts4_tex);
+        ts4_param = ts4[jikparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;
@@ -878,23 +872,20 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
         f.y += fi[1];
         f.z += fi[2];
 
-        //int kk = (nbor_k - offset_k - 2*nbor_pitch) / n_stride;
-        //int idx = kk*n_stride + j*t_per_atom + offset_k;
         //idx to zetaij is shifted by n_stride relative to nbor_k in dev_short_nbor
         int idx = nbor_k;
         if (dev_packed==dev_nbor) idx -= n_stride;
-//        zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//                 j, nbor_k, offset_k, idx);
-        acctyp4 zeta_jk = zetaij[idx]; // fetch(zeta_jk,idx,zeta_tex);
+
+        acctyp4 zeta_jk = zetaij[idx];
         numtyp prefactor_jk = zeta_jk.y;
         int jkiparam=elem2param[jtype*nelements*nelements+ktype*nelements+itype];
-        ts1_param = ts1[jkiparam]; //fetch4(ts1_jkiparam,jkiparam,ts1_tex);
+        ts1_param = ts1[jkiparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jkiparam]; //fetch4(ts2_jkiparam,jkiparam,ts2_tex);
+        ts2_param = ts2[jkiparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jkiparam]; //fetch4(ts4_jkiparam,jkiparam,ts4_tex);
+        ts4_param = ts4[jkiparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;
@@ -1050,7 +1041,7 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-      acctyp4 zeta_ji = zetaij[idx]; //  fetch(zeta_ji,idx,zeta_tex);
+      acctyp4 zeta_ji = zetaij[idx];
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
       f.x += delr1[0]*force;
@@ -1094,13 +1085,13 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
 
         numtyp fi[3], fj[3], fk[3];
         numtyp4 ts1_param, ts2_param, ts4_param;
-        ts1_param = ts1[jikparam]; //fetch4(ts1_jikparam,jikparam,ts1_tex);
+        ts1_param = ts1[jikparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jikparam]; //fetch4(ts2_jikparam,jikparam,ts2_tex);
+        ts2_param = ts2[jikparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jikparam]; //fetch4(ts4_jikparam,jikparam,ts4_tex);
+        ts4_param = ts4[jikparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;
@@ -1118,24 +1109,21 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
         virial[4] += TWOTHIRD*(mdelr1[0]*fj[2] + delr2[0]*fk[2]);
         virial[5] += TWOTHIRD*(mdelr1[1]*fj[2] + delr2[1]*fk[2]);
 
-        //int kk = (nbor_k - offset_k - 2*nbor_pitch) / n_stride;
-        //int idx = kk*n_stride + j*t_per_atom + offset_k;
         //idx to zetaij is shifted by n_stride relative to nbor_k in dev_short_nbor
         int idx = nbor_k;
         if (dev_packed==dev_nbor) idx -= n_stride;
-//        zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//                 j, nbor_k, offset_k, idx);
-        acctyp4 zeta_jk = zetaij[idx]; // fetch(zeta_jk,idx,zeta_tex);
+
+        acctyp4 zeta_jk = zetaij[idx];
         numtyp prefactor_jk = zeta_jk.y;
 
         int jkiparam=elem2param[jtype*nelements*nelements+ktype*nelements+itype];
-        ts1_param = ts1[jkiparam]; //fetch4(ts1_jkiparam,jkiparam,ts1_tex);
+        ts1_param = ts1[jkiparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jkiparam]; //fetch4(ts2_jkiparam,jkiparam,ts2_tex);
+        ts2_param = ts2[jkiparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jkiparam]; //fetch4(ts4_jkiparam,jkiparam,ts4_tex);
+        ts4_param = ts4[jkiparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;

--- a/lib/gpu/lal_tersoff_mod.cu
+++ b/lib/gpu/lal_tersoff_mod.cu
@@ -11,7 +11,7 @@
 //
 //       begin                :
 //       email                : ndactrung@gmail.com
-// ***************************************************************************/
+// **************************************************************************
 
 #ifdef NV_KERNEL
 #include "lal_tersoff_mod_extra.h"
@@ -356,13 +356,9 @@ __kernel void k_tersoff_mod_zeta(const __global numtyp4 *restrict x_,
                   ijkparam_c5, rsq1, rsq2, delr1, delr2);
       }
 
-      //int jj = (nbor_j-offset_j-2*nbor_pitch)/n_stride;
-      //int idx = jj*n_stride + i*t_per_atom + offset_j;
       //idx to zetaij is shifted by n_stride relative to nbor_j in dev_short_nbor
       int idx = nbor_j;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               i, nbor_j, offset_j, idx);
       acc_zeta(z, tid, t_per_atom, offset_k);
 
       numtyp4 ts1_ijparam = ts1[ijparam]; //fetch4(ts1_ijparam,ijparam,ts1_tex);
@@ -574,7 +570,6 @@ __kernel void k_tersoff_mod_three_center(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -768,7 +763,6 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -823,21 +817,11 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
-        ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
-      }
 
-      //int iix = (ijnum - offset_kf - 2*nbor_pitch) / n_stride;
-      //int idx = iix*n_stride + j*t_per_atom + offset_kf;
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               j, ijnum, offset_kf, idx);
+
       acctyp4 zeta_ji = zetaij[idx]; // fetch(zeta_ji,idx,zeta_tex);
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
@@ -1022,7 +1006,6 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -1077,21 +1060,11 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
-        ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
-      }
 
-      //int iix = (ijnum - offset_kf - 2*nbor_pitch) / n_stride;
-      //int idx = iix*n_stride + j*t_per_atom + offset_kf;
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               j, ijnum, offset_kf, idx);
+
       acctyp4 zeta_ji = zetaij[idx]; //  fetch(zeta_ji,idx,zeta_tex);
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;

--- a/lib/gpu/lal_tersoff_mod.cu
+++ b/lib/gpu/lal_tersoff_mod.cu
@@ -726,8 +726,6 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[2*BLOCK_PAIR];
-
   __syncthreads();
 
   if (ii<inum) {
@@ -799,15 +797,13 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
       int nbork_start = nbor_k;
 
       // look up for zeta_ji: find i in the j's neighbor list
-      int m = tid / t_per_atom;
+
       int ijnum = -1;
       for ( ; nbor_k<k_end; nbor_k+=n_stride) {
         int k=nbor_mem[nbor_k];
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[2*m+0] = ijnum;
-          red_acc[2*m+1] = offset_k;
           break;
         }
       }
@@ -966,8 +962,6 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[2*BLOCK_PAIR];
-
   __syncthreads();
 
   if (ii<inum) {
@@ -1039,15 +1033,13 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
       int nbork_start = nbor_k;
 
       // look up for zeta_ji
-      int m = tid / t_per_atom;
+
       int ijnum = -1;
       for ( ; nbor_k<k_end; nbor_k+=n_stride) {
         int k=nbor_mem[nbor_k];
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[2*m+0] = ijnum;
-          red_acc[2*m+1] = offset_k;
           break;
         }
       }

--- a/lib/gpu/lal_tersoff_mod.cu
+++ b/lib/gpu/lal_tersoff_mod.cu
@@ -337,18 +337,18 @@ __kernel void k_tersoff_mod_zeta(const __global numtyp4 *restrict x_,
 
         if (rsq2 > cutsq[ijkparam]) continue;
 
-        numtyp4 ts1_ijkparam = ts1[ijkparam]; //fetch4(ts1_ijkparam,ijkparam,ts1_tex);
+        numtyp4 ts1_ijkparam = ts1[ijkparam];
         numtyp ijkparam_lam3 = ts1_ijkparam.z;
         numtyp ijkparam_powermint = ts1_ijkparam.w;
-        numtyp4 ts2_ijkparam = ts2[ijkparam]; //fetch4(ts2_ijkparam,ijkparam,ts2_tex);
+        numtyp4 ts2_ijkparam = ts2[ijkparam];
         numtyp ijkparam_bigr = ts2_ijkparam.z;
         numtyp ijkparam_bigd = ts2_ijkparam.w;
-        numtyp4 ts4_ijkparam = ts4[ijkparam]; //fetch4(ts4_ijkparam,ijkparam,ts4_tex);
+        numtyp4 ts4_ijkparam = ts4[ijkparam];
         numtyp ijkparam_c1 = ts4_ijkparam.x;
         numtyp ijkparam_c2 = ts4_ijkparam.y;
         numtyp ijkparam_c3 = ts4_ijkparam.z;
         numtyp ijkparam_c4 = ts4_ijkparam.w;
-        numtyp4 ts5_ijkparam = ts5[ijkparam]; //fetch4(ts4_ijkparam,ijkparam,ts4_tex);
+        numtyp4 ts5_ijkparam = ts5[ijkparam];
         numtyp ijkparam_c5 = ts5_ijkparam.x;
         numtyp ijkparam_h = ts5_ijkparam.y;
         z += zeta(ijkparam_powermint, ijkparam_lam3, ijkparam_bigr, ijkparam_bigd,
@@ -361,13 +361,13 @@ __kernel void k_tersoff_mod_zeta(const __global numtyp4 *restrict x_,
       if (dev_packed==dev_nbor) idx -= n_stride;
       acc_zeta(z, tid, t_per_atom, offset_k);
 
-      numtyp4 ts1_ijparam = ts1[ijparam]; //fetch4(ts1_ijparam,ijparam,ts1_tex);
+      numtyp4 ts1_ijparam = ts1[ijparam];
       numtyp ijparam_lam2 = ts1_ijparam.y;
-      numtyp4 ts2_ijparam = ts2[ijparam]; //fetch4(ts2_ijparam,ijparam,ts2_tex);
+      numtyp4 ts2_ijparam = ts2[ijparam];
       numtyp ijparam_bigb = ts2_ijparam.y;
       numtyp ijparam_bigr = ts2_ijparam.z;
       numtyp ijparam_bigd = ts2_ijparam.w;
-      numtyp4 ts3_ijparam = ts3[ijparam]; //fetch4(ts3_ijparam,ijparam,ts3_tex);
+      numtyp4 ts3_ijparam = ts3[ijparam];
       numtyp ijparam_beta = ts3_ijparam.x;
       numtyp ijparam_powern = ts3_ijparam.y;
       numtyp ijparam_powern_del = ts3_ijparam.z;
@@ -583,14 +583,11 @@ __kernel void k_tersoff_mod_three_center(const __global numtyp4 *restrict x_,
 
       // look up for zeta_ij
 
-      //int jj = (nbor_j-offset_j-2*nbor_pitch) / n_stride;
-      //int idx = jj*n_stride + i*t_per_atom + offset_j;
       //idx to zetaij is shifted by n_stride relative to nbor_j in dev_short_nbor
       int idx = nbor_j;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               i, nbor_j, offset_j, idx);
-      acctyp4 zeta_ij = zetaij[idx]; // fetch(zeta_ij,idx,zeta_tex);
+
+      acctyp4 zeta_ij = zetaij[idx];
       numtyp force = zeta_ij.x*tpainv;
       numtyp prefactor = zeta_ij.y;
       f.x += delr1[0]*force;
@@ -639,18 +636,18 @@ __kernel void k_tersoff_mod_three_center(const __global numtyp4 *restrict x_,
         numtyp r2inv = ucl_rsqrt(rsq2);
 
         numtyp fi[3], fj[3], fk[3];
-        numtyp4 ts1_ijkparam = ts1[ijkparam]; //fetch4(ts1_ijkparam,ijkparam,ts1_tex);
+        numtyp4 ts1_ijkparam = ts1[ijkparam];
         lam3 = ts1_ijkparam.z;
         powermint = ts1_ijkparam.w;
-        numtyp4 ts2_ijkparam = ts2[ijkparam]; //fetch4(ts2_ijkparam,ijkparam,ts2_tex);
+        numtyp4 ts2_ijkparam = ts2[ijkparam];
         bigr = ts2_ijkparam.z;
         bigd = ts2_ijkparam.w;
-        numtyp4 ts4_ijkparam = ts4[ijkparam]; //fetch4(ts4_ijkparam,ijkparam,ts4_tex);
+        numtyp4 ts4_ijkparam = ts4[ijkparam];
         c1 = ts4_ijkparam.x;
         c2 = ts4_ijkparam.y;
         c3 = ts4_ijkparam.z;
         c4 = ts4_ijkparam.w;
-        numtyp4 ts5_ijkparam = ts5[ijkparam]; //fetch4(ts5_ijkparam,ijkparam,ts5_tex);
+        numtyp4 ts5_ijkparam = ts5[ijkparam];
         c5 = ts5_ijkparam.x;
         h = ts5_ijkparam.y;
         if (vflag>0)
@@ -822,7 +819,7 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
 
-      acctyp4 zeta_ji = zetaij[idx]; // fetch(zeta_ji,idx,zeta_tex);
+      acctyp4 zeta_ji = zetaij[idx];
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
       f.x += delr1[0]*force;
@@ -866,18 +863,18 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
         numtyp4 ts1_param, ts2_param, ts4_param, ts5_param;
         numtyp fi[3];
 
-        ts1_param = ts1[jikparam]; //fetch4(ts1_jikparam,jikparam,ts1_tex);
+        ts1_param = ts1[jikparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jikparam]; //fetch4(ts2_jikparam,jikparam,ts2_tex);
+        ts2_param = ts2[jikparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jikparam]; //fetch4(ts4_jikparam,jikparam,ts4_tex);
+        ts4_param = ts4[jikparam];
         c1 = ts4_param.x;
         c2 = ts4_param.y;
         c3 = ts4_param.z;
         c4 = ts4_param.w;
-        ts5_param = ts5[jikparam]; //fetch4(ts5_jikparam,jikparam,ts5_tex);
+        ts5_param = ts5[jikparam];
         c5 = ts5_param.x;
         h = ts5_param.y;
         attractive_fj(bigr, bigd, powermint, lam3, h, c1, c2, c3, c4, c5,
@@ -886,28 +883,25 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
         f.y += fi[1];
         f.z += fi[2];
 
-        //int kk = (nbor_k - offset_k - 2*nbor_pitch) / n_stride;
-        //int idx = kk*n_stride + j*t_per_atom + offset_k;
         //idx to zetaij is shifted by n_stride relative to nbor_k in dev_short_nbor
         int idx = nbor_k;
         if (dev_packed==dev_nbor) idx -= n_stride;
-//        zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//                 j, nbor_k, offset_k, idx);
-        acctyp4 zeta_jk = zetaij[idx]; // fetch(zeta_jk,idx,zeta_tex);
+
+        acctyp4 zeta_jk = zetaij[idx];
         numtyp prefactor_jk = zeta_jk.y;
         int jkiparam=elem2param[jtype*nelements*nelements+ktype*nelements+itype];
-        ts1_param = ts1[jkiparam]; //fetch4(ts1_jkiparam,jkiparam,ts1_tex);
+        ts1_param = ts1[jkiparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jkiparam]; //fetch4(ts2_jkiparam,jkiparam,ts2_tex);
+        ts2_param = ts2[jkiparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jkiparam]; //fetch4(ts4_jkiparam,jkiparam,ts4_tex);
+        ts4_param = ts4[jkiparam];
         c1 = ts4_param.x;
         c2 = ts4_param.y;
         c3 = ts4_param.z;
         c4 = ts4_param.w;
-        ts5_param = ts5[jkiparam]; //fetch4(ts5_ikiparam,jkiparam,ts5_tex);
+        ts5_param = ts5[jkiparam];
         c5 = ts5_param.x;
         h = ts5_param.y;
         attractive_fk(bigr, bigd, powermint, lam3, h, c1, c2, c3, c4, c5,
@@ -1065,7 +1059,7 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
 
-      acctyp4 zeta_ji = zetaij[idx]; //  fetch(zeta_ji,idx,zeta_tex);
+      acctyp4 zeta_ji = zetaij[idx];
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
       f.x += delr1[0]*force;
@@ -1109,18 +1103,18 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
 
         numtyp fi[3], fj[3], fk[3];
         numtyp4 ts1_param, ts2_param, ts4_param, ts5_param;
-        ts1_param = ts1[jikparam]; //fetch4(ts1_jikparam,jikparam,ts1_tex);
+        ts1_param = ts1[jikparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jikparam]; //fetch4(ts2_jikparam,jikparam,ts2_tex);
+        ts2_param = ts2[jikparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jikparam]; //fetch4(ts4_jikparam,jikparam,ts4_tex);
+        ts4_param = ts4[jikparam];
         c1 = ts4_param.x;
         c2 = ts4_param.y;
         c3 = ts4_param.z;
         c4 = ts4_param.w;
-        ts5_param = ts5[jikparam]; //fetch4(ts5_jijparam,jikparam,ts5_tex);
+        ts5_param = ts5[jikparam];
         c5 = ts5_param.x;
         h = ts5_param.y;
         attractive(bigr, bigd, powermint, lam3, h, c1, c2, c3, c4, c5,
@@ -1136,29 +1130,26 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
         virial[4] += TWOTHIRD*(mdelr1[0]*fj[2] + delr2[0]*fk[2]);
         virial[5] += TWOTHIRD*(mdelr1[1]*fj[2] + delr2[1]*fk[2]);
 
-        //int kk = (nbor_k - offset_k - 2*nbor_pitch) / n_stride;
-        //int idx = kk*n_stride + j*t_per_atom + offset_k;
         //idx to zetaij is shifted by n_stride relative to nbor_k in dev_short_nbor
         int idx = nbor_k;
         if (dev_packed==dev_nbor) idx -= n_stride;
-//        zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//                 j, nbor_k, offset_k, idx);
-        acctyp4 zeta_jk = zetaij[idx]; // fetch(zeta_jk,idx,zeta_tex);
+
+        acctyp4 zeta_jk = zetaij[idx];
         numtyp prefactor_jk = zeta_jk.y;
 
         int jkiparam=elem2param[jtype*nelements*nelements+ktype*nelements+itype];
-        ts1_param = ts1[jkiparam]; //fetch4(ts1_jkiparam,jkiparam,ts1_tex);
+        ts1_param = ts1[jkiparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jkiparam]; //fetch4(ts2_jkiparam,jkiparam,ts2_tex);
+        ts2_param = ts2[jkiparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jkiparam]; //fetch4(ts4_jkiparam,jkiparam,ts4_tex);
+        ts4_param = ts4[jkiparam];
         c1 = ts4_param.x;
         c2 = ts4_param.y;
         c3 = ts4_param.z;
         c4 = ts4_param.w;
-        ts5_param = ts5[jkiparam]; //fetch4(ts5_ikiparam,jkiparam,ts5_tex);
+        ts5_param = ts5[jkiparam];
         c5 = ts5_param.x;
         h = ts5_param.y;
         attractive(bigr, bigd, powermint, lam3, h, c1, c2, c3, c4, c5,

--- a/lib/gpu/lal_tersoff_zbl.cu
+++ b/lib/gpu/lal_tersoff_zbl.cu
@@ -343,13 +343,13 @@ __kernel void k_tersoff_zbl_zeta(const __global numtyp4 *restrict x_,
 
         if (rsq2 > cutsq[ijkparam]) continue;
 
-        numtyp4 ts1_ijkparam = ts1[ijkparam]; //fetch4(ts1_ijkparam,ijkparam,ts1_tex);
+        numtyp4 ts1_ijkparam = ts1[ijkparam];
         numtyp ijkparam_lam3 = ts1_ijkparam.z;
         numtyp ijkparam_powermint = ts1_ijkparam.w;
-        numtyp4 ts2_ijkparam = ts2[ijkparam]; //fetch4(ts2_ijkparam,ijkparam,ts2_tex);
+        numtyp4 ts2_ijkparam = ts2[ijkparam];
         numtyp ijkparam_bigr = ts2_ijkparam.z;
         numtyp ijkparam_bigd = ts2_ijkparam.w;
-        numtyp4 ts4_ijkparam = ts4[ijkparam]; //fetch4(ts4_ijkparam,ijkparam,ts4_tex);
+        numtyp4 ts4_ijkparam = ts4[ijkparam];
         numtyp ijkparam_c = ts4_ijkparam.x;
         numtyp ijkparam_d = ts4_ijkparam.y;
         numtyp ijkparam_h = ts4_ijkparam.z;
@@ -359,30 +359,27 @@ __kernel void k_tersoff_zbl_zeta(const __global numtyp4 *restrict x_,
                   rsq1, rsq2, delr1, delr2);
       }
 
-      //int jj = (nbor_j-offset_j-2*nbor_pitch)/n_stride;
-      //int idx = jj*n_stride + i*t_per_atom + offset_j;
       //idx to zetaij is shifted by n_stride relative to nbor_j in dev_short_nbor
       int idx = nbor_j;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               i, nbor_j, offset_j, idx);
+
       acc_zeta(z, tid, t_per_atom, offset_k);
 
-      numtyp4 ts1_ijparam = ts1[ijparam]; //fetch4(ts1_ijparam,ijparam,ts1_tex);
+      numtyp4 ts1_ijparam = ts1[ijparam];
       numtyp ijparam_lam2 = ts1_ijparam.y;
-      numtyp4 ts2_ijparam = ts2[ijparam]; //fetch4(ts2_ijparam,ijparam,ts2_tex);
+      numtyp4 ts2_ijparam = ts2[ijparam];
       numtyp ijparam_bigb = ts2_ijparam.y;
       numtyp ijparam_bigr = ts2_ijparam.z;
       numtyp ijparam_bigd = ts2_ijparam.w;
-      numtyp4 ts3_ijparam = ts3[ijparam]; //fetch4(ts3_ijparam,ijparam,ts3_tex);
+      numtyp4 ts3_ijparam = ts3[ijparam];
       numtyp ijparam_c1 = ts3_ijparam.x;
       numtyp ijparam_c2 = ts3_ijparam.y;
       numtyp ijparam_c3 = ts3_ijparam.z;
       numtyp ijparam_c4 = ts3_ijparam.w;
-      numtyp4 ts5_ijparam = ts5[ijparam]; //fetch4(ts5_ijparam,ijparam,ts5_tex);
+      numtyp4 ts5_ijparam = ts5[ijparam];
       numtyp ijparam_beta = ts5_ijparam.x;
       numtyp ijparam_powern = ts5_ijparam.y;
-      numtyp4 ts6_ijparam = ts6[ijparam]; //fetch4(ts6_ijparam,ijparam,ts6_tex);
+      numtyp4 ts6_ijparam = ts6[ijparam];
       numtyp ijparam_ZBLcut = ts6_ijparam.z;
       numtyp ijparam_ZBLexpscale = ts6_ijparam.w;
 
@@ -590,7 +587,6 @@ __kernel void k_tersoff_zbl_three_center(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -604,14 +600,11 @@ __kernel void k_tersoff_zbl_three_center(const __global numtyp4 *restrict x_,
 
       // look up for zeta_ij
 
-      //int jj = (nbor_j-offset_j-2*nbor_pitch) / n_stride;
-      //int idx = jj*n_stride + i*t_per_atom + offset_j;
       //idx to zetaij is shifted by n_stride relative to nbor_j in dev_short_nbor
       int idx = nbor_j;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               i, nbor_j, offset_j, idx);
-      acctyp4 zeta_ij = zetaij[idx]; // fetch(zeta_ij,idx,zeta_tex);
+
+      acctyp4 zeta_ij = zetaij[idx];
       numtyp force = zeta_ij.x*tpainv;
       numtyp prefactor = zeta_ij.y;
       f.x += delr1[0]*force;
@@ -660,13 +653,13 @@ __kernel void k_tersoff_zbl_three_center(const __global numtyp4 *restrict x_,
         numtyp r2inv = ucl_rsqrt(rsq2);
 
         numtyp fi[3], fj[3], fk[3];
-        numtyp4 ts1_ijkparam = ts1[ijkparam]; //fetch4(ts1_ijkparam,ijkparam,ts1_tex);
+        numtyp4 ts1_ijkparam = ts1[ijkparam];
         lam3 = ts1_ijkparam.z;
         powermint = ts1_ijkparam.w;
-        numtyp4 ts2_ijkparam = ts2[ijkparam]; //fetch4(ts2_ijkparam,ijkparam,ts2_tex);
+        numtyp4 ts2_ijkparam = ts2[ijkparam];
         bigr = ts2_ijkparam.z;
         bigd = ts2_ijkparam.w;
-        numtyp4 ts4_ijkparam = ts4[ijkparam]; //fetch4(ts4_ijkparam,ijkparam,ts4_tex);
+        numtyp4 ts4_ijkparam = ts4[ijkparam];
         c = ts4_ijkparam.x;
         d = ts4_ijkparam.y;
         h = ts4_ijkparam.z;
@@ -837,7 +830,7 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
 
-      acctyp4 zeta_ji = zetaij[idx]; // fetch(zeta_ji,idx,zeta_tex);
+      acctyp4 zeta_ji = zetaij[idx];
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
       f.x += delr1[0]*force;
@@ -881,13 +874,13 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
         numtyp4 ts1_param, ts2_param, ts4_param;
         numtyp fi[3];
 
-        ts1_param = ts1[jikparam]; //fetch4(ts1_jikparam,jikparam,ts1_tex);
+        ts1_param = ts1[jikparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jikparam]; //fetch4(ts2_jikparam,jikparam,ts2_tex);
+        ts2_param = ts2[jikparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jikparam]; //fetch4(ts4_jikparam,jikparam,ts4_tex);
+        ts4_param = ts4[jikparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;
@@ -898,23 +891,20 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
         f.y += fi[1];
         f.z += fi[2];
 
-        //int kk = (nbor_k - offset_k - 2*nbor_pitch) / n_stride;
-        //int idx = kk*n_stride + j*t_per_atom + offset_k;
         //idx to zetaij is shifted by n_stride relative to nbor_k in dev_short_nbor
         int idx = nbor_k;
         if (dev_packed==dev_nbor) idx -= n_stride;
-//        zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//                 j, nbor_k, offset_k, idx);
-        acctyp4 zeta_jk = zetaij[idx]; // fetch(zeta_jk,idx,zeta_tex);
+
+        acctyp4 zeta_jk = zetaij[idx];
         numtyp prefactor_jk = zeta_jk.y;
         int jkiparam=elem2param[jtype*nelements*nelements+ktype*nelements+itype];
-        ts1_param = ts1[jkiparam]; //fetch4(ts1_jkiparam,jkiparam,ts1_tex);
+        ts1_param = ts1[jkiparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jkiparam]; //fetch4(ts2_jkiparam,jkiparam,ts2_tex);
+        ts2_param = ts2[jkiparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jkiparam]; //fetch4(ts4_jkiparam,jkiparam,ts4_tex);
+        ts4_param = ts4[jkiparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;
@@ -1071,7 +1061,7 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
 
-      acctyp4 zeta_ji = zetaij[idx]; //  fetch(zeta_ji,idx,zeta_tex);
+      acctyp4 zeta_ji = zetaij[idx];
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
       f.x += delr1[0]*force;
@@ -1115,13 +1105,13 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
 
         numtyp fi[3], fj[3], fk[3];
         numtyp4 ts1_param, ts2_param, ts4_param;
-        ts1_param = ts1[jikparam]; //fetch4(ts1_jikparam,jikparam,ts1_tex);
+        ts1_param = ts1[jikparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jikparam]; //fetch4(ts2_jikparam,jikparam,ts2_tex);
+        ts2_param = ts2[jikparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jikparam]; //fetch4(ts4_jikparam,jikparam,ts4_tex);
+        ts4_param = ts4[jikparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;
@@ -1139,24 +1129,21 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
         virial[4] += TWOTHIRD*(mdelr1[0]*fj[2] + delr2[0]*fk[2]);
         virial[5] += TWOTHIRD*(mdelr1[1]*fj[2] + delr2[1]*fk[2]);
 
-        //int kk = (nbor_k - offset_k - 2*nbor_pitch) / n_stride;
-        //int idx = kk*n_stride + j*t_per_atom + offset_k;
         //idx to zetaij is shifted by n_stride relative to nbor_k in dev_short_nbor
         int idx = nbor_k;
         if (dev_packed==dev_nbor) idx -= n_stride;
-//        zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//                 j, nbor_k, offset_k, idx);
-        acctyp4 zeta_jk = zetaij[idx]; // fetch(zeta_jk,idx,zeta_tex);
+
+        acctyp4 zeta_jk = zetaij[idx];
         numtyp prefactor_jk = zeta_jk.y;
 
         int jkiparam=elem2param[jtype*nelements*nelements+ktype*nelements+itype];
-        ts1_param = ts1[jkiparam]; //fetch4(ts1_jkiparam,jkiparam,ts1_tex);
+        ts1_param = ts1[jkiparam];
         lam3 = ts1_param.z;
         powermint = ts1_param.w;
-        ts2_param = ts2[jkiparam]; //fetch4(ts2_jkiparam,jkiparam,ts2_tex);
+        ts2_param = ts2[jkiparam];
         bigr = ts2_param.z;
         bigd = ts2_param.w;
-        ts4_param = ts4[jkiparam]; //fetch4(ts4_jkiparam,jkiparam,ts4_tex);
+        ts4_param = ts4[jkiparam];
         c = ts4_param.x;
         d = ts4_param.y;
         h = ts4_param.z;

--- a/lib/gpu/lal_tersoff_zbl.cu
+++ b/lib/gpu/lal_tersoff_zbl.cu
@@ -11,7 +11,7 @@
 //
 //       begin                :
 //       email                : ndactrung@gmail.com
-// ***************************************************************************/
+// **************************************************************************
 
 #ifdef NV_KERNEL
 #include "lal_tersoff_zbl_extra.h"
@@ -778,7 +778,6 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -833,21 +832,11 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
-        ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
-      }
 
-      //int iix = (ijnum - offset_kf - 2*nbor_pitch) / n_stride;
-      //int idx = iix*n_stride + j*t_per_atom + offset_kf;
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               j, ijnum, offset_kf, idx);
+
       acctyp4 zeta_ji = zetaij[idx]; // fetch(zeta_ji,idx,zeta_tex);
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;
@@ -1023,7 +1012,6 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -1078,21 +1066,11 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
-        ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
-      }
 
-      //int iix = (ijnum - offset_kf - 2*nbor_pitch) / n_stride;
-      //int idx = iix*n_stride + j*t_per_atom + offset_kf;
       //idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
       if (dev_packed==dev_nbor) idx -= n_stride;
-//      zeta_idx(dev_nbor,dev_packed, nbor_pitch, n_stride, t_per_atom,
-//               j, ijnum, offset_kf, idx);
+
       acctyp4 zeta_ji = zetaij[idx]; //  fetch(zeta_ji,idx,zeta_tex);
       numtyp force = zeta_ji.x*tpainv;
       numtyp prefactor_ji = zeta_ji.y;

--- a/lib/gpu/lal_tersoff_zbl.cu
+++ b/lib/gpu/lal_tersoff_zbl.cu
@@ -737,8 +737,6 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[2*BLOCK_PAIR];
-
   __syncthreads();
 
   if (ii<inum) {
@@ -810,15 +808,13 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
       int nbork_start = nbor_k;
 
       // look up for zeta_ji: find i in the j's neighbor list
-      int m = tid / t_per_atom;
+
       int ijnum = -1;
       for ( ; nbor_k<k_end; nbor_k+=n_stride) {
         int k=nbor_mem[nbor_k];
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[2*m+0] = ijnum;
-          red_acc[2*m+1] = offset_k;
           break;
         }
       }
@@ -968,8 +964,6 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[2*BLOCK_PAIR];
-
   __syncthreads();
 
   if (ii<inum) {
@@ -1041,15 +1035,13 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
       int nbork_start = nbor_k;
 
       // look up for zeta_ji
-      int m = tid / t_per_atom;
+
       int ijnum = -1;
       for ( ; nbor_k<k_end; nbor_k+=n_stride) {
         int k=nbor_mem[nbor_k];
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[2*m+0] = ijnum;
-          red_acc[2*m+1] = offset_k;
           break;
         }
       }


### PR DESCRIPTION
## Purpose

This removes code in the GPU package library of GPU kernels, that nvcc indicates is not used, and also removes some commented out code.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

No issues expected.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines

