### PR TITLE
update makefiles in lib/gpu for more recent architectures

### DIFF
--- a/lib/gpu/Makefile.linux
+++ b/lib/gpu/Makefile.linux
@@ -22,13 +22,13 @@ NVCC = nvcc
 #CUDA_ARCH = -arch=sm_21
 
 # Kepler hardware
-CUDA_ARCH = -arch=sm_30
+#CUDA_ARCH = -arch=sm_30
 #CUDA_ARCH = -arch=sm_32
 #CUDA_ARCH = -arch=sm_35
 #CUDA_ARCH = -arch=sm_37
 
 # Maxwell hardware
-#CUDA_ARCH = -arch=sm_50
+CUDA_ARCH = -arch=sm_50
 #CUDA_ARCH = -arch=sm_52
 
 # Pascal hardware

--- a/lib/gpu/Makefile.linux.double
+++ b/lib/gpu/Makefile.linux.double
@@ -7,17 +7,39 @@
 
 EXTRAMAKE = Makefile.lammps.standard
 
+ifeq ($(CUDA_HOME),)
 CUDA_HOME = /usr/local/cuda
+endif
+
 NVCC = nvcc
 
-# Kepler CUDA
-#CUDA_ARCH = -arch=sm_35
-# Tesla CUDA
-CUDA_ARCH = -arch=sm_21
-# newer CUDA
+# obsolete hardware. not supported by current drivers anymore.
 #CUDA_ARCH = -arch=sm_13
-# older CUDA
 #CUDA_ARCH = -arch=sm_10 -DCUDA_PRE_THREE
+
+# Fermi hardware
+#CUDA_ARCH = -arch=sm_20
+#CUDA_ARCH = -arch=sm_21
+
+# Kepler hardware
+#CUDA_ARCH = -arch=sm_30
+#CUDA_ARCH = -arch=sm_32
+#CUDA_ARCH = -arch=sm_35
+#CUDA_ARCH = -arch=sm_37
+
+# Maxwell hardware
+CUDA_ARCH = -arch=sm_50
+#CUDA_ARCH = -arch=sm_52
+
+# Pascal hardware
+#CUDA_ARCH = -arch=sm_60
+#CUDA_ARCH = -arch=sm_61
+
+# Volta hardware
+#CUDA_ARCH = -arch=sm_70
+
+# Turing hardware
+#CUDA_ARCH = -arch=sm_75
 
 # this setting should match LAMMPS Makefile
 # one of LAMMPS_SMALLBIG (default), LAMMPS_BIGBIG and LAMMPS_SMALLSMALL
@@ -33,7 +55,7 @@ CUDA_PRECISION = -D_DOUBLE_DOUBLE
 
 CUDA_INCLUDE = -I$(CUDA_HOME)/include
 CUDA_LIB = -L$(CUDA_HOME)/lib64 -L$(CUDA_HOME)/lib64/stubs
-CUDA_OPTS = -DUNIX -O3 --use_fast_math
+CUDA_OPTS = -DUNIX -O3 --use_fast_math $(LMP_INC) -Xcompiler -fPIC
 
 CUDR_CPP = mpic++ -DMPI_GERYON -DUCL_NO_EXIT -DMPICH_IGNORE_CXX_SEEK
 CUDR_OPTS = -O2 # -xHost -no-prec-div -ansi-alias

--- a/lib/gpu/Makefile.linux.mixed
+++ b/lib/gpu/Makefile.linux.mixed
@@ -7,17 +7,40 @@
 
 EXTRAMAKE = Makefile.lammps.standard
 
+ifeq ($(CUDA_HOME),)
 CUDA_HOME = /usr/local/cuda
+endif
+
 NVCC = nvcc
 
-# Kepler CUDA
-#CUDA_ARCH = -arch=sm_35
-# Tesla CUDA
-CUDA_ARCH = -arch=sm_21
-# newer CUDA
+# obsolete hardware. not supported by current drivers anymore.
 #CUDA_ARCH = -arch=sm_13
 # older CUDA
 #CUDA_ARCH = -arch=sm_10 -DCUDA_PRE_THREE
+
+# Fermi hardware
+#CUDA_ARCH = -arch=sm_20
+#CUDA_ARCH = -arch=sm_21
+
+# Kepler hardware
+#CUDA_ARCH = -arch=sm_30
+#CUDA_ARCH = -arch=sm_32
+#CUDA_ARCH = -arch=sm_35
+#CUDA_ARCH = -arch=sm_37
+
+# Maxwell hardware
+CUDA_ARCH = -arch=sm_50
+#CUDA_ARCH = -arch=sm_52
+
+# Pascal hardware
+#CUDA_ARCH = -arch=sm_60
+#CUDA_ARCH = -arch=sm_61
+
+# Volta hardware
+#CUDA_ARCH = -arch=sm_70
+
+# Turing hardware
+#CUDA_ARCH = -arch=sm_75
 
 # this setting should match LAMMPS Makefile
 # one of LAMMPS_SMALLBIG (default), LAMMPS_BIGBIG and LAMMPS_SMALLSMALL
