### PR TITLE
New example/UNITS dir

### DIFF
--- a/doc/src/Examples.txt
+++ b/doc/src/Examples.txt
@@ -141,6 +141,7 @@ HEAT: compute thermal conductivity for LJ and water via fix ehex
 KAPPA: compute thermal conductivity via several methods
 MC: using LAMMPS in a Monte Carlo mode to relax the energy of a system
 SPIN: examples for features of the SPIN package
+UNITS: examples that run the same simulation in lj, real, metal units
 USER: examples for USER packages and USER-contributed commands
 VISCOSITY: compute viscosity via several methods :tb(s=:)
 

--- a/examples/README
+++ b/examples/README
@@ -76,6 +76,7 @@ ellipse:  ellipsoidal particles in spherical solvent, 2d system
 flow:     Couette and Poiseuille flow in a 2d channel
 friction: frictional contact of spherical asperities between 2d surfaces
 gcmc:     Grand Canonical Monte Carlo (GCMC) via the fix gcmc command
+gjf:      use of fix langevin Gronbech-Jensen/Farago option
 granregion: use of fix wall/region/gran as boundary on granular particles
 hugoniostat: Hugoniostat shock dynamics
 hyper:    global and local hyperdynamics of diffusion on Pt surface
@@ -162,6 +163,12 @@ the KAPPA/README file for more info.
 The MC directory has an example script for using LAMMPS as an
 energy-evaluation engine in a iterative Monte Carlo energy-relaxation
 loop.
+
+The UNITS directory contains examples of input scripts modeling the
+same Lennard-Jones liquid model, written in 3 different unit systems:
+lj, real, and metal.  So that you can see how to scale/unscale input
+and output values read/written by LAMMPS to verify you are performing
+the same simulation in different unit systems.
 
 The USER directory contains subdirectories of user-provided example
 scripts for ser packages.  See the README files in those directories

--- a/examples/UNITS/README
+++ b/examples/UNITS/README
@@ -33,15 +33,20 @@ unscaled back to LJ units.  So that you can see the outputs are the
 same if you examine the log files.  Comments about this comparison
 are at the bottom of the real and metal scripts.
 
-If you understand LJ reduced units (see Allen & Tildesley's Computer
-Simulation of Liquids, Appendix B for a nice discussion), and you
-study these scripts, you should be able to convert an input script in
-one set of units to an identical input script in an alternate set of
-units.  Where "identical" means it runs the same simulation in a
-statistical sense.  For example you could easily define conversion
-factors from real to metal units or vice versa, and use them to scale
-inputs and outputs in one script to produce a script in alternate
-units.
+These 3 scripts are provided, because converting from lj reduced units
+to physical units (e.g. real or metal) or vice versa is the trickiest
+case.  Converting input scripts between 2 sets of physical units
+(e.g. reak <--> metal) is much easier.  But you can use the same ideas
+as in these scripts; just define a set of scale/unscale factors.
+
+See Allen & Tildesley's Computer Simulation of Liquids, Appendix B for
+a nice discussion of reduced units.  It will explain the conversion
+formulas used in the real and metal scripts.
+
+Hopefully, if you study these scripts, you should be able to convert
+an input script of your own, written in one set of units, to an
+identical input script in an alternate set of units.  Where
+"identical" means it runs the same simulation in a statistical sense.
 
 You can find the full set of scale factors LAMMPS uses internally for
 different unit systems it supports, at the top of the src/udpate.cpp

--- a/examples/UNITS/README
+++ b/examples/UNITS/README
@@ -1,0 +1,49 @@
+This directory has 3 scripts which show how to run the same problem
+using the 3 most common units system used in LAMMPS: lj, real, and
+metal units.  As stated on the units command doc page:
+
+"Any simulation you perform for one choice of units can be duplicated
+with any other unit setting LAMMPS supports. ...  To perform the same
+simulation in a different set of units you must change all the
+unit-based input parameters in your input script and other input files
+(data file, potential files, etc) correctly to the new units.  And you
+must correctly convert all output from the new units to the old units
+when comparing to the original results.  That is often not simple to
+do."
+
+These examples are meant to illustrate how to do this for a simple
+Lennard-Jones liquid (argon).  All of the scripts have a set of
+variables defined at the top which can be changed as command line
+arguments (e.g. -v cutoff 3.0).  All 3 scripts give identical output,
+modulo round-offs due to the finite precision of the conversion
+factors used, either internally in LAMMPS or in the scripts.  If there
+were run for a long time, the trajectories would diverge, but they
+would still give statistically identical results.
+
+The LJ script is the simplest; it is similar to the bench/in.lj
+script.
+
+The real and metal scripts each have a set of variables at the top
+which define scale factors for converting quantities like distance,
+energy, pressure from reduced LJ units to real or metal units.  Once
+these are defined the rest of the input script is very similar to the
+LJ script.  The approprate scale factor is applied to every input.
+Output quantities are printed in both the native real/metal units and
+unscaled back to LJ units.  So that you can see the outputs are the
+same if you examine the log files.  Comments about this comparison
+are at the bottom of the real and metal scripts.
+
+If you understand LJ reduced units (see Allen & Tildesley's Computer
+Simulation of Liquids, Appendix B for a nice discussion), and you
+study these scripts, you should be able to convert an input script in
+one set of units to an identical input script in an alternate set of
+units.  Where "identical" means it runs the same simulation in a
+statistical sense.  For example you could easily define conversion
+factors from real to metal units or vice versa, and use them to scale
+inputs and outputs in one script to produce a script in alternate
+units.
+
+You can find the full set of scale factors LAMMPS uses internally for
+different unit systems it supports, at the top of the src/udpate.cpp
+file.  A couple of those values are used in the real and metal
+scripts.

--- a/examples/UNITS/in.ar.lj
+++ b/examples/UNITS/in.ar.lj
@@ -1,0 +1,43 @@
+# Ar in lj units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon = sigma = mass = 1.0
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# script
+
+units		lj
+atom_style	atomic
+
+lattice		fcc ${rhostar}
+region		box block 0 $x 0 $y 0 $z
+create_box	1 box
+create_atoms	1 box
+mass		1 1.0
+
+velocity	all create ${tinitial} 12345
+
+pair_style	lj/cut ${cutoff}
+pair_coeff	1 1 1.0 1.0
+
+neighbor	${skin} bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	${dt}
+
+thermo		10
+
+run		100

--- a/examples/UNITS/in.ar.metal
+++ b/examples/UNITS/in.ar.metal
@@ -1,0 +1,98 @@
+# Ar in metal units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon, sigma, mass set below
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# physical constants from update.cpp
+
+variable        kb index 8.617343e-5          # kB in eV/K
+variable        avogadro index 6.02214129e23  # Avogadro's number
+
+# Ar properties in metal units
+
+variable        epskb index 117.7             # LJ epsilon/kB in degrees K
+variable        sigma index 3.504             # LJ sigma in Angstroms
+variable        epsilon equal ${epskb}*${kb}  # LJ epsilon in eV
+variable        mass index 39.95              # mass in g/mole
+
+# scale factors
+
+# sigma = scale factor on distance, converts reduced distance to Angs
+# epsilon = scale factor on energy, converts reduced energy to eV
+# tmpscale = scale factor on temperature, converts reduced temp to degrees K
+# tscale = scale factor on time, converts reduced time to ps
+#   formula is t = t* / sqrt(epsilon/mass/sigma^2), but need t in fs
+#   use epsilon (Joule), mass (kg/atom), sigma (meter) to get t in seconds
+# pscale = scale factor on pressure, converts reduced pressure to bars
+#   formula is P = P* / (sigma^3/epsilon), but need P in atmospheres
+#   use sigma (meter), epsilon (Joule) to get P in nt/meter^2, convert to bars
+
+variable        eVtoJoule index 1.602e-19     # convert eV to Joules
+variable        NtMtoAtm equal 1.0e-5         # convert Nt/meter^2 to bars
+
+variable        tmpscale equal ${epskb}
+variable        epsilonJ equal ${epsilon}*${eVtoJoule}
+variable        massKgAtom equal ${mass}/1000.0/${avogadro}
+variable        sigmaM equal ${sigma}/1.0e10
+variable        sigmaMsq equal ${sigmaM}*${sigmaM}
+variable        tscale equal 1.0e12/sqrt(${epsilonJ}/${massKgAtom}/${sigmaMsq})
+variable        sigmaM3 equal ${sigmaM}*${sigmaM}*${sigmaM}
+variable        pscale equal ${NtMtoAtm}/(${sigmaM3}/(${epsilonJ}))
+
+# variables
+# alat = lattice constant in Angs (at reduced density rhostar)
+# temp = reduced temperature for output
+# epair,emol,etotal = reduced epair,emol,etotal energies for output
+# press = reduced pressure for output
+
+variable        alat equal (4.0*${sigma}*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        temp equal temp/${tmpscale}
+variable        epair equal epair/${epsilon}
+variable        emol equal emol/${epsilon}
+variable        etotal equal etotal/${epsilon}
+variable        press equal press/${pscale}
+
+# same script as in.ar.lj
+
+units		metal
+atom_style	atomic
+
+lattice		fcc ${alat}
+region		box block 0 $x 0 $y 0 $z
+create_box	1 box
+create_atoms	1 box
+mass		1 ${mass}
+
+velocity	all create $(v_tinitial*v_epskb) 12345
+
+pair_style	lj/cut $(v_cutoff*v_sigma)
+pair_coeff	1 1 ${epsilon} ${sigma}
+
+neighbor	$(v_skin*v_sigma) bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	$(v_dt*v_tscale)
+
+# columns 2,3,4 = temp,pe,press in metal units
+# columns 5-9 = temp,energy.press in reduced units, compare to in.ar.lj
+# need to include metal unit output to enable use of reduced variables
+
+thermo_style    custom step temp pe press v_temp v_epair v_emol v_etotal v_press
+thermo_modify	norm yes
+thermo		${nthermo}
+
+run		${nsteps}

--- a/examples/UNITS/in.ar.real
+++ b/examples/UNITS/in.ar.real
@@ -1,0 +1,98 @@
+# Ar in real units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon, sigma, mass set below
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# physical constants from update.cpp
+
+variable        kb index 0.0019872067         # kB in Kcal/mole/K
+variable        avogadro index 6.02214129e23  # Avogadro's number
+
+# Ar properties in real units
+
+variable        epskb index 117.7             # LJ epsilon/kB in degrees K
+variable        sigma index 3.504             # LJ sigma in Angstroms
+variable        epsilon equal ${epskb}*${kb}  # LJ epsilon in Kcal/mole
+variable        mass index 39.95              # mass in g/mole
+
+# scale factors
+
+# sigma = scale factor on distance, converts reduced distance to Angs
+# epsilon = scale factor on energy, converts reduced energy to Kcal/mole
+# tmpscale = scale factor on temperature, converts reduced temp to degrees K
+# tscale = scale factor on time, converts reduced time to fs
+#   formula is t = t* / sqrt(epsilon/mass/sigma^2), but need t in fs
+#   use epsilon (Joule/mole), mass (kg/mole), sigma (meter) to get t in seconds
+# pscale = scale factor on pressure, converts reduced pressure to atmospheres
+#   formula is P = P* / (sigma^3/epsilon), but need P in atmospheres
+#   use sigma (meter), epsilon (Joule) to get P in nt/meter^2, convert to atms
+
+variable        KcaltoJoule index 4.1868e3    # convert Kcals to Joules
+variable        NtMtoAtm equal 1.0/1.0135e5   # convert Nt/meter^2 to Atmospheres
+
+variable        tmpscale equal ${epskb}
+variable        epsJmole equal ${epsilon}*${KcaltoJoule}
+variable        massKgmole equal ${mass}/1000.0
+variable        sigmaM equal ${sigma}/1.0e10
+variable        sigmaMsq equal ${sigmaM}*${sigmaM}
+variable        tscale equal 1.0e15/sqrt(${epsJmole}/${massKgmole}/${sigmaMsq})
+variable        sigmaM3 equal ${sigmaM}*${sigmaM}*${sigmaM}
+variable        pscale equal ${NtMtoAtm}/(${sigmaM3}/(${epsJmole}/${avogadro}))
+
+# variables
+# alat = lattice constant in Angs (at reduced density rhostar)
+# temp = reduced temperature for output
+# epair,emol,etotal = reduced epair,emol,etotal energies for output
+# press = reduced pressure for output
+
+variable        alat equal (4.0*${sigma}*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        temp equal temp/${tmpscale}
+variable        epair equal epair/${epsilon}
+variable        emol equal emol/${epsilon}
+variable        etotal equal etotal/${epsilon}
+variable        press equal press/${pscale}
+
+# same script as in.ar.lj
+
+units		real
+atom_style	atomic
+
+lattice		fcc ${alat}
+region		box block 0 $x 0 $y 0 $z
+create_box	1 box
+create_atoms	1 box
+mass		1 ${mass}
+
+velocity	all create $(v_tinitial*v_epskb) 12345
+
+pair_style	lj/cut $(v_cutoff*v_sigma)
+pair_coeff	1 1 ${epsilon} ${sigma}
+
+neighbor	$(v_skin*v_sigma) bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	$(v_dt*v_tscale)
+
+# columns 2,3,4 = temp,pe,press in real units
+# columns 5-9 = temp,energy.press in reduced units, compare to in.ar.lj
+# need to include real unit output to enable use of reduced variables
+
+thermo_style    custom step temp pe press v_temp v_epair v_emol v_etotal v_press
+thermo_modify	norm yes
+thermo		${nthermo}
+
+run		${nsteps}

--- a/examples/UNITS/log.ar.lj.8Oct19.g++.1
+++ b/examples/UNITS/log.ar.lj.8Oct19.g++.1
@@ -1,0 +1,109 @@
+LAMMPS (19 Sep 2019)
+# Ar in lj units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon = sigma = mass = 1.0
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# script
+
+units		lj
+atom_style	atomic
+
+lattice		fcc ${rhostar}
+lattice		fcc 0.8842
+Lattice spacing in x,y,z = 1.65388 1.65388 1.65388
+region		box block 0 $x 0 $y 0 $z
+region		box block 0 5 0 $y 0 $z
+region		box block 0 5 0 5 0 $z
+region		box block 0 5 0 5 0 5
+create_box	1 box
+Created orthogonal box = (0 0 0) to (8.26938 8.26938 8.26938)
+  1 by 1 by 1 MPI processor grid
+create_atoms	1 box
+Created 500 atoms
+  create_atoms CPU = 0.000547171 secs
+mass		1 1.0
+
+velocity	all create ${tinitial} 12345
+velocity	all create 1.0 12345
+
+pair_style	lj/cut ${cutoff}
+pair_style	lj/cut 2.5
+pair_coeff	1 1 1.0 1.0
+
+neighbor	${skin} bin
+neighbor	0.3 bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	${dt}
+timestep	0.005
+
+thermo		10
+
+run		100
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 2.8
+  ghost atom cutoff = 2.8
+  binsize = 1.4, bins = 6 6 6
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair lj/cut, perpetual
+      attributes: half, newton on
+      pair build: half/bin/atomonly/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 2.644 | 2.644 | 2.644 Mbytes
+Step Temp E_pair E_mol TotEng Press 
+       0            1   -7.1026383            0   -5.6056383   -5.1224757 
+      10   0.74213042   -6.7245488            0   -5.6135795   -3.1363153 
+      20   0.36167746   -6.1681704            0   -5.6267393  -0.40461854 
+      30    0.4684512   -6.3315744            0    -5.630303   -1.0390065 
+      40   0.46774191   -6.3308002            0   -5.6305906    -1.077533 
+      50   0.48323399   -6.3533122            0   -5.6299109   -1.1506287 
+      60   0.49569105   -6.3711644            0   -5.6291149   -1.2296104 
+      70    0.5208333   -6.4096336            0   -5.6299462   -1.4483636 
+      80   0.53708431   -6.4345933            0   -5.6305781   -1.5945708 
+      90   0.52618946   -6.4185937            0   -5.6308881   -1.5264055 
+     100   0.52862701   -6.4231724            0   -5.6318178   -1.5714077 
+Loop time of 0.065218 on 1 procs for 100 steps with 500 atoms
+
+Performance: 662394.104 tau/day, 1533.320 timesteps/s
+99.9% CPU use with 1 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.053584   | 0.053584   | 0.053584   |   0.0 | 82.16
+Neigh   | 0.0075939  | 0.0075939  | 0.0075939  |   0.0 | 11.64
+Comm    | 0.0022638  | 0.0022638  | 0.0022638  |   0.0 |  3.47
+Output  | 0.00021172 | 0.00021172 | 0.00021172 |   0.0 |  0.32
+Modify  | 0.0011077  | 0.0011077  | 0.0011077  |   0.0 |  1.70
+Other   |            | 0.0004568  |            |       |  0.70
+
+Nlocal:    500 ave 500 max 500 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:    1946 ave 1946 max 1946 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:    19572 ave 19572 max 19572 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 19572
+Ave neighs/atom = 39.144
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:00

--- a/examples/UNITS/log.ar.lj.8Oct19.g++.4
+++ b/examples/UNITS/log.ar.lj.8Oct19.g++.4
@@ -1,0 +1,109 @@
+LAMMPS (19 Sep 2019)
+# Ar in lj units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon = sigma = mass = 1.0
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# script
+
+units		lj
+atom_style	atomic
+
+lattice		fcc ${rhostar}
+lattice		fcc 0.8842
+Lattice spacing in x,y,z = 1.65388 1.65388 1.65388
+region		box block 0 $x 0 $y 0 $z
+region		box block 0 5 0 $y 0 $z
+region		box block 0 5 0 5 0 $z
+region		box block 0 5 0 5 0 5
+create_box	1 box
+Created orthogonal box = (0 0 0) to (8.26938 8.26938 8.26938)
+  1 by 2 by 2 MPI processor grid
+create_atoms	1 box
+Created 500 atoms
+  create_atoms CPU = 0.000570774 secs
+mass		1 1.0
+
+velocity	all create ${tinitial} 12345
+velocity	all create 1.0 12345
+
+pair_style	lj/cut ${cutoff}
+pair_style	lj/cut 2.5
+pair_coeff	1 1 1.0 1.0
+
+neighbor	${skin} bin
+neighbor	0.3 bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	${dt}
+timestep	0.005
+
+thermo		10
+
+run		100
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 2.8
+  ghost atom cutoff = 2.8
+  binsize = 1.4, bins = 6 6 6
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair lj/cut, perpetual
+      attributes: half, newton on
+      pair build: half/bin/atomonly/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 2.609 | 2.609 | 2.609 Mbytes
+Step Temp E_pair E_mol TotEng Press 
+       0            1   -7.1026383            0   -5.6056383   -5.1224757 
+      10   0.73621446   -6.7154544            0   -5.6133413    -3.089257 
+      20   0.35775263   -6.1618707            0    -5.626315  -0.37875949 
+      30   0.47139877   -6.3359656            0   -5.6302816   -1.1018761 
+      40   0.46337135   -6.3247084            0   -5.6310415   -1.0985336 
+      50   0.48738877    -6.360393            0    -5.630772   -1.2274707 
+      60   0.50832261   -6.3913892            0   -5.6304302    -1.374293 
+      70   0.50988271   -6.3936997            0   -5.6304053   -1.4112286 
+      80   0.53931444   -6.4367444            0   -5.6293906   -1.6484686 
+      90   0.55277272   -6.4563334            0   -5.6288326    -1.760598 
+     100   0.54916776   -6.4507537            0   -5.6286495    -1.728837 
+Loop time of 0.0237499 on 4 procs for 100 steps with 500 atoms
+
+Performance: 1818955.951 tau/day, 4210.546 timesteps/s
+97.1% CPU use with 4 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.0098808  | 0.011585   | 0.015043   |   1.9 | 48.78
+Neigh   | 0.0015168  | 0.0017335  | 0.001997   |   0.4 |  7.30
+Comm    | 0.005949   | 0.0097297  | 0.011739   |   2.3 | 40.97
+Output  | 0.00019789 | 0.0002324  | 0.00032282 |   0.0 |  0.98
+Modify  | 0.00021482 | 0.00025994 | 0.00031853 |   0.0 |  1.09
+Other   |            | 0.0002095  |            |       |  0.88
+
+Nlocal:    125 ave 133 max 117 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Nghost:    1099 ave 1107 max 1091 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Neighs:    4909 ave 5493 max 4644 min
+Histogram: 1 2 0 0 0 0 0 0 0 1
+
+Total # of neighbors = 19636
+Ave neighs/atom = 39.272
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:00

--- a/examples/UNITS/log.ar.metal.8Oct19.g++.1
+++ b/examples/UNITS/log.ar.metal.8Oct19.g++.1
@@ -1,0 +1,197 @@
+LAMMPS (19 Sep 2019)
+# Ar in metal units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon, sigma, mass set below
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# physical constants from update.cpp
+
+variable        kb index 8.617343e-5          # kB in eV/K
+variable        avogadro index 6.02214129e23  # Avogadro's number
+
+# Ar properties in metal units
+
+variable        epskb index 117.7             # LJ epsilon/kB in degrees K
+variable        sigma index 3.504             # LJ sigma in Angstroms
+variable        epsilon equal ${epskb}*${kb}  # LJ epsilon in eV
+variable        epsilon equal 117.7*${kb}  
+variable        epsilon equal 117.7*8.617343e-5  
+variable        mass index 39.95              # mass in g/mole
+
+# scale factors
+
+# sigma = scale factor on distance, converts reduced distance to Angs
+# epsilon = scale factor on energy, converts reduced energy to eV
+# tmpscale = scale factor on temperature, converts reduced temp to degrees K
+# tscale = scale factor on time, converts reduced time to ps
+#   formula is t = t* / sqrt(epsilon/mass/sigma^2), but need t in fs
+#   use epsilon (Joule), mass (kg/atom), sigma (meter) to get t in seconds
+# pscale = scale factor on pressure, converts reduced pressure to bars
+#   formula is P = P* / (sigma^3/epsilon), but need P in atmospheres
+#   use sigma (meter), epsilon (Joule) to get P in nt/meter^2, convert to bars
+
+variable        eVtoJoule index 1.602e-19     # convert eV to Joules
+variable        NtMtoAtm equal 1.0e-5         # convert Nt/meter^2 to bars
+
+variable        tmpscale equal ${epskb}
+variable        tmpscale equal 117.7
+variable        epsilonJ equal ${epsilon}*${eVtoJoule}
+variable        epsilonJ equal 0.010142612711*${eVtoJoule}
+variable        epsilonJ equal 0.010142612711*1.602e-19
+variable        massKgAtom equal ${mass}/1000.0/${avogadro}
+variable        massKgAtom equal 39.95/1000.0/${avogadro}
+variable        massKgAtom equal 39.95/1000.0/6.02214129e23
+variable        sigmaM equal ${sigma}/1.0e10
+variable        sigmaM equal 3.504/1.0e10
+variable        sigmaMsq equal ${sigmaM}*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*3.504e-10
+variable        tscale equal 1.0e12/sqrt(${epsilonJ}/${massKgAtom}/${sigmaMsq})
+variable        tscale equal 1.0e12/sqrt(1.6248465563022e-21/${massKgAtom}/${sigmaMsq})
+variable        tscale equal 1.0e12/sqrt(1.6248465563022e-21/6.6338529895236e-26/${sigmaMsq})
+variable        tscale equal 1.0e12/sqrt(1.6248465563022e-21/6.6338529895236e-26/1.2278016e-19)
+variable        sigmaM3 equal ${sigmaM}*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*3.504e-10
+variable        pscale equal ${NtMtoAtm}/(${sigmaM3}/(${epsilonJ}))
+variable        pscale equal 1e-05/(${sigmaM3}/(${epsilonJ}))
+variable        pscale equal 1e-05/(4.3022168064e-29/(${epsilonJ}))
+variable        pscale equal 1e-05/(4.3022168064e-29/(1.6248465563022e-21))
+
+# variables
+# alat = lattice constant in Angs (at reduced density rhostar)
+# temp = reduced temperature for output
+# epair,emol,etotal = reduced epair,emol,etotal energies for output
+# press = reduced pressure for output
+
+variable        alat equal (4.0*${sigma}*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/0.8842)^(1.0/3.0)
+variable        temp equal temp/${tmpscale}
+variable        temp equal temp/117.7
+variable        epair equal epair/${epsilon}
+variable        epair equal epair/0.010142612711
+variable        emol equal emol/${epsilon}
+variable        emol equal emol/0.010142612711
+variable        etotal equal etotal/${epsilon}
+variable        etotal equal etotal/0.010142612711
+variable        press equal press/${pscale}
+variable        press equal press/377.676586146256
+
+# same script as in.ar.lj
+
+units		metal
+atom_style	atomic
+
+lattice		fcc ${alat}
+lattice		fcc 5.79518437579763
+Lattice spacing in x,y,z = 5.79518 5.79518 5.79518
+region		box block 0 $x 0 $y 0 $z
+region		box block 0 5 0 $y 0 $z
+region		box block 0 5 0 5 0 $z
+region		box block 0 5 0 5 0 5
+create_box	1 box
+Created orthogonal box = (0 0 0) to (28.9759 28.9759 28.9759)
+  1 by 1 by 1 MPI processor grid
+create_atoms	1 box
+Created 500 atoms
+  create_atoms CPU = 0.000549078 secs
+mass		1 ${mass}
+mass		1 39.95
+
+velocity	all create $(v_tinitial*v_epskb) 12345
+velocity	all create 117.70000000000000284 12345
+
+pair_style	lj/cut $(v_cutoff*v_sigma)
+pair_style	lj/cut 8.7599999999999997868
+pair_coeff	1 1 ${epsilon} ${sigma}
+pair_coeff	1 1 0.010142612711 ${sigma}
+pair_coeff	1 1 0.010142612711 3.504
+
+neighbor	$(v_skin*v_sigma) bin
+neighbor	1.0511999999999999122 bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	$(v_dt*v_tscale)
+timestep	0.011194658410003900315
+
+# columns 2,3,4 = temp,pe,press in metal units
+# columns 5-9 = temp,energy.press in reduced units, compare to in.ar.lj
+# need to include metal unit output to enable use of reduced variables
+
+thermo_style    custom step temp pe press v_temp v_epair v_emol v_etotal v_press
+thermo_modify	norm yes
+thermo		${nthermo}
+thermo		10
+
+run		${nsteps}
+run		100
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 9.8112
+  ghost atom cutoff = 9.8112
+  binsize = 4.9056, bins = 6 6 6
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair lj/cut, perpetual
+      attributes: half, newton on
+      pair build: half/bin/atomonly/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 2.644 | 2.644 | 2.644 Mbytes
+Step Temp PotEng Press v_temp v_epair v_emol v_etotal v_press 
+       0        117.7  -0.07203931   -1934.8523            1   -7.1026383            0   -5.6056383     -5.12304 
+      10    87.345225  -0.06820404   -1184.5618   0.74210047    -6.724504            0   -5.6135796   -3.1364449 
+      20    42.569809 -0.062561408   -152.82812   0.36168062   -6.1681748            0   -5.6267389  -0.40465341 
+      30    55.137637 -0.064219154   -392.49645   0.46845911   -6.3316185            0   -5.6303352   -1.0392396 
+      40    55.053014 -0.064210828   -406.99941   0.46774014   -6.3307976            0   -5.6305906     -1.07764 
+      50     56.87723 -0.064439241   -434.61958     0.483239   -6.3533177            0   -5.6299089   -1.1507718 
+      60    58.344019 -0.064620383    -464.4684    0.4957011   -6.3711772            0   -5.6291126   -1.2298046 
+      70     61.30301 -0.065010529   -547.09852    0.5208412   -6.4096433            0    -5.629944     -1.44859 
+      80    63.214836 -0.065263563   -602.29599   0.53708442   -6.4345909            0   -5.6305755   -1.5947401 
+      90    61.931826 -0.065101194    -576.5342   0.52618374   -6.4185823            0   -5.6308852   -1.5265288 
+     100    62.221816 -0.065148028   -593.59878   0.52864755   -6.4231998            0   -5.6318144   -1.5717119 
+Loop time of 0.04864 on 1 procs for 100 steps with 500 atoms
+
+Performance: 1988.524 ns/day, 0.012 hours/ns, 2055.921 timesteps/s
+99.8% CPU use with 1 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.039802   | 0.039802   | 0.039802   |   0.0 | 81.83
+Neigh   | 0.0057771  | 0.0057771  | 0.0057771  |   0.0 | 11.88
+Comm    | 0.0015905  | 0.0015905  | 0.0015905  |   0.0 |  3.27
+Output  | 0.00033736 | 0.00033736 | 0.00033736 |   0.0 |  0.69
+Modify  | 0.00077343 | 0.00077343 | 0.00077343 |   0.0 |  1.59
+Other   |            | 0.0003595  |            |       |  0.74
+
+Nlocal:    500 ave 500 max 500 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:    1946 ave 1946 max 1946 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:    19572 ave 19572 max 19572 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 19572
+Ave neighs/atom = 39.144
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:00

--- a/examples/UNITS/log.ar.metal.8Oct19.g++.4
+++ b/examples/UNITS/log.ar.metal.8Oct19.g++.4
@@ -1,0 +1,197 @@
+LAMMPS (19 Sep 2019)
+# Ar in metal units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon, sigma, mass set below
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# physical constants from update.cpp
+
+variable        kb index 8.617343e-5          # kB in eV/K
+variable        avogadro index 6.02214129e23  # Avogadro's number
+
+# Ar properties in metal units
+
+variable        epskb index 117.7             # LJ epsilon/kB in degrees K
+variable        sigma index 3.504             # LJ sigma in Angstroms
+variable        epsilon equal ${epskb}*${kb}  # LJ epsilon in eV
+variable        epsilon equal 117.7*${kb}  
+variable        epsilon equal 117.7*8.617343e-5  
+variable        mass index 39.95              # mass in g/mole
+
+# scale factors
+
+# sigma = scale factor on distance, converts reduced distance to Angs
+# epsilon = scale factor on energy, converts reduced energy to eV
+# tmpscale = scale factor on temperature, converts reduced temp to degrees K
+# tscale = scale factor on time, converts reduced time to ps
+#   formula is t = t* / sqrt(epsilon/mass/sigma^2), but need t in fs
+#   use epsilon (Joule), mass (kg/atom), sigma (meter) to get t in seconds
+# pscale = scale factor on pressure, converts reduced pressure to bars
+#   formula is P = P* / (sigma^3/epsilon), but need P in atmospheres
+#   use sigma (meter), epsilon (Joule) to get P in nt/meter^2, convert to bars
+
+variable        eVtoJoule index 1.602e-19     # convert eV to Joules
+variable        NtMtoAtm equal 1.0e-5         # convert Nt/meter^2 to bars
+
+variable        tmpscale equal ${epskb}
+variable        tmpscale equal 117.7
+variable        epsilonJ equal ${epsilon}*${eVtoJoule}
+variable        epsilonJ equal 0.010142612711*${eVtoJoule}
+variable        epsilonJ equal 0.010142612711*1.602e-19
+variable        massKgAtom equal ${mass}/1000.0/${avogadro}
+variable        massKgAtom equal 39.95/1000.0/${avogadro}
+variable        massKgAtom equal 39.95/1000.0/6.02214129e23
+variable        sigmaM equal ${sigma}/1.0e10
+variable        sigmaM equal 3.504/1.0e10
+variable        sigmaMsq equal ${sigmaM}*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*3.504e-10
+variable        tscale equal 1.0e12/sqrt(${epsilonJ}/${massKgAtom}/${sigmaMsq})
+variable        tscale equal 1.0e12/sqrt(1.6248465563022e-21/${massKgAtom}/${sigmaMsq})
+variable        tscale equal 1.0e12/sqrt(1.6248465563022e-21/6.6338529895236e-26/${sigmaMsq})
+variable        tscale equal 1.0e12/sqrt(1.6248465563022e-21/6.6338529895236e-26/1.2278016e-19)
+variable        sigmaM3 equal ${sigmaM}*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*3.504e-10
+variable        pscale equal ${NtMtoAtm}/(${sigmaM3}/(${epsilonJ}))
+variable        pscale equal 1e-05/(${sigmaM3}/(${epsilonJ}))
+variable        pscale equal 1e-05/(4.3022168064e-29/(${epsilonJ}))
+variable        pscale equal 1e-05/(4.3022168064e-29/(1.6248465563022e-21))
+
+# variables
+# alat = lattice constant in Angs (at reduced density rhostar)
+# temp = reduced temperature for output
+# epair,emol,etotal = reduced epair,emol,etotal energies for output
+# press = reduced pressure for output
+
+variable        alat equal (4.0*${sigma}*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/0.8842)^(1.0/3.0)
+variable        temp equal temp/${tmpscale}
+variable        temp equal temp/117.7
+variable        epair equal epair/${epsilon}
+variable        epair equal epair/0.010142612711
+variable        emol equal emol/${epsilon}
+variable        emol equal emol/0.010142612711
+variable        etotal equal etotal/${epsilon}
+variable        etotal equal etotal/0.010142612711
+variable        press equal press/${pscale}
+variable        press equal press/377.676586146256
+
+# same script as in.ar.lj
+
+units		metal
+atom_style	atomic
+
+lattice		fcc ${alat}
+lattice		fcc 5.79518437579763
+Lattice spacing in x,y,z = 5.79518 5.79518 5.79518
+region		box block 0 $x 0 $y 0 $z
+region		box block 0 5 0 $y 0 $z
+region		box block 0 5 0 5 0 $z
+region		box block 0 5 0 5 0 5
+create_box	1 box
+Created orthogonal box = (0 0 0) to (28.9759 28.9759 28.9759)
+  1 by 2 by 2 MPI processor grid
+create_atoms	1 box
+Created 500 atoms
+  create_atoms CPU = 0.000674009 secs
+mass		1 ${mass}
+mass		1 39.95
+
+velocity	all create $(v_tinitial*v_epskb) 12345
+velocity	all create 117.70000000000000284 12345
+
+pair_style	lj/cut $(v_cutoff*v_sigma)
+pair_style	lj/cut 8.7599999999999997868
+pair_coeff	1 1 ${epsilon} ${sigma}
+pair_coeff	1 1 0.010142612711 ${sigma}
+pair_coeff	1 1 0.010142612711 3.504
+
+neighbor	$(v_skin*v_sigma) bin
+neighbor	1.0511999999999999122 bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	$(v_dt*v_tscale)
+timestep	0.011194658410003900315
+
+# columns 2,3,4 = temp,pe,press in metal units
+# columns 5-9 = temp,energy.press in reduced units, compare to in.ar.lj
+# need to include metal unit output to enable use of reduced variables
+
+thermo_style    custom step temp pe press v_temp v_epair v_emol v_etotal v_press
+thermo_modify	norm yes
+thermo		${nthermo}
+thermo		10
+
+run		${nsteps}
+run		100
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 9.8112
+  ghost atom cutoff = 9.8112
+  binsize = 4.9056, bins = 6 6 6
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair lj/cut, perpetual
+      attributes: half, newton on
+      pair build: half/bin/atomonly/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 2.609 | 2.609 | 2.609 Mbytes
+Step Temp PotEng Press v_temp v_epair v_emol v_etotal v_press 
+       0        117.7  -0.07203931   -1934.8523            1   -7.1026383            0   -5.6056383     -5.12304 
+      10    86.648851  -0.06811179   -1166.7855   0.73618395   -6.7154088            0   -5.6133414   -3.0893774 
+      20    42.107954 -0.062497536   -143.06615   0.35775662   -6.1618774            0   -5.6263157  -0.37880598 
+      30    55.484504 -0.064263032   -416.20245   0.47140615   -6.3359445            0   -5.6302495   -1.1020075 
+      40    54.538222 -0.064148334   -414.88071   0.46336637   -6.3246361            0   -5.6309766   -1.0985079 
+      50    57.367693 -0.064511259   -463.67683   0.48740606   -6.3604182            0   -5.6307714   -1.2277087 
+      60    59.828794 -0.064824938   -519.05997   0.50831601   -6.3913451            0    -5.630396   -1.3743504 
+      70    60.014616 -0.064848979   -533.07604   0.50989478   -6.3937154            0   -5.6304029   -1.4114617 
+      80     63.47861 -0.065285885   -622.71073   0.53932549   -6.4367917            0   -5.6294215   -1.6487936 
+      90    65.060881 -0.065484011   -664.99883   0.55276874   -6.4563257            0   -5.6288309   -1.7607627 
+     100    64.637033 -0.065427467   -653.00765   0.54916765   -6.4507508            0   -5.6286468   -1.7290128 
+Loop time of 0.0258265 on 4 procs for 100 steps with 500 atoms
+
+Performance: 3745.060 ns/day, 0.006 hours/ns, 3871.990 timesteps/s
+99.6% CPU use with 4 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.0090213  | 0.012419   | 0.015494   |   2.1 | 48.09
+Neigh   | 0.0013709  | 0.0018765  | 0.0022483  |   0.7 |  7.27
+Comm    | 0.0071132  | 0.010597   | 0.014538   |   2.6 | 41.03
+Output  | 0.00039983 | 0.00042897 | 0.00049567 |   0.0 |  1.66
+Modify  | 0.00024104 | 0.00028801 | 0.00031543 |   0.0 |  1.12
+Other   |            | 0.0002173  |            |       |  0.84
+
+Nlocal:    125 ave 133 max 117 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Nghost:    1099 ave 1107 max 1091 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Neighs:    4908.75 ave 5492 max 4644 min
+Histogram: 1 2 0 0 0 0 0 0 0 1
+
+Total # of neighbors = 19635
+Ave neighs/atom = 39.27
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:00

--- a/examples/UNITS/log.ar.real.8Oct19.g++.1
+++ b/examples/UNITS/log.ar.real.8Oct19.g++.1
@@ -1,0 +1,197 @@
+LAMMPS (19 Sep 2019)
+# Ar in real units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon, sigma, mass set below
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# physical constants from update.cpp
+
+variable        kb index 0.0019872067         # kB in Kcal/mole/K
+variable        avogadro index 6.02214129e23  # Avogadro's number
+
+# Ar properties in real units
+
+variable        epskb index 117.7             # LJ epsilon/kB in degrees K
+variable        sigma index 3.504             # LJ sigma in Angstroms
+variable        epsilon equal ${epskb}*${kb}  # LJ epsilon in Kcal/mole
+variable        epsilon equal 117.7*${kb}  
+variable        epsilon equal 117.7*0.0019872067  
+variable        mass index 39.95              # mass in g/mole
+
+# scale factors
+
+# sigma = scale factor on distance, converts reduced distance to Angs
+# epsilon = scale factor on energy, converts reduced energy to Kcal/mole
+# tmpscale = scale factor on temperature, converts reduced temp to degrees K
+# tscale = scale factor on time, converts reduced time to fs
+#   formula is t = t* / sqrt(epsilon/mass/sigma^2), but need t in fs
+#   use epsilon (Joule/mole), mass (kg/mole), sigma (meter) to get t in seconds
+# pscale = scale factor on pressure, converts reduced pressure to atmospheres
+#   formula is P = P* / (sigma^3/epsilon), but need P in atmospheres
+#   use sigma (meter), epsilon (Joule) to get P in nt/meter^2, convert to atms
+
+variable        KcaltoJoule index 4.1868e3    # convert Kcals to Joules
+variable        NtMtoAtm equal 1.0/1.0135e5   # convert Nt/meter^2 to Atmospheres
+
+variable        tmpscale equal ${epskb}
+variable        tmpscale equal 117.7
+variable        epsJmole equal ${epsilon}*${KcaltoJoule}
+variable        epsJmole equal 0.23389422859*${KcaltoJoule}
+variable        epsJmole equal 0.23389422859*4.1868e3
+variable        massKgmole equal ${mass}/1000.0
+variable        massKgmole equal 39.95/1000.0
+variable        sigmaM equal ${sigma}/1.0e10
+variable        sigmaM equal 3.504/1.0e10
+variable        sigmaMsq equal ${sigmaM}*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*3.504e-10
+variable        tscale equal 1.0e15/sqrt(${epsJmole}/${massKgmole}/${sigmaMsq})
+variable        tscale equal 1.0e15/sqrt(979.268356260612/${massKgmole}/${sigmaMsq})
+variable        tscale equal 1.0e15/sqrt(979.268356260612/0.03995/${sigmaMsq})
+variable        tscale equal 1.0e15/sqrt(979.268356260612/0.03995/1.2278016e-19)
+variable        sigmaM3 equal ${sigmaM}*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*3.504e-10
+variable        pscale equal ${NtMtoAtm}/(${sigmaM3}/(${epsJmole}/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(${sigmaM3}/(${epsJmole}/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(4.3022168064e-29/(${epsJmole}/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(4.3022168064e-29/(979.268356260612/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(4.3022168064e-29/(979.268356260612/6.02214129e23))
+
+# variables
+# alat = lattice constant in Angs (at reduced density rhostar)
+# temp = reduced temperature for output
+# epair,emol,etotal = reduced epair,emol,etotal energies for output
+# press = reduced pressure for output
+
+variable        alat equal (4.0*${sigma}*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/0.8842)^(1.0/3.0)
+variable        temp equal temp/${tmpscale}
+variable        temp equal temp/117.7
+variable        epair equal epair/${epsilon}
+variable        epair equal epair/0.23389422859
+variable        emol equal emol/${epsilon}
+variable        emol equal emol/0.23389422859
+variable        etotal equal etotal/${epsilon}
+variable        etotal equal etotal/0.23389422859
+variable        press equal press/${pscale}
+variable        press equal press/372.936366301003
+
+# same script as in.ar.lj
+
+units		real
+atom_style	atomic
+
+lattice		fcc ${alat}
+lattice		fcc 5.79518437579763
+Lattice spacing in x,y,z = 5.79518 5.79518 5.79518
+region		box block 0 $x 0 $y 0 $z
+region		box block 0 5 0 $y 0 $z
+region		box block 0 5 0 5 0 $z
+region		box block 0 5 0 5 0 5
+create_box	1 box
+Created orthogonal box = (0 0 0) to (28.9759 28.9759 28.9759)
+  1 by 1 by 1 MPI processor grid
+create_atoms	1 box
+Created 500 atoms
+  create_atoms CPU = 0.000550985 secs
+mass		1 ${mass}
+mass		1 39.95
+
+velocity	all create $(v_tinitial*v_epskb) 12345
+velocity	all create 117.70000000000000284 12345
+
+pair_style	lj/cut $(v_cutoff*v_sigma)
+pair_style	lj/cut 8.7599999999999997868
+pair_coeff	1 1 ${epsilon} ${sigma}
+pair_coeff	1 1 0.23389422859 ${sigma}
+pair_coeff	1 1 0.23389422859 3.504
+
+neighbor	$(v_skin*v_sigma) bin
+neighbor	1.0511999999999999122 bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	$(v_dt*v_tscale)
+timestep	11.190297512378050371
+
+# columns 2,3,4 = temp,pe,press in real units
+# columns 5-9 = temp,energy.press in reduced units, compare to in.ar.lj
+# need to include real unit output to enable use of reduced variables
+
+thermo_style    custom step temp pe press v_temp v_epair v_emol v_etotal v_press
+thermo_modify	norm yes
+thermo		${nthermo}
+thermo		10
+
+run		${nsteps}
+run		100
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 9.8112
+  ghost atom cutoff = 9.8112
+  binsize = 4.9056, bins = 6 6 6
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair lj/cut, perpetual
+      attributes: half, newton on
+      pair build: half/bin/atomonly/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 2.644 | 2.644 | 2.644 Mbytes
+Step Temp PotEng Press v_temp v_epair v_emol v_etotal v_press 
+       0        117.7   -1.6612661   -1909.5509            1   -7.1026383            0   -5.6056383   -5.1203128 
+      10    87.369977   -1.5728967   -1169.6414   0.74231077   -6.7248204            0   -5.6135812   -3.1363029 
+      20    42.567295   -1.4427006   -150.87379   0.36165926   -6.1681752            0   -5.6267713  -0.40455638 
+      30    55.130978    -1.480902   -387.17817   0.46840253   -6.3315028            0   -5.6303042   -1.0381883 
+      40    55.054202   -1.4807485   -401.72653   0.46775023   -6.3308469            0   -5.6306248   -1.0771986 
+      50    56.873955   -1.4860029    -428.9126   0.48321117   -6.3533113            0   -5.6299442   -1.1500959 
+      60     58.33701    -1.490161   -458.23636   0.49564154   -6.3710892            0   -5.6291138   -1.2287253 
+      70     61.29671   -1.4991528   -539.72484   0.52078768   -6.4095331            0    -5.629914   -1.4472304 
+      80    63.214984    -1.504992   -594.34987   0.53708567   -6.4344983            0    -5.630481   -1.5937032 
+      90    61.936907   -1.5013008   -569.13985    0.5262269   -6.4187169            0   -5.6309552   -1.5261045 
+     100     62.20662   -1.5023046   -585.49121   0.52851844   -6.4230083            0   -5.6318162   -1.5699494 
+Loop time of 0.047307 on 1 procs for 100 steps with 500 atoms
+
+Performance: 2043.760 ns/day, 0.012 hours/ns, 2113.851 timesteps/s
+98.0% CPU use with 1 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.038646   | 0.038646   | 0.038646   |   0.0 | 81.69
+Neigh   | 0.0056832  | 0.0056832  | 0.0056832  |   0.0 | 12.01
+Comm    | 0.0015347  | 0.0015347  | 0.0015347  |   0.0 |  3.24
+Output  | 0.0003581  | 0.0003581  | 0.0003581  |   0.0 |  0.76
+Modify  | 0.00075364 | 0.00075364 | 0.00075364 |   0.0 |  1.59
+Other   |            | 0.0003314  |            |       |  0.70
+
+Nlocal:    500 ave 500 max 500 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:    1946 ave 1946 max 1946 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:    19572 ave 19572 max 19572 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 19572
+Ave neighs/atom = 39.144
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:00

--- a/examples/UNITS/log.ar.real.8Oct19.g++.4
+++ b/examples/UNITS/log.ar.real.8Oct19.g++.4
@@ -1,0 +1,197 @@
+LAMMPS (19 Sep 2019)
+# Ar in real units
+
+# simulation params in reduced units
+# settable from command line
+# epsilon, sigma, mass set below
+
+variable	x index 5
+variable	y index 5
+variable	z index 5
+variable        rhostar index 0.8842
+variable        dt index 0.005
+variable        cutoff index 2.5
+variable        skin index 0.3
+variable        tinitial index 1.0
+variable        nthermo index 10
+variable        nsteps index 100
+
+# physical constants from update.cpp
+
+variable        kb index 0.0019872067         # kB in Kcal/mole/K
+variable        avogadro index 6.02214129e23  # Avogadro's number
+
+# Ar properties in real units
+
+variable        epskb index 117.7             # LJ epsilon/kB in degrees K
+variable        sigma index 3.504             # LJ sigma in Angstroms
+variable        epsilon equal ${epskb}*${kb}  # LJ epsilon in Kcal/mole
+variable        epsilon equal 117.7*${kb}  
+variable        epsilon equal 117.7*0.0019872067  
+variable        mass index 39.95              # mass in g/mole
+
+# scale factors
+
+# sigma = scale factor on distance, converts reduced distance to Angs
+# epsilon = scale factor on energy, converts reduced energy to Kcal/mole
+# tmpscale = scale factor on temperature, converts reduced temp to degrees K
+# tscale = scale factor on time, converts reduced time to fs
+#   formula is t = t* / sqrt(epsilon/mass/sigma^2), but need t in fs
+#   use epsilon (Joule/mole), mass (kg/mole), sigma (meter) to get t in seconds
+# pscale = scale factor on pressure, converts reduced pressure to atmospheres
+#   formula is P = P* / (sigma^3/epsilon), but need P in atmospheres
+#   use sigma (meter), epsilon (Joule) to get P in nt/meter^2, convert to atms
+
+variable        KcaltoJoule index 4.1868e3    # convert Kcals to Joules
+variable        NtMtoAtm equal 1.0/1.0135e5   # convert Nt/meter^2 to Atmospheres
+
+variable        tmpscale equal ${epskb}
+variable        tmpscale equal 117.7
+variable        epsJmole equal ${epsilon}*${KcaltoJoule}
+variable        epsJmole equal 0.23389422859*${KcaltoJoule}
+variable        epsJmole equal 0.23389422859*4.1868e3
+variable        massKgmole equal ${mass}/1000.0
+variable        massKgmole equal 39.95/1000.0
+variable        sigmaM equal ${sigma}/1.0e10
+variable        sigmaM equal 3.504/1.0e10
+variable        sigmaMsq equal ${sigmaM}*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*${sigmaM}
+variable        sigmaMsq equal 3.504e-10*3.504e-10
+variable        tscale equal 1.0e15/sqrt(${epsJmole}/${massKgmole}/${sigmaMsq})
+variable        tscale equal 1.0e15/sqrt(979.268356260612/${massKgmole}/${sigmaMsq})
+variable        tscale equal 1.0e15/sqrt(979.268356260612/0.03995/${sigmaMsq})
+variable        tscale equal 1.0e15/sqrt(979.268356260612/0.03995/1.2278016e-19)
+variable        sigmaM3 equal ${sigmaM}*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*${sigmaM}*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*${sigmaM}
+variable        sigmaM3 equal 3.504e-10*3.504e-10*3.504e-10
+variable        pscale equal ${NtMtoAtm}/(${sigmaM3}/(${epsJmole}/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(${sigmaM3}/(${epsJmole}/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(4.3022168064e-29/(${epsJmole}/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(4.3022168064e-29/(979.268356260612/${avogadro}))
+variable        pscale equal 9.86679822397632e-06/(4.3022168064e-29/(979.268356260612/6.02214129e23))
+
+# variables
+# alat = lattice constant in Angs (at reduced density rhostar)
+# temp = reduced temperature for output
+# epair,emol,etotal = reduced epair,emol,etotal energies for output
+# press = reduced pressure for output
+
+variable        alat equal (4.0*${sigma}*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*${sigma}*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*${sigma}/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/${rhostar})^(1.0/3.0)
+variable        alat equal (4.0*3.504*3.504*3.504/0.8842)^(1.0/3.0)
+variable        temp equal temp/${tmpscale}
+variable        temp equal temp/117.7
+variable        epair equal epair/${epsilon}
+variable        epair equal epair/0.23389422859
+variable        emol equal emol/${epsilon}
+variable        emol equal emol/0.23389422859
+variable        etotal equal etotal/${epsilon}
+variable        etotal equal etotal/0.23389422859
+variable        press equal press/${pscale}
+variable        press equal press/372.936366301003
+
+# same script as in.ar.lj
+
+units		real
+atom_style	atomic
+
+lattice		fcc ${alat}
+lattice		fcc 5.79518437579763
+Lattice spacing in x,y,z = 5.79518 5.79518 5.79518
+region		box block 0 $x 0 $y 0 $z
+region		box block 0 5 0 $y 0 $z
+region		box block 0 5 0 5 0 $z
+region		box block 0 5 0 5 0 5
+create_box	1 box
+Created orthogonal box = (0 0 0) to (28.9759 28.9759 28.9759)
+  1 by 2 by 2 MPI processor grid
+create_atoms	1 box
+Created 500 atoms
+  create_atoms CPU = 0.000664949 secs
+mass		1 ${mass}
+mass		1 39.95
+
+velocity	all create $(v_tinitial*v_epskb) 12345
+velocity	all create 117.70000000000000284 12345
+
+pair_style	lj/cut $(v_cutoff*v_sigma)
+pair_style	lj/cut 8.7599999999999997868
+pair_coeff	1 1 ${epsilon} ${sigma}
+pair_coeff	1 1 0.23389422859 ${sigma}
+pair_coeff	1 1 0.23389422859 3.504
+
+neighbor	$(v_skin*v_sigma) bin
+neighbor	1.0511999999999999122 bin
+neigh_modify	delay 0 every 20 check no
+
+fix		1 all nve
+
+timestep	$(v_dt*v_tscale)
+timestep	11.190297512378050371
+
+# columns 2,3,4 = temp,pe,press in real units
+# columns 5-9 = temp,energy.press in reduced units, compare to in.ar.lj
+# need to include real unit output to enable use of reduced variables
+
+thermo_style    custom step temp pe press v_temp v_epair v_emol v_etotal v_press
+thermo_modify	norm yes
+thermo		${nthermo}
+thermo		10
+
+run		${nsteps}
+run		100
+Neighbor list info ...
+  update every 20 steps, delay 0 steps, check no
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 9.8112
+  ghost atom cutoff = 9.8112
+  binsize = 4.9056, bins = 6 6 6
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair lj/cut, perpetual
+      attributes: half, newton on
+      pair build: half/bin/atomonly/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 2.609 | 2.609 | 2.609 Mbytes
+Step Temp PotEng Press v_temp v_epair v_emol v_etotal v_press 
+       0        117.7   -1.6612661   -1909.5509            1   -7.1026383            0   -5.6056383   -5.1203128 
+      10    86.674156   -1.5707707   -1152.1077   0.73639895    -6.715731            0   -5.6133417   -3.0892877 
+      20    42.104452   -1.4412091   -141.16344   0.35772687   -6.1617986            0   -5.6262815  -0.37851883 
+      30    55.478223   -1.4819221   -410.58592   0.47135278   -6.3358644            0   -5.6302493   -1.1009544 
+      40     54.54231   -1.4793231   -409.58446    0.4634011   -6.3247524            0    -5.631041    -1.098269 
+      50    57.354168   -1.4876242   -457.34719   0.48729115   -6.3602431            0   -5.6307682   -1.2263411 
+      60    59.835295   -1.4949249   -512.38519   0.50837124    -6.391457            0   -5.6304252   -1.3739212 
+      70    60.005554   -1.4954174     -525.858   0.50981779   -6.3935625            0   -5.6303653   -1.4100475 
+      80    63.469566    -1.505493   -614.29111   0.53924865   -6.4366403            0   -5.6293851   -1.6471741 
+      90    65.064012   -1.5100983   -656.32951   0.55279535   -6.4563301            0   -5.6287955   -1.7598968 
+     100     64.63774   -1.5088033   -644.51211   0.54917366   -6.4507932            0   -5.6286803   -1.7282093 
+Loop time of 0.0285767 on 4 procs for 100 steps with 500 atoms
+
+Performance: 3383.318 ns/day, 0.007 hours/ns, 3499.350 timesteps/s
+99.7% CPU use with 4 MPI tasks x no OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 0.012398   | 0.014826   | 0.016774   |   1.6 | 51.88
+Neigh   | 0.001797   | 0.0021547  | 0.0025899  |   0.6 |  7.54
+Comm    | 0.0079622  | 0.010444   | 0.013427   |   2.3 | 36.55
+Output  | 0.00042987 | 0.00047708 | 0.00059676 |   0.0 |  1.67
+Modify  | 0.00028896 | 0.00038844 | 0.00049448 |   0.0 |  1.36
+Other   |            | 0.0002864  |            |       |  1.00
+
+Nlocal:    125 ave 133 max 117 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Nghost:    1099 ave 1107 max 1091 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Neighs:    4908.75 ave 5493 max 4644 min
+Histogram: 1 2 0 0 0 0 0 0 0 1
+
+Total # of neighbors = 19635
+Ave neighs/atom = 39.27
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:00


### PR DESCRIPTION
**Summary**

Provide 3 input scripts that simluate the same physical system (LJ liquid argond) in 3 different LAMMPS units: lj, real, metal.  They illustrate how to scale/unscale input/output quantities between unit systems, so that users can hopefully do this for any input script they might need to.

**Related Issues**

Questions about how to do this arise occasionally on the mail list.

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


