### PR TITLE
Fix Kokkos issue and remove N2 neigh list option

### DIFF
--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -306,7 +306,7 @@ void KokkosLMP::accelerator(int narg, char **arg)
           neighflag = HALFTHREAD;
         else
           neighflag = HALF;
-      } else if (strcmp(arg[iarg+1],"n2") == 0) neighflag = N2;
+      }
       else error->all(FLERR,"Illegal package kokkos command");
       if (!neighflag_qeq_set) neighflag_qeq = neighflag;
       iarg += 2;
@@ -318,7 +318,7 @@ void KokkosLMP::accelerator(int narg, char **arg)
           neighflag_qeq = HALFTHREAD;
         else
           neighflag_qeq = HALF;
-      } else if (strcmp(arg[iarg+1],"n2") == 0) neighflag_qeq = N2;
+      }
       else error->all(FLERR,"Illegal package kokkos command");
       neighflag_qeq_set = 1;
       iarg += 2;

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -22,7 +22,7 @@
 #include <Kokkos_Vectorization.hpp>
 #include <Kokkos_ScatterView.hpp>
 
-enum{FULL=1u,HALFTHREAD=2u,HALF=4u,N2=8u};
+enum{FULL=1u,HALFTHREAD=2u,HALF=4u};
 
 #if defined(KOKKOS_ENABLE_CXX11)
 #undef ISFINITE

--- a/src/KOKKOS/pair_buck_coul_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_buck_coul_cut_kokkos.cpp
@@ -307,9 +307,6 @@ void PairBuckCoulCutKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with buck/coul/cut/kk");
   }

--- a/src/KOKKOS/pair_buck_kokkos.cpp
+++ b/src/KOKKOS/pair_buck_kokkos.cpp
@@ -229,9 +229,6 @@ void PairBuckKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with buck/kk");
   }

--- a/src/KOKKOS/pair_buck_kokkos.h
+++ b/src/KOKKOS/pair_buck_kokkos.h
@@ -31,7 +31,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairBuckKokkos : public PairBuck {
  public:
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -98,15 +98,12 @@ class PairBuckKokkos : public PairBuck {
   friend class PairComputeFunctor<PairBuckKokkos,FULL,true>;
   friend class PairComputeFunctor<PairBuckKokkos,HALF,true>;
   friend class PairComputeFunctor<PairBuckKokkos,HALFTHREAD,true>;
-  friend class PairComputeFunctor<PairBuckKokkos,N2,true>;
   friend class PairComputeFunctor<PairBuckKokkos,FULL,false>;
   friend class PairComputeFunctor<PairBuckKokkos,HALF,false>;
   friend class PairComputeFunctor<PairBuckKokkos,HALFTHREAD,false>;
-  friend class PairComputeFunctor<PairBuckKokkos,N2,false>;
   friend EV_FLOAT pair_compute_neighlist<PairBuckKokkos,FULL,void>(PairBuckKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairBuckKokkos,HALF,void>(PairBuckKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairBuckKokkos,HALFTHREAD,void>(PairBuckKokkos*,NeighListKokkos<DeviceType>*);
-  friend EV_FLOAT pair_compute_neighlist<PairBuckKokkos,N2,void>(PairBuckKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute<PairBuckKokkos,void>(PairBuckKokkos*,NeighListKokkos<DeviceType>*);
   friend void pair_virial_fdotr_compute<PairBuckKokkos>(PairBuckKokkos*);
 };

--- a/src/KOKKOS/pair_coul_debye_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_debye_kokkos.cpp
@@ -276,9 +276,6 @@ void PairCoulDebyeKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with coul/debye/kk");
   }

--- a/src/KOKKOS/pair_kokkos.h
+++ b/src/KOKKOS/pair_kokkos.h
@@ -87,6 +87,8 @@ struct PairComputeFunctor  {
   c(*c_ptr),list(*list_ptr) {
     // allocate duplicated memory
     f = c.f;
+    d_eatom = c.d_eatom;
+    d_vatom = c.d_vatom;
     dup_f     = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, NeedDup<NEIGHFLAG,device_type>::value >(c.f);
     dup_eatom = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, NeedDup<NEIGHFLAG,device_type>::value >(c.d_eatom);
     dup_vatom = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, NeedDup<NEIGHFLAG,device_type>::value >(c.d_vatom);
@@ -690,148 +692,6 @@ struct PairComputeFunctor  {
   }
 };
 
-template <class PairStyle, bool STACKPARAMS, class Specialisation>
-struct PairComputeFunctor<PairStyle,N2,STACKPARAMS,Specialisation>  {
-  typedef typename PairStyle::device_type device_type ;
-  typedef EV_FLOAT value_type;
-
-  PairStyle c;
-  NeighListKokkos<device_type> list;
-
-  PairComputeFunctor(PairStyle* c_ptr,
-                          NeighListKokkos<device_type>* list_ptr):
-  c(*c_ptr),list(*list_ptr) {};
-  ~PairComputeFunctor() {c.cleanup_copy();list.copymode = 1;};
-
-  KOKKOS_INLINE_FUNCTION int sbmask(const int& j) const {
-    return j >> SBBITS & 3;
-  }
-
-
-  void contribute() {}
-
-  template<int EVFLAG, int NEWTON_PAIR>
-  KOKKOS_FUNCTION
-  EV_FLOAT compute_item(const int& ii,
-                        const NeighListKokkos<device_type> &list, const NoCoulTag&) const {
-    (void) list;
-    EV_FLOAT ev;
-    const int i = ii;//list.d_ilist[ii];
-    const X_FLOAT xtmp = c.x(i,0);
-    const X_FLOAT ytmp = c.x(i,1);
-    const X_FLOAT ztmp = c.x(i,2);
-    const int itype = c.type(i);
-
-    //const AtomNeighborsConst neighbors_i = list.get_neighbors_const(i);
-    const int jnum = c.nall;
-
-    F_FLOAT fxtmp = 0.0;
-    F_FLOAT fytmp = 0.0;
-    F_FLOAT fztmp = 0.0;
-
-    for (int jj = 0; jj < jnum; jj++) {
-      int j = jj;//neighbors_i(jj);
-      if(i==j) continue;
-      const F_FLOAT factor_lj = c.special_lj[sbmask(j)];
-      j &= NEIGHMASK;
-      const X_FLOAT delx = xtmp - c.x(j,0);
-      const X_FLOAT dely = ytmp - c.x(j,1);
-      const X_FLOAT delz = ztmp - c.x(j,2);
-      const int jtype = c.type(j);
-      const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-
-      if(rsq < (STACKPARAMS?c.m_cutsq[itype][jtype]:c.d_cutsq(itype,jtype))) {
-
-        const F_FLOAT fpair = factor_lj*c.template compute_fpair<STACKPARAMS,Specialisation>(rsq,i,j,itype,jtype);
-        fxtmp += delx*fpair;
-        fytmp += dely*fpair;
-        fztmp += delz*fpair;
-
-        if (EVFLAG) {
-          F_FLOAT evdwl = 0.0;
-          if (c.eflag) {
-            evdwl = 0.5*
-              factor_lj * c.template compute_evdwl<STACKPARAMS,Specialisation>(rsq,i,j,itype,jtype);
-            ev.evdwl += evdwl;
-          }
-
-          if (c.vflag_either || c.eflag_atom) ev_tally(ev,i,j,evdwl,fpair,delx,dely,delz);
-        }
-      }
-    }
-
-    c.f(i,0) += fxtmp;
-    c.f(i,1) += fytmp;
-    c.f(i,2) += fztmp;
-
-    return ev;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-    void ev_tally(EV_FLOAT &ev, const int &i, const int &j,
-      const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
-                  const F_FLOAT &dely, const F_FLOAT &delz) const
-  {
-    const int EFLAG = c.eflag;
-    const int VFLAG = c.vflag_either;
-
-    if (EFLAG) {
-      if (c.eflag_atom) {
-        const E_FLOAT epairhalf = 0.5 * epair;
-        if (i < c.nlocal) c.d_eatom[i] += epairhalf;
-        if (j < c.nlocal) c.d_eatom[j] += epairhalf;
-      }
-    }
-
-    if (VFLAG) {
-      const E_FLOAT v0 = delx*delx*fpair;
-      const E_FLOAT v1 = dely*dely*fpair;
-      const E_FLOAT v2 = delz*delz*fpair;
-      const E_FLOAT v3 = delx*dely*fpair;
-      const E_FLOAT v4 = delx*delz*fpair;
-      const E_FLOAT v5 = dely*delz*fpair;
-
-      if (c.vflag_global) {
-          ev.v[0] += 0.5*v0;
-          ev.v[1] += 0.5*v1;
-          ev.v[2] += 0.5*v2;
-          ev.v[3] += 0.5*v3;
-          ev.v[4] += 0.5*v4;
-          ev.v[5] += 0.5*v5;
-      }
-
-      if (c.vflag_atom) {
-        if (i < c.nlocal) {
-          c.d_vatom(i,0) += 0.5*v0;
-          c.d_vatom(i,1) += 0.5*v1;
-          c.d_vatom(i,2) += 0.5*v2;
-          c.d_vatom(i,3) += 0.5*v3;
-          c.d_vatom(i,4) += 0.5*v4;
-          c.d_vatom(i,5) += 0.5*v5;
-        }
-      }
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const int i) const {
-    compute_item<0,0>(i,list,typename DoCoul<PairStyle::COUL_FLAG>::type());
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const int i, value_type &energy_virial) const {
-    energy_virial += compute_item<1,0>(i,list,typename DoCoul<PairStyle::COUL_FLAG>::type());
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const typename Kokkos::TeamPolicy<>::member_type& team) const
-  {}
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const typename Kokkos::TeamPolicy<>::member_type& team, value_type &energy_virial) const
-  {}
-
-};
 
 // Filter out Neighflags which are not supported for PairStyle
 // The enable_if clause will invalidate the last parameter of the function, so that
@@ -867,7 +727,7 @@ int GetTeamSize(FunctorStyle& functor, int inum, int reduce_flag, int team_size,
     return team_size;
 }
 
-// Submit ParallelFor for NEIGHFLAG=HALF,HALFTHREAD,FULL,N2
+// Submit ParallelFor for NEIGHFLAG=HALF,HALFTHREAD,FULL
 template<class PairStyle, unsigned NEIGHFLAG, class Specialisation>
 EV_FLOAT pair_compute_neighlist (PairStyle* fpair, typename std::enable_if<(NEIGHFLAG&PairStyle::EnabledNeighFlags) != 0, NeighListKokkos<typename PairStyle::device_type>*>::type list) {
   EV_FLOAT ev;
@@ -918,8 +778,6 @@ EV_FLOAT pair_compute (PairStyle* fpair, NeighListKokkos<typename PairStyle::dev
     ev = pair_compute_neighlist<PairStyle,HALFTHREAD,Specialisation> (fpair,list);
   } else if (fpair->neighflag == HALF) {
     ev = pair_compute_neighlist<PairStyle,HALF,Specialisation> (fpair,list);
-  } else if (fpair->neighflag == N2) {
-    ev = pair_compute_neighlist<PairStyle,N2,Specialisation> (fpair,list);
   }
   return ev;
 }

--- a/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.cpp
@@ -309,9 +309,6 @@ void PairLJClass2CoulCutKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/class2/coul/cut/kk");
   }

--- a/src/KOKKOS/pair_lj_class2_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_class2_kokkos.cpp
@@ -247,9 +247,6 @@ void PairLJClass2Kokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/class2/kk");
   }

--- a/src/KOKKOS/pair_lj_class2_kokkos.h
+++ b/src/KOKKOS/pair_lj_class2_kokkos.h
@@ -31,7 +31,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairLJClass2Kokkos : public PairLJClass2 {
  public:
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -104,15 +104,12 @@ class PairLJClass2Kokkos : public PairLJClass2 {
   friend class PairComputeFunctor<PairLJClass2Kokkos,FULL,true>;
   friend class PairComputeFunctor<PairLJClass2Kokkos,HALF,true>;
   friend class PairComputeFunctor<PairLJClass2Kokkos,HALFTHREAD,true>;
-  friend class PairComputeFunctor<PairLJClass2Kokkos,N2,true>;
   friend class PairComputeFunctor<PairLJClass2Kokkos,FULL,false>;
   friend class PairComputeFunctor<PairLJClass2Kokkos,HALF,false>;
   friend class PairComputeFunctor<PairLJClass2Kokkos,HALFTHREAD,false>;
-  friend class PairComputeFunctor<PairLJClass2Kokkos,N2,false>;
   friend EV_FLOAT pair_compute_neighlist<PairLJClass2Kokkos,FULL,void>(PairLJClass2Kokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJClass2Kokkos,HALF,void>(PairLJClass2Kokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJClass2Kokkos,HALFTHREAD,void>(PairLJClass2Kokkos*,NeighListKokkos<DeviceType>*);
-  friend EV_FLOAT pair_compute_neighlist<PairLJClass2Kokkos,N2,void>(PairLJClass2Kokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute<PairLJClass2Kokkos,void>(PairLJClass2Kokkos*,NeighListKokkos<DeviceType>*);
   friend void pair_virial_fdotr_compute<PairLJClass2Kokkos>(PairLJClass2Kokkos*);
 };

--- a/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.cpp
@@ -300,9 +300,6 @@ void PairLJCutCoulCutKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/cut/coul/cut/kk");
   }

--- a/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.cpp
@@ -329,9 +329,6 @@ void PairLJCutCoulDebyeKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/cut/coul/debye/kk");
   }

--- a/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.cpp
@@ -322,9 +322,6 @@ void PairLJCutCoulDSFKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/cut/coul/cut/kk");
   }

--- a/src/KOKKOS/pair_lj_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_kokkos.cpp
@@ -85,6 +85,7 @@ void PairLJCutKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   ev_init(eflag,vflag,0);
 
   // reallocate per-atom arrays if necessary
+  //
 
   if (eflag_atom) {
     memoryKK->destroy_kokkos(k_eatom,eatom);
@@ -241,9 +242,6 @@ void PairLJCutKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/cut/kk");
   }

--- a/src/KOKKOS/pair_lj_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_kokkos.cpp
@@ -85,7 +85,6 @@ void PairLJCutKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   ev_init(eflag,vflag,0);
 
   // reallocate per-atom arrays if necessary
-  //
 
   if (eflag_atom) {
     memoryKK->destroy_kokkos(k_eatom,eatom);

--- a/src/KOKKOS/pair_lj_cut_kokkos.h
+++ b/src/KOKKOS/pair_lj_cut_kokkos.h
@@ -31,7 +31,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairLJCutKokkos : public PairLJCut {
  public:
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -99,15 +99,12 @@ class PairLJCutKokkos : public PairLJCut {
   friend class PairComputeFunctor<PairLJCutKokkos,FULL,true>;
   friend class PairComputeFunctor<PairLJCutKokkos,HALF,true>;
   friend class PairComputeFunctor<PairLJCutKokkos,HALFTHREAD,true>;
-  friend class PairComputeFunctor<PairLJCutKokkos,N2,true>;
   friend class PairComputeFunctor<PairLJCutKokkos,FULL,false>;
   friend class PairComputeFunctor<PairLJCutKokkos,HALF,false>;
   friend class PairComputeFunctor<PairLJCutKokkos,HALFTHREAD,false>;
-  friend class PairComputeFunctor<PairLJCutKokkos,N2,false>;
   friend EV_FLOAT pair_compute_neighlist<PairLJCutKokkos,FULL,void>(PairLJCutKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJCutKokkos,HALF,void>(PairLJCutKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJCutKokkos,HALFTHREAD,void>(PairLJCutKokkos*,NeighListKokkos<DeviceType>*);
-  friend EV_FLOAT pair_compute_neighlist<PairLJCutKokkos,N2,void>(PairLJCutKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute<PairLJCutKokkos,void>(PairLJCutKokkos*,NeighListKokkos<DeviceType>*);
   friend void pair_virial_fdotr_compute<PairLJCutKokkos>(PairLJCutKokkos*);
 };

--- a/src/KOKKOS/pair_lj_expand_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_expand_kokkos.cpp
@@ -249,9 +249,6 @@ void PairLJExpandKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/expand/kk");
   }

--- a/src/KOKKOS/pair_lj_expand_kokkos.h
+++ b/src/KOKKOS/pair_lj_expand_kokkos.h
@@ -31,7 +31,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairLJExpandKokkos : public PairLJExpand {
  public:
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -105,15 +105,12 @@ class PairLJExpandKokkos : public PairLJExpand {
   friend class PairComputeFunctor<PairLJExpandKokkos,FULL,true>;
   friend class PairComputeFunctor<PairLJExpandKokkos,HALF,true>;
   friend class PairComputeFunctor<PairLJExpandKokkos,HALFTHREAD,true>;
-  friend class PairComputeFunctor<PairLJExpandKokkos,N2,true>;
   friend class PairComputeFunctor<PairLJExpandKokkos,FULL,false>;
   friend class PairComputeFunctor<PairLJExpandKokkos,HALF,false>;
   friend class PairComputeFunctor<PairLJExpandKokkos,HALFTHREAD,false>;
-  friend class PairComputeFunctor<PairLJExpandKokkos,N2,false>;
   friend EV_FLOAT pair_compute_neighlist<PairLJExpandKokkos,FULL,void>(PairLJExpandKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJExpandKokkos,HALF,void>(PairLJExpandKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJExpandKokkos,HALFTHREAD,void>(PairLJExpandKokkos*,NeighListKokkos<DeviceType>*);
-  friend EV_FLOAT pair_compute_neighlist<PairLJExpandKokkos,N2,void>(PairLJExpandKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute<PairLJExpandKokkos,void>(PairLJExpandKokkos*,NeighListKokkos<DeviceType>*);
   friend void pair_virial_fdotr_compute<PairLJExpandKokkos>(PairLJExpandKokkos*);
 };

--- a/src/KOKKOS/pair_lj_sdk_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_sdk_kokkos.cpp
@@ -279,9 +279,6 @@ void PairLJSDKKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/sdk/kk");
   }

--- a/src/KOKKOS/pair_lj_sdk_kokkos.h
+++ b/src/KOKKOS/pair_lj_sdk_kokkos.h
@@ -31,7 +31,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairLJSDKKokkos : public PairLJSDK {
  public:
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -100,15 +100,12 @@ class PairLJSDKKokkos : public PairLJSDK {
   friend class PairComputeFunctor<PairLJSDKKokkos,FULL,true>;
   friend class PairComputeFunctor<PairLJSDKKokkos,HALF,true>;
   friend class PairComputeFunctor<PairLJSDKKokkos,HALFTHREAD,true>;
-  friend class PairComputeFunctor<PairLJSDKKokkos,N2,true>;
   friend class PairComputeFunctor<PairLJSDKKokkos,FULL,false>;
   friend class PairComputeFunctor<PairLJSDKKokkos,HALF,false>;
   friend class PairComputeFunctor<PairLJSDKKokkos,HALFTHREAD,false>;
-  friend class PairComputeFunctor<PairLJSDKKokkos,N2,false>;
   friend EV_FLOAT pair_compute_neighlist<PairLJSDKKokkos,FULL,void>(PairLJSDKKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJSDKKokkos,HALF,void>(PairLJSDKKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairLJSDKKokkos,HALFTHREAD,void>(PairLJSDKKokkos*,NeighListKokkos<DeviceType>*);
-  friend EV_FLOAT pair_compute_neighlist<PairLJSDKKokkos,N2,void>(PairLJSDKKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute<PairLJSDKKokkos,void>(PairLJSDKKokkos*,NeighListKokkos<DeviceType>*);
   friend void pair_virial_fdotr_compute<PairLJSDKKokkos>(PairLJSDKKokkos*);
 };

--- a/src/KOKKOS/pair_morse_kokkos.cpp
+++ b/src/KOKKOS/pair_morse_kokkos.cpp
@@ -258,9 +258,6 @@ void PairMorseKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with morse/kk");
   }

--- a/src/KOKKOS/pair_morse_kokkos.h
+++ b/src/KOKKOS/pair_morse_kokkos.h
@@ -31,7 +31,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairMorseKokkos : public PairMorse {
  public:
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   PairMorseKokkos(class LAMMPS *);
@@ -98,15 +98,12 @@ class PairMorseKokkos : public PairMorse {
   friend class PairComputeFunctor<PairMorseKokkos,FULL,true>;
   friend class PairComputeFunctor<PairMorseKokkos,HALF,true>;
   friend class PairComputeFunctor<PairMorseKokkos,HALFTHREAD,true>;
-  friend class PairComputeFunctor<PairMorseKokkos,N2,true>;
   friend class PairComputeFunctor<PairMorseKokkos,FULL,false>;
   friend class PairComputeFunctor<PairMorseKokkos,HALF,false>;
   friend class PairComputeFunctor<PairMorseKokkos,HALFTHREAD,false>;
-  friend class PairComputeFunctor<PairMorseKokkos,N2,false>;
   friend EV_FLOAT pair_compute_neighlist<PairMorseKokkos,FULL,void>(PairMorseKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairMorseKokkos,HALF,void>(PairMorseKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairMorseKokkos,HALFTHREAD,void>(PairMorseKokkos*,NeighListKokkos<DeviceType>*);
-  friend EV_FLOAT pair_compute_neighlist<PairMorseKokkos,N2,void>(PairMorseKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute<PairMorseKokkos,void>(PairMorseKokkos*,NeighListKokkos<DeviceType>*);
   friend void pair_virial_fdotr_compute<PairMorseKokkos>(PairMorseKokkos*);
 };

--- a/src/KOKKOS/pair_table_kokkos.cpp
+++ b/src/KOKKOS/pair_table_kokkos.cpp
@@ -136,12 +136,6 @@ void PairTableKokkos<DeviceType>::compute_style(int eflag_in, int vflag_in)
       if (eflag || vflag) Kokkos::parallel_reduce(list->inum,f,ev);
       else Kokkos::parallel_for(list->inum,f);
       f.contribute();
-    } else if (neighflag == N2) {
-      PairComputeFunctor<PairTableKokkos<DeviceType>,N2,false,S_TableCompute<DeviceType,TABSTYLE> >
-        f(this,(NeighListKokkos<DeviceType>*) list);
-      if (eflag || vflag) Kokkos::parallel_reduce(list->inum,f,ev);
-      else Kokkos::parallel_for(list->inum,f);
-      f.contribute();
     }
   } else {
     if (neighflag == FULL) {
@@ -158,12 +152,6 @@ void PairTableKokkos<DeviceType>::compute_style(int eflag_in, int vflag_in)
       f.contribute();
     } else if (neighflag == HALF) {
       PairComputeFunctor<PairTableKokkos<DeviceType>,HALF,true,S_TableCompute<DeviceType,TABSTYLE> >
-        f(this,(NeighListKokkos<DeviceType>*) list);
-      if (eflag || vflag) Kokkos::parallel_reduce(list->inum,f,ev);
-      else Kokkos::parallel_for(list->inum,f);
-      f.contribute();
-    } else if (neighflag == N2) {
-      PairComputeFunctor<PairTableKokkos<DeviceType>,N2,true,S_TableCompute<DeviceType,TABSTYLE> >
         f(this,(NeighListKokkos<DeviceType>*) list);
       if (eflag || vflag) Kokkos::parallel_reduce(list->inum,f,ev);
       else Kokkos::parallel_for(list->inum,f);
@@ -525,9 +513,6 @@ void PairTableKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/cut/kk");
   }

--- a/src/KOKKOS/pair_table_kokkos.h
+++ b/src/KOKKOS/pair_table_kokkos.h
@@ -41,7 +41,7 @@ template<class DeviceType>
 class PairTableKokkos : public PairTable {
  public:
 
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -139,38 +139,30 @@ class PairTableKokkos : public PairTable {
   friend class PairComputeFunctor<PairTableKokkos,FULL,true,S_TableCompute<DeviceType,LOOKUP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,true,S_TableCompute<DeviceType,LOOKUP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,true,S_TableCompute<DeviceType,LOOKUP> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,true,S_TableCompute<DeviceType,LOOKUP> >;
   friend class PairComputeFunctor<PairTableKokkos,FULL,false,S_TableCompute<DeviceType,LOOKUP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,false,S_TableCompute<DeviceType,LOOKUP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,false,S_TableCompute<DeviceType,LOOKUP> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,false,S_TableCompute<DeviceType,LOOKUP> >;
 
   friend class PairComputeFunctor<PairTableKokkos,FULL,true,S_TableCompute<DeviceType,LINEAR> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,true,S_TableCompute<DeviceType,LINEAR> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,true,S_TableCompute<DeviceType,LINEAR> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,true,S_TableCompute<DeviceType,LINEAR> >;
   friend class PairComputeFunctor<PairTableKokkos,FULL,false,S_TableCompute<DeviceType,LINEAR> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,false,S_TableCompute<DeviceType,LINEAR> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,false,S_TableCompute<DeviceType,LINEAR> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,false,S_TableCompute<DeviceType,LINEAR> >;
 
   friend class PairComputeFunctor<PairTableKokkos,FULL,true,S_TableCompute<DeviceType,SPLINE> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,true,S_TableCompute<DeviceType,SPLINE> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,true,S_TableCompute<DeviceType,SPLINE> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,true,S_TableCompute<DeviceType,SPLINE> >;
   friend class PairComputeFunctor<PairTableKokkos,FULL,false,S_TableCompute<DeviceType,SPLINE> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,false,S_TableCompute<DeviceType,SPLINE> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,false,S_TableCompute<DeviceType,SPLINE> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,false,S_TableCompute<DeviceType,SPLINE> >;
 
   friend class PairComputeFunctor<PairTableKokkos,FULL,true,S_TableCompute<DeviceType,BITMAP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,true,S_TableCompute<DeviceType,BITMAP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,true,S_TableCompute<DeviceType,BITMAP> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,true,S_TableCompute<DeviceType,BITMAP> >;
   friend class PairComputeFunctor<PairTableKokkos,FULL,false,S_TableCompute<DeviceType,BITMAP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALF,false,S_TableCompute<DeviceType,BITMAP> >;
   friend class PairComputeFunctor<PairTableKokkos,HALFTHREAD,false,S_TableCompute<DeviceType,BITMAP> >;
-  friend class PairComputeFunctor<PairTableKokkos,N2,false,S_TableCompute<DeviceType,BITMAP> >;
 
   friend void pair_virial_fdotr_compute<PairTableKokkos>(PairTableKokkos*);
 };

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -665,8 +665,6 @@ void PairTableRXKokkos<DeviceType>::compute_style(int eflag_in, int vflag_in)
       nspecies, isite1, isite2, fractionalWeighting,
       mixWtSite1old, mixWtSite2old, mixWtSite1, mixWtSite2);
 
-  if (neighflag == N2) error->all(FLERR,"pair table/rx/kk can't handle N2 yet\n");
-
   NeighListKokkos<DeviceType>* l =
     dynamic_cast<NeighListKokkos<DeviceType>*>(list);
 
@@ -1282,9 +1280,6 @@ void PairTableRXKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/cut/kk");
   }

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -30,7 +30,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairTableRXKokkos : public PairTable {
  public:
-  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
+  enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF};
   typedef DeviceType device_type;
 
   PairTableRXKokkos(class LAMMPS *);

--- a/src/KOKKOS/pair_yukawa_kokkos.h
+++ b/src/KOKKOS/pair_yukawa_kokkos.h
@@ -103,18 +103,14 @@ class PairYukawaKokkos : public PairYukawa {
   friend class PairComputeFunctor<PairYukawaKokkos,FULL,true>;
   friend class PairComputeFunctor<PairYukawaKokkos,HALF,true>;
   friend class PairComputeFunctor<PairYukawaKokkos,HALFTHREAD,true>;
-  friend class PairComputeFunctor<PairYukawaKokkos,N2,true>;
   friend class PairComputeFunctor<PairYukawaKokkos,FULL,false>;
   friend class PairComputeFunctor<PairYukawaKokkos,HALF,false>;
   friend class PairComputeFunctor<PairYukawaKokkos,HALFTHREAD,false>;
-  friend class PairComputeFunctor<PairYukawaKokkos,N2,false>;
   friend EV_FLOAT pair_compute_neighlist<PairYukawaKokkos,FULL,void>(
     PairYukawaKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairYukawaKokkos,HALF,void>(
     PairYukawaKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute_neighlist<PairYukawaKokkos,HALFTHREAD,void>(
-    PairYukawaKokkos*,NeighListKokkos<DeviceType>*);
-  friend EV_FLOAT pair_compute_neighlist<PairYukawaKokkos,N2,void>(
     PairYukawaKokkos*,NeighListKokkos<DeviceType>*);
   friend EV_FLOAT pair_compute<PairYukawaKokkos,void>(
     PairYukawaKokkos*,NeighListKokkos<DeviceType>*);

--- a/src/KOKKOS/pair_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_zbl_kokkos.cpp
@@ -103,9 +103,6 @@ void PairZBLKokkos<DeviceType>::init_style()
   } else if (neighflag == HALF || neighflag == HALFTHREAD) {
     neighbor->requests[irequest]->full = 0;
     neighbor->requests[irequest]->half = 1;
-  } else if (neighflag == N2) {
-    neighbor->requests[irequest]->full = 0;
-    neighbor->requests[irequest]->half = 0;
   } else {
     error->all(FLERR,"Cannot use chosen neighbor list style with lj/cut/kk");
   }


### PR DESCRIPTION
**Summary**

When using a full neighbor list and the team option (default for 16K atoms or less), the per-atom energy/virial wasn't getting properly accumulated, and leading to a segfault. Also remove the unused `N2` neigh list option.

**Related Issues**

None

**Author(s)**

Stan Moore (Sandia)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.