### PR TITLE
Some more conversions and corrections for the LAMMPS manual

### DIFF
--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -287,22 +287,29 @@ KOKKOS\_ARCH settings described below.  Note that for CMake, these are
 really Kokkos variables, not LAMMPS variables.  Hence you must use
 case-sensitive values, e.g. BDW, not bdw.
 
+* AMDAVX = AMD 64-bit x86 CPUs
+* EPYC   = AMD EPYC Zen class CPUs
 * ARMv80 = ARMv8.0 Compatible CPU
 * ARMv81 = ARMv8.1 Compatible CPU
 * ARMv8-ThunderX = ARMv8 Cavium ThunderX CPU
-* BGQ = IBM Blue Gene/Q CPUs
-* Power8 = IBM POWER8 CPUs
-* Power9 = IBM POWER9 CPUs
+* ARMv8-TX2 = ARMv8 Cavium ThunderX2 CPU
+* WSM = Intel Westmere CPUs
 * SNB = Intel Sandy/Ivy Bridge CPUs
 * HSW = Intel Haswell CPUs
 * BDW = Intel Broadwell Xeon E-class CPUs
 * SKX = Intel Sky Lake Xeon E-class HPC CPUs (AVX512)
 * KNC = Intel Knights Corner Xeon Phi
 * KNL = Intel Knights Landing Xeon Phi
+* BGQ = IBM Blue Gene/Q CPUs
+* Power7 = IBM POWER8 CPUs
+* Power8 = IBM POWER8 CPUs
+* Power9 = IBM POWER9 CPUs
+* Kepler = NVIDIA Kepler default (generation CC 3.5)
 * Kepler30 = NVIDIA Kepler generation CC 3.0
 * Kepler32 = NVIDIA Kepler generation CC 3.2
 * Kepler35 = NVIDIA Kepler generation CC 3.5
 * Kepler37 = NVIDIA Kepler generation CC 3.7
+* Maxwell = NVIDIA Maxwell default (generation CC 5.0)
 * Maxwell50 = NVIDIA Maxwell generation CC 5.0
 * Maxwell52 = NVIDIA Maxwell generation CC 5.2
 * Maxwell53 = NVIDIA Maxwell generation CC 5.3

--- a/doc/src/Commands_all.rst
+++ b/doc/src/Commands_all.rst
@@ -17,7 +17,7 @@ General commands
 An alphabetic list of all general LAMMPS commands.
 
 .. table_from_list::
-   :columns: 6
+   :columns: 5
 
    * :doc:`angle_coeff <angle_coeff>`
    * :doc:`angle_style <angle_style>`

--- a/doc/src/Commands_category.rst
+++ b/doc/src/Commands_category.rst
@@ -9,133 +9,161 @@ have their own pages where they are listed alphabetically.
 Initialization:
 ------------------------------
 
-* :doc:`newton <newton>`,
-* :doc:`package <package>`,
-* :doc:`processors <processors>`,
-* :doc:`suffix <suffix>`,
-* :doc:`units <units>`
+.. table_from_list::
+   :columns: 5
+
+   * :doc:`newton <newton>`
+   * :doc:`package <package>`
+   * :doc:`processors <processors>`
+   * :doc:`suffix <suffix>`
+   * :doc:`units <units>`
 
 Setup simulation box:
 ------------------------------
 
-* :doc:`boundary <boundary>`,
-* :doc:`box <box>`,
-* :doc:`change_box <change_box>`,
-* :doc:`create_box <create_box>`,
-* :doc:`dimension <dimension>`,
-* :doc:`lattice <lattice>`,
-* :doc:`region <region>`
+.. table_from_list::
+   :columns: 4
+
+   * :doc:`boundary <boundary>`
+   * :doc:`box <box>`
+   * :doc:`change_box <change_box>`
+   * :doc:`create_box <create_box>`
+   * :doc:`dimension <dimension>`
+   * :doc:`lattice <lattice>`
+   * :doc:`region <region>`
 
 Setup atoms:
 ------------------------------
 
-* :doc:`atom_modify <atom_modify>`,
-* :doc:`atom_style <atom_style>`,
-* :doc:`balance <balance>`,
-* :doc:`create_atoms <create_atoms>`,
-* :doc:`create_bonds <create_bonds>`,
-* :doc:`delete_atoms <delete_atoms>`,
-* :doc:`delete_bonds <delete_bonds>`,
-* :doc:`displace_atoms <displace_atoms>`,
-* :doc:`group <group>`,
-* :doc:`mass <mass>`,
-* :doc:`molecule <molecule>`,
-* :doc:`read_data <read_data>`,
-* :doc:`read_dump <read_dump>`,
-* :doc:`read_restart <read_restart>`,
-* :doc:`replicate <replicate>`,
-* :doc:`set <set>`,
-* :doc:`velocity <velocity>`
+.. table_from_list::
+   :columns: 4
+
+   * :doc:`atom_modify <atom_modify>`
+   * :doc:`atom_style <atom_style>`
+   * :doc:`balance <balance>`
+   * :doc:`create_atoms <create_atoms>`
+   * :doc:`create_bonds <create_bonds>`
+   * :doc:`delete_atoms <delete_atoms>`
+   * :doc:`delete_bonds <delete_bonds>`
+   * :doc:`displace_atoms <displace_atoms>`
+   * :doc:`group <group>`
+   * :doc:`mass <mass>`
+   * :doc:`molecule <molecule>`
+   * :doc:`read_data <read_data>`
+   * :doc:`read_dump <read_dump>`
+   * :doc:`read_restart <read_restart>`
+   * :doc:`replicate <replicate>`
+   * :doc:`set <set>`
+   * :doc:`velocity <velocity>`
 
 Force fields:
 ------------------------------
 
-* :doc:`angle_coeff <angle_coeff>`,
-* :doc:`angle_style <angle_style>`,
-* :doc:`bond_coeff <bond_coeff>`,
-* :doc:`bond_style <bond_style>`,
-* :doc:`bond_write <bond_write>`,
-* :doc:`dielectric <dielectric>`,
-* :doc:`dihedral_coeff <dihedral_coeff>`,
-* :doc:`dihedral_style <dihedral_style>`,
-* :doc:`improper_coeff <improper_coeff>`,
-* :doc:`improper_style <improper_style>`,
-* :doc:`kspace_modify <kspace_modify>`,
-* :doc:`kspace_style <kspace_style>`,
-* :doc:`pair_coeff <pair_coeff>`,
-* :doc:`pair_modify <pair_modify>`,
-* :doc:`pair_style <pair_style>`,
-* :doc:`pair_write <pair_write>`,
-* :doc:`special_bonds <special_bonds>`
+.. table_from_list::
+   :columns: 4
+
+   * :doc:`angle_coeff <angle_coeff>`
+   * :doc:`angle_style <angle_style>`
+   * :doc:`bond_coeff <bond_coeff>`
+   * :doc:`bond_style <bond_style>`
+   * :doc:`bond_write <bond_write>`
+   * :doc:`dielectric <dielectric>`
+   * :doc:`dihedral_coeff <dihedral_coeff>`
+   * :doc:`dihedral_style <dihedral_style>`
+   * :doc:`improper_coeff <improper_coeff>`
+   * :doc:`improper_style <improper_style>`
+   * :doc:`kspace_modify <kspace_modify>`
+   * :doc:`kspace_style <kspace_style>`
+   * :doc:`pair_coeff <pair_coeff>`
+   * :doc:`pair_modify <pair_modify>`
+   * :doc:`pair_style <pair_style>`
+   * :doc:`pair_write <pair_write>`
+   * :doc:`special_bonds <special_bonds>`
 
 Settings:
 ------------------------------
 
-* :doc:`comm_modify <comm_modify>`,
-* :doc:`comm_style <comm_style>`,
-* :doc:`info <info>`,
-* :doc:`min_modify <min_modify>`,
-* :doc:`min_style <min_style>`,
-* :doc:`neigh_modify <neigh_modify>`,
-* :doc:`neighbor <neighbor>`,
-* :doc:`partition <partition>`,
-* :doc:`reset_timestep <reset_timestep>`,
-* :doc:`run_style <run_style>`,
-* :doc:`timer <timer>`,
-* :doc:`timestep <timestep>`
+.. table_from_list::
+   :columns: 4
+
+   * :doc:`comm_modify <comm_modify>`
+   * :doc:`comm_style <comm_style>`
+   * :doc:`info <info>`
+   * :doc:`min_modify <min_modify>`
+   * :doc:`min_style <min_style>`
+   * :doc:`neigh_modify <neigh_modify>`
+   * :doc:`neighbor <neighbor>`
+   * :doc:`partition <partition>`
+   * :doc:`reset_timestep <reset_timestep>`
+   * :doc:`run_style <run_style>`
+   * :doc:`timer <timer>`
+   * :doc:`timestep <timestep>`
 
 Operations within timestepping (fixes) and diagnostics (computes):
 ------------------------------------------------------------------------------------------
 
-* :doc:`compute <compute>`,
-* :doc:`compute_modify <compute_modify>`,
-* :doc:`fix <fix>`,
-* :doc:`fix_modify <fix_modify>`,
-* :doc:`uncompute <uncompute>`,
-* :doc:`unfix <unfix>`
+.. table_from_list::
+   :columns: 4
+
+   * :doc:`compute <compute>`
+   * :doc:`compute_modify <compute_modify>`
+   * :doc:`fix <fix>`
+   * :doc:`fix_modify <fix_modify>`
+   * :doc:`uncompute <uncompute>`
+   * :doc:`unfix <unfix>`
 
 Output:
 ------------------------------
 
-* :doc:`dump image <dump_image>`,
-* :doc:`dump movie <dump_image>`,
-* :doc:`dump <dump>`,
-* :doc:`dump_modify <dump_modify>`,
-* :doc:`restart <restart>`,
-* :doc:`thermo <thermo>`,
-* :doc:`thermo_modify <thermo_modify>`,
-* :doc:`thermo_style <thermo_style>`,
-* :doc:`undump <undump>`,
-* :doc:`write_coeff <write_coeff>`,
-* :doc:`write_data <write_data>`,
-* :doc:`write_dump <write_dump>`,
-* :doc:`write_restart <write_restart>`
+.. table_from_list::
+   :columns: 4
+
+   * :doc:`dump image <dump_image>`
+   * :doc:`dump movie <dump_image>`
+   * :doc:`dump <dump>`
+   * :doc:`dump_modify <dump_modify>`
+   * :doc:`restart <restart>`
+   * :doc:`thermo <thermo>`
+   * :doc:`thermo_modify <thermo_modify>`
+   * :doc:`thermo_style <thermo_style>`
+   * :doc:`undump <undump>`
+   * :doc:`write_coeff <write_coeff>`
+   * :doc:`write_data <write_data>`
+   * :doc:`write_dump <write_dump>`
+   * :doc:`write_restart <write_restart>`
 
 Actions:
 ------------------------------
 
-* :doc:`minimize <minimize>`,
-* :doc:`neb <neb>`,
-* :doc:`neb_spin <neb_spin>`,
-* :doc:`prd <prd>`,
-* :doc:`rerun <rerun>`,
-* :doc:`run <run>`,
-* :doc:`tad <tad>`,
-* :doc:`temper <temper>`
+.. table_from_list::
+   :columns: 6
+
+   * :doc:`minimize <minimize>`
+   * :doc:`neb <neb>`
+   * :doc:`neb_spin <neb_spin>`
+   * :doc:`prd <prd>`
+   * :doc:`rerun <rerun>`
+   * :doc:`run <run>`
+   * :doc:`tad <tad>`
+   * :doc:`temper <temper>`
 
 Input script control:
 ------------------------------
 
-* :doc:`clear <clear>`,
-* :doc:`echo <echo>`,
-* :doc:`if <if>`,
-* :doc:`include <include>`,
-* :doc:`jump <jump>`,
-* :doc:`label <label>`,
-* :doc:`log <log>`,
-* :doc:`next <next>`,
-* :doc:`print <print>`,
-* :doc:`python <python>`,
-* :doc:`quit <quit>`,
-* :doc:`shell <shell>`,
-* :doc:`variable <variable>`
+.. table_from_list::
+   :columns: 7
+
+   * :doc:`clear <clear>`
+   * :doc:`echo <echo>`
+   * :doc:`if <if>`
+   * :doc:`include <include>`
+   * :doc:`info <info>`
+   * :doc:`jump <jump>`
+   * :doc:`label <label>`
+   * :doc:`log <log>`
+   * :doc:`next <next>`
+   * :doc:`print <print>`
+   * :doc:`python <python>`
+   * :doc:`quit <quit>`
+   * :doc:`shell <shell>`
+   * :doc:`variable <variable>`

--- a/doc/src/Commands_compute.rst
+++ b/doc/src/Commands_compute.rst
@@ -20,7 +20,7 @@ additional letters in parenthesis: g = GPU, i = USER-INTEL, k =
 KOKKOS, o = USER-OMP, t = OPT.
 
 .. table_from_list::
-   :columns: 6
+   :columns: 5
 
    * :doc:`ackland/atom <compute_ackland_atom>`
    * :doc:`adf <compute_adf>`

--- a/doc/src/Commands_fix.rst
+++ b/doc/src/Commands_fix.rst
@@ -20,7 +20,7 @@ parenthesis: g = GPU, i = USER-INTEL, k = KOKKOS, o = USER-OMP, t =
 OPT.
 
 .. table_from_list::
-   :columns: 6
+   :columns: 5
 
    * :doc:`adapt <fix_adapt>`
    * :doc:`adapt/fep <fix_adapt_fep>`

--- a/doc/src/Commands_pair.rst
+++ b/doc/src/Commands_pair.rst
@@ -26,6 +26,10 @@ OPT.
    * :doc:`zero <pair_zero>`
    * :doc:`hybrid (k) <pair_hybrid>`
    * :doc:`hybrid/overlay (k) <pair_hybrid>`
+   * :doc:`kim <pair_kim>`
+   * :doc:`list <pair_list>`
+   *
+   *
    *
    *
    *
@@ -108,14 +112,12 @@ OPT.
    * :doc:`hbond/dreiding/lj (o) <pair_hbond_dreiding>`
    * :doc:`hbond/dreiding/morse (o) <pair_hbond_dreiding>`
    * :doc:`ilp/graphene/hbn <pair_ilp_graphene_hbn>`
-   * :doc:`kim <pair_kim>`
    * :doc:`kolmogorov/crespi/full <pair_kolmogorov_crespi_full>`
    * :doc:`kolmogorov/crespi/z <pair_kolmogorov_crespi_z>`
    * :doc:`lcbop <pair_lcbop>`
    * :doc:`lebedeva/z <pair_lebedeva_z>`
    * :doc:`lennard/mdf <pair_mdf>`
    * :doc:`line/lj <pair_line_lj>`
-   * :doc:`list <pair_list>`
    * :doc:`lj/charmm/coul/charmm (iko) <pair_charmm>`
    * :doc:`lj/charmm/coul/charmm/implicit (ko) <pair_charmm>`
    * :doc:`lj/charmm/coul/long (gikot) <pair_charmm>`

--- a/doc/src/Howto_drude2.rst
+++ b/doc/src/Howto_drude2.rst
@@ -181,7 +181,7 @@ include Coulomb interactions, for instance *lj/cut/coul/long* with
 
 As compared to the non-polarizable input file, *pair\_coeff* lines need
 to be added for the DPs.  Since the DPs have no Lennard-Jones
-interactions, their *epsilon* is 0. so the only *pair\_coeff* line
+interactions, their :math:`\epsilon` is 0. so the only *pair\_coeff* line
 that needs to be added is
 
 

--- a/doc/src/Howto_triclinic.rst
+++ b/doc/src/Howto_triclinic.rst
@@ -55,7 +55,7 @@ rotation of **A**\ , **B**\ , and **C** and can be computed as follows:
   c_z = & |\mathbf{C} \cdot \widehat{(\mathbf{A} \times \mathbf{B})}|\quad = \quad \sqrt{C^2 - {c_x}^2 - {c_y}^2}
 
 where A = \| **A** \| indicates the scalar length of **A**\ . The hat symbol (\^)
-indicates the corresponding unit vector. *beta* and *gamma* are angles
+indicates the corresponding unit vector. :math:`\beta` and :math:`\gamma` are angles
 between the vectors described below. Note that by construction,
 **a**\ , **b**\ , and **c** have strictly positive x, y, and z components, respectively.
 If it should happen that

--- a/doc/src/Install_git.rst
+++ b/doc/src/Install_git.rst
@@ -11,16 +11,20 @@ has several advantages:
 * You can submit your new features back to GitHub for inclusion in
   LAMMPS.
 
-You must have `git <git_>`_ installed on your system to communicate with
-the public git server for LAMMPS.
+You must have `git <git_>`_ installed on your system to use the
+commands explained below to communicate with the git servers on
+GitHub.  For people still using subversion (svn), GitHub also
+provides `limited support for subversion clients <svn_>`_.
+
 
 .. warning::
 
    As of October 2016, the official home of public LAMMPS development is
    on GitHub.  The previously advertised LAMMPS git repositories on
-   git.lammps.org and bitbucket.org are now deprecated, and may go away at any time.
+   git.lammps.org and bitbucket.org are now deprecated or offline.
 
 .. _git: https://git-scm.com
+.. _svn: https://help.github.com/en/github/importing-your-projects-to-github/working-with-subversion-on-github
 
 You can follow LAMMPS development on 3 different git branches:
 

--- a/doc/src/Manual.rst
+++ b/doc/src/Manual.rst
@@ -78,7 +78,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`search`
-
-.. raw:: html
-
-   </BODY>

--- a/doc/src/Modify_overview.rst
+++ b/doc/src/Modify_overview.rst
@@ -4,7 +4,7 @@ Overview
 The best way to add a new feature to LAMMPS is to find a similar
 feature and look at the corresponding source and header files to figure
 out what it does.  You will need some knowledge of C++ to be able to
-understand the hi-level structure of LAMMPS and its class
+understand the high-level structure of LAMMPS and its class
 organization, but functions (class methods) that do actual
 computations are written in vanilla C-style code and operate on simple
 C-style data structures (vectors and arrays).

--- a/doc/src/Python_mpi.rst
+++ b/doc/src/Python_mpi.rst
@@ -66,7 +66,7 @@ and see one line of output for each processor you run on.
    insure both are using the same version of MPI.  If you only have one
    MPI installed on your system, this is not an issue, but it can be if
    you have multiple MPIs.  Your LAMMPS build is explicit about which MPI
-   it is using, since you specify the details in your lo-level
+   it is using, since you specify the details in your low-level
    src/MAKE/Makefile.foo file.  Mpi4py uses the "mpicc" command to find
    information about the MPI it uses to build against.  And it tries to
    load "libmpi.so" from the LD\_LIBRARY\_PATH.  This may or may not find

