### PR TITLE
A partial fix for ReaxFF failure when the number of atoms increases during a simulation

### DIFF
--- a/src/USER-REAXC/fix_reaxc.cpp
+++ b/src/USER-REAXC/fix_reaxc.cpp
@@ -41,16 +41,15 @@ FixReaxC::FixReaxC(LAMMPS *lmp,int narg, char **arg) :
 {
   // perform initial allocation of atom-based arrays
   // register with atom class
-
+  
+  oldnmax = 0;
   num_bonds = NULL;
   num_hbonds = NULL;
   grow_arrays(atom->nmax);
   atom->add_callback(0);
 
   // initialize arrays to MIN so atom migration is OK the 1st time
-
-  for (int i = 0; i < atom->nmax; i++)
-    num_bonds[i] = num_hbonds[i] = MIN_REAX_BONDS;
+  // it is done in grow_arrays() now
 
   // set comm sizes needed by this fix
 
@@ -98,6 +97,11 @@ void FixReaxC::grow_arrays(int nmax)
 {
   memory->grow(num_bonds,nmax,"reaxc:num_bonds");
   memory->grow(num_hbonds,nmax,"reaxc:num_hbonds");
+  for (int i = oldnmax; i < nmax; i++) {
+    num_hbonds[i] = MIN_REAX_HBONDS;
+    num_bonds[i] = MIN_REAX_BONDS;
+  }
+  oldnmax = nmax;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-REAXC/fix_reaxc.cpp
+++ b/src/USER-REAXC/fix_reaxc.cpp
@@ -49,8 +49,7 @@ FixReaxC::FixReaxC(LAMMPS *lmp,int narg, char **arg) :
 
   // initialize arrays to MIN so atom migration is OK the 1st time
 
-  int nlocal = atom->nlocal;
-  for (int i = 0; i < nlocal; i++)
+  for (int i = 0; i < atom->nmax; i++)
     num_bonds[i] = num_hbonds[i] = MIN_REAX_BONDS;
 
   // set comm sizes needed by this fix

--- a/src/USER-REAXC/fix_reaxc.h
+++ b/src/USER-REAXC/fix_reaxc.h
@@ -56,6 +56,7 @@ class FixReaxC : public Fix {
   int maxhbonds;             // max # of Hbonds for any atom
   int *num_bonds;            // # of bonds for each atom
   int *num_hbonds;           // # of Hbonds for each atom
+  int oldnmax;               // arrays' size before growing
 };
 
 }


### PR DESCRIPTION
**Summary**

This pull request fixes partially a long-standing issue of ReaxFF and increasing number of atoms. Briefly, if the number of atoms increase too much during a simulation, LAMMPS exits with an error similar to the one below:
`p0: not enough space for bonds! total=1516016387 allocated=25000`
A simple input script which triggers the problem is attached.

**Author(s)**

Michał Kański, Jagiellonian University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

**Implementation Notes**

Two arrays (num_bonds and num_hbonds) in fix_reaxc.cpp are used for selecting space for bonds of a given atom. At the beginning the arrays are not fully initialized, which leads to problems when the number of atoms increases. The fix is to initialize the entire arrays. 

This is only a partial fix, because "mincap" keyword has to be used as in the attached example. There is also a corner case which remains unaddressed - the simulation will fail if there is at least one MPI thread without any ReaxFF bonds/hbonds. However, I think that this pull request can be merged as-is since it solves most of the problems.    

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

[input.in.txt](https://github.com/lammps/lammps/files/2919455/input.in.txt) - It creates a water molecule file and uses it with fix deposit and ReaxFF.


