### PR TITLE
Fixed the doc page for fix wall/body/polyhedron

### DIFF
--- a/doc/src/fix_wall_body_polyhedron.rst
+++ b/doc/src/fix_wall_body_polyhedron.rst
@@ -15,15 +15,14 @@ Syntax
 * k_n = normal repulsion strength (force/distance units or pressure units - see discussion below)
 * c_n = normal damping coefficient (force/distance units or pressure units - see discussion below)
 * c_t = tangential damping coefficient (force/distance units or pressure units - see discussion below)
-* wallstyle = *xplane* or *yplane* or *zplane* or *zcylinder*
+* wallstyle = *xplane* or *yplane* or *zplane*
 * args = list of arguments for a particular style
 
   .. parsed-literal::
 
-       *xplane* or *yplane* args = lo hi
+       *xplane* or *yplane* or *zplane* args = lo hi
          lo,hi = position of lower and upper plane (distance units), either can be NULL)
-       *zcylinder* args = radius
-         radius = cylinder radius (distance units)
+
 
 * zero or more keyword/value pairs may be appended to args
 * keyword = *wiggle*
@@ -60,8 +59,7 @@ those specified with the :doc:`pair_style body/rounded/polyhedron <pair_body_rou
 The *wallstyle* can be planar or cylindrical.  The 3 planar options
 specify a pair of walls in a dimension.  Wall positions are given by
 *lo* and *hi*\ .  Either of the values can be specified as NULL if a
-single wall is desired.  For a *zcylinder* wallstyle, the cylinder's
-axis is at x = y = 0.0, and the radius of the cylinder is specified.
+single wall is desired.
 
 Optionally, the wall can be moving, if the *wiggle* keyword is appended.
 
@@ -71,8 +69,7 @@ particles.  The arguments to the *wiggle* keyword specify a dimension
 for the motion, as well as it's *amplitude* and *period*\ .  Note that
 if the dimension is in the plane of the wall, this is effectively a
 shearing motion.  If the dimension is perpendicular to the wall, it is
-more of a shaking motion.  A *zcylinder* wall can only be wiggled in
-the z dimension.
+more of a shaking motion.
 
 Each timestep, the position of a wiggled wall in the appropriate *dim*
 is set according to this equation:


### PR DESCRIPTION
**Summary**

Fixed the doc page for fix wall body/polyhedron: removing the mention of zcylinder, which is not supported by this fix for the time being, and adding zplane, which is actually supported.

**Related Issues**

n/a

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

n/a

**Implementation Notes**

n/a

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete


