### PR TITLE
Add Singularity definition files suitable for compiling and debugging LAMMPS

### DIFF
--- a/doc/src/Tools.txt
+++ b/doc/src/Tools.txt
@@ -87,6 +87,7 @@ Miscellaneous tools :h3
 "emacs"_#emacs,
 "i-pi"_#ipi,
 "kate"_#kate,
+"singularity"_#singularity_tool,
 "vim"_#vim :tb(c=5,ea=c,a=l)
 
 :line
@@ -539,6 +540,15 @@ See the README file in tools/spin/interpolate_gneb for more details.
 This tool was written by the SPIN package author, Julien
 Tranchida at Sandia National Labs (jtranch at sandia.gov, and by Aleksei
 Ivanov, at University of Iceland (ali5 at hi.is).
+
+:line
+
+singularity tool :h4,link(singularity_tool)
+
+The singularity sub-directory contains container definitions files
+that can be used to build container images for building and testing
+LAMMPS on specific OS variants using the "Singularity"_https://sylabs.io
+container software. Contributions for additional variants are welcome.
 
 :line
 

--- a/tools/singularity/README.md
+++ b/tools/singularity/README.md
@@ -18,7 +18,7 @@ mkdir build-centos7
 cd build-centos7
 sudo singularity build centos7.sif ../tools/singularity/centos7.def
 singularity shell centos7.sif
-cmake ../cmake -C ../cmake/presets/most.cmake -DCMAKE_CXX_FLAGS="-O3 -g -fopenmp -std=c++11"
+cmake -C ../cmake/presets/most.cmake -D CMAKE_CXX_FLAGS="-O3 -g -fopenmp -std=c++11" ../cmake
 make
 ```
 

--- a/tools/singularity/README.md
+++ b/tools/singularity/README.md
@@ -1,0 +1,28 @@
+# Singularity container definitions for compiling/testing LAMMPS
+
+The *.def files in this folder can be used to build container images
+for [Singularity](https://sylabs.io) suitable for compiling and testing
+LAMMPS on a variety of OS variants with support for most standard packages
+and building/spellchecking the manual. This allows to test and debug
+LAMMPS code on different OS variants than what is locally installed on
+your development workstation, e.g. when bugs are reported that can only
+be reproduced on a specific OS or with specific (mostly older) versions
+of tools, compilers, or libraries.
+
+Here is a workflow for testing a compilation of LAMMPS with a CentOS 7.x container.
+
+```
+cd some/work/directory
+git clone --depth 500  git://github.com/lammps/lammps.git lammps
+mkdir build-centos7
+cd build-centos7
+sudo singularity build centos7.sif ../tools/singularity/centos7.def
+singularity shell centos7.sif
+cmake ../cmake -C ../cmake/presets/most.cmake -DCMAKE_CXX_FLAGS="-O3 -g -fopenmp -std=c++11"
+make
+```
+
+| Currently available: |     |
+| --- | --- |
+| centos7.def | CentOS 7.x with EPEL enabled |
+| ubuntu18.04.def | Ubuntu 18.04LTS with default MPI == OpenMPI |

--- a/tools/singularity/centos7.def
+++ b/tools/singularity/centos7.def
@@ -1,0 +1,10 @@
+BootStrap: library
+From: centos:7
+
+%post
+	yum -y install epel-release
+        yum -y update
+	yum -y install vim-enhanced ccache gcc-c++ gcc-gfortran clang gdb valgrind-openmpi make cmake cmake3 patch which file git libpng-devel libjpeg-devel openmpi-devel mpich-devel python-devel python-virtualenv fftw-devel voro++-devel eigen3-devel gsl-devel openblas-devel enchant
+
+%labels
+	Author akohlmey

--- a/tools/singularity/ubuntu18.04.def
+++ b/tools/singularity/ubuntu18.04.def
@@ -1,0 +1,9 @@
+BootStrap: docker
+From: ubuntu:18.04
+
+%post
+	apt-get update -y
+	env DEBIAN_FRONTEND=noninteractive apt-get install -y make cmake git gcc g++ gfortran libfftw3-dev libjpeg-dev libpng-dev libblas-dev liblapack-dev mpi-default-bin mpi-default-dev libeigen3-dev libgsl-dev libopenblas-dev virtualenv python-dev enchant vim-nox ccache voro++-dev
+
+%labels
+	Author akohlmey


### PR DESCRIPTION
**Summary**

This adds a sub-directory `singularity` to the `tools` folder, that allows to build custom container images for use with singularity, that can be used to test/compile/debug LAMMPS with many
packages out-of-the-box. Particularly useful to try and reproduce issues that only show up with older OS variants.

**NOTE:** These are not ready-to-use images and they do not contain LAMMPS, so this is not aimed at the same audience issue #1433 was asking for. This is aimed at LAMMPS developer/contributors.

**Author(s)**

Axel Kohlmeyer (ICTP)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

New files. No issues.

**Implementation Notes**

The ubuntu 18.04 example is based a docker image, since the image present in the singularity library cannot install an MPI package (I suspect that is deliberate, but it can also mean, that I am not in tune enough with ubuntu to figure it out).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
