### PR TITLE
A few more static code analysis fixes

### DIFF
--- a/src/USER-DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/USER-DIFFRACTION/fix_saed_vtk.cpp
@@ -145,8 +145,6 @@ FixSAEDVTK::FixSAEDVTK(LAMMPS *lmp, int narg, char **arg) :
   memory->create(vector,nrows,"saed/vtk:vector");
   memory->create(vector_total,nrows,"saed/vtk:vector_total");
 
-  extlist = nullptr;
-
   vector_flag = 1;
   size_vector = nrows;
 
@@ -282,7 +280,6 @@ FixSAEDVTK::FixSAEDVTK(LAMMPS *lmp, int narg, char **arg) :
 
 FixSAEDVTK::~FixSAEDVTK()
 {
-  delete [] extlist;
   delete [] filename;
   delete [] ids;
   memory->destroy(vector);

--- a/src/USER-MISC/compute_viscosity_cos.cpp
+++ b/src/USER-MISC/compute_viscosity_cos.cpp
@@ -53,8 +53,10 @@ ComputeViscosityCos::ComputeViscosityCos(LAMMPS *lmp, int narg, char **arg) :
 /* ---------------------------------------------------------------------- */
 
 ComputeViscosityCos::~ComputeViscosityCos() {
-  if (!copymode)
+  if (!copymode) {
     delete[] vector;
+    delete[] extlist;
+  }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_slice.cpp
+++ b/src/compute_slice.cpp
@@ -224,6 +224,7 @@ ComputeSlice::~ComputeSlice()
   for (int m = 0; m < nvalues; m++) delete [] ids[m];
   delete [] ids;
   delete [] value2index;
+  delete [] extlist;
 
   memory->destroy(vector);
   memory->destroy(array);

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -234,7 +234,7 @@ DumpCustom::~DumpCustom()
 
   for (int i = 0; i < ncustom; i++) delete [] id_custom[i];
   memory->sfree(id_custom);
-  delete [] flag_custom;
+  memory->sfree(flag_custom);
 
   memory->destroy(choose);
   memory->destroy(dchoose);

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -760,7 +760,7 @@ void FixAveHisto::end_of_step()
   }
 
   irepeat = 0;
-  nvalid = ntimestep + nfreq - (nrepeat-1)*nevery;
+  nvalid = ntimestep + nfreq - static_cast<bigint>(nrepeat-1)*nevery;
   modify->addstep_compute(nvalid);
 
   // merge histogram stats across procs if necessary
@@ -1046,7 +1046,7 @@ bigint FixAveHisto::nextvalid()
   if (nvalid-nfreq == update->ntimestep && nrepeat == 1)
     nvalid = update->ntimestep;
   else
-    nvalid -= (nrepeat-1)*nevery;
+    nvalid -= static_cast<bigint>(nrepeat-1)*nevery;
   if (nvalid < update->ntimestep) nvalid += nfreq;
   return nvalid;
 }

--- a/src/fix_ave_histo_weight.cpp
+++ b/src/fix_ave_histo_weight.cpp
@@ -403,7 +403,7 @@ void FixAveHistoWeight::end_of_step()
   }
 
   irepeat = 0;
-  nvalid = ntimestep + nfreq - (nrepeat-1)*nevery;
+  nvalid = ntimestep + nfreq - static_cast<bigint>(nrepeat-1)*nevery;
   modify->addstep_compute(nvalid);
 
   // merge histogram stats across procs if necessary

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -640,7 +640,7 @@ void FixAveTime::invoke_scalar(bigint ntimestep)
   }
 
   irepeat = 0;
-  nvalid = ntimestep + nfreq - (nrepeat-1)*nevery;
+  nvalid = ntimestep + nfreq - static_cast<bigint>(nrepeat-1)*nevery;
   modify->addstep_compute(nvalid);
 
   // average the final result for the Nfreq timestep
@@ -743,7 +743,7 @@ void FixAveTime::invoke_vector(bigint ntimestep)
         if (!varlen[i] || which[i] != COMPUTE) continue;
         if (nrepeat > 1 && ave == ONE) {
           Compute *compute = modify->compute[value2index[i]];
-          compute->lock(this,ntimestep,ntimestep+(nrepeat-1)*nevery);
+          compute->lock(this,ntimestep,ntimestep+static_cast<bigint>(nrepeat-1)*nevery);
         } else if ((ave == RUNNING || ave == WINDOW) && !lockforever) {
           Compute *compute = modify->compute[value2index[i]];
           compute->lock(this,update->ntimestep,-1);
@@ -838,7 +838,7 @@ void FixAveTime::invoke_vector(bigint ntimestep)
   }
 
   irepeat = 0;
-  nvalid = ntimestep+nfreq - (nrepeat-1)*nevery;
+  nvalid = ntimestep+nfreq - static_cast<bigint>(nrepeat-1)*nevery;
   modify->addstep_compute(nvalid);
 
   // unlock any variable length computes at end of Nfreq epoch
@@ -1146,7 +1146,7 @@ bigint FixAveTime::nextvalid()
   if (nvalid-nfreq == update->ntimestep && nrepeat == 1)
     nvalid = update->ntimestep;
   else
-    nvalid -= (nrepeat-1)*nevery;
+    nvalid -= static_cast<bigint>(nrepeat-1)*nevery;
   if (nvalid < update->ntimestep) nvalid += nfreq;
   return nvalid;
 }

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -244,7 +244,7 @@ void Min::setup(int flag)
 
   bigint ndofme = 3 * static_cast<bigint>(atom->nlocal);
   for (int m = 0; m < nextra_atom; m++)
-    ndofme += extra_peratom[m]*atom->nlocal;
+    ndofme += extra_peratom[m]*static_cast<bigint>(atom->nlocal);
   MPI_Allreduce(&ndofme,&ndoftotal,1,MPI_LMP_BIGINT,MPI_SUM,world);
   ndoftotal += nextra_global;
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -51,6 +51,7 @@ Update::Update(LAMMPS *lmp) : Pointers(lmp)
   multireplica = 0;
 
   eflag_global = vflag_global = -1;
