### PR TITLE
Fix handling of CL_DEVICE_TYPE flags

### DIFF
--- a/lib/gpu/geryon/ocl_device.h
+++ b/lib/gpu/geryon/ocl_device.h
@@ -625,9 +625,9 @@ int UCL_Device::set_platform_accelerator(int pid) {
     for (int n=0; n<_num_platforms; n++) {
       set_platform(n);
       for (int i=0; i<num_devices(); i++) {
-        if (_properties[i].device_type==CL_DEVICE_TYPE_CPU ||
-            _properties[i].device_type==CL_DEVICE_TYPE_GPU ||
-            _properties[i].device_type==CL_DEVICE_TYPE_ACCELERATOR) {
+        if ((_properties[i].device_type & CL_DEVICE_TYPE_CPU) ||
+            (_properties[i].device_type & CL_DEVICE_TYPE_GPU) ||
+            (_properties[i].device_type & CL_DEVICE_TYPE_ACCELERATOR)) {
           found = 1;
           break;
         }


### PR DESCRIPTION
**Summary**

The current implementation of OpenCL backend tests a device type by equality:
```
        if (_properties[i].device_type==CL_DEVICE_TYPE_CPU ||
            _properties[i].device_type==CL_DEVICE_TYPE_GPU ||
            _properties[i].device_type==CL_DEVICE_TYPE_ACCELERATOR) {
```
while device_type is a bitfield and only the corresponding bits should be tested. So it returns an error if the device specifies more than one type at once, which is not typical for the real devices, but still is valid (I am currently trying to run LAMMPS with a virtual generic device that returns device_type `0b1111`).

**Author(s)**

Vsevolod Nikolskiy (thevsevak@gmail.com, @Vsevak)
International Laboratory for Supercomputer Atomistic Modelling and Multi-scale Analysis
HSE University, Moscow, Russia

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Keeps

**Post Submission Checklist**


- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

**Further Information, Files, and Links**
https://www.khronos.org/registry/OpenCL/specs/opencl-1.2.pdf p.36
https://github.com/KhronosGroup/OpenCL-Docs/issues/224

