### PR TITLE
Fix invalid result when dihedral quadratic angle is > pi or < -pi

### DIFF
--- a/src/USER-MISC/dihedral_quadratic.cpp
+++ b/src/USER-MISC/dihedral_quadratic.cpp
@@ -195,6 +195,8 @@ void DihedralQuadratic::compute(int eflag, int vflag)
     siinv = 1.0/si;
 
     double dphi = phi-phi0[type];
+    if (dphi > MY_PI) dphi -= 2*MY_PI;
+    else if (dphi < -MY_PI) dphi += 2*MY_PI;
     p = k[type]*dphi;
     pd = - 2.0 * p * siinv;
     p = p * dphi;

--- a/src/USER-OMP/dihedral_quadratic_omp.cpp
+++ b/src/USER-OMP/dihedral_quadratic_omp.cpp
@@ -23,11 +23,13 @@
 #include "neighbor.h"
 #include "force.h"
 #include "update.h"
+#include "math_const.h"
 #include "error.h"
 
 
 #include "suffix.h"
 using namespace LAMMPS_NS;
+using namespace MathConst;
 
 #define TOLERANCE 0.05
 #define SMALL     0.001
@@ -218,6 +220,8 @@ void DihedralQuadraticOMP::eval(int nfrom, int nto, ThrData * const thr)
     siinv = 1.0/si;
 
     double dphi = phi-phi0[type];
+    if (dphi > MY_PI) dphi -= 2*MY_PI;
+    else if (dphi < -MY_PI) dphi += 2*MY_PI;
     p = k[type]*dphi;
     pd = - 2.0 * p * siinv;
     p = p * dphi;


### PR DESCRIPTION
**Summary**

Reput the dihedral angle difference (dphi) between -pi and pi to avoid output bad energy values.

**Author(s)**

Julien Devémy
Alain Dequidt

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

Here attached a data and input file to test, with a quadratic dihedral at 180°.

Without the fix, the molecule moves too much and the dihedral energy changes a lot.
With the fix, the molecule is stable and the dihedral energy is quite constant.

[test_dih_quad.tar.gz](https://github.com/lammps/lammps/files/5621187/test_dih_quad.tar.gz)


