### PR TITLE
Fix mismatches in CUDA execution space qualifiers between declarations and definitions.

### DIFF
--- a/src/KOKKOS/README
+++ b/src/KOKKOS/README
@@ -14,8 +14,9 @@ manual for information on building LAMMPS with external libraries.
 The settings in the Makefile.lammps file in that directory must be
 correct for LAMMPS to build correctly with this package installed.
 
-This package was developed primaritly by Christian Trott (Sandia) with
+This package was developed primarily by Christian Trott (Sandia) with
 contributions of various styles by others, including Sikandar Mashayak
-(UIUC).  The underlying Kokkos library was written primarily by Carter
-Edwards, Christian Trott, and Dan Sunderland (all Sandia).
+(UIUC).  It is now maintained by Stan Moore (Sandia).  The underlying
+Kokkos library was written primarily by Carter Edwards,
+ Christian Trott, and Dan Sunderland (all Sandia).
 

--- a/src/KOKKOS/fix_enforce2d_kokkos.cpp
+++ b/src/KOKKOS/fix_enforce2d_kokkos.cpp
@@ -136,6 +136,7 @@ void FixEnforce2DKokkos<DeviceType>::post_force(int vflag)
 
 template <class DeviceType>
 template <int omega_flag, int angmom_flag, int torque_flag>
+KOKKOS_INLINE_FUNCTION
 void FixEnforce2DKokkos<DeviceType>::post_force_item( int i ) const
 {
   if (mask[i] & groupbit){

--- a/src/KOKKOS/fix_neigh_history_kokkos.cpp
+++ b/src/KOKKOS/fix_neigh_history_kokkos.cpp
@@ -105,12 +105,14 @@ void FixNeighHistoryKokkos<DeviceType>::pre_exchange()
 /* ---------------------------------------------------------------------- */
 
 template <class DeviceType>
+KOKKOS_INLINE_FUNCTION
 void FixNeighHistoryKokkos<DeviceType>::zero_partner_count_item(const int &i) const
 {
   d_npartner[i] = 0;
 }
 
 template <class DeviceType>
+KOKKOS_INLINE_FUNCTION
 void FixNeighHistoryKokkos<DeviceType>::pre_exchange_item(const int &ii) const
 {
   const int i = d_ilist[ii];

--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -354,6 +354,7 @@ int NeighborKokkosExecute<DeviceType>::exclusion(const int &i,const int &j,
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType> template<int HalfNeigh,int Newton,int Tri>
+KOKKOS_FUNCTION
 void NeighborKokkosExecute<DeviceType>::
    build_Item(const int &i) const
 {
@@ -704,6 +705,7 @@ void NeighborKokkosExecute<DeviceType>::build_ItemCuda(typename Kokkos::TeamPoli
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>  template<int HalfNeigh>
+KOKKOS_FUNCTION
 void NeighborKokkosExecute<DeviceType>::
    build_Item_Ghost(const int &i) const
 {
@@ -826,6 +828,7 @@ void NeighborKokkosExecute<DeviceType>::
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType> template<int HalfNeigh,int Newton,int Tri>
+KOKKOS_FUNCTION
 void NeighborKokkosExecute<DeviceType>::
    build_ItemSize(const int &i) const
 {


### PR DESCRIPTION
**Summary**

It is ill formed no diagnostic required if different declarations of a function have different CUDA execution space qualifiers. This occurs in the LAMMPS codebase due to the omission of some `KOKKOS_*FUNCTION` macros from the definitions of some functions. The `KOKKOS_*FUNCTION` macros expand to (among other things) `__host__ __device__`. Without them, the definitions have no execution space specifier and thus are implicitly `__host__`.

This prevents compilation of LAMMPS with Clang CUDA.

Add missing `KOKKOS_INLINE_FUNCTION` to the definition of:
- `FixEnforce2DKokkos::post_force_item`
- `FixNeighHistoryKokkos::zero_partner_count_item`
- `FixNeighHistoryKokkos::pre_exchange_item`

Note that I question whether these functions, whose definitions live in source files, should be marked `KOKKOS_INLINE_FUNCTION` instead of `KOKKOS_FUNCTION` in the first place. `KOKKOS_INLINE_FUNCTION` presumably adds `__forceinclude__`; however, the definition of these functions lives in the source file, so they cannot be inlined into other TUs. If the macro just adds `inline`, I still think it's questionable - why do these functions need ODR relaxation? If desired I'll update this PR to change these functions to be declared with `KOKKOS_FUNCTION` instead.

Add missing `KOKKOS_FUNCTION` to the definition of:
- `NeighborKokkosExecute::build_Item`
- `NeighborKokkosExecute::build_Item_Ghost`
- `NeighborKokkosExecute::build_ItemSize`

**Author(s)**

Bryce Adelstein Lelbach, blelbach@nvidia.com, NVIDIA Corporation.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No.

**Implementation Notes**

N/A.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
