### PR TITLE
Add optimized version of Kokkos SNAP potential

### DIFF
--- a/src/KOKKOS/pair_snap_kokkos.h
+++ b/src/KOKKOS/pair_snap_kokkos.h
@@ -31,10 +31,17 @@ PairStyle(snap/kk/host,PairSNAPKokkos<LMPHostType>)
 namespace LAMMPS_NS {
 
 template<int NEIGHFLAG, int EVFLAG>
-struct TagPairSNAPCompute{};
+struct TagPairSNAPComputeForce{};
 
 struct TagPairSNAPBeta{};
-struct TagPairSNAPBispectrum{};
+struct TagPairSNAPComputeNeigh{};
+struct TagPairSNAPPreUi{};
+struct TagPairSNAPComputeUi{};
+struct TagPairSNAPComputeZi{};
+struct TagPairSNAPComputeBi{};
+struct TagPairSNAPComputeYi{};
+struct TagPairSNAPComputeDuidrj{};
+struct TagPairSNAPComputeDeidrj{};
 
 template<class DeviceType>
 class PairSNAPKokkos : public PairSNAP {
@@ -56,17 +63,38 @@ public:
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPCompute<NEIGHFLAG,EVFLAG> >::member_type& team) const;
+  void operator() (TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG> >::member_type& team) const;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPCompute<NEIGHFLAG,EVFLAG> >::member_type& team, EV_FLOAT&) const;
+  void operator() (TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG> >::member_type& team, EV_FLOAT&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPComputeNeigh,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeNeigh>::member_type& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPPreUi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPPreUi>::member_type& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPComputeUi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeUi>::member_type& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPComputeZi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeZi>::member_type& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPComputeBi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeBi>::member_type& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPComputeYi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeYi>::member_type& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPComputeDuidrj,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeDuidrj>::member_type& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (TagPairSNAPComputeDeidrj,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeDeidrj>::member_type& team) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator() (TagPairSNAPBeta,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBeta>::member_type& team) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (TagPairSNAPBispectrum,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBispectrum>::member_type& team) const;
 
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
@@ -90,15 +118,10 @@ protected:
   t_dbvec dbvec;
   SNAKokkos<DeviceType> snaKK;
 
-  // How much parallelism to use within an interaction
-  int vector_length,team_size;
-  int team_scratch_size;
-  int thread_scratch_size;
+  int inum,max_neighs,chunk_offset;
 
   int eflag,vflag;
 
-  void compute_beta();
-  void compute_bispectrum();
   void allocate();
   //void read_files(char *, char *);
   /*template<class DeviceType>
@@ -131,6 +154,7 @@ inline double dist2(double* x,double* y);
   Kokkos::View<F_FLOAT*, DeviceType> d_wjelem;               // elements weights
   Kokkos::View<F_FLOAT**, Kokkos::LayoutRight, DeviceType> d_coeffelem;           // element bispectrum coefficients
   Kokkos::View<T_INT*, DeviceType> d_map;                    // mapping from atom types to elements
+  Kokkos::View<T_INT*, DeviceType> d_ninside;                // ninside for all atoms in list
   Kokkos::View<F_FLOAT**, DeviceType> d_beta;                // betas for all atoms in list
   Kokkos::View<F_FLOAT**, DeviceType> d_bispectrum;          // bispectrum components for all atoms in list
 

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -57,7 +57,6 @@ PairSNAPKokkos<DeviceType>::PairSNAPKokkos(LAMMPS *lmp) : PairSNAP(lmp)
   datamask_read = EMPTY_MASK;
   datamask_modify = EMPTY_MASK;
 
-  vector_length = 8;
   k_cutsq = tdual_fparams("PairSNAPKokkos::cutsq",atom->ntypes+1,atom->ntypes+1);
   auto d_cutsq = k_cutsq.template view<DeviceType>();
   rnd_cutsq = d_cutsq;
@@ -164,7 +163,7 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_numneigh = k_list->d_numneigh;
   d_neighbors = k_list->d_neighbors;
   d_ilist = k_list->d_ilist;
-  int inum = list->inum;
+  inum = list->inum;
 
   need_dup = lmp->kokkos->need_dup<DeviceType>();
   if (need_dup) {
@@ -181,70 +180,112 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     const int num_neighs = neighs_i.get_num_neighs();
     if (max_neighs<num_neighs) max_neighs = num_neighs;
   }*/
-  int max_neighs = 0;
+  max_neighs = 0;
   Kokkos::parallel_reduce("PairSNAPKokkos::find_max_neighs",inum, FindMaxNumNeighs<DeviceType>(k_list), Kokkos::Experimental::Max<int>(max_neighs));
 
-  snaKK.nmax = max_neighs;
-
-  team_scratch_size = snaKK.size_team_scratch_arrays();
-  thread_scratch_size = snaKK.size_thread_scratch_arrays();
-
-  //printf("Sizes: %i %i\n",team_scratch_size/1024,thread_scratch_size/1024);
+  int vector_length = 1;
+  int ui_vector_length = 1;
+  int team_size = 1;
+  int yi_team_size = 1;
   int team_size_max = Kokkos::TeamPolicy<DeviceType>::team_size_max(*this);
-  vector_length = 8;
 #ifdef KOKKOS_ENABLE_CUDA
   team_size = 32;//max_neighs;
   if (team_size*vector_length > team_size_max)
     team_size = team_size_max/vector_length;
-#else
-  team_size = 1;
+
+  yi_team_size = 256;
+  if (yi_team_size*vector_length > team_size_max)
+    yi_team_size = team_size_max/vector_length;
+
+  ui_vector_length = 8;
+  if (team_size*ui_vector_length > team_size_max)
+    team_size = team_size_max/ui_vector_length;
 #endif
 
-  if (beta_max < list->inum) {
-    d_beta = Kokkos::View<F_FLOAT**, DeviceType>("PairSNAPKokkos:beta",
-     list->inum,ncoeff);
-    d_bispectrum = Kokkos::View<F_FLOAT**, DeviceType>("PairSNAPKokkos:bispectrum",
-     list->inum,ncoeff);
-    beta_max = list->inum;
+  if (beta_max < inum) {
+    beta_max = inum;
+    d_beta = Kokkos::View<F_FLOAT**, DeviceType>("PairSNAPKokkos:beta",inum,ncoeff);
+    d_ninside = Kokkos::View<int*, DeviceType>("PairSNAPKokkos:ninside",inum);
   }
 
-  // compute dE_i/dB_i = beta_i for all i in list
+  int chunk_size = 2000;
+  chunk_offset = 0;
 
-  if (quadraticflag || eflag) 
-    compute_bispectrum();
-  compute_beta();
+  snaKK.grow_rij(chunk_size,max_neighs);
 
   EV_FLOAT ev;
 
-  if (eflag) {
-    if (neighflag == HALF) {
-      typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPCompute<HALF,1> > policy(inum,team_size,vector_length);
-      Kokkos::parallel_reduce(policy
-          .set_scratch_size(1,Kokkos::PerThread(thread_scratch_size))
-          .set_scratch_size(1,Kokkos::PerTeam(team_scratch_size))
-        ,*this,ev);
-    } else if (neighflag == HALFTHREAD) {
-      typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPCompute<HALFTHREAD,1> > policy(inum,team_size,vector_length);
-      Kokkos::parallel_reduce(policy
-          .set_scratch_size(1,Kokkos::PerThread(thread_scratch_size))
-          .set_scratch_size(1,Kokkos::PerTeam(team_scratch_size))
-        ,*this,ev);
+  while (chunk_offset < inum) { // chunk up loop to prevent running out of memory
+
+    EV_FLOAT ev_tmp;
+
+    if (chunk_size > inum - chunk_offset)
+      chunk_size = inum - chunk_offset;
+
+    //ComputeNeigh
+    typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeNeigh> policy_neigh(chunk_size,team_size,vector_length);
+    Kokkos::parallel_for("ComputeNeigh",policy_neigh,*this);
+
+    //PreUi
+    typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPPreUi> policy_preui(chunk_size,team_size,vector_length);
+    Kokkos::parallel_for("PreUi",policy_preui,*this);
+
+    //ComputeUi
+    typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeUi> policy_ui(((inum+team_size-1)/team_size)*max_neighs,team_size,ui_vector_length);
+    Kokkos::parallel_for("ComputeUi",policy_ui,*this);
+
+    //Compute bispectrum
+    if (quadraticflag || eflag) {
+      //ComputeZi
+      typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeZi> policy_zi(chunk_size,team_size,vector_length);
+      Kokkos::parallel_for("ComputeZi",policy_zi,*this);
+
+      //ComputeBi
+      typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeBi> policy_bi(chunk_size,team_size,vector_length);
+      Kokkos::parallel_for("ComputeBi",policy_bi,*this);
     }
-  } else {
-    if (neighflag == HALF) {
-      typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPCompute<HALF,0> > policy(inum,team_size,vector_length);
-      Kokkos::parallel_for(policy
-          .set_scratch_size(1,Kokkos::PerThread(thread_scratch_size))
-          .set_scratch_size(1,Kokkos::PerTeam(team_scratch_size))
-        ,*this);
-    } else if (neighflag == HALFTHREAD) {
-      typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPCompute<HALFTHREAD,0> > policy(inum,team_size,vector_length);
-      Kokkos::parallel_for(policy
-          .set_scratch_size(1,Kokkos::PerThread(thread_scratch_size))
-          .set_scratch_size(1,Kokkos::PerTeam(team_scratch_size))
-        ,*this);
+
+    //Compute beta = dE_i/dB_i for all i in list
+    typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBeta> policy_beta(chunk_size,team_size,vector_length);
+    Kokkos::parallel_for("ComputeBeta",policy_beta,*this);
+
+    //ComputeYi
+    typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeYi> policy_yi(chunk_size,yi_team_size,vector_length);
+    Kokkos::parallel_for("ComputeYi",policy_yi,*this);
+
+    //ComputeDuidrj
+    typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeDuidrj> policy_duidrj(((inum+team_size-1)/team_size)*max_neighs,team_size,vector_length);
+    Kokkos::parallel_for("ComputeDuidrj",policy_duidrj,*this);
+
+    //ComputeDeidrj
+    typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeDeidrj> policy_deidrj(((inum+team_size-1)/team_size)*max_neighs,team_size,vector_length);
+    Kokkos::parallel_for("ComputeDeidrj",policy_deidrj,*this);
+
+    //ComputeForce
+    if (eflag) {
+      if (neighflag == HALF) {
+        typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeForce<HALF,1> > policy_force(chunk_size,team_size,vector_length);
+        Kokkos::parallel_reduce(policy_force
+          ,*this,ev_tmp);
+      } else if (neighflag == HALFTHREAD) {
+        typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeForce<HALFTHREAD,1> > policy_force(chunk_size,team_size,vector_length);
+        Kokkos::parallel_reduce(policy_force
+          ,*this,ev_tmp);
+      }
+    } else {
+      if (neighflag == HALF) {
+        typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeForce<HALF,0> > policy_force(chunk_size,team_size,vector_length);
+        Kokkos::parallel_for(policy_force
+          ,*this);
+      } else if (neighflag == HALFTHREAD) {
+        typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeForce<HALFTHREAD,0> > policy_force(chunk_size,team_size,vector_length);
+        Kokkos::parallel_for(policy_force
+          ,*this);
+      }
     }
-  }
+    ev += ev_tmp;
+    chunk_offset += chunk_size;
+  } // end while
 
   if (need_dup)
     Kokkos::Experimental::contribute(f, dup_f);
@@ -284,32 +325,19 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
 }
 
-/* ----------------------------------------------------------------------
-   compute beta
-------------------------------------------------------------------------- */
-
-template<class DeviceType>
-void PairSNAPKokkos<DeviceType>::compute_beta()
-{
-  // TODO: use RangePolicy instead, or thread over ncoeff?
-  int inum = list->inum;
-  typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBeta> policy(inum,team_size,vector_length);
-  Kokkos::parallel_for(policy
-      .set_scratch_size(1,Kokkos::PerThread(thread_scratch_size))
-      .set_scratch_size(1,Kokkos::PerTeam(team_scratch_size))
-    ,*this);
-}
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPBeta,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBeta>::member_type& team) const {
 
+  // TODO: use RangePolicy instead, or thread over ncoeff?
   const int ii = team.league_rank();
-  const int i = d_ilist[ii];
+  const int i = d_ilist[ii + chunk_offset];
   const int itype = type[i];
   const int ielem = d_map[itype];
+  SNAKokkos<DeviceType> my_sna = snaKK;
+
   Kokkos::View<double*,Kokkos::LayoutRight,DeviceType,Kokkos::MemoryTraits<Kokkos::Unmanaged>>
     d_coeffi(d_coeffelem,ielem,Kokkos::ALL);
 
@@ -319,116 +347,17 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPBeta,const typename Kokk
   if (quadraticflag) {
     int k = ncoeff+1;
     for (int icoeff = 0; icoeff < ncoeff; icoeff++) {
-      double bveci = d_bispectrum(ii,icoeff);
+      double bveci = my_sna.blist(ii,icoeff);
       d_beta(ii,icoeff) += d_coeffi[k]*bveci;
       k++;
       for (int jcoeff = icoeff+1; jcoeff < ncoeff; jcoeff++) {
-        double bvecj = d_bispectrum(ii,jcoeff);
+        double bvecj = my_sna.blist(ii,jcoeff);
         d_beta(ii,icoeff) += d_coeffi[k]*bvecj;
         d_beta(ii,jcoeff) += d_coeffi[k]*bveci;
         k++;
       }
     }
   }
-}
-
-/* ----------------------------------------------------------------------
-   compute bispectrum
-------------------------------------------------------------------------- */
-
-template<class DeviceType>
-void PairSNAPKokkos<DeviceType>::compute_bispectrum()
-{
-  int inum = list->inum;
-  typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBispectrum> policy(inum,team_size,vector_length);
-  Kokkos::parallel_for(policy
-      .set_scratch_size(1,Kokkos::PerThread(thread_scratch_size))
-      .set_scratch_size(1,Kokkos::PerTeam(team_scratch_size))
-    ,*this);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-KOKKOS_INLINE_FUNCTION
-void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPBispectrum,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBispectrum>::member_type& team) const {
-
-  const int ii = team.league_rank();
-  const int i = d_ilist[ii];
-  SNAKokkos<DeviceType> my_sna(snaKK,team);
-  const double xtmp = x(i,0);
-  const double ytmp = x(i,1);
-  const double ztmp = x(i,2);
-  const int itype = type[i];
-  const int ielem = d_map[itype];
-  const double radi = d_radelem[ielem];
-
-  const int num_neighs = d_numneigh[i];
-
-  // rij[][3] = displacements between atom I and those neighbors
-  // inside = indices of neighbors of I within cutoff
-  // wj = weights for neighbors of I within cutoff
-  // rcutij = cutoffs for neighbors of I within cutoff
-  // note Rij sign convention => dU/dRij = dU/dRj = -dU/dRi
-
-  int ninside = 0;
-  Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team,num_neighs),
-      [&] (const int jj, int& count) {
-    Kokkos::single(Kokkos::PerThread(team), [&] (){
-      T_INT j = d_neighbors(i,jj);
-      const F_FLOAT dx = x(j,0) - xtmp;
-      const F_FLOAT dy = x(j,1) - ytmp;
-      const F_FLOAT dz = x(j,2) - ztmp;
-
-      const int jtype = type(j);
-      const F_FLOAT rsq = dx*dx + dy*dy + dz*dz;
-      const int elem_j = d_map[jtype];
-
-      if ( rsq < rnd_cutsq(itype,jtype) )
-       count++;
-    });
-  },ninside);
-
-  if (team.team_rank() == 0)
-  Kokkos::parallel_scan(Kokkos::ThreadVectorRange(team,num_neighs),
-      [&] (const int jj, int& offset, bool final) {
-  //for (int jj = 0; jj < num_neighs; jj++) {
-    T_INT j = d_neighbors(i,jj);
-    const F_FLOAT dx = x(j,0) - xtmp;
-    const F_FLOAT dy = x(j,1) - ytmp;
-    const F_FLOAT dz = x(j,2) - ztmp;
-
-    const int jtype = type(j);
-    const F_FLOAT rsq = dx*dx + dy*dy + dz*dz;
-    const int elem_j = d_map[jtype];
-
-    if ( rsq < rnd_cutsq(itype,jtype) ) {
-      if (final) {
-        my_sna.rij(offset,0) = dx;
-        my_sna.rij(offset,1) = dy;
-        my_sna.rij(offset,2) = dz;
-        my_sna.inside[offset] = j;
-        my_sna.wj[offset] = d_wjelem[elem_j];
-        my_sna.rcutij[offset] = (radi + d_radelem[elem_j])*rcutfac;
-      }
-      offset++;
-    }
-  });
-  team.team_barrier();
-
-  // compute Ui, Zi, and Bi for atom I
-
-  my_sna.compute_ui(team,ninside);
-  team.team_barrier();
-
-  my_sna.compute_zi(team);
-  team.team_barrier();
-
-  my_sna.compute_bi(team);
-  team.team_barrier();
-
-  for (int icoeff = 0; icoeff < ncoeff; icoeff++)
-    d_bispectrum(ii,icoeff) = my_sna.blist[icoeff];
 }
 
 /* ----------------------------------------------------------------------
@@ -496,30 +425,21 @@ void PairSNAPKokkos<DeviceType>::coeff(int narg, char **arg)
   Kokkos::deep_copy(d_coeffelem,h_coeffelem);
   Kokkos::deep_copy(d_map,h_map);
 
-  // allocate memory for per OpenMP thread data which
-  // is wrapped into the sna class
-
   snaKK = SNAKokkos<DeviceType>(rfac0,twojmax,
                   rmin0,switchflag,bzeroflag);
-  snaKK.grow_rij(0);
+  snaKK.grow_rij(0,0);
   snaKK.init();
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPCompute<NEIGHFLAG,EVFLAG> >::member_type& team, EV_FLOAT& ev) const {
-
-  // The f array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
-
-  auto v_f = ScatterViewHelper<NeedDup<NEIGHFLAG,DeviceType>::value,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
-  auto a_f = v_f.template access<AtomicDup<NEIGHFLAG,DeviceType>::value>();
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeNeigh,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeNeigh>::member_type& team) const {
 
   const int ii = team.league_rank();
-  const int i = d_ilist[ii];
-  SNAKokkos<DeviceType> my_sna(snaKK,team);
+  const int i = d_ilist[ii + chunk_offset];
+  SNAKokkos<DeviceType> my_sna = snaKK;
   const double xtmp = x(i,0);
   const double ytmp = x(i,1);
   const double ztmp = x(i,2);
@@ -553,6 +473,8 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG
     });
   },ninside);
 
+  d_ninside(ii) = ninside;
+
   if (team.team_rank() == 0)
   Kokkos::parallel_scan(Kokkos::ThreadVectorRange(team,num_neighs),
       [&] (const int jj, int& offset, bool final) {
@@ -568,43 +490,124 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG
 
     if ( rsq < rnd_cutsq(itype,jtype) ) {
       if (final) {
-        my_sna.rij(offset,0) = dx;
-        my_sna.rij(offset,1) = dy;
-        my_sna.rij(offset,2) = dz;
-        my_sna.inside[offset] = j;
-        my_sna.wj[offset] = d_wjelem[elem_j];
-        my_sna.rcutij[offset] = (radi + d_radelem[elem_j])*rcutfac;
+        my_sna.rij(ii,offset,0) = dx;
+        my_sna.rij(ii,offset,1) = dy;
+        my_sna.rij(ii,offset,2) = dz;
+        my_sna.inside(ii,offset) = j;
+        my_sna.wj(ii,offset) = d_wjelem[elem_j];
+        my_sna.rcutij(ii,offset) = (radi + d_radelem[elem_j])*rcutfac;
       }
       offset++;
     }
   });
-  team.team_barrier();
+}
 
-  // compute Ui, Yi for atom I
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPPreUi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPPreUi>::member_type& team) const {
+  const int ii = team.league_rank();
+  SNAKokkos<DeviceType> my_sna = snaKK;
+  my_sna.pre_ui(team,ii);
+}
 
-  my_sna.compute_ui(team,ninside);
-  team.team_barrier();
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeUi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeUi>::member_type& team) const {
+  SNAKokkos<DeviceType> my_sna = snaKK;
 
-  // for neighbors of I within cutoff:
-  // compute Fij = dEi/dRj = -dEi/dRi 
-  // add to Fi, subtract from Fj
+  // Extract the atom number
+  const int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
+  if (ii >= inum) return;
 
-  my_sna.compute_yi(team,d_beta,ii);
-  team.team_barrier();
+  // Extract the neighbor number
+  const int jj = team.league_rank() / ((inum+team.team_size()-1)/team.team_size());
+  const int ninside = d_ninside(ii);
+  if (jj >= ninside) return;
 
-  Kokkos::View<double*,Kokkos::LayoutRight,DeviceType,Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-    d_coeffi(d_coeffelem,ielem,Kokkos::ALL);
+  my_sna.compute_ui(team,ii,jj);
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeYi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeYi>::member_type& team) const {
+  const int ii = team.league_rank();
+  SNAKokkos<DeviceType> my_sna = snaKK;
+  my_sna.compute_yi(team,ii,d_beta);
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeZi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeZi>::member_type& team) const {
+  const int ii = team.league_rank();
+  SNAKokkos<DeviceType> my_sna = snaKK;
+  my_sna.compute_zi(team,ii);
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeBi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeBi>::member_type& team) const {
+  const int ii = team.league_rank();
+  SNAKokkos<DeviceType> my_sna = snaKK;
+  my_sna.compute_bi(team,ii);
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeDuidrj,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeDuidrj>::member_type& team) const {
+  SNAKokkos<DeviceType> my_sna = snaKK;
+
+  // Extract the atom number
+  const int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
+  if (ii >= inum) return;
+
+  // Extract the neighbor number
+  const int jj = team.league_rank() / ((inum+team.team_size()-1)/team.team_size());
+  const int ninside = d_ninside(ii);
+  if (jj >= ninside) return;
+
+  my_sna.compute_duidrj(team,ii,jj);
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeDeidrj,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeDeidrj>::member_type& team) const {
+  SNAKokkos<DeviceType> my_sna = snaKK;
+
+  // Extract the atom number
+  const int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
+  if (ii >= inum) return;
+
+  // Extract the neighbor number
+  const int jj = team.league_rank() / ((inum+team.team_size()-1)/team.team_size());
+  const int ninside = d_ninside(ii);
+  if (jj >= ninside) return;
+ 
+  my_sna.compute_deidrj(team,ii,jj);
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int EVFLAG>
+KOKKOS_INLINE_FUNCTION
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG> >::member_type& team, EV_FLOAT& ev) const {
+
+  // The f array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
+
+  auto v_f = ScatterViewHelper<NeedDup<NEIGHFLAG,DeviceType>::value,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
+  auto a_f = v_f.template access<AtomicDup<NEIGHFLAG,DeviceType>::value>();
+
+  const int ii = team.league_rank();
+  const int i = d_ilist[ii + chunk_offset];
+  SNAKokkos<DeviceType> my_sna = snaKK;
+  const int ninside = d_ninside(ii);
 
   Kokkos::parallel_for (Kokkos::TeamThreadRange(team,ninside),
       [&] (const int jj) {
-  //for (int jj = 0; jj < ninside; jj++) {
-    int j = my_sna.inside[jj];
-
-    my_sna.compute_duidrj(team,&my_sna.rij(jj,0),
-                           my_sna.wj[jj],my_sna.rcutij[jj],jj);
+    int j = my_sna.inside(ii,jj);
 
     F_FLOAT fij[3];
-    my_sna.compute_deidrj(team,fij);
+    fij[0] = my_sna.dedr(ii,jj,0);
+    fij[1] = my_sna.dedr(ii,jj,1);
+    fij[2] = my_sna.dedr(ii,jj,2);
 
     Kokkos::single(Kokkos::PerThread(team), [&] (){
       a_f(i,0) += fij[0];
@@ -620,8 +623,8 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG
         if (vflag_either) {
           v_tally_xyz<NEIGHFLAG>(ev,i,j,
             fij[0],fij[1],fij[2],
-            -my_sna.rij(jj,0),-my_sna.rij(jj,1),
-            -my_sna.rij(jj,2));
+            -my_sna.rij(ii,jj,0),-my_sna.rij(ii,jj,1),
+            -my_sna.rij(ii,jj,2));
         }
       }
       
@@ -633,6 +636,11 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG
   if (EVFLAG) {
     if (eflag_either) {
 
+      const int itype = type(i);
+      const int ielem = d_map[itype];
+      Kokkos::View<double*,Kokkos::LayoutRight,DeviceType,Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+        d_coeffi(d_coeffelem,ielem,Kokkos::ALL);
+
       Kokkos::single(Kokkos::PerTeam(team), [&] () {
 
         // evdwl = energy of atom I, sum over coeffs_k * Bi_k
@@ -640,21 +648,21 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG
         double evdwl = d_coeffi[0];
         
         // E = beta.B + 0.5*B^t.alpha.B
-        
+
         // linear contributions
         
         for (int icoeff = 0; icoeff < ncoeff; icoeff++)
-          evdwl += d_coeffi[icoeff+1]*d_bispectrum(ii,icoeff);
+          evdwl += d_coeffi[icoeff+1]*my_sna.blist(ii,icoeff);
         
         // quadratic contributions
         
         if (quadraticflag) {
           int k = ncoeff+1;
           for (int icoeff = 0; icoeff < ncoeff; icoeff++) {
-            double bveci = d_bispectrum(ii,icoeff);
+            double bveci = my_sna.blist(ii,icoeff);
             evdwl += 0.5*d_coeffi[k++]*bveci*bveci;
             for (int jcoeff = icoeff+1; jcoeff < ncoeff; jcoeff++) {
-              double bvecj = d_bispectrum(ii,jcoeff);
+              double bvecj = my_sna.blist(ii,jcoeff);
               evdwl += d_coeffi[k++]*bveci*bvecj;
             }
           }
@@ -671,9 +679,9 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG
 template<class DeviceType>
 template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPCompute<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType,TagPairSNAPCompute<NEIGHFLAG,EVFLAG> >::member_type& team) const {
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG>,const typename Kokkos::TeamPolicy<DeviceType,TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG> >::member_type& team) const {
   EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairSNAPCompute<NEIGHFLAG,EVFLAG>(), team, ev);
+  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairSNAPComputeForce<NEIGHFLAG,EVFLAG>(), team, ev);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -738,4 +746,5 @@ double PairSNAPKokkos<DeviceType>::memory_usage()
   bytes += snaKK.memory_usage();
   return bytes;
 }
+
 }

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -208,7 +208,7 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     d_ninside = Kokkos::View<int*, DeviceType>("PairSNAPKokkos:ninside",inum);
   }
 
-  int chunk_size = 2000;
+  int chunk_size = MIN(2000,inum);
   chunk_offset = 0;
 
   snaKK.grow_rij(chunk_size,max_neighs);

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -332,7 +332,7 @@ KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPBeta,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBeta>::member_type& team) const {
 
   // TODO: use RangePolicy instead, or thread over ncoeff?
-  const int ii = team.league_rank();
+  int ii = team.league_rank();
   const int i = d_ilist[ii + chunk_offset];
   const int itype = type[i];
   const int ielem = d_map[itype];
@@ -437,7 +437,7 @@ template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeNeigh,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeNeigh>::member_type& team) const {
 
-  const int ii = team.league_rank();
+  int ii = team.league_rank();
   const int i = d_ilist[ii + chunk_offset];
   SNAKokkos<DeviceType> my_sna = snaKK;
   const double xtmp = x(i,0);
@@ -505,7 +505,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeNeigh,const typen
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPPreUi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPPreUi>::member_type& team) const {
-  const int ii = team.league_rank();
+  int ii = team.league_rank();
   SNAKokkos<DeviceType> my_sna = snaKK;
   my_sna.pre_ui(team,ii);
 }
@@ -516,7 +516,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeUi,const typename
   SNAKokkos<DeviceType> my_sna = snaKK;
 
   // Extract the atom number
-  const int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
+  int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
   if (ii >= inum) return;
 
   // Extract the neighbor number
@@ -530,7 +530,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeUi,const typename
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeYi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeYi>::member_type& team) const {
-  const int ii = team.league_rank();
+  int ii = team.league_rank();
   SNAKokkos<DeviceType> my_sna = snaKK;
   my_sna.compute_yi(team,ii,d_beta);
 }
@@ -538,7 +538,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeYi,const typename
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeZi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeZi>::member_type& team) const {
-  const int ii = team.league_rank();
+  int ii = team.league_rank();
   SNAKokkos<DeviceType> my_sna = snaKK;
   my_sna.compute_zi(team,ii);
 }
@@ -546,7 +546,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeZi,const typename
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeBi,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeBi>::member_type& team) const {
-  const int ii = team.league_rank();
+  int ii = team.league_rank();
   SNAKokkos<DeviceType> my_sna = snaKK;
   my_sna.compute_bi(team,ii);
 }
@@ -557,7 +557,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeDuidrj,const type
   SNAKokkos<DeviceType> my_sna = snaKK;
 
   // Extract the atom number
-  const int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
+  int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
   if (ii >= inum) return;
 
   // Extract the neighbor number
@@ -574,7 +574,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeDeidrj,const type
   SNAKokkos<DeviceType> my_sna = snaKK;
 
   // Extract the atom number
-  const int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
+  int ii = team.team_rank() + team.team_size() * (team.league_rank() % ((inum+team.team_size()-1)/team.team_size()));
   if (ii >= inum) return;
 
   // Extract the neighbor number
@@ -595,7 +595,7 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeForce<NEIGHFLAG,E
   auto v_f = ScatterViewHelper<NeedDup<NEIGHFLAG,DeviceType>::value,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
   auto a_f = v_f.template access<AtomicDup<NEIGHFLAG,DeviceType>::value>();
 
-  const int ii = team.league_rank();
+  int ii = team.league_rank();
   const int i = d_ilist[ii + chunk_offset];
   SNAKokkos<DeviceType> my_sna = snaKK;
   const int ninside = d_ninside(ii);


### PR DESCRIPTION
**Summary**

Optimize the Kokkos version of pair_style SNAP. Runs over 3x faster on a V100 GPU.

**Author(s)**

Rahul Gayatri (NERSC), Stan Moore (SNL), Aidan Thompson (SNL), Sarah Anderson (Cray), with collaboration and discussions with Evan Weinberg (NVIDIA). This work was done as part of the NERSC NESAP program and the OLCF/NERSC GPU Hackathon.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.