### PR TITLE
Extend support of "rotate" keyword to all styles of "create_atoms"

### DIFF
--- a/doc/src/create_atoms.txt
+++ b/doc/src/create_atoms.txt
@@ -242,9 +242,8 @@ write_dump      all atom sinusoid.lammpstrj :pre
 
 :c,image(JPG/sinusoid_small.jpg,JPG/sinusoid.jpg)
 
-The {rotate} keyword can only be used with the {single} style and
-when adding a single molecule. It allows to specify the orientation
-at which the molecule is inserted.  The axis of rotation is
+The {rotate} keyword allows to specify the orientation
+at which molecules are inserted.  The axis of rotation is
 determined by the rotation vector (Rx,Ry,Rz) that goes through the
 insertion point.  The specified {theta} determines the angle of
 rotation around that axis.  Note that the direction of rotation for

--- a/doc/src/create_atoms.txt
+++ b/doc/src/create_atoms.txt
@@ -242,7 +242,7 @@ write_dump      all atom sinusoid.lammpstrj :pre
 
 :c,image(JPG/sinusoid_small.jpg,JPG/sinusoid.jpg)
 
-The {rotate} keyword allows to specify the orientation
+The {rotate} keyword allows specification of the orientation
 at which molecules are inserted.  The axis of rotation is
 determined by the rotation vector (Rx,Ry,Rz) that goes through the
 insertion point.  The specified {theta} determines the angle of

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -176,8 +176,6 @@ void CreateAtoms::command(int narg, char **arg)
       } else error->all(FLERR,"Illegal create_atoms command");
       iarg += 3;
     } else if (strcmp(arg[iarg],"rotate") == 0) {
-      if (style != SINGLE)
-        error->all(FLERR,"Cannot use create_atoms rotate unless single style");
       if (iarg+5 > narg) error->all(FLERR,"Illegal create_atoms command");
       double thetaone;
       double axisone[3];
@@ -678,7 +676,9 @@ void CreateAtoms::add_random()
         coord[1] >= sublo[1] && coord[1] < subhi[1] &&
         coord[2] >= sublo[2] && coord[2] < subhi[2]) {
       if (mode == ATOM) atom->avec->create_atom(ntype,xone);
-      else add_molecule(xone);
+      else if (quatone[0] == 0 && quatone[1] == 0 && quatone[2] == 0)
+        add_molecule(xone);
+      else add_molecule(xone, quatone);
     }
   }
 
@@ -832,7 +832,9 @@ void CreateAtoms::add_lattice()
           // add the atom or entire molecule to my list of atoms
 
           if (mode == ATOM) atom->avec->create_atom(basistype[m],x);
-          else add_molecule(x);
+          else if (quatone[0] == 0 && quatone[1] == 0 && quatone[2] == 0)
+            add_molecule(x);
+          else add_molecule(x,quatone);
         }
       }
     }


### PR DESCRIPTION
**Summary**

This PR adds support for `rotate` keyword to all styles of `create_atoms`. It is useful if, for example, one wants to create a molecular crystal with lattice different than simple cubic. 

**Related Issues**

None

**Author(s)**

Michał Kański, Jagiellonian University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Full

**Implementation Notes**

The logic from `CreateAtoms::add_single()` has been used in other methods. 

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


