### PR TITLE
allowing shrink wrap with comm tiled

### DIFF
--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -1963,7 +1963,7 @@ void ReadData::parse_keyword(int first)
     }
     while (eof == 0 && done == 0) {
       int blank = strspn(line," \t\n\r");
-      if ((blank == strlen(line)) || (line[blank] == '#')) {
+      if ((blank == (int)strlen(line)) || (line[blank] == '#')) {
         if (fgets(line,MAXLINE,fp) == NULL) eof = 1;
       } else done = 1;
     }

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -872,9 +872,9 @@ void ReadData::command(int narg, char **arg)
   if (domain->nonperiodic == 2) {
     if (domain->triclinic) domain->x2lamda(atom->nlocal);
     domain->reset_box();
-    comm->init();
-    comm->exchange();
-    if (atom->map_style) atom->map_set();
+    Irregular *irregular = new Irregular(lmp);
+    irregular->migrate_atoms(1);
+    delete irregular;
     if (domain->triclinic) domain->lamda2x(atom->nlocal);
 
     bigint natoms;
@@ -1963,7 +1963,7 @@ void ReadData::parse_keyword(int first)
     }
     while (eof == 0 && done == 0) {
       int blank = strspn(line," \t\n\r");
-      if ((blank == (int)strlen(line)) || (line[blank] == '#')) {
+      if ((blank == strlen(line)) || (line[blank] == '#')) {
         if (fgets(line,MAXLINE,fp) == NULL) eof = 1;
       } else done = 1;
     }


### PR DESCRIPTION
**Summary**

Alters read_data.cpp to enable the use of shrink wrap with comm style tiled. The irregular atom migration is used instead of comm->exchange since there were uninitialized data structures at the time it was called.

**Author(s)**

Adrian Diaz (University of Florida)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under the GNU General Public License version 2.

_Please complete the following statement by adding "yes" or "no":_
My contribution may be re-licensed as LGPL (for use of LAMMPS as a library linked to proprietary software): yes

**Backward Compatibility**

Clear of Conflict

**Implementation Notes**

Irregular is instanced and its migrate atoms function is used in read_data.cpp in place of comm->exchange. The change was tested with a shrink wrapped model that previously failed with comm tiled but worked with comm brick. 

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_



**Further Information, Files, and Links**





[in2tiletestshrink.txt](https://github.com/lammps/lammps/files/2853247/in2tiletestshrink.txt)

[Silicon_Crystal.txt](https://github.com/lammps/lammps/files/2853248/Silicon_Crystal.txt)



