### PR TITLE
Validate more numbers read from data files

### DIFF
--- a/src/DIPOLE/atom_vec_dipole.cpp
+++ b/src/DIPOLE/atom_vec_dipole.cpp
@@ -780,19 +780,19 @@ void AtomVecDipole::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = atof(values[2]);
+  q[nlocal] = force->numeric(FLERR,values[2]);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
   x[nlocal][2] = coord[2];
 
-  mu[nlocal][0] = atof(values[6]);
-  mu[nlocal][1] = atof(values[7]);
-  mu[nlocal][2] = atof(values[8]);
+  mu[nlocal][0] = force->numeric(FLERR,values[6]);
+  mu[nlocal][1] = force->numeric(FLERR,values[7]);
+  mu[nlocal][2] = force->numeric(FLERR,values[8]);
   mu[nlocal][3] = sqrt(mu[nlocal][0]*mu[nlocal][0] +
                        mu[nlocal][1]*mu[nlocal][1] +
                        mu[nlocal][2]*mu[nlocal][2]);
@@ -814,10 +814,10 @@ void AtomVecDipole::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecDipole::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = atof(values[0]);
-  mu[nlocal][0] = atof(values[1]);
-  mu[nlocal][1] = atof(values[2]);
-  mu[nlocal][2] = atof(values[3]);
+  q[nlocal] = force->numeric(FLERR,values[0]);
+  mu[nlocal][0] = force->numeric(FLERR,values[1]);
+  mu[nlocal][1] = force->numeric(FLERR,values[2]);
+  mu[nlocal][2] = force->numeric(FLERR,values[3]);
   mu[nlocal][3] = sqrt(mu[nlocal][0]*mu[nlocal][0] +
                        mu[nlocal][1]*mu[nlocal][1] +
                        mu[nlocal][2]*mu[nlocal][2]);

--- a/src/DIPOLE/atom_vec_dipole.cpp
+++ b/src/DIPOLE/atom_vec_dipole.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/DIPOLE/atom_vec_dipole.cpp
+++ b/src/DIPOLE/atom_vec_dipole.cpp
@@ -22,6 +22,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -781,19 +782,19 @@ void AtomVecDipole::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = force->numeric(FLERR,values[2]);
+  q[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
   x[nlocal][2] = coord[2];
 
-  mu[nlocal][0] = force->numeric(FLERR,values[6]);
-  mu[nlocal][1] = force->numeric(FLERR,values[7]);
-  mu[nlocal][2] = force->numeric(FLERR,values[8]);
+  mu[nlocal][0] = utils::numeric(FLERR,values[6],true,lmp);
+  mu[nlocal][1] = utils::numeric(FLERR,values[7],true,lmp);
+  mu[nlocal][2] = utils::numeric(FLERR,values[8],true,lmp);
   mu[nlocal][3] = sqrt(mu[nlocal][0]*mu[nlocal][0] +
                        mu[nlocal][1]*mu[nlocal][1] +
                        mu[nlocal][2]*mu[nlocal][2]);
@@ -815,10 +816,10 @@ void AtomVecDipole::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecDipole::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = force->numeric(FLERR,values[0]);
-  mu[nlocal][0] = force->numeric(FLERR,values[1]);
-  mu[nlocal][1] = force->numeric(FLERR,values[2]);
-  mu[nlocal][2] = force->numeric(FLERR,values[3]);
+  q[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
+  mu[nlocal][0] = utils::numeric(FLERR,values[1],true,lmp);
+  mu[nlocal][1] = utils::numeric(FLERR,values[2],true,lmp);
+  mu[nlocal][2] = utils::numeric(FLERR,values[3],true,lmp);
   mu[nlocal][3] = sqrt(mu[nlocal][0]*mu[nlocal][0] +
                        mu[nlocal][1]*mu[nlocal][1] +
                        mu[nlocal][2]*mu[nlocal][2]);

--- a/src/KOKKOS/atom_vec_angle_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_angle_kokkos.cpp
@@ -1632,9 +1632,9 @@ void AtomVecAngleKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = atoi(values[0]);
-  h_molecule(nlocal) = atoi(values[1]);
-  h_type(nlocal) = atoi(values[2]);
+  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
+  h_type(nlocal) = force->inumeric(FLERR,values[2]);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -1661,7 +1661,7 @@ void AtomVecAngleKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecAngleKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = atoi(values[0]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   return 1;

--- a/src/KOKKOS/atom_vec_angle_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_angle_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -1633,9 +1634,9 @@ void AtomVecAngleKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
-  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
-  h_type(nlocal) = force->inumeric(FLERR,values[2]);
+  h_tag(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[1],true,lmp);
+  h_type(nlocal) = utils::inumeric(FLERR,values[2],true,lmp);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -1662,7 +1663,7 @@ void AtomVecAngleKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecAngleKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   return 1;

--- a/src/KOKKOS/atom_vec_angle_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_angle_kokkos.cpp
@@ -16,6 +16,7 @@
 #include "atom_kokkos.h"
 #include "comm_kokkos.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "atom_masks.h"

--- a/src/KOKKOS/atom_vec_atomic_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_atomic_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -824,8 +825,8 @@ void AtomVecAtomicKokkos::data_atom(double *coord, tagint imagetmp,
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  h_tag[nlocal] = force->inumeric(FLERR,values[0]);
-  h_type[nlocal] = force->inumeric(FLERR,values[1]);
+  h_tag[nlocal] = utils::inumeric(FLERR,values[0],true,lmp);
+  h_type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/KOKKOS/atom_vec_atomic_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_atomic_kokkos.cpp
@@ -16,6 +16,7 @@
 #include "atom_kokkos.h"
 #include "comm_kokkos.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "atom_masks.h"

--- a/src/KOKKOS/atom_vec_atomic_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_atomic_kokkos.cpp
@@ -823,8 +823,8 @@ void AtomVecAtomicKokkos::data_atom(double *coord, tagint imagetmp,
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  h_tag[nlocal] = atoi(values[0]);
-  h_type[nlocal] = atoi(values[1]);
+  h_tag[nlocal] = force->inumeric(FLERR,values[0]);
+  h_type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/KOKKOS/atom_vec_bond_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_bond_kokkos.cpp
@@ -1058,9 +1058,9 @@ void AtomVecBondKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = atoi(values[0]);
-  h_molecule(nlocal) = atoi(values[1]);
-  h_type(nlocal) = atoi(values[2]);
+  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
+  h_type(nlocal) = force->inumeric(FLERR,values[2]);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -1086,7 +1086,7 @@ void AtomVecBondKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecBondKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = atoi(values[0]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
   h_num_bond(nlocal) = 0;
   return 1;
 }

--- a/src/KOKKOS/atom_vec_bond_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_bond_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -1059,9 +1060,9 @@ void AtomVecBondKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
-  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
-  h_type(nlocal) = force->inumeric(FLERR,values[2]);
+  h_tag(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[1],true,lmp);
+  h_type(nlocal) = utils::inumeric(FLERR,values[2],true,lmp);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -1087,7 +1088,7 @@ void AtomVecBondKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecBondKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
   h_num_bond(nlocal) = 0;
   return 1;
 }

--- a/src/KOKKOS/atom_vec_bond_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_bond_kokkos.cpp
@@ -16,6 +16,7 @@
 #include "atom_kokkos.h"
 #include "comm_kokkos.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "atom_masks.h"

--- a/src/KOKKOS/atom_vec_charge_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_charge_kokkos.cpp
@@ -959,12 +959,12 @@ void AtomVecChargeKokkos::data_atom(double *coord, imageint imagetmp,
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  h_tag[nlocal] = atoi(values[0]);
-  h_type[nlocal] = atoi(values[1]);
+  h_tag[nlocal] = force->inumeric(FLERR,values[0]);
+  h_type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  h_q[nlocal] = atof(values[2]);
+  h_q[nlocal] = force->numeric(FLERR,values[2]);
 
   h_x(nlocal,0) = coord[0];
   h_x(nlocal,1) = coord[1];
@@ -988,7 +988,7 @@ void AtomVecChargeKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecChargeKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_q[nlocal] = atof(values[0]);
+  h_q[nlocal] = force->numeric(FLERR,values[0]);
 
   return 1;
 }

--- a/src/KOKKOS/atom_vec_charge_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_charge_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -960,12 +961,12 @@ void AtomVecChargeKokkos::data_atom(double *coord, imageint imagetmp,
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  h_tag[nlocal] = force->inumeric(FLERR,values[0]);
-  h_type[nlocal] = force->inumeric(FLERR,values[1]);
+  h_tag[nlocal] = utils::inumeric(FLERR,values[0],true,lmp);
+  h_type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  h_q[nlocal] = force->numeric(FLERR,values[2]);
+  h_q[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
 
   h_x(nlocal,0) = coord[0];
   h_x(nlocal,1) = coord[1];
@@ -989,7 +990,7 @@ void AtomVecChargeKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecChargeKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_q[nlocal] = force->numeric(FLERR,values[0]);
+  h_q[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
 
   return 1;
 }

--- a/src/KOKKOS/atom_vec_charge_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_charge_kokkos.cpp
@@ -16,6 +16,7 @@
 #include "atom_kokkos.h"
 #include "comm_kokkos.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "atom_masks.h"

--- a/src/KOKKOS/atom_vec_dpd_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -1724,11 +1725,11 @@ void AtomVecDPDKokkos::data_atom(double *coord, tagint imagetmp,
   if (nlocal == nmax) grow(0);
 
   h_tag[nlocal] = ATOTAGINT(values[0]);
-  h_type[nlocal] = force->inumeric(FLERR,values[1]);
+  h_type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  h_dpdTheta[nlocal] = force->numeric(FLERR,values[2]);
+  h_dpdTheta[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
   if (h_dpdTheta[nlocal] <= 0)
     error->one(FLERR,"Internal temperature in Atoms section of date file must be > zero");
 
@@ -1762,7 +1763,7 @@ void AtomVecDPDKokkos::data_atom(double *coord, tagint imagetmp,
 
 int AtomVecDPDKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_dpdTheta(nlocal) = force->numeric(FLERR,values[0]);
+  h_dpdTheta(nlocal) = utils::numeric(FLERR,values[0],true,lmp);
 
   atomKK->modified(Host,DPDTHETA_MASK);
 

--- a/src/KOKKOS/atom_vec_dpd_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.cpp
@@ -1723,11 +1723,11 @@ void AtomVecDPDKokkos::data_atom(double *coord, tagint imagetmp,
   if (nlocal == nmax) grow(0);
 
   h_tag[nlocal] = ATOTAGINT(values[0]);
-  h_type[nlocal] = atoi(values[1]);
+  h_type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  h_dpdTheta[nlocal] = atof(values[2]);
+  h_dpdTheta[nlocal] = force->numeric(FLERR,values[2]);
   if (h_dpdTheta[nlocal] <= 0)
     error->one(FLERR,"Internal temperature in Atoms section of date file must be > zero");
 
@@ -1761,7 +1761,7 @@ void AtomVecDPDKokkos::data_atom(double *coord, tagint imagetmp,
 
 int AtomVecDPDKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_dpdTheta(nlocal) = atof(values[0]);
+  h_dpdTheta(nlocal) = force->numeric(FLERR,values[0]);
 
   atomKK->modified(Host,DPDTHETA_MASK);
 

--- a/src/KOKKOS/atom_vec_dpd_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.cpp
@@ -16,6 +16,7 @@
 #include "atom_kokkos.h"
 #include "comm_kokkos.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "atom_masks.h"

--- a/src/KOKKOS/atom_vec_full_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_full_kokkos.cpp
@@ -1487,13 +1487,13 @@ void AtomVecFullKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = atoi(values[0]);
-  h_molecule(nlocal) = atoi(values[1]);
-  h_type(nlocal) = atoi(values[2]);
+  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
+  h_type(nlocal) = force->inumeric(FLERR,values[2]);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  h_q(nlocal) = atof(values[3]);
+  h_q(nlocal) = force->numeric(FLERR,values[3]);
 
   h_x(nlocal,0) = coord[0];
   h_x(nlocal,1) = coord[1];
@@ -1520,8 +1520,8 @@ void AtomVecFullKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecFullKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = atoi(values[0]);
-  h_q(nlocal) = atof(values[1]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
+  h_q(nlocal) = force->numeric(FLERR,values[1]);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   h_num_dihedral(nlocal) = 0;

--- a/src/KOKKOS/atom_vec_full_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_full_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -1488,13 +1489,13 @@ void AtomVecFullKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
-  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
-  h_type(nlocal) = force->inumeric(FLERR,values[2]);
+  h_tag(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[1],true,lmp);
+  h_type(nlocal) = utils::inumeric(FLERR,values[2],true,lmp);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  h_q(nlocal) = force->numeric(FLERR,values[3]);
+  h_q(nlocal) = utils::numeric(FLERR,values[3],true,lmp);
 
   h_x(nlocal,0) = coord[0];
   h_x(nlocal,1) = coord[1];
@@ -1521,8 +1522,8 @@ void AtomVecFullKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecFullKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
-  h_q(nlocal) = force->numeric(FLERR,values[1]);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_q(nlocal) = utils::numeric(FLERR,values[1],true,lmp);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   h_num_dihedral(nlocal) = 0;

--- a/src/KOKKOS/atom_vec_full_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_full_kokkos.cpp
@@ -16,6 +16,7 @@
 #include "atom_kokkos.h"
 #include "comm_kokkos.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "atom_masks.h"

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "memory_kokkos.h"
 #include "error.h"
 #include "atom_masks.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -976,7 +977,7 @@ void AtomVecHybridKokkos::data_atom(double *coord, imageint imagetmp, char **val
   if (nlocal == nmax) grow(0);
 
   h_tag[nlocal] = ATOTAGINT(values[0]);
-  h_type[nlocal] = force->inumeric(FLERR,values[1]);
+  h_type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (h_type[nlocal] <= 0 || h_type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom h_type in Atoms section of data file");
 
@@ -1020,9 +1021,9 @@ void AtomVecHybridKokkos::data_vel(int m, char **values)
 {
   atomKK->sync(Host,V_MASK);
 
-  h_v(m,0) = force->numeric(FLERR,values[0]);
-  h_v(m,1) = force->numeric(FLERR,values[1]);
-  h_v(m,2) = force->numeric(FLERR,values[2]);
+  h_v(m,0) = utils::numeric(FLERR,values[0],true,lmp);
+  h_v(m,1) = utils::numeric(FLERR,values[1],true,lmp);
+  h_v(m,2) = utils::numeric(FLERR,values[2],true,lmp);
 
   atomKK->modified(Host,V_MASK);
 

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
@@ -975,7 +975,7 @@ void AtomVecHybridKokkos::data_atom(double *coord, imageint imagetmp, char **val
   if (nlocal == nmax) grow(0);
 
   h_tag[nlocal] = ATOTAGINT(values[0]);
-  h_type[nlocal] = atoi(values[1]);
+  h_type[nlocal] = force->inumeric(FLERR,values[1]);
   if (h_type[nlocal] <= 0 || h_type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom h_type in Atoms section of data file");
 
@@ -1019,9 +1019,9 @@ void AtomVecHybridKokkos::data_vel(int m, char **values)
 {
   atomKK->sync(Host,V_MASK);
 
-  h_v(m,0) = atof(values[0]);
-  h_v(m,1) = atof(values[1]);
-  h_v(m,2) = atof(values[2]);
+  h_v(m,0) = force->numeric(FLERR,values[0]);
+  h_v(m,1) = force->numeric(FLERR,values[1]);
+  h_v(m,2) = force->numeric(FLERR,values[2]);
 
   atomKK->modified(Host,V_MASK);
 

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
@@ -16,6 +16,7 @@
 #include "atom_vec_hybrid_kokkos.h"
 #include "atom_kokkos.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory_kokkos.h"

--- a/src/KOKKOS/atom_vec_molecular_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_molecular_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -1892,9 +1893,9 @@ void AtomVecMolecularKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
-  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
-  h_type(nlocal) = force->inumeric(FLERR,values[2]);
+  h_tag(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[1],true,lmp);
+  h_type(nlocal) = utils::inumeric(FLERR,values[2],true,lmp);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -1923,7 +1924,7 @@ void AtomVecMolecularKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecMolecularKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   h_num_dihedral(nlocal) = 0;

--- a/src/KOKKOS/atom_vec_molecular_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_molecular_kokkos.cpp
@@ -1891,9 +1891,9 @@ void AtomVecMolecularKokkos::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
   atomKK->modified(Host,ALL_MASK);
 
-  h_tag(nlocal) = atoi(values[0]);
-  h_molecule(nlocal) = atoi(values[1]);
-  h_type(nlocal) = atoi(values[2]);
+  h_tag(nlocal) = force->inumeric(FLERR,values[0]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[1]);
+  h_type(nlocal) = force->inumeric(FLERR,values[2]);
   if (h_type(nlocal) <= 0 || h_type(nlocal) > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -1922,7 +1922,7 @@ void AtomVecMolecularKokkos::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecMolecularKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  h_molecule(nlocal) = atoi(values[0]);
+  h_molecule(nlocal) = force->inumeric(FLERR,values[0]);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   h_num_dihedral(nlocal) = 0;

--- a/src/KOKKOS/atom_vec_molecular_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_molecular_kokkos.cpp
@@ -18,6 +18,7 @@
 #include "domain.h"
 #include "modify.h"
 #include "fix.h"
+#include "force.h"
 #include "atom_masks.h"
 #include "memory_kokkos.h"
 #include "error.h"

--- a/src/KOKKOS/atom_vec_sphere_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.cpp
@@ -27,6 +27,7 @@
 #include "memory.h"
 #include "error.h"
 #include "memory_kokkos.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -2549,15 +2550,15 @@ void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp, char **val
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  radius[nlocal] = 0.5 * force->numeric(FLERR,values[2]);
+  radius[nlocal] = 0.5 * utils::numeric(FLERR,values[2],true,lmp);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = force->numeric(FLERR,values[3]);
+  double density = utils::numeric(FLERR,values[3],true,lmp);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -2592,11 +2593,11 @@ void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp, char **val
 
 int AtomVecSphereKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  radius[nlocal] = 0.5 * force->numeric(FLERR,values[0]);
+  radius[nlocal] = 0.5 * utils::numeric(FLERR,values[0],true,lmp);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = force->numeric(FLERR,values[1]);
+  double density = utils::numeric(FLERR,values[1],true,lmp);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -2618,12 +2619,12 @@ int AtomVecSphereKokkos::data_atom_hybrid(int nlocal, char **values)
 void AtomVecSphereKokkos::data_vel(int m, char **values)
 {
   atomKK->sync(Host,V_MASK|OMEGA_MASK);
-  h_v(m,0) = force->numeric(FLERR,values[0]);
-  h_v(m,1) = force->numeric(FLERR,values[1]);
-  h_v(m,2) = force->numeric(FLERR,values[2]);
-  h_omega(m,0) = force->numeric(FLERR,values[3]);
-  h_omega(m,1) = force->numeric(FLERR,values[4]);
-  h_omega(m,2) = force->numeric(FLERR,values[5]);
+  h_v(m,0) = utils::numeric(FLERR,values[0],true,lmp);
+  h_v(m,1) = utils::numeric(FLERR,values[1],true,lmp);
+  h_v(m,2) = utils::numeric(FLERR,values[2],true,lmp);
+  h_omega(m,0) = utils::numeric(FLERR,values[3],true,lmp);
+  h_omega(m,1) = utils::numeric(FLERR,values[4],true,lmp);
+  h_omega(m,2) = utils::numeric(FLERR,values[5],true,lmp);
   atomKK->modified(Host,V_MASK|OMEGA_MASK);
 }
 
@@ -2634,9 +2635,9 @@ void AtomVecSphereKokkos::data_vel(int m, char **values)
 int AtomVecSphereKokkos::data_vel_hybrid(int m, char **values)
 {
   atomKK->sync(Host,OMEGA_MASK);
-  omega[m][0] = force->numeric(FLERR,values[0]);
-  omega[m][1] = force->numeric(FLERR,values[1]);
-  omega[m][2] = force->numeric(FLERR,values[2]);
+  omega[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[2],true,lmp);
   atomKK->modified(Host,OMEGA_MASK);
   return 3;
 }

--- a/src/KOKKOS/atom_vec_sphere_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.cpp
@@ -2549,15 +2549,15 @@ void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp, char **val
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  radius[nlocal] = 0.5 * atof(values[2]);
+  radius[nlocal] = 0.5 * force->numeric(FLERR,values[2]);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = atof(values[3]);
+  double density = force->numeric(FLERR,values[3]);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -2592,11 +2592,11 @@ void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp, char **val
 
 int AtomVecSphereKokkos::data_atom_hybrid(int nlocal, char **values)
 {
-  radius[nlocal] = 0.5 * atof(values[0]);
+  radius[nlocal] = 0.5 * force->numeric(FLERR,values[0]);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = atof(values[1]);
+  double density = force->numeric(FLERR,values[1]);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -2618,12 +2618,12 @@ int AtomVecSphereKokkos::data_atom_hybrid(int nlocal, char **values)
 void AtomVecSphereKokkos::data_vel(int m, char **values)
 {
   atomKK->sync(Host,V_MASK|OMEGA_MASK);
-  h_v(m,0) = atof(values[0]);
-  h_v(m,1) = atof(values[1]);
-  h_v(m,2) = atof(values[2]);
-  h_omega(m,0) = atof(values[3]);
-  h_omega(m,1) = atof(values[4]);
-  h_omega(m,2) = atof(values[5]);
+  h_v(m,0) = force->numeric(FLERR,values[0]);
+  h_v(m,1) = force->numeric(FLERR,values[1]);
+  h_v(m,2) = force->numeric(FLERR,values[2]);
+  h_omega(m,0) = force->numeric(FLERR,values[3]);
+  h_omega(m,1) = force->numeric(FLERR,values[4]);
+  h_omega(m,2) = force->numeric(FLERR,values[5]);
   atomKK->modified(Host,V_MASK|OMEGA_MASK);
 }
 
@@ -2634,9 +2634,9 @@ void AtomVecSphereKokkos::data_vel(int m, char **values)
 int AtomVecSphereKokkos::data_vel_hybrid(int m, char **values)
 {
   atomKK->sync(Host,OMEGA_MASK);
-  omega[m][0] = atof(values[0]);
-  omega[m][1] = atof(values[1]);
-  omega[m][2] = atof(values[2]);
+  omega[m][0] = force->numeric(FLERR,values[0]);
+  omega[m][1] = force->numeric(FLERR,values[1]);
+  omega[m][2] = force->numeric(FLERR,values[2]);
   atomKK->modified(Host,OMEGA_MASK);
   return 3;
 }

--- a/src/MOLECULE/atom_vec_angle.cpp
+++ b/src/MOLECULE/atom_vec_angle.cpp
@@ -793,7 +793,7 @@ void AtomVecAngle::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = atoi(values[2]);
+  type[nlocal] = force->inumeric(FLERR,values[2]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/MOLECULE/atom_vec_angle.cpp
+++ b/src/MOLECULE/atom_vec_angle.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/MOLECULE/atom_vec_angle.cpp
+++ b/src/MOLECULE/atom_vec_angle.cpp
@@ -21,6 +21,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -794,7 +795,7 @@ void AtomVecAngle::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = force->inumeric(FLERR,values[2]);
+  type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/MOLECULE/atom_vec_bond.cpp
+++ b/src/MOLECULE/atom_vec_bond.cpp
@@ -739,7 +739,7 @@ void AtomVecBond::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = atoi(values[2]);
+  type[nlocal] = force->inumeric(FLERR,values[2]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/MOLECULE/atom_vec_bond.cpp
+++ b/src/MOLECULE/atom_vec_bond.cpp
@@ -21,6 +21,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -740,7 +741,7 @@ void AtomVecBond::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = force->inumeric(FLERR,values[2]);
+  type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/MOLECULE/atom_vec_bond.cpp
+++ b/src/MOLECULE/atom_vec_bond.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/MOLECULE/atom_vec_full.cpp
+++ b/src/MOLECULE/atom_vec_full.cpp
@@ -21,6 +21,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -943,11 +944,11 @@ void AtomVecFull::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = force->inumeric(FLERR,values[2]);
+  type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = force->numeric(FLERR,values[3]);
+  q[nlocal] = utils::numeric(FLERR,values[3],true,lmp);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -975,7 +976,7 @@ void AtomVecFull::data_atom(double *coord, imageint imagetmp, char **values)
 int AtomVecFull::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
-  q[nlocal] = force->numeric(FLERR,values[1]);
+  q[nlocal] = utils::numeric(FLERR,values[1],true,lmp);
 
   num_bond[nlocal] = 0;
   num_angle[nlocal] = 0;

--- a/src/MOLECULE/atom_vec_full.cpp
+++ b/src/MOLECULE/atom_vec_full.cpp
@@ -942,11 +942,11 @@ void AtomVecFull::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = atoi(values[2]);
+  type[nlocal] = force->inumeric(FLERR,values[2]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = atof(values[3]);
+  q[nlocal] = force->numeric(FLERR,values[3]);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -974,7 +974,7 @@ void AtomVecFull::data_atom(double *coord, imageint imagetmp, char **values)
 int AtomVecFull::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
-  q[nlocal] = atof(values[1]);
+  q[nlocal] = force->numeric(FLERR,values[1]);
 
   num_bond[nlocal] = 0;
   num_angle[nlocal] = 0;

--- a/src/MOLECULE/atom_vec_full.cpp
+++ b/src/MOLECULE/atom_vec_full.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/MOLECULE/atom_vec_molecular.cpp
+++ b/src/MOLECULE/atom_vec_molecular.cpp
@@ -21,6 +21,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -927,7 +928,7 @@ void AtomVecMolecular::data_atom(double *coord, imageint imagetmp,
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = force->inumeric(FLERR,values[2]);
+  type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/MOLECULE/atom_vec_molecular.cpp
+++ b/src/MOLECULE/atom_vec_molecular.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/MOLECULE/atom_vec_molecular.cpp
+++ b/src/MOLECULE/atom_vec_molecular.cpp
@@ -926,7 +926,7 @@ void AtomVecMolecular::data_atom(double *coord, imageint imagetmp,
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = atoi(values[2]);
+  type[nlocal] = force->inumeric(FLERR,values[2]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/MOLECULE/atom_vec_template.cpp
+++ b/src/MOLECULE/atom_vec_template.cpp
@@ -23,6 +23,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -746,8 +747,8 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
     error->one(FLERR,"Invalid atom ID in Atoms section of data file");
 
   molecule[nlocal] = ATOTAGINT(values[1]);
-  molindex[nlocal] = force->inumeric(FLERR,values[2]) - 1;
-  molatom[nlocal] = force->inumeric(FLERR,values[3]) - 1;
+  molindex[nlocal] = utils::inumeric(FLERR,values[2],true,lmp) - 1;
+  molatom[nlocal] = utils::inumeric(FLERR,values[3],true,lmp) - 1;
 
   if (molindex[nlocal] < 0 || molindex[nlocal] >= nset)
     error->one(FLERR,"Invalid template index in Atoms section of data file");
@@ -755,7 +756,7 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
       molatom[nlocal] >= onemols[molindex[nlocal]]->natoms)
     error->one(FLERR,"Invalid template atom in Atoms section of data file");
 
-  type[nlocal] = force->inumeric(FLERR,values[4]);
+  type[nlocal] = utils::inumeric(FLERR,values[4],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -781,8 +782,8 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
 int AtomVecTemplate::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
-  molindex[nlocal] = force->inumeric(FLERR,values[1]) - 1;
-  molatom[nlocal] = force->inumeric(FLERR,values[2]) - 1;
+  molindex[nlocal] = utils::inumeric(FLERR,values[1],true,lmp) - 1;
+  molatom[nlocal] = utils::inumeric(FLERR,values[2],true,lmp) - 1;
   return 3;
 }
 

--- a/src/MOLECULE/atom_vec_template.cpp
+++ b/src/MOLECULE/atom_vec_template.cpp
@@ -745,8 +745,8 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
     error->one(FLERR,"Invalid atom ID in Atoms section of data file");
 
   molecule[nlocal] = ATOTAGINT(values[1]);
-  molindex[nlocal] = atoi(values[2]) - 1;
-  molatom[nlocal] = atoi(values[3]) - 1;
+  molindex[nlocal] = force->inumeric(FLERR,values[2]) - 1;
+  molatom[nlocal] = force->inumeric(FLERR,values[3]) - 1;
 
   if (molindex[nlocal] < 0 || molindex[nlocal] >= nset)
     error->one(FLERR,"Invalid template index in Atoms section of data file");
@@ -754,7 +754,7 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
       molatom[nlocal] >= onemols[molindex[nlocal]]->natoms)
     error->one(FLERR,"Invalid template atom in Atoms section of data file");
 
-  type[nlocal] = atoi(values[4]);
+  type[nlocal] = force->inumeric(FLERR,values[4]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -780,8 +780,8 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
 int AtomVecTemplate::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
-  molindex[nlocal] = atoi(values[1]) - 1;
-  molatom[nlocal] = atoi(values[2]) - 1;
+  molindex[nlocal] = force->inumeric(FLERR,values[1]) - 1;
+  molatom[nlocal] = force->inumeric(FLERR,values[2]) - 1;
   return 3;
 }
 

--- a/src/MOLECULE/atom_vec_template.cpp
+++ b/src/MOLECULE/atom_vec_template.cpp
@@ -16,6 +16,7 @@
 #include "atom_vec_template.h"
 #include "atom.h"
 #include "molecule.h"
+#include "force.h"
 #include "comm.h"
 #include "domain.h"
 #include "modify.h"

--- a/src/PERI/atom_vec_peri.cpp
+++ b/src/PERI/atom_vec_peri.cpp
@@ -28,6 +28,7 @@
 #include "citeme.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -793,12 +794,12 @@ void AtomVecPeri::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  vfrac[nlocal] = force->numeric(FLERR,values[2]);
-  rmass[nlocal] = force->numeric(FLERR,values[3]);
+  vfrac[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
+  rmass[nlocal] = utils::numeric(FLERR,values[3],true,lmp);
   if (rmass[nlocal] <= 0.0) error->one(FLERR,"Invalid mass value");
 
   x[nlocal][0] = coord[0];
@@ -827,8 +828,8 @@ void AtomVecPeri::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecPeri::data_atom_hybrid(int nlocal, char **values)
 {
-  vfrac[nlocal] = force->numeric(FLERR,values[0]);
-  rmass[nlocal] = force->numeric(FLERR,values[1]);
+  vfrac[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
+  rmass[nlocal] = utils::numeric(FLERR,values[1],true,lmp);
   if (rmass[nlocal] <= 0.0) error->one(FLERR,"Invalid mass value");
 
   s0[nlocal] = DBL_MAX;

--- a/src/PERI/atom_vec_peri.cpp
+++ b/src/PERI/atom_vec_peri.cpp
@@ -22,6 +22,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "citeme.h"

--- a/src/PERI/atom_vec_peri.cpp
+++ b/src/PERI/atom_vec_peri.cpp
@@ -792,12 +792,12 @@ void AtomVecPeri::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  vfrac[nlocal] = atof(values[2]);
-  rmass[nlocal] = atof(values[3]);
+  vfrac[nlocal] = force->numeric(FLERR,values[2]);
+  rmass[nlocal] = force->numeric(FLERR,values[3]);
   if (rmass[nlocal] <= 0.0) error->one(FLERR,"Invalid mass value");
 
   x[nlocal][0] = coord[0];
@@ -826,8 +826,8 @@ void AtomVecPeri::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecPeri::data_atom_hybrid(int nlocal, char **values)
 {
-  vfrac[nlocal] = atof(values[0]);
-  rmass[nlocal] = atof(values[1]);
+  vfrac[nlocal] = force->numeric(FLERR,values[0]);
+  rmass[nlocal] = force->numeric(FLERR,values[1]);
   if (rmass[nlocal] <= 0.0) error->one(FLERR,"Invalid mass value");
 
   s0[nlocal] = DBL_MAX;

--- a/src/SPIN/atom_vec_spin.cpp
+++ b/src/SPIN/atom_vec_spin.cpp
@@ -35,6 +35,7 @@
 #include "force.h"
 #include "memory.h"
 #include "modify.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -813,7 +814,7 @@ void AtomVecSpin::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -821,10 +822,10 @@ void AtomVecSpin::data_atom(double *coord, imageint imagetmp, char **values)
   x[nlocal][1] = coord[1];
   x[nlocal][2] = coord[2];
 
-  sp[nlocal][3] = force->numeric(FLERR,values[2]);
-  sp[nlocal][0] = force->numeric(FLERR,values[6]);
-  sp[nlocal][1] = force->numeric(FLERR,values[7]);
-  sp[nlocal][2] = force->numeric(FLERR,values[8]);
+  sp[nlocal][3] = utils::numeric(FLERR,values[2],true,lmp);
+  sp[nlocal][0] = utils::numeric(FLERR,values[6],true,lmp);
+  sp[nlocal][1] = utils::numeric(FLERR,values[7],true,lmp);
+  sp[nlocal][2] = utils::numeric(FLERR,values[8],true,lmp);
   double inorm = 1.0/sqrt(sp[nlocal][0]*sp[nlocal][0] +
                           sp[nlocal][1]*sp[nlocal][1] +
                           sp[nlocal][2]*sp[nlocal][2]);
@@ -850,16 +851,16 @@ void AtomVecSpin::data_atom(double *coord, imageint imagetmp, char **values)
 int AtomVecSpin::data_atom_hybrid(int nlocal, char **values)
 {
 
-  sp[nlocal][0] = force->numeric(FLERR,values[0]);
-  sp[nlocal][1] = force->numeric(FLERR,values[1]);
-  sp[nlocal][2] = force->numeric(FLERR,values[2]);
+  sp[nlocal][0] = utils::numeric(FLERR,values[0],true,lmp);
+  sp[nlocal][1] = utils::numeric(FLERR,values[1],true,lmp);
+  sp[nlocal][2] = utils::numeric(FLERR,values[2],true,lmp);
   double inorm = 1.0/sqrt(sp[nlocal][0]*sp[nlocal][0] +
                           sp[nlocal][1]*sp[nlocal][1] +
                           sp[nlocal][2]*sp[nlocal][2]);
   sp[nlocal][0] *= inorm;
   sp[nlocal][1] *= inorm;
   sp[nlocal][2] *= inorm;
-  sp[nlocal][3] = force->numeric(FLERR,values[3]);
+  sp[nlocal][3] = utils::numeric(FLERR,values[3],true,lmp);
 
   return 4;
 }

--- a/src/SPIN/atom_vec_spin.cpp
+++ b/src/SPIN/atom_vec_spin.cpp
@@ -812,7 +812,7 @@ void AtomVecSpin::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -820,10 +820,10 @@ void AtomVecSpin::data_atom(double *coord, imageint imagetmp, char **values)
   x[nlocal][1] = coord[1];
   x[nlocal][2] = coord[2];
 
-  sp[nlocal][3] = atof(values[2]);
-  sp[nlocal][0] = atof(values[6]);
-  sp[nlocal][1] = atof(values[7]);
-  sp[nlocal][2] = atof(values[8]);
+  sp[nlocal][3] = force->numeric(FLERR,values[2]);
+  sp[nlocal][0] = force->numeric(FLERR,values[6]);
+  sp[nlocal][1] = force->numeric(FLERR,values[7]);
+  sp[nlocal][2] = force->numeric(FLERR,values[8]);
   double inorm = 1.0/sqrt(sp[nlocal][0]*sp[nlocal][0] +
                           sp[nlocal][1]*sp[nlocal][1] +
                           sp[nlocal][2]*sp[nlocal][2]);
@@ -849,16 +849,16 @@ void AtomVecSpin::data_atom(double *coord, imageint imagetmp, char **values)
 int AtomVecSpin::data_atom_hybrid(int nlocal, char **values)
 {
 
-  sp[nlocal][0] = atof(values[0]);
-  sp[nlocal][1] = atof(values[1]);
-  sp[nlocal][2] = atof(values[2]);
+  sp[nlocal][0] = force->numeric(FLERR,values[0]);
+  sp[nlocal][1] = force->numeric(FLERR,values[1]);
+  sp[nlocal][2] = force->numeric(FLERR,values[2]);
   double inorm = 1.0/sqrt(sp[nlocal][0]*sp[nlocal][0] +
                           sp[nlocal][1]*sp[nlocal][1] +
                           sp[nlocal][2]*sp[nlocal][2]);
   sp[nlocal][0] *= inorm;
   sp[nlocal][1] *= inorm;
   sp[nlocal][2] *= inorm;
-  sp[nlocal][3] = atof(values[3]);
+  sp[nlocal][3] = force->numeric(FLERR,values[3]);
 
   return 4;
 }

--- a/src/SPIN/atom_vec_spin.cpp
+++ b/src/SPIN/atom_vec_spin.cpp
@@ -32,6 +32,7 @@
 #include "domain.h"
 #include "error.h"
 #include "fix.h"
+#include "force.h"
 #include "memory.h"
 #include "modify.h"
 

--- a/src/USER-AWPMD/atom_vec_wavepacket.cpp
+++ b/src/USER-AWPMD/atom_vec_wavepacket.cpp
@@ -916,19 +916,19 @@ void AtomVecWavepacket::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = atof(values[2]);
-  spin[nlocal] = atoi(values[3]);
-  eradius[nlocal] = atof(values[4]);
+  q[nlocal] = force->numeric(FLERR,values[2]);
+  spin[nlocal] = force->inumeric(FLERR,values[3]);
+  eradius[nlocal] = force->numeric(FLERR,values[4]);
   if (eradius[nlocal] < 0.0)
     error->one(FLERR,"Invalid eradius in Atoms section of data file");
 
-  etag[nlocal] = atoi(values[5]);
-  cs[2*nlocal] = atoi(values[6]);
-  cs[2*nlocal+1] = atof(values[7]);
+  etag[nlocal] = force->inumeric(FLERR,values[5]);
+  cs[2*nlocal] = force->inumeric(FLERR,values[6]);
+  cs[2*nlocal+1] = force->numeric(FLERR,values[7]);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -952,15 +952,15 @@ void AtomVecWavepacket::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecWavepacket::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = atof(values[0]);
-  spin[nlocal] = atoi(values[1]);
-  eradius[nlocal] = atof(values[2]);
+  q[nlocal] = force->numeric(FLERR,values[0]);
+  spin[nlocal] = force->inumeric(FLERR,values[1]);
+  eradius[nlocal] = force->numeric(FLERR,values[2]);
   if (eradius[nlocal] < 0.0)
     error->one(FLERR,"Invalid eradius in Atoms section of data file");
 
-  etag[nlocal] = atoi(values[3]);
-  cs[2*nlocal] = atoi(values[4]);
-  cs[2*nlocal+1] = atof(values[5]);
+  etag[nlocal] = force->inumeric(FLERR,values[3]);
+  cs[2*nlocal] = force->inumeric(FLERR,values[4]);
+  cs[2*nlocal+1] = force->numeric(FLERR,values[5]);
 
   v[nlocal][0] = 0.0;
   v[nlocal][1] = 0.0;
@@ -976,10 +976,10 @@ int AtomVecWavepacket::data_atom_hybrid(int nlocal, char **values)
 
 void AtomVecWavepacket::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
-  ervel[m] = atof(values[3]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
+  ervel[m] = force->numeric(FLERR,values[3]);
 }
 
 /* ----------------------------------------------------------------------
@@ -988,7 +988,7 @@ void AtomVecWavepacket::data_vel(int m, char **values)
 
 int AtomVecWavepacket::data_vel_hybrid(int m, char **values)
 {
-  ervel[m] = atof(values[0]);
+  ervel[m] = force->numeric(FLERR,values[0]);
   return 1;
 }
 

--- a/src/USER-AWPMD/atom_vec_wavepacket.cpp
+++ b/src/USER-AWPMD/atom_vec_wavepacket.cpp
@@ -27,6 +27,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -916,19 +917,19 @@ void AtomVecWavepacket::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = force->numeric(FLERR,values[2]);
-  spin[nlocal] = force->inumeric(FLERR,values[3]);
-  eradius[nlocal] = force->numeric(FLERR,values[4]);
+  q[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
+  spin[nlocal] = utils::inumeric(FLERR,values[3],true,lmp);
+  eradius[nlocal] = utils::numeric(FLERR,values[4],true,lmp);
   if (eradius[nlocal] < 0.0)
     error->one(FLERR,"Invalid eradius in Atoms section of data file");
 
-  etag[nlocal] = force->inumeric(FLERR,values[5]);
-  cs[2*nlocal] = force->inumeric(FLERR,values[6]);
-  cs[2*nlocal+1] = force->numeric(FLERR,values[7]);
+  etag[nlocal] = utils::inumeric(FLERR,values[5],true,lmp);
+  cs[2*nlocal] = utils::inumeric(FLERR,values[6],true,lmp);
+  cs[2*nlocal+1] = utils::numeric(FLERR,values[7],true,lmp);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -952,15 +953,15 @@ void AtomVecWavepacket::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecWavepacket::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = force->numeric(FLERR,values[0]);
-  spin[nlocal] = force->inumeric(FLERR,values[1]);
-  eradius[nlocal] = force->numeric(FLERR,values[2]);
+  q[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
+  spin[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
+  eradius[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
   if (eradius[nlocal] < 0.0)
     error->one(FLERR,"Invalid eradius in Atoms section of data file");
 
-  etag[nlocal] = force->inumeric(FLERR,values[3]);
-  cs[2*nlocal] = force->inumeric(FLERR,values[4]);
-  cs[2*nlocal+1] = force->numeric(FLERR,values[5]);
+  etag[nlocal] = utils::inumeric(FLERR,values[3],true,lmp);
+  cs[2*nlocal] = utils::inumeric(FLERR,values[4],true,lmp);
+  cs[2*nlocal+1] = utils::numeric(FLERR,values[5],true,lmp);
 
   v[nlocal][0] = 0.0;
   v[nlocal][1] = 0.0;
@@ -976,10 +977,10 @@ int AtomVecWavepacket::data_atom_hybrid(int nlocal, char **values)
 
 void AtomVecWavepacket::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
-  ervel[m] = force->numeric(FLERR,values[3]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  ervel[m] = utils::numeric(FLERR,values[3],true,lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -988,7 +989,7 @@ void AtomVecWavepacket::data_vel(int m, char **values)
 
 int AtomVecWavepacket::data_vel_hybrid(int m, char **values)
 {
-  ervel[m] = force->numeric(FLERR,values[0]);
+  ervel[m] = utils::numeric(FLERR,values[0],true,lmp);
   return 1;
 }
 

--- a/src/USER-AWPMD/atom_vec_wavepacket.cpp
+++ b/src/USER-AWPMD/atom_vec_wavepacket.cpp
@@ -928,7 +928,7 @@ void AtomVecWavepacket::data_atom(double *coord, imageint imagetmp,
     error->one(FLERR,"Invalid eradius in Atoms section of data file");
 
   etag[nlocal] = utils::inumeric(FLERR,values[5],true,lmp);
-  cs[2*nlocal] = utils::inumeric(FLERR,values[6],true,lmp);
+  cs[2*nlocal] = utils::numeric(FLERR,values[6],true,lmp);
   cs[2*nlocal+1] = utils::numeric(FLERR,values[7],true,lmp);
 
   x[nlocal][0] = coord[0];

--- a/src/USER-DPD/atom_vec_dpd.cpp
+++ b/src/USER-DPD/atom_vec_dpd.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/USER-DPD/atom_vec_dpd.cpp
+++ b/src/USER-DPD/atom_vec_dpd.cpp
@@ -814,11 +814,11 @@ void AtomVecDPD::data_atom(double *coord, tagint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  dpdTheta[nlocal] = atof(values[2]);
+  dpdTheta[nlocal] = force->numeric(FLERR,values[2]);
   if (dpdTheta[nlocal] <= 0)
     error->one(FLERR,"Internal temperature in Atoms section of date file must be > zero");
 
@@ -850,7 +850,7 @@ void AtomVecDPD::data_atom(double *coord, tagint imagetmp, char **values)
 
 int AtomVecDPD::data_atom_hybrid(int nlocal, char **values)
 {
-  dpdTheta[nlocal] = atof(values[0]);
+  dpdTheta[nlocal] = force->numeric(FLERR,values[0]);
 
   return 1;
 }

--- a/src/USER-DPD/atom_vec_dpd.cpp
+++ b/src/USER-DPD/atom_vec_dpd.cpp
@@ -25,6 +25,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -815,11 +816,11 @@ void AtomVecDPD::data_atom(double *coord, tagint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  dpdTheta[nlocal] = force->numeric(FLERR,values[2]);
+  dpdTheta[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
   if (dpdTheta[nlocal] <= 0)
     error->one(FLERR,"Internal temperature in Atoms section of date file must be > zero");
 
@@ -851,7 +852,7 @@ void AtomVecDPD::data_atom(double *coord, tagint imagetmp, char **values)
 
 int AtomVecDPD::data_atom_hybrid(int nlocal, char **values)
 {
-  dpdTheta[nlocal] = force->numeric(FLERR,values[0]);
+  dpdTheta[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
 
   return 1;
 }

--- a/src/USER-EFF/atom_vec_electron.cpp
+++ b/src/USER-EFF/atom_vec_electron.cpp
@@ -799,15 +799,15 @@ void AtomVecElectron::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = atof(values[2]);
-  spin[nlocal] = atoi(values[3]);
+  q[nlocal] = force->numeric(FLERR,values[2]);
+  spin[nlocal] = force->inumeric(FLERR,values[3]);
   if (spin[nlocal] == 3) atom->ecp_flag = 1;
 
-  eradius[nlocal] = atof(values[4]);
+  eradius[nlocal] = force->numeric(FLERR,values[4]);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -831,9 +831,9 @@ void AtomVecElectron::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecElectron::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = atof(values[0]);
-  spin[nlocal] = atoi(values[1]);
-  eradius[nlocal] = atof(values[2]);
+  q[nlocal] = force->numeric(FLERR,values[0]);
+  spin[nlocal] = force->inumeric(FLERR,values[1]);
+  eradius[nlocal] = force->numeric(FLERR,values[2]);
   if (eradius[nlocal] < 0.0)
     error->one(FLERR,"Invalid eradius in Atoms section of data file");
 
@@ -851,10 +851,10 @@ int AtomVecElectron::data_atom_hybrid(int nlocal, char **values)
 
 void AtomVecElectron::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
-  ervel[m] = atof(values[3]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
+  ervel[m] = force->numeric(FLERR,values[3]);
 }
 
 /* ----------------------------------------------------------------------
@@ -863,7 +863,7 @@ void AtomVecElectron::data_vel(int m, char **values)
 
 int AtomVecElectron::data_vel_hybrid(int m, char **values)
 {
-  ervel[m] = atof(values[0]);
+  ervel[m] = force->numeric(FLERR,values[0]);
   return 1;
 }
 

--- a/src/USER-EFF/atom_vec_electron.cpp
+++ b/src/USER-EFF/atom_vec_electron.cpp
@@ -28,6 +28,7 @@
 #include "citeme.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -799,15 +800,15 @@ void AtomVecElectron::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = force->numeric(FLERR,values[2]);
-  spin[nlocal] = force->inumeric(FLERR,values[3]);
+  q[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
+  spin[nlocal] = utils::inumeric(FLERR,values[3],true,lmp);
   if (spin[nlocal] == 3) atom->ecp_flag = 1;
 
-  eradius[nlocal] = force->numeric(FLERR,values[4]);
+  eradius[nlocal] = utils::numeric(FLERR,values[4],true,lmp);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -831,9 +832,9 @@ void AtomVecElectron::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecElectron::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = force->numeric(FLERR,values[0]);
-  spin[nlocal] = force->inumeric(FLERR,values[1]);
-  eradius[nlocal] = force->numeric(FLERR,values[2]);
+  q[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
+  spin[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
+  eradius[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
   if (eradius[nlocal] < 0.0)
     error->one(FLERR,"Invalid eradius in Atoms section of data file");
 
@@ -851,10 +852,10 @@ int AtomVecElectron::data_atom_hybrid(int nlocal, char **values)
 
 void AtomVecElectron::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
-  ervel[m] = force->numeric(FLERR,values[3]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  ervel[m] = utils::numeric(FLERR,values[3],true,lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -863,7 +864,7 @@ void AtomVecElectron::data_vel(int m, char **values)
 
 int AtomVecElectron::data_vel_hybrid(int m, char **values)
 {
-  ervel[m] = force->numeric(FLERR,values[0]);
+  ervel[m] = utils::numeric(FLERR,values[0],true,lmp);
   return 1;
 }
 

--- a/src/USER-MESO/atom_vec_edpd.cpp
+++ b/src/USER-MESO/atom_vec_edpd.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "update.h"

--- a/src/USER-MESO/atom_vec_edpd.cpp
+++ b/src/USER-MESO/atom_vec_edpd.cpp
@@ -759,12 +759,12 @@ void AtomVecEDPD::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  edpd_temp[nlocal] = atof(values[2]);
-  edpd_cv[nlocal] = atof(values[3]);
+  edpd_temp[nlocal] = force->numeric(FLERR,values[2]);
+  edpd_cv[nlocal] = force->numeric(FLERR,values[3]);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];

--- a/src/USER-MESO/atom_vec_edpd.cpp
+++ b/src/USER-MESO/atom_vec_edpd.cpp
@@ -22,6 +22,7 @@
 #include "update.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -760,12 +761,12 @@ void AtomVecEDPD::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  edpd_temp[nlocal] = force->numeric(FLERR,values[2]);
-  edpd_cv[nlocal] = force->numeric(FLERR,values[3]);
+  edpd_temp[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
+  edpd_cv[nlocal] = utils::numeric(FLERR,values[3],true,lmp);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];

--- a/src/USER-MESO/atom_vec_mdpd.cpp
+++ b/src/USER-MESO/atom_vec_mdpd.cpp
@@ -798,7 +798,7 @@ void AtomVecMDPD::data_atom(double *coord, imageint imagetmp, char **values) {
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -817,7 +817,7 @@ void AtomVecMDPD::data_atom(double *coord, imageint imagetmp, char **values) {
   vest[nlocal][1] = 0.0;
   vest[nlocal][2] = 0.0;
 
-  rho[nlocal] = atof(values[2]);
+  rho[nlocal] = force->numeric(FLERR,values[2]);
   drho[nlocal] = 0.0;
 
   atom->nlocal++;
@@ -830,7 +830,7 @@ void AtomVecMDPD::data_atom(double *coord, imageint imagetmp, char **values) {
 
 int AtomVecMDPD::data_atom_hybrid(int nlocal, char **values)
 {
-  rho[nlocal] = atof(values[0]);
+  rho[nlocal] = force->numeric(FLERR,values[0]);
   return 3;
 }
 

--- a/src/USER-MESO/atom_vec_mdpd.cpp
+++ b/src/USER-MESO/atom_vec_mdpd.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "update.h"

--- a/src/USER-MESO/atom_vec_mdpd.cpp
+++ b/src/USER-MESO/atom_vec_mdpd.cpp
@@ -23,6 +23,7 @@
 #include "update.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -799,7 +800,7 @@ void AtomVecMDPD::data_atom(double *coord, imageint imagetmp, char **values) {
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -818,7 +819,7 @@ void AtomVecMDPD::data_atom(double *coord, imageint imagetmp, char **values) {
   vest[nlocal][1] = 0.0;
   vest[nlocal][2] = 0.0;
 
-  rho[nlocal] = force->numeric(FLERR,values[2]);
+  rho[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
   drho[nlocal] = 0.0;
 
   atom->nlocal++;
@@ -831,7 +832,7 @@ void AtomVecMDPD::data_atom(double *coord, imageint imagetmp, char **values) {
 
 int AtomVecMDPD::data_atom_hybrid(int nlocal, char **values)
 {
-  rho[nlocal] = force->numeric(FLERR,values[0]);
+  rho[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
   return 3;
 }
 

--- a/src/USER-MESO/atom_vec_tdpd.cpp
+++ b/src/USER-MESO/atom_vec_tdpd.cpp
@@ -792,7 +792,7 @@ void AtomVecTDPD::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/USER-MESO/atom_vec_tdpd.cpp
+++ b/src/USER-MESO/atom_vec_tdpd.cpp
@@ -24,6 +24,7 @@
 #include "memory.h"
 #include "error.h"
 #include "input.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -792,7 +793,7 @@ void AtomVecTDPD::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/USER-SMD/atom_vec_smd.cpp
+++ b/src/USER-SMD/atom_vec_smd.cpp
@@ -1029,7 +1029,7 @@ void AtomVecSMD::data_atom(double *coord, imageint imagetmp, char **values) {
 
         tag[nlocal] = ATOTAGINT(values[0]);
 
-        type[nlocal] = atoi(values[1]);
+        type[nlocal] = force->inumeric(FLERR,values[1]);
         if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
                 error->one(FLERR, "Invalid atom type in Atoms section of data file");
 
@@ -1037,27 +1037,27 @@ void AtomVecSMD::data_atom(double *coord, imageint imagetmp, char **values) {
         if (molecule[nlocal] <= 0)
                 error->one(FLERR, "Invalid molecule in Atoms section of data file");
 
-        vfrac[nlocal] = atof(values[3]);
+        vfrac[nlocal] = force->numeric(FLERR,values[3]);
         if (vfrac[nlocal] < 0.0)
                 error->one(FLERR, "Invalid volume in Atoms section of data file");
 
-        rmass[nlocal] = atof(values[4]);
+        rmass[nlocal] = force->numeric(FLERR,values[4]);
         if (rmass[nlocal] == 0.0)
                 error->one(FLERR, "Invalid mass in Atoms section of data file");
 
-        radius[nlocal] = atof(values[5]);
+        radius[nlocal] = force->numeric(FLERR,values[5]);
         if (radius[nlocal] < 0.0)
                 error->one(FLERR, "Invalid radius in Atoms section of data file");
 
-        contact_radius[nlocal] = atof(values[6]);
+        contact_radius[nlocal] = force->numeric(FLERR,values[6]);
         if (contact_radius[nlocal] < 0.0)
                 error->one(FLERR, "Invalid contact radius in Atoms section of data file");
 
         e[nlocal] = 0.0;
 
-        x0[nlocal][0] = atof(values[7]);
-        x0[nlocal][1] = atof(values[8]);
-        x0[nlocal][2] = atof(values[9]);
+        x0[nlocal][0] = force->numeric(FLERR,values[7]);
+        x0[nlocal][1] = force->numeric(FLERR,values[8]);
+        x0[nlocal][2] = force->numeric(FLERR,values[9]);
 
         x[nlocal][0] = coord[0];
         x[nlocal][1] = coord[1];
@@ -1108,12 +1108,12 @@ int AtomVecSMD::data_atom_hybrid(int /*nlocal*/, char **/*values*/) {
  ------------------------------------------------------------------------- */
 
 void AtomVecSMD::data_vel(int m, char **values) {
-        v[m][0] = atof(values[0]);
-        v[m][1] = atof(values[1]);
-        v[m][2] = atof(values[2]);
-        vest[m][0] = atof(values[0]);
-        vest[m][1] = atof(values[1]);
-        vest[m][2] = atof(values[2]);
+        v[m][0] = force->numeric(FLERR,values[0]);
+        v[m][1] = force->numeric(FLERR,values[1]);
+        v[m][2] = force->numeric(FLERR,values[2]);
+        vest[m][0] = force->numeric(FLERR,values[0]);
+        vest[m][1] = force->numeric(FLERR,values[1]);
+        vest[m][2] = force->numeric(FLERR,values[2]);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-SMD/atom_vec_smd.cpp
+++ b/src/USER-SMD/atom_vec_smd.cpp
@@ -36,6 +36,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -1029,7 +1030,7 @@ void AtomVecSMD::data_atom(double *coord, imageint imagetmp, char **values) {
 
         tag[nlocal] = ATOTAGINT(values[0]);
 
-        type[nlocal] = force->inumeric(FLERR,values[1]);
+        type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
         if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
                 error->one(FLERR, "Invalid atom type in Atoms section of data file");
 
@@ -1037,27 +1038,27 @@ void AtomVecSMD::data_atom(double *coord, imageint imagetmp, char **values) {
         if (molecule[nlocal] <= 0)
                 error->one(FLERR, "Invalid molecule in Atoms section of data file");
 
-        vfrac[nlocal] = force->numeric(FLERR,values[3]);
+        vfrac[nlocal] = utils::numeric(FLERR,values[3],true,lmp);
         if (vfrac[nlocal] < 0.0)
                 error->one(FLERR, "Invalid volume in Atoms section of data file");
 
-        rmass[nlocal] = force->numeric(FLERR,values[4]);
+        rmass[nlocal] = utils::numeric(FLERR,values[4],true,lmp);
         if (rmass[nlocal] == 0.0)
                 error->one(FLERR, "Invalid mass in Atoms section of data file");
 
-        radius[nlocal] = force->numeric(FLERR,values[5]);
+        radius[nlocal] = utils::numeric(FLERR,values[5],true,lmp);
         if (radius[nlocal] < 0.0)
                 error->one(FLERR, "Invalid radius in Atoms section of data file");
 
-        contact_radius[nlocal] = force->numeric(FLERR,values[6]);
+        contact_radius[nlocal] = utils::numeric(FLERR,values[6],true,lmp);
         if (contact_radius[nlocal] < 0.0)
                 error->one(FLERR, "Invalid contact radius in Atoms section of data file");
 
         e[nlocal] = 0.0;
 
-        x0[nlocal][0] = force->numeric(FLERR,values[7]);
-        x0[nlocal][1] = force->numeric(FLERR,values[8]);
-        x0[nlocal][2] = force->numeric(FLERR,values[9]);
+        x0[nlocal][0] = utils::numeric(FLERR,values[7],true,lmp);
+        x0[nlocal][1] = utils::numeric(FLERR,values[8],true,lmp);
+        x0[nlocal][2] = utils::numeric(FLERR,values[9],true,lmp);
 
         x[nlocal][0] = coord[0];
         x[nlocal][1] = coord[1];
@@ -1108,12 +1109,12 @@ int AtomVecSMD::data_atom_hybrid(int /*nlocal*/, char **/*values*/) {
  ------------------------------------------------------------------------- */
 
 void AtomVecSMD::data_vel(int m, char **values) {
-        v[m][0] = force->numeric(FLERR,values[0]);
-        v[m][1] = force->numeric(FLERR,values[1]);
-        v[m][2] = force->numeric(FLERR,values[2]);
-        vest[m][0] = force->numeric(FLERR,values[0]);
-        vest[m][1] = force->numeric(FLERR,values[1]);
-        vest[m][2] = force->numeric(FLERR,values[2]);
+        v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+        v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+        v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+        vest[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+        vest[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+        vest[m][2] = utils::numeric(FLERR,values[2],true,lmp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-SPH/atom_vec_meso.cpp
+++ b/src/USER-SPH/atom_vec_meso.cpp
@@ -843,13 +843,13 @@ void AtomVecMeso::data_atom(double *coord, imageint imagetmp, char **values) {
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rho[nlocal] = atof(values[2]);
-  e[nlocal] = atof(values[3]);
-  cv[nlocal] = atof(values[4]);
+  rho[nlocal] = force->numeric(FLERR,values[2]);
+  e[nlocal] = force->numeric(FLERR,values[3]);
+  cv[nlocal] = force->numeric(FLERR,values[4]);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -881,9 +881,9 @@ void AtomVecMeso::data_atom(double *coord, imageint imagetmp, char **values) {
 
 int AtomVecMeso::data_atom_hybrid(int nlocal, char **values) {
 
-  rho[nlocal] = atof(values[0]);
-  e[nlocal] = atof(values[1]);
-  cv[nlocal] = atof(values[2]);
+  rho[nlocal] = force->numeric(FLERR,values[0]);
+  e[nlocal] = force->numeric(FLERR,values[1]);
+  cv[nlocal] = force->numeric(FLERR,values[2]);
 
   return 3;
 }

--- a/src/USER-SPH/atom_vec_meso.cpp
+++ b/src/USER-SPH/atom_vec_meso.cpp
@@ -22,6 +22,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -844,13 +845,13 @@ void AtomVecMeso::data_atom(double *coord, imageint imagetmp, char **values) {
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rho[nlocal] = force->numeric(FLERR,values[2]);
-  e[nlocal] = force->numeric(FLERR,values[3]);
-  cv[nlocal] = force->numeric(FLERR,values[4]);
+  rho[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
+  e[nlocal] = utils::numeric(FLERR,values[3],true,lmp);
+  cv[nlocal] = utils::numeric(FLERR,values[4],true,lmp);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -882,9 +883,9 @@ void AtomVecMeso::data_atom(double *coord, imageint imagetmp, char **values) {
 
 int AtomVecMeso::data_atom_hybrid(int nlocal, char **values) {
 
-  rho[nlocal] = force->numeric(FLERR,values[0]);
-  e[nlocal] = force->numeric(FLERR,values[1]);
-  cv[nlocal] = force->numeric(FLERR,values[2]);
+  rho[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
+  e[nlocal] = utils::numeric(FLERR,values[1],true,lmp);
+  cv[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
 
   return 3;
 }

--- a/src/USER-SPH/atom_vec_meso.cpp
+++ b/src/USER-SPH/atom_vec_meso.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -18,6 +18,7 @@
 #include "force.h"
 #include "domain.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -113,9 +114,9 @@ int AtomVec::grow_nmax_bonus(int nmax_bonus)
 void AtomVec::data_vel(int m, char **values)
 {
   double **v = atom->v;
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -113,9 +113,9 @@ int AtomVec::grow_nmax_bonus(int nmax_bonus)
 void AtomVec::data_vel(int m, char **values)
 {
   double **v = atom->v;
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom_vec_atomic.cpp
+++ b/src/atom_vec_atomic.cpp
@@ -612,7 +612,7 @@ void AtomVecAtomic::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/atom_vec_atomic.cpp
+++ b/src/atom_vec_atomic.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/atom_vec_atomic.cpp
+++ b/src/atom_vec_atomic.cpp
@@ -21,6 +21,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -613,7 +614,7 @@ void AtomVecAtomic::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 

--- a/src/atom_vec_body.cpp
+++ b/src/atom_vec_body.cpp
@@ -1280,16 +1280,16 @@ void AtomVecBody::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  body[nlocal] = atoi(values[2]);
+  body[nlocal] = force->inumeric(FLERR,values[2]);
   if (body[nlocal] == 0) body[nlocal] = -1;
   else if (body[nlocal] == 1) body[nlocal] = 0;
   else error->one(FLERR,"Invalid bodyflag in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[3]);
+  rmass[nlocal] = force->numeric(FLERR,values[3]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1318,12 +1318,12 @@ void AtomVecBody::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecBody::data_atom_hybrid(int nlocal, char **values)
 {
-  body[nlocal] = atoi(values[0]);
+  body[nlocal] = force->inumeric(FLERR,values[0]);
   if (body[nlocal] == 0) body[nlocal] = -1;
   else if (body[nlocal] == 1) body[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[1]);
+  rmass[nlocal] = force->numeric(FLERR,values[1]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1350,12 +1350,12 @@ void AtomVecBody::data_body(int m, int ninteger, int ndouble,
 
 void AtomVecBody::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
-  angmom[m][0] = atof(values[3]);
-  angmom[m][1] = atof(values[4]);
-  angmom[m][2] = atof(values[5]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
+  angmom[m][0] = force->numeric(FLERR,values[3]);
+  angmom[m][1] = force->numeric(FLERR,values[4]);
+  angmom[m][2] = force->numeric(FLERR,values[5]);
 }
 
 /* ----------------------------------------------------------------------
@@ -1364,9 +1364,9 @@ void AtomVecBody::data_vel(int m, char **values)
 
 int AtomVecBody::data_vel_hybrid(int m, char **values)
 {
-  angmom[m][0] = atof(values[0]);
-  angmom[m][1] = atof(values[1]);
-  angmom[m][2] = atof(values[2]);
+  angmom[m][0] = force->numeric(FLERR,values[0]);
+  angmom[m][1] = force->numeric(FLERR,values[1]);
+  angmom[m][2] = force->numeric(FLERR,values[2]);
   return 3;
 }
 

--- a/src/atom_vec_body.cpp
+++ b/src/atom_vec_body.cpp
@@ -1280,16 +1280,16 @@ void AtomVecBody::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  body[nlocal] = force->inumeric(FLERR,values[2]);
+  body[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (body[nlocal] == 0) body[nlocal] = -1;
   else if (body[nlocal] == 1) body[nlocal] = 0;
   else error->one(FLERR,"Invalid bodyflag in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[3]);
+  rmass[nlocal] = utils::numeric(FLERR,values[3],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1318,12 +1318,12 @@ void AtomVecBody::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecBody::data_atom_hybrid(int nlocal, char **values)
 {
-  body[nlocal] = force->inumeric(FLERR,values[0]);
+  body[nlocal] = utils::inumeric(FLERR,values[0],true,lmp);
   if (body[nlocal] == 0) body[nlocal] = -1;
   else if (body[nlocal] == 1) body[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[1]);
+  rmass[nlocal] = utils::numeric(FLERR,values[1],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1350,12 +1350,12 @@ void AtomVecBody::data_body(int m, int ninteger, int ndouble,
 
 void AtomVecBody::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
-  angmom[m][0] = force->numeric(FLERR,values[3]);
-  angmom[m][1] = force->numeric(FLERR,values[4]);
-  angmom[m][2] = force->numeric(FLERR,values[5]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  angmom[m][0] = utils::numeric(FLERR,values[3],true,lmp);
+  angmom[m][1] = utils::numeric(FLERR,values[4],true,lmp);
+  angmom[m][2] = utils::numeric(FLERR,values[5],true,lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1364,9 +1364,9 @@ void AtomVecBody::data_vel(int m, char **values)
 
 int AtomVecBody::data_vel_hybrid(int m, char **values)
 {
-  angmom[m][0] = force->numeric(FLERR,values[0]);
-  angmom[m][1] = force->numeric(FLERR,values[1]);
-  angmom[m][2] = force->numeric(FLERR,values[2]);
+  angmom[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  angmom[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  angmom[m][2] = utils::numeric(FLERR,values[2],true,lmp);
   return 3;
 }
 

--- a/src/atom_vec_charge.cpp
+++ b/src/atom_vec_charge.cpp
@@ -21,6 +21,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -664,11 +665,11 @@ void AtomVecCharge::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = force->numeric(FLERR,values[2]);
+  q[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -691,7 +692,7 @@ void AtomVecCharge::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecCharge::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = force->numeric(FLERR,values[0]);
+  q[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
 
   return 1;
 }

--- a/src/atom_vec_charge.cpp
+++ b/src/atom_vec_charge.cpp
@@ -663,11 +663,11 @@ void AtomVecCharge::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  q[nlocal] = atof(values[2]);
+  q[nlocal] = force->numeric(FLERR,values[2]);
 
   x[nlocal][0] = coord[0];
   x[nlocal][1] = coord[1];
@@ -690,7 +690,7 @@ void AtomVecCharge::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecCharge::data_atom_hybrid(int nlocal, char **values)
 {
-  q[nlocal] = atof(values[0]);
+  q[nlocal] = force->numeric(FLERR,values[0]);
 
   return 1;
 }

--- a/src/atom_vec_charge.cpp
+++ b/src/atom_vec_charge.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -1141,16 +1141,16 @@ void AtomVecEllipsoid::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  ellipsoid[nlocal] = atoi(values[2]);
+  ellipsoid[nlocal] = force->inumeric(FLERR,values[2]);
   if (ellipsoid[nlocal] == 0) ellipsoid[nlocal] = -1;
   else if (ellipsoid[nlocal] == 1) ellipsoid[nlocal] = 0;
   else error->one(FLERR,"Invalid ellipsoidflag in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[3]);
+  rmass[nlocal] = force->numeric(FLERR,values[3]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1178,12 +1178,12 @@ void AtomVecEllipsoid::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecEllipsoid::data_atom_hybrid(int nlocal, char **values)
 {
-  ellipsoid[nlocal] = atoi(values[0]);
+  ellipsoid[nlocal] = force->inumeric(FLERR,values[0]);
   if (ellipsoid[nlocal] == 0) ellipsoid[nlocal] = -1;
   else if (ellipsoid[nlocal] == 1) ellipsoid[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[1]);
+  rmass[nlocal] = force->numeric(FLERR,values[1]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1202,17 +1202,17 @@ void AtomVecEllipsoid::data_atom_bonus(int m, char **values)
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
   double *shape = bonus[nlocal_bonus].shape;
-  shape[0] = 0.5 * atof(values[0]);
-  shape[1] = 0.5 * atof(values[1]);
-  shape[2] = 0.5 * atof(values[2]);
+  shape[0] = 0.5 * force->numeric(FLERR,values[0]);
+  shape[1] = 0.5 * force->numeric(FLERR,values[1]);
+  shape[2] = 0.5 * force->numeric(FLERR,values[2]);
   if (shape[0] <= 0.0 || shape[1] <= 0.0 || shape[2] <= 0.0)
     error->one(FLERR,"Invalid shape in Ellipsoids section of data file");
 
   double *quat = bonus[nlocal_bonus].quat;
-  quat[0] = atof(values[3]);
-  quat[1] = atof(values[4]);
-  quat[2] = atof(values[5]);
-  quat[3] = atof(values[6]);
+  quat[0] = force->numeric(FLERR,values[3]);
+  quat[1] = force->numeric(FLERR,values[4]);
+  quat[2] = force->numeric(FLERR,values[5]);
+  quat[3] = force->numeric(FLERR,values[6]);
   MathExtra::qnormalize(quat);
 
   // reset ellipsoid mass
@@ -1230,12 +1230,12 @@ void AtomVecEllipsoid::data_atom_bonus(int m, char **values)
 
 void AtomVecEllipsoid::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
-  angmom[m][0] = atof(values[3]);
-  angmom[m][1] = atof(values[4]);
-  angmom[m][2] = atof(values[5]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
+  angmom[m][0] = force->numeric(FLERR,values[3]);
+  angmom[m][1] = force->numeric(FLERR,values[4]);
+  angmom[m][2] = force->numeric(FLERR,values[5]);
 }
 
 /* ----------------------------------------------------------------------
@@ -1244,9 +1244,9 @@ void AtomVecEllipsoid::data_vel(int m, char **values)
 
 int AtomVecEllipsoid::data_vel_hybrid(int m, char **values)
 {
-  angmom[m][0] = atof(values[0]);
-  angmom[m][1] = atof(values[1]);
-  angmom[m][2] = atof(values[2]);
+  angmom[m][0] = force->numeric(FLERR,values[0]);
+  angmom[m][1] = force->numeric(FLERR,values[1]);
+  angmom[m][2] = force->numeric(FLERR,values[2]);
   return 3;
 }
 

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -27,6 +27,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -1141,16 +1142,16 @@ void AtomVecEllipsoid::data_atom(double *coord, imageint imagetmp,
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  ellipsoid[nlocal] = force->inumeric(FLERR,values[2]);
+  ellipsoid[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (ellipsoid[nlocal] == 0) ellipsoid[nlocal] = -1;
   else if (ellipsoid[nlocal] == 1) ellipsoid[nlocal] = 0;
   else error->one(FLERR,"Invalid ellipsoidflag in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[3]);
+  rmass[nlocal] = utils::numeric(FLERR,values[3],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1178,12 +1179,12 @@ void AtomVecEllipsoid::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecEllipsoid::data_atom_hybrid(int nlocal, char **values)
 {
-  ellipsoid[nlocal] = force->inumeric(FLERR,values[0]);
+  ellipsoid[nlocal] = utils::inumeric(FLERR,values[0],true,lmp);
   if (ellipsoid[nlocal] == 0) ellipsoid[nlocal] = -1;
   else if (ellipsoid[nlocal] == 1) ellipsoid[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[1]);
+  rmass[nlocal] = utils::numeric(FLERR,values[1],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1202,17 +1203,17 @@ void AtomVecEllipsoid::data_atom_bonus(int m, char **values)
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
   double *shape = bonus[nlocal_bonus].shape;
-  shape[0] = 0.5 * force->numeric(FLERR,values[0]);
-  shape[1] = 0.5 * force->numeric(FLERR,values[1]);
-  shape[2] = 0.5 * force->numeric(FLERR,values[2]);
+  shape[0] = 0.5 * utils::numeric(FLERR,values[0],true,lmp);
+  shape[1] = 0.5 * utils::numeric(FLERR,values[1],true,lmp);
+  shape[2] = 0.5 * utils::numeric(FLERR,values[2],true,lmp);
   if (shape[0] <= 0.0 || shape[1] <= 0.0 || shape[2] <= 0.0)
     error->one(FLERR,"Invalid shape in Ellipsoids section of data file");
 
   double *quat = bonus[nlocal_bonus].quat;
-  quat[0] = force->numeric(FLERR,values[3]);
-  quat[1] = force->numeric(FLERR,values[4]);
-  quat[2] = force->numeric(FLERR,values[5]);
-  quat[3] = force->numeric(FLERR,values[6]);
+  quat[0] = utils::numeric(FLERR,values[3],true,lmp);
+  quat[1] = utils::numeric(FLERR,values[4],true,lmp);
+  quat[2] = utils::numeric(FLERR,values[5],true,lmp);
+  quat[3] = utils::numeric(FLERR,values[6],true,lmp);
   MathExtra::qnormalize(quat);
 
   // reset ellipsoid mass
@@ -1230,12 +1231,12 @@ void AtomVecEllipsoid::data_atom_bonus(int m, char **values)
 
 void AtomVecEllipsoid::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
-  angmom[m][0] = force->numeric(FLERR,values[3]);
-  angmom[m][1] = force->numeric(FLERR,values[4]);
-  angmom[m][2] = force->numeric(FLERR,values[5]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  angmom[m][0] = utils::numeric(FLERR,values[3],true,lmp);
+  angmom[m][1] = utils::numeric(FLERR,values[4],true,lmp);
+  angmom[m][2] = utils::numeric(FLERR,values[5],true,lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1244,9 +1245,9 @@ void AtomVecEllipsoid::data_vel(int m, char **values)
 
 int AtomVecEllipsoid::data_vel_hybrid(int m, char **values)
 {
-  angmom[m][0] = force->numeric(FLERR,values[0]);
-  angmom[m][1] = force->numeric(FLERR,values[1]);
-  angmom[m][2] = force->numeric(FLERR,values[2]);
+  angmom[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  angmom[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  angmom[m][2] = utils::numeric(FLERR,values[2],true,lmp);
   return 3;
 }
 

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -863,7 +863,7 @@ void AtomVecHybrid::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -903,9 +903,9 @@ void AtomVecHybrid::data_atom(double *coord, imageint imagetmp, char **values)
 
 void AtomVecHybrid::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
 
   // each sub-style parses sub-style specific values
 

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -16,6 +16,7 @@
 #include "atom_vec_hybrid.h"
 #include "atom.h"
 #include "domain.h"
+#include "force.h"
 #include "modify.h"
 #include "fix.h"
 #include "memory.h"

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -21,6 +21,7 @@
 #include "fix.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -864,7 +865,7 @@ void AtomVecHybrid::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
@@ -904,9 +905,9 @@ void AtomVecHybrid::data_atom(double *coord, imageint imagetmp, char **values)
 
 void AtomVecHybrid::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
 
   // each sub-style parses sub-style specific values
 

--- a/src/atom_vec_line.cpp
+++ b/src/atom_vec_line.cpp
@@ -1037,16 +1037,16 @@ void AtomVecLine::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = atoi(values[2]);
+  type[nlocal] = force->inumeric(FLERR,values[2]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  line[nlocal] = atoi(values[3]);
+  line[nlocal] = force->inumeric(FLERR,values[3]);
   if (line[nlocal] == 0) line[nlocal] = -1;
   else if (line[nlocal] == 1) line[nlocal] = 0;
   else error->one(FLERR,"Invalid lineflag in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[4]);
+  rmass[nlocal] = force->numeric(FLERR,values[4]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1082,12 +1082,12 @@ int AtomVecLine::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
 
-  line[nlocal] = atoi(values[1]);
+  line[nlocal] = force->inumeric(FLERR,values[1]);
   if (line[nlocal] == 0) line[nlocal] = -1;
   else if (line[nlocal] == 1) line[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[2]);
+  rmass[nlocal] = force->numeric(FLERR,values[2]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1110,10 +1110,10 @@ void AtomVecLine::data_atom_bonus(int m, char **values)
 
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
-  double x1 = atof(values[0]);
-  double y1 = atof(values[1]);
-  double x2 = atof(values[2]);
-  double y2 = atof(values[3]);
+  double x1 = force->numeric(FLERR,values[0]);
+  double y1 = force->numeric(FLERR,values[1]);
+  double x2 = force->numeric(FLERR,values[2]);
+  double y2 = force->numeric(FLERR,values[3]);
   double dx = x2 - x1;
   double dy = y2 - y1;
   double length = sqrt(dx*dx + dy*dy);
@@ -1150,12 +1150,12 @@ void AtomVecLine::data_atom_bonus(int m, char **values)
 
 void AtomVecLine::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
-  omega[m][0] = atof(values[3]);
-  omega[m][1] = atof(values[4]);
-  omega[m][2] = atof(values[5]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
+  omega[m][0] = force->numeric(FLERR,values[3]);
+  omega[m][1] = force->numeric(FLERR,values[4]);
+  omega[m][2] = force->numeric(FLERR,values[5]);
 }
 
 /* ----------------------------------------------------------------------
@@ -1164,9 +1164,9 @@ void AtomVecLine::data_vel(int m, char **values)
 
 int AtomVecLine::data_vel_hybrid(int m, char **values)
 {
-  omega[m][0] = atof(values[0]);
-  omega[m][1] = atof(values[1]);
-  omega[m][2] = atof(values[2]);
+  omega[m][0] = force->numeric(FLERR,values[0]);
+  omega[m][1] = force->numeric(FLERR,values[1]);
+  omega[m][2] = force->numeric(FLERR,values[2]);
   return 3;
 }
 

--- a/src/atom_vec_line.cpp
+++ b/src/atom_vec_line.cpp
@@ -24,6 +24,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -1037,16 +1038,16 @@ void AtomVecLine::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = force->inumeric(FLERR,values[2]);
+  type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  line[nlocal] = force->inumeric(FLERR,values[3]);
+  line[nlocal] = utils::inumeric(FLERR,values[3],true,lmp);
   if (line[nlocal] == 0) line[nlocal] = -1;
   else if (line[nlocal] == 1) line[nlocal] = 0;
   else error->one(FLERR,"Invalid lineflag in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[4]);
+  rmass[nlocal] = utils::numeric(FLERR,values[4],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1082,12 +1083,12 @@ int AtomVecLine::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
 
-  line[nlocal] = force->inumeric(FLERR,values[1]);
+  line[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (line[nlocal] == 0) line[nlocal] = -1;
   else if (line[nlocal] == 1) line[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[2]);
+  rmass[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1110,10 +1111,10 @@ void AtomVecLine::data_atom_bonus(int m, char **values)
 
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
-  double x1 = force->numeric(FLERR,values[0]);
-  double y1 = force->numeric(FLERR,values[1]);
-  double x2 = force->numeric(FLERR,values[2]);
-  double y2 = force->numeric(FLERR,values[3]);
+  double x1 = utils::numeric(FLERR,values[0],true,lmp);
+  double y1 = utils::numeric(FLERR,values[1],true,lmp);
+  double x2 = utils::numeric(FLERR,values[2],true,lmp);
+  double y2 = utils::numeric(FLERR,values[3],true,lmp);
   double dx = x2 - x1;
   double dy = y2 - y1;
   double length = sqrt(dx*dx + dy*dy);
@@ -1150,12 +1151,12 @@ void AtomVecLine::data_atom_bonus(int m, char **values)
 
 void AtomVecLine::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
-  omega[m][0] = force->numeric(FLERR,values[3]);
-  omega[m][1] = force->numeric(FLERR,values[4]);
-  omega[m][2] = force->numeric(FLERR,values[5]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  omega[m][0] = utils::numeric(FLERR,values[3],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[4],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[5],true,lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1164,9 +1165,9 @@ void AtomVecLine::data_vel(int m, char **values)
 
 int AtomVecLine::data_vel_hybrid(int m, char **values)
 {
-  omega[m][0] = force->numeric(FLERR,values[0]);
-  omega[m][1] = force->numeric(FLERR,values[1]);
-  omega[m][2] = force->numeric(FLERR,values[2]);
+  omega[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[2],true,lmp);
   return 3;
 }
 

--- a/src/atom_vec_sphere.cpp
+++ b/src/atom_vec_sphere.cpp
@@ -25,6 +25,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -965,15 +966,15 @@ void AtomVecSphere::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = force->inumeric(FLERR,values[1]);
+  type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  radius[nlocal] = 0.5 * force->numeric(FLERR,values[2]);
+  radius[nlocal] = 0.5 * utils::numeric(FLERR,values[2],true,lmp);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = force->numeric(FLERR,values[3]);
+  double density = utils::numeric(FLERR,values[3],true,lmp);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1006,11 +1007,11 @@ void AtomVecSphere::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecSphere::data_atom_hybrid(int nlocal, char **values)
 {
-  radius[nlocal] = 0.5 * force->numeric(FLERR,values[0]);
+  radius[nlocal] = 0.5 * utils::numeric(FLERR,values[0],true,lmp);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = force->numeric(FLERR,values[1]);
+  double density = utils::numeric(FLERR,values[1],true,lmp);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1028,12 +1029,12 @@ int AtomVecSphere::data_atom_hybrid(int nlocal, char **values)
 
 void AtomVecSphere::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
-  omega[m][0] = force->numeric(FLERR,values[3]);
-  omega[m][1] = force->numeric(FLERR,values[4]);
-  omega[m][2] = force->numeric(FLERR,values[5]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  omega[m][0] = utils::numeric(FLERR,values[3],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[4],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[5],true,lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1042,9 +1043,9 @@ void AtomVecSphere::data_vel(int m, char **values)
 
 int AtomVecSphere::data_vel_hybrid(int m, char **values)
 {
-  omega[m][0] = force->numeric(FLERR,values[0]);
-  omega[m][1] = force->numeric(FLERR,values[1]);
-  omega[m][2] = force->numeric(FLERR,values[2]);
+  omega[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[2],true,lmp);
   return 3;
 }
 

--- a/src/atom_vec_sphere.cpp
+++ b/src/atom_vec_sphere.cpp
@@ -965,15 +965,15 @@ void AtomVecSphere::data_atom(double *coord, imageint imagetmp, char **values)
   if (nlocal == nmax) grow(0);
 
   tag[nlocal] = ATOTAGINT(values[0]);
-  type[nlocal] = atoi(values[1]);
+  type[nlocal] = force->inumeric(FLERR,values[1]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  radius[nlocal] = 0.5 * atof(values[2]);
+  radius[nlocal] = 0.5 * force->numeric(FLERR,values[2]);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = atof(values[3]);
+  double density = force->numeric(FLERR,values[3]);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1006,11 +1006,11 @@ void AtomVecSphere::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecSphere::data_atom_hybrid(int nlocal, char **values)
 {
-  radius[nlocal] = 0.5 * atof(values[0]);
+  radius[nlocal] = 0.5 * force->numeric(FLERR,values[0]);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = atof(values[1]);
+  double density = force->numeric(FLERR,values[1]);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1028,12 +1028,12 @@ int AtomVecSphere::data_atom_hybrid(int nlocal, char **values)
 
 void AtomVecSphere::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
-  omega[m][0] = atof(values[3]);
-  omega[m][1] = atof(values[4]);
-  omega[m][2] = atof(values[5]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
+  omega[m][0] = force->numeric(FLERR,values[3]);
+  omega[m][1] = force->numeric(FLERR,values[4]);
+  omega[m][2] = force->numeric(FLERR,values[5]);
 }
 
 /* ----------------------------------------------------------------------
@@ -1042,9 +1042,9 @@ void AtomVecSphere::data_vel(int m, char **values)
 
 int AtomVecSphere::data_vel_hybrid(int m, char **values)
 {
-  omega[m][0] = atof(values[0]);
-  omega[m][1] = atof(values[1]);
-  omega[m][2] = atof(values[2]);
+  omega[m][0] = force->numeric(FLERR,values[0]);
+  omega[m][1] = force->numeric(FLERR,values[1]);
+  omega[m][2] = force->numeric(FLERR,values[2]);
   return 3;
 }
 

--- a/src/atom_vec_tri.cpp
+++ b/src/atom_vec_tri.cpp
@@ -1436,16 +1436,16 @@ void AtomVecTri::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = atoi(values[2]);
+  type[nlocal] = force->inumeric(FLERR,values[2]);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  tri[nlocal] = atoi(values[3]);
+  tri[nlocal] = force->inumeric(FLERR,values[3]);
   if (tri[nlocal] == 0) tri[nlocal] = -1;
   else if (tri[nlocal] == 1) tri[nlocal] = 0;
   else error->one(FLERR,"Invalid triflag in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[4]);
+  rmass[nlocal] = force->numeric(FLERR,values[4]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1484,12 +1484,12 @@ int AtomVecTri::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
 
-  tri[nlocal] = atoi(values[1]);
+  tri[nlocal] = force->inumeric(FLERR,values[1]);
   if (tri[nlocal] == 0) tri[nlocal] = -1;
   else if (tri[nlocal] == 1) tri[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = atof(values[2]);
+  rmass[nlocal] = force->numeric(FLERR,values[2]);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1513,15 +1513,15 @@ void AtomVecTri::data_atom_bonus(int m, char **values)
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
   double c1[3],c2[3],c3[3];
-  c1[0] = atof(values[0]);
-  c1[1] = atof(values[1]);
-  c1[2] = atof(values[2]);
-  c2[0] = atof(values[3]);
-  c2[1] = atof(values[4]);
-  c2[2] = atof(values[5]);
-  c3[0] = atof(values[6]);
-  c3[1] = atof(values[7]);
-  c3[2] = atof(values[8]);
+  c1[0] = force->numeric(FLERR,values[0]);
+  c1[1] = force->numeric(FLERR,values[1]);
+  c1[2] = force->numeric(FLERR,values[2]);
+  c2[0] = force->numeric(FLERR,values[3]);
+  c2[1] = force->numeric(FLERR,values[4]);
+  c2[2] = force->numeric(FLERR,values[5]);
+  c3[0] = force->numeric(FLERR,values[6]);
+  c3[1] = force->numeric(FLERR,values[7]);
+  c3[2] = force->numeric(FLERR,values[8]);
 
   // check for duplicate points
 
@@ -1641,15 +1641,15 @@ void AtomVecTri::data_atom_bonus(int m, char **values)
 
 void AtomVecTri::data_vel(int m, char **values)
 {
-  v[m][0] = atof(values[0]);
-  v[m][1] = atof(values[1]);
-  v[m][2] = atof(values[2]);
-  omega[m][0] = atof(values[3]);
-  omega[m][1] = atof(values[4]);
-  omega[m][2] = atof(values[5]);
-  angmom[m][0] = atof(values[6]);
-  angmom[m][1] = atof(values[7]);
-  angmom[m][2] = atof(values[8]);
+  v[m][0] = force->numeric(FLERR,values[0]);
+  v[m][1] = force->numeric(FLERR,values[1]);
+  v[m][2] = force->numeric(FLERR,values[2]);
+  omega[m][0] = force->numeric(FLERR,values[3]);
+  omega[m][1] = force->numeric(FLERR,values[4]);
+  omega[m][2] = force->numeric(FLERR,values[5]);
+  angmom[m][0] = force->numeric(FLERR,values[6]);
+  angmom[m][1] = force->numeric(FLERR,values[7]);
+  angmom[m][2] = force->numeric(FLERR,values[8]);
 }
 
 /* ----------------------------------------------------------------------
@@ -1658,12 +1658,12 @@ void AtomVecTri::data_vel(int m, char **values)
 
 int AtomVecTri::data_vel_hybrid(int m, char **values)
 {
-  omega[m][0] = atof(values[0]);
-  omega[m][1] = atof(values[1]);
-  omega[m][2] = atof(values[2]);
-  angmom[m][0] = atof(values[3]);
-  angmom[m][1] = atof(values[4]);
-  angmom[m][2] = atof(values[5]);
+  omega[m][0] = force->numeric(FLERR,values[0]);
+  omega[m][1] = force->numeric(FLERR,values[1]);
+  omega[m][2] = force->numeric(FLERR,values[2]);
+  angmom[m][0] = force->numeric(FLERR,values[3]);
+  angmom[m][1] = force->numeric(FLERR,values[4]);
+  angmom[m][2] = force->numeric(FLERR,values[5]);
   return 6;
 }
 

--- a/src/atom_vec_tri.cpp
+++ b/src/atom_vec_tri.cpp
@@ -25,6 +25,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -1436,16 +1437,16 @@ void AtomVecTri::data_atom(double *coord, imageint imagetmp, char **values)
 
   tag[nlocal] = ATOTAGINT(values[0]);
   molecule[nlocal] = ATOTAGINT(values[1]);
-  type[nlocal] = force->inumeric(FLERR,values[2]);
+  type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  tri[nlocal] = force->inumeric(FLERR,values[3]);
+  tri[nlocal] = utils::inumeric(FLERR,values[3],true,lmp);
   if (tri[nlocal] == 0) tri[nlocal] = -1;
   else if (tri[nlocal] == 1) tri[nlocal] = 0;
   else error->one(FLERR,"Invalid triflag in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[4]);
+  rmass[nlocal] = utils::numeric(FLERR,values[4],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1484,12 +1485,12 @@ int AtomVecTri::data_atom_hybrid(int nlocal, char **values)
 {
   molecule[nlocal] = ATOTAGINT(values[0]);
 
-  tri[nlocal] = force->inumeric(FLERR,values[1]);
+  tri[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (tri[nlocal] == 0) tri[nlocal] = -1;
   else if (tri[nlocal] == 1) tri[nlocal] = 0;
   else error->one(FLERR,"Invalid atom type in Atoms section of data file");
 
-  rmass[nlocal] = force->numeric(FLERR,values[2]);
+  rmass[nlocal] = utils::numeric(FLERR,values[2],true,lmp);
   if (rmass[nlocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 
@@ -1513,15 +1514,15 @@ void AtomVecTri::data_atom_bonus(int m, char **values)
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
   double c1[3],c2[3],c3[3];
-  c1[0] = force->numeric(FLERR,values[0]);
-  c1[1] = force->numeric(FLERR,values[1]);
-  c1[2] = force->numeric(FLERR,values[2]);
-  c2[0] = force->numeric(FLERR,values[3]);
-  c2[1] = force->numeric(FLERR,values[4]);
-  c2[2] = force->numeric(FLERR,values[5]);
-  c3[0] = force->numeric(FLERR,values[6]);
-  c3[1] = force->numeric(FLERR,values[7]);
-  c3[2] = force->numeric(FLERR,values[8]);
+  c1[0] = utils::numeric(FLERR,values[0],true,lmp);
+  c1[1] = utils::numeric(FLERR,values[1],true,lmp);
+  c1[2] = utils::numeric(FLERR,values[2],true,lmp);
+  c2[0] = utils::numeric(FLERR,values[3],true,lmp);
+  c2[1] = utils::numeric(FLERR,values[4],true,lmp);
+  c2[2] = utils::numeric(FLERR,values[5],true,lmp);
+  c3[0] = utils::numeric(FLERR,values[6],true,lmp);
+  c3[1] = utils::numeric(FLERR,values[7],true,lmp);
+  c3[2] = utils::numeric(FLERR,values[8],true,lmp);
 
   // check for duplicate points
 
@@ -1641,15 +1642,15 @@ void AtomVecTri::data_atom_bonus(int m, char **values)
 
 void AtomVecTri::data_vel(int m, char **values)
 {
-  v[m][0] = force->numeric(FLERR,values[0]);
-  v[m][1] = force->numeric(FLERR,values[1]);
-  v[m][2] = force->numeric(FLERR,values[2]);
-  omega[m][0] = force->numeric(FLERR,values[3]);
-  omega[m][1] = force->numeric(FLERR,values[4]);
-  omega[m][2] = force->numeric(FLERR,values[5]);
-  angmom[m][0] = force->numeric(FLERR,values[6]);
-  angmom[m][1] = force->numeric(FLERR,values[7]);
-  angmom[m][2] = force->numeric(FLERR,values[8]);
+  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  omega[m][0] = utils::numeric(FLERR,values[3],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[4],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[5],true,lmp);
+  angmom[m][0] = utils::numeric(FLERR,values[6],true,lmp);
+  angmom[m][1] = utils::numeric(FLERR,values[7],true,lmp);
+  angmom[m][2] = utils::numeric(FLERR,values[8],true,lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1658,12 +1659,12 @@ void AtomVecTri::data_vel(int m, char **values)
 
 int AtomVecTri::data_vel_hybrid(int m, char **values)
 {
-  omega[m][0] = force->numeric(FLERR,values[0]);
-  omega[m][1] = force->numeric(FLERR,values[1]);
-  omega[m][2] = force->numeric(FLERR,values[2]);
-  angmom[m][0] = force->numeric(FLERR,values[3]);
-  angmom[m][1] = force->numeric(FLERR,values[4]);
-  angmom[m][2] = force->numeric(FLERR,values[5]);
+  omega[m][0] = utils::numeric(FLERR,values[0],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[1],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  angmom[m][0] = utils::numeric(FLERR,values[3],true,lmp);
+  angmom[m][1] = utils::numeric(FLERR,values[4],true,lmp);
+  angmom[m][2] = utils::numeric(FLERR,values[5],true,lmp);
   return 6;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -141,6 +141,150 @@ std::string utils::check_packages_for_style(std::string style,
   return errmsg;
 }
 
+
+/* ----------------------------------------------------------------------
+   read a floating point value from a string
+   generate an error if not a legitimate floating point value
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+double utils::numeric(const char *file, int line, const char *str,
+                      bool do_abort, LAMMPS *lmp)
+{
+  int n = 0;
+
+  if (str) n = strlen(str);
+  if (n == 0) {
+    if (do_abort)
+      lmp->error->one(file,line,"Expected floating point parameter instead of"
+                      " NULL or empty string in input script or data file");
+    else
+      lmp->error->all(file,line,"Expected floating point parameter instead of"
+                      " NULL or empty string in input script or data file");
+  }
+
+  for (int i = 0; i < n; i++) {
+    if (isdigit(str[i])) continue;
+    if (str[i] == '-' || str[i] == '+' || str[i] == '.') continue;
+    if (str[i] == 'e' || str[i] == 'E') continue;
+    std::string msg("Expected floating point parameter instead of '");
+    msg += str;
+    msg += "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg.c_str());
+    else
+      lmp->error->all(file,line,msg.c_str());
+  }
+
+  return atof(str);
+}
+
+/* ----------------------------------------------------------------------
+   read an integer value from a string
+   generate an error if not a legitimate integer value
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+int utils::inumeric(const char *file, int line, const char *str,
+                    bool do_abort, LAMMPS *lmp)
+{
+  int n = 0;
+
+  if (str) n = strlen(str);
+  if (n == 0) {
+    if (do_abort)
+      lmp->error->one(file,line,"Expected integer parameter instead of "
+                      "NULL or empty string in input script or data file");
+    else
+      lmp->error->all(file,line,"Expected integer parameter instead of "
+                      "NULL or empty string in input script or data file");
+  }
+
+  for (int i = 0; i < n; i++) {
+    if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
+    std::string msg("Expected integer parameter instead of '");
+    msg += str;
+    msg += "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg.c_str());
+    else
+      lmp->error->all(file,line,msg.c_str());
+  }
+
+  return atoi(str);
+}
+
+/* ----------------------------------------------------------------------
+   read a big integer value from a string
+   generate an error if not a legitimate integer value
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+bigint utils::bnumeric(const char *file, int line, const char *str,
+                       bool do_abort, LAMMPS *lmp)
+{
+  int n = 0;
+
+  if (str) n = strlen(str);
+  if (n == 0) {
+    if (do_abort)
+      lmp->error->one(file,line,"Expected integer parameter instead of "
+                      "NULL or empty string in input script or data file");
+    else
+      lmp->error->all(file,line,"Expected integer parameter instead of "
+                      "NULL or empty string in input script or data file");
+  }
+
+  for (int i = 0; i < n; i++) {
+    if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
+    std::string msg("Expected integer parameter instead of '");
+    msg += str;
+    msg += "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg.c_str());
+    else
+      lmp->error->all(file,line,msg.c_str());
+  }
+
+  return ATOBIGINT(str);
+}
+
+/* ----------------------------------------------------------------------
+   read a tag integer value from a string
+   generate an error if not a legitimate integer value
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+tagint utils::tnumeric(const char *file, int line, const char *str,
+                       bool do_abort, LAMMPS *lmp)
+{
+  int n = 0;
+
+  if (str) n = strlen(str);
+  if (n == 0) {
+    if (do_abort)
+      lmp->error->one(file,line,"Expected integer parameter instead of "
+                      "NULL or empty string in input script or data file");
+    else
+      lmp->error->all(file,line,"Expected integer parameter instead of "
+                      "NULL or empty string in input script or data file");
+  }
+
+  for (int i = 0; i < n; i++) {
+    if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
+    std::string msg("Expected integer parameter instead of '");
+    msg += str;
+    msg += "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg.c_str());
+    else
+      lmp->error->all(file,line,msg.c_str());
+  }
+
+  return ATOTAGINT(str);
+}
+
+
 /* ------------------------------------------------------------------ */
 
 extern "C" {

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,6 +16,7 @@
 
 /*! \file utils.h */
 
+#include "lmptype.h"
 #include <string>
 #include <cstdio>
 
@@ -75,7 +76,60 @@ namespace LAMMPS_NS {
      *  \param lmp   pointer to top-level LAMMPS class instance
      *  \return string usable for error messages
      */
-    std::string check_packages_for_style(std::string style, std::string name, LAMMPS *lmp);
+    std::string check_packages_for_style(std::string style,
+                                         std::string name, LAMMPS *lmp);
+
+    /** \brief Convert a string to a floating point number while checking
+        if it is a valid floating point or integer number
+     *
+     *  \param file name of source file for error message
+     *  \param line in source file for error message
+     *  \param str  string to be converted to number
+     *  \param do_abort determines whether to call Error::one() or Error::all()
+     *  \param lmp   pointer to top-level LAMMPS class instance
+     *  \return double precision floating point number
+     */
+    double numeric(const char *file, int line, const char *str,
+                   bool do_abort, LAMMPS *lmp);
+
+    /** \brief Convert a string to an integer number while checking
+        if it is a valid integer number (regular int)
+     *
+     *  \param file name of source file for error message
+     *  \param line in source file for error message
+     *  \param str  string to be converted to number
+     *  \param do_abort determines whether to call Error::one() or Error::all()
+     *  \param lmp   pointer to top-level LAMMPS class instance
+     *  \return integer number (regular int)
+     */
+    int inumeric(const char *file, int line, const char *str,
+                 bool do_abort, LAMMPS *lmp);
+
+    /** \brief Convert a string to an integer number while checking
+        if it is a valid integer number (bigint)
+     *
+     *  \param file name of source file for error message
+     *  \param line in source file for error message
+     *  \param str  string to be converted to number
+     *  \param do_abort determines whether to call Error::one() or Error::all()
+     *  \param lmp   pointer to top-level LAMMPS class instance
+     *  \return integer number (bigint)
+     */
+    bigint bnumeric(const char *file, int line, const char *str,
+                    bool do_abort, LAMMPS *lmp);
+
+    /** \brief Convert a string to an integer number while checking
+        if it is a valid integer number (tagint)
+     *
+     *  \param file name of source file for error message
+     *  \param line in source file for error message
+     *  \param str  string to be converted to number
+     *  \param do_abort determines whether to call Error::one() or Error::all()
+     *  \param lmp   pointer to top-level LAMMPS class instance
+     *  \return integer number (tagint)
+     */
+    tagint tnumeric(const char *file, int line, const char *str,
+                    bool do_abort, LAMMPS *lmp);
   }
 }
 


### PR DESCRIPTION
**Summary**

Validate more numbers read from data files through using `utils::numeric()` and `utils::inumeric()` instead of `atof()` or `atoi()`, respectively. This will avoid continuing to read with undefined behavior when reading broken data files.
This also provides an implementation of those conversion functions in the utils namespace/library, which should allow to move this functionality away from the `Force` class, where it doesn't really belong.
The new implementation also provides a flag to signal calling `Error::one()` instead of `Error::all()`, which allows to use this function in cases, where the conversion is not done by all MPI ranks at the same time.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Broken data files should now throw an error.

**Implementation Notes**

Instances of `atof()` and `atoi()` were replaced automatically.
New variants of the conversion functions had to be added to utils.cpp.
Testing this change exposed a bug in the wavepacket atom style reader function, which is fixed by this PR.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

