### PR TITLE
HIP-backend for the GPU package

### DIFF
--- a/lib/gpu/Makefile.hip
+++ b/lib/gpu/Makefile.hip
@@ -1,0 +1,148 @@
+# /* ----------------------------------------------------------------------   
+#  Generic Linux Makefile for HIP
+#     - export HIP_PLATFORM=hcc (or nvcc) before execution
+#     - change HIP_ARCH for your GPU
+# ------------------------------------------------------------------------- */
+
+# this setting should match LAMMPS Makefile
+# one of LAMMPS_SMALLBIG (default), LAMMPS_BIGBIG and LAMMPS_SMALLSMALL
+
+LMP_INC = -DLAMMPS_SMALLBIG
+
+# precision for GPU calculations
+# -D_SINGLE_SINGLE  # Single precision for all calculations
+# -D_DOUBLE_DOUBLE  # Double precision for all calculations
+# -D_SINGLE_DOUBLE  # Accumulation of forces, etc. in double
+
+HIP_PRECISION = -D_SINGLE_DOUBLE
+
+HIP_OPTS = -O3 
+HIP_HOST_OPTS = -Wno-deprecated-declarations
+HIP_HOST_INCLUDE = 
+
+# use device sort 
+# requires linking with hipcc and hipCUB + (rocPRIM or CUB for AMD or Nvidia respectively)
+HIP_HOST_OPTS += -DUSE_HIP_DEVICE_SORT 
+# path to cub
+HIP_HOST_INCLUDE += -I./
+# path to hipcub
+HIP_HOST_INCLUDE += -I$(HIP_PATH)/../include
+
+# use mpi
+HIP_HOST_OPTS += -DMPI_GERYON -DUCL_NO_EXIT
+# this settings should match LAMMPS Makefile
+MPI_COMP_OPTS = $(shell mpicxx --showme:compile)
+MPI_LINK_OPTS = $(shell mpicxx --showme:link)
+#MPI_COMP_OPTS += -I/usr/include/mpi  -DMPICH_IGNORE_CXX_SEEK -DOMPI_SKIP_MPICXX=1
+
+HIP_PATH ?= $(wildcard /opt/rocm/hip)
+HIP_PLATFORM=$(shell $(HIP_PATH)/bin/hipconfig --compiler)
+
+ifeq (hcc,$(HIP_PLATFORM))
+	HIP_OPTS  += -ffast-math
+	# possible values: gfx803,gfx900,gfx906
+	HIP_ARCH = gfx906
+else ifeq (nvcc,$(HIP_PLATFORM))
+	HIP_OPTS  += --use_fast_math
+	HIP_ARCH = -gencode arch=compute_30,code=[sm_30,compute_30] -gencode arch=compute_32,code=[sm_32,compute_32] -gencode arch=compute_35,code=[sm_35,compute_35] \
+		    -gencode arch=compute_50,code=[sm_50,compute_50] -gencode arch=compute_52,code=[sm_52,compute_52] -gencode arch=compute_53,code=[sm_53,compute_53]\
+			-gencode arch=compute_60,code=[sm_60,compute_60] -gencode arch=compute_61,code=[sm_61,compute_61] -gencode arch=compute_62,code=[sm_62,compute_62]\
+			-gencode arch=compute_70,code=[sm_70,compute_70] -gencode arch=compute_72,code=[sm_72,compute_72] -gencode arch=compute_75,code=[sm_75,compute_75] 
+else
+	$(error Specify HIP platform using 'export HIP_PLATFORM=(hcc,nvcc)')
+endif
+
+BIN_DIR = .
+OBJ_DIR = ./obj
+LIB_DIR = .
+AR = ar
+BSH = /bin/sh
+
+
+# /* ----------------------------------------------------------------------   
+#  				don't change section below without need			
+# ------------------------------------------------------------------------- */
+
+HIP_OPTS += -DUSE_HIP $(HIP_PRECISION)
+HIP_GPU_OPTS += $(HIP_OPTS) -I./
+
+ifeq (hcc,$(HIP_PLATFORM))
+	HIP_HOST_OPTS += -fPIC
+	HIP_GPU_CC  = $(HIP_PATH)/bin/hipcc --genco
+	HIP_GPU_OPTS_S = -t="$(HIP_ARCH)" -f=\" 
+	HIP_GPU_OPTS_E = \"
+	HIP_KERNEL_SUFFIX = .cpp
+	HIP_LIBS_TARGET = export HCC_AMDGPU_TARGET := $(HIP_ARCH)
+	export HCC_AMDGPU_TARGET := $(HIP_ARCH)
+else ifeq (nvcc,$(HIP_PLATFORM))
+	HIP_GPU_CC  = $(HIP_PATH)/bin/hipcc --fatbin 
+	HIP_GPU_OPTS += $(HIP_ARCH)
+	HIP_GPU_SORT_ARCH = $(HIP_ARCH)
+	# fix nvcc can't handle -pthread flag
+	MPI_COMP_OPTS := $(subst -pthread,-Xcompiler -pthread,$(MPI_COMP_OPTS))
+	MPI_LINK_OPTS := $(subst -pthread,-Xcompiler -pthread,$(MPI_LINK_OPTS))
+endif
+
+# hipcc is essential for device sort, because of hipcub is header only library and ROCm gpu code generation is deferred to the linking stage
+HIP_HOST_CC = $(HIP_PATH)/bin/hipcc
+HIP_HOST_OPTS += $(HIP_OPTS) $(MPI_COMP_OPTS) $(LMP_INC)
+HIP_HOST_CC_CMD  = $(HIP_HOST_CC) $(HIP_HOST_OPTS) $(HIP_HOST_INCLUDE)
+
+# sources
+
+ALL_H  =  $(wildcard ./geryon/ucl*.h) $(wildcard ./geryon/hip*.h) $(wildcard ./lal_*.h)
+SRCS := $(wildcard ./lal_*.cpp)
+OBJS := $(subst ./,$(OBJ_DIR)/,$(SRCS:%.cpp=%.o))
+CUS  := $(wildcard lal_*.cu)
+CUHS := $(filter-out pppm_cubin.h, $(CUS:lal_%.cu=%_cubin.h)) pppm_f_cubin.h pppm_d_cubin.h
+CUHS := $(addprefix $(OBJ_DIR)/, $(CUHS))
+
+all: $(OBJ_DIR) $(CUHS) $(LIB_DIR)/libgpu.a $(BIN_DIR)/hip_get_devices
+
+$(OBJ_DIR):
+	mkdir -p $@    
+
+# GPU kernels compilation 
+
+$(OBJ_DIR)/pppm_f_cubin.h: lal_pppm.cu  $(ALL_H)
+	@cp $< $(OBJ_DIR)/temp_pppm_f.cu$(HIP_KERNEL_SUFFIX)
+	$(HIP_GPU_CC) $(HIP_GPU_OPTS_S) $(HIP_GPU_OPTS) -Dgrdtyp=float  -Dgrdtyp4=float4 $(HIP_GPU_OPTS_E)  -o $(OBJ_DIR)/pppm_f.cubin $(OBJ_DIR)/temp_pppm_f.cu$(HIP_KERNEL_SUFFIX)
+	@xxd -i $(OBJ_DIR)/pppm_f.cubin $@
+	@sed -i "s/[a-zA-Z0-9_]*pppm_f_cubin/pppm_f/g" $@
+	@rm $(OBJ_DIR)/temp_pppm_f.cu$(HIP_KERNEL_SUFFIX) $(OBJ_DIR)/pppm_f.cubin
+
+$(OBJ_DIR)/pppm_d_cubin.h: lal_pppm.cu  $(ALL_H)
+	@cp $< $(OBJ_DIR)/temp_pppm_d.cu$(HIP_KERNEL_SUFFIX)
+	$(HIP_GPU_CC) $(HIP_GPU_OPTS_S) $(HIP_GPU_OPTS) -Dgrdtyp=double -Dgrdtyp4=double4 $(HIP_GPU_OPTS_E)  -o $(OBJ_DIR)/pppm_d.cubin $(OBJ_DIR)/temp_pppm_d.cu$(HIP_KERNEL_SUFFIX)
+	@xxd -i $(OBJ_DIR)/pppm_d.cubin $@
+	@sed -i "s/[a-zA-Z0-9_]*pppm_d_cubin/pppm_d/g" $@
+	@rm $(OBJ_DIR)/temp_pppm_d.cu$(HIP_KERNEL_SUFFIX) $(OBJ_DIR)/pppm_d.cubin
+
+$(OBJ_DIR)/%_cubin.h: lal_%.cu  $(ALL_H)
+	@cp $< $(OBJ_DIR)/temp_$*.cu$(HIP_KERNEL_SUFFIX)
+	$(HIP_GPU_CC) $(HIP_GPU_OPTS_S) $(HIP_GPU_OPTS) $(HIP_GPU_OPTS_E)  -o $(OBJ_DIR)/$*.cubin $(OBJ_DIR)/temp_$*.cu$(HIP_KERNEL_SUFFIX)
+	@xxd -i $(OBJ_DIR)/$*.cubin $@
+	@sed -i "s/[a-zA-Z0-9_]*$*_cubin/$*/g" $@
+	@rm $(OBJ_DIR)/temp_$*.cu$(HIP_KERNEL_SUFFIX) $(OBJ_DIR)/$*.cubin
+
+# host sources compilation
+
+$(OBJ_DIR)/lal_atom.o: lal_atom.cpp $(CUHS) $(ALL_H)
+	$(HIP_HOST_CC_CMD) -o $@ -c $< -I$(OBJ_DIR) $(HIP_GPU_SORT_ARCH) 
+
+$(OBJ_DIR)/lal_%.o: lal_%.cpp $(CUHS) $(ALL_H)
+	$(HIP_HOST_CC_CMD) -o $@ -c $< -I$(OBJ_DIR)
+
+# libgpu building
+
+$(LIB_DIR)/libgpu.a: $(OBJS)
+	$(AR) -crs $@ $(OBJS)
+	echo "export HIP_PLATFORM := $(HIP_PLATFORM)\n$(HIP_LIBS_TARGET)" > 'Makefile.lammps'   
+
+# test app building
+
+$(BIN_DIR)/hip_get_devices: ./geryon/ucl_get_devices.cpp $(ALL_H)
+	$(HIP_HOST_CC_CMD) -o $@ $< -DUCL_HIP $(MPI_LINK_OPTS)
+
+clean:
+	-rm -f $(BIN_DIR)/hip_get_devices $(LIB_DIR)/libgpu.a $(OBJS) $(OBJ_DIR)/temp_* $(CUHS)

--- a/lib/gpu/geryon/hip_device.h
+++ b/lib/gpu/geryon/hip_device.h
@@ -1,0 +1,486 @@
+/***************************************************************************
+                                nvd_device.h
+                             -------------------
+                               W. Michael Brown
+
+  Utilities for dealing with cuda devices
+
+ __________________________________________________________________________
+    This file is part of the Geryon Unified Coprocessor Library (UCL)
+ __________________________________________________________________________
+
+    begin                : Thu Jan 21 2010
+    copyright            : (C) 2010 by W. Michael Brown
+    email                : brownw@ornl.gov
+ ***************************************************************************/
+
+/* -----------------------------------------------------------------------
+   Copyright (2009) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the Simplified BSD License.
+   ----------------------------------------------------------------------- */
+
+#ifndef NVD_DEVICE
+#define NVD_DEVICE
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include "nvd_macros.h"
+#include "ucl_types.h"
+
+namespace ucl_cudadr {
+
+// --------------------------------------------------------------------------
+// - COMMAND QUEUE STUFF
+// --------------------------------------------------------------------------
+typedef CUstream command_queue;
+
+inline void ucl_sync(CUstream &stream) {
+  CU_SAFE_CALL(cuStreamSynchronize(stream));
+}
+
+struct NVDProperties {
+  int device_id;
+  std::string name;
+  int major;
+  int minor;
+  CUDA_INT_TYPE totalGlobalMem;
+  int multiProcessorCount;
+
+  int maxThreadsPerBlock;
+  int maxThreadsDim[3];
+  int maxGridSize[3];
+  int sharedMemPerBlock;
+  int totalConstantMemory;
+  int SIMDWidth;
+  int memPitch;
+  int regsPerBlock;
+  int clockRate;
+  int textureAlign;
+
+  int kernelExecTimeoutEnabled;
+  int integrated;
+  int canMapHostMemory;
+  int concurrentKernels;
+  int ECCEnabled;
+  int computeMode;
+};
+
+/// Class for looking at device properties
+/** \note Calls to change the device outside of the class results in incorrect
+  *       behavior
+  * \note There is no error checking for indexing past the number of devices **/
+class UCL_Device {
+ public:
+  /// Collect properties for every GPU on the node
+  /** \note You must set the active GPU with set() before using the device **/
+  inline UCL_Device();
+
+  inline ~UCL_Device();
+
+  /// Returns 1 (For compatibility with OpenCL)
+  inline int num_platforms() { return 1; }
+
+  /// Return a string with name and info of the current platform
+  inline std::string platform_name()
+    { return "NVIDIA Corporation NVIDIA CUDA Driver"; }
+
+  /// Delete any contexts/data and set the platform number to be used
+  inline int set_platform(const int pid);
+
+  /// Return the number of devices that support CUDA
+  inline int num_devices() { return _properties.size(); }
+
+  /// Set the CUDA device to the specified device number
+  /** A context and default command queue will be created for the device
+    * Returns UCL_SUCCESS if successful or UCL_ERROR if the device could not
+    * be allocated for use. clear() is called to delete any contexts and
+    * associated data from previous calls to set(). **/
+  inline int set(int num);
+
+  /// Delete any context and associated data stored from a call to set()
+  inline void clear();
+
+  /// Get the current device number
+  inline int device_num() { return _device; }
+
+  /// Returns the default stream for the current device
+  inline command_queue & cq() { return cq(0); }
+
+  /// Returns the stream indexed by i
+  inline command_queue & cq(const int i) { return _cq[i]; }
+
+  /// Block until all commands in the default stream have completed
+  inline void sync() { sync(0); }
+
+  /// Block until all commands in the specified stream have completed
+  inline void sync(const int i) { ucl_sync(cq(i)); }
+
+  /// Get the number of command queues currently available on device
+  inline int num_queues()
+    { return _cq.size(); }
+
+  /// Add a stream for device computations
+  inline void push_command_queue() {
+    _cq.push_back(CUstream());
+    CU_SAFE_CALL(cuStreamCreate(&_cq.back(),0));
+  }
+
+  /// Remove a stream for device computations
+  /** \note You cannot delete the default stream **/
+  inline void pop_command_queue() {
+    if (_cq.size()<2) return;
+    CU_SAFE_CALL_NS(cuStreamDestroy(_cq.back()));
+    _cq.pop_back();
+  }
+
+  /// Set the default command queue (by default this is the null stream)
+  /** \param i index of the command queue (as added by push_command_queue())
+      If i is 0, the default command queue is set to the null stream **/
+  inline void set_command_queue(const int i) {
+    if (i==0) _cq[0]=0;
+    else _cq[0]=_cq[i];
+  }
+
+  /// Get the current CUDA device name
+  inline std::string name() { return name(_device); }
+  /// Get the CUDA device name
+  inline std::string name(const int i)
+    { return std::string(_properties[i].name); }
+
+  /// Get a string telling the type of the current device
+  inline std::string device_type_name() { return device_type_name(_device); }
+  /// Get a string telling the type of the device
+  inline std::string device_type_name(const int i) { return "GPU"; }
+
+  /// Get current device type (UCL_CPU, UCL_GPU, UCL_ACCELERATOR, UCL_DEFAULT)
+  inline int device_type() { return device_type(_device); }
+  /// Get device type (UCL_CPU, UCL_GPU, UCL_ACCELERATOR, UCL_DEFAULT)
+  inline int device_type(const int i) { return UCL_GPU; }
+
+  /// Returns true if host memory is efficiently addressable from device
+  inline bool shared_memory() { return shared_memory(_device); }
+  /// Returns true if host memory is efficiently addressable from device
+  inline bool shared_memory(const int i) { return device_type(i)==UCL_CPU; }
+
+  /// Returns true if double precision is support for the current device
+  inline bool double_precision() { return double_precision(_device); }
+  /// Returns true if double precision is support for the device
+  inline bool double_precision(const int i) {return arch(i)>=1.3;}
+
+  /// Get the number of compute units on the current device
+  inline unsigned cus() { return cus(_device); }
+  /// Get the number of compute units
+  inline unsigned cus(const int i)
+    { return _properties[i].multiProcessorCount; }
+
+  /// Get the number of cores in the current device
+  inline unsigned cores() { return cores(_device); }
+  /// Get the number of cores
+  inline unsigned cores(const int i)
+    { if (arch(i)<2.0) return _properties[i].multiProcessorCount*8;
+      else if (arch(i)<2.1) return _properties[i].multiProcessorCount*32;
+      else if (arch(i)<3.0) return _properties[i].multiProcessorCount*48;
+      else return _properties[i].multiProcessorCount*192; }
+
+  /// Get the gigabytes of global memory in the current device
+  inline double gigabytes() { return gigabytes(_device); }
+  /// Get the gigabytes of global memory
+  inline double gigabytes(const int i)
+    { return static_cast<double>(_properties[i].totalGlobalMem)/1073741824; }
+
+  /// Get the bytes of global memory in the current device
+  inline size_t bytes() { return bytes(_device); }
+  /// Get the bytes of global memory
+  inline size_t bytes(const int i) { return _properties[i].totalGlobalMem; }
+
+  // Get the gigabytes of free memory in the current device
+  inline double free_gigabytes() { return free_gigabytes(_device); }
+  // Get the gigabytes of free memory
+  inline double free_gigabytes(const int i)
+    { return static_cast<double>(free_bytes(i))/1073741824; }
+
+  // Get the bytes of free memory in the current device
+  inline size_t free_bytes() { return free_bytes(_device); }
+  // Get the bytes of free memory
+  inline size_t free_bytes(const int i) {
+    CUDA_INT_TYPE dfree, dtotal;
+    CU_SAFE_CALL_NS(cuMemGetInfo(&dfree, &dtotal));
+    return static_cast<size_t>(dfree);
+  }
+
+  /// Return the GPGPU compute capability for current device
+  inline double arch() { return arch(_device); }
+  /// Return the GPGPU compute capability
+  inline double arch(const int i)
+    { return static_cast<double>(_properties[i].minor)/10+_properties[i].major;}
+
+  /// Clock rate in GHz for current device
+  inline double clock_rate() { return clock_rate(_device); }
+  /// Clock rate in GHz
+  inline double clock_rate(const int i)
+    { return _properties[i].clockRate*1e-6;}
+
+  /// Get the maximum number of threads per block
+  inline size_t group_size() { return group_size(_device); }
+  /// Get the maximum number of threads per block
+  inline size_t group_size(const int i)
+    { return _properties[i].maxThreadsPerBlock; }
+
+  /// Return the maximum memory pitch in bytes for current device
+  inline size_t max_pitch() { return max_pitch(_device); }
+  /// Return the maximum memory pitch in bytes
+  inline size_t max_pitch(const int i) { return _properties[i].memPitch; }
+
+  /// Returns false if accelerator cannot be shared by multiple processes
+  /** If it cannot be determined, true is returned **/
+  inline bool sharing_supported() { return sharing_supported(_device); }
+  /// Returns false if accelerator cannot be shared by multiple processes
+  /** If it cannot be determined, true is returned **/
+  inline bool sharing_supported(const int i)
+    { return (_properties[i].computeMode == CU_COMPUTEMODE_DEFAULT); }
+
+  /// True if splitting device into equal subdevices supported
+  inline bool fission_equal()
+    { return fission_equal(_device); }
+  /// True if splitting device into equal subdevices supported
+  inline bool fission_equal(const int i)
+    { return false; }
+  /// True if splitting device into subdevices by specified counts supported
+  inline bool fission_by_counts()
+    { return fission_by_counts(_device); }
+  /// True if splitting device into subdevices by specified counts supported
+  inline bool fission_by_counts(const int i)
+    { return false; }
+  /// True if splitting device into subdevices by affinity domains supported
+  inline bool fission_by_affinity()
+    { return fission_by_affinity(_device); }
+  /// True if splitting device into subdevices by affinity domains supported
+  inline bool fission_by_affinity(const int i)
+    { return false; }
+
+  /// Maximum number of subdevices allowed from device fission
+  inline int max_sub_devices()
+    { return max_sub_devices(_device); }
+  /// Maximum number of subdevices allowed from device fission
+  inline int max_sub_devices(const int i)
+    { return 0; }
+
+  /// List all devices along with all properties
+  inline void print_all(std::ostream &out);
+
+  /// Select the platform that has accelerators (for compatibility with OpenCL)
+  inline int set_platform_accelerator(int pid=-1) { return UCL_SUCCESS; }
+
+ private:
+  int _device, _num_devices;
+  std::vector<NVDProperties> _properties;
+  std::vector<CUstream> _cq;
+  CUdevice _cu_device;
+  CUcontext _context;
+};
+
+// Grabs the properties for all devices
+UCL_Device::UCL_Device() {
+  CU_SAFE_CALL_NS(cuInit(0));
+  CU_SAFE_CALL_NS(cuDeviceGetCount(&_num_devices));
+  for (int i=0; i<_num_devices; ++i) {
+    CUdevice dev;
+    CU_SAFE_CALL_NS(cuDeviceGet(&dev,i));
+    int major, minor;
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, dev));
+    if (major==9999)
+      continue;
+
+    NVDProperties prop;
+    prop.device_id = i;
+    prop.major=major;
+    prop.minor=minor;
+
+    char namecstr[1024];
+    CU_SAFE_CALL_NS(cuDeviceGetName(namecstr,1024,dev));
+    prop.name=namecstr;
+
+    CU_SAFE_CALL_NS(cuDeviceTotalMem(&prop.totalGlobalMem,dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.multiProcessorCount, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, dev));
+
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.maxThreadsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.maxThreadsDim[0], CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.maxThreadsDim[1], CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.maxThreadsDim[2], CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.maxGridSize[0], CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.maxGridSize[1], CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.maxGridSize[2], CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.sharedMemPerBlock, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.totalConstantMemory, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.SIMDWidth, CU_DEVICE_ATTRIBUTE_WARP_SIZE, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.memPitch, CU_DEVICE_ATTRIBUTE_MAX_PITCH, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.regsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.clockRate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.textureAlign, CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT, dev));
+
+    #if CUDA_VERSION >= 2020
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.kernelExecTimeoutEnabled, CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT,dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.integrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.canMapHostMemory, CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.computeMode, CU_DEVICE_ATTRIBUTE_COMPUTE_MODE,dev));
+    #endif
+    #if CUDA_VERSION >= 3010
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.concurrentKernels, CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS, dev));
+    CU_SAFE_CALL_NS(cuDeviceGetAttribute(&prop.ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED, dev));
+    #endif
+
+    _properties.push_back(prop);
+  }
+  _device=-1;
+  _cq.push_back(CUstream());
+  _cq.back()=0;
+}
+
+UCL_Device::~UCL_Device() {
+  clear();
+}
+
+int UCL_Device::set_platform(const int pid) {
+  clear();
+  #ifdef UCL_DEBUG
+  assert(pid<num_platforms());
+  #endif
+  return UCL_SUCCESS;
+}
+
+// Set the CUDA device to the specified device number
+int UCL_Device::set(int num) {
+  clear();
+  _device=_properties[num].device_id;
+  CU_SAFE_CALL_NS(cuDeviceGet(&_cu_device,_device));
+  CUresult err=cuCtxCreate(&_context,0,_cu_device);
+  if (err!=CUDA_SUCCESS) {
+    #ifndef UCL_NO_EXIT
+    std::cerr << "UCL Error: Could not access accelerator number " << num
+              << " for use.\n";
+    UCL_GERYON_EXIT;
+    #endif
+    return UCL_ERROR;
+  }
+  return UCL_SUCCESS;
+}
+
+void UCL_Device::clear() {
+  if (_device>-1) {
+    for (int i=1; i<num_queues(); i++) pop_command_queue();
+    cuCtxDestroy(_context);
+  }
+  _device=-1;
+}
+
+// List all devices along with all properties
+void UCL_Device::print_all(std::ostream &out) {
+  #if CUDA_VERSION >= 2020
+  int driver_version;
+  cuDriverGetVersion(&driver_version);
+  out << "CUDA Driver Version:                           "
+      << driver_version/1000 << "." << driver_version%100
+                  << std::endl;
+  #endif
+
+  if (num_devices() == 0)
+    out << "There is no device supporting CUDA\n";
+  for (int i=0; i<num_devices(); ++i) {
+    out << "\nDevice " << i << ": \"" << name(i) << "\"\n";
+    out << "  Type of device:                                "
+        << device_type_name(i).c_str() << std::endl;
+    out << "  Compute capability:                            "
+        << arch(i) << std::endl;
+    out << "  Double precision support:                      ";
+    if (double_precision(i))
+      out << "Yes\n";
+    else
+      out << "No\n";
+    out << "  Total amount of global memory:                 "
+        << gigabytes(i) << " GB\n";
+    #if CUDA_VERSION >= 2000
+    out << "  Number of compute units/multiprocessors:       "
+        << _properties[i].multiProcessorCount << std::endl;
+    out << "  Number of cores:                               "
+        << cores(i) << std::endl;
+    #endif
+    out << "  Total amount of constant memory:               "
+        << _properties[i].totalConstantMemory << " bytes\n";
+    out << "  Total amount of local/shared memory per block: "
+        << _properties[i].sharedMemPerBlock << " bytes\n";
+    out << "  Total number of registers available per block: "
+        << _properties[i].regsPerBlock << std::endl;
+    out << "  Warp size:                                     "
+        << _properties[i].SIMDWidth << std::endl;
+    out << "  Maximum number of threads per block:           "
+        << _properties[i].maxThreadsPerBlock << std::endl;
+    out << "  Maximum group size (# of threads per block)    "
+        << _properties[i].maxThreadsDim[0] << " x "
+        << _properties[i].maxThreadsDim[1] << " x "
+        << _properties[i].maxThreadsDim[2] << std::endl;
+    out << "  Maximum item sizes (# threads for each dim)    "
+        << _properties[i].maxGridSize[0] << " x "
+        << _properties[i].maxGridSize[1] << " x "
+        << _properties[i].maxGridSize[2] << std::endl;
+    out << "  Maximum memory pitch:                          "
+        << max_pitch(i) << " bytes\n";
+    out << "  Texture alignment:                             "
+        << _properties[i].textureAlign << " bytes\n";
+    out << "  Clock rate:                                    "
+        << clock_rate(i) << " GHz\n";
+    #if CUDA_VERSION >= 2020
+    out << "  Run time limit on kernels:                     ";
+    if (_properties[i].kernelExecTimeoutEnabled)
+      out << "Yes\n";
+    else
+      out << "No\n";
+    out << "  Integrated:                                    ";
+    if (_properties[i].integrated)
+      out << "Yes\n";
+    else
+      out << "No\n";
+    out << "  Support host page-locked memory mapping:       ";
+    if (_properties[i].canMapHostMemory)
+      out << "Yes\n";
+    else
+      out << "No\n";
+    out << "  Compute mode:                                  ";
+    if (_properties[i].computeMode == CU_COMPUTEMODE_DEFAULT)
+      out << "Default\n"; // multiple threads can use device
+#if CUDA_VERSION >= 8000
+    else if (_properties[i].computeMode == CU_COMPUTEMODE_EXCLUSIVE_PROCESS)
+#else
+    else if (_properties[i].computeMode == CU_COMPUTEMODE_EXCLUSIVE)
+#endif
+      out << "Exclusive\n"; // only thread can use device
+    else if (_properties[i].computeMode == CU_COMPUTEMODE_PROHIBITED)
+      out << "Prohibited\n"; // no thread can use device
+    #if CUDART_VERSION >= 4000
+    else if (_properties[i].computeMode == CU_COMPUTEMODE_EXCLUSIVE_PROCESS)
+      out << "Exclusive Process\n"; // multiple threads 1 process
+    #endif
+    else
+      out << "Unknown\n";
+    #endif
+    #if CUDA_VERSION >= 3010
+    out << "  Concurrent kernel execution:                   ";
+    if (_properties[i].concurrentKernels)
+      out << "Yes\n";
+    else
+      out << "No\n";
+    out << "  Device has ECC support enabled:                ";
+    if (_properties[i].ECCEnabled)
+      out << "Yes\n";
+    else
+      out << "No\n";
+    #endif
+  }
+}
+
+}
+
+#endif

--- a/lib/gpu/geryon/hip_kernel.h
+++ b/lib/gpu/geryon/hip_kernel.h
@@ -1,0 +1,406 @@
+/***************************************************************************
+                                nvd_kernel.h
+                             -------------------
+                               W. Michael Brown
+
+  Utilities for dealing with CUDA Driver kernels
+
+ __________________________________________________________________________
+    This file is part of the Geryon Unified Coprocessor Library (UCL)
+ __________________________________________________________________________
+
+    begin                : Tue Feb 9 2010
+    copyright            : (C) 2010 by W. Michael Brown
+    email                : brownw@ornl.gov
+ ***************************************************************************/
+
+/* -----------------------------------------------------------------------
+   Copyright (2010) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the Simplified BSD License.
+   ----------------------------------------------------------------------- */
+
+#ifndef NVD_KERNEL
+#define NVD_KERNEL
+
+#include "nvd_device.h"
+#include <fstream>
+
+namespace ucl_cudadr {
+
+class UCL_Texture;
+template <class numtyp> class UCL_D_Vec;
+template <class numtyp> class UCL_D_Mat;
+template <class hosttype, class devtype> class UCL_Vector;
+template <class hosttype, class devtype> class UCL_Matrix;
+#define UCL_MAX_KERNEL_ARGS 256
+
+/// Class storing 1 or more kernel functions from a single string or file
+class UCL_Program {
+ public:
+  inline UCL_Program(UCL_Device &device) { _cq=device.cq(); }
+  inline UCL_Program(UCL_Device &device, const void *program,
+                     const char *flags="", std::string *log=NULL) {
+    _cq=device.cq();
+    init(device);
+    load_string(program,flags,log);
+  }
+
+  inline ~UCL_Program() {}
+
+  /// Initialize the program with a device
+  inline void init(UCL_Device &device) { _cq=device.cq(); }
+
+  /// Clear any data associated with program
+  /** \note Must call init() after each clear **/
+  inline void clear() { }
+
+  /// Load a program from a file and compile with flags
+  inline int load(const char *filename, const char *flags="",
+                  std::string *log=NULL) {
+    std::ifstream in(filename);
+    if (!in || in.is_open()==false) {
+      #ifndef UCL_NO_EXIT
+      std::cerr << "UCL Error: Could not open kernel file: "
+                << filename << std::endl;
+      UCL_GERYON_EXIT;
+      #endif
+      return UCL_FILE_NOT_FOUND;
+    }
+
+    std::string program((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+    in.close();
+    return load_string(program.c_str(),flags,log);
+  }
+
+  /// Load a program from a string and compile with flags
+  inline int load_string(const void *program, const char *flags="",
+                         std::string *log=NULL) {
+    if (std::string(flags)=="BINARY")
+      return load_binary((const char *)program);
+    const unsigned int num_opts=2;
+    CUjit_option options[num_opts];
+    void *values[num_opts];
+
+    // set up size of compilation log buffer
+    options[0] = CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES;
+    values[0] = (void *)(int)10240;
+    // set up pointer to the compilation log buffer
+    options[1] = CU_JIT_INFO_LOG_BUFFER;
+    char clog[10240];
+    values[1] = clog;
+
+    CUresult err=cuModuleLoadDataEx(&_module,program,num_opts,
+                                    options,(void **)values);
+
+    if (log!=NULL)
+      *log=std::string(clog);
+
+    if (err != CUDA_SUCCESS) {
+      #ifndef UCL_NO_EXIT
+      std::cerr << std::endl
+                << "----------------------------------------------------------\n"
+                << " UCL Error: Error compiling PTX Program...\n"
+                << "----------------------------------------------------------\n";
+      std::cerr << log << std::endl;
+      #endif
+      return UCL_COMPILE_ERROR;
+    }
+
+    return UCL_SUCCESS;
+  }
+
+  /// Load a precompiled program from a file
+  inline int load_binary(const char *filename) {
+    CUmodule _module;
+    CUresult err = cuModuleLoad(&_module,filename);
+    if (err==301) {
+      #ifndef UCL_NO_EXIT
+      std::cerr << "UCL Error: Could not open binary kernel file: "
+                << filename << std::endl;
+      UCL_GERYON_EXIT;
+      #endif
+      return UCL_FILE_NOT_FOUND;
+    } else if (err!=CUDA_SUCCESS) {
+      #ifndef UCL_NO_EXIT
+      std::cerr << "UCL Error: Error loading binary kernel file: "
+                << filename << std::endl;
+      UCL_GERYON_EXIT;
+      #endif
+      return UCL_FILE_NOT_FOUND;
+    }
+    //int ucl_error=UCL_SUCCESS;
+    //if (err==301)
+    //  return UCL_FILE_NOT_FOUND;
+    //else if (err!=CUDA_SUCCESS)
+    //  return UCL_ERROR;
+    return UCL_SUCCESS;
+  }
+
+  friend class UCL_Kernel;
+ private:
+  CUmodule _module;
+  CUstream _cq;
+  friend class UCL_Texture;
+};
+
+/// Class for dealing with CUDA Driver kernels
+class UCL_Kernel {
+ public:
+  UCL_Kernel() : _dimensions(1), _num_args(0) {
+    #if CUDA_VERSION < 4000
+    _param_size=0;
+    #endif
+    _num_blocks[0]=0;
+  }
+
+  UCL_Kernel(UCL_Program &program, const char *function) :
+    _dimensions(1), _num_args(0) {
+    #if CUDA_VERSION < 4000
+    _param_size=0;
+    #endif
+    _num_blocks[0]=0;
+    set_function(program,function);
+    _cq=program._cq;
+  }
+
+  ~UCL_Kernel() {}
+
+  /// Clear any function associated with the kernel
+  inline void clear() { }
+
+  /// Get the kernel function from a program
+  /** \ret UCL_ERROR_FLAG (UCL_SUCCESS, UCL_FILE_NOT_FOUND, UCL_ERROR) **/
+  inline int set_function(UCL_Program &program, const char *function) {
+    CUresult err=cuModuleGetFunction(&_kernel,program._module,function);
+    if (err!=CUDA_SUCCESS) {
+      #ifndef UCL_NO_EXIT
+      std::cerr << "UCL Error: Could not find function: " << function
+                << " in program.\n";
+      UCL_GERYON_EXIT;
+      #endif
+      return UCL_FUNCTION_NOT_FOUND;
+    }
+    _cq=program._cq;
+    return UCL_SUCCESS;
+  }
+
+  /// Set the kernel argument.
+  /** If not a device pointer, this must be repeated each time the argument
+    * changes
+    * \note To set kernel parameter i (i>0), parameter i-1 must be set **/
+  template <class dtype>
+  inline void set_arg(const unsigned index, const dtype * const arg) {
+    if (index==_num_args)
+      add_arg(arg);
+    else if (index<_num_args)
+      #if CUDA_VERSION >= 4000
+      _kernel_args[index]=arg;
+      #else
+      CU_SAFE_CALL(cuParamSetv(_kernel, _offsets[index], arg, sizeof(dtype)));
+      #endif
+    else
+      assert(0==1); // Must add kernel parameters in sequential order
+  }
+
+  /// Set a geryon container as a kernel argument.
+  template <class numtyp>
+  inline void set_arg(const UCL_D_Vec<numtyp> * const arg)
+    { set_arg(&arg->begin()); }
+
+  /// Set a geryon container as a kernel argument.
+  template <class numtyp>
+  inline void set_arg(const UCL_D_Mat<numtyp> * const arg)
+    { set_arg(&arg->begin()); }
+
+  /// Set a geryon container as a kernel argument.
+  template <class hosttype, class devtype>
+  inline void set_arg(const UCL_Vector<hosttype, devtype> * const arg)
+    { set_arg(&arg->device.begin()); }
+
+  /// Set a geryon container as a kernel argument.
+  template <class hosttype, class devtype>
+  inline void set_arg(const UCL_Matrix<hosttype, devtype> * const arg)
+    { set_arg(&arg->device.begin()); }
+
+  /// Add a kernel argument.
+  inline void add_arg(const CUdeviceptr* const arg) {
+    #if CUDA_VERSION >= 4000
+    _kernel_args[_num_args]=(void *)arg;
+    #else
+    void* ptr = (void*)(size_t)(*arg);
+    _param_size = (_param_size + __alignof(ptr) - 1) & ~(__alignof(ptr) - 1);
+    CU_SAFE_CALL(cuParamSetv(_kernel, _param_size, &ptr, sizeof(ptr)));
+    _offsets.push_back(_param_size);
+    _param_size+=sizeof(ptr);
+    #endif
+    _num_args++;
+    if (_num_args>UCL_MAX_KERNEL_ARGS) assert(0==1);
+  }
+
+  /// Add a kernel argument.
+  template <class dtype>
+  inline void add_arg(const dtype* const arg) {
+    #if CUDA_VERSION >= 4000
+    _kernel_args[_num_args]=const_cast<dtype * const>(arg);
+    #else
+    _param_size = (_param_size+__alignof(dtype)-1) & ~(__alignof(dtype)-1);
+    CU_SAFE_CALL(cuParamSetv(_kernel,_param_size,(void*)arg,sizeof(dtype)));
+    _offsets.push_back(_param_size);
+    _param_size+=sizeof(dtype);
+    #endif
+    _num_args++;
+    if (_num_args>UCL_MAX_KERNEL_ARGS) assert(0==1);
+  }
+
+  /// Add a geryon container as a kernel argument.
+  template <class numtyp>
+  inline void add_arg(const UCL_D_Vec<numtyp> * const arg)
+    { add_arg(&arg->begin()); }
+
+  /// Add a geryon container as a kernel argument.
+  template <class numtyp>
+  inline void add_arg(const UCL_D_Mat<numtyp> * const arg)
+    { add_arg(&arg->begin()); }
+
+  /// Add a geryon container as a kernel argument.
+  template <class hosttype, class devtype>
+  inline void add_arg(const UCL_Vector<hosttype, devtype> * const arg)
+    { add_arg(&arg->device.begin()); }
+
+  /// Add a geryon container as a kernel argument.
+  template <class hosttype, class devtype>
+  inline void add_arg(const UCL_Matrix<hosttype, devtype> * const arg)
+    { add_arg(&arg->device.begin()); }
+
+  /// Set the number of thread blocks and the number of threads in each block
+  /** \note This should be called before any arguments have been added
+      \note The default command queue is used for the kernel execution **/
+  inline void set_size(const size_t num_blocks, const size_t block_size) {
+    _dimensions=1;
+    _num_blocks[0]=num_blocks;
+    _num_blocks[1]=1;
+    _num_blocks[2]=1;
+    #if CUDA_VERSION >= 4000
+    _block_size[0]=block_size;
+    _block_size[1]=1;
+    _block_size[2]=1;
+    #else
+    CU_SAFE_CALL(cuFuncSetBlockShape(_kernel,block_size,1,1));
+    #endif
+  }
+
+  /// Set the number of thread blocks and the number of threads in each block
+  /** \note This should be called before any arguments have been added
+      \note The default command queue for the kernel is changed to cq **/
+  inline void set_size(const size_t num_blocks, const size_t block_size,
+                       command_queue &cq)
+    { _cq=cq; set_size(num_blocks,block_size); }
+
+  /// Set the number of thread blocks and the number of threads in each block
+  /** \note This should be called before any arguments have been added
+      \note The default command queue is used for the kernel execution **/
+  inline void set_size(const size_t num_blocks_x, const size_t num_blocks_y,
+                       const size_t block_size_x, const size_t block_size_y) {
+    _dimensions=2;
+    _num_blocks[0]=num_blocks_x;
+    _num_blocks[1]=num_blocks_y;
+    _num_blocks[2]=1;
+    #if CUDA_VERSION >= 4000
+    _block_size[0]=block_size_x;
+    _block_size[1]=block_size_y;
+    _block_size[2]=1;
+    #else
+    CU_SAFE_CALL(cuFuncSetBlockShape(_kernel,block_size_x,block_size_y,1));
+    #endif
+  }
+
+  /// Set the number of thread blocks and the number of threads in each block
+  /** \note This should be called before any arguments have been added
+      \note The default command queue for the kernel is changed to cq **/
+  inline void set_size(const size_t num_blocks_x, const size_t num_blocks_y,
+                       const size_t block_size_x, const size_t block_size_y,
+                       command_queue &cq)
+    {_cq=cq; set_size(num_blocks_x, num_blocks_y, block_size_x, block_size_y);}
+
+  /// Set the number of thread blocks and the number of threads in each block
+  /** \note This should be called before any arguments have been added
+      \note The default command queue is used for the kernel execution **/
+  inline void set_size(const size_t num_blocks_x, const size_t num_blocks_y,
+                       const size_t block_size_x,
+                       const size_t block_size_y, const size_t block_size_z) {
+    _dimensions=2;
+    _num_blocks[0]=num_blocks_x;
+    _num_blocks[1]=num_blocks_y;
+    _num_blocks[2]=1;
+    #if CUDA_VERSION >= 4000
+    _block_size[0]=block_size_x;
+    _block_size[1]=block_size_y;
+    _block_size[2]=block_size_z;
+    #else
+    CU_SAFE_CALL(cuFuncSetBlockShape(_kernel,block_size_x,block_size_y,
+                                     block_size_z));
+    #endif
+  }
+
+  /// Set the number of thread blocks and the number of threads in each block
+  /** \note This should be called before any arguments have been added
+      \note The default command queue is used for the kernel execution **/
+  inline void set_size(const size_t num_blocks_x, const size_t num_blocks_y,
+                       const size_t block_size_x, const size_t block_size_y,
+                       const size_t block_size_z, command_queue &cq) {
+    _cq=cq;
+    set_size(num_blocks_x, num_blocks_y, block_size_x, block_size_y,
+             block_size_z);
+  }
+
+  /// Run the kernel in the default command queue
+  inline void run() {
+    #if CUDA_VERSION >= 4000
+    CU_SAFE_CALL(cuLaunchKernel(_kernel,_num_blocks[0],_num_blocks[1],
+                                _num_blocks[2],_block_size[0],_block_size[1],
+                                _block_size[2],0,_cq,_kernel_args,NULL));
+    #else
+    CU_SAFE_CALL(cuParamSetSize(_kernel,_param_size));
+    CU_SAFE_CALL(cuLaunchGridAsync(_kernel,_num_blocks[0],_num_blocks[1],_cq));
+    #endif
+  }
+
+  /// Clear any arguments associated with the kernel
+  inline void clear_args() {
+    _num_args=0;
+    #if CUDA_VERSION < 4000
+    _offsets.clear();
+    _param_size=0;
+    #endif
+  }
+
+  /// Return the default command queue/stream associated with this data
+  inline command_queue & cq() { return _cq; }
+  /// Change the default command queue associated with matrix
+  inline void cq(command_queue &cq_in) { _cq=cq_in; }
+  #include "ucl_arg_kludge.h"
+
+ private:
+  CUfunction _kernel;
+  CUstream _cq;
+  unsigned _dimensions;
+  unsigned _num_blocks[3];
+  unsigned _num_args;
+  friend class UCL_Texture;
+
+  #if CUDA_VERSION >= 4000
+  unsigned _block_size[3];
+  void * _kernel_args[UCL_MAX_KERNEL_ARGS];
+  #else
+  std::vector<unsigned> _offsets;
+  unsigned _param_size;
+  #endif
+};
+
+} // namespace
+
+#endif
+

--- a/lib/gpu/geryon/hip_macros.h
+++ b/lib/gpu/geryon/hip_macros.h
@@ -1,0 +1,83 @@
+#ifndef NVD_MACROS_H
+#define NVD_MACROS_H
+
+#include <cstdio>
+#include <cassert>
+#include <cuda.h>
+
+#if CUDA_VERSION >= 3020
+#define CUDA_INT_TYPE size_t
+#else
+#define CUDA_INT_TYPE unsigned
+#endif
+
+#ifdef MPI_GERYON
+#include "mpi.h"
+#define NVD_GERYON_EXIT do {                                               \
+  int is_final;                                                            \
+  MPI_Finalized(&is_final);                                                \
+  if (!is_final)                                                           \
+    MPI_Abort(MPI_COMM_WORLD,-1);                                          \
+  } while(0)
+#else
+#define NVD_GERYON_EXIT assert(0==1)
+#endif
+
+#ifndef UCL_GERYON_EXIT
+#define UCL_GERYON_EXIT NVD_GERYON_EXIT
+#endif
+
+#ifdef UCL_DEBUG
+#define UCL_SYNC_DEBUG
+#define UCL_DESTRUCT_CHECK
+#endif
+
+#ifndef UCL_NO_API_CHECK
+
+#define CU_SAFE_CALL_NS( call ) do {                                         \
+    CUresult err = call;                                                     \
+    if( CUDA_SUCCESS != err) {                                               \
+        fprintf(stderr, "Cuda driver error %d in call at file '%s' in line %i.\n",   \
+                err, __FILE__, __LINE__ );                                   \
+        NVD_GERYON_EXIT;                                                     \
+    } } while (0)
+
+#ifdef UCL_SYNC_DEBUG
+
+#define CU_SAFE_CALL( call ) do {                                            \
+    CU_SAFE_CALL_NS( call );                                                 \
+    CUresult err=cuCtxSynchronize();                                                  \
+    if( CUDA_SUCCESS != err) {                                               \
+        fprintf(stderr, "Cuda driver error %d in file '%s' in line %i.\n",   \
+                err, __FILE__, __LINE__ );                                   \
+        NVD_GERYON_EXIT;                                                     \
+    } } while (0)
+
+#else
+
+#define CU_SAFE_CALL( call ) CU_SAFE_CALL_NS( call )
+
+#endif
+
+#else  // not DEBUG
+
+// void macros for performance reasons
+#define CU_SAFE_CALL_NS( call ) call
+#define CU_SAFE_CALL( call) call
+
+#endif
+
+#ifdef UCL_DESTRUCT_CHECK
+
+#define CU_DESTRUCT_CALL( call) CU_SAFE_CALL( call)
+#define CU_DESTRUCT_CALL_NS( call) CU_SAFE_CALL_NS( call)
+
+#else
+
+#define CU_DESTRUCT_CALL( call) call
+#define CU_DESTRUCT_CALL_NS( call) call
+
+#endif
+
+#endif
+

--- a/lib/gpu/geryon/hip_macros.h
+++ b/lib/gpu/geryon/hip_macros.h
@@ -1,15 +1,15 @@
-#ifndef NVD_MACROS_H
-#define NVD_MACROS_H
+#ifndef HIP_MACROS_H
+#define HIP_MACROS_H
 
 #include <cstdio>
 #include <cassert>
-#include <cuda.h>
+#include <hip/hip_runtime.h>
 
-#if CUDA_VERSION >= 3020
+//#if CUDA_VERSION >= 3020
 #define CUDA_INT_TYPE size_t
-#else
-#define CUDA_INT_TYPE unsigned
-#endif
+//#else
+//#define CUDA_INT_TYPE unsigned
+//#endif
 
 #ifdef MPI_GERYON
 #include "mpi.h"
@@ -35,9 +35,9 @@
 #ifndef UCL_NO_API_CHECK
 
 #define CU_SAFE_CALL_NS( call ) do {                                         \
