### PR TITLE
Fixed a bug in computing the langevin torques applied to rigid bodies

### DIFF
--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -994,12 +994,7 @@ void FixRigid::apply_langevin_thermostat()
 
       // convert omega from space frame to body frame
 
-      wbody[0] = omega[i][0]*ex_space[i][0] + omega[i][1]*ex_space[i][1] +
-        omega[i][2]*ex_space[i][2];
-      wbody[1] = omega[i][0]*ey_space[i][0] + omega[i][1]*ey_space[i][1] +
-        omega[i][2]*ey_space[i][2];
-      wbody[2] = omega[i][0]*ez_space[i][0] + omega[i][1]*ez_space[i][1] +
-        omega[i][2]*ez_space[i][2];
+      MathExtra::transpose_matvec(ex_space[i],ey_space[i],ez_space[i],omega[i],wbody);
 
       // compute langevin torques in the body frame
 
@@ -1012,12 +1007,7 @@ void FixRigid::apply_langevin_thermostat()
 
       // convert langevin torques from body frame back to space frame
 
-      langextra[i][3] = tbody[0]*ex_space[i][0] + tbody[1]*ey_space[i][0] +
-        tbody[2]*ez_space[i][0];
-      langextra[i][4] = tbody[0]*ex_space[i][1] + tbody[1]*ey_space[i][1] +
-        tbody[2]*ez_space[i][1];
-      langextra[i][5] = tbody[0]*ex_space[i][2] + tbody[1]*ey_space[i][2] +
-        tbody[2]*ez_space[i][2];
+      MathExtra::matvec(ex_space[i],ey_space[i],ez_space[i],tbody,&langextra[i][3]);
     }
   }
 

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -970,7 +970,7 @@ void FixRigid::apply_langevin_thermostat()
 {
   if (me == 0) {
     double gamma1,gamma2;
-
+    double wbody[3],tbody[3];
     double delta = update->ntimestep - update->beginstep;
     if (delta != 0.0) delta /= update->endstep - update->beginstep;
     t_target = t_start + delta * (t_stop-t_start);
@@ -991,12 +991,33 @@ void FixRigid::apply_langevin_thermostat()
 
       gamma1 = -1.0 / t_period / ftm2v;
       gamma2 = tsqrt * sqrt(24.0*boltz/t_period/dt/mvv2e) / ftm2v;
-      langextra[i][3] = inertia[i][0]*gamma1*omega[i][0] +
+
+      // convert omega from space frame to body frame
+
+      wbody[0] = omega[i][0]*ex_space[i][0] + omega[i][1]*ex_space[i][1] +
+        omega[i][2]*ex_space[i][2];
+      wbody[1] = omega[i][0]*ey_space[i][0] + omega[i][1]*ey_space[i][1] +
+        omega[i][2]*ey_space[i][2];
+      wbody[2] = omega[i][0]*ez_space[i][0] + omega[i][1]*ez_space[i][1] +
+        omega[i][2]*ez_space[i][2];
+
+      // compute langevin torques in the body frame
+
+      tbody[0] = inertia[i][0]*gamma1*wbody[0] +
         sqrt(inertia[i][0])*gamma2*(random->uniform()-0.5);
-      langextra[i][4] = inertia[i][1]*gamma1*omega[i][1] +
+      tbody[1] = inertia[i][1]*gamma1*wbody[1] +
         sqrt(inertia[i][1])*gamma2*(random->uniform()-0.5);
-      langextra[i][5] = inertia[i][2]*gamma1*omega[i][2] +
+      tbody[2] = inertia[i][2]*gamma1*wbody[2] +
         sqrt(inertia[i][2])*gamma2*(random->uniform()-0.5);
+
+      // convert langevin torques from body frame back to space frame
+
+      langextra[i][3] = tbody[0]*ex_space[i][0] + tbody[1]*ey_space[i][0] +
+        tbody[2]*ez_space[i][0];
+      langextra[i][4] = tbody[0]*ex_space[i][1] + tbody[1]*ey_space[i][1] +
+        tbody[2]*ez_space[i][1];
+      langextra[i][5] = tbody[0]*ex_space[i][2] + tbody[1]*ey_space[i][2] +
+        tbody[2]*ez_space[i][2];
     }
   }
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -860,12 +860,7 @@ void FixRigidSmall::apply_langevin_thermostat()
 
     // convert omega from space frame to body frame
 
-    wbody[0] = omega[0]*ex_space[0] + omega[1]*ex_space[1] +
-      omega[2]*ex_space[2];
-    wbody[1] = omega[0]*ey_space[0] + omega[1]*ey_space[1] +
-      omega[2]*ey_space[2];
-    wbody[2] = omega[0]*ez_space[0] + omega[1]*ez_space[1] +
-      omega[2]*ez_space[2];
+    MathExtra::transpose_matvec(ex_space,ey_space,ez_space,omega,wbody);
 
     // compute langevin torques in the body frame
 
@@ -878,12 +873,7 @@ void FixRigidSmall::apply_langevin_thermostat()
 
     // convert langevin torques from body frame back to space frame
 
-    langextra[ibody][3] = tbody[0]*ex_space[0] + tbody[1]*ey_space[0] +
-      tbody[2]*ez_space[0];
-    langextra[ibody][4] = tbody[0]*ex_space[1] + tbody[1]*ey_space[1] +
-      tbody[2]*ez_space[1];
-    langextra[ibody][5] = tbody[0]*ex_space[2] + tbody[1]*ey_space[2] +
-      tbody[2]*ez_space[2];
+    MathExtra::matvec(ex_space,ey_space,ez_space,tbody,&langextra[ibody][3]);    
   }
 }
 


### PR DESCRIPTION
**Summary**

This PR addresses the issue reported by #2288 where the langevin thermostat inside fix rigid and fix rigid/small (and their variants) does not function as expected.

**Related Issues**

Closes #2288 

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The PR should respect backward compatibility.

**Implementation Notes**

From the tests done by @valesori regarding the issue #2288, it seems that the body rotational degrees of freedom are not thermostated properly. This is because the langevin torques (langextra[3], langextra[4] and langextra[5]) to be added to the bodies should be in the space frame. Originally these torques were computed from the principal moments of inertia (defined in the body frame) and the body angular velocities in the space frame (omega), which are inconsistent with each other. The changes in this PR do the following: 1) converting the body angular velocities from the space frame into the body frame, then 2) computing the langevin torques in the body frame, and 3) converting the torques from the body frame back to the space frame. 

Since other fix rigid variants derive from FixRigid or from FixRigidSmall, the changes in this PR are applicable to those variants as well.

Currently, the temporary variables wbody[3] and tbody[3] and the convertion back and forth between the space and body frames are for code readability.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

