### PR TITLE
Add special highlights for commands which use IDs

### DIFF
--- a/doc/utils/sphinx-config/LAMMPSLexer.py
+++ b/doc/utils/sphinx-config/LAMMPSLexer.py
@@ -1,31 +1,53 @@
-from pygments.lexer import RegexLexer, words
+from pygments.lexer import RegexLexer, words, include, default
 from pygments.token import *
 
 LAMMPS_COMMANDS = ("angle_coeff", "angle_style", "atom_modify", "atom_style",
 "balance", "bond_coeff", "bond_style", "bond_write", "boundary", "box",
-"change_box", "clear", "comm_modify", "comm_style", "compute",
+"clear", "comm_modify", "comm_style",
 "compute_modify", "create_atoms", "create_bonds", "create_box", "delete_atoms",
 "delete_bonds", "dielectric", "dihedral_coeff", "dihedral_style", "dimension",
-"displace_atoms", "dump", "dump_modify", "dynamical_matrix", "echo", "fix",
-"fix_modify", "group", "group2ndx", "hyper", "if", "improper_coeff",
+"displace_atoms", "dump_modify", "dynamical_matrix", "echo",
+"fix_modify", "group2ndx", "hyper", "if", "improper_coeff",
 "improper_style", "include", "info", "jump", "kim_init", "kim_interactions",
 "kim_param", "kim_query", "kspace_modify", "kspace_style", "label", "lattice",
 "log", "mass", "message", "minimize", "min_modify", "min_style", "molecule",
 "ndx2group", "neb", "neb/spin", "neighbor", "neigh_modify", "newton", "next",
 "package", "pair_coeff", "pair_modify", "pair_style", "pair_write",
 "partition", "prd", "print", "processors", "python", "quit", "read_data",
-"read_dump", "read_restart", "region", "replicate", "rerun", "reset_ids",
+"read_dump", "read_restart", "replicate", "rerun", "reset_ids",
 "reset_timestep", "restart", "run", "run_style", "server", "set", "shell",
 "special_bonds", "suffix", "tad", "temper", "temper/grem", "temper/npt",
 "thermo", "thermo_modify", "thermo_style", "then", "third_order", "timer", "timestep",
-"uncompute", "undump", "unfix", "units", "variable", "velocity", "write_coeff",
-"write_data", "write_dump", "write_restart")
+"units", "velocity", "write_coeff",
+"write_data", "write_restart")
+
+#fix ID group-ID style args
+#compute ID group-ID style args
+#dump ID group-ID style N file args
+#region ID style args keyword arg ...
+#variable name style args ...
+#group ID style args
+#uncompute compute-ID
+#undump dump-ID
+#unfix fix-ID
+#write_dump group-ID style file dump-args modify dump_modify-args
 
 class LAMMPSLexer(RegexLexer):
     name = 'LAMMPS'
     tokens = {
         'root': [
-            (words(LAMMPS_COMMANDS, suffix=r'\b', prefix=r'^'), Keyword),
+            (r'fix\s+', Keyword, 'fix'),
+            (r'compute\s+', Keyword, 'compute'),
+            (r'dump\s+', Keyword, 'dump'),
+            (r'region\s+', Keyword, 'region'),
+            (r'variable\s+', Keyword, 'variable'),
+            (r'group\s+', Keyword, 'group'),
+            (r'change_box\s+', Keyword, 'change_box'),
+            (r'uncompute\s+', Keyword, 'uncompute'),
+            (r'unfix\s+', Keyword, 'unfix'),
+            (r'undump\s+', Keyword, 'undump'),
+            (r'write_dump\s+', Keyword, 'write_dump'),
+            include('keywords'),
             (r'#.*?\n', Comment),
             ('"', String, 'string'),
             ('\'', String, 'single_quote_string'),
@@ -37,6 +59,10 @@ class LAMMPSLexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'[\+\-\*\^\|\/\!%&=<>]', Operator),
         ],
+        'keywords' : [
+            (words(LAMMPS_COMMANDS, suffix=r'\b', prefix=r'^'), Keyword)
+        ]
+        ,
         'variable' : [
             ('[^\}]+', Name.Variable),
             ('\}', Name.Variable, '#pop'),
@@ -53,5 +79,56 @@ class LAMMPSLexer(RegexLexer):
             ('[^\(\)]+', Name.Variable),
             ('\(', Name.Variable, 'expression'),
             ('\)', Name.Variable, '#pop'),
+        ],
+        'fix' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            (r'\s+', Whitespace, 'group_id'),
+            default('#pop')
+        ],
+        'compute' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            (r'\s+', Whitespace, 'group_id'),
+            default('#pop')
+        ],
+        'dump' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            (r'\s+', Whitespace, 'group_id'),
+            default('#pop')
+        ],
+        'region' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'variable' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'group' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'change_box' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'unfix' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'undump' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'uncompute' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'write_dump' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop')
+        ],
+        'group_id' : [
+            (r'[\w_\-\.\[\]]+', Name.Variable.Identifier),
+            default('#pop:2')
         ]
     }


### PR DESCRIPTION
**Summary**

Adds special highlights in LAMMPS code-blocks of the documentation for commands that use IDs

**Author(s)**

@rbberger

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Implementation Notes**

It's a bit redundant, but I like it better this way to allow later modifications. We can generalize it at a later point.

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


