### PR TITLE
Set ghost atom groups for simple dynamic regions to enable partial use with tally computes

### DIFF
--- a/src/fix_group.h
+++ b/src/fix_group.h
@@ -38,6 +38,8 @@ class FixGroup : public Fix {
  private:
   int gbit,gbitinverse;
   int regionflag,varflag,propflag,typeflag;
+  int ghostflag; // 1 if also sets masks of ghost atoms
+  int initflag;  // 1 if groups are set on initialization
   int iregion,ivar,iprop;
   char *idregion,*idvar,*idprop;
   class Region *region;


### PR DESCRIPTION
**Summary**

Enables dynamic groups with only region constraints to set the groups of their ghost atoms via a new "ghost yes" option. This enables the USER-TALLY computes to work correctly with such dynamic groups. There is also an "init yes" option added to force the setting of groups on definition. This PR is basically a proof of concept as I want to know if it would be possible to implement such functions in LAMMPS and if I'm missing any edge cases.

**Related Issue(s)**

A short discussion in #1521.

**Author(s)**

Donatas Surblys (Tohoku University) surblys.donatas at gmail dot com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Full backward compatibility

**Implementation Notes**

As very briefly discussed in #1521, I'd really like to have the USER-TALLY computes work with dynamic groups.  I have an in-house solution, where a custom fix (not in this PR) sets the required dynamic groups in the pre_force phase and does the necessary forward communication, but for dynamic groups with only region constraints no inter-process communication should be needed, as the constraints are known globally. This PR simply enables the setting of atom masks on ghost atoms when the "ghost yes" option is set. The effect of this can be seen with the sample script:
```
units real
pair_style lj/cut 12
region box block -15 15 -15 15 -15 15
create_box 1 box
pair_coeff * * 1 3
mass * 100
create_atoms 1 random 10 101 box
velocity all create 100 101
region inf block INF INF INF INF INF INF

group dall dynamic all region inf every 1
group gall dynamic all region inf every 1 ghost yes init yes

fix integ all nve

compute   pe  all pe
compute stpe  all pe/tally  all
compute dtpe dall pe/tally dall
compute gtpe gall pe/tally gall

thermo 1
thermo_style custom step c_pe c_stpe c_dtpe c_gtpe
thermo_modify format float %.17e

run 2
```
NOTE: `dynamic_group_allow = 1` needs to be set in compute_pe_tally.cpp (not in PR).

This results in:
> Step c_pe c_stpe c_dtpe c_gtpe 
>        0 -7.47091469703964117e-01 -7.47091469703963784e-01 0.00000000000000000e+00 -7.47091469703963784e-01 
>        1 -7.47015326232009835e-01 -7.47015326232009946e-01 -7.31816520122599345e-01 -7.47015326232009946e-01 
>        2 -7.46943164797733816e-01 -7.46943164797734038e-01 -7.31733386758632198e-01 -7.46943164797734038e-01

Notice, how dynamic groups with "ghost yes" give correct potential energies.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


