### PR TITLE
minor optimization, avoiding double computation and extra communication

### DIFF
--- a/src/min_cg.cpp
+++ b/src/min_cg.cpp
@@ -109,11 +109,10 @@ int MinCG::iterate(int maxiter)
         dotall[1] += fextra[i]*gextra[i];
       }
 
-    fdotf = 0.0;
     if (update->ftol > 0.0) {
       if (normstyle == MAX) fdotf = fnorm_max();        // max force norm
       else if (normstyle == INF) fdotf = fnorm_inf();   // infinite force norm
-      else if (normstyle == TWO) fdotf = fnorm_sqr();   // Euclidean force 2-norm
+      else if (normstyle == TWO) fdotf = dotall[0];     // Euclidean force 2-norm
       else error->all(FLERR,"Illegal min_modify command");
       if (fdotf < update->ftol*update->ftol) return FTOL;
     }


### PR DESCRIPTION
**Summary**
- enhancement
minor optimization, avoiding double computation and extra communication.

**Related Issues**
In the CG minimizer, for the default normstyle==TWO, the computation has already been done before. Thus by correcting this, we avoid double computation and one extra communication 

**Author(s)**
Yaser Afshar

**Licensing**
By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
No issues.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



