### PR TITLE
Restart updates for fixes atom/swap, deposit, and gcmc

### DIFF
--- a/doc/src/fix_atom_swap.txt
+++ b/doc/src/fix_atom_swap.txt
@@ -141,10 +141,15 @@ specify if this should be done.
 
 This fix writes the state of the fix to "binary restart
 files"_restart.html.  This includes information about the random
-number generator seed, the next timestep for MC exchanges, etc.  See
+number generator seed, the next timestep for MC exchanges, the number
+of exchange attempts and successes etc.  See
 the "read_restart"_read_restart.html command for info on how to
 re-specify a fix in an input script that reads a restart file, so that
 the operation of the fix continues in an uninterrupted fashion.
+
+NOTE: For this to work correctly, the timestep must [not] be changed
+after reading the restart with "reset_timestep"_reset_timestep.html.
+The fix will try to detect it and stop with an error.
 
 None of the "fix_modify"_fix_modify.html options are relevant to this
 fix.

--- a/doc/src/fix_deposit.txt
+++ b/doc/src/fix_deposit.txt
@@ -261,6 +261,10 @@ next timestep for deposition, etc.  See the
 a fix in an input script that reads a restart file, so that the
 operation of the fix continues in an uninterrupted fashion.
 
+NOTE: For this to work correctly, the timestep must [not] be changed
+after reading the restart with "reset_timestep"_reset_timestep.html.
+The fix will try to detect it and stop with an error.
+
 None of the "fix_modify"_fix_modify.html options are relevant to this
 fix.  No global or per-atom quantities are stored by this fix for
 access by various "output commands"_Howto_output.html.  No parameter

--- a/doc/src/fix_gcmc.txt
+++ b/doc/src/fix_gcmc.txt
@@ -373,10 +373,15 @@ adds all inserted atoms of the specified type to the
 
 This fix writes the state of the fix to "binary restart
 files"_restart.html.  This includes information about the random
-number generator seed, the next timestep for MC exchanges, etc.  See
+number generator seed, the next timestep for MC exchanges,  the number
+of MC step attempts and successes etc.  See
 the "read_restart"_read_restart.html command for info on how to
 re-specify a fix in an input script that reads a restart file, so that
 the operation of the fix continues in an uninterrupted fashion.
+
+NOTE: For this to work correctly, the timestep must [not] be changed
+after reading the restart with "reset_timestep"_reset_timestep.html.
+The fix will try to detect it and stop with an error.
 
 None of the "fix_modify"_fix_modify.html options are relevant to this
 fix.

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -777,6 +777,7 @@ void FixAtomSwap::write_restart(FILE *fp)
   list[n++] = ubuf(next_reneighbor).d;
   list[n++] = nswap_attempts;
   list[n++] = nswap_successes;
