### PR TITLE
Fix some issues with lj/cut/tip4p/long/gpu

### DIFF
--- a/doc/src/pair_lj.rst
+++ b/doc/src/pair_lj.rst
@@ -90,14 +90,14 @@ pair\_style lj/cut/coul/wolf/omp command
 pair\_style lj/cut/tip4p/cut command
 ====================================
 
-pair\_style lj/cut/tip4p/cut/gpu command
-========================================
-
 pair\_style lj/cut/tip4p/cut/omp command
 ========================================
 
 pair\_style lj/cut/tip4p/long command
 =====================================
+
+pair\_style lj/cut/tip4p/long/gpu command
+========================================
 
 pair\_style lj/cut/tip4p/long/omp command
 =========================================

--- a/lib/gpu/lal_lj_tip4p_long.cpp
+++ b/lib/gpu/lal_lj_tip4p_long.cpp
@@ -235,22 +235,26 @@ void LJTIP4PLongT::copy_relations_data(int n, tagint *tag, int *map_array,
 
   m.resize_ib(n);
   m.zero();
+
   if (ago == 0) {
     hneight.zero();
-    UCL_H_Vec<int> host_tag_write(nall,*(this->ucl_device),UCL_WRITE_ONLY);
-    this->tag.resize_ib(nall);
-    for(int i=0; i<nall; ++i) host_tag_write[i] = tag[i];
-    ucl_copy(this->tag, host_tag_write, nall, false);
 
-    host_tag_write.resize_ib(max_same);
+    {
+      UCL_H_Vec<tagint> host_tag_write(nall,*(this->ucl_device),UCL_WRITE_ONLY);
+      this->tag.resize_ib(nall);
+      for(int i=0; i<nall; ++i) host_tag_write[i] = tag[i];
+      ucl_copy(this->tag, host_tag_write, nall, false);
+    }
+
+    UCL_H_Vec<int> host_write(max_same,*(this->ucl_device),UCL_WRITE_ONLY);
     this->atom_sametag.resize_ib(max_same);
-    for(int i=0; i<max_same; ++i) host_tag_write[i] = sametag[i];
-    ucl_copy(this->atom_sametag, host_tag_write, max_same, false);
+    for(int i=0; i<max_same; ++i) host_write[i] = sametag[i];
+    ucl_copy(this->atom_sametag, host_write, max_same, false);
 
-    host_tag_write.resize_ib(map_size);
+    host_write.resize_ib(map_size);
     this->map_array.resize_ib(map_size);
-    for(int i=0; i<map_size; ++i) host_tag_write[i] = map_array[i];
-    ucl_copy(this->map_array, host_tag_write, map_size, false);
+    for(int i=0; i<map_size; ++i) host_write[i] = map_array[i];
+    ucl_copy(this->map_array, host_write, map_size, false);
   }
 }
 

