### PR TITLE
Fix wrong size argument when checking for eos/table/rx string

### DIFF
--- a/src/KOKKOS/fix_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_rx_kokkos.cpp
@@ -128,7 +128,7 @@ void FixRxKokkos<DeviceType>::init()
 
   bool eos_flag = false;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"eos/table/rx",3) == 0) eos_flag = true;
+    if (strncmp(modify->fix[i]->style, "eos/table/rx", 12) == 0) eos_flag = true;
   if(!eos_flag) error->all(FLERR,"fix rx requires fix eos/table/rx to be specified");
 
   if (update_kinetics_data)


### PR DESCRIPTION
This PR fixes the size argument passed to `strncmp(modify->fix[i]->style, "eos/table/rx", 3)` call as the `"eos/table/rx"` string literal has a length of 12.

I am not aware of this codebase and so this might be an incorrect fix. If this check is correct, I would suggest updating the `"eos/table/rx"` string to just `"eos"`.