### PR TITLE
Update temp/csvr manual

### DIFF
--- a/doc/src/fix_temp_csvr.rst
+++ b/doc/src/fix_temp_csvr.rst
@@ -125,7 +125,7 @@ removed from each atom, thermostatting is performed on the remaining
 thermal degrees of freedom, and the bias is added back in.
 
 An important feature of these thermostats is that they have an 
-associated effective energy that is a contant of the motion.
+associated effective energy that is a constant of motion.
 The effective energy is the total energy (kinetic + potential) plus 
 the accumulated kinetic energy changes due to the thermostat. The 
 latter quantity is the global scalar computed by these fixes. This 

--- a/doc/src/fix_temp_csvr.rst
+++ b/doc/src/fix_temp_csvr.rst
@@ -166,7 +166,7 @@ These fixes are not invoked during :doc:`energy minimization <minimize>`.
 
 These fixes compute a global scalar which can be accessed by various
 :doc:`output commands <Howto_output>`.  The scalar is the cumulative
-kinetic energy change due to the fix.  The scalar value calculated by this fix
+energy change due to the fix.  The scalar value calculated by this fix
 is "extensive".
 
 Restrictions

--- a/doc/src/fix_temp_csvr.rst
+++ b/doc/src/fix_temp_csvr.rst
@@ -124,6 +124,19 @@ temperature is calculated taking the bias into account, bias is
 removed from each atom, thermostatting is performed on the remaining
 thermal degrees of freedom, and the bias is added back in.
 
+An important feature of these thermostats is that they have an 
+associated effective energy that is a contant of the motion.
+The effective energy is the total energy (kinetic + potential) plus 
+the accumulated kinetic energy changes due to the thermostat. The 
+latter quantity is the global scalar computed by these fixes. This 
+feature is useful to check the integration of the equations of motion 
+against discretization errors. In other words, the conservation of 
+the effective energy can be used to choose an appropriate integration 
+:doc:`timestep <timestep>`. This is similar to the usual paradigm of 
+checking the conservation of the total energy in the microcanonical 
+ensemble.
+
+
 ----------
 
 Restart, fix_modify, output, run start/stop, minimize info
@@ -153,7 +166,7 @@ These fixes are not invoked during :doc:`energy minimization <minimize>`.
 
 These fixes compute a global scalar which can be accessed by various
 :doc:`output commands <Howto_output>`.  The scalar is the cumulative
-energy change due to the fix.  The scalar value calculated by this fix
+kinetic energy change due to the fix.  The scalar value calculated by this fix
 is "extensive".
 
 Restrictions


### PR DESCRIPTION
**Summary**

These PR updates the manual of temp/csvr with information about the conserved quantity in the dynamics generated by this thermostat. Knowledge of this quantity is important to choose an appropriate timestep in the simulation. I have added the definition of the conserved quantity in terms of quantities computed by Lammps. I have also included a brief discussion of how to use it. Before these changes the only way to understand this was reading the original papers and the Lammps' source code for the thermostat.

I have also corrected the information of the global scalar computed by these fixes to reflect that changes in *kinetic* energy are accumulated.

I would also like to discuss the fact that the manual says that this thermostat is not compatible with fix shake. I have used the two fixes together many times with results very close to those of Gromacs. For instance, the simulation of TIP4P water molecules seems to work properly. If there is no evidence for the incompatibility perhaps that comment should be removed.

**Related Issue(s)**

None that I know of.

**Author(s)**

Pablo Piaggi
ppiaggi at princeton.edu
(Princeton University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Fully backward compatible.

**Implementation Notes**

The source code was not changed. The manual was updated with the interpretation of the computed quantities.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines (I think so)
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] ~~The feature has been verified to work with the conventional build system~~
- [x] ~~The feature has been verified to work with the CMake based build system~~
- [x] ~~Suitable tests have been added to the unittest tree.~~
- [x] ~~A package specific README file has been included or updated~~
- [x] ~~One or more example input decks are included~~

**Further Information, Files, and Links**

I used the information in the original articles:
https://journals.aps.org/pre/abstract/10.1103/PhysRevE.75.056707
https://aip.scitation.org/doi/full/10.1063/1.2408420
and also the comments in @GiovanniBussi 's implementation here:
https://sites.google.com/site/giovannibussi/Research/algorithms

