### PR TITLE
Explicitly set the pValue pointer to NULL.

### DIFF
--- a/src/KIM/kim_property.cpp
+++ b/src/KIM/kim_property.cpp
@@ -464,7 +464,8 @@ void kimProperty::command(int narg, char **arg)
         error->one(FLERR, "Error Python `kim_property_dump` function "
                           "evaluation failed!");
       }
-    }
+    } else
+      pValue = NULL;
 
     // Destroy the variable
     kim_str_cmd[1] = const_cast<char *>("delete");
@@ -472,7 +473,6 @@ void kimProperty::command(int narg, char **arg)
 
     Py_XDECREF(pArgs);
     Py_XDECREF(pFunc);
-    Py_XDECREF(pValue);
   }
 
   PyGILState_Release(gstate);


### PR DESCRIPTION
**Summary**
In the `kim_property.cpp` the `PyTuple_SetItem` “steals” a reference to `pValue`, but
does not set it to `NULL` after dereferencing it. It causes segmentation fault on some system on multiple processors since it is trying to decrement the reference count for an object which does not exist.

**Related Issues**
No reported issue

**Author(s)**
**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
It is completely backward compatibe.

**Implementation Notes**
Explicitly set the `pValue` pointer to NULL on non-master processors.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


