### PR TITLE
Fixes a bug in binary2txt

### DIFF
--- a/tools/binary2txt.cpp
+++ b/tools/binary2txt.cpp
@@ -158,7 +158,7 @@ int main(int narg, char **arg)
           delete [] unit_style;
           unit_style = new char[len+1];
           fread(unit_style, sizeof(char), len, fp);
-          unit_style[len+1] = '\0';
+          unit_style[len] = '\0';
           fprintf(fptxt, "ITEM: UNITS\n");
           fprintf(fptxt, "%s\n", unit_style);
         }
@@ -176,7 +176,7 @@ int main(int narg, char **arg)
         delete [] columns;
         columns = new char[len+1];
         fread(columns, sizeof(char), len, fp);
-        columns[len+1] = '\0';
+        columns[len] = '\0';
       }
 
       fread(&nchunk,sizeof(int),1,fp);


### PR DESCRIPTION
**Summary**

Fixes a bug in binary2txt that only showed up during 32bit builds, but is actually wrong in all cases.

**Related Issues**

Fixes #2300

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


