### PR TITLE
Enable write data for dihedral styles and related corrections

### DIFF
--- a/src/MOLECULE/dihedral_helix.cpp
+++ b/src/MOLECULE/dihedral_helix.cpp
@@ -39,7 +39,10 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralHelix::DihedralHelix(LAMMPS *lmp) : Dihedral(lmp) {}
+DihedralHelix::DihedralHelix(LAMMPS *lmp) : Dihedral(lmp)
+{
+  writedata = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MOLECULE/dihedral_multi_harmonic.cpp
+++ b/src/MOLECULE/dihedral_multi_harmonic.cpp
@@ -34,7 +34,10 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralMultiHarmonic::DihedralMultiHarmonic(LAMMPS *lmp) : Dihedral(lmp) {}
+DihedralMultiHarmonic::DihedralMultiHarmonic(LAMMPS *lmp) : Dihedral(lmp)
+{
+  writedata = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/dihedral_cosine_shift_exp.cpp
+++ b/src/USER-MISC/dihedral_cosine_shift_exp.cpp
@@ -36,7 +36,10 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralCosineShiftExp::DihedralCosineShiftExp(LAMMPS *lmp) : Dihedral(lmp) {}
+DihedralCosineShiftExp::DihedralCosineShiftExp(LAMMPS *lmp) : Dihedral(lmp)
+{
+  writedata = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/dihedral_nharmonic.cpp
+++ b/src/USER-MISC/dihedral_nharmonic.cpp
@@ -35,7 +35,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralNHarmonic::DihedralNHarmonic(LAMMPS *lmp) : Dihedral(lmp) {
+DihedralNHarmonic::DihedralNHarmonic(LAMMPS *lmp) : Dihedral(lmp)
+{
   writedata = 1;
 }
 

--- a/src/USER-MISC/dihedral_quadratic.cpp
+++ b/src/USER-MISC/dihedral_quadratic.cpp
@@ -38,7 +38,10 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralQuadratic::DihedralQuadratic(LAMMPS *lmp) : Dihedral(lmp) {}
+DihedralQuadratic::DihedralQuadratic(LAMMPS *lmp) : Dihedral(lmp)
+{
+  writedata = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-MISC/dihedral_spherical.cpp
+++ b/src/USER-MISC/dihedral_spherical.cpp
@@ -41,7 +41,8 @@ using namespace MathExtra;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralSpherical::DihedralSpherical(LAMMPS *lmp) : Dihedral(lmp) {
+DihedralSpherical::DihedralSpherical(LAMMPS *lmp) : Dihedral(lmp)
+{
   writedata = 1;
 }
 

--- a/src/USER-MISC/dihedral_spherical.cpp
+++ b/src/USER-MISC/dihedral_spherical.cpp
@@ -41,7 +41,9 @@ using namespace MathExtra;
 
 /* ---------------------------------------------------------------------- */
 
-DihedralSpherical::DihedralSpherical(LAMMPS *lmp) : Dihedral(lmp) {}
+DihedralSpherical::DihedralSpherical(LAMMPS *lmp) : Dihedral(lmp) {
+  writedata = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 
@@ -817,10 +819,11 @@ void DihedralSpherical::write_data(FILE *fp)
   for (int i = 1; i <= atom->ndihedraltypes; i++) {
     fprintf(fp,"%d %d ", i , nterms[i]);
     for (int j = 0; j < nterms[i]; j++) {
-      fprintf(fp, "%g %g %g %g %g %g %g %g %g ",
-              phi_mult[i][j],    phi_shift[i][j],    phi_offset[i][j],
-              theta1_mult[i][j], theta1_shift[i][j], theta1_offset[i][j],
-              theta2_mult[i][j], theta2_shift[i][j], theta2_offset[i][j]);
+      fprintf(fp, "%g %g %g %g %g %g %g %g %g %g ", Ccoeff[i][j],
+              phi_mult[i][j], phi_shift[i][j]*180.0/MY_PI, phi_offset[i][j],
+              theta1_mult[i][j], theta1_shift[i][j]*180.0/MY_PI,
+              theta1_offset[i][j], theta2_mult[i][j],
+              theta2_shift[i][j]*180.0/MY_PI, theta2_offset[i][j]);
     }
     fprintf(fp,"\n");
   }

--- a/src/USER-MISC/dihedral_table_cut.cpp
+++ b/src/USER-MISC/dihedral_table_cut.cpp
@@ -425,17 +425,6 @@ DihedralTableCut::DihedralTableCut(LAMMPS *lmp) : Dihedral(lmp)
 DihedralTableCut::~DihedralTableCut()
 {
   if (allocated) {
-    memory->destroy(setflag);
-    memory->destroy(setflag_d);
-    memory->destroy(setflag_aat);
-
-    memory->destroy(k1);
-    memory->destroy(k2);
-    memory->destroy(k3);
-    memory->destroy(phi1);
-    memory->destroy(phi2);
-    memory->destroy(phi3);
-
     memory->destroy(aat_k);
     memory->destroy(aat_theta0_1);
     memory->destroy(aat_theta0_2);
@@ -761,27 +750,15 @@ void DihedralTableCut::allocate()
   allocated = 1;
   int n = atom->ndihedraltypes;
 
-  memory->create(k1,n+1,"dihedral:k1");
-  memory->create(k2,n+1,"dihedral:k2");
-  memory->create(k3,n+1,"dihedral:k3");
-  memory->create(phi1,n+1,"dihedral:phi1");
-  memory->create(phi2,n+1,"dihedral:phi2");
-  memory->create(phi3,n+1,"dihedral:phi3");
-
   memory->create(aat_k,n+1,"dihedral:aat_k");
   memory->create(aat_theta0_1,n+1,"dihedral:aat_theta0_1");
   memory->create(aat_theta0_2,n+1,"dihedral:aat_theta0_2");
 
-  memory->create(setflag,n+1,"dihedral:setflag");
-  memory->create(setflag_d,n+1,"dihedral:setflag_d");
-  memory->create(setflag_aat,n+1,"dihedral:setflag_aat");
-
   memory->create(tabindex,n+1,"dihedral:tabindex");
-  //memory->create(phi0,n+1,"dihedral:phi0"); <-equilibrium angles not supported
   memory->create(setflag,n+1,"dihedral:setflag");
 
   for (int i = 1; i <= n; i++)
-    setflag[i] = setflag_d[i] = setflag_aat[i] = 0;
+    setflag[i] = 0;
 }
 
 void DihedralTableCut::settings(int narg, char **arg)
@@ -824,9 +801,6 @@ void DihedralTableCut::coeff(int narg, char **arg)
   int ilo,ihi;
   force->bounds(FLERR,arg[0],atom->ndihedraltypes,ilo,ihi);
 
-  int count = 0;
-
-
   double k_one = force->numeric(FLERR,arg[2]);
   double theta0_1_one = force->numeric(FLERR,arg[3]);
   double theta0_2_one = force->numeric(FLERR,arg[4]);
@@ -837,8 +811,6 @@ void DihedralTableCut::coeff(int narg, char **arg)
     aat_k[i] = k_one;
     aat_theta0_1[i] = theta0_1_one/180.0 * MY_PI;
     aat_theta0_2[i] = theta0_2_one/180.0 * MY_PI;
-    setflag_aat[i] = 1;
-    count++;
   }
 
   int me;
@@ -998,8 +970,7 @@ void DihedralTableCut::coeff(int narg, char **arg)
             //  To be nice and report something, I do the same thing here.)
             cyc_splintD(tb->phi, tb->e, tb->e2, tablength, MY_2PI,phi);
           f = -dU_dphi;
-        }
-        else
+        } else
           // Otherwise we calculated the tb->f[] array.  Report its contents.
           f = tb->f[i];
         if (tb->use_degrees) {
@@ -1015,9 +986,8 @@ void DihedralTableCut::coeff(int narg, char **arg)
   } // if (me == 0)
 
   // store ptr to table in tabindex
-  count = 0;
-  for (int i = ilo; i <= ihi; i++)
-  {
+  int count = 0;
+  for (int i = ilo; i <= ihi; i++) {
     tabindex[i] = ntables;
     //phi0[i] = tb->phi0; <- equilibrium dihedral angles not supported
     setflag[i] = 1;
@@ -1025,12 +995,7 @@ void DihedralTableCut::coeff(int narg, char **arg)
   }
   ntables++;
 
-
   if (count == 0) error->all(FLERR,"Incorrect args for dihedral coefficients");
-
-  for (int i = ilo; i <= ihi; i++)
-    if (setflag_d[i] == 1 && setflag_aat[i] == 1 )
-      setflag[i] = 1;
 }
 
 /* ----------------------------------------------------------------------
@@ -1041,12 +1006,6 @@ void DihedralTableCut::write_restart(FILE *fp)
 {
   fwrite(&tabstyle,sizeof(int),1,fp);
   fwrite(&tablength,sizeof(int),1,fp);
-  fwrite(&k1[1],sizeof(double),atom->ndihedraltypes,fp);
-  fwrite(&k2[1],sizeof(double),atom->ndihedraltypes,fp);
-  fwrite(&k3[1],sizeof(double),atom->ndihedraltypes,fp);
-  fwrite(&phi1[1],sizeof(double),atom->ndihedraltypes,fp);
-  fwrite(&phi2[1],sizeof(double),atom->ndihedraltypes,fp);
-  fwrite(&phi3[1],sizeof(double),atom->ndihedraltypes,fp);
 
   fwrite(&aat_k[1],sizeof(double),atom->ndihedraltypes,fp);
   fwrite(&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
@@ -1064,24 +1023,11 @@ void DihedralTableCut::read_restart(FILE *fp)
   if (comm->me == 0) {
     fread(&tabstyle,sizeof(int),1,fp);
     fread(&tablength,sizeof(int),1,fp);
-    fread(&k1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&k2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&k3[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&phi1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&phi2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&phi3[1],sizeof(double),atom->ndihedraltypes,fp);
 
     fread(&aat_k[1],sizeof(double),atom->ndihedraltypes,fp);
     fread(&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
     fread(&aat_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp);
   }
-
-  MPI_Bcast(&k1[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
-  MPI_Bcast(&k2[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
-  MPI_Bcast(&k3[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
-  MPI_Bcast(&phi1[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
-  MPI_Bcast(&phi2[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
-  MPI_Bcast(&phi3[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
 
   MPI_Bcast(&aat_k[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
   MPI_Bcast(&aat_theta0_1[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
@@ -1089,7 +1035,6 @@ void DihedralTableCut::read_restart(FILE *fp)
   MPI_Bcast(&tabstyle,1,MPI_INT,0,world);
   MPI_Bcast(&tablength,1,MPI_INT,0,world);
 
-  allocate();
   for (int i = 1; i <= atom->ndihedraltypes; i++) setflag[i] = 1;
 }
 
@@ -1474,22 +1419,3 @@ void DihedralTableCut::bcast_table(Table *tb)
 }
 
 
-
-/* ----------------------------------------------------------------------
-   proc 0 writes to data file
-------------------------------------------------------------------------- */
-
-void DihedralTableCut::write_data(FILE *fp)
-{
-  for (int i = 1; i <= atom->ndihedraltypes; i++)
-    fprintf(fp,"%d %g %g %g %g %g %g\n",i,
-            k1[i],phi1[i]*180.0/MY_PI,
-            k2[i],phi2[i]*180.0/MY_PI,
-            k3[i],phi3[i]*180.0/MY_PI);
-
-  fprintf(fp,"\nAngleAngleTorsion Coeffs\n\n");
-  for (int i = 1; i <= atom->ndihedraltypes; i++)
-    fprintf(fp,"%d %g %g %g\n",i,aat_k[i],
-            aat_theta0_1[i]*180.0/MY_PI,aat_theta0_2[i]*180.0/MY_PI);
-
-}

--- a/src/USER-MISC/dihedral_table_cut.cpp
+++ b/src/USER-MISC/dihedral_table_cut.cpp
@@ -1006,10 +1006,6 @@ void DihedralTableCut::write_restart(FILE *fp)
 {
   fwrite(&tabstyle,sizeof(int),1,fp);
   fwrite(&tablength,sizeof(int),1,fp);
-
-  fwrite(&aat_k[1],sizeof(double),atom->ndihedraltypes,fp);
-  fwrite(&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
-  fwrite(&aat_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1023,19 +1019,10 @@ void DihedralTableCut::read_restart(FILE *fp)
   if (comm->me == 0) {
     fread(&tabstyle,sizeof(int),1,fp);
     fread(&tablength,sizeof(int),1,fp);
-
-    fread(&aat_k[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&aat_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp);
   }
 
-  MPI_Bcast(&aat_k[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
-  MPI_Bcast(&aat_theta0_1[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
-  MPI_Bcast(&aat_theta0_2[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
   MPI_Bcast(&tabstyle,1,MPI_INT,0,world);
   MPI_Bcast(&tablength,1,MPI_INT,0,world);
-
-  for (int i = 1; i <= atom->ndihedraltypes; i++) setflag[i] = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-MISC/dihedral_table_cut.h
+++ b/src/USER-MISC/dihedral_table_cut.h
@@ -20,7 +20,6 @@ DihedralStyle(table/cut,DihedralTableCut)
 #ifndef LMP_DIHEDRAL_TABLE_CUT_H
 #define LMP_DIHEDRAL_TABLE_CUT_H
 
-#include <stdio.h>
 #include "dihedral.h"
 
 namespace LAMMPS_NS {
@@ -34,26 +33,19 @@ class DihedralTableCut : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
-  void write_data(FILE *);
   double single(int type, int i1, int i2, int i3, int i4);
 
  protected:
-  double *k1,*k2,*k3;
-  double *phi1,*phi2,*phi3;
   double *aat_k,*aat_theta0_1,*aat_theta0_2;
-  int *setflag_d;
-  int *setflag_aat;
 
   void allocate();
 
   int tabstyle,tablength;
-  // double *phi0;       <- equilibrium angles not supported
   char *checkU_fname;
   char *checkF_fname;
 
   struct Table {
     int ninput;
-    //double phi0;      <-equilibrium angles not supported
     int f_unspecified; // boolean (but MPI does not like type "bool")
     int use_degrees;   // boolean (but MPI does not like type "bool")
     double *phifile,*efile,*ffile;

--- a/src/USER-MISC/dihedral_table_cut.h
+++ b/src/USER-MISC/dihedral_table_cut.h
@@ -33,7 +33,6 @@ class DihedralTableCut : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
-  double single(int type, int i1, int i2, int i3, int i4);
 
  protected:
   double *aat_k,*aat_theta0_1,*aat_theta0_2;


### PR DESCRIPTION
**Summary**

This adds missing `writedata = 1;` statements to constructors of several dihedral styles, and corrects some related issues in dihedral style sphere and table/cut

**Related Issues**

This supersedes #1369 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Dihedral style table/cut was storing incorrectly coefficient data in restart files. Also, it cannot support write_data, so the related function was removed. 

**Implementation Notes**

this fixes omissions from commit 6f9a2245d2d6df61526250c44d285acd87ac652e

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


