### PR TITLE
Documentation link formatting cleanup and fixup

### DIFF
--- a/doc/src/Intro_features.rst
+++ b/doc/src/Intro_features.rst
@@ -87,7 +87,7 @@ commands)
 * water potentials: TIP3P, TIP4P, SPC
 * implicit solvent potentials: hydrodynamic lubrication, Debye
 * force-field compatibility with common CHARMM, AMBER, DREIDING,     OPLS, GROMACS, COMPASS options
-* access to the `OpenKIM Repository <http://openkim.org>`_ of potentials via     :doc:`kim\_init, kim\_interactions, and kim\_query <kim_commands>` commands
+* access to the `OpenKIM Repository <http://openkim.org>`_ of potentials via     :doc:`kim_init, kim_interactions, and kim_query <kim_commands>` commands
 * hybrid potentials: multiple pair, bond, angle, dihedral, improper     potentials can be used in one simulation
 * overlaid potentials: superposition of multiple pair potentials
 

--- a/doc/src/Packages_details.rst
+++ b/doc/src/Packages_details.rst
@@ -927,7 +927,7 @@ Also several computes which calculate properties of rigid bodies.
 
 * src/RIGID: filenames -> commands
 * :doc:`compute erotate/rigid <compute_erotate_rigid>`
-* fix shake"_fix\_shake.html
+* :doc:`fix shake <fix_shake>`
 * :doc:`fix rattle <fix_shake>`
 * :doc:`fix rigid/\* <fix_rigid>`
 * examples/ASPHERE

--- a/doc/src/angle_cosine_buck6d.rst
+++ b/doc/src/angle_cosine_buck6d.rst
@@ -46,9 +46,9 @@ internally.
 
 Additional to the cosine term the *cosine/buck6d* angle style computes
 the short range (vdW) interaction belonging to the
-:doc:`pair\_buck6d <pair_buck6d_coul_gauss>` between the end atoms of the
+:doc:`pair_style buck6d <pair_buck6d_coul_gauss>` between the end atoms of the
 angle.  For this reason this angle style only works in combination
-with the :doc:`pair\_buck6d <pair_buck6d_coul_gauss>` styles and needs
+with the :doc:`pair_style buck6d <pair_buck6d_coul_gauss>` styles and needs
 the :doc:`special_bonds <special_bonds>` 1-3 interactions to be weighted
 0.0 to prevent double counting.
 
@@ -61,7 +61,7 @@ Restrictions
 
 
 *cosine/buck6d* can only be used in combination with the
-:doc:`pair\_buck6d <pair_buck6d_coul_gauss>` style and with a
+:doc:`pair_style buck6d <pair_buck6d_coul_gauss>` style and with a
 :doc:`special_bonds <special_bonds>` 0.0 weighting of 1-3 interactions.
 
 This angle style can only be used if LAMMPS was built with the

--- a/doc/src/angle_cosine_shift.rst
+++ b/doc/src/angle_cosine_shift.rst
@@ -83,6 +83,6 @@ Related commands
 """"""""""""""""
 
 :doc:`angle_coeff <angle_coeff>`,
-:doc:`angle\_cosine\_shift\_exp <angle_cosine_shift_exp>`
+:doc:`angle_style cosine/shift/exp <angle_cosine_shift_exp>`
 
 **Default:** none

--- a/doc/src/angle_cosine_shift_exp.rst
+++ b/doc/src/angle_cosine_shift_exp.rst
@@ -94,7 +94,7 @@ Related commands
 """"""""""""""""
 
 :doc:`angle_coeff <angle_coeff>`,
-:doc:`angle\_cosine\_shift <angle_cosine_shift>`,
-:doc:`dihedral\_cosine\_shift\_exp <dihedral_cosine_shift_exp>`
+:doc:`angle_style cosine/shift <angle_cosine_shift>`,
+:doc:`dihedral_style cosine/shift/exp <dihedral_cosine_shift_exp>`
 
 **Default:** none

--- a/doc/src/bond_harmonic_shift_cut.rst
+++ b/doc/src/bond_harmonic_shift_cut.rst
@@ -86,6 +86,6 @@ Related commands
 
 :doc:`bond_coeff <bond_coeff>`, :doc:`delete_bonds <delete_bonds>`,
 :doc:`bond_harmonic <bond_harmonic>`,
-:doc:`bond\_harmonic\_shift <bond_harmonic_shift>`
+:doc:`bond_style harmonic/shift <bond_harmonic_shift>`
 
 **Default:** none

--- a/doc/src/compute_fep.rst
+++ b/doc/src/compute_fep.rst
@@ -301,7 +301,7 @@ Related commands
 """"""""""""""""
 
 :doc:`fix adapt/fep <fix_adapt_fep>`, :doc:`fix ave/time <fix_ave_time>`,
-:doc:`pair\_fep\_soft <pair_fep_soft>`
+:doc:`pair_style .../soft <pair_fep_soft>`
 
 Default
 """""""

--- a/doc/src/compute_hma.rst
+++ b/doc/src/compute_hma.rst
@@ -54,19 +54,22 @@ effects, smaller timestep inaccuracy, faster equilibration and shorter
 decorrelation time.
 
 HMA should not be used if atoms are expected to diffuse.  It is also
-restricted to simulations in the NVT ensemble.  While this compute may be
-used with any potential in LAMMPS, it will provide inaccurate results
+restricted to simulations in the NVT ensemble.  While this compute may
+be used with any potential in LAMMPS, it will provide inaccurate results
 for potentials that do not go to 0 at the truncation distance;
-:doc:`pair\_lj\_smooth\_linear <pair_lj_smooth_linear>` and Ewald summation should
-work fine, while :doc:`pair_lj <pair_lj>` will perform poorly unless
-the potential is shifted (via :doc:`pair_modify <pair_modify>` shift) or the cutoff is large.  Furthermore, computation of the heat capacity with
-this compute is restricted to those that implement the single\_hessian method
-in Pair.  Implementing single\_hessian in additional pair styles is simple.
-Please contact Andrew Schultz (ajs42 at buffalo.edu) and David Kofke (kofke at
-buffalo.edu) if your desired pair style does not have this method.  This is
-the list of pair styles that currently implement pair\_hessian:
+:doc:`pair_style lj/smooth/linear <pair_lj_smooth_linear>` and Ewald
+summation should work fine, while :doc:`pair_style lj/cut <pair_lj>`
+will perform poorly unless the potential is shifted (via
+:doc:`pair_modify <pair_modify>` shift) or the cutoff is large.
+Furthermore, computation of the heat capacity with this compute is
+restricted to those that implement the *single\_hessian* method in Pair.
+Implementing *single\_hessian* in additional pair styles is simple.
+Please contact Andrew Schultz (ajs42 at buffalo.edu) and David Kofke
+(kofke at buffalo.edu) if your desired pair style does not have this
+method.  This is the list of pair styles that currently implement
+*single\_hessian*:
 
-* :doc:`lj\_smooth\_linear <pair_lj_smooth_linear>`
+* :doc:`pair_style lj/smooth/linear <pair_lj_smooth_linear>`
 
 
 In this method, the analytically known harmonic behavior of a crystal is removed from the traditional ensemble

--- a/doc/src/dihedral_cosine_shift_exp.rst
+++ b/doc/src/dihedral_cosine_shift_exp.rst
@@ -92,7 +92,7 @@ Related commands
 """"""""""""""""
 
 :doc:`dihedral_coeff <dihedral_coeff>`,
-:doc:`angle\_cosine\_shift\_exp <angle_cosine_shift_exp>`
+:doc:`angle_style cosine/shift/exp <angle_cosine_shift_exp>`
 
 **Default:** none
 

--- a/doc/src/fix_adapt_fep.rst
+++ b/doc/src/fix_adapt_fep.rst
@@ -319,7 +319,7 @@ Restrictions
 Related commands
 """"""""""""""""
 
-:doc:`compute fep <compute_fep>`, :doc:`fix adapt <fix_adapt>`, :doc:`compute ti <compute_ti>`, :doc:`pair\_fep\_soft <pair_fep_soft>`
+:doc:`compute fep <compute_fep>`, :doc:`fix adapt <fix_adapt>`, :doc:`compute ti <compute_ti>`, :doc:`pair_style \*/soft <pair_fep_soft>`
 
 Default
 """""""

--- a/doc/src/fix_atc.rst
+++ b/doc/src/fix_atc.rst
@@ -143,97 +143,97 @@ Related commands
 
 After specifying this fix in your input script, several other :doc:`fix_modify <fix_modify>` commands are used to setup the problem, e.g. define the finite element mesh and prescribe initial and boundary conditions.
 
-fix\_modify commands for setup:
+*fix\_modify* commands for setup:
 
-* `fix\_modify AtC mesh create <USER/atc/man_mesh_create.html>`_
-* `fix\_modify AtC mesh quadrature <USER/atc/man_mesh_quadrature.html>`_
-* `fix\_modify AtC mesh read <USER/atc/man_mesh_read.html>`_
-* `fix\_modify AtC mesh write <USER/atc/man_mesh_write.html>`_
-* `fix\_modify AtC mesh create\_nodeset <USER/atc/man_mesh_create_nodeset.html>`_
-* `fix\_modify AtC mesh add\_to\_nodeset <USER/atc/man_mesh_add_to_nodeset.html>`_
-* `fix\_modify AtC mesh create\_faceset box <USER/atc/man_mesh_create_faceset_box.html>`_
-* `fix\_modify AtC mesh create\_faceset plane <USER/atc/man_mesh_create_faceset_plane.html>`_
-* `fix\_modify AtC mesh create\_elementset <USER/atc/man_mesh_create_elementset.html>`_
-* `fix\_modify AtC mesh delete\_elements <USER/atc/man_mesh_delete_elements.html>`_
-* `fix\_modify AtC mesh nodeset\_to\_elementset <USER/atc/man_mesh_nodeset_to_elementset.html>`_
-* `fix\_modify AtC boundary <USER/atc/man_boundary.html>`_
-* `fix\_modify AtC internal\_quadrature <USER/atc/man_internal_quadrature.html>`_
-* `fix\_modify AtC time\_integration (thermal) <USER/atc/man_thermal_time_integration.html>`_
-* `fix\_modify AtC time\_integration (momentum) <USER/atc/man_momentum_time_integration.html>`_
-* `fix\_modify AtC extrinsic electron\_integration <USER/atc/man_electron_integration.html>`_
-* `fix\_modify AtC internal\_element\_set <USER/atc/man_internal_element_set.html>`_
-* `fix\_modify AtC decomposition <USER/atc/man_decomposition.html>`_
+* `fix_modify AtC mesh create <USER/atc/man_mesh_create.html>`_
+* `fix_modify AtC mesh quadrature <USER/atc/man_mesh_quadrature.html>`_
+* `fix_modify AtC mesh read <USER/atc/man_mesh_read.html>`_
+* `fix_modify AtC mesh write <USER/atc/man_mesh_write.html>`_
+* `fix_modify AtC mesh create_nodeset <USER/atc/man_mesh_create_nodeset.html>`_
+* `fix_modify AtC mesh add_to_nodeset <USER/atc/man_mesh_add_to_nodeset.html>`_
+* `fix_modify AtC mesh create_faceset box <USER/atc/man_mesh_create_faceset_box.html>`_
+* `fix_modify AtC mesh create_faceset plane <USER/atc/man_mesh_create_faceset_plane.html>`_
+* `fix_modify AtC mesh create_elementset <USER/atc/man_mesh_create_elementset.html>`_
+* `fix_modify AtC mesh delete_elements <USER/atc/man_mesh_delete_elements.html>`_
+* `fix_modify AtC mesh nodeset_to_elementset <USER/atc/man_mesh_nodeset_to_elementset.html>`_
+* `fix_modify AtC boundary <USER/atc/man_boundary.html>`_
+* `fix_modify AtC internal_quadrature <USER/atc/man_internal_quadrature.html>`_
+* `fix_modify AtC time_integration (thermal) <USER/atc/man_thermal_time_integration.html>`_
+* `fix_modify AtC time_integration (momentum) <USER/atc/man_momentum_time_integration.html>`_
+* `fix_modify AtC extrinsic electron_integration <USER/atc/man_electron_integration.html>`_
+* `fix_modify AtC internal_element_set <USER/atc/man_internal_element_set.html>`_
+* `fix_modify AtC decomposition <USER/atc/man_decomposition.html>`_
 
-fix\_modify commands for boundary and initial conditions:
+*fix\_modify* commands for boundary and initial conditions:
 
-* `fix\_modify AtC initial <USER/atc/man_initial.html>`_
-* `fix\_modify AtC fix <USER/atc/man_fix_nodes.html>`_
-* `fix\_modify AtC unfix <USER/atc/man_unfix_nodes.html>`_
-* `fix\_modify AtC fix\_flux <USER/atc/man_fix_flux.html>`_
-* `fix\_modify AtC unfix\_flux <USER/atc/man_unfix_flux.html>`_
-* `fix\_modify AtC source <USER/atc/man_source.html>`_
-* `fix\_modify AtC remove\_source <USER/atc/man_remove_source.html>`_
+* `fix_modify AtC initial <USER/atc/man_initial.html>`_
+* `fix_modify AtC fix <USER/atc/man_fix_nodes.html>`_
+* `fix_modify AtC unfix <USER/atc/man_unfix_nodes.html>`_
+* `fix_modify AtC fix_flux <USER/atc/man_fix_flux.html>`_
+* `fix_modify AtC unfix_flux <USER/atc/man_unfix_flux.html>`_
+* `fix_modify AtC source <USER/atc/man_source.html>`_
+* `fix_modify AtC remove_source <USER/atc/man_remove_source.html>`_
 
-fix\_modify commands for control and filtering:
+*fix\_modify* commands for control and filtering:
 
-* `fix\_modify AtC control <USER/atc/man_control.html>`_
-* `fix\_modify AtC control thermal <USER/atc/man_control_thermal.html>`_
-* `fix\_modify AtC control thermal correction\_max\_iterations <USER/atc/man_control_thermal_correction_max_iterations.html>`_
-* `fix\_modify AtC control momentum <USER/atc/man_control_momentum.html>`_
-* `fix\_modify AtC control localized\_lambda <USER/atc/man_localized_lambda.html>`_
-* `fix\_modify AtC control lumped\_lambda\_solve <USER/atc/man_lumped_lambda_solve.html>`_
-* `fix\_modify AtC control mask\_direction <USER/atc/man_mask_direction.html>`_ control
-* `fix\_modify AtC filter <USER/atc/man_time_filter.html>`_
-* `fix\_modify AtC filter scale <USER/atc/man_filter_scale.html>`_
-* `fix\_modify AtC filter type <USER/atc/man_filter_type.html>`_
-* `fix\_modify AtC equilibrium\_start <USER/atc/man_equilibrium_start.html>`_
-* `fix\_modify AtC extrinsic exchange <USER/atc/man_extrinsic_exchange.html>`_
-* `fix\_modify AtC poisson\_solver <USER/atc/man_poisson_solver.html>`_
+* `fix_modify AtC control <USER/atc/man_control.html>`_
+* `fix_modify AtC control thermal <USER/atc/man_control_thermal.html>`_
+* `fix_modify AtC control thermal correction_max_iterations <USER/atc/man_control_thermal_correction_max_iterations.html>`_
+* `fix_modify AtC control momentum <USER/atc/man_control_momentum.html>`_
+* `fix_modify AtC control localized_lambda <USER/atc/man_localized_lambda.html>`_
+* `fix_modify AtC control lumped_lambda_solve <USER/atc/man_lumped_lambda_solve.html>`_
+* `fix_modify AtC control mask_direction <USER/atc/man_mask_direction.html>`_ control
+* `fix_modify AtC filter <USER/atc/man_time_filter.html>`_
+* `fix_modify AtC filter scale <USER/atc/man_filter_scale.html>`_
+* `fix_modify AtC filter type <USER/atc/man_filter_type.html>`_
+* `fix_modify AtC equilibrium_start <USER/atc/man_equilibrium_start.html>`_
+* `fix_modify AtC extrinsic exchange <USER/atc/man_extrinsic_exchange.html>`_
+* `fix_modify AtC poisson_solver <USER/atc/man_poisson_solver.html>`_
 
-fix\_modify commands for output:
+*fix\_modify* commands for output:
 
-* `fix\_modify AtC output <USER/atc/man_output.html>`_
-* `fix\_modify AtC output nodeset <USER/atc/man_output_nodeset.html>`_
-* `fix\_modify AtC output elementset <USER/atc/man_output_elementset.html>`_
-* `fix\_modify AtC output boundary\_integral <USER/atc/man_boundary_integral.html>`_
-* `fix\_modify AtC output contour\_integral <USER/atc/man_contour_integral.html>`_
-* `fix\_modify AtC mesh output <USER/atc/man_mesh_output.html>`_
-* `fix\_modify AtC write\_restart <USER/atc/man_write_restart.html>`_
-* `fix\_modify AtC read\_restart <USER/atc/man_read_restart.html>`_
+* `fix_modify AtC output <USER/atc/man_output.html>`_
+* `fix_modify AtC output nodeset <USER/atc/man_output_nodeset.html>`_
+* `fix_modify AtC output elementset <USER/atc/man_output_elementset.html>`_
+* `fix_modify AtC output boundary_integral <USER/atc/man_boundary_integral.html>`_
+* `fix_modify AtC output contour_integral <USER/atc/man_contour_integral.html>`_
+* `fix_modify AtC mesh output <USER/atc/man_mesh_output.html>`_
+* `fix_modify AtC write_restart <USER/atc/man_write_restart.html>`_
+* `fix_modify AtC read_restart <USER/atc/man_read_restart.html>`_
 
-fix\_modify commands for post-processing:
+*fix\_modify* commands for post-processing:
 
-* `fix\_modify AtC kernel <USER/atc/man_hardy_kernel.html>`_
-* `fix\_modify AtC fields <USER/atc/man_hardy_fields.html>`_
-* `fix\_modify AtC grdients <USER/atc/man_hardy_gradients.html>`_
-* `fix\_modify AtC rates <USER/atc/man_hardy_rates.html>`_
-* `fix\_modify AtC computes <USER/atc/man_hardy_computes.html>`_
-* `fix\_modify AtC on\_the\_fly <USER/atc/man_hardy_on_the_fly.html>`_
-* `fix\_modify AtC pair\_interactions/bond\_interactions <USER/atc/man_pair_interactions.html>`_
-* `fix\_modify AtC sample\_frequency <USER/atc/man_sample_frequency.html>`_
-* `fix\_modify AtC set <USER/atc/man_set.html>`_
+* `fix_modify AtC kernel <USER/atc/man_hardy_kernel.html>`_
+* `fix_modify AtC fields <USER/atc/man_hardy_fields.html>`_
+* `fix_modify AtC grdients <USER/atc/man_hardy_gradients.html>`_
+* `fix_modify AtC rates <USER/atc/man_hardy_rates.html>`_
+* `fix_modify AtC computes <USER/atc/man_hardy_computes.html>`_
+* `fix_modify AtC on_the_fly <USER/atc/man_hardy_on_the_fly.html>`_
+* `fix_modify AtC pair_interactions/bond_interactions <USER/atc/man_pair_interactions.html>`_
+* `fix_modify AtC sample_frequency <USER/atc/man_sample_frequency.html>`_
+* `fix_modify AtC set <USER/atc/man_set.html>`_
 
-miscellaneous fix\_modify commands:
+miscellaneous *fix\_modify* commands:
 
-* `fix\_modify AtC atom\_element\_map <USER/atc/man_atom_element_map.html>`_
-* `fix\_modify AtC atom\_weight <USER/atc/man_atom_weight.html>`_
-* `fix\_modify AtC write\_atom\_weights <USER/atc/man_write_atom_weights.html>`_
-* `fix\_modify AtC reset\_time <USER/atc/man_reset_time.html>`_
-* `fix\_modify AtC reset\_atomic\_reference\_positions <USER/atc/man_reset_atomic_reference_positions.html>`_
-* `fix\_modify AtC fe\_md\_boundary <USER/atc/man_fe_md_boundary.html>`_
-* `fix\_modify AtC boundary\_faceset <USER/atc/man_boundary_faceset.html>`_
-* `fix\_modify AtC consistent\_fe\_initialization <USER/atc/man_consistent_fe_initialization.html>`_
-* `fix\_modify AtC mass\_matrix <USER/atc/man_mass_matrix.html>`_
-* `fix\_modify AtC material <USER/atc/man_material.html>`_
-* `fix\_modify AtC atomic\_charge <USER/atc/man_atomic_charge.html>`_
-* `fix\_modify AtC source\_integration <USER/atc/man_source_integration.html>`_
-* `fix\_modify AtC temperature\_definition <USER/atc/man_temperature_definition.html>`_
-* `fix\_modify AtC track\_displacement <USER/atc/man_track_displacement.html>`_
-* `fix\_modify AtC boundary\_dynamics <USER/atc/man_boundary_dynamics.html>`_
-* `fix\_modify AtC add\_species <USER/atc/man_add_species.html>`_
-* `fix\_modify AtC add\_molecule <USER/atc/man_add_molecule.html>`_
-* `fix\_modify AtC remove\_species <USER/atc/man_remove_species.html>`_
-* `fix\_modify AtC remove\_molecule <USER/atc/man_remove_molecule.html>`_
+* `fix_modify AtC atom_element_map <USER/atc/man_atom_element_map.html>`_
+* `fix_modify AtC atom_weight <USER/atc/man_atom_weight.html>`_
+* `fix_modify AtC write_atom_weights <USER/atc/man_write_atom_weights.html>`_
+* `fix_modify AtC reset_time <USER/atc/man_reset_time.html>`_
+* `fix_modify AtC reset_atomic_reference_positions <USER/atc/man_reset_atomic_reference_positions.html>`_
+* `fix_modify AtC fe_md_boundary <USER/atc/man_fe_md_boundary.html>`_
+* `fix_modify AtC boundary_faceset <USER/atc/man_boundary_faceset.html>`_
+* `fix_modify AtC consistent_fe_initialization <USER/atc/man_consistent_fe_initialization.html>`_
+* `fix_modify AtC mass_matrix <USER/atc/man_mass_matrix.html>`_
+* `fix_modify AtC material <USER/atc/man_material.html>`_
+* `fix_modify AtC atomic_charge <USER/atc/man_atomic_charge.html>`_
+* `fix_modify AtC source_integration <USER/atc/man_source_integration.html>`_
+* `fix_modify AtC temperature_definition <USER/atc/man_temperature_definition.html>`_
+* `fix_modify AtC track_displacement <USER/atc/man_track_displacement.html>`_
+* `fix_modify AtC boundary_dynamics <USER/atc/man_boundary_dynamics.html>`_
+* `fix_modify AtC add_species <USER/atc/man_add_species.html>`_
+* `fix_modify AtC add_molecule <USER/atc/man_add_molecule.html>`_
+* `fix_modify AtC remove_species <USER/atc/man_remove_species.html>`_
+* `fix_modify AtC remove_molecule <USER/atc/man_remove_molecule.html>`_
 
 Note: a set of example input files with the attendant material files are included with this package
 

--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -390,7 +390,7 @@ the activation energy (:doc:`units <units>` of energy), and *seed* is a
 random number seed. The temperature is defined as the instantaneous
 temperature averaged over all atoms in the reaction site, and is
 calculated in the same manner as for example
-:doc:`compute\_temp\_chunk <compute_temp_chunk>`. Currently, there are no
+:doc:`compute temp/chunk <compute_temp_chunk>`. Currently, there are no
 options for additional temperature averaging or velocity-biased
 temperature calculations. A uniform random number between 0 and 1 is
 generated using *seed*\ ; if this number is less than the result of the

--- a/doc/src/fix_nh_uef.rst
+++ b/doc/src/fix_nh_uef.rst
@@ -89,14 +89,14 @@ in the LAMMPS frame. Only when the positions and velocities are
 updated is the system rotated to the flow frame, and it is rotated
 back to the LAMMPS frame immediately afterwards. For this reason, all
 vector-valued quantities (except for the tensors from
-:doc:`compute\_pressure/uef <compute_pressure_uef>` and
-:doc:`compute\_temp/uef <compute_temp_uef>`) will be computed in the
+:doc:`compute pressure/uef <compute_pressure_uef>` and
+:doc:`compute temp/uef <compute_temp_uef>`) will be computed in the
 LAMMPS frame. Rotationally invariant scalar quantities like the
 temperature and hydrostatic pressure are frame-invariant and will be
 computed correctly. Additionally, the system is in the LAMMPS frame
 during all of the output steps, and therefore trajectory files made
 using the dump command will be in the LAMMPS frame unless the
-:doc:`dump\_cfg/uef <dump_cfg_uef>` command is used.
+:doc:`dump cfg/uef <dump_cfg_uef>` command is used.
 
 
 ----------

--- a/doc/src/fix_precession_spin.rst
+++ b/doc/src/fix_precession_spin.rst
@@ -85,7 +85,7 @@ function for the same parameters.
 
 The temperature effects are accounted for by connecting the spin
 :math:`i` to a thermal bath using a Langevin thermostat (see
-:doc:`fix\_langevin\_spin <fix_langevin_spin>` for the definition of 
+:doc:`fix langevin/spin <fix_langevin_spin>` for the definition of 
 this thermostat).
 
 Style *anisotropy* is used to simulate an easy axis or an easy plane

--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -89,7 +89,7 @@ The nature of the wall/particle interactions are determined by the
 *pair\_coeff* command for the latter.  The equation for the force
 between the wall and particles touching it is the same as the
 corresponding equation on the :doc:`pair_style gran/\* <pair_gran>` and
-:doc:`pair\_style\_granular <pair_granular>` doc pages, in the limit of
+:doc:`pair_style granular <pair_granular>` doc pages, in the limit of
 one of the two particles going to infinite radius and mass (flat
 wall).  Specifically, delta = radius - r = overlap of particle with
 wall, m\_eff = mass of particle, and the effective radius of contact =

--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -83,17 +83,18 @@ close enough to touch it.
 
 The nature of the wall/particle interactions are determined by the
 *fstyle* setting.  It can be any of the styles defined by the
-:doc:`pair_style gran/\* <pair_gran>` or the more general `pair\_style granular <pair_granular.html">`_ commands.  Currently the options are
-*hooke*\ , *hooke/history*\ , or *hertz/history* for the former, and
-*granular* with all the possible options of the associated
+:doc:`pair_style gran/\* <pair_gran>` or the more general
+:doc:`pair_style granular <pair_granular>` commands.  Currently the
+options are *hooke*\ , *hooke/history*\ , or *hertz/history* for the
+former, and *granular* with all the possible options of the associated
 *pair\_coeff* command for the latter.  The equation for the force
 between the wall and particles touching it is the same as the
 corresponding equation on the :doc:`pair_style gran/\* <pair_gran>` and
 :doc:`pair_style granular <pair_granular>` doc pages, in the limit of
-one of the two particles going to infinite radius and mass (flat
-wall).  Specifically, delta = radius - r = overlap of particle with
-wall, m\_eff = mass of particle, and the effective radius of contact =
-RiRj/Ri+Rj is set to the radius of the particle.
+one of the two particles going to infinite radius and mass (flat wall).
+Specifically, delta = radius - r = overlap of particle with wall, m\_eff
+= mass of particle, and the effective radius of contact = RiRj/Ri+Rj is
+set to the radius of the particle.
 
 The parameters *Kn*\ , *Kt*\ , *gamma\_n*, *gamma\_t*, *xmu* and *dampflag*
 have the same meaning and units as those specified with the

--- a/doc/src/fix_wall_gran_region.rst
+++ b/doc/src/fix_wall_gran_region.rst
@@ -154,15 +154,16 @@ corresponding manner.
 
 The nature of the wall/particle interactions are determined by the
 *fstyle* setting.  It can be any of the styles defined by the
-:doc:`pair_style gran/\* <pair_gran>` or the more general `pair\_style granular <pair_granular.html">`_ commands.  Currently the options are
-*hooke*\ , *hooke/history*\ , or *hertz/history* for the former, and
-*granular* with all the possible options of the associated
+:doc:`pair_style gran/\* <pair_gran>` or the more general
+:doc:`pair_style granular <pair_granular>` commands.  Currently the
+options are *hooke*\ , *hooke/history*\ , or *hertz/history* for the
+former, and *granular* with all the possible options of the associated
 *pair\_coeff* command for the latter.  The equation for the force
 between the wall and particles touching it is the same as the
 corresponding equation on the :doc:`pair_style gran/\* <pair_gran>` and
 :doc:`pair_style granular <pair_granular>` doc pages, but the effective
-radius is calculated using the radius of the particle and the radius
-of curvature of the wall at the contact point.
+radius is calculated using the radius of the particle and the radius of
+curvature of the wall at the contact point.
 
 Specifically, delta = radius - r = overlap of particle with wall,
 m\_eff = mass of particle, and RiRj/Ri+Rj is the effective radius, with

--- a/doc/src/fix_wall_gran_region.rst
+++ b/doc/src/fix_wall_gran_region.rst
@@ -160,7 +160,7 @@ The nature of the wall/particle interactions are determined by the
 *pair\_coeff* command for the latter.  The equation for the force
 between the wall and particles touching it is the same as the
 corresponding equation on the :doc:`pair_style gran/\* <pair_gran>` and
-:doc:`pair\_style\_granular <pair_granular>` doc pages, but the effective
+:doc:`pair_style granular <pair_granular>` doc pages, but the effective
 radius is calculated using the radius of the particle and the radius
 of curvature of the wall at the contact point.
 

--- a/doc/src/min_modify.rst
+++ b/doc/src/min_modify.rst
@@ -106,34 +106,31 @@ all atoms in the system:
 For the min styles *spin*\ , *spin/cg* and *spin/lbfgs*\ , the force
 norm is replaced by the spin-torque norm.
 
-Keywords *alpha\_damp* and *discrete\_factor* only make sense when
-a :doc:`min_spin <min_spin>` command is declared.
-Keyword *alpha\_damp* defines an analog of a magnetic Gilbert
-damping. It defines a relaxation rate toward an equilibrium for
-a given magnetic system.
-Keyword *discrete\_factor* defines a discretization factor for the
-adaptive timestep used in the *spin* minimization.
-See :doc:`min_spin <min_spin>` for more information about those
-quantities.
+Keywords *alpha\_damp* and *discrete\_factor* only make sense when a
+:doc:`min_spin <min_spin>` command is declared.  Keyword *alpha\_damp*
+defines an analog of a magnetic Gilbert damping. It defines a relaxation
+rate toward an equilibrium for a given magnetic system.  Keyword
+*discrete\_factor* defines a discretization factor for the adaptive
+timestep used in the *spin* minimization.  See :doc:`min_spin
+<min_spin>` for more information about those quantities.
 
-The choice of a line search algorithm for the *spin/cg* and
-*spin/lbfgs* styles can be specified via the *line* keyword.
-The *spin\_cubic* and  *spin\_none* only make sense when one of those 
-two minimization styles is declared.
-The *spin\_cubic* performs the line search based on a cubic interpolation
-of the energy along the search direction. The *spin\_none* keyword
-deactivates the line search procedure.
-The *spin\_none* is a default value for *line* keyword for both *spin/lbfgs*
-and *spin/cg*\ . Convergence of *spin/lbfgs* can be more robust if
-*spin\_cubic* line search is used.
+The choice of a line search algorithm for the *spin/cg* and *spin/lbfgs*
+styles can be specified via the *line* keyword.  The *spin\_cubic* and
+*spin\_none* options only make sense when one of those two minimization
+styles is declared.  The *spin\_cubic* option performs the line search
+based on a cubic interpolation of the energy along the search
+direction. The *spin\_none* option deactivates the line search
+procedure.  The *spin\_none* option is a default value for *line*
+keyword for both *spin/lbfgs* and *spin/cg*\ . Convergence of
+*spin/lbfgs* can be more robust if *spin\_cubic* line search is used.
 
 Restrictions
 """"""""""""
 
 
-For magnetic GNEB calculations, only *spin\_none* value for *line* keyword can be used
-when styles *spin/cg* and *spin/lbfgs* are employed.
-See :doc:`neb/spin <neb_spin>` for more explanation.
+For magnetic GNEB calculations, only the *spin\_none* value for *line* keyword can be used
+when minimization styles *spin/cg* and *spin/lbfgs* are employed.
+See :doc:`neb/spin <neb_spin>` for more explanations.
 
 Related commands
 """"""""""""""""

--- a/doc/src/min_spin.rst
+++ b/doc/src/min_spin.rst
@@ -70,14 +70,13 @@ discretization factor *discrete\_factor*.
 By default, style *spin/cg* does not employ the line search procedure 
 and uses the adaptive time-step technique in the same way as style *spin*\ .
 
-Style *spin/lbfgs* defines an orthogonal spin optimization
-(OSO) combined to a limited-memory Broyden-Fletcher-Goldfarb-Shanno 
-(L-BFGS) algorithm.
-By default, style *spin/lbfgs* does not employ line search procedure.
-If the line search procedure is not used then the discrete factor defines
-the maximum root mean squared rotation angle of spins by equation *pi/(5\*Kappa)*.
-The default value for Kappa is 10.
-The *spin\_cubic* line search can improve the convergence of the 
+Style *spin/lbfgs* defines an orthogonal spin optimization (OSO)
+combined to a limited-memory Broyden-Fletcher-Goldfarb-Shanno (L-BFGS)
+algorithm.  By default, style *spin/lbfgs* does not employ line search
+procedure.  If the line search procedure is not used then the discrete
+factor defines the maximum root mean squared rotation angle of spins by
+equation *pi/(5\*Kappa)*.  The default value for Kappa is 10.  The
+*spin\_cubic* line search option can improve the convergence of the
 *spin/lbfgs* algorithm.
 
 The :doc:`min_modify <min_modify>` command can be used to

