### PR TITLE
MEAM/C: embedding-function related refactoring 

### DIFF
--- a/doc/src/pair_meamc.txt
+++ b/doc/src/pair_meamc.txt
@@ -147,7 +147,8 @@ asub     = "A" parameter for MEAM (see e.g. "(Baskes)"_#Baskes) :pre
 
 The alpha, b0, b1, b2, b3, t0, t1, t2, t3 parameters correspond to the
 standard MEAM parameters in the literature "(Baskes)"_#Baskes (the b
-parameters are the standard beta parameters).  The rozero parameter is
+parameters are the standard beta parameters). Note that only parameters
+normalized to t0 = 1.0 are supported.  The rozero parameter is
 an element-dependent density scaling that weights the reference
 background density (see e.g. equation 4.5 in "(Gullet)"_#Gullet) and
 is typically 1.0 for single-element systems.  The ibar parameter

--- a/src/USER-MEAMC/meam.h
+++ b/src/USER-MEAMC/meam.h
@@ -93,8 +93,9 @@ private:
   int augt1, ialloy, mix_ref_t, erose_form;
   int emb_lin_neg, bkgd_dyn;
   double gsmooth_factor;
-  int vind2D[3][3], vind3D[3][3][3];
-  int v2D[6], v3D[10];
+
+  int vind2D[3][3], vind3D[3][3][3];                  // x-y-z to Voigt-like index
+  int v2D[6], v3D[10];                                // multiplicity of Voigt index (i.e. [1] -> xy+yx = 2
 
   int nr, nrar;
   double dr, rdrar;
@@ -121,6 +122,7 @@ protected:
     else if (xi <= 0.0)
       return 0.0;
     else {
+      // ( 1.d0 - (1.d0 - xi)**4 )**2, but with better codegen
       a = 1.0 - xi;
       a *= a; a *= a;
       a = 1.0 - a;

--- a/src/USER-MEAMC/meam.h
+++ b/src/USER-MEAMC/meam.h
@@ -187,6 +187,7 @@ protected:
   double G_gam(const double gamma, const int ibar, int &errorflag) const;
   double dG_gam(const double gamma, const int ibar, double &dG) const;
   static double zbl(const double r, const int z1, const int z2);
+  double embedding(const double A, const double Ec, const double rhobar, double& dF) const;
   static double erose(const double r, const double re, const double alpha, const double Ec, const double repuls, const double attrac, const int form);
 
   static void get_shpfcn(const lattice_t latt, double (&s)[3]);

--- a/src/USER-MEAMC/meam_dens_final.cpp
+++ b/src/USER-MEAMC/meam_dens_final.cpp
@@ -112,7 +112,7 @@ MEAM::meam_dens_final(int nlocal, int eflag_either, int eflag_global, int eflag_
       }
 
       Fl = embedding(this->A_meam[elti], this->Ec_meam[elti][elti], rhob, frhop[i]);
-      
+
       if (eflag_either != 0) {
         if (eflag_global != 0) {
           *eng_vdwl = *eng_vdwl + Fl;

--- a/src/USER-MEAMC/meam_dens_final.cpp
+++ b/src/USER-MEAMC/meam_dens_final.cpp
@@ -10,7 +10,7 @@ MEAM::meam_dens_final(int nlocal, int eflag_either, int eflag_global, int eflag_
   int i, elti;
   int m;
   double rhob, G, dG, Gbar, dGbar, gam, shp[3], Z;
-  double B, denom, rho_bkgd;
+  double denom, rho_bkgd, Fl;
 
   //     Complete the calculation of density
 
@@ -111,35 +111,14 @@ MEAM::meam_dens_final(int nlocal, int eflag_either, int eflag_global, int eflag_
         dgamma3[i] = 0.0;
       }
 
-      B = this->A_meam[elti] * this->Ec_meam[elti][elti];
-
-      if (!iszero(rhob)) {
-        if (this->emb_lin_neg == 1 && rhob <= 0) {
-          frhop[i] = -B;
-        } else {
-          frhop[i] = B * (log(rhob) + 1.0);
+      Fl = embedding(this->A_meam[elti], this->Ec_meam[elti][elti], rhob, frhop[i]);
+      
+      if (eflag_either != 0) {
+        if (eflag_global != 0) {
+          *eng_vdwl = *eng_vdwl + Fl;
         }
-        if (eflag_either != 0) {
-          if (eflag_global != 0) {
-            if (this->emb_lin_neg == 1 && rhob <= 0) {
-              *eng_vdwl = *eng_vdwl - B * rhob;
-            } else {
-              *eng_vdwl = *eng_vdwl + B * rhob * log(rhob);
-            }
-          }
-          if (eflag_atom != 0) {
-            if (this->emb_lin_neg == 1 && rhob <= 0) {
-              eatom[i] = eatom[i] - B * rhob;
-            } else {
-              eatom[i] = eatom[i] + B * rhob * log(rhob);
-            }
-          }
-        }
-      } else {
-        if (this->emb_lin_neg == 1) {
-          frhop[i] = -B;
-        } else {
-          frhop[i] = B;
+        if (eflag_atom != 0) {
+          eatom[i] = eatom[i] + Fl;
         }
       }
     }

--- a/src/USER-MEAMC/meam_funcs.cpp
+++ b/src/USER-MEAMC/meam_funcs.cpp
@@ -144,6 +144,28 @@ MEAM::zbl(const double r, const int z1, const int z2)
 }
 
 //-----------------------------------------------------------------------------
+// Compute embedding function F(rhobar) and derivative F'(rhobar), eqn I.5
+//
+double
+MEAM::embedding(const double A, const double Ec, const double rhobar, double& dF) const
+{
+  const double AEc = A * Ec;
+
+  if (rhobar > 0.0) {
+      dF = AEc * (1.0 + log(rhobar));
+      return AEc * rhobar * log(rhobar);
+  } else {
+    if (this->emb_lin_neg == 0) {
+      dF = 0.0;
+      return 0.0;
+    } else {
+      dF = - AEc;
+      return - AEc * rhobar;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
 // Compute Rose energy function, I.16
 //
 double

--- a/src/USER-MEAMC/meam_funcs.cpp
+++ b/src/USER-MEAMC/meam_funcs.cpp
@@ -52,7 +52,7 @@ MEAM::G_gam(const double gamma, const int ibar, int& errorflag) const
     case 1:
       return MathSpecial::fm_exp(gamma / 2.0);
     case 3:
-      return 2.0 / (1.0 + exp(-gamma));
+      return 2.0 / (1.0 + MathSpecial::fm_exp(-gamma));
     case -5:
       if ((1.0 + gamma) >= 0) {
         return sqrt(1.0 + gamma);
@@ -152,8 +152,9 @@ MEAM::embedding(const double A, const double Ec, const double rhobar, double& dF
   const double AEc = A * Ec;
 
   if (rhobar > 0.0) {
-      dF = AEc * (1.0 + log(rhobar));
-      return AEc * rhobar * log(rhobar);
+      const double lrb = log(rhobar);
+      dF = AEc * (1.0 + lrb);
+      return AEc * rhobar * lrb;
   } else {
     if (this->emb_lin_neg == 0) {
       dF = 0.0;

--- a/src/USER-MEAMC/meam_setup_done.cpp
+++ b/src/USER-MEAMC/meam_setup_done.cpp
@@ -319,7 +319,7 @@ MEAM::phi_meam(double r, int a, int b)
   double t11av, t21av, t31av, t12av, t22av, t32av;
   double G1, G2, s1[3], s2[3], rho0_1, rho0_2;
   double Gam1, Gam2, Z1, Z2;
-  double rhobar1, rhobar2, F1, F2;
+  double rhobar1, rhobar2, F1, F2, dF;
   double rho01, rho11, rho21, rho31;
   double rho02, rho12, rho22, rho32;
   double scalfac, phiaa, phibb;
@@ -447,22 +447,10 @@ MEAM::phi_meam(double r, int a, int b)
   }
 
   // compute embedding functions, eqn I.5
-  if (iszero(rhobar1))
-    F1 = 0.0;
-  else {
-    if (this->emb_lin_neg == 1 && rhobar1 <= 0)
-      F1 = -this->A_meam[a] * this->Ec_meam[a][a] * rhobar1;
-    else
-      F1 = this->A_meam[a] * this->Ec_meam[a][a] * rhobar1 * log(rhobar1);
-  }
-  if (iszero(rhobar2))
-    F2 = 0.0;
-  else {
-    if (this->emb_lin_neg == 1 && rhobar2 <= 0)
-      F2 = -this->A_meam[b] * this->Ec_meam[b][b] * rhobar2;
-    else
-      F2 = this->A_meam[b] * this->Ec_meam[b][b] * rhobar2 * log(rhobar2);
-  }
+
+  F1 = embedding(this->A_meam[a], this->Ec_meam[a][a], rhobar1, dF);
+  F2 = embedding(this->A_meam[b], this->Ec_meam[b][b], rhobar2, dF);
+  
 
   // compute Rose function, I.16
   Eu = erose(r, this->re_meam[a][b], this->alpha_meam[a][b], this->Ec_meam[a][b], this->repuls_meam[a][b],

--- a/src/USER-MEAMC/meam_setup_done.cpp
+++ b/src/USER-MEAMC/meam_setup_done.cpp
@@ -697,7 +697,7 @@ MEAM::get_densref(double r, int a, int b, double* rho01, double* rho11, double* 
       get_sijk(C, a, a, b, &s112);
       get_sijk(C, b, b, a, &s221);
       S11 = s111 * s111 * s112 * s112;
-      S22 = pow(s221, 4);
+      S22 = s221 * s221 * s221 * s221;
       *rho01 = *rho01 + 6 * S11 * rhoa01nn;
       *rho02 = *rho02 + 6 * S22 * rhoa02nn;
 

--- a/src/USER-MEAMC/pair_meamc.cpp
+++ b/src/USER-MEAMC/pair_meamc.cpp
@@ -460,6 +460,9 @@ void PairMEAMC::read_files(char *globalfile, char *userfile)
     rozero[i] = atof(words[17]);
     ibar[i] = atoi(words[18]);
 
+    if (!iszero(t0[i]-1.0))
+      error->all(FLERR,"Unsupported parameter in MEAM potential file");
+
     nset++;
   }
 


### PR DESCRIPTION
**Summary**

This PR contains two changes, a minor fix, and a performance improvement:

- extracted the embedding function and fixed an inconsistency regarding emb_lin_neg=0 (it is now the same as KISSMD)
- refactored screening calculations with more early-out checks. This improves speed by saving a few FLOps and improves readability. Note that there is still some code duplication left that can't be avoided.
- catch t1!=1 as an error (this is not supported in any MEAM code)
- use fastmath exp in all gamma expressions, replace pow(..,4) with multiplications, compute log(rho) only once in embedding function

**Author(s)**

Sebastian Hütter (OvGU)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No functional changes except for unphysical situations or bad input. Correctness was verified against Lee's KISSMD.


**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
