### PR TITLE
Update USER-PLUMED to include support for version 2.6.0. Fix bug in API check

### DIFF
--- a/cmake/Modules/Packages/USER-PLUMED.cmake
+++ b/cmake/Modules/Packages/USER-PLUMED.cmake
@@ -49,8 +49,8 @@ if(PKG_USER-PLUMED)
     message(STATUS "PLUMED download requested - we will build our own")
     include(ExternalProject)
     ExternalProject_Add(plumed_build
-      URL https://github.com/plumed/plumed2/releases/download/v2.5.3/plumed-src-2.5.3.tgz
-      URL_MD5 de30d6e7c2dcc0973298e24a6da24286
+      URL https://github.com/plumed/plumed2/releases/download/v2.6.0/plumed-src-2.6.0.tgz
+      URL_MD5 204d2edae58d9b10ba3ad460cad64191
       BUILD_IN_SOURCE 1
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
                                                ${CONFIGURE_REQUEST_PIC}

--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -880,6 +880,9 @@ USER-PLUMED package
 Before building LAMMPS with this package, you must first build PLUMED.
 PLUMED can be built as part of the LAMMPS build or installed separately
 from LAMMPS using the generic `plumed installation instructions <plumedinstall_>`_.
+The USER-PLUMED package has been tested to work with Plumed versions
+2.4.x, 2.5.x, and 2.6.x and will error out, when trying to run calculations
+with a different version of the Plumed kernel.
 
 
 PLUMED can be linked into MD codes in three different modes: static,

--- a/examples/USER/plumed/log.4Feb20.peptide-plumed.g++.1
+++ b/examples/USER/plumed/log.4Feb20.peptide-plumed.g++.1
@@ -1,5 +1,4 @@
-LAMMPS (27 Nov 2018)
-  using 1 OpenMP thread(s) per MPI task
+LAMMPS (4 Feb 2020)
 # Solvated 5-mer peptide
 
 units		real
@@ -39,6 +38,8 @@ read_data	data.peptide
   7 = max # of 1-3 neighbors
   14 = max # of 1-4 neighbors
   18 = max # of special neighbors
+  special bonds CPU = 0.000809431 secs
+  read_data CPU = 0.0102327 secs
 
 neighbor	2.0 bin
 neigh_modify	delay 5
@@ -66,6 +67,7 @@ fix		4 all shake 0.0001 10 100 b 4 6 8 10 12 14 18 a 31
   6 = # of size 3 clusters
   3 = # of size 4 clusters
   640 = # of frozen angles
+  find clusters CPU = 0.000631809 secs
 
 #dump		1 colvar custom 1 dump.colvar.lammpstrj id xu yu zu fx fy fz
 #dump_modify 1 sort id
@@ -77,13 +79,13 @@ variable        pe equal pe
 
 run		101
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:321)
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
   G vector (1/distance) = 0.268725
   grid = 15 15 15
   stencil order = 5
   estimated absolute RMS force accuracy = 0.0228209
   estimated relative force accuracy = 6.87243e-05
-  using double precision FFTs
+  using double precision FFTW3
   3d grid and FFT values/proc = 10648 3375
 Neighbor list info ...
   update every 1 steps, delay 5 steps, check yes
@@ -106,7 +108,7 @@ SHAKE stats (type/ave/delta) on step 0
   14 0.96 0
   18 0.957206 4.37979e-05
   31 104.519 0.00396029
-Per MPI rank memory allocation (min/avg/max) = 18.74 | 18.74 | 18.74 Mbytes
+Per MPI rank memory allocation (min/avg/max) = 19.07 | 19.07 | 19.07 Mbytes
 Step Temp TotEng PotEng KinEng E_pair E_bond f_2 
        0    282.10052    -5237.458   -6372.3766    1134.9186    -6442.768    16.557152            0 
       10     276.9783   -5234.3057   -6348.6171    1114.3114   -6421.6171    17.024361   0.47785504 
@@ -129,22 +131,22 @@ SHAKE stats (type/ave/delta) on step 100
   31 104.52 0.000760401
      100    270.40648   -5234.9604   -6322.8327    1087.8723     -6417.73    19.666404 0.0094784372 
      101    270.99811   -5235.8295    -6326.082    1090.2525   -6418.8974    17.285816  0.086681332 
