### PR TITLE
Correct the title information of "lammps/examples/gcmc/H2O.txt" file

### DIFF
--- a/examples/gcmc/H2O.txt
+++ b/examples/gcmc/H2O.txt
@@ -1,4 +1,4 @@
-# CO2 molecule file. TraPPE model.
+# H2O molecule file. SPC/E model.
 
 3 atoms
 2 bonds


### PR DESCRIPTION
The first line of the "lammps/examples/gcmc/H2O.txt" file falsly states that it is for CO2. It should be replaced to  
# H2O molecule file. SPC/E model.


