### PR TITLE
Add unittest tool for lattice and region (/w create_box/create_atoms)

### DIFF
--- a/doc/src/lattice.rst
+++ b/doc/src/lattice.rst
@@ -260,25 +260,21 @@ of Aidan Thompson), with its 8 atom unit cell.
    variable b equal  $a*sqrt(3.0)
    variable c equal  $a*sqrt(8.0/3.0)
 
-   variable 1_3 equal 1.0/3.0
-   variable 2_3 equal 2.0/3.0
-   variable 1_6 equal 1.0/6.0
-   variable 5_6 equal 5.0/6.0
-   variable 1_12 equal 1.0/12.0
-   variable 5_12 equal 5.0/12.0
+   variable third equal 1.0/3.0
+   variable five6 equal 5.0/6.0
 
    lattice custom    1.0     &
-           a1      $a      0.0     0.0     &
-           a2      0.0     $b      0.0     &
-           a3      0.0     0.0     $c      &
-           basis   0.0     0.0     0.0     &
-           basis   0.5     0.5     0.0     &
-           basis   ${1_3}  0.0     0.5     &
-           basis   ${5_6}  0.5     0.5     &
-           basis   0.0     0.0     0.625   &
-           basis   0.5     0.5     0.625   &
-           basis   ${1_3}  0.0     0.125   &
-           basis   ${5_6}  0.5     0.125
+           a1      $a       0.0     0.0     &
+           a2      0.0      $b      0.0     &
+           a3      0.0      0.0     $c      &
+           basis   0.0      0.0     0.0     &
+           basis   0.5      0.5     0.0     &
+           basis   ${third} 0.0     0.5     &
+           basis   ${five6} 0.5     0.5     &
+           basis   0.0      0.0     0.625   &
+           basis   0.5      0.5     0.625   &
+           basis   ${third} 0.0     0.125   &
+           basis   ${five6} 0.5     0.125
 
    region myreg block 0 1 0 1 0 1
    create_box      2 myreg

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -71,6 +71,20 @@ void CreateAtoms::command(int narg, char **arg)
     error->all(FLERR,"Cannot create_atoms after "
                "reading restart file with per-atom info");
 
+  // check for compatible lattice
+
+  int latsty = domain->lattice->style;
+  if (domain->dimension == 2) {
+    if (latsty == Lattice::SC || latsty == Lattice::BCC
+        || latsty == Lattice::FCC || latsty == Lattice::HCP
+        || latsty == Lattice::DIAMOND)
+      error->all(FLERR,"Lattice style incompatible with simulation dimension");
+  } else {
+    if (latsty == Lattice::SQ ||latsty == Lattice::SQ2
+        || latsty == Lattice::HEX)
+      error->all(FLERR,"Lattice style incompatible with simulation dimension");
+  }
+
   // parse arguments
 
   if (narg < 2) error->all(FLERR,"Illegal create_atoms command");

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -28,8 +28,6 @@ using namespace LAMMPS_NS;
 
 #define BIG 1.0e30
 
-enum{NONE,SC,BCC,FCC,HCP,DIAMOND,SQ,SQ2,HEX,CUSTOM};
-
 /* ---------------------------------------------------------------------- */
 
 Lattice::Lattice(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)

