### PR TITLE
Fix segfault in fix_setforce_kokkos

### DIFF
--- a/src/KOKKOS/fix_setforce_kokkos.cpp
+++ b/src/KOKKOS/fix_setforce_kokkos.cpp
@@ -47,6 +47,7 @@ FixSetForceKokkos<DeviceType>::FixSetForceKokkos(LAMMPS *lmp, int narg, char **a
 
   memory->destroy(sforce);
   memoryKK->create_kokkos(k_sforce,sforce,maxatom,3,"setforce:sforce");
+  d_sforce = k_sforce.view<DeviceType>();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -103,6 +104,7 @@ void FixSetForceKokkos<DeviceType>::post_force(int vflag)
     maxatom = atom->nmax;
     memoryKK->destroy_kokkos(k_sforce,sforce);
     memoryKK->create_kokkos(k_sforce,sforce,maxatom,3,"setforce:sforce");
+    d_sforce = k_sforce.view<DeviceType>();
   }
 
   foriginal[0] = foriginal[1] = foriginal[2] = 0.0;


### PR DESCRIPTION
**Summary**

Fix a bug in `fix_setforce_kokkos` leading to a segfault when using a non-constant variable for the force.

**Author(s)**

Stan Moore (SNL), thanks to Jon Belof (LLNL) for reporting the issue.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.