### PR TITLE
More application of fix/compute simplification

### DIFF
--- a/src/ASPHERE/fix_nph_asphere.cpp
+++ b/src/ASPHERE/fix_nph_asphere.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_nph_asphere.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -35,35 +36,21 @@ FixNPHAsphere::FixNPHAsphere(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp/asphere";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  modify->add_compute(tcmd + " all temp/asphere");
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  modify->add_compute(pcmd + " all pressure " + std::string(id_temp));
   pcomputeflag = 1;
 }

--- a/src/ASPHERE/fix_npt_asphere.cpp
+++ b/src/ASPHERE/fix_npt_asphere.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_npt_asphere.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -34,35 +35,21 @@ FixNPTAsphere::FixNPTAsphere(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp/asphere";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  modify->add_compute(tcmd + " all temp/asphere");
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  modify->add_compute(pcmd + " all pressure " + std::string(id_temp));
   pcomputeflag = 1;
 }

--- a/src/ASPHERE/fix_nvt_asphere.cpp
+++ b/src/ASPHERE/fix_nvt_asphere.cpp
@@ -13,9 +13,11 @@
 
 #include "fix_nvt_asphere.h"
 #include <cstring>
+#include <string>
 #include "group.h"
 #include "modify.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -33,17 +35,11 @@ FixNVTAsphere::FixNVTAsphere(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp/asphere";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  cmd += fmt::format(" {} temp/asphere",group->names[igroup]);
+  modify->add_compute(cmd);
   tcomputeflag = 1;
 }

--- a/src/BODY/fix_nph_body.cpp
+++ b/src/BODY/fix_nph_body.cpp
@@ -17,6 +17,7 @@
 
 #include "fix_nph_body.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -38,35 +39,21 @@ FixNPHBody::FixNPHBody(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp/body";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  modify->add_compute(tcmd + " all temp/body");
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  modify->add_compute(pcmd + " all pressure " + std::string(id_temp));
   pcomputeflag = 1;
 }

--- a/src/BODY/fix_npt_body.cpp
+++ b/src/BODY/fix_npt_body.cpp
@@ -17,6 +17,7 @@
 
 #include "fix_npt_body.h"
 #include <cstring>
+#include <string>
 #include "modify.h"
 #include "error.h"
 
@@ -38,35 +39,21 @@ FixNPTBody::FixNPTBody(LAMMPS *lmp, int narg, char **arg) :
   // compute group = all since pressure is always global (group all)
   // and thus its KE/temperature contribution should use group all
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp/body";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  modify->add_compute(tcmd + " all temp/body");
   tcomputeflag = 1;
 
   // create a new compute pressure style
   // id = fix-ID + press, compute group = all
   // pass id_temp as 4th arg to pressure constructor
 
-  n = strlen(id) + 7;
-  id_press = new char[n];
-  strcpy(id_press,id);
-  strcat(id_press,"_press");
+  std::string pcmd = id + std::string("_press");
+  id_press = new char[pcmd.size()+1];
+  strcpy(id_press,pcmd.c_str());
 
-  newarg = new char*[4];
-  newarg[0] = id_press;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pressure";
-  newarg[3] = id_temp;
-  modify->add_compute(4,newarg);
-  delete [] newarg;
+  modify->add_compute(pcmd + " all pressure " + std::string(id_temp));
   pcomputeflag = 1;
 }

--- a/src/BODY/fix_nvt_body.cpp
+++ b/src/BODY/fix_nvt_body.cpp
@@ -17,6 +17,7 @@
 
 #include "fix_nvt_body.h"
 #include <cstring>
+#include <string>
 #include "group.h"
 #include "modify.h"
 #include "error.h"
