### PR TITLE
cmake: add support for latte super-build

### DIFF
--- a/cmake/Modules/Packages/LATTE.cmake
+++ b/cmake/Modules/Packages/LATTE.cmake
@@ -1,4 +1,11 @@
 enable_language(Fortran)
+
+# using lammps in a super-build setting
+if(TARGET LATTE::latte)
+  target_link_libraries(lammps PRIVATE LATTE::latte)
+  return()
+endif()
+
 find_package(LATTE)
 if(LATTE_FOUND)
   set(DOWNLOAD_LATTE_DEFAULT OFF)


### PR DESCRIPTION
**Summary**

This allow to include lammps into a setting where the `LATTE::latte` target is already defined.

**Related Issues**

https://github.com/lanl/LATTE/pull/113

**Author(s)**

@junghans

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

**Implementation Notes**

all cmake

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated

**Further Information, Files, and Links**



