### PR TITLE
Include MPI version and vendor info in LAMMPS help message

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -355,19 +355,7 @@ void Info::command(int narg, char **arg)
 
   if (flags & COMM) {
     int major,minor,len;
-#if (defined(MPI_VERSION) && (MPI_VERSION > 2)) || defined(MPI_STUBS)
-    char version[MPI_MAX_LIBRARY_VERSION_STRING];
-    MPI_Get_library_version(version,&len);
-#else
-    char version[] = "Undetected MPI implementation";
-    len = strlen(version);
-#endif
-
-    MPI_Get_version(&major,&minor);
-    if (len > 80) {
-      char *ptr = strchr(version+80,'\n');
-      if (ptr) *ptr = '\0';
-    }
+    const char *version = get_mpi_info(major,minor);
 
     fprintf(out,"\nCommunication information:\n");
     fprintf(out,"MPI library level: MPI v%d.%d\n",major,minor);
@@ -1207,6 +1195,25 @@ const char *Info::get_openmp_info()
 #endif
 
 #endif
+}
+
+const char *Info::get_mpi_info(int &major, int &minor)
+{
+  int len;
+  #if (defined(MPI_VERSION) && (MPI_VERSION > 2)) || defined(MPI_STUBS)
+  static char version[MPI_MAX_LIBRARY_VERSION_STRING];
+  MPI_Get_library_version(version,&len);
+#else
+  static char version[] = "Undetected MPI implementation";
+  len = strlen(version);
+#endif
+
+  MPI_Get_version(&major,&minor);
+  if (len > 80) {
+    char *ptr = strchr(version+80,'\n');
+    if (ptr) *ptr = '\0';
+  }
+  return version;
 }
 
 const char *Info::get_cxx_info()

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -354,7 +354,7 @@ void Info::command(int narg, char **arg)
   }
 
   if (flags & COMM) {
-    int major,minor,len;
+    int major,minor;
     const char *version = get_mpi_info(major,minor);
 
     fprintf(out,"\nCommunication information:\n");

--- a/src/info.h
+++ b/src/info.h
@@ -43,6 +43,7 @@ class Info : protected Pointers {
   static char *get_os_info();
   static char *get_compiler_info();
   static const char *get_openmp_info();
+  static const char *get_mpi_info(int &, int &);
   static const char *get_cxx_info();
 
   char **get_variable_names(int &num);

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -1271,14 +1271,18 @@ void LAMMPS::print_config(FILE *fp)
   const char *pkg;
   int ncword, ncline = 0;
 
-  char *infobuf = Info::get_os_info();
+  const char *infobuf = Info::get_os_info();
   fprintf(fp,"OS: %s\n\n",infobuf);
   delete[] infobuf;
 
   infobuf = Info::get_compiler_info();
   fprintf(fp,"Compiler: %s with %s\n",infobuf,Info::get_openmp_info());
   delete[] infobuf;
-  fprintf(fp,"C++ standard: %s\n\n",Info::get_cxx_info());
+  fprintf(fp,"C++ standard: %s\n",Info::get_cxx_info());
+
+  int major,minor;
+  infobuf = Info::get_mpi_info(major,minor);
+  fprintf(fp,"MPI v%d.%d: %s\n\n",major,minor,infobuf);
 
   fputs("Active compile time flags:\n\n",fp);
   if (Info::has_gzip_support()) fputs("-DLAMMPS_GZIP\n",fp);


### PR DESCRIPTION
**Summary**

Refactor the query of the MPI revision and version string in the Info class, so it can be output with the LAMMPS help message as well.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
