### PR TITLE
Updating the list of potentials in fix_adapt_fep.txt

### DIFF
--- a/doc/src/fix_adapt_fep.txt
+++ b/doc/src/fix_adapt_fep.txt
@@ -114,13 +114,23 @@ styles and their energy formulas for the meaning of these parameters:
 
 "born"_pair_born.html: a,b,c: type pairs:
 "buck"_pair_buck.html: a,c: type pairs:
+"buck/mdf"_pair_mdf.html: a,c: type pairs:
 "coul/cut"_pair_coul.html: scale: type pairs:
 "coul/debye"_pair_coul.html: scale: type pairs:
 "coul/long"_pair_coul.html: scale: type pairs:
+"gauss"_pair_gauss.html: a: type pairs:
+"lennard/mdf"_pair_mdf.html: A,B: type pairs:
+"lj/class2"_pair_class2.html: epsilon,sigma: type pairs:
+"lj/class2/coul/cut"_pair_class2.html: epsilon,sigma,coulombic_cutoff: type pairs:
 "lj/cut"_pair_lj.html: epsilon,sigma: type pairs:
 "lj/expand"_pair_lj_expand.html: epsilon,sigma,delta: type pairs:
+"lj/mdf"_pair_mdf.html: epsilon,sigma: type pairs:
 "lubricate"_pair_lubricate.html: mu: global:
-"gauss"_pair_gauss.html: a: type pairs:
+"mie/cut"_pair_mie.html: epsilon,sigma,gamma_repulsive,gamma_attractive: type pairs:
+"morse"_pair_morse.html: D0,R0,alpha: type pairs:
+"morse/soft"_pair_morse.html: D0,R0,alpha,lambda: type pairs:
+"nm/cut"_pair_nm.html: E0,R0,m,n: type pairs:
+"ufm"_pair_ufm.html: epsilon,sigma: type pairs:
 "soft"_pair_soft.html: a: type pairs :tb(c=3,s=:)
 
 NOTE: It is easy to add new potentials and their parameters to this


### PR DESCRIPTION
There are several potentials that contain the method extract() but they are not included in the "fix adapt" and "fix adapt/fep"
A small update of the list is attempted here. The same potentials might be added to the documentation of fix_adapt if it is useful.

## Purpose

_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request. If this addresses an open GitHub Issue, mention the issue number, e.g. with `fixes #221` or `closes #135`, so that issue will be automatically closed when the pull request is merged_

## Author(s)

_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


