### PR TITLE
Workaround for compiling KOKKOS with CCache, CLang, and CMake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -4,6 +4,16 @@
 # Created by Christoph Junghans and Richard Berger
 cmake_minimum_required(VERSION 2.8.12)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    option(ENABLE_CCACHE "Speed up compilation with ccache" ON)
+else()
+    option(ENABLE_CCACHE "Speed up compilation with ccache" OFF)
+endif()
+if(ENABLE_CCACHE)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 project(lammps CXX)
 set(SOVERSION 0)
 get_filename_component(LAMMPS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../src ABSOLUTE)


### PR DESCRIPTION
**Summary**

This works around the failure to compile LAMMPS with KOKKOS enabled when using CLang and ccache via symbolic links.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

When enabling KOKKOS with CLang, there are bogus `--gcc-toolchain` flags popping up in the variables `KOKKOS_CXXFLAGS` and `KOKKOS_LDFLAGS`, when CLang is using ccache through symbolic links. As a consequence, CLang cannot find any of the system header files and compilation fails. This change works around it by using the CMake feature `RULE_LAUNCH_COMPILE` which is set explicitly to `ccache`, if it is available. This seems to allow to correctly detect the patch for the `--gcc-toolchain` flag, *even* if both `clang++` and `g++` are symbolic links to the `ccache` executable.

**TODO**

- [ ] Update manual and CMake flags doc file
- [ ] Get some benchmark numbers (after #1542 is complete)
- [ ] Test with non-default GCC
- [ ] Test with Intel compiler
- [ ] Test on CentOS 7
- [ ] Test on Ubuntu LTS

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated


