### PR TITLE
Make MIN_HBONDS define for reax/c configurable via an input option

### DIFF
--- a/doc/src/pair_reaxc.rst
+++ b/doc/src/pair_reaxc.rst
@@ -21,12 +21,13 @@ Syntax
 
   .. parsed-literal::
 
-     keyword = *checkqeq* or *lgvdw* or *safezone* or *mincap*
+     keyword = *checkqeq* or *lgvdw* or *safezone* or *mincap* or *minhbonds*
        *checkqeq* value = *yes* or *no* = whether or not to require qeq/reax fix
        *enobonds* value = *yes* or *no* = whether or not to tally energy of atoms with no bonds
        *lgvdw* value = *yes* or *no* = whether or not to use a low gradient vdW correction
        *safezone* = factor used for array allocation
        *mincap* = minimum size for array allocation
+       *minhbonds* = minimum size use for storing hydrogen bonds
 
 Examples
 """"""""
@@ -146,11 +147,11 @@ zero.  The latter behavior is usual not desired, as it causes
 discontinuities in the potential energy when the bonding of an atom
 drops to zero.
 
-Optional keywords *safezone* and *mincap* are used for allocating
-reax/c arrays.  Increasing these values can avoid memory problems,
-such as segmentation faults and bondchk failed errors, that could
-occur under certain conditions. These keywords are not used by the
-Kokkos version, which instead uses a more robust memory allocation
+Optional keywords *safezone*\ , *mincap*\ , and *minhbonds* are used
+for allocating reax/c arrays.  Increasing these values can avoid memory
+problems, such as segmentation faults and bondchk failed errors, that
+could occur under certain conditions. These keywords are not used by
+the Kokkos version, which instead uses a more robust memory allocation
 scheme that checks if the sizes of the arrays have been exceeded and
 automatically allocates more memory.
 
@@ -352,7 +353,7 @@ Default
 """""""
 
 The keyword defaults are checkqeq = yes, enobonds = yes, lgvdw = no,
-safezone = 1.2, mincap = 50.
+safezone = 1.2, mincap = 50, minhbonds = 25.
 
 ----------
 

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -1786,6 +1786,7 @@ Militzer
 Minary
 mincap
 Mindlin
+minhbonds
 mingw
 minima
 minimizations

--- a/src/USER-OMP/pair_reaxc_omp.cpp
+++ b/src/USER-OMP/pair_reaxc_omp.cpp
@@ -508,7 +508,7 @@ int PairReaxCOMP::estimate_reax_lists()
     num_nbrs += numneigh[i];
   }
 
-  int new_estimate = MAX (num_nbrs, mincap*MIN_NBRS);
+  int new_estimate = MAX(num_nbrs, mincap*REAX_MIN_NBRS);
 
   return new_estimate;
 }

--- a/src/USER-OMP/reaxc_forces_omp.cpp
+++ b/src/USER-OMP/reaxc_forces_omp.cpp
@@ -310,7 +310,7 @@ void Validate_ListsOMP(reax_system *system, storage * /*workspace*/, reax_list *
       Hindex = system->my_atoms[i].Hindex;
       if (Hindex > -1) {
         system->my_atoms[i].num_hbonds =
-          (int)(MAX( Num_Entries(Hindex, hbonds)*saferzone, MIN_HBONDS ));
+          (int)(MAX(Num_Entries(Hindex,hbonds)*saferzone,system->minhbonds));
 
         if (Hindex < numH-1)
           comp = Start_Index(Hindex+1, hbonds);

--- a/src/USER-OMP/reaxc_init_md_omp.cpp
+++ b/src/USER-OMP/reaxc_init_md_omp.cpp
@@ -68,7 +68,7 @@ int Init_ListsOMP(reax_system *system, control_params *control,
       system->my_atoms[i].num_hbonds = hb_top[i];
       total_hbonds += hb_top[i];
     }
-    total_hbonds = (int)(MAX( total_hbonds*saferzone, mincap*MIN_HBONDS ));
+    total_hbonds = (int)(MAX(total_hbonds*saferzone,mincap*system->minhbonds));
 
     if( !Make_List( system->Hcap, total_hbonds, TYP_HBOND,
                     *lists+HBONDS ) ) {

--- a/src/USER-REAXC/fix_qeq_reax.cpp
+++ b/src/USER-REAXC/fix_qeq_reax.cpp
@@ -43,11 +43,8 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 
 #define EV_TO_KCAL_PER_MOL 14.4
-//#define DANGER_ZONE     0.95
-//#define LOOSE_ZONE      0.7
 #define SQR(x) ((x)*(x))
 #define CUBE(x) ((x)*(x)*(x))
-#define MIN_NBRS 100
 
 static const char cite_fix_qeq_reax[] =
   "fix qeq/reax command:\n\n"
@@ -300,8 +297,8 @@ void FixQEqReax::allocate_matrix()
     mincap = reaxc->system->mincap;
     safezone = reaxc->system->safezone;
   } else {
-    mincap = MIN_CAP;
-    safezone = SAFE_ZONE;
+    mincap = REAX_MIN_CAP;
+    safezone = REAX_SAFE_ZONE;
   }
 
   n = atom->nlocal;
@@ -324,7 +321,7 @@ void FixQEqReax::allocate_matrix()
     i = ilist[ii];
     m += numneigh[i];
   }
-  m_cap = MAX( (int)(m * safezone), mincap * MIN_NBRS);
+  m_cap = MAX( (int)(m * safezone), mincap * REAX_MIN_NBRS);
 
   H.n = n_cap;
   H.m = m_cap;

--- a/src/USER-REAXC/pair_reaxc.cpp
+++ b/src/USER-REAXC/pair_reaxc.cpp
@@ -244,9 +244,10 @@ void PairReaxC::settings(int narg, char **arg)
   qeqflag = 1;
   control->lgflag = 0;
   control->enobondsflag = 1;
-  system->mincap = MIN_CAP;
-  system->safezone = SAFE_ZONE;
-  system->saferzone = SAFER_ZONE;
+  system->mincap = REAX_MIN_CAP;
+  system->minhbonds = REAX_MIN_HBONDS;
+  system->safezone = REAX_SAFE_ZONE;
+  system->saferzone = REAX_SAFER_ZONE;
 
   // process optional keywords
 
@@ -265,7 +266,7 @@ void PairReaxC::settings(int narg, char **arg)
       else if (strcmp(arg[iarg+1],"no") == 0) control->enobondsflag = 0;
       else error->all(FLERR,"Illegal pair_style reax/c command");
       iarg += 2;
-  } else if (strcmp(arg[iarg],"lgvdw") == 0) {
+    } else if (strcmp(arg[iarg],"lgvdw") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal pair_style reax/c command");
       if (strcmp(arg[iarg+1],"yes") == 0) control->lgflag = 1;
       else if (strcmp(arg[iarg+1],"no") == 0) control->lgflag = 0;
@@ -283,6 +284,12 @@ void PairReaxC::settings(int narg, char **arg)
       system->mincap = force->inumeric(FLERR,arg[iarg+1]);
       if (system->mincap < 0)
         error->all(FLERR,"Illegal pair_style reax/c mincap command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"minhbonds") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal pair_style reax/c command");
+      system->minhbonds = force->inumeric(FLERR,arg[iarg+1]);
+      if (system->minhbonds < 0)
+        error->all(FLERR,"Illegal pair_style reax/c minhbonds command");
       iarg += 2;
     } else error->all(FLERR,"Illegal pair_style reax/c command");
   }
@@ -712,7 +719,7 @@ int PairReaxC::estimate_reax_lists()
 
   free( marked );
 
-  return static_cast<int> (MAX( num_nbrs*safezone, mincap*MIN_NBRS ));
+  return static_cast<int> (MAX(num_nbrs*safezone, mincap*REAX_MIN_NBRS));
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-REAXC/reaxc_allocate.cpp
+++ b/src/USER-REAXC/reaxc_allocate.cpp
@@ -340,7 +340,7 @@ static int Reallocate_HBonds_List( reax_system *system, reax_list *hbonds )
     if ((system->my_atoms[i].Hindex) >= 0) {
       total_hbonds += system->my_atoms[i].num_hbonds;
     }
