### PR TITLE
extends automated neighbor rebuild diagnostics 

### DIFF
--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -34,6 +34,7 @@ AtomVec::AtomVec(LAMMPS *lmp) : Pointers(lmp)
   forceclearflag = 0;
   size_data_bonus = 0;
   kokkosable = 0;
+  check_distance_flag=0;
 
   nargcopy = 0;
   argcopy = NULL;

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -48,6 +48,8 @@ class AtomVec : protected Pointers {
   int nargcopy;          // copy of command-line args for atom_style command
   char **argcopy;        // used when AtomVec is realloced (restart,replicate)
 
+  int check_distance_flag; //determines whether the atom style has its own neighbor rebuild check
+
   AtomVec(class LAMMPS *);
   virtual ~AtomVec();
   void store_args(int, char **);
@@ -116,6 +118,8 @@ class AtomVec : protected Pointers {
   virtual void pack_property_atom(int, double *, int, int) {}
 
   virtual bigint memory_usage() = 0;
+  virtual int check_distance_function(double deltasq) {return 0;} //specific neighbor rebuild check function an atom style might need
+  virtual void set_hold_properties() {} //specific neighbor rebuild check function an atom style might need
 
  protected:
   int nmax;                             // local copy of atom->nmax

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -123,6 +123,13 @@ void AtomVecHybrid::process_args(int narg, char **arg)
   size_velocity = 3;
   if (atom->omega_flag) size_velocity += 3;
   if (atom->angmom_flag) size_velocity += 3;
+
+  //determine if the set of substyles requires a specific neighbor rebuild check
+  int current_flag;
+  for (int k = 0; k < nstyles; k++){
+      current_flag = styles[k]->check_distance_flag;
+      if(current_flag!=0) check_distance_flag=1;
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1069,6 +1076,32 @@ int AtomVecHybrid::known_style(char *str)
   for (int i = 0; i < nallstyles; i++)
     if (strcmp(str,allstyles[i]) == 0) return 1;
   return 0;
+}
+
+/* ----------------------------------------------------------------------
+   set a hold value for atomvec properties used to compare with current property values
+------------------------------------------------------------------------- */
+
+void AtomVecHybrid::set_hold_properties(){
+	for (int k = 0; k < nstyles; k++)
+       styles[k]->set_hold_properties();
+}
+
+/* ----------------------------------------------------------------------
+   check whether substyle reneighbor checks require reneighboring on the current timestep
+------------------------------------------------------------------------- */
+
+int AtomVecHybrid::check_distance_function(double deltasq){
+	int flag=0;
+  int current_flag=0;
+	for (int k = 0; k < nstyles; k++){
+      current_flag = styles[k]->check_distance_function(deltasq);
+      if(current_flag!=0) {
+        flag=1;
+        break;
+        }
+  }
+	return flag;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom_vec_hybrid.h
+++ b/src/atom_vec_hybrid.h
@@ -66,6 +66,8 @@ class AtomVecHybrid : public AtomVec {
   int property_atom(char *);
   void pack_property_atom(int, double *, int, int);
   bigint memory_usage();
+  virtual int check_distance_function(double deltasq); //calls the specific neighbor rebuild diagnostics of each substyle
+  virtual void set_hold_properties(); //sets holds for specific atom properties needed for neighbor rebuild diagnostics for each substyle
 
  private:
   tagint *tag;

--- a/src/neighbor.h
+++ b/src/neighbor.h
@@ -31,6 +31,7 @@ class Neighbor : protected Pointers {
   int oneatom;                     // max # of neighbors for one atom
   int includegroup;                // only build pairwise lists for this group
   int build_once;                  // 1 if only build lists once per run
+  int atomvec_check_flag;          // 1 if atom style invokes its own check function for rebuilds
 
   double skin;                     // skin distance
   double cutneighmin;              // min neighbor cutoff for all type pairs


### PR DESCRIPTION

**Summary**

Adds functionality in the form of a check_distance function and a set_hold_properties function to atom_vec. These serve the role of enabling developers to program their own neighbor rebuild diagnostics for automated neighbor rebuilds. The interface to call these functions is also placed in neighbor.cpp

**Related Issues**


**Author(s)**

Adrian Diaz (University of Florida)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Clear of Conflict

**Implementation Notes**

The only additional computation for a standard run is three if checks in neighbor.cpp. The implementation was tested with a custom atom vec style that invokes extended objects. Correctness was verified by comparing the outputs of "check every n" with the automated rebuild strategy for dynamic simulations.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_


**Further Information, Files, and Links**




