### PR TITLE
Enable write_data in dihedral_style multi/harmonic

### DIFF
--- a/src/MOLECULE/dihedral_multi_harmonic.cpp
+++ b/src/MOLECULE/dihedral_multi_harmonic.cpp
@@ -34,7 +34,9 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralMultiHarmonic::DihedralMultiHarmonic(LAMMPS *lmp) : Dihedral(lmp) {}
+DihedralMultiHarmonic::DihedralMultiHarmonic(LAMMPS *lmp) : Dihedral(lmp) {
+  writedata = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 


### PR DESCRIPTION
**Summary**

Enables the output of dihedral_style multi/harmonic coefficients into data files via write_data.

**Author(s)**

Donatas Surblys (Tohoku University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No conflicts

**Implementation Notes**

Sets `writedata = 1` in  dihedral_multi_harmonic.cpp (MOLECULE package). The write_data function was already present, and only the flag was missing. The produced output appears to be be correct. 

I've also observed similar state for several other potentials, but have not personally checked if they work correctly with the flag enabled.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


