### PR TITLE
Fixed an issue with fix rigid/nve for bodies with very small values of inertia moments

### DIFF
--- a/src/math_extra.cpp
+++ b/src/math_extra.cpp
@@ -258,8 +258,8 @@ void no_squish_rotate(int k, double *p, double *q, double *inertia,
   // obtain phi, cosines and sines
 
   phi = p[0]*kq[0] + p[1]*kq[1] + p[2]*kq[2] + p[3]*kq[3];
-  phi /= (4.0 * inertia[k-1]);
-  if (!std::isfinite(phi)) phi = 0.0;
+  if (fabs(inertia[k-1]) < 1e-250) phi *= 0.0;
+  else phi /= 4.0 * inertia[k-1];
   c_phi = cos(dt * phi);
   s_phi = sin(dt * phi);
 

--- a/src/math_extra.cpp
+++ b/src/math_extra.cpp
@@ -258,7 +258,7 @@ void no_squish_rotate(int k, double *p, double *q, double *inertia,
   // obtain phi, cosines and sines
 
   phi = p[0]*kq[0] + p[1]*kq[1] + p[2]*kq[2] + p[3]*kq[3];
-  if (fabs(inertia[k-1]) < 1e-250) phi *= 0.0;
+  if (inertia[k-1] == 0.0) phi = 0.0;
   else phi /= 4.0 * inertia[k-1];
   c_phi = cos(dt * phi);
   s_phi = sin(dt * phi);

--- a/src/math_extra.cpp
+++ b/src/math_extra.cpp
@@ -258,8 +258,8 @@ void no_squish_rotate(int k, double *p, double *q, double *inertia,
   // obtain phi, cosines and sines
 
   phi = p[0]*kq[0] + p[1]*kq[1] + p[2]*kq[2] + p[3]*kq[3];
-  if (fabs(inertia[k-1]) < 1e-6) phi *= 0.0;
-  else phi /= 4.0 * inertia[k-1];
+  phi /= (4.0 * inertia[k-1]);
+  if (!std::isfinite(phi)) phi = 0.0;
   c_phi = cos(dt * phi);
   s_phi = sin(dt * phi);
 


### PR DESCRIPTION
**Summary**

This PR is to fix the bug reported by #1657 where the rotational degrees of freedom are not updated properly by fix rigid/nve and other related styles that are derived from fix rigid/nh.

**Related Issues**

fixes #1657 

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Should maintain backward compatibility

**Implementation Notes**

fix rigid/nve updates the body quaternions using the function no_squish_rotate(), which is implemented in math_extra.cpp. This no_squish_rotate() function currently uses a hard-coded threshold (1.0e-6) to judge if the body inertia moments are treated as zero, or not. 

In most use cases, the threshold 1.0e-6 is sufficient for small values, sometimes defined as EPSILON in other parts of LAMMPS. For the particular case reported by #1657 , however, the body inertia moments happen to be smaller than 1.0e-6 (around 1.0e-14 and 1.0e-15). Consequently, they are considered "zeros" by fix rigid/nve, and the body quaterions are not updated properly, i.e. the bodies are not rotated at all.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system



