### PR TITLE
Fix typo in latex formula (cosine was not squared)

### DIFF
--- a/doc/src/pair_cosine_squared.rst
+++ b/doc/src/pair_cosine_squared.rst
@@ -46,7 +46,7 @@ Style *cosine/squared* computes a potential of the form
    E =
    \begin{cases}
    -\epsilon& \quad r < \sigma \\
-   -\epsilon\cos\left(\frac{\pi\left(r - \sigma\right)}{2\left(r_c - \sigma\right)}\right)&\quad \sigma \leq r < r_c \\
+   -\epsilon\cos\left(\frac{\pi\left(r - \sigma\right)}{2\left(r_c - \sigma\right)}\right)^2&\quad \sigma \leq r < r_c \\
    0& \quad r \geq r_c
    \end{cases}
 


### PR DESCRIPTION


**Summary**

Fix typo in latex formula (cosine was not squared). I am assuming it is squared in the implementation.

**Related Issues**

Not applicable.

**Author(s)**

No credit required.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No effects.

**Implementation Notes**

Not applicable.

**Post Submission Checklist**

- [x] Licensing information is complete
- [x] The added/updated documentation is integrated and tested with the documentation build system

**Further Information, Files, and Links**

None.

