### PR TITLE
Improve portability of GPU library to CLang compilers

### DIFF
--- a/lib/gpu/lal_answer.cpp
+++ b/lib/gpu/lal_answer.cpp
@@ -15,7 +15,7 @@
 
 #include "lal_answer.h"
 
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define AnswerT Answer<numtyp,acctyp>
 
 template <class numtyp, class acctyp>
@@ -311,4 +311,4 @@ void AnswerT::cq(const int cq_index) {
 }
 
 template class Answer<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_atom.cpp
+++ b/lib/gpu/lal_atom.cpp
@@ -15,7 +15,7 @@
 
 #include "lal_atom.h"
 
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define AtomT Atom<numtyp,acctyp>
 
 template <class numtyp, class acctyp>
@@ -349,4 +349,4 @@ void AtomT::compile_kernels(UCL_Device &dev) {
 #endif
 
 template class Atom<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_base_atomic.cpp
+++ b/lib/gpu/lal_base_atomic.cpp
@@ -14,7 +14,8 @@
  ***************************************************************************/
 
 #include "lal_base_atomic.h"
-using namespace LAMMPS_AL;
+
+namespace LAMMPS_AL {
 #define BaseAtomicT BaseAtomic<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> global_device;
@@ -285,4 +286,4 @@ void BaseAtomicT::compile_kernels(UCL_Device &dev, const void *pair_str,
 }
 
 template class BaseAtomic<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_base_charge.cpp
+++ b/lib/gpu/lal_base_charge.cpp
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 #include "lal_base_charge.h"
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BaseChargeT BaseCharge<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> global_device;
@@ -302,4 +302,4 @@ void BaseChargeT::compile_kernels(UCL_Device &dev, const void *pair_str,
 }
 
 template class BaseCharge<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_base_dipole.cpp
+++ b/lib/gpu/lal_base_dipole.cpp
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 #include "lal_base_dipole.h"
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BaseDipoleT BaseDipole<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> global_device;
@@ -311,4 +311,4 @@ void BaseDipoleT::compile_kernels(UCL_Device &dev, const void *pair_str,
 }
 
 template class BaseDipole<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_base_dpd.cpp
+++ b/lib/gpu/lal_base_dpd.cpp
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 #include "lal_base_dpd.h"
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BaseDPDT BaseDPD<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> global_device;
@@ -308,4 +308,4 @@ void BaseDPDT::compile_kernels(UCL_Device &dev, const void *pair_str,
 }
 
 template class BaseDPD<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_base_ellipsoid.cpp
+++ b/lib/gpu/lal_base_ellipsoid.cpp
@@ -15,7 +15,7 @@
 
 #include "lal_base_ellipsoid.h"
 #include <cstdlib>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 
 #if defined(USE_OPENCL)
 #include "ellipsoid_nbor_cl.h"
@@ -488,4 +488,4 @@ void BaseEllipsoidT::compile_kernels(UCL_Device &dev,
 }
 
 template class BaseEllipsoid<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_base_three.cpp
+++ b/lib/gpu/lal_base_three.cpp
@@ -14,7 +14,7 @@
  ***************************************************************************/
 
 #include "lal_base_three.h"
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BaseThreeT BaseThree<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> global_device;
@@ -397,4 +397,4 @@ void BaseThreeT::compile_kernels(UCL_Device &dev, const void *pair_str,
 }
 
 template class BaseThree<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_beck.cpp
+++ b/lib/gpu/lal_beck.cpp
@@ -23,7 +23,7 @@ const char *beck=0;
 
 #include "lal_beck.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BeckT Beck<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -150,3 +150,4 @@ void BeckT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Beck<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_born.cpp
+++ b/lib/gpu/lal_born.cpp
@@ -23,7 +23,7 @@ const char *born=0;
 
 #include "lal_born.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BornT Born<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -179,3 +179,4 @@ void BornT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Born<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_born_coul_long.cpp
+++ b/lib/gpu/lal_born_coul_long.cpp
@@ -23,7 +23,7 @@ const char *born_coul_long=0;
 
 #include "lal_born_coul_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BornCoulLongT BornCoulLong<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -173,3 +173,4 @@ void BornCoulLongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class BornCoulLong<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_born_coul_long_cs.cpp
+++ b/lib/gpu/lal_born_coul_long_cs.cpp
@@ -23,7 +23,7 @@ const char *born_coul_long_cs=0;
 
 #include "lal_born_coul_long_cs.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BornCoulLongCST BornCoulLongCS<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -93,3 +93,4 @@ int BornCoulLongCST::init(const int ntypes, double **host_cutsq, double **host_r
 }
 
 template class BornCoulLongCS<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_born_coul_wolf.cpp
+++ b/lib/gpu/lal_born_coul_wolf.cpp
@@ -23,7 +23,7 @@ const char *born_coul_wolf=0;
 
 #include "lal_born_coul_wolf.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BornCoulWolfT BornCoulWolf<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -174,3 +174,4 @@ void BornCoulWolfT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class BornCoulWolf<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_born_coul_wolf_cs.cpp
+++ b/lib/gpu/lal_born_coul_wolf_cs.cpp
@@ -23,7 +23,7 @@ const char *born_coul_wolf_cs=0;
 
 #include "lal_born_coul_wolf_cs.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BornCoulWolfCST BornCoulWolfCS<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -95,3 +95,4 @@ int BornCoulWolfCST::init(const int ntypes, double **host_cutsq, double **host_r
 }
 
 template class BornCoulWolfCS<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_buck.cpp
+++ b/lib/gpu/lal_buck.cpp
@@ -23,7 +23,7 @@ const char *buck=0;
 
 #include "lal_buck.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BuckT Buck<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -168,3 +168,4 @@ void BuckT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Buck<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_buck_coul.cpp
+++ b/lib/gpu/lal_buck_coul.cpp
@@ -23,7 +23,7 @@ const char *buck_coul=0;
 
 #include "lal_buck_coul.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BuckCoulT BuckCoul<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -161,3 +161,4 @@ void BuckCoulT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class BuckCoul<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_buck_coul_long.cpp
+++ b/lib/gpu/lal_buck_coul_long.cpp
@@ -23,7 +23,7 @@ const char *buck_coul_long=0;
 
 #include "lal_buck_coul_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define BuckCoulLongT BuckCoulLong<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -166,3 +166,4 @@ void BuckCoulLongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class BuckCoulLong<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_charmm_long.cpp
+++ b/lib/gpu/lal_charmm_long.cpp
@@ -23,7 +23,7 @@ const char *charmm_long=0;
 
 #include "lal_charmm_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CHARMMLongT CHARMMLong<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -174,3 +174,4 @@ void CHARMMLongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class CHARMMLong<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_colloid.cpp
+++ b/lib/gpu/lal_colloid.cpp
@@ -23,7 +23,7 @@ const char *colloid=0;
 
 #include "lal_colloid.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define ColloidT Colloid<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -179,3 +179,4 @@ void ColloidT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Colloid<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_coul.cpp
+++ b/lib/gpu/lal_coul.cpp
@@ -23,7 +23,7 @@ const char *coul=0;
 
 #include "lal_coul.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CoulT Coul<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -164,3 +164,4 @@ void CoulT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Coul<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_coul_debye.cpp
+++ b/lib/gpu/lal_coul_debye.cpp
@@ -23,7 +23,7 @@ const char *coul_debye=0;
 
 #include "lal_coul_debye.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CoulDebyeT CoulDebye<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -165,3 +165,4 @@ void CoulDebyeT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class CoulDebye<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_coul_dsf.cpp
+++ b/lib/gpu/lal_coul_dsf.cpp
@@ -23,7 +23,7 @@ const char *coul_dsf=0;
 
 #include "lal_coul_dsf.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CoulDSFT CoulDSF<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -151,3 +151,4 @@ void CoulDSFT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class CoulDSF<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_coul_long.cpp
+++ b/lib/gpu/lal_coul_long.cpp
@@ -23,7 +23,7 @@ const char *coul_long=0;
 
 #include "lal_coul_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CoulLongT CoulLong<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> pair_gpu_device;
@@ -156,3 +156,4 @@ void CoulLongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class CoulLong<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_coul_long_cs.cpp
+++ b/lib/gpu/lal_coul_long_cs.cpp
@@ -23,7 +23,7 @@ const char *coul_long_cs=0;
 
 #include "lal_coul_long_cs.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CoulLongCST CoulLongCS<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> pair_gpu_device;
@@ -76,3 +76,4 @@ int CoulLongCST::init(const int ntypes, double **host_scale,
 }
 
 template class CoulLongCS<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_device.cpp
+++ b/lib/gpu/lal_device.cpp
@@ -30,7 +30,7 @@ const char *device=0;
 #include "device_cubin.h"
 #endif
 
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define DeviceT Device<numtyp, acctyp>
 
 template <class numtyp, class acctyp>
@@ -762,7 +762,9 @@ double DeviceT::host_memory_usage() const {
 
 template class Device<PRECISION,ACC_PRECISION>;
 Device<PRECISION,ACC_PRECISION> global_device;
+}
 
+using namespace LAMMPS_AL;
 int lmp_init_device(MPI_Comm world, MPI_Comm replica, const int first_gpu,
                     const int last_gpu, const int gpu_mode,
                     const double particle_split, const int nthreads,
@@ -781,4 +783,3 @@ double lmp_gpu_forces(double **f, double **tor, double *eatom,
                       double **vatom, double *virial, double &ecoul) {
   return global_device.fix_gpu(f,tor,eatom,vatom,virial,ecoul);
 }
-

--- a/lib/gpu/lal_dipole_lj.cpp
+++ b/lib/gpu/lal_dipole_lj.cpp
@@ -23,7 +23,7 @@ const char *dipole_lj=0;
 
 #include "lal_dipole_lj.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define DipoleLJT DipoleLJ<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -168,3 +168,4 @@ void DipoleLJT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class DipoleLJ<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_dipole_lj_sf.cpp
+++ b/lib/gpu/lal_dipole_lj_sf.cpp
@@ -23,7 +23,7 @@ const char *dipole_lj_sf=0;
 
 #include "lal_dipole_lj_sf.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define DipoleLJSFT DipoleLJSF<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -168,3 +168,4 @@ void DipoleLJSFT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class DipoleLJSF<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_dipole_long_lj.cpp
+++ b/lib/gpu/lal_dipole_long_lj.cpp
@@ -23,7 +23,7 @@ const char *dipole_long_lj=0;
 
 #include "lal_dipole_long_lj.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define DipoleLongLJT DipoleLongLJ<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -171,3 +171,4 @@ void DipoleLongLJT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class DipoleLongLJ<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_dpd.cpp
+++ b/lib/gpu/lal_dpd.cpp
@@ -23,7 +23,7 @@ const char *dpd=0;
 
 #include "lal_dpd.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define DPDT DPD<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -168,3 +168,4 @@ void DPDT::update_coeff(int ntypes, double **host_a0, double **host_gamma,
 }
 
 template class DPD<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_eam.cpp
+++ b/lib/gpu/lal_eam.cpp
@@ -23,7 +23,7 @@ const char *eam=0;
 
 #include "lal_eam.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define EAMT EAM<numtyp, acctyp>
 
 
@@ -531,3 +531,4 @@ void EAMT::loop2(const bool _eflag, const bool _vflag) {
 }
 
 template class EAM<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_gauss.cpp
+++ b/lib/gpu/lal_gauss.cpp
@@ -23,7 +23,7 @@ const char *gauss=0;
 
 #include "lal_gauss.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define GaussT Gauss<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -159,3 +159,4 @@ void GaussT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Gauss<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_gayberne.cpp
+++ b/lib/gpu/lal_gayberne.cpp
@@ -26,7 +26,7 @@ const char *gayberne_lj=0;
 
 #include "lal_gayberne.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 
 #define GayBerneT GayBerne<numtyp, acctyp>
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -315,4 +315,4 @@ void GayBerneT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class GayBerne<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_lj.cpp
+++ b/lib/gpu/lal_lj.cpp
@@ -23,7 +23,7 @@ const char *lj=0;
 
 #include "lal_lj.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJT LJ<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -168,3 +168,4 @@ void LJT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJ<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj96.cpp
+++ b/lib/gpu/lal_lj96.cpp
@@ -23,7 +23,7 @@ const char *lj96=0;
 
 #include "lal_lj96.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJ96T LJ96<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -152,3 +152,4 @@ void LJ96T::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJ96<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_class2_long.cpp
+++ b/lib/gpu/lal_lj_class2_long.cpp
@@ -23,7 +23,7 @@ const char *lj_class2_long=0;
 
 #include "lal_lj_class2_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 
 #define LJClass2LongT LJClass2Long<numtyp, acctyp>
 
@@ -164,4 +164,4 @@ void LJClass2LongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJClass2Long<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_lj_coul.cpp
+++ b/lib/gpu/lal_lj_coul.cpp
@@ -23,7 +23,7 @@ const char *lj_coul=0;
 
 #include "lal_lj_coul.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJCoulT LJCoul<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -164,3 +164,4 @@ void LJCoulT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJCoul<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_coul_debye.cpp
+++ b/lib/gpu/lal_lj_coul_debye.cpp
@@ -23,7 +23,7 @@ const char *lj_coul_debye=0;
 
 #include "lal_lj_coul_debye.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJCoulDebyeT LJCoulDebye<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -166,3 +166,4 @@ void LJCoulDebyeT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJCoulDebye<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_coul_long.cpp
