### PR TITLE
ENH: Output computes/fixes of with arbitrary number of columns to NetCDF

### DIFF
--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -317,7 +317,7 @@ void DumpNetCDF::openfile()
           else {
             sprintf(dimstr, "vec%i", dims);
           }
-          if (dims != 1) {
+          if (dims != 1) {
             NCERRX( nc_inq_dimid(ncid, dimstr, &vector_dim[dims]),
                     dimstr );
           }

--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -281,6 +281,9 @@ void DumpNetCDF::openfile()
 
   // get total number of atoms
   ntotalgr = group->count(igroup);
+  for (int i = 0; i < DUMP_NC_MAX_DIMS; i++) {
+    vector_dim[i] = -1;
+  }
 
   if (filewriter) {
     if (append_flag && !multifile && access(filecurrent, F_OK) != -1) {
@@ -294,15 +297,32 @@ void DumpNetCDF::openfile()
 
       // dimensions
       NCERRX( nc_inq_dimid(ncid, NC_FRAME_STR, &frame_dim), NC_FRAME_STR );
-      NCERRX( nc_inq_dimid(ncid, NC_SPATIAL_STR, &spatial_dim),
-          NC_SPATIAL_STR );
-      NCERRX( nc_inq_dimid(ncid, NC_VOIGT_STR, &Voigt_dim), NC_VOIGT_STR );
       NCERRX( nc_inq_dimid(ncid, NC_ATOM_STR, &atom_dim), NC_ATOM_STR );
       NCERRX( nc_inq_dimid(ncid, NC_CELL_SPATIAL_STR, &cell_spatial_dim),
           NC_CELL_SPATIAL_STR );
       NCERRX( nc_inq_dimid(ncid, NC_CELL_ANGULAR_STR, &cell_angular_dim),
           NC_CELL_ANGULAR_STR );
       NCERRX( nc_inq_dimid(ncid, NC_LABEL_STR, &label_dim), NC_LABEL_STR );
+
+      for (int i = 0; i < n_perat; i++) {
+        int dims = perat[i].dims;
+        if (vector_dim[dims] < 0) {
+          char dimstr[1024];
+          if (dims == 3) {
+            strcpy(dimstr, NC_SPATIAL_STR);
+          }
+          else if (dims == 6) {
+            strcpy(dimstr, NC_VOIGT_STR);
+          }
+          else {
+            sprintf(dimstr, "vec%i", dims);
+          }
+          if (dims != 1) {
+            NCERRX( nc_inq_dimid(ncid, dimstr, &vector_dim[dims]),
+                    dimstr );
+          }
+        }
+      }
 
       // default variables
       NCERRX( nc_inq_varid(ncid, NC_SPATIAL_STR, &spatial_var),
@@ -320,7 +340,6 @@ void DumpNetCDF::openfile()
       NCERRX( nc_inq_varid(ncid, NC_CELL_ANGLES_STR, &cell_angles_var),
           NC_CELL_ANGLES_STR);
 
-      // variables specified in the input file
       for (int i = 0; i < n_perat; i++) {
         NCERRX( nc_inq_varid(ncid, perat[i].name, &perat[i].var),
                 perat[i].name );
@@ -359,10 +378,6 @@ void DumpNetCDF::openfile()
       // dimensions
       NCERRX( nc_def_dim(ncid, NC_FRAME_STR, NC_UNLIMITED, &frame_dim),
           NC_FRAME_STR );
-      NCERRX( nc_def_dim(ncid, NC_SPATIAL_STR, 3, &spatial_dim),
-          NC_SPATIAL_STR );
-      NCERRX( nc_def_dim(ncid, NC_VOIGT_STR, 6, &Voigt_dim),
-          NC_VOIGT_STR );
       NCERRX( nc_def_dim(ncid, NC_ATOM_STR, ntotalgr, &atom_dim),
           NC_ATOM_STR );
       NCERRX( nc_def_dim(ncid, NC_CELL_SPATIAL_STR, 3, &cell_spatial_dim),
@@ -372,13 +387,33 @@ void DumpNetCDF::openfile()
       NCERRX( nc_def_dim(ncid, NC_LABEL_STR, 10, &label_dim),
           NC_LABEL_STR );
 
+      for (int i = 0; i < n_perat; i++) {
+        int dims = perat[i].dims;
+        if (vector_dim[dims] < 0) {
+          char dimstr[1024];
+          if (dims == 3) {
+            strcpy(dimstr, NC_SPATIAL_STR);
+          }
+          else if (dims == 6) {
+            strcpy(dimstr, NC_VOIGT_STR);
+          }
+          else {
+            sprintf(dimstr, "vec%i", dims);
+          }
+          if (dims != 1) {
+            NCERRX( nc_def_dim(ncid, dimstr, dims, &vector_dim[dims]),
+                    dimstr );
+          }
+        }
+      }
+
       // default variables
-      dims[0] = spatial_dim;
+      dims[0] = vector_dim[3];
       NCERRX( nc_def_var(ncid, NC_SPATIAL_STR, NC_CHAR, 1, dims, &spatial_var),
           NC_SPATIAL_STR );
       NCERRX( nc_def_var(ncid, NC_CELL_SPATIAL_STR, NC_CHAR, 1, dims,
              &cell_spatial_var), NC_CELL_SPATIAL_STR );
-      dims[0] = spatial_dim;
+      dims[0] = vector_dim[3];
       dims[1] = label_dim;
       NCERRX( nc_def_var(ncid, NC_CELL_ANGULAR_STR, NC_CHAR, 2, dims,
              &cell_angular_var), NC_CELL_ANGULAR_STR );
@@ -400,7 +435,7 @@ void DumpNetCDF::openfile()
       // variables specified in the input file
       dims[0] = frame_dim;
       dims[1] = atom_dim;
-      dims[2] = spatial_dim;
+      dims[2] = vector_dim[3];
 
       for (int i = 0; i < n_perat; i++) {
         nc_type xtype;
@@ -419,53 +454,27 @@ void DumpNetCDF::openfile()
 
         if (perat[i].constant) {
           // this quantity will only be written once
-          if (perat[i].dims == 6) {
-            // this is a tensor in Voigt notation
-            dims[2] = Voigt_dim;
-            NCERRX( nc_def_var(ncid, perat[i].name, xtype, 2, dims+1,
-                   &perat[i].var), perat[i].name );
-          }
-          else if (perat[i].dims == 3) {
-            // this is a vector, we need to store x-, y- and z-coordinates
-            dims[2] = spatial_dim;
-            NCERRX( nc_def_var(ncid, perat[i].name, xtype, 2, dims+1,
-                   &perat[i].var), perat[i].name );
-          }
-          else if (perat[i].dims == 1) {
+          if (perat[i].dims == 1) {
             NCERRX( nc_def_var(ncid, perat[i].name, xtype, 1, dims+1,
-                   &perat[i].var), perat[i].name );
+                               &perat[i].var), perat[i].name );
           }
           else {
-            char errstr[1024];
-            sprintf(errstr, "%i dimensions for '%s'. Not sure how to write "
-                    "this to the NetCDF trajectory file.", perat[i].dims,
-                    perat[i].name);
-            error->all(FLERR,errstr);
+            // this is a vector
+            dims[1] = vector_dim[perat[i].dims];
+            NCERRX( nc_def_var(ncid, perat[i].name, xtype, 2, dims+1,
+                               &perat[i].var), perat[i].name );
           }
         }
         else {
-          if (perat[i].dims == 6) {
-            // this is a tensor in Voigt notation
-            dims[2] = Voigt_dim;
-            NCERRX( nc_def_var(ncid, perat[i].name, xtype, 3, dims,
-                   &perat[i].var), perat[i].name );
-          }
-          else if (perat[i].dims == 3) {
-            // this is a vector, we need to store x-, y- and z-coordinates
-            dims[2] = spatial_dim;
-            NCERRX( nc_def_var(ncid, perat[i].name, xtype, 3, dims,
-                   &perat[i].var), perat[i].name );
-          }
-          else if (perat[i].dims == 1) {
+          if (perat[i].dims == 1) {
             NCERRX( nc_def_var(ncid, perat[i].name, xtype, 2, dims,
                    &perat[i].var), perat[i].name );
           }
           else {
-            char errstr[1024];
-            sprintf(errstr, "%i dimensions for '%s'. Not sure how to write "
-                    "this to the NetCDF trajectory file.", perat[i].dims,
-                    perat[i].name);
-            error->all(FLERR,errstr);
+            // this is a vector
+            dims[2] = vector_dim[perat[i].dims];
+            NCERRX( nc_def_var(ncid, perat[i].name, xtype, 3, dims,
+                               &perat[i].var), perat[i].name );
           }
         }
       }

--- a/src/USER-NETCDF/dump_netcdf.h
+++ b/src/USER-NETCDF/dump_netcdf.h
@@ -72,8 +72,7 @@ class DumpNetCDF : public DumpCustom {
   int ncid;
 
   int frame_dim;
-  int spatial_dim;
-  int Voigt_dim;
+  int vector_dim[DUMP_NC_MAX_DIMS];
   int atom_dim;
   int cell_spatial_dim;
   int cell_angular_dim;

--- a/src/USER-NETCDF/dump_netcdf_mpiio.cpp
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.cpp
@@ -278,6 +278,9 @@ void DumpNetCDFMPIIO::openfile()
 
   // get total number of atoms
   ntotalgr = group->count(igroup);
+  for (int i = 0; i < DUMP_NC_MPIIO_MAX_DIMS; i++) {
+    vector_dim[i] = -1;
+  }
 
   if (append_flag && !multifile && access(filecurrent, F_OK) != -1) {
     // Fixme! Perform checks if dimensions and variables conform with
@@ -294,15 +297,32 @@ void DumpNetCDFMPIIO::openfile()
 
     // dimensions
     NCERRX( ncmpi_inq_dimid(ncid, NC_FRAME_STR, &frame_dim), NC_FRAME_STR );
-    NCERRX( ncmpi_inq_dimid(ncid, NC_SPATIAL_STR, &spatial_dim),
-            NC_SPATIAL_STR );
-    NCERRX( ncmpi_inq_dimid(ncid, NC_VOIGT_STR, &Voigt_dim), NC_VOIGT_STR );
     NCERRX( ncmpi_inq_dimid(ncid, NC_ATOM_STR, &atom_dim), NC_ATOM_STR );
     NCERRX( ncmpi_inq_dimid(ncid, NC_CELL_SPATIAL_STR, &cell_spatial_dim),
             NC_CELL_SPATIAL_STR );
     NCERRX( ncmpi_inq_dimid(ncid, NC_CELL_ANGULAR_STR, &cell_angular_dim),
             NC_CELL_ANGULAR_STR );
     NCERRX( ncmpi_inq_dimid(ncid, NC_LABEL_STR, &label_dim), NC_LABEL_STR );
+
+    for (int i = 0; i < n_perat; i++) {
+      int dims = perat[i].dims;
+      if (vector_dim[dims] < 0) {
+        char dimstr[1024];
+        if (dims == 3) {
+          strcpy(dimstr, NC_SPATIAL_STR);
+        }
+        else if (dims == 6) {
+          strcpy(dimstr, NC_VOIGT_STR);
+        }
+        else {
+          sprintf(dimstr, "vec%i", dims);
+        }
+        if (dims != 1) {
+          NCERRX( ncmpi_inq_dimid(ncid, dimstr, &vector_dim[dims]),
+                  dimstr );
+        }
+      }
+    }
 
     // default variables
     NCERRX( ncmpi_inq_varid(ncid, NC_SPATIAL_STR, &spatial_var),
@@ -358,10 +378,6 @@ void DumpNetCDFMPIIO::openfile()
     // dimensions
     NCERRX( ncmpi_def_dim(ncid, NC_FRAME_STR, NC_UNLIMITED, &frame_dim),
             NC_FRAME_STR );
-    NCERRX( ncmpi_def_dim(ncid, NC_SPATIAL_STR, 3, &spatial_dim),
-            NC_SPATIAL_STR );
-    NCERRX( ncmpi_def_dim(ncid, NC_VOIGT_STR, 6, &Voigt_dim),
-            NC_VOIGT_STR );
     NCERRX( ncmpi_def_dim(ncid, NC_ATOM_STR, ntotalgr, &atom_dim),
             NC_ATOM_STR );
     NCERRX( ncmpi_def_dim(ncid, NC_CELL_SPATIAL_STR, 3, &cell_spatial_dim),
@@ -371,13 +387,33 @@ void DumpNetCDFMPIIO::openfile()
     NCERRX( ncmpi_def_dim(ncid, NC_LABEL_STR, 10, &label_dim),
             NC_LABEL_STR );
 
+    for (int i = 0; i < n_perat; i++) {
+      int dims = perat[i].dims;
+      if (vector_dim[dims] < 0) {
+        char dimstr[1024];
+        if (dims == 3) {
+          strcpy(dimstr, NC_SPATIAL_STR);
+        }
+        else if (dims == 6) {
+          strcpy(dimstr, NC_VOIGT_STR);
+        }
+        else {
+          sprintf(dimstr, "vec%i", dims);
+        }
+        if (dims != 1) {
+          NCERRX( ncmpi_def_dim(ncid, dimstr, dims, &vector_dim[dims]),
+                  dimstr );
+        }
+      }
+    }
+
     // default variables
-    dims[0] = spatial_dim;
+    dims[0] = vector_dim[3];
     NCERRX( ncmpi_def_var(ncid, NC_SPATIAL_STR, NC_CHAR, 1, dims, &spatial_var),
             NC_SPATIAL_STR );
     NCERRX( ncmpi_def_var(ncid, NC_CELL_SPATIAL_STR, NC_CHAR, 1, dims,
                           &cell_spatial_var), NC_CELL_SPATIAL_STR );
-    dims[0] = spatial_dim;
+    dims[0] = vector_dim[3];
     dims[1] = label_dim;
     NCERRX( ncmpi_def_var(ncid, NC_CELL_ANGULAR_STR, NC_CHAR, 2, dims,
                           &cell_angular_var), NC_CELL_ANGULAR_STR );
@@ -399,7 +435,7 @@ void DumpNetCDFMPIIO::openfile()
     // variables specified in the input file
     dims[0] = frame_dim;
     dims[1] = atom_dim;
-    dims[2] = spatial_dim;
+    dims[2] = vector_dim[3];
 
     for (int i = 0; i < n_perat; i++) {
       nc_type xtype;
@@ -416,28 +452,15 @@ void DumpNetCDFMPIIO::openfile()
           xtype = NC_FLOAT;
       }
 
-      if (perat[i].dims == 6) {
-        // this is a tensor in Voigt notation
-        dims[2] = Voigt_dim;
-        NCERRX( ncmpi_def_var(ncid, perat[i].name, xtype, 3, dims,
-                                &perat[i].var), perat[i].name );
-      }
-      else if (perat[i].dims == 3) {
-        // this is a vector, we need to store x-, y- and z-coordinates
-        dims[2] = spatial_dim;
-        NCERRX( ncmpi_def_var(ncid, perat[i].name, xtype, 3, dims,
-                              &perat[i].var), perat[i].name );
-      }
-      else if (perat[i].dims == 1) {
+      if (perat[i].dims == 1) {
         NCERRX( ncmpi_def_var(ncid, perat[i].name, xtype, 2, dims,
                               &perat[i].var), perat[i].name );
       }
       else {
-        char errstr[1024];
-        sprintf(errstr, "%i dimensions for '%s'. Not sure how to write "
-                "this to the NetCDF trajectory file.", perat[i].dims,
-                perat[i].name);
-        error->all(FLERR,errstr);
+        // this is a vector
+        dims[2] = vector_dim[perat[i].dims];
+        NCERRX( ncmpi_def_var(ncid, perat[i].name, xtype, 3, dims,
+                              &perat[i].var), perat[i].name );
       }
     }
 

--- a/src/USER-NETCDF/dump_netcdf_mpiio.h
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.h
@@ -71,8 +71,7 @@ class DumpNetCDFMPIIO : public DumpCustom {
   int ncid;
 
   int frame_dim;
-  int spatial_dim;
-  int Voigt_dim;
+  int vector_dim[DUMP_NC_MPIIO_MAX_DIMS];
   int atom_dim;
   int cell_spatial_dim;
   int cell_angular_dim;


### PR DESCRIPTION
## Purpose

Right now, the NetCDF output was limited to outputting computes or fixes of length 3 (vectors) and 6 (tensors). This has been extended to allow for arbitrary length.


## Author(s)

Lars Pastewka, University of Freiburg

## Backward Compatibility

Backwards compatibility is not broken.



