### PR TITLE
Collected small changes and fixes for the next patch release

### DIFF
--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -73,6 +73,7 @@
 #include "variable.h"
 #include "utils.h"
 #include "fix_store_kim.h"
+#include "fmt/format.h"
 
 extern "C" {
 #include "KIM_SimulatorHeaders.h"
@@ -254,31 +255,21 @@ void KimInteractions::do_setup(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-void KimInteractions::KIM_SET_TYPE_PARAMETERS(char const *const input_line) const
+void KimInteractions::KIM_SET_TYPE_PARAMETERS(const std::string &input_line) const
 {
-  char strbuf[MAXLINE];
-  strcpy(strbuf,input_line);
-  char *cmd, *key, *filename;
   int nocomment;
-  cmd = strtok(strbuf," \t");
-  key = strtok(NULL," \t");
-  filename = strtok(NULL," \t");
+  auto words = utils::split_words(input_line);
+
+  std::string key = words[1];
+  std::string filename = words[2];
+  std::vector<std::string> species(words.begin()+3,words.end());
+  if (species.size() != atom->ntypes)
+    error->one(FLERR,"Incorrect args for KIM_SET_TYPE_PARAMETERS command");
 
   FILE *fp;
-  fp = fopen(filename,"r");
+  fp = fopen(filename.c_str(),"r");
   if (fp == NULL) {
     error->one(FLERR,"Parameter file not found");
-  }
-
-  char *species1, *species2, *the_rest;
-  std::vector<char *> species;
-  for (int i = 0; i < atom->ntypes; ++i)
-  {
-    char *str;
-    str = strtok(NULL," \t");
-    if (str == NULL)
-      error->one(FLERR,"Incorrect args for KIM_SET_TYPE_PARAMETERS command");
-    species.push_back(str);
   }
 
   char line[MAXLINE],*ptr;
@@ -299,42 +290,29 @@ void KimInteractions::KIM_SET_TYPE_PARAMETERS(char const *const input_line) cons
 
     ptr = line;
     nocomment = line[0] != '#';
+    char *species1, *species2, *the_rest;
 
     if(nocomment) {
-      if (strcmp(key,"pair") == 0) {
+      if (key == "pair") {
         species1 = strtok(ptr," \t");
         species2 = strtok(NULL," \t");
         the_rest = strtok(NULL,"\n");
 
-        for (int type_a = 0; type_a < atom->ntypes; ++type_a) {
-          for (int type_b = type_a; type_b < atom->ntypes; ++type_b) {
-            if(((strcmp(species[type_a],species1) == 0) &&
-                (strcmp(species[type_b],species2) == 0))
-               ||
-               ((strcmp(species[type_b],species1) == 0) &&
-                (strcmp(species[type_a],species2) == 0))
-               ) {
-              char pair_command[MAXLINE];
-              sprintf(pair_command,"pair_coeff %i %i %s",type_a+1,type_b+1,
-                      the_rest);
-              input->one(pair_command);
-            }
-          }
+        for (int ia = 0; ia < atom->ntypes; ++ia) {
+          for (int ib = ia; ib < atom->ntypes; ++ib)
+            if (((species[ia] == species1) && (species[ib] == species2))
+                || ((species[ib] == species1) && (species[ia] == species2)))
+              input->one(fmt::format("pair_coeff {} {} {}",ia+1,ib+1,the_rest));
         }
-      }
-      else if (strcmp(key,"charge") == 0) {
+      } else if (key == "charge") {
         species1 = strtok(ptr," \t");
         the_rest = strtok(NULL,"\n");
 
-        for (int type_a = 0; type_a < atom->ntypes; ++type_a) {
-          if(strcmp(species[type_a],species1) == 0) {
-            char pair_command[MAXLINE];
-            sprintf(pair_command,"set type %i charge %s",type_a+1,the_rest);
-            input->one(pair_command);
-          }
+        for (int ia = 0; ia < atom->ntypes; ++ia) {
+          if (species[ia] == species1)
+            input->one(fmt::format("set type {} charge {}",ia+1,the_rest));
         }
-      }
-      else{
+      } else {
         error->one(FLERR,"Unrecognized KEY for KIM_SET_TYPE_PARAMETERS command");
       }
     }

--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -73,7 +73,6 @@
 #include "variable.h"
 #include "utils.h"
 #include "fix_store_kim.h"
-#include "fmt/format.h"
 
 extern "C" {
 #include "KIM_SimulatorHeaders.h"
@@ -255,21 +254,31 @@ void KimInteractions::do_setup(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-void KimInteractions::KIM_SET_TYPE_PARAMETERS(const std::string &input_line) const
+void KimInteractions::KIM_SET_TYPE_PARAMETERS(char const *const input_line) const
 {
+  char strbuf[MAXLINE];
+  strcpy(strbuf,input_line);
+  char *cmd, *key, *filename;
   int nocomment;
-  auto words = utils::split_words(input_line);
-
-  std::string key = words[1];
-  std::string filename = words[2];
-  std::vector<std::string> species(words.begin()+3,words.end());
-  if (species.size() != atom->ntypes)
-    error->one(FLERR,"Incorrect args for KIM_SET_TYPE_PARAMETERS command");
+  cmd = strtok(strbuf," \t");
+  key = strtok(NULL," \t");
+  filename = strtok(NULL," \t");
 
   FILE *fp;
-  fp = fopen(filename.c_str(),"r");
+  fp = fopen(filename,"r");
   if (fp == NULL) {
     error->one(FLERR,"Parameter file not found");
+  }
+
+  char *species1, *species2, *the_rest;
+  std::vector<char *> species;
+  for (int i = 0; i < atom->ntypes; ++i)
+  {
+    char *str;
+    str = strtok(NULL," \t");
+    if (str == NULL)
+      error->one(FLERR,"Incorrect args for KIM_SET_TYPE_PARAMETERS command");
+    species.push_back(str);
   }
 
   char line[MAXLINE],*ptr;
@@ -290,29 +299,42 @@ void KimInteractions::KIM_SET_TYPE_PARAMETERS(const std::string &input_line) con
 
     ptr = line;
     nocomment = line[0] != '#';
-    char *species1, *species2, *the_rest;
 
     if(nocomment) {
-      if (key == "pair") {
+      if (strcmp(key,"pair") == 0) {
         species1 = strtok(ptr," \t");
         species2 = strtok(NULL," \t");
         the_rest = strtok(NULL,"\n");
 
-        for (int ia = 0; ia < atom->ntypes; ++ia) {
-          for (int ib = ia; ib < atom->ntypes; ++ib)
-            if (((species[ia] == species1) && (species[ib] == species2))
-                || ((species[ib] == species1) && (species[ia] == species2)))
-              input->one(fmt::format("pair_coeff {} {} {}",ia+1,ib+1,the_rest));
+        for (int type_a = 0; type_a < atom->ntypes; ++type_a) {
+          for (int type_b = type_a; type_b < atom->ntypes; ++type_b) {
+            if(((strcmp(species[type_a],species1) == 0) &&
+                (strcmp(species[type_b],species2) == 0))
+               ||
+               ((strcmp(species[type_b],species1) == 0) &&
+                (strcmp(species[type_a],species2) == 0))
+               ) {
+              char pair_command[MAXLINE];
+              sprintf(pair_command,"pair_coeff %i %i %s",type_a+1,type_b+1,
+                      the_rest);
+              input->one(pair_command);
+            }
+          }
         }
-      } else if (key == "charge") {
+      }
+      else if (strcmp(key,"charge") == 0) {
         species1 = strtok(ptr," \t");
         the_rest = strtok(NULL,"\n");
 
-        for (int ia = 0; ia < atom->ntypes; ++ia) {
-          if (species[ia] == species1)
-            input->one(fmt::format("set type {} charge {}",ia+1,the_rest));
+        for (int type_a = 0; type_a < atom->ntypes; ++type_a) {
+          if(strcmp(species[type_a],species1) == 0) {
+            char pair_command[MAXLINE];
+            sprintf(pair_command,"set type %i charge %s",type_a+1,the_rest);
+            input->one(pair_command);
+          }
         }
-      } else {
+      }
+      else{
         error->one(FLERR,"Unrecognized KEY for KIM_SET_TYPE_PARAMETERS command");
       }
     }

--- a/src/KIM/kim_interactions.h
+++ b/src/KIM/kim_interactions.h
@@ -77,7 +77,7 @@ class KimInteractions : protected Pointers {
  private:
   void do_setup(int, char **);
   int species_to_atomic_no(const std::string &species) const;
-  void KIM_SET_TYPE_PARAMETERS(char const *const input_line) const;
+  void KIM_SET_TYPE_PARAMETERS(const std::string &input_line) const;
 };
 
 }

--- a/src/KIM/kim_interactions.h
+++ b/src/KIM/kim_interactions.h
@@ -77,7 +77,7 @@ class KimInteractions : protected Pointers {
  private:
   void do_setup(int, char **);
   int species_to_atomic_no(const std::string &species) const;
-  void KIM_SET_TYPE_PARAMETERS(const std::string &input_line) const;
+  void KIM_SET_TYPE_PARAMETERS(char const *const input_line) const;
 };
 
 }

--- a/src/KOKKOS/fix_gravity_kokkos.cpp
+++ b/src/KOKKOS/fix_gravity_kokkos.cpp
@@ -41,7 +41,7 @@ FixGravityKokkos<DeviceType>::FixGravityKokkos(LAMMPS *lmp, int narg, char **arg
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-void FixGravityKokkos<DeviceType>::post_force(int vflag)
+void FixGravityKokkos<DeviceType>::post_force(int /*vflag*/)
 {
   // update gravity due to variables
 

--- a/src/KOKKOS/fix_langevin_kokkos.cpp
+++ b/src/KOKKOS/fix_langevin_kokkos.cpp
@@ -137,7 +137,7 @@ void FixLangevinKokkos<DeviceType>::grow_arrays(int nmax)
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-void FixLangevinKokkos<DeviceType>::initial_integrate(int vflag)
+void FixLangevinKokkos<DeviceType>::initial_integrate(int /*vflag*/)
 {
   atomKK->sync(execution_space,datamask_read);
   atomKK->modified(execution_space,datamask_modify);

--- a/src/KOKKOS/fix_setforce_kokkos.cpp
+++ b/src/KOKKOS/fix_setforce_kokkos.cpp
@@ -73,7 +73,7 @@ void FixSetForceKokkos<DeviceType>::init()
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-void FixSetForceKokkos<DeviceType>::post_force(int vflag)
+void FixSetForceKokkos<DeviceType>::post_force(int /*vflag*/)
 {
   atomKK->sync(execution_space, X_MASK | F_MASK | MASK_MASK);
 

--- a/src/KSPACE/fix_tune_kspace.cpp
+++ b/src/KSPACE/fix_tune_kspace.cpp
@@ -23,6 +23,7 @@
 #include "comm.h"
 #include "update.h"
 #include "force.h"
+#include "info.h"
 #include "kspace.h"
 #include "pair.h"
 #include "error.h"
@@ -45,7 +46,8 @@ using namespace FixConst;
 /* ---------------------------------------------------------------------- */
 
 FixTuneKspace::FixTuneKspace(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg)
+  Fix(lmp, narg, arg),
+  acc_str(""), kspace_style(""), pair_style(""), base_pair_style("")
 {
   if (narg < 3) error->all(FLERR,"Illegal fix tune/kspace command");
 
@@ -98,10 +100,9 @@ void FixTuneKspace::init()
   if (force->kspace->dipoleflag)
     error->all(FLERR,"Cannot use fix tune/kspace with dipole long-range solver");
 
+  store_old_kspace_settings();
   double old_acc = force->kspace->accuracy/force->kspace->two_charge_force;
-  char old_acc_str[16];
-  snprintf(old_acc_str,16,"%g",old_acc);
-  strncpy(new_acc_str,old_acc_str,16);
+  acc_str = std::to_string(old_acc);
 
   int itmp;
   double *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
@@ -120,34 +121,35 @@ void FixTuneKspace::pre_exchange()
   if (next_reneighbor != update->ntimestep) return;
   next_reneighbor = update->ntimestep + nevery;
 
+  Info *info = new Info(lmp);
+  bool has_msm = info->has_style("pair", base_pair_style + "/msm");
+  delete info;
+
   double time = get_timing_info();
 
-  if (strcmp(force->kspace_style,"ewald") == 0) ewald_time = time;
-  if (strcmp(force->kspace_style,"pppm") == 0) pppm_time = time;
-  if (strcmp(force->kspace_style,"msm") == 0) msm_time = time;
+  if (utils::strmatch(force->kspace_style,"^ewald")) ewald_time = time;
+  if (utils::strmatch(force->kspace_style,"^pppm")) pppm_time = time;
+  if (utils::strmatch(force->kspace_style,"^msm")) msm_time = time;
 
   niter++;
   if (niter == 1) {
     // test Ewald
     store_old_kspace_settings();
-    strcpy(new_kspace_style,"ewald");
-    snprintf(new_pair_style,64,"%s/long",base_pair_style);
-    update_pair_style(new_pair_style,pair_cut_coul);
-    update_kspace_style(new_kspace_style,new_acc_str);
+    pair_style = base_pair_style + "/long";
+    update_pair_style(pair_style,pair_cut_coul);
+    update_kspace_style("ewald",acc_str);
   } else if (niter == 2) {
     // test PPPM
     store_old_kspace_settings();
-    strcpy(new_kspace_style,"pppm");
-    snprintf(new_pair_style,64,"%s/long",base_pair_style);
-    update_pair_style(new_pair_style,pair_cut_coul);
-    update_kspace_style(new_kspace_style,new_acc_str);
-  } else if (niter == 3) {
+    pair_style = base_pair_style + "/long";
+    update_pair_style(pair_style,pair_cut_coul);
+    update_kspace_style("pppm",acc_str);
+  } else if (has_msm && (niter == 3)) {
     // test MSM
     store_old_kspace_settings();
-    strcpy(new_kspace_style,"msm");
-    snprintf(new_pair_style,64,"%s/msm",base_pair_style);
-    update_pair_style(new_pair_style,pair_cut_coul);
-    update_kspace_style(new_kspace_style,new_acc_str);
+    pair_style = base_pair_style + "/msm";
+    update_pair_style(pair_style,pair_cut_coul);
+    update_kspace_style("msm",acc_str);
   } else if (niter == 4) {
     store_old_kspace_settings();
     if (comm->me == 0)
@@ -156,16 +158,17 @@ void FixTuneKspace::pre_exchange()
                                      "msm_time = {}\n",
                                      ewald_time, pppm_time, msm_time));
     // switch to fastest one
-    strcpy(new_kspace_style,"ewald");
-    snprintf(new_pair_style,64,"%s/long",base_pair_style);
+    if (msm_time == 0.0) msm_time = 1.0e300;
+    kspace_style = "ewald";
+    pair_style = base_pair_style + "/long";
     if (pppm_time < ewald_time && pppm_time < msm_time)
-      strcpy(new_kspace_style,"pppm");
+      kspace_style = "pppm";
     else if (msm_time < pppm_time && msm_time < ewald_time) {
-      strcpy(new_kspace_style,"msm");
-      snprintf(new_pair_style,64,"%s/msm",base_pair_style);
+      kspace_style = "msm";
+      pair_style = base_pair_style + "/msm";
     }
-    update_pair_style(new_pair_style,pair_cut_coul);
-    update_kspace_style(new_kspace_style,new_acc_str);
+    update_pair_style(pair_style,pair_cut_coul);
+    update_kspace_style(kspace_style,acc_str);
   } else {
     adjust_rcut(time);
   }
@@ -207,30 +210,26 @@ double FixTuneKspace::get_timing_info()
 
 void FixTuneKspace::store_old_kspace_settings()
 {
-  int n = strlen(force->kspace_style) + 1;
-  char *old_kspace_style = new char[n];
-  strcpy(old_kspace_style,force->kspace_style);
-  strcpy(new_kspace_style,old_kspace_style);
-  double old_acc = force->kspace->accuracy_relative;
-  char old_acc_str[16];
-  snprintf(old_acc_str,16,"%g",old_acc);
-  strcpy(new_pair_style,force->pair_style);
-  strcpy(base_pair_style,force->pair_style);
-  char *trunc;
-  if ((trunc = strstr(base_pair_style, "/long")) != NULL) *trunc = '\0';
-  if ((trunc = strstr(base_pair_style, "/msm" )) != NULL) *trunc = '\0';
+  kspace_style = force->kspace_style;
+  pair_style = force->pair_style;
+
+  std::size_t found;
+  if (std::string::npos != (found = pair_style.rfind("/long")))
+    base_pair_style = pair_style.substr(0,found);
+  else if (std::string::npos != (found = pair_style.rfind("/msm")))
+    base_pair_style = pair_style.substr(0,found);
+  else base_pair_style = pair_style;
 
   old_differentiation_flag = force->kspace->differentiation_flag;
   old_slabflag = force->kspace->slabflag;
   old_slab_volfactor = force->kspace->slab_volfactor;
-  delete[] old_kspace_style;
 }
 
 /* ----------------------------------------------------------------------
    update the pair style if necessary, preserving the settings
 ------------------------------------------------------------------------- */
 
-void FixTuneKspace::update_pair_style(char *new_pair_style,
+void FixTuneKspace::update_pair_style(const std::string &new_pair_style,
                                       double pair_cut_coul)
 {
   int itmp;
@@ -238,7 +237,7 @@ void FixTuneKspace::update_pair_style(char *new_pair_style,
   *p_cutoff = pair_cut_coul;
 
   // check to see if we need to change pair styles
-  if (strcmp(new_pair_style,force->pair_style) == 0) return;
+  if (new_pair_style == force->pair_style) return;
 
   // create a temporary file to store current pair settings
   FILE *p_pair_settings_file;
@@ -247,8 +246,9 @@ void FixTuneKspace::update_pair_style(char *new_pair_style,
   rewind(p_pair_settings_file);
   if (comm->me == 0)
     utils::logmesg(lmp,fmt::format("Creating new pair style: {}\n",new_pair_style));
+
   // delete old pair style and create new one
-  force->create_pair(new_pair_style,1);
+  force->create_pair(new_pair_style.c_str(),1);
 
   // restore current pair settings from temporary file
   force->pair->read_restart(p_pair_settings_file);
@@ -267,26 +267,14 @@ void FixTuneKspace::update_pair_style(char *new_pair_style,
    update the kspace style if necessary
 ------------------------------------------------------------------------- */
 
-void FixTuneKspace::update_kspace_style(char *new_kspace_style,
-                                        char *new_acc_str)
+void FixTuneKspace::update_kspace_style(const std::string &new_kspace_style,
+                                        const std::string &new_acc_str)
 {
-  // create kspace style char string
-
-  int narg = 2;
-  char **arg;
-  arg = NULL;
-  int maxarg = 100;
-  arg = (char **) memory->srealloc(arg,maxarg*sizeof(char *),"tune/kspace:arg");
-  int n = 12;
-  arg[0] = new char[n];
-  strcpy(arg[0],new_kspace_style);
-  arg[1] = new char[n];
-  strcpy(arg[1],new_acc_str);
-
   // delete old kspace style and create new one
 
-  force->create_kspace(arg[0],1);
-  force->kspace->settings(narg-1,&arg[1]);
+  char *tmp_acc_str = (char *)new_acc_str.c_str();
+  force->create_kspace(new_kspace_style.c_str(),1);
+  force->kspace->settings(1,&tmp_acc_str);
   force->kspace->differentiation_flag = old_differentiation_flag;
   force->kspace->slabflag = old_slabflag;
   force->kspace->slab_volfactor = old_slab_volfactor;
@@ -305,8 +293,6 @@ void FixTuneKspace::update_kspace_style(char *new_kspace_style,
   // Re-init computes to update pointers to virials, etc.
 
   for (int i = 0; i < modify->ncompute; i++) modify->compute[i]->init();
-
-  memory->sfree(arg);
 }
 
 /* ----------------------------------------------------------------------
@@ -315,7 +301,7 @@ void FixTuneKspace::update_kspace_style(char *new_kspace_style,
 
 void FixTuneKspace::adjust_rcut(double time)
 {
-  if (strcmp(force->kspace_style,"msm") == 0) return;
+  if (utils::strmatch(force->kspace_style,"^msm")) return;
   if (converged) return;
 
   double temp;
@@ -401,8 +387,8 @@ void FixTuneKspace::adjust_rcut(double time)
     utils::logmesg(lmp,fmt::format("Adjusted Coulomb cutoff for real space: {}\n", current_cutoff));
 
   store_old_kspace_settings();
-  update_pair_style(new_pair_style,pair_cut_coul);
-  update_kspace_style(new_kspace_style,new_acc_str);
+  update_pair_style(pair_style,pair_cut_coul);
+  update_kspace_style(kspace_style,acc_str);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/fix_tune_kspace.h
+++ b/src/KSPACE/fix_tune_kspace.h
@@ -21,6 +21,7 @@ FixStyle(tune/kspace,FixTuneKspace)
 #define LMP_FIX_TUNE_KSPACE_H
 
 #include "fix.h"
+#include <string>
 
 namespace LAMMPS_NS {
 
@@ -33,8 +34,8 @@ class FixTuneKspace : public Fix {
   void pre_exchange();
   double get_timing_info();
   void store_old_kspace_settings();
-  void update_pair_style(char *, double);
-  void update_kspace_style(char *, char *);
+  void update_pair_style(const std::string &, double);
+  void update_kspace_style(const std::string &, const std::string &);
   void adjust_rcut(double);
   void mnbrak();
   void brent0();
@@ -51,10 +52,10 @@ class FixTuneKspace : public Fix {
 
   double ewald_time,pppm_time,msm_time;
   double pair_cut_coul;
-  char new_acc_str[16];
-  char new_kspace_style[64];
-  char new_pair_style[64];
-  char base_pair_style[64];
+  std::string acc_str;
+  std::string kspace_style;
+  std::string pair_style;
+  std::string base_pair_style;
 
   int old_differentiation_flag;
   int old_slabflag;

--- a/src/MC/fix_bond_create_angle.cpp
+++ b/src/MC/fix_bond_create_angle.cpp
@@ -34,13 +34,8 @@ FixBondCreateAngle::FixBondCreateAngle(LAMMPS *lmp, int narg, char **arg) :
 int FixBondCreateAngle::constrain(int i, int j, double amin, double amax)
 {
   double **x = atom->x;
-  tagint *tag = atom->tag;
-  tagint **bond_atom = atom->bond_atom;
-  int *num_bond = atom->num_bond;
   int **nspecial = atom->nspecial;
   tagint **special = atom->special;
-  int *mask = atom->mask;
-  int *type = atom->type;
 
   double v1x = 0.0;
   double v1y = 0.0;

--- a/src/MLIAP/compute_mliap.cpp
+++ b/src/MLIAP/compute_mliap.cpp
@@ -247,11 +247,9 @@ void ComputeMLIAP::compute_array()
   for (int ielem = 0; ielem < data->nelements; ielem++) {
     const int elemoffset = data->nparams*ielem;
     for (int jparam = 0; jparam < data->nparams; jparam++) {
-      int irow = 1;
       for (int i = 0; i < ntotal; i++) {
         double *gradforcei = data->gradforce[i]+elemoffset;
-        int iglobal = atom->tag[i];
-        int irow = 3*(iglobal-1)+1;
+        tagint irow = 3*(atom->tag[i]-1)+1;
         mliaparray[irow][jparam+elemoffset] += gradforcei[jparam];
         mliaparray[irow+1][jparam+elemoffset] += gradforcei[jparam+data->yoffset];
         mliaparray[irow+2][jparam+elemoffset] += gradforcei[jparam+data->zoffset];

--- a/src/MLIAP/mliap_data.cpp
+++ b/src/MLIAP/mliap_data.cpp
@@ -32,16 +32,14 @@
 
 using namespace LAMMPS_NS;
 
-MLIAPData::MLIAPData(LAMMPS *lmp,
-                     int gradgradflag_in, int *map_in, class MLIAPModel* model_in,
-                     class MLIAPDescriptor* descriptor_in, class PairMLIAP* pairmliap_in) :
-  Pointers(lmp),
-  list(NULL),
-  gradforce(NULL),
-  betas(NULL), descriptors(NULL), gamma_row_index(NULL), gamma_col_index(NULL),
-  gamma(NULL), egradient(NULL), model(NULL), descriptor(NULL),
-  iatoms(NULL), ielems(NULL), numneighs(NULL),
-  jatoms(NULL), jelems(NULL), rij(NULL), graddesc(NULL)
+MLIAPData::MLIAPData(LAMMPS *lmp, int gradgradflag_in, int *map_in,
+                     class MLIAPModel* model_in,
+                     class MLIAPDescriptor* descriptor_in,
+                     class PairMLIAP* pairmliap_in) :
+  Pointers(lmp), gradforce(NULL), betas(NULL), descriptors(NULL), gamma(NULL),
+  gamma_row_index(NULL), gamma_col_index(NULL), egradient(NULL),
+  numneighs(NULL), iatoms(NULL), ielems(NULL), jatoms(NULL), jelems(NULL),
+  rij(NULL), graddesc(NULL), model(NULL), descriptor(NULL), list(NULL)
 {
   gradgradflag = gradgradflag_in;
   map = map_in;

--- a/src/MLIAP/mliap_data.h
+++ b/src/MLIAP/mliap_data.h
@@ -68,8 +68,8 @@ class MLIAPData : protected Pointers {
   class PairMLIAP *pairmliap;   // access to pair tally functions
 
  private:
-  class MLIAPModel* model;
-  class MLIAPDescriptor* descriptor;
+  class MLIAPModel *model;
+  class MLIAPDescriptor *descriptor;
 
   int nmax;
   class NeighList *list;        // LAMMPS neighbor list

--- a/src/MLIAP/mliap_descriptor_snap.cpp
+++ b/src/MLIAP/mliap_descriptor_snap.cpp
@@ -76,12 +76,8 @@ MLIAPDescriptorSNAP::~MLIAPDescriptorSNAP()
 
 void MLIAPDescriptorSNAP::compute_descriptors(class MLIAPData* data)
 {
-
-  double **x = atom->x;
-
   int ij = 0;
   for (int ii = 0; ii < data->natoms; ii++) {
-    const int i = data->iatoms[ii];
     const int ielem = data->ielems[ii];
 
     // insure rij, inside, wj, and rcutij are of size jnum
@@ -130,8 +126,6 @@ void MLIAPDescriptorSNAP::compute_descriptors(class MLIAPData* data)
 void MLIAPDescriptorSNAP::compute_forces(class MLIAPData* data)
 {
   double fij[3];
-
-  double **x = atom->x;
   double **f = atom->f;
 
   int ij = 0;
@@ -208,8 +202,6 @@ void MLIAPDescriptorSNAP::compute_forces(class MLIAPData* data)
 
 void MLIAPDescriptorSNAP::compute_force_gradients(class MLIAPData* data)
 {
-  double **x = atom->x;
-
   int ij = 0;
   for (int ii = 0; ii < data->natoms; ii++) {
     const int i = data->iatoms[ii];
@@ -285,11 +277,8 @@ void MLIAPDescriptorSNAP::compute_force_gradients(class MLIAPData* data)
 
 void MLIAPDescriptorSNAP::compute_descriptor_gradients(class MLIAPData* data)
 {
-  double **x = atom->x;
-
   int ij = 0;
   for (int ii = 0; ii < data->natoms; ii++) {
-    const int i = data->iatoms[ii];
     const int ielem = data->ielems[ii];
 
     // insure rij, inside, wj, and rcutij are of size jnum
@@ -328,8 +317,6 @@ void MLIAPDescriptorSNAP::compute_descriptor_gradients(class MLIAPData* data)
 
     ij = ij0;
     for (int jj = 0; jj < ninside; jj++) {
-      const int j = snaptr->inside[jj];
-
       if(chemflag)
         snaptr->compute_duidrj(snaptr->rij[jj], snaptr->wj[jj],
                                snaptr->rcutij[jj],jj, snaptr->element[jj]);

--- a/src/MLIAP/mliap_model_linear.cpp
+++ b/src/MLIAP/mliap_model_linear.cpp
@@ -102,7 +102,6 @@ void MLIAPModelLinear::compute_gradgrads(class MLIAPData* data)
     data->egradient[l] = 0.0;
 
   for (int ii = 0; ii < data->natoms; ii++) {
-    const int i = data->iatoms[ii];
     const int ielem = data->ielems[ii];
     const int elemoffset = data->nparams*ielem;
 
@@ -145,8 +144,6 @@ void MLIAPModelLinear::compute_force_gradients(class MLIAPData* data)
 
     for (int jj = 0; jj < data->numneighs[ii]; jj++) {
       const int j = data->jatoms[ij];
-      const int jelem = data->ielems[ij];
-
       int l = elemoffset+1;
       for (int icoeff = 0; icoeff < data->ndescriptors; icoeff++) {
         data->gradforce[i][l]         += data->graddesc[ij][icoeff][0];

--- a/src/MLIAP/mliap_model_quadratic.cpp
+++ b/src/MLIAP/mliap_model_quadratic.cpp
@@ -127,7 +127,6 @@ void MLIAPModelQuadratic::compute_gradgrads(class MLIAPData* data)
     data->egradient[l] = 0.0;
 
   for (int ii = 0; ii < data->natoms; ii++) {
-    const int i = data->iatoms[ii];
     const int ielem = data->ielems[ii];
     const int elemoffset = data->nparams*ielem;
 
@@ -216,9 +215,6 @@ void MLIAPModelQuadratic::compute_force_gradients(class MLIAPData* data) {
 
     for (int jj = 0; jj < data->numneighs[ii]; jj++) {
       const int j = data->jatoms[ij];
-      const int jelem = data->ielems[ij];
-      const int ij0 = ij;
-
       int l = elemoffset+1;
       for (int icoeff = 0; icoeff < data->ndescriptors; icoeff++) {
         data->gradforce[i][l]               += data->graddesc[ij][icoeff][0];

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -310,7 +310,7 @@ void DihedralCharmm::allocate()
   int n = atom->ndihedraltypes;
 
   memory->create(k,n+1,"dihedral:k");
-  memory->create(multiplicity,n+1,"dihedral:k");
+  memory->create(multiplicity,n+1,"dihedral:multiplicity");
   memory->create(shift,n+1,"dihedral:shift");
   memory->create(cos_shift,n+1,"dihedral:cos_shift");
   memory->create(sin_shift,n+1,"dihedral:sin_shift");

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -328,7 +328,7 @@ void DihedralCharmmfsw::allocate()
   int n = atom->ndihedraltypes;
 
   memory->create(k,n+1,"dihedral:k");
-  memory->create(multiplicity,n+1,"dihedral:k");
+  memory->create(multiplicity,n+1,"dihedral:multiplicity");
   memory->create(shift,n+1,"dihedral:shift");
   memory->create(cos_shift,n+1,"dihedral:cos_shift");
   memory->create(sin_shift,n+1,"dihedral:sin_shift");

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -359,7 +359,7 @@ void PythonImpl::invoke_function(int ifunc, char *result)
 
 /* ------------------------------------------------------------------ */
 
-int PythonImpl::find(char *name)
+int PythonImpl::find(const char *name)
 {
   for (int i = 0; i < nfunc; i++)
     if (strcmp(name,pfuncs[i].name) == 0) return i;
@@ -368,7 +368,8 @@ int PythonImpl::find(char *name)
 
 /* ------------------------------------------------------------------ */
 
-int PythonImpl::variable_match(char *name, char *varname, int numeric)
+int PythonImpl::variable_match(const char *name, const char *varname,
+                               int numeric)
 {
   int ifunc = find(name);
   if (ifunc < 0) return -1;

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -410,7 +410,7 @@ int PythonImpl::create_entry(char *name)
 
   if (!format && ninput+noutput)
     error->all(FLERR,"Invalid python command");
-  else if (format && strlen(format) != ninput+noutput)
+  else if (format && ((int) strlen(format) != ninput+noutput))
     error->all(FLERR,"Invalid python command");
 
   // process inputs as values or variables

--- a/src/PYTHON/python_impl.h
+++ b/src/PYTHON/python_impl.h
@@ -27,8 +27,8 @@ class PythonImpl : protected Pointers, public PythonInterface {
   ~PythonImpl();
   void command(int, char **);
   void invoke_function(int, char *);
-  int find(char *);
-  int variable_match(char *, char *, int);
+  int find(const char *);
+  int variable_match(const char *, const char *, int);
   char *long_string(int);
   int execute_string(char *);
   int execute_file(char *);

--- a/src/USER-MISC/angle_cosine_shift.cpp
+++ b/src/USER-MISC/angle_cosine_shift.cpp
@@ -156,11 +156,11 @@ void AngleCosineShift::allocate()
   allocated = 1;
   int n = atom->nangletypes;
 
-  memory->create(k      ,n+1,"Angle:k");
-  memory->create(ksint  ,n+1,"Angle:ksint");
-  memory->create(kcost  ,n+1,"Angle:kcost");
-  memory->create(theta  ,n+1,"Angle:theta");
-  memory->create(setflag,n+1, "Angle:setflag");
+  memory->create(k,n+1,"angle:k");
+  memory->create(ksint,n+1,"angle:ksint");
+  memory->create(kcost,n+1,"angle:kcost");
+  memory->create(theta,n+1,"angle:theta");
+  memory->create(setflag,n+1,"angle:setflag");
 
   for (int i = 1; i <= n; i++) setflag[i] = 0;
 }

--- a/src/USER-MISC/bond_harmonic_shift.cpp
+++ b/src/USER-MISC/bond_harmonic_shift.cpp
@@ -110,9 +110,9 @@ void BondHarmonicShift::allocate()
   allocated = 1;
   int n = atom->nbondtypes;
 
-  memory->create(k ,    n+1,"bond:k");
-  memory->create(r0,    n+1,"bond:r0");
-  memory->create(r1,    n+1,"bond:r1");
+  memory->create(k,n+1,"bond:k");
+  memory->create(r0,n+1,"bond:r0");
+  memory->create(r1,n+1,"bond:r1");
   memory->create(setflag,n+1,"bond:setflag");
 
   for (int i = 1; i <= n; i++) setflag[i] = 0;

--- a/src/VORONOI/compute_voronoi_atom.cpp
+++ b/src/VORONOI/compute_voronoi_atom.cpp
@@ -511,7 +511,7 @@ void ComputeVoronoi::processCell(voronoicell_neighbor &c, int i)
       c.face_areas(narea);
       have_narea = true;
       voro[i][1] = 0.0;
-      for (j=0; j<narea.size(); ++j)
+      for (j=0; j < (int)narea.size(); ++j)
         if (narea[j] > fthresh) voro[i][1] += 1.0;
     } else {
       // unthresholded face count
@@ -526,7 +526,7 @@ void ComputeVoronoi::processCell(voronoicell_neighbor &c, int i)
       voro[i][2] = 0.0;
 
       // each entry in neigh should correspond to an entry in narea
-      if (neighs != narea.size())
+      if (neighs != (int)narea.size())
         error->one(FLERR,"Voro++ error: narea and neigh have a different size");
 
       // loop over all faces (neighbors) and check if they are in the surface group
@@ -587,7 +587,7 @@ void ComputeVoronoi::processCell(voronoicell_neighbor &c, int i)
 
       if (!have_narea) c.face_areas(narea);
 
-      if (neighs != narea.size())
+      if (neighs != (int)narea.size())
         error->one(FLERR,"Voro++ error: narea and neigh have a different size");
       tagint itag, jtag;
       tagint *tag = atom->tag;

--- a/src/fmt/format.h
+++ b/src/fmt/format.h
@@ -74,7 +74,7 @@
 #endif
 
 #if __cplusplus == 201103L || __cplusplus == 201402L
-#  if defined(__clang__)
+#  if defined(__clang__) && !defined(__INTEL_COMPILER)
 #    define FMT_FALLTHROUGH [[clang::fallthrough]]
 #  elif FMT_GCC_VERSION >= 700 && !defined(__PGI) && !defined(__INTEL_COMPILER)
 #    define FMT_FALLTHROUGH [[gnu::fallthrough]]

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -584,10 +584,10 @@ void Group::create(char *name, int *flag)
    return group index if name matches existing group, -1 if no such group
 ------------------------------------------------------------------------- */
 
-int Group::find(const char *name)
+int Group::find(const std::string &name)
 {
   for (int igroup = 0; igroup < MAX_GROUP; igroup++)
-    if (names[igroup] && strcmp(name,names[igroup]) == 0) return igroup;
+    if (names[igroup] && (name == names[igroup])) return igroup;
   return -1;
 }
 

--- a/src/group.h
+++ b/src/group.h
@@ -33,7 +33,7 @@ class Group : protected Pointers {
   void assign(int, char **);         // assign atoms to a group
   void assign(const std::string &);  // convenience function
   void create(char *, int *);        // add flagged atoms to a group
-  int find(const char *);            // lookup name in list of groups
+  int find(const std::string &);     // lookup name in list of groups
   int find_or_create(const char *);  // lookup name or create new group
   void write_restart(FILE *);
   void read_restart(FILE *);

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -198,7 +198,7 @@ class KSpace : protected Pointers {
   void pair_check();
   void ev_init(int eflag, int vflag, int alloc = 1) {
     if (eflag||vflag) ev_setup(eflag, vflag, alloc);
-    else evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom = 0;
+    else evflag = evflag_atom = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom = 0;
   }
   void ev_setup(int, int, int alloc = 1);
   double estimate_table_accuracy(double, double);

--- a/src/lmppython.cpp
+++ b/src/lmppython.cpp
@@ -80,7 +80,7 @@ void Python::invoke_function(int ifunc, char *result)
 
 /* ------------------------------------------------------------------ */
 
-int Python::find(char *name)
+int Python::find(const char *name)
 {
   init();
   return impl->find(name);
@@ -88,7 +88,7 @@ int Python::find(char *name)
 
 /* ------------------------------------------------------------------ */
 
-int Python::variable_match(char *name, char *varname, int numeric)
+int Python::variable_match(const char *name, const char *varname, int numeric)
 {
   init();
   return impl->variable_match(name, varname, numeric);

--- a/src/lmppython.h
+++ b/src/lmppython.h
@@ -23,9 +23,9 @@ public:
   virtual ~PythonInterface();
   virtual void command(int, char **) = 0;
   virtual void invoke_function(int, char *) = 0;
-  virtual int find(char *) = 0;
-  virtual int variable_match(char *, char *, int) = 0;
-  virtual char * long_string(int ifunc) = 0;
+  virtual int find(const char *) = 0;
+  virtual int variable_match(const char *, const char *, int) = 0;
+  virtual char *long_string(int ifunc) = 0;
   virtual int execute_string(char *) = 0;
   virtual int execute_file(char *) = 0;
   virtual bool has_minimum_version(int major, int minor) = 0;
@@ -38,8 +38,8 @@ public:
 
   void command(int, char **);
   void invoke_function(int, char *);
-  int find(char *);
-  int variable_match(char *, char *, int);
+  int find(const char *);
+  int variable_match(const char *, const char *, int);
   char * long_string(int ifunc);
   int execute_string(char *);
   int execute_file(char *);

--- a/src/nbin.cpp
+++ b/src/nbin.cpp
@@ -26,10 +26,12 @@ using namespace LAMMPS_NS;
 NBin::NBin(LAMMPS *lmp) : Pointers(lmp)
 {
   last_bin = -1;
-  maxbin = maxatom = 0;
+  mbins = maxbin = maxatom = 0;
   binhead = NULL;
   bins = NULL;
   atom2bin = NULL;
+
+  neighbor->last_setup_bins = -1;
 
   // geometry settings
 

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -2078,6 +2078,7 @@ void Neighbor::build(int topoflag)
   //   leading to errors or even a crash
 
   if (style != Neighbor::NSQ) {
+    if (last_setup_bins < 0) setup_bins();
     for (int i = 0; i < nbin; i++) {
       neigh_bin[i]->bin_atoms_setup(nall);
       neigh_bin[i]->bin_atoms();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -436,6 +436,7 @@ std::vector<std::string> utils::split_words(const std::string &text)
   const char *buf = text.c_str();
   std::size_t beg = 0;
   std::size_t len = 0;
+  std::size_t add = 0;
   char c = *buf;
 
   while (c) {
@@ -452,8 +453,9 @@ std::vector<std::string> utils::split_words(const std::string &text)
 
     // handle single quote
     if (c == '\'') {
+      ++beg;
+      add = 1;
       c = *++buf;
-      ++len;
       while (((c != '\'') && (c != '\0'))
              || ((c == '\\') && (buf[1] == '\''))) {
         if ((c == '\\') && (buf[1] == '\'')) {
@@ -463,13 +465,14 @@ std::vector<std::string> utils::split_words(const std::string &text)
         c = *++buf;
         ++len;
       }
+      if (c != '\'') ++len;
       c = *++buf;
-      ++len;
 
       // handle double quote
     } else if (c == '"') {
+      ++beg;
+      add = 1;
       c = *++buf;
-      ++len;
       while (((c != '"') && (c != '\0'))
              || ((c == '\\') && (buf[1] == '"'))) {
         if ((c == '\\') && (buf[1] == '"')) {
@@ -479,8 +482,8 @@ std::vector<std::string> utils::split_words(const std::string &text)
         c = *++buf;
         ++len;
       }
+      if (c != '"') ++len;
       c = *++buf;
-      ++len;
     }
 
     // unquoted
@@ -496,7 +499,7 @@ std::vector<std::string> utils::split_words(const std::string &text)
       if ((c == ' ') || (c == '\t') || (c == '\r') || (c == '\n')
           || (c == '\f') || (c == '\0')) {
           list.push_back(text.substr(beg,len));
-          beg += len;
+          beg += len + add;
           break;
       }
       c = *++buf;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -752,9 +752,9 @@ int Variable::next(int narg, char **arg)
    return index or -1 if not found
 ------------------------------------------------------------------------- */
 
-int Variable::find(char *name)
+int Variable::find(const char *name)
 {
-  if(name==NULL) return -1;
+  if (name == nullptr) return -1;
   for (int i = 0; i < nvar; i++)
     if (strcmp(name,names[i]) == 0) return i;
   return -1;
@@ -864,7 +864,7 @@ int Variable::internalstyle(int ivar)
      caller must respond
 ------------------------------------------------------------------------- */
 
-char *Variable::retrieve(char *name)
+char *Variable::retrieve(const char *name)
 {
   int ivar = find(name);
   if (ivar < 0) return NULL;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -4221,12 +4221,13 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
       if (eval_in_progress[ivar])
         print_var_error(FLERR,"Variable has circular dependency",ivar);
 
-      if ((method == AVE) && (nvec == 0))
-        print_var_error(FLERR,"Cannot compute average of empty vector",ivar);
-
       double *vec;
       nvec = compute_vector(ivar,&vec);
       nstride = 1;
+
+      if ((method == AVE) && (nvec == 0))
+        print_var_error(FLERR,"Cannot compute average of empty vector",ivar);
+
 
     } else print_var_error(FLERR,"Invalid special function in "
                            "variable formula",ivar);

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -541,6 +541,22 @@ void Variable::set(int narg, char **arg)
 }
 
 /* ----------------------------------------------------------------------
+   convenience function to allow defining a variable from a single string
+------------------------------------------------------------------------- */
+
+void Variable::set(const std::string &setcmd)
+{
+  std::vector<std::string> args = utils::split_words(setcmd);
+  char **newarg = new char*[args.size()];
+  int i=0;
+  for (const auto &arg : args) {
+    newarg[i++] = (char *)arg.c_str();
+  }
+  set(args.size(),newarg);
+  delete[] newarg;
+}
+
+/* ----------------------------------------------------------------------
    INDEX variable created by command-line argument
    make it INDEX rather than STRING so cannot be re-defined in input script
 ------------------------------------------------------------------------- */

--- a/src/variable.h
+++ b/src/variable.h
@@ -29,7 +29,7 @@ class Variable : protected Pointers {
   int set_string(char *, char *);
   int next(int, char **);
 
-  int find(char *);
+  int find(const char *);
   void set_arrays(int);
   void python_command(int, char **);
 
@@ -39,7 +39,7 @@ class Variable : protected Pointers {
   char *pythonstyle(char *, char *);
   int internalstyle(int);
 
-  char *retrieve(char *);
+  char *retrieve(const char *);
   double compute_equal(int);
   double compute_equal(char *);
   void compute_atom(int, int, double *, int, int);

--- a/src/variable.h
+++ b/src/variable.h
@@ -24,6 +24,7 @@ class Variable : protected Pointers {
  public:
   Variable(class LAMMPS *);
   ~Variable();
+  void set(const std::string &);
   void set(int, char **);
   void set(char *, int, char **);
   int set_string(char *, char *);

--- a/unittest/commands/test_reset_ids.cpp
+++ b/unittest/commands/test_reset_ids.cpp
@@ -500,7 +500,7 @@ TEST(ResetMolIds, CMDFail)
     lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
-    TEST_FAILURE(".*ERROR: Reset_mol_ids command before box is.*",
+    TEST_FAILURE(".*ERROR: Reset_mol_ids command before simulation box is.*",
                  lmp->input->one("reset_mol_ids all"););
 
     if (!verbose) ::testing::internal::CaptureStdout();

--- a/unittest/commands/test_simple_commands.cpp
+++ b/unittest/commands/test_simple_commands.cpp
@@ -297,7 +297,7 @@ TEST_F(SimpleCommandsTest, Units)
     ASSERT_EQ(num, sizeof(dt) / sizeof(double));
 
     ASSERT_THAT(lmp->update->unit_style, StrEq("lj"));
-    for (int i = 0; i < num; ++i) {
+    for (std::size_t i = 0; i < num; ++i) {
         if (!verbose) ::testing::internal::CaptureStdout();
         lmp->input->one(fmt::format("units {}", names[i]));
         if (!verbose) ::testing::internal::GetCapturedStdout();

--- a/unittest/commands/test_simple_commands.cpp
+++ b/unittest/commands/test_simple_commands.cpp
@@ -30,6 +30,12 @@
 // whether to print verbose output (i.e. not capturing LAMMPS screen output).
 bool verbose = false;
 
+#if defined(OMPI_MAJOR_VERSION)
+const bool have_openmpi = true;
+#else
+const bool have_openmpi = false;
+#endif
+
 using LAMMPS_NS::utils::split_words;
 
 namespace LAMMPS_NS {
@@ -37,11 +43,19 @@ using ::testing::ExitedWithCode;
 using ::testing::MatchesRegex;
 using ::testing::StrEq;
 
-#define TEST_FAILURE(...)                \
-    if (Info::has_exceptions()) {        \
-        ASSERT_ANY_THROW({__VA_ARGS__}); \
-    } else {                             \
-        ASSERT_DEATH({__VA_ARGS__}, ""); \
+#define TEST_FAILURE(errmsg, ...)                                 \
+    if (Info::has_exceptions()) {                                 \
+        ::testing::internal::CaptureStdout();                     \
+        ASSERT_ANY_THROW({__VA_ARGS__});                          \
+        auto mesg = ::testing::internal::GetCapturedStdout();     \
+        ASSERT_THAT(mesg, MatchesRegex(errmsg));                  \
+    } else {                                                      \
+        if (!have_openmpi) {                                      \
+            ::testing::internal::CaptureStdout();                 \
+            ASSERT_DEATH({__VA_ARGS__}, "");                      \
+            auto mesg = ::testing::internal::GetCapturedStdout(); \
+            ASSERT_THAT(mesg, MatchesRegex(errmsg));              \
+        }                                                         \
     }
 
 class SimpleCommandsTest : public ::testing::Test {
@@ -68,10 +82,7 @@ protected:
 
 TEST_F(SimpleCommandsTest, UnknownCommand)
 {
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("XXX one two three"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Unknown command.*"));
+    TEST_FAILURE(".*ERROR: Unknown command.*", lmp->input->one("XXX one two"););
 }
 
 TEST_F(SimpleCommandsTest, Echo)
@@ -103,15 +114,8 @@ TEST_F(SimpleCommandsTest, Echo)
     ASSERT_EQ(lmp->input->echo_screen, 0);
     ASSERT_EQ(lmp->input->echo_log, 1);
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("echo"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex("^ERROR: Illegal echo command.*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("echo xxx"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex("^ERROR: Illegal echo command.*"));
+    TEST_FAILURE(".*ERROR: Illegal echo command.*", lmp->input->one("echo"););
+    TEST_FAILURE(".*ERROR: Illegal echo command.*", lmp->input->one("echo xxx"););
 }
 
 TEST_F(SimpleCommandsTest, Log)
@@ -154,24 +158,20 @@ TEST_F(SimpleCommandsTest, Log)
     in.close();
     remove("simple_command_test.log");
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("log"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal log command.*"));
+    TEST_FAILURE(".*ERROR: Illegal log command.*", lmp->input->one("log"););
 }
 
 TEST_F(SimpleCommandsTest, Quit)
 {
     ::testing::internal::CaptureStdout();
     lmp->input->one("echo none");
-    TEST_FAILURE(lmp->input->one("quit xxx"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Expected integer .*"));
+    ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: Expected integer .*", lmp->input->one("quit xxx"););
 
-#if !defined(OMPI_MAJOR_VERSION) // this stalls with OpenMPI. skip.
+    // the following tests must be skipped with OpenMPI due to using threads
+    if (have_openmpi) GTEST_SKIP();
     ASSERT_EXIT(lmp->input->one("quit"), ExitedWithCode(0), "");
     ASSERT_EXIT(lmp->input->one("quit 9"), ExitedWithCode(9), "");
-#endif
 }
 
 TEST_F(SimpleCommandsTest, ResetTimestep)
@@ -188,25 +188,10 @@ TEST_F(SimpleCommandsTest, ResetTimestep)
     if (!verbose) ::testing::internal::GetCapturedStdout();
     ASSERT_EQ(lmp->update->ntimestep, 0);
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("reset_timestep -10"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Timestep must be >= 0.*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("reset_timestep"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal reset_timestep .*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("reset_timestep 10 10"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal reset_timestep .*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("reset_timestep xxx"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Expected integer .*"));
+    TEST_FAILURE(".*ERROR: Timestep must be >= 0.*", lmp->input->one("reset_timestep -10"););
+    TEST_FAILURE(".*ERROR: Illegal reset_timestep .*", lmp->input->one("reset_timestep"););
+    TEST_FAILURE(".*ERROR: Illegal reset_timestep .*", lmp->input->one("reset_timestep 10 10"););
+    TEST_FAILURE(".*ERROR: Expected integer .*", lmp->input->one("reset_timestep xxx"););
 }
 
 TEST_F(SimpleCommandsTest, Suffix)
@@ -215,10 +200,8 @@ TEST_F(SimpleCommandsTest, Suffix)
     ASSERT_EQ(lmp->suffix, nullptr);
     ASSERT_EQ(lmp->suffix2, nullptr);
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("suffix on"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: May only enable suffixes after defining one.*"));
+    TEST_FAILURE(".*ERROR: May only enable suffixes after defining one.*",
+                 lmp->input->one("suffix on"););
 
     if (!verbose) ::testing::internal::CaptureStdout();
     lmp->input->one("suffix one");
@@ -247,20 +230,9 @@ TEST_F(SimpleCommandsTest, Suffix)
     if (!verbose) ::testing::internal::GetCapturedStdout();
     ASSERT_EQ(lmp->suffix_enable, 1);
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("suffix"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal suffix command.*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("suffix hybrid"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal suffix command.*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("suffix hybrid one"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal suffix command.*"));
+    TEST_FAILURE(".*ERROR: Illegal suffix command.*", lmp->input->one("suffix"););
+    TEST_FAILURE(".*ERROR: Illegal suffix command.*", lmp->input->one("suffix hybrid"););
+    TEST_FAILURE(".*ERROR: Illegal suffix command.*", lmp->input->one("suffix hybrid one"););
 }
 
 TEST_F(SimpleCommandsTest, Thermo)
@@ -284,20 +256,9 @@ TEST_F(SimpleCommandsTest, Thermo)
     ASSERT_EQ(lmp->output->thermo_every, 10);
     ASSERT_EQ(lmp->output->var_thermo, nullptr);
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("thermo"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal thermo command.*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("thermo -1"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal thermo command.*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("thermo xxx"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Expected integer.*"));
+    TEST_FAILURE(".*ERROR: Illegal thermo command.*", lmp->input->one("thermo"););
+    TEST_FAILURE(".*ERROR: Illegal thermo command.*", lmp->input->one("thermo -1"););
+    TEST_FAILURE(".*ERROR: Expected integer.*", lmp->input->one("thermo xxx"););
 }
 
 TEST_F(SimpleCommandsTest, TimeStep)
@@ -324,15 +285,8 @@ TEST_F(SimpleCommandsTest, TimeStep)
     if (!verbose) ::testing::internal::GetCapturedStdout();
     ASSERT_EQ(lmp->update->dt, -0.1);
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("timestep"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal timestep command.*"));
-
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("timestep xxx"););
-    mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Expected floating point.*"));
+    TEST_FAILURE(".*ERROR: Illegal timestep command.*", lmp->input->one("timestep"););
+    TEST_FAILURE(".*ERROR: Expected floating point.*", lmp->input->one("timestep xxx"););
 }
 
 TEST_F(SimpleCommandsTest, Units)
@@ -356,10 +310,7 @@ TEST_F(SimpleCommandsTest, Units)
     if (!verbose) ::testing::internal::GetCapturedStdout();
     ASSERT_THAT(lmp->update->unit_style, StrEq("lj"));
 
-    ::testing::internal::CaptureStdout();
-    TEST_FAILURE(lmp->input->one("units unknown"););
-    auto mesg = ::testing::internal::GetCapturedStdout();
-    ASSERT_THAT(mesg, MatchesRegex(".*ERROR: Illegal units command.*"));
+    TEST_FAILURE(".*ERROR: Illegal units command.*", lmp->input->one("units unknown"););
 }
 } // namespace LAMMPS_NS
 
@@ -367,6 +318,10 @@ int main(int argc, char **argv)
 {
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
+
+    if (have_openmpi && !LAMMPS_NS::Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. "
+                     "Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/utils/test_utils.cpp
+++ b/unittest/utils/test_utils.cpp
@@ -21,13 +21,14 @@
 #include <vector>
 
 using namespace LAMMPS_NS;
-using ::testing::Eq;
 using ::testing::EndsWith;
+using ::testing::Eq;
+using ::testing::StrEq;
 
 TEST(Utils, trim_comment)
 {
     auto trimmed = utils::trim_comment("some text # comment");
-    ASSERT_THAT(trimmed, Eq("some text "));
+    ASSERT_THAT(trimmed, StrEq("some text "));
 }
 
 TEST(Utils, count_words)
@@ -59,24 +60,36 @@ TEST(Utils, split_words_simple)
 {
     std::vector<std::string> list = utils::split_words("one two three");
     ASSERT_EQ(list.size(), 3);
+    ASSERT_THAT(list[0], StrEq("one"));
+    ASSERT_THAT(list[1], StrEq("two"));
+    ASSERT_THAT(list[2], StrEq("three"));
 }
 
 TEST(Utils, split_words_quoted)
 {
     std::vector<std::string> list = utils::split_words("one 'two' \"three\"");
     ASSERT_EQ(list.size(), 3);
+    ASSERT_THAT(list[0], StrEq("one"));
+    ASSERT_THAT(list[1], StrEq("two"));
+    ASSERT_THAT(list[2], StrEq("three"));
 }
 
 TEST(Utils, split_words_escaped)
 {
     std::vector<std::string> list = utils::split_words("1\\' '\"two\"' 3\\\"");
     ASSERT_EQ(list.size(), 3);
+    ASSERT_THAT(list[0], StrEq("1\\'"));
+    ASSERT_THAT(list[1], StrEq("\"two\""));
+    ASSERT_THAT(list[2], StrEq("3\\\""));
 }
 
 TEST(Utils, split_words_quote_in_quoted)
 {
     std::vector<std::string> list = utils::split_words("one 't\\'wo' \"th\\\"ree\"");
     ASSERT_EQ(list.size(), 3);
+    ASSERT_THAT(list[0], StrEq("one"));
+    ASSERT_THAT(list[1], StrEq("t\\'wo"));
+    ASSERT_THAT(list[2], StrEq("th\\\"ree"));
 }
 
 TEST(Utils, valid_integer1)
@@ -334,13 +347,13 @@ TEST(Utils, strmatch_whitespace_nonwhitespace)
 TEST(Utils, guesspath)
 {
     char buf[256];
-    FILE *fp = fopen("test_guesspath.txt","w");
+    FILE *fp = fopen("test_guesspath.txt", "w");
 #if defined(__linux__)
-    const char *path = utils::guesspath(buf,sizeof(buf),fp);
-    ASSERT_THAT(path,EndsWith("test_guesspath.txt"));
+    const char *path = utils::guesspath(buf, sizeof(buf), fp);
+    ASSERT_THAT(path, EndsWith("test_guesspath.txt"));
 #else
-    const char *path = utils::guesspath(buf,sizeof(buf),fp);
-    ASSERT_THAT(path,EndsWith("(unknown)"));
+    const char *path = utils::guesspath(buf, sizeof(buf), fp);
+    ASSERT_THAT(path, EndsWith("(unknown)"));
 #endif
     fclose(fp);
 }


### PR DESCRIPTION
**Summary**

This pull request combines various small changes to silence compiler warnings, remove dead code and refactor APIs to make better and more efficient use of std::string.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues

**Implementation Notes**

The following individual changes are included:
- remove dead code in recently added or modified files
- some cosmetic changes. closes #2243 
- silence (some) compiler warnings about unused parameters
- make more use of const char * pointers in APIs so we need fewer const casts.
- skip death tests when using OpenMPI without exceptions
- workaround for using fmtlib with Intel compilers on MacOS
- refactor fix tune/kspace and fix some related initialization issues. make it suffix compatible. also make it work for pair styles that don't have MSM support.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
