### PR TITLE
USER-CGDNA: Introduced ellipsoid pointer in quaternion data access

### DIFF
--- a/src/USER-CGDNA/bond_oxdna_fene.cpp
+++ b/src/USER-CGDNA/bond_oxdna_fene.cpp
@@ -173,6 +173,7 @@ void BondOxdnaFene::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int **bondlist = neighbor->bondlist;
   int nbondlist = neighbor->nbondlist;
@@ -190,9 +191,9 @@ void BondOxdnaFene::compute(int eflag, int vflag)
     b = bondlist[in][0];
     type = bondlist[in][2];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
-    qb=bonus[b].quat;
+    qb=bonus[ellipsoid[b]].quat;
     MathExtra::q_to_exyz(qb,bx,by,bz);
 
     // vector COM-backbone site a and b

--- a/src/USER-CGDNA/pair_oxdna2_coaxstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna2_coaxstk.cpp
@@ -133,6 +133,7 @@ void PairOxdna2Coaxstk::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,ia,ib,anum,bnum,atype,btype;
 
@@ -154,7 +155,7 @@ void PairOxdna2Coaxstk::compute(int eflag, int vflag)
     a = alist[ia];
     atype = type[a];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
 
     // vector COM a - stacking site a
@@ -178,7 +179,7 @@ void PairOxdna2Coaxstk::compute(int eflag, int vflag)
 
       btype = type[b];
 
-      qb=bonus[b].quat;
+      qb=bonus[ellipsoid[b]].quat;
       MathExtra::q_to_exyz(qb,bx,by,bz);
 
       // vector COM b - stacking site b

--- a/src/USER-CGDNA/pair_oxdna2_dh.cpp
+++ b/src/USER-CGDNA/pair_oxdna2_dh.cpp
@@ -102,6 +102,7 @@ void PairOxdna2Dh::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,ia,ib,anum,bnum,atype,btype;
 
@@ -120,7 +121,7 @@ void PairOxdna2Dh::compute(int eflag, int vflag)
     a = alist[ia];
     atype = type[a];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
 
     // vector COM-backbone site a
@@ -140,7 +141,7 @@ void PairOxdna2Dh::compute(int eflag, int vflag)
       b &= NEIGHMASK;
       btype = type[b];
 
-      qb=bonus[b].quat;
+      qb=bonus[ellipsoid[b]].quat;
       MathExtra::q_to_exyz(qb,bx,by,bz);
 
       // vector COM-backbone site b

--- a/src/USER-CGDNA/pair_oxdna_coaxstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_coaxstk.cpp
@@ -145,6 +145,7 @@ void PairOxdnaCoaxstk::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,ia,ib,anum,bnum,atype,btype;
 
@@ -166,7 +167,7 @@ void PairOxdnaCoaxstk::compute(int eflag, int vflag)
     a = alist[ia];
     atype = type[a];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
 
     // vector COM a - stacking site a
@@ -190,7 +191,7 @@ void PairOxdnaCoaxstk::compute(int eflag, int vflag)
 
       btype = type[b];
 
-      qb=bonus[b].quat;
+      qb=bonus[ellipsoid[b]].quat;
       MathExtra::q_to_exyz(qb,bx,by,bz);
 
       // vector COM b - stacking site b

--- a/src/USER-CGDNA/pair_oxdna_excv.cpp
+++ b/src/USER-CGDNA/pair_oxdna_excv.cpp
@@ -134,6 +134,7 @@ void PairOxdnaExcv::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,ia,ib,anum,bnum,atype,btype;
 
@@ -152,7 +153,7 @@ void PairOxdnaExcv::compute(int eflag, int vflag)
     a = alist[ia];
     atype = type[a];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
 
     // vector COM - backbone and base site a
@@ -177,7 +178,7 @@ void PairOxdnaExcv::compute(int eflag, int vflag)
 
       btype = type[b];
 
-      qb=bonus[b].quat;
+      qb=bonus[ellipsoid[b]].quat;
       MathExtra::q_to_exyz(qb,bx,by,bz);
 
       // vector COM - backbone and base site b

--- a/src/USER-CGDNA/pair_oxdna_hbond.cpp
+++ b/src/USER-CGDNA/pair_oxdna_hbond.cpp
@@ -164,6 +164,7 @@ void PairOxdnaHbond::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,ia,ib,anum,bnum,atype,btype;
 
@@ -185,7 +186,7 @@ void PairOxdnaHbond::compute(int eflag, int vflag)
     a = alist[ia];
     atype = type[a];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
 
     ra_chb[0] = d_chb*ax[0];
