### PR TITLE
Collected small bug fixes and updates

### DIFF
--- a/doc/lammps.1
+++ b/doc/lammps.1
@@ -11,12 +11,17 @@ or
 
 mpirun \-np 2
 .B lmp
-<input file> [OPTIONS] ...
+\-in <input file> [OPTIONS] ...
 
 or
 
 .B lmp
 \-r2data file.restart file.data
+
+or
+
+.B lmp
+\-h
 
 .SH DESCRIPTION
 .B LAMMPS
@@ -249,7 +254,7 @@ the chapter on errors in the
 manual gives some additional information about error messages, if possible.
 
 .SH COPYRIGHT
-© 2003--2019 Sandia Corporation
+© 2003--2020 Sandia Corporation
 
 This package is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 2 as

--- a/doc/src/fix_ave_correlate_long.rst
+++ b/doc/src/fix_ave_correlate_long.rst
@@ -70,11 +70,12 @@ Examples
 Description
 """""""""""
 
-This fix is similar in spirit and syntax to the :doc:`fix ave/correlate <fix_ave_correlate>`.  However, this fix allows the
-efficient calculation of time correlation functions on the fly over
-extremely long time windows without too much CPU overhead, using a
-multiple-tau method :ref:`(Ramirez) <Ramirez>` that decreases the resolution
-of the stored correlation function with time.
+This fix is similar in spirit and syntax to the :doc:`fix ave/correlate <fix_ave_correlate>`.
+However, this fix allows the efficient calculation of time correlation
+functions on-the-fly over extremely long time windows with little
+additional CPU overhead, using a multiple-tau method
+:ref:`(Ramirez) <Ramirez>` that decreases the resolution of the stored
+correlation function with time.  It is not a full drop-in replacement.
 
 The group specified with this command is ignored.  However, note that
 specified values may represent calculations performed by computes and
@@ -115,11 +116,13 @@ For the meaning of the additional optional keywords, see the :doc:`fix ave/corre
 
 **Restart, fix\_modify, output, run start/stop, minimize info:**
 
-Since this fix in intended for the calculation of time correlation
-functions over very long MD simulations, the information about this
-fix is written automatically to binary restart files, so that the time
-correlation calculation can continue in subsequent simulations. None
-of the fix\_modify options are relevant to this fix.
+Contrary to doc:`fix ave/correlate <fix_ave_correlate>`_ this fix
+does **not** provide access to its internal data to various output
+options. Since this fix in intended for the calculation of time
+correlation functions over very long MD simulations, the information
+about this fix is written automatically to binary restart files, so
+that the time correlation calculation can continue in subsequent
+simulations. None of the fix\_modify options are relevant to this fix.
 
 No parameter of this fix can be used with the start/stop keywords of
 the run command. This fix is not invoked during energy minimization.

--- a/src/GPU/pair_born_coul_long_gpu.cpp
+++ b/src/GPU/pair_born_coul_long_gpu.cpp
@@ -177,6 +177,10 @@ void PairBornCoulLongGPU::init_style()
     error->all(FLERR,"Pair style requires a KSpace style");
   g_ewald = force->kspace->g_ewald;
 
+  // setup force tables
+
+  if (ncoultablebits) init_tables(cut_coul,cut_respa);
+
   int maxspecial=0;
   if (atom->molecular)
     maxspecial=atom->maxspecial;

--- a/src/GPU/pair_buck_coul_long_gpu.cpp
+++ b/src/GPU/pair_buck_coul_long_gpu.cpp
@@ -173,6 +173,10 @@ void PairBuckCoulLongGPU::init_style()
     error->all(FLERR,"Pair style requires a KSpace style");
   g_ewald = force->kspace->g_ewald;
 
+  // setup force tables
+
+  if (ncoultablebits) init_tables(cut_coul,cut_respa);
+
   int maxspecial=0;
   if (atom->molecular)
     maxspecial=atom->maxspecial;

--- a/src/GPU/pair_lj_class2_coul_long_gpu.cpp
+++ b/src/GPU/pair_lj_class2_coul_long_gpu.cpp
@@ -170,6 +170,10 @@ void PairLJClass2CoulLongGPU::init_style()
     error->all(FLERR,"Pair style requires a KSpace style");
   g_ewald = force->kspace->g_ewald;
 
+  // setup force tables
+
+  if (ncoultablebits) init_tables(cut_coul,cut_respa);
+
   int maxspecial=0;
   if (atom->molecular)
     maxspecial=atom->maxspecial;

--- a/src/KSPACE/pair_born_coul_long.cpp
+++ b/src/KSPACE/pair_born_coul_long.cpp
@@ -47,6 +47,7 @@ PairBornCoulLong::PairBornCoulLong(LAMMPS *lmp) : Pair(lmp)
   ewaldflag = pppmflag = 1;
   ftable = NULL;
   writedata = 1;
+  cut_respa = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_buck_long_coul_long.cpp
+++ b/src/KSPACE/pair_buck_long_coul_long.cpp
@@ -52,6 +52,7 @@ PairBuckLongCoulLong::PairBuckLongCoulLong(LAMMPS *lmp) : Pair(lmp)
   writedata = 1;
   ftable = NULL;
   fdisptable = NULL;
+  cut_respa = NULL;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/pair_coul_long.cpp
+++ b/src/KSPACE/pair_coul_long.cpp
@@ -46,6 +46,7 @@ PairCoulLong::PairCoulLong(LAMMPS *lmp) : Pair(lmp)
   ewaldflag = pppmflag = 1;
   ftable = NULL;
   qdist = 0.0;
+  cut_respa = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_lj_charmm_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmm_coul_long.cpp
@@ -51,6 +51,7 @@ PairLJCharmmCoulLong::PairLJCharmmCoulLong(LAMMPS *lmp) : Pair(lmp)
   implicit = 0;
   mix_flag = ARITHMETIC;
   writedata = 1;
+  cut_respa = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
@@ -55,6 +55,7 @@ PairLJCharmmfswCoulLong::PairLJCharmmfswCoulLong(LAMMPS *lmp) : Pair(lmp)
   implicit = 0;
   mix_flag = ARITHMETIC;
   writedata = 1;
+  cut_respa = NULL;
 
   // short-range/long-range flag accessed by DihedralCharmmfsw
 

--- a/src/KSPACE/pair_lj_cut_coul_long.cpp
+++ b/src/KSPACE/pair_lj_cut_coul_long.cpp
@@ -53,6 +53,7 @@ PairLJCutCoulLong::PairLJCutCoulLong(LAMMPS *lmp) : Pair(lmp)
   writedata = 1;
   ftable = NULL;
   qdist = 0.0;
+  cut_respa = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_lj_long_coul_long.cpp
+++ b/src/KSPACE/pair_lj_long_coul_long.cpp
@@ -55,6 +55,7 @@ PairLJLongCoulLong::PairLJLongCoulLong(LAMMPS *lmp) : Pair(lmp)
   ftable = NULL;
   fdisptable = NULL;
   qdist = 0.0;
+  cut_respa = NULL;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -527,6 +527,11 @@ void Modify::thermo_energy_atom(int nlocal, double *energy)
 void Modify::post_run()
 {
   for (int i = 0; i < nfix; i++) fix[i]->post_run();
+
+  // must reset this to its default value, since computes may be added
+  // or removed between runs and with this change we will redirect any
+  // calls to addstep_compute() to addstep_compute_all() instead.
+  n_timeflag = -1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -50,6 +50,7 @@ Modify::Modify(LAMMPS *lmp) : Pointers(lmp)
   n_pre_force_respa = n_post_force_respa = n_final_integrate_respa = 0;
   n_min_pre_exchange = n_min_pre_force = n_min_pre_reverse = 0;
   n_min_post_force = n_min_energy = 0;
+  n_timeflag = -1;
 
   fix = NULL;
   fmask = NULL;
@@ -1283,6 +1284,14 @@ void Modify::clearstep_compute()
 
 void Modify::addstep_compute(bigint newstep)
 {
+  // If we are called before the first run init, n_timeflag is not yet
+  // initialized, thus defer to addstep_compute_all() instead
+
+  if (n_timeflag < 0) {
+     addstep_compute_all(newstep);
+     return;
+  }
+
   for (int icompute = 0; icompute < n_timeflag; icompute++)
     if (compute[list_timeflag[icompute]]->invoked_flag)
       compute[list_timeflag[icompute]]->addstep(newstep);

--- a/src/pair_coul_streitz.h
+++ b/src/pair_coul_streitz.h
@@ -55,7 +55,6 @@ class PairCoulStreitz : public Pair {
   // Kspace parameters
   int kspacetype;
   double cut_coul, cut_coulsq;
-  double *cut_respa;
   double **scale;
 
   // Wolf

--- a/src/pair_lj96_cut.cpp
+++ b/src/pair_lj96_cut.cpp
@@ -41,6 +41,7 @@ PairLJ96Cut::PairLJ96Cut(LAMMPS *lmp) : Pair(lmp)
 {
   respa_enable = 1;
   writedata = 1;
+  cut_respa = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_mie_cut.cpp
+++ b/src/pair_mie_cut.cpp
@@ -40,6 +40,7 @@ using namespace MathConst;
 PairMIECut::PairMIECut(LAMMPS *lmp) : Pair(lmp)
 {
   respa_enable = 1;
+  cut_respa = NULL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -58,13 +59,13 @@ int ReaderNative::read_time(bigint &ntimestep)
 
   // skip over unit and time information, if present.
 
-  if (strstr(line,"ITEM: UNITS") == line)
+  if (utils::strmatch(line,"^\\s*ITEM: UNITS\\s*$"))
     read_lines(2);
 
-  if (strstr(line,"ITEM: TIME") == line)
+  if (utils::strmatch(line,"^\\s*ITEM: TIME\\s*$"))
     read_lines(2);
 
-  if (strstr(line,"ITEM: TIMESTEP") != line)
+  if (!utils::strmatch(line,"^\\s*ITEM: TIMESTEP\\s*$"))
     error->one(FLERR,"Dump file is incorrectly formatted");
 
   read_lines(1);

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -1084,13 +1084,18 @@ void Set::setrandom(int keyword)
     ranmars->select_subset(nsubset,count,flag,work);
 
     // change types of selected atoms
+    // flag vecftor from select_subset() is only for eligible atoms
 
     count = 0;
-    for (i = 0; i < nlocal; i++)
-      if (select[i] && flag[i]) {
+    int eligible = 0;
+    for (i = 0; i < nlocal; i++) {
+      if (!select[i]) continue;
+      if (flag[eligible]) {
         atom->type[i] = newtype;
         count++;
       }
+      eligible++;
+    }
 
     // clean up
 

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -1084,7 +1084,7 @@ void Set::setrandom(int keyword)
     ranmars->select_subset(nsubset,count,flag,work);
 
     // change types of selected atoms
-    // flag vecftor from select_subset() is only for eligible atoms
+    // flag vector from select_subset() is only for eligible atoms
 
     count = 0;
     int eligible = 0;

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -16,15 +16,16 @@
 
 namespace LAMMPS_NS {
 
-enum Suffix {
-  NONE   = 0,
-  OPT    = 1<<0,
-  GPU    = 1<<1,
-  OMP    = 1<<2,
-  INTEL  = 1<<3,
-  KOKKOS = 1<<4
-};
-
+namespace Suffix {
+  enum {
+    NONE   = 0,
+    OPT    = 1<<0,
+    GPU    = 1<<1,
+    OMP    = 1<<2,
+    INTEL  = 1<<3,
+    KOKKOS = 1<<4
+  };
+}
 }
 
 #endif


### PR DESCRIPTION
**Summary**

This pull request collects small updates and bugfixes for the next release

**Author(s)**

Axel Kohlmeyer (Temple U), Steve Plimpton (SNL), and Michał Kański (Jagiellonian University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues

**Implementation Notes**

The following individual changes are included:
- a fix for 'set type/ratio' that was assigning incorrect ratios in case it was applied to a subset of atoms
- have `Modify::addstep_compute()` defer to `Modify::addstep_compute_all()` in case it is called before `Modify::n_timeflag` is properly set up
- skip over `TIME:` items when reading native dump files
- add clarification to `fix ave/correlate/long` docs about lack of access to internal data
- need to initialize coulomb tables in GPU pair styles so that using pair->single() will not segfault
- make sure cut_respa is initialized to NULL in the constructor for more pair styles to avoid uninitialized reads and thus false positives with valgrind

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
