### PR TITLE
Fix a bug in pair_kim

### DIFF
--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -241,7 +241,7 @@ void PairKIM::compute(int eflag, int vflag)
     comm->reverse_comm_pair(this);
   }
 
-  if ((vflag_atom) &&
+  if ((vflag_atom != 0) &&
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
                                  KIM_SUPPORT_STATUS_notSupported)) {
     // flip sign and order of virial if KIM is computing it
@@ -651,11 +651,11 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
   // see Pair::ev_setup & Integrate::ev_set() 
   // for values of eflag (0-3) and vflag (0-14)
   // -------------------------------------------------------------------------
-  if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
-                                 KIM_SUPPORT_STATUS_notSupported) && 
-      KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
+  if ((vflag_atom != 0) &&
+      KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
                                  KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom != 0)) {
+      KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
+                                 KIM_SUPPORT_STATUS_notSupported)) {
     const double *const fp = &(atom->f[0][0]);
     const double *const va = &(vatom[0][0]);
     for (int i = first; i < last; i++) {
@@ -672,11 +672,11 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
     }
     return m;
   } 
-  if (KIM_SupportStatus_Equal(kim_model_support_for_forces,
+  if ((vflag_atom != 0) &&
+      KIM_SupportStatus_Equal(kim_model_support_for_forces,
                               KIM_SUPPORT_STATUS_notSupported) &&
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                 KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom != 0)) {
+                                 KIM_SUPPORT_STATUS_notSupported)) {
     const double *const va = &(vatom[0][0]);
     for (int i = first; i < last; i++) {
       buf[m++] = va[6*i+0];
@@ -710,11 +710,11 @@ void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
     }
     return;
   }
-  if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
+  if ((vflag_atom != 0) &&
+      KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
                                  KIM_SUPPORT_STATUS_notSupported) &&
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                 KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom != 0)) {
+                                 KIM_SUPPORT_STATUS_notSupported)) {
     double *const fp = &(atom->f[0][0]);
     double *const va = &(vatom[0][0]);
     for (int i = 0; i < n; i++) {
@@ -732,11 +732,11 @@ void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
     }
     return;
   } 
-  if (KIM_SupportStatus_Equal(kim_model_support_for_forces,
+  if ((vflag_atom != 0) &&
+      KIM_SupportStatus_Equal(kim_model_support_for_forces,
                               KIM_SUPPORT_STATUS_notSupported) &&
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                 KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom != 0)) {
+                                 KIM_SUPPORT_STATUS_notSupported)) {
     double *const va=&(vatom[0][0]);
     for (int i = 0; i < n; i++) {
       const int j = list[i];
@@ -946,9 +946,9 @@ void PairKIM::set_argument_pointers()
   }
 
   // Set KIM pointer appropriately for particleVirial
-  if (KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
-                              KIM_SUPPORT_STATUS_required)
-      && (vflag_atom != 4)) {
+  if ((vflag_atom == 0) &&
+      KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
+                              KIM_SUPPORT_STATUS_required)) {
     // reallocate per-atom virial array if necessary
     if (atom->nmax > maxvatom) {
       maxvatom = atom->nmax;
@@ -957,9 +957,9 @@ void PairKIM::set_argument_pointers()
     }
   }
 
