### PR TITLE
Fix issue in AtomVec deallocation with Kokkos enabled

### DIFF
--- a/src/KOKKOS/atom_vec_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_kokkos.cpp
@@ -34,6 +34,19 @@ AtomVecKokkos::AtomVecKokkos(LAMMPS *lmp) : AtomVec(lmp)
 
 /* ---------------------------------------------------------------------- */
 
+AtomVecKokkos::~AtomVecKokkos()
+{
+  atom->tag = NULL;
+  atom->type = NULL;
+  atom->mask = NULL;
+  atom->image = NULL;
+  atom->x = NULL;
+  atom->v = NULL;
+  atom->f = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
 template<class DeviceType,int PBC_FLAG,int TRICLINIC>
 struct AtomVecKokkos_PackComm {
   typedef DeviceType device_type;

--- a/src/KOKKOS/atom_vec_kokkos.h
+++ b/src/KOKKOS/atom_vec_kokkos.h
@@ -34,7 +34,7 @@ union d_ubuf {
 class AtomVecKokkos : public AtomVec {
  public:
   AtomVecKokkos(class LAMMPS *);
-  virtual ~AtomVecKokkos() {}
+  virtual ~AtomVecKokkos();
   virtual int pack_comm(int, int *, double *, int, int *);
   virtual int pack_comm_vel(int, int *, double *, int, int *);
   virtual void unpack_comm(int, int, double *);


### PR DESCRIPTION
**Summary**

Fix issue in AtomVec deallocation. Kokkos AtomVec Views are reference-counted and don't need to be deallocated by the parent class. Trying to free the host pointer of a Kokkos view leads to a crash.

**Related Issues**

Fixes #2184 

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes