### PR TITLE
Make f2c_string utility function of the new Fortran module portable across Fortran compilers

### DIFF
--- a/doc/src/Fortran.rst
+++ b/doc/src/Fortran.rst
@@ -24,7 +24,7 @@ of the source files: the lammps.f90 file needs to be compiled first,
 since it provides the ``LIBLAMMPS`` module that is imported by the
 Fortran code using the interface.
 
-.. versionadded:: 30Sep2020
+.. versionadded:: 6Oct2020
 
 .. admonition:: Work in Progress
 

--- a/fortran/lammps.f90
+++ b/fortran/lammps.f90
@@ -16,8 +16,8 @@
 ! and library.h using the ISO_C_BINDING module of the Fortran compiler.
 !
 ! Based on the LAMMPS Fortran 2003 module contributed by:
-!   Karl D. Hammond <karlh@ugcs.caltech.edu>
-!   University of Tennessee, Knoxville (USA), 2012
+!   Karl D. Hammond <hammondkd@missouri.edu>
+!   University of Missouri, 2012-2020
 !
 ! The Fortran module tries to follow the API of the C-library interface
 ! closely, but like the Python wrapper it employs an object oriented
@@ -30,7 +30,7 @@
 MODULE LIBLAMMPS
 
   USE, INTRINSIC :: ISO_C_BINDING, ONLY: c_ptr, c_null_ptr, c_loc, &
-      c_int, c_char, c_null_char, c_double
+      c_int, c_char, c_null_char, c_double, c_size_t, c_f_pointer
 
   IMPLICIT NONE
   PRIVATE
@@ -113,6 +113,12 @@ MODULE LIBLAMMPS
         TYPE(c_ptr), VALUE :: handle
         TYPE(c_ptr), VALUE :: str
       END SUBROUTINE lammps_commands_string
+
+      FUNCTION lammps_malloc(size) BIND(C, name='malloc')
+        IMPORT :: c_ptr, c_size_t
+        INTEGER(c_size_t), value :: size
+        TYPE(c_ptr) :: lammps_malloc
+      END FUNCTION lammps_malloc
 
       SUBROUTINE lammps_free(ptr) BIND(C, name='lammps_free')
         IMPORT :: c_ptr
@@ -267,14 +273,14 @@ CONTAINS
     CHARACTER (len=*), INTENT(in)           :: f_string
     CHARACTER (len=1, kind=c_char), POINTER :: c_string(:)
     TYPE(c_ptr) :: ptr
-    INTEGER :: i, n
+    INTEGER(c_size_t) :: i, n
 
     n = LEN_TRIM(f_string)
-    ALLOCATE(c_string(n+1))
+    ptr = lammps_malloc(n+1)
+    CALL C_F_POINTER(ptr,c_string,[1])
     DO i=1,n
         c_string(i) = f_string(i:i)
     END DO
     c_string(n+1) = c_null_char
-    ptr = c_loc(c_string(1))
   END FUNCTION f2c_string
 END MODULE LIBLAMMPS


### PR DESCRIPTION
**Summary**

This replaces code that was reliant on Fotran's ALLOCATE() intrinsic being compatible with malloc()/free() with code that uses malloc() directly and then converts into a Fortran compatible array pointer. The old implementation could cause crashes with the Intel Fortran compiler.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
