### PR TITLE
Adjusted compute_bond_local to allow components of force to be obtained. 

### DIFF
--- a/doc/src/compute_bond_local.txt
+++ b/doc/src/compute_bond_local.txt
@@ -15,10 +15,11 @@ compute ID group-ID bond/local value1 value2 ... keyword args ... :pre
 ID, group-ID are documented in "compute"_compute.html command :ulb,l
 bond/local = style name of this compute command :l
 one or more values may be appended :l
-value = {dist} or {engpot} or {force} or {engvib} or {engrot} or {engtrans} or {omega} or {velvib} or {v_name} :l
+value = {dist} or {engpot} or {force} or {fx} or {fy} or {fz} or {engvib} or {engrot} or {engtrans} or {omega} or {velvib} or {v_name} :l
   {dist} = bond distance
   {engpot} = bond potential energy
   {force} = bond force :pre
+  {fx},{fy},{fz} = components of bond force
   {engvib} = bond kinetic energy of vibration
   {engrot} = bond kinetic energy of rotation
   {engtrans} = bond kinetic energy of translation
@@ -38,6 +39,7 @@ keyword = {set} :l
 
 compute 1 all bond/local engpot
 compute 1 all bond/local dist engpot force :pre
+compute 1 all bond/local dist fx fy fz :pre
 compute 1 all angle/local dist v_distsq set dist d :pre
 
 [Description:]
@@ -58,6 +60,9 @@ based on the current separation of the pair of atoms in the bond.
 
 The value {force} is the magnitude of the force acting between the
 pair of atoms in the bond.
+
+The values {fx}, {fy}, and {fz} are the xyz components of
+{force} between the pair of atoms in the bond.
 
 The remaining properties are all computed for motion of the two atoms
 relative to the center of mass (COM) velocity of the 2 atoms in the

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -405,6 +405,7 @@ int ComputeBondLocal::compute_bonds(int flag)
             break;
           case FZ:
             ptr[n] = dz*fbond;
+            break;
           case ENGVIB:
             ptr[n] = engvib;
             break;

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -33,7 +33,7 @@ using namespace LAMMPS_NS;
 #define DELTA 10000
 #define EPSILON 1.0e-12
 
-enum{DIST,VELVIB,OMEGA,ENGTRANS,ENGVIB,ENGROT,ENGPOT,FORCE,VARIABLE};
+enum{DIST,VELVIB,OMEGA,ENGTRANS,ENGVIB,ENGROT,ENGPOT,FORCE,FX,FY,FZ,VARIABLE};
 
 /* ---------------------------------------------------------------------- */
 
@@ -64,6 +64,9 @@ ComputeBondLocal::ComputeBondLocal(LAMMPS *lmp, int narg, char **arg) :
     if (strcmp(arg[iarg],"dist") == 0) bstyle[nvalues++] = DIST;
     else if (strcmp(arg[iarg],"engpot") == 0) bstyle[nvalues++] = ENGPOT;
     else if (strcmp(arg[iarg],"force") == 0) bstyle[nvalues++] = FORCE;
+    else if (strcmp(arg[iarg],"fx") == 0) bstyle[nvalues++] = FX;
+    else if (strcmp(arg[iarg],"fy") == 0) bstyle[nvalues++] = FY;
+    else if (strcmp(arg[iarg],"fz") == 0) bstyle[nvalues++] = FZ;
     else if (strcmp(arg[iarg],"engvib") == 0) bstyle[nvalues++] = ENGVIB;
     else if (strcmp(arg[iarg],"engrot") == 0) bstyle[nvalues++] = ENGROT;
     else if (strcmp(arg[iarg],"engtrans") == 0) bstyle[nvalues++] = ENGTRANS;
@@ -127,7 +130,8 @@ ComputeBondLocal::ComputeBondLocal(LAMMPS *lmp, int narg, char **arg) :
   singleflag = 0;
   velflag = 0;
   for (int i = 0; i < nvalues; i++) {
-    if (bstyle[i] == ENGPOT || bstyle[i] == FORCE) singleflag = 1;
+    if (bstyle[i] == ENGPOT || bstyle[i] == FORCE || bstyle[i] == FX       || 
+        bstyle[i] == FY     || bstyle[i] == FZ) singleflag = 1;
     if (bstyle[i] == VELVIB || bstyle[i] == OMEGA || bstyle[i] == ENGTRANS ||
         bstyle[i] == ENGVIB || bstyle[i] == ENGROT) velflag = 1;
   }
@@ -393,6 +397,14 @@ int ComputeBondLocal::compute_bonds(int flag)
           case FORCE:
             ptr[n] = sqrt(rsq)*fbond;
             break;
+          case FX:
+            ptr[n] = dx*fbond;
+            break;
+          case FY:
+            ptr[n] = dy*fbond;
+            break;
+          case FZ:
+            ptr[n] = dz*fbond;
           case ENGVIB:
             ptr[n] = engvib;
             break;


### PR DESCRIPTION
**Summary**

Added components to compute_bond_local which is required for a number of cases, which include
    - transient time correlation function (TTCF) calculation
    - Forces on tethered walls to get component applied when shearing or using for barostat

A simple addition (enhancement) to the core code so should have minimum impact.

**Related Issues**
N/A

**Author(s)**

Edward Smith, Lecturer at University of Brunel, London 
edward.smith@brunel.ac.uk
Long term contacts:
website www.edwardsmith.ac.uk
edwardsmith999@hotmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
No expected issues

**Implementation Notes**

The documentation and src code changes are exactly based on functionality in compute_pair_local so should be in correct format. Compiles correctly.

**Post Submission Checklist**

- [x ] The feature or features in this pull request is complete
- [ x] Licensing information is complete
- [x ] Corresponding author information is complete
- [x ] The source code follows the LAMMPS formatting guidelines
- [x ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [x ] One or more example input decks are included