--- a/doc/src/neb_spin.rst
+++ b/doc/src/neb_spin.rst
@@ -389,8 +389,9 @@ This command can only be used if LAMMPS was built with the SPIN
 package.  See the :doc:`Build package <Build_package>` doc
 page for more info.
 
-For magnetic GNEB calculations, only *spin\_none* value for *line* keyword can be used
-when styles *spin/cg* and *spin/lbfgs* are employed.
+For magnetic GNEB calculations, only the *spin\_none* value for the
+*line* keyword can be used when minimization styles *spin/cg* and
+*spin/lbfgs* are employed.
 
 
 ----------

--- a/doc/src/pair_class2.rst
+++ b/doc/src/pair_class2.rst
@@ -133,7 +133,7 @@ cutoff distance.
 
 A version of these styles with a soft core, *lj/cut/soft*\ , suitable for use in
 free energy calculations, is part of the USER-FEP package and is documented with
-the :doc:`pair\_fep\_soft <pair_fep_soft>` styles. The version with soft core is
+the :doc:`pair_style */soft <pair_fep_soft>` styles. The version with soft core is
 only available if LAMMPS was built with that package. See the :doc:`Build package <Build_package>` doc page for more info.
 
 
@@ -203,7 +203,7 @@ LAMMPS was built with that package.  See the :doc:`Build package <Build_package>
 Related commands
 """"""""""""""""
 
-:doc:`pair_coeff <pair_coeff>`, :doc:`pair\_fep\_soft <pair_fep_soft>`
+:doc:`pair_coeff <pair_coeff>`, :doc:`pair_style */soft <pair_fep_soft>`
 
 **Default:** none
 

--- a/doc/src/pair_coul.rst
+++ b/doc/src/pair_coul.rst
@@ -392,7 +392,7 @@ info.
 Related commands
 """"""""""""""""
 
-:doc:`pair_coeff <pair_coeff>`, :doc:`pair\_style, hybrid/overlay <pair_hybrid>`, :doc:`kspace_style <kspace_style>`
+:doc:`pair_coeff <pair_coeff>`, :doc:`pair_style, hybrid/overlay <pair_hybrid>`, :doc:`kspace_style <kspace_style>`
 
 **Default:** none
 

--- a/doc/src/pair_fep_soft.rst
+++ b/doc/src/pair_fep_soft.rst
@@ -193,7 +193,7 @@ and Coulomb potentials modified by a soft core, with the functional form
 The *lj/class2/soft* style is a 9-6 potential with the exponent of the
 denominator of the first term in brackets taking the value 1.5 instead of 2
 (other details differ, see the form of the potential in
-:doc:`pair\_class2 <pair_class2>`).
+:doc:`pair_style lj/class2 <pair_class2>`).
 
 Coulomb interactions can also be damped with a soft core at short distance,
 
@@ -255,14 +255,14 @@ optional cutoffs.
 
 Style *lj/charmm/coul/long/soft* implements a soft-core version of the modified
 12-6 LJ potential used in CHARMM and documented in the
-:doc:`pair\_lj\_charmm <pair_charmm>` style. In the soft version the parameters n,
+:doc:`pair_style lj/charmm/coul/long <pair_charmm>` style. In the soft version the parameters n,
 alpha\_LJ and alpha\_C are set in the :doc:`pair_style <pair_style>` command, before
 the global cutoffs. The activation parameter lambda is introduced as an argument
 of the :doc:`pair_coeff <pair_coeff>` command, after epsilon and sigma and
 before the optional eps14 and sigma14.
 
 Style *lj/class2/soft* implements a soft-core version of the 9-6 potential in
-:doc:`pair\_class2 <pair_class2>`. In the soft version the parameters n, alpha\_LJ
+:doc:`pair_style lj/class2 <pair_class2>`. In the soft version the parameters n, alpha\_LJ
 and alpha\_C are set in the :doc:`pair_style <pair_style>` command, before the
 global cutoffs. The activation parameter lambda is introduced as an argument of
 the the :doc:`pair_coeff <pair_coeff>` command, after epsilon and sigma and before

--- a/doc/src/pair_lj.rst
+++ b/doc/src/pair_lj.rst
@@ -348,7 +348,7 @@ pair\_style command.
 
 A version of these styles with a soft core, *lj/cut/soft*\ , suitable for use in
 free energy calculations, is part of the USER-FEP package and is documented with
-the :doc:`pair\_fep\_soft <pair_fep_soft>` styles. The version with soft core is
+the :doc:`pair_style */soft <pair_fep_soft>` styles. The version with soft core is
 only available if LAMMPS was built with that package. See the :doc:`Build package <Build_package>` doc page for more info.
 
 

--- a/doc/src/pair_lj_long.rst
+++ b/doc/src/pair_lj_long.rst
@@ -180,7 +180,7 @@ specified in the pair\_style command.
 
 A version of these styles with a soft core, *lj/cut/soft*\ , suitable for use in
 free energy calculations, is part of the USER-FEP package and is documented with
-the :doc:`pair\_fep\_soft <pair_fep_soft>` styles. The version with soft core is
+the :doc:`pair_style */soft <pair_fep_soft>` styles. The version with soft core is
 only available if LAMMPS was built with that package. See the :doc:`Build package <Build_package>` doc page for more info.
 
 

--- a/doc/src/pair_morse.rst
+++ b/doc/src/pair_morse.rst
@@ -95,7 +95,7 @@ the *morse* and *morse/smooth/linear* styles.
 
 A version of the *morse* style with a soft core, *morse/soft*\ , suitable for use in
 free energy calculations, is part of the USER-FEP package and is documented with
-the :doc:`pair\_fep\_soft <pair_fep_soft>` styles. The version with soft core is only
+the :doc:`pair_style */soft <pair_fep_soft>` styles. The version with soft core is only
 available if LAMMPS was built with that package. See the :doc:`Build package <Build_package>` doc page for more info.
 
 
@@ -160,7 +160,7 @@ built with the USER-MISC package.  See the :doc:`Build package <Build_package>` 
 Related commands
 """"""""""""""""
 
-:doc:`pair_coeff <pair_coeff>`, :doc:`pair\_fep\_soft <pair_fep_soft>`
+:doc:`pair_coeff <pair_coeff>`, :doc:`pair_style */soft <pair_fep_soft>`
 
 **Default:** none
 

--- a/doc/src/pair_spin_exchange.rst
+++ b/doc/src/pair_spin_exchange.rst
@@ -55,7 +55,7 @@ in :ref:`(Tranchida) <Tranchida3>`.
 
 From this exchange interaction, each spin :math:`i` will be submitted
 to a magnetic torque :math:`\vec{\omega}`, and its associated atom can be submitted to a
-force :math:`\vec{F}` for spin-lattice calculations (see :doc:`fix\_nve\_spin <fix_nve_spin>`),
+force :math:`\vec{F}` for spin-lattice calculations (see :doc:`fix nve/spin <fix_nve_spin>`),
 such as:
 
 .. math::

--- a/doc/src/pair_spin_magelec.rst
+++ b/doc/src/pair_spin_magelec.rst
@@ -41,7 +41,7 @@ direction of a screened dielectric atomic polarization (in eV).
 
 From this magneto-electric interaction, each spin i will be submitted
 to a magnetic torque omega, and its associated atom can be submitted to a
-force F for spin-lattice calculations (see :doc:`fix\_nve\_spin <fix_nve_spin>`),
+force F for spin-lattice calculations (see :doc:`fix nve/spin <fix_nve_spin>`),
 such as:
 
 .. image:: Eqs/pair_spin_me_forces.jpg
@@ -68,7 +68,7 @@ Related commands
 """"""""""""""""
 
 :doc:`atom_style spin <atom_style>`, :doc:`pair_coeff <pair_coeff>`,
-:doc:`pair\_spin\_exchange <pair_spin_exchange>`, :doc:`pair_eam <pair_eam>`,
+:doc:`pair_style spin/exchange <pair_spin_exchange>`, :doc:`pair_eam <pair_eam>`,
 
 **Default:** none
 

--- a/doc/src/pair_thole.rst
+++ b/doc/src/pair_thole.rst
@@ -53,7 +53,7 @@ describes how to use the :doc:`thermalized Drude oscillator model <Howto_drude>`
 discussed on the :doc:`Howto polarizable <Howto_polarizable>` doc page.
 
 The *thole* pair style should be used as a sub-style within in the
-:doc:`pair\_hybrid/overlay <pair_hybrid>` command, in conjunction with a
+:doc:`pair_style hybrid/overlay <pair_hybrid>` command, in conjunction with a
 main pair style including Coulomb interactions, i.e. any pair style
 containing *coul/cut* or *coul/long* in its style name.
 

--- a/doc/src/rerun.rst
+++ b/doc/src/rerun.rst
@@ -115,13 +115,13 @@ However if you specify a series of dump files in an incorrect order
 (with respect to the timesteps they contain), you may skip large
 numbers of snapshots
 
-Note that the dump files specified as part of the *dump* keyword can
-be parallel files, i.e. written as multiple files either per processor
+Note that the dump files specified as part of the *dump* keyword can be
+parallel files, i.e. written as multiple files either per processor
 and/or per snapshot.  If that is the case they will also be read in
 parallel which can make the rerun command operate dramatically faster
-for large systems.  See the doc page for the `read\_dump <read_dump>`_ and
-:doc:`dump <dump>` commands which describe how to read and write
-parallel dump files.
+for large systems.  See the doc page for the :doc:`read_dump
+<read_dump>` and :doc:`dump <dump>` commands which describe how to read
+and write parallel dump files.
 
 The *first*\ , *last*\ , *every*\ , *skip* keywords determine which
 snapshots are read from the dump file(s).  Snapshots are skipped until

--- a/doc/src/temper_grem.rst
+++ b/doc/src/temper_grem.rst
@@ -14,7 +14,7 @@ Syntax
 * N = total # of timesteps to run
 * M = attempt a tempering swap every this many steps
 * lambda = initial lambda for this ensemble
-* fix-ID = ID of fix\_grem
+* fix-ID = ID of *fix grem*
 * thermostat-ID = ID of the thermostat that controls kinetic temperature
 * seed1 = random # seed used to decide on adjacent temperature to partner with
 * seed2 = random # seed for Boltzmann factor in Metropolis swap


### PR DESCRIPTION
**Summary**

This pull request corrects some misformatted, mistranslated, or incorrect links in the .rst version of the documentation sources. Now that the original .txt files are gone, these issues will not re-appear and replacing `\_` with `_` in the links will simplify future maintenance.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system

