### PR TITLE
Document and fix store_contacts in fix gran/wall and gran/wall/region

### DIFF
--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -57,7 +57,7 @@ Syntax
          dim = *x* or *y* or *z*
          vshear = magnitude of shear velocity (velocity units)
       *contacts* value = none
-         store contact information for each particle colliding with wall
+         generate contact information for each particle
 
 
 Examples

--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -186,14 +186,17 @@ info on how to re-specify a fix in an input script that reads a
 restart file, so that the operation of the fix continues in an
 uninterrupted fashion.
 
-If the :code:`contacts` option is used, this fix will store the contact
-information for each atom that interacts with the wall as per-atom array with 8
-columns. The values of these columns are listed in the following table:
+If the :code:`contacts` option is used, this fix generates a per-atom vector
+with 8 columns as output, containing the contact information for owned
+particles (nlocal on each processor). All columns in this per-atom vector will
+be zero if no contact has occured.  The values of these columns are listed in
+the following table:
 
 +-------+----------------------------------------------------+----------------+
 | Index | Value                                              | Units          |
 +=======+====================================================+================+
-|     1 | Atom ID                                            |                |
+|     1 | 1.0 if particle is in contact with wall,           |                |
+|       | 0.0 otherwise                                      |                |
 +-------+----------------------------------------------------+----------------+
 |     2 | Force :math:`f_x` exerted on the wall              | force units    |
 +-------+----------------------------------------------------+----------------+

--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -8,7 +8,7 @@ Syntax
 
 .. parsed-literal::
 
-   fix ID group-ID wall/gran fstyle fstyle_params wallstyle args keyword values ... [store_contacts]
+   fix ID group-ID wall/gran fstyle fstyle_params wallstyle args keyword values ...
 
 * ID, group-ID are documented in :doc:`fix <fix>` command
 * wall/gran = style name of this fix command
@@ -45,7 +45,7 @@ Syntax
          radius = cylinder radius (distance units)
 
 * zero or more keyword/value pairs may be appended to args
-* keyword = *wiggle* or *shear* or *store_contacts*
+* keyword = *wiggle* or *shear* or *contacts*
 
   .. parsed-literal::
 
@@ -56,7 +56,8 @@ Syntax
        *shear* values = dim vshear
          dim = *x* or *y* or *z*
          vshear = magnitude of shear velocity (velocity units)
-      *store_contacts* = store contact information for each particle colliding with wall
+      *contacts* value = none
+         store contact information for each particle colliding with wall
 
 
 Examples
@@ -70,7 +71,7 @@ Examples
    fix 3 all wall/gran/region granular hooke 1000.0 50.0 tangential linear_nohistory 1.0 0.4 damping velocity region myBox
    fix 4 all wall/gran/region granular jkr 1e5 1500.0 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall region myCone
    fix 5 all wall/gran/region granular dmt 1e5 0.2 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall damping tsuji region myCone
