### PR TITLE
Enable gathering of git info with git v1.8.3.1

### DIFF
--- a/cmake/Modules/generate_lmpgitversion.cmake
+++ b/cmake/Modules/generate_lmpgitversion.cmake
@@ -7,17 +7,20 @@ set(temp_git_info "false")
 message(STATUS "Git Directory: ${LAMMPS_DIR}/.git")
 if(GIT_FOUND AND EXISTS ${LAMMPS_DIR}/.git)
   set(temp_git_info "true")
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${LAMMPS_DIR} rev-parse HEAD
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
     OUTPUT_VARIABLE temp_git_commit
     ERROR_QUIET
+    WORKING_DIRECTORY ${LAMMPS_DIR}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${LAMMPS_DIR} rev-parse --abbrev-ref HEAD
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
     OUTPUT_VARIABLE temp_git_branch
     ERROR_QUIET
+    WORKING_DIRECTORY ${LAMMPS_DIR}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${LAMMPS_DIR} describe --dirty=-modified
+  execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty=-modified
     OUTPUT_VARIABLE temp_git_describe
     ERROR_QUIET
+    WORKING_DIRECTORY ${LAMMPS_DIR}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 


### PR DESCRIPTION
**Summary**

The -C flag wasn't supported back then. The workaround is to change the
working directory via CMake. This issue was detected while building on
CentOS 7.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

Richard Berger (Temple University) @rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


