### PR TITLE
Bugfix for fix pour and PBC

### DIFF
--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -790,7 +790,7 @@ bool FixPour::outside(int dim, double value, double lo, double hi)
   bool outside_regular_range = (value < lo || value > hi);
 
   if (domain->periodicity[dim]) {
-    if (lo < boxlo && hi > boxhi) {
+    if ((lo < boxlo && hi > boxhi) || (hi - lo) > domain->prd[dim]) {
       // value is always inside
       outside_pbc_range = false;
     } else if (lo < boxlo) {

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -782,25 +782,27 @@ int FixPour::overlap(int i)
    return 1 if value is outside, 0 if inside
 ------------------------------------------------------------------------- */
 
-int FixPour::outside(int dim, double value, double lo, double hi)
+bool FixPour::outside(int dim, double value, double lo, double hi)
 {
   double boxlo = domain->boxlo[dim];
   double boxhi = domain->boxhi[dim];
+  bool outside_pbc_range = true;
+  bool outside_regular_range = (value < lo || value > hi);
 
   if (domain->periodicity[dim]) {
     if (lo < boxlo && hi > boxhi) {
-      return 0;
+      // value is always inside
+      outside_pbc_range = false;
     } else if (lo < boxlo) {
-      if (value > hi && value < lo + domain->prd[dim]) return 1;
+      // lower boundary crosses periodic boundary
+      outside_pbc_range = (value > hi && value < lo + domain->prd[dim]);
     } else if (hi > boxhi) {
-      if (value > hi - domain->prd[dim] && value < lo) return 1;
-    } else {
-      if (value < lo || value > hi) return 1;
+      // upper boundary crosses periodic boundary
+      outside_pbc_range = (value < lo && value > hi - domain->prd[dim]);
     }
   }
 
-  if (value < lo || value > hi) return 1;
-  return 0;
+  return (outside_pbc_range && outside_regular_range);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/GRANULAR/fix_pour.h
+++ b/src/GRANULAR/fix_pour.h
@@ -70,7 +70,7 @@ class FixPour : public Fix {
 
   void find_maxid();
   int overlap(int);
-  int outside(int, double, double, double);
+  bool outside(int, double, double, double);
   void xyz_random(double, double *);
   double radius_sample();
   void options(int, char **);


### PR DESCRIPTION
**Summary**

There was a logic error in the `outside()` function used by fix pour.
The previous implementation was essentially doing this:

```
outside = outside_pbc_range || outside_regular_range
```

It should have been:

```
outside = outside_pbc_range && outside_regular_range
```

**Related Issues**

Closes #1695 

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

insertions that were previously considered are now ignored if particles are in the PBC area

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


