### PR TITLE
Detect UTF-8 multibyte characters input and replace with ASCII equivalents where known

### DIFF
--- a/doc/src/Commands_parse.rst
+++ b/doc/src/Commands_parse.rst
@@ -162,3 +162,26 @@ LAMMPS:
    triple quotes can be nested in the usual manner.  See the doc pages
    for those commands for examples.  Only one of level of nesting is
    allowed, but that should be sufficient for most use cases.
+
+.. admonition:: ASCII versus UTF-8
+        :class: note
+
+   LAMMPS expects and processes 7-bit ASCII format text internally.
+   Many modern environments use UTF-8 encoding, which is a superset
+   of the 7-bit ASCII character table and thus mostly compatible.
+   However, there are several non-ASCII characters that can look
+   very similar to their ASCII equivalents or are invisible (so they
+   look like a blank), but are encoded differently.  Web browsers,
+   PDF viewers, document editors are known to sometimes replace one
+   with the other for a better looking output.  However, that can
+   lead to problems, for instance, when using cut-n-paste of input
+   file examples from web pages, or when using a document editor
+   (not a dedicated plain text editor) for writing LAMMPS inputs.
+   LAMMPS will try to detect this and substitute the non-ASCII
+   characters with their ASCII equivalents where known.  There also
+   is going to be a warning printed, if this occurs.  It is
+   recommended to avoid such characters altogether in LAMMPS input,
+   data and potential files.  The replacement tables are likely
+   incomplete and dependent on users reporting problems processing
+   correctly looking input containing UTF-8 encoded non-ASCII
+   characters.

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -77,6 +77,12 @@ and parsing files or arguments.
 .. doxygenfunction:: trim_comment
    :project: progguide
 
+.. doxygenfunction:: has_utf8
+   :project: progguide
+
+.. doxygenfunction:: utf8_subst
+   :project: progguide
+
 .. doxygenfunction:: count_words(const char *text)
    :project: progguide
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -106,6 +106,7 @@ Input::Input(LAMMPS *lmp, int argc, char **argv) : Pointers(lmp)
   label_active = 0;
   labelstr = nullptr;
   jump_skip = 0;
+  utf8_warn = true;
 
   if (me == 0) {
     nfile = 1;
@@ -419,6 +420,16 @@ void Input::parse()
       else if (quoteflag == 1 && *ptr == '\'') quoteflag = 0;
     }
     ptr++;
+  }
+
+  if (utils::has_utf8(copy)) {
+    std::string buf = utils::utf8_subst(copy);
+    strcpy(copy,buf.c_str());
+    if (utf8_warn && (comm->me == 0))
+      error->warning(FLERR,"Detected non-ASCII characters in input. "
+                     "Will try to continue by replacing with ASCII "
+                     "equivalents where known.");
+    utf8_warn = false;
   }
 
   // perform $ variable substitution (print changes)

