### PR TITLE
Detect fix tune/kspace incompatible configurations

### DIFF
--- a/doc/src/fix_tune_kspace.txt
+++ b/doc/src/fix_tune_kspace.txt
@@ -86,6 +86,9 @@ package"_Build_package.html doc page for more info.
 Do not set "neigh_modify once yes" or else this fix will never be
 called.  Reneighboring is required.
 
+This fix is not compatible with a hybrid pair style, long-range dispersion,
+TIP4P water support, or long-range point dipole support.
+
 [Related commands:]
 
 "kspace_style"_kspace_style.html, "boundary"_boundary.html

--- a/src/KSPACE/fix_tune_kspace.cpp
+++ b/src/KSPACE/fix_tune_kspace.cpp
@@ -89,6 +89,14 @@ void FixTuneKspace::init()
     error->all(FLERR,"Cannot use fix tune/kspace without a kspace style");
   if (!force->pair)
     error->all(FLERR,"Cannot use fix tune/kspace without a pair style");
+  if (strncmp(force->pair_style,"hybrid",6) == 0)
+    error->all(FLERR,"Cannot use fix tune/kspace with a hybrid pair style");
+  if (force->kspace->dispersionflag)
+    error->all(FLERR,"Cannot use fix tune/kspace with long-range dispersion");
+  if (force->kspace->tip4pflag)
+    error->all(FLERR,"Cannot use fix tune/kspace with TIP4P water");
+  if (force->kspace->dipoleflag)
+    error->all(FLERR,"Cannot use fix tune/kspace with dipole long-range solver");
 
   double old_acc = force->kspace->accuracy/force->kspace->two_charge_force;
   char old_acc_str[12];


### PR DESCRIPTION
## Purpose

This detects several more setups that are incompatible with using fix tune/kspace and documents them.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

N/A

