### PR TITLE
Fix issue in Kokkos neighbor binning when using non-Kokkos lists on GPUs

### DIFF
--- a/src/KOKKOS/nbin_kokkos.cpp
+++ b/src/KOKKOS/nbin_kokkos.cpp
@@ -40,6 +40,7 @@ NBinKokkos<DeviceType>::NBinKokkos(LAMMPS *lmp) : NBinStandard(lmp) {
 #endif
   h_resize() = 1;
 
+  kokkos = 1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/neighbor_kokkos.cpp
+++ b/src/KOKKOS/neighbor_kokkos.cpp
@@ -301,6 +301,7 @@ void NeighborKokkos::build_kokkos(int topoflag)
 
   if (style != Neighbor::NSQ) {
     for (int i = 0; i < nbin; i++) {
+      if (!neigh_bin[i]->kokkos) atomKK->sync(Host,ALL_MASK);
       neigh_bin[i]->bin_atoms_setup(nall);
       neigh_bin[i]->bin_atoms();
     }

--- a/src/nbin.cpp
+++ b/src/nbin.cpp
@@ -35,6 +35,8 @@ NBin::NBin(LAMMPS *lmp) : Pointers(lmp)
 
   dimension = domain->dimension;
   triclinic = domain->triclinic;
+
+  kokkos = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/nbin.h
+++ b/src/nbin.h
@@ -47,6 +47,10 @@ class NBin : protected Pointers {
   virtual void setup_bins(int) = 0;
   virtual void bin_atoms() = 0;
 
+  // Kokkos package
+
+  int kokkos;                       // 1 if class stores Kokkos data
+
  protected:
 
   // data from Neighbor class


### PR DESCRIPTION
**Summary**

Fix issue in Kokkos neighbor binning when using non-Kokkos lists on GPUs.

**Author(s)**

Stan Moore (SNL), issue reported by Jon Belof (LLNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.