### PR TITLE
Correct restarting of bonded hybrid styles for table styles

### DIFF
--- a/doc/src/angle_table.txt
+++ b/doc/src/angle_table.txt
@@ -143,6 +143,16 @@ instructions on how to use the accelerated styles effectively.
 
 :line
 
+[Restart info:]
+
+This angle style writes the settings for the "angle_style table"
+command to "binary restart files"_restart.html, so a angle_style
+command does not need to specified in an input script that reads a
+restart file.  However, the coefficient information is not stored in
+the restart file, since it is tabulated in the potential files.  Thus,
+angle_coeff commands do need to be specified in the restart input
+script.
+
 [Restrictions:]
 
 This angle style can only be used if LAMMPS was built with the

--- a/doc/src/bond_table.txt
+++ b/doc/src/bond_table.txt
@@ -140,6 +140,16 @@ instructions on how to use the accelerated styles effectively.
 
 :line
 
+[Restart info:]
+
+This bond style writes the settings for the "bond_style table"
+command to "binary restart files"_restart.html, so a bond_style
+command does not need to specified in an input script that reads a
+restart file.  However, the coefficient information is not stored in
+the restart file, since it is tabulated in the potential files.  Thus,
+bond_coeff commands do need to be specified in the restart input
+script.
+
 [Restrictions:]
 
 This bond style can only be used if LAMMPS was built with the MOLECULE

--- a/doc/src/dihedral_table.txt
+++ b/doc/src/dihedral_table.txt
@@ -191,6 +191,16 @@ switch"_Run_options.html when you invoke LAMMPS, or you can use the
 See the "Speed packages"_Speed_packages.html doc page for more
 instructions on how to use the accelerated styles effectively.
 
+[Restart info:]
+
+This dihedral style writes the settings for the "dihedral_style table"
+command to "binary restart files"_restart.html, so a dihedral_style
+command does not need to specified in an input script that reads a
+restart file.  However, the coefficient information is not stored in
+the restart file, since it is tabulated in the potential files.  Thus,
+dihedral_coeff commands do need to be specified in the restart input
+script.
+
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the

--- a/doc/src/dihedral_table_cut.txt
+++ b/doc/src/dihedral_table_cut.txt
@@ -189,6 +189,16 @@ Note that one file can contain many sections, each with a tabulated
 potential. LAMMPS reads the file section by section until it finds one
 that matches the specified keyword.
 
+[Restart info:]
+
+This dihedral style writes the settings for the "dihedral_style table/cut"
+command to "binary restart files"_restart.html, so a dihedral_style
+command does not need to specified in an input script that reads a
+restart file.  However, the coefficient information is not stored in
+the restart file, since it is tabulated in the potential files.  Thus,
+dihedral_coeff commands do need to be specified in the restart input
+script.
+
 [Restrictions:]
 
 This dihedral style can only be used if LAMMPS was built with the

--- a/src/MOLECULE/angle_table.cpp
+++ b/src/MOLECULE/angle_table.cpp
@@ -278,8 +278,7 @@ double AngleTable::equilibrium_angle(int i)
 
 void AngleTable::write_restart(FILE *fp)
 {
-  fwrite(&tabstyle,sizeof(int),1,fp);
-  fwrite(&tablength,sizeof(int),1,fp);
+  write_restart_settings(fp);
 }
 
 /* ----------------------------------------------------------------------
@@ -288,14 +287,32 @@ void AngleTable::write_restart(FILE *fp)
 
 void AngleTable::read_restart(FILE *fp)
 {
+  read_restart_settings(fp);
+  allocate();
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to restart file
+ ------------------------------------------------------------------------- */
+
+void AngleTable::write_restart_settings(FILE *fp)
+{
+  fwrite(&tabstyle,sizeof(int),1,fp);
+  fwrite(&tablength,sizeof(int),1,fp);
+}
+
+/* ----------------------------------------------------------------------
+    proc 0 reads from restart file, bcasts
+ ------------------------------------------------------------------------- */
+
+void AngleTable::read_restart_settings(FILE *fp)
+{
   if (comm->me == 0) {
     fread(&tabstyle,sizeof(int),1,fp);
     fread(&tablength,sizeof(int),1,fp);
   }
   MPI_Bcast(&tabstyle,1,MPI_INT,0,world);
   MPI_Bcast(&tablength,1,MPI_INT,0,world);
-
-  allocate();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/angle_table.h
+++ b/src/MOLECULE/angle_table.h
@@ -35,6 +35,8 @@ class AngleTable : public Angle {
   double equilibrium_angle(int);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_restart_settings(FILE *);
+  void read_restart_settings(FILE *);
   double single(int, int, int, int);
 
  protected:

--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -222,8 +222,7 @@ double BondTable::equilibrium_distance(int i)
 
 void BondTable::write_restart(FILE *fp)
 {
-  fwrite(&tabstyle,sizeof(int),1,fp);
-  fwrite(&tablength,sizeof(int),1,fp);
+  write_restart_settings(fp);
 }
 
 /* ----------------------------------------------------------------------
@@ -232,14 +231,32 @@ void BondTable::write_restart(FILE *fp)
 
 void BondTable::read_restart(FILE *fp)
 {
+  read_restart_settings(fp);
+  allocate();
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to restart file
+ ------------------------------------------------------------------------- */
+
+void BondTable::write_restart_settings(FILE *fp)
+{
+  fwrite(&tabstyle,sizeof(int),1,fp);
+  fwrite(&tablength,sizeof(int),1,fp);
+}
+
+/* ----------------------------------------------------------------------
+    proc 0 reads from restart file, bcasts
+ ------------------------------------------------------------------------- */
+
+void BondTable::read_restart_settings(FILE *fp)
+{
   if (comm->me == 0) {
     fread(&tabstyle,sizeof(int),1,fp);
     fread(&tablength,sizeof(int),1,fp);
   }
   MPI_Bcast(&tabstyle,1,MPI_INT,0,world);
   MPI_Bcast(&tablength,1,MPI_INT,0,world);
-
-  allocate();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/bond_table.h
+++ b/src/MOLECULE/bond_table.h
@@ -35,6 +35,8 @@ class BondTable : public Bond {
   double equilibrium_distance(int);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_restart_settings(FILE *);
+  void read_restart_settings(FILE *);
   double single(int, double, int, int, double &);
 
  protected:

--- a/src/USER-MISC/dihedral_table.cpp
+++ b/src/USER-MISC/dihedral_table.cpp
@@ -1012,8 +1012,7 @@ void DihedralTable::coeff(int narg, char **arg)
 
 void DihedralTable::write_restart(FILE *fp)
 {
-  fwrite(&tabstyle,sizeof(int),1,fp);
-  fwrite(&tablength,sizeof(int),1,fp);
+  write_restart_settings(fp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1022,6 +1021,27 @@ void DihedralTable::write_restart(FILE *fp)
 
 void DihedralTable::read_restart(FILE *fp)
 {
+  read_restart_settings(fp);
+  allocate();
+}
+
+
+/* ----------------------------------------------------------------------
+   proc 0 writes to restart file
+ ------------------------------------------------------------------------- */
+
+void DihedralTable::write_restart_settings(FILE *fp)
+{
+  fwrite(&tabstyle,sizeof(int),1,fp);
+  fwrite(&tablength,sizeof(int),1,fp);
+}
+
+/* ----------------------------------------------------------------------
+    proc 0 reads from restart file, bcasts
+ ------------------------------------------------------------------------- */
+
+void DihedralTable::read_restart_settings(FILE *fp)
+{
   if (comm->me == 0) {
     fread(&tabstyle,sizeof(int),1,fp);
     fread(&tablength,sizeof(int),1,fp);
@@ -1029,8 +1049,6 @@ void DihedralTable::read_restart(FILE *fp)
 
   MPI_Bcast(&tabstyle,1,MPI_INT,0,world);
   MPI_Bcast(&tablength,1,MPI_INT,0,world);
-
-  allocate();
 }
 
 

--- a/src/USER-MISC/dihedral_table.h
+++ b/src/USER-MISC/dihedral_table.h
@@ -36,6 +36,8 @@ class DihedralTable : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_restart_settings(FILE *);
+  void read_restart_settings(FILE *);
   double single(int type, int i1, int i2, int i3, int i4);
 
  protected:

--- a/src/USER-MISC/dihedral_table_cut.cpp
+++ b/src/USER-MISC/dihedral_table_cut.cpp
@@ -1003,8 +1003,7 @@ void DihedralTableCut::coeff(int narg, char **arg)
 
 void DihedralTableCut::write_restart(FILE *fp)
 {
-  fwrite(&tabstyle,sizeof(int),1,fp);
-  fwrite(&tablength,sizeof(int),1,fp);
+  write_restart_settings(fp);
 }
 
 /* ----------------------------------------------------------------------
@@ -1013,8 +1012,26 @@ void DihedralTableCut::write_restart(FILE *fp)
 
 void DihedralTableCut::read_restart(FILE *fp)
 {
+  read_restart_settings(fp);
   allocate();
+}
 
+/* ----------------------------------------------------------------------
+   proc 0 writes out coeffs to restart file
+------------------------------------------------------------------------- */
+
+void DihedralTableCut::write_restart_settings(FILE *fp)
+{
+  fwrite(&tabstyle,sizeof(int),1,fp);
+  fwrite(&tablength,sizeof(int),1,fp);
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 reads coeffs from restart file, bcasts them
+------------------------------------------------------------------------- */
+
+void DihedralTableCut::read_restart_settings(FILE *fp)
+{
   if (comm->me == 0) {
     fread(&tabstyle,sizeof(int),1,fp);
     fread(&tablength,sizeof(int),1,fp);

--- a/src/USER-MISC/dihedral_table_cut.h
+++ b/src/USER-MISC/dihedral_table_cut.h
@@ -33,6 +33,8 @@ class DihedralTableCut : public Dihedral {
   void coeff(int, char **);
   void write_restart(FILE *);
   void read_restart(FILE *);
+  void write_restart_settings(FILE *);
+  void read_restart_settings(FILE *);
 
  protected:
   double *aat_k,*aat_theta0_1,*aat_theta0_2;

--- a/src/angle.h
+++ b/src/angle.h
@@ -46,6 +46,8 @@ class Angle : protected Pointers {
   virtual double equilibrium_angle(int) = 0;
   virtual void write_restart(FILE *) = 0;
   virtual void read_restart(FILE *) = 0;
+  virtual void write_restart_settings(FILE *) {};
+  virtual void read_restart_settings(FILE *) {};
   virtual void write_data(FILE *) {}
   virtual double single(int, int, int, int) = 0;
   virtual double memory_usage();

--- a/src/angle_hybrid.cpp
+++ b/src/angle_hybrid.cpp
@@ -324,6 +324,7 @@ void AngleHybrid::write_restart(FILE *fp)
     n = strlen(keywords[m]) + 1;
     fwrite(&n,sizeof(int),1,fp);
     fwrite(keywords[m],sizeof(char),n,fp);
+    styles[m]->write_restart_settings(fp);
   }
 }
 
@@ -349,6 +350,7 @@ void AngleHybrid::read_restart(FILE *fp)
     if (me == 0) fread(keywords[m],sizeof(char),n,fp);
     MPI_Bcast(keywords[m],n,MPI_CHAR,0,world);
     styles[m] = force->new_angle(keywords[m],0,dummy);
+    styles[m]->read_restart_settings(fp);
   }
 }
 

--- a/src/bond.h
+++ b/src/bond.h
@@ -48,6 +48,8 @@ class Bond : protected Pointers {
   virtual double equilibrium_distance(int) = 0;
   virtual void write_restart(FILE *) = 0;
   virtual void read_restart(FILE *) = 0;
+  virtual void write_restart_settings(FILE *) {};
+  virtual void read_restart_settings(FILE *) {};
   virtual void write_data(FILE *) {}
   virtual double single(int, double, int, int, double &) = 0;
   virtual double memory_usage();

--- a/src/bond_hybrid.cpp
+++ b/src/bond_hybrid.cpp
@@ -325,6 +325,7 @@ void BondHybrid::write_restart(FILE *fp)
     n = strlen(keywords[m]) + 1;
     fwrite(&n,sizeof(int),1,fp);
     fwrite(keywords[m],sizeof(char),n,fp);
+    styles[m]->write_restart_settings(fp);
   }
 }
 
@@ -350,6 +351,7 @@ void BondHybrid::read_restart(FILE *fp)
     if (me == 0) fread(keywords[m],sizeof(char),n,fp);
     MPI_Bcast(keywords[m],n,MPI_CHAR,0,world);
     styles[m] = force->new_bond(keywords[m],0,dummy);
+    styles[m]->read_restart_settings(fp);
   }
 }
 

--- a/src/dihedral.h
+++ b/src/dihedral.h
@@ -45,6 +45,8 @@ class Dihedral : protected Pointers {
   virtual void coeff(int, char **) = 0;
   virtual void write_restart(FILE *) = 0;
   virtual void read_restart(FILE *) = 0;
+  virtual void write_restart_settings(FILE *) {};
+  virtual void read_restart_settings(FILE *) {};
   virtual void write_data(FILE *) {}
   virtual double memory_usage();
 

--- a/src/dihedral_hybrid.cpp
+++ b/src/dihedral_hybrid.cpp
@@ -309,6 +309,7 @@ void DihedralHybrid::write_restart(FILE *fp)
     n = strlen(keywords[m]) + 1;
     fwrite(&n,sizeof(int),1,fp);
     fwrite(keywords[m],sizeof(char),n,fp);
+    styles[m]->write_restart_settings(fp);
   }
 }
 
@@ -334,6 +335,7 @@ void DihedralHybrid::read_restart(FILE *fp)
     if (me == 0) fread(keywords[m],sizeof(char),n,fp);
     MPI_Bcast(keywords[m],n,MPI_CHAR,0,world);
     styles[m] = force->new_dihedral(keywords[m],0,dummy);
+    styles[m]->read_restart_settings(fp);
   }
 }
 

--- a/src/improper.h
+++ b/src/improper.h
@@ -45,6 +45,8 @@ class Improper : protected Pointers {
   virtual void coeff(int, char **) = 0;
   virtual void write_restart(FILE *) = 0;
   virtual void read_restart(FILE *) = 0;
+  virtual void write_restart_settings(FILE *) {};
+  virtual void read_restart_settings(FILE *) {};
   virtual void write_data(FILE *) {}
   virtual double memory_usage();
 

--- a/src/improper_hybrid.cpp
+++ b/src/improper_hybrid.cpp
@@ -306,6 +306,7 @@ void ImproperHybrid::write_restart(FILE *fp)
     n = strlen(keywords[m]) + 1;
     fwrite(&n,sizeof(int),1,fp);
     fwrite(keywords[m],sizeof(char),n,fp);
+    styles[m]->write_restart_settings(fp);
   }
 }
 
@@ -331,6 +332,7 @@ void ImproperHybrid::read_restart(FILE *fp)
     if (me == 0) fread(keywords[m],sizeof(char),n,fp);
     MPI_Bcast(keywords[m],n,MPI_CHAR,0,world);
     styles[m] = force->new_improper(keywords[m],0,dummy);
+    styles[m]->read_restart_settings(fp);
   }
 }
 

