### PR TITLE
Defines to build and link the Lepton library with MSVC

### DIFF
--- a/cmake/Modules/Packages/USER-COLVARS.cmake
+++ b/cmake/Modules/Packages/USER-COLVARS.cmake
@@ -12,6 +12,8 @@ if(COLVARS_LEPTON)
   if(NOT BUILD_SHARED_LIBS)
     install(TARGETS lepton EXPORT LAMMPS_Targets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
+  # Change the define below to LEPTON_BUILDING_SHARED_LIBRARY when linking Lepton as a DLL with MSVC
+  target_compile_definitions(lepton PRIVATE -DLEPTON_BUILDING_STATIC_LIBRARY)
   set_target_properties(lepton PROPERTIES OUTPUT_NAME lammps_lepton${LAMMPS_MACHINE})
   target_include_directories(lepton PRIVATE ${LEPTON_DIR}/include)
 endif()
@@ -27,6 +29,8 @@ target_link_libraries(lammps PRIVATE colvars)
 
 if(COLVARS_LEPTON)
   target_link_libraries(lammps PRIVATE lepton)
-  target_compile_options(colvars PRIVATE -DLEPTON)
+  target_compile_definitions(colvars PRIVATE -DLEPTON)
+  # Disable the line below when linking Lepton as a DLL with MSVC
+  target_compile_definitions(colvars PRIVATE -DLEPTON_USE_STATIC_LIBRARIES)
   target_include_directories(colvars PUBLIC ${LEPTON_DIR}/include)
 endif()

--- a/lib/colvars/Makefile.common
+++ b/lib/colvars/Makefile.common
@@ -61,7 +61,7 @@ ifeq ($(COLVARS_LEPTON),no)
 LEPTON_INCFLAGS = 
 COLVARS_OBJS = $(COLVARS_SRCS:.cpp=.o)
 else
-LEPTON_INCFLAGS = -Ilepton/include -DLEPTON
+LEPTON_INCFLAGS = -Ilepton/include -DLEPTON -DLEPTON_USE_STATIC_LIBRARIES
 COLVARS_OBJS = $(COLVARS_SRCS:.cpp=.o) $(LEPTON_SRCS:.cpp=.o)
 endif
 
@@ -82,4 +82,20 @@ Makefile.deps: $(COLVARS_SRCS)
 	  done
 
 include Makefile.deps
+
+# Exceptions to pattern rule above for Lepton objects
+
+lepton/src/CompiledExpression.o: lepton/src/CompiledExpression.cpp
+	$(CXX) $(CXXFLAGS) -Ilepton/include -DLEPTON_BUILDING_STATIC_LIBRARY -c -o $@ $<
+lepton/src/ExpressionProgram.o: lepton/src/ExpressionProgram.cpp
+	$(CXX) $(CXXFLAGS) -Ilepton/include -DLEPTON_BUILDING_STATIC_LIBRARY -c -o $@ $<
+lepton/src/ExpressionTreeNode.o: lepton/src/ExpressionTreeNode.cpp
+	$(CXX) $(CXXFLAGS) -Ilepton/include -DLEPTON_BUILDING_STATIC_LIBRARY -c -o $@ $<
+lepton/src/Operation.o: lepton/src/Operation.cpp
+	$(CXX) $(CXXFLAGS) -Ilepton/include -DLEPTON_BUILDING_STATIC_LIBRARY -c -o $@ $<
+lepton/src/ParsedExpression.o: lepton/src/ParsedExpression.cpp
+	$(CXX) $(CXXFLAGS) -Ilepton/include -DLEPTON_BUILDING_STATIC_LIBRARY -c -o $@ $<
+lepton/src/Parser.o: lepton/src/Parser.cpp
+	$(CXX) $(CXXFLAGS) -Ilepton/include -DLEPTON_BUILDING_STATIC_LIBRARY -c -o $@ $<
+
 include Makefile.lepton.deps # Hand-generated


### PR DESCRIPTION
**Summary**

Adds to the build systems the correct flags necessary to handle `dllexport` and `dllimport` correctly for the Lepton library with MicroSoft Visual Studio (MSVC).
MSVC is not presently supported with LAMMPS to my knowledge: if someone tries it at some point, this PR aims to fix a potential issue with it.

**Related Issues**

Mentioned in a comment to #1992.

**Author(s)**

@giacomofiorin 
The Lepton library is authored by @peastman and distributed at https://github.com/openmm/openmm/

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

Relevant defines for Lepton have been added to the Colvars Makefile and CMake recipe file.  Both assume that all the libraries used by LAMMPS packages are linked statically, regardless of the value of `BUILD_SHARED_LIBS`: the latter only specifies linkage for the LAMMPS library (*).  I left two comments instructing to change the defines accordingly if libraries are linked dynamically at some point.

(*) I have been confused by it indeed.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system


