### PR TITLE
Fix issue in Kokkos "team" energy

### DIFF
--- a/src/KOKKOS/atom_vec_kokkos.h
+++ b/src/KOKKOS/atom_vec_kokkos.h
@@ -153,15 +153,7 @@ class AtomVecKokkos : public AtomVec {
        buffer = Kokkos::kokkos_realloc<Kokkos::CudaHostPinnedSpace>(buffer,src.span());
        buffer_size = src.span();
     }
-    return mirror_type( buffer ,
-                             src.extent(0) ,
-                             src.extent(1) ,
-                             src.extent(2) ,
-                             src.extent(3) ,
-                             src.extent(4) ,
-                             src.extent(5) ,
-                             src.extent(6) ,
-                             src.extent(7) );
+    return mirror_type(buffer, src.d_view.layout());
   }
 
   template<class ViewType>
@@ -179,15 +171,8 @@ class AtomVecKokkos : public AtomVec {
        buffer = Kokkos::kokkos_realloc<Kokkos::CudaHostPinnedSpace>(buffer,src.span()*sizeof(typename ViewType::value_type));
        buffer_size = src.span();
     }
-    mirror_type tmp_view( (typename ViewType::value_type*)buffer ,
-                             src.extent(0) ,
-                             src.extent(1) ,
-                             src.extent(2) ,
-                             src.extent(3) ,
-                             src.extent(4) ,
-                             src.extent(5) ,
-                             src.extent(6) ,
-                             src.extent(7) );
+    mirror_type tmp_view((typename ViewType::value_type*)buffer, src.d_view.layout());
+
     if(space == Device) {
       Kokkos::deep_copy(LMPHostType(),tmp_view,src.h_view),
       Kokkos::deep_copy(LMPHostType(),src.d_view,tmp_view);


### PR DESCRIPTION
**Summary**

Kokkos "team" option (default for full neigh list and 16K atoms or less) was giving the wrong energy on CUDA with coulomb interactions (and maybe other cases). Also fixed a runtime view issue.

**Related Issues**

None

**Author(s)**

Stan Moore (Sandia)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.