### PR TITLE
Bug fix for USER-INTEL package with triclinic neighbor builds.

### DIFF
--- a/src/USER-INTEL/npair_intel.cpp
+++ b/src/USER-INTEL/npair_intel.cpp
@@ -360,7 +360,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
             if (THREE) ttag[u] = tag[j];
           }
 
-          if (FULL == 0 || TRI == 1) {
+          if (FULL == 0 && TRI != 1) {
             icount = 0;
             istart = ncount;
             IP_PRE_edge_align(istart, sizeof(int));
@@ -392,7 +392,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
         // ---------------------- Loop over i bin
 
         int n = 0;
-        if (FULL == 0 || TRI == 1) {
+        if (FULL == 0 && TRI != 1) {
           #if defined(LMP_SIMD_COMPILER)
           #pragma vector aligned
           #pragma ivdep


### PR DESCRIPTION
**Summary**

Two line changes to fix bug in USER-INTEL neighbor build with triclinic boxes.

**Related Issues**

Fixes issue reported on mailing list.

**Author(s)**

Mike Brown (Intel)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


