### PR TITLE
memcpy2memmove

### DIFF
--- a/src/math_extra.cpp
+++ b/src/math_extra.cpp
@@ -56,7 +56,7 @@ int mldivide3(const double m[3][3], const double *v, double *ans)
       if (fabs(aug[j][i]) > fabs(aug[i][i])) {
         double tempv[4];
         memcpy(tempv,aug[i],4*sizeof(double));
-        memcpy(aug[i],aug[j],4*sizeof(double));
+        memmove(aug[i],aug[j],4*sizeof(double));
         memcpy(aug[j],tempv,4*sizeof(double));
       }
     }
@@ -68,7 +68,7 @@ int mldivide3(const double m[3][3], const double *v, double *ans)
       if (p != i) {
         double tempv[4];
         memcpy(tempv,aug[i],4*sizeof(double));
-        memcpy(aug[i],aug[p],4*sizeof(double));
+        memmove(aug[i],aug[p],4*sizeof(double));
         memcpy(aug[p],tempv,4*sizeof(double));
       }
 

--- a/src/rcb.cpp
+++ b/src/rcb.cpp
@@ -537,7 +537,7 @@ void RCB::compute(int dimension, int n, double **x, double *wt,
       if (dotmark[i] == markactive)
         memcpy(&buf[outgoing++],&dots[i],sizeof(Dot));
       else
-        memcpy(&dots[keep++],&dots[i],sizeof(Dot));
+        memmove(&dots[keep++],&dots[i],sizeof(Dot));
     }
 
     // post receives for dots
@@ -1029,7 +1029,7 @@ void RCB::compute_old(int dimension, int n, double **x, double *wt,
       if (dotmark[i] == markactive)
         memcpy(&buf[outgoing++],&dots[i],sizeof(Dot));
       else
-        memcpy(&dots[keep++],&dots[i],sizeof(Dot));
+        memmove(&dots[keep++],&dots[i],sizeof(Dot));
     }
 
     // post receives for dots


### PR DESCRIPTION
…ame source and destination arrays; this is not every instance of this issue in the source code

**Summary**

Avoids the possibility of undefined behavior in certain cases that use memcpy with the same source
and destination arrays. Should make valgrind reports cleaner etc.

**Related Issues**


**Author(s)**

Adrian Diaz (University of Florida)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Clear of Conflict

**Implementation Notes**

The problematic instances of memcpy are replaced with memmove

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**




