### PR TITLE
Fix lib/plumed/Install.py

### DIFF
--- a/doc/src/Build_extras.txt
+++ b/doc/src/Build_extras.txt
@@ -796,6 +796,10 @@ make lib-plumed args="-b"               # download and build PLUMED in lib/plume
 make lib-plumed args="-p $HOME/.local"  # use existing PLUMED installation in $HOME/.local
 make lib-plumed args="-p /usr/local -m shared"  # use existing PLUMED installation in
                                                 # /usr/local and use shared linkage mode
+make lib-plumed args="-p $HOME/plumed2 --noinstall -m shared"  # use existing PLUMED
+                                                               # compiled source code in
+                                                               # $HOME/plumed2 and use
+                                                               # shared linkage mode
 :pre
 
 Note that 2 symbolic (soft) links, "includelink" and "liblink" are

--- a/doc/src/Build_extras.txt
+++ b/doc/src/Build_extras.txt
@@ -796,10 +796,6 @@ make lib-plumed args="-b"               # download and build PLUMED in lib/plume
 make lib-plumed args="-p $HOME/.local"  # use existing PLUMED installation in $HOME/.local
 make lib-plumed args="-p /usr/local -m shared"  # use existing PLUMED installation in
                                                 # /usr/local and use shared linkage mode
-make lib-plumed args="-p $HOME/plumed2 --noinstall -m shared"  # use existing PLUMED
-                                                               # compiled source code in
-                                                               # $HOME/plumed2 and use
-                                                               # shared linkage mode
 :pre
 
 Note that 2 symbolic (soft) links, "includelink" and "liblink" are

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -139,6 +139,7 @@ while iarg < nargs:
   else: error()
 
 homepath = fullpath(homepath)
+homedir = "%s/plumed2" % (homepath)
 
 if (pathflag):
     if not os.path.isdir(plumedpath): error("Plumed2 path does not exist")
@@ -170,8 +171,8 @@ if buildflag:
   if os.path.exists("%s/plumed-%s" % (homepath,version)):
     cmd = 'rm -rf "%s/plumed-%s"' % (homepath,version)
     subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-  if os.path.exists("%s/plumed2" % (homepath)):
-    cmd = 'rm -rf "%s/plumed2"' % (homepath)
+  if os.path.exists(homedir):
+    cmd = 'rm -rf "%s"' % (homedir)
     subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
   cmd = 'cd "%s"; tar -xzvf %s' % (homepath,filename)
   subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
@@ -181,7 +182,7 @@ if buildflag:
  
 if buildflag:
    print("Building plumed ...")
-   cmd = 'cd %s/plumed-%s; ./configure --prefix=%s/plumed2 --enable-static-patch ; make ; make install' % (homepath,version,homepath)
+   cmd = 'cd %s/plumed-%s; ./configure --prefix=%s --enable-static-patch ; make ; make install' % (homepath,version,homedir)
    txt = subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
    print(txt.decode('UTF-8'))
 # 

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -200,6 +200,6 @@ if linkflag:
   subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
   if os.path.isfile("Makefile.lammps.%s" % mode):
     print("Creating Makefile.lammps")
-    cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
+    cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/plumed/src/lib/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
     subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
 

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -12,12 +12,10 @@ help = """
 Syntax from src dir: make lib-plumed args="-b"
                  or: make lib-plumed args="-b -v 2.4.3"
                  or: make lib-plumed args="-p /usr/local/plumed2 -m shared"
-                 or: make lib-plumed args="-p /home/myname/myplumed2sourcecode --noinstall"
 
 Syntax from lib dir: python Install.py -b -v 2.4.3
                  or: python Install.py -b
                  or: python Install.py -p /usr/local/plumed2 -m shared
-                 or: python Install.py -p /home/myname/myplumed2sourcecode --noinstall
 
 specify one or more options, order does not matter
 
@@ -25,13 +23,11 @@ specify one or more options, order does not matter
   -v = set version of plumed2 to download and build (default: 2.4.3)
   -p = specify folder of existing plumed2 installation
   -m = set plumed linkage mode: static (default), shared, or runtime
-  --noinstall = use existing plumed2 source code folder where make was issued but make install was not
 
 Example:
 
 make lib-plumed args="-b"   # download/build in lib/plumed/plumed2
-make lib-plumed args="-p /usr/local/plumed2 -m shared" # use existing Plumed2 installation in /usr/local/plumed2
-make lib-plumed args="-p $HOME/plumed2 -m shared --noinstall" # use existing Plumed2 source code folder in $HOME/plumed2
+make lib-plumed args="-p $HOME/plumed2 -m shared" # use existing Plumed2 installation in $HOME/plumed2
 """
 
 # settings
