### PR TITLE
Rename pair style lebedeva to lebedeva/z

### DIFF
--- a/doc/src/Commands_pair.txt
+++ b/doc/src/Commands_pair.txt
@@ -107,6 +107,7 @@ OPT.
 "kolmogorov/crespi/full"_pair_kolmogorov_crespi_full.html,
 "kolmogorov/crespi/z"_pair_kolmogorov_crespi_z.html,
 "lcbop"_pair_lcbop.html,
+"lebedeva/z"_pair_lebedeva_z.html,
 "lennard/mdf"_pair_mdf.html,
 "line/lj"_pair_line_lj.html,
 "list"_pair_list.html,

--- a/doc/src/lammps.book
+++ b/doc/src/lammps.book
@@ -585,6 +585,7 @@ pair_kim.html
 pair_kolmogorov_crespi_full.html
 pair_kolmogorov_crespi_z.html
 pair_lcbop.html
+pair_lebedeva_z.html
 pair_line_lj.html
 pair_list.html
 pair_lj.html

--- a/doc/src/pair_ilp_graphene_hbn.txt
+++ b/doc/src/pair_ilp_graphene_hbn.txt
@@ -10,7 +10,7 @@ pair_style ilp/graphene/hbn command :h3
 
 [Syntax:]
 
-pair_style hybrid/overlay ilp/graphene/hbn cutoff tap_flag :pre
+pair_style \[hybrid/overlay ...\] ilp/graphene/hbn cutoff tap_flag :pre
 
 cutoff = global cutoff (distance units)
 tap_flag = 0/1 to turn off/on the taper function
@@ -110,6 +110,7 @@ units, if your simulation does not use {metal} units.
 "pair_style hybrid/overlay"_pair_hybrid.html,
 "pair_style pair_kolmogorov_crespi_z"_pair_kolmogorov_crespi_z.html,
 "pair_style pair_kolmogorov_crespi_full"_pair_kolmogorov_crespi_full.html,
+"pair_style pair_lebedeva_z"_pair_lebedeva_z.html,
 "pair_style pair_coul_shield"_pair_coul_shield.html.
 
 [Default:] tap_flag = 1

--- a/doc/src/pair_kolmogorov_crespi_full.txt
+++ b/doc/src/pair_kolmogorov_crespi_full.txt
@@ -100,6 +100,7 @@ units.
 "pair_coeff"_pair_coeff.html,
 "pair_none"_pair_none.html,
 "pair_style hybrid/overlay"_pair_hybrid.html,
+"pair_style pair_lebedeva_z"_pair_lebedeva_z.html,
 "pair_style kolmogorov/crespi/z"_pair_kolmogorov_crespi_z.html,
 "pair_style ilp/graphene/hbn"_pair_ilp_graphene_hbn.html.
 

--- a/doc/src/pair_kolmogorov_crespi_z.txt
+++ b/doc/src/pair_kolmogorov_crespi_z.txt
@@ -10,7 +10,7 @@ pair_style kolmogorov/crespi/z command :h3
 
 [Syntax:]
 
-pair_style hybrid/overlay kolmogorov/crespi/z cutoff :pre
+pair_style \[hybrid/overlay ...\] kolmogorov/crespi/z cutoff :pre
 
 [Examples:]
 
@@ -56,9 +56,12 @@ package"_Build_package.html doc page for more info.
 
 [Related commands:]
 
-"pair_coeff"_pair_coeff.html
-"pair_none"_pair_none.html
-"pair_style hybrid/overlay"_pair_hybrid.html
+"pair_coeff"_pair_coeff.html,
+"pair_none"_pair_none.html,
+"pair_style hybrid/overlay"_pair_hybrid.html,
+"pair_style ilp/graphene/hbn"_pair_ilp_graphene_hbn.html.
+"pair_style kolmogorov/crespi/full"_pair_kolmogorov_crespi_full.html,
+"pair_style lebedeva/z"_pair_lebedeva_z.html
 
 [Default:] none
 

--- a/doc/src/pair_lebedeva_z.txt
+++ b/doc/src/pair_lebedeva_z.txt
@@ -6,25 +6,25 @@
 
 :line
 
-pair_style lebedeva command :h3
+pair_style lebedeva/z command :h3
 
 [Syntax:]
 
-pair_style hybrid/overlay lebedeva cutoff :pre
+pair_style \[hybrid/overlay ...\] lebedeva/z cutoff :pre
 
 [Examples:]
 
-pair_style hybrid/overlay lebedeva 20.0
+pair_style hybrid/overlay lebedeva/z 20.0
 pair_coeff * * none
-pair_coeff 1 2 lebedeva  CC.Lebedeva   C C :pre
+pair_coeff 1 2 lebedeva/z  CC.Lebedeva   C C :pre
 
-pair_style hybrid/overlay rebo lebedeva 14.0
+pair_style hybrid/overlay rebo lebedeva/z 14.0
 pair_coeff * * rebo                 CH.airebo  C C
-pair_coeff 1 2 lebedeva  CC.Lebedeva      C C :pre
+pair_coeff 1 2 lebedeva/z  CC.Lebedeva      C C :pre
 
 [Description:]
 
-The {lebedeva} style computes the Lebedeva interaction
+The {lebedeva/z} style computes the Lebedeva interaction
 potential as described in "(Lebedeva et al.)"_#Leb01. An important simplification is made,
 which is to take all normals along the z-axis.
 
@@ -50,9 +50,12 @@ package"_Build_package.html doc page for more info.
 
 [Related commands:]
 
-"pair_coeff"_pair_coeff.html
-"pair_none"_pair_none.html
-"pair_style hybrid/overlay"_pair_hybrid.html
+"pair_coeff"_pair_coeff.html,
+"pair_style none"_pair_none.html,
+"pair_style hybrid/overlay"_pair_hybrid.html,
+"pair_style ilp/graphene/hbd"_pair_ilp_graphene_hbn.html,
+"pair_style kolmogorov/crespi/z"_pair_kolmogorov_crespi_z.html,
+"pair_style kolmogorov/crespi/full"_pair_kolmogorov_crespi_full.html.
 
 [Default:] none
 

--- a/doc/src/pair_style.txt
+++ b/doc/src/pair_style.txt
@@ -174,6 +174,7 @@ accelerated styles exist.
 "kolmogorov/crespi/full"_pair_kolmogorov_crespi_full.html - Kolmogorov-Crespi (KC) potential with no simplifications
 "kolmogorov/crespi/z"_pair_kolmogorov_crespi_z.html - Kolmogorov-Crespi (KC) potential with normals along z-axis
 "lcbop"_pair_lcbop.html - long-range bond-order potential (LCBOP)
+"lebedeva/z"_pair_lebedeva_z.html - Lebedeva inter-layer potential for graphene with normals along z-axis
 "lennard/mdf"_pair_mdf.html - LJ potential in A/B form with a taper function
 "line/lj"_pair_line_lj.html - LJ potential between line segments
 "list"_pair_list.html - potential between pairs of atoms explicitly listed in an input file

--- a/doc/src/pairs.txt
+++ b/doc/src/pairs.txt
@@ -50,6 +50,7 @@ Pair Styles :h1
    pair_kolmogorov_crespi_full
    pair_kolmogorov_crespi_z
    pair_lcbop
+   pair_lebedeva_z
    pair_line_lj
    pair_list
    pair_lj

--- a/examples/USER/misc/lebedeva/2particles.in
+++ b/examples/USER/misc/lebedeva/2particles.in
@@ -1,4 +1,4 @@
-# After running LAMMPS with this input script a number of dump files is created. 
+# After running LAMMPS with this input script a number of dump files is created.
 # To extract the data from there I used grep script:
 # grep '^2 ' *cfg > LammpsResult.dat
 # After that after removing some text from LammpsResult.dat,
@@ -8,17 +8,17 @@
 # Email: softquake@gmail.com
 
 
-# ---------- Start simulation --------------------- 
+# ---------- Start simulation ---------------------
 clear
-units metal 
-dimension 3 
-boundary f f f 
-atom_style atomic 
+units metal
+dimension 3
+boundary f f f
+atom_style atomic
 
 # ========================== Create Atomistic Structure ===========================
 
 region whole block 0 20 0 20 0 10
-create_box 2 whole 
+create_box 2 whole
 
 read_data 2particles.dat add append
 
@@ -27,22 +27,22 @@ group graphite type 1 2
 group graphene1 type 1
 group graphene2 type 2
 
-pair_style hybrid/overlay lebedeva 20
+pair_style hybrid/overlay lebedeva/z 20
 pair_coeff * * none
-pair_coeff 1 2 lebedeva CC.Lebedeva C C
+pair_coeff 1 2 lebedeva/z CC.Lebedeva C C
 
 mass 1 12.01 # Carbon
 mass 2 12.01 # Carbon
 
-neighbor 0.3 bin 
-neigh_modify delay 1 check yes 
+neighbor 0.3 bin
+neigh_modify delay 1 check yes
 
 compute              peratom all pe/atom
 
 dump 1 all custom 1 dump_lebedeva_*.cfg id x y z c_peratom fx fy fz
 dump_modify 1 pad 3
 
-thermo 10 
+thermo 10
 thermo_style custom step pe press temp
 thermo_modify lost ignore
 

--- a/src/USER-MISC/README
+++ b/src/USER-MISC/README
@@ -71,6 +71,7 @@ pair_style dipole/sf, Mario Orsi, orsimario at gmail.com, 8 Aug 11
 pair_style edip, Luca Ferraro, luca.ferraro at caspur.it, 15 Sep 11
 pair_style extep, Jaap Kroes (Radboud U), jaapkroes at gmail dot com, 28 Nov 17
 pair_style gauss/cut, Axel Kohlmeyer, akohlmey at gmail.com, 1 Dec 11
+pair_style lebedeva/z, Zbigniew Koziol (National Center for Nuclear Research), softquake at gmail dot com, 4 Jan 19
 pair_style lennard/mdf, Paolo Raiteri, p.raiteri at curtin.edu.au, 2 Dec 15
 pair_style list, Axel Kohlmeyer (Temple U), akohlmey at gmail.com, 1 Jun 13
 pair_style lj/mdf, Paolo Raiteri, p.raiteri at curtin.edu.au, 2 Dec 15

--- a/src/USER-MISC/pair_lebedeva.cpp
+++ b/src/USER-MISC/pair_lebedeva.cpp
@@ -17,7 +17,7 @@
    e-mail: softquake at gmail dot com
    Writing this was based on C code of Kolmogorov-Crespi potential 
    of Jaap Kroes and others.
-  
+
    This is potential described in
    [Lebedeva et al., Physica E, 44(6), 949-954, 2012.]
 ------------------------------------------------------------------------- */
@@ -41,7 +41,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairLebedeva::PairLebedeva(LAMMPS *lmp) : Pair(lmp)
+PairLebedevaZ::PairLebedevaZ(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
 
@@ -59,7 +59,7 @@ PairLebedeva::PairLebedeva(LAMMPS *lmp) : Pair(lmp)
 
 /* ---------------------------------------------------------------------- */
 
-PairLebedeva::~PairLebedeva()
+PairLebedevaZ::~PairLebedevaZ()
 {
   if (allocated) {
     memory->destroy(setflag);
@@ -78,7 +78,7 @@ PairLebedeva::~PairLebedeva()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLebedeva::compute(int eflag, int vflag)
+void PairLebedevaZ::compute(int eflag, int vflag)
 {
   int i,j,ii,jj,inum,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair,der;
@@ -122,7 +122,7 @@ void PairLebedeva::compute(int eflag, int vflag)
       rhosq = delx*delx + dely*dely;
       rho = sqrt(rhosq);
       rsq = rhosq + delz*delz;
-      
+
       if (rsq < cutsq[itype][jtype]) {
 
         int iparam_ij = elem2param[map[itype]][map[jtype]];
@@ -173,7 +173,7 @@ void PairLebedeva::compute(int eflag, int vflag)
    allocate all arrays
 ------------------------------------------------------------------------- */
 
-void PairLebedeva::allocate()
+void PairLebedevaZ::allocate()
 {
   allocated = 1;
   int n = atom->ntypes;
@@ -193,7 +193,7 @@ void PairLebedeva::allocate()
    global settings
 ------------------------------------------------------------------------- */
 
-void PairLebedeva::settings(int narg, char **arg)
+void PairLebedevaZ::settings(int narg, char **arg)
 {
   if (narg != 1) error->all(FLERR,"Illegal pair_style command");
   if (strcmp(force->pair_style,"hybrid/overlay")!=0)
@@ -215,7 +215,7 @@ void PairLebedeva::settings(int narg, char **arg)
    set coeffs for one or more type pairs
 ------------------------------------------------------------------------- */
 
-void PairLebedeva::coeff(int narg, char **arg)
+void PairLebedevaZ::coeff(int narg, char **arg)
 {
   int i,j,n; 
 
@@ -258,7 +258,7 @@ void PairLebedeva::coeff(int narg, char **arg)
 
 
   read_file(arg[2]);
-  
+
   double cut_one = cut_global;
 
   int count = 0;
@@ -278,7 +278,7 @@ void PairLebedeva::coeff(int narg, char **arg)
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
 
-double PairLebedeva::init_one(int i, int j)
+double PairLebedevaZ::init_one(int i, int j)
 {
   if (setflag[i][j] == 0) error->all(FLERR,"All pair coeffs are not set");
 
@@ -296,7 +296,7 @@ double PairLebedeva::init_one(int i, int j)
    read Lebedeva potential file
 ------------------------------------------------------------------------- */
 
-void PairLebedeva::read_file(char *filename)
+void PairLebedevaZ::read_file(char *filename)
 {
   int params_per_line = 12;
   char **words = new char*[params_per_line+1];

--- a/src/USER-MISC/pair_lebedeva.h
+++ b/src/USER-MISC/pair_lebedeva.h
@@ -13,21 +13,21 @@
 
 #ifdef PAIR_CLASS
 
-PairStyle(lebedeva,PairLebedeva)
+PairStyle(lebedeva/z,PairLebedevaZ)
 
 #else
 
-#ifndef LMP_PAIR_LEBEDEVA_H
-#define LMP_PAIR_LEBEDEVA_H
+#ifndef LMP_PAIR_LEBEDEVA_Z_H
+#define LMP_PAIR_LEBEDEVA_Z_H
 
 #include "pair.h"
 
 namespace LAMMPS_NS {
 
-class PairLebedeva : public Pair {
+class PairLebedevaZ : public Pair {
  public:
-  PairLebedeva(class LAMMPS *);
-  virtual ~PairLebedeva();
+  PairLebedevaZ(class LAMMPS *);
+  virtual ~PairLebedevaZ();
 
   virtual void compute(int, int);
   void settings(int, char **);


### PR DESCRIPTION
## Purpose

To be consistent with the naming conventions for the Kolmogorov-Crespi pair styles, we should rename the pair style `lebedeva` to `lebedeva/z`, since this also expects normals along z.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

n/a

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

