### PR TITLE
USER-CGDNA: Added oxRNA2 files to .gitignore

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -280,6 +280,8 @@
 /bond_oxdna_fene.h
 /bond_oxdna2_fene.cpp
 /bond_oxdna2_fene.h
+/bond_oxrna2_fene.cpp
+/bond_oxrna2_fene.h
 /bond_quartic.cpp
 /bond_quartic.h
 /bond_table.cpp
@@ -982,6 +984,8 @@
 /pair_oxdna_*.h
 /pair_oxdna2_*.cpp
 /pair_oxdna2_*.h
+/pair_oxrna2_*.cpp
+/pair_oxrna2_*.h
 /mf_oxdna.h
 /pair_peri_eps.cpp
 /pair_peri_eps.h


### PR DESCRIPTION
**Summary**

This pull request adds the new oxRNA2 files to .gitignore.

**Author(s)**

Oliver Henrich, University of Strathclyde, Glasgow, UK

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Full backward compatible.