### PR TITLE
Deallocate per-atom data less aggressively so replicate command keeps working

### DIFF
--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -33,6 +33,8 @@ using namespace MathConst;
 #define DELTA 16384
 #define DELTA_BONUS 8192
 
+int AtomVec::num_atom_vecs = 0;
+
 /* ---------------------------------------------------------------------- */
 
 AtomVec::AtomVec(LAMMPS *lmp) : Pointers(lmp)
@@ -53,6 +55,8 @@ AtomVec::AtomVec(LAMMPS *lmp) : Pointers(lmp)
   argcopy = NULL;
 
   threads = NULL;
+
+  ++num_atom_vecs;
 
   // peratom variables auto-included in corresponding child style fields string
   // these fields cannot be specified in the fields string
@@ -93,44 +97,48 @@ AtomVec::~AtomVec()
   int datatype,cols;
   void *pdata;
 
+  --num_atom_vecs;
+
   for (int i = 0; i < nargcopy; i++) delete [] argcopy[i];
   delete [] argcopy;
 
-  memory->destroy(atom->tag);
-  memory->destroy(atom->type);
-  memory->destroy(atom->mask);
-  memory->destroy(atom->image);
-  memory->destroy(atom->x);
-  memory->destroy(atom->v);
-  memory->destroy(atom->f);
+  if (num_atom_vecs == 0) {
+    memory->destroy(atom->tag);
+    memory->destroy(atom->type);
+    memory->destroy(atom->mask);
+    memory->destroy(atom->image);
+    memory->destroy(atom->x);
+    memory->destroy(atom->v);
+    memory->destroy(atom->f);
 
-  for (int i = 0; i < ngrow; i++) {
-    pdata = mgrow.pdata[i];
-    datatype = mgrow.datatype[i];
-    cols = mgrow.cols[i];
-    if (datatype == Atom::DOUBLE) {
-      if (cols == 0)
-        memory->destroy(*((double **) pdata));
-      else if (cols > 0)
-        memory->destroy(*((double ***) pdata));
-      else {
-        memory->destroy(*((double ***) pdata));
-      }
-    } else if (datatype == Atom::INT) {
-      if (cols == 0)
-        memory->destroy(*((int **) pdata));
-      else if (cols > 0)
-        memory->destroy(*((int ***) pdata));
-      else {
-        memory->destroy(*((int ***) pdata));
-      }
-    } else if (datatype == Atom::BIGINT) {
-      if (cols == 0)
-        memory->destroy(*((bigint **) pdata));
-      else if (cols > 0)
-        memory->destroy(*((bigint ***) pdata));
-      else {
-        memory->destroy(*((bigint ***) pdata));
+    for (int i = 0; i < ngrow; i++) {
+      pdata = mgrow.pdata[i];
+      datatype = mgrow.datatype[i];
+      cols = mgrow.cols[i];
+      if (datatype == Atom::DOUBLE) {
+        if (cols == 0)
+          memory->destroy(*((double **) pdata));
+        else if (cols > 0)
+          memory->destroy(*((double ***) pdata));
+        else {
+          memory->destroy(*((double ***) pdata));
+        }
+      } else if (datatype == Atom::INT) {
+        if (cols == 0)
+          memory->destroy(*((int **) pdata));
+        else if (cols > 0)
+          memory->destroy(*((int ***) pdata));
+        else {
+          memory->destroy(*((int ***) pdata));
+        }
+      } else if (datatype == Atom::BIGINT) {
+        if (cols == 0)
+          memory->destroy(*((bigint **) pdata));
+        else if (cols > 0)
+          memory->destroy(*((bigint ***) pdata));
+        else {
+          memory->destroy(*((bigint ***) pdata));
+        }
       }
     }
   }

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -209,6 +209,10 @@ class AtomVec : protected Pointers {
 
   bool *threads;
 
+  // counter for atom vec instances
+
+  static int num_atom_vecs;
+
   // local methods
 
   void grow_nmax();


### PR DESCRIPTION
**Summary**

The AtomVec class may not deallocate per-atom data if there are other instances in use, e.g. within the replicate command.

**Related Issues**

Fixes #2177 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
