### PR TITLE
Bugfix for bond_style table with MPI

### DIFF
--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -503,7 +503,7 @@ void BondTable::param_extract(Table *tb, char *line)
 void BondTable::bcast_table(Table *tb)
 {
   MPI_Bcast(&tb->ninput,1,MPI_INT,0,world);
-  MPI_Bcast(&tb->r0,1,MPI_INT,0,world);
+  MPI_Bcast(&tb->r0,1,MPI_DOUBLE,0,world);
 
   int me;
   MPI_Comm_rank(world,&me);

--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -522,7 +522,6 @@ void BondTable::bcast_table(Table *tb)
     MPI_Bcast(&tb->fplo,1,MPI_DOUBLE,0,world);
     MPI_Bcast(&tb->fphi,1,MPI_DOUBLE,0,world);
   }
-  MPI_Bcast(&tb->r0,1,MPI_INT,0,world);
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

Very small bug fix - an incorrect MPI datatype was causing undefined behaviour for tabulated bond potentials (bond_style table).

**Related Issues**

None known

**Author(s)**

Sam Niblett, LBNL

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No impact

**Implementation Notes**

The equilibrium bond length of the tabulated potential (tb->r0) was incorrectly specified as an MPI_INT during a broadcast. Therefore, all non-root processes received a truncated value of this parameter. This simple fix produced the expected behaviour for me.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

