### PR TITLE
Support using a variable instead of a constant interval for fix print

### DIFF
--- a/doc/src/fix_print.txt
+++ b/doc/src/fix_print.txt
@@ -14,7 +14,7 @@ fix ID group-ID print N string keyword value ... :pre
 
 ID, group-ID are documented in "fix"_fix.html command :ulb,l
 print = style name of this fix command :l
-N = print every N steps :l
+N = print every N steps; N can be a variable (see below) :l
 string = text string to print with optional variable names :l
 zero or more keyword/value pairs may be appended :l
 keyword = {file} or {append} or {screen} or {title} :l
@@ -39,6 +39,21 @@ it should be enclosed in double quotes if it is more than one word.
 If it contains variables it must be enclosed in double quotes to
 insure they are not evaluated when the input script line is read, but
 will instead be evaluated each time the string is printed.
+
+Instead of a numeric value, N can be specified as an "equal-style
+variable"_variable.html, which should be specified as v_name, where
+name is the variable name.  In this case, the variable is evaluated at
+the beginning of a run to determine the [next] timestep at which the
+string will be written out.  On that timestep, the variable will be
+evaluated again to determine the next timestep, etc.
+Thus the variable should return timestep values.  See the stagger()
+and logfreq() and stride() math functions for "equal-style
+variables"_variable.html, as examples of useful functions to use in
+this context. For example, the following commands will print output at
+timesteps 10,20,30,100,200,300,1000,2000,etc:
+
+variable        s equal logfreq(10,3,10)
+fix extra all print v_s "Coords of marker atom = $x $y $z" :pre
 
 The specified group-ID is ignored by this fix.
 

--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -29,11 +29,18 @@ using namespace FixConst;
 
 FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg),
-  fp(NULL), string(NULL), copy(NULL), work(NULL)
+  fp(NULL), string(NULL), copy(NULL), work(NULL), var_print(NULL)
 {
   if (narg < 5) error->all(FLERR,"Illegal fix print command");
-  nevery = force->inumeric(FLERR,arg[3]);
-  if (nevery <= 0) error->all(FLERR,"Illegal fix print command");
+  if (strstr(arg[3],"v_") == arg[3]) {
+    int n = strlen(&arg[3][2]) + 1;
+    var_print = new char[n];
+    strcpy(var_print,&arg[3][2]);
+    nevery = 1;
+  } else {
+    nevery = force->inumeric(FLERR,arg[3]);
+    if (nevery <= 0) error->all(FLERR,"Illegal fix print command");
+  }
 
   MPI_Comm_rank(world,&me);
 
@@ -89,13 +96,6 @@ FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
   }
 
   delete [] title;
-
-  // add nfirst to all computes that store invocation times
-  // since don't know a priori which are invoked via variables by this fix
-  // once in end_of_step() can set timestep for ones actually invoked
-
-  const bigint nfirst = (update->ntimestep/nevery)*nevery + nevery;
-  modify->addstep_compute_all(nfirst);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -103,6 +103,7 @@ FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
 FixPrint::~FixPrint()
 {
   delete [] string;
+  delete [] var_print;
   memory->sfree(copy);
   memory->sfree(work);
 
@@ -120,8 +121,35 @@ int FixPrint::setmask()
 
 /* ---------------------------------------------------------------------- */
 
+void FixPrint::init()
+{
+  if (var_print) {
+    ivar_print = input->variable->find(var_print);
+    if (ivar_print < 0)
+      error->all(FLERR,"Variable name for fix print timestep does not exist");
+    if (!input->variable->equalstyle(ivar_print))
+      error->all(FLERR,"Variable for fix print timestep is invalid style");
+    next_print = static_cast<bigint>
+      (input->variable->compute_equal(ivar_print));
+    if (next_print <= update->ntimestep)
+      error->all(FLERR,"Fix print timestep variable returned a bad timestep");
+  } else {
+     next_print = (update->ntimestep/nevery)*nevery + nevery;
+  }
+
+  // add next_print to all computes that store invocation times
+  // since don't know a priori which are invoked via variables by this fix
+  // once in end_of_step() can set timestep for ones actually invoked
+
+  modify->addstep_compute_all(next_print);
+}
+
+/* ---------------------------------------------------------------------- */
+
 void FixPrint::end_of_step()
 {
+  if (update->ntimestep != next_print) return;
+
   // make a copy of string to work on
   // substitute for $ variables (no printing)
   // append a newline and print final copy
@@ -132,7 +160,15 @@ void FixPrint::end_of_step()
   strcpy(copy,string);
   input->substitute(copy,work,maxcopy,maxwork,0);
 
-  modify->addstep_compute(update->ntimestep + nevery);
+  if (var_print) {
+    next_print = static_cast<bigint>
+      (input->variable->compute_equal(ivar_print));
+    if (next_print <= update->ntimestep)
+      error->all(FLERR,"Fix print timestep variable returned a bad timestep");
+  } else {
+    next_print = (update->ntimestep/nevery)*nevery + nevery;
+  }
+  modify->addstep_compute(next_print);
 
   if (me == 0) {
     if (screenflag && screen) fprintf(screen,"%s\n",copy);

--- a/src/fix_print.h
+++ b/src/fix_print.h
@@ -29,6 +29,7 @@ class FixPrint : public Fix {
  public:
   FixPrint(class LAMMPS *, int, char **);
   ~FixPrint();
+  void init();
   int setmask();
   void end_of_step();
 
@@ -37,6 +38,9 @@ class FixPrint : public Fix {
   FILE *fp;
   char *string,*copy,*work;
   int maxcopy,maxwork;
+  char *var_print;
+  int ivar_print;
+  bigint next_print;
 };
 
 }


### PR DESCRIPTION
**Summary**

With the changes in this PR, `fix print` supports using an equal-style variable (or compatible) to compute the steps when to print its output.

**Related Issues**

closes #1442 
a similar feature was also requested in lammps-users

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

**Implementation Notes**

This follows the logic of the `thermo` command. When using the variable, `nevery` is set to 1 and the test if output should be generated is at the beginning of the `end_of_step()` method, which will be called every step.

Perhaps we should have two additional, optional keywords (`first`, `last`) with yes/no values, that would trigger output on the first or last step of a run, similar to how thermo output works. 

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system


