### PR TITLE
Consistent exclusion settings with multiple kspace-like sub-styles in pair hybrid

### DIFF
--- a/src/pair_hybrid.h
+++ b/src/pair_hybrid.h
@@ -29,6 +29,7 @@ class PairHybrid : public Pair {
   friend class FixIntel;
   friend class FixOMP;
   friend class Force;
+  friend class Neighbor;
   friend class Respa;
   friend class Info;
   friend class PairDeprecated;


### PR DESCRIPTION
**Summary**

This handles the special case shown in issue #1753 where multiple hybrid substyles would match but the special case for exclusions does not trigger, since `Force::pair_match()` returns NULL for multiple matches.

**Related Issues**

Fixes #1753 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

Since we cannot know how many multiples of the same sub-style exists, we assume that all hybrid sub-styles are the same. Since we only need to see, if there is a single match, it doesn't matter, that we have lots of missed matches due to looking for multiples that do not exist.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system


