### PR TITLE
Do not enable OpenMP by default for gcc 9.x with CMake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -316,7 +316,18 @@ pkg_depends(USER-SCAFACOS MPI)
 
 include(CheckIncludeFileCXX)
 find_package(OpenMP QUIET)
-option(BUILD_OMP "Build with OpenMP support" ${OpenMP_FOUND})
+
+# TODO: this is a temporary workaround until a better solution is found. AK 2019-05-30
+# GNU GCC 9.x uses settings incompatible with our use of 'default(none)' in OpenMP pragmas
+# where we assume older GCC semantics. For the time being, we disable OpenMP by default
+# for GCC 9.x and beyond. People may manually turn it on, but need to run the script
+# src/USER-OMP/hack_openmp_for_pgi_gcc9.sh on all sources to make it compatible with gcc 9.
+if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0.0))
+  option(BUILD_OMP "Build with OpenMP support" OFF)
+else()
+  option(BUILD_OMP "Build with OpenMP support" ${OpenMP_FOUND})
+endif()
+
 if(BUILD_OMP)
   find_package(OpenMP REQUIRED)
   check_include_file_cxx(omp.h HAVE_OMP_H_INCLUDE)


### PR DESCRIPTION
**Summary**

Temporary workaround for the incompatibility of OpenMP support in gcc 9.x and the OpenMP directives in LAMMPS. To avoid unexpected failure to compile with CMake, we don't automatically enable the 'BUILD_OMP' flag in that case. This way people that just run cmake to compile LAMMPS will by default get a working executable and no rather cryptic error messages. Manually enabling OpenMP will still cause compilation failures unless the script in `src/USER-OMP/hack_openmp_for_pgi_gcc9.sh` is used to convert all affected sources to not use the `default(none)` directive, but `default(shared)` instead.

This is primarily intended for the upcoming stable release to avoid frequent reports of "LAMMPS broken with gcc 9" by people that are not aware, that OpenMP would be enabled by default, even if they are not using it. It needs a more permanent solution that re-enables OpenMP support for the affected compilers, but it is not clear at the moment, what a good approach would be.

**Related Issues**

closes #1482 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

n/a

**Implementation Notes**

Please see the discussion of issues #1482 and #1326 for more details.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the CMake based build system
