### PR TITLE
molecule: findfragments correction

### DIFF
--- a/doc/src/Errors_messages.rst
+++ b/doc/src/Errors_messages.rst
@@ -5723,9 +5723,6 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
 *Molecule file has no Fragments section*
    Self-explanatory.
 
-*Molecule file has no Molecules section*
-   Self-explanatory.
-
 *Molecule file has special flags but no bonds*
    Self-explanatory.
 

--- a/doc/src/Errors_messages.rst
+++ b/doc/src/Errors_messages.rst
@@ -5708,6 +5708,9 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
 *Molecule file has dihedrals but no ndihedrals setting*
    Self-explanatory.
 
+*Molecule file has fragments but no nfragments setting*
+   Self-explanatory.
+
 *Molecule file has impropers but no nimpropers setting*
    Self-explanatory.
 
@@ -5715,6 +5718,12 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
    Self-explanatory.
 
 *Molecule file has no Body Integers section*
+   Self-explanatory.
+
+*Molecule file has no Fragments section*
+   Self-explanatory.
+
+*Molecule file has no Molecules section*
    Self-explanatory.
 
 *Molecule file has special flags but no bonds*

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1610,7 +1610,6 @@ void Molecule::body(int flag, int pflag, char *line)
 
 int Molecule::findfragment(const char *name)
 {
-  if (!fragmentflag) return -1;
   for (int i = 0; i < nfragments; i++)
     if (fragmentnames[i] == name) return i;
   return -1;
@@ -1692,6 +1691,7 @@ void Molecule::initialize()
   nmolecules = 1;
   nbondtypes = nangletypes = ndihedraltypes = nimpropertypes = 0;
   nibody = ndbody = 0;
+  nfragments = 0;
 
   bond_per_atom = angle_per_atom = dihedral_per_atom = improper_per_atom = 0;
   maxspecial = 0;

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -636,7 +636,7 @@ void Molecule::read(int flag)
       error->all(FLERR,"Molecule file has no Body Doubles section");
     if (nmolecules > 0 && !moleculeflag)
       error->all(FLERR,"Molecule file has no Molecules section");
-    if (nfragments > 0 && !fragmentsflag)
+    if (nfragments > 0 && !fragmentflag)
       error->all(FLERR,"Molecule file has no Fragments section");
   }
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1610,6 +1610,7 @@ void Molecule::body(int flag, int pflag, char *line)
 
 int Molecule::findfragment(const char *name)
 {
+  if (!fragmentflag) return -1;
   for (int i = 0; i < nfragments; i++)
     if (fragmentnames[i] == name) return i;
   return -1;

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -535,6 +535,8 @@ void Molecule::read(int flag)
       if (flag) molecules(line);
       else skip_lines(natoms,line);
     } else if (strcmp(keyword,"Fragments") == 0) {
+      if (nfragments == 0)
+        error->all(FLERR,"Molecule file has fragments but no nfragments setting");
       fragmentflag = 1;
       if (flag) fragments(line);
       else skip_lines(nfragments,line);

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -636,8 +636,6 @@ void Molecule::read(int flag)
       error->all(FLERR,"Molecule file has no Body Integers section");
     if (bodyflag && ndbody && dbodyflag == 0)
       error->all(FLERR,"Molecule file has no Body Doubles section");
-    if (nmolecules > 0 && !moleculeflag)
-      error->all(FLERR,"Molecule file has no Molecules section");
     if (nfragments > 0 && !fragmentflag)
       error->all(FLERR,"Molecule file has no Fragments section");
   }

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -634,6 +634,10 @@ void Molecule::read(int flag)
       error->all(FLERR,"Molecule file has no Body Integers section");
     if (bodyflag && ndbody && dbodyflag == 0)
       error->all(FLERR,"Molecule file has no Body Doubles section");
+    if (nmolecules > 0 && !moleculeflag)
+      error->all(FLERR,"Molecule file has no Molecules section");
+    if (nfragments > 0 && !fragmentsflag)
+      error->all(FLERR,"Molecule file has no Fragments section");
   }
 
   // auto-generate special bonds if needed and not in file

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -281,10 +281,6 @@ E: Molecule file has no Body Doubles section
 
 Self-explanatory.
 
-E: Molecule file has no Molecules section
-
-Self-explanatory.
-
 E: Molecule file has no Fragments section
 
 Self-explanatory.

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -241,6 +241,10 @@ E: Molecule file has impropers but no nimpropers setting
 
 Self-explanatory.
 
+E: Molecule file has fragments but no nfragments setting
+
+Self-explanatory.
+
 E: Molecule file shake flags not before shake atoms
 
 The order of the two sections is important.
@@ -274,6 +278,14 @@ E: Molecule file has no Body Integers section
 Self-explanatory.
 
 E: Molecule file has no Body Doubles section
+
+Self-explanatory.
+
+E: Molecule file has no Molecules section
+
+Self-explanatory.
+
+E: Molecule file has no Fragments section
 
 Self-explanatory.
 


### PR DESCRIPTION
**Summary**

one-line bug when checking for molecule fragments. can occur when no fragments have been defined

**Related Issue(s)**

none

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


