### PR TITLE
Fix 32-bit integer overflow in Kokkos neighlist build on GPUs

### DIFF
--- a/src/KOKKOS/neigh_list_kokkos.h
+++ b/src/KOKKOS/neigh_list_kokkos.h
@@ -31,7 +31,7 @@ class AtomNeighbors
   num_neighs(_num_neighs), _firstneigh(firstneigh), _stride(stride) {};
   KOKKOS_INLINE_FUNCTION
   int& operator()(const int &i) const {
-    return _firstneigh[i*_stride];
+    return _firstneigh[(bigint) i*_stride];
   }
 
  private:
@@ -51,7 +51,7 @@ class AtomNeighborsConst
   _firstneigh(firstneigh), num_neighs(_num_neighs), _stride(stride) {};
   KOKKOS_INLINE_FUNCTION
   const int& operator()(const int &i) const {
-    return _firstneigh[i*_stride];
+    return _firstneigh[(bigint) i*_stride];
   }
 
  private:


### PR DESCRIPTION
**Summary**

For huge systems on GPUs (e.g. 32 million atoms or larger), a 32-bit integer in the Kokkos neighbor list build could overflow, leading to crashes.

**Related Issues**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.