### PR TITLE
new atomic stress definition for correct computation of heat flux with many-body interactions

### DIFF
--- a/src/USER-OMP/thr_omp.cpp
+++ b/src/USER-OMP/thr_omp.cpp
@@ -106,7 +106,7 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
     if (vflag & 4) {
       thr->vatom_angle = vatom + tid*nall;
       if (nall > 0)
-        memset(&(thr->vatom_angle[0][0]),0,nall*6*sizeof(double));
+        memset(&(thr->vatom_angle[0][0]),0,nall*9*sizeof(double));
     }
   }
 
@@ -119,7 +119,7 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
     if (vflag & 4) {
       thr->vatom_dihed = vatom + tid*nall;
       if (nall > 0)
-        memset(&(thr->vatom_dihed[0][0]),0,nall*6*sizeof(double));
+        memset(&(thr->vatom_dihed[0][0]),0,nall*9*sizeof(double));
     }
   }
 
@@ -132,7 +132,7 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
     if (vflag & 4) {
       thr->vatom_imprp = vatom + tid*nall;
       if (nall > 0)
-        memset(&(thr->vatom_imprp[0][0]),0,nall*6*sizeof(double));
+        memset(&(thr->vatom_imprp[0][0]),0,nall*9*sizeof(double));
     }
   }
 
@@ -276,7 +276,7 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         data_reduce_thr(&(angle->eatom[0]), nall, nthreads, 1, tid);
       }
       if (vflag & 4) {
-        data_reduce_thr(&(angle->vatom[0][0]), nall, nthreads, 6, tid);
+        data_reduce_thr(&(angle->vatom[0][0]), nall, nthreads, 9, tid);
       }
 
     }
@@ -307,7 +307,7 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         data_reduce_thr(&(dihedral->eatom[0]), nall, nthreads, 1, tid);
       }
       if (vflag & 4) {
-        data_reduce_thr(&(dihedral->vatom[0][0]), nall, nthreads, 6, tid);
+        data_reduce_thr(&(dihedral->vatom[0][0]), nall, nthreads, 9, tid);
       }
 
     }
@@ -346,7 +346,7 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         data_reduce_thr(&(pair->eatom[0]), nall, nthreads, 1, tid);
       }
       if (vflag & 4) {
-        data_reduce_thr(&(dihedral->vatom[0][0]), nall, nthreads, 6, tid);
+        data_reduce_thr(&(dihedral->vatom[0][0]), nall, nthreads, 9, tid);
         data_reduce_thr(&(pair->vatom[0][0]), nall, nthreads, 6, tid);
       }
     }
@@ -377,7 +377,7 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         data_reduce_thr(&(improper->eatom[0]), nall, nthreads, 1, tid);
       }
       if (vflag & 4) {
-        data_reduce_thr(&(improper->vatom[0][0]), nall, nthreads, 6, tid);
+        data_reduce_thr(&(improper->vatom[0][0]), nall, nthreads, 9, tid);
       }
 
     }
@@ -449,6 +449,19 @@ static void v_tally(double * const vout, const double * const vin)
   vout[3] += vin[3];
   vout[4] += vin[4];
   vout[5] += vin[5];
+}
+
+static void v_tally9(double * const vout, const double * const vin)
+{
+  vout[0] += vin[0];
+  vout[1] += vin[1];
+  vout[2] += vin[2];
+  vout[3] += vin[3];
+  vout[4] += vin[4];
+  vout[5] += vin[5];
+  vout[6] += vin[6];
+  vout[7] += vin[7];
+  vout[8] += vin[8];
 }
 
 static void v_tally(double * const vout, const double scale, const double * const vin)

