### PR TITLE
Change fix nvt/sllod to allow suffix styles of fix deform

### DIFF
--- a/src/USER-EFF/fix_nvt_sllod_eff.cpp
+++ b/src/USER-EFF/fix_nvt_sllod_eff.cpp
@@ -75,7 +75,7 @@ void FixNVTSllodEff::init()
 
   int i;
   for (i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+    if (strncmp(modify->fix[i]->style,"deform",6) == 0) {
       if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod/eff with inconsistent fix deform "
                    "remap option");

--- a/src/USER-INTEL/fix_nvt_sllod_intel.cpp
+++ b/src/USER-INTEL/fix_nvt_sllod_intel.cpp
@@ -76,7 +76,7 @@ void FixNVTSllodIntel::init()
 
   int i;
   for (i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+    if (strncmp(modify->fix[i]->style,"deform",6) == 0) {
       if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod with inconsistent fix deform "
                    "remap option");

--- a/src/USER-OMP/fix_nvt_sllod_omp.cpp
+++ b/src/USER-OMP/fix_nvt_sllod_omp.cpp
@@ -82,7 +82,7 @@ void FixNVTSllodOMP::init()
 
   int i;
   for (i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+    if (strncmp(modify->fix[i]->style,"deform",6) == 0) {
       if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod/omp with inconsistent fix "
                    "deform remap option");

--- a/src/fix_nvt_sllod.cpp
+++ b/src/fix_nvt_sllod.cpp
@@ -80,7 +80,7 @@ void FixNVTSllod::init()
 
   int i;
   for (i = 0; i < modify->nfix; i++)
-    if (strstr(modify->fix[i]->style,"deform")) {
+    if (strncmp(modify->fix[i]->style,"deform",6) == 0) {
       if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod with inconsistent fix deform "
                    "remap option");

--- a/src/fix_nvt_sllod.cpp
+++ b/src/fix_nvt_sllod.cpp
@@ -80,7 +80,7 @@ void FixNVTSllod::init()
 
   int i;
   for (i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+    if (strstr(modify->fix[i]->style,"deform")) {
       if (((FixDeform *) modify->fix[i])->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix nvt/sllod with inconsistent fix deform "
                    "remap option");


### PR DESCRIPTION
## Purpose

`fix nvt/sllod` errors out when using suffix styles of `fix deform`. This PR fixes this issue.

## Author(s)

Stan Moore (Sandia), reported by Gary Grest (Sandia)

## Backward Compatibility

No issues.