### PR TITLE
Optimization for create_atoms with regions (2nd attempt)

### DIFF
--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -705,6 +705,26 @@ void CreateAtoms::add_lattice()
     bboxlo[2] = domain->sublo[2]; bboxhi[2] = domain->subhi[2];
   } else domain->bbox(domain->sublo_lamda,domain->subhi_lamda,bboxlo,bboxhi);
 
+  // narrow down the subbox by the bounding box of the given region, if available.
+  // for small regions in large boxes, this can result in a significant speedup
+
+  if ((style == REGION) && domain->regions[nregion]->bboxflag) {
+
+    const double rxmin = domain->regions[nregion]->extent_xlo;
+    const double rxmax = domain->regions[nregion]->extent_xhi;
+    const double rymin = domain->regions[nregion]->extent_ylo;
+    const double rymax = domain->regions[nregion]->extent_yhi;
+    const double rzmin = domain->regions[nregion]->extent_zlo;
+    const double rzmax = domain->regions[nregion]->extent_zhi;
+
+    if (rxmin > bboxlo[0]) bboxlo[0] = (rxmin > bboxhi[0]) ? bboxhi[0] : rxmin;
+    if (rxmax < bboxhi[0]) bboxhi[0] = (rxmax < bboxlo[0]) ? bboxlo[0] : rxmax;
+    if (rymin > bboxlo[1]) bboxlo[1] = (rymin > bboxhi[1]) ? bboxhi[1] : rymin;
+    if (rymax < bboxhi[1]) bboxhi[1] = (rymax < bboxlo[1]) ? bboxlo[1] : rymax;
+    if (rzmin > bboxlo[2]) bboxlo[2] = (rzmin > bboxhi[2]) ? bboxhi[2] : rzmin;
+    if (rzmax < bboxhi[2]) bboxhi[2] = (rzmax < bboxlo[2]) ? bboxlo[2] : rzmax;
+  }
+
   double xmin,ymin,zmin,xmax,ymax,zmax;
   xmin = ymin = zmin = BIG;
   xmax = ymax = zmax = -BIG;


### PR DESCRIPTION

**Summary**

New attempt at the create_atoms optimization for small regions in large boxes
this passes the test input with the rotated lattice

_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request._

**Related Issues**

This is a re-implementation of the code that was removed in commit 1b4ed9cb8d0bb682d4b844a3e90d4531e940209b

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under the GNU General Public License version 2.

My contribution may be re-licensed as LGPL: yes

**Backward Compatibility**

yes

**Implementation Notes**

To avoid any issues with lattices, the bounding box used for the lattice point loops is now updated right at the beginning of the `set_lattice()` function, where the per-MPI-rank subbox is determined in regular coordinates.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


