### PR TITLE
Complete data file read validation

### DIFF
--- a/src/DIPOLE/atom_vec_dipole.cpp
+++ b/src/DIPOLE/atom_vec_dipole.cpp
@@ -781,7 +781,7 @@ void AtomVecDipole::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/KOKKOS/atom_vec_dpd_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.cpp
@@ -1724,7 +1724,7 @@ void AtomVecDPDKokkos::data_atom(double *coord, tagint imagetmp,
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  h_tag[nlocal] = ATOTAGINT(values[0]);
+  h_tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   h_type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
@@ -976,7 +976,7 @@ void AtomVecHybridKokkos::data_atom(double *coord, imageint imagetmp, char **val
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  h_tag[nlocal] = ATOTAGINT(values[0]);
+  h_tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   h_type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (h_type[nlocal] <= 0 || h_type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom h_type in Atoms section of data file");

--- a/src/KOKKOS/atom_vec_sphere_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.cpp
@@ -2549,7 +2549,7 @@ void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp, char **val
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/MOLECULE/atom_vec_angle.cpp
+++ b/src/MOLECULE/atom_vec_angle.cpp
@@ -793,8 +793,8 @@ void AtomVecAngle::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
-  molecule[nlocal] = ATOTAGINT(values[1]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[1],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
@@ -822,7 +822,7 @@ void AtomVecAngle::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecAngle::data_atom_hybrid(int nlocal, char **values)
 {
-  molecule[nlocal] = ATOTAGINT(values[0]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
 
   num_bond[nlocal] = 0;
   num_angle[nlocal] = 0;

--- a/src/MOLECULE/atom_vec_bond.cpp
+++ b/src/MOLECULE/atom_vec_bond.cpp
@@ -739,8 +739,8 @@ void AtomVecBond::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
-  molecule[nlocal] = ATOTAGINT(values[1]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[1],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
@@ -767,7 +767,7 @@ void AtomVecBond::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecBond::data_atom_hybrid(int nlocal, char **values)
 {
-  molecule[nlocal] = ATOTAGINT(values[0]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
 
   num_bond[nlocal] = 0;
 

--- a/src/MOLECULE/atom_vec_full.cpp
+++ b/src/MOLECULE/atom_vec_full.cpp
@@ -942,8 +942,8 @@ void AtomVecFull::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
-  molecule[nlocal] = ATOTAGINT(values[1]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[1],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
@@ -975,7 +975,7 @@ void AtomVecFull::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecFull::data_atom_hybrid(int nlocal, char **values)
 {
-  molecule[nlocal] = ATOTAGINT(values[0]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   q[nlocal] = utils::numeric(FLERR,values[1],true,lmp);
 
   num_bond[nlocal] = 0;

--- a/src/MOLECULE/atom_vec_molecular.cpp
+++ b/src/MOLECULE/atom_vec_molecular.cpp
@@ -926,8 +926,8 @@ void AtomVecMolecular::data_atom(double *coord, imageint imagetmp,
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
-  molecule[nlocal] = ATOTAGINT(values[1]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[1],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
@@ -957,7 +957,7 @@ void AtomVecMolecular::data_atom(double *coord, imageint imagetmp,
 
 int AtomVecMolecular::data_atom_hybrid(int nlocal, char **values)
 {
-  molecule[nlocal] = ATOTAGINT(values[0]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
 
   num_bond[nlocal] = 0;
   num_angle[nlocal] = 0;

--- a/src/MOLECULE/atom_vec_template.cpp
+++ b/src/MOLECULE/atom_vec_template.cpp
@@ -742,11 +742,11 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   if (tag[nlocal] <= 0)
     error->one(FLERR,"Invalid atom ID in Atoms section of data file");
 
-  molecule[nlocal] = ATOTAGINT(values[1]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[1],true,lmp);
   molindex[nlocal] = utils::inumeric(FLERR,values[2],true,lmp) - 1;
   molatom[nlocal] = utils::inumeric(FLERR,values[3],true,lmp) - 1;
 
@@ -781,7 +781,7 @@ void AtomVecTemplate::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecTemplate::data_atom_hybrid(int nlocal, char **values)
 {
-  molecule[nlocal] = ATOTAGINT(values[0]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   molindex[nlocal] = utils::inumeric(FLERR,values[1],true,lmp) - 1;
   molatom[nlocal] = utils::inumeric(FLERR,values[2],true,lmp) - 1;
   return 3;

--- a/src/PERI/atom_vec_peri.cpp
+++ b/src/PERI/atom_vec_peri.cpp
@@ -793,7 +793,7 @@ void AtomVecPeri::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/SPIN/atom_vec_spin.cpp
+++ b/src/SPIN/atom_vec_spin.cpp
@@ -813,7 +813,7 @@ void AtomVecSpin::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/USER-AWPMD/atom_vec_wavepacket.cpp
+++ b/src/USER-AWPMD/atom_vec_wavepacket.cpp
@@ -916,7 +916,7 @@ void AtomVecWavepacket::data_atom(double *coord, imageint imagetmp,
 
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/USER-DPD/atom_vec_dpd.cpp
+++ b/src/USER-DPD/atom_vec_dpd.cpp
@@ -815,7 +815,7 @@ void AtomVecDPD::data_atom(double *coord, tagint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/USER-EFF/atom_vec_electron.cpp
+++ b/src/USER-EFF/atom_vec_electron.cpp
@@ -799,7 +799,7 @@ void AtomVecElectron::data_atom(double *coord, imageint imagetmp, char **values)
 
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/USER-MESO/atom_vec_edpd.cpp
+++ b/src/USER-MESO/atom_vec_edpd.cpp
@@ -760,7 +760,7 @@ void AtomVecEDPD::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/USER-MESO/atom_vec_mdpd.cpp
+++ b/src/USER-MESO/atom_vec_mdpd.cpp
@@ -799,7 +799,7 @@ void AtomVecMDPD::data_atom(double *coord, imageint imagetmp, char **values) {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/USER-MESO/atom_vec_tdpd.cpp
+++ b/src/USER-MESO/atom_vec_tdpd.cpp
@@ -792,7 +792,7 @@ void AtomVecTDPD::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/USER-SMD/atom_vec_smd.cpp
+++ b/src/USER-SMD/atom_vec_smd.cpp
@@ -1028,13 +1028,13 @@ void AtomVecSMD::data_atom(double *coord, imageint imagetmp, char **values) {
         if (nlocal == nmax)
                 grow(0);
 
-        tag[nlocal] = ATOTAGINT(values[0]);
+        tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
 
         type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
         if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
                 error->one(FLERR, "Invalid atom type in Atoms section of data file");
 
-        molecule[nlocal] = ATOTAGINT(values[2]);
+        molecule[nlocal] = utils::tnumeric(FLERR,values[2],true,lmp);
         if (molecule[nlocal] <= 0)
                 error->one(FLERR, "Invalid molecule in Atoms section of data file");
 

--- a/src/USER-SPH/atom_vec_meso.cpp
+++ b/src/USER-SPH/atom_vec_meso.cpp
@@ -844,7 +844,7 @@ void AtomVecMeso::data_atom(double *coord, imageint imagetmp, char **values) {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/atom_vec_atomic.cpp
+++ b/src/atom_vec_atomic.cpp
@@ -613,7 +613,7 @@ void AtomVecAtomic::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/atom_vec_body.cpp
+++ b/src/atom_vec_body.cpp
@@ -1279,7 +1279,7 @@ void AtomVecBody::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/atom_vec_charge.cpp
+++ b/src/atom_vec_charge.cpp
@@ -664,7 +664,7 @@ void AtomVecCharge::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -1141,7 +1141,7 @@ void AtomVecEllipsoid::data_atom(double *coord, imageint imagetmp,
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -864,7 +864,7 @@ void AtomVecHybrid::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/atom_vec_line.cpp
+++ b/src/atom_vec_line.cpp
@@ -1036,8 +1036,8 @@ void AtomVecLine::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
-  molecule[nlocal] = ATOTAGINT(values[1]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[1],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
@@ -1081,7 +1081,7 @@ void AtomVecLine::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecLine::data_atom_hybrid(int nlocal, char **values)
 {
-  molecule[nlocal] = ATOTAGINT(values[0]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
 
   line[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (line[nlocal] == 0) line[nlocal] = -1;

--- a/src/atom_vec_sphere.cpp
+++ b/src/atom_vec_sphere.cpp
@@ -965,7 +965,7 @@ void AtomVecSphere::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");

--- a/src/atom_vec_tri.cpp
+++ b/src/atom_vec_tri.cpp
@@ -1435,8 +1435,8 @@ void AtomVecTri::data_atom(double *coord, imageint imagetmp, char **values)
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
 
-  tag[nlocal] = ATOTAGINT(values[0]);
-  molecule[nlocal] = ATOTAGINT(values[1]);
+  tag[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[1],true,lmp);
   type[nlocal] = utils::inumeric(FLERR,values[2],true,lmp);
   if (type[nlocal] <= 0 || type[nlocal] > atom->ntypes)
     error->one(FLERR,"Invalid atom type in Atoms section of data file");
@@ -1483,7 +1483,7 @@ void AtomVecTri::data_atom(double *coord, imageint imagetmp, char **values)
 
 int AtomVecTri::data_atom_hybrid(int nlocal, char **values)
 {
-  molecule[nlocal] = ATOTAGINT(values[0]);
+  molecule[nlocal] = utils::tnumeric(FLERR,values[0],true,lmp);
 
   tri[nlocal] = utils::inumeric(FLERR,values[1],true,lmp);
   if (tri[nlocal] == 0) tri[nlocal] = -1;


### PR DESCRIPTION
**Summary**

This completes the change started in PR #1552 by replacing ATOTAGINT() calls that were missed with calls to utils::tnumeric() in AtomVec classes

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

no known issues.

**Implementation Notes**

This is the next step in using the `utils::*numeric()` functions throughout LAMMPS.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
