### PR TITLE
Get number of chunks from compute chunk/atom

### DIFF
--- a/doc/src/Howto_output.rst
+++ b/doc/src/Howto_output.rst
@@ -3,13 +3,15 @@ Output from LAMMPS (thermo, dumps, computes, fixes, variables)
 
 There are four basic kinds of LAMMPS output:
 
-* :doc:`Thermodynamic output <thermo_style>`, which is a list
-  of quantities printed every few timesteps to the screen and logfile.
+* :doc:`Thermodynamic output <thermo_style>`, which is a list of
+  quantities printed every few timesteps to the screen and logfile.
 * :doc:`Dump files <dump>`, which contain snapshots of atoms and various
   per-atom values and are written at a specified frequency.
-* Certain fixes can output user-specified quantities to files: :doc:`fix ave/time <fix_ave_time>` for time averaging, :doc:`fix ave/chunk <fix_ave_chunk>` for spatial or other averaging, and :doc:`fix print <fix_print>` for single-line output of
-  :doc:`variables <variable>`.  Fix print can also output to the
-  screen.
+* Certain fixes can output user-specified quantities to files:
+  :doc:`fix ave/time <fix_ave_time>` for time averaging,
+  :doc:`fix ave/chunk <fix_ave_chunk>` for spatial or other averaging, and
+  :doc:`fix print <fix_print>` for single-line output of
+  :doc:`variables <variable>`.  Fix print can also output to the screen.
 * :doc:`Restart files <restart>`.
 
 A simulation prints one set of thermodynamic output and (optionally)
@@ -80,6 +82,25 @@ once (vector -> scalar, array -> vector).  Using two brackets reduces
 the dimension twice (array -> scalar).  Thus a command that uses
 scalar values as input can typically also process elements of a vector
 or array.
+
+.. _disambiguation:
+
+Disambiguation
+--------------
+
+Some computes and fixes produce multiple kinds of data, e.g. a global
+scalar and a global vector, or a global scalar and a per-atom vector
+(i.e. one value per atom).  Usually the context in which those are used
+determines which datum is accessed.  Example: if a compute provides both
+a global scalar and a per-atom vector, the former will be used when
+using ``c_ID`` in an equal-style variable, while the latter will be
+referenced as ``c_ID`` in an atom-style variable.  While atom-style
+variables are otherwise also able to access global scalars, access to
+the global scalar of the compute is not directly possible in this case.
+This is resolved through first defining an equal-style variable that
+accesses the scalar property and then access that equal-style variable
+in the atom-style variable, which then may then also access the per-atom
+property.
 
 .. _thermo:
 

--- a/doc/src/Howto_output.rst
+++ b/doc/src/Howto_output.rst
@@ -43,7 +43,7 @@ to output and the kind of data they operate on and produce:
 .. _global:
 
 Global/per-atom/local data
----------------------------------------
+--------------------------
 
 Various output-related commands work with three different styles of
 data: global, per-atom, or local.  A global datum is one or more
@@ -56,7 +56,7 @@ bond distances.
 .. _scalar:
 
 Scalar/vector/array data
--------------------------------------
+------------------------
 
 Global, per-atom, and local datums can each come in three kinds: a
 single scalar value, a vector of values, or a 2d array of values.  The
@@ -88,24 +88,22 @@ or array.
 Disambiguation
 --------------
 
-Some computes and fixes produce multiple kinds of data, e.g. a global
-scalar and a global vector, or a global scalar and a per-atom vector
-(i.e. one value per atom).  Usually the context in which those are used
-determines which datum is accessed.  Example: if a compute provides both
-a global scalar and a per-atom vector, the former will be used when
-using ``c_ID`` in an equal-style variable, while the latter will be
-referenced as ``c_ID`` in an atom-style variable.  While atom-style
-variables are otherwise also able to access global scalars, access to
-the global scalar of the compute is not directly possible in this case.
-This is resolved through first defining an equal-style variable that
-accesses the scalar property and then access that equal-style variable
-in the atom-style variable, which then may then also access the per-atom
-property.
+Some computes and fixes produce data in multiple styles, e.g. a global
+scalar and a per-atom vector. Usually the context in which the input
+script references the data determines which style is meant. Example: if
+a compute provides both a global scalar and a per-atom vector, the
+former will be accessed by using ``c_ID`` in an equal-style variable,
+while the latter will be accessed by using ``c_ID`` in an atom-style
+variable.  Note that atom-style variable formulas can also access global
+scalars, but in this case it is not possible to do directly because of
+the ambiguity.  Instead, an equal-style variable can be defined which
+accesses the global scalar, and that variable used in the atom-style
+variable formula in place of ``c_ID``.
 
 .. _thermo:
 
 Thermodynamic output
----------------------------------
+--------------------
 
 The frequency and format of thermodynamic output is set by the
 :doc:`thermo <thermo>`, :doc:`thermo_style <thermo_style>`, and
@@ -133,7 +131,7 @@ intensive result.
 .. _dump:
 
 Dump file output
