### PR TITLE
Updated Makefile.stampede: replacement options icc

### DIFF
--- a/src/MAKE/MACHINES/Makefile.stampede
+++ b/src/MAKE/MACHINES/Makefile.stampede
@@ -6,13 +6,13 @@ SHELL = /bin/sh
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
 
-CC =		mpicc -openmp -DLMP_INTEL_OFFLOAD -DLAMMPS_MEMALIGN=64
-MIC_OPT =       -offload-option,mic,compiler,"-fp-model fast=2 -mGLOB_default_function_attrs=\"gather_scatter_loop_unroll=4\""
-CCFLAGS =	-O3 -xhost -fp-model precise -restrict -override-limits $(MIC_OPT)
+CC =		mpicc -qopenmp -DLMP_INTEL_OFFLOAD -DLAMMPS_MEMALIGN=64
+MIC_OPT =       -qoffload-option,mic,compiler,"-fp-model fast=2 -mGLOB_default_function_attrs=\"gather_scatter_loop_unroll=4\""
+CCFLAGS =	-O3 -xhost -fp-model precise -restrict -qoverride-limits $(MIC_OPT)
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
-LINK =		mpicc -openmp
+LINK =		mpicc -qopenmp
 LINKFLAGS =	-O3 -xhost
 LIB =           -ltbbmalloc
 SIZE =		size


### PR DESCRIPTION
**Summary**
The default options for Makefile.stampede did not compile. They had to be updated to include the `q` replacement options.

**Related Issues**
None

**Author(s)**
Christian Tabedzki

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2).

**Backward Compatibility**

_Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why_

**Implementation Notes**
The software was built on STAMPEDE2 and can run some example files.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

