### PR TITLE
Bond/react update all charges by default

### DIFF
--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -270,14 +270,14 @@ A discussion of correctly handling this is also provided on the
 The map file is a text document with the following format:
 
 A map file has a header and a body. The header of map file the
-contains one mandatory keyword and five optional keywords. The
+contains one mandatory keyword and four optional keywords. The
 mandatory keyword is 'equivalences':
 
 .. parsed-literal::
 
    N *equivalences* = # of atoms N in the reaction molecule templates
 
-The optional keywords are 'edgeIDs', 'deleteIDs', 'customIDs' and
+The optional keywords are 'edgeIDs', 'deleteIDs', 'chiralIDs' and
 'constraints':
 
 .. parsed-literal::
@@ -285,7 +285,6 @@ The optional keywords are 'edgeIDs', 'deleteIDs', 'customIDs' and
    N *edgeIDs* = # of edge atoms N in the pre-reacted molecule template
    N *deleteIDs* = # of atoms N that are specified for deletion
    N *chiralIDs* = # of specified chiral centers N
-   N *customIDs* = # of atoms N that are specified for a custom update
    N *constraints* = # of specified reaction constraints N
 
 The body of the map file contains two mandatory sections and four

--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -41,7 +41,7 @@ Syntax
 * template-ID(post-reacted) = ID of a molecule template containing post-reaction topology
 * map_file = name of file specifying corresponding atom-IDs in the pre- and post-reacted templates
 * zero or more individual keyword/value pairs may be appended to each react argument
-* individual_keyword = *prob* or *max_rxn* or *stabilize_steps* or *update_edges*
+* individual_keyword = *prob* or *max_rxn* or *stabilize_steps* or *custom_charges*
 
   .. parsed-literal::
 
@@ -52,10 +52,9 @@ Syntax
            N = maximum number of reactions allowed to occur
          *stabilize_steps* value = timesteps
            timesteps = number of timesteps to apply the internally-created :doc:`nve/limit <fix_nve_limit>` fix to reacting atoms
-         *update_edges* value = *none* or *charges* or *custom*
-           *none* = do not update topology near the edges of reaction templates
-           *charges* = update atomic charges of all atoms in reaction templates
-           *custom* = force the update of user-specified atomic charges
+         *custom_charges* value = *no* or *fragmentID*
+           no = update all atomic charges (default)
+           fragmentID = ID of molecule fragment whose charges are updated
 
 Examples
 """"""""
@@ -289,7 +288,7 @@ The optional keywords are 'edgeIDs', 'deleteIDs', 'customIDs' and
    N *customIDs* = # of atoms N that are specified for a custom update
    N *constraints* = # of specified reaction constraints N
 
-The body of the map file contains two mandatory sections and five
+The body of the map file contains two mandatory sections and four
 optional sections. The first mandatory section begins with the keyword
 'BondingIDs' and lists the atom IDs of the bonding atom pair in the
 pre-reacted molecule template. The second mandatory section begins
@@ -303,16 +302,11 @@ molecule template. The second optional section begins with the keyword
 'DeleteIDs' and lists the atom IDs of pre-reaction template atoms to
 delete. The third optional section begins with the keyword 'ChiralIDs'
 lists the atom IDs of chiral atoms whose handedness should be
-enforced. The fourth optional section begins with the keyword 'Custom
-Edges' and allows for forcing the update of a specific atom's atomic
-charge. The first column is the ID of an atom near the edge of the
-pre-reacted molecule template, and the value of the second column is
-either 'none' or 'charges.' Further details are provided in the
-discussion of the 'update_edges' keyword. The fifth optional section
-begins with the keyword 'Constraints' and lists additional criteria
-that must be satisfied in order for the reaction to occur. Currently,
-there are five types of constraints available, as discussed below:
-'distance', 'angle', 'dihedral', 'arrhenius', and 'rmsd'.
+enforced. The fourth optional section begins with the keyword
+'Constraints' and lists additional criteria that must be satisfied in
+order for the reaction to occur. Currently, there are five types of
+constraints available, as discussed below: 'distance', 'angle',
+'dihedral', 'arrhenius', and 'rmsd'.
 
 A sample map file is given below:
 
@@ -488,17 +482,12 @@ individually tuned for each fix reaction step. Note that in some
 situations, decreasing rather than increasing this parameter will
 result in an increase in stability.
 
-The *update_edges* keyword can increase the number of atoms whose
-atomic charges are updated, when the pre-reaction template contains
-edge atoms. When the value is set to 'charges,' all atoms' atomic
-charges are updated to those specified by the post-reaction template,
-including atoms near the edge of reaction templates. When the value is
-set to 'custom,' an additional section must be included in the map
-file that specifies whether or not to update charges, on a per-atom
-basis. The format of this section is detailed above. Listing a
-pre-reaction atom ID with a value of 'charges' will force the update
-of the atom's charge, even if it is near a template edge. Atoms not
-near a template edge are unaffected by this setting.
+The *custom_charges* keyword can be used to specify which atoms'
+atomic charges are updated. When the value is set to 'no,' all atomic
+charges are updated to those specified by the post-reaction template
+(default). Otherwise, the value should be the name of a molecule
+fragment defined in the pre-reaction molecule template. In this case,
+only the atomic charges of atoms in the molecule fragment are updated.
 
 A few other considerations:
 
@@ -584,7 +573,7 @@ Default
 """""""
 
 The option defaults are stabilization = no, prob = 1.0, stabilize_steps = 60,
-reset_mol_ids = yes, update_edges = none
+reset_mol_ids = yes, custom_charges = no
 
 ----------
 

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -2643,11 +2643,11 @@ void FixBondReact::update_everything()
       twomol = atom->molecules[reacted_mol[rxnID]];
       for (int j = 0; j < twomol->natoms; j++) {
         int jj = equivalences[j][1][rxnID]-1;
-        if ((landlocked_atoms[j][rxnID] == 1 || custom_charges[jj][rxnID] == 1) &&
-            atom->map(update_mega_glove[jj+1][i]) >= 0 &&
+        if (atom->map(update_mega_glove[jj+1][i]) >= 0 &&
             atom->map(update_mega_glove[jj+1][i]) < nlocal) {
-          type[atom->map(update_mega_glove[jj+1][i])] = twomol->type[j];
-          if (twomol->qflag && atom->q_flag) {
+          if (landlocked_atoms[j][rxnID] == 1)
+            type[atom->map(update_mega_glove[jj+1][i])] = twomol->type[j];
+          if (twomol->qflag && atom->q_flag && custom_charges[jj][rxnID] == 1) {
             double *q = atom->q;
             q[atom->map(update_mega_glove[jj+1][i])] = twomol->q[j];
           }

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -438,7 +438,7 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
   }
   delete [] files;
 
-  if (atom->molecular != Atom::ATOMIC)
+  if (atom->molecular != Atom::MOLECULAR)
     error->all(FLERR,"Bond/react: Cannot use fix bond/react with non-molecular systems");
 
   // check if bonding atoms are 1-2, 1-3, or 1-4 bonded neighbors

--- a/src/USER-REACTION/fix_bond_react.h
+++ b/src/USER-REACTION/fix_bond_react.h
@@ -64,7 +64,7 @@ class FixBondReact : public Fix {
   int reset_mol_ids_flag;
   int custom_exclude_flag;
   int *stabilize_steps_flag;
-  int *update_edges_flag;
+  int *custom_charges_fragid;
   int nconstraints;
   int narrhenius;
   double **constraints;
@@ -113,7 +113,7 @@ class FixBondReact : public Fix {
 
   int *ibonding,*jbonding;
   int *closeneigh; // indicates if bonding atoms of a rxn are 1-2, 1-3, or 1-4 neighbors
-  int nedge,nequivalent,ncustom,ndelete,nchiral,nconstr; // # edge, equivalent, custom atoms in mapping file
+  int nedge,nequivalent,ndelete,nchiral,nconstr; // # edge, equivalent atoms in mapping file
   int attempted_rxn; // there was an attempt!
   int *local_rxn_count;
   int *ghostly_rxn_count;
@@ -127,7 +127,7 @@ class FixBondReact : public Fix {
   int ***equivalences; // relation between pre- and post-reacted templates
   int ***reverse_equiv; // re-ordered equivalences
   int **landlocked_atoms; // all atoms at least three bonds away from edge atoms
-  int **custom_edges; // atoms in molecule templates with incorrect valences
+  int **custom_charges; // atoms whose charge should be updated
   int **delete_atoms; // atoms in pre-reacted templates to delete
   int ***chiral_atoms; // pre-react chiral atoms. 1) flag 2) orientation 3-4) ordered atom types
 
@@ -151,8 +151,8 @@ class FixBondReact : public Fix {
   void read(int);
   void EdgeIDs(char *, int);
   void Equivalences(char *, int);
-  void CustomEdges(char *, int);
   void DeleteAtoms(char *, int);
+  void CustomCharges(int, int);
   void ChiralCenters(char *, int);
   void Constraints(char *, int);
   void readID(char *, int, int, int);


### PR DESCRIPTION
**Summary**

update all atomic charges by default (which was not the case previously, when there were edge atoms). this is much more intuitive behavior.

precise control over which charges are updated is still possible, but now using molecule fragments. also, keyword has been updated to be more intuitive

thanks to György Hantal for bringing this up

also, bugfix for recent changes in #2360

**Related Issues**

none

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

*Not backwards compatible*, when edge atoms are included. New default behavior, and keywords have changed

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


