### PR TITLE
Collected small changes for the next patch release

### DIFF
--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -320,12 +320,13 @@ to have an executable that will run on this and newer architectures.
 
 .. note::
 
-   If you run Kokkos on a newer GPU architecture than what LAMMPS was
-   compiled with, there will be a delay during device initialization
-   since the just-in-time compiler has to recompile all GPU kernels
-   for the new hardware.  This is, however, not possible when compiled
-   for NVIDIA GPUs with CC 3.x (Kepler) for GPUs with CC 5.0 (Maxwell)
-   and newer as they are not compatible.
+   If you run Kokkos on a different GPU architecture than what LAMMPS
+   was compiled with, there will be a delay during device initialization
+   while the just-in-time compiler is recompiling all GPU kernels for
+   the new hardware.  This is, however, only supported for GPUs of the
+   **same** major hardware version and different minor hardware versions,
+   e.g. 5.0 and 5.2 but not 5.2 and 6.0.  LAMMPS will abort with an
+   error message indicating a mismatch, if that happens.
 
 The settings discussed below have been tested with LAMMPS and are
 confirmed to work.  Kokkos is an active project with ongoing improvements
@@ -580,9 +581,14 @@ recommended when developing a Kokkos-enabled style in LAMMPS.
 
 The CMake option ``-DKokkos_ENABLE_CUDA_UVM=on`` or the makefile
 setting ``KOKKOS_CUDA_OPTIONS=enable_lambda,force_uvm`` enables the
-use of CUDA "Unified Virtual Memory" in Kokkos.  Please note, that
-the LAMMPS KOKKOS package must **always** be compiled with the
-*enable_lambda* option when using GPUs.
+use of CUDA "Unified Virtual Memory" (UVM) in Kokkos.  UVM allows to
+transparently use RAM on the host to supplement the memory used on the
+GPU (with some performance penalty) and thus enables running larger
+problems that would otherwise not fit into the RAM on the GPU.
+
+Please note, that the LAMMPS KOKKOS package must **always** be compiled
+with the *enable_lambda* option when using GPUs.  The CMake configuration
+will thus always enable it.
 
 ----------
 

--- a/src/STUBS/mpi.c
+++ b/src/STUBS/mpi.c
@@ -377,7 +377,7 @@ MPI_Fint MPI_Comm_c2f(MPI_Comm comm) { return comm; };
 
 MPI_Comm MPI_Comm_f2c(MPI_Fint comm) { return comm; };
 
-//* ---------------------------------------------------------------------- */
+/* ---------------------------------------------------------------------- */
 
 int MPI_Comm_group(MPI_Comm comm, MPI_Group *group)
 {

--- a/src/STUBS/mpi.c
+++ b/src/STUBS/mpi.c
@@ -353,7 +353,7 @@ int MPI_Get_count(MPI_Status *status, MPI_Datatype datatype, int *count)
 
 int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *comm_out)
 {
-  *comm_out = comm;
+  *comm_out = comm+1;
   return 0;
 }
 
@@ -361,7 +361,7 @@ int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *comm_out)
 
 int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *comm_out)
 {
-  *comm_out = comm;
+  *comm_out = comm+1;
   return 0;
 }
 

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -604,10 +604,13 @@ void Atom::add_peratom(const char *name, void *address,
 void Atom::add_peratom_change_columns(const char *name, int cols)
 {
   int i;
-  for (int i = 0; i < nperatom; i++)
-    if (strcmp(name,peratom[i].name) == 0) peratom[i].cols = cols;
-  if (i == nperatom)
-    error->all(FLERR,"Could not find name of peratom array for column change");
+  for (i = 0; i < nperatom; i++) {
+    if (strcmp(name,peratom[i].name) == 0) {
+            peratom[i].cols = cols;
+            return;
+    }
+  }
+  error->all(FLERR,"Could not find name of peratom array for column change");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -603,8 +603,7 @@ void Atom::add_peratom(const char *name, void *address,
 
 void Atom::add_peratom_change_columns(const char *name, int cols)
 {
-  int i;
-  for (i = 0; i < nperatom; i++) {
+  for (int i = 0; i < nperatom; i++) {
     if (strcmp(name,peratom[i].name) == 0) {
             peratom[i].cols = cols;
             return;

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -192,7 +192,6 @@ void AtomVec::grow(int n)
 {
   int datatype,cols,maxcols;
   void *pdata;
-  int nthreads = comm->nthreads;
 
   if (n == 0) grow_nmax();
   else nmax = n;
@@ -206,38 +205,39 @@ void AtomVec::grow(int n)
   image = memory->grow(atom->image,nmax,"atom:image");
   x = memory->grow(atom->x,nmax,3,"atom:x");
   v = memory->grow(atom->v,nmax,3,"atom:v");
-  f = memory->grow(atom->f,nmax*nthreads,3,"atom:f");
+  f = memory->grow(atom->f,nmax*comm->nthreads,3,"atom:f");
 
   for (int i = 0; i < ngrow; i++) {
     pdata = mgrow.pdata[i];
     datatype = mgrow.datatype[i];
     cols = mgrow.cols[i];
+    const int nthreads = threads[i] ? comm->nthreads : 1;
     if (datatype == DOUBLE) {
       if (cols == 0)
-        memory->grow(*((double **) pdata),nmax*(threads[i]?nthreads:1),"atom:dvec");
+        memory->grow(*((double **) pdata),nmax*nthreads,"atom:dvec");
       else if (cols > 0)
-        memory->grow(*((double ***) pdata),nmax*(threads[i]?nthreads:1),cols,"atom:darray");
+        memory->grow(*((double ***) pdata),nmax*nthreads,cols,"atom:darray");
       else {
         maxcols = *(mgrow.maxcols[i]);
-        memory->grow(*((double ***) pdata),nmax*(threads[i]?nthreads:1),maxcols,"atom:darray");
+        memory->grow(*((double ***) pdata),nmax*nthreads,maxcols,"atom:darray");
       }
     } else if (datatype == INT) {
       if (cols == 0)
-        memory->grow(*((int **) pdata),nmax*(threads[i]?nthreads:1),"atom:ivec");
+        memory->grow(*((int **) pdata),nmax*nthreads,"atom:ivec");
       else if (cols > 0)
-        memory->grow(*((int ***) pdata),nmax*(threads[i]?nthreads:1),cols,"atom:iarray");
+        memory->grow(*((int ***) pdata),nmax*nthreads,cols,"atom:iarray");
       else {
         maxcols = *(mgrow.maxcols[i]);
-        memory->grow(*((int ***) pdata),nmax*(threads[i]?nthreads:1),maxcols,"atom:iarray");
+        memory->grow(*((int ***) pdata),nmax*nthreads,maxcols,"atom:iarray");
       }
     } else if (datatype == BIGINT) {
       if (cols == 0)
-        memory->grow(*((bigint **) pdata),nmax*(threads[i]?nthreads:1),"atom:bvec");
+        memory->grow(*((bigint **) pdata),nmax*nthreads,"atom:bvec");
       else if (cols > 0)
-        memory->grow(*((bigint ***) pdata),nmax*(threads[i]?nthreads:1),cols,"atom:barray");
+        memory->grow(*((bigint ***) pdata),nmax*nthreads,cols,"atom:barray");
       else {
         maxcols = *(mgrow.maxcols[i]);
-        memory->grow(*((int ***) pdata),nmax*(threads[i]?nthreads:1),maxcols,"atom:barray");
+        memory->grow(*((int ***) pdata),nmax*nthreads,maxcols,"atom:barray");
       }
     }
   }
@@ -2281,7 +2281,6 @@ bigint AtomVec::memory_usage()
 {
   int datatype,cols,index,maxcols;
   void *pdata;
-  int nthreads = comm->nthreads;
 
   bigint bytes = 0;
 
@@ -2291,39 +2290,40 @@ bigint AtomVec::memory_usage()
   bytes += memory->usage(image,nmax);
   bytes += memory->usage(x,nmax,3);
   bytes += memory->usage(v,nmax,3);
-  bytes += memory->usage(f,nmax*nthreads,3);
+  bytes += memory->usage(f,nmax*comm->nthreads,3);
 
   for (int i = 0; i < ngrow; i++) {
     pdata = mgrow.pdata[i];
     datatype = mgrow.datatype[i];
     cols = mgrow.cols[i];
     index = mgrow.index[i];
+    const int nthreads = threads[i] ? comm->nthreads : 1;
     if (datatype == DOUBLE) {
       if (cols == 0) {
-        bytes += memory->usage(*((double **) pdata),nmax*(threads[i]?nthreads:1));
+        bytes += memory->usage(*((double **) pdata),nmax*nthreads);
       } else if (cols > 0) {
-        bytes += memory->usage(*((double ***) pdata),nmax*(threads[i]?nthreads:1),cols);
+        bytes += memory->usage(*((double ***) pdata),nmax*nthreads,cols);
       } else {
         maxcols = *(mgrow.maxcols[i]);
-        bytes += memory->usage(*((double ***) pdata),nmax*(threads[i]?nthreads:1),maxcols);
+        bytes += memory->usage(*((double ***) pdata),nmax*nthreads,maxcols);
       }
     } else if (datatype == INT) {
       if (cols == 0) {
-        bytes += memory->usage(*((int **) pdata),nmax*(threads[i]?nthreads:1));
+        bytes += memory->usage(*((int **) pdata),nmax*nthreads);
       } else if (cols > 0) {
-        bytes += memory->usage(*((int ***) pdata),nmax*(threads[i]?nthreads:1),cols);
+        bytes += memory->usage(*((int ***) pdata),nmax*nthreads,cols);
       } else {
         maxcols = *(mgrow.maxcols[i]);
-        bytes += memory->usage(*((int ***) pdata),nmax*(threads[i]?nthreads:1),maxcols);
+        bytes += memory->usage(*((int ***) pdata),nmax*nthreads,maxcols);
       }
     } else if (datatype == BIGINT) {
       if (cols == 0) {
-        bytes += memory->usage(*((bigint **) pdata),nmax*(threads[i]?nthreads:1));
+        bytes += memory->usage(*((bigint **) pdata),nmax*nthreads);
       } else if (cols > 0) {
-        bytes += memory->usage(*((bigint ***) pdata),nmax*(threads[i]?nthreads:1),cols);
+        bytes += memory->usage(*((bigint ***) pdata),nmax*nthreads,cols);
       } else {
         maxcols = *(mgrow.maxcols[i]);
-        bytes += memory->usage(*((bigint ***) pdata),nmax*(threads[i]?nthreads:1),maxcols);
+        bytes += memory->usage(*((bigint ***) pdata),nmax*nthreads,maxcols);
       }
     }
   }

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -192,7 +192,7 @@ int AtomVec::grow_nmax_bonus(int nmax_bonus)
 void AtomVec::grow(int n)
 {
   int datatype,cols,maxcols;
-  void *pdata,*plength;
+  void *pdata;
 
   if (n == 0) grow_nmax();
   else nmax = n;
@@ -1775,7 +1775,7 @@ void AtomVec::pack_data(double **buf)
 
   int nlocal = atom->nlocal;
 
-  for (int i = 0; i < nlocal; i++) {
+  for (i = 0; i < nlocal; i++) {
 
     // if needed, change values before packing
 
@@ -1841,33 +1841,26 @@ void AtomVec::write_data(FILE *fp, int n, double **buf)
 
     j = 1;
     for (nn = 1; nn < ndata_atom; nn++) {
-      pdata = mdata_atom.pdata[nn];
       datatype = mdata_atom.datatype[nn];
       cols = mdata_atom.cols[nn];
       if (datatype == DOUBLE) {
         if (cols == 0) {
-          double *vec = *((double **) pdata);
           fprintf(fp," %-1.16e",buf[i][j++]);
         } else {
-          double **array = *((double ***) pdata);
           for (m = 0; m < cols; m++)
             fprintf(fp," %-1.16e",buf[i][j++]);
         }
       } else if (datatype == INT) {
         if (cols == 0) {
-          int *vec = *((int **) pdata);
           fprintf(fp," %d",(int) ubuf(buf[i][j++]).i);
         } else {
-          int **array = *((int ***) pdata);
           for (m = 0; m < cols; m++)
             fprintf(fp," %d",(int) ubuf(buf[i][j++]).i);
         }
       } else if (datatype == BIGINT) {
         if (cols == 0) {
-          bigint *vec = *((bigint **) pdata);
           fprintf(fp," " BIGINT_FORMAT,(bigint) ubuf(buf[i][j++]).i);
         } else {
-          bigint **array = *((bigint ***) pdata);
           for (m = 0; m < cols; m++)
             fprintf(fp," " BIGINT_FORMAT,(bigint) ubuf(buf[i][j++]).i);
         }

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -207,8 +207,7 @@ class AtomVec : protected Pointers {
   // thread info for fields that are duplicated over threads
   // used by fields in grow() and memory_usage()
 
-  int nthreads;
-  int *threads;
+  bool *threads;
 
   // union data struct for packing 32-bit and 64-bit ints into double bufs
   // this avoids aliasing issues by having 2 pointers (double,int)

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -192,7 +192,6 @@ void AtomVecEllipsoid::unpack_comm_bonus(int n, int first, double *buf)
 int AtomVecEllipsoid::pack_border_bonus(int n, int *list, double *buf)
 {
   int i,j,m;
-  double dx,dy,dz;
   double *shape,*quat;
 
   m = 0;

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -206,10 +206,13 @@ typedef int bigint;
 #define _noalias
 #endif
 
-// declaration to turn off optimization for specific functions
-// and avoid compiler warnings about variable tracking
+// Declaration to turn off optimization for specific noncritical
+// functions and avoid compiler warnings about variable tracking.
+// Disable for broken -D_FORTIFY_SOURCE feature.
 
-#if defined(__clang__)
+#if defined(_FORTIFY_SOURCE) && (_FORTIFY_SOURCE > 0)
+#define _noopt
+#elif defined(__clang__)
 #  define _noopt __attribute__((optnone))
 #elif defined(__INTEL_COMPILER)
 #  define _noopt

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -661,6 +661,8 @@ int Variable::next(int narg, char **arg)
 
   } else if (istyle == UNIVERSE || istyle == ULOOP) {
 
+    RanMars *random = nullptr;
+
     uloop_again:
 
     // wait until lock file can be created and owned by proc 0 of this world
@@ -674,7 +676,7 @@ int Variable::next(int narg, char **arg)
     int nextindex = -1;
     if (me == 0) {
       int seed = 12345 + universe->me + which[find(arg[0])];
-      RanMars *random = new RanMars(lmp,seed);
+      if (!random) random = new RanMars(lmp,seed);
       int delay = (int) (1000000*random->uniform());
       usleep(delay);
       while (1) {
@@ -682,7 +684,6 @@ int Variable::next(int narg, char **arg)
         delay = (int) (1000000*random->uniform());
         usleep(delay);
       }
-      delete random;
 
       // if the file cannot be found, we may have a race with some
       // other MPI rank that has called rename at the same time
@@ -706,6 +707,9 @@ int Variable::next(int narg, char **arg)
         delay = (int) (1000000*random->uniform());
         usleep(delay);
       }
+      delete random;
+      random = nullptr;
+
       if (nextindex < 0)
         error->one(FLERR,"Unexpected error while incrementing uloop "
                    "style variable. Please contact LAMMPS developers.");


### PR DESCRIPTION
**Summary**

The PR collects multiple small changes that do not warrant pull requests of their own.

**Related Issues**

Avoids false positive reported in and thus closes #2078
Addresses the issue reported in and thus closes #2081 

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues

**Implementation Notes**

This PR contains the following changes:
- remove unused variables left from AtomVec refactoring in PR #1788 
- address uninitialized variable access due to shadow variable declaration introduced by PR #1788 
- handle the case of `comm->nthreads` changing after the atom style was defined. (#2081)
- fix "use after delete" bug in uloop variable handling
- avoid false positive reports from `-D_FORTIFY_SOURCE` feature (#2078)
- small update/correct for KOKKOS related docs about JIT compilation and UVM

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

