### PR TITLE
Refactor input file processing flow of control

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -85,8 +85,9 @@ Input::Input(LAMMPS *lmp, int argc, char **argv) : Pointers(lmp)
   ifthenelse_flag = 0;
 
   if (me == 0) {
-    nfile = maxfile = 1;
-    infiles = (FILE **) memory->smalloc(sizeof(FILE *),"input:infiles");
+    nfile = 1;
+    maxfile = 16;
+    infiles = new FILE *[maxfile];
     infiles[0] = infile;
   } else infiles = NULL;
 
@@ -138,7 +139,7 @@ Input::~Input()
   memory->sfree(work);
   if (labelstr) delete [] labelstr;
   memory->sfree(arg);
-  memory->sfree(infiles);
+  delete [] infiles;
   delete variable;
 
   delete command_map;
@@ -251,11 +252,8 @@ void Input::file(const char *filename)
   // call to file() will close filename and decrement nfile
 
   if (me == 0) {
-    if (nfile == maxfile) {
-      maxfile++;
-      infiles = (FILE **)
-        memory->srealloc(infiles,maxfile*sizeof(FILE *),"input:infiles");
-    }
+    if (nfile == maxfile)
+      error->one(FLERR,"Too many nested levels of input scripts");
 
     infile = fopen(filename,"r");
     if (infile == NULL) {
@@ -1044,11 +1042,9 @@ void Input::include()
     error->all(FLERR,"Cannot use include command within an if command");
 
   if (me == 0) {
-    if (nfile == maxfile) {
-      maxfile++;
-      infiles = (FILE **)
-        memory->srealloc(infiles,maxfile*sizeof(FILE *),"input:infiles");
-    }
+    if (nfile == maxfile)
+      error->one(FLERR,"Too many nested levels of input scripts");
+
     infile = fopen(arg[0],"r");
     if (infile == NULL) {
       char str[128];

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -78,6 +78,7 @@ Input::Input(LAMMPS *lmp, int argc, char **argv) : Pointers(lmp)
 
   echo_screen = 0;
   echo_log = 1;
+  eof_return = 0;
 
   label_active = 0;
   labelstr = NULL;
@@ -206,6 +207,7 @@ void Input::file()
     MPI_Bcast(&n,1,MPI_INT,0,world);
     if (n == 0) {
       if (label_active) error->all(FLERR,"Label wasn't found in input script");
+      if (eof_return) break;
       if (me == 0) {
         if (infile != stdin) {
           fclose(infile);
@@ -1057,6 +1059,11 @@ void Input::include()
       error->one(FLERR,str);
     }
     infiles[nfile++] = infile;
+    eof_return = 1;
+    file();
+    eof_return = 0;
+    nfile--;
+    infile = infiles[nfile-1];
   }
 }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -78,7 +78,6 @@ Input::Input(LAMMPS *lmp, int argc, char **argv) : Pointers(lmp)
 
   echo_screen = 0;
   echo_log = 1;
-  eof_return = 0;
 
   label_active = 0;
   labelstr = NULL;
@@ -207,18 +206,7 @@ void Input::file()
     MPI_Bcast(&n,1,MPI_INT,0,world);
     if (n == 0) {
       if (label_active) error->all(FLERR,"Label wasn't found in input script");
-      if (eof_return) break;
-      if (me == 0) {
-        if (infile != stdin) {
-          fclose(infile);
-          infile = NULL;
-        }
-        nfile--;
-      }
-      MPI_Bcast(&nfile,1,MPI_INT,0,world);
-      if (nfile == 0) break;
-      if (me == 0) infile = infiles[nfile-1];
-      continue;
+      break;
     }
 
     if (n > maxline) reallocate(line,maxline,n);
@@ -1059,9 +1047,8 @@ void Input::include()
       error->one(FLERR,str);
     }
     infiles[nfile++] = infile;
-    eof_return = 1;
     file();
-    eof_return = 0;
+    fclose(infile);
     nfile--;
     infile = infiles[nfile-1];
   }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -240,8 +240,8 @@ void Input::file()
 }
 
 /* ----------------------------------------------------------------------
-   process all input from filename
-   called from library interface
+   process all input from file at filename
+   mostly called from library interface
 ------------------------------------------------------------------------- */
 
 void Input::file(const char *filename)
@@ -251,21 +251,30 @@ void Input::file(const char *filename)
   // call to file() will close filename and decrement nfile
 
   if (me == 0) {
-    if (nfile > 1)
-      error->one(FLERR,"Invalid use of library file() function");
+    if (nfile == maxfile) {
+      maxfile++;
+      infiles = (FILE **)
+        memory->srealloc(infiles,maxfile*sizeof(FILE *),"input:infiles");
+    }
 
-    if (infile && infile != stdin) fclose(infile);
     infile = fopen(filename,"r");
     if (infile == NULL) {
       char str[128];
       snprintf(str,128,"Cannot open input script %s",filename);
       error->one(FLERR,str);
     }
-    infiles[0] = infile;
-    nfile = 1;
+    infiles[nfile++] = infile;
   }
 
+  // process contents of file
+
   file();
+
+  if (me == 0) {
+    fclose(infile);
+    nfile--;
+    infile = infiles[nfile-1];
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -1047,7 +1056,13 @@ void Input::include()
       error->one(FLERR,str);
     }
     infiles[nfile++] = infile;
-    file();
+  }
+
+  // process contents of file
+
+  file();
+
+  if (me == 0) {
     fclose(infile);
     nfile--;
     infile = infiles[nfile-1];


### PR DESCRIPTION
**Summary**

This changes the logic of how (additional) input files are processed, e.g. via `include` or `Input::file( const char *)`. Lifts some limitations discovered when writing the KIM simulator model interface (PR #1440).

**Related Issues**

A subset of the change was added to PR #1440 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Should be fully compatible. At least that is the plan and so far it has worked.

**Implementation Notes**

Rather than just opening a file and adding it to the stack of open file pointers and waiting until returning to `Input::file()` to do all the processing and logic of closing files and unwinding the stack, we just stop in `Input::file()` at the end of a file and wait for the calling code to close a file and unwind the stack. This means, that now `Input::include()` needs to call `Input::file()`, but makes the whole process cleaner and puts the file closing logic where the file is opened. This will also allow to using `Input->file(const  char*)` from inside some code in a similar fashion as the `include` command.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
