### PR TITLE
cmake: added ccache support

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -133,6 +133,16 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   endif()
 endif()
 
+option(ENABLE_CCACHE "Try to use ccache to speed-up compilation" OFF)
+if(ENABLE_CCACHE)
+  find_program(CCACHE_EXECUTABLE ccache)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(CCACHE REQUIRED_VARS CCACHE_EXECUTABLE)
+  if(CCACHE_FOUND)
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
+  endif()
+endif()
+
 ########################################################################
 # User input options                                                   #
 ########################################################################


### PR DESCRIPTION
## Purpose

Make the use of `ccache` easy.

## Author(s)

@junghans

## Backward Compatibility

Yes

## Implementation Notes

Nothing special

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

https://ccache.samba.org/performance.html

To test this:
```
cmake -DENABLE_CCACHE=ON ../cmake
ccache -z
time make
ccache -s
make clean
time make
ccache -s
```
