### PR TITLE
Create logic in parsing KIM Simulator Models to treat periodic vs. aperiodic simulations differently

### DIFF
--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -251,7 +251,6 @@ void KimInteractions::KIM_SET_TYPE_PARAMETERS(const std::string &input_line) con
   int nocomment;
   auto words = utils::split_words(input_line);
 
-  char *species1, *species2, *the_rest;
   std::string key = words[1];
   std::string filename = words[2];
   std::vector<std::string> species(words.begin()+3,words.end());
@@ -285,16 +284,11 @@ void KimInteractions::KIM_SET_TYPE_PARAMETERS(const std::string &input_line) con
     if(nocomment) {
       words = utils::split_words(line);
       if (key == "pair") {
-	ptr=line;
-	species1 = strtok(ptr," \t");
-	species2 = strtok(NULL," \t");
-	the_rest = strtok(NULL,"\n");
-
-        for (int ia = 0; ia < atom->ntypes; ++ia) {
+	for (int ia = 0; ia < atom->ntypes; ++ia) {
           for (int ib = ia; ib < atom->ntypes; ++ib)
             if (((species[ia] == words[0]) && (species[ib] == words[1]))
                 || ((species[ib] == words[0]) && (species[ia] == words[1])))
-              input->one(fmt::format("pair_coeff {} {} {}",ia+1,ib+1,the_rest));
+	      input->one(fmt::format("pair_coeff {} {} {}",ia+1,ib+1,fmt::join(words.begin()+2,words.end()," ")));
         }
       } else if (key == "charge") {
         for (int ia = 0; ia < atom->ntypes; ++ia)

--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -284,11 +284,11 @@ void KimInteractions::KIM_SET_TYPE_PARAMETERS(const std::string &input_line) con
     if(nocomment) {
       words = utils::split_words(line);
       if (key == "pair") {
-	for (int ia = 0; ia < atom->ntypes; ++ia) {
+        for (int ia = 0; ia < atom->ntypes; ++ia) {
           for (int ib = ia; ib < atom->ntypes; ++ib)
             if (((species[ia] == words[0]) && (species[ib] == words[1]))
                 || ((species[ib] == words[0]) && (species[ia] == words[1])))
-	      input->one(fmt::format("pair_coeff {} {} {}",ia+1,ib+1,fmt::join(words.begin()+2,words.end()," ")));
+              input->one(fmt::format("pair_coeff {} {} {}",ia+1,ib+1,fmt::join(words.begin()+2,words.end()," ")));
         }
       } else if (key == "charge") {
         for (int ia = 0; ia < atom->ntypes; ++ia)


### PR DESCRIPTION
Updates to kim_interactions to generalize the interpreter for smspec.edn to allow for different variants of the model commands for aperiodic vs periodic simulations

**Summary**

OpenKIM simulator models (SMs) work by creating appropriate input commands at runtime and sending them to the LAMMPS input parser.  With this extension, we allow for an SM to send different commands depending on whether the simulation being run is periodic or aperiodic (thereby using, or not, kspace features as appropriate for example)

**Related Issue(s)**

None.

**Author(s)**

Ron Miller, Carleton University
Ryan Elliott, U Minnesota
Ellad Tadmor, U Minnesota

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

fully backward compatible.

**Implementation Notes**

confined to the KIM package.  No other features should be affected.

**Post Submission Checklist**


- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


