### PR TITLE
bug fix for tiled communication at cutoffs near box size

### DIFF
--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -1255,14 +1255,14 @@ void Balance::dumpout(bigint tstep)
       int m = 0;
       for (int i = 0; i < nprocs; i++) {
         domain->lamda_box_corners(&boxall[i][0],&boxall[i][3]);
-        fprintf(fp,"%d %d %g %g %g\n",m+1,1,bc[0][0],bc[0][1],bc[0][1]);
-        fprintf(fp,"%d %d %g %g %g\n",m+2,1,bc[1][0],bc[1][1],bc[1][1]);
-        fprintf(fp,"%d %d %g %g %g\n",m+3,1,bc[2][0],bc[2][1],bc[2][1]);
-        fprintf(fp,"%d %d %g %g %g\n",m+4,1,bc[3][0],bc[3][1],bc[3][1]);
-        fprintf(fp,"%d %d %g %g %g\n",m+5,1,bc[4][0],bc[4][1],bc[4][1]);
-        fprintf(fp,"%d %d %g %g %g\n",m+6,1,bc[5][0],bc[5][1],bc[5][1]);
-        fprintf(fp,"%d %d %g %g %g\n",m+7,1,bc[6][0],bc[6][1],bc[6][1]);
-        fprintf(fp,"%d %d %g %g %g\n",m+8,1,bc[7][0],bc[7][1],bc[7][1]);
+        fprintf(fp,"%d %d %g %g %g\n",m+1,1,bc[0][0],bc[0][1],bc[0][2]);
+        fprintf(fp,"%d %d %g %g %g\n",m+2,1,bc[1][0],bc[1][1],bc[1][2]);
+        fprintf(fp,"%d %d %g %g %g\n",m+3,1,bc[2][0],bc[2][1],bc[2][2]);
+        fprintf(fp,"%d %d %g %g %g\n",m+4,1,bc[3][0],bc[3][1],bc[3][2]);
+        fprintf(fp,"%d %d %g %g %g\n",m+5,1,bc[4][0],bc[4][1],bc[4][2]);
+        fprintf(fp,"%d %d %g %g %g\n",m+6,1,bc[5][0],bc[5][1],bc[5][2]);
+        fprintf(fp,"%d %d %g %g %g\n",m+7,1,bc[6][0],bc[6][1],bc[6][2]);
+        fprintf(fp,"%d %d %g %g %g\n",m+8,1,bc[7][0],bc[7][1],bc[7][2]);
         m += 8;
       }
     }

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -512,7 +512,7 @@ void CommTiled::forward_comm(int /*dummy*/)
                     MPI_DOUBLE,recvproc[iswap][i],0,world,&requests[i]);
       }
       if (sendother[iswap]) {
-        for (i = 0; i < nsendproc[iswap]; i++) {
+        for (i = 0; i < nsend; i++) {
           n = avec->pack_comm(sendnum[iswap][i],sendlist[iswap][i],
                               buf_send,pbc_flag[iswap][i],pbc[iswap][i]);
           MPI_Send(buf_send,n,MPI_DOUBLE,sendproc[iswap][i],0,world);

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -46,9 +46,9 @@ enum{IGNORE,END,EXTRA};
 
 FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg),
-  nvalues(0), which(NULL), argindex(NULL), value2index(NULL), 
+  nvalues(0), which(NULL), argindex(NULL), value2index(NULL),
   ids(NULL), fp(NULL), stats_list(NULL),
-  bin(NULL), bin_total(NULL), bin_all(NULL), bin_list(NULL), 
+  bin(NULL), bin_total(NULL), bin_all(NULL), bin_list(NULL),
   coord(NULL), vector(NULL)
 {
   if (narg < 10) error->all(FLERR,"Illegal fix ave/histo command");
@@ -232,7 +232,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
 
     } else if (which[i] == VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
-      if (ivariable < 0) 
+      if (ivariable < 0)
         error->all(FLERR,"Fix ave/histo input is invalid variable");
       // variables only produce one kind of output
       if (input->variable->equalstyle(ivariable)) kindglobal = 1;
@@ -247,13 +247,13 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
       if (kindperatom) kind = PERATOM;
       if (kindlocal) kind = LOCAL;
     } else if (kind == GLOBAL) {
-      if (!kindglobal) 
+      if (!kindglobal)
         error->all(FLERR,"Fix ave/histo input kind is invalid");
     } else if (kind == PERATOM) {
-      if (!kindperatom) 
+      if (!kindperatom)
         error->all(FLERR,"Fix ave/histo input kind is invalid");
     } else if (kind == LOCAL) {
-      if (!kindlocal) 
+      if (!kindlocal)
         error->all(FLERR,"Fix ave/histo input kind is invalid");
     }
   }

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -274,10 +274,6 @@ void FixBalance::rebalance()
     comm->layout = Comm::LAYOUT_TILED;
   }
 
-  // output of new decomposition
-
-  if (balance->outflag) balance->dumpout(update->ntimestep);
-
   // reset proc sub-domains
   // check and warn if any proc's subbox is smaller than neigh skin
   //   since may lead to lost atoms in comm->exchange()
@@ -286,12 +282,17 @@ void FixBalance::rebalance()
   domain->set_local_box();
   domain->subbox_too_small_check(neighbor->skin);
 
+  // output of new decomposition
+
+  if (balance->outflag) balance->dumpout(update->ntimestep);
+
   // move atoms to new processors via irregular()
   // for non-RCB only needed if migrate_check() says an atom moves too far
   // else allow caller's comm->exchange() to do it
   // set disable = 0, so weights migrate with atoms
   //   important to delay disable = 1 until after pre_neighbor imbfinal calc
   //   b/c atoms may migrate again in comm->exchange()
+  // NOTE: for reproducible debug runs, set 1st arg of migrate_atoms() to 1
 
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
   if (wtflag) balance->fixstore->disable = 0;


### PR DESCRIPTION
**Summary**

Fix a bug with tiled decomposition communication when the ghost cutoff is long enough that a processor is sending ghost atoms to itself.  Also fixes an output issue with fix balance output
occurring before the rebalance rather than after.

**Related Issues**

Fixes #1385

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


