### PR TITLE
Added electronic stopping as a friction term with a velocity cutoff w…

### DIFF
--- a/doc/src/fix_esfriction.rst
+++ b/doc/src/fix_esfriction.rst
@@ -1,0 +1,76 @@
+.. index:: fix esfriction
+
+fix esfriction command
+======================
+
+Syntax
+""""""
+
+
+.. parsed-literal::
+
+   fix ID group-ID esfriction Z1 Z2 A1 A2 Ne_val E_pka ES_cutoff
+
+* ID, group-ID are documented in :doc:`fix <fix>` command
+* esfriction = style name of this fix command
+* Z1, Z2 = atomic numbers of the PKA source and target atoms
+* A1, A1 = atomic mass of the PKA source and target atoms
+* Ne_val = no. of valance shell electrons
+* E_pka = energy of PKA in metal units
+* ES_cutoff = minimum kinetic energy for electronic stopping (metal units)
+
+
+
+Examples
+""""""""
+
+
+.. parsed-literal::
+
+   fix 2 mobile esfriction 26 26 55.847 55.847 2 5000 60.0
+
+
+Description
+"""""""""""
+
+This fix offers an alternative implementation to apply electronic stopping (ES). The other implementation in LAMMPS is :doc:`fix electron/stopping <fix_electron_stopping>`. Our implementation computes and applies the frictional force due to ES to each atom (with energy above cutoff) on-the-fly. Which means, it does not require any pre-computed table as input.It applies effect of ES by damping the velocity of an atom by a viscous force:
+
+.. math::
+
+  \vec{F_{es}} = \beta \vec{v}
+
+where :math:`\beta` is the drag coefficient having units of mass/time, and :math:`\vec{v}` is the velocity of the energetic atom. Here, the value of :math:`\beta` is calculated using Lindhard and Scharff's (LS) formula for energy dissipation in energetic ions as described in :ref:`our paper <esfriction_paper>`. 
+The fix will also output the total energy lost due to ES (computed numerically) to screen and logfile. For validation, it also writes the expected energy lost due to ES as computed by the NRT model. 
+
+
+**Restart, fix_modify, output, run start/stop, minimize info:**
+
+No information about this fix is written to :doc:`binary restart files <restart>`.
+
+The :doc:`fix_modify <fix_modify>` options are not supported.
+
+This fix does not set any global scalar or vector.
+
+The *start/stop* keywords of the :doc:`run <run>` command have no effect
+on this fix.
+
+
+Restrictions
+""""""""""""
+This fix is part of the USER-MISC package. It is only enabled if LAMMPS was 
+built with that package. See the :doc:`Build package <Build_package>` doc 
+page for more info. This fix only supports metal units.
+
+Related commands
+""""""""""""""""
+
+:doc:`fix drag <fix_drag>`, :doc:`fix electron/stopping <fix_electron_stopping>`
+
+**Default:** none
+
+----------
+
+.. _esfriction_paper:
+
+**(ESFriction)** H. Hemani and A. Majalee and U. Bhardwaj and A. Arya and K. Nordlund and M. Warrier, Inclusion and validation of electronic stopping in the open source LAMMPS code, https://arxiv.org/abs/2005.11940.
+

--- a/src/USER-ESFRICTION/README
+++ b/src/USER-ESFRICTION/README
@@ -1,0 +1,5 @@
+The paper explaining the addition of electronic stopping in LAMMPS is available at
+https://arxiv.org/abs/2005.11940
+
+The 'Results and Discussions' section of the above paper has a discussion on the three
+methods of including electronic stopping in collision cascade simulations with LAMMPS.

--- a/src/USER-ESFRICTION/fix_esfriction.cpp
+++ b/src/USER-ESFRICTION/fix_esfriction.cpp
@@ -1,0 +1,203 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+       Contributing Author: Harsh Hemani and Manoj Warrier
+       (Bhabha Atomc Research Center, Computational Analysis Division,
+        Visakhapatnam, India)
+       harshscience777@gmail.com, Manoj.Warrier@gmail.com
+---------------------------------------------------------------------- */
+
+#include <mpi.h>
+#include <cmath>
+#include <cstring>
+#include "fix_esfriction.h"
+#include "atom.h"
+#include "domain.h"
+#include "update.h"
+#include "error.h"
+#include "force.h"
+#include "respa.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+/* ---------------------------------------------------------------------- */
+
+FixESFriction::FixESFriction(LAMMPS *lmp, int narg, char **arg) :
+  Fix(lmp, narg, arg)
+{
+  if (narg < 4) error->all(FLERR,"Illegal fix es-friction command");
+  // args -- 0: fix, 1: fix-id, 2: group-id
+  if (strcmp(update->unit_style,"metal") != 0) {
+    error->all(FLERR, "fix es-friction supports only metal units");
+  }
+  Z1 = utils::numeric(FLERR, arg[3], false, lmp); // atomic number of PKA
+  Z2 = utils::numeric(FLERR, arg[4], false, lmp); // atomic number of target
+  A1 = utils::numeric(FLERR, arg[5], false, lmp); // mass number of PKA
+  A2 = utils::numeric(FLERR, arg[6], false, lmp); // mass number of target
+  Ne_val = utils::numeric(FLERR, arg[7], false, lmp);  // no. of valance shell electrons
+  E_pka = utils::numeric(FLERR, arg[8], false, lmp);   // PKA energy
+  /* ES_cutoff is the energy cutoff for applying ES.
+     That is, atoms with energy below this will not experience ES */
+  ES_cutoff = utils::numeric(FLERR, arg[9], false, lmp);
+  // Compute total energy lost due to ES as per NRT model
+  double E_hat = get_ehat();
+  ES_loss_NRT = E_pka - E_hat;
+  // following computes coefficient of friction (beta) using LS model
+  double number_density = atom->natoms / 
+    (domain->xprd * domain->yprd * domain->zprd) * 1e30; // number-per-m3
+  double E_0 = h_cross*h_cross / (2*m_e) * 
+    pow( 3*pi*pi*Ne_val*(number_density), 2.0/3.0) * joules_to_ev; // eV
+  double v_0 = 5.931e5 * sqrt(E_0) * 1e-2; // ang/ps
+  // lambda is in eV-Angstrom-ps units
+  double lambda = 8.0 * pi * (e_charge * e_charge * 10) * bohr_radius * 
+    pow(Z1, 1.0/6.0) * Z1*Z2 / ( v_0 * pow( pow(Z1, 2.0/3.0) + 
+    pow(Z2, 2.0/3.0) , 3.0/2.0) ); 
+  beta = number_density * lambda / 1.0e30; //eV-ps-angstrom^-2 units
+  // Init energy lost due to ES as per LS model (calculated numerically)
+  ES_loss_LS = 0.0;
+  MPI_Comm_rank(world, &my_rank);
+  if (my_rank==0){
+    if(screen){
+      fprintf(screen, "E_pka = %g eV\n", E_pka);
+      fprintf(screen, "Energy loss due to ES (from NRT model) = %g\n", 
+        ES_loss_NRT);
+    }
+    if (logfile){
+      fprintf(logfile, "E_pka = %g eV\n", E_pka);
+      fprintf(logfile, "Energy loss due to ES (from NRT model) = %g\n", 
+        ES_loss_NRT);
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double FixESFriction::get_kenergy(double A, double vx, double vy, double vz)
+{
+  double gms_to_kg = 1e-3;  // grams to kg
+  double apps_to_mps = 100; // amstrong per picoseconds -to- m/s
+  return (0.5 * A * ( vx*vx + vy*vy + vz*vz ) * gms_to_kg * apps_to_mps * 
+    apps_to_mps * joules_to_ev / Nav); // in eV
+}
+
+/* ----------------------------------------------------------------------
+   Ehat is total energy lost due to ES based on NRT model 
+----------------------------------------------------------------------- */
+
+double FixESFriction::get_ehat()
+{
+  double Emax = 25.0 * pow(Z1, 4.0/3.0) * A1;
+  if (E_pka >= Emax){
+    if (screen){
+      fprintf(screen, "E_pka >= Emax (%g > %g) in esfriction fix.\n", E_pka, 
+        Emax);
+      fprintf(screen, "Hence E_hat calculation (NRT) might be invalid.\n");
+    }
+    if (logfile){
+      fprintf(logfile, "E_pka >= Emax (%g > %g) in esfriction fix.\n", E_pka, 
+        Emax);
+      fprintf(logfile, "Hence E_hat calculation (NRT) might be invalid.\n");
+    }
+  }
+  double eps, gofeps, kay;
+  double const1 = pow( (9.0 * pi*pi / 128.0), (1.0/3.0) );
+  double a = ( const1 * (bohr_radius /  10.0) ) / sqrt( pow(Z1, 2/3.0) + 
+    pow(Z2, 2/3.0) ) ;
+  eps = ( A2 / (A1+A2) ) * ( (a / ( Z1 * Z2 * e_charge * e_charge ) ) ) * 
+    E_pka;
+  gofeps = (3.4008 * pow(eps, 1/6.0)) + (0.40244 * pow(eps, 3.0/4.0)) + eps;
+  kay = 0.1337 * pow(Z1, 1/6.0) * sqrt(Z1/A1);
+  double Ehat = E_pka / (1.0 + kay * gofeps);
+  return Ehat;
+}
+
+/* ---------------------------------------------------------------------- */
+FixESFriction::~FixESFriction()
+{
+}
+/* ---------------------------------------------------------------------- */
+
+int FixESFriction::setmask()
+{
+  int mask = 0;
+  mask |= POST_FORCE;
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixESFriction::init()
+{
+}
+/* ---------------------------------------------------------------------- */
+
+
+/* ----------------------------------------------------------------------
+Apply frictional force due to electronic stopping on each atom 
+proportional to its velocity.
+---------------------------------------------------------------------- */
+
+void FixESFriction::post_force(int /*vflag*/)
+{
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  int *mask = atom->mask;
+  int *type = atom->type;
+  int nlocal = atom->nlocal;
+  double E_i = 0.0; // energy of ith local atom
+  double ES_loss_LS_local = 0.0; // ES loss (LS model) for this process rank
+  for (int i = 0; i < nlocal; i++){
+    if (mask[i] & groupbit) {
+      E_i = get_kenergy(A2, v[i][0], v[i][1], v[i][2]);
+      if(E_i > ES_cutoff){ 
+        f[i][0] -= beta * v[i][0];
+        f[i][1] -= beta * v[i][1];
+        f[i][2] -= beta * v[i][2];
+        ES_loss_LS_local += beta * ( pow(v[i][0], 2) + pow(v[i][1], 2) + 
+          pow(v[i][2], 2) ) * update->dt;
+      }
+    }
+  }
+  double ES_loss_step = 0; // energy lost in this time step
+  MPI_Allreduce(&ES_loss_LS_local, &ES_loss_step, 1, MPI_DOUBLE, MPI_SUM, 
+    world);
+  ES_loss_LS += ES_loss_step; // energy lost till now
+}
+
+/* ---------------------------------------------------------------------- */
+
+
+void FixESFriction::post_run()
+{
+  if(my_rank==0){
+    if (screen){
+      fprintf(screen, 
+        "Energy Lost due to ES (based on NRT model): %g\n", ES_loss_NRT);
+      fprintf(screen, 
+        "Energy Lost due to ES (numerically computed using LS model): %g\n", 
+        ES_loss_LS);
+    }
+  if (logfile){
+      fprintf(logfile, 
+        "Energy Lost due to ES (based on NRT model): %g\n", ES_loss_NRT);
+      fprintf(logfile, 
+        "Energy Lost due to ES (numerically computed using LS model): %g\n", 
+        ES_loss_LS);
+    }
+
+  }
+}
+/* ---------------------------------------------------------------------- */

--- a/src/USER-ESFRICTION/fix_esfriction.h
+++ b/src/USER-ESFRICTION/fix_esfriction.h
@@ -1,0 +1,72 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+FixStyle(esfriction, FixESFriction)
+#else
+
+#ifndef LMP_FIX_ESFRICTION_H
+#define LMP_FIX_ESFRICTION_H
+
+#include "fix.h"
+
+namespace LAMMPS_NS {
+
+class FixESFriction : public Fix {
+ public:
+  FixESFriction(class LAMMPS *, int, char **);
+  virtual ~FixESFriction();
+  int setmask();
+  void init();
+  void post_run();
+  void post_force(int);
+  double get_ehat();
+  double get_kenergy(double, double, double, double);
+
+  double const ev_to_joules = 1.6022e-19;
+  double const joules_to_ev = 1.0 / ev_to_joules;
+  double const Nav = 6.0221e23; // Avogadro's constant
+  double const bohr_radius = 5.2917721067e-1 ; // Angstroms
+  double const h_cross = 1.0546e-34; // planck's constant/(2pi) in J-s
+  double const m_e = 9.1090e-31; // electron mass in Kg
+  double const e_charge = 1.2; // sqrt(eV-nm)
+  double const pi = 3.14159265359;
+
+ protected:
+  int my_rank; // process rank
+  // input quantities
+  double Z1, Z2, A1, A2; // atomic number and mass number of PKA & target
+  double Ne_val; // no. of electrons in outermost shell; valance electrons
+  double ES_cutoff; // Energy cutoff for applying electronic stopping
+  double Vol_molar; // volume per mole
+  double pka_vx, pka_vy, pka_vz; // pka velocities
+  // computed quantities
+  double beta; // coefficient of friction due to ES (computed)
+  double E_pka; // energy of PKA
+  double ES_loss_NRT, ES_loss_LS; // ES loss using NRT & LS models
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+*/


### PR DESCRIPTION
**Summary**

<!--Added electronic stopping as a friction term with a velocity cutoff which is an input. The friction coefficient is evaluated using the Lindhard-Scharff model. The electronic loss is validated by comparing with the standard NRT model. See https://arxiv.org/abs/2005.11940 for details. The 'Results and Discussions' section of the above paper has a discussion on the three
methods of including electronic stopping in collision cascade simulations with LAMMPS. .-->

**Related Issue(s)**

<!--None-->

**Author(s)**

<!--Harsh Hemani (harshscience777@gmail.com). Manoj Warrier (Manoj.Warrier@gmail.com), Bhabha Atomic Research Center, Visakhapatnam, India-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--This pull request should not break any backward compatibility-->

**Implementation Notes**

<!--No features in LAMMPS are affected. We adhered to the LAMMPS coding standards checklist. The code was compiled and an example problem was run.-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


