### PR TITLE
initial version of encapsulated resource_ptr

### DIFF
--- a/src/USER-BOCS/compute_pressure_bocs.h
+++ b/src/USER-BOCS/compute_pressure_bocs.h
@@ -25,6 +25,7 @@ ComputeStyle(PRESSURE/BOCS,ComputePressureBocs)
 #define LMP_COMPUTE_PRESSURE_BOCS_H
 
 #include "compute.h"
+#include "resource_ptr.h"
 
 namespace LAMMPS_NS {
 // ComputePressure -> ComputePressureBocs MRD NJD
@@ -48,10 +49,10 @@ class ComputePressureBocs : public Compute {
  protected:
   double boltz,nktv2p,inv_volume;
   int nvirial,dimension;
-  double **vptr;
+  memory_ptr<double *[]> vptr;
   double *kspace_virial;
   Compute *temperature;
-  char *id_temp;
+  memory_ptr<char[]> id_temp;
   double virial[6];
   int keflag,pairflag,bondflag,angleflag,dihedralflag,improperflag;
   int fixflag,kspaceflag;
@@ -62,7 +63,7 @@ class ComputePressureBocs : public Compute {
   double vavg;
   int N_mol;
   int N_basis;
-  double *phi_coeff;
+  C_memory_ptr<double[]> phi_coeff;
   double ** splines;
   int spline_length;
 

--- a/src/USER-BOCS/fix_bocs.h
+++ b/src/USER-BOCS/fix_bocs.h
@@ -25,6 +25,7 @@ FixStyle(bocs,FixBocs)
 #define LMP_FIX_BOCS_H
 
 #include "fix.h"
+#include "resource_ptr.h"
 
 
 namespace LAMMPS_NS {
@@ -79,9 +80,9 @@ class FixBocs : public Fix {
   int kspace_flag;                 // 1 if KSpace invoked, 0 if not
   int nrigid;                      // number of rigid fixes
   int dilate_group_bit;            // mask for dilation group
-  int *rfix;                       // indices of rigid fixes
+  memory_ptr<int[]> rfix;          // indices of rigid fixes
   char *id_dilate;                 // group name to dilate
-  class Irregular *irregular;      // for migrating atoms after box flips
+  memory_ptr<class Irregular> irregular;      // for migrating atoms after box flips
 
 // MRD NJD
   int p_basis_type;
@@ -89,8 +90,8 @@ class FixBocs : public Fix {
   double vavg;
   int N_mol;
   int N_p_match;
-  double *p_match_coeffs;
-  double ** splines;
+  C_memory_ptr<double[]> p_match_coeffs;
+  C_memory_ptr_noncontiguous_2d<double *[]> splines;
   int spline_length;
 
 
@@ -102,16 +103,16 @@ class FixBocs : public Fix {
   int tcomputeflag,pcomputeflag;   // 1 = compute was created by fix
                                    // 0 = created externally
 
-  double *eta,*eta_dot;            // chain thermostat for particles
-  double *eta_dotdot;
-  double *eta_mass;
+  memory_ptr<double[]> eta,eta_dot;            // chain thermostat for particles
+  memory_ptr<double[]> eta_dotdot;
+  memory_ptr<double[]> eta_mass;
   int mtchain;                     // length of chain
   int mtchain_default_flag;        // 1 = mtchain is default
 
-  double *etap;                    // chain thermostat for barostat
-  double *etap_dot;
-  double *etap_dotdot;
-  double *etap_mass;
+  memory_ptr<double[]> etap;                    // chain thermostat for barostat
+  memory_ptr<double[]> etap_dot;
+  memory_ptr<double[]> etap_dotdot;
+  memory_ptr<double[]> etap_mass;
   int mpchain;                     // length of chain
 
   int mtk_flag;                    // 0 if using Hoover barostat

--- a/src/resource_ptr.h
+++ b/src/resource_ptr.h
@@ -1,0 +1,306 @@
+#ifndef RESOURCE_PTR_H
+#define RESOURCE_PTR_H
+
+#include <stddef.h>
+#include <stdlib.h>
+#include "memory.h"
+
+namespace LAMMPS_NS {
+namespace detail {
+template <typename T>
+struct default_delete {
+  void operator() (T* ptr) const {
+    delete ptr;
+  }
+};
+
+template <typename T>
+struct default_delete<T[]> {
+  void operator() (T* ptr) const {
+    delete[] ptr;
+  }
+};
+
+template <typename T, size_t dim>
+struct multidimensional_delete {};
+
+template <typename T, size_t dim>
+struct multidimensional_delete<T[], dim> {
+  void operator() (T* ptr) const {
+    if (ptr) multidimensional_delete<T[], dim-1>().operator()(ptr[0]);
+    delete[] ptr;
+  }
+};
+
+template <typename T>
+struct multidimensional_delete<T[], 1> {
+  void operator() (T* ptr) const {
+    delete[] ptr;
+  }
+};
+
+template <typename T>
+struct multidimensional_delete<T[], 0> {};
+
+template <typename T, size_t dim>
+struct C_multidimensional_delete {};
+
+template <typename T, size_t dim>
+struct C_multidimensional_delete<T[], dim> {
+  void operator() (T* ptr) const {
+    if (ptr) C_multidimensional_delete<T[], dim-1>().operator()(ptr[0]);
+    free (ptr);
+  }
+};
+
+template <typename T>
+struct C_multidimensional_delete<T[], 1> {
+  void operator() (T* ptr) const {
+    free (ptr);
+  }
+};
+
+template <typename T>
+struct C_multidimensional_delete<T[], 0> {};
+
+template <typename T>
+struct C_noncontiguous_2d_delete {};
+
+template <typename T>
+struct C_noncontiguous_2d_delete<T[]> {
+  size_t array_size;
+  C_noncontiguous_2d_delete (size_t size = size_t()) : array_size(size) {}
+  void operator() (T* ptr) const {
+    for (int i=0; i<array_size; ++i) free (ptr[i]);
+    free (ptr);
+  }
+};
+
+template <typename T>
+struct LAMMPS_delete {
+  void operator() (T* ptr) const {
+    Memory::sfree (ptr);
+  }
+};
+
+template <typename T, size_t dim>
+struct LAMMPS_multidimensional_delete {};
+
+template <typename T, size_t dim>
+struct LAMMPS_multidimensional_delete<T[], dim> {
+  void operator() (T* ptr) const {
+    if (ptr) LAMMPS_multidimensional_delete<T[], dim-1>().operator()(ptr[0]);
+    Memory::sfree (ptr);
+  }
+};
+
+template <typename T>
+struct LAMMPS_multidimensional_delete<T[], 1> {
+  void operator() (T* ptr) const {
+    Memory::sfree (ptr);
+  }
+};
+
+template <typename T>
+struct LAMMPS_multidimensional_delete<T[], 0> {};
+
+template<bool B, class T, class F>
+struct conditional {typedef T type;};
+ 
+template<class T, class F>
+struct conditional<false, T, F> {typedef F type;};
+
+template <class T> struct is_reference     {static const bool value = false;};
+template <class T> struct is_reference<T&> {static const bool value = true;};
+
+template<class T>
+struct remove_extent {typedef T type;};
+ 
+template<class T>
+struct remove_extent<T[]> {typedef T type;};
+ 
+template<class T, std::size_t N>
+struct remove_extent<T[N]> {typedef T type;};
+
+template <typename T>
+struct C_delete {
+  typedef typename remove_extent<T>::type* pointer_type;
+  void operator() (pointer_type ptr) const {
+    free (ptr);
+  }
+};
+
+}
+
+template <typename T, typename D = detail::default_delete<T> >
+class resource_ptr {
+  typedef typename detail::conditional<detail::is_reference<D>::value,
+                                       D,
+                                       const D&>::type deleter_ref_type;
+public:
+  typedef T element_type;
+  typedef T* pointer_type;
+  typedef D deleter_type;
+  
+  resource_ptr (pointer_type p = pointer_type()) : _ptr(p), _deleter() {}
+  
+  resource_ptr (pointer_type p, deleter_ref_type d) : _ptr(p), _deleter(d) {}
+  
+  ~resource_ptr () {
+    if (_ptr != pointer_type()) {
+      _deleter (_ptr);
+      _ptr = pointer_type();
+    }
+  }
+  
+  bool null () const {return _ptr==pointer_type();}
+  
+  pointer_type get () const {return _ptr;}
+  
+  deleter_type & get_deleter () {return _deleter;}
+  const deleter_type & get_deleter () const {return _deleter;}
+  
+  pointer_type* get_address () {return &_ptr;}
+  
+  element_type & operator* () const {return *_ptr;}
+  pointer_type operator-> () const {return _ptr;}
+  
+  pointer_type release () {
+    pointer_type p = _ptr;
+    _ptr = pointer_type();
+    return p;
+  }
+  
+  void reset (pointer_type p = pointer_type()) {
+    if (_ptr != pointer_type()) _deleter (_ptr);
+    _ptr = p;
+  }
+protected:
+  pointer_type _ptr;
+  deleter_type _deleter;
+  
+private:
+  resource_ptr (const resource_ptr &);
+  resource_ptr & operator= (const resource_ptr &);
+};
+
+template <typename T, typename D>
+bool operator== (const resource_ptr<T, D> &lhs, typename resource_ptr<T, D>::pointer_type rhs) {
+  return lhs.get() == rhs;
+}
+
+template <typename T, typename D>
+bool operator== (typename resource_ptr<T, D>::pointer_type lhs, const resource_ptr<T, D> &rhs) {
+  return lhs == rhs.get();
+}
+
+template <typename T, typename D>
+bool operator== (const resource_ptr<T, D> &lhs, resource_ptr<T, D> &rhs) {
+  return lhs.get() == rhs.get();
+}
+
+template <typename T, typename D>
+bool operator!= (const resource_ptr<T, D> &lhs, typename resource_ptr<T, D>::pointer_type rhs) {
+  return lhs.get() != rhs;
+}
+
+template <typename T, typename D>
+bool operator!= (typename resource_ptr<T, D>::pointer_type lhs, const resource_ptr<T, D> &rhs) {
+  return lhs != rhs.get();
+}
+
+template <typename T, typename D>
+bool operator!= (const resource_ptr<T, D> &lhs, resource_ptr<T, D> &rhs) {
+  return lhs.get() != rhs.get();
+}
+
+template <typename T, typename D>
+class resource_ptr<T[], D> {
+  typedef typename detail::conditional<detail::is_reference<D>::value,
+                                       D,
+                                       const D&>::type deleter_ref_type;
+public:
+  typedef T element_type;
+  typedef T* pointer_type;
+  typedef D deleter_type;
+  
+  resource_ptr (pointer_type p = pointer_type()) : _ptr(p), _deleter() {}
+  
+  resource_ptr (pointer_type p, deleter_ref_type d) : _ptr(p), _deleter(d) {}
+  
+  ~resource_ptr () {
+    if (_ptr != pointer_type()) {
+      _deleter (_ptr);
+      _ptr = pointer_type();
+    }
+  }
+  
+  pointer_type get () const {return _ptr;}
+  
+  deleter_type & get_deleter () {return _deleter;}
+  const deleter_type & get_deleter () const {return _deleter;}
+  
+  pointer_type* get_address () {return &_ptr;}
+  
+  element_type & operator[] (size_t i) const {return _ptr[i];}
+  
+  pointer_type release () {
+    pointer_type p = _ptr;
+    _ptr = pointer_type();
+    return p;
+  }
+  
+  void reset (pointer_type p = pointer_type()) {
+    if (_ptr != pointer_type()) _deleter (_ptr);
+    _ptr = p;
+  }
+protected:
+  pointer_type _ptr;
+  deleter_type _deleter;
+  
+private:
+  resource_ptr (const resource_ptr &);
+  resource_ptr & operator= (const resource_ptr &);
+};
+
+template <typename T>
+struct memory_ptr : public resource_ptr<T, detail::default_delete<T> > {
+  typedef T* pointer_type;
+  memory_ptr () : resource_ptr<T, detail::default_delete<T> > () {}
+  memory_ptr (pointer_type p) : resource_ptr<T, detail::default_delete<T> > (p) {}
+  void operator= (pointer_type p) {this->reset (p);}
+};
+
+template <typename T>
+struct memory_ptr<T[]> : public resource_ptr<T[], detail::default_delete<T[]> > {
+  typedef T* pointer_type;
+  memory_ptr () : resource_ptr<T[], detail::default_delete<T[]> > () {}
+  memory_ptr (pointer_type p) : resource_ptr<T[], detail::default_delete<T[]> > (p) {}
+  void operator= (pointer_type p) {this->reset (p);}
+};
+
+template <typename T>
+struct C_memory_ptr : public resource_ptr<T, detail::C_delete<T> > {
+  typedef typename detail::remove_extent<T>::type* pointer_type;
+  C_memory_ptr () : resource_ptr<T, detail::C_delete<T> > () {}
+  C_memory_ptr (pointer_type p) : resource_ptr<T, detail::C_delete<T> > (p) {}
+  void operator= (pointer_type p) {this->reset (p);}
+};
+
+template <typename T>
+struct C_memory_ptr_noncontiguous_2d : public resource_ptr<T, detail::C_noncontiguous_2d_delete<T> > {
+  typedef typename detail::remove_extent<T>::type pointer_type;
+  typedef typename detail::remove_extent<T>::type* pointer2pointer_type;
+  typedef detail::C_noncontiguous_2d_delete<T> deleter_type;
+  C_memory_ptr_noncontiguous_2d ()
+  : resource_ptr<T, deleter_type> (pointer2pointer_type(), deleter_type()) {}
+  C_memory_ptr_noncontiguous_2d (pointer2pointer_type p, size_t array_size)
+  : resource_ptr<T, deleter_type> (p, deleter_type(array_size)) {}
+  void reset_ptr_and_size (pointer2pointer_type p, size_t array_size) {
+    this->reset (p);
+    this->get_deleter() = deleter_type(array_size);
+  }
+};
+}
+
+#endif


### PR DESCRIPTION
## Purpose

Provides an implementation for encapsulated pointers suggested in issue #1200 and fixes #1109 

## Author(s)

Morteza Jalalvand

## Backward Compatibility

No issues.

## Implementation Notes

There is a `resource_ptr<T,D>` template class where `T` is the type of resource being pointed and `D` is a deleter class which specifies how the resource should be deallocated. Currently we have these deleters:
* `default_delete<T>` : for memory acquired with `new`, uses `delete`
* `default_delete<T[]>` : specialized version of the above for arrays, for memory acquired with `new[]`, uses `delete[]`
* `C_delete<T>` : for memory acquired C functions, uses `free`
* `LAMMPS_delete<T>` : for memory acquired LAMMPS memory functions, uses `sfree`, this requires the `sfree` to be made static but this has no side effects on other parts of LAMMPS
* `multidimensional_delete<T[], dim>` : for contiguously allocated multidimmensional arrays, for memory acquired with `new[]`, uses `delete`, for example if dim=3 first calls `delete [] ptr[0][0];` then `delete [] ptr[0];` then `delete [] ptr;`
* `C_multidimensional_delete<T[], dim>` : same as above but uses `free` instead
* `LAMMPS_multidimensional_delete<T[], dim>` : same as above but uses `sfree` instead
* `C_noncontiguous_2d_delete<T[]>` : I provided this one reluctantly because non-contiguous 2d arrays were used in fix_bocs, this requires specifying the array size in constructor to delete all the arrays

There are several classes that inherit from `resource_ptr` but with prespecified deleter. Effectively they act as template typedefs:
* `memory_ptr<T>` inherits from `resource_ptr<T, default_delete<T> >`
* `memory_ptr<T[]>` inherits from `resource_ptr<T[], default_delete<T[]> >`
* `C_memory_ptr<T>` inherits from `resource_ptr<T, C_delete<T> >`
* `C_memory_ptr_noncontiguous_2d` : `resource_ptr<T, detail::C_noncontiguous_2d_delete<T> >`
* other variants will be added, once we're sure current design is good

The interface is similar to STL's `unique_ptr` except the following:
* no move constructor/assignment (not in C++98)
* private copy constructor/assignment (can not delete them in C++98)
* we support assignment from raw pointers (it's convenient and will not be ambiguous since there's no other assignment)

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [-](Not Applicable) Suitable new documentation files and/or updates to the existing docs are included
- [-](Not Applicable) One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

*Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)*