--- a/doc/src/Python_test.rst
+++ b/doc/src/Python_test.rst
@@ -38,7 +38,7 @@ If an error occurs, carefully go through the steps on the
 library and the :doc:`Python\_install <Python_install>` doc page about
 insuring Python can find the necessary two files it needs.
 
-**Test LAMMPS and Python in serial:**
+Test LAMMPS and Python in serial:
 -------------------------------------
 
 To run a LAMMPS test in serial, type these lines into Python
@@ -67,7 +67,7 @@ typed something like:
 
    lmp_g++ -in in.lj
 
-**Test LAMMPS and Python in parallel:**
+Test LAMMPS and Python in parallel:
 ---------------------------------------
 
 To run LAMMPS in parallel, assuming you have installed the
@@ -128,7 +128,7 @@ described in the PyPar documentation.  The last line of your Python
 script should be pypar.finalize(), to insure MPI is shut down
 correctly.
 
-**Running Python scripts:**
+Running Python scripts:
 ---------------------------
 
 Note that any Python script (not just for LAMMPS) can be invoked in

--- a/doc/src/Run_options.rst
+++ b/doc/src/Run_options.rst
@@ -196,9 +196,9 @@ Specify a log file for LAMMPS to write status information to.  In
 one-partition mode, if the switch is not used, LAMMPS writes to the
 file log.lammps.  If this switch is used, LAMMPS writes to the
 specified file.  In multi-partition mode, if the switch is not used, a
-log.lammps file is created with hi-level status information.  Each
+log.lammps file is created with high-level status information.  Each
 partition also writes to a log.lammps.N file where N is the partition
-ID.  If the switch is specified in multi-partition mode, the hi-level
+ID.  If the switch is specified in multi-partition mode, the high-level
 logfile is named "file" and each partition also logs information to a
 file.N.  For both one-partition and multi-partition mode, if the
 specified file is "none", then no log files are created.  Using a
@@ -529,10 +529,10 @@ Specify a file for LAMMPS to write its screen information to.  In
 one-partition mode, if the switch is not used, LAMMPS writes to the
 screen.  If this switch is used, LAMMPS writes to the specified file
 instead and you will see no screen output.  In multi-partition mode,
-if the switch is not used, hi-level status information is written to
+if the switch is not used, high-level status information is written to
 the screen.  Each partition also writes to a screen.N file where N is
 the partition ID.  If the switch is specified in multi-partition mode,
-the hi-level screen dump is named "file" and each partition also
+the high-level screen dump is named "file" and each partition also
 writes screen information to a file.N.  For both one-partition and
 multi-partition mode, if the specified file is "none", then no screen
 output is performed. Option -pscreen will override the name of the

--- a/doc/src/angle_sdk.rst
+++ b/doc/src/angle_sdk.rst
@@ -35,13 +35,14 @@ The *sdk* angle style is a combination of the harmonic angle potential,
    E = K (\theta - \theta_0)^2 
 
 
-where :math:`\theta_0` is the equilibrium value of the angle and :math:`K` a prefactor,
-with the *repulsive* part of the non-bonded *lj/sdk* pair style
-between the atoms 1 and 3.  This angle potential is intended for
-coarse grained MD simulations with the CMM parameterization using the
-:doc:`pair_style lj/sdk <pair_sdk>`.  Relative to the pair\_style
-*lj/sdk*\ , however, the energy is shifted by *epsilon*\ , to avoid sudden
-jumps.  Note that the usual 1/2 factor is included in :math:`K`.
+where :math:`\theta_0` is the equilibrium value of the angle and
+:math:`K` a prefactor, with the *repulsive* part of the non-bonded
+*lj/sdk* pair style between the atoms 1 and 3.  This angle potential is
+intended for coarse grained MD simulations with the CMM parameterization
+using the :doc:`pair_style lj/sdk <pair_sdk>`.  Relative to the
+pair\_style *lj/sdk*\ , however, the energy is shifted by
+:math:`\epsilon`, to avoid sudden jumps.  Note that the usual 1/2 factor
+is included in :math:`K`.
 
 The following coefficients must be defined for each angle type via the
 :doc:`angle_coeff <angle_coeff>` command as in the example above:

--- a/doc/src/compute_ke.rst
+++ b/doc/src/compute_ke.rst
@@ -28,8 +28,8 @@ Description
 Define a computation that calculates the translational kinetic energy
 of a group of particles.
 
-The kinetic energy of each particle is computed as 1/2 m v\^2, where m
-and v are the mass and velocity of the particle.
+The kinetic energy of each particle is computed as :math:`\frac{1}{2} m
+v^2`, where *m* and *v* are the mass and velocity of the particle.
 
 There is a subtle difference between the quantity calculated by this
 compute and the kinetic energy calculated by the *ke* or *etotal*
@@ -37,12 +37,13 @@ keyword used in thermodynamic output, as specified by the
 :doc:`thermo_style <thermo_style>` command.  For this compute, kinetic
 energy is "translational" kinetic energy, calculated by the simple
 formula above.  For thermodynamic output, the *ke* keyword infers
-kinetic energy from the temperature of the system with 1/2 Kb T of
-energy for each degree of freedom.  For the default temperature
-computation via the :doc:`compute temp <compute_temp>` command, these
-are the same.  But different computes that calculate temperature can
-subtract out different non-thermal components of velocity and/or
-include different degrees of freedom (translational, rotational, etc).
+kinetic energy from the temperature of the system with
+:math:`\frac{1}{2} k_B T` of energy for each degree of freedom.  For the
+default temperature computation via the :doc:`compute temp
+<compute_temp>` command, these are the same.  But different computes
+that calculate temperature can subtract out different non-thermal
+components of velocity and/or include different degrees of freedom
+(translational, rotational, etc).
 
 **Output info:**
 

--- a/doc/src/compute_ke_atom_eff.rst
+++ b/doc/src/compute_ke_atom_eff.rst
@@ -18,7 +18,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    compute 1 all ke/atom/eff
 
@@ -30,11 +30,12 @@ Define a computation that calculates the per-atom translational
 group.  The particles are assumed to be nuclei and electrons modeled
 with the :doc:`electronic force field <pair_eff>`.
 
-The kinetic energy for each nucleus is computed as 1/2 m v\^2, where m
-corresponds to the corresponding nuclear mass, and the kinetic energy
-for each electron is computed as 1/2 (me v\^2 + 3/4 me s\^2), where me
-and v correspond to the mass and translational velocity of each
-electron, and s to its radial velocity, respectively.
+The kinetic energy for each nucleus is computed as :math:`\frac{1}{2} m
+v^2`, where *m* corresponds to the corresponding nuclear mass, and the
+kinetic energy for each electron is computed as :math:`\frac{1}{2} (m_e
+v^2 + \frac{3}{4} m_e s^2)`, where :math:`m_e` and *v* correspond to the mass
+and translational velocity of each electron, and *s* to its radial
+velocity, respectively.
 
 There is a subtle difference between the quantity calculated by this
 compute and the kinetic energy calculated by the *ke* or *etotal*
@@ -43,8 +44,8 @@ keyword used in thermodynamic output, as specified by the
 energy is "translational" plus electronic "radial" kinetic energy,
 calculated by the simple formula above. For thermodynamic output, the
 *ke* keyword infers kinetic energy from the temperature of the system
-with 1/2 Kb T of energy for each (nuclear-only) degree of freedom in
-eFF.
+with :math:`\frac{1}{2} k_B T` of energy for each (nuclear-only) degree
+of freedom in eFF.
 
 .. note::
 
@@ -53,7 +54,7 @@ eFF.
    command, as shown in the following example:
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    compute         effTemp all temp/eff
    thermo_style    custom step etotal pe ke temp press

--- a/doc/src/compute_ke_eff.rst
+++ b/doc/src/compute_ke_eff.rst
@@ -29,11 +29,12 @@ Define a computation that calculates the kinetic energy of motion of a
 group of eFF particles (nuclei and electrons), as modeled with the
 :doc:`electronic force field <pair_eff>`.
 
-The kinetic energy for each nucleus is computed as 1/2 m v\^2 and the
-kinetic energy for each electron is computed as 1/2(me v\^2 + 3/4 me
-s\^2), where m corresponds to the nuclear mass, me to the electron
-mass, v to the translational velocity of each particle, and s to the
-radial velocity of the electron, respectively.
+The kinetic energy for each nucleus is computed as :math:`\frac{1}{2} m
+v^2` and the kinetic energy for each electron is computed as
+:math:`\frac{1}{2}(m_e v^2 + \frac{3}{4} m_e s^2)`, where *m*
+corresponds to the nuclear mass, :math:`m_e` to the electron mass, *v*
+to the translational velocity of each particle, and *s* to the radial
+velocity of the electron, respectively.
 
 There is a subtle difference between the quantity calculated by this
 compute and the kinetic energy calculated by the *ke* or *etotal*
@@ -42,18 +43,20 @@ keyword used in thermodynamic output, as specified by the
 energy is "translational" and "radial" (only for electrons) kinetic
 energy, calculated by the simple formula above.  For thermodynamic
 output, the *ke* keyword infers kinetic energy from the temperature of
-the system with 1/2 Kb T of energy for each degree of freedom.  For
-the eFF temperature computation via the :doc:`compute temp\_eff <compute_temp_eff>` command, these are the same.  But
-different computes that calculate temperature can subtract out
-different non-thermal components of velocity and/or include other
-degrees of freedom.
+the system with :math:`\frac{1}{2} k_B T` of energy for each degree of
+freedom.  For the eFF temperature computation via the :doc:`compute
+temp\_eff <compute_temp_eff>` command, these are the same.  But
+different computes that calculate temperature can subtract out different
+non-thermal components of velocity and/or include other degrees of
+freedom.
 
-IMPRORTANT NOTE: The temperature in eFF models should be monitored via
-the :doc:`compute temp/eff <compute_temp_eff>` command, which can be
-printed with thermodynamic output by using the
-:doc:`thermo_modify <thermo_modify>` command, as shown in the following
-example:
+.. warning::
 
+   The temperature in eFF models should be monitored via
+   the :doc:`compute temp/eff <compute_temp_eff>` command, which can be
+   printed with thermodynamic output by using the
+   :doc:`thermo_modify <thermo_modify>` command, as shown in the following
+   example:
 
 .. parsed-literal::
 

--- a/doc/src/compute_pressure.rst
+++ b/doc/src/compute_pressure.rst
@@ -21,7 +21,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    compute 1 all pressure thermo_temp
    compute 1 all pressure NULL pair bond
@@ -42,20 +42,20 @@ The pressure is computed by the formula
    P = \frac{N k_B T}{V} + \frac{\sum_{i}^{N'} r_i \bullet f_i}{dV}
 
 
-where N is the number of atoms in the system (see discussion of DOF
-below), Kb is the Boltzmann constant, T is the temperature, d is the
-dimensionality of the system (2 or 3 for 2d/3d), and V is the system
-volume (or area in 2d).  The second term is the virial, equal to
+where *N* is the number of atoms in the system (see discussion of DOF
+below), :math:`k_B` is the Boltzmann constant, *T* is the temperature, d
+is the dimensionality of the system (2 or 3 for 2d/3d), and *V* is the
+system volume (or area in 2d).  The second term is the virial, equal to
 -dU/dV, computed for all pairwise as well as 2-body, 3-body, 4-body,
-many-body, and long-range interactions, where r\_i and f\_i are the
-position and force vector of atom i, and the black dot indicates a dot
-product.  When periodic boundary conditions are used, N' necessarily
-includes periodic image (ghost) atoms outside the central box, and the
-position and force vectors of ghost atoms are thus included in the
-summation.  When periodic boundary conditions are not used, N' = N =
-the number of atoms in the system.  :doc:`Fixes <fix>` that impose
-constraints (e.g. the :doc:`fix shake <fix_shake>` command) also
-contribute to the virial term.
+many-body, and long-range interactions, where :math:`r_i` and
+:math:`f_i` are the position and force vector of atom *i*, and the black
+dot indicates a dot product.  When periodic boundary conditions are
+used, N' necessarily includes periodic image (ghost) atoms outside the
+central box, and the position and force vectors of ghost atoms are thus
+included in the summation.  When periodic boundary conditions are not
+used, N' = N = the number of atoms in the system.  :doc:`Fixes <fix>`
+that impose constraints (e.g. the :doc:`fix shake <fix_shake>` command)
+also contribute to the virial term.
 
 A symmetric pressure tensor, stored as a 6-element vector, is also
 calculated by this compute.  The 6 components of the vector are
@@ -108,7 +108,7 @@ A compute of this style with the ID of "thermo\_press" is created when
 LAMMPS starts up, as if this command were in the input script:
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    compute thermo_press all pressure thermo_temp
 

--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -89,7 +89,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    dump d0 all image 100 dump.\*.jpg type type
    dump d1 mobile image 500 snap.\*.png element element ssao yes 4539 0.6
@@ -121,19 +121,12 @@ script to generate the images/movie.
 Here are two sample images, rendered as 1024x1024 JPEG files.  Click
 to see the full-size images:
 
-.. raw:: html
-
-   <DIV ALIGN=center>
-
 .. image:: JPG/dump1_small.jpg
    :target: JPG/dump1.jpg
-
+   :width: 48%
 .. image:: JPG/dump2_small.jpg
    :target: JPG/dump2.jpg
-
-.. raw:: html
-
-   </DIV>
+   :width: 48%
 
 Only atoms in the specified group are rendered in the image.  The
 :doc:`dump_modify region and thresh <dump_modify>` commands can also
@@ -235,8 +228,6 @@ the `AtomEye <atomeye_>`_ visualization package.
 
 .. _atomeye: http://mt.seas.upenn.edu/Archive/Graphics/A
 
-
-
 If other atom attributes are used for the *color* or *diameter*
 settings, they are interpreted in the following way.
 
@@ -258,9 +249,7 @@ drawn.  Note that finite-size spherical particles, as defined by
 :doc:`atom_style sphere <atom_style>` define a per-particle radius or
 diameter, which can be used as the *diameter* setting.
 
-
 ----------
-
 
 The various keywords listed above control how the image is rendered.
 As listed below, all of the keywords have defaults, most of which you
@@ -268,9 +257,7 @@ will likely not need to change.  The :doc:`dump modify <dump_modify>`
 also has options specific to the dump image style, particularly for
 assigning colors to atoms, bonds, and other image features.
 
-
 ----------
-
 
 The *atom* keyword allow you to turn off the drawing of all atoms, if
 the specified value is *no*\ .  Note that this will not turn off the
@@ -283,9 +270,7 @@ set a single numeric *size*\ .  All atoms will be drawn with that
 diameter, e.g. 1.5, which is in whatever distance :doc:`units <units>`
 the input script defines, e.g. Angstroms.
 
-
 ----------
-
 
 The *bond* keyword allows to you to alter how bonds are drawn.  A bond
 is only drawn if both atoms in the bond are being drawn due to being
@@ -329,9 +314,7 @@ If *type* is specified for the *width* value then the diameter of each
 bond is determined by its bond type.  By default all types have
 diameter 0.5.  This mapping can be changed by the :doc:`dump_modify bdiam <dump_modify>` command.
 
-
 ----------
-
 
 The *line* keyword can be used when :doc:`atom_style line <atom_style>`
 is used to define particles as line segments, and will draw them as
@@ -586,10 +569,10 @@ MPEG or other movie file you can use:
 
 * a) Use the ImageMagick convert program.
   
-  .. parsed-literal::
+  .. code-block:: bash
   
-     % convert \*.jpg foo.gif
-     % convert -loop 1 \*.ppm foo.mpg
+     % convert *.jpg foo.gif
+     % convert -loop 1 *.ppm foo.mpg
 
 
   Animated GIF files from ImageMagick are not optimized. You can use
@@ -614,17 +597,14 @@ MPEG or other movie file you can use:
   allows extremely flexible encoding and decoding of movies.
 
   
-  .. parsed-literal::
+  .. code-block:: bash
   
-     cat snap.\*.jpg \| ffmpeg -y -f image2pipe -c:v mjpeg -i - -b:v 2000k movie.m4v
-     cat snap.\*.ppm \| ffmpeg -y -f image2pipe -c:v ppm -i - -b:v 2400k movie.avi
+     cat snap.*.jpg | ffmpeg -y -f image2pipe -c:v mjpeg -i - -b:v 2000k movie.m4v
+     cat snap.*.ppm | ffmpeg -y -f image2pipe -c:v ppm -i - -b:v 2400k movie.avi
 
 
   Front ends for FFmpeg exist for multiple platforms. For more
   information see the `FFmpeg homepage <http://www.ffmpeg.org/>`_
-
-
-
 
 ----------
 
@@ -640,7 +620,7 @@ Play the movie:
   movie. Both are available for multiple OSes and support a large
   variety of file formats and decoders.
   
-  .. parsed-literal::
+  .. code-block:: bash
   
      % mplayer foo.mpg
      % ffplay bar.avi
@@ -649,9 +629,9 @@ Play the movie:
   `animate tool <http://www.sandia.gov/~sjplimp/pizza/doc/animate.html>`_,
   which works directly on a series of image files.
   
-  .. parsed-literal::
+  .. code-block:: python
   
-     a = animate("foo\*.jpg")
+     a = animate("foo*.jpg")
 
 * d) QuickTime and other Windows- or MacOS-based media players can
   obviously play movie files directly. Similarly for corresponding tools
@@ -660,10 +640,7 @@ Play the movie:
   additional libraries, purchasing a license, or may not be
   supported.
 
-
-
 ----------
-
 
 See the :doc:`Modify <Modify>` doc page for information on how to add
 new compute and fix styles to LAMMPS to calculate per-atom quantities

--- a/doc/src/fix_hyper_local.rst
+++ b/doc/src/fix_hyper_local.rst
@@ -155,17 +155,15 @@ simulation domain.
 
 To accomplish this, if :math:`B_{ij} < B_{target}`, the :math:`C_{ij}`
 prefactor for bond *ij* is incremented on the current timestep by an
-amount proportional to the inverse of the specified *alpha* and the
-difference (:math:`B_{ij} - B_{target}`).
-Conversely if :math:`B_{ij} > B_{target}`, :math:`C_{ij}` is decremented
-by the same amount.
-This procedure is termed "boostostatting" in :ref:`(Voter2013) <Voter2013lhd>`.
-It drives all of the individual :math:`C_{ij}` to
-values such that when :math:`V^{max}_{ij}` is applied as a bias to
-bond *ij*, the resulting boost factor :math:`B_{ij}` will be close
-to :math:`B_{target}` on average.
-Thus the LHD time acceleration factor for the overall system is
-effectively *Btarget*\ .
+amount proportional to the inverse of the specified :math:`\alpha` and
+the difference (:math:`B_{ij} - B_{target}`).  Conversely if
+:math:`B_{ij} > B_{target}`, :math:`C_{ij}` is decremented by the same
+amount.  This procedure is termed "boostostatting" in :ref:`(Voter2013)
+<Voter2013lhd>`.  It drives all of the individual :math:`C_{ij}` to
+values such that when :math:`V^{max}_{ij}` is applied as a bias to bond
+*ij*, the resulting boost factor :math:`B_{ij}` will be close to
+:math:`B_{target}` on average.  Thus the LHD time acceleration factor
+for the overall system is effectively *Btarget*\ .
 
 Note that in LHD, the boost factor :math:`B_{target}` is specified by the user.
 This is in contrast to global hyperdynamics (GHD) where the boost

