### PR TITLE
Add utilities for checking code

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -676,6 +676,7 @@ endif()
 
 include(Testing)
 include(CodeCoverage)
+include(CodingStandard)
 
 ###############################################################################
 # Print package summary

--- a/cmake/Modules/CodingStandard.cmake
+++ b/cmake/Modules/CodingStandard.cmake
@@ -16,9 +16,19 @@ if (Python3_EXECUTABLE)
           WORKING_DIRECTORY  ${LAMMPS_DIR}
           COMMENT "Check for whitespace errors")
         add_custom_target(
+          check-permissions
+          ${Python3_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/permissions.py .
+          WORKING_DIRECTORY  ${LAMMPS_DIR}
+          COMMENT "Check for permission errors")
+        add_custom_target(
           fix-whitespace
           ${Python3_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/whitespace.py -f .
           WORKING_DIRECTORY  ${LAMMPS_DIR}
           COMMENT "Fix whitespace errors")
+        add_custom_target(
+          fix-permissions
+          ${Python3_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/permission.py -f .
+          WORKING_DIRECTORY  ${LAMMPS_DIR}
+          COMMENT "Fix permission errors")
     endif()
 endif()

--- a/cmake/Modules/CodingStandard.cmake
+++ b/cmake/Modules/CodingStandard.cmake
@@ -1,0 +1,21 @@
+if(CMAKE_VERSION VERSION_LESS 3.12)
+    find_package(PythonInterp) # Deprecated since version 3.12
+    if(PYTHONINTERP_FOUND)
+        set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
+    endif()
+else()
+    find_package(Python COMPONENTS Interpreter)
+endif()
+
+if (Python_EXECUTABLE)
+    add_custom_target(
+      check-whitespace
+      ${Python_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/whitespace.py .
+      WORKING_DIRECTORY  ${LAMMPS_DIR}
+      COMMENT "Check for whitespace errors")
+    add_custom_target(
+      fix-whitespace
+      ${Python_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/whitespace.py -f .
+      WORKING_DIRECTORY  ${LAMMPS_DIR}
+      COMMENT "Fix whitespace errors")
+endif()

--- a/cmake/Modules/CodingStandard.cmake
+++ b/cmake/Modules/CodingStandard.cmake
@@ -1,21 +1,24 @@
 if(CMAKE_VERSION VERSION_LESS 3.12)
-    find_package(PythonInterp) # Deprecated since version 3.12
+    find_package(PythonInterp 3.5 QUIET) # Deprecated since version 3.12
     if(PYTHONINTERP_FOUND)
-        set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
+        set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
+        set(Python3_VERSION ${PYTHON_VERSION_STRING})
     endif()
 else()
-    find_package(Python COMPONENTS Interpreter)
+    find_package(Python3 COMPONENTS Interpreter QUIET)
 endif()
 
-if (Python_EXECUTABLE)
-    add_custom_target(
-      check-whitespace
-      ${Python_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/whitespace.py .
-      WORKING_DIRECTORY  ${LAMMPS_DIR}
-      COMMENT "Check for whitespace errors")
-    add_custom_target(
-      fix-whitespace
-      ${Python_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/whitespace.py -f .
-      WORKING_DIRECTORY  ${LAMMPS_DIR}
-      COMMENT "Fix whitespace errors")
+if (Python3_EXECUTABLE)
+    if(Python3_VERSION VERSION_GREATER_EQUAL 3.5)
+        add_custom_target(
+          check-whitespace
+          ${Python3_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/whitespace.py .
+          WORKING_DIRECTORY  ${LAMMPS_DIR}
+          COMMENT "Check for whitespace errors")
+        add_custom_target(
+          fix-whitespace
+          ${Python3_EXECUTABLE} ${LAMMPS_TOOLS_DIR}/coding_standard/whitespace.py -f .
+          WORKING_DIRECTORY  ${LAMMPS_DIR}
+          COMMENT "Fix whitespace errors")
+    endif()
 endif()

--- a/tools/coding_standard/permissions.py
+++ b/tools/coding_standard/permissions.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Utility for detecting and fixing file permission issues in LAMMPS
+#
+# Written by Richard Berger (Temple University)
+import os
+import glob
+import yaml
+import argparse
+import stat
+
+DEFAULT_CONFIG = """
+permission: "rw-r--r--"
+recursive: true
+include:
+    - cmake/**
+    - doc/src/**
+    - python
+    - src/**
+    - examples/**
+    - tools/coding_standard
+patterns:
+    - "*.c"
+    - "*.cmake"
+    - "*.cpp"
+    - "*.h"
+    - "*.jpg"
+    - "*.md"
+    - "*.pdf"
+    - "*.png"
+    - "*.rst"
+    - "*.tex"
+    - ".gitignore"
+    - "README"
+    - "in.*"
+    - "requirements.txt"
+"""
+
+def check_permission(path, mask):
+    st = os.stat(path)
+    return bool(stat.S_IMODE(st.st_mode) == mask)
+
+def generate_permission_mask(line):
+    assert(len(line) == 9)
+    mask = 0
+
+    # USER
+    if line[0] == "r":
+        mask |= stat.S_IRUSR
+    if line[1] == "w":
+        mask |= stat.S_IWUSR
+    if line[2] == "x":
+        mask |= stat.S_IXUSR
+
+    # GROUP
+    if line[3] == "r":
+        mask |= stat.S_IRGRP
+    if line[4] == "w":
+        mask |= stat.S_IWGRP
+    if line[5] == "x":
+        mask |= stat.S_IXGRP
+
+    # OTHER
+    if line[6] == "r":
+        mask |= stat.S_IROTH
+    if line[7] == "w":
+        mask |= stat.S_IWOTH
+    if line[8] == "x":
+        mask |= stat.S_IXOTH
+
+    return mask
+
+def check_folder(directory, config, fix=False, verbose=False):
+    files = []
+
+    for base_path in config['include']:
+        for pattern in config['patterns']:
+            path = os.path.join(directory, base_path, pattern)
+            files += glob.glob(path, recursive=config['recursive'])
+
+    mask = generate_permission_mask(config['permission'])
+
+    for f in files:
+        path = os.path.normpath(f)
+
+        if verbose:
+            print("Checking file:", path)
+
+        ok = check_permission(path, mask)
+
+        if not ok:
+            print("[Error] Wrong file permissions @ {}".format(path))
+
+            if fix:
+                if os.access(path, os.W_OK):
+                    print("Changing permissions of file {} to '{}'".format(path, config['permission']))
+                    os.chmod(path, mask)
+                else:
+                    print("[Error] Can not write permissions of file {}".format(path))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Utility for detecting and fixing file permission issues in LAMMPS')
+    parser.add_argument('-c', '--config', metavar='CONFIG_FILE', help='location of a optional configuration file')
+    parser.add_argument('-f', '--fix', action='store_true', help='automatically fix permissions')
+    parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+    parser.add_argument('DIRECTORY', help='directory that should be checked')
+    args = parser.parse_args()
+
+    if args.config:
+        with open(args.config, 'r') as cfile:
+            config = yaml.load(cfile, Loader=yaml.FullLoader)
+    else:
+        config = yaml.load(DEFAULT_CONFIG, Loader=yaml.FullLoader)
+
+    check_folder(args.DIRECTORY, config, args.fix, args.verbose)
+
+if __name__ == "__main__":
+    main()

--- a/tools/coding_standard/whitespace.py
+++ b/tools/coding_standard/whitespace.py
@@ -17,18 +17,19 @@ include:
     - doc/src/**
     - python
     - src/**
+    - tools/coding_standard
 patterns:
+    - "*.c"
+    - "*.cmake"
+    - "*.cpp"
+    - "*.h"
+    - "*.md"
+    - "*.py"
+    - "*.rst"
+    - "*.sh"
     - ".gitignore"
     - "README"
     - "requirements.txt"
-    - "*.c"
-    - "*.cpp"
-    - "*.h"
-    - "*.sh"
-    - "*.py"
-    - "*.md"
-    - "*.rst"
-    - "*.cmake"
 """
 
 def check_trailing_whitespace(f):

--- a/tools/coding_standard/whitespace.py
+++ b/tools/coding_standard/whitespace.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Utility for detecting and fixing whitespace issues in LAMMPS
+#
+# Written by Richard Berger (Temple University)
+import os
+import glob
+import re
+import yaml
+import argparse
+import shutil
+
+DEFAULT_CONFIG = """
+recursive: true
+include:
+    - cmake/**
+    - doc
+    - doc/src/**
+    - python
+    - src/**
+patterns:
+    - ".gitignore"
+    - "README"
+    - "requirements.txt"
+    - "*.c"
+    - "*.cpp"
+    - "*.h"
+    - "*.sh"
+    - "*.py"
+    - "*.md"
+    - "*.rst"
+    - "*.cmake"
+"""
+
+def check_trailing_whitespace(f):
+    pattern = re.compile(r'\s+\n$')
+    last_line = "\n"
+    lineno = 1
+    errors = set()
+
+    for line in f:
+        if pattern.match(line):
+            errors.add(lineno)
+        last_line = line
+        lineno += 1
+
+    return errors, last_line
+
+def check_file(path):
+    encoding = 'UTF-8'
+    last_line = "\n"
+    whitespace_errors = set()
+    try:
+        with open(path, 'r') as f:
+            whitespace_errors, last_line = check_trailing_whitespace(f)
+    except UnicodeDecodeError:
+        encoding = 'ISO-8859-1'
+        try:
+            with open(path, 'r', encoding=encoding) as f:
+                whitespace_errors, last_line = check_trailing_whitespace(f)
+        except Exception:
+            encoding = 'unknown'
+
+    return {
+        'whitespace_errors': whitespace_errors,
+        'encoding': encoding,
+        'eof_error': not last_line.endswith('\n')
+    }
+
+def fix_file(path, check_result):
+    newfile = path + ".modified"
+    with open(newfile, 'w', encoding='UTF-8') as out:
+        with open(path, 'r', encoding=check_result['encoding']) as src:
+            for line in src:
+                print(line.rstrip(), file=out)
+    shutil.move(newfile, path)
+
+def check_folder(directory, config, fix=False, verbose=False):
+    files = []
+
+    for base_path in config['include']:
+        for pattern in config['patterns']:
+            path = os.path.join(directory, base_path, pattern)
+            files += glob.glob(path, recursive=config['recursive'])
+
+    for f in files:
+        path = os.path.normpath(f)
+
+        if verbose:
+            print("Checking file:", path)
+
+        result = check_file(path)
+
+        has_resolvable_errors = False
+
+        for lineno in result['whitespace_errors']:
+            print("[Error] Trailing whitespace @ {}:{}".format(path, lineno))
+            has_resolvable_errors = True
+
+        if result['eof_error']:
+            print("[Error] Missing newline at end of file @ {}".format(path))
+            has_resolvable_errors = True
+
+        if result['encoding'] == 'unknown':
+            print("[Error] Unknown text encoding @ {}".format(path))
+            has_resolvable_errors = False
+        elif result['encoding'] == 'ISO-8859-1':
+            print("[Error] Found ISO-8859-1 encoding instead of UTF-8 @ {}".format(path))
+            has_resolvable_errors = True
+
+        if has_resolvable_errors and fix:
+            print("Applying automatic fixes to file:", path)
+            fix_file(path, result)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Utility for detecting and fixing whitespace issues in LAMMPS')
+    parser.add_argument('-c', '--config', metavar='CONFIG_FILE', help='location of a optional configuration file')
+    parser.add_argument('-f', '--fix', action='store_true', help='automatically fix common issues')
+    parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+    parser.add_argument('DIRECTORY', help='directory that should be checked')
+    args = parser.parse_args()
+
+    if args.config:
+        with open(args.config, 'r') as cfile:
+            config = yaml.load(cfile, Loader=yaml.FullLoader)
+    else:
+        config = yaml.load(DEFAULT_CONFIG, Loader=yaml.FullLoader)
+
+    check_folder(args.DIRECTORY, config, args.fix, args.verbose)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Summary**

* Adds whitespace utility to check and fix common whitespace and file encoding issues
* Adds `check-whitespace` and `fix-whitespace` targets to cmake build
* Adds check for file permissions (e.g. source files or input scripts shouldn't be executable)
* Add `check-permissions` and `fix-permissions` targets to cmake build

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


