### PR TITLE
Fix element mapping and a few other issues for interlayer potentials 

### DIFF
--- a/doc/src/pair_ilp_graphene_hbn.txt
+++ b/doc/src/pair_ilp_graphene_hbn.txt
@@ -21,7 +21,7 @@ pair_style hybrid/overlay ilp/graphene/hbn 16.0 1
 pair_coeff * * ilp/graphene/hbn  BNCH.ILP B N C :pre
 
 pair_style  hybrid/overlay rebo tersoff ilp/graphene/hbn 16.0 coul/shield 16.0
-pair_coeff  * * rebo                 CH.airebo   NULL NULL C
+pair_coeff  * * rebo                 CH.rebo     NULL NULL C
 pair_coeff  * * tersoff              BNC.tersoff B    N    NULL
 pair_coeff  * * ilp/graphene/hbn     BNCH.ILP    B    N    C
 pair_coeff  1 1 coul/shield 0.70

--- a/doc/src/pair_kolmogorov_crespi_full.txt
+++ b/doc/src/pair_kolmogorov_crespi_full.txt
@@ -22,7 +22,7 @@ pair_coeff * * none
 pair_coeff * * kolmogorov/crespi/full  CH.KC   C C :pre
 
 pair_style hybrid/overlay rebo kolmogorov/crespi/full 16.0 1
-pair_coeff * * rebo                    CH.airebo    C H
+pair_coeff * * rebo                    CH.rebo      C H
 pair_coeff * * kolmogorov/crespi/full  CH_taper.KC  C H :pre
 
 [Description:]

--- a/doc/src/pair_kolmogorov_crespi_z.txt
+++ b/doc/src/pair_kolmogorov_crespi_z.txt
@@ -19,7 +19,7 @@ pair_coeff * * none
 pair_coeff 1 2 kolmogorov/crespi/z  CC.KC   C C :pre
 
 pair_style hybrid/overlay rebo kolmogorov/crespi/z 14.0
-pair_coeff * * rebo                 CH.airebo  C C
+pair_coeff * * rebo                 CH.rebo    C C
 pair_coeff 1 2 kolmogorov/crespi/z  CC.KC      C C :pre
 
 [Description:]

--- a/doc/src/pair_lebedeva_z.txt
+++ b/doc/src/pair_lebedeva_z.txt
@@ -19,8 +19,8 @@ pair_coeff * * none
 pair_coeff 1 2 lebedeva/z  CC.Lebedeva   C C :pre
 
 pair_style hybrid/overlay rebo lebedeva/z 14.0
-pair_coeff * * rebo                 CH.airebo  C C
-pair_coeff 1 2 lebedeva/z  CC.Lebedeva      C C :pre
+pair_coeff * * rebo        CH.rebo       C C
+pair_coeff 1 2 lebedeva/z  CC.Lebedeva   C C :pre
 
 [Description:]
 

--- a/src/USER-MISC/pair_ilp_graphene_hbn.cpp
+++ b/src/USER-MISC/pair_ilp_graphene_hbn.cpp
@@ -801,9 +801,10 @@ void PairILPGrapheneHBN::coeff(int narg, char **arg)
     error->all(FLERR,"Incorrect args for pair coefficients");
   if (!allocated) allocate();
 
-  int ilo,ihi,jlo,jhi;
-  force->bounds(FLERR,arg[0],atom->ntypes,ilo,ihi);
-  force->bounds(FLERR,arg[1],atom->ntypes,jlo,jhi);
+  // insure I,J args are * *
+
+  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
+    error->all(FLERR,"Incorrect args for pair coefficients");
 
   // read args that map atom types to elements in potential file
   // map[i] = which element the Ith atom type is, -1 if NULL

--- a/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
@@ -871,6 +871,8 @@ void PairKolmogorovCrespiFull::coeff(int narg, char **arg)
 double PairKolmogorovCrespiFull::init_one(int i, int j)
 {
   if (setflag[i][j] == 0) error->all(FLERR,"All pair coeffs are not set");
+  if (!offset_flag)
+    error->all(FLERR,"Must use 'pair_modify shift yes' with this pair style");
 
   if (offset_flag && (cut[i][j] > 0.0)) {
     int iparam_ij = elem2param[map[i]][map[j]];

--- a/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_full.cpp
@@ -46,6 +46,8 @@ using namespace LAMMPS_NS;
 
 PairKolmogorovCrespiFull::PairKolmogorovCrespiFull(LAMMPS *lmp) : Pair(lmp)
 {
+  restartinfo = 0;
+
   // initialize element to parameter maps
   nelements = 0;
   elements = NULL;

--- a/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
@@ -292,6 +292,8 @@ void PairKolmogorovCrespiZ::coeff(int narg, char **arg)
 double PairKolmogorovCrespiZ::init_one(int i, int j)
 {
   if (setflag[i][j] == 0) error->all(FLERR,"All pair coeffs are not set");
+  if (!offset_flag)
+    error->all(FLERR,"Must use 'pair_modify shift yes' with this pair style");
 
   if (offset_flag && (cut[i][j] > 0.0)) {
     int iparam_ij = elem2param[map[i]][map[j]];

--- a/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
@@ -226,10 +226,9 @@ void PairKolmogorovCrespiZ::coeff(int narg, char **arg)
     error->all(FLERR,"Incorrect args for pair coefficients");
   if (!allocated) allocate();
 
-  // insure I,J args are * *
-
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+  int ilo,ihi,jlo,jhi;
+  force->bounds(FLERR,arg[0],atom->ntypes,ilo,ihi);
+  force->bounds(FLERR,arg[1],atom->ntypes,jlo,jhi);
 
   // read args that map atom types to elements in potential file
   // map[i] = which element the Ith atom type is, -1 if NULL
@@ -262,23 +261,18 @@ void PairKolmogorovCrespiZ::coeff(int narg, char **arg)
 
   read_file(arg[2]);
 
-  // clear setflag since coeff() called once with I,J = * *
-
-  n = atom->ntypes;
-  for (int i = 1; i <= n; i++)
-    for (int j = i; j <= n; j++)
-      setflag[i][j] = 0;
-
-  // set setflag i,j for type pairs where both are mapped to elements
+  // set setflag only for i,j pairs where both are mapped to elements
 
   int count = 0;
-  for (int i = 1; i <= n; i++)
-    for (int j = i; j <= n; j++)
-      if (map[i] >= 0 && map[j] >= 0) {
-        setflag[i][j] = 1;
+  for (int i = ilo; i <= ihi; i++) {
+    for (int j = MAX(jlo,i); j <= jhi; j++) {
+      if ((map[i] >=0) && (map[j] >= 0)) {
         cut[i][j] = cut_global;
+        setflag[i][j] = 1;
         count++;
       }
+    }
+  }
 
   if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
 }

--- a/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
@@ -260,7 +260,6 @@ void PairKolmogorovCrespiZ::coeff(int narg, char **arg)
     }
   }
 
-
   read_file(arg[2]);
 
   // clear setflag since coeff() called once with I,J = * *

--- a/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
+++ b/src/USER-MISC/pair_kolmogorov_crespi_z.cpp
@@ -226,9 +226,10 @@ void PairKolmogorovCrespiZ::coeff(int narg, char **arg)
     error->all(FLERR,"Incorrect args for pair coefficients");
   if (!allocated) allocate();
 
-  int ilo,ihi,jlo,jhi;
-  force->bounds(FLERR,arg[0],atom->ntypes,ilo,ihi);
-  force->bounds(FLERR,arg[1],atom->ntypes,jlo,jhi);
+  // insure I,J args are * *
+
+  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
+    error->all(FLERR,"Incorrect args for pair coefficients");
 
   // read args that map atom types to elements in potential file
   // map[i] = which element the Ith atom type is, -1 if NULL
@@ -262,16 +263,23 @@ void PairKolmogorovCrespiZ::coeff(int narg, char **arg)
 
   read_file(arg[2]);
 
-  double cut_one = cut_global;
+  // clear setflag since coeff() called once with I,J = * *
+
+  n = atom->ntypes;
+  for (int i = 1; i <= n; i++)
+    for (int j = i; j <= n; j++)
+      setflag[i][j] = 0;
+
+  // set setflag i,j for type pairs where both are mapped to elements
 
   int count = 0;
-  for (int i = ilo; i <= ihi; i++) {
-    for (int j = MAX(jlo,i); j <= jhi; j++) {
-      cut[i][j] = cut_one;
-      setflag[i][j] = 1;
-      count++;
-    }
-  }
+  for (int i = 1; i <= n; i++)
+    for (int j = i; j <= n; j++)
+      if (map[i] >= 0 && map[j] >= 0) {
+        setflag[i][j] = 1;
+        cut[i][j] = cut_global;
+        count++;
+      }
 
   if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
 }

--- a/src/USER-MISC/pair_lebedeva_z.cpp
+++ b/src/USER-MISC/pair_lebedeva_z.cpp
@@ -44,6 +44,7 @@ using namespace LAMMPS_NS;
 PairLebedevaZ::PairLebedevaZ(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
+  restartinfo = 0;
 
   // initialize element to parameter maps
   nelements = 0;
@@ -254,17 +255,18 @@ void PairLebedevaZ::coeff(int narg, char **arg)
     }
   }
 
-
   read_file(arg[2]);
 
-  double cut_one = cut_global;
+  // set setflag only for i,j pairs where both are mapped to elements
 
   int count = 0;
   for (int i = ilo; i <= ihi; i++) {
     for (int j = MAX(jlo,i); j <= jhi; j++) {
-      cut[i][j] = cut_one;
-      setflag[i][j] = 1;
-      count++;
+      if ((map[i] >= 0) && (map[j] >= 0)) {
+        cut[i][j] = cut_global;
+        setflag[i][j] = 1;
+        count++;
+      }
     }
   }
 
@@ -279,6 +281,8 @@ void PairLebedevaZ::coeff(int narg, char **arg)
 double PairLebedevaZ::init_one(int i, int j)
 {
   if (setflag[i][j] == 0) error->all(FLERR,"All pair coeffs are not set");
+  if (!offset_flag)
+    error->all(FLERR,"Must use 'pair_modify shift yes' with this pair style");
 
   if (offset_flag && (cut[i][j] > 0.0)) {
     int iparam_ij = elem2param[map[i]][map[j]];


### PR DESCRIPTION
**Summary**

This addresses some issues in multiple interlayer potentials in the USER-MISC package, that would crash when used in setups with additional elements. example shown on [lammps-users](https://sourceforge.net/p/lammps/mailman/message/36659505/)

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This will disallow incorrect use of `pair_coeff` statements and `pair_modify shift` statements with these pair styles, that were previously accepted.

**Implementation Notes**

Processing of `pair_coeff` did not enforce using only '* *' type assignment arguments and would lead to incorrect flagging of pairs of atom types with setflag, which in turn will lead to incorrect neighbor (skip) lists, which will lead to segfaults when looking up non-existing parameters. This PR applies similar procedures as with other manybody potentials that require '* *' coeff settings. 

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

