### PR TITLE
Warn about too small box for periodic molecular system

### DIFF
--- a/doc/src/special_bonds.rst
+++ b/doc/src/special_bonds.rst
@@ -239,7 +239,14 @@ their default values before modifying them, each time the
 
 Restrictions
 """"""""""""
-none
+
+If the neighbor list cutoff (i.e. the largest cutoff of any pair style)
+is larger than the simulation cell for a periodic dimension, then the
+detetmination of which pairs of non-bonded interactions need to be
+excluded, may be incorrect.  LAMMPS will print a warning message if this
+is the case.  A workaround for this would be to use the
+:doc:`replicate command <replicate>` to enlarge the system along that
+direction.
 
 Related commands
 """"""""""""""""

--- a/doc/src/special_bonds.rst
+++ b/doc/src/special_bonds.rst
@@ -242,7 +242,7 @@ Restrictions
 
 If the neighbor list cutoff (i.e. the largest cutoff of any pair style)
 is larger than the simulation cell for a periodic dimension, then the
-detetmination of which pairs of non-bonded interactions need to be
+determination of which pairs of non-bonded interactions need to be
 excluded, may be incorrect.  LAMMPS will print a warning message if this
 is the case.  A workaround for this would be to use the
 :doc:`replicate command <replicate>` to enlarge the system along that


### PR DESCRIPTION
**Summary**

If the neighbor list cutoff is larger than the box in a periodic direction, the determination of neighborlist exclusions can fail.
This adds code to detect and warn about this issue and document it as a Restriction of the "special_bonds" command.

**Related Issue(s)**

This was reported on lammps-users:
https://sourceforge.net/p/lammps/mailman/message/37126018/
https://sourceforge.net/p/lammps/mailman/message/37129504/

**Author(s)**

Axel Kohlmeyer, Temple U
Steve Plimpton, SNL

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