--- a/src/lattice.h
+++ b/src/lattice.h
@@ -20,6 +20,8 @@ namespace LAMMPS_NS {
 
 class Lattice : protected Pointers {
  public:
+  enum{NONE,SC,BCC,FCC,HCP,DIAMOND,SQ,SQ2,HEX,CUSTOM};
+
   int style;                           // NONE,SC,FCC,etc
   double xlattice,ylattice,zlattice;   // lattice scale factors in 3 dims
   double a1[3],a2[3],a3[3];            // edge vectors of unit cell

--- a/unittest/commands/CMakeLists.txt
+++ b/unittest/commands/CMakeLists.txt
@@ -3,6 +3,10 @@ add_executable(test_simple_commands test_simple_commands.cpp)
 target_link_libraries(test_simple_commands PRIVATE lammps GTest::GMock GTest::GTest)
 add_test(NAME SimpleCommands COMMAND test_simple_commands WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+add_executable(test_lattice_region test_lattice_region.cpp)
+target_link_libraries(test_lattice_region PRIVATE lammps GTest::GMock GTest::GTest)
+add_test(NAME LatticeRegion COMMAND test_lattice_region WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(test_kim_commands test_kim_commands.cpp)
 target_link_libraries(test_kim_commands PRIVATE lammps GTest::GMock GTest::GTest)
 add_test(NAME KimCommands COMMAND test_kim_commands WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/unittest/commands/test_lattice_region.cpp
+++ b/unittest/commands/test_lattice_region.cpp
@@ -159,6 +159,10 @@ TEST_F(LatticeRegionTest, lattice_sc)
                  lmp->input->one("lattice sc 1.0 orient x 2 2 0"););
     TEST_FAILURE(".*ERROR: Lattice orient vectors are not right-handed.*",
                  lmp->input->one("lattice sc 1.0 orient y 0 -1 0"););
+    TEST_FAILURE(".*ERROR: Lattice spacings are invalid.*",
+                 lmp->input->one("lattice sc 1.0 spacing 0.0 1.0 1.0"););
+    TEST_FAILURE(".*ERROR: Lattice spacings are invalid.*",
+                 lmp->input->one("lattice sc 1.0 spacing 1.0 -0.1 1.0"););
 
     if (!verbose) ::testing::internal::CaptureStdout();
     lmp->input->one("units lj");
@@ -224,6 +228,13 @@ TEST_F(LatticeRegionTest, lattice_fcc)
     ASSERT_EQ(lattice->basis[3][1], 0.5);
     ASSERT_EQ(lattice->basis[3][2], 0.5);
 
+    TEST_FAILURE(".*ERROR: Invalid option in lattice command for non-custom style.*",
+                 lmp->input->one("lattice fcc 1.0 basis 0.0 0.0 0.0"););
+    TEST_FAILURE(".*ERROR: Invalid option in lattice command for non-custom style.*",
+                 lmp->input->one("lattice fcc 1.0 a1 0.0 1.0 0.0"););
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*",
+                 lmp->input->one("lattice fcc 1.0 orient w 1 0 0"););
+
     if (!verbose) ::testing::internal::CaptureStdout();
     lmp->input->one("dimension 2");
     if (!verbose) ::testing::internal::GetCapturedStdout();
@@ -264,6 +275,10 @@ TEST_F(LatticeRegionTest, lattice_hcp)
     ASSERT_EQ(lattice->a3[1], 0.0);
     ASSERT_DOUBLE_EQ(lattice->a3[2], sqrt(8.0 / 3.0));
 
+    TEST_FAILURE(".*ERROR: Invalid option in lattice command for non-custom style.*",
+                 lmp->input->one("lattice hcp 1.0 a2 0.0 1.0 0.0"););
+    TEST_FAILURE(".*ERROR: Invalid option in lattice command for non-custom style.*",
+                 lmp->input->one("lattice hcp 1.0 a3 0.0 1.0 0.0"););
     if (!verbose) ::testing::internal::CaptureStdout();
     lmp->input->one("dimension 2");
     if (!verbose) ::testing::internal::GetCapturedStdout();
@@ -430,43 +445,62 @@ TEST_F(LatticeRegionTest, lattice_custom)
     if (!verbose) ::testing::internal::GetCapturedStdout();
     auto lattice = lmp->domain->lattice;
     ASSERT_EQ(lattice->style, Lattice::CUSTOM);
-    EXPECT_DOUBLE_EQ(lattice->xlattice, 4.34);
-    EXPECT_DOUBLE_EQ(lattice->ylattice, 4.34 * sqrt(3.0));
-    EXPECT_DOUBLE_EQ(lattice->zlattice, 4.34 * sqrt(8.0 / 3.0));
+    ASSERT_DOUBLE_EQ(lattice->xlattice, 4.34);
+    ASSERT_DOUBLE_EQ(lattice->ylattice, 4.34 * sqrt(3.0));
+    ASSERT_DOUBLE_EQ(lattice->zlattice, 4.34 * sqrt(8.0 / 3.0));
     ASSERT_EQ(lattice->nbasis, 8);
-    EXPECT_DOUBLE_EQ(lattice->basis[0][0], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[0][1], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[0][2], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[1][0], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[1][1], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[1][2], 0.0);
-    EXPECT_NEAR(lattice->basis[2][0], 1.0 / 3.0, 1.0e-14);
-    EXPECT_DOUBLE_EQ(lattice->basis[2][1], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[2][2], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[3][0], 5.0 / 6.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[3][1], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[3][2], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[4][0], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[4][1], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[4][2], 0.625);
-    EXPECT_DOUBLE_EQ(lattice->basis[5][0], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[5][1], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[5][2], 0.625);
-    EXPECT_NEAR(lattice->basis[6][0], 1.0 / 3.0, 1.0e-14);
-    EXPECT_DOUBLE_EQ(lattice->basis[6][1], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[6][2], 0.125);
-    EXPECT_DOUBLE_EQ(lattice->basis[7][0], 5.0 / 6.0);
-    EXPECT_DOUBLE_EQ(lattice->basis[7][1], 0.5);
-    EXPECT_DOUBLE_EQ(lattice->basis[7][2], 0.125);
-    EXPECT_DOUBLE_EQ(lattice->a1[0], 4.34);
-    EXPECT_DOUBLE_EQ(lattice->a1[1], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->a1[2], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->a2[0], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->a2[1], 4.34 * sqrt(3.0));
-    EXPECT_DOUBLE_EQ(lattice->a2[2], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->a3[0], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->a3[1], 0.0);
-    EXPECT_DOUBLE_EQ(lattice->a3[2], 4.34 * sqrt(8.0 / 3.0));
+    ASSERT_DOUBLE_EQ(lattice->basis[0][0], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[0][1], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[0][2], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[1][0], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[1][1], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[1][2], 0.0);
+    ASSERT_NEAR(lattice->basis[2][0], 1.0 / 3.0, 1.0e-14);
+    ASSERT_DOUBLE_EQ(lattice->basis[2][1], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[2][2], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[3][0], 5.0 / 6.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[3][1], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[3][2], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[4][0], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[4][1], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[4][2], 0.625);
+    ASSERT_DOUBLE_EQ(lattice->basis[5][0], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[5][1], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[5][2], 0.625);
+    ASSERT_NEAR(lattice->basis[6][0], 1.0 / 3.0, 1.0e-14);
+    ASSERT_DOUBLE_EQ(lattice->basis[6][1], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[6][2], 0.125);
+    ASSERT_DOUBLE_EQ(lattice->basis[7][0], 5.0 / 6.0);
+    ASSERT_DOUBLE_EQ(lattice->basis[7][1], 0.5);
+    ASSERT_DOUBLE_EQ(lattice->basis[7][2], 0.125);
+    ASSERT_DOUBLE_EQ(lattice->a1[0], 4.34);
+    ASSERT_DOUBLE_EQ(lattice->a1[1], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->a1[2], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->a2[0], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->a2[1], 4.34 * sqrt(3.0));
+    ASSERT_DOUBLE_EQ(lattice->a2[2], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->a3[0], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->a3[1], 0.0);
+    ASSERT_DOUBLE_EQ(lattice->a3[2], 4.34 * sqrt(8.0 / 3.0));
+
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*",
+                 lmp->input->one("lattice custom 1.0 basis -0.1 0 0"););
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*",
+                 lmp->input->one("lattice custom 1.0 basis 0.0 1.0 0"););
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 2");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: No basis atoms in lattice.*",
+                 lmp->input->one("lattice custom 1.0"););
+    TEST_FAILURE(".*ERROR: Lattice settings are not compatible with 2d simulation.*",
+                 lmp->input->one("lattice custom 1.0 origin 0.5 0.5 0.5 basis 0.0 0.0 0.0"););
+    TEST_FAILURE(".*ERROR: Lattice settings are not compatible with 2d simulation.*",
+                 lmp->input->one("lattice custom 1.0 a1 1.0 1.0 1.0 basis 0.0 0.0 0.0"););
+    TEST_FAILURE(".*ERROR: Lattice settings are not compatible with 2d simulation.*",
+                 lmp->input->one("lattice custom 1.0 a2 1.0 1.0 1.0 basis 0.0 0.0 0.0"););
+    TEST_FAILURE(".*ERROR: Lattice settings are not compatible with 2d simulation.*",
+                 lmp->input->one("lattice custom 1.0 a3 1.0 1.0 1.0 basis 0.0 0.0 0.0"););
 }
 
 TEST_F(LatticeRegionTest, region_fail)

--- a/unittest/commands/test_lattice_region.cpp
+++ b/unittest/commands/test_lattice_region.cpp
@@ -99,6 +99,14 @@ TEST_F(LatticeRegionTest, lattice_none)
     TEST_FAILURE(".*ERROR: Illegal lattice command.*", lmp->input->one("lattice xxx"););
     TEST_FAILURE(".*ERROR: Illegal lattice command.*", lmp->input->one("lattice none 1.0 origin"););
     TEST_FAILURE(".*ERROR: Expected floating point.*", lmp->input->one("lattice none xxx"););
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("units lj");
+    lmp->input->one("lattice none 1.0");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    ASSERT_EQ(lattice->xlattice, 1.0);
+    ASSERT_EQ(lattice->ylattice, 1.0);
+    ASSERT_EQ(lattice->zlattice, 1.0);
 }
 
 TEST_F(LatticeRegionTest, lattice_sc)
@@ -135,6 +143,20 @@ TEST_F(LatticeRegionTest, lattice_sc)
                  lmp->input->one("lattice sc 1.0 origin 1.0"););
     TEST_FAILURE(".*ERROR: Expected floating point.*",
                  lmp->input->one("lattice sc 1.0 origin xxx 1.0 1.0"););
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("units lj");
+    lmp->input->one("lattice sc 2.0");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    ASSERT_DOUBLE_EQ(lattice->xlattice, pow(0.5, 1.0 / 3.0));
+    ASSERT_DOUBLE_EQ(lattice->ylattice, pow(0.5, 1.0 / 3.0));
+    ASSERT_DOUBLE_EQ(lattice->zlattice, pow(0.5, 1.0 / 3.0));
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 2");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: Lattice style incompatible with simulation dimension.*",
+                 lmp->input->one("lattice sc 1.0"););
 }
 
 TEST_F(LatticeRegionTest, lattice_bcc)
@@ -144,8 +166,8 @@ TEST_F(LatticeRegionTest, lattice_bcc)
     if (!verbose) ::testing::internal::GetCapturedStdout();
     auto lattice = lmp->domain->lattice;
     ASSERT_EQ(lattice->style, Lattice::BCC);
-    ASSERT_DOUBLE_EQ(lattice->xlattice, sqrt(2.0)*4.2);
-    ASSERT_DOUBLE_EQ(lattice->ylattice, sqrt(2.0)*4.2);
+    ASSERT_DOUBLE_EQ(lattice->xlattice, sqrt(2.0) * 4.2);
+    ASSERT_DOUBLE_EQ(lattice->ylattice, sqrt(2.0) * 4.2);
     ASSERT_DOUBLE_EQ(lattice->zlattice, 4.2);
     ASSERT_EQ(lattice->nbasis, 2);
     ASSERT_EQ(lattice->basis[0][0], 0.0);
@@ -154,6 +176,92 @@ TEST_F(LatticeRegionTest, lattice_bcc)
     ASSERT_EQ(lattice->basis[1][0], 0.5);
     ASSERT_EQ(lattice->basis[1][1], 0.5);
     ASSERT_EQ(lattice->basis[1][2], 0.5);
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 2");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: Lattice style incompatible with simulation dimension.*",
+                 lmp->input->one("lattice bcc 1.0"););
+}
+
+TEST_F(LatticeRegionTest, lattice_fcc)
+{
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("lattice fcc 3.5 origin 0.5 0.5 0.5");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    auto lattice = lmp->domain->lattice;
+    ASSERT_EQ(lattice->style, Lattice::FCC);
+    ASSERT_DOUBLE_EQ(lattice->xlattice, 3.5);
+    ASSERT_DOUBLE_EQ(lattice->ylattice, 3.5);
+    ASSERT_DOUBLE_EQ(lattice->zlattice, 3.5);
+    ASSERT_EQ(lattice->nbasis, 4);
+    ASSERT_EQ(lattice->basis[0][0], 0.0);
+    ASSERT_EQ(lattice->basis[0][1], 0.0);
+    ASSERT_EQ(lattice->basis[0][2], 0.0);
+    ASSERT_EQ(lattice->basis[1][0], 0.5);
+    ASSERT_EQ(lattice->basis[1][1], 0.5);
+    ASSERT_EQ(lattice->basis[1][2], 0.0);
+    ASSERT_EQ(lattice->basis[2][0], 0.5);
+    ASSERT_EQ(lattice->basis[2][1], 0.0);
+    ASSERT_EQ(lattice->basis[2][2], 0.5);
+    ASSERT_EQ(lattice->basis[3][0], 0.0);
+    ASSERT_EQ(lattice->basis[3][1], 0.5);
+    ASSERT_EQ(lattice->basis[3][2], 0.5);
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 2");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: Lattice style incompatible with simulation dimension.*",
+                 lmp->input->one("lattice fcc 1.0"););
+}
+
+TEST_F(LatticeRegionTest, lattice_sq)
+{
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 2");
+    lmp->input->one("lattice sq 3.0");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    auto lattice = lmp->domain->lattice;
+    ASSERT_EQ(lattice->style, Lattice::SQ);
+    ASSERT_DOUBLE_EQ(lattice->xlattice, 3.0);
+    ASSERT_DOUBLE_EQ(lattice->ylattice, 3.0);
+    ASSERT_DOUBLE_EQ(lattice->zlattice, 3.0);
+    ASSERT_EQ(lattice->nbasis, 1);
+    ASSERT_EQ(lattice->basis[0][0], 0.0);
+    ASSERT_EQ(lattice->basis[0][1], 0.0);
+    ASSERT_EQ(lattice->basis[0][2], 0.0);
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 3");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: Lattice style incompatible with simulation dimension.*",
+                 lmp->input->one("lattice sq 1.0"););
+}
+
+TEST_F(LatticeRegionTest, lattice_sq2)
+{
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 2");
+    lmp->input->one("lattice sq2 2.0");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    auto lattice = lmp->domain->lattice;
+    ASSERT_EQ(lattice->style, Lattice::SQ2);
+    ASSERT_DOUBLE_EQ(lattice->xlattice, 2.0);
+    ASSERT_DOUBLE_EQ(lattice->ylattice, 2.0);
+    ASSERT_DOUBLE_EQ(lattice->zlattice, 2.0);
+    ASSERT_EQ(lattice->nbasis, 2);
+    ASSERT_EQ(lattice->basis[0][0], 0.0);
+    ASSERT_EQ(lattice->basis[0][1], 0.0);
+    ASSERT_EQ(lattice->basis[0][2], 0.0);
+    ASSERT_EQ(lattice->basis[1][0], 0.5);
+    ASSERT_EQ(lattice->basis[1][1], 0.5);
+    ASSERT_EQ(lattice->basis[1][2], 0.0);
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("dimension 3");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: Lattice style incompatible with simulation dimension.*",
+                 lmp->input->one("lattice sq2 1.0"););
 }
 
 } // namespace LAMMPS_NS