--- a/src/USER-OMP/thr_omp.cpp
+++ b/src/USER-OMP/thr_omp.cpp
@@ -1234,12 +1234,85 @@ void ThrOMP::ev_tally_thr(Improper * const imprp, const int i1, const int i2,
 
   if (imprp->vflag_either) {
     double v[6];
-    v[0] = vb1x*f1[0] + vb2x*f3[0] + (vb3x+vb2x)*f4[0];
-    v[1] = vb1y*f1[1] + vb2y*f3[1] + (vb3y+vb2y)*f4[1];
-    v[2] = vb1z*f1[2] + vb2z*f3[2] + (vb3z+vb2z)*f4[2];
-    v[3] = vb1x*f1[1] + vb2x*f3[1] + (vb3x+vb2x)*f4[1];
-    v[4] = vb1x*f1[2] + vb2x*f3[2] + (vb3x+vb2x)*f4[2];
-    v[5] = vb1y*f1[2] + vb2y*f3[2] + (vb3y+vb2y)*f4[2];
+    double f2[3], v1[9], v2[9], v3[9], v4[9];
+    double a1[3], a2[3], a3[3], a4[3];
+
+    f2[0] = - f1[0] - f3[0] - f4[0];
+    f2[1] = - f1[1] - f3[1] - f4[1];
+    f2[2] = - f1[2] - f3[2] - f4[2];
+
+    // f1*r1+f2*r2+f3*r3+f4*r4
+    //     = (f1(r12+r13+r14)+f2(r21+r23+r24)+f3(r31+r32+r34)+f4(r41+r42+r43))/4
+    // vb1: r12
+    // vb2: r32
+    // vb3: r43
+
+    // a1 = (r12 + r13 + r14)/4 = (3*vb1 - 2*vb2 - vb3)/4
+    a1[0] = 0.25*(3*vb1x - 2*vb2x - vb3x);
+    a1[1] = 0.25*(3*vb1y - 2*vb2y - vb3y);
+    a1[2] = 0.25*(3*vb1z - 2*vb2z - vb3z);
+
+    // a2 = (r21 + r23 + r24)/4 = (-vb1 - 2*vb2 - vb3)/4
+    a2[0] = 0.25*(-vb1x - 2*vb2x - vb3x);
+    a2[1] = 0.25*(-vb1y - 2*vb2y - vb3y);
+    a2[2] = 0.25*(-vb1z - 2*vb2z - vb3z);
+
+    // a3 = (r31 + r32 + r34)/4 = (-vb1 + 2*vb2 - vb3)/4
+    a3[0] = 0.25*(-vb1x + 2*vb2x - vb3x);
+    a3[1] = 0.25*(-vb1y + 2*vb2y - vb3y);
+    a3[2] = 0.25*(-vb1z + 2*vb2z - vb3z);
+
+    // a4 = (r41 + r42 + r43)/4 = (-vb1 + 2*vb2 + 3*vb3)/4
+    a4[0] = 0.25*(-vb1x + 2*vb2x + 3*vb3x);
+    a4[1] = 0.25*(-vb1y + 2*vb2y + 3*vb3y);
+    a4[2] = 0.25*(-vb1z + 2*vb2z + 3*vb3z);
+
+    v1[0] = a1[0]*f1[0];
+    v1[1] = a1[1]*f1[1];
+    v1[2] = a1[2]*f1[2];
+    v1[3] = a1[0]*f1[1];
+    v1[4] = a1[0]*f1[2];
+    v1[5] = a1[1]*f1[2];
+    v1[6] = a1[1]*f1[0];
+    v1[7] = a1[2]*f1[0];
+    v1[8] = a1[2]*f1[1];
+
+    v2[0] = a2[0]*f2[0];
+    v2[1] = a2[1]*f2[1];
+    v2[2] = a2[2]*f2[2];
+    v2[3] = a2[0]*f2[1];
+    v2[4] = a2[0]*f2[2];
+    v2[5] = a2[1]*f2[2];
+    v2[6] = a2[1]*f2[0];
+    v2[7] = a2[2]*f2[0];
+    v2[8] = a2[2]*f2[1];
+
+    v3[0] = a3[0]*f3[0];
+    v3[1] = a3[1]*f3[1];
+    v3[2] = a3[2]*f3[2];
+    v3[3] = a3[0]*f3[1];
+    v3[4] = a3[0]*f3[2];
+    v3[5] = a3[1]*f3[2];
+    v3[6] = a3[1]*f3[0];
+    v3[7] = a3[2]*f3[0];
+    v3[8] = a3[2]*f3[1];
+
+    v4[0] = a4[0]*f4[0];
+    v4[1] = a4[1]*f4[1];
+    v4[2] = a4[2]*f4[2];
+    v4[3] = a4[0]*f4[1];
+    v4[4] = a4[0]*f4[2];
+    v4[5] = a4[1]*f4[2];
+    v4[6] = a4[1]*f4[0];
+    v4[7] = a4[2]*f4[0];
+    v4[8] = a4[2]*f4[1];
+
+    v[0] = v1[0] + v2[0] + v3[0] + v4[0];
+    v[1] = v1[1] + v2[1] + v3[1] + v4[1];
+    v[2] = v1[2] + v2[2] + v3[2] + v4[2];
+    v[3] = v1[3] + v2[3] + v3[3] + v4[3];
+    v[4] = v1[4] + v2[4] + v3[4] + v4[4];
+    v[5] = v1[5] + v2[5] + v3[5] + v4[5];
 
     if (imprp->vflag_global) {
       if (newton_bond) {
@@ -1254,24 +1327,17 @@ void ThrOMP::ev_tally_thr(Improper * const imprp, const int i1, const int i2,
       }
     }
 
-    v[0] *= 0.25;
-    v[1] *= 0.25;
-    v[2] *= 0.25;
-    v[3] *= 0.25;
-    v[4] *= 0.25;
-    v[5] *= 0.25;
-
     if (imprp->vflag_atom) {
       if (newton_bond) {
-        v_tally(thr->vatom_imprp[i1],v);
-        v_tally(thr->vatom_imprp[i2],v);
-        v_tally(thr->vatom_imprp[i3],v);
-        v_tally(thr->vatom_imprp[i4],v);
+        v_tally9(thr->vatom_imprp[i1],v1);
+        v_tally9(thr->vatom_imprp[i2],v2);
+        v_tally9(thr->vatom_imprp[i3],v3);
+        v_tally9(thr->vatom_imprp[i4],v4);
       } else {
-        if (i1 < nlocal) v_tally(thr->vatom_imprp[i1],v);
-        if (i2 < nlocal) v_tally(thr->vatom_imprp[i2],v);
-        if (i3 < nlocal) v_tally(thr->vatom_imprp[i3],v);
-        if (i4 < nlocal) v_tally(thr->vatom_imprp[i4],v);
+        if (i1 < nlocal) v_tally9(thr->vatom_imprp[i1],v1);
+        if (i2 < nlocal) v_tally9(thr->vatom_imprp[i2],v2);
+        if (i3 < nlocal) v_tally9(thr->vatom_imprp[i3],v3);
+        if (i4 < nlocal) v_tally9(thr->vatom_imprp[i4],v4);
       }
     }
   }

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -103,7 +103,7 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
     maxvatom = atom->nmax;
     if (alloc) {
       memory->destroy(vatom);
-      memory->create(vatom,comm->nthreads*maxvatom,6,"angle:vatom");
+      memory->create(vatom,comm->nthreads*maxvatom,9,"angle:vatom");
     }
   }
 
@@ -238,6 +238,6 @@ void Angle::ev_tally(int i, int j, int k, int nlocal, int newton_bond,
 double Angle::memory_usage()
 {
   double bytes = comm->nthreads*maxeatom * sizeof(double);
-  bytes += comm->nthreads*maxvatom*6 * sizeof(double);
+  bytes += comm->nthreads*maxvatom*9 * sizeof(double);
   return bytes;
 }

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -126,6 +126,9 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
       vatom[i][3] = 0.0;
       vatom[i][4] = 0.0;
       vatom[i][5] = 0.0;
+      vatom[i][6] = 0.0;
+      vatom[i][7] = 0.0;
+      vatom[i][8] = 0.0;
     }
   }
 }
