### PR TITLE
Removed TEMPLATED_FIX_LANGEVIN ifdef and untemplated version of fix langevin

### DIFF
--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -304,7 +304,6 @@ void FixLangevin::post_force(int /*vflag*/)
   // this avoids testing them inside inner loop:
   // TSTYLEATOM, GJF, TALLY, BIAS, RMASS, ZERO
 
-#ifdef TEMPLATED_FIX_LANGEVIN
   if (tstyle == ATOM)
     if (gjfflag)
       if (tallyflag)
@@ -431,10 +430,6 @@ void FixLangevin::post_force(int /*vflag*/)
           else
             if (zeroflag) post_force_templated<0,0,0,0,0,1>();
             else          post_force_templated<0,0,0,0,0,0>();
-#else
-  post_force_untemplated(int(tstyle==ATOM), gjfflag, tallyflag,
-                         int(tbiasflag==BIAS), int(rmass!=NULL), zeroflag);
-#endif
 }
 
 /* ---------------------------------------------------------------------- */
@@ -448,15 +443,9 @@ void FixLangevin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
    modify forces using one of the many Langevin styles
 ------------------------------------------------------------------------- */
 
-#ifdef TEMPLATED_FIX_LANGEVIN
 template < int Tp_TSTYLEATOM, int Tp_GJF, int Tp_TALLY,
            int Tp_BIAS, int Tp_RMASS, int Tp_ZERO >
 void FixLangevin::post_force_templated()
-#else
-void FixLangevin::post_force_untemplated
-  (int Tp_TSTYLEATOM, int Tp_GJF, int Tp_TALLY,
-   int Tp_BIAS, int Tp_RMASS, int Tp_ZERO)
-#endif
 {
   double gamma1,gamma2;
 

--- a/src/fix_langevin.h
+++ b/src/fix_langevin.h
@@ -72,16 +72,10 @@ class FixLangevin : public Fix {
   class RanMars *random;
   int seed;
 
-  // comment next line to turn off templating
-#define TEMPLATED_FIX_LANGEVIN
-#ifdef TEMPLATED_FIX_LANGEVIN
   template < int Tp_TSTYLEATOM, int Tp_GJF, int Tp_TALLY,
              int Tp_BIAS, int Tp_RMASS, int Tp_ZERO >
   void post_force_templated();
-#else
-  void post_force_untemplated(int, int, int,
-                              int, int, int);
-#endif
+
   void omega_thermostat();
   void angmom_thermostat();
   void compute_target();


### PR DESCRIPTION
**Summary**

The templated implementation of FixLangevin::post_force supports many options efficiently and is not causing any problems. Therefore, the untemplated version is no longer needed and has been removed. One less ifdef.

**Related Issues**

**Author(s)**

Aidan Thompson

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No

**Implementation Notes**

None

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


