### PR TITLE
Correctly and fully support pair style hybrid and hybrid/overlay for pair style quip

### DIFF
--- a/doc/src/pair_quip.txt
+++ b/doc/src/pair_quip.txt
@@ -92,10 +92,6 @@ pairs from the neighbor list. This needs to be very carefully tested,
 because it may remove pairs from the neighbor list that are still
 required.
 
-Pair style {quip} cannot be used with pair style {hybrid}, only
-with {hybrid/overlay} and only the {quip} sub-style is applied to
-all atom types.
-
 [Related commands:]
 
 "pair_coeff"_pair_coeff.html

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -218,11 +218,9 @@ void PairQUIP::compute(int eflag, int vflag)
    global settings
 ------------------------------------------------------------------------- */
 
-void PairQUIP::settings(int narg, char **/*arg*/)
+void PairQUIP::settings(int narg, char ** /* arg */)
 {
   if (narg != 0) error->all(FLERR,"Illegal pair_style command");
-  if (strcmp(force->pair_style,"hybrid") == 0)
-    error->all(FLERR,"Pair style quip is only compatible with hybrid/overlay");
 
   // check if linked to the correct QUIP library API version
   // as of 2017-07-19 this is API_VERSION 1

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -107,14 +107,14 @@ void PairQUIP::compute(int eflag, int vflag)
     jnum = numneigh[i];
 
     for (jj = 0; jj < jnum; jj++) {
-       quip_neigh[iquip] = (jlist[jj] & NEIGHMASK) + 1;
-       iquip++;
+      quip_neigh[iquip] = (jlist[jj] & NEIGHMASK) + 1;
+      iquip++;
     }
   }
 
   atomic_numbers = new int[ntotal];
   for (ii = 0; ii < ntotal; ii++)
-     atomic_numbers[ii] = map[type[ii]-1];
+     atomic_numbers[ii] = map[type[ii]];
 
   quip_local_e = new double [ntotal];
   quip_force = new double [ntotal*3];
@@ -239,7 +239,7 @@ void PairQUIP::allocate()
 
   setflag = memory->create(setflag,n+1,n+1,"pair:setflag");
   cutsq = memory->create(cutsq,n+1,n+1,"pair:cutsq");
-  map = new int[n];
+  map = new int[n+1];
 }
 
 void PairQUIP::coeff(int narg, char **arg)

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -39,16 +39,16 @@ using namespace LAMMPS_NS;
 
 PairQUIP::PairQUIP(LAMMPS *lmp) : Pair(lmp)
 {
-   single_enable = 0;
-   restartinfo = 0;
-   one_coeff = 1;
-   no_virial_fdotr_compute = 1;
-   manybody_flag = 1;
+  single_enable = 0;
+  restartinfo = 0;
+  one_coeff = 1;
+  no_virial_fdotr_compute = 1;
+  manybody_flag = 1;
 
-   map = NULL;
-   quip_potential = NULL;
-   quip_file = NULL;
-   quip_string = NULL;
+  map = NULL;
+  quip_potential = NULL;
+  quip_file = NULL;
+  quip_string = NULL;
 }
 
 PairQUIP::~PairQUIP()

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -44,6 +44,11 @@ PairQUIP::PairQUIP(LAMMPS *lmp) : Pair(lmp)
    one_coeff = 1;
    no_virial_fdotr_compute = 1;
    manybody_flag = 1;
+
+   map = NULL;
+   quip_potential = NULL;
+   quip_file = NULL;
+   quip_string = NULL;
 }
 
 PairQUIP::~PairQUIP()
@@ -52,8 +57,10 @@ PairQUIP::~PairQUIP()
     memory->destroy(setflag);
     memory->destroy(cutsq);
     delete [] map;
-    delete [] quip_potential;
   }
+  delete [] quip_potential;
+  delete [] quip_file;
+  delete [] quip_string;
 }
 
 void PairQUIP::compute(int eflag, int vflag)

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -227,6 +227,11 @@ void PairQUIP::settings(int narg, char ** /* arg */)
   if (quip_lammps_api_version() != 1)
     error->all(FLERR,"QUIP LAMMPS wrapper API version is not compatible "
         "with this version of LAMMPS");
+
+  // QUIP potentials are parameterized in metal units
+
+  if (strcmp("metal",update->unit_style) != 0)
+    error->all(FLERR,"QUIP potentials require 'metal' units");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-QUIP/pair_quip.h
+++ b/src/USER-QUIP/pair_quip.h
@@ -26,10 +26,10 @@ extern "C"
 {
   int quip_lammps_api_version();
   void quip_lammps_wrapper(int*, int*, int*, int*,
-      int*, int*, int*,
-      int*, int*, double*,
-      int*, int*, double*,
-      double*, double*, double*, double*, double*);
+                           int*, int*, int*,
+                           int*, int*, double*,
+                           int*, int*, double*,
+                           double*, double*, double*, double*, double*);
   void quip_lammps_potential_initialise(int*, int*, double*, char*, int*, char*, int*);
 }
 


### PR DESCRIPTION
**Summary**

Pair style quip would only support pair style `hybrid/overlay` and only when spanning all atom types, since it didn't properly handle `NULL` entries for atom type assignments. This PR removes that limitation and implements a few other cleanups.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes. only broken use of hybrid pair style configurations may now produce errors. The use of metal units is now enforced (not just documented that it is required).

**Implementation Notes**

This correctly handles the map array and also applies setflag only to atom types where it is really used. In addition some minor cleanups and formatting changes were implemented. 

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

