### PR TITLE
Collected small changes and bug fixes for the next patch release

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -3,6 +3,11 @@
 # This file is part of LAMMPS
 # Created by Christoph Junghans and Richard Berger
 cmake_minimum_required(VERSION 3.10)
+# set policy to silence warnings about ignoring <PackageName>_ROOT but use it
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+########################################
 
 project(lammps CXX)
 set(SOVERSION 0)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -60,11 +60,11 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-  set(CMAKE_TUNE_DEFAULT "-ffast-math -march=native")
+  set(CMAKE_TUNE_DEFAULT "-march=native")
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-  set(CMAKE_TUNE_DEFAULT "-ffast-math -march=native")
+  set(CMAKE_TUNE_DEFAULT "-march=native")
 endif()
 
 # we require C++11 without extensions

--- a/cmake/Modules/FindTBB_MALLOC.cmake
+++ b/cmake/Modules/FindTBB_MALLOC.cmake
@@ -6,7 +6,9 @@
 #  TBB_MALLOC_FOUND        - True if tbb found.
 #
 
-
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+  cmake_policy(SET CMP0074 NEW)
+endif()
 ########################################################
 # TBB Malloc
 

--- a/cmake/Modules/FindTBB_MALLOC.cmake
+++ b/cmake/Modules/FindTBB_MALLOC.cmake
@@ -6,10 +6,6 @@
 #  TBB_MALLOC_FOUND        - True if tbb found.
 #
 
-# silence warning about ignoring <PackageName>_ROOT and use it.
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
 ########################################################
 # TBB Malloc
 

--- a/cmake/Modules/FindTBB_MALLOC.cmake
+++ b/cmake/Modules/FindTBB_MALLOC.cmake
@@ -6,7 +6,8 @@
 #  TBB_MALLOC_FOUND        - True if tbb found.
 #
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+# silence warning about ignoring <PackageName>_ROOT and use it.
+if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 ########################################################

--- a/cmake/Modules/Packages/USER-H5MD.cmake
+++ b/cmake/Modules/Packages/USER-H5MD.cmake
@@ -1,8 +1,10 @@
 enable_language(C)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+# silence warning about ignoring <PackageName>_ROOT and use it.
+if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
+
 find_package(HDF5 REQUIRED)
 target_link_libraries(h5md PRIVATE ${HDF5_LIBRARIES})
 target_include_directories(h5md PUBLIC ${HDF5_INCLUDE_DIRS})

--- a/cmake/Modules/Packages/USER-H5MD.cmake
+++ b/cmake/Modules/Packages/USER-H5MD.cmake
@@ -1,10 +1,5 @@
 enable_language(C)
 
-# silence warning about ignoring <PackageName>_ROOT and use it.
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
 find_package(HDF5 REQUIRED)
 target_link_libraries(h5md PRIVATE ${HDF5_LIBRARIES})
 target_include_directories(h5md PUBLIC ${HDF5_INCLUDE_DIRS})

--- a/cmake/Modules/Packages/USER-NETCDF.cmake
+++ b/cmake/Modules/Packages/USER-NETCDF.cmake
@@ -1,8 +1,12 @@
 # USER-NETCDF can use NetCDF, Parallel NetCDF (PNetCDF), or both. At least one necessary.
 # NetCDF library enables dump style "netcdf", while PNetCDF enables dump style "netcdf/mpiio"
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+
+# silence warning about ignoring <PackageName>_ROOT and use it.
+if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
+
+# may use NetCDF or PNetCDF with MPI, but must have NetCDF without
 if(NOT BUILD_MPI)
   find_package(NetCDF REQUIRED)
 else()

--- a/cmake/Modules/Packages/USER-NETCDF.cmake
+++ b/cmake/Modules/Packages/USER-NETCDF.cmake
@@ -1,11 +1,6 @@
 # USER-NETCDF can use NetCDF, Parallel NetCDF (PNetCDF), or both. At least one necessary.
 # NetCDF library enables dump style "netcdf", while PNetCDF enables dump style "netcdf/mpiio"
 
-# silence warning about ignoring <PackageName>_ROOT and use it.
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
 # may use NetCDF or PNetCDF with MPI, but must have NetCDF without
 if(NOT BUILD_MPI)
   find_package(NetCDF REQUIRED)

--- a/src/CLASS2/bond_class2.cpp
+++ b/src/CLASS2/bond_class2.cpp
@@ -224,7 +224,7 @@ double BondClass2::single(int type, double rsq, int /*i*/, int /*j*/, double &ff
 
 /* ---------------------------------------------------------------------- */
 
-void *BondClass2::extract( char *str, int &dim )
+void *BondClass2::extract(const char *str, int &dim)
 {
   dim = 1;
   if (strcmp(str,"r0")==0) return (void*) r0;

--- a/src/CLASS2/bond_class2.h
+++ b/src/CLASS2/bond_class2.h
@@ -35,7 +35,7 @@ class BondClass2 : public Bond {
   virtual void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
-  virtual void *extract(char *, int &);
+  virtual void *extract(const char *, int &);
 
  protected:
   double *r0,*k2,*k3,*k4;

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -276,7 +276,7 @@ double BondFENE::single(int type, double rsq, int /*i*/, int /*j*/,
 
 /* ---------------------------------------------------------------------- */
 
-void *BondFENE::extract( char *str, int &dim )
+void *BondFENE::extract(const char *str, int &dim)
 {
   dim = 1;
   if (strcmp(str,"kappa")==0) return (void*) k;

--- a/src/MOLECULE/bond_fene.h
+++ b/src/MOLECULE/bond_fene.h
@@ -36,7 +36,7 @@ class BondFENE : public Bond {
   void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
-  virtual void *extract(char *, int &);
+  virtual void *extract(const char *, int &);
 
  protected:
   double TWO_1_3;

--- a/src/MOLECULE/bond_gromos.cpp
+++ b/src/MOLECULE/bond_gromos.cpp
@@ -189,7 +189,7 @@ void BondGromos::write_data(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double BondGromos::single(int type, double rsq, int /*i*/, int /*j*/,
-                        double &fforce)
+                          double &fforce)
 {
   double dr = rsq - r0[type]*r0[type];
   fforce = -4.0*k[type] * dr;
@@ -199,7 +199,7 @@ double BondGromos::single(int type, double rsq, int /*i*/, int /*j*/,
 /* ----------------------------------------------------------------------
     Return ptr to internal members upon request.
 ------------------------------------------------------------------------ */
-void *BondGromos::extract( char *str, int &dim )
+void *BondGromos::extract(const char *str, int &dim)
 {
   dim = 1;
   if (strcmp(str,"kappa")==0) return (void*) k;

--- a/src/MOLECULE/bond_gromos.h
+++ b/src/MOLECULE/bond_gromos.h
@@ -35,7 +35,7 @@ class BondGromos : public Bond {
   void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
-  virtual void *extract(char *, int &);
+  virtual void *extract(const char *, int &);
 
  protected:
   double *k,*r0;

--- a/src/MOLECULE/bond_harmonic.cpp
+++ b/src/MOLECULE/bond_harmonic.cpp
@@ -190,7 +190,7 @@ void BondHarmonic::write_data(FILE *fp)
 /* ---------------------------------------------------------------------- */
 
 double BondHarmonic::single(int type, double rsq, int /*i*/, int /*j*/,
-                        double &fforce)
+                            double &fforce)
 {
   double r = sqrt(rsq);
   double dr = r - r0[type];
@@ -203,7 +203,7 @@ double BondHarmonic::single(int type, double rsq, int /*i*/, int /*j*/,
 /* ----------------------------------------------------------------------
     Return ptr to internal members upon request.
 ------------------------------------------------------------------------ */
-void *BondHarmonic::extract( char *str, int &dim )
+void *BondHarmonic::extract(const char *str, int &dim)
 {
   dim = 1;
   if (strcmp(str,"kappa")==0) return (void*) k;

--- a/src/MOLECULE/bond_harmonic.h
+++ b/src/MOLECULE/bond_harmonic.h
@@ -35,7 +35,7 @@ class BondHarmonic : public Bond {
   virtual void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
-  virtual void *extract(char *, int &);
+  virtual void *extract(const char *, int &);
 
  protected:
   double *k,*r0;

--- a/src/MOLECULE/bond_morse.cpp
+++ b/src/MOLECULE/bond_morse.cpp
@@ -209,7 +209,7 @@ double BondMorse::single(int type, double rsq, int /*i*/, int /*j*/,
 
 /* ---------------------------------------------------------------------- */
 
-void *BondMorse::extract(char *str, int &dim )
+void *BondMorse::extract(const char *str, int &dim)
 {
   dim = 1;
   if (strcmp(str,"r0")==0) return (void*) r0;

--- a/src/MOLECULE/bond_morse.h
+++ b/src/MOLECULE/bond_morse.h
@@ -35,7 +35,7 @@ class BondMorse : public Bond {
   void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
-  virtual void *extract(char *, int &);
+  virtual void *extract(const char *, int &);
 
  protected:
   double *d0,*alpha,*r0;

--- a/src/MOLECULE/bond_nonlinear.cpp
+++ b/src/MOLECULE/bond_nonlinear.cpp
@@ -206,7 +206,7 @@ double BondNonlinear::single(int type, double rsq, int /*i*/, int /*j*/,
 
 /* ---------------------------------------------------------------------- */
 
-void *BondNonlinear::extract( char *str, int &dim )
+void *BondNonlinear::extract(const char *str, int &dim)
 {
   dim = 1;
   if (strcmp(str,"epsilon")==0) return (void*) epsilon;

--- a/src/MOLECULE/bond_nonlinear.h
+++ b/src/MOLECULE/bond_nonlinear.h
@@ -35,7 +35,7 @@ class BondNonlinear : public Bond {
   void read_restart(FILE *);
   void write_data(FILE *);
   double single(int, double, int, int, double &);
-  virtual void *extract(char *, int &);
+  virtual void *extract(const char *, int &);
 
  protected:
   double *epsilon,*r0,*lamda;

--- a/src/USER-INTEL/pair_eam_intel.cpp
+++ b/src/USER-INTEL/pair_eam_intel.cpp
@@ -711,6 +711,8 @@ void PairEAMIntel::pack_force_const(ForceConst<flt_t> &fc,
       if (type2rhor[i][j] >= 0) {
         const int joff = ioff + j * fc.rhor_jstride();
         for (int k = 0; k < nr + 1; k++) {
+          if ((type2rhor[j][i] < 0) || (type2rhor[i][j] < 0))
+            continue;
           if (type2rhor[j][i] != type2rhor[i][j])
             _onetype = 0;
           else if (_onetype < 0)

--- a/src/USER-OMP/fix_omp.h
+++ b/src/USER-OMP/fix_omp.h
@@ -70,6 +70,8 @@ class FixOMP : public Fix {
   bool _neighbor;   // en/disable threads for neighbor list construction
   bool _mixed;      // whether to prefer mixed precision compute kernels
   bool _reduced;    // whether forces have been reduced for this step
+  bool _pair_compute_flag;    // whether pair_compute is called
+  bool _kspace_compute_flag;  // whether kspace_compute is called
 
   void set_neighbor_omp();
 };

--- a/src/USER-OMP/pair_lj_class2_coul_long_omp.cpp
+++ b/src/USER-OMP/pair_lj_class2_coul_long_omp.cpp
@@ -39,6 +39,7 @@ PairLJClass2CoulLongOMP::PairLJClass2CoulLongOMP(LAMMPS *lmp) :
 {
   suffix_flag |= Suffix::OMP;
   respa_enable = 0;
+  cut_respa = NULL;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -85,8 +86,9 @@ void PairLJClass2CoulLongOMP::compute(int eflag, int vflag)
 template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
 void PairLJClass2CoulLongOMP::eval(int iifrom, int iito, ThrData * const thr)
 {
-  int i,j,ii,jj,jnum,itype,jtype;
+  int i,j,ii,jj,jnum,itype,jtype,itable;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
   double r,rsq,rinv,r2inv,r3inv,r6inv,forcecoul,forcelj,factor_coul,factor_lj;
   double grij,expm2,prefactor,t,erfc;
   int *ilist,*jlist,*numneigh,**firstneigh;
@@ -137,14 +139,29 @@ void PairLJClass2CoulLongOMP::eval(int iifrom, int iito, ThrData * const thr)
         r2inv = 1.0/rsq;
 
         if (rsq < cut_coulsq) {
-          r = sqrt(rsq);
-          grij = g_ewald * r;
-          expm2 = exp(-grij*grij);
-          t = 1.0 / (1.0 + EWALD_P*grij);
-          erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
-          prefactor = qqrd2e * qtmp*q[j]/r;
-          forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
-          if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+          if (!ncoultablebits || rsq <= tabinnersq) {
+            r = sqrt(rsq);
+            grij = g_ewald * r;
+            expm2 = exp(-grij*grij);
+            t = 1.0 / (1.0 + EWALD_P*grij);
+            erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
+            prefactor = qqrd2e * qtmp*q[j]/r;
+            forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+            if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+          } else {
+            union_int_float_t rsq_lookup;
+            rsq_lookup.f = rsq;
+            itable = rsq_lookup.i & ncoulmask;
+            itable >>= ncoulshiftbits;
+            fraction = (rsq_lookup.f - rtable[itable]) * drtable[itable];
+            table = ftable[itable] + fraction*dftable[itable];
+            forcecoul = qtmp*q[j] * table;
+            if (factor_coul < 1.0) {
+              table = ctable[itable] + fraction*dctable[itable];
+              prefactor = qtmp*q[j] * table;
+              forcecoul -= (1.0-factor_coul)*prefactor;
+            }
+          }
         } else forcecoul = 0.0;
 
         if (rsq < cut_ljsq[itype][jtype]) {
@@ -168,7 +185,12 @@ void PairLJClass2CoulLongOMP::eval(int iifrom, int iito, ThrData * const thr)
 
         if (EFLAG) {
           if (rsq < cut_coulsq) {
-            ecoul = prefactor*erfc;
+            if (!ncoultablebits || rsq <= tabinnersq)
+              ecoul = prefactor*erfc;
+            else {
+              table = etable[itable] + fraction*detable[itable];
+              ecoul = qtmp*q[j] * table;
+            }
             if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
           } else ecoul = 0.0;
 

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -2279,7 +2279,7 @@ void AtomVec::write_improper(FILE *fp, int n, tagint **buf, int index)
 
 bigint AtomVec::memory_usage()
 {
-  int datatype,cols,index,maxcols;
+  int datatype,cols,maxcols;
   void *pdata;
 
   bigint bytes = 0;
@@ -2296,7 +2296,6 @@ bigint AtomVec::memory_usage()
     pdata = mgrow.pdata[i];
     datatype = mgrow.datatype[i];
     cols = mgrow.cols[i];
-    index = mgrow.index[i];
     const int nthreads = threads[i] ? comm->nthreads : 1;
     if (datatype == DOUBLE) {
       if (cols == 0) {

--- a/src/bond.h
+++ b/src/bond.h
@@ -52,7 +52,7 @@ class Bond : protected Pointers {
   virtual void write_data(FILE *) {}
   virtual double single(int, double, int, int, double &) = 0;
   virtual double memory_usage();
-  virtual void *extract(char *, int &) {return NULL;}
+  virtual void *extract(const char *, int &) {return NULL;}
   virtual void reinit();
 
   void write_file(int, char**);

--- a/src/bond_zero.cpp
+++ b/src/bond_zero.cpp
@@ -144,12 +144,19 @@ void BondZero::write_data(FILE *fp)
     fprintf(fp,"%d %g\n",i,r0[i]);
 }
 
-
-
 /* ---------------------------------------------------------------------- */
 
 double BondZero::single(int /*type*/, double /*rsq*/, int /*i*/, int /*j*/,
                         double & /*fforce*/)
 {
   return 0.0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void *BondZero::extract(const char *str, int &dim)
+{
+  dim = 1;
+  if (strcmp(str,"r0")==0) return (void*) r0;
+  return NULL;
 }

--- a/src/bond_zero.h
+++ b/src/bond_zero.h
@@ -38,6 +38,7 @@ class BondZero : public Bond {
   void write_data(FILE *);
 
   double single(int, double, int, int, double &);
+  virtual void *extract(const char *, int &);
 
  protected:
   double *r0;

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -18,6 +18,7 @@
 #include "atom_masks.h"
 #include "memory.h"
 #include "error.h"
+#include "suffix.h"
 
 using namespace LAMMPS_NS;
 
@@ -32,6 +33,7 @@ Dihedral::Dihedral(LAMMPS *lmp) : Pointers(lmp)
   writedata = 0;
 
   allocated = 0;
+  suffix_flag = Suffix::NONE;
 
   maxeatom = maxvatom = maxcvatom = 0;
   eatom = NULL;

--- a/src/random_mars.cpp
+++ b/src/random_mars.cpp
@@ -151,7 +151,7 @@ double RanMars::besselexp(double theta, double alpha, double cp)
 {
   double first,v1,v2;
 
-  if (theta < 0.0 || alpha < 0.0 || alpha < 1.0)
+  if (theta < 0.0 || alpha < 0.0 || alpha > 1.0)
     error->all(FLERR,"Invalid Bessel exponential distribution parameters");
 
   v1 = uniform();

--- a/tools/singularity/centos7.def
+++ b/tools/singularity/centos7.def
@@ -46,7 +46,7 @@ EOF
         . /etc/profile
         module load mpi
         # restrict OpenMPI to shared memory comm by default
-        OMPI_MCA_btl="sm,self"
+        OMPI_MCA_btl="tcp,self"
         # do not warn about unused components as this messes up testing
         OMPI_MCA_btl_base_warn_component_unused="0"
         export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/centos8.def
+++ b/tools/singularity/centos8.def
@@ -51,7 +51,7 @@ EOF
         . /etc/profile
         module load mpi
         # restrict OpenMPI to shared memory comm by default
-        OMPI_MCA_btl="sm,self"
+        OMPI_MCA_btl="tcp,self"
         # do not warn about unused components as this messes up testing
         OMPI_MCA_btl_base_warn_component_unused="0"
         export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/fedora32_mingw.def
+++ b/tools/singularity/fedora32_mingw.def
@@ -66,7 +66,7 @@ EOF
         . /etc/profile
         module load mpi
         # restrict OpenMPI to shared memory comm by default
-        OMPI_MCA_btl="sm,self"
+        OMPI_MCA_btl="tcp,self"
         # do not warn about unused components as this messes up testing
         OMPI_MCA_btl_base_warn_component_unused="0"
         export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/ubuntu16.04.def
+++ b/tools/singularity/ubuntu16.04.def
@@ -29,7 +29,7 @@ EOF
         LC_ALL=C
         export LC_ALL
         # restrict OpenMPI to shared memory comm by default
-        OMPI_MCA_btl="sm,self"
+        OMPI_MCA_btl="tcp,self"
         # do not warn about unused components as this messes up testing
         OMPI_MCA_btl_base_warn_component_unused="0"
         export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/ubuntu18.04.def
+++ b/tools/singularity/ubuntu18.04.def
@@ -84,7 +84,7 @@ EOF
     export LC_ALL
     export PATH=/usr/lib/ccache:$PATH
     # restrict OpenMPI to shared memory comm by default
-    OMPI_MCA_btl="sm,self"
+    OMPI_MCA_btl="tcp,self"
     # do not warn about unused components as this messes up testing
     OMPI_MCA_btl_base_warn_component_unused="0"
     export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/ubuntu18.04_amd_rocm.def
+++ b/tools/singularity/ubuntu18.04_amd_rocm.def
@@ -90,7 +90,7 @@ EOF
     LC_ALL=C
     export LC_ALL
     # restrict OpenMPI to shared memory comm by default
-    OMPI_MCA_btl="sm,self"
+    OMPI_MCA_btl="tcp,self"
     # do not warn about unused components as this messes up testing
     OMPI_MCA_btl_base_warn_component_unused="0"
     export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/ubuntu18.04_gpu.def
+++ b/tools/singularity/ubuntu18.04_gpu.def
@@ -117,7 +117,7 @@ EOF
     LC_ALL=C
     export LC_ALL
     # restrict OpenMPI to shared memory comm by default
-    OMPI_MCA_btl="sm,self"
+    OMPI_MCA_btl="tcp,self"
     # do not warn about unused components as this messes up testing
     OMPI_MCA_btl_base_warn_component_unused="0"
     export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/ubuntu18.04_intel_opencl.def
+++ b/tools/singularity/ubuntu18.04_intel_opencl.def
@@ -83,7 +83,7 @@ EOF
     LC_ALL=C
     export LC_ALL
     # restrict OpenMPI to shared memory comm by default
-    OMPI_MCA_btl="sm,self"
+    OMPI_MCA_btl="tcp,self"
     # do not warn about unused components as this messes up testing
     OMPI_MCA_btl_base_warn_component_unused="0"
     export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/ubuntu18.04_nvidia.def
+++ b/tools/singularity/ubuntu18.04_nvidia.def
@@ -82,7 +82,7 @@ EOF
     LC_ALL=C
     export LC_ALL
     # restrict OpenMPI to shared memory comm by default
-    OMPI_MCA_btl="sm,self"
+    OMPI_MCA_btl="tcp,self"
     # do not warn about unused components as this messes up testing
     OMPI_MCA_btl_base_warn_component_unused="0"
     export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused

--- a/tools/singularity/ubuntu20.04.def
+++ b/tools/singularity/ubuntu20.04.def
@@ -80,7 +80,7 @@ EOF
     LC_ALL=C
     export LC_ALL
     # restrict OpenMPI to shared memory comm by default
-    OMPI_MCA_btl="sm,self"
+    OMPI_MCA_btl="tcp,self"
     # do not warn about unused components as this messes up testing
     OMPI_MCA_btl_base_warn_component_unused="0"
     export OMPI_MCA_btl OMPI_MCA_btl_base_warn_component_unused


### PR DESCRIPTION
**Summary**

This pull request collects multiple small changes that do not warrant a pull request of their own

**Related Issues**

Most of these issues showed up while working on implementing the test infrastructure in PR #1970 
Fixes #2096 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

The following individual changes are included:
- add missing tabulation for long-range coulomb to pair style lj/class2/coul/long
- silence compiler warnings by removing unused variables in a few places
- fix a bug in USER-OMP that was not properly reducing forces with "pair_modify compute no" or "kspace_modify compute no"
- do not use `-ffast-math` by default. it creates too much instability and numerical noise
- the dihedral base class did not properly initialize its suffix_flag member.
- avoid segmentation fault when using pair style eam/intel with a hybrid pair style.
- the first argument to `Bond::extract()` should be `const char *` and **not** `char *`. 
- add `extract()` method to bond style "zero".
- set CMake policy was missing for finding TBB malloc.
- reintroduce bugfix for bessel function distributed random numbers.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
