### PR TITLE
Fix MVAPICH2 env variable for CUDA/aware

### DIFF
--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -253,13 +253,13 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
 #if defined(MPICH) && defined(MVAPICH2_VERSION)
       char* str;
       cuda_aware_flag = 0;
-      if ((str = getenv("MV2_ENABLE_CUDA")))
+      if ((str = getenv("MV2_USE_CUDA")))
         if ((strcmp(str,"1") == 0))
           cuda_aware_flag = 1;
 
       if (!cuda_aware_flag)
         if (me == 0)
-          error->warning(FLERR,"MVAPICH2 'MV2_ENABLE_CUDA' environment variable is not set. Disabling CUDA-aware MPI");
+          error->warning(FLERR,"MVAPICH2 'MV2_USE_CUDA' environment variable is not set. Disabling CUDA-aware MPI");
     // pure MPICH or some unsupported MPICH derivative
 #elif defined(MPICH) && !defined(MVAPICH2_VERSION)
       if (me == 0)


### PR DESCRIPTION
**Summary**

The `MV2_USE_CUDA` variable in kokkos.cpp was accidentally renamed to `MV2_ENABLE_CUDA`, which messed up the logic for checking auto-detecting CUDA/aware MPI support. This PR fixes that issue.

**Related Issues**

None.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes