### PR TITLE
Additional Kokkos/HIP porting work

### DIFF
--- a/src/KOKKOS/atom_vec_kokkos.h
+++ b/src/KOKKOS/atom_vec_kokkos.h
@@ -137,24 +137,24 @@ class AtomVecKokkos : public AtomVec {
   size_t buffer_size;
   void* buffer;
 
-  #ifdef KOKKOS_ENABLE_CUDA
+  #ifdef LMP_KOKKOS_GPU
   template<class ViewType>
   Kokkos::View<typename ViewType::data_type,
                typename ViewType::array_layout,
-               Kokkos::CudaHostPinnedSpace,
+               LMPPinnedHostType,
                Kokkos::MemoryTraits<Kokkos::Unmanaged> >
   create_async_copy(const ViewType& src) {
     typedef Kokkos::View<typename ViewType::data_type,
                  typename ViewType::array_layout,
                  typename std::conditional<
                    std::is_same<typename ViewType::execution_space,LMPDeviceType>::value,
-                   Kokkos::CudaHostPinnedSpace,typename ViewType::memory_space>::type,
+                   LMPPinnedHostType,typename ViewType::memory_space>::type,
                  Kokkos::MemoryTraits<Kokkos::Unmanaged> > mirror_type;
     if (buffer_size == 0) {
-       buffer = Kokkos::kokkos_malloc<Kokkos::CudaHostPinnedSpace>(src.span());
+       buffer = Kokkos::kokkos_malloc<LMPPinnedHostType>(src.span());
        buffer_size = src.span();
     } else if (buffer_size < src.span()) {
-       buffer = Kokkos::kokkos_realloc<Kokkos::CudaHostPinnedSpace>(buffer,src.span());
+       buffer = Kokkos::kokkos_realloc<LMPPinnedHostType>(buffer,src.span());
        buffer_size = src.span();
     }
     return mirror_type(buffer, src.d_view.layout());
@@ -166,13 +166,13 @@ class AtomVecKokkos : public AtomVec {
                  typename ViewType::array_layout,
                  typename std::conditional<
                    std::is_same<typename ViewType::execution_space,LMPDeviceType>::value,
-                   Kokkos::CudaHostPinnedSpace,typename ViewType::memory_space>::type,
+                   LMPPinnedHostType,typename ViewType::memory_space>::type,
                  Kokkos::MemoryTraits<Kokkos::Unmanaged> > mirror_type;
     if (buffer_size == 0) {
-       buffer = Kokkos::kokkos_malloc<Kokkos::CudaHostPinnedSpace>(src.span()*sizeof(typename ViewType::value_type));
+       buffer = Kokkos::kokkos_malloc<LMPPinnedHostType>(src.span()*sizeof(typename ViewType::value_type));
        buffer_size = src.span();
     } else if (buffer_size < src.span()) {
-       buffer = Kokkos::kokkos_realloc<Kokkos::CudaHostPinnedSpace>(buffer,src.span()*sizeof(typename ViewType::value_type));
+       buffer = Kokkos::kokkos_realloc<LMPPinnedHostType>(buffer,src.span()*sizeof(typename ViewType::value_type));
        buffer_size = src.span();
     }
     mirror_type tmp_view((typename ViewType::value_type*)buffer, src.d_view.layout());

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -419,7 +419,7 @@ void CommKokkos::forward_comm_pair_device(Pair *pair)
     if (sendproc[iswap] != me) {
       double* buf_send_pair;
       double* buf_recv_pair;
-      if (lmp->kokkos->cuda_aware_flag) {
+      if (lmp->kokkos->gpu_aware_flag) {
         buf_send_pair = k_buf_send_pair.view<DeviceType>().data();
         buf_recv_pair = k_buf_recv_pair.view<DeviceType>().data();
       } else {
@@ -437,7 +437,7 @@ void CommKokkos::forward_comm_pair_device(Pair *pair)
         MPI_Send(buf_send_pair,n,MPI_DOUBLE,sendproc[iswap],0,world);
       if (recvnum[iswap]) MPI_Wait(&request,MPI_STATUS_IGNORE);
 
-      if (!lmp->kokkos->cuda_aware_flag) {
+      if (!lmp->kokkos->gpu_aware_flag) {
         k_buf_recv_pair.modify<LMPHostType>();
         k_buf_recv_pair.sync<DeviceType>();
       }

--- a/src/KOKKOS/gridcomm_kokkos.cpp
+++ b/src/KOKKOS/gridcomm_kokkos.cpp
@@ -678,7 +678,7 @@ forward_comm_kspace_regular(KSpace *kspace, int nper, int which,
   KokkosBaseFFT* kspaceKKBase = dynamic_cast<KokkosBaseFFT*>(kspace);
   FFT_SCALAR* buf1;
   FFT_SCALAR* buf2;
-  if (lmp->kokkos->cuda_aware_flag) {
+  if (lmp->kokkos->gpu_aware_flag) {
     buf1 = k_buf1.view<DeviceType>().data();
     buf2 = k_buf2.view<DeviceType>().data();
   } else {
@@ -695,7 +695,7 @@ forward_comm_kspace_regular(KSpace *kspace, int nper, int which,
 
     if (swap[m].sendproc != me) {
 
-      if (!lmp->kokkos->cuda_aware_flag) {
+      if (!lmp->kokkos->gpu_aware_flag) {
         k_buf1.modify<DeviceType>();
         k_buf1.sync<LMPHostType>();
       }
@@ -706,7 +706,7 @@ forward_comm_kspace_regular(KSpace *kspace, int nper, int which,
                                   swap[m].sendproc,0,gridcomm);
       if (swap[m].nunpack) MPI_Wait(&request,MPI_STATUS_IGNORE);
 
-      if (!lmp->kokkos->cuda_aware_flag) {
+      if (!lmp->kokkos->gpu_aware_flag) {
         k_buf2.modify<LMPHostType>();
         k_buf2.sync<DeviceType>();
       }
@@ -731,7 +731,7 @@ forward_comm_kspace_tiled(KSpace *kspace, int nper, int which,
   KokkosBaseFFT* kspaceKKBase = dynamic_cast<KokkosBaseFFT*>(kspace);
   FFT_SCALAR* buf1;
   FFT_SCALAR* buf2;
-  if (lmp->kokkos->cuda_aware_flag) {
+  if (lmp->kokkos->gpu_aware_flag) {
     buf1 = k_buf1.view<DeviceType>().data();
     buf2 = k_buf2.view<DeviceType>().data();
   } else {
@@ -753,7 +753,7 @@ forward_comm_kspace_tiled(KSpace *kspace, int nper, int which,
     kspaceKKBase->pack_forward_grid_kokkos(which,k_buf1,send[m].npack,k_send_packlist,m);
     DeviceType().fence();
 
-    if (!lmp->kokkos->cuda_aware_flag) {
+    if (!lmp->kokkos->gpu_aware_flag) {
       k_buf1.modify<DeviceType>();
       k_buf1.sync<LMPHostType>();
     }
@@ -773,7 +773,7 @@ forward_comm_kspace_tiled(KSpace *kspace, int nper, int which,
   for (i = 0; i < nrecv; i++) {
     MPI_Waitany(nrecv,requests,&m,MPI_STATUS_IGNORE);
 
-    if (!lmp->kokkos->cuda_aware_flag) {
+    if (!lmp->kokkos->gpu_aware_flag) {
       k_buf2.modify<LMPHostType>();
       k_buf2.sync<DeviceType>();
     }
@@ -814,7 +814,7 @@ reverse_comm_kspace_regular(KSpace *kspace, int nper, int which,
   KokkosBaseFFT* kspaceKKBase = dynamic_cast<KokkosBaseFFT*>(kspace);
   FFT_SCALAR* buf1;
   FFT_SCALAR* buf2;
-  if (lmp->kokkos->cuda_aware_flag) {
+  if (lmp->kokkos->gpu_aware_flag) {
     buf1 = k_buf1.view<DeviceType>().data();
     buf2 = k_buf2.view<DeviceType>().data();
   } else {
@@ -831,7 +831,7 @@ reverse_comm_kspace_regular(KSpace *kspace, int nper, int which,
 
     if (swap[m].recvproc != me) {
 
-      if (!lmp->kokkos->cuda_aware_flag) {
+      if (!lmp->kokkos->gpu_aware_flag) {
         k_buf1.modify<DeviceType>();
         k_buf1.sync<LMPHostType>();
       }
@@ -843,7 +843,7 @@ reverse_comm_kspace_regular(KSpace *kspace, int nper, int which,
       if (swap[m].npack) MPI_Wait(&request,MPI_STATUS_IGNORE);
 
 
-      if (!lmp->kokkos->cuda_aware_flag) {
+      if (!lmp->kokkos->gpu_aware_flag) {
         k_buf2.modify<LMPHostType>();
         k_buf2.sync<DeviceType>();
       }
@@ -869,7 +869,7 @@ reverse_comm_kspace_tiled(KSpace *kspace, int nper, int which,
 
   FFT_SCALAR* buf1;
   FFT_SCALAR* buf2;
-  if (lmp->kokkos->cuda_aware_flag) {
+  if (lmp->kokkos->gpu_aware_flag) {
     buf1 = k_buf1.view<DeviceType>().data();
     buf2 = k_buf2.view<DeviceType>().data();
   } else {
@@ -891,7 +891,7 @@ reverse_comm_kspace_tiled(KSpace *kspace, int nper, int which,
     kspaceKKBase->pack_reverse_grid_kokkos(which,k_buf1,recv[m].nunpack,k_recv_unpacklist,m);
     DeviceType().fence();
 
-    if (!lmp->kokkos->cuda_aware_flag) {
+    if (!lmp->kokkos->gpu_aware_flag) {
       k_buf1.modify<DeviceType>();
       k_buf1.sync<LMPHostType>();
     }
@@ -911,7 +911,7 @@ reverse_comm_kspace_tiled(KSpace *kspace, int nper, int which,
   for (i = 0; i < nsend; i++) {
     MPI_Waitany(nsend,requests,&m,MPI_STATUS_IGNORE);
 
-    if (!lmp->kokkos->cuda_aware_flag) {
+    if (!lmp->kokkos->gpu_aware_flag) {
       k_buf2.modify<LMPHostType>();
       k_buf2.sync<DeviceType>();
     }

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -38,7 +38,7 @@ class KokkosLMP : protected Pointers {
   int nthreads,ngpus;
   int numa;
   int auto_sync;
-  int cuda_aware_flag;
+  int gpu_aware_flag;
   int neigh_thread;
   int neigh_thread_set;
   int newtonflag;

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -211,6 +211,21 @@ struct ExecutionSpaceFromDevice<Kokkos::Experimental::HIP> {
 };
 #endif
 
+// set host pinned space
+#if defined(KOKKOS_ENABLE_CUDA)
+typedef Kokkos::CudaHostPinnedSpace LMPPinnedHostType;
+#elif defined(KOKKOS_ENABLE_HIP)
+typedef Kokkos::Experimental::HIPHostPinnedSpace LMPPinnedHostType;
+#endif
+
+// create simple LMPDeviceSpace typedef for non HIP or CUDA specific
+// behaviour
+#if defined(KOKKOS_ENABLE_CUDA)
+typedef Kokkos::Cuda LMPDeviceSpace;
+#elif defined(KOKKOS_ENABLE_HIP)
+typedef Kokkos::Experimental::HIP LMPDeviceSpace;
+#endif
+
 
 // Determine memory traits for force array
 // Do atomic trait when running HALFTHREAD neighbor list style
@@ -239,7 +254,7 @@ struct AtomicDup<HALFTHREAD,Kokkos::Cuda> {
 };
 #endif
 
-#if defined(KOKKOS_ENABLE_HIP)
+#ifdef KOKKOS_ENABLE_HIP
 template<>
 struct AtomicDup<HALFTHREAD,Kokkos::Experimental::HIP> {
   using value = Kokkos::Experimental::ScatterAtomic;

--- a/src/KOKKOS/npair_kokkos.h
+++ b/src/KOKKOS/npair_kokkos.h
@@ -310,7 +310,7 @@ class NeighborKokkosExecute
   KOKKOS_FUNCTION
   void build_ItemSize(const int &i) const;
 
-#ifdef KOKKOS_ENABLE_CUDA
+#ifdef LMP_KOKKOS_GPU
   template<int HalfNeigh, int Newton, int Tri>
   __device__ inline
   void build_ItemCuda(typename Kokkos::TeamPolicy<DeviceType>::member_type dev) const;
@@ -387,7 +387,7 @@ struct NPairKokkosBuildFunctor {
   void operator() (const int & i) const {
     c.template build_Item<HALF_NEIGH,GHOST_NEWTON,TRI>(i);
   }
-#ifdef KOKKOS_ENABLE_CUDA
+#ifdef LMP_KOKKOS_GPU
   __device__ inline
 
   void operator() (typename Kokkos::TeamPolicy<DeviceType>::member_type dev) const {
@@ -445,7 +445,7 @@ struct NPairKokkosBuildFunctorSize {
     c.template build_ItemSize<HALF_NEIGH,GHOST_NEWTON,TRI>(i);
   }
 
-#ifdef KOKKOS_ENABLE_CUDA
+#ifdef LMP_KOKKOS_GPU
   __device__ inline
   void operator() (typename Kokkos::TeamPolicy<DeviceType>::member_type dev) const {
     c.template build_ItemSizeCuda<HALF_NEIGH,GHOST_NEWTON,TRI>(dev);

--- a/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
+++ b/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
@@ -112,10 +112,10 @@ void PairDPDfdtEnergyKokkos<DeviceType>::init_style()
 #endif
 }
 
-#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)) || defined(KOKKOS_ENABLE_HIP)
 // CUDA specialization of init_style to properly call rand_pool.init()
 template<>
-void PairDPDfdtEnergyKokkos<Kokkos::Cuda>::init_style()
+void PairDPDfdtEnergyKokkos<LMPDeviceSpace>::init_style()
 {
   PairDPDfdtEnergy::init_style();
 
@@ -125,10 +125,10 @@ void PairDPDfdtEnergyKokkos<Kokkos::Cuda>::init_style()
   int irequest = neighbor->nrequest - 1;
 
   neighbor->requests[irequest]->
-    kokkos_host = std::is_same<Kokkos::Cuda,LMPHostType>::value &&
-    !std::is_same<Kokkos::Cuda,LMPDeviceType>::value;
+    kokkos_host = std::is_same<LMPDeviceSpace,LMPHostType>::value &&
+    !std::is_same<LMPDeviceSpace,LMPDeviceType>::value;
   neighbor->requests[irequest]->
-    kokkos_device = std::is_same<Kokkos::Cuda,LMPDeviceType>::value;
+    kokkos_device = std::is_same<LMPDeviceSpace,LMPDeviceType>::value;
 
   if (neighflag == FULL) {
     neighbor->requests[irequest]->full = 1;

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -811,22 +811,22 @@ void PPPMKokkos<DeviceType>::allocate()
   // remap takes data from 3d brick to FFT decomposition
 
   int collective_flag = 0; // not yet supported in Kokkos version
-  int cuda_aware_flag = lmp->kokkos->cuda_aware_flag;
+  int gpu_aware_flag = lmp->kokkos->gpu_aware_flag;
   int tmp;
 
   fft1 = new FFT3dKokkos<DeviceType>(lmp,world,nx_pppm,ny_pppm,nz_pppm,
                          nxlo_fft,nxhi_fft,nylo_fft,nyhi_fft,nzlo_fft,nzhi_fft,
                          nxlo_fft,nxhi_fft,nylo_fft,nyhi_fft,nzlo_fft,nzhi_fft,
-                         0,0,&tmp,collective_flag,cuda_aware_flag);
+                         0,0,&tmp,collective_flag,gpu_aware_flag);
 
   fft2 = new FFT3dKokkos<DeviceType>(lmp,world,nx_pppm,ny_pppm,nz_pppm,
                          nxlo_fft,nxhi_fft,nylo_fft,nyhi_fft,nzlo_fft,nzhi_fft,
                          nxlo_in,nxhi_in,nylo_in,nyhi_in,nzlo_in,nzhi_in,
-                         0,0,&tmp,collective_flag,cuda_aware_flag);
+                         0,0,&tmp,collective_flag,gpu_aware_flag);
   remap = new RemapKokkos<DeviceType>(lmp,world,
                           nxlo_in,nxhi_in,nylo_in,nyhi_in,nzlo_in,nzhi_in,
                           nxlo_fft,nxhi_fft,nylo_fft,nyhi_fft,nzlo_fft,nzhi_fft,
-                          1,0,0,FFT_PRECISION,collective_flag,cuda_aware_flag);
+                          1,0,0,FFT_PRECISION,collective_flag,gpu_aware_flag);
 
   // create ghost grid object for rho and electric field communication
   // also create 2 bufs for ghost grid cell comm, passed to GridComm methods


### PR DESCRIPTION
@stanmoore1 -- FYI, got my additional HIP changes through the review process.  

Marking as WIP, as this is more a grab-bag of the (stable) changes I have on my end.  Completely open to feedback on what we want to incorporate at this point, and what to hold back.  

**Summary**

- Add LMPPinnedHostType to switch between CUDA and HIP  
- Add rename "cuda_aware_*" to "gpu_aware_*".  Right now it (should) default to non-GPU aware MPI for HIP, but are working to see if we can detect ROCm + UCX MPI  (e.g., https://github.com/openucx/ucx/wiki/Build-and-run-ROCM-UCX-OpenMPI)  
- Add syncthreads_count workaround for ROCm < 3.7  
- Enable build_ItemCuda to take CUDA path for HIP as well

**Related Issues**

N/A

**Author(s)**

Nick Curtis: arghdos@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Not to my knowledge -- but I am not 100% sure that the current Kokkos version bundled w/ LAMMPS has the HIPHostPinnedType overloads.

**Implementation Notes**

Tested on all the benchmarks in lammps/bench w/ ROCm 3.7.
Known failures include PME solves (rocFFT support being added), and some of the larger (in terms of kernel size) benchmarks, e.g., ReaxFF.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**



