### PR TITLE
github templates: turn comments in real comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,24 +9,24 @@ assignees: ''
 
 **Summary**
 
-_Please provide a clear and concise description of what the bug is._
+<!--Please provide a clear and concise description of what the bug is.-->
 
 **LAMMPS Version and Platform**
 
-_Please specify precisely which LAMMPS version this issue was detected with (the first line of the output) and what platform (operating system and its version, hardware) you are running on. If possible, test with the most recent LAMMPS patch version_
+<!--Please specify precisely which LAMMPS version this issue was detected with (the first line of the output) and what platform (operating system and its version, hardware) you are running on. If possible, test with the most recent LAMMPS patch version-->
 
 **Expected Behavior**
 
-_Describe the expected behavior.  Quote from the LAMMPS manual where needed, or explain why the expected behavior is meaningful, especially when it differs from the manual_
+<!--Describe the expected behavior.  Quote from the LAMMPS manual where needed, or explain why the expected behavior is meaningful, especially when it differs from the manual-->
 
 **Actual Behavior**
 
-_Describe the actual behavior, how it differs from the expected behavior, and how this can be observed.  Try to be specific and do **not** use vague terms like "doesn't work" or "wrong result".  Do not assume that the person reading this has any experience with or knowledge of your specific area of research._
+<!--Describe the actual behavior, how it differs from the expected behavior, and how this can be observed.  Try to be specific and do **not** use vague terms like "doesn't work" or "wrong result".  Do not assume that the person reading this has any experience with or knowledge of your specific area of research.-->
 
 **Steps to Reproduce**
 
-_Describe the steps required to (quickly) reproduce the issue. You can attach (small) files to the section below or add URLs where to download an archive with all necessary files. Please try to create an input set that is as minimal and small as possible and reproduces the bug as quickly as possible. **NOTE:** the less effort and time it takes to reproduce your reported bug, the more likely it becomes, that somebody will look into it and fix the problem._
+<!--Describe the steps required to (quickly) reproduce the issue. You can attach (small) files to the section below or add URLs where to download an archive with all necessary files. Please try to create an input set that is as minimal and small as possible and reproduces the bug as quickly as possible. **NOTE:** the less effort and time it takes to reproduce your reported bug, the more likely it becomes, that somebody will look into it and fix the problem.-->
 
 **Further Information, Files, and Links**
 
-_Put any additional information here, attach relevant text or image files and URLs to external sites, e.g. relevant publications_
+<!--Put any additional information here, attach relevant text or image files and URLs to external sites, e.g. relevant publications-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,12 +9,12 @@ assignees: ''
 
 **Summary**
 
-_Please provide a brief and concise description of the suggested feature or change_
+<!--Please provide a brief and concise description of the suggested feature or change-->
 
 **Detailed Description**
 
-_Please explain how you would like to see LAMMPS enhanced, what feature(s) you are looking for, what specific problems this will solve. If possible, provide references to relevant background information like publications or web pages, and whether you are planning to implement the enhancement yourself or would like to participate in the implementation. If applicable add a reference to an existing bug report or issue that this will address._
+<!--Please explain how you would like to see LAMMPS enhanced, what feature(s) you are looking for, what specific problems this will solve. If possible, provide references to relevant background information like publications or web pages, and whether you are planning to implement the enhancement yourself or would like to participate in the implementation. If applicable add a reference to an existing bug report or issue that this will address.-->
 
 **Further Information, Files, and Links**
 
-_Put any additional information here, attach relevant text or image files and URLs to external sites, e.g. relevant publications_
+<!--Put any additional information here, attach relevant text or image files and URLs to external sites, e.g. relevant publications-->

--- a/.github/ISSUE_TEMPLATE/generic.md
+++ b/.github/ISSUE_TEMPLATE/generic.md
@@ -9,13 +9,13 @@ assignees: ''
 
 **Summary**
 
-_Please provide a clear and concise description of what this issue report is about._
+<!--Please provide a clear and concise description of what this issue report is about.-->
 
 **LAMMPS Version and Platform**
 
-_Please specify precisely which LAMMPS version this issue was detected with (the first line of the output) and what platform (operating system and its version, hardware) you are running on. If possible, test with the most recent LAMMPS patch version_
+<!--Please specify precisely which LAMMPS version this issue was detected with (the first line of the output) and what platform (operating system and its version, hardware) you are running on. If possible, test with the most recent LAMMPS patch version-->
 
 **Details**
 
-_Please explain the issue in detail here_
+<!--Please explain the issue in detail here-->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,14 @@
 **Summary**
 
-_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request._
+<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->
 
 **Related Issues**
 
-_If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged_
+<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->
 
 **Author(s)**
 
-_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code._
+<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->
 
 **Licensing**
 
@@ -16,15 +16,15 @@ By submitting this pull request, I agree, that my contribution will be included 
 
 **Backward Compatibility**
 
-_Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why_
+<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
 
 **Implementation Notes**
 
-_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_
+<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
 
 **Post Submission Checklist**
 
-_Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply_
+<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->
 
 - [ ] The feature or features in this pull request is complete
 - [ ] Licensing information is complete
@@ -39,6 +39,6 @@ _Please check the fields below as they are completed **after** the pull request 
 
 **Further Information, Files, and Links**
 
-_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_
+<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -9,15 +9,15 @@ assignees: ''
 
 **Summary**
 
-_Briefly describe the bug or bugs, that are eliminated by this pull request._
+<!--Briefly describe the bug or bugs, that are eliminated by this pull request.-->
 
 **Related Issue(s)**
 
-_If this request addresses or is related to an existing (open) GitHub issue, e.g. a bug report, mention the issue number number here following a pound sign (aka hashmark), e.g.`#222`._
+<!--If this request addresses or is related to an existing (open) GitHub issue, e.g. a bug report, mention the issue number number here following a pound sign (aka hashmark), e.g.`#222`.-->
 
 **Author(s)**
 
-_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_
+<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request-->
 
 **Licensing**
 
@@ -25,18 +25,18 @@ By submitting this pull request I implicitly accept, that my submission is subje
 
 **Backward Compatibility**
 
-_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_
+<!--Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
 
 **Detailed Description**
 
-_Provide any relevant details about how the fixed bug can be reproduced, how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_
+<!--Provide any relevant details about how the fixed bug can be reproduced, how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
 
 ## Post Submission Checklist
 
-_Please check the fields below as they are completed *after* the pull request is submitted_
+<!--Please check the fields below as they are completed *after* the pull request is submitted-->
 - [ ] The code in this pull request is complete
 - [ ] The source code follows the LAMMPS formatting guidelines
 
 ## Further Information, Files, and Links
 
-_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. to download input decks for testing)_
+<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. to download input decks for testing)-->

--- a/.github/PULL_REQUEST_TEMPLATE/maintenance_refactoring.md
+++ b/.github/PULL_REQUEST_TEMPLATE/maintenance_refactoring.md
@@ -9,15 +9,15 @@ assignees: ''
 
 **Summary**
 
-_Briefly describe the included changes._
+<!--Briefly describe the included changes.-->
 
 **Related Issue(s)**
 
-_If this request addresses or is related to an existing (open) GitHub issue, e.g. a bug report, mention the issue number number here following a pound sign (aka hashmark), e.g.`#222`.
+<!--If this request addresses or is related to an existing (open) GitHub issue, e.g. a bug report, mention the issue number number here following a pound sign (aka hashmark), e.g.`#222`.
 
 **Author(s)**
 
-_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_
+<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request-->
 
 **Licensing**
 
@@ -25,11 +25,11 @@ By submitting this pull request I implicitly accept, that my submission is subje
 
 **Detailed Description**
 
-_Provide any relevant details about the included changes._
+<!--Provide any relevant details about the included changes.-->
 
 ## Post Submission Checklist
 
-_Please check the fields below as they are completed *after* the pull request is submitted_
+<!--Please check the fields below as they are completed *after* the pull request is submitted-->
 - [ ] The pull request is complete
 - [ ] The source code follows the LAMMPS formatting guidelines
 

