### PR TITLE
Change compute entropy/atom to use occasional neigh list

### DIFF
--- a/src/USER-MISC/compute_entropy_atom.cpp
+++ b/src/USER-MISC/compute_entropy_atom.cpp
@@ -141,7 +141,7 @@ void ComputeEntropyAtom::init()
   neighbor->requests[irequest]->compute = 1;
   neighbor->requests[irequest]->half = 0;
   neighbor->requests[irequest]->full = 1;
-  neighbor->requests[irequest]->occasional = 0;
+  neighbor->requests[irequest]->occasional = 1;
   if (avg_flag) {
     // need a full neighbor list with neighbors of the ghost atoms
     neighbor->requests[irequest]->ghost = 1;
@@ -196,7 +196,11 @@ void ComputeEntropyAtom::compute_peratom()
     }
   }
 
-  inum = list->inum +  list->gnum;
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  inum = list->inum + list->gnum;
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;


### PR DESCRIPTION
**Summary**

`Compute entropy/atom` requests a `perpetual` neighbor list. In most cases this doesn't affect performance because it is just copied from the pair style. However, when using Kokkos there is a large slowdown because there is not a compatible neigh list to copy from so `compute entropy/atom` builds a perpetual list. This PR changes the `perpetual` list to `occasional` as in other computes.

**Related Issues**

None

**Author(s)**

Stan Moore (SNL

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.