### PR TITLE
Correct warning issue in min_cg.cpp

### DIFF
--- a/src/SPIN/min_spin.cpp
+++ b/src/SPIN/min_spin.cpp
@@ -165,9 +165,9 @@ int MinSpin::iterate(int maxiter)
 
     fmdotfm = fmsq = 0.0;
     if (update->ftol > 0.0) {
-      if (normstyle == MAX) fmsq = max_torque();	// max torque norm
-      else if (normstyle == INF) fmsq = inf_torque();	// inf torque norm
-      else if (normstyle == TWO) fmsq = total_torque();	// Euclidean torque 2-norm
+      if (normstyle == MAX) fmsq = max_torque();        // max torque norm
+      else if (normstyle == INF) fmsq = inf_torque();   // inf torque norm
+      else if (normstyle == TWO) fmsq = total_torque(); // Euclidean torque 2-norm
       else error->all(FLERR,"Illegal min_modify command");
       fmdotfm = fmsq*fmsq;
       if (update->multireplica == 0) {

--- a/src/SPIN/min_spin_cg.cpp
+++ b/src/SPIN/min_spin_cg.cpp
@@ -270,9 +270,9 @@ int MinSpinCG::iterate(int maxiter)
 
     fmdotfm = fmsq = 0.0;
     if (update->ftol > 0.0) {
-      if (normstyle == MAX) fmsq = max_torque();	// max torque norm
-      else if (normstyle == INF) fmsq = inf_torque();	// inf torque norm
-      else if (normstyle == TWO) fmsq = total_torque();	// Euclidean torque 2-norm
+      if (normstyle == MAX) fmsq = max_torque();        // max torque norm
+      else if (normstyle == INF) fmsq = inf_torque();   // inf torque norm
+      else if (normstyle == TWO) fmsq = total_torque(); // Euclidean torque 2-norm
       else error->all(FLERR,"Illegal min_modify command");
       fmdotfm = fmsq*fmsq;
       if (update->multireplica == 0) {

--- a/src/SPIN/min_spin_lbfgs.cpp
+++ b/src/SPIN/min_spin_lbfgs.cpp
@@ -285,9 +285,9 @@ int MinSpinLBFGS::iterate(int maxiter)
 
     fmdotfm = fmsq = 0.0;
     if (update->ftol > 0.0) {
-      if (normstyle == MAX) fmsq = max_torque();	// max torque norm
-      else if (normstyle == INF) fmsq = inf_torque();	// inf torque norm
-      else if (normstyle == TWO) fmsq = total_torque();	// Euclidean torque 2-norm
+      if (normstyle == MAX) fmsq = max_torque();        // max torque norm
+      else if (normstyle == INF) fmsq = inf_torque();   // inf torque norm
+      else if (normstyle == TWO) fmsq = total_torque(); // Euclidean torque 2-norm
       else error->all(FLERR,"Illegal min_modify command");
       fmdotfm = fmsq*fmsq;
       if (update->multireplica == 0) {

--- a/src/min_cg.cpp
+++ b/src/min_cg.cpp
@@ -36,7 +36,7 @@ MinCG::MinCG(LAMMPS *lmp) : MinLineSearch(lmp) {}
 int MinCG::iterate(int maxiter)
 {
   int i,m,n,fail,ntimestep;
-  double beta,gg,dot[2],dotall[2],fmax;
+  double beta,gg,dot[2],dotall[2],fdotf;
   double *fatom,*gatom,*hatom;
 
   // nlimit = max # of CG iterations before restarting
@@ -100,7 +100,6 @@ int MinCG::iterate(int maxiter)
         for (i = 0; i < n; i++) {
           dot[0] += fatom[i]*fatom[i];
           dot[1] += fatom[i]*gatom[i];
-	  fmax = MAX(fmax,fatom[i]*fatom[i]);
         }
       }
     MPI_Allreduce(dot,dotall,2,MPI_DOUBLE,MPI_SUM,world);
@@ -110,16 +109,14 @@ int MinCG::iterate(int maxiter)
         dotall[1] += fextra[i]*gextra[i];
       }
 
-    fmax = 0.0;
-    if (normstyle == MAX) {		// max force norm
-      fmax = fnorm_max();
-      if (fmax < update->ftol*update->ftol) return FTOL;
-    } else if (normstyle == INF) {	// infinite force norm
-      fmax = fnorm_inf();
-      if (fmax < update->ftol*update->ftol) return FTOL;
-    } else if (normstyle == TWO) {	// Euclidean force 2-norm
-      if (dotall[0] < update->ftol*update->ftol) return FTOL;
-    } else error->all(FLERR,"Illegal min_modify command"); 
+    fdotf = 0.0;
+    if (update->ftol > 0.0) {
+      if (normstyle == MAX) fdotf = fnorm_max();        // max force norm
+      else if (normstyle == INF) fdotf = fnorm_inf();   // infinite force norm
+      else if (normstyle == TWO) fdotf = fnorm_sqr();   // Euclidean force 2-norm
+      else error->all(FLERR,"Illegal min_modify command");
+      if (fdotf < update->ftol*update->ftol) return FTOL;
+    }
 
     // update new search direction h from new f = -Grad(x) and old g
     // this is Polak-Ribieri formulation

--- a/src/min_fire.cpp
+++ b/src/min_fire.cpp
@@ -250,10 +250,11 @@ int MinFire::iterate(int maxiter)
     // force tolerance criterion
     // sync across replicas if running multi-replica minimization
 
+    fdotf = 0.0;
     if (update->ftol > 0.0) {
-      if (normstyle == MAX) fdotf = fnorm_max();	// max force norm
-      else if (normstyle == INF) fdotf = fnorm_inf();	// inf force norm
-      else if (normstyle == TWO) fdotf = fnorm_sqr();	// Euclidean force 2-norm
+      if (normstyle == MAX) fdotf = fnorm_max();        // max force norm
+      else if (normstyle == INF) fdotf = fnorm_inf();   // inf force norm
+      else if (normstyle == TWO) fdotf = fnorm_sqr();   // Euclidean force 2-norm
       else error->all(FLERR,"Illegal min_modify command");
       if (update->multireplica == 0) {
         if (fdotf < update->ftol*update->ftol) return FTOL;

--- a/src/min_quickmin.cpp
+++ b/src/min_quickmin.cpp
@@ -215,10 +215,11 @@ int MinQuickMin::iterate(int maxiter)
     // force tolerance criterion
     // sync across replicas if running multi-replica minimization
 
+    fdotf = 0.0;
     if (update->ftol > 0.0) {
-      if (normstyle == MAX) fdotf = fnorm_max();     // max force norm
-      else if (normstyle == INF) fdotf = fnorm_inf(); // inf force norm
-      else if (normstyle == TWO) fdotf = fnorm_sqr(); // Euclidean force 2-norm
+      if (normstyle == MAX) fdotf = fnorm_max();       // max force norm
+      else if (normstyle == INF) fdotf = fnorm_inf();  // inf force norm
+      else if (normstyle == TWO) fdotf = fnorm_sqr();  // Euclidean force 2-norm
       else error->all(FLERR,"Illegal min_modify command");
       if (update->multireplica == 0) {
         if (fdotf < update->ftol*update->ftol) return FTOL;

--- a/src/min_sd.cpp
+++ b/src/min_sd.cpp
@@ -78,11 +78,14 @@ int MinSD::iterate(int maxiter)
 
     // force tolerance criterion
 
-    if (normstyle == MAX) fdotf = fnorm_max();		// max force norm
-    else if (normstyle == INF) fdotf = fnorm_inf();	// infinite force norm
-    else if (normstyle == TWO) fdotf = fnorm_sqr();	// Euclidean force 2-norm
-    else error->all(FLERR,"Illegal min_modify command");
-    if (fdotf < update->ftol*update->ftol) return FTOL;
+    fdotf = 0.0;
+    if (update->ftol > 0.0) {
+      if (normstyle == MAX) fdotf = fnorm_max();        // max force norm
+      else if (normstyle == INF) fdotf = fnorm_inf();   // infinite force norm
+      else if (normstyle == TWO) fdotf = fnorm_sqr();   // Euclidean force 2-norm
+      else error->all(FLERR,"Illegal min_modify command");
+      if (fdotf < update->ftol*update->ftol) return FTOL;
+    }
 
     // set new search direction h to f = -Grad(x)
 


### PR DESCRIPTION
**Summary**

Correct a warning issue in min_cg.cpp.: the 'fmax' variable was used without being initialized. 

**Related Issues**

None. 

**Author(s)**

Julien Tranchida (jtranch@sandia.gov)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Checked.

**Implementation Notes**

I checked the correction by re-running a set of serial and mpi minimization examples.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**
-


