### PR TITLE
Put #ifdef around #include "curl/curl.h" in kim_query.cpp

### DIFF
--- a/src/KIM/kim_query.cpp
+++ b/src/KIM/kim_query.cpp
@@ -64,8 +64,10 @@
 #include "input.h"
 #include "variable.h"
 
+#if defined(LMP_KIM_CURL)
 #include <sys/types.h>
 #include <curl/curl.h>
+#endif
 
 using namespace LAMMPS_NS;
 


### PR DESCRIPTION
**Summary**
Fix up build for when curl is not installed

**Author(s)**

Ryan S. Elliott

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


