### PR TITLE
Small bugfix in output.cpp enabling fixed interval thermo after variable

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -675,8 +675,10 @@ void Output::set_thermo(int narg, char **arg)
 {
   if (narg != 1) error->all(FLERR,"Illegal thermo command");
 
+  delete [] var_thermo;
+  var_thermo = NULL;
+
   if (strstr(arg[0],"v_") == arg[0]) {
-    delete [] var_thermo;
     int n = strlen(&arg[0][2]) + 1;
     var_thermo = new char[n];
     strcpy(var_thermo,&arg[0][2]);


### PR DESCRIPTION
**Summary**

A small fix to the "thermo" command (output.cpp) that enables redefining fixed-interval thermo output after variable-defined output was previously used.

**Author(s)**

Eugen Rožić, UCL, Šarić group

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Shouldn't have any impact (except if someone relied on this bug in some weird way - highly unlikely).

**Implementation Notes**

Before, once a variable was used for the "thermo" command one was unable to switch back to fixed-interval thermo output because the "var_thermo" variable was not reset and it is used as a flag in the code to check what kind of output should be written. Now the "var_thermo" variable is reset whenever "thermo" command is called, regardless of it being called with a variable or a fixed interval.

I built it locally and it built and worked as expected.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