--- a/doc/src/fix_langevin.rst
+++ b/doc/src/fix_langevin.rst
@@ -51,7 +51,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    fix 3 boundary langevin 1.0 1.0 1000.0 699483
    fix 1 all langevin 1.0 1.1 100.0 48279 scale 3 1.5
@@ -67,35 +67,35 @@ performs Brownian dynamics (BD), since the total force on each atom
 will have the form:
 
 
-.. parsed-literal::
+.. math::
 
-   F = Fc + Ff + Fr
-   Ff = - (m / damp) v
-   Fr is proportional to sqrt(Kb T m / (dt damp))
+   F = & F_c + F_f + F_r \\
+   F_f = & - \frac{m}{\mathrm{damp}} v \\
+   F_r \propto & \sqrt{\frac{k_B T m}{dt~\mathrm{damp}}}
 
-Fc is the conservative force computed via the usual inter-particle
-interactions (:doc:`pair_style <pair_style>`,
-:doc:`bond_style <bond_style>`, etc).
+:math:`F_c` is the conservative force computed via the usual
+inter-particle interactions (:doc:`pair_style <pair_style>`,
+:doc:`bond_style <bond_style>`, etc).  The :math:`F_f` and :math:`F_r`
+terms are added by this fix on a per-particle basis.  See the
+:doc:`pair_style dpd/tstat <pair_dpd>` command for a thermostatting
+option that adds similar terms on a pairwise basis to pairs of
+interacting particles.
 
-The Ff and Fr terms are added by this fix on a per-particle basis.
-See the :doc:`pair_style dpd/tstat <pair_dpd>` command for a
-thermostatting option that adds similar terms on a pairwise basis to
-pairs of interacting particles.
+:math:`F_f` is a frictional drag or viscous damping term proportional to
+the particle's velocity.  The proportionality constant for each atom is
+computed as :math:`\frac{m}{\mathrm{damp}}`, where *m* is the mass of the
+particle and damp is the damping factor specified by the user.
 
-Ff is a frictional drag or viscous damping term proportional to the
-particle's velocity.  The proportionality constant for each atom is
-computed as m/damp, where m is the mass of the particle and damp is
-the damping factor specified by the user.
-
-Fr is a force due to solvent atoms at a temperature T randomly bumping
-into the particle.  As derived from the fluctuation/dissipation
-theorem, its magnitude as shown above is proportional to sqrt(Kb T m /
-dt damp), where Kb is the Boltzmann constant, T is the desired
-temperature, m is the mass of the particle, dt is the timestep size,
-and damp is the damping factor.  Random numbers are used to randomize
-the direction and magnitude of this force as described in
-:ref:`(Dunweg) <Dunweg1>`, where a uniform random number is used (instead of
-a Gaussian random number) for speed.
+:math:`F_r` is a force due to solvent atoms at a temperature *T*
+randomly bumping into the particle.  As derived from the
+fluctuation/dissipation theorem, its magnitude as shown above is
+proportional to :math:`\sqrt{\frac{k_B T m}{dt~\mathrm{damp}}}`, where
+:math:`k_B` is the Boltzmann constant, *T* is the desired temperature,
+*m* is the mass of the particle, *dt* is the timestep size, and damp is
+the damping factor.  Random numbers are used to randomize the direction
+and magnitude of this force as described in :ref:`(Dunweg) <Dunweg1>`,
+where a uniform random number is used (instead of a Gaussian random
+number) for speed.
 
 Note that unless you use the *omega* or *angmom* keywords, the
 thermostat effect of this fix is applied to only the translational
@@ -107,14 +107,15 @@ thermostatting takes place; see the description below.
 
 .. note::
 
-   Unlike the :doc:`fix nvt <fix_nh>` command which performs
-   Nose/Hoover thermostatting AND time integration, this fix does NOT
-   perform time integration.  It only modifies forces to effect
-   thermostatting.  Thus you must use a separate time integration fix,
-   like :doc:`fix nve <fix_nve>` to actually update the velocities and
-   positions of atoms using the modified forces.  Likewise, this fix
-   should not normally be used on atoms that also have their temperature
-   controlled by another fix - e.g. by :doc:`fix nvt <fix_nh>` or :doc:`fix temp/rescale <fix_temp_rescale>` commands.
+   Unlike the :doc:`fix nvt <fix_nh>` command which performs Nose/Hoover
+   thermostatting AND time integration, this fix does NOT perform time
+   integration.  It only modifies forces to effect thermostatting.  Thus
+   you must use a separate time integration fix, like :doc:`fix nve
+   <fix_nve>` to actually update the velocities and positions of atoms
+   using the modified forces.  Likewise, this fix should not normally be
+   used on atoms that also have their temperature controlled by another
+   fix - e.g. by :doc:`fix nvt <fix_nh>` or :doc:`fix temp/rescale
+   <fix_temp_rescale>` commands.
 
 See the :doc:`Howto thermostat <Howto_thermostat>` doc page for
 a discussion of different ways to compute temperature and perform
@@ -154,13 +155,14 @@ the remaining thermal degrees of freedom, and the bias is added back
 in.
 
 The *damp* parameter is specified in time units and determines how
-rapidly the temperature is relaxed.  For example, a value of 100.0
-means to relax the temperature in a timespan of (roughly) 100 time
-units (tau or fmsec or psec - see the :doc:`units <units>` command).
-The damp factor can be thought of as inversely related to the
-viscosity of the solvent.  I.e. a small relaxation time implies a
-hi-viscosity solvent and vice versa.  See the discussion about gamma
-and viscosity in the documentation for the :doc:`fix viscous <fix_viscous>` command for more details.
+rapidly the temperature is relaxed.  For example, a value of 100.0 means
+to relax the temperature in a timespan of (roughly) 100 time units
+(:math:`\tau` or fs or ps - see the :doc:`units <units>` command).  The
+damp factor can be thought of as inversely related to the viscosity of
+the solvent.  I.e. a small relaxation time implies a high-viscosity
+solvent and vice versa.  See the discussion about :math:`\gamma` and
+viscosity in the documentation for the :doc:`fix viscous <fix_viscous>`
+command for more details.
 
 The random # *seed* must be a positive integer.  A Marsaglia random
 number generator is used.  Each processor uses the input seed to
@@ -191,39 +193,40 @@ The rotational temperature of the particles can be monitored by the
 :doc:`compute temp/sphere <compute_temp_sphere>` and :doc:`compute temp/asphere <compute_temp_asphere>` commands with their rotate
 options.
 
-For the *omega* keyword there is also a scale factor of 10.0/3.0 that
-is applied as a multiplier on the Ff (damping) term in the equation
-above and of sqrt(10.0/3.0) as a multiplier on the Fr term.  This does
-not affect the thermostatting behavior of the Langevin formalism but
-insures that the randomized rotational diffusivity of spherical
-particles is correct.
+For the *omega* keyword there is also a scale factor of
+:math:`\frac{10.0}{3.0}` that is applied as a multiplier on the
+:math:`F_f` (damping) term in the equation above and of
+:math:`\sqrt{\frac{10.0}{3.0}}` as a multiplier on the :math:`F_r` term.
+This does not affect the thermostatting behavior of the Langevin
+formalism but insures that the randomized rotational diffusivity of
+spherical particles is correct.
 
 For the *angmom* keyword a similar scale factor is needed which is
-10.0/3.0 for spherical particles, but is anisotropic for aspherical
-particles (e.g. ellipsoids).  Currently LAMMPS only applies an
-isotropic scale factor, and you can choose its magnitude as the
+:math:`\frac{10.0}{3.0}` for spherical particles, but is anisotropic for
+aspherical particles (e.g. ellipsoids).  Currently LAMMPS only applies
+an isotropic scale factor, and you can choose its magnitude as the
 specified value of the *angmom* keyword.  If your aspherical particles
-are (nearly) spherical than a value of 10.0/3.0 = 3.333 is a good
-choice.  If they are highly aspherical, a value of 1.0 is as good a
-choice as any, since the effects on rotational diffusivity of the
-particles will be incorrect regardless.  Note that for any reasonable
-scale factor, the thermostatting effect of the *angmom* keyword on the
-rotational temperature of the aspherical particles should still be
-valid.
+are (nearly) spherical than a value of :math:`\frac{10.0}{3.0} =
+3.\overline{3}` is a good choice.  If they are highly aspherical, a
+value of 1.0 is as good a choice as any, since the effects on rotational
+diffusivity of the particles will be incorrect regardless.  Note that
+for any reasonable scale factor, the thermostatting effect of the
+*angmom* keyword on the rotational temperature of the aspherical
+particles should still be valid.
 
 The keyword *scale* allows the damp factor to be scaled up or down by
 the specified factor for atoms of that type.  This can be useful when
 different atom types have different sizes or masses.  It can be used
 multiple times to adjust damp for several atom types.  Note that
 specifying a ratio of 2 increases the relaxation time which is
-equivalent to the solvent's viscosity acting on particles with 1/2 the
-diameter.  This is the opposite effect of scale factors used by the
-:doc:`fix viscous <fix_viscous>` command, since the damp factor in fix
-*langevin* is inversely related to the gamma factor in fix *viscous*\ .
-Also note that the damping factor in fix *langevin* includes the
-particle mass in Ff, unlike fix *viscous*\ .  Thus the mass and size of
-different atom types should be accounted for in the choice of ratio
-values.
+equivalent to the solvent's viscosity acting on particles with
+:math:`\frac{1}{2}` the diameter.  This is the opposite effect of scale
+factors used by the :doc:`fix viscous <fix_viscous>` command, since the
+damp factor in fix *langevin* is inversely related to the :math:`\gamma`
+factor in fix *viscous*\ .  Also note that the damping factor in fix
+*langevin* includes the particle mass in Ff, unlike fix *viscous*\ .
+Thus the mass and size of different atom types should be accounted for
+in the choice of ratio values.
 
 The keyword *tally* enables the calculation of the cumulative energy
 added/subtracted to the atoms as they are thermostatted.  Effectively

--- a/doc/src/fix_langevin_eff.rst
+++ b/doc/src/fix_langevin_eff.rst
@@ -41,7 +41,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    fix 3 boundary langevin/eff 1.0 1.0 10.0 699483
    fix 1 all langevin/eff 1.0 1.1 10.0 48279 scale 3 1.5
@@ -55,28 +55,31 @@ this command performs Brownian dynamics (BD), since the total force on
 each atom will have the form:
 
 
-.. parsed-literal::
+.. math::
 
-   F = Fc + Ff + Fr
-   Ff = - (m / damp) v
-   Fr is proportional to sqrt(Kb T m / (dt damp))
+   F   = & F_c + F_f + F_r \\
+   F_f = & - \frac{m}{\mathrm{damp}} v \\
+   F_r \propto &  \sqrt{\frac{k_B T m}{dt~\mathrm{damp}}}
 
-Fc is the conservative force computed via the usual inter-particle
-interactions (:doc:`pair_style <pair_style>`).
 
-The Ff and Fr terms are added by this fix on a per-particle basis.
+:math:`F_c` is the conservative force computed via the usual
+inter-particle interactions (:doc:`pair_style <pair_style>`).
+The :math:`F_f` and :math:`F_r` terms are added by this fix on a
+per-particle basis.
 
-The operation of this fix is exactly like that described by the :doc:`fix langevin <fix_langevin>` command, except that the thermostatting
-is also applied to the radial electron velocity for electron
-particles.
+The operation of this fix is exactly like that described by the
+:doc:`fix langevin <fix_langevin>` command, except that the
+thermostatting is also applied to the radial electron velocity for
+electron particles.
 
 **Restart, fix\_modify, output, run start/stop, minimize info:**
 
-No information about this fix is written to :doc:`binary restart files <restart>`.  Because the state of the random number generator
-is not saved in restart files, this means you cannot do "exact"
-restarts with this fix, where the simulation continues on the same as
-if no restart had taken place.  However, in a statistical sense, a
-restarted simulation should produce the same behavior.
+No information about this fix is written to :doc:`binary restart files
+<restart>`.  Because the state of the random number generator is not
+saved in restart files, this means you cannot do "exact" restarts with
+this fix, where the simulation continues on the same as if no restart
+had taken place.  However, in a statistical sense, a restarted
+simulation should produce the same behavior.
 
 The :doc:`fix_modify <fix_modify>` *temp* option is supported by this
 fix.  You can use it to assign a temperature :doc:`compute <compute>`

--- a/doc/src/fix_lb_fluid.rst
+++ b/doc/src/fix_lb_fluid.rst
@@ -137,7 +137,7 @@ calculated as:
 
 where :math:`\mathbf{v}_n` is the velocity of the MD particle,
 :math:`\mathbf{u}_f` is the fluid
-velocity interpolated to the particle location, and gamma is the force
+velocity interpolated to the particle location, and :math:`\gamma` is the force
 coupling constant.  :math:`\zeta` is a weight assigned to the grid point,
 obtained by distributing the particle to the nearest lattice sites.
 For this, the user has the choice between a trilinear stencil, which
@@ -163,10 +163,10 @@ t_{collision}` is a collision time, chosen such that
 :math:`\frac{\tau}{\Delta t_{collision}} = 1` (see :ref:`Mackay and
 Denniston <Mackay2>` for full details).  In order to calculate :math:`m_u`,
 the fluid density is interpolated to the MD particle location, and
-multiplied by a volume, node\_area\*dx\_lb, where node\_area
+multiplied by a volume, node\_area * :math:`dx_{LB}`, where node\_area
 represents the portion of the surface area of the composite object
 associated with a given MD particle.  By default, node\_area is set
-equal to dx\_lb\*dx\_lb; however specific values for given atom types
+equal to :math:`dx_{LB}^2`; however specific values for given atom types
 can be set using the *setArea* keyword.
 
 The user also has the option of specifying their own value for the
@@ -174,7 +174,7 @@ force coupling constant, for all the MD particles associated with the
 fix, through the use of the *setGamma* keyword.  This may be useful
 when modelling porous particles.  See :ref:`Mackay et al. <fluid-Mackay>` for a
 detailed description of the method by which the user can choose an
-appropriate gamma value.
+appropriate :math:`\gamma` value.
 
 .. note::
 
@@ -188,7 +188,9 @@ appropriate gamma value.
    used to integrate the particle motion.  However, if the user specifies
    their own value for the force coupling constant, as mentioned in
    :ref:`Mackay et al. <fluid-Mackay>`, the built-in LAMMPS integrators may prove to
-   be unstable.  Therefore, we have included our own integrators :doc:`fix lb/rigid/pc/sphere <fix_lb_rigid_pc_sphere>`, and :doc:`fix lb/pc <fix_lb_pc>`, to solve for the particle motion in these
+   be unstable.  Therefore, we have included our own integrators
+   :doc:`fix lb/rigid/pc/sphere <fix_lb_rigid_pc_sphere>`, and
+   :doc:`fix lb/pc <fix_lb_pc>`, to solve for the particle motion in these
    cases.  These integrators should not be used with the
    :doc:`lb/viscous <fix_lb_viscous>` fix, as they add hydrodynamic forces
    to the particles directly.  In addition, they can not be used if the
@@ -207,28 +209,29 @@ appropriate gamma value.
    location, in order to approximate an infinitely massive particle (see
    the dragforce test run for an example).
 
-
 ----------
 
-
 Inside the fix, parameters are scaled by the lattice-Boltzmann
-timestep, dt, grid spacing, dx, and mass unit, dm.  dt is set equal to
-(nevery\*dt\_MD), where dt\_MD is the MD timestep.  By default, dm is set
-equal to 1.0, and dx is chosen so that tau/(dt) =
-(3\*eta\*dt)/(rho\*dx\^2) is approximately equal to 1.  However, the user
-has the option of specifying their own values for dm, and dx, by using
+timestep, :math:`dt_{LB}`, grid spacing, :math:`dx_{LB}`, and mass unit,
+:math:`dm_{LB}`.  :math:`dt_{LB}` is set equal to
+:math:`\mathrm{nevery}\cdot dt_{MD}`, where :math:`dt_{MD}` is the MD timestep.
+By default,
+:math:`dm_{LB}` is set equal to 1.0, and :math:`dx_{LB}` is chosen so that
+:math:`\frac{\tau}{dt} = \frac{3\eta dt}{\rho dx^2}` is approximately equal to 1.
+However, the user has the option of specifying their own values for
+:math:`dm_{LB}`, and :math:`dx_{LB}`, by using
 the optional keywords *dm*\ , and *dx* respectively.
 
 .. note::
 
-   Care must be taken when choosing both a value for dx, and a
-   simulation domain size.  This fix uses the same subdivision of the
-   simulation domain among processors as the main LAMMPS program.  In
+   Care must be taken when choosing both a value for :math:`dx_{LB}`,
+   and a simulation domain size.  This fix uses the same subdivision of
+   the simulation domain among processors as the main LAMMPS program.  In
    order to uniformly cover the simulation domain with lattice sites, the
    lengths of the individual LAMMPS sub-domains must all be evenly
-   divisible by dx.  If the simulation domain size is cubic, with equal
-   lengths in all dimensions, and the default value for dx is used, this
-   will automatically be satisfied.
+   divisible by :math:`dx_{LB}`.  If the simulation domain size is cubic,
+   with equal lengths in all dimensions, and the default value for
+   :math:`dx_{LB}` is used, this will automatically be satisfied.
 
 Physical parameters describing the fluid are specified through
 *viscosity*\ , *density*\ , and *a0*\ . If the force coupling constant is
@@ -240,27 +243,25 @@ the mass, distance, and time units chosen for the main LAMMPS run, as
 they are scaled by the LB timestep, lattice spacing, and mass unit,
 inside the fix.
 
-
 ----------
-
 
 The *setArea* keyword allows the user to associate a surface area with
 a given atom type.  For example if a spherical composite object of
 radius R is represented as a spherical shell of N evenly distributed
 MD particles, all of the same type, the surface area per particle
-associated with that atom type should be set equal to 4\*pi\*R\^2/N.
+associated with that atom type should be set equal to :math:`\frac{4\pi R^2}{N}`.
 This keyword should only be used if the force coupling constant,
-gamma, is set the default way.
+:math:`\gamma`, is set the default way.
 
 The *setGamma* keyword allows the user to specify their own value for
-the force coupling constant, gamma, instead of using the default
+the force coupling constant, :math:`\gamma`, instead of using the default
 value.
 
 The *scaleGamma* keyword should be used in conjunction with the
-*setGamma* keyword, when the user wishes to specify different gamma
+*setGamma* keyword, when the user wishes to specify different :math:`\gamma`
 values for different atom types.  This keyword allows the user to
-scale the *setGamma* gamma value by a factor, gammaFactor, for a given
-atom type.
+scale the *setGamma* :math:`\gamma` value by a factor, gammaFactor,
+for a given atom type.
 
 The *dx* keyword allows the user to specify a value for the LB grid
 spacing.
@@ -269,9 +270,10 @@ The *dm* keyword allows the user to specify the LB mass unit.
 
 If the *a0* keyword is used, the value specified is used for the
 square of the speed of sound in the fluid.  If this keyword is not
-present, the speed of sound squared is set equal to (1/3)\*(dx/dt)\^2.
-Setting a0 > (dx/dt)\^2 is not allowed, as this may lead to
-instabilities.
+present, the speed of sound squared is set equal to
+:math:`\frac{1}{3}\left(\frac{dx_{LB}}{dt_{LB}}\right)^2`.
+Setting :math:`a0 > (\frac{dx_{LB}}{dt_{LB}})^2` is not allowed,
+as this may lead to instabilities.
 
 If the *noise* keyword is used, followed by a positive temperature
 value, and a positive integer random number seed, a thermal
@@ -388,13 +390,13 @@ By default, the force coupling constant is set according to
    \gamma = \frac{2m_um_v}{m_u+m_v}\left(\frac{1}{\Delta t_{collision}}\right)
 
 
-and an area of dx\_lb\^2 per node, used to calculate the fluid mass at
+and an area of :math:`dx_{LB}^2` per node, used to calculate the fluid mass at
 the particle node location, is assumed.
 
-dx is chosen such that tau/(delta t\_LB) =
-(3 eta dt\_LB)/(rho dx\_lb\^2) is approximately equal to 1.
-dm is set equal to 1.0.
-a0 is set equal to (1/3)\*(dx\_lb/dt\_lb)\^2.
+*dx* is chosen such that :math:`\frac{\tau}{dt_{LB}} =
+\frac{3\eta dt_{LB}}{\rho dx_{LB}^2}` is approximately equal to 1.
+*dm* is set equal to 1.0.
+*a0* is set equal to :math:`\frac{1}{3}\left(\frac{dx_{LB}}{dt_{LB}}\right)^2`.
 The Peskin stencil is used as the default interpolation method.
 The D3Q15 lattice is used for the lattice-Boltzmann algorithm.
 If walls are present, they are assumed to be stationary.

--- a/doc/src/fix_lb_fluid.rst
+++ b/doc/src/fix_lb_fluid.rst
@@ -125,9 +125,9 @@ functions,
 Full details of the lattice-Boltzmann algorithm used can be found in
 :ref:`Mackay et al. <fluid-Mackay>`.
 
-The fluid is coupled to the MD particles described by *group-ID*
-through a velocity dependent force.  The contribution to the fluid
-force on a given lattice mesh site j due to MD particle alpha is
+The fluid is coupled to the MD particles described by *group-ID* through
+a velocity dependent force.  The contribution to the fluid force on a
+given lattice mesh site j due to MD particle :math:`\alpha` is
 calculated as:
 
 .. math::

--- a/doc/src/fix_msst.rst
+++ b/doc/src/fix_msst.rst
@@ -35,7 +35,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    fix 1 all msst y 100.0 q 1.0e5 mu 1.0e5
    fix 2 all msst z 50.0 q 1.0e4 mu 1.0e4  v0 4.3419e+03 p0 3.7797e+03 e0 -9.72360e+02 tscale 0.01
@@ -101,16 +101,17 @@ timestep. To do this, the fix creates its own computes of style "temp"
 "pressure", and "pe", as if these commands had been issued:
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    compute fix-ID_MSST_temp all temp
    compute fix-ID_MSST_press all pressure fix-ID_MSST_temp
 
    compute fix-ID_MSST_pe all pe
 
-See the :doc:`compute temp <compute_temp>` and :doc:`compute pressure <compute_pressure>` commands for details.  Note that the
-IDs of the new computes are the fix-ID + "_MSST\_temp`or <MSST_press">`_
-or "_MSST\_pe".  The group for the new computes is "all".
+See the :doc:`compute temp <compute_temp>` and :doc:`compute pressure
+<compute_pressure>` commands for details.  Note that the IDs of the
+new computes are the fix-ID + "_MSST\_temp" or "MSST\_press" or
+"_MSST\_pe".  The group for the new computes is "all".
 
 
 ----------
