### PR TITLE
Fixes memory deallocation for `nterms` variable.

### DIFF
--- a/src/USER-MISC/dihedral_nharmonic.cpp
+++ b/src/USER-MISC/dihedral_nharmonic.cpp
@@ -49,7 +49,7 @@ DihedralNHarmonic::~DihedralNHarmonic()
     for (int i = 1; i <= atom->ndihedraltypes; i++)
       delete [] a[i];
     delete [] a;
-    delete [] nterms;
+    memory->destroy(nterms);
   }
 }
 


### PR DESCRIPTION
**Summary**
In `USER-MISC/dihedral_nharmonic.cpp` the variable `nterms` is allocated with `memory->create` at line 264, so I would expect a call to `memory->destroy` to free memory.

**Author(s)**

Cristian Di Pietrantonio
Supercomputing Applications Specialist @ Pawsey Supercomputing Centre

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Backward compatible

**Post Submission Checklist**

_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

