### PR TITLE
Using PLUMED to compute committor with LAMMPS

### DIFF
--- a/src/USER-PLUMED/fix_plumed.cpp
+++ b/src/USER-PLUMED/fix_plumed.cpp
@@ -406,6 +406,8 @@ void FixPlumed::post_force(int /* vflag */)
 
   // pass all pointers to plumed:
   p->cmd("setStep",&step);
+  int plumedStopCondition=0; 
+  p->cmd("setStopFlag",&plumedStopCondition);
   p->cmd("setPositions",&atom->x[0][0]);
   p->cmd("setBox",&box[0][0]);
   p->cmd("setForces",&atom->f[0][0]);
@@ -477,6 +479,8 @@ void FixPlumed::post_force(int /* vflag */)
   }
   // do the real calculation:
   p->cmd("performCalc");
+
+  if(plumedStopCondition) error->all(FLERR,"received instruction from PLUMED to stop");
 
   // retransform virial to lammps representation and assign it to this
   // fix's virial. If the energy is biased, Plumed is giving back the full

--- a/src/USER-PLUMED/fix_plumed.cpp
+++ b/src/USER-PLUMED/fix_plumed.cpp
@@ -34,6 +34,7 @@
 #include "modify.h"
 #include "pair.h"
 #include "utils.h"
+#include "timer.h"
 
 #include "plumed/wrapper/Plumed.h"
 
@@ -480,7 +481,7 @@ void FixPlumed::post_force(int /* vflag */)
   // do the real calculation:
   p->cmd("performCalc");
 
-  if(plumedStopCondition) error->all(FLERR,"received instruction from PLUMED to stop");
+  if(plumedStopCondition) timer->force_timeout();
 
   // retransform virial to lammps representation and assign it to this
   // fix's virial. If the energy is biased, Plumed is giving back the full


### PR DESCRIPTION
…if it needs to.  This would be needed if you were computing committors for example

**Summary**

This is a small change to the interface between LAMMPS and PLUMED.  This change has been made to address a feature that was asked for by a user.  I am not sure that this is the correct way to do things on the LAMMPS side or even if this is a sensible way to implement the particular method that the user asked for.

Essentially the feature added here allows PLUMED to stop the LAMMPS calculation when some condition is satisfied.  This would be useful if you were calculating a committor or something similar.  The way that this is implemented is that LAMMPS passes PLUMED an integer that has a value of 0.  If PLUMED wants to stop LAMMPS then it sets this integer equal to 1.  LAMMPS then checks the value of the int and if it is not zero it throws an error and thus stops the calculation.

I throw an error as I wasn't sure what method to use to stop the calculation otherwise.  My worry is that the user might, for instance, have multiple run cycles in the single lammps input and want these additional runs to execute once the first one finishes and arrives at the point when PLUMED tells it to stop.  Alternatively, there might be some analysis of the output after the stop point, which wouldn't be executed because the error was thrown.  At the same time though it may be that the error is the right thing to throw as the user could perhaps have things after the run command that require the full number of steps that was asked for.  

I would appreciate some advice on what you think is the correct way to do this or if doing this sort of calculation even makes sense at all.  Thanks in advance.  

**Related Issues**

This does not address a GitHub issue

**Author(s)**

Gareth Tribello, Queen's University Belfast

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This does not affect backwards compatibility.  

**Implementation Notes**

I ran the tests on the interface that I developed and placed on Travis-ci locally when I built the interface between PLUMED and lammps and they still all give the same results.  I also checked that PLUMED can indeed stop lammps.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**

No changes were made to the documentation because the way these features would be used is documented on the PLUMED website.

