### PR TITLE
bug-fix for miscounting atoms for read_dump add keep

### DIFF
--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -480,11 +480,16 @@ void ReadDump::atoms()
     nread += nchunk;
   }
 
+  // if addflag = YESADD or KEEPADD, update total atom count
+
+  if (addflag == YESADD || addflag == KEEPADD) {
+    bigint nblocal = atom->nlocal;
+    MPI_Allreduce(&nblocal,&atom->natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  }
+
   // if addflag = YESADD, assign IDs to new snapshot atoms
 
   if (addflag == YESADD) {
-    bigint nblocal = atom->nlocal;
-    MPI_Allreduce(&nblocal,&atom->natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
     if (atom->natoms < 0 || atom->natoms >= MAXBIGINT)
       error->all(FLERR,"Too many total atoms");
     if (atom->tag_enable) atom->tag_extend();


### PR DESCRIPTION
## Purpose

Fix a bug with read_dump add keep, not updating the total atom count correctly.
Closes #1218 as reported by Alex Stukowski

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

Test script provided by Alex now works.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines


