### PR TITLE
temper timeout synchronization fix

### DIFF
--- a/src/REPLICA/temper.cpp
+++ b/src/REPLICA/temper.cpp
@@ -219,13 +219,12 @@ void Temper::command(int narg, char **arg)
 
     timer->init_timeout();
     update->integrate->run(nevery);
-    
+
     // check for timeout across all procs
+
     int my_timeout=0;
     int any_timeout=0;
-    if (timer->is_timeout()){
-      my_timeout=1;
-    }
+    if (timer->is_timeout()) my_timeout=1;
     MPI_Allreduce(&my_timeout, &any_timeout, 1, MPI_INT, MPI_SUM, universe->uworld);
     if (any_timeout) break;
 

--- a/src/REPLICA/temper.cpp
+++ b/src/REPLICA/temper.cpp
@@ -226,7 +226,10 @@ void Temper::command(int narg, char **arg)
     int any_timeout=0;
     if (timer->is_timeout()) my_timeout=1;
     MPI_Allreduce(&my_timeout, &any_timeout, 1, MPI_INT, MPI_SUM, universe->uworld);
-    if (any_timeout) break;
+    if (any_timeout) {
+      timer->force_timeout();
+      break;
+    }
 
     // compute PE
     // notify compute it will be called at next swap

--- a/src/REPLICA/temper.cpp
+++ b/src/REPLICA/temper.cpp
@@ -219,7 +219,15 @@ void Temper::command(int narg, char **arg)
 
     timer->init_timeout();
     update->integrate->run(nevery);
-    if (timer->is_timeout()) break;
+    
+    // check for timeout across all procs
+    int my_timeout=0;
+    int any_timeout=0;
+    if (timer->is_timeout()){
+      my_timeout=1;
+    }
+    MPI_Allreduce(&my_timeout, &any_timeout, 1, MPI_INT, MPI_SUM, universe->uworld);
+    if (any_timeout) break;
 
     // compute PE
     // notify compute it will be called at next swap

--- a/src/USER-MISC/temper_grem.cpp
+++ b/src/USER-MISC/temper_grem.cpp
@@ -241,7 +241,14 @@ void TemperGrem::command(int narg, char **arg)
 
     timer->init_timeout();
     update->integrate->run(nevery);
-    if (timer->is_timeout()) break;
+
+    // check for timeout across all procs
+
+    int my_timeout=0;
+    int any_timeout=0;
+    if (timer->is_timeout()) my_timeout=1;
+    MPI_Allreduce(&my_timeout, &any_timeout, 1, MPI_INT, MPI_SUM, universe->uworld);
+    if (any_timeout) break;
 
     // compute PE
     // notify compute it will be called at next swap

--- a/src/USER-MISC/temper_grem.cpp
+++ b/src/USER-MISC/temper_grem.cpp
@@ -248,7 +248,10 @@ void TemperGrem::command(int narg, char **arg)
     int any_timeout=0;
     if (timer->is_timeout()) my_timeout=1;
     MPI_Allreduce(&my_timeout, &any_timeout, 1, MPI_INT, MPI_SUM, universe->uworld);
-    if (any_timeout) break;
+    if (any_timeout) {
+      timer->force_timeout();
+      break;
+    }
 
     // compute PE
     // notify compute it will be called at next swap

--- a/src/USER-MISC/temper_npt.cpp
+++ b/src/USER-MISC/temper_npt.cpp
@@ -220,7 +220,14 @@ void TemperNPT::command(int narg, char **arg)
 
     timer->init_timeout();
     update->integrate->run(nevery);
-    if (timer->is_timeout()) break;
+
+    // check for timeout across all procs
+
+    int my_timeout=0;
+    int any_timeout=0;
+    if (timer->is_timeout()) my_timeout=1;
+    MPI_Allreduce(&my_timeout, &any_timeout, 1, MPI_INT, MPI_SUM, universe->uworld);
+    if (any_timeout) break;
 
     // compute PE
     // notify compute it will be called at next swap

--- a/src/USER-MISC/temper_npt.cpp
+++ b/src/USER-MISC/temper_npt.cpp
@@ -227,7 +227,10 @@ void TemperNPT::command(int narg, char **arg)
     int any_timeout=0;
     if (timer->is_timeout()) my_timeout=1;
     MPI_Allreduce(&my_timeout, &any_timeout, 1, MPI_INT, MPI_SUM, universe->uworld);
-    if (any_timeout) break;
+    if (any_timeout) {
+      timer->force_timeout();
+      break;
+    }
 
     // compute PE
     // notify compute it will be called at next swap


### PR DESCRIPTION
**Summary**

Using the timer timeout command with the temper command does not always result in a clean program exit if the replicas run at different speeds. The slowest one can timeout after the faster ones have already passed the check which results in the program hanging.

I have added a MPI_Allreduce to check if any replica has hit timeout.

**Related Issues**

**Author(s)**
Stephen Farr, University of Cambridge, sef43@cam.ac.uk

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**


**Implementation Notes**


**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


