### PR TITLE
Use utils::strmatch() in USER-DPD and KOKKOS for safer style matches

### DIFF
--- a/src/KOKKOS/fix_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_rx_kokkos.cpp
@@ -27,6 +27,7 @@
 #include "comm.h"
 #include "domain.h"
 #include "kokkos.h"
+#include "utils.h"
 
 #include <cfloat> // DBL_EPSILON
 
@@ -128,7 +129,7 @@ void FixRxKokkos<DeviceType>::init()
 
   bool eos_flag = false;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"eos/table/rx",3) == 0) eos_flag = true;
+    if (utils::strmatch(modify->fix[i]->style,"^eos/table/rx")) eos_flag = true;
   if(!eos_flag) error->all(FLERR,"fix rx requires fix eos/table/rx to be specified");
 
   if (update_kinetics_data)

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -33,6 +33,7 @@
 #include "kokkos_few.h"
 #include "kokkos.h"
 #include "modify.h"
+#include "utils.h"
 #include <cassert>
 
 using namespace LAMMPS_NS;
@@ -1022,7 +1023,7 @@ void PairTableRXKokkos<DeviceType>::coeff(int narg, char **arg)
 
   bool rx_flag = false;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"rx",2) == 0) rx_flag = true;
+    if (utils::strmatch(modify->fix[i]->style,"^rx")) rx_flag = true;
   if (!rx_flag) error->all(FLERR,"PairTableRX requires a fix rx command.");
 
   int ilo,ihi,jlo,jhi;

--- a/src/USER-DPD/fix_eos_table_rx.cpp
+++ b/src/USER-DPD/fix_eos_table_rx.cpp
@@ -51,7 +51,7 @@ FixEOStableRX::FixEOStableRX(LAMMPS *lmp, int narg, char **arg) :
   rx_flag = false;
   nspecies = 1;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"rx",2) == 0){
+    if (utils::strmatch(modify->fix[i]->style,"^rx")) {
       rx_flag = true;
       nspecies = atom->nspecies_dpd;
       if(nspecies==0) error->all(FLERR,"There are no rx species specified.");

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -31,6 +31,7 @@
 #include "neigh_request.h"
 #include "math_special.h"
 #include "pair_dpd_fdt_energy.h"
+#include "utils.h"
 
 #include <vector> // std::vector<>
 #include <algorithm> // std::max
@@ -256,7 +257,7 @@ void FixRX::post_constructor()
   bool match;
 
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"property/atom",13) == 0)
+    if (utils::strmatch(modify->fix[i]->style,"^property/atom") == 0)
       error->all(FLERR,"fix rx cannot be combined with fix property/atom");
 
   char **tmpspecies = new char*[maxspecies];

