### PR TITLE
Added changes to support SMs setting charges in kim_interactions

### DIFF
--- a/src/KIM/kim_interactions.h
+++ b/src/KIM/kim_interactions.h
@@ -77,7 +77,7 @@ class KimInteractions : protected Pointers {
  private:
   void do_setup(int, char **);
   int species_to_atomic_no(std::string const species) const;
-  void KIM_MATCH_PAIRS(char const *const input_line) const;
+  void KIM_SET_TYPE_PARAMETERS(char const *const input_line) const;
   void kim_interactions_log_delimiter(std::string const begin_end) const;
 };
 


### PR DESCRIPTION
**Summary**

Update and expand `kim_interactions` support for internal commands to enable more robust KIM Simulator Model definitions.

**Related Issues**

none

**Author(s)**

Ronald Miller (Carleton U)
Ryan S. Elliott (U Minn)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

no issues

**Implementation Notes**

support "species string" setting of charge as well as pair_coeff.  Also allow comment lines in associated parameter files.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



