### PR TITLE
add warning to fix bond/create

### DIFF
--- a/doc/src/Errors_warnings.rst
+++ b/doc/src/Errors_warnings.rst
@@ -195,6 +195,12 @@ Doc page with :doc:`ERROR messages <Errors_messages>`
 *Fix SRD walls overlap but fix srd overlap not set*
    You likely want to set this in your input script.
 
+* Fix bond/create is used multiple times or with fix bond/break - may not work as expected*
+   When using fix bond/create multiple times or in combination with
+   fix bond/break, the individual fix instances do not share information
+   about changes they made at the same time step and thus it may result
+   in unexpected behavior.
+
 *Fix bond/swap will ignore defined angles*
    See the doc page for fix bond/swap for more info on this
    restriction.

--- a/doc/txt/Errors_warnings.txt
+++ b/doc/txt/Errors_warnings.txt
@@ -239,6 +239,13 @@ will be truncated to attempt to prevent the bond from blowing up. :dd
 
 You likely want to set this in your input script. :dd
 
+{ Fix bond/create is used multiple times or with fix bond/break - may not work as expected} :dt
+
+When using fix bond/create multiple times or in combination with
+fix bond/break, the individual fix instances do not share information
+about changes they made at the same time step and thus it may result
+in unexpected behavior. :dd
+
 {Fix bond/swap will ignore defined angles} :dt
 
 See the doc page for fix bond/swap for more info on this

--- a/src/MC/fix_bond_break.cpp
+++ b/src/MC/fix_bond_break.cpp
@@ -33,7 +33,8 @@ using namespace FixConst;
 
 FixBondBreak::FixBondBreak(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg),
-  partner(NULL), finalpartner(NULL), distsq(NULL), probability(NULL), broken(NULL), copy(NULL), random(NULL)
+  partner(NULL), finalpartner(NULL), distsq(NULL), probability(NULL), 
+  broken(NULL), copy(NULL), random(NULL)
 {
   if (narg < 6) error->all(FLERR,"Illegal fix bond/break command");
 

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -18,6 +18,7 @@
 #include "respa.h"
 #include "atom.h"
 #include "force.h"
+#include "modify.h"
 #include "pair.h"
 #include "comm.h"
 #include "neighbor.h"
@@ -215,6 +216,19 @@ void FixBondCreate::init()
 
   if (force->pair == NULL || cutsq > force->pair->cutsq[iatomtype][jatomtype])
     error->all(FLERR,"Fix bond/create cutoff is longer than pairwise cutoff");
+
+  // warn if more than one fix bond/create or also a fix bond/break
+  // because this fix stores per-atom state in bondcount
+  //   if other fixes create/break bonds, this fix will not know about it
+
+  int count = 0;
+  for (int i = 0; i < modify->nfix; i++) {
+    if (strcmp(modify->fix[i]->style,"bond/create") == 0) count++;
+    if (strcmp(modify->fix[i]->style,"bond/break") == 0) count++;
+  }
+  if (count > 1 && me == 0) 
+    error->warning(FLERR,"Fix bond/create is used multiple times "
+                   " or with fix bond/break - may not work as expected");
 
   // enable angle/dihedral/improper creation if atype/dtype/itype
   //   option was used and a force field has been specified

--- a/src/MC/fix_bond_create.h
+++ b/src/MC/fix_bond_create.h
@@ -170,4 +170,11 @@ See the read_data command for info on setting the "extra special per
 atom" header value to allow for additional special values to be
 stored.
 
+W: Fix bond/create is used multiple times or with fix bond/break - may not work as expected
+
+When using fix bond/create multiple times or in combination with
+fix bond/break, the individual fix instances do not share information
+about changes they made at the same time step and thus it may result
+in unexpected behavior.
+
 */


### PR DESCRIPTION
**Summary**

Add a warning to fix bond/create if used multiple times or in conjunction with fix bond/break.  B/c the stored state on bond counts will possibly not be current in fix bond/create.

**Related Issues**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


