### PR TITLE
Add support plumed2 library version 2.7.0

### DIFF
--- a/cmake/Modules/Packages/USER-PLUMED.cmake
+++ b/cmake/Modules/Packages/USER-PLUMED.cmake
@@ -55,8 +55,8 @@ if(DOWNLOAD_PLUMED)
   endif()
   include(ExternalProject)
   ExternalProject_Add(plumed_build
-    URL https://github.com/plumed/plumed2/releases/download/v2.6.1/plumed-src-2.6.1.tgz
-    URL_MD5 89a9a450fc6025299fe16af235957163
+    URL https://github.com/plumed/plumed2/releases/download/v2.7.0/plumed-src-2.7.0.tgz
+    URL_MD5 95f29dd0c067577f11972ff90dfc7d12
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
                                              ${CONFIGURE_REQUEST_PIC}

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -17,7 +17,7 @@ parser = ArgumentParser(prog='Install.py',
 
 # settings
 
-version = "2.6.1"
+version = "2.7.0"
 mode = "static"
 
 # help message
@@ -49,6 +49,7 @@ checksums = { \
         '2.5.4' : 'f31b7d16a4be2e30aa7d5c19c3d37853', \
         '2.6.0' : '204d2edae58d9b10ba3ad460cad64191', \
         '2.6.1' : '89a9a450fc6025299fe16af235957163', \
+        '2.7.0' : '95f29dd0c067577f11972ff90dfc7d12', \
         }
 
 # parse and process arguments

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -2542,13 +2542,13 @@ void FixShake::stats()
       const auto bcnt = b_count_all[i]/2;
       if (bcnt)
         mesg += fmt::format("{:>6d}   {:<9.6} {:<11.6} {:>8d}\n",i,
-                            b_ave_all[i]/bcnt,b_max_all[i]-b_min_all[i],bcnt);
+                            b_ave_all[i]/bcnt/2.0,b_max_all[i]-b_min_all[i],bcnt);
     }
     for (i = 1; i < na; i++) {
       const auto acnt = a_count_all[i]/3;
       if (acnt)
         mesg += fmt::format("{:>6d}   {:<9.6} {:<11.6} {:>8d}\n",i,
-                            a_ave_all[i]/acnt,a_max_all[i]-a_min_all[i],acnt);
+                            a_ave_all[i]/acnt/3.0,a_max_all[i]-a_min_all[i],acnt);
     }
     utils::logmesg(lmp,mesg);
   }

--- a/src/USER-PLUMED/fix_plumed.cpp
+++ b/src/USER-PLUMED/fix_plumed.cpp
@@ -78,9 +78,9 @@ FixPlumed::FixPlumed(LAMMPS *lmp, int narg, char **arg) :
 
   int api_version=0;
   p->cmd("getApiVersion",&api_version);
-  if ((api_version < 5) || (api_version > 7))
+  if ((api_version < 5) || (api_version > 8))
     error->all(FLERR,"Incompatible API version for PLUMED in fix plumed. "
-               "Only Plumed 2.4.x, 2.5.x, and 2.6.x are tested and supported.");
+               "Only Plumed 2.4.x, 2.5.x, 2.6.x, 2.7.x are tested and supported.");
 
 #if !defined(MPI_STUBS)
   // If the -partition option is activated then enable


### PR DESCRIPTION
**Summary**

This updates the default version of Plumed2 to be used by USER-PLUMED to the latest version 2.7.0

This also includes a small change to the "SHAKE stats" where a scaling factor was incorrectly removed for the averages, when the count of constraints was corrected.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. Only the URLs and md5sum hashes are updated.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