@@ -37,17 +38,10 @@ FixNVTBody::FixNVTBody(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string tcmd = id + std::string("_temp");
+  id_temp = new char[tcmd.size()+1];
+  strcpy(id_temp,tcmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "temp/body";
-
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  modify->add_compute(tcmd + " all temp/body");
   tcomputeflag = 1;
 }

--- a/src/CORESHELL/compute_temp_cs.cpp
+++ b/src/CORESHELL/compute_temp_cs.cpp
@@ -70,7 +70,7 @@ ComputeTempCS::ComputeTempCS(LAMMPS *lmp, int narg, char **arg) :
 
   std::string fixcmd = id + std::string("_COMPUTE_STORE");
   id_fix = new char[fixcmd.size()+1];
-  strcpy(id_fix,fix_cmd.c_str());
+  strcpy(id_fix,fixcmd.c_str());
 
   fixcmd += fmt::format(" {} STORE peratom 0 1", group->names[igroup]);
   modify->add_fix(fixcmd);

--- a/src/CORESHELL/compute_temp_cs.cpp
+++ b/src/CORESHELL/compute_temp_cs.cpp
@@ -19,6 +19,7 @@
 #include "compute_temp_cs.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "atom_vec.h"
 #include "domain.h"
@@ -30,6 +31,7 @@
 #include "comm.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -66,21 +68,13 @@ ComputeTempCS::ComputeTempCS(LAMMPS *lmp, int narg, char **arg) :
   // create a new fix STORE style
   // id = compute-ID + COMPUTE_STORE, fix group = compute group
 
-  int n = strlen(id) + strlen("_COMPUTE_STORE") + 1;
-  id_fix = new char[n];
-  strcpy(id_fix,id);
-  strcat(id_fix,"_COMPUTE_STORE");
+  std::string fixcmd = id + std::string("_COMPUTE_STORE");
+  id_fix = new char[fixcmd.size()+1];
+  strcpy(id_fix,fix_cmd.c_str());
 
-  char **newarg = new char*[6];
-  newarg[0] = id_fix;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "STORE";
-  newarg[3] = (char *) "peratom";
-  newarg[4] = (char *) "0";
-  newarg[5] = (char *) "1";
-  modify->add_fix(6,newarg);
+  fixcmd += fmt::format(" {} STORE peratom 0 1", group->names[igroup]);
+  modify->add_fix(fixcmd);
   fix = (FixStore *) modify->fix[modify->nfix-1];
-  delete [] newarg;
 
   // set fix store values = 0 for now
   // fill them in via setup() once Comm::borders() has been called

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -19,6 +19,7 @@
 #include <mpi.h>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "force.h"
 #include "update.h"
@@ -65,13 +66,7 @@ PairGranHookeHistory::PairGranHookeHistory(LAMMPS *lmp) : Pair(lmp)
   // this is so final order of Modify:fix will conform to input script
 
   fix_history = NULL;
-
-  char **fixarg = new char*[3];
-  fixarg[0] = (char *) "NEIGH_HISTORY_HH_DUMMY";
-  fixarg[1] = (char *) "all";
-  fixarg[2] = (char *) "DUMMY";
-  modify->add_fix(3,fixarg,1);
-  delete [] fixarg;
+  modify->add_fix("NEIGH_HISTORY_HH_DUMMY all DUMMY");
   fix_dummy = (FixDummy *) modify->fix[modify->nfix-1];
 }
 

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -21,6 +21,7 @@
 #include <mpi.h>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "force.h"
 #include "update.h"
@@ -96,13 +97,7 @@ PairGranular::PairGranular(LAMMPS *lmp) : Pair(lmp)
   // this is so final order of Modify:fix will conform to input script
 
   fix_history = NULL;
-
-  char **fixarg = new char*[3];
-  fixarg[0] = (char *) "NEIGH_HISTORY_GRANULAR_DUMMY";
-  fixarg[1] = (char *) "all";
-  fixarg[2] = (char *) "DUMMY";
-  modify->add_fix(3,fixarg,1);
-  delete [] fixarg;
+  modify->add_fix("NEIGH_HISTORY_GRANULAR_DUMMY all DUMMY");
   fix_dummy = (FixDummy *) modify->fix[modify->nfix-1];
 }
 

