### PR TITLE
MEAM/C: Improve documentation, error messages

### DIFF
--- a/doc/src/Errors_messages.rst
+++ b/doc/src/Errors_messages.rst
@@ -2783,7 +2783,7 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
    if this helps.
 
 *Did not find all elements in MEAM library file*
-   The requested elements were not found in the MEAM file.
+   Some requested elements were not found in the MEAM file. Check spelling etc.
 
 *Did not find fix shake partner info*
    Could not find bond partners implied by fix shake command.  This error
@@ -3134,6 +3134,9 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
 
 *Epsilon or sigma reference not set by pair style in ewald/n*
    The pair style is not providing the needed epsilon or sigma values.
+
+*Error in MEAM parameter file: keyword %s (further information)*
+   Self-explanatory. Check the parameter file.
 
 *Error in vdw spline: inner radius > outer radius*
    A pre-tabulated spline is invalid.  Likely a problem with the
@@ -4611,7 +4614,7 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
 *Incorrect format in COMB3 potential file*
    Incorrect number of words per line in the potential file.
 
-*Incorrect format in MEAM potential file*
+*Incorrect format in MEAM library file*
    Incorrect number of words per line in the potential file.
 
 *Incorrect format in SNAP coefficient file*
@@ -5668,6 +5671,9 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
 *Mismatched fix in variable formula*
    A fix is referenced incorrectly or a fix that produces per-atom
    values is used in an equal-style variable formula.
+
+*Mismatched parameter in MEAM library file: z!=lat*
+   The coordination number and lattice do not match, check that consistent values are given.
 
 *Mismatched variable in variable formula*
    A variable is referenced incorrectly or an atom-style variable that
@@ -7764,6 +7770,9 @@ keyword to allow for additional bonds to be formed
 *Too many atoms to dump sort*
    Cannot sort when running with more than 2\^31 atoms.
 
+*Too many elements extracted from MEAM library.*
+   Increase 'maxelt' in meam.h and recompile.
+
 *Too many exponent bits for lookup table*
    Table size specified via pair_modify command does not work with your
    machine's floating point representation.
@@ -7997,11 +8006,11 @@ keyword to allow for additional bonds to be formed
 *Unknown unit_style*
    Self-explanatory. Check the input script or data file.
 
-*Unrecognized lattice type in MEAM file 1*
+*Unrecognized lattice type in MEAM library file*
    The lattice type in an entry of the MEAM library file is not
    valid.
 
-*Unrecognized lattice type in MEAM file 2*
+*Unrecognized lattice type in MEAM parameter file*
    The lattice type in an entry of the MEAM parameter file is not
    valid.
 
@@ -8016,6 +8025,9 @@ keyword to allow for additional bonds to be formed
 
 *Unsupported order in kspace_style pppm/disp, pair_style %s*
    Only pair styles with 1/r and 1/r\^6 dependence are currently supported.
+
+*Unsupported parameter in MEAM library file*
+   Self-explanatory.
 
 *Use cutoff keyword to set cutoff in single mode*
    Mode is single so cutoff/multi keyword cannot be used.

--- a/doc/src/pair_meamc.rst
+++ b/doc/src/pair_meamc.rst
@@ -93,12 +93,13 @@ and the 4th to be C, you would use the following pair_coeff command:
    pair_coeff * * library.meam Si C sic.meam Si Si Si C
 
 The 1st 2 arguments must be \* \* so as to span all LAMMPS atom types.
-The two filenames are for the library and parameter file respectively.
-The Si and C arguments (between the file names) are the two elements
-for which info will be extracted from the library file.  The first
-three trailing Si arguments map LAMMPS atom types 1,2,3 to the MEAM Si
-element.  The final C argument maps LAMMPS atom type 4 to the MEAM C
-element.
+The first filename is the element library file. The list of elements following
+it extracts lines from the library file and assigns numeric indices to these
+elements. The second filename is the alloy parameter file, which refers to
+elements using the numeric indices assigned before.
+The arguments after the parameter file map LAMMPS atom types to elements, i.e.
+LAMMPS atom types 1,2,3 to the MEAM Si element.  The final C argument maps
+LAMMPS atom type 4 to the MEAM C element.
 
 If the 2nd filename is specified as NULL, no parameter file is read,
 which simply means the generic parameters in the library file are
@@ -140,7 +141,7 @@ not required.  The other numeric parameters match values in the
 formulas above.  The value of the "elt" string is what is used in the
 pair_coeff command to identify which settings from the library file
 you wish to read in.  There can be multiple entries in the library
-file with the same "elt" value; LAMMPS reads the 1st matching entry it
+file with the same "elt" value; LAMMPS reads the first matching entry it
 finds and ignores the rest.
 
 Other parameters in the MEAM library file correspond to single-element
@@ -192,7 +193,7 @@ trailing comment (starting with #) which is ignored.
 
 The indices I, J, K correspond to the elements selected from the
 MEAM library file numbered in the order of how those elements were
-selected starting from 1. Thus for the example given below
+selected starting from 1. Thus for the example given before
 
 .. code-block:: LAMMPS
 
@@ -201,11 +202,6 @@ selected starting from 1. Thus for the example given below
 an index of 1 would refer to Si and an index of 2 to C.
 
 The recognized keywords for the parameter file are as follows:
-
-Ec, alpha, rho0, delta, lattce, attrac, repuls, nn2, Cmin, Cmax, rc, delr,
-augt1, gsmooth_factor, re
-
-where
 
 .. parsed-literal::
 

--- a/src/USER-MEAMC/meam_setup_param.cpp
+++ b/src/USER-MEAMC/meam_setup_param.cpp
@@ -49,6 +49,12 @@ MEAM::meam_checkindex(int num, int lim, int nidx, int* idx /*idx(3)*/, int* ierr
 //     20 = bkgd_dyn
 //     21 = theta
 
+//     The returned errorflag has the following meanings:
+
+//     0 = no error
+//     1 = "which" out of range / invalid keyword
+//     2 = not enough indices given
+//     3 = an element index is out of range
 
 void
 MEAM::meam_setup_param(int which, double value, int nindex, int* index /*index(3)*/, int* errorflag)

--- a/src/USER-MEAMC/pair_meamc.h
+++ b/src/USER-MEAMC/pair_meamc.h
@@ -89,26 +89,37 @@ E: Cannot open MEAM potential file %s
 The specified MEAM potential file cannot be opened.  Check that the
 path and name are correct.
 
-E: Incorrect format in MEAM potential file
+E: Incorrect format in MEAM library file
 
 Incorrect number of words per line in the potential file.
 
-E: Unrecognized lattice type in MEAM file 1
+E: Too many elements extracted from MEAM library.
 
-The lattice type in an entry of the MEAM library file is not
+Increase 'maxelt' in meam.h and recompile.
+
+E: Unrecognized lattice type in MEAM library/parameter file
+
+The lattice type in an entry of the MEAM library/parameter file is not
 valid.
+
+E: Unsupported parameter in MEAM library file: ...
+
+Self-explanatory.
+
+E: Mismatched parameter in MEAM library file: z!=lat
+
+The coordination number and lattice do not match, check that consistent values are given.
 
 E: Did not find all elements in MEAM library file
 
-The requested elements were not found in the MEAM file.
+Some requested elements were not found in the MEAM file. Check spelling etc.
 
 E: Keyword %s in MEAM parameter file not recognized
 
 Self-explanatory.
 
-E: Unrecognized lattice type in MEAM file 2
+E: Error in MEAM parameter file: keyword %s (further information)
 
-The lattice type in an entry of the MEAM parameter file is not
-valid.
+Self-explanatory. Check the parameter file.
 
 */


### PR DESCRIPTION
**Summary**

As promised on the mailing list, this PR tries to make using meam/c easier:
- reword some of the documentation to make it clearer how to specify and map parameters
- during coeff() specify what input caused a read error
- improve runtime error messages (no more "library error 3")
- update the error doc-block in `pair_meamc.h`

I've also included a rewrite of the loading itself regarding MPI distribution. The new version has clearer variable scopes(, less communication) and simpler presentation of errors.

**Author(s)**

Sebastian Hütter, OvGU

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No functional changes. Some error messages have changed, but not what they are raised for.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the CMake based build system
