### PR TITLE
fire bug fix

### DIFF
--- a/doc/src/min_style.rst
+++ b/doc/src/min_style.rst
@@ -182,4 +182,4 @@ Jonsson, Mills, Jacobsen.
 .. _Guenole:
 
 **(Guenole)** Guenole, Noehring, Vaid, Houlle, Xie, Prakash, Bitzek,
-Comput Mater Sci, (2020), in press (arXiv:190802038).
+Comput Mater Sci, 175, 109584 (2020).

--- a/src/min_fire.cpp
+++ b/src/min_fire.cpp
@@ -115,7 +115,7 @@ int MinFire::iterate(int maxiter)
   int flag,flagall;
 
   alpha_final = 0.0;
- 
+
   // Leap Frog integration initialization
 
   if (integrator == 2) {

--- a/src/min_fire.cpp
+++ b/src/min_fire.cpp
@@ -271,8 +271,9 @@ int MinFire::iterate(int maxiter)
       flagv0 = 1;
     }
 
-    // 1st iter: evauates velocity
-    // required to limit timestep in case of particles
+    // evaluates velocties to estimate wether dtv has to be limited
+    // required when v have been reset
+
     if (flagv0) {
       dtf = dt * force->ftm2v;
       energy_force(0);
@@ -307,7 +308,7 @@ int MinFire::iterate(int maxiter)
 
     MPI_Allreduce(&dtvone,&dtv,1,MPI_DOUBLE,MPI_MIN,world);
 
-    // 1st iter: velocities reset to 0
+    // reset velocities when necessary
 
     if (flagv0) {
       for (int i = 0; i < nlocal; i++)

--- a/src/min_fire.cpp
+++ b/src/min_fire.cpp
@@ -146,6 +146,18 @@ int MinFire::iterate(int maxiter)
         v[i][2] = dtfm * f[i][2];
       }
     }
+    // limit timestep so no particle moves further than dmax
+
+    dtvone = dt;
+
+    for (int i = 0; i < nlocal; i++) {
+      vmax = MAX(fabs(v[i][0]),fabs(v[i][1]));
+      vmax = MAX(vmax,fabs(v[i][2]));
+      if (dtvone*vmax > dmax) dtvone = dmax/vmax;
+    }
+
+    MPI_Allreduce(&dtvone,&dtv,1,MPI_DOUBLE,MPI_MIN,world);
+
   }
 
   for (int iter = 0; iter < maxiter; iter++) {
@@ -259,9 +271,9 @@ int MinFire::iterate(int maxiter)
 
       if (halfstepback_flag) {
         for (int i = 0; i < nlocal; i++) {
-          x[i][0] -= 0.5 * dtv * v[i][0];
-          x[i][1] -= 0.5 * dtv * v[i][1];
-          x[i][2] -= 0.5 * dtv * v[i][2];
+          x[i][0] -= 0.5 * dt * v[i][0];
+          x[i][1] -= 0.5 * dt * v[i][1];
+          x[i][2] -= 0.5 * dt * v[i][2];
         }
       }
 

--- a/src/min_fire.h
+++ b/src/min_fire.h
@@ -37,7 +37,7 @@ class MinFire : public Min {
   double dt,dtmax,dtmin;
   double alpha;
   bigint last_negative,ntimestep_start;
-  int vdotf_negatif;
+  int vdotf_negatif,flagv0;
 };
 
 }


### PR DESCRIPTION
 **Summary**

When atoms are too close to each other at the beginning of the simulation, fire crashes but not fire/old.

**Related Issues**

Fixes #1907 

**Author(s)**

Julien Guénolé

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

--

**Implementation Notes**

Identification:
To limit particles motion when their are too close, the algorithm predict their displacement by using their velocities. This control fails when the velocities have been artificially zeroed, that is either at the beginning of the minimization or periodically.

Solution:
Flag (`flagv0`) whether the velocites have been zeroed or not.
- If velocties not zeroed:
-- test the dmax parameter.
- If velocites zeroed:
-- evaluates forces
-- compute velocities
-- test the dmax parameter
-- zeroed the velocities

Comment on the difference between fire and fire/old:
This bug didn't affect fire/old, but affect fire with its default parameters. Using fire with the eulerexplicit integrator produces the same results as with fire/old. The issue is actually related to the integrator itself.
The bug described in #1907 does not affect the eulerexplicit integrator, as this integrator moves the particles before computing their velocities. In the case described in this issue, the 1st step of the eulerexplicit integrator actually does not move any particle as it compute a displacement by using a velocity equal to 0. On the 2nd steps, as the computed velocities of the 1st steps are very large, the test on dmax successfully limit the displacements.

**Misc**

I combine to this pull request two minor changes:
- updated citation.
- minor correction of a variable (lines 263-265) that should not impact the algo but is more logical.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
