### PR TITLE
Reduce use of local print buffers, simplify output handling with std::string and fmtlib

### DIFF
--- a/examples/README
+++ b/examples/README
@@ -88,6 +88,7 @@ melt:     rapid melt of 3d LJ system
 message:  client/server coupling of 2 codes
 micelle:  self-assembly of small lipid-like molecules into 2d bilayers
 min:      energy minimization of 2d LJ melt
+mliap:    examples for using several bundled MLIAP potentials
 mscg:     parameterize a multi-scale coarse-graining (MSCG) model
 msst:     MSST shock dynamics
 nb3b:     use of nonbonded 3-body harmonic pair style

--- a/lib/awpmd/ivutils/include/pairhash.h
+++ b/lib/awpmd/ivutils/include/pairhash.h
@@ -122,11 +122,8 @@
 # define PAIRHASH_H
 
 /*e @file pairhash.h @brief pair hash table
-*/ 
+*/
 
-
-/*r @file pairhash.h @brief работа с хеш-таблицами парных величин 
-*/ 
 
 # include "refobj.h"
 
@@ -146,7 +143,7 @@ public:
       incr=inc_first ? parent->sizex : 1 ;
     };
     iterator(T *ptr_,size_t incr_):ptr(ptr_),incr(incr_){}
-  public: 
+  public:
     iterator(const iterator &other):ptr(other.ptr),incr(other.incr){
     }
     iterator():ptr(NULL),incr(0){}
@@ -159,7 +156,7 @@ public:
       ++*this;
       return tmp;
     }
-    iterator operator+(int delta) const { 
+    iterator operator+(int delta) const {
       return iterator(ptr+delta*incr,incr);
     }
     bool operator!=(const iterator &other) const {
@@ -194,7 +191,7 @@ public:
         init(other.sizex,other.sizey,1);
       size_t n=get_datasize(sizex,sizey);
       for(size_t i=0;i<n;i++)
-        arr[i]=other.arr[i];  
+        arr[i]=other.arr[i];
     }
     return *this;
   }
@@ -224,7 +221,7 @@ public:
 
   virtual int init(size_t nx, size_t ny, int smanaged=-1){
     int managed=parr.managed();
-    if(managed && (sizex!=nx || sizey!=ny)){  
+    if(managed && (sizex!=nx || sizey!=ny)){
       parr.reset(NULL,0);
     }
     if(smanaged>=0){ // for changing the managed flag?
@@ -241,14 +238,14 @@ public:
       arr=parr.ptr();
     }
     return 1;
-  } 
+  }
 
-  recmatrix(size_t nx, size_t ny):sizex(0), sizey(0){ 
+  recmatrix(size_t nx, size_t ny):sizex(0), sizey(0){
     init(nx,ny,1);
   }
 
   //e initializes by unmanaged pointer
-  recmatrix(size_t nx, size_t ny , T *ptr):parr(ptr,0),sizex(nx), sizey(ny) { 
+  recmatrix(size_t nx, size_t ny , T *ptr):parr(ptr,0),sizex(nx), sizey(ny) {
     init(nx,ny);
   }
 
@@ -264,14 +261,14 @@ public:
     size_t i, n=get_datasize(sizex,sizey);
     for(i=0;i<n;i++)arr[i]=val;
   }
-  
+
   void SetDiag(const T &val){
     size_t i, size=(sizex>sizey? sizey: sizex);
     for(i=0;i<size;i++){
       (*this)(i,i)=val;
     }
   }
- 
+
   /// returns iterator with fixed first index to iterate through matrix line elements
   iterator fix_first(size_t first, size_t second) const {
     return iterator(this,first,second,false);
@@ -281,14 +278,14 @@ public:
   iterator fix_second(size_t first, size_t second) const {
     return iterator(this,first,second, true);
   }
- 
+
 };
 
 
 //e square matrix
 template <class T>
 class sqmatrix: public recmatrix<T> {
-  
+
 public:
 
   size_t size;
@@ -313,18 +310,18 @@ public:
     return n*n;
   }
 
- 
+
   virtual int init(size_t n, int smanaged=-1){
     size=n;
     return recmatrix<T>::init(n,n,smanaged);
-  } 
+  }
 
-  sqmatrix(size_t n):size(0){ 
+  sqmatrix(size_t n):size(0){
     init(n,1);
   }
 
   //e initializes by unmanaged pointer
-  sqmatrix(size_t n, T * /* ptr */):size(n){ 
+  sqmatrix(size_t n, T * /* ptr */):size(n){
     init(n);
   }
 
@@ -335,7 +332,7 @@ public:
     recmatrix<T>::parr.reset(ptr,0);
   }
 
- 
+
 };
 
 
@@ -355,7 +352,7 @@ public:
       incr=inc_first ? parent->size : 1 ;
     };
     iterator(T *ptr_,size_t incr_):ptr(ptr_),incr(incr_){}
-  public: 
+  public:
     iterator(const iterator &other):ptr(other.ptr),incr(other.incr){
     }
     iterator():ptr(NULL),incr(0){}
@@ -368,7 +365,7 @@ public:
       ++*this;
       return tmp;
     }
-    iterator operator+(int delta) const { 
+    iterator operator+(int delta) const {
       return iterator(ptr+delta*incr,incr);
     }
     bool operator!=(const iterator &other) const {
@@ -403,7 +400,7 @@ public:
         init(other.size,1);
       size_t n=get_datasize(size);
       for(size_t i=0;i<n;i++)
-        arr[i]=other.arr[i];  
+        arr[i]=other.arr[i];
     }
     return *this;
   }
@@ -432,7 +429,7 @@ public:
 
   virtual int init(size_t n, int smanaged=-1){
     int managed=parr.managed();
-    if(managed && size!=n){  
+    if(managed && size!=n){
       parr.reset(NULL,0);
     }
     if(smanaged>=0){ // for changing the managed flag?
@@ -448,14 +445,14 @@ public:
       arr=parr.ptr();
     }
     return 1;
-  } 
+  }
 
-  sqmatrix(size_t n):size(0){ 
+  sqmatrix(size_t n):size(0){
     init(n,1);
   }
 
   //e initializes by unmanaged pointer
-  sqmatrix(size_t n, T *ptr):parr(ptr,0),size(n){ 
+  sqmatrix(size_t n, T *ptr):parr(ptr,0),size(n){
     init(n);
   }
 
@@ -470,14 +467,14 @@ public:
     size_t i, n=get_datasize(size);
     for(i=0;i<n;i++)arr[i]=val;
   }
-  
+
   void SetDiag(const T &val){
     size_t i;
     for(i=0;i<size;i++){
       (*this)(i,i)=val;
     }
   }
- 
+
   /// returns iterator with fixed first index to iterate through matrix line elements
   iterator fix_first(size_t first, size_t second) const {
     return iterator(this,first,second,false);
@@ -487,15 +484,15 @@ public:
   iterator fix_second(size_t first, size_t second) const {
     return iterator(this,first,second, true);
   }
- 
+
 };
 
-# endif 
+# endif
 
  //e prints the matrix into a file
 template< class matrix_t>
 int fileout(FILE *f, const matrix_t &matr, const char *elm_fmt, const char *elm_sep=" ", const char *line_sep="\n"){
-  size_t i, j; 
+  size_t i, j;
   int res=0;
   for(i=0;i<matr.size;i++){
     for(j=0;j<matr.size;j++){
@@ -513,15 +510,15 @@ template <class T>
 class smatrix: public sqmatrix<T>{
   typedef  sqmatrix<T> base_t;
 public:
- 
+
   virtual size_t get_datasize(size_t n) const{
     return n*(n+1)/2;
   }
-  
+
   size_t index(size_t i, size_t j) const {
     if(i>=j)
       return (2*base_t::size-j-1)*j/2+i;
-    else 
+    else
       return (2*base_t::size-i-1)*i/2+j;
   }
 
@@ -572,7 +569,7 @@ public:
   hmatrix() : smatrix<T>() {}
 
   hmatrix(const smatrix<T> &other) : smatrix<T>(other) {}
-  
+
   //e copy constructor: makes a managed copy
   hmatrix(const hmatrix &other): smatrix<T>(other){}
 
@@ -671,7 +668,7 @@ public:
     indm.Set(-1);
     return 1;
   }
-  
+
   virtual ~PairHashM(){
     delete [] arr;
   }

--- a/potentials/charmm22.cmap
+++ b/potentials/charmm22.cmap
@@ -1,4 +1,4 @@
-# DATE: 2016-09-26 CONTRIBUTOR: Robert Latour, latourr@clemson.edu  CITATION: TBA
+# DATE: 2016-09-26 UNITS: real CONTRIBUTOR: Robert Latour, latourr@clemson.edu  CITATION: TBA
 # Title: charmm22/charmm27 dihedral correction map
 
 #  alanine map, type 1

--- a/potentials/charmm36.cmap
+++ b/potentials/charmm36.cmap
@@ -1,4 +1,4 @@
-# DATE: 2016-09-26 CONTRIBUTOR: Robert Latour, latourr@clemson.edu  CITATION: TBA
+# DATE: 2016-09-26 UNITS:real CONTRIBUTOR: Robert Latour, latourr@clemson.edu  CITATION: TBA
 # Title: charmm36 dihedral correction map
 
 #  alanine map, type 1

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -669,6 +669,7 @@ void PairEAM::file2array()
 
   // create a z2r array for each file against other files, only for I >= J
   // interpolate zri and zrj to a single grid and cutoff
+  // final z2r includes unit conversion of 27.2 eV/Hartree and 0.529 Ang/Bohr
 
   double zri,zrj;
 

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -83,7 +83,6 @@ void BondFENE::compute(int eflag, int vflag)
     // if r -> r0, then rlogarg < 0.0 which is an error
     // issue a warning and reset rlogarg = epsilon
     // if r > 2*r0 something serious is wrong, abort
-    printf("r = %g  r0 = %g  rlogarg = %g\n",sqrt(rsq),sqrt(r0sq),rlogarg);
 
     if (rlogarg < 0.1) {
       error->warning(FLERR,fmt::format("FENE bond too long: {} {} {} {}",

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -18,6 +18,7 @@
 #include "memory.h"
 #include "error.h"
 #include "tokenizer.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -215,12 +216,9 @@ void AtomVecHybrid::process_args(int narg, char **arg)
   for (int idup = 0; idup < ndupfield; idup++) {
     char *dup = (char *) dupfield[idup];
     ptr = strstr(concat_grow,dup);
-    if (ptr && strstr(ptr+1,dup)) {
-      char str[128];
-      sprintf(str,"Peratom %s is in multiple sub-styles - "
-              "must be used consistently",dup);
-      if (comm->me == 0) error->warning(FLERR,str);
-    }
+    if ((ptr && strstr(ptr+1,dup)) && (comm->me == 0))
+      error->warning(FLERR,fmt::format("Peratom {} is in multiple sub-styles "
+                                       "- must be used consistently",dup));
   }
 
   delete [] concat_grow;

--- a/src/compute_cna_atom.cpp
+++ b/src/compute_cna_atom.cpp
@@ -30,6 +30,7 @@
 #include "comm.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -184,11 +185,9 @@ void ComputeCNAAtom::compute_peratom()
 
   int nerrorall;
   MPI_Allreduce(&nerror,&nerrorall,1,MPI_INT,MPI_SUM,world);
-  if (nerrorall && comm->me == 0) {
-    char str[128];
-    sprintf(str,"Too many neighbors in CNA for %d atoms",nerrorall);
-    error->warning(FLERR,str,0);
-  }
+  if (nerrorall && comm->me == 0)
+    error->warning(FLERR,fmt::format("Too many neighbors in CNA for {} "
+                                     "atoms",nerrorall),0);
 
   // compute CNA for each atom in group
   // only performed if # of nearest neighbors = 12 or 14 (fcc,hcp)
@@ -345,11 +344,9 @@ void ComputeCNAAtom::compute_peratom()
   // warning message
 
   MPI_Allreduce(&nerror,&nerrorall,1,MPI_INT,MPI_SUM,world);
-  if (nerrorall && comm->me == 0) {
-    char str[128];
-    sprintf(str,"Too many common neighbors in CNA %d times",nerrorall);
-    error->warning(FLERR,str);
-  }
+  if (nerrorall && comm->me == 0)
+    error->warning(FLERR,fmt::format("Too many common neighbors in CNA {} "
+                                     "times", nerrorall));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/compute_group_group.cpp
+++ b/src/compute_group_group.cpp
@@ -147,12 +147,9 @@ void ComputeGroupGroup::init()
 
   if (kspaceflag) {
     kspace_correction();
-    if (fabs(e_correction) > SMALL && comm->me == 0) {
-      char str[128];
-      sprintf(str,"Both groups in compute group/group have a net charge; "
-              "the Kspace boundary correction to energy will be non-zero");
-      error->warning(FLERR,str);
-    }
+    if ((fabs(e_correction) > SMALL) && (comm->me == 0))
+      error->warning(FLERR,"Both groups in compute group/group have a net charge; "
+                     "the Kspace boundary correction to energy will be non-zero");
   }
 
   // recheck that group 2 has not been deleted

--- a/src/compute_orientorder_atom.cpp
+++ b/src/compute_orientorder_atom.cpp
@@ -32,6 +32,7 @@
 #include "memory.h"
 #include "error.h"
 #include "math_const.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -715,11 +716,8 @@ void ComputeOrientOrderAtom::init_clebsch_gordan()
 
 double ComputeOrientOrderAtom::factorial(int n)
 {
-  if (n < 0 || n > nmaxfactorial) {
-    char str[128];
-    sprintf(str, "Invalid argument to factorial %d", n);
-    error->all(FLERR, str);
-  }
+  if (n < 0 || n > nmaxfactorial)
+    error->all(FLERR,fmt::format("Invalid argument to factorial {}", n));
 
   return nfac_table[n];
 }

--- a/src/dump_cfg.cpp
+++ b/src/dump_cfg.cpp
@@ -126,9 +126,7 @@ void DumpCFG::write_header(bigint n)
   if (atom->peri_flag) scale = atom->pdscale;
   else if (unwrapflag == 1) scale = UNWRAPEXPAND;
 
-  char str[64];
-  sprintf(str,"Number of particles = %s\n",BIGINT_FORMAT);
-  fprintf(fp,str,n);
+  fprintf(fp,"Number of particles = " BIGINT_FORMAT "\n", n);
   fprintf(fp,"A = %g Angstrom (basic length-scale)\n",scale);
   fprintf(fp,"H0(1,1) = %g A\n",domain->xprd);
   fprintf(fp,"H0(1,2) = 0 A \n");

--- a/src/dump_movie.cpp
+++ b/src/dump_movie.cpp
@@ -20,6 +20,7 @@
 #include "comm.h"
 #include "force.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -58,11 +59,9 @@ void DumpMovie::openfile()
     fp = popen(moviecmd,"w");
 #endif
 
-    if (fp == NULL) {
-      char str[128];
-      sprintf(str,"Failed to open FFmpeg pipeline to file %s",filename);
-      error->one(FLERR,str);
-    }
+    if (fp == NULL)
+      error->one(FLERR,fmt::format("Failed to open FFmpeg pipeline to "
+                                   "file {}",filename));
   }
 }
 /* ---------------------------------------------------------------------- */

--- a/src/finish.cpp
+++ b/src/finish.cpp
@@ -32,6 +32,8 @@
 #include "error.h"
 #include "timer.h"
 #include "universe.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 #ifdef LMP_USER_OMP
 #include "modify.h"
@@ -121,12 +123,9 @@ void Finish::end(int flag)
 
     if (me == 0) {
       int ntasks = nprocs * nthreads;
-      const char fmt1[] = "Loop time of %g on %d procs "
-        "for %d steps with " BIGINT_FORMAT " atoms\n\n";
-      if (screen) fprintf(screen,fmt1,time_loop,ntasks,update->nsteps,
-                          atom->natoms);
-      if (logfile) fprintf(logfile,fmt1,time_loop,ntasks,update->nsteps,
-                           atom->natoms);
+      utils::logmesg(lmp,fmt::format("Loop time of {:.6g} on {} procs for "
+                                     "{} steps with {} atoms\n\n",time_loop,
+                                     ntasks,update->nsteps,atom->natoms));
 
       // Gromacs/NAMD-style performance metric for suitable unit settings
 
@@ -144,24 +143,20 @@ void Finish::end(int flag)
 
         if (strcmp(update->unit_style,"lj") == 0) {
           double tau_day = 24.0*3600.0 / t_step * update->dt / one_fs;
-          const char perf[] = "Performance: %.3f tau/day, %.3f timesteps/s\n";
-          if (screen) fprintf(screen,perf,tau_day,step_t);
-          if (logfile) fprintf(logfile,perf,tau_day,step_t);
+          utils::logmesg(lmp,fmt::format("Performance: {:.3f} tau/day, {:.3f} "
+                                         "timesteps/s\n",tau_day,step_t));
         } else if (strcmp(update->unit_style,"electron") == 0) {
           double hrs_fs = t_step / update->dt * one_fs / 3600.0;
           double fs_day = 24.0*3600.0 / t_step * update->dt / one_fs;
-          const char perf[] =
-            "Performance: %.3f fs/day, %.3f hours/fs, %.3f timesteps/s\n";
-          if (screen) fprintf(screen,perf,fs_day,hrs_fs,step_t);
-          if (logfile) fprintf(logfile,perf,fs_day,hrs_fs,step_t);
-
+          utils::logmesg(lmp,fmt::format("Performance: {:.3f} fs/day, {:.3f} "
+                                         "hours/fs, {:.3f} timesteps/s\n",
+                                         fs_day,hrs_fs,step_t));
         } else {
           double hrs_ns = t_step / update->dt * 1000000.0 * one_fs / 3600.0;
           double ns_day = 24.0*3600.0 / t_step * update->dt / one_fs/1000000.0;
-          const char perf[] =
-            "Performance: %.3f ns/day, %.3f hours/ns, %.3f timesteps/s\n";
-          if (screen) fprintf(screen,perf,ns_day,hrs_ns,step_t);
-          if (logfile) fprintf(logfile,perf,ns_day,hrs_ns,step_t);
+          utils::logmesg(lmp,fmt::format("Performance: {:.3f} ns/day, {:.3f} "
+                                         "hours/ns, {:.3f} timesteps/s\n",
+                                         ns_day,hrs_ns,step_t));
         }
       }
 
@@ -169,23 +164,17 @@ void Finish::end(int flag)
 
       if (timeflag) {
         if (lmp->kokkos) {
-          const char fmt2[] =
-            "%.1f%% CPU use with %d MPI tasks x %d OpenMP threads\n";
-          if (screen) fprintf(screen,fmt2,cpu_loop,nprocs,
-                              lmp->kokkos->nthreads);
-          if (logfile) fprintf(logfile,fmt2,cpu_loop,nprocs,
-                               lmp->kokkos->nthreads);
+          utils::logmesg(lmp,fmt::format("{:.1f}% CPU use with {} MPI tasks "
+                                         "x {} OpenMP threads\n",cpu_loop,nprocs,
+                                         lmp->kokkos->nthreads));
         } else {
 #if defined(_OPENMP)
-          const char fmt2[] =
-            "%.1f%% CPU use with %d MPI tasks x %d OpenMP threads\n";
-          if (screen) fprintf(screen,fmt2,cpu_loop,nprocs,nthreads);
-          if (logfile) fprintf(logfile,fmt2,cpu_loop,nprocs,nthreads);
+          utils::logmesg(lmp,fmt::format("{:.1f}% CPU use with {} MPI tasks "
+                                         "x {} OpenMP threads\n",
+                                         cpu_loop,nprocs,nthreads));
 #else
-          const char fmt2[] =
-            "%.1f%% CPU use with %d MPI tasks x no OpenMP threads\n";
-          if (screen) fprintf(screen,fmt2,cpu_loop,nprocs);
-          if (logfile) fprintf(logfile,fmt2,cpu_loop,nprocs);
+          utils::logmesg(lmp,fmt::format("{:.1f}% CPU use with {} MPI tasks "
+                                         "x no OpenMP threads\n",cpu_loop,nprocs));
 #endif
         }
       }

--- a/src/finish.cpp
+++ b/src/finish.cpp
@@ -195,289 +195,140 @@ void Finish::end(int flag)
 
   if (minflag) {
     if (me == 0) {
-      if (screen) fprintf(screen,"\n");
-      if (logfile) fprintf(logfile,"\n");
-    }
+      std::string mesg = "\nMinimization stats:\n";
 
-    if (me == 0) {
-      if (screen) {
-        fprintf(screen,"Minimization stats:\n");
-        fprintf(screen,"  Stopping criterion = %s\n",
-                update->minimize->stopstr);
-        fprintf(screen,"  Energy initial, next-to-last, final = \n"
-                "    %18.12g %18.12g %18.12g\n",
-                update->minimize->einitial,update->minimize->eprevious,
-                update->minimize->efinal);
-        fprintf(screen,"  Force two-norm initial, final = %g %g\n",
-                update->minimize->fnorm2_init,update->minimize->fnorm2_final);
-        fprintf(screen,"  Force max component initial, final = %g %g\n",
-                update->minimize->fnorminf_init,
-                update->minimize->fnorminf_final);
-        fprintf(screen,"  Final line search alpha, max atom move = %g %g\n",
-                update->minimize->alpha_final,
-                update->minimize->alpha_final*
-                update->minimize->fnorminf_final);
-        fprintf(screen,"  Iterations, force evaluations = %d %d\n",
-                update->minimize->niter,update->minimize->neval);
-      }
-      if (logfile) {
-        fprintf(logfile,"Minimization stats:\n");
-        fprintf(logfile,"  Stopping criterion = %s\n",
-                update->minimize->stopstr);
-        fprintf(logfile,"  Energy initial, next-to-last, final = \n"
-                "    %18.12g %18.12g %18.12g\n",
-                update->minimize->einitial,update->minimize->eprevious,
-                update->minimize->efinal);
-        fprintf(logfile,"  Force two-norm initial, final = %g %g\n",
-                update->minimize->fnorm2_init,update->minimize->fnorm2_final);
-        fprintf(logfile,"  Force max component initial, final = %g %g\n",
-                update->minimize->fnorminf_init,
-                update->minimize->fnorminf_final);
-        fprintf(logfile,"  Final line search alpha, max atom move = %g %g\n",
-                update->minimize->alpha_final,
-                update->minimize->alpha_final*
-                update->minimize->fnorminf_final);
-        fprintf(logfile,"  Iterations, force evaluations = %d %d\n",
-                update->minimize->niter,update->minimize->neval);
-      }
+      mesg += fmt::format("  Stopping criterion = {}\n",
+                          update->minimize->stopstr);
+      mesg += fmt::format("  Energy initial, next-to-last, final = \n"
+                          "    {:18.15g} {:18.15g} {:18.15g}\n",
+                          update->minimize->einitial,
+                          update->minimize->eprevious,
+                          update->minimize->efinal);
+      mesg += fmt::format("  Force two-norm initial, final = {} {}\n",
+                          update->minimize->fnorm2_init,update->minimize->fnorm2_final);
+      mesg += fmt::format("  Force max component initial, final = {} {}\n",
+                          update->minimize->fnorminf_init,
+                          update->minimize->fnorminf_final);
+      mesg += fmt::format("  Final line search alpha, max atom move = {} {}\n",
+                          update->minimize->alpha_final,
+                          update->minimize->alpha_final*
+                          update->minimize->fnorminf_final);
+      mesg += fmt::format("  Iterations, force evaluations = {} {}\n",
+                          update->minimize->niter,update->minimize->neval);
+      utils::logmesg(lmp,mesg);
     }
   }
 
   // PRD stats
 
   if (prdflag) {
-    if (me == 0) {
-      if (screen) fprintf(screen,"\nPRD stats:\n");
-      if (logfile) fprintf(logfile,"\nPRD stats:\n");
-    }
+    if (me == 0) utils::logmesg(lmp,"\nPRD stats:\n");
 
     time = timer->get_wall(Timer::DEPHASE);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Dephase  time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Dephase  time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Dephase  time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::DYNAMICS);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Dynamics time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Dynamics time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Dynamics time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::QUENCH);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Quench   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Quench   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
-      time = timer->get_wall(Timer::REPCOMM);
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Quench   time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
+    time = timer->get_wall(Timer::REPCOMM);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Comm     time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Comm     time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Comm     time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::REPOUT);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Output   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Output   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Output   time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = time_other;
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) { // XXXX: replica comm, replica output
-      if (screen)
-        fprintf(screen,"  Other    time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Other    time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Other    time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
   }
 
   // TAD stats
 
   if (tadflag) {
-    if (me == 0) {
-      if (screen) fprintf(screen,"\n");
-      if (logfile) fprintf(logfile,"\n");
-    }
-
-    if (screen) fprintf(screen,"TAD stats:\n");
-    if (logfile) fprintf(logfile,"TAD stats:\n");
+    if (me == 0) utils::logmesg(lmp,"\nTAD stats:\n");
 
     time = timer->get_wall(Timer::NEB);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  NEB      time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  NEB      time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  NEB      time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::DYNAMICS);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Dynamics time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Dynamics time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Dynamics time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::QUENCH);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Quench   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Quench   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Quench   time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::REPCOMM);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Comm     time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Comm     time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Comm     time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::REPOUT);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Output   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Output   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Output   time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = time_other;
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Other    time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Other    time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Other    time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
   }
 
   // HYPER stats
 
   if (hyperflag) {
-    if (me == 0) {
-      if (screen) fprintf(screen,"\nHyper stats:\n");
-      if (logfile) fprintf(logfile,"\nHyper stats:\n");
-    }
+    if (me == 0) utils::logmesg(lmp,"\nHyper stats:\n");
 
     time = timer->get_wall(Timer::DYNAMICS);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Dynamics time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Dynamics time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Dynamics time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = timer->get_wall(Timer::QUENCH);
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Quench   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Quench   time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
-
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Quench   time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
     time = time_other;
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
-    if (me == 0) {
-      if (screen)
-        fprintf(screen,"  Other    time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-      if (logfile)
-        fprintf(logfile,"  Other    time (%%) = %g (%g)\n",
-                time,time/time_loop*100.0);
-    }
+    if (me == 0) utils::logmesg(lmp,fmt::format("  Other    time (%) = {} ({})\n",
+                                                time,time/time_loop*100.0));
   }
 
   // further timing breakdowns
 
   if (timeflag && timer->has_normal()) {
 
-    if (timer->has_full()) {
-      const char hdr[] = "\nMPI task timing breakdown:\n"
-        "Section |  min time  |  avg time  |  max time  "
-        "|%varavg|  %CPU | %total\n"
-        "-----------------------------------------------"
-        "------------------------\n";
-      if (me == 0) {
-        if (screen)  fputs(hdr,screen);
-        if (logfile) fputs(hdr,logfile);
-      }
-    } else {
-      const char hdr[] = "\nMPI task timing breakdown:\n"
-        "Section |  min time  |  avg time  |  max time  |%varavg| %total\n"
-        "---------------------------------------------------------------\n";
-      if (me == 0) {
-        if (screen)  fputs(hdr,screen);
-        if (logfile) fputs(hdr,logfile);
-      }
+    if (me == 0) {
+      if (timer->has_full())
+        utils::logmesg(lmp,"\nMPI task timing breakdown:\nSection |  min time "
+                       " |  avg time  |  max time  |%varavg|  %CPU | %total\n"
+                       "-----------------------------------------------------"
+                       "------------------\n");
+      else
+        utils::logmesg(lmp,"\nMPI task timing breakdown:\nSection |  min time "
+                       " |  avg time  |  max time  |%varavg| %total\n---------"
+                       "------------------------------------------------------\n");
     }
 
     mpi_timings("Pair",timer,Timer::PAIR, world,nprocs,
@@ -507,25 +358,19 @@ void Finish::end(int flag)
     MPI_Allreduce(&time,&tmp,1,MPI_DOUBLE,MPI_SUM,world);
     time = tmp/nprocs;
 
-    const char *fmt;
-    if (timer->has_full())
-      fmt = "Other   |            |%- 12.4g|            |       |       |%6.2f\n";
-    else
-      fmt = "Other   |            |%- 12.4g|            |       |%6.2f\n";
-
     if (me == 0) {
-      if (screen) fprintf(screen,fmt,time,time/time_loop*100.0);
-      if (logfile) fprintf(logfile,fmt,time,time/time_loop*100.0);
+      if (timer->has_full())
+        utils::logmesg(lmp,fmt::format("Other   |            | {:<10.4g} |    "
+                                       "        |       |       |{:6.2f}\n",
+                                       time,time/time_loop*100.0));
+      else
+        utils::logmesg(lmp,fmt::format("Other   |            | {:<10.4g} |    "
+                                       "        |       |{:6.2f}\n",
+                                       time,time/time_loop*100.0));
     }
   }
 
 #ifdef LMP_USER_OMP
-  const char thr_hdr_fmt[] =
-    "\nThread timing breakdown (MPI rank %d):\nTotal threaded time %.4g / %.1f%%\n";
-  const char thr_header[] =
-    "Section |  min time  |  avg time  |  max time  |%varavg| %total\n"
-    "---------------------------------------------------------------\n";
-
   int ifix = modify->find_fix("package_omp");
 
   // print thread breakdown only with full timer detail
@@ -541,23 +386,17 @@ void Finish::end(int flag)
     thr_total /= (double) nthreads;
 
     if (thr_total > 0.0) {
-      if (screen) {
-        fprintf(screen,thr_hdr_fmt,me,thr_total,thr_total/time_loop*100.0);
-        fputs(thr_header,screen);
-      }
-      if (logfile) {
-        fprintf(logfile,thr_hdr_fmt,me,thr_total,thr_total/time_loop*100.0);
-        fputs(thr_header,logfile);
-      }
+      const std::string thr_fmt =
+        "\nThread timing breakdown (MPI rank {}):\nTotal threaded time {:.4g} / {:.1f}%\n"
+        "Section |  min time  |  avg time  |  max time  |%varavg| %total\n"
+        "---------------------------------------------------------------\n";
+      utils::logmesg(lmp,fmt::format(thr_fmt,me,thr_total,thr_total/time_loop*100.0));
 
       omp_times(fixomp,"Pair",Timer::PAIR,nthreads,screen,logfile);
-
       if (atom->molecular)
         omp_times(fixomp,"Bond",Timer::BOND,nthreads,screen,logfile);
-
       if (force->kspace)
         omp_times(fixomp,"Kspace",Timer::KSPACE,nthreads,screen,logfile);
-
       omp_times(fixomp,"Neigh",Timer::NEIGH,nthreads,screen,logfile);
       omp_times(fixomp,"Reduce",Timer::COMM,nthreads,screen,logfile);
     }
@@ -579,11 +418,7 @@ void Finish::end(int flag)
   // time_kspace may be 0.0 if another partition is doing Kspace
 
   if (fftflag) {
-    if (me == 0) {
-      if (screen) fprintf(screen,"\n");
-      if (logfile) fprintf(logfile,"\n");
-    }
-
+    if (me == 0) utils::logmesg(lmp,"\n");
     int nsteps = update->nsteps;
 
     double time3d;
@@ -626,56 +461,30 @@ void Finish::end(int flag)
       flop1 = nfft*nflops/1.0e9/(time1d/nsteps);
     } else fraction = flop3 = flop1 = 0.0;
 
-    if (me == 0) {
-      if (screen) {
-        fprintf(screen,"FFT time (%% of Kspce) = %g (%g)\n",time3d,fraction);
-        fprintf(screen,"FFT Gflps 3d (1d only) = %g %g\n",flop3,flop1);
-      }
-      if (logfile) {
-        fprintf(logfile,"FFT time (%% of Kspce) = %g (%g)\n",time3d,fraction);
-        fprintf(logfile,"FFT Gflps 3d (1d only) = %g %g\n",flop3,flop1);
-      }
-    }
+    if (me == 0)
+      utils::logmesg(lmp,fmt::format("FFT time (% of Kspce) = {} ({})\n"
+                                     "FFT Gflps 3d (1d only) = {} {}\n",
+                                     time3d,fraction,flop3,flop1));
   }
 
   if (histoflag) {
-    if (me == 0) {
-      if (screen) fprintf(screen,"\n");
-      if (logfile) fprintf(logfile,"\n");
-    }
-
+    std::string mesg = "\n";
     tmp = atom->nlocal;
     stats(1,&tmp,&ave,&max,&min,10,histo);
     if (me == 0) {
-      if (screen) {
-        fprintf(screen,"Nlocal:    %g ave %g max %g min\n",ave,max,min);
-        fprintf(screen,"Histogram:");
-        for (i = 0; i < 10; i++) fprintf(screen," %d",histo[i]);
-        fprintf(screen,"\n");
-      }
-      if (logfile) {
-        fprintf(logfile,"Nlocal:    %g ave %g max %g min\n",ave,max,min);
-        fprintf(logfile,"Histogram:");
-        for (i = 0; i < 10; i++) fprintf(logfile," %d",histo[i]);
-        fprintf(logfile,"\n");
-      }
+      mesg += fmt::format("Nlocal:    {} ave {} max {} min\n",ave,max,min);
+      mesg += "Histogram:";
+      for (i = 0; i < 10; i++) mesg += fmt::format(" {}",histo[i]);
+      mesg += "\n";
     }
 
     tmp = atom->nghost;
     stats(1,&tmp,&ave,&max,&min,10,histo);
     if (me == 0) {
-      if (screen) {
-        fprintf(screen,"Nghost:    %g ave %g max %g min\n",ave,max,min);
-        fprintf(screen,"Histogram:");
-        for (i = 0; i < 10; i++) fprintf(screen," %d",histo[i]);
-        fprintf(screen,"\n");
-      }
-      if (logfile) {
-        fprintf(logfile,"Nghost:    %g ave %g max %g min\n",ave,max,min);
-        fprintf(logfile,"Histogram:");
-        for (i = 0; i < 10; i++) fprintf(logfile," %d",histo[i]);
-        fprintf(logfile,"\n");
-      }
+      mesg += fmt::format("Nghost:    {} ave {} max {} min\n",ave,max,min);
+      mesg += "Histogram:";
+      for (i = 0; i < 10; i++) mesg += fmt::format(" {}",histo[i]);
+      mesg += "\n";
     }
 
     // find a non-skip neighbor list containing half pairwise interactions
@@ -701,18 +510,10 @@ void Finish::end(int flag)
     tmp = nneigh;
     stats(1,&tmp,&ave,&max,&min,10,histo);
     if (me == 0) {
-      if (screen) {
-        fprintf(screen,"Neighs:    %g ave %g max %g min\n",ave,max,min);
-        fprintf(screen,"Histogram:");
-        for (i = 0; i < 10; i++) fprintf(screen," %d",histo[i]);
-        fprintf(screen,"\n");
-      }
-      if (logfile) {
-        fprintf(logfile,"Neighs:    %g ave %g max %g min\n",ave,max,min);
-        fprintf(logfile,"Histogram:");
-        for (i = 0; i < 10; i++) fprintf(logfile," %d",histo[i]);
-        fprintf(logfile,"\n");
-      }
+      mesg += fmt::format("Neighs:    {} ave {} max {} min\n",ave,max,min);
+      mesg += "Histogram:";
+      for (i = 0; i < 10; i++) mesg += fmt::format(" {}",histo[i]);
+      mesg += "\n";
     }
 
     // find a non-skip neighbor list containing full pairwise interactions
@@ -732,32 +533,23 @@ void Finish::end(int flag)
         for (i = 0; i < inum; i++)
           nneighfull += numneigh[ilist[i]];
       } else if (lmp->kokkos)
-          nneighfull = lmp->kokkos->neigh_count(m);
+        nneighfull = lmp->kokkos->neigh_count(m);
 
       tmp = nneighfull;
       stats(1,&tmp,&ave,&max,&min,10,histo);
       if (me == 0) {
-        if (screen) {
-          fprintf(screen,"FullNghs:  %g ave %g max %g min\n",ave,max,min);
-          fprintf(screen,"Histogram:");
-          for (i = 0; i < 10; i++) fprintf(screen," %d",histo[i]);
-          fprintf(screen,"\n");
-        }
-        if (logfile) {
-          fprintf(logfile,"FullNghs:  %g ave %g max %g min\n",ave,max,min);
-          fprintf(logfile,"Histogram:");
-          for (i = 0; i < 10; i++) fprintf(logfile," %d",histo[i]);
-          fprintf(logfile,"\n");
-        }
+        mesg += fmt::format("FullNghs:  {} ave {} max {} min\n",ave,max,min);
+        mesg += "Histogram:";
+        for (i = 0; i < 10; i++) mesg += fmt::format(" {}",histo[i]);
+        mesg += "\n";
+
       }
     }
+    if (me == 0) utils::logmesg(lmp,mesg);
   }
 
   if (neighflag) {
-    if (me == 0) {
-      if (screen) fprintf(screen,"\n");
-      if (logfile) fprintf(logfile,"\n");
-    }
+    if (me == 0) utils::logmesg(lmp,"\n");
 
     tmp = MAX(nneigh,nneighfull);
     double nall;
@@ -790,40 +582,19 @@ void Finish::end(int flag)
     }
 
     if (me == 0) {
-      if (screen) {
-        if (nall < 2.0e9)
-          fprintf(screen,
-                  "Total # of neighbors = %d\n",static_cast<int> (nall));
-        else fprintf(screen,"Total # of neighbors = %g\n",nall);
-        if (atom->natoms > 0)
-          fprintf(screen,"Ave neighs/atom = %g\n",nall/atom->natoms);
-        if (atom->molecular && atom->natoms > 0)
-          fprintf(screen,"Ave special neighs/atom = %g\n",
-                  nspec_all/atom->natoms);
-        fprintf(screen,"Neighbor list builds = " BIGINT_FORMAT "\n",
-                neighbor->ncalls);
-        if (neighbor->dist_check)
-          fprintf(screen,"Dangerous builds = " BIGINT_FORMAT "\n",
-                  neighbor->ndanger);
-        else fprintf(screen,"Dangerous builds not checked\n");
-      }
-      if (logfile) {
-        if (nall < 2.0e9)
-          fprintf(logfile,
-                  "Total # of neighbors = %d\n",static_cast<int> (nall));
-        else fprintf(logfile,"Total # of neighbors = %g\n",nall);
-        if (atom->natoms > 0)
-          fprintf(logfile,"Ave neighs/atom = %g\n",nall/atom->natoms);
-        if (atom->molecular && atom->natoms > 0)
-          fprintf(logfile,"Ave special neighs/atom = %g\n",
-                  nspec_all/atom->natoms);
-        fprintf(logfile,"Neighbor list builds = " BIGINT_FORMAT "\n",
-                neighbor->ncalls);
-        if (neighbor->dist_check)
-          fprintf(logfile,"Dangerous builds = " BIGINT_FORMAT "\n",
-                  neighbor->ndanger);
-        else fprintf(logfile,"Dangerous builds not checked\n");
-      }
+      std::string mesg;
+
+      mesg += fmt::format("Total # of neighbors = {}\n",static_cast<bigint>(nall));
+      if (atom->natoms > 0)
+        mesg += fmt::format("Ave neighs/atom = {}\n",nall/atom->natoms);
+      if (atom->molecular && atom->natoms > 0)
+        mesg += fmt::format("Ave special neighs/atom = {}\n",
+                            nspec_all/atom->natoms);
+      mesg += fmt::format("Neighbor list builds = {}\n",neighbor->ncalls);
+      if (neighbor->dist_check)
+        mesg += fmt::format("Dangerous builds = {}\n",neighbor->ndanger);
+      else mesg += "Dangerous builds not checked\n";
+      utils::logmesg(lmp,mesg);
     }
   }
 
@@ -910,23 +681,18 @@ void mpi_timings(const char *label, Timer *t, enum Timer::ttype tt,
   else
     time_sq = 0.0;
 
-
   if (me == 0) {
     tmp = time/time_loop*100.0;
-    if (t->has_full()) {
-      const char fmt[] = "%-8s|%- 12.5g|%- 12.5g|%- 12.5g|%6.1f |%6.1f |%6.2f\n";
-      if (scr)
-        fprintf(scr,fmt,label,time_min,time,time_max,time_sq,time_cpu,tmp);
-      if (log)
-        fprintf(log,fmt,label,time_min,time,time_max,time_sq,time_cpu,tmp);
-      time_loop = 100.0/time_loop;
-    } else {
-      const char fmt[] = "%-8s|%- 12.5g|%- 12.5g|%- 12.5g|%6.1f |%6.2f\n";
-      if (scr)
-        fprintf(scr,fmt,label,time_min,time,time_max,time_sq,tmp);
-      if (log)
-        fprintf(log,fmt,label,time_min,time,time_max,time_sq,tmp);
-    }
+    std::string mesg;
+    if (t->has_full())
+      mesg = fmt::format("{:<8s}| {:<10.5g} | {:<10.5g} | {:<10.5g} |{:6.1f} |"
+                         "{:6.1f} |{:6.2f}\n",
+                         label,time_min,time,time_max,time_sq,time_cpu,tmp);
+    else
+      mesg = fmt::format("{:<8s}| {:<10.5g} | {:<10.5g} | {:<10.5g} |{:6.1f} |"
+                         "{:6.2f}\n",label,time_min,time,time_max,time_sq,tmp);
+    if (scr) fputs(mesg.c_str(),scr);
+    if (log) fputs(mesg.c_str(),log);
   }
 }
 
