### PR TITLE
Initialize omega and angmom when reading a data file

### DIFF
--- a/src/PERI/atom_vec_peri.cpp
+++ b/src/PERI/atom_vec_peri.cpp
@@ -64,7 +64,7 @@ AtomVecPeri::AtomVecPeri(LAMMPS *lmp) : AtomVec(lmp)
   fields_restart = (char *) "rmass vfrac s0 x0";
   fields_create = (char *) "rmass vfrac s0 x0";
   fields_data_atom = (char *) "id type vfrac rmass x";
-  fields_data_vel = (char *) "id v omega";
+  fields_data_vel = (char *) "id v";
 
   setup_fields();
 }

--- a/src/SPIN/atom_vec_spin.cpp
+++ b/src/SPIN/atom_vec_spin.cpp
@@ -56,7 +56,7 @@ AtomVecSpin::AtomVecSpin(LAMMPS *lmp) : AtomVec(lmp)
   fields_restart = (char *) "sp";
   fields_create = (char *) "sp";
   fields_data_atom = (char *) "id type x sp";
-  fields_data_vel = (char *) "id v omega";
+  fields_data_vel = (char *) "id v";
 
   setup_fields();
 }

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -84,6 +84,7 @@ void AtomVecEllipsoid::grow_pointers()
 {
   ellipsoid = atom->ellipsoid;
   rmass = atom->rmass;
+  angmom = atom->angmom;
 }
 
 /* ----------------------------------------------------------------------
@@ -444,6 +445,10 @@ void AtomVecEllipsoid::data_atom_post(int ilocal)
 
   if (rmass[ilocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
+
+  angmom[ilocal][0] = 0.0;
+  angmom[ilocal][1] = 0.0;
+  angmom[ilocal][2] = 0.0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom_vec_ellipsoid.h
+++ b/src/atom_vec_ellipsoid.h
@@ -65,6 +65,7 @@ class AtomVecEllipsoid : public AtomVec {
  private:
   int *ellipsoid;
   double *rmass;
+  double **angmom;
 
   int nghost_bonus,nmax_bonus;
   int ellipsoid_flag;

--- a/src/atom_vec_sphere.cpp
+++ b/src/atom_vec_sphere.cpp
@@ -109,6 +109,7 @@ void AtomVecSphere::grow_pointers()
 {
   radius = atom->radius;
   rmass = atom->rmass;
+  omega = atom->omega;
 }
 
 /* ----------------------------------------------------------------------
@@ -135,6 +136,10 @@ void AtomVecSphere::data_atom_post(int ilocal)
 
   if (rmass[ilocal] <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
+
+  omega[ilocal][0] = 0.0;
+  omega[ilocal][1] = 0.0;
+  omega[ilocal][2] = 0.0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom_vec_sphere.h
+++ b/src/atom_vec_sphere.h
@@ -38,6 +38,7 @@ class AtomVecSphere : public AtomVec {
 
  private:
   double *radius,*rmass;
+  double **omega;
 
   int radvary;
   double radius_one,rmass_one;


### PR DESCRIPTION
**Summary**

Fix a bug in the new AtomVec refactoring where omega and angmom were not initialized when a data file was read that didn't explicitly also initialize them.

**Related Issues**

This should fix the issue with valgrind errors of examples/ASPHERE/box/in.box* scripts.
Not sure if that is a numbered issue.

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


