### PR TITLE
Move the members `version` and `num_ver` form Universe class to LAMMPS class

### DIFF
--- a/doc/src/pg_cplusplus.rst
+++ b/doc/src/pg_cplusplus.rst
@@ -26,7 +26,6 @@ the ``delete`` operator.  Here is a simple example:
 .. code-block:: c++
 
    #include "lammps.h"
-   #include "universe.h"
 
    #include <mpi.h>
    #include <iostream>
@@ -44,7 +43,7 @@ the ``delete`` operator.  Here is a simple example:
        // create LAMMPS instance
        lmp = new LAMMPS_NS::LAMMPS(lmpargc, (char **)lmpargv, MPI_COMM_WORLD);
        // output numerical version string
-       std::cout << "LAMMPS version: " << lmp->universe->num_ver << std::endl;
+       std::cout << "LAMMPS version ID: " << lmp->num_ver << std::endl;
        // delete LAMMPS instance
        delete lmp;
 
@@ -53,8 +52,8 @@ the ``delete`` operator.  Here is a simple example:
        return 0;
    }
 
-Please note that this requires to include the ``lammps.h`` header for accessing
-the members of the LAMMPS class and then the ``universe.h`` header for accessing the ``num_ver`` member of the :cpp:class:`Universe` class.
+This minimal example only requires to include the ``lammps.h`` header
+file since it only accesses a non-pointer member of the LAMMPS class.
 
 
 Executing LAMMPS commands

--- a/src/KIM/kim_init.cpp
+++ b/src/KIM/kim_init.cpp
@@ -313,7 +313,7 @@ void KimInit::do_init(char *model_name, char *user_units, char *model_units, KIM
       mesg += "# For Simulator             : ";
       mesg += std::string(sim_name) + " " + sim_version + "\n";
       mesg += "# Running on                : LAMMPS ";
-      mesg += universe->version;
+      mesg += lmp->version;
       mesg += "\n";
       mesg += "#\n";
 

--- a/src/USER-ADIOS/dump_atom_adios.cpp
+++ b/src/USER-ADIOS/dump_atom_adios.cpp
@@ -337,9 +337,9 @@ void DumpAtomADIOS::init_style()
     internal->io.DefineAttribute<std::string>("boundarystr", boundstr);
     internal->io.DefineAttribute<std::string>("LAMMPS/dump_style", "atom");
     internal->io.DefineAttribute<std::string>("LAMMPS/version",
-                                              universe->version);
+                                              lmp->version);
     internal->io.DefineAttribute<std::string>("LAMMPS/num_ver",
-                                              universe->num_ver);
+                                              std::to_string(lmp->num_ver));
 
     internal->io.DefineVariable<uint64_t>(
         "nme", {adios2::LocalValueDim}); // local dimension variable

--- a/src/USER-ADIOS/dump_custom_adios.cpp
+++ b/src/USER-ADIOS/dump_custom_adios.cpp
@@ -424,9 +424,9 @@ void DumpCustomADIOS::init_style()
     internal->io.DefineAttribute<std::string>("boundarystr", boundstr);
     internal->io.DefineAttribute<std::string>("LAMMPS/dump_style", "custom");
     internal->io.DefineAttribute<std::string>("LAMMPS/version",
-                                              universe->version);
+                                              lmp->version);
     internal->io.DefineAttribute<std::string>("LAMMPS/num_ver",
-                                              universe->num_ver);
+                                              std::to_string(lmp->num_ver));
 
     internal->io.DefineVariable<uint64_t>(
         "nme", {adios2::LocalValueDim}); // local dimension variable