@@ -936,7 +702,6 @@ void mpi_timings(const char *label, Timer *t, enum Timer::ttype tt,
 void omp_times(FixOMP *fix, const char *label, enum Timer::ttype which,
                       const int nthreads,FILE *scr, FILE *log)
 {
-  const char fmt[] = "%-8s|%- 12.5g|%- 12.5g|%- 12.5g|%6.1f |%6.2f\n";
   double time_min, time_max, time_avg, time_total, time_std;
 
   time_min =  1.0e100;
@@ -962,10 +727,11 @@ void omp_times(FixOMP *fix, const char *label, enum Timer::ttype which,
   else
     time_std = 0.0;
 
-  if (scr) fprintf(scr,fmt,label,time_min,time_avg,time_max,time_std,
-                   time_avg/time_total*100.0);
-  if (log) fprintf(log,fmt,label,time_min,time_avg,time_max,time_std,
-                   time_avg/time_total*100.0);
+  std::string mesg = fmt::format("{:<8s}| {:10.5g} | {:10.5g} | {:10.5g} |"
+                                 "{:6.1f} |{:6.2f}\n",label,time_min,time_avg,
+                                 time_max,time_std,time_avg/time_total*100.0);
+  if (scr) fputs(mesg.c_str(),scr);
+  if (log) fputs(mesg.c_str(),log);
 }
 #endif
 

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -15,6 +15,7 @@
 #include <mpi.h>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "update.h"
 #include "force.h"
 #include "input.h"
@@ -25,6 +26,7 @@
 #include "comm.h"
 #include "timer.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -224,15 +226,13 @@ void FixHalt::end_of_step()
   // soft/continue halt -> trigger timer to break from run loop
   // print message with ID of fix halt in case multiple instances
 
-  char str[128];
-  sprintf(str,"Fix halt condition for fix-id %s met on step "
-          BIGINT_FORMAT " with value %g",
-          id, update->ntimestep, attvalue);
-
+  std::string message = fmt::format("Fix halt condition for fix-id {} met on "
+                                    "step {} with value {}",
+                                    id, update->ntimestep, attvalue);
   if (eflag == HARD) {
-    error->all(FLERR,str);
+    error->all(FLERR,message);
   } else if (eflag == SOFT || eflag == CONTINUE) {
-    if (comm->me == 0 && msgflag == YESMSG) error->message(FLERR,str);
+    if (comm->me == 0 && msgflag == YESMSG) error->message(FLERR,message);
     timer->force_timeout();
   }
 }

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -1026,7 +1026,7 @@ FILE *Force::open_potential(const char *name, int *auto_convert)
     }
 
     if (auto_convert == nullptr) {
-      if (units != unit_style) {
+      if (!units.empty() && (units != unit_style)) {
         error->one(FLERR, fmt::format("Potential file {} requires {} units "
                                       "but {} units are in use", name, units,
                                       unit_style));

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -848,16 +848,12 @@ bool Info::is_active(const char *category, const char *name)
 
   if (!match && lmp->suffix_enable) {
     if (lmp->suffix) {
-      char *name_w_suffix = new char [len + 2 + strlen(lmp->suffix)];
-      sprintf(name_w_suffix,"%s/%s",name,lmp->suffix);
-      if (strcmp(style,name_w_suffix) == 0) match = 1;
-      delete[] name_w_suffix;
+      std::string name_w_suffix = name + std::string("/") + lmp->suffix;
+      if (name_w_suffix == style) match = 1;
     }
     if (!match && lmp->suffix2) {
-      char *name_w_suffix = new char [len + 2 + strlen(lmp->suffix2)];
-      sprintf(name_w_suffix,"%s/%s",name,lmp->suffix2);
-      if (strcmp(style,name_w_suffix) == 0) match = 1;
-      delete[] name_w_suffix;
+      std::string name_w_suffix = name + std::string("/") + lmp->suffix2;
+      if (name_w_suffix == style) match = 1;
     }
   }
   return match ? true : false;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1243,10 +1243,10 @@ void Input::quit()
 
 char *shell_failed_message(const char* cmd, int errnum)
 {
-  const char *errmsg = strerror(errnum);
-  int len = strlen(cmd)+strlen(errmsg)+64;
-  char *msg = new char[len];
-  snprintf(msg, len, "Shell command '%s' failed with error '%s'", cmd, errmsg);
+  std::string errmsg = fmt::format("Shell command '{}' failed with error '{}'",
+                                   cmd, strerror(errnum));
+  char *msg = new char[errmsg.size()+1];
+  strcpy(msg, errmsg.c_str());
   return msg;
 }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -227,11 +227,8 @@ void Input::file()
 
     // execute the command
 
-    if (execute_command()) {
-      char *str = new char[maxline+32];
-      sprintf(str,"Unknown command: %s",line);
-      error->all(FLERR,str);
-    }
+    if (execute_command())
+      error->all(FLERR,fmt::format("Unknown command: {}",line));
   }
 }
 
@@ -1249,7 +1246,7 @@ char *shell_failed_message(const char* cmd, int errnum)
   const char *errmsg = strerror(errnum);
   int len = strlen(cmd)+strlen(errmsg)+64;
   char *msg = new char[len];
-  sprintf(msg,"Shell command '%s' failed with error '%s'", cmd, errmsg);
+  snprintf(msg, len, "Shell command '%s' failed with error '%s'", cmd, errmsg);
   return msg;
 }
 

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "comm.h"
 #include "force.h"