--- a/src/input.h
+++ b/src/input.h
@@ -54,6 +54,7 @@ class Input : protected Pointers {
   int label_active;            // 0 = no label, 1 = looking for label
   char *labelstr;              // label string being looked for
   int jump_skip;               // 1 if skipping next jump, 0 otherwise
+  bool utf8_warn;              // true if need to warn about UTF-8 chars
 
   FILE **infiles;              // list of open input files
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -210,6 +210,7 @@ std::string ValueTokenizer::next_string() {
 int ValueTokenizer::next_int() {
     if (has_next()) {
         std::string current = tokens.next();
+        if (utils::has_utf8(current)) current = utils::utf8_subst(current);
         if (!utils::is_integer(current)) {
             throw InvalidIntegerException(current);
         }
@@ -225,6 +226,7 @@ int ValueTokenizer::next_int() {
 bigint ValueTokenizer::next_bigint() {
     if (has_next()) {
         std::string current = tokens.next();
+        if (utils::has_utf8(current)) current = utils::utf8_subst(current);
         if (!utils::is_integer(current)) {
             throw InvalidIntegerException(current);
         }
@@ -240,6 +242,7 @@ bigint ValueTokenizer::next_bigint() {
 tagint ValueTokenizer::next_tagint() {
     if (has_next()) {
         std::string current = tokens.next();
+        if (utils::has_utf8(current)) current = utils::utf8_subst(current);
         if (!utils::is_integer(current)) {
             throw InvalidIntegerException(current);
         }
@@ -255,6 +258,7 @@ tagint ValueTokenizer::next_tagint() {
 double ValueTokenizer::next_double() {
     if (has_next()) {
         std::string current = tokens.next();
+        if (utils::has_utf8(current)) current = utils::utf8_subst(current);
         if (!utils::is_double(current)) {
             throw InvalidFloatException(current);
         }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -237,28 +237,27 @@ double utils::numeric(const char *file, int line, const char *str,
 
   if (str) n = strlen(str);
   if (n == 0) {
-    if (do_abort)
-      lmp->error->one(file,line,"Expected floating point parameter instead of"
-                      " NULL or empty string in input script or data file");
-    else
-      lmp->error->all(file,line,"Expected floating point parameter instead of"
-                      " NULL or empty string in input script or data file");
-  }
-
-  for (int i = 0; i < n; i++) {
-    if (isdigit(str[i])) continue;
-    if (str[i] == '-' || str[i] == '+' || str[i] == '.') continue;
-    if (str[i] == 'e' || str[i] == 'E') continue;
-    std::string msg("Expected floating point parameter instead of '");
-    msg += str;
-    msg += "' in input script or data file";
+    const char msg[] = "Expected floating point parameter instead of"
+      " NULL or empty string in input script or data file";
     if (do_abort)
       lmp->error->one(file,line,msg);
     else
       lmp->error->all(file,line,msg);
   }
 
-  return atof(str);
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  if (buf.find_first_not_of("0123456789-+.eE") != std::string::npos) {
+    std::string msg("Expected floating point parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg);
+    else
+      lmp->error->all(file,line,msg);
+  }
+
+  return atof(buf.c_str());
 }
 
 /* ----------------------------------------------------------------------
@@ -274,26 +273,27 @@ int utils::inumeric(const char *file, int line, const char *str,
 
   if (str) n = strlen(str);
   if (n == 0) {
-    if (do_abort)
-      lmp->error->one(file,line,"Expected integer parameter instead of "
-                      "NULL or empty string in input script or data file");
-    else
-      lmp->error->all(file,line,"Expected integer parameter instead of "
-                      "NULL or empty string in input script or data file");
-  }
-
-  for (int i = 0; i < n; i++) {
-    if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
-    std::string msg("Expected integer parameter instead of '");
-    msg += str;
-    msg += "' in input script or data file";
+    const char msg[] = "Expected integer parameter instead of"
+      " NULL or empty string in input script or data file";
     if (do_abort)
       lmp->error->one(file,line,msg);
     else
       lmp->error->all(file,line,msg);
   }
 
-  return atoi(str);
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  if (buf.find_first_not_of("0123456789-+") != std::string::npos) {
+    std::string msg("Expected integer parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg);
+    else
+      lmp->error->all(file,line,msg);
+  }
+
+  return atoi(buf.c_str());
 }
 
 /* ----------------------------------------------------------------------
@@ -309,26 +309,27 @@ bigint utils::bnumeric(const char *file, int line, const char *str,
 
   if (str) n = strlen(str);
   if (n == 0) {
-    if (do_abort)
-      lmp->error->one(file,line,"Expected integer parameter instead of "
-                      "NULL or empty string in input script or data file");
-    else
-      lmp->error->all(file,line,"Expected integer parameter instead of "
-                      "NULL or empty string in input script or data file");
-  }
-
-  for (int i = 0; i < n; i++) {
-    if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
-    std::string msg("Expected integer parameter instead of '");
-    msg += str;
-    msg += "' in input script or data file";
+    const char msg[] = "Expected integer parameter instead of"
+      " NULL or empty string in input script or data file";
     if (do_abort)
       lmp->error->one(file,line,msg);
     else
       lmp->error->all(file,line,msg);
   }
 
-  return ATOBIGINT(str);
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  if (buf.find_first_not_of("0123456789-+") != std::string::npos) {
+    std::string msg("Expected integer parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg);
+    else
+      lmp->error->all(file,line,msg);
+  }
+
+  return ATOBIGINT(buf.c_str());
 }
 
 /* ----------------------------------------------------------------------
@@ -344,26 +345,27 @@ tagint utils::tnumeric(const char *file, int line, const char *str,
 
   if (str) n = strlen(str);
   if (n == 0) {
-    if (do_abort)
-      lmp->error->one(file,line,"Expected integer parameter instead of "
-                      "NULL or empty string in input script or data file");
-    else
-      lmp->error->all(file,line,"Expected integer parameter instead of "
-                      "NULL or empty string in input script or data file");
-  }
-
-  for (int i = 0; i < n; i++) {
-    if (isdigit(str[i]) || str[i] == '-' || str[i] == '+') continue;
-    std::string msg("Expected integer parameter instead of '");
-    msg += str;
-    msg += "' in input script or data file";
+    const char msg[] = "Expected integer parameter instead of"
+      " NULL or empty string in input script or data file";
     if (do_abort)
       lmp->error->one(file,line,msg);
     else
       lmp->error->all(file,line,msg);
   }
 
-  return ATOTAGINT(str);
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  if (buf.find_first_not_of("0123456789-+") != std::string::npos) {
+    std::string msg("Expected integer parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      lmp->error->one(file,line,msg);
+    else
+      lmp->error->all(file,line,msg);
+  }
+
+  return ATOTAGINT(buf.c_str());
 }
 
 /* ----------------------------------------------------------------------

--- a/src/utils.h
+++ b/src/utils.h
@@ -197,17 +197,59 @@ namespace LAMMPS_NS {
 
     /** Trim leading and trailing whitespace. Like TRIM() in Fortran.
      *
-     * \param line string that should be trimmed
+     * \param line  string that should be trimmed
      * \return new string without whitespace (string) */
 
     std::string trim(const std::string &line);
 
     /** Return string with anything from '#' onward removed
      *
-     * \param line string that should be trimmed
+     * \param line  string that should be trimmed
      * \return new string without comment (string) */
 
     std::string trim_comment(const std::string &line);
+
+    /** Check if a string will likely have UTF-8 encoded characters
+     *
+     * UTF-8 uses the 7-bit standard ASCII table for the first 127 characters and
+     * all other characters are encoded as multiple bytes.  For the multi-byte
+     * characters the first byte has either the highest two, three, or four bits
+     * set followed by a zero bit and followed by one, two, or three more bytes,
+     * respectively, where the highest bit is set and the second highest bit set
+     * to 0.  The remaining bits combined are the character code, which is thus
+     * limited to 21-bits.
+     *
+     * For the sake of efficiency this test only checks if a character in the string
+     * has the highest two bits set and thus is likely an UTF-8 character.  It
+     *
+\verbatim embed:rst
+
+*See also*
+   :cpp:func:`utils::utf8_subst`
+
+\endverbatim
+     * \param line  string that should be checked
+     * \return true if string contains UTF-8 encoded characters (bool) */
+
+    inline bool has_utf8(const std::string &line)
+    {
+      const unsigned char * const in = (const unsigned char *)line.c_str();
+      for (int i=0; i < line.size(); ++i) if (in[i] & 0xc0U) return true;
+      return false;
+    }
+
+    /** Replace known UTF-8 characters with ASCII equivalents
+     *
+\verbatim embed:rst
+
+*See also*
+   :cpp:func:`utils::has_utf8`
+
+\endverbatim
+     * \param line  string that should be converted
+     * \return new string with ascii replacements (string) */
+
+    std::string utf8_subst(const std::string &line);
 
     /** Count words in string with custom choice of separating characters
      *

--- a/src/utils.h
+++ b/src/utils.h
@@ -220,7 +220,9 @@ namespace LAMMPS_NS {
      * limited to 21-bits.
      *
      * For the sake of efficiency this test only checks if a character in the string
-     * has the highest two bits set and thus is likely an UTF-8 character.  It
+     * has the highest bit set and thus is very likely an UTF-8 character.  It will
+     * not be able to tell this this is a valid UTF-8 character or whether it is a
+     * 2-byte, 3-byte, or 4-byte character.
      *
 \verbatim embed:rst
 
@@ -234,7 +236,7 @@ namespace LAMMPS_NS {
     inline bool has_utf8(const std::string &line)
     {
       const unsigned char * const in = (const unsigned char *)line.c_str();
-      for (int i=0; i < line.size(); ++i) if (in[i] & 0xc0U) return true;
+      for (int i=0; i < line.size(); ++i) if (in[i] & 0x80U) return true;
       return false;
     }
 

--- a/unittest/utils/test_utils.cpp
+++ b/unittest/utils/test_utils.cpp
@@ -54,6 +54,23 @@ TEST(Utils, trim_comment)
     ASSERT_THAT(trimmed, StrEq("some text "));
 }
 
+TEST(Utils, has_utf8)
+{
+    const char ascii_string[] = " -2";
+    const char utf8_string[] = " −2";
+    ASSERT_FALSE(utils::has_utf8(ascii_string));
+    ASSERT_TRUE(utils::has_utf8(utf8_string));
+}
+
+TEST(Utils, utf8_subst)
+{
+    const char ascii_string[] = " -2";
+    const char utf8_string[] = " −2";
+    auto ascii = utils::utf8_subst(ascii_string);
+    auto utf8  = utils::utf8_subst(utf8_string);
+    ASSERT_TRUE(ascii == utf8);
+}
+
 TEST(Utils, count_words)
 {
     ASSERT_EQ(utils::count_words("some text # comment"), 4);


### PR DESCRIPTION
**Summary**

This adds two utility functions `utils::has_utf8()` and `utils::utf8_subst()` that can detect if non-ASCII characters are present in a string and try to replace cases where ASCII equivalents are known. This modifies the `utils::*numeric()` functions, the `ValueTokenizer` class and `Input::parse()` to make use of those functions and thus transparently capture and correct most of those cases. A warning is printed when the input contains non-ASCII, non-comment characters.

**Related Issue(s)**

Closes #2563 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes, all unit tests pass.

**Implementation Notes**

The `utils::has_utf8()` function is implemented to be inline and fast, but may trigger on non-UTF-8 non-ASCII characters.
This is reasonable, since those would be very rare and should trigger non-ASCII warnings anyway.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