--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -512,7 +512,7 @@ void DumpNetCDF::openfile()
       NCERR( nc_put_att_text(ncid, NC_GLOBAL, "program",
                  6, "LAMMPS") );
       NCERR( nc_put_att_text(ncid, NC_GLOBAL, "programVersion",
-                 strlen(universe->version), universe->version) );
+                 strlen(lmp->version), lmp->version) );
 
       // units
       if (!strcmp(update->unit_style, "lj")) {

--- a/src/USER-NETCDF/dump_netcdf_mpiio.cpp
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.cpp
@@ -497,7 +497,7 @@ void DumpNetCDFMPIIO::openfile()
     NCERR( ncmpi_put_att_text(ncid, NC_GLOBAL, "program",
                               6, "LAMMPS") );
     NCERR( ncmpi_put_att_text(ncid, NC_GLOBAL, "programVersion",
-                              strlen(universe->version), universe->version) );
+                              strlen(lmp->version), lmp->version) );
 
     // units
     if (!strcmp(update->unit_style, "lj")) {

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -267,7 +267,7 @@ void Info::command(int narg, char **arg)
 
   if (flags & CONFIG) {
     fmt::print(out,"\nLAMMPS version: {} / {}\n",
-               universe->version, universe->num_ver);
+               lmp->version, lmp->num_ver);
 
     if (lmp->has_git_info)
       fmt::print(out,"Git info: {} / {} / {}\n",

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -114,6 +114,9 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
   error = new Error(this);
   universe = new Universe(this,communicator);
 
+  version = (const char *) LAMMPS_VERSION;
+  num_ver = utils::date2num(version);
+
   clientserver = 0;
   cslib = nullptr;
   cscomm = 0;
@@ -460,7 +463,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     }
 
     if ((universe->me == 0) && !helpflag)
-      utils::logmesg(this,fmt::format("LAMMPS ({})\n",universe->version));
+      utils::logmesg(this,fmt::format("LAMMPS ({})\n",version));
 
   // universe is one or more worlds, as setup by partition switch
   // split universe communicator into separate world communicators
@@ -538,15 +541,15 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     if ((universe->me == 0) && (!helpflag)) {
       const char fmt[] = "LAMMPS ({})\nRunning on {} partitions of processors\n";
       if (universe->uscreen)
-        fmt::print(universe->uscreen,fmt,universe->version,universe->nworlds);
+        fmt::print(universe->uscreen,fmt,version,universe->nworlds);
 
       if (universe->ulogfile)
-        fmt::print(universe->ulogfile,fmt,universe->version,universe->nworlds);
+        fmt::print(universe->ulogfile,fmt,version,universe->nworlds);
     }
 
     if ((me == 0) && (!helpflag))
       utils::logmesg(this,fmt::format("LAMMPS ({})\nProcessor partition = {}\n",
-                                      universe->version, universe->iworld));
+                                      version, universe->iworld));
   }
 
   // check consistency of datatype settings in lmptype.h

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -38,6 +38,12 @@ class LAMMPS {
   class Output *output;          // thermo/dump/restart
   class Timer *timer;            // CPU timing info
 
+  const char *version;           // LAMMPS version string = date
+  int num_ver;                   // numeric version id derived from *version*
+                                 // that is constructed so that will be greater
+                                 // for newer versions in numeric or string
+                                 // value comparisons
+
   MPI_Comm world;                // MPI communicator
   FILE *infile;                  // infile
   FILE *screen;                  // screen output

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -559,7 +559,7 @@ growing with every new LAMMPS release.
 int lammps_version(void *handle)
 {
   LAMMPS *lmp = (LAMMPS *) handle;
-  return atoi(lmp->universe->num_ver);
+  return lmp->num_ver;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -621,7 +621,7 @@ void ReadRestart::header()
       char *version = read_string();
       if (me == 0)
         utils::logmesg(lmp,fmt::format("  restart file = {}, LAMMPS = {}\n",
-                                       version,universe->version));
+                                       version,lmp->version));
       delete [] version;
 
       // we have no forward compatibility, thus exit with error

