### PR TITLE
Bug fixes for pair style granular

### DIFF
--- a/doc/src/pair_granular.txt
+++ b/doc/src/pair_granular.txt
@@ -412,7 +412,7 @@ option by an additional factor of {a}, the radius of the contact region. The tan
 \end\{equation\}
 
 Here, {a} is the radius of the contact region, given by \(a =\sqrt\{R\delta\}\)
- for all normal contact models, except for {jkr}, where it is given
+for all normal contact models, except for {jkr}, where it is given
 implicitly by \(\delta = a^2/R - 2\sqrt\{\pi \gamma a/E\}\), see
 discussion above. To match the Mindlin solution, one should set \(k_t
 = 8G\), where \(G\) is the shear modulus, related to Young's modulus

--- a/doc/src/pair_granular.txt
+++ b/doc/src/pair_granular.txt
@@ -177,7 +177,7 @@ following general form:
 \end\{equation\}
 
 Here, \(\mathbf\{v\}_\{n,rel\} = (\mathbf\{v\}_j - \mathbf\{v\}_i)
-\cdot \mathbf\{n\}\) is the component of relative velocity along
+\cdot \mathbf\{n\} \mathbf\{n\}\) is the component of relative velocity along
 \(\mathbf\{n\}\).
 
 The optional {damping} keyword to the {pair_coeff} command followed by
@@ -299,8 +299,8 @@ the normal damping \(\eta_n\) (see above):
 \eta_t = -x_\{\gamma,t\} \eta_n
 \end\{equation\}
 
-The normal damping prefactor \(\eta_n\) is determined by the choice of
-the {damping} keyword, as discussed above.  Thus, the {damping}
+The normal damping prefactor \(\eta_n\) is determined by the choice
+of the {damping} keyword, as discussed above.  Thus, the {damping}
 keyword also affects the tangential damping.  The parameter
 \(x_\{\gamma,t\}\) is a scaling coefficient. Several works in the
 literature use \(x_\{\gamma,t\} = 1\) ("Marshall"_#Marshall2009,
@@ -308,10 +308,10 @@ literature use \(x_\{\gamma,t\} = 1\) ("Marshall"_#Marshall2009,
 tangential velocity at the point of contact is given by
 \(\mathbf\{v\}_\{t, rel\} = \mathbf\{v\}_\{t\} - (R_i\Omega_i +
 R_j\Omega_j) \times \mathbf\{n\}\), where \(\mathbf\{v\}_\{t\} =
-\mathbf\{v\}_r - \mathbf\{v\}_r\cdot\mathbf\{n\}\), \(\mathbf\{v\}_r =
-\mathbf\{v\}_j - \mathbf\{v\}_i\). The direction of the applied force
-is \(\mathbf\{t\} =
-\mathbf\{v_\{t,rel\}\}/\|\mathbf\{v_\{t,rel\}\}\|\).
+\mathbf\{v\}_r - \mathbf\{v\}_r\cdot\mathbf\{n\}\{n\}\),
+\(\mathbf\{v\}_r = \mathbf\{v\}_j - \mathbf\{v\}_i\).
+The direction of the applied force is \(\mathbf\{t\} =
+\mathbf\{v_\{t,rel\}\}/\|\mathbf\{v_\{t,rel\}\}\|\) .
 
 The normal force value \(F_\{n0\}\) used to compute the critical force
 depends on the form of the contact model. For non-cohesive models

--- a/doc/src/pair_granular.txt
+++ b/doc/src/pair_granular.txt
@@ -100,7 +100,7 @@ on particle {i} due to contact with particle {j} is given by:
 \mathbf\{F\}_\{ne, Hooke\} = k_N \delta_\{ij\} \mathbf\{n\}
 \end\{equation\}
 
-Where \(\delta = R_i + R_j - \|\mathbf\{r\}_\{ij\}\|\) is the particle
+Where \(\delta_\{ij\} = R_i + R_j - \|\mathbf\{r\}_\{ij\}\|\) is the particle
 overlap, \(R_i, R_j\) are the particle radii, \(\mathbf\{r\}_\{ij\} =
 \mathbf\{r\}_i - \mathbf\{r\}_j\) is the vector separating the two
 particle centers (note the i-j ordering so that \(F_\{ne\}\) is
@@ -411,8 +411,8 @@ option by an additional factor of {a}, the radius of the contact region. The tan
 \mathbf\{F\}_t =  -min(\mu_t F_\{n0\}, \|-k_t a \mathbf\{\xi\} + \mathbf\{F\}_\mathrm\{t,damp\}\|) \mathbf\{t\}
 \end\{equation\}
 
-Here, {a} is the radius of the contact region, given by \(a = \delta
-R\) for all normal contact models, except for {jkr}, where it is given
+Here, {a} is the radius of the contact region, given by \(a =\sqrt\{R\delta\}\)
+ for all normal contact models, except for {jkr}, where it is given
 implicitly by \(\delta = a^2/R - 2\sqrt\{\pi \gamma a/E\}\), see
 discussion above. To match the Mindlin solution, one should set \(k_t
 = 8G\), where \(G\) is the shear modulus, related to Young's modulus
@@ -680,7 +680,7 @@ The single() function of these pair styles returns 0.0 for the energy
 of a pairwise interaction, since energy is not conserved in these
 dissipative potentials.  It also returns only the normal component of
 the pairwise interaction force.  However, the single() function also
-calculates 10 extra pairwise quantities.  The first 3 are the
+calculates 12 extra pairwise quantities.  The first 3 are the
 components of the tangential force between particles I and J, acting
 on particle I.  The 4th is the magnitude of this tangential force.
 The next 3 (5-7) are the components of the rolling torque acting on

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -635,7 +635,7 @@ void PairGranular::compute(int eflag, int vflag)
             torque[j][2] -= torroll3;
           }
         }
-        if (evflag) ev_tally_xyz(i,j,nlocal,0,
+        if (evflag) ev_tally_xyz(i,j,nlocal,force->newton_pair,
             0.0,0.0,fx,fy,fz,delx,dely,delz);
       }
     }

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -391,6 +391,7 @@ void PairGranular::compute(int eflag, int vflag)
         } else {
           Fncrit = fabs(Fntot);
         }
+		Fscrit = tangential_coeffs[itype][jtype][2] * Fncrit;
 
         //------------------------------
         // tangential forces
@@ -446,7 +447,6 @@ void PairGranular::compute(int eflag, int vflag)
           fs3 = -k_tangential*history[2] - damp_tangential*vtr3;
 
           // rescale frictional displacements and forces if needed
-          Fscrit = tangential_coeffs[itype][jtype][2] * Fncrit;
           fs = sqrt(fs1*fs1 + fs2*fs2 + fs3*fs3);
           if (fs > Fscrit) {
             shrmag = sqrt(history[0]*history[0] + history[1]*history[1] +
@@ -464,8 +464,8 @@ void PairGranular::compute(int eflag, int vflag)
             } else fs1 = fs2 = fs3 = 0.0;
           }
         } else { // classic pair gran/hooke (no history)
-          fs = meff*damp_tangential*vrel;
-          if (vrel != 0.0) Ft = MIN(Fne,fs) / vrel;
+          fs = damp_tangential*vrel; // From documentation: F_{t,damp} = - \eta_t v_{t,rel}, no need for extra `meff`
+          if (vrel != 0.0) Ft = MIN(Fscrit,fs) / vrel; // From documentation: critical force `Fscrit` used, not elastic normal force `Fne`
           else Ft = 0.0;
           fs1 = -Ft*vtr1;
           fs2 = -Ft*vtr2;
@@ -635,7 +635,7 @@ void PairGranular::compute(int eflag, int vflag)
             torque[j][2] -= torroll3;
           }
         }
-        if (evflag) ev_tally_xyz(i,j,nlocal,0,
+        if (evflag) ev_tally_xyz(i,j,nlocal,0,//Should `newton_pair` passed instead of 0 ?
             0.0,0.0,fx,fy,fz,delx,dely,delz);
       }
     }
@@ -1451,11 +1451,13 @@ double PairGranular::single(int i, int j, int itype, int jtype,
   }
 
   if (damping_model[itype][jtype] == VELOCITY) {
-    damp_normal = normal_coeffs[itype][jtype][1];
+    damp_normal = 1;
+  } else if (damping_model[itype][jtype] == MASS_VELOCITY) {
+    damp_normal = meff;
   } else if (damping_model[itype][jtype] == VISCOELASTIC) {
-    damp_normal = normal_coeffs[itype][jtype][1]*a*meff;
+    damp_normal = a*meff;
   } else if (damping_model[itype][jtype] == TSUJI) {
-    damp_normal = normal_coeffs[itype][jtype][1]*sqrt(meff*knfac);
+    damp_normal = sqrt(meff*knfac);
   }
 
   damp_normal_prefactor = normal_coeffs[itype][jtype][1]*damp_normal;
@@ -1473,6 +1475,7 @@ double PairGranular::single(int i, int j, int itype, int jtype,
       if (neighprev >= jnum) neighprev = 0;
       if (jlist[neighprev] == j) break;
     }
