### PR TITLE
Fix redundant computation in Kokkos Pair SNAP on GPUs

### DIFF
--- a/src/KOKKOS/pair_snap_kokkos.h
+++ b/src/KOKKOS/pair_snap_kokkos.h
@@ -112,7 +112,7 @@ public:
   void operator() (TagPairSNAPComputeDeidrjCPU,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPComputeDeidrjCPU>::member_type& team) const;
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (TagPairSNAPBeta,const typename Kokkos::TeamPolicy<DeviceType, TagPairSNAPBeta>::member_type& team) const;
+  void operator() (TagPairSNAPBeta,const int& ii) const;
 
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -284,13 +284,8 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     }
 
     //Compute beta = dE_i/dB_i for all i in list
-    {
-      int vector_length = vector_length_default;
-      int team_size = team_size_default;
-      check_team_size_for<TagPairSNAPBeta>(chunk_size,team_size,vector_length);
-      typename Kokkos::TeamPolicy<DeviceType,TagPairSNAPBeta> policy_beta(chunk_size,team_size,vector_length);
-      Kokkos::parallel_for("ComputeBeta",policy_beta,*this);
-    }
+    typename Kokkos::RangePolicy<DeviceType,TagPairSNAPBeta> policy_beta(0,chunk_size);
+    Kokkos::parallel_for("ComputeBeta",policy_beta,*this);
 
     //ZeroYi
     {
@@ -424,10 +419,8 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPBeta,const typename Kokkos::TeamPolicy<DeviceType,TagPairSNAPBeta>::member_type& team) const {
+void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPBeta,const int& ii) const {
 
-  // TODO: use RangePolicy instead, or thread over ncoeff?
-  int ii = team.league_rank();
   const int i = d_ilist[ii + chunk_offset];
   const int itype = type[i];
   const int ielem = d_map[itype];


### PR DESCRIPTION
**Summary**

Fix redundant computation in Kokkos Pair SNAP on GPUs. The `compute beta` kernel was using a team size of 32 on GPUs but each thread was doing the same calculation. This PR changes the `TeamPolicy` to a flat `RangePolicy`.

**Related Issues**

None.

**Author(s)**

Stan Moore (SNL), reported by Evan Weinberg (NVIDIA) @weinbe2 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.