--- a/src/universe.cpp
+++ b/src/universe.cpp
@@ -30,11 +30,6 @@ using namespace LAMMPS_NS;
 
 Universe::Universe(LAMMPS *lmp, MPI_Comm communicator) : Pointers(lmp)
 {
-  version = (const char *) LAMMPS_VERSION;
-  auto tmp_ver = new char[10];
-  snprintf(tmp_ver,10,"%08d",utils::date2num(version));
-  num_ver = tmp_ver;
-
   uworld = uorig = communicator;
   MPI_Comm_rank(uworld,&me);
   MPI_Comm_size(uworld,&nprocs);
@@ -59,7 +54,6 @@ Universe::~Universe()
   memory->destroy(procs_per_world);
   memory->destroy(root_proc);
   memory->destroy(uni2orig);
-  delete [] num_ver;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/universe.h
+++ b/src/universe.h
@@ -20,10 +20,6 @@ namespace LAMMPS_NS {
 
 class Universe : protected Pointers {
  public:
-  const char *version;    // LAMMPS version string = date
-  const char *num_ver;    // numeric version id derived from version that
-                          // can be used for string or numeric comparisons
-
   MPI_Comm uworld;        // communicator for entire universe
   int me,nprocs;          // my place in universe
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -4713,7 +4713,7 @@ int Variable::is_constant(char *word)
 double Variable::constant(char *word)
 {
   if (strcmp(word,"PI") == 0) return MY_PI;
-  if (strcmp(word,"version") == 0) return atof(universe->num_ver);
+  if (strcmp(word,"version") == 0) return lmp->num_ver;
   if (strcmp(word,"yes") == 0) return 1.0;
   if (strcmp(word,"no") == 0) return 0.0;
   if (strcmp(word,"on") == 0) return 1.0;

--- a/src/write_coeff.cpp
+++ b/src/write_coeff.cpp
@@ -95,7 +95,7 @@ void WriteCoeff::command(int narg, char **arg)
                                    file+4, utils::getsyserror()));
 
     fprintf(two,"# LAMMPS coeff file via write_coeff, version %s\n",
-            universe->version);
+            lmp->version);
 
     while(1) {
       int coeff_mode = REGULAR_MODE;

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -229,7 +229,7 @@ void WriteData::write(const std::string &file)
 void WriteData::header()
 {
   fmt::print(fp,"LAMMPS data file via write_data, version {}, "
-             "timestep = {}\n\n",universe->version,update->ntimestep);
+             "timestep = {}\n\n",lmp->version,update->ntimestep);
 
   fmt::print(fp,"{} atoms\n{} atom types\n",atom->natoms,atom->ntypes);
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -424,7 +424,7 @@ void WriteRestart::write(std::string file)
 
 void WriteRestart::header()
 {
-  write_string(VERSION,universe->version);
+  write_string(VERSION,lmp->version);
   write_int(SMALLINT,sizeof(smallint));
   write_int(IMAGEINT,sizeof(imageint));
   write_int(TAGINT,sizeof(tagint));

--- a/unittest/force-styles/test_angle_style.cpp
+++ b/unittest/force-styles/test_angle_style.cpp
@@ -236,7 +236,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     YamlWriter writer(outfile);
 
     // lammps_version
-    writer.emit("lammps_version", lmp->universe->version);
+    writer.emit("lammps_version", lmp->version);
 
     // date_generated
     std::time_t now = time(NULL);

--- a/unittest/force-styles/test_bond_style.cpp
+++ b/unittest/force-styles/test_bond_style.cpp
@@ -236,7 +236,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     YamlWriter writer(outfile);
 
     // lammps_version
-    writer.emit("lammps_version", lmp->universe->version);
+    writer.emit("lammps_version", lmp->version);
 
     // date_generated
     std::time_t now = time(NULL);

--- a/unittest/force-styles/test_fix_timestep.cpp
+++ b/unittest/force-styles/test_fix_timestep.cpp
@@ -194,7 +194,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     YamlWriter writer(outfile);
 
     // lammps_version
-    writer.emit("lammps_version", lmp->universe->version);
+    writer.emit("lammps_version", lmp->version);
 
     // date_generated
     std::time_t now = time(NULL);

--- a/unittest/force-styles/test_pair_style.cpp
+++ b/unittest/force-styles/test_pair_style.cpp
@@ -239,7 +239,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     YamlWriter writer(outfile);
 
     // lammps_version
-    writer.emit("lammps_version", lmp->universe->version);
+    writer.emit("lammps_version", lmp->version);
 
     // date_generated
     std::time_t now = time(NULL);


### PR DESCRIPTION
**Summary**

The LAMMPS class is the primary user and logical destination to hold the version string.
Also the num_ver value is primarily used as a numeric value, so it would be better to store it as an int.
This PR changes this and thus simplifies a few steps and updates the code using those members.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This will break external code that expects "version" to be in "lmp->universe".
LAMMPS functionality including the library interfaces are not affected.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
