### PR TITLE
Fixing bug in nve/kk when using rmass.

### DIFF
--- a/src/KOKKOS/fix_nve_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_kokkos.cpp
@@ -98,7 +98,7 @@ KOKKOS_INLINE_FUNCTION
 void FixNVEKokkos<DeviceType>::initial_integrate_rmass_item(int i) const
 {
   if (mask[i] & groupbit) {
-    const double dtfm = dtf / rmass[type[i]];
+    const double dtfm = dtf / rmass[i];
     v(i,0) += dtfm * f(i,0);
     v(i,1) += dtfm * f(i,1);
     v(i,2) += dtfm * f(i,2);

--- a/src/KOKKOS/fix_nve_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_kokkos.cpp
@@ -154,7 +154,7 @@ KOKKOS_INLINE_FUNCTION
 void FixNVEKokkos<DeviceType>::final_integrate_rmass_item(int i) const
 {
   if (mask[i] & groupbit) {
-    const double dtfm = dtf / rmass[type[i]];
+    const double dtfm = dtf / rmass[i];
     v(i,0) += dtfm * f(i,0);
     v(i,1) += dtfm * f(i,1);
     v(i,2) += dtfm * f(i,2);


### PR DESCRIPTION
**Summary**

Fixing bug in Kokkos version of nve when using rmass. It was using type[i] as an index for rmass. Should use i instead since rmass is per atom.

**Author(s)**

Denis Taniguchi (denis.taniguchi@gmail.com)
Newcastle University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No backward compatibility issues.

**Implementation Notes**

The problem can be easily detected simply by looking at the code.

**Post Submission Checklist**

- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines

