### PR TITLE
Add missing Kokkos dependency

### DIFF
--- a/src/Depend.sh
+++ b/src/Depend.sh
@@ -69,6 +69,7 @@ if (test $1 = "DIPOLE") then
 fi
 
 if (test $1 = "GRANULAR") then
+  depend KOKKOS
   depend USER-OMP
 fi
 


### PR DESCRIPTION
**Summary**

There is a missing dependency between the Granular and Kokkos packages in the `gmake` build system.

**Related Issues**

None.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes