### PR TITLE
Gpu mem leak with init invoked multiple times

### DIFF
--- a/lib/gpu/lal_base_atomic.cpp
+++ b/lib/gpu/lal_base_atomic.cpp
@@ -25,12 +25,16 @@ BaseAtomicT::BaseAtomic() : _compiled(false), _max_bytes(0)  {
   device=&global_device;
   ans=new Answer<numtyp,acctyp>();
   nbor=new Neighbor();
+  pair_program=NULL;
 }
 
 template <class numtyp, class acctyp>
 BaseAtomicT::~BaseAtomic() {
   delete ans;
   delete nbor;
+  if (pair_program) delete pair_program;
+  k_pair_fast.clear();
+  k_pair.clear();
 }
 
 template <class numtyp, class acctyp>
@@ -109,19 +113,11 @@ void BaseAtomicT::clear_atomic() {
   device->output_times(time_pair,*ans,*nbor,avg_split,_max_bytes+_max_an_bytes,
                        _gpu_overhead,_driver_overhead,_threads_per_atom,screen);
 
-  if (_compiled) {
-    k_pair_fast.clear();
-    k_pair.clear();
-    delete pair_program;
-    _compiled=false;
-  }
-
   time_pair.clear();
   hd_balancer.clear();
 
   nbor->clear();
   ans->clear();
-  device->clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -276,6 +272,7 @@ void BaseAtomicT::compile_kernels(UCL_Device &dev, const void *pair_str,
     return;
 
   std::string s_fast=std::string(kname)+"_fast";
+  if (pair_program) delete pair_program;
   pair_program=new UCL_Program(dev);
   pair_program->load_string(pair_str,device->compile_string().c_str());
   k_pair_fast.set_function(*pair_program,s_fast.c_str());

--- a/lib/gpu/lal_base_charge.cpp
+++ b/lib/gpu/lal_base_charge.cpp
@@ -25,12 +25,16 @@ BaseChargeT::BaseCharge() : _compiled(false), _max_bytes(0) {
   device=&global_device;
   ans=new Answer<numtyp,acctyp>();
   nbor=new Neighbor();
+  pair_program=NULL;
 }
 
 template <class numtyp, class acctyp>
 BaseChargeT::~BaseCharge() {
   delete ans;
   delete nbor;
+  if (pair_program) delete pair_program;
+  k_pair_fast.clear();
+  k_pair.clear();
 }
 
 template <class numtyp, class acctyp>
@@ -111,19 +115,11 @@ void BaseChargeT::clear_atomic() {
   device->output_times(time_pair,*ans,*nbor,avg_split,_max_bytes+_max_an_bytes,
                        _gpu_overhead,_driver_overhead,_threads_per_atom,screen);
 
-  if (_compiled) {
-    k_pair_fast.clear();
-    k_pair.clear();
-    delete pair_program;
-    _compiled=false;
-  }
-
   time_pair.clear();
   hd_balancer.clear();
 
   nbor->clear();
   ans->clear();
-  device->clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +287,7 @@ void BaseChargeT::compile_kernels(UCL_Device &dev, const void *pair_str,
     return;
 
   std::string s_fast=std::string(kname)+"_fast";
+  if (pair_program) delete pair_program;
   pair_program=new UCL_Program(dev);
   pair_program->load_string(pair_str,device->compile_string().c_str());
   k_pair_fast.set_function(*pair_program,s_fast.c_str());

--- a/lib/gpu/lal_base_dipole.cpp
+++ b/lib/gpu/lal_base_dipole.cpp
@@ -25,12 +25,16 @@ BaseDipoleT::BaseDipole() : _compiled(false), _max_bytes(0) {
   device=&global_device;
   ans=new Answer<numtyp,acctyp>();
   nbor=new Neighbor();
+  pair_program=NULL;
 }
 
 template <class numtyp, class acctyp>
 BaseDipoleT::~BaseDipole() {
   delete ans;
   delete nbor;
+  if (pair_program) delete pair_program;
+  k_pair_fast.clear();
+  k_pair.clear();
 }
 
 template <class numtyp, class acctyp>
@@ -113,19 +117,11 @@ void BaseDipoleT::clear_atomic() {
   device->output_times(time_pair,*ans,*nbor,avg_split,_max_bytes+_max_an_bytes,
                        _gpu_overhead,_driver_overhead,_threads_per_atom,screen);
 
-  if (_compiled) {
-    k_pair_fast.clear();
-    k_pair.clear();
-    delete pair_program;
-    _compiled=false;
-  }
-
   time_pair.clear();
   hd_balancer.clear();
 
   nbor->clear();
   ans->clear();
-  device->clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +295,7 @@ void BaseDipoleT::compile_kernels(UCL_Device &dev, const void *pair_str,
     return;
 
   std::string s_fast=std::string(kname)+"_fast";
+  if (pair_program) delete pair_program;
   pair_program=new UCL_Program(dev);
   pair_program->load_string(pair_str,device->compile_string().c_str());
   k_pair_fast.set_function(*pair_program,s_fast.c_str());

--- a/lib/gpu/lal_base_ellipsoid.cpp
+++ b/lib/gpu/lal_base_ellipsoid.cpp
@@ -33,12 +33,25 @@ BaseEllipsoidT::BaseEllipsoid() : _compiled(false), _max_bytes(0) {
   device=&global_device;
   ans=new Answer<numtyp,acctyp>();
   nbor=new Neighbor();
+  nbor_program=NULL;
+  ellipsoid_program=NULL;
+  lj_program=NULL;
 }
 
 template <class numtyp, class acctyp>
 BaseEllipsoidT::~BaseEllipsoid() {
   delete ans;
   delete nbor;
+  k_nbor_fast.clear();
+  k_nbor.clear();
+  k_ellipsoid.clear();
+  k_ellipsoid_sphere.clear();
+  k_sphere_ellipsoid.clear();
+  k_lj_fast.clear();
+  k_lj.clear();
+  if (nbor_program) delete nbor_program;
+  if (ellipsoid_program) delete ellipsoid_program;
+  if (lj_program) delete lj_program;
 }
 
 template <class numtyp, class acctyp>
@@ -146,20 +159,6 @@ void BaseEllipsoidT::clear_base() {
   output_times();
   host_olist.clear();
 
-  if (_compiled) {
-    k_nbor_fast.clear();
-    k_nbor.clear();
-    k_ellipsoid.clear();
-    k_ellipsoid_sphere.clear();
-    k_sphere_ellipsoid.clear();
-    k_lj_fast.clear();
-    k_lj.clear();
-    delete nbor_program;
-    delete ellipsoid_program;
-    delete lj_program;
-    _compiled=false;
-  }
-
   time_nbor1.clear();
   time_ellipsoid.clear();
   time_nbor2.clear();
@@ -171,7 +170,6 @@ void BaseEllipsoidT::clear_base() {
 
   nbor->clear();
   ans->clear();
-  device->clear();
 }
 
 template <class numtyp, class acctyp>
@@ -437,6 +435,7 @@ int** BaseEllipsoidT::compute(const int ago, const int inum_full, const int nall
   ans->copy_answers(eflag,vflag,eatom,vatom);
   device->add_ans_object(ans);
   hd_balancer.stop_timer();
+
   return nbor->host_jlist.begin()-host_start;
 }
 
@@ -462,18 +461,21 @@ void BaseEllipsoidT::compile_kernels(UCL_Device &dev,
 
   std::string flags=device->compile_string();
 
+  if (nbor_program) delete nbor_program;
   nbor_program=new UCL_Program(dev);
   nbor_program->load_string(ellipsoid_nbor,flags.c_str());
   k_nbor_fast.set_function(*nbor_program,"kernel_nbor_fast");
   k_nbor.set_function(*nbor_program,"kernel_nbor");
   neigh_tex.get_texture(*nbor_program,"pos_tex");
 
+  if (ellipsoid_program) delete ellipsoid_program;
   ellipsoid_program=new UCL_Program(dev);
   ellipsoid_program->load_string(ellipsoid_string,flags.c_str());
   k_ellipsoid.set_function(*ellipsoid_program,kname);
   pos_tex.get_texture(*ellipsoid_program,"pos_tex");
   quat_tex.get_texture(*ellipsoid_program,"quat_tex");
 
+  if (lj_program) delete lj_program;
   lj_program=new UCL_Program(dev);
   lj_program->load_string(lj_string,flags.c_str());
   k_sphere_ellipsoid.set_function(*lj_program,s_sphere_ellipsoid.c_str());

--- a/lib/gpu/lal_base_three.cpp
+++ b/lib/gpu/lal_base_three.cpp
@@ -27,6 +27,7 @@ BaseThreeT::BaseThree() : _compiled(false), _max_bytes(0) {
   #ifdef THREE_CONCURRENT
   ans2=new Answer<numtyp,acctyp>();
   #endif
+  pair_program=NULL;
 }
 
 template <class numtyp, class acctyp>
@@ -36,6 +37,12 @@ BaseThreeT::~BaseThree() {
   #ifdef THREE_CONCURRENT
   delete ans2;
   #endif
+  if (pair_program) delete pair_program;
+  k_three_center.clear();
+  k_three_end.clear();
+  k_three_end_vatom.clear();
+  k_pair.clear();
+  k_short_nbor.clear();
 }
 
 template <class numtyp, class acctyp>
@@ -139,16 +146,6 @@ void BaseThreeT::clear_atomic() {
   device->output_times(time_pair,*ans,*nbor,avg_split,_max_bytes+_max_an_bytes,
                        _gpu_overhead,_driver_overhead,_threads_per_atom,screen);
 
-  if (_compiled) {
-    k_three_center.clear();
-    k_three_end.clear();
-    k_three_end_vatom.clear();
-    k_pair.clear();
-    k_short_nbor.clear();
-    delete pair_program;
-    _compiled=false;
-  }
-
   time_pair.clear();
   hd_balancer.clear();
 
@@ -161,7 +158,6 @@ void BaseThreeT::clear_atomic() {
   // ucl_device will clean up the command queue in its destructor
 //  ucl_device->pop_command_queue();
   #endif
-  device->clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -378,7 +374,7 @@ void BaseThreeT::compile_kernels(UCL_Device &dev, const void *pair_str,
     return;
 
   std::string vatom_name=std::string(three_end)+"_vatom";
-
+  if (pair_program) delete pair_program;
   pair_program=new UCL_Program(dev);
   pair_program->load_string(pair_str,device->compile_string().c_str());
   k_three_center.set_function(*pair_program,three_center);

--- a/lib/gpu/lal_pppm.cpp
+++ b/lib/gpu/lal_pppm.cpp
@@ -35,12 +35,17 @@ PPPMT::PPPM() : _allocated(false), _compiled(false),
                                   _max_bytes(0) {
   device=&global_device;
   ans=new Answer<numtyp,acctyp>();
+  pppm_program=NULL;
 }
 
 template <class numtyp, class acctyp, class grdtyp, class grdtyp4>
 PPPMT::~PPPM() {
   clear(0.0);
   delete ans;
+  k_particle_map.clear();
+  k_make_rho.clear();
+  k_interp.clear();
+  if (pppm_program) delete pppm_program;
 }
 
 template <class numtyp, class acctyp, class grdtyp, class grdtyp4>
@@ -192,14 +197,6 @@ void PPPMT::clear(const double cpu_time) {
                               *ans,_max_bytes+_max_an_bytes,cpu_time,
                               _cpu_idle_time,screen);
 
-  if (_compiled) {
-    k_particle_map.clear();
-    k_make_rho.clear();
-    k_interp.clear();
-    delete pppm_program;
-    _compiled=false;
-  }
-
   time_in.clear();
   time_out.clear();
   time_map.clear();
@@ -207,7 +204,6 @@ void PPPMT::clear(const double cpu_time) {
   time_interp.clear();
 
   ans->clear();
-  device->clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -380,6 +376,7 @@ void PPPMT::compile_kernels(UCL_Device &dev) {
          ucl_template_name<grdtyp>()+"4";
   #endif
 
+  if (pppm_program) delete pppm_program;
   pppm_program=new UCL_Program(dev);
 
   #ifdef USE_OPENCL


### PR DESCRIPTION
**Summary**

This PR is to address the issue #1678 with the GPU package where host memory allocation increases when the run command is called multiple times.
 
**Related Issues**

Fixes #1678 

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

The issue disappears if "pre no" is used, suggesting that the problem comes from init_style() in the /gpu pair styles, which go into the init function of the corresponding pair styles and pppm in the GPU library. The host memory increase is not reported as memory leaks by valgrind, but massif does show the memory allocation increase associated with libcuda.so for CUDA builds and libopencl.so with OpenCL builds. The changes in this PR are made to the base classes, which 1) remove a call to device->clear() in the clear_atomic() function, 2) move the section where the kernel and program deallocation to the destructor (assuming that the kernels and program are needed to be compiled once), and 3) initialize pair_program with NULL in the constructor, and delete the pointer if it is not NULL (that is, already allocated).

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
