### PR TITLE
Added missing "Syntax" label

### DIFF
--- a/doc/src/fix_orient.rst
+++ b/doc/src/fix_orient.rst
@@ -6,6 +6,9 @@ fix orient/fcc command
 fix orient/bcc command
 ======================
 
+Syntax
+""""""
+
 .. parsed-literal::
 
    fix ID group-ID orient/fcc nstats dir alat dE cutlo cuthi file0 file1

--- a/doc/src/fix_poems.rst
+++ b/doc/src/fix_poems.rst
@@ -3,7 +3,8 @@
 fix poems command
 =================
 
-Syntax:
+Syntax
+""""""
 
 .. parsed-literal::
 

--- a/doc/src/fix_rhok.rst
+++ b/doc/src/fix_rhok.rst
@@ -3,6 +3,9 @@
 fix rhok command
 ================
 
+Syntax
+""""""
+
 .. parsed-literal::
 
    fix ID group-ID rhok nx ny nz K a

--- a/doc/src/pair_lubricate.rst
+++ b/doc/src/pair_lubricate.rst
@@ -28,7 +28,9 @@ Syntax
 * flagHI (optional) = 0/1 to exclude/include 1/r hydrodynamic interactions
 * flagVF (optional) = 0/1 to exclude/include volume fraction corrections in the long-range isotropic terms
 
-**Examples:** (all assume radius = 1)
+Examples
+""""""""
+(all assume radius = 1)
 
 .. code-block:: LAMMPS
 

--- a/doc/src/pair_lubricateU.rst
+++ b/doc/src/pair_lubricateU.rst
@@ -22,7 +22,9 @@ Syntax
 * flagHI (optional) = 0/1 to exclude/include 1/r hydrodynamic interactions
 * flagVF (optional) = 0/1 to exclude/include volume fraction corrections in the long-range isotropic terms
 
-**Examples:** (all assume radius = 1)
+Examples
+""""""""
+(all assume radius = 1)
 
 .. code-block:: LAMMPS
 

--- a/doc/src/special_bonds.rst
+++ b/doc/src/special_bonds.rst
@@ -28,7 +28,8 @@ Syntax
        *angle* value = *yes* or *no*
        *dihedral* value = *yes* or *no*
 
-Examples:
+Examples
+""""""""
 
 .. code-block:: LAMMPS
 


### PR DESCRIPTION
**Summary**

In the documentation-.rst files of 3 fix-commands the "Syntax" label was missing or not correctly formatted.

**Author(s)**


**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [x] Corresponding author information is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