--- a/src/USER-DPD/fix_shardlow.cpp
+++ b/src/USER-DPD/fix_shardlow.cpp
@@ -54,6 +54,7 @@
 #include "pair_dpd_fdt_energy.h"
 #include "npair_half_bin_newton_ssa.h"
 #include "citeme.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -155,12 +156,13 @@ void FixShardlow::setup(int /*vflag*/)
   bool fixShardlow = false;
 
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"nvt",3) == 0 || strncmp(modify->fix[i]->style,"npt",3) == 0)
-      error->all(FLERR,"Cannot use constant temperature integration routines with DPD.");
+    if (strstr(modify->fix[i]->style,"nvt") || strstr(modify->fix[i]->style,"npt") ||
+        strstr(modify->fix[i]->style,"gle") || strstr(modify->fix[i]->style,"gld"))
+      error->all(FLERR,"Cannot use constant temperature integration routines with USER-DPD.");
 
   for (int i = 0; i < modify->nfix; i++){
-    if (strncmp(modify->fix[i]->style,"shardlow",3) == 0) fixShardlow = true;
-    if (strncmp(modify->fix[i]->style,"nve",3) == 0 || (strncmp(modify->fix[i]->style,"nph",3) == 0)){
+    if (utils::strmatch(modify->fix[i]->style,"^shardlow")) fixShardlow = true;
+    if (utils::strmatch(modify->fix[i]->style,"^nve") || utils::strmatch(modify->fix[i]->style,"^nph")){
       if(fixShardlow) break;
       else error->all(FLERR,"The deterministic integrator must follow fix shardlow in the input file.");
     }

--- a/src/USER-DPD/pair_dpd_fdt.cpp
+++ b/src/USER-DPD/pair_dpd_fdt.cpp
@@ -316,7 +316,7 @@ void PairDPDfdt::init_style()
   splitFDT_flag = false;
   neighbor->request(this,instance_me);
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"shardlow", 8) == 0){
+    if (utils::strmatch(modify->fix[i]->style,"^shardlow")) {
       splitFDT_flag = true;
     }
 

--- a/src/USER-DPD/pair_dpd_fdt_energy.cpp
+++ b/src/USER-DPD/pair_dpd_fdt_energy.cpp
@@ -409,7 +409,7 @@ void PairDPDfdtEnergy::init_style()
   splitFDT_flag = false;
   neighbor->request(this,instance_me);
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"shardlow", 8) == 0){
+    if (utils::strmatch(modify->fix[i]->style,"^shardlow")) {
       splitFDT_flag = true;
     }
 
@@ -420,8 +420,8 @@ void PairDPDfdtEnergy::init_style()
 
   bool eos_flag = false;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"eos",3) == 0) eos_flag = true;
-  if(!eos_flag) error->all(FLERR,"pair_style dpd/fdt/energy requires an EOS to be specified");
+    if (utils::strmatch(modify->fix[i]->style,"^eos")) eos_flag = true;
+  if(!eos_flag) error->all(FLERR,"pair_style dpd/fdt/energy requires an EOS fix to be specified");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-DPD/pair_exp6_rx.cpp
+++ b/src/USER-DPD/pair_exp6_rx.cpp
@@ -582,7 +582,7 @@ void PairExp6rx::coeff(int narg, char **arg)
 
   bool rx_flag = false;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"rx",2) == 0) rx_flag = true;
+    if (utils::strmatch(modify->fix[i]->style,"^rx")) rx_flag = true;
   if (!rx_flag) error->all(FLERR,"PairExp6rx requires a fix rx command.");
 
   if (!allocated) allocate();

--- a/src/USER-DPD/pair_multi_lucy_rx.cpp
+++ b/src/USER-DPD/pair_multi_lucy_rx.cpp
@@ -368,7 +368,7 @@ void PairMultiLucyRX::coeff(int narg, char **arg)
 
   bool rx_flag = false;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"rx",2) == 0) rx_flag = true;
+    if (utils::strmatch(modify->fix[i]->style,"^rx")) rx_flag = true;
   if (!rx_flag) error->all(FLERR,"PairMultiLucyRX requires a fix rx command.");
 
   if (!allocated) allocate();

--- a/src/USER-DPD/pair_table_rx.cpp
+++ b/src/USER-DPD/pair_table_rx.cpp
@@ -26,6 +26,7 @@
 #include "error.h"
 #include "modify.h"
 #include "fix.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
 
@@ -303,8 +304,8 @@ void PairTableRX::coeff(int narg, char **arg)
 
   bool rx_flag = false;
   for (int i = 0; i < modify->nfix; i++)
-    if (strncmp(modify->fix[i]->style,"rx",2) == 0) rx_flag = true;
-  if (!rx_flag) error->all(FLERR,"PairTableRX requires a fix rx command.");
+    if (utils::strmatch(modify->fix[i]->style,"^rx")) rx_flag = true;
+  if (!rx_flag) error->all(FLERR,"Pair style table/rx requires a fix rx command.");
 
   int ilo,ihi,jlo,jhi;
   force->bounds(FLERR,arg[0],atom->ntypes,ilo,ihi);


### PR DESCRIPTION
**Summary**

Some style comparisons were still using strncmp() instead of utils::strmatch() and in part those were incorrect. This PR remedies the situation.

**Related Issues**

This obsoletes and thus closes #1991 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
