### PR TITLE
Add topology interaction check to Force::init()

### DIFF
--- a/doc/src/Errors_warnings.txt
+++ b/doc/src/Errors_warnings.txt
@@ -31,30 +31,6 @@ Doc page with "ERROR messages"_Errors_messages.html
 
 :dlb
 
-{1-2 special neighbor interactions != 1.0} :dt
-
-The topology contains bonds, but there is no bond style defined
-and a 1-2 special neighbor scaling factor was not 1.0. This
-means that pair style interactions may have scaled or missing
-pairs in the neighbor list in expectation of interactions for
-those pairs being computed from the bond style. :dd
-
-{1-3 special neighbor interactions != 1.0} :dt
-
-The topology contains angles, but there is no angle style defined
-and a 1-3 special neighbor scaling factor was not 1.0. This
-means that pair style interactions may have scaled or missing
-pairs in the neighbor list in expectation of interactions for
-those pairs being computed from the angle style. :dd
-
-{1-4 special neighbor interactions != 1.0} :dt
-
-The topology contains dihedrals, but there is no dihedral style defined
-and a 1-4 special neighbor scaling factor was not 1.0. This
-means that pair style interactions may have scaled or missing
-pairs in the neighbor list in expectation of interactions for
-those pairs being computed from the dihedral style. :dd
-
 {Adjusting Coulombic cutoff for MSM, new cutoff = %g} :dt
 
 The adjust/cutoff command is turned on and the Coulombic cutoff has been
@@ -450,6 +426,30 @@ or are not consecutively numbered. :dd
 This library function cannot be used if atom IDs are not defined or
 are not consecutively numbered, or if no atom map is defined.  See the
 atom_modify command for details about atom maps. :dd
+
+{Likewise 1-2 special neighbor interactions != 1.0} :dt
+
+The topology contains bonds, but there is no bond style defined
+and a 1-2 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the bond style. :dd
+
+{Likewise 1-3 special neighbor interactions != 1.0} :dt
+
+The topology contains angles, but there is no angle style defined
+and a 1-3 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the angle style. :dd
+
+{Likewise 1-4 special neighbor interactions != 1.0} :dt
+
+The topology contains dihedrals, but there is no dihedral style defined
+and a 1-4 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the dihedral style. :dd
 
 {Lost atoms via change_box: original %ld current %ld} :dt
 

--- a/doc/src/Errors_warnings.txt
+++ b/doc/src/Errors_warnings.txt
@@ -31,6 +31,30 @@ Doc page with "ERROR messages"_Errors_messages.html
 
 :dlb
 
+{1-2 special neighbor interactions != 1.0} :dt
+
+The topology contains bonds, but there is no bond style defined
+and a 1-2 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the bond style. :dd
+
+{1-3 special neighbor interactions != 1.0} :dt
+
+The topology contains angles, but there is no angle style defined
+and a 1-3 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the angle style. :dd
+
+{1-4 special neighbor interactions != 1.0} :dt
+
+The topology contains dihedrals, but there is no dihedral style defined
+and a 1-4 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the dihedral style. :dd
+
 {Adjusting Coulombic cutoff for MSM, new cutoff = %g} :dt
 
 The adjust/cutoff command is turned on and the Coulombic cutoff has been
@@ -46,6 +70,11 @@ too far away. :dd
 {Angle style in data file differs from currently defined angle style} :dt
 
 Self-explanatory. :dd
+
+{Angles are defined but no angle style is set} :dt
+
+The topology contains angles, but there are no angle forces computed
+since there was no angle_style command. :dd
 
 {Atom style in data file differs from currently defined atom style} :dt
 
@@ -72,6 +101,11 @@ short or the bond has blown apart and an atom is too far away. :dd
 {Bond style in data file differs from currently defined bond style} :dt
 
 Self-explanatory. :dd
+
+{Bonds are defined but no bond style is set} :dt
+
+The topology contains bonds, but there are no bond forces computed
+since there was no bond_style command. :dd
 
 {Bond/angle/dihedral extent > half of periodic box length} :dt
 
@@ -185,6 +219,11 @@ to check your simulation geometry. :dd
 {Dihedral style in data file differs from currently defined dihedral style} :dt
 
 Self-explanatory. :dd
+
+{Dihedrals are defined but no dihedral style is set} :dt
+
+The topology contains dihedrals, but there are no dihedral forces computed
+since there was no dihedral_style command. :dd
 
 {Dump dcd/xtc timestamp may be wrong with fix dt/reset} :dt
 
@@ -351,6 +390,11 @@ to check your simulation geometry. :dd
 {Improper style in data file differs from currently defined improper style} :dt
 
 Self-explanatory. :dd
+
+{Impropers are defined but no improper style is set} :dt
+
+The topology contains impropers, but there are no improper forces computed
+since there was no improper_style command. :dd
 
 {Inconsistent image flags} :dt
 

--- a/doc/src/min_spin.txt
+++ b/doc/src/min_spin.txt
@@ -17,8 +17,8 @@ min_style spin/lbfgs :pre
 
 [Examples:]
 
-min_style 	spin/lbfgs 
-min_modify      line spin_cubic discrete_factor 10.0 :pre
+min_style  spin/lbfgs
+min_modify line spin_cubic discrete_factor 10.0 :pre
 
 [Description:]
 

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -196,6 +196,28 @@ void Force::init()
   if (angle) angle->init();
   if (dihedral) dihedral->init();
   if (improper) improper->init();
+
+  // print warnings if topology and force field are inconsistent
+
+  if (comm->me == 0) {
+    if (!bond && (atom->nbonds > 0)) {
+      error->warning(FLERR,"Bonds are defined but no bond style is set");
+      if ((special_lj[1] != 1.0) || (special_coul[1] != 1.0))
+	error->warning(FLERR,"1-2 special neighbor interactions != 1.0");
+    }
+    if (!angle && (atom->nangles > 0)) {
+      error->warning(FLERR,"Angles are defined but no angle style is set");
+      if ((special_lj[2] != 1.0) || (special_coul[2] != 1.0))
+	error->warning(FLERR,"1-3 special neighbor interactions != 1.0");
+    }
+    if (!dihedral && (atom->ndihedrals > 0)) {
+      error->warning(FLERR,"Dihedrals are defined but no dihedral style is set");
+      if ((special_lj[3] != 1.0) || (special_coul[3] != 1.0))
+	error->warning(FLERR,"1-4 special neighbor interactions != 1.0");
+    }
+    if (!improper && (atom->nimpropers > 0))
+      error->warning(FLERR,"Impropers are defined but no improper style is set");
+  }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -203,17 +203,17 @@ void Force::init()
     if (!bond && (atom->nbonds > 0)) {
       error->warning(FLERR,"Bonds are defined but no bond style is set");
       if ((special_lj[1] != 1.0) || (special_coul[1] != 1.0))
-	error->warning(FLERR,"1-2 special neighbor interactions != 1.0");
+	error->warning(FLERR,"Likewise 1-2 special neighbor interactions != 1.0");
     }
     if (!angle && (atom->nangles > 0)) {
       error->warning(FLERR,"Angles are defined but no angle style is set");
       if ((special_lj[2] != 1.0) || (special_coul[2] != 1.0))
-	error->warning(FLERR,"1-3 special neighbor interactions != 1.0");
+	error->warning(FLERR,"Likewise 1-3 special neighbor interactions != 1.0");
     }
     if (!dihedral && (atom->ndihedrals > 0)) {
       error->warning(FLERR,"Dihedrals are defined but no dihedral style is set");
       if ((special_lj[3] != 1.0) || (special_coul[3] != 1.0))
-	error->warning(FLERR,"1-4 special neighbor interactions != 1.0");
+	error->warning(FLERR,"Likewise 1-4 special neighbor interactions != 1.0");
     }
     if (!improper && (atom->nimpropers > 0))
       error->warning(FLERR,"Impropers are defined but no improper style is set");

--- a/src/force.h
+++ b/src/force.h
@@ -246,7 +246,7 @@ W: Impropers are defined but no improper style is set
 The topology contains impropers, but there are no improper forces computed
 since there was no improper_style command.
 
-W: 1-2 special neighbor interactions != 1.0
+W: Likewise 1-2 special neighbor interactions != 1.0
 
 The topology contains bonds, but there is no bond style defined
 and a 1-2 special neighbor scaling factor was not 1.0. This
@@ -254,7 +254,7 @@ means that pair style interactions may have scaled or missing
 pairs in the neighbor list in expectation of interactions for
 those pairs being computed from the bond style.
 
-W: 1-3 special neighbor interactions != 1.0
+W: Likewise 1-3 special neighbor interactions != 1.0
 
 The topology contains angles, but there is no angle style defined
 and a 1-3 special neighbor scaling factor was not 1.0. This
@@ -262,7 +262,7 @@ means that pair style interactions may have scaled or missing
 pairs in the neighbor list in expectation of interactions for
 those pairs being computed from the angle style.
 
-W: 1-4 special neighbor interactions != 1.0
+W: Likewise 1-4 special neighbor interactions != 1.0
 
 The topology contains dihedrals, but there is no dihedral style defined
 and a 1-4 special neighbor scaling factor was not 1.0. This

--- a/src/force.h
+++ b/src/force.h
@@ -226,4 +226,48 @@ A command with an argument that specifies an integer or range of
 integers is using a value that is less than 1 or greater than the
 maximum allowed limit.
 
+W: Bonds are defined but no bond style is set
+
+The topology contains bonds, but there are no bond forces computed
+since there was no bond_style command.
+
+W: Angles are defined but no angle style is set
+
+The topology contains angles, but there are no angle forces computed
+since there was no angle_style command.
+
+W: Dihedrals are defined but no dihedral style is set
+
+The topology contains dihedrals, but there are no dihedral forces computed
+since there was no dihedral_style command.
+
+W: Impropers are defined but no improper style is set
+
+The topology contains impropers, but there are no improper forces computed
+since there was no improper_style command.
+
+W: 1-2 special neighbor interactions != 1.0
+
+The topology contains bonds, but there is no bond style defined
+and a 1-2 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the bond style.
+
+W: 1-3 special neighbor interactions != 1.0
+
+The topology contains angles, but there is no angle style defined
+and a 1-3 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the angle style.
+
+W: 1-4 special neighbor interactions != 1.0
+
+The topology contains dihedrals, but there is no dihedral style defined
+and a 1-4 special neighbor scaling factor was not 1.0. This
+means that pair style interactions may have scaled or missing
+pairs in the neighbor list in expectation of interactions for
+those pairs being computed from the dihedral style.
+
 */


### PR DESCRIPTION
**Summary**

Print a warning when the topology contains bonds, angles, dihedrals, or impropers and no corresponding force style is defined. 

This is a warning similar in spirit to the warning that reminds people about forces being computed but no time integration fixes defined.

**Author(s)**

Axel Kohlmeyer (ICTP)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known backward compatibility issues.

**Implementation Notes**

There is an additional check and warning, if there is a pair style in use and the corresponding 1-2, 1-3, or 1-4 scaling factor is not 1.0 for both LJ and Coulomb. This would mean that pairwise interactions would be missing or scaled in the pair style, but there is no corresponding force computation for the bonded interactions.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

