### PR TITLE
Support using fix qeq/shielded with pair style reax/c

### DIFF
--- a/doc/src/fix_qeq.txt
+++ b/doc/src/fix_qeq.txt
@@ -22,7 +22,7 @@ Nevery = perform charge equilibration every this many steps :l
 cutoff = global cutoff for charge-charge interactions (distance unit) :l
 tolerance = precision to which charges will be equilibrated :l
 maxiter = maximum iterations to perform charge equilibration :l
-qfile = a filename with QEq parameters :l
+qfile = a filename with QEq parameters or {coul/streitz} or {reax/c} :l
 
 zero or more keyword/value pairs may be appended :l
 keyword = {alpha} or {qdamp} or {qstep} :l
@@ -122,7 +122,9 @@ field"_#vanDuin paper.  The shielding accounts for charge overlap
 between charged particles at small separation.  This style is the same
 as "fix qeq/reax"_fix_qeq_reax.html, and can be used with "pair_style
 reax/c"_pair_reaxc.html.  Only the {chi}, {eta}, and {gamma}
-parameters from the {qfile} file are used.  This style solves partial
+parameters from the {qfile} file are used. When using the string
+{reax/c} as filename, these parameters are extracted directly from
+an active {reax/c} pair style.  This style solves partial
 charges on atoms via the matrix inversion method.  A tolerance of
 1.0e-6 is usually a good number.
 
@@ -132,7 +134,9 @@ that the interaction between a pair of charged particles is the
 product of two Slater 1{s} orbitals.  The expression for the Slater
 1{s} orbital is given under equation (6) of the
 "Streitz-Mintmire"_#Streitz1 paper.  Only the {chi}, {eta}, {zeta}, and
-{qcore} parameters from the {qfile} file are used.  This style solves
+{qcore} parameters from the {qfile} file are used. When using the string
+{coul/streitz} as filename, these parameters are extracted directly from
+an active {coul/streitz} pair style.  This style solves
 partial charges on atoms via the matrix inversion method.  A tolerance
 of 1.0e-6 is usually a good number.  Keyword {alpha} can be used to
 change the Slater type orbital exponent.

--- a/examples/reax/in.reaxc.rdx-shielded
+++ b/examples/reax/in.reaxc.rdx-shielded
@@ -1,0 +1,52 @@
+# ReaxFF potential for RDX system
+# this run is equivalent to reax/in.reax.rdx
+
+units		real
+
+atom_style	charge
+read_data	data.rdx
+
+pair_style      reax/c control.reax_c.rdx
+pair_coeff      * * ffield.reax C H O N
+
+compute reax all pair reax/c
+
+variable eb  	 equal c_reax[1]
+variable ea  	 equal c_reax[2]
+variable elp 	 equal c_reax[3]
+variable emol 	 equal c_reax[4]
+variable ev 	 equal c_reax[5]
+variable epen 	 equal c_reax[6]
+variable ecoa 	 equal c_reax[7]
+variable ehb 	 equal c_reax[8]
+variable et 	 equal c_reax[9]
+variable eco 	 equal c_reax[10]
+variable ew 	 equal c_reax[11]
+variable ep 	 equal c_reax[12]
+variable efi 	 equal c_reax[13]
+variable eqeq 	 equal c_reax[14]
+
+neighbor	2.5 bin
+neigh_modify	every 10 delay 0 check no
+
+fix		1 all nve
+fix             2 all qeq/shielded 1 10.0 1.0e-6 100 reax/c
+
+thermo		10
+thermo_style 	custom step temp epair etotal press &
+		v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa &
+		v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq
+
+timestep	1.0
+
+#dump		1 all atom 10 dump.reaxc.rdx
+
+#dump		2 all image 25 image.*.jpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 25 movie.mpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+run		100

