### PR TITLE
Fixes bug in extract_compute() python method

### DIFF
--- a/python/lammps.py
+++ b/python/lammps.py
@@ -390,10 +390,15 @@ class lammps(object):
   def extract_compute(self,id,style,type):
     if id: id = id.encode()
     if type == 0:
-      if style > 0: return None
-      self.lib.lammps_extract_compute.restype = POINTER(c_double)
-      ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
-      return ptr[0]
+      if style == 0:
+        self.lib.lammps_extract_compute.restype = POINTER(c_double)
+        ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
+        return ptr[0]
+      else if style == 1:
+        return None
+      else if style == 2:
+        self.lib.lammps_extract_compute.restype = POINTER(c_int)
+        return ptr[0]
     if type == 1:
       self.lib.lammps_extract_compute.restype = POINTER(c_double)
       ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -399,14 +399,9 @@ class lammps(object):
       ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
       return ptr
     if type == 2:
-      if style == 0:
-        self.lib.lammps_extract_compute.restype = POINTER(c_int)
-        ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
-        return ptr[0]
-      else:
-        self.lib.lammps_extract_compute.restype = POINTER(POINTER(c_double))
-        ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
-        return ptr
+      self.lib.lammps_extract_compute.restype = POINTER(POINTER(c_double))
+      ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
+      return ptr
     return None
 
   # extract fix info


### PR DESCRIPTION
**Summary**

Using the Python interface to extract a global array quantity from a compute returned an int instead of double**. Apparently nobody ever tried this before.

**Related Issues**

None

**Author(s)**

@sjplimp 

**Licensing**

I agree

**Backward Compatibility**
Yes

**Implementation Notes**

N/a

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


