### PR TITLE
Update linux linux doc

### DIFF
--- a/doc/src/Install_linux.txt
+++ b/doc/src/Install_linux.txt
@@ -15,7 +15,7 @@ Binaries are available for different versions of Linux:
 "Pre-built Fedora Linux executables"_#fedora
 "Pre-built EPEL Linux executables (RHEL, CentOS)"_#epel
 "Pre-built OpenSuse Linux executables"_#opensuse
-"Pre-built Gentoo Linux executable"_#gentoo :all(b)
+"Gentoo Linux executable"_#gentoo :all(b)
 
 :line
 
@@ -150,7 +150,7 @@ Thanks to Christoph Junghans (LANL) for making LAMMPS available in OpenSuse.
 
 :line
 
-Pre-built Gentoo Linux executable :h4,link(gentoo)
+Gentoo Linux executable :h4,link(gentoo)
 
 LAMMPS is part of Gentoo's main package tree and can be installed by
 typing:

--- a/doc/src/Install_linux.txt
+++ b/doc/src/Install_linux.txt
@@ -87,11 +87,11 @@ linking to the C library interface (lammps-devel, lammps-mpich-devel,
 lammps-openmpi-devel), the header for compiling programs using
 the C library interface (lammps-headers), and the LAMMPS python
 module for Python 3. All packages can be installed at the same
-time and the name of the LAMMPS executable is {lmp} in all 3 cases.
-By default, {lmp} will refer to the serial executable, unless
-one of the MPI environment modules is loaded
+time and the name of the LAMMPS executable is {lmp} and {lmp_openmpi}
+or {lmp_mpich} respectively.  By default, {lmp} will refer to the
+serial executable, unless one of the MPI environment modules is loaded
 ("module load mpi/mpich-x86_64" or "module load mpi/openmpi-x86_64").
-Then the corresponding parallel LAMMPS executable is used.
+Then the corresponding parallel LAMMPS executable can be used.
 The same mechanism applies when loading the LAMMPS python module.
 
 To install LAMMPS with OpenMPI and run an input in.lj with 2 CPUs do:


### PR DESCRIPTION
With version 20181212 the mpi-enabled executables in Fedora will be called `lmp_openmpi` and `lmp_mpich`.