### PR TITLE
Fix compile error with pair_sw_kokkos

### DIFF
--- a/src/MANYBODY/pair_sw.h
+++ b/src/MANYBODY/pair_sw.h
@@ -36,7 +36,6 @@ class PairSW : public Pair {
 
   static const int NPARAMS_PER_LINE = 14;
 
- protected:
   struct Param {
     double epsilon,sigma;
     double littlea,lambda,gamma,costheta;
@@ -49,6 +48,7 @@ class PairSW : public Pair {
     int ielement,jelement,kelement;
   };
 
+ protected:
   double cutmax;                // max cutoff for all elements
   int nelements;                // # of unique elements
   char **elements;              // names of unique elements


### PR DESCRIPTION
**Summary**

The Kokkos CUDA version of Pair Stillinger-Weber doesn't compile. This is due to a change in the parent pair_sw.h: https://github.com/lammps/lammps/commit/8329a5498b84db97084be1d5fb7bc5b14fd7ace0#diff-be32eb6c98353af8e19924eeee603505R39
 
The specific compile error is:
```
error: A type that is defined inside a class and has private or protected access ("LAMMPS_NS::PairSW::Param")
cannot be used in the template argument type of a __global__ function template instantiation, unless the class is local to a __device__ or __global__ function
```
Which was caused by making the class-internal PairSW::Param struct `protected`. This moves the `protected` below the definition of `PairSW::Param`.

**Related Issues**

None

**Author(s)**

Stan Moore (SNL), reported by Evan Weinberg (NVIDIA)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes