### PR TITLE
Collected small changes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -453,7 +453,7 @@ if(PKG_VORONOI)
     set(VORO_BUILD_OPTIONS CXX=${CMAKE_CXX_COMPILER} CFLAGS=${VORO_BUILD_CFLAGS})
 
     ExternalProject_Add(voro_build
-      URL http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz
+      URL https://download.lammps.org/thirdparty/voro++-0.4.6.tar.gz
       URL_MD5 2338b824c3b7b25590e18e8df5d68af9
       CONFIGURE_COMMAND "" BUILD_COMMAND make ${VORO_BUILD_OPTIONS} BUILD_IN_SOURCE 1 INSTALL_COMMAND ""
       )

--- a/doc/src/Build_basics.txt
+++ b/doc/src/Build_basics.txt
@@ -116,6 +116,18 @@ enables OpenMP. For GNU compilers it is -fopenmp.  For (recent) Intel
 compilers it is -qopenmp.  If you are using a different compiler,
 please refer to its documentation.
 
+[OpenMP Compiler compatibility info]: :link(default-none-issues)
+
+Some compilers do not fully support the 'default(none)' directive
+and others (e.g. GCC version 9 and beyond) may implement OpenMP 4.0
+semantics, which are incompatible with the OpenMP 3.1 directives used
+in LAMMPS (for maximal compatibility with compiler versions in use).
+In those case, all 'default(none)' directives (which aid in detecting
+incorrect and unwanted sharing) can be replaced with 'default(shared)'
+while dropping all 'shared()' directives. The script
+'src/USER-OMP/hack_openmp_for_pgi_gcc9.sh' can be used to automate
+this conversion.
+
 :line
 
 Choice of compiler and compile/link options :h4,link(compile)

--- a/doc/src/Build_extras.txt
+++ b/doc/src/Build_extras.txt
@@ -932,7 +932,9 @@ LINKFLAGS: -fopenmp             # for GNU Compilers
 LINKFLAGS: -qopenmp             # for Intel compilers on Linux :pre
 
 For other platforms and compilers, please consult the documentation
-about OpenMP support for your compiler.
+about OpenMP support for your compiler. Please see the note about
+how to address compatibility "issues with the 'default(none)'
+directive"_Build_basics.html#default-none-issues of some compilers.
 
 :line
 

--- a/doc/src/fix_wall_gran_region.txt
+++ b/doc/src/fix_wall_gran_region.txt
@@ -71,12 +71,13 @@ exterior surfaces of regions.
 Regions can either be primitive shapes (block, sphere, cylinder, etc)
 or combinations of primitive shapes specified via the {union} or
 {intersect} region styles.  These latter styles can be used to
-construct particle containers with complex shapes.  Regions can also
-move dynamically via the "region"_region.html command keywords (move)
-and {rotate}, or change their shape by use of variables as inputs to
-the "region"_region.html command.  If such a region is used with this
-fix, then the region surface will move in time in the corresponding
-manner.
+construct particle containers with complex shapes.
+
+Regions can also move dynamically via the "region"_region.html command
+keywords (move) and {rotate}, or change their shape by use of variables
+as inputs to the "region"_region.html command.  If such a region is used
+with this fix, then the region surface will move in time in the
+corresponding manner.
 
 NOTE: As discussed on the "region"_region.html command doc page,
 regions in LAMMPS do not get wrapped across periodic boundaries.  It

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -1951,6 +1951,7 @@ ons
 OO
 openKIM
 OpenMP
+openmp
 openmpi
 opls
 Oppelstrup
@@ -2044,6 +2045,7 @@ peru
 Peskin
 Pettifor
 pfactor
+pgi
 ph
 Phillpot
 phiphi

--- a/lib/voronoi/Install.py
+++ b/lib/voronoi/Install.py
@@ -18,7 +18,7 @@ parser = ArgumentParser(prog='Install.py',
 # settings
 
 version = "voro++-0.4.6"
-url = "http://math.lbl.gov/voro++/download/dir/%s.tar.gz" % version
+url = "https://download.lammps.org/thirdparty/%s.tar.gz" % version
 
 # known checksums for different Voro++ versions. used to validate the download.
 checksums = { \

--- a/src/GPU/fix_gpu.cpp
+++ b/src/GPU/fix_gpu.cpp
@@ -288,7 +288,7 @@ void FixGPU::min_setup(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGPU::post_force(int vflag)
+void FixGPU::post_force(int /* vflag */)
 {
   if (!force->pair) return;
 
@@ -320,7 +320,7 @@ void FixGPU::min_post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGPU::post_force_respa(int vflag, int ilevel, int iloop)
+void FixGPU::post_force_respa(int vflag, int /* ilevel */, int /* iloop */)
 {
   post_force(vflag);
 }

--- a/src/GPU/pair_beck_gpu.cpp
+++ b/src/GPU/pair_beck_gpu.cpp
@@ -171,8 +171,9 @@ double PairBeckGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairBeckGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                               int *ilist, int *numneigh, int **firstneigh) {
+void PairBeckGPU::cpu_compute(int start, int inum, int eflag,
+                              int /* vflag */, int *ilist,
+                              int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,r5,force_beck,factor_lj;

--- a/src/GPU/pair_born_coul_wolf_gpu.cpp
+++ b/src/GPU/pair_born_coul_wolf_gpu.cpp
@@ -191,9 +191,9 @@ double PairBornCoulWolfGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairBornCoulWolfGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                      int *ilist, int *numneigh,
-                                      int **firstneigh) {
+void PairBornCoulWolfGPU::cpu_compute(int start, int inum, int eflag,
+                                      int /* vflag */, int *ilist,
+                                      int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,qtmp,delx,dely,delz,evdwl,ecoul,fpair;
   double rsq,r2inv,r6inv,forcecoul,forceborn,factor_coul,factor_lj;

--- a/src/GPU/pair_born_gpu.cpp
+++ b/src/GPU/pair_born_gpu.cpp
@@ -185,8 +185,9 @@ double PairBornGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairBornGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                              int *ilist, int *numneigh, int **firstneigh) {
+void PairBornGPU::cpu_compute(int start, int inum, int eflag,
+                              int /* vflag */, int *ilist,
+                              int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,r2inv,r6inv,forceborn,factor_lj;

--- a/src/GPU/pair_buck_coul_cut_gpu.cpp
+++ b/src/GPU/pair_buck_coul_cut_gpu.cpp
@@ -179,9 +179,9 @@ double PairBuckCoulCutGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairBuckCoulCutGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                     int *ilist, int *numneigh,
-                                     int **firstneigh) {
+void PairBuckCoulCutGPU::cpu_compute(int start, int inum, int eflag,
+                                     int /* vflag */, int *ilist,
+                                     int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,qtmp,delx,dely,delz,evdwl,ecoul,fpair;
   double rsq,r2inv,r6inv,forcecoul,forcebuck,factor_coul,factor_lj;

--- a/src/GPU/pair_buck_gpu.cpp
+++ b/src/GPU/pair_buck_gpu.cpp
@@ -182,8 +182,8 @@ double PairBuckGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairBuckGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                               int *ilist, int *numneigh, int **firstneigh) {
+void PairBuckGPU::cpu_compute(int start, int inum, int eflag, int /* vflag */,
+                              int *ilist, int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,r2inv,r6inv,forcebuck,factor_lj;

--- a/src/GPU/pair_coul_cut_gpu.cpp
+++ b/src/GPU/pair_coul_cut_gpu.cpp
@@ -186,9 +186,9 @@ double PairCoulCutGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairCoulCutGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                      int *ilist, int *numneigh,
-                                      int **firstneigh)
+void PairCoulCutGPU::cpu_compute(int start, int inum, int eflag,
+                                 int /* vflag */, int *ilist,
+                                 int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;

--- a/src/GPU/pair_coul_debye_gpu.cpp
+++ b/src/GPU/pair_coul_debye_gpu.cpp
@@ -189,8 +189,8 @@ double PairCoulDebyeGPU::memory_usage()
 /* ---------------------------------------------------------------------- */
 
 void PairCoulDebyeGPU::cpu_compute(int start, int inum, int eflag,
-                                        int vflag, int *ilist,
-                                        int *numneigh, int **firstneigh)
+                                   int /* vflag */, int *ilist,
+                                   int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;

--- a/src/GPU/pair_coul_dsf_gpu.cpp
+++ b/src/GPU/pair_coul_dsf_gpu.cpp
@@ -196,9 +196,9 @@ double PairCoulDSFGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairCoulDSFGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                 int *ilist, int *numneigh,
-                                 int **firstneigh)
+void PairCoulDSFGPU::cpu_compute(int start, int inum, int eflag,
+                                 int /* vflag */, int *ilist,
+                                 int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;

--- a/src/GPU/pair_dpd_gpu.cpp
+++ b/src/GPU/pair_dpd_gpu.cpp
@@ -319,8 +319,8 @@ double PairDPDGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairDPDGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                               int *ilist, int *numneigh, int **firstneigh) {
+void PairDPDGPU::cpu_compute(int start, int inum, int eflag, int /* vflag */,
+                             int *ilist, int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double vxtmp,vytmp,vztmp,delvx,delvy,delvz;

--- a/src/GPU/pair_dpd_tstat_gpu.cpp
+++ b/src/GPU/pair_dpd_tstat_gpu.cpp
@@ -336,8 +336,9 @@ double PairDPDTstatGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairDPDTstatGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                               int *ilist, int *numneigh, int **firstneigh) {
+void PairDPDTstatGPU::cpu_compute(int start, int inum, int /* eflag */,
+                                  int /* vflag */, int *ilist,
+                                  int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,fpair;
   double vxtmp,vytmp,vztmp,delvx,delvy,delvz;

--- a/src/GPU/pair_gauss_gpu.cpp
+++ b/src/GPU/pair_gauss_gpu.cpp
@@ -178,7 +178,7 @@ double PairGaussGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairGaussGPU::cpu_compute(int start, int inum, int eflag, int vflag,
+void PairGaussGPU::cpu_compute(int start, int inum, int eflag, int /* vflag */,
                                int *ilist, int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;

--- a/src/GPU/pair_lj96_cut_gpu.cpp
+++ b/src/GPU/pair_lj96_cut_gpu.cpp
@@ -171,8 +171,9 @@ double PairLJ96CutGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLJ96CutGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                 int *ilist, int *numneigh, int **firstneigh)
+void PairLJ96CutGPU::cpu_compute(int start, int inum, int eflag,
+                                 int /* vflag */, int *ilist,
+                                 int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;

--- a/src/GPU/pair_lj_class2_gpu.cpp
+++ b/src/GPU/pair_lj_class2_gpu.cpp
@@ -168,8 +168,9 @@ double PairLJClass2GPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLJClass2GPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                 int *ilist, int *numneigh, int **firstneigh)
+void PairLJClass2GPU::cpu_compute(int start, int inum, int eflag,
+                                  int /* vflag */, int *ilist,
+                                  int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;

--- a/src/GPU/pair_lj_cubic_gpu.cpp
+++ b/src/GPU/pair_lj_cubic_gpu.cpp
@@ -174,8 +174,9 @@ double PairLJCubicGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLJCubicGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                               int *ilist, int *numneigh, int **firstneigh) {
+void PairLJCubicGPU::cpu_compute(int start, int inum, int eflag,
+                                 int /* vflag */, int *ilist,
+                                 int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,r2inv,r6inv,forcelj,factor_lj;

--- a/src/GPU/pair_lj_cut_coul_cut_gpu.cpp
+++ b/src/GPU/pair_lj_cut_coul_cut_gpu.cpp
@@ -180,9 +180,9 @@ double PairLJCutCoulCutGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLJCutCoulCutGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                      int *ilist, int *numneigh,
-                                      int **firstneigh)
+void PairLJCutCoulCutGPU::cpu_compute(int start, int inum, int eflag,
+                                      int /* vflag */, int *ilist,
+                                      int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;

--- a/src/GPU/pair_lj_cut_coul_debye_gpu.cpp
+++ b/src/GPU/pair_lj_cut_coul_debye_gpu.cpp
@@ -184,7 +184,7 @@ double PairLJCutCoulDebyeGPU::memory_usage()
 /* ---------------------------------------------------------------------- */
 
 void PairLJCutCoulDebyeGPU::cpu_compute(int start, int inum, int eflag,
-                                        int vflag, int *ilist,
+                                        int /* vflag */, int *ilist,
                                         int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;

--- a/src/GPU/pair_lj_cut_coul_dsf_gpu.cpp
+++ b/src/GPU/pair_lj_cut_coul_dsf_gpu.cpp
@@ -198,9 +198,9 @@ double PairLJCutCoulDSFGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLJCutCoulDSFGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                      int *ilist, int *numneigh,
-                                      int **firstneigh)
+void PairLJCutCoulDSFGPU::cpu_compute(int start, int inum, int eflag,
+                                      int /* vflag */, int *ilist,
+                                      int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;

--- a/src/GPU/pair_lj_cut_gpu.cpp
+++ b/src/GPU/pair_lj_cut_gpu.cpp
@@ -184,7 +184,7 @@ double PairLJCutGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLJCutGPU::cpu_compute(int start, int inum, int eflag, int vflag,
+void PairLJCutGPU::cpu_compute(int start, int inum, int eflag, int /* vflag */,
                                int *ilist, int *numneigh, int **firstneigh) {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;

--- a/src/GPU/pair_lj_expand_gpu.cpp
+++ b/src/GPU/pair_lj_expand_gpu.cpp
@@ -181,8 +181,9 @@ double PairLJExpandGPU::memory_usage()
 
 /* ---------------------------------------------------------------------- */
 
-void PairLJExpandGPU::cpu_compute(int start, int inum, int eflag, int vflag,
-                                  int *ilist, int *numneigh, int **firstneigh)
+void PairLJExpandGPU::cpu_compute(int start, int inum, int eflag,
+                                  int /* vflag */, int *ilist,
+                                  int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;

--- a/src/GPU/pair_lj_gromacs_gpu.cpp
+++ b/src/GPU/pair_lj_gromacs_gpu.cpp
@@ -177,7 +177,7 @@ double PairLJGromacsGPU::memory_usage()
 /* ---------------------------------------------------------------------- */
 
 void PairLJGromacsGPU::cpu_compute(int start, int inum, int eflag,
-                                   int vflag, int *ilist,
+                                   int /* vflag */, int *ilist,
                                    int *numneigh, int **firstneigh)
 {
   int i,j,ii,jj,jnum,itype,jtype;

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -2116,7 +2116,7 @@ but of the vector r_ij.
 
 */
 
-double PairAIREBO::bondorderLJ(int i, int j, double /*rij_mod*/[3], double rijmag_mod,
+double PairAIREBO::bondorderLJ(int i, int j, double /* rij_mod */[3], double rijmag_mod,
                                double VA, double rij[3], double rijmag,
                                double **f, int vflag_atom)
 {

--- a/src/USER-MISC/fix_ave_correlate_long.cpp
+++ b/src/USER-MISC/fix_ave_correlate_long.cpp
@@ -307,7 +307,7 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS * lmp, int narg, char **arg):
 
   for (int i=0;i<npair;i++)
     for (int j=0;j<numcorrelators;j++) {
-      for (int k=0;k<p;k++) {
+      for (unsigned int k=0;k<p;k++) {
         shift[i][j][k]=-2E10;
         shift2[i][j][k]=0.0;
         correlation[i][j][k]=0.0;
@@ -317,7 +317,7 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS * lmp, int narg, char **arg):
     }
 
   for (int i=0;i<numcorrelators;i++) {
-    for (int j=0;j<p;j++) ncorrelation[i][j]=0;
+    for (unsigned int j=0;j<p;j++) ncorrelation[i][j]=0;
     naccumulator[i]=0;
     insertindex[i]=0;
   }
@@ -515,7 +515,7 @@ void FixAveCorrelateLong::evaluate() {
   unsigned int jm=0;
 
   // First correlator
-  for (int j=0;j<p;++j) {
+  for (unsigned int j=0;j<p;++j) {
     if (ncorrelation[0][j] > 0) {
       t[jm] = j;
       for (int i=0;i<npair;++i)
@@ -526,7 +526,7 @@ void FixAveCorrelateLong::evaluate() {
 
   // Subsequent correlators
   for (int k=1;k<kmax;++k) {
-    for (int j=dmin;j<p;++j) {
+    for (unsigned int j=dmin;j<p;++j) {
       if (ncorrelation[k][j]>0) {
         t[jm] = j * pow((double)m, k);
         for (int i=0;i<npair;++i)
@@ -610,7 +610,7 @@ void FixAveCorrelateLong::add(const int i, const double w, const int k){
   unsigned int ind1=insertindex[k];
   if (k==0) { // First correlator is different
     int ind2=ind1;
-    for (int j=0;j<p;++j) {
+    for (unsigned int j=0;j<p;++j) {
       if (shift[i][k][ind2] > -1e10) {
         correlation[i][k][j]+= shift[i][k][ind1]*shift[i][k][ind2];
         if (i==0) ++ncorrelation[k][j];
@@ -620,7 +620,7 @@ void FixAveCorrelateLong::add(const int i, const double w, const int k){
     }
   } else {
     int ind2=ind1-dmin;
-    for (int j=dmin;j<p;++j) {
+    for (unsigned int j=dmin;j<p;++j) {
       if (ind2<0) ind2+=p;
       if (shift[i][k][ind2] > -1e10) {
         correlation[i][k][j]+= shift[i][k][ind1]*shift[i][k][ind2];
@@ -661,7 +661,7 @@ void FixAveCorrelateLong::add(const int i, const double wA, const double wB,
   unsigned int ind1=insertindex[k];
   if (k==0) {
     int ind2=ind1;
-    for (int j=0;j<p;++j) {
+    for (unsigned int j=0;j<p;++j) {
       if (shift[i][k][ind2] > -1e10) {
         correlation[i][k][j]+= shift[i][k][ind1]*shift2[i][k][ind2];
         if (i==0) ++ncorrelation[k][j];
@@ -672,7 +672,7 @@ void FixAveCorrelateLong::add(const int i, const double wA, const double wB,
   }
   else {
     int ind2=ind1-dmin;
-    for (int j=dmin;j<p;++j) {
+    for (unsigned int j=dmin;j<p;++j) {
       if (ind2<0) ind2+=p;
       if (shift[i][k][ind2] > -1e10) {
         correlation[i][k][j]+= shift[i][k][ind1]*shift2[i][k][ind2];
@@ -743,7 +743,7 @@ void FixAveCorrelateLong::write_restart(FILE *fp) {
     list[n++] = last_accumulated_step;
     for (int i=0;i<npair;i++)
       for (int j=0;j<numcorrelators;j++) {
-        for (int k=0;k<p;k++) {
+        for (unsigned int k=0;k<p;k++) {
           list[n++]=shift[i][j][k];
           list[n++]=shift2[i][j][k];
           list[n++]=correlation[i][j][k];
@@ -752,7 +752,7 @@ void FixAveCorrelateLong::write_restart(FILE *fp) {
         list[n++]=accumulator2[i][j];
       }
     for (int i=0;i<numcorrelators;i++) {
-      for (int j=0;j<p;j++) list[n++]=ncorrelation[i][j];
+      for (unsigned int j=0;j<p;j++) list[n++]=ncorrelation[i][j];
       list[n++]=naccumulator[i];
       list[n++]=insertindex[i];
     }
@@ -779,12 +779,12 @@ void FixAveCorrelateLong::restart(char *buf)
   last_accumulated_step = static_cast<int> (list[n++]);
 
   if ((npairin!=npair) || (numcorrelatorsin!=numcorrelators)
-      || (pin!=p) || (min!=m))
+      || (pin!=(int)p) || (min!=(int)m))
     error->all(FLERR,"Fix ave/correlate/long: restart and input data are different");
 
   for (int i=0;i<npair;i++)
     for (int j=0;j<numcorrelators;j++) {
-      for (int k=0;k<p;k++) {
+      for (unsigned int k=0;k<p;k++) {
         shift[i][j][k] = list[n++];
         shift2[i][j][k] = list[n++];
         correlation[i][j][k] = list[n++];
@@ -793,7 +793,7 @@ void FixAveCorrelateLong::restart(char *buf)
       accumulator2[i][j] = list[n++];
     }
   for (int i=0;i<numcorrelators;i++) {
-    for (int j=0;j<p;j++)
+    for (unsigned int j=0;j<p;j++)
       ncorrelation[i][j] = static_cast<unsigned long int>(list[n++]);
     naccumulator[i] = static_cast<unsigned int> (list[n++]);
     insertindex[i] = static_cast<unsigned int> (list[n++]);

--- a/src/USER-MISC/fix_ave_correlate_long.h
+++ b/src/USER-MISC/fix_ave_correlate_long.h
@@ -52,7 +52,7 @@ class FixAveCorrelateLong : public Fix {
   unsigned int *insertindex;
 
   int numcorrelators; // Recommended 20
-  int p; // Points per correlator (recommended 16)
+  unsigned int p; // Points per correlator (recommended 16)
   unsigned int m; // Num points for average (recommended 2; p mod m = 0)
   unsigned int dmin; // Min distance between ponts for correlators k>0; dmin=p/m
 

--- a/src/USER-MISC/pair_extep.cpp
+++ b/src/USER-MISC/pair_extep.cpp
@@ -1075,10 +1075,10 @@ void PairExTeP::costheta_d(double *rij_hat, double rij,
 // initialize spline for F_corr (based on PairLCBOP::F_conj)
 
 void PairExTeP::spline_init() {
-  for ( size_t iel=0; iel<atom->ntypes; iel++) {
-    for ( size_t jel=0; jel<atom->ntypes; jel++) {
-      for ( size_t N_ij=0; N_ij<4; N_ij++ ) {
-        for ( size_t N_ji=0; N_ji<4; N_ji++ ) {
+  for ( int iel=0; iel<atom->ntypes; iel++) {
+    for ( int jel=0; jel<atom->ntypes; jel++) {
+      for ( int N_ij=0; N_ij<4; N_ij++ ) {
+        for ( int N_ji=0; N_ji<4; N_ji++ ) {
           TF_corr_param &f = F_corr_param[iel][jel][N_ij][N_ji];
 
           // corner points for each spline function
@@ -1150,8 +1150,8 @@ double PairExTeP::F_corr(int iel, int jel, double Ndij, double Ndji, double *dFN
 
   // compute F_XY
 
-  size_t Ndij_int         = static_cast<size_t>( floor( Ndij ) );
-  size_t Ndji_int         = static_cast<size_t>( floor( Ndji ) );
+  int Ndij_int         = static_cast<int>( floor( Ndij ) );
+  int Ndji_int         = static_cast<int>( floor( Ndji ) );
   double x                = Ndij - Ndij_int;
   double y                = Ndji - Ndji_int;
   TF_corr_param &f  = F_corr_param[iel][jel][Ndij_int][Ndji_int];

--- a/src/USER-MISC/pair_lebedeva_z.cpp
+++ b/src/USER-MISC/pair_lebedeva_z.cpp
@@ -82,8 +82,8 @@ void PairLebedevaZ::compute(int eflag, int vflag)
 {
   int i,j,ii,jj,inum,jnum,itype,jtype;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair,der;
-  double rsq,r,rhosq,rho,exp1,exp2,exp3,r6,r8;
-  double frho,sumD,Ulm,fxy,fz,rdsq;
+  double rsq,r,rhosq,exp1,exp2,exp3,r6,r8;
+  double sumD,Ulm,fxy,fz;
   int *ilist,*jlist,*numneigh,**firstneigh;
 
   evdwl = 0.0;
@@ -120,7 +120,6 @@ void PairLebedevaZ::compute(int eflag, int vflag)
       delz = ztmp - x[j][2];
       // rho^2 = r^2 - z^2
       rhosq = delx*delx + dely*dely;
-      rho = sqrt(rhosq);
       rsq = rhosq + delz*delz;
 
       if (rsq < cutsq[itype][jtype]) {

--- a/src/USER-MOLFILE/reader_molfile.cpp
+++ b/src/USER-MOLFILE/reader_molfile.cpp
@@ -197,7 +197,7 @@ void ReaderMolfile::skip()
 
 bigint ReaderMolfile::read_header(double box[3][3], int &triclinic,
                                   int fieldinfo, int nfield,
-                                  int *fieldtype, char **fieldlabel,
+                                  int *fieldtype, char ** /* fieldlabel */,
                                   int scaleflag, int wrapflag, int &fieldflag,
                                   int &xflag, int &yflag, int &zflag)
 {

--- a/src/USER-OMP/fix_gravity_omp.cpp
+++ b/src/USER-OMP/fix_gravity_omp.cpp
@@ -42,7 +42,7 @@ FixGravityOMP::FixGravityOMP(LAMMPS *lmp, int narg, char **arg) :
 
 /* ---------------------------------------------------------------------- */
 
-void FixGravityOMP::post_force(int vflag)
+void FixGravityOMP::post_force(int /* vflag */)
 {
   // update gravity due to variables
 
@@ -106,7 +106,7 @@ void FixGravityOMP::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGravityOMP::post_force_respa(int vflag, int ilevel, int iloop)
+void FixGravityOMP::post_force_respa(int vflag, int ilevel, int /* iloop */)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }

--- a/src/USER-OMP/fix_nve_omp.cpp
+++ b/src/USER-OMP/fix_nve_omp.cpp
@@ -29,7 +29,7 @@ FixNVEOMP::FixNVEOMP(LAMMPS *lmp, int narg, char **arg) :
    allow for both per-type and per-atom mass
 ------------------------------------------------------------------------- */
 
-void FixNVEOMP::initial_integrate(int vflag)
+void FixNVEOMP::initial_integrate(int /* vflag */)
 {
   // update v and x of atoms in group
 

--- a/src/USER-OMP/fix_nve_sphere_omp.cpp
+++ b/src/USER-OMP/fix_nve_sphere_omp.cpp
@@ -37,7 +37,7 @@ enum{NODLM,DLM};
 
 /* ---------------------------------------------------------------------- */
 
-void FixNVESphereOMP::initial_integrate(int vflag)
+void FixNVESphereOMP::initial_integrate(int /* vflag */)
 {
   double * const * const x = atom->x;
   double * const * const v = atom->v;

--- a/src/USER-OMP/fix_qeq_comb_omp.cpp
+++ b/src/USER-OMP/fix_qeq_comb_omp.cpp
@@ -73,7 +73,7 @@ void FixQEQCombOMP::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEQCombOMP::post_force(int vflag)
+void FixQEQCombOMP::post_force(int /* vflag */)
 {
   int i,ii,iloop,loopmax,inum,*ilist;
   double heatpq,qmass,dtq,dtq2;

--- a/src/USER-OMP/fix_qeq_reax_omp.cpp
+++ b/src/USER-OMP/fix_qeq_reax_omp.cpp
@@ -275,7 +275,7 @@ void FixQEqReaxOMP::init_storage()
 
 /* ---------------------------------------------------------------------- */
 
-void FixQEqReaxOMP::pre_force(int vflag)
+void FixQEqReaxOMP::pre_force(int /* vflag */)
 {
 
 #ifdef OMP_TIMING

--- a/src/USER-OMP/fix_wall_gran_omp.cpp
+++ b/src/USER-OMP/fix_wall_gran_omp.cpp
@@ -37,7 +37,7 @@ FixWallGranOMP::FixWallGranOMP(LAMMPS *lmp, int narg, char **arg) :
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallGranOMP::post_force(int vflag)
+void FixWallGranOMP::post_force(int /* vflag */)
 {
   double vwall[3];
 
@@ -48,7 +48,7 @@ void FixWallGranOMP::post_force(int vflag)
 
   if (neighbor->ago == 0 && fix_rigid) {
     int tmp;
-    const int * const body = (const int * const) fix_rigid->extract("body",tmp);
+    const int * const body = (const int *) fix_rigid->extract("body",tmp);
     double *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
@@ -180,7 +180,7 @@ void FixWallGranOMP::post_force(int vflag)
 
 /* ---------------------------------------------------------------------- */
 
-void FixWallGranOMP::post_force_respa(int vflag, int ilevel, int iloop)
+void FixWallGranOMP::post_force_respa(int vflag, int ilevel, int /* iloop */)
 {
   if (ilevel == nlevels_respa-1) post_force(vflag);
 }

--- a/src/USER-OMP/hack_openmp_for_pgi.sh
+++ b/src/USER-OMP/hack_openmp_for_pgi.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-for f in *.h *.cpp
-do \
-   sed -e '/#pragma omp/s/^\(.*default\)(none)\(.*\)$/\1(shared)\2/' \
-       -e '/#pragma omp/s/shared([a-z0-9,_]\+)//' \
-       -i.bak $f
-done

--- a/src/USER-OMP/hack_openmp_for_pgi_gcc9.sh
+++ b/src/USER-OMP/hack_openmp_for_pgi_gcc9.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# convert default(none) directives for OpenMP pragmas to default(shared) and remove shared() directive
+# this allows compiling OpenMP pragmas in LAMMPS with compilers that don't support default(none) properly
+# or require backward incompatible OpenMP 4 and OpenMP 5 semantics
+
+for f in *.h *.cpp
+do \
+   sed -e '/#pragma omp/s/^\(.*default\)(none)\(.*\)$/\1(shared)\2/' \
+       -e '/#pragma omp/s/shared([a-z0-9,_]\+)//' \
+       -i.bak $f
+done

--- a/src/USER-OMP/pair_airebo_omp.cpp
+++ b/src/USER-OMP/pair_airebo_omp.cpp
@@ -1869,7 +1869,7 @@ there probably also need to be performed here.
 
 */
 
-double PairAIREBOOMP::bondorderLJ_thr(int i, int j, double rij_mod[3], double rijmag_mod,
+double PairAIREBOOMP::bondorderLJ_thr(int i, int j, double /* rij_mod */[3], double rijmag_mod,
                                       double VA, double rij[3], double rijmag,
                                       int vflag_atom, ThrData * const thr)
 {

--- a/src/USER-OMP/pair_rebo_omp.cpp
+++ b/src/USER-OMP/pair_rebo_omp.cpp
@@ -24,7 +24,7 @@ PairREBOOMP::PairREBOOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp) {}
    global settings
 ------------------------------------------------------------------------- */
 
-void PairREBOOMP::settings(int narg, char **arg)
+void PairREBOOMP::settings(int narg, char ** /* arg */)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-UEF/uef_utils.h
+++ b/src/USER-UEF/uef_utils.h
@@ -103,7 +103,6 @@ bool mat_same(T x1[3][3], T x2[3][3])
 template<typename T>
 void transpose(T m[3][3])
 {
-  T t[3][3];
   for (int k=0;k<3;k++)
     for (int j=k+1;j<3;j++) {
       T x = m[k][j];

--- a/src/USER-YAFF/angle_cross.cpp
+++ b/src/USER-YAFF/angle_cross.cpp
@@ -61,9 +61,9 @@ void AngleCross::compute(int eflag, int vflag)
   int i1,i2,i3,n,type;
   double delx1,dely1,delz1,delx2,dely2,delz2;
   double eangle,f1[3],f3[3];
-  double dtheta,dtheta2,dtheta3,dtheta4,de_angle;
+  double dtheta;
   double dr1,dr2,tk1,tk2,aa1,aa2,aa11,aa12,aa21,aa22;
-  double rsq1,rsq2,r1,r2,c,s,a,a11,a12,a22,b1,b2;
+  double rsq1,rsq2,r1,r2,c,s,b1,b2;
   double vx11,vx12,vy11,vy12,vz11,vz12,vx21,vx22,vy21,vy22,vz21,vz22;
 
   eangle = 0.0;
@@ -305,7 +305,7 @@ void AngleCross::read_restart(FILE *fp)
 void AngleCross::write_data(FILE *fp)
 {
   for (int i = 1; i <= atom->nangletypes; i++)
-    fprintf(fp,"%d %g %g %g %g\n",
+    fprintf(fp,"%d %g %g %g %g %g %g\n",
             i,kss[i],kbs0[i],kbs1[i],r00[i],r01[i],theta0[i]/MY_PI*180.0);
 }
 

--- a/src/USER-YAFF/angle_mm3.cpp
+++ b/src/USER-YAFF/angle_mm3.cpp
@@ -58,9 +58,7 @@ void AngleMM3::compute(int eflag, int vflag)
   double delx1,dely1,delz1,delx2,dely2,delz2;
   double eangle,f1[3],f3[3];
   double dtheta,dtheta2,dtheta3,dtheta4,de_angle;
-  double dr1,dr2,tk1,tk2,aa1,aa2,aa11,aa12,aa21,aa22;
-  double rsq1,rsq2,r1,r2,c,s,a,a11,a12,a22,b1,b2;
-  double vx11,vx12,vy11,vy12,vz11,vz12,vx21,vx22,vy21,vy22,vz21,vz22;
+  double rsq1,rsq2,r1,r2,c,s,a,a11,a12,a22;
 
   eangle = 0.0;
   if (eflag || vflag) ev_setup(eflag,vflag);

--- a/src/USER-YAFF/bond_mm3.cpp
+++ b/src/USER-YAFF/bond_mm3.cpp
@@ -201,12 +201,13 @@ void BondMM3::write_data(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double BondMM3::single(int type, double rsq, int i, int j, double &fforce)
+double BondMM3::single(int type, double rsq,
+                       int /* i */, int /* j */, double &fforce)
 {
   /*
-  E = K(r-r0)^2 [1-2.55*(r-r0)+(7/12)*2.55^(2)*(r-r0)^2]
-  with -2.55 in angstrom^(-1) and (7/12)*2.55^(2) in angstrom^(-2)
-  These prefactors are converted here to the correct units
+    E = K(r-r0)^2 [1-2.55*(r-r0)+(7/12)*2.55^(2)*(r-r0)^2]
+    with -2.55 in angstrom^(-1) and (7/12)*2.55^(2) in angstrom^(-2)
+    These prefactors are converted here to the correct units
   */
   double K3 = -2.55/force->angstrom;
   double K4 = 7.0/12.0*2.55*2.55/force->angstrom/force->angstrom;

--- a/src/USER-YAFF/pair_lj_switch3_coulgauss_long.cpp
+++ b/src/USER-YAFF/pair_lj_switch3_coulgauss_long.cpp
@@ -82,13 +82,13 @@ PairLJSwitch3CoulGaussLong::~PairLJSwitch3CoulGaussLong()
 
 void PairLJSwitch3CoulGaussLong::compute(int eflag, int vflag)
 {
-  int i,ii,j,jj,inum,jnum,itype,jtype,itable,jtable,ktable;
-  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,ecoul2,fpair;
-  double fraction,fraction2,table;
+  int i,ii,j,jj,inum,jnum,itype,jtype,itable;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
   double r,r2inv,r6inv,forcecoul,forcecoul2,forcelj,factor_coul,factor_lj,tr,ftr,trx;
-  double grij,expm2,prefactor,prefactor2,t,erfc1,erfc2,rrij,expn2,expb,g_ewald2i,g_ewaldi;
+  double grij,expm2,prefactor,prefactor2,t,erfc1,erfc2,rrij,expn2;
   int *ilist,*jlist,*numneigh,**firstneigh;
-  double rsq, lookup_corr;
+  double rsq;
 
   evdwl = ecoul = 0.0;
   if (eflag || vflag) ev_setup(eflag,vflag);
@@ -109,9 +109,6 @@ void PairLJSwitch3CoulGaussLong::compute(int eflag, int vflag)
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
-  g_ewaldi = 1.0/g_ewald;
-  g_ewald2i = g_ewaldi*g_ewaldi;
-  lookup_corr = 0.0;
 
   // loop over neighbors of my atoms
   for (ii = 0; ii < inum; ii++) {
@@ -610,13 +607,13 @@ void PairLJSwitch3CoulGaussLong::write_data_all(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double PairLJSwitch3CoulGaussLong::single(int i, int j, int itype, int jtype,
-                                 double rsq,
-                                 double factor_coul, double factor_lj,
-                                 double &fforce)
+                                          double rsq,
+                                          double factor_coul, double factor_lj,
+                                          double &fforce)
 {
-  double r2inv,r6inv,r,grij,expm2,t,erfc1,prefactor,prefactor2,rrij,expn2,erfc2;
-  double fraction,table,forcecoul,forcecoul2,forcelj,phicoul,phicoul2,philj;
-  double expb, ecoul, evdwl, trx, tr, ftr;
+  double r2inv,r6inv,r,grij,expm2,t,erfc1,prefactor,prefactor2;
+  double fraction,table,forcecoul,forcecoul2,forcelj,phicoul;
+  double rrij,expn2,erfc2,expb,ecoul,evdwl,trx,tr,ftr;
 
   int itable;
 

--- a/src/USER-YAFF/pair_mm3_switch3_coulgauss_long.cpp
+++ b/src/USER-YAFF/pair_mm3_switch3_coulgauss_long.cpp
@@ -82,13 +82,13 @@ PairMM3Switch3CoulGaussLong::~PairMM3Switch3CoulGaussLong()
 
 void PairMM3Switch3CoulGaussLong::compute(int eflag, int vflag)
 {
-  int i,ii,j,jj,inum,jnum,itype,jtype,itable,jtable,ktable;
-  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,ecoul2,fpair;
-  double fraction,fraction2,table;
+  int i,ii,j,jj,inum,jnum,itype,jtype,itable;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
   double r,r2inv,r6inv,forcecoul,forcecoul2,forcelj,factor_coul,factor_lj,tr,ftr,trx;
-  double grij,expm2,prefactor,prefactor2,t,erfc1,erfc2,rrij,expn2,expb,g_ewald2i,g_ewaldi;
+  double grij,expm2,prefactor,prefactor2,t,erfc1,erfc2,rrij,expn2,expb;
   int *ilist,*jlist,*numneigh,**firstneigh;
-  double rsq, lookup_corr;
+  double rsq;
 
   evdwl = ecoul = 0.0;
   if (eflag || vflag) ev_setup(eflag,vflag);
@@ -109,9 +109,6 @@ void PairMM3Switch3CoulGaussLong::compute(int eflag, int vflag)
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
-  g_ewaldi = 1.0/g_ewald;
-  g_ewald2i = g_ewaldi*g_ewaldi;
-  lookup_corr = 0.0;
 
   // loop over neighbors of my atoms
   for (ii = 0; ii < inum; ii++) {
@@ -615,9 +612,9 @@ double PairMM3Switch3CoulGaussLong::single(int i, int j, int itype, int jtype,
                                  double factor_coul, double factor_lj,
                                  double &fforce)
 {
-  double r2inv,r6inv,r,grij,expm2,t,erfc1,prefactor,prefactor2,rrij,expn2,erfc2;
-  double fraction,table,forcecoul,forcecoul2,forcelj,phicoul,phicoul2,philj;
-  double expb, ecoul, evdwl, trx, tr, ftr;
+  double r2inv,r6inv,r,grij,expm2,t,erfc1,prefactor,prefactor2;
+  double fraction,table,forcecoul,forcecoul2,forcelj,phicoul;
+  double expb,rrij,expn2,erfc2,ecoul,evdwl,trx,tr,ftr;
 
   int itable;
 

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1161,23 +1161,23 @@ const char *Info::get_openmp_info()
 // specifications as posted at https://www.openmp.org/specifications/
 
 #if _OPENMP > 201811
-  return (const char *)"OpenMP newer than v5.0";
+  return (const char *)"OpenMP newer than version 5.0";
 #elif _OPENMP == 201811
-  return (const char *)"OpenMP v5.0";
+  return (const char *)"OpenMP 5.0";
 #elif _OPENMP == 201611
-  return (const char *)"OpenMP v5.0 preview 1";
+  return (const char *)"OpenMP 5.0 preview 1";
 #elif _OPENMP == 201511
-  return (const char *)"OpenMP v4.5";
+  return (const char *)"OpenMP 4.5";
 #elif _OPENMP == 201307
-  return (const char *)"OpenMP v4.0";
+  return (const char *)"OpenMP 4.0";
 #elif _OPENMP == 201107
-  return (const char *)"OpenMP v3.1";
+  return (const char *)"OpenMP 3.1";
 #elif _OPENMP == 200805
-  return (const char *)"OpenMP v3.0";
+  return (const char *)"OpenMP 3.0";
 #elif _OPENMP == 200505
-  return (const char *)"OpenMP v2.5";
+  return (const char *)"OpenMP 2.5";
 #elif _OPENMP == 200203
-  return (const char *)"OpenMP v2.0";
+  return (const char *)"OpenMP 2.0";
 #else
   return (const char *)"unknown OpenMP version";
 #endif

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1162,7 +1162,7 @@ const char *Info::get_openmp_info()
 
 #if _OPENMP > 201811
   return (const char *)"OpenMP newer than v5.0";
-#if _OPENMP == 201811
+#elif _OPENMP == 201811
   return (const char *)"OpenMP v5.0 or newer";
 #elif _OPENMP == 201511
   return (const char *)"OpenMP v4.5";

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1163,7 +1163,9 @@ const char *Info::get_openmp_info()
 #if _OPENMP > 201811
   return (const char *)"OpenMP newer than v5.0";
 #elif _OPENMP == 201811
-  return (const char *)"OpenMP v5.0 or newer";
+  return (const char *)"OpenMP v5.0";
+#elif _OPENMP == 201611
+  return (const char *)"OpenMP v5.0 preview 1";
 #elif _OPENMP == 201511
   return (const char *)"OpenMP v4.5";
 #elif _OPENMP == 201307

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -263,7 +263,7 @@ void Info::command(int narg, char **arg)
     fprintf(out,"\nLAMMPS version: %s / %s\n\n",
             universe->version, universe->num_ver);
 
-    char *infobuf = get_os_info();
+    const char *infobuf = get_os_info();
     fprintf(out,"OS information: %s\n\n",infobuf);
     delete[] infobuf;
 
@@ -273,7 +273,7 @@ void Info::command(int narg, char **arg)
     fprintf(out,"sizeof(bigint):   %3d-bit\n",(int)sizeof(bigint)*8);
 
     infobuf = get_compiler_info();
-    fprintf(out,"\nCompiler: %s\n",infobuf);
+    fprintf(out,"\nCompiler: %s with %s\n",infobuf,get_openmp_info());
     delete[] infobuf;
 
     fputs("\nActive compile time flags:\n\n",out);
@@ -1148,6 +1148,39 @@ char *Info::get_compiler_info()
   snprintf(buf,_INFOBUF_SIZE,"(Unknown)");
 #endif
   return buf;
+}
+
+const char *Info::get_openmp_info()
+{
+
+#if !defined(_OPENMP)
+  return (const char *)"OpenMP not enabled";
+#else
+
+// Supported OpenMP version corresponds to the release date of the
+// specifications as posted at https://www.openmp.org/specifications/
+
+#if _OPENMP > 201811
+  return (const char *)"OpenMP newer than v5.0";
+#if _OPENMP == 201811
+  return (const char *)"OpenMP v5.0 or newer";
+#elif _OPENMP == 201511
+  return (const char *)"OpenMP v4.5";
+#elif _OPENMP == 201307
+  return (const char *)"OpenMP v4.0";
+#elif _OPENMP == 201107
+  return (const char *)"OpenMP v3.1";
+#elif _OPENMP == 200805
+  return (const char *)"OpenMP v3.0";
+#elif _OPENMP == 200505
+  return (const char *)"OpenMP v2.5";
+#elif _OPENMP == 200203
+  return (const char *)"OpenMP v2.0";
+#else
+  return (const char *)"unknown OpenMP version";
+#endif
+
+#endif
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/info.h
+++ b/src/info.h
@@ -42,6 +42,7 @@ class Info : protected Pointers {
 
   static char *get_os_info();
   static char *get_compiler_info();
+  static const char *get_openmp_info();
 
   char **get_variable_names(int &num);
 

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -1087,7 +1087,7 @@ void LAMMPS::print_config(FILE *fp)
   delete[] infobuf;
 
   infobuf = Info::get_compiler_info();
-  fprintf(fp,"Compiler: %s\n\n",infobuf);
+  fprintf(fp,"Compiler: %s with %s\n\n",infobuf,Info::get_openmp_info());
   delete[] infobuf;
 
   fputs("Active compile time flags:\n\n",fp);


### PR DESCRIPTION
**Summary**

This pull request includes several small code maintenance related changes and adds support for detecting the supported OpenMP standard and outputting it in the help message and with `info config`

**Related Issues**

This PR adds documentation about how to use the script provided with USER-OMP to convert all OpenMP directives from using `default(none)` to `default(shared)`, to enhance compatibility with compilers having problems with `default(none)` or have incompatible semantics. This is a simple
workaround for the issue mentioned in #1326 until we come to a more permanent solution, e.g. one based on the prototype code in #1330 

**Author(s)**

Axel Kohlmeyer (ICTP)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under the GNU General Public License version 2.

My contribution may be re-licensed as LGPL (for use of LAMMPS as a library linked to proprietary software): yes

**Backward Compatibility**

yes.

**Implementation Notes**

The following individual changes are included:
- move download server for Voro++ library from LBL to download.lammps.org. The LBL server seems to crash rather regularly causing errors in integration testing on ci.lammps.org. 
- silence compiler warnings about unused parameters for new code and GPU/USER-OMP package
- some dead code removal in recently added sources
- new function in the Info class to detect the supported OpenMP version and translate the yyyymm code into the actual version number.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

n/a


