### PR TITLE
Add keyword hybridpair for compute_pressure

### DIFF
--- a/doc/src/compute_pressure.txt
+++ b/doc/src/compute_pressure.txt
@@ -16,12 +16,13 @@ ID, group-ID are documented in "compute"_compute.html command
 pressure = style name of this compute command
 temp-ID = ID of compute that calculates temperature, can be NULL if not needed
 zero or more keywords may be appended
-keyword = {ke} or {pair} or {bond} or {angle} or {dihedral} or {improper} or {kspace} or {fix} or {virial} :ul
+keyword = {ke} or {pair} or {bond} or {angle} or {dihedral} or {improper} or {kspace} or {fix} or {virial} or {hybridpair} :ul
 
 [Examples:]
 
 compute 1 all pressure thermo_temp
-compute 1 all pressure NULL pair bond :pre
+compute 1 all pressure NULL pair bond
+compute 1 all pressure NULL hybridpair lj/cut :pre
 
 [Description:]
 
@@ -66,6 +67,9 @@ virial as the sum of pair, bond, angle, dihedral, improper, kspace
 extra keywords are listed, then only those components are summed to
 compute temperature or ke and/or the virial.  The {virial} keyword
 means include all terms except the kinetic energy {ke}.
+
+The {hybridpair} keyword means to only include contribution
+from a subpair in a {hybrid} or {hybrid/overlay} pair style.
 
 Details of how LAMMPS computes the virial efficiently for the entire
 system, including for many-body potentials and accounting for the

--- a/doc/src/compute_pressure.txt
+++ b/doc/src/compute_pressure.txt
@@ -16,7 +16,7 @@ ID, group-ID are documented in "compute"_compute.html command
 pressure = style name of this compute command
 temp-ID = ID of compute that calculates temperature, can be NULL if not needed
 zero or more keywords may be appended
-keyword = {ke} or {pair} or {bond} or {angle} or {dihedral} or {improper} or {kspace} or {fix} or {virial} or {hybridpair} :ul
+keyword = {ke} or {pair} or {bond} or {angle} or {dihedral} or {improper} or {kspace} or {fix} or {virial} or {pair/hybrid} :ul
 
 [Examples:]
 
@@ -68,7 +68,7 @@ extra keywords are listed, then only those components are summed to
 compute temperature or ke and/or the virial.  The {virial} keyword
 means include all terms except the kinetic energy {ke}.
 
-The {hybridpair} keyword means to only include contribution
+The {pair/hybrid} keyword means to only include contribution
 from a sub-style in a {hybrid} or {hybrid/overlay} pair style.
 
 Details of how LAMMPS computes the virial efficiently for the entire

