### PR TITLE
Step up cmake required version to support CMAKE_CXX_STANDARD

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMake build system
 # This file is part of LAMMPS
 # Created by Christoph Junghans and Richard Berger
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.3)
 
 project(lammps CXX)
 set(SOVERSION 0)


### PR DESCRIPTION
**Summary**

`CMAKE_CXX_STANDARD` is not supported by CMake versions prior to 3.1. The C++11 test does not add the relevant compiler flag, and setting manually `-DCMAKE_CXX_STANDARD=11` raises a warning about the variable being unused.

It is still possible, though less portable, to enforce C++ standard via `CXXFLAGS`.

Error found on CentOS 7.7 with `cmake` 2.8.12 (RPM repository version).

**Author(s)**

@giacomofiorin 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Fix.

**Implementation Notes**

Single-line change from `2.8.12` to `3.1.3`.

**Post Submission Checklist**

- [x] The feature has been verified to work with the CMake based build system

