### PR TITLE
fix typo in the math of pair style dpd doc

### DIFF
--- a/doc/src/pair_dpd.rst
+++ b/doc/src/pair_dpd.rst
@@ -75,9 +75,9 @@ of 3 terms
 
 where :math:`F^C` is a conservative force, :math:`F^D` is a dissipative
 force, and :math:`F^R` is a random force.  :math:`r_{ij}` is a unit
-vector in the direction :math:`r_i - r_j`, :math:`V_{ij} is the vector
+vector in the direction :math:`r_i - r_j`, :math:`v_{ij}` is the vector
 difference in velocities of the two atoms :math:`= \vec{v}_i -
-\vec{v}_j, :math:`\alpha` is a Gaussian random number with zero mean and
+\vec{v}_j`, :math:`\alpha` is a Gaussian random number with zero mean and
 unit variance, dt is the timestep size, and w(r) is a weighting factor
 that varies between 0 and 1.  :math:`r_c` is the cutoff.  :math:`\sigma`
 is set equal to :math:`\sqrt{2 k_B T \gamma}`, where :math:`k_B` is the


### PR DESCRIPTION
- missing closing backticks for math
- V fixed to v for relative velocity

**Summary**

This is a typo fix for https://lammps.sandia.gov/doc/pair_dpd.html . The math was badly escaped in the description of the force terms.

**Author(s)**

Pierre de Buyl, KU Leuven, Belgium

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No compatibility issue.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