+++ b/lib/gpu/lal_lj_coul_long.cpp
@@ -23,7 +23,7 @@ const char *lj_coul_long=0;
 
 #include "lal_lj_coul_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJCoulLongT LJCoulLong<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -181,3 +181,4 @@ void LJCoulLongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJCoulLong<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_coul_msm.cpp
+++ b/lib/gpu/lal_lj_coul_msm.cpp
@@ -23,7 +23,7 @@ const char *lj_coul_msm=0;
 
 #include "lal_lj_coul_msm.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJCoulMSMT LJCoulMSM<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -198,3 +198,4 @@ void LJCoulMSMT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJCoulMSM<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_cubic.cpp
+++ b/lib/gpu/lal_lj_cubic.cpp
@@ -23,7 +23,7 @@ const char *lj_cubic=0;
 
 #include "lal_lj_cubic.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJCubicT LJCubic<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -157,3 +157,4 @@ void LJCubicT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJCubic<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_dsf.cpp
+++ b/lib/gpu/lal_lj_dsf.cpp
@@ -23,7 +23,7 @@ const char *lj_dsf=0;
 
 #include "lal_lj_dsf.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJDSFT LJDSF<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -166,3 +166,4 @@ void LJDSFT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJDSF<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_expand.cpp
+++ b/lib/gpu/lal_lj_expand.cpp
@@ -23,7 +23,7 @@ const char *lj_expand=0;
 
 #include "lal_lj_expand.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJExpandT LJExpand<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -171,3 +171,4 @@ void LJExpandT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJExpand<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_expand_coul_long.cpp
+++ b/lib/gpu/lal_lj_expand_coul_long.cpp
@@ -23,7 +23,7 @@ const char *lj_expand_coul_long=0;
 
 #include "lal_lj_expand_coul_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJExpandCoulLongT LJExpandCoulLong<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -181,3 +181,4 @@ void LJExpandCoulLongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJExpandCoulLong<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_gromacs.cpp
+++ b/lib/gpu/lal_lj_gromacs.cpp
@@ -23,7 +23,7 @@ const char *lj_gromacs=0;
 
 #include "lal_lj_gromacs.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define LJGROMACST LJGROMACS<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -162,3 +162,4 @@ void LJGROMACST::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class LJGROMACS<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_sdk.cpp
+++ b/lib/gpu/lal_lj_sdk.cpp
@@ -23,7 +23,7 @@ const char *lj_sdk=0;
 
 #include "lal_lj_sdk.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CGCMMT CGCMM<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -152,3 +152,4 @@ void CGCMMT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class CGCMM<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_lj_sdk_long.cpp
+++ b/lib/gpu/lal_lj_sdk_long.cpp
@@ -23,7 +23,7 @@ const char *lj_sdk_long=0;
 
 #include "lal_lj_sdk_long.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define CGCMMLongT CGCMMLong<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -164,3 +164,4 @@ void CGCMMLongT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class CGCMMLong<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_mie.cpp
+++ b/lib/gpu/lal_mie.cpp
@@ -23,7 +23,7 @@ const char *mie=0;
 
 #include "lal_mie.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define MieT Mie<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -150,3 +150,4 @@ void MieT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Mie<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_morse.cpp
+++ b/lib/gpu/lal_morse.cpp
@@ -23,7 +23,7 @@ const char *morse=0;
 
 #include "lal_morse.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define MorseT Morse<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -150,4 +150,4 @@ void MorseT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Morse<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_pppm.cpp
+++ b/lib/gpu/lal_pppm.cpp
@@ -25,7 +25,7 @@ const char *pppm_d=0;
 #include "lal_pppm.h"
 #include <cassert>
 
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define PPPMT PPPM<numtyp, acctyp, grdtyp, grdtyp4>
 
 extern Device<PRECISION,ACC_PRECISION> global_device;
@@ -402,3 +402,4 @@ void PPPMT::compile_kernels(UCL_Device &dev) {
 
 template class PPPM<PRECISION,ACC_PRECISION,float,_lgpu_float4>;
 template class PPPM<PRECISION,ACC_PRECISION,double,_lgpu_double4>;
+}

--- a/lib/gpu/lal_re_squared.cpp
+++ b/lib/gpu/lal_re_squared.cpp
@@ -26,7 +26,7 @@ const char *re_squared_lj=0;
 
 #include "lal_re_squared.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 
 #define RESquaredT RESquared<numtyp, acctyp>
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -315,4 +315,4 @@ void RESquaredT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class RESquared<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_soft.cpp
+++ b/lib/gpu/lal_soft.cpp
@@ -23,7 +23,7 @@ const char *soft=0;
 
 #include "lal_soft.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define SoftT Soft<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -158,3 +158,4 @@ void SoftT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Soft<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_sw.cpp
+++ b/lib/gpu/lal_sw.cpp
@@ -23,7 +23,7 @@ const char *sw=0;
 
 #include "lal_sw.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define SWT SW<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -262,4 +262,4 @@ void SWT::loop(const bool _eflag, const bool _vflag, const int evatom) {
 }
 
 template class SW<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_table.cpp
+++ b/lib/gpu/lal_table.cpp
@@ -23,7 +23,7 @@ const char *table=0;
 
 #include "lal_table.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define TableT Table<numtyp, acctyp>
 
 #define LOOKUP 0
@@ -337,3 +337,4 @@ void TableT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Table<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_tersoff.cpp
+++ b/lib/gpu/lal_tersoff.cpp
@@ -23,7 +23,7 @@ const char *tersoff=0;
 
 #include "lal_tersoff.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define TersoffT Tersoff<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -329,4 +329,4 @@ void TersoffT::loop(const bool _eflag, const bool _vflag, const int evatom) {
 }
 
 template class Tersoff<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_tersoff_mod.cpp
+++ b/lib/gpu/lal_tersoff_mod.cpp
@@ -23,7 +23,7 @@ const char *tersoff_mod=0;
 
 #include "lal_tersoff_mod.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define TersoffMT TersoffMod<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -329,4 +329,4 @@ void TersoffMT::loop(const bool _eflag, const bool _vflag, const int evatom) {
 }
 
 template class TersoffMod<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_tersoff_zbl.cpp
+++ b/lib/gpu/lal_tersoff_zbl.cpp
@@ -23,7 +23,7 @@ const char *tersoff_zbl=0;
 
 #include "lal_tersoff_zbl.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define TersoffZT TersoffZBL<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -355,4 +355,4 @@ void TersoffZT::loop(const bool _eflag, const bool _vflag, const int evatom) {
 }
 
 template class TersoffZBL<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_ufm.cpp
+++ b/lib/gpu/lal_ufm.cpp
@@ -25,7 +25,7 @@ const char *ufm=0;
 
 #include "lal_ufm.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define UFMT UFM<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -170,3 +170,4 @@ void UFMT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class UFM<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_vashishta.cpp
+++ b/lib/gpu/lal_vashishta.cpp
@@ -23,7 +23,7 @@ const char *vashishta=0;
 
 #include "lal_vashishta.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define VashishtaT Vashishta<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -295,4 +295,4 @@ void VashishtaT::loop(const bool _eflag, const bool _vflag, const int evatom) {
 }
 
 template class Vashishta<PRECISION,ACC_PRECISION>;
-
+}

--- a/lib/gpu/lal_yukawa.cpp
+++ b/lib/gpu/lal_yukawa.cpp
@@ -23,7 +23,7 @@ const char *yukawa=0;
 
 #include "lal_yukawa.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define YukawaT Yukawa<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -147,3 +147,4 @@ void YukawaT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class Yukawa<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_yukawa_colloid.cpp
+++ b/lib/gpu/lal_yukawa_colloid.cpp
@@ -23,7 +23,7 @@ const char *yukawa_colloid=0;
 
 #include "lal_yukawa_colloid.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define YukawaColloidT YukawaColloid<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -289,3 +289,4 @@ void YukawaColloidT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class YukawaColloid<PRECISION,ACC_PRECISION>;
+}

--- a/lib/gpu/lal_zbl.cpp
+++ b/lib/gpu/lal_zbl.cpp
@@ -23,7 +23,7 @@ const char *zbl=0;
 
 #include "lal_zbl.h"
 #include <cassert>
-using namespace LAMMPS_AL;
+namespace LAMMPS_AL {
 #define ZBLT ZBL<numtyp, acctyp>
 
 extern Device<PRECISION,ACC_PRECISION> device;
@@ -157,3 +157,4 @@ void ZBLT::loop(const bool _eflag, const bool _vflag) {
 }
 
 template class ZBL<PRECISION,ACC_PRECISION>;
+}


### PR DESCRIPTION
**Summary**

CLang 7.x complains about incorrect namespace scoping of some code in the GPU package library code. This PR remedies that by placing the corresponding parts of the code into a "nampspace LAMMPS_AL" block instead of applying "using namespace LAMMPS_AL".

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

no known issues.

**Implementation Notes**

This should actually be more standard conforming.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

