### PR TITLE
Add min_post_force in fix_precession_spin

### DIFF
--- a/src/SPIN/fix_precession_spin.cpp
+++ b/src/SPIN/fix_precession_spin.cpp
@@ -230,8 +230,8 @@ void FixPrecessionSpin::compute_single_precession(int i, double spi[3], double f
 void FixPrecessionSpin::compute_zeeman(int i, double fmi[3])
 {
   double **sp = atom->sp;
-  fmi[0] += sp[i][0]*hx;
-  fmi[1] += sp[i][1]*hy;
+  fmi[0] += sp[i][3]*hx;
+  fmi[1] += sp[i][3]*hy;
   fmi[2] += sp[i][3]*hz;
 }
 

--- a/src/SPIN/fix_precession_spin.cpp
+++ b/src/SPIN/fix_precession_spin.cpp
@@ -115,6 +115,7 @@ int FixPrecessionSpin::setmask()
 {
   int mask = 0;
   mask |= POST_FORCE;
+  mask |= MIN_POST_FORCE;
   mask |= THERMO_ENERGY;
   mask |= POST_FORCE_RESPA;
   return mask;
@@ -171,6 +172,7 @@ void FixPrecessionSpin::setup(int vflag)
 
 void FixPrecessionSpin::post_force(int /*vflag*/)
 {
+
   // update mag field with time (potential improvement)
 
   if (varflag != CONSTANT) {
@@ -200,7 +202,7 @@ void FixPrecessionSpin::post_force(int /*vflag*/)
 
     if (aniso_flag) {           // compute magnetic anisotropy
       compute_anisotropy(spi,fmi);
-      emag -= (spi[0]*fmi[0] + spi[1]*fmi[1] + spi[2]*fmi[2]);
+      emag -= 0.5*(spi[0]*fmi[0] + spi[1]*fmi[1] + spi[2]*fmi[2]);
     }
 
     fm[i][0] += fmi[0];
@@ -228,9 +230,9 @@ void FixPrecessionSpin::compute_single_precession(int i, double spi[3], double f
 void FixPrecessionSpin::compute_zeeman(int i, double fmi[3])
 {
   double **sp = atom->sp;
-  fmi[0] -= sp[i][3]*hx;
-  fmi[1] -= sp[i][3]*hy;
-  fmi[2] -= sp[i][3]*hz;
+  fmi[0] += sp[i][0]*hx;
+  fmi[1] += sp[i][1]*hy;
+  fmi[2] += sp[i][3]*hz;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -279,4 +281,11 @@ double FixPrecessionSpin::compute_scalar()
     eflag = 1;
   }
   return emag_all;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixPrecessionSpin::min_post_force(int vflag)
+{
+  post_force(vflag);
 }

--- a/src/SPIN/fix_precession_spin.h
+++ b/src/SPIN/fix_precession_spin.h
@@ -33,8 +33,9 @@ class FixPrecessionSpin : public Fix {
   int setmask();
   void init();
   void setup(int);
-  virtual void post_force(int);
-  virtual void post_force_respa(int, int, int);
+  void post_force(int);
+  void post_force_respa(int, int, int);
+  void min_post_force(int);
   double compute_scalar();
 
   int zeeman_flag, aniso_flag;


### PR DESCRIPTION
- correct. error in fix_precession_spin
- added min_post_force in fix_precession_spin

**Summary**

Added a min_post_force method in fix_precession_spin so that this fix can be used in within an upcoming spin minimizer.
A correction in the field calculation was also performed.

**Related Issues**

This fix was not being computed when used within a minimizing routine.
The magnetic field calculation was wrong.

**Author(s)**

Julien Tranchida

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

n/a

**Implementation Notes**

This change concerns only two files (fix_precession_spin.cpp/h).
The fix was successfully used with an upcoming spin minimizer.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] One or more example input decks are included

**Further Information, Files, and Links**