--- a/lib/gpu/lal_lj_tip4p_long.cu
+++ b/lib/gpu/lal_lj_tip4p_long.cu
@@ -226,9 +226,7 @@ __kernel void k_lj_tip4p_newsite(const __global numtyp4 *restrict x_,
     __global int *restrict hneigh,
     __global numtyp4 *restrict m,
     const int typeO, const int typeH,
-    const numtyp alpha, const __global numtyp *restrict q_,
-    const __global int *restrict tag, const __global int *restrict map,
-    const __global int *restrict sametag) {
+    const numtyp alpha, const __global numtyp *restrict q_) {
   int tid, ii, offset;
   atom_info(t_per_atom,ii,tid,offset);
   int i = BLOCK_ID_X*(BLOCK_SIZE_X)+tid;
@@ -268,8 +266,7 @@ __kernel void k_lj_tip4p_long(const __global numtyp4 *restrict x_,
     const __global numtyp *restrict cutsq,
     const numtyp qqrd2e, const numtyp g_ewald,
     const numtyp cut_coulsq, const numtyp cut_coulsqplus,
-    const __global int *restrict tag, const __global int *restrict map,
-    const __global int *restrict sametag, __global acctyp4 *restrict ansO) {
+    __global acctyp4 *restrict ansO) {
   int tid, ii, offset;
   atom_info(t_per_atom,ii,tid,offset);
 

--- a/lib/gpu/lal_lj_tip4p_long.cu
+++ b/lib/gpu/lal_lj_tip4p_long.cu
@@ -16,6 +16,16 @@
 #ifdef NV_KERNEL
 
 #include "lal_aux_fun1.h"
+#ifdef LAMMPS_SMALLBIG
+#define tagint int
+#endif
+#ifdef LAMMPS_BIGBIG
+#include "inttypes.h"
+#define tagint int64_t
+#endif
+#ifdef LAMMPS_SMALLSMALL
+#define tagint int
+#endif
 #ifndef _DOUBLE_DOUBLE
 texture<float4> pos_tex;
 texture<float> q_tex;
@@ -29,7 +39,7 @@ texture<int2> q_tex;
 #define q_tex q_
 #endif
 
-ucl_inline int atom_mapping(const __global int *map, int glob) {
+ucl_inline int atom_mapping(const __global int *map, tagint glob) {
   return map[glob];
 }
 
@@ -170,7 +180,7 @@ __kernel void k_lj_tip4p_reneigh(const __global numtyp4 *restrict x_,
     __global int *restrict hneigh,
     __global numtyp4 *restrict m,
     const int typeO, const int typeH,
-    const __global int *restrict tag, const __global int *restrict map,
+    const __global tagint *restrict tag, const __global int *restrict map,
     const __global int *restrict sametag) {
   int tid, ii, offset;
   atom_info(t_per_atom,ii,tid,offset);

--- a/lib/gpu/lal_lj_tip4p_long.h
+++ b/lib/gpu/lal_lj_tip4p_long.h
@@ -110,7 +110,7 @@ public:
   UCL_D_Vec<acctyp4> ansO; // force applied to virtual particle
   // UCL_D_Vec<acctyp4> force_comp;
 
-  UCL_D_Vec<int> tag;
+  UCL_D_Vec<tagint> tag;
   UCL_D_Vec<int> map_array;
   UCL_D_Vec<int> atom_sametag;
 

--- a/src/GPU/Install.sh
+++ b/src/GPU/Install.sh
@@ -143,8 +143,8 @@ action pair_ufm_gpu.cpp
 action pair_ufm_gpu.h
 action pair_lj_cut_dipole_long_gpu.cpp pair_lj_cut_dipole_long.cpp
 action pair_lj_cut_dipole_long_gpu.h pair_lj_cut_dipole_long.cpp
-action pair_lj_cut_tip4p_long_gpu.h
-action pair_lj_cut_tip4p_long_gpu.cpp
+action pair_lj_cut_tip4p_long_gpu.h pair_lj_cut_tip4p_long.cpp
+action pair_lj_cut_tip4p_long_gpu.cpp pair_lj_cut_tip4p_long.cpp
 
 # edit 2 Makefile.package files to include/exclude package info
 


### PR DESCRIPTION
**Summary**

This PR includes 4 small fixes of `lj/cut/tip4p/long/gpu`, which was added in #1776.
1. Specify the dependency of `pair_lj_cut_tip4p_long_gpu.cpp`(GPU) on `pair_lj_cut_tip4p_long.cpp` (KSPACE) in the Install.sh of the package. Without this correction, building with the GPU package and without enabled KSPACE fails with "Fatal error: pair_lj_cut_tip4p_long.h: No such file or directory".
2. As @akohlmey suggested in #1776, I added `tagint` where it was necessary.
3. Reduce host-device data transfer and shorten the argument lists of the kernels a bit. 
4. Сorrect the name `lj/cut/tip4p/long/gpu` in the doc source.

**Author(s)**

Vsevolod Nikolskiy (thevsevak@gmail.com, @Vsevak), Vladimir Stegailov (v.stegailov@hse.ru, @vvsteg)
International Laboratory for Supercomputer Atomistic Modelling and Multi-scale Analysis
Higher School of Economics, Moscow, Russia

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The pull request keeps the backward compatibility.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
