### PR TITLE
Add OpenMP specific define to select between incompatible const sharing semantics

### DIFF
--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -275,7 +275,11 @@ void KSpace::qsum_qsq()
   double qsum_local(0.0), qsqsum_local(0.0);
 
 #if defined(_OPENMP)
+#if defined(LMP_OPENMP_MUST_SHARE_CONST)
+#pragma omp parallel for default(none) shared(nlocal,q) reduction(+:qsum_local,qsqsum_local)
+#else
 #pragma omp parallel for default(none) reduction(+:qsum_local,qsqsum_local)
+#endif
 #endif
   for (int i = 0; i < nlocal; i++) {
     qsum_local += q[i];

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -200,6 +200,38 @@ typedef int bigint;
 #define _noalias
 #endif
 
+// Identify compilers that use OpenMP 4.0 and later semantics
+// on const variable sharing and thus require different,
+// incompatible OpenMP pragmas.  If LMP_OPENMP_MUST_SHARE_CONST
+// is defined, const variables must be explicitly listed in
+// "shared()", while otherwise they must not.
+//
+// Known compilers
+// GNU g++ enforces OpenMP 4.0 (Jul/2013) semantics only with
+//         OpenMP 5.0 (Nov/2018) support added to GNU g++ 9.x
+// Intel icpc 2017 supports OpenMP 4.5 (Nov/2015) and both kinds
+//         of sharing semantics so we don't need to find the
+//         exact point where this is switched over
+// Clang 7.0 supports OpenMP 3.1 (Jul/2011) only.
+// by default we follow the standard and enforce new sharing
+// semantics with OpenMP 4.0 and later
+
+#if defined(_OPENMP)
+#  if defined(__INTEL_COMPILER)
+#    if _OPENMP >= 201511
+#      define LMP_OPENMP_MUST_SHARE_CONST 1
+#    endif
+#  elif defined(__GNUC__)
+#    if (_OPENMP >= 201811)
+#      define LMP_OPENMP_MUST_SHARE_CONST 1
+#    endif
+#  else
+#    if (_OPENMP >= 201307)
+#      define LMP_OPENMP_MUST_SHARE_CONST 1
+#    endif
+#  endif
+#endif
+
 // settings to enable LAMMPS to build under Windows
 
 #ifdef _WIN32


### PR DESCRIPTION
**Summary**

This pull request implements a new define `LMP_OPENMP_MUST_SHARE_CONST` when OpenMP is enabled and the compiler enforces the semantics for sharing const variables that was included in OpenMP 4.0. Different compilers have different cross-over points and different compatibility support.

**Related Issue**

This provides a possible infrastructure to support the issue raised in #1326 

**Author(s)**

Axel Kohlmeyer (ICTP)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under the GNU General Public License version 2.

My contribution may be re-licensed as LGPL (for use of LAMMPS as a library linked to proprietary software): yes

**Backward Compatibility**

not sure. we may need to tweak the crossover point for different compilers in `lmptype.h` to avoid compilation errors with OpenMP enabled.

**Implementation Notes**

This implements the support for changed semantics for sharing const variables introduced in OpenMP 4.0. GNU g++ didn't implement those, but remained compatible with older semantics. However with version 9.x it is changing and **enforcing** the new semantics. Other compiler vendors like Intel seem to have chosen to allow both variants and not enforced adding const variables to the `shared()` directive.
So it is not as critical to hit the mark exactly. For intel we switch to the new semantics with the 2017 version which provides OpenMP 4.5.

This only converts one specific case in `kspace.cpp` that was mentioned in #1326 
There is likely more code that needs to be adapted.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system


