### PR TITLE
Use std::string in arguments to Error class function

### DIFF
--- a/src/KIM/kim_init.cpp
+++ b/src/KIM/kim_init.cpp
@@ -275,7 +275,7 @@ void KimInit::determine_model_type_and_units(char * model_name,
       std::string mesg("Incompatible units for KIM Simulator Model, "
                        "required units = ");
       mesg += *model_units;
-      error->all(FLERR,mesg.c_str());
+      error->all(FLERR,mesg);
     }
   }
 }
@@ -328,8 +328,7 @@ void KimInit::do_init(char *model_name, char *user_units, char *model_units, KIM
       mesg += "\n";
       mesg += "#\n";
 
-      if (screen) fputs(mesg.c_str(),screen);
-      if (logfile) fputs(mesg.c_str(),logfile);
+      utils::logmesg(lmp,mesg);
     }
 
     fix_store->setptr("simulator_model", (void *) simulatorModel);
@@ -346,7 +345,7 @@ void KimInit::do_init(char *model_name, char *user_units, char *model_units, KIM
 
   std::string cmd("units ");
   cmd += model_units;
-  input->one(cmd.c_str());
+  input->one(cmd);
 
   if (model_type == SM) {
     int sim_fields, sim_lines;
@@ -519,7 +518,7 @@ void KimInit::do_variables(char *user_units, char *model_units)
                         "unit = " + units[i] + "; "
                         "from = " + from + "; "
                         "to = " + to + ".";
-      error->all(FLERR,err.c_str());
+      error->all(FLERR,err);
     }
     variable->internal_set(v_unit,conversion_factor);
     if (comm->me == 0) {

--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -192,7 +192,7 @@ void KimInteractions::do_setup(int narg, char **arg)
           std::string msg("Species '");
           msg += strword;
           msg += "' is not supported by this KIM Simulator Model";
-          error->all(FLERR,msg.c_str());
+          error->all(FLERR,msg);
         }
         strword = strtok(NULL," \t");
       }
@@ -276,8 +276,8 @@ void KimInteractions::do_setup(int narg, char **arg)
       cmd2 += " ";
     }
 
-    input->one(cmd1.c_str());
-    input->one(cmd2.c_str());
+    input->one(cmd1);
+    input->one(cmd2);
   }
 
   // End output to log file

--- a/src/KIM/kim_param.cpp
+++ b/src/KIM/kim_param.cpp
@@ -163,7 +163,7 @@ void KimParam::command(int narg, char **arg)
   if (!kim_param_get && !kim_param_set) {
     std::string msg("Incorrect arguments in kim_param command.\n");
     msg += "'kim_param get/set' is mandatory.";
-    error->all(FLERR, msg.c_str());
+    error->all(FLERR, msg);
   }
 
   // Check if we called a kim_init command
@@ -225,7 +225,7 @@ void KimParam::command(int narg, char **arg)
       msg += "To set the new parameter values, pair style must be assigned.\n";
       msg += "Must use 'kim_interactions' or";
       msg += "'pair_style kim ' before 'kim_param set'";
-      error->all(FLERR, msg.c_str());
+      error->all(FLERR, msg);
     } else {
       KIM_LengthUnit lengthUnit;
       KIM_EnergyUnit energyUnit;
@@ -296,7 +296,7 @@ void KimParam::command(int narg, char **arg)
           msg += "This Model does not have the requested '";
           msg += paramname;
           msg += "' parameter.";
-          error->all(FLERR, msg.c_str());
+          error->all(FLERR, msg);
         }
 
         // Get the index_range for the requested parameter
@@ -313,7 +313,7 @@ void KimParam::command(int narg, char **arg)
             msg += "Expected integer parameter(s) instead of '";
             msg += argtostr;
             msg += "' in index_range.";
-            error->all(FLERR, msg.c_str());
+            error->all(FLERR, msg);
           }
 
           std::string::size_type npos = argtostr.find(':');
@@ -330,7 +330,7 @@ void KimParam::command(int narg, char **arg)
               msg += "' parameter with extent of '";
               msg += SNUM(extent);
               msg += "' .";
-              error->all(FLERR, msg.c_str());
+              error->all(FLERR, msg);
             }
           } else {
             std::stringstream str(argtostr);
@@ -342,7 +342,7 @@ void KimParam::command(int narg, char **arg)
               msg += "' with the extent of '";
               msg += SNUM(extent);
               msg += "' .";
-              error->all(FLERR, msg.c_str());
+              error->all(FLERR, msg);
             }
             nubound = nlbound;
           }
@@ -350,7 +350,7 @@ void KimParam::command(int narg, char **arg)
           std::string msg("Wrong number of arguments in ");
           msg += "kim_param get command.\n";
           msg += "Index range after parameter name is mandatory.";
-          error->all(FLERR, msg.c_str());
+          error->all(FLERR, msg);
         }
 
         int const nvars = nubound - nlbound + 1;
@@ -363,7 +363,7 @@ void KimParam::command(int narg, char **arg)
           std::string msg("Wrong number of arguments in ");
           msg += "kim_param get command.\n";
           msg += "The LAMMPS variable name is mandatory.";
-          error->all(FLERR, msg.c_str());
+          error->all(FLERR, msg);
         }
 
         // indicator flag for list request
@@ -400,7 +400,7 @@ void KimParam::command(int narg, char **arg)
               msg += "' variable names or '";
               msg += varname;
               msg += " split' is mandatory.";
-              error->all(FLERR, msg.c_str());
+              error->all(FLERR, msg);
             }
           } else {
             std::string msg("Wrong number of arguments in ");
@@ -410,7 +410,7 @@ void KimParam::command(int narg, char **arg)
             msg += "' variable names or '";
             msg += varname;
             msg += " split/list' is mandatory.";
-            error->all(FLERR, msg.c_str());
+            error->all(FLERR, msg);
           }
         } else {
           varsname = new char *[1];
@@ -524,7 +524,7 @@ void KimParam::command(int narg, char **arg)
         set_cmd += " ";
         set_cmd += arg[i];
       }
-      input->one(set_cmd.c_str());
+      input->one(set_cmd);
     }
   } else
     error->all(FLERR, "This model has No mutable parameters.");

--- a/src/KIM/kim_property.cpp
+++ b/src/KIM/kim_property.cpp
@@ -100,13 +100,13 @@ void kimProperty::command(int narg, char **arg)
     std::string msg("Error incorrect arguments in kim_property command.\n");
     msg += "`kim_property create/destroy/modify/remove/dump` ";
     msg += "is mandatory.";
-    error->all(FLERR, msg.c_str());
+    error->all(FLERR, msg);
   }
 
   if (comm->me == 0) {
     std::string msg;
     msg = "#=== kim-property ===========================================\n";
-    input->write_echo(msg.c_str());
+    input->write_echo(msg);
   }
 
   // Get the kim_str ptr to the data associated with a kim_property_str

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -429,7 +429,7 @@ void PairKIM::coeff(int narg, char **arg)
     } else {
       std::string msg("create_kim_particle_codes: symbol not found: ");
       msg += lmps_unique_elements[i];
-      error->all(FLERR, msg.c_str());
+      error->all(FLERR, msg);
     }
   }
   // Set the new values for PM parameters
@@ -441,7 +441,7 @@ void PairKIM::coeff(int narg, char **arg)
     if (!numberOfParameters) {
       std::string msg("Incorrect args for pair coefficients \n");
       msg += "This model has No mutable parameters.";
-      error->all(FLERR, msg.c_str());
+      error->all(FLERR, msg);
     }
 
     int kimerror;
@@ -477,7 +477,7 @@ void PairKIM::coeff(int narg, char **arg)
         msg += "This Model does not have the requested '";
         msg += paramname;
         msg += "' parameter.";
-        error->all(FLERR, msg.c_str());
+        error->all(FLERR, msg);
       }
 
       // Get the index_range for the requested parameter
@@ -493,7 +493,7 @@ void PairKIM::coeff(int narg, char **arg)
           msg += "Expected integer parameter(s) instead of '";
           msg += argtostr;
           msg += "' in index_range.";
-          error->all(FLERR, msg.c_str());
+          error->all(FLERR, msg);
         }
 
         std::string::size_type npos = argtostr.find(':');
@@ -510,7 +510,7 @@ void PairKIM::coeff(int narg, char **arg)
             msg += "' parameter with extent of '";
             msg += SNUM(extent);
             msg += "' .";
-            error->all(FLERR, msg.c_str());
+            error->all(FLERR, msg);
           }
         } else {
           std::stringstream str(argtostr);
@@ -522,7 +522,7 @@ void PairKIM::coeff(int narg, char **arg)
             msg += "' parameter with extent of '";
             msg += SNUM(extent);
             msg += "' .";
-            error->all(FLERR, msg.c_str());
+            error->all(FLERR, msg);
           }
           nubound = nlbound;
         }
@@ -530,7 +530,7 @@ void PairKIM::coeff(int narg, char **arg)
         std::string msg =
         "Wrong number of arguments for pair coefficients.\n";
         msg += "Index range after parameter name is mandatory.";
-        error->all(FLERR, msg.c_str());
+        error->all(FLERR, msg);
       }
 
       // Parameter values
@@ -561,7 +561,7 @@ void PairKIM::coeff(int narg, char **arg)
         msg += "' values are requested for '";
         msg += paramname;
         msg += "' parameter.";
-        error->all(FLERR, msg.c_str());
+        error->all(FLERR, msg);
       }
     }
 
@@ -1122,7 +1122,7 @@ void PairKIM::set_kim_model_has_flags()
                                      KIM_SUPPORT_STATUS_required)) {
       std::string msg("KIM Model requires unsupported compute argument: ");
       msg += KIM_ComputeArgumentName_ToString(computeArgumentName);
-      error->all(FLERR, msg.c_str());
+      error->all(FLERR, msg);
     }
   }
 

--- a/src/USER-DPD/fix_rx.cpp
+++ b/src/USER-DPD/fix_rx.cpp
@@ -124,7 +124,7 @@ FixRX::FixRX(LAMMPS *lmp, int narg, char **arg) :
     else {
       std::string errmsg = "Illegal command " + std::string(word)
                              + " expected \"sparse\" or \"dense\"\n";
-      error->all(FLERR, errmsg.c_str());
+      error->all(FLERR, errmsg);
     }
 
     if (comm->me == 0 and Verbosity > 1){
@@ -134,7 +134,7 @@ FixRX::FixRX(LAMMPS *lmp, int narg, char **arg) :
       else
          msg += std::string("dense");
 
-      error->message(FLERR, msg.c_str());
+      error->message(FLERR, msg);
     }
   }
 
@@ -149,7 +149,7 @@ FixRX::FixRX(LAMMPS *lmp, int narg, char **arg) :
       odeIntegrationFlag = ODE_LAMMPS_RKF45;
     else {
       std::string errmsg = "Illegal ODE integration type: " + std::string(word);
-      error->all(FLERR, errmsg.c_str());
+      error->all(FLERR, errmsg);
     }
   }
 

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -761,7 +761,7 @@ AtomVec *Atom::new_avec(const char *style, int trysuffix, int &sflag)
     return avec_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("atom",style,lmp).c_str());
+  error->all(FLERR,utils::check_packages_for_style("atom",style,lmp));
   return NULL;
 }
 

--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -39,6 +39,8 @@
 #include "imbalance_var.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -506,7 +508,9 @@ void Balance::options(int iarg, int narg, char **arg)
 
   if (outflag && comm->me == 0) {
     fp = fopen(arg[outarg],"w");
-    if (fp == NULL) error->one(FLERR,"Cannot open (fix) balance output file");
+    if (fp == NULL)
+      error->one(FLERR,fmt::format("Cannot open (fix) balance output file {}: {}",
+                                   arg[outarg], utils::getsyserror()));
   }
 }
 

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -21,6 +21,8 @@
 #include "atom_masks.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -254,7 +256,9 @@ void Bond::write_file(int narg, char **arg)
   FILE *fp;
   if (me == 0) {
     fp = fopen(arg[4],"a");
-    if (fp == NULL) error->one(FLERR,"Cannot open bond_write file");
+    if (fp == NULL)
+      error->one(FLERR,fmt::format("Cannot open bond_write file {}: {}",
+                                   arg[4], utils::getsyserror()));
   }
 
   // initialize potentials before evaluating bond potential

--- a/src/change_box.cpp
+++ b/src/change_box.cpp
@@ -26,6 +26,8 @@
 #include "group.h"
 #include "error.h"
 #include "force.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -388,12 +390,10 @@ void ChangeBox::command(int narg, char **arg)
   bigint natoms;
   bigint nblocal = atom->nlocal;
   MPI_Allreduce(&nblocal,&natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
-  if (natoms != atom->natoms && comm->me == 0) {
-    char str[128];
-    sprintf(str,"Lost atoms via change_box: original " BIGINT_FORMAT
-            " current " BIGINT_FORMAT,atom->natoms,natoms);
-    error->warning(FLERR,str);
-  }
+  if (natoms != atom->natoms && comm->me == 0)
+    error->warning(FLERR,fmt::format("Lost atoms via change_box: "
+                                     "original {} current {}",
+                                     atom->natoms,natoms));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -35,6 +35,7 @@
 #include "memory.h"
 #include "error.h"
 #include "update.h"
+#include "fmt/format.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -678,23 +679,19 @@ double Comm::get_comm_cutoff()
   if (!force->pair && (cutghostuser == 0.0)) {
     maxcommcutoff = MAX(maxcommcutoff,maxbondcutoff);
   } else {
-    if ((me == 0) && (maxbondcutoff > maxcommcutoff)) {
-      char mesg[256];
-      snprintf(mesg,256,"Communication cutoff %g is shorter than a bond "
-               "length based estimate of %g. This may lead to errors.",
-               maxcommcutoff,maxbondcutoff);
-      error->warning(FLERR,mesg);
-    }
+    if ((me == 0) && (maxbondcutoff > maxcommcutoff))
+      error->warning(FLERR,fmt::format("Communication cutoff {} is shorter "
+                                       "than a bond length based estimate of "
+                                       "{}. This may lead to errors.",
+                                       maxcommcutoff,maxbondcutoff));
   }
 
   // print warning if neighborlist cutoff overrides user cutoff
 
   if ((me == 0) && (update->setupflag == 1)) {
-    if ((cutghostuser > 0.0) && (maxcommcutoff > cutghostuser)) {
-      char mesg[128];
-      snprintf(mesg,128,"Communication cutoff adjusted to %g",maxcommcutoff);
-      error->warning(FLERR,mesg);
-    }
+    if ((cutghostuser > 0.0) && (maxcommcutoff > cutghostuser))
+      error->warning(FLERR,fmt::format("Communication cutoff adjusted to {}",
+                                       maxcommcutoff));
   }
 
   return maxcommcutoff;

--- a/src/displace_atoms.cpp
+++ b/src/displace_atoms.cpp
@@ -34,6 +34,7 @@
 #include "math_extra.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -353,12 +354,10 @@ void DisplaceAtoms::command(int narg, char **arg)
   bigint natoms;
   bigint nblocal = atom->nlocal;
   MPI_Allreduce(&nblocal,&natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
-  if (natoms != atom->natoms && comm->me == 0) {
-    char str[128];
-    sprintf(str,"Lost atoms via displace_atoms: original " BIGINT_FORMAT
-            " current " BIGINT_FORMAT,atom->natoms,natoms);
-    error->warning(FLERR,str);
-  }
+  if (natoms != atom->natoms && comm->me == 0)
+    error->warning(FLERR,fmt::format("Lost atoms via displace_atoms: "
+                                     "original {} current {}",
+                                     atom->natoms,natoms);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/displace_atoms.cpp
+++ b/src/displace_atoms.cpp
@@ -357,7 +357,7 @@ void DisplaceAtoms::command(int narg, char **arg)
   if (natoms != atom->natoms && comm->me == 0)
     error->warning(FLERR,fmt::format("Lost atoms via displace_atoms: "
                                      "original {} current {}",
-                                     atom->natoms,natoms);
+                                     atom->natoms,natoms));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -157,7 +157,7 @@ void Domain::init()
   std::string mesg = "Must not have multiple fixes change box parameter ";
 
 #define CHECK_BOX_FIX_ERROR(par)                                        \
-  if (box_change_ ## par > 1) error->all(FLERR,(mesg + #par).c_str())
+  if (box_change_ ## par > 1) error->all(FLERR,(mesg + #par))
 
   CHECK_BOX_FIX_ERROR(x);
   CHECK_BOX_FIX_ERROR(y);
@@ -1788,7 +1788,7 @@ void Domain::add_region(int narg, char **arg)
   if (region_map->find(arg[1]) != region_map->end()) {
     RegionCreator region_creator = (*region_map)[arg[1]];
     regions[nregion] = region_creator(lmp, narg, arg);
-  } else error->all(FLERR,utils::check_packages_for_style("region",arg[1],lmp).c_str());
+  } else error->all(FLERR,utils::check_packages_for_style("region",arg[1],lmp));
 
   // initialize any region variables via init()
   // in case region is used between runs, e.g. to print a variable

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -228,9 +228,8 @@ void Error::warning(const std::string &file, int line, const std::string &str, i
 
 void Error::message(const std::string &file, int line, const std::string &str, int logflag)
 {
-  std::string mesg = fmt::format("{} ({}:{})\n",
-                                 str,truncpath(file),line);
-  
+  std::string mesg = fmt::format("{} ({}:{})\n",str,truncpath(file),line);
+
   if (screen) fputs(mesg.c_str(),screen);
   if (logflag && logfile) fputs(mesg.c_str(),logfile);
 }

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -15,10 +15,13 @@
 #include <mpi.h>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include "universe.h"
 #include "output.h"
 #include "input.h"
 #include "accelerator_kokkos.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 #if defined(LAMMPS_EXCEPTIONS)
 #include "update.h"
@@ -28,23 +31,19 @@ using namespace LAMMPS_NS;
 
 // helper function to truncate a string to a segment starting with "src/";
 
-static const char *truncpath(const char *path)
+static std::string truncpath(const std::string &path)
 {
-   if (path) {
-     int len = strlen(path);
-     for (int i = len-4; i > 0; --i) {
-        if (strncmp("src/",path+i,4) == 0)
-          return path+i;
-     }
-   }
-   return path;
+  std::size_t found = path.find("src/");
+  if (found != std::string::npos)
+    return path.substr(found);
+  else return path;
 }
 
 /* ---------------------------------------------------------------------- */
 
 Error::Error(LAMMPS *lmp) : Pointers(lmp) {
 #ifdef LAMMPS_EXCEPTIONS
-  last_error_message = NULL;
+  last_error_message.clear();
   last_error_type = ERROR_NONE;
 #endif
 }
@@ -55,15 +54,14 @@ Error::Error(LAMMPS *lmp) : Pointers(lmp) {
    no abort, so insure all procs in universe call, else will hang
 ------------------------------------------------------------------------- */
 
-void Error::universe_all(const char *file, int line, const char *str)
+void Error::universe_all(const std::string &file, int line, const std::string &str)
 {
   MPI_Barrier(universe->uworld);
-
+  std::string mesg = fmt::format("ERROR: {} ({}:{})\n",
+                                 str,truncpath(file),line);
   if (universe->me == 0) {
-    if (universe->uscreen) fprintf(universe->uscreen,
-                                   "ERROR: %s (%s:%d)\n",str,truncpath(file),line);
-    if (universe->ulogfile) fprintf(universe->ulogfile,
-                                    "ERROR: %s (%s:%d)\n",str,truncpath(file),line);
+    if (universe->uscreen)  fputs(mesg.c_str(),universe->uscreen);
+    if (universe->ulogfile) fputs(mesg.c_str(),universe->ulogfile);
   }
 
   if (output) delete output;
@@ -80,9 +78,7 @@ void Error::universe_all(const char *file, int line, const char *str)
 
   if (update) update->whichflag = 0;
 
-  char msg[100];
-  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, truncpath(file), line);
-  throw LAMMPSException(msg);
+  throw LAMMPSException(mesg);
 #else
   if (lmp->kokkos) Kokkos::finalize();
   MPI_Finalize();
@@ -95,11 +91,11 @@ void Error::universe_all(const char *file, int line, const char *str)
    forces abort of entire universe if any proc in universe calls
 ------------------------------------------------------------------------- */
 
-void Error::universe_one(const char *file, int line, const char *str)
+void Error::universe_one(const std::string &file, int line, const std::string &str)
 {
-  if (universe->uscreen)
-    fprintf(universe->uscreen,"ERROR on proc %d: %s (%s:%d)\n",
-            universe->me,str,truncpath(file),line);
+  std::string mesg = fmt::format("ERROR on proc {}: {} ({}:{})\n",
+                                 universe->me,str,truncpath(file),line);
+  if (universe->uscreen) fputs(mesg.c_str(),universe->uscreen);
 
 #ifdef LAMMPS_EXCEPTIONS
 
@@ -108,9 +104,7 @@ void Error::universe_one(const char *file, int line, const char *str)
 
   if (update) update->whichflag = 0;
 
-  char msg[100];
-  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, truncpath(file), line);
-  throw LAMMPSAbortException(msg, universe->uworld);
+  throw LAMMPSAbortException(mesg, universe->uworld);
 #else
   MPI_Abort(universe->uworld,1);
 #endif
@@ -121,11 +115,11 @@ void Error::universe_one(const char *file, int line, const char *str)
    prints a warning message to the screen
 ------------------------------------------------------------------------- */
 
-void Error::universe_warn(const char *file, int line, const char *str)
+void Error::universe_warn(const std::string &file, int line, const std::string &str)
 {
   if (universe->uscreen)
-    fprintf(universe->uscreen,"WARNING on proc %d: %s (%s:%d)\n",
-            universe->me,str,truncpath(file),line);
+    fmt::print(universe->uscreen,"WARNING on proc {}: {} ({}:{})\n",
+               universe->me,str,truncpath(file),line);
 }
 
 /* ----------------------------------------------------------------------
@@ -135,23 +129,19 @@ void Error::universe_warn(const char *file, int line, const char *str)
    force MPI_Abort if running in multi-partition mode
 ------------------------------------------------------------------------- */
 
-void Error::all(const char *file, int line, const char *str)
+void Error::all(const std::string &file, int line, const std::string &str)
 {
   MPI_Barrier(world);
 
   int me;
-  const char *lastcmd = (const char*)"(unknown)";
+  std::string lastcmd = "(unknown)";
 
   MPI_Comm_rank(world,&me);
 
   if (me == 0) {
     if (input && input->line) lastcmd = input->line;
-    if (screen) fprintf(screen,"ERROR: %s (%s:%d)\n"
-                        "Last command: %s\n",
-                        str,truncpath(file),line,lastcmd);
-    if (logfile) fprintf(logfile,"ERROR: %s (%s:%d)\n"
-                         "Last command: %s\n",
-                         str,truncpath(file),line,lastcmd);
+    utils::logmesg(lmp,fmt::format("ERROR: {} ({}:{})\nLast command: {}\n",
+                                   str,truncpath(file),line,lastcmd));
   }
 
 #ifdef LAMMPS_EXCEPTIONS
@@ -161,8 +151,8 @@ void Error::all(const char *file, int line, const char *str)
 
   if (update) update->whichflag = 0;
 
-  char msg[100];
-  snprintf(msg, 100, "ERROR: %s (%s:%d)\n", str, truncpath(file), line);
+  std::string msg = fmt::format("ERROR: {} ({}:{})\n",
+                                str, truncpath(file), line);
 
   if (universe->nworlds > 1) {
     throw LAMMPSAbortException(msg, universe->uworld);
@@ -188,24 +178,20 @@ void Error::all(const char *file, int line, const char *str)
    forces abort of entire world (and universe) if any proc in world calls
 ------------------------------------------------------------------------- */
 
-void Error::one(const char *file, int line, const char *str)
+void Error::one(const std::string &file, int line, const std::string &str)
 {
   int me;
-  const char *lastcmd = (const char*)"(unknown)";
+  std::string lastcmd = "(unknown)";
   MPI_Comm_rank(world,&me);
 
   if (input && input->line) lastcmd = input->line;
-  if (screen) fprintf(screen,"ERROR on proc %d: %s (%s:%d)\n"
-                      "Last command: %s\n",
-                      me,str,truncpath(file),line,lastcmd);
-  if (logfile) fprintf(logfile,"ERROR on proc %d: %s (%s:%d)\n"
-                       "Last command: %s\n",
-                       me,str,truncpath(file),line,lastcmd);
+  std::string mesg = fmt::format("ERROR on proc {}: {} ({}:{})\n",
+                                 me,str,truncpath(file),line,lastcmd);
+  utils::logmesg(lmp,mesg);
 
   if (universe->nworlds > 1)
     if (universe->uscreen)
-      fprintf(universe->uscreen,"ERROR on proc %d: %s (%s:%d)\n",
-              universe->me,str,truncpath(file),line);
+      fputs(mesg.c_str(),universe->uscreen);
 
 #ifdef LAMMPS_EXCEPTIONS
 
@@ -214,9 +200,7 @@ void Error::one(const char *file, int line, const char *str)
 
   if (update) update->whichflag = 0;
 
-  char msg[100];
-  snprintf(msg, 100, "ERROR on proc %d: %s (%s:%d)\n", me, str, truncpath(file), line);
-  throw LAMMPSAbortException(msg, world);
+  throw LAMMPSAbortException(mesg, world);
 #else
   if (screen) fflush(screen);
   if (logfile) fflush(logfile);
@@ -229,11 +213,12 @@ void Error::one(const char *file, int line, const char *str)
    only write to screen if non-NULL on this proc since could be file
 ------------------------------------------------------------------------- */
 
-void Error::warning(const char *file, int line, const char *str, int logflag)
+void Error::warning(const std::string &file, int line, const std::string &str, int logflag)
 {
-  if (screen) fprintf(screen,"WARNING: %s (%s:%d)\n",str,truncpath(file),line);
-  if (logflag && logfile) fprintf(logfile,"WARNING: %s (%s:%d)\n",
-                                  str,truncpath(file),line);
+  std::string mesg = fmt::format("WARNING: {} ({}:{})\n",
+                                 str,truncpath(file),line);
+  if (screen) fputs(mesg.c_str(),screen);
+  if (logflag && logfile) fputs(mesg.c_str(),logfile);
 }
 
 /* ----------------------------------------------------------------------
@@ -241,10 +226,13 @@ void Error::warning(const char *file, int line, const char *str, int logflag)
    write message to screen and logfile (if logflag is set)
 ------------------------------------------------------------------------- */
 
-void Error::message(const char *file, int line, const char *str, int logflag)
+void Error::message(const std::string &file, int line, const std::string &str, int logflag)
 {
-  if (screen) fprintf(screen,"%s (%s:%d)\n",str,truncpath(file),line);
-  if (logflag && logfile) fprintf(logfile,"%s (%s:%d)\n",str,truncpath(file),line);
+  std::string mesg = fmt::format("{} ({}:{})\n",
+                                 str,truncpath(file),line);
+  
+  if (screen) fputs(mesg.c_str(),screen);
+  if (logflag && logfile) fputs(mesg.c_str(),logfile);
 }
 
 /* ----------------------------------------------------------------------
@@ -273,7 +261,7 @@ void Error::done(int status)
    compiled with -DLAMMPS_EXCEPTIONS)
 ------------------------------------------------------------------------- */
 
-char * Error::get_last_error() const
+std::string Error::get_last_error() const
 {
   return last_error_message;
 }
@@ -293,16 +281,9 @@ ErrorType Error::get_last_error_type() const
    (only used if compiled with -DLAMMPS_EXCEPTIONS)
 ------------------------------------------------------------------------- */
 
-void Error::set_last_error(const char * msg, ErrorType type)
+void Error::set_last_error(const std::string &msg, ErrorType type)
 {
-  delete [] last_error_message;
-
-  if(msg) {
-    last_error_message = new char[strlen(msg)+1];
-    strcpy(last_error_message, msg);
-  } else {
-    last_error_message = NULL;
-  }
+  last_error_message = msg;
   last_error_type = type;
 }
 #endif

--- a/src/error.h
+++ b/src/error.h
@@ -15,6 +15,7 @@
 #define LMP_ERROR_H
 
 #include "pointers.h"
+#include <string>
 
 #ifdef LAMMPS_EXCEPTIONS
 #include "exceptions.h"
@@ -26,23 +27,23 @@ class Error : protected Pointers {
  public:
   Error(class LAMMPS *);
 
-  void universe_all(const char *, int, const char *);
-  void universe_one(const char *, int, const char *);
-  void universe_warn(const char *, int, const char *);
+  void universe_all(const std::string &, int, const std::string &);
+  void universe_one(const std::string &, int, const std::string &);
+  void universe_warn(const std::string &, int, const std::string &);
 
-  void all(const char *, int, const char *);
-  void one(const char *, int, const char *);
-  void warning(const char *, int, const char *, int = 1);
-  void message(const char *, int, const char *, int = 1);
+  void all(const std::string &, int, const std::string &);
+  void one(const std::string &, int, const std::string &);
+  void warning(const std::string &, int, const std::string &, int = 1);
+  void message(const std::string &, int, const std::string &, int = 1);
   void done(int = 0); // 1 would be fully backwards compatible
 
 #ifdef LAMMPS_EXCEPTIONS
-  char *    get_last_error() const;
+  std::string get_last_error() const;
   ErrorType get_last_error_type() const;
-  void   set_last_error(const char * msg, ErrorType type = ERROR_NORMAL);
+  void   set_last_error(const std::string &msg, ErrorType type = ERROR_NORMAL);
 
  private:
-  char * last_error_message;
+  std::string last_error_message;
   ErrorType last_error_type;
 #endif
 };

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -25,7 +25,7 @@ class LAMMPSException : public std::exception
 public:
   std::string message;
 
-  LAMMPSException(std::string msg) : message(msg) {
+  LAMMPSException(const std::string &msg) : message(msg) {
   }
 
   ~LAMMPSException() throw() {
@@ -40,7 +40,7 @@ class LAMMPSAbortException : public LAMMPSException {
 public:
   MPI_Comm universe;
 
-  LAMMPSAbortException(std::string msg, MPI_Comm universe) :
+  LAMMPSAbortException(const std::string &msg, MPI_Comm universe) :
     LAMMPSException(msg),
     universe(universe)
   {

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -27,6 +27,8 @@
 #include "variable.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -223,11 +225,9 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix ave/chunk command");
       if (me == 0) {
         fp = fopen(arg[iarg+1],"w");
-        if (fp == NULL) {
-          char str[128];
-          snprintf(str,128,"Cannot open fix ave/chunk file %s",arg[iarg+1]);
-          error->one(FLERR,str);
-        }
+        if (fp == NULL)
+          error->one(FLERR,fmt::format("Cannot open fix ave/chunk file {}: {}",
+                                       arg[iarg+1], utils::getsyserror()));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"overwrite") == 0) {

--- a/src/fix_ave_correlate.cpp
+++ b/src/fix_ave_correlate.cpp
@@ -30,6 +30,8 @@
 #include "memory.h"
 #include "error.h"
 #include "force.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -148,11 +150,9 @@ FixAveCorrelate::FixAveCorrelate(LAMMPS * lmp, int narg, char **arg):
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix ave/correlate command");
       if (me == 0) {
         fp = fopen(arg[iarg+1],"w");
-        if (fp == NULL) {
-          char str[128];
-          snprintf(str,128,"Cannot open fix ave/correlate file %s",arg[iarg+1]);
-          error->one(FLERR,str);
-        }
+        if (fp == NULL)
+          error->one(FLERR,fmt::format("Cannot open fix ave/correlate file {}:"" {}",
+                                       arg[iarg+1], utils::getsyserror()));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"overwrite") == 0) {

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -25,6 +25,8 @@
 #include "memory.h"
 #include "error.h"
 #include "force.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -963,11 +965,9 @@ void FixAveHisto::options(int iarg, int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix ave/histo command");
       if (me == 0) {
         fp = fopen(arg[iarg+1],"w");
-        if (fp == NULL) {
-          char str[128];
-          snprintf(str,128,"Cannot open fix ave/histo file %s",arg[iarg+1]);
-          error->one(FLERR,str);
-        }
+        if (fp == NULL)
+          error->one(FLERR,fmt::format("Cannot open fix ave/histo file {}: {}",
+                                       arg[iarg+1], utils::getsyserror()));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"kind") == 0) {

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -28,6 +28,8 @@
 #include "variable.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -1043,11 +1045,9 @@ void FixAveTime::options(int iarg, int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix ave/time command");
       if (me == 0) {
         fp = fopen(arg[iarg+1],"w");
-        if (fp == NULL) {
-          char str[128];
-          snprintf(str,128,"Cannot open fix ave/time file %s",arg[iarg+1]);
-          error->one(FLERR,str);
-        }
+        if (fp == NULL)
+          error->one(FLERR,fmt::format("Cannot open fix ave/time file {}: {}",
+                                       arg[iarg+1], utils::getsyserror()));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"ave") == 0) {

--- a/src/fix_enforce2d.cpp
+++ b/src/fix_enforce2d.cpp
@@ -19,6 +19,7 @@
 #include "modify.h"
 #include "respa.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -76,11 +77,9 @@ void FixEnforce2D::init()
       if (modify->fix[i]->enforce2d_flag) {
         if (myindex < 0)
           flist[nfixlist++] = modify->fix[i];
-        else {
-          char msg[256];
-          snprintf(msg,256,"Fix enforce2d must be defined after fix %s",modify->fix[i]->style);
-          error->all(FLERR,msg);
-        }
+        else
+          error->all(FLERR,fmt::format("Fix enforce2d must be defined after fix {}",
+                                       modify->fix[i]->style));
       }
       if (modify->fix[i] == this) myindex = i;
     }

--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -21,6 +21,8 @@
 #include "memory.h"
 #include "error.h"
 #include "force.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -65,11 +67,9 @@ FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
       if (me == 0) {
         if (strcmp(arg[iarg],"file") == 0) fp = fopen(arg[iarg+1],"w");
         else fp = fopen(arg[iarg+1],"a");
-        if (fp == NULL) {
-          char str[128];
-          snprintf(str,128,"Cannot open fix print file %s",arg[iarg+1]);
-          error->one(FLERR,str);
-        }
+        if (fp == NULL)
+          error->one(FLERR,fmt::format("Cannot open fix print file {}: {}",
+                                       arg[iarg+1], utils::getsyserror()));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"screen") == 0) {

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -19,6 +19,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -221,11 +222,8 @@ void FixPropertyAtom::read_data_section(char *keyword, int n, char *buf,
   int nwords = utils::count_words(buf);
   *next = '\n';
 
-  if (nwords != nvalue+1) {
-    char str[128];
-    snprintf(str,128,"Incorrect %s format in data file",keyword);
-    error->all(FLERR,str);
-  }
+  if (nwords != nvalue+1)
+    error->all(FLERR,fmt::format("Incorrect {} format in data file",keyword));
 
   char **values = new char*[nwords];
 
@@ -239,28 +237,21 @@ void FixPropertyAtom::read_data_section(char *keyword, int n, char *buf,
     next = strchr(buf,'\n');
 
     values[0] = strtok(buf," \t\n\r\f");
-    if (values[0] == NULL) {
-      char str[128];
-      snprintf(str,128,"Too few lines in %s section of data file",keyword);
-      error->one(FLERR,str);
-    }
+    if (values[0] == NULL)
+      error->all(FLERR,fmt::format("Too few lines in {} section of data file",keyword));
+
     int format_ok = 1;
     for (j = 1; j < nwords; j++) {
       values[j] = strtok(NULL," \t\n\r\f");
       if (values[j] == NULL) format_ok = 0;
     }
-    if (!format_ok) {
-      char str[128];
-      snprintf(str,128,"Incorrect %s format in data file",keyword);
-      error->all(FLERR,str);
-    }
+    if (!format_ok)
+      error->all(FLERR,fmt::format("Incorrect {} format in data file",keyword));
 
     itag = ATOTAGINT(values[0]) + id_offset;
-    if (itag <= 0 || itag > map_tag_max) {
-      char str[128];
-      snprintf(str,128,"Invalid atom ID in %s section of data file",keyword);
-      error->one(FLERR,str);
-    }
+    if (itag <= 0 || itag > map_tag_max)
+      error->all(FLERR,fmt::format("Invalid atom ID {} in {} section of "
+                                   "data file",itag, keyword));
 
     // assign words in line to per-atom vectors
 

--- a/src/fix_restrain.cpp
+++ b/src/fix_restrain.cpp
@@ -29,6 +29,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -82,8 +83,8 @@ FixRestrain::FixRestrain(LAMMPS *lmp, int narg, char **arg) :
     if (strcmp(arg[iarg],"bond") == 0) {
       if (iarg+6 > narg) error->all(FLERR,"Illegal fix restrain command");
       rstyle[nrestrain] = BOND;
-      ids[nrestrain][0] = force->inumeric(FLERR,arg[iarg+1]);
-      ids[nrestrain][1] = force->inumeric(FLERR,arg[iarg+2]);
+      ids[nrestrain][0] = force->tnumeric(FLERR,arg[iarg+1]);
+      ids[nrestrain][1] = force->tnumeric(FLERR,arg[iarg+2]);
       kstart[nrestrain] = force->numeric(FLERR,arg[iarg+3]);
       kstop[nrestrain] = force->numeric(FLERR,arg[iarg+4]);
       deqstart[nrestrain] = force->numeric(FLERR,arg[iarg+5]);
@@ -97,8 +98,8 @@ FixRestrain::FixRestrain(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"lbound") == 0) {
       if (iarg+6 > narg) error->all(FLERR,"Illegal fix restrain command");
       rstyle[nrestrain] = LBOUND;
-      ids[nrestrain][0] = force->inumeric(FLERR,arg[iarg+1]);
-      ids[nrestrain][1] = force->inumeric(FLERR,arg[iarg+2]);
+      ids[nrestrain][0] = force->tnumeric(FLERR,arg[iarg+1]);
+      ids[nrestrain][1] = force->tnumeric(FLERR,arg[iarg+2]);
       kstart[nrestrain] = force->numeric(FLERR,arg[iarg+3]);
       kstop[nrestrain] = force->numeric(FLERR,arg[iarg+4]);
       deqstart[nrestrain] = force->numeric(FLERR,arg[iarg+5]);
@@ -112,9 +113,9 @@ FixRestrain::FixRestrain(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"angle") == 0) {
       if (iarg+7 > narg) error->all(FLERR,"Illegal fix restrain command");
       rstyle[nrestrain] = ANGLE;
-      ids[nrestrain][0] = force->inumeric(FLERR,arg[iarg+1]);
-      ids[nrestrain][1] = force->inumeric(FLERR,arg[iarg+2]);
-      ids[nrestrain][2] = force->inumeric(FLERR,arg[iarg+3]);
+      ids[nrestrain][0] = force->tnumeric(FLERR,arg[iarg+1]);
+      ids[nrestrain][1] = force->tnumeric(FLERR,arg[iarg+2]);
+      ids[nrestrain][2] = force->tnumeric(FLERR,arg[iarg+3]);
       kstart[nrestrain] = force->numeric(FLERR,arg[iarg+4]);
       kstop[nrestrain] = force->numeric(FLERR,arg[iarg+5]);
       target[nrestrain] = force->numeric(FLERR,arg[iarg+6]);
@@ -124,10 +125,10 @@ FixRestrain::FixRestrain(LAMMPS *lmp, int narg, char **arg) :
       if (iarg+8 > narg) error->all(FLERR,"Illegal fix restrain command");
       rstyle[nrestrain] = DIHEDRAL;
       mult[nrestrain]   = 1;
-      ids[nrestrain][0] = force->inumeric(FLERR,arg[iarg+1]);
-      ids[nrestrain][1] = force->inumeric(FLERR,arg[iarg+2]);
-      ids[nrestrain][2] = force->inumeric(FLERR,arg[iarg+3]);
-      ids[nrestrain][3] = force->inumeric(FLERR,arg[iarg+4]);
+      ids[nrestrain][0] = force->tnumeric(FLERR,arg[iarg+1]);
+      ids[nrestrain][1] = force->tnumeric(FLERR,arg[iarg+2]);
+      ids[nrestrain][2] = force->tnumeric(FLERR,arg[iarg+3]);
+      ids[nrestrain][3] = force->tnumeric(FLERR,arg[iarg+4]);
       kstart[nrestrain] = force->numeric(FLERR,arg[iarg+5]);
       kstop[nrestrain] = force->numeric(FLERR,arg[iarg+6]);
       target[nrestrain] = force->numeric(FLERR,arg[iarg+7]);
@@ -271,24 +272,16 @@ void FixRestrain::restrain_bond(int m)
 
   if (newton_bond) {
     if (i2 == -1 || i2 >= nlocal) return;
-    if (i1 == -1) {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d missing on proc %d at step " BIGINT_FORMAT,
-              ids[m][0],ids[m][1],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} missing on "
+                                   "proc {} at step {}", ids[m][0],ids[m][1],
+                                   comm->me,update->ntimestep));
   } else {
     if ((i1 == -1 || i1 >= nlocal) && (i2 == -1 || i2 >= nlocal)) return;
-    if (i1 == -1 || i2 == -1)  {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d missing on proc %d at step " BIGINT_FORMAT,
-              ids[m][0],ids[m][1],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1 || i2 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} missing on "
+                                   "proc {} at step {}", ids[m][0],ids[m][1],
+                                   comm->me,update->ntimestep));
   }
 
   delx = x[i1][0] - x[i2][0];
@@ -352,24 +345,16 @@ void FixRestrain::restrain_lbound(int m)
 
   if (newton_bond) {
     if (i2 == -1 || i2 >= nlocal) return;
-    if (i1 == -1) {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d missing on proc %d at step " BIGINT_FORMAT,
-              ids[m][0],ids[m][1],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} missing on "
+                                   "proc {} at step {}",ids[m][0],ids[m][1],
+                                   comm->me,update->ntimestep));
   } else {
     if ((i1 == -1 || i1 >= nlocal) && (i2 == -1 || i2 >= nlocal)) return;
-    if (i1 == -1 || i2 == -1)  {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d missing on proc %d at step " BIGINT_FORMAT,
-              ids[m][0],ids[m][1],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1 || i2 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} missing on "
+                                   "proc {} at step {}",ids[m][0],ids[m][1],
+                                   comm->me,update->ntimestep));
   }
 
   delx = x[i1][0] - x[i2][0];
@@ -442,27 +427,17 @@ void FixRestrain::restrain_angle(int m)
 
   if (newton_bond) {
     if (i2 == -1 || i2 >= nlocal) return;
-    if (i1 == -1 || i3 == -1) {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d %d missing on proc %d at step "
-              BIGINT_FORMAT,
-              ids[m][0],ids[m][1],ids[m][2],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1 || i3 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} {} missing on "
+                                   "proc {} at step {}",ids[m][0],ids[m][1],
+                                   ids[m][2],comm->me,update->ntimestep));
   } else {
     if ((i1 == -1 || i1 >= nlocal) && (i2 == -1 || i2 >= nlocal) &&
         (i3 == -1 || i3 >= nlocal)) return;
-    if (i1 == -1 || i2 == -1 || i3 == -1) {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d %d missing on proc %d at step "
-              BIGINT_FORMAT,
-              ids[m][0],ids[m][1],ids[m][2],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1 || i2 == -1 || i3 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} {} missing on "
+                                   "proc {} at step {}",ids[m][0],ids[m][1],
+                                   ids[m][2],comm->me,update->ntimestep));
   }
 
   // 1st bond
@@ -572,27 +547,19 @@ void FixRestrain::restrain_dihedral(int m)
 
   if (newton_bond) {
     if (i2 == -1 || i2 >= nlocal) return;
-    if (i1 == -1 || i3 == -1 || i4 == -1) {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d %d %d missing on proc %d at step "
-              BIGINT_FORMAT,
-              ids[m][0],ids[m][1],ids[m][2],ids[m][3],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1 || i3 == -1 || i4 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} {} {} missing on "
+                                   "proc {} at step {}",ids[m][0],ids[m][1],
+                                   ids[m][2],ids[m][3],comm->me,
+                                   update->ntimestep));
   } else {
     if ((i1 == -1 || i1 >= nlocal) && (i2 == -1 || i2 >= nlocal) &&
         (i3 == -1 || i3 >= nlocal) && (i4 == -1 || i3 >= nlocal)) return;
-    if (i1 == -1 || i2 == -1 || i3 == -1 || i4 == -1) {
-      char str[128];
-      sprintf(str,
-              "Restrain atoms %d %d %d %d missing on proc %d at step "
-              BIGINT_FORMAT,
-              ids[m][0],ids[m][1],ids[m][2],ids[m][3],
-              comm->me,update->ntimestep);
-      error->one(FLERR,str);
-    }
+    if (i1 == -1 || i2 == -1 || i3 == -1 || i4 == -1)
+      error->one(FLERR,fmt::format("Restrain atoms {} {} {} {} missing on "
+                                   "proc {} at step {}",ids[m][0],ids[m][1],
+                                   ids[m][2],ids[m][3],comm->me,
+                                   update->ntimestep));
   }
 
   // 1st bond
@@ -648,21 +615,18 @@ void FixRestrain::restrain_dihedral(int m)
     int me;
     MPI_Comm_rank(world,&me);
     if (screen) {
-      char str[128];
-      sprintf(str,"Restrain problem: %d " BIGINT_FORMAT " "
-              TAGINT_FORMAT " " TAGINT_FORMAT " "
-              TAGINT_FORMAT " " TAGINT_FORMAT,
-              me,update->ntimestep,
-              atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
+      std::string str = fmt::format("Restrain problem: {} {} {} {} {} {}",
+                                    me,update->ntimestep,atom->tag[i1],
+                                    atom->tag[i2],atom->tag[i3],atom->tag[i4]);
       error->warning(FLERR,str);
-      fprintf(screen,"  1st atom: %d %g %g %g\n",
-              me,x[i1][0],x[i1][1],x[i1][2]);
-      fprintf(screen,"  2nd atom: %d %g %g %g\n",
-              me,x[i2][0],x[i2][1],x[i2][2]);
-      fprintf(screen,"  3rd atom: %d %g %g %g\n",
-              me,x[i3][0],x[i3][1],x[i3][2]);
-      fprintf(screen,"  4th atom: %d %g %g %g\n",
-              me,x[i4][0],x[i4][1],x[i4][2]);
+      fmt::print(screen,"  1st atom: {} {} {} {}\n"
+                 "  2nd atom: {} {} {} {}\n"
+                 "  3rd atom: {} {} {} {}\n"
+                 "  4th atom: {} {} {} {}\n",
+                  comm->me,x[i1][0],x[i1][1],x[i1][2],
+                  comm->me,x[i2][0],x[i2][1],x[i2][2],
+                  comm->me,x[i3][0],x[i3][1],x[i3][2],
+                  comm->me,x[i4][0],x[i4][1],x[i4][2]);
     }
   }
 

--- a/src/fix_restrain.h
+++ b/src/fix_restrain.h
@@ -43,7 +43,7 @@ class FixRestrain : public Fix {
   int nrestrain,maxrestrain;
   int *rstyle;
   int *mult;
-  int **ids;
+  tagint **ids;
   double *kstart,*kstop,*deqstart,*deqstop,*target;
   double *cos_target,*sin_target;
   double energy,energy_all;

--- a/src/fix_tmd.cpp
+++ b/src/fix_tmd.cpp
@@ -30,6 +30,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -73,11 +74,9 @@ nfileevery(0), fp(NULL), xf(NULL), xold(NULL)
     if (narg != 7) error->all(FLERR,"Illegal fix tmd command");
     if (me == 0) {
       fp = fopen(arg[6],"w");
-      if (fp == NULL) {
-        char str[128];
-        snprintf(str,128,"Cannot open fix tmd file %s",arg[6]);
-        error->one(FLERR,str);
-      }
+      if (fp == NULL)
+        error->one(FLERR,fmt::format("Cannot open fix tmd file {}: {}",
+                                     arg[6], utils::getsyserror()));
       fprintf(fp,"%s %s\n","# Step rho_target rho_old gamma_back",
               "gamma_forward lambda work_lambda work_analytical");
     }

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -185,12 +185,9 @@ void Force::init()
 
   // check if pair style must be specified after restart
   if (pair_restart) {
-    if (!pair) {
-      char msg[128];
-      snprintf(msg,128,"Must re-specify non-restarted pair style (%s) "
-               "after read_restart", pair_restart);
-      error->all(FLERR,msg);
-    }
+    if (!pair)
+      error->all(FLERR,fmt::format("Must re-specify non-restarted pair style "
+                                   "({}) after read_restart", pair_restart));
   }
 
   if (kspace) kspace->init();         // kspace must come before pair

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -284,7 +284,7 @@ Pair *Force::new_pair(const char *style, int trysuffix, int &sflag)
     return pair_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("pair",style,lmp).c_str());
+  error->all(FLERR,utils::check_packages_for_style("pair",style,lmp));
 
   return NULL;
 }
@@ -397,7 +397,7 @@ Bond *Force::new_bond(const char *style, int trysuffix, int &sflag)
     return bond_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("bond",style,lmp).c_str());
+  error->all(FLERR,utils::check_packages_for_style("bond",style,lmp));
 
   return NULL;
 }
@@ -476,7 +476,7 @@ Angle *Force::new_angle(const char *style, int trysuffix, int &sflag)
     return angle_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("angle",style,lmp).c_str());
+  error->all(FLERR,utils::check_packages_for_style("angle",style,lmp));
 
   return NULL;
 }
@@ -556,7 +556,7 @@ Dihedral *Force::new_dihedral(const char *style, int trysuffix, int &sflag)
     return dihedral_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("dihedral",style,lmp).c_str());
+  error->all(FLERR,utils::check_packages_for_style("dihedral",style,lmp));
 
   return NULL;
 }
@@ -635,7 +635,7 @@ Improper *Force::new_improper(const char *style, int trysuffix, int &sflag)
     return improper_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("improper",style,lmp).c_str());
+  error->all(FLERR,utils::check_packages_for_style("improper",style,lmp));
 
   return NULL;
 }
@@ -718,7 +718,7 @@ KSpace *Force::new_kspace(const char *style, int trysuffix, int &sflag)
     return kspace_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("kspace",style,lmp).c_str());
+  error->all(FLERR,utils::check_packages_for_style("kspace",style,lmp));
 
   return NULL;
 }
@@ -947,9 +947,8 @@ double Force::numeric(const char *file, int line, char *str)
     if (isdigit(str[i])) continue;
     if (str[i] == '-' || str[i] == '+' || str[i] == '.') continue;
     if (str[i] == 'e' || str[i] == 'E') continue;
-    std::string msg = fmt::format("Expected floating point parameter "
-                    "instead of '{}' in input script or data file",str);
-    error->all(file,line,msg.c_str());
+    error->all(file,line,fmt::format("Expected floating point parameter "
+               "instead of '{}' in input script or data file",str));
   }
 
   return atof(str);
@@ -972,9 +971,8 @@ int Force::inumeric(const char *file, int line, char *str)
 
   for (int i = 0; i < n; i++) {
     if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
-    std::string msg = fmt::format("Expected integer parameter instead "
-                    "of '{}' in input script or data file",str);
-    error->all(file,line,msg.c_str());
+    error->all(file,line,fmt::format("Expected integer parameter instead "
+               "of '{}' in input script or data file",str));
   }
 
   return atoi(str);
@@ -997,9 +995,8 @@ bigint Force::bnumeric(const char *file, int line, char *str)
 
   for (int i = 0; i < n; i++) {
     if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
-    std::string msg = fmt::format("Expected integer parameter instead "
-                    "of '{}' in input script or data file",str);
-    error->all(file,line,msg.c_str());
+    error->all(file,line,fmt::format("Expected integer parameter instead "
+               "of '{}' in input script or data file",str));
   }
 
   return ATOBIGINT(str);
@@ -1022,9 +1019,8 @@ tagint Force::tnumeric(const char *file, int line, char *str)
 
   for (int i = 0; i < n; i++) {
     if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
-    std::string msg = fmt::format("Expected integer parameter instead "
-                    "of '{}' in input script or data file",str);
-    error->all(file,line,msg.c_str());
+    error->all(file,line,fmt::format("Expected integer parameter instead "
+               "of '{}' in input script or data file",str));
   }
 
   return ATOTAGINT(str);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -302,7 +302,7 @@ char *Input::one(const std::string &single)
   // execute the command and return its name
 
   if (execute_command())
-    error->all(FLERR,fmt::format("Unknown command: {}",line).c_str());
+    error->all(FLERR,fmt::format("Unknown command: {}",line));
 
   return command;
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -252,7 +252,8 @@ void Input::file(const char *filename)
 
     infile = fopen(filename,"r");
     if (infile == NULL)
-      error->one(FLERR,fmt::format("Cannot open input script {}",filename));
+      error->one(FLERR,fmt::format("Cannot open input script {}: {}",
+                                   filename, utils::getsyserror()));
 
     infiles[nfile++] = infile;
   }
@@ -1036,7 +1037,8 @@ void Input::include()
 
     infile = fopen(arg[0],"r");
     if (infile == NULL)
-      error->one(FLERR,fmt::format("Cannot open input script {}",arg[0]));
+      error->one(FLERR,fmt::format("Cannot open input script {}: {}",
+                                   arg[0], utils::getsyserror()));
 
     infiles[nfile++] = infile;
   }
@@ -1069,7 +1071,8 @@ void Input::jump()
       if (infile && infile != stdin) fclose(infile);
       infile = fopen(arg[0],"r");
       if (infile == NULL)
-        error->one(FLERR,fmt::format("Cannot open input script {}",arg[0]));
+        error->one(FLERR,fmt::format("Cannot open input script {}: {}",
+                                     arg[0], utils::getsyserror()));
 
       infiles[nfile-1] = infile;
     }
@@ -1112,7 +1115,8 @@ void Input::log()
       else logfile = fopen(arg[0],"w");
 
       if (logfile == NULL)
-        error->one(FLERR,fmt::format("Cannot open logfile {}",arg[0]));
+        error->one(FLERR,fmt::format("Cannot open logfile {}: {}",
+                                     arg[0], utils::getsyserror()));
 
     }
     if (universe->nworlds == 1) universe->ulogfile = logfile;
@@ -1189,8 +1193,8 @@ void Input::print()
         if (strcmp(arg[iarg],"file") == 0) fp = fopen(arg[iarg+1],"w");
         else fp = fopen(arg[iarg+1],"a");
         if (fp == NULL)
-          error->one(FLERR,fmt::format("Cannot open print file {}",
-                                       arg[iarg+1]));
+          error->one(FLERR,fmt::format("Cannot open print file {}: {}",
+                                       arg[iarg+1], utils::getsyserror()));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"screen") == 0) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -251,11 +251,9 @@ void Input::file(const char *filename)
       error->one(FLERR,"Too many nested levels of input scripts");
 
     infile = fopen(filename,"r");
-    if (infile == NULL) {
-      char str[128];
-      snprintf(str,128,"Cannot open input script %s",filename);
-      error->one(FLERR,str);
-    }
+    if (infile == NULL)
+      error->one(FLERR,fmt::format("Cannot open input script {}",filename));
+
     infiles[nfile++] = infile;
   }
 
@@ -545,11 +543,10 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
         value = variable->retrieve(var);
       }
 
-      if (value == NULL) {
-        char str[128];
-        snprintf(str,128,"Substitution for illegal variable %s",var);
-        error->one(FLERR,str);
-      }
+      if (value == NULL)
+        error->one(FLERR,fmt::format("Substitution for illegal "
+                                     "variable {}",var));
+
       // check if storage in str2 needs to be expanded
       // re-initialize ptr and ptr2 to the point beyond the variable.
 
@@ -1038,11 +1035,9 @@ void Input::include()
       error->one(FLERR,"Too many nested levels of input scripts");
 
     infile = fopen(arg[0],"r");
-    if (infile == NULL) {
-      char str[128];
-      snprintf(str,128,"Cannot open input script %s",arg[0]);
-      error->one(FLERR,str);
-    }
+    if (infile == NULL)
+      error->one(FLERR,fmt::format("Cannot open input script {}",arg[0]));
+
     infiles[nfile++] = infile;
   }
 
@@ -1073,11 +1068,9 @@ void Input::jump()
     else {
       if (infile && infile != stdin) fclose(infile);
       infile = fopen(arg[0],"r");
-      if (infile == NULL) {
-        char str[128];
-        snprintf(str,128,"Cannot open input script %s",arg[0]);
-        error->one(FLERR,str);
-      }
+      if (infile == NULL)
+        error->one(FLERR,fmt::format("Cannot open input script {}",arg[0]));
+
       infiles[nfile-1] = infile;
     }
   }
@@ -1118,11 +1111,9 @@ void Input::log()
       if (appendflag) logfile = fopen(arg[0],"a");
       else logfile = fopen(arg[0],"w");
 
-      if (logfile == NULL) {
-        char str[128];
-        snprintf(str,128,"Cannot open logfile %s",arg[0]);
-        error->one(FLERR,str);
-      }
+      if (logfile == NULL)
+        error->one(FLERR,fmt::format("Cannot open logfile {}",arg[0]));
+
     }
     if (universe->nworlds == 1) universe->ulogfile = logfile;
   }
@@ -1197,11 +1188,9 @@ void Input::print()
         if (fp != NULL) fclose(fp);
         if (strcmp(arg[iarg],"file") == 0) fp = fopen(arg[iarg+1],"w");
         else fp = fopen(arg[iarg+1],"a");
-        if (fp == NULL) {
-          char str[128];
-          snprintf(str,128,"Cannot open print file %s",arg[iarg+1]);
-          error->one(FLERR,str);
-        }
+        if (fp == NULL)
+          error->one(FLERR,fmt::format("Cannot open print file {}",
+                                       arg[iarg+1]));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"screen") == 0) {
@@ -1810,18 +1799,15 @@ void Input::pair_style()
 {
   if (narg < 1) error->all(FLERR,"Illegal pair_style command");
   if (force->pair) {
+    std::string style = arg[0];
     int match = 0;
-    if (strcmp(arg[0],force->pair_style) == 0) match = 1;
+    if (style == force->pair_style) match = 1;
     if (!match && lmp->suffix_enable) {
-      char estyle[256];
-      if (lmp->suffix) {
-        snprintf(estyle,256,"%s/%s",arg[0],lmp->suffix);
-        if (strcmp(estyle,force->pair_style) == 0) match = 1;
-      }
-      if (lmp->suffix2) {
-        snprintf(estyle,256,"%s/%s",arg[0],lmp->suffix2);
-        if (strcmp(estyle,force->pair_style) == 0) match = 1;
-      }
+      if (lmp->suffix)
+        if (style + "/" + lmp->suffix == force->pair_style) match = 1;
+
+      if (lmp->suffix2)
+        if (style + "/" + lmp->suffix2 == force->pair_style) match = 1;
     }
     if (match) {
       force->pair->settings(narg-1,&arg[1]);

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -436,11 +436,9 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if (universe->me == 0) {
       if (inflag == 0) infile = stdin;
       else infile = fopen(arg[inflag],"r");
-      if (infile == NULL) {
-        char str[128];
-        snprintf(str,128,"Cannot open input script %s",arg[inflag]);
-        error->one(FLERR,str);
-      }
+      if (infile == NULL)
+        error->one(FLERR,fmt::format("Cannot open input script {}",
+                                     arg[inflag]));
     }
 
     if ((universe->me == 0) && !helpflag)

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -400,20 +400,25 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     else {
       universe->uscreen = fopen(arg[screenflag],"w");
       if (universe->uscreen == NULL)
-        error->universe_one(FLERR,"Cannot open universe screen file");
+        error->universe_one(FLERR,fmt::format("Cannot open universe screen "
+                                              "file {}: {}",arg[screenflag],
+                                              utils::getsyserror()));
     }
     if (logflag == 0) {
       if (helpflag == 0) {
         universe->ulogfile = fopen("log.lammps","w");
         if (universe->ulogfile == NULL)
-          error->universe_warn(FLERR,"Cannot open log.lammps for writing");
+          error->universe_warn(FLERR,"Cannot open log.lammps for writing: "
+                               + utils::getsyserror());
       }
     } else if (strcmp(arg[logflag],"none") == 0)
       universe->ulogfile = NULL;
     else {
       universe->ulogfile = fopen(arg[logflag],"w");
       if (universe->ulogfile == NULL)
-        error->universe_one(FLERR,"Cannot open universe log file");
+        error->universe_one(FLERR,fmt::format("Cannot open universe log "
+                                              "file {}: {}",arg[logflag],
+                                              utils::getsyserror()));
     }
   }
 
@@ -437,8 +442,8 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
       if (inflag == 0) infile = stdin;
       else infile = fopen(arg[inflag],"r");
       if (infile == NULL)
-        error->one(FLERR,fmt::format("Cannot open input script {}",
-                                     arg[inflag]));
+        error->one(FLERR,fmt::format("Cannot open input script {}: {}",
+                                     arg[inflag], utils::getsyserror()));
     }
 
     if ((universe->me == 0) && !helpflag)
@@ -461,45 +466,58 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
         if (screenflag == 0) {
           str = fmt::format("screen.{}",universe->iworld);
           screen = fopen(str.c_str(),"w");
-          if (screen == NULL) error->one(FLERR,"Cannot open screen file");
+          if (screen == NULL)
+            error->one(FLERR,fmt::format("Cannot open screen file {}: {}",
+                                         str,utils::getsyserror()));
         } else if (strcmp(arg[screenflag],"none") == 0) {
           screen = NULL;
         } else {
           str = fmt::format("{}.{}",arg[screenflag],universe->iworld);
           screen = fopen(str.c_str(),"w");
-          if (screen == NULL) error->one(FLERR,"Cannot open screen file");
+          if (screen == NULL)
+            error->one(FLERR,fmt::format("Cannot open screen file {}: {}",
+                                         arg[screenflag],utils::getsyserror()));
         }
       } else if (strcmp(arg[partscreenflag],"none") == 0) {
         screen = NULL;
       } else {
         str = fmt::format("{}.{}",arg[partscreenflag],universe->iworld);
         screen = fopen(str.c_str(),"w");
-        if (screen == NULL) error->one(FLERR,"Cannot open screen file");
+        if (screen == NULL)
+          error->one(FLERR,fmt::format("Cannot open screen file {}: {}",
+                                       str,utils::getsyserror()));
       }
 
       if (partlogflag == 0) {
         if (logflag == 0) {
           str = fmt::format("log.lammps.{}",universe->iworld);
           logfile = fopen(str.c_str(),"w");
-          if (logfile == NULL) error->one(FLERR,"Cannot open logfile");
+          if (logfile == NULL)
+            error->one(FLERR,fmt::format("Cannot open logfile {}: {}",
+                                         str, utils::getsyserror()));
         } else if (strcmp(arg[logflag],"none") == 0) {
           logfile = NULL;
         } else {
           str = fmt::format("{}.{}",arg[logflag],universe->iworld);
           logfile = fopen(str.c_str(),"w");
-          if (logfile == NULL) error->one(FLERR,"Cannot open logfile");
+          if (logfile == NULL)
+            error->one(FLERR,fmt::format("Cannot open logfile {}: {}",
+                                         str, utils::getsyserror()));
         }
       } else if (strcmp(arg[partlogflag],"none") == 0) {
         logfile = NULL;
       } else {
         str = fmt::format("{}.{}",arg[partlogflag],universe->iworld);
         logfile = fopen(str.c_str(),"w");
-        if (logfile == NULL) error->one(FLERR,"Cannot open logfile");
+        if (logfile == NULL)
+          error->one(FLERR,fmt::format("Cannot open logfile {}: {}",
+                                       str, utils::getsyserror()));
       }
 
       infile = fopen(arg[inflag],"r");
       if (infile == NULL)
-        error->one(FLERR,fmt::format("Cannot open input script {}",arg[inflag]));
+        error->one(FLERR,fmt::format("Cannot open input script {}: {}",
+                                     arg[inflag], utils::getsyserror()));
     }
 
     // screen and logfile messages for universe and world

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -500,10 +500,8 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
       }
 
       infile = fopen(arg[inflag],"r");
-      if (infile == NULL) {
-        str = fmt::format("Cannot open input script {}",arg[inflag]);
-        error->one(FLERR,str.c_str());
-      }
+      if (infile == NULL)
+        error->one(FLERR,fmt::format("Cannot open input script {}",arg[inflag]));
     }
 
     // screen and logfile messages for universe and world
@@ -614,13 +612,13 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
   if (restart2data || restart2dump) {
     std::string cmd = fmt::format("read_restart {}",restartfile);
     if (restartremap) cmd += " remap\n";
-    input->one(cmd.c_str());
+    input->one(cmd);
     if (restart2data) cmd = "write_data ";
     else cmd = "write_dump";
     for (iarg = wfirst; iarg < wlast; iarg++)
        cmd += fmt::format(" {}", arg[iarg]);
     if (restart2data) cmd += " noinit";
-    input->one(cmd.c_str());
+    input->one(cmd);
     error->done(0);
   }
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -78,12 +78,12 @@ using namespace LAMMPS_NS;
     MPI_Comm_size(ae.universe, &nprocs ); \
     \
     if (nprocs > 1) { \
-      error->set_last_error(ae.message.c_str(), ERROR_ABORT); \
+      error->set_last_error(ae.message, ERROR_ABORT); \
     } else { \
-      error->set_last_error(ae.message.c_str(), ERROR_NORMAL); \
+      error->set_last_error(ae.message, ERROR_NORMAL); \
     } \
   } catch(LAMMPSException & e) { \
-    error->set_last_error(e.message.c_str(), ERROR_NORMAL); \
+    error->set_last_error(e.message, ERROR_NORMAL); \
   }
 #else
 #define BEGIN_CAPTURE
