### PR TITLE
Fix spline meam binning

### DIFF
--- a/src/USER-MISC/pair_meam_spline.cpp
+++ b/src/USER-MISC/pair_meam_spline.cpp
@@ -717,6 +717,7 @@ void PairMEAMSpline::SplineFunction::prepareSpline(Error* error)
     Y2[i] /= h*6.0;
 #endif
   }
+  inv_h = (1/h);
   xmax_shifted = xmax - xmin;
 }
 
@@ -732,6 +733,7 @@ void PairMEAMSpline::SplineFunction::communicate(MPI_Comm& world, int me)
   MPI_Bcast(&isGridSpline, 1, MPI_INT, 0, world);
   MPI_Bcast(&h, 1, MPI_DOUBLE, 0, world);
   MPI_Bcast(&hsq, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&inv_h, 1, MPI_DOUBLE, 0, world);
   if(me != 0) {
     X = new double[N];
     Xs = new double[N];

--- a/src/USER-MISC/pair_meam_spline.h
+++ b/src/USER-MISC/pair_meam_spline.h
@@ -142,7 +142,7 @@ protected:
           ((a*a*a - a) * Y2[klo] + (b*b*b - b) * Y2[khi])*(h*h)/6.0;
 #else
         // For a spline with regular grid, we directly calculate the interval X is in.
-        int klo = (int)(x / h);
+        int klo = (int)(x*(1/h));
         int khi = klo + 1;
         double a = Xs[khi] - x;
         double b = h - a;

--- a/src/USER-MISC/pair_meam_spline.h
+++ b/src/USER-MISC/pair_meam_spline.h
@@ -186,7 +186,7 @@ protected:
            (b*b*b - b) * Y2[khi]) * (h*h) / 6.0;
 #else
         // For a spline with regular grid, we directly calculate the interval X is in.
-        int klo = (int)(x / h);
+        int klo = (int)(x*(1/h));
         int khi = klo + 1;
         double a = Xs[khi] - x;
         double b = h - a;

--- a/src/USER-MISC/pair_meam_spline.h
+++ b/src/USER-MISC/pair_meam_spline.h
@@ -142,7 +142,7 @@ protected:
           ((a*a*a - a) * Y2[klo] + (b*b*b - b) * Y2[khi])*(h*h)/6.0;
 #else
         // For a spline with regular grid, we directly calculate the interval X is in.
-        int klo = (int)(x*(1/h));
+        int klo = (int)(x*inv_h);
         int khi = klo + 1;
         double a = Xs[khi] - x;
         double b = h - a;
@@ -186,7 +186,7 @@ protected:
            (b*b*b - b) * Y2[khi]) * (h*h) / 6.0;
 #else
         // For a spline with regular grid, we directly calculate the interval X is in.
-        int klo = (int)(x*(1/h));
+        int klo = (int)(x*inv_h);
         int khi = klo + 1;
         double a = Xs[khi] - x;
         double b = h - a;
@@ -224,6 +224,7 @@ protected:
     int isGridSpline;// Indicates that all spline knots are on a regular grid.
     double h;        // The distance between knots if this is a grid spline with equidistant knots.
     double hsq;      // The squared distance between knots if this is a grid spline with equidistant knots.
+    double inv_h;    // (1/h), used to avoid numerical errors in binnning for grid spline with equidistant knots.
     double xmax_shifted; // The end of the spline interval after it has been shifted to begin at X=0.
   };
 

--- a/src/USER-MISC/pair_meam_sw_spline.cpp
+++ b/src/USER-MISC/pair_meam_sw_spline.cpp
@@ -674,6 +674,7 @@ void PairMEAMSWSpline::SplineFunction::prepareSpline(Error* error)
                 Y2[i] /= h*6.0;
 #endif
         }
+        inv_h = 1/h;
         xmax_shifted = xmax - xmin;
 }
 
@@ -689,6 +690,7 @@ void PairMEAMSWSpline::SplineFunction::communicate(MPI_Comm& world, int me)
         MPI_Bcast(&isGridSpline, 1, MPI_INT, 0, world);
         MPI_Bcast(&h, 1, MPI_DOUBLE, 0, world);
         MPI_Bcast(&hsq, 1, MPI_DOUBLE, 0, world);
+        MPI_Bcast(&inv_h, 1, MPI_DOUBLE, 0, world);
         if(me != 0) {
                 X = new double[N];
                 Xs = new double[N];

--- a/src/USER-MISC/pair_meam_sw_spline.h
+++ b/src/USER-MISC/pair_meam_sw_spline.h
@@ -130,7 +130,7 @@ protected:
 #else
                                 // For a spline with grid points, we can directly calculate the interval X is in.
                                 //
-                                int klo = (int)(x / h);
+                                int klo = (int)(x*inv_h);
                                 if ( klo > N - 2 ) klo = N - 2;
                                 int khi = klo + 1;
                                 double a = Xs[khi] - x;
@@ -170,7 +170,7 @@ protected:
                                 return a * Y[klo] + b * Y[khi] + ((a*a*a - a) * Y2[klo] + (b*b*b - b) * Y2[khi]) * (h*h) / 6.0;
 #else
                                 // For a spline with grid points, we can directly calculate the interval X is in.
-                                int klo = (int)(x / h);
+                                int klo = (int)(x*inv_h);
                                 if ( klo > N - 2 ) klo = N - 2;
                                 int khi = klo + 1;
                                 double a = Xs[khi] - x;
@@ -207,6 +207,7 @@ protected:
                 int isGridSpline;                // Indicates that all spline knots are on a regular grid.
                 double h;                                // The distance between knots if this is a grid spline with equidistant knots.
                 double hsq;                                // The squared distance between knots if this is a grid spline with equidistant knots.
+                double inv_h;    // (1/h), used to avoid numerical errors in binnning for grid spline with equidistant knots.
                 double xmax_shifted;        // The end of the spline interval after it has been shifted to begin at X=0.
         };
 


### PR DESCRIPTION
**Summary**

Due to round-off error, x-values passed into `SplineFunction.eval()` could be improperly binned, causing the wrong knot value to be used and leading to incorrect energy evaluations.

The offending code was line 145 in `pair_meam_spline.h`: `int klo = (int)(x / h);`
By changing this line to instead be `int klo = (int)(x*(1/h));`, proper binning is now observed.

I don't have a LAMMPS example that reproduces this error, but the behavior can be seen in any double-precision floating point arithmetic. In my particular case, I first encountered this problem for `x = 1.9999999999999998` and `h = 0.3333333333333333`:

```
Python 3.6.10 |Anaconda, Inc.| (default, Jan  7 2020, 21:14:29)
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> x = 1.9999999999999998
>>> h = 0.3333333333333333
>>> x/h
6.0
>>> x*(1/h)
5.999999999999999
```

Since `x < 2` is true, `x` should be placed into the bin to the left of the knot at position `x=2.0`, but it is instead being placed into the bin to the _right_ of `x=2.0`. 

Included below is an example where this problem caused erroneous jumps in the energy evaluation. The results before this patch are shown in orange, while the results after are shown in blue.

![lammps_problem](https://user-images.githubusercontent.com/15058514/80025971-ffd7ed00-84a6-11ea-9ed2-dc6a4dce58ee.png)