-  total_hbonds = (int)(MAX( total_hbonds*saferzone, mincap*MIN_HBONDS ));
+  total_hbonds = (int)(MAX(total_hbonds*saferzone, mincap*system->minhbonds));
 
   Delete_List( hbonds);
   if (!Make_List( system->Hcap, total_hbonds, TYP_HBOND, hbonds )) {
@@ -456,7 +456,7 @@ void ReAllocate( reax_system *system, control_params *control,
       }
 
       newsize = static_cast<int>
-        (MAX( realloc->num_far*safezone, mincap*MIN_NBRS ));
+        (MAX( realloc->num_far*safezone, mincap*REAX_MIN_NBRS));
 
       Reallocate_Neighbor_List( far_nbrs, system->total_cap, newsize);
       realloc->num_far = 0;

--- a/src/USER-REAXC/reaxc_defs.h
+++ b/src/USER-REAXC/reaxc_defs.h
@@ -75,37 +75,32 @@
 #define MAX_TOKENS          1024
 #define MAX_TOKEN_LEN       1024
 
-#define MAX_ATOM_ID         100000
-#define MAX_RESTRICT        15
-#define MAX_MOLECULE_SIZE   20
-#define MAX_ATOM_TYPES      25
-
 #define NUM_INTRS      10
 #define ALMOST_ZERO    1e-10
 #define NEG_INF       -1e10
 #define NO_BOND        1e-3  // 0.001
 #define HB_THRESHOLD   1e-2  // 0.01
 
-#define MIN_CAP        50
-#define MIN_NBRS       100
-#define MIN_HENTRIES   100
-#define MAX_BONDS      30
-#define MIN_BONDS      25
-#define MIN_HBONDS     25
-#define MIN_3BODIES    1000
-#define MIN_GCELL_POPL 50
-#define MIN_SEND       100
-#define SAFE_ZONE      1.2
-#define SAFER_ZONE     1.4
-#define DANGER_ZONE    0.90
-#define LOOSE_ZONE     0.75
-#define MAX_3BODY_PARAM     5
-#define MAX_4BODY_PARAM     5
+#define REAX_MIN_CAP    50
+#define REAX_MIN_NBRS   100
+#define MIN_HENTRIES    100
+#define MAX_BONDS       30
+#define MIN_BONDS       25
+#define REAX_MIN_HBONDS 25
+#define MIN_3BODIES     1000
+#define MIN_GCELL_POPL  50
+#define MIN_SEND        100
+#define REAX_SAFE_ZONE  1.2
+#define REAX_SAFER_ZONE 1.4
+#define DANGER_ZONE     0.90
+#define LOOSE_ZONE      0.75
+#define MAX_3BODY_PARAM 5
+#define MAX_4BODY_PARAM 5
 
-#define MAX_dV              1.01
-#define MIN_dV              0.99
-#define MAX_dT              4.00
-#define MIN_dT              0.00
+#define MAX_dV          1.01
+#define MIN_dV          0.99
+#define MAX_dT          4.00
+#define MIN_dT          0.00
 
 #define MASTER_NODE 0
 #define MAX_NBRS 6 //27

--- a/src/USER-REAXC/reaxc_forces.cpp
+++ b/src/USER-REAXC/reaxc_forces.cpp
@@ -152,7 +152,7 @@ void Validate_Lists( reax_system *system, storage * /*workspace*/, reax_list **l
       Hindex = system->my_atoms[i].Hindex;
       if (Hindex > -1) {
         system->my_atoms[i].num_hbonds =
-          (int)(MAX( Num_Entries(Hindex, hbonds)*saferzone, MIN_HBONDS ));
+          (int)(MAX(Num_Entries(Hindex, hbonds)*saferzone, system->minhbonds));
 
         //if( Num_Entries(i, hbonds) >=
         //(Start_Index(i+1,hbonds)-Start_Index(i,hbonds))*0.90/*DANGER_ZONE*/){
@@ -423,7 +423,7 @@ void Estimate_Storages( reax_system *system, control_params *control,
 
   *Htop = (int)(MAX( *Htop * safezone, mincap * MIN_HENTRIES ));
   for( i = 0; i < system->n; ++i )
-    hb_top[i] = (int)(MAX( hb_top[i] * saferzone, MIN_HBONDS ));
+    hb_top[i] = (int)(MAX(hb_top[i] * saferzone, system->minhbonds));
 
   for( i = 0; i < system->N; ++i ) {
     *num_3body += SQR(bond_top[i]);

--- a/src/USER-REAXC/reaxc_init_md.cpp
+++ b/src/USER-REAXC/reaxc_init_md.cpp
@@ -179,7 +179,7 @@ int  Init_Lists( reax_system *system, control_params *control,
       system->my_atoms[i].num_hbonds = hb_top[i];
       total_hbonds += hb_top[i];
     }
-    total_hbonds = (int)(MAX( total_hbonds*saferzone, mincap*MIN_HBONDS ));
+    total_hbonds = (int)(MAX(total_hbonds*saferzone,mincap*system->minhbonds));
 
     if( !Make_List( system->Hcap, total_hbonds, TYP_HBOND,
                     *lists+HBONDS ) ) {

--- a/src/USER-REAXC/reaxc_lookup.cpp
+++ b/src/USER-REAXC/reaxc_lookup.cpp
@@ -27,7 +27,6 @@
 #include "reaxc_lookup.h"
 #include <mpi.h>
 #include <cstdlib>
-#include "reaxc_defs.h"
 #include "reaxc_nonbonded.h"
 #include "reaxc_tool_box.h"
 
@@ -153,7 +152,7 @@ int Init_Lookup_Tables( reax_system *system, control_params *control,
 {
   int i, j, r;
   int num_atom_types;
-  int existing_types[MAX_ATOM_TYPES], aggregated[MAX_ATOM_TYPES];
+  int existing_types[REAX_MAX_ATOM_TYPES], aggregated[REAX_MAX_ATOM_TYPES];
   double dr;
   double *h, *fh, *fvdw, *fele, *fCEvd, *fCEclmb;
   double v0_vdw, v0_ele, vlast_vdw, vlast_ele;
@@ -186,12 +185,12 @@ int Init_Lookup_Tables( reax_system *system, control_params *control,
     LR[i] = (LR_lookup_table*)
       scalloc(system->error_ptr,  num_atom_types, sizeof(LR_lookup_table), "lookup:LR[i]");
 
-  for( i = 0; i < MAX_ATOM_TYPES; ++i )
+  for( i = 0; i < REAX_MAX_ATOM_TYPES; ++i )
     existing_types[i] = 0;
   for( i = 0; i < system->n; ++i )
     existing_types[ system->my_atoms[i].type ] = 1;
 
-  MPI_Allreduce( existing_types, aggregated, MAX_ATOM_TYPES,
+  MPI_Allreduce( existing_types, aggregated, REAX_MAX_ATOM_TYPES,
                  MPI_INT, MPI_SUM, mpi_data->world );
 
   for( i = 0; i < num_atom_types; ++i ) {

--- a/src/USER-REAXC/reaxc_traj.cpp
+++ b/src/USER-REAXC/reaxc_traj.cpp
@@ -39,11 +39,11 @@ int Reallocate_Output_Buffer( LAMMPS_NS::Error *error_ptr, output_controls *out_
   if (out_control->buffer_len > 0)
     free( out_control->buffer );
 
-  out_control->buffer_len = (int)(req_space*SAFE_ZONE);
+  out_control->buffer_len = (int)(req_space*REAX_SAFE_ZONE);
   out_control->buffer = (char*) malloc(out_control->buffer_len*sizeof(char));
   if (out_control->buffer == NULL) {
     char errmsg[256];
-    snprintf(errmsg, 256, "Insufficient memory for required buffer size %d", (int) (req_space*SAFE_ZONE));
+    snprintf(errmsg, 256, "Insufficient memory for required buffer size %d", (int) (req_space*REAX_SAFE_ZONE));
     error_ptr->one(FLERR,errmsg);
   }
 

--- a/src/USER-REAXC/reaxc_types.h
+++ b/src/USER-REAXC/reaxc_types.h
@@ -409,7 +409,7 @@ struct _reax_system
   class LAMMPS_NS::Error *error_ptr;
   class LAMMPS_NS::Pair *pair_ptr;
   int my_bonds;
-  int mincap;
+  int mincap,minhbonds;
   double safezone, saferzone;
 
   _LR_lookup_table **LR;


### PR DESCRIPTION
**Summary**

This makes the `MIN_HBONDS` parameter in USER-REAXC configurable at runtime through a keyword similar to `mincap`

**Related Issues**

Closes #2012 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes. The current constant is the default value for the new keyword

**Implementation Notes**

This also removes a few unused defines and renames a few with common names.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

