### PR TITLE
Update atom_vec_sph.cpp

### DIFF
--- a/src/USER-SPH/atom_vec_sph.cpp
+++ b/src/USER-SPH/atom_vec_sph.cpp
@@ -45,7 +45,7 @@ AtomVecSPH::AtomVecSPH(LAMMPS *lmp) : AtomVec(lmp)
   fields_border_vel = (char *) "rho esph cv vest";
   fields_exchange = (char *) "rho esph cv vest";
   fields_restart = (char * ) "rho esph cv vest";
-  fields_create = (char *) "rho esph cv vest de drho";
+  fields_create = (char *) "rho esph cv vest desph drho";
   fields_data_atom = (char *) "id type rho esph cv x";
   fields_data_vel = (char *) "id v";
 


### PR DESCRIPTION


**Summary**

Looks like one 'de' wasn't renamed to 'desph' in recent commit.

**Related Issues**

Fixes following issue.
ERROR: Peratom field de not recognized (../atom_vec.cpp:2475)
Last command: atom_style         sph

**Author(s)**

Christopher Knight (ANL) cjknight2009@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No.

**Implementation Notes**

examples/user/sph/cavity_flow now runs to completion.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**




