### PR TITLE
Fix atomicAdd in PPPM/GPU for the HIP backend

### DIFF
--- a/lib/gpu/lal_pppm.cu
+++ b/lib/gpu/lal_pppm.cu
@@ -26,7 +26,7 @@ _texture( q_tex,int2);
 
 // Allow PPPM to compile without atomics for NVIDIA 1.0 cards, error
 // generated at runtime with use of pppm/gpu
-#if (__CUDA_ARCH__ < 110)
+#if defined(NV_KERNEL) && (__CUDA_ARCH__ < 110)
 #define atomicAdd(x,y) *(x)+=0
 #endif
 


### PR DESCRIPTION
**Summary**

The condition (\_\_CUDA_ARCH\_\_ < 110) would be used to detect NVIDIA 1.0 cards, but it is also met by HIP backend and AMD systems. So the macro breaks atomicAdd and violates the PPPM kernels for the HIP backend. The fix is trivial.

**Author(s)**

Vsevolod Nikolskiy (thevsevak@gmail.com, @Vsevak)
International Laboratory for Supercomputer Atomistic Modelling and Multi-scale Analysis
HSE University, Moscow, Russia

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Keeps

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