@@ -121,7 +117,6 @@ buildflag = False
 pathflag = False
 suffixflag = False
 linkflag = True
-noinstallflag = False
 
 iarg = 0
 while iarg < nargs:
@@ -140,9 +135,6 @@ while iarg < nargs:
     iarg += 2
   elif args[iarg] == "-b":
     buildflag = True
-    iarg += 1
-  elif args[iarg] == "--noinstall":
-    noinstallflag = True
     iarg += 1
   else: error()
 
@@ -205,21 +197,12 @@ if linkflag:
     os.remove("includelink")
   if os.path.isfile("liblink") or os.path.islink("liblink"):
     os.remove("liblink")
-  if noinstallflag:
-    cmd = 'ln -s "%s/src/include" includelink' % homedir
-    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-    cmd = 'ln -s "%s/src/lib" liblink' % homedir
-    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-  else:
-    cmd = 'ln -s "%s/include" includelink' % homedir
-    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-    cmd = 'ln -s "%s/lib" liblink' % homedir
-    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+  cmd = 'ln -s "%s/include" includelink' % homedir
+  subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+  cmd = 'ln -s "%s/lib" liblink' % homedir
+  subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
   if os.path.isfile("Makefile.lammps.%s" % mode):
     print("Creating Makefile.lammps")
-    if noinstallflag:
-      cmd = 'echo PLUMED_LIBDIR="%s/src/lib" > Makefile.lammps; cat liblink/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
-    else:
-      cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/plumed/src/lib/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
+    cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/plumed/src/lib/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
     subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
 

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -12,10 +12,12 @@ help = """
 Syntax from src dir: make lib-plumed args="-b"
                  or: make lib-plumed args="-b -v 2.4.3"
                  or: make lib-plumed args="-p /usr/local/plumed2 -m shared"
+                 or: make lib-plumed args="-p /home/myname/myplumed2sourcecode --noinstall"
 
 Syntax from lib dir: python Install.py -b -v 2.4.3
                  or: python Install.py -b
                  or: python Install.py -p /usr/local/plumed2 -m shared
+                 or: python Install.py -p /home/myname/myplumed2sourcecode --noinstall
 
 specify one or more options, order does not matter
 
@@ -23,11 +25,13 @@ specify one or more options, order does not matter
   -v = set version of plumed2 to download and build (default: 2.4.3)
   -p = specify folder of existing plumed2 installation
   -m = set plumed linkage mode: static (default), shared, or runtime
+  --noinstall = use existing plumed2 source code folder where make was issued but make install was not
 
 Example:
 
 make lib-plumed args="-b"   # download/build in lib/plumed/plumed2
-make lib-plumed args="-p $HOME/plumed2 -m shared" # use existing Plumed2 installation in $HOME/plumed2
+make lib-plumed args="-p /usr/local/plumed2 -m shared" # use existing Plumed2 installation in /usr/local/plumed2
+make lib-plumed args="-p $HOME/plumed2 -m shared --noinstall" # use existing Plumed2 source code folder in $HOME/plumed2
 """
 
 # settings
@@ -117,6 +121,7 @@ buildflag = False
 pathflag = False
 suffixflag = False
 linkflag = True
+noinstallflag = False
 
 iarg = 0
 while iarg < nargs:
@@ -135,6 +140,9 @@ while iarg < nargs:
     iarg += 2
   elif args[iarg] == "-b":
     buildflag = True
+    iarg += 1
+  elif args[iarg] == "--noinstall":
+    noinstallflag = True
     iarg += 1
   else: error()
 
@@ -194,12 +202,21 @@ if linkflag:
     os.remove("includelink")
   if os.path.isfile("liblink") or os.path.islink("liblink"):
     os.remove("liblink")
-  cmd = 'ln -s "%s/include" includelink' % homedir
-  subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-  cmd = 'ln -s "%s/lib" liblink' % homedir
-  subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+  if noinstallflag:
+    cmd = 'ln -s "%s/src/include" includelink' % homedir
+    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+    cmd = 'ln -s "%s/src/lib" liblink' % homedir
+    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+  else:
+    cmd = 'ln -s "%s/include" includelink' % homedir
+    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+    cmd = 'ln -s "%s/lib" liblink' % homedir
+    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
   if os.path.isfile("Makefile.lammps.%s" % mode):
     print("Creating Makefile.lammps")
-    cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/plumed/src/lib/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
+    if noinstallflag:
+      cmd = 'echo PLUMED_LIBDIR="%s/src/lib" > Makefile.lammps; cat liblink/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
+    else:
+      cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/plumed/src/lib/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
     subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
 

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -186,14 +186,17 @@ if buildflag:
   subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
   os.remove("%s/%s" % (homepath,filename))
 
-# build plumed
+  # build plumed
+  print("Building plumed ...")
+  try:
+    import multiprocessing
+    n_cpus = multiprocessing.cpu_count()
+  except:
+    n_cpus = 1
+  cmd = 'cd %s/plumed-%s; ./configure --prefix=%s --enable-static-patch ; make -j%d ; make install' % (homepath,version,homedir,n_cpus)
+  txt = subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+  print(txt.decode('UTF-8'))
  
-if buildflag:
-   print("Building plumed ...")
-   cmd = 'cd %s/plumed-%s; ./configure --prefix=%s --enable-static-patch ; make -j8 ; make install' % (homepath,version,homedir)
-   txt = subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-   print(txt.decode('UTF-8'))
-# 
 # create 2 links in lib/plumed to plumed2 installation dir
 
 if linkflag:

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -200,6 +200,6 @@ if linkflag:
   subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
   if os.path.isfile("Makefile.lammps.%s" % mode):
     print("Creating Makefile.lammps")
-    cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/plumed/src/lib/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
+    cmd = 'echo PLUMED_LIBDIR="%s/lib" > Makefile.lammps; cat liblink/Plumed.inc.%s Makefile.lammps.%s >> Makefile.lammps' % (homedir,mode,mode)
     subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
 

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -182,7 +182,7 @@ if buildflag:
  
 if buildflag:
    print("Building plumed ...")
-   cmd = 'cd %s/plumed-%s; ./configure --prefix=%s --enable-static-patch ; make ; make install' % (homepath,version,homedir)
+   cmd = 'cd %s/plumed-%s; ./configure --prefix=%s --enable-static-patch ; make -j8 ; make install' % (homepath,version,homedir)
    txt = subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
    print(txt.decode('UTF-8'))
 # 


### PR DESCRIPTION
## Purpose

I noticed that I could not properly install plumed, and I think I found a couple of small bugs in lib/plumed/Install.py
Hope this can be helpful.

## Author(s)

Michele Invernizzi

## Backward Compatibility

no issue

## Implementation Notes

`make lib-plumed args="-b"` was giving an error, due to the fact that the variable `homedir` was not initialized.

Also the `-p` option had issues, because it couldn't find a file due to a wrong path. I am not an expert on this, but the solution I propose worked for me. 

Finally I added an option `-j8` to the make of plumed, because for me this way was much faster. Of course this is not so important, and if can causes problem should be reverted.

I tested static and shared patch using @gtribello reg tests ( https://github.com/gtribello/test-lammps-and-plumed ) and everything worked as expected.


## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links