----------------------------
+----------------
 
 Dump file output is specified by the :doc:`dump <dump>` and
 :doc:`dump_modify <dump_modify>` commands.  There are several
@@ -159,7 +157,7 @@ command.
 .. _fixoutput:
 
 Fixes that write output files
----------------------------------------------
+-----------------------------
 
 Several fixes take various quantities as input and can write output
 files: :doc:`fix ave/time <fix_ave_time>`, :doc:`fix ave/chunk <fix_ave_chunk>`, :doc:`fix ave/histo <fix_ave_histo>`,
@@ -213,7 +211,7 @@ from normal thermodynamic or dump file output.
 .. _computeoutput:
 
 Computes that process output quantities
------------------------------------------------------------
+---------------------------------------
 
 The :doc:`compute reduce <compute_reduce>` and :doc:`compute reduce/region <compute_reduce>` commands take one or more per-atom
 or local vector quantities as inputs and "reduce" them (sum, min, max,
@@ -240,7 +238,7 @@ output commands.
 .. _fixprocoutput:
 
 Fixes that process output quantities
---------------------------------------------------------
+------------------------------------
 
 The :doc:`fix vector <fix_vector>` command can create global vectors as
 output from global scalars as input, accumulating them one element at
@@ -265,7 +263,7 @@ The output of this fix can be used as input to other output commands.
 .. _compute:
 
 Computes that generate values to output
------------------------------------------------------
+---------------------------------------
 
 Every :doc:`compute <compute>` in LAMMPS produces either global or
 per-atom or local values.  The values can be scalars or vectors or
@@ -278,7 +276,7 @@ without the word "atom" or "local" produce global values.
 .. _fix:
 
 Fixes that generate values to output
-----------------------------------------------
+------------------------------------
 
 Some :doc:`fixes <fix>` in LAMMPS produces either global or per-atom or
 local values which can be accessed by other commands.  The values can
@@ -290,7 +288,7 @@ describes them.
 .. _variable:
 
 Variables that generate values to output
--------------------------------------------------------
+----------------------------------------
 
 :doc:`Variables <variable>` defined in an input script can store one or
 more strings.  But equal-style, vector-style, and atom-style or
@@ -305,7 +303,7 @@ commands described in this section.
 .. _table:
 
 Summary table of output options and data flow between commands
---------------------------------------------------------------------------
+--------------------------------------------------------------
 
 This table summarizes the various commands that can be used for
 generating output from LAMMPS.  Each command produces output data of

--- a/doc/src/compute_chunk_atom.rst
+++ b/doc/src/compute_chunk_atom.rst
@@ -622,14 +622,16 @@ cylinder, x for a y-axis cylinder, and x for a z-axis cylinder.
 
 **Output info:**
 
-This compute calculates a per-atom vector, which can be accessed by
-any command that uses per-atom values from a compute as input.  See
-the :doc:`Howto output <Howto_output>` doc page for an overview of
+This compute calculates a per-atom vector (the chunk ID), which can
+be accessed by any command that uses per-atom values from a compute
+as input.  It also calculates a global scalar (the number of chunks),
+which can be similarly accessed everywhere outside of a per-atom context.
+See the :doc:`Howto output <Howto_output>` doc page for an overview of
 LAMMPS output options.
 
 The per-atom vector values are unitless chunk IDs, ranging from 1 to
 *Nchunk* (inclusive) for atoms assigned to chunks, and 0 for atoms not
-belonging to a chunk.
+belonging to a chunk.  The scalar contains the value of *Nchunk*.
 
 Restrictions
 """"""""""""

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -64,6 +64,8 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
   if (narg < 4) error->all(FLERR,"Illegal compute chunk/atom command");
 
   peratom_flag = 1;
+  scalar_flag = 1;
+  extscalar = 0;
   size_peratom_cols = 0;
   create_attribute = 1;
 
@@ -637,6 +639,20 @@ void ComputeChunkAtom::compute_peratom()
 
   int nlocal = atom->nlocal;
   for (int i = 0; i < nlocal; i++) chunk[i] = ichunk[i];
+}
+
+
+/* ----------------------------------------------------------------------
+   to return the number of chunks, we first need to make certain
+   that compute_peratom() has been called.
+------------------------------------------------------------------------- */
+double ComputeChunkAtom::compute_scalar()
+{
+  if (invoked_peratom != update->ntimestep)
+    compute_peratom();
+  invoked_scalar = update->ntimestep;
+
+  return (scalar = nchunk);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/compute_chunk_atom.h
+++ b/src/compute_chunk_atom.h
@@ -39,6 +39,7 @@ class ComputeChunkAtom : public Compute {
   void init();
   void setup();
   void compute_peratom();
+  double compute_scalar();
   void set_arrays(int);
   double memory_usage();
 


### PR DESCRIPTION
**Summary**

This adds a `compute_scalar()` function to the `ComputeChunkAtom` class which allows to access the number of chunks in equal style variables and thermo output and otherwise. When accessed in a per-atom context, the compute will - as before - return the chunk ID. To access the number of chunks in a per-atom context like other global scalars, it would need to be accessed indirectly, e.g. through an equal style variable.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
