### PR TITLE
Collected small changes for the next patch

### DIFF
--- a/doc/src/Commands_bond.txt
+++ b/doc/src/Commands_bond.txt
@@ -28,8 +28,12 @@ OPT.
 
 "none"_bond_none.html,
 "zero"_bond_zero.html,
-"hybrid"_bond_hybrid.html :tb(c=3,ea=c)
-
+"hybrid"_bond_hybrid.html,
+,
+,
+,
+,
+,
 "class2 (ko)"_bond_class2.html,
 "fene (iko)"_bond_fene.html,
 "fene/expand (o)"_bond_fene_expand.html,
@@ -56,8 +60,12 @@ OPT.
 
 "none"_angle_none.html,
 "zero"_angle_zero.html,
-"hybrid"_angle_hybrid.html :tb(c=3,ea=c)
-
+"hybrid"_angle_hybrid.html,
+,
+,
+,
+,
+,
 "charmm (iko)"_angle_charmm.html,
 "class2 (ko)"_angle_class2.html,
 "class2/p6"_angle_class2.html,
@@ -89,8 +97,12 @@ OPT.
 
 "none"_dihedral_none.html,
 "zero"_dihedral_zero.html,
-"hybrid"_dihedral_hybrid.html :tb(c=3,ea=c)
-
+"hybrid"_dihedral_hybrid.html,
+,
+,
+,
+,
+,
 "charmm (iko)"_dihedral_charmm.html,
 "charmmfsw"_dihedral_charmm.html,
 "class2 (ko)"_dihedral_class2.html,
@@ -117,8 +129,12 @@ OPT.
 
 "none"_improper_none.html,
 "zero"_improper_zero.html,
-"hybrid"_improper_hybrid.html :tb(c=3,ea=c)
-
+"hybrid"_improper_hybrid.html,
+,
+,
+,
+,
+,
 "class2 (ko)"_improper_class2.html,
 "cossq (o)"_improper_cossq.html,
 "cvff (io)"_improper_cvff.html,

--- a/doc/src/Commands_pair.txt
+++ b/doc/src/Commands_pair.txt
@@ -27,8 +27,11 @@ OPT.
 "none"_pair_none.html,
 "zero"_pair_zero.html,
 "hybrid (k)"_pair_hybrid.html,
-"hybrid/overlay (k)"_pair_hybrid.html :tb(c=4,ea=c)
-
+"hybrid/overlay (k)"_pair_hybrid.html,
+,
+,
+,
+,
 "adp (o)"_pair_adp.html,
 "agni (o)"_pair_agni.html,
 "airebo (io)"_pair_airebo.html,

--- a/doc/src/Errors_messages.txt
+++ b/doc/src/Errors_messages.txt
@@ -7097,6 +7097,18 @@ Self-explanatory. :dd
 
 One or more GPUs must be used when Kokkos is compiled for CUDA. :dd
 
+{Kspace_modify mesh parameter must be all zero or all positive} :dt
+
+Valid kspace mesh parameters are >0. The code will try to auto-detect
+suitable values when all three mesh sizes are set to zero (the default). :dd
+
+{Kspace_modify mesh/disp parameter must be all zero or all positive} :dt
+
+Valid kspace mesh/disp parameters are >0. The code will try to auto-detect
+suitable values when all three mesh sizes are set to zero [and]
+the required accuracy via {force/disp/real} as well as
+{force/disp/kspace} is set. :dd
+
 {Kspace style does not support compute group/group} :dt
 
 Self-explanatory. :dd

--- a/src/Makefile
+++ b/src/Makefile
@@ -154,7 +154,6 @@ help:
 
 
 lmpinstalledpkgs.h: $(SRC) $(INC)
-	@echo 'Gathering installed package information (may take a little while)'
 	@echo '#ifndef LMP_INSTALLED_PKGS_H' >  ${TMPNAME}.lmpinstalled
 	@echo '#define LMP_INSTALLED_PKGS_H' >> ${TMPNAME}.lmpinstalled
 	@echo 'const char * LAMMPS_NS::LAMMPS::installed_packages[] = {' >> ${TMPNAME}.lmpinstalled
@@ -204,6 +203,7 @@ gitversion:
 	@test -f MAKE/Makefile.$@ -o -f MAKE/OPTIONS/Makefile.$@ -o \
 	  -f MAKE/MACHINES/Makefile.$@ -o -f MAKE/MINE/Makefile.$@
 	@if [ ! -d $(objdir) ]; then mkdir $(objdir); fi