+  eflag_atom = vflag_atom = 0;
 
   dt_default = 1;
   unit_style = nullptr;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -2687,23 +2687,23 @@ double Variable::collapse_tree(Tree *tree)
   }
 
   if (tree->type == STAGGER) {
-    int ivalue1 = static_cast<int> (collapse_tree(tree->first));
-    int ivalue2 = static_cast<int> (collapse_tree(tree->second));
+    bigint ivalue1 = static_cast<bigint> (collapse_tree(tree->first));
+    bigint ivalue2 = static_cast<bigint> (collapse_tree(tree->second));
     if (tree->first->type != VALUE || tree->second->type != VALUE) return 0.0;
     tree->type = VALUE;
     if (ivalue1 <= 0 || ivalue2 <= 0 || ivalue1 <= ivalue2)
       error->one(FLERR,"Invalid math function in variable formula");
-    int lower = update->ntimestep/ivalue1 * ivalue1;
-    int delta = update->ntimestep - lower;
+    bigint lower = update->ntimestep/ivalue1 * ivalue1;
+    bigint delta = update->ntimestep - lower;
     if (delta < ivalue2) tree->value = lower+ivalue2;
     else tree->value = lower+ivalue1;
     return tree->value;
   }
 
   if (tree->type == LOGFREQ) {
-    int ivalue1 = static_cast<int> (collapse_tree(tree->first));
-    int ivalue2 = static_cast<int> (collapse_tree(tree->second));
-    int ivalue3 = static_cast<int> (collapse_tree(tree->extra[0]));
+    bigint ivalue1 = static_cast<bigint> (collapse_tree(tree->first));
+    bigint ivalue2 = static_cast<bigint> (collapse_tree(tree->second));
+    bigint ivalue3 = static_cast<bigint> (collapse_tree(tree->extra[0]));
     if (tree->first->type != VALUE || tree->second->type != VALUE ||
         tree->extra[0]->type != VALUE) return 0.0;
     tree->type = VALUE;
@@ -2711,9 +2711,9 @@ double Variable::collapse_tree(Tree *tree)
       error->one(FLERR,"Invalid math function in variable formula");
     if (update->ntimestep < ivalue1) tree->value = ivalue1;
     else {
-      int lower = ivalue1;
+      bigint lower = ivalue1;
       while (update->ntimestep >= ivalue3*lower) lower *= ivalue3;
-      int multiple = update->ntimestep/lower;
+      bigint multiple = update->ntimestep/lower;
       if (multiple < ivalue2) tree->value = (multiple+1)*lower;
       else tree->value = lower*ivalue3;
     }
@@ -2721,9 +2721,9 @@ double Variable::collapse_tree(Tree *tree)
   }
 
   if (tree->type == LOGFREQ2) {
-    int ivalue1 = static_cast<int> (collapse_tree(tree->first));
-    int ivalue2 = static_cast<int> (collapse_tree(tree->second));
-    int ivalue3 = static_cast<int> (collapse_tree(tree->extra[0]));
+    bigint ivalue1 = static_cast<bigint> (collapse_tree(tree->first));
+    bigint ivalue2 = static_cast<bigint> (collapse_tree(tree->second));
+    bigint ivalue3 = static_cast<bigint> (collapse_tree(tree->extra[0]));
     if (tree->first->type != VALUE || tree->second->type != VALUE ||
         tree->extra[0]->type != VALUE) return 0.0;
     tree->type = VALUE;
@@ -2733,7 +2733,7 @@ double Variable::collapse_tree(Tree *tree)
     else {
       tree->value = ivalue1;
       double delta = ivalue1*(ivalue3-1.0)/ivalue2;
-      int count = 0;
+      bigint count = 0;
       while (update->ntimestep >= tree->value) {
         tree->value += delta;
         count++;
@@ -2745,9 +2745,9 @@ double Variable::collapse_tree(Tree *tree)
   }
 
   if (tree->type == LOGFREQ3) {
-    int ivalue1 = static_cast<int> (collapse_tree(tree->first));
-    int ivalue2 = static_cast<int> (collapse_tree(tree->second));
-    int ivalue3 = static_cast<int> (collapse_tree(tree->extra[0]));
+    bigint ivalue1 = static_cast<bigint> (collapse_tree(tree->first));
+    bigint ivalue2 = static_cast<bigint> (collapse_tree(tree->second));
+    bigint ivalue3 = static_cast<bigint> (collapse_tree(tree->extra[0]));
     if (tree->first->type != VALUE || tree->second->type != VALUE ||
         tree->extra[0]->type != VALUE) return 0.0;
     tree->type = VALUE;
@@ -2760,7 +2760,7 @@ double Variable::collapse_tree(Tree *tree)
       tree->value = ivalue1;
       double logsp = ivalue1;
       double factor = pow(((double)ivalue3)/ivalue1, 1.0/(ivalue2-1));
-      int linsp = ivalue1;
+      bigint linsp = ivalue1;
       while (update->ntimestep >= (tree->value)) {
         logsp *= factor;
         linsp++;
@@ -2774,9 +2774,9 @@ double Variable::collapse_tree(Tree *tree)
   }
 
   if (tree->type == STRIDE) {
-    int ivalue1 = static_cast<int> (collapse_tree(tree->first));
-    int ivalue2 = static_cast<int> (collapse_tree(tree->second));
-    int ivalue3 = static_cast<int> (collapse_tree(tree->extra[0]));
+    bigint ivalue1 = static_cast<bigint> (collapse_tree(tree->first));
+    bigint ivalue2 = static_cast<bigint> (collapse_tree(tree->second));
+    bigint ivalue3 = static_cast<bigint> (collapse_tree(tree->extra[0]));
     if (tree->first->type != VALUE || tree->second->type != VALUE ||
         tree->extra[0]->type != VALUE) return 0.0;
     tree->type = VALUE;
@@ -2784,7 +2784,7 @@ double Variable::collapse_tree(Tree *tree)
       error->one(FLERR,"Invalid math function in variable formula");
     if (update->ntimestep < ivalue1) tree->value = ivalue1;
     else if (update->ntimestep < ivalue2) {
-      int offset = update->ntimestep - ivalue1;
+      bigint offset = update->ntimestep - ivalue1;
       tree->value = ivalue1 + (offset/ivalue3)*ivalue3 + ivalue3;
       if (tree->value > ivalue2) tree->value = (double) MAXBIGINT;
     } else tree->value = (double) MAXBIGINT;
@@ -2792,12 +2792,12 @@ double Variable::collapse_tree(Tree *tree)
   }
 
   if (tree->type == STRIDE2) {
-    int ivalue1 = static_cast<int> (collapse_tree(tree->first));
-    int ivalue2 = static_cast<int> (collapse_tree(tree->second));
-    int ivalue3 = static_cast<int> (collapse_tree(tree->extra[0]));
-    int ivalue4 = static_cast<int> (collapse_tree(tree->extra[1]));
-    int ivalue5 = static_cast<int> (collapse_tree(tree->extra[2]));
-    int ivalue6 = static_cast<int> (collapse_tree(tree->extra[3]));
+    bigint ivalue1 = static_cast<bigint> (collapse_tree(tree->first));
+    bigint ivalue2 = static_cast<bigint> (collapse_tree(tree->second));
+    bigint ivalue3 = static_cast<bigint> (collapse_tree(tree->extra[0]));
+    bigint ivalue4 = static_cast<bigint> (collapse_tree(tree->extra[1]));
+    bigint ivalue5 = static_cast<bigint> (collapse_tree(tree->extra[2]));
+    bigint ivalue6 = static_cast<bigint> (collapse_tree(tree->extra[3]));
     if (tree->first->type != VALUE || tree->second->type != VALUE ||
         tree->extra[0]->type != VALUE || tree->extra[1]->type != VALUE ||
         tree->extra[2]->type != VALUE || tree->extra[3]->type != VALUE)
@@ -2813,15 +2813,15 @@ double Variable::collapse_tree(Tree *tree)
     if (update->ntimestep < ivalue1) istep = ivalue1;
     else if (update->ntimestep < ivalue2) {
       if (update->ntimestep < ivalue4 || update->ntimestep > ivalue5) {
-        int offset = update->ntimestep - ivalue1;
+        bigint offset = update->ntimestep - ivalue1;
         istep = ivalue1 + (offset/ivalue3)*ivalue3 + ivalue3;
         if (update->ntimestep < ivalue2 && istep > ivalue4)
           tree->value = ivalue4;
       } else {
-        int offset = update->ntimestep - ivalue4;
+        bigint offset = update->ntimestep - ivalue4;
         istep = ivalue4 + (offset/ivalue6)*ivalue6 + ivalue6;
         if (istep > ivalue5) {
-          int offset = ivalue5 - ivalue1;
+          bigint offset = ivalue5 - ivalue1;
           istep = ivalue1 + (offset/ivalue3)*ivalue3 + ivalue3;
           if (istep > ivalue2) istep = MAXBIGINT;
         }


### PR DESCRIPTION
**Summary**

This pull request contains fixes for issues reported by running GitHub's CodeQL on LAMMPS

**Author(s)**

Axel Kohlmeyer, Temple U

**Related Issue(s)**

Fixes #2399 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

These are mostly minor fixes for issues that are unlikely to happen under normal circumstances.
- fix a new/malloc() delete[]/free() mismatch in dump custom
- avoid 32-bit integer overflows in various timestep related variable functions
- avoid 32-bit integer overflows in timestep related computations for averaging fixes
- avoid 32-bit integer overflow when counting added degrees of freedom during minimization
- fix a few small memory leaks and remove some dead code related to "extlist" in fixes and computes
- initialize `eflag_atom` and `vflag_atom` to zero in Update class constructor

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
