### PR TITLE
Update singularity definition files in tools folder

### DIFF
--- a/tools/singularity/README.md
+++ b/tools/singularity/README.md
@@ -9,7 +9,13 @@ your development workstation, e.g. when bugs are reported that can only
 be reproduced on a specific OS or with specific (mostly older) versions
 of tools, compilers, or libraries.
 
-Here is a workflow for testing a compilation of LAMMPS with a CentOS 7.x container.
+Ready-to-use container images built from these definition files are
+occasionally uploaded to the container library at sylabs.io. They
+can be found here: https://cloud.sylabs.io/library/lammps/default/lammps_development#
+and will be signed with the key fingerprint: EEA103764C6C633EDC8AC428D9B44E93BF0C375A
+
+Here is a workflow for testing a compilation of LAMMPS with a locally
+built CentOS 7.x singularity container.
 
 ```
 cd some/work/directory
@@ -19,6 +25,20 @@ cd build-centos7
 sudo singularity build centos7.sif ../tools/singularity/centos7.def
 singularity shell centos7.sif
 cmake -C ../cmake/presets/most.cmake -D CMAKE_CXX_FLAGS="-O3 -g -fopenmp -std=c++11" ../cmake
+make
+```
+
+And here is the equivalent workflow for testing a compilation of LAMMPS
+using a pre-built Ubuntu 18.04LTS singularity container.
+
+```
+cd some/work/directory
+git clone --depth 500  git://github.com/lammps/lammps.git lammps
+mkdir build-ubuntu18
+cd build-ubuntu18
+singularity pull library://lammps/default/lammps_development:ubuntu18.04
+singularity shell lammps_development_ubuntu18.04.sif
+cmake -C ../cmake/presets/most.cmake ../cmake
 make
 ```
 

--- a/tools/singularity/README.md
+++ b/tools/singularity/README.md
@@ -25,4 +25,6 @@ make
 | Currently available: |     |
 | --- | --- |
 | centos7.def | CentOS 7.x with EPEL enabled |
+| centos8.def | CentOS 8.x with EPEL enabled |
+| ubuntu16.04.def | Ubuntu 16.04LTS with default MPI == OpenMPI |
 | ubuntu18.04.def | Ubuntu 18.04LTS with default MPI == OpenMPI |

--- a/tools/singularity/centos7.def
+++ b/tools/singularity/centos7.def
@@ -4,7 +4,7 @@ From: centos:7
 %post
 	yum -y install epel-release
         yum -y update
-	yum -y install vim-enhanced ccache gcc-c++ gcc-gfortran clang gdb valgrind-openmpi make cmake cmake3 patch which file git libpng-devel libjpeg-devel openmpi-devel mpich-devel python-devel python-virtualenv fftw-devel voro++-devel eigen3-devel gsl-devel openblas-devel enchant
+	yum -y install vim-enhanced ccache gcc-c++ gcc-gfortran clang gdb valgrind-openmpi make cmake cmake3 ninja-build patch which file git libpng-devel libjpeg-devel openmpi-devel mpich-devel python-devel python-virtualenv fftw-devel voro++-devel eigen3-devel gsl-devel openblas-devel enchant
 
 %labels
 	Author akohlmey

--- a/tools/singularity/centos8.def
+++ b/tools/singularity/centos8.def
@@ -2,13 +2,12 @@ BootStrap: docker
 From: centos:8
 
 %post
-	dnf -y install epel-release
+	dnf -y install epel-release dnf-utils
+        dnf config-manager --set-enabled PowerTools
         dnf -y update
-	dnf -y install vim-enhanced ccache gcc-c++ gcc-gfortran clang gdb make cmake patch which file git libpng-devel libjpeg-devel openmpi-devel mpich-devel fftw-devel voro++-devel gsl-devel enchant platform-python-devel python3-virtualenv valgrind openblas
+	dnf -y install vim-enhanced ccache gcc-c++ gcc-gfortran clang gdb make cmake patch which file git libpng-devel libjpeg-devel openmpi-devel mpich-devel fftw-devel voro++-devel gsl-devel enchant platform-python-devel python3-virtualenv valgrind openblas ninja-build eigen3-devel
 
 #No match for argument: valgrind-openmpi
-#No match for argument: ninja-build
-#No match for argument: eigen3-devel
 
 %labels
 	Author akohlmey

--- a/tools/singularity/centos8.def
+++ b/tools/singularity/centos8.def
@@ -1,0 +1,14 @@
+BootStrap: docker
+From: centos:8
+
+%post
+	dnf -y install epel-release
+        dnf -y update
+	dnf -y install vim-enhanced ccache gcc-c++ gcc-gfortran clang gdb make cmake patch which file git libpng-devel libjpeg-devel openmpi-devel mpich-devel fftw-devel voro++-devel gsl-devel enchant platform-python-devel python3-virtualenv valgrind openblas
+
+#No match for argument: valgrind-openmpi
+#No match for argument: ninja-build
+#No match for argument: eigen3-devel
+
+%labels
+	Author akohlmey

--- a/tools/singularity/ubuntu16.04.def
+++ b/tools/singularity/ubuntu16.04.def
@@ -1,0 +1,9 @@
+BootStrap: docker
+From: ubuntu:16.04
+
+%post
+	apt-get update -y
+	env DEBIAN_FRONTEND=noninteractive apt-get install -y make cmake cmake-curses-gui ninja-build git ccache gcc g++ gfortran libfftw3-dev libjpeg-dev libpng12-dev libblas-dev liblapack-dev mpi-default-bin mpi-default-dev libeigen3-dev libgsl-dev libopenblas-dev virtualenv python-dev enchant vim-nox
+
+%labels
+	Author akohlmey

--- a/tools/singularity/ubuntu18.04.def
+++ b/tools/singularity/ubuntu18.04.def
@@ -3,7 +3,7 @@ From: ubuntu:18.04
 
 %post
 	apt-get update -y
-	env DEBIAN_FRONTEND=noninteractive apt-get install -y make cmake git gcc g++ gfortran libfftw3-dev libjpeg-dev libpng-dev libblas-dev liblapack-dev mpi-default-bin mpi-default-dev libeigen3-dev libgsl-dev libopenblas-dev virtualenv python-dev enchant vim-nox ccache voro++-dev
+	env DEBIAN_FRONTEND=noninteractive apt-get install -y make cmake cmake-curses-gui ninja-build git ccache gcc g++ gfortran libfftw3-dev libjpeg-dev libpng-dev libblas-dev liblapack-dev mpi-default-bin mpi-default-dev libeigen3-dev libgsl-dev libopenblas-dev virtualenv python-dev enchant vim-nox voro++-dev
 
 %labels
 	Author akohlmey


### PR DESCRIPTION
**Summary**

This adds singularity definition files for two more popular Linux distribution versions with long-term support: CentOS 8.x and Ubuntu 16.04LTS and provides info on how to download them pre-build directly from the singularity library.

**Author(s)**

Axel Kohlmeyer (ICTP)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. Does not affect base LAMMPS distribution.

**Implementation Notes**

CentOS 8 uses a Docker hub based image unlike CentOS 7.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] A package specific README file has been included or updated
