### PR TITLE
Collected small changes for the next patch release

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -613,8 +613,9 @@ if(PKG_USER-PLUMED)
 endif()
 
 if(PKG_USER-MOLFILE)
+  set(MOLFILE_INCLUDE_DIRS "${LAMMPS_LIB_SOURCE_DIR}/molfile" CACHE STRING "Path to VMD molfile plugin headers")
   add_library(molfile INTERFACE)
-  target_include_directories(molfile INTERFACE ${LAMMPS_LIB_SOURCE_DIR}/molfile)
+  target_include_directories(molfile INTERFACE ${MOLFILE_INCLUDE_DIRS})
   target_link_libraries(molfile INTERFACE ${CMAKE_DL_LIBS})
   list(APPEND LAMMPS_LINK_LIBS molfile)
 endif()
@@ -625,7 +626,6 @@ if(PKG_USER-NETCDF)
   list(APPEND LAMMPS_LINK_LIBS ${NETCDF_LIBRARIES})
   add_definitions(-DLMP_HAS_NETCDF -DNC_64BIT_DATA=0x0020)
 endif()
-
 
 if(PKG_USER-SMD)
   option(DOWNLOAD_EIGEN3 "Download Eigen3 instead of using an already installed one)" OFF)

--- a/doc/src/Build_extras.txt
+++ b/doc/src/Build_extras.txt
@@ -893,7 +893,17 @@ USER-MOLFILE package :h4,link(user-molfile)
 
 [CMake build]:
 
-No additional settings are needed besides "-D PKG_USER-MOLFILE=yes".
+-D MOLFILE_INCLUDE_DIRS=path   # (optional) path where VMD molfile plugin headers are installed
+-D PKG_USER-MOLFILE=yes     :pre
+
+
+Using "-D PKG_USER-MOLFILE=yes" enables the package, and setting
+"-D MOLFILE_INCLUDE DIRS" allows to provide a custom location for
+the molfile plugin header files. These should match the ABI of the
+plugin files used, and thus one typically sets them to include
+folder of the local VMD installation in use. LAMMPS ships with a
+couple of default header files that correspond to a popular VMD
+version, usually the latest release.
 
 [Traditional make]:
 
@@ -902,7 +912,11 @@ loading library libdl.a that is typically present on all systems.  It
 is required for LAMMPS to link with this package.  If the setting is
 not valid for your system, you will need to edit the Makefile.lammps
 file.  See lib/molfile/README and lib/molfile/Makefile.lammps for
-details.
+details. It is also possible to configure a different folder with
+the VMD molfile plugin header files. LAMMPS ships with a couple of
+default headers, but these are not compatible with all VMD versions,
+so it is often best to change this setting to the location of the
+same include files of the local VMD installation in use.
 
 :line
 

--- a/lib/gpu/lal_device.cpp
+++ b/lib/gpu/lal_device.cpp
@@ -237,7 +237,7 @@ int DeviceT::set_ocl_params(char *ocl_vendor) {
                         " -DBLOCK_CELL_ID="+params[11]+
                         " -DMAX_BIO_SHARED_TYPES="+params[12];
   }
-  _ocl_compile_string="-cl-fast-relaxed-math -cl-mad-enable "+std::string(OCL_INT_TYPE)+" "+
+  _ocl_compile_string="-cl-std=CL1.2 -cl-fast-relaxed-math -cl-mad-enable "+std::string(OCL_INT_TYPE)+" "+
                       std::string(OCL_PRECISION_COMPILE)+" "+_ocl_vendor_string;
   #endif
   return 0;

--- a/src/CLASS2/pair_lj_class2.cpp
+++ b/src/CLASS2/pair_lj_class2.cpp
@@ -38,20 +38,20 @@ PairLJClass2::PairLJClass2(LAMMPS *lmp) : Pair(lmp)
 
 PairLJClass2::~PairLJClass2()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut);
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut);
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(offset);
   }
 }
 

--- a/src/CLASS2/pair_lj_class2_coul_cut.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_cut.cpp
@@ -39,23 +39,23 @@ PairLJClass2CoulCut::PairLJClass2CoulCut(LAMMPS *lmp) : Pair(lmp)
 
 PairLJClass2CoulCut::~PairLJClass2CoulCut()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(cut_coul);
-      memory->destroy(cut_coulsq);
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(cut_coul);
+    memory->destroy(cut_coulsq);
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(offset);
   }
 }
 

--- a/src/CLASS2/pair_lj_class2_coul_long.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_long.cpp
@@ -50,21 +50,21 @@ PairLJClass2CoulLong::PairLJClass2CoulLong(LAMMPS *lmp) : Pair(lmp)
 
 PairLJClass2CoulLong::~PairLJClass2CoulLong()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(offset);
   }
   if (ftable) free_tables();
 }

--- a/src/KSPACE/pair_buck_coul_long.cpp
+++ b/src/KSPACE/pair_buck_coul_long.cpp
@@ -50,23 +50,23 @@ PairBuckCoulLong::PairBuckCoulLong(LAMMPS *lmp) : Pair(lmp)
 
 PairBuckCoulLong::~PairBuckCoulLong()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(a);
-      memory->destroy(rho);
-      memory->destroy(c);
-      memory->destroy(rhoinv);
-      memory->destroy(buck1);
-      memory->destroy(buck2);
-      memory->destroy(offset);
-    }
-    if (ftable) free_tables();
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(a);
+    memory->destroy(rho);
+    memory->destroy(c);
+    memory->destroy(rhoinv);
+    memory->destroy(buck1);
+    memory->destroy(buck2);
+    memory->destroy(offset);
   }
+  if (ftable) free_tables();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_coul_long.cpp
+++ b/src/KSPACE/pair_coul_long.cpp
@@ -55,15 +55,15 @@ PairCoulLong::PairCoulLong(LAMMPS *lmp) : Pair(lmp)
 
 PairCoulLong::~PairCoulLong()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(scale);
-    }
-    if (ftable) free_tables();
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(scale);
   }
+  if (ftable) free_tables();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_lj_charmm_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmm_coul_long.cpp
@@ -59,27 +59,27 @@ PairLJCharmmCoulLong::PairLJCharmmCoulLong(LAMMPS *lmp) : Pair(lmp)
 
 PairLJCharmmCoulLong::~PairLJCharmmCoulLong()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(eps14);
-      memory->destroy(sigma14);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(lj14_1);
-      memory->destroy(lj14_2);
-      memory->destroy(lj14_3);
-      memory->destroy(lj14_4);
-      memory->destroy(offset);
-    }
-    if (ftable) free_tables();
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(eps14);
+    memory->destroy(sigma14);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(lj14_1);
+    memory->destroy(lj14_2);
+    memory->destroy(lj14_3);
+    memory->destroy(lj14_4);
+    memory->destroy(offset);
   }
+  if (ftable) free_tables();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
@@ -77,27 +77,6 @@ PairLJCharmmfswCoulLong::PairLJCharmmfswCoulLong(LAMMPS *lmp) : Pair(lmp)
 
 PairLJCharmmfswCoulLong::~PairLJCharmmfswCoulLong()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
-
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(eps14);
-      memory->destroy(sigma14);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(lj14_1);
-      memory->destroy(lj14_2);
-      memory->destroy(lj14_3);
-      memory->destroy(lj14_4);
-    }
-    if (ftable) free_tables();
-  }
-
   // switch qqr2e back from CHARMM value to LAMMPS value
 
   if (update && strcmp(update->unit_style,"real") == 0) {
@@ -106,6 +85,27 @@ PairLJCharmmfswCoulLong::~PairLJCharmmfswCoulLong()
                      " conversion constant");
     force->qqr2e = force->qqr2e_lammps_real;
   }
+
+  if (copymode) return;
+
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(eps14);
+    memory->destroy(sigma14);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(lj14_1);
+    memory->destroy(lj14_2);
+    memory->destroy(lj14_3);
+    memory->destroy(lj14_4);
+  }
+  if (ftable) free_tables();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/pair_lj_charmm_coul_charmm.cpp
+++ b/src/MOLECULE/pair_lj_charmm_coul_charmm.cpp
@@ -43,8 +43,9 @@ PairLJCharmmCoulCharmm::PairLJCharmmCoulCharmm(LAMMPS *lmp) : Pair(lmp)
 
 PairLJCharmmCoulCharmm::~PairLJCharmmCoulCharmm()
 {
-  if (!copymode) {
-   if (allocated) {
+  if (copymode) return;
+
+  if (allocated) {
     memory->destroy(setflag);
     memory->destroy(cutsq);
 
@@ -60,7 +61,6 @@ PairLJCharmmCoulCharmm::~PairLJCharmmCoulCharmm()
     memory->destroy(lj14_2);
     memory->destroy(lj14_3);
     memory->destroy(lj14_4);
-   }
   }
 }
 

--- a/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
+++ b/src/MOLECULE/pair_lj_charmmfsw_coul_charmmfsh.cpp
@@ -62,26 +62,6 @@ PairLJCharmmfswCoulCharmmfsh::PairLJCharmmfswCoulCharmmfsh(LAMMPS *lmp) :
 
 PairLJCharmmfswCoulCharmmfsh::~PairLJCharmmfswCoulCharmmfsh()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
-
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(eps14);
-      memory->destroy(sigma14);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(lj14_1);
-      memory->destroy(lj14_2);
-      memory->destroy(lj14_3);
-      memory->destroy(lj14_4);
-    }
-  }
-
   // switch qqr2e back from CHARMM value to LAMMPS value
 
   if (update && strcmp(update->unit_style,"real") == 0) {
@@ -89,6 +69,26 @@ PairLJCharmmfswCoulCharmmfsh::~PairLJCharmmfswCoulCharmmfsh()
       error->message(FLERR,"Restoring original LAMMPS coulomb energy"
                      " conversion constant");
     force->qqr2e = force->qqr2e_lammps_real;
+  }
+
+  if (copymode) return;
+
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(eps14);
+    memory->destroy(sigma14);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(lj14_1);
+    memory->destroy(lj14_2);
+    memory->destroy(lj14_3);
+    memory->destroy(lj14_4);
   }
 }
 

--- a/src/USER-FEP/pair_lj_class2_coul_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_class2_coul_cut_soft.cpp
@@ -39,24 +39,24 @@ PairLJClass2CoulCutSoft::PairLJClass2CoulCutSoft(LAMMPS *lmp) : Pair(lmp)
 
 PairLJClass2CoulCutSoft::~PairLJClass2CoulCutSoft()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(cut_coul);
-      memory->destroy(cut_coulsq);
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(lambda);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(cut_coul);
+    memory->destroy(cut_coulsq);
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(lambda);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(offset);
   }
 }
 

--- a/src/USER-FEP/pair_lj_class2_coul_long_soft.cpp
+++ b/src/USER-FEP/pair_lj_class2_coul_long_soft.cpp
@@ -49,22 +49,22 @@ PairLJClass2CoulLongSoft::PairLJClass2CoulLongSoft(LAMMPS *lmp) : Pair(lmp)
 
 PairLJClass2CoulLongSoft::~PairLJClass2CoulLongSoft()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(lambda);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(lambda);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(offset);
   }
 }
 

--- a/src/USER-FEP/pair_lj_class2_soft.cpp
+++ b/src/USER-FEP/pair_lj_class2_soft.cpp
@@ -32,28 +32,26 @@ using namespace MathConst;
 PairLJClass2Soft::PairLJClass2Soft(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  allocated = 0;
 }
 
 /* ---------------------------------------------------------------------- */
 
 PairLJClass2Soft::~PairLJClass2Soft()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut);
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(lambda);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(offset);
-      allocated=0;
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut);
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(lambda);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(offset);
   }
 }
 

--- a/src/USER-MOFFF/pair_buck6d_coul_gauss_dsf.cpp
+++ b/src/USER-MOFFF/pair_buck6d_coul_gauss_dsf.cpp
@@ -48,29 +48,29 @@ PairBuck6dCoulGaussDSF::PairBuck6dCoulGaussDSF(LAMMPS *lmp) : Pair(lmp)
 
 PairBuck6dCoulGaussDSF::~PairBuck6dCoulGaussDSF()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(alpha_ij);
-      memory->destroy(f_shift_ij);
-      memory->destroy(e_shift_ij);
-      memory->destroy(buck6d1);
-      memory->destroy(buck6d2);
-      memory->destroy(buck6d3);
-      memory->destroy(buck6d4);
-      memory->destroy(c0);
-      memory->destroy(c1);
-      memory->destroy(c2);
-      memory->destroy(c3);
-      memory->destroy(c4);
-      memory->destroy(c5);
-      memory->destroy(rsmooth_sq);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(alpha_ij);
+    memory->destroy(f_shift_ij);
+    memory->destroy(e_shift_ij);
+    memory->destroy(buck6d1);
+    memory->destroy(buck6d2);
+    memory->destroy(buck6d3);
+    memory->destroy(buck6d4);
+    memory->destroy(c0);
+    memory->destroy(c1);
+    memory->destroy(c2);
+    memory->destroy(c3);
+    memory->destroy(c4);
+    memory->destroy(c5);
+    memory->destroy(rsmooth_sq);
+    memory->destroy(offset);
   }
 }
 