-  if (KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
-                              KIM_SUPPORT_STATUS_optional)
-      && (vflag_atom != 4)) {
+  if ((vflag_atom == 0) &&
+      KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
+                              KIM_SUPPORT_STATUS_optional)) {
     kimerror = kimerror || KIM_ComputeArguments_SetArgumentPointerDouble(
       pargs,
       KIM_COMPUTE_ARGUMENT_NAME_partialParticleVirial,

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -636,9 +636,9 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
   int const last = first + n;
   if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
                                  KIM_SUPPORT_STATUS_notSupported) &&
-      ((vflag_atom == 0) ||
-       KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
-                               KIM_SUPPORT_STATUS_notSupported))) {
+      (KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
+                               KIM_SUPPORT_STATUS_notSupported) || 
+       (vflag_atom == 0))) {
     const double *const fp = &(atom->f[0][0]);
     for (int i = first; i < last; i++) {
       buf[m++] = fp[3*i+0];
@@ -648,22 +648,14 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
     return m;
   } 
   // ----------------------------------------------------------------------
-  //  for virial computation setup, see pair::ev_setup
-  //
-  //  vflag = 4 = per-atom virial only
-  //  vflag = 5 or 6 = both global and per-atom virial
-  //  vflag = 12 = both per-atom virial and per-atom centroid virial
-  //  vflag = 13 or 15 = global, per-atom virial and per-atom centroid virial
-  //
-  //  vflag_atom = vflag & 4;
-  //
-  //  per-atom virial -> vflag_atom == 4
+  // see Pair::ev_setup & Integrate::ev_set() 
+  // for values of eflag (0-3) and vflag (0-14)
   // -------------------------------------------------------------------------
   if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
-                                 KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom == 4) &&
+                                 KIM_SUPPORT_STATUS_notSupported) && 
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                 KIM_SUPPORT_STATUS_notSupported)) {
+                                 KIM_SUPPORT_STATUS_notSupported) &&
+      (vflag_atom != 0)) {
     const double *const fp = &(atom->f[0][0]);
     const double *const va = &(vatom[0][0]);
     for (int i = first; i < last; i++) {
@@ -682,9 +674,9 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
   } 
   if (KIM_SupportStatus_Equal(kim_model_support_for_forces,
                               KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom == 4) &&
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                 KIM_SUPPORT_STATUS_notSupported)) {
+                                 KIM_SUPPORT_STATUS_notSupported) &&
+      (vflag_atom != 0)) {
     const double *const va = &(vatom[0][0]);
     for (int i = first; i < last; i++) {
       buf[m++] = va[6*i+0];
@@ -706,9 +698,9 @@ void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
   int m = 0;
   if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
                                  KIM_SUPPORT_STATUS_notSupported) &&
-      ((vflag_atom == 0) ||
-       KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
-                               KIM_SUPPORT_STATUS_notSupported))) {
+      (KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
+                               KIM_SUPPORT_STATUS_notSupported) ||
+       (vflag_atom == 0))) {
     double *const fp = &(atom->f[0][0]);
     for (int i = 0; i < n; i++) {
       const int j = list[i];
@@ -720,9 +712,9 @@ void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
   }
   if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
                                  KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom == 4) &&
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                 KIM_SUPPORT_STATUS_notSupported)) {
+                                 KIM_SUPPORT_STATUS_notSupported) &&
+      (vflag_atom != 0)) {
     double *const fp = &(atom->f[0][0]);
     double *const va = &(vatom[0][0]);
     for (int i = 0; i < n; i++) {
@@ -742,9 +734,9 @@ void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
   } 
   if (KIM_SupportStatus_Equal(kim_model_support_for_forces,
                               KIM_SUPPORT_STATUS_notSupported) &&
-      (vflag_atom == 4) &&
       KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                 KIM_SUPPORT_STATUS_notSupported)) {
+                                 KIM_SUPPORT_STATUS_notSupported) &&
+      (vflag_atom != 0)) {
     double *const va=&(vatom[0][0]);
     for (int i = 0; i < n; i++) {
       const int j = list[i];

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -632,19 +632,15 @@ double PairKIM::init_one(int i, int j)
 
 int PairKIM::pack_reverse_comm(int n, int first, double *buf)
 {
-  int i,m,last;
-  double *fp;
-  fp = &(atom->f[0][0]);
-
-  m = 0;
-  last = first + n;
+  int m = 0;
+  int const last = first + n;
   if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
-                                 KIM_SUPPORT_STATUS_notSupported)
-      &&
+                                 KIM_SUPPORT_STATUS_notSupported) &&
       ((vflag_atom == 0) ||
        KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
                                KIM_SUPPORT_STATUS_notSupported))) {
-    for (i = first; i < last; i++) {
+    const double *const fp = &(atom->f[0][0]);
+    for (int i = first; i < last; i++) {
       buf[m++] = fp[3*i+0];
       buf[m++] = fp[3*i+1];
       buf[m++] = fp[3*i+2];
@@ -665,11 +661,12 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
   // -------------------------------------------------------------------------
   if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
                                  KIM_SUPPORT_STATUS_notSupported) &&
-             (vflag_atom == 4) &&
-             KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                        KIM_SUPPORT_STATUS_notSupported)) {
-    double *va=&(vatom[0][0]);
-    for (i = first; i < last; i++) {
+      (vflag_atom == 4) &&
+      KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
+                                 KIM_SUPPORT_STATUS_notSupported)) {
+    const double *const fp = &(atom->f[0][0]);
+    const double *const va = &(vatom[0][0]);
+    for (int i = first; i < last; i++) {
       buf[m++] = fp[3*i+0];
       buf[m++] = fp[3*i+1];
       buf[m++] = fp[3*i+2];
@@ -685,11 +682,11 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
   } 
   if (KIM_SupportStatus_Equal(kim_model_support_for_forces,
                               KIM_SUPPORT_STATUS_notSupported) &&
-             (vflag_atom == 4) &&
-             KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                        KIM_SUPPORT_STATUS_notSupported)) {
-    double *va=&(vatom[0][0]);
-    for (i = first; i < last; i++) {
+      (vflag_atom == 4) &&
+      KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
+                                 KIM_SUPPORT_STATUS_notSupported)) {
+    const double *const va = &(vatom[0][0]);
+    for (int i = first; i < last; i++) {
       buf[m++] = va[6*i+0];
       buf[m++] = va[6*i+1];
       buf[m++] = va[6*i+2];
@@ -706,32 +703,30 @@ int PairKIM::pack_reverse_comm(int n, int first, double *buf)
 
 void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
 {
-  int i,j,m;
-  double *fp;
-  fp = &(atom->f[0][0]);
-
-  m = 0;
+  int m = 0;
   if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
-                                 KIM_SUPPORT_STATUS_notSupported)
-      &&
+                                 KIM_SUPPORT_STATUS_notSupported) &&
       ((vflag_atom == 0) ||
        KIM_SupportStatus_Equal(kim_model_support_for_particleVirial,
                                KIM_SUPPORT_STATUS_notSupported))) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
+    double *const fp = &(atom->f[0][0]);
+    for (int i = 0; i < n; i++) {
+      const int j = list[i];
       fp[3*j+0]+= buf[m++];
       fp[3*j+1]+= buf[m++];
       fp[3*j+2]+= buf[m++];
     }
-  } else if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
-                                        KIM_SUPPORT_STATUS_notSupported)
-             &&
-             (vflag_atom == 4) &&
-             KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                        KIM_SUPPORT_STATUS_notSupported)) {
-    double *va=&(vatom[0][0]);
-    for (i = 0; i < n; i++) {
-      j = list[i];
+    return;
+  }
+  if (KIM_SupportStatus_NotEqual(kim_model_support_for_forces,
+                                 KIM_SUPPORT_STATUS_notSupported) &&
+      (vflag_atom == 4) &&
+      KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
+                                 KIM_SUPPORT_STATUS_notSupported)) {
+    double *const fp = &(atom->f[0][0]);
+    double *const va = &(vatom[0][0]);
+    for (int i = 0; i < n; i++) {
+      const int j = list[i];
       fp[3*j+0]+= buf[m++];
       fp[3*j+1]+= buf[m++];
       fp[3*j+2]+= buf[m++];
@@ -743,15 +738,16 @@ void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
       va[j*6+4]+=buf[m++];
       va[j*6+5]+=buf[m++];
     }
-  } else if (KIM_SupportStatus_Equal(kim_model_support_for_forces,
-                                     KIM_SUPPORT_STATUS_notSupported)
-             &&
-             (vflag_atom == 4) &&
-             KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
-                                        KIM_SUPPORT_STATUS_notSupported)) {
-    double *va=&(vatom[0][0]);
-    for (i = 0; i < n; i++) {
-      j = list[i];
+    return;
+  } 
+  if (KIM_SupportStatus_Equal(kim_model_support_for_forces,
+                              KIM_SUPPORT_STATUS_notSupported) &&
+      (vflag_atom == 4) &&
+      KIM_SupportStatus_NotEqual(kim_model_support_for_particleVirial,
+                                 KIM_SUPPORT_STATUS_notSupported)) {
+    double *const va=&(vatom[0][0]);
+    for (int i = 0; i < n; i++) {
+      const int j = list[i];
       va[j*6+0]+=buf[m++];
       va[j*6+1]+=buf[m++];
       va[j*6+2]+=buf[m++];
@@ -759,9 +755,8 @@ void PairKIM::unpack_reverse_comm(int n, int *list, double *buf)
       va[j*6+4]+=buf[m++];
       va[j*6+5]+=buf[m++];
     }
-  } else {
-    ; // do nothing
   }
+  // do nothing
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

This PR includes:
- Bugfix in pair_kim.
- Clean up the code and remove the unnecessary else condition and improve the readability
- Following the latest LAMMPS update #2481, the check is updated as `vflag_atom` for zero vs. non-zero.

This bug results in the wrong computation of stress/atom in LAMMPS when using pair style Kim.
This is created after the PR #1704 , where the `vflag_atom` is updated from `vflag_atom = vflag / 4;` to `vflag_atom = vflag & 4;`. It results in passing the wrong pointer to the KIM-API.

**Author(s)**

Yaser Afshar @yafshar (UMN)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This PR is fully backward compatible.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


