### PR TITLE
add parallel dump file info to rerun doc page

### DIFF
--- a/doc/src/rerun.txt
+++ b/doc/src/rerun.txt
@@ -107,6 +107,14 @@ However if you specify a series of dump files in an incorrect order
 (with respect to the timesteps they contain), you may skip large
 numbers of snapshots
 
+Note that the dump files specified as part of the {dump} keyword can
+be parallel files, i.e. written as multiple files either per processor
+and/or per snapshot.  If that is the case they will also be read in
+parallel which can make the rerun command operate dramatically faster
+for large systems.  See the doc page for the "read_dump"_read_dump and
+"dump"_dump.html commands which describe how to read and write
+parallel dump files.
+
 The {first}, {last}, {every}, {skip} keywords determine which
 snapshots are read from the dump file(s).  Snapshots are skipped until
 they have a timestamp >= {Nfirst}.  When a snapshot with a timestamp >


### PR DESCRIPTION
## Purpose

Add doc page info on parallel dump files to the rerun command doc page.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


