### PR TITLE
add EPYC to KOKKOS_ARCH_LIST

### DIFF
--- a/lib/kokkos/cmake/kokkos_options.cmake
+++ b/lib/kokkos/cmake/kokkos_options.cmake
@@ -78,6 +78,7 @@ set(KOKKOS_ARCH_LIST)
 list(APPEND KOKKOS_ARCH_LIST
      None            # No architecture optimization
      AMDAVX          # (HOST) AMD chip
+     EPYC            # (HOST) AMD EPYC Zen-Core CPU
      ARMv80          # (HOST) ARMv8.0 Compatible CPU
      ARMv81          # (HOST) ARMv8.1 Compatible CPU
      ARMv8-ThunderX  # (HOST) ARMv8 Cavium ThunderX CPU


### PR DESCRIPTION
**Summary**

EPYC architecture is supported by KOKKOS (e.g., see `lib/kokkos/Makefile.kokkos`) but can't be enabled in LAMMPS using cmake because it's missing from KOKKOS_ARCH_LIST in `lib/kokkos/cmake/kokkos_options.cmake`. This PR simply adds it.

**Related Issues**

related to https://github.com/easybuilders/easybuild-easyblocks/pull/1975

**Author(s)**

Miguel Dias Costa, National University of Singapore

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N.A.

**Implementation Notes**

N.A.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

N.A.

