### PR TITLE
Fix bug in fix nve/intel

### DIFF
--- a/src/USER-INTEL/fix_nh_intel.cpp
+++ b/src/USER-INTEL/fix_nh_intel.cpp
@@ -335,7 +335,7 @@ void FixNHIntel::reset_dt()
   if (nlocal > _nlocal_max) {
     if (_nlocal_max) memory->destroy(_dtfm);
     _nlocal_max = static_cast<int>(1.20 * nlocal);
-    memory->create(_dtfm, _nlocal_max * 3, "fix_nve_intel:dtfm");
+    memory->create(_dtfm, _nlocal_max * 3, "fix_nh_intel:dtfm");
   }
 
   _nlocal3 = nlocal * 3;

--- a/src/USER-INTEL/fix_nve_intel.cpp
+++ b/src/USER-INTEL/fix_nve_intel.cpp
@@ -75,6 +75,7 @@ void FixNVEIntel::initial_integrate(int /*vflag*/)
       x[i] += dtv * v[i];
     }
   } else if (igroup == 0) {
+    if (neighbor->ago == 0) reset_dt();
     #if defined(LMP_SIMD_COMPILER)
     #pragma vector aligned
     #pragma simd
@@ -84,6 +85,7 @@ void FixNVEIntel::initial_integrate(int /*vflag*/)
       x[i] += dtv * v[i];
     }
   } else {
+    if (neighbor->ago == 0) reset_dt();
     #if defined(LMP_SIMD_COMPILER)
     #pragma vector aligned
     #pragma simd
@@ -114,6 +116,15 @@ void FixNVEIntel::final_integrate()
     #endif
     for (int i = 0; i < _nlocal3; i++)
       v[i] += dtfm * f[i];
+  } else if (igroup == 0) {
+    if (neighbor->ago == 0) reset_dt();
+    #if defined(LMP_SIMD_COMPILER)
+    #pragma vector aligned
+    #pragma simd
+    #endif
+    for (int i = 0; i < _nlocal3; i++) {
+      v[i] += _dtfm[i] * f[i];
+    }
   } else {
     if (neighbor->ago == 0) reset_dt();
     #if defined(LMP_SIMD_COMPILER)


### PR DESCRIPTION
**Summary**

This fixes the bug in `fix nve/intel` reported by Jesse Carter on lammps-users.

**Related Issues**

[Link to bug report on lammps-users archive](https://sourceforge.net/p/lammps/mailman/message/36714834/)

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes.

**Implementation Notes**

The code uses the array `_dtfm` to better vectorize time integration updates of velocities. this array is allocated and initialized inside the `reset_dt()` method. however, while in the nose-hoover integrators this is called for every velocity update, i.e. during `Fix::initial_integrate()` and `Fix::final_integrate()`, when the neighbor lists have just been updated, it is only called during `Fix::final_integrate()` in `fix nve/intel`. this carries over the behavior to `Fix::initial_integrate()` and properly handles the three cases considered.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
