### PR TITLE
Fix issue in pair_snap_kokkos

### DIFF
--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -405,7 +405,7 @@ void PairSNAPKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     {
       int team_size = team_size_default;
       int vector_length = vector_length_default;
-      if (eflag) {
+      if (evflag) {
         if (neighflag == HALF) {
           check_team_size_reduce<TagPairSNAPComputeForce<HALF,1> >(chunk_size,team_size,vector_length);
           typename Kokkos::TeamPolicy<DeviceType,TagPairSNAPComputeForce<HALF,1> > policy_force(chunk_size,team_size,vector_length);


### PR DESCRIPTION
**Summary**

The virial was only computed if the energy was also computed.

**Related Issues**

None

**Author(s)**

Stan Moore (SNL), reported by Jonathan Willman (USF)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes