### PR TITLE
Fix the system-dependent function call to `malloc_usable_size`.

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -22,7 +22,11 @@
 #include "tbb/scalable_allocator.h"
 #else
 #include <cstring>
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#else
 #include <malloc.h>
+#endif
 #endif
 #endif
 
@@ -84,7 +88,13 @@ void *Memory::srealloc(void *ptr, bigint nbytes, const char *name)
   if (offset) {
     void *optr = ptr;
     ptr = smalloc(nbytes, name);
+#if defined(__APPLE__)
+    memcpy(ptr, optr, MIN(nbytes,malloc_size(optr)));
+#elif defined(_WIN32) || defined(__MINGW32__)
+    memcpy(ptr, optr, MIN(nbytes,_msize(optr)));
+#else
     memcpy(ptr, optr, MIN(nbytes,malloc_usable_size(optr)));
+#endif
     free(optr);
   }
 #else


### PR DESCRIPTION
**Summary**
This PR includes a bugfix to correct the system-dependent function call and the header inclusion for getting the size of the block of memory allocated from the heap.

- [`malloc_usable_size`](https://man7.org/linux/man-pages/man3/malloc_usable_size.3.html) on Linux
- [`malloc_size`](https://www.unix.com/man-page/osx/3/malloc_size/) on macOS
- [`_msize`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/msize?view=vs-2017) on Windows

**Related Issues**

Compiling LAMMPS 
````sh
cmake -C ../cmake/presets/all_on.cmake -C ../cmake/presets/nolib.cmake ../cmake -DCMAKE_CXX_COMPILER=icpc
````
on macOS with Intel Parallel Studio XE 2020 update 1, (version ` 19.1.1.216 20200306`) fails with 
````sh
/lammps/src/memory.cpp(25): catastrophic error: cannot open source file "malloc.h"
  #include <malloc.h>
````

while the correct behavior is compiling without error.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**
This implementation is tested on macOS Catalina (version `10.15.5 (19F101)`), but the correct function call is also provided for macOS, & Windows.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


