### PR TITLE
USER-INTEL: Changes to support LAMMPS_BIGBIG in USER-INTEL + fixed ch…

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1124,9 +1124,6 @@ if(PKG_OPT)
 endif()
 
 if(PKG_USER-INTEL)
-  if(LAMMPS_SIZES STREQUAL BIGBIG)
-    message(FATAL_ERROR "The USER-INTEL Package is not compatible with -DLAMMPS_BIGBIG")
-  endif()
   add_definitions(-DLMP_USER_INTEL)
 
   set(INTEL_ARCH "cpu" CACHE STRING "Architectures used by USER-INTEL (cpu or knl)")

--- a/src/USER-INTEL/fix_intel.cpp
+++ b/src/USER-INTEL/fix_intel.cpp
@@ -34,10 +34,6 @@
 #include <cstdio>
 #include <cmath>
 
-#ifdef LAMMPS_BIGBIG
-#error "The USER-INTEL package is not compatible with -DLAMMPS_BIGBIG"
-#endif
-
 #ifdef _LMP_INTEL_OFFLOAD
 #ifndef INTEL_OFFLOAD_NOAFFINITY
 #include <unistd.h>
@@ -378,13 +374,13 @@ void FixIntel::setup(int vflag)
   if (neighbor->style != Neighbor::BIN)
     error->all(FLERR,
             "Currently, neighbor style BIN must be used with Intel package.");
-  if (neighbor->exclude_setting() != 0)
-    error->all(FLERR,
-            "Currently, cannot use neigh_modify exclude with Intel package.");
-  if (vflag_atom)
+  if (vflag > 3)
    error->all(FLERR,
                "Cannot currently get per-atom virials with Intel package.");
   #ifdef _LMP_INTEL_OFFLOAD
+  if (neighbor->exclude_setting() != 0)
+    error->all(FLERR,
+     "Currently, cannot use neigh_modify exclude with Intel package offload.");
   post_force(vflag);
   #endif
 }

--- a/src/USER-INTEL/fix_intel.h
+++ b/src/USER-INTEL/fix_intel.h
@@ -495,9 +495,9 @@ E: Currently, neighbor style BIN must be used with Intel package.
 This is the only neighbor style that has been implemented for the Intel
 package.
 
-E: Currently, cannot use neigh_modify exclude with Intel package.
+E: Currently, cannot use neigh_modify exclude with Intel package offload.
 
-This is a current restriction of the Intel package.
+This is a current restriction of the Intel package when built for offload.
 
 W: Unknown Intel Compiler Version
 

--- a/src/USER-INTEL/intel_buffers.cpp
+++ b/src/USER-INTEL/intel_buffers.cpp
@@ -186,8 +186,8 @@ void IntelBuffers<flt_t, acc_t>::free_nmax()
 {
   #ifdef _LMP_INTEL_OFFLOAD
   if (_off_map_nmax > 0) {
-    const int * tag = _off_map_tag;
-    const int * special = _off_map_special;
+    const tagint * tag = _off_map_tag;
+    const tagint * special = _off_map_special;
     const int * nspecial = _off_map_nspecial;
     #pragma offload_transfer target(mic:_cop) \
       nocopy(tag:alloc_if(0) free_if(1)) \
@@ -209,7 +209,8 @@ void IntelBuffers<flt_t, acc_t>::_grow_nmax(const int offload_end)
   _host_nmax = size;
 
   if (!offload_end) return;
-  int *special, *nspecial;
+  tagint *special;
+  int *nspecial;
   int tag_length, special_length, nspecial_length;
   if (lmp->atom->molecular) {
     special = lmp->atom->special[0];
@@ -226,7 +227,7 @@ void IntelBuffers<flt_t, acc_t>::_grow_nmax(const int offload_end)
     tag_length = size;
   else
     tag_length = 1;
-  int *tag = lmp->atom->tag;
+  tagint *tag = lmp->atom->tag;
   #pragma offload_transfer target(mic:_cop) \
     nocopy(tag:length(tag_length) alloc_if(1) free_if(0)) \
     nocopy(special:length(special_length) alloc_if(1) free_if(0)) \
@@ -523,7 +524,7 @@ void IntelBuffers<flt_t, acc_t>::free_ncache()
     flt_t *ncachez = _ncachez;
     int *ncachej = _ncachej;
     int *ncachejtype = _ncachejtype;
-    int *ncachetag = _ncachetag;
+    tagint *ncachetag = _ncachetag;
 
     #ifdef _LMP_INTEL_OFFLOAD
     if (_off_ncache) {
@@ -603,7 +604,7 @@ void IntelBuffers<flt_t, acc_t>::grow_ncache(const int off_flag,
       tsize = 16;
       lmp->memory->create(_ncachetag, tsize, "_ncachetag");
     }
-    int *ncachetag = _ncachetag;
+    tagint *ncachetag = _ncachetag;
     #pragma offload_transfer target(mic:_cop)                   \
       nocopy(ncachetag:length(tsize) alloc_if(1) free_if(0))
     _off_ncache = 1;

--- a/src/USER-INTEL/intel_buffers.h
+++ b/src/USER-INTEL/intel_buffers.h
@@ -132,7 +132,7 @@ class IntelBuffers {
   inline flt_t * get_ncachez() { return _ncachez; }
   inline int * get_ncachej() { return _ncachej; }
   inline int * get_ncachejtype() { return _ncachejtype; }
-  inline int * get_ncachetag() { return _ncachetag; }
+  inline tagint * get_ncachetag() { return _ncachetag; }
 
   inline int get_max_nbors() {
     int mn = lmp->neighbor->oneatom * sizeof(int) /
@@ -336,7 +336,8 @@ class IntelBuffers {
 
   int _ncache_stride, _ncache_alloc;
   flt_t *_ncachex, *_ncachey, *_ncachez;
-  int *_ncachej, *_ncachejtype, *_ncachetag;
+  int *_ncachej, *_ncachejtype;
+  tagint *_ncachetag;
 
   int _need_tag, _host_nmax;
 
@@ -352,8 +353,8 @@ class IntelBuffers {
   quat_t *_host_quat;
   vec3_acc_t *_off_f;
   int _off_map_nmax, _cop, _off_ccache, _off_ncache;
-  int *_off_map_ilist;
-  int *_off_map_special, *_off_map_nspecial, *_off_map_tag;
+  int *_off_map_ilist, *_off_map_nspecial;
+  tagint *_off_map_tag, *_off_map_special;
   int **_off_map_firstneigh, *_off_map_numneigh;
   bool _off_list_alloc;
   #endif

--- a/src/USER-INTEL/npair_full_bin_ghost_intel.cpp
+++ b/src/USER-INTEL/npair_full_bin_ghost_intel.cpp
@@ -194,7 +194,7 @@ void NPairFullBinGhostIntel::fbi(const int offload, NeighList * list,
   flt_t * _noalias const ncachez = buffers->get_ncachez();
   int * _noalias const ncachej = buffers->get_ncachej();
   int * _noalias const ncachejtype = buffers->get_ncachejtype();
-  int * _noalias const ncachetag = buffers->get_ncachetag();
+  tagint * _noalias const ncachetag = buffers->get_ncachetag();
   const int ncache_stride = buffers->ncache_stride();
 
   const int mbinx = this->mbinx;
@@ -304,7 +304,7 @@ void NPairFullBinGhostIntel::fbi(const int offload, NeighList * list,
       flt_t * _noalias const tz = ncachez + toffs;
       int * _noalias const tj = ncachej + toffs;
       int * _noalias const tjtype = ncachejtype + toffs;
-      int * _noalias const ttag = ncachetag + toffs;
+      tagint * _noalias const ttag = ncachetag + toffs;
 
       // loop over all atoms in other bins in stencil, store every pair
       int ncount, oldbin = -9999999;
@@ -392,7 +392,7 @@ void NPairFullBinGhostIntel::fbi(const int offload, NeighList * list,
           const flt_t dely = ytmp - ty[u];
           const flt_t delz = ztmp - tz[u];
           const int jtype = tjtype[u];
-          const int jtag = ttag[u];
+          const tagint jtag = ttag[u];
           const flt_t rsq = delx * delx + dely * dely + delz * delz;
           if (rsq > cutsq[ioffset + jtype]) addme = 0;
 

--- a/src/USER-INTEL/npair_intel.cpp
+++ b/src/USER-INTEL/npair_intel.cpp
@@ -191,7 +191,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
   flt_t * _noalias const ncachez = buffers->get_ncachez();
   int * _noalias const ncachej = buffers->get_ncachej();
   int * _noalias const ncachejtype = buffers->get_ncachejtype();
-  int * _noalias const ncachetag = buffers->get_ncachetag();
+  tagint * _noalias const ncachetag = buffers->get_ncachetag();
   const int ncache_stride = buffers->ncache_stride();
 
   int sb = 1;
@@ -308,7 +308,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
       flt_t * _noalias const tz = ncachez + toffs;
       int * _noalias const tj = ncachej + toffs;
       int * _noalias const tjtype = ncachejtype + toffs;
-      int * _noalias const ttag = ncachetag + toffs;
+      tagint * _noalias const ttag = ncachetag + toffs;
 
       flt_t * _noalias itx;
       flt_t * _noalias ity;
@@ -501,7 +501,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
           }
 
           if (THREE) {
-            const int jtag = ttag[u];
+            const tagint jtag = ttag[u];
             int flist = 0;
             if (itag > jtag) {
               if (((itag+jtag) & 1) == 0) flist = 1;


### PR DESCRIPTION
…eck for per-atom virials + fixed check for exclusion with offload.

**Summary**

Minor changes to support building with LAMMPS_BIGBIG defined. This also fixes the error check for per-atom virials and exclusion lists (latter only supported without offload).

**Related Issues**

**Author(s)**

Mike Brown (Intel)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**



