### PR TITLE
Add non-numeric pressure check to fix box/relax

### DIFF
--- a/src/fix_box_relax.cpp
+++ b/src/fix_box_relax.cpp
@@ -735,12 +735,18 @@ void FixBoxRelax::couple()
     p_current[2] = tensor[2];
   }
 
+  if (!std::isfinite(p_current[0]) || !std::isfinite(p_current[1]) || !std::isfinite(p_current[2]))
+    error->all(FLERR,"Non-numeric pressure - simulation unstable");
+
   // switch order from xy-xz-yz to Voigt
 
   if (pstyle == TRICLINIC) {
     p_current[3] = tensor[5];
     p_current[4] = tensor[4];
     p_current[5] = tensor[3];
+
+    if (!std::isfinite(p_current[3]) || !std::isfinite(p_current[4]) || !std::isfinite(p_current[5]))
+      error->all(FLERR,"Non-numeric pressure - simulation unstable");
   }
 }
 


### PR DESCRIPTION
**Summary**

Add non-numeric pressure check to `fix box/relax` so that the minimizer doesn't hang when the pressure is NaN, etc. This check matches that already in `fix_nh.cpp`, see https://github.com/lammps/lammps/blob/master/src/fix_nh.cpp#L1061.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Calvin Anderson (Miami University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes