### PR TITLE
Added invisible helper function to check values of Clebsch-Gordan coeffs

### DIFF
--- a/src/SNAP/sna.cpp
+++ b/src/SNAP/sna.cpp
@@ -20,6 +20,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "comm.h"
 
 using namespace std;
 using namespace LAMMPS_NS;
@@ -283,7 +284,7 @@ void SNA::build_indexlist()
 void SNA::init()
 {
   init_clebsch_gordan();
-  // print_clebsch_gordan();
+  //   print_clebsch_gordan();
   init_rootpqarray();
 }
 
@@ -1523,6 +1524,8 @@ void SNA::init_clebsch_gordan()
 
 void SNA::print_clebsch_gordan()
 {
+  if (comm->me) return;
+
   int aa2, bb2, cc2;
   for (int j = 0; j <= twojmax; j += 1) {
     printf("c = %g\n",j/2.0);

--- a/src/SNAP/sna.cpp
+++ b/src/SNAP/sna.cpp
@@ -283,6 +283,7 @@ void SNA::build_indexlist()
 void SNA::init()
 {
   init_clebsch_gordan();
+  // print_clebsch_gordan();
   init_rootpqarray();
 }
 
@@ -1513,6 +1514,38 @@ void SNA::init_clebsch_gordan()
           }
         }
       }
+}
+
+/* ----------------------------------------------------------------------
+   print out values of Clebsch-Gordan coefficients
+   format and notation follows VMK Table 8.11
+------------------------------------------------------------------------- */
+
+void SNA::print_clebsch_gordan()
+{
+  int aa2, bb2, cc2;
+  for (int j = 0; j <= twojmax; j += 1) {
+    printf("c = %g\n",j/2.0);
+    printf("a alpha b beta C_{a alpha b beta}^{c alpha+beta}\n");
+    for (int j1 = 0; j1 <= twojmax; j1++)
+      for (int j2 = 0; j2 <= j1; j2++)
+        if (j1-j2 <= j && j1+j2 >= j && (j1+j2+j)%2 == 0) {
+          int idxcg_count = idxcg_block[j1][j2][j]; 
+          for (int m1 = 0; m1 <= j1; m1++) {
+            aa2 = 2*m1-j1;
+            for (int m2 = 0; m2 <= j2; m2++) {
+              bb2 = 2*m2-j2;
+              double cgtmp = cglist[idxcg_count];
+              cc2 = aa2+bb2;
+              if (cc2 >= -j && cc2 <= j)
+                if (j1 != j2 || (aa2 > bb2 && aa2 >= -bb2) || (aa2 == bb2 && aa2 >= 0))
+                  printf("%4g %4g %4g %4g %10.6g\n",
+                         j1/2.0,aa2/2.0,j2/2.0,bb2/2.0,cgtmp);
+              idxcg_count++;
+            }
+          }
+        }
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/SNAP/sna.h
+++ b/src/SNAP/sna.h
@@ -103,6 +103,7 @@ private:
   void create_twojmax_arrays();
   void destroy_twojmax_arrays();
   void init_clebsch_gordan();
+  void print_clebsch_gordan();
   void init_rootpqarray();
   void zero_uarraytot();
   void addself_uarraytot(double);


### PR DESCRIPTION
**Summary**

Added a member function to SNA class that prints out Clebsch-Gordan coefficients.  Will not be called by LAMMPS under normal circumstances, but very useful for debugging.

**Related Issues**

None

**Author(s)**

Aidan Thompson

**Licensing**

None

**Backward Compatibility**

None

**Implementation Notes**

Compared to VMK Table 8.11

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


