### PR TITLE
Fix issues in Kokkos package with pair/only on

### DIFF
--- a/src/KOKKOS/fix_dpd_energy_kokkos.cpp
+++ b/src/KOKKOS/fix_dpd_energy_kokkos.cpp
@@ -58,7 +58,8 @@ void FixDPDenergyKokkos<DeviceType>::take_half_step()
 
   auto dt = update->dt;
 
-  Kokkos::parallel_for(nlocal, LAMMPS_LAMBDA(int i) {
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+    LAMMPS_LAMBDA(int i) {
     uCond(i) += 0.5*dt*duCond(i);
     uMech(i) += 0.5*dt*duMech(i);
   });

--- a/src/KOKKOS/fix_dpd_energy_kokkos.cpp
+++ b/src/KOKKOS/fix_dpd_energy_kokkos.cpp
@@ -59,7 +59,7 @@ void FixDPDenergyKokkos<DeviceType>::take_half_step()
   auto dt = update->dt;
 
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
-    LAMMPS_LAMBDA(int i) {
+   LAMMPS_LAMBDA(int i) {
     uCond(i) += 0.5*dt*duCond(i);
     uMech(i) += 0.5*dt*duMech(i);
   });

--- a/src/KOKKOS/fix_momentum_kokkos.cpp
+++ b/src/KOKKOS/fix_momentum_kokkos.cpp
@@ -59,7 +59,8 @@ static double get_kinetic_energy(
   if (atomKK->rmass) {
     atomKK->sync(execution_space, RMASS_MASK);
     typename AT::t_float_1d_randomread rmass = atomKK->k_rmass.view<DeviceType>();
-    Kokkos::parallel_reduce(nlocal, LAMMPS_LAMBDA(int i, double& update) {
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+      LAMMPS_LAMBDA(int i, double& update) {
       if (mask(i) & groupbit)
         update += rmass(i) *
           (v(i,0)*v(i,0) + v(i,1)*v(i,1) + v(i,2)*v(i,2));
@@ -69,7 +70,8 @@ static double get_kinetic_energy(
     atomKK->sync(execution_space, TYPE_MASK);
     typename AT::t_int_1d_randomread type = atomKK->k_type.view<DeviceType>();
     typename AT::t_float_1d_randomread mass = atomKK->k_mass.view<DeviceType>();
-    Kokkos::parallel_reduce(nlocal, LAMMPS_LAMBDA(int i, double& update) {
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+      LAMMPS_LAMBDA(int i, double& update) {
       if (mask(i) & groupbit)
         update += mass(type(i)) *
           (v(i,0)*v(i,0) + v(i,1)*v(i,1) + v(i,2)*v(i,2));
@@ -121,7 +123,8 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
     auto yflag2 = yflag;
     auto zflag2 = zflag;
 
-    Kokkos::parallel_for(nlocal, LAMMPS_LAMBDA(int i) {
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+      LAMMPS_LAMBDA(int i) {
       if (mask(i) & groupbit2) {
         if (xflag2) v(i,0) -= vcm[0];
         if (yflag2) v(i,1) -= vcm[1];
@@ -159,7 +162,8 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
     auto prd = Few<double,3>(domain->prd);
     auto h = Few<double,6>(domain->h);
     auto triclinic = domain->triclinic;
-    Kokkos::parallel_for(nlocal, LAMMPS_LAMBDA(int i) {
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+      LAMMPS_LAMBDA(int i) {
       if (mask[i] & groupbit2) {
         Few<double,3> x_i;
         x_i[0] = x(i,0);
@@ -185,7 +189,8 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
 
     double factor = 1.0;
     if (ekin_new != 0.0) factor = sqrt(ekin_old/ekin_new);
-    Kokkos::parallel_for(nlocal, LAMMPS_LAMBDA(int i) {
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+      LAMMPS_LAMBDA(int i) {
       if (mask(i) & groupbit2) {
         v(i,0) *= factor;
         v(i,1) *= factor;

--- a/src/KOKKOS/fix_momentum_kokkos.cpp
+++ b/src/KOKKOS/fix_momentum_kokkos.cpp
@@ -60,7 +60,7 @@ static double get_kinetic_energy(
     atomKK->sync(execution_space, RMASS_MASK);
     typename AT::t_float_1d_randomread rmass = atomKK->k_rmass.view<DeviceType>();
     Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal),
-      LAMMPS_LAMBDA(int i, double& update) {
+     LAMMPS_LAMBDA(int i, double& update) {
       if (mask(i) & groupbit)
         update += rmass(i) *
           (v(i,0)*v(i,0) + v(i,1)*v(i,1) + v(i,2)*v(i,2));
@@ -71,7 +71,7 @@ static double get_kinetic_energy(
     typename AT::t_int_1d_randomread type = atomKK->k_type.view<DeviceType>();
     typename AT::t_float_1d_randomread mass = atomKK->k_mass.view<DeviceType>();
     Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal),
-      LAMMPS_LAMBDA(int i, double& update) {
+     LAMMPS_LAMBDA(int i, double& update) {
       if (mask(i) & groupbit)
         update += mass(type(i)) *
           (v(i,0)*v(i,0) + v(i,1)*v(i,1) + v(i,2)*v(i,2));
@@ -124,7 +124,7 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
     auto zflag2 = zflag;
 
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
-      LAMMPS_LAMBDA(int i) {
+     LAMMPS_LAMBDA(int i) {
       if (mask(i) & groupbit2) {
         if (xflag2) v(i,0) -= vcm[0];
         if (yflag2) v(i,1) -= vcm[1];
@@ -163,7 +163,7 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
     auto h = Few<double,6>(domain->h);
     auto triclinic = domain->triclinic;
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
-      LAMMPS_LAMBDA(int i) {
+     LAMMPS_LAMBDA(int i) {
       if (mask[i] & groupbit2) {
         Few<double,3> x_i;
         x_i[0] = x(i,0);
@@ -190,7 +190,7 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
     double factor = 1.0;
     if (ekin_new != 0.0) factor = sqrt(ekin_old/ekin_new);
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
-      LAMMPS_LAMBDA(int i) {
+     LAMMPS_LAMBDA(int i) {
       if (mask(i) & groupbit2) {
         v(i,0) *= factor;
         v(i,1) *= factor;

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -242,7 +242,7 @@ void FixShakeKokkos<DeviceType>::pre_neighbor()
     auto d_nlist = this->d_nlist;
     auto map_array = this->map_array;
 
-    Kokkos::parallel_for(nlocal, LAMMPS_LAMBDA(const int& i) {
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i) {
       if (d_shake_flag[i]) {
         if (d_shake_flag[i] == 2) {
           const int atom1 = map_array(d_shake_atom(i,0));
@@ -306,9 +306,9 @@ void FixShakeKokkos<DeviceType>::post_force(int vflag)
   nlocal = atomKK->nlocal;
 
   if (d_rmass.data())
-    atomKK->sync(Device,X_MASK|F_MASK|RMASS_MASK);
+    atomKK->sync(execution_space,X_MASK|F_MASK|RMASS_MASK);
   else
-    atomKK->sync(Device,X_MASK|F_MASK|TYPE_MASK);
+    atomKK->sync(execution_space,X_MASK|F_MASK|TYPE_MASK);
 
   k_shake_flag.sync<DeviceType>();
   k_shake_atom.sync<DeviceType>();
@@ -406,7 +406,7 @@ void FixShakeKokkos<DeviceType>::post_force(int vflag)
   if (need_dup)
     Kokkos::Experimental::contribute(d_f,dup_f);
 
-  atomKK->modified(Device,F_MASK);
+  atomKK->modified(execution_space,F_MASK);
 
   if (vflag_global) {
     virial[0] += ev.v[0];
@@ -463,7 +463,7 @@ int FixShakeKokkos<DeviceType>::dof(int igroup)
   d_tag = atomKK->k_tag.view<DeviceType>();
   nlocal = atom->nlocal;
 
-  atomKK->sync(Device,MASK_MASK|TAG_MASK);
+  atomKK->sync(execution_space,MASK_MASK|TAG_MASK);
   k_shake_flag.sync<DeviceType>();
   k_shake_atom.sync<DeviceType>();
 
@@ -480,7 +480,7 @@ int FixShakeKokkos<DeviceType>::dof(int igroup)
     auto mask = this->d_mask;
     auto groupbit = group->bitmask[igroup];
 
-    Kokkos::parallel_reduce(nlocal, LAMMPS_LAMBDA(const int& i, int& n) {
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i, int& n) {
       if (!(mask[i] & groupbit)) return;
       if (d_shake_flag[i] == 0) return;
       if (d_shake_atom(i,0) != tag[i]) return;
@@ -513,9 +513,9 @@ void FixShakeKokkos<DeviceType>::unconstrained_update()
   nlocal = atom->nlocal;
 
   if (d_rmass.data())
-    atomKK->sync(Device,X_MASK|V_MASK|F_MASK|RMASS_MASK);
+    atomKK->sync(execution_space,X_MASK|V_MASK|F_MASK|RMASS_MASK);
   else
-    atomKK->sync(Device,X_MASK|V_MASK|F_MASK|TYPE_MASK);
+    atomKK->sync(execution_space,X_MASK|V_MASK|F_MASK|TYPE_MASK);
 
 
   k_shake_flag.sync<DeviceType>();
@@ -536,7 +536,7 @@ void FixShakeKokkos<DeviceType>::unconstrained_update()
 
       auto rmass = this->d_rmass;
 
-      Kokkos::parallel_for(nlocal, LAMMPS_LAMBDA(const int& i) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i) {
         if (d_shake_flag[i]) {
           const double dtfmsq = dtfsq / rmass[i];
           d_xshake(i,0) = x(i,0) + dtv*v(i,0) + dtfmsq*f(i,0);
@@ -549,7 +549,7 @@ void FixShakeKokkos<DeviceType>::unconstrained_update()
       auto mass = this->d_mass;
       auto type = this->d_type;
 
-      Kokkos::parallel_for(nlocal, LAMMPS_LAMBDA(const int& i) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i) {
         if (d_shake_flag[i]) {
           const double dtfmsq = dtfsq / mass[type[i]];
           d_xshake(i,0) = x(i,0) + dtv*v(i,0) + dtfmsq*f(i,0);

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -242,7 +242,8 @@ void FixShakeKokkos<DeviceType>::pre_neighbor()
     auto d_nlist = this->d_nlist;
     auto map_array = this->map_array;
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i) {
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+     LAMMPS_LAMBDA(const int& i) {
       if (d_shake_flag[i]) {
         if (d_shake_flag[i] == 2) {
           const int atom1 = map_array(d_shake_atom(i,0));
@@ -480,7 +481,8 @@ int FixShakeKokkos<DeviceType>::dof(int igroup)
     auto mask = this->d_mask;
     auto groupbit = group->bitmask[igroup];
 
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i, int& n) {
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+     LAMMPS_LAMBDA(const int& i, int& n) {
       if (!(mask[i] & groupbit)) return;
       if (d_shake_flag[i] == 0) return;
       if (d_shake_atom(i,0) != tag[i]) return;
@@ -536,7 +538,8 @@ void FixShakeKokkos<DeviceType>::unconstrained_update()
 
       auto rmass = this->d_rmass;
 
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+       LAMMPS_LAMBDA(const int& i) {
         if (d_shake_flag[i]) {
           const double dtfmsq = dtfsq / rmass[i];
           d_xshake(i,0) = x(i,0) + dtv*v(i,0) + dtfmsq*f(i,0);
@@ -549,7 +552,8 @@ void FixShakeKokkos<DeviceType>::unconstrained_update()
       auto mass = this->d_mass;
       auto type = this->d_type;
 
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
+       LAMMPS_LAMBDA(const int& i) {
         if (d_shake_flag[i]) {
           const double dtfmsq = dtfsq / mass[type[i]];
           d_xshake(i,0) = x(i,0) + dtv*v(i,0) + dtfmsq*f(i,0);

--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -653,7 +653,7 @@ void FixShardlowKokkos<DeviceType>::initial_integrate(int /*vflag*/)
       atomKK->sync(execution_space,UCOND_MASK | UMECH_MASK);
       auto l_uCond = uCond;
       auto l_uMech = uMech;
-      Kokkos::parallel_for(Kokkos::RangePolicy<LMPDeviceType>(nlocal,nlocal+nghost), LAMMPS_LAMBDA (const int i) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(nlocal,nlocal+nghost), LAMMPS_LAMBDA (const int i) {
         l_uCond(i) = 0.0;
         l_uMech(i) = 0.0;
       });

--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -653,7 +653,8 @@ void FixShardlowKokkos<DeviceType>::initial_integrate(int /*vflag*/)
       atomKK->sync(execution_space,UCOND_MASK | UMECH_MASK);
       auto l_uCond = uCond;
       auto l_uMech = uMech;
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(nlocal,nlocal+nghost), LAMMPS_LAMBDA (const int i) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(nlocal,nlocal+nghost),
+       LAMMPS_LAMBDA (const int i) {
         l_uCond(i) = 0.0;
         l_uMech(i) = 0.0;
       });

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -1154,11 +1154,7 @@ typedef SNAComplex<SNAreal> SNAcomplex;
 #define ISFINITE(x) std::isfinite(x)
 #endif
 
-#ifdef LMP_KOKKOS_GPU
-#define LAMMPS_LAMBDA [=] __device__
-#else
-#define LAMMPS_LAMBDA [=]
-#endif
+#define LAMMPS_LAMBDA KOKKOS_LAMBDA
 
 #ifdef LMP_KOKKOS_GPU
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)

--- a/src/KOKKOS/nbin_ssa_kokkos.cpp
+++ b/src/KOKKOS/nbin_ssa_kokkos.cpp
@@ -158,7 +158,7 @@ void NBinSSAKokkos<DeviceType>::bin_atoms()
     auto gbincount_ = gbincount;
     auto gbins_ = gbins;
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<LMPDeviceType>(nlocal,nall),
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(nlocal,nall),
       LAMMPS_LAMBDA (const int i) {
       const int iAIR = binID_(i);
       if (iAIR > 0) { // include only ghost atoms in an AIR
@@ -166,7 +166,7 @@ void NBinSSAKokkos<DeviceType>::bin_atoms()
         gbins_(iAIR, ac) = i;
       }
     });
-    Kokkos::parallel_for(Kokkos::RangePolicy<LMPDeviceType>(1,8),
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(1,8),
       LAMMPS_LAMBDA (const int i) {
       sortBin(gbincount_, gbins_, i);
     });
@@ -190,7 +190,7 @@ void NBinSSAKokkos<DeviceType>::bin_atoms()
     NPairSSAKokkosBinAtomsFunctor<DeviceType> f(*this);
     Kokkos::parallel_for(nlocal, f);
 
-    Kokkos::parallel_for(mbins,
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,mbins),
       LAMMPS_LAMBDA (const int i) {
       sortBin(bincount_, bins_, i);
     });

--- a/src/KOKKOS/nbin_ssa_kokkos.cpp
+++ b/src/KOKKOS/nbin_ssa_kokkos.cpp
@@ -159,7 +159,7 @@ void NBinSSAKokkos<DeviceType>::bin_atoms()
     auto gbins_ = gbins;
 
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(nlocal,nall),
-      LAMMPS_LAMBDA (const int i) {
+     LAMMPS_LAMBDA (const int i) {
       const int iAIR = binID_(i);
       if (iAIR > 0) { // include only ghost atoms in an AIR
         const int ac = Kokkos::atomic_fetch_add(&gbincount_[iAIR], (int)1);
@@ -167,7 +167,7 @@ void NBinSSAKokkos<DeviceType>::bin_atoms()
       }
     });
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(1,8),
-      LAMMPS_LAMBDA (const int i) {
+     LAMMPS_LAMBDA (const int i) {
       sortBin(gbincount_, gbins_, i);
     });
   }
@@ -191,7 +191,7 @@ void NBinSSAKokkos<DeviceType>::bin_atoms()
     Kokkos::parallel_for(nlocal, f);
 
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,mbins),
-      LAMMPS_LAMBDA (const int i) {
+     LAMMPS_LAMBDA (const int i) {
       sortBin(bincount_, bins_, i);
     });
   }

--- a/src/KOKKOS/npair_ssa_kokkos.cpp
+++ b/src/KOKKOS/npair_ssa_kokkos.cpp
@@ -461,7 +461,7 @@ fprintf(stdout, "tota%03d total %3d could use %6d inums, expected %6d inums. inu
 
     // loop over bins with local atoms, storing half of the neighbors
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,ssa_phaseCt),
-      LAMMPS_LAMBDA (const int workPhase) {
+     LAMMPS_LAMBDA (const int workPhase) {
       data.build_locals_onePhase(firstTry, comm->me, workPhase);
     });
     k_ssa_itemLoc.modify<DeviceType>();
@@ -475,7 +475,7 @@ fprintf(stdout, "tota%03d total %3d could use %6d inums, expected %6d inums. inu
 
     // loop over AIR ghost atoms, storing their local neighbors
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,ssa_gphaseCt),
-      LAMMPS_LAMBDA (const int workPhase) {
+     LAMMPS_LAMBDA (const int workPhase) {
       data.build_ghosts_onePhase(workPhase);
     });
     k_ssa_gitemLoc.modify<DeviceType>();

--- a/src/KOKKOS/npair_ssa_kokkos.cpp
+++ b/src/KOKKOS/npair_ssa_kokkos.cpp
@@ -460,7 +460,8 @@ fprintf(stdout, "tota%03d total %3d could use %6d inums, expected %6d inums. inu
     Kokkos::deep_copy(data.new_maxneighs, data.h_new_maxneighs);
 
     // loop over bins with local atoms, storing half of the neighbors
-    Kokkos::parallel_for(ssa_phaseCt, LAMMPS_LAMBDA (const int workPhase) {
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,ssa_phaseCt),
+      LAMMPS_LAMBDA (const int workPhase) {
       data.build_locals_onePhase(firstTry, comm->me, workPhase);
     });
     k_ssa_itemLoc.modify<DeviceType>();
@@ -473,7 +474,8 @@ fprintf(stdout, "tota%03d total %3d could use %6d inums, expected %6d inums. inu
       h_ssa_itemLen(ssa_phaseCt-1,h_ssa_phaseLen(ssa_phaseCt-1)-1);
 
     // loop over AIR ghost atoms, storing their local neighbors
-    Kokkos::parallel_for(ssa_gphaseCt, LAMMPS_LAMBDA (const int workPhase) {
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,ssa_gphaseCt),
+      LAMMPS_LAMBDA (const int workPhase) {
       data.build_ghosts_onePhase(workPhase);
     });
     k_ssa_gitemLoc.modify<DeviceType>();

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -572,7 +572,7 @@ static void compute_all_items(
                  typename KKDevice<DeviceType>::value,
                  Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > v_eatom) {
   if (eflag || vflag) {
-    Kokkos::parallel_reduce(inum,
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,inum),
     LAMMPS_LAMBDA(int i, EV_FLOAT& energy_virial) {
         energy_virial +=
           compute_item<DeviceType,NEIGHFLAG,STACKPARAMS,TABSTYLE,1,NEWTON_PAIR>(
@@ -583,7 +583,7 @@ static void compute_all_items(
             vflag, vflag_global, vflag_atom, v_vatom, v_eatom);
     }, ev);
   } else {
-    Kokkos::parallel_for(inum,
+    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,inum),
     LAMMPS_LAMBDA(int i) {
         compute_item<DeviceType,NEIGHFLAG,STACKPARAMS,TABSTYLE,0,NEWTON_PAIR>(
             i, nlocal, d_ilist, d_neighbors, d_numneigh, x, type,
@@ -606,7 +606,7 @@ static void getAllMixingWeights(
     Kokkos::View<double*, DeviceType> const& mixWtSite2old,
     Kokkos::View<double*, DeviceType> const& mixWtSite1,
     Kokkos::View<double*, DeviceType> const& mixWtSite2) {
-  Kokkos::parallel_for(ntotal,
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,ntotal),
   LAMMPS_LAMBDA(int i) {
       getMixingWeights<DeviceType>(dvector,nspecies,isite1,isite2,fractionalWeighting,
         i, mixWtSite1old(i), mixWtSite2old(i), mixWtSite1(i), mixWtSite2(i));

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -573,7 +573,7 @@ static void compute_all_items(
                  Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > v_eatom) {
   if (eflag || vflag) {
     Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,inum),
-    LAMMPS_LAMBDA(int i, EV_FLOAT& energy_virial) {
+     LAMMPS_LAMBDA(int i, EV_FLOAT& energy_virial) {
         energy_virial +=
           compute_item<DeviceType,NEIGHFLAG,STACKPARAMS,TABSTYLE,1,NEWTON_PAIR>(
             i, nlocal, d_ilist, d_neighbors, d_numneigh, x, type,
@@ -584,7 +584,7 @@ static void compute_all_items(
     }, ev);
   } else {
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,inum),
-    LAMMPS_LAMBDA(int i) {
+     LAMMPS_LAMBDA(int i) {
         compute_item<DeviceType,NEIGHFLAG,STACKPARAMS,TABSTYLE,0,NEWTON_PAIR>(
             i, nlocal, d_ilist, d_neighbors, d_numneigh, x, type,
             mixWtSite1old, mixWtSite2old, mixWtSite1, mixWtSite2,
@@ -607,7 +607,7 @@ static void getAllMixingWeights(
     Kokkos::View<double*, DeviceType> const& mixWtSite1,
     Kokkos::View<double*, DeviceType> const& mixWtSite2) {
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,ntotal),
-  LAMMPS_LAMBDA(int i) {
+   LAMMPS_LAMBDA(int i) {
       getMixingWeights<DeviceType>(dvector,nspecies,isite1,isite2,fractionalWeighting,
         i, mixWtSite1old(i), mixWtSite2old(i), mixWtSite1(i), mixWtSite2(i));
   });


### PR DESCRIPTION
**Summary**

Fix issues in Kokkos package with `pair/only on`. In some places, views were being sync'd to Device instead of the template parameter, and some lambdas were running with the default execution space instead of the template parameter.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Evan Weinberg (NVIDIA) @weinbe2

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes