### PR TITLE
Bug fixes to pair granular

### DIFF
--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -890,6 +890,7 @@ void PairGranular::coeff(int narg, char **arg)
       if (iarg + 1 >= narg)
         error->all(FLERR, "Illegal pair_coeff command, not enough parameters");
       cutoff_one = force->numeric(FLERR,arg[iarg+1]);
+      iarg += 2;
     } else error->all(FLERR, "Illegal pair coeff command");
   }
 
@@ -1234,7 +1235,7 @@ void PairGranular::write_restart(FILE *fp)
         fwrite(&tangential_coeffs[i][j],sizeof(double),3,fp);
         fwrite(&roll_coeffs[i][j],sizeof(double),3,fp);
         fwrite(&twist_coeffs[i][j],sizeof(double),3,fp);
-        fwrite(&cut[i][j],sizeof(double),1,fp);
+        fwrite(&cutoff_type[i][j],sizeof(double),1,fp);
       }
     }
   }
@@ -1264,7 +1265,7 @@ void PairGranular::read_restart(FILE *fp)
           fread(&tangential_coeffs[i][j],sizeof(double),3,fp);
           fread(&roll_coeffs[i][j],sizeof(double),3,fp);
           fread(&twist_coeffs[i][j],sizeof(double),3,fp);
-          fread(&cut[i][j],sizeof(double),1,fp);
+          fread(&cutoff_type[i][j],sizeof(double),1,fp);
         }
         MPI_Bcast(&normal_model[i][j],1,MPI_INT,0,world);
         MPI_Bcast(&damping_model[i][j],1,MPI_INT,0,world);
@@ -1275,7 +1276,7 @@ void PairGranular::read_restart(FILE *fp)
         MPI_Bcast(&tangential_coeffs[i][j],3,MPI_DOUBLE,0,world);
         MPI_Bcast(&roll_coeffs[i][j],3,MPI_DOUBLE,0,world);
         MPI_Bcast(&twist_coeffs[i][j],3,MPI_DOUBLE,0,world);
-        MPI_Bcast(&cut[i][j],1,MPI_DOUBLE,0,world);
+        MPI_Bcast(&cutoff_type[i][j],1,MPI_DOUBLE,0,world);
       }
     }
   }

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -475,16 +475,12 @@ void PairGranular::compute(int eflag, int vflag)
           fs3 = -Ft*vtr3;
         }
 
-        //****************************************
-        // rolling resistance
-        //****************************************
-
-        if (roll_model[itype][jtype] != ROLL_NONE) {
+	if (roll_model[itype][jtype] != ROLL_NONE ||
+	    twist_model[itype][jtype] != TWIST_NONE){
           relrot1 = omega[i][0] - omega[j][0];
           relrot2 = omega[i][1] - omega[j][1];
           relrot3 = omega[i][2] - omega[j][2];
-
-          // rolling velocity,
+	  // rolling velocity,
           // see eq. 31 of Wang et al, Particuology v 23, p 49 (2015)
           // this is different from the Marshall papers,
           // which use the Bagi/Kuhn formulation
@@ -492,7 +488,12 @@ void PairGranular::compute(int eflag, int vflag)
           // - 0.5*((radj-radi)/radsum)*vtr1;
           // - 0.5*((radj-radi)/radsum)*vtr2;
           // - 0.5*((radj-radi)/radsum)*vtr3;
+	}
+        //****************************************
+        // rolling resistance
+        //****************************************
 
+        if (roll_model[itype][jtype] != ROLL_NONE) {
           vrl1 = Reff*(relrot2*nz - relrot3*ny);
           vrl2 = Reff*(relrot3*nx - relrot1*nz);
           vrl3 = Reff*(relrot1*ny - relrot2*nx);
@@ -1231,10 +1232,10 @@ void PairGranular::write_restart(FILE *fp)
         fwrite(&tangential_model[i][j],sizeof(int),1,fp);
         fwrite(&roll_model[i][j],sizeof(int),1,fp);
         fwrite(&twist_model[i][j],sizeof(int),1,fp);
-        fwrite(&normal_coeffs[i][j],sizeof(double),4,fp);
-        fwrite(&tangential_coeffs[i][j],sizeof(double),3,fp);
-        fwrite(&roll_coeffs[i][j],sizeof(double),3,fp);
-        fwrite(&twist_coeffs[i][j],sizeof(double),3,fp);
+        fwrite(normal_coeffs[i][j],sizeof(double),4,fp);
+        fwrite(tangential_coeffs[i][j],sizeof(double),3,fp);
+        fwrite(roll_coeffs[i][j],sizeof(double),3,fp);
+        fwrite(twist_coeffs[i][j],sizeof(double),3,fp);
         fwrite(&cutoff_type[i][j],sizeof(double),1,fp);
       }
     }
@@ -1261,10 +1262,10 @@ void PairGranular::read_restart(FILE *fp)
           fread(&tangential_model[i][j],sizeof(int),1,fp);
           fread(&roll_model[i][j],sizeof(int),1,fp);
           fread(&twist_model[i][j],sizeof(int),1,fp);
-          fread(&normal_coeffs[i][j],sizeof(double),4,fp);
-          fread(&tangential_coeffs[i][j],sizeof(double),3,fp);
-          fread(&roll_coeffs[i][j],sizeof(double),3,fp);
-          fread(&twist_coeffs[i][j],sizeof(double),3,fp);
+          fread(normal_coeffs[i][j],sizeof(double),4,fp);
+          fread(tangential_coeffs[i][j],sizeof(double),3,fp);
+          fread(roll_coeffs[i][j],sizeof(double),3,fp);
+          fread(twist_coeffs[i][j],sizeof(double),3,fp);
           fread(&cutoff_type[i][j],sizeof(double),1,fp);
         }
         MPI_Bcast(&normal_model[i][j],1,MPI_INT,0,world);
@@ -1272,10 +1273,10 @@ void PairGranular::read_restart(FILE *fp)
         MPI_Bcast(&tangential_model[i][j],1,MPI_INT,0,world);
         MPI_Bcast(&roll_model[i][j],1,MPI_INT,0,world);
         MPI_Bcast(&twist_model[i][j],1,MPI_INT,0,world);
-        MPI_Bcast(&normal_coeffs[i][j],4,MPI_DOUBLE,0,world);
-        MPI_Bcast(&tangential_coeffs[i][j],3,MPI_DOUBLE,0,world);
-        MPI_Bcast(&roll_coeffs[i][j],3,MPI_DOUBLE,0,world);
-        MPI_Bcast(&twist_coeffs[i][j],3,MPI_DOUBLE,0,world);
+        MPI_Bcast(normal_coeffs[i][j],4,MPI_DOUBLE,0,world);
+        MPI_Bcast(tangential_coeffs[i][j],3,MPI_DOUBLE,0,world);
+        MPI_Bcast(roll_coeffs[i][j],3,MPI_DOUBLE,0,world);
+        MPI_Bcast(twist_coeffs[i][j],3,MPI_DOUBLE,0,world);
         MPI_Bcast(&cutoff_type[i][j],1,MPI_DOUBLE,0,world);
       }
     }


### PR DESCRIPTION
**Summary**

Fixes segfault issues with restarts of pair granular, fixes issue with user-specified global cutoffs causing a halt, and allows twisting friction to be used without rolling friction.


**Author(s)**

Dan Bolintineanu, Sandia National Labs

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

Yes

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

