### PR TITLE
Allowed dpd/tstat/gpu and dpd/gpu to work together in pair style hybrid

### DIFF
--- a/lib/gpu/Nvidia.makefile
+++ b/lib/gpu/Nvidia.makefile
@@ -69,7 +69,7 @@ OBJS = $(OBJ_DIR)/lal_atom.o $(OBJ_DIR)/lal_ans.o \
        $(OBJ_DIR)/lal_soft.o $(OBJ_DIR)/lal_soft_ext.o \
        $(OBJ_DIR)/lal_lj_coul_msm.o $(OBJ_DIR)/lal_lj_coul_msm_ext.o \
        $(OBJ_DIR)/lal_lj_gromacs.o $(OBJ_DIR)/lal_lj_gromacs_ext.o \
-       $(OBJ_DIR)/lal_dpd.o $(OBJ_DIR)/lal_dpd_ext.o \
+       $(OBJ_DIR)/lal_dpd.o $(OBJ_DIR)/lal_dpd_ext.o $(OBJ_DIR)/lal_dpd_tstat_ext.o \
        $(OBJ_DIR)/lal_tersoff.o $(OBJ_DIR)/lal_tersoff_ext.o \
        $(OBJ_DIR)/lal_tersoff_zbl.o $(OBJ_DIR)/lal_tersoff_zbl_ext.o \
        $(OBJ_DIR)/lal_tersoff_mod.o $(OBJ_DIR)/lal_tersoff_mod_ext.o \
@@ -731,6 +731,15 @@ $(OBJ_DIR)/dpd.cubin: lal_dpd.cu lal_precision.h lal_preprocessor.h
 $(OBJ_DIR)/dpd_cubin.h: $(OBJ_DIR)/dpd.cubin $(OBJ_DIR)/dpd.cubin
 	$(BIN2C) -c -n dpd $(OBJ_DIR)/dpd.cubin > $(OBJ_DIR)/dpd_cubin.h
 
+$(OBJ_DIR)/lal_dpd.o: $(ALL_H) lal_dpd.h lal_dpd.cpp $(OBJ_DIR)/dpd_cubin.h $(OBJ_DIR)/lal_base_dpd.o
+	$(CUDR) -o $@ -c lal_dpd.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_dpd_ext.o: $(ALL_H) lal_dpd.h lal_dpd_ext.cpp lal_base_dpd.h
+	$(CUDR) -o $@ -c lal_dpd_ext.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_dpd_tstat_ext.o: $(ALL_H) lal_dpd.h lal_dpd_tstat_ext.cpp lal_base_dpd.h
+	$(CUDR) -o $@ -c lal_dpd_tstat_ext.cpp -I$(OBJ_DIR)
+
 $(OBJ_DIR)/ufm.cubin: lal_ufm.cu lal_precision.h lal_preprocessor.h
 	$(CUDA) --cubin -DNV_KERNEL -o $@ lal_ufm.cu
 
