### PR TITLE
Fix in extract() method of pair_thole

### DIFF
--- a/src/USER-DRUDE/pair_lj_cut_thole_long.cpp
+++ b/src/USER-DRUDE/pair_lj_cut_thole_long.cpp
@@ -683,7 +683,7 @@ void *PairLJCutTholeLong::extract(const char *str, int &dim)
 {
   dim = 0;
   if (strcmp(str,"cut_coul") == 0) return (void *) &cut_coul;
-  dim = 6;
+  dim = 2;
   if (strcmp(str,"epsilon") == 0) return (void *) epsilon;
   if (strcmp(str,"sigma") == 0) return (void *) sigma;
   if (strcmp(str,"scale") == 0) return (void *) scale;

--- a/src/USER-DRUDE/pair_thole.cpp
+++ b/src/USER-DRUDE/pair_thole.cpp
@@ -414,7 +414,7 @@ double PairThole::single(int i, int j, int itype, int jtype,
 
 void *PairThole::extract(const char *str, int &dim)
 {
-  dim = 4;
+  dim = 2;
   if (strcmp(str,"scale") == 0) return (void *) scale;
   if (strcmp(str,"polar") == 0) return (void *) polar;
   if (strcmp(str,"thole") == 0) return (void *) thole;


### PR DESCRIPTION
## Purpose

Minor correction in extract() method of Thole pair styles.

## Author(s)

Agilio Padua

## Backward Compatibility

No issues

## Implementation Notes

The value of the dim variable was corrected.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines

## Further Information, Files, and Links