--- a/src/USER-MOFFF/pair_buck6d_coul_gauss_long.cpp
+++ b/src/USER-MOFFF/pair_buck6d_coul_gauss_long.cpp
@@ -51,27 +51,27 @@ PairBuck6dCoulGaussLong::PairBuck6dCoulGaussLong(LAMMPS *lmp) : Pair(lmp)
 
 PairBuck6dCoulGaussLong::~PairBuck6dCoulGaussLong()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(alpha_ij);
-      memory->destroy(buck6d1);
-      memory->destroy(buck6d2);
-      memory->destroy(buck6d3);
-      memory->destroy(buck6d4);
-      memory->destroy(c0);
-      memory->destroy(c1);
-      memory->destroy(c2);
-      memory->destroy(c3);
-      memory->destroy(c4);
-      memory->destroy(c5);
-      memory->destroy(rsmooth_sq);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(alpha_ij);
+    memory->destroy(buck6d1);
+    memory->destroy(buck6d2);
+    memory->destroy(buck6d3);
+    memory->destroy(buck6d4);
+    memory->destroy(c0);
+    memory->destroy(c1);
+    memory->destroy(c2);
+    memory->destroy(c3);
+    memory->destroy(c4);
+    memory->destroy(c5);
+    memory->destroy(rsmooth_sq);
+    memory->destroy(offset);
   }
 }
 

--- a/src/USER-SMTBQ/README
+++ b/src/USER-SMTBQ/README
@@ -2,9 +2,11 @@ This package implements the Second Moment Tight Binding - QEq (SMTB-Q)
 potential for the description of ionocovalent bonds in oxides.
 
 Authors: Nicolas Salles, Emile Maras, Olivier Politano, Robert Tetot
-at LAAS-CNRS in France.
+at ICB, Universite de Bourgogne and ICMMO, Universite Paris-Sud.
 
-Contact emails:  lammps@u-bourgogne.fr, nsalles@laas.fr
+Contact emails:  lammps@u-bourgogne.fr, nsalles33@gmail.com
+
+This package is occasionally maintained.
 
 See the doc page for the pair_style smtbq command to get started.
 

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -423,7 +423,12 @@ void Dump::write()
     atom->x = xpbc;
     atom->v = vpbc;
     atom->image = imagepbc;
+
+    // for triclinic, PBC is applied in lamda coordinates
+
+    if (domain->triclinic) domain->x2lamda(nlocal);
     domain->pbc();
+    if (domain->triclinic) domain->lamda2x(nlocal);
   }
 
   // pack my data into buf

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -72,6 +72,9 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   single_extra = 0;
   svector = NULL;
 
+  setflag = NULL;
+  cutsq = NULL;
+
   ewaldflag = pppmflag = msmflag = dispersionflag = tip4pflag = dipoleflag = 0;
   reinitflag = 1;
 

