### PR TITLE
correct fix langevin with tally yes zero yes

### DIFF
--- a/doc/src/Errors_warnings.txt
+++ b/doc/src/Errors_warnings.txt
@@ -178,12 +178,6 @@ When using fixes like box/relax, the potential energy used by the minimizer
 is augmented by an additional energy provided by the fix. Thus the printed
 converged energy may be different from the total potential energy. :dd
 
-{Energy tally does not account for 'zero yes'} :dt
-
-The energy removed by using the 'zero yes' flag is not accounted
-for in the energy tally and thus energy conservation cannot be
-monitored in this case. :dd
-
 {Estimated error in splitting of dispersion coeffs is %g} :dt
 
 Error is greater than 0.0001 percent. :dd

--- a/doc/src/fix_langevin.txt
+++ b/doc/src/fix_langevin.txt
@@ -217,10 +217,6 @@ the particles.  As described below, this energy can then be printed
 out or added to the potential energy of the system to monitor energy
 conservation.
 
-NOTE: this accumulated energy does NOT include kinetic energy removed
-by the {zero} flag. LAMMPS will print a warning when both options are
-active.
-
 The keyword {zero} can be used to eliminate drift due to the
 thermostat. Because the random forces on different atoms are
 independent, they do not sum exactly to zero.  As a result, this fix

--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -605,6 +605,11 @@ void FixLangevin::post_force_untemplated
         f[i][0] -= fsumall[0];
         f[i][1] -= fsumall[1];
         f[i][2] -= fsumall[2];
+        if (Tp_TALLY) {
+          flangevin[i][0] -= fsumall[0];
+          flangevin[i][1] -= fsumall[1];
+          flangevin[i][2] -= fsumall[2];
+        }
       }
     }
   }

--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -177,8 +177,6 @@ FixLangevin::FixLangevin(LAMMPS *lmp, int narg, char **arg) :
     }
   }
 
-  if (tallyflag && zeroflag && comm->me == 0)
-    error->warning(FLERR,"Energy tally does not account for 'zero yes'");
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix_langevin.h
+++ b/src/fix_langevin.h
@@ -104,12 +104,6 @@ E: Fix langevin period must be > 0.0
 
 The time window for temperature relaxation must be > 0
 
-W: Energy tally does not account for 'zero yes'
-
-The energy removed by using the 'zero yes' flag is not accounted
-for in the energy tally and thus energy conservation cannot be
-monitored in this case.
-
 E: Fix langevin omega requires atom style sphere
 
 Self-explanatory.


### PR DESCRIPTION
**Summary**

Allow correct accounting of energy in fix langevin via 'tally yes' even when 'zero yes' option is enabled.

**Author(s)**

Donatas Surblys (Tohoku University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under the GNU General Public License version 2.

My contribution may be re-licensed as LGPL (for use of LAMMPS as a library linked to proprietary software): yes

**Backward Compatibility**

yes

**Implementation Notes**

When 'zero yes' is set, `fsumall` is the force that is subtracted from affected atoms to make the total random force 0. The modification simply reuses `fsumall` and subtracts it from `flangevin` that is used by 'tally yes'.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

An input script is attached, which demonstrates the effect of correctly accounting for energy with 'zero yes'. 

[in.test.txt](https://github.com/lammps/lammps/files/2864504/in.test.txt)


