### PR TITLE
Refactor parsing of input files in fix ttm and fix ttm/mod

### DIFF
--- a/src/MISC/fix_ttm.cpp
+++ b/src/MISC/fix_ttm.cpp
@@ -42,11 +42,11 @@ using namespace FixConst;
 
 FixTTM::FixTTM(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg),
-  random(NULL), fp(NULL), nsum(NULL), nsum_all(NULL),
-  T_initial_set(NULL), gfactor1(NULL), gfactor2(NULL), ratio(NULL),
-  flangevin(NULL), T_electron(NULL), T_electron_old(NULL), sum_vsq(NULL),
-  sum_mass_vsq(NULL), sum_vsq_all(NULL), sum_mass_vsq_all(NULL),
-  net_energy_transfer(NULL), net_energy_transfer_all(NULL)
+  random(NULL), fp(NULL), T_initial_set(NULL), nsum(NULL), nsum_all(NULL),
+  gfactor1(NULL), gfactor2(NULL), ratio(NULL), flangevin(NULL),
+  T_electron(NULL), T_electron_old(NULL), sum_vsq(NULL), sum_mass_vsq(NULL),
+  sum_vsq_all(NULL), sum_mass_vsq_all(NULL), net_energy_transfer(NULL),
+  net_energy_transfer_all(NULL)
 {
   if (narg < 15) error->all(FLERR,"Illegal fix ttm command");
 
@@ -327,7 +327,7 @@ void FixTTM::reset_dt()
 
 void FixTTM::read_initial_electron_temperatures(const char *filename)
 {
-  memset(&T_initial_set[0][0][0],0,total_nnodes*sizeof(double));
+  memset(&T_initial_set[0][0][0],0,total_nnodes*sizeof(int));
 
   std::string name = utils::get_potential_file_path(filename);
   if (name.empty())
@@ -360,8 +360,9 @@ void FixTTM::read_initial_electron_temperatures(const char *filename)
       error->one(FLERR,"Fix ttm electron temperatures must be > 0.0");
 
     T_electron[ixnode][iynode][iznode] = T_tmp;
-    T_initial_set[ixnode][iynode][iznode] = 1.0;
+    T_initial_set[ixnode][iynode][iznode] = 1;
   }
+  fclose(fpr);
 
   // check completeness of input data
 
@@ -370,8 +371,6 @@ void FixTTM::read_initial_electron_temperatures(const char *filename)
       for (int iznode = 0; iznode < nznodes; iznode++)
         if (T_initial_set[ixnode][iynode][iznode] == 0)
           error->one(FLERR,"Initial temperatures not all set in fix ttm");
-
-  fclose(fpr);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MISC/fix_ttm.cpp
+++ b/src/MISC/fix_ttm.cpp
@@ -145,7 +145,7 @@ FixTTM::FixTTM(LAMMPS *lmp, int narg, char **arg) :
 
   // set initial electron temperatures from user input file
 
-  if (me == 0) read_initial_electron_temperatures(arg[13]);
+  if (comm->me == 0) read_initial_electron_temperatures(arg[13]);
   MPI_Bcast(&T_electron[0][0][0],total_nnodes,MPI_DOUBLE,0,world);
 }
 
@@ -153,7 +153,7 @@ FixTTM::FixTTM(LAMMPS *lmp, int narg, char **arg) :
 
 FixTTM::~FixTTM()
 {
-  if (nfileevery && me == 0) fclose(fp);
+  if (fp) fclose(fp);
 
   delete random;
 
@@ -360,7 +360,7 @@ void FixTTM::read_initial_electron_temperatures(const char *filename)
       error->one(FLERR,"Fix ttm electron temperatures must be > 0.0");
 
     T_electron[ixnode][iynode][iznode] = T_tmp;
-    T_initial_set[ixnode][iynode][iznode] = 1;
+    T_initial_set[ixnode][iynode][iznode] = 1.0;
   }
 
   // check completeness of input data
@@ -475,7 +475,7 @@ void FixTTM::end_of_step()
               (T_electron_old[ixnode][iynode][right_znode] +
                T_electron_old[ixnode][iynode][left_znode] -
                2*T_electron_old[ixnode][iynode][iznode])/dz/dz) -
-              (net_energy_transfer_all[ixnode][iynode][iznode])/del_vol);
+             (net_energy_transfer_all[ixnode][iynode][iznode])/del_vol);
         }
   }
 
@@ -526,7 +526,7 @@ void FixTTM::end_of_step()
     MPI_Allreduce(&sum_mass_vsq[0][0][0],&sum_mass_vsq_all[0][0][0],
                   total_nnodes,MPI_DOUBLE,MPI_SUM,world);
 
-    if (me == 0) {
+    if (comm->me == 0) {
       fmt::print(fp,"{}",update->ntimestep);
 
       double T_a;

--- a/src/MISC/fix_ttm.h
+++ b/src/MISC/fix_ttm.h
@@ -48,7 +48,6 @@ class FixTTM : public Fix {
   double compute_vector(int);
 
  private:
-  int me;
   int nfileevery;
   int nlevels_respa;
   int seed;

--- a/src/MISC/fix_ttm.h
+++ b/src/MISC/fix_ttm.h
@@ -55,10 +55,9 @@ class FixTTM : public Fix {
   FILE *fp;
   int nxnodes,nynodes,nznodes;
   bigint total_nnodes;
-  int ***nsum;
-  int ***nsum_all,***T_initial_set;
-  double *gfactor1,*gfactor2,*ratio;
-  double **flangevin;
+  int ***T_initial_set;
+  int ***nsum, ***nsum_all;
+  double *gfactor1,*gfactor2,*ratio,**flangevin;
   double ***T_electron,***T_electron_old;
   double ***sum_vsq,***sum_mass_vsq;
   double ***sum_vsq_all,***sum_mass_vsq_all;

--- a/src/MISC/fix_ttm.h
+++ b/src/MISC/fix_ttm.h
@@ -53,8 +53,9 @@ class FixTTM : public Fix {
   int nlevels_respa;
   int seed;
   class RanMars *random;
-  FILE *fp,*fpr;
-  int nxnodes,nynodes,nznodes,total_nnodes;
+  FILE *fp;
+  int nxnodes,nynodes,nznodes;
+  bigint total_nnodes;
   int ***nsum;
   int ***nsum_all,***T_initial_set;
   double *gfactor1,*gfactor2,*ratio;
@@ -67,7 +68,7 @@ class FixTTM : public Fix {
   double electronic_thermal_conductivity;
   double gamma_p,gamma_s,v_0,v_0_sq;
 
-  void read_initial_electron_temperatures();
+  void read_initial_electron_temperatures(const char *);
 };
 
 }

--- a/src/MISC/fix_ttm.h
+++ b/src/MISC/fix_ttm.h
@@ -55,7 +55,6 @@ class FixTTM : public Fix {
   FILE *fp;
   int nxnodes,nynodes,nznodes;
   bigint total_nnodes;
-  int ***T_initial_set;
   int ***nsum, ***nsum_all;
   double *gfactor1,*gfactor2,*ratio,**flangevin;
   double ***T_electron,***T_electron_old;

--- a/src/USER-MISC/fix_ttm_mod.cpp
+++ b/src/USER-MISC/fix_ttm_mod.cpp
@@ -407,133 +407,133 @@ void FixTTMMod::read_parameters(const char *filename)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  esheat_0 = utils::numeric(FLERR,line,true,lmp);
+  esheat_0 = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // C1 (metal*10^3)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  esheat_1 = utils::numeric(FLERR,line,true,lmp);
+  esheat_1 = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // C2 (metal*10^6)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  esheat_2 = utils::numeric(FLERR,line,true,lmp);
+  esheat_2 = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // C3 (metal*10^9)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  esheat_3 = utils::numeric(FLERR,line,true,lmp);
+  esheat_3 = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // C4 (metal*10^12)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  esheat_4 = utils::numeric(FLERR,line,true,lmp);
+  esheat_4 = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // C_limit
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  C_limit = utils::numeric(FLERR,line,true,lmp);
+  C_limit = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // Temperature damping factor
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  T_damp = utils::numeric(FLERR,line,true,lmp);
+  T_damp = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // rho_e
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  electronic_density = utils::numeric(FLERR,line,true,lmp);
+  electronic_density = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // thermal_diffusion
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  el_th_diff = utils::numeric(FLERR,line,true,lmp);
+  el_th_diff = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // gamma_p
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  gamma_p = utils::numeric(FLERR,line,true,lmp);
+  gamma_p = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // gamma_s
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  gamma_s = utils::numeric(FLERR,line,true,lmp);
+  gamma_s = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // v0
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  v_0 = utils::numeric(FLERR,line,true,lmp);
+  v_0 = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // average intensity of pulse (source of energy) (metal units)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  intensity = utils::numeric(FLERR,line,true,lmp);
+  intensity = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // coordinate of 1st surface in x-direction (in box units) - constant
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  surface_l = utils::inumeric(FLERR,line,true,lmp);
+  surface_l = utils::inumeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // coordinate of 2nd surface in x-direction (in box units) - constant
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  surface_r = utils::inumeric(FLERR,line,true,lmp);
+  surface_r = utils::inumeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // skin_layer = intensity is reduced (I=I0*exp[-x/skin_layer])
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  skin_layer = utils::inumeric(FLERR,line,true,lmp);
+  skin_layer = utils::inumeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // width of pulse (picoseconds)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  width = utils::numeric(FLERR,line,true,lmp);
+  width = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // factor of electronic pressure (PF) Pe = PF*Ce*Te
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  pres_factor = utils::numeric(FLERR,line,true,lmp);
+  pres_factor = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // effective free path of electrons (angstrom)
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  free_path = utils::numeric(FLERR,line,true,lmp);
+  free_path = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // ionic density (ions*angstrom^{-3})
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  ionic_density = utils::numeric(FLERR,line,true,lmp);
+  ionic_density = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // if movsur = 0: surface is frozen
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  movsur = utils::inumeric(FLERR,line,true,lmp);
+  movsur = utils::inumeric(FLERR,utils::trim(line).c_str(),true,lmp);
 
   // electron_temperature_min
 
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
   utils::sfgets(FLERR,line,MAXLINE,fpr,filename,error);
-  electron_temperature_min = utils::numeric(FLERR,line,true,lmp);
+  electron_temperature_min = utils::numeric(FLERR,utils::trim(line).c_str(),true,lmp);
   fclose(fpr);
 }
 

--- a/src/USER-MISC/fix_ttm_mod.cpp
+++ b/src/USER-MISC/fix_ttm_mod.cpp
@@ -167,7 +167,7 @@ FixTTMMod::FixTTMMod(LAMMPS *lmp, int narg, char **arg) :
 
   // set initial electron temperatures from user input file
 
-  if (comm->me == 0) read_initial_electron_temperatures(arg[13]);
+  if (comm->me == 0) read_initial_electron_temperatures(arg[8]);
   MPI_Bcast(&T_electron[0][0][0],total_nnodes,MPI_DOUBLE,0,world);
 }
 

--- a/src/USER-MISC/fix_ttm_mod.h
+++ b/src/USER-MISC/fix_ttm_mod.h
@@ -53,7 +53,6 @@ class FixTTMMod : public Fix {
   double compute_vector(int);
 
  private:
-  int me;
   int nfileevery;
   int nlevels_respa;
   int seed;

--- a/src/USER-MISC/fix_ttm_mod.h
+++ b/src/USER-MISC/fix_ttm_mod.h
@@ -58,11 +58,11 @@ class FixTTMMod : public Fix {
   int seed;
   class RanMars *random;
   FILE *fp;
-  int nxnodes,nynodes,nznodes,total_nnodes;
-  int ***nsum;
-  int ***nsum_all,***T_initial_set;
-  double *gfactor1,*gfactor2,*ratio;
-  double **flangevin;
+  int nxnodes,nynodes,nznodes;
+  bigint total_nnodes;
+  int ***T_initial_set;
+  int ***nsum, ***nsum_all;
+  double *gfactor1,*gfactor2,*ratio,**flangevin;
   double ***T_electron,***T_electron_old,***T_electron_first;
   double ***sum_vsq,***sum_mass_vsq;
   double ***sum_vsq_all,***sum_mass_vsq_all;

--- a/src/USER-MISC/fix_ttm_mod.h
+++ b/src/USER-MISC/fix_ttm_mod.h
@@ -60,7 +60,6 @@ class FixTTMMod : public Fix {
   FILE *fp;
   int nxnodes,nynodes,nznodes;
   bigint total_nnodes;
-  int ***T_initial_set;
   int ***nsum, ***nsum_all;
   double *gfactor1,*gfactor2,*ratio,**flangevin;
   double ***T_electron,***T_electron_old,***T_electron_first;

--- a/src/USER-MISC/fix_ttm_mod.h
+++ b/src/USER-MISC/fix_ttm_mod.h
@@ -79,7 +79,8 @@ class FixTTMMod : public Fix {
   double electron_temperature_min;
   el_heat_capacity_thermal_conductivity el_properties(double);
   double el_sp_heat_integral(double);
-  void read_initial_electron_temperatures(FILE *);
+  void read_parameters(const char *);
+  void read_initial_electron_temperatures(const char *);
 };
 
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -349,6 +349,19 @@ tagint utils::tnumeric(const char *file, int line, const char *str,
 }
 
 /* ----------------------------------------------------------------------
+   Return string without leading or trailing whitespace
+------------------------------------------------------------------------- */
+
+std::string utils::trim(const std::string & line) {
+  int beg = re_match(line.c_str(),"\\S+");
+  int end = re_match(line.c_str(),"\\s+$");
+  if (beg < 0) beg = 0;
+  if (end < 0) end = line.size();
+
+  return line.substr(beg,end-beg);
+}
+
+/* ----------------------------------------------------------------------
    Return string without trailing # comment
 ------------------------------------------------------------------------- */
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -144,6 +144,13 @@ namespace LAMMPS_NS {
                     bool do_abort, LAMMPS *lmp);
 
     /**
+     * \brief Trim leading and trailing whitespace. Like TRIM() in Fortran.
+     * \param line string that should be trimmed
+     * \return new string without whitespace (string)
+     */
+    std::string trim(const std::string &line);
+
+    /**
      * \brief Trim anything from '#' onward
      * \param line string that should be trimmed
      * \return new string without comment (string)

--- a/unittest/utils/test_utils.cpp
+++ b/unittest/utils/test_utils.cpp
@@ -25,6 +25,24 @@ using ::testing::EndsWith;
 using ::testing::Eq;
 using ::testing::StrEq;
 
+TEST(Utils, trim)
+{
+    auto trimmed = utils::trim("\t some text");
+    ASSERT_THAT(trimmed, StrEq("some text"));
+
+    trimmed = utils::trim("some text \r\n");
+    ASSERT_THAT(trimmed, StrEq("some text"));
+
+    trimmed = utils::trim("\v some text \f");
+    ASSERT_THAT(trimmed, StrEq("some text"));
+
+    trimmed = utils::trim("   some\t text    ");
+    ASSERT_THAT(trimmed, StrEq("some\t text"));
+
+    trimmed = utils::trim("  \t\n   ");
+    ASSERT_THAT(trimmed, StrEq(""));
+}
+
 TEST(Utils, trim_comment)
 {
     auto trimmed = utils::trim_comment("some text # comment");


### PR DESCRIPTION
**Summary**

This refactors the parsing of the input files for fix ttm and fix ttm/mod. It uses the new tokenizer class and can detect incorrectly formatted files.
To support the parsing a new utility function `utils::trim()` is added that trims leading and trailing whitespace from a string (similar to TRIM() in Fortran).

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

The 3d array used for testing whether the grid was entered completely was made a temporary allocation, since it is only used when reading the file. Its memory use could be further reduced by converting it to a `std::vector<bool>`.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
