### PR TITLE
bond/react: rmsd constraint bugfix

### DIFF
--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -1863,6 +1863,8 @@ int FixBondReact::check_constraints()
         if (prrhob < rrhandom[(int) constraints[i][2]]->uniform()) return 0;
       } else if (constraints[i][1] == RMSD) {
         // call superpose
+        int iatom;
+        int iref = -1; // choose first atom as reference
         int n2superpose = 0;
         double **xfrozen; // coordinates for the "frozen" target molecule
         double **xmobile; // coordinates for the "mobile" molecule
@@ -1875,20 +1877,28 @@ int FixBondReact::check_constraints()
           int myincr = 0;
           for (int j = 0; j < onemol->natoms; j++) {
             if (onemol->fragmentmask[ifragment][j]) {
+              iatom = atom->map(glove[j][1]);
+              if (iref == -1) iref = iatom;
+              iatom = domain->closest_image(iref,iatom);
               for (int k = 0; k < 3; k++) {
-                xfrozen[myincr][k] = x[atom->map(glove[j][1])][k];
+                xfrozen[myincr][k] = x[iatom][k];
                 xmobile[myincr][k] = onemol->x[j][k];
               }
               myincr++;
             }
           }
         } else {
+          int iatom;
+          int iref = -1; // choose first atom as reference
           n2superpose = onemol->natoms;
           memory->create(xfrozen,n2superpose,3,"bond/react:xfrozen");
           memory->create(xmobile,n2superpose,3,"bond/react:xmobile");
           for (int j = 0; j < n2superpose; j++) {
+            iatom = atom->map(glove[j][1]);
+            if (iref == -1) iref = iatom;
+            iatom = domain->closest_image(iref,iatom);
             for (int k = 0; k < 3; k++) {
-              xfrozen[j][k] = x[atom->map(glove[j][1])][k];
+              xfrozen[j][k] = x[iatom][k];
               xmobile[j][k] = onemol->x[j][k];
             }
           }


### PR DESCRIPTION
**Summary**

serial bugfix for the recently-added RMSD reaction constraint. previously, eligible reactions could have been temporarily prevented, at the edge of the box

**Related Issue(s)**

none

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


