### PR TITLE
Use modernized version of sphinx-fortran

### DIFF
--- a/doc/utils/requirements.txt
+++ b/doc/utils/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx
 sphinxcontrib-spelling
-sphinx-fortran
+git+https://github.com/akohlmey/sphinx-fortran@parallel-read
 breathe
 Pygments


### PR DESCRIPTION
**Summary**

This temporarily diverts the installation of the sphinx Fortran extension to a version with support for parallel reads, which should make processing faster and silence some annoying warning message.  The code is submitted for inclusion into upstream, so eventually this can be reverted back to the original entry after the new version has made it to PyPI.

**Author(s)**

Axel Kohlmeyer and Richard Berger, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The added/updated documentation is integrated and tested with the documentation build system
