### PR TITLE
Expose neighbor lists through library interface

### DIFF
--- a/examples/python/in.fix_python_invoke_neighlist
+++ b/examples/python/in.fix_python_invoke_neighlist
@@ -1,0 +1,67 @@
+# 3d Lennard-Jones melt
+
+units		lj
+atom_style	atomic
+
+lattice		fcc 0.8442
+region		box block 0 10 0 10 0 10
+create_box	1 box
+create_atoms	1 box
+mass		1 1.0
+
+velocity	all create 3.0 87287
+
+pair_style	lj/cut 2.5
+pair_coeff	1 1 1.0 1.0 2.5
+
+neighbor	0.3 bin
+
+neigh_modify	every 20 delay 0 check no
+
+python         post_force_callback here """
+from __future__ import print_function
+from lammps import lammps
+
+def post_force_callback(lmp, v):
+  L = lammps(ptr=lmp)
+  t = L.extract_global("ntimestep", 0)
+  nlist = L.neighbor_lists
+  print("### POST_FORCE ###", t, "nlist", nlist)
+
+  try:
+    mylist = nlist[0]
+    nlocal = L.extract_global("nlocal", 0)
+    nghost = L.extract_global("nghost", 0)
+    ntypes = L.extract_global("ntypes", 0)
+    mass = L.numpy.extract_atom_darray("mass", ntypes+1)
+    atype = L.numpy.extract_atom_iarray("type", nlocal+nghost)
+    x = L.numpy.extract_atom_darray("x", nlocal+nghost, dim=3)
+    v = L.numpy.extract_atom_darray("v", nlocal+nghost, dim=3)
+    f = L.numpy.extract_atom_darray("f", nlocal+nghost, dim=3)
+
+    for iatom, numneigh, neighs in mylist:
+      print("- {}".format(iatom), x[iatom], v[iatom], f[iatom], " : ",  numneigh, "Neighbors")
+      for jatom in neighs:
+        if jatom < nlocal:
+            print("    *  ", jatom, x[jatom], v[jatom], f[jatom])
+        else:
+            print("    * [GHOST]", jatom, x[jatom], v[jatom], f[jatom])
+  except Exception as e:
+    print(e)
+"""
+
+fix		1 all nve
+fix     3 all python/invoke 50 post_force post_force_callback
+
+#dump		id all atom 50 dump.melt
+
+#dump		2 all image 25 image.*.jpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 25 movie.mpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+thermo		50
+run		250

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -46,6 +46,38 @@ class MPIAbortException(Exception):
   def __str__(self):
     return repr(self.message)
 
+class NeighList:
+    def __init__(self, lmp, idx):
+        self.lmp = lmp
+        self.idx = idx
+        self._inum = c_int(0)
+        self._ilist = POINTER(c_int)()
+        self._numneigh = POINTER(c_int)()
+        self._firstneigh = POINTER(POINTER(c_int))()
+        self.lmp.lib.lammps_get_neighlist(self.lmp.lmp, self.idx, byref(self._inum), byref(self._ilist), byref(self._numneigh), byref(self._firstneigh))
+
+    def __str__(self):
+        return "Neighbor List ({} atoms)".format(self._inum.value)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __iter__(self):
+        class Neighbors:
+            def __init__(self, numneigh, neighs):
+                self._numneigh = numneigh
+                self._neighs = neighs
+
+            def __iter__(self):
+                for jj in range(self._numneigh):
+                    yield self._neighs[jj] & 0x3FFFFFFF
+
+        for ii in range(self._inum.value):
+            iatom = self._ilist[ii]
+            numneigh = self._numneigh[iatom]
+            neighs = Neighbors(numneigh, self._firstneigh[iatom])
+            yield iatom, numneigh, neighs
+
 class lammps(object):
 
   # detect if Python is using version of mpi4py that can pass a communicator
@@ -596,6 +628,16 @@ class lammps(object):
         self.lib.lammps_config_package_name(idx, sb, 100)
         self._installed_packages.append(sb.value.decode())
     return self._installed_packages
