### PR TITLE
Update compute_gyration_shape.cpp

### DIFF
--- a/doc/src/compute_gyration_shape.txt
+++ b/doc/src/compute_gyration_shape.txt
@@ -84,3 +84,6 @@ package"_Build_package.html doc page for more info.
 :link(Theodorou)
 [(Theodorou)] Theodorou, Suter, Macromolecules, 18, 1206 (1985).
 
+:link(Mattice)
+[(Mattice)] Mattice, Suter, Conformational Theory of Large Molecules, Wiley, New York, 1994. 
+

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -1582,6 +1582,7 @@ Materias
 mathbf
 matlab
 matplotlib
+Mattice
 Mattox
 Mattson
 maxangle

--- a/src/USER-MISC/compute_gyration_shape.cpp
+++ b/src/USER-MISC/compute_gyration_shape.cpp
@@ -112,19 +112,15 @@ void ComputeGyrationShape::compute_vector()
   }
 
   // compute the shape parameters of the gyration tensor
-  double sq_eigen_x = MathSpecial::square(evalues[0]);
-  double sq_eigen_y = MathSpecial::square(evalues[1]);
-  double sq_eigen_z = MathSpecial::square(evalues[2]);
-
-  double nominator = MathSpecial::square(sq_eigen_x)
-    + MathSpecial::square(sq_eigen_y)
-    + MathSpecial::square(sq_eigen_z);
-  double denominator = MathSpecial::square(sq_eigen_x+sq_eigen_y+sq_eigen_z);
+  double nominator = MathSpecial::square(evalues[0])
+    + MathSpecial::square(evalues[1])
+    + MathSpecial::square(evalues[2]);
+  double denominator = MathSpecial::square(evalues[0]+evalues[1]+evalues[2]);
 
   vector[0] = evalues[0];
   vector[1] = evalues[1];
   vector[2] = evalues[2];
-  vector[3] = sq_eigen_z - 0.5*(sq_eigen_x + sq_eigen_y);
-  vector[4] = sq_eigen_y - sq_eigen_x;
-  vector[5] = 0.5*(3*nominator/denominator - 1.0);
+  vector[3] = evalues[0] - 0.5*(evalues[1] + evalues[2]);
+  vector[4] = evalues[1] - evalues[2];
+  vector[5] = 1.5*nominator/denominator - 0.5;
 }


### PR DESCRIPTION
Correct for squaring the eigenvalues of the gyration tensor and simplifying the expressions for the shape parameters

**Summary**

In the initial version I submitted, the eigenvalues of the gyration tensor were raised to the power of two which was erroneous. Upon fixing that logical bug, the other expressions for the shape parameters can be further simplified and made shorter. 

**Related Issues**

Not related to any issue

**Author(s)**

Evangelos Voyiatzis @ Royal DSM (evoyiatzis@gmail.com)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No backward compatibility issues



**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included




