### PR TITLE
Refactor python module installer and add install-python target to CMake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1475,23 +1475,47 @@ install(
 )
 
 ###############################################################################
-# Install LAMMPS module into site-packages folder
-# Only available, if a shared library is built
+# Install LAMMPS lib and python module into site-packages folder with
+# "install-python" target.  Behaves exactly like "make install-python" for
+# conventional build.  Only available, if a shared library is built.
+# This is primarily for people that only want to use the Python wrapper.
 ###############################################################################
 if(BUILD_LIB AND BUILD_SHARED_LIBS)
   find_package(PythonInterp)
-  add_custom_target(
-    install-python
-    ${PYTHON_EXECUTABLE} install.py -v ${LAMMPS_SOURCE_DIR}/version.h
-    -m ${CMAKE_CURRENT_SOURCE_DIR}/../python/lammps.py
-    -l ${CMAKE_BINARY_DIR}/liblammps${CMAKE_SHARED_LIBRARY_SUFFIX}
-    WORKING_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/../python
-    COMMENT "Installing LAMMPS Python module"
-    )
+  if (${PYTHONINTERP_FOUND})
+    add_custom_target(
+      install-python
+      ${PYTHON_EXECUTABLE} install.py -v ${LAMMPS_SOURCE_DIR}/version.h
+      -m ${CMAKE_CURRENT_SOURCE_DIR}/../python/lammps.py
+      -l ${CMAKE_BINARY_DIR}/liblammps${CMAKE_SHARED_LIBRARY_SUFFIX}
+      WORKING_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/../python
+      COMMENT "Installing LAMMPS Python module")
+  else()
+    add_custom_target(
+      install-python
+      echo "Must have Python installed to install the LAMMPS Python module")
+  endif()
 else()
   add_custom_target(
     install-python
-    echo "Installation of the LAMMPS Python module requires building the LAMMPS shared library")
+    echo "Must build LAMMPS as a shared library to use the Python module")
+endif()
+
+###############################################################################
+# Add LAMMPS python module to "install" target. This is taylored for building
+# LAMMPS for package managers and with different prefix settings.
+# This requires either a shared library or that the PYTHON package is included.
+###############################################################################
+if((BUILD_LIB AND BUILD_SHARED_LIBS) OR (PKG_PYTHON))
+  find_package(PythonInterp)
+  if (${PYTHONINTERP_FOUND})
+    if(NOT PYTHON_INSTDIR)
+      execute_process(COMMAND ${PYTHON_EXECUTABLE}
+        -c "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
+        OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../python/lammps.py DESTINATION ${PYTHON_INSTDIR})
+  endif()
 endif()
 
 ###############################################################################

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -381,19 +381,10 @@ if(PKG_MSCG OR PKG_USER-ATC OR PKG_USER-AWPMD OR PKG_USER-QUIP OR PKG_LATTE)
 endif()
 
 if(PKG_PYTHON)
-  find_package(PythonInterp REQUIRED)
   find_package(PythonLibs REQUIRED)
   add_definitions(-DLMP_PYTHON)
   include_directories(${PYTHON_INCLUDE_DIR})
   list(APPEND LAMMPS_LINK_LIBS ${PYTHON_LIBRARY})
-  if(BUILD_LIB AND BUILD_SHARED_LIBS)
-    if(NOT PYTHON_INSTDIR)
-      execute_process(COMMAND ${PYTHON_EXECUTABLE}
-        -c "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
-        OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-    endif()
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../python/lammps.py DESTINATION ${PYTHON_INSTDIR})
-  endif()
 endif()
 
 find_package(JPEG QUIET)
@@ -1482,6 +1473,22 @@ install(
         ${CMAKE_BINARY_DIR}/etc/profile.d/lammps.csh
   DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/profile.d
 )
+
+###############################################################################
+# Install LAMMPS module into site-packages folder
+# Only available, if a shared library is built
+###############################################################################
+if(BUILD_LIB AND BUILD_SHARED_LIBS)
+  find_package(PythonInterp)
+  add_custom_target(
+    install-python
+    ${PYTHON_EXECUTABLE} install.py -v ${LAMMPS_SOURCE_DIR}/version.h
+    -m ${CMAKE_CURRENT_SOURCE_DIR}/../python/lammps.py
+    -l ${CMAKE_BINARY_DIR}/liblammps${CMAKE_SHARED_LIBRARY_SUFFIX}
+    WORKING_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/../python
+    COMMENT "Installing LAMMPS Python module"
+    )
+endif()
 
 ###############################################################################
 # Testing

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1482,7 +1482,7 @@ install(
 ###############################################################################
 if(BUILD_LIB AND BUILD_SHARED_LIBS)
   find_package(PythonInterp)
-  if (${PYTHONINTERP_FOUND})
+  if (PYTHONINTERP_FOUND)
     add_custom_target(
       install-python
       ${PYTHON_EXECUTABLE} install.py -v ${LAMMPS_SOURCE_DIR}/version.h
@@ -1493,12 +1493,12 @@ if(BUILD_LIB AND BUILD_SHARED_LIBS)
   else()
     add_custom_target(
       install-python
-      echo "Must have Python installed to install the LAMMPS Python module")
+      ${CMAKE_COMMAND} -E echo "Must have Python installed to install the LAMMPS Python module")
   endif()
 else()
   add_custom_target(
     install-python
-    echo "Must build LAMMPS as a shared library to use the Python module")
+    ${CMAKE_COMMAND} -E echo "Must build LAMMPS as a shared library to use the Python module")
 endif()
 
 ###############################################################################
@@ -1508,12 +1508,11 @@ endif()
 ###############################################################################
 if((BUILD_LIB AND BUILD_SHARED_LIBS) OR (PKG_PYTHON))
   find_package(PythonInterp)
-  if (${PYTHONINTERP_FOUND})
-    if(NOT PYTHON_INSTDIR)
-      execute_process(COMMAND ${PYTHON_EXECUTABLE}
-        -c "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
-        OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-    endif()
+  if (PYTHONINTERP_FOUND)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE}
+      -c "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
+      OUTPUT_VARIABLE PYTHON_DEFAULT_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(PYTHON_INSTDIR ${PYTHON_DEFAULT_INSTDIR} CACHE PATH "Installation folder for LAMMPS Python module")
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../python/lammps.py DESTINATION ${PYTHON_INSTDIR})
   endif()
 endif()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1488,6 +1488,10 @@ if(BUILD_LIB AND BUILD_SHARED_LIBS)
     WORKING_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/../python
     COMMENT "Installing LAMMPS Python module"
     )
+else()
+  add_custom_target(
+    install-python
+    echo "Installation of the LAMMPS Python module requires building the LAMMPS shared library")
 endif()
 
 ###############################################################################

--- a/doc/src/Howto_pylammps.txt
+++ b/doc/src/Howto_pylammps.txt
@@ -57,6 +57,17 @@ library is then loaded by the Python interface. In this example we enable the
 MOLECULE package and compile LAMMPS with C++ exceptions, PNG, JPEG and FFMPEG
 output support enabled.
 
+Step 1a: For the CMake based build system, the steps are:
+
+mkdir $LAMMPS_DIR/build-shared
+cd  $LAMMPS_DIR/build-shared :pre
+
+# MPI, PNG, Jpeg, FFMPEG are auto-detected
+cmake ../cmake -DPKG_MOLECULE=yes -DLAMMPS_EXCEPTIONS=yes -DBUILD_LIB=yes -DBUILD_SHARED_LIBS=yes
+make :pre
+
+Step 1b: For the legacy, make based build system, the steps are:
+
 cd $LAMMPS_DIR/src :pre
 
 # add packages if necessary
@@ -68,10 +79,9 @@ make mpi mode=shlib LMP_INC="-DLAMMPS_PNG -DLAMMPS_JPEG -DLAMMPS_FFMPEG -DLAMMPS
 Step 2: Installing the LAMMPS Python package :h6
 
 PyLammps is part of the lammps Python package. To install it simply install
-that package into your current Python installation.
+that package into your current Python installation with:
 
-cd $LAMMPS_DIR/python
-python install.py :pre
+make install-python :pre
 
 NOTE: Recompiling the shared library requires re-installing the Python package
 
@@ -94,14 +104,21 @@ apt-get install python-virtualenv :pre
 
 Creating a virtualenv with lammps installed :h6
 
-# create virtualenv name 'testing' :pre
+# create virtualenv named 'testing'
+virtualenv $HOME/python/testing :pre
 
 # activate 'testing' environment
-source testing/bin/activate :pre
+source $HOME/python/testing/bin/activate :pre
+
+Now configure and compile the LAMMPS shared library as outlined above.
+When using CMake and the shared library has already been build, you
+need to re-run CMake to update the location of the python executable
+to the location in the virtual environment with:
+
+cmake . -DPYTHON_EXECUTABLE=$(which python) :pre
 
 # install LAMMPS package in virtualenv
-(testing) cd $LAMMPS_DIR/python
-(testing) python install.py :pre
+(testing) make install-python :pre
 
 # install other useful packages
 (testing) pip install matplotlib jupyter mpi4py :pre

--- a/doc/src/Python_install.txt
+++ b/doc/src/Python_install.txt
@@ -25,7 +25,7 @@ run "make install-python" or run the python/install.py script explicitly :ul
 
 When calling "make install-python" LAMMPS will try to install the
 python module and the shared library into the python site-packages folders;
