### PR TITLE
Reset image flag(s) when changing from periodic to non-periodic

### DIFF
--- a/doc/src/change_box.rst
+++ b/doc/src/change_box.rst
@@ -299,6 +299,12 @@ match what is stored in the restart file.  So if you wish to change
 them, you should use the change_box command after the read_restart
 command.
 
+.. note::
+
+   Changing a periodic boundary to a non-periodic one will also
+   cause the image flag for that dimension to be reset to 0 for
+   all atoms.  LAMMPS will print a warning message, if that happens.
+
 ----------
 
 The *ortho* and *triclinic* keywords convert the simulation box to be

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1905,7 +1905,7 @@ void Domain::set_boundary(int narg, char **arg, int flag)
         (((imageint) (zbox + IMGMAX) & IMGMASK) << IMG2BITS);
     }
     int flag_all;
-    MPI_Allreduce(&flag,&flag_all, MPI_INT, 1, MPI_SUM, world);
+    MPI_Allreduce(&flag,&flag_all, 1, MPI_INT, MPI_SUM, world);
     if ((flag_all > 0) && (comm->me == 0))
       error->warning(FLERR,"Reset image flags for non-periodic boundary");
   }


### PR DESCRIPTION
**Summary**

When using `change_box` to alter boundaries, we may also need to reset image flags.
Otherwise it would be possible to have non-zero image flags for non-periodic boundaries which will result in bogus results, e.g. for fix rigid or for writing out unwrapped coordinates.
This PR changes the behavior. I will test whether any boundary was changed from periodic to non-periodic and only then loop over all local atoms, decode image flags, force the ones for non-periodic dimensions to 0 and reencode them. I will print a warning if that has happened.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
