### PR TITLE
Fix print patch to allow print on rerun

### DIFF
--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -149,7 +149,7 @@ void FixPrint::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixPrint::setup(int vflag)
+void FixPrint::setup(int /* vflag */)
 {
   end_of_step();
 }

--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -148,7 +148,8 @@ void FixPrint::init()
 
 void FixPrint::end_of_step()
 {
-  if (update->ntimestep != next_print) return;
+  //Only execute if we have advanced one step (normal run) or we are on the same step (rerun)
+  if ((update->ntimestep != next_print) & (update->ntimestep != next_print-nevery)) return;
 
   // make a copy of string to work on
   // substitute for $ variables (no printing)

--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -134,7 +134,10 @@ void FixPrint::init()
     if (next_print <= update->ntimestep)
       error->all(FLERR,"Fix print timestep variable returned a bad timestep");
   } else {
-     next_print = (update->ntimestep/nevery)*nevery + nevery;
+    if (update->ntimestep % nevery)
+      next_print = (update->ntimestep/nevery)*nevery + nevery;
+    else 
+      next_print = update->ntimestep;
   }
 
   // add next_print to all computes that store invocation times
@@ -146,10 +149,16 @@ void FixPrint::init()
 
 /* ---------------------------------------------------------------------- */
 
+void FixPrint::setup(int vflag)
+{
+  end_of_step();
+}
+
+/* ---------------------------------------------------------------------- */
+
 void FixPrint::end_of_step()
 {
-  //Only execute if we have advanced one step (normal run) or we are on the same step (rerun)
-  if ((update->ntimestep != next_print) & (update->ntimestep != next_print-nevery)) return;
+  if (update->ntimestep != next_print) return;
 
   // make a copy of string to work on
   // substitute for $ variables (no printing)
@@ -169,6 +178,7 @@ void FixPrint::end_of_step()
   } else {
     next_print = (update->ntimestep/nevery)*nevery + nevery;
   }
+
   modify->addstep_compute(next_print);
 
   if (me == 0) {

--- a/src/fix_print.h
+++ b/src/fix_print.h
@@ -29,6 +29,7 @@ class FixPrint : public Fix {
   FixPrint(class LAMMPS *, int, char **);
   ~FixPrint();
   void init();
+  void setup(int);
   int setmask();
   void end_of_step();
 


### PR DESCRIPTION
**Summary**

With the changes on this PR, `fix print` will output during a rerun. 

**Related Issues**

Closes #1741 

**Author(s)**

Carlos Bueno (Rice U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Implementation Notes**

Before this change using a output frequency of 0 was not valid, while using a frequency output of 1 didn't print anything. In older versions of lammps, it was possible to use fix print during reruns. During a rerun the timestep doesn't change at the end of the step. After this change, if the timestep doesn't change, fix print will print the required variables.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included