@@ -33,7 +56,7 @@ CUDA_PRECISION = -D_SINGLE_DOUBLE
 
 CUDA_INCLUDE = -I$(CUDA_HOME)/include
 CUDA_LIB = -L$(CUDA_HOME)/lib64 -L$(CUDA_HOME)/lib64/stubs
-CUDA_OPTS = -DUNIX -O3 --use_fast_math
+CUDA_OPTS = -DUNIX -O3 --use_fast_math $(LMP_INC) -Xcompiler -fPIC
 
 CUDR_CPP = mpic++ -DMPI_GERYON -DUCL_NO_EXIT -DMPICH_IGNORE_CXX_SEEK
 CUDR_OPTS = -O2 # -xHost -no-prec-div -ansi-alias

--- a/lib/gpu/Makefile.linux.single
+++ b/lib/gpu/Makefile.linux.single
@@ -7,17 +7,39 @@
 
 EXTRAMAKE = Makefile.lammps.standard
 
+ifeq ($(CUDA_HOME),)
 CUDA_HOME = /usr/local/cuda
+endif
+
 NVCC = nvcc
 
-# Kepler CUDA
-#CUDA_ARCH = -arch=sm_35
-# Tesla CUDA
-CUDA_ARCH = -arch=sm_21
-# newer CUDA
+# obsolete hardware. not supported by current drivers anymore.
 #CUDA_ARCH = -arch=sm_13
-# older CUDA
 #CUDA_ARCH = -arch=sm_10 -DCUDA_PRE_THREE
+
+# Fermi hardware
+#CUDA_ARCH = -arch=sm_20
+#CUDA_ARCH = -arch=sm_21
+
+# Kepler hardware
+#CUDA_ARCH = -arch=sm_30
+#CUDA_ARCH = -arch=sm_32
+#CUDA_ARCH = -arch=sm_35
+#CUDA_ARCH = -arch=sm_37
+
+# Maxwell hardware
+CUDA_ARCH = -arch=sm_50
+#CUDA_ARCH = -arch=sm_52
+
+# Pascal hardware
+#CUDA_ARCH = -arch=sm_60
+#CUDA_ARCH = -arch=sm_61
+
+# Volta hardware
+#CUDA_ARCH = -arch=sm_70
+
+# Turing hardware
+#CUDA_ARCH = -arch=sm_75
 
 # this setting should match LAMMPS Makefile
 # one of LAMMPS_SMALLBIG (default), LAMMPS_BIGBIG and LAMMPS_SMALLSMALL
@@ -33,7 +55,7 @@ CUDA_PRECISION = -D_SINGLE_SINGLE
 
 CUDA_INCLUDE = -I$(CUDA_HOME)/include
 CUDA_LIB = -L$(CUDA_HOME)/lib64 -L$(CUDA_HOME)/lib64/stubs
-CUDA_OPTS = -DUNIX -O3 --use_fast_math
+CUDA_OPTS = -DUNIX -O3 --use_fast_math $(LMP_INC) -Xcompiler -fPIC
 
 CUDR_CPP = mpic++ -DMPI_GERYON -DUCL_NO_EXIT -DMPICH_IGNORE_CXX_SEEK
 CUDR_OPTS = -O2 # -xHost -no-prec-div -ansi-alias

--- a/lib/gpu/Makefile.linux_multi
+++ b/lib/gpu/Makefile.linux_multi
@@ -19,11 +19,11 @@ NVCC = nvcc
 #CUDA_ARCH = -arch=sm_13
 # older CUDA
 #CUDA_ARCH = -arch=sm_10 -DCUDA_PRE_THREE
-CUDA_ARCH = -arch=sm_30
+CUDA_ARCH = -arch=sm_50
 
-CUDA_CODE = -gencode arch=compute_60,code=[sm_60,compute_60] -gencode arch=compute_61,code=[sm_61,compute_61] \
-	    -gencode arch=compute_30,code=[sm_30,compute_30] -gencode arch=compute_35,code=[sm_35,compute_35] \
-	    -gencode arch=compute_50,code=[sm_50,compute_50] -gencode arch=compute_52,code=[sm_52,compute_52]
+CUDA_CODE = -gencode arch=compute_50,code=[sm_50,compute_50] -gencode arch=compute_52,code=[sm_52,compute_52] \
+	    -gencode arch=compute_60,code=[sm_60,compute_60] -gencode arch=compute_61,code=[sm_61,compute_61] \
+	    -gencode arch=compute_70,code=[sm_70,compute_70] -gencode arch=compute_75,code=[sm_75,compute_75]
 
 CUDA_ARCH += $(CUDA_CODE)
 

