### PR TITLE
Homogenised label of relative hbond and stk strength to conform with oxDNA literature

### DIFF
--- a/src/USER-CGDNA/pair_oxdna2_coaxstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna2_coaxstk.cpp
@@ -62,9 +62,9 @@ PairOxdna2Coaxstk::~PairOxdna2Coaxstk()
     memory->destroy(cut_cxst_hi);
     memory->destroy(cut_cxst_lc);
     memory->destroy(cut_cxst_hc);
+    memory->destroy(cutsq_cxst_hc);
     memory->destroy(b_cxst_lo);
     memory->destroy(b_cxst_hi);
-    memory->destroy(cutsq_cxst_hc);
 
     memory->destroy(a_cxst1);
     memory->destroy(theta_cxst1_0);

--- a/src/USER-CGDNA/pair_oxdna2_dh.cpp
+++ b/src/USER-CGDNA/pair_oxdna2_dh.cpp
@@ -225,8 +225,8 @@ void PairOxdna2Dh::compute(int eflag, int vflag)
 
         // increment energy and virial
 
-          if (evflag) ev_tally(a,b,nlocal,newton_pair,
-                  evdwl,0.0,fpair,delr[0],delr[1],delr[2]);
+        if (evflag) ev_tally(a,b,nlocal,newton_pair,
+                evdwl,0.0,fpair,delr[0],delr[1],delr[2]);
       }
 
     }

--- a/src/USER-CGDNA/pair_oxdna_coaxstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_coaxstk.cpp
@@ -62,9 +62,9 @@ PairOxdnaCoaxstk::~PairOxdnaCoaxstk()
     memory->destroy(cut_cxst_hi);
     memory->destroy(cut_cxst_lc);
     memory->destroy(cut_cxst_hc);
+    memory->destroy(cutsq_cxst_hc); 
     memory->destroy(b_cxst_lo);
     memory->destroy(b_cxst_hi);
-    memory->destroy(cutsq_cxst_hc);
 
     memory->destroy(a_cxst1);
     memory->destroy(theta_cxst1_0);

--- a/src/USER-CGDNA/pair_oxdna_hbond.cpp
+++ b/src/USER-CGDNA/pair_oxdna_hbond.cpp
@@ -40,7 +40,7 @@ using namespace MFOxdna;
 
 // sequence-specific base-pairing strength
 // A:0 C:1 G:2 T:3, 5'- (i,j) -3'
-static const double alpha[4][4] =
+static const double alpha_hb[4][4] = 
 {{1.00000,1.00000,1.00000,0.82915},
  {1.00000,1.00000,1.15413,1.00000},
  {1.00000,1.15413,1.00000,1.00000},
@@ -71,10 +71,10 @@ PairOxdnaHbond::~PairOxdnaHbond()
     memory->destroy(cut_hb_hi);
     memory->destroy(cut_hb_lc);
     memory->destroy(cut_hb_hc);
+    memory->destroy(cutsq_hb_hc);
     memory->destroy(b_hb_lo);
     memory->destroy(b_hb_hi);
     memory->destroy(shift_hb);
-    memory->destroy(cutsq_hb_hc);
 
     memory->destroy(a_hb1);
     memory->destroy(theta_hb1_0);
@@ -732,7 +732,7 @@ void PairOxdnaHbond::coeff(int narg, char **arg)
     for (int j = MAX(jlo,i); j <= jhi; j++) {
 
       epsilon_hb[i][j] = epsilon_hb_one;
-      if (seqdepflag) epsilon_hb[i][j] *= alpha[i-1][j-1];
+      if (seqdepflag) epsilon_hb[i][j] *= alpha_hb[i-1][j-1];
       a_hb[i][j] = a_hb_one;
       cut_hb_0[i][j] = cut_hb_0_one;
       cut_hb_c[i][j] = cut_hb_c_one;
@@ -743,7 +743,7 @@ void PairOxdnaHbond::coeff(int narg, char **arg)
       b_hb_lo[i][j] = b_hb_lo_one;
       b_hb_hi[i][j] = b_hb_hi_one;
       shift_hb[i][j] = shift_hb_one;
-      if (seqdepflag) shift_hb[i][j] *= alpha[i-1][j-1];
+      if (seqdepflag) shift_hb[i][j] *= alpha_hb[i-1][j-1];
 
       a_hb1[i][j] = a_hb1_one;
       theta_hb1_0[i][j] = theta_hb1_0_one;
@@ -831,7 +831,7 @@ double PairOxdnaHbond::init_one(int i, int j)
   }
 
   if (seqdepflag) {
-    epsilon_hb[j][i] = epsilon_hb[i][j] / alpha[i-1][j-1] * alpha[j-1][i-1];
+    epsilon_hb[j][i] = epsilon_hb[i][j] / alpha_hb[i-1][j-1] * alpha_hb[j-1][i-1];
   }
   else {
     epsilon_hb[j][i] = epsilon_hb[i][j];
@@ -846,7 +846,7 @@ double PairOxdnaHbond::init_one(int i, int j)
   cut_hb_lc[j][i] = cut_hb_lc[i][j];
   cut_hb_hc[j][i] = cut_hb_hc[i][j];
   if (seqdepflag) {
-    shift_hb[j][i] = shift_hb[i][j] / alpha[i-1][j-1] * alpha[j-1][i-1];
+    shift_hb[j][i] = shift_hb[i][j] / alpha_hb[i-1][j-1] * alpha_hb[j-1][i-1];
   }
   else {
     shift_hb[j][i] = shift_hb[i][j];

--- a/src/USER-CGDNA/pair_oxdna_stk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_stk.cpp
@@ -40,7 +40,7 @@ using namespace MFOxdna;
 
 // sequence-specific stacking strength
 // A:0 C:1 G:2 T:3, 5'- (i,j) -3'
-static const double alpha[4][4] =
+static const double eta_st[4][4] =
 {{1.11960,1.00852,0.96950,0.99632},
  {1.01889,0.97804,1.02681,0.96950},
  {0.98169,1.05913,0.97804,1.00852},
@@ -156,7 +156,7 @@ void PairOxdnaStk::compute(int eflag, int vflag)
   evdwl = 0.0;
   ev_init(eflag,vflag);
 
-  // loop over stacking interaction neighours using bond topology
+  // loop over stacking interaction neighbors using bond topology
 
   for (in = 0; in < nbondlist; in++) {
 
@@ -774,7 +774,7 @@ void PairOxdnaStk::coeff(int narg, char **arg)
     for (int j = MAX(jlo,i); j <= jhi; j++) {
 
       epsilon_st[i][j] = epsilon_st_one;
-      if (seqdepflag) epsilon_st[i][j] *= alpha[i-1][j-1];
+      if (seqdepflag) epsilon_st[i][j] *= eta_st[i-1][j-1];
       a_st[i][j] = a_st_one;
       cut_st_0[i][j] = cut_st_0_one;
       cut_st_c[i][j] = cut_st_c_one;
@@ -785,7 +785,7 @@ void PairOxdnaStk::coeff(int narg, char **arg)
       b_st_lo[i][j] = b_st_lo_one;
       b_st_hi[i][j] = b_st_hi_one;
       shift_st[i][j] = shift_st_one;
-      if (seqdepflag) shift_st[i][j] *= alpha[i-1][j-1];
+      if (seqdepflag) shift_st[i][j] *= eta_st[i-1][j-1];
 
       a_st4[i][j] = a_st4_one;
       theta_st4_0[i][j] = theta_st4_0_one;
@@ -865,7 +865,7 @@ double PairOxdnaStk::init_one(int i, int j)
   }
 
   if (seqdepflag) {
-    epsilon_st[j][i] = epsilon_st[i][j]  / alpha[i-1][j-1] * alpha[j-1][i-1];
+    epsilon_st[j][i] = epsilon_st[i][j]  / eta_st[i-1][j-1] * eta_st[j-1][i-1];
   }
   else {
     epsilon_st[j][i] = epsilon_st[i][j];
@@ -880,7 +880,7 @@ double PairOxdnaStk::init_one(int i, int j)
   cut_st_lc[j][i] = cut_st_lc[i][j];
   cut_st_hc[j][i] = cut_st_hc[i][j];
   if (seqdepflag) {
-    shift_st[j][i] = shift_st[i][j] / alpha[i-1][j-1] * alpha[j-1][i-1];
+    shift_st[j][i] = shift_st[i][j] / eta_st[i-1][j-1] * eta_st[j-1][i-1];
   }
   else {
     shift_st[j][i] = shift_st[i][j];

--- a/src/USER-CGDNA/pair_oxdna_xstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_xstk.cpp
@@ -62,9 +62,9 @@ PairOxdnaXstk::~PairOxdnaXstk()
     memory->destroy(cut_xst_hi);
     memory->destroy(cut_xst_lc);
     memory->destroy(cut_xst_hc);
+    memory->destroy(cutsq_xst_hc);
     memory->destroy(b_xst_lo);
     memory->destroy(b_xst_hi);
-    memory->destroy(cutsq_xst_hc);
 
     memory->destroy(a_xst1);
     memory->destroy(theta_xst1_0);


### PR DESCRIPTION
This is merely a relabelling of some variables according to the oxDNA literature, in particular P. Sulc, F. Romano, T. E. Ouldridge, et al., J. Chem. Phys. 137, 135101 (2012), which will help with further code extension. The output is unchanged.