### PR TITLE
Remove unnecessary memory allocation in Kokkos PairSNAP

### DIFF
--- a/src/KOKKOS/sna_kokkos_impl.h
+++ b/src/KOKKOS/sna_kokkos_impl.h
@@ -247,8 +247,6 @@ void SNAKokkos<DeviceType>::grow_rij(int newnatom, int newnmax)
 
   //ylist = t_sna_2c_lr("sna:ylist",natom,idxu_max);
   ylist = t_sna_2c_ll("sna:ylist",idxu_max,natom);
-
-  dulist = t_sna_4c_ll("sna:dulist",idxu_max,natom,nmax);
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

Remove unnecessary memory allocation in Kokkos PairSNAP, that can lead to a large memory overhead

**Related Issues**

None

**Author(s)**

Stan Moore (SNL), reported by @charlessievers 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

@weinbe2 