### PR TITLE
Simplify adding fixes and computes from inside LAMMPS

### DIFF
--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -489,32 +489,21 @@ void Balance::options(int iarg, int narg, char **arg)
 
 void Balance::weight_storage(char *prefix)
 {
-  char *fixargs[6];
+  std::string cmd = "";
 
-  if (prefix) {
-    int n = strlen(prefix) + 32;
-    fixargs[0] = new char[n];
-    strcpy(fixargs[0],prefix);
-    strcat(fixargs[0],"IMBALANCE_WEIGHTS");
-  } else fixargs[0] = (char *) "IMBALANCE_WEIGHTS";
+  if (prefix) cmd = prefix;
+  cmd += "IMBALANCE_WEIGHTS";
 
-  fixargs[1] = (char *) "all";
-  fixargs[2] = (char *) "STORE";
-  fixargs[3] = (char *) "peratom";
-  fixargs[4] = (char *) "0";
-  fixargs[5] = (char *) "1";
-
-  int ifix = modify->find_fix(fixargs[0]);
+  int ifix = modify->find_fix(cmd.c_str());
   if (ifix < 1) {
-    modify->add_fix(6,fixargs);
+    cmd += " all STORE peratom 0 1";
+    modify->add_fix(cmd);
     fixstore = (FixStore *) modify->fix[modify->nfix-1];
   } else fixstore = (FixStore *) modify->fix[ifix];
 
   // do not carry weights with atoms during normal atom migration
 
   fixstore->disable = 1;
-
-  if (prefix) delete [] fixargs[0];
 }
 
 /* ----------------------------------------------------------------------

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -36,6 +36,7 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -581,21 +582,9 @@ void ComputeChunkAtom::init()
   // fixstore initializes all values to 0.0
 
   if ((idsflag == ONCE || lockcount) && !fixstore) {
-    int n = strlen(id) + strlen("_COMPUTE_STORE") + 1;
-    id_fix = new char[n];
-    strcpy(id_fix,id);
-    strcat(id_fix,"_COMPUTE_STORE");
-
-    char **newarg = new char*[6];
-    newarg[0] = id_fix;
-    newarg[1] = group->names[igroup];
-    newarg[2] = (char *) "STORE";
-    newarg[3] = (char *) "peratom";
-    newarg[4] = (char *) "1";
-    newarg[5] = (char *) "1";
-    modify->add_fix(6,newarg);
+    modify->add_fix(fmt::format("{}_COMPUTE_STORE {} STORE peratom 1 1",
+                                id,group->names[igroup]));
     fixstore = (FixStore *) modify->fix[modify->nfix-1];
-    delete [] newarg;
   }
 
   if ((idsflag != ONCE && !lockcount) && fixstore) {

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -582,8 +582,12 @@ void ComputeChunkAtom::init()
   // fixstore initializes all values to 0.0
 
   if ((idsflag == ONCE || lockcount) && !fixstore) {
-    modify->add_fix(fmt::format("{}_COMPUTE_STORE {} STORE peratom 1 1",
-                                id,group->names[igroup]));
+    std::string cmd = id + std::string("_COMPUTE_STORE");
+    id_fix = new char[cmd.size()+1];
+    strcpy(id_fix,cmd.c_str());
+
+    cmd += fmt::format(" {} STORE peratom 1 1", group->names[igroup]);
+    modify->add_fix(cmd);
     fixstore = (FixStore *) modify->fix[modify->nfix-1];
   }
 

--- a/src/compute_displace_atom.cpp
+++ b/src/compute_displace_atom.cpp
@@ -73,8 +73,12 @@ ComputeDisplaceAtom::ComputeDisplaceAtom(LAMMPS *lmp, int narg, char **arg) :
   // create a new fix STORE style
   // id = compute-ID + COMPUTE_STORE, fix group = compute group
 
-  modify->add_fix(fmt::format("{}_COMPUTE_STORE {} STORE peratom 1 3",
-                              id,group->names[igroup]));
+  std::string cmd = id + std::string("_COMPUTE_STORE");
+  id_fix = new char[cmd.size()+1];
+  strcpy(id_fix,cmd.c_str());
+
+  cmd += fmt::format(" {} STORE peratom 1 3", group->names[igroup]);
+  modify->add_fix(cmd);
   fix = (FixStore *) modify->fix[modify->nfix-1];
 
   // calculate xu,yu,zu for fix store array

--- a/src/compute_displace_atom.cpp
+++ b/src/compute_displace_atom.cpp
@@ -24,6 +24,7 @@
 #include "variable.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -72,21 +73,9 @@ ComputeDisplaceAtom::ComputeDisplaceAtom(LAMMPS *lmp, int narg, char **arg) :
   // create a new fix STORE style
   // id = compute-ID + COMPUTE_STORE, fix group = compute group
 
-  int n = strlen(id) + strlen("_COMPUTE_STORE") + 1;
-  id_fix = new char[n];
-  strcpy(id_fix,id);
-  strcat(id_fix,"_COMPUTE_STORE");
-
-  char **newarg = new char*[6];
-  newarg[0] = id_fix;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "STORE";
-  newarg[3] = (char *) "peratom";
-  newarg[4] = (char *) "1";
-  newarg[5] = (char *) "3";
-  modify->add_fix(6,newarg);
+  modify->add_fix(fmt::format("{}_COMPUTE_STORE {} STORE peratom 1 3",
+                              id,group->names[igroup]));
   fix = (FixStore *) modify->fix[modify->nfix-1];
-  delete [] newarg;
 
   // calculate xu,yu,zu for fix store array
   // skip if reset from restart file

--- a/src/fix_box_relax.cpp
+++ b/src/fix_box_relax.cpp
@@ -18,6 +18,7 @@
 #include "fix_box_relax.h"
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "domain.h"
 #include "update.h"
@@ -28,6 +29,7 @@
 #include "compute.h"
 #include "error.h"
 #include "math_extra.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -317,36 +319,24 @@ FixBoxRelax::FixBoxRelax(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   //   and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  tcmd += " all temp";
+  modify->add_compute(tcmd);
   tflag = 1;
 
   // create a new compute pressure style (virial only)
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[5];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  newarg[4] = (char *) "virial";
-  modify->add_compute(5,newarg);
-  delete [] newarg;
+  pcmd += " all pressure " + std::string(id_temp) + " virial";
+  modify->add_compute(pcmd);
   pflag = 1;
 
   dimension = domain->dimension;

--- a/src/fix_nph.cpp
+++ b/src/fix_nph.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_nph.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -34,35 +35,23 @@ FixNPH::FixNPH(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  tcmd += " all temp";
+  modify->add_compute(tcmd);
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  pcmd += " all pressure " + std::string(id_temp);
+  modify->add_compute(pcmd);
   pcomputeflag = 1;
 }

--- a/src/fix_nph_sphere.cpp
+++ b/src/fix_nph_sphere.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_nph_sphere.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -34,35 +35,23 @@ FixNPHSphere::FixNPHSphere(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp/sphere";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  tcmd += " all temp/sphere";
+  modify->add_compute(tcmd);
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  pcmd += " all pressure " + std::string(id_temp);
+  modify->add_compute(pcmd);
   pcomputeflag = 1;
 }

--- a/src/fix_npt.cpp
+++ b/src/fix_npt.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_npt.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -34,35 +35,23 @@ FixNPT::FixNPT(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  tcmd += " all temp";
+  modify->add_compute(tcmd);
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  pcmd += " all pressure " + std::string(id_temp);
+  modify->add_compute(pcmd);
   pcomputeflag = 1;
 }

--- a/src/fix_npt_sphere.cpp
+++ b/src/fix_npt_sphere.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_npt_sphere.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -34,35 +35,23 @@ FixNPTSphere::FixNPTSphere(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp/sphere";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  tcmd += " all temp/sphere";
+  modify->add_compute(tcmd);
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  pcmd += " all pressure " + std::string(id_temp);
+  modify->add_compute(pcmd);
   pcomputeflag = 1;
 }

--- a/src/fix_numdiff.cpp
+++ b/src/fix_numdiff.cpp
@@ -55,17 +55,12 @@ FixNumDiff::FixNumDiff(LAMMPS *lmp, int narg, char **arg) :
   if (nevery <= 0 || delta <= 0.0)
     error->all(FLERR,"Illegal fix numdiff command");
 
-  int n = strlen(id) + 6;
-  id_pe = new char[n];
-  strcpy(id_pe,id);
-  strcat(id_pe,"_pe");
+  std::string cmd = id + std::string("_pe");
+  id_pe = new char[cmd.size()+1];
+  strcpy(id_pe,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_pe;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pe";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += " all pe";
+  modify->add_compute(cmd);
 
   maxatom = 0;
 

--- a/src/fix_nvt.cpp
+++ b/src/fix_nvt.cpp
@@ -13,9 +13,11 @@
 
 #include "fix_nvt.h"
 #include <cstring>
+#include <string>
 #include "group.h"
 #include "modify.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -33,17 +35,11 @@ FixNVT::FixNVT(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  tcmd += fmt::format(" {} temp",group->names[igroup]);
+  modify->add_compute(tcmd);
   tcomputeflag = 1;
 }

--- a/src/fix_nvt_sllod.cpp
+++ b/src/fix_nvt_sllod.cpp
@@ -26,6 +26,7 @@
 #include "fix_deform.h"
 #include "compute.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -48,18 +49,12 @@ FixNVTSllod::FixNVTSllod(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp/deform";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += fmt::format(" {} temp/deform",group->names[igroup]);
+  modify->add_compute(cmd);
   tcomputeflag = 1;
 }
 

--- a/src/fix_nvt_sphere.cpp
+++ b/src/fix_nvt_sphere.cpp
@@ -16,6 +16,7 @@
 #include "group.h"
 #include "modify.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -33,17 +34,11 @@ FixNVTSphere::FixNVTSphere(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp/sphere";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += fmt::format(" {} temp/sphere",group->names[igroup]);
+  modify->add_compute(cmd);
   tcomputeflag = 1;
 }

--- a/src/fix_press_berendsen.cpp
+++ b/src/fix_press_berendsen.cpp
@@ -14,6 +14,7 @@
 #include "fix_press_berendsen.h"
 #include <cstring>
 #include <cmath>
+#include <string>
 #include "atom.h"
 #include "force.h"
 #include "comm.h"
@@ -217,35 +218,24 @@ FixPressBerendsen::FixPressBerendsen(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   //   and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  tcmd += " all temp";
+  modify->add_compute(tcmd);
   tflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  pcmd += " all pressure " + std::string(id_temp);
+  modify->add_compute(pcmd);
   pflag = 1;
 
   nrigid = 0;

--- a/src/fix_temp_berendsen.cpp
+++ b/src/fix_temp_berendsen.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_temp_berendsen.h"
 #include <cstring>
+#include <string>
 #include <cmath>
 #include "atom.h"
 #include "force.h"
@@ -70,17 +71,12 @@ FixTempBerendsen::FixTempBerendsen(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp, compute group = fix group
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += group->names[igroup] + std::string(" temp");
+  modify->add_compute(cmd);
   tflag = 1;
 
   energy = 0;

--- a/src/fix_temp_berendsen.cpp
+++ b/src/fix_temp_berendsen.cpp
@@ -25,6 +25,7 @@
 #include "modify.h"
 #include "compute.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -75,7 +76,7 @@ FixTempBerendsen::FixTempBerendsen(LAMMPS *lmp, int narg, char **arg) :
   id_temp = new char[cmd.size()+1];
   strcpy(id_temp,cmd.c_str());
 
-  cmd += group->names[igroup] + std::string(" temp");
+  cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;
 

--- a/src/fix_temp_csld.cpp
+++ b/src/fix_temp_csld.cpp
@@ -17,6 +17,7 @@
 
 #include "fix_temp_csld.h"
 #include <cstring>
+#include <string>
 #include <cmath>
 #include "atom.h"
 #include "force.h"
@@ -79,17 +80,12 @@ FixTempCSLD::FixTempCSLD(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp, compute group = fix group
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += group->names[igroup] + std::string(" temp");
+  modify->add_compute(cmd);
   tflag = 1;
 
   vhold = NULL;

--- a/src/fix_temp_csld.cpp
+++ b/src/fix_temp_csld.cpp
@@ -31,6 +31,7 @@
 #include "compute.h"
 #include "random_mars.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -84,7 +85,7 @@ FixTempCSLD::FixTempCSLD(LAMMPS *lmp, int narg, char **arg) :
   id_temp = new char[cmd.size()+1];
   strcpy(id_temp,cmd.c_str());
 
-  cmd += group->names[igroup] + std::string(" temp");
+  cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;
 

--- a/src/fix_temp_csvr.cpp
+++ b/src/fix_temp_csvr.cpp
@@ -32,6 +32,7 @@
 #include "compute.h"
 #include "random_mars.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -161,7 +162,7 @@ FixTempCSVR::FixTempCSVR(LAMMPS *lmp, int narg, char **arg) :
   id_temp = new char[cmd.size()+1];
   strcpy(id_temp,cmd.c_str());
 
-  cmd += group->names[igroup] + std::string(" temp");
+  cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;
 

--- a/src/fix_temp_csvr.cpp
+++ b/src/fix_temp_csvr.cpp
@@ -20,6 +20,7 @@
 #include <mpi.h>
 #include <cstring>
 #include <cmath>
+#include <string>
 #include "atom.h"
 #include "force.h"
 #include "comm.h"
@@ -156,17 +157,12 @@ FixTempCSVR::FixTempCSVR(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp, compute group = fix group
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += group->names[igroup] + std::string(" temp");
+  modify->add_compute(cmd);
   tflag = 1;
 
   nmax = -1;

--- a/src/fix_temp_rescale.cpp
+++ b/src/fix_temp_rescale.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_temp_rescale.h"
 #include <cstring>
+#include <string>
 #include <cmath>
 #include "atom.h"
 #include "force.h"
@@ -66,17 +67,12 @@ FixTempRescale::FixTempRescale(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp
   // id = fix-ID + temp, compute group = fix group
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[6];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += group->names[igroup] + std::string(" temp");
+  modify->add_compute(cmd);
   tflag = 1;
 
   energy = 0.0;

--- a/src/fix_temp_rescale.cpp
+++ b/src/fix_temp_rescale.cpp
@@ -25,6 +25,7 @@
 #include "modify.h"
 #include "compute.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -71,7 +72,7 @@ FixTempRescale::FixTempRescale(LAMMPS *lmp, int narg, char **arg) :
   id_temp = new char[cmd.size()+1];
   strcpy(id_temp,cmd.c_str());
 
-  cmd += group->names[igroup] + std::string(" temp");
+  cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;
 

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -942,6 +942,23 @@ void Modify::add_fix(int narg, char **arg, int trysuffix)
 }
 
 /* ----------------------------------------------------------------------
+   convenience function to allow adding a fix from a single string
+------------------------------------------------------------------------- */
+
+void Modify::add_fix(const std::string &fixcmd, int trysuffix)
+{
+  std::vector<std::string> args = utils::split_words(fixcmd);
+  char **newarg = new char*[args.size()];
+  int i=0;
+  for (const auto &arg : args) {
+    newarg[i++] = (char *)arg.c_str();
+  }
+  add_fix(args.size(),newarg,trysuffix);
+  delete[] newarg;
+}
+
+
+/* ----------------------------------------------------------------------
    replace replaceID fix with a new fix
    this is used by callers to preserve ordering of fixes
    e.g. create replaceID as a FixDummy instance early in the input script
@@ -1227,6 +1244,23 @@ void Modify::add_compute(int narg, char **arg, int trysuffix)
 
   ncompute++;
 }
+
+/* ----------------------------------------------------------------------
+   convenience function to allow adding a compute from a single string
+------------------------------------------------------------------------- */
+
+void Modify::add_compute(const std::string &computecmd, int trysuffix)
+{
+  std::vector<std::string> args = utils::split_words(computecmd);
+  char **newarg = new char*[args.size()];
+  int i=0;
+  for (const auto &arg : args) {
+    newarg[i++] = (char *)arg.c_str();
+  }
+  add_compute(args.size(),newarg,trysuffix);
+  delete[] newarg;
+}
+
 
 /* ----------------------------------------------------------------------
    one instance per compute in style_compute.h

--- a/src/modify.h
+++ b/src/modify.h
@@ -96,6 +96,7 @@ class Modify : protected Pointers {
   virtual int min_reset_ref();
 
   void add_fix(int, char **, int trysuffix=1);
+  void add_fix(const std::string &, int trysuffix=1);
   void replace_fix(const char *, int, char **, int trysuffix=1);
   void modify_fix(int, char **);
   void delete_fix(const char *);
@@ -108,6 +109,7 @@ class Modify : protected Pointers {
   int check_rigid_list_overlap(int *);
 
   void add_compute(int, char **, int trysuffix=1);
+  void add_compute(const std::string &, int trysuffix=1);
   void modify_compute(int, char **);
   void delete_compute(const char *);
   int find_compute(const char *);

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -1544,8 +1544,8 @@ void Neighbor::print_pairwise_info()
     if (lists[i]->bin_method == 0) out += "bin: none\n";
     else out += fmt::format("bin: {}\n",binnames[lists[i]->bin_method-1]);
 
-    utils::logmesg(lmp,out);
   }
+  utils::logmesg(lmp,out);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -46,28 +46,13 @@ Output::Output(LAMMPS *lmp) : Pointers(lmp)
 {
   // create default computes for temp,pressure,pe
 
-  char **newarg = new char*[4];
-  newarg[0] = (char *) "thermo_temp";
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-
-  newarg[0] = (char *) "thermo_press";
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = (char *) "thermo_temp";
-  modify->add_compute(4,newarg);
-
-  newarg[0] = (char *) "thermo_pe";
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pe";
-  modify->add_compute(3,newarg);
-
-  delete [] newarg;
+  modify->add_compute("thermo_temp all temp");
+  modify->add_compute("thermo_press all pressure thermo_temp");
+  modify->add_compute("thermo_pe all pe");
 
   // create default Thermo class
 
-  newarg = new char*[1];
+  char **newarg = new char*[1];
   newarg[0] = (char *) "one";
   thermo = new Thermo(lmp,1,newarg);
   delete [] newarg;

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -316,8 +316,7 @@ void Thermo::header()
 
   std::string hdr;
   for (int i = 0; i < nfield; i++) hdr +=  keyword[i] + std::string(" ");
-  hdr += "\n";
-  if (me == 0) utils::logmesg(lmp,hdr);
+  if (me == 0) utils::logmesg(lmp,hdr+"\n");
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -5073,24 +5073,16 @@ VarReader::VarReader(LAMMPS *lmp, char *name, char *file, int flag) :
 
   if (style == ATOMFILE) {
     if (atom->map_style == 0)
-      error->all(FLERR,
-                 "Cannot use atomfile-style variable unless atom map exists");
+      error->all(FLERR,"Cannot use atomfile-style "
+                 "variable unless an atom map exists");
 
-    int n = strlen(name) + strlen("_VARIABLE_STORE") + 1;
-    id_fix = new char[n];
-    strcpy(id_fix,name);
-    strcat(id_fix,"_VARIABLE_STORE");
+    std::string cmd = name + std::string("_VARIABLE_STORE");
+    id_fix = new char[cmd.size()+1];
+    strcpy(id_fix,cmd.c_str());
 
-    char **newarg = new char*[6];
-    newarg[0] = id_fix;
-    newarg[1] = (char *) "all";
-    newarg[2] = (char *) "STORE";
-    newarg[3] = (char *) "peratom";
-    newarg[4] = (char *) "0";
-    newarg[5] = (char *) "1";
-    modify->add_fix(6,newarg);
+    cmd += " all STORE peratom 0 1";
+    modify->add_fix(cmd);
     fixstore = (FixStore *) modify->fix[modify->nfix-1];
-    delete [] newarg;
 
     buffer = new char[CHUNK*MAXLINE];
   }


### PR DESCRIPTION
**Summary**

This PR adds a more convenient version of `modify->add_fix()` and `modify->add_compute()` where there is a single string as argument instead of the number of arguments and list of arguments. Instead this list is created on the fly.
In combination with using `fmt::format()`, this can reduce the code to create a new fix or compute to a single line.


**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

Things would be cleaner if LAMMPS would be using `const char *` wherever possible instead of `char *`.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
