### PR TITLE
Test to avoid bad delete and Seg Fault

### DIFF
--- a/src/USER-MISC/dihedral_nharmonic.cpp
+++ b/src/USER-MISC/dihedral_nharmonic.cpp
@@ -47,7 +47,7 @@ DihedralNHarmonic::~DihedralNHarmonic()
   if (allocated) {
     memory->destroy(setflag);
     for (int i = 1; i <= atom->ndihedraltypes; i++)
-      delete [] a[i];
+      if ( a[i] ) delete [] a[i];
     delete [] a;
     delete [] nterms;
   }
@@ -263,6 +263,7 @@ void DihedralNHarmonic::allocate()
 
   nterms = new int[n+1];
   a = new double *[n+1];
+  for (int i = 1; i <= n; i++) a[i] = 0;
 
   memory->create(setflag,n+1,"dihedral:setflag");
   for (int i = 1; i <= n; i++) setflag[i] = 0;


### PR DESCRIPTION
**Summary**

Set `a` array values to 0 and check when destroy if allocated to avoid Seg Fault.

**Author(s)**

Julien Devémy

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

The same technic is used in `dihedral_fourier.cpp`

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


