### PR TITLE
Remove unnecessary error check in USER-DPD fix rx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,6 @@ src/SPIN/*            @julient31
 src/USER-CGDNA/*      @ohenrich
 src/USER-CGSDK/*      @akohlmey
 src/USER-COLVARS/*    @giacomofiorin
-src/USER-DPD/*        @timattox
 src/USER-INTEL/*      @wmbrownintel
 src/USER-MANIFOLD/*   @Pakketeretet2
 src/USER-MEAMC/*      @martok

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -256,10 +256,6 @@ void FixRX::post_constructor()
   int nUniqueSpecies = 0;
   bool match;
 
-  for (int i = 0; i < modify->nfix; i++)
-    if (utils::strmatch(modify->fix[i]->style,"^property/atom") == 0)
-      error->all(FLERR,"fix rx cannot be combined with fix property/atom");
-
   char **tmpspecies = new char*[maxspecies];
   int tmpmaxstrlen = 0;
   for(int jj=0; jj < maxspecies; jj++)

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -31,7 +31,6 @@
 #include "neigh_request.h"
 #include "math_special.h"
 #include "pair_dpd_fdt_energy.h"
-#include "utils.h"
 
 #include <vector> // std::vector<>
 #include <algorithm> // std::max


### PR DESCRIPTION
**Summary**

Remove unnecessary error check in USER-DPD `fix rx`, per the direction of Jim Larentzos (USER-DPD developer).

**Related Issues**

Fixes #2001.

**Author(s)**

Stan Moore (Sandia)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.