### PR TITLE
Finalize Kokkos on error exit

### DIFF
--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -61,6 +61,11 @@ class KokkosLMP {
   int neigh_count(int) {return 0;}
 };
 
+class Kokkos {
+ public:
+  static void finalize() {}
+};
+
 class AtomKokkos : public Atom {
  public:
   tagint **k_special;

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -18,6 +18,7 @@
 #include "universe.h"
 #include "output.h"
 #include "input.h"
+#include "accelerator_kokkos.h"
 
 #if defined(LAMMPS_EXCEPTIONS)
 #include "update.h"
@@ -83,6 +84,7 @@ void Error::universe_all(const char *file, int line, const char *str)
   snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, truncpath(file), line);
   throw LAMMPSException(msg);
 #else
+  if (lmp->kokkos) Kokkos::finalize();
   MPI_Finalize();
   exit(1);
 #endif
@@ -173,6 +175,7 @@ void Error::all(const char *file, int line, const char *str)
   if (logfile) fclose(logfile);
 
   if (universe->nworlds > 1) MPI_Abort(universe->uworld,1);
+  if (lmp->kokkos) Kokkos::finalize();
   MPI_Finalize();
   exit(1);
 #endif
@@ -259,6 +262,7 @@ void Error::done(int status)
   if (screen && screen != stdout) fclose(screen);
   if (logfile) fclose(logfile);
 
+  if (lmp->kokkos) Kokkos::finalize();
   MPI_Finalize();
   exit(status);
 }


### PR DESCRIPTION
**Summary**

Finalize Kokkos on error exit, otherwise each rank prints an error message such as `Kokkos::Cuda ERROR: Failed to call Kokkos::Cuda::finalize()`. This could lead users to falsely believe there is a bug in Kokkos which led to the exit.

**Related Issues**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.