--- a/src/pair_buck_coul_cut.cpp
+++ b/src/pair_buck_coul_cut.cpp
@@ -42,7 +42,9 @@ PairBuckCoulCut::PairBuckCoulCut(LAMMPS *lmp) : Pair(lmp)
 
 PairBuckCoulCut::~PairBuckCoulCut()
 {
-  if (!copymode) {
+  if (copymode) return;
+
+  if (allocated) {
     memory->destroy(setflag);
     memory->destroy(cutsq);
 

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -45,7 +45,7 @@ PairHybrid::PairHybrid(LAMMPS *lmp) : Pair(lmp),
 
 PairHybrid::~PairHybrid()
 {
-  if (nstyles) {
+  if (nstyles > 0) {
     for (int m = 0; m < nstyles; m++) {
       delete styles[m];
       delete [] keywords[m];
@@ -243,11 +243,18 @@ void PairHybrid::settings(int narg, char **arg)
 
   // delete old lists, since cannot just change settings
 
-  if (nstyles) {
-    for (int m = 0; m < nstyles; m++) delete styles[m];
-    delete [] styles;
-    for (int m = 0; m < nstyles; m++) delete [] keywords[m];
-    delete [] keywords;
+  if (nstyles > 0) {
+    for (int m = 0; m < nstyles; m++) {
+      delete styles[m];
+      delete [] keywords[m];
+      if (special_lj[m])   delete [] special_lj[m];
+      if (special_coul[m]) delete [] special_coul[m];
+    }
+    delete[] styles;
+    delete[] keywords;
+    delete[] multiple;
+    delete[] special_lj;
+    delete[] special_coul;
   }
 
   if (allocated) {
@@ -669,6 +676,12 @@ void PairHybrid::read_restart(FILE *fp)
   MPI_Bcast(&nstyles,1,MPI_INT,0,world);
 
   // allocate list of sub-styles
+
+  delete[] styles;
+  delete[] keywords;
+  delete[] multiple;
+  delete[] special_lj;
+  delete[] special_coul;
 
   styles = new Pair*[nstyles];
   keywords = new char*[nstyles];

--- a/src/pair_lj_cut_coul_dsf.cpp
+++ b/src/pair_lj_cut_coul_dsf.cpp
@@ -52,21 +52,21 @@ PairLJCutCoulDSF::PairLJCutCoulDSF(LAMMPS *lmp) : Pair(lmp)
 
 PairLJCutCoulDSF::~PairLJCutCoulDSF()
 {
-  if (!copymode) {
-    if (allocated) {
-      memory->destroy(setflag);
-      memory->destroy(cutsq);
+  if (copymode) return;
 
-      memory->destroy(cut_lj);
-      memory->destroy(cut_ljsq);
-      memory->destroy(epsilon);
-      memory->destroy(sigma);
-      memory->destroy(lj1);
-      memory->destroy(lj2);
-      memory->destroy(lj3);
-      memory->destroy(lj4);
-      memory->destroy(offset);
-    }
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+
+    memory->destroy(cut_lj);
+    memory->destroy(cut_ljsq);
+    memory->destroy(epsilon);
+    memory->destroy(sigma);
+    memory->destroy(lj1);
+    memory->destroy(lj2);
+    memory->destroy(lj3);
+    memory->destroy(lj4);
+    memory->destroy(offset);
   }
 }
 

--- a/src/pair_lj_expand.cpp
+++ b/src/pair_lj_expand.cpp
@@ -38,8 +38,9 @@ PairLJExpand::PairLJExpand(LAMMPS *lmp) : Pair(lmp)
 
 PairLJExpand::~PairLJExpand()
 {
-  if (!copymode) {
-   if (allocated) {
+  if (copymode) return;
+
+  if (allocated) {
     memory->destroy(setflag);
     memory->destroy(cutsq);
 
@@ -52,7 +53,6 @@ PairLJExpand::~PairLJExpand()
     memory->destroy(lj3);
     memory->destroy(lj4);
     memory->destroy(offset);
-   }
   }
 }
 

--- a/src/pair_lj_gromacs.cpp
+++ b/src/pair_lj_gromacs.cpp
@@ -41,8 +41,9 @@ PairLJGromacs::PairLJGromacs(LAMMPS *lmp) : Pair(lmp)
 
 PairLJGromacs::~PairLJGromacs()
 {
-  if (!copymode) {
-   if (allocated) {
+  if (copymode) return;
+
+  if (allocated) {
     memory->destroy(setflag);
     memory->destroy(cutsq);
 
@@ -60,7 +61,6 @@ PairLJGromacs::~PairLJGromacs()
     memory->destroy(ljsw3);
     memory->destroy(ljsw4);
     memory->destroy(ljsw5);
-   }
   }
 }
 

--- a/src/pair_lj_gromacs_coul_gromacs.cpp
+++ b/src/pair_lj_gromacs_coul_gromacs.cpp
@@ -41,8 +41,9 @@ PairLJGromacsCoulGromacs::PairLJGromacsCoulGromacs(LAMMPS *lmp) : Pair(lmp)
 
 PairLJGromacsCoulGromacs::~PairLJGromacsCoulGromacs()
 {
-  if (!copymode) {
-   if (allocated) {
+  if (copymode) return;
+
+  if (allocated) {
     memory->destroy(setflag);
     memory->destroy(cutsq);
 
@@ -57,7 +58,6 @@ PairLJGromacsCoulGromacs::~PairLJGromacsCoulGromacs()
     memory->destroy(ljsw3);
     memory->destroy(ljsw4);
     memory->destroy(ljsw5);
-   }
   }
 }
 


### PR DESCRIPTION
**Summary**

This pull request combines multiple small bugfixes and updates.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes.

**Implementation Notes**

Included are the following individual changes:
- updated README file with new e-mail addresses for USER-SMTBQ
- bugfix for crashes due to calling `memory->destroy()` on uninitialized arrays with pair style buck/coul/cut
- bugfix for `dump_modify pbc yes` with triclinic cells. fixes #1378 
- consistent handling of `copymode` flag in pair style destructors
- fix for a small memory leak in pair style hybrid when reading restart files
- explicitly compile OpenCL kernels in GPU package for OpenCL 1.2
- add option to CMake build to override the location of the VMD molfile plugin headers when using the USER-MOLFILE package.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] A package specific README file has been included or updated