+	@echo 'Gathering installed package information (may take a little while)'
 	@$(SHELL) Make.sh style
 	@$(SHELL) Make.sh packages
 	@$(MAKE) $(MFLAGS) lmpinstalledpkgs.h gitversion

--- a/src/USER-FEP/pair_lj_class2_coul_long_soft.cpp
+++ b/src/USER-FEP/pair_lj_class2_coul_long_soft.cpp
@@ -74,7 +74,6 @@ void PairLJClass2CoulLongSoft::compute(int eflag, int vflag)
 {
   int i,j,ii,jj,inum,jnum,itype,jtype;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
-  double fraction;
   double rsq,r,forcecoul,forcelj;
   double grij,expm2,prefactor,t,erfc;
   double factor_coul,factor_lj;
@@ -490,7 +489,7 @@ double PairLJClass2CoulLongSoft::single(int i, int j, int itype, int jtype,
                                     double &fforce)
 {
   double denc,r,denlj,r4sig6,grij,expm2,t,erfc,prefactor;
-  double fraction,forcecoul,forcelj,phicoul,philj;
+  double forcecoul,forcelj,phicoul,philj;
 
   if (rsq < cut_coulsq) {
       r = sqrt(rsq);

--- a/src/USER-PLUMED/fix_plumed.cpp
+++ b/src/USER-PLUMED/fix_plumed.cpp
@@ -33,6 +33,7 @@
 #include "compute.h"
 #include "modify.h"
 #include "pair.h"
+#include "utils.h"
 
 #include "plumed/wrapper/Plumed.h"
 
@@ -250,15 +251,15 @@ FixPlumed::FixPlumed(LAMMPS *lmp, int narg, char **arg) :
     // Avoid conflict with fixes that define internal pressure computes.
     // See comment in the setup method
 
-    if ((strncmp(check_style,"nph",3) == 0) ||
-        (strncmp(check_style,"npt",3) == 0) ||
-        (strncmp(check_style,"rigid/nph",9) == 0) ||
-        (strncmp(check_style,"rigid/npt",9) == 0) ||
-        (strncmp(check_style,"msst",4) == 0) ||
-        (strncmp(check_style,"nphug",5) == 0) ||
-        (strncmp(check_style,"ipi",3) == 0) ||
-        (strncmp(check_style,"press/berendsen",15) == 0) ||
-        (strncmp(check_style,"qbmsst",6) == 0))
+    if (utils::strmatch(check_style,"^nph") ||
+        utils::strmatch(check_style,"^npt") ||
+        utils::strmatch(check_style,"^rigid/nph") ||
+        utils::strmatch(check_style,"^rigid/npt") ||
+        utils::strmatch(check_style,"^msst") ||
+        utils::strmatch(check_style,"^nphug") ||
+        utils::strmatch(check_style,"^ipi") ||
+        utils::strmatch(check_style,"^press/berendsen") ||
+        utils::strmatch(check_style,"^qbmsst"))
       error->all(FLERR,"Fix plumed must be defined before any other fixes, "
                  "that compute pressure internally");
   }
@@ -289,7 +290,7 @@ int FixPlumed::setmask()
 
 void FixPlumed::init()
 {
-  if (strcmp(update->integrate_style,"respa") == 0)
+  if (utils::strmatch(update->integrate_style,"^respa"))
     nlevels_respa = ((Respa *) update->integrate)->nlevels;
 
   // This avoids nan pressure if compute_pressure is called
@@ -309,12 +310,12 @@ void FixPlumed::setup(int vflag)
   // has to be executed first. This creates a race condition with the
   // setup method of fix_nh. This is why in the constructor I check if
   // nh fixes have already been called.
-  if (strcmp(update->integrate_style,"verlet") == 0)
-    post_force(vflag);
-  else {
+  if (utils::strmatch(update->integrate_style,"^respa")) {
     ((Respa *) update->integrate)->copy_flevel_f(nlevels_respa-1);
     post_force_respa(vflag,nlevels_respa-1,0);
     ((Respa *) update->integrate)->copy_f_flevel(nlevels_respa-1);
+  } else {
+    post_force(vflag);
   }
 }
 

--- a/src/USER-QTB/fix_qbmsst.cpp
+++ b/src/USER-QTB/fix_qbmsst.cpp
@@ -41,6 +41,7 @@
 #include "group.h"
 #include "kspace.h"
 #include "thermo.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -410,14 +411,14 @@ void FixQBMSST::init()
   // rfix[] = indices to each fix rigid
   nrigid = 0;
   for (int i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"rigid") == 0 ||
-        strcmp(modify->fix[i]->style,"poems") == 0) nrigid++;
-  if (nrigid) {
+    if (utils::strmatch(modify->fix[i]->style,"^rigid") ||
+        (strcmp(modify->fix[i]->style,"poems") == 0)) nrigid++;
+  if (nrigid > 0) {
     rfix = new int[nrigid];
     nrigid = 0;
     for (int i = 0; i < modify->nfix; i++)
-      if (strcmp(modify->fix[i]->style,"rigid") == 0 ||
-          strcmp(modify->fix[i]->style,"poems") == 0) rfix[nrigid++] = i;
+      if (utils::strmatch(modify->fix[i]->style,"^rigid") ||
+          (strcmp(modify->fix[i]->style,"poems") == 0)) rfix[nrigid++] = i;
   }
 }
 

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -31,6 +31,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -375,8 +376,7 @@ void FixAdapt::init()
 
       // if pair hybrid, test that ilo,ihi,jlo,jhi are valid for sub-style
 
-      if (strcmp(force->pair_style,"hybrid") == 0 ||
-          strcmp(force->pair_style,"hybrid/overlay") == 0) {
+      if (utils::strmatch(force->pair_style,"^hybrid")) {
         PairHybrid *pair = (PairHybrid *) force->pair;
         for (i = ad->ilo; i <= ad->ihi; i++)
           for (j = MAX(ad->jlo,i); j <= ad->jhi; j++)
@@ -416,8 +416,7 @@ void FixAdapt::init()
 
       if (ad->bdim == 1) ad->vector = (double *) ptr;
 
-      if (strcmp(force->bond_style,"hybrid") == 0 ||
-          strcmp(force->bond_style,"hybrid_overlay") == 0)
+      if (utils::strmatch(force->bond_style,"^hybrid"))
         error->all(FLERR,"Fix adapt does not support bond_style hybrid");
 
       delete [] bstyle;

--- a/src/fix_nve_limit.cpp
+++ b/src/fix_nve_limit.cpp
@@ -23,6 +23,7 @@
 #include "modify.h"
 #include "comm.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -72,8 +73,8 @@ void FixNVELimit::init()
   // warn if using fix shake, which will lead to invalid constraint forces
 
   for (int i = 0; i < modify->nfix; i++)
-    if ((strcmp(modify->fix[i]->style,"shake") == 0)
-        || (strcmp(modify->fix[i]->style,"rattle") == 0)) {
+    if (utils::strmatch(modify->fix[i]->style,"^shake")
+        || utils::strmatch(modify->fix[i]->style,"^rattle")) {
       if (comm->me == 0)
         error->warning(FLERR,"Should not use fix nve/limit with fix shake or fix rattle");
     }

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -80,7 +80,11 @@ Force::Force(LAMMPS *lmp) : Pointers(lmp)
   strcpy(kspace_style,str);
 
   pair_restart = NULL;
+  create_factories();
+}
 
+void _noopt Force::create_factories()
+{
   // fill pair map with pair styles listed in style_pair.h
 
   pair_map = new PairCreatorMap();

--- a/src/force.h
+++ b/src/force.h
@@ -143,6 +143,7 @@ class Force : protected Pointers {
   bigint memory_usage();
 
  private:
+  void create_factories();
   template <typename T> static Pair *pair_creator(LAMMPS *);
   template <typename T> static Bond *bond_creator(LAMMPS *);
   template <typename T> static Angle *angle_creator(LAMMPS *);

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -443,7 +443,11 @@ void KSpace::modify_params(int narg, char **arg)
       nx_pppm = nx_msm_max = force->inumeric(FLERR,arg[iarg+1]);
       ny_pppm = ny_msm_max = force->inumeric(FLERR,arg[iarg+2]);
       nz_pppm = nz_msm_max = force->inumeric(FLERR,arg[iarg+3]);
-      if (nx_pppm == 0 && ny_pppm == 0 && nz_pppm == 0) gridflag = 0;
+      if (nx_pppm == 0 && ny_pppm == 0 && nz_pppm == 0)
+        gridflag = 0;
+      else if (nx_pppm <= 0 || ny_pppm <= 0 || nz_pppm <= 0)
+        error->all(FLERR,"Kspace_modify mesh parameters must be all "
+                   "zero or all positive");
       else gridflag = 1;
       iarg += 4;
     } else if (strcmp(arg[iarg],"mesh/disp") == 0) {
@@ -451,7 +455,11 @@ void KSpace::modify_params(int narg, char **arg)
       nx_pppm_6 = force->inumeric(FLERR,arg[iarg+1]);
       ny_pppm_6 = force->inumeric(FLERR,arg[iarg+2]);
       nz_pppm_6 = force->inumeric(FLERR,arg[iarg+3]);
-      if (nx_pppm_6 == 0 || ny_pppm_6 == 0 || nz_pppm_6 == 0) gridflag_6 = 0;
+      if (nx_pppm_6 == 0 && ny_pppm_6 == 0 && nz_pppm_6 == 0)
+        gridflag_6 = 0;
+      else if (nx_pppm_6 <= 0 || ny_pppm_6 <= 0 || nz_pppm_6 == 0)
+        error->all(FLERR,"Kspace_modify mesh/disp parameters must be all "
+                   "zero or all positive");
       else gridflag_6 = 1;
       iarg += 4;
     } else if (strcmp(arg[iarg],"order") == 0) {

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -251,6 +251,18 @@ E: Bad kspace_modify slab parameter
 
 Kspace_modify value for the slab/volume keyword must be >= 2.0.
 
+E: Kspace_modify mesh parameter must be all zero or all positive
+
+Valid kspace mesh parameters are >0. The code will try to auto-detect
+suitable values when all three mesh sizes are set to zero (the default).
+
+E: Kspace_modify mesh/disp parameter must be all zero or all positive
+
+Valid kspace mesh/disp parameters are >0. The code will try to auto-detect
+suitable values when all three mesh sizes are set to zero [and]
+the required accuracy via {force/disp/real} as well as
+{force/disp/kspace} is set.
+
 W: Kspace_modify slab param < 2.0 may cause unphysical behavior
 
 The kspace_modify slab parameter should be larger to insure periodic

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -53,6 +53,12 @@
 #include "memory.h"
 #include "error.h"
 
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))
+#pragma GCC optimize ("O0")
+#endif
+#endif
+
 #include "lmpinstalledpkgs.h"
 #include "lmpgitversion.h"
 

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -55,7 +55,7 @@
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))
-#pragma GCC optimize ("no-var-tracking")
+#pragma GCC optimize ("no-var-tracking-assignments")
 #endif
 #endif
 

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -55,7 +55,7 @@
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))
-#pragma GCC optimize ("O0")
+#pragma GCC optimize ("no-var-tracking")
 #endif
 #endif
 
@@ -114,7 +114,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
   initclock = MPI_Wtime();
 
   init_pkg_lists();
-  
+
   // check if -mpi is first arg
   // if so, then 2 apps were launched with one mpirun command
   //   this means passed communicator (e.g. MPI_COMM_WORLD) is bigger than LAMMPS

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -53,12 +53,6 @@
 #include "memory.h"
 #include "error.h"
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
-#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))
-#pragma GCC optimize ("no-var-tracking-assignments")
-#endif
-#endif
-
 #include "lmpinstalledpkgs.h"
 #include "lmpgitversion.h"
 
@@ -902,7 +896,7 @@ void LAMMPS::destroy()
    initialize lists of styles in packages
 ------------------------------------------------------------------------- */
 
-void LAMMPS::init_pkg_lists()
+void _noopt LAMMPS::init_pkg_lists()
 {
   pkg_lists = new package_styles_lists;
 #define PACKAGE "UNKNOWN"
@@ -1002,7 +996,7 @@ void LAMMPS::init_pkg_lists()
 #include "packages_region.h"
 #undef RegionStyle
 #undef REGION_CLASS
-} 
+}
 
 bool LAMMPS::is_installed_pkg(const char *pkg) 
 {
@@ -1045,7 +1039,7 @@ const char *LAMMPS::match_style(const char *style, const char *name)
    help message for command line options and styles present in executable
 ------------------------------------------------------------------------- */
 
-void LAMMPS::help()
+void _noopt LAMMPS::help()
 {
   FILE *fp = screen;
   const char *pager = NULL;

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -179,6 +179,9 @@ typedef int bigint;
 #ifdef _noalias
 #undef _noalias
 #endif
+#ifdef _noopt
+#undef _noopt
+#endif
 
 // define stack variable alignment
 
@@ -198,6 +201,23 @@ typedef int bigint;
 #define _noalias __restrict
 #else
 #define _noalias
+#endif
+
+// declaration to turn off optimization for specific functions
+// and avoid compiler warnings about variable tracking
+
+#if defined(__clang__)
+#  define _noopt __attribute__((optnone))
+#elif defined(__INTEL_COMPILER)
+#  define _noopt
+#elif defined(__GNUC__)
+#  if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))
+#    define _noopt __attribute__((optimize("O0","no-var-tracking-assignments")))
+#  else
+#    define _noopt __attribute__((optimize("O0")))
+#  endif
+#else
+#  define _noopt
 #endif
 
 // settings to enable LAMMPS to build under Windows

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -81,6 +81,11 @@ Modify::Modify(LAMMPS *lmp) : Pointers(lmp)
   ncompute = maxcompute = 0;
   compute = NULL;
 
+  create_factories();
+}
+
+void _noopt Modify::create_factories()
+{
   // fill map with fixes listed in style_fix.h
 
   fix_map = new FixCreatorMap();

--- a/src/modify.h
+++ b/src/modify.h
@@ -172,6 +172,7 @@ class Modify : protected Pointers {
   FixCreatorMap *fix_map;
 
  protected:
+  void create_factories();
   template <typename T> static Compute *compute_creator(LAMMPS *, int, char **);
   template <typename T> static Fix *fix_creator(LAMMPS *, int, char **);
 };

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -46,6 +46,7 @@
 #include "citeme.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 #include <map>
 
@@ -1282,8 +1283,8 @@ void Neighbor::init_topology()
   int bond_off = 0;
   int angle_off = 0;
   for (i = 0; i < modify->nfix; i++)
-    if ((strcmp(modify->fix[i]->style,"shake") == 0)
-        || (strcmp(modify->fix[i]->style,"rattle") == 0))
+    if (utils::strmatch(modify->fix[i]->style,"^shake")
+        || utils::strmatch(modify->fix[i]->style,"^rattle"))
       bond_off = angle_off = 1;
   if (force->bond && force->bond_match("quartic")) bond_off = 1;
 

--- a/src/pair_coul_streitz.cpp
+++ b/src/pair_coul_streitz.cpp
@@ -219,12 +219,6 @@ void PairCoulStreitz::init_style()
       error->all(FLERR,"Pair style requires a KSpace style");
     g_ewald = force->kspace->g_ewald;
   }
-
-  // ptr to QEQ fix
-  //for (i = 0; i < modify->nfix; i++)
-  //  if (strcmp(modify->fix[i]->style,"qeq") == 0) break;
-  //if (i < modify->nfix) fixqeq = (FixQEQ *) modify->fix[i];
-  //else fixqeq = NULL;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -112,7 +112,7 @@ void Velocity::command(int narg, char **arg)
 
   int initcomm = 0;
   if (style == ZERO && rfix >= 0 &&
-      strcmp(modify->fix[rfix]->style,"rigid/small") == 0) initcomm = 1;
+      utils::strmatch(modify->fix[rfix]->style,"^rigid/small")) initcomm = 1;
   if ((style == CREATE || style == SET) && temperature &&
       strcmp(temperature->style,"temp/cs") == 0) initcomm = 1;
 


### PR DESCRIPTION
**Summary**

This pull request combines a variety of small changes and bugfixes

**Related Issues**

This closes #1403 
This supersedes and closes #1491 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes, for valid inputs using `kspace_modify mesh` and `kspace_modify mesh/disp`. Incorrect inputs that may have been accepted before will now be rejected.

**Implementation Notes**

The following individual changes are included:
- nicer formatting of the tables of styles
- require all zero or fully valid inputs of kspace meshes for coulomb and dispersion
- print the message "Gathering installed package information (may take a little while)" earlier in the conventional build process and thus properly inform people on slow file system, that things may be slow, *before* and slow - because of lots of i/o -  operations starts.
- more accurate matching for styles using `utils::strmatch()` so that styles that differ by suffixes are matched correctly as well.
- try to turn off optimization for functions that build "factories" as they can take an excessive time to compile with full optimization for no gain. also for GCC >= 4.4 turn of variable tracking and thus avoid a confusing warning about overflowing the pre-defined space for it.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


