### PR TITLE
move two_charge_force calc to occur at init, not constructor

### DIFF
--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -210,6 +210,10 @@ void PPPMKokkos<DeviceType>::init()
     error->all(FLERR,str);
   }
 
+  // compute two charge force
+
+  two_charge();
+
   // extract short-range Coulombic cutoff from pair style
 
   triclinic = domain->triclinic;

--- a/src/KSPACE/ewald.cpp
+++ b/src/KSPACE/ewald.cpp
@@ -112,6 +112,10 @@ void Ewald::init()
                  "and slab correction");
   }
 
+  // compute two charge force
+
+  two_charge();
+
   // extract short-range Coulombic cutoff from pair style
 
   triclinic = domain->triclinic;

--- a/src/KSPACE/ewald_dipole.cpp
+++ b/src/KSPACE/ewald_dipole.cpp
@@ -76,9 +76,9 @@ void EwaldDipole::init()
   if (dipoleflag && q2)
     error->all(FLERR,"Cannot (yet) use charges with Kspace style EwaldDipole");
 
-  triclinic_check();
-
   // no triclinic ewald dipole (yet)
+
+  triclinic_check();
 
   triclinic = domain->triclinic;
   if (triclinic)
@@ -99,6 +99,10 @@ void EwaldDipole::init()
         domain->boundary[2][0] != 1 || domain->boundary[2][1] != 1)
       error->all(FLERR,"Incorrect boundaries with slab EwaldDipole");
   }
+
+  // compute two charge force
+
+  two_charge();
 
   // extract short-range Coulombic cutoff from pair style
 

--- a/src/KSPACE/ewald_dipole_spin.cpp
+++ b/src/KSPACE/ewald_dipole_spin.cpp
@@ -70,9 +70,9 @@ void EwaldDipoleSpin::init()
 
   spinflag = atom->sp?1:0;
 
-  triclinic_check();
-
   // no triclinic ewald spin (yet)
+
+  triclinic_check();
 
   triclinic = domain->triclinic;
   if (triclinic)
@@ -93,6 +93,10 @@ void EwaldDipoleSpin::init()
         domain->boundary[2][0] != 1 || domain->boundary[2][1] != 1)
       error->all(FLERR,"Incorrect boundaries with slab EwaldDipoleSpin");
   }
+
+  // compute two charge force
+
+  two_charge();
 
   // extract short-range Coulombic cutoff from pair style
 

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -181,6 +181,10 @@ void MSM::init()
     error->all(FLERR,"Cannot (yet) use single precision with MSM "
                "(remove -DFFT_SINGLE from Makefile and re-compile)");
 
+  // compute two charge force
+
+  two_charge();
+
   // extract short-range Coulombic cutoff from pair style
 
   triclinic = domain->triclinic;

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -225,6 +225,10 @@ void PPPM::init()
     error->all(FLERR,str);
   }
 
+  // compute two charge force
+
+  two_charge();
+
   // extract short-range Coulombic cutoff from pair style
 
   triclinic = domain->triclinic;

--- a/src/KSPACE/pppm_dipole.cpp
+++ b/src/KSPACE/pppm_dipole.cpp
@@ -149,6 +149,10 @@ void PPPMDipole::init()
     error->all(FLERR,str);
   }
 
+  // compute two charge force
+
+  two_charge();
+
   // extract short-range Coulombic cutoff from pair style
 
   triclinic = domain->triclinic;

--- a/src/KSPACE/pppm_dipole_spin.cpp
+++ b/src/KSPACE/pppm_dipole_spin.cpp
@@ -129,6 +129,10 @@ void PPPMDipoleSpin::init()
     error->all(FLERR,str);
   }
 
+  // compute two charge force
+
+  two_charge();
+
   // extract short-range Coulombic cutoff from pair style
 
   triclinic = domain->triclinic;

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -259,7 +259,10 @@ void PPPMDisp::init()
     if (logfile) fprintf(logfile,"PPPMDisp initialization ...\n");
   }
 
+  // error check
+
   triclinic_check();
+
   if (domain->dimension == 2)
     error->all(FLERR,"Cannot use PPPMDisp with 2d simulation");
   if (comm->style != 0)
@@ -279,6 +282,10 @@ void PPPMDisp::init()
     sprintf(str,"PPPMDisp coulomb order cannot be greater than %d",MAXORDER);
     error->all(FLERR,str);
   }
+
+  // compute two charge force
+
+  two_charge();
 
   // free all arrays previously allocated
 

--- a/src/USER-MISC/pair_extep.cpp
+++ b/src/USER-MISC/pair_extep.cpp
@@ -719,8 +719,8 @@ void PairExTeP::read_file(char *file)
   words = new char*[params_per_line+1];
 
   // intialize F_corr_data to all zeros
-  for (int iel=0;iel<atom->ntypes;iel++)
-    for (int jel=0;jel<atom->ntypes;jel++)
+  for (int iel=0;iel<nelements;iel++)
+    for (int jel=0;jel<nelements;jel++)
       for (int in=0;in<4;in++)
         for (int jn=0;jn<4;jn++)
           for (int ivar=0;ivar<3;ivar++)

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -39,7 +39,8 @@ KSpace::KSpace(LAMMPS *lmp) : Pointers(lmp)
   virial[0] = virial[1] = virial[2] = virial[3] = virial[4] = virial[5] = 0.0;
 
   triclinic_support = 1;
-  ewaldflag = pppmflag = msmflag = dispersionflag = tip4pflag = dipoleflag = spinflag = 0;
+  ewaldflag = pppmflag = msmflag = dispersionflag = tip4pflag = 
+    dipoleflag = spinflag = 0;
   compute_flag = 1;
   group_group_enable = 0;
   stagger_flag = 0;
@@ -78,9 +79,6 @@ KSpace::KSpace(LAMMPS *lmp) : Pointers(lmp)
   accuracy_absolute = -1.0;
   accuracy_real_6 = -1.0;
   accuracy_kspace_6 = -1.0;
-  two_charge_force = force->qqr2e *
-    (force->qelectron * force->qelectron) /
-    (force->angstrom * force->angstrom);
 
   neighrequest_flag = 1;
   mixflag = 0;
@@ -156,6 +154,17 @@ KSpace::~KSpace()
   memory->destroy(vatom);
   memory->destroy(gcons);
   memory->destroy(dgcons);
+}
+
+/* ----------------------------------------------------------------------
+   calculate this in init() so that units are finalized
+------------------------------------------------------------------------- */
+
+void KSpace::two_charge()
+{
+  two_charge_force = force->qqr2e *
+    (force->qelectron * force->qelectron) /
+    (force->angstrom * force->angstrom);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -95,6 +95,7 @@ class KSpace : protected Pointers {
 
   KSpace(class LAMMPS *);
   virtual ~KSpace();
+  void two_charge();
   void triclinic_check();
   void modify_params(int, char **);
   void *extract(const char *);


### PR DESCRIPTION
**Summary**

Fix a bug in the Kspace methods that occurs when you have a Kspace command before
a read_restart command in your input script, and the restart file changes the units.
E.g. from lj (default) to real or metal.  The KSpace constructor computed a two_charge_force
that depends on the units.  When the KSpace grid is setup (after the units change),
then the grid is not correct (usually far too large).  This fix moves the two_charge_force
calculation to init() instead of in the constructor.

Also contains a small bugfix for pair style extep when used with more atom types than elements.
This closes #1851 

**Related Issues**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