-either the system-wide ones, or the local users ones (in case of unsufficient
+either the system-wide ones, or the local users ones (in case of insufficient
 permissions for the global install). Python will then find the module
 and shared library file automatically.
 

--- a/doc/src/Python_install.txt
+++ b/doc/src/Python_install.txt
@@ -12,16 +12,22 @@ Installing LAMMPS in Python :h3
 For Python to invoke LAMMPS, there are 2 files it needs to know about:
 
 python/lammps.py
-src/liblammps.so :ul
+liblammps.so or liblammps.dylib :ul
 
-Lammps.py is the Python wrapper on the LAMMPS library interface.
-Liblammps.so is the shared LAMMPS library that Python loads, as
-described above.
+The python source code in lammps.py is the Python wrapper on the
+LAMMPS library interface. The liblammps.so or liblammps.dylib file
+is the shared LAMMPS library that Python loads dynamically.
 
 You can insure Python can find these files in one of two ways:
 
-set two environment variables
-run the python/install.py script :ul
+set two environment variables pointing to the location in the source tree
+run "make install-python" or run the python/install.py script explicitly :ul
+
+When calling "make install-python" LAMMPS will try to install the
+python module and the shared library into the python site-packages folders;
+either the system-wide ones, or the local users ones (in case of unsufficient
+permissions for the global install). Python will then find the module
+and shared library file automatically.
 
 If you set the paths to these files as environment variables, you only
 have to do it once.  For the csh or tcsh shells, add something like
@@ -30,42 +36,28 @@ this to your ~/.cshrc file, one line for each of the two files:
 setenv PYTHONPATH $\{PYTHONPATH\}:/home/sjplimp/lammps/python
 setenv LD_LIBRARY_PATH $\{LD_LIBRARY_PATH\}:/home/sjplimp/lammps/src :pre
 
-If you use the python/install.py script, you need to invoke it every
-time you rebuild LAMMPS (as a shared library) or make changes to the
-python/lammps.py file.
+On MacOSX you may also need to set DYLD_LIBRARY_PATH accordingly.
+For Bourne/Korn shells accordingly into the corresponding files using
+the "export" shell builtin.
 
-You can invoke install.py from the python directory as
+If you use "make install-python" or the python/install.py script, you need
+to invoke it every time you rebuild LAMMPS (as a shared library) or
+make changes to the python/lammps.py file, so that the site-packages
+files are updated with the new version.
 
-% python install.py \[libdir\] \[pydir\] :pre
+If the default settings of "make install-python" are not what you want,
+you can invoke install.py from the python directory manually as
 
-The optional libdir is where to copy the LAMMPS shared library to; the
-default is /usr/local/lib.  The optional pydir is where to copy the
-lammps.py file to; the default is the site-packages directory of the
-version of Python that is running the install script.
+% python install.py -m \<python module\> -l <shared library> -v <version.h file> \[-d \<pydir\>\] :pre
 
-Note that libdir must be a location that is in your default
-LD_LIBRARY_PATH, like /usr/local/lib or /usr/lib.  And pydir must be a
-location that Python looks in by default for imported modules, like
-its site-packages dir.  If you want to copy these files to
-non-standard locations, such as within your own user space, you will
-need to set your PYTHONPATH and LD_LIBRARY_PATH environment variables
-accordingly, as above.
-
-If the install.py script does not allow you to copy files into system
-directories, prefix the python command with "sudo".  If you do this,
-make sure that the Python that root runs is the same as the Python you
-run.  E.g. you may need to do something like
-
-% sudo /usr/local/bin/python install.py \[libdir\] \[pydir\] :pre
-
-You can also invoke install.py from the make command in the src
-directory as
-
-% make install-python :pre
-
-In this mode you cannot append optional arguments.  Again, you may
-need to prefix this with "sudo".  In this mode you cannot control
-which Python is invoked by root.
+The -m flag points to the lammps.py python module file to be installed,
+the -l flag points to the LAMMPS shared library file to be installed,
+the -v flag points to the version.h file in the LAMMPS source and the
+optional -d flag to the desired installation folder, if you don't want
+the Python specific site-packages folder. If you want to copy these files to
+non-standard locations, you will need to set your PYTHONPATH and
+LD_LIBRARY_PATH (and DYLD_LIBRARY_PATH) environment variables
+accordingly, as described above.
 
 Note that if you want Python to be able to load different versions of
 the LAMMPS shared library (see "this section"_Python_shlib.html), you will

--- a/doc/src/Python_install.txt
+++ b/doc/src/Python_install.txt
@@ -18,7 +18,7 @@ The python source code in lammps.py is the Python wrapper on the
 LAMMPS library interface. The liblammps.so or liblammps.dylib file
 is the shared LAMMPS library that Python loads dynamically.
 
-You can insure Python can find these files in one of two ways:
+You can achieve that Python can find these files in one of two ways:
 
 set two environment variables pointing to the location in the source tree
 run "make install-python" or run the python/install.py script explicitly :ul
@@ -27,7 +27,8 @@ When calling "make install-python" LAMMPS will try to install the
 python module and the shared library into the python site-packages folders;
 either the system-wide ones, or the local users ones (in case of insufficient
 permissions for the global install). Python will then find the module
-and shared library file automatically.
+and shared library file automatically. The exact location of these folders
+depends on your python version and your operating system.
 
 If you set the paths to these files as environment variables, you only
 have to do it once.  For the csh or tcsh shells, add something like
@@ -52,12 +53,12 @@ you can invoke install.py from the python directory manually as
 
 The -m flag points to the lammps.py python module file to be installed,
 the -l flag points to the LAMMPS shared library file to be installed,
-the -v flag points to the version.h file in the LAMMPS source and the
-optional -d flag to the desired installation folder, if you don't want
-the Python specific site-packages folder. If you want to copy these files to
-non-standard locations, you will need to set your PYTHONPATH and
-LD_LIBRARY_PATH (and DYLD_LIBRARY_PATH) environment variables
-accordingly, as described above.
+the -v flag points to the version.h file in the LAMMPS source
+and the optional -d flag to a custom (legacy) installation folder :ul
+
+If you use a legacy installation folder, you will need to set your
+PYTHONPATH and LD_LIBRARY_PATH (and/or DYLD_LIBRARY_PATH) environment
+variables accordingly, as described above.
 
 Note that if you want Python to be able to load different versions of
 the LAMMPS shared library (see "this section"_Python_shlib.html), you will

--- a/doc/src/Python_overview.txt
+++ b/doc/src/Python_overview.txt
@@ -13,11 +13,11 @@ Overview of Python and LAMMPS :h3
 LAMMPS can work together with Python in three ways.  First, Python can
 wrap LAMMPS through the its "library interface"_Howto_library.html, so
 that a Python script can create one or more instances of LAMMPS and
-launch one or more simulations.  In Python lingo, this is "extending"
-Python with LAMMPS.
+launch one or more simulations.  In Python lingo, this is called
+"extending" Python with a LAMMPS module.
 
 Second, a lower-level Python interface can be used indirectly through
-provided PyLammps and IPyLammps wrapper classes, written in Python.
+the provided PyLammps and IPyLammps wrapper classes, written in Python.
 These wrappers try to simplify the usage of LAMMPS in Python by
 providing an object-based interface to common LAMMPS functionality.
 They also reduces the amount of code necessary to parameterize LAMMPS
@@ -25,11 +25,12 @@ scripts through Python and make variables and computes directly
 accessible.
 
 Third, LAMMPS can use the Python interpreter, so that a LAMMPS
-input script can invoke Python code directly, and pass information
-back-and-forth between the input script and Python functions you
-write.  This Python code can also callback to LAMMPS to query or change
-its attributes.  In Python lingo, this is "embedding" Python in
-LAMMPS.  When used in this mode, Python can perform operations that
-the simple LAMMPS input script syntax cannot.
+input script or styles can invoke Python code directly, and pass
+information back-and-forth between the input script and Python
+functions you write.  This Python code can also callback to LAMMPS
+to query or change its attributes through the LAMMPS Python module
+mentioned above.  In Python lingo, this is "embedding" Python in
+LAMMPS.  When used in this mode, Python can perform script operations
+that the simple LAMMPS input script syntax can not.
 
 

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -250,6 +250,7 @@ Boresch
 Botero
 Botu
 Bouguet
+Bourne
 boxcolor
 bp
 bpls
@@ -627,6 +628,7 @@ dVx
 dW
 dx
 dy
+dylib
 dyn
 dyne
 dynes
@@ -1298,6 +1300,7 @@ Kondor
 konglt
 Koning
 Kooser
+Korn
 Koskinen
 Koster
 Kosztin

--- a/python/README
+++ b/python/README
@@ -9,12 +9,12 @@ doc/Section_python.html and in doc/Section_start.html#start_5.
 Basically you need to follow these steps in the src directory:
 
 % make g++ mode=shlib           # build for whatever machine target you wish
-% make install-python           # may need to do this via sudo
+% make install-python           # install into site-packages folder
 
 You can replace the last step by a one-time setting of environment
 variables in your shell script.  Or you can run the python/install.py
 script directly to give you more control over where the two relevant
-files are installed.  See doc/Section_python.html for details.
+files are installed.  See doc/Python_install.html for details.
 
 You should then be able to launch Python and instantiate an instance
 of LAMMPS:

--- a/python/install.py
+++ b/python/install.py
@@ -118,6 +118,7 @@ try:
         author_email = "sjplimp@sandia.gov",
         url = "https://lammps.sandia.gov",
         description = "LAMMPS Molecular Dynamics Python module",
+        license = "GPL",
         py_modules = ["lammps"],
         data_files = [(get_python_lib(prefix=args.prefix), [args.lib])])
 except:
@@ -128,14 +129,13 @@ if tryuser:
   try:
     sys.argv = ["setup.py","install","--user"]    # as if had run "python setup.py install --user"
     setup(name = "lammps",
-    version = verstr,
-    author = "Steve Plimpton",
-    author_email = "sjplimp@sandia.gov",
-    url = "https://lammps.sandia.gov",
-    description = "LAMMPS Molecular Dynamics Python module",
-    py_modules = ["lammps"],
-    data_files = [(site.USER_SITE, [args.lib])])
+          version = verstr,
+          author = "Steve Plimpton",
+          author_email = "sjplimp@sandia.gov",
+          url = "https://lammps.sandia.gov",
+          description = "LAMMPS Molecular Dynamics Python module",
+          license = "GPL",
+          py_modules = ["lammps"],
+          data_files = [(site.USER_SITE, [args.lib])])
   except:
     print("Installation into user site package folder failed.")
-
-

--- a/python/install.py
+++ b/python/install.py
@@ -23,11 +23,8 @@ parser.add_argument("-l", "--lib", required=True,
 parser.add_argument("-v", "--version", required=True,
                     help="path to the LAMMPS version.h header file")
 
-pgroup = parser.add_mutually_exclusive_group()
-pgroup.add_argument("-d","--dir",
-                    help="Legacy custom installation folder for module and library")
-pgroup.add_argument("-p","--prefix",
-                    help="Installation prefix for module and library")
+parser.add_argument("-d","--dir",
+                    help="Legacy custom installation folder selection for module and library")
 
 args = parser.parse_args()
 
@@ -65,14 +62,6 @@ if args.dir:
   else:
     args.dir = os.path.abspath(args.dir)
 
-if args.prefix:
-  if not os.path.isdir(args.prefix):
-    print( "ERROR: Installation prefix folder %s does not exist" % args.prefix)
-    parser.print_help()
-    sys.exit(1)
-  else:
-    args.prefix = os.path.abspath(args.prefix)
-
 # if a custom directory is given, we copy the files directly
 # without any special processing or additional steps to that folder
 
@@ -108,10 +97,7 @@ import site
 tryuser=False
 
 try:
-  if args.prefix:
-    sys.argv = ["setup.py","install","--prefix=%s" % args.prefix]    # as if had run "python setup.py install --prefix=XXX"
-  else:
-    sys.argv = ["setup.py","install"]    # as if had run "python setup.py install"
+  sys.argv = ["setup.py","install"]    # as if had run "python setup.py install"
   setup(name = "lammps",
         version = verstr,
         author = "Steve Plimpton",
@@ -120,7 +106,7 @@ try:
         description = "LAMMPS Molecular Dynamics Python module",
         license = "GPL",
         py_modules = ["lammps"],
-        data_files = [(get_python_lib(prefix=args.prefix), [args.lib])])
+        data_files = [(get_python_lib(), [args.lib])])
 except:
   tryuser=True
   print ("Installation into global site-packages folder failed.\nTrying user folder %s now." % site.USER_SITE)

--- a/src/Makefile
+++ b/src/Makefile
@@ -275,7 +275,8 @@ mpi-stubs:
 
 sinclude ../lib/python/Makefile.lammps
 install-python:
-	@$(PYTHON) ../python/install.py
+	@$(PYTHON) ../python/install.py -v ../src/version.h \
+		-m ../python/lammps.py -l ../src/liblammps.so
 
 # Create a tarball of src dir and packages
 


### PR DESCRIPTION
**Summary**

This pull request provides some refactoring of the LAMMPS python module installation script to improve platform neutrality and include it cleanly into both, conventional and CMake based builds

**Related Issues**

closes #1373 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The command line flags for manually running the Python module install script have changed. However suitable help messages and consistency checks on arguments have been added.

**Implementation Notes**

The CMake old configuration made (part of) the python module installation dependent on enabling the PYTHON package. This makes this independent and CMake builds should behave similar to conventional make now.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


