### PR TITLE
Add CMake code to download and compile a suitable version of libyaml in case it is not found locally

### DIFF
--- a/cmake/Modules/YAML.cmake
+++ b/cmake/Modules/YAML.cmake
@@ -5,7 +5,7 @@ set(YAML_URL "https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz" CACHE STRIN
 mark_as_advanced(YAML_URL)
 ExternalProject_Add(libyaml
                     URL               ${YAML_URL}
-                    URL_MD5           bb15429d8fb787e7d3f1c83ae129a999  
+                    URL_MD5           bb15429d8fb787e7d3f1c83ae129a999
                     SOURCE_DIR        "${CMAKE_BINARY_DIR}/yaml-src"
                     BINARY_DIR        "${CMAKE_BINARY_DIR}/yaml-build"
                     CONFIGURE_COMMAND <SOURCE_DIR>/configure ${CONFIGURE_REQUEST_PIC}

--- a/cmake/Modules/YAML.cmake
+++ b/cmake/Modules/YAML.cmake
@@ -1,0 +1,32 @@
+message(STATUS "Downloading and building YAML library")
+
+include(ExternalProject)
+set(YAML_URL "https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz" CACHE STRING "URL for libyaml tarball")
+mark_as_advanced(YAML_URL)
+ExternalProject_Add(libyaml
+                    URL               ${YAML_URL}
+                    URL_MD5           bb15429d8fb787e7d3f1c83ae129a999  
+                    SOURCE_DIR        "${CMAKE_BINARY_DIR}/yaml-src"
+                    BINARY_DIR        "${CMAKE_BINARY_DIR}/yaml-build"
+                    CONFIGURE_COMMAND <SOURCE_DIR>/configure ${CONFIGURE_REQUEST_PIC}
+                                      CXX=${CMAKE_CXX_COMPILER}
+                                      CC=${CMAKE_C_COMPILER}
+                                      --prefix=<INSTALL_DIR> --disable-shared
+                    BUILD_BYPRODUCTS  <INSTALL_DIR>/lib/${CMAKE_FIND_LIBRARY_PREFIXES}yaml.a
+                    TEST_COMMAND      "")
+
+ExternalProject_Get_Property(libyaml INSTALL_DIR)
+set(YAML_INCLUDE_DIR ${INSTALL_DIR}/include)
+set(YAML_LIBRARY_DIR ${INSTALL_DIR}/lib)
+
+# workaround for CMake 3.10 on ubuntu 18.04
+file(MAKE_DIRECTORY ${YAML_INCLUDE_DIR})
+file(MAKE_DIRECTORY ${YAML_LIBRARY_DIR})
+
+set(YAML_LIBRARY_PATH ${INSTALL_DIR}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}yaml.a)
+
+add_library(Yaml::Yaml UNKNOWN IMPORTED)
+set_target_properties(Yaml::Yaml PROPERTIES
+        IMPORTED_LOCATION ${YAML_LIBRARY_PATH}
+        INTERFACE_INCLUDE_DIRECTORIES ${YAML_INCLUDE_DIR})
+add_dependencies(Yaml::Yaml libyaml)

--- a/doc/src/Build_development.rst
+++ b/doc/src/Build_development.rst
@@ -111,8 +111,10 @@ error margin).  The status of this automated testing can be viewed on
 The unit testing facility is integrated into the CMake build process
 of the LAMMPS source code distribution itself.  It can be enabled by
 setting ``-D ENABLE_TESTING=on`` during the CMake configuration step.
-It requires the `PyYAML <http://pyyaml.org/>`_ library and development
-headers to compile and will download and compile a recent version of the
+It requires the `YAML <http://pyyaml.org/>`_ library and development
+headers (if not found locally a recent version will be downloaded
+and compiled transparently) to compile and will download and compile
+a specific recent version of the
 `Googletest <https://github.com/google/googletest/>`_ C++ test framework
 for implementing the tests.
 

--- a/unittest/force-styles/CMakeLists.txt
+++ b/unittest/force-styles/CMakeLists.txt
@@ -1,8 +1,8 @@
 
 find_package(YAML)
 if(NOT YAML_FOUND)
-  message(STATUS "Skipping tests because libyaml is not found")
-  return()
+  # download and build a local copy of libyaml
+  include(YAML)
 endif()
 
 if(CMAKE_VERSION VERSION_LESS 3.12)


### PR DESCRIPTION
**Summary**

This allows to run build and the force-style tests even if no libyaml development package is installed.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

This liberally borrows from other existing CMake code to download and build external libraries. Since is a bit of a hybrid of several .cmake files and "works for me(tm)". There is probably room for improvement, but that is beyond my level of experience in CMake scripting.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the CMake based build system
