### PR TITLE
Remove now unneeded check for C++11 in Lepton CMake build

### DIFF
--- a/cmake/Modules/Packages/USER-COLVARS.cmake
+++ b/cmake/Modules/Packages/USER-COLVARS.cmake
@@ -5,22 +5,7 @@ if(PKG_USER-COLVARS)
   file(GLOB COLVARS_SOURCES ${COLVARS_SOURCE_DIR}/[^.]*.cpp)
 
   # Build Lepton by default
-  set(COLVARS_LEPTON_DEFAULT ON)
-  # but not if C++11 is disabled per user request
-  if(DEFINED DISABLE_CXX11_REQUIREMENT)
-    if(DISABLE_CXX11_REQUIREMENT)
-      set(COLVARS_LEPTON_DEFAULT OFF)
-    endif()
-  endif()
-
-  option(COLVARS_LEPTON "Build and link the Lepton library" ${COLVARS_LEPTON_DEFAULT})
-
-  # Verify that the user's choice is consistent
-  if(DEFINED DISABLE_CXX11_REQUIREMENT)
-    if((DISABLE_CXX11_REQUIREMENT) AND (COLVARS_LEPTON))
-      message(FATAL_ERROR "Building the Lepton library requires C++11 or later.")
-    endif()
-  endif()
+  option(COLVARS_LEPTON "Build and link the Lepton library" ON)
 
   if(COLVARS_LEPTON)
     set(LEPTON_DIR ${LAMMPS_LIB_SOURCE_DIR}/colvars/lepton)


### PR DESCRIPTION
**Summary**

Because C++11 is now on everywhere, no need to automatically disable building of the Lepton library (never needed).

**Author(s)**

@giacomofiorin 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Same as the rest of LAMMPS > 3Mar2020.

**Implementation Notes**

Edit of CMake recipe file for `USER-COLVARS`.  No changes to conventional make (user-controlled).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system
