### PR TITLE
Improve handling of LAMMPS integer size defines in library.h

### DIFF
--- a/src/library.h
+++ b/src/library.h
@@ -16,8 +16,12 @@
    new LAMMPS-specific functions can be added
 */
 
+/*
+ * Follow the behavior of regular LAMMPS compilation and assume
+ * -DLAMMPS_SMALLBIG when no define is set.
+ */
 #if !defined(LAMMPS_BIGBIG) && !defined(LAMMPS_SMALLBIG) && !defined(LAMMPS_SMALLSMALL)
-#error Must define LAMMPS_BIGBIG, LAMMPS_SMALLBIG, or LAMMPS_SMALLSMALL
+#define LAMMPS_SMALLBIG
 #endif
 
 #include <mpi.h>

--- a/src/library.h
+++ b/src/library.h
@@ -16,6 +16,10 @@
    new LAMMPS-specific functions can be added
 */
 
+#if !defined(LAMMPS_BIGBIG) && !defined(LAMMPS_SMALLBIG) && !defined(LAMMPS_SMALLSMALL)
+#error Must define LAMMPS_BIGBIG, LAMMPS_SMALLBIG, or LAMMPS_SMALLSMALL
+#endif
+
 #include <mpi.h>
 #if defined(LAMMPS_BIGBIG) || defined(LAMMPS_SMALLBIG)
 #include <inttypes.h>  /* for int64_t */
@@ -58,10 +62,10 @@ void lammps_gather_atoms_subset(void *, char *, int, int, int, int *, void *);
 void lammps_scatter_atoms(void *, char *, int, int, void *);
 void lammps_scatter_atoms_subset(void *, char *, int, int, int, int *, void *);
 
-#ifdef LAMMPS_BIGBIG
+#if defined(LAMMPS_BIGBIG)
 typedef void (*FixExternalFnPtr)(void *, int64_t, int, int64_t *, double **, double **);
 void lammps_set_fix_external_callback(void *, char *, FixExternalFnPtr, void*);
-#elif LAMMPS_SMALLBIG
+#elif defined(LAMMPS_SMALLBIG)
 typedef void (*FixExternalFnPtr)(void *, int64_t, int, int *, double **, double **);
 void lammps_set_fix_external_callback(void *, char *, FixExternalFnPtr, void*);
 #else


### PR DESCRIPTION
**Summary**

When including library.h when using the LAMMPS library interface, we need to set one of `-DLAMMPS_BIGBIG`, `-DLAMMPS_SMALLBIG`, or `-DLAMMPS_SMALLSMALL`. This should be the same as was used when compiling the library interface, but until we generate a file `lmpconfig.h` (similar to how we use `lmpgitversion.h`) that contains this information and include it, we have to depend on the user setting the correct value. For now we assume `-DLAMMPS_SMALLBIG` if no define is set by the user.

This PR also changes the incorrect use of `#elif` that was recently added.

**Related Issues**

Fixes #1791 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

