### PR TITLE
Fix rare issue in Kokkos neighlist

### DIFF
--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -55,6 +55,7 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_neighbor_info()
 
   newton_pair = force->newton_pair;
   k_cutneighsq = neighborKK->k_cutneighsq;
+  k_cutneighsq.modify<LMPHostType>();
 
   // exclusion info
 


### PR DESCRIPTION
**Summary**

The Kokkos `cutneighsq` variable was missing a "modify". This caused the `srd.mixture` example to fail when using CUDA and a "full" neighbor list.

**Related Issues**

None

**Author(s)**

Stan Moore (Sandia)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.