### PR TITLE
Patching neighbor history restarts

### DIFF
--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -870,7 +870,7 @@ int FixNeighHistory::pack_restart(int i, double *buf)
   for (int n = 0; n < npartner[i]; n++) {
     buf[m++] = partner[i][n];
     memcpy(&buf[m],&valuepartner[i][dnum*n],dnumbytes);
-    m += dnum;    
+    m += dnum;
   }
   // pack buf[0] this way because other fixes unpack it
   buf[0] = m;

--- a/src/fix_neigh_history.h
+++ b/src/fix_neigh_history.h
@@ -53,6 +53,7 @@ class FixNeighHistory : public Fix {
   void unpack_reverse_comm(int, int *, double *);
   int pack_exchange(int, double *);
   int unpack_exchange(int, double *);
+  void write_restart(FILE *);  
   int pack_restart(int, double *);
   void unpack_restart(int, int);
   int size_restart(int);


### PR DESCRIPTION
**Summary**

When writing a restart file, fix neighbor/history writes data stored in per-atom arrays. However, this data is one timestep out of date. In the prior pair->compute call, only the data in page files is updated. This PR addresses this bug by calling an extra instance of pre_exchange (which copies page file data into per-atom arrays) before packing restart data.

**Related Issue(s)**

None

**Author(s)**

Joel Clemmer (SNL) - jtclemm@sandia.gov

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Old restart files may not work if they saved neighbor/history data.

**Implementation Notes**

Added new write_restart method in fix neighbor/history to call pre_exchange(). It doesn't actually write data (other than the size of the data written, 0).

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

None


