### PR TITLE
Bonus data checks and updates

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -58,6 +58,7 @@ Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
   natoms = 0;
   nlocal = nghost = nmax = 0;
   ntypes = 0;
+  nellipsoids = nlines = ntris = nbodies = 0;
   nbondtypes = nangletypes = ndihedraltypes = nimpropertypes = 0;
   nbonds = nangles = ndihedrals = nimpropers = 0;
 
@@ -736,6 +737,45 @@ int Atom::tag_consecutive()
 
   if (idminall != 1 || idmaxall != natoms) return 0;
   return 1;
+}
+
+/* ----------------------------------------------------------------------
+   check that bonus data settings are valid
+   error if number of atoms with ellipsoid/line/tri/body flags
+   are consistent with global setting.
+------------------------------------------------------------------------- */
+
+void Atom::bonus_check()
+{
+  bigint local_ellipsoids = 0, local_lines = 0, local_tris = 0;
+  bigint local_bodies = 0, num_global;
+
+  for (int i = 0; i < nlocal; ++i) {
+    if (ellipsoid && (ellipsoid[i] >=0)) ++local_ellipsoids;
+    if (line && (line[i] >=0)) ++local_lines;
+    if (tri && (tri[i] >=0)) ++local_tris;
+    if (body && (body[i] >=0)) ++local_bodies;
+  }
+
+  MPI_Allreduce(&local_ellipsoids,&num_global,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  if (nellipsoids != num_global)
+    error->all(FLERR,"Inconsistent 'ellipsoids' header value and number of "
+               "atoms with enabled ellipsoid flags");
+
+  MPI_Allreduce(&local_lines,&num_global,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  if (nlines != num_global)
+    error->all(FLERR,"Inconsistent 'lines' header value and number of "
+               "atoms with enabled line flags");
+
+  MPI_Allreduce(&local_tris,&num_global,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  if (ntris != num_global)
+    error->all(FLERR,"Inconsistent 'tris' header value and number of "
+               "atoms with enabled tri flags");
+
+  MPI_Allreduce(&local_bodies,&num_global,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  if (nbodies != num_global)
+    error->all(FLERR,"Inconsistent 'bodies' header value and number of "
+               "atoms with enabled body flags");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom.h
+++ b/src/atom.h
@@ -34,6 +34,10 @@ class Atom : protected Pointers {
   int tag_enable;               // 0/1 if atom ID tags are defined
   int molecular;                // 0 = atomic, 1 = standard molecular system,
                                 // 2 = molecule template system
+  bigint nellipsoids;           // number of ellipsoids
+  bigint nlines;                // number of lines
+  bigint ntris;                 // number of triangles
+  bigint nbodies;               // number of bodies
 
   bigint nbonds,nangles,ndihedrals,nimpropers;
   int ntypes,nbondtypes,nangletypes,ndihedraltypes,nimpropertypes;
@@ -232,6 +236,8 @@ class Atom : protected Pointers {
   void tag_check();
   void tag_extend();
   int tag_consecutive();
+
+  void bonus_check();
 
   int parse_data(const char *);
   int count_words(const char *);

--- a/src/atom_vec_body.cpp
+++ b/src/atom_vec_body.cpp
@@ -1286,7 +1286,7 @@ void AtomVecBody::data_atom(double *coord, imageint imagetmp, char **values)
   body[nlocal] = atoi(values[2]);
   if (body[nlocal] == 0) body[nlocal] = -1;
   else if (body[nlocal] == 1) body[nlocal] = 0;
-  else error->one(FLERR,"Invalid atom type in Atoms section of data file");
+  else error->one(FLERR,"Invalid bodyflag in Atoms section of data file");
 
   rmass[nlocal] = atof(values[3]);
   if (rmass[nlocal] <= 0.0)

--- a/src/atom_vec_body.h
+++ b/src/atom_vec_body.h
@@ -92,6 +92,8 @@ class AtomVecBody : public AtomVec {
   double radius_body(int, int, int *, double *);
   void set_quat(int, double *);
 
+  int nlocal_bonus;
+
  private:
   tagint *tag;
   int *type,*mask;
@@ -102,7 +104,7 @@ class AtomVecBody : public AtomVec {
   double **angmom,**torque;
   int *body;
 
-  int nlocal_bonus,nghost_bonus,nmax_bonus;
+  int nghost_bonus,nmax_bonus;
   int intdoubleratio;       // sizeof(double) / sizeof(int)
 
   MyPoolChunk<int> *icp;

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -1148,7 +1148,7 @@ void AtomVecEllipsoid::data_atom(double *coord, imageint imagetmp,
   ellipsoid[nlocal] = atoi(values[2]);
   if (ellipsoid[nlocal] == 0) ellipsoid[nlocal] = -1;
   else if (ellipsoid[nlocal] == 1) ellipsoid[nlocal] = 0;
-  else error->one(FLERR,"Invalid atom type in Atoms section of data file");
+  else error->one(FLERR,"Invalid ellipsoidflag in Atoms section of data file");
 
   rmass[nlocal] = atof(values[3]);
   if (rmass[nlocal] <= 0.0)

--- a/src/atom_vec_ellipsoid.h
+++ b/src/atom_vec_ellipsoid.h
@@ -83,6 +83,8 @@ class AtomVecEllipsoid : public AtomVec {
 
   void set_shape(int, double, double, double);
 
+  int nlocal_bonus;
+
  private:
   tagint *tag;
   int *type,*mask;
@@ -92,7 +94,7 @@ class AtomVecEllipsoid : public AtomVec {
   double **angmom,**torque;
   int *ellipsoid;
 
-  int nlocal_bonus,nghost_bonus,nmax_bonus;
+  int nghost_bonus,nmax_bonus;
 
   void grow_bonus();
   void copy_bonus(int, int);

--- a/src/atom_vec_line.cpp
+++ b/src/atom_vec_line.cpp
@@ -1044,7 +1044,7 @@ void AtomVecLine::data_atom(double *coord, imageint imagetmp, char **values)
   line[nlocal] = atoi(values[3]);
   if (line[nlocal] == 0) line[nlocal] = -1;
   else if (line[nlocal] == 1) line[nlocal] = 0;
-  else error->one(FLERR,"Invalid atom type in Atoms section of data file");
+  else error->one(FLERR,"Invalid lineflag in Atoms section of data file");
 
   rmass[nlocal] = atof(values[4]);
   if (rmass[nlocal] <= 0.0)

--- a/src/atom_vec_line.h
+++ b/src/atom_vec_line.h
@@ -83,6 +83,8 @@ class AtomVecLine : public AtomVec {
 
   void set_length(int, double);
 
+  int nlocal_bonus;
+
  private:
   tagint *tag;
   int *type,*mask;
@@ -93,7 +95,7 @@ class AtomVecLine : public AtomVec {
   double **omega,**torque;
   int *line;
 
-  int nlocal_bonus,nghost_bonus,nmax_bonus;
+  int nghost_bonus,nmax_bonus;
 
   void grow_bonus();
   void copy_bonus(int, int);

--- a/src/atom_vec_tri.cpp
+++ b/src/atom_vec_tri.cpp
@@ -1443,7 +1443,7 @@ void AtomVecTri::data_atom(double *coord, imageint imagetmp, char **values)
   tri[nlocal] = atoi(values[3]);
   if (tri[nlocal] == 0) tri[nlocal] = -1;
   else if (tri[nlocal] == 1) tri[nlocal] = 0;
-  else error->one(FLERR,"Invalid atom type in Atoms section of data file");
+  else error->one(FLERR,"Invalid triflag in Atoms section of data file");
 
   rmass[nlocal] = atof(values[4]);
   if (rmass[nlocal] <= 0.0)

--- a/src/atom_vec_tri.h
+++ b/src/atom_vec_tri.h
@@ -85,6 +85,8 @@ class AtomVecTri : public AtomVec {
 
   void set_equilateral(int, double);
 
+  int nlocal_bonus;
+
  private:
   tagint *tag;
   int *type,*mask;
@@ -95,7 +97,7 @@ class AtomVecTri : public AtomVec {
   double **omega,**angmom,**torque;
   int *tri;
 
-  int nlocal_bonus,nghost_bonus,nmax_bonus;
+  int nghost_bonus,nmax_bonus;
 
   void grow_bonus();
   void copy_bonus(int, int);

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -140,19 +140,19 @@ void DeleteAtoms::command(int narg, char **arg)
 
   if (atom->nellipsoids > 0) {
     nlocal_bonus = avec_ellipsoid->nlocal_bonus;
-    MPI_Allreduce(&nlocal_bonus,&atom->nellipsoids,1,MPI_LMP_BIGINT,MPI_MIN,world);
+    MPI_Allreduce(&nlocal_bonus,&atom->nellipsoids,1,MPI_LMP_BIGINT,MPI_SUM,world);
   }
   if (atom->nlines > 0) {
     nlocal_bonus = avec_line->nlocal_bonus;
-    MPI_Allreduce(&nlocal_bonus,&atom->nlines,1,MPI_LMP_BIGINT,MPI_MIN,world);
+    MPI_Allreduce(&nlocal_bonus,&atom->nlines,1,MPI_LMP_BIGINT,MPI_SUM,world);
   }
   if (atom->ntris > 0) {
     nlocal_bonus = avec_tri->nlocal_bonus;
-    MPI_Allreduce(&nlocal_bonus,&atom->ntris,1,MPI_LMP_BIGINT,MPI_MIN,world);
+    MPI_Allreduce(&nlocal_bonus,&atom->ntris,1,MPI_LMP_BIGINT,MPI_SUM,world);
   }
   if (atom->nbodies > 0) {
     nlocal_bonus = avec_body->nlocal_bonus;
-    MPI_Allreduce(&nlocal_bonus,&atom->nbodies,1,MPI_LMP_BIGINT,MPI_MIN,world);
+    MPI_Allreduce(&nlocal_bonus,&atom->nbodies,1,MPI_LMP_BIGINT,MPI_SUM,world);
   }
 
   // reset atom->map if it exists

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -16,6 +16,10 @@
 #include "delete_atoms.h"
 #include "atom.h"
 #include "atom_vec.h"
+#include "atom_vec_ellipsoid.h"
+#include "atom_vec_line.h"
+#include "atom_vec_tri.h"
+#include "atom_vec_body.h"
 #include "molecule.h"
 #include "comm.h"
 #include "domain.h"
@@ -121,11 +125,39 @@ void DeleteAtoms::command(int narg, char **arg)
   }
 
   // reset atom->natoms and also topology counts
-  // reset atom->map if it exists
-  // set nghost to 0 so old ghosts of deleted atoms won't be mapped
 
   bigint nblocal = atom->nlocal;
   MPI_Allreduce(&nblocal,&atom->natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
+
+  // reset bonus data counts
+
+  AtomVecEllipsoid *avec_ellipsoid =
+    (AtomVecEllipsoid *) atom->style_match("ellipsoid");
+  AtomVecLine *avec_line = (AtomVecLine *) atom->style_match("line");
+  AtomVecTri *avec_tri = (AtomVecTri *) atom->style_match("tri");
+  AtomVecBody *avec_body = (AtomVecBody *) atom->style_match("body");
+  bigint nlocal_bonus;
+
+  if (atom->nellipsoids > 0) {
+    nlocal_bonus = avec_ellipsoid->nlocal_bonus;
+    MPI_Allreduce(&nlocal_bonus,&atom->nellipsoids,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  }
+  if (atom->nlines > 0) {
+    nlocal_bonus = avec_line->nlocal_bonus;
+    MPI_Allreduce(&nlocal_bonus,&atom->nlines,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  }
+  if (atom->ntris > 0) {
+    nlocal_bonus = avec_tri->nlocal_bonus;
+    MPI_Allreduce(&nlocal_bonus,&atom->ntris,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  }
+  if (atom->nbodies > 0) {
+    nlocal_bonus = avec_body->nlocal_bonus;
+    MPI_Allreduce(&nlocal_bonus,&atom->nbodies,1,MPI_LMP_BIGINT,MPI_MIN,world);
+  }
+
+  // reset atom->map if it exists
+  // set nghost to 0 so old ghosts of deleted atoms won't be mapped
+
   if (atom->map_style) {
     atom->nghost = 0;
     atom->map_init();

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -396,7 +396,8 @@ void ReadData::command(int narg, char **arg)
 
   // values in this data file
 
-  natoms = ntypes = 0;
+  natoms = 0;
+  ntypes = 0;
   nbonds = nangles = ndihedrals = nimpropers = 0;
   nbondtypes = nangletypes = ndihedraltypes = nimpropertypes = 0;
 
@@ -993,18 +994,29 @@ void ReadData::header(int firstpass)
       if (!avec_ellipsoid)
         error->all(FLERR,"No ellipsoids allowed with this atom style");
       sscanf(line,BIGINT_FORMAT,&nellipsoids);
+      if (addflag == NONE) atom->nellipsoids = nellipsoids;
+      else if (firstpass) atom->nellipsoids += nellipsoids;
+
     } else if (strstr(line,"lines")) {
       if (!avec_line)
         error->all(FLERR,"No lines allowed with this atom style");
       sscanf(line,BIGINT_FORMAT,&nlines);
+      if (addflag == NONE) atom->nlines = nlines;
+      else if (firstpass) atom->nlines += nlines;
+
     } else if (strstr(line,"triangles")) {
       if (!avec_tri)
         error->all(FLERR,"No triangles allowed with this atom style");
       sscanf(line,BIGINT_FORMAT,&ntris);
+      if (addflag == NONE) atom->ntris = ntris;
+      else if (firstpass) atom->ntris += ntris;
+
     } else if (strstr(line,"bodies")) {
       if (!avec_body)
         error->all(FLERR,"No bodies allowed with this atom style");
       sscanf(line,BIGINT_FORMAT,&nbodies);
+      if (addflag == NONE) atom->nbodies = nbodies;
+      else if (firstpass) atom->nbodies += nbodies;
 
     } else if (strstr(line,"bonds")) {
       sscanf(line,BIGINT_FORMAT,&nbonds);
@@ -1084,6 +1096,10 @@ void ReadData::header(int firstpass)
   // error check on total system size
 
   if (atom->natoms < 0 || atom->natoms >= MAXBIGINT ||
+      atom->nellipsoids < 0 || atom->nellipsoids >= MAXBIGINT ||
+      atom->nlines < 0 || atom->nlines >= MAXBIGINT ||
+      atom->ntris < 0 || atom->ntris >= MAXBIGINT ||
+      atom->nbodies < 0 || atom->nbodies >= MAXBIGINT ||
       atom->nbonds < 0 || atom->nbonds >= MAXBIGINT ||
       atom->nangles < 0 || atom->nangles >= MAXBIGINT ||
       atom->ndihedrals < 0 || atom->ndihedrals >= MAXBIGINT ||
@@ -1173,6 +1189,10 @@ void ReadData::atoms()
   // check that atom IDs are valid
 
   atom->tag_check();
+
+  // check that bonus data has been reserved as needed
+
+  atom->bonus_check();
 
   // create global mapping of atoms
 

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -964,6 +964,21 @@ void Set::set(int keyword)
     count++;
   }
 
+  // update bonus data numbers
+  if (keyword == SHAPE) {
+    bigint nlocal_bonus = avec_ellipsoid->nlocal_bonus;
+    MPI_Allreduce(&nlocal_bonus,&atom->nellipsoids,1,
+                  MPI_LMP_BIGINT,MPI_SUM,world);
+  }
+  if (keyword == LENGTH) {
+    bigint nlocal_bonus = avec_line->nlocal_bonus;
+    MPI_Allreduce(&nlocal_bonus,&atom->nlines,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  }
+  if (keyword == TRI) {
+    bigint nlocal_bonus = avec_tri->nlocal_bonus;
+    MPI_Allreduce(&nlocal_bonus,&atom->ntris,1,MPI_LMP_BIGINT,MPI_SUM,world);
+  }
+
   // clear up per-atom memory if allocated
 
   memory->destroy(vec1);

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -177,6 +177,17 @@ void WriteData::write(char *file)
     MPI_Allreduce(&nimpropers_local,&nimpropers,1,MPI_LMP_BIGINT,MPI_SUM,world);
   }
 
+  // check for bonus data.
+  if (me == 0) {
+    if ((atom->nellipsoids > 0)
+        || (atom->nlines > 0)
+        || (atom->ntris > 0)
+        || (atom->nbodies > 0))
+      error->warning(FLERR,"System has ellipsoids, lines, triangles, or bodies. "
+                     "Those are not yet supported by write_data. The data file "
+                     "will thus be incomplete.");
+  }
+
   // open data file
 
   if (me == 0) {


### PR DESCRIPTION
**Summary**

This PR adds global counters for bonus structure elements, so there can be consistency checks when reading data files and the corresponding data can be included when using `write_data`

**Related Issues**

implements most of what is requested in #1327 
write support for bonus data in data files will be added in a separated pull request.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under the GNU General Public License version 2.
My contribution may be re-licensed as LGPL: yes

**Backward Compatibility**

yes. 

**Implementation Notes**

- [x] Checks in `read_data`
- [x] Update counters when using `delete_atoms`
- [x] Update counters when using `set`
- [ ] Add support to `write_data`

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


