### PR TITLE
MC/fix_bond_break: Use TAGINT_FORMAT where appropriate

### DIFF
--- a/src/MC/fix_bond_break.cpp
+++ b/src/MC/fix_bond_break.cpp
@@ -800,26 +800,27 @@ void FixBondBreak::print_bb()
   for (int i = 0; i < atom->nlocal; i++) {
     printf("TAG " TAGINT_FORMAT ": %d nbonds: ",atom->tag[i],atom->num_bond[i]);
     for (int j = 0; j < atom->num_bond[i]; j++) {
-      printf(" %d",atom->bond_atom[i][j]);
+      printf(" " TAGINT_FORMAT, atom->bond_atom[i][j]);
     }
     printf("\n");
     printf("TAG " TAGINT_FORMAT ": %d nangles: ",atom->tag[i],atom->num_angle[i]);
     for (int j = 0; j < atom->num_angle[i]; j++) {
-      printf(" %d %d %d,",atom->angle_atom1[i][j],
-             atom->angle_atom2[i][j],atom->angle_atom3[i][j]);
+      printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT ",",
+             atom->angle_atom1[i][j],atom->angle_atom2[i][j],
+             atom->angle_atom3[i][j]);
     }
     printf("\n");
     printf("TAG " TAGINT_FORMAT ": %d ndihedrals: ",atom->tag[i],atom->num_dihedral[i]);
     for (int j = 0; j < atom->num_dihedral[i]; j++) {
-      printf(" %d %d %d %d,",atom->dihedral_atom1[i][j],
-             atom->dihedral_atom2[i][j],atom->dihedral_atom3[i][j],
-             atom->dihedral_atom4[i][j]);
+      printf(" " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT ",",
+             atom->dihedral_atom1[i][j],atom->dihedral_atom2[i][j],
+             atom->dihedral_atom3[i][j],atom->dihedral_atom4[i][j]);
     }
     printf("\n");
     printf("TAG " TAGINT_FORMAT ": %d %d %d nspecial: ",atom->tag[i],
            atom->nspecial[i][0],atom->nspecial[i][1],atom->nspecial[i][2]);
     for (int j = 0; j < atom->nspecial[i][2]; j++) {
-      printf(" %d",atom->special[i][j]);
+      printf(" " TAGINT_FORMAT, atom->special[i][j]);
     }
     printf("\n");
   }
@@ -830,7 +831,7 @@ void FixBondBreak::print_bb()
 void FixBondBreak::print_copy(const char *str, tagint m,
                               int n1, int n2, int n3, int *v)
 {
-  printf("%s %i: %d %d %d nspecial: ",str,m,n1,n2,n3);
+  printf("%s " TAGINT_FORMAT ": %d %d %d nspecial: ",str,m,n1,n2,n3);
   for (int j = 0; j < n3; j++) printf(" %d",v[j]);
   printf("\n");
 }

--- a/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
+++ b/src/USER-MANIFOLD/fix_nve_manifold_rattle.cpp
@@ -559,7 +559,8 @@ void FixNVEManifoldRattle::rattle_manifold_x(double *x, double *v,
 
   if (iters >= max_iter && res > tolerance) {
     char msg[2048];
-    sprintf(msg,"Failed to constrain atom %d (x = (%f, %f, %f)! res = %e, iters = %d\n",
+    sprintf(msg,"Failed to constrain atom " TAGINT_FORMAT
+            " (x = (%f, %f, %f)! res = %e, iters = %d\n",
             tagi, x[0], x[1], x[2], res, iters);
     error->one(FLERR,msg);
   }
@@ -652,7 +653,8 @@ void FixNVEManifoldRattle::rattle_manifold_v(double *v, double *f,
 
   if (iters >= max_iter && res >= tolerance) {
           char msg[2048];
-          sprintf(msg,"Failed to constrain atom %d (x = (%f, %f, %f)! res = %e, iters = %d\n",
+          sprintf(msg,"Failed to constrain atom " TAGINT_FORMAT
+                  " (x = (%f, %f, %f)! res = %e, iters = %d\n",
                   tagi, x[0], x[1], x[2], res, iters);
           error->all(FLERR,msg);
   }

--- a/src/USER-SMD/pair_smd_tlsph.cpp
+++ b/src/USER-SMD/pair_smd_tlsph.cpp
@@ -308,7 +308,7 @@ void PairTlsph::PreCompute() {
                          */
 
                         if ((detF[i] < DETF_MIN) || (detF[i] > DETF_MAX) || (numNeighsRefConfig[i] == 0)) {
-                                printf("deleting particle [%d] because det(F)=%f is outside stable range %f -- %f \n", tag[i],
+                                printf("deleting particle [" TAGINT_FORMAT "] because det(F)=%f is outside stable range %f -- %f \n", tag[i],
                                                 Fincr[i].determinant(),
                                                 DETF_MIN, DETF_MAX);
                                 printf("nn = %d, damage=%f\n", numNeighsRefConfig[i], damage[i]);


### PR DESCRIPTION
**Summary**

`MC/fix_bond_break.cpp` was using `%d` or `%i` as the format for `tagint` in `printf`. This is changed to use `TAGINT_FORMAT`.

**Author(s)**

Risto Toijala (University of Helsinki)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No breaking changes. The changed places are in debug code that is currently not used.

**Implementation Notes**

Straight-forward replacement of the places the compiler warns about, after manual checking.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
