### PR TITLE
Apply compute group correctly for compute ptm/atom

### DIFF
--- a/doc/src/compute_ptm_atom.rst
+++ b/doc/src/compute_ptm_atom.rst
@@ -15,7 +15,7 @@ Syntax
 * ptm/atom = style name of this compute command
 * structures = structure types to search for
 * threshold = lattice distortion threshold (RMSD)
-* group2-ID determines which group are used for neighbor selection (optional, default "all")
+* group2-ID determines which groups are used for neighbor selection (optional, default "all")
 
 Examples
 """"""""

--- a/doc/src/compute_ptm_atom.rst
+++ b/doc/src/compute_ptm_atom.rst
@@ -15,7 +15,7 @@ Syntax
 * ptm/atom = style name of this compute command
 * structures = structure types to search for
 * threshold = lattice distortion threshold (RMSD)
-* group2-ID determines which groups are used for neighbor selection (optional, default "all")
+* group2-ID determines which group is used for neighbor selection (optional, default "all")
 
 Examples
 """"""""
@@ -83,7 +83,9 @@ The neighbor list needed to compute this quantity is constructed each
 time the calculation is performed (e.g. each time a snapshot of atoms
 is dumped).  Thus it can be inefficient to compute/dump this quantity
 too frequently or to have multiple compute/dump commands, each with a
-*ptm/atom* style.
+*ptm/atom* style. By default the compute processes **all** neighbors
+unless the optional *group2-ID* argument is given, then only members
+of that group are considered as neighbors.
 
 **Output info:**
 
@@ -107,6 +109,7 @@ The interatomic distance is computed from the scale factor in the RMSD equation.
 The (qw,qx,qy,qz) parameters represent the orientation of the local structure
 in quaternion form.  The reference coordinates for each template (from which the
 orientation is determined) can be found in the *ptm\_constants.h* file in the PTM source directory.
+For atoms that are not within the compute group-ID, all values are set to zero.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_ptm_atom.rst
+++ b/doc/src/compute_ptm_atom.rst
@@ -9,12 +9,13 @@ Syntax
 
 .. parsed-literal::
 
-   compute ID group-ID ptm/atom structures threshold
+   compute ID group-ID ptm/atom structures threshold group2-ID
 
 * ID, group-ID are documented in :doc:`compute <compute>` command
 * ptm/atom = style name of this compute command
 * structures = structure types to search for
 * threshold = lattice distortion threshold (RMSD)
+* group2-ID determines which group are used for neighbor selection (optional, default "all")
 
 Examples
 """"""""
@@ -22,8 +23,8 @@ Examples
 
 .. parsed-literal::
 
-   compute 1 all ptm/atom default 0.1
-   compute 1 all ptm/atom fcc-hcp-dcub-dhex 0.15
+   compute 1 all ptm/atom default 0.1 all
+   compute 1 all ptm/atom fcc-hcp-dcub-dhex 0.15 all
    compute 1 all ptm/atom all 0
 
 Description

--- a/src/USER-PTM/compute_ptm_atom.cpp
+++ b/src/USER-PTM/compute_ptm_atom.cpp
@@ -168,6 +168,8 @@ typedef struct
   int **firstneigh;
   int *ilist;
   int nlocal;
+  int *mask;
+  int groupbit;
 
 } ptmnbrdata_t;
 
@@ -184,6 +186,8 @@ static bool sorthelper_compare(ptmnbr_t const &a, ptmnbr_t const &b) {
 static int get_neighbours(void* vdata, size_t central_index, size_t atom_index, int num, size_t* nbr_indices, int32_t* numbers, double (*nbr_pos)[3])
 {
   ptmnbrdata_t* data = (ptmnbrdata_t*)vdata;
+  int *mask = data->mask;
+  int groupbit = data->groupbit;
 
   double **x = data->x;
   double *pos = x[atom_index];
@@ -203,6 +207,9 @@ static int get_neighbours(void* vdata, size_t central_index, size_t atom_index, 
 
   for (int jj = 0; jj < jnum; jj++) {
     int j = jlist[jj];
+    if (!(mask[j] & groupbit))
+      continue;
+
     j &= NEIGHMASK;
     if (j == atom_index)
       continue;
@@ -265,7 +272,7 @@ void ComputePTMAtom::compute_peratom() {
 
   double **x = atom->x;
   int *mask = atom->mask;
-  ptmnbrdata_t nbrlist = {x, numneigh, firstneigh, ilist, atom->nlocal};
+  ptmnbrdata_t nbrlist = {x, numneigh, firstneigh, ilist, atom->nlocal, mask, groupbit};
 
   for (int ii = 0; ii < inum; ii++) {
 

--- a/src/USER-PTM/compute_ptm_atom.cpp
+++ b/src/USER-PTM/compute_ptm_atom.cpp
@@ -62,7 +62,7 @@ static const char cite_user_ptm_package[] =
 
 ComputePTMAtom::ComputePTMAtom(LAMMPS *lmp, int narg, char **arg)
     : Compute(lmp, narg, arg), list(NULL), output(NULL) {
-  if (narg < 5)
+  if (narg < 5 || narg > 6)
     error->all(FLERR, "Illegal compute ptm/atom command");
 
   char *structures = arg[3];
@@ -282,6 +282,10 @@ void ComputePTMAtom::compute_peratom() {
   double **x = atom->x;
   int *mask = atom->mask;
   ptmnbrdata_t nbrlist = {x, numneigh, firstneigh, ilist, atom->nlocal, mask, group2bit};
+
+  // zero output
+
+  memset(output,0,nmax*NUM_COLUMNS*sizeof(double));
 
   for (int ii = 0; ii < inum; ii++) {
 

--- a/src/USER-PTM/compute_ptm_atom.h
+++ b/src/USER-PTM/compute_ptm_atom.h
@@ -39,6 +39,7 @@ class ComputePTMAtom : public Compute {
   double rmsd_threshold;
   class NeighList *list;
   double **output;
+  int group2bit;
 };
 
 }


### PR DESCRIPTION
**Summary**

When creating the USER-PTM package I did not correctly account for lammps groups. Here I have fixed the neighbour selection function so that only atoms in the active group are selected.

**Author(s)**
Peter Larsen
peter.mahler.larsen@gmail.com

Thanks to Ingrid de A. Ribeiro for reporting the problem.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).