### PR TITLE
Update Install.py

### DIFF
--- a/lib/scafacos/Install.py
+++ b/lib/scafacos/Install.py
@@ -5,10 +5,11 @@
 
 from __future__ import print_function
 import sys,os,re,subprocess
+from argparse import ArgumentParser
 
 # help message
 
-help = """
+help_text = """
 Syntax from src dir: make lib-scafacos args="-b"
                  or: make lib-scafacos args="-p /usr/local/scafacos"
 Syntax from lib dir: python Install.py -b
@@ -18,6 +19,7 @@ specify zero or more options, order does not matter
 
   -b = download and build the Scafacos library
   -p = specify folder of existing Scafacos installation
+  -v = set version of Scafacos to download and build (default scafacos-1.0.1)
 
    always creates includelink, liblink to Scafacos dirs
 
@@ -32,13 +34,6 @@ make lib-scafacos args="-p $HOME/scafacos" # use existing Scafacos installation 
 version = "scafacos-1.0.1"
 url = "https://github.com/scafacos/scafacos/releases/download/v1.0.1/scafacos-1.0.1.tar.gz"
 #url = "https://gigamove.rz.rwth-aachen.de/d/id/CTzyApN76MXMJ6/dd/100" % version
-
-# print error message or help
-
-def error(str=None):
-  if not str: print(help)
-  else: print("ERROR",str)
-  sys.exit()
 
 # expand to full path name
 # process leading '~' or relative path
@@ -84,68 +79,51 @@ def geturl(url,fname):
       print("Calling wget failed with: %s" % e.output.decode('UTF-8'))
 
   if not success:
-    error("Failed to download source code with 'curl' or 'wget'")
+    sys.exit("ERROR Failed to download source code with 'curl' or 'wget'")
   return
 
 # parse args
+parser = ArgumentParser(description = help_text)
 
-args = sys.argv[1:]
-nargs = len(args)
+parser.add_argument("--build", help="download and build the Scafacos library.", default=True)
+parser.add_argument("--path", help="specify folder of existing Scafacos installation.")
+parser.add_argument("--version", help="set version of Voro++ to download and build (default scafacos-1.0.1).", default=version)
 
 homepath = "."
 
-buildflag = True 
-pathflag = False
-linkflag = True
-
-iarg = 0
-while iarg < nargs:
-  if args[iarg] == "-v":
-    if iarg+2 > nargs: error()
-    version = args[iarg+1]
-    iarg += 2
-  elif args[iarg] == "-p":
-    if iarg+2 > nargs: error()
-    scafacospath = fullpath(args[iarg+1])
-    pathflag = True
-    iarg += 2
-  elif args[iarg] == "-b":
-    buildflag = True
-    iarg += 1
-  else: error()
+args = parser.parse_args()
 
 homepath = fullpath(homepath)
-homedir = "%s/%s" % (homepath,version)
+homedir = "%s/%s" % (homepath,args.version)
 
-if (pathflag):
-    if not os.path.isdir(scafacospath): error("Scafacos path does not exist")
-    homedir =scafacospath
+if args.path is not None:
+    if not os.path.isdir(args.path): sys.exit("ERROR Scafacos path does not exist")
+    homedir = args.path
 
-if (buildflag and pathflag):
-    error("Cannot use -b and -p flag at the same time")
+if args.build is None and args.path is None:
+    sys.exit("ERROR Cannot use -b and -p flag at the same time")
 
 # download and unpack Scafacos tarball
 
-if buildflag:
+if args.build:
   print("Downloading Scafacos ...")
-  geturl(url,"%s/%s.tar.gz" % (homepath,version))
+  geturl(url,"%s/%s.tar.gz" % (homepath,args.version))
 
   print("Unpacking Scafacos tarball ...")
-  if os.path.exists("%s/%s" % (homepath,version)):
-    cmd = 'rm -rf "%s/%s"' % (homepath,version)
+  if os.path.exists("%s/%s" % (homepath,args.version)):
+    cmd = 'rm -rf "%s/%s"' % (homepath,args.version)
     subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-  cmd = 'cd "%s"; tar -xzvf %s.tar.gz' % (homepath,version)
+  cmd = 'cd "%s"; tar -xzvf %s.tar.gz' % (homepath,args.version)
   subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-  os.remove("%s/%s.tar.gz" % (homepath,version))
-  if os.path.basename(homedir) != version:
+  os.remove("%s/%s.tar.gz" % (homepath,args.version))
+  if os.path.basename(homedir) != args.version:
     if os.path.exists(homedir):
       cmd = 'rm -rf "%s"' % homedir
       subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-    os.rename("%s/%s" % (homepath,version),homedir)
+    os.rename("%s/%s" % (homepath,args.version),homedir)
 
 # build Scafacos
 
-if buildflag:
   print("Building Scafacos ...")
   cmd = 'cd "%s"; ./configure --prefix="`pwd`/build" --disable-doc --enable-fcs-solvers=fmm,p2nfft,direct,ewald,p3m --with-internal-fftw --with-internal-pfft --with-internal-pnfft CC=mpicc FC=mpif90 CXX=mpicxx F77= > log.txt; make -j; make install' % homedir
   txt = subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
@@ -153,13 +131,12 @@ if buildflag:
 
 # create 2 links in lib/scafacos to Scafacos include/lib dirs
 
-if linkflag:
-  print("Creating links to Scafacos include and lib files")
-  if os.path.isfile("includelink") or os.path.islink("includelink"):
-    os.remove("includelink")
-  if os.path.isfile("liblink") or os.path.islink("liblink"):
-    os.remove("liblink")
-  cmd = 'ln -s "%s/build/include" includelink' % homedir
-  subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
-  cmd = 'ln -s "%s/build/lib" liblink' % homedir
-  subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+print("Creating links to Scafacos include and lib files")
+if os.path.isfile("includelink") or os.path.islink("includelink"):
+  os.remove("includelink")
+if os.path.isfile("liblink") or os.path.islink("liblink"):
+  os.remove("liblink")
+cmd = 'ln -s "%s/build/include" includelink' % homedir
+subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+cmd = 'ln -s "%s/build/lib" liblink' % homedir
+subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)


### PR DESCRIPTION
- Using argparse module for parsing input arguments instead of custom parser
- The linkflag is always equal to True so the if statement can be removed
- Replacing calls to error() custom function to sys.exit()
- Document the -v option in the help text
Note that the buildflag is set by default to true. In other packages (such as Voronoi) buildflag is False by default.

## Purpose

A first attempt to replace the custom parser with the argparse module of standard python 2 and 3 for the Install.py of scafacos library

## Author(s)

Evangelos Voyiatzis

## Backward Compatibility

Changes in the pull request do not break backward compatibility


## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


