### PR TITLE
Portability improvement for src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ SHLIB =  liblammps_$@.so
 ARLINK = liblammps.a
 SHLINK = liblammps.so
 TMPNAME= tmp_$@_name
-LMPLINK=$(shell echo $(ARLIB) | sed -e 's,lib\([+0-9a-z_-]\+\)\.a$$,-L. -l\1,')
+LMPLINK= -L. -llammps_$@
 
 OBJDIR =   Obj_$@
 OBJSHDIR = Obj_shared_$@
@@ -75,13 +75,18 @@ PACKEXT = kim latte mscg voronoi \
 
 PACKALL = $(PACKAGE) $(PACKUSER)
 
-PACKAGEUC = $(shell echo $(PACKAGE) | tr a-z A-Z)
-PACKUSERUC = $(shell echo $(PACKUSER) | tr a-z A-Z)
+# Helper GNU make function for conversion to upper case without using shell commands
+uppercase_TABLE:=a,A b,B c,C d,D e,E f,F g,G h,H i,I j,J k,K l,L m,M n,N o,O p,P q,Q r,R s,S t,T u,U v,V w,W x,X y,Y z,Z
+uppercase_internal=$(if $1,$$(subst $(firstword $1),$(call uppercase_internal,$(wordlist 2,$(words $1),$1),$2)),$2)
+uppercase=$(eval uppercase_RESULT:=$(call uppercase_internal,$(uppercase_TABLE),$1))$(uppercase_RESULT)
 
-YESDIR = $(shell echo $(@:yes-%=%) | tr a-z A-Z)
-NODIR  = $(shell echo $(@:no-%=%) | tr a-z A-Z)
-LIBDIR = $(shell echo $(@:lib-%=%))
-LIBUSERDIR = $(shell echo $(@:lib-user-%=%))
+PACKAGEUC = $(call uppercase,$(PACKAGE))
+PACKUSERUC = $(call uppercase,$(PACKUSER))
+
+YESDIR = $(call uppercase,$(@:yes-%=%))
+NODIR  = $(call uppercase,$(@:no-%=%))
+LIBDIR = $($(@:lib-%=%))
+LIBUSERDIR = $($(@:lib-user-%=%))
 
 # List of all targets
 


### PR DESCRIPTION
**Summary**

Use GNU make features to do operations previously delegated to shell commands.
This avoids having to worry about conflicts with shell command features on non-Linux machines.
It should also result in (slightly) faster execution.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. 

**Implementation Notes**

The uppercase conversion method is already used in lib/kokkos/Makefile.kokkos

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
