### PR TITLE
Work around team_size issue in npair_kokkos

### DIFF
--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -214,7 +214,6 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
 #ifdef KOKKOS_ENABLE_CUDA
     #define BINS_PER_BLOCK 2
     const int factor = atoms_per_bin<64?2:1;
-    Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,atoms_per_bin*factor);
 #else
     const int factor = 1;
 #endif
@@ -227,9 +226,14 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
         if (SIZE) {
           NPairKokkosBuildFunctorSize<DeviceType,TRI?0:HALF_NEIGH,1,TRI> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
 #ifdef KOKKOS_ENABLE_CUDA
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device)
-            Kokkos::parallel_for(config, f);
-          else
+          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
+            int team_size = atoms_per_bin*factor;
+            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
+            if (team_size <= team_size_max) {
+              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
+              Kokkos::parallel_for(config, f);
+            } else Kokkos::parallel_for(nall, f); // fall back to flat method
+          } else
             Kokkos::parallel_for(nall, f);
 #else
           Kokkos::parallel_for(nall, f);
@@ -237,9 +241,14 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
         } else {
           NPairKokkosBuildFunctor<DeviceType,TRI?0:HALF_NEIGH,1,TRI> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
 #ifdef KOKKOS_ENABLE_CUDA
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device)
-            Kokkos::parallel_for(config, f);
-          else
+          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
+            int team_size = atoms_per_bin*factor;
+            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
+            if (team_size <= team_size_max) {
+              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
+              Kokkos::parallel_for(config, f);
+            } else Kokkos::parallel_for(nall, f); // fall back to flat method
+          } else
             Kokkos::parallel_for(nall, f);
 #else
           Kokkos::parallel_for(nall, f);
@@ -249,9 +258,14 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
         if (SIZE) {
           NPairKokkosBuildFunctorSize<DeviceType,HALF_NEIGH,0,0> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
 #ifdef KOKKOS_ENABLE_CUDA
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device)
-            Kokkos::parallel_for(config, f);
-          else
+          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
+            int team_size = atoms_per_bin*factor;
+            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
+            if (team_size <= team_size_max) {
+              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
+              Kokkos::parallel_for(config, f);
+            } else Kokkos::parallel_for(nall, f); // fall back to flat method
+          } else
             Kokkos::parallel_for(nall, f);
 #else
           Kokkos::parallel_for(nall, f);
@@ -259,9 +273,14 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
         } else {
           NPairKokkosBuildFunctor<DeviceType,HALF_NEIGH,0,0> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
 #ifdef KOKKOS_ENABLE_CUDA
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device)
-            Kokkos::parallel_for(config, f);
-          else
+          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
+            int team_size = atoms_per_bin*factor;
+            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
+            if (team_size <= team_size_max) {
+              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
+              Kokkos::parallel_for(config, f);
+            } else Kokkos::parallel_for(nall, f); // fall back to flat method 
+          } else
             Kokkos::parallel_for(nall, f);
 #else
           Kokkos::parallel_for(nall, f);


### PR DESCRIPTION
**Summary**

In `npair_kokkos.cpp`, if the atoms per bin count exceeds the maximum team_size, then Kokkos throws an error. This PR allows the code to fall back to a non-team (flat) method when this occurs to avoid the error.

**Related Issues**

#1870 

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.