### PR TITLE
Error out when per-atom stress is requested for USER-INTEL styles

### DIFF
--- a/doc/src/Speed_intel.txt
+++ b/doc/src/Speed_intel.txt
@@ -34,6 +34,10 @@ rebo, sw, tersoff :l
 K-Space Styles: pppm, pppm/disp :l
 :ule
 
+IMPORTANT NOTE: None of the styles in the USER-INTEL package currently
+support computing per-atom stress.  If any compute or fix in your
+input requires it, LAMMPS will abort with an error message.
+
 [Speed-ups to expect:]
 
 The speedups will depend on your simulation, the hardware, which

--- a/src/USER-INTEL/README
+++ b/src/USER-INTEL/README
@@ -2,13 +2,13 @@
                      --------------------------------
                           LAMMPS Intel(R) Package
                      --------------------------------
-                     
+
              W. Michael Brown (Intel) michael.w.brown at intel.com
                   Markus Hohnerbach (RWTH Aachen University)
                    William McDoniel (RWTH Aachen University)
                    Rodrigo Canales (RWTH Aachen University)
                            Stan Moore (Sandia)
-		   Ahmed E. Ismail (RWTH Aachen University)
+                   Ahmed E. Ismail (RWTH Aachen University)
                    Paolo Bientinesi (RWTH Aachen University)
                           Anupama Kurpad (Intel)
                           Biswajit Mishra (Shell)
@@ -20,8 +20,14 @@ This package provides LAMMPS styles that:
    1. include support for single and mixed precision in addition to double.
    2. include modifications to support vectorization for key routines
    3. include modifications for data layouts to improve cache efficiency
-   3. include modifications to support offload to Intel(R) Xeon Phi(TM) 
+   3. include modifications to support offload to Intel(R) Xeon Phi(TM)
       coprocessors
+
+-----------------------------------------------------------------------------
+
+As of 2019/03/28 none of the styles provided in this package support
+tallying per-atom stresses. Any attempt to compute/access it will
+cause an error termination.
 
 -----------------------------------------------------------------------------
 
@@ -31,12 +37,12 @@ be added or changed in the Makefile depending on the version:
 2017 update 2         - No changes needed
 2017 updates 3 or 4   - Use -xCOMMON-AVX512 and not -xHost or -xCORE-AVX512
 2018 inital release   - Use -xCOMMON-AVX512 and not -xHost or -xCORE-AVX512
-2018u1 or newer       - Use -xHost or -xCORE-AVX512 and -qopt-zmm-usage=high 
+2018u1 or newer       - Use -xHost or -xCORE-AVX512 and -qopt-zmm-usage=high
 
 -----------------------------------------------------------------------------
 
 When using the suffix command with "intel", intel styles will be used if they
-exist. If the suffix command is used with "hybrid intel omp" and the USER-OMP 
+exist. If the suffix command is used with "hybrid intel omp" and the USER-OMP
 is installed, USER-OMP styles will be used whenever USER-INTEL styles are not
 available. This allow for running most styles in LAMMPS with threading.
 
@@ -55,21 +61,21 @@ need to be changed.
 
 Unless Intel Math Kernel Library (MKL) is unavailable, -DLMP_USE_MKL_RNG
 should be added to the compile flags. This will enable using the MKL Mersenne
-Twister random number generator (RNG) for Dissipative Particle Dynamics 
-(DPD). This RNG can allow significantly faster performance and it also has a 
+Twister random number generator (RNG) for Dissipative Particle Dynamics
+(DPD). This RNG can allow significantly faster performance and it also has a
 significantly longer period than the standard RNG for DPD.
 
 -----------------------------------------------------------------------------
 
-In order to use offload to Intel(R) Xeon Phi(TM) coprocessors, the flag 
--DLMP_INTEL_OFFLOAD should be set in the Makefile. Offload requires the use of 
+In order to use offload to Intel(R) Xeon Phi(TM) coprocessors, the flag
+-DLMP_INTEL_OFFLOAD should be set in the Makefile. Offload requires the use of
 Intel compilers.
 
 -----------------------------------------------------------------------------
 
-For portability reasons, vectorization directives are currently only enabled 
+For portability reasons, vectorization directives are currently only enabled
 for Intel compilers. Using other compilers may result in significantly
-lower performance. This behavior can be changed by defining 
+lower performance. This behavior can be changed by defining
 LMP_SIMD_COMPILER for the preprocessor (see intel_preprocess.h).
 
 -----------------------------------------------------------------------------
@@ -81,9 +87,9 @@ compile with -DINTEL_OFFLOAD_NOAFFINITY.
 
 -----------------------------------------------------------------------------
 
-Vector intrinsics are temporarily being used for the Stillinger-Weber 
+Vector intrinsics are temporarily being used for the Stillinger-Weber
 potential to allow for advanced features in the AVX512 instruction set to
 be exploited on early hardware. We hope to see compiler improvements for
 AVX512 that will eliminate this requirement, so it is not recommended to
-develop code based on the intrinsics implementation. Please e-mail the 
+develop code based on the intrinsics implementation. Please e-mail the
 authors for more details.

--- a/src/USER-INTEL/angle_charmm_intel.cpp
+++ b/src/USER-INTEL/angle_charmm_intel.cpp
@@ -79,6 +79,8 @@ void AngleCharmmIntel::compute(int eflag, int vflag,
                                const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/angle_harmonic_intel.cpp
+++ b/src/USER-INTEL/angle_harmonic_intel.cpp
@@ -79,6 +79,8 @@ void AngleHarmonicIntel::compute(int eflag, int vflag,
                                const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/bond_fene_intel.cpp
+++ b/src/USER-INTEL/bond_fene_intel.cpp
@@ -75,6 +75,8 @@ void BondFENEIntel::compute(int eflag, int vflag,
                                 const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/bond_harmonic_intel.cpp
+++ b/src/USER-INTEL/bond_harmonic_intel.cpp
@@ -75,6 +75,8 @@ void BondHarmonicIntel::compute(int eflag, int vflag,
                                 const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/dihedral_charmm_intel.cpp
+++ b/src/USER-INTEL/dihedral_charmm_intel.cpp
@@ -85,6 +85,8 @@ void DihedralCharmmIntel::compute(int eflag, int vflag,
                                   const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 

--- a/src/USER-INTEL/dihedral_fourier_intel.cpp
+++ b/src/USER-INTEL/dihedral_fourier_intel.cpp
@@ -74,6 +74,8 @@ void DihedralFourierIntel::compute(int eflag, int vflag,
                                    const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/dihedral_harmonic_intel.cpp
+++ b/src/USER-INTEL/dihedral_harmonic_intel.cpp
@@ -74,6 +74,8 @@ void DihedralHarmonicIntel::compute(int eflag, int vflag,
                                   const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/dihedral_opls_intel.cpp
+++ b/src/USER-INTEL/dihedral_opls_intel.cpp
@@ -78,6 +78,8 @@ void DihedralOPLSIntel::compute(int eflag, int vflag,
                                   const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/improper_cvff_intel.cpp
+++ b/src/USER-INTEL/improper_cvff_intel.cpp
@@ -84,6 +84,8 @@ void ImproperCvffIntel::compute(int eflag, int vflag,
                                     const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/improper_harmonic_intel.cpp
+++ b/src/USER-INTEL/improper_harmonic_intel.cpp
@@ -85,6 +85,8 @@ void ImproperHarmonicIntel::compute(int eflag, int vflag,
                                     const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   if (evflag) {
     if (vflag && !eflag) {

--- a/src/USER-INTEL/pair_airebo_intel.cpp
+++ b/src/USER-INTEL/pair_airebo_intel.cpp
@@ -293,6 +293,9 @@ void PairAIREBOIntel::compute(
     int eflag, int vflag, IntelBuffers<flt_t,acc_t> * buffers
 ) {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
+
   pvector[0] = pvector[1] = pvector[2] = 0.0;
 
   const int inum = list->inum;

--- a/src/USER-INTEL/pair_buck_coul_cut_intel.cpp
+++ b/src/USER-INTEL/pair_buck_coul_cut_intel.cpp
@@ -74,6 +74,8 @@ void PairBuckCoulCutIntel::compute(int eflag, int vflag,
                                    const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_buck_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_buck_coul_long_intel.cpp
@@ -74,6 +74,8 @@ void PairBuckCoulLongIntel::compute(int eflag, int vflag,
                                     const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_buck_intel.cpp
+++ b/src/USER-INTEL/pair_buck_intel.cpp
@@ -67,6 +67,8 @@ void PairBuckIntel::compute(int eflag, int vflag,
                             const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_dpd_intel.cpp
+++ b/src/USER-INTEL/pair_dpd_intel.cpp
@@ -83,6 +83,8 @@ void PairDPDIntel::compute(int eflag, int vflag,
                            const ForceConst<flt_t> &fc)
 {
   ev_init(eflag, vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_eam_intel.cpp
+++ b/src/USER-INTEL/pair_eam_intel.cpp
@@ -79,6 +79,8 @@ void PairEAMIntel::compute(int eflag, int vflag,
                            const ForceConst<flt_t> &fc)
 {
   ev_init(eflag, vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_gayberne_intel.cpp
+++ b/src/USER-INTEL/pair_gayberne_intel.cpp
@@ -73,6 +73,8 @@ void PairGayBerneIntel::compute(int eflag, int vflag,
                                 const ForceConst<flt_t> &fc)
 {
   ev_init(eflag, vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nall = atom->nlocal + atom->nghost;

--- a/src/USER-INTEL/pair_lj_charmm_coul_charmm_intel.cpp
+++ b/src/USER-INTEL/pair_lj_charmm_coul_charmm_intel.cpp
@@ -67,6 +67,8 @@ void PairLJCharmmCoulCharmmIntel::compute(int eflag, int vflag,
                                         const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_lj_charmm_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_lj_charmm_coul_long_intel.cpp
@@ -71,6 +71,8 @@ void PairLJCharmmCoulLongIntel::compute(int eflag, int vflag,
                                         const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_lj_cut_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_lj_cut_coul_long_intel.cpp
@@ -72,6 +72,8 @@ void PairLJCutCoulLongIntel::compute(int eflag, int vflag,
                                      const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_lj_cut_intel.cpp
+++ b/src/USER-INTEL/pair_lj_cut_intel.cpp
@@ -63,6 +63,8 @@ void PairLJCutIntel::compute(int eflag, int vflag,
                              const ForceConst<flt_t> &fc)
 {
   ev_init(eflag, vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_rebo_intel.cpp
+++ b/src/USER-INTEL/pair_rebo_intel.cpp
@@ -28,7 +28,7 @@ PairREBOIntel::PairREBOIntel(LAMMPS *lmp) : PairAIREBOIntel(lmp) {}
    global settings
 ------------------------------------------------------------------------- */
 
-void PairREBOIntel::settings(int narg, char **/*arg*/)
+void PairREBOIntel::settings(int narg, char ** /* arg */)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
 

--- a/src/USER-INTEL/pair_sw_intel.cpp
+++ b/src/USER-INTEL/pair_sw_intel.cpp
@@ -96,6 +96,8 @@ void PairSWIntel::compute(int eflag, int vflag,
                           const ForceConst<flt_t> &fc)
 {
   ev_init(eflag, vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;

--- a/src/USER-INTEL/pair_tersoff_intel.cpp
+++ b/src/USER-INTEL/pair_tersoff_intel.cpp
@@ -108,6 +108,8 @@ void PairTersoffIntel::compute(int eflag, int vflag,
                                      const ForceConst<flt_t> &fc)
 {
   ev_init(eflag,vflag);
+  if (vflag_atom)
+    error->all(FLERR,"USER-INTEL package does not support per-atom stress");
 
   const int inum = list->inum;
   const int nthreads = comm->nthreads;


### PR DESCRIPTION
**Summary**

The styles in the USER-INTEL package do not support tallying per-atom stress and quietly return 0.0. This PR adds a check for it and aborts the calculation instead.

**Related Issues**

closes #1389 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] A package specific README file has been included or updated
- [ ] One or more example input decks are included


