### PR TITLE
Update bundled fmtlib to version 7.0.3

### DIFF
--- a/src/fmt/core.h
+++ b/src/fmt/core.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
-#define FMT_VERSION 70002
+#define FMT_VERSION 70003
 
 #ifdef __clang__
 #  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
@@ -305,7 +305,7 @@ template <typename T> struct std_string_view {};
 
 #ifdef FMT_USE_INT128
 // Do nothing.
-#elif defined(__SIZEOF_INT128__) && !FMT_NVCC
+#elif defined(__SIZEOF_INT128__) && !FMT_NVCC && !(FMT_CLANG_VERSION && FMT_MSC_VER)
 #  define FMT_USE_INT128 1
 using int128_t = __int128_t;
 using uint128_t = __uint128_t;
@@ -1721,7 +1721,7 @@ template <typename Context> class basic_format_args {
   }
 
   template <typename Char> int get_id(basic_string_view<Char> name) const {
-    if (!has_named_args()) return {};
+    if (!has_named_args()) return -1;
     const auto& named_args =
         (is_packed() ? values_[-1] : args_[-1].value_).named_args;
     for (size_t i = 0; i < named_args.size; ++i) {

--- a/src/fmt/core.h
+++ b/src/fmt/core.h
@@ -177,6 +177,12 @@
 #  endif
 #endif
 
+// LAMMPS customization
+// use 'v7_lmp' namespace instead of 'v7' so that our
+// bundled copy does not collide with linking other code
+// using system wide installations which may be using
+// a different version.
+
 #ifndef FMT_BEGIN_NAMESPACE
 #  if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
       FMT_MSC_VER >= 1900
@@ -488,6 +494,8 @@ template <typename S, FMT_ENABLE_IF(is_compile_string<S>::value)>
 constexpr basic_string_view<typename S::char_type> to_string_view(const S& s) {
   return s;
 }
+
+// LAMMPS customization using 'v7_lmp' instead of 'v7'
 
 namespace detail {
 void to_string_view(...);

--- a/src/fmt/format.h
+++ b/src/fmt/format.h
@@ -730,13 +730,18 @@ class FMT_API format_error : public std::runtime_error {
 
 namespace detail {
 
+template <typename T>
+using is_signed =
+    std::integral_constant<bool, std::numeric_limits<T>::is_signed ||
+                                     std::is_same<T, int128_t>::value>;
+
 // Returns true if value is negative, false otherwise.
 // Same as `value < 0` but doesn't produce warnings if T is an unsigned type.
-template <typename T, FMT_ENABLE_IF(std::numeric_limits<T>::is_signed)>
+template <typename T, FMT_ENABLE_IF(is_signed<T>::value)>
 FMT_CONSTEXPR bool is_negative(T value) {
   return value < 0;
 }
-template <typename T, FMT_ENABLE_IF(!std::numeric_limits<T>::is_signed)>
+template <typename T, FMT_ENABLE_IF(!is_signed<T>::value)>
 FMT_CONSTEXPR bool is_negative(T) {
   return false;
 }
@@ -751,9 +756,9 @@ FMT_CONSTEXPR bool is_supported_floating_point(T) {
 // Smallest of uint32_t, uint64_t, uint128_t that is large enough to
 // represent all values of T.
 template <typename T>
-using uint32_or_64_or_128_t = conditional_t<
-    num_bits<T>() <= 32, uint32_t,
-    conditional_t<num_bits<T>() <= 64, uint64_t, uint128_t>>;
+using uint32_or_64_or_128_t =
+    conditional_t<num_bits<T>() <= 32, uint32_t,
+                  conditional_t<num_bits<T>() <= 64, uint64_t, uint128_t>>;
 
 // Static data is placed in this class template for the header-only config.
 template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
@@ -1599,7 +1604,11 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
                               make_checked(p, s.size()));
     }
     if (prefix_size != 0) p[-1] = static_cast<Char>('-');
-    write(out, basic_string_view<Char>(buffer.data(), buffer.size()), specs);
+    using iterator = remove_reference_t<decltype(reserve(out, 0))>;
+    auto data = buffer.data();
+    out = write_padded<align::right>(out, specs, size, size, [=](iterator it) {
+      return copy_str<Char>(data, data + size, it);
+    });
   }
 
   void on_chr() { *out++ = static_cast<Char>(abs_value); }

--- a/src/fmt/format.h
+++ b/src/fmt/format.h
@@ -69,6 +69,12 @@
 #  define FMT_NOINLINE
 #endif
 
+// LAMMPS customizations:
+// 1) Intel compilers on MacOS have __clang__ defined
+//    but fail to recognize [[clang::fallthrough]]
+// 2) Intel compilers on Linux identify as GCC compatible
+//    but fail to recognize [[gnu::fallthrough]]
+
 #if __cplusplus == 201103L || __cplusplus == 201402L
 #  if defined(__clang__) && !defined(__INTEL_COMPILER)
 #    define FMT_FALLTHROUGH [[clang::fallthrough]]


### PR DESCRIPTION
**Summary**

This updates the bundled fmtlib version to the bugfix release 7.0.3
It also adds comments to mark the LAMMPS specific customizations

**Author(s)**

Axel Kohlmeyer, Temple U
The fmtlib developers

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
