### PR TITLE
Bond/react: limit number of reactions

### DIFF
--- a/doc/src/fix_bond_react.txt
+++ b/doc/src/fix_bond_react.txt
@@ -36,10 +36,12 @@ react = mandatory argument indicating new reaction specification :l
   template-ID(post-reacted) = ID of a molecule template containing post-reaction topology :l
   map_file = name of file specifying corresponding atom-IDs in the pre- and post-reacted templates :l
   zero or more individual keyword/value pairs may be appended to each react argument :l
-  individual_keyword = {prob} or {stabilize_steps} or {update_edges} :l
+  individual_keyword = {prob} or {max_rxn} or {stabilize_steps} or {update_edges} :l
     {prob} values = fraction seed
       fraction = initiate reaction with this probability if otherwise eligible
       seed = random number seed (positive integer)
+    {max_rxn} value = N
+      N = maximum number of reactions allowed to occur
     {stabilize_steps} value = timesteps
       timesteps = number of timesteps to apply the internally-created "nve/limit"_fix_nve_limit.html fix to reacting atoms
     {update_edges} value = {none} or {charges} or {custom}
@@ -285,7 +287,8 @@ The {prob} keyword can affect whether an eligible reaction actually
 occurs. The fraction setting must be a value between 0.0 and 1.0. A
 uniform random number between 0.0 and 1.0 is generated and the
 eligible reaction only occurs if the random number is less than the
-fraction.
+fraction. Up to N reactions are permitted to occur, as optionally
+specified by the {max_rxn} keyword.
 
 The {stabilize_steps} keyword allows for the specification of how many
 timesteps a reaction site is stabilized before being returned to the

--- a/src/USER-MISC/fix_bond_react.h
+++ b/src/USER-MISC/fix_bond_react.h
@@ -54,7 +54,7 @@ class FixBondReact : public Fix {
   FILE *fp;
   int *iatomtype,*jatomtype;
   int *seed;
-  double **cutsq,*fraction;
+  double **cutsq,*fraction,*max_rxn;
   tagint lastcheck;
   int stabilization_flag;
   int custom_exclude_flag;


### PR DESCRIPTION
## Purpose

limit total number of reaction occurrences. thanks to Wolfgang Verestek for idea and code

## Author(s)

Wolfgang Verestek, Jake Gissinger, Axel Kohlmeyer 

## Backward Compatibility

yes

## Implementation Notes

currently a 'soft limit.' a strict limit implementation is underway. 

includes Axel's bug fixes from #1282.  ...not sure if that makes things easier or harder...

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


