### PR TITLE
Various small fixes and cleanups. Bugfixes for atom style hybrid

### DIFF
--- a/doc/src/compute_orientorder_atom.rst
+++ b/doc/src/compute_orientorder_atom.rst
@@ -61,8 +61,8 @@ The summation is over the *nnn* nearest
 neighbors of the central atom.
 The angles :math:`theta` and :math:`phi` are the standard spherical polar angles
 defining the direction of the bond vector :math:`r_{ij}`.
-The phase and sign of :math:`Y_{lm}` follow the standard conventions, 
-so that :math:`{\rm sign}(Y_{ll}(0,0)) = (-1)^l`.   
+The phase and sign of :math:`Y_{lm}` follow the standard conventions,
+so that :math:`{\rm sign}(Y_{ll}(0,0)) = (-1)^l`.
 The second equation defines :math:`Q_l`, which is a
 rotationally invariant non-negative amplitude obtained by summing
 over all the components of degree *l*\ .
@@ -181,13 +181,13 @@ values for each atom will be added to the output array, which are real numbers.
 
 If the keyword *components* is set, then the real and imaginary parts
 of each component of *normalized* :math:`\hat{Y}_{lm}` will be added to the
-output array in the following order: :math:`{\rm Re}(\hat{Y}_{-m}), {\rm Im}(\hat{Y}_{-m}), 
-{\rm Re}(\hat{Y}_{-m+1}), {\rm Im}(\hat{Y}_{-m+1}), \dots , {\rm Re}(\hat{Y}_m), {\rm Im}(\hat{Y}_m)`.  
+output array in the following order: :math:`{\rm Re}(\hat{Y}_{-m}), {\rm Im}(\hat{Y}_{-m}),
+{\rm Re}(\hat{Y}_{-m+1}), {\rm Im}(\hat{Y}_{-m+1}), \dots , {\rm Re}(\hat{Y}_m), {\rm Im}(\hat{Y}_m)`.
 
 In summary, the per-atom array will contain *nlvalues* columns, followed by
 an additional *nlvalues* columns if *wl* is set to yes, followed by
 an additional *nlvalues* columns if *wl/hat* is set to yes, followed
-by an additional 2\*(2\* *ldegree*\ +1) columns if the *components* 
+by an additional 2\*(2\* *ldegree*\ +1) columns if the *components*
 keyword is set.
 
 These values can be accessed by any command that uses per-atom values

--- a/doc/src/pair_mliap.rst
+++ b/doc/src/pair_mliap.rst
@@ -16,19 +16,19 @@ Examples
 .. code-block:: LAMMPS
 
    pair_style mliap model linear InP.mliap.model descriptor sna InP.mliap.descriptor
-   pair_style mliap model quadratic W.mliap.model descriptor sna W.mliap.descriptor 
+   pair_style mliap model quadratic W.mliap.model descriptor sna W.mliap.descriptor
    pair_coeff * * In P
 
 Description
 """""""""""
 
-Pair style *mliap* provides a general interface to families of 
-machine-learning interatomic potentials. It provides separate 
+Pair style *mliap* provides a general interface to families of
+machine-learning interatomic potentials. It provides separate
 definitions of the interatomic potential functional form (*model*)
 and the geometric quantities that characterize the atomic positions
-(*descriptor*). By defining *model* and *descriptor* separately, 
+(*descriptor*). By defining *model* and *descriptor* separately,
 it is possible to use many different models with a given descriptor,
-or many different descriptors with a given model. Currently, the pair_style 
+or many different descriptors with a given model. Currently, the pair_style
 supports just two models, *linear* and *quadratic*,
 and one descriptor, *sna*, the SNAP descriptor used by :doc:`pair_style snap <pair_snap>`, including the linear, quadratic,
 and chem variants. Work is currently underway to extend
@@ -37,23 +37,23 @@ and it is also straightforward to add new descriptor styles.
 
 The pair_style *mliap* command must be followed by two keywords
 *model* and *descriptor* in either order. A single
-*pair_coeff* command is also required. The first 2 arguments 
+*pair_coeff* command is also required. The first 2 arguments
 must be \* \* so as to span all LAMMPS atom types.
 This is followed by a list of N arguments
 that specify the mapping of MLIAP
-element names to LAMMPS atom types, 
+element names to LAMMPS atom types,
 where N is the number of LAMMPS atom types.
 
 The *model* keyword is followed by a model style, currently limited to
 either *linear* or *quadratic*. In both cases,
-this is followed by a single argument specifying the model filename containing the 
-linear or quadratic coefficients for a set of elements. 
+this is followed by a single argument specifying the model filename containing the
+linear or quadratic coefficients for a set of elements.
 The model filename usually ends in the *.mliap.model* extension.
 It may contain coefficients for many elements. The only requirement is that it
 contain at least those element names appearing in the
 *pair_coeff* command.
 
-The top of the model file can contain any number of blank and comment lines (start with #), 
+The top of the model file can contain any number of blank and comment lines (start with #),
 but follows a strict format after that. The first non-blank non-comment
 line must contain two integers:
 
@@ -64,20 +64,20 @@ This is followed by one block for each of the *nelem* elements.
 Each block consists of *ncoeff* coefficients, one per line.
 Note that this format is similar, but not identical to that used
 for the :doc:`pair_style snap <pair_snap>` coefficient file.
-Specifically, the line containing the element weight and radius is omitted, 
+Specifically, the line containing the element weight and radius is omitted,
 since these are handled by the *descriptor*.
 
 The *descriptor* keyword is followed by a descriptor style, and additional arguments.
-Currently the only descriptor style is *sna*, indicating the bispectrum component 
-descriptors used by the Spectral Neighbor Analysis Potential (SNAP) potentials of 
+Currently the only descriptor style is *sna*, indicating the bispectrum component
+descriptors used by the Spectral Neighbor Analysis Potential (SNAP) potentials of
 :doc:`pair_style snap <pair_snap>`.
-The \'p\' in SNAP is dropped, because keywords that match pair_styles are silently stripped 
-out by the LAMMPS command parser. A single additional argument specifies the descriptor filename 
-containing the parameters and setting used by the SNAP descriptor. 
+The \'p\' in SNAP is dropped, because keywords that match pair_styles are silently stripped
+out by the LAMMPS command parser. A single additional argument specifies the descriptor filename
+containing the parameters and setting used by the SNAP descriptor.
 The descriptor filename usually ends in the *.mliap.descriptor* extension.
 
-The SNAP descriptor file closely follows the format of the 
-:doc:`pair_style snap <pair_snap>` parameter file. 
+The SNAP descriptor file closely follows the format of the
+:doc:`pair_style snap <pair_snap>` parameter file.
 The file can contain blank and comment lines (start
 with #) anywhere. Each non-blank non-comment line must contain one
 keyword/value pair. The required keywords are *rcutfac* and
@@ -87,7 +87,7 @@ In addition, the SNAP descriptor file must contain
 the *nelems*, *elems*, *radelems*, and *welems* keywords.
 The *nelems* keyword specifies the number of elements
 provided in the other three keywords.
-The *elems* keyword is followed by a list of *nelems* 
+The *elems* keyword is followed by a list of *nelems*
 element names that must include the element
 names appearing in the *pair_coeff* command,
 but can contain other names too.

--- a/doc/src/pair_snap.rst
+++ b/doc/src/pair_snap.rst
@@ -25,9 +25,9 @@ Description
 """""""""""
 
 Pair style *snap* defines the spectral
-neighbor analysis potential (SNAP), a machine-learning 
+neighbor analysis potential (SNAP), a machine-learning
 interatomic potential :ref:`(Thompson) <Thompson20142>`.
-Like the GAP framework of Bartok et al. :ref:`(Bartok2010) <Bartok20102>`, 
+Like the GAP framework of Bartok et al. :ref:`(Bartok2010) <Bartok20102>`,
 SNAP uses bispectrum components
 to characterize the local neighborhood of each atom
 in a very general way. The mathematical definition of the
@@ -139,7 +139,7 @@ The SNAP parameter file can contain blank and comment lines (start
 with #) anywhere. Each non-blank non-comment line must contain one
 keyword/value pair. The required keywords are *rcutfac* and
 *twojmax*\ . Optional keywords are *rfac0*\ , *rmin0*\ ,
-*switchflag*\ , *bzeroflag*\ , *quadraticflag*\ , *chemflag*\ , 
+*switchflag*\ , *bzeroflag*\ , *quadraticflag*\ , *chemflag*\ ,
 *bnormflag*\ , *wselfallflag*\ , and *chunksize*\ .
 
 The default values for these keywords are
@@ -154,34 +154,34 @@ The default values for these keywords are
 * *wselfallflag* = 0
 * *chunksize* = 2000
 
-If *quadraticflag* is set to 1, then the SNAP energy expression includes additional quadratic terms 
+If *quadraticflag* is set to 1, then the SNAP energy expression includes additional quadratic terms
 that have been shown to increase the overall accuracy of the potential without much increase
-in computational cost :ref:`(Wood) <Wood20182>`. 
+in computational cost :ref:`(Wood) <Wood20182>`.
 
 .. math::
 
    E^i_{SNAP}(\mathbf{B}^i) = \beta^{\mu_i}_0 + \boldsymbol{\beta}^{\mu_i} \cdot \mathbf{B}_i + \frac{1}{2}\mathbf{B}^t_i \cdot \boldsymbol{\alpha}^{\mu_i} \cdot \mathbf{B}_i
 
-where :math:`\mathbf{B}_i` is the *K*-vector of bispectrum components, 
-:math:`\boldsymbol{\beta}^{\mu_i}` is the *K*-vector of linear coefficients 
-for element :math:`\mu_i`, and :math:`\boldsymbol{\alpha}^{\mu_i}` 
+where :math:`\mathbf{B}_i` is the *K*-vector of bispectrum components,
+:math:`\boldsymbol{\beta}^{\mu_i}` is the *K*-vector of linear coefficients
+for element :math:`\mu_i`, and :math:`\boldsymbol{\alpha}^{\mu_i}`
 is the symmetric *K* by *K* matrix of quadratic coefficients.
 The SNAP element file should contain *K*\ (\ *K*\ +1)/2 additional coefficients
 for each element, the upper-triangular elements of :math:`\boldsymbol{\alpha}^{\mu_i}`.
 
 If *chemflag* is set to 1, then the energy expression is written in terms of explicit multi-element bispectrum
 components indexed on ordered triplets of elements, which has been shown to increase the ability of the SNAP
-potential to capture energy differences in chemically complex systems, 
+potential to capture energy differences in chemically complex systems,
 at the expense of a significant increase in computational cost :ref:`(Cusentino) <Cusentino20202>`.
 
 .. math::
 
-   E^i_{SNAP}(\mathbf{B}^i) = \beta^{\mu_i}_0 + \sum_{\kappa,\lambda,\mu} \boldsymbol{\beta}^{\kappa\lambda\mu}_{\mu_i} \cdot \mathbf{B}^{\kappa\lambda\mu}_i 
+   E^i_{SNAP}(\mathbf{B}^i) = \beta^{\mu_i}_0 + \sum_{\kappa,\lambda,\mu} \boldsymbol{\beta}^{\kappa\lambda\mu}_{\mu_i} \cdot \mathbf{B}^{\kappa\lambda\mu}_i
 
-where :math:`\mathbf{B}^{\kappa\lambda\mu}_i` is the *K*-vector of bispectrum components 
-for neighbors of elements :math:`\kappa`, :math:`\lambda`, and :math:`\mu` and 
-:math:`\boldsymbol{\beta}^{\kappa\lambda\mu}_{\mu_i}` is the corresponding *K*-vector 
-of linear coefficients for element :math:`\mu_i`. The SNAP element file should contain 
+where :math:`\mathbf{B}^{\kappa\lambda\mu}_i` is the *K*-vector of bispectrum components
+for neighbors of elements :math:`\kappa`, :math:`\lambda`, and :math:`\mu` and
+:math:`\boldsymbol{\beta}^{\kappa\lambda\mu}_{\mu_i}` is the corresponding *K*-vector
+of linear coefficients for element :math:`\mu_i`. The SNAP element file should contain
 a total of :math:`K N_{elem}^3` coefficients for each of the :math:`N_{elem}` elements.
 
 The keyword *chunksize* is only applicable when using the

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -236,7 +236,7 @@ void PairBodyRoundedPolygon::compute(int eflag, int vflag)
         edge[jefirst+nj][4] = 0;
       }
 
-      int interact, num_contacts, done;
+      int num_contacts, done;
       double delta_a, j_a;
       Contact contact_list[MAX_CONTACTS];
 
@@ -244,15 +244,13 @@ void PairBodyRoundedPolygon::compute(int eflag, int vflag)
 
       // check interaction between i's vertices and j' edges
 
-      interact = vertex_against_edge(i, j, k_nij, k_naij,
-                                     x, f, torque, tag, contact_list,
-                                     num_contacts, evdwl, facc);
+      vertex_against_edge(i, j, k_nij, k_naij, x, f, torque, tag,
+                          contact_list, num_contacts, evdwl, facc);
 
       // check interaction between j's vertices and i' edges
 
-      interact = vertex_against_edge(j, i, k_nij, k_naij,
-                                     x, f, torque, tag, contact_list,
-                                     num_contacts, evdwl, facc);
+      vertex_against_edge(j, i, k_nij, k_naij, x, f, torque, tag,
+                          contact_list, num_contacts, evdwl, facc);
 
       if (num_contacts >= 2) {
 

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -588,19 +588,17 @@ void PairBodyRoundedPolygon::body2space(int i)
 
 void PairBodyRoundedPolygon::sphere_against_sphere(int i, int j,
                        double delx, double dely, double delz, double rsq,
-                       double k_n, double k_na, double** /*x*/, double** v,
+                       double k_n, double k_na, double** /*x*/, double** /*v*/,
                        double** f, int evflag)
 {
   double rradi,rradj;
-  double vr1,vr2,vr3,vnnr,vn1,vn2,vn3;
-  double rij,rsqinv,R,fx,fy,fz,fpair,shift,energy;
+  double rij,R,fx,fy,fz,fpair,shift,energy;
   int nlocal = atom->nlocal;
   int newton_pair = force->newton_pair;
 
   rradi = rounded_radius[i];
   rradj = rounded_radius[j];
 
-  rsqinv = 1.0/rsq;
   rij = sqrt(rsq);
   R = rij - (rradi + rradj);
   shift = k_na * cut_inner;

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -592,7 +592,7 @@ void PairBodyRoundedPolygon::sphere_against_sphere(int i, int j,
                        double** f, int evflag)
 {
   double rradi,rradj;
-  double vr1,vr2,vr3,vnnr,vn1,vn2,vn3,vt1,vt2,vt3;
+  double vr1,vr2,vr3,vnnr,vn1,vn2,vn3;
   double rij,rsqinv,R,fx,fy,fz,fpair,shift,energy;
   int nlocal = atom->nlocal;
   int newton_pair = force->newton_pair;
@@ -633,12 +633,6 @@ void PairBodyRoundedPolygon::sphere_against_sphere(int i, int j,
     vn1 = delx*vnnr * rsqinv;
     vn2 = dely*vnnr * rsqinv;
     vn3 = delz*vnnr * rsqinv;
-
-    // tangential component
-
-    vt1 = vr1 - vn1;
-    vt2 = vr2 - vn2;
-    vt3 = vr3 - vn3;
   }
 
   f[i][0] += fx;
@@ -1347,4 +1341,3 @@ void PairBodyRoundedPolygon::distance(const double* x2, const double* x1,
     + (x2[1] - x1[1]) * (x2[1] - x1[1])
     + (x2[2] - x1[2]) * (x2[2] - x1[2]));
 }
-

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -619,22 +619,6 @@ void PairBodyRoundedPolygon::sphere_against_sphere(int i, int j,
   fy = dely*fpair/rij;
   fz = delz*fpair/rij;
 
-  if (R <= EPSILON) { // in contact
-
-    // relative translational velocity
-
-    vr1 = v[i][0] - v[j][0];
-    vr2 = v[i][1] - v[j][1];
-    vr3 = v[i][2] - v[j][2];
-
-    // normal component
-
-    vnnr = vr1*delx + vr2*dely + vr3*delz;
-    vn1 = delx*vnnr * rsqinv;
-    vn2 = dely*vnnr * rsqinv;
-    vn3 = delz*vnnr * rsqinv;
-  }
-
   f[i][0] += fx;
   f[i][1] += fy;
   f[i][2] += fz;

--- a/src/KOKKOS/atom_vec_kokkos.h
+++ b/src/KOKKOS/atom_vec_kokkos.h
@@ -103,14 +103,14 @@ class AtomVecKokkos : public AtomVec {
                          ExecutionSpace space) = 0;
 
   virtual int
-    pack_border_vel_kokkos(int n, DAT::tdual_int_2d k_sendlist,
-                           DAT::tdual_xfloat_2d buf,int iswap,
-                           int pbc_flag, int *pbc, ExecutionSpace space) { return 0; }
+    pack_border_vel_kokkos(int /*n*/, DAT::tdual_int_2d /*k_sendlist*/,
+                           DAT::tdual_xfloat_2d /*buf*/,int /*iswap*/,
+                           int /*pbc_flag*/, int * /*pbc*/, ExecutionSpace /*space*/) { return 0; }
 
   virtual void
-    unpack_border_vel_kokkos(const int &n, const int &nfirst,
-                             const DAT::tdual_xfloat_2d &buf,
-                             ExecutionSpace space) {}
+    unpack_border_vel_kokkos(const int &/*n*/, const int & /*nfirst*/,
+                             const DAT::tdual_xfloat_2d & /*buf*/,
+                             ExecutionSpace /*space*/) {}
 
   virtual int
     pack_exchange_kokkos(const int &nsend, DAT::tdual_xfloat_2d &buf,

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -272,7 +272,7 @@ template<typename T1, typename T2>
 class ScatterViewHelper<Kokkos::Experimental::ScatterDuplicated,T1,T2> {
 public:
   KOKKOS_INLINE_FUNCTION
-  static T1 get(const T1 &dup, const T2 &nondup) {
+  static T1 get(const T1 &dup, const T2 & /*nondup*/) {
     return dup;
   }
 };

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -1025,7 +1025,7 @@ struct params_lj_coul {
   KOKKOS_INLINE_FUNCTION
   params_lj_coul(){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
   KOKKOS_INLINE_FUNCTION
-  params_lj_coul(int i){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
+  params_lj_coul(int /*i*/){cut_ljsq=0;cut_coulsq=0;lj1=0;lj2=0;lj3=0;lj4=0;offset=0;};
   F_FLOAT cut_ljsq,cut_coulsq,lj1,lj2,lj3,lj4,offset;
 };
 

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -632,8 +632,8 @@ void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPComputeNeigh,const typen
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairSNAPKokkos<DeviceType>::operator() (TagPairSNAPBeta,const int& ii) const {
-  
-  if (ii >= chunk_size) return; 
+
+  if (ii >= chunk_size) return;
 
   const int iatom_mod = ii % 32;
   const int iatom_div = ii / 32;

--- a/src/KOKKOS/sna_kokkos.h
+++ b/src/KOKKOS/sna_kokkos.h
@@ -160,17 +160,17 @@ inline
 
   t_sna_3c_ll ulist;
   t_sna_3c_ll ylist;
-  
+
   // derivatives of data
   t_sna_4c3_ll dulist;
-  
+
   // Modified structures for GPU backend
   t_sna_3d_ll ulisttot_re; // split real,
   t_sna_3d_ll ulisttot_im; // imag
   t_sna_4c_ll ulisttot_pack; // AoSoA layout
   t_sna_4c_ll zlist_pack; // AoSoA layout
   t_sna_4d_ll blist_pack;
-  t_sna_4d_ll ylist_pack_re; // split real, 
+  t_sna_4d_ll ylist_pack_re; // split real,
   t_sna_4d_ll ylist_pack_im; // imag AoSoA layout
 
   int idxcg_max, idxu_max, idxz_max, idxb_max;

--- a/src/KOKKOS/sna_kokkos_impl.h
+++ b/src/KOKKOS/sna_kokkos_impl.h
@@ -295,7 +295,7 @@ void SNAKokkos<DeviceType>::pre_ui(const typename Kokkos::TeamPolicy<DeviceType>
 
         // if m is on the "diagonal", initialize it with the self energy.
         // Otherwise zero it out
-        double re_part = 0.; 
+        double re_part = 0.;
         if (m % (j+2) == 0 && (!chem_flag || ielem == jelem || wselfall_flag)) { re_part = wself; }
 
         ulisttot_re(jjup, jelem, iatom) = re_part;
@@ -436,7 +436,7 @@ void SNAKokkos<DeviceType>::compute_ui(const typename Kokkos::TeamPolicy<DeviceT
         } else {
           u_accum.re = -u_accum.re;
         }
-        
+
         buf2[jju_shared_flip] = u_accum;
 
         // split re, im to get fully coalesced atomic add
@@ -607,7 +607,7 @@ void SNAKokkos<DeviceType>::compute_bi(const int& iatom_mod, const int& jjb, con
         blist_pack(iatom_mod, jjb, itriple, iatom_div) = sumzu;
             //} // end loop over j
           //} // end loop over j1, j2
-        itriple++; 
+        itriple++;
       } // end loop over elem3
       idouble++;
     } // end loop over elem2
@@ -788,7 +788,7 @@ void SNAKokkos<DeviceType>::compute_fused_deidrj(const typename Kokkos::TeamPoli
 
   // single has a warp barrier at the end
   Kokkos::single(Kokkos::PerThread(team), [=]() {
-    
+
     ulist_buf1[0] = {1., 0.};
     dulist_buf1[0] = {0., 0.};
   });
@@ -878,7 +878,7 @@ void SNAKokkos<DeviceType>::compute_fused_deidrj(const typename Kokkos::TeamPoli
       // u[ma-j][mb-j] = (-1)^(ma-mb)*Conj([u[ma][mb])
       if (j%2==1 && mb+1==n_mb) {
         int sign_factor = (((ma+mb)%2==0)?1:-1);
-        
+
         const int jju_shared_flip = (j+1-mb)*(j+1)-(ma+1);
 
         if (sign_factor == 1) {
@@ -1138,7 +1138,7 @@ void SNAKokkos<DeviceType>::compute_bi_cpu(const typename Kokkos::TeamPolicy<Dev
                 if (elem1 == elem2 && elem1 == elem3) {
                   sumzu -= bzero[j];
                 }
-              } else { 
+              } else {
                 sumzu -= bzero[j];
               }
             }
@@ -1153,7 +1153,7 @@ void SNAKokkos<DeviceType>::compute_bi_cpu(const typename Kokkos::TeamPolicy<Dev
       idouble++;
     } // end loop over elem2
   } // end loop over elem1
-  
+
 }
 
 /* ----------------------------------------------------------------------
@@ -2036,7 +2036,7 @@ double SNAKokkos<DeviceType>::memory_usage()
 
 #ifdef KOKKOS_ENABLE_CUDA
   if (std::is_same<DeviceType,Kokkos::Cuda>::value) {
-    
+
     bytes += natom * idxu_max * nelements * sizeof(double);          // ulisttot_re
     bytes += natom * idxu_max * nelements * sizeof(double);          // ulisttot_im
     bytes += natom_pad * idxu_max * nelements * sizeof(double) * 2;  // ulisttot_pack

--- a/src/KOKKOS/sna_kokkos_impl.h
+++ b/src/KOKKOS/sna_kokkos_impl.h
@@ -368,7 +368,6 @@ void SNAKokkos<DeviceType>::compute_ui(const typename Kokkos::TeamPolicy<DeviceT
 
   for (int j = 1; j <= twojmax; j++) {
     const int jju = idxu_block[j];
-    const int jjup = idxu_block[j-1];
 
     // fill in left side of matrix layer from previous layer
 
@@ -1080,7 +1079,6 @@ void SNAKokkos<DeviceType>::compute_bi_cpu(const typename Kokkos::TeamPolicy<Dev
         Kokkos::parallel_for(Kokkos::TeamThreadRange(team,idxb_max),
           [&] (const int& jjb) {
         //for(int jjb = 0; jjb < idxb_max; jjb++) {
-          const auto jjballoy = itriple;
           const int j1 = idxb(jjb, 0);
           const int j2 = idxb(jjb, 1);
           const int j = idxb(jjb, 2);
@@ -2024,7 +2022,6 @@ double SNAKokkos<DeviceType>::memory_usage()
 {
   int jdimpq = twojmax + 2;
   int jdim = twojmax + 1;
-  int natom_pad = ((natom + 32 - 1) / 32) * 32; // for AoSoA layouts
   double bytes;
 
   bytes = 0;
@@ -2032,10 +2029,9 @@ double SNAKokkos<DeviceType>::memory_usage()
   bytes += jdimpq*jdimpq * sizeof(double);               // pqarray
   bytes += idxcg_max * sizeof(double);                   // cglist
 
-
-
 #ifdef KOKKOS_ENABLE_CUDA
   if (std::is_same<DeviceType,Kokkos::Cuda>::value) {
+    int natom_pad = ((natom + 32 - 1) / 32) * 32; // for AoSoA layouts
 
     bytes += natom * idxu_max * nelements * sizeof(double);          // ulisttot_re
     bytes += natom * idxu_max * nelements * sizeof(double);          // ulisttot_im

--- a/src/KSPACE/fix_tune_kspace.cpp
+++ b/src/KSPACE/fix_tune_kspace.cpp
@@ -149,7 +149,7 @@ void FixTuneKspace::pre_exchange()
     update_pair_style(new_pair_style,pair_cut_coul);
     update_kspace_style(new_kspace_style,new_acc_str);
   } else if (niter == 4) {
-    store_old_kspace_settings();    
+    store_old_kspace_settings();
     if (comm->me == 0)
       utils::logmesg(lmp,fmt::format("ewald_time = {}\n"
                                      "pppm_time = {}\n"

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -316,7 +316,6 @@ void PPPMDisp::init()
   for (int i=0; i<=EWALD_MAXORDER; ++i)                 // transcribe order
     if (ewald_order&(1<<i)) {                           // from pair_style
       int  k=0;
-      char str[128];
       switch (i) {
         case 1:
           k = 0; break;

--- a/src/MLIAP/mliap_descriptor_snap.cpp
+++ b/src/MLIAP/mliap_descriptor_snap.cpp
@@ -149,15 +149,13 @@ void MLIAPDescriptorSNAP::forward(int* map, NeighList* list, double **descriptor
 void MLIAPDescriptorSNAP::backward(PairMLIAP* pairmliap, NeighList* list, double **beta, int vflag)
 {
   int i,j,jnum,ninside;
-  double delx,dely,delz,evdwl,rsq;
+  double delx,dely,delz,rsq;
   double fij[3];
   int *jlist,*numneigh,**firstneigh;
 
   double **x = atom->x;
   double **f = atom->f;
   int *type = atom->type;
-  int nlocal = atom->nlocal;
-  int newton_pair = force->newton_pair;
 
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;

--- a/src/MLIAP/mliap_descriptor_snap.cpp
+++ b/src/MLIAP/mliap_descriptor_snap.cpp
@@ -36,7 +36,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-MLIAPDescriptorSNAP::MLIAPDescriptorSNAP(LAMMPS *lmp, char *paramfilename): 
+MLIAPDescriptorSNAP::MLIAPDescriptorSNAP(LAMMPS *lmp, char *paramfilename):
   MLIAPDescriptor(lmp)
 {
   nelements = 0;
@@ -242,13 +242,13 @@ void MLIAPDescriptorSNAP::backward(PairMLIAP* pairmliap, NeighList* list, double
 
       // add in gloabl and per-atom virial contributions
       // this is optional and has no effect on force calculation
-      
+
       if (vflag)
         pairmliap->v_tally(i,j,
                      fij[0],fij[1],fij[2],
                      -snaptr->rij[jj][0],-snaptr->rij[jj][1],
                      -snaptr->rij[jj][2]);
-      
+
     }
   }
 
@@ -338,8 +338,8 @@ void MLIAPDescriptorSNAP::read_paramfile(char *paramfilename)
       utils::logmesg(lmp, fmt::format("SNAP keyword {} {} \n", keywd, keyval));
     }
 
-    // check for keywords with one value per element 
-    
+    // check for keywords with one value per element
+
     if (strcmp(keywd,"elems") == 0 ||
         strcmp(keywd,"radelems") == 0 ||
         strcmp(keywd,"welems") == 0) {
@@ -372,9 +372,9 @@ void MLIAPDescriptorSNAP::read_paramfile(char *paramfilename)
 
     } else {
 
-    // all other keywords take one value 
+    // all other keywords take one value
 
-      if (nwords != 2) 
+      if (nwords != 2)
         error->all(FLERR,"Incorrect SNAP parameter file");
 
       if (strcmp(keywd,"nelems") == 0) {
@@ -408,8 +408,8 @@ void MLIAPDescriptorSNAP::read_paramfile(char *paramfilename)
 
     }
   }
-  
-  if (!rcutfacflag || !twojmaxflag || !nelementsflag || 
+
+  if (!rcutfacflag || !twojmaxflag || !nelementsflag ||
       !elementsflag || !radelemflag || !wjelemflag)
     error->all(FLERR,"Incorrect SNAP parameter file");
 

--- a/src/MLIAP/mliap_model.cpp
+++ b/src/MLIAP/mliap_model.cpp
@@ -142,7 +142,6 @@ void MLIAPModel::read_coeffs(char *coefffilename)
   }
 
   if (comm->me == 0) fclose(fpcoeff);
-
 }
 
 /* ----------------------------------------------------------------------
@@ -153,9 +152,7 @@ double MLIAPModel::memory_usage()
 {
   double bytes = 0;
 
-  int n = atom->ntypes+1;
   bytes += nelements*nparams*sizeof(double);  // coeffelem
-
   return bytes;
 }
 

--- a/src/MLIAP/mliap_model_linear.cpp
+++ b/src/MLIAP/mliap_model_linear.cpp
@@ -28,7 +28,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-MLIAPModelLinear::MLIAPModelLinear(LAMMPS* lmp, char* coefffilename) : 
+MLIAPModelLinear::MLIAPModelLinear(LAMMPS* lmp, char* coefffilename) :
   MLIAPModel(lmp, coefffilename)
 {
   nonlinearflag = 0;
@@ -71,7 +71,7 @@ void MLIAPModelLinear::gradient(PairMLIAP* pairmliap, NeighList* list, double **
 
       for (int icoeff = 0; icoeff < ndescriptors; icoeff++)
         etmp += coeffi[icoeff+1]*descriptors[ii][icoeff];
-      
+
       pairmliap->e_tally(i,etmp);
     }
   }

--- a/src/MLIAP/mliap_model_quadratic.cpp
+++ b/src/MLIAP/mliap_model_quadratic.cpp
@@ -28,7 +28,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-MLIAPModelQuadratic::MLIAPModelQuadratic(LAMMPS* lmp, char* coefffilename) : 
+MLIAPModelQuadratic::MLIAPModelQuadratic(LAMMPS* lmp, char* coefffilename) :
   MLIAPModel(lmp, coefffilename)
 {
   nonlinearflag = 1;
@@ -72,7 +72,7 @@ void MLIAPModelQuadratic::gradient(PairMLIAP* pairmliap, NeighList* list, double
 
     // add in contributions to global and per-atom energy
     // this is optional and has no effect on force calculation
- 
+
     if (eflag) {
 
       // energy of atom I

--- a/src/MLIAP/pair_mliap.cpp
+++ b/src/MLIAP/pair_mliap.cpp
@@ -93,10 +93,10 @@ void PairMLIAP::compute(int eflag, int vflag)
   model->gradient(this, list, descriptors, beta, eflag);
 
   // calculate force contributions beta_i*dB_i/dR_j
- 
+
   descriptor->backward(this, list, beta, vflag);
 
-  // calculate stress 
+  // calculate stress
 
   if (vflag_fdotr) virial_fdotr_compute();
 }

--- a/src/MLIAP/pair_mliap.h
+++ b/src/MLIAP/pair_mliap.h
@@ -45,7 +45,7 @@ protected:
 
   double** beta;                // betas for all atoms in list
   double** descriptors;         // descriptors for all atoms in list
-  int ndescriptors;             // number of descriptors 
+  int ndescriptors;             // number of descriptors
   int beta_max;                 // number of atoms allocated for beta, descriptors
 
   class MLIAPModel* model;

--- a/src/REPLICA/fix_hyper_local.cpp
+++ b/src/REPLICA/fix_hyper_local.cpp
@@ -1683,7 +1683,7 @@ double FixHyperLocal::compute_vector(int i)
     return (double) allovercount;
   }
   */
-  
+
   return 0.0;
 }
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -410,9 +410,9 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
 
   if (comm->me == 0) {
     if (screen)
-      fprintf(screen,"  create bodies CPU = %g secs\n",time2-time1);
+      fprintf(screen,"  create bodies CPU = %g seconds\n",time2-time1);
     if (logfile)
-      fprintf(logfile,"  create bodies CPU = %g secs\n",time2-time1);
+      fprintf(logfile,"  create bodies CPU = %g seconds\n",time2-time1);
   }
 
   // set nlocal_body and allocate bodies I own

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -229,9 +229,9 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
 
   if (comm->me == 0) {
     if (screen)
-      fprintf(screen,"  find clusters CPU = %g secs\n",time2-time1);
+      fprintf(screen,"  find clusters CPU = %g seconds\n",time2-time1);
     if (logfile)
-      fprintf(logfile,"  find clusters CPU = %g secs\n",time2-time1);
+      fprintf(logfile,"  find clusters CPU = %g seconds\n",time2-time1);
   }
 
   // initialize list of SHAKE clusters to constrain

--- a/src/SNAP/compute_sna_atom.cpp
+++ b/src/SNAP/compute_sna_atom.cpp
@@ -259,7 +259,7 @@ void ComputeSNAAtom::compute_peratom()
         int jtype = type[j];
         int jelem = 0;
         if (chemflag)
-          int jelem = map[jtype];
+          jelem = map[jtype];
         if (rsq < cutsq[itype][jtype] && rsq>1e-20) {
           snaptr->rij[ninside][0] = delx;
           snaptr->rij[ninside][1] = dely;

--- a/src/USER-CGDNA/bond_oxdna_fene.cpp
+++ b/src/USER-CGDNA/bond_oxdna_fene.cpp
@@ -328,29 +328,9 @@ void BondOxdnaFene::coeff(int narg, char **arg)
 
 void BondOxdnaFene::init_style()
 {
-  /* special bonds have to be lj = 0 1 1 and coul = 1 1 1 to exclude
-     the ss excluded volume interaction between nearest neighbors   */
-
-  force->special_lj[1] = 0.0;
-  force->special_lj[2] = 1.0;
-  force->special_lj[3] = 1.0;
-  force->special_coul[1] = 1.0;
-  force->special_coul[2] = 1.0;
-  force->special_coul[3] = 1.0;
-
-  fprintf(screen,"Finding 1-2 1-3 1-4 neighbors ...\n"
-                 " Special bond factors lj:   %-10g %-10g %-10g\n"
-                 " Special bond factors coul: %-10g %-10g %-10g\n",
-                 force->special_lj[1],force->special_lj[2],force->special_lj[3],
-                 force->special_coul[1],force->special_coul[2],force->special_coul[3]);
-
   if (force->special_lj[1] != 0.0 || force->special_lj[2] != 1.0 || force->special_lj[3] != 1.0 ||
       force->special_coul[1] != 1.0 || force->special_coul[2] != 1.0 || force->special_coul[3] != 1.0)
-  {
-    if (comm->me == 0)
-      error->warning(FLERR,"Use special bonds lj = 0,1,1 and coul = 1,1,1 with bond style oxdna/fene");
-  }
-
+    error->all(FLERR,"Must use 'special_bonds lj 0 1 1 coul 1 1 1' with bond style oxdna/fene");
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-MISC/pair_tersoff_table.cpp
+++ b/src/USER-MISC/pair_tersoff_table.cpp
@@ -852,7 +852,7 @@ void PairTersoffTable::read_file(char *file)
   if (comm->me == 0) {
     PotentialFileReader reader(lmp, file, "TersoffTable", unit_convert_flag);
     char *line;
-    
+
     // transparently convert units for supported conversions
 
     int unit_convert = reader.get_unit_convert();

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -57,8 +57,6 @@ AtomVecHybrid::~AtomVecHybrid()
   delete [] styles;
   for (int k = 0; k < nstyles; k++) delete [] keywords[k];
   delete [] keywords;
-
-  for (int k = 0; k < nstyles_bonus; k++) delete styles_bonus[k];
   delete [] styles_bonus;
 
   if (!fields_allocated) return;

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -223,6 +223,7 @@ void AtomVecHybrid::process_args(int narg, char **arg)
 
   // set bonus_flag if any substyle has bonus data
   // set nstyles_bonus & styles_bonus
+  // sum two sizes over contributions from each substyle with bonus data.
 
   nstyles_bonus = 0;
   for (int k = 0; k < nstyles; k++)
@@ -232,6 +233,8 @@ void AtomVecHybrid::process_args(int narg, char **arg)
     bonus_flag = 1;
     styles_bonus = new AtomVec*[nstyles_bonus];
     nstyles_bonus = 0;
+    size_forward_bonus = 0;
+    size_border_bonus = 0;
     for (int k = 0; k < nstyles; k++) {
       if (styles[k]->bonus_flag) {
         styles_bonus[nstyles_bonus++] = styles[k];

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -233,8 +233,11 @@ void AtomVecHybrid::process_args(int narg, char **arg)
     styles_bonus = new AtomVec*[nstyles_bonus];
     nstyles_bonus = 0;
     for (int k = 0; k < nstyles; k++) {
-      if (styles[k]->bonus_flag)
+      if (styles[k]->bonus_flag) {
         styles_bonus[nstyles_bonus++] = styles[k];
+        size_forward_bonus += styles[k]->size_forward_bonus;
+        size_border_bonus += styles[k]->size_border_bonus;
+      }
     }
   }
 

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1939,12 +1939,13 @@ void Domain::print_box(const std::string &prefix)
   if (comm->me == 0) {
     std::string mesg = prefix;
     if (triclinic == 0) {
-      mesg += fmt::format("orthogonal box = ({} {} {}) to ({} {} {})\n",
-                          boxlo[0],boxlo[1],boxlo[2],
-                          boxhi[0],boxhi[1],boxhi[2]);
+      mesg += fmt::format("orthogonal box = ({:.8g} {:.8g} {:.8g}) to "
+                          "({:.8g} {:.8g} {:.8g})\n",boxlo[0],boxlo[1],
+                          boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
     } else {
-      mesg += fmt::format("triclinic box = ({} {} {}) to ({} {} {}) "
-                          "with tilt ({} {} {})\n",boxlo[0],boxlo[1],
+      mesg += fmt::format("triclinic box = ({:.8g} {:.8g} {:.8g}) to "
+                          "({:.8g} {:.8g} {:.8g}) with tilt "
+                          "({:.8g} {:.8g} {:.8g})\n",boxlo[0],boxlo[1],
                           boxlo[2],boxhi[0],boxhi[1],boxhi[2],xy,xz,yz);
     }
     utils::logmesg(lmp,mesg);

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -586,9 +586,9 @@ void FixAdapt::change_settings()
       // reset radius to new value, for both owned and ghost atoms
       // also reset rmass to new value assuming density remains constant
       // for scaleflag, previous_diam_scale is the scale factor on previous step
-      
+
       if (ad->aparam == DIAMETER) {
-        double density,scale;
+        double scale;
         double *radius = atom->radius;
         double *rmass = atom->rmass;
         int *mask = atom->mask;
@@ -691,14 +691,14 @@ void FixAdapt::restore_settings()
 
     } else if (ad->which == ATOM) {
       if (diamflag) {
-        double density,scale;
+        double scale;
 
         double *vec = fix_diam->vstore;
         double *radius = atom->radius;
         double *rmass = atom->rmass;
         int *mask = atom->mask;
         int nlocal = atom->nlocal;
-        
+
         if (scaleflag) scale = previous_diam_scale;
 
         for (int i = 0; i < nlocal; i++)

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -140,12 +140,12 @@ nadapt(0), id_fix_diam(NULL), id_fix_chg(NULL), adapt(NULL)
       } else error->all(FLERR,"Illegal fix adapt command");
       nadapt++;
       iarg += 2;
-      
+
     } else if (strcmp(arg[iarg],"atom") == 0) {
       if (iarg+3 > narg) error->all(FLERR,"Illegal fix adapt command");
       adapt[nadapt].which = ATOM;
       if (strcmp(arg[iarg+1],"diameter") == 0 ||
-	  strcmp(arg[iarg+1],"diameter/disc") == 0) {
+          strcmp(arg[iarg+1],"diameter/disc") == 0) {
         adapt[nadapt].aparam = DIAMETER;
         diamflag = 1;
         discflag = 0;
@@ -195,10 +195,10 @@ nadapt(0), id_fix_diam(NULL), id_fix_chg(NULL), adapt(NULL)
   // if scaleflag set with diameter or charge adaptation,
   // then previous step scale factors are written to restart file
   // initialize them here in case one is used and other is never defined
-  
+
   if (scaleflag && (diamflag || chgflag)) restart_global = 1;
   previous_diam_scale = previous_chg_scale = 1.0;
-  
+
   // allocate pair style arrays
 
   int n = atom->ntypes;
@@ -452,7 +452,7 @@ void FixAdapt::init()
       }
     }
   }
-    
+
   if (restart_reset) restart_reset = 0;
 
   // make copy of original pair/bond array values
@@ -608,7 +608,7 @@ void FixAdapt::change_settings()
             else radius[i] = 0.5*value;
           }
         }
-	  
+
         if (scaleflag) previous_diam_scale = value;
 
       // reset charge to new value, for both owned and ghost atoms
@@ -621,15 +621,15 @@ void FixAdapt::change_settings()
         int nlocal = atom->nlocal;
         int nall = nlocal + atom->nghost;
 
-	if (scaleflag) scale = value / previous_chg_scale;
-	
+        if (scaleflag) scale = value / previous_chg_scale;
+
         for (i = 0; i < nall; i++) {
           if (mask[i] & groupbit) {
             if (scaleflag) q[i] *= scale;
             else q[i] = value;
           }
-	}
-	
+        }
+
         if (scaleflag) previous_chg_scale = value;
       }
     }
@@ -745,7 +745,7 @@ void FixAdapt::set_arrays(int i)
 void FixAdapt::write_restart(FILE *fp)
 {
   int size = 2*sizeof(double);
-  
+
   fwrite(&size,sizeof(int),1,fp);
   fwrite(&previous_diam_scale,sizeof(double),1,fp);
   fwrite(&previous_chg_scale,sizeof(double),1,fp);
@@ -758,7 +758,7 @@ void FixAdapt::write_restart(FILE *fp)
 void FixAdapt::restart(char *buf)
 {
   double *dbuf = (double *) buf;
-  
+
   previous_diam_scale = dbuf[0];
   previous_chg_scale = dbuf[1];
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -793,7 +793,6 @@ bool Info::is_active(const char *category, const char *name)
 {
   if ((category == NULL) || (name == NULL)) return false;
   const char *style = "none";
-  const int len = strlen(name);
 
   if (strcmp(category,"package") == 0) {
     if (strcmp(name,"gpu") == 0) {

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -304,7 +304,8 @@ Lattice::Lattice(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   // print lattice spacings
 
   if (comm->me == 0)
-    utils::logmesg(lmp,fmt::format("Lattice spacing in x,y,z = {} {} {}\n",
+    utils::logmesg(lmp,fmt::format("Lattice spacing in x,y,z = "
+                                   "{:.8g} {:.8g} {:.8g}\n",
                                    xlattice,ylattice,zlattice));
 }
 

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -1466,10 +1466,10 @@ void Neighbor::print_pairwise_info()
                      every,delay,dist_check ? "yes" : "no");
   out += fmt::format("  max neighbors/atom: {}, page size: {}\n",
                      oneatom, pgsize);
-  out += fmt::format("  master list distance cutoff = {}\n",cutneighmax);
-  out += fmt::format("  ghost atom cutoff = {}\n",cutghost);
+  out += fmt::format("  master list distance cutoff = {:.8g}\n",cutneighmax);
+  out += fmt::format("  ghost atom cutoff = {:.8g}\n",cutghost);
   if (style != Neighbor::NSQ)
-    out += fmt::format("  binsize = {}, bins = {} {} {}\n",binsize,
+    out += fmt::format("  binsize = {:.8g}, bins = {:g} {:g} {:g}\n",binsize,
                        ceil(bbox[0]/binsize), ceil(bbox[1]/binsize),
                        ceil(bbox[2]/binsize));
 

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -1438,7 +1438,7 @@ void Neighbor::init_topology()
 
 void Neighbor::print_pairwise_info()
 {
-  int i,m;
+  int i;
   NeighRequest *rq;
 
   const double cutghost = MAX(cutneighmax,comm->cutghostuser);

--- a/src/pair_table.cpp
+++ b/src/pair_table.cpp
@@ -70,7 +70,6 @@ void PairTable::compute(int eflag, int vflag)
   int i,j,ii,jj,inum,jnum,itype,jtype,itable;
   double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
   double rsq,factor_lj,fraction,value,a,b;
-  char estr[128];
   int *ilist,*jlist,*numneigh,**firstneigh;
   Table *tb;
 

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -897,7 +897,7 @@ void ReadData::command(int narg, char **arg)
   MPI_Barrier(world);
 
   if (comm->me == 0)
-    utils::logmesg(lmp,fmt::format("  read_data CPU = {:.3f} secs\n",
+    utils::logmesg(lmp,fmt::format("  read_data CPU = {:.3f} seconds\n",
                                    MPI_Wtime()-time1));
 }
 

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -511,7 +511,7 @@ void ReadRestart::command(int narg, char **arg)
   MPI_Barrier(world);
 
   if (comm->me == 0)
-    utils::logmesg(lmp,fmt::format("  read_restart CPU = {:.3f} secs\n",
+    utils::logmesg(lmp,fmt::format("  read_restart CPU = {:.3f} seconds\n",
                                    MPI_Wtime()-time1));
 }
 

--- a/src/replicate.cpp
+++ b/src/replicate.cpp
@@ -779,6 +779,6 @@ void Replicate::command(int narg, char **arg)
   MPI_Barrier(world);
 
   if (me == 0)
-    utils::logmesg(lmp,fmt::format("  replicate CPU = {:.3f} secs\n",
+    utils::logmesg(lmp,fmt::format("  replicate CPU = {:.3f} seconds\n",
                                    MPI_Wtime()-time1));
 }

--- a/src/special.cpp
+++ b/src/special.cpp
@@ -1314,6 +1314,6 @@ void Special::fix_alteration()
 void Special::timer_output(double time1)
 {
   if (comm->me == 0)
-    utils::logmesg(lmp,fmt::format("  special bonds CPU = {:.3f} secs\n",
+    utils::logmesg(lmp,fmt::format("  special bonds CPU = {:.3f} seconds\n",
                                    MPI_Wtime()-time1));
 }

--- a/src/special.cpp
+++ b/src/special.cpp
@@ -63,8 +63,8 @@ void Special::build()
     const double * const special_lj   = force->special_lj;
     const double * const special_coul = force->special_coul;
     fmt::print(screen,"Finding 1-2 1-3 1-4 neighbors ...\n"
-               "  special bond factors lj:   {:<10g} {:<10g} {:<10g}\n"
-               "  special bond factors coul: {:<10g} {:<10g} {:<10g}\n",
+               "  special bond factors lj:   {:<8g} {:<8g} {:<8g}\n"
+               "  special bond factors coul: {:<8g} {:<8g} {:<8g}\n",
                special_lj[1],special_lj[2],special_lj[3],
                special_coul[1],special_coul[2],special_coul[3]);
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -549,9 +549,9 @@ bool utils::is_double(const std::string & str) {
 
 std::string utils::path_basename(const std::string & path) {
 #if defined(_WIN32)
-  size_t start = path.find_last_of('/\\');
+  size_t start = path.find_last_of("/\\");
 #else
-  size_t start = path.find_last_of('/');
+  size_t start = path.find_last_of("/");
 #endif
 
   if (start == std::string::npos) {

--- a/unittest/force-styles/pair_style.cpp
+++ b/unittest/force-styles/pair_style.cpp
@@ -1007,6 +1007,9 @@ TEST(PairStyle, single)
     char **argv = (char **)args;
     int argc    = sizeof(args) / sizeof(char *);
 
+    // need to add this dependency
+    test_config.prerequisites.push_back(std::make_pair("atom", "full"));
+
     // create a LAMMPS instance with standard settings to detect the number of atom types
     if (!verbose) ::testing::internal::CaptureStdout();
     LAMMPS *lmp = init_lammps(argc, argv, test_config);
@@ -1018,8 +1021,10 @@ TEST(PairStyle, single)
         for (auto prerequisite : test_config.prerequisites) {
             std::cerr << prerequisite.first << "_style " << prerequisite.second << "\n";
         }
+        test_config.prerequisites.pop_back();
         GTEST_SKIP();
     }
+    test_config.prerequisites.pop_back();
 
     // gather some information and skip if unsupported
     int ntypes    = lmp->atom->ntypes;

--- a/unittest/force-styles/tests/atomic-pair-eam.yaml
+++ b/unittest/force-styles/tests/atomic-pair-eam.yaml
@@ -1,7 +1,7 @@
 ---
 lammps_version: 15 Jun 2020
 date_generated: Thu Jun 25 12:25:55 202
-epsilon: 5e-12
+epsilon: 6e-12
 prerequisites: ! |
   pair eam
 pre_commands: ! |


### PR DESCRIPTION
**Summary**

This fixes several smaller issues and bugs and specifically fixes a communication bug with hybrid atom styles that include ellipsoid or body.

**Author(s)**

Axel Kohlmeyer (Temple U) and Steve Plimpton (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

The following changes are included:
- do not delete substyles with bonus data twice
- correctly report buffer sizes for forward and border communication in atom style hybrid with atoms containing "bonus" data (e.g. ellipsoid)
- remove trailing whitespace and replace tabs with blanks
- remove dead code and silence compiler warnings
- bugfix for compute sna/atom when 
- fix a few output format issues where numbers were printed with excessive precision
- fix bug that crashed the atom style tester in the "single" test w/o the MOLECULE package
- correctly find path separators on windows
- fix issue in bond style oxdna/fene that was replacing settings w/o updating data structures instead of a hard error

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