-    CUresult err = call;                                                     \
-    if( CUDA_SUCCESS != err) {                                               \
-        fprintf(stderr, "Cuda driver error %d in call at file '%s' in line %i.\n",   \
+    hipError_t err = call;                                                     \
+    if( hipSuccess != err) {                                               \
+        fprintf(stderr, "HIP runtime error %d in call at file '%s' in line %i.\n",   \
                 err, __FILE__, __LINE__ );                                   \
         NVD_GERYON_EXIT;                                                     \
     } } while (0)
@@ -46,9 +46,9 @@
 
 #define CU_SAFE_CALL( call ) do {                                            \
     CU_SAFE_CALL_NS( call );                                                 \
-    CUresult err=cuCtxSynchronize();                                                  \
-    if( CUDA_SUCCESS != err) {                                               \
-        fprintf(stderr, "Cuda driver error %d in file '%s' in line %i.\n",   \
+    hipError_t err=hipCtxSynchronize();                                                  \
+    if( hipSuccess != err) {                                               \
+        fprintf(stderr, "HIP runtime error %d in file '%s' in line %i.\n",   \
                 err, __FILE__, __LINE__ );                                   \
         NVD_GERYON_EXIT;                                                     \
     } } while (0)

--- a/lib/gpu/geryon/hip_mat.h
+++ b/lib/gpu/geryon/hip_mat.h
@@ -1,19 +1,3 @@
-/***************************************************************************
-                                  nvd_mat.h
-                             -------------------
-                               W. Michael Brown
-
-  CUDA Driver Specific Vector/Matrix Containers, Memory Management, and I/O
-
- __________________________________________________________________________
-    This file is part of the Geryon Unified Coprocessor Library (UCL)
- __________________________________________________________________________
-
-    begin                : Thu Jan 21 2010
-    copyright            : (C) 2010 by W. Michael Brown
-    email                : brownw@ornl.gov
- ***************************************************************************/
-
 /* -----------------------------------------------------------------------
    Copyright (2010) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
@@ -23,13 +7,15 @@
 
 /*! \file */
 
-#ifndef NVD_MAT_H
-#define NVD_MAT_H
+#ifndef HIP_MAT_H
+#define HIP_MAT_H
 
-#include "nvd_memory.h"
+
+#include <hip/hip_runtime.h>
+#include "hip_memory.h"
 
 /// Namespace for CUDA Driver routines
-namespace ucl_cudadr {
+namespace ucl_hip {
 
 #define _UCL_MAT_ALLOW
 #define _UCL_DEVICE_PTR_MAT

--- a/lib/gpu/geryon/hip_mat.h
+++ b/lib/gpu/geryon/hip_mat.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+                                  nvd_mat.h
+                             -------------------
+                               W. Michael Brown
+
+  CUDA Driver Specific Vector/Matrix Containers, Memory Management, and I/O
+
+ __________________________________________________________________________
+    This file is part of the Geryon Unified Coprocessor Library (UCL)
+ __________________________________________________________________________
+
+    begin                : Thu Jan 21 2010
+    copyright            : (C) 2010 by W. Michael Brown
+    email                : brownw@ornl.gov
+ ***************************************************************************/
+
+/* -----------------------------------------------------------------------
+   Copyright (2010) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the Simplified BSD License.
+   ----------------------------------------------------------------------- */
+
+/*! \file */
+
+#ifndef NVD_MAT_H
+#define NVD_MAT_H
+
+#include "nvd_memory.h"
+
+/// Namespace for CUDA Driver routines
+namespace ucl_cudadr {
+
+#define _UCL_MAT_ALLOW
+#define _UCL_DEVICE_PTR_MAT
+#include "ucl_basemat.h"
+#include "ucl_h_vec.h"
+#include "ucl_h_mat.h"
+#include "ucl_d_vec.h"
+#include "ucl_d_mat.h"
+#include "ucl_s_obj_help.h"
+#include "ucl_vector.h"
+#include "ucl_matrix.h"
+#undef _UCL_DEVICE_PTR_MAT
+#undef _UCL_MAT_ALLOW
+
+#define UCL_COPY_ALLOW
+#include "ucl_copy.h"
+#undef UCL_COPY_ALLOW
+
+#define UCL_PRINT_ALLOW
+#include "ucl_print.h"
+#undef UCL_PRINT_ALLOW
+
+} // namespace ucl_cudadr
+
+#endif

--- a/lib/gpu/geryon/hip_memory.h
+++ b/lib/gpu/geryon/hip_memory.h
@@ -1,0 +1,657 @@
+/***************************************************************************
+                                nvd_memory.h
+                             -------------------
+                               W. Michael Brown
+
+  CUDA Driver Specific Memory Management and Vector/Matrix Containers
+
+ __________________________________________________________________________
+    This file is part of the Geryon Unified Coprocessor Library (UCL)
+ __________________________________________________________________________
+
+    begin                : Thu Jan 21 2010
+    copyright            : (C) 2010 by W. Michael Brown
+    email                : brownw@ornl.gov
+ ***************************************************************************/
+
+/* -----------------------------------------------------------------------
+   Copyright (2010) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the Simplified BSD License.
+   ----------------------------------------------------------------------- */
+
+#ifndef NVD_MEMORY_H
+#define NVD_MEMORY_H
+
+#include <iostream>
+#include <cassert>
+#include <cstring>
+#include "nvd_macros.h"
+#include "ucl_types.h"
+
+namespace ucl_cudadr {
+
+// --------------------------------------------------------------------------
+// - API Specific Types
+// --------------------------------------------------------------------------
+//typedef dim3 ucl_kernel_dim;
+
+// --------------------------------------------------------------------------
+// - API SPECIFIC DEVICE POINTERS
+// --------------------------------------------------------------------------
+typedef CUdeviceptr device_ptr;
+
+// --------------------------------------------------------------------------
+// - HOST MEMORY ALLOCATION ROUTINES
+// --------------------------------------------------------------------------
+template <class mat_type, class copy_type>
+inline int _host_alloc(mat_type &mat, copy_type &cm, const size_t n,
+                       const enum UCL_MEMOPT kind, const enum UCL_MEMOPT kind2){
+  CUresult err=CUDA_SUCCESS;
+  if (kind==UCL_NOT_PINNED)
+    *(mat.host_ptr())=(typename mat_type::data_type*)malloc(n);
+  else if (kind==UCL_WRITE_ONLY)
+    err=cuMemHostAlloc((void **)mat.host_ptr(),n,CU_MEMHOSTALLOC_WRITECOMBINED);
+  else
+    err=cuMemAllocHost((void **)mat.host_ptr(),n);
+  if (err!=CUDA_SUCCESS || *(mat.host_ptr())==NULL)
+    return UCL_MEMORY_ERROR;
+  mat.cq()=cm.cq();
+  return UCL_SUCCESS;
+}
+
+template <class mat_type>
+inline int _host_alloc(mat_type &mat, UCL_Device &dev, const size_t n,
+                       const enum UCL_MEMOPT kind, const enum UCL_MEMOPT kind2){
+  CUresult err=CUDA_SUCCESS;
+  if (kind==UCL_NOT_PINNED)
+    *(mat.host_ptr())=(typename mat_type::data_type*)malloc(n);
+  else if (kind==UCL_WRITE_ONLY)
+    err=cuMemHostAlloc((void **)mat.host_ptr(),n,CU_MEMHOSTALLOC_WRITECOMBINED);
+  else
+    err=cuMemAllocHost((void **)mat.host_ptr(),n);
+  if (err!=CUDA_SUCCESS || *(mat.host_ptr())==NULL)
+    return UCL_MEMORY_ERROR;
+  mat.cq()=dev.cq();
+  return UCL_SUCCESS;
+}
+
+template <class mat_type>
+inline void _host_free(mat_type &mat) {
+  if (mat.kind()==UCL_VIEW)
+    return;
+  else if (mat.kind()!=UCL_NOT_PINNED)
+    CU_DESTRUCT_CALL(cuMemFreeHost(mat.begin()));
+  else
+    free(mat.begin());
+}
+
+template <class mat_type>
+inline int _host_resize(mat_type &mat, const size_t n) {
+  _host_free(mat);
+  CUresult err=CUDA_SUCCESS;
+  if (mat.kind()==UCL_NOT_PINNED)
+    *(mat.host_ptr())=(typename mat_type::data_type*)malloc(n);
+  else if (mat.kind()==UCL_WRITE_ONLY)
+    err=cuMemHostAlloc((void **)mat.host_ptr(),n,CU_MEMHOSTALLOC_WRITECOMBINED);
+  else
+    err=cuMemAllocHost((void **)mat.host_ptr(),n);
+  if (err!=CUDA_SUCCESS || *(mat.host_ptr())==NULL)
+    return UCL_MEMORY_ERROR;
+  return UCL_SUCCESS;
+}
+
+// --------------------------------------------------------------------------
+// - DEVICE MEMORY ALLOCATION ROUTINES
+// --------------------------------------------------------------------------
+template <class mat_type, class copy_type>
+inline int _device_alloc(mat_type &mat, copy_type &cm, const size_t n,
+                         const enum UCL_MEMOPT kind) {
+  CUresult err=cuMemAlloc(&mat.cbegin(),n);
+  if (err!=CUDA_SUCCESS)
+    return UCL_MEMORY_ERROR;
+  mat.cq()=cm.cq();
+  return UCL_SUCCESS;
+}
+
+template <class mat_type>
+inline int _device_alloc(mat_type &mat, UCL_Device &dev, const size_t n,
+                         const enum UCL_MEMOPT kind) {
+  CUresult err=cuMemAlloc(&mat.cbegin(),n);
+  if (err!=CUDA_SUCCESS)
+    return UCL_MEMORY_ERROR;
+  mat.cq()=dev.cq();
+  return UCL_SUCCESS;
+}
+
+template <class mat_type, class copy_type>
+inline int _device_alloc(mat_type &mat, copy_type &cm, const size_t rows,
+                         const size_t cols, size_t &pitch,
+                         const enum UCL_MEMOPT kind) {
+  CUresult err;
+  CUDA_INT_TYPE upitch;
+  err=cuMemAllocPitch(&mat.cbegin(),&upitch,
+                      cols*sizeof(typename mat_type::data_type),rows,16);
+  pitch=static_cast<size_t>(upitch);
+  if (err!=CUDA_SUCCESS)
+    return UCL_MEMORY_ERROR;
+  mat.cq()=cm.cq();
+  return UCL_SUCCESS;
+}
+
+template <class mat_type, class copy_type>
+inline int _device_alloc(mat_type &mat, UCL_Device &d, const size_t rows,
+                         const size_t cols, size_t &pitch,
+                         const enum UCL_MEMOPT kind) {
+  CUresult err;
+  unsigned upitch;
+  err=cuMemAllocPitch(&mat.cbegin(),&upitch,
+                      cols*sizeof(typename mat_type::data_type),rows,16);
+  pitch=static_cast<size_t>(upitch);
+  if (err!=CUDA_SUCCESS)
+    return UCL_MEMORY_ERROR;
+  mat.cq()=d.cq();
+  return UCL_SUCCESS;
+}
+
+template <class mat_type>
+inline void _device_free(mat_type &mat) {
+  if (mat.kind()!=UCL_VIEW)
+    CU_DESTRUCT_CALL(cuMemFree(mat.cbegin()));
+}
+
+template <class mat_type>
+inline int _device_resize(mat_type &mat, const size_t n) {
+  _device_free(mat);
+  CUresult err=cuMemAlloc(&mat.cbegin(),n);
+  if (err!=CUDA_SUCCESS)
+    return UCL_MEMORY_ERROR;
+  return UCL_SUCCESS;
+}
+
+template <class mat_type>
+inline int _device_resize(mat_type &mat, const size_t rows,
+                          const size_t cols, size_t &pitch) {
+  _device_free(mat);
+  CUresult err;
+  CUDA_INT_TYPE upitch;
+  err=cuMemAllocPitch(&mat.cbegin(),&upitch,
+                      cols*sizeof(typename mat_type::data_type),rows,16);
+  pitch=static_cast<size_t>(upitch);
+  if (err!=CUDA_SUCCESS)
+    return UCL_MEMORY_ERROR;
+  return UCL_SUCCESS;
+}
+
+inline void _device_view(CUdeviceptr *ptr, CUdeviceptr &in) {
+  *ptr=in;
+}
+
+template <class numtyp>
+inline void _device_view(CUdeviceptr *ptr, numtyp *in) {
+  *ptr=0;
+}
+
+inline void _device_view(CUdeviceptr *ptr, CUdeviceptr &in,
+                         const size_t offset, const size_t numsize) {
+  *ptr=in+offset*numsize;
+}
+
+template <class numtyp>
+inline void _device_view(CUdeviceptr *ptr, numtyp *in,
+                         const size_t offset, const size_t numsize) {
+  *ptr=0;
+}
+
+// --------------------------------------------------------------------------
+// - DEVICE IMAGE ALLOCATION ROUTINES
+// --------------------------------------------------------------------------
+template <class mat_type, class copy_type>
+inline void _device_image_alloc(mat_type &mat, copy_type &cm, const size_t rows,
+                                const size_t cols) {
+  assert(0==1);
+}
+
+template <class mat_type, class copy_type>
+inline void _device_image_alloc(mat_type &mat, UCL_Device &d, const size_t rows,
+                                const size_t cols) {
+  assert(0==1);
+}
+
+template <class mat_type>
+inline void _device_image_free(mat_type &mat) {
+  assert(0==1);
+}
+
+// --------------------------------------------------------------------------
+// - ZERO ROUTINES
+// --------------------------------------------------------------------------
+inline void _host_zero(void *ptr, const size_t n) {
+  memset(ptr,0,n);
+}
+
+template <class mat_type>
+inline void _device_zero(mat_type &mat, const size_t n, command_queue &cq) {
+  if (n%32==0)
+    CU_SAFE_CALL(cuMemsetD32Async(mat.cbegin(),0,n/4,cq));
+  else if (n%16==0)
+    CU_SAFE_CALL(cuMemsetD16Async(mat.cbegin(),0,n/2,cq));
+  else
+    CU_SAFE_CALL(cuMemsetD8Async(mat.cbegin(),0,n,cq));
+}
+
+// --------------------------------------------------------------------------
+// - HELPER FUNCTIONS FOR MEMCPY ROUTINES
+// --------------------------------------------------------------------------
+
+inline void _nvd_set_2D_loc(CUDA_MEMCPY2D &ins, const size_t dpitch,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+  ins.srcXInBytes=0;
+  ins.srcY=0;
+  ins.srcPitch=spitch;
+  ins.dstXInBytes=0;
+  ins.dstY=0;
+  ins.dstPitch=dpitch;
+  ins.WidthInBytes=cols;
+  ins.Height=rows;
+}
+
+template <int mem> struct _nvd_set_2D_mem;
+template <> struct _nvd_set_2D_mem<1>
+  { static CUmemorytype a() { return CU_MEMORYTYPE_HOST; } };
+template <> struct _nvd_set_2D_mem<2>
+  { static CUmemorytype a() { return CU_MEMORYTYPE_ARRAY; } };
+template <int mem> struct _nvd_set_2D_mem
+  { static CUmemorytype a() { return CU_MEMORYTYPE_DEVICE; } };
+
+
+// --------------------------------------------------------------------------
+// - MEMCPY ROUTINES
+// --------------------------------------------------------------------------
+
+template<int mem1, int mem2> struct _ucl_memcpy;
+
+// Both are images
+template<> struct _ucl_memcpy<2,2> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstArray=dst.cbegin();
+    ins.srcArray=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstArray=dst.cbegin();
+    ins.srcArray=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Destination is texture, source on device
+template<> struct _ucl_memcpy<2,0> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstArray=dst.cbegin();
+    ins.srcDevice=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstArray=dst.cbegin();
+    ins.srcDevice=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Destination is texture, source on host
+template<> struct _ucl_memcpy<2,1> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstArray=dst.cbegin();
+    ins.srcHost=src.begin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstArray=dst.cbegin();
+    ins.srcHost=src.begin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Source is texture, dest on device
+template<> struct _ucl_memcpy<0,2> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstDevice=dst.cbegin();
+    ins.srcArray=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstDevice=dst.cbegin();
+    ins.srcArray=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Source is texture, dest on host
+template<> struct _ucl_memcpy<1,2> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    assert(0==1);
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstHost=dst.begin();
+    ins.srcArray=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstHost=dst.begin();
+    ins.srcArray=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Neither are textures, destination on host
+template <> struct _ucl_memcpy<1,0> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    CU_SAFE_CALL(cuMemcpyDtoH(dst.begin(),src.cbegin(),n));
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    CU_SAFE_CALL(cuMemcpyDtoHAsync(dst.begin(),src.cbegin(),n,cq));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstHost=dst.begin();
+    ins.srcDevice=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstHost=dst.begin();
+    ins.srcDevice=src.cbegin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Neither are textures, source on host
+template <> struct _ucl_memcpy<0,1> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    CU_SAFE_CALL(cuMemcpyHtoD(dst.cbegin(),src.begin(),n));
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    CU_SAFE_CALL(cuMemcpyHtoDAsync(dst.cbegin(),src.begin(),n,cq));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstDevice=dst.cbegin();
+    ins.srcHost=src.begin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstDevice=dst.cbegin();
+    ins.srcHost=src.begin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Neither are textures, both on host
+template <> struct _ucl_memcpy<1,1> {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n)
+    { memcpy(dst.begin(),src.begin(),n); }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq)
+    { memcpy(dst.begin(),src.begin(),n); }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstHost=dst.begin();
+    ins.srcHost=src.begin();
+    CU_SAFE_CALL(cuMemcpy2D(&ins));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    CUDA_MEMCPY2D ins;
+    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+    ins.dstHost=dst.begin();
+    ins.srcHost=src.begin();
+    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+  }
+};
+
+// Neither are textures, both on device
+template <int mem1, int mem2> struct _ucl_memcpy {
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
+    CU_SAFE_CALL(cuMemcpyDtoD(dst.cbegin(),src.cbegin(),n));
+  }
+  template <class p1, class p2>
+  static inline void mc(p1 &dst, const p2 &src, const size_t n,
+                        CUstream &cq) {
+    CU_SAFE_CALL(cuMemcpyDtoDAsync(dst.cbegin(),src.cbegin(),n,cq));
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows) {
+    if (p1::PADDED==0 || p2::PADDED==0) {
+      size_t src_offset=0, dst_offset=0;
+      for (size_t i=0; i<rows; i++) {
+        CU_SAFE_CALL(cuMemcpyDtoD(dst.cbegin()+dst_offset,
+                                  src.cbegin()+src_offset,cols));
+        src_offset+=spitch;
+        dst_offset+=dpitch;
+      }
+    } else {
+      CUDA_MEMCPY2D ins;
+      _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+      ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+      ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+      ins.dstDevice=dst.cbegin();
+      ins.srcDevice=src.cbegin();
+      CU_SAFE_CALL(cuMemcpy2D(&ins));
+    }
+  }
+  template <class p1, class p2>
+      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
+                            const size_t spitch, const size_t cols,
+                            const size_t rows, CUstream &cq) {
+    if (p1::PADDED==0 || p2::PADDED==0) {
+      size_t src_offset=0, dst_offset=0;
+      for (size_t i=0; i<rows; i++) {
+        CU_SAFE_CALL(cuMemcpyDtoDAsync(dst.cbegin()+dst_offset,
+                                       src.cbegin()+src_offset,cols,cq));
+        src_offset+=spitch;
+        dst_offset+=dpitch;
+      }
+    } else {
+      CUDA_MEMCPY2D ins;
+      _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
+      ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
+      ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
+      ins.dstDevice=dst.cbegin();
+      ins.srcDevice=src.cbegin();
+      CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
+    }
+  }
+};
+
+template<class mat1, class mat2>
+inline void ucl_mv_cpy(mat1 &dst, const mat2 &src, const size_t n) {
+  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,src,n);
+}
+
+template<class mat1, class mat2>
+inline void ucl_mv_cpy(mat1 &dst, const mat2 &src, const size_t n,
+                       CUstream &cq) {
+  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,src,n,cq);
+}
+
+template<class mat1, class mat2>
+inline void ucl_mv_cpy(mat1 &dst, const size_t dpitch, const mat2 &src,
+                       const size_t spitch, const size_t cols,
+                       const size_t rows) {
+  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,dpitch,src,spitch,cols,
+                                                 rows);
+}
+
+template<class mat1, class mat2>
+inline void ucl_mv_cpy(mat1 &dst, const size_t dpitch, const mat2 &src,
+                       const size_t spitch, const size_t cols,
+                       const size_t rows,CUstream &cq) {
+  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,dpitch,src,spitch,cols,
+                                                 rows,cq);
+}
+
+} // namespace ucl_cudart
+
+#endif
+

--- a/lib/gpu/geryon/hip_memory.h
+++ b/lib/gpu/geryon/hip_memory.h
@@ -1,19 +1,3 @@
-/***************************************************************************
-                                nvd_memory.h
-                             -------------------
-                               W. Michael Brown
-
-  CUDA Driver Specific Memory Management and Vector/Matrix Containers
-
- __________________________________________________________________________
-    This file is part of the Geryon Unified Coprocessor Library (UCL)
- __________________________________________________________________________
-
-    begin                : Thu Jan 21 2010
-    copyright            : (C) 2010 by W. Michael Brown
-    email                : brownw@ornl.gov
- ***************************************************************************/
-
 /* -----------------------------------------------------------------------
    Copyright (2010) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
@@ -21,26 +5,42 @@
    the Simplified BSD License.
    ----------------------------------------------------------------------- */
 
-#ifndef NVD_MEMORY_H
-#define NVD_MEMORY_H
+#ifndef HIP_MEMORY_H
+#define HIP_MEMORY_H
 
+
+#include <hip/hip_runtime.h>
 #include <iostream>
 #include <cassert>
 #include <cstring>
-#include "nvd_macros.h"
+#include "hip_macros.h"
+#include "hip_device.h"
 #include "ucl_types.h"
 
-namespace ucl_cudadr {
+namespace ucl_hip {
 
 // --------------------------------------------------------------------------
 // - API Specific Types
 // --------------------------------------------------------------------------
 //typedef dim3 ucl_kernel_dim;
 
+#ifdef __HIP_PLATFORM_NVCC__
+typedef enum hipArray_Format {
+    HIP_AD_FORMAT_UNSIGNED_INT8 = 0x01,
+    HIP_AD_FORMAT_UNSIGNED_INT16 = 0x02,
+    HIP_AD_FORMAT_UNSIGNED_INT32 = 0x03,
+    HIP_AD_FORMAT_SIGNED_INT8 = 0x08,
+    HIP_AD_FORMAT_SIGNED_INT16 = 0x09,
+    HIP_AD_FORMAT_SIGNED_INT32 = 0x0a,
+    HIP_AD_FORMAT_HALF = 0x10,
+    HIP_AD_FORMAT_FLOAT = 0x20
+}hipArray_Format;
+#endif
+
 // --------------------------------------------------------------------------
 // - API SPECIFIC DEVICE POINTERS
 // --------------------------------------------------------------------------
-typedef CUdeviceptr device_ptr;
+typedef hipDeviceptr_t device_ptr;
 
 // --------------------------------------------------------------------------
 // - HOST MEMORY ALLOCATION ROUTINES
@@ -48,14 +48,14 @@ typedef CUdeviceptr device_ptr;
 template <class mat_type, class copy_type>
 inline int _host_alloc(mat_type &mat, copy_type &cm, const size_t n,
                        const enum UCL_MEMOPT kind, const enum UCL_MEMOPT kind2){
-  CUresult err=CUDA_SUCCESS;
+  hipError_t err=hipSuccess;
   if (kind==UCL_NOT_PINNED)
     *(mat.host_ptr())=(typename mat_type::data_type*)malloc(n);
   else if (kind==UCL_WRITE_ONLY)
-    err=cuMemHostAlloc((void **)mat.host_ptr(),n,CU_MEMHOSTALLOC_WRITECOMBINED);
+    err=hipHostMalloc((void **)mat.host_ptr(),n,hipHostMallocWriteCombined);
   else
-    err=cuMemAllocHost((void **)mat.host_ptr(),n);
-  if (err!=CUDA_SUCCESS || *(mat.host_ptr())==NULL)
+    err=hipHostMalloc((void **)mat.host_ptr(),n,hipHostMallocDefault);
+  if (err!=hipSuccess || *(mat.host_ptr())==NULL)
     return UCL_MEMORY_ERROR;
   mat.cq()=cm.cq();
   return UCL_SUCCESS;
@@ -64,14 +64,14 @@ inline int _host_alloc(mat_type &mat, copy_type &cm, const size_t n,
 template <class mat_type>
 inline int _host_alloc(mat_type &mat, UCL_Device &dev, const size_t n,
                        const enum UCL_MEMOPT kind, const enum UCL_MEMOPT kind2){
-  CUresult err=CUDA_SUCCESS;
+  hipError_t err=hipSuccess;
   if (kind==UCL_NOT_PINNED)
     *(mat.host_ptr())=(typename mat_type::data_type*)malloc(n);
   else if (kind==UCL_WRITE_ONLY)
-    err=cuMemHostAlloc((void **)mat.host_ptr(),n,CU_MEMHOSTALLOC_WRITECOMBINED);
+    err=hipHostMalloc((void **)mat.host_ptr(),n,hipHostMallocWriteCombined);
   else
-    err=cuMemAllocHost((void **)mat.host_ptr(),n);
-  if (err!=CUDA_SUCCESS || *(mat.host_ptr())==NULL)
+    err=hipHostMalloc((void **)mat.host_ptr(),n,hipHostMallocDefault);
+  if (err!=hipSuccess || *(mat.host_ptr())==NULL)
     return UCL_MEMORY_ERROR;
   mat.cq()=dev.cq();
   return UCL_SUCCESS;
@@ -82,7 +82,7 @@ inline void _host_free(mat_type &mat) {
   if (mat.kind()==UCL_VIEW)
     return;
   else if (mat.kind()!=UCL_NOT_PINNED)
-    CU_DESTRUCT_CALL(cuMemFreeHost(mat.begin()));
+    CU_DESTRUCT_CALL(hipHostFree(mat.begin()));
   else
     free(mat.begin());
 }
@@ -90,14 +90,14 @@ inline void _host_free(mat_type &mat) {
 template <class mat_type>
 inline int _host_resize(mat_type &mat, const size_t n) {
   _host_free(mat);
-  CUresult err=CUDA_SUCCESS;
+  hipError_t err=hipSuccess;
   if (mat.kind()==UCL_NOT_PINNED)
     *(mat.host_ptr())=(typename mat_type::data_type*)malloc(n);
   else if (mat.kind()==UCL_WRITE_ONLY)
-    err=cuMemHostAlloc((void **)mat.host_ptr(),n,CU_MEMHOSTALLOC_WRITECOMBINED);
+    err=hipHostMalloc((void **)mat.host_ptr(),n,hipHostMallocWriteCombined);
   else
-    err=cuMemAllocHost((void **)mat.host_ptr(),n);
-  if (err!=CUDA_SUCCESS || *(mat.host_ptr())==NULL)
+    err=hipHostMalloc((void **)mat.host_ptr(),n,hipHostMallocDefault);
+  if (err!=hipSuccess || *(mat.host_ptr())==NULL)
     return UCL_MEMORY_ERROR;
   return UCL_SUCCESS;
 }
@@ -108,8 +108,8 @@ inline int _host_resize(mat_type &mat, const size_t n) {
 template <class mat_type, class copy_type>
 inline int _device_alloc(mat_type &mat, copy_type &cm, const size_t n,
                          const enum UCL_MEMOPT kind) {
-  CUresult err=cuMemAlloc(&mat.cbegin(),n);
-  if (err!=CUDA_SUCCESS)
+  hipError_t err=hipMalloc((void**)&mat.cbegin(),n);
+  if (err!=hipSuccess)
     return UCL_MEMORY_ERROR;
   mat.cq()=cm.cq();
   return UCL_SUCCESS;
@@ -118,8 +118,8 @@ inline int _device_alloc(mat_type &mat, copy_type &cm, const size_t n,
 template <class mat_type>
 inline int _device_alloc(mat_type &mat, UCL_Device &dev, const size_t n,
                          const enum UCL_MEMOPT kind) {
-  CUresult err=cuMemAlloc(&mat.cbegin(),n);
-  if (err!=CUDA_SUCCESS)
+  hipError_t err=hipMalloc((void**)&mat.cbegin(),n);
+  if (err!=hipSuccess)
     return UCL_MEMORY_ERROR;
   mat.cq()=dev.cq();
   return UCL_SUCCESS;
@@ -129,12 +129,12 @@ template <class mat_type, class copy_type>
 inline int _device_alloc(mat_type &mat, copy_type &cm, const size_t rows,
                          const size_t cols, size_t &pitch,
                          const enum UCL_MEMOPT kind) {
-  CUresult err;
-  CUDA_INT_TYPE upitch;
-  err=cuMemAllocPitch(&mat.cbegin(),&upitch,
-                      cols*sizeof(typename mat_type::data_type),rows,16);
+  hipError_t err;
+  size_t upitch;
+  err=hipMallocPitch((void**)&mat.cbegin(),&upitch,
+                      cols*sizeof(typename mat_type::data_type),rows);
   pitch=static_cast<size_t>(upitch);
-  if (err!=CUDA_SUCCESS)
+  if (err!=hipSuccess)
     return UCL_MEMORY_ERROR;
   mat.cq()=cm.cq();
   return UCL_SUCCESS;
@@ -144,12 +144,12 @@ template <class mat_type, class copy_type>
 inline int _device_alloc(mat_type &mat, UCL_Device &d, const size_t rows,
                          const size_t cols, size_t &pitch,
                          const enum UCL_MEMOPT kind) {
-  CUresult err;
-  unsigned upitch;
-  err=cuMemAllocPitch(&mat.cbegin(),&upitch,
-                      cols*sizeof(typename mat_type::data_type),rows,16);
+  hipError_t err;
+  size_t upitch;
+  err=hipMallocPitch((void**)&mat.cbegin(),&upitch,
+                      cols*sizeof(typename mat_type::data_type),rows);
   pitch=static_cast<size_t>(upitch);
-  if (err!=CUDA_SUCCESS)
+  if (err!=hipSuccess)
     return UCL_MEMORY_ERROR;
   mat.cq()=d.cq();
   return UCL_SUCCESS;
@@ -157,15 +157,16 @@ inline int _device_alloc(mat_type &mat, UCL_Device &d, const size_t rows,
 
 template <class mat_type>
 inline void _device_free(mat_type &mat) {
-  if (mat.kind()!=UCL_VIEW)
-    CU_DESTRUCT_CALL(cuMemFree(mat.cbegin()));
+  if (mat.kind()!=UCL_VIEW){
+    CU_DESTRUCT_CALL(hipFree((void*)mat.cbegin()));
+  }
 }
 
 template <class mat_type>
 inline int _device_resize(mat_type &mat, const size_t n) {
   _device_free(mat);
-  CUresult err=cuMemAlloc(&mat.cbegin(),n);
-  if (err!=CUDA_SUCCESS)
+  hipError_t err=hipMalloc((void**)&mat.cbegin(),n);
+  if (err!=hipSuccess)
     return UCL_MEMORY_ERROR;
   return UCL_SUCCESS;
 }
@@ -174,32 +175,32 @@ template <class mat_type>
 inline int _device_resize(mat_type &mat, const size_t rows,
                           const size_t cols, size_t &pitch) {
   _device_free(mat);
-  CUresult err;
-  CUDA_INT_TYPE upitch;
-  err=cuMemAllocPitch(&mat.cbegin(),&upitch,
-                      cols*sizeof(typename mat_type::data_type),rows,16);
+  hipError_t err;
+  size_t upitch;
+  err=hipMallocPitch((void**)&mat.cbegin(),&upitch,
+                      cols*sizeof(typename mat_type::data_type),rows);
   pitch=static_cast<size_t>(upitch);
-  if (err!=CUDA_SUCCESS)
+  if (err!=hipSuccess)
     return UCL_MEMORY_ERROR;
   return UCL_SUCCESS;
 }
 
-inline void _device_view(CUdeviceptr *ptr, CUdeviceptr &in) {
+inline void _device_view(hipDeviceptr_t *ptr, hipDeviceptr_t &in) {
   *ptr=in;
 }
 
 template <class numtyp>
-inline void _device_view(CUdeviceptr *ptr, numtyp *in) {
+inline void _device_view(hipDeviceptr_t *ptr, numtyp *in) {
   *ptr=0;
 }
 
-inline void _device_view(CUdeviceptr *ptr, CUdeviceptr &in,
+inline void _device_view(hipDeviceptr_t *ptr, hipDeviceptr_t &in,
                          const size_t offset, const size_t numsize) {
-  *ptr=in+offset*numsize;
+  *ptr=(hipDeviceptr_t)(((char*)in)+offset*numsize);
 }
 
 template <class numtyp>
-inline void _device_view(CUdeviceptr *ptr, numtyp *in,
+inline void _device_view(hipDeviceptr_t *ptr, numtyp *in,
                          const size_t offset, const size_t numsize) {
   *ptr=0;
 }
@@ -233,422 +234,43 @@ inline void _host_zero(void *ptr, const size_t n) {
 
 template <class mat_type>
 inline void _device_zero(mat_type &mat, const size_t n, command_queue &cq) {
-  if (n%32==0)
-    CU_SAFE_CALL(cuMemsetD32Async(mat.cbegin(),0,n/4,cq));
-  else if (n%16==0)
-    CU_SAFE_CALL(cuMemsetD16Async(mat.cbegin(),0,n/2,cq));
-  else
-    CU_SAFE_CALL(cuMemsetD8Async(mat.cbegin(),0,n,cq));
+    CU_SAFE_CALL(hipMemsetAsync((void*)mat.cbegin(),0,n,cq));
 }
-
-// --------------------------------------------------------------------------
-// - HELPER FUNCTIONS FOR MEMCPY ROUTINES
-// --------------------------------------------------------------------------
-
-inline void _nvd_set_2D_loc(CUDA_MEMCPY2D &ins, const size_t dpitch,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-  ins.srcXInBytes=0;
-  ins.srcY=0;
-  ins.srcPitch=spitch;
-  ins.dstXInBytes=0;
-  ins.dstY=0;
-  ins.dstPitch=dpitch;
-  ins.WidthInBytes=cols;
-  ins.Height=rows;
-}
-
-template <int mem> struct _nvd_set_2D_mem;
-template <> struct _nvd_set_2D_mem<1>
-  { static CUmemorytype a() { return CU_MEMORYTYPE_HOST; } };
-template <> struct _nvd_set_2D_mem<2>
-  { static CUmemorytype a() { return CU_MEMORYTYPE_ARRAY; } };
-template <int mem> struct _nvd_set_2D_mem
-  { static CUmemorytype a() { return CU_MEMORYTYPE_DEVICE; } };
 
 
 // --------------------------------------------------------------------------
 // - MEMCPY ROUTINES
 // --------------------------------------------------------------------------
 
-template<int mem1, int mem2> struct _ucl_memcpy;
-
-// Both are images
-template<> struct _ucl_memcpy<2,2> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstArray=dst.cbegin();
-    ins.srcArray=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstArray=dst.cbegin();
-    ins.srcArray=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Destination is texture, source on device
-template<> struct _ucl_memcpy<2,0> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstArray=dst.cbegin();
-    ins.srcDevice=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstArray=dst.cbegin();
-    ins.srcDevice=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Destination is texture, source on host
-template<> struct _ucl_memcpy<2,1> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstArray=dst.cbegin();
-    ins.srcHost=src.begin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstArray=dst.cbegin();
-    ins.srcHost=src.begin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Source is texture, dest on device
-template<> struct _ucl_memcpy<0,2> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstDevice=dst.cbegin();
-    ins.srcArray=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstDevice=dst.cbegin();
-    ins.srcArray=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Source is texture, dest on host
-template<> struct _ucl_memcpy<1,2> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    assert(0==1);
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstHost=dst.begin();
-    ins.srcArray=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstHost=dst.begin();
-    ins.srcArray=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Neither are textures, destination on host
-template <> struct _ucl_memcpy<1,0> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    CU_SAFE_CALL(cuMemcpyDtoH(dst.begin(),src.cbegin(),n));
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    CU_SAFE_CALL(cuMemcpyDtoHAsync(dst.begin(),src.cbegin(),n,cq));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstHost=dst.begin();
-    ins.srcDevice=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstHost=dst.begin();
-    ins.srcDevice=src.cbegin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Neither are textures, source on host
-template <> struct _ucl_memcpy<0,1> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    CU_SAFE_CALL(cuMemcpyHtoD(dst.cbegin(),src.begin(),n));
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    CU_SAFE_CALL(cuMemcpyHtoDAsync(dst.cbegin(),src.begin(),n,cq));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstDevice=dst.cbegin();
-    ins.srcHost=src.begin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstDevice=dst.cbegin();
-    ins.srcHost=src.begin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Neither are textures, both on host
-template <> struct _ucl_memcpy<1,1> {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n)
-    { memcpy(dst.begin(),src.begin(),n); }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq)
-    { memcpy(dst.begin(),src.begin(),n); }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstHost=dst.begin();
-    ins.srcHost=src.begin();
-    CU_SAFE_CALL(cuMemcpy2D(&ins));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    CUDA_MEMCPY2D ins;
-    _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-    ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-    ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-    ins.dstHost=dst.begin();
-    ins.srcHost=src.begin();
-    CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-  }
-};
-
-// Neither are textures, both on device
-template <int mem1, int mem2> struct _ucl_memcpy {
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n) {
-    CU_SAFE_CALL(cuMemcpyDtoD(dst.cbegin(),src.cbegin(),n));
-  }
-  template <class p1, class p2>
-  static inline void mc(p1 &dst, const p2 &src, const size_t n,
-                        CUstream &cq) {
-    CU_SAFE_CALL(cuMemcpyDtoDAsync(dst.cbegin(),src.cbegin(),n,cq));
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows) {
-    if (p1::PADDED==0 || p2::PADDED==0) {
-      size_t src_offset=0, dst_offset=0;
-      for (size_t i=0; i<rows; i++) {
-        CU_SAFE_CALL(cuMemcpyDtoD(dst.cbegin()+dst_offset,
-                                  src.cbegin()+src_offset,cols));
-        src_offset+=spitch;
-        dst_offset+=dpitch;
-      }
-    } else {
-      CUDA_MEMCPY2D ins;
-      _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-      ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-      ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-      ins.dstDevice=dst.cbegin();
-      ins.srcDevice=src.cbegin();
-      CU_SAFE_CALL(cuMemcpy2D(&ins));
-    }
-  }
-  template <class p1, class p2>
-      static inline void mc(p1 &dst, const size_t dpitch, const p2 &src,
-                            const size_t spitch, const size_t cols,
-                            const size_t rows, CUstream &cq) {
-    if (p1::PADDED==0 || p2::PADDED==0) {
-      size_t src_offset=0, dst_offset=0;
-      for (size_t i=0; i<rows; i++) {
-        CU_SAFE_CALL(cuMemcpyDtoDAsync(dst.cbegin()+dst_offset,
-                                       src.cbegin()+src_offset,cols,cq));
-        src_offset+=spitch;
-        dst_offset+=dpitch;
-      }
-    } else {
-      CUDA_MEMCPY2D ins;
-      _nvd_set_2D_loc(ins,dpitch,spitch,cols,rows);
-      ins.dstMemoryType=_nvd_set_2D_mem<p1::MEM_TYPE>::a();
-      ins.srcMemoryType=_nvd_set_2D_mem<p2::MEM_TYPE>::a();
-      ins.dstDevice=dst.cbegin();
-      ins.srcDevice=src.cbegin();
-      CU_SAFE_CALL(cuMemcpy2DAsync(&ins,cq));
-    }
-  }
-};
 
 template<class mat1, class mat2>
-inline void ucl_mv_cpy(mat1 &dst, const mat2 &src, const size_t n) {
-  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,src,n);
+hipMemcpyKind _memcpy_kind(mat1 &dst, const mat2 &src){
+  assert(mat1::MEM_TYPE < 2 && mat2::MEM_TYPE < 2);
+  return (hipMemcpyKind)((1 - mat2::MEM_TYPE)*2 + (1 - mat1::MEM_TYPE));
 }
 
 template<class mat1, class mat2>
-inline void ucl_mv_cpy(mat1 &dst, const mat2 &src, const size_t n,
-                       CUstream &cq) {
-  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,src,n,cq);
+inline void ucl_mv_cpy(mat1 &dst, const mat2 &src, const size_t n) {
+  CU_SAFE_CALL(hipMemcpy((void*)dst.begin(), (void*)src.begin(), n, _memcpy_kind(dst, src)));
+}
+
+template<class mat1, class mat2>
+inline void ucl_mv_cpy(mat1 &dst, const mat2 &src, const size_t n, hipStream_t &cq) {
+  CU_SAFE_CALL(hipMemcpyAsync((void*)dst.begin(), (void*)src.begin(), n, _memcpy_kind(dst, src), cq));
 }
 
 template<class mat1, class mat2>
 inline void ucl_mv_cpy(mat1 &dst, const size_t dpitch, const mat2 &src,
                        const size_t spitch, const size_t cols,
                        const size_t rows) {
-  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,dpitch,src,spitch,cols,
-                                                 rows);
+  CU_SAFE_CALL(hipMemcpy2D((void*)dst.begin(), dpitch, (void*)src.begin(), spitch, cols, rows, _memcpy_kind(dst, src)));
 }
 
 template<class mat1, class mat2>
 inline void ucl_mv_cpy(mat1 &dst, const size_t dpitch, const mat2 &src,
                        const size_t spitch, const size_t cols,
-                       const size_t rows,CUstream &cq) {
-  _ucl_memcpy<mat1::MEM_TYPE,mat2::MEM_TYPE>::mc(dst,dpitch,src,spitch,cols,
-                                                 rows,cq);
+                       const size_t rows,hipStream_t &cq) {
+  CU_SAFE_CALL(hipMemcpy2DAsync((void*)dst.begin(), dpitch, (void*)src.begin(), spitch, cols, rows, _memcpy_kind(dst, src), cq));
 }
 
 } // namespace ucl_cudart

--- a/lib/gpu/geryon/hip_texture.h
+++ b/lib/gpu/geryon/hip_texture.h
@@ -1,0 +1,100 @@
+/***************************************************************************
+                                nvd_texture.h
+                             -------------------
+                               W. Michael Brown
+
+  Utilities for dealing with CUDA Driver textures
+
+ __________________________________________________________________________
+    This file is part of the Geryon Unified Coprocessor Library (UCL)
+ __________________________________________________________________________
+
+    begin                : Fri Jul 2 2010
+    copyright            : (C) 2010 by W. Michael Brown
+    email                : brownw@ornl.gov
+ ***************************************************************************/
+
+/* -----------------------------------------------------------------------
+   Copyright (2010) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the Simplified BSD License.
+   ----------------------------------------------------------------------- */
+
+#ifndef NVD_TEXTURE
+#define NVD_TEXTURE
+
+#include "nvd_kernel.h"
+#include "nvd_mat.h"
+
+namespace ucl_cudadr {
+
+/// Class storing a texture reference
+class UCL_Texture {
+ public:
+  UCL_Texture() {}
+  ~UCL_Texture() {}
+  /// Construct with a specified texture reference
+  inline UCL_Texture(UCL_Program &prog, const char *texture_name)
+    { get_texture(prog,texture_name); }
+  /// Set the texture reference for this object
+  inline void get_texture(UCL_Program &prog, const char *texture_name)
+    { CU_SAFE_CALL(cuModuleGetTexRef(&_tex, prog._module, texture_name)); }
+
+  /// Bind a float array where each fetch grabs a vector of length numel
+  template<class numtyp>
+  inline void bind_float(UCL_D_Vec<numtyp> &vec, const unsigned numel)
+    { _bind_float(vec,numel); }
+
+  /// Bind a float array where each fetch grabs a vector of length numel
+  template<class numtyp>
+  inline void bind_float(UCL_D_Mat<numtyp> &vec, const unsigned numel)
+    { _bind_float(vec,numel); }
+
+  /// Bind a float array where each fetch grabs a vector of length numel
+  template<class numtyp, class devtyp>
+  inline void bind_float(UCL_Vector<numtyp, devtyp> &vec, const unsigned numel)
+    { _bind_float(vec.device,numel); }
+
+  /// Bind a float array where each fetch grabs a vector of length numel
+  template<class numtyp, class devtyp>
+  inline void bind_float(UCL_Matrix<numtyp, devtyp> &vec, const unsigned numel)
+    { _bind_float(vec.device,numel); }
+
+  /// Unbind the texture reference from the memory allocation
+  inline void unbind() { }
+
+  /// Make a texture reference available to kernel
+  inline void allow(UCL_Kernel &kernel) {
+    #if CUDA_VERSION < 4000
+    CU_SAFE_CALL(cuParamSetTexRef(kernel._kernel, CU_PARAM_TR_DEFAULT, _tex));
+    #endif
+  }
+
+ private:
+  CUtexref _tex;
+  friend class UCL_Kernel;
+
+  template<class mat_typ>
+  inline void _bind_float(mat_typ &vec, const unsigned numel) {
+    #ifdef UCL_DEBUG
+    assert(numel!=0 && numel<5);
+    #endif
+    CU_SAFE_CALL(cuTexRefSetAddress(NULL, _tex, vec.cbegin(),
+                 vec.numel()*vec.element_size()));
+    if (vec.element_size()==sizeof(float))
+      CU_SAFE_CALL(cuTexRefSetFormat(_tex, CU_AD_FORMAT_FLOAT, numel));
+    else {
+      if (numel>2)
+        CU_SAFE_CALL(cuTexRefSetFormat(_tex, CU_AD_FORMAT_SIGNED_INT32, numel));
+      else
+        CU_SAFE_CALL(cuTexRefSetFormat(_tex,CU_AD_FORMAT_SIGNED_INT32,numel*2));
+    }
+  }
+
+};
+
+} // namespace
+
+#endif
+

--- a/lib/gpu/geryon/hip_timer.h
+++ b/lib/gpu/geryon/hip_timer.h
@@ -1,0 +1,121 @@
+/***************************************************************************
+                                 nvd_timer.h
+                             -------------------
+                               W. Michael Brown
+
+  Class for timing CUDA Driver routines
+
+ __________________________________________________________________________
+    This file is part of the Geryon Unified Coprocessor Library (UCL)
+ __________________________________________________________________________
+
+    begin                : Fri Jan 22 2010
+    copyright            : (C) 2010 by W. Michael Brown
+    email                : brownw@ornl.gov
+ ***************************************************************************/
+
+/* -----------------------------------------------------------------------
+   Copyright (2010) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the Simplified BSD License.
+   ----------------------------------------------------------------------- */
+
+#ifndef NVD_TIMER_H
+#define NVD_TIMER_H
+
+#include "nvd_macros.h"
+#include "nvd_device.h"
+
+namespace ucl_cudadr {
+
+/// Class for timing CUDA Driver events
+class UCL_Timer {
+ public:
+  inline UCL_Timer() : _total_time(0.0f), _initialized(false) { }
+  inline UCL_Timer(UCL_Device &dev) : _total_time(0.0f), _initialized(false)
+    { init(dev); }
+
+  inline ~UCL_Timer() { clear(); }
+
+  /// Clear any data associated with timer
+  /** \note init() must be called to reuse timer after a clear() **/
+  inline void clear() {
+    if (_initialized) {
+      CU_DESTRUCT_CALL(cuEventDestroy(start_event));
+      CU_DESTRUCT_CALL(cuEventDestroy(stop_event));
+      _initialized=false;
+      _total_time=0.0;
+    }
+  }
+
+  /// Initialize default command queue for timing
+  inline void init(UCL_Device &dev) { init(dev, dev.cq()); }
+
+  /// Initialize command queue for timing
+  inline void init(UCL_Device &dev, command_queue &cq) {
+    clear();
+    _cq=cq;
+    _initialized=true;
+    CU_SAFE_CALL( cuEventCreate(&start_event,0) );
+    CU_SAFE_CALL( cuEventCreate(&stop_event,0) );
+  }
+
+  /// Start timing on command queue
+  inline void start() { CU_SAFE_CALL(cuEventRecord(start_event,_cq)); }
+
+  /// Stop timing on command queue
+  inline void stop() { CU_SAFE_CALL(cuEventRecord(stop_event,_cq)); }
+
+  /// Block until the start event has been reached on device
+  inline void sync_start()
+    { CU_SAFE_CALL(cuEventSynchronize(start_event)); }
+
+  /// Block until the stop event has been reached on device
+  inline void sync_stop()
+    { CU_SAFE_CALL(cuEventSynchronize(stop_event)); }
+
+  /// Set the time elapsed to zero (not the total_time)
+  inline void zero() {
+    CU_SAFE_CALL(cuEventRecord(start_event,_cq));
+    CU_SAFE_CALL(cuEventRecord(stop_event,_cq));
+  }
+
+  /// Set the total time to zero
+  inline void zero_total() { _total_time=0.0; }
+
+  /// Add time from previous start and stop to total
+  /** Forces synchronization **/
+  inline double add_to_total()
+    { double t=time(); _total_time+=t; return t/1000.0; }
+
+  /// Add a user specified time to the total (ms)
+  inline void add_time_to_total(const double t) { _total_time+=t; }
+
+  /// Return the time (ms) of last start to stop - Forces synchronization
+  inline double time() {
+    float timer;
+    CU_SAFE_CALL(cuEventSynchronize(stop_event));
+    CU_SAFE_CALL( cuEventElapsedTime(&timer,start_event,stop_event) );
+    return timer;
+  }
+
+  /// Return the time (s) of last start to stop - Forces synchronization
+  inline double seconds() { return time()/1000.0; }
+
+  /// Return the total time in ms
+  inline double total_time() { return _total_time; }
+
+  /// Return the total time in seconds
+  inline double total_seconds() { return _total_time/1000.0; }
+
+ private:
+  CUevent start_event, stop_event;
+  CUstream _cq;
+  double _total_time;
+  bool _initialized;
+};
+
+} // namespace
+
+#endif

--- a/lib/gpu/geryon/ucl_get_devices.cpp
+++ b/lib/gpu/geryon/ucl_get_devices.cpp
@@ -36,6 +36,11 @@ using namespace ucl_cudadr;
 using namespace ucl_cudart;
 #endif
 
+#ifdef UCL_HIP
+#include "hip_device.h"
+using namespace ucl_hip;
+#endif
+
 int main(int argc, char** argv) {
   UCL_Device cop;
   std::cout << "Found " << cop.num_platforms() << " platform(s).\n";

--- a/lib/gpu/lal_answer.h
+++ b/lib/gpu/lal_answer.h
@@ -27,6 +27,10 @@ using namespace ucl_opencl;
 #include "geryon/nvc_timer.h"
 #include "geryon/nvc_mat.h"
 using namespace ucl_cudart;
+#elif defined(USE_HIP)
+#include "geryon/hip_timer.h"
+#include "geryon/hip_mat.h"
+using namespace ucl_hip;
 #else
 #include "geryon/nvd_timer.h"
 #include "geryon/nvd_mat.h"

--- a/lib/gpu/lal_atom.cpp
+++ b/lib/gpu/lal_atom.cpp
@@ -15,6 +15,11 @@
 
 #include "lal_atom.h"
 
+#ifdef USE_HIP_DEVICE_SORT
+#include <hip/hip_runtime.h>
+#include <hipcub/hipcub.hpp>
+#endif
+
 namespace LAMMPS_AL {
 #define AtomT Atom<numtyp,acctyp>
 
@@ -67,6 +72,26 @@ bool AtomT::alloc(const int nall) {
     CUDPPResult result = cudppPlan(&sort_plan, sort_config, _max_atoms, 1, 0);
     if (CUDPP_SUCCESS != result)
       return false;
+  }
+  #endif
+
+  #ifdef USE_HIP_DEVICE_SORT
+  if (_gpu_nbor==1) {
+    size_t   temp_storage_bytes = 0;
+    if(hipSuccess != hipcub::DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes, sort_out_keys, sort_out_keys, sort_out_values, sort_out_values, _max_atoms))
+      return false;
+    if(sort_out_size < _max_atoms){
+      if (sort_out_keys  ) hipFree(sort_out_keys);
+      if (sort_out_values) hipFree(sort_out_values);
+      hipMalloc(&sort_out_keys  , _max_atoms * sizeof(unsigned));
+      hipMalloc(&sort_out_values, _max_atoms * sizeof(int     ));
+      sort_out_size = _max_atoms;
+    }
+    if(temp_storage_bytes > sort_temp_storage_size){
+      if(sort_temp_storage) hipFree(sort_temp_storage);
+      hipMalloc(&sort_temp_storage, temp_storage_bytes);
+      sort_temp_storage_size = temp_storage_bytes;
+    }
   }
   #endif
 
@@ -184,6 +209,27 @@ bool AtomT::add_fields(const bool charge, const bool rot,
         return false;
     }
     #endif
+
+    #ifdef USE_HIP_DEVICE_SORT
+    if (_gpu_nbor==1) {
+      size_t   temp_storage_bytes = 0;
+      if(hipSuccess != hipcub::DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes, sort_out_keys, sort_out_keys, sort_out_values, sort_out_values, _max_atoms))
+        return false;
+      if(sort_out_size < _max_atoms){
+        if (sort_out_keys  ) hipFree(sort_out_keys);
+        if (sort_out_values) hipFree(sort_out_values);
+        hipMalloc(&sort_out_keys  , _max_atoms * sizeof(unsigned));
+        hipMalloc(&sort_out_values, _max_atoms * sizeof(int     ));
+        sort_out_size = _max_atoms;
+      }
+      if(temp_storage_bytes > sort_temp_storage_size){
+        if(sort_temp_storage) hipFree(sort_temp_storage);
+        hipMalloc(&sort_temp_storage, temp_storage_bytes);
+        sort_temp_storage_size = temp_storage_bytes;
+      }
+    }
+    #endif
+
     success=success && (dev_particle_id.alloc(_max_atoms,*dev,
                                               UCL_READ_ONLY)==UCL_SUCCESS);
     gpu_bytes+=dev_particle_id.row_bytes();
@@ -275,6 +321,19 @@ void AtomT::clear_resize() {
   if (_gpu_nbor==1) cudppDestroyPlan(sort_plan);
   #endif
 
+  #ifdef USE_HIP_DEVICE_SORT
+  if (_gpu_nbor==1) {
+    if(sort_out_keys)     hipFree(sort_out_keys);
+    if(sort_out_values)   hipFree(sort_out_values);
+    if(sort_temp_storage) hipFree(sort_temp_storage);
+    sort_out_keys = nullptr;
+    sort_out_values = nullptr;
+    sort_temp_storage = nullptr;
+    sort_temp_storage_size = 0;
+    sort_out_size = 0;
+  }
+  #endif
+
   if (_gpu_nbor==2) {
     host_particle_id.clear();
     host_cell_id.clear();
@@ -325,6 +384,22 @@ void AtomT::sort_neighbor(const int num_atoms) {
     printf("Error in cudppSort\n");
     UCL_GERYON_EXIT;
   }
+  #endif
+
+  #ifdef USE_HIP_DEVICE_SORT
+    if(sort_out_size < num_atoms){
+      printf("AtomT::sort_neighbor: invalid temp buffer size\n");
+      UCL_GERYON_EXIT;
+    }
+    if(hipSuccess != hipcub::DeviceRadixSort::SortPairs(sort_temp_storage, sort_temp_storage_size, (unsigned *)dev_cell_id.begin(), sort_out_keys, (int *)dev_particle_id.begin(), sort_out_values, num_atoms)){
+      printf("AtomT::sort_neighbor: DeviceRadixSort error\n");
+      UCL_GERYON_EXIT;
+    }
+    if(hipSuccess != hipMemcpy((unsigned *)dev_cell_id.begin(), sort_out_keys  , num_atoms*sizeof(unsigned), hipMemcpyDeviceToDevice) ||
+       hipSuccess != hipMemcpy((int *) dev_particle_id.begin(), sort_out_values, num_atoms*sizeof(int     ), hipMemcpyDeviceToDevice)){
+      printf("AtomT::sort_neighbor: copy output error\n");
+      UCL_GERYON_EXIT;
+    }
   #endif
 }
 

--- a/lib/gpu/lal_atom.cu
+++ b/lib/gpu/lal_atom.cu
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_preprocessor.h"
 #endif
 

--- a/lib/gpu/lal_atom.h
+++ b/lib/gpu/lal_atom.h
@@ -482,6 +482,14 @@ class Atom {
   CUDPPConfiguration sort_config;
   CUDPPHandle sort_plan;
   #endif
+
+  #ifdef USE_HIP_DEVICE_SORT
+  unsigned* sort_out_keys = nullptr;
+  int* sort_out_values = nullptr;
+  void* sort_temp_storage = nullptr;
+  size_t sort_temp_storage_size = 0;
+  size_t sort_out_size = 0;
+  #endif
 };
 
 }

--- a/lib/gpu/lal_atom.h
+++ b/lib/gpu/lal_atom.h
@@ -29,6 +29,11 @@ using namespace ucl_opencl;
 #include "geryon/nvc_mat.h"
 #include "geryon/nvc_kernel.h"
 using namespace ucl_cudart;
+#elif defined(USE_HIP)
+#include "geryon/hip_timer.h"
+#include "geryon/hip_mat.h"
+#include "geryon/hip_kernel.h"
+using namespace ucl_hip;
 #else
 #include "geryon/nvd_timer.h"
 #include "geryon/nvd_mat.h"

--- a/lib/gpu/lal_aux_fun1.h
+++ b/lib/gpu/lal_aux_fun1.h
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_preprocessor.h"
 #endif
 

--- a/lib/gpu/lal_base_atomic.h
+++ b/lib/gpu/lal_base_atomic.h
@@ -24,6 +24,8 @@
 #include "geryon/ocl_texture.h"
 #elif defined(USE_CUDART)
 #include "geryon/nvc_texture.h"
+#elif defined(USE_HIP)
+#include "geryon/hip_texture.h"
 #else
 #include "geryon/nvd_texture.h"
 #endif

--- a/lib/gpu/lal_base_charge.h
+++ b/lib/gpu/lal_base_charge.h
@@ -25,6 +25,8 @@
 #include "geryon/ocl_texture.h"
 #elif defined(USE_CUDART)
 #include "geryon/nvc_texture.h"
+#elif defined(USE_HIP)
+#include "geryon/hip_texture.h"
 #else
 #include "geryon/nvd_texture.h"
 #endif

--- a/lib/gpu/lal_base_dipole.h
+++ b/lib/gpu/lal_base_dipole.h
@@ -23,6 +23,8 @@
 
 #ifdef USE_OPENCL
 #include "geryon/ocl_texture.h"
+#elif defined(USE_HIP)
+#include "geryon/hip_texture.h"
 #else
 #include "geryon/nvd_texture.h"
 #endif

--- a/lib/gpu/lal_base_dpd.h
+++ b/lib/gpu/lal_base_dpd.h
@@ -23,6 +23,8 @@
 
 #ifdef USE_OPENCL
 #include "geryon/ocl_texture.h"
+#elif defined(USE_HIP)
+#include "geryon/hip_texture.h"
 #else
 #include "geryon/nvd_texture.h"
 #endif

--- a/lib/gpu/lal_base_ellipsoid.h
+++ b/lib/gpu/lal_base_ellipsoid.h
@@ -24,6 +24,8 @@
 #include "geryon/ocl_texture.h"
 #elif defined(USE_CUDART)
 #include "geryon/nvc_texture.h"
+#elif defined(USE_HIP)
+#include "geryon/hip_texture.h"
 #else
 #include "geryon/nvd_texture.h"
 #endif

--- a/lib/gpu/lal_base_three.h
+++ b/lib/gpu/lal_base_three.h
@@ -24,6 +24,8 @@
 #include "geryon/ocl_texture.h"
 #elif defined(USE_CUDART)
 #include "geryon/nvc_texture.h"
+#elif defined(USE_HIP)
+#include "geryon/hip_texture.h"
 #else
 #include "geryon/nvd_texture.h"
 #endif

--- a/lib/gpu/lal_beck.cu
+++ b/lib/gpu/lal_beck.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_born.cu
+++ b/lib/gpu/lal_born.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_born_coul_long.cu
+++ b/lib/gpu/lal_born_coul_long.cu
@@ -13,15 +13,15 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_born_coul_long_cs.cu
+++ b/lib/gpu/lal_born_coul_long_cs.cu
@@ -13,15 +13,16 @@
 //    email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
+
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_born_coul_wolf.cu
+++ b/lib/gpu/lal_born_coul_wolf.cu
@@ -13,15 +13,15 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_born_coul_wolf_cs.cu
+++ b/lib/gpu/lal_born_coul_wolf_cs.cu
@@ -13,15 +13,15 @@
 //    email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_buck.cu
+++ b/lib/gpu/lal_buck.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_buck_coul.cu
+++ b/lib/gpu/lal_buck_coul.cu
@@ -13,15 +13,15 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_buck_coul_long.cu
+++ b/lib/gpu/lal_buck_coul_long.cu
@@ -13,15 +13,15 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_charmm_long.cu
+++ b/lib/gpu/lal_charmm_long.cu
@@ -13,15 +13,15 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_colloid.cu
+++ b/lib/gpu/lal_colloid.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_coul.cu
+++ b/lib/gpu/lal_coul.cu
@@ -13,15 +13,15 @@
 //    email                : ndtrung@umich.edu
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_coul_debye.cu
+++ b/lib/gpu/lal_coul_debye.cu
@@ -13,15 +13,15 @@
 //    email                : ndtrung@umich.edu
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_coul_dsf.cu
+++ b/lib/gpu/lal_coul_dsf.cu
@@ -13,15 +13,15 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_coul_long.cu
+++ b/lib/gpu/lal_coul_long.cu
@@ -13,15 +13,15 @@
 //    email                : a.kohlmeyer@temple.edu
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_coul_long_cs.cu
+++ b/lib/gpu/lal_coul_long_cs.cu
@@ -13,15 +13,15 @@
 //    email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_device.cpp
+++ b/lib/gpu/lal_device.cpp
@@ -712,7 +712,7 @@ int DeviceT::compile_kernels() {
   gpu_lib_data.update_host(false);
 
   _ptx_arch=static_cast<double>(gpu_lib_data[0])/100.0;
-  #ifndef USE_OPENCL
+  #if !(defined(USE_OPENCL) || defined(USE_HIP))
   if (_ptx_arch>gpu->arch() || floor(_ptx_arch)<floor(gpu->arch()))
     return -4;
   #endif

--- a/lib/gpu/lal_device.cpp
+++ b/lib/gpu/lal_device.cpp
@@ -268,7 +268,7 @@ int DeviceT::init(Answer<numtyp,acctyp> &ans, const bool charge,
     gpu_nbor=1;
   else if (_gpu_mode==Device<numtyp,acctyp>::GPU_HYB_NEIGH)
     gpu_nbor=2;
-  #ifndef USE_CUDPP
+  #if !defined(USE_CUDPP) && !defined(USE_HIP_DEVICE_SORT)
   if (gpu_nbor==1)
     gpu_nbor=2;
   #endif
@@ -341,7 +341,7 @@ int DeviceT::init_nbor(Neighbor *nbor, const int nlocal,
     gpu_nbor=1;
   else if (_gpu_mode==Device<numtyp,acctyp>::GPU_HYB_NEIGH)
     gpu_nbor=2;
-  #ifndef USE_CUDPP
+  #if !defined(USE_CUDPP) && !defined(USE_HIP_DEVICE_SORT)
   if (gpu_nbor==1)
     gpu_nbor=2;
   #endif

--- a/lib/gpu/lal_device.cu
+++ b/lib/gpu/lal_device.cu
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_preprocessor.h"
 #endif
 

--- a/lib/gpu/lal_dipole_lj.cu
+++ b/lib/gpu/lal_dipole_lj.cu
@@ -13,16 +13,16 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
-texture<float4> mu_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
+_texture( mu_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
-texture<int4,1> mu_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
+_texture_2d( mu_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_dipole_lj_sf.cu
+++ b/lib/gpu/lal_dipole_lj_sf.cu
@@ -13,17 +13,17 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
-texture<float4> mu_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
+_texture( mu_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
-texture<int4,1> mu_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
+_texture_2d( mu_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_dipole_long_lj.cu
+++ b/lib/gpu/lal_dipole_long_lj.cu
@@ -13,16 +13,16 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
-texture<float4> mu_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
+_texture( mu_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
-texture<int4,1> mu_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
+_texture_2d( mu_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_dpd.cu
+++ b/lib/gpu/lal_dpd.cu
@@ -13,14 +13,14 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float4> vel_tex;
+_texture( pos_tex,float4);
+_texture( vel_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int4,1> vel_tex;
+_texture_2d( pos_tex,int4);
+_texture_2d( vel_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_eam.cu
+++ b/lib/gpu/lal_eam.cu
@@ -13,27 +13,27 @@
 //    email                : brownw@ornl.gov nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> fp_tex;
-texture<float4> rhor_sp1_tex;
-texture<float4> rhor_sp2_tex;
-texture<float4> frho_sp1_tex;
-texture<float4> frho_sp2_tex;
-texture<float4> z2r_sp1_tex;
-texture<float4> z2r_sp2_tex;
+_texture( pos_tex,float4);
+_texture( fp_tex,float);
+_texture( rhor_sp1_tex,float4);
+_texture( rhor_sp2_tex,float4);
+_texture( frho_sp1_tex,float4);
+_texture( frho_sp2_tex,float4);
+_texture( z2r_sp1_tex,float4);
+_texture( z2r_sp2_tex,float4);
 #else
-texture<int4> pos_tex;
-texture<int2> fp_tex;
-texture<int4> rhor_sp1_tex;
-texture<int4> rhor_sp2_tex;
-texture<int4> frho_sp1_tex;
-texture<int4> frho_sp2_tex;
-texture<int4> z2r_sp1_tex;
-texture<int4> z2r_sp2_tex;
+_texture( pos_tex,int4);
+_texture( fp_tex,int2);
+_texture( rhor_sp1_tex,int4);
+_texture( rhor_sp2_tex,int4);
+_texture( frho_sp1_tex,int4);
+_texture( frho_sp2_tex,int4);
+_texture( z2r_sp1_tex,int4);
+_texture( z2r_sp2_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_ellipsoid_extra.h
+++ b/lib/gpu/lal_ellipsoid_extra.h
@@ -18,12 +18,14 @@
 
 enum{SPHERE_SPHERE,SPHERE_ELLIPSE,ELLIPSE_SPHERE,ELLIPSE_ELLIPSE};
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex, quat_tex;
+_texture( pos_tex, float4);
+_texture( quat_tex,float4);
 #else
-texture<int4,1> pos_tex, quat_tex;
+_texture_2d( pos_tex,int4);
+_texture_2d( quat_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_ellipsoid_nbor.cu
+++ b/lib/gpu/lal_ellipsoid_nbor.cu
@@ -13,12 +13,12 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_preprocessor.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_gauss.cu
+++ b/lib/gpu/lal_gauss.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_gayberne.cu
+++ b/lib/gpu/lal_gayberne.cu
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_ellipsoid_extra.h"
 #endif
 

--- a/lib/gpu/lal_gayberne_lj.cu
+++ b/lib/gpu/lal_gayberne_lj.cu
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_ellipsoid_extra.h"
 #endif
 

--- a/lib/gpu/lal_lj.cu
+++ b/lib/gpu/lal_lj.cu
@@ -13,12 +13,12 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_lj96.cu
+++ b/lib/gpu/lal_lj96.cu
@@ -13,12 +13,12 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_lj_class2_long.cu
+++ b/lib/gpu/lal_lj_class2_long.cu
@@ -13,15 +13,15 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_coul.cu
+++ b/lib/gpu/lal_lj_coul.cu
@@ -13,15 +13,15 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_coul_debye.cu
+++ b/lib/gpu/lal_lj_coul_debye.cu
@@ -13,15 +13,15 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_coul_long.cu
+++ b/lib/gpu/lal_lj_coul_long.cu
@@ -13,15 +13,15 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_coul_msm.cu
+++ b/lib/gpu/lal_lj_coul_msm.cu
@@ -13,19 +13,19 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
-texture<float> gcons_tex;
-texture<float> dgcons_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
+_texture( gcons_tex,float);
+_texture( dgcons_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
-texture<int2> gcons_tex;
-texture<int2> dgcons_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
+_texture( gcons_tex,int2);
+_texture( dgcons_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_cubic.cu
+++ b/lib/gpu/lal_lj_cubic.cu
@@ -13,12 +13,12 @@
 //    email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_lj_dsf.cu
+++ b/lib/gpu/lal_lj_dsf.cu
@@ -13,15 +13,15 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_expand.cu
+++ b/lib/gpu/lal_lj_expand.cu
@@ -13,13 +13,13 @@
 //    email                : ibains@nvidia.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_expand_coul_long.cu
+++ b/lib/gpu/lal_lj_expand_coul_long.cu
@@ -13,15 +13,15 @@
 //    email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_gromacs.cu
+++ b/lib/gpu/lal_lj_gromacs.cu
@@ -13,13 +13,13 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_lj_sdk.cu
+++ b/lib/gpu/lal_lj_sdk.cu
@@ -13,12 +13,12 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_lj_sdk_long.cu
+++ b/lib/gpu/lal_lj_sdk_long.cu
@@ -13,15 +13,15 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_mie.cu
+++ b/lib/gpu/lal_mie.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_morse.cu
+++ b/lib/gpu/lal_morse.cu
@@ -13,13 +13,13 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_neighbor_cpu.cu
+++ b/lib/gpu/lal_neighbor_cpu.cu
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_preprocessor.h"
 #endif
 

--- a/lib/gpu/lal_neighbor_gpu.cu
+++ b/lib/gpu/lal_neighbor_gpu.cu
@@ -14,7 +14,7 @@
 //    email                : penwang@nvidia.com, brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_preprocessor.h"
 #ifdef LAMMPS_SMALLBIG
 #define tagint int
@@ -27,9 +27,9 @@
 #define tagint int
 #endif
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 
 __kernel void calc_cell_id(const numtyp4 *restrict pos,

--- a/lib/gpu/lal_neighbor_shared.h
+++ b/lib/gpu/lal_neighbor_shared.h
@@ -24,6 +24,10 @@ using namespace ucl_opencl;
 #include "geryon/nvc_kernel.h"
 #include "geryon/nvc_texture.h"
 using namespace ucl_cudart;
+#elif defined(USE_HIP)
+#include "geryon/hip_kernel.h"
+#include "geryon/hip_texture.h"
+using namespace ucl_hip;
 #else
 #include "geryon/nvd_kernel.h"
 #include "geryon/nvd_texture.h"

--- a/lib/gpu/lal_pppm.cu
+++ b/lib/gpu/lal_pppm.cu
@@ -13,15 +13,15 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_preprocessor.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> q_tex;
+_texture( pos_tex,float4);
+_texture( q_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> q_tex;
+_texture_2d( pos_tex,int4);
+_texture( q_tex,int2);
 #endif
 
 // Allow PPPM to compile without atomics for NVIDIA 1.0 cards, error

--- a/lib/gpu/lal_pppm.h
+++ b/lib/gpu/lal_pppm.h
@@ -23,6 +23,8 @@
 #include "geryon/ocl_texture.h"
 #elif defined(USE_CUDART)
 #include "geryon/nvc_texture.h"
+#elif defined(USE_HIP)
+#include "geryon/hip_texture.h"
 #else
 #include "geryon/nvd_texture.h"
 #endif

--- a/lib/gpu/lal_precision.h
+++ b/lib/gpu/lal_precision.h
@@ -24,8 +24,10 @@ struct _lgpu_int2 {
   int x; int y;
 };
 
+#ifndef USE_HIP
 #ifndef int2
 #define int2 _lgpu_int2
+#endif
 #endif
 
 struct _lgpu_float2 {

--- a/lib/gpu/lal_re_squared.cu
+++ b/lib/gpu/lal_re_squared.cu
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_ellipsoid_extra.h"
 #endif
 

--- a/lib/gpu/lal_re_squared_lj.cu
+++ b/lib/gpu/lal_re_squared_lj.cu
@@ -13,7 +13,7 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_ellipsoid_extra.h"
 #endif
 

--- a/lib/gpu/lal_soft.cu
+++ b/lib/gpu/lal_soft.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_sw.cu
+++ b/lib/gpu/lal_sw.cu
@@ -13,19 +13,19 @@
 //    email                : brownw@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float4> sw1_tex;
-texture<float4> sw2_tex;
-texture<float4> sw3_tex;
+_texture( pos_tex,float4);
+_texture( sw1_tex,float4);
+_texture( sw2_tex,float4);
+_texture( sw3_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int4> sw1_tex;
-texture<int4> sw2_tex;
-texture<int4> sw3_tex;
+_texture_2d( pos_tex,int4);
+_texture( sw1_tex,int4);
+_texture( sw2_tex,int4);
+_texture( sw3_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_table.cu
+++ b/lib/gpu/lal_table.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_tersoff.cu
+++ b/lib/gpu/lal_tersoff.cu
@@ -13,23 +13,23 @@
 //       email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_tersoff_extra.h"
 
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float4> ts1_tex;
-texture<float4> ts2_tex;
-texture<float4> ts3_tex;
-texture<float4> ts4_tex;
-texture<float4> ts5_tex;
+_texture( pos_tex,float4);
+_texture( ts1_tex,float4);
+_texture( ts2_tex,float4);
+_texture( ts3_tex,float4);
+_texture( ts4_tex,float4);
+_texture( ts5_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int4> ts1_tex;
-texture<int4> ts2_tex;
-texture<int4> ts3_tex;
-texture<int4> ts4_tex;
-texture<int4> ts5_tex;
+_texture_2d( pos_tex,int4);
+_texture( ts1_tex,int4);
+_texture( ts2_tex,int4);
+_texture( ts3_tex,int4);
+_texture( ts4_tex,int4);
+_texture( ts5_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_tersoff_extra.h
+++ b/lib/gpu/lal_tersoff_extra.h
@@ -16,7 +16,7 @@
 #ifndef LAL_TERSOFF_EXTRA_H
 #define LAL_TERSOFF_EXTRA_H
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #else
 #endif

--- a/lib/gpu/lal_tersoff_mod.cu
+++ b/lib/gpu/lal_tersoff_mod.cu
@@ -13,23 +13,23 @@
 //       email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_tersoff_mod_extra.h"
 
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float4> ts1_tex;
-texture<float4> ts2_tex;
-texture<float4> ts3_tex;
-texture<float4> ts4_tex;
-texture<float4> ts5_tex;
+_texture( pos_tex,float4);
+_texture( ts1_tex,float4);
+_texture( ts2_tex,float4);
+_texture( ts3_tex,float4);
+_texture( ts4_tex,float4);
+_texture( ts5_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int4> ts1_tex;
-texture<int4> ts2_tex;
-texture<int4> ts3_tex;
-texture<int4> ts4_tex;
-texture<int4> ts5_tex;
+_texture_2d( pos_tex,int4);
+_texture( ts1_tex,int4);
+_texture( ts2_tex,int4);
+_texture( ts3_tex,int4);
+_texture( ts4_tex,int4);
+_texture( ts5_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_tersoff_mod_extra.h
+++ b/lib/gpu/lal_tersoff_mod_extra.h
@@ -16,7 +16,7 @@
 #ifndef LAL_TERSOFF_MOD_EXTRA_H
 #define LAL_TERSOFF_MOD_EXTRA_H
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #else
 #endif

--- a/lib/gpu/lal_tersoff_zbl.cu
+++ b/lib/gpu/lal_tersoff_zbl.cu
@@ -13,25 +13,25 @@
 //       email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_tersoff_zbl_extra.h"
 
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float4> ts1_tex;
-texture<float4> ts2_tex;
-texture<float4> ts3_tex;
-texture<float4> ts4_tex;
-texture<float4> ts5_tex;
-texture<float4> ts6_tex;
+_texture( pos_tex,float4);
+_texture( ts1_tex,float4);
+_texture( ts2_tex,float4);
+_texture( ts3_tex,float4);
+_texture( ts4_tex,float4);
+_texture( ts5_tex,float4);
+_texture( ts6_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int4> ts1_tex;
-texture<int4> ts2_tex;
-texture<int4> ts3_tex;
-texture<int4> ts4_tex;
-texture<int4> ts5_tex;
-texture<int4> ts6_tex;
+_texture_2d( pos_tex,int4);
+_texture( ts1_tex,int4);
+_texture( ts2_tex,int4);
+_texture( ts3_tex,int4);
+_texture( ts4_tex,int4);
+_texture( ts5_tex,int4);
+_texture( ts6_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_tersoff_zbl_extra.h
+++ b/lib/gpu/lal_tersoff_zbl_extra.h
@@ -16,7 +16,7 @@
 #ifndef LAL_TERSOFF_ZBL_EXTRA_H
 #define LAL_TERSOFF_ZBL_EXTRA_H
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #else
 #endif

--- a/lib/gpu/lal_ufm.cu
+++ b/lib/gpu/lal_ufm.cu
@@ -15,12 +15,12 @@
                            dekoning@ifi.unicamp.br
  ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_vashishta.cu
+++ b/lib/gpu/lal_vashishta.cu
@@ -13,23 +13,23 @@
 //    email                : andershaf@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float4> param1_tex;
-texture<float4> param2_tex;
-texture<float4> param3_tex;
-texture<float4> param4_tex;
-texture<float4> param5_tex;
+_texture( pos_tex,float4);
+_texture( param1_tex,float4);
+_texture( param2_tex,float4);
+_texture( param3_tex,float4);
+_texture( param4_tex,float4);
+_texture( param5_tex,float4);
 #else
-texture<int4,1> pos_tex;
-texture<int4> param1_tex;
-texture<int4> param2_tex;
-texture<int4> param3_tex;
-texture<int4> param4_tex;
-texture<int4> param5_tex;
+_texture_2d( pos_tex,int4);
+_texture( param1_tex,int4);
+_texture( param2_tex,int4);
+_texture( param3_tex,int4);
+_texture( param4_tex,int4);
+_texture( param5_tex,int4);
 #endif
 
 #else

--- a/lib/gpu/lal_yukawa.cu
+++ b/lib/gpu/lal_yukawa.cu
@@ -13,12 +13,12 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/lib/gpu/lal_yukawa_colloid.cu
+++ b/lib/gpu/lal_yukawa_colloid.cu
@@ -13,15 +13,15 @@
 //    email                : nguyentd@ornl.gov
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
-texture<float> rad_tex;
+_texture( pos_tex,float4);
+_texture( rad_tex,float);
 #else
-texture<int4,1> pos_tex;
-texture<int2> rad_tex;
+_texture_2d( pos_tex,int4);
+_texture( rad_tex,int2);
 #endif
 
 #else

--- a/lib/gpu/lal_zbl.cu
+++ b/lib/gpu/lal_zbl.cu
@@ -13,12 +13,12 @@
 //    email                : ndactrung@gmail.com
 // ***************************************************************************/
 
-#ifdef NV_KERNEL
+#if defined(NV_KERNEL) || defined(USE_HIP)
 #include "lal_aux_fun1.h"
 #ifndef _DOUBLE_DOUBLE
-texture<float4> pos_tex;
+_texture( pos_tex,float4);
 #else
-texture<int4,1> pos_tex;
+_texture_2d( pos_tex,int4);
 #endif
 #else
 #define pos_tex x_

--- a/src/MAKE/OPTIONS/Makefile.hip
+++ b/src/MAKE/OPTIONS/Makefile.hip
@@ -1,0 +1,120 @@
+# hip = MPI with HIP(clang)
+
+SHELL = /bin/sh
+
+# ---------------------------------------------------------------------
+# compiler/linker settings
+# specify flags and libraries needed for your compiler
+
+CC =		mpicxx
+CCFLAGS =	-g -O3 
+SHFLAGS =	-fPIC
+DEPFLAGS =	-M
+
+HIP_PATH ?= $(wildcard /opt/rocm/hip)
+LINK =		$(HIP_PATH)/bin/hipcc
+LINKFLAGS =	-g -O3 $(shell mpicxx --showme:link)
+LIB = 
+SIZE =		size
+
+ARCHIVE =	ar
+ARFLAGS =	-rc
+SHLIBFLAGS =	-shared
+
+# ---------------------------------------------------------------------
+# LAMMPS-specific settings, all OPTIONAL
+# specify settings for LAMMPS features you will use
+# if you change any -D setting, do full re-compile after "make clean"
+
+# LAMMPS ifdef settings
+# see possible settings in Section 2.2 (step 4) of manual
+
+LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64
+
+# MPI library
+# see discussion in Section 2.2 (step 5) of manual
+# MPI wrapper compiler/linker can provide this info
+# can point to dummy MPI library in src/STUBS as in Makefile.serial
+# use -D MPICH and OMPI settings in INC to avoid C++ lib conflicts
+# INC = path for mpi.h, MPI compiler settings
+# PATH = path for MPI library
+# LIB = name of MPI library
+
+MPI_INC =       -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1
+MPI_PATH = 
+MPI_LIB =	
+
+# FFT library
+# see discussion in Section 2.2 (step 6) of manual
+# can be left blank to use provided KISS FFT library
+# INC = -DFFT setting, e.g. -DFFT_FFTW, FFT compiler settings
+# PATH = path for FFT library
+# LIB = name of FFT library
+
+FFT_INC =    	
+FFT_PATH = 
+FFT_LIB =	
+
+# JPEG and/or PNG library
+# see discussion in Section 2.2 (step 7) of manual
+# only needed if -DLAMMPS_JPEG or -DLAMMPS_PNG listed with LMP_INC
+# INC = path(s) for jpeglib.h and/or png.h
+# PATH = path(s) for JPEG library and/or PNG library
+# LIB = name(s) of JPEG library and/or PNG library
+
+JPG_INC =       
+JPG_PATH = 	
+JPG_LIB =	
+
+# ---------------------------------------------------------------------
+# build rules and dependencies
+# do not edit this section
+
+include	Makefile.package.settings
+include	Makefile.package
+
+ifeq (nvcc,${HIP_PLATFORM})
+	# fix nvcc can't handle -pthread flag
+	LINKFLAGS := $(subst -pthread,-Xcompiler -pthread,$(LINKFLAGS))
+endif
+
+EXTRA_INC = $(LMP_INC) $(PKG_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
+EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
+
+# Path to src files
+
+vpath %.cpp ..
+vpath %.h ..
+
+# Link target
+
+$(EXE):	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(LINK) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(EXTRA_LIB) $(LIB) -o $(EXE)
+	$(SIZE) $(EXE)
+
+# Library targets
+
+lib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(ARCHIVE) $(ARFLAGS) $(EXE) $(OBJ)
+
+shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(SHLIBFLAGS) $(EXTRA_PATH) -o $(EXE) \
+        $(OBJ) $(EXTRA_LIB) $(LIB)
+
+# Compilation rules
+
+%.o:%.cpp
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+# Individual dependencies
+
+depend : fastdep.exe $(SRC)
+	@./fastdep.exe $(EXTRA_INC) -- $^ > .depend || exit 1
+
+fastdep.exe: ../DEPEND/fastdep.c
+	cc -O -o $@ $<
+
+sinclude .depend


### PR DESCRIPTION
**Summary**

This PR enhances LAMMPS with the capability for using the new HIP C++ runtime API for GPU-offloading of MD calculations as implemented in the GPU package that has been developed with support of CUDA and OpenCL backends using the unification layer of the _geryon_ library. This PR adds a new HIP-backend to this library. HIP is a part of the AMD ROCm open source GPU framework. This new HIP-backend can be used either with the hcc compiler for AMD GPUs, or with the nvcc compiler for Nvidia GPUs.

**Related Issues**

This PR is related to the issue #1368 and opens a new way of running LAMMPS on AMD GPUs that support ROCm without fixing the current version of the GPU package OpenCL-backend that is not fully compatible with the OpenCL 2.0 standard required for ROCm. The issue #1368 could be probably closed after merging.

**Author(s)**

Evgeny Kuznetsov (eokuznetsov@edu.hse.ru) and Vladimir Stegailov (v.stegailov@hse.ru, stegailov@gmail.com), International Laboratory for Supercomputer Atomistic Modelling and Multi-scale Analysis, Higher School of Economics, Moscow

**Licensing**

By submitting this pull request, we agree, that our contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This PR should not break backward compatibility.

**Implementation Notes**

For porting to HIP framework, we use the CUDA-backend of the GPU acceleration capability of LAMMPS developed by Mike Brown et al. This acceleration library is based on the _geryon_ library that serves as a unification layer for CUDA and OpenCL backends.

A ROCm _hipify_ tool provides a fast method to translate CUDA runtime and driver API calls and types to their HIP analogs. Not all CUDA functions have corresponding HIP wrappers and those that have, sometimes are not fully implemented. In particular, this applies to CUDA driver API calls used in the _geryon_ library. Despite that _hipify_, empowered by the Clang C++ parser, allows translating the most part of CUDA code in a mistake-free manner.

Due to existing architecture differences, it has been essential to revise GPU kernels. This applies especially to inline assembly and warp operations. AMD and Nvidia GPUs have different warp sizes, 64 and 32 respectively, so it has been necessary to make sure all warp vote and shuffle functions, `__ballot` for example, use appropriate integer types and there are no "magic" constants like 32, 31, 5 and so on. `Printf` and `assert` calls from GPU kernels are still under development in ROCm, and it is worth noting that in the ROCm version 2.2 an assert call causes kernel execution abort regardless of the condition.

Another pitfall is using texture references and objects. In the ROCm version 2.2, AMD HSA imposes hard limits on texture dimensions (up to 4096 elements for 1D texture, for example), that makes them useless in practice. Moreover, textures are declared in kernel modules as external symbols, and they should be defined in the host scope. So, it becomes impossible to load and use binary kernel modules with texture declarations. A possible workaround to avoid significant code fixes, in this case, is to use device global pointer variables as pseudo-textures. Device pointers binding to texture references or objects turn into global variables assignments, and, like textures, global variables can be extracted by their names.

GPU sorting requires to install _hipcub_ (https://github.com/ROCmSoftwarePlatform/hipCUB). The HIP CUDA-backend additionally requires _cub_ (https://nvlabs.github.io/cub/).

Linking the MPI code with the `hipcc` compiler requires getting the corresponding linking options from a standard MPI-wrapper of the MPI stack deployed (e.g. OpenMPI or MPICH). These options should be included into the makefiles for `libgpu.a` and for `lmp_hip` binaries.

This PR has been tested using ROCm 2.2-2.6 and different standard LAMMPS input examples on Radeon RX 480 (gfx803), Radeon RX Vega (gfx900), Radeon VII (gfx906) and Titan V (sm_70) with OpenMPI and MPICH.

The PR code has been merged with the pull #1430.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [x] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

The following text is proposed for addition to lib/gpu/README

BUILDING FOR HIP FRAMEWORK

1. Install the latest ROCm framework (https://github.com/RadeonOpenCompute/ROCm).

2. GPU sorting requires installing hipcub (https://github.com/ROCmSoftwarePlatform/hipCUB). The HIP CUDA-backend additionally requires cub (https://nvlabs.github.io/cub). Download and extract the cub directory to lammps/lib/gpu/ or specify an appropriate path in lammps/lib/gpu/Makefile.hip.

3. In Makefile.hip it is possible to specify the target platform via export HIP_PLATFORM=hcc or HIP_PLATFORM=nvcc as well as the target architecture(s) (gfx803, gfx900, gfx906 etc.)

4. If your MPI implementation does not support mpicxx --showme command, it is required to specify the corresponding MPI compiler and linker flags in lammps/lib/gpu/Makefile.hip and in lammps/src/MAKE/OPTIONS/Makefile.hip.

5. Building the GPU library (libgpu.a): cd lammps/lib/gpu; make -f Makefile.hip -j8

6. Building the LAMMPS executable (lmp_hip): cd ../../src; make hip -j8
