### PR TITLE
Workaround to make formatting of code blocks consistent

### DIFF
--- a/doc/utils/sphinx-config/_themes/lammps_theme/static/css/theme.css
+++ b/doc/utils/sphinx-config/_themes/lammps_theme/static/css/theme.css
@@ -5092,4 +5092,17 @@ span[id*='MathJax-Span'] {
   src: local("Roboto Slab Bold"), local("RobotoSlab-Bold"), url(../fonts/RobotoSlab-Bold.ttf) format("truetype");
 }
 
+.codeblock, pre.literal-block, .rst-content .literal-block, .rst-content pre.literal-block, div[class^='highlight'] {
+  font-size: 12px;
+  line-height: 1.5;
+  display: block;
+  overflow: auto;
+  color: #404040;
+  padding: 12px 12px;
+}
+
+.codeblock,div[class^='highlight'] {
+  padding: 0;
+}
+
 /*# sourceMappingURL=theme.css.map */


### PR DESCRIPTION
**Summary**

Minor change to LAMMPS documentation theme to workaround inconsistent code block formatting.

![Comparison](https://user-images.githubusercontent.com/2828630/60377731-35c35680-99e7-11e9-9824-7f0f0864f2f6.png)


**Author(s)**

@rbberger

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


