### PR TITLE
Don't reallocate views every time in neigh_bond_kokkos

### DIFF
--- a/src/KOKKOS/neigh_bond_kokkos.cpp
+++ b/src/KOKKOS/neigh_bond_kokkos.cpp
@@ -200,6 +200,7 @@ void NeighBondKokkos<DeviceType>::build_topology_kk()
 {
   atomKK->sync(execution_space, X_MASK | TAG_MASK);
   int nall = atom->nlocal + atom->nghost;
+  int nmax = atom->nmax;
 
   nlocal = atom->nlocal;
   x = atomKK->k_x.view<DeviceType>();
@@ -215,7 +216,9 @@ void NeighBondKokkos<DeviceType>::build_topology_kk()
 
   int* map_array_host = atom->get_map_array();
   int map_size = atom->get_map_size();
-  k_map_array = DAT::tdual_int_1d("NeighBond:map_array",map_size);
+  int map_maxarray = atom->get_map_maxarray();
+  if (map_maxarray > k_map_array.extent(0))
+    k_map_array = DAT::tdual_int_1d("NeighBond:map_array",map_maxarray);
   for (int i=0; i<map_size; i++)
     k_map_array.h_view[i] = map_array_host[i];
   k_map_array.template modify<LMPHostType>();
@@ -223,7 +226,8 @@ void NeighBondKokkos<DeviceType>::build_topology_kk()
   map_array = k_map_array.view<DeviceType>();
 
   int* sametag_host = atomKK->sametag;
-  k_sametag = DAT::tdual_int_1d("NeighBond:sametag",nall);
+  if (nmax > k_sametag.extent(0))
+    k_sametag = DAT::tdual_int_1d("NeighBond:sametag",nmax);
   for (int i=0; i<nall; i++)
     k_sametag.h_view[i] = sametag_host[i];
   k_sametag.template modify<LMPHostType>();

--- a/src/atom.h
+++ b/src/atom.h
@@ -286,6 +286,7 @@ class Atom : protected Pointers {
 
   inline int* get_map_array() {return map_array;};
   inline int get_map_size() {return map_tag_max+1;};
+  inline int get_map_maxarray() {return map_maxarray+1;};
 
   bigint memory_usage();
   int memcheck(const char *);


### PR DESCRIPTION
**Summary**

Only reallocate two views in neigh_bond_kokkos if the size has been exceeded. 

**Related Issues**

Fixes #1473.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues