### PR TITLE
bump kim-api to 2.1.3

### DIFF
--- a/cmake/Modules/Packages/KIM.cmake
+++ b/cmake/Modules/Packages/KIM.cmake
@@ -28,8 +28,8 @@ if(PKG_KIM)
       message(FATAL_ERROR "Compiling the KIM-API library requires a Fortran compiler")
     endif()
     ExternalProject_Add(kim_build
-      URL https://s3.openkim.org/kim-api/kim-api-2.1.2.txz
-      URL_MD5 6ac52e14ef52967fc7858220b208cba5
+      URL https://s3.openkim.org/kim-api/kim-api-2.1.3.txz
+      URL_MD5 6ee829a1bbba5f8b9874c88c4c4ebff8
       BINARY_DIR build
       CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/lib/kim/Install.py
+++ b/lib/kim/Install.py
@@ -18,7 +18,7 @@ parser = ArgumentParser(prog='Install.py',
 # settings
 
 thisdir = fullpath('.')
-version = "kim-api-2.1.2"
+version = "kim-api-2.1.3"
 
 # help message
 


### PR DESCRIPTION
**Summary**

bump kim-api to 2.1.3.  This release fixes some issues with building the kim-api with gfortran 4.8 and below.

**Related Issues**

none

**Author(s)**

Ryan S. Elliott (UMN)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

no

none

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

