### PR TITLE
more robust version of atom exchange size

### DIFF
--- a/src/BODY/body_nparticle.cpp
+++ b/src/BODY/body_nparticle.cpp
@@ -44,6 +44,7 @@ BodyNparticle::BodyNparticle(LAMMPS *lmp, int narg, char **arg) :
 
   icp = new MyPoolChunk<int>(1,1);
   dcp = new MyPoolChunk<double>(3*nmin,3*nmax);
+  maxexchange = 1 + 3*nmax;        // icp max + dcp max
 
   memory->create(imflag,nmax,"body/nparticle:imflag");
   memory->create(imdata,nmax,4,"body/nparticle:imdata");

--- a/src/BODY/body_rounded_polygon.cpp
+++ b/src/BODY/body_rounded_polygon.cpp
@@ -61,6 +61,7 @@ BodyRoundedPolygon::BodyRoundedPolygon(LAMMPS *lmp, int narg, char **arg) :
 
   icp = new MyPoolChunk<int>(1,1);
   dcp = new MyPoolChunk<double>(3*nmin+2*nmin+1+1,3*nmax+2*nmax+1+1);
+  maxexchange = 1 + 3*nmax+2*nmax+1+1;      // icp max + dcp max
 
   memory->create(imflag,nmax,"body/rounded/polygon:imflag");
   memory->create(imdata,nmax,7,"body/nparticle:imdata");

--- a/src/BODY/body_rounded_polyhedron.cpp
+++ b/src/BODY/body_rounded_polyhedron.cpp
@@ -61,6 +61,7 @@ BodyRoundedPolyhedron::BodyRoundedPolyhedron(LAMMPS *lmp, int narg, char **arg) 
   icp = new MyPoolChunk<int>(1,3);
   dcp = new MyPoolChunk<double>(3*nmin+2+1+1,
                                 3*nmax+2*nmax+MAX_FACE_SIZE*nmax+1+1);
+  maxexchange = 3 + 3*nmax+2*nmax+MAX_FACE_SIZE*nmax+1+1;  // icp max + dcp max
 
   memory->create(imflag,2*nmax,"body/rounded/polyhedron:imflag");
   memory->create(imdata,2*nmax,7,"body/polyhedron:imdata");

--- a/src/KOKKOS/fix_neigh_history_kokkos.cpp
+++ b/src/KOKKOS/fix_neigh_history_kokkos.cpp
@@ -99,7 +99,7 @@ void FixNeighHistoryKokkos<DeviceType>::pre_exchange()
 
   copymode = 0;
 
-  comm->maxexchange_fix = MAX(comm->maxexchange_fix,(dnum+1)*maxpartner+1);
+  maxexchange = (dnum+1)*maxpartner+1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-OMP/fix_neigh_history_omp.cpp
+++ b/src/USER-OMP/fix_neigh_history_omp.cpp
@@ -175,6 +175,8 @@ void FixNeighHistoryOMP::pre_exchange_onesided()
     }
 
     // set maxpartner = max # of partners of any owned atom
+    // maxexchange = max # of values for any Comm::exchange() atom
+
     maxpartner = m = 0;
     for (i = lfrom; i < lto; i++)
       m = MAX(m,npartner[i]);
@@ -184,7 +186,7 @@ void FixNeighHistoryOMP::pre_exchange_onesided()
 #endif
     {
       maxpartner = MAX(m,maxpartner);
-      comm->maxexchange_fix =MAX(comm->maxexchange_fix,(dnum+1)*maxpartner+1);
+      maxexchange = (dnum+1)*maxpartner+1;
     }
   }
 
@@ -347,6 +349,7 @@ void FixNeighHistoryOMP::pre_exchange_newton()
     }
 
     // set maxpartner = max # of partners of any owned atom
+    // maxexchange = max # of values for any Comm::exchange() atom
     m = 0;
     for (i = lfrom; i < lto; i++)
       m = MAX(m,npartner[i]);
@@ -356,7 +359,7 @@ void FixNeighHistoryOMP::pre_exchange_newton()
 #endif
     {
       maxpartner = MAX(m,maxpartner);
-      comm->maxexchange_fix = MAX(comm->maxexchange_fix,(dnum+1)*maxpartner+1);
+      maxexchange = (dnum+1)*maxpartner+1;
     }
   }
 
@@ -485,6 +488,8 @@ void FixNeighHistoryOMP::pre_exchange_no_newton()
     }
 
     // set maxpartner = max # of partners of any owned atom
+    // maxexchange = max # of values for any Comm::exchange() atom
+
     m = 0;
     for (i = lfrom; i < lto; i++)
       m = MAX(m,npartner[i]);
@@ -494,7 +499,7 @@ void FixNeighHistoryOMP::pre_exchange_no_newton()
 #endif
     {
       maxpartner = MAX(m,maxpartner);
-      comm->maxexchange_fix = MAX(comm->maxexchange_fix,(dnum+1)*maxpartner+1);
+      maxexchange = (dnum+1)*maxpartner+1;
     }
   }
 }

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -34,6 +34,8 @@ AtomVec::AtomVec(LAMMPS *lmp) : Pointers(lmp)
   mass_type = dipole_type = 0;
   forceclearflag = 0;
   size_data_bonus = 0;
+  maxexchange = 0;
+
   kokkosable = 0;
 
   nargcopy = 0;

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -39,6 +39,8 @@ class AtomVec : protected Pointers {
   int size_data_vel;                   // number of values in Velocity line
   int size_data_bonus;                 // number of values in Bonus line
   int xcol_data;                       // column (1-N) where x is in Atom line
+  int maxexchange;                     // max size of exchanged atom
+                                       // only needs to be set if size > BUFEXTRA
 
   class Molecule **onemols;            // list of molecules for style template
   int nset;                            // # of molecules in list

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -95,6 +95,7 @@ void AtomVecHybrid::process_args(int narg, char **arg)
   size_data_atom = 5;
   size_data_vel = 4;
   xcol_data = 3;
+  maxexchange = 0;
 
   for (int k = 0; k < nstyles; k++) {
     if ((styles[k]->molecular == 1 && molecular == 2) ||
@@ -120,6 +121,8 @@ void AtomVecHybrid::process_args(int narg, char **arg)
     size_border += styles[k]->size_border - 6;
     size_data_atom += styles[k]->size_data_atom - 5;
     size_data_vel += styles[k]->size_data_vel - 4;
+
+    maxexchange += styles[k]->maxexchange;
   }
 
   size_velocity = 3;

--- a/src/body.h
+++ b/src/body.h
@@ -28,6 +28,8 @@ class Body : protected Pointers {
   char *style;
   int size_forward;           // max extra values packed for comm
   int size_border;            // max extra values packed for border comm
+  int maxexchange;            // max size of exchanged atom
+
   AtomVecBody *avec;          // ptr to class that stores body bonus info
 
   Body(class LAMMPS *, int, char **);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -39,7 +39,7 @@
 
 using namespace LAMMPS_NS;
 
-#define BUFMIN 1000             // also in comm styles
+#define BUFEXTRA 1024
 
 enum{ONELEVEL,TWOLEVEL,NUMA,CUSTOM};
 enum{CART,CARTREORDER,XYZ};
@@ -65,7 +65,10 @@ Comm::Comm(LAMMPS *lmp) : Pointers(lmp)
   outfile = NULL;
   recv_from_partition = send_to_partition = -1;
   otherflag = 0;
-  maxexchange_atom = maxexchange_fix = 0;
+
+  maxexchange = maxexchange_atom = maxexchange_fix = 0;
+  maxexchange_fix_dynamic = 0;
+  bufextra = BUFEXTRA;
 
   grid2proc = NULL;
   xsplit = ysplit = zsplit = NULL;
@@ -225,6 +228,39 @@ void Comm::init()
 
   if (force->newton == 0) maxreverse = 0;
   if (force->pair) maxreverse = MAX(maxreverse,force->pair->comm_reverse_off);
+
+  // maxexchange_atom = size of an exchanged atom, set by AtomVec
+  //   only needs to be set if size > BUFEXTRA
+  // maxexchange_fix_dynamic = 1 if any fix sets its maxexchange dynamically
+
+  maxexchange_atom = atom->avec->maxexchange;
+
+  int nfix = modify->nfix;
+  Fix **fix = modify->fix;
+
+  maxexchange_fix_dynamic = 0;
+  for (int i = 0; i < nfix; i++)
+    if (fix[i]->maxexchange_dynamic) maxexchange_fix_dynamic = 1;
+}
+
+/* ----------------------------------------------------------------------
+   set maxexchange based on AtomVec and fixes
+------------------------------------------------------------------------- */
+
+void Comm::init_exchange()
+{
+  int nfix = modify->nfix;
+  Fix **fix = modify->fix;
+
+  int onefix;
+  maxexchange_fix = 0;
+  for (int i = 0; i < nfix; i++) {
+    onefix = fix[i]->maxexchange;
+    maxexchange_fix = MAX(maxexchange_fix,onefix);
+  }
+
+  maxexchange = maxexchange_atom + maxexchange_fix;
+  bufextra = maxexchange + BUFEXTRA;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/comm.h
+++ b/src/comm.h
@@ -134,7 +134,7 @@ class Comm : protected Pointers {
   int maxexchange_atom;         // contribution to maxexchange from AtomVec
   int maxexchange_fix;          // static contribution to maxexchange from Fixes
   int maxexchange_fix_dynamic;  // 1 if a fix has a dynamic contribution
-  int bufextra;                 // augment size of send buf for an exchange atom
+  int bufextra;                 // augment send buf size for an exchange atom
 
 
   int gridflag;                     // option for creating 3d grid

--- a/src/comm.h
+++ b/src/comm.h
@@ -38,9 +38,8 @@ class Comm : protected Pointers {
                                     // -1 if no recv or send
   int other_partition_style;        // 0 = recv layout dims must be multiple of
                                     //     my layout dims
-  int maxexchange_atom;             // max contribution to exchange from AtomVec
-  int maxexchange_fix;              // max contribution to exchange from Fixes
-  int nthreads;                     // OpenMP threads per MPI process
+
+  int nthreads;                // OpenMP threads per MPI process
 
   // public settings specific to layout = UNIFORM, NONUNIFORM
 
@@ -130,8 +129,13 @@ class Comm : protected Pointers {
   int size_reverse;                 // # of datums in reverse comm
   int size_border;                  // # of datums in forward border comm
 
-  int maxforward,maxreverse;        // max # of datums in forward/reverse comm
-  int maxexchange;                  // max # of datums/atom in exchange comm
+  int maxforward,maxreverse;    // max # of datums in forward/reverse comm
+  int maxexchange;              // max size of one exchanged atom
+  int maxexchange_atom;         // contribution to maxexchange from AtomVec
+  int maxexchange_fix;          // static contribution to maxexchange from Fixes
+  int maxexchange_fix_dynamic;  // 1 if a fix has a dynamic contribution
+  int bufextra;                 // augment size of send buf for an exchange atom
+
 
   int gridflag;                     // option for creating 3d grid
   int mapflag;                      // option for mapping procs to 3d grid
@@ -147,6 +151,7 @@ class Comm : protected Pointers {
   int coregrid[3];                  // 3d grid of cores within a node
   int user_coregrid[3];             // user request for cores in each dim
 
+  void init_exchange();
   int rendezvous_irregular(int, char *, int, int, int *,
                            int (*)(int, char *, int &, int *&, char *&, void *),
                            int, char *&, int, void *, int);

--- a/src/comm_brick.h
+++ b/src/comm_brick.h
@@ -74,7 +74,6 @@ class CommBrick : public Comm {
   double *buf_send;                 // send buffer for all comm
   double *buf_recv;                 // recv buffer for all comm
   int maxsend,maxrecv;              // current size of send/recv buffer
-  int bufextra;                     // extra space beyond maxsend in send buffer
   int smax,rmax;             // max size in atoms of single borders send/recv
 
   // NOTE: init_buffers is called from a constructor and must not be made virtual

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -101,7 +101,7 @@ void CommTiled::init()
 
   int bufextra_old = bufextra;
   init_exchange();
-  if (bufextra > bufextra_old) grow_send(maxsend+bufextra,0);
+  if (bufextra > bufextra_old) grow_send(maxsend+bufextra,2);
 
   // temporary restrictions
 
@@ -645,7 +645,7 @@ void CommTiled::exchange()
   if (maxexchange_fix_dynamic) {
     int bufextra_old = bufextra;
     init_exchange();
-    if (bufextra > bufextra_old) grow_send(maxsend+bufextra,1);
+    if (bufextra > bufextra_old) grow_send(maxsend+bufextra,2);
   }
 
   // domain properties used in exchange method and methods it calls

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -79,9 +79,9 @@ CommTiled::~CommTiled()
 
 void CommTiled::init_buffers()
 {
-  maxsend = BUFMIN;
-  memory->create(buf_send,maxsend+bufextra,"comm:buf_send");
-  maxrecv = BUFMIN;
+  buf_send = buf_recv = NULL;
+  maxsend = maxrecv = BUFMIN;
+  grow_send(maxsend,2);
   memory->create(buf_recv,maxrecv,"comm:buf_recv");
 
   maxoverlap = 0;
@@ -1804,18 +1804,23 @@ int CommTiled::coord2proc(double *x, int &igx, int &igy, int &igz)
 
 /* ----------------------------------------------------------------------
    realloc the size of the send buffer as needed with BUFFACTOR and bufextra
-   if flag = 1, realloc
-   if flag = 0, don't need to realloc with copy, just free/malloc
+   flag = 0, don't need to realloc with copy, just free/malloc w/ BUFFACTOR
+   flag = 1, realloc with BUFFACTOR
+   flag = 2, free/malloc w/out BUFFACTOR
 ------------------------------------------------------------------------- */
 
 void CommTiled::grow_send(int n, int flag)
 {
-  maxsend = static_cast<int> (BUFFACTOR * n);
-  if (flag)
-    memory->grow(buf_send,maxsend+bufextra,"comm:buf_send");
-  else {
+  if (flag == 0) {
+    maxsend = static_cast<int> (BUFFACTOR * n);
     memory->destroy(buf_send);
     memory->create(buf_send,maxsend+bufextra,"comm:buf_send");
+  } else if (flag == 1) {
+    maxsend = static_cast<int> (BUFFACTOR * n);
+    memory->grow(buf_send,maxsend+bufextra,"comm:buf_send");
+  } else {
+    memory->destroy(buf_send);
+    memory->grow(buf_send,maxsend+bufextra,"comm:buf_send");
   }
 }
 

--- a/src/comm_tiled.h
+++ b/src/comm_tiled.h
@@ -87,7 +87,6 @@ class CommTiled : public Comm {
   double *buf_send;             // send buffer for all comm
   double *buf_recv;             // recv buffer for all comm
   int maxsend,maxrecv;          // current size of send/recv buffer
-  int bufextra;                 // extra space beyond maxsend in send buffer
   int smaxone,rmaxone;          // max size in atoms of single borders send/recv
   int smaxall,rmaxall;          // max size in atoms of any borders send/recv
                                 //   for comm to all procs in one swap

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -78,6 +78,8 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   enforce2d_flag = 0;
   respa_level_support = 0;
   respa_level = -1;
+  maxexchange = 0;
+  maxexchange_dynamic = 0;
 
   scalar_flag = vector_flag = array_flag = 0;
   peratom_flag = local_flag = 0;

--- a/src/fix.h
+++ b/src/fix.h
@@ -56,6 +56,8 @@ class Fix : protected Pointers {
   int enforce2d_flag;            // 1 if has enforce2d method
   int respa_level_support;       // 1 if fix supports fix_modify respa
   int respa_level;               // which respa level to apply fix (1-Nrespa)
+  int maxexchange;               // max # of per-atom values for Comm::exchange()
+  int maxexchange_dynamic;       // 1 if fix sets maxexchange dynamically  
 
   int scalar_flag;               // 0/1 if compute_scalar() function exists
   int vector_flag;               // 0/1 if compute_vector() function exists

--- a/src/fix.h
+++ b/src/fix.h
@@ -57,7 +57,7 @@ class Fix : protected Pointers {
   int respa_level_support;       // 1 if fix supports fix_modify respa
   int respa_level;               // which respa level to apply fix (1-Nrespa)
   int maxexchange;               // max # of per-atom values for Comm::exchange()
-  int maxexchange_dynamic;       // 1 if fix sets maxexchange dynamically  
+  int maxexchange_dynamic;       // 1 if fix sets maxexchange dynamically
 
   int scalar_flag;               // 0/1 if compute_scalar() function exists
   int vector_flag;               // 0/1 if compute_vector() function exists

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -42,6 +42,7 @@ FixNeighHistory::FixNeighHistory(LAMMPS *lmp, int narg, char **arg) :
 
   restart_peratom = 1;
   create_attribute = 1;
+  maxexchange_dynamic = 1;
 
   newton_pair = force->newton_pair;
 
@@ -296,11 +297,11 @@ void FixNeighHistory::pre_exchange_onesided()
   }
 
   // set maxpartner = max # of partners of any owned atom
-  // bump up comm->maxexchange_fix if necessary
+  // maxexchange = max # of values for any Comm::exchange() atom
 
   maxpartner = 0;
   for (i = 0; i < nlocal_neigh; i++) maxpartner = MAX(maxpartner,npartner[i]);
-  comm->maxexchange_fix = MAX(comm->maxexchange_fix,(dnum+1)*maxpartner+1);
+  maxexchange = (dnum+1)*maxpartner + 1;
 
   // zero npartner values from previous nlocal_neigh to current nlocal
 
@@ -424,11 +425,11 @@ void FixNeighHistory::pre_exchange_newton()
   comm->reverse_comm_fix_variable(this);
 
   // set maxpartner = max # of partners of any owned atom
-  // bump up comm->maxexchange_fix if necessary
+  // maxexchange = max # of values for any Comm::exchange() atom
 
   maxpartner = 0;
   for (i = 0; i < nlocal_neigh; i++) maxpartner = MAX(maxpartner,npartner[i]);
-  comm->maxexchange_fix = MAX(comm->maxexchange_fix,(dnum+1)*maxpartner+1);
+  maxexchange = (dnum+1)*maxpartner + 1;
 
   // zero npartner values from previous nlocal_neigh to current nlocal
 
@@ -531,11 +532,11 @@ void FixNeighHistory::pre_exchange_no_newton()
   }
 
   // set maxpartner = max # of partners of any owned atom
-  // bump up comm->maxexchange_fix if necessary
+  // maxexchange = max # of values for any Comm::exchange() atom
 
   maxpartner = 0;
   for (i = 0; i < nlocal_neigh; i++) maxpartner = MAX(maxpartner,npartner[i]);
-  comm->maxexchange_fix = MAX(comm->maxexchange_fix,(dnum+1)*maxpartner+1);
+  maxexchange = (dnum+1)*maxpartner + 1;
 
   // zero npartner values from previous nlocal_neigh to current nlocal
 
@@ -796,9 +797,6 @@ void FixNeighHistory::unpack_reverse_comm(int n, int *list, double *buf)
 
 int FixNeighHistory::pack_exchange(int i, double *buf)
 {
-  // NOTE: how do I know comm buf is big enough if extreme # of touching neighs
-  // Comm::BUFEXTRA may need to be increased
-
   int m = 0;
   buf[m++] = npartner[i];
   for (int n = 0; n < npartner[i]; n++) {

--- a/src/fix_store.cpp
+++ b/src/fix_store.cpp
@@ -106,6 +106,7 @@ vstore(NULL), astore(NULL), rbuf(NULL)
       for (int i = 0; i < nlocal; i++)
         for (int j = 0; j < nvalues; j++)
           astore[i][j] = 0.0;
+    maxexchange = nvalues;
   }
 }
 

--- a/src/irregular.cpp
+++ b/src/irregular.cpp
@@ -19,6 +19,8 @@
 #include "atom_vec.h"
 #include "domain.h"
 #include "comm.h"
+#include "modify.h"
+#include "fix.h"
 #include "memory.h"
 
 using namespace LAMMPS_NS;
@@ -35,8 +37,8 @@ static int compare_standalone(const int, const int, void *);
 #endif
 
 #define BUFFACTOR 1.5
-#define BUFMIN 1000
-#define BUFEXTRA 1000
+#define BUFMIN 1024
+#define BUFEXTRA 1024
 
 /* ---------------------------------------------------------------------- */
 
@@ -69,9 +71,10 @@ Irregular::Irregular(LAMMPS *lmp) : Pointers(lmp)
   // initialize buffers for migrate atoms, not used for datum comm
   // these can persist for multiple irregular operations
 
-  maxsend = BUFMIN;
-  memory->create(buf_send,maxsend+BUFEXTRA,"comm:buf_send");
-  maxrecv = BUFMIN;
+  buf_send = buf_recv = NULL;
+  maxsend = maxrecv = BUFMIN;
+  bufextra = BUFEXTRA;
+  grow_send(maxsend,2);
   memory->create(buf_recv,maxrecv,"comm:buf_recv");
 }
 
@@ -103,6 +106,13 @@ Irregular::~Irregular()
 
 void Irregular::migrate_atoms(int sortflag, int preassign, int *procassign)
 {
+  // check if buf_send needs to be extended due to atom style or per-atom fixes
+  // same as in Comm::exchange()
+
+  int bufextra_old = bufextra;
+  init_exchange();
+  if (bufextra > bufextra_old) grow_send(maxsend+bufextra,2);
+
   // clear global->local map since atoms move to new procs
   // clear old ghosts so map_set() at end will operate only on local atoms
   // exchange() doesn't need to clear ghosts b/c borders()
@@ -983,24 +993,52 @@ void Irregular::destroy_data()
 }
 
 /* ----------------------------------------------------------------------
-   realloc the size of the send buffer as needed with BUFFACTOR & BUFEXTRA
-   if flag = 1, realloc
-   if flag = 0, don't need to realloc with copy, just free/malloc
+   set bufextra based on AtomVec and fixes
+   similar to Comm::init_exchange()
+------------------------------------------------------------------------- */
+
+void Irregular::init_exchange()
+{
+  int nfix = modify->nfix;
+  Fix **fix = modify->fix;
+
+  int onefix;
+  int maxexchange_fix = 0;
+  for (int i = 0; i < nfix; i++) {
+    onefix = fix[i]->maxexchange;
+    maxexchange_fix = MAX(maxexchange_fix,onefix);
+  }
+
+  int maxexchange = atom->avec->maxexchange + maxexchange_fix;
+  bufextra = maxexchange + BUFEXTRA;
+}
+
+/* ----------------------------------------------------------------------
+   realloc the size of the send buffer as needed with BUFFACTOR and bufextra
+   flag = 0, don't need to realloc with copy, just free/malloc w/ BUFFACTOR
+   flag = 1, realloc with BUFFACTOR
+   flag = 2, free/malloc w/out BUFFACTOR
+   same as Comm::grow_send()
 ------------------------------------------------------------------------- */
 
 void Irregular::grow_send(int n, int flag)
 {
-  maxsend = static_cast<int> (BUFFACTOR * n);
-  if (flag)
-    memory->grow(buf_send,maxsend+BUFEXTRA,"comm:buf_send");
-  else {
+  if (flag == 0) {
+    maxsend = static_cast<int> (BUFFACTOR * n);
     memory->destroy(buf_send);
-    memory->create(buf_send,maxsend+BUFEXTRA,"comm:buf_send");
+    memory->create(buf_send,maxsend+bufextra,"comm:buf_send");
+  } else if (flag == 1) {
+    maxsend = static_cast<int> (BUFFACTOR * n);
+    memory->grow(buf_send,maxsend+bufextra,"comm:buf_send");
+  } else {
+    memory->destroy(buf_send);
+    memory->grow(buf_send,maxsend+bufextra,"comm:buf_send");
   }
 }
 
 /* ----------------------------------------------------------------------
    free/malloc the size of the recv buffer as needed with BUFFACTOR
+   same as Comm::grow_recv()
 ------------------------------------------------------------------------- */
 
 void Irregular::grow_recv(int n)

--- a/src/irregular.h
+++ b/src/irregular.h
@@ -43,6 +43,7 @@ class Irregular : protected Pointers {
   int triclinic;
   int map_style;
 
+  int bufextra;                     // augment send buf size for a migrating atom
   int maxsend,maxrecv;              // size of buf send/recv in # of doubles
   double *buf_send,*buf_recv;       // bufs used in migrate_atoms
   int maxdbuf;                      // size of double buf in bytes
@@ -91,6 +92,7 @@ class Irregular : protected Pointers {
 
   int binary(double, int, double *);
 
+  void init_exchange();             // reset bufxtra
   void grow_send(int,int);          // reallocate send buffer
   void grow_recv(int);              // free/allocate recv buffer
 };


### PR DESCRIPTION
**Summary**

Make the communication parameter for the size of the exchange() send buffer more robust,
to account for fixes and atom styles that may have extreme sizes per atom.

**Related Issues**

Fixes #1554
Closes #1541 
Fixes #1528

**Author(s)**

Steve Plimpton with contributions from Stan Moore and Axel Kohlmeyer

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Hopefully N/A.

**Implementation Notes**

Comm classes now check more carefully with atom style and fixes to set counts for the size of one exchanged atom.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