-Loop time of 2.73445 on 1 procs for 101 steps with 2004 atoms
+Loop time of 2.69839 on 1 procs for 101 steps with 2004 atoms
 
-Performance: 6.383 ns/day, 3.760 hours/ns, 36.936 timesteps/s
-99.7% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 6.468 ns/day, 3.711 hours/ns, 37.430 timesteps/s
+99.7% CPU use with 1 MPI tasks x no OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 2.2617     | 2.2617     | 2.2617     |   0.0 | 82.71
-Bond    | 0.0044148  | 0.0044148  | 0.0044148  |   0.0 |  0.16
-Kspace  | 0.17883    | 0.17883    | 0.17883    |   0.0 |  6.54
-Neigh   | 0.23945    | 0.23945    | 0.23945    |   0.0 |  8.76
-Comm    | 0.011672   | 0.011672   | 0.011672   |   0.0 |  0.43
-Output  | 0.00028348 | 0.00028348 | 0.00028348 |   0.0 |  0.01
-Modify  | 0.0365     | 0.0365     | 0.0365     |   0.0 |  1.33
-Other   |            | 0.001611   |            |       |  0.06
+Pair    | 2.2853     | 2.2853     | 2.2853     |   0.0 | 84.69
+Bond    | 0.0065637  | 0.0065637  | 0.0065637  |   0.0 |  0.24
+Kspace  | 0.14949    | 0.14949    | 0.14949    |   0.0 |  5.54
+Neigh   | 0.1938     | 0.1938     | 0.1938     |   0.0 |  7.18
+Comm    | 0.0096588  | 0.0096588  | 0.0096588  |   0.0 |  0.36
+Output  | 0.00039172 | 0.00039172 | 0.00039172 |   0.0 |  0.01
+Modify  | 0.050643   | 0.050643   | 0.050643   |   0.0 |  1.88
+Other   |            | 0.00258    |            |       |  0.10
 
 Nlocal:    2004 ave 2004 max 2004 min
 Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/USER/plumed/log.4Feb20.peptide-plumed.g++.4
+++ b/examples/USER/plumed/log.4Feb20.peptide-plumed.g++.4
@@ -1,5 +1,4 @@
-LAMMPS (27 Nov 2018)
-  using 1 OpenMP thread(s) per MPI task
+LAMMPS (4 Feb 2020)
 # Solvated 5-mer peptide
 
 units		real
@@ -39,6 +38,8 @@ read_data	data.peptide
   7 = max # of 1-3 neighbors
   14 = max # of 1-4 neighbors
   18 = max # of special neighbors
+  special bonds CPU = 0.00095129 secs
+  read_data CPU = 0.0199838 secs
 
 neighbor	2.0 bin
 neigh_modify	delay 5
@@ -66,6 +67,7 @@ fix		4 all shake 0.0001 10 100 b 4 6 8 10 12 14 18 a 31
   6 = # of size 3 clusters
   3 = # of size 4 clusters
   640 = # of frozen angles
+  find clusters CPU = 0.000829935 secs
 
 #dump		1 colvar custom 1 dump.colvar.lammpstrj id xu yu zu fx fy fz
 #dump_modify 1 sort id
@@ -77,13 +79,13 @@ variable        pe equal pe
 
 run		101
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:321)
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
   G vector (1/distance) = 0.268725
   grid = 15 15 15
   stencil order = 5
   estimated absolute RMS force accuracy = 0.0228209
   estimated relative force accuracy = 6.87243e-05
-  using double precision FFTs
+  using double precision FFTW3
   3d grid and FFT values/proc = 4312 960
 Neighbor list info ...
   update every 1 steps, delay 5 steps, check yes
@@ -106,7 +108,7 @@ SHAKE stats (type/ave/delta) on step 0
   14 0.96 0
   18 0.957206 4.37979e-05
   31 104.519 0.00396029
-Per MPI rank memory allocation (min/avg/max) = 15.66 | 15.87 | 16.06 Mbytes
+Per MPI rank memory allocation (min/avg/max) = 16.02 | 16.23 | 16.42 Mbytes
 Step Temp TotEng PotEng KinEng E_pair E_bond f_2 
        0    282.10052    -5237.458   -6372.3766    1134.9186    -6442.768    16.557152            0 
       10     276.9783   -5234.3057   -6348.6171    1114.3114   -6421.6171    17.024361   0.47785504 
@@ -129,22 +131,22 @@ SHAKE stats (type/ave/delta) on step 100
   31 104.52 0.000760401
      100    270.40648   -5234.9604   -6322.8327    1087.8723     -6417.73    19.666404 0.0094784372 
      101    270.99811   -5235.8295    -6326.082    1090.2525   -6418.8974    17.285816  0.086681332 
-Loop time of 0.812799 on 4 procs for 101 steps with 2004 atoms
+Loop time of 0.873215 on 4 procs for 101 steps with 2004 atoms
 
-Performance: 21.472 ns/day, 1.118 hours/ns, 124.262 timesteps/s
-97.5% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 19.987 ns/day, 1.201 hours/ns, 115.664 timesteps/s
+92.5% CPU use with 4 MPI tasks x no OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.57957    | 0.59988    | 0.62504    |   2.6 | 73.80
-Bond    | 0.00080013 | 0.0017412  | 0.0028315  |   2.1 |  0.21
-Kspace  | 0.075724   | 0.10008    | 0.12023    |   6.4 | 12.31
-Neigh   | 0.067733   | 0.067947   | 0.068168   |   0.1 |  8.36
-Comm    | 0.01375    | 0.014175   | 0.014681   |   0.3 |  1.74
-Output  | 0.00025511 | 0.00051183 | 0.001277   |   0.0 |  0.06
-Modify  | 0.026406   | 0.026436   | 0.026462   |   0.0 |  3.25
-Other   |            | 0.002027   |            |       |  0.25
+Pair    | 0.58191    | 0.61681    | 0.66371    |   3.8 | 70.64
+Bond    | 0.00099587 | 0.0023546  | 0.0041356  |   2.8 |  0.27
+Kspace  | 0.096162   | 0.14486    | 0.18119    |   8.1 | 16.59
+Neigh   | 0.059843   | 0.059864   | 0.059876   |   0.0 |  6.86
+Comm    | 0.013623   | 0.01368    | 0.013723   |   0.0 |  1.57
+Output  | 0.00031137 | 0.0010193  | 0.0024326  |   2.6 |  0.12
+Modify  | 0.031552   | 0.031697   | 0.032087   |   0.1 |  3.63
+Other   |            | 0.002938   |            |       |  0.34
 
 Nlocal:    501 ave 512 max 492 min
 Histogram: 1 0 0 1 0 1 0 0 0 1

--- a/examples/USER/plumed/reference/p.log
+++ b/examples/USER/plumed/reference/p.log
@@ -1,12 +1,12 @@
 PLUMED: PLUMED is starting
-PLUMED: Version: 2.4.2 (git: Unknown) compiled on Jul 11 2018 at 19:09:03
-PLUMED: Please cite this paper when using PLUMED [1]
+PLUMED: Version: 2.6.0 (git: Unknown) compiled on Feb 13 2020 at 15:49:44
+PLUMED: Please cite these papers when using PLUMED [1][2]
 PLUMED: For further information see the PLUMED web page at http://www.plumed.org
-PLUMED: Root: /Users/gareth/MD_code/lammps-permanent/lammps/lib/plumed/plumed2-2.4.2/
-PLUMED: For installed feature, see /Users/gareth/MD_code/lammps-permanent/lammps/lib/plumed/plumed2-2.4.2//src/config/config.txt
+PLUMED: Root: /home/akohlmey/compile/lammps/build-gcc/plumed_build-prefix/lib/plumed
+PLUMED: For installed feature, see /home/akohlmey/compile/lammps/build-gcc/plumed_build-prefix/lib/plumed/src/config/config.txt
 PLUMED: Molecular dynamics engine: LAMMPS
 PLUMED: Precision of reals: 8
-PLUMED: Running over 1 node
+PLUMED: Running over 4 nodes
 PLUMED: Number of threads: 1
 PLUMED: Cache line size: 512
 PLUMED: Number of atoms: 2004
@@ -14,13 +14,13 @@ PLUMED: File suffix:
 PLUMED: FILE: plumed.dat
 PLUMED: Action UNITS
 PLUMED:   with label @0
-PLUMED:   length: A
-PLUMED:   energy: kcal/mol
+PLUMED:   length: A = 0.1 nm
+PLUMED:   energy: kcal/mol = 4.184 kj/mol
 PLUMED:   time: ps
 PLUMED:   charge: e
 PLUMED:   mass: amu
 PLUMED:   using physical units
-PLUMED:   inside PLUMED, Boltzmann constant is 0.001987
+PLUMED:   inside PLUMED, Boltzmann constant is 0.0019872
 PLUMED: Action DISTANCE
 PLUMED:   with label dd
 PLUMED:   between atoms 45 48
@@ -44,14 +44,15 @@ PLUMED: Timestep: 0.002000
 PLUMED: KbT has not been set by the MD engine
 PLUMED: It should be set by hand where needed
 PLUMED: Relevant bibliography:
-PLUMED:   [1] Tribello, Bonomi, Branduardi, Camilloni, and Bussi, Comput. Phys. Commun. 185, 604 (2014)
+PLUMED:   [1] The PLUMED consortium, Nat. Methods 16, 670 (2019)
+PLUMED:   [2] Tribello, Bonomi, Branduardi, Camilloni, and Bussi, Comput. Phys. Commun. 185, 604 (2014)
 PLUMED: Please read and cite where appropriate!
 PLUMED: Finished setup
 PLUMED:                                               Cycles        Total      Average      Minumum      Maximum
-PLUMED:                                                    1     0.020354     0.020354     0.020354     0.020354
-PLUMED: 1 Prepare dependencies                           102     0.000256     0.000003     0.000001     0.000006
-PLUMED: 2 Sharing data                                   102     0.010002     0.000098     0.000078     0.000546
-PLUMED: 3 Waiting for data                               102     0.001398     0.000014     0.000011     0.000072
-PLUMED: 4 Calculating (forward loop)                     102     0.001797     0.000018     0.000013     0.000058
-PLUMED: 5 Applying (backward loop)                       102     0.002666     0.000026     0.000022     0.000062
-PLUMED: 6 Update                                         102     0.001126     0.000011     0.000007     0.000055
+PLUMED:                                                    1     0.010018     0.010018     0.010018     0.010018
+PLUMED: 1 Prepare dependencies                           102     0.000241     0.000002     0.000001     0.000003
+PLUMED: 2 Sharing data                                   102     0.002132     0.000021     0.000006     0.000151
+PLUMED: 3 Waiting for data                               102     0.001640     0.000016     0.000008     0.000067
+PLUMED: 4 Calculating (forward loop)                     102     0.000825     0.000008     0.000005     0.000013
+PLUMED: 5 Applying (backward loop)                       102     0.000522     0.000005     0.000002     0.000015
+PLUMED: 6 Update                                         102     0.001755     0.000017     0.000011     0.000067

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -17,7 +17,7 @@ parser = ArgumentParser(prog='Install.py',
 
 # settings
 
-version = "2.5.3"
+version = "2.6.0"
 mode = "static"
 
 # help message
@@ -46,6 +46,8 @@ checksums = { \
         '2.5.1' : 'c2a7b519e32197a120cdf47e0f194f81', \
         '2.5.2' : 'bd2f18346c788eb54e1e52f4f6acf41a', \
         '2.5.3' : 'de30d6e7c2dcc0973298e24a6da24286', \
+        '2.5.4' : 'f31b7d16a4be2e30aa7d5c19c3d37853', \
+        '2.6.0' : '204d2edae58d9b10ba3ad460cad64191', \
         }
 
 # parse and process arguments

--- a/src/USER-PLUMED/fix_plumed.cpp
+++ b/src/USER-PLUMED/fix_plumed.cpp
@@ -78,8 +78,9 @@ FixPlumed::FixPlumed(LAMMPS *lmp, int narg, char **arg) :
 
   int api_version;
   p->cmd("getApiVersion",&api_version);
-  if (api_version > 6)
-    error->all(FLERR,"Incompatible API version for PLUMED in fix plumed");
+  if ((api_version < 5) || (api_version > 7))
+    error->all(FLERR,"Incompatible API version for PLUMED in fix plumed. "
+               "Only Plumed 2.4.x, 2.5.x, and 2.6.x are tested and supported.");
 
   // If the -partition option is activated then enable
   // inter-partition communication


### PR DESCRIPTION
**Summary**

This adds support for Plumed 2.6.0, describes in the documentation what versions of Plumed are tested and thus supported and fixes a bug in the API version check, that did not cover unsupported older versions of the API.

**Related Issues**

This supersedes and thus closes #1878 

**Author(s)**

Axel Kohlmeyer (Temple U) based on information provided in PR #1878 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
