### PR TITLE
Update pair_kim.cpp so settings() may come before box is defined

### DIFF
--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -285,13 +285,6 @@ void PairKIM::allocate()
 
 void PairKIM::settings(int narg, char **arg)
 {
-  // some of the code below needs to know the number of atom types,
-  // but that is not set until the simulation box is created.
-
-  if (domain->box_exist == 0)
-    error->all(FLERR,"May not use 'pair_style kim' command before "
-               "simulation box is defined");
-
   // This is called when "pair_style kim ..." is read from input
   // may be called multiple times
   ++settings_call_count;
@@ -311,15 +304,6 @@ void PairKIM::settings(int narg, char **arg)
   // ensure we are in a clean state for KIM (needed on repeated call)
   // first time called will do nothing...
   kim_free();
-
-  // make sure things are allocated
-  if (allocated != 1) allocate();
-
-  // clear setflag to ensure coeff() is called after settings()
-  int n = atom->ntypes;
-  for (int i = 1; i <= n; i++)
-    for (int j = i; j <= n; j++)
-      setflag[i][j] = 0;
 
   // set lmps_* bool flags
   set_lmps_flags();


### PR DESCRIPTION
Addresses #2215

**Summary**

Remove unnecessary allocation (and use of `atom->ntypes`) in `PairKIM::settings()`

**Related Issues**

Addresses #2215 

**Author(s)**

Ryan S. Elliott (UMN)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

none

**Implementation Notes**


**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**



