### PR TITLE
Fixed gjf setup to work with other units and not just metal.

### DIFF
--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -339,7 +339,7 @@ void FixLangevin::setup(int vflag)
     if (rmass) {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = force->ftm2v * 0.5 * dt / rmass[i];
+          dtfm = 0.5 * dt * force->ftm2v / rmass[i];
           v[i][0] -= dtfm * f[i][0];
           v[i][1] -= dtfm * f[i][1];
           v[i][2] -= dtfm * f[i][2];
@@ -355,7 +355,7 @@ void FixLangevin::setup(int vflag)
     } else {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = force->ftm2v * 0.5 * dt / mass[type[i]];
+          dtfm = 0.5 * dt * force->ftm2v / mass[type[i]];
           v[i][0] -= dtfm * f[i][0];
           v[i][1] -= dtfm * f[i][1];
           v[i][2] -= dtfm * f[i][2];
@@ -389,7 +389,7 @@ void FixLangevin::setup(int vflag)
     if (rmass) {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = force->ftm2v * 0.5 * dt / rmass[i];
+          dtfm = 0.5 * dt * force->ftm2v / rmass[i];
           v[i][0] += dtfm * f[i][0];
           v[i][1] += dtfm * f[i][1];
           v[i][2] += dtfm * f[i][2];
@@ -401,7 +401,7 @@ void FixLangevin::setup(int vflag)
     } else {
       for (int i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) {
-          dtfm = force->ftm2v * 0.5 * dt / mass[type[i]];
+          dtfm = 0.5 * dt * force->ftm2v / mass[type[i]];
           v[i][0] += dtfm * f[i][0];
           v[i][1] += dtfm * f[i][1];
           v[i][2] += dtfm * f[i][2];


### PR DESCRIPTION
**Summary**

_Bug Fix: Previous GJF-2GJ implementation only worked with units metal, now it works with all units._

**Related Issues**

fixes #1871

**Author(s)**

_Charles A. Sievers_

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

_It is backwards compatible._

**Implementation Notes**

_Added in force->ftm2v_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


