### PR TITLE
Improve code consistency when accessing the communication cutoff

### DIFF
--- a/doc/src/Errors_warnings.txt
+++ b/doc/src/Errors_warnings.txt
@@ -390,6 +390,11 @@ have fully consistent image flags, since some bonds will cross
 periodic boundaries and connect two atoms with the same image
 flag. :dd
 
+{Increasing communication cutoff for GPU style} :dt
+
+The pair style has increased the communication cutoff to be consistent with
+the communication cutoff requirements for this pair style when run on the GPU. :dd
+
 {KIM Model does not provide 'energy'; Potential energy will be zero} :dt
 
 Self-explanatory. :dd

--- a/src/GPU/gpu_extra.h
+++ b/src/GPU/gpu_extra.h
@@ -133,4 +133,9 @@ E: Unknown error in GPU library
 
 Self-explanatory.
 
+W: Increasing communication cutoff for GPU style
+
+The pair style has increased the communication cutoff to be consistent with
+the communication cutoff requirements for this pair style when run on the GPU.
+
 */

--- a/src/GPU/pair_sw_gpu.cpp
+++ b/src/GPU/pair_sw_gpu.cpp
@@ -206,8 +206,11 @@ void PairSWGPU::init_style()
     neighbor->requests[irequest]->ghost = 1;
   }
 
-  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin) )
+  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin)) {
     comm->cutghostuser=2.0*cutmax + neighbor->skin;
+    if (comm->me == 0)
+       error->warning(FLERR,"Increasing communication cutoff for GPU style");
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/GPU/pair_tersoff_gpu.cpp
+++ b/src/GPU/pair_tersoff_gpu.cpp
@@ -240,8 +240,11 @@ void PairTersoffGPU::init_style()
     neighbor->requests[irequest]->ghost = 1;
   }
 
-  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin) )
+  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin)) {
     comm->cutghostuser = 2.0*cutmax + neighbor->skin;
+    if (comm->me == 0)
+       error->warning(FLERR,"Increasing communication cutoff for GPU style");
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/GPU/pair_tersoff_mod_gpu.cpp
+++ b/src/GPU/pair_tersoff_mod_gpu.cpp
@@ -232,8 +232,11 @@ void PairTersoffMODGPU::init_style()
     neighbor->requests[irequest]->ghost = 1;
   }
 
-  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin) )
+  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin)) {
     comm->cutghostuser = 2.0*cutmax + neighbor->skin;
+    if (comm->me == 0)
+       error->warning(FLERR,"Increasing communication cutoff for GPU style");
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/GPU/pair_tersoff_zbl_gpu.cpp
+++ b/src/GPU/pair_tersoff_zbl_gpu.cpp
@@ -254,8 +254,11 @@ void PairTersoffZBLGPU::init_style()
     neighbor->requests[irequest]->ghost = 1;
   }
 
-  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin) )
+  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin)) {
     comm->cutghostuser = 2.0*cutmax + neighbor->skin;
+    if (comm->me == 0)
+       error->warning(FLERR,"Increasing communication cutoff for GPU style");
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/GPU/pair_vashishta_gpu.cpp
+++ b/src/GPU/pair_vashishta_gpu.cpp
@@ -234,9 +234,11 @@ void PairVashishtaGPU::init_style()
     neighbor->requests[irequest]->ghost = 1;
   }
 
-  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin) )
+  if (comm->cutghostuser < (2.0*cutmax + neighbor->skin)) {
     comm->cutghostuser=2.0*cutmax + neighbor->skin;
-
+    if (comm->me == 0)
+       error->warning(FLERR,"Increasing communication cutoff for GPU style");
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/REPLICA/fix_hyper_local.cpp
+++ b/src/REPLICA/fix_hyper_local.cpp
@@ -250,11 +250,7 @@ void FixHyperLocal::init()
   // warn if no drift distance added to cutghost
 
   if (firstflag) {
-    double cutghost;
-    if (force->pair)
-      cutghost = MAX(force->pair->cutforce+neighbor->skin,comm->cutghostuser);
-    else
-      cutghost = comm->cutghostuser;
+    double cutghost = comm->get_comm_cutoff();
 
     if (cutghost < dcut)
       error->all(FLERR,"Fix hyper/local domain cutoff exceeds ghost atom range - "

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -3097,7 +3097,7 @@ void FixSRD::setup_bounds()
   //     max distance to move without being lost during comm->exchange()
   //   subsize = perp distance between sub-domain faces (orthog or triclinic)
 
-  double cut = MAX(neighbor->cutneighmax,comm->cutghostuser);
+  double cut = comm->get_comm_cutoff();
   double onemove = dt_big*vmax;
 
   if (bigexist) {

--- a/src/USER-SMD/pair_smd_tlsph.cpp
+++ b/src/USER-SMD/pair_smd_tlsph.cpp
@@ -86,7 +86,7 @@ PairTlsph::PairTlsph(LAMMPS *lmp) :
         comm_forward = 22; // this pair style communicates 20 doubles to ghost atoms : PK1 tensor + F tensor + shepardWeight
         fix_tlsph_reference_configuration = NULL;
 
-        cut_comm = MAX(neighbor->cutneighmax, comm->cutghostuser); // cutoff radius within which ghost atoms are communicated.
+        cut_comm = comm->get_comm_cutoff();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -916,7 +916,7 @@ void PairTlsph::settings(int narg, char **arg) {
          * is the folowing.
          */
 
-        cut_comm = MAX(neighbor->cutneighmax, comm->cutghostuser); // cutoff radius within which ghost atoms are communicated.
+        cut_comm = comm->get_comm_cutoff();
         update_threshold = cut_comm;
         update_method = UPDATE_NONE;
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -668,7 +668,7 @@ double Comm::get_comm_cutoff()
   // always take the larger of max neighbor list and user specified cutoff
 
   if (force->pair)
-    maxcommcutoff = MAX(neighbor->cutneighmax,pair->cutforce+neighbor->skin);
+    maxcommcutoff = MAX(neighbor->cutneighmax,force->pair->cutforce+neighbor->skin);
 
   maxcommcutoff = MAX(maxcommcutoff,cutghostuser);
 
@@ -676,7 +676,7 @@ double Comm::get_comm_cutoff()
   // cutoff was given and no pair style present. Otherwise print a
   // warning, if the estimated bond based cutoff is larger than what
   // is currently used.
-  
+
   if (!force->pair && (cutghostuser == 0.0)) {
     maxcommcutoff = MAX(maxcommcutoff,maxbondcutoff);
   } else {

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -667,7 +667,10 @@ double Comm::get_comm_cutoff()
 
   // always take the larger of max neighbor list and user specified cutoff
 
-  maxcommcutoff = MAX(cutghostuser,neighbor->cutneighmax);
+  if (force->pair)
+    maxcommcutoff = MAX(neighbor->cutneighmax,pair->cutforce+neighbor->skin);
+
+  maxcommcutoff = MAX(maxcommcutoff,cutghostuser);
 
   // use cutoff estimate from bond length only if no user specified
   // cutoff was given and no pair style present. Otherwise print a

--- a/src/compute_adf.cpp
+++ b/src/compute_adf.cpp
@@ -299,9 +299,9 @@ void ComputeADF::init()
   if (!(force->pair) || maxouter > force->pair->cutforce) {
     double skin = neighbor->skin;
     mycutneigh = maxouter + skin;
-    if (mycutneigh > comm->cutghostuser)
+    if (mycutneigh > comm->get_comm_cutoff())
       error->all(FLERR,"Compute adf outer cutoff exceeds ghost atom range - "
-                 "use comm_modify cutoff command");
+                 "use comm_modify cutoff command to increase it");
   }
 
   // assign ordinate values to 1st column of output array

--- a/src/compute_rdf.cpp
+++ b/src/compute_rdf.cpp
@@ -161,17 +161,12 @@ void ComputeRDF::init()
 
   if (cutflag) {
     double skin = neighbor->skin;
+    double cutghost = comm->get_comm_cutoff();
     mycutneigh = cutoff_user + skin;
 
-    double cutghost;            // as computed by Neighbor and Comm
-    if (force->pair)
-      cutghost = MAX(force->pair->cutforce+skin,comm->cutghostuser);
-    else
-      cutghost = comm->cutghostuser;
-
     if (mycutneigh > cutghost)
-      error->all(FLERR,"Compute rdf cutoff exceeds ghost atom range - "
-                 "use comm_modify cutoff command");
+      error->all(FLERR,"Compute rdf cutoff plus skin exceeds ghost atom range - "
+                 "use comm_modify cutoff command to increase it");
     if (force->pair && mycutneigh < force->pair->cutforce + skin)
       if (comm->me == 0)
         error->warning(FLERR,"Compute rdf cutoff less than neighbor cutoff - "


### PR DESCRIPTION
**Summary**

Refactor code that would either incorrectly only look at `comm->cutghostuser` or try to mimic the automatic computation of the communication cutoff to use the recently added `comm->get_comm_cutoff()` API, so that that information is consistent with whatever computations or heuristics are used to determine this cutoff.

Also add a few warnings when pair styles in the GPU package increase the communication cutoff to satisfy the requirements for their neighbor list processing (to improve performance).
  
**Author(s)**

Axel Kohlmeyer (ICTP)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issue. Should improve correctness, where the cutoff determination was not fully consistent with the recently changed code.

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

