### PR TITLE
Move definition(s) of union ubuf to lmptype.h

### DIFF
--- a/doc/src/reset_ids.rst
+++ b/doc/src/reset_ids.rst
@@ -57,7 +57,7 @@ can be useful for debugging or comparing output from two different
 runs.
 
 Note that the spatial sort requires communication of atom IDs and
-coordinates bewteen processors in an all-to-all manner.  This is done
+coordinates between processors in an all-to-all manner.  This is done
 efficiently in LAMMPS, but it is more expensive than how atom IDs are
 reset without sorting.
 

--- a/doc/src/reset_ids.rst
+++ b/doc/src/reset_ids.rst
@@ -10,8 +10,8 @@ Syntax
 
    reset_ids keyword values ...
 
-* zero or more keyword/value pairs may be appended
-* keyword = *sort*
+   * zero or more keyword/value pairs may be appended
+   * keyword = *sort*
 
 .. parsed-literal::
 

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -554,7 +554,7 @@ void PairADP::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if (values.count() != file->nelements + 1)
+      if ((int)values.count() != file->nelements + 1)
         error->one(FLERR,"Incorrect element names in ADP potential file");
 
       file->elements = new char*[file->nelements];

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -3488,7 +3488,7 @@ void PairAIREBO::read_file(char *filename)
       // global parameters
       current_section = "global parameters";
 
