### PR TITLE
Recover cross compilation with MinGW 

### DIFF
--- a/lib/colvars/lepton/src/MSVC_erfc.h
+++ b/lib/colvars/lepton/src/MSVC_erfc.h
@@ -8,7 +8,7 @@
  * (VC11 has _MSC_VER=1700).
  */
 
-#if defined(_MSC_VER) || defined (__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #if !defined(M_PI)
 #define M_PI 3.14159265358979323846264338327950288
 #endif

--- a/lib/colvars/lepton/src/MSVC_erfc.h
+++ b/lib/colvars/lepton/src/MSVC_erfc.h
@@ -8,9 +8,13 @@
  * (VC11 has _MSC_VER=1700).
  */
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined (__MINGW32__)
+#if !defined(M_PI)
 #define M_PI 3.14159265358979323846264338327950288
+#endif
+#endif
 
+#if defined(_MSC_VER)
 #if _MSC_VER <= 1700 // 1700 is VC11, 1800 is VC12
 /***************************
 *   erf.cpp

--- a/src/GRANULAR/fix_wall_gran.cpp
+++ b/src/GRANULAR/fix_wall_gran.cpp
@@ -1134,15 +1134,15 @@ void FixWallGran::granular(double rsq, double dx, double dy, double dz,
     t2 = 8*dR*dR2*E*E*E;
     t3 = 4*dR2*E;
     sqrt1 = MAX(0, t0*(t1+2*t2)); // in case sqrt(0) < 0 due to precision issues
-    t4 = cbrt(t1+t2+THREEROOT3*M_PI*sqrt(sqrt1));
+    t4 = cbrt(t1+t2+THREEROOT3*MY_PI*sqrt(sqrt1));
     t5 = t3/t4 + t4/E;
     sqrt2 = MAX(0, 2*dR + t5);
     t6 = sqrt(sqrt2);
-    sqrt3 = MAX(0, 4*dR - t5 + SIXROOT6*coh*M_PI*R2/(E*t6));
+    sqrt3 = MAX(0, 4*dR - t5 + SIXROOT6*coh*MY_PI*R2/(E*t6));
     a = INVROOT6*(t6 + sqrt(sqrt3));
     a2 = a*a;
     knfac = normal_coeffs[0]*a;
-    Fne = knfac*a2/Reff - TWOPI*a2*sqrt(4*coh*E/(M_PI*a));
+    Fne = knfac*a2/Reff - TWOPI*a2*sqrt(4*coh*E/(MY_PI*a));
   } else {
     knfac = E; //Hooke
     a = sqrt(dR);
@@ -1192,11 +1192,11 @@ void FixWallGran::granular(double rsq, double dx, double dy, double dz,
   vrel = sqrt(vrel);
 
   if (normal_model == JKR) {
-    F_pulloff = 3*M_PI*coh*Reff;
+    F_pulloff = 3*MY_PI*coh*Reff;
     Fncrit = fabs(Fne + 2*F_pulloff);
   }
   else if (normal_model == DMT) {
-    F_pulloff = 4*M_PI*coh*Reff;
+    F_pulloff = 4*MY_PI*coh*Reff;
     Fncrit = fabs(Fne + 2*F_pulloff);
   }
   else{
@@ -1589,8 +1589,8 @@ double FixWallGran::pulloff_distance(double radius)
   double coh, E, a, dist;
   coh = normal_coeffs[3];
   E = normal_coeffs[0]*THREEQUARTERS;
-  a = cbrt(9*M_PI*coh*radius/(4*E));
-  dist = a*a/radius - 2*sqrt(M_PI*coh*a/E);
+  a = cbrt(9*MY_PI*coh*radius/(4*E));
+  dist = a*a/radius - 2*sqrt(MY_PI*coh*a/E);
   return dist;
 }
 

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -30,10 +30,12 @@
 #include "neighbor.h"
 #include "neigh_list.h"
 #include "memory.h"
+#include "math_const.h"
 #include "error.h"
 #include "utils.h"
 
 using namespace LAMMPS_NS;
+using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
@@ -272,7 +274,7 @@ void PairPeriEPS::compute(int eflag, int vflag)
     double horizon = cut[itype][itype];
     double tdnorm = compute_DeviatoricForceStateNorm(i);
     double pointwiseYieldvalue = 25.0 * yieldStress *
-                            yieldStress / 8 / M_PI / pow(horizon,5);
+                            yieldStress / 8 / MY_PI / pow(horizon,5);
 
 
     double fsurf = (tdnorm * tdnorm)/2 - pointwiseYieldvalue;

--- a/src/USER-INTEL/pair_airebo_intel.cpp
+++ b/src/USER-INTEL/pair_airebo_intel.cpp
@@ -49,8 +49,10 @@
 #include "kspace.h"
 #include "modify.h"
 #include "suffix.h"
+#include "math_const.h"
 
 using namespace LAMMPS_NS;
+using namespace MathConst;
 
 #ifdef __INTEL_OFFLOAD
 #pragma offload_attribute(push, target(mic))
@@ -637,8 +639,6 @@ namespace overloaded {
     compared to original code.
    ---------------------------------------------------------------------- */
 
-#define M_PI           3.14159265358979323846  /* pi */
-
 #define CARBON 0
 #define HYDROGEN 1
 #define TOL 1.0e-9
@@ -662,8 +662,8 @@ inline flt_t Sp(flt_t r, flt_t lo, flt_t hi, flt_t * del) {
     if (del) *del = 0;
     return 0;
   } else {
-    t *= static_cast<flt_t>(M_PI);
-    if (del) *del = static_cast<flt_t>(-0.5 * M_PI)
+    t *= static_cast<flt_t>(MY_PI);
+    if (del) *del = static_cast<flt_t>(-0.5 * MY_PI)
                   * overloaded::sin(t) / (hi - lo);
     return static_cast<flt_t>(0.5) * (1 + overloaded::cos(t));
   }
@@ -2248,7 +2248,7 @@ static fvec aut_Sp_deriv(fvec r, fvec lo, fvec hi, fvec * d) {
   fvec c_1 = fvec::set1(1);
   fvec c_0_5 = fvec::set1(0.5);
   fvec c_m0_5 = fvec::set1(-0.5);
-  fvec c_PI = fvec::set1(M_PI);
+  fvec c_PI = fvec::set1(MY_PI);
   bvec m_lo = fvec::cmple(r, lo);
   bvec m_hi = fvec::cmpnlt(r, hi); // nlt == ge
   bvec m_tr = bvec::kandn(m_lo, ~ m_hi);
@@ -2273,7 +2273,7 @@ static fvec aut_Sp_deriv(fvec r, fvec lo, fvec hi, fvec * d) {
 static fvec aut_mask_Sp(bvec mask, fvec r, fvec lo, fvec hi) {
   fvec c_1 = fvec::set1(1);
   fvec c_0_5 = fvec::set1(0.5);
-  fvec c_PI = fvec::set1(M_PI);
+  fvec c_PI = fvec::set1(MY_PI);
   bvec m_lo = fvec::mask_cmple(mask, r, lo);
   bvec m_hi = fvec::mask_cmpnlt(mask, r, hi); // nlt == ge
   bvec m_tr = bvec::kandn(m_lo, bvec::kandn(m_hi, mask));

--- a/src/USER-MISC/fix_pimd.cpp
+++ b/src/USER-MISC/fix_pimd.cpp
@@ -32,11 +32,13 @@
 #include "atom.h"
 #include "domain.h"
 #include "update.h"
+#include "math_const.h"
 #include "memory.h"
 #include "error.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
+using namespace MathConst;
 
 enum{PIMD,NMPIMD,CMD};
 
@@ -165,7 +167,7 @@ void FixPIMD::init()
   const double Boltzmann = 1.3806488E-23;    // SI unit: J/K
   const double Plank     = 6.6260755E-34;    // SI unit: m^2 kg / s
 
-  double hbar = Plank / ( 2.0 * M_PI ) * sp;
+  double hbar = Plank / ( 2.0 * MY_PI ) * sp;
   double beta = 1.0 / ( Boltzmann * input.nh_temp);
 
   // - P / ( beta^2 * hbar^2)   SI unit: s^-2
@@ -181,7 +183,7 @@ void FixPIMD::init()
   const double Boltzmann = force->boltz;
   const double Plank     = force->hplanck;
 
-  double hbar   = Plank / ( 2.0 * M_PI );
+  double hbar   = Plank / ( 2.0 * MY_PI );
   double beta   = 1.0 / (Boltzmann * nhc_temp);
   double _fbond = 1.0 * np / (beta*beta*hbar*hbar) ;
 
@@ -429,7 +431,7 @@ void FixPIMD::nmpimd_init()
 
   for(int i=2; i<=np/2; i++)
   {
-    lam[2*i-3] = lam[2*i-2] = 2.0 * np * (1.0 - 1.0 *cos(2.0*M_PI*(i-1)/np));
+    lam[2*i-3] = lam[2*i-2] = 2.0 * np * (1.0 - 1.0 *cos(2.0*MY_PI*(i-1)/np));
   }
 
   // Set up eigenvectors for non-degenerated modes
@@ -444,8 +446,8 @@ void FixPIMD::nmpimd_init()
 
   for(int i=0; i<(np-1)/2; i++) for(int j=0; j<np; j++)
   {
-    M_x2xp[2*i+1][j] =   sqrt(2.0) * cos ( 2.0 * M_PI * (i+1) * j / np) / np;
-    M_x2xp[2*i+2][j] = - sqrt(2.0) * sin ( 2.0 * M_PI * (i+1) * j / np) / np;
+    M_x2xp[2*i+1][j] =   sqrt(2.0) * cos ( 2.0 * MY_PI * (i+1) * j / np) / np;
+    M_x2xp[2*i+2][j] = - sqrt(2.0) * sin ( 2.0 * MY_PI * (i+1) * j / np) / np;
   }
 
   // Set up Ut

--- a/src/USER-MISC/fix_rhok.cpp
+++ b/src/USER-MISC/fix_rhok.cpp
@@ -25,9 +25,11 @@
 #include "respa.h"
 #include "update.h"
 #include "citeme.h"
+#include "math_const.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
+using namespace MathConst;
 
 static const char cite_fix_rhok[] =
   "Bias on the collective density field (fix rhok):\n\n"
@@ -70,9 +72,9 @@ FixRhok::FixRhok( LAMMPS* inLMP, int inArgc, char** inArgv )
   n[1]   = force->inumeric(FLERR,inArgv[4]);
   n[2]   = force->inumeric(FLERR,inArgv[5]);
 
-  mK[0] = n[0]*(2*M_PI / (domain->boxhi[0] - domain->boxlo[0]));
-  mK[1] = n[1]*(2*M_PI / (domain->boxhi[1] - domain->boxlo[1]));
-  mK[2] = n[2]*(2*M_PI / (domain->boxhi[2] - domain->boxlo[2]));
+  mK[0] = n[0]*(2*MY_PI / (domain->boxhi[0] - domain->boxlo[0]));
+  mK[1] = n[1]*(2*MY_PI / (domain->boxhi[1] - domain->boxlo[1]));
+  mK[2] = n[2]*(2*MY_PI / (domain->boxhi[2] - domain->boxlo[2]));
 
   mKappa = force->numeric(FLERR,inArgv[6]);
   mRhoK0 = force->numeric(FLERR,inArgv[7]);

--- a/src/USER-QTB/fix_qbmsst.cpp
+++ b/src/USER-QTB/fix_qbmsst.cpp
@@ -32,10 +32,12 @@
 #include "memory.h"
 #include "error.h"
 #include "kspace.h"
+#include "math_const.h"
 #include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
+using namespace MathConst;
 
 /* ----------------------------------------------------------------------
    read parameters
@@ -538,7 +540,7 @@ void FixQBMSST::initial_integrate(int /*vflag*/)
       } else {
       double energy_k= force->hplanck * fabs(f_k);
         omega_H[k]=sqrt( energy_k * (0.5+1.0/( exp(energy_k/(force->boltz * t_current)) - 1.0 )) );
-        omega_H[k]*=alpha*sin((k-N_f)*M_PI/(2*alpha*N_f))/sin((k-N_f)*M_PI/(2*N_f));
+        omega_H[k]*=alpha*sin((k-N_f)*MY_PI/(2*alpha*N_f))/sin((k-N_f)*MY_PI/(2*N_f));
       }
     }
 