--- a/examples/reax/in.reaxc.tatb-shielded
+++ b/examples/reax/in.reaxc.tatb-shielded
@@ -1,0 +1,55 @@
+# ReaxFF potential for TATB system
+# this run is equivalent to reax/in.reax.tatb,
+
+units		real
+
+atom_style	charge
+read_data	data.tatb
+
+pair_style      reax/c control.reax_c.tatb
+pair_coeff      * * ffield.reax C H O N
+
+compute reax all pair reax/c
+
+variable eb  	 equal c_reax[1]
+variable ea  	 equal c_reax[2]
+variable elp 	 equal c_reax[3]
+variable emol 	 equal c_reax[4]
+variable ev 	 equal c_reax[5]
+variable epen 	 equal c_reax[6]
+variable ecoa 	 equal c_reax[7]
+variable ehb 	 equal c_reax[8]
+variable et 	 equal c_reax[9]
+variable eco 	 equal c_reax[10]
+variable ew 	 equal c_reax[11]
+variable ep 	 equal c_reax[12]
+variable efi 	 equal c_reax[13]
+variable eqeq 	 equal c_reax[14]
+
+neighbor	2.5 bin
+neigh_modify	delay 0 every 5 check no
+
+fix		1 all nve
+fix             2 all qeq/shielded 1 10.0 1.0e-6 100 reax/c
+fix   		4 all reax/c/bonds 5 bonds.reaxc
+
+thermo		5
+thermo_style 	custom step temp epair etotal press &
+		v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa &
+		v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq
+
+timestep	0.0625
+
+#dump		1 all custom 100 dump.reaxc.tatb id type q x y z
+
+#dump		2 all image 5 image.*.jpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 5 movie.mpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+fix 		3 all reax/c/species 1 5 5 species.tatb
+
+run		25

--- a/examples/reax/log.4Jan19.reaxc.rdx-shielded.g++.1
+++ b/examples/reax/log.4Jan19.reaxc.rdx-shielded.g++.1
@@ -1,0 +1,116 @@
+LAMMPS (4 Jan 2019)
+# ReaxFF potential for RDX system
+# this run is equivalent to reax/in.reax.rdx
+
+units		real
+
+atom_style	charge
+read_data	data.rdx
+  orthogonal box = (35 35 35) to (48 48 48)
+  1 by 1 by 1 MPI processor grid
+  reading atoms ...
+  21 atoms
+
+pair_style      reax/c control.reax_c.rdx
+pair_coeff      * * ffield.reax C H O N
+Reading potential file ffield.reax with DATE: 2010-02-19
+
+compute reax all pair reax/c
+
+variable eb  	 equal c_reax[1]
+variable ea  	 equal c_reax[2]
+variable elp 	 equal c_reax[3]
+variable emol 	 equal c_reax[4]
+variable ev 	 equal c_reax[5]
+variable epen 	 equal c_reax[6]
+variable ecoa 	 equal c_reax[7]
+variable ehb 	 equal c_reax[8]
+variable et 	 equal c_reax[9]
+variable eco 	 equal c_reax[10]
+variable ew 	 equal c_reax[11]
+variable ep 	 equal c_reax[12]
+variable efi 	 equal c_reax[13]
+variable eqeq 	 equal c_reax[14]
+
+neighbor	2.5 bin
+neigh_modify	every 10 delay 0 check no
+
+fix		1 all nve
+fix             2 all qeq/shielded 1 10.0 1.0e-6 100 reax/c
+
+thermo		10
+thermo_style 	custom step temp epair etotal press 		v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa 		v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq
+
+timestep	1.0
+
+#dump		1 all atom 10 dump.reaxc.rdx
+
+#dump		2 all image 25 image.*.jpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 25 movie.mpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+run		100
+Neighbor list info ...
+  update every 10 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 12.5
+  ghost atom cutoff = 12.5
+  binsize = 6.25, bins = 3 3 3
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: half/ghost/bin/3d/newtoff
+      bin: standard
+  (2) fix qeq/shielded, perpetual
+      attributes: full, newton on
+      pair build: full/bin/atomonly
+      stencil: full/bin/3d
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 15.54 | 15.54 | 15.54 Mbytes
+Step Temp E_pair TotEng Press v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq 
+       0            0   -1884.3081   -1884.3081    27186.181   -2958.4712    79.527715   0.31082031            0    98.589783    25.846176  -0.18034154            0    16.709078   -9.1620736    938.43732   -244.79939            0    168.88404 
+      10    1288.6115   -1989.6644   -1912.8422   -19456.353   -2734.6769    -15.60722    0.2017796            0    54.629557    3.1252289     -77.7067            0    14.933901   -5.8108542    843.92073   -180.43321            0    107.75934 
+      20    538.95832   -1942.7037   -1910.5731   -10725.665   -2803.7395    7.9078296  0.077926657            0     81.61005   0.22951928     -57.5571            0    30.331204   -10.178049    878.99014   -159.69088            0     89.31512 
+      30    463.09535   -1933.5765   -1905.9685   -33255.521   -2749.8591   -8.0154561  0.027628873            0     81.62739   0.11972409   -50.262289            0    20.820315   -9.6327029    851.88723   -149.49502            0    79.205749 
+      40    885.49232   -1958.9126   -1906.1229    -4814.704    -2795.644    9.1506683   0.13747502            0    70.947988    0.2436053   -57.862679            0    19.076499   -11.141216    873.73896   -159.99392            0    92.434085 
+      50    861.16622   -1954.4599   -1903.1204   -1896.7878   -2784.8448    3.8269901   0.15793272            0    79.851828    3.3492155   -78.066128            0    32.628996   -7.9565333    872.81832   -190.98567            0    114.75995 
+      60    1167.7852    -1971.843   -1902.2241   -3482.6875   -2705.8632   -17.121673   0.22749075            0    44.507672     7.856086   -74.788945            0    16.256491   -4.6046463    835.83056   -188.33693            0    114.19414 
+      70     1439.997   -1989.3024   -1903.4553    23845.434   -2890.7895    31.958869   0.26671726            0    85.758681    3.1803462   -71.002898            0     24.35711   -10.311314    905.86781   -175.38471            0    106.79648 
+      80    502.39629   -1930.7545   -1900.8035   -20356.384   -2703.8111    -18.66263   0.11286065            0    99.804114    2.0329076   -76.171338            0     19.23692   -6.2786691    826.47429   -166.03132            0    92.539464 
+      90    749.08722   -1946.9837   -1902.3259    17798.557   -2863.7579    42.068808   0.24338058            0    96.181716   0.96183793   -69.955449            0    24.615308    -11.58277    903.68837   -190.13841            0     120.6914 
+     100    1109.6997   -1968.5874   -1902.4313   -4490.2776    -2755.896   -7.1232734   0.21757686            0    61.806176    7.0827207   -75.645383            0    20.114879   -6.2371839    863.56324   -198.56967            0    122.09951 
+Loop time of 0.657427 on 1 procs for 100 steps with 21 atoms
+
+Performance: 13.142 ns/day, 1.826 hours/ns, 152.108 timesteps/s
+99.3% CPU use with 1 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.59308    | 0.59308    | 0.59308    |   0.0 | 90.21
+Neigh   | 0.020665   | 0.020665   | 0.020665   |   0.0 |  3.14
+Comm    | 0.0015757  | 0.0015757  | 0.0015757  |   0.0 |  0.24
+Output  | 0.00039387 | 0.00039387 | 0.00039387 |   0.0 |  0.06
+Modify  | 0.04156    | 0.04156    | 0.04156    |   0.0 |  6.32
+Other   |            | 0.000154   |            |       |  0.02
+
+Nlocal:    21 ave 21 max 21 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:    546 ave 546 max 546 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:    1096 ave 1096 max 1096 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+FullNghs:  1306 ave 1306 max 1306 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 1306
+Ave neighs/atom = 62.1905
+Neighbor list builds = 10
+Dangerous builds not checked
+
+Please see the log.cite file for references relevant to this simulation
+
+Total wall time: 0:00:00

--- a/examples/reax/log.4Jan19.reaxc.rdx-shielded.g++.4
+++ b/examples/reax/log.4Jan19.reaxc.rdx-shielded.g++.4
@@ -1,0 +1,116 @@
+LAMMPS (4 Jan 2019)
+# ReaxFF potential for RDX system
+# this run is equivalent to reax/in.reax.rdx
+
+units		real
+
+atom_style	charge
+read_data	data.rdx
+  orthogonal box = (35 35 35) to (48 48 48)
+  1 by 2 by 2 MPI processor grid
+  reading atoms ...
+  21 atoms
+
+pair_style      reax/c control.reax_c.rdx
+pair_coeff      * * ffield.reax C H O N
+Reading potential file ffield.reax with DATE: 2010-02-19
+
+compute reax all pair reax/c
+
+variable eb  	 equal c_reax[1]
+variable ea  	 equal c_reax[2]
+variable elp 	 equal c_reax[3]
+variable emol 	 equal c_reax[4]
+variable ev 	 equal c_reax[5]
+variable epen 	 equal c_reax[6]
+variable ecoa 	 equal c_reax[7]
+variable ehb 	 equal c_reax[8]
+variable et 	 equal c_reax[9]
+variable eco 	 equal c_reax[10]
+variable ew 	 equal c_reax[11]
+variable ep 	 equal c_reax[12]
+variable efi 	 equal c_reax[13]
+variable eqeq 	 equal c_reax[14]
+
+neighbor	2.5 bin
+neigh_modify	every 10 delay 0 check no
+
+fix		1 all nve
+fix             2 all qeq/shielded 1 10.0 1.0e-6 100 reax/c
+
+thermo		10
+thermo_style 	custom step temp epair etotal press 		v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa 		v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq
+
+timestep	1.0
+
+#dump		1 all atom 10 dump.reaxc.rdx
+
+#dump		2 all image 25 image.*.jpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 25 movie.mpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+run		100
+Neighbor list info ...
+  update every 10 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 12.5
+  ghost atom cutoff = 12.5
+  binsize = 6.25, bins = 3 3 3
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: half/ghost/bin/3d/newtoff
+      bin: standard
+  (2) fix qeq/shielded, perpetual
+      attributes: full, newton on
+      pair build: full/bin/atomonly
+      stencil: full/bin/3d
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 10.62 | 12.08 | 13.84 Mbytes
+Step Temp E_pair TotEng Press v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq 
+       0            0   -1884.3081   -1884.3081    27186.178   -2958.4712    79.527715   0.31082031            0    98.589783    25.846176  -0.18034154            0    16.709078   -9.1620736    938.43732   -244.79987            0    168.88452 
+      10    1288.6116   -1989.6644   -1912.8422   -19456.355   -2734.6769    -15.60722    0.2017796            0    54.629559    3.1252284     -77.7067            0    14.933902   -5.8108544    843.92073   -180.43321            0    107.75934 
+      20    538.95818   -1942.7037   -1910.5731   -10725.629   -2803.7394    7.9078295  0.077926694            0     81.61005   0.22951941   -57.557106            0    30.331206   -10.178049     878.9901   -159.68969            0    89.313929 
+      30    463.09529   -1933.5765   -1905.9685   -33255.529    -2749.859   -8.0154758  0.027628845            0    81.627406    0.1197241    -50.26229            0     20.82031   -9.6327013    851.88715   -149.49497            0    79.205706 
+      40    885.49462   -1958.9125   -1906.1227   -4814.6528   -2795.6439    9.1506212   0.13747486            0     70.94804   0.24360501   -57.862675            0    19.076509   -11.141214     873.7389   -159.99391            0    92.434076 
+      50    861.16112   -1954.4601    -1903.121   -1896.6704   -2784.8452    3.8270543   0.15793292            0    79.851662    3.3492078   -78.066133            0    32.628979   -7.9565431    872.81857    -190.9857            0    114.75999 
+      60    1167.7837   -1971.8434   -1902.2245   -3482.8961   -2705.8635   -17.121601   0.22749083            0    44.507696    7.8559922   -74.789025            0    16.256492   -4.6046625    835.83053   -188.33688            0    114.19412 
+      70    1439.9917   -1989.3024   -1903.4555    23845.887   -2890.7894    31.958677   0.26671714            0    85.758424    3.1804092   -71.002955            0    24.357221   -10.311284    905.86805   -175.38496            0     106.7967 
+      80    502.39695   -1930.7548   -1900.8039   -20356.331   -2703.8113   -18.662598   0.11286102            0    99.803743    2.0329429   -76.171299            0    19.236922   -6.2786652     826.4744   -166.03139            0    92.539525 
+      90    749.08478    -1946.984   -1902.3264    17798.605   -2863.7581    42.068587   0.24338052            0    96.181622   0.96184063   -69.955519            0    24.615456   -11.582749    903.68853   -190.13827            0    120.69126 
+     100    1109.6952   -1968.5879   -1902.4321   -4490.2728   -2755.8985   -7.1225966   0.21757682            0    61.805902    7.0826502    -75.64544            0    20.115369   -6.2372513    863.56451   -198.56956            0    122.09944 
+Loop time of 0.634333 on 4 procs for 100 steps with 21 atoms
+
+Performance: 13.621 ns/day, 1.762 hours/ns, 157.646 timesteps/s
+93.8% CPU use with 4 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.53395    | 0.5352     | 0.53805    |   0.2 | 84.37
+Neigh   | 0.0088253  | 0.012023   | 0.016203   |   2.4 |  1.90
+Comm    | 0.0051677  | 0.0081     | 0.0093861  |   1.9 |  1.28
+Output  | 0.00049353 | 0.00054371 | 0.00058222 |   0.0 |  0.09
+Modify  | 0.074155   | 0.078299   | 0.081472   |   0.9 | 12.34
+Other   |            | 0.0001715  |            |       |  0.03
+
+Nlocal:    5.25 ave 15 max 0 min
+Histogram: 1 0 2 0 0 0 0 0 0 1
+Nghost:    355.5 ave 432 max 282 min
+Histogram: 1 0 0 0 1 1 0 0 0 1
+Neighs:    298.75 ave 822 max 0 min
+Histogram: 1 0 2 0 0 0 0 0 0 1
+FullNghs:  326.5 ave 927 max 0 min
+Histogram: 1 0 2 0 0 0 0 0 0 1
+
+Total # of neighbors = 1306
+Ave neighs/atom = 62.1905
+Neighbor list builds = 10
+Dangerous builds not checked
+
+Please see the log.cite file for references relevant to this simulation
+
+Total wall time: 0:00:00

--- a/examples/reax/log.4Jan19.reaxc.tatb-shielded.g++.1
+++ b/examples/reax/log.4Jan19.reaxc.tatb-shielded.g++.1
@@ -1,0 +1,114 @@
+LAMMPS (4 Jan 2019)
+# ReaxFF potential for TATB system
+# this run is equivalent to reax/in.reax.tatb,
+
+units		real
+
+atom_style	charge
+read_data	data.tatb
+  triclinic box = (0 0 0) to (13.624 17.1149 15.1826) with tilt (-5.75316 -6.32547 7.42573)
+  1 by 1 by 1 MPI processor grid
+  reading atoms ...
+  384 atoms
+
+pair_style      reax/c control.reax_c.tatb
+pair_coeff      * * ffield.reax C H O N
+Reading potential file ffield.reax with DATE: 2010-02-19
+
+compute reax all pair reax/c
+
+variable eb  	 equal c_reax[1]
+variable ea  	 equal c_reax[2]
+variable elp 	 equal c_reax[3]
+variable emol 	 equal c_reax[4]
+variable ev 	 equal c_reax[5]
+variable epen 	 equal c_reax[6]
+variable ecoa 	 equal c_reax[7]
+variable ehb 	 equal c_reax[8]
+variable et 	 equal c_reax[9]
+variable eco 	 equal c_reax[10]
+variable ew 	 equal c_reax[11]
+variable ep 	 equal c_reax[12]
+variable efi 	 equal c_reax[13]
+variable eqeq 	 equal c_reax[14]
+
+neighbor	2.5 bin
+neigh_modify	delay 0 every 5 check no
+
+fix		1 all nve
+fix             2 all qeq/shielded 1 10.0 1.0e-6 100 reax/c
+fix   		4 all reax/c/bonds 5 bonds.reaxc
+
+thermo		5
+thermo_style 	custom step temp epair etotal press 		v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa 		v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq
+
+timestep	0.0625
+
+#dump		1 all custom 100 dump.reaxc.tatb id type q x y z
+
+#dump		2 all image 5 image.*.jpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 5 movie.mpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+fix 		3 all reax/c/species 1 5 5 species.tatb
+
+run		25
+Neighbor list info ...
+  update every 5 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 12.5
+  ghost atom cutoff = 12.5
+  binsize = 6.25, bins = 5 4 3
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: half/ghost/bin/3d/newtoff
+      bin: standard
+  (2) fix qeq/shielded, perpetual
+      attributes: full, newton on
+      pair build: full/bin/atomonly
+      stencil: full/bin/3d
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 169.6 | 169.6 | 169.6 Mbytes
+Step Temp E_pair TotEng Press v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq 
+       0            0   -44760.998   -44760.998    7827.7879   -61120.591     486.4378    4.7236377            0    1574.1033    20.788929   -279.51642   -1556.4696    252.57147   -655.84699    18862.412   -8740.6394            0    6391.0274 
+       5   0.61603942   -44761.698   -44760.994     8934.628   -61118.769    486.81263    4.7234094            0    1573.9241    20.768834   -278.24084   -1557.6713    252.64377   -655.74435    18859.379    -8738.193            0    6388.6691 
+      10    2.3525549   -44763.227   -44760.541    12288.614   -61113.174    487.82738    4.7226863            0     1573.411    20.705939   -274.50358   -1560.7569    252.85309   -655.44063    18850.391   -8730.9684            0    6381.7061 
+      15    4.9013311    -44766.36   -44760.764    17716.982   -61103.434    489.14721    4.7213644            0    1572.6349    20.593139   -268.56847   -1566.3829    252.95174   -654.96611    18835.777   -8719.2449            0    6370.4111 
+      20    7.8294673   -44769.686   -44760.747    25205.558   -61089.006    490.21313     4.719302            0    1571.7022    20.420943   -260.85565   -1573.7378     253.3539   -654.31623     18816.07   -8703.5142            0    6355.2654 
+      25    10.697904   -44772.904   -44760.691    34232.821   -61069.308    490.25886    4.7163736            0    1570.7397    20.181346   -251.91378   -1582.3261    253.82253   -653.53184    18791.975   -8684.3541            0    6336.8349 
+Loop time of 7.80985 on 1 procs for 25 steps with 384 atoms
+
+Performance: 0.017 ns/day, 1388.418 hours/ns, 3.201 timesteps/s
+100.0% CPU use with 1 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 5.003      | 5.003      | 5.003      |   0.0 | 64.06
+Neigh   | 1.1164     | 1.1164     | 1.1164     |   0.0 | 14.29
+Comm    | 0.0065806  | 0.0065806  | 0.0065806  |   0.0 |  0.08
+Output  | 0.00029969 | 0.00029969 | 0.00029969 |   0.0 |  0.00
+Modify  | 1.6831     | 1.6831     | 1.6831     |   0.0 | 21.55
+Other   |            | 0.0004976  |            |       |  0.01
+
+Nlocal:    384 ave 384 max 384 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:    7559 ave 7559 max 7559 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:    286828 ave 286828 max 286828 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+FullNghs:  336304 ave 336304 max 336304 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 336304
+Ave neighs/atom = 875.792
+Neighbor list builds = 5
+Dangerous builds not checked
+
+Please see the log.cite file for references relevant to this simulation
+
+Total wall time: 0:00:08

--- a/examples/reax/log.4Jan19.reaxc.tatb-shielded.g++.4
+++ b/examples/reax/log.4Jan19.reaxc.tatb-shielded.g++.4
@@ -1,0 +1,114 @@
+LAMMPS (4 Jan 2019)
+# ReaxFF potential for TATB system
+# this run is equivalent to reax/in.reax.tatb,
+
+units		real
+
+atom_style	charge
+read_data	data.tatb
+  triclinic box = (0 0 0) to (13.624 17.1149 15.1826) with tilt (-5.75316 -6.32547 7.42573)
+  1 by 2 by 2 MPI processor grid
+  reading atoms ...
+  384 atoms
+
+pair_style      reax/c control.reax_c.tatb
+pair_coeff      * * ffield.reax C H O N
+Reading potential file ffield.reax with DATE: 2010-02-19
+
+compute reax all pair reax/c
+
+variable eb  	 equal c_reax[1]
+variable ea  	 equal c_reax[2]
+variable elp 	 equal c_reax[3]
+variable emol 	 equal c_reax[4]
+variable ev 	 equal c_reax[5]
+variable epen 	 equal c_reax[6]
+variable ecoa 	 equal c_reax[7]
+variable ehb 	 equal c_reax[8]
+variable et 	 equal c_reax[9]
+variable eco 	 equal c_reax[10]
+variable ew 	 equal c_reax[11]
+variable ep 	 equal c_reax[12]
+variable efi 	 equal c_reax[13]
+variable eqeq 	 equal c_reax[14]
+
+neighbor	2.5 bin
+neigh_modify	delay 0 every 5 check no
+
+fix		1 all nve
+fix             2 all qeq/shielded 1 10.0 1.0e-6 100 reax/c
+fix   		4 all reax/c/bonds 5 bonds.reaxc
+
+thermo		5
+thermo_style 	custom step temp epair etotal press 		v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa 		v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq
+
+timestep	0.0625
+
+#dump		1 all custom 100 dump.reaxc.tatb id type q x y z
+
+#dump		2 all image 5 image.*.jpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+#dump		3 all movie 5 movie.mpg type type #		axes yes 0.8 0.02 view 60 -30
+#dump_modify	3 pad 3
+
+fix 		3 all reax/c/species 1 5 5 species.tatb
+
+run		25
+Neighbor list info ...
+  update every 5 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 12.5
+  ghost atom cutoff = 12.5
+  binsize = 6.25, bins = 5 4 3
+  2 neighbor lists, perpetual/occasional/extra = 2 0 0
+  (1) pair reax/c, perpetual
+      attributes: half, newton off, ghost
+      pair build: half/bin/newtoff/ghost
+      stencil: half/ghost/bin/3d/newtoff
+      bin: standard
+  (2) fix qeq/shielded, perpetual
+      attributes: full, newton on
+      pair build: full/bin/atomonly
+      stencil: full/bin/3d
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 113 | 113 | 113 Mbytes
+Step Temp E_pair TotEng Press v_eb v_ea v_elp v_emol v_ev v_epen v_ecoa v_ehb v_et v_eco v_ew v_ep v_efi v_eqeq 
+       0            0   -44760.998   -44760.998    7827.7866   -61120.591     486.4378    4.7236377            0    1574.1033    20.788929   -279.51642   -1556.4696    252.57147   -655.84699    18862.412   -8740.6398            0    6391.0277 
+       5   0.61603968   -44761.698   -44760.994    8934.6336   -61118.769    486.81263    4.7234094            0    1573.9241    20.768834   -278.24084   -1557.6713    252.64377   -655.74435    18859.379   -8738.1906            0    6388.6666 
+      10    2.3525543   -44763.227   -44760.541    12288.588   -61113.174    487.82738    4.7226863            0     1573.411    20.705939   -274.50357   -1560.7569    252.85309   -655.44063    18850.391   -8730.9756            0    6381.7133 
+      15    4.9013233    -44766.36   -44760.764    17716.934   -61103.434    489.14722    4.7213644            0    1572.6349    20.593139   -268.56847   -1566.3829    252.95174   -654.96611    18835.777   -8719.2627            0    6370.4289 
+      20    7.8294615   -44769.686   -44760.747    25205.586   -61089.006    490.21314    4.7193021            0    1571.7022    20.420943   -260.85565   -1573.7378     253.3539   -654.31623     18816.07   -8703.4958            0    6355.2471 
+      25    10.697919   -44772.904   -44760.691    34232.898   -61069.308    490.25887    4.7163736            0    1570.7397    20.181347   -251.91377   -1582.3261    253.82253   -653.53184    18791.975   -8684.3285            0    6336.8093 
+Loop time of 4.34178 on 4 procs for 25 steps with 384 atoms
+
+Performance: 0.031 ns/day, 771.872 hours/ns, 5.758 timesteps/s
+96.8% CPU use with 4 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 3.1756     | 3.1763     | 3.1771     |   0.0 | 73.16
+Neigh   | 0.58917    | 0.59661    | 0.6035     |   0.9 | 13.74
+Comm    | 0.0088837  | 0.010178   | 0.011116   |   0.8 |  0.23
+Output  | 0.00036407 | 0.0019013  | 0.003552   |   2.7 |  0.04
+Modify  | 0.54882    | 0.55637    | 0.56413    |   0.8 | 12.81
+Other   |            | 0.0004123  |            |       |  0.01
+
+Nlocal:    96 ave 96 max 96 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Nghost:    5118 ave 5118 max 5118 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Neighs:    79754 ave 79754 max 79754 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+FullNghs:  84076 ave 84076 max 84076 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 336304
+Ave neighs/atom = 875.792
+Neighbor list builds = 5
+Dangerous builds not checked
+
+Please see the log.cite file for references relevant to this simulation
+
+Total wall time: 0:00:04

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -100,6 +100,7 @@ FixQEq::FixQEq(LAMMPS *lmp, int narg, char **arg) :
   q1 = NULL;
   q2 = NULL;
   streitz_flag = 0;
