### PR TITLE
Add missing molecule_flag=1 in atom_vec_bond_kokkos

### DIFF
--- a/src/KOKKOS/atom_vec_bond_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_bond_kokkos.cpp
@@ -43,6 +43,8 @@ AtomVecBondKokkos::AtomVecBondKokkos(LAMMPS *lmp) : AtomVecKokkos(lmp)
   size_data_vel = 4;
   xcol_data = 4;
 
+  atom->molecule_flag = 1;
+
   k_count = DAT::tdual_int_1d("atom::k_count",1);
   atomKK = (AtomKokkos *) atom;
   commKK = (CommKokkos *) comm;


### PR DESCRIPTION
**Summary**

When running the Micelle test case with KOKKOS the following error message is printed.

```
ERROR: Fix rigid molecule requires atom attribute molecule (src/RIGID/fix_rigid.cpp:183)
```
The used atom style is `bond`.  When comparing `atom_vec_bond.cpp` and `atom_vec_bond_kokkos.cpp` it seems like the flag is not being set. This PR fixes this issue.

https://ci2.lammps.org/job/lammps/job/master/job/cmake/job/cmake-testing-kokkos-cuda/8/testReport/tests.test_examples/MicelleTestCase/test_micelle_rigid_kokkos_cuda/

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


