### PR TITLE
Fix issue when generating lmpgitversion.h

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -6,13 +6,16 @@ cmake_minimum_required(VERSION 3.10)
 
 project(lammps CXX)
 set(SOVERSION 0)
-get_filename_component(LAMMPS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../src ABSOLUTE)
-get_filename_component(LAMMPS_LIB_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../lib ABSOLUTE)
+
+get_filename_component(LAMMPS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUTE)
 get_filename_component(LAMMPS_LIB_BINARY_DIR ${CMAKE_BINARY_DIR}/lib ABSOLUTE)
-get_filename_component(LAMMPS_DOC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../doc ABSOLUTE)
-get_filename_component(LAMMPS_TOOLS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../tools ABSOLUTE)
-get_filename_component(LAMMPS_PYTHON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../python ABSOLUTE)
-get_filename_component(LAMMPS_POTENTIALS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../potentials ABSOLUTE)
+
+set(LAMMPS_SOURCE_DIR     ${LAMMPS_DIR}/src)
+set(LAMMPS_LIB_SOURCE_DIR ${LAMMPS_DIR}/lib)
+set(LAMMPS_DOC_DIR        ${LAMMPS_DIR}/doc)
+set(LAMMPS_TOOLS_DIR      ${LAMMPS_DIR}/tools)
+set(LAMMPS_PYTHON_DIR     ${LAMMPS_DIR}/python)
+set(LAMMPS_POTENTIALS_DIR ${LAMMPS_DIR}/potentials)
 
 find_package(Git)
 
@@ -491,7 +494,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LAMMPS_STYLE_HE
 # Generate lmpgitversion.h
 ######################################
 add_custom_target(gitversion COMMAND ${CMAKE_COMMAND}
-  -DCMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+  -DLAMMPS_DIR="${LAMMPS_DIR}"
   -DGIT_EXECUTABLE="${GIT_EXECUTABLE}"
   -DGIT_FOUND="${GIT_FOUND}"
   -DLAMMPS_STYLE_HEADERS_DIR="${LAMMPS_STYLE_HEADERS_DIR}"

--- a/cmake/Modules/generate_lmpgitversion.cmake
+++ b/cmake/Modules/generate_lmpgitversion.cmake
@@ -3,17 +3,19 @@ set(temp_git_commit "(unknown)")
 set(temp_git_branch "(unknown)")
 set(temp_git_describe "(unknown)")
 set(temp_git_info "false")
-if(GIT_FOUND AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.git)
+
+message(STATUS "Git Directory: ${LAMMPS_DIR}/.git")
+if(GIT_FOUND AND EXISTS ${LAMMPS_DIR}/.git)
   set(temp_git_info "true")
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR}/.. rev-parse HEAD
+  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${LAMMPS_DIR} rev-parse HEAD
     OUTPUT_VARIABLE temp_git_commit
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR}/.. rev-parse --abbrev-ref HEAD
+  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${LAMMPS_DIR} rev-parse --abbrev-ref HEAD
     OUTPUT_VARIABLE temp_git_branch
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR}/.. describe --dirty=-modified
+  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${LAMMPS_DIR} describe --dirty=-modified
     OUTPUT_VARIABLE temp_git_describe
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
**Summary**

Updates `cmake/Modules/generate_lmpgitversion.cmake` to use the absolute path of `LAMMPS_DIR` instead of `CMAKE_CURRENT_SOURCE_DIR`. The previous version only works if the `build` directory is  a subdirectory of `LAMMPS_DIR`. If the folder is somewhere else, it produces the following `styles/lmpgitversion.h`:

```c++
#ifndef LMP_GIT_VERSION_H
#define LMP_GIT_VERSION_H
const bool LAMMPS_NS::LAMMPS::has_git_info = false;
const char LAMMPS_NS::LAMMPS::git_commit[] = "(unknown)";
const char LAMMPS_NS::LAMMPS::git_branch[] = "(unknown)";
const char LAMMPS_NS::LAMMPS::git_descriptor[] = "(unknown)";
#endif
```

This PR fixes this issue.

**Related Issues**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

- https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_SOURCE_DIR.html


