### PR TITLE
Introduce enums for energy and virial flags

### DIFF
--- a/doc/src/compute_stress_atom.rst
+++ b/doc/src/compute_stress_atom.rst
@@ -33,32 +33,31 @@ Examples
 Description
 """""""""""
 
-Define a computation that computes per-atom stress
-tensor for each atom in a group.  In case of compute *stress/atom*,
-the tensor for each atom is symmetric with 6
-components and is stored as a 6-element vector in the following order:
-:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
-In case of compute *centroid/stress/atom*,
-the tensor for each atom is asymmetric with 9 components
-and is stored as a 9-element vector in the following order:
-:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`,
-:math:`yx`, :math:`zx`, :math:`zy`.
-See the :doc:`compute pressure <compute_pressure>` command if you want the stress tensor
+Define a computation that computes per-atom stress tensor for each
+atom in a group.  In case of compute *stress/atom*, the tensor for
+each atom is symmetric with 6 components and is stored as a 6-element
+vector in the following order: :math:`xx`, :math:`yy`, :math:`zz`,
+:math:`xy`, :math:`xz`, :math:`yz`.  In case of compute
+*centroid/stress/atom*, the tensor for each atom is asymmetric with 9
+components and is stored as a 9-element vector in the following order:
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`, :math:`yx`, :math:`zx`, :math:`zy`.  See the :doc:`compute
+pressure <compute_pressure>` command if you want the stress tensor
 (pressure) of the entire system.
 
-The stress tensor for atom :math:`I` is given by the following formula,
-where :math:`a` and :math:`b` take on values :math:`x`, :math:`y`, :math:`z`
-to generate the components of the tensor:
+The stress tensor for atom :math:`I` is given by the following
+formula, where :math:`a` and :math:`b` take on values :math:`x`,
+:math:`y`, :math:`z` to generate the components of the tensor:
 
 .. math::
 
    S_{ab}  =  - m v_a v_b - W_{ab}
 
-The first term is a kinetic energy contribution for atom :math:`I`.  See
-details below on how the specified *temp-ID* can affect the velocities
-used in this calculation. The second term is the virial
-contribution due to intra and intermolecular interactions,
-where the exact computation details are determined by the compute style.
+The first term is a kinetic energy contribution for atom :math:`I`.
+See details below on how the specified *temp-ID* can affect the
+velocities used in this calculation. The second term is the virial
+contribution due to intra and intermolecular interactions, where the
+exact computation details are determined by the compute style.
 
 In case of compute *stress/atom*, the virial contribution is:
 
@@ -68,29 +67,26 @@ In case of compute *stress/atom*, the virial contribution is:
   & + \frac{1}{3} \sum_{n = 1}^{N_a} (r_{1_a} F_{1_b} + r_{2_a} F_{2_b} + r_{3_a} F_{3_b}) + \frac{1}{4} \sum_{n = 1}^{N_d} (r_{1_a} F_{1_b} + r_{2_a} F_{2_b} + r_{3_a} F_{3_b} + r_{4_a} F_{4_b}) \\
   & + \frac{1}{4} \sum_{n = 1}^{N_i} (r_{1_a} F_{1_b} + r_{2_a} F_{2_b} + r_{3_a} F_{3_b} + r_{4_a} F_{4_b}) + {\rm Kspace}(r_{i_a},F_{i_b}) + \sum_{n = 1}^{N_f} r_{i_a} F_{i_b}
 
-The first term is a pairwise energy
-contribution where :math:`n` loops over the :math:`N_p`
-neighbors of atom :math:`I`, :math:`\mathbf{r}_1` and :math:`\mathbf{r}_2`
-are the positions of the 2 atoms in the pairwise interaction,
-and :math:`\mathbf{F}_1` and :math:`\mathbf{F}_2` are the forces
-on the 2 atoms resulting from the pairwise interaction.
-The second term is a bond contribution of
-similar form for the :math:`N_b` bonds which atom :math:`I` is part of.
-There are similar terms for the :math:`N_a` angle, :math:`N_d` dihedral,
-and :math:`N_i` improper interactions atom :math:`I` is part of.
-There is also a term for the KSpace
-contribution from long-range Coulombic interactions, if defined.
-Finally, there is a term for the :math:`N_f` :doc:`fixes <fix>` that apply
-internal constraint forces to atom :math:`I`. Currently, only the
-:doc:`fix shake <fix_shake>` and :doc:`fix rigid <fix_rigid>` commands
-contribute to this term.
-As the coefficients in the formula imply, a virial contribution
-produced by a small set of atoms (e.g. 4 atoms in a dihedral or 3
-atoms in a Tersoff 3-body interaction) is assigned in equal portions
-to each atom in the set.  E.g. 1/4 of the dihedral virial to each of
-the 4 atoms, or 1/3 of the fix virial due to SHAKE constraints applied
-to atoms in a water molecule via the :doc:`fix shake <fix_shake>`
-command.
+The first term is a pairwise energy contribution where :math:`n` loops
+over the :math:`N_p` neighbors of atom :math:`I`, :math:`\mathbf{r}_1`
+and :math:`\mathbf{r}_2` are the positions of the 2 atoms in the
+pairwise interaction, and :math:`\mathbf{F}_1` and
+:math:`\mathbf{F}_2` are the forces on the 2 atoms resulting from the
+pairwise interaction.  The second term is a bond contribution of
+similar form for the :math:`N_b` bonds which atom :math:`I` is part
+of.  There are similar terms for the :math:`N_a` angle, :math:`N_d`
+dihedral, and :math:`N_i` improper interactions atom :math:`I` is part
+of.  There is also a term for the KSpace contribution from long-range
+Coulombic interactions, if defined.  Finally, there is a term for the
+:math:`N_f` :doc:`fixes <fix>` that apply internal constraint forces
+to atom :math:`I`. Currently, only the :doc:`fix shake <fix_shake>`
+and :doc:`fix rigid <fix_rigid>` commands contribute to this term.  As
+the coefficients in the formula imply, a virial contribution produced
+by a small set of atoms (e.g. 4 atoms in a dihedral or 3 atoms in a
+Tersoff 3-body interaction) is assigned in equal portions to each atom
+in the set.  E.g. 1/4 of the dihedral virial to each of the 4 atoms,
+or 1/3 of the fix virial due to SHAKE constraints applied to atoms in
+a water molecule via the :doc:`fix shake <fix_shake>` command.
 
 In case of compute *centroid/stress/atom*, the virial contribution is:
 
@@ -99,71 +95,69 @@ In case of compute *centroid/stress/atom*, the virial contribution is:
    W_{ab} & = \sum_{n = 1}^{N_p} r_{I0_a} F_{I_b} + \sum_{n = 1}^{N_b} r_{I0_a} F_{I_b} + \sum_{n = 1}^{N_a} r_{I0_a}  F_{I_b} + \sum_{n = 1}^{N_d} r_{I0_a} F_{I_b} + \sum_{n = 1}^{N_i} r_{I0_a} F_{I_b} \\
   & + {\rm Kspace}(r_{i_a},F_{i_b}) + \sum_{n = 1}^{N_f} r_{i_a} F_{i_b}
 
-As with compute *stress/atom*, the first, second, third, fourth and fifth terms
-are pairwise, bond, angle, dihedral and improper contributions,
-but instead of assigning the virial contribution equally to each atom,
-only the force :math:`\mathbf{F}_I` acting on atom :math:`I`
-due to the interaction and the relative
-position :math:`\mathbf{r}_{I0}` of the atom :math:`I` to the geometric center
-of the interacting atoms, i.e. centroid, is used.
-As the geometric center is different
-for each interaction, the :math:`\mathbf{r}_{I0}` also differs.
-The sixth and seventh terms, Kspace and :doc:`fix <fix>` contribution
-respectively, are computed identical to compute *stress/atom*.
-Although the total system virial is the same as compute *stress/atom*,
-compute *centroid/stress/atom* is know to result in more consistent
-heat flux values for angle, dihedrals and improper contributions
-when computed via :doc:`compute heat/flux <compute_heat_flux>`.
+As with compute *stress/atom*, the first, second, third, fourth and
+fifth terms are pairwise, bond, angle, dihedral and improper
+contributions, but instead of assigning the virial contribution
+equally to each atom, only the force :math:`\mathbf{F}_I` acting on
+atom :math:`I` due to the interaction and the relative position
+:math:`\mathbf{r}_{I0}` of the atom :math:`I` to the geometric center
+of the interacting atoms, i.e. centroid, is used.  As the geometric
+center is different for each interaction, the :math:`\mathbf{r}_{I0}`
+also differs.  The sixth and seventh terms, Kspace and :doc:`fix
+<fix>` contribution respectively, are computed identical to compute
+*stress/atom*.  Although the total system virial is the same as
+compute *stress/atom*, compute *centroid/stress/atom* is know to
+result in more consistent heat flux values for angle, dihedrals and
+improper contributions when computed via :doc:`compute heat/flux
+<compute_heat_flux>`.
 
-If no extra keywords are listed, the kinetic contribution
-all of the virial contribution terms are
-included in the per-atom stress tensor.  If any extra keywords are
-listed, only those terms are summed to compute the tensor.  The
-*virial* keyword means include all terms except the kinetic energy
-*ke*\ .
+If no extra keywords are listed, the kinetic contribution all of the
+virial contribution terms are included in the per-atom stress tensor.
+If any extra keywords are listed, only those terms are summed to
+compute the tensor.  The *virial* keyword means include all terms
+except the kinetic energy *ke*\ .
 
 Note that the stress for each atom is due to its interaction with all
 other atoms in the simulation, not just with other atoms in the group.
 
-Details of how compute *stress/atom* obtains the virial for individual atoms for
-either pairwise or many-body potentials, and including the effects of
-periodic boundary conditions is discussed in :ref:`(Thompson) <Thompson2>`.
-The basic idea for many-body potentials is to treat each component of
-the force computation between a small cluster of atoms in the same
-manner as in the formula above for bond, angle, dihedral, etc
-interactions.  Namely the quantity :math:`\mathbf{r} \cdot \mathbf{F}`
-is summed over the atoms in
-the interaction, with the :math:`r` vectors unwrapped by periodic boundaries
-so that the cluster of atoms is close together.  The total
+Details of how compute *stress/atom* obtains the virial for individual
+atoms for either pairwise or many-body potentials, and including the
+effects of periodic boundary conditions is discussed in
+:ref:`(Thompson) <Thompson2>`.  The basic idea for many-body
+potentials is to treat each component of the force computation between
+a small cluster of atoms in the same manner as in the formula above
+for bond, angle, dihedral, etc interactions.  Namely the quantity
+:math:`\mathbf{r} \cdot \mathbf{F}` is summed over the atoms in the
+interaction, with the :math:`r` vectors unwrapped by periodic
+boundaries so that the cluster of atoms is close together.  The total
 contribution for the cluster interaction is divided evenly among those
-atoms. Details of how compute *centroid/stress/atom* obtains
-the virial for individual atoms
-is given in :ref:`(Surblys) <Surblys1>`,
-where the idea is that the virial of the atom :math:`I`
-is the result of only the force :math:`\mathbf{F}_I` on the atom due
-to the interaction
-and its positional vector :math:`\mathbf{r}_{I0}`,
-relative to the geometric center of the
-interacting atoms, regardless of the number of participating atoms.
-The periodic boundary treatment is identical to
+atoms.
+
+Details of how compute *centroid/stress/atom* obtains the virial for
+individual atoms is given in :ref:`(Surblys) <Surblys1>`, where the
+idea is that the virial of the atom :math:`I` is the result of only
+the force :math:`\mathbf{F}_I` on the atom due to the interaction and
+its positional vector :math:`\mathbf{r}_{I0}`, relative to the
+geometric center of the interacting atoms, regardless of the number of
+participating atoms.  The periodic boundary treatment is identical to
 that of compute *stress/atom*, and both of them reduce to identical
-expressions for two-body interactions,
-i.e. computed values for contributions from bonds and two-body pair styles,
-such as :doc:`Lennard-Jones <pair_lj>`, will be the same,
-while contributions from angles, dihedrals and impropers will be different.
+expressions for two-body interactions, i.e. computed values for
+contributions from bonds and two-body pair styles, such as
+:doc:`Lennard-Jones <pair_lj>`, will be the same, while contributions
+from angles, dihedrals and impropers will be different.
 
 The :doc:`dihedral_style charmm <dihedral_charmm>` style calculates
 pairwise interactions between 1-4 atoms.  The virial contribution of
 these terms is included in the pair virial, not the dihedral virial.
 
 The KSpace contribution is calculated using the method in
-:ref:`(Heyes) <Heyes2>` for the Ewald method and by the methodology described
-in :ref:`(Sirk) <Sirk1>` for PPPM.  The choice of KSpace solver is specified
-by the :doc:`kspace_style pppm <kspace_style>` command.  Note that for
-PPPM, the calculation requires 6 extra FFTs each timestep that
-per-atom stress is calculated.  Thus it can significantly increase the
-cost of the PPPM calculation if it is needed on a large fraction of
-the simulation timesteps.
+:ref:`(Heyes) <Heyes2>` for the Ewald method and by the methodology
+described in :ref:`(Sirk) <Sirk1>` for PPPM.  The choice of KSpace
+solver is specified by the :doc:`kspace_style pppm <kspace_style>`
+command.  Note that for PPPM, the calculation requires 6 extra FFTs
+each timestep that per-atom stress is calculated.  Thus it can
+significantly increase the cost of the PPPM calculation if it is
+needed on a large fraction of the simulation timesteps.
 
 The *temp-ID* argument can be used to affect the per-atom velocities
 used in the kinetic energy contribution to the total stress.  If the
@@ -189,10 +183,10 @@ See the :doc:`compute voronoi/atom <compute_voronoi_atom>` command for
 one possible way to estimate a per-atom volume.
 
 Thus, if the diagonal components of the per-atom stress tensor are
-summed for all atoms in the system and the sum is divided by :math:`dV`, where
-:math:`d` = dimension and :math:`V` is the volume of the system,
-the result should be :math:`-P`, where :math:`P`
-is the total pressure of the system.
+summed for all atoms in the system and the sum is divided by
+:math:`dV`, where :math:`d` = dimension and :math:`V` is the volume of
+the system, the result should be :math:`-P`, where :math:`P` is the
+total pressure of the system.
 
 These lines in an input script for a 3d system should yield that
 result. I.e. the last 2 columns of thermo output will be the same:
@@ -207,33 +201,43 @@ result. I.e. the last 2 columns of thermo output will be the same:
 .. note::
 
    The per-atom stress does not include any Lennard-Jones tail
-   corrections to the pressure added by the :doc:`pair_modify tail yes <pair_modify>` command, since those are contributions to the
-   global system pressure.
+   corrections to the pressure added by the :doc:`pair_modify tail yes
+   <pair_modify>` command, since those are contributions to the global
+   system pressure.
 
 Output info
 """""""""""
 
-This compute *stress/atom* calculates a per-atom array with 6 columns, which can be
-accessed by indices 1-6 by any command that uses per-atom values from
-a compute as input.
-The compute *centroid/stress/atom* produces a per-atom array with 9 columns,
-but otherwise can be used in an identical manner to compute *stress/atom*.
-See the :doc:`Howto output <Howto_output>` doc page
-for an overview of LAMMPS output options.
+Compute *stress/atom* calculates a per-atom array with 6 columns,
+which can be accessed by indices 1-6 by any command that uses per-atom
+values from a compute as input.  Compute *centroid/stress/atom*
+produces a per-atom array with 9 columns, but otherwise can be used in
+an identical manner to compute *stress/atom*.  See the :doc:`Howto
+output <Howto_output>` doc page for an overview of LAMMPS output
+options.
 
-The per-atom array values will be in pressure\*volume
-:doc:`units <units>` as discussed above.
+The per-atom array values will be in pressure\*volume :doc:`units
+<units>` as discussed above.
 
 Restrictions
 """"""""""""
 
-Currently (Spring 2020), compute *centroid/stress/atom* does not support
-pair styles with many-body interactions, such as :doc:`Tersoff
-<pair_tersoff>`, or pair styles with long-range Coulomb interactions.
-LAMMPS will generate an error in such cases.  In principal, equivalent
-formulation to that of angle, dihedral and improper contributions in the
-virial :math:`W_{ab}` formula can also be applied to the many-body pair
-styles, and is planned in the future.
+Currently, compute *centroid/stress/atom* does not support pair styles
+with many-body interactions (:doc:`EAM <pair_eam>` is an exception,
+since its computations are performed pairwise), nor granular pair
+styles with pairwise forces which are not aligned with the vector
+between the pair of particles.  All bond styles are supported.  All
+angle, dihedral, improper styles are supported with the exception of
+USER-INTEL and KOKKOS variants of specific styles.  It also does not
+support models with long-range Coulombic or dispersion forces,
+i.e. the kspace_style command in LAMMPS.  It also does not support the
+following fixes which add rigid-body constraints: :doc:`fix shake
+<fix_shake>`, :doc:`fix rattle <fix_rattle>`, :doc:`fix rigid
+<fix_rigid>`, :doc:`fix rigid/small <fix_rigid>`.
+
+LAMMPS will generate an error if one of these options is included in
+your model.  Extension of centroid stress calculations to these force
+and fix styles is planned for the futre.
 
 Related commands
 """"""""""""""""

--- a/src/CLASS2/pair_lj_class2.cpp
+++ b/src/CLASS2/pair_lj_class2.cpp
@@ -35,7 +35,7 @@ PairLJClass2::PairLJClass2(LAMMPS *lmp) : Pair(lmp)
 {
   respa_enable = 1;
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/CLASS2/pair_lj_class2_coul_cut.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_cut.cpp
@@ -33,7 +33,7 @@ using namespace MathConst;
 PairLJClass2CoulCut::PairLJClass2CoulCut(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -34,7 +34,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
@@ -43,6 +42,7 @@ PairGranHookeHistory::PairGranHookeHistory(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 1;
   no_virial_fdotr_compute = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   history = 1;
   size_history = 3;
 

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -66,6 +66,7 @@ PairGranular::PairGranular(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 1;
   no_virial_fdotr_compute = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   single_extra = 12;
   svector = new double[single_extra];

--- a/src/KOKKOS/angle_charmm_kokkos.cpp
+++ b/src/KOKKOS/angle_charmm_kokkos.cpp
@@ -42,6 +42,8 @@ AngleCharmmKokkos<DeviceType>::AngleCharmmKokkos(LAMMPS *lmp) : AngleCharmm(lmp)
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
   datamask_read = X_MASK | F_MASK | ENERGY_MASK | VIRIAL_MASK;
   datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/angle_class2_kokkos.cpp
+++ b/src/KOKKOS/angle_class2_kokkos.cpp
@@ -42,6 +42,8 @@ AngleClass2Kokkos<DeviceType>::AngleClass2Kokkos(LAMMPS *lmp) : AngleClass2(lmp)
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
   datamask_read = X_MASK | F_MASK | ENERGY_MASK | VIRIAL_MASK;
   datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/angle_cosine_kokkos.cpp
+++ b/src/KOKKOS/angle_cosine_kokkos.cpp
@@ -42,6 +42,8 @@ AngleCosineKokkos<DeviceType>::AngleCosineKokkos(LAMMPS *lmp) : AngleCosine(lmp)
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
   datamask_read = X_MASK | F_MASK | ENERGY_MASK | VIRIAL_MASK;
   datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/angle_harmonic_kokkos.cpp
+++ b/src/KOKKOS/angle_harmonic_kokkos.cpp
@@ -42,6 +42,8 @@ AngleHarmonicKokkos<DeviceType>::AngleHarmonicKokkos(LAMMPS *lmp) : AngleHarmoni
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
   datamask_read = X_MASK | F_MASK | ENERGY_MASK | VIRIAL_MASK;
   datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/dihedral_charmm_kokkos.cpp
+++ b/src/KOKKOS/dihedral_charmm_kokkos.cpp
@@ -76,7 +76,7 @@ void DihedralCharmmKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 
-  if (weightflag && vflag_global == 2)
+  if (weightflag && vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   // reallocate per-atom arrays if necessary

--- a/src/KOKKOS/dihedral_charmm_kokkos.cpp
+++ b/src/KOKKOS/dihedral_charmm_kokkos.cpp
@@ -48,6 +48,8 @@ DihedralCharmmKokkos<DeviceType>::DihedralCharmmKokkos(LAMMPS *lmp) : DihedralCh
   k_warning_flag = Kokkos::DualView<int,DeviceType>("Dihedral:warning_flag");
   d_warning_flag = k_warning_flag.template view<DeviceType>();
   h_warning_flag = k_warning_flag.h_view;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -47,6 +47,8 @@ DihedralClass2Kokkos<DeviceType>::DihedralClass2Kokkos(LAMMPS *lmp) : DihedralCl
   k_warning_flag = DAT::tdual_int_scalar("Dihedral:warning_flag");
   d_warning_flag = k_warning_flag.view<DeviceType>();
   h_warning_flag = k_warning_flag.h_view;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/dihedral_harmonic_kokkos.cpp
+++ b/src/KOKKOS/dihedral_harmonic_kokkos.cpp
@@ -47,6 +47,8 @@ DihedralHarmonicKokkos<DeviceType>::DihedralHarmonicKokkos(LAMMPS *lmp) : Dihedr
   k_warning_flag = DAT::tdual_int_scalar("Dihedral:warning_flag");
   d_warning_flag = k_warning_flag.view<DeviceType>();
   h_warning_flag = k_warning_flag.h_view;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/dihedral_opls_kokkos.cpp
+++ b/src/KOKKOS/dihedral_opls_kokkos.cpp
@@ -47,6 +47,8 @@ DihedralOPLSKokkos<DeviceType>::DihedralOPLSKokkos(LAMMPS *lmp) : DihedralOPLS(l
   k_warning_flag = DAT::tdual_int_scalar("Dihedral:warning_flag");
   d_warning_flag = k_warning_flag.view<DeviceType>();
   h_warning_flag = k_warning_flag.h_view;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/improper_class2_kokkos.cpp
+++ b/src/KOKKOS/improper_class2_kokkos.cpp
@@ -43,6 +43,8 @@ ImproperClass2Kokkos<DeviceType>::ImproperClass2Kokkos(LAMMPS *lmp) : ImproperCl
   k_warning_flag = DAT::tdual_int_scalar("Dihedral:warning_flag");
   d_warning_flag = k_warning_flag.view<DeviceType>();
   h_warning_flag = k_warning_flag.h_view;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/improper_harmonic_kokkos.cpp
+++ b/src/KOKKOS/improper_harmonic_kokkos.cpp
@@ -44,6 +44,8 @@ ImproperHarmonicKokkos<DeviceType>::ImproperHarmonicKokkos(LAMMPS *lmp) : Improp
   k_warning_flag = Kokkos::DualView<int,DeviceType>("Dihedral:warning_flag");
   d_warning_flag = k_warning_flag.template view<DeviceType>();
   h_warning_flag = k_warning_flag.h_view;
+
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/pair_hybrid_kokkos.cpp
+++ b/src/KOKKOS/pair_hybrid_kokkos.cpp
@@ -64,23 +64,23 @@ void PairHybridKokkos::compute(int eflag, int vflag)
   int i,j,m,n;
 
   // if no_virial_fdotr_compute is set and global component of
-  //   incoming vflag = 2, then
-  // reset vflag as if global component were 1
+  //   incoming vflag = VIRIAL_FDOTR, then
+  // reset vflag as if global component were VIRIAL_PAIR
   // necessary since one or more sub-styles cannot compute virial as F dot r
 
   int neighflag = lmp->kokkos->neighflag;
   if (neighflag == FULL) no_virial_fdotr_compute = 1;
 
-  if (no_virial_fdotr_compute && vflag % 4 == 2) vflag = 1 + vflag/4 * 4;
+  if (no_virial_fdotr_compute && vflag & VIRIAL_FDOTR) vflag = VIRIAL_PAIR | (vflag & ~VIRIAL_FDOTR);
 
   ev_init(eflag,vflag);
 
-  // check if global component of incoming vflag = 2
-  // if so, reset vflag passed to substyle as if it were 0
+  // check if global component of incoming vflag = VIRIAL_FDOTR
+  // if so, reset vflag passed to substyle as if it were VIRIAL_NONE
   // necessary so substyle will not invoke virial_fdotr_compute()
 
   int vflag_substyle;
-  if (vflag % 4 == 2) vflag_substyle = vflag/4 * 4;
+  if (vflag & VIRIAL_FDOTR) vflag_substyle = VIRIAL_NONE | (vflag & ~VIRIAL_FDOTR);
   else vflag_substyle = vflag;
 
   double *saved_special = save_special();

--- a/src/KOKKOS/pair_reaxc_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxc_kokkos.cpp
@@ -3629,7 +3629,7 @@ void PairReaxCKokkos<DeviceType>::v_tally3_atom(EV_FLOAT_REAX &ev, const int &i,
 
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
-   see integrate::ev_set() for values of eflag (0-3) and vflag (0-6)
+   see integrate::ev_set() for values of eflag and vflag
 ------------------------------------------------------------------------- */
 
 template<class DeviceType>
@@ -3645,7 +3645,7 @@ void PairReaxCKokkos<DeviceType>::ev_setup(int eflag, int vflag, int)
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
-  vflag_atom = vflag / 4; // TODO
+  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
 
   // reallocate per-atom arrays if necessary
 
@@ -3673,11 +3673,11 @@ void PairReaxCKokkos<DeviceType>::ev_setup(int eflag, int vflag, int)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, PairReaxZeroVAtom>(0,maxvatom),*this);
   }
 
-  // if vflag_global = 2 and pair::compute() calls virial_fdotr_compute()
+  // if vflag_global = VIRIAL_FDOTR and pair::compute() calls virial_fdotr_compute()
   // compute global virial via (F dot r) instead of via pairwise summation
   // unset other flags as appropriate
 
-  if (vflag_global == 2 && no_virial_fdotr_compute == 0) {
+  if (vflag_global == VIRIAL_FDOTR && no_virial_fdotr_compute == 0) {
     vflag_fdotr = 1;
     vflag_global = 0;
     if (vflag_atom == 0) vflag_either = 0;

--- a/src/KOKKOS/pair_reaxc_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxc_kokkos.cpp
@@ -3640,12 +3640,12 @@ void PairReaxCKokkos<DeviceType>::ev_setup(int eflag, int vflag, int)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_ATOM;
 
   vflag_either = vflag;
-  vflag_global = vflag % 4;
-  vflag_atom = vflag / 4;
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag / 4; // TODO
 
   // reallocate per-atom arrays if necessary
 

--- a/src/KOKKOS/pair_reaxc_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxc_kokkos.cpp
@@ -3630,6 +3630,8 @@ void PairReaxCKokkos<DeviceType>::v_tally3_atom(EV_FLOAT_REAX &ev, const int &i,
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
    see integrate::ev_set() for values of eflag and vflag
+   see pair::ev_setup() for values of eflag_* and vflag_*
+   VIRIAL_CENTROID bitflag is not yet supported by ReaxFF
 ------------------------------------------------------------------------- */
 
 template<class DeviceType>
@@ -3645,7 +3647,7 @@ void PairReaxCKokkos<DeviceType>::ev_setup(int eflag, int vflag, int)
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
-  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
+  vflag_atom = vflag & VIRIAL_ATOM;
 
   // reallocate per-atom arrays if necessary
 

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -69,6 +69,7 @@ PairADP::PairADP(LAMMPS *lmp) : Pair(lmp)
   single_enable = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -69,6 +69,7 @@ PairAIREBO::PairAIREBO(LAMMPS *lmp)
   nC = nH = nullptr;
   map = nullptr;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   sigwid = 0.84;
   sigcut = 3.0;

--- a/src/MANYBODY/pair_atm.cpp
+++ b/src/MANYBODY/pair_atm.cpp
@@ -52,6 +52,7 @@ PairATM::PairATM(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 1;
   one_coeff = 0;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MANYBODY/pair_bop.cpp
+++ b/src/MANYBODY/pair_bop.cpp
@@ -61,6 +61,7 @@ PairBOP::PairBOP(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   ghostneigh = 1;
   allocated = 0;
 

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -53,6 +53,7 @@ PairComb::PairComb(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   nmax = 0;
   NCo = nullptr;

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -51,6 +51,8 @@ PairComb3::PairComb3(LAMMPS *lmp) : Pair(lmp)
   single_enable = 0;
   restartinfo = 0;
   one_coeff = 1;
+  manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   ghostneigh = 1;
 
   nmax = 0;

--- a/src/MANYBODY/pair_eim.cpp
+++ b/src/MANYBODY/pair_eim.cpp
@@ -39,6 +39,7 @@ PairEIM::PairEIM(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   unit_convert_flag = utils::get_supported_conversions(utils::ENERGY);
 
   setfl = nullptr;

--- a/src/MANYBODY/pair_gw.cpp
+++ b/src/MANYBODY/pair_gw.cpp
@@ -48,6 +48,7 @@ PairGW::PairGW(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   unit_convert_flag = utils::get_supported_conversions(utils::ENERGY);
 
   nelements = 0;

--- a/src/MANYBODY/pair_lcbop.cpp
+++ b/src/MANYBODY/pair_lcbop.cpp
@@ -45,6 +45,7 @@ PairLCBOP::PairLCBOP(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   ghostneigh = 1;
 
   maxlocal = 0;

--- a/src/MANYBODY/pair_nb3b_harmonic.cpp
+++ b/src/MANYBODY/pair_nb3b_harmonic.cpp
@@ -46,7 +46,8 @@ PairNb3bHarmonic::PairNb3bHarmonic(LAMMPS *lmp) : Pair(lmp)
   single_enable = 0;
   restartinfo = 0;
   one_coeff = 1;
-  manybody_flag = 1;
+  manybody_flag = 1; 
+  centroidstressflag = CENTROID_NOTAVAIL;
   unit_convert_flag = utils::get_supported_conversions(utils::ENERGY);
 
   nelements = 0;

--- a/src/MANYBODY/pair_polymorphic.cpp
+++ b/src/MANYBODY/pair_polymorphic.cpp
@@ -44,6 +44,8 @@ PairPolymorphic::PairPolymorphic(LAMMPS *lmp) : Pair(lmp)
   single_enable = 0;
   restartinfo = 0;
   one_coeff = 1;
+  manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   nelements = 0;
   elements = nullptr;

--- a/src/MANYBODY/pair_sw.cpp
+++ b/src/MANYBODY/pair_sw.cpp
@@ -43,6 +43,7 @@ PairSW::PairSW(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   unit_convert_flag = utils::get_supported_conversions(utils::ENERGY);
 
   nelements = 0;

--- a/src/MANYBODY/pair_tersoff.cpp
+++ b/src/MANYBODY/pair_tersoff.cpp
@@ -47,6 +47,7 @@ PairTersoff::PairTersoff(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   unit_convert_flag = utils::get_supported_conversions(utils::ENERGY);
 
   nelements = 0;

--- a/src/MANYBODY/pair_vashishta.cpp
+++ b/src/MANYBODY/pair_vashishta.cpp
@@ -45,6 +45,7 @@ PairVashishta::PairVashishta(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   unit_convert_flag = utils::get_supported_conversions(utils::ENERGY);
 
   nelements = 0;

--- a/src/MLIAP/pair_mliap.cpp
+++ b/src/MLIAP/pair_mliap.cpp
@@ -38,7 +38,7 @@ PairMLIAP::PairMLIAP(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
-
+  centroidstressflag = CENTROID_NOTAVAIL;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/bond_quartic.cpp
+++ b/src/MOLECULE/bond_quartic.cpp
@@ -63,7 +63,7 @@ void BondQuartic::compute(int eflag, int vflag)
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 
-  if (vflag_global == 2)
+  if (vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   double **cutsq = force->pair->cutsq;

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -79,7 +79,7 @@ void DihedralCharmm::compute(int eflag, int vflag)
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 
-  if (weightflag && vflag_global == 2)
+  if (weightflag && vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   double **x = atom->x;

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -82,7 +82,7 @@ void DihedralCharmmfsw::compute(int eflag, int vflag)
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 
-  if (weightflag && vflag_global == 2)
+  if (weightflag && vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   double **x = atom->x;

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -42,8 +42,6 @@
 #include "memory.h"
 #include "error.h"
 
-
-
 using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace MathConst;
@@ -74,6 +72,7 @@ FixCMAP::FixCMAP(LAMMPS *lmp, int narg, char **arg) :
   restart_peratom = 1;
   peatom_flag = 1;
   virial_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   thermo_virial = 1;
   peratom_freq = 1;
   scalar_flag = 1;

--- a/src/POEMS/fix_poems.cpp
+++ b/src/POEMS/fix_poems.cpp
@@ -74,6 +74,7 @@ FixPOEMS::FixPOEMS(LAMMPS *lmp, int narg, char **arg) :
   time_integrate = 1;
   rigid_flag = 1;
   virial_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   thermo_virial = 1;
   dof_flag = 1;
 

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -41,7 +41,7 @@ PairPython::PairPython(LAMMPS *lmp) : Pair(lmp) {
   one_coeff = 1;
   reinitflag = 0;
   cut_global = 0.0;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 
   py_potential = nullptr;
   skip_types = nullptr;

--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -40,6 +40,7 @@ PairSNAP::PairSNAP(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   nelements = 0;
   elements = nullptr;

--- a/src/USER-FEP/pair_coul_cut_soft.cpp
+++ b/src/USER-FEP/pair_coul_cut_soft.cpp
@@ -33,7 +33,7 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 PairCoulCutSoft::PairCoulCutSoft(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-FEP/pair_lj_class2_coul_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_class2_coul_cut_soft.cpp
@@ -33,7 +33,7 @@ using namespace MathConst;
 PairLJClass2CoulCutSoft::PairLJClass2CoulCutSoft(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-FEP/pair_lj_class2_soft.cpp
+++ b/src/USER-FEP/pair_lj_class2_soft.cpp
@@ -32,7 +32,7 @@ using namespace MathConst;
 PairLJClass2Soft::PairLJClass2Soft(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-FEP/pair_lj_cut_coul_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_coul_cut_soft.cpp
@@ -37,7 +37,7 @@ using namespace MathConst;
 PairLJCutCoulCutSoft::PairLJCutCoulCutSoft(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-FEP/pair_lj_cut_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_soft.cpp
@@ -43,7 +43,7 @@ PairLJCutSoft::PairLJCutSoft(LAMMPS *lmp) : Pair(lmp)
   respa_enable = 1;
   writedata = 1;
   allocated = 0;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-INTEL/dihedral_charmm_intel.cpp
+++ b/src/USER-INTEL/dihedral_charmm_intel.cpp
@@ -91,7 +91,7 @@ void DihedralCharmmIntel::compute(int eflag, int vflag,
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 
-  if (weightflag && vflag_global == 2)
+  if (weightflag && vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   if (evflag) {

--- a/src/USER-INTEL/intel_preprocess.h
+++ b/src/USER-INTEL/intel_preprocess.h
@@ -502,7 +502,7 @@ enum {TIME_PACK, TIME_HOST_NEIGHBOR, TIME_HOST_PAIR, TIME_OFFLOAD_NEIGHBOR,
   acc_t *f_scalar = &f_start[0].x;                                      \
   int f_stride4 = f_stride * 4;                                         \
   int t;                                                                \
-  if (vflag == 2) t = 4; else t = 1;                                    \
+  if (vflag == VIRIAL_FDOTR) t = 4; else t = 1;                         \
   acc_t *f_scalar2 = f_scalar + f_stride4 * t;                          \
   for ( ; t < nthreads; t++) {                                          \
     _use_simd_pragma("vector aligned")                                  \
@@ -512,7 +512,7 @@ enum {TIME_PACK, TIME_HOST_NEIGHBOR, TIME_HOST_PAIR, TIME_OFFLOAD_NEIGHBOR,
     f_scalar2 += f_stride4;                                             \
   }                                                                     \
                                                                         \
-  if (vflag == 2) {                                                     \
+  if (vflag == VIRIAL_FDOTR) {                                          \
     int nt_min = MIN(4,nthreads);                                       \
     IP_PRE_fdotr_acc_force_l5(iifrom, iito, minlocal, nt_min, f_start,  \
                               f_stride, pos, ov0, ov1, ov2, ov3, ov4,   \

--- a/src/USER-INTEL/pair_buck_coul_cut_intel.cpp
+++ b/src/USER-INTEL/pair_buck_coul_cut_intel.cpp
@@ -245,7 +245,7 @@ void PairBuckCoulCutIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl = secoul = (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         #if defined(LMP_SIMD_COMPILER)
         #pragma vector aligned

--- a/src/USER-INTEL/pair_buck_intel.cpp
+++ b/src/USER-INTEL/pair_buck_intel.cpp
@@ -227,7 +227,7 @@ void PairBuckIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl =  (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         #if defined(LMP_SIMD_COMPILER)
         #pragma vector aligned

--- a/src/USER-INTEL/pair_dpd_intel.cpp
+++ b/src/USER-INTEL/pair_dpd_intel.cpp
@@ -265,7 +265,7 @@ void PairDPDIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl = (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         if (rngi + jnum > rng_size) {
           #ifdef LMP_USE_MKL_RNG

--- a/src/USER-INTEL/pair_eam_intel.cpp
+++ b/src/USER-INTEL/pair_eam_intel.cpp
@@ -481,7 +481,7 @@ void PairEAMIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl = (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         int ej = 0;
         #if defined(LMP_SIMD_COMPILER)

--- a/src/USER-INTEL/pair_gayberne_intel.cpp
+++ b/src/USER-INTEL/pair_gayberne_intel.cpp
@@ -399,7 +399,7 @@ void PairGayBerneIntel::eval(const int offload, const int vflag,
 
         if (EFLAG) fwtmp = sevdwl = (acc_t)0.0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0.0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0.0;
 
         bool multiple_forms = false;
         int packed_j = 0;

--- a/src/USER-INTEL/pair_lj_charmm_coul_charmm_intel.cpp
+++ b/src/USER-INTEL/pair_lj_charmm_coul_charmm_intel.cpp
@@ -265,7 +265,7 @@ void PairLJCharmmCoulCharmmIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl = secoul = (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         int ej = 0;
         #if defined(LMP_SIMD_COMPILER)

--- a/src/USER-INTEL/pair_lj_charmm_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_lj_charmm_coul_long_intel.cpp
@@ -282,7 +282,7 @@ void PairLJCharmmCoulLongIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl = secoul = (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         int ej = 0;
         #if defined(LMP_SIMD_COMPILER)

--- a/src/USER-INTEL/pair_lj_cut_coul_long_intel.cpp
+++ b/src/USER-INTEL/pair_lj_cut_coul_long_intel.cpp
@@ -275,7 +275,7 @@ void PairLJCutCoulLongIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl = secoul = (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         int ej = 0;
         #if defined(LMP_SIMD_COMPILER)

--- a/src/USER-INTEL/pair_lj_cut_intel.cpp
+++ b/src/USER-INTEL/pair_lj_cut_intel.cpp
@@ -233,7 +233,7 @@ void PairLJCutIntel::eval(const int offload, const int vflag,
         fxtmp = fytmp = fztmp = (acc_t)0;
         if (EFLAG) fwtmp = sevdwl = (acc_t)0;
         if (NEWTON_PAIR == 0)
-          if (vflag==1) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
+          if (vflag == VIRIAL_PAIR) sv0 = sv1 = sv2 = sv3 = sv4 = sv5 = (acc_t)0;
 
         #if defined(LMP_SIMD_COMPILER)
         #pragma vector aligned nog2s

--- a/src/USER-MEAMC/pair_meamc.cpp
+++ b/src/USER-MEAMC/pair_meamc.cpp
@@ -17,7 +17,6 @@
 
 #include "pair_meamc.h"
 
-
 #include <cstring>
 
 #include "meam.h"
@@ -29,8 +28,6 @@
 #include "neigh_request.h"
 #include "memory.h"
 #include "error.h"
-
-
 
 using namespace LAMMPS_NS;
 
@@ -52,6 +49,7 @@ PairMEAMC::PairMEAMC(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   allocated = 0;
 

--- a/src/USER-MESONT/pair_mesocnt.cpp
+++ b/src/USER-MESONT/pair_mesocnt.cpp
@@ -23,7 +23,6 @@
 
 #include <cstring>
 
-
 #include "atom.h"
 #include "comm.h"
 #include "force.h"
@@ -33,9 +32,6 @@
 #include "memory.h"
 #include "error.h"
 #include "update.h"
-
-
-
 #include "math_const.h"
 #include "math_extra.h"
 
@@ -58,6 +54,7 @@ PairMesoCNT::PairMesoCNT(LAMMPS *lmp) : Pair(lmp)
   respa_enable = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   no_virial_fdotr_compute = 0;
   writedata = 0;
   ghostneigh = 0;

--- a/src/USER-MISC/pair_agni.cpp
+++ b/src/USER-MISC/pair_agni.cpp
@@ -81,6 +81,7 @@ PairAGNI::PairAGNI(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   no_virial_fdotr_compute = 1;
 

--- a/src/USER-MISC/pair_agni.cpp
+++ b/src/USER-MISC/pair_agni.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "citeme.h"
 #include "comm.h"
+#include "force.h"
 #include "error.h"
 #include "math_const.h"
 #include "math_special.h"

--- a/src/USER-MISC/pair_drip.cpp
+++ b/src/USER-MISC/pair_drip.cpp
@@ -34,7 +34,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 
 #define MAXLINE 1024
@@ -48,6 +47,7 @@ PairDRIP::PairDRIP(LAMMPS *lmp) : Pair(lmp)
   single_enable = 0;
   restartinfo = 0;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   params = nullptr;
   nearest3neigh = nullptr;

--- a/src/USER-MISC/pair_edip.cpp
+++ b/src/USER-MISC/pair_edip.cpp
@@ -36,7 +36,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 
 #define MAXLINE 1024
@@ -63,6 +62,7 @@ PairEDIP::PairEDIP(LAMMPS *lmp) :
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   nelements = 0;
   elements = nullptr;

--- a/src/USER-MISC/pair_edip_multi.cpp
+++ b/src/USER-MISC/pair_edip_multi.cpp
@@ -68,6 +68,7 @@ PairEDIPMulti::PairEDIPMulti(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   nelements = 0;
   elements = nullptr;

--- a/src/USER-MISC/pair_extep.cpp
+++ b/src/USER-MISC/pair_extep.cpp
@@ -49,6 +49,7 @@ PairExTeP::PairExTeP(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   ghostneigh = 1;
 
   nelements = 0;

--- a/src/USER-MISC/pair_meam_sw_spline.cpp
+++ b/src/USER-MISC/pair_meam_sw_spline.cpp
@@ -47,6 +47,7 @@ PairMEAMSWSpline::PairMEAMSWSpline(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   nelements = 0;
   elements = nullptr;

--- a/src/USER-MISC/pair_tersoff_table.cpp
+++ b/src/USER-MISC/pair_tersoff_table.cpp
@@ -61,6 +61,7 @@ PairTersoffTable::PairTersoffTable(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   unit_convert_flag = utils::get_supported_conversions(utils::ENERGY);
 
   nelements = 0;

--- a/src/USER-MOFFF/angle_cosine_buck6d.cpp
+++ b/src/USER-MOFFF/angle_cosine_buck6d.cpp
@@ -72,7 +72,7 @@ void AngleCosineBuck6d::compute(int eflag, int vflag)
 
   // insure pair->ev_tally() will use 1-3 virial contribution
 
-  if (vflag_global == 2)
+  if (vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   double **x = atom->x;

--- a/src/USER-OMP/bond_quartic_omp.cpp
+++ b/src/USER-OMP/bond_quartic_omp.cpp
@@ -45,7 +45,7 @@ void BondQuarticOMP::compute(int eflag, int vflag)
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 
-  if (vflag_global == 2)
+  if (vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   const int nall = atom->nlocal + atom->nghost;

--- a/src/USER-OMP/dihedral_charmm_omp.cpp
+++ b/src/USER-OMP/dihedral_charmm_omp.cpp
@@ -49,7 +49,7 @@ void DihedralCharmmOMP::compute(int eflag, int vflag)
 
   // insure pair->ev_tally() will use 1-4 virial contribution
 
-  if (weightflag && vflag_global == 2)
+  if (weightflag && vflag_global == VIRIAL_FDOTR)
     force->pair->vflag_either = force->pair->vflag_global = 1;
 
   const int nall = atom->nlocal + atom->nghost;

--- a/src/USER-OMP/thr_omp.cpp
+++ b/src/USER-OMP/thr_omp.cpp
@@ -70,20 +70,20 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
   if (tid == 0) thr_error = 0;
 
   if (thr_style & THR_PAIR) {
-    if (eflag & 2) {
+    if (eflag & ENERGY_ATOM) {
       thr->eatom_pair = eatom + tid*nall;
       if (nall > 0)
         memset(&(thr->eatom_pair[0]),0,nall*sizeof(double));
     }
     // per-atom virial and per-atom centroid virial are the same for two-body
     // many-body pair styles not yet implemented
-    if (vflag & 12) {
+    if (vflag & (VIRIAL_ATOM | VIRIAL_CENTROID)) {
       thr->vatom_pair = vatom + tid*nall;
       if (nall > 0)
         memset(&(thr->vatom_pair[0][0]),0,nall*6*sizeof(double));
     }
     // check cvatom_pair, because can't access centroidstressflag
-    if ((vflag & 8) && cvatom) {
+    if ((vflag & VIRIAL_CENTROID) && cvatom) {
       thr->cvatom_pair = cvatom + tid*nall;
       if (nall > 0)
         memset(&(thr->cvatom_pair[0][0]),0,nall*9*sizeof(double));
@@ -94,13 +94,13 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
   }
 
   if (thr_style & THR_BOND) {
-    if (eflag & 2) {
+    if (eflag & ENERGY_ATOM) {
       thr->eatom_bond = eatom + tid*nall;
       if (nall > 0)
         memset(&(thr->eatom_bond[0]),0,nall*sizeof(double));
     }
     // per-atom virial and per-atom centroid virial are the same for bonds
-    if (vflag & 12) {
+    if (vflag & (VIRIAL_ATOM | VIRIAL_CENTROID)) {
       thr->vatom_bond = vatom + tid*nall;
       if (nall > 0)
         memset(&(thr->vatom_bond[0][0]),0,nall*6*sizeof(double));
@@ -108,17 +108,17 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
   }
 
   if (thr_style & THR_ANGLE) {
-    if (eflag & 2) {
+    if (eflag & ENERGY_ATOM) {
       thr->eatom_angle = eatom + tid*nall;
       if (nall > 0)
         memset(&(thr->eatom_angle[0]),0,nall*sizeof(double));
     }
-    if (vflag & 4) {
+    if (vflag & VIRIAL_ATOM) {
       thr->vatom_angle = vatom + tid*nall;
       if (nall > 0)
         memset(&(thr->vatom_angle[0][0]),0,nall*6*sizeof(double));
     }
-    if (vflag & 8) {
+    if (vflag & VIRIAL_CENTROID) {
       thr->cvatom_angle = cvatom + tid*nall;
       if (nall > 0)
         memset(&(thr->cvatom_angle[0][0]),0,nall*9*sizeof(double));
@@ -126,17 +126,17 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
   }
 
   if (thr_style & THR_DIHEDRAL) {
-    if (eflag & 2) {
+    if (eflag & ENERGY_ATOM) {
       thr->eatom_dihed = eatom + tid*nall;
       if (nall > 0)
         memset(&(thr->eatom_dihed[0]),0,nall*sizeof(double));
     }
-    if (vflag & 4) {
+    if (vflag & VIRIAL_ATOM) {
       thr->vatom_dihed = vatom + tid*nall;
       if (nall > 0)
         memset(&(thr->vatom_dihed[0][0]),0,nall*6*sizeof(double));
     }
-    if (vflag & 8) {
+    if (vflag & VIRIAL_CENTROID) {
       thr->cvatom_dihed = cvatom + tid*nall;
       if (nall > 0)
         memset(&(thr->cvatom_dihed[0][0]),0,nall*9*sizeof(double));
@@ -144,17 +144,17 @@ void ThrOMP::ev_setup_thr(int eflag, int vflag, int nall, double *eatom,
   }
 
   if (thr_style & THR_IMPROPER) {
-    if (eflag & 2) {
+    if (eflag & ENERGY_ATOM) {
       thr->eatom_imprp = eatom + tid*nall;
       if (nall > 0)
         memset(&(thr->eatom_imprp[0]),0,nall*sizeof(double));
     }
-    if (vflag & 4) {
+    if (vflag & VIRIAL_ATOM) {
       thr->vatom_imprp = vatom + tid*nall;
       if (nall > 0)
         memset(&(thr->vatom_imprp[0][0]),0,nall*6*sizeof(double));
     }
-    if (vflag & 8) {
+    if (vflag & VIRIAL_CENTROID) {
       thr->cvatom_imprp = cvatom + tid*nall;
       if (nall > 0)
         memset(&(thr->cvatom_imprp[0][0]),0,nall*9*sizeof(double));
@@ -222,29 +222,29 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
 #pragma omp critical
 #endif
       {
-        if (eflag & 1) {
+        if (eflag & ENERGY_GLOBAL) {
           pair->eng_vdwl += thr->eng_vdwl;
           pair->eng_coul += thr->eng_coul;
           thr->eng_vdwl = 0.0;
           thr->eng_coul = 0.0;
         }
-        if (vflag & 3)
+        if (vflag & (VIRIAL_PAIR | VIRIAL_FDOTR))
           for (int i=0; i < 6; ++i) {
             pair->virial[i] += thr->virial_pair[i];
             thr->virial_pair[i] = 0.0;
           }
       }
 
-      if (eflag & 2) {
+      if (eflag & ENERGY_ATOM) {
         data_reduce_thr(&(pair->eatom[0]), nall, nthreads, 1, tid);
       }
       // per-atom virial and per-atom centroid virial are the same for two-body
       // many-body pair styles not yet implemented
-      if (vflag & 12) {
+      if (vflag & (VIRIAL_ATOM | VIRIAL_CENTROID)) {
         data_reduce_thr(&(pair->vatom[0][0]), nall, nthreads, 6, tid);
       }
       // check cvatom_pair, because can't access centroidstressflag
-      if ((vflag & 8) && thr->cvatom_pair) {
+      if ((vflag & VIRIAL_CENTROID) && thr->cvatom_pair) {
         data_reduce_thr(&(pair->cvatom[0][0]), nall, nthreads, 9, tid);
       }
     }
@@ -259,12 +259,12 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
 #pragma omp critical
 #endif
       {
-        if (eflag & 1) {
+        if (eflag & ENERGY_GLOBAL) {
           bond->energy += thr->eng_bond;
           thr->eng_bond = 0.0;
         }
 
-        if (vflag & 3) {
+        if (vflag & (VIRIAL_PAIR | VIRIAL_FDOTR)) {
           for (int i=0; i < 6; ++i) {
             bond->virial[i] += thr->virial_bond[i];
             thr->virial_bond[i] = 0.0;
@@ -272,11 +272,11 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         }
       }
 
-      if (eflag & 2) {
+      if (eflag & ENERGY_ATOM) {
         data_reduce_thr(&(bond->eatom[0]), nall, nthreads, 1, tid);
       }
       // per-atom virial and per-atom centroid virial are the same for bonds
-      if (vflag & 12) {
+      if (vflag & (VIRIAL_ATOM | VIRIAL_CENTROID)) {
         data_reduce_thr(&(bond->vatom[0][0]), nall, nthreads, 6, tid);
       }
 
@@ -291,12 +291,12 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
 #pragma omp critical
 #endif
       {
-        if (eflag & 1) {
+        if (eflag & ENERGY_GLOBAL) {
           angle->energy += thr->eng_angle;
           thr->eng_angle = 0.0;
         }
 
-        if (vflag & 3) {
+        if (vflag & (VIRIAL_PAIR | VIRIAL_FDOTR)) {
           for (int i=0; i < 6; ++i) {
             angle->virial[i] += thr->virial_angle[i];
             thr->virial_angle[i] = 0.0;
@@ -304,13 +304,13 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         }
       }
 
-      if (eflag & 2) {
+      if (eflag & ENERGY_ATOM) {
         data_reduce_thr(&(angle->eatom[0]), nall, nthreads, 1, tid);
       }
-      if (vflag & 4) {
+      if (vflag & VIRIAL_ATOM) {
         data_reduce_thr(&(angle->vatom[0][0]), nall, nthreads, 6, tid);
       }
-      if (vflag & 8) {
+      if (vflag & VIRIAL_CENTROID) {
         data_reduce_thr(&(angle->cvatom[0][0]), nall, nthreads, 9, tid);
       }
 
@@ -325,12 +325,12 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
 #pragma omp critical
 #endif
       {
-        if (eflag & 1) {
+        if (eflag & ENERGY_GLOBAL) {
           dihedral->energy += thr->eng_dihed;
           thr->eng_dihed = 0.0;
         }
 
-        if (vflag & 3) {
+        if (vflag & (VIRIAL_PAIR | VIRIAL_FDOTR)) {
           for (int i=0; i < 6; ++i) {
             dihedral->virial[i] += thr->virial_dihed[i];
             thr->virial_dihed[i] = 0.0;
@@ -338,13 +338,13 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         }
       }
 
-      if (eflag & 2) {
+      if (eflag & ENERGY_ATOM) {
         data_reduce_thr(&(dihedral->eatom[0]), nall, nthreads, 1, tid);
       }
-      if (vflag & 4) {
+      if (vflag & VIRIAL_ATOM) {
         data_reduce_thr(&(dihedral->vatom[0][0]), nall, nthreads, 6, tid);
       }
-      if (vflag & 8) {
+      if (vflag & VIRIAL_CENTROID) {
         data_reduce_thr(&(dihedral->cvatom[0][0]), nall, nthreads, 9, tid);
       }
 
@@ -360,7 +360,7 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
 #pragma omp critical
 #endif
       {
-        if (eflag & 1) {
+        if (eflag & ENERGY_GLOBAL) {
           dihedral->energy += thr->eng_dihed;
           pair->eng_vdwl += thr->eng_vdwl;
           pair->eng_coul += thr->eng_coul;
@@ -369,7 +369,7 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
           thr->eng_coul = 0.0;
         }
 
-        if (vflag & 3) {
+        if (vflag & (VIRIAL_PAIR | VIRIAL_FDOTR)) {
           for (int i=0; i < 6; ++i) {
             dihedral->virial[i] += thr->virial_dihed[i];
             pair->virial[i] += thr->virial_pair[i];
@@ -379,23 +379,23 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         }
       }
 
-      if (eflag & 2) {
+      if (eflag & ENERGY_ATOM) {
         data_reduce_thr(&(dihedral->eatom[0]), nall, nthreads, 1, tid);
         data_reduce_thr(&(pair->eatom[0]), nall, nthreads, 1, tid);
       }
-      if (vflag & 4) {
+      if (vflag & VIRIAL_ATOM) {
         data_reduce_thr(&(dihedral->vatom[0][0]), nall, nthreads, 6, tid);
       }
-      if (vflag & 8) {
+      if (vflag & VIRIAL_CENTROID) {
         data_reduce_thr(&(dihedral->cvatom[0][0]), nall, nthreads, 9, tid);
       }
       // per-atom virial and per-atom centroid virial are the same for two-body
       // many-body pair styles not yet implemented
-      if (vflag & 12) {
+      if (vflag & (VIRIAL_ATOM | VIRIAL_CENTROID)) {
         data_reduce_thr(&(pair->vatom[0][0]), nall, nthreads, 6, tid);
       }
       // check cvatom_pair, because can't access centroidstressflag
-      if ((vflag & 8) && thr->cvatom_pair) {
+      if ((vflag & VIRIAL_CENTROID) && thr->cvatom_pair) {
         data_reduce_thr(&(pair->cvatom[0][0]), nall, nthreads, 9, tid);
       }
     }
@@ -409,12 +409,12 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
 #pragma omp critical
 #endif
       {
-        if (eflag & 1) {
+        if (eflag & ENERGY_GLOBAL) {
           improper->energy += thr->eng_imprp;
           thr->eng_imprp = 0.0;
         }
 
-        if (vflag & 3) {
+        if (vflag & (VIRIAL_PAIR | VIRIAL_FDOTR)) {
           for (int i=0; i < 6; ++i) {
             improper->virial[i] += thr->virial_imprp[i];
             thr->virial_imprp[i] = 0.0;
@@ -422,13 +422,13 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
         }
       }
 
-      if (eflag & 2) {
+      if (eflag & ENERGY_ATOM) {
         data_reduce_thr(&(improper->eatom[0]), nall, nthreads, 1, tid);
       }
-      if (vflag & 4) {
+      if (vflag & VIRIAL_ATOM) {
         data_reduce_thr(&(improper->vatom[0][0]), nall, nthreads, 6, tid);
       }
-      if (vflag & 8) {
+      if (vflag & VIRIAL_CENTROID) {
         data_reduce_thr(&(improper->cvatom[0][0]), nall, nthreads, 9, tid);
       }
 

--- a/src/USER-QUIP/pair_quip.cpp
+++ b/src/USER-QUIP/pair_quip.cpp
@@ -16,7 +16,6 @@
                          Aidan Thompson (Sandia, athomps@sandia.gov)
 ------------------------------------------------------------------------- */
 
-
 #include <cmath>
 #include <cstdio>
 
@@ -44,6 +43,7 @@ PairQUIP::PairQUIP(LAMMPS *lmp) : Pair(lmp)
   one_coeff = 1;
   no_virial_fdotr_compute = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   map = nullptr;
   quip_potential = nullptr;

--- a/src/USER-REAXC/pair_reaxc.cpp
+++ b/src/USER-REAXC/pair_reaxc.cpp
@@ -40,7 +40,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 #include "reaxc_defs.h"
 #include "reaxc_types.h"
 #include "reaxc_allocate.h"
@@ -77,6 +76,7 @@ PairReaxC::PairReaxC(LAMMPS *lmp) : Pair(lmp)
   restartinfo = 0;
   one_coeff = 1;
   manybody_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
   ghostneigh = 1;
 
   fix_id = new char[24];

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -75,7 +75,16 @@ void Angle::init()
 
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
-   see integrate::ev_set() for values of eflag (0-3) and vflag (0-6)
+   see integrate::ev_set() for bitwise settings of eflag/vflag
+   set the following flags, values are otherwise 0:
+     evflag       = 1 if any bits of eflag or vflag are set
+     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
+     eflag_either = 1 if eflag_global or eflag_atom is set
+     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
+     vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
 
 void Angle::ev_setup(int eflag, int vflag, int alloc)

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -77,7 +77,7 @@ void Angle::init()
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
-   set the following flags, values are otherwise 0:
+   set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
@@ -105,6 +105,7 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
   vflag_atom = vflag & VIRIAL_ATOM;
   if (vflag & VIRIAL_CENTROID && centroidstressflag != CENTROID_AVAIL)
     vflag_atom = 1;
+  cvflag_atom = 0;
   if (vflag & VIRIAL_CENTROID && centroidstressflag == CENTROID_AVAIL)
     cvflag_atom = 1;
   vflag_either = vflag_global || vflag_atom || cvflag_atom;

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -94,12 +94,12 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_ATOM;
 
-  vflag_global = vflag % 4;
-  vflag_atom = vflag & 4;
-  cvflag_atom = vflag & 8;
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag & VIRIAL_ATOM;
+  cvflag_atom = vflag & VIRIAL_CENTROID;
   vflag_either = vflag_global || vflag_atom;
 
   // reallocate per-atom arrays if necessary

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -40,6 +40,7 @@ Angle::Angle(LAMMPS *lmp) : Pointers(lmp)
   vatom = nullptr;
   cvatom = nullptr;
   setflag = nullptr;
+  centroidstressflag = CENTROID_AVAIL;
 
   execution_space = Host;
   datamask_read = ALL_MASK;
@@ -77,14 +78,17 @@ void Angle::init()
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise 0:
-     evflag       = 1 if any bits of eflag or vflag are set
-     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
-     eflag_either = 1 if eflag_global or eflag_atom is set
-     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
-     cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
-     vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
+     evflag       != 0 if any bits of eflag or vflag are set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_either != 0 if eflag_global or eflag_atom is set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
+     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
+                       and centroidstressflag != CENTROID_AVAIL
+     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag set
+                       and centroidstressflag = CENTROID_AVAIL
+     vflag_either != 0 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
 
 void Angle::ev_setup(int eflag, int vflag, int alloc)
@@ -99,8 +103,11 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;
-  cvflag_atom = vflag & VIRIAL_CENTROID;
-  vflag_either = vflag_global || vflag_atom;
+  if (vflag & VIRIAL_CENTROID && centroidstressflag != CENTROID_AVAIL)
+    vflag_atom = 1;
+  if (vflag & VIRIAL_CENTROID && centroidstressflag == CENTROID_AVAIL)
+    cvflag_atom = 1;
+  vflag_either = vflag_global || vflag_atom || cvflag_atom;
 
   // reallocate per-atom arrays if necessary
 

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -82,7 +82,7 @@ void Angle::init()
      eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
      cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
      vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */

--- a/src/angle.h
+++ b/src/angle.h
@@ -30,6 +30,11 @@ class Angle : protected Pointers {
   double *eatom,**vatom;          // accumulated per-atom energy/virial
   double **cvatom;                // accumulated per-atom centroid virial
 
+  int centroidstressflag;        // centroid stress compared to two-body stress
+                                 // CENTROID_SAME = same as two-body stress
+                                 // CENTROID_AVAIL = different and implemented
+                                 // CENTROID_NOTAVAIL = different, not yet implemented
+
   // KOKKOS host/device flag and data masks
 
   ExecutionSpace execution_space;

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -98,13 +98,13 @@ void Bond::ev_setup(int eflag, int vflag, int alloc)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_ATOM;
 
   vflag_either = vflag;
-  vflag_global = vflag % 4;
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   // per-atom virial and per-atom centroid virial are the same for bonds
-  vflag_atom = vflag / 4;
+  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
 
   // reallocate per-atom arrays if necessary
 

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -87,7 +87,7 @@ void Bond::init()
      eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_PERATOM or VIRIAL_CENTROID bit of vflag set
+     vflag_atom   = 1 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag set
      vflag_either = 1 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
 

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -80,7 +80,15 @@ void Bond::init()
 
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
-   see integrate::ev_set() for values of eflag (0-3) and vflag (0-6)
+   see integrate::ev_set() for bitwise settings of eflag/vflag
+   set the following flags, values are otherwise 0:
+     evflag       = 1 if any bits of eflag or vflag are set
+     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
+     eflag_either = 1 if eflag_global or eflag_atom is set
+     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   = 1 if VIRIAL_PERATOM or VIRIAL_CENTROID bit of vflag set
+     vflag_either = 1 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
 
 void Bond::ev_setup(int eflag, int vflag, int alloc)

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -82,13 +82,14 @@ void Bond::init()
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise 0:
-     evflag       = 1 if any bits of eflag or vflag are set
-     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
-     eflag_either = 1 if eflag_global or eflag_atom is set
-     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag set
-     vflag_either = 1 if vflag_global or vflag_atom is set
+     evflag       != 0 if any bits of eflag or vflag are set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_either != 0 if eflag_global or eflag_atom is set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   != 0 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag set
+                       two-body and centroid stress are identical for bonds
+     vflag_either != 0 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
 
 void Bond::ev_setup(int eflag, int vflag, int alloc)
@@ -103,7 +104,6 @@ void Bond::ev_setup(int eflag, int vflag, int alloc)
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
-  // per-atom virial and per-atom centroid virial are the same for bonds
   vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
 
   // reallocate per-atom arrays if necessary

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -81,7 +81,7 @@ void Bond::init()
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
-   set the following flags, values are otherwise 0:
+   set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -126,7 +126,7 @@ void ComputeCentroidStressAtom::init()
 
   // check if pair styles support centroid atom stress
   if (pairflag && force->pair)
-    if (force->pair->centroidstressflag == CENTROID_NOTAVAIL)
+    if (force->pair->centroidstressflag & CENTROID_NOTAVAIL)
       error->all(FLERR, "Pair style does not support compute centroid/stress/atom");
 }
 
@@ -178,7 +178,7 @@ void ComputeCentroidStressAtom::compute_peratom()
   // per-atom virial and per-atom centroid virial are the same for two-body
   // many-body pair styles not yet implemented
   if (pairflag && force->pair && force->pair->compute_flag) {
-    if (force->pair->centroidstressflag == CENTROID_AVAIL) {
+    if (force->pair->centroidstressflag & CENTROID_AVAIL) {
       double **cvatom = force->pair->cvatom;
       for (i = 0; i < npair; i++)
         for (j = 0; j < 9; j++)

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -257,7 +257,7 @@ void ComputeCentroidStressAtom::compute_peratom()
 
   if (kspaceflag && force->kspace && force->kspace->compute_flag) {
     double **vatom = force->kspace->vatom;
-    for (i = 0; i < nkspace; i++)
+    for (i = 0; i < nkspace; i++) {
       for (j = 0; j < 6; j++)
         stress[i][j] += vatom[i][j];
       for (j = 6; j < 9; j++)

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -221,8 +221,8 @@ void ComputeCentroidStressAtom::compute_peratom()
 
   // per-atom virial and per-atom centroid virial are the same for bonds
   // bond styles are all CENTROID_SAME
-  // all other styles are CENTROID_AVAIL or CENTROID_NOTAVAIL
-  // add KSpace when it becomes supported
+  // angle, dihedral, improper styles are CENTROID_AVAIL or CENTROID_NOTAVAIL
+  // KSpace styles are all CENTROID_NOTAVAIL, placeholder CENTROID_SAME below
   
   if (bondflag && force->bond) {
     double **vatom = force->bond->vatom;
@@ -255,12 +255,15 @@ void ComputeCentroidStressAtom::compute_peratom()
         stress[i][j] += cvatom[i][j];
   }
 
-  //if (kspaceflag && force->kspace && force->kspace->compute_flag) {
-  //  double **vatom = force->kspace->vatom;
-  //  for (i = 0; i < nkspace; i++)
-  //    for (j = 0; j < 9; j++)
-  //      stress[i][j] += cvatom[i][j];
-  // }
+  if (kspaceflag && force->kspace && force->kspace->compute_flag) {
+    double **vatom = force->kspace->vatom;
+    for (i = 0; i < nkspace; i++)
+      for (j = 0; j < 6; j++)
+        stress[i][j] += vatom[i][j];
+      for (j = 6; j < 9; j++)
+        stress[i][j] += vatom[i][j-3];
+    }
+  }
 
   // add in per-atom contributions from relevant fixes
   // skip if vatom = nullptr

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -222,6 +222,7 @@ void ComputeCentroidStressAtom::compute_peratom()
   // per-atom virial and per-atom centroid virial are the same for bonds
   // bond styles are all CENTROID_SAME
   // all other styles are CENTROID_AVAIL or CENTROID_NOTAVAIL
+  // add KSpace when it becomes supported
   
   if (bondflag && force->bond) {
     double **vatom = force->bond->vatom;
@@ -254,12 +255,12 @@ void ComputeCentroidStressAtom::compute_peratom()
         stress[i][j] += cvatom[i][j];
   }
 
-  if (kspaceflag && force->kspace && force->kspace->compute_flag) {
-    double **vatom = force->kspace->vatom;
-    for (i = 0; i < nkspace; i++)
-      for (j = 0; j < 9; j++)
-        stress[i][j] += cvatom[i][j];
-  }
+  //if (kspaceflag && force->kspace && force->kspace->compute_flag) {
+  //  double **vatom = force->kspace->vatom;
+  //  for (i = 0; i < nkspace; i++)
+  //    for (j = 0; j < 9; j++)
+  //      stress[i][j] += cvatom[i][j];
+  // }
 
   // add in per-atom contributions from relevant fixes
   // skip if vatom = nullptr

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -126,7 +126,7 @@ void ComputeCentroidStressAtom::init()
 
   // check if pair styles support centroid atom stress
   if (pairflag && force->pair)
-    if (force->pair->centroidstressflag & 4)
+    if (force->pair->centroidstressflag == CENTROID_NOTAVAIL)
       error->all(FLERR, "Pair style does not support compute centroid/stress/atom");
 }
 
@@ -178,7 +178,7 @@ void ComputeCentroidStressAtom::compute_peratom()
   // per-atom virial and per-atom centroid virial are the same for two-body
   // many-body pair styles not yet implemented
   if (pairflag && force->pair && force->pair->compute_flag) {
-    if (force->pair->centroidstressflag & 2) {
+    if (force->pair->centroidstressflag == CENTROID_AVAIL) {
       double **cvatom = force->pair->cvatom;
       for (i = 0; i < npair; i++)
         for (j = 0; j < 9; j++)

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -74,7 +74,16 @@ void Dihedral::init()
 
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
-   see integrate::ev_set() for values of eflag (0-3) and vflag (0-6)
+   see integrate::ev_set() for bitwise settings of eflag/vflag
+   set the following flags, values are otherwise 0:
+     evflag       = 1 if any bits of eflag or vflag are set
+     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
+     eflag_either = 1 if eflag_global or eflag_atom is set
+     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
+     vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
 
 void Dihedral::ev_setup(int eflag, int vflag, int alloc)

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -76,7 +76,7 @@ void Dihedral::init()
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
-   set the following flags, values are otherwise 0:
+   set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
@@ -104,6 +104,7 @@ void Dihedral::ev_setup(int eflag, int vflag, int alloc)
   vflag_atom = vflag & VIRIAL_ATOM;
   if (vflag & VIRIAL_CENTROID && centroidstressflag != CENTROID_AVAIL)
     vflag_atom = 1;
+  cvflag_atom = 0;
   if (vflag & VIRIAL_CENTROID && centroidstressflag == CENTROID_AVAIL)
     cvflag_atom = 1;
   vflag_either = vflag_global || vflag_atom || cvflag_atom;

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -81,7 +81,7 @@ void Dihedral::init()
      eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
      cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
      vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -93,12 +93,12 @@ void Dihedral::ev_setup(int eflag, int vflag, int alloc)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_ATOM;
 
-  vflag_global = vflag % 4;
-  vflag_atom = vflag & 4;
-  cvflag_atom = vflag & 8;
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag & VIRIAL_ATOM;
+  cvflag_atom = vflag & VIRIAL_CENTROID;
   vflag_either = vflag_global || vflag_atom;
 
   // reallocate per-atom arrays if necessary

--- a/src/dihedral.h
+++ b/src/dihedral.h
@@ -30,6 +30,11 @@ class Dihedral : protected Pointers {
   double *eatom,**vatom;             // accumulated per-atom energy/virial
   double **cvatom;                   // accumulated per-atom centroid virial
 
+  int centroidstressflag;        // centroid stress compared to two-body stress
+                                 // CENTROID_SAME = same as two-body stress
+                                 // CENTROID_AVAIL = different and implemented
+                                 // CENTROID_NOTAVAIL = different, not yet implemented
+
   // KOKKOS host/device flag and data masks
 
   ExecutionSpace execution_space;

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -16,6 +16,7 @@
 #include "atom.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "force.h"
 #include "group.h"
 #include "memory.h"
 
@@ -189,12 +190,12 @@ void Fix::ev_setup(int eflag, int vflag)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2; // TODO
-  eflag_atom = eflag / 2;  // TODO
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_ATOM;
 
   vflag_either = vflag;
-  vflag_global = vflag % 4; // TODO
-  vflag_atom = vflag / 4; // TODO
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
 
   // reallocate per-atom arrays if necessary
 
@@ -234,7 +235,7 @@ void Fix::ev_setup(int eflag, int vflag)
 /* ----------------------------------------------------------------------
    if thermo_virial is on:
      setup for virial computation
-     see integrate::ev_set() for values of vflag (0-6)
+     see integrate::ev_set() for values of vflag
      fixes call this if use v_tally()
    else: set evflag=0
 ------------------------------------------------------------------------- */
@@ -250,8 +251,8 @@ void Fix::v_setup(int vflag)
 
   evflag = 1;
 
-  vflag_global = vflag % 4; // TODO
-  vflag_atom = vflag / 4; // TODO
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
 
   // reallocate per-atom array if necessary
 

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -189,12 +189,12 @@ void Fix::ev_setup(int eflag, int vflag)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag % 2; // TODO
+  eflag_atom = eflag / 2;  // TODO
 
   vflag_either = vflag;
-  vflag_global = vflag % 4;
-  vflag_atom = vflag / 4;
+  vflag_global = vflag % 4; // TODO
+  vflag_atom = vflag / 4; // TODO
 
   // reallocate per-atom arrays if necessary
 
@@ -250,8 +250,8 @@ void Fix::v_setup(int vflag)
 
   evflag = 1;
 
-  vflag_global = vflag % 4;
-  vflag_atom = vflag / 4;
+  vflag_global = vflag % 4; // TODO
+  vflag_atom = vflag / 4; // TODO
 
   // reallocate per-atom array if necessary
 

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -104,7 +104,8 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
 
   maxeatom = maxvatom = 0;
   vflag_atom = 0;
-
+  centroidstressflag = CENTROID_SAME;
+  
   // KOKKOS per-fix data masks
 
   execution_space = Host;

--- a/src/fix.h
+++ b/src/fix.h
@@ -102,6 +102,11 @@ class Fix : protected Pointers {
   double virial[6];              // accumulated virial
   double *eatom,**vatom;         // accumulated per-atom energy/virial
 
+  int centroidstressflag;        // centroid stress compared to two-body stress
+                                 // CENTROID_SAME = same as two-body stress
+                                 // CENTROID_AVAIL = different and implemented
+                                 // CENTROID_NOTAVAIL = different, not yet implemented
+
   int restart_reset;             // 1 if restart just re-initialized fix
 
   // KOKKOS host/device flag and data masks

--- a/src/force.h
+++ b/src/force.h
@@ -29,15 +29,21 @@ namespace LAMMPS_NS {
 enum {
   ENERGY_NONE    = 0x00,
   ENERGY_GLOBAL  = 0x01,
-  ENERGY_PERATOM = 0x02
+  ENERGY_ATOM    = 0x02
 };
 
 enum {
   VIRIAL_NONE     = 0x00,
-  VIRIAL_TALLY    = 0x01,
+  VIRIAL_PAIR     = 0x01,
   VIRIAL_FDOTR    = 0x02,
-  VIRIAL_PERATOM  = 0x04,
+  VIRIAL_ATOM     = 0x04,
   VIRIAL_CENTROID = 0x08
+};
+
+enum {
+  CENTROID_SAME     = 0x00,
+  CENTROID_AVAIL    = 0x01,
+  CENTROID_NOTAVAIL = 0x02
 };
 
 class Force : protected Pointers {

--- a/src/force.h
+++ b/src/force.h
@@ -41,9 +41,9 @@ enum {
 };
 
 enum {
-  CENTROID_SAME     = 0x00,
-  CENTROID_AVAIL    = 0x01,
-  CENTROID_NOTAVAIL = 0x02
+  CENTROID_SAME     = 0x01,
+  CENTROID_AVAIL    = 0x02,
+  CENTROID_NOTAVAIL = 0x04
 };
 
 class Force : protected Pointers {

--- a/src/force.h
+++ b/src/force.h
@@ -41,9 +41,9 @@ enum {
 };
 
 enum {
-  CENTROID_SAME     = 0x01,
-  CENTROID_AVAIL    = 0x02,
-  CENTROID_NOTAVAIL = 0x04
+  CENTROID_SAME     = 0,
+  CENTROID_AVAIL    = 1,
+  CENTROID_NOTAVAIL = 2
 };
 
 class Force : protected Pointers {

--- a/src/force.h
+++ b/src/force.h
@@ -26,6 +26,20 @@ namespace LAMMPS_NS {
   class KSpace;
   class Pair;
 
+enum {
+  ENERGY_NONE    = 0x00,
+  ENERGY_GLOBAL  = 0x01,
+  ENERGY_PERATOM = 0x02
+};
+
+enum {
+  VIRIAL_NONE     = 0x00,
+  VIRIAL_TALLY    = 0x01,
+  VIRIAL_FDOTR    = 0x02,
+  VIRIAL_PERATOM  = 0x04,
+  VIRIAL_CENTROID = 0x08
+};
+
 class Force : protected Pointers {
  public:
   double boltz;                      // Boltzmann constant (eng/degree-K)

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -72,7 +72,16 @@ void Improper::init()
 
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
-   see integrate::ev_set() for values of eflag (0-3) and vflag (0-6)
+   see integrate::ev_set() for bitwise settings of eflag/vflag
+   set the following flags, values are otherwise 0:
+     evflag       = 1 if any bits of eflag or vflag are set
+     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
+     eflag_either = 1 if eflag_global or eflag_atom is set
+     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
+     vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
 
 void Improper::ev_setup(int eflag, int vflag, int alloc)

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -74,7 +74,7 @@ void Improper::init()
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
-   set the following flags, values are otherwise 0:
+   set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
@@ -102,6 +102,7 @@ void Improper::ev_setup(int eflag, int vflag, int alloc)
   vflag_atom = vflag & VIRIAL_ATOM;
   if (vflag & VIRIAL_CENTROID && centroidstressflag != CENTROID_AVAIL)
     vflag_atom = 1;
+  cvflag_atom = 0;
   if (vflag & VIRIAL_CENTROID && centroidstressflag == CENTROID_AVAIL)
     cvflag_atom = 1;
   vflag_either = vflag_global || vflag_atom || cvflag_atom;

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -75,12 +75,12 @@ void Improper::init()
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise 0:
-     evflag       = 1 if any bits of eflag or vflag are set
-     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
-     eflag_either = 1 if eflag_global or eflag_atom is set
-     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
+     evflag       != 0 if any bits of eflag or vflag are set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_either != 0 if eflag_global or eflag_atom is set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
      vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
                        and centroidstressflag != CENTROID_AVAIL
      cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag set

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -91,12 +91,12 @@ void Improper::ev_setup(int eflag, int vflag, int alloc)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_ATOM;
 
-  vflag_global = vflag % 4;
-  vflag_atom = vflag & 4;
-  cvflag_atom = vflag & 8;
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag & VIRIAL_ATOM;
+  cvflag_atom = vflag & VIRIAL_CENTROID;
   vflag_either = vflag_global || vflag_atom;
 
   // reallocate per-atom arrays if necessary

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -79,7 +79,7 @@ void Improper::init()
      eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
      cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
      vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -37,6 +37,7 @@ Improper::Improper(LAMMPS *lmp) : Pointers(lmp)
   vatom = nullptr;
   cvatom = nullptr;
   setflag = nullptr;
+  centroidstressflag = CENTROID_AVAIL;
 
   execution_space = Host;
   datamask_read = ALL_MASK;
@@ -80,8 +81,11 @@ void Improper::init()
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
      vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
-     cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
-     vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
+     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
+                       and centroidstressflag != CENTROID_AVAIL
+     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag set
+                       and centroidstressflag = CENTROID_AVAIL
+     vflag_either != 0 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
 
 void Improper::ev_setup(int eflag, int vflag, int alloc)
@@ -96,8 +100,11 @@ void Improper::ev_setup(int eflag, int vflag, int alloc)
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;
-  cvflag_atom = vflag & VIRIAL_CENTROID;
-  vflag_either = vflag_global || vflag_atom;
+  if (vflag & VIRIAL_CENTROID && centroidstressflag != CENTROID_AVAIL)
+    vflag_atom = 1;
+  if (vflag & VIRIAL_CENTROID && centroidstressflag == CENTROID_AVAIL)
+    cvflag_atom = 1;
+  vflag_either = vflag_global || vflag_atom || cvflag_atom;
 
   // reallocate per-atom arrays if necessary
 

--- a/src/improper.h
+++ b/src/improper.h
@@ -30,6 +30,11 @@ class Improper : protected Pointers {
   double *eatom,**vatom;          // accumulated per-atom energy/virial
   double **cvatom;                // accumulated per-atom centroid virial
 
+  int centroidstressflag;        // centroid stress compared to two-body stress
+                                 // CENTROID_SAME = same as two-body stress
+                                 // CENTROID_AVAIL = different and implemented
+                                 // CENTROID_NOTAVAIL = different, not yet implemented
+
   // KOKKOS host/device flag and data masks
 
   ExecutionSpace execution_space;

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -116,7 +116,7 @@ void Integrate::ev_setup()
    eflag: set any or no bits
      ENERGY_GLOBAL bit for global energy
      ENERGY_ATOM   bit for per-atom energy
-   vflag: set any or no bits, but GLOBAL/FDOTR bit cannot both be set
+   vflag: set any or no bits, but PAIR/FDOTR bits cannot both be set
      VIRIAL_PAIR     bit for global virial as sum of pairwise terms
      VIRIAL_FDOTR    bit for global virial via F dot r
      VIRIAL_ATOM     bit for per-atom virial

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -142,7 +142,7 @@ void Integrate::ev_set(bigint ntimestep)
   int eflag_atom = 0;
   for (i = 0; i < nelist_atom; i++)
     if (elist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) eflag_atom = ENERGY_PER_ATOM;
+  if (flag) eflag_atom = ENERGY_PERATOM;
 
   if (eflag_global) update->eflag_global = ntimestep;
   if (eflag_atom) update->eflag_atom = ntimestep;
@@ -158,13 +158,13 @@ void Integrate::ev_set(bigint ntimestep)
   int vflag_atom = 0;
   for (i = 0; i < nvlist_atom; i++)
     if (vlist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) vflag_atom = VIRIAL_PER_ATOM;
+  if (flag) vflag_atom = VIRIAL_PERATOM;
 
   flag = 0;
   int cvflag_atom = 0;
   for (i = 0; i < ncvlist_atom; i++)
     if (cvlist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) cvflag_atom = VIRIAL_PER_ATOM_CENTROID;
+  if (flag) cvflag_atom = VIRIAL_CENTROID;
 
   if (vflag_global) update->vflag_global = ntimestep;
   if (vflag_atom || cvflag_atom) update->vflag_atom = ntimestep;

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -111,21 +111,18 @@ void Integrate::ev_setup()
 
 /* ----------------------------------------------------------------------
    set eflag,vflag for current iteration
+   based on computes that need energy/virial info on this timestep
    invoke matchstep() on all timestep-dependent computes to clear their arrays
-   eflag/vflag based on computes that need info on this ntimestep
-   eflag = 0 = no energy computation
-   eflag = 1 = global energy only
-   eflag = 2 = per-atom energy only
-   eflag = 3 = both global and per-atom energy
-   vflag = 0 = no virial computation (pressure)
-   vflag = 1 = global virial with pair portion via sum of pairwise interactions
-   vflag = 2 = global virial with pair portion via F dot r including ghosts
-   vflag = 4 = per-atom virial only
-   vflag = 5 or 6 = both global and per-atom virial
-   vflag = 8 = per-atom centroid virial only
-   vflag = 9 or 10 = both global and per-atom centroid virial
-   vflag = 12 = both per-atom virial and per-atom centroid virial
-   vflag = 13 or 14 = global, per-atom virial and per-atom centroid virial
+   eflag: set any or no bits
+     ENERGY_GLOBAL bit for global energy
+     ENERGY_ATOM   bit for per-atom energy
+   vflag: set any or no bits, but GLOBAL/FDOTR bit cannot both be set
+     VIRIAL_PAIR     bit for global virial as sum of pairwise terms
+     VIRIAL_FDOTR    bit for global virial via F dot r
+     VIRIAL_ATOM     bit for per-atom virial
+     VIRIAL_CENTROID bit for per-atom centroid virial
+   all force components (pair,bond,angle,...,kspace) use eflag/vflag
+     in their ev_setup() method to set local energy/virial flags
 ------------------------------------------------------------------------- */
 
 void Integrate::ev_set(bigint ntimestep)
@@ -136,7 +133,7 @@ void Integrate::ev_set(bigint ntimestep)
   int eflag_global = 0;
   for (i = 0; i < nelist_global; i++)
     if (elist_global[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) eflag_global = 1;
+  if (flag) eflag_global = ENERGY_GLOBAL;
 
   flag = 0;
   int eflag_atom = 0;

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -139,7 +139,7 @@ void Integrate::ev_set(bigint ntimestep)
   int eflag_atom = 0;
   for (i = 0; i < nelist_atom; i++)
     if (elist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) eflag_atom = ENERGY_PERATOM;
+  if (flag) eflag_atom = ENERGY_ATOM;
 
   if (eflag_global) update->eflag_global = ntimestep;
   if (eflag_atom) update->eflag_atom = ntimestep;
@@ -155,7 +155,7 @@ void Integrate::ev_set(bigint ntimestep)
   int vflag_atom = 0;
   for (i = 0; i < nvlist_atom; i++)
     if (vlist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) vflag_atom = VIRIAL_PERATOM;
+  if (flag) vflag_atom = VIRIAL_ATOM;
 
   flag = 0;
   int cvflag_atom = 0;

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -125,7 +125,7 @@ void Integrate::ev_setup()
    vflag = 8 = per-atom centroid virial only
    vflag = 9 or 10 = both global and per-atom centroid virial
    vflag = 12 = both per-atom virial and per-atom centroid virial
-   vflag = 13 or 15 = global, per-atom virial and per-atom centroid virial
+   vflag = 13 or 14 = global, per-atom virial and per-atom centroid virial
 ------------------------------------------------------------------------- */
 
 void Integrate::ev_set(bigint ntimestep)
@@ -142,7 +142,7 @@ void Integrate::ev_set(bigint ntimestep)
   int eflag_atom = 0;
   for (i = 0; i < nelist_atom; i++)
     if (elist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) eflag_atom = 2;
+  if (flag) eflag_atom = ENERGY_PER_ATOM;
 
   if (eflag_global) update->eflag_global = ntimestep;
   if (eflag_atom) update->eflag_atom = ntimestep;
@@ -158,13 +158,13 @@ void Integrate::ev_set(bigint ntimestep)
   int vflag_atom = 0;
   for (i = 0; i < nvlist_atom; i++)
     if (vlist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) vflag_atom = 4;
+  if (flag) vflag_atom = VIRIAL_PER_ATOM;
 
   flag = 0;
   int cvflag_atom = 0;
   for (i = 0; i < ncvlist_atom; i++)
     if (cvlist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) cvflag_atom = 8;
+  if (flag) cvflag_atom = VIRIAL_PER_ATOM_CENTROID;
 
   if (vflag_global) update->vflag_global = ntimestep;
   if (vflag_atom || cvflag_atom) update->vflag_atom = ntimestep;

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -221,7 +221,7 @@ void KSpace::pair_check()
      eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
      vflag_either = 1 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
 

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -88,7 +88,7 @@ KSpace::KSpace(LAMMPS *lmp) : Pointers(lmp)
   maxeatom = maxvatom = 0;
   eatom = nullptr;
   vatom = nullptr;
-  centroidstressatom = NOTAVAIL;
+  centroidstressflag = CENTROID_NOTAVAIL;
   
   execution_space = Host;
   datamask_read = ALL_MASK;
@@ -216,7 +216,7 @@ void KSpace::pair_check()
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
-   set the following flags, values are otherwise 0:
+   set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
@@ -225,6 +225,7 @@ void KSpace::pair_check()
      vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
                        no current support for centroid stress
      vflag_either != 0 if vflag_global or vflag_atom is set
+     evflag_atom  != 0 if eflag_atom or vflag_atom is set
 ------------------------------------------------------------------------- */
 
 void KSpace::ev_setup(int eflag, int vflag, int alloc)

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -221,7 +221,7 @@ void KSpace::pair_check()
      eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
+     vflag_atom   = 1 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag set
      vflag_either = 1 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
 
@@ -237,7 +237,7 @@ void KSpace::ev_setup(int eflag, int vflag, int alloc)
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
-  vflag_atom = vflag / 4; // TODO
+  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
 
   if (eflag_atom || vflag_atom) evflag_atom = 1;
   else evflag_atom = 0;

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -214,7 +214,15 @@ void KSpace::pair_check()
 
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
-   see integrate::ev_set() for values of eflag (0-3) and vflag (0-6)
+   see integrate::ev_set() for bitwise settings of eflag/vflag
+   set the following flags, values are otherwise 0:
+     evflag       = 1 if any bits of eflag or vflag are set
+     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
+     eflag_either = 1 if eflag_global or eflag_atom is set
+     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     vflag_either = 1 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
 
 void KSpace::ev_setup(int eflag, int vflag, int alloc)

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -232,12 +232,12 @@ void KSpace::ev_setup(int eflag, int vflag, int alloc)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_ATOM;
 
   vflag_either = vflag;
-  vflag_global = vflag % 4;
-  vflag_atom = vflag / 4;
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag / 4; // TODO
 
   if (eflag_atom || vflag_atom) evflag_atom = 1;
   else evflag_atom = 0;

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -88,7 +88,8 @@ KSpace::KSpace(LAMMPS *lmp) : Pointers(lmp)
   maxeatom = maxvatom = 0;
   eatom = nullptr;
   vatom = nullptr;
-
+  centroidstressatom = NOTAVAIL;
+  
   execution_space = Host;
   datamask_read = ALL_MASK;
   datamask_modify = ALL_MASK;
@@ -216,13 +217,14 @@ void KSpace::pair_check()
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise 0:
-     evflag       = 1 if any bits of eflag or vflag are set
-     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
-     eflag_either = 1 if eflag_global or eflag_atom is set
-     vflag_global = 1 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag set
-     vflag_either = 1 if vflag_global or vflag_atom is set
+     evflag       != 0 if any bits of eflag or vflag are set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_either != 0 if eflag_global or eflag_atom is set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
+                       no current support for centroid stress
+     vflag_either != 0 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
 
 void KSpace::ev_setup(int eflag, int vflag, int alloc)
@@ -237,7 +239,7 @@ void KSpace::ev_setup(int eflag, int vflag, int alloc)
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
-  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
+  vflag_atom = vflag & VIRIAL_ATOM;
 
   if (eflag_atom || vflag_atom) evflag_atom = 1;
   else evflag_atom = 0;

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -80,6 +80,11 @@ class KSpace : protected Pointers {
 
   int group_group_enable;         // 1 if style supports group/group calculation
 
+  int centroidstressflag;        // centroid stress compared to two-body stress
+                                 // CENTROID_SAME = same as two-body stress
+                                 // CENTROID_AVAIL = different and implemented
+                                 // CENTROID_NOTAVAIL = different, not yet implemented
+
   // KOKKOS host/device flag and data masks
 
   ExecutionSpace execution_space;

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -798,25 +798,20 @@ void Min::ev_setup()
 }
 
 /* ----------------------------------------------------------------------
-  TODO: comment
-
    set eflag,vflag for current iteration
    invoke matchstep() on all timestep-dependent computes to clear their arrays
    eflag/vflag based on computes that need info on this ntimestep
    always set eflag_global = 1, since need energy every iteration
-   eflag = 0 = no energy computation
-   eflag = 1 = global energy only
-   eflag = 2 = per-atom energy only
-   eflag = 3 = both global and per-atom energy
-   vflag = 0 = no virial computation (pressure)
-   vflag = 1 = global virial with pair portion via sum of pairwise interactions
-   vflag = 2 = global virial with pair portion via F dot r including ghosts
-   vflag = 4 = per-atom virial only
-   vflag = 5 or 6 = both global and per-atom virial
-   vflag = 8 = per-atom centroid virial only
-   vflag = 9 or 10 = both global and per-atom centroid virial
-   vflag = 12 = both per-atom virial and per-atom centroid virial
-   vflag = 13 or 15 = global, per-atom virial and per-atom centroid virial
+   eflag: set any or no bits
+     ENERGY_GLOBAL bit for global energy
+     ENERGY_ATOM   bit for per-atom energy
+   vflag: set any or no bits, but GLOBAL/FDOTR bit cannot both be set
+     VIRIAL_PAIR     bit for global virial as sum of pairwise terms
+     VIRIAL_FDOTR    bit for global virial via F dot r
+     VIRIAL_ATOM     bit for per-atom virial
+     VIRIAL_CENTROID bit for per-atom centroid virial
+   all force components (pair,bond,angle,...,kspace) use eflag/vflag
+     in their ev_setup() method to set local energy/virial flags
 ------------------------------------------------------------------------- */
 
 void Min::ev_set(bigint ntimestep)

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -798,6 +798,8 @@ void Min::ev_setup()
 }
 
 /* ----------------------------------------------------------------------
+  TODO: comment
+
    set eflag,vflag for current iteration
    invoke matchstep() on all timestep-dependent computes to clear their arrays
    eflag/vflag based on computes that need info on this ntimestep
@@ -829,7 +831,7 @@ void Min::ev_set(bigint ntimestep)
   int eflag_atom = 0;
   for (i = 0; i < nelist_atom; i++)
     if (elist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) eflag_atom = 2;
+  if (flag) eflag_atom = ENERGY_ATOM;
 
   if (eflag_global) update->eflag_global = update->ntimestep;
   if (eflag_atom) update->eflag_atom = update->ntimestep;
@@ -845,13 +847,13 @@ void Min::ev_set(bigint ntimestep)
   int vflag_atom = 0;
   for (i = 0; i < nvlist_atom; i++)
     if (vlist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) vflag_atom = 4;
+  if (flag) vflag_atom = VIRIAL_ATOM;
 
   flag = 0;
   int cvflag_atom = 0;
   for (i = 0; i < ncvlist_atom; i++)
     if (cvlist_atom[i]->matchstep(ntimestep)) flag = 1;
-  if (flag) cvflag_atom = 8;
+  if (flag) cvflag_atom = VIRIAL_CENTROID;
 
   if (vflag_global) update->vflag_global = update->ntimestep;
   if (vflag_atom || cvflag_atom) update->vflag_atom = update->ntimestep;

--- a/src/min.cpp
+++ b/src/min.cpp
@@ -144,11 +144,12 @@ void Min::init()
   requestor = nullptr;
 
   // virial_style:
-  // 1 if computed explicitly by pair->compute via sum over pair interactions
-  // 2 if computed implicitly by pair->virial_compute via sum over ghost atoms
+  // VIRIAL_PAIR if computed explicitly in pair via sum over pair interactions
+  // VIRIAL_FDOTR if computed implicitly in pair by
+  //   virial_fdotr_compute() via sum over ghosts
 
-  if (force->newton_pair) virial_style = 2;
-  else virial_style = 1;
+  if (force->newton_pair) virial_style = VIRIAL_FDOTR;
+  else virial_style = VIRIAL_PAIR;
 
   // setup lists of computes for global and per-atom PE and pressure
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -869,7 +869,7 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
     }
   }
 
-  // if vflag_global = VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS and pair::compute() calls virial_fdotr_compute()
+  // if vflag_global = VIRIAL_FDOTR and pair::compute() calls virial_fdotr_compute()
   // compute global virial via (F dot r) instead of via pairwise summation
   // unset other flags as appropriate
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -77,7 +77,7 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   ewaldflag = pppmflag = msmflag = dispersionflag =
     tip4pflag = dipoleflag = spinflag = 0;
   reinitflag = 1;
-  centroidstressflag = CENTROID_SAME;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   // pair_modify settings
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -785,7 +785,7 @@ void Pair::del_tally_callback(Compute *ptr)
      eflag_either = 1 if eflag_global or eflag_atom is set
      vflag_global = 1 if VIRIAL_PAIR bit of vflag set
      vflag_global = 2 if VIRIAL_FDOTR bit of vflag set
-     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     vflag_atom   = 1 if VIRIAL_ATOM bit of vflag set
      vflag_atom   = 1 if VIRIAL_CENTROID bit of vflag set
                       and centroidstressflag != CENTROID_AVAIL
      cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
@@ -805,10 +805,10 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
 
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
-  eflag_atom = eflag & ENERGY_PERATOM;
+  eflag_atom = eflag & ENERGY_ATOM;
 
-  vflag_global = vflag & (VIRIAL_TALLY | VIRIAL_FDOTR);
-  vflag_atom = vflag & VIRIAL_PERATOM;
+  vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
+  vflag_atom = vflag & VIRIAL_ATOM;
   cvflag_atom = 0;
 
   if (vflag & VIRIAL_CENTROID) {

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -786,14 +786,14 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
   evflag = 1;
 
   eflag_either = eflag;
-  eflag_global = eflag % 2;
-  eflag_atom = eflag / 2;
+  eflag_global = eflag & ENERGY_GLOBAL;
+  eflag_atom = eflag & ENERGY_PER_ATOM;
 
-  vflag_global = vflag % 4;
-  vflag_atom = vflag & 4;
+  vflag_global = vflag & (VIRIAL_GLOBAL_PW_SUM | VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS);
+  vflag_atom = vflag & VIRIAL_PER_ATOM;
   cvflag_atom = 0;
 
-  if (vflag & 8) {
+  if (vflag & VIRIAL_PER_ATOM_CENTROID) {
     if (centroidstressflag & 2) {
       cvflag_atom = 1;
     } else {
@@ -869,11 +869,11 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
     }
   }
 
-  // if vflag_global = 2 and pair::compute() calls virial_fdotr_compute()
+  // if vflag_global = VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS and pair::compute() calls virial_fdotr_compute()
   // compute global virial via (F dot r) instead of via pairwise summation
   // unset other flags as appropriate
 
-  if (vflag_global == 2 && no_virial_fdotr_compute == 0) {
+  if (vflag_global == VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS && no_virial_fdotr_compute == 0) {
     vflag_fdotr = 1;
     vflag_global = 0;
     if (vflag_atom == 0 && cvflag_atom == 0) vflag_either = 0;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -812,13 +812,13 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
   cvflag_atom = 0;
 
   if (vflag & VIRIAL_CENTROID) {
-    if (centroidstressflag & 2) {
+    if (centroidstressflag & CENTROID_AVAIL) {
       cvflag_atom = 1;
     } else {
       vflag_atom = 1;
     }
     // extra check, because both bits might be set
-    if (centroidstressflag & 1) vflag_atom = 1;
+    if (centroidstressflag & CENTROID_SAME) vflag_atom = 1;
   }
 
   vflag_either = vflag_global || vflag_atom;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -815,7 +815,8 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
   vflag_either = vflag_global || vflag_atom || cvflag_atom;
 
   evflag = eflag_either || vflag_either;
-
+  if (!evflag) return;
+  
   // reallocate per-atom arrays if necessary
 
   if (eflag_atom && atom->nmax > maxeatom) {

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -787,13 +787,13 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
 
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
-  eflag_atom = eflag & ENERGY_PER_ATOM;
+  eflag_atom = eflag & ENERGY_PERATOM;
 
-  vflag_global = vflag & (VIRIAL_GLOBAL_PW_SUM | VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS);
-  vflag_atom = vflag & VIRIAL_PER_ATOM;
+  vflag_global = vflag & (VIRIAL_TALLY | VIRIAL_FDOTR);
+  vflag_atom = vflag & VIRIAL_PERATOM;
   cvflag_atom = 0;
 
-  if (vflag & VIRIAL_PER_ATOM_CENTROID) {
+  if (vflag & VIRIAL_CENTROID) {
     if (centroidstressflag & 2) {
       cvflag_atom = 1;
     } else {
@@ -873,7 +873,7 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
   // compute global virial via (F dot r) instead of via pairwise summation
   // unset other flags as appropriate
 
-  if (vflag_global == VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS && no_virial_fdotr_compute == 0) {
+  if (vflag_global == VIRIAL_FDOTR && no_virial_fdotr_compute == 0) {
     vflag_fdotr = 1;
     vflag_global = 0;
     if (vflag_atom == 0 && cvflag_atom == 0) vflag_either = 0;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -74,9 +74,10 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   setflag = nullptr;
   cutsq = nullptr;
 
-  ewaldflag = pppmflag = msmflag = dispersionflag = tip4pflag = dipoleflag = spinflag = 0;
+  ewaldflag = pppmflag = msmflag = dispersionflag =
+    tip4pflag = dipoleflag = spinflag = 0;
   reinitflag = 1;
-  centroidstressflag = 4;
+  centroidstressflag = CENTROID_SAME;
 
   // pair_modify settings
 
@@ -776,7 +777,24 @@ void Pair::del_tally_callback(Compute *ptr)
 
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
-   see integrate::ev_set() for values of eflag (0-3) and vflag (0-6)
+   see integrate::ev_set() for bitwise settings of eflag/vflag
+   set the following flags, values are otherwise 0:
+     evflag       = 1 if any bits of eflag or vflag are set
+     eflag_global = 1 if ENERGY_GLOBAL bit of eflag set
+     eflag_atom   = 1 if ENERGY_ATOM bit of eflag set
+     eflag_either = 1 if eflag_global or eflag_atom is set
+     vflag_global = 1 if VIRIAL_PAIR bit of vflag set
+     vflag_global = 2 if VIRIAL_FDOTR bit of vflag set
+     vflag_atom   = 1 if VIRIAL_PERATOM bit of vflag set
+     vflag_atom   = 1 if VIRIAL_CENTROID bit of vflag set
+                      and centroidstressflag != CENTROID_AVAIL
+     cvflag_atom  = 1 if VIRIAL_CENTROID bit of vflag set
+                      and centroidstressflag = CENTROID_AVAIL
+     vflag_either = 1 if any of vflag_global, vflag_atom, cvflag_atom is set
+   centroidstressflag is set by the pair style to one of these values:
+     CENTROID_SAME = same as two-body stress
+     CENTROID_AVAIL = different and implemented
+     CENTROID_NOTAVAIL = different but not yet implemented
 ------------------------------------------------------------------------- */
 
 void Pair::ev_setup(int eflag, int vflag, int alloc)

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -778,7 +778,7 @@ void Pair::del_tally_callback(Compute *ptr)
 /* ----------------------------------------------------------------------
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
-   set the following flags, values are otherwise 0:
+   set the following flags, values are otherwise set to 0:
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
      eflag_either != 0 if eflag_global or eflag_atom is set
@@ -811,6 +811,7 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
   if (vflag & VIRIAL_FDOTR && no_virial_fdotr_compute == 0) vflag_fdotr = 1;
   vflag_atom = vflag & VIRIAL_ATOM;
   if (vflag & VIRIAL_CENTROID && centroidstressflag != CENTROID_AVAIL) vflag_atom = 1;
+  cvflag_atom = 0;
   if (vflag & VIRIAL_CENTROID && centroidstressflag == CENTROID_AVAIL) cvflag_atom = 1;
   vflag_either = vflag_global || vflag_atom || cvflag_atom;
 

--- a/src/pair.h
+++ b/src/pair.h
@@ -68,10 +68,10 @@ class Pair : protected Pointers {
   int spinflag;                  // 1 if compatible with spin solver
   int reinitflag;                // 1 if compatible with fix adapt and alike
 
-  int centroidstressflag;        // compatibility with centroid atomic stress
-                                 // 1 if same as two-body atomic stress
-                                 // 2 if implemented and different from two-body
-                                 // 4 if not compatible/implemented
+  int centroidstressflag;        // centroid atomic compared to two-body stress
+                                 // CENTROID_SAME = same as two-body stress
+                                 // CENTROID_AVAIL = different and implemented
+                                 // CENTROID_NOTAVAIL = different, not yet implemented
 
   int tail_flag;                 // pair_modify flag for LJ tail correction
   double etail,ptail;            // energy/pressure tail corrections

--- a/src/pair.h
+++ b/src/pair.h
@@ -68,7 +68,7 @@ class Pair : protected Pointers {
   int spinflag;                  // 1 if compatible with spin solver
   int reinitflag;                // 1 if compatible with fix adapt and alike
 
-  int centroidstressflag;        // centroid atomic compared to two-body stress
+  int centroidstressflag;        // centroid stress compared to two-body stress
                                  // CENTROID_SAME = same as two-body stress
                                  // CENTROID_AVAIL = different and implemented
                                  // CENTROID_NOTAVAIL = different, not yet implemented

--- a/src/pair.h
+++ b/src/pair.h
@@ -18,6 +18,20 @@
 
 namespace LAMMPS_NS {
 
+enum {
+  ENERGY_NO_COMPUTATION  = 0x00,
+  ENERGY_GLOBAL          = 0x01,
+  ENERGY_PER_ATOM        = 0x02
+};
+
+enum {
+  VIRIAL_NO_COMPUTATION           = 0x00,
+  VIRIAL_GLOBAL_PW_SUM            = 0x01,
+  VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS = 0x02,
+  VIRIAL_PER_ATOM                 = 0x04,
+  VIRIAL_PER_ATOM_CENTROID        = 0x08
+};
+
 class Pair : protected Pointers {
   friend class AngleSDK;
   friend class AngleSDKOMP;

--- a/src/pair.h
+++ b/src/pair.h
@@ -18,20 +18,6 @@
 
 namespace LAMMPS_NS {
 
-enum {
-  ENERGY_NO_COMPUTATION  = 0x00,
-  ENERGY_GLOBAL          = 0x01,
-  ENERGY_PER_ATOM        = 0x02
-};
-
-enum {
-  VIRIAL_NO_COMPUTATION           = 0x00,
-  VIRIAL_GLOBAL_PW_SUM            = 0x01,
-  VIRIAL_GLOBAL_PW_FDOTR_W_GHOSTS = 0x02,
-  VIRIAL_PER_ATOM                 = 0x04,
-  VIRIAL_PER_ATOM_CENTROID        = 0x08
-};
-
 class Pair : protected Pointers {
   friend class AngleSDK;
   friend class AngleSDKOMP;

--- a/src/pair_beck.cpp
+++ b/src/pair_beck.cpp
@@ -26,15 +26,12 @@
 #include "error.h"
 #include "math_special.h"
 
-
 using namespace LAMMPS_NS;
 using namespace MathSpecial;
 
 /* ---------------------------------------------------------------------- */
 
-PairBeck::PairBeck(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = CENTROID_SAME;
-}
+PairBeck::PairBeck(LAMMPS *lmp) : Pair(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/pair_beck.cpp
+++ b/src/pair_beck.cpp
@@ -33,7 +33,7 @@ using namespace MathSpecial;
 /* ---------------------------------------------------------------------- */
 
 PairBeck::PairBeck(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_buck.cpp
+++ b/src/pair_buck.cpp
@@ -32,7 +32,6 @@ using namespace MathConst;
 PairBuck::PairBuck(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_buck.cpp
+++ b/src/pair_buck.cpp
@@ -32,7 +32,7 @@ using namespace MathConst;
 PairBuck::PairBuck(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_buck_coul_cut.cpp
+++ b/src/pair_buck_coul_cut.cpp
@@ -36,7 +36,7 @@ using namespace MathConst;
 PairBuckCoulCut::PairBuckCoulCut(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_buck_coul_cut.cpp
+++ b/src/pair_buck_coul_cut.cpp
@@ -36,7 +36,6 @@ using namespace MathConst;
 PairBuckCoulCut::PairBuckCoulCut(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_coul_cut.cpp
+++ b/src/pair_coul_cut.cpp
@@ -29,7 +29,7 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 PairCoulCut::PairCoulCut(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_coul_cut.cpp
+++ b/src/pair_coul_cut.cpp
@@ -28,9 +28,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairCoulCut::PairCoulCut(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = CENTROID_SAME;
-}
+PairCoulCut::PairCoulCut(LAMMPS *lmp) : Pair(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/pair_coul_dsf.cpp
+++ b/src/pair_coul_dsf.cpp
@@ -44,7 +44,7 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 PairCoulDSF::PairCoulDSF(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_coul_dsf.cpp
+++ b/src/pair_coul_dsf.cpp
@@ -29,7 +29,6 @@
 #include "math_const.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
@@ -43,9 +42,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-PairCoulDSF::PairCoulDSF(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = CENTROID_SAME;
-}
+PairCoulDSF::PairCoulDSF(LAMMPS *lmp) : Pair(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/pair_coul_wolf.cpp
+++ b/src/pair_coul_wolf.cpp
@@ -36,7 +36,6 @@ using namespace MathConst;
 PairCoulWolf::PairCoulWolf(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;        // NOTE: single() method below is not yet correct
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_coul_wolf.cpp
+++ b/src/pair_coul_wolf.cpp
@@ -36,7 +36,7 @@ using namespace MathConst;
 PairCoulWolf::PairCoulWolf(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;        // NOTE: single() method below is not yet correct
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -417,7 +417,7 @@ void PairHybrid::flags()
   for (m = 0; m < nstyles; m++) {
     if (styles[m]->centroidstressflag == CENTROID_NOTAVAIL)
       centroidstressflag == CENTROID_NOTAVAIL;
-    if (centroidstyle == CENTROID_SAME &&
+    if (centroidstressflag == CENTROID_SAME &&
 	styles[m]->centroidstressflag == CENTROID_AVAIL)
       centroidstressflag == CENTROID_AVAIL;
   }

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -82,10 +82,10 @@ PairHybrid::~PairHybrid()
 /* ----------------------------------------------------------------------
   call each sub-style's compute() or compute_outer() function
   accumulate sub-style global/peratom energy/virial in hybrid
-  for global vflag = 1:
+  for global vflag = VIRIAL_PAIR:
     each sub-style computes own virial[6]
     sum sub-style virial[6] to hybrid's virial[6]
-  for global vflag = 2:
+  for global vflag = VIRIAL_FDOTR:
     call sub-style with adjusted vflag to prevent it calling
       virial_fdotr_compute()
     hybrid calls virial_fdotr_compute() on final accumulated f
@@ -96,20 +96,20 @@ void PairHybrid::compute(int eflag, int vflag)
   int i,j,m,n;
 
   // if no_virial_fdotr_compute is set and global component of
-  //   incoming vflag = 2, then
-  // reset vflag as if global component were 1
+  //   incoming vflag = VIRIAL_FDOTR, then
+  // reset vflag as if global component were VIRIAL_PAIR
   // necessary since one or more sub-styles cannot compute virial as F dot r
 
-  if (no_virial_fdotr_compute && vflag % 4 == 2) vflag = 1 + vflag/4 * 4;
+  if (no_virial_fdotr_compute && (vflag & VIRIAL_FDOTR)) vflag = VIRIAL_PAIR | (vflag & ~VIRIAL_FDOTR);
 
   ev_init(eflag,vflag);
 
-  // check if global component of incoming vflag = 2
-  // if so, reset vflag passed to substyle as if it were 0
+  // check if global component of incoming vflag = VIRIAL_FDOTR
+  // if so, reset vflag passed to substyle as if it were VIRIAL_NONE
   // necessary so substyle will not invoke virial_fdotr_compute()
 
   int vflag_substyle;
-  if (vflag % 4 == 2) vflag_substyle = vflag/4 * 4;
+  if (vflag & VIRIAL_FDOTR) vflag_substyle = vflag & ~VIRIAL_FDOTR;
   else vflag_substyle = vflag;
 
   double *saved_special = save_special();

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -416,10 +416,10 @@ void PairHybrid::flags()
 
   for (m = 0; m < nstyles; m++) {
     if (styles[m]->centroidstressflag == CENTROID_NOTAVAIL)
-      centroidstressflag == CENTROID_NOTAVAIL;
+      centroidstressflag = CENTROID_NOTAVAIL;
     if (centroidstressflag == CENTROID_SAME &&
 	styles[m]->centroidstressflag == CENTROID_AVAIL)
-      centroidstressflag == CENTROID_AVAIL;
+      centroidstressflag = CENTROID_AVAIL;
   }
 }
 

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -45,7 +45,7 @@ PairHybrid::PairHybrid(LAMMPS *lmp) : Pair(lmp),
 
   // assume pair hybrid always supports centroid atomic stress,
   // so that cflag_atom gets set when needed
-  centroidstressflag = 2;
+  centroidstressflag = CENTROID_AVAIL;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -168,7 +168,7 @@ void PairHybrid::compute(int eflag, int vflag)
     if (cvflag_atom) {
       n = atom->nlocal;
       if (force->newton_pair) n += atom->nghost;
-      if (styles[m]->centroidstressflag & 2) {
+      if (styles[m]->centroidstressflag & CENTROID_AVAIL) {
         double **cvatom_substyle = styles[m]->cvatom;
         for (i = 0; i < n; i++)
           for (j = 0; j < 9; j++)
@@ -401,7 +401,7 @@ void PairHybrid::flags()
     if (styles[m]->dispersionflag) dispersionflag = 1;
     if (styles[m]->tip4pflag) tip4pflag = 1;
     if (styles[m]->compute_flag) compute_flag = 1;
-    if (styles[m]->centroidstressflag & 4) centroidstressflag |= 4;
+    if (styles[m]->centroidstressflag & CENTROID_NOTAVAIL) centroidstressflag |= CENTROID_NOTAVAIL;
   }
   single_enable = (single_enable == nstyles) ? 1 : 0;
   respa_enable = (respa_enable == nstyles) ? 1 : 0;

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -101,7 +101,7 @@ void PairHybrid::compute(int eflag, int vflag)
   ev_init(eflag,vflag);
 
   // check if global component of incoming vflag = VIRIAL_FDOTR
-  // if so, reset vflag passed to substyle as if it were VIRIAL_NONE
+  // if so, reset vflag passed to substyle so VIRIAL_FDOTR is turned off
   // necessary so substyle will not invoke virial_fdotr_compute()
 
   int vflag_substyle;

--- a/src/pair_lj_cubic.cpp
+++ b/src/pair_lj_cubic.cpp
@@ -33,7 +33,7 @@ using namespace PairLJCubicConstants;
 /* ---------------------------------------------------------------------- */
 
 PairLJCubic::PairLJCubic(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cubic.cpp
+++ b/src/pair_lj_cubic.cpp
@@ -32,9 +32,7 @@ using namespace PairLJCubicConstants;
 
 /* ---------------------------------------------------------------------- */
 
-PairLJCubic::PairLJCubic(LAMMPS *lmp) : Pair(lmp) {
-  centroidstressflag = CENTROID_SAME;
-}
+PairLJCubic::PairLJCubic(LAMMPS *lmp) : Pair(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/pair_lj_cut.cpp
+++ b/src/pair_lj_cut.cpp
@@ -41,7 +41,7 @@ PairLJCut::PairLJCut(LAMMPS *lmp) : Pair(lmp)
 {
   respa_enable = 1;
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cut.cpp
+++ b/src/pair_lj_cut.cpp
@@ -31,7 +31,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
@@ -41,7 +40,6 @@ PairLJCut::PairLJCut(LAMMPS *lmp) : Pair(lmp)
 {
   respa_enable = 1;
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cut_coul_cut.cpp
+++ b/src/pair_lj_cut_coul_cut.cpp
@@ -33,7 +33,7 @@ using namespace MathConst;
 PairLJCutCoulCut::PairLJCutCoulCut(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cut_coul_cut.cpp
+++ b/src/pair_lj_cut_coul_cut.cpp
@@ -33,7 +33,6 @@ using namespace MathConst;
 PairLJCutCoulCut::PairLJCutCoulCut(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cut_coul_dsf.cpp
+++ b/src/pair_lj_cut_coul_dsf.cpp
@@ -46,7 +46,7 @@ using namespace MathConst;
 PairLJCutCoulDSF::PairLJCutCoulDSF(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cut_coul_dsf.cpp
+++ b/src/pair_lj_cut_coul_dsf.cpp
@@ -46,7 +46,6 @@ using namespace MathConst;
 PairLJCutCoulDSF::PairLJCutCoulDSF(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cut_coul_wolf.cpp
+++ b/src/pair_lj_cut_coul_wolf.cpp
@@ -37,7 +37,6 @@ PairLJCutCoulWolf::PairLJCutCoulWolf(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_cut_coul_wolf.cpp
+++ b/src/pair_lj_cut_coul_wolf.cpp
@@ -37,7 +37,7 @@ PairLJCutCoulWolf::PairLJCutCoulWolf(LAMMPS *lmp) : Pair(lmp)
 {
   single_enable = 0;
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_expand.cpp
+++ b/src/pair_lj_expand.cpp
@@ -32,7 +32,6 @@ using namespace MathConst;
 PairLJExpand::PairLJExpand(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_expand.cpp
+++ b/src/pair_lj_expand.cpp
@@ -32,7 +32,7 @@ using namespace MathConst;
 PairLJExpand::PairLJExpand(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_gromacs_coul_gromacs.cpp
+++ b/src/pair_lj_gromacs_coul_gromacs.cpp
@@ -26,7 +26,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
@@ -34,7 +33,6 @@ using namespace LAMMPS_NS;
 PairLJGromacsCoulGromacs::PairLJGromacsCoulGromacs(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_gromacs_coul_gromacs.cpp
+++ b/src/pair_lj_gromacs_coul_gromacs.cpp
@@ -34,7 +34,7 @@ using namespace LAMMPS_NS;
 PairLJGromacsCoulGromacs::PairLJGromacsCoulGromacs(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_smooth.cpp
+++ b/src/pair_lj_smooth.cpp
@@ -33,7 +33,6 @@ using namespace LAMMPS_NS;
 PairLJSmooth::PairLJSmooth(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_smooth.cpp
+++ b/src/pair_lj_smooth.cpp
@@ -33,7 +33,7 @@ using namespace LAMMPS_NS;
 PairLJSmooth::PairLJSmooth(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_smooth_linear.cpp
+++ b/src/pair_lj_smooth_linear.cpp
@@ -25,14 +25,12 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
 PairLJSmoothLinear::PairLJSmoothLinear(LAMMPS *lmp) : Pair(lmp) {
   single_hessian_enable = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_lj_smooth_linear.cpp
+++ b/src/pair_lj_smooth_linear.cpp
@@ -32,7 +32,7 @@ using namespace LAMMPS_NS;
 
 PairLJSmoothLinear::PairLJSmoothLinear(LAMMPS *lmp) : Pair(lmp) {
   single_hessian_enable = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_morse.cpp
+++ b/src/pair_morse.cpp
@@ -30,7 +30,7 @@ using namespace LAMMPS_NS;
 PairMorse::PairMorse(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_morse.cpp
+++ b/src/pair_morse.cpp
@@ -22,7 +22,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
@@ -30,7 +29,6 @@ using namespace LAMMPS_NS;
 PairMorse::PairMorse(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_ufm.cpp
+++ b/src/pair_ufm.cpp
@@ -28,7 +28,6 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
@@ -36,7 +35,6 @@ using namespace LAMMPS_NS;
 PairUFM::PairUFM(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair_ufm.cpp
+++ b/src/pair_ufm.cpp
@@ -36,7 +36,7 @@ using namespace LAMMPS_NS;
 PairUFM::PairUFM(LAMMPS *lmp) : Pair(lmp)
 {
   writedata = 1;
-  centroidstressflag = 1;
+  centroidstressflag = CENTROID_SAME;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/respa.cpp
+++ b/src/respa.cpp
@@ -311,9 +311,10 @@ void Respa::init()
     if (force->pair && force->pair->respa_enable == 0)
       error->all(FLERR,"Pair style does not support rRESPA inner/middle/outer");
 
-  // virial_style = 1 (explicit) since never computed implicitly like Verlet
+  // virial_style = VIRIAL_PAIR (explicit)
+  //   since never computed implicitly with virial_fdotr_compute() like Verlet
 
-  virial_style = 1;
+  virial_style = VIRIAL_PAIR;
 
   // setup lists of computes for global and per-atom PE and pressure
 

--- a/src/verlet.cpp
+++ b/src/verlet.cpp
@@ -54,11 +54,12 @@ void Verlet::init()
     error->warning(FLERR,"No fixes defined, atoms won't move");
 
   // virial_style:
-  // 1 if computed explicitly by pair->compute via sum over pair interactions
-  // 2 if computed implicitly by pair->virial_fdotr_compute via sum over ghosts
+  // VIRIAL_PAIR if computed explicitly in pair via sum over pair interactions
+  // VIRIAL_FDOTR if computed implicitly in pair by
+  //   virial_fdotr_compute() via sum over ghosts
 
-  if (force->newton_pair) virial_style = 2;
-  else virial_style = 1;
+  if (force->newton_pair) virial_style = VIRIAL_FDOTR;
+  else virial_style = VIRIAL_PAIR;
 
   // setup lists of computes for global and per-atom PE and pressure
 


### PR DESCRIPTION
**Summary**

Define energy and virial constants in `force.h` to reduce magic numbers in code.
Also defines constants `CENTROID_SAME`, `CENTROID_AVAIL` and `CENTROID_NOTAVAIL`.

**Related Issue(s)**

#2469 

**Author(s)**

Richard Berger (Temple U) @rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