-      for(int i = 0; i < params.size(); i++) {
+      for(int i = 0; i < (int)params.size(); i++) {
         *params[i] = reader.next_double();
       }
 

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -312,7 +312,7 @@ double PairComb3::init_one(int i, int j)
 
 void PairComb3::read_lib()
 {
-  int i,j,k,l,m;
+  int i,j,k,l;
   int ii,jj,kk,ll,mm,iii;
 
   // open library file on proc 0

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -469,8 +469,6 @@ void PairEAM::read_file(char *filename)
     PotentialFileReader reader(lmp, filename, "EAM");
 
     try {
-      char * line = nullptr;
-
       reader.skip_line();
 
       ValueTokenizer values = reader.next_values(2);

--- a/src/MANYBODY/pair_eam_alloy.cpp
+++ b/src/MANYBODY/pair_eam_alloy.cpp
@@ -130,7 +130,7 @@ void PairEAMAlloy::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if (values.count() != file->nelements + 1)
+      if ((int)values.count() != file->nelements + 1)
         error->one(FLERR,"Incorrect element names in EAM potential file");
 
       file->elements = new char*[file->nelements];

--- a/src/MANYBODY/pair_eam_cd.cpp
+++ b/src/MANYBODY/pair_eam_cd.cpp
@@ -518,7 +518,7 @@ void PairEAMCD::read_h_coeff(char *filename)
     int degree = values.next_int();
     nhcoeff = degree+1;
 
-    if (values.count() != nhcoeff + 1 || nhcoeff < 1)
+    if ((int)values.count() != nhcoeff + 1 || nhcoeff < 1)
       error->one(FLERR, "Failed to read h(x) function coefficients in EAM file.");
 
     hcoeff = new double[nhcoeff];

--- a/src/MANYBODY/pair_eam_fs.cpp
+++ b/src/MANYBODY/pair_eam_fs.cpp
@@ -122,8 +122,6 @@ void PairEAMFS::read_file(char *filename)
     PotentialFileReader reader(lmp, filename, "EAM");
 
     try {
-      char * line = nullptr;
-
       reader.skip_line();
       reader.skip_line();
       reader.skip_line();
@@ -132,7 +130,7 @@ void PairEAMFS::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if (values.count() != file->nelements + 1)
+      if ((int)values.count() != file->nelements + 1)
         error->one(FLERR,"Incorrect element names in EAM potential file");
 
       file->elements = new char*[file->nelements];

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -73,7 +73,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
   dof_flag = 1;
   enforce2d_flag = 1;
   stores_ids = 1;
-  
+
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -65,7 +65,7 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
   create_attribute = 1;
   dof_flag = 1;
   stores_ids = 1;
-  
+
   // error check
 
   molecular = atom->molecular;

--- a/src/USER-OMP/pair_eam_alloy_omp.cpp
+++ b/src/USER-OMP/pair_eam_alloy_omp.cpp
@@ -130,7 +130,7 @@ void PairEAMAlloyOMP::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if (values.count() != file->nelements + 1)
+      if ((int)values.count() != file->nelements + 1)
         error->one(FLERR,"Incorrect element names in EAM potential file");
 
       file->elements = new char*[file->nelements];

--- a/src/USER-OMP/pair_eam_fs_omp.cpp
+++ b/src/USER-OMP/pair_eam_fs_omp.cpp
@@ -130,7 +130,7 @@ void PairEAMFSOMP::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if (values.count() != file->nelements + 1)
+      if ((int)values.count() != file->nelements + 1)
         error->one(FLERR,"Incorrect element names in EAM potential file");
 
       file->elements = new char*[file->nelements];

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -209,25 +209,6 @@ class AtomVec : protected Pointers {
 
   bool *threads;
 
-  // union data struct for packing 32-bit and 64-bit ints into double bufs
-  // this avoids aliasing issues by having 2 pointers (double,int)
-  //   to same buf memory
-  // constructor for 32-bit int prevents compiler
-  //   from possibly calling the double constructor when passed an int
-  // copy to a double *buf:
-  //   buf[m++] = ubuf(foo).d, where foo is a 32-bit or 64-bit int
-  // copy from a double *buf:
-  //   foo = (int) ubuf(buf[m++]).i;, where (int) or (tagint) match foo
-  //   the cast prevents compiler warnings about possible truncation
-
-  union ubuf {
-    double d;
-    int64_t i;
-    ubuf(double arg) : d(arg) {}
-    ubuf(int64_t arg) : i(arg) {}
-    ubuf(int arg) : i(arg) {}
-  };
-
   // local methods
 
   void grow_nmax();

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -256,7 +256,6 @@ void Comm::init_exchange()
   int nfix = modify->nfix;
   Fix **fix = modify->fix;
 
-  int onefix;
   maxexchange_fix = 0;
   for (int i = 0; i < nfix; i++)
     maxexchange_fix += fix[i]->maxexchange;

--- a/src/compute.h
+++ b/src/compute.h
@@ -161,17 +161,6 @@ class Compute : protected Pointers {
     return j >> SBBITS & 3;
   }
 
-  // union data struct for packing 32-bit and 64-bit ints into double bufs
-  // see atom_vec.h for documentation
-
-  union ubuf {
-    double d;
-    int64_t i;
-    ubuf(double arg) : d(arg) {}
-    ubuf(int64_t arg) : i(arg) {}
-    ubuf(int arg) : i(arg) {}
-  };
-
   // private methods
 
   void adjust_dof_fix();

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -81,7 +81,7 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   maxexchange_dynamic = 0;
   pre_exchange_migrate = 0;
   stores_ids = 0;
-  
+
   scalar_flag = vector_flag = array_flag = 0;
   peratom_flag = local_flag = 0;
   global_freq = local_freq = peratom_freq = -1;

--- a/src/fix.h
+++ b/src/fix.h
@@ -242,17 +242,6 @@ class Fix : protected Pointers {
   void v_tally(int, int *, double, double *);
   void v_tally(int, double *);
   void v_tally(int, int, double);
-
-  // union data struct for packing 32-bit and 64-bit ints into double bufs
-  // see atom_vec.h for documentation
-
-  union ubuf {
-    double d;
-    int64_t i;
-    ubuf(double arg) : d(arg) {}
-    ubuf(int64_t arg) : i(arg) {}
-    ubuf(int arg) : i(arg) {}
-  };
 };
 
 namespace FixConst {

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1667,7 +1667,7 @@ int lammps_style_name(void* ptr, char * category, int index, char * buffer, int 
   Info info(lmp);
   auto styles = info.get_available_styles(category);
 
-  if (index < styles.size()) {
+  if (index < (int)styles.size()) {
     strncpy(buffer, styles[index].c_str(), max_size);
     return true;
   }

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -171,6 +171,46 @@ typedef int bigint;
 
 #endif
 
+  /// Data structe for packing 32-bit and 64-bit integers
+  /// into double (communication) buffers
+  ///
+  /// Using this union avoids aliasing issues by having member types
+  /// (double, int) referencing the same buffer memory location.
+  ///
+  /// The explicit constructor for 32-bit integers prevents compilers
+  /// from (incorrectly) calling the double constructor when storing
+  ///  an int into a double buffer.
+  /*
+\verbatim embed:rst
+**Usage:**
+
+To copy an integer into a double buffer:
+
+.. code-block: c++
+
+   double buf[2];
+   int    foo =   1;
+   tagint bar = 2<<40;
+   buf[1] = ubuf(foo).d;
+   buf[2] = ubuf(bar).d;
+
+To copy from a double buffer back to an int:
+
+.. code-block: c++
+
+   foo = (int)    ubuf(buf[1]).i;
+   bar = (tagint) ubuf(buf[2]).i;
+
+The typecast prevents compiler warnings about possible truncations.
+\endverbatim
+  */
+  union ubuf {
+    double  d;
+    int64_t i;
+    ubuf(const double  &arg) : d(arg) {}
+    ubuf(const int64_t &arg) : i(arg) {}
+    ubuf(const int     &arg) : i(arg) {}
+  };
 }
 
 // preprocessor macros for compiler specific settings

--- a/src/pair.h
+++ b/src/pair.h
@@ -258,17 +258,6 @@ class Pair : protected Pointers {
                       double, double, double, double, double, double);
   void virial_fdotr_compute();
 
-  // union data struct for packing 32-bit and 64-bit ints into double bufs
-  // see atom_vec.h for documentation
-
-  union ubuf {
-    double d;
-    int64_t i;
-    ubuf(double arg) : d(arg) {}
-    ubuf(int64_t arg) : i(arg) {}
-    ubuf(int arg) : i(arg) {}
-  };
-
   inline int sbmask(int j) const {
     return j >> SBBITS & 3;
   }

--- a/src/reset_ids.cpp
+++ b/src/reset_ids.cpp
@@ -63,7 +63,7 @@ void ResetIDs::command(int narg, char **arg)
   // process args
 
   int sortflag = 0;
-  
+
   int iarg = 0;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"sort") == 0) {
@@ -74,7 +74,7 @@ void ResetIDs::command(int narg, char **arg)
       iarg += 2;
     } else error->all(FLERR,"Illegal reset_ids command");
   }
-  
+
   // create an atom map if one doesn't exist already
 
   int mapflag = 0;
@@ -260,7 +260,7 @@ void ResetIDs::command(int narg, char **arg)
   }
 
   // reset IDs and atom map for owned atoms
-  
+
   atom->map_clear();
   atom->nghost = 0;
   for (int i = 0; i < nlocal; i++) tag[i] = (tagint) ubuf(newIDs[i][0]).i;
@@ -302,7 +302,7 @@ void ResetIDs::sort()
   // bboxlo,bboxhi = bounding box on all atoms in system
   // expanded by 0.01 percent
   // bbox should work for orthogonal or triclinic system
-  
+
   double **x = atom->x;
   int nlocal = atom->nlocal;
 
@@ -333,7 +333,7 @@ void ResetIDs::sort()
   // nbin_estimate = estimate of total number of bins, each with PERBIN atoms
   // binsize = edge length of a cubic bin
   // nbin xyz = bin count in each dimension
-  
+
   bigint nbin_estimate = atom->natoms / PERBIN;
   double vol;
   if (dim == 2) vol = (bboxhi[0]-bboxlo[0]) * (bboxhi[1]-bboxlo[1]);
@@ -343,7 +343,7 @@ void ResetIDs::sort()
   int nbinx = static_cast<int> ((bboxhi[0]-bboxlo[0]) / binsize) + 1;
   int nbiny = static_cast<int> ((bboxhi[1]-bboxlo[1]) / binsize) + 1;
   int nbinz = static_cast<int> ((bboxhi[2]-bboxlo[2]) / binsize) + 1;
-  
+
   double invx = 1.0 / (bboxhi[0]-bboxlo[0]);
   double invy = 1.0 / (bboxhi[1]-bboxlo[1]);
   double invz;
@@ -359,13 +359,13 @@ void ResetIDs::sort()
   // nbinlo = # of bins owned by low group procs
   // binlo to binhi-1 = bin indices this proc will own in Rvous decomp
   // bins are numbered from 0 to Nbins-1
-  
+
   bigint nbins = (bigint) nbinx*nbiny*nbinz;
   int nlo = nbins / nprocs;
   int nhi = nlo + 1;
   int nplo = nprocs - (nbins % nprocs);
   bigint nbinlo = nplo*nlo;
-  
+
   if (me < nplo) {
     binlo = me * nlo;
     binhi = (me+1) * nlo;
@@ -375,9 +375,9 @@ void ResetIDs::sort()
   }
 
   // fill atombuf with info on my atoms
-  // ibin = which bin the atom is in 
+  // ibin = which bin the atom is in
   // proclist = proc that owns ibin
-  
+
   int *proclist;
   memory->create(proclist,nlocal,"special:proclist");
   AtomRvous *atombuf = (AtomRvous *)
@@ -385,7 +385,7 @@ void ResetIDs::sort()
 
   int ibinx,ibiny,ibinz,iproc;
   bigint ibin;
-  
+
   for (int i = 0; i < nlocal; i++) {
     ibinx = static_cast<int> ((x[i][0]-bboxlo[0])*invx * nbinx);
     ibiny = static_cast<int> ((x[i][1]-bboxlo[1])*invy * nbiny);
@@ -395,7 +395,7 @@ void ResetIDs::sort()
     if (ibin < nbinlo) iproc = ibin / nlo;
     else iproc = nplo + (ibin-nbinlo) / nhi;
     proclist[i] = iproc;
-    
+
     atombuf[i].ibin = ibin;
     atombuf[i].proc = me;
     atombuf[i].ilocal = i;
@@ -403,7 +403,7 @@ void ResetIDs::sort()
     atombuf[i].x[1] = x[i][1];
     atombuf[i].x[2] = x[i][2];
   }
-  
+
   // perform rendezvous operation, send atombuf to other procs
 
   char *buf;
@@ -418,7 +418,7 @@ void ResetIDs::sort()
   // set new ID for all owned atoms
 
   int ilocal;
-  
+
   for (int i = 0; i < nreturn; i++) {
     ilocal = outbuf[i].ilocal;
     atom->tag[ilocal] = outbuf[i].newID;
@@ -438,7 +438,7 @@ int ResetIDs::sort_bins(int n, char *inbuf,
 			void *ptr)
 {
   int i,ibin,index;
-  
+
   ResetIDs *rptr = (ResetIDs *) ptr;
   Memory *memory = rptr->memory;
   Error *error = rptr->error;
@@ -448,7 +448,7 @@ int ResetIDs::sort_bins(int n, char *inbuf,
 
   // nbins = my subset of bins from binlo to binhi-1
   // initialize linked lists of my Rvous atoms in each bin
-  
+
   int *next,*head,*last,*count;
 
   int nbins = binhi - binlo;
@@ -456,16 +456,16 @@ int ResetIDs::sort_bins(int n, char *inbuf,
   memory->create(head,nbins,"resetIDs:head");
   memory->create(last,nbins,"resetIDs:last");
   memory->create(count,nbins,"resetIDs:count");
-  
+
   for (i = 0; i < n; i++) next[i] = -1;
-  
+
   for (ibin = 0; ibin < nbins; ibin++) {
     head[ibin] = last[ibin] = -1;
     count[ibin] = 0;
   }
 
   AtomRvous *in = (AtomRvous *) inbuf;
-  
+
   for (i = 0; i < n; i++) {
     if (in[i].ibin < binlo || in[i].ibin >= binhi) {
       //printf("BAD me %d i %d %d ibin %d binlohi %d %d\n",
@@ -496,7 +496,7 @@ int ResetIDs::sort_bins(int n, char *inbuf,
       index = next[index];
     }
 
-    
+
 #if defined(LMP_QSORT)
     sortrvous = in;
     qsort(order,count[ibin],sizeof(int),compare_coords);
@@ -518,7 +518,7 @@ int ResetIDs::sort_bins(int n, char *inbuf,
   tagint nprev;
   MPI_Scan(&ntag,&nprev,1,MPI_LMP_TAGINT,MPI_SUM,world);
   nprev -= n;
-  
+
   // loop over bins and sorted atoms in each bin, reset ids to be consecutive
   // pass outbuf of IDRvous datums back to comm->rendezvous
 
@@ -548,9 +548,9 @@ int ResetIDs::sort_bins(int n, char *inbuf,
   memory->destroy(last);
   memory->destroy(count);
   memory->destroy(order);
-  
+
   // flag = 2: new outbuf
-  
+
   flag = 2;
   return nout;
 }

--- a/src/reset_ids.h
+++ b/src/reset_ids.h
@@ -53,17 +53,6 @@ class ResetIDs : protected Pointers {
   static int sort_bins(int, char *, int &, int *&, char *&, void *);
   
   void sort();
-  
-  // union data struct for packing 32-bit and 64-bit ints into double bufs
-  // see atom_vec.h for documentation
-
-  union ubuf {
-    double d;
-    int64_t i;
-    ubuf(double arg) : d(arg) {}
-    ubuf(int64_t arg) : i(arg) {}
-    ubuf(int arg) : i(arg) {}
-  };
 };
 
 }

--- a/src/table_file_reader.cpp
+++ b/src/table_file_reader.cpp
@@ -38,7 +38,7 @@ TableFileReader::~TableFileReader() {
 
 char * TableFileReader::find_section_start(const std::string & keyword) {
   char * line = nullptr;
-  while (line = reader->next_line()) {
+  while ((line = reader->next_line())) {
     ValueTokenizer values(line);
     std::string word = values.next_string();
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -498,7 +498,7 @@ std::string utils::get_potential_date(const std::string & path, const std::strin
   reader.ignore_comments = false;
   char * line = nullptr;
 
-  while (line = reader.next_line()) {
+  while ((line = reader.next_line())) {
     ValueTokenizer values(line);
     while (values.has_next()) {
       std::string word = values.next_string();

--- a/unittest/utils/test_fmtlib.cpp
+++ b/unittest/utils/test_fmtlib.cpp
@@ -42,45 +42,63 @@ TEST(FmtLib, insert_neg_int) {
 }
 
 TEST(FmtLib, insert_bigint) {
-    if (sizeof(bigint) == 4) GTEST_SKIP();
+#if defined(LAMMPS_BIGBIG) || defined(LAMMPS_SMALLBIG)
     const bigint val = 9945234592L;
     auto text = fmt::format("word {}",val);
     ASSERT_THAT(text, Eq("word 9945234592"));
+#else
+    GTEST_SKIP();
+#endif
 }
 
 TEST(FmtLib, insert_neg_bigint) {
-    if (sizeof(bigint) == 4) GTEST_SKIP();
+#if defined(LAMMPS_BIGBIG) || defined(LAMMPS_SMALLBIG)
     const bigint val = -9945234592L;
     auto text = fmt::format("word {}",val);
     ASSERT_THAT(text, Eq("word -9945234592"));
+#else
+    GTEST_SKIP();
+#endif
 }
 
 TEST(FmtLib, insert_tagint) {
-    if (sizeof(tagint) == 4) GTEST_SKIP();
+#if defined(LAMMPS_BIGBIG)
     const tagint val = 9945234592L;
     auto text = fmt::format("word {}",val);
     ASSERT_THAT(text, Eq("word 9945234592"));
+#else
+    GTEST_SKIP();
+#endif
 }
 
 TEST(FmtLib, insert_neg_tagint) {
-    if (sizeof(tagint) == 4) GTEST_SKIP();
+#if defined(LAMMPS_BIGBIG)
     const tagint val = -9945234592L;
     auto text = fmt::format("word {}",val);
     ASSERT_THAT(text, Eq("word -9945234592"));
+#else
+    GTEST_SKIP();
+#endif
 }
 
 TEST(FmtLib, insert_imageint) {
-    if (sizeof(imageint) == 4) GTEST_SKIP();
+#if defined(LAMMPS_BIGBIG)
     const imageint val = 9945234592L;
     auto text = fmt::format("word {}",val);
     ASSERT_THAT(text, Eq("word 9945234592"));
+#else
+    GTEST_SKIP();
+#endif
 }
 
 TEST(FmtLib, insert_neg_imageint) {
-    if (sizeof(imageint) == 4) GTEST_SKIP();
+#if defined(LAMMPS_BIGBIG)
     const imageint val = -9945234592L;
     auto text = fmt::format("word {}",val);
     ASSERT_THAT(text, Eq("word -9945234592"));
+#else
+    GTEST_SKIP();
+#endif
 }
 
 TEST(FmtLib, insert_double) {


### PR DESCRIPTION
**Summary**

Consolidate the growing number of `union ubuf` definitions to a single version in `lmptype.h`.

**Related Issues**

Already includes code from PR #2142 as that added another definition.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

This also includes a possible optimization by making the constructor use a constant reference parameter, which should tell the compiler that it is not needed to make a copy. Most compilers should do this already with higher optimization levels, but it cannot hurt to make it explicit.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
