### PR TITLE
Make USER-TALLY compute styles compatible with hybrid pair styles

### DIFF
--- a/src/USER-TALLY/README
+++ b/src/USER-TALLY/README
@@ -21,7 +21,7 @@ The person who created this package is Axel Kohlmeyer (akohlmey@gmail.com)
 at Temple University with a little help and inspiration from
 Loris Ercole (SISSA/ISAS Trieste), who contributed compute heat/flux/tally.
 
-Additional contributed compute style for this package are welcome.
+Additional contributed compute styles for this package are welcome.
 Please contact Axel, if you have questions about the implementation.
 
 

--- a/src/USER-TALLY/compute_force_tally.cpp
+++ b/src/USER-TALLY/compute_force_tally.cpp
@@ -85,6 +85,11 @@ void ComputeForceTally::init()
 
 void ComputeForceTally::pair_setup_callback(int, int)
 {
+  // run setup only once per time step.
+  // we may be called from multiple pair styles
+
+  if (did_setup == update->ntimestep) return;
+
   const int ntotal = atom->nlocal + atom->nghost;
 
   // grow per-atom storage, if needed

--- a/src/USER-TALLY/compute_heat_flux_tally.cpp
+++ b/src/USER-TALLY/compute_heat_flux_tally.cpp
@@ -87,6 +87,11 @@ void ComputeHeatFluxTally::init()
 /* ---------------------------------------------------------------------- */
 void ComputeHeatFluxTally::pair_setup_callback(int, int)
 {
+  // run setup only once per time step.
+  // we may be called from multiple pair styles
+
+  if (did_setup == update->ntimestep) return;
+
   const int ntotal = atom->nlocal + atom->nghost;
 
   // grow per-atom storage, if needed

--- a/src/USER-TALLY/compute_pe_mol_tally.cpp
+++ b/src/USER-TALLY/compute_pe_mol_tally.cpp
@@ -82,6 +82,11 @@ void ComputePEMolTally::init()
 
 void ComputePEMolTally::pair_setup_callback(int, int)
 {
+  // run setup only once per time step.
+  // we may be called from multiple pair styles
+
+  if (did_setup == update->ntimestep) return;
+
   etotal[0] = etotal[1] = etotal[2] = etotal[3] = 0.0;
   did_setup = update->ntimestep;
 }

--- a/src/USER-TALLY/compute_pe_tally.cpp
+++ b/src/USER-TALLY/compute_pe_tally.cpp
@@ -84,6 +84,11 @@ void ComputePETally::init()
 
 void ComputePETally::pair_setup_callback(int, int)
 {
+  // run setup only once per time step.
+  // we may be called from multiple pair styles
+
+  if (did_setup == update->ntimestep) return;
+
   const int ntotal = atom->nlocal + atom->nghost;
 
   // grow per-atom storage, if needed

--- a/src/USER-TALLY/compute_stress_tally.cpp
+++ b/src/USER-TALLY/compute_stress_tally.cpp
@@ -87,6 +87,11 @@ void ComputeStressTally::init()
 
 void ComputeStressTally::pair_setup_callback(int, int)
 {
+  // run setup only once per time step.
+  // we may be called from multiple pair styles
+
+  if (did_setup == update->ntimestep) return;
+
   const int ntotal = atom->nlocal + atom->nghost;
 
   // grow per-atom storage, if needed


### PR DESCRIPTION
**Summary**

This change corrects handling of hybrid pair styles with computes from the USER-TALLY package

**Related Issues**

closes #1509 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

**Implementation Notes**

We have to check whether the setup call back has been run already at this time step and in that case simply return. This may break when people do multiple `run 0 pre no`, but that is not guaranteed to work for complex things anyway.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] A package specific README file has been included or updated

