### PR TITLE
Include bonds in communication cutoff estimate

### DIFF
--- a/doc/src/Errors_warnings.txt
+++ b/doc/src/Errors_warnings.txt
@@ -129,6 +129,16 @@ Self-explanatory. :dd
 
 Self-explanatory. :dd
 
+{Communication cutoff is 0.0. No ghost atoms will be generated. Atoms may get lost} :dt
+
+The communication cutoff defaults to the maximum of what is inferred from
+pair and bond styles (will be zero, if none are defined) and what is specified
+via "comm_modify cutoff"_comm_modify.html (defaults to 0.0).  If this results
+to 0.0, no ghost atoms will be generated and LAMMPS may lose atoms or use
+incorrect periodic images of atoms in interaction lists.  To avoid, either use
+"pair style zero"_pair_zero.html with a suitable cutoff or use "comm_modify
+cutoff"_comm_modify.html. :dd
+
 {Communication cutoff is too small for SNAP micro load balancing, increased to %lf} :dt
 
 Self-explanatory. :dd

--- a/doc/src/comm_modify.txt
+++ b/doc/src/comm_modify.txt
@@ -69,18 +69,15 @@ processors.  By default the ghost cutoff = neighbor cutoff = pairwise
 force cutoff + neighbor skin.  See the "neighbor"_neighbor.html command
 for more information about the skin distance.  If the specified Rcut is
 greater than the neighbor cutoff, then extra ghost atoms will be acquired.
-If the provided cutoff is smaller, the provided value will be ignored
-and the ghost cutoff is set to the neighbor cutoff. Specifying a
-cutoff value of 0.0 will reset any previous value to the default.
-If bonded interactions exist and equilibrium bond length information is
-available, then also a heuristic based on that bond length (2.0x {r_eq}
-for systems with dihedrals or improper, 1.5x {r_eq} without) plus
-neighbor skin is applied if the communication cutoff is set to its
-default value of 0.0.  This avoids problems for systems without a pair
-style or where the non-bonded cutoff is (much) shorter than the largest
-bond lengths.  A warning message is printed, if a specified
-communication cutoff > 0.0 is overridden or the bond length heuristics
-lead to a larger communication cutoff.
+If the provided cutoff is smaller, the provided value will be ignored,
+the ghost cutoff is set to the neighbor cutoff and a warning will be
+printed. Specifying a cutoff value of 0.0 will reset any previous value
+to the default. If bonded interactions exist and equilibrium bond length
+information is available, then also a heuristic based on that bond length
+is computed. It is used as communication cutoff, if there is no pair
+style present and no {comm_modify cutoff} command used. Otherwise a
+warning is printed, if this bond based estimate is larger than the
+communication cutoff used. A
 
 The {cutoff/multi} option is equivalent to {cutoff}, but applies to
 communication mode {multi} instead. Since in this case the communication

--- a/doc/src/comm_modify.txt
+++ b/doc/src/comm_modify.txt
@@ -72,6 +72,15 @@ greater than the neighbor cutoff, then extra ghost atoms will be acquired.
 If the provided cutoff is smaller, the provided value will be ignored
 and the ghost cutoff is set to the neighbor cutoff. Specifying a
 cutoff value of 0.0 will reset any previous value to the default.
+If bonded interactions exist and equilibrium bond length information is
+available, then also a heuristic based on that bond length (2.0x {r_eq}
+for systems with dihedrals or improper, 1.5x {r_eq} without) plus
+neighbor skin is applied if the communication cutoff is set to its
+default value of 0.0.  This avoids problems for systems without a pair
+style or where the non-bonded cutoff is (much) shorter than the largest
+bond lengths.  A warning message is printed, if a specified
+communication cutoff > 0.0 is overridden or the bond length heuristics
+lead to a larger communication cutoff.
 
 The {cutoff/multi} option is equivalent to {cutoff}, but applies to
 communication mode {multi} instead. Since in this case the communication

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -617,6 +617,11 @@ double Comm::get_comm_cutoff()
   }
   maxcommcutoff = MAX(maxcommcutoff,neighbor->cutneighmax);
   maxcommcutoff = MAX(maxcommcutoff,cutghostuser);
+  if ((me == 0) && (cutghostuser > 0.0) && (maxcommcutoff > cutghostuser)) {
+    char mesg[128];
+    snprintf(mesg,128,"Communication cutoff is changed to %g",maxcommcutoff);
+    error->warning(FLERR,mesg);
+  }
 
   return maxcommcutoff;
 }

--- a/src/comm.h
+++ b/src/comm.h
@@ -237,6 +237,15 @@ Self-explanatory.
 
 E: Cannot put data on ring from NULL pointer
 
