### PR TITLE
Parsing of process variable in fix controller corrected

### DIFF
--- a/src/fix_controller.cpp
+++ b/src/fix_controller.cpp
@@ -120,7 +120,7 @@ FixController::FixController(LAMMPS *lmp, int narg, char **arg) :
                           "calculate a global scalar or vector");
     if (pvindex && pvindex > f->size_vector)
       error->all(FLERR,"Fix controller fix vector is accessed out-of-range");
-  } else if (pvwhich == FIX) {
+  } else if (pvwhich == VARIABLE) {
     int ivariable = input->variable->find(pvID);
     if (ivariable < 0)
       error->all(FLERR,"Variable name for fix controller does not exist");


### PR DESCRIPTION
**Summary**

A minor bug fix for fix_controller.cpp
The error checking for arguments passed to fix controller was not correct when argument 'pvar' was  passed as a lammps variable.
 
**Related Issues**

None.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The change is backward compatible.

**Implementation Notes**

NA

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] Licensing information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

None.
