### PR TITLE
Fix NaN in Tersoffs GPU-accelerated with OpenCL backend

### DIFF
--- a/lib/gpu/lal_tersoff.cu
+++ b/lib/gpu/lal_tersoff.cu
@@ -709,7 +709,7 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[BLOCK_PAIR];
+  __local int ijnum_shared[BLOCK_PAIR];
 
   __syncthreads();
 
@@ -789,14 +789,14 @@ __kernel void k_tersoff_three_end(const __global numtyp4 *restrict x_,
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[m] = ijnum;
+          ijnum_shared[m] = ijnum;
           break;
         }
       }
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      if (ijnum < 0) ijnum = red_acc[m];
+      if (ijnum < 0) ijnum = ijnum_shared[m];
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;

--- a/lib/gpu/lal_tersoff_mod.cu
+++ b/lib/gpu/lal_tersoff_mod.cu
@@ -719,7 +719,7 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[BLOCK_PAIR];
+  __local int ijnum_shared[BLOCK_PAIR];
 
   __syncthreads();
 
@@ -799,14 +799,14 @@ __kernel void k_tersoff_mod_three_end(const __global numtyp4 *restrict x_,
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[m] = ijnum;
+          ijnum_shared[m] = ijnum;
           break;
         }
       }
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      if (ijnum < 0) ijnum = red_acc[m];
+      if (ijnum < 0) ijnum = ijnum_shared[m];
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;
@@ -957,7 +957,7 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[BLOCK_PAIR];
+  __local int ijnum_shared[BLOCK_PAIR];
 
   __syncthreads();
 
@@ -1037,14 +1037,14 @@ __kernel void k_tersoff_mod_three_end_vatom(const __global numtyp4 *restrict x_,
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[m] = ijnum;
+          ijnum_shared[m] = ijnum;
           break;
         }
       }
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      if (ijnum < 0) ijnum = red_acc[m];
+      if (ijnum < 0) ijnum = ijnum_shared[m];
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;

--- a/lib/gpu/lal_tersoff_zbl.cu
+++ b/lib/gpu/lal_tersoff_zbl.cu
@@ -729,7 +729,7 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
   for (int i=0; i<6; i++)
     virial[i]=(acctyp)0;
 
-  __local int red_acc[BLOCK_PAIR];
+  __local int ijnum_shared[BLOCK_PAIR];
 
   __syncthreads();
 
@@ -809,14 +809,14 @@ __kernel void k_tersoff_zbl_three_end(const __global numtyp4 *restrict x_,
         k &= NEIGHMASK;
         if (k == i) {
           ijnum = nbor_k;
-          red_acc[m] = ijnum;
+          ijnum_shared[m] = ijnum;
           break;
         }
       }
 
       numtyp r1 = ucl_sqrt(rsq1);
       numtyp r1inv = ucl_rsqrt(rsq1);
-      if (ijnum < 0) ijnum = red_acc[m];
+      if (ijnum < 0) ijnum = ijnum_shared[m];
 
       // idx to zetaij is shifted by n_stride relative to ijnum in dev_short_nbor
       int idx = ijnum;


### PR DESCRIPTION
**Summary**

We wanted to use tersoff/zbl/gpu on a cluster that currently runs only with OpenCL drivers. The calculations were corrupted by NaNs quite shortly after the start. I managed to find a minimal way to fix it.

**Related Issues**

Pretty much related to https://github.com/lammps/lammps/issues/1368
The issue addressed in the current PR itself is a symptom of a more general problem with OpenCL backend that it does not follow OpenCL specifications on the use of local (shared) memory (6.5.2 in OCL 1.2). The rule on the scope of local memory is broken literally in every pairstyle of lib/gpu, but most compilers of OpenCL 1.2 epoch accept the code, and usually, it works without problems. Stricter and most modern compilers reject the code with errors.
Perhaps I could fix most of the pairstyles, but I may need help with testing all these changes because I have no inputs and no experience for many of them.

**Author(s)**

Vsevolod Nikolskiy (thevsevak@gmail.com, @Vsevak)
International Laboratory for Supercomputer Atomistic Modelling and Multi-scale Analysis
HSE University, Moscow, Russia

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Keeps

**Implementation Notes**

The kernels for Tersoff re-declared a local memory buffer with a different type in the inner scope:
```
__local int red_acc[BLOCK_PAIR];
...
if (ii<inum) {
    ...
    if (t_per_atom>1) {
        __local acctyp red_acc[6][BLOCK_PAIR];
        ...
    }
}
```
I renamed `red_acc` in the outer scope and now tersoff/zbl/gpu works for us. I found the same in tersoff/mod/gpu and tersoff/gpu and fixed them too, but I didn't test them very thoroughly.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

https://www.khronos.org/registry/OpenCL/specs/opencl-1.2.pdf
