### PR TITLE
Add support for "internal" kim_match_pairs command

### DIFF
--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -307,7 +307,7 @@ void KimInteractions::KIM_MATCH_PAIRS(char const *const input_line) const
     char *str;
     str = strtok(NULL," \t");
     if (str == NULL)
-      error->one(FLERR,"Incorrect args for pair_species_coeff command");
+      error->one(FLERR,"Incorrect args for KIM_MATCH_PAIRS command");
     species.push_back(str);
   }
 

--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -15,6 +15,7 @@
    Contributing authors: Axel Kohlmeyer (Temple U),
                          Ryan S. Elliott (UMN)
                          Ellad B. Tadmor (UMN)
+                         Ronald Miller   (Carleton U)
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
@@ -57,8 +58,10 @@
 
 #include "kim_interactions.h"
 #include <cstring>
+#include <cstdio>
 #include <string>
 #include <sstream>
+#include <vector>
 #include "error.h"
 #include "atom.h"
 #include "comm.h"
@@ -79,6 +82,8 @@ extern "C" {
                                           << std::dec << x).str()
 
 using namespace LAMMPS_NS;
+
+#define MAXLINE 1024
 
 /* ---------------------------------------------------------------------- */
 
@@ -223,8 +228,16 @@ void KimInteractions::do_setup(int narg, char **arg)
         for (int j=0; j < sim_lines; ++j) {
           KIM_SimulatorModel_GetSimulatorFieldLine(
               simulatorModel,sim_model_idx,j,&sim_value);
-          input->one(sim_value);
-        }
+	  char strbuf[MAXLINE];
+	  char * strword;
+	  strcpy(strbuf,sim_value);
+	  strword = strtok(strbuf," \t");
+	  if (0==strcmp(strword,"kim_match_pairs")) {
+	    kim_match_pairs(sim_value);
+	  } else {
+            input->one(sim_value);
+          }
+	}
       }
     }
 
@@ -259,6 +272,73 @@ void KimInteractions::do_setup(int narg, char **arg)
   // End output to log file
   kim_interactions_log_delimiter("end");
 
+}
+
+/* ---------------------------------------------------------------------- */
+
+void KimInteractions::kim_match_pairs(char const *const input_line) const
+{
+  char strbuf[MAXLINE];
+  strcpy(strbuf,input_line);
+  char *cmd, *filename;
+  cmd = strtok(strbuf," \t");
+  filename = strtok(NULL," \t");
+
+  FILE *fp;
+  fp = fopen(filename,"r");
+  if (fp == NULL) {
+    error->one(FLERR,"Parameter file not found");
+  }
+
+  std::vector<char *> species;
+  for (int i = 0; i < atom->ntypes; ++i)
+  {
+    char *str;
+    str = strtok(NULL," \t");
+    if (str == NULL)
+      error->one(FLERR,"Incorrect args for pair_species_coeff command");
+    species.push_back(str);
+  }
+
+  char line[MAXLINE],*ptr;
+  int n, eof = 0;
+
+  while (1) {
+    if (comm->me == 0) {
+      ptr = fgets(line,MAXLINE,fp);
+      if (ptr == NULL) {
+        eof = 1;
+        fclose(fp);
+      } else n = strlen(line) + 1;
+    }
+    MPI_Bcast(&eof,1,MPI_INT,0,world);
+    if (eof) break;
+    MPI_Bcast(&n,1,MPI_INT,0,world);
+    MPI_Bcast(line,n,MPI_CHAR,0,world);
+
+    char *species1, *species2, *the_rest;
+    ptr = line;
+    species1 = strtok(ptr," \t");
+    species2 = strtok(NULL," \t");
+    the_rest = strtok(NULL,"\n");
+
+    for (int type_a = 0; type_a < atom->ntypes; ++type_a) {
+      for (int type_b = type_a; type_b < atom->ntypes; ++type_b) {
+	if(((strcmp(species[type_a],species1) == 0) &&
+            (strcmp(species[type_b],species2) == 0))
+           ||
+	   ((strcmp(species[type_b],species1) == 0) &&
+            (strcmp(species[type_a],species2) == 0))
+          ) {
+          char pair_command[MAXLINE];
+	  sprintf(pair_command,"pair_coeff %i %i %s",type_a+1,type_b+1,
+                  the_rest);
+	  input->one(pair_command);
+	}
+      }
+    }
+  }
+  fclose(fp);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -232,8 +232,19 @@ void KimInteractions::do_setup(int narg, char **arg)
 	  char * strword;
 	  strcpy(strbuf,sim_value);
 	  strword = strtok(strbuf," \t");
-	  if (0==strcmp(strword,"kim_match_pairs")) {
-	    kim_match_pairs(sim_value);
+	  if (0==strcmp(strword,"KIM_MATCH_PAIRS")) {
+            // Notes regarding the KIM_MATCH_PAIRS command
+            //  * This is an INTERNAL command.
+            //  * It is intended for use only by KIM Simulator Models.
+            //  * It is not possible to use this command outside of the context
+            //    of the kim_interactions command and KIM Simulator Models.
+            //  * The command performs a transformation from symbolic
+            //    string-based atom types to lammps numeric atom types for
+            //    the pair_coeff settings.
+            //  * The command is not documented fully as it is expected to be
+            //    temporary.  Eventually it should be replaced by a more
+            //    comprehensive symbolic types support in lammps.
+	    KIM_MATCH_PAIRS(sim_value);
 	  } else {
             input->one(sim_value);
           }
@@ -276,7 +287,7 @@ void KimInteractions::do_setup(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-void KimInteractions::kim_match_pairs(char const *const input_line) const
+void KimInteractions::KIM_MATCH_PAIRS(char const *const input_line) const
 {
   char strbuf[MAXLINE];
   strcpy(strbuf,input_line);

--- a/src/KIM/kim_interactions.h
+++ b/src/KIM/kim_interactions.h
@@ -77,7 +77,7 @@ class KimInteractions : protected Pointers {
  private:
   void do_setup(int, char **);
   int species_to_atomic_no(std::string const species) const;
-  void kim_match_pairs(char const *const input_line) const;
+  void KIM_MATCH_PAIRS(char const *const input_line) const;
   void kim_interactions_log_delimiter(std::string const begin_end) const;
 };
 

--- a/src/KIM/kim_interactions.h
+++ b/src/KIM/kim_interactions.h
@@ -15,6 +15,7 @@
    Contributing authors: Axel Kohlmeyer (Temple U),
                          Ryan S. Elliott (UMN)
                          Ellad B. Tadmor (UMN)
+                         Ronald Miller   (Carleton U)
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
@@ -76,6 +77,7 @@ class KimInteractions : protected Pointers {
  private:
   void do_setup(int, char **);
   int species_to_atomic_no(std::string const species) const;
+  void kim_match_pairs(char const *const input_line) const;
   void kim_interactions_log_delimiter(std::string const begin_end) const;
 };
 


### PR DESCRIPTION
**Summary**

Add support for a `kim_match_pairs` command within processing for KIM Simulator Model commands to the `kim_interactions` command.

**Related Issues**

PR #1989 would provide the necessary support, but that PR is likely to take time to resolve.  In the meantime, we would like to have this feature available for KIM SM's.

**Author(s)**
Ron Miller (Carleton U)
Ryan S. Elliott (UMinn)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues

**Implementation Notes**

None

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