--- a/unittest/commands/test_lattice_region.cpp
+++ b/unittest/commands/test_lattice_region.cpp
@@ -1,0 +1,185 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "domain.h"
+#include "fmt/format.h"
+#include "info.h"
+#include "input.h"
+#include "lammps.h"
+#include "lattice.h"
+#include "region.h"
+#include "utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mpi.h>
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+#if defined(OMPI_MAJOR_VERSION)
+const bool have_openmpi = true;
+#else
+const bool have_openmpi = false;
+#endif
+
+using LAMMPS_NS::utils::split_words;
+
+namespace LAMMPS_NS {
+using ::testing::ExitedWithCode;
+using ::testing::MatchesRegex;
+using ::testing::StrEq;
+
+#define TEST_FAILURE(errmsg, ...)                                 \
+    if (Info::has_exceptions()) {                                 \
+        ::testing::internal::CaptureStdout();                     \
+        ASSERT_ANY_THROW({__VA_ARGS__});                          \
+        auto mesg = ::testing::internal::GetCapturedStdout();     \
+        ASSERT_THAT(mesg, MatchesRegex(errmsg));                  \
+    } else {                                                      \
+        if (!have_openmpi) {                                      \
+            ::testing::internal::CaptureStdout();                 \
+            ASSERT_DEATH({__VA_ARGS__}, "");                      \
+            auto mesg = ::testing::internal::GetCapturedStdout(); \
+            ASSERT_THAT(mesg, MatchesRegex(errmsg));              \
+        }                                                         \
+    }
+
+class LatticeRegionTest : public ::testing::Test {
+protected:
+    LAMMPS *lmp;
+
+    void SetUp() override
+    {
+        const char *args[] = {"LatticeRegionTest", "-log", "none", "-echo", "screen", "-nocite"};
+        char **argv        = (char **)args;
+        int argc           = sizeof(args) / sizeof(char *);
+        if (!verbose) ::testing::internal::CaptureStdout();
+        lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+        lmp->input->one("units metal");
+        if (!verbose) ::testing::internal::GetCapturedStdout();
+    }
+
+    void TearDown() override
+    {
+        if (!verbose) ::testing::internal::CaptureStdout();
+        delete lmp;
+        if (!verbose) ::testing::internal::GetCapturedStdout();
+    }
+};
+
+TEST_F(LatticeRegionTest, lattice_none)
+{
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("lattice none 2.0");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    auto lattice = lmp->domain->lattice;
+    ASSERT_EQ(lattice->style, Lattice::NONE);
+    ASSERT_EQ(lattice->xlattice, 2.0);
+    ASSERT_EQ(lattice->ylattice, 2.0);
+    ASSERT_EQ(lattice->zlattice, 2.0);
+    ASSERT_EQ(lattice->nbasis, 0);
+    ASSERT_EQ(lattice->basis, nullptr);
+
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*", lmp->input->one("lattice"););
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*", lmp->input->one("lattice xxx"););
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*", lmp->input->one("lattice none 1.0 origin"););
+    TEST_FAILURE(".*ERROR: Expected floating point.*", lmp->input->one("lattice none xxx"););
+}
+
+TEST_F(LatticeRegionTest, lattice_sc)
+{
+    ::testing::internal::CaptureStdout();
+    lmp->input->one("lattice sc 2.0");
+    auto output = ::testing::internal::GetCapturedStdout();
+    if (verbose) std::cout << output;
+    ASSERT_THAT(output, MatchesRegex(".*Lattice spacing in x,y,z = 2.0* 2.0* 2.0*.*"));
+
+    auto lattice = lmp->domain->lattice;
+    ASSERT_EQ(lattice->style, Lattice::SC);
+    ASSERT_EQ(lattice->xlattice, 2.0);
+    ASSERT_EQ(lattice->ylattice, 2.0);
+    ASSERT_EQ(lattice->zlattice, 2.0);
+    ASSERT_EQ(lattice->nbasis, 1);
+    ASSERT_NE(lattice->basis, nullptr);
+    ASSERT_EQ(lattice->a1[0], 1.0);
+    ASSERT_EQ(lattice->a1[1], 0.0);
+    ASSERT_EQ(lattice->a1[2], 0.0);
+    ASSERT_EQ(lattice->a2[0], 0.0);
+    ASSERT_EQ(lattice->a2[1], 1.0);
+    ASSERT_EQ(lattice->a2[2], 0.0);
+    ASSERT_EQ(lattice->a3[0], 0.0);
+    ASSERT_EQ(lattice->a3[1], 0.0);
+    ASSERT_EQ(lattice->a3[2], 1.0);
+    ASSERT_EQ(lattice->basis[0][0], 0.0);
+    ASSERT_EQ(lattice->basis[0][1], 0.0);
+    ASSERT_EQ(lattice->basis[0][2], 0.0);
+
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*",
+                 lmp->input->one("lattice sc 1.0 origin 1.0 1.0 1.0"););
+    TEST_FAILURE(".*ERROR: Illegal lattice command.*",
+                 lmp->input->one("lattice sc 1.0 origin 1.0"););
+    TEST_FAILURE(".*ERROR: Expected floating point.*",
+                 lmp->input->one("lattice sc 1.0 origin xxx 1.0 1.0"););
+}
+
+TEST_F(LatticeRegionTest, lattice_bcc)
+{
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("lattice bcc 4.2 orient x 1 1 0 orient y -1 1 0");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    auto lattice = lmp->domain->lattice;
+    ASSERT_EQ(lattice->style, Lattice::BCC);
+    ASSERT_DOUBLE_EQ(lattice->xlattice, sqrt(2.0)*4.2);
+    ASSERT_DOUBLE_EQ(lattice->ylattice, sqrt(2.0)*4.2);
+    ASSERT_DOUBLE_EQ(lattice->zlattice, 4.2);
+    ASSERT_EQ(lattice->nbasis, 2);
+    ASSERT_EQ(lattice->basis[0][0], 0.0);
+    ASSERT_EQ(lattice->basis[0][1], 0.0);
+    ASSERT_EQ(lattice->basis[0][2], 0.0);
+    ASSERT_EQ(lattice->basis[1][0], 0.5);
+    ASSERT_EQ(lattice->basis[1][1], 0.5);
+    ASSERT_EQ(lattice->basis[1][2], 0.5);
+}
+
+} // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    if (have_openmpi && !LAMMPS_NS::Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. "
+                     "Death tests will be skipped\n";
+
+    // handle arguments passed via environment variable
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = split_words(var);
+        for (auto arg : env) {
+            if (arg == "-v") {
+                verbose = true;
+            }
+        }
+    }
+
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}


### PR DESCRIPTION
**Summary**

This adds a unittest tools for testing the lattice commands and its application in combination with the region command to create simulation boxes and atoms.

**Related Issues**

#2099 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

This moves the lattice style constants into the class definition of the header, so it can be used in the tester and elsewere.
This also adds a test for the case the dimension was changed after the lattice was defined, so that atoms are not created when there is a mismatch.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
