### PR TITLE
Fixed error in Wurtzite script and added more explanation

### DIFF
--- a/doc/src/lattice.rst
+++ b/doc/src/lattice.rst
@@ -251,12 +251,16 @@ in commands that use the spacings should be decipherable.
 
 ----------
 
-Example commands for generating a Wurtzite crystal (courtesy
-of Aidan Thompson), with its 8 atom unit cell.
+Example commands for generating a Wurtzite crystal.
+The lattice constants approximate those of CdSe.
+The :math:`\sqrt{3}\times 1` orthorhombic supercell is used
+with the x, y, and z directions oriented 
+along :math:`[\bar{1}\bar{2}30]`,  
+:math:`[10\bar{1}0]`, and :math:`[0001]`, respectively.   
 
 .. code-block:: LAMMPS
 
-   variable a equal  4.340330
+   variable a equal  4.34
    variable b equal  $a*sqrt(3.0)
    variable c equal  $a*sqrt(8.0/3.0)
 
@@ -264,8 +268,8 @@ of Aidan Thompson), with its 8 atom unit cell.
    variable five6 equal 5.0/6.0
 
    lattice custom    1.0     &
-           a1      $a       0.0     0.0     &
-           a2      0.0      $b      0.0     &
+           a1      $b       0.0     0.0     &
+           a2      0.0      $a      0.0     &
            a3      0.0      0.0     $c      &
            basis   0.0      0.0     0.0     &
            basis   0.5      0.5     0.0     &


### PR DESCRIPTION
**Summary**

Fixed stupid error in lattice example generating Wurtzite crystal structure. 

**Related Issue(s)**

This issue was raised on the mailing list recently by Andreas Kyritsakis, and by someone else in 2016.

**Author(s)**

Aidan Thompson, Andreas Kyritsakis

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No

**Implementation Notes**

None

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


