### PR TITLE
Add pair/only option for accelerator styles

### DIFF
--- a/doc/src/package.rst
+++ b/doc/src/package.rst
@@ -548,7 +548,7 @@ available (currently only possible with OpenMPI v2.0.0 or later), then
 the *cuda/aware* keyword is automatically set to *off* by default. When
 the *cuda/aware* keyword is set to *off* while any of the *comm*
 keywords are set to *device*\ , the value for these *comm* keywords will
-be automatically changed to *host*\ . This setting has no effect if not
+be automatically changed to *no*\ . This setting has no effect if not
 running on GPUs or if using only one MPI rank. CUDA-aware MPI is available
 for OpenMPI 1.8 (or later versions), Mvapich2 1.9 (or later) when the
 "MV2_USE_CUDA" environment variable is set to "1", CrayMPI, and IBM
@@ -558,7 +558,8 @@ The *pair/only* keyword can change how the KOKKOS suffix "kk" is applied
 when using an accelerator device.  By default device acceleration is
 always used for all available styles.  With *pair/only* set to *on* the
 suffix setting will choose device acceleration only for pair styles and
-run all other force computations concurrently on the host GPU.  This can
+run all other force computations concurrently on the host CPU.
+The *comm* flags will also automatically be changed to *no*\ . This can
 result in better performance for certain configurations and system sizes.
 
 ----------

--- a/doc/src/package.rst
+++ b/doc/src/package.rst
@@ -18,13 +18,16 @@ Syntax
        *gpu* args = Ngpu keyword value ...
          Ngpu = # of GPUs per node
          zero or more keyword/value pairs may be appended
-         keywords = *neigh* or *newton* or *binsize* or *split* or *gpuID* or *tpa* or *device* or *blocksize*
+         keywords = *neigh* or *newton* or *pair/only* or *binsize* or *split* or *gpuID* or *tpa* or *device* or *blocksize*
            *neigh* value = *yes* or *no*
              yes = neighbor list build on GPU (default)
              no = neighbor list build on CPU
            *newton* = *off* or *on*
              off = set Newton pairwise flag off (default and required)
              on = set Newton pairwise flag on (currently not allowed)
+           *pair/only* = *off* or *on*
+             off = apply "gpu" suffix to all available styles in the GPU package (default)
+             on  - apply "gpu" suffix only pair styles
            *binsize* value = size
              size = bin size for neighbor list construction (distance units)
            *split* = fraction
@@ -65,7 +68,7 @@ Syntax
            *no_affinity* values = none
        *kokkos* args = keyword value ...
          zero or more keyword/value pairs may be appended
-         keywords = *neigh* or *neigh/qeq* or *neigh/thread* or *newton* or *binsize* or *comm* or *comm/exchange* or *comm/forward* or *comm/reverse* or *cuda/aware*
+         keywords = *neigh* or *neigh/qeq* or *neigh/thread* or *newton* or *binsize* or *comm* or *comm/exchange* or *comm/forward* or *comm/reverse* or *cuda/aware* or *pair/only*
            *neigh* value = *full* or *half*
              full = full neighbor list
              half = half neighbor list built in thread-safe manner
@@ -91,6 +94,9 @@ Syntax
            *cuda/aware* = *off* or *on*
              off = do not use CUDA-aware MPI
              on = use CUDA-aware MPI (default)
+           *pair/only* = *off* or *on*
+             off = use device acceleration (e.g. GPU) for all available styles in the KOKKOS package (default)
+             on  = use device acceleration only for pair styles (and host acceleration for others)
        *omp* args = Nthreads keyword value ...
          Nthread = # of OpenMP threads to associate with each MPI process
          zero or more keyword/value pairs may be appended
@@ -193,6 +199,14 @@ computation is done, but less communication.  In the future a value of
 for compatibility with the package command for other accelerator
 styles.  Note that the newton setting for bonded interactions is not
 affected by this keyword.
+
+The *pair/only* keyword can change how any "gpu" suffix is applied.
+By default a suffix is applied to all styles for which an accelerated
+variant is available.  However, that is not always the most effective
+way to use an accelerator.  With *pair/only* set to *on* the suffix
+will only by applied to supported pair styles, which tend to be the
+most effective in using an accelerator and their operation can be
+overlapped with all other computations on the CPU.
 
 The *binsize* keyword sets the size of bins used to bin atoms in
 neighbor list builds performed on the GPU, if *neigh* = *yes* is set.
@@ -539,6 +553,13 @@ running on GPUs or if using only one MPI rank. CUDA-aware MPI is available
 for OpenMPI 1.8 (or later versions), Mvapich2 1.9 (or later) when the
 "MV2_USE_CUDA" environment variable is set to "1", CrayMPI, and IBM
 Spectrum MPI when the "-gpu" flag is used.
+
+The *pair/only* keyword can change how the KOKKOS suffix "kk" is applied
+when using an accelerator device.  By default device acceleration is
+always used for all available styles.  With *pair/only* set to *on* the
+suffix setting will choose device acceleration only for pair styles and
+run all other force computations concurrently on the host GPU.  This can
+result in better performance for certain configurations and system sizes.
 
 ----------
 

--- a/src/GPU/fix_gpu.cpp
+++ b/src/GPU/fix_gpu.cpp
@@ -120,6 +120,7 @@ FixGPU::FixGPU(LAMMPS *lmp, int narg, char **arg) :
   double binsize = 0.0;
   char *opencl_flags = nullptr;
   int block_pair = -1;
+  int pair_only_flag = 0;
 
   int iarg = 4;
   while (iarg < narg) {
@@ -169,6 +170,12 @@ FixGPU::FixGPU(LAMMPS *lmp, int narg, char **arg) :
       if (iarg+2 > narg) error->all(FLERR,"Illegal package gpu command");
       block_pair = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
+    } else if (strcmp(arg[iarg],"pair/only") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal package gpu command");
+      if (strcmp(arg[iarg+1],"off") == 0) pair_only_flag = 0;
+      else if (strcmp(arg[iarg+1],"on") == 0) pair_only_flag = 1;
+      else error->all(FLERR,"Illegal package gpu command");
+      iarg += 2;
     } else error->all(FLERR,"Illegal package gpu command");
   }
 
@@ -185,6 +192,11 @@ FixGPU::FixGPU(LAMMPS *lmp, int narg, char **arg) :
   force->newton_pair = newtonflag;
   if (force->newton_pair || force->newton_bond) force->newton = 1;
   else force->newton = 0;
+
+  if (pair_only_flag) {
+    lmp->suffixp = lmp->suffix;
+    lmp->suffix = nullptr;
+  }
 
   // pass params to GPU library
   // change binsize default (0.0) to -1.0 used by GPU lib

--- a/src/GPU/fix_gpu.cpp
+++ b/src/GPU/fix_gpu.cpp
@@ -196,6 +196,11 @@ FixGPU::FixGPU(LAMMPS *lmp, int narg, char **arg) :
   if (pair_only_flag) {
     lmp->suffixp = lmp->suffix;
     lmp->suffix = nullptr;
+  } else {
+    if (lmp->suffixp) {
+      lmp->suffix = lmp->suffixp;
+      lmp->suffixp = nullptr;
+    }
   }
 
   // pass params to GPU library

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -425,36 +425,36 @@ void KokkosLMP::accelerator(int narg, char **arg)
   int nmpi = 0;
   MPI_Comm_size(world,&nmpi);
 
-  // if "cuda/aware off" or "pair/only on", and "comm device", change to "comm host"
+  // if "cuda/aware off" or "pair/only on", and "comm device", change to "comm no"
 
