### PR TITLE
Revert "Change compute entropy/atom to use occasional neigh list"

### DIFF
--- a/src/USER-MISC/compute_entropy_atom.cpp
+++ b/src/USER-MISC/compute_entropy_atom.cpp
@@ -141,7 +141,7 @@ void ComputeEntropyAtom::init()
   neighbor->requests[irequest]->compute = 1;
   neighbor->requests[irequest]->half = 0;
   neighbor->requests[irequest]->full = 1;
-  neighbor->requests[irequest]->occasional = 1;
+  neighbor->requests[irequest]->occasional = 0;
   if (avg_flag) {
     // need a full neighbor list with neighbors of the ghost atoms
     neighbor->requests[irequest]->ghost = 1;
@@ -196,11 +196,7 @@ void ComputeEntropyAtom::compute_peratom()
     }
   }
 
-  // invoke full neighbor list (will copy or build if necessary)
-
-  neighbor->build_one(list);
-
-  inum = list->inum + list->gnum;
+  inum = list->inum +  list->gnum;
   ilist = list->ilist;
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;


### PR DESCRIPTION
Reverts lammps/lammps#1901

We cannot use the occasional neighbor list, because LAMMPS stops running the example in USER/misc/entropy with:
```
ERROR: Cannot request an occasional binned neighbor list with ghost info (src/neighbor.cpp:674)
```