### PR TITLE
Small typo at the Z rotation matrix member

### DIFF
--- a/src/math_extra.cpp
+++ b/src/math_extra.cpp
@@ -638,7 +638,7 @@ void BuildRyMatrix(double R[3][3], const double angle)
 }
 
 /* ----------------------------------------------------------------------
- Build rotation matrix for a small angle rotation around the Y axis
+ Build rotation matrix for a small angle rotation around the Z axis
  ------------------------------------------------------------------------- */
 
 void BuildRzMatrix(double R[3][3], const double angle)


### PR DESCRIPTION
The comment from the previous function (rotation around Y axis) seems to have been copy/pasted


