### PR TITLE
Use {fmt}, std::string and utils::logmesg() in more places

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -340,7 +340,8 @@ void AtomKokkos::sync_modify(ExecutionSpace execution_space,
   modified(execution_space,datamask_modify);
 }
 
-AtomVec *AtomKokkos::new_avec(const char *style, int trysuffix, int &sflag)
+AtomVec *AtomKokkos::new_avec(const std::string &style,
+                              int trysuffix, int &sflag)
 {
   AtomVec* avec = Atom::new_avec(style,trysuffix,sflag);
   if (!avec->kokkosable)

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -74,7 +74,7 @@ class AtomKokkos : public Atom {
   virtual void deallocate_topology();
   void sync_modify(ExecutionSpace, unsigned int, unsigned int);
  private:
-   class AtomVec *new_avec(const char *, int, int &);
+  class AtomVec *new_avec(const std::string &, int, int &);
 };
 
 template<class ViewType, class IndexView>

--- a/src/MPIIO/restart_mpiio.cpp
+++ b/src/MPIIO/restart_mpiio.cpp
@@ -36,7 +36,7 @@ RestartMPIIO::RestartMPIIO(LAMMPS *lmp) : Pointers(lmp)
    for some file servers it is most efficient to only read or only write
 ------------------------------------------------------------------------- */
 
-void RestartMPIIO::openForRead(char *filename)
+void RestartMPIIO::openForRead(const char *filename)
 {
   int err = MPI_File_open(world, filename, MPI_MODE_RDONLY ,
                           MPI_INFO_NULL, &mpifh);
@@ -56,7 +56,7 @@ void RestartMPIIO::openForRead(char *filename)
    for some file servers it is most efficient to only read or only write
 ------------------------------------------------------------------------- */
 
-void RestartMPIIO::openForWrite(char *filename)
+void RestartMPIIO::openForWrite(const char *filename)
 {
   int err = MPI_File_open(world, filename, MPI_MODE_WRONLY,
                           MPI_INFO_NULL, &mpifh);

--- a/src/MPIIO/restart_mpiio.cpp
+++ b/src/MPIIO/restart_mpiio.cpp
@@ -22,6 +22,14 @@
 
 using namespace LAMMPS_NS;
 
+// the (rather old) version of ROMIO in MPICH for Windows
+// uses "char *" instead of "const char *". This works around it.
+#if defined(_WIN32)
+#define ROMIO_COMPAT_CAST (char *)
+#else
+#define ROMIO_COMPAT_CAST
+#endif
+
 /* ---------------------------------------------------------------------- */
 
 RestartMPIIO::RestartMPIIO(LAMMPS *lmp) : Pointers(lmp)
@@ -38,7 +46,7 @@ RestartMPIIO::RestartMPIIO(LAMMPS *lmp) : Pointers(lmp)
 
 void RestartMPIIO::openForRead(const char *filename)
 {
-  int err = MPI_File_open(world, filename, MPI_MODE_RDONLY ,
+  int err = MPI_File_open(world, ROMIO_COMPAT_CAST filename, MPI_MODE_RDONLY,
                           MPI_INFO_NULL, &mpifh);
   if (err != MPI_SUCCESS) {
     char str[MPI_MAX_ERROR_STRING+128];
@@ -58,7 +66,7 @@ void RestartMPIIO::openForRead(const char *filename)
 
 void RestartMPIIO::openForWrite(const char *filename)
 {
-  int err = MPI_File_open(world, filename, MPI_MODE_WRONLY,
+  int err = MPI_File_open(world, ROMIO_COMPAT_CAST filename, MPI_MODE_WRONLY,
                           MPI_INFO_NULL, &mpifh);
   if (err != MPI_SUCCESS) {
     char str[MPI_MAX_ERROR_STRING+128];

--- a/src/MPIIO/restart_mpiio.h
+++ b/src/MPIIO/restart_mpiio.h
@@ -28,8 +28,8 @@ class RestartMPIIO  : protected Pointers {
 
   RestartMPIIO(class LAMMPS *);
   ~RestartMPIIO() {}
-  void openForRead(char *);
-  void openForWrite(char *);
+  void openForRead(const char *);
+  void openForWrite(const char *);
   void write(MPI_Offset, int, double *);
   void read(MPI_Offset, bigint, double *);
   void close();

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -2406,7 +2406,7 @@ void FixRigid::readfile(int which, double *vec,
    only proc 0 writes list of global bodies to file
 ------------------------------------------------------------------------- */
 
-void FixRigid::write_restart_file(char *file)
+void FixRigid::write_restart_file(const char *file)
 {
   if (me) return;
 

--- a/src/RIGID/fix_rigid.h
+++ b/src/RIGID/fix_rigid.h
@@ -36,7 +36,7 @@ class FixRigid : public Fix {
   virtual void final_integrate();
   void initial_integrate_respa(int, int, int);
   void final_integrate_respa(int, int);
-  void write_restart_file(char *);
+  void write_restart_file(const char *);
   virtual double compute_scalar();
 
   double memory_usage();

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -2562,7 +2562,7 @@ void FixRigidSmall::readfile(int which, double **array, int *inbody)
    each proc contributes info for rigid bodies it owns
 ------------------------------------------------------------------------- */
 
-void FixRigidSmall::write_restart_file(char *file)
+void FixRigidSmall::write_restart_file(const char *file)
 {
   FILE *fp;
 

--- a/src/RIGID/fix_rigid_small.h
+++ b/src/RIGID/fix_rigid_small.h
@@ -38,7 +38,7 @@ class FixRigidSmall : public Fix {
   virtual void final_integrate();
   void initial_integrate_respa(int, int, int);
   void final_integrate_respa(int, int);
-  void write_restart_file(char *);
+  void write_restart_file(const char *);
 
   void grow_arrays(int);
   void copy_arrays(int, int, int);

--- a/src/angle_deprecated.cpp
+++ b/src/angle_deprecated.cpp
@@ -16,7 +16,7 @@
 ------------------------------------------------------------------------- */
 
 #include "angle_deprecated.h"
-#include <cstring>
+#include <string>
 #include "angle_hybrid.h"
 #include "comm.h"
 #include "force.h"
@@ -25,21 +25,11 @@
 
 using namespace LAMMPS_NS;
 
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This angle style is no longer available");
-}
-
 /* ---------------------------------------------------------------------- */
 
 void AngleDeprecated::settings(int, char **)
 {
-  const char *my_style = force->angle_style;
+  std::string my_style = force->angle_style;
 
   // hybrid substyles are created in AngleHybrid::settings(), so when this is
   // called, our style was just added at the end of the list of substyles
@@ -49,10 +39,13 @@ void AngleDeprecated::settings(int, char **)
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 
-  if (strcmp(my_style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nAngle style 'DEPRECATED' is a dummy style\n\n",0);
-
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nAngle style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+
+  lmp->error->all(FLERR,"This angle style is no longer available");
 }
 
 

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -16,6 +16,7 @@
 #include <climits>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include "style_atom.h"
 #include "atom_vec.h"
 #include "atom_vec_ellipsoid.h"
@@ -681,7 +682,7 @@ void Atom::set_atomflag_defaults()
    called from lammps.cpp, input script, restart file, replicate
 ------------------------------------------------------------------------- */
 
-void Atom::create_avec(const char *style, int narg, char **arg, int trysuffix)
+void Atom::create_avec(const std::string &style, int narg, char **arg, int trysuffix)
 {
   delete [] atom_style;
   if (avec) delete avec;
@@ -704,16 +705,14 @@ void Atom::create_avec(const char *style, int narg, char **arg, int trysuffix)
   avec->grow(1);
 
   if (sflag) {
-    char estyle[256];
-    if (sflag == 1) snprintf(estyle,256,"%s/%s",style,lmp->suffix);
-    else snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
-    int n = strlen(estyle) + 1;
-    atom_style = new char[n];
-    strcpy(atom_style,estyle);
+    std::string estyle = style + "/";
+    if (sflag == 1) estyle += lmp->suffix;
+    else estyle += lmp->suffix2;
+    atom_style = new char[estyle.size()+1];
+    strcpy(atom_style,estyle.c_str());
   } else {
-    int n = strlen(style) + 1;
-    atom_style = new char[n];
-    strcpy(atom_style,style);
+    atom_style = new char[style.size()+1];
+    strcpy(atom_style,style.c_str());
   }
 
   // if molecular system:
@@ -731,13 +730,12 @@ void Atom::create_avec(const char *style, int narg, char **arg, int trysuffix)
    generate an AtomVec class, first with suffix appended
 ------------------------------------------------------------------------- */
 
-AtomVec *Atom::new_avec(const char *style, int trysuffix, int &sflag)
+AtomVec *Atom::new_avec(const std::string &style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (avec_map->find(estyle) != avec_map->end()) {
         AtomVecCreator avec_creator = (*avec_map)[estyle];
         return avec_creator(lmp);
@@ -746,8 +744,7 @@ AtomVec *Atom::new_avec(const char *style, int trysuffix, int &sflag)
 
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + "/" + lmp->suffix2;
       if (avec_map->find(estyle) != avec_map->end()) {
         AtomVecCreator avec_creator = (*avec_map)[estyle];
         return avec_creator(lmp);

--- a/src/atom.h
+++ b/src/atom.h
@@ -262,8 +262,8 @@ class Atom : protected Pointers {
   void add_peratom_change_columns(const char *, int);
   void add_peratom_vary(const char *, void *, int, int *,
                         void *, int collength=0);
-  void create_avec(const char *, int, char **, int);
-  virtual class AtomVec *new_avec(const char *, int, int &);
+  void create_avec(const std::string &, int, char **, int);
+  virtual class AtomVec *new_avec(const std::string &, int, int &);
 
   void init();
   void setup();

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -25,6 +25,7 @@
 #include "error.h"
 #include "utils.h"
 #include "tokenizer.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -1837,7 +1838,7 @@ void AtomVec::write_data(FILE *fp, int n, double **buf)
   int i,j,m,nn,datatype,cols;
 
   for (i = 0; i < n; i++) {
-    fprintf(fp,TAGINT_FORMAT,(tagint) ubuf(buf[i][0]).i);
+    fmt::print(fp,"{}",(tagint) ubuf(buf[i][0]).i);
 
     j = 1;
     for (nn = 1; nn < ndata_atom; nn++) {
@@ -1859,10 +1860,10 @@ void AtomVec::write_data(FILE *fp, int n, double **buf)
         }
       } else if (datatype == BIGINT) {
         if (cols == 0) {
-          fprintf(fp," " BIGINT_FORMAT,(bigint) ubuf(buf[i][j++]).i);
+          fmt::print(fp," {}",(bigint) ubuf(buf[i][j++]).i);
         } else {
           for (m = 0; m < cols; m++)
-            fprintf(fp," " BIGINT_FORMAT,(bigint) ubuf(buf[i][j++]).i);
+            fmt::print(fp," {}",(bigint) ubuf(buf[i][j++]).i);
         }
       }
     }
@@ -1985,7 +1986,7 @@ void AtomVec::write_vel(FILE *fp, int n, double **buf)
   int i,j,m,nn,datatype,cols;
 
   for (i = 0; i < n; i++) {
-    fprintf(fp,TAGINT_FORMAT,(tagint) ubuf(buf[i][0]).i);
+    fmt::print(fp,"{}",(tagint) ubuf(buf[i][0]).i);
 
     j = 1;
     for (nn = 1; nn < ndata_vel; nn++) {
@@ -2007,10 +2008,10 @@ void AtomVec::write_vel(FILE *fp, int n, double **buf)
         }
       } else if (datatype == BIGINT) {
         if (cols == 0) {
-          fprintf(fp," " BIGINT_FORMAT,(bigint) ubuf(buf[i][j++]).i);
+          fmt::print(fp," {}",(bigint) ubuf(buf[i][j++]).i);
         } else {
           for (m = 0; m < cols; m++)
-            fprintf(fp," " BIGINT_FORMAT,(bigint) ubuf(buf[i][j++]).i);
+            fmt::print(fp," {}",(bigint) ubuf(buf[i][j++]).i);
         }
       }
     }

--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -16,7 +16,7 @@
      Axel Kohlmeyer (Temple U), Iain Bethune (EPCC)
 ------------------------------------------------------------------------- */
 
-//#define BALANCE_DEBUG 1
+// #define BALANCE_DEBUG 1
 
 #include "balance.h"
 #include <mpi.h>
@@ -1160,8 +1160,7 @@ void Balance::dumpout(bigint tstep)
   double *boxlo = domain->boxlo;
   double *boxhi = domain->boxhi;
 
-  fprintf(fp,"ITEM: TIMESTEP\n");
-  fprintf(fp,BIGINT_FORMAT "\n",tstep);
+  fmt::print(fp,"ITEM: TIMESTEP\n{}\n",tstep);
   fprintf(fp,"ITEM: NUMBER OF NODES\n");
   if (dimension == 2) fprintf(fp,"%d\n",4*nprocs);
   else fprintf(fp,"%d\n",8*nprocs);
@@ -1236,8 +1235,7 @@ void Balance::dumpout(bigint tstep)
 
   // write out one square/cube per processor for 2d/3d
 
-  fprintf(fp,"ITEM: TIMESTEP\n");
-  fprintf(fp,BIGINT_FORMAT "\n",tstep);
+  fmt::print(fp,"ITEM: TIMESTEP\n{}\n",tstep);
   if (dimension == 2) fprintf(fp,"ITEM: NUMBER OF SQUARES\n");
   else fprintf(fp,"ITEM: NUMBER OF CUBES\n");
   fprintf(fp,"%d\n",nprocs);
@@ -1281,14 +1279,11 @@ void Balance::debug_shift_output(int idim, int m, int np, double *split)
   else if (bdim[idim] == Z) dim = "Z";
   fprintf(stderr,"Dimension %s, Iteration %d\n",dim,m);
 
-  fprintf(stderr,"  Count:");
-  for (i = 0; i < np; i++) fprintf(stderr," " BIGINT_FORMAT,count[i]);
-  fprintf(stderr,"\n");
   fprintf(stderr,"  Sum:");
-  for (i = 0; i <= np; i++) fprintf(stderr," " BIGINT_FORMAT,sum[i]);
+  for (i = 0; i <= np; i++) fmt::print(stderr," {}",sum[i]);
   fprintf(stderr,"\n");
   fprintf(stderr,"  Target:");
-  for (i = 0; i <= np; i++) fprintf(stderr," " BIGINT_FORMAT,target[i]);
+  for (i = 0; i <= np; i++) fmt::print(stderr," {}",target[i]);
   fprintf(stderr,"\n");
   fprintf(stderr,"  Actual cut:");
   for (i = 0; i <= np; i++)
@@ -1301,20 +1296,16 @@ void Balance::debug_shift_output(int idim, int m, int np, double *split)
   for (i = 0; i <= np; i++) fprintf(stderr," %g",lo[i]);
   fprintf(stderr,"\n");
   fprintf(stderr,"  Low-sum:");
-  for (i = 0; i <= np; i++) fprintf(stderr," " BIGINT_FORMAT,losum[i]);
+  for (i = 0; i <= np; i++) fmt::print(stderr," {}",losum[i]);
   fprintf(stderr,"\n");
   fprintf(stderr,"  Hi:");
   for (i = 0; i <= np; i++) fprintf(stderr," %g",hi[i]);
   fprintf(stderr,"\n");
   fprintf(stderr,"  Hi-sum:");
-  for (i = 0; i <= np; i++) fprintf(stderr," " BIGINT_FORMAT,hisum[i]);
+  for (i = 0; i <= np; i++) fmt::print(stderr," {}",hisum[i]);
   fprintf(stderr,"\n");
   fprintf(stderr,"  Delta:");
   for (i = 0; i < np; i++) fprintf(stderr," %g",split[i+1]-split[i]);
   fprintf(stderr,"\n");
-
-  bigint max = 0;
-  for (i = 0; i < np; i++) max = MAX(max,count[i]);
-  fprintf(stderr,"  Imbalance factor: %g\n",1.0*max*np/target[np]);
 }
 #endif

--- a/src/bond_deprecated.cpp
+++ b/src/bond_deprecated.cpp
@@ -16,42 +16,36 @@
 ------------------------------------------------------------------------- */
 
 #include "bond_deprecated.h"
-#include <cstring>
+#include <string>
 #include "bond_hybrid.h"
 #include "comm.h"
 #include "force.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This bond style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 void BondDeprecated::settings(int, char **)
 {
-  const char *my_style = force->bond_style;
+  std::string my_style = force->bond_style;
 
   // hybrid substyles are created in BondHybrid::settings(), so when this is
   // called, our style was just added at the end of the list of substyles
 
-  if (strncmp(my_style,"hybrid",6) == 0) {
+  if (utils::strmatch(my_style,"^hybrid")) {
     BondHybrid *hybrid = (BondHybrid *)force->bond;
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 
-  if (strcmp(my_style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nBond style 'DEPRECATED' is a dummy style\n\n",0);
-
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nBond style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+
+  lmp->error->all(FLERR,"This bond style is no longer available");
 }
 
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -35,6 +35,7 @@
 #include "memory.h"
 #include "error.h"
 #include "update.h"
+#include "fmt/format.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -1220,35 +1221,31 @@ void Comm::rendezvous_stats(int n, int nout, int nrvous, int nrvous_out,
   if (me == 0) {
     if (screen) {
       fprintf(screen,"Rendezvous balance and memory info: (tot,ave,max,min) \n");
-      fprintf(screen,"  input datum count: "
-              BIGINT_FORMAT " %g " BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-              size_in_all/insize,1.0*size_in_all/nprocs/insize,
-              size_in_max/insize,size_in_min/insize);
+      fmt::print(screen,"  input datum count: {} {} {} {}\n",
+                 size_in_all/insize,1.0*size_in_all/nprocs/insize,
+                 size_in_max/insize,size_in_min/insize);
       fprintf(screen,"  input data (MB): %g %g %g %g\n",
               1.0*size_in_all/mbytes,1.0*size_in_all/nprocs/mbytes,
               1.0*size_in_max/mbytes,1.0*size_in_min/mbytes);
       if (outsize)
-        fprintf(screen,"  output datum count: "
-                BIGINT_FORMAT " %g " BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-                size_out_all/outsize,1.0*size_out_all/nprocs/outsize,
-                size_out_max/outsize,size_out_min/outsize);
+        fmt::print(screen,"  output datum count: {} {} {} {}\n",
+                   size_out_all/outsize,1.0*size_out_all/nprocs/outsize,
+                   size_out_max/outsize,size_out_min/outsize);
       else
         fprintf(screen,"  output datum count: %d %g %d %d\n",0,0.0,0,0);
       fprintf(screen,"  output data (MB): %g %g %g %g\n",
               1.0*size_out_all/mbytes,1.0*size_out_all/nprocs/mbytes,
               1.0*size_out_max/mbytes,1.0*size_out_min/mbytes);
-      fprintf(screen,"  input rvous datum count: "
-              BIGINT_FORMAT " %g " BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-              size_inrvous_all/insize,1.0*size_inrvous_all/nprocs/insize,
-              size_inrvous_max/insize,size_inrvous_min/insize);
+      fmt::print(screen,"  input rvous datum count: {} {} {} {}\n",
+                 size_inrvous_all/insize,1.0*size_inrvous_all/nprocs/insize,
+                 size_inrvous_max/insize,size_inrvous_min/insize);
       fprintf(screen,"  input rvous data (MB): %g %g %g %g\n",
               1.0*size_inrvous_all/mbytes,1.0*size_inrvous_all/nprocs/mbytes,
               1.0*size_inrvous_max/mbytes,1.0*size_inrvous_min/mbytes);
       if (outsize)
-        fprintf(screen,"  output rvous datum count: "
-                BIGINT_FORMAT " %g " BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-                size_outrvous_all/outsize,1.0*size_outrvous_all/nprocs/outsize,
-                size_outrvous_max/outsize,size_outrvous_min/outsize);
+        fmt::print(screen,"  output rvous datum count: {} {} {} {}\n",
+                   size_outrvous_all/outsize,1.0*size_outrvous_all/nprocs/outsize,
+                   size_outrvous_max/outsize,size_outrvous_min/outsize);
       else
         fprintf(screen,"  output rvous datum count: %d %g %d %d\n",0,0.0,0,0);
       fprintf(screen,"  output rvous data (MB): %g %g %g %g\n",

--- a/src/compute_deprecated.cpp
+++ b/src/compute_deprecated.cpp
@@ -12,28 +12,25 @@
 ------------------------------------------------------------------------- */
 
 #include "compute_deprecated.h"
-#include <cstring>
+#include <string>
 #include "comm.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This compute style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 ComputeDeprecated::ComputeDeprecated(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg)
 {
-  if (strcmp(style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nCompute style 'DEPRECATED' is a dummy style\n\n",0);
+  std::string my_style = style;
+
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nCompute style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+
+  lmp->error->all(FLERR,"This compute style is no longer available");
 }

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -587,7 +587,7 @@ void CreateAtoms::command(int narg, char **arg)
   MPI_Barrier(world);
   if (me == 0)
     utils::logmesg(lmp, fmt::format("Created {} atoms\n"
-                        "  create_atoms CPU = {:.3g} seconds\n",
+                        "  create_atoms CPU = {:.3f} seconds\n",
                         atom->natoms - natoms_previous,
                         MPI_Wtime() - time1));
 }

--- a/src/create_bonds.cpp
+++ b/src/create_bonds.cpp
@@ -20,6 +20,7 @@
 #include "create_bonds.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "domain.h"
 #include "force.h"
@@ -30,6 +31,8 @@
 #include "group.h"
 #include "special.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -318,19 +321,9 @@ void CreateBonds::many()
 
   bigint nadd_bonds = atom->nbonds - nbonds_previous;
 
-  if (comm->me == 0) {
-    if (screen) {
-      fprintf(screen,"Added " BIGINT_FORMAT
-              " bonds, new total = " BIGINT_FORMAT "\n",
-              nadd_bonds,atom->nbonds);
-    }
-
-    if (logfile) {
-      fprintf(logfile,"Added " BIGINT_FORMAT
-              " bonds, new total = " BIGINT_FORMAT "\n",
-              nadd_bonds,atom->nbonds);
-    }
-  }
+  if (comm->me == 0)
+    utils::logmesg(lmp,fmt::format("Added {} bonds, new total = {}\n",
+                                   nadd_bonds,atom->nbonds));
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -34,8 +34,11 @@
 #include "random_mars.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 #include <map>
+#include <string>
 
 using namespace LAMMPS_NS;
 
@@ -176,53 +179,23 @@ void DeleteAtoms::command(int narg, char **arg)
   bigint ndelete_impropers = nimpropers_previous - atom->nimpropers;
 
   if (comm->me == 0) {
-    if (screen) {
-      fprintf(screen,"Deleted " BIGINT_FORMAT
-              " atoms, new total = " BIGINT_FORMAT "\n",
-              ndelete,atom->natoms);
-      if (bond_flag || mol_flag) {
-        if (nbonds_previous)
-          fprintf(screen,"Deleted " BIGINT_FORMAT
-                  " bonds, new total = " BIGINT_FORMAT "\n",
-                  ndelete_bonds,atom->nbonds);
-        if (nangles_previous)
-          fprintf(screen,"Deleted " BIGINT_FORMAT
-                  " angles, new total = " BIGINT_FORMAT "\n",
-                  ndelete_angles,atom->nangles);
-        if (ndihedrals_previous)
-          fprintf(screen,"Deleted " BIGINT_FORMAT
-                  " dihedrals, new total = " BIGINT_FORMAT "\n",
-                  ndelete_dihedrals,atom->ndihedrals);
-        if (nimpropers_previous)
-          fprintf(screen,"Deleted " BIGINT_FORMAT
-                  " impropers, new total = " BIGINT_FORMAT "\n",
-                  ndelete_impropers,atom->nimpropers);
-      }
+    std::string mesg = fmt::format("Deleted {} atoms, new total = {}\n",
+                                   ndelete,atom->natoms);
+    if (bond_flag || mol_flag) {
+      if (nbonds_previous)
+        mesg += fmt::format("Deleted {} bonds, new total = {}\n",
+                            ndelete_bonds,atom->nbonds);
+      if (nangles_previous)
+        mesg += fmt::format("Deleted {} angles, new total = {}\n",
+                            ndelete_angles,atom->nangles);
+      if (ndihedrals_previous)
+        mesg += fmt::format("Deleted {} dihedrals, new total = {}\n",
+                            ndelete_dihedrals,atom->ndihedrals);
+      if (nimpropers_previous)
+        mesg += fmt::format("Deleted {} impropers, new total = {}\n",
+                            ndelete_impropers,atom->nimpropers);
     }
-
-    if (logfile) {
-      fprintf(logfile,"Deleted " BIGINT_FORMAT
-              " atoms, new total = " BIGINT_FORMAT "\n",
-              ndelete,atom->natoms);
-      if (bond_flag || mol_flag) {
-        if (nbonds_previous)
-          fprintf(logfile,"Deleted " BIGINT_FORMAT
-                  " bonds, new total = " BIGINT_FORMAT "\n",
-                  ndelete_bonds,atom->nbonds);
-        if (nangles_previous)
-          fprintf(logfile,"Deleted " BIGINT_FORMAT
-                  " angles, new total = " BIGINT_FORMAT "\n",
-                  ndelete_angles,atom->nangles);
-        if (ndihedrals_previous)
-          fprintf(logfile,"Deleted " BIGINT_FORMAT
-                  " dihedrals, new total = " BIGINT_FORMAT "\n",
-                  ndelete_dihedrals,atom->ndihedrals);
-        if (nimpropers_previous)
-          fprintf(logfile,"Deleted " BIGINT_FORMAT
-                  " impropers, new total = " BIGINT_FORMAT "\n",
-                  ndelete_impropers,atom->nimpropers);
-      }
-    }
+    utils::logmesg(lmp,mesg);
   }
 }
 

--- a/src/delete_bonds.cpp
+++ b/src/delete_bonds.cpp
@@ -15,6 +15,7 @@
 #include <mpi.h>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "atom_vec.h"
 #include "domain.h"
@@ -23,6 +24,8 @@
 #include "group.h"
 #include "special.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -535,50 +538,25 @@ void DeleteBonds::command(int narg, char **arg)
   }
 
   if (comm->me == 0) {
-    if (atom->avec->bonds_allow) {
-      if (screen) fprintf(screen,
-                          "  " BIGINT_FORMAT " total bonds, " BIGINT_FORMAT
-                          " turned on, " BIGINT_FORMAT " turned off\n",
-                          atom->nbonds,bond_on,bond_off);
-      if (logfile) fprintf(logfile,
-                           "  " BIGINT_FORMAT " total bonds, " BIGINT_FORMAT
-                           " turned on, " BIGINT_FORMAT " turned off\n",
-                           atom->nbonds,bond_on,bond_off);
-    }
-    if (atom->avec->angles_allow) {
-      if (screen) fprintf(screen,
-                          "  " BIGINT_FORMAT " total angles, " BIGINT_FORMAT
-                          " turned on, " BIGINT_FORMAT " turned off\n",
-                          atom->nangles,angle_on,angle_off);
-      if (logfile) fprintf(logfile,
-                          "  " BIGINT_FORMAT " total angles, " BIGINT_FORMAT
-                           " turned on, " BIGINT_FORMAT " turned off\n",
-                           atom->nangles,angle_on,angle_off);
-    }
-    if (atom->avec->dihedrals_allow) {
-      if (screen) fprintf(screen,
-                          "  " BIGINT_FORMAT " total dihedrals, "
-                          BIGINT_FORMAT " turned on, " BIGINT_FORMAT
-                          " turned off\n",
-                          atom->ndihedrals,dihedral_on,dihedral_off);
-      if (logfile) fprintf(logfile,
-                          "  " BIGINT_FORMAT " total dihedrals, "
-                          BIGINT_FORMAT " turned on, " BIGINT_FORMAT
-                          " turned off\n",
-                          atom->ndihedrals,dihedral_on,dihedral_off);
-    }
-    if (atom->avec->impropers_allow) {
-      if (screen) fprintf(screen,
-                          "  " BIGINT_FORMAT " total impropers, "
-                          BIGINT_FORMAT " turned on, " BIGINT_FORMAT
-                          " turned off\n",
-                          atom->nimpropers,improper_on,improper_off);
-      if (logfile) fprintf(logfile,
-                          "  " BIGINT_FORMAT " total impropers, "
-                          BIGINT_FORMAT " turned on, " BIGINT_FORMAT
-                          " turned off\n",
-                          atom->nimpropers,improper_on,improper_off);
-    }
+    if (atom->avec->bonds_allow)
+      utils::logmesg(lmp,fmt::format("  {} total bonds, "
+                                     "{} turned on, {} turned off\n",
+                                     atom->nbonds,bond_on,bond_off));
+
+    if (atom->avec->angles_allow)
+      utils::logmesg(lmp,fmt::format("  {} total angles, "
+                                     "{} turned on, {} turned off\n",
+                                     atom->nangles,angle_on,angle_off));
+
+    if (atom->avec->dihedrals_allow)
+      utils::logmesg(lmp,fmt::format("  {} total dihedrals, "
+                                     "{} turned on, {} turned off\n",
+                                     atom->ndihedrals,dihedral_on,dihedral_off));
+
+    if (atom->avec->impropers_allow)
+      utils::logmesg(lmp,fmt::format("  {} total impropers, "
+                                     "{} turned on, {} turned off\n",
+                                     atom->nimpropers,improper_on,improper_off));
   }
 
   // re-compute special list if requested

--- a/src/dihedral_deprecated.cpp
+++ b/src/dihedral_deprecated.cpp
@@ -16,42 +16,35 @@
 ------------------------------------------------------------------------- */
 
 #include "dihedral_deprecated.h"
-#include <cstring>
+#include <string>
 #include "dihedral_hybrid.h"
 #include "comm.h"
 #include "force.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This dihedral style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 void DihedralDeprecated::settings(int, char **)
 {
-  const char *my_style = force->dihedral_style;
+  std::string my_style = force->dihedral_style;
 
-  // hybrid substyles are created in DihedralHybrid::settings(), so when this is
-  // called, our style was just added at the end of the list of substyles
+  // hybrid substyles are created in DihedralHybrid::settings(),
+  // so when this is called, our style was just added at the end
+  // of the list of substyles
 
-  if (strncmp(my_style,"hybrid",6) == 0) {
+  if (utils::strmatch(my_style,"^hybrid")) {
     DihedralHybrid *hybrid = (DihedralHybrid *)force->dihedral;
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 
-  if (strcmp(my_style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nDihedral style 'DEPRECATED' is a dummy style\n\n",0);
-
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nDihedral style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+
+  lmp->error->all(FLERR,"This dihedral style is no longer available");
 }
-
-

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1762,8 +1762,8 @@ void Domain::add_region(int narg, char **arg)
 
   if (lmp->suffix_enable) {
     if (lmp->suffix) {
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",arg[1],lmp->suffix);
+      std::string estyle = arg[1];
+      estyle += std::string("/") + lmp->suffix;
       if (region_map->find(estyle) != region_map->end()) {
         RegionCreator region_creator = (*region_map)[estyle];
         regions[nregion] = region_creator(lmp, narg, arg);
@@ -1774,8 +1774,8 @@ void Domain::add_region(int narg, char **arg)
     }
 
     if (lmp->suffix2) {
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",arg[1],lmp->suffix2);
+      std::string estyle = arg[1];
+      estyle += std::string("/") + lmp->suffix2;
       if (region_map->find(estyle) != region_map->end()) {
         RegionCreator region_creator = (*region_map)[estyle];
         regions[nregion] = region_creator(lmp, narg, arg);

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1762,8 +1762,7 @@ void Domain::add_region(int narg, char **arg)
 
   if (lmp->suffix_enable) {
     if (lmp->suffix) {
-      std::string estyle = arg[1];
-      estyle += std::string("/") + lmp->suffix;
+      std::string estyle = std::string(arg[1]) + "/" + lmp->suffix;
       if (region_map->find(estyle) != region_map->end()) {
         RegionCreator region_creator = (*region_map)[estyle];
         regions[nregion] = region_creator(lmp, narg, arg);
@@ -1774,8 +1773,7 @@ void Domain::add_region(int narg, char **arg)
     }
 
     if (lmp->suffix2) {
-      std::string estyle = arg[1];
-      estyle += std::string("/") + lmp->suffix2;
+      std::string estyle = std::string(arg[1]) + "/" + lmp->suffix2;
       if (region_map->find(estyle) != region_map->end()) {
         RegionCreator region_creator = (*region_map)[estyle];
         regions[nregion] = region_creator(lmp, narg, arg);

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -39,6 +39,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -1935,33 +1936,20 @@ void Domain::set_box(int narg, char **arg)
    print box info, orthogonal or triclinic
 ------------------------------------------------------------------------- */
 
-void Domain::print_box(const char *str)
+void Domain::print_box(const std::string &prefix)
 {
   if (comm->me == 0) {
-    if (screen) {
-      if (triclinic == 0)
-        fprintf(screen,"%sorthogonal box = (%g %g %g) to (%g %g %g)\n",
-                str,boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
-      else {
-        char *format = (char *)
-          "%striclinic box = (%g %g %g) to (%g %g %g) with tilt (%g %g %g)\n";
-        fprintf(screen,format,
-                str,boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2],
-                xy,xz,yz);
-      }
+    std::string mesg = prefix;
+    if (triclinic == 0) {
+      mesg += fmt::format("orthogonal box = ({} {} {}) to ({} {} {})\n",
+                          boxlo[0],boxlo[1],boxlo[2],
+                          boxhi[0],boxhi[1],boxhi[2]);
+    } else {
+      mesg += fmt::format("triclinic box = ({} {} {}) to ({} {} {}) "
+                          "with tilt ({} {} {})\n",boxlo[0],boxlo[1],
+                          boxlo[2],boxhi[0],boxhi[1],boxhi[2],xy,xz,yz);
     }
-    if (logfile) {
-      if (triclinic == 0)
-        fprintf(logfile,"%sorthogonal box = (%g %g %g) to (%g %g %g)\n",
-                str,boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
-      else {
-        char *format = (char *)
-          "%striclinic box = (%g %g %g) to (%g %g %g) with tilt (%g %g %g)\n";
-        fprintf(logfile,format,
-                str,boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2],
-                xy,xz,yz);
-      }
-    }
+    utils::logmesg(lmp,mesg);
   }
 }
 

--- a/src/domain.h
+++ b/src/domain.h
@@ -131,7 +131,7 @@ class Domain : protected Pointers {
   int find_region(char *);
   void set_boundary(int, char **, int);
   void set_box(int, char **);
-  void print_box(const char *);
+  void print_box(const std::string &);
   void boundary_string(char *);
 
   virtual void lamda2x(int);

--- a/src/dump_deprecated.cpp
+++ b/src/dump_deprecated.cpp
@@ -12,29 +12,25 @@
 ------------------------------------------------------------------------- */
 
 #include "dump_deprecated.h"
-#include <cstring>
+#include <string>
 #include "comm.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This dump style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 DumpDeprecated::DumpDeprecated(LAMMPS *lmp, int narg, char **arg) :
   Dump(lmp, narg, arg)
 {
-  if (strcmp(style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nDump style 'DEPRECATED' is a dummy style\n\n",0);
+  std::string my_style = style;
 
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nDump style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+
+  lmp->error->all(FLERR,"This dump style is no longer available");
 }

--- a/src/fix.h
+++ b/src/fix.h
@@ -137,7 +137,7 @@ class Fix : protected Pointers {
   virtual void end_of_step() {}
   virtual void post_run() {}
   virtual void write_restart(FILE *) {}
-  virtual void write_restart_file(char *) {}
+  virtual void write_restart_file(const char *) {}
   virtual void restart(char *) {}
 
   virtual void grow_arrays(int) {}

--- a/src/fix_deprecated.cpp
+++ b/src/fix_deprecated.cpp
@@ -12,39 +12,37 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_deprecated.h"
-#include <cstring>
+#include <string>
 #include "comm.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This fix style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 FixDeprecated::FixDeprecated(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg)
 {
-  if (strcmp(style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nFix style 'DEPRECATED' is a dummy style\n\n",0);
+  std::string my_style = style;
 
-  } else if (strncmp(style,"ave/spatial",11) == 0) {
-    writemsg(lmp,"\nFix styles 'ave/spatial' and 'ave/spatial/sphere' have "
-             "been replaced\nby the more general fix ave/chunk and compute "
-             "chunk/atom commands.\nAll ave/spatial and ave/spatial/sphere "
-             "functionality is available in these\nnew commands. These "
-             "ave/spatial keywords & options are part of fix ave/chunk:\n"
-             "  Nevery, Nrepeat, Nfreq, input values, norm, ave, file, "
-             "overwrite, title123\nThese ave/spatial keywords & options for "
-             "binning are part of compute chunk/atom:\n  dim, origin, delta,"
-             " region, bound, discard, units\n\n");
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nFix style 'DEPRECATED' is a dummy style\n\n");
+    return;
+  } else if (utils::strmatch(my_style,"^ave/spatial")) {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nFix styles 'ave/spatial' and 'ave/spatial/sphere'"
+                     " have been replaced\nby the more general fix ave/chunk "
+                     "and compute chunk/atom commands.\nAll ave/spatial and "
+                     "ave/spatial/sphere functionality is available in these"
+                     "\nnew commands. These ave/spatial keywords & options are"
+                     " part of fix ave/chunk:\n  Nevery, Nrepeat, Nfreq, input"
+                     " values, norm, ave, file, overwrite, title123\nThese "
+                     "ave/spatial keywords & options for binning are part of "
+                     "compute chunk/atom:\n  dim, origin, delta, region, "
+                     "bound, discard, units\n\n");
   }
+
+  lmp->error->all(FLERR,"This fix style is no longer available");
 }

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -234,7 +234,7 @@ void Force::setup()
    create a pair style, called from input script or restart file
 ------------------------------------------------------------------------- */
 
-void Force::create_pair(const char *style, int trysuffix)
+void Force::create_pair(const std::string &style, int trysuffix)
 {
   delete [] pair_style;
   if (pair) delete pair;
@@ -254,13 +254,12 @@ void Force::create_pair(const char *style, int trysuffix)
    return sflag = 0 for no suffix added, 1 or 2 for suffix1/2 added
 ------------------------------------------------------------------------- */
 
-Pair *Force::new_pair(const char *style, int trysuffix, int &sflag)
+Pair *Force::new_pair(const std::string &style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (pair_map->find(estyle) != pair_map->end()) {
         PairCreator pair_creator = (*pair_map)[estyle];
         return pair_creator(lmp);
@@ -268,8 +267,7 @@ Pair *Force::new_pair(const char *style, int trysuffix, int &sflag)
     }
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + "/" + lmp->suffix2;
       if (pair_map->find(estyle) != pair_map->end()) {
         PairCreator pair_creator = (*pair_map)[estyle];
         return pair_creator(lmp);
@@ -278,7 +276,7 @@ Pair *Force::new_pair(const char *style, int trysuffix, int &sflag)
   }
 
   sflag = 0;
-  if (strcmp(style,"none") == 0) return NULL;
+  if (style == "none") return NULL;
   if (pair_map->find(style) != pair_map->end()) {
     PairCreator pair_creator = (*pair_map)[style];
     return pair_creator(lmp);
@@ -307,17 +305,17 @@ Pair *Force::pair_creator(LAMMPS *lmp)
    return NULL if no match or if nsub=0 and multiple sub-styles match
 ------------------------------------------------------------------------- */
 
-Pair *Force::pair_match(const char *word, int exact, int nsub)
+Pair *Force::pair_match(const std::string &word, int exact, int nsub)
 {
   int iwhich,count;
 
-  if (exact && strcmp(pair_style,word) == 0) return pair;
+  if (exact && (word == pair_style)) return pair;
   else if (!exact && utils::strmatch(pair_style,word)) return pair;
   else if (utils::strmatch(pair_style,"^hybrid")) {
     PairHybrid *hybrid = (PairHybrid *) pair;
     count = 0;
     for (int i = 0; i < hybrid->nstyles; i++)
-      if ((exact && strcmp(hybrid->keywords[i],word) == 0) ||
+      if ((exact && (word == hybrid->keywords[i])) ||
           (!exact && utils::strmatch(hybrid->keywords[i],word))) {
         iwhich = i;
         count++;
@@ -352,7 +350,7 @@ char *Force::pair_match_ptr(Pair *ptr)
    create a bond style, called from input script or restart file
 ------------------------------------------------------------------------- */
 
-void Force::create_bond(const char *style, int trysuffix)
+void Force::create_bond(const std::string &style, int trysuffix)
 {
   delete [] bond_style;
   if (bond) delete bond;
@@ -366,13 +364,12 @@ void Force::create_bond(const char *style, int trysuffix)
    generate a bond class, fist with suffix appended
 ------------------------------------------------------------------------- */
 
-Bond *Force::new_bond(const char *style, int trysuffix, int &sflag)
+Bond *Force::new_bond(const std::string &style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (bond_map->find(estyle) != bond_map->end()) {
         BondCreator bond_creator = (*bond_map)[estyle];
         return bond_creator(lmp);
@@ -381,8 +378,7 @@ Bond *Force::new_bond(const char *style, int trysuffix, int &sflag)
 
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + "/" + lmp->suffix2;
       if (bond_map->find(estyle) != bond_map->end()) {
         BondCreator bond_creator = (*bond_map)[estyle];
         return bond_creator(lmp);
@@ -391,7 +387,7 @@ Bond *Force::new_bond(const char *style, int trysuffix, int &sflag)
   }
 
   sflag = 0;
-  if (strcmp(style,"none") == 0) return NULL;
+  if (style == "none") return NULL;
   if (bond_map->find(style) != bond_map->end()) {
     BondCreator bond_creator = (*bond_map)[style];
     return bond_creator(lmp);
@@ -416,13 +412,13 @@ Bond *Force::bond_creator(LAMMPS *lmp)
    return ptr to current bond class or hybrid sub-class if matches style
 ------------------------------------------------------------------------- */
 
-Bond *Force::bond_match(const char *style)
+Bond *Force::bond_match(const std::string &style)
 {
-  if (strcmp(bond_style,style) == 0) return bond;
+  if (style == bond_style) return bond;
   else if (strcmp(bond_style,"hybrid") == 0) {
     BondHybrid *hybrid = (BondHybrid *) bond;
     for (int i = 0; i < hybrid->nstyles; i++)
-      if (strcmp(hybrid->keywords[i],style) == 0) return hybrid->styles[i];
+      if (style == hybrid->keywords[i]) return hybrid->styles[i];
   }
   return NULL;
 }
@@ -431,7 +427,7 @@ Bond *Force::bond_match(const char *style)
    create an angle style, called from input script or restart file
 ------------------------------------------------------------------------- */
 
-void Force::create_angle(const char *style, int trysuffix)
+void Force::create_angle(const std::string &style, int trysuffix)
 {
   delete [] angle_style;
   if (angle) delete angle;
@@ -445,13 +441,12 @@ void Force::create_angle(const char *style, int trysuffix)
    generate an angle class
 ------------------------------------------------------------------------- */
 
-Angle *Force::new_angle(const char *style, int trysuffix, int &sflag)
+Angle *Force::new_angle(const std::string &style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (angle_map->find(estyle) != angle_map->end()) {
         AngleCreator angle_creator = (*angle_map)[estyle];
         return angle_creator(lmp);
@@ -460,8 +455,7 @@ Angle *Force::new_angle(const char *style, int trysuffix, int &sflag)
 
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (angle_map->find(estyle) != angle_map->end()) {
         AngleCreator angle_creator = (*angle_map)[estyle];
         return angle_creator(lmp);
@@ -470,7 +464,7 @@ Angle *Force::new_angle(const char *style, int trysuffix, int &sflag)
   }
 
   sflag = 0;
-  if (strcmp(style,"none") == 0) return NULL;
+  if (style == "none") return NULL;
   if (angle_map->find(style) != angle_map->end()) {
     AngleCreator angle_creator = (*angle_map)[style];
     return angle_creator(lmp);
@@ -491,18 +485,17 @@ Angle *Force::angle_creator(LAMMPS *lmp)
   return new T(lmp);
 }
 
-
 /* ----------------------------------------------------------------------
    return ptr to current angle class or hybrid sub-class if matches style
 ------------------------------------------------------------------------- */
 
-Angle *Force::angle_match(const char *style)
+Angle *Force::angle_match(const std::string &style)
 {
-  if (strcmp(angle_style,style) == 0) return angle;
-  else if (strcmp(angle_style,"hybrid") == 0) {
+  if (style == angle_style) return angle;
+  else if (utils::strmatch(angle_style,"^hybrid")) {
     AngleHybrid *hybrid = (AngleHybrid *) angle;
     for (int i = 0; i < hybrid->nstyles; i++)
-      if (strcmp(hybrid->keywords[i],style) == 0) return hybrid->styles[i];
+      if (style == hybrid->keywords[i]) return hybrid->styles[i];
   }
   return NULL;
 }
@@ -511,7 +504,7 @@ Angle *Force::angle_match(const char *style)
    create a dihedral style, called from input script or restart file
 ------------------------------------------------------------------------- */
 
-void Force::create_dihedral(const char *style, int trysuffix)
+void Force::create_dihedral(const std::string &style, int trysuffix)
 {
   delete [] dihedral_style;
   if (dihedral) delete dihedral;
@@ -525,13 +518,12 @@ void Force::create_dihedral(const char *style, int trysuffix)
    generate a dihedral class
 ------------------------------------------------------------------------- */
 
-Dihedral *Force::new_dihedral(const char *style, int trysuffix, int &sflag)
+Dihedral *Force::new_dihedral(const std::string &style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (dihedral_map->find(estyle) != dihedral_map->end()) {
         DihedralCreator dihedral_creator = (*dihedral_map)[estyle];
         return dihedral_creator(lmp);
@@ -540,8 +532,7 @@ Dihedral *Force::new_dihedral(const char *style, int trysuffix, int &sflag)
 
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + "/" + lmp->suffix2;
       if (dihedral_map->find(estyle) != dihedral_map->end()) {
         DihedralCreator dihedral_creator = (*dihedral_map)[estyle];
         return dihedral_creator(lmp);
@@ -550,7 +541,7 @@ Dihedral *Force::new_dihedral(const char *style, int trysuffix, int &sflag)
   }
 
   sflag = 0;
-  if (strcmp(style,"none") == 0) return NULL;
+  if (style == "none") return NULL;
   if (dihedral_map->find(style) != dihedral_map->end()) {
     DihedralCreator dihedral_creator = (*dihedral_map)[style];
     return dihedral_creator(lmp);
@@ -575,13 +566,13 @@ Dihedral *Force::dihedral_creator(LAMMPS *lmp)
    return ptr to current angle class or hybrid sub-class if matches style
 ------------------------------------------------------------------------- */
 
-Dihedral *Force::dihedral_match(const char *style)
+Dihedral *Force::dihedral_match(const std::string &style)
 {
-  if (strcmp(dihedral_style,style) == 0) return dihedral;
-  else if (strcmp(dihedral_style,"hybrid") == 0) {
+  if (style == dihedral_style) return dihedral;
+  else if (utils::strmatch(dihedral_style,"^hybrid")) {
     DihedralHybrid *hybrid = (DihedralHybrid *) dihedral;
     for (int i = 0; i < hybrid->nstyles; i++)
-      if (strcmp(hybrid->keywords[i],style) == 0) return hybrid->styles[i];
+      if (style == hybrid->keywords[i]) return hybrid->styles[i];
   }
   return NULL;
 }
@@ -590,7 +581,7 @@ Dihedral *Force::dihedral_match(const char *style)
    create an improper style, called from input script or restart file
 ------------------------------------------------------------------------- */
 
-void Force::create_improper(const char *style, int trysuffix)
+void Force::create_improper(const std::string &style, int trysuffix)
 {
   delete [] improper_style;
   if (improper) delete improper;
@@ -604,13 +595,12 @@ void Force::create_improper(const char *style, int trysuffix)
    generate a improper class
 ------------------------------------------------------------------------- */
 
-Improper *Force::new_improper(const char *style, int trysuffix, int &sflag)
+Improper *Force::new_improper(const std::string &style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (improper_map->find(estyle) != improper_map->end()) {
         ImproperCreator improper_creator = (*improper_map)[estyle];
         return improper_creator(lmp);
@@ -619,8 +609,7 @@ Improper *Force::new_improper(const char *style, int trysuffix, int &sflag)
 
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + "/" + lmp->suffix2;
       if (improper_map->find(estyle) != improper_map->end()) {
         ImproperCreator improper_creator = (*improper_map)[estyle];
         return improper_creator(lmp);
@@ -629,7 +618,7 @@ Improper *Force::new_improper(const char *style, int trysuffix, int &sflag)
   }
 
   sflag = 0;
-  if (strcmp(style,"none") == 0) return NULL;
+  if (style == "none") return NULL;
   if (improper_map->find(style) != improper_map->end()) {
     ImproperCreator improper_creator = (*improper_map)[style];
     return improper_creator(lmp);
@@ -654,13 +643,13 @@ Improper *Force::improper_creator(LAMMPS *lmp)
    return ptr to current improper class or hybrid sub-class if matches style
 ------------------------------------------------------------------------- */
 
-Improper *Force::improper_match(const char *style)
+Improper *Force::improper_match(const std::string &style)
 {
-  if (strcmp(improper_style,style) == 0) return improper;
-  else if (strcmp(improper_style,"hybrid") == 0) {
+  if (style == improper_style) return improper;
+  else if (utils::strmatch(improper_style,"^hybrid")) {
     ImproperHybrid *hybrid = (ImproperHybrid *) improper;
     for (int i = 0; i < hybrid->nstyles; i++)
-      if (strcmp(hybrid->keywords[i],style) == 0) return hybrid->styles[i];
+      if (style == hybrid->keywords[i]) return hybrid->styles[i];
   }
   return NULL;
 }
@@ -669,7 +658,7 @@ Improper *Force::improper_match(const char *style)
    new kspace style
 ------------------------------------------------------------------------- */
 
-void Force::create_kspace(const char *style, int trysuffix)
+void Force::create_kspace(const std::string &style, int trysuffix)
 {
   delete [] kspace_style;
   if (kspace) delete kspace;
@@ -687,13 +676,12 @@ void Force::create_kspace(const char *style, int trysuffix)
    generate a kspace class
 ------------------------------------------------------------------------- */
 
-KSpace *Force::new_kspace(const char *style, int trysuffix, int &sflag)
+KSpace *Force::new_kspace(const std::string &style, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + "/" + lmp->suffix;
       if (kspace_map->find(estyle) != kspace_map->end()) {
         KSpaceCreator kspace_creator = (*kspace_map)[estyle];
         return kspace_creator(lmp);
@@ -702,8 +690,7 @@ KSpace *Force::new_kspace(const char *style, int trysuffix, int &sflag)
 
     if (lmp->suffix2) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + "/" + lmp->suffix2;
       if (kspace_map->find(estyle) != kspace_map->end()) {
         KSpaceCreator kspace_creator = (*kspace_map)[estyle];
         return kspace_creator(lmp);
@@ -712,7 +699,7 @@ KSpace *Force::new_kspace(const char *style, int trysuffix, int &sflag)
   }
 
   sflag = 0;
-  if (strcmp(style,"none") == 0) return NULL;
+  if (style == "none") return NULL;
   if (kspace_map->find(style) != kspace_map->end()) {
     KSpaceCreator kspace_creator = (*kspace_map)[style];
     return kspace_creator(lmp);
@@ -740,9 +727,9 @@ KSpace *Force::kspace_creator(LAMMPS *lmp)
    return NULL if no match
 ------------------------------------------------------------------------- */
 
-KSpace *Force::kspace_match(const char *word, int exact)
+KSpace *Force::kspace_match(const std::string &word, int exact)
 {
-  if (exact && strcmp(kspace_style,word) == 0) return kspace;
+  if (exact && (word == kspace_style)) return kspace;
   else if (!exact && utils::strmatch(kspace_style,word)) return kspace;
   return NULL;
 }
@@ -753,20 +740,15 @@ KSpace *Force::kspace_match(const char *word, int exact)
    if sflag = 1/2, append suffix or suffix2 to style
 ------------------------------------------------------------------------- */
 
-void Force::store_style(char *&str, const char *style, int sflag)
+void Force::store_style(char *&str, const std::string &style, int sflag)
 {
-  if (sflag) {
-    char estyle[256];
-    if (sflag == 1) snprintf(estyle,256,"%s/%s",style,lmp->suffix);
-    else snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
-    int n = strlen(estyle) + 1;
-    str = new char[n];
-    strcpy(str,estyle);
-  } else {
-    int n = strlen(style) + 1;
-    str = new char[n];
-    strcpy(str,style);
-  }
+  std::string estyle = style;
+
+  if (sflag == 1) estyle += std::string("/") + lmp->suffix;
+  else if (sflag == 2) estyle += std::string("/") + lmp->suffix2;
+
+  str = new char[estyle.size()+1];
+  strcpy(str,estyle.c_str());
 }
 
 /* ----------------------------------------------------------------------

--- a/src/force.h
+++ b/src/force.h
@@ -101,32 +101,32 @@ class Force : protected Pointers {
   void init();
   void setup();
 
-  void create_pair(const char *, int);
-  class Pair *new_pair(const char *, int, int &);
-  class Pair *pair_match(const char *, int, int nsub=0);
+  void create_pair(const std::string &, int);
+  class Pair *new_pair(const std::string &, int, int &);
+  class Pair *pair_match(const std::string &, int, int nsub=0);
   char *pair_match_ptr(Pair *);
 
-  void create_bond(const char *, int);
-  class Bond *new_bond(const char *, int, int &);
-  class Bond *bond_match(const char *);
+  void create_bond(const std::string &, int);
+  class Bond *new_bond(const std::string &, int, int &);
+  class Bond *bond_match(const std::string &);
 
-  void create_angle(const char *, int);
-  class Angle *new_angle(const char *, int, int &);
-  class Angle *angle_match(const char *);
+  void create_angle(const std::string &, int);
+  class Angle *new_angle(const std::string &, int, int &);
+  class Angle *angle_match(const std::string &);
 
-  void create_dihedral(const char *, int);
-  class Dihedral *new_dihedral(const char *, int, int &);
-  class Dihedral *dihedral_match(const char *);
+  void create_dihedral(const std::string &, int);
+  class Dihedral *new_dihedral(const std::string &, int, int &);
+  class Dihedral *dihedral_match(const std::string &);
 
-  void create_improper(const char *, int);
-  class Improper *new_improper(const char *, int, int &);
-  class Improper *improper_match(const char *);
+  void create_improper(const std::string &, int);
+  class Improper *new_improper(const std::string &, int, int &);
+  class Improper *improper_match(const std::string &);
 
-  void create_kspace(const char *, int);
-  class KSpace *new_kspace(const char *, int, int &);
-  class KSpace *kspace_match(const char *, int);
+  void create_kspace(const std::string &, int);
+  class KSpace *new_kspace(const std::string &, int, int &);
+  class KSpace *kspace_match(const std::string &, int);
 
-  void store_style(char *&, const char *, int);
+  void store_style(char *&, const std::string &, int);
   void set_special(int, char **);
   void bounds(const char *, int, char *, int, int &, int &, int nmin=1);
   void boundsbig(const char *, int, char *, bigint, bigint &, bigint &, bigint nmin=1);

--- a/src/imbalance.h
+++ b/src/imbalance.h
@@ -15,6 +15,7 @@
 #define LMP_IMBALANCE_H
 
 #include "pointers.h"  // IWYU pragma: export
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -30,7 +31,7 @@ class Imbalance : protected Pointers {
   // compute and apply weight factors to local atom array (required)
   virtual void compute(double *) = 0;
   // print information about the state of this imbalance compute (required)
-  virtual void info(FILE *) = 0;
+  virtual std::string info() = 0;
 
   // disallow default and copy constructor, assignment operator
   // private:

--- a/src/imbalance_group.cpp
+++ b/src/imbalance_group.cpp
@@ -16,6 +16,8 @@
 #include "force.h"
 #include "group.h"
 #include "error.h"
+#include <string>
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -75,14 +77,17 @@ void ImbalanceGroup::compute(double *weight)
 
 /* -------------------------------------------------------------------- */
 
-void ImbalanceGroup::info(FILE *fp)
+std::string ImbalanceGroup::info()
 {
+  std::string mesg = "";
+
   if (num > 0) {
     const char * const * const names = group->names;
 
-    fprintf(fp,"  group weights:");
+    mesg += "  group weights:";
     for (int i = 0; i < num; ++i)
-      fprintf(fp," %s=%g",names[id[i]],factor[i]);
-    fputs("\n",fp);
+      mesg += fmt::format(" {}={}",names[id[i]],factor[i]);
+    mesg += "\n";
   }
+  return mesg;
 }

--- a/src/imbalance_group.h
+++ b/src/imbalance_group.h
@@ -24,11 +24,11 @@ class ImbalanceGroup : public Imbalance {
   virtual ~ImbalanceGroup();
 
   // parse options, return number of arguments consumed
-  virtual int options(int, char **);
+  virtual int options(int, char **) override;
   // compute and apply weight factors to local atom array
-  virtual void compute(double *);
+  virtual void compute(double *) override;
   // print information about the state of this imbalance compute
-  virtual void info(FILE *);
+  virtual std::string info() override;
 
  private:
   int num;                     // number of groups with weights

--- a/src/imbalance_neigh.cpp
+++ b/src/imbalance_neigh.cpp
@@ -20,6 +20,7 @@
 #include "neigh_request.h"
 #include "neigh_list.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -106,7 +107,7 @@ void ImbalanceNeigh::compute(double *weight)
 
 /* -------------------------------------------------------------------- */
 
-void ImbalanceNeigh::info(FILE *fp)
+std::string ImbalanceNeigh::info()
 {
-  fprintf(fp,"  neigh weight factor: %g\n",factor);
+  return fmt::format("  neighbor weight factor: {}\n",factor);
 }

--- a/src/imbalance_neigh.h
+++ b/src/imbalance_neigh.h
@@ -25,11 +25,11 @@ class ImbalanceNeigh : public Imbalance {
 
  public:
   // parse options, return number of arguments consumed
-  virtual int options(int, char **);
+  virtual int options(int, char **) override;
   // compute and apply weight factors to local atom array
-  virtual void compute(double *);
+  virtual void compute(double *) override;
   // print information about the state of this imbalance compute
-  virtual void info(FILE *);
+  virtual std::string info() override;
 
  private:
   double factor;               // weight factor for neighbor imbalance

--- a/src/imbalance_store.cpp
+++ b/src/imbalance_store.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include "atom.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -62,7 +63,7 @@ void ImbalanceStore::compute(double *weight)
 
 /* -------------------------------------------------------------------- */
 
-void ImbalanceStore::info(FILE *fp)
+std::string ImbalanceStore::info()
 {
-  fprintf(fp,"  storing weight in atom property d_%s\n",name);
+  return fmt::format("  storing weight in atom property d_{}\n",name);
 }

--- a/src/imbalance_store.h
+++ b/src/imbalance_store.h
@@ -25,11 +25,11 @@ class ImbalanceStore : public Imbalance {
 
  public:
   // parse options, return number of arguments consumed
-  virtual int options(int, char **);
+  virtual int options(int, char **) override;
   // compute per-atom imbalance and apply to weight array
-  virtual void compute(double *);
+  virtual void compute(double *) override;
   // print information about the state of this imbalance compute (required)
-  virtual void info(FILE *);
+  virtual std::string info() override;
 
  private:
   char *name;                  // property name

--- a/src/imbalance_time.cpp
+++ b/src/imbalance_time.cpp
@@ -17,6 +17,7 @@
 #include "force.h"
 #include "timer.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -104,7 +105,7 @@ void ImbalanceTime::compute(double *weight)
 
 /* -------------------------------------------------------------------- */
 
-void ImbalanceTime::info(FILE *fp)
+std::string ImbalanceTime::info()
 {
-  fprintf(fp,"  time weight factor: %g\n",factor);
+  return fmt::format("  time weight factor: {}\n",factor);
 }

--- a/src/imbalance_time.h
+++ b/src/imbalance_time.h
@@ -25,13 +25,13 @@ class ImbalanceTime : public Imbalance {
 
  public:
   // parse options, return number of arguments consumed
-  virtual int options(int, char **);
+  virtual int options(int, char **) override;
   // reinitialize internal data
-  virtual void init(int);
+  virtual void init(int) override;
   // compute and apply weight factors to local atom array
-  virtual void compute(double *);
+  virtual void compute(double *) override;
   // print information about the state of this imbalance compute
-  virtual void info(FILE *);
+  virtual std::string info() override;
 
  private:
   double factor;               // weight factor for time imbalance

--- a/src/imbalance_var.cpp
+++ b/src/imbalance_var.cpp
@@ -20,6 +20,7 @@
 #include "variable.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -88,7 +89,7 @@ void ImbalanceVar::compute(double *weight)
 
 /* -------------------------------------------------------------------- */
 
-void ImbalanceVar::info(FILE *fp)
+std::string ImbalanceVar::info()
 {
-  fprintf(fp,"  weight variable: %s\n",name);
+  return fmt::format("  weight variable: {}\n",name);
 }

--- a/src/imbalance_var.h
+++ b/src/imbalance_var.h
@@ -25,13 +25,13 @@ class ImbalanceVar : public Imbalance {
 
  public:
   // parse options. return number of arguments consumed.
-  virtual int options(int, char **);
+  virtual int options(int, char **) override;
   // re-initialize internal data, e.g. variable ID
-  virtual void init(int);
+  virtual void init(int) override;
   // compute per-atom imbalance and apply to weight array
-  virtual void compute(double *);
+  virtual void compute(double *) override;
   // print information about the state of this imbalance compute (required)
-  virtual void info(FILE *);
+  virtual std::string info() override;
 
  private:
   char *name;                  // variable name

--- a/src/improper_deprecated.cpp
+++ b/src/improper_deprecated.cpp
@@ -16,42 +16,37 @@
 ------------------------------------------------------------------------- */
 
 #include "improper_deprecated.h"
-#include <cstring>
+#include <string>
 #include "improper_hybrid.h"
 #include "comm.h"
 #include "force.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This improper style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 void ImproperDeprecated::settings(int, char **)
 {
-  const char *my_style = force->improper_style;
+  std::string my_style = force->improper_style;
 
-  // hybrid substyles are created in ImproperHybrid::settings(), so when this is
-  // called, our style was just added at the end of the list of substyles
+  // hybrid substyles are created in ImproperHybrid::settings(),
+  // so when this is called, our style was just added at the end
+  // of the list of substyles
 
-  if (strncmp(my_style,"hybrid",6) == 0) {
+  if (utils::strmatch(my_style,"^hybrid")) {
     ImproperHybrid *hybrid = (ImproperHybrid *)force->improper;
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 
-  if (strcmp(my_style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nImproper style 'DEPRECATED' is a dummy style\n\n",0);
-
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nImproper style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+
+  lmp->error->all(FLERR,"This improper style is no longer available");
 }
 
 

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -364,7 +364,7 @@ void Info::command(int narg, char **arg)
     fmt::print(out,"\nCommunication information:\n"
                "MPI library level: MPI v{}.{}\n"
                "MPI version: {}\n",major,minor,version);
-    
+
     fmt::print(out,"Comm style = {},  Comm layout = {}\n"
                "Communicate velocities for ghost atoms = {}\n",
                commstyles[comm->style], commlayout[comm->layout],

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -49,6 +49,7 @@
 #include "update.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 #ifdef _WIN32
 #define PSAPI_VERSION 1
@@ -267,27 +268,24 @@ void Info::command(int narg, char **arg)
   fprintf(out,"Printed on %s\n",ctime(&now));
 
   if (flags & CONFIG) {
-    if (lmp->has_git_info) {
-      fprintf(out,"\nLAMMPS version: %s / %s\nGit info: %s / %s / %s\n\n",
-              universe->version, universe->num_ver,lmp->git_branch,
-              lmp->git_descriptor,lmp->git_commit);
-    } else {
-      fprintf(out,"\nLAMMPS version: %s / %s\n\n",
-              universe->version, universe->num_ver);
-    }
-    const char *infobuf = get_os_info();
-    fprintf(out,"OS information: %s\n\n",infobuf);
-    delete[] infobuf;
+    fmt::print(out,"\nLAMMPS version: {} / {}\n",
+               universe->version, universe->num_ver);
 
-    fprintf(out,"sizeof(smallint): %3d-bit\n",(int)sizeof(smallint)*8);
-    fprintf(out,"sizeof(imageint): %3d-bit\n",(int)sizeof(imageint)*8);
-    fprintf(out,"sizeof(tagint):   %3d-bit\n",(int)sizeof(tagint)*8);
-    fprintf(out,"sizeof(bigint):   %3d-bit\n",(int)sizeof(bigint)*8);
+    if (lmp->has_git_info)
+      fmt::print(out,"Git info: {} / {} / {}\n",
+                 lmp->git_branch, lmp->git_descriptor,lmp->git_commit);
 
-    infobuf = get_compiler_info();
-    fprintf(out,"\nCompiler: %s with %s\n",infobuf,get_openmp_info());
-    delete[] infobuf;
-    fprintf(out,"C++ standard: %s\n",get_cxx_info());
+    fmt::print(out,"\nOS information: {}\n\n",get_os_info());
+
+    fmt::print(out,"sizeof(smallint): {}-bit\n"
+               "sizeof(imageint): {}-bit\n"
+               "sizeof(tagint):   {}-bit\n"
+               "sizeof(bigint):   {}-bit\n",
+               sizeof(smallint)*8, sizeof(imageint)*8,
+               sizeof(tagint)*8, sizeof(bigint)*8);
+
+    fmt::print(out,"\nCompiler: {} with {}\nC++ standard: {}\n",
+               get_compiler_info(),get_openmp_info(),get_cxx_info());
 
     fputs("\nActive compile time flags:\n\n",out);
     if (has_gzip_support()) fputs("-DLAMMPS_GZIP\n",out);
@@ -361,21 +359,21 @@ void Info::command(int narg, char **arg)
 
   if (flags & COMM) {
     int major,minor;
-    const char *version = get_mpi_info(major,minor);
+    string version = get_mpi_info(major,minor);
 
-    fprintf(out,"\nCommunication information:\n");
-    fprintf(out,"MPI library level: MPI v%d.%d\n",major,minor);
-    fprintf(out,"MPI version: %s\n",version);
-    fprintf(out,"Comm style = %s,  Comm layout = %s\n",
-            commstyles[comm->style], commlayout[comm->layout]);
-    fprintf(out,"Communicate velocities for ghost atoms = %s\n",
-            comm->ghost_velocity ? "yes" : "no");
+    fmt::print(out,"\nCommunication information:\n"
+               "MPI library level: MPI v{}.{}\n"
+               "MPI version: {}\n",major,minor,version);
+    
+    fmt::print(out,"Comm style = {},  Comm layout = {}\n"
+               "Communicate velocities for ghost atoms = {}\n",
+               commstyles[comm->style], commlayout[comm->layout],
+               comm->ghost_velocity ? "yes" : "no");
 
-    if (comm->mode == 0) {
-      fprintf(out,"Communication mode = single\n");
-      fprintf(out,"Communication cutoff = %g\n",
-              comm->get_comm_cutoff());
-    }
+    if (comm->mode == 0)
+      fmt::print(out,"Communication mode = single\n"
+                 "Communication cutoff = {}\n",
+                 comm->get_comm_cutoff());
 
     if (comm->mode == 1) {
       fprintf(out,"Communication mode = multi\n");
@@ -395,7 +393,7 @@ void Info::command(int narg, char **arg)
 
   if (flags & SYSTEM) {
     fprintf(out,"\nSystem information:\n");
-    fprintf(out,"Units      = %s\n",update->unit_style);
+    fprintf(out,"Units      = %s\n", update->unit_style);
     fprintf(out,"Atom style = %s\n", atom->atom_style);
     fprintf(out,"Atom map   = %s\n", mapstyles[atom->map_style]);
     if (atom->molecular > 0) {
@@ -987,7 +985,7 @@ bool Info::has_style(const string & category, const string & name)
   return false;
 }
 
-vector<std::string> Info::get_available_styles(const string & category)
+vector<string> Info::get_available_styles(const string & category)
 {
   if ( category == "atom" ) {
     return get_style_names(atom->avec_map);
@@ -1153,9 +1151,9 @@ bool Info::has_package(const char * package_name) {
 /* ---------------------------------------------------------------------- */
 #define _INFOBUF_SIZE 256
 
-char *Info::get_os_info()
+string Info::get_os_info()
 {
-  char *buf = new char[_INFOBUF_SIZE];
+  string buf;
 
 #if defined(_WIN32)
   DWORD fullversion,majorv,minorv,buildv=0;
@@ -1166,92 +1164,91 @@ char *Info::get_os_info()
   if (fullversion < 0x80000000)
     buildv = (DWORD) (HIWORD(fullversion));
 
+  buf = fmt::format("Windows {}.{} ({}) on ",majorv,minorv,buildv);
+
   SYSTEM_INFO si;
   GetSystemInfo(&si);
 
-  const char *machine;
   switch (si.wProcessorArchitecture) {
   case PROCESSOR_ARCHITECTURE_AMD64:
-    machine = (const char *) "x86_64";
+    buf += "x86_64";
     break;
   case PROCESSOR_ARCHITECTURE_ARM:
-    machine = (const char *) "arm";
+    buf += "arm";
     break;
   case PROCESSOR_ARCHITECTURE_IA64:
-    machine = (const char *) "ia64";
+    buf += "ia64";
     break;
   case PROCESSOR_ARCHITECTURE_INTEL:
-    machine = (const char *) "i386";
+    buf += "i386";
     break;
   default:
-    machine = (const char *) "(unknown)";
+    buf += "(unknown)";
   }
-  snprintf(buf,_INFOBUF_SIZE,"Windows %d.%d (%d) on %s",
-           majorv,minorv,buildv,machine);
 #else
   struct utsname ut;
   uname(&ut);
-  snprintf(buf,_INFOBUF_SIZE,"%s %s on %s",
-           ut.sysname, ut.release, ut.machine);
+  buf = fmt::format("{} {} on {}", ut.sysname, ut.release, ut.machine);
 #endif
   return buf;
 }
 
-char *Info::get_compiler_info()
+string Info::get_compiler_info()
 {
-  char *buf = new char[_INFOBUF_SIZE];
+  string buf;
 #if __clang__
-  snprintf(buf,_INFOBUF_SIZE,"Clang C++ %s", __VERSION__);
+  buf = fmt::format("Clang C++ {}", __VERSION__);
 #elif __INTEL_COMPILER
   double version = static_cast<double>(__INTEL_COMPILER)*0.01;
-  snprintf(buf,_INFOBUF_SIZE,"Intel C++ %5.2f.%d / %s", version, __INTEL_COMPILER_UPDATE, __VERSION__);
+  buf = fmt::format("Intel C++ {:.2f}.{} / {}", version,
+                    __INTEL_COMPILER_UPDATE, __VERSION__);
 #elif __GNUC__
-  snprintf(buf,_INFOBUF_SIZE,"GNU C++ %s",   __VERSION__);
+  buf = fmt::format("GNU C++ {}",   __VERSION__);
 #else
-  snprintf(buf,_INFOBUF_SIZE,"(Unknown)");
+  buf = "(Unknown)";
 #endif
   return buf;
 }
 
-const char *Info::get_openmp_info()
+string Info::get_openmp_info()
 {
 
 #if !defined(_OPENMP)
-  return (const char *)"OpenMP not enabled";
+  return "OpenMP not enabled";
 #else
 
 // Supported OpenMP version corresponds to the release date of the
 // specifications as posted at https://www.openmp.org/specifications/
 
 #if _OPENMP > 201811
-  return (const char *)"OpenMP newer than version 5.0";
+  return "OpenMP newer than version 5.0";
 #elif _OPENMP == 201811
-  return (const char *)"OpenMP 5.0";
+  return "OpenMP 5.0";
 #elif _OPENMP == 201611
-  return (const char *)"OpenMP 5.0 preview 1";
+  return "OpenMP 5.0 preview 1";
 #elif _OPENMP == 201511
-  return (const char *)"OpenMP 4.5";
+  return "OpenMP 4.5";
 #elif _OPENMP == 201307
-  return (const char *)"OpenMP 4.0";
+  return "OpenMP 4.0";
 #elif _OPENMP == 201107
-  return (const char *)"OpenMP 3.1";
+  return "OpenMP 3.1";
 #elif _OPENMP == 200805
-  return (const char *)"OpenMP 3.0";
+  return "OpenMP 3.0";
 #elif _OPENMP == 200505
-  return (const char *)"OpenMP 2.5";
+  return "OpenMP 2.5";
 #elif _OPENMP == 200203
-  return (const char *)"OpenMP 2.0";
+  return "OpenMP 2.0";
 #else
-  return (const char *)"unknown OpenMP version";
+  return "unknown OpenMP version";
 #endif
 
 #endif
 }
 
-const char *Info::get_mpi_info(int &major, int &minor)
+string Info::get_mpi_info(int &major, int &minor)
 {
   int len;
-  #if (defined(MPI_VERSION) && (MPI_VERSION > 2)) || defined(MPI_STUBS)
+#if (defined(MPI_VERSION) && (MPI_VERSION > 2)) || defined(MPI_STUBS)
   static char version[MPI_MAX_LIBRARY_VERSION_STRING];
   MPI_Get_library_version(version,&len);
 #else
@@ -1264,23 +1261,23 @@ const char *Info::get_mpi_info(int &major, int &minor)
     char *ptr = strchr(version+80,'\n');
     if (ptr) *ptr = '\0';
   }
-  return version;
+  return string(version);
 }
 
-const char *Info::get_cxx_info()
+string Info::get_cxx_info()
 {
 #if __cplusplus > 201703L
-  return (const char *)"newer than C++17";
+  return "newer than C++17";
 #elif __cplusplus == 201703L
-  return (const char *)"C++17";
+  return "C++17";
 #elif __cplusplus == 201402L
-  return (const char *)"C++14";
+  return "C++14";
 #elif __cplusplus == 201103L
-  return (const char *)"C++11";
+  return "C++11";
 #elif __cplusplus == 199711L
-  return (const char *)"C++98";
+  return "C++98";
 #else
-  return (const char *)"unknown";
+  return "unknown";
 #endif
 }
 

--- a/src/info.h
+++ b/src/info.h
@@ -45,11 +45,11 @@ class Info : protected Pointers {
   static bool has_exceptions();
   static bool has_package(const char * package_name);
 
-  static char *get_os_info();
-  static char *get_compiler_info();
-  static const char *get_openmp_info();
-  static const char *get_mpi_info(int &, int &);
-  static const char *get_cxx_info();
+  static std::string get_os_info();
+  static std::string get_compiler_info();
+  static std::string get_openmp_info();
+  static std::string get_mpi_info(int &, int &);
+  static std::string get_cxx_info();
 
   char **get_variable_names(int &num);
 

--- a/src/kspace_deprecated.cpp
+++ b/src/kspace_deprecated.cpp
@@ -16,33 +16,27 @@
 ------------------------------------------------------------------------- */
 
 #include "kspace_deprecated.h"
-#include <cstring>
+#include <string>
 #include "comm.h"
 #include "force.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This kspace style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 void KSpaceDeprecated::settings(int, char **)
 {
-  const char *my_style = force->kspace_style;
+  std::string my_style = force->kspace_style;
 
-  if (strcmp(my_style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nKSpace style 'DEPRECATED' is a dummy style\n\n",0);
-
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nKSpace style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+
+  lmp->error->all(FLERR,"This kspace style is no longer available");
 }
 
 

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -1238,18 +1238,15 @@ void LAMMPS::print_config(FILE *fp)
   const char *pkg;
   int ncword, ncline = 0;
 
-  const char *infobuf = Info::get_os_info();
-  fprintf(fp,"OS: %s\n\n",infobuf);
-  delete[] infobuf;
+  fmt::print(fp,"OS: {}\n\n",Info::get_os_info());
 
-  infobuf = Info::get_compiler_info();
-  fprintf(fp,"Compiler: %s with %s\n",infobuf,Info::get_openmp_info());
-  delete[] infobuf;
-  fprintf(fp,"C++ standard: %s\n",Info::get_cxx_info());
+  fmt::print(fp,"Compiler: {} with {}\nC++ standard: {}\n",
+             Info::get_compiler_info(),Info::get_openmp_info(),
+             Info::get_cxx_info());
 
   int major,minor;
-  infobuf = Info::get_mpi_info(major,minor);
-  fprintf(fp,"MPI v%d.%d: %s\n\n",major,minor,infobuf);
+  std::string infobuf = Info::get_mpi_info(major,minor);
+  fmt::print(fp,"MPI v{}.{}: {}\n\n",major,minor,infobuf);
 
   fputs("Active compile time flags:\n\n",fp);
   if (Info::has_gzip_support()) fputs("-DLAMMPS_GZIP\n",fp);
@@ -1264,11 +1261,13 @@ void LAMMPS::print_config(FILE *fp)
 #else // defined(LAMMPS_SMALLSMALL)
   fputs("-DLAMMPS_SMALLSMALL\n",fp);
 #endif
-  fprintf(fp,"\nsizeof(smallint): %3d-bit\n",(int)sizeof(smallint)*8);
-  fprintf(fp,"sizeof(imageint): %3d-bit\n",(int)sizeof(imageint)*8);
-  fprintf(fp,"sizeof(tagint):   %3d-bit\n",(int)sizeof(tagint)*8);
-  fprintf(fp,"sizeof(bigint):   %3d-bit\n",(int)sizeof(bigint)*8);
 
+  fmt::print(fp,"sizeof(smallint): {}-bit\n"
+             "sizeof(imageint): {}-bit\n"
+             "sizeof(tagint):   {}-bit\n"
+             "sizeof(bigint):   {}-bit\n",
+             sizeof(smallint)*8, sizeof(imageint)*8,
+             sizeof(tagint)*8, sizeof(bigint)*8);
 
   fputs("\nInstalled packages:\n\n",fp);
   for (int i = 0; NULL != (pkg = installed_packages[i]); ++i) {

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -45,6 +45,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -212,9 +213,8 @@ void Min::setup(int flag)
     fprintf(screen,"Setting up %s style minimization ...\n",
             update->minimize_style);
     if (flag) {
-      fprintf(screen,"  Unit style    : %s\n", update->unit_style);
-      fprintf(screen,"  Current step  : " BIGINT_FORMAT "\n",
-              update->ntimestep);
+      fmt::print(screen,"  Unit style    : {}\n", update->unit_style);
+      fmt::print(screen,"  Current step  : {}\n", update->ntimestep);
       timer->print_timeout(screen);
     }
   }

--- a/src/mpiio.h
+++ b/src/mpiio.h
@@ -38,8 +38,8 @@ class RestartMPIIO {
 
   RestartMPIIO(class LAMMPS *) {mpiio_exists = 0;}
   ~RestartMPIIO() {}
-  void openForRead(char *) {}
-  void openForWrite(char *) {}
+  void openForRead(const char *) {}
+  void openForWrite(const char *) {}
   void write(MPI_Offset,int,double *) {}
   void read(MPI_Offset,long,double *) {}
   void close() {}

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -14,6 +14,7 @@
 #include "output.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "style_dump.h"
 #include "atom.h"
 #include "neighbor.h"
@@ -31,6 +32,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -331,13 +333,14 @@ void Output::write(bigint ntimestep)
 
   if (next_restart == ntimestep) {
     if (next_restart_single == ntimestep) {
-      char *file = new char[strlen(restart1) + 16];
-      char *ptr = strchr(restart1,'*');
-      *ptr = '\0';
-      sprintf(file,"%s" BIGINT_FORMAT "%s",restart1,ntimestep,ptr+1);
-      *ptr = '*';
+
+      std::string file = restart1;
+      std::size_t found = file.find("*");
+      if (found != std::string::npos)
+        file.replace(found,1,fmt::format("{}",update->ntimestep));
+
       if (last_restart != ntimestep) restart->write(file);
-      delete [] file;
+
       if (restart_every_single) next_restart_single += restart_every_single;
       else {
         modify->clearstep_compute();
@@ -419,13 +422,11 @@ void Output::write_dump(bigint ntimestep)
 void Output::write_restart(bigint ntimestep)
 {
   if (restart_flag_single) {
-    char *file = new char[strlen(restart1) + 16];
-    char *ptr = strchr(restart1,'*');
-    *ptr = '\0';
-    sprintf(file,"%s" BIGINT_FORMAT "%s",restart1,ntimestep,ptr+1);
-    *ptr = '*';
+    std::string file = restart1;
+    std::size_t found = file.find("*");
+    if (found != std::string::npos)
+      file.replace(found,1,fmt::format("{}",update->ntimestep));
     restart->write(file);
-    delete [] file;
   }
 
   if (restart_flag_double) {

--- a/src/pair_deprecated.cpp
+++ b/src/pair_deprecated.cpp
@@ -16,45 +16,40 @@
 ------------------------------------------------------------------------- */
 
 #include "pair_deprecated.h"
-#include <cstring>
+#include <string>
 #include "pair_hybrid.h"
 #include "comm.h"
 #include "force.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This pair style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 void PairDeprecated::settings(int, char **)
 {
-  const char *my_style = force->pair_style;
+  std::string my_style = force->pair_style;
 
   // hybrid substyles are created in PairHybrid::settings(), so when this is
   // called, our style was just added at the end of the list of substyles
 
-  if (strncmp(my_style,"hybrid",6) == 0) {
+  if (utils::strmatch(my_style,"^hybrid")) {
     PairHybrid *hybrid = (PairHybrid *)force->pair;
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 
-  if (strcmp(my_style,"reax") == 0) {
-    writemsg(lmp,"\nPair style 'reax' has been removed from LAMMPS "
-                    "after the 12 December 2018 version\n\n",1);
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nPair style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
 
-  if (strcmp(my_style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nPair style 'DEPRECATED' is a dummy style\n\n",0);
-
+  if (my_style == "reax") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nPair style 'reax' has been removed from LAMMPS "
+                     "after the 12 December 2018 version\n\n");
   }
+
+  lmp->error->all(FLERR,"This pair style is no longer available");
 }

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -42,6 +42,7 @@
 #include "error.h"
 #include "memory.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -815,36 +816,18 @@ void ReadData::command(int narg, char **arg)
     }
 
     if (me == 0) {
-      if (atom->nbonds) {
-        if (screen)
-          fprintf(screen,"  " BIGINT_FORMAT " template bonds\n",atom->nbonds);
-        if (logfile)
-          fprintf(logfile,"  " BIGINT_FORMAT " template bonds\n",atom->nbonds);
-      }
-      if (atom->nangles) {
-        if (screen)
-          fprintf(screen,"  " BIGINT_FORMAT " template angles\n",
-                  atom->nangles);
-        if (logfile)
-          fprintf(logfile,"  " BIGINT_FORMAT " template angles\n",
-                  atom->nangles);
-      }
-      if (atom->ndihedrals) {
-        if (screen)
-          fprintf(screen,"  " BIGINT_FORMAT " template dihedrals\n",
-                  atom->nbonds);
-        if (logfile)
-          fprintf(logfile,"  " BIGINT_FORMAT " template bonds\n",
-                  atom->ndihedrals);
-      }
-      if (atom->nimpropers) {
-        if (screen)
-          fprintf(screen,"  " BIGINT_FORMAT " template impropers\n",
-                  atom->nimpropers);
-        if (logfile)
-          fprintf(logfile,"  " BIGINT_FORMAT " template impropers\n",
-                  atom->nimpropers);
-      }
+      std::string mesg;
+
+      if (atom->nbonds)
+        mesg += fmt::format("  {} template bonds\n",atom->nbonds);
+      if (atom->nangles)
+        mesg += fmt::format("  {} template angles\n",atom->nangles);
+      if (atom->ndihedrals)
+        mesg += fmt::format("  {} template dihedrals\n",atom->ndihedrals);
+      if (atom->nimpropers)
+        mesg += fmt::format("  {} template impropers\n",atom->nimpropers);
+
+      utils::logmesg(lmp,mesg);
     }
   }
 
@@ -914,14 +897,10 @@ void ReadData::command(int narg, char **arg)
   // total time
 
   MPI_Barrier(world);
-  double time2 = MPI_Wtime();
 
-  if (comm->me == 0) {
-    if (screen)
-      fprintf(screen,"  read_data CPU = %g secs\n",time2-time1);
-    if (logfile)
-      fprintf(logfile,"  read_data CPU = %g secs\n",time2-time1);
-  }
+  if (comm->me == 0)
+    utils::logmesg(lmp,fmt::format("  read_data CPU = {:.3f} secs\n",
+                                   MPI_Wtime()-time1));
 }
 
 /* ----------------------------------------------------------------------
@@ -1225,10 +1204,7 @@ void ReadData::atoms()
 {
   int nchunk,eof;
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  reading atoms ...\n");
-    if (logfile) fprintf(logfile,"  reading atoms ...\n");
-  }
+  if (me == 0) utils::logmesg(lmp,"  reading atoms ...\n");
 
   bigint nread = 0;
 
@@ -1247,10 +1223,7 @@ void ReadData::atoms()
   MPI_Allreduce(&n,&sum,1,MPI_LMP_BIGINT,MPI_SUM,world);
   bigint nassign = sum - (atom->natoms - natoms);
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " atoms\n",nassign);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " atoms\n",nassign);
-  }
+  if (me == 0) utils::logmesg(lmp,fmt::format("  {} atoms\n",nassign));
 
   if (sum != atom->natoms)
     error->all(FLERR,"Did not assign all atoms correctly");
@@ -1280,10 +1253,7 @@ void ReadData::velocities()
 {
   int nchunk,eof;
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  reading velocities ...\n");
-    if (logfile) fprintf(logfile,"  reading velocities ...\n");
-  }
+  if (me == 0) utils::logmesg(lmp,"  reading velocities ...\n");
 
   int mapflag = 0;
   if (atom->map_style == 0) {
@@ -1307,10 +1277,7 @@ void ReadData::velocities()
     atom->map_style = 0;
   }
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " velocities\n",natoms);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " velocities\n",natoms);
-  }
+  if (me == 0) utils::logmesg(lmp,fmt::format("  {} velocities\n",natoms));
 }
 
 /* ----------------------------------------------------------------------
@@ -1322,13 +1289,8 @@ void ReadData::bonds(int firstpass)
   int nchunk,eof;
 
   if (me == 0) {
-    if (firstpass) {
-      if (screen) fprintf(screen,"  scanning bonds ...\n");
-      if (logfile) fprintf(logfile,"  scanning bonds ...\n");
-    } else {
-      if (screen) fprintf(screen,"  reading bonds ...\n");
-      if (logfile) fprintf(logfile,"  reading bonds ...\n");
-    }
+    if (firstpass) utils::logmesg(lmp,"  scanning bonds ...\n");
+    else utils::logmesg(lmp,"  reading bonds ...\n");
   }
 
   // allocate count if firstpass
@@ -1363,10 +1325,8 @@ void ReadData::bonds(int firstpass)
     MPI_Allreduce(&max,&maxall,1,MPI_INT,MPI_MAX,world);
     if (addflag == NONE) maxall += atom->extra_bond_per_atom;
 
-    if (me == 0) {
-      if (screen) fprintf(screen,"  %d = max bonds/atom\n",maxall);
-      if (logfile) fprintf(logfile,"  %d = max bonds/atom\n",maxall);
-    }
+    if (me == 0)
+      utils::logmesg(lmp,fmt::format("  {} = max bonds/atom\n",maxall));
 
     if (addflag != NONE) {
       if (maxall > atom->bond_per_atom)
@@ -1387,10 +1347,8 @@ void ReadData::bonds(int firstpass)
   int factor = 1;
   if (!force->newton_bond) factor = 2;
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " bonds\n",sum/factor);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " bonds\n",sum/factor);
-  }
+  if (me == 0)
+    utils::logmesg(lmp,fmt::format("  {} bonds\n",sum/factor));
 
   if (sum != factor*nbonds)
     error->all(FLERR,"Bonds assigned incorrectly");
@@ -1405,13 +1363,8 @@ void ReadData::angles(int firstpass)
   int nchunk,eof;
 
   if (me == 0) {
-    if (firstpass) {
-      if (screen) fprintf(screen,"  scanning angles ...\n");
-      if (logfile) fprintf(logfile,"  scanning angles ...\n");
-    } else {
-      if (screen) fprintf(screen,"  reading angles ...\n");
-      if (logfile) fprintf(logfile,"  reading angles ...\n");
-    }
+    if (firstpass) utils::logmesg(lmp,"  scanning angles ...\n");
+    else utils::logmesg(lmp,"  reading angles ...\n");
   }
 
   // allocate count if firstpass
@@ -1446,10 +1399,8 @@ void ReadData::angles(int firstpass)
     MPI_Allreduce(&max,&maxall,1,MPI_INT,MPI_MAX,world);
     if (addflag == NONE) maxall += atom->extra_angle_per_atom;
 
-    if (me == 0) {
-      if (screen) fprintf(screen,"  %d = max angles/atom\n",maxall);
-      if (logfile) fprintf(logfile,"  %d = max angles/atom\n",maxall);
-    }
+    if (me == 0)
+      utils::logmesg(lmp,fmt::format("  {} = max angles/atom\n",maxall));
 
     if (addflag != NONE) {
       if (maxall > atom->angle_per_atom)
@@ -1470,10 +1421,8 @@ void ReadData::angles(int firstpass)
   int factor = 1;
   if (!force->newton_bond) factor = 3;
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " angles\n",sum/factor);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " angles\n",sum/factor);
-  }
+  if (me == 0)
+    utils::logmesg(lmp,fmt::format("  {} angles\n",sum/factor));
 
   if (sum != factor*nangles)
     error->all(FLERR,"Angles assigned incorrectly");
@@ -1488,13 +1437,8 @@ void ReadData::dihedrals(int firstpass)
   int nchunk,eof;
 
   if (me == 0) {
-    if (firstpass) {
-      if (screen) fprintf(screen,"  scanning dihedrals ...\n");
-      if (logfile) fprintf(logfile,"  scanning dihedrals ...\n");
-    } else {
-      if (screen) fprintf(screen,"  reading dihedrals ...\n");
-      if (logfile) fprintf(logfile,"  reading dihedrals ...\n");
-    }
+    if (firstpass) utils::logmesg(lmp,"  scanning dihedrals ...\n");
+    else utils::logmesg(lmp,"  reading dihedrals ...\n");
   }
 
   // allocate count if firstpass
@@ -1529,10 +1473,8 @@ void ReadData::dihedrals(int firstpass)
     MPI_Allreduce(&max,&maxall,1,MPI_INT,MPI_MAX,world);
     if (addflag == NONE) maxall += atom->extra_dihedral_per_atom;
 
-    if (me == 0) {
-      if (screen) fprintf(screen,"  %d = max dihedrals/atom\n",maxall);
-      if (logfile) fprintf(logfile,"  %d = max dihedrals/atom\n",maxall);
-    }
+    if (me == 0)
+      utils::logmesg(lmp,fmt::format("  {} = max dihedrals/atom\n",maxall));
 
     if (addflag != NONE) {
       if (maxall > atom->dihedral_per_atom)
@@ -1553,10 +1495,8 @@ void ReadData::dihedrals(int firstpass)
   int factor = 1;
   if (!force->newton_bond) factor = 4;
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " dihedrals\n",sum/factor);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " dihedrals\n",sum/factor);
-  }
+  if (me == 0)
+    utils::logmesg(lmp,fmt::format("  {} dihedrals\n",sum/factor));
 
   if (sum != factor*ndihedrals)
     error->all(FLERR,"Dihedrals assigned incorrectly");
@@ -1571,13 +1511,8 @@ void ReadData::impropers(int firstpass)
   int nchunk,eof;
 
   if (me == 0) {
-    if (firstpass) {
-      if (screen) fprintf(screen,"  scanning impropers ...\n");
-      if (logfile) fprintf(logfile,"  scanning impropers ...\n");
-    } else {
-      if (screen) fprintf(screen,"  reading impropers ...\n");
-      if (logfile) fprintf(logfile,"  reading impropers ...\n");
-    }
+    if (firstpass) utils::logmesg(lmp,"  scanning impropers ...\n");
+    else utils::logmesg(lmp,"  reading impropers ...\n");
   }
 
   // allocate count if firstpass
@@ -1612,10 +1547,8 @@ void ReadData::impropers(int firstpass)
     MPI_Allreduce(&max,&maxall,1,MPI_INT,MPI_MAX,world);
     if (addflag == NONE) maxall += atom->extra_improper_per_atom;
 
-    if (me == 0) {
-      if (screen) fprintf(screen,"  %d = max impropers/atom\n",maxall);
-      if (logfile) fprintf(logfile,"  %d = max impropers/atom\n",maxall);
-    }
+    if (me == 0)
+      utils::logmesg(lmp,fmt::format("  {} = max impropers/atom\n",maxall));
 
     if (addflag != NONE) {
       if (maxall > atom->improper_per_atom)
@@ -1636,10 +1569,8 @@ void ReadData::impropers(int firstpass)
   int factor = 1;
   if (!force->newton_bond) factor = 4;
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " impropers\n",sum/factor);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " impropers\n",sum/factor);
-  }
+  if (me == 0)
+    utils::logmesg(lmp,fmt::format("  {} impropers\n",sum/factor));
 
   if (sum != factor*nimpropers)
     error->all(FLERR,"Impropers assigned incorrectly");
@@ -1677,10 +1608,8 @@ void ReadData::bonus(bigint nbonus, AtomVec *ptr, const char *type)
     atom->map_style = 0;
   }
 
-  if (me == 0) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " %s\n",natoms,type);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " %s\n",natoms,type);
-  }
+  if (me == 0)
+    utils::logmesg(lmp,fmt::format("  {} {}\n",natoms,type));
 }
 
 /* ----------------------------------------------------------------------
@@ -1783,10 +1712,8 @@ void ReadData::bodies(int firstpass, AtomVec *ptr)
     atom->map_style = 0;
   }
 
-  if (me == 0 && firstpass) {
-    if (screen) fprintf(screen,"  " BIGINT_FORMAT " bodies\n",natoms);
-    if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " bodies\n",natoms);
-  }
+  if (me == 0 && firstpass)
+    utils::logmesg(lmp,fmt::format("  {} bodies\n",natoms));
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -35,6 +35,7 @@
 #include "error.h"
 #include "memory.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -165,26 +166,14 @@ void ReadDump::command(int narg, char **arg)
 
   domain->print_box("  ");
 
-  if (me == 0) {
-    if (screen) {
-      fprintf(screen,"  " BIGINT_FORMAT " atoms before read\n",natoms_prev);
-      fprintf(screen,"  " BIGINT_FORMAT " atoms in snapshot\n",nsnap_all);
-      fprintf(screen,"  " BIGINT_FORMAT " atoms purged\n",npurge_all);
-      fprintf(screen,"  " BIGINT_FORMAT " atoms replaced\n",nreplace_all);
-      fprintf(screen,"  " BIGINT_FORMAT " atoms trimmed\n",ntrim_all);
-      fprintf(screen,"  " BIGINT_FORMAT " atoms added\n",nadd_all);
-      fprintf(screen,"  " BIGINT_FORMAT " atoms after read\n",atom->natoms);
-    }
-    if (logfile) {
-      fprintf(logfile,"  " BIGINT_FORMAT " atoms before read\n",natoms_prev);
-      fprintf(logfile,"  " BIGINT_FORMAT " atoms in snapshot\n",nsnap_all);
-      fprintf(logfile,"  " BIGINT_FORMAT " atoms purged\n",npurge_all);
-      fprintf(logfile,"  " BIGINT_FORMAT " atoms replaced\n",nreplace_all);
-      fprintf(logfile,"  " BIGINT_FORMAT " atoms trimmed\n",ntrim_all);
-      fprintf(logfile,"  " BIGINT_FORMAT " atoms added\n",nadd_all);
-      fprintf(logfile,"  " BIGINT_FORMAT " atoms after read\n",atom->natoms);
-    }
-  }
+  if (me == 0)
+    utils::logmesg(lmp, fmt::format("  {} atoms before read\n",natoms_prev)
+                   + fmt::format("  {} atoms in snapshot\n",nsnap_all)
+                   + fmt::format("  {} atoms purged\n",npurge_all)
+                   + fmt::format("  {} atoms replaced\n",nreplace_all)
+                   + fmt::format("  {} atoms trimmed\n",ntrim_all)
+                   + fmt::format("  {} atoms added\n",nadd_all)
+                   + fmt::format("  {} atoms after read\n",atom->natoms));
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/region_deprecated.cpp
+++ b/src/region_deprecated.cpp
@@ -12,29 +12,24 @@
 ------------------------------------------------------------------------- */
 
 #include "region_deprecated.h"
-#include <cstring>
+#include <string>
 #include "comm.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace LAMMPS_NS;
-
-static void writemsg(LAMMPS *lmp, const char *msg, int abend=1)
-{
-  if (lmp->comm->me == 0) {
-    if (lmp->screen) fputs(msg,lmp->screen);
-    if (lmp->logfile) fputs(msg,lmp->logfile);
-  }
-  if (abend)
-    lmp->error->all(FLERR,"This region style is no longer available");
-}
 
 /* ---------------------------------------------------------------------- */
 
 RegionDeprecated::RegionDeprecated(LAMMPS *lmp, int narg, char **arg) :
   Region(lmp, narg, arg)
 {
-  if (strcmp(style,"DEPRECATED") == 0) {
-    writemsg(lmp,"\nRegion style 'DEPRECATED' is a dummy style\n\n",0);
+  std::string my_style = style;
 
+  if (my_style == "DEPRECATED") {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp,"\nRegion style 'DEPRECATED' is a dummy style\n\n");
+    return;
   }
+  lmp->error->all(FLERR,"This region style is no longer available");
 }

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -14,6 +14,7 @@
 #include "write_data.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "atom_vec.h"
 #include "force.h"
@@ -32,6 +33,8 @@
 #include "thermo.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -58,14 +61,10 @@ void WriteData::command(int narg, char **arg)
 
   // if filename contains a "*", replace with current timestep
 
-  char *ptr;
-  int n = strlen(arg[0]) + 16;
-  char *file = new char[n];
-
-  if ((ptr = strchr(arg[0],'*'))) {
-    *ptr = '\0';
-    sprintf(file,"%s" BIGINT_FORMAT "%s",arg[0],update->ntimestep,ptr+1);
-  } else strcpy(file,arg[0]);
+  std::string file = arg[0];
+  std::size_t found = file.find("*");
+  if (found != std::string::npos)
+    file.replace(found,1,fmt::format("{}",update->ntimestep));
 
   // read optional args
   // noinit is a hidden arg, only used by -r command-line switch
@@ -124,9 +123,7 @@ void WriteData::command(int narg, char **arg)
     if (domain->triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
   }
 
-  write(file);
-
-  delete [] file;
+  write(file.c_str());
 }
 
 /* ----------------------------------------------------------------------
@@ -134,7 +131,7 @@ void WriteData::command(int narg, char **arg)
    might later let it be directly called within run/minimize loop
 ------------------------------------------------------------------------- */
 
-void WriteData::write(char *file)
+void WriteData::write(const char *file)
 {
   // special case where reneighboring is not done in integrator
   //   on timestep data file is written (due to build_once being set)
@@ -235,34 +232,26 @@ void WriteData::write(char *file)
 
 void WriteData::header()
 {
-  fprintf(fp,"LAMMPS data file via write_data, version %s, "
-          "timestep = " BIGINT_FORMAT "\n",
-          universe->version,update->ntimestep);
+  fmt::print(fp,"LAMMPS data file via write_data, version {}, "
+             "timestep = {}\n\n",universe->version,update->ntimestep);
 
-  fprintf(fp,"\n");
-
-  fprintf(fp,BIGINT_FORMAT " atoms\n",atom->natoms);
-  fprintf(fp,"%d atom types\n",atom->ntypes);
+  fmt::print(fp,"{} atoms\n{} atom types\n",atom->natoms,atom->ntypes);
 
   // do not write molecular topology info for atom_style template
 
   if (atom->molecular == 1) {
-    if (atom->nbonds || atom->nbondtypes) {
-      fprintf(fp,BIGINT_FORMAT " bonds\n",nbonds);
-      fprintf(fp,"%d bond types\n",atom->nbondtypes);
-    }
-    if (atom->nangles || atom->nangletypes) {
-      fprintf(fp,BIGINT_FORMAT " angles\n",nangles);
-      fprintf(fp,"%d angle types\n",atom->nangletypes);
-    }
-    if (atom->ndihedrals || atom->ndihedraltypes) {
-      fprintf(fp,BIGINT_FORMAT " dihedrals\n",ndihedrals);
-      fprintf(fp,"%d dihedral types\n",atom->ndihedraltypes);
-    }
-    if (atom->nimpropers || atom->nimpropertypes) {
-      fprintf(fp,BIGINT_FORMAT " impropers\n",nimpropers);
-      fprintf(fp,"%d improper types\n",atom->nimpropertypes);
-    }
+    if (atom->nbonds || atom->nbondtypes)
+      fmt::print(fp,"{} bonds\n{} bond types\n",
+                 nbonds,atom->nbondtypes);
+    if (atom->nangles || atom->nangletypes)
+      fmt::print(fp,"{} angles\n{} angle types\n",
+                 nangles,atom->nangletypes);
+    if (atom->ndihedrals || atom->ndihedraltypes)
+      fmt::print(fp,"{} dihedrals\n{} dihedral types\n",
+                 ndihedrals,atom->ndihedraltypes);
+    if (atom->nimpropers || atom->nimpropertypes)
+      fmt::print(fp,"{} impropers\n{} improper types\n",
+                 nimpropers,atom->nimpropertypes);
   }
 
   if (fixflag)

--- a/src/write_data.h
+++ b/src/write_data.h
@@ -28,7 +28,7 @@ class WriteData : protected Pointers {
  public:
   WriteData(class LAMMPS *);
   void command(int, char **);
-  void write(char *);
+  void write(const char *);
 
  private:
   int me,nprocs;

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -232,7 +232,7 @@ void WriteRestart::write(std::string file)
   if (me == 0) {
     std::string base = file;
     if (multiproc) base.replace(base.find("%"),1,"base");
-    
+
     fp = fopen(base.c_str(),"wb");
     if (fp == NULL)
       error->one(FLERR,fmt::format("Cannot open restart file {}",base).c_str());

--- a/src/write_restart.h
+++ b/src/write_restart.h
@@ -21,6 +21,7 @@ CommandStyle(write_restart,WriteRestart)
 #define LMP_WRITE_RESTART_H
 
 #include "pointers.h"
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -29,7 +30,7 @@ class WriteRestart : protected Pointers {
   WriteRestart(class LAMMPS *);
   void command(int, char **);
   void multiproc_options(int, int, int, char **);
-  void write(char *);
+  void write(std::string);
 
  private:
   int me,nprocs;


### PR DESCRIPTION
**Summary**

This PR refactors several source files to benefit from the recent additions of {fmt} and utils::logmesg() and thus makes code simpler and more maintainable.

**Related Issues**

#2102 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