+W: Communication cutoff is 0.0. No ghost atoms will be generated. Atoms may get lost.
+
+The communication cutoff defaults to the maximum of what is inferred from pair and
+bond styles (will be zero, if none are defined) and what is specified via
+"comm_modify cutoff" (defaults to 0.0).  If this results to 0.0, no ghost atoms will
+be generated and LAMMPS may lose atoms or use incorrect periodic images of atoms in
+interaction lists.  To avoid, either define pair style zero with a suitable cutoff
+or use comm_modify cutoff.
+
 UNDOCUMENTED
 
 U: OMP_NUM_THREADS environment is not set.

--- a/src/comm.h
+++ b/src/comm.h
@@ -70,6 +70,8 @@ class Comm : protected Pointers {
   void set_processors(int, char **);      // set 3d processor grid attributes
   virtual void set_proc_grid(int outflag = 1); // setup 3d grid of procs
 
+  double get_comm_cutoff();     // determine communication cutoff
+
   virtual void setup() = 0;                      // setup 3d comm pattern
   virtual void forward_comm(int dummy = 0) = 0;  // forward comm of atom coords
   virtual void reverse_comm() = 0;               // reverse comm of forces

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -175,7 +175,7 @@ void CommBrick::setup()
   int ntypes = atom->ntypes;
   double *prd,*sublo,*subhi;
 
-  double cut = MAX(neighbor->cutneighmax,cutghostuser);
+  double cut = get_comm_cutoff();
   if ((cut == 0.0) && (me == 0))
     error->warning(FLERR,"Communication cutoff is 0.0. No ghost atoms "
                    "will be generated. Atoms may get lost.");

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -176,6 +176,9 @@ void CommBrick::setup()
   double *prd,*sublo,*subhi;
 
   double cut = MAX(neighbor->cutneighmax,cutghostuser);
+  if ((cut == 0.0) && (me == 0))
+    error->warning(FLERR,"Communication cutoff is 0.0. No ghost atoms "
+                   "will be generated. Atoms may get lost.");
 
   if (triclinic == 0) {
     prd = domain->prd;

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -158,6 +158,10 @@ void CommTiled::setup()
   // check that cutoff < any periodic box length
 
   double cut = MAX(neighbor->cutneighmax,cutghostuser);
+  if ((cut == 0.0) && (me == 0))
+    error->warning(FLERR,"Communication cutoff is 0.0. No ghost atoms "
+                   "will be generated. Atoms may get lost.");
+
   cutghost[0] = cutghost[1] = cutghost[2] = cut;
 
   if ((periodicity[0] && cut > prd[0]) ||

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -157,7 +157,7 @@ void CommTiled::setup()
   // set cutoff for comm forward and comm reverse
   // check that cutoff < any periodic box length
 
-  double cut = MAX(neighbor->cutneighmax,cutghostuser);
+  double cut = get_comm_cutoff();
   if ((cut == 0.0) && (me == 0))
     error->warning(FLERR,"Communication cutoff is 0.0. No ghost atoms "
                    "will be generated. Atoms may get lost.");

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -366,7 +366,7 @@ void Info::command(int narg, char **arg)
     if (comm->mode == 0) {
       fprintf(out,"Communication mode = single\n");
       fprintf(out,"Communication cutoff = %g\n",
-              MAX(comm->cutghostuser,neighbor->cutneighmax));
+              comm->get_comm_cutoff());
     }
 
     if (comm->mode == 1) {

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -278,9 +278,10 @@ void Neighbor::init()
   // cutneighghost = pair cutghost if it requests it, else same as cutneigh
 
   // also consider bonded interactions for estimating the the neighborlist
-  // and communication cutoff. we use the bond equilibrium distance as
-  // cutoff, if only a bond style exists. if also an angle style exists we
-  // multiply by 2, for dihedral or improper we multiply by 3.
+  // and communication cutoff. we use the 1.5x the bond equilibrium distance
+  // as cutoff, if only a bond style exists. if also an angle style exists we
+  // multiply by 2.5, for dihedral or improper we multiply by 3.5. (1,2, or 3
+  // bonds plus half a bond length total stretch).
   // this plus "skin" will become the default communication cutoff, if no
   // pair style is defined. otherwise the maximum of the largest pairwise
   // cutoff of this is used.
@@ -293,9 +294,11 @@ void Neighbor::init()
        maxbondcutoff = MAX(bondcutoff,maxbondcutoff);
     }
     if (force->dihedral || force->improper) {
-      maxbondcutoff *= 3.0;
+      maxbondcutoff *= 3.5;
     } else if (force->angle) {
-      maxbondcutoff *=2.0;
+      maxbondcutoff *=2.5;
+    } else {
+      maxbondcutoff *=1.5;
     }
   }
 

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -35,6 +35,7 @@
 #include "comm.h"
 #include "force.h"
 #include "pair.h"
+#include "bond.h"
 #include "domain.h"
 #include "group.h"
 #include "modify.h"
@@ -276,6 +277,28 @@ void Neighbor::init()
   // cutneigh = force cutoff + skin if cutforce > 0, else cutneigh = 0
   // cutneighghost = pair cutghost if it requests it, else same as cutneigh
 
+  // also consider bonded interactions for estimating the the neighborlist
+  // and communication cutoff. we use the bond equilibrium distance as
+  // cutoff, if only a bond style exists. if also an angle style exists we
+  // multiply by 2, for dihedral or improper we multiply by 3.
+  // this plus "skin" will become the default communication cutoff, if no
+  // pair style is defined. otherwise the maximum of the largest pairwise
+  // cutoff of this is used.
+
+  double maxbondcutoff = 0.0;
+  if (force->bond) {
+    n = atom->nbondtypes;
+    for (i = 1; i <= n; ++i) {
+       double bondcutoff = force->bond->equilibrium_distance(i);
+       maxbondcutoff = MAX(bondcutoff,maxbondcutoff);
+    }
+    if (force->dihedral || force->improper) {
+      maxbondcutoff *= 3.0;
+    } else if (force->angle) {
+      maxbondcutoff *=2.0;
+    }
+  }
+
   triggersq = 0.25*skin*skin;
   boxcheck = 0;
   if (domain->box_change && (domain->xperiodic || domain->yperiodic ||
@@ -293,7 +316,7 @@ void Neighbor::init()
 
   double cutoff,delta,cut;
   cutneighmin = BIG;
-  cutneighmax = 0.0;
+  cutneighmax = maxbondcutoff;
 
   for (i = 1; i <= n; i++) {
     cuttype[i] = cuttypesq[i] = 0.0;

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -35,7 +35,6 @@
 #include "comm.h"
 #include "force.h"
 #include "pair.h"
-#include "bond.h"
 #include "domain.h"
 #include "group.h"
 #include "modify.h"
@@ -277,31 +276,6 @@ void Neighbor::init()
   // cutneigh = force cutoff + skin if cutforce > 0, else cutneigh = 0
   // cutneighghost = pair cutghost if it requests it, else same as cutneigh
 
-  // also consider bonded interactions for estimating the the neighborlist
-  // and communication cutoff. we use the 1.5x the bond equilibrium distance
-  // as cutoff, if only a bond style exists. if also an angle style exists we
-  // multiply by 2.5, for dihedral or improper we multiply by 3.5. (1,2, or 3
-  // bonds plus half a bond length total stretch).
-  // this plus "skin" will become the default communication cutoff, if no
-  // pair style is defined. otherwise the maximum of the largest pairwise
-  // cutoff of this is used.
-
-  double maxbondcutoff = 0.0;
-  if (force->bond) {
-    n = atom->nbondtypes;
-    for (i = 1; i <= n; ++i) {
-       double bondcutoff = force->bond->equilibrium_distance(i);
-       maxbondcutoff = MAX(bondcutoff,maxbondcutoff);
-    }
-    if (force->dihedral || force->improper) {
-      maxbondcutoff *= 3.5;
-    } else if (force->angle) {
-      maxbondcutoff *=2.5;
-    } else {
-      maxbondcutoff *=1.5;
-    }
-  }
-
   triggersq = 0.25*skin*skin;
   boxcheck = 0;
   if (domain->box_change && (domain->xperiodic || domain->yperiodic ||
@@ -319,7 +293,7 @@ void Neighbor::init()
 
   double cutoff,delta,cut;
   cutneighmin = BIG;
-  cutneighmax = maxbondcutoff;
+  cutneighmax = 0.0;
 
   for (i = 1; i <= n; i++) {
     cuttype[i] = cuttypesq[i] = 0.0;


### PR DESCRIPTION
**Summary**

Add a function to the `Comm` class that determines the communication cutoff consistently. When determining the communication cutoff use the larger of `Neighbor::maxneighcut` and the user provided communication cutoff, but also consider bond lengths and whether angles and dihedrals are present. If there is no pair style and no user provided cutoff, use the bond length inferred value, otherwise print a warning, if that estimate is larger than the actual communication cutoff. Also print a warning message, when the user specified communication cutoff is overridden.

**Related Issues**

Fixes #1577 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes.

**Post Submission Checklist**
- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