+	// the `history` pointer must not be modified here in single() function. already calculated in the compute() function. If modified here it changes the pair forces that have friction/twisting/rolling and history effects !
     history = &allhistory[size_history*neighprev];
   }
 
@@ -1506,6 +1509,7 @@ double PairGranular::single(int i, int j, int itype, int jtype,
   } else {
     Fncrit = fabs(Fntot);
   }
+  Fscrit = tangential_coeffs[itype][jtype][2] * Fncrit;
 
   //------------------------------
   // tangential forces
@@ -1518,13 +1522,6 @@ double PairGranular::single(int i, int j, int itype, int jtype,
       k_tangential *= a;
     } else if (tangential_model[itype][jtype] == TANGENTIAL_MINDLIN_RESCALE) {
       k_tangential *= a;
-      // on unloading, rescale the shear displacements
-      if (a < history[3]) {
-        double factor = a/history[3];
-        history[0] *= factor;
-        history[1] *= factor;
-        history[2] *= factor;
-      }
     }
 
     shrmag = sqrt(history[0]*history[0] + history[1]*history[1] +
@@ -1535,28 +1532,26 @@ double PairGranular::single(int i, int j, int itype, int jtype,
     fs2 = -k_tangential*history[1] - damp_tangential*vtr2;
     fs3 = -k_tangential*history[2] - damp_tangential*vtr3;
 
-    // rescale frictional displacements and forces if needed
-    Fscrit = tangential_coeffs[itype][jtype][2] * Fncrit;
+    // rescale frictional forces if needed
     fs = sqrt(fs1*fs1 + fs2*fs2 + fs3*fs3);
     if (fs > Fscrit) {
       if (shrmag != 0.0) {
-        history[0] = -1.0/k_tangential*(Fscrit*fs1/fs + damp_tangential*vtr1);
-        history[1] = -1.0/k_tangential*(Fscrit*fs2/fs + damp_tangential*vtr2);
-        history[2] = -1.0/k_tangential*(Fscrit*fs3/fs + damp_tangential*vtr3);
         fs1 *= Fscrit/fs;
         fs2 *= Fscrit/fs;
         fs3 *= Fscrit/fs;
-      } else fs1 = fs2 = fs3 = 0.0;
+		fs *= Fscrit/fs; // saves the correct value of `fs` to svector
+      } else fs1 = fs2 = fs3 = fs = 0.0; // saves the correct of `fs` value to svector
     }
 
   // classic pair gran/hooke (no history)
   } else {
-    fs = meff*damp_tangential*vrel;
-    if (vrel != 0.0) Ft = MIN(Fne,fs) / vrel;
+    fs = damp_tangential*vrel;
+    if (vrel != 0.0) Ft = MIN(Fscrit,fs) / vrel;
     else Ft = 0.0;
     fs1 = -Ft*vtr1;
     fs2 = -Ft*vtr2;
     fs3 = -Ft*vtr3;
+	fs = Ft*vrel; // saves the correct value of `fs` to svector
   }
 
   //****************************************
@@ -1601,7 +1596,8 @@ double PairGranular::single(int i, int j, int itype, int jtype,
         fr1 *= Frcrit/fr;
         fr2 *= Frcrit/fr;
         fr3 *= Frcrit/fr;
-      } else fr1 = fr2 = fr3 = 0.0;
+		fr *= Frcrit/fr; // saves the correct value of `fr` to svector
+      } else fr1 = fr2 = fr3 = fr = 0.0; // saves the correct value of `fr` to svector
     }
 
   }

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -464,8 +464,8 @@ void PairGranular::compute(int eflag, int vflag)
             } else fs1 = fs2 = fs3 = 0.0;
           }
         } else { // classic pair gran/hooke (no history)
-          fs = damp_tangential*vrel; // From documentation: F_{t,damp} = - \eta_t v_{t,rel}, no need for extra `meff`
-          if (vrel != 0.0) Ft = MIN(Fscrit,fs) / vrel; // From documentation: critical force `Fscrit` used, not elastic normal force `Fne`
+          fs = damp_tangential*vrel;
+          if (vrel != 0.0) Ft = MIN(Fscrit,fs) / vrel;
           else Ft = 0.0;
           fs1 = -Ft*vtr1;
           fs2 = -Ft*vtr2;
@@ -635,7 +635,7 @@ void PairGranular::compute(int eflag, int vflag)
             torque[j][2] -= torroll3;
           }
         }
-        if (evflag) ev_tally_xyz(i,j,nlocal,0,//Should `newton_pair` passed instead of 0 ?
+        if (evflag) ev_tally_xyz(i,j,nlocal,0,
             0.0,0.0,fx,fy,fz,delx,dely,delz);
       }
     }
@@ -1475,7 +1475,6 @@ double PairGranular::single(int i, int j, int itype, int jtype,
       if (neighprev >= jnum) neighprev = 0;
       if (jlist[neighprev] == j) break;
     }
-	// the `history` pointer must not be modified here in single() function. already calculated in the compute() function. If modified here it changes the pair forces that have friction/twisting/rolling and history effects !
     history = &allhistory[size_history*neighprev];
   }
 
@@ -1539,8 +1538,8 @@ double PairGranular::single(int i, int j, int itype, int jtype,
         fs1 *= Fscrit/fs;
         fs2 *= Fscrit/fs;
         fs3 *= Fscrit/fs;
-		fs *= Fscrit/fs; // saves the correct value of `fs` to svector
-      } else fs1 = fs2 = fs3 = fs = 0.0; // saves the correct of `fs` value to svector
+		fs *= Fscrit/fs;
+      } else fs1 = fs2 = fs3 = fs = 0.0;
     }
 
   // classic pair gran/hooke (no history)
@@ -1551,7 +1550,7 @@ double PairGranular::single(int i, int j, int itype, int jtype,
     fs1 = -Ft*vtr1;
     fs2 = -Ft*vtr2;
     fs3 = -Ft*vtr3;
-	fs = Ft*vrel; // saves the correct value of `fs` to svector
+	fs = Ft*vrel;
   }
 
   //****************************************
@@ -1596,8 +1595,8 @@ double PairGranular::single(int i, int j, int itype, int jtype,
         fr1 *= Frcrit/fr;
         fr2 *= Frcrit/fr;
         fr3 *= Frcrit/fr;
-		fr *= Frcrit/fr; // saves the correct value of `fr` to svector
-      } else fr1 = fr2 = fr3 = fr = 0.0; // saves the correct value of `fr` to svector
+		fr *= Frcrit/fr;
+      } else fr1 = fr2 = fr3 = fr = 0.0;
     }
 
   }

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -1630,7 +1630,11 @@ double PairGranular::single(int i, int j, int itype, int jtype,
       magtortwist = -Mtcrit * signtwist; // eq 34
     }
   }
-
+	
+  // set force and return no energy
+	
+  fforce = Fntot*rinv;
+	
   // set single_extra quantities
 
   svector[0] = fs1;


### PR DESCRIPTION
**Summary**

I found several issues in the computation of pair forces and output for the `granular` pair style:

1. the formula for tangential contact forces for `linear_nohistory` are not consistent in functions `PairGranular::compute()` and `PairGranular::single()` and differ from what is documented. The tangent contact forces are not computed as they should be;
2. the tangential displacement history is modified within the `PairGranular::single()` function. This should not happen as calling that function, e.g. using `compute pair/local` just for output, can currently alter the trajectory. There was no such update in the older `gran/*` pair style and there should not be;
3. the normal contact force is not returned to the `fforce` variable in `PairGranular::single()`, resulting in an undefined behavior and wrong values being output by the `compute pair/local` command with keyworkds `force`,`fx`,`fy` and `fz`.
4. values of tangential force and rolling resistance magnitude are not rescaled or zeroed in `PairGranular::single()`, potentially returning wrong outputs. The 3 components are well rescaled/zeroed;
5. A couple typos in the documentation have been corrected

This patch solves those issues.


**Author(s)**

Jibril B. Coulibaly, Northwestern University, jibril.coulibaly@northwestern.edu


**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

For each issue, the following corrections have been done:

1. in calculating the `linear_nohistory` tangential force: the extra `meff` was deleted and `Fscrit` was used instead of `Fne`. In `PairGranular::single()`, the normal damping coefficient was used twice and is now used only once. Everything is now matching the correct definitions from the documentation;
2. the lines updating the `history` pointer in `PairGranular::single()` have been deleted.
3. the total normal force divided by the branch vector length is assigned to the `fforce` argument: `fforce = Fntot*rinv;` the same way older pair styles `gran/*` use: `fforce = ccel;`;
4. magnitudes are rescaled or zeroed the same way the components already are.

I left some temporary non-compliant comments to help for the review.
The following MWEs illustrate the different issues. 


* Issue 1
```
units si
dimension 3
boundary p p p
atom_style sphere
comm_modify	vel yes
newton off
atom_modify map yes
region box block -5 5 -5 5 -5 5
create_box 1 box
create_atoms 1 single -0.25 0.0 0.0 #Create particle 1
create_atoms 1 single 0.25 0.0 0.0 #Create particle 1
variable d equal 1.0
variable dens equal "1.0*6/(PI*v_d^3)" # mass = 1, meff = 1/2 so that we can see influence of error: tangent force equals half of theoretical value
variable kn equal 1e3
variable etan0 equal 0.5
variable xgt equal 1.0
variable mus equal 0.25
variable delta equal "v_d - (x[2] - x[1])"
print "$(v_delta)"
set group all diameter $d density ${dens}
group p2 id 2
pair_style granular
pair_coeff * * hooke ${kn} ${etan0} tangential linear_nohistory ${xgt} ${mus} damping velocity
variable Ftcrit equal "v_kn*v_delta*v_mus" # Threshold tangent force
variable vtrelcrit equal "v_Ftcrit/(v_xgt*v_etan0)" # theoretical tangent relative velocity to reach threshold force using 'velocity' damping
variable vtrel equal 5.0*v_vtrelcrit
variable Ftdamp equal "v_xgt*v_etan0*v_vtrel" # theoretical tangent damping force using 'velocity' damping
variable fy equal fy[1] # tangent force actually computed (with an error, extra `meff`)
compute contact_forces all pair/local p4 # tangent force computed in ::single() function (with multiple errors, extra `meff` and extra `etan0` coefficient)
compute ftan all reduce ave c_contact_forces # tangent force computed in ::single() function (with multiple errors, extra `meff` and extra `etan0` coefficient)
velocity p2 set 0.0 ${vtrel} 0.0
thermo_style custom v_Ftdamp v_Ftcrit v_fy c_ftan
run 0
```
On my implementation of 07Aug2019, the thermo output is
- without the present patch: 625 125 312.5 156.25
- with the present patch: 625 125 125 125

* Issue 2 (not the most minimal MWE)

```
units si
dimension 3
boundary p p p
atom_style sphere
comm_modify	vel yes
newton off
atom_modify map yes
region box block -5 5 -5 5 -5 5
create_box 1 box
lattice sc 1
create_atoms 1 region box
set group all diameter 1.0 density 1.0
#pair_style gran/hertz/history 1e3 NULL 0.0 NULL 0.25 0 #Frictionless linear contact law without history Kn Kt gamma_n gamma_t xmu dampflag
#pair_coeff	* * #All particles under granular forces
pair_style granular
pair_coeff * * hertz/material 1e3 0.0 0.0 tangential mindlin_rescale NULL 0.0 0.25
thermo 10000
timestep 0.00001
velocity all create $(1e22) 012345 # Temperature based on gas kinetic theory T=mv^2/3kb (Boltzmann constant kb=1.380e-23), v based on overlap = d/1e4 (arbitrary, small) and characteristic time
fix 1 all nve
run 100000
velocity all set 0.0 0.0 0.0
fix 2 all deform 10 x trate -0.03 y trate -0.03 z trate -0.03 remap x
fix 3 all viscous 1
compute contact_forces all pair/local force
compute fcontact all reduce ave c_contact_forces # normal force
thermo 10000
thermo_style custom step pxx pyy pzz lx ly lz c_fcontact # GIVE ONE RESULT
thermo_style custom step pxx pyy pzz lx ly lz #c_fcontact # GIVE ANOTHER RESULT WHEN c_fmax_contact IS COMMENTED OUT
run 1000000
```
Depending on whether or not the `thermo_style` includes the output of the normal force `c_fcontact`, the pressures slightly differ, indicating different trajectories. This does not happen with `linear_nohistory` or older `gran/*` pair styles.

* issue 3

```
units si
dimension 3
boundary f f f
atom_style sphere
comm_modify	vel yes
newton off
atom_modify map yes
region box block -10 10 -10 10 -10 10
create_box 1 box
create_atoms 1 single -0.25 0.0 0.0 #Create particle 1
create_atoms 1 single 0.25 0.0 0.0 #Create particle 1
set group all diameter 1.0 density 1.0
pair_style granular
pair_coeff * * hooke 1e3 0.0 tangential linear_nohistory 0.0 0.0
compute contact_forces all pair/local force cutoff radius
compute fmax_contact all reduce ave c_contact_forces # Sum of normal force
variable f equal fx[2] 
thermo 1
thermo_style custom v_f c_fmax_contact
run 0
```
On my implementation of 07Aug2019, the thermo output is
- without the present patch: 500        0
- with the present patch: 500 500

* issue 4, the patch showed no difference with current implementation for the simple cases I tested.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

