### PR TITLE
Chem snap

### DIFF
--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -655,8 +655,11 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPZeroYi,const typename Ko
   const int ii = team.league_rank() / ((my_sna.idxu_max+team.team_size()-1)/team.team_size());
   if (ii >= chunk_size) return;
 
-  for(int ielem = 0; ielem < nelements; ielem++)
-    my_sna.zero_yi(idx,ii,ielem);
+  if (chemflag)
+    for(int ielem = 0; ielem < nelements; ielem++)
+      my_sna.zero_yi(idx,ii,ielem);
+  else
+    my_sna.zero_yi(idx,ii,0);
 }
 
 template<class DeviceType>


### PR DESCRIPTION
**Summary**

Remove extra for loop when not utilizing chem snap.

**Related Issues**

Potentially fixes #2166 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Implementation Notes**

I have run in.snap.W, in.snap.WBe, and in.snap.InP using both KOKKOS openmp and cuda while Kokkos_ENABLE_DEBUG=on and report no error.


