### PR TITLE
Remove C++11 check for stable release

### DIFF
--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -28,13 +28,6 @@
 #ifndef LMP_LMPTYPE_H
 #define LMP_LMPTYPE_H
 
-// C++11 check
-#ifndef LAMMPS_CXX98
-#if __cplusplus <= 199711L
-  #error LAMMPS is planning to transition to C++11. To disable this error please use a C++11 compliant compiler, enable C++11 (or later) compliance, or define LAMMPS_CXX98 in your makefile
-#endif
-#endif
-
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif


### PR DESCRIPTION
The upcoming stable release will be the last version of LAMMPS compatible with pre-C++11 compilers.

In order to avoid needless complications for users, we remove the conditional check and will restore a proper unconditional check (and consistent c++11 standard enabling compiler flags) after the stable release. 