### PR TITLE
Add feature to make coordinate wrapping of per-chunk computes selectable

### DIFF
--- a/doc/src/compute_com_chunk.rst
+++ b/doc/src/compute_com_chunk.rst
@@ -8,11 +8,19 @@ Syntax
 
 .. parsed-literal::
 
-   compute ID group-ID com/chunk chunkID
+  compute ID group-ID com/chunk chunkID [wrapstyle <style>]
 
 * ID, group-ID are documented in :doc:`compute <compute>` command
 * com/chunk = style name of this compute command
 * chunkID = ID of :doc:`compute chunk/atom <compute_chunk_atom>` command
+* wrapstyle *style* = (optional) style of coordinate (un-)wrapping: *unwrap*\ , *atom*\ , *chunk*\ , *com*
+
+.. parsed-literal::
+
+  *unwrap* = completely unwrap coordinates
+  *atom*   = wrap coordinates per atom
+  *chunk*  = wrap per-chunk based on the lowest atom-ID in chunk
+  *com*    = wrap per-chunk based on center of mass position
 
 Examples
 """"""""
@@ -27,16 +35,29 @@ Description
 Define a computation that calculates the center-of-mass for multiple
 chunks of atoms.
 
-In LAMMPS, chunks are collections of atoms defined by a :doc:`compute chunk/atom <compute_chunk_atom>` command, which assigns each atom
-to a single chunk (or no chunk).  The ID for this command is specified
-as chunkID.  For example, a single chunk could be the atoms in a
-molecule or atoms in a spatial bin.  See the :doc:`compute chunk/atom <compute_chunk_atom>` and :doc:`Howto chunk <Howto_chunk>`
-doc pages for details of how chunks can be defined and examples of how
-they can be used to measure properties of a system.
+In LAMMPS, chunks are collections of atoms defined by a :doc:`compute
+chunk/atom <compute_chunk_atom>` command, which assigns each atom to a
+single chunk (or no chunk).  The ID for this command is specified as
+chunkID.  For example, a single chunk could be the atoms in a molecule
+or atoms in a spatial bin.  See the :doc:`compute chunk/atom
+<compute_chunk_atom>` and :doc:`Howto chunk <Howto_chunk>` doc pages for
+details of how chunks can be defined and examples of how they can be
+used to measure properties of a system.
 
-This compute calculates the x,y,z coordinates of the center-of-mass
-for each chunk, which includes all effects due to atoms passing through
-periodic boundaries.
+This compute calculates the x,y,z coordinates of the center-of-mass for
+each chunk.  The optional *wrapstyle* keyword determines how the effects
+due to atoms passing through periodic boundaries are considered.  With
+the default setting, *unwrap*\ , the center-of-mass is based on fully
+unwrapped coordinates (this may be desired with per-molecule chunks);
+when using the *atom* wrap style, no unwrapping is performed (this may
+be desired when the chunks are bins); when using the *chunk* wrap style,
+positions are wrapped back, but on a per-chunk basis using the atom with
+the lowest atom-ID in a chunk (this may be desired in combination with
+clusters); and finally the *com* style is similar to *chunk* only that
+the per chunk center-of-mass is used as reference position.  Please
+note, that while the computation of the per-chunk property selects atoms
+also based on the group-ID of this compute (see below), the wrapping
+itself considers all atoms in each chunk.
 
 Note that only atoms in the specified group contribute to the
 calculation.  The :doc:`compute chunk/atom <compute_chunk_atom>` command

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -3214,6 +3214,7 @@ wn
 Wolde
 workflow
 Worley
+wrapstyle
 Wriggers
 Wuppertal
 Wurtzite

--- a/src/chunk_wrap.cpp
+++ b/src/chunk_wrap.cpp
@@ -1,0 +1,184 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "chunk_wrap.h"
+#include <mpi.h>
+#include <cstring>
+#include <string>
+#include "atom.h"
+#include "compute_chunk_atom.h"
+#include "domain.h"
+#include "error.h"
+#include "memory.h"
+#include "modify.h"
+
+using namespace LAMMPS_NS;
+
+ChunkWrap::ChunkWrap(LAMMPS *lmp, const char *chunkid, const char *wrapstyle)
+  : Pointers(lmp), imgdiff(NULL), x(NULL), image(NULL)
+{
+  maxchunk = -1;
+  wrapflag = UNWRAP;
+  int n = strlen(chunkid) + 1;
+  idchunk = new char[n];
+  strcpy(idchunk,chunkid);
+
+  if (strcmp(wrapstyle,"unwrap") == 0) {
+    wrapflag = UNWRAP;
+  } else if (strcmp(wrapstyle,"atom") == 0) {
+    wrapflag = ATOM;
+  } else if (strcmp(wrapstyle,"chunk") == 0) {
+    wrapflag = CHUNK;
+  } else if (strcmp(wrapstyle,"com") == 0) {
+    wrapflag = COM;
+  } else {
+    std::string errmsg = "Unknown chunk wrap style: ";
+    errmsg += wrapstyle;
+    error->all(FLERR,errmsg.c_str());
+  }
+}
+
+ChunkWrap::~ChunkWrap()
+{
+  memory->destroy(imgdiff);
+}
+
+void ChunkWrap::init()
+{
+  x = atom->x;
+  image = atom->image;
+
+  // imageint value for (0,0,0)
+
+  const imageint zeroimg = ((imageint) IMGMAX)
+    | (((imageint) IMGMAX) << IMGBITS)
+    | (((imageint) IMGMAX) << IMG2BITS);
+
+  if ((wrapflag == CHUNK) || (wrapflag == COM)) {
+    int icompute = modify->find_compute(idchunk);
+    if (icompute < 0)
+      error->all(FLERR,"Chunk/atom compute does not exist for wrap");
+    ComputeChunkAtom *cca = (ComputeChunkAtom *) modify->compute[icompute];
+    nchunk = cca->setup_chunks();
+    cca->compute_ichunk();
+
+    if (nchunk+1 > maxchunk) {
+      memory->destroy(imgdiff);
+      maxchunk = nchunk+1;
+      memory->create(imgdiff, maxchunk, "chunkwrap:imgdiff");
+    }
+
+    if (wrapflag == CHUNK) {
+      // find atom with the smallest atom id for each chunk,
+      // and store the imageflag difference.
+
+      tagint *localid, *refid;
+      memory->create(localid, nchunk+1, "chunkwrap:localid");
+      memory->create(refid, nchunk+1, "chunkwrap:refid");
+      for (int i=0; i < nchunk+1; ++i) localid[i] = MAXTAGINT;
+
+      const int nlocal = atom->nlocal;
+      tagint *tag = atom->tag;
+      ichunk = cca->ichunk;
+      for (int i=0; i < nlocal; ++i) {
+        const int mychunk = ichunk[i];
+        if (mychunk > 0) localid[mychunk] = MIN(localid[mychunk],tag[i]);
+      }
+      MPI_Allreduce(localid,refid,nchunk+1,MPI_LMP_TAGINT,MPI_MIN,world);
+      memory->destroy(localid);
+
+      imageint *localimg;
+      memory->create(localimg,nchunk+1,"chunkwrap:localimg");
+      localimg[0] = 0;
+      for (int i=1; i < nchunk+1; ++i) {
+        const int idx = atom->map(refid[i]);
+        if ((idx >= 0) && (idx < nlocal)) {
+          localimg[i] = image[idx] - zeroimg;
+        } else localimg[i] = 0;
+      }
+      MPI_Allreduce(localimg,imgdiff,nchunk+1,MPI_LMP_IMAGEINT,MPI_SUM,world);
+      memory->destroy(refid);
+      memory->destroy(localimg);
+
+    } else if (wrapflag == COM) {
+
+      // get per-chunk center of mass from unwrapped coordinates, compute
+      // the imageflags for that position and store the difference to (0,0,0)
+
+      double *masslocal, *masstotal, **comlocal, **comtotal;
+      memory->create(masslocal, nchunk+1, "chunkwrap:masslocal");
+      memory->create(masstotal, nchunk+1, "chunkwrap:masstotal");
+      memory->create(comlocal, nchunk+1, 3, "chunkwrap:comlocal");
+      memory->create(comtotal, nchunk+1, 3, "chunkwrap:comtotal");
+      memset(masslocal,0,static_cast<size_t>(nchunk+1)*sizeof(double));
+      memset(&comlocal[0][0],0,3*static_cast<size_t>(nchunk+1)*sizeof(double));
+
+      int *type = atom->type;
+      double *rmass = atom->rmass;
+      double *mass = atom->mass;
+      const int nlocal = atom->nlocal;
+      double massone, unwrap[3];
+      imageint myimage;
+      ichunk = cca->ichunk;
+      for (int i=0; i < nlocal; ++i) {
+        const int mychunk = ichunk[i];
+        if (mychunk > 0) {
+          if (rmass) massone = rmass[i];
+          else massone = mass[type[i]];
+          domain->unmap(x[i],image[i],unwrap);
+          comlocal[mychunk][0] += unwrap[0] * massone;
+          comlocal[mychunk][1] += unwrap[1] * massone;
+          comlocal[mychunk][2] += unwrap[2] * massone;
+          masslocal[mychunk] += massone;
+        }
+      }
+      MPI_Allreduce(masslocal,masstotal,nchunk+1,MPI_DOUBLE,MPI_SUM,world);
+      MPI_Allreduce(&comlocal[0][0],&comtotal[0][0],3*(nchunk+1),MPI_DOUBLE,MPI_SUM,world);
+      memory->destroy(masslocal);
+      memory->destroy(comlocal);
+      for (int i=1; i < nchunk+1; ++i) {
+        myimage = zeroimg;
+        if (masstotal[i] > 0.0) {
+          comtotal[i][0] /= masstotal[i];
+          comtotal[i][1] /= masstotal[i];
+          comtotal[i][2] /= masstotal[i];
+          domain->remap(&comtotal[i][0],myimage);
+        }
+        imgdiff[i] = myimage - zeroimg;
+      }
+      memory->destroy(masstotal);
+      memory->destroy(comtotal);
+    }
+  }
+}
+
+void ChunkWrap::wrap(int idx, double *out)
+{
+  if (wrapflag == ATOM) {
+    out[0] = x[idx][0];
+    out[1] = x[idx][1];
+    out[2] = x[idx][2];
+  } else if (wrapflag == UNWRAP) {
+    domain->unmap(x[idx],image[idx],out);
+  } else if ((wrapflag == CHUNK) || (wrapflag == COM)) {
+    int id = ichunk[idx];
+    if (id > 0) {
+      imageint chunkimg = image[idx] - imgdiff[id];
+      domain->unmap(x[idx],chunkimg,out);
+    }
+  } else { // we should never get here.
+    out[0] = 0.0;
+    out[1] = 0.0;
+    out[2] = 0.0;
+  }
+}

--- a/src/chunk_wrap.h
+++ b/src/chunk_wrap.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifndef LMP_CHUNK_WRAP_H
+#define LMP_CHUNK_WRAP_H
+
+#include "pointers.h"
+
+namespace LAMMPS_NS {
+
+class ChunkWrap : protected Pointers {
+ public:
+  enum {UNWRAP, ATOM, CHUNK, COM};
+
+  ChunkWrap(LAMMPS *, const char *, const char *);
+  virtual ~ChunkWrap();
+
+  void init();
+  void wrap(int, double *);
+
+ private:
+  int wrapflag, nchunk, maxchunk;
+  int *ichunk;
+  char *idchunk;
+  imageint *imgdiff;
+  double **x;
+  imageint *image;
+};
+}
+
+#endif

--- a/src/compute_com_chunk.cpp
+++ b/src/compute_com_chunk.cpp
@@ -32,19 +32,30 @@ ComputeCOMChunk::ComputeCOMChunk(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   idchunk(NULL), masstotal(NULL), massproc(NULL), com(NULL), comall(NULL)
 {
-  if (narg != 4) error->all(FLERR,"Illegal compute com/chunk command");
+  if (narg < 4) error->all(FLERR,"Illegal compute com/chunk command");
 
   array_flag = 1;
   size_array_cols = 3;
   size_array_rows = 0;
   size_array_rows_variable = 1;
   extarray = 0;
+  unwrap_flag = 1;
 
   // ID of compute chunk/atom
 
   int n = strlen(arg[3]) + 1;
   idchunk = new char[n];
   strcpy(idchunk,arg[3]);
+
+  if (narg == 6) {
+    if (strcmp(arg[4],"unwrap") == 0) {
+       if (strcmp(arg[5],"yes") == 0) {
+         unwrap_flag = 1;
+       } else if (strcmp(arg[6],"no") == 0) {
+         unwrap_flag = 0;
+       } else error->all(FLERR,"Illegal compute com/chunk command");
+    } else error->all(FLERR,"Illegal compute com/chunk command");
+  } else error->all(FLERR,"Illegal compute com/chunk command");
 
   init();
 
@@ -137,7 +148,7 @@ void ComputeCOMChunk::compute_array()
       if (index < 0) continue;
       if (rmass) massone = rmass[i];
       else massone = mass[type[i]];
-      domain->unmap(x[i],image[i],unwrap);
+      if (unwrap_flag) domain->unmap(x[i],image[i],unwrap);
       com[index][0] += unwrap[0] * massone;
       com[index][1] += unwrap[1] * massone;
       com[index][2] += unwrap[2] * massone;

--- a/src/compute_com_chunk.h
+++ b/src/compute_com_chunk.h
@@ -45,7 +45,7 @@ class ComputeCOMChunk : public Compute {
 
  private:
   int nchunk,maxchunk;
-  int firstflag,massneed;
+  int firstflag,massneed,unwrap_flag;
   class ComputeChunkAtom *cchunk;
 
   double *massproc;

--- a/src/compute_com_chunk.h
+++ b/src/compute_com_chunk.h
@@ -45,8 +45,9 @@ class ComputeCOMChunk : public Compute {
 
  private:
   int nchunk,maxchunk;
-  int firstflag,massneed,unwrap_flag;
+  int firstflag,massneed;
   class ComputeChunkAtom *cchunk;
+  class ChunkWrap *wrap;
 
   double *massproc;
   double **com,**comall;


### PR DESCRIPTION
**Summary**

Add an optional keyword `wrapstyle` to per-chunk computes to allow selecting how coordinates are wrapped or unwrapped before computing the per-chunk property.

**Related Issues**

This tries to address the issues discussed in #1710 and #575 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes, the new keyword is optional and the default setting is the current behavior.

**Implementation Notes**

To reduce code redundancy, the processing of coordinate (un)wrapping is implemented in a separate class, that can be added to existing computes. For demonstration purposes, this is added to compute com/chunk only, where changing from the default *unwrap* to the *atom* style (i.e. no unwrapping) would be desired for binning.

This architecture allows adding other processing options, if needed.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
