### PR TITLE
Fix compiler warnings in the GPU package

### DIFF
--- a/examples/threebody/CdTeZnSeHgS0.sw
+++ b/examples/threebody/CdTeZnSeHgS0.sw
@@ -1,0 +1,1 @@
+../../potentials/CdTeZnSeHgS0.sw

--- a/lib/gpu/lal_tersoff.cu
+++ b/lib/gpu/lal_tersoff.cu
@@ -566,7 +566,6 @@ __kernel void k_tersoff_three_center(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -749,7 +748,6 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -804,12 +802,8 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
+      if (ijnum < 0) {
         ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
       }
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
@@ -987,7 +981,6 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -1042,12 +1035,8 @@ __kernel void k_tersoff_three_end_vatom(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
+      if (ijnum < 0) {
         ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
       }
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor

--- a/lib/gpu/lal_tersoff_mod.cu
+++ b/lib/gpu/lal_tersoff_mod.cu
@@ -570,7 +570,6 @@ __kernel void k_tersoff_mod_three_center(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -759,7 +758,6 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -814,12 +812,8 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
+      if (ijnum < 0) {
         ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
       }
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
@@ -1005,7 +999,6 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -1060,12 +1053,8 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
+      if (ijnum < 0) {
         ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
       }
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor

--- a/lib/gpu/lal_tersoff_zbl.cu
+++ b/lib/gpu/lal_tersoff_zbl.cu
@@ -586,7 +586,6 @@ __kernel void k_tersoff_zbl_three_center(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -769,7 +768,6 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -824,12 +822,8 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
+      if (ijnum < 0) {
         ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
       }
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
@@ -1006,7 +1000,6 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
       numtyp4 jx; fetch4(jx,j,pos_tex); //x_[j];
       int jtype=jx.w;
       jtype=map[jtype];
-      int ijparam=elem2param[itype*nelements*nelements+jtype*nelements+jtype];
 
       // Compute r12
       numtyp delr1[3];
@@ -1061,12 +1054,8 @@ __kernel void k_tersoff_zbl_three_end_vatom(const __global numtyp4 *restrict x_,
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      int offset_kf;
-      if (ijnum >= 0) {
-        offset_kf = offset_k;
-      } else {
+      if (ijnum < 0) {
         ijnum = red_acc[2*m+0];
-        offset_kf = red_acc[2*m+1];
       }
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor


### PR DESCRIPTION
**Summary**

Few unused variables left in `lal_tersoff*.cu` are generating tens of warnings "variable xxx was declared but never referenced" during the building of the GPU package. I would consider these warnings as true positive in this case and delete the corresponding lines to keep the compiler output clear and informative.

**Author(s)**

Vsevolod Nikolskiy (thevsevak@gmail.com, @Vsevak)
International Laboratory for Supercomputer Atomistic Modelling and Multi-scale Analysis
HSE University, Moscow, Russia

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Keeps

**Implementation Notes**

The thermodynamics output of examples/threebody with `thermo_modify  format float "%.15g"` and enabled GPU stays exactly the same after the changes. Btw I faced that a symlink to one of the required potentials is missing in examples/threebody, so I added it.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [x] One or more example input decks are included