+  list[n++] = ubuf(update->ntimestep).d;
 
   if (comm->me == 0) {
     int size = n * sizeof(double);
@@ -804,4 +805,8 @@ void FixAtomSwap::restart(char *buf)
 
   nswap_attempts = static_cast<int>(list[n++]);
   nswap_successes = static_cast<int>(list[n++]);
+
+  bigint ntimestep_restart = (bigint) ubuf(list[n++]).i;
+  if (ntimestep_restart != update->ntimestep)
+    error->all(FLERR,"Must not reset timestep when restarting fix atom/swap");
 }

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -771,10 +771,12 @@ double FixAtomSwap::memory_usage()
 void FixAtomSwap::write_restart(FILE *fp)
 {
   int n = 0;
-  double list[4];
+  double list[6];
   list[n++] = random_equal->state();
   list[n++] = random_unequal->state();
-  list[n++] = next_reneighbor;
+  list[n++] = ubuf(next_reneighbor).d;
+  list[n++] = nswap_attempts;
+  list[n++] = nswap_successes;
 
   if (comm->me == 0) {
     int size = n * sizeof(double);
@@ -798,5 +800,8 @@ void FixAtomSwap::restart(char *buf)
   seed = static_cast<int> (list[n++]);
   random_unequal->reset(seed);
 
-  next_reneighbor = static_cast<int> (list[n++]);
+  next_reneighbor = (bigint) ubuf(list[n++]).i;
+
+  nswap_attempts = static_cast<int>(list[n++]);
+  nswap_successes = static_cast<int>(list[n++]);
 }

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -2531,10 +2531,19 @@ double FixGCMC::memory_usage()
 void FixGCMC::write_restart(FILE *fp)
 {
   int n = 0;
-  double list[4];
+  double list[12];
   list[n++] = random_equal->state();
   list[n++] = random_unequal->state();
-  list[n++] = next_reneighbor;
+  list[n++] = ubuf(next_reneighbor).d;
+  list[n++] = ntranslation_attempts;
+  list[n++] = ntranslation_successes;
+  list[n++] = nrotation_attempts;
+  list[n++] = nrotation_successes;
+  list[n++] = ndeletion_attempts;
+  list[n++] = ndeletion_successes;
+  list[n++] = ninsertion_attempts;
+  list[n++] = ninsertion_successes;
+
 
   if (comm->me == 0) {
     int size = n * sizeof(double);
@@ -2558,7 +2567,16 @@ void FixGCMC::restart(char *buf)
   seed = static_cast<int> (list[n++]);
   random_unequal->reset(seed);
 
-  next_reneighbor = static_cast<int> (list[n++]);
+  next_reneighbor = (bigint) ubuf(list[n++]).i;
+
+  ntranslation_attempts  = list[n++];
+  ntranslation_successes = list[n++];
+  nrotation_attempts     = list[n++];
+  nrotation_successes    = list[n++];
+  ndeletion_attempts     = list[n++];
+  ndeletion_successes    = list[n++];
+  ninsertion_attempts    = list[n++];
+  ninsertion_successes   = list[n++];
 }
 
 void FixGCMC::grow_molecule_arrays(int nmolatoms) {

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -2543,7 +2543,7 @@ void FixGCMC::write_restart(FILE *fp)
   list[n++] = ndeletion_successes;
   list[n++] = ninsertion_attempts;
   list[n++] = ninsertion_successes;
-
+  list[n++] = ubuf(update->ntimestep).d;
 
   if (comm->me == 0) {
     int size = n * sizeof(double);
@@ -2577,6 +2577,10 @@ void FixGCMC::restart(char *buf)
   ndeletion_successes    = list[n++];
   ninsertion_attempts    = list[n++];
   ninsertion_successes   = list[n++];
+
+  bigint ntimestep_restart = (bigint) ubuf(list[n++]).i;
+  if (ntimestep_restart != update->ntimestep)
+    error->all(FLERR,"Must not reset timestep when restarting fix gcmc");
 }
 
 void FixGCMC::grow_molecule_arrays(int nmolatoms) {

--- a/src/MISC/fix_deposit.cpp
+++ b/src/MISC/fix_deposit.cpp
@@ -798,11 +798,12 @@ void FixDeposit::options(int narg, char **arg)
 void FixDeposit::write_restart(FILE *fp)
 {
   int n = 0;
-  double list[4];
+  double list[5];
   list[n++] = random->state();
   list[n++] = ninserted;
   list[n++] = nfirst;
   list[n++] = ubuf(next_reneighbor).d;
+  list[n++] = ubuf(update->ntimestep).d;
 
   if (comm->me == 0) {
     int size = n * sizeof(double);
@@ -824,6 +825,10 @@ void FixDeposit::restart(char *buf)
   ninserted = static_cast<int> (list[n++]);
   nfirst = static_cast<int> (list[n++]);
   next_reneighbor = (bigint) ubuf(list[n++]).i;
+
+  bigint ntimestep_restart = (bigint) ubuf(list[n++]).i;
+  if (ntimestep_restart != update->ntimestep)
+    error->all(FLERR,"Must not reset timestep when restarting this fix");
 
   random->reset(seed);
 }

--- a/src/MISC/fix_deposit.cpp
+++ b/src/MISC/fix_deposit.cpp
@@ -802,7 +802,7 @@ void FixDeposit::write_restart(FILE *fp)
   list[n++] = random->state();
   list[n++] = ninserted;
   list[n++] = nfirst;
-  list[n++] = next_reneighbor;
+  list[n++] = ubuf(next_reneighbor).d;
 
   if (comm->me == 0) {
     int size = n * sizeof(double);
@@ -823,7 +823,7 @@ void FixDeposit::restart(char *buf)
   seed = static_cast<int> (list[n++]);
   ninserted = static_cast<int> (list[n++]);
   nfirst = static_cast<int> (list[n++]);
-  next_reneighbor = static_cast<int> (list[n++]);
+  next_reneighbor = (bigint) ubuf(list[n++]).i;
 
   random->reset(seed);
 }


### PR DESCRIPTION
**Summary**

This PR has some updates and improvements when restarting fixes `atom/swap`, `deposit`, and `gcmc`

**Related Issues**

This adds a check to avoid unexpected behavior as [reported on lammps-users](https://sourceforge.net/p/lammps/mailman/message/36679929/)

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Restart files for the fixes atom/swap, deposit, and gcmc will not be backward compatible due to storing additional information.

**Implementation Notes**

This uses the ubuf() union to correctly store 64-bit timestep numbers in double buffers of the restart file. It also stores the number of MC attempts and successes as reported by the corresponding compute_vector() method of the fix into the restart file (so they won't start from zero again).
It also stores the timestep when the restart was written, so that upon reading back the state, it can be checked whether the timestep was changed via `reset_timestep`. This is creating a problem, since the restart stores at what timestep the MC step(s) of the fix should be attempted next. if it is changed via reset_timestep, the restarted fix may remain inactive for a very long time.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system


