### PR TITLE
Fix memory issue in Kokkos neigh list when using half-from-full

### DIFF
--- a/src/KOKKOS/neigh_list_kokkos.cpp
+++ b/src/KOKKOS/neigh_list_kokkos.cpp
@@ -36,7 +36,7 @@ void NeighListKokkos<Device>::grow(int nmax)
 {
   // skip if this list is already long enough to store nmax atoms
 
-  if (nmax <= maxatoms) return;
+  if (nmax <= maxatoms && d_neighbors.extent(1) >= maxneighs) return;
   maxatoms = nmax;
 
   k_ilist =

--- a/src/KOKKOS/neigh_list_kokkos.cpp
+++ b/src/KOKKOS/neigh_list_kokkos.cpp
@@ -35,6 +35,7 @@ template<class Device>
 void NeighListKokkos<Device>::grow(int nmax)
 {
   // skip if this list is already long enough to store nmax atoms
+  //  and maxneighs neighbors
 
   if (nmax <= maxatoms && d_neighbors.extent(1) >= maxneighs) return;
   maxatoms = nmax;


### PR DESCRIPTION
**Summary**

Fix a memory issue in Kokkos neigh list when using a `half-from-full` method. In some cases when using a `half-from-full` neighbor list, the memory allocation wasn't big enough, leading to bad dynamics and crashes.

**Author(s)**

Stan Moore (SNL), thanks to Randy Hood (LLNL) for reporting the issue.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.