### PR TITLE
Added functions for detecting the compile time configurations of the GPU package

### DIFF
--- a/lib/gpu/Makefile.hip
+++ b/lib/gpu/Makefile.hip
@@ -144,6 +144,9 @@ $(OBJ_DIR)/lal_%.o: lal_%.cpp $(CUHS) $(ALL_H)
 $(LIB_DIR)/libgpu.a: $(OBJS)
 	$(AR) -crs $@ $(OBJS)
 	printf "export HIP_PLATFORM := %s\n%s\n" "$(HIP_PLATFORM)" "$(HIP_LIBS_TARGET)" > Makefile.lammps
+	@echo "api = HIP_API" > configure.options
+	@echo "precision = $(HIP_PRECISION)" >> configure.options
+	@echo "arch = $(HIP_ARCH)" >> configure.options
 
 # test app building
 

--- a/lib/gpu/Nvidia.makefile
+++ b/lib/gpu/Nvidia.makefile
@@ -902,6 +902,9 @@ $(BIN_DIR)/nvc_get_devices: ./geryon/ucl_get_devices.cpp $(NVD_H)
 $(GPU_LIB): $(OBJS) $(CUDPP)
 	$(AR) -crusv $(GPU_LIB) $(OBJS) $(CUDPP)
 	@cp $(EXTRAMAKE) Makefile.lammps
+	@echo "api = CUDA_API" > configure.options
+	@echo "precision = $(CUDA_PRECISION)" >> configure.options
+	@echo "arch = $(CUDA_ARCH)" >> configure.options
 
 clean:
 	-rm -f $(EXECS) $(GPU_LIB) $(OBJS) $(CUDPP) $(CBNS) *.linkinfo

--- a/lib/gpu/Nvidia.makefile_multi
+++ b/lib/gpu/Nvidia.makefile_multi
@@ -902,6 +902,9 @@ $(BIN_DIR)/nvc_get_devices: ./geryon/ucl_get_devices.cpp $(NVD_H)
 $(GPU_LIB): $(OBJS) $(CUDPP)
 	$(AR) -crusv $(GPU_LIB) $(OBJS) $(CUDPP)
 	@cp $(EXTRAMAKE) Makefile.lammps
+	@echo "api = CUDA_API" > configure.options
+	@echo "precision = $(CUDA_PRECISION)" >> configure.options
+	@echo "arch = $(CUDA_ARCH)" >> configure.options
 
 clean:
 	-rm -f $(EXECS) $(GPU_LIB) $(OBJS) $(CUDPP) $(CBNS) *.linkinfo

--- a/lib/gpu/Opencl.makefile
+++ b/lib/gpu/Opencl.makefile
@@ -660,6 +660,9 @@ $(BIN_DIR)/ocl_get_devices: ./geryon/ucl_get_devices.cpp $(OCL_H)
 $(OCL_LIB): $(OBJS) $(PTXS)
 	$(AR) -crusv $(OCL_LIB) $(OBJS)
 	@cp $(EXTRAMAKE) Makefile.lammps
+	@echo "api = OPENCL_API" > configure.options
+	@echo "precision = $(OCL_PREC)" >> configure.options
+	@echo "arch = $(OCL_TUNE)" >> configure.options
 
 opencl: $(OCL_EXECS)
 

--- a/lib/gpu/lal_device.cpp
+++ b/lib/gpu/lal_device.cpp
@@ -37,6 +37,21 @@ template <class numtyp, class acctyp>
 DeviceT::Device() : _init_count(0), _device_init(false),
                     _gpu_mode(GPU_FORCE), _first_device(0),
                     _last_device(0), _platform_id(-1), _compiled(false) {
+  #if defined(USE_OPENCL)
+  _api=OPENCL_API;
+  #elif defined(USE_HIP)
+  _api=HIP_API;
+  #else
+  _api=CUDA_API;
+  #endif
+
+  if (sizeof(numtyp)==4) {
+    if (sizeof(acctyp)==4)
+      _precision_mode=SINGLE_SINGLE;
+    else
+      _precision_mode=SINGLE_DOUBLE;
+  } else
+    _precision_mode=DOUBLE_DOUBLE;
 }
 
 template <class numtyp, class acctyp>