@@ -132,9 +133,10 @@ timestepping.  DFTB+ will communicate its info to LAMMPS via that fix.
 
 **Restart, fix\_modify, output, run start/stop, minimize info:**
 
-This fix writes the state of all internal variables to :doc:`binary restart files <restart>`.  See the :doc:`read_restart <read_restart>` command
-for info on how to re-specify a fix in an input script that reads a
-restart file, so that the operation of the fix continues in an
+This fix writes the state of all internal variables to :doc:`binary
+restart files <restart>`.  See the :doc:`read_restart <read_restart>`
+command for info on how to re-specify a fix in an input script that
+reads a restart file, so that the operation of the fix continues in an
 uninterrupted fashion.
 
 The progress of the MSST can be monitored by printing the global
@@ -161,7 +163,7 @@ To print these quantities to the log file with descriptive column
 headers, the following LAMMPS commands are suggested:
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    fix              msst all msst z
    fix_modify       msst energy yes
@@ -172,15 +174,17 @@ headers, the following LAMMPS commands are suggested:
    thermo_style     custom step temp ke pe lz pzz etotal v_dhug v_dray v_lgr_vel v_lgr_pos f_msst
 
 These fixes compute a global scalar and a global vector of 4
-quantities, which can be accessed by various :doc:`output commands <Howto_output>`.  The scalar values calculated by this fix
-are "extensive"; the vector values are "intensive".
+quantities, which can be accessed by various :doc:`output commands
+<Howto_output>`.  The scalar values calculated by this fix are
+"extensive"; the vector values are "intensive".
 
 Restrictions
 """"""""""""
 
 
 This fix style is part of the SHOCK package.  It is only enabled if
-LAMMPS was built with that package. See the :doc:`Build package <Build_package>` doc page for more info.
+LAMMPS was built with that package. See the :doc:`Build package
+<Build_package>` doc page for more info.
 
 All cell dimensions must be periodic. This fix can not be used with a
 triclinic cell.  The MSST fix has been tested only for the group-ID

--- a/doc/src/fix_nve_dotc_langevin.rst
+++ b/doc/src/fix_nve_dotc_langevin.rst
@@ -29,7 +29,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    fix 1 all nve/dotc/langevin 1.0 1.0 0.03 457145 angmom 10
    fix 1 all nve/dotc/langevin 0.1 0.1 78.9375 457145 angmom 10
@@ -61,33 +61,33 @@ over the standard integrator, permitting slightly larger timestep sizes.
 The total force on each atom will have the form:
 
 
-.. parsed-literal::
+.. math::
 
-   F = Fc + Ff + Fr
-   Ff = - (m / damp) v
-   Fr is proportional to sqrt(Kb T m / (dt damp))
+   F =   & F_c + F_f + F_r \\
+   F_f = & - \frac{m}{\mathrm{damp}} v \\
+   F_r \propto & \sqrt{\frac{k_B T m}{dt~\mathrm{damp}}}
 
-Fc is the conservative force computed via the usual inter-particle
-interactions (:doc:`pair_style <pair_style>`,
-:doc:`bond_style <bond_style>`, etc).
+:math:`F_c` is the conservative force computed via the usual
+inter-particle interactions (:doc:`pair_style <pair_style>`,
+:doc:`bond_style <bond_style>`, etc). The :math:`F_f` and :math:`F_r`
+terms are implicitly taken into account by this fix on a per-particle
+basis.
 
-The Ff and Fr terms are implicitly taken into account by this fix
-on a per-particle basis.
+:math:`F_f` is a frictional drag or viscous damping term proportional to
+the particle's velocity.  The proportionality constant for each atom is
+computed as :math:`\frac{m}{\mathrm{damp}}`, where *m* is the mass of
+the particle and damp is the damping factor specified by the user.
 
-Ff is a frictional drag or viscous damping term proportional to the
-particle's velocity.  The proportionality constant for each atom is
-computed as m/damp, where m is the mass of the particle and damp is
-the damping factor specified by the user.
-
-Fr is a force due to solvent atoms at a temperature T randomly bumping
-into the particle.  As derived from the fluctuation/dissipation
-theorem, its magnitude as shown above is proportional to sqrt(Kb T m /
-dt damp), where Kb is the Boltzmann constant, T is the desired
-temperature, m is the mass of the particle, dt is the timestep size,
-and damp is the damping factor.  Random numbers are used to randomize
-the direction and magnitude of this force as described in
-:ref:`(Dunweg) <Dunweg5>`, where a uniform random number is used (instead of
-a Gaussian random number) for speed.
+:math:`F_r` is a force due to solvent atoms at a temperature *T*
+randomly bumping into the particle.  As derived from the
+fluctuation/dissipation theorem, its magnitude as shown above is
+proportional to :math:`\sqrt{\frac{k_B T m}{dt~\mathrm{damp}}}`, where
+:math:`k_B` is the Boltzmann constant, *T* is the desired temperature,
+*m* is the mass of the particle, *dt* is the timestep size, and damp is
+the damping factor.  Random numbers are used to randomize the direction
+and magnitude of this force as described in :ref:`(Dunweg) <Dunweg5>`,
+where a uniform random number is used (instead of a Gaussian random
+number) for speed.
 
 
 ----------
@@ -104,7 +104,7 @@ means to relax the temperature in a timespan of (roughly) 0.03 time
 units tau (see the :doc:`units <units>` command).
 The damp factor can be thought of as inversely related to the
 viscosity of the solvent, i.e. a small relaxation time implies a
-hi-viscosity solvent and vice versa.  See the discussion about gamma
+high-viscosity solvent and vice versa.  See the discussion about gamma
 and viscosity in the documentation for the :doc:`fix viscous <fix_viscous>` command for more details.
 Note that the value 78.9375 in the second example above corresponds
 to a diffusion constant, which is about an order of magnitude larger
@@ -124,10 +124,10 @@ particles are always considered to have a finite size.
 The keyword *angmom* enables thermostatting of the rotational degrees of
 freedom in addition to the usual translational degrees of freedom.
 
-The scale factor after the *angmom* keyword gives the ratio of the rotational to
-the translational friction coefficient.
+The scale factor after the *angmom* keyword gives the ratio of the
+rotational to the translational friction coefficient.
 
-An example input file can be found in /examples/USER/cgdna/examples/duplex2/.
+An example input file can be found in examples/USER/cgdna/examples/duplex2/.
 Further details of the implementation and stability of the integrators are contained in :ref:`(Henrich) <Henrich5>`.
 The preprint version of the article can be found `here <PDF/USER-CGDNA.pdf>`_.
 

--- a/doc/src/fix_qbmsst.rst
+++ b/doc/src/fix_qbmsst.rst
@@ -118,18 +118,18 @@ term, see :ref:`(Qi) <Qi>`, and :math:`E^{tot}_0 = e0` is the
 initial total energy.
 
 The *eta* (:math:`\eta`) parameter is a unitless coupling constant
-between the shock system and the quantum thermal bath. A small *eta*
+between the shock system and the quantum thermal bath. A small :math:`\eta`
 value cannot adjust the quantum temperature fast enough during the
-temperature ramping period of shock compression while large *eta*
-leads to big temperature oscillation. A value of *eta* between 0.3 and
+temperature ramping period of shock compression while large :math:`\eta`
+leads to big temperature oscillation. A value of :math:`\eta` between 0.3 and
 1 is usually appropriate for simulating most systems under shock
-compression. We observe that different values of *eta* lead to almost
+compression. We observe that different values of :math:`\eta` lead to almost
 the same final thermodynamic state behind the shock, as expected.
 
 The quantum temperature is updated every *beta* (:math:`\beta`) steps
-with an integration time interval *beta* times longer than the
+with an integration time interval :math:`\beta` times longer than the
 simulation time step. In that case, :math:`E^{tot}` is taken as its
-average over the past *beta* steps. The temperature of the quantum
+average over the past :math:`\beta` steps. The temperature of the quantum
 thermal bath :math:`T^{qm}` changes dynamically according to
 the following equation where :math:`\Delta_t` is the MD time step and
 :math:`\gamma` is the friction constant which is equal to the inverse

--- a/doc/src/fix_qbmsst.rst
+++ b/doc/src/fix_qbmsst.rst
@@ -45,12 +45,12 @@ Examples
    fix 1 all qbmsst z 0.122 q 25 mu 0.9 tscale 0.01 damp 200 seed 35082 f_max 0.3 N_f 100 eta 1 beta 400 T_init 110 (liquid methane modeled with the REAX force field, real units)
    fix 2 all qbmsst z 72 q 40 tscale 0.05 damp 1 seed 47508 f_max 120.0 N_f 100 eta 1.0 beta 500 T_init 300 (quartz modeled with the BKS force field, metal units)
 
-Two example input scripts are given, including shocked alpha quartz
-and shocked liquid methane. The input script first equilibrate an
-initial state with the quantum thermal bath at the target temperature
-and then apply the qbmsst to simulate shock compression with quantum
-nuclear correction.  The following two figures plot related quantities
-for shocked alpha quartz.
+Two example input scripts are given, including shocked
+:math:`\alpha-\mathrm{quartz}` and shocked liquid methane.
+The input script first equilibrate an initial state with the quantum
+thermal bath at the target temperature and then apply the qbmsst to
+simulate shock compression with quantum nuclear correction.  The
+following two figures plot related quantities for shocked alpha quartz.
 
 .. image:: JPG/qbmsst_init.jpg
    :align: center

--- a/doc/src/fix_qbmsst.rst
+++ b/doc/src/fix_qbmsst.rst
@@ -26,7 +26,7 @@ Syntax
        *v0* value = initial simulation cell volume in the shock equations (distance\^3 units)
        *e0* value = initial total energy (energy units)
        *tscale* value = reduction in initial temperature (unitless fraction between 0.0 and 1.0)
-       *damp* value = damping parameter (time units) inverse of friction <i>&gamma;</i>
+       *damp* value = damping parameter (time units) inverse of friction *gamma*
        *seed* value = random number seed (positive integer)
        *f_max* value = upper cutoff frequency of the vibration spectrum (1/time units)
        *N_f* value = number of frequency bins (positive integer)
@@ -40,44 +40,47 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
-   fix 1 all qbmsst z 0.122 q 25 mu 0.9 tscale 0.01 damp 200 seed 35082 f_max 0.3 N_f 100 eta 1 beta 400 T_init 110 (liquid methane modeled with the REAX force field, real units)
-   fix 2 all qbmsst z 72 q 40 tscale 0.05 damp 1 seed 47508 f_max 120.0 N_f 100 eta 1.0 beta 500 T_init 300 (quartz modeled with the BKS force field, metal units)
+   # (liquid methane modeled with the REAX force field, real units)
+   fix 1 all qbmsst z 0.122 q 25 mu 0.9 tscale 0.01 damp 200 seed 35082 f_max 0.3 N_f 100 eta 1 beta 400 T_init 110
+   # (quartz modeled with the BKS force field, metal units)
+   fix 2 all qbmsst z 72 q 40 tscale 0.05 damp 1 seed 47508 f_max 120.0 N_f 100 eta 1.0 beta 500 T_init 300
 
 Two example input scripts are given, including shocked
-:math:`\alpha-\mathrm{quartz}` and shocked liquid methane.
-The input script first equilibrate an initial state with the quantum
-thermal bath at the target temperature and then apply the qbmsst to
-simulate shock compression with quantum nuclear correction.  The
-following two figures plot related quantities for shocked alpha quartz.
+:math:`\alpha\textrm{-quartz}` and shocked liquid methane.  The input
+script first equilibrates an initial state with the quantum thermal
+bath at the target temperature and then applies *fix qbmsst* to simulate
+shock compression with quantum nuclear correction.  The following two
+figures plot relevant quantities for shocked
+:math:`\alpha\textrm{-quartz}`.
 
 .. image:: JPG/qbmsst_init.jpg
    :align: center
 
-Figure 1. Classical temperature <i>T</i><sup>cl</sup> = &sum;
-<i>m<sub>i</sub>v<sub>i</sub><sup>2</sup>/3Nk</i><sub>B</sub> vs. time
-for coupling the alpha quartz initial state with the quantum thermal
-bath at target quantum temperature <i>T</i><sup>qm</sup> = 300 K. The
-NpH ensemble is used for time integration while QTB provides the
-colored random force. <i>T</i><sup>cl</sup> converges at the timescale
-of *damp* which is set to be 1 ps.
+Figure 1. Classical temperature
+:math:`T_{cl} = \sum \frac{m_iv_i^2}{3Nk_B}` vs. time for coupling the
+:math:`\alpha\textrm{-quartz}` initial state with the quantum thermal
+bath at target quantum temperature :math:`T^{qm} = 300 K`. The NpH
+ensemble is used for time integration while QTB provides the colored
+random force. :math:`T^{cl}` converges at the timescale of *damp*
+which is set to be 1 ps.
 
 .. image:: JPG/qbmsst_shock.jpg
    :align: center
 
 Figure 2. Quantum temperature and pressure vs. time for simulating
-shocked alpha quartz with the QBMSST. The shock propagates along the z
-direction. Restart of the QBMSST command is demonstrated in the
-example input script. Thermodynamic quantities stay continuous before
-and after the restart.
+shocked :math:`\alpha\textrm{-quartz}` with *fix qbmsst*\. The shock
+propagates along the z direction. Restart of the *fix qbmsst* command
+is demonstrated in the example input script. Thermodynamic quantities
+stay continuous before and after the restart.
 
 Description
 """""""""""
 
 This command performs the Quantum-Bath coupled Multi-Scale Shock
 Technique (QBMSST) integration. See :ref:`(Qi) <Qi>` for a detailed
-description of this method.  The QBMSST provides description of the
+description of this method.  QBMSST provides description of the
 thermodynamics and kinetics of shock processes while incorporating
 quantum nuclear effects.  The *shockvel* setting determines the steady
 shock velocity that will be simulated along direction *dir*\ .
@@ -107,14 +110,14 @@ in the command :doc:`fix msst <fix_msst>`. The values of *e0*\ , *p0*\ , or
 parameter of *damp*\ , *f\_max*, and *N\_f* are described in the command
 :doc:`fix qtb <fix_qtb>`.
 
-The fix qbmsst command couples the shock system to a quantum thermal
+The *fix qbmsst* command couples the shock system to a quantum thermal
 bath with a rate that is proportional to the change of the total
-energy of the shock system, <i>etot</i> - <i>etot</i><sub>0</sub>.
-Here <i>etot</i> consists of both the system energy and a thermal
-term, see :ref:`(Qi) <Qi>`, and <i>etot</i><sub>0</sub> = *e0* is the
+energy of the shock system, :math:`E^{tot} - E^{tot}_0`.
+Here :math:`E^{etot}` consists of both the system energy and a thermal
+term, see :ref:`(Qi) <Qi>`, and :math:`E^{tot}_0 = e0` is the
 initial total energy.
 
-The *eta* (<i>&eta;</i>) parameter is a unitless coupling constant
+The *eta* (:math:`\eta`) parameter is a unitless coupling constant
 between the shock system and the quantum thermal bath. A small *eta*
 value cannot adjust the quantum temperature fast enough during the
 temperature ramping period of shock compression while large *eta*
@@ -123,21 +126,18 @@ leads to big temperature oscillation. A value of *eta* between 0.3 and
 compression. We observe that different values of *eta* lead to almost
 the same final thermodynamic state behind the shock, as expected.
 
-The quantum temperature is updated every *beta* (<i>&beta;</i>) steps
+The quantum temperature is updated every *beta* (:math:`\beta`) steps
 with an integration time interval *beta* times longer than the
-simulation time step. In that case, <i>etot</i> is taken as its
+simulation time step. In that case, :math:`E^{tot}` is taken as its
 average over the past *beta* steps. The temperature of the quantum
-thermal bath <i>T</i><sup>qm</sup> changes dynamically according to
-the following equation where &Delta;<i>t</i> is the MD time step and
-<i>&gamma;</i> is the friction constant which is equal to the inverse
+thermal bath :math:`T^{qm}` changes dynamically according to
+the following equation where :math:`\Delta_t` is the MD time step and
+:math:`\gamma` is the friction constant which is equal to the inverse
 of the *damp* parameter.
 
-.. raw:: html
+.. math::
 
-   <center><font size="4"> <i>dT</i><sup>qm</sup>/<i>dt =
-   &gamma;&eta;</i>&sum;<i><sup>&beta;</sup><sub>l =
-   1</sub></i>[<i>etot</i>(<i>t-l</i>&Delta;<i>t</i>)-<i>etot</i><sub>0</sub>]/<i>3&beta;Nk</i><sub>B</sub>
-   </font></center>
+   \frac{dT^{qm}}{dt} = \gamma\eta\sum^\beta_{l=1}\frac{E^{tot}(t-l\Delta t) - E^{tot}_0}{3\beta N k_B}
 
 The parameter *T\_init* is the initial temperature of the quantum
 thermal bath and the system before shock loading.
@@ -172,12 +172,12 @@ vector contains five values in this order:
 2. *drayleigh* is the departure from the Rayleigh line (pressure units).
 3. *lagrangian\_speed* is the laboratory-frame Lagrangian speed (particle velocity) of the computational cell (velocity units).
 4. *lagrangian\_position* is the computational cell position in the reference frame moving at the shock speed. This is the distance of the computational cell behind the shock front.
-5. *quantum\_temperature* is the temperature of the quantum thermal bath <i>T</i><sup>qm</sup>.
+5. *quantum\_temperature* is the temperature of the quantum thermal bath :math:`T^{qm}`.
 
 To print these quantities to the log file with descriptive column
 headers, the following LAMMPS commands are suggested. Here the
 :doc:`fix_modify <fix_modify>` energy command is also enabled to allow
-the thermo keyword *etotal* to print the quantity <i>etot</i>.  See
+the thermo keyword *etotal* to print the quantity :math:`E^{tot}`.  See
 also the :doc:`thermo_style <thermo_style>` command.
 
 
@@ -193,10 +193,11 @@ also the :doc:`thermo_style <thermo_style>` command.
    thermo_style    custom  step temp ke pe lz pzz etotal v_dhug v_dray v_lgr_vel v_lgr_pos v_T_qm f_fix_id
 
 The global scalar under the entry f\_fix\_id is the quantity of thermo
-energy as an extra part of <i>etot</i>. This global scalar and the
-vector of 5 quantities can be accessed by various :doc:`output commands <Howto_output>`. It is worth noting that the temp keyword
+energy as an extra part of :math:`E^{tot}`. This global scalar and the
+vector of 5 quantities can be accessed by various :doc:`output commands <Howto_output>`.
+It is worth noting that the temp keyword
 under the :doc:`thermo_style <thermo_style>` command print the
-instantaneous classical temperature <i>T</i><sup>cl</sup> as described
+instantaneous classical temperature :math:`T^{cl}` as described
 in the command :doc:`fix qtb <fix_qtb>`.
 
 

--- a/doc/src/fix_qtb.rst
+++ b/doc/src/fix_qtb.rst
@@ -19,7 +19,7 @@ Syntax
   .. parsed-literal::
   
        *temp* value = target quantum temperature (temperature units)
-       *damp* value = damping parameter (time units) inverse of friction <i>&gamma</i>;
+       *damp* value = damping parameter (time units) inverse of friction *gamma*
        *seed* value = random number seed (positive integer)
        *f_max* value = upper cutoff frequency of the vibration spectrum (1/time units)
        *N_f* value = number of frequency bins (positive integer)
@@ -30,12 +30,14 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
+   # (liquid methane modeled with the REAX force field, real units)
    fix 1 all nve
-   fix 1 all qtb temp 110 damp 200 seed 35082 f_max 0.3 N_f 100 (liquid methane modeled with the REAX force field, real units)
+   fix 1 all qtb temp 110 damp 200 seed 35082 f_max 0.3 N_f 100
+   # (quartz modeled with the BKS force field, metal units)
    fix 2 all nph iso 1.01325 1.01325 1
-   fix 2 all qtb temp 300 damp 1 seed 47508 f_max 120.0 N_f 100 (quartz modeled with the BKS force field, metal units)
+   fix 2 all qtb temp 300 damp 1 seed 47508 f_max 120.0 N_f 100
 
 Description
 """""""""""
@@ -56,61 +58,54 @@ atoms and thus higher classical limits.
 The equation of motion implemented by this command follows a Langevin
 form:
 
-.. raw:: html
+.. math::
 
-   <center><font size="4"><i> m<sub>i</sub>a<sub>i</sub> = f<sub>i</sub>
-   + R<sub>i</sub> -
-   m<sub>i</sub>&gamma;v<sub>i</sub>. </i></font></center>
+   m_i a_i = f_i + R_i - m_i\gamma v_i
 
-Here <i>m<sub>i</sub></i>, <i>a<sub>i</sub></i>, <i>f<sub>i</sub>
-</i>, <i>R<sub>i</sub></i>, <i>&gamma;</i> and <i>v<sub>i</sub> </i>
-represent mass, acceleration, force exerted by all other atoms, random
+Here :math:`m_i, a_i, f_i, R_i, \gamma, \textrm{and} v_i`
+represent in this order mass, acceleration, force exerted by all other atoms, random
 force, frictional coefficient (the inverse of damping parameter damp),
-and velocity. The random force <i>R<sub>i</sub></i> is "colored" so
-that any vibrational mode with frequency <i>&omega;</i> will have a
-temperature-sensitive energy <i>&theta;</i>(<i>&omega;,T</i>) which
+and velocity. The random force :math:`R_i` is "colored" so
+that any vibrational mode with frequency :math:`\omega` will have a
+temperature-sensitive energy :math:`\theta(\omega,T)` which
 resembles the energy expectation for a quantum harmonic oscillator
 with the same natural frequency:
 
-.. raw:: html
 
-   <center><font size="4"> <i>&theta;</i>(<i>&omega;,T</i>) =
-   &#8463;&omega;/2 +
-   &#8463;&omega;[</i>exp(<i>&#8463;&omega;/k</i><sub>B</sub><i>T</i>)<i>-1</i>]<i><sup>-1</sup></i>
-   </font></center>
+.. math::
+
+   \theta(\omega T) = \frac{\hbar}{2} + \hbar\omega \left[\exp(\frac{\hbar\omega}{k_B T})-1 \right]^{-1}
 
 To efficiently generate the random forces, we employ the method
 of :ref:`(Barrat) <Barrat>`, that circumvents the need to generate all
 random forces for all times before the simulation. The memory
 requirement of this approach is less demanding and independent
-of the simulation duration. Since the total random force <i>R</i><sub>tot</sub>
+of the simulation duration. Since the total random force :math:`R_{tot}`
 does not necessarily vanish for a finite number of atoms,
-<i>R<sub>i</sub></i> is replaced by <i>R<sub>i</sub></i> - <i>R</i><sub>tot</sub>/<i>N</i><sub>tot</sub>
+:math:`R_i` is replaced by :math:`R_i - \frac{R_{tot}}{N_{tot}}`
 to avoid collective motion of the system.
 
 The *temp* parameter sets the target quantum temperature. LAMMPS will
 still have an output temperature in its thermo style. That is the
-instantaneous classical temperature <i>T</i><sup>cl</sup> derived from
+instantaneous classical temperature :math:`T^{cl}` derived from
 the atom velocities at thermal equilibrium. A non-zero
-<i>T</i><sup>cl</sup> will be present even when the quantum
+:math:`T^{cl}` will be present even when the quantum
 temperature approaches zero. This is associated with zero-point energy
 at low temperatures.
 
-.. raw:: html
+.. math::
 
-   <center><font size="4"> <i>T</i><sup>cl</sup> = &sum;
-   <i>m<sub>i</sub>v<sub>i</sub><sup>2</sup>/3Nk</i><sub>B</sub>
-   </font></center>
+   T^{cl} = \sum \frac{m_i v_i^2}{3 N k_B}
 
 The *damp* parameter is specified in time units, and it equals the
-inverse of the frictional coefficient <i>&gamma;</i>. <i>&gamma;</i>
+inverse of the frictional coefficient :math:`\gamma`. :math:`\gamma`
 should be as small as possible but slightly larger than the timescale
 of anharmonic coupling in the system which is about 10 ps to 100
-ps. When <i>&gamma;</i> is too large, it gives an energy spectrum that
-differs from the desired Bose-Einstein spectrum. When <i>&gamma;</i>
+ps. When :math:`\gamma` is too large, it gives an energy spectrum that
+differs from the desired Bose-Einstein spectrum. When :math:`\gamma`
 is too small, the quantum thermal bath coupling to the system will be
 less significant than anharmonic effects, reducing to a classical
-limit. We find that setting <i>&gamma;</i> between 5 THz and 1 THz
+limit. We find that setting :math:`\gamma` between 5 THz and 1 THz
 could be appropriate depending on the system.
 
 The random number *seed* is a positive integer used to initiate a
@@ -121,23 +116,22 @@ runs on different numbers of processors.
 
 The *f\_max* parameter truncate the noise frequency domain so that
 vibrational modes with frequencies higher than *f\_max* will not be
-modulated. If we denote &Delta;<i>t</i> as the time interval for the
+modulated. If we denote :math:`\Delta t` as the time interval for the
 MD integration, *f\_max* is always reset by the code to make
-<i>&alpha;</i> = (int)(2*f\_max*&Delta;<i>t</i>)<sup><i>-1</i></sup> a
+:math:`\alpha = (int)(2` *f\_max* :math:`\Delta t)^{-1}` a
 positive integer and print out relative information. An appropriate
-value for the cutoff frequency *f\_max* would be around 2~3
-<i>f</i><sub>D</sub>, where <i>f</i><sub>D</sub> is the Debye
-frequency.
+value for the cutoff frequency *f\_max* would be around 2~3 :math:`f_D`,
+where :math:`f_D` is the Debye frequency.
 
 The *N\_f* parameter is the frequency grid size, the number of points
 from 0 to *f\_max* in the frequency domain that will be
-sampled. <i>3&times;2</i> *N\_f* per-atom random numbers are required
+sampled. 3*2\ *N\_f* per-atom random numbers are required
 in the random force generation and there could be as many atoms as in
 the whole simulation that can migrate into every individual
 processor. A larger *N\_f* provides a more accurate sampling of the
 spectrum while consumes more memory.  With fixed *f\_max* and
-<i>&gamma;</i>, *N\_f* should be big enough to converge the classical
-temperature <i>T</i><sup>cl</sup> as a function of target quantum bath
+:math:`\gamma`, *N\_f* should be big enough to converge the classical
+temperature :math:`T^{cl}` as a function of target quantum bath
 temperature. Memory usage per processor could be from 10 to 100
 Mbytes.
 
@@ -147,10 +141,12 @@ Mbytes.
    Nose/Hoover thermostatting AND time integration, this fix does NOT
    perform time integration. It only modifies forces to a colored
    thermostat. Thus you must use a separate time integration fix, like
-   :doc:`fix nve <fix_nve>` or :doc:`fix nph <fix_nh>` to actually update the
-   velocities and positions of atoms (as shown in the
-   examples). Likewise, this fix should not normally be used with other
-   fixes or commands that also specify system temperatures , e.g. :doc:`fix nvt <fix_nh>` and :doc:`fix temp/rescale <fix_temp_rescale>`.
+   :doc:`fix nve <fix_nve>` or :doc:`fix nph <fix_nh>` to actually
+   update the velocities and positions of atoms (as shown in the
+   examples). Likewise, this fix should not normally be used with
+   other fixes or commands that also specify system temperatures ,
+   e.g. :doc:`fix nvt <fix_nh>` and :doc:`fix temp/rescale
+   <fix_temp_rescale>`.
 
 
 ----------
@@ -158,10 +154,11 @@ Mbytes.
 
 **Restart, fix\_modify, output, run start/stop, minimizie info:**
 
-No information about this fix is written to :doc:`binary restart files <restart>`.  Because the state of the random number generator
-is not saved in restart files, this means you cannot do "exact"
-restarts with this fix. However, in a statistical sense, a restarted
-simulation should produce similar behaviors of the system.
+No information about this fix is written to :doc:`binary restart files
+<restart>`.  Because the state of the random number generator is not
+saved in restart files, this means you cannot do "exact" restarts with
+this fix. However, in a statistical sense, a restarted simulation
+should produce similar behaviors of the system.
 
 This fix is not invoked during :doc:`energy minimization <minimize>`.
 
@@ -174,7 +171,8 @@ Restrictions
 
 
 This fix style is part of the USER-QTB package.  It is only enabled if
-LAMMPS was built with that package. See the :doc:`Build package <Build_package>` doc page for more info.
+LAMMPS was built with that package. See the :doc:`Build package
+<Build_package>` doc page for more info.
 
 
 ----------
@@ -183,7 +181,8 @@ LAMMPS was built with that package. See the :doc:`Build package <Build_package>`
 Related commands
 """"""""""""""""
 
-:doc:`fix nve <fix_nve>`, :doc:`fix nph <fix_nh>`, :doc:`fix langevin <fix_langevin>`, :doc:`fix qbmsst <fix_qbmsst>`
+:doc:`fix nve <fix_nve>`, :doc:`fix nph <fix_nh>`,
+:doc:`fix langevin <fix_langevin>`, :doc:`fix qbmsst <fix_qbmsst>`
 
 
 ----------

--- a/doc/src/fix_srd.rst
+++ b/doc/src/fix_srd.rst
@@ -84,36 +84,37 @@ the implementation and usage of mixture systems (solute particles in
 an SRD fluid).  See the examples/srd directory for sample input
 scripts using SRD particles in both settings.
 
-This fix does 2 things:
+This fix does two things:
 
-(1) It advects the SRD particles, performing collisions between SRD
-and big particles or walls every timestep, imparting force and torque
-to the big particles.  Collisions also change the position and
-velocity of SRD particles.
+  1. It advects the SRD particles, performing collisions between SRD
+     and big particles or walls every timestep, imparting force and torque
+     to the big particles.  Collisions also change the position and
+     velocity of SRD particles.
 
-(2) It resets the velocity distribution of SRD particles via random
-rotations every N timesteps.
+  2. It resets the velocity distribution of SRD particles via random
+     rotations every N timesteps.
 
 SRD particles have a mass, temperature, characteristic timestep
-dt\_SRD, and mean free path between collisions (lamda).  The
-fundamental equation relating these 4 quantities is
+:math:`dt_{SRD}`, and mean free path between collisions
+(:math:`\lambda`).  The fundamental equation relating these 4 quantities
+is
 
 
-.. parsed-literal::
+.. math::
 
-   lamda = dt_SRD \* sqrt(Kboltz \* Tsrd / mass)
+   \lambda = dt_{SRD} \sqrt{\frac{k_B T_{SRD}}{m}}
 
-The mass of SRD particles is set by the :doc:`mass <mass>` command
-elsewhere in the input script.  The SRD timestep dt\_SRD is N times the
-step dt defined by the :doc:`timestep <timestep>` command.  Big
-particles move in the normal way via a time integration :doc:`fix <fix>`
-with a short timestep dt.  SRD particles advect with a large timestep
-dt\_SRD >= dt.
+The mass *m* of SRD particles is set by the :doc:`mass <mass>` command
+elsewhere in the input script.  The SRD timestep :math:`dt_{SRD}` is N
+times the step *dt* defined by the :doc:`timestep <timestep>` command.
+Big particles move in the normal way via a time integration :doc:`fix
+<fix>` with a short timestep dt.  SRD particles advect with a large
+timestep :math:`dt_{SRD} \ge dt`.
 
 If the *lamda* keyword is not specified, the SRD temperature
-*Tsrd* is used in the above formula to compute lamda.  If the *lamda*
-keyword is specified, then the *Tsrd* setting is ignored and the above
-equation is used to compute the SRD temperature.
+:math:`T_{SRD}` is used in the above formula to compute :math:`\lambda`.
+If the *lamda* keyword is specified, then the *Tsrd* setting is ignored
+and the above equation is used to compute the SRD temperature.
 
 The characteristic length scale for the SRD fluid is set by *hgrid*
 which is used to bin SRD particles for purposes of resetting their
@@ -121,13 +122,14 @@ velocities.  Normally hgrid is set to be 1/4 of the big particle
 diameter or smaller, to adequately resolve fluid properties around the
 big particles.
 
-Lamda cannot be smaller than 0.6 \* hgrid, else an error is generated
-(unless the *shift* keyword is used, see below).  The velocities of
-SRD particles are bounded by Vmax, which is set so that an SRD
-particle will not advect further than Dmax = 4\*lamda in dt\_SRD.  This
-means that roughly speaking, Dmax should not be larger than a big
-particle diameter, else SRDs may pass through big particles without
-colliding.  A warning is generated if this is the case.
+:math:`\lambda` cannot be smaller than 0.6 \* hgrid, else an error is
+generated (unless the *shift* keyword is used, see below).  The
+velocities of SRD particles are bounded by Vmax, which is set so that an
+SRD particle will not advect further than :math:`D_{max} = 4 \lambda` in
+:math:`dt_{SRD}`.  This means that roughly speaking, :math:`D_{max}`
+should not be larger than a big particle diameter, else SRDs may pass
+through big particles without colliding.  A warning is generated if this
+is the case.
 
 Collisions between SRD particles and big particles or walls are
 modeled as a lightweight SRD point particle hitting a heavy big
@@ -160,11 +162,12 @@ the big particles appropriately should be used.
 The *overlap* keyword should be set to *yes* if two (or more) big
 particles can ever overlap.  This depends on the pair potential
 interaction used for big-big interactions, or could be the case if
-multiple big particles are held together as rigid bodies via the :doc:`fix rigid <fix_rigid>` command.  If the *overlap* keyword is *no* and
-big particles do in fact overlap, then SRD/big collisions can generate
-an error if an SRD ends up inside two (or more) big particles at once.
-How this error is treated is determined by the *inside* keyword.
-Running with *overlap* set to *no* allows for faster collision
+multiple big particles are held together as rigid bodies via the
+:doc:`fix rigid <fix_rigid>` command.  If the *overlap* keyword is *no*
+and big particles do in fact overlap, then SRD/big collisions can
+generate an error if an SRD ends up inside two (or more) big particles
+at once.  How this error is treated is determined by the *inside*
+keyword.  Running with *overlap* set to *no* allows for faster collision
 checking, so it should only be set to *yes* if needed.
 
 The *inside* keyword determines how a collision is treated if the
@@ -258,30 +261,30 @@ warning is generated.
    reneighboring.  Note that changing the SRD bin size may alter the
    properties of the SRD fluid, such as its viscosity.
 
-The *shift* keyword determines whether the coordinates of SRD
-particles are randomly shifted when binned for purposes of rotating
-their velocities.  When no shifting is performed, SRD particles are
-binned and the velocity distribution of the set of SRD particles in
-each bin is adjusted via a rotation operator.  This is a statistically
-valid operation if SRD particles move sufficiently far between
-successive rotations.  This is determined by their mean-free path
-lamda.  If lamda is less than 0.6 of the SRD bin size, then shifting
-is required.  A shift means that all of the SRD particles are shifted
-by a vector whose coordinates are chosen randomly in the range [-1/2
-bin size, 1/2 bin size].  Note that all particles are shifted by the
-same vector.  The specified random number *shiftseed* is used to
-generate these vectors.  This operation sufficiently randomizes which
-SRD particles are in the same bin, even if lamda is small.
+The *shift* keyword determines whether the coordinates of SRD particles
+are randomly shifted when binned for purposes of rotating their
+velocities.  When no shifting is performed, SRD particles are binned and
+the velocity distribution of the set of SRD particles in each bin is
+adjusted via a rotation operator.  This is a statistically valid
+operation if SRD particles move sufficiently far between successive
+rotations.  This is determined by their mean-free path :math:`\lambda`.
+If :math:`\lambda` is less than 0.6 of the SRD bin size, then shifting
+is required.  A shift means that all of the SRD particles are shifted by
+a vector whose coordinates are chosen randomly in the range [-1/2 bin
+size, 1/2 bin size].  Note that all particles are shifted by the same
+vector.  The specified random number *shiftseed* is used to generate
+these vectors.  This operation sufficiently randomizes which SRD
+particles are in the same bin, even if :math:`lambda` is small.
 
 If the *shift* flag is set to *no*\ , then no shifting is performed, but
-bin data will be communicated if bins overlap processor boundaries.
-An error will be generated if lamda < 0.6 of the SRD bin size.  If the
-*shift* flag is set to *possible*\ , then shifting is performed only if
-lamda < 0.6 of the SRD bin size.  A warning is generated to let you
-know this is occurring.  If the *shift* flag is set to *yes* then
-shifting is performed regardless of the magnitude of lamda.  Note that
-the *shiftseed* is not used if the *shift* flag is set to *no*\ , but
-must still be specified.
+bin data will be communicated if bins overlap processor boundaries.  An
+error will be generated if :math:`\lambda < 0.6` of the SRD bin size.
+If the *shift* flag is set to *possible*\ , then shifting is performed
+only if :math:`\lambda < 0.6` of the SRD bin size.  A warning is
+generated to let you know this is occurring.  If the *shift* flag is set
+to *yes* then shifting is performed regardless of the magnitude of
+:math:`\lambda`.  Note that the *shiftseed* is not used if the *shift*
+flag is set to *no*\ , but must still be specified.
 
 Note that shifting of SRD coordinates requires extra communication,
 hence it should not normally be enabled unless required.
@@ -398,10 +401,10 @@ Related commands
 Default
 """""""
 
-The option defaults are lamda inferred from Tsrd, collision = noslip,
-overlap = no, inside = error, exact = yes, radius = 1.0, bounce = 0,
-search = hgrid, cubic = error 0.01, shift = no, tstat = no, and
-rescale = yes.
+The option defaults are: *lamda* (:math:`\lambda`) is inferred from *Tsrd*,
+collision = noslip, overlap = no, inside = error, exact = yes, radius =
+1.0, bounce = 0, search = hgrid, cubic = error 0.01, shift = no, tstat =
+no, and rescale = yes.
 
 
 ----------

--- a/doc/src/fix_viscous.rst
+++ b/doc/src/fix_viscous.rst
@@ -47,11 +47,11 @@ energy to the system), it has the effect of slowly (or rapidly)
 freezing the system; hence it can also be used as a simple energy
 minimization technique.
 
-The damping force F is given by F = - gamma \* velocity.  The larger
-the coefficient, the faster the kinetic energy is reduced.  If the
-optional keyword *scale* is used, gamma can scaled up or down by the
-specified factor for atoms of that type.  It can be used multiple
-times to adjust gamma for several atom types.
+The damping force :math:`F_i` is given by :math:`F_i = - \gamma v_i`.
+The larger the coefficient, the faster the kinetic energy is reduced.
+If the optional keyword *scale* is used, :math:`\gamma` can scaled up or
+down by the specified factor for atoms of that type.  It can be used
+multiple times to adjust :math:`\gamma` for several atom types.
 
 .. note::
 
@@ -60,38 +60,40 @@ times to adjust gamma for several atom types.
    :doc:`units <units>` options like "real" or "metal" that are not
    self-consistent.
 
-In a Brownian dynamics context, gamma = Kb T / D, where Kb =
-Boltzmann's constant, T = temperature, and D = particle diffusion
-coefficient.  D can be written as Kb T / (3 pi eta d), where eta =
-dynamic viscosity of the frictional fluid and d = diameter of
-particle.  This means gamma = 3 pi eta d, and thus is proportional to
-the viscosity of the fluid and the particle diameter.
+In a Brownian dynamics context, :math:`\gamma = \frac{k_B T}{D}`, where
+:math:`k_B =` Boltzmann's constant, *T* = temperature, and *D* = particle
+diffusion coefficient.  *D* can be written as :math:`\frac{k_B T}{3 \pi
+\eta d}`, where :math:`\eta =` dynamic viscosity of the frictional fluid
+and d = diameter of particle.  This means :math:`\gamma = 3 \pi \eta d`,
+and thus is proportional to the viscosity of the fluid and the particle
+diameter.
 
 In the current implementation, rather than have the user specify a
-viscosity, gamma is specified directly in force/velocity units.  If
-needed, gamma can be adjusted for atoms of different sizes
-(i.e. sigma) by using the *scale* keyword.
+viscosity, :math:`\gamma` is specified directly in force/velocity units.
+If needed, :math:`\gamma` can be adjusted for atoms of different sizes
+(i.e. :math:`\sigma`) by using the *scale* keyword.
 
 Note that Brownian dynamics models also typically include a randomized
-force term to thermostat the system at a chosen temperature.  The :doc:`fix langevin <fix_langevin>` command does this.  It has the same
+force term to thermostat the system at a chosen temperature.  The
+:doc:`fix langevin <fix_langevin>` command does this.  It has the same
 viscous damping term as fix viscous and adds a random force to each
-atom.  The random force term is proportional to the sqrt of the chosen
-thermostatting temperature.  Thus if you use fix langevin with a
-target T = 0, its random force term is zero, and you are essentially
-performing the same operation as fix viscous.  Also note that the
-gamma of fix viscous is related to the damping parameter of :doc:`fix langevin <fix_langevin>`, however the former is specified in units
-of force/velocity and the latter in units of time, so that it can more
-easily be used as a thermostat.
-
+atom.  The random force term is proportional to the square root of the
+chosen thermostatting temperature.  Thus if you use fix langevin with a
+target :math:`T = 0`, its random force term is zero, and you are
+essentially performing the same operation as fix viscous.  Also note
+that the gamma of fix viscous is related to the damping parameter of
+:doc:`fix langevin <fix_langevin>`, however the former is specified in
+units of force/velocity and the latter in units of time, so that it can
+more easily be used as a thermostat.
 
 ----------
 
-
 **Restart, fix\_modify, output, run start/stop, minimize info:**
 
-No information about this fix is written to :doc:`binary restart files <restart>`.  None of the :doc:`fix_modify <fix_modify>` options
-are relevant to this fix.  No global or per-atom quantities are stored
-by this fix for access by various :doc:`output commands <Howto_output>`.
+No information about this fix is written to :doc:`binary restart files
+<restart>`.  None of the :doc:`fix_modify <fix_modify>` options are
+relevant to this fix.  No global or per-atom quantities are stored by
+this fix for access by various :doc:`output commands <Howto_output>`.
 No parameter of this fix can be used with the *start/stop* keywords of
 the :doc:`run <run>` command.
 

--- a/doc/src/fix_wall.rst
+++ b/doc/src/fix_wall.rst
@@ -158,7 +158,7 @@ For style *wall/morse*\ , the energy E is given by a Morse potential:
 
 
 In all cases, *r* is the distance from the particle to the wall at
-position *coord*\ , and Rc is the *cutoff* distance at which the
+position *coord*\ , and :math:`r_c` is the *cutoff* distance at which the
 particle and wall no longer interact.  The energy of the wall
 potential is shifted so that the wall-particle interaction energy is
 0.0 at the cutoff distance.
@@ -185,10 +185,10 @@ box parameters and timestep and elapsed time.  Thus it is easy to
 specify a time-dependent wall position.  See examples below.
 
 For the *wall/lj93* and *wall/lj126* and *wall/lj1043* styles,
-*epsilon* and *sigma* are the usual Lennard-Jones parameters, which
+:math:`\epsilon` and :math:`\sigma` are the usual Lennard-Jones parameters, which
 determine the strength and size of the particle as it interacts with
-the wall.  Epsilon has energy units.  Note that this *epsilon* and
-*sigma* may be different than any *epsilon* or *sigma* values defined
+the wall.  Epsilon has energy units.  Note that this :math:`\epsilon` and
+:math:`\sigma` may be different than any :math:`\epsilon` or :math:`\sigma` values defined
 for a pair style that computes particle-particle interactions.
 
 The *wall/lj93* interaction is derived by integrating over a 3d
@@ -197,39 +197,39 @@ interaction is effectively a harder, more repulsive wall interaction.
 The *wall/lj1043* interaction is yet a different form of wall
 interaction, described in Magda et al in :ref:`(Magda) <Magda>`.
 
-For the *wall/colloid* style, *R* is the radius of the colloid
-particle, *D* is the distance from the surface of the colloid particle
-to the wall (r-R), and *sigma* is the size of a constituent LJ
-particle inside the colloid particle and wall.  Note that the cutoff
-distance Rc in this case is the distance from the colloid particle
-center to the wall.  The prefactor *epsilon* can be thought of as an
-effective Hamaker constant with energy units for the strength of the
-colloid-wall interaction.  More specifically, the *epsilon* pre-factor
-= 4 \* pi\^2 \* rho\_wall \* rho\_colloid \* epsilon \* sigma\^6, where epsilon
-and sigma are the LJ parameters for the constituent LJ
-particles. Rho\_wall and rho\_colloid are the number density of the
-constituent particles, in the wall and colloid respectively, in units
-of 1/volume.
+For the *wall/colloid* style, *R* is the radius of the colloid particle,
+*D* is the distance from the surface of the colloid particle to the wall
+(r-R), and :math:`\sigma` is the size of a constituent LJ particle
+inside the colloid particle and wall.  Note that the cutoff distance Rc
+in this case is the distance from the colloid particle center to the
+wall.  The prefactor :math:`\epsilon` can be thought of as an effective
+Hamaker constant with energy units for the strength of the colloid-wall
+interaction.  More specifically, the :math:`\epsilon` pre-factor is
+:math:`4\pi^2 \rho_{wall} \rho_{colloid} \epsilon \sigma^6`, where
+:math:`\epsilon` and :math:`\sigma` are the LJ parameters for the
+constituent LJ particles. :math:`\rho_{wall}` and :math:`\rho_{colloid}`
+are the number density of the constituent particles, in the wall and
+colloid respectively, in units of 1/volume.
 
 The *wall/colloid* interaction is derived by integrating over
-constituent LJ particles of size *sigma* within the colloid particle
-and a 3d half-lattice of Lennard-Jones 12/6 particles of size *sigma*
+constituent LJ particles of size :math:`\sigma` within the colloid particle
+and a 3d half-lattice of Lennard-Jones 12/6 particles of size :math:`\sigma`
 in the wall.  As mentioned in the preceding paragraph, the density of
 particles in the wall and colloid can be different, as specified by
-the *epsilon* pre-factor.
+the :math:`\epsilon` pre-factor.
 
-For the *wall/harmonic* style, *epsilon* is effectively the spring
+For the *wall/harmonic* style, :math:`\epsilon` is effectively the spring
 constant K, and has units (energy/distance\^2).  The input parameter
-*sigma* is ignored.  The minimum energy position of the harmonic
+:math:`\sigma` is ignored.  The minimum energy position of the harmonic
 spring is at the *cutoff*\ .  This is a repulsive-only spring since the
 interaction is truncated at the *cutoff*
 
 For the *wall/morse* style, the three parameters are in this order:
-*D\_0* the depth of the potential, *alpha* the width parameter, and
-*r\_0* the location of the minimum.  *D\_0* has energy units, *alpha*
-inverse distance units, and *r\_0* distance units.
+:math:`D_0` the depth of the potential, :math:`\alpha` the width parameter, and
+:math:`r_0` the location of the minimum.  :math:`D_0` has energy units, :math:`\alpha`
+inverse distance units, and :math:`r_0` distance units.
 
-For any wall, the *epsilon* and/or *sigma* and/or *alpha* parameter can
+For any wall, the :math:`\epsilon` and/or :math:`\sigma` and/or :math:`\alpha` parameter can
 be specified
 as an :doc:`equal-style variable <variable>`, in which case it should be
 specified as v\_name, where name is the variable name.  As with a
@@ -253,7 +253,7 @@ time.  Thus it is easy to specify a time-dependent wall interaction.
    the finite-size particles of radius R must be a distance larger than R
    from the wall position *coord*\ .  The *harmonic* style is a softer
    potential and does not blow up as r -> 0, but you must use a large
-   enough *epsilon* that particles always reamin on the correct side of
+   enough :math:`\epsilon` that particles always reamin on the correct side of
    the wall (r > 0).
 
 The *units* keyword determines the meaning of the distance units used

--- a/doc/src/kspace_style.rst
+++ b/doc/src/kspace_style.rst
@@ -229,7 +229,7 @@ parameters and how to choose them is described in
 
    All of the PPPM styles can be used with single-precision FFTs by
    using the compiler switch -DFFT\_SINGLE for the FFT\_INC setting in your
-   lo-level Makefile.  This setting also changes some of the PPPM
+   low-level Makefile.  This setting also changes some of the PPPM
    operations (e.g. mapping charge to mesh and interpolating electric
    fields to particles) to be performed in single precision.  This option
    can speed-up long-range calculations, particularly in parallel or on
@@ -397,7 +397,7 @@ produce the same results, except for round-off and precision issues.
 More specifically, the *pppm/gpu* style performs charge assignment and
 force interpolation calculations on the GPU.  These processes are
 performed either in single or double precision, depending on whether
-the -DFFT\_SINGLE setting was specified in your lo-level Makefile, as
+the -DFFT\_SINGLE setting was specified in your low-level Makefile, as
 discussed above.  The FFTs themselves are still calculated on the CPU.
 If *pppm/gpu* is used with a GPU-enabled pair style, part of the PPPM
 calculation can be performed concurrently on the GPU while other

--- a/doc/src/pair_buck6d_coul_gauss.rst
+++ b/doc/src/pair_buck6d_coul_gauss.rst
@@ -87,9 +87,9 @@ is thus evaluated as:
 
 where C is an energy-conversion constant, :math:`q_i` and :math:`q_j`
 are the charges on the 2 atoms, epsilon is the dielectric constant which
-can be set by the :doc:`dielectric <dielectric>` command, alpha is ion
-pair dependent damping parameter and erf() is the error-function.  The
-cutoff Rc truncates the interaction distance.
+can be set by the :doc:`dielectric <dielectric>` command, :math:`\alpha`
+is the ion pair dependent damping parameter and erf() is the
+error-function.  The cutoff :math:`r_c` truncates the interaction distance.
 
 The style *buck6d/coul/gauss/dsf* computes the Coulomb interaction
 via the damped shifted force model described in :ref:`(Fennell) <Fennell>`

--- a/doc/src/pair_comb.rst
+++ b/doc/src/pair_comb.rst
@@ -45,8 +45,8 @@ Description
 Style *comb* computes the second-generation variable charge COMB
 (Charge-Optimized Many-Body) potential.  Style *comb3* computes the
 third-generation COMB potential.  These COMB potentials are described
-in :ref:`(COMB) <COMB>` and :ref:`(COMB3) <COMB3>`.  Briefly, the total energy
-*E<sub>T</sub>* of a system of atoms is given by
+in :ref:`(COMB) <COMB>` and :ref:`(COMB3) <COMB3>`.  Briefly, the
+total energy :math:`E_T` of a system of atoms is given by
 
 .. math::
 

--- a/doc/src/pair_coul.rst
+++ b/doc/src/pair_coul.rst
@@ -207,7 +207,7 @@ manipulation of adding and subtracting a self term (for i = j) to the
 first and second term on the right-hand-side, respectively, and a
 small enough :math:`\alpha` damping parameter, the second term shrinks and
 the potential becomes a rapidly-converging real-space summation.  With
-a long enough cutoff and small enough alpha parameter, the energy and
+a long enough cutoff and small enough :math:`\alpha` parameter, the energy and
 forces calculated by the Wolf summation method approach those of the
 Ewald sum.  So it is a means of getting effective long-range
 interactions with a short-range potential.

--- a/doc/src/pair_edip.rst
+++ b/doc/src/pair_edip.rst
@@ -88,14 +88,14 @@ and three-body coefficients in the formula above:
 * B (distance units)
 * cutoffA (distance units)
 * cutoffC (distance units)
-* alpha
-* beta
-* eta
-* gamma (distance units)
-* lambda (energy units)
-* mu
-* tho
-* sigma (distance units)
+* :math:`\alpha`
+* :math:`\beta`
+* :math:`\eta`
+* :math:`\gamma` (distance units)
+* :math:`lambda` (energy units)
+* :math:`\mu`
+* :math:`\tau`
+* :math:`\sigma` (distance units)
 * Q0
 * u1
 * u2

--- a/doc/src/pair_line_lj.rst
+++ b/doc/src/pair_line_lj.rst
@@ -28,13 +28,13 @@ Description
 """""""""""
 
 Style *line/lj* treats particles which are line segments as a set of
-small spherical particles that tile the line segment length as
-explained below.  Interactions between two line segments, each with N1
-and N2 spherical particles, are calculated as the pairwise sum of
-N1\*N2 Lennard-Jones interactions.  Interactions between a line segment
-with N spherical particles and a point particle are treated as the
-pairwise sum of N Lennard-Jones interactions.  See the :doc:`pair_style lj/cut <pair_lj>` doc page for the definition of Lennard-Jones
-interactions.
+small spherical particles that tile the line segment length as explained
+below.  Interactions between two line segments, each with N1 and N2
+spherical particles, are calculated as the pairwise sum of N1\*N2
+Lennard-Jones interactions.  Interactions between a line segment with N
+spherical particles and a point particle are treated as the pairwise sum
+of N Lennard-Jones interactions.  See the :doc:`pair_style lj/cut
+<pair_lj>` doc page for the definition of Lennard-Jones interactions.
 
 The set of non-overlapping spherical sub-particles that represent a
 line segment are generated in the following manner.  Their size is a
@@ -50,10 +50,10 @@ each pair of points.
 
 The LJ interaction between 2 spheres on different line segments (or a
 sphere on a line segment and a point particles) is computed with
-sub-particle epsilon, sigma, and cutoff values that are set by the
-pair\_coeff command, as described below.  If the distance between the 2
-spheres is greater than the sub-particle cutoff, there is no
-interaction.  This means that some pairs of sub-particles on 2 line
+sub-particle :math:`\epsilon`, :math:`\sigma`, and *cutoff* values that
+are set by the pair\_coeff command, as described below.  If the distance
+between the 2 spheres is greater than the sub-particle cutoff, there is
+no interaction.  This means that some pairs of sub-particles on 2 line
 segments may interact, but others may not.
 
 For purposes of creating the neighbor list for pairs of interacting
@@ -86,8 +86,8 @@ commands:
 
 * sizeI (distance units)
 * sizeJ (distance units)
-* epsilon (energy units)
-* sigma (distance units)
+* :math:`\epsilon` (energy units)
+* :math:`\sigma` (distance units)
 * subcutoff (distance units)
 * cutoff (distance units)
 
@@ -102,11 +102,11 @@ sizeI will apply to all segments of type I.  If typeI or typeJ refers
 to point particles, the corresponding sizeI or sizeJ is ignored; it
 can be set to 0.0.
 
-The *epsilon*\ , *sigma*\ , and *subcutoff* coefficients are used to
-compute an LJ interactions between a pair of sub-particles on 2 line
-segments (of type I and J), or between a sub particle/point particle
-pair.  As discussed above, the *subcutoff* and *cutoff* params are
-different.  The latter is only used for building the neighbor list
+The :math:`\epsilon`, :math:`\sigma`, and *subcutoff* coefficients are
+used to compute an LJ interactions between a pair of sub-particles on 2
+line segments (of type I and J), or between a sub particle/point
+particle pair.  As discussed above, the *subcutoff* and *cutoff* params
+are different.  The latter is only used for building the neighbor list
 when the distance between centers of two line segments or one segment
 and a point particle is calculated.
 

--- a/doc/src/pair_lj.rst
+++ b/doc/src/pair_lj.rst
@@ -295,7 +295,7 @@ a self term (for i = j) to the first and second term on the
 right-hand-side, respectively, and a small enough :math:`\alpha` damping
 parameter, the second term shrinks and the potential becomes a
 rapidly-converging real-space summation.  With a long enough cutoff and
-small enough alpha parameter, the energy and forces calculated by the
+small enough :math:`\alpha` parameter, the energy and forces calculated by the
 Wolf summation method approach those of the Ewald sum.  So it is a means
 of getting effective long-range interactions with a short-range
 potential.

--- a/doc/src/pair_local_density.rst
+++ b/doc/src/pair_local_density.rst
@@ -128,7 +128,7 @@ where :math:`\alpha` gives the type of atom *i*\ , :math:`\beta` the
 type of atom *j*\ , and the coefficients *a* and *b* filter for atom
 types as specified by the user. *a* is called the central atom filter as
 it determines to which atoms the potential applies; :math:`a_{\alpha} =
-1` if the LD potential applies to atom type alpha else zero. On the
+1` if the LD potential applies to atom type :math:`\alpha` else zero. On the
 other hand, *b* is called the neighbor atom filter because it specifies
 which atom types to use in the calculation of the LD; :math:`b_{\beta} =
 1` if atom type :math:`\beta` contributes to the LD and zero otherwise.
@@ -210,12 +210,15 @@ and potential.  In general, blank lines anywhere are ignored.
 ----------
 
 **Mixing, shift, table, tail correction, restart, info**\ :
-This pair style does not support automatic mixing. For atom type pairs alpha,
-beta and alpha != beta, even if LD potentials of type (alpha, alpha) and 
-(beta, beta) are provided, you will need to explicitly provide LD potential 
-types (alpha, beta) and (beta, alpha) if need be (Here, the notation (alpha,
-beta) means that alpha is the central atom to which the LD potential is applied
-and beta is the neighbor atom which contributes to the LD potential on alpha).
+This pair style does not support automatic mixing. For atom type pairs
+:math:`\alpha`, :math:`\beta` and :math:`\alpha` != :math:`\beta`, even
+if LD potentials of type (:math:`\alpha`, :math:`\alpha`) and
+(:math:`\beta`, :math:`\beta`) are provided, you will need to explicitly
+provide LD potential types (:math:`\alpha`, :math:`\beta`) and
+(:math:`\beta`, :math:`\alpha`) if need be (Here, the notation
+(:math:`\alpha`, :math:`\beta`) means that :math:`\alpha` is the central
+atom to which the LD potential is applied and :math:`\beta` is the
+neighbor atom which contributes to the LD potential on :math:`\alpha`).
 
 This pair style does not support the :doc:`pair_modify <pair_modify>`
 shift, table, and tail options.

--- a/doc/src/pair_modify.rst
+++ b/doc/src/pair_modify.rst
@@ -90,30 +90,29 @@ See the doc page for individual pair styles for those restrictions.  Note also t
 coefficients for a specific I != J pairing, in which case no mixing is
 performed.
 
-mix *geometric*
+- mix *geometric*
 
 
-.. parsed-literal::
+  .. math::
 
-   epsilon_ij = sqrt(epsilon_i \* epsilon_j)
-   sigma_ij = sqrt(sigma_i \* sigma_j)
+     \epsilon_{ij} = & \sqrt{\epsilon_i  \epsilon_j} \\
+     \sigma_{ij}   = & \sqrt{\sigma_i  \sigma_j}
 
-mix *arithmetic*
-
-
-.. parsed-literal::
-
-   epsilon_ij = sqrt(epsilon_i \* epsilon_j)
-   sigma_ij = (sigma_i + sigma_j) / 2
-
-mix *sixthpower*
+- mix *arithmetic*
 
 
-.. parsed-literal::
+  .. math::
 
-   epsilon_ij = (2 \* sqrt(epsilon_i\*epsilon_j) \* sigma_i\^3 \* sigma_j\^3) /
-                (sigma_i\^6 + sigma_j\^6)
-   sigma_ij = ((sigma_i\*\*6 + sigma_j\*\*6) / 2) \^ (1/6)
+    \epsilon_{ij} = & \sqrt{\epsilon_i  \epsilon_j} \\
+    \sigma_{ij}   = & \frac{1}{2} (\sigma_i + \sigma_j)
+
+- mix *sixthpower*
+
+
+  .. math::
+
+    \epsilon_{ij} = & \frac{2 \sqrt{\epsilon_i \epsilon_j} \sigma_i^3 \sigma_j^3}{\sigma_i^6 + \sigma_j^6} \\
+    \sigma_{ij} =   & \left(\frac{1}{2} (\sigma_i^6 + \sigma_j^6) \right)^{\frac{1}{6}}
 
 The *shift* keyword determines whether a Lennard-Jones potential is
 shifted at its cutoff to 0.0.  If so, this adds an energy term to each

--- a/doc/src/pair_morse.rst
+++ b/doc/src/pair_morse.rst
@@ -70,9 +70,9 @@ above, or in the data file or restart files read by the
 :doc:`read_data <read_data>` or :doc:`read_restart <read_restart>`
 commands:
 
-* D0 (energy units)
-* alpha (1/distance units)
-* r0 (distance units)
+* :math:`D_0` (energy units)
+* :math:`\alpha` (1/distance units)
+* :math:`r_0` (distance units)
 * cutoff (distance units)
 
 The last coefficient is optional.  If not specified, the global morse

--- a/doc/src/pair_peri.rst
+++ b/doc/src/pair_peri.rst
@@ -91,11 +91,11 @@ For the *peri/pmb* style:
 * c (energy/distance/volume\^2 units)
 * horizon (distance units)
 * s00 (unitless)
-* alpha (unitless)
+* :math:`\alpha` (unitless)
 
 C is the effectively a spring constant for Peridynamic bonds, the
 horizon is a cutoff distance for truncating interactions, and s00 and
-alpha are used as a bond breaking criteria.  The units of c are such
+:math:`\alpha` are used as a bond breaking criteria.  The units of c are such
 that c/distance = stiffness/volume\^2, where stiffness is
 energy/distance\^2 and volume is distance\^3.  See the users guide for
 more details.
@@ -106,10 +106,10 @@ For the *peri/lps* style:
 * G (force/area units)
 * horizon (distance units)
 * s00 (unitless)
-* alpha (unitless)
+* :math:`\alpha` (unitless)
 
 K is the bulk modulus and G is the shear modulus.  The horizon is a
-cutoff distance for truncating interactions, and s00 and alpha are
+cutoff distance for truncating interactions, and s00 and :math:`\alpha` are
 used as a bond breaking criteria. See the users guide for more
 details.
 
@@ -119,12 +119,12 @@ For the *peri/ves* style:
 * G (force/area units)
 * horizon (distance units)
 * s00 (unitless)
-* alpha (unitless)
+* :math:`\alpha` (unitless)
 * m\_lambdai (unitless)
 * m\_taubi (unitless)
 
 K is the bulk modulus and G is the shear modulus. The horizon is a
-cutoff distance for truncating interactions, and s00 and alpha are
+cutoff distance for truncating interactions, and s00 and :math:`\alpha` are
 used as a bond breaking criteria. m\_lambdai and m\_taubi are the
 viscoelastic relaxation parameter and time constant,
 respectively. m\_lambdai varies within zero to one. For very small
@@ -138,11 +138,11 @@ For the *peri/eps* style:
 * G (force/area units)
 * horizon (distance units)
 * s00 (unitless)
-* alpha (unitless)
+* :math:`\alpha` (unitless)
 * m\_yield\_stress (force/area units)
 
 K is the bulk modulus and G is the shear modulus. The horizon is a
-cutoff distance and s00 and alpha are used as a bond breaking
+cutoff distance and s00 and :math:`\alpha` are used as a bond breaking
 criteria.  m\_yield\_stress is the yield stress of the material. For
 details please see the description in "(Mtchell2011a)".
 

--- a/doc/src/pair_smtbq.rst
+++ b/doc/src/pair_smtbq.rst
@@ -47,13 +47,13 @@ smooth convergence to zero interaction.
 
 The parameters appearing in the upper expressions are set in the
 ffield.SMTBQ.Syst file where Syst corresponds to the selected system
-(e.g. field.SMTBQ.Al2O3). Examples for TiO2,
-Al2O3 are provided.  A single pair\_coeff command
+(e.g. field.SMTBQ.Al2O3). Examples for :math:`\mathrm{TiO_2}`,
+:math:`\mathrm{Al_2O_3}` are provided.  A single pair\_coeff command
 is used with the SMTBQ styles which provides the path to the potential
 file with parameters for needed elements. These are mapped to LAMMPS
 atom types by specifying additional arguments after the potential
 filename in the pair\_coeff command. Note that atom type 1 must always
-correspond to oxygen atoms. As an example, to simulate a TiO2 system,
+correspond to oxygen atoms. As an example, to simulate a :math:`\mathrm{TiO_2}` system,
 atom type 1 has to be oxygen and atom type 2 Ti. The following
 pair\_coeff command should then be used:
 
@@ -76,7 +76,7 @@ Interaction between oxygen, :math:`E_{OO}`, consists of two parts,
 an attractive and a repulsive part. The attractive part is effective
 only at short range (< :math:`r_2^{OO}`). The attractive
 contribution was optimized to study surfaces reconstruction
-(e.g. :ref:`SMTB-Q\_2 <SMTB-Q_2>` in TiO2) and is not necessary
+(e.g. :ref:`SMTB-Q\_2 <SMTB-Q_2>` in :math:`\mathrm{TiO_2}`) and is not necessary
 for oxide bulk modeling. The repulsive part is the Pauli interaction
 between the electron clouds of oxygen. The Pauli repulsion and the
 coulombic electrostatic interaction have same cut off value. In the
@@ -99,7 +99,7 @@ ffield.SMTBQ.Syst. The energy band term is given by:
    \delta Q_i & =  | Q_i^{F} | - | Q_i |
 
 
-where :math:\eta_i` is the stoichiometry of atom *i*\ ,
+where :math:`\eta_i` is the stoichiometry of atom *i*\ ,
 :math:`\delta Q_i` is the charge delocalization of atom *i*\ ,
 compared to its formal charge
 :math:`Q^F_i`. :math:`n_0`, the number of hybridized
@@ -118,7 +118,7 @@ two visions is explained in appendix A of the article in the
 SrTiO3 :ref:`SMTB-Q\_3 <SMTB-Q_3>` (parameter :math:`\beta` shown in
 this article is in fact the :math:`\beta_O`). To summarize the
 relationship between the hopping integral :math:`\xi^O`  and the
-others, we have in an oxide CnOm the following
+others, we have in an oxide :math:`\mathrm{C_n O_m}` the following
 relationship:
 
 .. math::
@@ -127,7 +127,7 @@ relationship:
    \frac{\beta_O}{\sqrt{m}} & = \frac{\beta_C}{\sqrt{n}} = \xi^0 \frac{\sqrt{m}+\sqrt{n}}{2}
 
 
-Thus parameter :math:`\mu`, indicated above, is given by :math:`\mu = (\sqrt{n} + \sqrt{m}) / 2`
+Thus parameter :math:`\mu`, indicated above, is given by :math:`\mu = \frac{1}{2}(\sqrt{n}+\sqrt{m})`
 
 The potential offers the possibility to consider the polarizability of
 the electron clouds of oxygen by changing the slater radius of the
@@ -158,7 +158,7 @@ quotation marks ('').
 1) Number of different element in the oxide:
 
 * N_elem= 2 or 3
-* Dividing line
+* Divider line
 
 2) Atomic parameters
 
@@ -166,67 +166,110 @@ For the anion (oxygen)
 
 * Name of element (char) and stoichiometry in oxide
 * Formal charge and mass of element
-* Principal quantum number of outer orbital n), electronegativity (:math:`\xi^0_i`) and hardness (:math:`J^0_i`)
+* Principal quantum number of outer orbital n), electronegativity (:math:`\chi^0_i`) and hardness (:math:`J^0_i`)
 * Ionic radius parameters  : max coordination number (\ *coordBB* = 6 by default), bulk coordination number *(coordB)*\ , surface coordination number  *(coordS)* and *rBB, rB and rS*  the slater radius for each coordination number. (**note : If you don't want to change the slater radius, use three identical radius values**)
 * Number of orbital shared by the element in the oxide (:math:`d_i`)
-* Dividing line
+* Divider line
 
 For each cations (metal):
 
 * Name of element (char) and stoichiometry in oxide
 * Formal charge and mass of element
-* Number of electron in outer orbital *(ne)*\ , electronegativity (\ *&#967<sup>0</sup><sub>i</simulationub>*\ ), hardness (\ *J<sup>0</sup><sub>i</sub>*\ ) and *r<sub>Salter</sub>* the slater radius for the cation.
-* Number of orbitals shared by the elements in the oxide (\ *d<sub>i</sub>*\ )
-* Dividing line
+* Number of electron in outer orbital *(ne)*\ , electronegativity (:math:`\chi^0_i`), hardness (:math:`J^0_i`) and :math:`r_{Slater}` the slater radius for the cation.
+* Number of orbitals shared by the elements in the oxide (:math:`d_i`)
+* Divider line
 
 3) Potential parameters:
 
-* Keyword for element1, element2 and interaction potential ('second\_moment' or 'buck' or 'buckPlusAttr') between element 1 and 2.  If the potential is 'second\_moment', specify 'oxide' or 'metal' for metal-oxygen or metal-metal interactions respectively.
-* Potential parameter: <pre><br/> If type of potential is 'second\_moment' : *A (eV)*\ , *p*\ , *&#958<sup>0</sup>* (eV) and *q* <br/> *r<sub>c1</sub>* (&#197), *r<sub>c2</sub>* (&#197) and *r<sub>0</sub>* (&#197) <br/> If type of potential is 'buck' : *C* (eV) and *&#961* (&#197) <br/> If type of potential is 'buckPlusAttr' : *C* (eV) and *&#961* (&#197) <br/> *D* (eV), *B* (&#197<sup>-1</sup>), *r<sub>1</sub><sup>OO</sup>* (&#197) and *r<sub>2</sub><sup>OO</sup>* (&#197) </pre>
-* Dividing line
+* Keyword for element1, element2 and interaction potential
+  ('second\_moment' or 'buck' or 'buckPlusAttr') between element 1
+  and 2.  If the potential is 'second\_moment', specify 'oxide' or
+  'metal' for metal-oxygen or metal-metal interactions respectively.
+* Potential parameter:
+
+  - If type of potential is 'second\_moment' : A (eV), *p*,
+    :math:`\zeta^0` (eV) and *q*, :math:`r_{c1} (\mathrm{\mathring{A}})`, :math:`r_{c2}
+    (\mathrm{\mathring{A}})` and :math:`r_0 (\mathrm{\mathring{A}})`
+  - If type of potential is 'buck' : *C* (eV) and :math:`\rho (\mathrm{\mathring{A}})`
+  - If type of potential is 'buckPlusAttr' : *C* (eV) and :math:`\rho
+    (\mathrm{\mathring{A}})` *D* (eV), *B* :math:`(\mathrm{\mathring{A}}^{-1})`, :math:`r^{OO}_1 (\mathrm{\mathring{A}})` and
+    :math:`r^{OO}_2 (\mathrm{\mathring{A}})`
+* Divider line
 
 4) Tables parameters:
 
-* Cutoff radius for the Coulomb interaction (\ *R<sub>coul</sub>*\ )
-* Starting radius  (\ *r<sub>min</sub>* = 1,18845 &#197) and increments (\ *dr* = 0,001 &#197) for creating the potential table.
-* Dividing line
+* Cutoff radius for the Coulomb interaction (:math:`R_{coul}`)
+* Starting radius (:math:`r_{min} = 1,18845 \mathrm{\mathring{A}}`) and increments
+  (:math:`dr = 0.001 \mathrm{\mathring{A}}`) for creating the potential table.
+* Divider line
 
 5) Rick model parameter:
 
-* *Nevery* : parameter to set the frequency (\ *1/Nevery*\ ) of the charge resolution. The charges are evaluated each *Nevery* time steps.
-* Max number of iterative loop (\ *loopmax*\ ) and precision criterion (\ *prec*\ ) in eV of the charge resolution
-* Dividing line
+* *Nevery* : parameter to set the frequency of the charge
+  resolution. The charges are evaluated each *Nevery* time steps.
+* Max number of iterative loop (\ *loopmax*\ ) and convergence criterion
+  (\ *prec*\ ) in eV of the charge resolution
+* Divider line
 
 6) Coordination parameter:
 
-* First (\ *r<sub>1n</sub>*\ ) and second (\ *r<sub>2n</sub>*\ ) neighbor distances in &#197
-* Dividing line
+* First (:math:`r_{1n}`) and second (:math:`r_{2n}`) neighbor distances
+  in angstrom
+* Divider line
 
 7) Charge initialization mode:
 
-* Keyword (\ *QInitMode*\ ) and initial oxygen charge (\ *Q<sub>init</sub>*\ ). If keyword = 'true', all oxygen charges are initially set equal to *Q<sub>init</sub>*\ . The charges on the cations are initially set in order to respect the neutrality of the box. If keyword = 'false', all atom charges are initially set equal to 0 if you use "create\_atom"#create\_atom command or the charge specified in the file structure using :doc:`read_data <read_data>` command.
-* Dividing line
+* Keyword (\ *QInitMode*\ ) and initial oxygen charge
+  (:math:`Q_{init}`). If keyword = 'true', all oxygen charges are
+  initially set equal to :math:`Q_{init}`. The charges on the cations
+  are initially set in order to respect the neutrality of the box. If
+  keyword = 'false', all atom charges are initially set equal to 0 if
+  you use the :doc:`create_atoms <create_atoms>` command or the charge
+  specified in the file structure using :doc:`read_data <read_data>`
+  command.
+* Divider line
 
-8) Mode for the electronegativity equalization (Qeq) 
+8) Mode for the electronegativity equalization (Qeq)
 
-* Keyword mode: <pre> <br/> QEqAll  (one QEq group) \|   no parameters <br/> QEqAllParallel (several QEq groups) \|   no parameters <br/> Surface \|   zlim   (QEq only for z>zlim)   </pre>
+* Keyword (\ *mode*\ ) followed by:
+
+  - QEqAll  (one QEq group) \|   no parameters
+  - QEqAllParallel (several QEq groups) \|   no parameters
+  - Surface \|   zlim   (QEq only for z>zlim)
+
 * Parameter if necessary
-* Dividing line
+* Divider line
 
 9) Verbose 
 
 * If you want the code to work in verbose mode or not : 'true' or 'false'
-* If you want to print or not in file 'Energy\_component.txt' the three main contributions to the energy of the system according to the description presented above : 'true' or 'false' and *N<sub>Energy</sub>*\ . This option writes in file every *N<sub>Energy</sub>* time step. If the value is 'false' then *N<sub>Energy</sub>* = 0. The file take into account the possibility to have several QEq group *g* then it writes: time step, number of atoms in group *g*\ , electrostatic part of energy, *E<sub>ES</sub>*\ , the interaction between oxygen, *E<sub>OO</sub>*\ , and short range metal-oxygen interaction, *E<sub>MO</sub>*\ .
-* If you want to print in file 'Electroneg\_component.txt' the electronegativity component (\ *&#8706E<sub>tot</sub> &#8260&#8706Q<sub>i</sub>*\ ) or not: 'true' or 'false' and *N<sub>Electroneg</sub>*\ .This option writes in file every *N<sub>Electroneg</sub>* time step. If the value is 'false' then *N<sub>Electroneg</sub>* = 0.  The file consist in atom number *i*\ , atom type (1 for oxygen and # higher than 1 for metal), atom position: *x*\ , *y* and *z*\ , atomic charge of atom *i*\ , electrostatic part of atom *i* electronegativity, covalent part of atom *i* electronegativity, the hopping integral of atom *i* *(Z&#946<sup>2</sup>)<sub>i<sub>* and box electronegativity.
+* If you want to print or not in the file 'Energy\_component.txt' the
+  three main contributions to the energy of the system according to the
+  description presented above : 'true' or 'false' and
+  :math:`N_{Energy}`. This option writes to the file every
+  :math:`N_{Energy}` time steps. If the value is 'false' then
+  :math:`N_{Energy} = 0`. The file takes into account the possibility to
+  have several QEq groups *g* then it writes: time step, number of atoms
+  in group *g*\ , electrostatic part of energy, :math:`E_{ES}`, the
+  interaction between oxygen, :math:`E_{OO}`, and short range
+  metal-oxygen interaction, :math:`E_{MO}`.
+* If you want to print to the file 'Electroneg\_component.txt' the
+  electronegativity component (:math:`\frac{\partial E_{tot}}{\partial
+  Q_i}`) or not: 'true' or 'false' and :math:`N_{Electroneg}`. This
+  option writes to the file every :math:`N_{Electroneg}` time steps. If
+  the value is 'false' then :math:`N_{Electroneg} = 0`.  The file
+  consist of atom number *i*\ , atom type (1 for oxygen and # higher
+  than 1 for metal), atom position: *x*\ , *y* and *z*\ , atomic charge
+  of atom *i*\ , electrostatic part of atom *i* electronegativity,
+  covalent part of atom *i* electronegativity, the hopping integral of
+  atom *i* :math:`(Z\beta^2)_i` and box electronegativity.
 
 .. note::
 
    This last option slows down the calculation dramatically.  Use
    only with a single processor simulation.
 
-
 ----------
-
 
 **Mixing, shift, table, tail correction, restart, rRESPA info:**
 
@@ -241,9 +284,7 @@ This pair style can only be used via the *pair* keyword of the
 :doc:`run_style respa <run_style>` command.  It does not support the
 *inner*\ , *middle*\ , *outer* keywords.
 
-
 ----------
-
 
 **Restriction:**
 
@@ -259,50 +300,36 @@ for pair interactions.
 The SMTB-Q potential files provided with LAMMPS (see the potentials
 directory) are parameterized for metal :doc:`units <units>`.
 
-
 ----------
-
 
 **Citing this work:**
 
 Please cite related publication: N. Salles, O. Politano, E. Amzallag
 and R. Tetot, Comput. Mater. Sci. 111 (2016) 181-189
 
-
 ----------
 
-
 .. _SMTB-Q\_1:
-
-
 
 **(SMTB-Q\_1)** N. Salles, O. Politano, E. Amzallag, R. Tetot,
 Comput. Mater. Sci. 111 (2016) 181-189
 
 .. _SMTB-Q\_2:
 
-
-
 **(SMTB-Q\_2)** E. Maras, N. Salles, R. Tetot, T. Ala-Nissila,
 H. Jonsson, J. Phys. Chem. C 2015, 119, 10391-10399
 
 .. _SMTB-Q\_3:
-
-
 
 **(SMTB-Q\_3)** R. Tetot, N. Salles, S. Landron, E. Amzallag, Surface
 Science 616, 19-8722 28 (2013)
 
 .. _Wolf2:
 
-
-
 **(Wolf)** D. Wolf, P. Keblinski, S. R. Phillpot, J. Eggebrecht, J Chem
 Phys, 110, 8254 (1999).
 
 .. _Rick3:
-
-
 
 **(Rick)** S. W. Rick, S. J. Stuart, B. J. Berne, J Chem Phys 101, 6141
 (1994).

--- a/doc/src/pair_snap.rst
+++ b/doc/src/pair_snap.rst
@@ -113,9 +113,9 @@ by the following commands:
    variable zblz equal 73
    pair_style hybrid/overlay &
    zbl ${zblcutinner} ${zblcutouter} snap
-   pair_coeff \* \* zbl 0.0
+   pair_coeff * * zbl 0.0
    pair_coeff 1 1 zbl ${zblz}
-   pair_coeff \* \* snap Ta06A.snapcoeff Ta06A.snapparam Ta
+   pair_coeff * * snap Ta06A.snapcoeff Ta06A.snapparam Ta
 
 It is convenient to keep these commands in a separate file that can
 be inserted in any LAMMPS input script using the :doc:`include <include>`
@@ -164,8 +164,7 @@ into two passes.
 Detailed definitions for all the other keywords 
 are given on the :doc:`compute sna/atom <compute_sna_atom>` doc page. 
 
-If *quadraticflag* is set to 1, then the SNAP energy expression includes the quadratic term,
-0.5\*B\^t.alpha.B, where alpha is a symmetric *K* by *K* matrix.
+If *quadraticflag* is set to 1, then the SNAP energy expression includes the quadratic term, 0.5\*B\^t.alpha.B, where alpha is a symmetric *K* by *K* matrix.
 The SNAP element file should contain *K*\ (\ *K*\ +1)/2 additional coefficients
 for each element, the upper-triangular elements of alpha.
 

--- a/doc/src/pair_thole.rst
+++ b/doc/src/pair_thole.rst
@@ -113,7 +113,7 @@ For pair\_style *thole*\ , the following coefficients must be defined for
 each pair of atoms types via the :doc:`pair_coeff <pair_coeff>` command
 as in the example above.
 
-* alpha (distance units\^3)
+* :math:`\alpha` (distance units\^3)
 * damp
 * cutoff (distance units)
 
@@ -126,10 +126,10 @@ For pair style *lj/cut/thole/long*\ , the following coefficients must be
 defined for each pair of atoms types via the :doc:`pair_coeff <pair_coeff>`
 command.
 
-* epsilon (energy units)
-* sigma (length units)
-* alpha (distance units\^3)
-* damps
+* :math:`\epsilon` (energy units)
+* :math:`\sigma` (length units)
+* :math:`\alpha` (distance units\^3)
+* damp
 * LJ cutoff (distance units)
 
 The last two coefficients are optional and default to the global values from
@@ -168,12 +168,9 @@ are defined using
 
 .. math::
 
-   \alpha_{ij} = \sqrt{\alpha_i\alpha_j}
-
-
-.. math::
-
-   a_{ij} = \frac 1 2 (a_i + a_j)
+   \alpha_{ij} = & \sqrt{\alpha_i\alpha_j} \\
+   & \\
+   a_{ij} = & \frac 1 2 (a_i + a_j)
 
 Restrictions
 """"""""""""

--- a/doc/src/thermo_style.rst
+++ b/doc/src/thermo_style.rst
@@ -50,7 +50,7 @@ Syntax
            ke = kinetic energy
            etotal = total energy (pe + ke)
            enthalpy = enthalpy (etotal + press\*vol)
-           evdwl = VanderWaal pairwise energy (includes etail)
+           evdwl = van der Waals pairwise energy (includes etail)
            ecoul = Coulombic pairwise energy
            epair = pairwise energy (evdwl + ecoul + elong)
            ebond = bond energy
@@ -59,7 +59,7 @@ Syntax
            eimp = improper energy
            emol = molecular energy (ebond + eangle + edihed + eimp)
            elong = long-range kspace energy
-           etail = VanderWaal energy long-range tail correction
+           etail = van der Waals energy long-range tail correction
            vol = volume
            density = mass density of system
            lx,ly,lz = box lengths in x,y,z
@@ -205,13 +205,13 @@ change the attributes of this potential energy via the
 
 
 The kinetic energy of the system *ke* is inferred from the temperature
-of the system with 1/2 Kb T of energy for each degree of freedom.
-Thus, using different :doc:`compute commands <compute>` for calculating
-temperature, via the :doc:`thermo_modify temp <thermo_modify>` command,
-may yield different kinetic energies, since different computes that
-calculate temperature can subtract out different non-thermal
-components of velocity and/or include different degrees of freedom
-(translational, rotational, etc).
+of the system with :math:`\frac{1}{2} k_B T` of energy for each degree
+of freedom.  Thus, using different :doc:`compute commands <compute>` for
+calculating temperature, via the :doc:`thermo_modify temp
+<thermo_modify>` command, may yield different kinetic energies, since
+different computes that calculate temperature can subtract out different
+non-thermal components of velocity and/or include different degrees of
+freedom (translational, rotational, etc).
 
 The potential energy of the system *pe* will include contributions
 from fixes if the :doc:`fix_modify thermo <fix_modify>` option is set
@@ -219,7 +219,7 @@ for a fix that calculates such a contribution.  For example, the :doc:`fix wall/
 interacting with the wall.  See the doc pages for "individual fixes"
 to see which ones contribute.
 
-A long-range tail correction *etail* for the VanderWaal pairwise
+A long-range tail correction *etail* for the van der Waals pairwise
 energy will be non-zero only if the :doc:`pair_modify tail <pair_modify>` option is turned on.  The *etail* contribution
 is included in *evdwl*\ , *epair*\ , *pe*\ , and *etotal*\ , and the
 corresponding tail correction to the pressure is included in *press*

--- a/doc/src/units.rst
+++ b/doc/src/units.rst
@@ -57,13 +57,13 @@ is often not simple to do.
 
 For style *lj*\ , all quantities are unitless.  Without loss of
 generality, LAMMPS sets the fundamental quantities mass, :math:`\sigma`,
-:math:`\epsilon`, and the Boltzmann constant :math:`k_B = 1`.
-The masses, distances,
-energies you specify are multiples of these fundamental values.  The
-formulas relating the reduced or unitless quantity (with an asterisk)
-to the same quantity with units is also given.  Thus you can use the
-mass & sigma & epsilon values for a specific material and convert the
-results from a unitless LJ simulation into physical quantities.
+:math:`\epsilon`, and the Boltzmann constant :math:`k_B = 1`.  The
+masses, distances, energies you specify are multiples of these
+fundamental values.  The formulas relating the reduced or unitless
+quantity (with an asterisk) to the same quantity with units is also
+given.  Thus you can use the mass & :math:`\sigma` & :math:`\epsilon`
+values for a specific material and convert the results from a unitless
+LJ simulation into physical quantities.
 
 * mass = mass or *m*
 * distance = :math:`\sigma`, where :math:`x^* = \frac{x}{\sigma}`

--- a/doc/src/units.rst
+++ b/doc/src/units.rst
@@ -17,7 +17,7 @@ Examples
 """"""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    units metal
    units lj
@@ -56,28 +56,29 @@ is often not simple to do.
 
 
 For style *lj*\ , all quantities are unitless.  Without loss of
-generality, LAMMPS sets the fundamental quantities mass, sigma,
-epsilon, and the Boltzmann constant = 1.  The masses, distances,
+generality, LAMMPS sets the fundamental quantities mass, :math:`\sigma`,
+:math:`\epsilon`, and the Boltzmann constant :math:`k_B = 1`.
+The masses, distances,
 energies you specify are multiples of these fundamental values.  The
 formulas relating the reduced or unitless quantity (with an asterisk)
 to the same quantity with units is also given.  Thus you can use the
 mass & sigma & epsilon values for a specific material and convert the
 results from a unitless LJ simulation into physical quantities.
 
-* mass = mass or m
-* distance = sigma, where x\* = x / sigma
-* time = tau, where t\* = t (epsilon / m / sigma\^2)\^1/2
-* energy = epsilon, where E\* = E / epsilon
-* velocity = sigma/tau, where v\* = v tau / sigma
-* force = epsilon/sigma, where f\* = f sigma / epsilon
-* torque = epsilon, where t\* = t / epsilon
-* temperature = reduced LJ temperature, where T\* = T Kb / epsilon
-* pressure = reduced LJ pressure, where P\* = P sigma\^3 / epsilon
-* dynamic viscosity = reduced LJ viscosity, where eta\* = eta sigma\^3 / epsilon / tau
-* charge = reduced LJ charge, where q\* = q / (4 pi perm0 sigma epsilon)\^1/2
-* dipole = reduced LJ dipole, moment where \*mu = mu / (4 pi perm0 sigma\^3 epsilon)\^1/2
-* electric field = force/charge, where E\* = E (4 pi perm0 sigma epsilon)\^1/2 sigma / epsilon
-* density = mass/volume, where rho\* = rho sigma\^dim
+* mass = mass or *m*
+* distance = :math:`\sigma`, where :math:`x^* = \frac{x}{\sigma}`
+* time = :math:`\tau`, where :math:`\tau^* = \tau \sqrt{\frac{\epsilon}{m \sigma^2}}`
+* energy = :math:`\epsilon`, where :math:`E^* = \frac{E}{\epsilon}`
+* velocity = :math:`\frac{\sigma}{\tau}`, where :math:`v^* = v \frac{\tau}{\sigma}`
+* force = :math:`\frac{\epsilon}{\sigma}`, where :math:`f^* = f \frac{\sigma}{\epsilon}`
+* torque = :math:`\epsilon`, where :math:`t^* = \frac{t}{\epsilon}`
+* temperature = reduced LJ temperature, where :math:`T^* = \frac{T k_B}{\epsilon}`
+* pressure = reduced LJ pressure, where :math:`p^* = p \frac{\sigma^3}{\epsilon}`
+* dynamic viscosity = reduced LJ viscosity, where :math:`\eta^* = \eta \frac{\sigma^3}{\epsilon\tau}`
+* charge = reduced LJ charge, where :math:`q^* = q \frac{1}{\sqrt{4 \pi \varepsilon_0 \sigma \epsilon}}`
+* dipole = reduced LJ dipole, moment where :math:`\mu^* = \mu \frac{1}{\sqrt{4 \pi \varepsilon_0 \sigma^3 \epsilon}}`
+* electric field = force/charge, where :math:`E^* = E \frac{\sqrt{4 \pi \varepsilon_0 \sigma \epsilon} \sigma}{\epsilon}`
+* density = mass/volume, where :math:`\rho^* = \rho \sigma^{dim}`
 
 Note that for LJ units, the default mode of thermodynamic output via
 the :doc:`thermo_style <thermo_style>` command is to normalize all
@@ -228,6 +229,6 @@ Default
 """""""
 
 
-.. parsed-literal::
+.. code-block:: LAMMPS
 
    units lj

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -3129,6 +3129,7 @@ webpage
 Weckner
 WeinanE
 Wennberg
+Westmere
 Westview
 wget
 Whelan


### PR DESCRIPTION
**Summary**

This PR addresses some of the issues that were caused by the transition from .txt markup to .rst.:
- Embedded raw HTML typesetting is replaced with embedded math and some transcriptions are also converted
- Some corner cases confusing the txt2rst translation are fixed.
- Command by section lists are converted to tables for a more compact presentation and better readability in the PDF version
- Command table widths are adjusted to fit the page widths in the PDF version
- k_B is used consistently for the Boltzmann constant

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Documentation changes only.
**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
