### PR TITLE
Add unit conversion in setup() in fix_langevin.cpp

### DIFF
--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -339,7 +339,7 @@ void FixLangevin::setup(int vflag)
     if (rmass) {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = 0.5 * dt / rmass[i];
+          dtfm = force->ftm2v * 0.5 * dt / rmass[i];
           v[i][0] -= dtfm * f[i][0];
           v[i][1] -= dtfm * f[i][1];
           v[i][2] -= dtfm * f[i][2];
@@ -355,7 +355,7 @@ void FixLangevin::setup(int vflag)
     } else {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = 0.5 * dt / mass[type[i]];
+          dtfm = force->ftm2v * 0.5 * dt / mass[type[i]];
           v[i][0] -= dtfm * f[i][0];
           v[i][1] -= dtfm * f[i][1];
           v[i][2] -= dtfm * f[i][2];
@@ -389,7 +389,7 @@ void FixLangevin::setup(int vflag)
     if (rmass) {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = 0.5 * dt / rmass[i];
+          dtfm = force->ftm2v * 0.5 * dt / rmass[i];
           v[i][0] += dtfm * f[i][0];
           v[i][1] += dtfm * f[i][1];
           v[i][2] += dtfm * f[i][2];
@@ -401,7 +401,7 @@ void FixLangevin::setup(int vflag)
     } else {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = 0.5 * dt / mass[type[i]];
+          dtfm = force->ftm2v * 0.5 * dt / mass[type[i]];
           v[i][0] += dtfm * f[i][0];
           v[i][1] += dtfm * f[i][1];
           v[i][2] += dtfm * f[i][2];


### PR DESCRIPTION
**Summary**

The setup() function in fix_langevin.cpp was missing a unit conversion in the variable dtfm. This leads to wrong starting velocities/temperatures when starting new simulations with the gjf method. The example files use the "unit metal" for which the numerical implications are minor. Larger deviation can be found when "unit real" is used. A simple multiplication of the variable "dtfm" with "force->ftm2v" should do the trick.

**Related Issues**

N/A

**Author(s)**

Viktor Klippenstein

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

Rescaling of the variable dtfm in the function setup() in fix_langevin.cpp for correct units conversion.

**Post Submission Checklist**



- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

N/A