--- a/src/KIM/kim_init.cpp
+++ b/src/KIM/kim_init.cpp
@@ -291,11 +291,7 @@ void KimInit::do_init(char *model_name, char *user_units, char *model_units, KIM
 
   int ifix = modify->find_fix("KIM_MODEL_STORE");
   if (ifix >= 0) modify->delete_fix(ifix);
-  char *fixarg[3];
-  fixarg[0] = (char *)"KIM_MODEL_STORE";
-  fixarg[1] = (char *)"all";
-  fixarg[2] = (char *)"STORE/KIM";
-  modify->add_fix(3,fixarg);
+  modify->add_fix("KIM_MODEL_STORE all STORE/KIM");
   ifix = modify->find_fix("KIM_MODEL_STORE");
 
   FixStoreKIM *fix_store = (FixStoreKIM *) modify->fix[ifix];

--- a/src/MC/fix_bond_swap.cpp
+++ b/src/MC/fix_bond_swap.cpp
@@ -86,17 +86,11 @@ FixBondSwap::FixBondSwap(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute temp style
   // id = fix-ID + temp, compute group = fix group
 
-  int n = strlen(id) + 6;
-  id_temp = new char[n];
-  strcpy(id_temp,id);
-  strcat(id_temp,"_temp");
+  std::string cmd = id + std::string("_temp");
+  id_temp = new char[cmd.size()+1];
+  strcpy(id_temp,cmd.c_str());
 
-  char **newarg = new char*[3];
-  newarg[0] = id_temp;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "temp";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  modify->add_compute(cmd + " all temp");
   tflag = 1;
 
   // initialize atom list

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -19,6 +19,7 @@
 #include <mpi.h>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "domain.h"
 #include "lattice.h"
@@ -515,14 +516,7 @@ void PairPeriEPS::init_style()
 
   // if first init, create Fix needed for storing fixed neighbors
 
-  if (ifix_peri == -1) {
-    char **fixarg = new char*[3];
-    fixarg[0] = (char *) "PERI_NEIGH";
-    fixarg[1] = (char *) "all";
-    fixarg[2] = (char *) "PERI_NEIGH";
-    modify->add_fix(3,fixarg);
-    delete [] fixarg;
-  }
+  if (ifix_peri == -1) modify->add_fix("PERI_NEIGH all PERI_NEIGH");
 
   // find associated PERI_NEIGH fix that must exist
   // could have changed locations in fix list since created

--- a/src/PERI/pair_peri_lps.cpp
+++ b/src/PERI/pair_peri_lps.cpp
@@ -19,6 +19,7 @@
 #include <mpi.h>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "domain.h"
 #include "lattice.h"
@@ -439,14 +440,7 @@ void PairPeriLPS::init_style()
 
   // if first init, create Fix needed for storing fixed neighbors
 
-  if (ifix_peri == -1) {
-    char **fixarg = new char*[3];
-    fixarg[0] = (char *) "PERI_NEIGH";
-    fixarg[1] = (char *) "all";
-    fixarg[2] = (char *) "PERI_NEIGH";
-    modify->add_fix(3,fixarg);
-    delete [] fixarg;
-  }
+  if (ifix_peri == -1) modify->add_fix("PERI_NEIGH all PERI_NEIGH");
 
   // find associated PERI_NEIGH fix that must exist
   // could have changed locations in fix list since created

--- a/src/PERI/pair_peri_pmb.cpp
+++ b/src/PERI/pair_peri_pmb.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cfloat>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "domain.h"
 #include "lattice.h"
@@ -369,14 +370,7 @@ void PairPeriPMB::init_style()
 
   // if first init, create Fix needed for storing fixed neighbors
 
-  if (ifix_peri == -1) {
-    char **fixarg = new char*[3];
-    fixarg[0] = (char *) "PERI_NEIGH";
-    fixarg[1] = (char *) "all";
-    fixarg[2] = (char *) "PERI_NEIGH";
-    modify->add_fix(3,fixarg);
-    delete [] fixarg;
-  }
+  if (ifix_peri == -1) modify->add_fix("PERI_NEIGH all PERI_NEIGH");
 
   // find associated PERI_NEIGH fix that must exist
   // could have changed locations in fix list since created

--- a/src/PERI/pair_peri_ves.cpp
+++ b/src/PERI/pair_peri_ves.cpp
@@ -19,6 +19,7 @@
 #include <mpi.h>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "domain.h"
 #include "lattice.h"
@@ -495,14 +496,7 @@ void PairPeriVES::init_style()
 
   // if first init, create Fix needed for storing fixed neighbors
 
-  if (ifix_peri == -1) {
-    char **fixarg = new char*[3];
-    fixarg[0] = (char *) "PERI_NEIGH";
-    fixarg[1] = (char *) "all";
-    fixarg[2] = (char *) "PERI_NEIGH";
-    modify->add_fix(3,fixarg);
-    delete [] fixarg;
-  }
+  if (ifix_peri == -1) modify->add_fix("PERI_NEIGH all PERI_NEIGH");
 
   // find associated PERI_NEIGH fix that must exist
   // could have changed locations in fix list since created

--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -20,6 +20,7 @@
 #include <mpi.h>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include "universe.h"
 #include "update.h"
 #include "atom.h"
@@ -148,17 +149,10 @@ FixNEB::FixNEB(LAMMPS *lmp, int narg, char **arg) :
   // create a new compute pe style
   // id = fix-ID + pe, compute group = all
 
-  int n = strlen(id) + 4;
-  id_pe = new char[n];
-  strcpy(id_pe,id);
-  strcat(id_pe,"_pe");
-
-  char **newarg = new char*[3];
-  newarg[0] = id_pe;
-  newarg[1] = (char *) "all";
-  newarg[2] = (char *) "pe";
-  modify->add_compute(3,newarg);
-  delete [] newarg;
+  std::string cmd = id + std::string("_pe");
+  id_pe = new char[cmd.size()+1];
+  strcpy(id_pe,cmd.c_str());
+  modify->add_compute(cmd + " all pe");
 
   // initialize local storage
 

--- a/src/REPLICA/hyper.cpp
+++ b/src/REPLICA/hyper.cpp
@@ -14,6 +14,7 @@
 #include "hyper.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "update.h"
 #include "domain.h"
 #include "region.h"
@@ -100,13 +101,8 @@ void Hyper::command(int narg, char **arg)
 
   // create FixEventHyper class to store event and pre-quench states
 
-  char **args = new char*[3];
-  args[0] = (char *) "hyper_event";
-  args[1] = (char *) "all";
-  args[2] = (char *) "EVENT/HYPER";
-  modify->add_fix(3,args);
+  modify->add_fix("hyper_event all EVENT/HYPER");
   fix_event = (FixEventHyper *) modify->fix[modify->nfix-1];
-  delete [] args;
 
   // create Finish for timing output
 

--- a/src/REPLICA/prd.cpp
+++ b/src/REPLICA/prd.cpp
@@ -18,6 +18,7 @@
 #include "prd.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "universe.h"
 #include "update.h"
 #include "atom.h"
@@ -146,11 +147,7 @@ void PRD::command(int narg, char **arg)
 
   // create ComputeTemp class to monitor temperature
 
-  char **args = new char*[3];
-  args[0] = (char *) "prd_temp";
-  args[1] = (char *) "all";
-  args[2] = (char *) "temp";
-  modify->add_compute(3,args);
+  modify->add_compute("prd_temp all temp");
   temperature = modify->compute[modify->ncompute-1];
 
   // create Velocity class for velocity creation in dephasing
@@ -160,6 +157,7 @@ void PRD::command(int narg, char **arg)
   velocity = new Velocity(lmp);
   velocity->init_external("all");
 
+  char *args[2];
   args[0] = (char *) "temp";
   args[1] = (char *) "prd_temp";
   velocity->options(2,args);
@@ -172,10 +170,7 @@ void PRD::command(int narg, char **arg)
 
   // create FixEventPRD class to store event and pre-quench states
 
-  args[0] = (char *) "prd_event";
-  args[1] = (char *) "all";
-  args[2] = (char *) "EVENT/PRD";
-  modify->add_fix(3,args);
+  modify->add_fix("prd_event all EVENT/PRD");
   fix_event = (FixEventPRD *) modify->fix[modify->nfix-1];
 
   // create Finish for timing output
@@ -184,7 +179,6 @@ void PRD::command(int narg, char **arg)
 
   // string clean-up
 
-  delete [] args;
   delete [] loop_setting;
   delete [] dist_setting;
 

--- a/src/USER-COLVARS/ndx_group.cpp
+++ b/src/USER-COLVARS/ndx_group.cpp
@@ -226,12 +226,7 @@ void Ndx2Group::create(char *name, bigint num, tagint *tags)
 {
   // wipe out all members if the group exists. gid==0 is group "all"
   int gid = group->find(name);
-  if (gid > 0) {
-    char *cmd[2];
-    cmd[0] = name;
-    cmd[1] = (char *)"clear";
-    group->assign(2,cmd);
-  }
+  if (gid > 0) group->assign(std::string(name) + " clear");
 
   // map from global to local
   const int nlocal = atom->nlocal;

--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -494,7 +494,7 @@ void Balance::weight_storage(char *prefix)
   if (prefix) cmd = prefix;
   cmd += "IMBALANCE_WEIGHTS";
 
-  int ifix = modify->find_fix(cmd.c_str());
+  int ifix = modify->find_fix(cmd);
   if (ifix < 1) {
     cmd += " all STORE peratom 0 1";
     modify->add_fix(cmd);

--- a/src/compute_msd.cpp
+++ b/src/compute_msd.cpp
@@ -14,6 +14,7 @@
 #include "compute_msd.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "update.h"
 #include "group.h"
@@ -21,6 +22,7 @@
 #include "modify.h"
 #include "fix_store.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -63,21 +65,13 @@ ComputeMSD::ComputeMSD(LAMMPS *lmp, int narg, char **arg) :
   // create a new fix STORE style for reference positions
   // id = compute-ID + COMPUTE_STORE, fix group = compute group
 
-  int n = strlen(id) + strlen("_COMPUTE_STORE") + 1;
-  id_fix = new char[n];
-  strcpy(id_fix,id);
-  strcat(id_fix,"_COMPUTE_STORE");
+  std::string fixcmd = id + std::string("_COMPUTE_STORE");
+  id_fix = new char[fixcmd.size()+1];
+  strcpy(id_fix,fixcmd.c_str());
 
-  char **newarg = new char*[6];
-  newarg[0] = id_fix;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "STORE";
-  newarg[3] = (char *) "peratom";
-  newarg[4] = (char *) "1";
-  newarg[5] = (char *) "3";
-  modify->add_fix(6,newarg);
+  fixcmd += fmt::format(" {} STORE peratom 1 3",group->names[igroup]);
+  modify->add_fix(fixcmd);
   fix = (FixStore *) modify->fix[modify->nfix-1];
-  delete [] newarg;
 
   // calculate xu,yu,zu for fix store array
   // skip if reset from restart file

--- a/src/compute_msd_chunk.cpp
+++ b/src/compute_msd_chunk.cpp
@@ -14,6 +14,7 @@
 #include "compute_msd_chunk.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "group.h"
 #include "update.h"
@@ -23,6 +24,7 @@
 #include "fix_store.h"
 #include "memory.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -56,21 +58,13 @@ ComputeMSDChunk::ComputeMSDChunk(LAMMPS *lmp, int narg, char **arg) :
   //   potentially re-populate the fix array (and change it to correct size)
   // otherwise size reset and init will be done in setup()
 
-  n = strlen(id) + strlen("_COMPUTE_STORE") + 1;
-  id_fix = new char[n];
-  strcpy(id_fix,id);
-  strcat(id_fix,"_COMPUTE_STORE");
+  std::string fixcmd = id + std::string("_COMPUTE_STORE");
+  id_fix = new char[fixcmd.size()+1];
+  strcpy(id_fix,fixcmd.c_str());
 
-  char **newarg = new char*[6];
-  newarg[0] = id_fix;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "STORE";
-  newarg[3] = (char *) "global";
-  newarg[4] = (char *) "1";
-  newarg[5] = (char *) "1";
-  modify->add_fix(6,newarg);
+  fixcmd += fmt::format(" {} STORE global 1 1",group->names[igroup]);
+  modify->add_fix(fixcmd);
   fix = (FixStore *) modify->fix[modify->nfix-1];
-  delete [] newarg;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_vacf.cpp
+++ b/src/compute_vacf.cpp
@@ -14,12 +14,14 @@
 #include "compute_vacf.h"
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "update.h"
 #include "group.h"
 #include "modify.h"
 #include "fix_store.h"
 #include "error.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -39,21 +41,12 @@ ComputeVACF::ComputeVACF(LAMMPS *lmp, int narg, char **arg) :
   // create a new fix STORE style
   // id = compute-ID + COMPUTE_STORE, fix group = compute group
 
-  int n = strlen(id) + strlen("_COMPUTE_STORE") + 1;
-  id_fix = new char[n];
-  strcpy(id_fix,id);
-  strcat(id_fix,"_COMPUTE_STORE");
-
-  char **newarg = new char*[6];
-  newarg[0] = id_fix;
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "STORE";
-  newarg[3] = (char *) "peratom";
-  newarg[4] = (char *) "1";
-  newarg[5] = (char *) "3";
-  modify->add_fix(6,newarg);
+  std::string fixcmd = id + std::string("_COMPUTE_STORE");
+  id_fix = new char[fixcmd.size()+1];
+  strcpy(id_fix,fixcmd.c_str());
+  fixcmd += fmt::format(" {} STORE peratom 1 3", group->names[igroup]);
+  modify->add_fix(fixcmd);
   fix = (FixStore *) modify->fix[modify->nfix-1];
-  delete [] newarg;
 
   // store current velocities in fix store array
   // skip if reset from restart file

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -14,6 +14,7 @@
 #include "dump_custom.h"
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include "atom.h"
 #include "force.h"
 #include "domain.h"
@@ -28,6 +29,7 @@
 #include "error.h"
 #include "update.h"
 #include "variable.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 
@@ -1981,22 +1983,12 @@ int DumpCustom::modify_param(int narg, char **arg)
                          "dump:thresh_fixID");
       memory->grow(thresh_first,(nthreshlast+1),"dump:thresh_first");
 
-      int n = strlen(id) + strlen("_DUMP_STORE") + 8;
-      thresh_fixID[nthreshlast] = new char[n];
-      strcpy(thresh_fixID[nthreshlast],id);
-      sprintf(&thresh_fixID[nthreshlast][strlen(id)],"%d",nthreshlast);
-      strcat(thresh_fixID[nthreshlast],"_DUMP_STORE");
-
-      char **newarg = new char*[6];
-      newarg[0] = thresh_fixID[nthreshlast];
-      newarg[1] = group->names[igroup];
-      newarg[2] = (char *) "STORE";
-      newarg[3] = (char *) "peratom";
-      newarg[4] = (char *) "1";
-      newarg[5] = (char *) "1";
-      modify->add_fix(6,newarg);
+      std::string threshid = fmt::format("{}{}_DUMP_STORE",id,nthreshlast);
+      thresh_fixID[nthreshlast] = new char[threshid.size()+1];
+      strcpy(thresh_fixID[nthreshlast],threshid.c_str());
+      modify->add_fix(fmt::format("{} {} STORE peratom 1 1",threshid,
+                                  group->names[igroup]));
       thresh_fix[nthreshlast] = (FixStore *) modify->fix[modify->nfix-1];
-      delete [] newarg;
 
       thresh_last[nthreshlast] = nthreshlast;
       thresh_first[nthreshlast] = 1;

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -31,6 +31,7 @@
 #include "memory.h"
 #include "error.h"
 #include "utils.h"
+#include "fmt/format.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -265,20 +266,12 @@ void FixAdapt::post_constructor()
   id_fix_diam = NULL;
   id_fix_chg = NULL;
 
-  char **newarg = new char*[6];
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "STORE";
-  newarg[3] = (char *) "peratom";
-  newarg[4] = (char *) "1";
-  newarg[5] = (char *) "1";
-
   if (diamflag && atom->radius_flag) {
-    int n = strlen(id) + strlen("_FIX_STORE_DIAM") + 1;
-    id_fix_diam = new char[n];
-    strcpy(id_fix_diam,id);
-    strcat(id_fix_diam,"_FIX_STORE_DIAM");
-    newarg[0] = id_fix_diam;
-    modify->add_fix(6,newarg);
+    std::string fixcmd = id + std::string("_FIX_STORE_DIAM");
+    id_fix_diam = new char[fixcmd.size()+1];
+    strcpy(id_fix_diam,fixcmd.c_str());
+    fixcmd += fmt::format(" {} STORE peratom 1 1",group->names[igroup]);
+    modify->add_fix(fixcmd);
     fix_diam = (FixStore *) modify->fix[modify->nfix-1];
 
     if (fix_diam->restart_reset) fix_diam->restart_reset = 0;
@@ -296,12 +289,11 @@ void FixAdapt::post_constructor()
   }
 
   if (chgflag && atom->q_flag) {
-    int n = strlen(id) + strlen("_FIX_STORE_CHG") + 1;
-    id_fix_chg = new char[n];
-    strcpy(id_fix_chg,id);
-    strcat(id_fix_chg,"_FIX_STORE_CHG");
-    newarg[0] = id_fix_chg;
-    modify->add_fix(6,newarg);
+    std::string fixcmd = id + std::string("_FIX_STORE_CHG");
+    id_fix_chg = new char[fixcmd.size()+1];
+    strcpy(id_fix_chg,fixcmd.c_str());
+    fixcmd += fmt::format(" {} STORE peratom 1 1",group->names[igroup]);
+    modify->add_fix(fixcmd);
     fix_chg = (FixStore *) modify->fix[modify->nfix-1];
 
     if (fix_chg->restart_reset) fix_chg->restart_reset = 0;
@@ -317,8 +309,6 @@ void FixAdapt::post_constructor()
       }
     }
   }
-
-  delete [] newarg;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix_nph_sphere.cpp
+++ b/src/fix_nph_sphere.cpp
@@ -39,8 +39,7 @@ FixNPHSphere::FixNPHSphere(LAMMPS *lmp, int narg, char **arg) :
   id_temp = new char[tcmd.size()+1];
   strcpy(id_temp,tcmd.c_str());
 
-  tcmd += " all temp/sphere";
-  modify->add_compute(tcmd);
+  modify->add_compute(tcmd + " all temp/sphere");
   tcomputeflag = 1;
 
   // create a new compute pressure style
@@ -51,7 +50,6 @@ FixNPHSphere::FixNPHSphere(LAMMPS *lmp, int narg, char **arg) :
   id_press = new char[pcmd.size()+1];
   strcpy(id_press,pcmd.c_str());
 
-  pcmd += " all pressure " + std::string(id_temp);
-  modify->add_compute(pcmd);
+  modify->add_compute(pcmd + " all pressure " + std::string(id_temp));
   pcomputeflag = 1;
 }

--- a/src/fix_npt_sphere.cpp
+++ b/src/fix_npt_sphere.cpp
@@ -39,8 +39,7 @@ FixNPTSphere::FixNPTSphere(LAMMPS *lmp, int narg, char **arg) :
   id_temp = new char[tcmd.size()+1];
   strcpy(id_temp,tcmd.c_str());
 
-  tcmd += " all temp/sphere";
-  modify->add_compute(tcmd);
+  modify->add_compute(tcmd + " all temp/sphere");
   tcomputeflag = 1;
 
   // create a new compute pressure style
@@ -51,7 +50,6 @@ FixNPTSphere::FixNPTSphere(LAMMPS *lmp, int narg, char **arg) :
   id_press = new char[pcmd.size()+1];
   strcpy(id_press,pcmd.c_str());
 
-  pcmd += " all pressure " + std::string(id_temp);
-  modify->add_compute(pcmd);
+  modify->add_compute(pcmd + " all pressure " + std::string(id_temp));
   pcomputeflag = 1;
 }

--- a/src/fix_nvt_sphere.cpp
+++ b/src/fix_nvt_sphere.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_nvt_sphere.h"
 #include <cstring>
+#include <string>
 #include "group.h"
 #include "modify.h"
 #include "error.h"

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -1033,7 +1033,7 @@ FILE *Force::open_potential(const char *name, int *auto_convert)
         return nullptr;
       }
     } else {
-      if (units == unit_style) {
+      if (units.empty() || units == unit_style) {
         *auto_convert = utils::NOCONVERT;
       } else {
         if ((units == "metal") && (unit_style == "real")

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -124,11 +124,8 @@ void Group::assign(int narg, char **arg)
     int bits = inversemask[igroup];
     for (i = 0; i < nlocal; i++) mask[i] &= bits;
 
-    if (dynamic[igroup]) {
-      std::string fixID = "GROUP_";
-      fixID += names[igroup];
-      modify->delete_fix(fixID.c_str());
-    }
+    if (dynamic[igroup])
+      modify->delete_fix(std::string("GROUP_") + names[igroup]);
 
     delete [] names[igroup];
     names[igroup] = NULL;
@@ -491,24 +488,15 @@ void Group::assign(int narg, char **arg)
 
     // if group is already dynamic, delete existing FixGroup
 
-    if (dynamic[igroup]) {
-      std::string fixID = "GROUP_";
-      fixID += names[igroup];
-      modify->delete_fix(fixID.c_str());
-    }
+    if (dynamic[igroup])
+      modify->delete_fix(std::string("GROUP_") + names[igroup]);
 
     dynamic[igroup] = 1;
 
-    std::string fixID = "GROUP_";
-    fixID += names[igroup];
-
-    char **newarg = new char*[narg];
-    newarg[0] = (char *)fixID.c_str();
-    newarg[1] = arg[2];
-    newarg[2] = (char *) "GROUP";
-    for (int i = 3; i < narg; i++) newarg[i] = arg[i];
-    modify->add_fix(narg,newarg);
-    delete [] newarg;
+    std::string fixcmd = "GROUP_";
+    fixcmd += fmt::format("{} {} GROUP",names[igroup],arg[2]);
+    for (int i = 3; i < narg; i++) fixcmd += std::string(" ") + arg[i];
+    modify->add_fix(fixcmd);
 
   // style = static
   // remove dynamic FixGroup if necessary
@@ -517,11 +505,8 @@ void Group::assign(int narg, char **arg)
 
     if (narg != 2) error->all(FLERR,"Illegal group command");
 
-    if (dynamic[igroup]) {
-      std::string fixID = "GROUP_";
-      fixID += names[igroup];
-      modify->delete_fix(fixID.c_str());
-    }
+    if (dynamic[igroup])
+      modify->delete_fix(std::string("GROUP_") + names[igroup]);
 
     dynamic[igroup] = 0;
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -548,6 +548,22 @@ void Group::assign(int narg, char **arg)
 }
 
 /* ----------------------------------------------------------------------
+   convenience function to allow assigning to groups from a single string
+------------------------------------------------------------------------- */
+
+void Group::assign(const std::string &fixcmd)
+{
+  std::vector<std::string> args = utils::split_words(fixcmd);
+  char **newarg = new char*[args.size()];
+  int i=0;
+  for (const auto &arg : args) {
+    newarg[i++] = (char *)arg.c_str();
+  }
+  assign(args.size(),newarg);
+  delete[] newarg;
+}
+
+/* ----------------------------------------------------------------------
    add flagged atoms to a new or existing group
 ------------------------------------------------------------------------- */
 

--- a/src/group.h
+++ b/src/group.h
@@ -16,6 +16,7 @@
 
 #include "pointers.h"
 #include <map>
+#include <string>
 
 namespace LAMMPS_NS {
 

--- a/src/group.h
+++ b/src/group.h
@@ -30,6 +30,7 @@ class Group : protected Pointers {
   Group(class LAMMPS *);
   ~Group();
   void assign(int, char **);         // assign atoms to a group
+  void assign(const std::string &);  // convenience function
   void create(char *, int *);        // add flagged atoms to a group
   int find(const char *);            // lookup name in list of groups
   int find_or_create(const char *);  // lookup name or create new group

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -113,18 +113,13 @@ Min::~Min()
 void Min::init()
 {
   if (lmp->kokkos && !kokkosable)
-    error->all(FLERR,"Must use a Kokkos-enabled min style (e.g. min_style cg/kk) "
-     "with Kokkos minimize");
+    error->all(FLERR,"Must use a Kokkos-enabled min style "
+               "(e.g. min_style cg/kk) with Kokkos minimize");
 
   // create fix needed for storing atom-based quantities
   // will delete it at end of run
 
-  char **fixarg = new char*[3];
-  fixarg[0] = (char *) "MINIMIZE";
-  fixarg[1] = (char *) "all";
-  fixarg[2] = (char *) "MINIMIZE";
-  modify->add_fix(3,fixarg);
-  delete [] fixarg;
+  modify->add_fix("MINIMIZE all MINIMIZE");
   fix_minimize = (FixMinimize *) modify->fix[modify->nfix-1];
 
   // clear out extra global and per-atom dof

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -1031,7 +1031,7 @@ void Modify::modify_fix(int narg, char **arg)
    Atom class must update indices in its list of callbacks to fixes
 ------------------------------------------------------------------------- */
 
-void Modify::delete_fix(const char *id)
+void Modify::delete_fix(const std::string &id)
 {
   int ifix = find_fix(id);
   if (ifix < 0) error->all(FLERR,"Could not find fix ID to delete");
@@ -1055,14 +1055,12 @@ void Modify::delete_fix(int ifix)
    return index of fix or -1 if not found
 ------------------------------------------------------------------------- */
 
-int Modify::find_fix(const char *id)
+int Modify::find_fix(const std::string &id)
 {
-  if (id == NULL) return -1;
-  int ifix;
-  for (ifix = 0; ifix < nfix; ifix++)
-    if (strcmp(id,fix[ifix]->id) == 0) break;
-  if (ifix == nfix) return -1;
-  return ifix;
+  if (id.empty()) return -1;
+  for (int ifix = 0; ifix < nfix; ifix++)
+    if (id == fix[ifix]->id) return ifix;
+  return -1;
 }
 
 /* ----------------------------------------------------------------------
@@ -1295,7 +1293,7 @@ void Modify::modify_compute(int narg, char **arg)
    delete a Compute from list of Computes
 ------------------------------------------------------------------------- */
 
-void Modify::delete_compute(const char *id)
+void Modify::delete_compute(const std::string &id)
 {
   int icompute = find_compute(id);
   if (icompute < 0) error->all(FLERR,"Could not find compute ID to delete");
@@ -1312,14 +1310,12 @@ void Modify::delete_compute(const char *id)
    return index of compute or -1 if not found
 ------------------------------------------------------------------------- */
 
-int Modify::find_compute(const char *id)
+int Modify::find_compute(const std::string &id)
 {
-  if(id==NULL) return -1;
-  int icompute;
-  for (icompute = 0; icompute < ncompute; icompute++)
-    if (strcmp(id,compute[icompute]->id) == 0) break;
-  if (icompute == ncompute) return -1;
-  return icompute;
+  if(id.empty()) return -1;
+  for (int icompute = 0; icompute < ncompute; icompute++)
+    if (id == compute[icompute]->id) return icompute;
+  return -1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/modify.h
+++ b/src/modify.h
@@ -99,9 +99,9 @@ class Modify : protected Pointers {
   void add_fix(const std::string &, int trysuffix=1);
   void replace_fix(const char *, int, char **, int trysuffix=1);
   void modify_fix(int, char **);
-  void delete_fix(const char *);
+  void delete_fix(const std::string &);
   void delete_fix(int);
-  int find_fix(const char *);
+  int find_fix(const std::string &);
   int find_fix_by_style(const char *);
   int check_package(const char *);
   int check_rigid_group_overlap(int);
@@ -111,8 +111,8 @@ class Modify : protected Pointers {
   void add_compute(int, char **, int trysuffix=1);
   void add_compute(const std::string &, int trysuffix=1);
   void modify_compute(int, char **);
-  void delete_compute(const char *);
-  int find_compute(const char *);
+  void delete_compute(const std::string &);
+  int find_compute(const std::string &);
 
   void clearstep_compute();
   void addstep_compute(bigint);

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -423,19 +423,9 @@ void ReadRestart::command(int narg, char **arg)
     // create a temporary fix to hold and migrate extra atom info
     // necessary b/c irregular will migrate atoms
 
-    if (nextra) {
-      char cextra[8],fixextra[8];
-      sprintf(cextra,"%d",nextra);
-      sprintf(fixextra,"%d",modify->nfix_restart_peratom);
-      char **newarg = new char*[5];
-      newarg[0] = (char *) "_read_restart";
-      newarg[1] = (char *) "all";
-      newarg[2] = (char *) "READ_RESTART";
-      newarg[3] = cextra;
-      newarg[4] = fixextra;
-      modify->add_fix(5,newarg);
-      delete [] newarg;
-    }
+    if (nextra)
+      modify->add_fix(fmt::format("_read_restart all READ_RESTART {} {}",
+                                  nextra,modify->nfix_restart_peratom));
 
     // move atoms to new processors via irregular()
     // turn sorting on in migrate_atoms() to avoid non-reproducible restarts

--- a/src/respa.cpp
+++ b/src/respa.cpp
@@ -299,22 +299,11 @@ void Respa::init()
 
   // create fix needed for storing atom-based respa level forces
   // will delete it at end of run
-
-  char **fixarg = new char*[5];
-  fixarg[0] = (char *) "RESPA";
-  fixarg[1] = (char *) "all";
-  fixarg[2] = (char *) "RESPA";
-  fixarg[3] = new char[8];
-  sprintf(fixarg[3],"%d",nlevels);
   // if supported, we also store torques on a per-level basis
-  if (atom->torque_flag) {
-    fixarg[4] = (char *) "torque";
-    modify->add_fix(5,fixarg);
-  } else {
-    modify->add_fix(4,fixarg);
-  }
-  delete [] fixarg[3];
-  delete [] fixarg;
+
+  std::string cmd = fmt::format("RESPA all RESPA {}",nlevels);
+  if (atom->torque_flag) modify->add_fix(cmd + " torque");
+  else modify->add_fix(cmd);
   fix_respa = (FixRespa *) modify->fix[modify->nfix-1];
 
   // insure respa inner/middle/outer is using Pair class that supports it

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -483,7 +483,7 @@ void Thermo::modify_params(int narg, char **arg)
         icompute = modify->find_compute(id_compute[index_press_vector]);
         if (icompute < 0) error->all(FLERR,
                                      "Pressure ID for thermo does not exist");
-      } else icompute = modify->find_compute((char *) "thermo_press");
+      } else icompute = modify->find_compute("thermo_press");
 
       modify->compute[icompute]->reset_extra_compute_fix(arg[iarg+1]);
 


### PR DESCRIPTION
**Summary**

This extends PR #2191 with a few more applications and also changing the signatures for `delete/find_compute/fix` to use a `const std::string &`, which avoids some use of typecasts and `std::string.c_str()` and also simplifies the logic of the find routines.
It includes commits 7f05c578f5985539b195c918888ab96862ab166c and 5be366bfaec6be55df7e6be56e2869ea666e3723 from PR #2195 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