-   fix 6 all wall/gran hooke  200000.0 NULL 50.0 NULL 0.5 0 xplane -10.0 10.0 store_contacts
+   fix 6 all wall/gran hooke  200000.0 NULL 50.0 NULL 0.5 0 xplane -10.0 10.0 contacts
 
 Description
 """""""""""
@@ -185,30 +186,29 @@ info on how to re-specify a fix in an input script that reads a
 restart file, so that the operation of the fix continues in an
 uninterrupted fashion.
 
-If the :code:`store_contacts` option is used, this fix will store the contact
-information for each atom that interacts with the wall. The following table
-summarizes which values are available as per-atom quantities
-(:code:`f_FIXID[Index]`) to access by various :doc:`output commands <Howto_output>`:
+If the :code:`contacts` option is used, this fix will store the contact
+information for each atom that interacts with the wall as per-atom array with 8
+columns. The values of these columns are listed in the following table:
 
-+-------+----------------------------------------------------+
-| Index | Value                                              |
-+=======+====================================================+
-|     1 | Atom ID                                            |
-+-------+----------------------------------------------------+
-|     2 | Force :math:`f_x` exerted on the wall              |
-+-------+----------------------------------------------------+
-|     3 | Force :math:`f_y` exerted on the wall              |
-+-------+----------------------------------------------------+
-|     4 | Force :math:`f_z` exerted on the wall              |
-+-------+----------------------------------------------------+
-|     5 | :math:`\Delta x` between wall surface and particle |
-+-------+----------------------------------------------------+
-|     6 | :math:`\Delta y` between wall surface and particle |
-+-------+----------------------------------------------------+
-|     7 | :math:`\Delta z` between wall surface and particle |
-+-------+----------------------------------------------------+
-|     8 | Radius :math:`r` of atom                           |
-+-------+----------------------------------------------------+
++-------+----------------------------------------------------+----------------+
+| Index | Value                                              | Units          |
++=======+====================================================+================+
+|     1 | Atom ID                                            |                |
++-------+----------------------------------------------------+----------------+
+|     2 | Force :math:`f_x` exerted on the wall              | force units    |
++-------+----------------------------------------------------+----------------+
+|     3 | Force :math:`f_y` exerted on the wall              | force units    |
++-------+----------------------------------------------------+----------------+
+|     4 | Force :math:`f_z` exerted on the wall              | force units    |
++-------+----------------------------------------------------+----------------+
+|     5 | :math:`\Delta x` between wall surface and particle | distance units |
++-------+----------------------------------------------------+----------------+
+|     6 | :math:`\Delta y` between wall surface and particle | distance units |
++-------+----------------------------------------------------+----------------+
+|     7 | :math:`\Delta z` between wall surface and particle | distance units |
++-------+----------------------------------------------------+----------------+
+|     8 | Radius :math:`r` of atom                           | distance units |
++-------+----------------------------------------------------+----------------+
 
 None of the :doc:`fix_modify <fix_modify>` options are relevant to this fix.
 No parameter of this fix can be used with the *start/stop* keywords of the

--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -189,7 +189,7 @@ uninterrupted fashion.
 If the :code:`contacts` option is used, this fix generates a per-atom vector
 with 8 columns as output, containing the contact information for owned
 particles (nlocal on each processor). All columns in this per-atom vector will
-be zero if no contact has occured.  The values of these columns are listed in
+be zero if no contact has occurred.  The values of these columns are listed in
 the following table:
 
 +-------+----------------------------------------------------+----------------+

--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -8,7 +8,7 @@ Syntax
 
 .. parsed-literal::
 
-   fix ID group-ID wall/gran fstyle fstyle_params wallstyle args keyword values ...
+   fix ID group-ID wall/gran fstyle fstyle_params wallstyle args keyword values ... [store_contacts]
 
 * ID, group-ID are documented in :doc:`fix <fix>` command
 * wall/gran = style name of this fix command
@@ -45,7 +45,7 @@ Syntax
          radius = cylinder radius (distance units)
 
 * zero or more keyword/value pairs may be appended to args
-* keyword = *wiggle* or *shear*
+* keyword = *wiggle* or *shear* or *store_contacts*
 
   .. parsed-literal::
 
@@ -56,6 +56,8 @@ Syntax
        *shear* values = dim vshear
          dim = *x* or *y* or *z*
          vshear = magnitude of shear velocity (velocity units)
+      *store_contacts* = store contact information for each particle colliding with wall
+
 
 Examples
 """"""""
@@ -68,6 +70,7 @@ Examples
    fix 3 all wall/gran/region granular hooke 1000.0 50.0 tangential linear_nohistory 1.0 0.4 damping velocity region myBox
    fix 4 all wall/gran/region granular jkr 1e5 1500.0 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall region myCone
    fix 5 all wall/gran/region granular dmt 1e5 0.2 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall damping tsuji region myCone
+   fix 6 all wall/gran hooke  200000.0 NULL 50.0 NULL 0.5 0 xplane -10.0 10.0 store_contacts
 
 Description
 """""""""""
@@ -171,6 +174,7 @@ the clockwise direction for *vshear* > 0 or counter-clockwise for
 *vshear* < 0.  In this case, *vshear* is the tangential velocity of
 the wall at whatever *radius* has been defined.
 
+
 **Restart, fix_modify, output, run start/stop, minimize info:**
 
 This fix writes the shear friction state of atoms interacting with the
@@ -181,11 +185,35 @@ info on how to re-specify a fix in an input script that reads a
 restart file, so that the operation of the fix continues in an
 uninterrupted fashion.
 
-None of the :doc:`fix_modify <fix_modify>` options are relevant to this
-fix.  No global or per-atom quantities are stored by this fix for
-access by various :doc:`output commands <Howto_output>`.  No parameter
-of this fix can be used with the *start/stop* keywords of the
-:doc:`run <run>` command.  This fix is not invoked during :doc:`energy minimization <minimize>`.
+If the :code:`store_contacts` option is used, this fix will store the contact
+information for each atom that interacts with the wall. The following table
+summarizes which values are available as per-atom quantities
+(:code:`f_FIXID[Index]`) to access by various :doc:`output commands <Howto_output>`:
+
++-------+----------------------------------------------------+
+| Index | Value                                              |
++=======+====================================================+
+|     1 | Atom ID                                            |
++-------+----------------------------------------------------+
+|     2 | Force :math:`f_x` exerted on the wall              |
++-------+----------------------------------------------------+
+|     3 | Force :math:`f_y` exerted on the wall              |
++-------+----------------------------------------------------+
+|     4 | Force :math:`f_z` exerted on the wall              |
++-------+----------------------------------------------------+
+|     5 | :math:`\Delta x` between wall surface and particle |
++-------+----------------------------------------------------+
+|     6 | :math:`\Delta y` between wall surface and particle |
++-------+----------------------------------------------------+
+|     7 | :math:`\Delta z` between wall surface and particle |
++-------+----------------------------------------------------+
+|     8 | Radius :math:`r` of atom                           |
++-------+----------------------------------------------------+
+
+None of the :doc:`fix_modify <fix_modify>` options are relevant to this fix.
+No parameter of this fix can be used with the *start/stop* keywords of the
+:doc:`run <run>` command. This fix is not invoked during :doc:`energy
+minimization <minimize>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/fix_wall_gran.rst
+++ b/doc/src/fix_wall_gran.rst
@@ -186,9 +186,9 @@ info on how to re-specify a fix in an input script that reads a
 restart file, so that the operation of the fix continues in an
 uninterrupted fashion.
 
-If the :code:`contacts` option is used, this fix generates a per-atom vector
+If the :code:`contacts` option is used, this fix generates a per-atom array
 with 8 columns as output, containing the contact information for owned
-particles (nlocal on each processor). All columns in this per-atom vector will
+particles (nlocal on each processor). All columns in this per-atom array will
 be zero if no contact has occurred.  The values of these columns are listed in
 the following table:
 

--- a/doc/src/fix_wall_gran_region.rst
+++ b/doc/src/fix_wall_gran_region.rst
@@ -8,7 +8,7 @@ Syntax
 
 .. parsed-literal::
 
-   fix ID group-ID wall/gran/region fstyle fstyle_params wallstyle regionID
+   fix ID group-ID wall/gran/region fstyle fstyle_params wallstyle regionID [store_contacts]
 
 * ID, group-ID are documented in :doc:`fix <fix>` command
 * wall/region = style name of this fix command
@@ -36,6 +36,7 @@ Syntax
 
 * wallstyle = region (see :doc:`fix wall/gran <fix_wall_gran>` for options for other kinds of walls)
 * region-ID = region whose boundary will act as wall
+* store_contacts = store contact information for each particle colliding with wall
 
 Examples
 """"""""
@@ -46,6 +47,7 @@ Examples
    fix 3 all wall/gran/region granular hooke 1000.0 50.0 tangential linear_nohistory 1.0 0.4 damping velocity region myBox
    fix 4 all wall/gran/region granular jkr 1e5 1500.0 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall region myCone
    fix 5 all wall/gran/region granular dmt 1e5 0.2 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall damping tsuji region myCone
+   fix wall all wall/gran/region hooke/history 1000.0 200.0 200.0 100.0 0.5 1 region myCone store_contacts
 
 Description
 """""""""""
@@ -215,11 +217,35 @@ uninterrupted fashion.
    use the same fix ID for fix wall/gran/region, but assign it a region
    with a different region ID.
 
-None of the :doc:`fix_modify <fix_modify>` options are relevant to this
-fix.  No global or per-atom quantities are stored by this fix for
-access by various :doc:`output commands <Howto_output>`.  No parameter
-of this fix can be used with the *start/stop* keywords of the
-:doc:`run <run>` command.  This fix is not invoked during :doc:`energy minimization <minimize>`.
+If the :code:`store_contacts` option is used, this fix will store the contact
+information for each atom that interacts with the wall. The following table
+summarizes which values are available as per-atom quantities
+(:code:`f_FIXID[Index]`) to access by various :doc:`output commands <Howto_output>`:
+
++-------+----------------------------------------------------+
+| Index | Value                                              |
++=======+====================================================+
+|     1 | Atom ID                                            |
++-------+----------------------------------------------------+
+|     2 | Force :math:`f_x` exerted on the wall              |
++-------+----------------------------------------------------+
+|     3 | Force :math:`f_y` exerted on the wall              |
++-------+----------------------------------------------------+
+|     4 | Force :math:`f_z` exerted on the wall              |
++-------+----------------------------------------------------+
+|     5 | :math:`\Delta x` between wall surface and particle |
++-------+----------------------------------------------------+
+|     6 | :math:`\Delta y` between wall surface and particle |
++-------+----------------------------------------------------+
+|     7 | :math:`\Delta z` between wall surface and particle |
++-------+----------------------------------------------------+
+|     8 | Radius :math:`r` of atom                           |
++-------+----------------------------------------------------+
+
+None of the :doc:`fix_modify <fix_modify>` options are relevant to this fix.
+No parameter of this fix can be used with the *start/stop* keywords of the
+:doc:`run <run>` command. This fix is not invoked during :doc:`energy
+minimization <minimize>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/fix_wall_gran_region.rst
+++ b/doc/src/fix_wall_gran_region.rst
@@ -8,7 +8,7 @@ Syntax
 
 .. parsed-literal::
 
-   fix ID group-ID wall/gran/region fstyle fstyle_params wallstyle regionID [store_contacts]
+   fix ID group-ID wall/gran/region fstyle fstyle_params wallstyle regionID keyword values ...
 
 * ID, group-ID are documented in :doc:`fix <fix>` command
 * wall/region = style name of this fix command
@@ -36,7 +36,12 @@ Syntax
 
 * wallstyle = region (see :doc:`fix wall/gran <fix_wall_gran>` for options for other kinds of walls)
 * region-ID = region whose boundary will act as wall
-* store_contacts = store contact information for each particle colliding with wall
+* keyword = *contacts*
+
+  .. parsed-literal::
+
+      *contacts* value = none
+         generate contact information for each particle
 
 Examples
 """"""""
@@ -47,7 +52,7 @@ Examples
    fix 3 all wall/gran/region granular hooke 1000.0 50.0 tangential linear_nohistory 1.0 0.4 damping velocity region myBox
    fix 4 all wall/gran/region granular jkr 1e5 1500.0 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall region myCone
    fix 5 all wall/gran/region granular dmt 1e5 0.2 0.3 10.0 tangential mindlin NULL 1.0 0.5 rolling sds 500.0 200.0 0.5 twisting marshall damping tsuji region myCone
-   fix wall all wall/gran/region hooke/history 1000.0 200.0 200.0 100.0 0.5 1 region myCone store_contacts
+   fix wall all wall/gran/region hooke/history 1000.0 200.0 200.0 100.0 0.5 1 region myCone contacts
 
 Description
 """""""""""
@@ -217,30 +222,32 @@ uninterrupted fashion.
    use the same fix ID for fix wall/gran/region, but assign it a region
    with a different region ID.
 
-If the :code:`store_contacts` option is used, this fix will store the contact
-information for each atom that interacts with the wall. The following table
-summarizes which values are available as per-atom quantities
-(:code:`f_FIXID[Index]`) to access by various :doc:`output commands <Howto_output>`:
+If the :code:`contacts` option is used, this fix generates a per-atom vector
+with 8 columns as output, containing the contact information for owned
+particles (nlocal on each processor). All columns in this per-atom vector will
+be zero if no contact has occured.  The values of these columns are listed in
+the following table:
 
-+-------+----------------------------------------------------+
-| Index | Value                                              |
-+=======+====================================================+
-|     1 | Atom ID                                            |
-+-------+----------------------------------------------------+
-|     2 | Force :math:`f_x` exerted on the wall              |
-+-------+----------------------------------------------------+
-|     3 | Force :math:`f_y` exerted on the wall              |
-+-------+----------------------------------------------------+
-|     4 | Force :math:`f_z` exerted on the wall              |
-+-------+----------------------------------------------------+
-|     5 | :math:`\Delta x` between wall surface and particle |
-+-------+----------------------------------------------------+
-|     6 | :math:`\Delta y` between wall surface and particle |
-+-------+----------------------------------------------------+
-|     7 | :math:`\Delta z` between wall surface and particle |
-+-------+----------------------------------------------------+
-|     8 | Radius :math:`r` of atom                           |
-+-------+----------------------------------------------------+
++-------+----------------------------------------------------+----------------+
+| Index | Value                                              | Units          |
++=======+====================================================+================+
+|     1 | 1.0 if particle is in contact with wall,           |                |
+|       | 0.0 otherwise                                      |                |
++-------+----------------------------------------------------+----------------+
+|     2 | Force :math:`f_x` exerted on the wall              | force units    |
++-------+----------------------------------------------------+----------------+
+|     3 | Force :math:`f_y` exerted on the wall              | force units    |
++-------+----------------------------------------------------+----------------+
+|     4 | Force :math:`f_z` exerted on the wall              | force units    |
++-------+----------------------------------------------------+----------------+
+|     5 | :math:`\Delta x` between wall surface and particle | distance units |
++-------+----------------------------------------------------+----------------+
+|     6 | :math:`\Delta y` between wall surface and particle | distance units |
++-------+----------------------------------------------------+----------------+
+|     7 | :math:`\Delta z` between wall surface and particle | distance units |
++-------+----------------------------------------------------+----------------+
+|     8 | Radius :math:`r` of atom                           | distance units |
++-------+----------------------------------------------------+----------------+
 
 None of the :doc:`fix_modify <fix_modify>` options are relevant to this fix.
 No parameter of this fix can be used with the *start/stop* keywords of the

--- a/doc/src/fix_wall_gran_region.rst
+++ b/doc/src/fix_wall_gran_region.rst
@@ -225,7 +225,7 @@ uninterrupted fashion.
 If the :code:`contacts` option is used, this fix generates a per-atom vector
 with 8 columns as output, containing the contact information for owned
 particles (nlocal on each processor). All columns in this per-atom vector will
-be zero if no contact has occured.  The values of these columns are listed in
+be zero if no contact has occurred. The values of these columns are listed in
 the following table:
 
 +-------+----------------------------------------------------+----------------+

--- a/doc/src/fix_wall_gran_region.rst
+++ b/doc/src/fix_wall_gran_region.rst
@@ -222,9 +222,9 @@ uninterrupted fashion.
    use the same fix ID for fix wall/gran/region, but assign it a region
    with a different region ID.
 
-If the :code:`contacts` option is used, this fix generates a per-atom vector
+If the :code:`contacts` option is used, this fix generates a per-atom array
 with 8 columns as output, containing the contact information for owned
-particles (nlocal on each processor). All columns in this per-atom vector will
+particles (nlocal on each processor). All columns in this per-atom array will
 be zero if no contact has occurred. The values of these columns are listed in
 the following table:
 

--- a/src/GRANULAR/fix_wall_gran.cpp
+++ b/src/GRANULAR/fix_wall_gran.cpp
@@ -669,7 +669,7 @@ void FixWallGran::post_force(int /*vflag*/)
 
         // store contact info
         if (peratom_flag) {
-          array_atom[i][0] = (double)atom->tag[i];
+          array_atom[i][0] = 1.0;
           array_atom[i][4] = x[i][0] - dx;
           array_atom[i][5] = x[i][1] - dy;
           array_atom[i][6] = x[i][2] - dz;

--- a/src/GRANULAR/fix_wall_gran.cpp
+++ b/src/GRANULAR/fix_wall_gran.cpp
@@ -426,10 +426,7 @@ FixWallGran::FixWallGran(LAMMPS *lmp, int narg, char **arg) :
   }
 
   if (peratom_flag) {
-    int nlocal = atom->nlocal;
-    for (int i = 0; i < nlocal; i++)
-      for (int m = 0; m < size_peratom_cols; m++)
-        array_atom[i][m] = 0.0;
+    clear_stored_contacts();
   }
 
   time_origin = update->ntimestep;
@@ -596,6 +593,10 @@ void FixWallGran::post_force(int /*vflag*/)
 
   rwall = 0.0;
 
+  if (peratom_flag) {
+    clear_stored_contacts();
+  }
+
   for (int i = 0; i < nlocal; i++) {
     if (mask[i] & groupbit) {
 
@@ -698,6 +699,15 @@ void FixWallGran::post_force(int /*vflag*/)
               omega[i],torque[i],radius[i],meff,history_one[i],
               contact);
       }
+    }
+  }
+}
+
+void FixWallGran::clear_stored_contacts() {
+  const int nlocal = atom->nlocal;
+  for (int i = 0; i < nlocal; i++) {
+    for (int m = 0; m < size_peratom_cols; m++) {
+      array_atom[i][m] = 0.0;
     }
   }
 }

--- a/src/GRANULAR/fix_wall_gran.cpp
+++ b/src/GRANULAR/fix_wall_gran.cpp
@@ -370,7 +370,7 @@ FixWallGran::FixWallGran(LAMMPS *lmp, int narg, char **arg) :
       vshear = force->numeric(FLERR,arg[iarg+2]);
       wshear = 1;
       iarg += 3;
-    } else if (strcmp(arg[iarg],"store_contacts") == 0) {
+    } else if (strcmp(arg[iarg],"contacts") == 0) {
       peratom_flag = 1;
       size_peratom_cols = 8;
       peratom_freq = 1;

--- a/src/GRANULAR/fix_wall_gran.h
+++ b/src/GRANULAR/fix_wall_gran.h
@@ -110,6 +110,8 @@ class FixWallGran : public Fix {
   // store particle interactions
 
   int store;
+
+  void clear_stored_contacts();
 };
 
 }

--- a/src/GRANULAR/fix_wall_gran_region.cpp
+++ b/src/GRANULAR/fix_wall_gran_region.cpp
@@ -178,6 +178,10 @@ void FixWallGranRegion::post_force(int /*vflag*/)
     region->set_velocity();
   }
 
+  if (peratom_flag) {
+    clear_stored_contacts();
+  }
+
   for (i = 0; i < nlocal; i++) {
     if (mask[i] & groupbit) {
       if (!region->match(x[i][0],x[i][1],x[i][2])) continue;


### PR DESCRIPTION
**Summary**

Documents a hidden feature in fix `gran/wall` and `gran/wall/region` to store contact information of all particles colliding with walls. Fixes an issue where old contacts will be stored indefinitely.

**Related Issues**

Closes #2085

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Implementation Notes**

The previous implementation kept values of contacts during past timesteps. All contact information is now cleared at the beginning of the calculation (`post_force`)

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



