### PR TITLE
Fixed error in neighbor distance check for box dimensions

### DIFF
--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -1941,6 +1941,7 @@ int Neighbor::decide()
    conservative shrink procedure:
      compute distance each of 8 corners of box has moved since last reneighbor
      reduce skin distance by sum of 2 largest of the 8 values
+     if reduced skin distance is negative, set to zero 
      new trigger = 1/2 of reduced skin distance
    for orthogonal box, only need 2 lo/hi corners
    for triclinic, need all 8 corners since deformations can displace all 8
@@ -1962,6 +1963,7 @@ int Neighbor::check_distance()
       delz = bboxhi[2] - boxhi_hold[2];
       delta2 = sqrt(delx*delx + dely*dely + delz*delz);
       delta = 0.5 * (skin - (delta1+delta2));
+      if (delta < 0.0) delta = 0.0; 
       deltasq = delta*delta;
     } else {
       domain->box_corners();
@@ -1975,6 +1977,7 @@ int Neighbor::check_distance()
         else if (delta > delta2) delta2 = delta;
       }
       delta = 0.5 * (skin - (delta1+delta2));
+      if (delta < 0.0) delta = 0.0; 
       deltasq = delta*delta;
     }
   } else deltasq = triggersq;


### PR DESCRIPTION
**Summary**

This fixes an error in the reneighboring criterion for changes in box dimensions that was causing neighbor lists to be out of date.  For large changes in box dimensions or small skin distance, the reduced skin distance is negative, producing in a positive value of deltasq. The correct value in this case is deltasq=0. 
 
**Related Issues**

None

**Author(s)**

@athomps. Thanks to Randy Hood for noticing this.

**Licensing**

N/A

**Backward Compatibility**

No change to user interface

**Implementation Notes**

N/A

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