+
+  @property
+  def neighbor_lists(self):
+    nlist = self.lib.lammps_get_num_neighlists(self.lmp)
+    lists = []
+
+    for i in range(nlist):
+      lists.append(NeighList(self, i))
+
+    return lists
 
 # -------------------------------------------------------------------------
 # -------------------------------------------------------------------------

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1652,35 +1652,34 @@ int lammps_neighlist_element(void * ptr, int idx, int ii) {
 
 int lammps_neighlist_element_neighbor_count(void * ptr, int idx, int i) {
   LAMMPS *  lmp = (LAMMPS *) ptr;
-  Atom * atom = lmp->atom;
   Neighbor * neighbor = lmp->neighbor;
 
   if(idx < 0 || idx >= neighbor->nlist) {
     return -1;
   }
 
-  if(i < 0 || i >= (atom->nlocal + atom->nghost)) {
+  NeighList * list = neighbor->lists[idx];
+
+  if(i < 0 || i >= list->maxatom) {
     return -1;
   }
 
-  NeighList * list = neighbor->lists[idx];
   return list->numneigh[i];
 }
 
 int lammps_neighlist_element_neighbor(void * ptr, int idx, int i, int jj) {
   LAMMPS *  lmp = (LAMMPS *) ptr;
-  Atom * atom = lmp->atom;
   Neighbor * neighbor = lmp->neighbor;
 
   if(idx < 0 || idx >= neighbor->nlist) {
     return -1;
   }
 
-  if(i < 0 || i >= (atom->nlocal + atom->nghost)) {
+  NeighList * list = neighbor->lists[idx];
+
+  if(i < 0 || i >= list->maxatom) {
     return -1;
   }
-
-  NeighList * list = neighbor->lists[idx];
 
   if(jj < 0 || jj >= list->numneigh[i]) {
     return -1;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1614,29 +1614,77 @@ int lammps_get_last_error_message(void *ptr, char * buffer, int buffer_size) {
 
 #endif
 
-int lammps_get_num_neighlists(void *ptr) {
+
+int lammps_neighlist_count(void * ptr) {
   LAMMPS *  lmp = (LAMMPS *) ptr;
   Neighbor * neighbor = lmp->neighbor;
   return neighbor->nlist;
 }
 
-int lammps_get_neighlist(void *ptr, int idx, int * inum, int ** ilist, int ** numneigh, int ***firstneigh) {
+int lammps_neighlist_size(void * ptr, int idx) {
   LAMMPS *  lmp = (LAMMPS *) ptr;
   Neighbor * neighbor = lmp->neighbor;
 
   if(idx < 0 || idx >= neighbor->nlist) {
-    *inum = 0;
-    *ilist = NULL;
-    *numneigh = NULL;
-    *firstneigh = NULL;
     return -1;
   }
 
   NeighList * list = neighbor->lists[idx];
-  *inum = list->inum;
-  *ilist = list->ilist;
-  *numneigh = list->numneigh;
-  *firstneigh = list->firstneigh;
+  return list->inum;
+}
 
-  return 0;
+int lammps_neighlist_element(void * ptr, int idx, int ii) {
+  LAMMPS *  lmp = (LAMMPS *) ptr;
+  Neighbor * neighbor = lmp->neighbor;
+
+  if(idx < 0 || idx >= neighbor->nlist) {
+    return -1;
+  }
+
+  NeighList * list = neighbor->lists[idx];
+
+  if(ii < 0 || ii >= list->inum) {
+    return -1;
+  }
+
+  return list->ilist[ii];
+}
+
+int lammps_neighlist_element_neighbor_count(void * ptr, int idx, int i) {
+  LAMMPS *  lmp = (LAMMPS *) ptr;
+  Atom * atom = lmp->atom;
+  Neighbor * neighbor = lmp->neighbor;
+
+  if(idx < 0 || idx >= neighbor->nlist) {
+    return -1;
+  }
+
+  if(i < 0 || i >= (atom->nlocal + atom->nghost)) {
+    return -1;
+  }
+
+  NeighList * list = neighbor->lists[idx];
+  return list->numneigh[i];
+}
+
+int lammps_neighlist_element_neighbor(void * ptr, int idx, int i, int jj) {
+  LAMMPS *  lmp = (LAMMPS *) ptr;
+  Atom * atom = lmp->atom;
+  Neighbor * neighbor = lmp->neighbor;
+
+  if(idx < 0 || idx >= neighbor->nlist) {
+    return -1;
+  }
+
+  if(i < 0 || i >= (atom->nlocal + atom->nghost)) {
+    return -1;
+  }
+
+  NeighList * list = neighbor->lists[idx];
+
+  if(jj < 0 || jj >= list->numneigh[i]) {
+    return -1;
+  }
+
+  return list->firstneigh[i][jj];
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -39,6 +39,8 @@
 #include "error.h"
 #include "force.h"
 #include "info.h"
+#include "neighbor.h"
+#include "neigh_list.h"
 
 using namespace LAMMPS_NS;
 
@@ -1611,3 +1613,30 @@ int lammps_get_last_error_message(void *ptr, char * buffer, int buffer_size) {
 }
 
 #endif
+
+int lammps_get_num_neighlists(void *ptr) {
+  LAMMPS *  lmp = (LAMMPS *) ptr;
+  Neighbor * neighbor = lmp->neighbor;
+  return neighbor->nlist;
+}
+
+int lammps_get_neighlist(void *ptr, int idx, int * inum, int ** ilist, int ** numneigh, int ***firstneigh) {
+  LAMMPS *  lmp = (LAMMPS *) ptr;
+  Neighbor * neighbor = lmp->neighbor;
+
+  if(idx < 0 || idx >= neighbor->nlist) {
+    *inum = 0;
+    *ilist = NULL;
+    *numneigh = NULL;
+    *firstneigh = NULL;
+    return -1;
+  }
+
+  NeighList * list = neighbor->lists[idx];
+  *inum = list->inum;
+  *ilist = list->ilist;
+  *numneigh = list->numneigh;
+  *firstneigh = list->firstneigh;
+
+  return 0;
+}

--- a/src/library.h
+++ b/src/library.h
@@ -65,8 +65,11 @@ int lammps_config_has_jpeg_support();
 int lammps_config_has_ffmpeg_support();
 int lammps_config_has_exceptions();
 
-int lammps_get_num_neighlists(void *ptr);
-int lammps_get_neighlist(void *ptr, int idx, int * inum, int ** ilist, int ** numneigh, int ***firstneigh);
+int lammps_neighlist_count(void* ptr);
+int lammps_neighlist_size(void* ptr, int idx);
+int lammps_neighlist_element(void* ptr, int idx, int ii);
+int lammps_neighlist_element_neighbor_count(void* ptr, int idx, int i);
+int lammps_neighlist_element_neighbor(void* ptr, int idx, int i, int jj);
 
 // lammps_create_atoms() takes tagint and imageint as args
 // ifdef insures they are compatible with rest of LAMMPS

--- a/src/library.h
+++ b/src/library.h
@@ -65,6 +65,9 @@ int lammps_config_has_jpeg_support();
 int lammps_config_has_ffmpeg_support();
 int lammps_config_has_exceptions();
 
+int lammps_get_num_neighlists(void *ptr);
+int lammps_get_neighlist(void *ptr, int idx, int * inum, int ** ilist, int ** numneigh, int ***firstneigh);
+
 // lammps_create_atoms() takes tagint and imageint as args
 // ifdef insures they are compatible with rest of LAMMPS
 // caller must match to how LAMMPS library is built


### PR DESCRIPTION
## Purpose

Exposes LAMMPS neighbor lists via the library interface and adds `neighbor_lists` property to Python wrapper.

```Python
# contents of a callback function (e.g. via fix python/invoke) that 
# wants to manipulate the LAMMPS state
L = lammps(ptr=lmp)
nlist = L.neighbor_lists

mylist = nlist[0]
nlocal = L.extract_global("nlocal", 0)
nghost = L.extract_global("nghost", 0)
x = L.numpy.extract_atom_darray("x", nlocal+nghost, dim=3)
v = L.numpy.extract_atom_darray("v", nlocal+nghost, dim=3)
f = L.numpy.extract_atom_darray("f", nlocal+nghost, dim=3)

for iatom, numneigh, neighs in mylist:
  print("- {}".format(iatom), x[iatom], v[iatom], f[iatom], " : ",  numneigh, "Neighbors")
  for jatom in neighs:
    if jatom < nlocal:
      print("    *  ", jatom, x[jatom], v[jatom], f[jatom])
    else:
      print("    * [GHOST]", jatom, x[jatom], v[jatom], f[jatom])
```

## Author(s)

@rbberger (Temple U)

## Backward Compatibility

yes

## Implementation Notes

Adds several C library functions to expose data from neighbor lists. Additional functions could be added to retrieve neighbor list configuration.

```C++
int lammps_neighlist_count(void* ptr); // return number of neighbor lists
int lammps_neighlist_size(void* ptr, int idx); // return inum
int lammps_neighlist_element(void* ptr, int idx, int ii); // returns ilist[ii]
int lammps_neighlist_element_neighbor_count(void* ptr, int idx, int i); // returns numneigh[i]
int lammps_neighlist_element_neighbor(void* ptr, int idx, int i, jj); //return firstneigh[i][jj]
```

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines


