### PR TITLE
Fixed bug in lammps_scatter_atoms_subset...

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1363,9 +1363,11 @@ void lammps_scatter_atoms_subset(void *ptr, char *name,
       int *dptr = (int *) data;
 
       if (count == 1) {
-        for (i = 0; i < ndata; i++)
-          if ((m = lmp->atom->map(i+1)) >= 0)
+        for (i = 0; i < ndata; i++) {
+          id = ids[i];
+          if ((m = lmp->atom->map(id)) >= 0)
             vector[m] = dptr[i];
+        }
 
       } else if (imgpack) {
         for (i = 0; i < ndata; i++) {


### PR DESCRIPTION
**Summary**
```ids``` array was ignored in case of single-value integer arrays (e.g. type, id, ...)

**Related Issues**

Fixes #1343

**Author(s)**

Eugen Rožić, PhD student at UCL

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under the GNU General Public License version 2.

My contribution may be re-licensed as LGPL (for use of LAMMPS as a library linked to proprietary software): yes

**Backward Compatibility**

Yes

**Implementation Notes**

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
