### PR TITLE
Embed git branch and revision info

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1332,22 +1332,38 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LAMMPS_STYLE_HE
 # Generate lmpgitversion.h
 ######################################
 set(temp "#ifndef LMP_GIT_VERSION_H\n#define LMP_GIT_VERSION_H\n")
-set(temp "${temp}const char LAMMPS_NS::LAMMPS::git_version[] =")
+set(temp_git_commit "(unknown)")
+set(temp_git_branch "(unknown)")
+set(temp_git_describe "(unknown)")
+set(temp_git_info "false")
 if(GIT_FOUND)
   execute_process(COMMAND ${GIT_EXECUTABLE} describe HEAD
-    OUTPUT_VARIABLE temp_git_version
+    RESULT_VARIABLE temp_in_git_checkout
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-    OUTPUT_VARIABLE temp_git_branch
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  set(temp_git "${temp_git_branch} / ${temp_git_version}")
-else()
-  set(temp_git "")
+  if(temp_in_git_checkout EQUAL 0)
+    set(temp_git_info "true")
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+      OUTPUT_VARIABLE temp_git_commit
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+      OUTPUT_VARIABLE temp_git_branch
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty=-modified
+      OUTPUT_VARIABLE temp_git_describe
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
 endif()
 
-set(temp "${temp} \"${temp_git}\";\n#endif\n\n")
+set(temp "${temp}const bool LAMMPS_NS::LAMMPS::has_git_info = ${temp_git_info};\n")
+set(temp "${temp}const char LAMMPS_NS::LAMMPS::git_commit[] = \"${temp_git_commit}\";\n")
+set(temp "${temp}const char LAMMPS_NS::LAMMPS::git_branch[] = \"${temp_git_branch}\";\n")
+set(temp "${temp}const char LAMMPS_NS::LAMMPS::git_descriptor[] = \"${temp_git_describe}\";\n")
+set(temp "${temp}#endif\n\n")
+
 message(STATUS "Generating lmpgitversion.h...")
 file(WRITE "${LAMMPS_STYLE_HEADERS_DIR}/lmpgitversion.h.tmp" "${temp}" )
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LAMMPS_STYLE_HEADERS_DIR}/lmpgitversion.h.tmp" "${LAMMPS_STYLE_HEADERS_DIR}/lmpgitversion.h")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -11,6 +11,8 @@ get_filename_component(LAMMPS_LIB_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../lib 
 get_filename_component(LAMMPS_LIB_BINARY_DIR ${CMAKE_BINARY_DIR}/lib ABSOLUTE)
 get_filename_component(LAMMPS_DOC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../doc ABSOLUTE)
 
+find_package(Git)
+
 # by default, install into $HOME/.local (not /usr/local), so that no root access (and sudo!!) is needed
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/.local" CACHE PATH "default install path" FORCE )
@@ -85,7 +87,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" BTYPE)
 # this is fast, so check for it all the time
 message(STATUS "Running check for auto-generated files from make-based build system")
 file(GLOB SRC_AUTOGEN_FILES ${LAMMPS_SOURCE_DIR}/style_*.h)
-list(APPEND SRC_AUTOGEN_FILES ${LAMMPS_SOURCE_DIR}/lmpinstalledpkgs.h)
+list(APPEND SRC_AUTOGEN_FILES ${LAMMPS_SOURCE_DIR}/lmpinstalledpkgs.h ${LAMMPS_SOURCE_DIR}/lmpgitversion.h)
 foreach(_SRC ${SRC_AUTOGEN_FILES})
   get_filename_component(FILENAME "${_SRC}" NAME)
   if(EXISTS ${LAMMPS_SOURCE_DIR}/${FILENAME})
@@ -1325,6 +1327,30 @@ set(temp "${temp}  NULL\n};\n#endif\n\n")
 message(STATUS "Generating lmpinstalledpkgs.h...")
 file(WRITE "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h.tmp" "${temp}" )
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h.tmp" "${LAMMPS_STYLE_HEADERS_DIR}/lmpinstalledpkgs.h")
+
+######################################
+# Generate lmpgitversion.h
+######################################
+set(temp "#ifndef LMP_GIT_VERSION_H\n#define LMP_GIT_VERSION_H\n")
+set(temp "${temp}const char LAMMPS_NS::LAMMPS::git_version[] =")
+if(GIT_FOUND)
+  execute_process(COMMAND ${GIT_EXECUTABLE} describe HEAD
+    OUTPUT_VARIABLE temp_git_version
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+    OUTPUT_VARIABLE temp_git_branch
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(temp_git "${temp_git_branch} / ${temp_git_version}")
+else()
+  set(temp_git "")
+endif()
+
+set(temp "${temp} \"${temp_git}\";\n#endif\n\n")
+message(STATUS "Generating lmpgitversion.h...")
+file(WRITE "${LAMMPS_STYLE_HEADERS_DIR}/lmpgitversion.h.tmp" "${temp}" )
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LAMMPS_STYLE_HEADERS_DIR}/lmpgitversion.h.tmp" "${LAMMPS_STYLE_HEADERS_DIR}/lmpgitversion.h")
 
 ###########################################
 # Actually add executable and lib to build

--- a/src/Makefile
+++ b/src/Makefile
@@ -171,13 +171,21 @@ gitversion:
 	@echo 'Gathering git version information'
 	@echo '#ifndef LMP_GIT_VERSION_H' >  ${TMPNAME}.lmpgitversion
 	@echo '#define LMP_GIT_VERSION_H' >> ${TMPNAME}.lmpgitversion
-	@echo 'const char LAMMPS_NS::LAMMPS::git_version[] = ' >> ${TMPNAME}.lmpgitversion
 	@if (type git && git describe HEAD ) >> /dev/null 2>> /dev/null ; then \
-	  export v1=$$(git rev-parse --abbrev-ref HEAD); export v2=$$(git describe HEAD); \
-	  echo "\"$${v1} / $${v2}\";" >> ${TMPNAME}.lmpgitversion ; \
+	  git='true';					\
+	  commit=$$(git rev-parse HEAD);		\
+	  branch=$$(git rev-parse --abbrev-ref HEAD);	\
+	  describe=$$(git describe --dirty=-modified);	\
 	else \
-	  echo '"";' >> ${TMPNAME}.lmpgitversion ; \
-	fi
+	  git='false' ;					\
+	  commit='(unknown)' ;				\
+	  branch='(unknown)' ;				\
+	  describe='(unknown)' ;			\
+	fi ; \
+	echo "const bool LAMMPS_NS::LAMMPS::has_git_info = $${git};"        >> ${TMPNAME}.lmpgitversion ; \
+	echo "const char LAMMPS_NS::LAMMPS::git_commit[] = \"$${commit}\";" >> ${TMPNAME}.lmpgitversion ; \
+	echo "const char LAMMPS_NS::LAMMPS::git_branch[] = \"$${branch}\";" >> ${TMPNAME}.lmpgitversion ; \
+	echo "const char LAMMPS_NS::LAMMPS::git_descriptor[] = \"$${describe}\";" >> ${TMPNAME}.lmpgitversion
 	@echo '#endif' >> ${TMPNAME}.lmpgitversion
 	@if [ -f lmpgitversion.h ]; \
           then test "`diff --brief ${TMPNAME}.lmpgitversion lmpgitversion.h`" != "" && \

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ OBJDIR =   Obj_$@
 OBJSHDIR = Obj_shared_$@
 
 SRC =	$(wildcard *.cpp)
-INC =	$(filter-out lmpinstalledpkgs.h,$(wildcard *.h))
+INC =	$(filter-out lmpinstalledpkgs.h lmpgitversion.h,$(wildcard *.h))
 OBJ = 	$(SRC:.cpp=.o)
 
 SRCLIB = $(filter-out main.cpp,$(SRC))
@@ -167,6 +167,23 @@ lmpinstalledpkgs.h: $(SRC) $(INC)
 	        mv ${TMPNAME}.lmpinstalled lmpinstalledpkgs.h || rm ${TMPNAME}.lmpinstalled ; \
         else mv ${TMPNAME}.lmpinstalled lmpinstalledpkgs.h ; fi
 
+gitversion:
+	@echo 'Gathering git version information'
+	@echo '#ifndef LMP_GIT_VERSION_H' >  ${TMPNAME}.lmpgitversion
+	@echo '#define LMP_GIT_VERSION_H' >> ${TMPNAME}.lmpgitversion
+	@echo 'const char LAMMPS_NS::LAMMPS::git_version[] = ' >> ${TMPNAME}.lmpgitversion
+	@if (type git && git describe HEAD ) >> /dev/null 2>> /dev/null ; then \
+	  export v1=$$(git rev-parse --abbrev-ref HEAD); export v2=$$(git describe HEAD); \
+	  echo "\"$${v1} / $${v2}\";" >> ${TMPNAME}.lmpgitversion ; \
+	else \
+	  echo '"";' >> ${TMPNAME}.lmpgitversion ; \
+	fi
+	@echo '#endif' >> ${TMPNAME}.lmpgitversion
+	@if [ -f lmpgitversion.h ]; \
+          then test "`diff --brief ${TMPNAME}.lmpgitversion lmpgitversion.h`" != "" && \
+	        mv ${TMPNAME}.lmpgitversion lmpgitversion.h || rm ${TMPNAME}.lmpgitversion ; \
+        else mv ${TMPNAME}.lmpgitversion lmpgitversion.h ; fi
+
 # Build LAMMPS in one of 4 modes
 # exe =   exe with static compile in Obj_machine (default)
 # shexe = exe with shared compile in Obj_shared_machine
@@ -180,7 +197,7 @@ lmpinstalledpkgs.h: $(SRC) $(INC)
 	  -f MAKE/MACHINES/Makefile.$@ -o -f MAKE/MINE/Makefile.$@
 	@if [ ! -d $(objdir) ]; then mkdir $(objdir); fi
 	@$(SHELL) Make.sh style
-	@$(MAKE) $(MFLAGS) lmpinstalledpkgs.h
+	@$(MAKE) $(MFLAGS) lmpinstalledpkgs.h gitversion
 	@echo 'Compiling LAMMPS for machine $@'
 	@if [ -f MAKE/MACHINES/Makefile.$@ ]; \
 	  then cp MAKE/MACHINES/Makefile.$@ $(objdir)/Makefile; fi

--- a/src/Purge.list
+++ b/src/Purge.list
@@ -24,6 +24,7 @@ style_nstencil.h
 style_ntopo.h
 # other auto-generated files
 lmpinstalledpkgs.h
