### PR TITLE
Add pair/only flag to Kokkos

### DIFF
--- a/src/KOKKOS/fix_qeq_reax_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.h
@@ -241,7 +241,7 @@ class FixQEqReaxKokkos : public FixQEqReax, public KokkosBase {
 
 template <class DeviceType>
 struct FixQEqReaxKokkosNumNeighFunctor  {
-  typedef DeviceType  device_type ;
+  typedef DeviceType device_type;
   typedef int value_type ;
   FixQEqReaxKokkos<DeviceType> c;
   FixQEqReaxKokkosNumNeighFunctor(FixQEqReaxKokkos<DeviceType>* c_ptr):c(*c_ptr) {
@@ -269,6 +269,7 @@ struct FixQEqReaxKokkosMatVecFunctor  {
 template <class DeviceType, int NEIGHFLAG>
 struct FixQEqReaxKokkosComputeHFunctor {
   int atoms_per_team, vector_length;
+  typedef DeviceType device_type;
   typedef int value_type;
   typedef Kokkos::ScratchMemorySpace<DeviceType> scratch_space;
   FixQEqReaxKokkos<DeviceType> c;

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -390,6 +390,12 @@ void KokkosLMP::accelerator(int narg, char **arg)
       else if (strcmp(arg[iarg+1],"on") == 0) gpu_aware_flag = 1;
       else error->all(FLERR,"Illegal package kokkos command");
       iarg += 2;
+    } else if (strcmp(arg[iarg],"pair/only") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
+      if (strcmp(arg[iarg+1],"off") == 0) pair_only_flag = 0;
+      else if (strcmp(arg[iarg+1],"on") == 0) pair_only_flag = 1;
+      else error->all(FLERR,"Illegal package kokkos command");
+      iarg += 2;
     } else if (strcmp(arg[iarg],"neigh/thread") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
       if (strcmp(arg[iarg+1],"off") == 0) neigh_thread = 0;
@@ -452,6 +458,15 @@ void KokkosLMP::accelerator(int narg, char **arg)
   neighbor->binsize_user = binsize;
   if (binsize <= 0.0) neighbor->binsizeflag = 0;
   else neighbor->binsizeflag = 1;
+
+  if (pair_only_flag) {
+    delete [] lmp->suffix;
+    lmp->suffix = new char[7];
+    strcpy(lmp->suffix,"kk/host");
+
+    exchange_comm_classic = forward_comm_classic = reverse_comm_classic = 1;
+    exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 0;
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -39,6 +39,7 @@ class KokkosLMP : protected Pointers {
   int numa;
   int auto_sync;
   int gpu_aware_flag;
+  int pair_only_flag;
   int neigh_thread;
   int neigh_thread_set;
   int newtonflag;

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -53,6 +53,7 @@ class KokkosLMP {
   int nthreads;
   int ngpus;
   int numa;
+  int pair_only_flag;
 
   KokkosLMP(class LAMMPS *, int, char **) {kokkos_exists = 0;}
   ~KokkosLMP() {}

--- a/src/compute_pair.cpp
+++ b/src/compute_pair.cpp
@@ -19,6 +19,7 @@
 #include "force.h"
 #include "pair.h"
 #include "error.h"
+#include "accelerator_kokkos.h"
 
 using namespace LAMMPS_NS;
 
@@ -67,8 +68,12 @@ ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
 
   pair = force->pair_match(pstyle,1,nsub);
   if (!pair && lmp->suffix) {
-    strcat(pstyle,"/");
-    strcat(pstyle,lmp->suffix);
+    if (lmp->kokkos && lmp->kokkos->pair_only_flag) {
+      strcat(pstyle,"/kk");
+    } else {
+      strcat(pstyle,"/");
+      strcat(pstyle,lmp->suffix);
+    }
     pair = force->pair_match(pstyle,1,nsub);
   }
 

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -239,7 +239,7 @@ void Force::create_pair(const std::string &style, int trysuffix)
 
   int sflag;
   pair = new_pair(style,trysuffix,sflag);
-  store_style(pair_style,style,sflag);
+  store_style(pair_style,style,sflag,1);
 }
 
 /* ----------------------------------------------------------------------
@@ -254,6 +254,8 @@ Pair *Force::new_pair(const std::string &style, int trysuffix, int &sflag)
     if (lmp->suffix) {
       sflag = 1;
       std::string estyle = style + "/" + lmp->suffix;
+      if (lmp->kokkos && lmp->kokkos->pair_only_flag)
+        estyle = style + "/kk";
       if (pair_map->find(estyle) != pair_map->end()) {
         PairCreator &pair_creator = (*pair_map)[estyle];
         return pair_creator(lmp);
@@ -730,11 +732,16 @@ KSpace *Force::kspace_match(const std::string &word, int exact)
    if sflag = 1/2, append suffix or suffix2 to style
 ------------------------------------------------------------------------- */
 
-void Force::store_style(char *&str, const std::string &style, int sflag)
+void Force::store_style(char *&str, const std::string &style, int sflag, int pair_flag)
 {
   std::string estyle = style;
 
-  if (sflag == 1) estyle += std::string("/") + lmp->suffix;
+  if (sflag == 1) {
+    if (pair_flag && lmp->kokkos && lmp->kokkos->pair_only_flag)
+      estyle += std::string("/kk");
+    else
+      estyle += std::string("/") + lmp->suffix;
+  }
   else if (sflag == 2) estyle += std::string("/") + lmp->suffix2;
 
   str = new char[estyle.size()+1];

--- a/src/force.h
+++ b/src/force.h
@@ -152,7 +152,7 @@ class Force : protected Pointers {
   KSpace *new_kspace(const std::string &, int, int &);
   KSpace *kspace_match(const std::string &, int);
 
-  void store_style(char *&, const std::string &, int);
+  void store_style(char *&, const std::string &, int, int pair_flag = 0);
   void set_special(int, char **);
 
   double memory_usage();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1715,8 +1715,12 @@ void Input::pair_style()
     int match = 0;
     if (style == force->pair_style) match = 1;
     if (!match && lmp->suffix_enable) {
-      if (lmp->suffix)
-        if (style + "/" + lmp->suffix == force->pair_style) match = 1;
+      if (lmp->suffix) {
+        if (lmp->kokkos && lmp->kokkos->pair_only_flag)
+          if (style + "/kk" == force->pair_style) match = 1;
+        else
+          if (style + "/" + lmp->suffix == force->pair_style) match = 1;
+      }
 
       if (lmp->suffix2)
         if (style + "/" + lmp->suffix2 == force->pair_style) match = 1;


### PR DESCRIPTION
**Summary**

Add a `pair/only` flag to Kokkos. This is a convenient command-line shortcut to run only the `pair_style` and neighbor list on the GPU and everything else on the host CPU, and basically allows the KOKKOS package to easily mimic the GPU package. This mode can be faster for small systems when running on more than 1 MPI rank, or when using diagnostics (fixes/computes) haven't been ported to Kokkos yet. Without this PR, a user must manually edit the input script and change the kokkos package args to get this mode of operation.

**Related Issue(s)**

None.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes