### PR TITLE
Fix bug in checking PLUMED version

### DIFF
--- a/src/USER-PLUMED/fix_plumed.cpp
+++ b/src/USER-PLUMED/fix_plumed.cpp
@@ -78,7 +78,7 @@ FixPlumed::FixPlumed(LAMMPS *lmp, int narg, char **arg) :
 
   int api_version;
   p->cmd("getApiVersion",&api_version);
-  if (api_version > 6)
+  if (api_version < 6)
     error->all(FLERR,"Incompatible API version for PLUMED in fix plumed");
 
   // If the -partition option is activated then enable


### PR DESCRIPTION

**Summary**

LAMMPS incorrectly enforces a PLUMED version smaller or equal to 2.5. Since the PLUMED API is meant to be extended in a backward compatible manner, it should rather enforce a PLUMED version greater or equal to 2.5 (i.e. Api version >6).

**Related Issues**

Reported [here](https://github.com/plumed/plumed2/issues/555).

**Author(s)**

Giovanni Bussi. It's a minimal change suggested by Omar Valsson.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

_Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why_

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