-  if (!gpu_aware_flag && nmpi > 1 || pair_only_flag) {
+  if ((!gpu_aware_flag && nmpi > 1) || pair_only_flag) {
     if (exchange_comm_classic == 0 && exchange_comm_on_host == 0) {
-      exchange_comm_on_host = 1;
+      exchange_comm_classic = 1;
       exchange_comm_changed = 1;
     }
     if (forward_comm_classic == 0 && forward_comm_on_host == 0) {
-      forward_comm_on_host = 1;
+      forward_comm_classic = 1;
       forward_comm_changed = 1;
     }
     if (reverse_comm_classic == 0 && reverse_comm_on_host == 0) {
-      reverse_comm_on_host = 1;
+      reverse_comm_classic = 1;
       reverse_comm_changed = 1;
     }
   }
 
-  // if "cuda/aware on" or "pair/only off" and comm flags were changed previously, change them back
+  // if "cuda/aware on" and "pair/only off", and comm flags were changed previously, change them back
 
   if (gpu_aware_flag && !pair_only_flag) {
     if (exchange_comm_changed) {
-      exchange_comm_on_host = 0;
+      exchange_comm_classic = 0;
       exchange_comm_changed = 0;
     }
     if (forward_comm_changed) {
-      forward_comm_on_host = 0;
+      forward_comm_classic = 0;
       forward_comm_changed = 0;
     }
     if (reverse_comm_changed) {
-      reverse_comm_on_host = 0;
+      reverse_comm_classic = 0;
       reverse_comm_changed = 0;
     }
   }

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -467,6 +467,14 @@ void KokkosLMP::accelerator(int narg, char **arg)
 
     exchange_comm_classic = forward_comm_classic = reverse_comm_classic = 1;
     exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 0;
+  } else {
+    // restore settings to regular suffix use, if previously, pair/only was used.
+    if (lmp->suffixp) {
+      delete[] lmp->suffix;
+      lmp->suffix = lmp->suffixp;
+      lmp->suffixp = nullptr;
+      // TODO: restore communication settings
+    }
   }
 }
 

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -301,6 +301,7 @@ KokkosLMP::~KokkosLMP()
 
 void KokkosLMP::accelerator(int narg, char **arg)
 {
+  int pair_only_flag = 0;
   int iarg = 0;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"neigh") == 0) {
@@ -390,6 +391,12 @@ void KokkosLMP::accelerator(int narg, char **arg)
       else if (strcmp(arg[iarg+1],"on") == 0) gpu_aware_flag = 1;
       else error->all(FLERR,"Illegal package kokkos command");
       iarg += 2;
+    } else if (strcmp(arg[iarg],"pair/only") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
+      if (strcmp(arg[iarg+1],"off") == 0) pair_only_flag = 0;
+      else if (strcmp(arg[iarg+1],"on") == 0) pair_only_flag = 1;
+      else error->all(FLERR,"Illegal package kokkos command");
+      iarg += 2;
     } else if (strcmp(arg[iarg],"neigh/thread") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
       if (strcmp(arg[iarg+1],"off") == 0) neigh_thread = 0;
@@ -452,6 +459,15 @@ void KokkosLMP::accelerator(int narg, char **arg)
   neighbor->binsize_user = binsize;
   if (binsize <= 0.0) neighbor->binsizeflag = 0;
   else neighbor->binsizeflag = 1;
+
+  if (pair_only_flag) {
+    lmp->suffixp = lmp->suffix;
+    lmp->suffix = new char[7];
+    strcpy(lmp->suffix,"kk/host");
+
+    exchange_comm_classic = forward_comm_classic = reverse_comm_classic = 1;
+    exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 0;
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1715,7 +1715,10 @@ void Input::pair_style()
     int match = 0;
     if (style == force->pair_style) match = 1;
     if (!match && lmp->suffix_enable) {
-      if (lmp->suffix)
+      if (lmp->suffixp)
+        if (style + "/" + lmp->suffixp == force->pair_style) match = 1;
+
+      if (lmp->suffix && !lmp->suffixp)
         if (style + "/" + lmp->suffix == force->pair_style) match = 1;
 
       if (lmp->suffix2)

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -173,7 +173,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
   int citeflag = 1;
   int helpflag = 0;
 
-  suffix = suffix2 = nullptr;
+  suffix = suffix2 = suffixp = nullptr;
   suffix_enable = 0;
   if (arg) exename = arg[0];
   else exename = nullptr;
@@ -714,6 +714,7 @@ LAMMPS::~LAMMPS()
   delete kokkos;
   delete [] suffix;
   delete [] suffix2;
+  delete [] suffixp;
 
   // free the MPI comm created by -mpi command-line arg processed in constructor
   // it was passed to universe as if original universe world

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -51,7 +51,7 @@ class LAMMPS {
 
   double initclock;              // wall clock at instantiation
 
-  char *suffix,*suffix2;         // suffixes to add to input script style names
+  char *suffix,*suffix2,*suffixp;// suffixes to add to input script style names
   int suffix_enable;             // 1 if suffixes are enabled, 0 if disabled
   char *exename;                 // pointer to argv[0]
   char ***packargs;              // arguments for cmdline package commands


### PR DESCRIPTION
**Summary**

This is an alternate, more minimal approach to implement a pair/only option for suffixes that makes the (primary) suffix applicable only to pair styles, which can be useful for GPU acceleration to better overlap with host computations.

**Related Issue(s)**

This tries to implement the same behavior as #2512 but in a way that is not limited to KOKKOS.
GPU package should already be supported, but it could be also applied to USER-INTEL and USER-OMP.

**Author(s)**

Stan Moore, SNL and Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issue.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
