### PR TITLE
cmake: check for immintrin.h

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1134,6 +1134,12 @@ if(PKG_OPT)
 endif()
 
 if(PKG_USER-INTEL)
+  include(CheckIncludeFile)
+  check_include_file(immintrin.h FOUND_IMMINTRIN)
+  if(NOT FOUND_IMMINTRIN)
+    message(FATAL_ERROR "immintrin.h header not found, Intel package won't work without it")
+  endif()
+
   add_definitions(-DLMP_USER_INTEL)
 
   set(INTEL_ARCH "cpu" CACHE STRING "Architectures used by USER-INTEL (cpu or knl)")


### PR DESCRIPTION
**Summary**

Bug fix for plattforms, which don't have `immintrin.h`.

**Related Issues**

`USER-INTEL` won't compile on non-x86 plattforms 

**Author(s)**

@junghans

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

_Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why_

**Implementation Notes**

Yes

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

