### PR TITLE
Set Coulomb summation cutoff radii when it is explicitly specified

### DIFF
--- a/src/pair_lj_cut_coul_wolf.cpp
+++ b/src/pair_lj_cut_coul_wolf.cpp
@@ -217,7 +217,8 @@ void PairLJCutCoulWolf::settings(int narg, char **arg)
 
   alf = force->numeric(FLERR,arg[0]);
   cut_lj_global = force->numeric(FLERR,arg[1]);
-  if (narg == 2) cut_coul = cut_lj_global;
+  if (narg == 3) cut_coul = force->numeric(FLERR,arg[2]);
+  else           cut_coul = cut_lj_global;
 
   if (allocated) {
     int i,j;


### PR DESCRIPTION
**Summary**

Variable `cut_coul` is not set for the case it is explicitly specified by the user. This PR fixes this behavior.

**Author(s)**

Vishal Boddu
Friedrich-Alexander-Universität Erlangen-Nürnberg

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Backward compatible