### PR TITLE
Bond/react: add logic to constraints

### DIFF
--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -616,8 +616,8 @@ reset_mol_ids = yes, custom_charges = no, molecule = off
 
 .. _Gissinger:
 
-**(Gissinger)** Gissinger, Jensen and Wise, Polymer, 128, 211 (2017).
+**(Gissinger)** Gissinger, Jensen and Wise, Polymer, 128, 211-217 (2017).
 
 .. _Gissinger2020:
 
-**(Gissinger)** Gissinger, Jensen and Wise, Macromolecules (2020, in press).
+**(Gissinger)** Gissinger, Jensen and Wise, Macromolecules, 53, 22, 9953–9961 (2020).

--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -457,6 +457,21 @@ example, the molecule fragment could consist of only the backbone
 atoms of a polymer chain. This constraint can be used to enforce a
 specific relative position and orientation between reacting molecules.
 
+By default, all constraints must be satisfied for the reaction to
+occur. In other words, constraints are evaluated as a series of
+logical values using the logical AND operator "&&". More complex logic
+can be achieved by explicitly adding "&&" or "||" after a given
+constraint command. Logical operators must be placed after all
+constraint parameters, on the same line as the constraint (one per
+line). Similarly, parentheses can be used to group constraints. The
+expression that results from concatenating all constraints should be a
+valid logical expression that can be read by the :doc:`variable <variable>`
+command after converting each constraint to a logical value. Because
+exactly one constraint is allowed per line, having a valid logical
+expression implies that left parentheses "(" should only appear
+before a constraint, and right parentheses ")" should only appear
+after a constraint and before any logical operator.
+
 Once a reaction site has been successfully identified, data structures
 within LAMMPS that store bond topology are updated to reflect the
 post-reacted molecule template. All force fields with fixed bonds,

--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -460,17 +460,19 @@ specific relative position and orientation between reacting molecules.
 By default, all constraints must be satisfied for the reaction to
 occur. In other words, constraints are evaluated as a series of
 logical values using the logical AND operator "&&". More complex logic
-can be achieved by explicitly adding "&&" or "||" after a given
-constraint command. Logical operators must be placed after all
-constraint parameters, on the same line as the constraint (one per
-line). Similarly, parentheses can be used to group constraints. The
-expression that results from concatenating all constraints should be a
-valid logical expression that can be read by the :doc:`variable <variable>`
-command after converting each constraint to a logical value. Because
-exactly one constraint is allowed per line, having a valid logical
-expression implies that left parentheses "(" should only appear
-before a constraint, and right parentheses ")" should only appear
-after a constraint and before any logical operator.
+can be achieved by explicitly adding the logical AND operator "&&" or
+the logical OR operator "||" after a given constraint command. If a
+logical operator is specified after a constraint, it must be placed
+after all constraint parameters, on the same line as the constraint
+(one per line). Similarly, parentheses can be used to group
+constraints. The expression that results from concatenating all
+constraints should be a valid logical expression that can be read by
+the :doc:`variable <variable>` command after converting each
+constraint to a logical value. Because exactly one constraint is
+allowed per line, having a valid logical expression implies that left
+parentheses "(" should only appear before a constraint, and right
+parentheses ")" should only appear after a constraint and before any
+logical operator.
 
 Once a reaction site has been successfully identified, data structures
 within LAMMPS that store bond topology are updated to reflect the

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -442,7 +442,7 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
   int tmp = 0;
   for (int i = 0; i < nconstraints; i++) {
     if (constraints[i].type == ARRHENIUS) {
-      rrhandom[tmp++] = new RanMars(lmp,(int) constraints[i].par[6] + me);
+      rrhandom[tmp++] = new RanMars(lmp,(int) constraints[i].par[4] + me);
     }
   }
 
@@ -1896,9 +1896,9 @@ int FixBondReact::check_constraints()
         if (ANDgate != 1) return 0;
       } else if (constraints[i].type == ARRHENIUS) {
         t = get_temperature();
-        prrhob = constraints[i].par[3]*pow(t,constraints[i].par[4])*
-          exp(-constraints[i].par[5]/(force->boltz*t));
-        if (prrhob < rrhandom[(int) constraints[i].par[2]]->uniform()) return 0;
+        prrhob = constraints[i].par[1]*pow(t,constraints[i].par[2])*
+          exp(-constraints[i].par[3]/(force->boltz*t));
+        if (prrhob < rrhandom[(int) constraints[i].par[0]]->uniform()) return 0;
       } else if (constraints[i].type == RMSD) {
         // call superpose
         int iatom;
@@ -3390,12 +3390,12 @@ void FixBondReact::ReadConstraints(char *line, int myrxn)
       constraints[nconstraints].par[13] = tmp[3]/180.0 * MY_PI;
     } else if (strcmp(constraint_type,"arrhenius") == 0) {
       constraints[nconstraints].type = ARRHENIUS;
-      constraints[nconstraints].par[2] = narrhenius++;
+      constraints[nconstraints].par[0] = narrhenius++;
       sscanf(line,"%*s %lg %lg %lg %lg",&tmp[0],&tmp[1],&tmp[2],&tmp[3]);
-      constraints[nconstraints].par[3] = tmp[0];
-      constraints[nconstraints].par[4] = tmp[1];
-      constraints[nconstraints].par[5] = tmp[2];
-      constraints[nconstraints].par[6] = tmp[3];
+      constraints[nconstraints].par[1] = tmp[0];
+      constraints[nconstraints].par[2] = tmp[1];
+      constraints[nconstraints].par[3] = tmp[2];
+      constraints[nconstraints].par[4] = tmp[3];
     } else if (strcmp(constraint_type,"rmsd") == 0) {
       constraints[nconstraints].type = RMSD;
       strcpy(strargs[0],"0");

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -1805,9 +1805,9 @@ int FixBondReact::check_constraints()
         rsq = delx*delx + dely*dely + delz*delz;
         if (rsq < constraints[i].par[0] || rsq > constraints[i].par[1]) return 0;
       } else if (constraints[i].type == ANGLE) {
-        get_IDcoords((int) constraints[i].par[2], (int) constraints[i].par[3], x1);
-        get_IDcoords((int) constraints[i].par[4], (int) constraints[i].par[5], x2);
-        get_IDcoords((int) constraints[i].par[6], (int) constraints[i].par[7], x3);
+        get_IDcoords(constraints[i].idtype[0], constraints[i].id[0], x1);
+        get_IDcoords(constraints[i].idtype[1], constraints[i].id[1], x2);
+        get_IDcoords(constraints[i].idtype[2], constraints[i].id[2], x3);
 
         // 1st bond
         delx1 = x1[0] - x2[0];
@@ -1830,7 +1830,7 @@ int FixBondReact::check_constraints()
         c /= r1*r2;
         if (c > 1.0) c = 1.0;
         if (c < -1.0) c = -1.0;
-        if (acos(c) < constraints[i].par[8] || acos(c) > constraints[i].par[9]) return 0;
+        if (acos(c) < constraints[i].par[0] || acos(c) > constraints[i].par[1]) return 0;
       } else if (constraints[i].type == DIHEDRAL) {
         // phi calculation from dihedral style harmonic
         get_IDcoords((int) constraints[i].par[2], (int) constraints[i].par[3], x1);
@@ -3369,11 +3369,11 @@ void FixBondReact::ReadConstraints(char *line, int myrxn)
     } else if (strcmp(constraint_type,"angle") == 0) {
       constraints[nconstraints].type = ANGLE;
       sscanf(line,"%*s %s %s %s %lg %lg",strargs[0],strargs[1],strargs[2],&tmp[0],&tmp[1]);
-      readID(strargs[0], nconstraints, 2, 3);
-      readID(strargs[1], nconstraints, 4, 5);
-      readID(strargs[2], nconstraints, 6, 7);
-      constraints[nconstraints].par[8] = tmp[0]/180.0 * MY_PI;
-      constraints[nconstraints].par[9] = tmp[1]/180.0 * MY_PI;
+      readID(strargs[0], nconstraints, 0);
+      readID(strargs[1], nconstraints, 1);
+      readID(strargs[2], nconstraints, 2);
+      constraints[nconstraints].par[0] = tmp[0]/180.0 * MY_PI;
+      constraints[nconstraints].par[1] = tmp[1]/180.0 * MY_PI;
     } else if (strcmp(constraint_type,"dihedral") == 0) {
       constraints[nconstraints].type = DIHEDRAL;
       tmp[2] = 181.0; // impossible range

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -3420,7 +3420,7 @@ if ID starts with character, assume it is a pre-reaction molecule fragment ID
 otherwise, it is a pre-reaction atom ID
 ---------------------------------------------------------------------- */
 
-void FixBondReact::readID(char *strarg, int iconstr, int i, int dummy)
+void FixBondReact::readID(char *strarg, int iconstr, int i)
 {
   if (isalpha(strarg[0])) {
     constraints[iconstr].idtype[i] = FRAG; // fragment vs. atom ID flag

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -231,6 +231,7 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
     stabilize_steps_flag[i] = 0;
     custom_charges_fragid[i] = -1;
     molecule_keyword[i] = OFF;
+    nconstraints[i] = 0;
     // set default limit duration to 60 timesteps
     limit_duration[i] = 60;
     reaction_count[i] = 0;

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -1962,11 +1962,16 @@ int FixBondReact::check_constraints()
     }
   }
 
-  for (int i = 0; i < nconstraints[rxnID]; i++) {
-    if (satisfied[i] == 0) {
-      memory->destroy(satisfied);
-      return 0;
+  if (nconstraints[rxnID] > 0) {
+    char evalstr[MAXLINE],*ptr,valstr;
+    strcpy(evalstr,constraintstr[rxnID]);
+    for (int i = 0; i < nconstraints[rxnID]; i++) {
+      sprintf(&valstr,"%d", satisfied[i]);
+      ptr = strchr(evalstr,'C');
+      *ptr = valstr;
     }
+    double verdict = input->variable->evaluate_boolean(evalstr);
+    if (verdict == 0.0) return 0;
   }
 
   // let's also check chirality within 'check_constraint'

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -1906,7 +1906,7 @@ int FixBondReact::check_constraints()
         int n2superpose = 0;
         double **xfrozen; // coordinates for the "frozen" target molecule
         double **xmobile; // coordinates for the "mobile" molecule
-        int ifragment = constraints[i].par[3];
+        int ifragment = constraints[i].id[0];
         if (ifragment >= 0) {
           for (int j = 0; j < onemol->natoms; j++)
             if (onemol->fragmentmask[ifragment][j]) n2superpose++;
@@ -1943,7 +1943,7 @@ int FixBondReact::check_constraints()
         }
         Superpose3D<double, double **> superposer(n2superpose);
         double rmsd = superposer.Superpose(xfrozen, xmobile);
-        if (rmsd > constraints[i].par[2]) return 0;
+        if (rmsd > constraints[i].par[0]) return 0;
         memory->destroy(xfrozen);
         memory->destroy(xmobile);
       }
@@ -3400,12 +3400,12 @@ void FixBondReact::ReadConstraints(char *line, int myrxn)
       constraints[nconstraints].type = RMSD;
       strcpy(strargs[0],"0");
       sscanf(line,"%*s %lg %s",&tmp[0],strargs[0]);
-      constraints[nconstraints].par[2] = tmp[0]; // RMSDmax
-      constraints[nconstraints].par[3] = -1; // optional molecule fragment
+      constraints[nconstraints].par[0] = tmp[0]; // RMSDmax
+      constraints[nconstraints].id[0] = -1; // optional molecule fragment
       if (isalpha(strargs[0][0])) {
         int ifragment = onemol->findfragment(strargs[0]);
         if (ifragment < 0) error->one(FLERR,"Bond/react: Molecule fragment does not exist");
-        else constraints[nconstraints].par[3] = ifragment;
+        else constraints[nconstraints].id[0] = ifragment;
       }
     } else
       error->one(FLERR,"Bond/react: Illegal constraint type in 'Constraints' section of map file");

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -1833,10 +1833,10 @@ int FixBondReact::check_constraints()
         if (acos(c) < constraints[i].par[0] || acos(c) > constraints[i].par[1]) return 0;
       } else if (constraints[i].type == DIHEDRAL) {
         // phi calculation from dihedral style harmonic
-        get_IDcoords((int) constraints[i].par[2], (int) constraints[i].par[3], x1);
-        get_IDcoords((int) constraints[i].par[4], (int) constraints[i].par[5], x2);
-        get_IDcoords((int) constraints[i].par[6], (int) constraints[i].par[7], x3);
-        get_IDcoords((int) constraints[i].par[8], (int) constraints[i].par[9], x4);
+        get_IDcoords(constraints[i].idtype[0], constraints[i].id[0], x1);
+        get_IDcoords(constraints[i].idtype[1], constraints[i].id[1], x2);
+        get_IDcoords(constraints[i].idtype[2], constraints[i].id[2], x3);
+        get_IDcoords(constraints[i].idtype[3], constraints[i].id[3], x4);
 
         vb1x = x1[0] - x2[0];
         vb1y = x1[1] - x2[1];
@@ -1883,15 +1883,15 @@ int FixBondReact::check_constraints()
         phi = atan2(s,c);
 
         ANDgate = 0;
-        if (constraints[i].par[10] < constraints[i].par[11]) {
-          if (phi > constraints[i].par[10] && phi < constraints[i].par[11]) ANDgate = 1;
+        if (constraints[i].par[0] < constraints[i].par[1]) {
+          if (phi > constraints[i].par[0] && phi < constraints[i].par[1]) ANDgate = 1;
         } else {
-          if (phi > constraints[i].par[10] || phi < constraints[i].par[11]) ANDgate = 1;
+          if (phi > constraints[i].par[0] || phi < constraints[i].par[1]) ANDgate = 1;
         }
-        if (constraints[i].par[12] < constraints[i].par[13]) {
-          if (phi > constraints[i].par[12] && phi < constraints[i].par[13]) ANDgate = 1;
+        if (constraints[i].par[2] < constraints[i].par[3]) {
+          if (phi > constraints[i].par[2] && phi < constraints[i].par[3]) ANDgate = 1;
         } else {
-          if (phi > constraints[i].par[12] || phi < constraints[i].par[13]) ANDgate = 1;
+          if (phi > constraints[i].par[2] || phi < constraints[i].par[3]) ANDgate = 1;
         }
         if (ANDgate != 1) return 0;
       } else if (constraints[i].type == ARRHENIUS) {
@@ -3380,14 +3380,14 @@ void FixBondReact::ReadConstraints(char *line, int myrxn)
       tmp[3] = 182.0;
       sscanf(line,"%*s %s %s %s %s %lg %lg %lg %lg",strargs[0],strargs[1],
              strargs[2],strargs[3],&tmp[0],&tmp[1],&tmp[2],&tmp[3]);
-      readID(strargs[0], nconstraints, 2, 3);
-      readID(strargs[1], nconstraints, 4, 5);
-      readID(strargs[2], nconstraints, 6, 7);
-      readID(strargs[3], nconstraints, 8, 9);
-      constraints[nconstraints].par[10] = tmp[0]/180.0 * MY_PI;
-      constraints[nconstraints].par[11] = tmp[1]/180.0 * MY_PI;
-      constraints[nconstraints].par[12] = tmp[2]/180.0 * MY_PI;
-      constraints[nconstraints].par[13] = tmp[3]/180.0 * MY_PI;
+      readID(strargs[0], nconstraints, 0);
+      readID(strargs[1], nconstraints, 1);
+      readID(strargs[2], nconstraints, 2);
+      readID(strargs[3], nconstraints, 3);
+      constraints[nconstraints].par[0] = tmp[0]/180.0 * MY_PI;
+      constraints[nconstraints].par[1] = tmp[1]/180.0 * MY_PI;
+      constraints[nconstraints].par[2] = tmp[2]/180.0 * MY_PI;
+      constraints[nconstraints].par[3] = tmp[3]/180.0 * MY_PI;
     } else if (strcmp(constraint_type,"arrhenius") == 0) {
       constraints[nconstraints].type = ARRHENIUS;
       constraints[nconstraints].par[0] = narrhenius++;

--- a/src/USER-REACTION/fix_bond_react.h
+++ b/src/USER-REACTION/fix_bond_react.h
@@ -68,7 +68,7 @@ class FixBondReact : public Fix {
   int *stabilize_steps_flag;
   int *custom_charges_fragid;
   int *molecule_keyword;
-  int nconstraints;
+  int *nconstraints;
   int narrhenius;
   int **var_flag,**var_id; // for keyword values with variable inputs
   int status;
@@ -115,7 +115,7 @@ class FixBondReact : public Fix {
 
   int *ibonding,*jbonding;
   int *closeneigh; // indicates if bonding atoms of a rxn are 1-2, 1-3, or 1-4 neighbors
-  int nedge,nequivalent,ndelete,nchiral,nconstr; // # edge, equivalent atoms in mapping file
+  int nedge,nequivalent,ndelete,nchiral; // # edge, equivalent atoms in mapping file
   int attempted_rxn; // there was an attempt!
   int *local_rxn_count;
   int *ghostly_rxn_count;
@@ -157,7 +157,7 @@ class FixBondReact : public Fix {
   void CustomCharges(int, int);
   void ChiralCenters(char *, int);
   void ReadConstraints(char *, int);
-  void readID(char *, int, int);
+  void readID(char *, int, int, int);
 
   void make_a_guess ();
   void neighbor_loop();
@@ -204,7 +204,7 @@ class FixBondReact : public Fix {
     int idtype[MAXCONIDS];
     double par[MAXCONPAR];
   };
-  Constraint *constraints;
+  Constraint **constraints;
 
   // DEBUG
 

--- a/src/USER-REACTION/fix_bond_react.h
+++ b/src/USER-REACTION/fix_bond_react.h
@@ -157,7 +157,7 @@ class FixBondReact : public Fix {
   void CustomCharges(int, int);
   void ChiralCenters(char *, int);
   void ReadConstraints(char *, int);
-  void readID(char *, int, int, int);
+  void readID(char *, int, int);
 
   void make_a_guess ();
   void neighbor_loop();

--- a/src/USER-REACTION/fix_bond_react.h
+++ b/src/USER-REACTION/fix_bond_react.h
@@ -31,7 +31,9 @@ namespace LAMMPS_NS {
 class FixBondReact : public Fix {
  public:
 
-  enum {MAXLINE=256};
+  enum {MAXLINE=256}; // max length of line read from files
+  enum {MAXCONIDS=4}; // max # of IDs used by any constraint
+  enum {MAXCONPAR=4}; // max # of constraint parameters
 
   FixBondReact(class LAMMPS *, int, char **);
   ~FixBondReact();
@@ -68,7 +70,6 @@ class FixBondReact : public Fix {
   int *molecule_keyword;
   int nconstraints;
   int narrhenius;
-  double **constraints;
   int **var_flag,**var_id; // for keyword values with variable inputs
   int status;
   int *groupbits;
@@ -155,7 +156,7 @@ class FixBondReact : public Fix {
   void DeleteAtoms(char *, int);
   void CustomCharges(int, int);
   void ChiralCenters(char *, int);
-  void Constraints(char *, int);
+  void ReadConstraints(char *, int);
   void readID(char *, int, int, int);
 
   void make_a_guess ();
@@ -194,6 +195,16 @@ class FixBondReact : public Fix {
     int reaction_count_total;
   };
   Set *set;
+
+  struct Constraint {
+    int type;
+    int rxnID;
+    int op;
+    int id[MAXCONIDS];
+    int idtype[MAXCONIDS];
+    double par[MAXCONPAR];
+  };
+  Constraint *constraints;
 
   // DEBUG
 

--- a/src/USER-REACTION/fix_bond_react.h
+++ b/src/USER-REACTION/fix_bond_react.h
@@ -69,6 +69,7 @@ class FixBondReact : public Fix {
   int *custom_charges_fragid;
   int *molecule_keyword;
   int *nconstraints;
+  char **constraintstr;
   int narrhenius;
   int **var_flag,**var_id; // for keyword values with variable inputs
   int status;
@@ -198,8 +199,6 @@ class FixBondReact : public Fix {
 
   struct Constraint {
     int type;
-    int rxnID;
-    int op;
     int id[MAXCONIDS];
     int idtype[MAXCONIDS];
     double par[MAXCONPAR];


### PR DESCRIPTION
**Summary**

add boolean logic feature to reaction constraints. whereas previously all constraints had to be satisfied, they can now be grouped together with logical operators (|| and &&)

**Related Issue(s)**

none

**Author(s)**

JG. Thanks to Ben Jensen for suggestions and discussion

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