--- a/lib/gpu/Makefile.linux_multi
+++ b/lib/gpu/Makefile.linux_multi
@@ -13,13 +13,23 @@ endif
 
 NVCC = nvcc
 
-# Kepler CUDA
-#CUDA_ARCH = -arch=sm_35
-# newer CUDA
+# obsolete hardware. not supported by current drivers anymore.
 #CUDA_ARCH = -arch=sm_13
-# older CUDA
 #CUDA_ARCH = -arch=sm_10 -DCUDA_PRE_THREE
+
+# Fermi hardware
+#CUDA_ARCH = -arch=sm_20
+#CUDA_ARCH = -arch=sm_21
+
+# Kepler hardware
+#CUDA_ARCH = -arch=sm_30
+#CUDA_ARCH = -arch=sm_32
+#CUDA_ARCH = -arch=sm_35
+#CUDA_ARCH = -arch=sm_37
+
+# Maxwell hardware
 CUDA_ARCH = -arch=sm_50
+#CUDA_ARCH = -arch=sm_52
 
 CUDA_CODE = -gencode arch=compute_50,code=[sm_50,compute_50] -gencode arch=compute_52,code=[sm_52,compute_52] \
 	    -gencode arch=compute_60,code=[sm_60,compute_60] -gencode arch=compute_61,code=[sm_61,compute_61] \

--- a/lib/gpu/Makefile.serial
+++ b/lib/gpu/Makefile.serial
@@ -13,13 +13,33 @@ endif
 
 NVCC = nvcc
 
-# Tesla CUDA
-CUDA_ARCH = -arch=sm_21
-# newer CUDA
+# obsolete hardware. not supported by current drivers anymore.
 #CUDA_ARCH = -arch=sm_13
-# older CUDA
 #CUDA_ARCH = -arch=sm_10 -DCUDA_PRE_THREE
-CUDA_ARCH = -arch=sm_35
+
+# Fermi hardware
+#CUDA_ARCH = -arch=sm_20
+#CUDA_ARCH = -arch=sm_21
+
+# Kepler hardware
+#CUDA_ARCH = -arch=sm_30
+#CUDA_ARCH = -arch=sm_32
+#CUDA_ARCH = -arch=sm_35
+#CUDA_ARCH = -arch=sm_37
+
+# Maxwell hardware
+CUDA_ARCH = -arch=sm_50
+#CUDA_ARCH = -arch=sm_52
+
+# Pascal hardware
+#CUDA_ARCH = -arch=sm_60
+#CUDA_ARCH = -arch=sm_61
+
+# Volta hardware
+#CUDA_ARCH = -arch=sm_70
+
+# Turing hardware
+#CUDA_ARCH = -arch=sm_75
 
 # this setting should match LAMMPS Makefile
 # one of LAMMPS_SMALLBIG (default), LAMMPS_BIGBIG and LAMMPS_SMALLSMALL
@@ -35,7 +55,7 @@ CUDA_PRECISION = -D_SINGLE_DOUBLE
 
 CUDA_INCLUDE = -I$(CUDA_HOME)/include
 CUDA_LIB = -L$(CUDA_HOME)/lib64 -L$(CUDA_HOME)/lib64/stubs -L../../src/STUBS -lmpi_stubs
-CUDA_OPTS = -DUNIX -O3 --use_fast_math $(LMP_INC)
+CUDA_OPTS = -DUNIX -O3 --use_fast_math $(LMP_INC) -Xcompiler -fPIC
 
 CUDR_CPP = g++ -DMPI_GERYON -DUCL_NO_EXIT -fPIC -I../../src/STUBS
 CUDR_OPTS = -O2 $(LMP_INC) # -xHost -no-prec-div -ansi-alias


### PR DESCRIPTION
**Summary**

The PR updates the default compute capabiity from 3.0 (and 3.5) to 5.0 for the conventional CUDA builds of the GPU package.

**Related Issues**

This is to keep the conventional build in sync with the CMake setting.

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

For NVIDIA GPUs with compute capability of 3.5 or 3.7 (Kepler), manual changes to CUDA_ARCH are needed. For example,  in Makefile.linux, uncomment the line CUDA_ARCH = -arch=sm_35

**Post Submission Checklist**


- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


