### PR TITLE
Patch of class2 dihedral in OMP and Kokkos

### DIFF
--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -253,10 +253,16 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   const F_FLOAT costh13 = c0;
   const F_FLOAT costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
 
-  costh12 = MAX(MIN(costh12, 1.0), -1.0);
-  costh13 = MAX(MIN(costh13, 1.0), -1.0);
-  costh23 = MAX(MIN(costh23, 1.0), -1.0);
-  c0 = costh13;
+  {
+    F_FLOAT& ctmp12 = const_cast<F_FLOAT&>(costh12);
+    F_FLOAT& ctmp13 = const_cast<F_FLOAT&>(costh13);
+    F_FLOAT& ctmp23 = const_cast<F_FLOAT&>(costh23);
+    F_FLOAT& ctmp0  = const_cast<F_FLOAT&>(c0);
+    ctmp12 = MAX(MIN(costh12, 1.0), -1.0);
+    ctmp13 = MAX(MIN(costh13, 1.0), -1.0);
+    ctmp23 = MAX(MIN(costh23, 1.0), -1.0);
+    ctmp0  = costh13;
+  }
 
   // cos and sin of 2 angles and final c
 

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -243,26 +243,20 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   const F_FLOAT sb3 = 1.0/r3mag2;
   const F_FLOAT rb3 = 1.0/r3;
 
-  const F_FLOAT c0 = (vb1x*vb3x + vb1y*vb3y + vb1z*vb3z) * rb1*rb3;
+  F_FLOAT c0 = (vb1x*vb3x + vb1y*vb3y + vb1z*vb3z) * rb1*rb3;
 
   // 1st and 2nd angle
 
   const F_FLOAT r12c1 = rb1*rb2;
   const F_FLOAT r12c2 = rb2*rb3;
-  const F_FLOAT costh12 = (vb1x*vb2x + vb1y*vb2y + vb1z*vb2z) * r12c1;
-  const F_FLOAT costh13 = c0;
-  const F_FLOAT costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
+  F_FLOAT costh12 = (vb1x*vb2x + vb1y*vb2y + vb1z*vb2z) * r12c1;
+  F_FLOAT costh13 = c0;
+  F_FLOAT costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
 
-  {
-    F_FLOAT& ctmp12 = const_cast<F_FLOAT&>(costh12);
-    F_FLOAT& ctmp13 = const_cast<F_FLOAT&>(costh13);
-    F_FLOAT& ctmp23 = const_cast<F_FLOAT&>(costh23);
-    F_FLOAT& ctmp0  = const_cast<F_FLOAT&>(c0);
-    ctmp12 = MAX(MIN(costh12, 1.0), -1.0);
-    ctmp13 = MAX(MIN(costh13, 1.0), -1.0);
-    ctmp23 = MAX(MIN(costh23, 1.0), -1.0);
-    ctmp0  = costh13;
-  }
+  costh12 = MAX(MIN(costh12, 1.0), -1.0);
+  costh13 = MAX(MIN(costh13, 1.0), -1.0);
+  costh23 = MAX(MIN(costh23, 1.0), -1.0);
+  c0 = costh13;
 
   // cos and sin of 2 angles and final c
 

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -253,6 +253,11 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   const F_FLOAT costh13 = c0;
   const F_FLOAT costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
 
+  costh12 = MAX(MIN(costh12, 1.0), -1.0);
+  costh13 = MAX(MIN(costh13, 1.0), -1.0);
+  costh23 = MAX(MIN(costh23, 1.0), -1.0);
+  c0 = costh13;
+
   // cos and sin of 2 angles and final c
 
   F_FLOAT sin2 = MAX(1.0 - costh12*costh12,0.0);

--- a/src/USER-OMP/dihedral_class2_omp.cpp
+++ b/src/USER-OMP/dihedral_class2_omp.cpp
@@ -159,6 +159,11 @@ void DihedralClass2OMP::eval(int nfrom, int nto, ThrData * const thr)
     costh13 = c0;
     costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
 
+    costh12 = MAX(MIN(costh12, 1.0), -1.0);
+    costh13 = MAX(MIN(costh13, 1.0), -1.0);
+    costh23 = MAX(MIN(costh23, 1.0), -1.0);
+    c0 = costh13;
+
     // cos and sin of 2 angles and final c
 
     sin2 = MAX(1.0 - costh12*costh12,0.0);


### PR DESCRIPTION
**Summary**

Path of class2 dihedral in OMP and KOKKOS

**Related Issues**

Additional patch of dihedral class2 in OMP and KOKKOS to eliminate the NAN problem when two bonds are nearly parallel.

**Author(s)**

Lucien Pan

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


