### PR TITLE
Updates to qmmm package

### DIFF
--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -1215,13 +1215,10 @@ USER-QMMM package
    for a QM/MM simulation.  You must also build Quantum ESPRESSO and
    create a new executable (pwqmmm.x) which links LAMMPS and Quantum
    ESPRESSO together.  These are steps 3 and 4 described in the
-   lib/qmmm/README file.  Unfortunately, the Quantum ESPRESSO developers
-   have been breaking the interface that the QM/MM code in LAMMPS is using,
-   so that currently (Summer 2018) using this feature requires either
-   correcting the library interface feature in recent Quantum ESPRESSO
-   releases, or using an outdated version of QE. The last version of
-   Quantum ESPRESSO known to work with this QM/MM interface was version
-   5.4.1 from 2016.
+   lib/qmmm/README file.  This requires a compatible Quantum espresso
+   and LAMMPS version.  The current interface and makefiles have
+   last been verified to work in February 2020 with Quantum Espresso
+   versions 6.3 to 6.5.
 
 **CMake build**\ :
 

--- a/lib/qmmm/Makefile.gfortran
+++ b/lib/qmmm/Makefile.gfortran
@@ -3,13 +3,13 @@
 # this file will be copied to Makefile.lammps
 EXTRAMAKE = Makefile.lammps.empty
 
-# top level directory of Quantum ESPRESSO 5.4.1 or later
+# top level directory of Quantum ESPRESSO 6.4 or later
 QETOPDIR=$(HOME)/compile/espresso
 
 # import compiler settings from Quantum ESPRESSO
-sinclude $(QETOPDIR)/make.sys
+sinclude $(QETOPDIR)/make.inc
 
-# FLAGS for c++ OpenMPI 1.8.8 or later when QE was compiled with GNU Fortran 4.x
+# FLAGS for c++ OpenMPI 3.x.x  when QE was compiled with GNU Fortran 6.x or 7.x
 MPICXX=mpicxx
 MPICXXFLAGS=-DOMPI_SKIP_MPICXX=1 -O2 -Wall -g -fPIC\
 	-I../../src -I$(QETOPDIR)/COUPLE/include
@@ -24,13 +24,21 @@ $(QETOPDIR)/Modules/libqemod.a
 # part 2: lo-level libraries for all of Q-E
 LIBOBJS = \
 $(QETOPDIR)/FFTXlib/libqefft.a \
+$(QETOPDIR)/dft-d3/libdftd3qe.a  \
+$(QETOPDIR)/KS_Solvers/PPCG/libppcg.a  \
+$(QETOPDIR)/KS_Solvers/CG/libcg.a  \
+$(QETOPDIR)/KS_Solvers/Davidson/libdavid.a  \
+$(QETOPDIR)/UtilXlib/libutil.a   \
 $(QETOPDIR)/LAXlib/libqela.a   \
 $(QETOPDIR)/clib/clib.a   \
 $(QETOPDIR)/iotk/src/libiotk.a
+# foxlibs
+
+LIBS += -L${QETOPDIR}/FoX/lib -lFoX_dom -lFoX_sax -lFoX_wxml -lFoX_common -lFoX_utils -lFoX_fsys -L${LAPACK_LIB} -L${BLAS_LIB} -llapack -lblas 
 
 # part 3: add-on libraries and main library for LAMMPS
 sinclude ../../src/Makefile.package
-LAMMPSCFG = openmpi-omp
+LAMMPSCFG = mpi
 LAMMPSLIB = ../../src/liblammps_$(LAMMPSCFG).a
 
 # part 4: local QM/MM library and progams

--- a/lib/qmmm/Makefile.gfortran
+++ b/lib/qmmm/Makefile.gfortran
@@ -3,13 +3,13 @@
 # this file will be copied to Makefile.lammps
 EXTRAMAKE = Makefile.lammps.empty
 
-# top level directory of Quantum ESPRESSO 6.4 or later
+# top level directory of Quantum ESPRESSO 5.4.1 or later
 QETOPDIR=$(HOME)/compile/espresso
 
 # import compiler settings from Quantum ESPRESSO
 sinclude $(QETOPDIR)/make.inc
 
-# FLAGS for c++ OpenMPI 3.x.x  when QE was compiled with GNU Fortran 6.x or 7.x
+# FLAGS for c++ OpenMPI 3.x.x or later when QE was compiled with GNU Fortran 6.x or 7.x
 MPICXX=mpicxx
 MPICXXFLAGS=-DOMPI_SKIP_MPICXX=1 -O2 -Wall -g -fPIC\
 	-I../../src -I$(QETOPDIR)/COUPLE/include

--- a/lib/qmmm/Makefile.ifort
+++ b/lib/qmmm/Makefile.ifort
@@ -3,7 +3,7 @@
 # this file will be copied to Makefile.lammps
 EXTRAMAKE = Makefile.lammps.empty
 
-# top level directory of Quantum ESPRESSO 6.4444 or later
+# top level directory of Quantum ESPRESSO 6.4 or later
 QETOPDIR=$(HOME)/compile/espresso
 
 # import compiler settings from Quantum ESPRESSO

--- a/lib/qmmm/Makefile.ifort
+++ b/lib/qmmm/Makefile.ifort
@@ -3,17 +3,20 @@
 # this file will be copied to Makefile.lammps
 EXTRAMAKE = Makefile.lammps.empty
 
-# top level directory of Quantum ESPRESSO 5.4.1 or later
+# top level directory of Quantum ESPRESSO 6.4444 or later
 QETOPDIR=$(HOME)/compile/espresso
 
 # import compiler settings from Quantum ESPRESSO
-sinclude $(QETOPDIR)/make.sys
+sinclude $(QETOPDIR)/make.inc
 
 # FLAGS for c++ with IntelMPI when QE was compiled with Intel Fortran
-MPICXX=icpc
-MPICXXFLAGS=-DOMPI_SKIP_MPICXX=1 -O2 -Wall -g -fPIC\
-        -I../../src -I$(QETOPDIR)/COUPLE/include -I${INTELMPI_HOME}/include64
-MPILIBS=-openmp  -L${INTELMPI_HOME}/lib64  -lz  -lifcore -L$(I_MPI_ROOT)/lib64 -lmpi -lmpiif
+
+MPICXX=mpiicpc
+MPICXXFLAGS=-DOMPI_SKIP_MPICXX=1 -DFC_ABORT_ARG -O2 -Wall -g -fPIC -I${INTEL_HOME}/include -I${INTELMPI_HOME}/include64 \
+        -I../../src -I$(QETOPDIR)/COUPLE/include   -I$(QETOPDIR)/LAXlib -I$(QETOPDIR)/UtilXlib -I$(QETOPDIR)/FoX/finclude -tbb
+
+MPILIBS=-qopenmp  -L${INTELMPI_HOME}/lib64  -lz  -lifcore -lifport -L$(I_MPI_ROOT)/lib64 -lmpi -lmpifort
+
 
 # location of required libraries
 # part 1: hi-level libraries for building pw.x
@@ -24,13 +27,20 @@ $(QETOPDIR)/Modules/libqemod.a
 # part 2: lo-level libraries for all of Q-E
 LIBOBJS = \
 $(QETOPDIR)/FFTXlib/libqefft.a \
+$(QETOPDIR)/dft-d3/libdftd3qe.a  \
+$(QETOPDIR)/KS_Solvers/PPCG/libppcg.a  \
+$(QETOPDIR)/KS_Solvers/CG/libcg.a  \
+$(QETOPDIR)/KS_Solvers/Davidson/libdavid.a  \
+$(QETOPDIR)/UtilXlib/libutil.a   \
 $(QETOPDIR)/LAXlib/libqela.a   \
 $(QETOPDIR)/clib/clib.a   \
 $(QETOPDIR)/iotk/src/libiotk.a
+# foxlibs
 
+LIBS += -L${QETOPDIR}/FoX/lib -lFoX_dom -lFoX_sax -lFoX_wxml -lFoX_common -lFoX_utils -lFoX_fsys  -mkl  -ltbbmalloc
 # part 3: add-on libraries and main library for LAMMPS
 sinclude ../../src/Makefile.package
-LAMMPSCFG = galileo-omp
+LAMMPSCFG =intel_cpu
 LAMMPSLIB = ../../src/liblammps_$(LAMMPSCFG).a
 
 # part 4: local QM/MM library and progams

--- a/lib/qmmm/README
+++ b/lib/qmmm/README
@@ -32,9 +32,7 @@ and 4 manually, as outlined below.
 WARNING: This is experimental code under developement and is provided
 at this early stage to encourage others to write interfaces to other
 QM codes. Please test *very* carefully before using this software for
-production calculations. At the time of the last update of this README
-(July 2016) you have to download a QE snapshot (revision 12611) from
-the QE subversion repository.
+production calculations. 
 
 At this point, both mechanical and multipole based electrostatic
 coupling have been successfully tested on a cluster of water

--- a/lib/qmmm/README
+++ b/lib/qmmm/README
@@ -70,12 +70,7 @@ to confirm that the classical part of the code is set up correctly.
 
 Step 3)
 Build a standalone pw.x executable in the Quantum ESPRESSO directory
-and also make the "couple" target. At the time of this writing 
-(July 2016) you have to download a QE snapshot (revision 12611)
-from the SVN repository, since no official release with the
-completed QM/MM support code has been made available yet. The current
-plan is to have a usable QM/MM interface released with the next
-Quantum ESPRESSO release version 6.0. Building the standalone pw.x
+and also make the "couple" target. Building the standalone pw.x
 binary is also needed to confirm that corresponding QM input is
 working correctly and to run test calculations on QM atoms only.
 

--- a/lib/qmmm/README
+++ b/lib/qmmm/README
@@ -4,7 +4,7 @@ Axel Kohlmeyer, akohlmey@gmail.com
 Temple University, Philadelphia and ICTP, Trieste
 
 with contributions by
-Carlo Cavazzoni & Mariella Ippolito
+Mariella Ippolito & Carlo Cavazzoni
 Cineca, Italy
 
 This library provides  the basic glue code to combine LAMMPS with the


### PR DESCRIPTION
**Summary**
Within the package qmmm, Mekefile.ifort and Makefile.gfortran has been updated linking the libraries necessary for qe 6.3 or later, in this way the interface between lammps and qe works properly. Some modifications have been necessary also in qe to make still working the interface between lammps and qe.
 
**Author(s)**

Mariella Ippolito
CINECA SuperComputing Applications and Innovation Department - SCAI 
via dei Tizii 6, 00185 Roma - ITALY 
m.ippolito@cineca.it

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The changes in the pull request don' t break backward compatibility for inputs


**Implementation Notes**

Makefile.intel and Makefile.gfortran have been used successfully to build  pwqmmm.x with lammps/7aug2019 and qe/6.4. The old Makefiles included in the package qmmm work only with qe/6.2 or earlier. README file in the package qmmm has been updated too.


**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] A package specific README file has been included or updated


**Further Information, Files, and Links**

There is no additional information.



