### PR TITLE
Add a kspace style zero for debugging pair styles with long-range coulomb

### DIFF
--- a/doc/src/Commands_kspace.rst
+++ b/doc/src/Commands_kspace.rst
@@ -37,3 +37,4 @@ OPT.
    * :doc:`pppm/stagger <kspace_style>`
    * :doc:`pppm/tip4p (o) <kspace_style>`
    * :doc:`scafacos <kspace_style>`
+   * :doc:`zero <kspace_style>`

--- a/doc/src/kspace_style.rst
+++ b/doc/src/kspace_style.rst
@@ -10,7 +10,7 @@ Syntax
 
    kspace_style style value
 
-* style = *none* or *ewald* or *ewald/dipole* or *ewald/dipole/spin* or *ewald/disp* or *ewald/omp* or *pppm* or *pppm/cg* or *pppm/disp* or *pppm/tip4p* or *pppm/stagger* or *pppm/disp/tip4p* or *pppm/gpu* or *pppm/intel* or *pppm/disp/intel* or *pppm/kk* or *pppm/omp* or *pppm/cg/omp* or *pppm/disp/tip4p/omp* or *pppm/tip4p/omp* or *msm* or *msm/cg* or *msm/omp* or *msm/cg/omp* or *scafacos*
+* style = *none* or *ewald* or *ewald/dipole* or *ewald/dipole/spin* or *ewald/disp* or *ewald/omp* or *pppm* or *pppm/cg* or *pppm/disp* or *pppm/tip4p* or *pppm/stagger* or *pppm/disp/tip4p* or *pppm/gpu* or *pppm/intel* or *pppm/disp/intel* or *pppm/kk* or *pppm/omp* or *pppm/cg/omp* or *pppm/disp/tip4p/omp* or *pppm/tip4p/omp* or *msm* or *msm/cg* or *msm/omp* or *msm/cg/omp* or *scafacos* or *zero*
 
   .. parsed-literal::
 
@@ -74,6 +74,7 @@ Syntax
        *scafacos* values = method accuracy
          method = fmm or p2nfft or p3m or ewald or direct
          accuracy = desired relative error in forces
+       *zero* value = none
 
 Examples
 """"""""
@@ -85,6 +86,7 @@ Examples
    kspace style msm 1.0e-4
    kspace style scafacos fmm 1.0e-4
    kspace_style none
+   kspace_style zero
 
 Description
 """""""""""
@@ -308,6 +310,13 @@ the :doc:`kspace_modify scafacos accuracy <kspace_modify>` doc page.
 
 The :doc:`kspace_modify scafacos <kspace_modify>` command also explains
 other ScaFaCoS options currently exposed to LAMMPS.
+
+----------
+
+The KSpace style *zero* does not compute anything but signals that
+it is compatible with pair styles requiring a long-range coulomb solver.
+It can be used to debug the forces computed from such a pair style
+without being modified by the forces from the long-range solver.
 
 ----------
 

--- a/doc/src/kspace_style.rst
+++ b/doc/src/kspace_style.rst
@@ -74,7 +74,8 @@ Syntax
        *scafacos* values = method accuracy
          method = fmm or p2nfft or p3m or ewald or direct
          accuracy = desired relative error in forces
-       *zero* value = none
+       *zero* value = gewald
+         gewald = G-ewald parameter for Coulomb (1/distance units)
 
 Examples
 """"""""
@@ -317,6 +318,8 @@ The KSpace style *zero* does not compute anything but signals that
 it is compatible with pair styles requiring a long-range coulomb solver.
 It can be used to debug the forces computed from such a pair style
 without being modified by the forces from the long-range solver.
+Since this style does no computation as all, you have to provide the
+G-ewald parameter to be used in the corresponding pair style as argument.
 
 ----------
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -772,6 +772,8 @@
 /improper_umbrella.cpp
 /improper_umbrella.h
 /kissfft.h
+/kspace_zero.cpp
+/kspace_zero.h
 /lj_sdk_common.h
 /math_complex.h
 /math_vector.h

--- a/src/KSPACE/kspace_zero.cpp
+++ b/src/KSPACE/kspace_zero.cpp
@@ -1,0 +1,83 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "kspace_zero.h"
+#include <mpi.h>
+#include "comm.h"
+#include "force.h"
+#include "pair.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+KSpaceZero::KSpaceZero(LAMMPS *lmp) : KSpace(lmp)
+{
+  ewaldflag = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void KSpaceZero::init()
+{
+  if (comm->me == 0) {
+    if (screen) fprintf(screen,"KSpaceZero initialization ...\n");
+    if (logfile) fprintf(logfile,"KSpaceZero initialization ...\n");
+  }
+
+  if (force->pair == NULL)
+    error->all(FLERR,"KSpace solver requires a pair style");
+
+  if (!force->pair->ewaldflag && !force->pair->pppmflag && !force->pair->msmflag)
+    error->all(FLERR,"KSpace style is incompatible with Pair style");
+
+  int itmp;
+  double *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  if (p_cutoff == NULL)
+    error->all(FLERR,"KSpace style is incompatible with Pair style");
+
+  // compute qsum & qsqsum and warn if not charge-neutral
+
+  scale = 1.0;
+  qqrd2e = force->qqrd2e;
+  qsum_qsq();
+
+  // set accuracy (force units) from accuracy_relative or accuracy_absolute
+
+  accuracy = 0.0;
+  setup();
+}
+
+/* ----------------------------------------------------------------------
+   compute the KSpaceZero long-range force, energy, virial
+------------------------------------------------------------------------- */
+
+void KSpaceZero::compute(int eflag, int vflag)
+{
+  // set energy/virial flags
+
+  ev_init(eflag,vflag);
+}
+
+/* ----------------------------------------------------------------------
+   memory usage of local arrays
+------------------------------------------------------------------------- */
+
+double KSpaceZero::memory_usage()
+{
+  return (double)sizeof(KSpaceZero);
+}
+
+
+

--- a/src/KSPACE/kspace_zero.cpp
+++ b/src/KSPACE/kspace_zero.cpp
@@ -24,7 +24,17 @@ using namespace LAMMPS_NS;
 
 KSpaceZero::KSpaceZero(LAMMPS *lmp) : KSpace(lmp)
 {
+  g_ewald = 0.0;
   ewaldflag = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void KSpaceZero::settings(int narg, char **arg)
+{
+  if (narg != 1) error->all(FLERR,"Illegal kspace_style zero command");
+
+  g_ewald = force->numeric(FLERR,arg[0]);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/kspace_zero.h
+++ b/src/KSPACE/kspace_zero.h
@@ -1,0 +1,59 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef KSPACE_CLASS
+
+KSpaceStyle(zero,KSpaceZero)
+
+#else
+
+#ifndef LMP_KSPACE_ZERO_H
+#define LMP_KSPACE_ZERO_H
+
+#include "kspace.h"
+
+namespace LAMMPS_NS {
+
+class KSpaceZero : public KSpace {
+ public:
+  KSpaceZero(class LAMMPS *);
+  virtual ~KSpaceZero() {};
+  void init();
+  void setup() {};
+  virtual void compute(int, int);
+  double memory_usage();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: KSpace style is incompatible with Pair style
+
+Setting a kspace style requires that a pair style with matching
+long-range Coulombic or dispersion components be used.
+
+E: KSpace accuracy must be > 0
+
+The kspace accuracy designated in the input must be greater than zero.
+
+*/

--- a/src/KSPACE/kspace_zero.h
+++ b/src/KSPACE/kspace_zero.h
@@ -30,6 +30,7 @@ class KSpaceZero : public KSpace {
   virtual ~KSpaceZero() {};
   void init();
   void setup() {};
+  void settings(int, char**);
   virtual void compute(int, int);
   double memory_usage();
 };


### PR DESCRIPTION
**Summary**

This implements a kspace style called `zero`, that similar to the corresponding pair, bond, angle and other styles does not compute anything, but otherwise signals that it is compatible with `/long` and '/msm' pair styles. This is being used for unit testing, but can also be used for other scenarios where one wants to only compute the real-space contributions.

**Related Issues**

None.

**Author(s)**

Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
