### PR TITLE
Autodetect OpenMP compatibility setting for known compiler signatures

### DIFF
--- a/doc/src/Build_basics.rst
+++ b/doc/src/Build_basics.rst
@@ -159,11 +159,11 @@ others (e.g. GCC version 9 and beyond, Clang version 10 and later) may
 implement strict OpenMP 4.0 and later semantics, which are incompatible
 with the OpenMP 3.1 semantics used in LAMMPS for maximal compatibility
 with compiler versions in use.  If compilation with OpenMP enabled fails
-because of your compiler requiring strict OpenMP 4.0 semantic, you can
+because of your compiler requiring strict OpenMP 4.0 semantics, you can
 change the behavior by adding ``-D LAMMPS_OMP_COMPAT=4`` to the
 ``LMP_INC`` variable in your makefile, or add it to the command line
-while configuring with CMake. CMake will detect the suitable setting for
-the GNU, Clang, and Intel compilers.
+while configuring with CMake.  LAMMPS will autodetect a suitable setting
+for most GNU, Clang, and Intel compilers.
 
 ----------
 

--- a/src/omp_compat.h
+++ b/src/omp_compat.h
@@ -38,7 +38,7 @@
 #      define LAMMPS_OMP_COMPAT 4
 #    endif
 #  elif defined(__GNUC__)
-#    if __GNUC__ >= 0
+#    if __GNUC__ >= 9
 #      define LAMMPS_OMP_COMPAT 4
 #    endif
 #  endif

--- a/src/omp_compat.h
+++ b/src/omp_compat.h
@@ -25,11 +25,30 @@
 // so this is what LAMMPS primarily uses.  For those compilers
 // that strictly implement OpenMP 4.0 (such as GCC 9.0 and later
 // or Clang 10.0 and later), we give up default(none).
+
+// autodetect OpenMP compatibility if not explicitly set
+
+#ifndef LAMMPS_OMP_COMPAT
+#  if defined(__INTEL_COMPILER)
+#    if __INTEL_COMPILER > 18
+#      define LAMMPS_OMP_COMPAT 4
+#    endif
+#  elif defined(__clang__)
+#    if __clang_major__ >= 10
+#      define LAMMPS_OMP_COMPAT 4
+#    endif
+#  elif defined(__GNUC__)
+#    if __GNUC__ >= 0
+#      define LAMMPS_OMP_COMPAT 4
+#    endif
+#  endif
+#endif
+
 #if LAMMPS_OMP_COMPAT == 4
-#    define LMP_SHARED(...)
-#    define LMP_DEFAULT_NONE default(shared)
+#  define LMP_SHARED(...)
+#  define LMP_DEFAULT_NONE default(shared)
 #else
-#    define LMP_SHARED(...) shared(__VA_ARGS__)
-#    define LMP_DEFAULT_NONE default(none)
+#  define LMP_SHARED(...) shared(__VA_ARGS__)
+#  define LMP_DEFAULT_NONE default(none)
 #endif
 


### PR DESCRIPTION
**Summary**

Compilers that implement strict OpenMP 4.0 and later semantics we need to define `-DLAMMP_OMP_COMPAT=4` to adjust the non-backward compatible settings in the `#pragma omp ` lines. With this change, we try to auto detect this for some popular compilers from their pre-processor signatures.  This should reduce the number of complaints from inexperienced users that  use the traditional Makefile build system as Linux distributions with newer compilers become more popular.

**Related Issue(s)**

#1326 #1330 #1331

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. Tested on Ubuntu20.04 Centos7 with intel 18.0

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
