### PR TITLE
Fix issues in Kokkos fix qeq/reax

### DIFF
--- a/src/KOKKOS/fix_qeq_reax_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.h
@@ -152,7 +152,7 @@ class FixQEqReaxKokkos : public FixQEqReax {
 
  private:
   int inum,ignum;
-  int allocated_flag;
+  int allocated_flag, last_allocate;
   int need_dup;
 
   typename AT::t_int_scalar d_mfill_offset;


### PR DESCRIPTION
**Summary**

Fix a few issues in Kokkos fix qeq/reax:

- The code assumed the fix was called every timestep, this fixes the logic for when `nevery` not equal to 1. 
- Add missing sync to `unpack_exchange`, necessary if that proc doesn't pack any particles.

**Related Issues**

None

**Author(s)**

Stan Moore (SNL), reported by Grégoire Defoort (LIST)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes