### PR TITLE
Bug correction in the SPIN package, and fix nve/spin option modification

### DIFF
--- a/doc/src/fix_langevin_spin.txt
+++ b/doc/src/fix_langevin_spin.txt
@@ -50,7 +50,7 @@ As an example:
 
 fix 1 all precession/spin zeeman 0.01 0.0 0.0 1.0
 fix 2 all langevin/spin 300.0 0.01 21
-fix 3 all nve/spin lattice yes :pre
+fix 3 all nve/spin lattice moving :pre
 
 is correct, but defining a force/spin command after the langevin/spin command
 would give an error message.

--- a/doc/src/fix_nve_spin.txt
+++ b/doc/src/fix_nve_spin.txt
@@ -15,22 +15,26 @@ fix ID group-ID nve/spin keyword values :pre
 ID, group-ID are documented in "fix"_fix.html command :ulb,l
 nve/spin = style name of this fix command :l
 keyword = {lattice} :l
-  {lattice} value = {no} or {yes} :pre
+  {lattice} value = {moving} or {frozen}
+    moving = integrate both spin and atomic degress of freedom
+    frozen = integrate spins on a fixed lattice :pre
 :ule
 
 [Examples:]
 
-fix 3 all nve/spin lattice yes
-fix 1 all nve/spin lattice no :pre
+fix 3 all nve/spin lattice moving
+fix 1 all nve/spin lattice frozen :pre
 
 [Description:]
 
 Perform a symplectic integration for the spin or spin-lattice system.
 
 The {lattice} keyword defines if the spins are integrated on a lattice
-of fixed atoms (lattice = no), or if atoms are moving (lattice = yes).
-
-By default (lattice = yes), a spin-lattice integration is performed.
+of fixed atoms (lattice = frozen), or if atoms are moving
+(lattice = moving).
+The first case corresponds to a spin dynamics calculation, and
+the second to a spin-lattice calculation.
+By default a spin-lattice integration is performed (lattice = moving).
 
 The {nve/spin} fix applies a Suzuki-Trotter decomposition to
 the equations of motion of the spin lattice system, following the scheme:
@@ -63,7 +67,9 @@ instead of "array" is also valid.
 
 "atom_style spin"_atom_style.html, "fix nve"_fix_nve.html
 
-[Default:] none
+[Default:] 
+
+The option default is lattice = moving.
 
 :line
 

--- a/examples/SPIN/bfo/in.spin.bfo
+++ b/examples/SPIN/bfo/in.spin.bfo
@@ -32,7 +32,7 @@ neigh_modify 	every 10 check yes delay 20
 
 fix 		1 all precession/spin anisotropy 0.0000033 0.0 0.0 1.0
 fix 		2 all langevin/spin 0.0 0.1 21
-fix 		3 all nve/spin lattice no
+fix 		3 all nve/spin lattice frozen
 
 timestep	0.0002
 

--- a/examples/SPIN/cobalt_fcc/in.spin.cobalt_fcc
+++ b/examples/SPIN/cobalt_fcc/in.spin.cobalt_fcc
@@ -35,7 +35,7 @@ fix_modify 	1 energy yes
 
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/cobalt_hcp/in.spin.cobalt_hcp
+++ b/examples/SPIN/cobalt_hcp/in.spin.cobalt_hcp
@@ -37,7 +37,7 @@ neigh_modify 	every 10 check yes delay 20
 fix 		1 all precession/spin anisotropy 0.01 0.0 0.0 1.0
 #fix 		2 all langevin/spin 0.0 0.0 21
 fix 		2 all langevin/spin 0.0 0.1 21
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 
 timestep	0.0001
 

