### PR TITLE
Fix pointer assignment in pair_kim

### DIFF
--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -481,7 +481,7 @@ void PairKIM::init_style()
       for (int i = 0; i < kim_number_of_neighbor_lists; ++i)
       {
         lmps_stripped_neigh_ptr[i]
-            = &(lmps_stripped_neigh_list[(i-1)*(neighbor->oneatom)]);
+            = &(lmps_stripped_neigh_list[i*(neighbor->oneatom)]);
       }
 
    }


### PR DESCRIPTION
Bug only affects cases where neighbor list needs to be stripped.
Thanks to Mingjian Wen (@mjwen) for finding and reporting this

**Related Issues**

none

**Author(s)**

Ryan S. Elliott and Mingjian Wen

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

none

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