@@ -742,12 +751,6 @@ $(OBJ_DIR)/lal_ufm.o: $(ALL_H) lal_ufm.h lal_ufm.cpp $(OBJ_DIR)/ufm_cubin.h $(OB
 
 $(OBJ_DIR)/lal_ufm_ext.o: $(ALL_H) lal_ufm.h lal_ufm_ext.cpp lal_base_atomic.h
 	$(CUDR) -o $@ -c lal_ufm_ext.cpp -I$(OBJ_DIR)
-
-$(OBJ_DIR)/lal_dpd.o: $(ALL_H) lal_dpd.h lal_dpd.cpp $(OBJ_DIR)/dpd_cubin.h $(OBJ_DIR)/lal_base_dpd.o
-	$(CUDR) -o $@ -c lal_dpd.cpp -I$(OBJ_DIR)
-
-$(OBJ_DIR)/lal_dpd_ext.o: $(ALL_H) lal_dpd.h lal_dpd_ext.cpp lal_base_dpd.h
-	$(CUDR) -o $@ -c lal_dpd_ext.cpp -I$(OBJ_DIR)
 
 $(OBJ_DIR)/tersoff.cubin: lal_tersoff.cu lal_precision.h lal_tersoff_extra.h lal_preprocessor.h
 	$(CUDA) --cubin -DNV_KERNEL -o $@ lal_tersoff.cu

--- a/lib/gpu/Nvidia.makefile_multi
+++ b/lib/gpu/Nvidia.makefile_multi
@@ -69,7 +69,7 @@ OBJS = $(OBJ_DIR)/lal_atom.o $(OBJ_DIR)/lal_ans.o \
        $(OBJ_DIR)/lal_soft.o $(OBJ_DIR)/lal_soft_ext.o \
        $(OBJ_DIR)/lal_lj_coul_msm.o $(OBJ_DIR)/lal_lj_coul_msm_ext.o \
        $(OBJ_DIR)/lal_lj_gromacs.o $(OBJ_DIR)/lal_lj_gromacs_ext.o \
-       $(OBJ_DIR)/lal_dpd.o $(OBJ_DIR)/lal_dpd_ext.o \
+       $(OBJ_DIR)/lal_dpd.o $(OBJ_DIR)/lal_dpd_ext.o $(OBJ_DIR)/lal_dpd_tstat_ext.o \
        $(OBJ_DIR)/lal_tersoff.o $(OBJ_DIR)/lal_tersoff_ext.o \
        $(OBJ_DIR)/lal_tersoff_zbl.o $(OBJ_DIR)/lal_tersoff_zbl_ext.o \
        $(OBJ_DIR)/lal_tersoff_mod.o $(OBJ_DIR)/lal_tersoff_mod_ext.o \
@@ -82,7 +82,8 @@ OBJS = $(OBJ_DIR)/lal_atom.o $(OBJ_DIR)/lal_ans.o \
        $(OBJ_DIR)/lal_lj_expand_coul_long.o $(OBJ_DIR)/lal_lj_expand_coul_long_ext.o \
        $(OBJ_DIR)/lal_coul_long_cs.o $(OBJ_DIR)/lal_coul_long_cs_ext.o \
        $(OBJ_DIR)/lal_born_coul_long_cs.o $(OBJ_DIR)/lal_born_coul_long_cs_ext.o \
-       $(OBJ_DIR)/lal_born_coul_wolf_cs.o $(OBJ_DIR)/lal_born_coul_wolf_cs_ext.o
+       $(OBJ_DIR)/lal_born_coul_wolf_cs.o $(OBJ_DIR)/lal_born_coul_wolf_cs_ext.o \
+       $(OBJ_DIR)/lal_lj_tip4p_long.o $(OBJ_DIR)/lal_lj_tip4p_long_ext.o
 
 CBNS = $(OBJ_DIR)/device.cubin $(OBJ_DIR)/device_cubin.h \
        $(OBJ_DIR)/atom.cubin $(OBJ_DIR)/atom_cubin.h \
@@ -143,7 +144,8 @@ CBNS = $(OBJ_DIR)/device.cubin $(OBJ_DIR)/device_cubin.h \
        $(OBJ_DIR)/lj_expand_coul_long.cubin $(OBJ_DIR)/lj_expand_coul_long_cubin.h \
        $(OBJ_DIR)/coul_long_cs.cubin $(OBJ_DIR)/coul_long_cs_cubin.h \
        $(OBJ_DIR)/born_coul_long_cs.cubin $(OBJ_DIR)/born_coul_long_cs_cubin.h \
-       $(OBJ_DIR)/born_coul_wolf_cs.cubin $(OBJ_DIR)/born_coul_wolf_cs_cubin.h
+       $(OBJ_DIR)/born_coul_wolf_cs.cubin $(OBJ_DIR)/born_coul_wolf_cs_cubin.h \
+       $(OBJ_DIR)/lj_tip4p_long.cubin $(OBJ_DIR)/lj_tip4p_long_cubin.h
 
 all: $(OBJ_DIR) $(GPU_LIB) $(EXECS)
 
@@ -296,6 +298,18 @@ $(OBJ_DIR)/lal_lj.o: $(ALL_H) lal_lj.h lal_lj.cpp $(OBJ_DIR)/lj_cubin.h $(OBJ_DI
 
 $(OBJ_DIR)/lal_lj_ext.o: $(ALL_H) lal_lj.h lal_lj_ext.cpp lal_base_atomic.h
 	$(CUDR) -o $@ -c lal_lj_ext.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lj_tip4p_long.cubin: lal_lj_tip4p_long.cu lal_precision.h lal_preprocessor.h
+	$(CUDA) --fatbin -DNV_KERNEL -o $@ lal_lj_tip4p_long.cu
+
+$(OBJ_DIR)/lj_tip4p_long_cubin.h: $(OBJ_DIR)/lj_tip4p_long.cubin $(OBJ_DIR)/lj_tip4p_long.cubin
+	$(BIN2C)  -c -n lj_tip4p_long $(OBJ_DIR)/lj_tip4p_long.cubin > $(OBJ_DIR)/lj_tip4p_long_cubin.h
+
+$(OBJ_DIR)/lal_lj_tip4p_long.o: $(ALL_H) lal_lj_tip4p_long.h lal_lj_tip4p_long.cpp  $(OBJ_DIR)/lj_tip4p_long_cubin.h $(OBJ_DIR)/lal_base_atomic.o
+	$(CUDR) -o $@ -c lal_lj_tip4p_long.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_lj_tip4p_long_ext.o: $(ALL_H) lal_lj_tip4p_long.h lal_lj_tip4p_long_ext.cpp lal_base_atomic.h
+	$(CUDR) -o $@ -c lal_lj_tip4p_long_ext.cpp -I$(OBJ_DIR)
 
 $(OBJ_DIR)/lj_coul.cubin: lal_lj_coul.cu lal_precision.h lal_preprocessor.h
 	$(CUDA) --fatbin -DNV_KERNEL -o $@ lal_lj_coul.cu
@@ -717,6 +731,15 @@ $(OBJ_DIR)/dpd.cubin: lal_dpd.cu lal_precision.h lal_preprocessor.h
 $(OBJ_DIR)/dpd_cubin.h: $(OBJ_DIR)/dpd.cubin $(OBJ_DIR)/dpd.cubin
 	$(BIN2C) -c -n dpd $(OBJ_DIR)/dpd.cubin > $(OBJ_DIR)/dpd_cubin.h
 
+$(OBJ_DIR)/lal_dpd.o: $(ALL_H) lal_dpd.h lal_dpd.cpp $(OBJ_DIR)/dpd_cubin.h $(OBJ_DIR)/lal_base_dpd.o
+	$(CUDR) -o $@ -c lal_dpd.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_dpd_ext.o: $(ALL_H) lal_dpd.h lal_dpd_ext.cpp lal_base_dpd.h
+	$(CUDR) -o $@ -c lal_dpd_ext.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_dpd_tstat_ext.o: $(ALL_H) lal_dpd.h lal_dpd_tstat_ext.cpp lal_base_dpd.h
+	$(CUDR) -o $@ -c lal_dpd_tstat_ext.cpp -I$(OBJ_DIR)
+
 $(OBJ_DIR)/ufm.cubin: lal_ufm.cu lal_precision.h lal_preprocessor.h
 	$(CUDA) --fatbin -DNV_KERNEL -o $@ lal_ufm.cu
 
@@ -728,12 +751,6 @@ $(OBJ_DIR)/lal_ufm.o: $(ALL_H) lal_ufm.h lal_ufm.cpp $(OBJ_DIR)/ufm_cubin.h $(OB
 
 $(OBJ_DIR)/lal_ufm_ext.o: $(ALL_H) lal_ufm.h lal_ufm_ext.cpp lal_base_atomic.h
 	$(CUDR) -o $@ -c lal_ufm_ext.cpp -I$(OBJ_DIR)
-
-$(OBJ_DIR)/lal_dpd.o: $(ALL_H) lal_dpd.h lal_dpd.cpp $(OBJ_DIR)/dpd_cubin.h $(OBJ_DIR)/lal_base_dpd.o
-	$(CUDR) -o $@ -c lal_dpd.cpp -I$(OBJ_DIR)
-
-$(OBJ_DIR)/lal_dpd_ext.o: $(ALL_H) lal_dpd.h lal_dpd_ext.cpp lal_base_dpd.h
-	$(CUDR) -o $@ -c lal_dpd_ext.cpp -I$(OBJ_DIR)
 
 $(OBJ_DIR)/tersoff.cubin: lal_tersoff.cu lal_precision.h lal_tersoff_extra.h lal_preprocessor.h
 	$(CUDA) --fatbin -DNV_KERNEL -o $@ lal_tersoff.cu

--- a/lib/gpu/Opencl.makefile
+++ b/lib/gpu/Opencl.makefile
@@ -58,7 +58,7 @@ OBJS = $(OBJ_DIR)/lal_atom.o $(OBJ_DIR)/lal_answer.o \
        $(OBJ_DIR)/lal_soft.o $(OBJ_DIR)/lal_soft_ext.o \
        $(OBJ_DIR)/lal_lj_coul_msm.o $(OBJ_DIR)/lal_lj_coul_msm_ext.o \
        $(OBJ_DIR)/lal_lj_gromacs.o $(OBJ_DIR)/lal_lj_gromacs_ext.o \
-       $(OBJ_DIR)/lal_dpd.o $(OBJ_DIR)/lal_dpd_ext.o \
+       $(OBJ_DIR)/lal_dpd.o $(OBJ_DIR)/lal_dpd_ext.o $(OBJ_DIR)/lal_dpd_tstat_ext.o \
        $(OBJ_DIR)/lal_tersoff.o $(OBJ_DIR)/lal_tersoff_ext.o \
        $(OBJ_DIR)/lal_tersoff_zbl.o $(OBJ_DIR)/lal_tersoff_zbl_ext.o \
        $(OBJ_DIR)/lal_tersoff_mod.o $(OBJ_DIR)/lal_tersoff_mod_ext.o \
@@ -533,6 +533,9 @@ $(OBJ_DIR)/lal_dpd.o: $(ALL_H) lal_dpd.h lal_dpd.cpp  $(OBJ_DIR)/dpd_cl.h $(OBJ_
 
 $(OBJ_DIR)/lal_dpd_ext.o: $(ALL_H) lal_dpd.h lal_dpd_ext.cpp lal_base_dpd.h
 	$(OCL) -o $@ -c lal_dpd_ext.cpp -I$(OBJ_DIR)
+
+$(OBJ_DIR)/lal_dpd_tstat_ext.o: $(ALL_H) lal_dpd.h lal_dpd_tstat_ext.cpp lal_base_dpd.h
+	$(OCL) -o $@ -c lal_dpd_tstat_ext.cpp -I$(OBJ_DIR)
 
 $(OBJ_DIR)/tersoff_cl.h: lal_tersoff.cu lal_tersoff_extra.h $(PRE1_H)
 	$(BSH) ./geryon/file_to_cstr.sh tersoff $(PRE1_H) lal_tersoff_extra.h lal_tersoff.cu $(OBJ_DIR)/tersoff_cl.h;

--- a/lib/gpu/lal_dpd_tstat_ext.cpp
+++ b/lib/gpu/lal_dpd_tstat_ext.cpp
@@ -1,16 +1,16 @@
 /***************************************************************************
-                                 dpd_ext.cpp
+                              dpd_stat_ext.cpp
                              -------------------
-                            Trung Dac Nguyen (ORNL)
+                        Trung Dac Nguyen (Northwestern)
 
-  Functions for LAMMPS access to dpd acceleration routines.
+  Functions for LAMMPS access to dpd/tstat acceleration routines.
 
  __________________________________________________________________________
     This file is part of the LAMMPS Accelerator Library (LAMMPS_AL)
  __________________________________________________________________________
 
-    begin                : Jan 15, 2014
-    email                : nguyentd@ornl.gov
+    begin                : Sep 18, 2020
+    email                : ndactrung@gmail.com
  ***************************************************************************/
 
 #include <iostream>
@@ -41,7 +41,7 @@ int dpd_tstat_gpu_init(const int ntypes, double **cutsq, double **host_a0,
   int gpu_rank=DPDTMF.device->gpu_rank();
   int procs_per_gpu=DPDTMF.device->procs_per_gpu();
 
-  DPDTMF.device->init_message(screen,"dpd",first_gpu,last_gpu);
+  DPDTMF.device->init_message(screen,"dpd/tstat",first_gpu,last_gpu);
 
   bool message=false;
   if (DPDTMF.device->replica_me()==0 && screen)

--- a/lib/gpu/lal_dpd_tstat_ext.cpp
+++ b/lib/gpu/lal_dpd_tstat_ext.cpp
@@ -22,29 +22,29 @@
 using namespace std;
 using namespace LAMMPS_AL;
 
-static DPD<PRECISION,ACC_PRECISION> DPDMF;
+static DPD<PRECISION,ACC_PRECISION> DPDTMF;
 
 // ---------------------------------------------------------------------------
 // Allocate memory on host and device and copy constants to device
 // ---------------------------------------------------------------------------
-int dpd_gpu_init(const int ntypes, double **cutsq, double **host_a0,
+int dpd_tstat_gpu_init(const int ntypes, double **cutsq, double **host_a0,
                  double **host_gamma, double **host_sigma, double **host_cut,
                  double *special_lj, const int inum,
                  const int nall, const int max_nbors,  const int maxspecial,
                  const double cell_size, int &gpu_mode, FILE *screen) {
-  DPDMF.clear();
-  gpu_mode=DPDMF.device->gpu_mode();
-  double gpu_split=DPDMF.device->particle_split();
-  int first_gpu=DPDMF.device->first_device();
-  int last_gpu=DPDMF.device->last_device();
-  int world_me=DPDMF.device->world_me();
-  int gpu_rank=DPDMF.device->gpu_rank();
-  int procs_per_gpu=DPDMF.device->procs_per_gpu();
+  DPDTMF.clear();
+  gpu_mode=DPDTMF.device->gpu_mode();
+  double gpu_split=DPDTMF.device->particle_split();
+  int first_gpu=DPDTMF.device->first_device();
+  int last_gpu=DPDTMF.device->last_device();
+  int world_me=DPDTMF.device->world_me();
+  int gpu_rank=DPDTMF.device->gpu_rank();
+  int procs_per_gpu=DPDTMF.device->procs_per_gpu();
 
-  DPDMF.device->init_message(screen,"dpd",first_gpu,last_gpu);
+  DPDTMF.device->init_message(screen,"dpd",first_gpu,last_gpu);
 
   bool message=false;
-  if (DPDMF.device->replica_me()==0 && screen)
+  if (DPDTMF.device->replica_me()==0 && screen)
     message=true;
 
   if (message) {
@@ -54,11 +54,11 @@ int dpd_gpu_init(const int ntypes, double **cutsq, double **host_a0,
 
   int init_ok=0;
   if (world_me==0)
-    init_ok=DPDMF.init(ntypes, cutsq, host_a0, host_gamma, host_sigma,
-                       host_cut, special_lj, false, inum, nall, 300,
+    init_ok=DPDTMF.init(ntypes, cutsq, host_a0, host_gamma, host_sigma,
+                       host_cut, special_lj, true, inum, nall, 300,
                        maxspecial, cell_size, gpu_split, screen);
 
-  DPDMF.device->world_barrier();
+  DPDTMF.device->world_barrier();
   if (message)
     fprintf(screen,"Done.\n");
 
@@ -72,11 +72,11 @@ int dpd_gpu_init(const int ntypes, double **cutsq, double **host_a0,
       fflush(screen);
     }
     if (gpu_rank==i && world_me!=0)
-      init_ok=DPDMF.init(ntypes, cutsq, host_a0, host_gamma, host_sigma,
-                         host_cut, special_lj, false, inum, nall, 300,
+      init_ok=DPDTMF.init(ntypes, cutsq, host_a0, host_gamma, host_sigma,
+                         host_cut, special_lj, true, inum, nall, 300,
                          maxspecial, cell_size, gpu_split, screen);
 
-    DPDMF.device->gpu_barrier();
+    DPDTMF.device->gpu_barrier();
     if (message)
       fprintf(screen,"Done.\n");
   }
@@ -84,15 +84,15 @@ int dpd_gpu_init(const int ntypes, double **cutsq, double **host_a0,
     fprintf(screen,"\n");
 
   if (init_ok==0)
-    DPDMF.estimate_gpu_overhead();
+    DPDTMF.estimate_gpu_overhead();
   return init_ok;
 }
 
-void dpd_gpu_clear() {
-  DPDMF.clear();
+void dpd_tstat_gpu_clear() {
+  DPDTMF.clear();
 }
 
-int ** dpd_gpu_compute_n(const int ago, const int inum_full, const int nall,
+int ** dpd_tstat_gpu_compute_n(const int ago, const int inum_full, const int nall,
                          double **host_x, int *host_type, double *sublo,
                          double *subhi, tagint *tag, int **nspecial,
                          tagint **special, const bool eflag, const bool vflag,
@@ -101,13 +101,13 @@ int ** dpd_gpu_compute_n(const int ago, const int inum_full, const int nall,
                          double **host_v, const double dtinvsqrt,
                          const int seed, const int timestep,
                          double *boxlo, double *prd) {
-  return DPDMF.compute(ago, inum_full, nall, host_x, host_type, sublo,
+  return DPDTMF.compute(ago, inum_full, nall, host_x, host_type, sublo,
                        subhi, tag, nspecial, special, eflag, vflag, eatom,
                        vatom, host_start, ilist, jnum, cpu_time, success,
                        host_v, dtinvsqrt, seed, timestep, boxlo, prd);
 }
 
-void dpd_gpu_compute(const int ago, const int inum_full, const int nall,
+void dpd_tstat_gpu_compute(const int ago, const int inum_full, const int nall,
                      double **host_x, int *host_type, int *ilist, int *numj,
                      int **firstneigh, const bool eflag, const bool vflag,
                      const bool eatom, const bool vatom, int &host_start,
@@ -115,19 +115,19 @@ void dpd_gpu_compute(const int ago, const int inum_full, const int nall,
                      double **host_v, const double dtinvsqrt,
                      const int seed, const int timestep,
                      const int nlocal, double *boxlo, double *prd) {
-  DPDMF.compute(ago, inum_full, nall, host_x, host_type, ilist, numj,
+  DPDTMF.compute(ago, inum_full, nall, host_x, host_type, ilist, numj,
                 firstneigh, eflag, vflag, eatom, vatom, host_start, cpu_time, success,
                 tag, host_v, dtinvsqrt, seed, timestep, nlocal, boxlo, prd);
 }
 
-void dpd_gpu_update_coeff(int ntypes, double **host_a0, double **host_gamma,
+void dpd_tstat_gpu_update_coeff(int ntypes, double **host_a0, double **host_gamma,
                           double **host_sigma, double **host_cut)
 {
-   DPDMF.update_coeff(ntypes,host_a0,host_gamma,host_sigma,host_cut);
+   DPDTMF.update_coeff(ntypes,host_a0,host_gamma,host_sigma,host_cut);
 }
 
-double dpd_gpu_bytes() {
-  return DPDMF.host_memory_usage();
+double dpd_tstat_gpu_bytes() {
+  return DPDTMF.host_memory_usage();
 }
 
 

--- a/src/GPU/pair_dpd_gpu.cpp
+++ b/src/GPU/pair_dpd_gpu.cpp
@@ -43,7 +43,7 @@ using namespace LAMMPS_NS;
 
 int dpd_gpu_init(const int ntypes, double **cutsq, double **host_a0,
                  double **host_gamma, double **host_sigma, double **host_cut,
-                 double *special_lj, bool tstat_only, const int inum,
+                 double *special_lj, const int inum,
                  const int nall, const int max_nbors,  const int maxspecial,
                  const double cell_size, int &gpu_mode, FILE *screen);
 void dpd_gpu_clear();
@@ -309,7 +309,7 @@ void PairDPDGPU::init_style()
   if (atom->molecular)
     maxspecial=atom->maxspecial;
   int success = dpd_gpu_init(atom->ntypes+1, cutsq, a0, gamma, sigma,
-                             cut, force->special_lj, false, atom->nlocal,
+                             cut, force->special_lj, atom->nlocal,
                              atom->nlocal+atom->nghost, 300, maxspecial,
                              cell_size, gpu_mode, screen);
   GPU_EXTRA::check_flag(success,error,world);


### PR DESCRIPTION
**Summary**

The changes in this PR allow dpd/gpu and dpd/tstat/gpu to work together in pair hybrid, without overriding each other, as reported by user (Changnian Han).

**Related Issue(s)**

Originally dpd/gpu and dpd/tstat/gpu shared the same static object in the GPU library, which is causing overriding issues if dpd/gpu and dpd/tstat/gpu are used in a pair style hybrid command. This PR creates a separate static object for dpd/tstat/gpu. This workaround requires minimal changes to the current code. A more elegant solution could be to use template for tstat_only 0 or 1, but needs more work and testing. More generally, maybe it would be better to replace static objects with objects created at runtime so that multiple instances of the same pair styles but with different settings can be used, which requires a pretty involving changes.

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

should be maintained

**Implementation Notes**


**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



