### PR TITLE
Corrected two small typos in fix/ave/correlate/long code and documentation

### DIFF
--- a/doc/src/fix_ave_correlate_long.rst
+++ b/doc/src/fix_ave_correlate_long.rst
@@ -27,7 +27,7 @@ Syntax
        v_name = global value calculated by an equal-style variable with name
 
 * zero or more keyword/arg pairs may be appended
-* keyword = *type* or *start* or *file* or *overwrite* or *title1* or *title2* or *ncorr* or *p* or *m*
+* keyword = *type* or *start* or *file* or *overwrite* or *title1* or *title2* or *ncorr* or *nlen* or *ncount*
   
   .. parsed-literal::
   

--- a/src/USER-MISC/fix_ave_correlate_long.cpp
+++ b/src/USER-MISC/fix_ave_correlate_long.cpp
@@ -495,7 +495,7 @@ void FixAveCorrelateLong::end_of_step()
     if(overwrite) fseek(fp,filepos,SEEK_SET);
     fprintf(fp,"# Timestep: " BIGINT_FORMAT "\n", ntimestep);
     for (unsigned int i=0;i<npcorr;++i) {
-      fprintf(fp, "%lg ", t[i]*update->dt);
+      fprintf(fp, "%lg ", t[i]*update->dt*Nevery);
       for (int j=0;j<npair;++j) {
         fprintf(fp, "%lg ", f[j][i]);
       }


### PR DESCRIPTION
**Summary**

I am the original author of this fix. I have corrected a small bug in the code that created wrong time column in the output correlation files. Also, I have corrected two typos in the documentation, to help clarify how to use the code.

**Related Issues**

No related issues.

**Author(s)**

Jorge Ramirez (jorge.ramirez@upm.es)
Universidad Politécnica de Madrid, Spain.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This pull request will not break any backwards compatibility.

**Implementation Notes**

The original code was tested thoroughly and has been used by many other groups since its original publication.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ X ] The feature or features in this pull request is complete
- [ X ] Licensing information is complete
- [ X ] Corresponding author information is complete
- [ X ] The source code follows the LAMMPS formatting guidelines
- [ X ] Suitable new documentation files and/or updates to the existing docs are included
- [ X ] The added/updated documentation is integrated and tested with the documentation build system
- [ X ] The feature has been verified to work with the conventional build system
- [ X ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

No further information. Everything is referenced in the documentation files.