+lmpgitversion.h
 # renamed on 7 January 2019
 pair_lebedeva.cpp
 pair_lebedeva.h

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -260,9 +260,13 @@ void Info::command(int narg, char **arg)
   fprintf(out,"Printed on %s\n",ctime(&now));
 
   if (flags & CONFIG) {
-    fprintf(out,"\nLAMMPS version: %s / %s\n\n",
-            universe->version, universe->num_ver);
-
+    if (strlen(lmp->git_version) > 0) {
+      fprintf(out,"\nLAMMPS version: %s / %s\nGit revision: %s\n\n",
+              universe->version, universe->num_ver,lmp->git_version);
+    } else {
+      fprintf(out,"\nLAMMPS version: %s / %s\n\n",
+              universe->version, universe->num_ver);
+    }
     const char *infobuf = get_os_info();
     fprintf(out,"OS information: %s\n\n",infobuf);
     delete[] infobuf;

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -260,9 +260,10 @@ void Info::command(int narg, char **arg)
   fprintf(out,"Printed on %s\n",ctime(&now));
 
   if (flags & CONFIG) {
-    if (strlen(lmp->git_version) > 0) {
-      fprintf(out,"\nLAMMPS version: %s / %s\nGit revision: %s\n\n",
-              universe->version, universe->num_ver,lmp->git_version);
+    if (lmp->has_git_info) {
+      fprintf(out,"\nLAMMPS version: %s / %s\nGit info: %s / %s / %s\n\n",
+              universe->version, universe->num_ver,lmp->git_branch,
+              lmp->git_descriptor,lmp->git_commit);
     } else {
       fprintf(out,"\nLAMMPS version: %s / %s\n\n",
               universe->version, universe->num_ver);

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -497,11 +497,15 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((universe->me == 0) && (!helpflag)) {
       if (universe->uscreen) {
         fprintf(universe->uscreen,"LAMMPS (%s)\n",universe->version);
+        if (strlen(git_version) > 0)
+           fprintf(universe->uscreen,"Git revision (%s)\n",git_version);
         fprintf(universe->uscreen,"Running on %d partitions of processors\n",
                 universe->nworlds);
       }
       if (universe->ulogfile) {
         fprintf(universe->ulogfile,"LAMMPS (%s)\n",universe->version);
+        if (strlen(git_version) > 0)
+           fprintf(universe->ulogfile,"Git revision (%s)\n",git_version);
         fprintf(universe->ulogfile,"Running on %d partitions of processors\n",
                 universe->nworlds);
       }
@@ -510,10 +514,14 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((me == 0) && (!helpflag)) {
       if (screen) {
         fprintf(screen,"LAMMPS (%s)\n",universe->version);
+        if (strlen(git_version) > 0)
+           fprintf(screen,"Git revision (%s)\n",git_version);
         fprintf(screen,"Processor partition = %d\n",universe->iworld);
       }
       if (logfile) {
         fprintf(logfile,"LAMMPS (%s)\n",universe->version);
+        if (strlen(git_version) > 0)
+           fprintf(logfile,"Git revision (%s)\n",git_version);
         fprintf(logfile,"Processor partition = %d\n",universe->iworld);
       }
     }
@@ -903,9 +911,16 @@ void LAMMPS::help()
 
   // general help message about command line and flags
 
+  if (strlen(git_version) > 0) {
+    fprintf(fp,
+            "\nLarge-scale Atomic/Molecular Massively Parallel Simulator - "
+            LAMMPS_VERSION "\nGit revision (%s)\n\n",git_version);
+  } else {
+    fprintf(fp,
+            "\nLarge-scale Atomic/Molecular Massively Parallel Simulator - "
+            LAMMPS_VERSION "\n\n");
+  }
   fprintf(fp,
-          "\nLarge-scale Atomic/Molecular Massively Parallel Simulator - "
-          LAMMPS_VERSION "\n\n"
           "Usage example: %s -var t 300 -echo screen -in in.alloy\n\n"
           "List of command line options supported by this LAMMPS executable:\n\n"
           "-echo none/screen/log/both  : echoing of input script (-e)\n"

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -419,10 +419,6 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((universe->me == 0) && !helpflag) {
       if (screen) fprintf(screen,"LAMMPS (%s)\n",universe->version);
       if (logfile) fprintf(logfile,"LAMMPS (%s)\n",universe->version);
-      if (strlen(git_version) > 0) {
-        if (screen) fprintf(screen,"Git revision (%s)\n",git_version);
-        if (logfile) fprintf(logfile,"Git revision (%s)\n",git_version);
-      }
     }
 
   // universe is one or more worlds, as setup by partition switch
@@ -497,15 +493,11 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((universe->me == 0) && (!helpflag)) {
       if (universe->uscreen) {
         fprintf(universe->uscreen,"LAMMPS (%s)\n",universe->version);
-        if (strlen(git_version) > 0)
-           fprintf(universe->uscreen,"Git revision (%s)\n",git_version);
         fprintf(universe->uscreen,"Running on %d partitions of processors\n",
                 universe->nworlds);
       }
       if (universe->ulogfile) {
         fprintf(universe->ulogfile,"LAMMPS (%s)\n",universe->version);
-        if (strlen(git_version) > 0)
-           fprintf(universe->ulogfile,"Git revision (%s)\n",git_version);
         fprintf(universe->ulogfile,"Running on %d partitions of processors\n",
                 universe->nworlds);
       }
@@ -514,14 +506,10 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((me == 0) && (!helpflag)) {
       if (screen) {
         fprintf(screen,"LAMMPS (%s)\n",universe->version);
-        if (strlen(git_version) > 0)
-           fprintf(screen,"Git revision (%s)\n",git_version);
         fprintf(screen,"Processor partition = %d\n",universe->iworld);
       }
       if (logfile) {
         fprintf(logfile,"LAMMPS (%s)\n",universe->version);
-        if (strlen(git_version) > 0)
-           fprintf(logfile,"Git revision (%s)\n",git_version);
         fprintf(logfile,"Processor partition = %d\n",universe->iworld);
       }
     }
@@ -911,13 +899,11 @@ void LAMMPS::help()
 
   // general help message about command line and flags
 
-  if (strlen(git_version) > 0) {
-    fprintf(fp,
-            "\nLarge-scale Atomic/Molecular Massively Parallel Simulator - "
-            LAMMPS_VERSION "\nGit revision (%s)\n\n",git_version);
+  if (has_git_info) {
+    fprintf(fp,"\nLarge-scale Atomic/Molecular Massively Parallel Simulator - "
+            LAMMPS_VERSION "\nGit info (%s / %s)\n\n",git_branch, git_descriptor);
   } else {
-    fprintf(fp,
-            "\nLarge-scale Atomic/Molecular Massively Parallel Simulator - "
+    fprintf(fp,"\nLarge-scale Atomic/Molecular Massively Parallel Simulator - "
             LAMMPS_VERSION "\n\n");
   }
   fprintf(fp,

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -52,6 +52,7 @@
 #include "error.h"
 
 #include "lmpinstalledpkgs.h"
+#include "lmpgitversion.h"
 
 using namespace LAMMPS_NS;
 
@@ -418,6 +419,10 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((universe->me == 0) && !helpflag) {
       if (screen) fprintf(screen,"LAMMPS (%s)\n",universe->version);
       if (logfile) fprintf(logfile,"LAMMPS (%s)\n",universe->version);
+      if (strlen(git_version) > 0) {
+        if (screen) fprintf(screen,"Git revision (%s)\n",git_version);
+        if (logfile) fprintf(logfile,"Git revision (%s)\n",git_version);
+      }
     }
 
   // universe is one or more worlds, as setup by partition switch

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -64,7 +64,11 @@ class LAMMPS {
   class CiteMe *citeme;          // citation info
 
   static const char * installed_packages[];
-  static const char git_version[];
+
+  static const bool has_git_info;
+  static const char git_commit[];
+  static const char git_branch[];
+  static const char git_descriptor[];
 
   LAMMPS(int, char **, MPI_Comm);
   ~LAMMPS();

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -64,6 +64,7 @@ class LAMMPS {
   class CiteMe *citeme;          // citation info
 
   static const char * installed_packages[];
+  static const char git_version[];
 
   LAMMPS(int, char **, MPI_Comm);
   ~LAMMPS();


### PR DESCRIPTION
**Summary**

When compiling LAMMPS in a working git checkout and git is installed, put some git revision info into `LAMMPS_NS::LAMMPS::git_version` and output it so one can tell which branch and revision a development binary was built with. Otherwise, this string will be empty and nothing additional is printed.

**Related Issues**

might also be useful to address some common scenarios of #1278 
perhaps we can use this info or something equivalent like comparing the hash of the HEAD revision to what it was the last time cmake was run and thus detect when cmake needs to be re-run due to switching or updating branches. in my experience, those are two cases, where having re-running cmake triggered automatically, would be extremely useful and convenient.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Not sure how portable the added script code is. 

**Implementation Notes**

FindGit.cmake is available since 2010 so it should be in CMake 2.8.12, which is the minimum CMake version required

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


