### PR TITLE
flushing buffer to see more messages for error->one calls

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -212,6 +212,8 @@ void Error::one(const char *file, int line, const char *str)
   snprintf(msg, 100, "ERROR on proc %d: %s (%s:%d)\n", me, str, truncpath(file), line);
   throw LAMMPSAbortException(msg, world);
 #else
+  if (screen) fflush(screen);
+  if (logfile) fflush(logfile);
   MPI_Abort(world,1);
 #endif
 }


### PR DESCRIPTION
**Summary**

This addresses some of (not bulletproof) the possibility that MPI_Abort will be called before the system buffer outputs an error message for error->one calls.

**Author(s)**

Adrian Diaz (University of Florida)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Clear of Conflict

**Implementation Notes**

A set of tests with messages that didn't print before printed messages once the flush was introduced.