@@ -773,6 +788,14 @@ int lmp_init_device(MPI_Comm world, MPI_Comm replica, const int first_gpu,
   return global_device.init_device(world,replica,first_gpu,last_gpu,gpu_mode,
                                    particle_split,nthreads,t_per_atom,
                                    cell_size,opencl_vendor,block_pair);
+}
+
+int lmp_get_api() {
+  return global_device.api();
+}
+
+int lmp_get_precision_mode() {
+  return global_device.precision_mode();
 }
 
 void lmp_clear_device() {

--- a/lib/gpu/lal_device.h
+++ b/lib/gpu/lal_device.h
@@ -256,12 +256,12 @@ class Device {
   inline int max_bio_shared_types() const { return _max_bio_shared_types; }
   /// Architecture gpu code compiled for (returns 0 for OpenCL)
   inline double ptx_arch() const { return _ptx_arch; }
-  /// Number of threads executing concurrently on same multiproc
+  /// Retrun the number of threads executing concurrently on same multiproc
   inline int warp_size() const { return _warp_size; }
-  /// API
+  /// Return the API in use
   enum{CUDA_API, OPENCL_API, HIP_API};
   inline int api() { return _api; }
-  /// Precision mode
+  /// Return the precision mode with which the library is built
   enum{SINGLE_SINGLE, SINGLE_DOUBLE, DOUBLE_DOUBLE};
   inline int precision_mode() { return _precision_mode; }
 

--- a/lib/gpu/lal_device.h
+++ b/lib/gpu/lal_device.h
@@ -258,6 +258,12 @@ class Device {
   inline double ptx_arch() const { return _ptx_arch; }
   /// Number of threads executing concurrently on same multiproc
   inline int warp_size() const { return _warp_size; }
+  /// API
+  enum{CUDA_API, OPENCL_API, HIP_API};
+  inline int api() { return _api; }
+  /// Precision mode
+  enum{SINGLE_SINGLE, SINGLE_DOUBLE, DOUBLE_DOUBLE};
+  inline int precision_mode() { return _precision_mode; }
 
   // -------------------- SHARED DEVICE ROUTINES --------------------
   // Perform asynchronous zero of integer array
@@ -333,6 +339,9 @@ class Device {
 
   std::string _ocl_vendor_name, _ocl_vendor_string, _ocl_compile_string;
   int set_ocl_params(char *);
+
+  int _api;
+  int _precision_mode;
 
   template <class t>
   inline std::string toa(const t& in) {

--- a/src/GPU/fix_gpu.cpp
+++ b/src/GPU/fix_gpu.cpp
@@ -35,6 +35,8 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
+enum{CUDA_API, OPENCL_API, HIP_API};
+enum{SINGLE_SINGLE, SINGLE_DOUBLE, DOUBLE_DOUBLE};
 enum{GPU_FORCE, GPU_NEIGH, GPU_HYB_NEIGH};
 
 extern int lmp_init_device(MPI_Comm world, MPI_Comm replica,
@@ -43,6 +45,8 @@ extern int lmp_init_device(MPI_Comm world, MPI_Comm replica,
                            const int nthreads, const int t_per_atom,
                            const double cell_size, char *opencl_flags,
                            const int block_pair);
+extern int lmp_get_api();
+extern int lmp_get_precision_mode();
 extern void lmp_clear_device();
 extern double lmp_gpu_forces(double **f, double **tor, double *eatom,
                              double **vatom, double *virial, double &ecoul);

--- a/src/GPU/fix_gpu.cpp
+++ b/src/GPU/fix_gpu.cpp
@@ -322,3 +322,17 @@ double FixGPU::memory_usage()
   return bytes;
 }
 
+/* ---------------------------------------------------------------------- */
+
+int FixGPU::get_api()
+{
+  return lmp_get_api();
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixGPU::get_precision_mode()
+{
+  return lmp_get_precision_mode();
+}
+

--- a/src/GPU/fix_gpu.h
+++ b/src/GPU/fix_gpu.h
@@ -36,6 +36,8 @@ class FixGPU : public Fix {
   void min_post_force(int);
   void post_force_respa(int, int, int);
   double memory_usage();
+  int get_api();
+  int get_precision_mode();
 
  private:
   int _gpu_mode;


### PR DESCRIPTION
**Summary**

This PR addresses the feature request #2551, adding functions that return the compile time settings of the GPU package. Two functions are added to return the API (CUDA, OpenCL or HIP) and the precision mode (single, mixed or double) used to build the GPU library.

**Related Issue(s)**

N/A

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

This implemetation may need further changes/re-arrangement to have a consistent interface across accelerator packages when detection is used in unit testing, or when using LAMMPS as a library from external codes. I am open for suggestions.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


