### PR TITLE
Fix bug in Kokkos occasional neighlist build

### DIFF
--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -97,7 +97,7 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_stencil_info()
   NPair::copy_stencil_info();
   nstencil = ns->nstencil;
 
-  if (neighbor->last_setup_bins == update->ntimestep) {
+  if (ns->last_stencil == update->ntimestep) {
     // copy stencil to device as it may have changed
 
     int maxstencil = ns->get_maxstencil();


### PR DESCRIPTION
**Summary**

Fix bug in Kokkos occasional neighlist build. A logic error caused the stencil to sometimes get out of date for occasional lists, leading to segmentation fault.

**Related Issues**

None

**Author(s)**

Stan Moore (Sandia)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues