### PR TITLE
Nose-Hoover simulations with fixed volume and flexible cell shape

### DIFF
--- a/doc/src/fix_nh.txt
+++ b/doc/src/fix_nh.txt
@@ -25,7 +25,7 @@ fix ID group-ID style_name keyword value ... :pre
 ID, group-ID are documented in "fix"_fix.html command :ulb,l
 style_name = {nvt} or {npt} or {nph} :l
 one or more keyword/value pairs may be appended :l
-keyword = {temp} or {iso} or {aniso} or {tri} or {x} or {y} or {z} or {xy} or {yz} or {xz} or {couple} or {tchain} or {pchain} or {mtk} or {tloop} or {ploop} or {nreset} or {drag} or {dilate} or {scalexy} or {scaleyz} or {scalexz} or {flip} or {fixedpoint} or {update}
+keyword = {temp} or {iso} or {aniso} or {tri} or {x} or {y} or {z} or {xy} or {yz} or {xz} or {couple} or {tchain} or {pchain} or {mtk} or {tloop} or {ploop} or {nreset} or {drag} or {dilate} or {scalexy} or {scaleyz} or {scalexz} or {flip} or {fixedpoint} or {update} or {fixvolume}
   {temp} values = Tstart Tstop Tdamp
     Tstart,Tstop = external temperature at start/end of run
     Tdamp = temperature damping parameter (time units)
@@ -58,7 +58,8 @@ keyword = {temp} or {iso} or {aniso} or {tri} or {x} or {y} or {z} or {xy} or {y
     x,y,z = perform barostat dilation/contraction around this point (distance units)
   {update} value = {dipole} or {dipole/dlm}
     dipole = update dipole orientation (only for sphere variants)
-    dipole/dlm = use DLM integrator to update dipole orientation (only for sphere variants) :pre
+    dipole/dlm = use DLM integrator to update dipole orientation (only for sphere variants)
+  {fixvolume} value = {yes} or {no} :pre
 :ule
 
 [Examples:]
@@ -141,7 +142,7 @@ they represent are varied together during a constant-pressure
 simulation.
 
 Other barostat-related keywords are {pchain}, {mtk}, {ploop},
-{nreset}, {drag}, and {dilate}, which are discussed below.
+{nreset}, {drag}, {dilate}, and {fixvolume} which are discussed below.
 
 Orthogonal simulation boxes have 3 adjustable dimensions (x,y,z).
 Triclinic (non-orthogonal) simulation boxes have 6 adjustable
@@ -251,6 +252,21 @@ xy 0.0 0.0 Pdamp
 yz 0.0 0.0 Pdamp
 xz 0.0 0.0 Pdamp
 couple none :pre
+
+:line
+
+When the {fixvolume} keyword is set to {yes}, the (N, V, sigma_a=0, T)
+ensemble is sampled. In this ensemble, the volume and the deviatoric stress
+are controlled, but the cell shape and isotropic pressure are unconstrained,
+as described in "(Rogge)"_#nh-Rogge. This ensemble can be used to obtain the
+pressure as a function of the cell volume for flexible materials.
+If {fixvolume yes} is specified, it is required that a Nose-Hoover barostat
+is specified using the {npt} command. Do note that the values of {Pstart}
+and {Pstop} are irrelevant for these simulations. Obviously, the cell shape
+has to be flexible when {fixvolume yes} is specified, which can be done by
+including the {tri} keyword.
+An example of usage can be found in the
+examples/USER/yaff/mil53al_pressure_profile directory
 
 :line
 
@@ -619,6 +635,9 @@ and barostat are defined for systems with a static set of atoms.  You
 may observe odd behavior if the atoms in a group vary dramatically
 over time or the atom count becomes very small.
 
+The {fixvolume yes} keyword/value pair can only be used for 3D simulations
+where a Nose-Hoover barostat with a fully flexible cell shape is used.
+
 [Related commands:]
 
 "fix nve"_fix_nve.html, "fix_modify"_fix_modify.html,
@@ -629,7 +648,8 @@ over time or the atom count becomes very small.
 The keyword defaults are tchain = 3, pchain = 3, mtk = yes, tloop = 1,
 ploop = 1, nreset = 0, drag = 0.0, dilate = all, couple = none,
 flip = yes, scaleyz = scalexz = scalexy = yes if periodic in 2nd
-dimension and not coupled to barostat, otherwise no.
+dimension and not coupled to barostat, otherwise no,
+fixvolume = no.
 
 :line
 
@@ -649,3 +669,7 @@ Martyna, J Phys A: Math Gen, 39, 5629 (2006).
 :link(nh-Dullweber)
 [(Dullweber)] Dullweber, Leimkuhler and McLachlan, J Chem Phys, 107,
 5840 (1997).
+
+:link(nh-Rogge)
+[(Rogge)] Rogge, Vanduyfhuys, Ghysels, Waroquier, Verstraelen, Maurin, 
+and Van Speybroeck, J Chem Theory Comput, 11, 5583-5597 (2015).

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -849,6 +849,7 @@ Finchham
 Finnis
 Fiorin
 fixID
+fixvolume
 fj
 Fji
 flagfld
@@ -949,6 +950,7 @@ Gezelter
 Gflop
 gfortran
 ghostwhite
+Ghysels
 Giacomo
 gif
 gifsicle
@@ -1557,6 +1559,7 @@ matlab
 matplotlib
 Mattox
 Mattson
+Maurin
 maxangle
 maxbond
 maxelt
@@ -2386,6 +2389,7 @@ ro
 Rochus
 Rockett
 Rodrigues
+Rogge
 Rohart
 Ronchetti
 Rosati
@@ -2549,6 +2553,7 @@ sp
 spacings
 Spearot
 Spellmeyer
+Speybroeck
 sph
 SPH
 Spickermann
@@ -2900,6 +2905,7 @@ Verlag
 verlet
 Verlet
 versa
+Verstraelen
 ves
 vhi
 vibrational
@@ -2963,6 +2969,7 @@ Wadley
 wallstyle
 walltime
 Waltham
+Waroquier
 wavepacket
 wB
 Wbody

--- a/examples/USER/yaff/README
+++ b/examples/USER/yaff/README
@@ -5,3 +5,10 @@ mil53al:
     NPT simulation of MIL-53(Al) using a QuickFF force field.
     If the pressure is high enough (for instance 2000 atm),
     a phase transition from large pore to narrow pore is observed
+
+mil53al_pressure_profile:
+    Construct the pressure profile as a function of the volume,
+    by performing fixed-volume simulations. Starting configurations
+    are extracted from an NPT simulation (see mil53al directory)
+    Theoretical background is provided in
+    https://pubs.acs.org/doi/10.1021/acs.jctc.5b00748

--- a/examples/USER/yaff/mil53al_pressure_profile/README
+++ b/examples/USER/yaff/mil53al_pressure_profile/README
@@ -1,0 +1,24 @@
+This example shows how to construct the pressure profile as a function of the
+volume. Theoretical background is provided in
+https://pubs.acs.org/doi/10.1021/acs.jctc.5b00748
+It is advised to use significantly longer simulation times for serious
+production runs.
+
+Step 1:
+    Run one or more NPT simulations. For this example the necessary files are
+    in ../mil53al Make sure that all volumes you are interested in, are
+    sampled during these simulations.
+
+Step 2:
+    Use the prepare.py script to generate the input files for the fixed-volume
+    simulations. The script will extract initial configurations from the NPT
+    simulations in step 1 that are close to the volumes for which you want to
+    compute the pressure.
+
+Step 3:
+    Run all fixed-volume simulations using the run_fixed_volume.sh script
+
+Step 4:
+    Use the postprocess.py script to read the average pressure from each
+    fixed-volume simulation. Using thermodynamic integration, also the free
+    energy profile can be obtained.

--- a/examples/USER/yaff/mil53al_pressure_profile/postprocess.py
+++ b/examples/USER/yaff/mil53al_pressure_profile/postprocess.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+from __future__ import division
+
+import numpy as np
+import os
+from glob import glob
+import subprocess
+from scipy import interpolate
+import matplotlib.pyplot as plt
+import matplotlib
+
+def read_lammps_volumes_pressures(fn):
+    '''Read time, volume and pressure from LAMMPS log file'''
+    out,err = subprocess.Popen(["grep","Time",fn],stdout=subprocess.PIPE,stderr=subprocess.PIPE).communicate()
+    time = []
+    for line in out.decode().split('\n'):
+        w = line.split()
+        if len(w)!=9: continue
+        time.append(float(w[5]))
+    time = np.asarray(time)
+    out,err = subprocess.Popen(["grep","Volume",fn],stdout=subprocess.PIPE,stderr=subprocess.PIPE).communicate()
+    volumes = []
+    for line in out.decode().split('\n'):
+        w = line.split()
+        if len(w)!=9: continue
+        volumes.append(float(w[-1]))
+    volumes = np.asarray(volumes)
+    out,err = subprocess.Popen(["grep","Press",fn],stdout=subprocess.PIPE,stderr=subprocess.PIPE).communicate()
+    pressures = []
+    for line in out.decode().split('\n'):
+        w = line.split()
+        if len(w)!=3: continue
+        pressures.append(float(w[2]))
+    pressures = np.asarray(pressures)
+    imax = np.amin([pressures.shape[0], volumes.shape[0], time.shape[0]])
+    return time[:imax], volumes[:imax], pressures[:imax]
+
+def thermo_integration_spline(v0,p0):
+    '''
+    Integrate the pressure over the volume to obtain the free energy.
+    '''
+    # Set the spacing of the interior knots:
+    # low values result in a spline that follows data closely, but might be noisy
+    # high values result in a spline that is smooth, but might deviate from data
+    window = 5
+    # Construct the spline
+    spline = interpolate.LSQUnivariateSpline(v0, p0, v0[1:-1:window])
+    # Find roots with negative slope
+    dp_spline = spline.derivative()
+    roots = spline.roots()
+    roots = roots[dp_spline(roots)<0.0]
+#    dp_spline2 = interpolate.LSQUnivariateSpline(v0, dp_spline(v0), v0[1:-1:window])
+    assert roots.shape[0] == 1 
+    trans_pressures = np.amax(p0)
+    # Evaluate spline at volume points
+    p0_spline = spline(v0)
+    # Integrate spline
+    spline_int = spline.antiderivative()
+    # Evaluate minus the integral at volume points, this is the free energy
+    f0_spline = -spline_int(v0)
+    # Shift free energy so minimum equals zero
+    f0_spline -= np.amin(f0_spline)
+    f_minima = -spline_int(roots)
+    f_minima -= np.amin(f_minima)
+    return f0_spline, p0_spline, roots, f_minima, trans_pressures
+
+if __name__=='__main__':
+    # The same units as in the LAMMPS scripts are retained, in this case real
+    # units. For example time in femtoseconds, volume in A**3, pressure in atm, ...
+    teq = 2500 # Only include samples beyond teq for calculating averages
+    # Collect data from all fixed-volume simulations
+    pattern = 'nvst*/lammps.out'
+    fns = sorted(glob(pattern))
+    data = []
+    for fn in fns:
+        dn = os.path.dirname(fn)
+        time, volume, pressure = read_lammps_volumes_pressures(fn)
+        mask = time>teq
+        if np.sum(mask)==0: continue
+        tmax = time[-1]
+        N = np.sum(mask)
+        V = np.mean(volume[mask])
+        # Check that the volume was constant
+        assert np.std(volume[mask]) < 1e-4, "%40s %5d %8.2e"%(fn,N,np.std(volume[mask]))
+        P = np.mean(pressure[mask])
+        Perr = np.std(pressure[mask])
+        row = [N,tmax,V,P,Perr]
+        print("%12s Nsamples = %6d tmax = %8.1f fs V = %8.2f A^3 P = %8.2f (+-%8.2f) atm" % (fn,row[0],row[1],row[2],row[3],row[4]))
+        data.append([row[2],row[3]])
+    data = np.asarray(data)
+    # Perform thermodynamic integration to get the free energy as a function
+    # of the volume
+    f, pf, roots, fmin, p_tr = thermo_integration_spline(data[:,0], data[:,1])
+    plt.clf()
+    plt.subplot(2,1,1)
+    plt.plot(data[:,0],data[:,1],marker='o')
+    plt.xlabel("Volume [A**3]")
+    plt.ylabel("Pressure [atm]")
+    plt.subplot(2,1,2)
+    # Conversion from atm*A**3 to kJ/mol
+    conversion = 6.101934874875e-05
+    plt.plot(data[:,0],f*conversion,marker='o')
+    plt.xlabel("Volume [A**3]")
+    plt.ylabel("Free energy [kJ/mol]")
+    plt.tight_layout()
+    plt.savefig('profile.png')

--- a/examples/USER/yaff/mil53al_pressure_profile/prepare.py
+++ b/examples/USER/yaff/mil53al_pressure_profile/prepare.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+from __future__ import division
+
+import numpy as np
+import os
+
+def read_volumes(fn):
+    '''Read the volumes from a LAMMPS x y z dump'''
+    def bounds2volume(bounds):
+        '''Convert bounding box to cell box, then compute volume from it'''
+        xy,xz,yz = bounds[0,2],bounds[1,2],bounds[2,2]
+        xlo = bounds[0,0] - np.amin([0.0,xy,xz,xy+xz])
+        xhi = bounds[0,1] - np.amax([0.0,xy,xz,xy+xz])
+        ylo = bounds[1,0] - np.amin([0.0,yz])
+        yhi = bounds[1,1] - np.amax([0.0,yz])
+        zlo = bounds[2,0]
+        zhi = bounds[2,1]
+        # Cell box is upper triangular, so volume is product of diagonal elements
+        return (xhi-xlo)*(yhi-ylo)*(zhi-zlo)
+    volumes = []
+    with open(fn,'r') as f:
+        while True:
+            line = f.readline()
+            if not line: break
+            if line.startswith("ITEM: TIMESTEP"):
+                timestep = int(f.readline())
+            if line.startswith("ITEM: BOX BOUNDS"):
+                bounds = np.array([[float(w) for w in f.readline().split()] for i in range(3)])
+                volume = bounds2volume(bounds)
+                volumes.append([timestep, volume])
+    return np.asarray(volumes)
+
+if __name__=='__main__':
+    # The following file should contain the positions obtained from an NPT run
+    npt_dir = '../mil53al'
+    fn_positions = os.path.join(npt_dir, 'positions.dat')
+    volumes = read_volumes(fn_positions)
+    # The following file is a template input for the fixed volume simulations
+    # Input values that need to be adapted should be in the format __value__
+    fn_template = 'template.in'
+    with open(fn_template,'r') as f:
+        template = f.read()
+    # Request simulations at the following fixed volumes
+    fixed_volumes = np.arange(1500.0,3200.0,step=25.0)
+    for iv, v in enumerate(fixed_volumes):
+        index = np.argmin(np.abs(volumes[:,1]-v))
+        scale = np.power(volumes[index,1]/v,-1.0/3.0)
+        # Check that there is a snapshot in the NPT simulation that is
+        # more or less near to the requested volume
+        assert np.abs(scale-1.0)<5e-2, "V wanted = %6.2f V found = %6.2f  Scale = %f" % (v/angstrom**3,allvolumes[index]/angstrom**3,scale)
+        dn = 'nvst_%05d'%(iv)
+        if not os.path.isdir(dn): os.makedirs(dn)
+        with open(os.path.join(dn,'lammps.in'),'w') as f:
+            lines = template.replace('__scale__','%8.6f'%scale)
+            lines = lines.replace('__nptdir__',os.path.join('..',npt_dir))
+            lines = lines.replace('__step__','%d'%(volumes[index,0]))
+            f.write(lines)

--- a/examples/USER/yaff/mil53al_pressure_profile/run_fixed_volume.sh
+++ b/examples/USER/yaff/mil53al_pressure_profile/run_fixed_volume.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+LMP=../../../../../src/lmp_serial
+origdir=$(pwd)
+for dn in nvst*/
+do
+    echo $dn
+    cd $dn
+    $LMP -i lammps.in > lammps.out
+    cd $origdir
+done

--- a/examples/USER/yaff/mil53al_pressure_profile/template.in
+++ b/examples/USER/yaff/mil53al_pressure_profile/template.in
@@ -20,23 +20,25 @@ dihedral_style  fourier
 improper_style  distharm
 box tilt large
 
-read_data       lammps.data       # Data file location
+read_data       __nptdir__/lammps.data       # Data file location
 kspace_style    pppm 0.0000001      # Ewald accuracy
 neighbor        2.0 multi
 neigh_modify    every 2 delay 4 check yes
 
+read_dump __nptdir__/positions.dat __step__ x y z
+change_box all x scale __scale__ y scale __scale__ z scale __scale__
+reset_timestep 0
 #########################################
 #Output settings
 #########################################
-thermo 100       # Provide output every n steps
+thermo 50       # Provide output every n steps
 thermo_style 	custom step time etotal ke temp pe emol evdwl ecoul elong etail vol press
 thermo_modify	line multi format float %20.12f
-dump 1 all custom 100 positions.dat id type x y z
 #########################################
 #Sampling options
 #########################################
 timestep 0.5 # in femtosecond
 velocity all create 0.0 5 # initial temperature in Kelvin and random seed
-fix 1 all npt temp 300.0 300.0 100.0 tri 2000.0 2000.0 1000.0 tchain 3 mtk yes nreset 1000
+fix 1 all npt temp 300.0 300.0 100.0 tri 0.0 0.0 1000.0 tchain 3 mtk yes nreset 1000 fixvolume yes
 fix_modify 1 energy yes # Add thermo/barostat contributions to energy
-run 10000
+run 25000

--- a/examples/USER/yaff/mil53al_pressure_profile/template.in
+++ b/examples/USER/yaff/mil53al_pressure_profile/template.in
@@ -23,7 +23,7 @@ box tilt large
 read_data       __nptdir__/lammps.data       # Data file location
 kspace_style    pppm 0.0000001      # Ewald accuracy
 neighbor        2.0 multi
-neigh_modify    every 2 delay 4 check yes
+neigh_modify    every 1 delay 0 check no
 
 read_dump __nptdir__/positions.dat __step__ x y z
 change_box all x scale __scale__ y scale __scale__ z scale __scale__

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -1525,6 +1525,7 @@ double FixNH::compute_scalar()
     // extra contributions from thermostat chain for barostat
 
     if (mpchain) {
+      if (fix_volume) lkt_press -= kt;
       energy += lkt_press * etap[0] + 0.5*etap_mass[0]*etap_dot[0]*etap_dot[0];
       for (ich = 1; ich < mpchain; ich++)
         energy += kt * etap[ich] +
@@ -1898,6 +1899,9 @@ void FixNH::nhc_press_integrate()
         pdof++;
       }
   }
