### PR TITLE
adding the standard header to prevent ‘NULL’ was not declared error

### DIFF
--- a/lib/message/cslib/src/STUBS_ZMQ/zmq.h
+++ b/lib/message/cslib/src/STUBS_ZMQ/zmq.h
@@ -17,6 +17,8 @@
 #ifndef ZMQ_DUMMY_H
 #define ZMQ_DUMMY_H
 
+#include <cstddef>
+
 namespace CSLIB_NS {
 
 #define ZMQ_REQ 0


### PR DESCRIPTION
**Summary**
Minor header file issue in the LAMMPS master branch.

`
'NULL' was not declared in this scope
`

`
cmake  -C ../cmake/presets/all_on.cmake -C ../cmake/presets/nolib.cmake -DCMAKE_CXX_COMPILER=g++ -DPKG_KOKKOS=on ../cmake
`
is expected to be completed successfully, but the actual beavior is 

```bash
[  8%] Building CXX object CMakeFiles/cslib.dir/Users/yaser/git/lammps/lib/message/cslib/src/msg_zmq.cpp.o
In file included from /Users/yaser/git/lammps/lib/message/cslib/src/msg_zmq.cpp:20:
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h: In function 'void* CSLIB_NS::zmq_ctx_new()':
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h:25:36: error: 'NULL' was not declared in this scope
   25 | static void *zmq_ctx_new() {return NULL;}
      |                                    ^~~~
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h:1:1: note: 'NULL' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
  +++ |+#include <cstddef>
    1 | /* ----------------------------------------------------------------------
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h: In function 'void* CSLIB_NS::zmq_connect(void*, char*)':
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h:26:50: error: 'NULL' was not declared in this scope
   26 | static void *zmq_connect(void *, char *) {return NULL;}
      |                                                  ^~~~
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h:26:50: note: 'NULL' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h: In function 'void* CSLIB_NS::zmq_socket(void*, int)':
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h:28:45: error: 'NULL' was not declared in this scope
   28 | static void *zmq_socket(void *,int) {return NULL;}
      |                                             ^~~~
/Users/yaser/git/lammps/lib/message/cslib/src/STUBS_ZMQ/zmq.h:28:45: note: 'NULL' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
make[2]: *** [CMakeFiles/cslib.dir/Users/yaser/git/lammps/lib/message/cslib/src/msg_zmq.cpp.o] Error 1
make[1]: *** [CMakeFiles/cslib.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

**Licensing**
By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