--- a/.github/PULL_REQUEST_TEMPLATE/new_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature.md
@@ -9,34 +9,34 @@ assignees: ''
 
 **Summary**
 
-_Briefly describe the new feature(s) included in this pull request._
+<!--Briefly describe the new feature(s) included in this pull request.-->
 
 **Related Issues**
 
-_If this addresses an existing (open) GitHub issue, e.g. a feature request, mention the issue number here following a pound sign (aka hashmark), e.g. `#331`._
+<!--If this addresses an existing (open) GitHub issue, e.g. a feature request, mention the issue number here following a pound sign (aka hashmark), e.g. `#331`.-->
 
 **Author(s)**
 
-_Please state name and affiliation of the author or authors that should be credited with the features added in this pull request. Please provide a suitable "long-lived" e-mail address (e.g. from gmail, yahoo, outlook, etc.) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this code. now and in the future_
+<!--Please state name and affiliation of the author or authors that should be credited with the features added in this pull request. Please provide a suitable "long-lived" e-mail address (e.g. from gmail, yahoo, outlook, etc.) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this code. now and in the future-->
 
 **Licensing**
 
-_Please add *yes* or *no* to the following two statements (please contact @lammps/core if you have questions about this)_
+<!--Please add *yes* or *no* to the following two statements (please contact @lammps/core if you have questions about this)-->
 
 My contribution may be licensed as GPL v2 (default LAMMPS license):
 My contribution may be licensed as LGPL (for use as a library with proprietary software):
 
 **Backward Compatibility**
 
-_Please state if any of the changes in this pull request will affect backward compatibility for inputs, and - if yes - explain what has been changed and why_
+<!--Please state if any of the changes in this pull request will affect backward compatibility for inputs, and - if yes - explain what has been changed and why-->
 
 **Implementation Notes**
 
-_Provide any relevant details about how the new features are implemented, how correctness was verified, what platforms (OS, compiler, MPI, hardware, number of processors, accelerator(s)) it was tested on_
+<!--Provide any relevant details about how the new features are implemented, how correctness was verified, what platforms (OS, compiler, MPI, hardware, number of processors, accelerator(s)) it was tested on-->
 
 ## Post Submission Checklist
 
-_Please check the fields below as they are completed *after* the pull request has been submitted_
+<!--Please check the fields below as they are completed *after* the pull request has been submitted-->
 
 - [ ] The feature or features in this pull request is complete
 - [ ] Licensing information is complete
@@ -51,6 +51,6 @@ _Please check the fields below as they are completed *after* the pull request ha
 
 ## Further Information, Files, and Links
 
-_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_
+<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE/update_enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/update_enhancement.md
@@ -9,11 +9,11 @@ assignees: ''
 
 **Summary**
 
-_Briefly describe what kind of updates or enhancements for a package or feature are included. If you are not the original author of the package or feature, please mention, whether your contribution was created independently or in collaboration/cooperation with the original author._
+<!--Briefly describe what kind of updates or enhancements for a package or feature are included. If you are not the original author of the package or feature, please mention, whether your contribution was created independently or in collaboration/cooperation with the original author.-->
 
 **Author(s)**
 
-_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_
+<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request-->
 
 **Licensing**
 
@@ -21,15 +21,15 @@ By submitting this pull request I implicitly accept, that my submission is subje
 
 **Backward Compatibility**
 
-_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_
+<!--Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
 
 **Implementation Notes**
 
-_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected_
+<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
 
 **Post Submission Checklist**
 
-_Please check the fields below as they are completed_
+<!--Please check the fields below as they are completed-->
 - [ ] The feature or features in this pull request is complete
 - [ ] Suitable updates to the existing docs are included
 - [ ] One or more example input decks are included
@@ -37,6 +37,6 @@ _Please check the fields below as they are completed_
 
 **Further Information, Files, and Links**
 
-_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_
+<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->
 
 


### PR DESCRIPTION
**Summary**

This removes the new to delete the comment block when creating an issue / pull request.

**Related Issues**

None

**Author(s)**

@junghans 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

Markdown only

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete

**Further Information, Files, and Links**


