### PR TITLE
Removes the first 2 lines skip from lammps2pdb.pl when reading a data file

### DIFF
--- a/tools/ch2lmp/lammps2pdb.pl
+++ b/tools/ch2lmp/lammps2pdb.pl
@@ -574,7 +574,6 @@
 
     foreach ((masses,atoms,bonds,angles,dihedrals,impropers)) { $hash{$_}=$_; }
     open(DATA, "<".$data_name);
-    for (my $i=0; $i<2; ++$i) { my $tmp = <DATA>; }	# skip first two lines
     while ($init&&!eof(DATA))				# interpret header
     {
       @tmp		= split(" ", <DATA>);


### PR DESCRIPTION
**Summary**

No longer skips the first 2 lines when reading a data file. It would make the script not recognize the "Masses" section. Probably was broken by a change in the DATA file formatting (when created via write_data in an input script).

**Author(s)**

Vinicius Santos de Pontes 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
Should maintain backward compability 

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete

