### PR TITLE
Updates to dynamical_matrix

### DIFF
--- a/src/USER-PHONON/dynamical_matrix.cpp
+++ b/src/USER-PHONON/dynamical_matrix.cpp
@@ -262,6 +262,7 @@ void DynamicalMatrix::calculateMatrix()
     if (comm->me == 0 && screen) fprintf(screen,"Calculating Dynamical Matrix...\n");
 
     update->nsteps = 0;
+    int prog = 0;
     for (bigint i=1; i<=natoms; i++){
         local_idx = atom->map(i);
         for (bigint alpha=0; alpha<3; alpha++){
@@ -300,7 +301,16 @@ void DynamicalMatrix::calculateMatrix()
         if (me == 0)
             writeMatrix(fdynmat);
         dynmat_clear(dynmat);
+        if (comm->me == 0 && screen) {
+            int p = 10 * i / natoms;
+            if (p > prog) {
+              prog = p;
+              fprintf(screen," %d%%",p*10);
+              fflush(screen);
+            }
+        }
     }
+    if (comm->me == 0 && screen) fprintf(screen,"\n");
 
     for (int i=0; i < 3; i++)
         delete [] dynmat[i];

--- a/src/USER-PHONON/dynamical_matrix.cpp
+++ b/src/USER-PHONON/dynamical_matrix.cpp
@@ -319,28 +319,24 @@ void DynamicalMatrix::calculateMatrix()
 
 void DynamicalMatrix::writeMatrix(double **dynmat)
 {
-    if (me != 0 || fp == NULL) return;
+    if (me != 0 || !fp)
+        return;
 
-    // print file comment lines
-
-    if (!binaryflag && fp) {
-        clearerr(fp);
+    clearerr(fp);
+    if (binaryflag) {
+        for (int i=0; i<3; i++)
+            fwrite(dynmat[i], sizeof(double), dynlen, fp);
+        if (ferror(fp))
+            error->one(FLERR, "Error writing to binary file");
+    } else {
         for (int i = 0; i < 3; i++) {
             for (bigint j = 0; j < dynlen; j++) {
                 if ((j+1)%3==0) fprintf(fp, "%4.8f\n", dynmat[i][j]);
                 else fprintf(fp, "%4.8f ",dynmat[i][j]);
             }
         }
-    }
-    if (ferror(fp))
-        error->one(FLERR,"Error writing to file");
-
-    if (binaryflag && fp) {
-        clearerr(fp);
-        for (int i=0; i<3; i++)
-            fwrite(dynmat[i], sizeof(double), dynlen, fp);
         if (ferror(fp))
-            error->one(FLERR, "Error writing to binary file");
+            error->one(FLERR,"Error writing to file");
     }
 }
 

--- a/src/USER-PHONON/dynamical_matrix.cpp
+++ b/src/USER-PHONON/dynamical_matrix.cpp
@@ -138,6 +138,9 @@ void DynamicalMatrix::command(int narg, char **arg)
     else if (style == ESKM) options(narg-3,&arg[3]); //COME BACK
     else if (comm->me == 0 && screen) fprintf(screen,"Illegal Dynamical Matrix command\n");
 
+    if (atom->map_style == 0)
+      error->all(FLERR,"Dynamical_matrix command requires an atom map, see atom_modify");
+
     // move atoms by 3-vector or specified variable(s)
 
     if (style == REGULAR) {

--- a/src/USER-PHONON/dynamical_matrix.cpp
+++ b/src/USER-PHONON/dynamical_matrix.cpp
@@ -337,7 +337,8 @@ void DynamicalMatrix::writeMatrix(double **dynmat)
 
     if (binaryflag && fp) {
         clearerr(fp);
-        fwrite(&dynmat[0], sizeof(double), 3 * dynlen, fp);
+        for (int i=0; i<3; i++)
+            fwrite(dynmat[i], sizeof(double), dynlen, fp);
         if (ferror(fp))
             error->one(FLERR, "Error writing to binary file");
     }

--- a/src/USER-PHONON/dynamical_matrix.h
+++ b/src/USER-PHONON/dynamical_matrix.h
@@ -58,7 +58,7 @@ namespace LAMMPS_NS {
         bigint dynlen;             // rank of dynamical matrix
         int scaleflag;
         int me;
-        int *groupmap;
+        bigint *groupmap;
 
         int compressed;            // 1 if dump file is written compressed, 0 no
         int binaryflag;            // 1 if dump file is written binary, 0 no


### PR DESCRIPTION
**Summary**

Collected updates and fixes to the USER-PHONON dynamical_matrix command. See below for detailed list of changes.
This is still a work-in-progress, creating the PR now for visibility only.

**Related Issues**

This updates PR #1314.

**Author(s)**

Sebastian Hütter (OvGU)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Bugfixes to a brand new command. There will be changes, but not many users should be affected.

**Implementation Notes**

- Check if an atom->map exists before running (will not have one ie. for `atom_style atomic`)
- Fix writing binary dynmat files (also streamline writeMatrix method for readability)
- Output progress indicator similar to USER-DIFFRACTION

**ToDo**

- [x] Correct generation of groupmaps
- [x] Dynmat of groups other than all (shape, order, MPI)
- [x] Early-out optimization if an atom will not generate a row or column q


**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included