### PR TITLE
Correct calls to atom->delete_callback()

### DIFF
--- a/src/REPLICA/fix_hyper_local.cpp
+++ b/src/REPLICA/fix_hyper_local.cpp
@@ -205,6 +205,8 @@ FixHyperLocal::~FixHyperLocal()
   memory->destroy(bonds);
   memory->destroy(numbond);
 
+  atom->delete_callback(id,0);
+
   memory->destroy(maxstrain);
   memory->destroy(maxstrain_region);
   memory->destroy(maxstrain_bondindex);

--- a/src/USER-MISC/fix_ffl.cpp
+++ b/src/USER-MISC/fix_ffl.cpp
@@ -136,6 +136,9 @@ FixFFL::FixFFL(LAMMPS *lmp, int narg, char **arg) :
 FixFFL::~FixFFL() {
   delete random;
 
+  atom->delete_callback(id,0);
+  atom->delete_callback(id,1);
+
   memory->destroy(sqrt_m);
   memory->destroy(ffl_tmp1);
   memory->destroy(ffl_tmp2);

--- a/src/USER-MISC/fix_filter_corotate.cpp
+++ b/src/USER-MISC/fix_filter_corotate.cpp
@@ -217,7 +217,6 @@ FixFilterCorotate::~FixFilterCorotate()
   memory->destroy(dn2dx);
   memory->destroy(dn3dx);
 
-  atom->delete_callback(id,2);
   atom->delete_callback(id,0);
 
   // delete locally stored arrays


### PR DESCRIPTION
## Purpose

Add missing or delete extraneous `atom->delete_callback()` calls in fixes.
This fixes memory leaks and avoids memory corruption or crashes (since LAMMPS will now check whether a request to delete a callback is valid, since invalid requests corrupt memory)

## Author(s)

Axel Kohlmeyer (ICTP)

## Backward Compatibility

yes. fix `filter/corotate` stopped working due to recent changes in the atom class and should now work again.

## Implementation Notes

This is skipping fix pimd (for now), as that needs much more work (there is no destructor for starters and thus lots of memory leakage, too).

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] The source code follows the LAMMPS formatting guidelines