@@ -141,6 +144,8 @@ void Angle::ev_tally(int i, int j, int k, int nlocal, int newton_bond,
                      double delx2, double dely2, double delz2)
 {
   double eanglethird,v[6];
+  double f2[3], v1[9], v2[9], v3[9];
+  double a1[3], a2[3], a3[3];
 
   if (eflag_either) {
     if (eflag_global) {
@@ -161,12 +166,70 @@ void Angle::ev_tally(int i, int j, int k, int nlocal, int newton_bond,
   }
 
   if (vflag_either) {
-    v[0] = delx1*f1[0] + delx2*f3[0];
-    v[1] = dely1*f1[1] + dely2*f3[1];
-    v[2] = delz1*f1[2] + delz2*f3[2];
-    v[3] = delx1*f1[1] + delx2*f3[1];
-    v[4] = delx1*f1[2] + delx2*f3[2];
-    v[5] = dely1*f1[2] + dely2*f3[2];
+
+    f2[0] = - f1[0] - f3[0];
+    f2[1] = - f1[1] - f3[1];
+    f2[2] = - f1[2] - f3[2];
+
+    // r0 = (r1+r2+r3)/3
+    // rij = ri-rj
+    // virial = r10*f1 + r20*f2 + r30*f3
+    // del1: r12
+    // del2: r32
+
+    // a1 = r10 = (2*r12 -   r32)/3
+    a1[0] = THIRD*(2*delx1-delx2);
+    a1[1] = THIRD*(2*dely1-dely2);
+    a1[2] = THIRD*(2*delz1-delz2);
+
+    // a2 = r20 = ( -r12 -   r32)/3
+    a2[0] = THIRD*(-delx1-delx2);
+    a2[1] = THIRD*(-dely1-dely2);
+    a2[2] = THIRD*(-delz1-delz2);
+
+    // a3 = r30 = ( -r12 + 2*r32)/3
+    a3[0] = THIRD*(-delx1+2*delx2);
+    a3[1] = THIRD*(-dely1+2*dely2);
+    a3[2] = THIRD*(-delz1+2*delz2);
+
+    // per-atom virial
+    v1[0] = a1[0]*f1[0];
+    v1[1] = a1[1]*f1[1];
+    v1[2] = a1[2]*f1[2];
+    v1[3] = a1[0]*f1[1];
+    v1[4] = a1[0]*f1[2];
+    v1[5] = a1[1]*f1[2];
+    v1[6] = a1[1]*f1[0];
+    v1[7] = a1[2]*f1[0];
+    v1[8] = a1[2]*f1[1];
+
+    v2[0] = a2[0]*f2[0];
+    v2[1] = a2[1]*f2[1];
+    v2[2] = a2[2]*f2[2];
+    v2[3] = a2[0]*f2[1];
+    v2[4] = a2[0]*f2[2];
+    v2[5] = a2[1]*f2[2];
+    v2[6] = a2[1]*f2[0];
+    v2[7] = a2[2]*f2[0];
+    v2[8] = a2[2]*f2[1];
+
+    v3[0] = a3[0]*f3[0];
+    v3[1] = a3[1]*f3[1];
+    v3[2] = a3[2]*f3[2];
+    v3[3] = a3[0]*f3[1];
+    v3[4] = a3[0]*f3[2];
+    v3[5] = a3[1]*f3[2];
+    v3[6] = a3[1]*f3[0];
+    v3[7] = a3[2]*f3[0];
+    v3[8] = a3[2]*f3[1];
+
+    // total virial
+    v[0] = v1[0] + v2[0] + v3[0];
+    v[1] = v1[1] + v2[1] + v3[1];
+    v[2] = v1[2] + v2[2] + v3[2];
+    v[3] = v1[3] + v2[3] + v3[3];
+    v[4] = v1[4] + v2[4] + v3[4];
+    v[5] = v1[5] + v2[5] + v3[5];
 
     if (vflag_global) {
       if (newton_bond) {
@@ -206,28 +269,37 @@ void Angle::ev_tally(int i, int j, int k, int nlocal, int newton_bond,
 
     if (vflag_atom) {
       if (newton_bond || i < nlocal) {
-        vatom[i][0] += THIRD*v[0];
-        vatom[i][1] += THIRD*v[1];
-        vatom[i][2] += THIRD*v[2];
-        vatom[i][3] += THIRD*v[3];
-        vatom[i][4] += THIRD*v[4];
-        vatom[i][5] += THIRD*v[5];
+        vatom[i][0] += v1[0];
+        vatom[i][1] += v1[1];
+        vatom[i][2] += v1[2];
+        vatom[i][3] += v1[3];
+        vatom[i][4] += v1[4];
+        vatom[i][5] += v1[5];
+        vatom[i][6] += v1[6];
+        vatom[i][7] += v1[7];
+        vatom[i][8] += v1[8];
       }
       if (newton_bond || j < nlocal) {
-        vatom[j][0] += THIRD*v[0];
-        vatom[j][1] += THIRD*v[1];
-        vatom[j][2] += THIRD*v[2];
-        vatom[j][3] += THIRD*v[3];
-        vatom[j][4] += THIRD*v[4];
-        vatom[j][5] += THIRD*v[5];
+        vatom[j][0] += v2[0];
+        vatom[j][1] += v2[1];
+        vatom[j][2] += v2[2];
+        vatom[j][3] += v2[3];
+        vatom[j][4] += v2[4];
+        vatom[j][5] += v2[5];
+        vatom[j][6] += v2[6];
+        vatom[j][7] += v2[7];
+        vatom[j][8] += v2[8];
       }
       if (newton_bond || k < nlocal) {
-        vatom[k][0] += THIRD*v[0];
-        vatom[k][1] += THIRD*v[1];
-        vatom[k][2] += THIRD*v[2];
-        vatom[k][3] += THIRD*v[3];
-        vatom[k][4] += THIRD*v[4];
-        vatom[k][5] += THIRD*v[5];
+        vatom[k][0] += v3[0];
+        vatom[k][1] += v3[1];
+        vatom[k][2] += v3[2];
+        vatom[k][3] += v3[3];
+        vatom[k][4] += v3[4];
+        vatom[k][5] += v3[5];
+        vatom[k][6] += v3[6];
+        vatom[k][7] += v3[7];
+        vatom[k][8] += v3[8];
       }
     }
   }

--- a/src/compute.h
+++ b/src/compute.h
@@ -59,6 +59,7 @@ class Compute : protected Pointers {
   int pressflag;      // 1 if Compute can be used as pressure (uses virial)
                       // must have both compute_scalar, compute_vector
   int pressatomflag;  // 1 if Compute calculates per-atom virial
+  int press9atomflag; // 1 if Compute calculates 3x3 per-atom virial
   int peflag;         // 1 if Compute calculates PE (uses Force energies)
   int peatomflag;     // 1 if Compute calculates per-atom PE
   int create_attribute;    // 1 if compute stores attributes that need

--- a/src/compute_heat_flux.cpp
+++ b/src/compute_heat_flux.cpp
@@ -138,18 +138,47 @@ void ComputeHeatFlux::compute_vector()
   double jv[3] = {0.0,0.0,0.0};
   double eng;
 
-  for (int i = 0; i < nlocal; i++) {
-    if (mask[i] & groupbit) {
-      eng = pe[i] + ke[i];
-      jc[0] += eng*v[i][0];
-      jc[1] += eng*v[i][1];
-      jc[2] += eng*v[i][2];
-      jv[0] -= stress[i][0]*v[i][0] + stress[i][3]*v[i][1] +
-        stress[i][4]*v[i][2];
-      jv[1] -= stress[i][3]*v[i][0] + stress[i][1]*v[i][1] +
-        stress[i][5]*v[i][2];
-      jv[2] -= stress[i][4]*v[i][0] + stress[i][5]*v[i][1] +
-        stress[i][2]*v[i][2];
+  if (c_stress->press9atomflag == 1) {
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+        eng = pe[i] + ke[i];
+        jc[0] += eng*v[i][0];
+        jc[1] += eng*v[i][1];
+        jc[2] += eng*v[i][2];
+        // stress[0]: rijx*fijx
+        // stress[1]: rijy*fijy
+        // stress[2]: rijz*fijz
+        // stress[3]: rijx*fijy
+        // stress[4]: rijx*fijz
+        // stress[5]: rijy*fijz
+        // stress[6]: rijy*fijx
+        // stress[7]: rijz*fijx
+        // stress[8]: rijz*fijy
+        // jv[0]  = rijx fijx vjx + rijx fijy vjy + rijx fijz vjz
+        jv[0] -= stress[i][0]*v[i][0] + stress[i][3]*v[i][1] +
+          stress[i][4]*v[i][2];
+        // jv[1]  = rijy fijx vjx + rijy fijy vjy + rijy fijz vjz
+        jv[1] -= stress[i][6]*v[i][0] + stress[i][1]*v[i][1] +
+          stress[i][5]*v[i][2];
+        // jv[2]  = rijz fijx vjx + rijz fijy vjy + rijz fijz vjz
+        jv[2] -= stress[i][7]*v[i][0] + stress[i][8]*v[i][1] +
+          stress[i][2]*v[i][2];
+      }
+    }
+  } else {
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+        eng = pe[i] + ke[i];
+        jc[0] += eng*v[i][0];
+        jc[1] += eng*v[i][1];
+        jc[2] += eng*v[i][2];
+        jv[0] -= stress[i][0]*v[i][0] + stress[i][3]*v[i][1] +
+          stress[i][4]*v[i][2];
+        jv[1] -= stress[i][3]*v[i][0] + stress[i][1]*v[i][1] +
+          stress[i][5]*v[i][2];
+        jv[2] -= stress[i][4]*v[i][0] + stress[i][5]*v[i][1] +
+          stress[i][2]*v[i][2];
+      }
     }
   }
 

--- a/src/compute_stress9_atom.cpp
+++ b/src/compute_stress9_atom.cpp
@@ -1,0 +1,425 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include <cstdlib>
+#include <cstring>
+#include "compute_stress9_atom.h"
+#include "atom.h"
+#include "update.h"
+#include "comm.h"
+#include "force.h"
+#include "pair.h"
+#include "bond.h"
+#include "angle.h"
+#include "dihedral.h"
+#include "improper.h"
+#include "kspace.h"
+#include "modify.h"
+#include "fix.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+enum{NOBIAS,BIAS};
+
+/* ---------------------------------------------------------------------- */
+
+ComputeStress9Atom::ComputeStress9Atom(LAMMPS *lmp, int narg, char **arg) :
+  Compute(lmp, narg, arg),
+  id_temp(NULL), stress(NULL)
+{
+  if (narg < 4) error->all(FLERR,"Illegal compute stress9/atom command");
+
+  peratom_flag = 1;
+  size_peratom_cols = 9;
+  pressatomflag = 1;
+  press9atomflag = 1;
+  timeflag = 1;
+  comm_reverse = 9;
+
+  // store temperature ID used by stress computation
+  // insure it is valid for temperature computation
+
+  if (strcmp(arg[3],"NULL") == 0) id_temp = NULL;
+  else {
+    int n = strlen(arg[3]) + 1;
+    id_temp = new char[n];
+    strcpy(id_temp,arg[3]);
+
+    int icompute = modify->find_compute(id_temp);
+    if (icompute < 0)
+      error->all(FLERR,"Could not find compute stress9/atom temperature ID");
+    if (modify->compute[icompute]->tempflag == 0)
+      error->all(FLERR,
+                 "Compute stress9/atom temperature ID does not "
+                 "compute temperature");
+  }
+
+  // process optional args
+
+  if (narg == 4) {
+    keflag = 1;
+    pairflag = 1;
+    bondflag = angleflag = dihedralflag = improperflag = 1;
+    kspaceflag = 1;
+    fixflag = 1;
+  } else {
+    keflag = 0;
+    pairflag = 0;
+    bondflag = angleflag = dihedralflag = improperflag = 0;
+    kspaceflag = 0;
+    fixflag = 0;
+    int iarg = 4;
+    while (iarg < narg) {
+      if (strcmp(arg[iarg],"ke") == 0) keflag = 1;
+      else if (strcmp(arg[iarg],"pair") == 0) pairflag = 1;
+      else if (strcmp(arg[iarg],"bond") == 0) bondflag = 1;
+      else if (strcmp(arg[iarg],"angle") == 0) angleflag = 1;
+      else if (strcmp(arg[iarg],"dihedral") == 0) dihedralflag = 1;
+      else if (strcmp(arg[iarg],"improper") == 0) improperflag = 1;
+      else if (strcmp(arg[iarg],"kspace") == 0) kspaceflag = 1;
+      else if (strcmp(arg[iarg],"fix") == 0) fixflag = 1;
+      else if (strcmp(arg[iarg],"virial") == 0) {
+        pairflag = 1;
+        bondflag = angleflag = dihedralflag = improperflag = 1;
+        kspaceflag = fixflag = 1;
+      } else error->all(FLERR,"Illegal compute stress9/atom command");
+      iarg++;
+    }
+  }
+
+  nmax = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeStress9Atom::~ComputeStress9Atom()
+{
+  delete [] id_temp;
+  memory->destroy(stress);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeStress9Atom::init()
+{
+  // set temperature compute, must be done in init()
+  // fixes could have changed or compute_modify could have changed it
+
+  if (id_temp) {
+    int icompute = modify->find_compute(id_temp);
+    if (icompute < 0)
+      error->all(FLERR,"Could not find compute stress9/atom temperature ID");
+    temperature = modify->compute[icompute];
+    if (temperature->tempbias) biasflag = BIAS;
+    else biasflag = NOBIAS;
+  } else biasflag = NOBIAS;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeStress9Atom::compute_peratom()
+{
+  int i,j;
+  double onemass;
+
+  invoked_peratom = update->ntimestep;
+  if (update->vflag_atom != invoked_peratom)
+    error->all(FLERR,"Per-atom virial was not tallied on needed timestep");
+
+  // grow local stress array if necessary
+  // needs to be atom->nmax in length
+
+  if (atom->nmax > nmax) {
+    memory->destroy(stress);
+    nmax = atom->nmax;
+    memory->create(stress,nmax,9,"stress9/atom:stress");
+    array_atom = stress;
+  }
+
+  // npair includes ghosts if either newton flag is set
+  //   b/c some bonds/dihedrals call pair::ev_tally with pairwise info
+  // nbond includes ghosts if newton_bond is set
+  // ntotal includes ghosts if either newton flag is set
+  // KSpace includes ghosts if tip4pflag is set
+
+  int nlocal = atom->nlocal;
+  int npair = nlocal;
+  int nbond = nlocal;
+  int ntotal = nlocal;
+  int nkspace = nlocal;
+  if (force->newton) npair += atom->nghost;
+  if (force->newton_bond) nbond += atom->nghost;
+  if (force->newton) ntotal += atom->nghost;
+  if (force->kspace && force->kspace->tip4pflag) nkspace += atom->nghost;
+
+  // clear local stress array
+
+  for (i = 0; i < ntotal; i++)
+    for (j = 0; j < 9; j++)
+      stress[i][j] = 0.0;
+
+  // add in per-atom contributions from each force
+
+  if (pairflag && force->pair) {
+    double **vatom = force->pair->vatom;
+    for (i = 0; i < npair; i++) {
+      for (j = 0; j < 6; j++)
+        stress[i][j] += vatom[i][j];
+      for (j = 6; j < 9; j++)
+        stress[i][j] += vatom[i][j-3];
+    }
+  }
+
+  if (bondflag && force->bond) {
+    double **vatom = force->bond->vatom;
+    for (i = 0; i < nbond; i++) {
+      for (j = 0; j < 6; j++)
+        stress[i][j] += vatom[i][j];
+      for (j = 6; j < 9; j++)
+        stress[i][j] += vatom[i][j-3];
+    }
+  }
+
+  if (angleflag && force->angle) {
+    double **vatom = force->angle->vatom;
+    for (i = 0; i < nbond; i++)
+      for (j = 0; j < 9; j++)
+        stress[i][j] += vatom[i][j];
+  }
+
+  if (dihedralflag && force->dihedral) {
+    double **vatom = force->dihedral->vatom;
+    for (i = 0; i < nbond; i++)
+      for (j = 0; j < 9; j++)
+        stress[i][j] += vatom[i][j];
+  }
+
+  if (improperflag && force->improper) {
+    double **vatom = force->improper->vatom;
+    for (i = 0; i < nbond; i++)
+      for (j = 0; j < 9; j++)
+        stress[i][j] += vatom[i][j];
+  }
+
+  if (kspaceflag && force->kspace) {
+    double **vatom = force->kspace->vatom;
+    for (i = 0; i < nkspace; i++) {
+      for (j = 0; j < 6; j++)
+        stress[i][j] += vatom[i][j];
+      for (j = 6; j < 9; j++)
+        stress[i][j] += vatom[i][j-3];
+    }
+  }
+
+  // add in per-atom contributions from relevant fixes
+  // skip if vatom = NULL
+  // possible during setup phase if fix has not initialized its vatom yet
+  // e.g. fix ave/spatial defined before fix shake,
+  //   and fix ave/spatial uses a per-atom stress from this compute as input
+
+  if (fixflag) {
+    for (int ifix = 0; ifix < modify->nfix; ifix++)
+      if (modify->fix[ifix]->virial_flag) {
+        double **vatom = modify->fix[ifix]->vatom;
+        if (vatom)
+          for (i = 0; i < nlocal; i++) {
+            for (j = 0; j < 6; j++)
+              stress[i][j] += vatom[i][j];
+            for (j = 6; j < 9; j++)
+              stress[i][j] += vatom[i][j-3];
+          }
+      }
+  }
+
+  // communicate ghost virials between neighbor procs
+
+  if (force->newton || (force->kspace && force->kspace->tip4pflag))
+    comm->reverse_comm_compute(this);
+
+  // zero virial of atoms not in group
+  // only do this after comm since ghost contributions must be included
+
+  int *mask = atom->mask;
+
+  for (i = 0; i < nlocal; i++)
+    if (!(mask[i] & groupbit)) {
+      stress[i][0] = 0.0;
+      stress[i][1] = 0.0;
+      stress[i][2] = 0.0;
+      stress[i][3] = 0.0;
+      stress[i][4] = 0.0;
+      stress[i][5] = 0.0;
+      stress[i][6] = 0.0;
+      stress[i][7] = 0.0;
+      stress[i][8] = 0.0;
+    }
+
+  // include kinetic energy term for each atom in group
+  // apply temperature bias is applicable
+  // mvv2e converts mv^2 to energy
+
+  if (keflag) {
+    double **v = atom->v;
+    double *mass = atom->mass;
+    double *rmass = atom->rmass;
+    int *type = atom->type;
+    double mvv2e = force->mvv2e;
+
+    if (biasflag == NOBIAS) {
+      if (rmass) {
+        for (i = 0; i < nlocal; i++)
+          if (mask[i] & groupbit) {
+            onemass = mvv2e * rmass[i];
+            stress[i][0] += onemass*v[i][0]*v[i][0];
+            stress[i][1] += onemass*v[i][1]*v[i][1];
+            stress[i][2] += onemass*v[i][2]*v[i][2];
+            stress[i][3] += onemass*v[i][0]*v[i][1];
+            stress[i][4] += onemass*v[i][0]*v[i][2];
+            stress[i][5] += onemass*v[i][1]*v[i][2];
+            stress[i][6] += onemass*v[i][1]*v[i][0];
+            stress[i][7] += onemass*v[i][2]*v[i][0];
+            stress[i][8] += onemass*v[i][2]*v[i][1];
+          }
+
+      } else {
+        for (i = 0; i < nlocal; i++)
+          if (mask[i] & groupbit) {
+            onemass = mvv2e * mass[type[i]];
+            stress[i][0] += onemass*v[i][0]*v[i][0];
+            stress[i][1] += onemass*v[i][1]*v[i][1];
+            stress[i][2] += onemass*v[i][2]*v[i][2];
+            stress[i][3] += onemass*v[i][0]*v[i][1];
+            stress[i][4] += onemass*v[i][0]*v[i][2];
+            stress[i][5] += onemass*v[i][1]*v[i][2];
+            stress[i][6] += onemass*v[i][1]*v[i][0];
+            stress[i][7] += onemass*v[i][2]*v[i][0];
+            stress[i][8] += onemass*v[i][2]*v[i][1];
+          }
+      }
+
+    } else {
+
+      // invoke temperature if it hasn't been already
+      // this insures bias factor is pre-computed
+
+      if (keflag && temperature->invoked_scalar != update->ntimestep)
+        temperature->compute_scalar();
+
+      if (rmass) {
+        for (i = 0; i < nlocal; i++)
+          if (mask[i] & groupbit) {
+            temperature->remove_bias(i,v[i]);
+            onemass = mvv2e * rmass[i];
+            stress[i][0] += onemass*v[i][0]*v[i][0];
+            stress[i][1] += onemass*v[i][1]*v[i][1];
+            stress[i][2] += onemass*v[i][2]*v[i][2];
+            stress[i][3] += onemass*v[i][0]*v[i][1];
+            stress[i][4] += onemass*v[i][0]*v[i][2];
+            stress[i][5] += onemass*v[i][1]*v[i][2];
+            stress[i][6] += onemass*v[i][1]*v[i][0];
+            stress[i][7] += onemass*v[i][2]*v[i][0];
+            stress[i][8] += onemass*v[i][2]*v[i][1];
+            temperature->restore_bias(i,v[i]);
+          }
+
+      } else {
+        for (i = 0; i < nlocal; i++)
+          if (mask[i] & groupbit) {
+            temperature->remove_bias(i,v[i]);
+            onemass = mvv2e * mass[type[i]];
+            stress[i][0] += onemass*v[i][0]*v[i][0];
+            stress[i][1] += onemass*v[i][1]*v[i][1];
+            stress[i][2] += onemass*v[i][2]*v[i][2];
+            stress[i][3] += onemass*v[i][0]*v[i][1];
+            stress[i][4] += onemass*v[i][0]*v[i][2];
+            stress[i][5] += onemass*v[i][1]*v[i][2];
+            stress[i][6] += onemass*v[i][1]*v[i][0];
+            stress[i][7] += onemass*v[i][2]*v[i][0];
+            stress[i][8] += onemass*v[i][2]*v[i][1];
+            temperature->restore_bias(i,v[i]);
+          }
+      }
+    }
+  }
+
+  // convert to stress*volume units = -pressure*volume
+
+  double nktv2p = -force->nktv2p;
+  for (i = 0; i < nlocal; i++)
+    if (mask[i] & groupbit) {
+      stress[i][0] *= nktv2p;
+      stress[i][1] *= nktv2p;
+      stress[i][2] *= nktv2p;
+      stress[i][3] *= nktv2p;
+      stress[i][4] *= nktv2p;
+      stress[i][5] *= nktv2p;
+      stress[i][6] *= nktv2p;
+      stress[i][7] *= nktv2p;
+      stress[i][8] *= nktv2p;
+    }
+}
+
+/* ---------------------------------------------------------------------- */
+
+int ComputeStress9Atom::pack_reverse_comm(int n, int first, double *buf)
+{
+  int i,m,last;
+
+  m = 0;
+  last = first + n;
+  for (i = first; i < last; i++) {
+    buf[m++] = stress[i][0];
+    buf[m++] = stress[i][1];
+    buf[m++] = stress[i][2];
+    buf[m++] = stress[i][3];
+    buf[m++] = stress[i][4];
+    buf[m++] = stress[i][5];
+    buf[m++] = stress[i][6];
+    buf[m++] = stress[i][7];
+    buf[m++] = stress[i][8];
+  }
+  return m;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeStress9Atom::unpack_reverse_comm(int n, int *list, double *buf)
+{
+  int i,j,m;
+
+  m = 0;
+  for (i = 0; i < n; i++) {
+    j = list[i];
+    stress[j][0] += buf[m++];
+    stress[j][1] += buf[m++];
+    stress[j][2] += buf[m++];
+    stress[j][3] += buf[m++];
+    stress[j][4] += buf[m++];
+    stress[j][5] += buf[m++];
+    stress[j][6] += buf[m++];
+    stress[j][7] += buf[m++];
+    stress[j][8] += buf[m++];
+  }
+}
+
+/* ----------------------------------------------------------------------
+   memory usage of local atom-based array
+------------------------------------------------------------------------- */
+
+double ComputeStress9Atom::memory_usage()
+{
+  double bytes = nmax*9 * sizeof(double);
+  return bytes;
+}

--- a/src/compute_stress9_atom.h
+++ b/src/compute_stress9_atom.h
@@ -1,0 +1,74 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+
+ComputeStyle(stress9/atom,ComputeStress9Atom)
+
+#else
+
+#ifndef LMP_COMPUTE_STRESS9_ATOM_H
+#define LMP_COMPUTE_STRESS9_ATOM_H
+
+#include "compute.h"
+
+namespace LAMMPS_NS {
+
+class ComputeStress9Atom : public Compute {
+ public:
+  ComputeStress9Atom(class LAMMPS *, int, char **);
+  ~ComputeStress9Atom();
+  void init();
+  void compute_peratom();
+  int pack_reverse_comm(int, int, double *);
+  void unpack_reverse_comm(int, int *, double *);
+  double memory_usage();
+
+ private:
+  int keflag,pairflag,bondflag,angleflag,dihedralflag,improperflag;
+  int kspaceflag,fixflag,biasflag;
+  Compute *temperature;
+  char *id_temp;
+
+  int nmax;
+  double **stress;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Could not find compute stress/atom temperature ID
+
+Self-explanatory.
+
+E: Compute stress/atom temperature ID does not compute temperature
+
+The specified compute must compute temperature.
+
+E: Per-atom virial was not tallied on needed timestep
+
+You are using a thermo keyword that requires potentials to have
+tallied the virial, but they didn't on this timestep.  See the
+variable doc page for ideas on how to make this work.
+
+*/

--- a/src/compute_stress_atom.cpp
+++ b/src/compute_stress_atom.cpp
@@ -187,23 +187,31 @@ void ComputeStressAtom::compute_peratom()
 
   if (angleflag && force->angle) {
     double **vatom = force->angle->vatom;
-    for (i = 0; i < nbond; i++)
-      for (j = 0; j < 6; j++)
+    for (i = 0; i < nbond; i++) {
+      for (j = 0; j < 3; j++)
         stress[i][j] += vatom[i][j];
+      for (j = 3; j < 6; j++)
+        stress[i][j] += 0.5*(vatom[i][j]+vatom[i][j+3]);
+    }
   }
 
   if (dihedralflag && force->dihedral) {
     double **vatom = force->dihedral->vatom;
-    for (i = 0; i < nbond; i++)
-      for (j = 0; j < 6; j++)
+    for (i = 0; i < nbond; i++) {
+      for (j = 0; j < 3; j++)
         stress[i][j] += vatom[i][j];
+      for (j = 3; j < 6; j++)
+        stress[i][j] += 0.5*(vatom[i][j]+vatom[i][j+3]);
+    }
   }
 
   if (improperflag && force->improper) {
     double **vatom = force->improper->vatom;
     for (i = 0; i < nbond; i++)
-      for (j = 0; j < 6; j++)
+      for (j = 0; j < 3; j++)
         stress[i][j] += vatom[i][j];
+      for (j = 3; j < 6; j++)
+        stress[i][j] += 0.5*(vatom[i][j]+vatom[i][j+3]);
   }
 
   if (kspaceflag && force->kspace) {

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -103,7 +103,7 @@ void Dihedral::ev_setup(int eflag, int vflag, int alloc)
     maxvatom = atom->nmax;
     if (alloc) {
       memory->destroy(vatom);
-      memory->create(vatom,comm->nthreads*maxvatom,6,"dihedral:vatom");
+      memory->create(vatom,comm->nthreads*maxvatom,9,"dihedral:vatom");
     }
   }
 
@@ -260,6 +260,6 @@ void Dihedral::ev_tally(int i1, int i2, int i3, int i4,
 double Dihedral::memory_usage()
 {
   double bytes = comm->nthreads*maxeatom * sizeof(double);
-  bytes += comm->nthreads*maxvatom*6 * sizeof(double);
+  bytes += comm->nthreads*maxvatom*9 * sizeof(double);
   return bytes;
 }

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -126,6 +126,9 @@ void Dihedral::ev_setup(int eflag, int vflag, int alloc)
       vatom[i][3] = 0.0;
       vatom[i][4] = 0.0;
       vatom[i][5] = 0.0;
+      vatom[i][6] = 0.0;
+      vatom[i][7] = 0.0;
+      vatom[i][8] = 0.0;
     }
   }
 }
@@ -145,6 +148,8 @@ void Dihedral::ev_tally(int i1, int i2, int i3, int i4,
                         double vb3x, double vb3y, double vb3z)
 {
   double edihedralquarter,v[6];
+  double f2[3], v1[9], v2[9], v3[9], v4[9];
+  double a1[3], a2[3], a3[3], a4[3];
 
   if (eflag_either) {
     if (eflag_global) {
@@ -167,12 +172,86 @@ void Dihedral::ev_tally(int i1, int i2, int i3, int i4,
   }
 
   if (vflag_either) {
-    v[0] = vb1x*f1[0] + vb2x*f3[0] + (vb3x+vb2x)*f4[0];
-    v[1] = vb1y*f1[1] + vb2y*f3[1] + (vb3y+vb2y)*f4[1];
-    v[2] = vb1z*f1[2] + vb2z*f3[2] + (vb3z+vb2z)*f4[2];
-    v[3] = vb1x*f1[1] + vb2x*f3[1] + (vb3x+vb2x)*f4[1];
-    v[4] = vb1x*f1[2] + vb2x*f3[2] + (vb3x+vb2x)*f4[2];
-    v[5] = vb1y*f1[2] + vb2y*f3[2] + (vb3y+vb2y)*f4[2];
+
+    f2[0] = - f1[0] - f3[0] - f4[0];
+    f2[1] = - f1[1] - f3[1] - f4[1];
+    f2[2] = - f1[2] - f3[2] - f4[2];
+
+    // r0 = (r1+r2+r3+r4)/4
+    // rij = ri-rj
+    // virial = r10*f1 + r20*f2 + r30*f3 + r40*f4
+    // vb1: r12
+    // vb2: r32
+    // vb3: r43
+
+    // a1 = r10 = (3*r12 - 2*r32 -   r43)/4
+    a1[0] = 0.25*(3*vb1x - 2*vb2x - vb3x);
+    a1[1] = 0.25*(3*vb1y - 2*vb2y - vb3y);
+    a1[2] = 0.25*(3*vb1z - 2*vb2z - vb3z);
+
+    // a2 = r20 = ( -r12 - 2*r32 -   r43)/4
+    a2[0] = 0.25*(-vb1x - 2*vb2x - vb3x);
+    a2[1] = 0.25*(-vb1y - 2*vb2y - vb3y);
+    a2[2] = 0.25*(-vb1z - 2*vb2z - vb3z);
+
+    // a3 = r30 = ( -r12 + 2*r32 -   r43)/4
+    a3[0] = 0.25*(-vb1x + 2*vb2x - vb3x);
+    a3[1] = 0.25*(-vb1y + 2*vb2y - vb3y);
+    a3[2] = 0.25*(-vb1z + 2*vb2z - vb3z);
+
+    // a4 = r40 = ( -r12 + 2*r32 + 3*r43)/4
+    a4[0] = 0.25*(-vb1x + 2*vb2x + 3*vb3x);
+    a4[1] = 0.25*(-vb1y + 2*vb2y + 3*vb3y);
+    a4[2] = 0.25*(-vb1z + 2*vb2z + 3*vb3z);
+
+    // per-atom virial
+    v1[0] = a1[0]*f1[0];
+    v1[1] = a1[1]*f1[1];
+    v1[2] = a1[2]*f1[2];
+    v1[3] = a1[0]*f1[1];
+    v1[4] = a1[0]*f1[2];
+    v1[5] = a1[1]*f1[2];
+    v1[6] = a1[1]*f1[0];
+    v1[7] = a1[2]*f1[0];
+    v1[8] = a1[2]*f1[1];
+
+    v2[0] = a2[0]*f2[0];
+    v2[1] = a2[1]*f2[1];
+    v2[2] = a2[2]*f2[2];
+    v2[3] = a2[0]*f2[1];
+    v2[4] = a2[0]*f2[2];
+    v2[5] = a2[1]*f2[2];
+    v2[6] = a2[1]*f2[0];
+    v2[7] = a2[2]*f2[0];
+    v2[8] = a2[2]*f2[1];
+
+    v3[0] = a3[0]*f3[0];
+    v3[1] = a3[1]*f3[1];
+    v3[2] = a3[2]*f3[2];
+    v3[3] = a3[0]*f3[1];
+    v3[4] = a3[0]*f3[2];
+    v3[5] = a3[1]*f3[2];
+    v3[6] = a3[1]*f3[0];
+    v3[7] = a3[2]*f3[0];
+    v3[8] = a3[2]*f3[1];
+
+    v4[0] = a4[0]*f4[0];
+    v4[1] = a4[1]*f4[1];
+    v4[2] = a4[2]*f4[2];
+    v4[3] = a4[0]*f4[1];
+    v4[4] = a4[0]*f4[2];
+    v4[5] = a4[1]*f4[2];
+    v4[6] = a4[1]*f4[0];
+    v4[7] = a4[2]*f4[0];
+    v4[8] = a4[2]*f4[1];
+
+    // total virial
+    v[0] = v1[0] + v2[0] + v3[0] + v4[0];
+    v[1] = v1[1] + v2[1] + v3[1] + v4[1];
+    v[2] = v1[2] + v2[2] + v3[2] + v4[2];
+    v[3] = v1[3] + v2[3] + v3[3] + v4[3];
+    v[4] = v1[4] + v2[4] + v3[4] + v4[4];
+    v[5] = v1[5] + v2[5] + v3[5] + v4[5];
 
     if (vflag_global) {
       if (newton_bond) {
@@ -220,36 +299,48 @@ void Dihedral::ev_tally(int i1, int i2, int i3, int i4,
 
     if (vflag_atom) {
       if (newton_bond || i1 < nlocal) {
-        vatom[i1][0] += 0.25*v[0];
-        vatom[i1][1] += 0.25*v[1];
-        vatom[i1][2] += 0.25*v[2];
-        vatom[i1][3] += 0.25*v[3];
-        vatom[i1][4] += 0.25*v[4];
-        vatom[i1][5] += 0.25*v[5];
+        vatom[i1][0] += v1[0];
+        vatom[i1][1] += v1[1];
+        vatom[i1][2] += v1[2];
+        vatom[i1][3] += v1[3];
+        vatom[i1][4] += v1[4];
+        vatom[i1][5] += v1[5];
+        vatom[i1][6] += v1[6];
+        vatom[i1][7] += v1[7];
+        vatom[i1][8] += v1[8];
       }
       if (newton_bond || i2 < nlocal) {
-        vatom[i2][0] += 0.25*v[0];
-        vatom[i2][1] += 0.25*v[1];
-        vatom[i2][2] += 0.25*v[2];
-        vatom[i2][3] += 0.25*v[3];
-        vatom[i2][4] += 0.25*v[4];
-        vatom[i2][5] += 0.25*v[5];
+        vatom[i2][0] += v2[0];
+        vatom[i2][1] += v2[1];
+        vatom[i2][2] += v2[2];
+        vatom[i2][3] += v2[3];
+        vatom[i2][4] += v2[4];
+        vatom[i2][5] += v2[5];
+        vatom[i2][6] += v2[6];
+        vatom[i2][7] += v2[7];
+        vatom[i2][8] += v2[8];
       }
       if (newton_bond || i3 < nlocal) {
-        vatom[i3][0] += 0.25*v[0];
-        vatom[i3][1] += 0.25*v[1];
-        vatom[i3][2] += 0.25*v[2];
-        vatom[i3][3] += 0.25*v[3];
-        vatom[i3][4] += 0.25*v[4];
-        vatom[i3][5] += 0.25*v[5];
+        vatom[i3][0] += v3[0];
+        vatom[i3][1] += v3[1];
+        vatom[i3][2] += v3[2];
+        vatom[i3][3] += v3[3];
+        vatom[i3][4] += v3[4];
+        vatom[i3][5] += v3[5];
+        vatom[i3][6] += v3[6];
+        vatom[i3][7] += v3[7];
+        vatom[i3][8] += v3[8];
       }
       if (newton_bond || i4 < nlocal) {
-        vatom[i4][0] += 0.25*v[0];
-        vatom[i4][1] += 0.25*v[1];
-        vatom[i4][2] += 0.25*v[2];
-        vatom[i4][3] += 0.25*v[3];
-        vatom[i4][4] += 0.25*v[4];
-        vatom[i4][5] += 0.25*v[5];
+        vatom[i4][0] += v4[0];
+        vatom[i4][1] += v4[1];
+        vatom[i4][2] += v4[2];
+        vatom[i4][3] += v4[3];
+        vatom[i4][4] += v4[4];
+        vatom[i4][5] += v4[5];
+        vatom[i4][6] += v4[6];
+        vatom[i4][7] += v4[7];
+        vatom[i4][8] += v4[8];
       }
     }
   }

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -101,7 +101,7 @@ void Improper::ev_setup(int eflag, int vflag, int alloc)
     maxvatom = atom->nmax;
     if (alloc) {
       memory->destroy(vatom);
-      memory->create(vatom,comm->nthreads*maxvatom,6,"improper:vatom");
+      memory->create(vatom,comm->nthreads*maxvatom,9,"improper:vatom");
     }
   }
 
@@ -258,6 +258,6 @@ void Improper::ev_tally(int i1, int i2, int i3, int i4,
 double Improper::memory_usage()
 {
   double bytes = comm->nthreads*maxeatom * sizeof(double);
-  bytes += comm->nthreads*maxvatom*6 * sizeof(double);
+  bytes += comm->nthreads*maxvatom*9 * sizeof(double);
   return bytes;
 }


### PR DESCRIPTION
**Summary**

Our group has recently published a paper [1] demonstrating that the current "group" form [2] of atomic stress in LAMMPS is inadequate when computing heat flux of systems containing many-body interactions such as angles, dihedrals and impropers. In short, when using the group form atomic stress, force-velocity relation breaks down and the heat/flux compute underestimates the contribution of many-body interaction in both EMD and NEMD systems.
In our paper, we also proposed a modification to the atomic stress definition with which heat/flux compute produces exact heat flux values in accordance to that of a previous formulation by our group [3] if used for the whole system, and gives a good approximation when used to compute local heat flux, such as in NEMD systems. This pull request is the code used for our paper that implements the new atomic stress definition for angle, dihedral and improper potentials. In principle, the same atomic stress definition could be applied to many-body pair style potentials, such as tersoff, but we would like to gain some guidance form the LAMMPS developers before proceeding further.


**Author(s)**

Donatas Surblys (Tohoku University) surblys.donatas at gmail dot com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Implementation Notes**

Instead of dividing the total virial of a many-body interaction equally to all participating atoms, we instead use ri0⊗fi formulation, where fi, is the force acting upon atom i due to many-body interaction and ri0 is the relative position of atom i to the geometric center of atoms involved in the many-body interaction. Because the total force is zero, the total virial remains unchanged.

Unfortunately, the per-atom atomic stress is no-longer symmetric, so we have to expand vatom arrays from 6 to 9 components. To maintain backwards compatibility, we have atom/stress compute produce 6 components as before, only now it takes the average between the appropriate off-diagonal components of vatom. We created a new compute atom/stress9 that properly has 9 components (xx, yy, zz, xy, xz, yz, yx, yz, zy), and added a new flag "press9atomflag" to the compute class to indicate this. The heat/flux compute was accordingly modified to accept both compute/stress and compute/stress9 computes.

These changes have been implemented for angles, dihedrals, impropers and their OMP versions. 

**Backward Compatibility**

These changes should not break any scripts. Although total pressure computations are in essence identical, some numerical difference might be present due to change in order of computational operations. Partial and total pressure and heat flux computations via atom/stress and heat/flux computes for systems with only pair-wise interactions should remain identical. Computation results of local stress (or pressure) via atom/stress for many-body interactions should change slightly, but as long as the control volumes are large enough and there is uniformity at the control volume boundaries, the discrepancies should be negligible. When these conditions do not hold, there is usually not much physical meaning in the results anyway as the values are highly influenced by approximation errors.

In principal, complete backward comparability could be achieved if we expanded vatom to 15 components, keeping the old atomic stress computations in the first 6 components, and placing the new atomic stress computations in the remaining 9.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

[1] https://journals.aps.org/pre/abstract/10.1103/PhysRevE.99.051301
[2] http://aip.scitation.org/doi/10.1063/1.3245303
[3] http://aip.scitation.org/doi/10.1063/1.2821963