+
+  // Keeping the volume fixed removes one degree of freedom from the cell tensor
+  if (fix_volume) pdof--;
 
   if (pstyle == ISO) lkt_press = kt;
   else lkt_press = pdof * kt;

--- a/src/fix_nh.h
+++ b/src/fix_nh.h
@@ -92,6 +92,7 @@ class FixNH : public Fix {
   int mpchain;                     // length of chain
 
   int mtk_flag;                    // 0 if using Hoover barostat
+  int fix_volume;                  // default 0, if 1 the volume is fixed
   int pdim;                        // number of barostatted dims
   double p_freq_max;               // maximum barostat frequency
 
@@ -275,5 +276,22 @@ The compute ID assigned to the fix must compute pressure.
 U: The dlm flag must be used with update dipole
 
 Self-explanatory.
+
+E: Fixvolume requires a Nose-Hoover barostat
+
+Self-explanatory.
+
+E: Fixvolume requires triclinic cell fluctuations
+
+The box shape needs to be flexible if the volume is constrained
+
+E: Fixvolume requires controlling all 6 pressure tensor components
+
+It is `possible` that this requirement is too strict, but the
+algorithm has not been tested for this case.
+
+E: Fixvolume is only implemented for three dimensional systems
+
+Self-explanatory
 
 */


### PR DESCRIPTION
**Summary**

This PR enhances LAMMPS with the (N, V, **sigma**<sub>a</sub>=0, T) ensemble, in which the cell volume and the deviatoric stress are controlled, but the cell shape and the isotropic pressure are unconstrained. The theoretical background was developed by [Rogge et al.](https://pubs.acs.org/doi/10.1021/acs.jctc.5b00748)

**Author(s)**

Steven Vandenbrande, Center for Molecular Modeling, Ghent University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This PR should not break backward compatibility

**Implementation Notes**

This ensemble can be considered a variant of the Nose-Hoover style NPT ensemble that is implemented in LAMMPS. The only difference is that the momentum tensor associated with the barostat particles (the _omega_dot_ array in fix_nh.cpp), should be kept traceless. This is why simulations within this ensemble are requested using a command very similar to the existing _npt_ command, but with the keyword _fixvolume yes_.

An example is included in the _examples/USER/yaff/mil53al_pressure_profile_ directory. It was checked that the volume was indeed constant during simulations, and that the average isotropic pressures correspond to published results.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [x] One or more example input decks are included
