### PR TITLE
Make sure include directories are passed to test binaries

### DIFF
--- a/unittest/force-styles/CMakeLists.txt
+++ b/unittest/force-styles/CMakeLists.txt
@@ -8,11 +8,11 @@ endif()
 set(TEST_INPUT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 add_library(style_tests STATIC yaml_writer.cpp error_stats.cpp test_config_reader.cpp test_main.cpp)
 target_compile_definitions(style_tests PRIVATE TEST_INPUT_FOLDER=${TEST_INPUT_FOLDER})
-target_link_libraries(style_tests PRIVATE MPI::MPI_CXX Yaml::Yaml)
+target_link_libraries(style_tests PUBLIC GTest::GTest GTest::GMock MPI::MPI_CXX Yaml::Yaml)
 
 # pair style tester
 add_executable(pair_style pair_style.cpp)
-target_link_libraries(pair_style PRIVATE lammps GTest::GTest GTest::GMock style_tests)
+target_link_libraries(pair_style PRIVATE lammps style_tests)
 
 # tests for a molecular systems and related pair styles
 file(GLOB MOL_PAIR_TESTS LIST_DIRECTORIES false ${TEST_INPUT_FOLDER}/mol-pair-*.yaml)
@@ -33,7 +33,7 @@ endforeach()
 
 # bond style tester
 add_executable(bond_style bond_style.cpp)
-target_link_libraries(bond_style PRIVATE lammps GTest::GTest GTest::GMock style_tests)
+target_link_libraries(bond_style PRIVATE lammps style_tests)
 
 file(GLOB BOND_TESTS LIST_DIRECTORIES false ${TEST_INPUT_FOLDER}/bond-*.yaml)
 foreach(TEST ${BOND_TESTS})
@@ -44,7 +44,7 @@ endforeach()
 
 # angle style tester
 add_executable(angle_style angle_style.cpp)
-target_link_libraries(angle_style PRIVATE lammps GTest::GTest GTest::GMock style_tests)
+target_link_libraries(angle_style PRIVATE lammps style_tests)
 
 file(GLOB ANGLE_TESTS LIST_DIRECTORIES false ${TEST_INPUT_FOLDER}/angle-*.yaml)
 foreach(TEST ${ANGLE_TESTS})


### PR DESCRIPTION
**Summary**

Right now the test binaries don't see the include directories of GTest. This PR fixes this issue.

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


