### PR TITLE
Extend lib interface to allow setting fix external callbacks

### DIFF
--- a/examples/COUPLE/python/example.py
+++ b/examples/COUPLE/python/example.py
@@ -23,7 +23,7 @@ def callback(caller, ntimestep, nlocal, tag, x, fext):
     print("="*40)
 
 L = lammps.lammps()
-L.file("in.lammps")
+L.file("in.fix_external")
 
 # you can pass an arbitrary Python object to the callback every time it is called
 # this can be useful if you need more state information such as the LAMMPS ptr to

--- a/examples/COUPLE/python/example.py
+++ b/examples/COUPLE/python/example.py
@@ -1,0 +1,36 @@
+# this example requires the LAMMPS Python package (lammps.py) to be installed
+# and LAMMPS to be loadable as shared library in LD_LIBRARY_PATH
+
+import lammps
+
+def callback(caller, ntimestep, nlocal, tag, x, fext):
+    """
+    This callback receives a caller object that was setup when registering the callback
+
+    In addition to timestep and number of local atoms, the tag and x arrays are passed as
+    NumPy arrays. The fext array is a force array allocated for fix external, which
+    can be used to apply forces to all atoms. Simply update the value in the array,
+    it will be directly written into the LAMMPS C arrays
+    """
+    print("Data passed by caller (optional)", caller)
+    print("Timestep:", ntimestep)
+    print("Number of Atoms:", nlocal)
+    print("Atom Tags:", tag)
+    print("Atom Positions:", x)
+    print("Force Additions:", fext)
+    fext.fill(1.0)
+    print("Force additions after update:", fext)
+    print("="*40)
+
+L = lammps.lammps()
+L.file("in.lammps")
+
+# you can pass an arbitrary Python object to the callback every time it is called
+# this can be useful if you need more state information such as the LAMMPS ptr to
+# make additional library calls
+custom_object = ["Some data", L]
+
+L.set_fix_external_callback("2", callback, custom_object)
+L.command("run 100")
+
+

--- a/examples/COUPLE/python/in.fix_external
+++ b/examples/COUPLE/python/in.fix_external
@@ -1,0 +1,23 @@
+# LAMMPS input for coupling LAMMPS with Python via fix external
+
+units		metal
+dimension	3
+atom_style	atomic
+atom_modify	sort 0 0.0
+
+lattice		diamond 5.43
+region		box block 0 1 0 1 0 1
+create_box	1 box
+create_atoms	1 box
+mass		1 28.08
+
+velocity	all create 300.0 87293 loop geom
+
+fix		1 all nve
+fix		2 all external pf/callback 1 1
+
+#dump		2 all image 25 image.*.jpg type type &
+#		axes yes 0.8 0.02 view 60 -30
+#dump_modify	2 pad 3
+
+thermo		1

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1606,6 +1606,11 @@ void lammps_create_atoms(void *ptr, int n, tagint *id, int *type,
   END_CAPTURE
 }
 
+/* ----------------------------------------------------------------------
+   find fix external with given ID and set the callback function
+   and caller pointer
+------------------------------------------------------------------------- */
+
 void lammps_set_fix_external_callback(void *ptr, char *id, FixExternalFnPtr callback_ptr, void * caller)
 {
   LAMMPS *lmp = (LAMMPS *) ptr;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1596,7 +1596,7 @@ void lammps_create_atoms(void *ptr, int n, tagint *id, int *type,
 
     if (lmp->atom->natoms != natoms_prev + n) {
       char str[128];
-      sprintf(str,"Library warning in lammps_create_atoms, "
+      snprintf(str, 128, "Library warning in lammps_create_atoms, "
               "invalid total atoms " BIGINT_FORMAT " " BIGINT_FORMAT,
               lmp->atom->natoms,natoms_prev+n);
       if (lmp->comm->me == 0)
@@ -1621,7 +1621,7 @@ void lammps_set_fix_external_callback(void *ptr, char *id, FixExternalFnPtr call
     int ifix = lmp->modify->find_fix(id);
     if (ifix < 0) {
       char str[50];
-      sprintf(str, "Can not find fix with ID '%s'!", id);
+      snprintf(str, 50, "Can not find fix with ID '%s'!", id);
       lmp->error->all(FLERR,str);
     }
 
@@ -1629,7 +1629,7 @@ void lammps_set_fix_external_callback(void *ptr, char *id, FixExternalFnPtr call
 
     if (strcmp("external",fix->style) != 0){
       char str[50];
-      sprintf(str, "Fix '%s' is not of style external!", id);
+      snprintf(str, 50, "Fix '%s' is not of style external!", id);
       lmp->error->all(FLERR,str);
     }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1620,16 +1620,16 @@ void lammps_set_fix_external_callback(void *ptr, char *id, FixExternalFnPtr call
   {
     int ifix = lmp->modify->find_fix(id);
     if (ifix < 0) {
-      char str[50];
-      snprintf(str, 50, "Can not find fix with ID '%s'!", id);
+      char str[128];
+      snprintf(str, 128, "Can not find fix with ID '%s'!", id);
       lmp->error->all(FLERR,str);
     }
 
     Fix *fix = lmp->modify->fix[ifix];
 
     if (strcmp("external",fix->style) != 0){
-      char str[50];
-      snprintf(str, 50, "Fix '%s' is not of style external!", id);
+      char str[128];
+      snprintf(str, 128, "Fix '%s' is not of style external!", id);
       lmp->error->all(FLERR,str);
     }
 

--- a/src/library.h
+++ b/src/library.h
@@ -58,6 +58,14 @@ void lammps_gather_atoms_subset(void *, char *, int, int, int, int *, void *);
 void lammps_scatter_atoms(void *, char *, int, int, void *);
 void lammps_scatter_atoms_subset(void *, char *, int, int, int, int *, void *);
 
+#ifdef LAMMPS_BIGBIG
+typedef void (*FixExternalFnPtr)(void *, int64_t, int, int64_t *, double **, double **);
+void lammps_set_fix_external_callback(void *, char *, FixExternalFnPtr, void*);
+#else
+typedef void (*FixExternalFnPtr)(void *, int, int, int *, double **, double **);
+void lammps_set_fix_external_callback(void *, char *, FixExternalFnPtr, void*);
+#endif
+
 int lammps_config_has_package(char * package_name);
 int lammps_config_package_count();
 int lammps_config_package_name(int index, char * buffer, int max_size);


### PR DESCRIPTION
**Summary**

This allows creating a callback in Python and attaching it to a fix external instance.

**Author(s)**
@rbberger (Temple University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

Uses CTypes to implement the callback. For simplicity, it also requires NumPy if you use this functionality from Python interface.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included