### PR TITLE
Prevent geometric grow of memory in CommBrick

### DIFF
--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -611,7 +611,7 @@ void CommBrick::exchange()
   maxexchange = maxexchange_atom + maxexchange_fix;
   bufextra = maxexchange + BUFEXTRA;
   if (bufextra > bufextra_old)
-    grow_send(maxsend+bufextra,1);
+    memory->grow(buf_send,maxsend+bufextra,"comm:buf_send");
 
   // subbox bounds for orthogonal or triclinic
 

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -612,7 +612,6 @@ void CommBrick::exchange()
   bufextra = maxexchange + BUFEXTRA;
   if (bufextra > bufextra_old)
     grow_send((maxsend+bufextra-bufextra_old)/BUFFACTOR+1,1);
-  fprintf(screen, "maxsend: %d\n", maxsend);
 
   // subbox bounds for orthogonal or triclinic
 

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -611,7 +611,8 @@ void CommBrick::exchange()
   maxexchange = maxexchange_atom + maxexchange_fix;
   bufextra = maxexchange + BUFEXTRA;
   if (bufextra > bufextra_old)
-    memory->grow(buf_send,maxsend+bufextra,"comm:buf_send");
+    grow_send((maxsend+bufextra-bufextra_old)/BUFFACTOR+1,1);
+  fprintf(screen, "maxsend: %d\n", maxsend);
 
   // subbox bounds for orthogonal or triclinic
 


### PR DESCRIPTION
**Summary**

Prevent geometric grow of memory in CommBrick.

**Related Issues**

Fixes #1528.

**Author(s)**

Denis Taniguchi (denis.taniguchi@gmail.com)
Newcastle University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No backward compatibility issues.

**Implementation Notes**

Changed call to grow_send to a direct call to memory->grow. Checked with granregion examples.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

None.