--- a/src/pair.h
+++ b/src/pair.h
@@ -61,7 +61,7 @@ class Pair : protected Pointers {
   int dispersionflag;            // 1 if compatible with LJ/dispersion solver
   int tip4pflag;                 // 1 if compatible with TIP4P solver
   int dipoleflag;                // 1 if compatible with dipole solver
-  int spinflag;			 // 1 if compatible with spin solver
+  int spinflag;                  // 1 if compatible with spin solver
   int reinitflag;                // 1 if compatible with fix adapt and alike
 
   int tail_flag;                 // pair_modify flag for LJ tail correction


### PR DESCRIPTION
**Summary**

Unlike other bonded styles, the table variants need additional arguments and a call to their `settings()` function to process those. This breaks restarting when they are used in hybrid styles. This PR corrects this behavior and allows for smooth restarts.

**Related Issues**

This addresses the issue discussed in [this thread](https://sourceforge.net/p/lammps/mailman/lammps-users/thread/ff9641f1-dba7-5471-9cd1-1ed08e43542d%40uib.no/#msg36724565) and avoids the segfaul in the dihedral style table.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This will break reading restart files from previous LAMMPS versions for systems with bond/angle/dihedral style table or table/cut.

**Implementation Notes**

Similar as for pair styles, this now splits the restarting into two functions, where the restart settings function are called from the restart functions, but also form inside hybrid restarts. It only requires changes to the hybrid styles table styles.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

