### PR TITLE
Add ability to retrieve the MPI communicator from LAMMPS instance via library/python interface

### DIFF
--- a/doc/src/pg_lib_properties.rst
+++ b/doc/src/pg_lib_properties.rst
@@ -21,6 +21,11 @@ event as atoms are migrating between sub-domains.
 
 -----------------------
 
+.. doxygenfunction:: lammps_get_mpi_comm
+   :project: progguide
+
+-----------------------
+
 .. doxygenfunction:: lammps_get_natoms
    :project: progguide
 

--- a/python/lammps.py
+++ b/python/lammps.py
@@ -332,6 +332,8 @@ class lammps(object):
 
     self.lib.lammps_version.argtypes = [c_void_p]
 
+    self.lib.lammps_get_mpi_comm.argtypes = [c_void_p]
+
     self.lib.lammps_decode_image_flags.argtypes = [self.c_imageint, POINTER(c_int*3)]
 
     self.lib.lammps_extract_atom.argtypes = [c_void_p, c_char_p]
@@ -598,6 +600,28 @@ class lammps(object):
     :rtype:  int
     """
     return self.lib.lammps_version(self.lmp)
+
+  # -------------------------------------------------------------------------
+
+  def get_mpi_comm(self):
+    """Get the MPI communicator in use by the current LAMMPS instance
+
+    This is a wrapper around the :cpp:func:`lammps_get_mpi_comm` function
+    of the C-library interface.  It will return ``None`` if either the
+    LAMMPS library was compiled without MPI support or the mpi4py
+    Python module is not available.
+
+    :return: MPI communicator
+    :rtype:  MPI_Comm
+    """
+
+    if self.has_mpi4py and self.has_mpi_support:
+        from mpi4py import MPI
+        f_comm = self.lib.lammps_get_mpi_comm(self.lmp)
+        c_comm = MPI.Comm.f2py(f_comm)
+        return c_comm
+    else:
+        return None
 
   # -------------------------------------------------------------------------
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -532,6 +532,40 @@ int lammps_version(void *handle)
   return atoi(lmp->universe->num_ver);
 }
 
+
+/* ---------------------------------------------------------------------- */
+
+/** Return current LAMMPS world communicator as integer
+ *
+\verbatim embed:rst
+
+This will take the LAMMPS "world" communicator and convert it to an
+integer using ``MPI_Comm_c2f()``, so it is equivalent to the
+corresponding MPI communicator in Fortran. This way it can be safely
+passed around between different programming languages.  To convert it
+to the C language representation use ``MPI_Comm_f2c()``.
+
+If LAMMPS was compiled with MPI_STUBS, this function returns -1.
+
+.. versionadded:: 15Sep2020
+
+\endverbatim
+ * \sa lammps_open_fortran
+ *
+ * \param  handle  pointer to a previously created LAMMPS instance
+ * \return         Fortran representation of the LAMMPS world communicator */
+
+int lammps_get_mpi_comm(void *handle)
+{
+#ifdef MPI_STUBS
+  return -1;
+#else
+  LAMMPS *lmp = (LAMMPS *) handle;
+  MPI_Fint f_comm = MPI_Comm_c2f(lmp->world);
+  return f_comm;
+#endif
+}
+
 /* ---------------------------------------------------------------------- */
 
 /** Return the total number of atoms in the system.

--- a/src/library.h
+++ b/src/library.h
@@ -98,6 +98,7 @@ void  lammps_commands_string(void *handle, const char *str);
  * ----------------------------------------------------------------------- */
 
 int    lammps_version(void *handle);
+int    lammps_get_mpi_comm(void* handle);
 double lammps_get_natoms(void *handle);
 double lammps_get_thermo(void *handle, char *keyword);
 

--- a/unittest/c-library/test_library_properties.cpp
+++ b/unittest/c-library/test_library_properties.cpp
@@ -41,5 +41,13 @@ protected:
     }
 };
 
+TEST_F(LAMMPS_properties, get_mpi_comm) {
+    int f_comm = lammps_get_mpi_comm(lmp);
+    if (lammps_config_has_mpi_support())
+        EXPECT_GE(f_comm,0);
+    else
+        EXPECT_EQ(f_comm,-1);
+};
+
 TEST_F(LAMMPS_properties, box) {
 };


### PR DESCRIPTION
**Summary**

This enables retrieving the communicator used by a LAMMPS instance in either the C-library interface or the python interface.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

For increased portability between programming languages and MPI implementations, the new library function returns the Fortran representation of the communicator, which is always an integer. It can be converted back using `MPI_Comm_f2c()`.

This is compatible with mpi4py and thus allows doing MPI calls from within Python functions that are launched via `python invoke` or similar.  A minimal example for using it is:
```
region box block 0 2 0 2 0 2
create_box 1 box

python pymod input 1 SELF format p here """

def pymod(lmpptr):
    from lammps import lammps
    lmp = lammps(ptr=lmpptr)

    comm = lmp.get_mpi_comm()
    size = comm.Get_size()
    rank = comm.Get_rank()
    print("This is rank %d of %d" % (rank,size))
"""

python pymod invoke
```
Which produces the following output when run with `mpirun -np 2 ./lmp -in in.mpi-in-python`:
```
LAMMPS (24 Aug 2020)
  using 1 OpenMP thread(s) per MPI task
Created orthogonal box = (0.0000000 0.0000000 0.0000000) to (2.0000000 2.0000000 2.0000000)
  1 by 1 by 2 MPI processor grid
This is rank 0 of 2
This is rank 1 of 2
Total wall time: 0:00:00
```

And, more importantly, when run with `mpirun -np 4 ./lmp -p 2x2 -in in.mpi-in-python`:
```
LAMMPS (24 Aug 2020)
Running on 2 partitions of processors
This is rank 0 of 2
This is rank 1 of 2
This is rank 0 of 2
This is rank 1 of 2
```

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
