### PR TITLE
Correct typo in pair_granular.rst

### DIFF
--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -432,7 +432,7 @@ option by an additional factor of *a*\ , the radius of the contact region. The t
 Here, *a* is the radius of the contact region, given by :math:`a =\sqrt{R\delta}`
 for all normal contact models, except for *jkr*\ , where it is given
 implicitly by :math:`\delta = a^2/R - 2\sqrt{\pi \gamma a/E}`, see
-discussion above. To match the Mindlin solution, one should set :math:`k_t = 8G`, where :math:`G` is the shear modulus, related to Young's modulus
+discussion above. To match the Mindlin solution, one should set :math:`k_t = 4G/(2-\nu)`, where :math:`G` is the shear modulus, related to Young's modulus
 :math:`E` by :math:`G = E/(2(1+\nu))`, where :math:`\nu` is Poisson's ratio. This
 can also be achieved by specifying *NULL* for :math:`k_t`, in which case a
 normal contact model that specifies material parameters :math:`E` and


### PR DESCRIPTION
**Summary**

The documentation states that tangent stiffness k_t equals 8G, instead of 4G/(2-\nu).
The calculation performed by `PairGranular::mix_stiffnessG()` is correct, this patch only corrects the typo in the documentation.

**Related Issues**

None

**Author(s)**

Jibril B. Coulibaly, Northwestern University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No backward compatibility issue

**Implementation Notes**

The value of k_t = 4G/(2-\nu) is consistent with the literature (e.g. Radjaï and Dubois, 2011, ISBN: 978-1-848-21260-2), and with what the documentation of the pair style `gran_hooke` states.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