@@ -1714,9 +1714,9 @@ int lammps_config_has_exceptions() {
 ------------------------------------------------------------------------- */
 
 int lammps_has_error(void *ptr) {
-  LAMMPS *  lmp = (LAMMPS *) ptr;
-  Error * error = lmp->error;
-  return error->get_last_error() ? 1 : 0;
+  LAMMPS  *lmp = (LAMMPS *)ptr;
+  Error *error = lmp->error;
+  return (error->get_last_error() != "") ? 1 : 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -1727,12 +1727,12 @@ int lammps_has_error(void *ptr) {
 ------------------------------------------------------------------------- */
 
 int lammps_get_last_error_message(void *ptr, char * buffer, int buffer_size) {
-  LAMMPS *  lmp = (LAMMPS *) ptr;
-  Error * error = lmp->error;
+  LAMMPS  *lmp = (LAMMPS *)ptr;
+  Error *error = lmp->error;
 
-  if(error->get_last_error()) {
+  if(error->get_last_error() != "") {
     int error_type = error->get_last_error_type();
-    strncpy(buffer, error->get_last_error(), buffer_size-1);
+    strncpy(buffer, error->get_last_error().c_str(), buffer_size-1);
     error->set_last_error(NULL, ERROR_NONE);
     return error_type;
   }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -41,6 +41,7 @@
 #include "neighbor.h"
 #include "neigh_list.h"
 #include "neigh_request.h"
+#include "fmt/format.h"
 
 #if defined(LAMMPS_EXCEPTIONS)
 #include "exceptions.h"
@@ -1582,14 +1583,11 @@ void lammps_create_atoms(void *ptr, int n, tagint *id, int *type,
 
     // warn if new natoms is not correct
 
-    if (lmp->atom->natoms != natoms_prev + n) {
-      char str[128];
-      snprintf(str, 128, "Library warning in lammps_create_atoms, "
-              "invalid total atoms " BIGINT_FORMAT " " BIGINT_FORMAT,
-              lmp->atom->natoms,natoms_prev+n);
-      if (lmp->comm->me == 0)
-        lmp->error->warning(FLERR,str);
-    }
+    if ((lmp->atom->natoms != natoms_prev + n) && (lmp->comm->me == 0))
+      lmp->error->warning(FLERR,fmt::format("Library warning in "
+                                            "lammps_create_atoms: "
+                                            "invalid total atoms {} vs. {}",
+                                            lmp->atom->natoms,natoms_prev+n));
   }
   END_CAPTURE
 }
@@ -1607,19 +1605,13 @@ void lammps_set_fix_external_callback(void *ptr, char *id, FixExternalFnPtr call
   BEGIN_CAPTURE
   {
     int ifix = lmp->modify->find_fix(id);
-    if (ifix < 0) {
-      char str[128];
-      snprintf(str, 128, "Can not find fix with ID '%s'!", id);
-      lmp->error->all(FLERR,str);
-    }
+    if (ifix < 0)
+      lmp->error->all(FLERR,fmt::format("Can not find fix with ID '{}'!", id));
 
     Fix *fix = lmp->modify->fix[ifix];
 
-    if (strcmp("external",fix->style) != 0){
-      char str[128];
-      snprintf(str, 128, "Fix '%s' is not of style external!", id);
-      lmp->error->all(FLERR,str);
-    }
+    if (strcmp("external",fix->style) != 0)
+      lmp->error->all(FLERR,fmt::format("Fix '{}' is not of style external!", id));
 
     FixExternal * fext = (FixExternal*) fix;
     fext->set_callback(callback, caller);

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -14,6 +14,7 @@
 #include "memory.h"
 #include <cstdlib>
 #include "error.h"
+#include "fmt/format.h"
 
 #if defined(LMP_USER_INTEL) && defined(__INTEL_COMPILER)
 #ifndef LMP_INTEL_NO_TBB
@@ -56,12 +57,9 @@ void *Memory::smalloc(bigint nbytes, const char *name)
 #else
   void *ptr = malloc(nbytes);
 #endif
-  if (ptr == NULL) {
-    char str[128];
-    sprintf(str,"Failed to allocate " BIGINT_FORMAT " bytes for array %s",
-            nbytes,name);
-    error->one(FLERR,str);
-  }
+  if (ptr == NULL)
+    error->one(FLERR,fmt::format("Failed to allocate {} bytes for array {}",
+                                 nbytes,name));
   return ptr;
 }
 
@@ -92,12 +90,9 @@ void *Memory::srealloc(void *ptr, bigint nbytes, const char *name)
 #else
   ptr = realloc(ptr,nbytes);
 #endif
-  if (ptr == NULL) {
-    char str[128];
-    sprintf(str,"Failed to reallocate " BIGINT_FORMAT " bytes for array %s",
-            nbytes,name);
-    error->one(FLERR,str);
-  }
+  if (ptr == NULL)
+    error->one(FLERR,fmt::format("Failed to reallocate {} bytes for array {}",
+                                 nbytes,name));
   return ptr;
 }
 
@@ -121,8 +116,6 @@ void Memory::sfree(void *ptr)
 
 void Memory::fail(const char *name)
 {
-  char str[128];
-  snprintf(str,128,
-           "Cannot create/grow a vector/array of pointers for %s",name);
-  error->one(FLERR,str);
+  error->one(FLERR,fmt::format("Cannot create/grow a vector/array of "
+                               "pointers for {}",name));
 }

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -904,7 +904,7 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
   }
 
   if (fix[ifix] == NULL)
-    error->all(FLERR,utils::check_packages_for_style("fix",arg[2],lmp).c_str());
+    error->all(FLERR,utils::check_packages_for_style("fix",arg[2],lmp));
 
   // check if Fix is in restart_global list
   // if yes, pass state info to the Fix so it can reset itself
@@ -1243,7 +1243,7 @@ void Modify::add_compute(int narg, char **arg, int trysuffix)
   }
 
   if (compute[ncompute] == NULL)
-    error->all(FLERR,utils::check_packages_for_style("compute",arg[2],lmp).c_str());
+    error->all(FLERR,utils::check_packages_for_style("compute",arg[2],lmp));
 
   ncompute++;
 }

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -28,6 +28,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -245,21 +246,15 @@ void Modify::init()
   // error if any fix or compute is using a dynamic group when not allowed
 
   for (i = 0; i < nfix; i++)
-    if (!fix[i]->dynamic_group_allow && group->dynamic[fix[i]->igroup]) {
-      char str[128];
-      snprintf(str,128,
-               "Fix %s does not allow use of dynamic group",fix[i]->id);
-      error->all(FLERR,str);
-    }
+    if (!fix[i]->dynamic_group_allow && group->dynamic[fix[i]->igroup])
+      error->all(FLERR,fmt::format("Fix {} does not allow use with a "
+                                   "dynamic group",fix[i]->id));
 
   for (i = 0; i < ncompute; i++)
     if (!compute[i]->dynamic_group_allow &&
-        group->dynamic[compute[i]->igroup]) {
-      char str[128];
-      snprintf(str,128,"Compute %s does not allow use of dynamic group",
-               fix[i]->id);
-      error->all(FLERR,str);
-    }
+        group->dynamic[compute[i]->igroup])
+      error->all(FLERR,fmt::format("Compute {} does not allow use with a "
+                                   "dynamic group",compute[i]->id));
 
   // warn if any particle is time integrated more than once
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1723,7 +1723,8 @@ void Molecule::open(char *file)
 {
   fp = fopen(file,"r");
   if (fp == NULL)
-    error->one(FLERR,fmt::format("Cannot open molecule file {}",file));
+    error->one(FLERR,fmt::format("Cannot open molecule file {}: {}",
+                                 file, utils::getsyserror()));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -26,6 +26,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -1721,11 +1722,8 @@ void Molecule::deallocate()
 void Molecule::open(char *file)
 {
   fp = fopen(file,"r");
-  if (fp == NULL) {
-    char str[128];
-    snprintf(str,128,"Cannot open molecule file %s",file);
-    error->one(FLERR,str);
-  }
+  if (fp == NULL)
+    error->one(FLERR,fmt::format("Cannot open molecule file {}",file));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/ntopo_angle_all.cpp
+++ b/src/ntopo_angle_all.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -58,15 +59,11 @@ void NTopoAngleAll::build()
       atom3 = atom->map(angle_atom3[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Angle atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  angle_atom1[i][m],angle_atom2[i][m],angle_atom3[i][m],
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Angle atoms {} {} {} missing on "
+                                       "proc {} at step {}",angle_atom1[i][m],
+                                       angle_atom2[i][m],angle_atom3[i][m],
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -90,10 +87,7 @@ void NTopoAngleAll::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Angle atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Angle atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_angle_partial.cpp
+++ b/src/ntopo_angle_partial.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -59,15 +60,11 @@ void NTopoAnglePartial::build()
       atom3 = atom->map(angle_atom3[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Angle atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  angle_atom1[i][m],angle_atom2[i][m],angle_atom3[i][m],
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Angle atoms {} {} {} missing on "
+                                       "proc {} at step {}",angle_atom1[i][m],
+                                       angle_atom2[i][m],angle_atom3[i][m],
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -91,10 +88,7 @@ void NTopoAnglePartial::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Angle atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Angle atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_angle_template.cpp
+++ b/src/ntopo_angle_template.cpp
@@ -23,6 +23,7 @@
 #include "molecule.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -76,16 +77,13 @@ void NTopoAngleTemplate::build()
       atom3 = atom->map(angle_atom3[iatom][m]+tagprev);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Angle atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  angle_atom1[iatom][m]+tagprev,angle_atom2[iatom][m]+tagprev,
-                  angle_atom3[iatom][m]+tagprev,
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Angle atoms {} {} {} missing on "
+                                       "proc {} at step {}",
+                                       angle_atom1[iatom][m]+tagprev,
+                                       angle_atom2[iatom][m]+tagprev,
+                                       angle_atom3[iatom][m]+tagprev,
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -110,10 +108,7 @@ void NTopoAngleTemplate::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Angle atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Angle atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_bond_all.cpp
+++ b/src/ntopo_bond_all.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -55,13 +56,10 @@ void NTopoBondAll::build()
       atom1 = atom->map(bond_atom[i][m]);
       if (atom1 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Bond atoms " TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  tag[i],bond_atom[i][m],me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Bond atoms {} {} missing on "
+                                       "proc {} at step {}",tag[i],
+                                       bond_atom[i][m],me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -82,10 +80,7 @@ void NTopoBondAll::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Bond atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Bond atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_bond_partial.cpp
+++ b/src/ntopo_bond_partial.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -56,13 +57,10 @@ void NTopoBondPartial::build()
       atom1 = atom->map(bond_atom[i][m]);
       if (atom1 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Bond atoms " TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  tag[i],bond_atom[i][m],me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Bond atoms {} {} missing on "
+                                       "proc {} at step {}",tag[i],
+                                       bond_atom[i][m],me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -83,10 +81,7 @@ void NTopoBondPartial::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Bond atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Bond atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_bond_template.cpp
+++ b/src/ntopo_bond_template.cpp
@@ -23,6 +23,7 @@
 #include "molecule.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -72,13 +73,11 @@ void NTopoBondTemplate::build()
       atom1 = atom->map(bond_atom[iatom][m]+tagprev);
       if (atom1 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Bond atoms " TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  tag[i],bond_atom[iatom][m]+tagprev,me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Bond atoms {} {} missing on "
+                                       "proc {} at step {}",tag[i],
+                                       bond_atom[iatom][m]+tagprev,
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -100,10 +99,7 @@ void NTopoBondTemplate::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Bond atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Bond atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_dihedral_all.cpp
+++ b/src/ntopo_dihedral_all.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -60,17 +61,12 @@ void NTopoDihedralAll::build()
       atom4 = atom->map(dihedral_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Dihedral atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  dihedral_atom1[i][m],dihedral_atom2[i][m],
-                  dihedral_atom3[i][m],dihedral_atom4[i][m],
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Dihedral atoms {} {} {} {} missing on "
+                                       "proc {} at step {}",
+                                       dihedral_atom1[i][m],dihedral_atom2[i][m],
+                                       dihedral_atom3[i][m],dihedral_atom4[i][m],
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -97,10 +93,7 @@ void NTopoDihedralAll::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Dihedral atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Dihedral atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_dihedral_partial.cpp
+++ b/src/ntopo_dihedral_partial.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -62,17 +63,12 @@ void NTopoDihedralPartial::build()
       atom4 = atom->map(dihedral_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Dihedral atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  dihedral_atom1[i][m],dihedral_atom2[i][m],
-                  dihedral_atom3[i][m],dihedral_atom4[i][m],
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Dihedral atoms {} {} {} {} missing on "
+                                       "proc {} at step {}",
+                                       dihedral_atom1[i][m],dihedral_atom2[i][m],
+                                       dihedral_atom3[i][m],dihedral_atom4[i][m],
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -99,10 +95,7 @@ void NTopoDihedralPartial::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Dihedral atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Dihedral atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_dihedral_template.cpp
+++ b/src/ntopo_dihedral_template.cpp
@@ -23,6 +23,7 @@
 #include "molecule.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -78,19 +79,14 @@ void NTopoDihedralTemplate::build()
       atom4 = atom->map(dihedral_atom4[iatom][m]+tagprev);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Dihedral atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  dihedral_atom1[iatom][m]+tagprev,
-                  dihedral_atom2[iatom][m]+tagprev,
-                  dihedral_atom3[iatom][m]+tagprev,
-                  dihedral_atom4[iatom][m]+tagprev,
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Dihedral atoms {} {} {} {} missing on "
+                                       "proc {} at step {}",
+                                       dihedral_atom1[iatom][m]+tagprev,
+                                       dihedral_atom2[iatom][m]+tagprev,
+                                       dihedral_atom3[iatom][m]+tagprev,
+                                       dihedral_atom4[iatom][m]+tagprev,
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
@@ -118,10 +114,7 @@ void NTopoDihedralTemplate::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Dihedral atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Dihedral atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_improper_all.cpp
+++ b/src/ntopo_improper_all.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -60,23 +61,18 @@ void NTopoImproperAll::build()
       atom4 = atom->map(improper_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Improper atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  improper_atom1[i][m],improper_atom2[i][m],
-                  improper_atom3[i][m],improper_atom4[i][m],
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Improper atoms {} {} {} {} missing on "
+                                       "proc {} at step {}",
+                                       improper_atom1[i][m],improper_atom2[i][m],
+                                       improper_atom3[i][m],improper_atom4[i][m],
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
       atom2 = domain->closest_image(i,atom2);
       atom3 = domain->closest_image(i,atom3);
-      atom4 = domain-> closest_image(i,atom4);
+      atom4 = domain->closest_image(i,atom4);
       if (newton_bond ||
           (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4)) {
         if (nimproperlist == maximproper) {
@@ -97,10 +93,7 @@ void NTopoImproperAll::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Improper atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Improper atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/ntopo_improper_partial.cpp
+++ b/src/ntopo_improper_partial.cpp
@@ -21,6 +21,7 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -62,17 +63,14 @@ void NTopoImproperPartial::build()
       atom4 = atom->map(improper_atom4[i][m]);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Improper atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  improper_atom1[i][m],improper_atom2[i][m],
-                  improper_atom3[i][m],improper_atom4[i][m],
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Improper atoms {} {} {} {}"
+                                       " missing on proc {} at step {}",
+                                       improper_atom1[i][m],
+                                       improper_atom2[i][m],
+                                       improper_atom3[i][m],
+                                       improper_atom4[i][m],
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);

--- a/src/ntopo_improper_template.cpp
+++ b/src/ntopo_improper_template.cpp
@@ -23,6 +23,7 @@
 #include "molecule.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -78,25 +79,20 @@ void NTopoImproperTemplate::build()
       atom4 = atom->map(improper_atom4[iatom][m]+tagprev);
       if (atom1 == -1 || atom2 == -1 || atom3 == -1 || atom4 == -1) {
         nmissing++;
-        if (lostbond == Thermo::ERROR) {
-          char str[128];
-          sprintf(str,"Improper atoms "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT
-                  " missing on proc %d at step " BIGINT_FORMAT,
-                  improper_atom1[iatom][m]+tagprev,
-                  improper_atom2[iatom][m]+tagprev,
-                  improper_atom3[iatom][m]+tagprev,
-                  improper_atom4[iatom][m]+tagprev,
-                  me,update->ntimestep);
-          error->one(FLERR,str);
-        }
+        if (lostbond == Thermo::ERROR)
+          error->one(FLERR,fmt::format("Improper atoms {} {} {} {}"
+                                       " missing on proc {} at step {}",
+                                       improper_atom1[iatom][m]+tagprev,
+                                       improper_atom2[iatom][m]+tagprev,
+                                       improper_atom3[iatom][m]+tagprev,
+                                       improper_atom4[iatom][m]+tagprev,
+                                       me,update->ntimestep));
         continue;
       }
       atom1 = domain->closest_image(i,atom1);
       atom2 = domain->closest_image(i,atom2);
       atom3 = domain->closest_image(i,atom3);
-      atom4 = domain-> closest_image(i,atom4);
+      atom4 = domain->closest_image(i,atom4);
       if (newton_bond ||
           (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4)) {
         if (nimproperlist == maximproper) {
@@ -118,10 +114,7 @@ void NTopoImproperTemplate::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Improper atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,fmt::format("Improper atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -584,7 +584,7 @@ void Output::add_dump(int narg, char **arg)
   if (dump_map->find(arg[2]) != dump_map->end()) {
     DumpCreator dump_creator = (*dump_map)[arg[2]];
     dump[ndump] = dump_creator(lmp, narg, arg);
-  } else error->all(FLERR,utils::check_packages_for_style("dump",arg[2],lmp).c_str());
+  } else error->all(FLERR,utils::check_packages_for_style("dump",arg[2],lmp));
 
   every_dump[ndump] = force->inumeric(FLERR,arg[3]);
   if (every_dump[ndump] <= 0) error->all(FLERR,"Illegal dump command");

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -33,6 +33,8 @@
 #include "memory.h"
 #include "math_const.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -1639,7 +1641,9 @@ void Pair::write_file(int narg, char **arg)
   FILE *fp;
   if (me == 0) {
     fp = fopen(arg[6],"a");
-    if (fp == NULL) error->one(FLERR,"Cannot open pair_write file");
+    if (fp == NULL)
+      error->one(FLERR,fmt::format("Cannot open pair_write file {}: {}",
+                                   arg[6], utils::getsyserror()));
     fprintf(fp,"# Pair potential %s for atom types %d %d: i,r,energy,force\n",
             force->pair_style,itype,jtype);
     if (style == RLINEAR)

--- a/src/pair_coul_streitz.cpp
+++ b/src/pair_coul_streitz.cpp
@@ -31,6 +31,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -249,11 +250,9 @@ void PairCoulStreitz::read_file(char *file)
   FILE *fp;
   if (comm->me == 0) {
     fp = fopen(file,"r");
-    if (fp == NULL) {
-      char str[128];
-      snprintf(str,128,"Cannot open coul/streitz potential file %s",file);
-      error->one(FLERR,str);
-    }
+    if (fp == NULL)
+      error->one(FLERR,fmt::format("Cannot open coul/streitz potential "
+                                   "file {}",file));
   }
 
   // read each line out of file, skipping blank lines or leading '#'

--- a/src/potential_file_reader.cpp
+++ b/src/potential_file_reader.cpp
@@ -38,8 +38,8 @@ PotentialFileReader::PotentialFileReader(LAMMPS *lmp,
   fp = force->open_potential(filename.c_str());
 
   if (fp == NULL)
-    error->one(FLERR,fmt::format("Cannot open {} potential file {}",
-                                 potential_name, filename));
+    error->one(FLERR,fmt::format("Cannot open {} potential file {}: {}",
+                                 potential_name, filename, utils::getsyserror()));
 }
 
 PotentialFileReader::~PotentialFileReader() {

--- a/src/potential_file_reader.cpp
+++ b/src/potential_file_reader.cpp
@@ -22,6 +22,7 @@
 #include "potential_file_reader.h"
 #include "utils.h"
 #include "tokenizer.h"
+#include "fmt/format.h"
 
 #include <cstring>
 
@@ -36,11 +37,9 @@ PotentialFileReader::PotentialFileReader(LAMMPS *lmp,
 
   fp = force->open_potential(filename.c_str());
 
-  if (fp == NULL) {
-    char str[128];
-    snprintf(str, 128, "cannot open %s potential file %s", potential_name.c_str(), filename.c_str());
-    error->one(FLERR, str);
-  }
+  if (fp == NULL)
+    error->one(FLERR,fmt::format("Cannot open {} potential file {}",
+                                 potential_name, filename));
 }
 
 PotentialFileReader::~PotentialFileReader() {
@@ -49,12 +48,9 @@ PotentialFileReader::~PotentialFileReader() {
 
 void PotentialFileReader::skip_line() {
   char *ptr = fgets(line, MAXLINE, fp);
-  if (ptr == nullptr) {
-    // EOF
-    char str[128];
-    snprintf(str, 128, "Missing line in %s potential file!", potential_name.c_str());
-    error->one(FLERR, str);
-  }
+  if (ptr == nullptr)
+    error->one(FLERR,fmt::format("Missing line in {} potential file!",
+                                 potential_name));
 }
 
 char *PotentialFileReader::next_line(int nparams) {
@@ -83,15 +79,12 @@ char *PotentialFileReader::next_line(int nparams) {
 
     if (ptr == nullptr) {
       // EOF
-      if (nwords > 0 && nwords < nparams) {
-        char str[128];
-        snprintf(str, 128, "Incorrect format in %s potential file! %d/%d parameters", potential_name.c_str(), nwords, nparams);
-        error->one(FLERR, str);
-      }
-
+      if (nwords > 0 && nwords < nparams)
+        error->one(FLERR,fmt::format("Incorrect format in {} potential "
+                                     "file! {}/{} parameters",
+                                     potential_name, nwords, nparams));
       return nullptr;
     }
-
 
     // strip comment
     if ((ptr = strchr(line, '#'))) *ptr = '\0';
@@ -114,11 +107,9 @@ void PotentialFileReader::next_dvector(int n, double * list) {
 
     if (ptr == nullptr) {
       // EOF
-      if (i < n) {
-        char str[128];
-        snprintf(str, 128, "Incorrect format in %s potential file! %d/%d values", potential_name.c_str(), i, n);
-        error->one(FLERR, str);
-      }
+      if (i < n)
+        error->one(FLERR,fmt::format("Incorrect format in {} potential file! "
+                                     "{}/{} values", potential_name, i, n));
     }
 
     ValueTokenizer values(line);

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -18,6 +18,7 @@
 #include "read_data.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include <cctype>
 #include "atom.h"
 #include "atom_vec.h"
@@ -42,6 +43,7 @@
 #include "error.h"
 #include "memory.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -709,11 +711,8 @@ void ReadData::command(int narg, char **arg)
         if (firstpass) impropercoeffs(1);
         else skip_lines(nimpropertypes);
 
-      } else {
-        char str[128];
-        snprintf(str,128,"Unknown identifier in data file: %s",keyword);
-        error->all(FLERR,str);
-      }
+      } else error->all(FLERR,fmt::format("Unknown identifier in data file: {}",
+                                          keyword));
 
       parse_keyword(0);
     }
@@ -2013,25 +2012,21 @@ void ReadData::open(char *file)
   if (!compressed) fp = fopen(file,"r");
   else {
 #ifdef LAMMPS_GZIP
-    char gunzip[128];
-    snprintf(gunzip,128,"gzip -c -d %s",file);
-
+    std::string gunzip = fmt::format("gzip -c -d {}",file);
 #ifdef _WIN32
-    fp = _popen(gunzip,"rb");
+    fp = _popen(gunzip.c_str(),"rb");
 #else
-    fp = popen(gunzip,"r");
+    fp = popen(gunzip.c_str(),"r");
 #endif
 
 #else
-    error->one(FLERR,"Cannot open gzipped file");
+    error->one(FLERR,"Cannot open gzipped file: " + utils::getsyserror());
 #endif
   }
 
-  if (fp == NULL) {
-    char str[128];
-    snprintf(str,128,"Cannot open file %s",file);
-    error->one(FLERR,str);
-  }
+  if (fp == NULL)
+    error->one(FLERR,fmt::format("Cannot open file {}: {}",
+                                 file, utils::getsyserror()));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -263,7 +263,7 @@ void ReadDump::setup_reader(int narg, char **arg)
 
   // unrecognized style
 
-  else error->all(FLERR,utils::check_packages_for_style("reader",readerstyle,lmp).c_str());
+  else error->all(FLERR,utils::check_packages_for_style("reader",readerstyle,lmp));
 
   if (utils::strmatch(readerstyle,"^adios")) {
       // everyone is a reader with adios

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -113,11 +113,9 @@ void ReadRestart::command(int narg, char **arg)
       *ptr = '%';
     } else hfile = file;
     fp = fopen(hfile,"rb");
-    if (fp == NULL) {
-      char str[128];
-      snprintf(str,128,"Cannot open restart file %s",hfile);
-      error->one(FLERR,str);
-    }
+    if (fp == NULL)
+      error->one(FLERR,fmt::format("Cannot open restart file {}: {}",
+                                   hfile, utils::getsyserror()));
     if (multiproc) delete [] hfile;
   }
 
@@ -282,12 +280,9 @@ void ReadRestart::command(int narg, char **arg)
       sprintf(procfile,"%s%d%s",file,iproc,ptr+1);
       *ptr = '%';
       fp = fopen(procfile,"rb");
-      if (fp == NULL) {
-        char str[128];
-        snprintf(str,128,"Cannot open restart file %s",procfile);
-        error->one(FLERR,str);
-      }
-
+      if (fp == NULL)
+        error->one(FLERR,fmt::format("Cannot open restart file {}: {}",
+                                     procfile, utils::getsyserror()));
       utils::sfread(FLERR,&flag,sizeof(int),1,fp,NULL,error);
       if (flag != PROCSPERFILE)
         error->one(FLERR,"Invalid flag in peratom section of restart file");
@@ -354,11 +349,9 @@ void ReadRestart::command(int narg, char **arg)
       sprintf(procfile,"%s%d%s",file,icluster,ptr+1);
       *ptr = '%';
       fp = fopen(procfile,"rb");
-      if (fp == NULL) {
-        char str[128];
-        snprintf(str,128,"Cannot open restart file %s",procfile);
-        error->one(FLERR,str);
-      }
+      if (fp == NULL)
+        error->one(FLERR,fmt::format("Cannot open restart file {}: {}",
+                                     procfile, utils::getsyserror()));
       delete [] procfile;
     }
 
@@ -718,12 +711,10 @@ void ReadRestart::header()
 
     } else if (flag == NPROCS) {
       nprocs_file = read_int();
-      if (nprocs_file != comm->nprocs && me == 0) {
-        char msg[128];
-        snprintf(msg,128,"Restart file used different # of processors: %d vs. %d",
-                 nprocs_file,comm->nprocs);
-        error->warning(FLERR,msg);
-      }
+      if (nprocs_file != comm->nprocs && me == 0)
+        error->warning(FLERR,fmt::format("Restart file used different # of "
+                                         "processors: {} vs. {}",nprocs_file,
+                                         comm->nprocs));
 
     // don't set procgrid, warn if different
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -14,6 +14,8 @@
 #include "reader.h"
 #include <cstring>
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -41,25 +43,21 @@ void Reader::open_file(const char *file)
   if (!compressed) fp = fopen(file,"r");
   else {
 #ifdef LAMMPS_GZIP
-    char gunzip[1024];
-    snprintf(gunzip,1024,"gzip -c -d %s",file);
-
+    std::string gunzip = fmt::format("gzip -c -d {}",file);
 #ifdef _WIN32
-    fp = _popen(gunzip,"rb");
+    fp = _popen(gunzip.c_str(),"rb");
 #else
-    fp = popen(gunzip,"r");
+    fp = popen(gunzip.c_str(),"r");
 #endif
 
 #else
-    error->one(FLERR,"Cannot open gzipped file");
+    error->one(FLERR,"Cannot open gzipped file: " + utils::getsyserror());
 #endif
   }
 
-  if (fp == NULL) {
-    char str[128];
-    snprintf(str,128,"Cannot open file %s",file);
-    error->one(FLERR,str);
-  }
+  if (fp == NULL)
+    error->one(FLERR,fmt::format("Cannot open file {}: {}",
+                                 file, utils::getsyserror()));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -14,6 +14,7 @@
 #include "utils.h"
 #include <cstring>
 #include <cstdlib>
+#include <cerrno>
 #include "lammps.h"
 #include "error.h"
 #include "tokenizer.h"
@@ -97,6 +98,14 @@ void utils::logmesg(LAMMPS *lmp, const std::string &mesg)
 {
   if (lmp->screen)  fputs(mesg.c_str(), lmp->screen);
   if (lmp->logfile) fputs(mesg.c_str(), lmp->logfile);
+}
+
+/* define this here, so we won't have to include the headers
+   everywhere and utils.h will more likely be included anyway. */
+
+std::string utils::getsyserror()
+{
+  return std::string(strerror(errno));
 }
 
 /** \brief try to detect pathname from FILE pointer. Currently only supported on Linux, otherwise will report "(unknown)".

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,6 +43,14 @@ namespace LAMMPS_NS {
      */
     void logmesg(LAMMPS *lmp, const std::string &mesg);
 
+    /** \brief return a string representing the current system error status
+     *
+     *  This is a wrapper around calling strerror(errno).
+     *
+     *  \return  error string
+     */
+    std::string getsyserror();
+
     /** \brief safe wrapper around fgets() which aborts on errors
      *  or EOF and prints a suitable error message to help debugging
      *

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -41,6 +41,7 @@
 #include "info.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -1336,7 +1337,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           std::string mesg = "Invalid compute ID '";
           mesg += (word+2);
           mesg += "' in variable formula";
-          print_var_error(FLERR,mesg.c_str(),ivar);
+          print_var_error(FLERR,mesg,ivar);
         }
         Compute *compute = modify->compute[icompute];
 
@@ -1641,7 +1642,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           std::string mesg = "Invalid fix ID '";
           mesg += (word+2);
           mesg += "' in variable formula";
-          print_var_error(FLERR,mesg.c_str(),ivar);
+          print_var_error(FLERR,mesg,ivar);
         }
         Fix *fix = modify->fix[ifix];
 
@@ -3831,7 +3832,7 @@ int Variable::group_function(char *word, char *contents, Tree **tree,
     std::string mesg = "Group ID '";
     mesg += args[0];
     mesg += "' in variable formula does not exist";
-    print_var_error(FLERR,mesg.c_str(),ivar);
+    print_var_error(FLERR,mesg,ivar);
   }
 
   // match word to group function
@@ -4044,7 +4045,7 @@ int Variable::region_function(char *id, int ivar)
     std::string mesg = "Region ID '";
     mesg += id;
     mesg += "' in variable formula does not exist";
-    print_var_error(FLERR,mesg.c_str(),ivar);
+    print_var_error(FLERR,mesg,ivar);
   }
 
   // init region in case sub-regions have been deleted
@@ -4126,7 +4127,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
         std::string mesg = "Invalid compute ID '";
         mesg += (args[0]+2);
         mesg += "' in variable formula";
-        print_var_error(FLERR,mesg.c_str(),ivar);
+        print_var_error(FLERR,mesg,ivar);
       }
       compute = modify->compute[icompute];
       if (index == 0 && compute->vector_flag) {
@@ -4171,7 +4172,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
         std::string mesg = "Invalid fix ID '";
         mesg += (args[0]+2);
         mesg += "' in variable formula";
-        print_var_error(FLERR,mesg.c_str(),ivar);
+        print_var_error(FLERR,mesg,ivar);
       }
       fix = modify->fix[ifix];
       if (index == 0 && fix->vector_flag) {
@@ -4179,7 +4180,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
           std::string mesg = "Fix with ID '";
           mesg += (args[0]+2);
           mesg += "' in variable formula not computed at compatible time";
-          print_var_error(FLERR,mesg.c_str(),ivar);
+          print_var_error(FLERR,mesg,ivar);
         }
         nvec = fix->size_vector;
         nstride = 1;
@@ -4391,7 +4392,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
       std::string mesg = "Variable ID '";
       mesg += args[0];
       mesg += "' in variable formula does not exist";
-      print_var_error(FLERR,mesg.c_str(),ivar);
+      print_var_error(FLERR,mesg,ivar);
     }
 
     // SCALARFILE has single current value, read next one
@@ -4772,13 +4773,11 @@ char *Variable::find_next_comma(char *str)
    helper routine for printing variable name with error message
 ------------------------------------------------------------------------- */
 
-void Variable::print_var_error(const char *srcfile, int lineno,
-                               const char *errmsg, int ivar, int global)
+void Variable::print_var_error(const std::string &srcfile, const int lineno,
+                               const std::string &errmsg, int ivar, int global)
 {
   if ((ivar >= 0) && (ivar < nvar)) {
-    char msg[128];
-
-    snprintf(msg,128,"Variable %s: %s",names[ivar],errmsg);
+    std::string msg = fmt::format("Variable {}: ",names[ivar]) + errmsg;
     if (global)
       error->all(srcfile,lineno,msg);
     else

--- a/src/variable.h
+++ b/src/variable.h
@@ -15,6 +15,7 @@
 #define LMP_VARIABLE_H
 
 #include "pointers.h"
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -123,7 +124,8 @@ class Variable : protected Pointers {
   double constant(char *);
   int parse_args(char *, char **);
   char *find_next_comma(char *);
-  void print_var_error(const char *, int, const char *, int, int global=1);
+  void print_var_error(const std::string &, int, const std::string &,
+                       int, int global=1);
   void print_tree(Tree *, int);
 };
 

--- a/src/write_coeff.cpp
+++ b/src/write_coeff.cpp
@@ -27,6 +27,7 @@
 #include "error.h"
 #include "domain.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -56,10 +57,9 @@ void WriteCoeff::command(int narg, char **arg)
     char str[256], coeff[256];
     FILE *one = fopen(file,"wb+");
 
-    if (one == NULL) {
-      snprintf(str,256,"Cannot open coeff file %s",file);
-      error->one(FLERR,str);
-    }
+    if (one == NULL)
+      error->one(FLERR,fmt::format("Cannot open coeff file {}: {}",
+                                   file, utils::getsyserror()));
 
     if (force->pair && force->pair->writedata) {
       fprintf(one,"# pair_style %s\npair_coeff\n",force->pair_style);
@@ -91,10 +91,10 @@ void WriteCoeff::command(int narg, char **arg)
     rewind(one);
 
     FILE *two = fopen(file+4,"w");
-    if (two == NULL) {
-      snprintf(str,256,"Cannot open coeff file %s",file+4);
-      error->one(FLERR,str);
-    }
+    if (two == NULL)
+      error->one(FLERR,fmt::format("Cannot open coeff file {}: {}",
+                                   file+4, utils::getsyserror()));
+
     fprintf(two,"# LAMMPS coeff file via write_coeff, version %s\n",
             universe->version);
 

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -32,6 +32,8 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -191,11 +193,9 @@ void WriteData::write(char *file)
 
   if (me == 0) {
     fp = fopen(file,"w");
-    if (fp == NULL) {
-      char str[128];
-      snprintf(str,128,"Cannot open data file %s",file);
-      error->one(FLERR,str);
-    }
+    if (fp == NULL)
+      error->one(FLERR,fmt::format("Cannot open data file {}: {}",
+                                   file, utils::getsyserror()));
   }
 
   // proc 0 writes header, ntype-length arrays, force fields

--- a/src/write_dump.cpp
+++ b/src/write_dump.cpp
@@ -63,7 +63,7 @@ void WriteDump::command(int narg, char **arg)
 #include "style_dump.h"
 #undef DUMP_CLASS
 
-  else error->all(FLERR,utils::check_packages_for_style("dump",arg[1],lmp).c_str());
+  else error->all(FLERR,utils::check_packages_for_style("dump",arg[1],lmp));
 
   if (modindex < narg) dump->modify_params(narg-modindex-1,&arg[modindex+1]);
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -35,6 +35,8 @@
 #include "mpiio.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 #include "lmprestart.h"
 
@@ -242,11 +244,9 @@ void WriteRestart::write(char *file)
       *ptr = '%';
     } else hfile = file;
     fp = fopen(hfile,"wb");
-    if (fp == NULL) {
-      char str[128];
-      snprintf(str,128,"Cannot open restart file %s",hfile);
-      error->one(FLERR,str);
-    }
+    if (fp == NULL)
+      error->one(FLERR, fmt::format("Cannot open restart file {}: {}",
+                                    hfile, utils::getsyserror()));
     if (multiproc) delete [] hfile;
   }
 
@@ -310,11 +310,9 @@ void WriteRestart::write(char *file)
 
     if (filewriter) {
       fp = fopen(multiname,"wb");
-      if (fp == NULL) {
-        char str[128];
-        snprintf(str,128,"Cannot open restart file %s",multiname);
-        error->one(FLERR,str);
-      }
+      if (fp == NULL)
+        error->one(FLERR, fmt::format("Cannot open restart file {}: {}",
+                                      multiname, utils::getsyserror()));
       write_int(PROCSPERFILE,nclusterprocs);
     }
 


### PR DESCRIPTION
**Summary**

This changes the `const char *` arguments in the `Error` class functions to `const std::string &`.
That in turn allows to get rid of a substantial number of `std::string::c_str()` calls and - in combination with {fmt} formatting - also to simplify some complex code and remove some fixed size local buffers. More future changes will benefit from it.

It also adds a convenience function `utils::getsyserror()` that returns the output of `strerror(errno)` as a c++ string and adds its output to several places where errors are reported about opening files.

In addition, this fixes a bug in fix restrain, where atom IDs were stored in int arrays instead of tagint ones.

**Related Issues**

#2103 

**Author(s)**

Axel Kohlmeyer, Richard Berger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
