### PR TITLE
Collected bug fixes and small updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@ src/GPU/pair_vashishta_gpu.*        @andeplane
 src/KOKKOS/pair_vashishta_kokkos.*  @andeplane
 src/MANYBODY/pair_vashishta_table.* @andeplane
 src/MANYBODY/pair_atm.*             @sergeylishchuk
-src/USER-MISC/fix_bond_react.*      @jrgissing
+src/USER-REACTION/fix_bond_react.*  @jrgissing
 src/USER-MISC/*_grem.*              @dstelter92
 src/USER-MISC/compute_stress_mop*.* @RomainVermorel
 

--- a/doc/include-file-conventions.md
+++ b/doc/include-file-conventions.md
@@ -49,22 +49,15 @@ include files provided with LAMMPS are included with double quotes
 
 For headers declaring functions of the C-library, the corresponding
 C++ versions should be included (examples: `#include <cstdlib>` or
-`#include <cctypes>`).  However, these includes are limited to those defined
-in the C++98 standard.  Some files thus must use the older style until
-the minimum C++ standard requirement of LAMMPS is lifted to C++11 or
-even beyond (examples: `#include <stdint.h>` versus `#include <cstdint>`
-or `#include <inttypes.h>` versus `#include <cinttypes>`).
+`#include <cctypes>` instead of `#include <stdlib.h>` or
+`#include<ctypes.h>` ).
 
 ### C++ Standard Compliance
 
-LAMMPS core files currently correspond to the C++98 standard. Files
-requiring C++11 or later are only permitted in (optional) packages
-and particularly packages that are not part of the list of commonly
-used packages such as MOLECULE, KSPACE, MANYBODY, or RIGID.
-
-Also, LAMMPS uses the C-style stdio library for I/O instead of iostreams.
-Since using both at the same time can cause problems, iostreams should
-be avoided where possible.
+LAMMPS core files use standard conforming C++ compatible with the
+C++11 standard, unless explicitly noted.  Also, LAMMPS uses the C-style
+stdio library for I/O instead of iostreams.  Since using both at the
+same time can cause problems, iostreams should be avoided where possible.
 
 ### Lean Header Files
 

--- a/doc/src/compute_stress_atom.rst
+++ b/doc/src/compute_stress_atom.rst
@@ -2,6 +2,7 @@
 
 compute stress/atom command
 ===========================
+
 compute centroid/stress/atom command
 ====================================
 
@@ -223,15 +224,14 @@ The per-atom array values will be in pressure\*volume
 
 Restrictions
 """"""""""""
-Currently, compute *centroid/stress/atom* does not support
-pair styles with many-body interactions,
-such as :doc:`Tersoff <pair_tersoff>`,
-and LAMMPS will generate an error in such cases.
-In principal, equivalent formulation
-to that of angle, dihedral and improper contributions
-in the virial :math:`W_{ab}` formula
-can also be applied to the many-body pair styles,
-and is planned in the future.
+
+Currently (Spring 2020), compute *centroid/stress/atom* does not support
+pair styles with many-body interactions, such as :doc:`Tersoff
+<pair_tersoff>`, or pair styles with long-range Coulomb interactions.
+LAMMPS will generate an error in such cases.  In principal, equivalent
+formulation to that of angle, dihedral and improper contributions in the
+virial :math:`W_{ab}` formula can also be applied to the many-body pair
+styles, and is planned in the future.
 
 Related commands
 """"""""""""""""

--- a/doc/src/fix_heat.rst
+++ b/doc/src/fix_heat.rst
@@ -47,16 +47,22 @@ and the specified geometric :doc:`region <region>` in order to have
 energy added or subtracted to it.  If not specified, then the atoms in
 the group are affected wherever they may move to.
 
-Heat addition/subtraction is performed every N timesteps.  The *eflux*
-parameter can be specified as a numeric constant or as a variable (see
-below).  If it is a numeric constant or equal-style variable which
-evaluates to a scalar value, then the *eflux* determines the change in
-aggregate energy of the entire group of atoms per unit time, e.g. in
-eV/psec for :doc:`metal units <units>`.  In this case it is an
-"extensive" quantity, meaning its magnitude should be scaled with the
-number of atoms in the group.  Note that since *eflux* has per-time
-units (i.e. it is a flux), this means that a larger value of N will
-add/subtract a larger amount of energy each time the fix is invoked.
+Heat addition/subtraction is performed every N timesteps.
+
+The *eflux* parameter can be specified as a numeric constant or as an
+equal- or atom-style :doc:`variable <variable>`.  If the value is a
+variable, it should be specified as v_name, where *name* is the variable
+name.  In this case, the variable will be evaluated each timestep, and
+its current value(s) used to determine the flux.
+
+If *eflux* is a numeric constant or equal-style variable which evaluates
+to a scalar value, then *eflux* determines the change in aggregate energy
+of the entire group of atoms per unit time, e.g. in eV/psec for
+:doc:`metal units <units>`.  In this case it is an "extensive" quantity,
+meaning its magnitude should be scaled with the number of atoms in the
+group.  Note that since *eflux* also has per-time units (i.e. it is a
+flux), this means that a larger value of N will add/subtract a larger
+amount of energy each time the fix is invoked.
 
 .. note::
 
@@ -70,12 +76,6 @@ the variable computes one value per atom.  In this case, each value is
 the energy flux for a single atom, again in units of energy per unit
 time.  In this case, each value is an "intensive" quantity, which need
 not be scaled with the number of atoms in the group.
-
-As mentioned above, the *eflux* parameter can be specified as an
-equal-style or atom_style :doc:`variable <variable>`.  If the value is a
-variable, it should be specified as v_name, where name is the variable
-name.  In this case, the variable will be evaluated each timestep, and
-its value(s) used to determine the flux.
 
 Equal-style variables can specify formulas with various mathematical
 functions, and include :doc:`thermo_style <thermo_style>` command

--- a/src/KSPACE/pair_buck_long_coul_long.cpp
+++ b/src/KSPACE/pair_buck_long_coul_long.cpp
@@ -430,10 +430,17 @@ void PairBuckLongCoulLong::write_data(FILE *fp)
 
 void PairBuckLongCoulLong::write_data_all(FILE *fp)
 {
-  for (int i = 1; i <= atom->ntypes; i++)
-    for (int j = i; j <= atom->ntypes; j++)
-      fprintf(fp,"%d %d %g %g %g\n",i,j,
-              buck_a_read[i][j],buck_rho_read[i][j],buck_c_read[i][j]);
+  for (int i = 1; i <= atom->ntypes; i++) {
+    for (int j = i; j <= atom->ntypes; j++) {
+      if (ewald_order & (1<<6)) {
+      fprintf(fp,"%d %d %g %g\n",i,j,
+              buck_a_read[i][j],buck_rho_read[i][j]);
+      } else {
+        fprintf(fp,"%d %d %g %g %g\n",i,j,
+                buck_a_read[i][j],buck_rho_read[i][j],buck_c_read[i][j]);
+      }
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/pair_lj_long_coul_long.cpp
+++ b/src/KSPACE/pair_lj_long_coul_long.cpp
@@ -427,10 +427,17 @@ void PairLJLongCoulLong::write_data(FILE *fp)
 
 void PairLJLongCoulLong::write_data_all(FILE *fp)
 {
-  for (int i = 1; i <= atom->ntypes; i++)
-    for (int j = i; j <= atom->ntypes; j++)
-      fprintf(fp,"%d %d %g %g %g\n",i,j,
-              epsilon_read[i][j],sigma_read[i][j],cut_lj_read[i][j]);
+  for (int i = 1; i <= atom->ntypes; i++) {
+    for (int j = i; j <= atom->ntypes; j++) {
+      if (ewald_order & (1<<6)) {
+        fprintf(fp,"%d %d %g %g\n",i,j,
+                epsilon_read[i][j],sigma_read[i][j]);
+      } else {
+        fprintf(fp,"%d %d %g %g %g\n",i,j,
+                epsilon_read[i][j],sigma_read[i][j],cut_lj_read[i][j]);
+      }
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/fix_heat.cpp
+++ b/src/fix_heat.cpp
@@ -300,6 +300,7 @@ double FixHeat::compute_scalar()
 {
   double average_scale = scale;
   if (hstyle == ATOM) {
+    if (!vscale) return 1.0;
     double scale_sum = 0.0;
     int ncount = 0;
     int *mask = atom->mask;

--- a/src/hashlittle.h
+++ b/src/hashlittle.h
@@ -6,7 +6,7 @@
 #define LMP_HASHLITTLE_H
 
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 
 namespace LAMMPS_NS {
   uint32_t hashlittle(const void *key, size_t length, uint32_t);

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -53,7 +53,7 @@
 #ifdef _WIN32
 #define PSAPI_VERSION 1
 #include <windows.h>
-#include <stdint.h> // <cstdint> requires C++-11
+#include <cstdint>
 #include <psapi.h>
 #else
 #include <sys/resource.h>

--- a/src/math_special.cpp
+++ b/src/math_special.cpp
@@ -1,6 +1,6 @@
 #include "math_special.h"
 #include <cmath>
-#include <stdint.h> // IWYU pragma: keep
+#include <cstdint> // IWYU pragma: keep
 
 using namespace LAMMPS_NS;
 

--- a/src/replicate.cpp
+++ b/src/replicate.cpp
@@ -196,6 +196,12 @@ void Replicate::command(int narg, char **arg)
   atom->dihedral_per_atom = old->dihedral_per_atom;
   atom->improper_per_atom = old->improper_per_atom;
 
+  atom->extra_bond_per_atom = old->extra_bond_per_atom;
+  atom->extra_angle_per_atom = old->extra_angle_per_atom;
+  atom->extra_dihedral_per_atom = old->extra_dihedral_per_atom;
+  atom->extra_improper_per_atom = old->extra_improper_per_atom;
+  atom->maxspecial = old->maxspecial;
+
   // store old simulation box
 
   int triclinic = domain->triclinic;

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -21,7 +21,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#include <stdint.h> // <cstdint> requires C++-11
+#include <cstdint>
 #else
 #include <sys/time.h>
 #include <sys/resource.h>

--- a/tools/singularity/ubuntu16.04.def
+++ b/tools/singularity/ubuntu16.04.def
@@ -8,7 +8,7 @@ From: ubuntu:16.04
     apt-get install --no-install-recommends -y \
         bc build-essential curl doxygen vim-nox wget \
         make cmake cmake-curses-gui ninja-build git \
-        rsync ssh \
+        rsync ssh less \
         ccache gcc g++ gfortran \
         mpi-default-bin mpi-default-dev \
         libfftw3-dev libjpeg-dev libpng12-dev libblas-dev liblapack-dev \

--- a/tools/singularity/ubuntu18.04.def
+++ b/tools/singularity/ubuntu18.04.def
@@ -20,15 +20,19 @@ From: ubuntu:18.04
         gfortran \
         git \
         hdf5-tools \
+        less \
         libblas-dev \
         libeigen3-dev \
         libenchant-dev \
         libfftw3-dev \
         libgsl-dev \
         libhdf5-serial-dev \
+        libhwloc-dev \
         libjpeg-dev \
         liblapack-dev \
+        libomp-dev \
         libopenblas-dev \
+        libnuma-dev \
         libpng-dev \
         libproj-dev \
         libvtk6-dev \

--- a/tools/singularity/ubuntu18.04_amd_rocm.def
+++ b/tools/singularity/ubuntu18.04_amd_rocm.def
@@ -24,14 +24,18 @@ From: rocm/dev-ubuntu-18.04
         gfortran \
         git \
         hdf5-tools \
+        kmod \
+        less \
         libblas-dev \
         libeigen3-dev \
         libenchant-dev \
         libfftw3-dev \
         libgsl-dev \
         libhdf5-serial-dev \
+        libhwloc-dev \
         libjpeg-dev \
         liblapack-dev \
+        libomp-dev \
         libopenblas-dev \
         libnuma-dev \
         libpng-dev \
@@ -53,6 +57,12 @@ From: rocm/dev-ubuntu-18.04
         rocm-libs \
         rsync \
         ssh \
+        texlive \
+        texlive-latex-recommended \
+        texlive-pictures \
+        texlive-publishers \
+        texlive-science \
+        dvipng \
         vim-nox \
         virtualenv \
         voro++-dev \

--- a/tools/singularity/ubuntu18.04_intel_opencl.def
+++ b/tools/singularity/ubuntu18.04_intel_opencl.def
@@ -22,15 +22,19 @@ From: ubuntu:18.04
         gfortran \
         git \
         hdf5-tools \
+        less \
         libblas-dev \
         libeigen3-dev \
         libenchant-dev \
         libfftw3-dev \
         libgsl-dev \
         libhdf5-serial-dev \
+        libhwloc-dev \
         libjpeg-dev \
         liblapack-dev \
+        libomp-dev \
         libopenblas-dev \
+        libnuma-dev \
         libpng-dev \
         libproj-dev \
         libvtk6-dev \
@@ -51,6 +55,12 @@ From: ubuntu:18.04
         python3-virtualenv \
         rsync \
         ssh \
+        texlive \
+        texlive-latex-recommended \
+        texlive-pictures \
+        texlive-publishers \
+        texlive-science \
+        dvipng \
         vim-nox \
         virtualenv \
         voro++-dev \

--- a/tools/singularity/ubuntu18.04_nvidia.def
+++ b/tools/singularity/ubuntu18.04_nvidia.def
@@ -22,15 +22,19 @@ From: nvidia/cuda:10.2-devel-ubuntu18.04
         gfortran \
         git \
         hdf5-tools \
+        less \
         libblas-dev \
         libeigen3-dev \
         libenchant-dev \
         libfftw3-dev \
         libgsl-dev \
         libhdf5-serial-dev \
+        libhwloc-dev \
         libjpeg-dev \
         liblapack-dev \
+        libomp-dev \
         libopenblas-dev \
+        libnuma-dev \
         libpng-dev \
         libproj-dev \
         libvtk6-dev \
@@ -51,6 +55,12 @@ From: nvidia/cuda:10.2-devel-ubuntu18.04
         python3-virtualenv \
         rsync \
         ssh \
+        texlive \
+        texlive-latex-recommended \
+        texlive-pictures \
+        texlive-publishers \
+        texlive-science \
+        dvipng \
         vim-nox \
         virtualenv \
         voro++-dev \

--- a/tools/singularity/ubuntu20.04.def
+++ b/tools/singularity/ubuntu20.04.def
@@ -20,16 +20,19 @@ From: ubuntu:20.04
         gfortran \
         git \
         hdf5-tools \
+        less \
         libblas-dev \
         libeigen3-dev \
         libenchant-dev \
         libfftw3-dev \
         libgsl-dev \
         libhdf5-serial-dev \
+        libhwloc-dev \
         libjpeg-dev \
         liblapack-dev \
-        libopenblas-dev \
         libomp-dev \
+        libopenblas-dev \
+        libnuma-dev \
         libpng-dev \
         libproj-dev \
         libvtk6-dev \


### PR DESCRIPTION
**Summary**

This PR fixes a few bugs that were reported recently.

It also updates the singularity definition files for LAMMPS development on ubuntu variants to allow testing more features.

Furthermore, some more details are added in the explanation of the restrictions of `compute centroid/stress/atom`.

The file `doc/include-file-conventions.md` was updated to reflect the new C++11 standard requirement and some `#include <stdint.h>` lines were changed to `#include <cstdint>`.

**Related Issues**

Fixes #2009 
Fixes #1982 

Fixes a segfault in fix heat, when using the global scalar with an atom style variable
https://sourceforge.net/p/lammps/mailman/message/36988973/

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Implementation Notes**

- to correct #2009 some additional data needs to be copied from the old to the new `Atom` class instance.
- to correct #1982 the per type-pair cutoff may not be written, when the LJ processing is set to `long` as then only the global cutoff may be used. Otherwise garbage data is written.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
