### PR TITLE
Fix virial computation in GPU accelerated TIP4P

### DIFF
--- a/src/GPU/pair_lj_cut_tip4p_long_gpu.cpp
+++ b/src/GPU/pair_lj_cut_tip4p_long_gpu.cpp
@@ -109,10 +109,7 @@ PairLJCutTIP4PLongGPU::~PairLJCutTIP4PLongGPU()
 
 void PairLJCutTIP4PLongGPU::compute(int eflag, int vflag)
 {
-
-  if (eflag || vflag) ev_setup(eflag,vflag);
-  else evflag = vflag_fdotr = 0;
-
+  ev_init(eflag,vflag);
   int nall = atom->nlocal + atom->nghost;
   int inum, host_start;
 


### PR DESCRIPTION
**Summary**

This PR fixes a bug in GPU accelerated TIP4P which led to incorrect virial accumulation in case  `eflag == 0, vflag == 1`.
Also, I got rid of compiler warnings when compiling this pair style.

**Related Issues**

Fixes #2175

**Author(s)**

Vsevolod Nikolskiy (thevsevak@gmail.com, @Vsevak)
International Laboratory for Supercomputer Atomistic Modelling and Multi-scale Analysis
HSE University, Moscow, Russia

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Keeps

**Implementation Notes**

The virial must be stored in memory with a various offset, depending on whether the energy is calculated at the current timestep or not. Testing was carried out using input from #2175.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [x] One or more example input decks are included


