### PR TITLE
Change test for OpenMP default setting to be compatible with CMake 2.8.x

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -322,7 +322,7 @@ find_package(OpenMP QUIET)
 # where we assume older GCC semantics. For the time being, we disable OpenMP by default
 # for GCC 9.x and beyond. People may manually turn it on, but need to run the script
 # src/USER-OMP/hack_openmp_for_pgi_gcc9.sh on all sources to make it compatible with gcc 9.
-if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 8.99.9))
+if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.99.9))
   option(BUILD_OMP "Build with OpenMP support" OFF)
 else()
   option(BUILD_OMP "Build with OpenMP support" ${OpenMP_FOUND})

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -322,7 +322,7 @@ find_package(OpenMP QUIET)
 # where we assume older GCC semantics. For the time being, we disable OpenMP by default
 # for GCC 9.x and beyond. People may manually turn it on, but need to run the script
 # src/USER-OMP/hack_openmp_for_pgi_gcc9.sh on all sources to make it compatible with gcc 9.
-if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0.0))
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.99.9))
   option(BUILD_OMP "Build with OpenMP support" OFF)
 else()
   option(BUILD_OMP "Build with OpenMP support" ${OpenMP_FOUND})

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -322,7 +322,7 @@ find_package(OpenMP QUIET)
 # where we assume older GCC semantics. For the time being, we disable OpenMP by default
 # for GCC 9.x and beyond. People may manually turn it on, but need to run the script
 # src/USER-OMP/hack_openmp_for_pgi_gcc9.sh on all sources to make it compatible with gcc 9.
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.99.9))
+if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 8.99.9))
   option(BUILD_OMP "Build with OpenMP support" OFF)
 else()
   option(BUILD_OMP "Build with OpenMP support" ${OpenMP_FOUND})


### PR DESCRIPTION
This augments the change in #1483 to be compatible with older CMake versions.