@@ -203,7 +204,7 @@ void PairOxdnaHbond::compute(int eflag, int vflag)
 
       btype = type[b];
 
-      qb=bonus[b].quat;
+      qb=bonus[ellipsoid[b]].quat;
       MathExtra::q_to_exyz(qb,bx,by,bz);
 
       rb_chb[0] = d_chb*bx[0];

--- a/src/USER-CGDNA/pair_oxdna_stk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_stk.cpp
@@ -245,6 +245,7 @@ void PairOxdnaStk::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,in,atype,btype;
 
@@ -262,9 +263,9 @@ void PairOxdnaStk::compute(int eflag, int vflag)
     a = bondlist[in][1];
     b = bondlist[in][0];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
-    qb=bonus[b].quat;
+    qb=bonus[ellipsoid[b]].quat;
     MathExtra::q_to_exyz(qb,bx,by,bz);
 
     // vector COM a - stacking site a

--- a/src/USER-CGDNA/pair_oxdna_xstk.cpp
+++ b/src/USER-CGDNA/pair_oxdna_xstk.cpp
@@ -142,6 +142,7 @@ void PairOxdnaXstk::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,ia,ib,anum,bnum,atype,btype;
 
@@ -163,7 +164,7 @@ void PairOxdnaXstk::compute(int eflag, int vflag)
     a = alist[ia];
     atype = type[a];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
 
     ra_chb[0] = d_chb*ax[0];
@@ -181,7 +182,7 @@ void PairOxdnaXstk::compute(int eflag, int vflag)
 
       btype = type[b];
 
-      qb=bonus[b].quat;
+      qb=bonus[ellipsoid[b]].quat;
       MathExtra::q_to_exyz(qb,bx,by,bz);
 
       rb_chb[0] = d_chb*bx[0];

--- a/src/USER-CGDNA/pair_oxrna2_stk.cpp
+++ b/src/USER-CGDNA/pair_oxrna2_stk.cpp
@@ -262,6 +262,7 @@ void PairOxrna2Stk::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,in,atype,btype;
 
@@ -279,9 +280,9 @@ void PairOxrna2Stk::compute(int eflag, int vflag)
     a = bondlist[in][1];
     b = bondlist[in][0];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
-    qb=bonus[b].quat;
+    qb=bonus[ellipsoid[b]].quat;
     MathExtra::q_to_exyz(qb,bx,by,bz);
 
     // vector COM a - 3'-stacking site a

--- a/src/USER-CGDNA/pair_oxrna2_xstk.cpp
+++ b/src/USER-CGDNA/pair_oxrna2_xstk.cpp
@@ -135,6 +135,7 @@ void PairOxrna2Xstk::compute(int eflag, int vflag)
 
   AtomVecEllipsoid *avec = (AtomVecEllipsoid *) atom->style_match("ellipsoid");
   AtomVecEllipsoid::Bonus *bonus = avec->bonus;
+  int *ellipsoid = atom->ellipsoid;
 
   int a,b,ia,ib,anum,bnum,atype,btype;
 
@@ -156,7 +157,7 @@ void PairOxrna2Xstk::compute(int eflag, int vflag)
     a = alist[ia];
     atype = type[a];
 
-    qa=bonus[a].quat;
+    qa=bonus[ellipsoid[a]].quat;
     MathExtra::q_to_exyz(qa,ax,ay,az);
 
     ra_chb[0] = d_chb*ax[0];
@@ -174,7 +175,7 @@ void PairOxrna2Xstk::compute(int eflag, int vflag)
 
       btype = type[b];
 
-      qb=bonus[b].quat;
+      qb=bonus[ellipsoid[b]].quat;
       MathExtra::q_to_exyz(qb,bx,by,bz);
 
       rb_chb[0] = d_chb*bx[0];


### PR DESCRIPTION
**Summary**

This fixes a bug in the access to quaternion data that caused issues in the master branch and stable release from 29th Oct 2020 when load balancing is enabled. Instead of the bare atom index we use now the ellipsoid pointer to access the bonus data.

**Related Issue(s)**

None. All related issues have been already closed.

**Author(s)**

Oliver Henrich
Department of Physics
University of Strathclyde
Glasgow, UK

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Backward compatibility of input files is fully retained.

**Implementation Notes**

We extended the relevant lines to use ellipsoid[i] instead of the bare index i. Tests were run with and without load balancing and raw quaternion data was printed off and the results were verified. 

**Post Submission Checklist**

- [ ] The feature has been verified to work with the CMake based build system
