### PR TITLE
Refactor handling of box change information from fixes

### DIFF
--- a/doc/src/Errors_messages.rst
+++ b/doc/src/Errors_messages.rst
@@ -5815,6 +5815,9 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
    Cannot use the temper command with only one processor partition.  Use
    the -partition command-line option.
 
+*Must not have multiple fixes change box parameter ...*
+   Self-explanatory.
+
 *Must read Atoms before Angles*
    The Atoms section of a data file must come before an Angles section.
 

--- a/src/RIGID/fix_rigid_nh.cpp
+++ b/src/RIGID/fix_rigid_nh.cpp
@@ -106,6 +106,10 @@ FixRigidNH::FixRigidNH(LAMMPS *lmp, int narg, char **arg) :
        p_period[0] != p_period[2]))
     error->all(FLERR,"Invalid fix rigid npt/nph command pressure settings");
 
+  if (p_flag[0]) box_change |= BOX_CHANGE_X;
+  if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+  if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+
   if ((tstat_flag && t_period <= 0.0) ||
       (p_flag[0] && p_period[0] <= 0.0) ||
       (p_flag[1] && p_period[1] <= 0.0) ||

--- a/src/RIGID/fix_rigid_nh_small.cpp
+++ b/src/RIGID/fix_rigid_nh_small.cpp
@@ -120,6 +120,10 @@ FixRigidNHSmall::FixRigidNHSmall(LAMMPS *lmp, int narg, char **arg) :
        p_period[0] != p_period[2]))
     error->all(FLERR,"Invalid fix rigid/small npt/nph command pressure settings");
 
+  if (p_flag[0]) box_change |= BOX_CHANGE_X;
+  if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+  if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+
   if ((tstat_flag && t_period <= 0.0) ||
       (p_flag[0] && p_period[0] <= 0.0) ||
       (p_flag[1] && p_period[1] <= 0.0) ||

--- a/src/RIGID/fix_rigid_nph.cpp
+++ b/src/RIGID/fix_rigid_nph.cpp
@@ -33,7 +33,6 @@ FixRigidNPH::FixRigidNPH(LAMMPS *lmp, int narg, char **arg) :
 
   scalar_flag = 1;
   restart_global = 1;
-  box_change_size = 1;
   extscalar = 1;
 
   // error checks

--- a/src/RIGID/fix_rigid_nph_small.cpp
+++ b/src/RIGID/fix_rigid_nph_small.cpp
@@ -33,7 +33,6 @@ FixRigidNPHSmall::FixRigidNPHSmall(LAMMPS *lmp, int narg, char **arg) :
 
   scalar_flag = 1;
   restart_global = 1;
-  box_change_size = 1;
   extscalar = 1;
 
   // error checks

--- a/src/RIGID/fix_rigid_npt.cpp
+++ b/src/RIGID/fix_rigid_npt.cpp
@@ -33,7 +33,6 @@ FixRigidNPT::FixRigidNPT(LAMMPS *lmp, int narg, char **arg) :
 
   scalar_flag = 1;
   restart_global = 1;
-  box_change_size = 1;
   extscalar = 1;
 
   // error checks

--- a/src/RIGID/fix_rigid_npt_small.cpp
+++ b/src/RIGID/fix_rigid_npt_small.cpp
@@ -33,7 +33,6 @@ FixRigidNPTSmall::FixRigidNPTSmall(LAMMPS *lmp, int narg, char **arg) :
 
   scalar_flag = 1;
   restart_global = 1;
-  box_change_size = 1;
   extscalar = 1;
 
   // error checks

--- a/src/SHOCK/fix_append_atoms.cpp
+++ b/src/SHOCK/fix_append_atoms.cpp
@@ -40,7 +40,6 @@ FixAppendAtoms::FixAppendAtoms(LAMMPS *lmp, int narg, char **arg) :
 {
   force_reneighbor = 1;
   next_reneighbor = -1;
-  box_change_size = 1;
   time_depend = 1;
 
   if (narg < 4) error->all(FLERR,"Illegal fix append/atoms command");
@@ -75,35 +74,41 @@ FixAppendAtoms::FixAppendAtoms(LAMMPS *lmp, int narg, char **arg) :
     if (strcmp(arg[iarg],"xlo") == 0) {
       error->all(FLERR,"Only zhi currently implemented for fix append/atoms");
       xloflag = 1;
+      box_change |= BOX_CHANGE_X;
       iarg++;
       if (domain->boundary[0][0] != 3)
         error->all(FLERR,"Append boundary must be shrink/minimum");
     } else if (strcmp(arg[iarg],"xhi") == 0) {
       error->all(FLERR,"Only zhi currently implemented for fix append/atoms");
       xhiflag = 1;
+      box_change |= BOX_CHANGE_X;
       iarg++;
       if (domain->boundary[0][1] != 3)
         error->all(FLERR,"Append boundary must be shrink/minimum");
     } else if (strcmp(arg[iarg],"ylo") == 0) {
       error->all(FLERR,"Only zhi currently implemented for fix append/atoms");
       yloflag = 1;
+      box_change |= BOX_CHANGE_Y;
       iarg++;
       if (domain->boundary[1][0] != 3)
         error->all(FLERR,"Append boundary must be shrink/minimum");
     } else if (strcmp(arg[iarg],"yhi") == 0) {
       error->all(FLERR,"Only zhi currently implemented for fix append/atoms");
       yhiflag = 1;
+      box_change |= BOX_CHANGE_Y;
       iarg++;
       if (domain->boundary[1][1] != 3)
         error->all(FLERR,"Append boundary must be shrink/minimum");
     } else if (strcmp(arg[iarg],"zlo") == 0) {
       error->all(FLERR,"Only zhi currently implemented for fix append/atoms");
       zloflag = 1;
+      box_change |= BOX_CHANGE_Z;
       iarg++;
       if (domain->boundary[2][0] != 3)
         error->all(FLERR,"Append boundary must be shrink/minimum");
     } else if (strcmp(arg[iarg],"zhi") == 0) {
       zhiflag = 1;
+      box_change |= BOX_CHANGE_Z;
       iarg++;
       if (domain->boundary[2][1] != 3)
         error->all(FLERR,"Append boundary must be shrink/minimum");

--- a/src/SHOCK/fix_msst.cpp
+++ b/src/SHOCK/fix_msst.cpp
@@ -46,7 +46,6 @@ FixMSST::FixMSST(LAMMPS *lmp, int narg, char **arg) :
   if (narg < 4) error->all(FLERR,"Illegal fix msst command");
 
   restart_global = 1;
-  box_change_size = 1;
   time_integrate = 1;
   scalar_flag = 1;
   vector_flag = 1;
@@ -78,10 +77,16 @@ FixMSST::FixMSST(LAMMPS *lmp, int narg, char **arg) :
   dftb = 0;
   beta = 0.0;
 
-  if (strcmp(arg[3],"x") == 0) direction = 0;
-  else if (strcmp(arg[3],"y") == 0) direction = 1;
-  else if (strcmp(arg[3],"z") == 0) direction = 2;
-  else error->all(FLERR,"Illegal fix msst command");
+  if (strcmp(arg[3],"x") == 0) {
+    direction = 0;
+    box_change |= BOX_CHANGE_X;
+  } else if (strcmp(arg[3],"y") == 0) {
+    direction = 1;
+    box_change |= BOX_CHANGE_Y;
+  } else if (strcmp(arg[3],"z") == 0) {
+    direction = 2;
+    box_change |= BOX_CHANGE_Z;
+  } else error->all(FLERR,"Illegal fix msst command");
 
   velocity = force->numeric(FLERR,arg[4]);
   if (velocity < 0) error->all(FLERR,"Illegal fix msst command");

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -375,13 +375,16 @@ void FixSRD::init()
 
   change_size = change_shape = deformflag = 0;
   if (domain->nonperiodic == 2) change_size = 1;
+
+  Fix **fixes = modify->fix;
   for (int i = 0; i < modify->nfix; i++) {
-    if (modify->fix[i]->box_change_size) change_size = 1;
-    if (modify->fix[i]->box_change_shape) change_shape = 1;
-    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+    if (fixes[i]->box_change & BOX_CHANGE_SIZE)  change_size = 1;
+    if (fixes[i]->box_change & BOX_CHANGE_SHAPE) change_shape = 1;
+    if (strcmp(fixes[i]->style,"deform") == 0) {
       deformflag = 1;
       FixDeform *deform = (FixDeform *) modify->fix[i];
-      if (deform->box_change_shape && deform->remapflag != Domain::V_REMAP)
+      if ((deform->box_change & BOX_CHANGE_SHAPE)
+          && deform->remapflag != Domain::V_REMAP)
         error->all(FLERR,"Using fix srd with inconsistent "
                    "fix deform remap option");
     }

--- a/src/USER-BOCS/fix_bocs.cpp
+++ b/src/USER-BOCS/fix_bocs.cpp
@@ -292,8 +292,12 @@ FixBocs::FixBocs(LAMMPS *lmp, int narg, char **arg) :
     if (p_flag[i]) pstat_flag = 1;
 
   if (pstat_flag) {
-    if (p_flag[0] || p_flag[1] || p_flag[2]) box_change_size = 1;
-    if (p_flag[3] || p_flag[4] || p_flag[5]) box_change_shape = 1;
+    if (p_flag[0]) box_change |= BOX_CHANGE_X;
+    if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+    if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+    if (p_flag[3]) box_change |= BOX_CHANGE_YZ;
+    if (p_flag[4]) box_change |= BOX_CHANGE_XZ;
+    if (p_flag[5]) box_change |= BOX_CHANGE_XY;
     no_change_box = 1;
     if (allremap == 0) restart_pbc = 1;
 

--- a/src/USER-MISC/fix_npt_cauchy.cpp
+++ b/src/USER-MISC/fix_npt_cauchy.cpp
@@ -492,8 +492,12 @@ FixNPTCauchy::FixNPTCauchy(LAMMPS *lmp, int narg, char **arg) :
     if (p_flag[i]) pstat_flag = 1;
 
   if (pstat_flag) {
-    if (p_flag[0] || p_flag[1] || p_flag[2]) box_change_size = 1;
-    if (p_flag[3] || p_flag[4] || p_flag[5]) box_change_shape = 1;
+    if (p_flag[0]) box_change |= BOX_CHANGE_X;
+    if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+    if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+    if (p_flag[3]) box_change |= BOX_CHANGE_YZ;
+    if (p_flag[4]) box_change |= BOX_CHANGE_XZ;
+    if (p_flag[5]) box_change |= BOX_CHANGE_XY;
     no_change_box = 1;
     if (allremap == 0) restart_pbc = 1;
 

--- a/src/USER-OMP/fix_rigid_nph_omp.cpp
+++ b/src/USER-OMP/fix_rigid_nph_omp.cpp
@@ -33,7 +33,6 @@ FixRigidNPHOMP::FixRigidNPHOMP(LAMMPS *lmp, int narg, char **arg) :
 
   scalar_flag = 1;
   restart_global = 1;
-  box_change_size = 1;
   extscalar = 1;
 
   // error checks

--- a/src/USER-OMP/fix_rigid_npt_omp.cpp
+++ b/src/USER-OMP/fix_rigid_npt_omp.cpp
@@ -33,7 +33,6 @@ FixRigidNPTOMP::FixRigidNPTOMP(LAMMPS *lmp, int narg, char **arg) :
 
   scalar_flag = 1;
   restart_global = 1;
-  box_change_size = 1;
   extscalar = 1;
 
   // error checks

--- a/src/USER-QTB/fix_qbmsst.cpp
+++ b/src/USER-QTB/fix_qbmsst.cpp
@@ -45,13 +45,16 @@ FixQBMSST::FixQBMSST(LAMMPS *lmp, int narg, char **arg) :
 {
   if (narg < 5) error->all(FLERR,"Illegal fix qbmsst command");
 
-  if ( strcmp(arg[3],"x") == 0 )
+  if ( strcmp(arg[3],"x") == 0 ) {
     direction = 0;
-  else if ( strcmp(arg[3],"y") == 0 )
+    box_change |= BOX_CHANGE_X;
+  } else if ( strcmp(arg[3],"y") == 0 ) {
     direction = 1;
-  else if ( strcmp(arg[3],"z") == 0 )
+    box_change |= BOX_CHANGE_Y;
+  } else if ( strcmp(arg[3],"z") == 0 ) {
     direction = 2;
-  else {
+    box_change |= BOX_CHANGE_Z;
+  } else {
     error->all(FLERR,"Illegal fix qbmsst command");
   }
   velocity = atof(arg[4]);
@@ -64,7 +67,6 @@ FixQBMSST::FixQBMSST(LAMMPS *lmp, int narg, char **arg) :
   extvector = 0;
   nevery = 1;
   restart_global = 1;
-  box_change_size = 1;
   time_integrate = 1;
   scalar_flag = 1;
   vector_flag = 1;

--- a/src/USER-UEF/fix_nh_uef.cpp
+++ b/src/USER-UEF/fix_nh_uef.cpp
@@ -163,7 +163,7 @@ FixNHUef::FixNHUef(LAMMPS *lmp, int narg, char **arg) :
 
   // flag that I change the box here (in case of nvt)
 
-  box_change_shape = 1;
+  box_change |= BOX_CHANGE_SHAPE;
 
   // initialize the UEFBox class which computes the box at each step
 

--- a/src/USER-UEF/fix_nh_uef.cpp
+++ b/src/USER-UEF/fix_nh_uef.cpp
@@ -244,7 +244,7 @@ void FixNHUef::init()
   for (int i=0; i < modify->nfix; i++)
   {
     if (strcmp(modify->fix[i]->id,id) != 0)
-      if (modify->fix[i]->box_change_shape != 0)
+      if ((modify->fix[i]->box_change & BOX_CHANGE_SHAPE) != 0)
         error->all(FLERR,"Can't use another fix which changes box shape with fix/nvt/npt/uef");
   }
 

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -19,6 +19,7 @@
 #include <mpi.h>
 #include <cstring>
 #include <cmath>
+#include <string>
 #include "style_region.h"
 #include "atom.h"
 #include "atom_vec.h"
@@ -133,12 +134,38 @@ void Domain::init()
 
   box_change_size = box_change_shape = box_change_domain = 0;
 
+  // flags for detecting, if multiple fixes try to change the
+  // same box size or shape parameter
+
+  int box_change_x=0, box_change_y=0, box_change_z=0;
+  int box_change_yz=0, box_change_xz=0, box_change_xy=0;
+  Fix **fixes = modify->fix;
+
   if (nonperiodic == 2) box_change_size = 1;
   for (int i = 0; i < modify->nfix; i++) {
-    if (modify->fix[i]->box_change_size) box_change_size = 1;
-    if (modify->fix[i]->box_change_shape) box_change_shape = 1;
-    if (modify->fix[i]->box_change_domain) box_change_domain = 1;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_SIZE)   box_change_size = 1;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_SHAPE)  box_change_shape = 1;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_DOMAIN) box_change_domain = 1;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_X)      box_change_x++;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_Y)      box_change_y++;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_Z)      box_change_z++;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_YZ)     box_change_yz++;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_XZ)     box_change_xz++;
+    if (fixes[i]->box_change & Fix::BOX_CHANGE_XY)     box_change_xy++;
   }
+
+  std::string mesg = "Must not have multiple fixes change box parameter ";
+
+#define CHECK_BOX_FIX_ERROR(par)                                        \
+  if (box_change_ ## par > 1) error->all(FLERR,(mesg + #par).c_str())
+
+  CHECK_BOX_FIX_ERROR(x);
+  CHECK_BOX_FIX_ERROR(y);
+  CHECK_BOX_FIX_ERROR(z);
+  CHECK_BOX_FIX_ERROR(yz);
+  CHECK_BOX_FIX_ERROR(xz);
+  CHECK_BOX_FIX_ERROR(xy);
+#undef CHECK_BOX_FIX_ERROR
 
   box_change = 0;
   if (box_change_size || box_change_shape || box_change_domain) box_change = 1;

--- a/src/domain.h
+++ b/src/domain.h
@@ -282,6 +282,10 @@ E: Both sides of boundary must be periodic
 Cannot specify a boundary as periodic only on the lo or hi side.  Must
 be periodic on both sides.
 
+E: Must not have multiple fixes change box parameter ...
+
+Self-explanatory.
+
 U: Box bounds are invalid
 
 The box boundaries specified in the read_data file are invalid.  The

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -58,7 +58,7 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
 
   restart_global = restart_peratom = restart_file = 0;
   force_reneighbor = 0;
-  box_change_size = box_change_shape = box_change_domain = 0;
+  box_change = NO_BOX_CHANGE;
   thermo_energy = 0;
   thermo_virial = 0;
   rigid_flag = 0;

--- a/src/fix.h
+++ b/src/fix.h
@@ -30,9 +30,14 @@ class Fix : protected Pointers {
   int restart_file;              // 1 if Fix writes own restart file, 0 if not
   int force_reneighbor;          // 1 if Fix forces reneighboring, 0 if not
 
-  int box_change_size;           // 1 if Fix changes box size, 0 if not
-  int box_change_shape;          // 1 if Fix changes box shape, 0 if not
-  int box_change_domain;         // 1 if Fix changes proc sub-domains, 0 if not
+  int box_change;                // >0 if Fix changes box size, shape, or sub-domains, 0 if not
+  enum {
+    NO_BOX_CHANGE = 0,    BOX_CHANGE_ANY = 1<<0, BOX_CHANGE_DOMAIN = 1<<1,
+    BOX_CHANGE_X  = 1<<2, BOX_CHANGE_Y   = 1<<3, BOX_CHANGE_Z      = 1<<4,
+    BOX_CHANGE_YZ = 1<<5, BOX_CHANGE_XZ  = 1<<6, BOX_CHANGE_XY     = 1<<7,
+    BOX_CHANGE_SIZE  = BOX_CHANGE_X  | BOX_CHANGE_Y  | BOX_CHANGE_Z,
+    BOX_CHANGE_SHAPE = BOX_CHANGE_YZ | BOX_CHANGE_XZ | BOX_CHANGE_XY
+  };
 
   bigint next_reneighbor;        // next timestep to force a reneighboring
   int thermo_energy;             // 1 if fix_modify enabled ThEng, 0 if not

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -39,7 +39,7 @@ FixBalance::FixBalance(LAMMPS *lmp, int narg, char **arg) :
 {
   if (narg < 6) error->all(FLERR,"Illegal fix balance command");
 
-  box_change_domain = 1;
+  box_change = BOX_CHANGE_DOMAIN;
   scalar_flag = 1;
   extscalar = 0;
   vector_flag = 1;

--- a/src/fix_box_relax.cpp
+++ b/src/fix_box_relax.cpp
@@ -218,8 +218,13 @@ FixBoxRelax::FixBoxRelax(LAMMPS *lmp, int narg, char **arg) :
     } else error->all(FLERR,"Illegal fix box/relax command");
   }
 
-  if (p_flag[0] || p_flag[1] || p_flag[2]) box_change_size = 1;
-  if (p_flag[3] || p_flag[4] || p_flag[5]) box_change_shape = 1;
+  if (p_flag[0]) box_change |= BOX_CHANGE_X;
+  if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+  if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+  if (p_flag[3]) box_change |= BOX_CHANGE_YZ;
+  if (p_flag[4]) box_change |= BOX_CHANGE_XZ;
+  if (p_flag[5]) box_change |= BOX_CHANGE_XY;
+
   if (allremap == 0) restart_pbc = 1;
 
   // error checks

--- a/src/fix_deform.cpp
+++ b/src/fix_deform.cpp
@@ -211,8 +211,12 @@ rfix(NULL), irregular(NULL), set(NULL)
     if (set[i].style == NONE) dimflag[i] = 0;
     else dimflag[i] = 1;
 
-  if (dimflag[0] || dimflag[1] || dimflag[2]) box_change_size = 1;
-  if (dimflag[3] || dimflag[4] || dimflag[5]) box_change_shape = 1;
+  if (dimflag[0]) box_change |= BOX_CHANGE_X;
+  if (dimflag[1]) box_change |= BOX_CHANGE_Y;
+  if (dimflag[2]) box_change |= BOX_CHANGE_Z;
+  if (dimflag[3]) box_change |= BOX_CHANGE_YZ;
+  if (dimflag[4]) box_change |= BOX_CHANGE_XZ;
+  if (dimflag[5]) box_change |= BOX_CHANGE_XY;
 
   // no tensile deformation on shrink-wrapped dims
   // b/c shrink wrap will change box-length

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -476,8 +476,12 @@ FixNH::FixNH(LAMMPS *lmp, int narg, char **arg) :
     if (p_flag[i]) pstat_flag = 1;
 
   if (pstat_flag) {
-    if (p_flag[0] || p_flag[1] || p_flag[2]) box_change_size = 1;
-    if (p_flag[3] || p_flag[4] || p_flag[5]) box_change_shape = 1;
+    if (p_flag[0]) box_change |= BOX_CHANGE_X;
+    if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+    if (p_flag[2]) box_change |= BOX_CHANGE_Z;
+    if (p_flag[3]) box_change |= BOX_CHANGE_YZ;
+    if (p_flag[4]) box_change |= BOX_CHANGE_XZ;
+    if (p_flag[5]) box_change |= BOX_CHANGE_XY;
     no_change_box = 1;
     if (allremap == 0) restart_pbc = 1;
 

--- a/src/fix_press_berendsen.cpp
+++ b/src/fix_press_berendsen.cpp
@@ -40,8 +40,6 @@ FixPressBerendsen::FixPressBerendsen(LAMMPS *lmp, int narg, char **arg) :
 {
   if (narg < 5) error->all(FLERR,"Illegal fix press/berendsen command");
 
-  box_change_size = 1;
-
   // Berendsen barostat applied every step
 
   nevery = 1;
@@ -203,6 +201,10 @@ FixPressBerendsen::FixPressBerendsen(LAMMPS *lmp, int narg, char **arg) :
       (p_flag[1] && p_period[1] <= 0.0) ||
       (p_flag[2] && p_period[2] <= 0.0))
     error->all(FLERR,"Fix press/berendsen damping parameters must be > 0.0");
+
+  if (p_flag[0]) box_change |= BOX_CHANGE_X;
+  if (p_flag[1]) box_change |= BOX_CHANGE_Y;
+  if (p_flag[2]) box_change |= BOX_CHANGE_Z;
 
   // pstyle = ISO if XYZ coupling or XY coupling in 2d -> 1 dof
   // else pstyle = ANISO -> 3 dof


### PR DESCRIPTION

**Summary**

The changes in this PR allow a more specific tracking of whether multiple fixes are
modifying the same box parameter and error out in that case instead of letting LAMMPS continue and produce bogus simulation results.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Compatibility on the command line is preserved, but (external) source code needs to be adapted, if it was using any of the removed class member variables of the fix class.

**Implementation Notes**

By using a (single) bitmask instead multiple per-category variables, we can now check more specifically which box parameters are manipulated by a fix. During Domain::init() this information is then used to determine if the box is changed per category (like before), but also a new check is added to ensure that no two fixes are modifying the same box parameter. In that case the code will error out.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

