### PR TITLE
KIM package echo/log refactor and bugfix

### DIFF
--- a/src/KIM/kim_init.h
+++ b/src/KIM/kim_init.h
@@ -83,10 +83,9 @@ class KimInit : protected Pointers {
   bool unit_conversion_mode;
 
   void determine_model_type_and_units(char *, char *, char **, KIM_Model *&);
-  void write_log_cite(char *);
+  void write_log_cite(const std::string &);
   void do_init(char *, char *, char *, KIM_Model *&);
   void do_variables(char*, char*);
-  void kim_init_log_delimiter(std::string const &begin_end) const;
 };
 
 }

--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -99,24 +99,6 @@ void KimInteractions::command(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-void KimInteractions::kim_interactions_log_delimiter(
-    std::string const begin_end) const
-{
-  if (comm->me == 0) {
-    std::string mesg;
-    if (begin_end == "begin")
-      mesg =
-          "#=== BEGIN kim_interactions ==================================\n";
-    else if (begin_end == "end")
-      mesg =
-          "#=== END kim_interactions ====================================\n\n";
-
-    input->write_echo(mesg.c_str());
-  }
-}
-
-/* ---------------------------------------------------------------------- */
-
 void KimInteractions::do_setup(int narg, char **arg)
 {
   bool fixed_types;
@@ -145,7 +127,7 @@ void KimInteractions::do_setup(int narg, char **arg)
   } else error->all(FLERR,"Must use 'kim_init' before 'kim_interactions'");
 
   // Begin output to log file
-  kim_interactions_log_delimiter("begin");
+  input->write_echo("#=== BEGIN kim_interactions ==================================\n");
 
   if (simulatorModel) {
 
@@ -167,7 +149,7 @@ void KimInteractions::do_setup(int narg, char **arg)
           simulatorModel,"atom-type-num-list",atom_type_num_list.c_str());
       KIM_SimulatorModel_CloseTemplateMap(simulatorModel);
 
-      int len = strlen(atom_type_sym_list.c_str())+1;
+      int len = atom_type_sym_list.size()+1;
       char *strbuf = new char[len];
       char *strword;
 
@@ -281,8 +263,7 @@ void KimInteractions::do_setup(int narg, char **arg)
   }
 
   // End output to log file
-  kim_interactions_log_delimiter("end");
-
+  input->write_echo("#=== END kim_interactions ====================================\n\n");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -377,7 +358,7 @@ void KimInteractions::KIM_SET_TYPE_PARAMETERS(char const *const input_line) cons
 
 /* ---------------------------------------------------------------------- */
 
-int KimInteractions::species_to_atomic_no(std::string const species) const
+int KimInteractions::species_to_atomic_no(const std::string &species) const
 {
   if (species == "H") return 1;
   else if (species == "He") return 2;

--- a/src/KIM/kim_interactions.h
+++ b/src/KIM/kim_interactions.h
@@ -76,9 +76,8 @@ class KimInteractions : protected Pointers {
   void command(int, char **);
  private:
   void do_setup(int, char **);
-  int species_to_atomic_no(std::string const species) const;
+  int species_to_atomic_no(const std::string &species) const;
   void KIM_SET_TYPE_PARAMETERS(char const *const input_line) const;
-  void kim_interactions_log_delimiter(std::string const begin_end) const;
 };
 
 }

--- a/src/KIM/kim_param.h
+++ b/src/KIM/kim_param.h
@@ -80,10 +80,7 @@ public:
   void command(int, char **);
 
 private:
-  void kim_param_log_delimiter(std::string const &begin_end) const;
-
-  void echo_var_assign(std::string const &name, std::string const &value)
-      const;
+  void echo_var_assign(const std::string &name, const std::string &value) const;
 
 private:
   bool kim_param_get;

--- a/src/KIM/kim_query.cpp
+++ b/src/KIM/kim_query.cpp
@@ -56,6 +56,7 @@
 ------------------------------------------------------------------------- */
 
 #include "kim_query.h"
+#include "fix_store_kim.h"
 #include <mpi.h>
 #include <cstring>
 #include <string>
@@ -67,7 +68,7 @@
 #include "variable.h"
 #include "version.h"
 #include "info.h"
-#include "fix_store_kim.h"
+#include "fmt/format.h"
 
 #if defined(LMP_KIM_CURL)
 #include <sys/types.h>
@@ -153,7 +154,7 @@ void KimQuery::command(int narg, char **arg)
     error->all(FLERR,errmsg);
   }
 
-  kim_query_log_delimiter("begin");
+  input->write_echo("#=== BEGIN kim-query =========================================\n");
   char **varcmd = new char*[3];
   varcmd[1] = (char *) "string";
 
@@ -186,7 +187,7 @@ void KimQuery::command(int narg, char **arg)
     input->variable->set(3,varcmd);
     echo_var_assign(varname, value_string);
   }
-  kim_query_log_delimiter("end");
+  input->write_echo("#=== END kim-query ===========================================\n\n");
 
   delete[] varcmd;
   delete[] value;
@@ -342,29 +343,8 @@ char *do_query(char *qfunction, char * model_name, int narg, char **arg,
 
 /* ---------------------------------------------------------------------- */
 
-void KimQuery::kim_query_log_delimiter(std::string const begin_end) const
+void KimQuery::echo_var_assign(const std::string & name,
+                               const std::string & value) const
 {
-  if (comm->me == 0) {
-    std::string mesg;
-    if (begin_end == "begin")
-      mesg =
-          "#=== BEGIN kim-query =========================================\n";
-    else if (begin_end == "end")
-      mesg =
-          "#=== END kim-query ===========================================\n\n";
-
-    input->write_echo(mesg.c_str());
-  }
-}
-
-/* ---------------------------------------------------------------------- */
-
-void KimQuery::echo_var_assign(std::string const & name,
-                               std::string const & value) const
-{
-  if (comm->me == 0) {
-    std::string mesg;
-    mesg += "variable " + name + " string " + value + "\n";
-    input->write_echo(mesg.c_str());
-  }
+  input->write_echo(fmt::format("variable {} string {}\n",name,value));
 }

--- a/src/KIM/kim_query.h
+++ b/src/KIM/kim_query.h
@@ -73,8 +73,7 @@ class KimQuery : protected Pointers {
   KimQuery(class LAMMPS *lmp) : Pointers(lmp) {};
   void command(int, char **);
  private:
-  void kim_query_log_delimiter(std::string const begin_end) const;
-  void echo_var_assign(std::string const & name, std::string const & value)
+  void echo_var_assign(const std::string &name, const std::string &value)
   const;
 };
 

--- a/src/KIM/kim_units.cpp
+++ b/src/KIM/kim_units.cpp
@@ -1370,9 +1370,9 @@ double get_unit_conversion_factor(unit_type &unit_type_enum,
 
 //  Wrapper to the routine that gets the unit conversion. Translates strings
 //  to enumerations and then call get_unit_conversion_factor()
-int lammps_unit_conversion(string const &unit_type_str,
-                           string const &from_system_str,
-                           string const &to_system_str,
+int lammps_unit_conversion(const string &unit_type_str,
+                           const string &from_system_str,
+                           const string &to_system_str,
                            double &conversion_factor)
 {
     // initialize

--- a/src/KIM/kim_units.h
+++ b/src/KIM/kim_units.h
@@ -53,7 +53,7 @@
    Designed for use with the kim-api-2.0.2 (and newer) package
 ------------------------------------------------------------------------- */
 
-int lammps_unit_conversion(std::string const &unit_type_str,
-                           std::string const &from_system_str,
-                           std::string const &to_system_str,
+int lammps_unit_conversion(const std::string &unit_type_str,
+                           const std::string &from_system_str,
+                           const std::string &to_system_str,
                            double &conversion_factor);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -309,11 +309,11 @@ char *Input::one(const std::string &single)
 /* ----------------------------------------------------------------------
    Send text to active echo file pointers
 ------------------------------------------------------------------------- */
-void Input::write_echo(const char *txt)
+void Input::write_echo(const std::string &txt)
 {
   if (me == 0) {
-    if (echo_screen && screen) fputs(txt,screen);
-    if (echo_log && logfile) fputs(txt,logfile);
+    if (echo_screen && screen) fputs(txt.c_str(),screen);
+    if (echo_log && logfile) fputs(txt.c_str(),logfile);
   }
 }
 

--- a/src/input.h
+++ b/src/input.h
@@ -38,7 +38,7 @@ class Input : protected Pointers {
   void substitute(char *&, char *&, int &, int &, int);
                                  // substitute for variables in a string
   int expand_args(int, char **, int, char **&);  // expand args due to wildcard
-  void write_echo(const char *); // send text to active echo file pointers
+  void write_echo(const std::string &); // send text to active echo file pointers
 
  protected:
   char *command;               // ptr to current command


### PR DESCRIPTION
**Summary**

With the inclusion of `{fmt}` and also the process of using `std::string` for `const char *`
the KIM package code can be significantly simplified. This also fixes a bug from a previous refactor.

**Related Issues**

This fixes #2146 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Code tests OK with the bundled KIM examples.

**Implementation Notes**

There is room for more improvement. Almost all use of stringstreams can be replaced with `fmt::format()` or `fmt::print()` and also incremental building of strings can be simplified. LAMMPS core APIs that require individual `const char *` arguments may be changed to `const std::string &` as needed. 

I would also want to point out that we use the convention of putting "const" before the type and not after and that we use more compact placement of braces.

Because input->write_echo() already checks whether comm->me == 0, there is no need to do that test when calling it.

Please check out the docs for fmt::format() at https://fmt.dev. It has very sophisticated options for defining width, alignment, fill characters and so on, so a lot of the efforts inside the KIM package sources to do that manually could be replaced by using fmt::format(). Please also note that a variant of fmt::format has been included into the C++20 standard, so some time in the future we will be able to replace fmt::format() with std::format() and remove the library code.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
