### PR TITLE
wrong cmake option for QUIP

### DIFF
--- a/doc/rst/Build_extras.rst
+++ b/doc/rst/Build_extras.rst
@@ -1254,7 +1254,7 @@ lib/quip/README file for details on how to do this.
 
 .. parsed-literal::
 
-   -D QUIP_LIBRARIES=path     # path to libquip.a (only needed if a custom location)
+   -D QUIP_LIBRARY=path     # path to libquip.a (only needed if a custom location)
 
 CMake will not download and build the QUIP library.  But once you have
 done that, a CMake build of LAMMPS with "-D PKG\_USER-QUIP=yes" should


### PR DESCRIPTION
**Summary**

small bugfix in docs: QUIP cmake option for specifying library path should be QUIP_LIBRARY not QUIP_LIBRARIES

**Post Submission Checklist**

- [x ] The feature or features in this pull request is complete
- [ x] The source code follows the LAMMPS formatting guidelines
- [ x] Suitable new documentation files and/or updates to the existing docs are included
 system
- [x ] The feature has been verified to work with the conventional build system
- [x ] The feature has been verified to work with the CMake based build system
- [x ] A package specific README file has been included or updated


