### PR TITLE
delay change_box error check on per-atom restart data existing

### DIFF
--- a/doc/src/change_box.rst
+++ b/doc/src/change_box.rst
@@ -147,24 +147,40 @@ new owning processors.
 
 .. note::
 
-   The simulation box size/shape can be changed by arbitrarily
-   large amounts by this command.  This is not a problem, except that the
+   The simulation box size/shape can be changed by arbitrarily large
+   amounts by this command.  This is not a problem, except that the
    mapping of processors to the simulation box is not changed from its
    initial 3d configuration; see the :doc:`processors <processors>`
    command.  Thus, if the box size/shape changes dramatically, the
-   mapping of processors to the simulation box may not end up as optimal
-   as the initial mapping attempted to be.
+   mapping of processors to the simulation box may not end up as
+   optimal as the initial mapping attempted to be.  You may wish to
+   re-balance the atoms by using the :doc:`balance <balance>` command
+   if that is the case.
 
 .. note::
 
-   Because the keywords used in this command are applied one at a
-   time to the simulation box and the atoms in it, care must be taken
-   with triclinic cells to avoid exceeding the limits on skew after each
-   transformation in the sequence.  If skew is exceeded before the final
-   transformation this can be avoided by changing the order of the
-   sequence, or breaking the transformation into two or more smaller
-   transformations.  For more information on the allowed limits for box
-   skew see the discussion on triclinic boxes on :doc:`Howto triclinic <Howto_triclinic>` doc page.
+   You cannot use this command after reading a restart file (and
+   before a run is performed) if the restart file stored per-atom
+   information from a fix and any of the specified keywords change the
+   box size or shape or boundary conditions.  This is because atoms
+   may be moved to new processors and the restart info will not
+   migrate with them.  LAMMPS will generate an error if this could
+   happen.  Only the *ortho* and *triclinic* keywords do not trigger
+   this error.  One solution is to perform a "run 0" command before
+   using the change_box command.  This clears the per-atom restart
+   data, whether it has been re-assigned to a new fix or not.
+
+.. note::
+
+   Because the keywords used in this command are applied one at a time
+   to the simulation box and the atoms in it, care must be taken with
+   triclinic cells to avoid exceeding the limits on skew after each
+   transformation in the sequence.  If skew is exceeded before the
+   final transformation this can be avoided by changing the order of
+   the sequence, or breaking the transformation into two or more
+   smaller transformations.  For more information on the allowed
+   limits for box skew see the discussion on triclinic boxes on
+   :doc:`Howto triclinic <Howto_triclinic>` doc page.
 
 
 ----------

--- a/src/change_box.cpp
+++ b/src/change_box.cpp
@@ -46,9 +46,6 @@ void ChangeBox::command(int narg, char **arg)
   if (domain->box_exist == 0)
     error->all(FLERR,"Change_box command before simulation box is defined");
   if (narg < 2) error->all(FLERR,"Illegal change_box command");
-  if (modify->nfix_restart_peratom)
-    error->all(FLERR,"Cannot change_box after "
-               "reading restart file with per-atom info");
 
   if (comm->me == 0 && screen) fprintf(screen,"Changing box ...\n");
 
@@ -173,6 +170,21 @@ void ChangeBox::command(int narg, char **arg)
   }
 
   if (nops == 0) error->all(FLERR,"Illegal change_box command");
+
+  // move_atoms = 1 if need to move atoms to new procs after box changes
+  // anything other than ORTHO or TRICLINIC may cause atom movement
+
+  int move_atoms = 0;
+  for (int m = 0; m < nops; m++) {
+    if (ops[m].style != ORTHO || ops[m].style != TRICLINIC) move_atoms = 1;
+  }
+
+  // error if moving atoms and there is stored per-atom restart state
+  // disallowed b/c restart per-atom fix info will not move with atoms
+
+  if (move_atoms && modify->nfix_restart_peratom)
+    error->all(FLERR,"Change_box parameter not allowed after "
+               "reading restart file with per-atom info");
 
   // read options from end of input line
 
@@ -349,6 +361,10 @@ void ChangeBox::command(int narg, char **arg)
     domain->reset_box();
     if (domain->triclinic) domain->lamda2x(atom->nlocal);
   }
+
+  // done if don't need to move atoms
+
+  if (!move_atoms) return;
 
   // move atoms back inside simulation box and to new processors
   // use remap() instead of pbc()


### PR DESCRIPTION
**Summary**

Allow the change box ortho/triclinic command to be used even if restarting from a restart file that contained per-atom fix info.  Do this by delaying the error check until after all the keywords are scanned.

**Related Issues**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

It should simply not throw an error for cases that the error check was too stringent before.

**Implementation Notes**

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