@@ -25,6 +26,7 @@
 #include "error.h"
 #include "suffix.h"
 #include "domain.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -307,10 +309,10 @@ void KSpace::qsum_qsq(int warning_flag)
   // so issue warning or error
 
   if (fabs(qsum) > SMALL) {
-    char str[128];
-    sprintf(str,"System is not charge neutral, net charge = %g",qsum);
-    if (!warn_nonneutral) error->all(FLERR,str);
-    if (warn_nonneutral == 1 && comm->me == 0) error->warning(FLERR,str);
+    std::string message = fmt::format("System is not charge neutral, net "
+                                      "charge = {}",qsum);
+    if (!warn_nonneutral) error->all(FLERR,message);
+    if (warn_nonneutral == 1 && comm->me == 0) error->warning(FLERR,message);
     warn_nonneutral = 2;
   }
 }
@@ -324,12 +326,10 @@ double KSpace::estimate_table_accuracy(double q2_over_sqrt, double spr)
   double table_accuracy = 0.0;
   int nctb = force->pair->ncoultablebits;
   if (comm->me == 0) {
-    char str[128];
     if (nctb)
-      sprintf(str,"  using %d-bit tables for long-range coulomb",nctb);
+      error->message(FLERR,fmt::format("  using {}-bit tables for long-range coulomb",nctb));
     else
-      sprintf(str,"  using polynomial approximation for long-range coulomb");
-    error->message(FLERR,str);
+      error->message(FLERR,"  using polynomial approximation for long-range coulomb");
   }
 
   if (nctb) {

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -667,15 +667,12 @@ LAMMPS::~LAMMPS()
 
   double totalclock = MPI_Wtime() - initclock;
   if ((me == 0) && (screen || logfile)) {
-    char outtime[128];
     int seconds = fmod(totalclock,60.0);
     totalclock  = (totalclock - seconds) / 60.0;
     int minutes = fmod(totalclock,60.0);
     int hours = (totalclock - minutes) / 60.0;
-    sprintf(outtime,"Total wall time: "
-            "%d:%02d:%02d\n", hours, minutes, seconds);
-    if (screen) fputs(outtime,screen);
-    if (logfile) fputs(outtime,logfile);
+    utils::logmesg(this,fmt::format("Total wall time: {}:{:02d}:{:02d}\n",
+                                    hours, minutes, seconds));
   }
 
   if (universe->nworlds == 1) {

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -21,6 +21,8 @@
 #include "force.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -301,14 +303,9 @@ Lattice::Lattice(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
 
   // print lattice spacings
 
-  if (comm->me == 0) {
-    if (screen)
-      fprintf(screen,"Lattice spacing in x,y,z = %g %g %g\n",
-              xlattice,ylattice,zlattice);
-    if (logfile)
-      fprintf(logfile,"Lattice spacing in x,y,z = %g %g %g\n",
-              xlattice,ylattice,zlattice);
-  }
+  if (comm->me == 0)
+    utils::logmesg(lmp,fmt::format("Lattice spacing in x,y,z = {} {} {}\n",
+                                   xlattice,ylattice,zlattice));
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -210,8 +210,8 @@ void Min::init()
 void Min::setup(int flag)
 {
   if (comm->me == 0 && screen) {
-    fprintf(screen,"Setting up %s style minimization ...\n",
-            update->minimize_style);
+    fmt::print(screen,"Setting up {} style minimization ...\n",
+               update->minimize_style);
     if (flag) {
       fmt::print(screen,"  Unit style    : {}\n", update->unit_style);
       fmt::print(screen,"  Current step  : {}\n", update->ntimestep);

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -908,16 +908,10 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
       fix[ifix]->restart(state_restart_global[i]);
       used_restart_global[i] = 1;
       fix[ifix]->restart_reset = 1;
-      if (comm->me == 0) {
-        if (screen)
-          fprintf(screen,"Resetting global fix info from restart file:\n");
-        if (logfile)
-          fprintf(logfile,"Resetting global fix info from restart file:\n");
-        if (screen) fprintf(screen,"  fix style: %s, fix ID: %s\n",
-                            fix[ifix]->style,fix[ifix]->id);
-        if (logfile) fprintf(logfile,"  fix style: %s, fix ID: %s\n",
-                             fix[ifix]->style,fix[ifix]->id);
-      }
+      if (comm->me == 0)
+        utils::logmesg(lmp,fmt::format("Resetting global fix info from restart file:\n"
+                                       "  fix style: {}, fix ID: {}\n",
+                                       fix[ifix]->style,fix[ifix]->id));
     }
 
   // check if Fix is in restart_peratom list
@@ -930,16 +924,10 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
       for (int j = 0; j < atom->nlocal; j++)
         fix[ifix]->unpack_restart(j,index_restart_peratom[i]);
       fix[ifix]->restart_reset = 1;
-      if (comm->me == 0) {
-        if (screen)
-          fprintf(screen,"Resetting peratom fix info from restart file:\n");
-        if (logfile)
-          fprintf(logfile,"Resetting peratom fix info from restart file:\n");
-        if (screen) fprintf(screen,"  fix style: %s, fix ID: %s\n",
-                            fix[ifix]->style,fix[ifix]->id);
-        if (logfile) fprintf(logfile,"  fix style: %s, fix ID: %s\n",
-                             fix[ifix]->style,fix[ifix]->id);
-      }
+      if (comm->me == 0)
+        utils::logmesg(lmp,fmt::format("Resetting peratom fix info from restart file:\n"
+                                       "  fix style: {}, fix ID: {}\n",
+                                       fix[ifix]->style,fix[ifix]->id));
     }
 
   // increment nfix (if new)
@@ -1505,21 +1493,13 @@ void Modify::restart_deallocate(int flag)
       for (i = 0; i < nfix_restart_global; i++)
         if (used_restart_global[i] == 0) break;
       if (i == nfix_restart_global) {
-        if (screen)
-          fprintf(screen,"All restart file global fix info "
-                  "was re-assigned\n");
-        if (logfile)
-          fprintf(logfile,"All restart file global fix info "
-                  "was re-assigned\n");
+        utils::logmesg(lmp,"All restart file global fix info was re-assigned\n");
       } else {
-        if (screen) fprintf(screen,"Unused restart file global fix info:\n");
-        if (logfile) fprintf(logfile,"Unused restart file global fix info:\n");
+        utils::logmesg(lmp,"Unused restart file global fix info:\n");
         for (i = 0; i < nfix_restart_global; i++) {
           if (used_restart_global[i]) continue;
-          if (screen) fprintf(screen,"  fix style: %s, fix ID: %s\n",
-                              style_restart_global[i],id_restart_global[i]);
-          if (logfile) fprintf(logfile,"  fix style: %s, fix ID: %s\n",
-                               style_restart_global[i],id_restart_global[i]);
+          utils::logmesg(lmp,fmt::format("  fix style: {}, fix ID: {}\n",
+                                         style_restart_global[i],id_restart_global[i]));
         }
       }
     }
@@ -1541,21 +1521,13 @@ void Modify::restart_deallocate(int flag)
       for (i = 0; i < nfix_restart_peratom; i++)
         if (used_restart_peratom[i] == 0) break;
       if (i == nfix_restart_peratom) {
-        if (screen)
-          fprintf(screen,"All restart file peratom fix info "
-                  "was re-assigned\n");
-        if (logfile)
-          fprintf(logfile,"All restart file peratom fix info "
-                  "was re-assigned\n");
+        utils::logmesg(lmp,"All restart file peratom fix info was re-assigned\n");
       } else {
-        if (screen) fprintf(screen,"Unused restart file peratom fix info:\n");
-        if (logfile) fprintf(logfile,"Unused restart file peratom fix info:\n");
+        utils::logmesg(lmp,"Unused restart file peratom fix info:\n");
         for (i = 0; i < nfix_restart_peratom; i++) {
           if (used_restart_peratom[i]) continue;
-          if (screen) fprintf(screen,"  fix style: %s, fix ID: %s\n",
-                              style_restart_peratom[i],id_restart_peratom[i]);
-          if (logfile) fprintf(logfile,"  fix style: %s, fix ID: %s\n",
-                               style_restart_peratom[i],id_restart_peratom[i]);
+          utils::logmesg(lmp,fmt::format("  fix style: {}, fix ID: {}\n",
+                                         style_restart_peratom[i],id_restart_peratom[i]));
         }
       }
     }

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -13,6 +13,7 @@
 
 #include "modify.h"
 #include <cstring>
+#include <string>
 #include "style_compute.h"
 #include "style_fix.h"
 #include "atom.h"
@@ -836,18 +837,17 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
     int match = 0;
     if (strcmp(arg[2],fix[ifix]->style) == 0) match = 1;
     if (!match && trysuffix && lmp->suffix_enable) {
-      char estyle[256];
       if (lmp->suffix) {
-        sprintf(estyle,"%s/%s",arg[2],lmp->suffix);
-        if (strcmp(estyle,fix[ifix]->style) == 0) match = 1;
+        std::string estyle = arg[2] + std::string("/") + lmp->suffix;
+        if (estyle == fix[ifix]->style) match = 1;
       }
       if (lmp->suffix2) {
-        sprintf(estyle,"%s/%s",arg[2],lmp->suffix2);
-        if (strcmp(estyle,fix[ifix]->style) == 0) match = 1;
+        std::string estyle = arg[2] + std::string("/") + lmp->suffix2;
+        if (estyle == fix[ifix]->style) match = 1;
       }
     }
-    if (!match) error->all(FLERR,
-                           "Replacing a fix, but new style != old style");
+    if (!match)
+      error->all(FLERR,"Replacing a fix, but new style != old style");
 
     if (fix[ifix]->igroup != igroup && comm->me == 0)
       error->warning(FLERR,"Replacing a fix, but new group != old group");
@@ -870,26 +870,24 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
 
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
-      int n = strlen(arg[2])+strlen(lmp->suffix)+2;
-      char *estyle = new char[n];
-      sprintf(estyle,"%s/%s",arg[2],lmp->suffix);
+      std::string estyle = arg[2] + std::string("/") + lmp->suffix;
       if (fix_map->find(estyle) != fix_map->end()) {
         FixCreator fix_creator = (*fix_map)[estyle];
         fix[ifix] = fix_creator(lmp,narg,arg);
         delete[] fix[ifix]->style;
-        fix[ifix]->style = estyle;
-      } else delete[] estyle;
+        fix[ifix]->style = new char[estyle.size()+1];
+        strcpy(fix[ifix]->style,estyle.c_str());
+      }
     }
     if (fix[ifix] == NULL && lmp->suffix2) {
-      int n = strlen(arg[2])+strlen(lmp->suffix2)+2;
-      char *estyle = new char[n];
-      sprintf(estyle,"%s/%s",arg[2],lmp->suffix2);
+      std::string estyle = arg[2] + std::string("/") + lmp->suffix2;
       if (fix_map->find(estyle) != fix_map->end()) {
         FixCreator fix_creator = (*fix_map)[estyle];
         fix[ifix] = fix_creator(lmp,narg,arg);
         delete[] fix[ifix]->style;
-        fix[ifix]->style = estyle;
-      } else delete[] estyle;
+        fix[ifix]->style = new char[estyle.size()+1];
+        strcpy(fix[ifix]->style,estyle.c_str());
+      }
     }
   }
 
@@ -1164,7 +1162,7 @@ int Modify::check_rigid_list_overlap(int *select)
 
   int n = 0;
   for (int ifix = 0; ifix < nfix; ifix++) {
-    if (strncmp("rigid",fix[ifix]->style,5) == 0) {
+    if (utils::strmatch(fix[ifix]->style,"^rigid")) {
       const int * const body = (const int *)fix[ifix]->extract("body",dim);
       if ((body == NULL) || (dim != 1)) break;
 
@@ -1209,26 +1207,24 @@ void Modify::add_compute(int narg, char **arg, int trysuffix)
 
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
-      int n = strlen(arg[2])+strlen(lmp->suffix)+2;
-      char *estyle = new char[n];
-      sprintf(estyle,"%s/%s",arg[2],lmp->suffix);
+      std::string estyle = arg[2] + std::string("/") + lmp->suffix;
       if (compute_map->find(estyle) != compute_map->end()) {
         ComputeCreator compute_creator = (*compute_map)[estyle];
         compute[ncompute] = compute_creator(lmp,narg,arg);
         delete[] compute[ncompute]->style;
-        compute[ncompute]->style = estyle;
-      } else delete[] estyle;
+        compute[ncompute]->style = new char[estyle.size()+1];
+        strcpy(compute[ncompute]->style,estyle.c_str());
+      }
     }
     if (compute[ncompute] == NULL && lmp->suffix2) {
-      int n = strlen(arg[2])+strlen(lmp->suffix2)+2;
-      char *estyle = new char[n];
-      sprintf(estyle,"%s/%s",arg[2],lmp->suffix2);
+      std::string estyle = arg[2] + std::string("/") + lmp->suffix2;
       if (compute_map->find(estyle) != compute_map->end()) {
         ComputeCreator compute_creator = (*compute_map)[estyle];
         compute[ncompute] = compute_creator(lmp,narg,arg);
         delete[] compute[ncompute]->style;
-        compute[ncompute]->style = estyle;
-      } else delete[] estyle;
+        compute[ncompute]->style = new char[estyle.size()+1];
+        strcpy(compute[ncompute]->style,estyle.c_str());
+      }
     }
   }
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -146,24 +146,17 @@ Molecule::Molecule(LAMMPS *lmp, int narg, char **arg, int &index) :
 
   // stats
 
-  if (me == 0) {
-    if (screen)
-      fprintf(screen,"Read molecule template %s:\n  %d molecules\n"
-              "  %d atoms with max type %d\n  %d bonds with max type %d\n"
-              "  %d angles with max type %d\n  %d dihedrals with max type %d\n"
-              "  %d impropers with max type %d\n",
-              id,nmolecules,natoms,ntypes,
-              nbonds,nbondtypes,nangles,nangletypes,
-              ndihedrals,ndihedraltypes,nimpropers,nimpropertypes);
-    if (logfile)
-      fprintf(logfile,"Read molecule template %s:\n  %d molecules\n"
-              "  %d atoms with max type %d\n  %d bonds with max type %d\n"
-              "  %d angles with max type %d\n  %d dihedrals with max type %d\n"
-              "  %d impropers with max type %d\n",
-              id,nmolecules,natoms,ntypes,
-              nbonds,nbondtypes,nangles,nangletypes,
-              ndihedrals,ndihedraltypes,nimpropers,nimpropertypes);
-  }
+  if (me == 0)
+    utils::logmesg(lmp,fmt::format("Read molecule template {}:\n"
+                                   "  {} molecules\n"
+                                   "  {} atoms with max type {}\n"
+                                   "  {} bonds with max type {}\n"
+                                   "  {} angles with max type {}\n"
+                                   "  {} dihedrals with max type {}\n"
+                                   "  {} impropers with max type {}\n",
+                                   id,nmolecules,natoms,ntypes,
+                                   nbonds,nbondtypes,nangles,nangletypes,
+                                   ndihedrals,ndihedraltypes,nimpropers,nimpropertypes));
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/ntopo_improper_partial.cpp
+++ b/src/ntopo_improper_partial.cpp
@@ -97,10 +97,7 @@ void NTopoImproperPartial::build()
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Improper atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && me == 0)
+    error->warning(FLERR,fmt::format("Improper atoms missing at step {}",
+                                     update->ntimestep));
 }

--- a/src/pair_table.cpp
+++ b/src/pair_table.cpp
@@ -116,37 +116,28 @@ void PairTable::compute(int eflag, int vflag)
 
       if (rsq < cutsq[itype][jtype]) {
         tb = &tables[tabindex[itype][jtype]];
-        if (rsq < tb->innersq) {
-          sprintf(estr,"Pair distance < table inner cutoff: "
-                  "ijtype %d %d dist %g",itype,jtype,sqrt(rsq));
-          error->one(FLERR,estr);
-        }
-
+        if (rsq < tb->innersq)
+          error->one(FLERR,fmt::format("Pair distance < table inner cutoff: "
+                                       "ijtype {} {} dist {}",itype,jtype,sqrt(rsq)));
         if (tabstyle == LOOKUP) {
           itable = static_cast<int> ((rsq - tb->innersq) * tb->invdelta);
-          if (itable >= tlm1) {
-            sprintf(estr,"Pair distance > table outer cutoff: "
-                    "ijtype %d %d dist %g",itype,jtype,sqrt(rsq));
-            error->one(FLERR,estr);
-          }
+          if (itable >= tlm1)
+            error->one(FLERR,fmt::format("Pair distance > table outer cutoff: "
+                                         "ijtype {} {} dist {}",itype,jtype,sqrt(rsq)));
           fpair = factor_lj * tb->f[itable];
         } else if (tabstyle == LINEAR) {
           itable = static_cast<int> ((rsq - tb->innersq) * tb->invdelta);
-          if (itable >= tlm1) {
-            sprintf(estr,"Pair distance > table outer cutoff: "
-                    "ijtype %d %d dist %g",itype,jtype,sqrt(rsq));
-            error->one(FLERR,estr);
-          }
+          if (itable >= tlm1)
+            error->one(FLERR,fmt::format("Pair distance > table outer cutoff: "
+                                         "ijtype {} {} dist {}",itype,jtype,sqrt(rsq)));
           fraction = (rsq - tb->rsq[itable]) * tb->invdelta;
           value = tb->f[itable] + fraction*tb->df[itable];
           fpair = factor_lj * value;
         } else if (tabstyle == SPLINE) {
           itable = static_cast<int> ((rsq - tb->innersq) * tb->invdelta);
-          if (itable >= tlm1) {
-            sprintf(estr,"Pair distance > table outer cutoff: "
-                    "ijtype %d %d dist %g",itype,jtype,sqrt(rsq));
-            error->one(FLERR,estr);
-          }
+          if (itable >= tlm1)
+            error->one(FLERR,fmt::format("Pair distance > table outer cutoff: "
+                                         "ijtype {} {} dist {}",itype,jtype,sqrt(rsq)));
           b = (rsq - tb->rsq[itable]) * tb->invdelta;
           a = 1.0 - b;
           value = a * tb->f[itable] + b * tb->f[itable+1] +

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -1157,11 +1157,8 @@ void ReadData::header(int firstpass)
   parse_keyword(1);
   for (n = 0; n < NSECTIONS; n++)
     if (strcmp(keyword,section_keywords[n]) == 0) break;
-  if (n == NSECTIONS) {
-    char str[128];
-    sprintf(str,"Unknown identifier in data file: %s",keyword);
-    error->all(FLERR,str);
-  }
+  if (n == NSECTIONS)
+    error->all(FLERR,fmt::format("Unknown identifier in data file: {}",keyword));
 
   // error checks on header values
   // must be consistent with atom style and other header values

--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -289,13 +289,9 @@ bigint ReadDump::seek(bigint nrequest, int exact)
     for (ifile = 0; ifile < nfile; ifile++) {
       ntimestep = -1;
       if (multiproc) {
-        char *ptr = strchr(files[ifile],'%');
-        char *multiname = new char[strlen(files[ifile]) + 16];
-        *ptr = '\0';
-        sprintf(multiname,"%s%d%s",files[ifile],0,ptr+1);
-        *ptr = '%';
-        readers[0]->open_file(multiname);
-        delete [] multiname;
+        std::string multiname = files[ifile];
+        multiname.replace(multiname.find("%"),1,"0");
+        readers[0]->open_file(multiname.c_str());
       } else readers[0]->open_file(files[ifile]);
 
       while (1) {
@@ -337,13 +333,9 @@ bigint ReadDump::seek(bigint nrequest, int exact)
   if (multiproc && filereader) {
     for (int i = 0; i < nreader; i++) {
       if (me == 0 && i == 0) continue;    // proc 0, reader 0 already found it
-      char *ptr = strchr(files[currentfile],'%');
-      char *multiname = new char[strlen(files[currentfile]) + 16];
-      *ptr = '\0';
-      sprintf(multiname,"%s%d%s",files[currentfile],firstfile+i,ptr+1);
-      *ptr = '%';
-      readers[i]->open_file(multiname);
-      delete [] multiname;
+      std::string multiname = files[currentfile];
+      multiname.replace(multiname.find("%"),1,fmt::format("{}",firstfile+i));
+      readers[i]->open_file(multiname.c_str());
 
       bigint step;
       while (1) {
@@ -389,13 +381,9 @@ bigint ReadDump::next(bigint ncurrent, bigint nlast, int nevery, int nskip)
       ntimestep = -1;
       if (ifile != currentfile) {
         if (multiproc) {
-          char *ptr = strchr(files[ifile],'%');
-          char *multiname = new char[strlen(files[ifile]) + 16];
-          *ptr = '\0';
-          sprintf(multiname,"%s%d%s",files[ifile],0,ptr+1);
-          *ptr = '%';
-          readers[0]->open_file(multiname);
-          delete [] multiname;
+          std::string multiname = files[ifile];
+          multiname.replace(multiname.find("%"),1,"0");
+          readers[0]->open_file(multiname.c_str());
         } else readers[0]->open_file(files[ifile]);
       }
 
@@ -447,13 +435,9 @@ bigint ReadDump::next(bigint ncurrent, bigint nlast, int nevery, int nskip)
   if (multiproc && filereader) {
     for (int i = 0; i < nreader; i++) {
       if (me == 0 && i == 0) continue;
-      char *ptr = strchr(files[currentfile],'%');
-      char *multiname = new char[strlen(files[currentfile]) + 16];
-      *ptr = '\0';
-      sprintf(multiname,"%s%d%s",files[currentfile],firstfile+i,ptr+1);
-      *ptr = '%';
-      readers[i]->open_file(multiname);
-      delete [] multiname;
+      std::string multiname = files[currentfile];
+      multiname.replace(multiname.find("%"),1,fmt::format("{}",firstfile+i));
+      readers[i]->open_file(multiname.c_str());
 
       bigint step;
       while (1) {

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -519,14 +519,10 @@ void ReadRestart::command(int narg, char **arg)
   // total time
 
   MPI_Barrier(world);
-  double time2 = MPI_Wtime();
 
-  if (comm->me == 0) {
-    if (screen)
-      fprintf(screen,"  read_restart CPU = %g secs\n",time2-time1);
-    if (logfile)
-      fprintf(logfile,"  read_restart CPU = %g secs\n",time2-time1);
-  }
+  if (comm->me == 0)
+    utils::logmesg(lmp,fmt::format("  read_restart CPU = {:.3f} secs\n",
+                                   MPI_Wtime()-time1));
 }
 
 /* ----------------------------------------------------------------------
@@ -810,12 +806,8 @@ void ReadRestart::header()
       for (int i = 0; i < nargcopy; i++)
         argcopy[i] = read_string();
       atom->create_avec(style,nargcopy,argcopy,1);
-      if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restoring atom style %s from "
-                            "restart\n", style);
-        if (logfile) fprintf(logfile,"  restoring atom style %s from "
-                             "restart\n", style);
-      }
+      if (comm->me ==0)
+        utils::logmesg(lmp,fmt::format("  restoring atom style {} from restart\n",style));
       for (int i = 0; i < nargcopy; i++) delete [] argcopy[i];
       delete [] argcopy;
       delete [] style;
@@ -947,22 +939,16 @@ void ReadRestart::force_fields()
       style = read_string();
       force->create_pair(style,1);
       delete [] style;
-      if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restoring pair style %s from "
-                            "restart\n", force->pair_style);
-        if (logfile) fprintf(logfile,"  restoring pair style %s from "
-                             "restart\n", force->pair_style);
-      }
+      if (comm->me ==0)
+        utils::logmesg(lmp,fmt::format("  restoring pair style {} from "
+                                       "restart\n", force->pair_style));
       force->pair->read_restart(fp);
 
     } else if (flag == NO_PAIR) {
       style = read_string();
-      if (comm->me ==0) {
-        if (screen) fprintf(screen,"  pair style %s stores no "
-                            "restart info\n", style);
-        if (logfile) fprintf(logfile,"  pair style %s stores no "
-                             "restart info\n", style);
-      }
+      if (comm->me ==0)
+        utils::logmesg(lmp,fmt::format("  pair style {} stores no "
+                                       "restart info\n", style));
       force->create_pair("none",0);
       force->pair_restart = style;
 
@@ -970,48 +956,36 @@ void ReadRestart::force_fields()
       style = read_string();
       force->create_bond(style,1);
       delete [] style;
-      if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restoring bond style %s from "
-                            "restart\n", force->bond_style);
-        if (logfile) fprintf(logfile,"  restoring bond style %s from "
-                             "restart\n", force->bond_style);
-      }
+      if (comm->me ==0)
+        utils::logmesg(lmp,fmt::format("  restoring bond style {} from "
+                                       "restart\n", force->bond_style));
       force->bond->read_restart(fp);
 
     } else if (flag == ANGLE) {
       style = read_string();
       force->create_angle(style,1);
       delete [] style;
-      if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restoring angle style %s from "
-                            "restart\n", force->angle_style);
-        if (logfile) fprintf(logfile,"  restoring angle style %s from "
-                             "restart\n", force->angle_style);
-      }
+      if (comm->me ==0)
+        utils::logmesg(lmp,fmt::format("  restoring angle style {} from "
+                                       "restart\n", force->angle_style));
       force->angle->read_restart(fp);
 
     } else if (flag == DIHEDRAL) {
       style = read_string();
       force->create_dihedral(style,1);
       delete [] style;
-      if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restoring dihedral style %s from "
-                            "restart\n", force->dihedral_style);
-        if (logfile) fprintf(logfile,"  restoring dihedral style %s from "
-                             "restart\n", force->dihedral_style);
-      }
+      if (comm->me ==0)
+        utils::logmesg(lmp,fmt::format("  restoring dihedral style {} from "
+                                       "restart\n", force->dihedral_style));
       force->dihedral->read_restart(fp);
 
     } else if (flag == IMPROPER) {
       style = read_string();
       force->create_improper(style,1);
       delete [] style;
-      if (comm->me ==0) {
-        if (screen) fprintf(screen,"  restoring improper style %s from "
-                            "restart\n", force->improper_style);
-        if (logfile) fprintf(logfile,"  restoring improper style %s from "
-                             "restart\n", force->improper_style);
-      }
+      if (comm->me ==0)
+        utils::logmesg(lmp,fmt::format("  restoring improper style {} from "
+                                       "restart\n", force->improper_style));
       force->improper->read_restart(fp);
 
     } else error->all(FLERR,

--- a/src/replicate.cpp
+++ b/src/replicate.cpp
@@ -777,12 +777,8 @@ void Replicate::command(int narg, char **arg)
   // total time
 
   MPI_Barrier(world);
-  double time2 = MPI_Wtime();
 
-  if (me == 0) {
-    if (screen)
-      fprintf(screen,"  replicate CPU = %g secs\n",time2-time1);
-    if (logfile)
-      fprintf(logfile,"  replicate CPU = %g secs\n",time2-time1);
-  }
+  if (me == 0)
+    utils::logmesg(lmp,fmt::format("  replicate CPU = {:.3f} secs\n",
+                                   MPI_Wtime()-time1));
 }

--- a/src/reset_ids.cpp
+++ b/src/reset_ids.cpp
@@ -24,6 +24,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -252,12 +253,9 @@ void ResetIDs::command(int narg, char **arg)
 
   int all;
   MPI_Allreduce(&badcount,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,"Reset_ids missing %d bond topology atom IDs - "
-            "use comm_modify cutoff",all);
-    error->all(FLERR,str);
-  }
+  if (all)
+    error->all(FLERR,fmt::format("Reset_ids missing {} bond topology atom IDs - "
+                                 "use comm_modify cutoff",all));
 
   // reset IDs and atom map for owned atoms
 

--- a/src/special.cpp
+++ b/src/special.cpp
@@ -1314,6 +1314,6 @@ void Special::fix_alteration()
 void Special::timer_output(double time1)
 {
   if (comm->me == 0)
-    utils::logmesg(lmp,fmt::format("  special bonds CPU = {:<.3g} secs\n",
+    utils::logmesg(lmp,fmt::format("  special bonds CPU = {:.3f} secs\n",
                                    MPI_Wtime()-time1));
 }

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -45,6 +45,7 @@
 #include "error.h"
 #include "math_const.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -423,21 +424,15 @@ bigint Thermo::lost_check()
 
   // error message
 
-  if (lostflag == Thermo::ERROR) {
-    char str[64];
-    sprintf(str,
-            "Lost atoms: original " BIGINT_FORMAT " current " BIGINT_FORMAT,
-            atom->natoms,ntotal);
-    error->all(FLERR,str);
-  }
+  if (lostflag == Thermo::ERROR)
+    error->all(FLERR,fmt::format("Lost atoms: original {} current {}",
+                                 atom->natoms,ntotal));
 
   // warning message
 
-  char str[64];
-  sprintf(str,
-          "Lost atoms: original " BIGINT_FORMAT " current " BIGINT_FORMAT,
-          atom->natoms,ntotal);
-  if (me == 0) error->warning(FLERR,str,0);
+  if (me == 0)
+    error->warning(FLERR,fmt::format("Lost atoms: original {} current {}",
+                                     atom->natoms,ntotal),0);
 
   // reset total atom count
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -309,18 +309,14 @@ void Update::create_integrate(int narg, char **arg, int trysuffix)
   int sflag;
   new_integrate(arg[0],narg-1,&arg[1],trysuffix,sflag);
 
+  std::string estyle = arg[0];
   if (sflag) {
-    char estyle[256];
-    if (sflag == 1) snprintf(estyle,256,"%s/%s",arg[0],lmp->suffix);
-    else snprintf(estyle,256,"%s/%s",arg[0],lmp->suffix2);
-    int n = strlen(estyle) + 1;
-    integrate_style = new char[n];
-    strcpy(integrate_style,estyle);
-  } else {
-    int n = strlen(arg[0]) + 1;
-    integrate_style = new char[n];
-    strcpy(integrate_style,arg[0]);
+    estyle += "/";
+    if (sflag == 1) estyle += lmp->suffix;
+    else  estyle += lmp->suffix2;
   }
+  integrate_style = new char[estyle.size()+1];
+  strcpy(integrate_style,estyle.c_str());
 }
 
 /* ----------------------------------------------------------------------
@@ -333,8 +329,7 @@ void Update::new_integrate(char *style, int narg, char **arg,
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + std::string("/") + lmp->suffix;
       if (integrate_map->find(estyle) != integrate_map->end()) {
         IntegrateCreator integrate_creator = (*integrate_map)[estyle];
         integrate = integrate_creator(lmp, narg, arg);
@@ -344,8 +339,7 @@ void Update::new_integrate(char *style, int narg, char **arg,
 
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + std::string("/") + lmp->suffix2;
       if (integrate_map->find(estyle) != integrate_map->end()) {
         IntegrateCreator integrate_creator = (*integrate_map)[estyle];
         integrate = integrate_creator(lmp, narg, arg);
@@ -386,18 +380,14 @@ void Update::create_minimize(int narg, char **arg, int trysuffix)
   int sflag;
   new_minimize(arg[0],narg-1,&arg[1],trysuffix,sflag);
 
+  std::string estyle = arg[0];
   if (sflag) {
-    char estyle[256];
-    if (sflag == 1) snprintf(estyle,256,"%s/%s",arg[0],lmp->suffix);
-    else snprintf(estyle,256,"%s/%s",arg[0],lmp->suffix2);
-    int n = strlen(estyle) + 1;
-    minimize_style = new char[n];
-    strcpy(minimize_style,estyle);
-  } else {
-    int n = strlen(arg[0]) + 1;
-    minimize_style = new char[n];
-    strcpy(minimize_style,arg[0]);
+    estyle += "/";
+    if (sflag == 1) estyle += lmp->suffix;
+    else estyle += lmp->suffix2;
   }
+  minimize_style = new char[estyle.size()+1];
+  strcpy(minimize_style,estyle.c_str());
 }
 
 /* ----------------------------------------------------------------------
@@ -410,8 +400,7 @@ void Update::new_minimize(char *style, int /* narg */, char ** /* arg */,
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
       sflag = 1;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix);
+      std::string estyle = style + std::string("/") + lmp->suffix;
       if (minimize_map->find(estyle) != minimize_map->end()) {
         MinimizeCreator minimize_creator = (*minimize_map)[estyle];
         minimize = minimize_creator(lmp);
@@ -421,8 +410,7 @@ void Update::new_minimize(char *style, int /* narg */, char ** /* arg */,
 
     if (lmp->suffix2) {
       sflag = 2;
-      char estyle[256];
-      snprintf(estyle,256,"%s/%s",style,lmp->suffix2);
+      std::string estyle = style + std::string("/") + lmp->suffix2;
       if (minimize_map->find(estyle) != minimize_map->end()) {
         MinimizeCreator minimize_creator = (*minimize_map)[estyle];
         minimize = minimize_creator(lmp);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -121,11 +121,10 @@ static const char *guesspath(char *buf, int len, FILE *fp)
   memset(buf,0,len);
 
 #if defined(__linux__)
-  char procpath[32];
   int fd = fileno(fp);
-  snprintf(procpath,32,"/proc/self/fd/%d",fd);
   // get pathname from /proc or copy (unknown)
-  if (readlink(procpath,buf,len-1) <= 0) strcpy(buf,"(unknown)");
+  if (readlink(fmt::format("/proc/self/fd/{}",fd).c_str(),buf,len-1) <= 0)
+    strcpy(buf,"(unknown)");
 #else
   strcpy(buf,"(unknown)");
 #endif

--- a/tools/README
+++ b/tools/README
@@ -17,6 +17,7 @@ binary2txt             convert a LAMMPS dump file from binary to ASCII text
 ch2lmp                 convert CHARMM files to LAMMPS input
 chain                  create a data file of bead-spring chains
 cmake                  tools and scripts for use with CMake
+coding_standard        python scripts to detect and fix some LAMMPS conventions
 colvars                post-process output of the fix colvars command
 createatoms            generate lattices of atoms within a geometry
 drude                  create Drude core/electron atom pairs in a data file
@@ -31,6 +32,7 @@ kate                   add-ons to Kate editor for editing LAMMPS input scripts
 lmp2arc                convert LAMMPS output to Accelrys Insight format
 lmp2cfg                convert LAMMPS output to CFG files for AtomEye viz
 matlab                 MatLab scripts for post-processing LAMMPS output
+mesont                 Tools for use with the USER-MESONT package
 micelle2d              create a data file of small lipid chains in solvent
 moltemplate            Instructions for installing the Moltemplate builder program
 msi2lmp                use Accelrys Insight code to setup LAMMPS input
@@ -40,8 +42,10 @@ pymol_asphere          convert LAMMPS output of ellipsoids to PyMol format
 python                 Python scripts for post-processing LAMMPS output
 reax                   Tools for analyzing output of ReaxFF simulations
 replica                tool to reorder LAMMPS replica trajectories according to temperature
+singularity            Singularity container descriptions suitable for LAMMPS development
 smd                    convert Smooth Mach Dynamics triangles to VTK
 spin                   perform a cubic polynomial interpolation of a GNEB MEP
+valgrind               suppression files for use with valgrind's memcheck tool
 vim                    add-ons to VIM editor for editing LAMMPS input scripts
 xmgrace                a collection of scripts to generate xmgrace plots
 

--- a/tools/coding_standard/README
+++ b/tools/coding_standard/README
@@ -1,0 +1,5 @@
+These Python scripts help to detect whether files in the repository
+conform to LAMMPS coding conventions or not, and can fix those issues, too.
+
+permissions.py   detects if sources have executable permissions and scripts have not
+whitespace.py    (currently) detects trailing whitespace

--- a/tools/valgrind/README
+++ b/tools/valgrind/README
@@ -1,0 +1,15 @@
+These files contain additional suppressions for LAMMPS when using valgrind's
+memcheck tool to search for memory access violations and memory leaks.
+These will suppress known false positives and thus help to focus finding
+and fixing real issues. When using CMake, these are automatically included
+when running "ctest -T memcheck". To manually add them to do a memory check
+on running LAMMPS, use a command line like following:
+
+valgrind --show-leak-kinds=all --track-origins=yes \
+   --suppressions=/path/to/lammps/tools/valgrind/OpenMP.supp \
+   --suppressions=/path/to/lammps/tools/valgrind/OpenMPI.supp \
+   --suppressions=/path/to/lammps/tools/valgrind/Python3.supp \
+    lmp -in in.melt
+
+Last update: 2020-06-24
+


### PR DESCRIPTION
**Summary**

This pull request further refactors the core LAMMPS code (i.e. in the `src` folder) to take advantage of C++ string handling with `std::string` and using `{fmt}` as well as `utils::logmesg()`. This results in smaller, simpler, and more readable code.
This becomes particularly visible in the `Finish` class.

It also fixes a few small unrelated issues, removes some debug code, adds/updates some README files and fixes a big logic bug in the legacy version of `open_potential()` that was incorrectly throwing an error, when a file had no UNITS: tag.

**Related Issues**

#2102 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. In some cases, the format of floating point numbers may be slightly different. fmtlib by default creates more digits of output with the general format that `"%g"`.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