+  reax_flag = 0;
   qv = NULL;
 
   comm_forward = comm_reverse = 1;
@@ -117,6 +118,8 @@ FixQEq::FixQEq(LAMMPS *lmp, int narg, char **arg) :
 
   if (strcmp(arg[7],"coul/streitz") == 0) {
     streitz_flag = 1;
+  } else if (strcmp(arg[7],"reax/c") == 0) {
+    reax_flag = 1;
   } else {
     read_file(arg[7]);
   }
@@ -138,7 +141,7 @@ FixQEq::~FixQEq()
 
   memory->destroy(shld);
 
-  if (!streitz_flag) {
+  if (!streitz_flag && !reax_flag) {
     memory->destroy(chi);
     memory->destroy(eta);
     memory->destroy(gamma);

--- a/src/QEQ/fix_qeq.h
+++ b/src/QEQ/fix_qeq.h
@@ -70,7 +70,7 @@ class FixQEq : public Fix {
   double *chi,*eta,*gamma,*zeta,*zcore;  // qeq parameters
   double *chizj;
   double **shld;
-  int streitz_flag;
+  int streitz_flag, reax_flag;
 
   bigint ngroup;
 

--- a/src/QEQ/fix_qeq_shielded.cpp
+++ b/src/QEQ/fix_qeq_shielded.cpp
@@ -29,6 +29,7 @@
 #include "update.h"
 #include "force.h"
 #include "group.h"
+#include "pair.h"
 #include "kspace.h"
 #include "respa.h"
 #include "memory.h"
@@ -39,7 +40,9 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 FixQEqShielded::FixQEqShielded(LAMMPS *lmp, int narg, char **arg) :
-  FixQEq(lmp, narg, arg) {}
+  FixQEq(lmp, narg, arg) {
+  if (reax_flag) extract_reax();
+}
 
 /* ---------------------------------------------------------------------- */
 
@@ -72,6 +75,22 @@ void FixQEqShielded::init()
     nlevels_respa = ((Respa *) update->integrate)->nlevels;
 
 }
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqShielded::extract_reax()
+{
+  Pair *pair = force->pair_match("reax/c",1);
+  if (pair == NULL) error->all(FLERR,"No pair reax/c for fix qeq/shielded");
+  int tmp;
+  chi = (double *) pair->extract("chi",tmp);
+  eta = (double *) pair->extract("eta",tmp);
+  gamma = (double *) pair->extract("gamma",tmp);
+  if (chi == NULL || eta == NULL || gamma == NULL)
+    error->all(FLERR,
+        "Fix qeq/slater could not extract params from pair reax/c");
+}
+
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/QEQ/fix_qeq_shielded.h
+++ b/src/QEQ/fix_qeq_shielded.h
@@ -32,6 +32,7 @@ class FixQEqShielded : public FixQEq {
   void pre_force(int);
 
  private:
+  void extract_reax();
   void init_shielding();
   void init_matvec();
   void compute_H();

--- a/src/USER-REAXC/pair_reaxc.cpp
+++ b/src/USER-REAXC/pair_reaxc.cpp
@@ -361,7 +361,8 @@ void PairReaxC::init_style( )
 
   int iqeq;
   for (iqeq = 0; iqeq < modify->nfix; iqeq++)
-    if (strstr(modify->fix[iqeq]->style,"qeq/reax")) break;
+    if (strstr(modify->fix[iqeq]->style,"qeq/reax")
+       || strstr(modify->fix[iqeq]->style,"qeq/shielded")) break;
   if (iqeq == modify->nfix && qeqflag == 1)
     error->all(FLERR,"Pair reax/c requires use of fix qeq/reax");
 


### PR DESCRIPTION
## Purpose

Fix `qeq/shielded` from the QEQ package implements the same charge equilibration algorithm as fix `qeq/reax`. This PR adds the necessary code changes, to a) allow to use fix `qeq/shielded` with pair style `reax/c` and b) support extracting the qeq parameters directly from the pair style instead of using a parameter file. In addition, the previously undocumented equivalent feature for fix `qeq/slater` to be used with pair style `coul/streitz` is now documented as well.

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

yes. tested with a few example inputs in `examples/reax`

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines
