### PR TITLE
Add check for required atom properties in USER-SDPD

### DIFF
--- a/src/USER-SDPD/pair_sdpd_taitwater_isothermal.cpp
+++ b/src/USER-SDPD/pair_sdpd_taitwater_isothermal.cpp
@@ -23,7 +23,9 @@
 #include "atom.h"
 #include "force.h"
 #include "comm.h"
+#include "neighbor.h"
 #include "neigh_list.h"
+#include "neigh_request.h"
 #include "memory.h"
 #include "error.h"
 #include "domain.h"
@@ -238,7 +240,7 @@ void PairSDPDTaitwaterIsothermal::allocate () {
 void PairSDPDTaitwaterIsothermal::settings (int narg, char **arg) {
   if (narg != 2 && narg != 3)
     error->all (FLERR, "Illegal number of arguments for "
-                "pair_style sdpd/taitwater/morris/isothermal");
+                "pair_style sdpd/taitwater/isothermal");
 
   temperature = force->numeric (FLERR, arg[0]);
   viscosity = force->numeric (FLERR, arg[1]);
@@ -298,12 +300,25 @@ void PairSDPDTaitwaterIsothermal::coeff (int narg, char **arg) {
 }
 
 /* ----------------------------------------------------------------------
+ init specific to this pair style
+------------------------------------------------------------------------- */
+
+void PairSDPDTaitwaterIsothermal::init_style()
+{
+  if ((!atom->rho_flag) || (atom->drho == NULL))
+    error->all(FLERR,"Pair style dpd/taitwater/isothermal requires atom "
+               "attributes rho and drho");
+
+  neighbor->request(this,instance_me);
+}
+
+/* ----------------------------------------------------------------------
  init for one type pair i,j and corresponding j,i
  ------------------------------------------------------------------------- */
 
 double PairSDPDTaitwaterIsothermal::init_one (int i, int j) {
   if (setflag[i][j] == 0)
-    error->all(FLERR,"Not all pair sph/taitwater/morris coeffs are set");
+    error->all(FLERR,"Not all pair sdpd/taitwater/isothermal coeffs are set");
 
   cut[j][i] = cut[i][j];
 

--- a/src/USER-SDPD/pair_sdpd_taitwater_isothermal.h
+++ b/src/USER-SDPD/pair_sdpd_taitwater_isothermal.h
@@ -36,6 +36,7 @@ class PairSDPDTaitwaterIsothermal : public Pair {
   void settings (int, char **);
   void coeff (int, char **);
   virtual double init_one (int, int);
+  virtual void init_style();
 
  protected:
   double viscosity, temperature;

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -175,6 +175,8 @@ Atom::Atom(LAMMPS *lmp) : Pointers(lmp)
   spin_flag = eradius_flag = ervel_flag = erforce_flag = ervelforce_flag = 0;
   cs_flag = csforce_flag = vforce_flag = etag_flag = 0;
 
+  // USER-SPH, USER-MESO, and USER-DPD flags
+
   rho_flag = e_flag = cv_flag = vest_flag = 0;
   dpd_flag = edpd_flag = tdpd_flag = 0;
 


### PR DESCRIPTION
**Summary**

The pair style in the USER-SDPD package did not check for atom style properties it uses, which could lead to segmentation faults. It doesn't show in the provided examples, because those use other commands that require those properties and check for them. The PR adds a check. It also corrects some incorrect names in the error message.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
