### PR TITLE
Fix make install-python for Mac Os X

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -277,7 +277,7 @@ mpi-stubs:
 sinclude ../lib/python/Makefile.lammps
 install-python:
 	@$(PYTHON) ../python/install.py -v ../src/version.h \
-		-m ../python/lammps.py -l ../src/liblammps.*[a-z]
+		-m ../python/lammps.py -l ../src/liblammps.*[dylib,so]
 
 # Create a tarball of src dir and packages
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -277,7 +277,7 @@ mpi-stubs:
 sinclude ../lib/python/Makefile.lammps
 install-python:
 	@$(PYTHON) ../python/install.py -v ../src/version.h \
-		-m ../python/lammps.py -l ../src/liblammps.*[dylib,so]
+		-m ../python/lammps.py -l ../src/liblammps.[!0-9]*[a-z]
 
 # Create a tarball of src dir and packages
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -277,7 +277,7 @@ mpi-stubs:
 sinclude ../lib/python/Makefile.lammps
 install-python:
 	@$(PYTHON) ../python/install.py -v ../src/version.h \
-		-m ../python/lammps.py -l ../src/liblammps.so
+		-m ../python/lammps.py -l ../src/liblammps.*
 
 # Create a tarball of src dir and packages
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -277,7 +277,7 @@ mpi-stubs:
 sinclude ../lib/python/Makefile.lammps
 install-python:
 	@$(PYTHON) ../python/install.py -v ../src/version.h \
-		-m ../python/lammps.py -l ../src/liblammps.*
+		-m ../python/lammps.py -l ../src/liblammps.*[a-z]
 
 # Create a tarball of src dir and packages
 


### PR DESCRIPTION
**Summary**

Fix for make install-python to work with *.dynlib files on Mac Os X 

**Related Issues**

For the previous version I already submitted a similar fix: https://github.com/lammps/lammps/pull/1315

**Author(s)**

Jan Janssen (MPIE) 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes, it is backward compatible 

**Implementation Notes**

I build the conda-forge lammps package for Mac OS X and Linux - both work fine with this patch https://github.com/conda-forge/lammps-feedstock/pull/16 

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**