@@ -547,7 +549,7 @@ void FixQBMSST::initial_integrate(int /*vflag*/)
       time_H[n] = 0;
       double t_n=(n-N_f);
       for (int k = 0; k < 2*N_f; k++) {
-        double omega_k=(k-N_f)*M_PI/N_f;
+        double omega_k=(k-N_f)*MY_PI/N_f;
         time_H[n] += omega_H[k]*(cos(omega_k*t_n));
       }
       time_H[n]/=(2.0*N_f);

--- a/src/USER-QTB/fix_qtb.cpp
+++ b/src/USER-QTB/fix_qtb.cpp
@@ -29,11 +29,13 @@
 #include "respa.h"
 #include "comm.h"
 #include "random_mars.h"
+#include "math_const.h"
 #include "memory.h"
 #include "error.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
+using namespace MathConst;
 
 /* ----------------------------------------------------------------------
    read parameters
@@ -195,7 +197,7 @@ void FixQTB::init()
     } else {
       double energy_k= force->hplanck * fabs(f_k);
       omega_H[k]=sqrt( energy_k * (0.5+1.0/( exp(energy_k/(force->boltz * t_target)) - 1.0 )) );
-      omega_H[k]*=alpha*sin((k-N_f)*M_PI/(2*alpha*N_f))/sin((k-N_f)*M_PI/(2*N_f));
+      omega_H[k]*=alpha*sin((k-N_f)*MY_PI/(2*alpha*N_f))/sin((k-N_f)*MY_PI/(2*N_f));
     }
   }
 
@@ -204,7 +206,7 @@ void FixQTB::init()
     time_H[n] = 0;
     double t_n=(n-N_f);
     for (int k = 0; k < 2*N_f; k++) {
-      double omega_k=(k-N_f)*M_PI/N_f;
+      double omega_k=(k-N_f)*MY_PI/N_f;
       time_H[n] += omega_H[k]*(cos(omega_k*t_n));
     }
     time_H[n]/=(2.0*N_f);


### PR DESCRIPTION
**Summary**

This handles using `M_PI` which is undefined in MinGW with `-std=c++11`. After the latest changes to LAMMPS and its build environments this causes compilations to fail.
For the LAMMPS parts the code should be using `MY_PI` from the `math_const.h` header anyway.
This pull request remedies this, too.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

