### PR TITLE
Adding a fix setforce/spin to the SPIN package

### DIFF
--- a/doc/src/Howto_spins.txt
+++ b/doc/src/Howto_spins.txt
@@ -45,13 +45,13 @@ relaxation of the magnetic configuration toward an equilibrium state.
 
 The command "fix setforce/spin"_fix_setforce.html allows to set the 
 components of the magnetic precession vectors (while erasing and 
-replacing the previsouly computed magnetic precession vectors on 
+replacing the previously computed magnetic precession vectors on 
 the atom). 
 This command can be used to freeze the magnetic moment of certain 
 atoms in the simulation by zeroing their precession vector. 
 
 The command "fix nve/spin"_fix_nve_spin.html can be used to
-perform a simplectic integration of the combined dynamics of spins 
+perform a symplectic integration of the combined dynamics of spins 
 and atomic motions.
 
 The minimization style "min/spin"_min_spin.html can be applied

--- a/doc/src/Howto_spins.txt
+++ b/doc/src/Howto_spins.txt
@@ -10,7 +10,7 @@ Documentation"_ld - "LAMMPS Commands"_lc :c
 Magnetic spins :h3
 
 The magnetic spin simulations are enabled by the SPIN package, whose
-implementation is detailed in "Tranchida"_#Tranchida7.
+implementation is detailed in "Tranchida"_#Tranchida.
 
 The model represents the simulation of atomic magnetic spins coupled
 to lattice vibrations. The dynamics of those magnetic spins can be used
@@ -36,12 +36,27 @@ A Langevin thermostat can be applied to those magnetic spins using
 "fix langevin/spin"_fix_langevin_spin.html. Typically, this thermostat
 can be coupled to another Langevin thermostat applied to the atoms
 using "fix langevin"_fix_langevin.html in order to simulate
-thermostatted spin-lattice system.
+thermostatted spin-lattice systems.
 
 The magnetic Gilbert damping can also be applied using "fix
 langevin/spin"_fix_langevin_spin.html. It allows to either dissipate
 the thermal energy of the Langevin thermostat, or to perform a
 relaxation of the magnetic configuration toward an equilibrium state.
+
+The command "fix setforce/spin"_fix_setforce.html allows to set the 
+components of the magnetic precession vectors (while erasing and 
+replacing the previsouly computed magnetic precession vectors on 
+the atom). 
+This command can be used to freeze the magnetic moment of certain 
+atoms in the simulation by zeroing their precession vector. 
+
+The command "fix nve/spin"_fix_nve_spin.html can be used to
+perform a simplectic integration of the combined dynamics of spins 
+and atomic motions.
+
+The minimization style "min/spin"_min_spin.html can be applied
+to the spins to perform a minimization of the spin configuration. 
+
 
 All the computed magnetic properties can be output by two main
 commands. The first one is "compute spin"_compute_spin.html, that
@@ -54,6 +69,6 @@ magnetic spin, or the magnetic force acting on this spin.
 
 :line
 
-:link(Tranchida7)
+:link(Tranchida)
 [(Tranchida)] Tranchida, Plimpton, Thibaudeau and Thompson,
-arXiv preprint arXiv:1801.10233, (2018).
+Journal of Computational Physics, 372, 406-425, (2018).

--- a/doc/src/fix_langevin_spin.txt
+++ b/doc/src/fix_langevin_spin.txt
@@ -99,4 +99,4 @@ integration fix (e.g. {fix nve/spin}).
 
 :link(Tranchida2)
 [(Tranchida)] Tranchida, Plimpton, Thibaudeau and Thompson,
-Journal of Computational Physics, (2018).
+Journal of Computational Physics, 372, 406-425, (2018).

--- a/doc/src/fix_nve_spin.txt
+++ b/doc/src/fix_nve_spin.txt
@@ -73,4 +73,4 @@ instead of "array" is also valid.
 
 :link(Tranchida1)
 [(Tranchida)] Tranchida, Plimpton, Thibaudeau and Thompson,
-Journal of Computational Physics, (2018).
+Journal of Computational Physics, 372, 406-425, (2018).

--- a/doc/src/fix_setforce.txt
+++ b/doc/src/fix_setforce.txt
@@ -8,6 +8,7 @@
 
 fix setforce command :h3
 fix setforce/kk command :h3
+fix setforce/spin command :h3
 
 [Syntax:]
 
@@ -27,6 +28,7 @@ keyword = {region}  :l
 
 fix freeze indenter setforce 0.0 0.0 0.0
 fix 2 edge setforce NULL 0.0 0.0
+fix 1 edge setforce/spin 0.0 0.0 0.0
 fix 2 edge setforce NULL 0.0 v_oscillate :pre
 
 [Description:]
@@ -62,6 +64,19 @@ field with optional time-dependence as well.
 If the {region} keyword is used, the atom must also be in the
 specified geometric "region"_region.html in order to have force added
 to it.
+
+:line
+
+Style {spin} suffix sets the components of the magnetic precession 
+vectors instead of the mechanical forces. This also erases all 
+previously computed magnetic precession vectors on the atom, though 
+additional magnetic fixes could add new forces.
+
+This command can be used to freeze the magnetic moment of certain 
+atoms in the simulation by zeroing their precession vector. 
+
+All options defined above remain valid, they just apply to the magnetic 
+precession vectors instead of the forces.
 
 :line
 
@@ -117,7 +132,10 @@ forces to any value besides zero when performing a minimization.  Use
 the "fix addforce"_fix_addforce.html command if you want to apply a
 non-zero force to atoms during a minimization.
 
-[Restrictions:] none
+[Restrictions:] 
+
+The fix {setforce/spin} only makes sense when LAMMPS was built with the
+SPIN package.
 
 [Related commands:]
 

--- a/doc/src/pair_spin_dmi.txt
+++ b/doc/src/pair_spin_dmi.txt
@@ -88,4 +88,4 @@ package"_Build_package.html doc page for more info.
 Physical Review B, 88(18), 184422. (2013).
 :link(Tranchida5)
 [(Tranchida)] Tranchida, Plimpton, Thibaudeau and Thompson,
-Journal of Computational Physics, (2018).
+Journal of Computational Physics, 372, 406-425, (2018).

--- a/doc/src/pair_spin_exchange.txt
+++ b/doc/src/pair_spin_exchange.txt
@@ -95,4 +95,4 @@ package"_Build_package.html doc page for more info.
 
 :link(Tranchida3)
 [(Tranchida)] Tranchida, Plimpton, Thibaudeau and Thompson,
-Journal of Computational Physics, (2018).
+Journal of Computational Physics, 372, 406-425, (2018).

--- a/doc/src/pair_spin_magelec.txt
+++ b/doc/src/pair_spin_magelec.txt
@@ -70,4 +70,4 @@ package"_Build_package.html doc page for more info.
 
 :link(Tranchida4)
 [(Tranchida)] Tranchida, Plimpton, Thibaudeau, and Thompson,
-Journal of Computational Physics, (2018).
+Journal of Computational Physics, 372, 406-425, (2018).

--- a/doc/src/pair_spin_neel.txt
+++ b/doc/src/pair_spin_neel.txt
@@ -80,4 +80,4 @@ package"_Build_package.html doc page for more info.
 
 :link(Tranchida6)
 [(Tranchida)] Tranchida, Plimpton, Thibaudeau and Thompson,
-Journal of Computational Physics, (2018).
+Journal of Computational Physics, 372, 406-425, (2018).

--- a/examples/SPIN/setforce_spin/in.spinmin.setforce
+++ b/examples/SPIN/setforce_spin/in.spinmin.setforce
@@ -1,0 +1,59 @@
+
+units 		metal
+dimension 	3
+boundary 	f f f
+atom_style 	spin
+
+# necessary for the serial algorithm (sametag)
+atom_modify 	map array 
+
+lattice 	sc 3.0
+region 		box block 0.0 10.0 0.0 10.0 0.0 1.0
+create_box 	2 box
+region		reg1 block 0.0 10.0 	0.0 5.0 	0.0 1.0
+region		reg2 block 0.0 10.0 	6.0 10.0 	0.0 1.0
+create_atoms 	1 region reg1 
+create_atoms 	2 region reg2
+
+# setting mass, mag. moments, and interactions for bcc iron
+
+mass		1 55.845
+mass		2 55.845
+set 		region reg1 spin 2.2 0.0 0.0 1.0
+set 		region reg2 spin/random 31 2.2
+
+group 		fixed_spin region reg1
+
+pair_style 	hybrid/overlay spin/exchange 3.1 spin/dmi 3.1
+pair_coeff 	* * spin/exchange exchange 3.1 -0.01593 0.06626915552 1.211
+pair_coeff	* * spin/dmi dmi 3.1 0.12e-03 0.0 0.0 1.0
+
+neighbor 	0.1 bin
+neigh_modify 	every 10 check yes delay 20
+
+fix 		1 all precession/spin zeeman 0.0 0.0 0.0 1.0 anisotropy 5e-05 0.0 0.0 1.0 
+fix_modify	1 energy yes
+fix 		2 fixed_spin setforce/spin 0.0 0.0 0.0
+fix 		3 all langevin/spin 0.0 0.1 21
+fix		4 all nve/spin lattice no 
+
+timestep	0.0001
+
+compute 	out_mag    all spin
+variable 	magx      equal c_out_mag[1]
+variable 	magy      equal c_out_mag[2]
+variable 	magz      equal c_out_mag[3]
+variable 	magnorm   equal c_out_mag[4]
+variable 	emag      equal c_out_mag[5]
+variable 	tmag      equal c_out_mag[6]
+
+thermo          1000
+thermo_style    custom step time v_magx v_magz v_magnorm v_tmag etotal
+thermo_modify   format float %20.15g
+
+compute 	outsp all property/atom spx spy spz sp fmx fmy fmz
+dump 		1 all custom 1000 dump.lammpstrj type x y z c_outsp[1] c_outsp[2] c_outsp[3] c_outsp[5] c_outsp[6] c_outsp[7]
+
+min_style	spin
+min_modify 	alpha_damp 1.0 discrete_factor 20.0
+minimize        1.0e-16 1.0e-16 50000 1000

--- a/src/SPIN/fix_nve_spin.cpp
+++ b/src/SPIN/fix_nve_spin.cpp
@@ -475,8 +475,6 @@ void FixNVESpin::ComputeInteractionsSpin(int i)
     locksetforcespin->single_setforce_spin(i,fmi);
   }
 
-  //printf("test after setforce: %g %g %g \n",fmi[0],fmi[1],fmi[2]);
-
   // replace the magnetic force fm[i] by its new value fmi
 
   fm[i][0] = fmi[0];

--- a/src/SPIN/fix_nve_spin.cpp
+++ b/src/SPIN/fix_nve_spin.cpp
@@ -88,7 +88,6 @@ FixNVESpin::FixNVESpin(LAMMPS *lmp, int narg, char **arg) :
   npairs = 0;
   npairspin = 0;
 
-
   // checking if map array or hash is defined
 
   if (atom->map_style == 0)
@@ -250,13 +249,10 @@ void FixNVESpin::init()
   // init. size of stacking lists (sectoring)
 
   nlocal_max = atom->nlocal;
-  stack_head = memory->grow(stack_head,nsectors,"NVE/spin:stack_head");
-  stack_foot = memory->grow(stack_foot,nsectors,"NVE/spin:stack_foot");
-  backward_stacks = memory->grow(backward_stacks,nlocal_max,"NVE/spin:backward_stacks");
-  forward_stacks = memory->grow(forward_stacks,nlocal_max,"NVE/spin:forward_stacks");
-  if (nlocal_max == 0)
-    error->all(FLERR,"Incorrect value of nlocal_max");
-
+  memory->grow(stack_head,nsectors,"NVE/spin:stack_head");
+  memory->grow(stack_foot,nsectors,"NVE/spin:stack_foot");
+  memory->grow(backward_stacks,nlocal_max,"NVE/spin:backward_stacks");
+  memory->grow(forward_stacks,nlocal_max,"NVE/spin:forward_stacks");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -389,8 +385,8 @@ void FixNVESpin::pre_neighbor()
 
   if (nlocal_max < nlocal) {                    // grow linked lists if necessary
     nlocal_max = nlocal;
-    backward_stacks = memory->grow(backward_stacks,nlocal_max,"NVE/spin:backward_stacks");
-    forward_stacks = memory->grow(forward_stacks,nlocal_max,"NVE/spin:forward_stacks");
+    memory->grow(backward_stacks,nlocal_max,"NVE/spin:backward_stacks");
+    memory->grow(forward_stacks,nlocal_max,"NVE/spin:forward_stacks");
   }
 
   for (int j = 0; j < nsectors; j++) {

--- a/src/SPIN/fix_nve_spin.h
+++ b/src/SPIN/fix_nve_spin.h
@@ -58,14 +58,16 @@ friend class PairSpin;
   int nlocal_max;			// max value of nlocal (for lists size)
 
   int pair_spin_flag;			// magnetic pair flags
-  int precession_spin_flag;			// magnetic precession flags
+  int precession_spin_flag;		// magnetic precession flags
   int maglangevin_flag;			// magnetic langevin flags
   int tdamp_flag, temp_flag;
+  int setforce_spin_flag;
 
   // pointers to magnetic fixes
 
   class FixPrecessionSpin *lockprecessionspin;
   class FixLangevinSpin *locklangevinspin;
+  class FixSetForceSpin *locksetforcespin;
 
   // pointers to magnetic pair styles
 

--- a/src/SPIN/fix_setforce_spin.cpp
+++ b/src/SPIN/fix_setforce_spin.cpp
@@ -1,0 +1,358 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <cstring>
+#include <cstdlib>
+//#include "fix_setforce.h"
+#include "fix_setforce_spin.h"
+#include "atom.h"
+#include "update.h"
+#include "modify.h"
+#include "domain.h"
+#include "region.h"
+#include "respa.h"
+#include "input.h"
+#include "variable.h"
+#include "memory.h"
+#include "error.h"
+#include "force.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+enum{NONE,CONSTANT,EQUAL,ATOM};
+
+/* ---------------------------------------------------------------------- */
+
+FixSetForceSpin::FixSetForceSpin(LAMMPS *lmp, int narg, char **arg) :
+  //FixSetForce(lmp, narg, arg),
+  Fix(lmp, narg, arg),
+  xstr(NULL), ystr(NULL), zstr(NULL), idregion(NULL), sforce(NULL)
+{
+  if (narg < 6) error->all(FLERR,"Illegal fix setforce spin command");
+
+  dynamic_group_allow = 1;
+  vector_flag = 1;
+  size_vector = 3;
+  global_freq = 1;
+  extvector = 1;
+  respa_level_support = 1;
+  ilevel_respa = nlevels_respa = 0;
+  xstr = ystr = zstr = NULL;
+
+  if (strstr(arg[3],"v_") == arg[3]) {
+    int n = strlen(&arg[3][2]) + 1;
+    xstr = new char[n];
+    strcpy(xstr,&arg[3][2]);
+  } else if (strcmp(arg[3],"NULL") == 0) {
+    xstyle = NONE;
+  } else {
+    xvalue = force->numeric(FLERR,arg[3]);
+    xstyle = CONSTANT;
+  }
+  if (strstr(arg[4],"v_") == arg[4]) {
+    int n = strlen(&arg[4][2]) + 1;
+    ystr = new char[n];
+    strcpy(ystr,&arg[4][2]);
+  } else if (strcmp(arg[4],"NULL") == 0) {
+    ystyle = NONE;
+  } else {
+    yvalue = force->numeric(FLERR,arg[4]);
+    ystyle = CONSTANT;
+  }
+  if (strstr(arg[5],"v_") == arg[5]) {
+    int n = strlen(&arg[5][2]) + 1;
+    zstr = new char[n];
+    strcpy(zstr,&arg[5][2]);
+  } else if (strcmp(arg[5],"NULL") == 0) {
+    zstyle = NONE;
+  } else {
+    zvalue = force->numeric(FLERR,arg[5]);
+    zstyle = CONSTANT;
+  }
+
+  // optional args
+
+  iregion = -1;
+  idregion = NULL;
+
+  int iarg = 6;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"region") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix setforce command");
+      iregion = domain->find_region(arg[iarg+1]);
+      if (iregion == -1)
+        error->all(FLERR,"Region ID for fix setforce does not exist");
+      int n = strlen(arg[iarg+1]) + 1;
+      idregion = new char[n];
+      strcpy(idregion,arg[iarg+1]);
+      iarg += 2;
+    } else error->all(FLERR,"Illegal fix setforce command");
+  }
+
+  force_flag = 0;
+  foriginal[0] = foriginal[1] = foriginal[2] = 0.0;
+
+  maxatom = 1;
+  memory->create(sforce,maxatom,3,"setforce:sforce");
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixSetForceSpin::~FixSetForceSpin()
+{
+  if (copymode) return;
+
+  delete [] xstr;
+  delete [] ystr;
+  delete [] zstr;
+  delete [] idregion;
+  memory->destroy(sforce);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixSetForceSpin::setmask()
+{
+  int mask = 0;
+  mask |= POST_FORCE;
+  mask |= POST_FORCE_RESPA;
+  mask |= MIN_POST_FORCE;
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixSetForceSpin::init()
+{
+  // check variables
+
+  if (xstr) {
+    xvar = input->variable->find(xstr);
+    if (xvar < 0)
+      error->all(FLERR,"Variable name for fix setforce does not exist");
+    if (input->variable->equalstyle(xvar)) xstyle = EQUAL;
+    else if (input->variable->atomstyle(xvar)) xstyle = ATOM;
+    else error->all(FLERR,"Variable for fix setforce is invalid style");
+  }
+  if (ystr) {
+    yvar = input->variable->find(ystr);
+    if (yvar < 0)
+      error->all(FLERR,"Variable name for fix setforce does not exist");
+    if (input->variable->equalstyle(yvar)) ystyle = EQUAL;
+    else if (input->variable->atomstyle(yvar)) ystyle = ATOM;
+    else error->all(FLERR,"Variable for fix setforce is invalid style");
+  }
+  if (zstr) {
+    zvar = input->variable->find(zstr);
+    if (zvar < 0)
+      error->all(FLERR,"Variable name for fix setforce does not exist");
+    if (input->variable->equalstyle(zvar)) zstyle = EQUAL;
+    else if (input->variable->atomstyle(zvar)) zstyle = ATOM;
+    else error->all(FLERR,"Variable for fix setforce is invalid style");
+  }
+
+  // set index and check validity of region
+
+  if (iregion >= 0) {
+    iregion = domain->find_region(idregion);
+    if (iregion == -1)
+      error->all(FLERR,"Region ID for fix setforce does not exist");
+  }
+
+  if (xstyle == ATOM || ystyle == ATOM || zstyle == ATOM)
+    varflag = ATOM;
+  else if (xstyle == EQUAL || ystyle == EQUAL || zstyle == EQUAL)
+    varflag = EQUAL;
+  else varflag = CONSTANT;
+
+  if (strstr(update->integrate_style,"respa")) {
+    nlevels_respa = ((Respa *) update->integrate)->nlevels;
+    if (respa_level >= 0) ilevel_respa = MIN(respa_level,nlevels_respa-1);
+    else ilevel_respa = nlevels_respa-1;
+  }
+
+  // cannot use non-zero forces for a minimization since no energy is integrated
+  // use fix addforce instead
+
+  int flag = 0;
+  if (update->whichflag == 2) {
+    if (xstyle == EQUAL || xstyle == ATOM) flag = 1;
+    if (ystyle == EQUAL || ystyle == ATOM) flag = 1;
+    if (zstyle == EQUAL || zstyle == ATOM) flag = 1;
+    if (xstyle == CONSTANT && xvalue != 0.0) flag = 1;
+    if (ystyle == CONSTANT && yvalue != 0.0) flag = 1;
+    if (zstyle == CONSTANT && zvalue != 0.0) flag = 1;
+  }
+  if (flag)
+    error->all(FLERR,"Cannot use non-zero forces in an energy minimization");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixSetForceSpin::setup(int vflag)
+{
+  if (strstr(update->integrate_style,"verlet"))
+    post_force(vflag);
+  else
+    for (int ilevel = 0; ilevel < nlevels_respa; ilevel++) {
+      ((Respa *) update->integrate)->copy_flevel_f(ilevel);
+      post_force_respa(vflag,ilevel,0);
+      ((Respa *) update->integrate)->copy_f_flevel(ilevel);
+    }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixSetForceSpin::min_setup(int vflag)
+{
+  post_force(vflag);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixSetForceSpin::post_force(int /*vflag*/)
+{
+  double **x = atom->x;
+  //double **f = atom->f;
+  double **fm = atom->fm;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+  // update region if necessary
+
+  Region *region = NULL;
+  if (iregion >= 0) {
+    region = domain->regions[iregion];
+    region->prematch();
+  }
+
+  // reallocate sforce array if necessary
+
+  if (varflag == ATOM && atom->nmax > maxatom) {
+    maxatom = atom->nmax;
+    memory->destroy(sforce);
+    memory->create(sforce,maxatom,3,"setforce:sforce");
+  }
+
+  foriginal[0] = foriginal[1] = foriginal[2] = 0.0;
+  force_flag = 0;
+
+  if (varflag == CONSTANT) {
+    for (int i = 0; i < nlocal; i++)
+      if (mask[i] & groupbit) {
+        if (region && !region->match(x[i][0],x[i][1],x[i][2])) continue;
+        foriginal[0] += fm[i][0];
+        foriginal[1] += fm[i][1];
+        foriginal[2] += fm[i][2];
+        if (xstyle) fm[i][0] = xvalue;
+        if (ystyle) fm[i][1] = yvalue;
+        if (zstyle) fm[i][2] = zvalue;
+      }
+
+  // variable force, wrap with clear/add
+
+  } else {
+
+    modify->clearstep_compute();
+
+    if (xstyle == EQUAL) xvalue = input->variable->compute_equal(xvar);
+    else if (xstyle == ATOM)
+      input->variable->compute_atom(xvar,igroup,&sforce[0][0],3,0);
+    if (ystyle == EQUAL) yvalue = input->variable->compute_equal(yvar);
+    else if (ystyle == ATOM)
+      input->variable->compute_atom(yvar,igroup,&sforce[0][1],3,0);
+    if (zstyle == EQUAL) zvalue = input->variable->compute_equal(zvar);
+    else if (zstyle == ATOM)
+      input->variable->compute_atom(zvar,igroup,&sforce[0][2],3,0);
+
+    modify->addstep_compute(update->ntimestep + 1);
+
+    for (int i = 0; i < nlocal; i++)
+      if (mask[i] & groupbit) {
+        if (region && !region->match(x[i][0],x[i][1],x[i][2])) continue;
+        foriginal[0] += fm[i][0];
+        foriginal[1] += fm[i][1];
+        foriginal[2] += fm[i][2];
+        if (xstyle == ATOM) fm[i][0] = sforce[i][0];
+        else if (xstyle) fm[i][0] = xvalue;
+        if (ystyle == ATOM) fm[i][1] = sforce[i][1];
+        else if (ystyle) fm[i][1] = yvalue;
+        if (zstyle == ATOM) fm[i][2] = sforce[i][2];
+        else if (zstyle) fm[i][2] = zvalue;
+      }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixSetForceSpin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
+{
+  // set force to desired value on requested level, 0.0 on other levels
+
+  if (ilevel == ilevel_respa) post_force(vflag);
+  else {
+    Region *region = NULL;
+    if (iregion >= 0) {
+      region = domain->regions[iregion];
+      region->prematch();
+    }
+
+    double **x = atom->x;
+    //double **f = atom->f;
+    double **fm = atom->fm;
+    int *mask = atom->mask;
+    int nlocal = atom->nlocal;
+
+    for (int i = 0; i < nlocal; i++)
+      if (mask[i] & groupbit) {
+        if (region && !region->match(x[i][0],x[i][1],x[i][2])) continue;
+        if (xstyle) fm[i][0] = 0.0;
+        if (ystyle) fm[i][1] = 0.0;
+        if (zstyle) fm[i][2] = 0.0;
+      }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixSetForceSpin::min_post_force(int vflag)
+{
+  post_force(vflag);
+}
+
+/* ----------------------------------------------------------------------
+   return components of total force on fix group before force was changed
+------------------------------------------------------------------------- */
+
+double FixSetForceSpin::compute_vector(int n)
+{
+  // only sum across procs one time
+
+  if (force_flag == 0) {
+    MPI_Allreduce(foriginal,foriginal_all,3,MPI_DOUBLE,MPI_SUM,world);
+    force_flag = 1;
+  }
+  return foriginal_all[n];
+}
+
+/* ----------------------------------------------------------------------
+   memory usage of local atom-based array
+------------------------------------------------------------------------- */
+
+double FixSetForceSpin::memory_usage()
+{
+  double bytes = 0.0;
+  if (varflag == ATOM) bytes = maxatom*3 * sizeof(double);
+  return bytes;
+}

--- a/src/SPIN/fix_setforce_spin.cpp
+++ b/src/SPIN/fix_setforce_spin.cpp
@@ -11,9 +11,18 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ------------------------------------------------------------------------
+   Contributing authors: Julien Tranchida (SNL)
+                         Aidan Thompson (SNL)
+
+   Please cite the related publication:
+   Tranchida, J., Plimpton, S. J., Thibaudeau, P., & Thompson, A. P. (2018).
+   Massively parallel symplectic algorithm for coupled magnetic spin dynamics
+   and molecular dynamics. Journal of Computational Physics.
+------------------------------------------------------------------------- */
+
 #include <cstring>
 #include <cstdlib>
-//#include "fix_setforce.h"
 #include "fix_setforce_spin.h"
 #include "atom.h"
 #include "update.h"
@@ -35,196 +44,13 @@ enum{NONE,CONSTANT,EQUAL,ATOM};
 /* ---------------------------------------------------------------------- */
 
 FixSetForceSpin::FixSetForceSpin(LAMMPS *lmp, int narg, char **arg) :
-  //FixSetForce(lmp, narg, arg),
-  Fix(lmp, narg, arg),
-  xstr(NULL), ystr(NULL), zstr(NULL), idregion(NULL), sforce(NULL)
-{
-  if (narg < 6) error->all(FLERR,"Illegal fix setforce spin command");
-
-  dynamic_group_allow = 1;
-  vector_flag = 1;
-  size_vector = 3;
-  global_freq = 1;
-  extvector = 1;
-  respa_level_support = 1;
-  ilevel_respa = nlevels_respa = 0;
-  xstr = ystr = zstr = NULL;
-
-  if (strstr(arg[3],"v_") == arg[3]) {
-    int n = strlen(&arg[3][2]) + 1;
-    xstr = new char[n];
-    strcpy(xstr,&arg[3][2]);
-  } else if (strcmp(arg[3],"NULL") == 0) {
-    xstyle = NONE;
-  } else {
-    xvalue = force->numeric(FLERR,arg[3]);
-    xstyle = CONSTANT;
-  }
-  if (strstr(arg[4],"v_") == arg[4]) {
-    int n = strlen(&arg[4][2]) + 1;
-    ystr = new char[n];
-    strcpy(ystr,&arg[4][2]);
-  } else if (strcmp(arg[4],"NULL") == 0) {
-    ystyle = NONE;
-  } else {
-    yvalue = force->numeric(FLERR,arg[4]);
-    ystyle = CONSTANT;
-  }
-  if (strstr(arg[5],"v_") == arg[5]) {
-    int n = strlen(&arg[5][2]) + 1;
-    zstr = new char[n];
-    strcpy(zstr,&arg[5][2]);
-  } else if (strcmp(arg[5],"NULL") == 0) {
-    zstyle = NONE;
-  } else {
-    zvalue = force->numeric(FLERR,arg[5]);
-    zstyle = CONSTANT;
-  }
-
-  // optional args
-
-  iregion = -1;
-  idregion = NULL;
-
-  int iarg = 6;
-  while (iarg < narg) {
-    if (strcmp(arg[iarg],"region") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix setforce command");
-      iregion = domain->find_region(arg[iarg+1]);
-      if (iregion == -1)
-        error->all(FLERR,"Region ID for fix setforce does not exist");
-      int n = strlen(arg[iarg+1]) + 1;
-      idregion = new char[n];
-      strcpy(idregion,arg[iarg+1]);
-      iarg += 2;
-    } else error->all(FLERR,"Illegal fix setforce command");
-  }
-
-  force_flag = 0;
-  foriginal[0] = foriginal[1] = foriginal[2] = 0.0;
-
-  maxatom = 1;
-  memory->create(sforce,maxatom,3,"setforce:sforce");
-}
-
-/* ---------------------------------------------------------------------- */
-
-FixSetForceSpin::~FixSetForceSpin()
-{
-  if (copymode) return;
-
-  delete [] xstr;
-  delete [] ystr;
-  delete [] zstr;
-  delete [] idregion;
-  memory->destroy(sforce);
-}
-
-/* ---------------------------------------------------------------------- */
-
-int FixSetForceSpin::setmask()
-{
-  int mask = 0;
-  mask |= POST_FORCE;
-  mask |= POST_FORCE_RESPA;
-  mask |= MIN_POST_FORCE;
-  return mask;
-}
-
-/* ---------------------------------------------------------------------- */
-
-void FixSetForceSpin::init()
-{
-  // check variables
-
-  if (xstr) {
-    xvar = input->variable->find(xstr);
-    if (xvar < 0)
-      error->all(FLERR,"Variable name for fix setforce does not exist");
-    if (input->variable->equalstyle(xvar)) xstyle = EQUAL;
-    else if (input->variable->atomstyle(xvar)) xstyle = ATOM;
-    else error->all(FLERR,"Variable for fix setforce is invalid style");
-  }
-  if (ystr) {
-    yvar = input->variable->find(ystr);
-    if (yvar < 0)
-      error->all(FLERR,"Variable name for fix setforce does not exist");
-    if (input->variable->equalstyle(yvar)) ystyle = EQUAL;
-    else if (input->variable->atomstyle(yvar)) ystyle = ATOM;
-    else error->all(FLERR,"Variable for fix setforce is invalid style");
-  }
-  if (zstr) {
-    zvar = input->variable->find(zstr);
-    if (zvar < 0)
-      error->all(FLERR,"Variable name for fix setforce does not exist");
-    if (input->variable->equalstyle(zvar)) zstyle = EQUAL;
-    else if (input->variable->atomstyle(zvar)) zstyle = ATOM;
-    else error->all(FLERR,"Variable for fix setforce is invalid style");
-  }
-
-  // set index and check validity of region
-
-  if (iregion >= 0) {
-    iregion = domain->find_region(idregion);
-    if (iregion == -1)
-      error->all(FLERR,"Region ID for fix setforce does not exist");
-  }
-
-  if (xstyle == ATOM || ystyle == ATOM || zstyle == ATOM)
-    varflag = ATOM;
-  else if (xstyle == EQUAL || ystyle == EQUAL || zstyle == EQUAL)
-    varflag = EQUAL;
-  else varflag = CONSTANT;
-
-  if (strstr(update->integrate_style,"respa")) {
-    nlevels_respa = ((Respa *) update->integrate)->nlevels;
-    if (respa_level >= 0) ilevel_respa = MIN(respa_level,nlevels_respa-1);
-    else ilevel_respa = nlevels_respa-1;
-  }
-
-  // cannot use non-zero forces for a minimization since no energy is integrated
-  // use fix addforce instead
-
-  int flag = 0;
-  if (update->whichflag == 2) {
-    if (xstyle == EQUAL || xstyle == ATOM) flag = 1;
-    if (ystyle == EQUAL || ystyle == ATOM) flag = 1;
-    if (zstyle == EQUAL || zstyle == ATOM) flag = 1;
-    if (xstyle == CONSTANT && xvalue != 0.0) flag = 1;
-    if (ystyle == CONSTANT && yvalue != 0.0) flag = 1;
-    if (zstyle == CONSTANT && zvalue != 0.0) flag = 1;
-  }
-  if (flag)
-    error->all(FLERR,"Cannot use non-zero forces in an energy minimization");
-}
-
-/* ---------------------------------------------------------------------- */
-
-void FixSetForceSpin::setup(int vflag)
-{
-  if (strstr(update->integrate_style,"verlet"))
-    post_force(vflag);
-  else
-    for (int ilevel = 0; ilevel < nlevels_respa; ilevel++) {
-      ((Respa *) update->integrate)->copy_flevel_f(ilevel);
-      post_force_respa(vflag,ilevel,0);
-      ((Respa *) update->integrate)->copy_f_flevel(ilevel);
-    }
-}
-
-/* ---------------------------------------------------------------------- */
-
-void FixSetForceSpin::min_setup(int vflag)
-{
-  post_force(vflag);
-}
+  FixSetForce(lmp, narg, arg) {}
 
 /* ---------------------------------------------------------------------- */
 
 void FixSetForceSpin::post_force(int /*vflag*/)
 {
   double **x = atom->x;
-  //double **f = atom->f;
   double **fm = atom->fm;
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
@@ -296,6 +122,85 @@ void FixSetForceSpin::post_force(int /*vflag*/)
 
 /* ---------------------------------------------------------------------- */
 
+void FixSetForceSpin::single_setforce_spin(int i, double fmi[3])
+{
+  double **x = atom->x;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+  //printf("test inside before setforce: %g %g %g \n",fmi[0],fmi[1],fmi[2]);
+
+  // update region if necessary
+
+  Region *region = NULL;
+  if (iregion >= 0) {
+    region = domain->regions[iregion];
+    region->prematch();
+  }
+
+  // reallocate sforce array if necessary
+
+  if (varflag == ATOM && atom->nmax > maxatom) {
+    maxatom = atom->nmax;
+    memory->destroy(sforce);
+    memory->create(sforce,maxatom,3,"setforce:sforce");
+  }
+
+  foriginal[0] = foriginal[1] = foriginal[2] = 0.0;
+  force_flag = 0;
+  
+  if (varflag == CONSTANT) {
+    if (mask[i] & groupbit) {
+      //if (region && !region->match(x[i][0],x[i][1],x[i][2])) continue;
+      //if (region && region->match(x[i][0],x[i][1],x[i][2])){
+      foriginal[0] += fmi[0];
+      foriginal[1] += fmi[1];
+      foriginal[2] += fmi[2];
+      if (xstyle) fmi[0] = xvalue;
+      if (ystyle) fmi[1] = yvalue;
+      if (zstyle) fmi[2] = zvalue;
+      //printf("test inside inter setforce: %g %g %g \n",fmi[0],fmi[1],fmi[2]);
+      //}
+    }
+
+  // variable force, wrap with clear/add
+
+  } else {
+
+    modify->clearstep_compute();
+
+    if (xstyle == EQUAL) xvalue = input->variable->compute_equal(xvar);
+    else if (xstyle == ATOM)
+      input->variable->compute_atom(xvar,igroup,&sforce[0][0],3,0);
+    if (ystyle == EQUAL) yvalue = input->variable->compute_equal(yvar);
+    else if (ystyle == ATOM)
+      input->variable->compute_atom(yvar,igroup,&sforce[0][1],3,0);
+    if (zstyle == EQUAL) zvalue = input->variable->compute_equal(zvar);
+    else if (zstyle == ATOM)
+      input->variable->compute_atom(zvar,igroup,&sforce[0][2],3,0);
+
+    modify->addstep_compute(update->ntimestep + 1);
+
+    if (mask[i] & groupbit) {
+      //if (region && !region->match(x[i][0],x[i][1],x[i][2])) continue;
+      if (region && region->match(x[i][0],x[i][1],x[i][2])) {
+        foriginal[0] += fmi[0];
+        foriginal[1] += fmi[1];
+        foriginal[2] += fmi[2];
+        if (xstyle == ATOM) fmi[0] = sforce[i][0];
+        else if (xstyle) fmi[0] = xvalue;
+        if (ystyle == ATOM) fmi[1] = sforce[i][1];
+        else if (ystyle) fmi[1] = yvalue;
+        if (zstyle == ATOM) fmi[2] = sforce[i][2];
+        else if (zstyle) fmi[2] = zvalue;
+      }
+    }
+  }
+  //printf("test inside after setforce: %g %g %g \n",fmi[0],fmi[1],fmi[2]);
+}
+
+/* ---------------------------------------------------------------------- */
+
 void FixSetForceSpin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   // set force to desired value on requested level, 0.0 on other levels
@@ -309,7 +214,6 @@ void FixSetForceSpin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
     }
 
     double **x = atom->x;
-    //double **f = atom->f;
     double **fm = atom->fm;
     int *mask = atom->mask;
     int nlocal = atom->nlocal;
@@ -322,37 +226,4 @@ void FixSetForceSpin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
         if (zstyle) fm[i][2] = 0.0;
       }
   }
-}
-
-/* ---------------------------------------------------------------------- */
-
-void FixSetForceSpin::min_post_force(int vflag)
-{
-  post_force(vflag);
-}
-
-/* ----------------------------------------------------------------------
-   return components of total force on fix group before force was changed
-------------------------------------------------------------------------- */
-
-double FixSetForceSpin::compute_vector(int n)
-{
-  // only sum across procs one time
-
-  if (force_flag == 0) {
-    MPI_Allreduce(foriginal,foriginal_all,3,MPI_DOUBLE,MPI_SUM,world);
-    force_flag = 1;
-  }
-  return foriginal_all[n];
-}
-
-/* ----------------------------------------------------------------------
-   memory usage of local atom-based array
-------------------------------------------------------------------------- */
-
-double FixSetForceSpin::memory_usage()
-{
-  double bytes = 0.0;
-  if (varflag == ATOM) bytes = maxatom*3 * sizeof(double);
-  return bytes;
 }

--- a/src/SPIN/fix_setforce_spin.cpp
+++ b/src/SPIN/fix_setforce_spin.cpp
@@ -128,8 +128,6 @@ void FixSetForceSpin::single_setforce_spin(int i, double fmi[3])
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
 
-  //printf("test inside before setforce: %g %g %g \n",fmi[0],fmi[1],fmi[2]);
-
   // update region if necessary
 
   Region *region = NULL;
@@ -148,19 +146,18 @@ void FixSetForceSpin::single_setforce_spin(int i, double fmi[3])
 
   foriginal[0] = foriginal[1] = foriginal[2] = 0.0;
   force_flag = 0;
-  
+ 
+  // constant force
+
   if (varflag == CONSTANT) {
     if (mask[i] & groupbit) {
-      //if (region && !region->match(x[i][0],x[i][1],x[i][2])) continue;
-      //if (region && region->match(x[i][0],x[i][1],x[i][2])){
+      if (region && !region->match(x[i][0],x[i][1],x[i][2])) return;
       foriginal[0] += fmi[0];
       foriginal[1] += fmi[1];
       foriginal[2] += fmi[2];
       if (xstyle) fmi[0] = xvalue;
       if (ystyle) fmi[1] = yvalue;
       if (zstyle) fmi[2] = zvalue;
-      //printf("test inside inter setforce: %g %g %g \n",fmi[0],fmi[1],fmi[2]);
-      //}
     }
 
   // variable force, wrap with clear/add
@@ -182,21 +179,18 @@ void FixSetForceSpin::single_setforce_spin(int i, double fmi[3])
     modify->addstep_compute(update->ntimestep + 1);
 
     if (mask[i] & groupbit) {
-      //if (region && !region->match(x[i][0],x[i][1],x[i][2])) continue;
-      if (region && region->match(x[i][0],x[i][1],x[i][2])) {
-        foriginal[0] += fmi[0];
-        foriginal[1] += fmi[1];
-        foriginal[2] += fmi[2];
-        if (xstyle == ATOM) fmi[0] = sforce[i][0];
-        else if (xstyle) fmi[0] = xvalue;
-        if (ystyle == ATOM) fmi[1] = sforce[i][1];
-        else if (ystyle) fmi[1] = yvalue;
-        if (zstyle == ATOM) fmi[2] = sforce[i][2];
-        else if (zstyle) fmi[2] = zvalue;
-      }
+      if (region && !region->match(x[i][0],x[i][1],x[i][2])) return;
+      foriginal[0] += fmi[0];
+      foriginal[1] += fmi[1];
+      foriginal[2] += fmi[2];
+      if (xstyle == ATOM) fmi[0] = sforce[i][0];
+      else if (xstyle) fmi[0] = xvalue;
+      if (ystyle == ATOM) fmi[1] = sforce[i][1];
+      else if (ystyle) fmi[1] = yvalue;
+      if (zstyle == ATOM) fmi[2] = sforce[i][2];
+      else if (zstyle) fmi[2] = zvalue;
     }
   }
-  //printf("test inside after setforce: %g %g %g \n",fmi[0],fmi[1],fmi[2]);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/SPIN/fix_setforce_spin.h
+++ b/src/SPIN/fix_setforce_spin.h
@@ -1,0 +1,90 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(setforce/spin,FixSetForceSpin)
+
+#else
+
+#ifndef LMP_FIX_SET_FORCE_SPIN_H
+#define LMP_FIX_SET_FORCE_SPIN_H
+
+#include "fix.h"
+//#include "fix_setforce.h"
+
+// only post_force and post_force_respa != from FixSetForce
+
+namespace LAMMPS_NS {
+
+//class FixSetForceSpin : public FixSetForce {
+class FixSetForceSpin : public Fix {
+ public:
+  FixSetForceSpin(class LAMMPS *, int, char **);
+  virtual ~FixSetForceSpin();
+  int setmask();
+  virtual void init();
+  void setup(int);
+  void min_setup(int);
+  virtual void post_force(int);
+  void post_force_respa(int, int, int);
+  void min_post_force(int);
+  double compute_vector(int);
+
+  double memory_usage();
+
+ protected:
+  double xvalue,yvalue,zvalue;
+  int varflag,iregion;
+  char *xstr,*ystr,*zstr;
+  char *idregion;
+  int xvar,yvar,zvar,xstyle,ystyle,zstyle;
+  double foriginal[3],foriginal_all[3];
+  int force_flag;
+  int nlevels_respa,ilevel_respa;
+
+  int maxatom;
+  double **sforce;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Region ID for fix setforce does not exist
+
+Self-explanatory.
+
+E: Variable name for fix setforce does not exist
+
+Self-explanatory.
+
+E: Variable for fix setforce is invalid style
+
+Only equal-style variables can be used.
+
+E: Cannot use non-zero forces in an energy minimization
+
+Fix setforce cannot be used in this manner.  Use fix addforce
+instead.
+
+*/

--- a/src/SPIN/fix_setforce_spin.h
+++ b/src/SPIN/fix_setforce_spin.h
@@ -20,41 +20,16 @@ FixStyle(setforce/spin,FixSetForceSpin)
 #ifndef LMP_FIX_SET_FORCE_SPIN_H
 #define LMP_FIX_SET_FORCE_SPIN_H
 
-#include "fix.h"
-//#include "fix_setforce.h"
-
-// only post_force and post_force_respa != from FixSetForce
+#include "fix_setforce.h"
 
 namespace LAMMPS_NS {
 
-//class FixSetForceSpin : public FixSetForce {
-class FixSetForceSpin : public Fix {
+class FixSetForceSpin : public FixSetForce {
  public:
   FixSetForceSpin(class LAMMPS *, int, char **);
-  virtual ~FixSetForceSpin();
-  int setmask();
-  virtual void init();
-  void setup(int);
-  void min_setup(int);
   virtual void post_force(int);
   void post_force_respa(int, int, int);
-  void min_post_force(int);
-  double compute_vector(int);
-
-  double memory_usage();
-
- protected:
-  double xvalue,yvalue,zvalue;
-  int varflag,iregion;
-  char *xstr,*ystr,*zstr;
-  char *idregion;
-  int xvar,yvar,zvar,xstyle,ystyle,zstyle;
-  double foriginal[3],foriginal_all[3];
-  int force_flag;
-  int nlevels_respa,ilevel_respa;
-
-  int maxatom;
-  double **sforce;
+  void single_setforce_spin(int, double *); 
 };
 
 }


### PR DESCRIPTION
**Summary**

- adding a fix setforce/spin to the SPIN package
- correcting a small bug in fix nve/spin
- updated the Howto_spin file in the documentation

**Related Issues**

- improvement of the spin package
- correction of a small bug in fix/nve/spin related to the way the grow() functions were used.

**Author(s)**

Julien Tranchida, Sandia National Labs, jtranch@sandia.gov

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

- the fix setforce/spin was created as a child class of setforce. It just needed the redefinition of two methods, and the creation of one method (called from fix/nve/spin).

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] One or more example input decks are included

**Further Information, Files, and Links**
