### PR TITLE
Simplify and update vim syntax highlighting files

### DIFF
--- a/tools/vim/README.txt
+++ b/tools/vim/README.txt
@@ -22,23 +22,21 @@ in the syntax file (lammps.vim). You can easily add new ones.
 
 (0) Create/edit ~/.vimrc to contain:
          syntax on
-(1) Create directories ~/.vim and ~/.vim/syntax
+(1) Create directories ~/.vim/syntax and ~/.vim/ftdetect
 (2) Copy lammps.vim to ~/.vim/syntax/lammps.vim
-(3) Create/edit ~/.vim/filetype.vim to contain
-
-" vim syntax highlight customizations
-if exists("did_load_filetypes")
- finish
-endif
-
-augroup filetypedetect
- au! BufRead,BufNewFile in.*           setfiletype lammps
- au! BufRead,BufNewFile *.lmp          setfiletype lammps
-augroup END
-(4) the end
+(3) Copy filetype.vim as ~/.vim/ftdetect/lammps.vim
 
 
 Gerolf Ziegenhain <gerolf@ziegenhain.com> 2007
+
+Distribution Packaging guidelines:
+==================================
+
+(0) Copy lammps.vim to ${VIMFILES}/syntax/lammps.vim
+(1) Copy filetype.vim as ${VIMFILES}/ftdetect/lammps.vim
+
+${VIMFILES} is typically /usr/share/vim/vimfiles
+Consult your packaging guidlines for exact location.
 
 ---------------
 

--- a/tools/vim/README.txt
+++ b/tools/vim/README.txt
@@ -7,10 +7,10 @@ end on *.lmp or start with in.* (see mysyntax.vim).
 By far not all commands are included
 in the syntax file (lammps.vim). You can easily add new ones.
 
-=To enable the highlighting:
+=To enable the highlighting (compatible with old versions of VIM):
 ============================
 (0)   Create a ~/.vimrc
-      You can have a look in /usr/local/share/vim/current/vimrc.example
+      You can have a look in /usr/share/vim/vim*/vimrc_example.vim
 (1)   Insert in ~/.vimrc
          let mysyntaxfile = "~/.vim/mysyntax.vim"
       just before
@@ -24,7 +24,7 @@ in the syntax file (lammps.vim). You can easily add new ones.
          syntax on
 (1) Create directories ~/.vim/syntax and ~/.vim/ftdetect
 (2) Copy lammps.vim to ~/.vim/syntax/lammps.vim
-(3) Copy filetype.vim as ~/.vim/ftdetect/lammps.vim
+(3) Copy filetype.vim to ~/.vim/ftdetect/lammps.vim
 
 
 Gerolf Ziegenhain <gerolf@ziegenhain.com> 2007

--- a/tools/vim/filetype.vim
+++ b/tools/vim/filetype.vim
@@ -1,0 +1,4 @@
+augroup filetypedetect
+ au! BufRead,BufNewFile in.*           setfiletype lammps
+ au! BufRead,BufNewFile *.lmp          setfiletype lammps
+augroup END

--- a/tools/vim/lammps.vim
+++ b/tools/vim/lammps.vim
@@ -2,25 +2,26 @@
 " Language:	         Lammps Simulation Script File
 " Maintainer:        Gerolf Ziegenhain <gerolf@ziegenhain.com>
 " Updates:           Axel Kohlmeyer <akohlmey@gmail.com>, Sam Bateman <sam.bateman@nrlssc.navy.mil>, Daniel Möller Montull <d.moller.m@gmail.com>
-" Latest Revision:   2012-06-19
+" Latest Revision:   2019-06-11
 
 syn clear
 
-syn keyword	lammpsOutput	log write_restart restart dump undump thermo thermo_modify thermo_style print 
-syn keyword	lammpsRead	include read read_restart read_data
+syn keyword	lammpsOutput	log write_data write_dump info shell write_restart restart dump undump thermo thermo_modify thermo_style print timer
+syn keyword	lammpsRead	include read_restart read_data read_dump molecule
 syn keyword	lammpsLattice	boundary units atom_style lattice region create_box create_atoms dielectric
-syn keyword	lammpsLattice	delete_atoms change_box dimension replicate
-syn keyword	lammpsParticle	pair_coeff pair_style pair_modify mass velocity angle_coeff angle_style
-syn keyword	lammpsParticle	atom_modify atom_style bond_coeff bond_style delete_bonds kspace_style
+syn keyword	lammpsLattice	delete_atoms displace_atoms change_box dimension replicate
+syn keyword	lammpsParticle	pair_coeff pair_style pair_modify pair_write mass velocity angle_coeff angle_style
+syn keyword	lammpsParticle	atom_modify atom_style bond_coeff bond_style bond_write create_bonds delete_bonds kspace_style
 syn keyword	lammpsParticle	kspace_modify dihedral_style dihedral_coeff improper_style improper_coeff
-syn keyword	lammpsSetup	min_style fix_modify run_style timestep neighbor neigh_modify fix unfix
-syn keyword	lammpsSetup	communicate newton nthreads processors reset_timestep
-syn keyword	lammpsRun	minimize run  
-syn keyword	lammpsDefine	variable group compute
+syn keyword	lammpsSetup	min_style fix_modify run_style timestep neighbor neigh_modify fix unfix suffix special_bonds
+syn keyword	lammpsSetup	balance box clear comm_modify comm_style newton package processors reset_ids reset_timestep
+syn keyword	lammpsRun	minimize run rerun tad neb prd quit server temper temper/grem temper/npt
+syn keyword	lammpsRun	min/spin message hyper dynamical_matrix
+syn keyword	lammpsDefine	variable group compute python set uncompute kim_query
 
 syn keyword	lammpsRepeat	jump next loop
 
-syn keyword	lammpsOperator	equal add sub mult div 
+syn keyword	lammpsOperator	equal add sub mult div
 
 syn keyword	lammpsConditional if then elif else
 


### PR DESCRIPTION
**Summary**

- Packaging instructions for vim syntax files
- Put file-type-detect instructions in a file
- Update list of known LAMMPS keywords

**Related Issues**

Closes #1500

**Author(s)**

Vishnu V. Krishnan (vishnugb -at- gmail.com)
Tata Institute of Fundamental Research, Hyderabad

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.

**Implementation Notes**

I verified that both forms of using the syntax files: (a) in `~/.vim/` and (b) in the typical location for vim-files in linux, allows for syntax highlighting to work when using Vim.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] A package specific README file has been included or updated
