### PR TITLE
add missing include needed on ppc64le

### DIFF
--- a/lib/gpu/lal_device.cpp
+++ b/lib/gpu/lal_device.cpp
@@ -17,6 +17,7 @@
 #include "lal_precision.h"
 #include <map>
 #include <cmath>
+#include <cstdlib>
 #ifdef _OPENMP
 #include <omp.h>
 #endif


### PR DESCRIPTION
**Summary**

On ppc64le (and aarch64), I ran into the following compile error:
```
BUILDSTDERR: /builddir/build/BUILD/lammps-stable_5Jun2019/lib/gpu/lal_device.cpp: In instantiation of 'int LAMMPS_AL::Device<numtyp, acctyp>::init_device(MPI_Comm, MPI_Comm, int, int, int, double, int, in
t, double, char*, int) [with numtyp = float; acctyp = double; MPI_Comm = int]':
BUILDSTDERR: /builddir/build/BUILD/lammps-stable_5Jun2019/lib/gpu/lal_device.cpp:742:16:   required from here
BUILDSTDERR: /builddir/build/BUILD/lammps-stable_5Jun2019/lib/gpu/lal_device.cpp:77:37: error: 'atoi' was not declared in this scope
make[2]: Leaving directory `/builddir/build/BUILD/lammps-stable_5Jun2019/mpich'
BUILDSTDERR: make[2]: *** [CMakeFiles/gpu.dir/builddir/build/BUILD/lammps-stable_5Jun2019/lib/gpu/lal_device.cpp.o] Error 1
```

**Related Issues**

None

**Author(s)**


@junghans

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

is compatibel

**Implementation Notes**

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [N/A] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [N/A] A package specific README file has been included or updated
- [N/A] One or more example input decks are included

**Further Information, Files, and Links**

https://koji.fedoraproject.org/koji/taskinfo?taskID=35841509