--- a/examples/SPIN/dipole_spin/in.spin.iron_dipole_cut
+++ b/examples/SPIN/dipole_spin/in.spin.iron_dipole_cut
@@ -33,7 +33,7 @@ fix 		1 all precession/spin cubic 0.001 0.0005 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1
 fix_modify 	1 energy yes
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/dipole_spin/in.spin.iron_dipole_ewald
+++ b/examples/SPIN/dipole_spin/in.spin.iron_dipole_ewald
@@ -35,7 +35,7 @@ fix 		1 all precession/spin cubic 0.001 0.0005 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1
 fix_modify 	1 energy yes
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/dipole_spin/in.spin.iron_dipole_pppm
+++ b/examples/SPIN/dipole_spin/in.spin.iron_dipole_pppm
@@ -36,7 +36,7 @@ fix 		1 all precession/spin cubic 0.001 0.0005 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1
 fix_modify 	1 energy yes
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/iron/in.spin.iron
+++ b/examples/SPIN/iron/in.spin.iron
@@ -33,7 +33,7 @@ neigh_modify 	every 10 check yes delay 20
 fix 		1 all precession/spin zeeman 0.0 0.0 0.0 1.0
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/iron/in.spin.iron_cubic
+++ b/examples/SPIN/iron/in.spin.iron_cubic
@@ -31,7 +31,7 @@ fix 		1 all precession/spin cubic 0.001 0.0005 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1
 fix_modify 	1 energy yes
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/nickel/in.spin.nickel
+++ b/examples/SPIN/nickel/in.spin.nickel
@@ -33,7 +33,7 @@ neigh_modify 	every 10 check yes delay 20
 fix 		1 all precession/spin zeeman 0.0 0.0 0.0 1.0
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/nickel/in.spin.nickel_cubic
+++ b/examples/SPIN/nickel/in.spin.nickel_cubic
@@ -35,7 +35,7 @@ fix 		1 all precession/spin cubic -0.0001 0.0 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.
 fix_modify 	1 energy yes
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/read_restart/in.spin.read_data
+++ b/examples/SPIN/read_restart/in.spin.read_data
@@ -20,7 +20,7 @@ neigh_modify 	every 1 check no delay 0
 fix 		1 all precession/spin zeeman 0.0 0.0 0.0 1.0
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # define outputs and computes

--- a/examples/SPIN/read_restart/in.spin.restart
+++ b/examples/SPIN/read_restart/in.spin.restart
@@ -24,7 +24,7 @@ neigh_modify 	every 1 check no delay 0
 fix 		1 all precession/spin zeeman 0.0 0.0 0.0 1.0
 fix 		2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice yes
+fix 		3 all nve/spin lattice moving
 timestep	0.0001
 
 # define outputs

--- a/examples/SPIN/read_restart/in.spin.write_restart
+++ b/examples/SPIN/read_restart/in.spin.write_restart
@@ -29,7 +29,7 @@ neigh_modify 	every 10 check yes delay 20
 fix 		1 all precession/spin zeeman 0.0 0.0 0.0 1.0
 fix 		2 all langevin/spin 100.0 0.01 21
 
-fix 		3 all nve/spin lattice no
+fix 		3 all nve/spin lattice frozen
 timestep	0.0001
 
 # compute and output options

--- a/examples/SPIN/setforce_spin/in.spinmin.setforce
+++ b/examples/SPIN/setforce_spin/in.spinmin.setforce
@@ -35,7 +35,7 @@ fix 		1 all precession/spin zeeman 0.0 0.0 0.0 1.0 anisotropy 5e-05 0.0 0.0 1.0
 fix_modify	1 energy yes
 fix 		2 fixed_spin setforce/spin 0.0 0.0 0.0
 fix 		3 all langevin/spin 0.0 0.1 21
-fix		4 all nve/spin lattice no 
+fix		4 all nve/spin lattice frozen 
 
 timestep	0.0001
 

--- a/src/SPIN/fix_nve_spin.cpp
+++ b/src/SPIN/fix_nve_spin.cpp
@@ -91,12 +91,17 @@ FixNVESpin::FixNVESpin(LAMMPS *lmp, int narg, char **arg) :
 
   // defining lattice_flag
 
+  // changing the lattice option, from (yes,no) -> (moving,frozen)
+  // for now, (yes,no) still works (to avoid user's confusions).
+
   int iarg = 3;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"lattice") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix/NVE/spin command");
       if (strcmp(arg[iarg+1],"no") == 0) lattice_flag = 0;
+      else if (strcmp(arg[iarg+1],"frozen") == 0) lattice_flag = 0;
       else if (strcmp(arg[iarg+1],"yes") == 0) lattice_flag = 1;
+      else if (strcmp(arg[iarg+1],"moving") == 0) lattice_flag = 1;
       else error->all(FLERR,"Illegal fix/NVE/spin command");
       iarg += 2;
     } else error->all(FLERR,"Illegal fix/NVE/spin command");

--- a/src/SPIN/pair_spin_exchange.cpp
+++ b/src/SPIN/pair_spin_exchange.cpp
@@ -504,7 +504,7 @@ void PairSpinExchange::read_restart(FILE *fp)
           fread(&J1_mag[i][j],sizeof(double),1,fp);
           fread(&J1_mech[i][j],sizeof(double),1,fp);
           fread(&J2[i][j],sizeof(double),1,fp);
-          fread(&J2[i][j],sizeof(double),1,fp);
+          fread(&J3[i][j],sizeof(double),1,fp);
           fread(&cut_spin_exchange[i][j],sizeof(double),1,fp);
         }
         MPI_Bcast(&J1_mag[i][j],1,MPI_DOUBLE,0,world);

--- a/src/SPIN/pair_spin_neel.cpp
+++ b/src/SPIN/pair_spin_neel.cpp
@@ -643,9 +643,7 @@ void PairSpinNeel::allocate()
   memory->create(q3,n+1,n+1,"pair/spin/soc/neel:q3");
 
   memory->create(cutsq,n+1,n+1,"pair/spin/soc/neel:cutsq");
-
 }
-
 
 /* ----------------------------------------------------------------------
    proc 0 writes to restart file

--- a/src/SPIN/pair_spin_neel.cpp
+++ b/src/SPIN/pair_spin_neel.cpp
@@ -694,11 +694,11 @@ void PairSpinNeel::read_restart(FILE *fp)
           fread(&g1[i][j],sizeof(double),1,fp);
           fread(&g1_mech[i][j],sizeof(double),1,fp);
           fread(&g2[i][j],sizeof(double),1,fp);
-          fread(&g2[i][j],sizeof(double),1,fp);
+          fread(&g3[i][j],sizeof(double),1,fp);
           fread(&q1[i][j],sizeof(double),1,fp);
           fread(&q1_mech[i][j],sizeof(double),1,fp);
           fread(&q2[i][j],sizeof(double),1,fp);
-          fread(&q2[i][j],sizeof(double),1,fp);
+          fread(&q3[i][j],sizeof(double),1,fp);
           fread(&cut_spin_neel[i][j],sizeof(double),1,fp);
         }
         MPI_Bcast(&g1[i][j],1,MPI_DOUBLE,0,world);


### PR DESCRIPTION
**Summary**

This PR corrects issues in the read_restart methods in src/SPIN/pair_spin_exchange and src/SPIN/pair_spin_neel.
It also modifies the lattice option in fix nve/spin. The _lattice_ option choices are modified from (yes/no) to (moving/frozen).

**Related Issues**

Bug in read_restart of src/SPIN/pair_spin_exchange and src/SPIN/pair_spin_neel.
Clarification of the possible options for fix nve/spin

**Author(s)**

Julien Tranchida, jtranch@sandia.gov

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

For the fix nve/spin option modification, the old option (yes/no) is still valid for now (although no longer documented).

**Implementation Notes**

All examples were modified (from yes/no to moving/frozen) and reran. 

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**
