### PR TITLE
Move comm destruction to after modify to leave available for fixes

### DIFF
--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -854,9 +854,6 @@ void LAMMPS::destroy()
   delete neighbor;
   neighbor = NULL;
 
-  delete comm;
-  comm = NULL;
-
   delete force;
   force = NULL;
 
@@ -869,6 +866,10 @@ void LAMMPS::destroy()
   delete modify;          // modify must come after output, force, update
                           //   since they delete fixes
   modify = NULL;
+
+  delete comm;            // comm must come after modify
+                          //   since fix destructors may access comm
+  comm = NULL;
 
   delete domain;          // domain must come after modify
                           //   since fix destructors access domain


### PR DESCRIPTION
Needed in some cases to cleanup asynchronous inter-step transfers.

## Summary

Have a fix that does non-block inter-step MPI transfers. The destructor needs to complete any the oustanding communications from the last step in order to cleanup.

Discovered that things segfaulted if I accessed `comm`. Don't see any reason the `comm` destruction shouldn't occur after `modify` to make comm available.

Actually, don't see why as many of these as possible aren't pushed after `modify`, but only did `comm` as that is the one our fix requires.

## Related Issues

None.

## Author(s)

This is pretty trivial. No need for a credit.

## Licensing

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

## Backward Compatibility

I do not believe this should break anything.

## Implementation Notes

If this change did break anything, it would have to be that `comm` accessed other components in its destruction that are now ahead of it. A review of the destructor reveals that it only deallocates memory though.

Of course I also complied the change and verified I was able to run a small simulation without issues.

## Post Submission Checklist

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

## Further Information, Files, and Links

Nothing.