### PR TITLE
Very minor bug fix for NEB

### DIFF
--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -490,9 +490,13 @@ void NEB::readfile(char *file, int flag)
           x[m][1] += fraction*dely;
           x[m][2] += fraction*delz;
         } else {
-          x[m][0] = xx;
-          x[m][1] = yy;
-          x[m][2] = zz;
+          delx = xx - x[m][0];
+          dely = yy - x[m][1];
+          delz = zz - x[m][2];
+          domain->minimum_image(delx,dely,delz);
+          x[m][0] += delx;
+          x[m][1] += dely;
+          x[m][2] += delz;
         }
       }
 

--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -69,9 +69,7 @@ NEB::NEB(LAMMPS *lmp, double etol_in, double ftol_in, int n1steps_in,
   MPI_Comm_rank(world,&me);
 
   // generate linear interpolate replica
-
   double fraction = ireplica/(nreplica-1.0);
-
   double **x = atom->x;
   int nlocal = atom->nlocal;
 
@@ -465,13 +463,12 @@ void NEB::readfile(char *file, int flag)
       // adjust atom coord based on replica fraction
       // for flag = 0, interpolate for intermediate and final replicas
       // for flag = 1, replace existing coord with new coord
-      // ignore image flags of final x
-      // for interpolation:
-      //   new x is displacement from old x via minimum image convention
-      //   if final x is across periodic boundary:
-      //     new x may be outside box
-      //     will be remapped back into box when simulation starts
-      //     its image flags will then be adjusted
+      // ignore image flags of replica x
+      // displacement from first replica is via minimum image convention
+      // if x of some replica is across periodic boundary:
+      //   new x may be outside box
+      //   will be remapped back into box when simulation starts
+      //   its image flags will then be adjusted
 
       tag = ATOTAGINT(values[0]);
       m = atom->map(tag);
@@ -481,19 +478,17 @@ void NEB::readfile(char *file, int flag)
         yy = atof(values[2]);
         zz = atof(values[3]);
 
+        delx = xx - x[m][0];
+        dely = yy - x[m][1];
+        delz = zz - x[m][2];
+
+        domain->minimum_image(delx,dely,delz);
+
         if (flag == 0) {
-          delx = xx - x[m][0];
-          dely = yy - x[m][1];
-          delz = zz - x[m][2];
-          domain->minimum_image(delx,dely,delz);
           x[m][0] += fraction*delx;
           x[m][1] += fraction*dely;
           x[m][2] += fraction*delz;
         } else {
-          delx = xx - x[m][0];
-          dely = yy - x[m][1];
-          delz = zz - x[m][2];
-          domain->minimum_image(delx,dely,delz);
           x[m][0] += delx;
           x[m][1] += dely;
           x[m][2] += delz;


### PR DESCRIPTION
**Summary**

 A very minor fix for the NEB routine, when reading in an initial path with "each". The pbc correction is not applied, leading to an issue when calculating barrier corrections of the form "force * displacement" with compute displace/atoms. The very minor proposed change simply ensures that the initial images are all a pbc minimum displacement from the starting configuration. 


**Author(s)**
Tom D Swinburne, CNRS / Aix-Marseille University, swinburne at cinam.univ-mrs.fr

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
 None forseen

**Implementation Notes**

**Post Submission Checklist**
- [X ] The feature or features in this pull request is complete
- [ X] Licensing information is complete
- [ X] Corresponding author information is complete
- [ X] The source code follows the LAMMPS formatting guidelines
- [ n/a] Suitable new documentation files and/or updates to the existing docs are included
- [n/a ] The added/updated documentation is integrated and tested with the documentation build system
- [X ] The feature has been verified to work with the conventional build system
- [X ] The feature has been verified to work with the CMake based build system
- [ n/a] Suitable tests have been added to the unittest tree.
- [ n/a] A package specific README file has been included or updated
- [ n/a] One or more example input decks are included

**Further Information, Files, and Links**



