### PR TITLE
Small extension of bonds supported by fix adapt

### DIFF
--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -288,11 +288,19 @@ Currently *bond* does not support bond_style hybrid nor bond_style
 hybrid/overlay as bond styles. The only bonds that currently are
 working with fix_adapt are
 
-+---------------------------------+-------+------------+
-| :doc:`gromos <bond_gromos>`     | k, r0 | type bonds |
-+---------------------------------+-------+------------+
-| :doc:`harmonic <bond_harmonic>` | k,r0  | type bonds |
-+---------------------------------+-------+------------+
++------------------------------------+-------+------------+
+| :doc:`class2 <bond_class2>`        | r0    | type bonds |
++------------------------------------+-------+------------+
+| :doc:`fene <bond_fene>`            | k, r0 | type bonds |
++------------------------------------+-------+------------+
+| :doc:`gromos <bond_gromos>`        | k, r0 | type bonds |
++------------------------------------+-------+------------+
+| :doc:`harmonic <bond_harmonic>`    | k,r0  | type bonds |
++------------------------------------+-------+------------+
+| :doc:`morse <bond_morse>`          | r0    | type bonds |
++------------------------------------+-------+------------+
+| :doc:`nonlinear <bond_nonlinear>`  | r0    | type bonds |
++------------------------------------+-------+------------+
 
 ----------
 

--- a/src/CLASS2/bond_class2.cpp
+++ b/src/CLASS2/bond_class2.cpp
@@ -15,6 +15,7 @@
    Contributing author: Eric Simon (Cray)
 ------------------------------------------------------------------------- */
 
+#include <cstring>
 #include "bond_class2.h"
 #include <mpi.h>
 #include <cmath>

--- a/src/CLASS2/bond_class2.cpp
+++ b/src/CLASS2/bond_class2.cpp
@@ -220,3 +220,12 @@ double BondClass2::single(int type, double rsq, int /*i*/, int /*j*/, double &ff
   else fforce = 0.0;
   return (k2[type]*dr2 + k3[type]*dr3 + k4[type]*dr4);
 }
+
+/* ---------------------------------------------------------------------- */
+
+void *BondClass2::extract( char *str, int &dim )
+{
+  dim = 1;
+  if (strcmp(str,"r0")==0) return (void*) r0;
+  return NULL;
+}

--- a/src/CLASS2/bond_class2.h
+++ b/src/CLASS2/bond_class2.h
@@ -35,6 +35,7 @@ class BondClass2 : public Bond {
   virtual void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
+  virtual void *extract(char *, int &);
 
  protected:
   double *r0,*k2,*k3,*k4;

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -272,3 +272,13 @@ double BondFENE::single(int type, double rsq, int /*i*/, int /*j*/,
 
   return eng;
 }
+
+/* ---------------------------------------------------------------------- */
+
+void *BondFENE::extract( char *str, int &dim )
+{
+  dim = 1;
+  if (strcmp(str,"kappa")==0) return (void*) k;
+  if (strcmp(str,"r0")==0) return (void*) r0;
+  return NULL;
+}

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -14,6 +14,7 @@
 #include "bond_fene.h"
 #include <mpi.h>
 #include <cmath>
+#include <cstring>
 #include "atom.h"
 #include "neighbor.h"
 #include "comm.h"

--- a/src/MOLECULE/bond_fene.h
+++ b/src/MOLECULE/bond_fene.h
@@ -36,6 +36,7 @@ class BondFENE : public Bond {
   void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
+  virtual void *extract(char *, int &);
 
  protected:
   double TWO_1_3;

--- a/src/MOLECULE/bond_morse.cpp
+++ b/src/MOLECULE/bond_morse.cpp
@@ -205,3 +205,12 @@ double BondMorse::single(int type, double rsq, int /*i*/, int /*j*/,
   if (r > 0.0) fforce = -2.0*d0[type]*alpha[type]*(1-ralpha)*ralpha/r;
   return d0[type]*(1-ralpha)*(1-ralpha);
 }
+
+/* ---------------------------------------------------------------------- */
+
+void *BondMorse::extract(char *str, int &dim )
+{
+  dim = 1;
+  if (strcmp(str,"r0")==0) return (void*) r0;
+  return NULL;
+}

--- a/src/MOLECULE/bond_morse.cpp
+++ b/src/MOLECULE/bond_morse.cpp
@@ -18,6 +18,7 @@
 #include "bond_morse.h"
 #include <mpi.h>
 #include <cmath>
+#include <cstring>
 #include "atom.h"
 #include "neighbor.h"
 #include "comm.h"

--- a/src/MOLECULE/bond_morse.h
+++ b/src/MOLECULE/bond_morse.h
@@ -35,6 +35,7 @@ class BondMorse : public Bond {
   void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
+  virtual void *extract(char *, int &);
 
  protected:
   double *d0,*alpha,*r0;

--- a/src/MOLECULE/bond_nonlinear.cpp
+++ b/src/MOLECULE/bond_nonlinear.cpp
@@ -14,6 +14,7 @@
 #include "bond_nonlinear.h"
 #include <mpi.h>
 #include <cmath>
+#include <cstring>
 #include "atom.h"
 #include "neighbor.h"
 #include "comm.h"

--- a/src/MOLECULE/bond_nonlinear.cpp
+++ b/src/MOLECULE/bond_nonlinear.cpp
@@ -202,3 +202,13 @@ double BondNonlinear::single(int type, double rsq, int /*i*/, int /*j*/,
   fforce = -epsilon[type]/r * 2.0*dr*lamdasq/denomsq;
   return epsilon[type] * drsq / denom;
 }
+
+/* ---------------------------------------------------------------------- */
+
+void *BondNonlinear::extract( char *str, int &dim )
+{
+  dim = 1;
+  if (strcmp(str,"epsilon")==0) return (void*) epsilon;
+  if (strcmp(str,"r0")==0) return (void*) r0;
+  return NULL;
+}

--- a/src/MOLECULE/bond_nonlinear.h
+++ b/src/MOLECULE/bond_nonlinear.h
@@ -35,6 +35,7 @@ class BondNonlinear : public Bond {
   void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
+  virtual void *extract(char *, int &);
 
  protected:
   double *epsilon,*r0,*lamda;


### PR DESCRIPTION
**Summary**

Addition of an "extract" method for a few bond styles so that fix adapt can modify the equilibrium length 

**Related Issues**

No related issue 

**Author(s)**

Evangelos Voyiatzis (Royal DSM) email: evoyiatzis@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

It does not break backward compatibility

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [X] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [X] Corresponding author information is complete
- [X] The source code follows the LAMMPS formatting guidelines
- [X] Suitable new documentation files and/or updates to the existing docs are included
- [X] The added/updated documentation is integrated and tested with the documentation build system
- [X] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


