### PR TITLE
Bug fixes for use of uninitialized variable and strict-aliasing in USER-INTEL

### DIFF
--- a/src/USER-INTEL/fix_intel.cpp
+++ b/src/USER-INTEL/fix_intel.cpp
@@ -352,15 +352,15 @@ void FixIntel::init()
   if (_offload_balance != 0.0) off_mode = 1;
   if (_precision_mode == PREC_MODE_SINGLE) {
     _single_buffers->zero_ev();
-    _single_buffers->grow_ncache(off_mode,_nthreads);
+    _single_buffers->grow_ncache(off_mode, comm->nthreads);
     _single_buffers->free_list_ptrs();
   } else if (_precision_mode == PREC_MODE_MIXED) {
     _mixed_buffers->zero_ev();
-    _mixed_buffers->grow_ncache(off_mode,_nthreads);
+    _mixed_buffers->grow_ncache(off_mode, comm->nthreads);
     _mixed_buffers->free_list_ptrs();
   } else {
     _double_buffers->zero_ev();
-    _double_buffers->grow_ncache(off_mode,_nthreads);
+    _double_buffers->grow_ncache(off_mode, comm->nthreads);
     _double_buffers->free_list_ptrs();
   }
 

--- a/src/USER-INTEL/intel_intrinsics_airebo.h
+++ b/src/USER-INTEL/intel_intrinsics_airebo.h
@@ -2223,7 +2223,9 @@ public:
   }
 
   VEC_INLINE static ivec unpackloepi32(const fvec &a) {
-    return reinterpret_cast<const int*>(&a.val_)[0];
+    union { int i; flt_t f; } atype;
+    atype.f = a.val_;
+    return ivec(atype.i);
   }
 
   VEC_INLINE static fvec mask_sincos(


### PR DESCRIPTION
**Summary**

Fixes use of an uninitialized variable that can cause crashes at LAMMPS run initialization with the USER-INTEL package and changes AIREBO intrinsics to make appropriate use of unions for type-punning with strict aliasing.

**Related Issues**

Fixes #1532 and #1499

**Author(s)**

Mike Brown (Intel)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


