### PR TITLE
Implement test for C++11 and document it

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -52,8 +52,15 @@ check_for_autogen_files(${LAMMPS_SOURCE_DIR})
 include(CheckCCompilerFlag)
 include(CheckIncludeFileCXX)
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -restrict")
+endif()
+
+option(DISABLE_CXX11_REQUIREMENT "Disable check that requires C++11 for compiling LAMMPS" OFF)
+if(DISABLE_CXX11_REQUIREMENT)
+  add_definitions(-DLAMMPS_CXX98)
+else()
+  set(CMAKE_CXX_STANDARD 11)
 endif()
 
 # GNU compiler features

--- a/doc/src/Build_settings.txt
+++ b/doc/src/Build_settings.txt
@@ -12,6 +12,7 @@ Optional build settings :h3
 LAMMPS can be built with several optional settings.  Each sub-section
 explain how to do this for building both with CMake and make.
 
+"C++11 standard compliance test"_#cxx11 when building all of LAMMPS
 "FFT library"_#fft for use with the "kspace_style pppm"_kspace_style.html command
 "Size of LAMMPS data types"_#size
 "Read or write compressed files"_#gzip
@@ -20,6 +21,28 @@ explain how to do this for building both with CMake and make.
 "Memory allocation alignment"_#align
 "Workaround for long long integers"_#longlong
 "Error handling exceptions"_#exceptions when using LAMMPS as a library :all(b)
+
+:line
+
+C++11 standard compliance test :h4(cxx11)
+
+The LAMMPS developers plan to transition to make the C++11 standard the
+minimum requirement for compiling LAMMPS.  Currently this only applies to
+some packages like KOKKOS while the rest aims to be compatible with the C++98
+standard.  Most currently used compilers are compatible with C++11; some need
+to set extra flags to switch.  To determine the impact of requiring C++11,
+we have added a simple compliance test to the source code, that will cause
+the compilation to abort, if C++11 compliance is not available or enabled.
+To bypass this check, you need to change a setting in the makefile or
+when calling CMake.
+
+[CMake variable]:
+
+-D DISABLE_CXX11_REQUIREMENT=yes
+
+[Makefile.machine setting]:
+
+LMP_INC = -DLAMMPS_CXX98
 
 :line
 

--- a/doc/src/Build_settings.txt
+++ b/doc/src/Build_settings.txt
@@ -24,7 +24,7 @@ explain how to do this for building both with CMake and make.
 
 :line
 
-C++11 standard compliance test :h4(cxx11)
+C++11 standard compliance test :h4,link(cxx11)
 
 The LAMMPS developers plan to transition to make the C++11 standard the
 minimum requirement for compiling LAMMPS.  Currently this only applies to

--- a/src/MAKE/Makefile.mpi
+++ b/src/MAKE/Makefile.mpi
@@ -26,12 +26,12 @@ SHLIBFLAGS =	-shared
 # if you change any -D setting, do full re-compile after "make clean"
 
 # LAMMPS ifdef settings
-# see possible settings in Section 2.2 (step 4) of manual
+# see possible settings in Section 3.5 of the manual
 
-LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64
+LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64  # -DLAMMPS_CXX98
 
 # MPI library
-# see discussion in Section 2.2 (step 5) of manual
+# see discussion in Section 3.4 of the manual
 # MPI wrapper compiler/linker can provide this info
 # can point to dummy MPI library in src/STUBS as in Makefile.serial
 # use -D MPICH and OMPI settings in INC to avoid C++ lib conflicts

--- a/src/MAKE/Makefile.serial
+++ b/src/MAKE/Makefile.serial
@@ -26,12 +26,12 @@ SHLIBFLAGS =	-shared
 # if you change any -D setting, do full re-compile after "make clean"
 
 # LAMMPS ifdef settings
-# see possible settings in Section 2.2 (step 4) of manual
+# see possible settings in Section 3.5 of the manual
 
-LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64
+LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64  # -DLAMMPS_CXX98
 
 # MPI library
-# see discussion in Section 2.2 (step 5) of manual
+# see discussion in Section 3.4 of the manual
 # MPI wrapper compiler/linker can provide this info
 # can point to dummy MPI library in src/STUBS as in Makefile.serial
 # use -D MPICH and OMPI settings in INC to avoid C++ lib conflicts

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -444,6 +444,19 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((universe->me == 0) && !helpflag) {
       if (screen) fprintf(screen,"LAMMPS (%s)\n",universe->version);
       if (logfile) fprintf(logfile,"LAMMPS (%s)\n",universe->version);
+#if defined(LAMMPS_CXX98)
+      const char warning[] = "\nWARNING-WARNING-WARNING-WARNING-WARNING\n"
+        "This LAMMPS executable was compiled using C++98 compatibility.\n"
+        "Please report the compiler info below at https://github.com/lammps/lammps/issues/1659\n";
+      const char *infobuf = Info::get_compiler_info();
+      if (screen)
+         fprintf(screen,"%s%s\nWARNING-WARNING-WARNING-WARNING-WARNING\n\n",
+                 warning,infobuf);
+      if (logfile)
+         fprintf(logfile,"%s%s\nWARNING-WARNING-WARNING-WARNING-WARNING\n\n",
+                 warning,infobuf);
+      delete[] infobuf;
+#endif
     }
 
   // universe is one or more worlds, as setup by partition switch

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -28,6 +28,13 @@
 #ifndef LMP_LMPTYPE_H
 #define LMP_LMPTYPE_H
 
+// C++11 check
+#ifndef LAMMPS_CXX98
+#if __cplusplus <= 199711L
+  #error LAMMPS is planning to transition to C++11. Do disable this error please use a C++11 compliant compiler, enable C++11 (or later) compliance, or define LAMMPS_CXX98 in your makefile
+#endif
+#endif
+
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif


### PR DESCRIPTION
**Summary**

This adds a test to lmptype.h that checks for C++11 compatibility of the compiler.
Some short explanation is added to the documentation (to be removed when C++11 becomes a requirement) and a corresponding variable is added to CMakeLists.txt and (commented out) defines to Makefile.mpi and Makefile.serial

**Related Issues**

See issue #1659 for further discussions and summaries of this topic.

**Author(s)**

Axel Kohlmeyer

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

User action is required to recover compilation with non-C++11 compilers. This is intentional to gauge how large the impact of requiring C++11 for a future stable release will be.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

