### PR TITLE
Patch of class2 dihedral

### DIFF
--- a/src/CLASS2/dihedral_class2.cpp
+++ b/src/CLASS2/dihedral_class2.cpp
@@ -2,12 +2,10 @@
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    http://lammps.sandia.gov, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
-
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
    certain rights in this software.  This software is distributed under
    the GNU General Public License.
-
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
@@ -27,6 +25,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -840,45 +839,45 @@ void DihedralClass2::read_restart(FILE *fp)
   allocate();
 
   if (comm->me == 0) {
-    fread(&k1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&k2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&k3[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&phi1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&phi2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&phi3[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&k1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&k2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&k3[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&phi1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&phi2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&phi3[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
 
-    fread(&mbt_f1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&mbt_f2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&mbt_f3[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&mbt_r0[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&mbt_f1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&mbt_f2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&mbt_f3[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&mbt_r0[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
 
-    fread(&ebt_f1_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&ebt_f2_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&ebt_f3_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&ebt_r0_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&ebt_f1_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&ebt_f2_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&ebt_f3_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&ebt_r0_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
 
-    fread(&ebt_f1_2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&ebt_f2_2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&ebt_f3_2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&ebt_r0_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&ebt_f1_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&ebt_f2_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&ebt_f3_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&ebt_r0_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
 
-    fread(&at_f1_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&at_f2_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&at_f3_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&at_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&at_f1_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&at_f2_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&at_f3_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&at_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
 
-    fread(&at_f1_2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&at_f2_2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&at_f3_2[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&at_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&at_f1_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&at_f2_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&at_f3_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&at_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
 
-    fread(&aat_k[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&aat_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&aat_k[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&aat_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
 
-    fread(&bb13t_k[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&bb13t_r10[1],sizeof(double),atom->ndihedraltypes,fp);
-    fread(&bb13t_r30[1],sizeof(double),atom->ndihedraltypes,fp);
+    utils::sfread(FLERR,&bb13t_k[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&bb13t_r10[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    utils::sfread(FLERR,&bb13t_r30[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
   }
 
   MPI_Bcast(&k1[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);
@@ -963,4 +962,3 @@ void DihedralClass2::write_data(FILE *fp)
             at_f1_2[i],at_f2_2[i],at_f3_2[i],
             at_theta0_1[i]*180.0/MY_PI,at_theta0_2[i]*180.0/MY_PI);
 }
-

--- a/src/CLASS2/dihedral_class2.cpp
+++ b/src/CLASS2/dihedral_class2.cpp
@@ -27,7 +27,6 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
-#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -181,6 +180,11 @@ void DihedralClass2::compute(int eflag, int vflag)
     costh12 = (vb1x*vb2x + vb1y*vb2y + vb1z*vb2z) * r12c1;
     costh13 = c0;
     costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
+
+    costh12 = MAX(MIN(costh12, 1.0), -1.0);
+    costh13 = MAX(MIN(costh13, 1.0), -1.0);
+    costh23 = MAX(MIN(costh23, 1.0), -1.0);
+    c0 = costh13;
 
     // cos and sin of 2 angles and final c
 
@@ -836,45 +840,45 @@ void DihedralClass2::read_restart(FILE *fp)
   allocate();
 
   if (comm->me == 0) {
-    utils::sfread(FLERR,&k1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&k2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&k3[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&phi1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&phi2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&phi3[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&k1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&k2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&k3[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&phi1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&phi2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&phi3[1],sizeof(double),atom->ndihedraltypes,fp);
 
-    utils::sfread(FLERR,&mbt_f1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&mbt_f2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&mbt_f3[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&mbt_r0[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&mbt_f1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&mbt_f2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&mbt_f3[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&mbt_r0[1],sizeof(double),atom->ndihedraltypes,fp);
 
-    utils::sfread(FLERR,&ebt_f1_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&ebt_f2_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&ebt_f3_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&ebt_r0_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&ebt_f1_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&ebt_f2_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&ebt_f3_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&ebt_r0_1[1],sizeof(double),atom->ndihedraltypes,fp);
 
-    utils::sfread(FLERR,&ebt_f1_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&ebt_f2_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&ebt_f3_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&ebt_r0_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&ebt_f1_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&ebt_f2_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&ebt_f3_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&ebt_r0_2[1],sizeof(double),atom->ndihedraltypes,fp);
 
-    utils::sfread(FLERR,&at_f1_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&at_f2_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&at_f3_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&at_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&at_f1_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&at_f2_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&at_f3_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&at_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
 
-    utils::sfread(FLERR,&at_f1_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&at_f2_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&at_f3_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&at_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&at_f1_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&at_f2_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&at_f3_2[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&at_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp);
 
-    utils::sfread(FLERR,&aat_k[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&aat_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&aat_k[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&aat_theta0_1[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&aat_theta0_2[1],sizeof(double),atom->ndihedraltypes,fp);
 
-    utils::sfread(FLERR,&bb13t_k[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&bb13t_r10[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
-    utils::sfread(FLERR,&bb13t_r30[1],sizeof(double),atom->ndihedraltypes,fp,NULL,error);
+    fread(&bb13t_k[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&bb13t_r10[1],sizeof(double),atom->ndihedraltypes,fp);
+    fread(&bb13t_r30[1],sizeof(double),atom->ndihedraltypes,fp);
   }
 
   MPI_Bcast(&k1[1],atom->ndihedraltypes,MPI_DOUBLE,0,world);

--- a/src/CLASS2/dihedral_class2.cpp
+++ b/src/CLASS2/dihedral_class2.cpp
@@ -2,10 +2,12 @@
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    http://lammps.sandia.gov, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
+
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
    certain rights in this software.  This software is distributed under
    the GNU General Public License.
+
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
@@ -962,3 +964,4 @@ void DihedralClass2::write_data(FILE *fp)
             at_f1_2[i],at_f2_2[i],at_f3_2[i],
             at_theta0_1[i]*180.0/MY_PI,at_theta0_2[i]*180.0/MY_PI);
 }
+


### PR DESCRIPTION
Fix the NAN problem when any two bonds are nearly parallel

**Summary**

When any two bonds of the dihedral are nearly parallel, the costh12 costh13 costh23 will exceed the limit of [-1,1] slightly because of cut-off error, leading  acos(costh12), acos(costh13) or acos(costh23) to be NAN.

**Related Issues**

_If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged_

**Author(s)**

Lucien Pan

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This fix is backward compatibility

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