--- a/doc/src/compute_pressure.txt
+++ b/doc/src/compute_pressure.txt
@@ -22,7 +22,7 @@ keyword = {ke} or {pair} or {bond} or {angle} or {dihedral} or {improper} or {ks
 
 compute 1 all pressure thermo_temp
 compute 1 all pressure NULL pair bond
-compute 1 all pressure NULL hybridpair lj/cut :pre
+compute 1 all pressure NULL pair/hybrid lj/cut :pre
 
 [Description:]
 

--- a/doc/src/compute_pressure.txt
+++ b/doc/src/compute_pressure.txt
@@ -69,7 +69,7 @@ compute temperature or ke and/or the virial.  The {virial} keyword
 means include all terms except the kinetic energy {ke}.
 
 The {hybridpair} keyword means to only include contribution
-from a subpair in a {hybrid} or {hybrid/overlay} pair style.
+from a sub-style in a {hybrid} or {hybrid/overlay} pair style.
 
 Details of how LAMMPS computes the virial efficiently for the entire
 system, including for many-body potentials and accounting for the

--- a/src/compute_pressure.cpp
+++ b/src/compute_pressure.cpp
@@ -87,7 +87,7 @@ ComputePressure::ComputePressure(LAMMPS *lmp, int narg, char **arg) :
         pstyle = new char[n];
         strcpy(pstyle,arg[iarg++]);
 
-        nsub = 0;
+        int nsub = 0;
 
         if (narg > iarg) {
           if (isdigit(arg[iarg][0])) {

--- a/src/compute_pressure.cpp
+++ b/src/compute_pressure.cpp
@@ -67,7 +67,7 @@ ComputePressure::ComputePressure(LAMMPS *lmp, int narg, char **arg) :
 
   // process optional args
 
-  hybridpairflag = 0;
+  pairhybridflag = 0;
   if (narg == 4) {
     keflag = 1;
     pairflag = 1;
@@ -81,7 +81,7 @@ ComputePressure::ComputePressure(LAMMPS *lmp, int narg, char **arg) :
     int iarg = 4;
     while (iarg < narg) {
       if (strcmp(arg[iarg],"ke") == 0) keflag = 1;
-      else if (strcmp(arg[iarg],"hybridpair") == 0) {
+      else if (strcmp(arg[iarg],"pair/hybrid") == 0) {
         int n = strlen(arg[++iarg]) + 1;
         if (lmp->suffix) n += strlen(lmp->suffix) + 1;
         pstyle = new char[n];
@@ -100,17 +100,17 @@ ComputePressure::ComputePressure(LAMMPS *lmp, int narg, char **arg) :
 
         // check if pair style with and without suffix exists
 
-        hybridpair = (Pair *) force->pair_match(pstyle,1,nsub);
-        if (!hybridpair && lmp->suffix) {
+        pairhybrid = (Pair *) force->pair_match(pstyle,1,nsub);
+        if (!pairhybrid && lmp->suffix) {
           strcat(pstyle,"/");
           strcat(pstyle,lmp->suffix);
-          hybridpair = (Pair *) force->pair_match(pstyle,1,nsub);
+          pairhybrid = (Pair *) force->pair_match(pstyle,1,nsub);
         }
 
-        if (!hybridpair)
+        if (!pairhybrid)
           error->all(FLERR,"Unrecognized pair style in compute pressure command");
 
-        hybridpairflag = 1;
+        pairhybridflag = 1;
       }
       else if (strcmp(arg[iarg],"pair") == 0) pairflag = 1;
       else if (strcmp(arg[iarg],"bond") == 0) bondflag = 1;
@@ -173,7 +173,7 @@ void ComputePressure::init()
   nvirial = 0;
   vptr = NULL;
 
-  if (hybridpairflag && force->pair) nvirial++;
+  if (pairhybridflag && force->pair) nvirial++;
   if (pairflag && force->pair) nvirial++;
   if (bondflag && atom->molecular && force->bond) nvirial++;
   if (angleflag && atom->molecular && force->angle) nvirial++;
@@ -186,10 +186,10 @@ void ComputePressure::init()
   if (nvirial) {
     vptr = new double*[nvirial];
     nvirial = 0;
-    if (hybridpairflag && force->pair) {
+    if (pairhybridflag && force->pair) {
       PairHybrid *ph = (PairHybrid *) force->pair;
       ph->no_virial_fdotr_compute = 1;
-      vptr[nvirial++] = hybridpair->virial;
+      vptr[nvirial++] = pairhybrid->virial;
     }
     if (pairflag && force->pair) vptr[nvirial++] = force->pair->virial;
     if (bondflag && force->bond) vptr[nvirial++] = force->bond->virial;

--- a/src/compute_pressure.cpp
+++ b/src/compute_pressure.cpp
@@ -87,7 +87,7 @@ ComputePressure::ComputePressure(LAMMPS *lmp, int narg, char **arg) :
         pstyle = new char[n];
         strcpy(pstyle,arg[iarg++]);
 
-        int nsub = 0;
+        nsub = 0;
 
         if (narg > iarg) {
           if (isdigit(arg[iarg][0])) {
@@ -164,6 +164,20 @@ void ComputePressure::init()
     if (icompute < 0)
       error->all(FLERR,"Could not find compute pressure temperature ID");
     temperature = modify->compute[icompute];
+  }
+
+  // recheck if pair style with and without suffix exists
+
+  if (pairhybridflag) {
+    pairhybrid = (Pair *) force->pair_match(pstyle,1,nsub);
+    if (!pairhybrid && lmp->suffix) {
+      strcat(pstyle,"/");
+      strcat(pstyle,lmp->suffix);
+      pairhybrid = (Pair *) force->pair_match(pstyle,1,nsub);
+    }
+
+    if (!pairhybrid)
+      error->all(FLERR,"Unrecognized pair style in compute pressure command");
   }
 
   // detect contributions to virial

--- a/src/compute_pressure.h
+++ b/src/compute_pressure.h
@@ -41,6 +41,7 @@ class ComputePressure : public Compute {
   Compute *temperature;
   char *id_temp;
   double virial[6];
+  int hybridpairflag;
   int keflag,pairflag,bondflag,angleflag,dihedralflag,improperflag;
   int fixflag,kspaceflag;
 

--- a/src/compute_pressure.h
+++ b/src/compute_pressure.h
@@ -41,8 +41,8 @@ class ComputePressure : public Compute {
   Compute *temperature;
   char *id_temp;
   double virial[6];
-  int hybridpairflag;
-  class Pair *hybridpair;
+  int pairhybridflag;
+  class Pair *pairhybrid;
   int keflag,pairflag,bondflag,angleflag,dihedralflag,improperflag;
   int fixflag,kspaceflag;
 

--- a/src/compute_pressure.h
+++ b/src/compute_pressure.h
@@ -42,10 +42,15 @@ class ComputePressure : public Compute {
   char *id_temp;
   double virial[6];
   int hybridpairflag;
+  class Pair *hybridpair;
   int keflag,pairflag,bondflag,angleflag,dihedralflag,improperflag;
   int fixflag,kspaceflag;
 
   void virial_compute(int, int);
+
+ private:
+  int nsub;
+  char *pstyle;
 };
 
 }

--- a/src/compute_pressure.h
+++ b/src/compute_pressure.h
@@ -49,7 +49,6 @@ class ComputePressure : public Compute {
   void virial_compute(int, int);
 
  private:
-  int nsub;
   char *pstyle;
 };
 

--- a/src/compute_pressure.h
+++ b/src/compute_pressure.h
@@ -50,6 +50,7 @@ class ComputePressure : public Compute {
 
  private:
   char *pstyle;
+  int nsub;
 };
 
 }

--- a/src/pair_hybrid.h
+++ b/src/pair_hybrid.h
@@ -33,6 +33,7 @@ class PairHybrid : public Pair {
   friend class Respa;
   friend class Info;
   friend class PairDeprecated;
+  friend class ComputePressure;
  public:
   PairHybrid(class LAMMPS *);
   virtual ~PairHybrid();

--- a/src/pair_hybrid.h
+++ b/src/pair_hybrid.h
@@ -33,7 +33,6 @@ class PairHybrid : public Pair {
   friend class Respa;
   friend class Info;
   friend class PairDeprecated;
-  friend class ComputePressure;
  public:
   PairHybrid(class LAMMPS *);
   virtual ~PairHybrid();


### PR DESCRIPTION
Add the keyword hybridpair in compute_pressure

**Summary**

_Add the possibility to use compute_pressure only on a pair type when using `hybrid` or `hybrid/overlay` with multiple pair types_

**Author(s)**

_Alain Dequidt_
_Julien Devemy_

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


