### PR TITLE
Bond/react: reaction constraints

### DIFF
--- a/doc/src/fix_bond_react.txt
+++ b/doc/src/fix_bond_react.txt
@@ -144,7 +144,7 @@ modified to match the post-reaction template.
 
 A bonding atom pair will be identified if several conditions are met.
 First, a pair of atoms I,J within the specified react-group-ID of type
-itype and jtype must separated by a distance between {Rmin} and
+itype and jtype must be separated by a distance between {Rmin} and
 {Rmax}. It is possible that multiple bonding atom pairs are
 identified: if the bonding atoms in the pre-reacted template are not
 1-2, 1-3, or 1-4 neighbors, the closest bonding atom partner is set as
@@ -213,9 +213,10 @@ mandatory keyword is 'equivalences' and the optional keywords are
 N {equivalences} = # of atoms N in the reaction molecule templates
 N {edgeIDs} = # of edge atoms N in the pre-reacted molecule template
 N {deleteIDs} = # of atoms N that are specified for deletion
-N {customIDs} = # of atoms N that are specified for a custom update :pre
+N {customIDs} = # of atoms N that are specified for a custom update
+N {constraints} = # of specified reaction constraints N :pre
 
-The body of the map file contains two mandatory sections and three
+The body of the map file contains two mandatory sections and four
 optional sections. The first mandatory section begins with the keyword
 'BondingIDs' and lists the atom IDs of the bonding atom pair in the
 pre-reacted molecule template. The second mandatory section begins
@@ -232,7 +233,10 @@ Edges' and allows for forcing the update of a specific atom's atomic
 charge. The first column is the ID of an atom near the edge of the
 pre-reacted molecule template, and the value of the second column is
 either 'none' or 'charges.' Further details are provided in the
-discussion of the 'update_edges' keyword.
+discussion of the 'update_edges' keyword. The fourth optional section
+begins with the keyword 'Constraints' and lists additional criteria
+that must be satisfied in order for the reaction to occur. Currently,
+there is one type of constraint available, as discussed below.
 
 A sample map file is given below:
 
@@ -264,6 +268,16 @@ Equivalences :pre
 7   7 :pre
 
 :line
+
+Any number of additional constraints may be specified in the
+Constraints section of the map file. Currently there is one type of
+additional constraint, of type 'distance', whose syntax is as follows:
+
+distance {ID1} {ID2} {rmin} {rmax} :pre
+
+where 'distance' is the required keyword, {ID1} and {ID2} are
+pre-reaction atom IDs, and these two atoms must be separated by a
+distance between {rmin} and {rmax} for the reaction to occur.
 
 Once a reaction site has been successfully identified, data structures
 within LAMMPS that store bond topology are updated to reflect the

--- a/doc/src/fix_bond_react.txt
+++ b/doc/src/fix_bond_react.txt
@@ -277,7 +277,9 @@ distance {ID1} {ID2} {rmin} {rmax} :pre
 
 where 'distance' is the required keyword, {ID1} and {ID2} are
 pre-reaction atom IDs, and these two atoms must be separated by a
-distance between {rmin} and {rmax} for the reaction to occur.
+distance between {rmin} and {rmax} for the reaction to occur. This
+constraint can be used to enforce a certain orientation between
+reacting molecules.
 
 Once a reaction site has been successfully identified, data structures
 within LAMMPS that store bond topology are updated to reflect the

--- a/src/USER-MISC/fix_bond_react.h
+++ b/src/USER-MISC/fix_bond_react.h
@@ -61,6 +61,8 @@ class FixBondReact : public Fix {
   int custom_exclude_flag;
   int *stabilize_steps_flag;
   int *update_edges_flag;
+  int *nconstraints;
+  double **constraints;
   int status;
   int *groupbits;
 
@@ -141,6 +143,7 @@ class FixBondReact : public Fix {
   void Equivalences(char *,int);
   void CustomEdges(char *,int);
   void DeleteAtoms(char *,int);
+  void Constraints(char *,int);
 
   void make_a_guess ();
   void neighbor_loop();
@@ -148,6 +151,7 @@ class FixBondReact : public Fix {
   void crosscheck_the_neighbor();
   void inner_crosscheck_loop();
   void ring_check();
+  int check_constraints();
 
   void open(char *);
   void readline(char *);


### PR DESCRIPTION
## Purpose

introduce the option for distance constraints between any two reaction-site atoms, which must be satisfied in order for reaction to occur. can be used to enforce a certain orientation between reacting molecules

## Author(s)

JG

## Backward Compatibility

yes

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


