### PR TITLE
Explicit netcdf dumper error message when trying to append to non-existant file

### DIFF
--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -288,7 +288,7 @@ void DumpNetCDF::openfile()
       // Fixme! Perform checks if dimensions and variables conform with
       // data structure standard.
       if (not utils::file_is_readable(filecurrent))
-        error->all(FLERR, fmt::format("cannot append to a non-existant file {}",
+        error->all(FLERR, fmt::format("cannot append to non-existant file {}",
                                       filecurrent));
 
       if (singlefile_opened) return;

--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -288,7 +288,7 @@ void DumpNetCDF::openfile()
       // Fixme! Perform checks if dimensions and variables conform with
       // data structure standard.
       if (not utils::file_is_readable(filecurrent))
-        error->all(FLERR, fmt::format("cannot append to non-existant file {}",
+        error->all(FLERR, fmt::format("cannot append to non-existent file {}",
                                       filecurrent));
 
       if (singlefile_opened) return;

--- a/src/USER-NETCDF/dump_netcdf.cpp
+++ b/src/USER-NETCDF/dump_netcdf.cpp
@@ -17,8 +17,6 @@
 
 #if defined(LMP_HAS_NETCDF)
 
-#include <unistd.h>
-
 #include <cstring>
 #include <netcdf.h>
 #include "dump_netcdf.h"
@@ -286,9 +284,12 @@ void DumpNetCDF::openfile()
   }
 
   if (filewriter) {
-    if (append_flag && !multifile && access(filecurrent, F_OK) != -1) {
+    if (append_flag && !multifile) {
       // Fixme! Perform checks if dimensions and variables conform with
       // data structure standard.
+      if (not utils::file_is_readable(filecurrent))
+        error->all(FLERR, fmt::format("cannot append to a non-existant file {}",
+                                      filecurrent));
 
       if (singlefile_opened) return;
       singlefile_opened = 1;

--- a/src/USER-NETCDF/dump_netcdf_mpiio.cpp
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.cpp
@@ -284,7 +284,7 @@ void DumpNetCDFMPIIO::openfile()
     // Fixme! Perform checks if dimensions and variables conform with
     // data structure standard.
     if (not utils::file_is_readable(filecurrent))
-      error->all(FLERR, fmt::format("cannot append to non-existant file {}",
+      error->all(FLERR, fmt::format("cannot append to non-existent file {}",
                                     filecurrent));
 
     MPI_Offset index[NC_MAX_VAR_DIMS], count[NC_MAX_VAR_DIMS];

--- a/src/USER-NETCDF/dump_netcdf_mpiio.cpp
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.cpp
@@ -284,7 +284,7 @@ void DumpNetCDFMPIIO::openfile()
     // Fixme! Perform checks if dimensions and variables conform with
     // data structure standard.
     if (not utils::file_is_readable(filecurrent))
-      error->all(FLERR, fmt::format("cannot append to a non-existant file {}",
+      error->all(FLERR, fmt::format("cannot append to non-existant file {}",
                                     filecurrent));
 
     MPI_Offset index[NC_MAX_VAR_DIMS], count[NC_MAX_VAR_DIMS];

--- a/src/USER-NETCDF/dump_netcdf_mpiio.cpp
+++ b/src/USER-NETCDF/dump_netcdf_mpiio.cpp
@@ -17,8 +17,6 @@
 
 #if defined(LMP_HAS_PNETCDF)
 
-#include <unistd.h>
-
 #include <cstring>
 #include <pnetcdf.h>
 #include "dump_netcdf_mpiio.h"
@@ -282,9 +280,12 @@ void DumpNetCDFMPIIO::openfile()
     vector_dim[i] = -1;
   }
 
-  if (append_flag && !multifile && access(filecurrent, F_OK) != -1) {
+  if (append_flag && !multifile) {
     // Fixme! Perform checks if dimensions and variables conform with
     // data structure standard.
+    if (not utils::file_is_readable(filecurrent))
+      error->all(FLERR, fmt::format("cannot append to a non-existant file {}",
+                                    filecurrent));
 
     MPI_Offset index[NC_MAX_VAR_DIMS], count[NC_MAX_VAR_DIMS];
     double d[1];


### PR DESCRIPTION
**Summary**

Previous behavior would print "at keyword requires use of 'append yes'" when trying to append to non-existant file, which was confusing. It now prints "cannot append to a non-existant file `filename`".

**Author(s)**

Lucas Frérot, Department of Physics and Astronomy, Johns Hopkins University

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Should be ok.

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

I make use of `utils::file_is_readable` instead of `access(2)` from `unistd.h`, and use of `fmt::format` to print the filename.

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


