### PR TITLE
Fix bug reported in Issue #1401

### DIFF
--- a/src/BODY/compute_body_local.cpp
+++ b/src/BODY/compute_body_local.cpp
@@ -39,8 +39,6 @@ ComputeBodyLocal::ComputeBodyLocal(LAMMPS *lmp, int narg, char **arg) :
 
   local_flag = 1;
   nvalues = narg - 3;
-  if (nvalues == 1) size_local_cols = 0;
-  else size_local_cols = nvalues;
 
   which = new int[nvalues];
   index = new int[nvalues];
@@ -65,6 +63,9 @@ ComputeBodyLocal::ComputeBodyLocal(LAMMPS *lmp, int narg, char **arg) :
     if (which[i] == INDEX && (index[i] < 0 || index[i] >= indexmax))
       error->all(FLERR,"Invalid index in compute body/local command");
   }
+
+  if (nvalues == 1) size_local_cols = 0;
+  else size_local_cols = nvalues;
 
   nmax = 0;
   vector = NULL;

--- a/src/RIGID/compute_rigid_local.cpp
+++ b/src/RIGID/compute_rigid_local.cpp
@@ -40,8 +40,6 @@ ComputeRigidLocal::ComputeRigidLocal(LAMMPS *lmp, int narg, char **arg) :
 
   local_flag = 1;
   nvalues = narg - 4;
-  if (nvalues == 1) size_local_cols = 0;
-  else size_local_cols = nvalues;
 
   int n = strlen(arg[3]) + 1;
   idrigid = new char[n];
@@ -88,7 +86,10 @@ ComputeRigidLocal::ComputeRigidLocal(LAMMPS *lmp, int narg, char **arg) :
     else error->all(FLERR,"Invalid keyword in compute rigid/local command");
   }
 
-  ncount = nmax = 0;
+  if (nvalues == 1) size_local_cols = 0;
+  else size_local_cols = nvalues;
+
+ncount = nmax = 0;
   vlocal = NULL;
   alocal = NULL;
 }

--- a/src/compute_improper_local.cpp
+++ b/src/compute_improper_local.cpp
@@ -46,9 +46,6 @@ ComputeImproperLocal::ComputeImproperLocal(LAMMPS *lmp, int narg, char **arg) :
 
   local_flag = 1;
   nvalues = narg - 3;
-  if (nvalues == 1) size_local_cols = 0;
-  else size_local_cols = nvalues;
-
   cflag = -1;
   nvalues = 0;
 
@@ -56,6 +53,9 @@ ComputeImproperLocal::ComputeImproperLocal(LAMMPS *lmp, int narg, char **arg) :
     if (strcmp(arg[iarg],"chi") == 0) cflag = nvalues++;
     else error->all(FLERR,"Invalid keyword in compute improper/local command");
   }
+
+  if (nvalues == 1) size_local_cols = 0;
+  else size_local_cols = nvalues;
 
   nmax = 0;
   vlocal = NULL;

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -43,9 +43,6 @@ ComputePairLocal::ComputePairLocal(LAMMPS *lmp, int narg, char **arg) :
 
   local_flag = 1;
   nvalues = narg - 3;
-  if (nvalues == 1) size_local_cols = 0;
-  else size_local_cols = nvalues;
-
   pstyle = new int[nvalues];
   pindex = new int[nvalues];
 
@@ -95,6 +92,9 @@ ComputePairLocal::ComputePairLocal(LAMMPS *lmp, int narg, char **arg) :
   singleflag = 0;
   for (int i = 0; i < nvalues; i++)
     if (pstyle[i] != DIST) singleflag = 1;
+
+  if (nvalues == 1) size_local_cols = 0;
+  else size_local_cols = nvalues;
 
   nmax = 0;
   vlocal = NULL;


### PR DESCRIPTION
**Summary**

This moves the assignment of `size_local_cols` **after** nvalues has been reset and only arguments contributing data was counted.

**Related Issues**

fixes #1401 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes. bugfix.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

