### PR TITLE
compute entropy/atom - enhancement

### DIFF
--- a/examples/USER/misc/entropy/log.entropy
+++ b/examples/USER/misc/entropy/log.entropy
@@ -1,4 +1,4 @@
-LAMMPS (30 Mar 2018)
+LAMMPS (4 Jan 2019)
 
 units		metal
 atom_style	full
@@ -45,10 +45,10 @@ fix             1 all nph x 1. 1. 10.
 fix             2 all temp/csvr 350. 350. 0.1 64582
 
 run             1000
-WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:138)
-WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:138)
-WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:138)
-WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:138)
+WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:139)
+WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:139)
+WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:139)
+WARNING: More than one compute entropy/atom (../compute_entropy_atom.cpp:139)
 Neighbor list info ...
   update every 1 steps, delay 10 steps, check yes
   max neighbors/atom: 2000, page size: 100000
@@ -56,27 +56,27 @@ Neighbor list info ...
   ghost atom cutoff = 13.2
   binsize = 6.6, bins = 21 6 6
   5 neighbor lists, perpetual/occasional/extra = 5 0 0
-  (1) pair eam/fs, perpetual
+  (1) pair eam/fs, perpetual, half/full from (2)
       attributes: half, newton on
-      pair build: half/bin/newton/tri
-      stencil: half/bin/3d/newton/tri
-      bin: standard
+      pair build: halffull/newton
+      stencil: none
+      bin: none
   (2) compute entropy/atom, perpetual
+      attributes: full, newton on
+      pair build: full/bin
+      stencil: full/bin/3d
+      bin: standard
+  (3) compute entropy/atom, perpetual, copy from (2)
+      attributes: full, newton on
+      pair build: copy
+      stencil: none
+      bin: none
+  (4) compute entropy/atom, perpetual
       attributes: full, newton on, ghost
       pair build: full/bin/ghost
       stencil: full/ghost/bin/3d
       bin: standard
-  (3) compute entropy/atom, perpetual, copy from (2)
-      attributes: full, newton on, ghost
-      pair build: copy
-      stencil: none
-      bin: none
-  (4) compute entropy/atom, perpetual, copy from (2)
-      attributes: full, newton on, ghost
-      pair build: copy
-      stencil: none
-      bin: none
-  (5) compute entropy/atom, perpetual, copy from (2)
+  (5) compute entropy/atom, perpetual, copy from (4)
       attributes: full, newton on, ghost
       pair build: copy
       stencil: none
@@ -85,34 +85,34 @@ Setting up Verlet run ...
   Unit style    : metal
   Current step  : 0
   Time step     : 0.002
-Per MPI rank memory allocation (min/avg/max) = 25.68 | 25.69 | 25.69 Mbytes
+Per MPI rank memory allocation (min/avg/max) = 19.6 | 19.6 | 19.6 Mbytes
 Step Temp E_pair E_mol TotEng Press Volume 
        0    346.29871    -4285.222            0   -4101.9191    594.65353    165399.75 
-     500    359.33758    -4285.247            0   -4095.0423    471.98587    165847.18 
-    1000    348.99659   -4276.2274            0   -4091.4964    149.27188    166966.18 
-Loop time of 5.3437 on 4 procs for 1000 steps with 4096 atoms
+     500    359.33769   -4285.2472            0   -4095.0424    472.02043    165847.09 
+    1000    348.99683   -4276.2282            0   -4091.4971    149.38771    166965.86 
+Loop time of 4.4394 on 4 procs for 1000 steps with 4096 atoms
 
-Performance: 32.337 ns/day, 0.742 hours/ns, 187.136 timesteps/s
-99.8% CPU use with 4 MPI tasks x no OpenMP threads
+Performance: 38.924 ns/day, 0.617 hours/ns, 225.256 timesteps/s
+99.5% CPU use with 4 MPI tasks x no OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 4.2832     | 4.3257     | 4.3839     |   1.8 | 80.95
-Bond    | 0.00018309 | 0.00019825 | 0.00021418 |   0.0 |  0.00
-Neigh   | 0.42195    | 0.42512    | 0.42739    |   0.3 |  7.96
-Comm    | 0.051679   | 0.1101     | 0.14916    |  10.8 |  2.06
-Output  | 0.40909    | 0.4091     | 0.40911    |   0.0 |  7.66
-Modify  | 0.060869   | 0.061921   | 0.06327    |   0.4 |  1.16
-Other   |            | 0.01161    |            |       |  0.22
+Pair    | 3.5298     | 3.5931     | 3.6669     |   2.6 | 80.94
+Bond    | 8.2099e-05 | 0.00011444 | 0.00014673 |   0.0 |  0.00
+Neigh   | 0.43384    | 0.4445     | 0.45558    |   1.4 | 10.01
+Comm    | 0.048904   | 0.11122    | 0.16728    |  12.7 |  2.51
+Output  | 0.22595    | 0.22595    | 0.22596    |   0.0 |  5.09
+Modify  | 0.053103   | 0.053795   | 0.054549   |   0.3 |  1.21
+Other   |            | 0.01068    |            |       |  0.24
 
 Nlocal:    1024 ave 1040 max 1001 min
 Histogram: 1 0 0 0 0 0 2 0 0 1
 Nghost:    4614.25 ave 4700 max 4540 min
 Histogram: 1 1 0 0 0 0 0 1 0 1
-Neighs:    121747 ave 126398 max 116931 min
+Neighs:    121747 ave 126398 max 116930 min
 Histogram: 1 0 0 1 0 0 1 0 0 1
-FullNghs:  243494 ave 252523 max 233842 min
+FullNghs:  243494 ave 252523 max 233841 min
 Histogram: 1 0 0 1 0 0 1 0 0 1
 
 Total # of neighbors = 973974
@@ -121,4 +121,4 @@ Ave special neighs/atom = 0
 Neighbor list builds = 13
 Dangerous builds = 0
 
-Total wall time: 0:00:05
+Total wall time: 0:00:04

--- a/src/USER-MISC/compute_entropy_atom.cpp
+++ b/src/USER-MISC/compute_entropy_atom.cpp
@@ -65,6 +65,7 @@ ComputeEntropyAtom(LAMMPS *lmp, int narg, char **arg) :
   if (cutoff <= 0.0) error->all(FLERR,"Illegal compute entropy/atom"
                                " command; cutoff must be positive");
 
+  cutoff2 = 0.;
   avg_flag = 0;
   local_flag = 0;
 
@@ -137,15 +138,20 @@ void ComputeEntropyAtom::init()
   if (count > 1 && comm->me == 0)
     error->warning(FLERR,"More than one compute entropy/atom");
 
-  // need a full neighbor list with neighbors of the ghost atoms
-
+  // Request neighbor list
   int irequest = neighbor->request(this,instance_me);
   neighbor->requests[irequest]->pair = 0;
   neighbor->requests[irequest]->compute = 1;
   neighbor->requests[irequest]->half = 0;
   neighbor->requests[irequest]->full = 1;
   neighbor->requests[irequest]->occasional = 0;
-  neighbor->requests[irequest]->ghost = 1;
+  if (avg_flag) {
+    // need a full neighbor list with neighbors of the ghost atoms
+    neighbor->requests[irequest]->ghost = 1;
+  } else {
+    // need a full neighbor list
+    neighbor->requests[irequest]->ghost = 0;
+  }
 
 }
 


### PR DESCRIPTION
## Purpose

This pull request contains an enhancement of the compute entropy/atom command. The previous implementation requests always a neighbor list including the neighbors of ghost atoms. Here I request this type of neighbor list only when needed, this is to say, when the _avg yes_ option is used in the command. This modification should make the calculations faster when the _avg yes_ option is not used. According to my benchmarks, this change makes the calculation at least 10% faster.

## Author(s)

Pablo Piaggi (EPFL)

## Backward Compatibility

Fully backwards compatible

## Implementation Notes

Correctness was verified by comparing the new and the old results of the example in examples/USER/misc/entropy

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the LAMMPS formatting guidelines

## Further Information

I also propose to change the example in examples/USER/misc/entropy such that instead of using the EAM potential Na_MendelevM_2014.eam.fs contained in that folder, a LJ potential or one of the potentials included already in Lammps is used. This would remove the Na_MendelevM_2014.eam.fs file that weighs 1 Mb. I haven't done this yet but I am willing to do it if you consider it relevant. 


