### PR TITLE
Update documentation to recommend lammps-stable packages for Ubuntu

### DIFF
--- a/doc/src/Install_linux.rst
+++ b/doc/src/Install_linux.rst
@@ -21,8 +21,14 @@ Pre-built Ubuntu Linux executables
 A pre-built LAMMPS executable suitable for running on the latest
 Ubuntu Linux versions, can be downloaded as a Debian package.  This
 allows you to install LAMMPS with a single command, and stay
-up-to-date with the current version of LAMMPS by simply updating your
-operating system.
+up-to-date with the current stable version of LAMMPS by simply updating
+your operating system.  Please note, that the repository below offers
+two LAMMPS packages, ``lammps-daily`` and ``lammps-stable``.  The
+LAMMPS developers recommend to use the ``lammps-stable`` package for
+any production simulations.  The ``lammps-daily`` package is built
+from the LAMMPS development sources, and those versions may have known
+issues and bugs when new features are added and the software has not
+undergone full release testing.
 
 To install the appropriate personal-package archives (PPAs), do the
 following once:
@@ -37,16 +43,16 @@ To install LAMMPS do the following once:
 
 .. code-block:: bash
 
-   $ sudo apt-get install lammps-daily
+   $ sudo apt-get install lammps-stable
 
-This downloads an executable named ``lmp_daily`` to your box, which
+This downloads an executable named ``lmp_stable`` to your box, which
 can then be used in the usual way to run input scripts:
 
 .. code-block:: bash
 
-   $ lmp_daily -in in.lj
+   $ lmp_stable -in in.lj
 
-To update LAMMPS to the most current version, do the following:
+To update LAMMPS to the most current stable version, do the following:
 
 .. code-block:: bash
 
@@ -58,25 +64,25 @@ To get a copy of the current documentation and examples:
 
 .. code-block:: bash
 
-   $ sudo apt-get install lammps-daily-doc
+   $ sudo apt-get install lammps-stable-doc
 
 which will download the doc files in
-``/usr/share/doc/lammps-daily-doc/doc`` and example problems in
+``/usr/share/doc/lammps-stable-doc/doc`` and example problems in
 ``/usr/share/doc/lammps-doc/examples``.
 
 To get a copy of the current potentials files:
 
 .. code-block:: bash
 
-   $ sudo apt-get install lammps-daily-data
+   $ sudo apt-get install lammps-stable-data
 
 which will download the potentials files to
-``/usr/share/lammps-daily/potentials``.  The ``lmp_daily`` binary is
+``/usr/share/lammps-stable/potentials``.  The ``lmp_stable`` binary is
 hard-coded to look for potential files in this directory (it does not
 use the `LAMMPS_POTENTIALS` environment variable, as described
 in :doc:`pair_coeff <pair_coeff>` command).
 
-The ``lmp_daily`` binary is built with the :ref:`KIM package <kim>` which
+The ``lmp_stable`` binary is built with the :ref:`KIM package <kim>` which
 results in the above command also installing the `kim-api` binaries when LAMMPS
 is installed.  In order to use potentials from `openkim.org <openkim_>`_, you
 can install the `openkim-models` package
@@ -89,9 +95,9 @@ To un-install LAMMPS, do the following:
 
 .. code-block:: bash
 
-   $ sudo apt-get remove lammps-daily
+   $ sudo apt-get remove lammps-stable
 
-Please use ``lmp_daily -help`` to see which compilation options, packages,
+Please use ``lmp_stable -help`` to see which compilation options, packages,
 and styles are included in the binary.
 
 Thanks to Anton Gladky (gladky.anton at gmail.com) for setting up this


### PR DESCRIPTION
**Summary**

In addition to "lammps-daily" packages that are compiled from the "master" branch, there are now also "lammps-stable" packages available for Ubuntu Linux.  Change the manual to recommend the latter as this is what most users of pre-compiled binaries should be using. 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
