### PR TITLE
"mixing rule" for  lambda in init_one() method

### DIFF
--- a/src/USER-FEP/pair_lj_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_soft.cpp
@@ -566,6 +566,9 @@ double PairLJCutSoft::init_one(int i, int j)
     epsilon[i][j] = mix_energy(epsilon[i][i],epsilon[j][j],
                                sigma[i][i],sigma[j][j]);
     sigma[i][j] = mix_distance(sigma[i][i],sigma[j][j]);
+    if (lambda[i][i] != lambda[j][j])
+      error->all(FLERR,"Pair lj/cut/soft different lambda values in mix");
+    lambda[i][j] = lambda[i][i];
     cut[i][j] = mix_distance(cut[i][i],cut[j][j]);
   }
 


### PR DESCRIPTION
The values of the lambda[i][j] were equal to zero and different from lambda[i][i] when the user was not using explicit pair_coeff commands for the i-j pairs in the input script. The "mixing rule" included in this file is the same with the one in the pair_lj_cut_coul_cut_soft.cpp and pair_lj_cut_coul_long_soft.cpp files.

## Author(s)

E. Voyiatzis

## Backward Compatibility

backward compatibility is maintained 

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [X ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


