### PR TITLE
Add ArgInfo class for simpler processing of compute, fix, and variable references

### DIFF
--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -424,6 +424,8 @@ INPUT                  = @LAMMPS_SOURCE_DIR@/utils.cpp                 \
                          @LAMMPS_SOURCE_DIR@/input.h                   \
                          @LAMMPS_SOURCE_DIR@/tokenizer.cpp             \
                          @LAMMPS_SOURCE_DIR@/tokenizer.h               \
+                         @LAMMPS_SOURCE_DIR@/arg_info.cpp              \
+                         @LAMMPS_SOURCE_DIR@/arg_info.h                \
                          @LAMMPS_SOURCE_DIR@/text_file_reader.cpp      \
                          @LAMMPS_SOURCE_DIR@/text_file_reader.h        \
                          @LAMMPS_SOURCE_DIR@/potential_file_reader.cpp \

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -292,6 +292,50 @@ This code example should produce the following output:
 
 ----------
 
+
+Argument parsing classes
+---------------------------
+
+The purpose of argument parsing classes it to simplify and unify how
+arguments of commands in LAMMPS are parsed and to make abstractions of
+repetitive tasks.
+
+The :cpp:class:`LAMMPS_NS::ArgInfo` class provides an abstraction
+for parsing references to compute or fix styles or variables. These
+would start with a "c\_", "f\_", "v\_" followed by the ID or name of
+than instance and may be postfixed with one or two array indices
+"[<number>]" with numbers > 0.
+
+A typical code segment would look like this:
+
+.. code-block:: C++
+   :caption: Usage example for ArgInfo class
+
+   int nvalues = 0;
+   for (iarg = 0; iarg < nargnew; iarg++) {
+     ArgInfo argi(arg[iarg]);
+
+     which[nvalues] = argi.get_type();
+     argindex[nvalues] = argi.get_index1();
+     ids[nvalues] = argi.copy_name();
+
+     if ((which[nvalues] == ArgInfo::UNKNOWN)
+          || (which[nvalues] == ArgInfo::NONE)
+          || (argi.get_dim() > 1))
+       error->all(FLERR,"Illegal compute XXX command");
+
+     nvalues++;
+   }
+
+----------
+
+.. doxygenclass:: LAMMPS_NS::ArgInfo
+   :project: progguide
+   :members:
+
+
+----------
+
 File reader classes
 -------------------
 

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -2478,6 +2478,9 @@ Poresag
 pos
 Poschel
 posix
+postfix
+postfixed
+postfixes
 Postma
 Potapkin
 potin

--- a/src/USER-DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/USER-DIFFRACTION/fix_saed_vtk.cpp
@@ -18,6 +18,8 @@
 
 #include "fix_saed_vtk.h"
 
+#include "arg_info.h"
+#include "comm.h"
 #include "compute.h"
 #include "compute_saed.h"
 #include "domain.h"
@@ -31,7 +33,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{COMPUTE};
 enum{ONE,RUNNING,WINDOW};
 enum{FIRST,MULTI};
 
@@ -45,84 +46,52 @@ FixSAEDVTK::FixSAEDVTK(LAMMPS *lmp, int narg, char **arg) :
 {
   if (narg < 7) error->all(FLERR,"Illegal fix saed/vtk command");
 
-  MPI_Comm_rank(world,&me);
-
   nevery = utils::inumeric(FLERR,arg[3],false,lmp);
   nrepeat = utils::inumeric(FLERR,arg[4],false,lmp);
   nfreq = utils::inumeric(FLERR,arg[5],false,lmp);
 
   global_freq = nfreq;
-
-  nvalues = 0;
-  int iarg = 6;
-  while (iarg < narg) {
-    if (strncmp(arg[iarg],"c_",2) == 0) {
-      nvalues++;
-      iarg++;
-    } else break;
-  }
-  if (nvalues != 1) error->all(FLERR,"Illegal fix saed/vtk command");
-
   options(narg,arg);
 
-  which = 0;
-  ids = nullptr;
+  ArgInfo argi(arg[6],ArgInfo::COMPUTE);
 
-  nvalues = 0;
+  if ((argi.get_type() == ArgInfo::NONE)
+      || (argi.get_type() == ArgInfo::UNKNOWN)
+      || (argi.get_dim() != 0) )
+    error->all(FLERR,"Illegal fix saed/vtk command");
 
-  iarg = 6;
-  while (iarg < narg) {
-    if (strncmp(arg[iarg],"c_",2) == 0) {
+  ids = argi.copy_name();
+  int icompute = modify->find_compute(ids);
+  if (icompute < 0)
+    error->all(FLERR,"Compute ID for fix saed/vtk does not exist");
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+  // Check that specified compute is for SAED
+  compute_saed = (ComputeSAED *) modify->compute[icompute];
+  if (strcmp(compute_saed->style,"saed") != 0)
+    error->all(FLERR,"Fix saed/vtk has invalid compute assigned");
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) error->all(FLERR,"Illegal fix saed/vtk command");
+  // Gather variables from specified compute_saed
+  double *saed_var = compute_saed->saed_var;
+  lambda   = saed_var[0];
+  Kmax     = saed_var[1];
+  Zone[0]  = saed_var[2];
+  Zone[1]  = saed_var[3];
+  Zone[2]  = saed_var[4];
+  c[0]     = saed_var[5];
+  c[1]     = saed_var[6];
+  c[2]     = saed_var[7];
+  dR_Ewald = saed_var[8];
+  double manual_double = saed_var[9];
+  manual = false;
+  if (manual_double == 1) manual = true;
 
-      n = strlen(suffix) + 1;
-      ids = new char[n];
-      strcpy(ids,suffix);
-      delete [] suffix;
+  // Standard error check for fix/ave/time
+  if (compute_saed->vector_flag == 0)
+    error->all(FLERR,"Fix saed/vtk compute does not calculate a vector");
+  if (compute_saed->extvector != 0)
+    error->all(FLERR,"Illegal fix saed/vtk command");
 
-      int icompute = modify->find_compute(ids);
-      if (icompute < 0)
-        error->all(FLERR,"Compute ID for fix saed/vtk does not exist");
-
-      Compute *compute = modify->compute[icompute];
-
-      // Check that specified compute is for SAED
-      compute_saed = (ComputeSAED*) modify->compute[icompute];
-      if (strcmp(compute_saed->style,"saed") != 0)
-        error->all(FLERR,"Fix saed/vtk has invalid compute assigned");
-
-      // Gather variables from specified compute_saed
-      double *saed_var = compute_saed->saed_var;
-      lambda   = saed_var[0];
-      Kmax     = saed_var[1];
-      Zone[0]  = saed_var[2];
-      Zone[1]  = saed_var[3];
-      Zone[2]  = saed_var[4];
-      c[0]     = saed_var[5];
-      c[1]     = saed_var[6];
-      c[2]     = saed_var[7];
-      dR_Ewald = saed_var[8];
-      double manual_double = saed_var[9];
-      manual = false;
-      if (manual_double == 1) manual = true;
-
-      // Standard error check for fix/ave/time
-      if (compute->vector_flag == 0)
-        error->all(FLERR,"Fix saed/vtk compute does not calculate a vector");
-      if (compute->extvector != 0)
-        error->all(FLERR,"Illegal fix saed/vtk command");
-
-      nrows = compute->size_vector;
-      nvalues++;
-      iarg++;
-    } else break;
-  }
+  nrows = compute_saed->size_vector;
 
   // setup and error check
   // for fix inputs, check that fix frequency is acceptable
@@ -140,7 +109,7 @@ FixSAEDVTK::FixSAEDVTK(LAMMPS *lmp, int narg, char **arg) :
   vector_list = nullptr;
 
   if (ave == WINDOW)
-    memory->create(vector_list,nwindow,nvalues,"saed/vtk:vector_list");
+    memory->create(vector_list,nwindow,1,"saed/vtk:vector_list");
 
   memory->create(vector,nrows,"saed/vtk:vector");
   memory->create(vector_total,nrows,"saed/vtk:vector_total");
@@ -284,7 +253,7 @@ FixSAEDVTK::~FixSAEDVTK()
   delete [] ids;
   memory->destroy(vector);
   memory->destroy(vector_total);
-  if (fp && me == 0) fclose(fp);
+  if (fp && comm->me == 0) fclose(fp);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -414,7 +383,7 @@ void FixSAEDVTK::invoke_vector(bigint ntimestep)
 
   // output result to file
 
-  if (fp && me == 0) {
+  if (fp && comm->me == 0) {
     if (nOutput > 0) {
       fclose(fp);
 
@@ -534,11 +503,11 @@ void FixSAEDVTK::options(int narg, char **arg)
   overwrite = 0;
 
   // optional args
-  int iarg = 6 + nvalues;
+  int iarg = 7;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"file") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix saed/vtk command");
-      if (me == 0) {
+      if (comm->me == 0) {
 
          nOutput = 0;
          int n = strlen(arg[iarg+1]) + 1;

--- a/src/USER-DIFFRACTION/fix_saed_vtk.h
+++ b/src/USER-DIFFRACTION/fix_saed_vtk.h
@@ -37,10 +37,8 @@ class FixSAEDVTK : public Fix {
 
 
  private:
-  int me,nvalues;
   int nrepeat,nfreq,irepeat;
   bigint nvalid;
-  int which;
   char *ids;
   FILE *fp;
   int nrows;

--- a/src/USER-MISC/fix_ave_correlate_long.cpp
+++ b/src/USER-MISC/fix_ave_correlate_long.cpp
@@ -23,6 +23,7 @@
 
 #include "fix_ave_correlate_long.h"
 
+#include "arg_info.h"
 #include "citeme.h"
 #include "compute.h"
 #include "error.h"
@@ -39,9 +40,7 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{COMPUTE,FIX,VARIABLE};
 enum{AUTO,UPPER,LOWER,AUTOUPPER,AUTOLOWER,FULL};
-
 
 static const char cite_fix_ave_correlate_long[] =
 "fix ave/correlate/long command:\n\n"
@@ -82,33 +81,18 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS * lmp, int narg, char **arg):
 
   int iarg = 5;
   while (iarg < narg) {
-    if (strncmp(arg[iarg],"c_",2) == 0 ||
-        strncmp(arg[iarg],"f_",2) == 0 ||
-        strncmp(arg[iarg],"v_",2) == 0) {
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+    ArgInfo argi(arg[iarg]);
+    if (argi.get_type() == ArgInfo::NONE) break;
+    if ((argi.get_type() == ArgInfo::UNKNOWN) || (argi.get_dim() > 1))
+      error->all(FLERR,"Illegal fix ave/correlate/long command");
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal fix ave/correlate/long command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
+    which[nvalues] = argi.get_type();
+    argindex[nvalues] = argi.get_index1();
+    ids[nvalues] = argi.copy_name();
 
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
-      delete [] suffix;
-
-      nvalues++;
-      iarg++;
-    } else break;
+    nvalues++;
+    iarg++;
   }
 
   // optional args
@@ -204,7 +188,7 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS * lmp, int narg, char **arg):
     error->all(FLERR,"Illegal fix ave/correlate/long command");
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/correlate/long does not exist");
@@ -218,7 +202,7 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS * lmp, int narg, char **arg):
         error->all(FLERR,"Fix ave/correlate/long compute vector "
                    "is accessed out-of-range");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/correlate/long does not exist");
@@ -233,7 +217,7 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS * lmp, int narg, char **arg):
         error->all(FLERR,"Fix for fix ave/correlate/long "
                    "not computed at compatible time");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/correlate/long does not exist");
@@ -377,19 +361,19 @@ void FixAveCorrelateLong::init()
   // set current indices for all computes,fixes,variables
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/correlate/long does not exist");
       value2index[i] = icompute;
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/correlate/long does not exist");
       value2index[i] = ifix;
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/correlate/long does not exist");
@@ -441,7 +425,7 @@ void FixAveCorrelateLong::end_of_step()
 
     // invoke compute if not previously invoked
 
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
@@ -460,7 +444,7 @@ void FixAveCorrelateLong::end_of_step()
 
     // access fix fields, guaranteed to be ready
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       if (argindex[i] == 0)
         scalar = modify->fix[m]->compute_scalar();
       else
@@ -468,7 +452,7 @@ void FixAveCorrelateLong::end_of_step()
 
     // evaluate equal-style variable
 
-    } else if (which[i] == VARIABLE)
+    } else if (which[i] == ArgInfo::VARIABLE)
       scalar = input->variable->compute_equal(m);
 
     values[i] = scalar;

--- a/src/USER-VTK/dump_vtk.cpp
+++ b/src/USER-VTK/dump_vtk.cpp
@@ -22,26 +22,27 @@
    Richard Berger (JKU)
 ------------------------------------------------------------------------- */
 
-#include <cmath>
-
-#include <cstring>
 #include "dump_vtk.h"
+
 #include "atom.h"
-#include "force.h"
+#include "compute.h"
 #include "domain.h"
-#include "region.h"
+#include "error.h"
+#include "fix.h"
+#include "force.h"
 #include "group.h"
 #include "input.h"
-#include "variable.h"
-#include "update.h"
-#include "modify.h"
-#include "compute.h"
-#include "fix.h"
 #include "memory.h"
-#include "error.h"
+#include "modify.h"
+#include "region.h"
+#include "update.h"
+#include "variable.h"
 
-#include <vector>
+#include <cmath>
+#include <cstring>
 #include <sstream>
+#include <vector>
+
 #include <vtkVersion.h>
 
 #ifndef VTK_MAJOR_VERSION
@@ -1731,146 +1732,123 @@ int DumpVTK::parse_fields(int narg, char **arg)
       vtype[TQZ] = Dump::DOUBLE;
       name[TQZ] = arg[iarg];
 
-    // compute value = c_ID
-    // if no trailing [], then arg is set to 0, else arg is int between []
+    } else {
 
-    } else if (strncmp(arg[iarg],"c_",2) == 0) {
-      pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_compute;
-      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
+      int n,tmp;
+      ArgInfo argi(arg[iarg],ArgInfo::COMPUTE|ArgInfo::FIX|ArgInfo::VARIABLE
+                   |ArgInfo::DNAME|ArgInfo::INAME);
+      argindex[ATTRIBUTES+i] = argi.get_index1();
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+      switch (argi.get_type()) {
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump vtk command");
-        argindex[ATTRIBUTES+i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[ATTRIBUTES+i] = 0;
+      case ArgInfo::UNKNOWN:
+        error->all(FLERR,"Invalid attribute in dump vtk command");
+        break;
 
-      n = modify->find_compute(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump vtk compute ID");
-      if (modify->compute[n]->peratom_flag == 0)
-        error->all(FLERR,"Dump vtk compute does not compute per-atom info");
-      if (argindex[ATTRIBUTES+i] == 0 && modify->compute[n]->size_peratom_cols > 0)
-        error->all(FLERR,
-                   "Dump vtk compute does not calculate per-atom vector");
-      if (argindex[ATTRIBUTES+i] > 0 && modify->compute[n]->size_peratom_cols == 0)
-        error->all(FLERR,\
-                   "Dump vtk compute does not calculate per-atom array");
-      if (argindex[ATTRIBUTES+i] > 0 &&
-          argindex[ATTRIBUTES+i] > modify->compute[n]->size_peratom_cols)
-        error->all(FLERR,"Dump vtk compute vector is accessed out-of-range");
+        // compute value = c_ID
+        // if no trailing [], then arg is set to 0, else arg is int between []
 
-      field2index[ATTRIBUTES+i] = add_compute(suffix);
-      name[ATTRIBUTES+i] = arg[iarg];
-      delete [] suffix;
+      case ArgInfo::COMPUTE:
+        pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_compute;
+        vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
-    // fix value = f_ID
-    // if no trailing [], then arg is set to 0, else arg is between []
+        n = modify->find_compute(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump vtk compute ID");
+        if (modify->compute[n]->peratom_flag == 0)
+          error->all(FLERR,"Dump vtk compute does not compute per-atom info");
+        if (argi.get_dim() == 0 && modify->compute[n]->size_peratom_cols > 0)
+          error->all(FLERR,
+                     "Dump vtk compute does not calculate per-atom vector");
+        if (argi.get_dim() > 0 && modify->compute[n]->size_peratom_cols == 0)
+          error->all(FLERR,
+                     "Dump vtk compute does not calculate per-atom array");
+        if (argi.get_dim() > 0 &&
+            argi.get_index1() > modify->compute[n]->size_peratom_cols)
+          error->all(FLERR,"Dump vtk compute vector is accessed out-of-range");
 
-    } else if (strncmp(arg[iarg],"f_",2) == 0) {
-      pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_fix;
-      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
+        field2index[ATTRIBUTES+i] = add_compute(argi.get_name());
+        name[ATTRIBUTES+i] = arg[iarg];
+        break;
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+        // fix value = f_ID
+        // if no trailing [], then arg is set to 0, else arg is between []
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump vtk command");
-        argindex[ATTRIBUTES+i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[ATTRIBUTES+i] = 0;
+      case ArgInfo::FIX:
+        pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_fix;
+        vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
-      n = modify->find_fix(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump vtk fix ID");
-      if (modify->fix[n]->peratom_flag == 0)
-        error->all(FLERR,"Dump vtk fix does not compute per-atom info");
-      if (argindex[ATTRIBUTES+i] == 0 && modify->fix[n]->size_peratom_cols > 0)
-        error->all(FLERR,"Dump vtk fix does not compute per-atom vector");
-      if (argindex[ATTRIBUTES+i] > 0 && modify->fix[n]->size_peratom_cols == 0)
-        error->all(FLERR,"Dump vtk fix does not compute per-atom array");
-      if (argindex[ATTRIBUTES+i] > 0 &&
-          argindex[ATTRIBUTES+i] > modify->fix[n]->size_peratom_cols)
-        error->all(FLERR,"Dump vtk fix vector is accessed out-of-range");
+        n = modify->find_fix(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump vtk fix ID");
+        if (modify->fix[n]->peratom_flag == 0)
+          error->all(FLERR,"Dump vtk fix does not compute per-atom info");
+        if (argi.get_dim() == 0 && modify->fix[n]->size_peratom_cols > 0)
+          error->all(FLERR,"Dump vtk fix does not compute per-atom vector");
+        if (argi.get_dim() > 0 && modify->fix[n]->size_peratom_cols == 0)
+          error->all(FLERR,"Dump vtk fix does not compute per-atom array");
+        if (argi.get_dim() > 0 &&
+            argi.get_index1() > modify->fix[n]->size_peratom_cols)
+          error->all(FLERR,"Dump vtk fix vector is accessed out-of-range");
 
-      field2index[ATTRIBUTES+i] = add_fix(suffix);
-      name[ATTRIBUTES+i] = arg[iarg];
-      delete [] suffix;
+        field2index[ATTRIBUTES+i] = add_fix(argi.get_name());
+        name[ATTRIBUTES+i] = arg[iarg];
+        break;
 
-    // variable value = v_name
+        // variable value = v_name
 
-    } else if (strncmp(arg[iarg],"v_",2) == 0) {
-      pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_variable;
-      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
+      case ArgInfo::VARIABLE:
+        pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_variable;
+        vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+        n = input->variable->find(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump vtk variable name");
+        if (input->variable->atomstyle(n) == 0)
+          error->all(FLERR,"Dump vtk variable is not atom-style variable");
 
-      argindex[ATTRIBUTES+i] = 0;
+        field2index[ATTRIBUTES+i] = add_variable(argi.get_name());
+        name[ATTRIBUTES+i] = arg[iarg];
+        break;
 
-      n = input->variable->find(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump vtk variable name");
-      if (input->variable->atomstyle(n) == 0)
-        error->all(FLERR,"Dump vtk variable is not atom-style variable");
+        // custom per-atom floating point value = d_ID
 
-      field2index[ATTRIBUTES+i] = add_variable(suffix);
-      name[ATTRIBUTES+i] = suffix;
-      delete [] suffix;
+      case ArgInfo::DNAME:
+        pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_custom;
+        vtype[ATTRIBUTES+i] = Dump::DOUBLE;
 
-    // custom per-atom floating point value = d_ID
+        tmp = -1;
+        n = atom->find_custom(argi.get_name(),tmp);
+        if (n < 0)
+          error->all(FLERR,"Could not find custom per-atom property ID");
 
-    } else if (strncmp(arg[iarg],"d_",2) == 0) {
-      pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_custom;
-      vtype[ATTRIBUTES+i] = Dump::DOUBLE;
+        if (tmp != 1)
+          error->all(FLERR,"Custom per-atom property ID is not floating point");
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
-      argindex[ATTRIBUTES+i] = 0;
+        field2index[ATTRIBUTES+i] = add_custom(argi.get_name(),1);
+        name[ATTRIBUTES+i] = arg[iarg];
+        break;
 
-      int tmp = -1;
-      n = atom->find_custom(suffix,tmp);
-      if (n < 0)
-        error->all(FLERR,"Could not find custom per-atom property ID");
+        // custom per-atom integer value = i_ID
 
-      if (tmp != 1)
-        error->all(FLERR,"Custom per-atom property ID is not floating point");
+      case ArgInfo::INAME:
+        pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_custom;
+        vtype[ATTRIBUTES+i] = Dump::INT;
 
-      field2index[ATTRIBUTES+i] = add_custom(suffix,1);
-      name[ATTRIBUTES+i] = suffix;
-      delete [] suffix;
+        tmp = -1;
+        n = atom->find_custom(argi.get_name(),tmp);
+        if (n < 0)
+          error->all(FLERR,"Could not find custom per-atom property ID");
 
-    // custom per-atom integer value = i_ID
+        if (tmp != 0)
+          error->all(FLERR,"Custom per-atom property ID is not integer");
 
-    } else if (strncmp(arg[iarg],"i_",2) == 0) {
-      pack_choice[ATTRIBUTES+i] = &DumpVTK::pack_custom;
-      vtype[ATTRIBUTES+i] = Dump::INT;
+        field2index[ATTRIBUTES+i] = add_custom(argi.get_name(),0);
+        name[ATTRIBUTES+i] = arg[iarg];
+        break;
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
-      argindex[ATTRIBUTES+i] = 0;
-
-      int tmp = -1;
-      n = atom->find_custom(suffix,tmp);
-      if (n < 0)
-        error->all(FLERR,"Could not find custom per-atom property ID");
-
-      if (tmp != 0)
-        error->all(FLERR,"Custom per-atom property ID is not integer");
-
-      field2index[ATTRIBUTES+i] = add_custom(suffix,0);
-      name[ATTRIBUTES+i] = suffix;
-      delete [] suffix;
-
-    } else return iarg;
+      default:
+        return iarg;
+        break;
+      }
+    }
   }
 
   identify_vectors();

--- a/src/USER-VTK/dump_vtk.cpp
+++ b/src/USER-VTK/dump_vtk.cpp
@@ -24,6 +24,7 @@
 
 #include "dump_vtk.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "compute.h"
 #include "domain.h"
@@ -1908,7 +1909,7 @@ void DumpVTK::identify_vectors()
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpVTK::add_compute(char *id)
+int DumpVTK::add_compute(const char *id)
 {
   int icompute;
   for (icompute = 0; icompute < ncompute; icompute++)
@@ -1933,7 +1934,7 @@ int DumpVTK::add_compute(char *id)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpVTK::add_fix(char *id)
+int DumpVTK::add_fix(const char *id)
 {
   int ifix;
   for (ifix = 0; ifix < nfix; ifix++)
@@ -1958,7 +1959,7 @@ int DumpVTK::add_fix(char *id)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpVTK::add_variable(char *id)
+int DumpVTK::add_variable(const char *id)
 {
   int ivariable;
   for (ivariable = 0; ivariable < nvariable; ivariable++)
@@ -1987,7 +1988,7 @@ int DumpVTK::add_variable(char *id)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpVTK::add_custom(char *id, int flag)
+int DumpVTK::add_custom(const char *id, int flag)
 {
   int icustom;
   for (icustom = 0; icustom < ncustom; icustom++)

--- a/src/USER-VTK/dump_vtk.h
+++ b/src/USER-VTK/dump_vtk.h
@@ -81,10 +81,10 @@ class DumpVTK : public DumpCustom {
 
   int parse_fields(int, char **);
   void identify_vectors();
-  int add_compute(char *);
-  int add_fix(char *);
-  int add_variable(char *);
-  int add_custom(char *, int);
+  int add_compute(const char *);
+  int add_fix(const char *);
+  int add_variable(const char *);
+  int add_custom(const char *, int);
   virtual int modify_param(int, char **);
 
   typedef void (DumpVTK::*FnPtrHeader)(bigint);

--- a/src/arg_info.cpp
+++ b/src/arg_info.cpp
@@ -1,0 +1,74 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://lammps.sandia.gov/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "arg_info.h"
+
+#include <stdexcept>
+#include <cstring>
+
+using namespace LAMMPS_NS;
+
+ArgInfo::ArgInfo(const std::string &arg, int allowed)
+  : type(NONE), dim(0), index1(-1), index2(-1)
+{
+  if ((arg.size() > 2) && (arg[1] == '_')) {
+    if ((arg[0] == 'c') && (allowed & COMPUTE))  type = COMPUTE;
+    else if ((arg[0] == 'f') && (allowed & FIX)) type = FIX;
+    else if ((arg[0] == 'v') && (allowed & VARIABLE)) type = VARIABLE;
+    else {
+      name = arg;
+      return;
+    }
+
+    std::size_t has_idx1 = arg.find('[',2);
+    if (has_idx1 != std::string::npos) {
+      name = arg.substr(2,has_idx1-2);
+      dim = 1;
+
+      std::size_t has_idx2 = arg.find('[',has_idx1+1);
+      if (has_idx2 != std::string::npos) {
+        dim = 2;
+
+        if (arg[arg.size()-1] != ']') {
+          type = UNKNOWN;
+        } else {
+          try {
+            index2 = std::stoi(arg.substr(has_idx2+1,arg.size()-(has_idx2+2)));
+          } catch (std::invalid_argument &) {
+            type = UNKNOWN;
+          }
+        }
+      } else has_idx2 = arg.size();
+
+      if (arg[has_idx2-1] != ']') {
+        type = UNKNOWN;
+      } else {
+        try {
+          index1 = std::stoi(arg.substr(has_idx1+1,arg.size()-(has_idx2+2)));
+        } catch (std::invalid_argument &) {
+          type = UNKNOWN;
+        }
+      }
+    } else name = arg.substr(2);
+  } else name = arg;
+}
+
+/* ---------------------------------------------------------------------- */
+
+char *ArgInfo::copy_name()
+{
+  char *dest = new char[name.size()+1];
+  strcpy(dest,name.c_str());
+  return dest;
+}
+

--- a/src/arg_info.cpp
+++ b/src/arg_info.cpp
@@ -18,6 +18,17 @@
 
 using namespace LAMMPS_NS;
 
+/** Class for processing references to fixes, computes and variables
+ *
+ * This class provides an abstraction for the repetitive task of
+ * parsing arguments that may contain references to fixes, computes,
+ * or variables. It will identify the name and the index in the first
+ * and second dimension, if present.
+ *
+ *
+ * \param arg      string with possible reference
+ * \param allowed  integer with bitmap of allowed types of references */
+
 ArgInfo::ArgInfo(const std::string &arg, int allowed)
   : type(NONE), dim(0), index1(-1), index2(-1)
 {
@@ -71,6 +82,16 @@ ArgInfo::ArgInfo(const std::string &arg, int allowed)
 }
 
 /* ---------------------------------------------------------------------- */
+
+/*! make copy of the ID of the reference as C-style string
+ *
+ * The ID is copied into a buffer allocated with "new" and thus
+ * must be later deleted with "delete []" to avoid a memory leak.
+ * Because it is a full copy in a newly allocated buffer, the
+ * lifetime of this string extends beyond the the time the ArgInfo
+ * class is in scope.
+ *
+ * \return copy of string as char * */
 
 char *ArgInfo::copy_name()
 {

--- a/src/arg_info.cpp
+++ b/src/arg_info.cpp
@@ -26,6 +26,7 @@ ArgInfo::ArgInfo(const std::string &arg, int allowed)
     else if ((arg[0] == 'f') && (allowed & FIX)) type = FIX;
     else if ((arg[0] == 'v') && (allowed & VARIABLE)) type = VARIABLE;
     else {
+      index1 = 0;
       name = arg;
       return;
     }
@@ -59,8 +60,14 @@ ArgInfo::ArgInfo(const std::string &arg, int allowed)
           type = UNKNOWN;
         }
       }
-    } else name = arg.substr(2);
-  } else name = arg;
+    } else {
+      index1 = 0;
+      name = arg.substr(2);
+    }
+  } else {
+    index1 = 0;
+    name = arg;
+  }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/arg_info.cpp
+++ b/src/arg_info.cpp
@@ -22,9 +22,8 @@ using namespace LAMMPS_NS;
  *
  * This class provides an abstraction for the repetitive task of
  * parsing arguments that may contain references to fixes, computes,
- * or variables. It will identify the name and the index in the first
- * and second dimension, if present.
- *
+ * variables, or custom per-atom properties. It will identify the name
+ * and the index value in the first and second dimension, if present.
  *
  * \param arg      string with possible reference
  * \param allowed  integer with bitmap of allowed types of references */
@@ -36,6 +35,8 @@ ArgInfo::ArgInfo(const std::string &arg, int allowed)
     if ((arg[0] == 'c') && (allowed & COMPUTE))  type = COMPUTE;
     else if ((arg[0] == 'f') && (allowed & FIX)) type = FIX;
     else if ((arg[0] == 'v') && (allowed & VARIABLE)) type = VARIABLE;
+    else if ((arg[0] == 'd') && (allowed & DNAME)) type = DNAME;
+    else if ((arg[0] == 'i') && (allowed & INAME)) type = INAME;
     else {
       index1 = 0;
       name = arg;

--- a/src/arg_info.h
+++ b/src/arg_info.h
@@ -97,7 +97,7 @@ namespace LAMMPS_NS {
      *
      * \return  C-style char * string */
     const char *get_name() const { return name.c_str(); }
-    
+
     char *copy_name();
 
   private:

--- a/src/arg_info.h
+++ b/src/arg_info.h
@@ -1,0 +1,71 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifndef LMP_ARG_INFO_H
+#define LMP_ARG_INFO_H
+
+/*! \file arg_info.h */
+
+#include <string>
+
+namespace LAMMPS_NS {
+  class ArgInfo {
+  public:
+    enum {
+      ERROR          =-2,
+      UNKNOWN        =-1,
+      NONE           = 0,
+      X              = 1<<0,
+      V              = 1<<1,
+      F              = 1<<2,
+      COMPUTE        = 1<<3,
+      FIX            = 1<<4,
+      VARIABLE       = 1<<5,
+      KEYWORD        = 1<<6,
+      TYPE           = 1<<7,
+      MOLECULE       = 1<<8,
+      DNAME          = 1<<9,
+      INAME          = 1<<10,
+      DENSITY_NUMBER = 1<<11,
+      DENSITY_MASS   = 1<<12,
+      MASS           = 1<<13,
+      TEMPERATURE    = 1<<14,
+      BIN1D          = 1<<15,
+      BIN2D          = 1<<16,
+      BIN3D          = 1<<17,
+      BINSPHERE      = 1<<18,
+      BINCYLINDER    = 1<<19
+    };
+
+    ArgInfo(const std::string &arg, int allowed=COMPUTE|FIX|VARIABLE);
+    virtual ~ArgInfo() {}
+
+  public:
+    int  get_type() const { return type; }
+    int  get_dim()  const { return dim; }
+    int  get_index1() const { return index1; }
+    int  get_index2() const { return index2; }
+    const char *get_name() const { return name.c_str(); }
+    char *copy_name();
+
+  private:
+    std::string name;
+    int type, dim, index1, index2;
+
+    // disabled standard methods
+    ArgInfo() {}
+    ArgInfo(const ArgInfo &) {}
+    void operator=(const ArgInfo &) {}
+  };
+}
+#endif

--- a/src/arg_info.h
+++ b/src/arg_info.h
@@ -21,7 +21,8 @@
 namespace LAMMPS_NS {
   class ArgInfo {
   public:
-    enum {
+    /*! constants for argument types */
+    enum ArgTypes {
       ERROR          =-2,
       UNKNOWN        =-1,
       NONE           = 0,
@@ -51,11 +52,52 @@ namespace LAMMPS_NS {
     virtual ~ArgInfo() {}
 
   public:
+    /*! get type of reference
+     *
+     * Return a type constant for the reference. This may be either
+     * COMPUTE, FIX, VARIABLE (if not restricted to a subset of those
+     * by the "allowed" argument of the constructor) or NONE, if it
+     * if not a recognized or allowed reference, or UNKNOWN, in case
+     * some error happened identifying or parsing the values of the indices
+     *
+     * \return  integer with a constant from ArgTypes enumerator */
+
     int  get_type() const { return type; }
+
+    /*! get dimension of reference
+     *
+     * This will return either 0, 1, 2 depending on whether the
+     * reference has no, one or two "[<number>]" postfixes.
+     *
+     * \return  integer with the dimensionality of the reference */
     int  get_dim()  const { return dim; }
+
+    /*! get index of first dimension
+     *
+     * This will return the <number> in the first "[<number>]"
+     * postfix or 0 if there is no postfix.
+     *
+     * \return  integer with index or the postfix or 0 */
     int  get_index1() const { return index1; }
+
+    /*! get index of second dimension
+     *
+     * This will return the <number> in the second "[<number>]"
+     * postfix or -1 if there is no second postfix.
+     *
+     * \return  integer with index of the postfix or -1 */
     int  get_index2() const { return index2; }
+
+    /*! return reference to the ID or name of the reference
+     *
+     * This string is pointing to an internal storage element and
+     * is only valid to use while the ArgInfo class instance is
+     * in scope. If you need a long-lived string make a copy
+     * with copy_name().
+     *
+     * \return  C-style char * string */
     const char *get_name() const { return name.c_str(); }
+    
     char *copy_name();
 
   private:

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -150,11 +150,11 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
     ArgInfo argi(arg[3]);
 
     which = argi.get_type();
-    argindex = argi.get_dim();
+    argindex = argi.get_index1();
     cfvid = argi.copy_name();
 
     if ((which == ArgInfo::UNKNOWN) || (which == ArgInfo::NONE)
-        || (argindex > 1))
+        || (argi.get_dim() > 1))
       error->all(FLERR,"Illegal compute chunk/atom command");
   }
 

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -15,6 +15,7 @@
 
 #include "compute_chunk_atom.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
@@ -39,8 +40,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-enum{BIN1D,BIN2D,BIN3D,BINSPHERE,BINCYLINDER,
-     TYPE,MOLECULE,COMPUTE,FIX,VARIABLE};
 enum{LOWER,CENTER,UPPER,COORD};
 enum{BOX,LATTICE,REDUCED};
 enum{NODISCARD,MIXED,YESDISCARD};
@@ -77,14 +76,14 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
 
   if (strcmp(arg[3],"bin/1d") == 0) {
     binflag = 1;
-    which = BIN1D;
+    which = ArgInfo::BIN1D;
     ncoord = 1;
     iarg = 4;
     readdim(narg,arg,iarg,0);
     iarg += 3;
   } else if (strcmp(arg[3],"bin/2d") == 0) {
     binflag = 1;
-    which = BIN2D;
+    which = ArgInfo::BIN2D;
     ncoord = 2;
     iarg = 4;
     readdim(narg,arg,iarg,0);
@@ -92,7 +91,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
     iarg += 6;
   } else if (strcmp(arg[3],"bin/3d") == 0) {
     binflag = 1;
-    which = BIN3D;
+    which = ArgInfo::BIN3D;
     ncoord = 3;
     iarg = 4;
     readdim(narg,arg,iarg,0);
@@ -102,7 +101,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
 
   } else if (strcmp(arg[3],"bin/sphere") == 0) {
     binflag = 1;
-    which = BINSPHERE;
+    which = ArgInfo::BINSPHERE;
     ncoord = 1;
     iarg = 4;
     if (iarg+6 > narg) error->all(FLERR,"Illegal compute chunk/atom command");
@@ -115,7 +114,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
     iarg += 6;
   } else if (strcmp(arg[3],"bin/cylinder") == 0) {
     binflag = 1;
-    which = BINCYLINDER;
+    which = ArgInfo::BINCYLINDER;
     ncoord = 2;
     iarg = 4;
     readdim(narg,arg,iarg,0);
@@ -141,38 +140,23 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
     iarg += 5;
 
   } else if (strcmp(arg[3],"type") == 0) {
-    which = TYPE;
+    which = ArgInfo::TYPE;
     iarg = 4;
   } else if (strcmp(arg[3],"molecule") == 0) {
-    which = MOLECULE;
+    which = ArgInfo::MOLECULE;
     iarg = 4;
 
-  } else if (strstr(arg[3],"c_") == arg[3] ||
-             strstr(arg[3],"f_") == arg[3] ||
-             strstr(arg[3],"v_") == arg[3]) {
-    if (arg[3][0] == 'c') which = COMPUTE;
-    else if (arg[3][0] == 'f') which = FIX;
-    else if (arg[3][0] == 'v') which = VARIABLE;
-    iarg = 4;
+  } else {
+    ArgInfo argi(arg[3]);
 
-    int n = strlen(arg[3]);
-    char *suffix = new char[n];
-    strcpy(suffix,&arg[3][2]);
+    which = argi.get_type();
+    argindex = argi.get_dim();
+    cfvid = argi.copy_name();
 
-    char *ptr = strchr(suffix,'[');
-    if (ptr) {
-      if (suffix[strlen(suffix)-1] != ']')
-        error->all(FLERR,"Illegal compute chunk/atom command");
-      argindex = atoi(ptr+1);
-      *ptr = '\0';
-    } else argindex = 0;
-
-    n = strlen(suffix) + 1;
-    cfvid = new char[n];
-    strcpy(cfvid,suffix);
-    delete [] suffix;
-
-  } else error->all(FLERR,"Illegal compute chunk/atom command");
+    if ((which == ArgInfo::UNKNOWN) || (which == ArgInfo::NONE)
+        || (argindex > 1))
+      error->all(FLERR,"Illegal compute chunk/atom command");
+  }
 
   // optional args
 
@@ -291,8 +275,8 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
       if (scaleflag == REDUCED) nchunkflag = ONCE;
       else nchunkflag = EVERY;
     }
-    if (which == TYPE) nchunkflag = ONCE;
-    if (which == MOLECULE) {
+    if (which == ArgInfo::TYPE) nchunkflag = ONCE;
+    if (which == ArgInfo::MOLECULE) {
       if (regionflag) nchunkflag = EVERY;
       else nchunkflag = ONCE;
     }
@@ -306,31 +290,31 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
 
   // error checks
 
-  if (which == MOLECULE && !atom->molecule_flag)
+  if (which == ArgInfo::MOLECULE && !atom->molecule_flag)
     error->all(FLERR,"Compute chunk/atom molecule for non-molecular system");
 
   if (!binflag && discard == MIXED)
     error->all(FLERR,"Compute chunk/atom without bins "
                "cannot use discard mixed");
-  if (which == BIN1D && delta[0] <= 0.0)
+  if (which == ArgInfo::BIN1D && delta[0] <= 0.0)
     error->all(FLERR,"Illegal compute chunk/atom command");
-  if (which == BIN2D && (delta[0] <= 0.0 || delta[1] <= 0.0))
+  if (which == ArgInfo::BIN2D && (delta[0] <= 0.0 || delta[1] <= 0.0))
     error->all(FLERR,"Illegal compute chunk/atom command");
-  if (which == BIN2D && (dim[0] == dim[1]))
+  if (which == ArgInfo::BIN2D && (dim[0] == dim[1]))
     error->all(FLERR,"Illegal compute chunk/atom command");
-  if (which == BIN3D &&
+  if (which == ArgInfo::BIN3D &&
       (delta[0] <= 0.0 || delta[1] <= 0.0 || delta[2] <= 0.0))
       error->all(FLERR,"Illegal compute chunk/atom command");
-  if (which == BIN3D &&
+  if (which == ArgInfo::BIN3D &&
       (dim[0] == dim[1] || dim[1] == dim[2] || dim[0] == dim[2]))
       error->all(FLERR,"Illegal compute chunk/atom command");
-  if (which == BINSPHERE) {
+  if (which == ArgInfo::BINSPHERE) {
     if (domain->dimension == 2 && sorigin_user[2] != 0.0)
       error->all(FLERR,"Compute chunk/atom sphere z origin must be 0.0 for 2d");
     if (sradmin_user < 0.0 || sradmin_user >= sradmax_user || nsbin < 1)
       error->all(FLERR,"Illegal compute chunk/atom command");
   }
-  if (which == BINCYLINDER) {
+  if (which == ArgInfo::BINCYLINDER) {
     if (delta[0] <= 0.0)
       error->all(FLERR,"Illegal compute chunk/atom command");
     if (domain->dimension == 2 && dim[0] != 2)
@@ -339,7 +323,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
       error->all(FLERR,"Illegal compute chunk/atom command");
   }
 
-  if (which == COMPUTE) {
+  if (which == ArgInfo::COMPUTE) {
     int icompute = modify->find_compute(cfvid);
     if (icompute < 0)
       error->all(FLERR,"Compute ID for compute chunk /atom does not exist");
@@ -360,7 +344,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
                  "accessed out-of-range");
   }
 
-  if (which == FIX) {
+  if (which == ArgInfo::FIX) {
     int ifix = modify->find_fix(cfvid);
     if (ifix < 0)
       error->all(FLERR,"Fix ID for compute chunk/atom does not exist");
@@ -377,7 +361,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
       error->all(FLERR,"Compute chunk/atom fix array is accessed out-of-range");
   }
 
-  if (which == VARIABLE) {
+  if (which == ArgInfo::VARIABLE) {
     int ivariable = input->variable->find(cfvid);
     if (ivariable < 0)
       error->all(FLERR,"Variable name for compute chunk/atom does not exist");
@@ -404,11 +388,11 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
 
   if (binflag) {
     double scale;
-    if (which == BIN1D || which == BIN2D || which == BIN3D ||
-        which == BINCYLINDER) {
-      if (which == BIN1D || which == BINCYLINDER) ndim = 1;
-      if (which == BIN2D) ndim = 2;
-      if (which == BIN3D) ndim = 3;
+    if (which == ArgInfo::BIN1D || which == ArgInfo::BIN2D
+        || which == ArgInfo::BIN3D || which == ArgInfo::BINCYLINDER) {
+      if (which == ArgInfo::BIN1D || which == ArgInfo::BINCYLINDER) ndim = 1;
+      if (which == ArgInfo::BIN2D) ndim = 2;
+      if (which == ArgInfo::BIN3D) ndim = 3;
       for (int idim = 0; idim < ndim; idim++) {
         if (dim[idim] == 0) scale = xscale;
         else if (dim[idim] == 1) scale = yscale;
@@ -419,13 +403,13 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
         if (minflag[idim] == COORD) minvalue[idim] *= scale;
         if (maxflag[idim] == COORD) maxvalue[idim] *= scale;
       }
-    } else if (which == BINSPHERE) {
+    } else if (which == ArgInfo::BINSPHERE) {
       sorigin_user[0] *= xscale;
       sorigin_user[1] *= yscale;
       sorigin_user[2] *= zscale;
       sradmin_user *= xscale;     // radii are scaled by xscale
       sradmax_user *= xscale;
-    } else if (which == BINCYLINDER) {
+    } else if (which == ArgInfo::BINCYLINDER) {
       if (dim[0] == 0) {
         corigin_user[cdim1] *= yscale;
         corigin_user[cdim2] *= zscale;
@@ -462,7 +446,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
   // computeflag = 1 if this compute might invoke another compute
   // during assign_chunk_ids()
 
-  if (which == COMPUTE || which == FIX || which == VARIABLE) computeflag = 1;
+  if (which == ArgInfo::COMPUTE || which == ArgInfo::FIX || which == ArgInfo::VARIABLE) computeflag = 1;
   else computeflag = 0;
 
   // other initializations
@@ -482,7 +466,7 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
   lockcount = 0;
   lockfix = nullptr;
 
-  if (which == MOLECULE) molcheck = 1;
+  if (which == ArgInfo::MOLECULE) molcheck = 1;
   else molcheck = 0;
 }
 
@@ -524,17 +508,17 @@ void ComputeChunkAtom::init()
 
   // set compute,fix,variable
 
-  if (which == COMPUTE) {
+  if (which == ArgInfo::COMPUTE) {
     int icompute = modify->find_compute(cfvid);
     if (icompute < 0)
       error->all(FLERR,"Compute ID for compute chunk/atom does not exist");
     cchunk = modify->compute[icompute];
-  } else if (which == FIX) {
+  } else if (which == ArgInfo::FIX) {
     int ifix = modify->find_fix(cfvid);
     if (ifix < 0)
       error->all(FLERR,"Fix ID for compute chunk/atom does not exist");
     fchunk = modify->fix[ifix];
-  } else if (which == VARIABLE) {
+  } else if (which == ArgInfo::VARIABLE) {
     int ivariable = input->variable->find(cfvid);
     if (ivariable < 0)
       error->all(FLERR,"Variable name for compute chunk/atom does not exist");
@@ -544,7 +528,7 @@ void ComputeChunkAtom::init()
   // for style MOLECULE, check that no mol IDs exceed MAXSMALLINT
   // don't worry about group or optional region
 
-  if (which == MOLECULE) {
+  if (which == ArgInfo::MOLECULE) {
     tagint *molecule = atom->molecule;
     int nlocal = atom->nlocal;
     tagint maxone = -1;
@@ -835,10 +819,11 @@ int ComputeChunkAtom::setup_chunks()
   // IDs are needed to scan for max ID and for compress()
 
   if (binflag) {
-    if (which == BIN1D || which == BIN2D || which == BIN3D)
+    if (which == ArgInfo::BIN1D || which == ArgInfo::BIN2D
+        || which == ArgInfo::BIN3D)
       nchunk = setup_xyz_bins();
-    else if (which == BINSPHERE) nchunk = setup_sphere_bins();
-    else if (which == BINCYLINDER) nchunk = setup_cylinder_bins();
+    else if (which == ArgInfo::BINSPHERE) nchunk = setup_sphere_bins();
+    else if (which == ArgInfo::BINCYLINDER) nchunk = setup_cylinder_bins();
     bin_volumes();
   } else {
     chunk_volume_scalar = domain->xprd * domain->yprd;
@@ -850,7 +835,7 @@ int ComputeChunkAtom::setup_chunks()
   // set nchunk for chunk styles other than binning
   // for styles other than TYPE, scan for max ID
 
-  if (which == TYPE) nchunk = atom->ntypes;
+  if (which == ArgInfo::TYPE) nchunk = atom->ntypes;
   else if (!binflag) {
 
     int nlocal = atom->nlocal;
@@ -937,27 +922,27 @@ void ComputeChunkAtom::assign_chunk_ids()
   // binning styles apply discard rule, others do not yet
 
   if (binflag) {
-    if (which == BIN1D) atom2bin1d();
-    else if (which == BIN2D) atom2bin2d();
-    else if (which == BIN3D) atom2bin3d();
-    else if (which == BINSPHERE) atom2binsphere();
-    else if (which == BINCYLINDER) atom2bincylinder();
+    if (which == ArgInfo::BIN1D) atom2bin1d();
+    else if (which == ArgInfo::BIN2D) atom2bin2d();
+    else if (which == ArgInfo::BIN3D) atom2bin3d();
+    else if (which == ArgInfo::BINSPHERE) atom2binsphere();
+    else if (which == ArgInfo::BINCYLINDER) atom2bincylinder();
 
-  } else if (which == TYPE) {
+  } else if (which == ArgInfo::TYPE) {
     int *type = atom->type;
     for (i = 0; i < nlocal; i++) {
       if (exclude[i]) continue;
       ichunk[i] = type[i];
     }
 
-  } else if (which == MOLECULE) {
+  } else if (which == ArgInfo::MOLECULE) {
     tagint *molecule = atom->molecule;
     for (i = 0; i < nlocal; i++) {
       if (exclude[i]) continue;
       ichunk[i] = static_cast<int> (molecule[i]);
     }
 
-  } else if (which == COMPUTE) {
+  } else if (which == ArgInfo::COMPUTE) {
     if (!(cchunk->invoked_flag & INVOKED_PERATOM)) {
       cchunk->compute_peratom();
       cchunk->invoked_flag |= INVOKED_PERATOM;
@@ -978,7 +963,7 @@ void ComputeChunkAtom::assign_chunk_ids()
       }
     }
 
-  } else if (which == FIX) {
+  } else if (which == ArgInfo::FIX) {
     if (update->ntimestep % fchunk->peratom_freq)
       error->all(FLERR,"Fix used in compute chunk/atom not "
                  "computed at compatible time");
@@ -998,7 +983,7 @@ void ComputeChunkAtom::assign_chunk_ids()
       }
     }
 
-  } else if (which == VARIABLE) {
+  } else if (which == ArgInfo::VARIABLE) {
     if (atom->nmax > maxvar) {
       maxvar = atom->nmax;
       memory->destroy(varatom);
@@ -1428,7 +1413,8 @@ int ComputeChunkAtom::setup_cylinder_bins()
 
 void ComputeChunkAtom::bin_volumes()
 {
-  if (which == BIN1D || which == BIN2D || which == BIN3D) {
+  if (which == ArgInfo::BIN1D || which == ArgInfo::BIN2D
+      || which == ArgInfo::BIN3D) {
     if (domain->dimension == 3)
       chunk_volume_scalar = domain->xprd * domain->yprd * domain->zprd;
     else chunk_volume_scalar = domain->xprd * domain->yprd;
@@ -1438,7 +1424,7 @@ void ComputeChunkAtom::bin_volumes()
     for (int m = 0; m < ndim; m++)
       chunk_volume_scalar *= delta[m]/prd[dim[m]];
 
-  } else if (which == BINSPHERE) {
+  } else if (which == ArgInfo::BINSPHERE) {
     memory->destroy(chunk_volume_vec);
     memory->create(chunk_volume_vec,nchunk,"chunk/atom:chunk_volume_vec");
     double rlo,rhi,vollo,volhi;
@@ -1451,7 +1437,7 @@ void ComputeChunkAtom::bin_volumes()
       chunk_volume_vec[i] = volhi - vollo;
     }
 
-  } else if (which == BINCYLINDER) {
+  } else if (which == ArgInfo::BINCYLINDER) {
     memory->destroy(chunk_volume_vec);
     memory->create(chunk_volume_vec,nchunk,"chunk/atom:chunk_volume_vec");
 

--- a/src/compute_chunk_spread_atom.cpp
+++ b/src/compute_chunk_spread_atom.cpp
@@ -69,11 +69,11 @@ ComputeChunkSpreadAtom(LAMMPS *lmp, int narg, char **arg) :
     ArgInfo argi(arg[iarg], ArgInfo::COMPUTE|ArgInfo::FIX);
 
     which[nvalues] = argi.get_type();
-    argindex[nvalues] = argi.get_dim();
+    argindex[nvalues] = argi.get_index1();
     ids[nvalues] = argi.copy_name();
 
     if ((which[nvalues] == ArgInfo::UNKNOWN) || (which[nvalues] == ArgInfo::NONE)
-        || (argindex[nvalues] > 1))
+        || (argi.get_dim() > 1))
       error->all(FLERR,"Illegal compute chunk/spread/atom command");
 
     nvalues++;

--- a/src/compute_global_atom.cpp
+++ b/src/compute_global_atom.cpp
@@ -13,6 +13,7 @@
 
 #include "compute_global_atom.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "error.h"
 #include "fix.h"
@@ -22,11 +23,8 @@
 #include "update.h"
 #include "variable.h"
 
-#include <cstring>
-
 using namespace LAMMPS_NS;
 
-enum{COMPUTE,FIX,VARIABLE};
 enum{VECTOR,ARRAY};
 
 #define INVOKED_VECTOR 2
@@ -49,31 +47,15 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
   // process index arg
 
   int iarg = 3;
+  ArgInfo argi(arg[iarg]);
 
-  if (strncmp(arg[iarg],"c_",2) == 0 ||
-      strncmp(arg[iarg],"f_",2) == 0 ||
-      strncmp(arg[iarg],"v_",2) == 0) {
-    if (arg[iarg][0] == 'c') whichref = COMPUTE;
-    else if (arg[iarg][0] == 'f') whichref = FIX;
-    else if (arg[iarg][0] == 'v') whichref = VARIABLE;
+  whichref = argi.get_type();
+  indexref = argi.get_index1();
+  idref = argi.copy_name();
 
-    int n = strlen(arg[iarg]);
-    char *suffix = new char[n];
-    strcpy(suffix,&arg[iarg][2]);
-
-    char *ptr = strchr(suffix,'[');
-    if (ptr) {
-      if (suffix[strlen(suffix)-1] != ']')
-        error->all(FLERR,"Illegal compute global/atom command");
-      indexref = atoi(ptr+1);
-      *ptr = '\0';
-    } else indexref = 0;
-
-    n = strlen(suffix) + 1;
-    idref = new char[n];
-    strcpy(idref,suffix);
-    delete [] suffix;
-  } else error->all(FLERR,"Illegal compute global/atom command");
+  if ((whichref == ArgInfo::UNKNOWN) || (which[nvalues] == ArgInfo::NONE)
+      || (argi.get_dim() > 1))
+    error->all(FLERR,"Illegal compute global/atom command");
 
   iarg++;
 
@@ -94,37 +76,18 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
   value2index = new int[nargnew];
   nvalues = 0;
 
-  iarg = 0;
-  while (iarg < nargnew) {
-    ids[nvalues] = nullptr;
-    if (strncmp(arg[iarg],"c_",2) == 0 ||
-        strncmp(arg[iarg],"f_",2) == 0 ||
-        strncmp(arg[iarg],"v_",2) == 0) {
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
+  for (iarg = 0; iarg < nargnew; iarg++) {
+    ArgInfo argi(arg[iarg]);
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+    which[nvalues] = argi.get_type();
+    argindex[nvalues] = argi.get_index1();
+    ids[nvalues] = argi.copy_name();
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal compute global/atom command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
+    if ((which[nvalues] == ArgInfo::UNKNOWN) || (which[nvalues] == ArgInfo::NONE)
+        || (argi.get_dim() > 1))
+      error->all(FLERR,"Illegal compute slice command");
 
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
-      nvalues++;
-      delete [] suffix;
-
-    } else error->all(FLERR,"Illegal compute global/atom command");
-
-    iarg++;
+    nvalues++;
   }
 
   // if wildcard expansion occurred, free earg memory from expand_args()
@@ -136,7 +99,7 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
 
   // setup and error check both index arg and values
 
-  if (whichref == COMPUTE) {
+  if (whichref == ArgInfo::COMPUTE) {
     int icompute = modify->find_compute(idref);
     if (icompute < 0)
       error->all(FLERR,"Compute ID for compute global/atom does not exist");
@@ -155,7 +118,7 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
       error->all(FLERR,
                  "Compute global/atom compute array is accessed out-of-range");
 
-  } else if (whichref == FIX) {
+  } else if (whichref == ArgInfo::FIX) {
     int ifix = modify->find_fix(idref);
     if (ifix < 0)
       error->all(FLERR,"Fix ID for compute global/atom does not exist");
@@ -173,7 +136,7 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
       error->all(FLERR,
                  "Compute global/atom fix array is accessed out-of-range");
 
-  } else if (whichref == VARIABLE) {
+  } else if (whichref == ArgInfo::VARIABLE) {
     int ivariable = input->variable->find(idref);
     if (ivariable < 0)
       error->all(FLERR,"Variable name for compute global/atom does not exist");
@@ -183,7 +146,7 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
   }
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute global/atom does not exist");
@@ -200,7 +163,7 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
                      "accessed out-of-range");
       }
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute global/atom does not exist");
@@ -217,7 +180,7 @@ ComputeGlobalAtom::ComputeGlobalAtom(LAMMPS *lmp, int narg, char **arg) :
                      "accessed out-of-range");
       }
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute global/atom "
@@ -263,17 +226,17 @@ void ComputeGlobalAtom::init()
 {
   // set indices of all computes,fixes,variables
 
-  if (whichref == COMPUTE) {
+  if (whichref == ArgInfo::COMPUTE) {
     int icompute = modify->find_compute(idref);
     if (icompute < 0)
       error->all(FLERR,"Compute ID for compute global/atom does not exist");
     ref2index = icompute;
-  } else if (whichref == FIX) {
+  } else if (whichref == ArgInfo::FIX) {
     int ifix = modify->find_fix(idref);
     if (ifix < 0)
       error->all(FLERR,"Fix ID for compute global/atom does not exist");
     ref2index = ifix;
-  } else if (whichref == VARIABLE) {
+  } else if (whichref == ArgInfo::VARIABLE) {
     int ivariable = input->variable->find(idref);
     if (ivariable < 0)
       error->all(FLERR,"Variable name for compute global/atom does not exist");
@@ -281,19 +244,19 @@ void ComputeGlobalAtom::init()
   }
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == COMPUTE) {
+    if (which[m] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[m]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute global/atom does not exist");
       value2index[m] = icompute;
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[m]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute global/atom does not exist");
       value2index[m] = ifix;
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[m]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute global/atom "
@@ -317,7 +280,7 @@ void ComputeGlobalAtom::compute_peratom()
     nmax = atom->nmax;
     memory->destroy(indices);
     memory->create(indices,nmax,"global/atom:indices");
-    if (whichref == VARIABLE) {
+    if (whichref == ArgInfo::VARIABLE) {
       memory->destroy(varatom);
       memory->create(varatom,nmax,"global/atom:varatom");
     }
@@ -337,7 +300,7 @@ void ComputeGlobalAtom::compute_peratom()
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
 
-  if (whichref == COMPUTE) {
+  if (whichref == ArgInfo::COMPUTE) {
     Compute *compute = modify->compute[ref2index];
 
     if (!(compute->invoked_flag & INVOKED_PERATOM)) {
@@ -358,7 +321,7 @@ void ComputeGlobalAtom::compute_peratom()
           indices[i] = static_cast<int> (compute_array[i][im1]) - 1;
     }
 
-  } else if (whichref == FIX) {
+  } else if (whichref == ArgInfo::FIX) {
     if (update->ntimestep % modify->fix[ref2index]->peratom_freq)
       error->all(FLERR,"Fix used in compute global/atom not "
                  "computed at compatible time");
@@ -377,7 +340,7 @@ void ComputeGlobalAtom::compute_peratom()
           indices[i] = static_cast<int> (fix_array[i][im1]) - 1;
     }
 
-  } else if (whichref == VARIABLE) {
+  } else if (whichref == ArgInfo::VARIABLE) {
     input->variable->compute_atom(ref2index,igroup,varatom,1,0);
     for (i = 0; i < nlocal; i++)
       if (mask[i] & groupbit)
@@ -394,7 +357,7 @@ void ComputeGlobalAtom::compute_peratom()
       int vmax;
       double *source;
 
-      if (which[m] == COMPUTE) {
+      if (which[m] == ArgInfo::COMPUTE) {
         Compute *compute = modify->compute[value2index[m]];
 
         if (!(compute->invoked_flag & INVOKED_VECTOR)) {
@@ -405,7 +368,7 @@ void ComputeGlobalAtom::compute_peratom()
         source = compute->vector;
         vmax = compute->size_vector;
 
-      } else if (which[m] == FIX) {
+      } else if (which[m] == ArgInfo::FIX) {
         if (update->ntimestep % modify->fix[value2index[m]]->peratom_freq)
           error->all(FLERR,"Fix used in compute global/atom not "
                      "computed at compatible time");
@@ -423,7 +386,7 @@ void ComputeGlobalAtom::compute_peratom()
 
         source = vecglobal;
 
-      } else if (which[m] == VARIABLE) {
+      } else if (which[m] == ArgInfo::VARIABLE) {
         vmax = input->variable->compute_vector(value2index[m],&source);
       }
 
@@ -452,7 +415,7 @@ void ComputeGlobalAtom::compute_peratom()
       double *source;
       int col = argindex[m] - 1;
 
-      if (which[m] == COMPUTE) {
+      if (which[m] == ArgInfo::COMPUTE) {
         Compute *compute = modify->compute[value2index[m]];
 
         if (!(compute->invoked_flag & INVOKED_ARRAY)) {
@@ -474,7 +437,7 @@ void ComputeGlobalAtom::compute_peratom()
 
         source = vecglobal;
 
-      } else if (which[m] == FIX) {
+      } else if (which[m] == ArgInfo::FIX) {
         if (update->ntimestep % modify->fix[value2index[m]]->peratom_freq)
           error->all(FLERR,"Fix used in compute global/atom not "
                      "computed at compatible time");
@@ -492,7 +455,7 @@ void ComputeGlobalAtom::compute_peratom()
 
         source = vecglobal;
 
-      } else if (which[m] == VARIABLE) {
+      } else if (which[m] == ArgInfo::VARIABLE) {
         vmax = input->variable->compute_vector(value2index[m],&source);
       }
 

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -130,10 +130,10 @@ ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
       ArgInfo argi(arg[iarg]);
 
       which[nvalues] = argi.get_type();
-      argindex[nvalues] = argi.get_dim();
+      argindex[nvalues] = argi.get_index1();
       ids[nvalues] = argi.copy_name();
 
-      if ((which[nvalues] == ArgInfo::UNKNOWN) || (argindex[nvalues] > 1))
+      if ((which[nvalues] == ArgInfo::UNKNOWN) || (argi.get_dim() > 1))
         error->all(FLERR,"Illegal compute reduce command");
 
       if (which[nvalues] == ArgInfo::NONE) break;

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -13,25 +13,19 @@
 
 #include "compute_reduce.h"
 
-#include <cstring>
-
+#include "arg_info.h"
 #include "atom.h"
-#include "update.h"
 #include "domain.h"
-#include "modify.h"
+#include "error.h"
 #include "fix.h"
 #include "group.h"
 #include "input.h"
-#include "variable.h"
 #include "memory.h"
-#include "error.h"
-
+#include "modify.h"
+#include "update.h"
+#include "variable.h"
 
 using namespace LAMMPS_NS;
-
-enum{SUM,SUMSQ,MINN,MAXX,AVE,AVESQ};             // also in ComputeReduceRegion
-enum{UNKNOWN=-1,X,V,F,COMPUTE,FIX,VARIABLE};
-enum{PERATOM,LOCAL};
 
 #define INVOKED_VECTOR 2
 #define INVOKED_ARRAY 4
@@ -92,7 +86,7 @@ ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
   ids = new char*[nargnew];
   value2index = new int[nargnew];
   for (int i=0; i < nargnew; ++i) {
-    which[i] = argindex[i] = flavor[i] = value2index[i] = UNKNOWN;
+    which[i] = argindex[i] = flavor[i] = value2index[i] = ArgInfo::UNKNOWN;
     ids[i] = nullptr;
   }
   nvalues = 0;
@@ -102,61 +96,49 @@ ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
     ids[nvalues] = nullptr;
 
     if (strcmp(arg[iarg],"x") == 0) {
-      which[nvalues] = X;
+      which[nvalues] = ArgInfo::X;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"y") == 0) {
-      which[nvalues] = X;
+      which[nvalues] = ArgInfo::X;
       argindex[nvalues++] = 1;
     } else if (strcmp(arg[iarg],"z") == 0) {
-      which[nvalues] = X;
+      which[nvalues] = ArgInfo::X;
       argindex[nvalues++] = 2;
 
     } else if (strcmp(arg[iarg],"vx") == 0) {
-      which[nvalues] = V;
+      which[nvalues] = ArgInfo::V;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"vy") == 0) {
-      which[nvalues] = V;
+      which[nvalues] = ArgInfo::V;
       argindex[nvalues++] = 1;
     } else if (strcmp(arg[iarg],"vz") == 0) {
-      which[nvalues] = V;
+      which[nvalues] = ArgInfo::V;
       argindex[nvalues++] = 2;
 
     } else if (strcmp(arg[iarg],"fx") == 0) {
-      which[nvalues] = F;
+      which[nvalues] = ArgInfo::F;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"fy") == 0) {
-      which[nvalues] = F;
+      which[nvalues] = ArgInfo::F;
       argindex[nvalues++] = 1;
     } else if (strcmp(arg[iarg],"fz") == 0) {
-      which[nvalues] = F;
+      which[nvalues] = ArgInfo::F;
       argindex[nvalues++] = 2;
 
-    } else if (strncmp(arg[iarg],"c_",2) == 0 ||
-               strncmp(arg[iarg],"f_",2) == 0 ||
-               strncmp(arg[iarg],"v_",2) == 0) {
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
+    } else {
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+      ArgInfo argi(arg[iarg]);
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal compute reduce command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
+      which[nvalues] = argi.get_type();
+      argindex[nvalues] = argi.get_dim();
+      ids[nvalues] = argi.copy_name();
 
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
+      if ((which[nvalues] == ArgInfo::UNKNOWN) || (argindex[nvalues] > 1))
+        error->all(FLERR,"Illegal compute reduce command");
+
+      if (which[nvalues] == ArgInfo::NONE) break;
       nvalues++;
-      delete [] suffix;
-
-    } else break;
+    }
 
     iarg++;
   }
@@ -203,10 +185,10 @@ ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
   // setup and error check
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == X || which[i] == V || which[i] == F)
+    if (which[i] == ArgInfo::X || which[i] == ArgInfo::V || which[i] == ArgInfo::F)
       flavor[i] = PERATOM;
 
-    else if (which[i] == COMPUTE) {
+    else if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute reduce does not exist");
@@ -239,7 +221,7 @@ ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
       } else error->all(FLERR,
                         "Compute reduce compute calculates global values");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute reduce does not exist");
@@ -269,7 +251,7 @@ ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
           error->all(FLERR,"Compute reduce fix array is accessed out-of-range");
       } else error->all(FLERR,"Compute reduce fix calculates global values");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute reduce does not exist");
@@ -330,25 +312,25 @@ void ComputeReduce::init()
   // set indices of all computes,fixes,variables
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == COMPUTE) {
+    if (which[m] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[m]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute reduce does not exist");
       value2index[m] = icompute;
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[m]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute reduce does not exist");
       value2index[m] = ifix;
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[m]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute reduce does not exist");
       value2index[m] = ivariable;
 
-    } else value2index[m] = UNKNOWN;
+    } else value2index[m] = ArgInfo::UNKNOWN;
   }
 
   // set index and check validity of region
@@ -475,7 +457,7 @@ double ComputeReduce::compute_one(int m, int flag)
   // initialization in case it has not yet been run, e.g. when
   // the compute was invoked right after it has been created
 
-  if (vidx == UNKNOWN) {
+  if (vidx == ArgInfo::UNKNOWN) {
     init();
     vidx = value2index[m];
   }
@@ -488,19 +470,19 @@ double ComputeReduce::compute_one(int m, int flag)
   if (mode == MINN) one = BIG;
   if (mode == MAXX) one = -BIG;
 
-  if (which[m] == X) {
+  if (which[m] == ArgInfo::X) {
     double **x = atom->x;
     if (flag < 0) {
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) combine(one,x[i][aidx],i);
     } else one = x[flag][aidx];
-  } else if (which[m] == V) {
+  } else if (which[m] == ArgInfo::V) {
     double **v = atom->v;
     if (flag < 0) {
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) combine(one,v[i][aidx],i);
     } else one = v[flag][aidx];
-  } else if (which[m] == F) {
+  } else if (which[m] == ArgInfo::F) {
     double **f = atom->f;
     if (flag < 0) {
       for (i = 0; i < nlocal; i++)
@@ -509,7 +491,7 @@ double ComputeReduce::compute_one(int m, int flag)
 
   // invoke compute if not previously invoked
 
-  } else if (which[m] == COMPUTE) {
+  } else if (which[m] == ArgInfo::COMPUTE) {
     Compute *compute = modify->compute[vidx];
 
     if (flavor[m] == PERATOM) {
@@ -561,7 +543,7 @@ double ComputeReduce::compute_one(int m, int flag)
 
   // access fix fields, check if fix frequency is a match
 
-  } else if (which[m] == FIX) {
+  } else if (which[m] == ArgInfo::FIX) {
     if (update->ntimestep % modify->fix[vidx]->peratom_freq)
       error->all(FLERR,"Fix used in compute reduce not "
                  "computed at compatible time");
@@ -605,7 +587,7 @@ double ComputeReduce::compute_one(int m, int flag)
 
   // evaluate atom-style variable
 
-  } else if (which[m] == VARIABLE) {
+  } else if (which[m] == ArgInfo::VARIABLE) {
     if (atom->nmax > maxatom) {
       maxatom = atom->nmax;
       memory->destroy(varatom);
@@ -628,9 +610,9 @@ bigint ComputeReduce::count(int m)
 {
   int vidx = value2index[m];
 
-  if (which[m] == X || which[m] == V || which[m] == F)
+  if (which[m] == ArgInfo::X || which[m] == ArgInfo::V || which[m] == ArgInfo::F)
     return group->count(igroup);
-  else if (which[m] == COMPUTE) {
+  else if (which[m] == ArgInfo::COMPUTE) {
     Compute *compute = modify->compute[vidx];
     if (flavor[m] == PERATOM) {
       return group->count(igroup);
@@ -640,7 +622,7 @@ bigint ComputeReduce::count(int m)
       MPI_Allreduce(&ncount,&ncountall,1,MPI_LMP_BIGINT,MPI_SUM,world);
       return ncountall;
     }
-  } else if (which[m] == FIX) {
+  } else if (which[m] == ArgInfo::FIX) {
     Fix *fix = modify->fix[vidx];
     if (flavor[m] == PERATOM) {
       return group->count(igroup);
@@ -650,7 +632,7 @@ bigint ComputeReduce::count(int m)
       MPI_Allreduce(&ncount,&ncountall,1,MPI_LMP_BIGINT,MPI_SUM,world);
       return ncountall;
     }
-  } else if (which[m] == VARIABLE)
+  } else if (which[m] == ArgInfo::VARIABLE)
     return group->count(igroup);
 
   bigint dummy = 0;

--- a/src/compute_reduce.h
+++ b/src/compute_reduce.h
@@ -26,6 +26,9 @@ namespace LAMMPS_NS {
 
 class ComputeReduce : public Compute {
  public:
+  enum {SUM,SUMSQ,MINN,MAXX,AVE,AVESQ};
+  enum {PERATOM,LOCAL};
+
   ComputeReduce(class LAMMPS *, int, char **);
   virtual ~ComputeReduce();
   void init();

--- a/src/compute_reduce_chunk.cpp
+++ b/src/compute_reduce_chunk.cpp
@@ -13,24 +13,23 @@
 
 #include "compute_reduce_chunk.h"
 
-#include <cstring>
-
+#include "arg_info.h"
 #include "atom.h"
-#include "update.h"
-#include "modify.h"
-#include "fix.h"
 #include "compute.h"
 #include "compute_chunk_atom.h"
-#include "input.h"
-#include "variable.h"
-#include "memory.h"
 #include "error.h"
+#include "fix.h"
+#include "input.h"
+#include "memory.h"
+#include "modify.h"
+#include "update.h"
+#include "variable.h"
 
+#include <cstring>
 
 using namespace LAMMPS_NS;
 
 enum{SUM,MINN,MAXX};
-enum{UNKNOWN=-1,COMPUTE,FIX,VARIABLE};
 
 #define INVOKED_PERATOM 8
 
@@ -77,43 +76,23 @@ ComputeReduceChunk::ComputeReduceChunk(LAMMPS *lmp, int narg, char **arg) :
   ids = new char*[nargnew];
   value2index = new int[nargnew];
   for (int i=0; i < nargnew; ++i) {
-    which[i] = argindex[i] = value2index[i] = UNKNOWN;
+    which[i] = argindex[i] = value2index[i] = ArgInfo::UNKNOWN;
     ids[i] = nullptr;
   }
   nvalues = 0;
 
-  iarg = 0;
-  while (iarg < nargnew) {
-    ids[nvalues] = nullptr;
+  for (iarg = 0; iarg < nargnew; iarg++) {
+    ArgInfo argi(arg[iarg]);
 
-    if (strncmp(arg[iarg],"c_",2) == 0 ||
-               strncmp(arg[iarg],"f_",2) == 0 ||
-               strncmp(arg[iarg],"v_",2) == 0) {
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
+    which[nvalues] = argi.get_type();
+    argindex[nvalues] = argi.get_dim();
+    ids[nvalues] = argi.copy_name();
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+    if ((which[nvalues] == ArgInfo::UNKNOWN) || (which[nvalues] == ArgInfo::NONE)
+        || (argindex[nvalues] > 1))
+      error->all(FLERR,"Illegal compute reduce/chunk command");
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal compute reduce/chunk command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
-
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
-      nvalues++;
-      delete [] suffix;
-
-    } else error->all(FLERR,"Illegal compute reduce/chunk command");
-
-    iarg++;
+    nvalues++;
   }
 
   // if wildcard expansion occurred, free earg memory from expand_args()
@@ -126,7 +105,7 @@ ComputeReduceChunk::ComputeReduceChunk(LAMMPS *lmp, int narg, char **arg) :
   // error check
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute reduce/chunk does not exist");
@@ -145,7 +124,7 @@ ComputeReduceChunk::ComputeReduceChunk(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Compute reduce/chunk compute array is accessed out-of-range");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute reduce/chunk does not exist");
@@ -163,7 +142,7 @@ ComputeReduceChunk::ComputeReduceChunk(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,"Compute reduce/chunk fix array is "
                    "accessed out-of-range");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute reduce/chunk does not exist");
@@ -229,19 +208,19 @@ void ComputeReduceChunk::init()
   // set indices of all computes,fixes,variables
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == COMPUTE) {
+    if (which[m] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[m]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute reduce/chunk does not exist");
       value2index[m] = icompute;
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[m]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute reduce/chunk does not exist");
       value2index[m] = ifix;
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[m]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute reduce/chunk does not exist");
@@ -366,12 +345,12 @@ void ComputeReduceChunk::compute_one(int m, double *vchunk, int nstride)
   // initialization in case it has not yet been run, e.g. when
   // the compute was invoked right after it has been created
 
-  if (vidx == UNKNOWN) {
+  if (vidx == ArgInfo::UNKNOWN) {
     init();
     vidx = value2index[m];
   }
 
-  if (which[m] == COMPUTE) {
+  if (which[m] == ArgInfo::COMPUTE) {
     Compute *compute = modify->compute[vidx];
 
     if (!(compute->invoked_flag & INVOKED_PERATOM)) {
@@ -400,7 +379,7 @@ void ComputeReduceChunk::compute_one(int m, double *vchunk, int nstride)
 
   // access fix fields, check if fix frequency is a match
 
-  } else if (which[m] == FIX) {
+  } else if (which[m] == ArgInfo::FIX) {
     Fix *fix = modify->fix[vidx];
     if (update->ntimestep % fix->peratom_freq)
       error->all(FLERR,"Fix used in compute reduce/chunk not "
@@ -427,7 +406,7 @@ void ComputeReduceChunk::compute_one(int m, double *vchunk, int nstride)
 
   // evaluate atom-style variable
 
-  } else if (which[m] == VARIABLE) {
+  } else if (which[m] == ArgInfo::VARIABLE) {
     if (atom->nmax > maxatom) {
       memory->destroy(varatom);
       maxatom = atom->nmax;

--- a/src/compute_reduce_chunk.cpp
+++ b/src/compute_reduce_chunk.cpp
@@ -85,11 +85,11 @@ ComputeReduceChunk::ComputeReduceChunk(LAMMPS *lmp, int narg, char **arg) :
     ArgInfo argi(arg[iarg]);
 
     which[nvalues] = argi.get_type();
-    argindex[nvalues] = argi.get_dim();
+    argindex[nvalues] = argi.get_index1();
     ids[nvalues] = argi.copy_name();
 
     if ((which[nvalues] == ArgInfo::UNKNOWN) || (which[nvalues] == ArgInfo::NONE)
-        || (argindex[nvalues] > 1))
+        || (argi.get_dim() > 1))
       error->all(FLERR,"Illegal compute reduce/chunk command");
 
     nvalues++;

--- a/src/compute_reduce_region.cpp
+++ b/src/compute_reduce_region.cpp
@@ -13,23 +13,20 @@
 
 #include "compute_reduce_region.h"
 
+#include "arg_info.h"
 #include "atom.h"
-#include "update.h"
-#include "modify.h"
 #include "domain.h"
-#include "group.h"
-#include "region.h"
-#include "fix.h"
-#include "input.h"
-#include "variable.h"
-#include "memory.h"
 #include "error.h"
+#include "fix.h"
+#include "group.h"
+#include "input.h"
+#include "memory.h"
+#include "modify.h"
+#include "region.h"
+#include "update.h"
+#include "variable.h"
 
 using namespace LAMMPS_NS;
-
-enum{SUM,SUMSQ,MINN,MAXX,AVE,AVESQ};             // also in ComputeReduce
-enum{UNKNOWN=-1,X,V,F,COMPUTE,FIX,VARIABLE};
-enum{PERATOM,LOCAL};
 
 #define INVOKED_VECTOR 2
 #define INVOKED_ARRAY 4
@@ -72,7 +69,7 @@ double ComputeReduceRegion::compute_one(int m, int flag)
 
   // initialization in case it has not yet been run,
   // e.g. when invoked
-  if (n == UNKNOWN) {
+  if (n == ArgInfo::UNKNOWN) {
     init();
     n = value2index[m];
   }
@@ -83,20 +80,20 @@ double ComputeReduceRegion::compute_one(int m, int flag)
   if (mode == MINN) one = BIG;
   if (mode == MAXX) one = -BIG;
 
-  if (which[m] == X) {
+  if (which[m] == ArgInfo::X) {
     if (flag < 0) {
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit && region->match(x[i][0],x[i][1],x[i][2]))
           combine(one,x[i][j],i);
     } else one = x[flag][j];
-  } else if (which[m] == V) {
+  } else if (which[m] == ArgInfo::V) {
     double **v = atom->v;
     if (flag < 0) {
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit && region->match(x[i][0],x[i][1],x[i][2]))
           combine(one,v[i][j],i);
     } else one = v[flag][j];
-  } else if (which[m] == F) {
+  } else if (which[m] == ArgInfo::F) {
     double **f = atom->f;
     if (flag < 0) {
       for (i = 0; i < nlocal; i++)
@@ -106,7 +103,7 @@ double ComputeReduceRegion::compute_one(int m, int flag)
 
   // invoke compute if not previously invoked
 
-  } else if (which[m] == COMPUTE) {
+  } else if (which[m] == ArgInfo::COMPUTE) {
     Compute *compute = modify->compute[n];
 
     if (flavor[m] == PERATOM) {
@@ -160,7 +157,7 @@ double ComputeReduceRegion::compute_one(int m, int flag)
 
   // check if fix frequency is a match
 
-  } else if (which[m] == FIX) {
+  } else if (which[m] == ArgInfo::FIX) {
     if (update->ntimestep % modify->fix[n]->peratom_freq)
       error->all(FLERR,"Fix used in compute reduce not computed at "
                  "compatible time");
@@ -206,7 +203,7 @@ double ComputeReduceRegion::compute_one(int m, int flag)
 
   // evaluate atom-style variable
 
-  } else if (which[m] == VARIABLE) {
+  } else if (which[m] == ArgInfo::VARIABLE) {
     if (atom->nmax > maxatom) {
       maxatom = atom->nmax;
       memory->destroy(varatom);
@@ -230,9 +227,9 @@ bigint ComputeReduceRegion::count(int m)
 {
   int n = value2index[m];
 
-  if (which[m] == X || which[m] == V || which[m] == F)
+  if (which[m] == ArgInfo::X || which[m] == ArgInfo::V || which[m] == ArgInfo::F)
     return group->count(igroup,iregion);
-  else if (which[m] == COMPUTE) {
+  else if (which[m] == ArgInfo::COMPUTE) {
     Compute *compute = modify->compute[n];
     if (flavor[m] == PERATOM) {
       return group->count(igroup,iregion);
@@ -242,7 +239,7 @@ bigint ComputeReduceRegion::count(int m)
       MPI_Allreduce(&ncount,&ncountall,1,MPI_DOUBLE,MPI_SUM,world);
       return ncountall;
     }
-  } else if (which[m] == FIX) {
+  } else if (which[m] == ArgInfo::FIX) {
     Fix *fix = modify->fix[n];
     if (flavor[m] == PERATOM) {
       return group->count(igroup,iregion);
@@ -252,7 +249,7 @@ bigint ComputeReduceRegion::count(int m)
       MPI_Allreduce(&ncount,&ncountall,1,MPI_DOUBLE,MPI_SUM,world);
       return ncountall;
     }
-  } else if (which[m] == VARIABLE)
+  } else if (which[m] == ArgInfo::VARIABLE)
     return group->count(igroup,iregion);
 
   bigint dummy = 0;

--- a/src/compute_slice.cpp
+++ b/src/compute_slice.cpp
@@ -56,12 +56,14 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
     ArgInfo argi(arg[iarg]);
 
     which[nvalues] = argi.get_type();
-    argindex[nvalues] = argi.get_dim();
+    argindex[nvalues] = argi.get_index1();
     ids[nvalues] = argi.copy_name();
 
     if ((which[nvalues] == ArgInfo::UNKNOWN) || (which[nvalues] == ArgInfo::NONE)
-        || (argindex[nvalues] > 1))
+        || (argi.get_dim() > 1))
       error->all(FLERR,"Illegal compute slice command");
+
+    nvalues++;
   }
 
   // setup and error check

--- a/src/compute_slice.cpp
+++ b/src/compute_slice.cpp
@@ -13,6 +13,7 @@
 
 #include "compute_slice.h"
 
+#include "arg_info.h"
 #include "error.h"
 #include "fix.h"
 #include "input.h"
@@ -21,11 +22,7 @@
 #include "update.h"
 #include "variable.h"
 
-#include <cstring>
-
 using namespace LAMMPS_NS;
-
-enum{COMPUTE,FIX,VARIABLE};
 
 #define INVOKED_VECTOR 2
 #define INVOKED_ARRAY 4
@@ -56,38 +53,21 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
   nvalues = 0;
 
   for (int iarg = 6; iarg < narg; iarg++) {
-    if (strncmp(arg[iarg],"c_",2) == 0 ||
-        strncmp(arg[iarg],"f_",2) == 0 ||
-        strncmp(arg[iarg],"v_",2) == 0) {
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
+    ArgInfo argi(arg[iarg]);
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+    which[nvalues] = argi.get_type();
+    argindex[nvalues] = argi.get_dim();
+    ids[nvalues] = argi.copy_name();
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal compute slice command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
-
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
-      nvalues++;
-      delete [] suffix;
-
-    } else error->all(FLERR,"Illegal compute slice command");
+    if ((which[nvalues] == ArgInfo::UNKNOWN) || (which[nvalues] == ArgInfo::NONE)
+        || (argindex[nvalues] > 1))
+      error->all(FLERR,"Illegal compute slice command");
   }
 
   // setup and error check
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute slice does not exist");
@@ -111,7 +91,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
       } else error->all(FLERR,"Compute slice compute does not calculate "
                         "global vector or array");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute slice does not exist");
@@ -132,7 +112,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
       } else error->all(FLERR,"Compute slice fix does not calculate "
                         "global vector or array");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute slice does not exist");
@@ -152,7 +132,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
     size_vector = (nstop-nstart) / nskip;
     memory->create(vector,size_vector,"slice:vector");
 
-    if (which[0] == COMPUTE) {
+    if (which[0] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[0]);
       if (argindex[0] == 0) {
         extvector = modify->compute[icompute]->extvector;
@@ -163,7 +143,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
             extlist[j++] = modify->compute[icompute]->extlist[i-1];
         }
       } else extvector = modify->compute[icompute]->extarray;
-    } else if (which[0] == FIX) {
+    } else if (which[0] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[0]);
       if (argindex[0] == 0) {
         extvector = modify->fix[ifix]->extvector;
@@ -174,7 +154,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
             extlist[j++] = modify->fix[ifix]->extlist[i-1];
         }
       } else extvector = modify->fix[ifix]->extarray;
-    } else if (which[0] == VARIABLE) {
+    } else if (which[0] == ArgInfo::VARIABLE) {
       extvector = 0;
     }
 
@@ -186,7 +166,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
 
     extarray = 0;
     for (int i = 0; i < nvalues; i++) {
-      if (which[i] == COMPUTE) {
+      if (which[i] == ArgInfo::COMPUTE) {
         int icompute = modify->find_compute(ids[i]);
         if (argindex[i] == 0) {
           if (modify->compute[icompute]->extvector == 1) extarray = 1;
@@ -197,7 +177,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
         } else {
           if (modify->compute[icompute]->extarray) extarray = 1;
         }
-      } else if (which[i] == FIX) {
+      } else if (which[i] == ArgInfo::FIX) {
         int ifix = modify->find_fix(ids[i]);
         if (argindex[i] == 0) {
           if (modify->fix[ifix]->extvector == 1) extarray = 1;
@@ -208,7 +188,7 @@ ComputeSlice::ComputeSlice(LAMMPS *lmp, int narg, char **arg) :
         } else {
           if (modify->fix[ifix]->extarray) extarray = 1;
         }
-      } else if (which[i] == VARIABLE) {
+      } else if (which[i] == ArgInfo::VARIABLE) {
         // variable is always intensive, does not change extarray
       }
     }
@@ -237,17 +217,17 @@ void ComputeSlice::init()
   // set indices and check validity of all computes,fixes
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == COMPUTE) {
+    if (which[m] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[m]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for compute slice does not exist");
       value2index[m] = icompute;
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[m]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for compute slice does not exist");
       value2index[m] = ifix;
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[m]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for compute slice does not exist");
@@ -286,7 +266,7 @@ void ComputeSlice::extract_one(int m, double *vec, int stride)
 
   // invoke the appropriate compute if needed
 
-  if (which[m] == COMPUTE) {
+  if (which[m] == ArgInfo::COMPUTE) {
     Compute *compute = modify->compute[value2index[m]];
 
     if (argindex[m] == 0) {
@@ -317,7 +297,7 @@ void ComputeSlice::extract_one(int m, double *vec, int stride)
 
   // access fix fields, check if fix frequency is a match
 
-  } else if (which[m] == FIX) {
+  } else if (which[m] == ArgInfo::FIX) {
     if (update->ntimestep % modify->fix[value2index[m]]->global_freq)
       error->all(FLERR,"Fix used in compute slice not "
                  "computed at compatible time");
@@ -340,7 +320,7 @@ void ComputeSlice::extract_one(int m, double *vec, int stride)
 
     // invoke vector-style variable
 
-  } else if (which[m] == VARIABLE) {
+  } else if (which[m] == ArgInfo::VARIABLE) {
     double *varvec;
     int nvec = input->variable->compute_vector(value2index[m],&varvec);
     if (nvec < nstop)

--- a/src/dump_cfg.cpp
+++ b/src/dump_cfg.cpp
@@ -17,11 +17,14 @@
 ------------------------------------------------------------------------- */
 
 #include "dump_cfg.h"
-#include <cstring>
+
+#include "arg_info.h"
 #include "atom.h"
 #include "domain.h"
 #include "memory.h"
 #include "error.h"
+
+#include <cstring>
 
 using namespace LAMMPS_NS;
 
@@ -67,18 +70,14 @@ DumpCFG::DumpCFG(LAMMPS *lmp, int narg, char **arg) :
 
   int i = 0;
   for (int iarg = 5; iarg < nfield; iarg++, i++) {
-    if ((strncmp(earg[iarg],"c_",2) == 0 ||
-         strncmp(earg[iarg],"f_",2) == 0 ||
-         strncmp(earg[iarg],"v_",2) == 0) && strchr(earg[iarg],'[')) {
-      char *ptr = strchr(earg[iarg],'[');
-      char *ptr2 = strchr(ptr,']');
-      auxname[i] = new char[strlen(earg[iarg])];
-      *ptr = '\0';
-      *ptr2 = '\0';
-      strcpy(auxname[i],earg[iarg]);
-      strcat(auxname[i],"_");
-      strcat(auxname[i],ptr+1);
+    ArgInfo argi(earg[iarg],ArgInfo::COMPUTE|ArgInfo::FIX|ArgInfo::VARIABLE
+                 |ArgInfo::DNAME|ArgInfo::INAME);
 
+    if (argi.get_dim() == 1) {
+      std::string newarg(std::to_string(earg[iarg][0]));
+      newarg += '_' + argi.get_name() + '_' + std::to_string(argi.get_index1());
+      auxname[i] = new char[newarg.size()+1];
+      strcpy(auxname[i],newarg.c_str());
     } else {
       auxname[i] = new char[strlen(earg[iarg]) + 1];
       strcpy(auxname[i],earg[iarg]);

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -13,6 +13,7 @@
 
 #include "dump_custom.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "compute.h"
 #include "domain.h"
@@ -1252,327 +1253,302 @@ int DumpCustom::parse_fields(int narg, char **arg)
 {
   // customize by adding to if statement
 
-  int i;
   for (int iarg = 0; iarg < narg; iarg++) {
-    i = iarg;
 
     if (strcmp(arg[iarg],"id") == 0) {
-      pack_choice[i] = &DumpCustom::pack_id;
-      if (sizeof(tagint) == sizeof(smallint)) vtype[i] = Dump::INT;
-      else vtype[i] = Dump::BIGINT;
+      pack_choice[iarg] = &DumpCustom::pack_id;
+      if (sizeof(tagint) == sizeof(smallint)) vtype[iarg] = Dump::INT;
+      else vtype[iarg] = Dump::BIGINT;
     } else if (strcmp(arg[iarg],"mol") == 0) {
       if (!atom->molecule_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_molecule;
-      if (sizeof(tagint) == sizeof(smallint)) vtype[i] = Dump::INT;
-      else vtype[i] = Dump::BIGINT;
+      pack_choice[iarg] = &DumpCustom::pack_molecule;
+      if (sizeof(tagint) == sizeof(smallint)) vtype[iarg] = Dump::INT;
+      else vtype[iarg] = Dump::BIGINT;
     } else if (strcmp(arg[iarg],"proc") == 0) {
-      pack_choice[i] = &DumpCustom::pack_proc;
-      vtype[i] = Dump::INT;
+      pack_choice[iarg] = &DumpCustom::pack_proc;
+      vtype[iarg] = Dump::INT;
     } else if (strcmp(arg[iarg],"procp1") == 0) {
-      pack_choice[i] = &DumpCustom::pack_procp1;
-      vtype[i] = Dump::INT;
+      pack_choice[iarg] = &DumpCustom::pack_procp1;
+      vtype[iarg] = Dump::INT;
     } else if (strcmp(arg[iarg],"type") == 0) {
-      pack_choice[i] = &DumpCustom::pack_type;
-      vtype[i] = Dump::INT;
+      pack_choice[iarg] = &DumpCustom::pack_type;
+      vtype[iarg] = Dump::INT;
     } else if (strcmp(arg[iarg],"element") == 0) {
-      pack_choice[i] = &DumpCustom::pack_type;
-      vtype[i] = Dump::STRING;
+      pack_choice[iarg] = &DumpCustom::pack_type;
+      vtype[iarg] = Dump::STRING;
     } else if (strcmp(arg[iarg],"mass") == 0) {
-      pack_choice[i] = &DumpCustom::pack_mass;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_mass;
+      vtype[iarg] = Dump::DOUBLE;
 
     } else if (strcmp(arg[iarg],"x") == 0) {
-      pack_choice[i] = &DumpCustom::pack_x;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_x;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"y") == 0) {
-      pack_choice[i] = &DumpCustom::pack_y;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_y;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"z") == 0) {
-      pack_choice[i] = &DumpCustom::pack_z;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_z;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"xs") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_xs_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_xs;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_xs_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_xs;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"ys") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_ys_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_ys;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_ys_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_ys;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"zs") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_zs_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_zs;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_zs_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_zs;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"xu") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_xu_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_xu;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_xu_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_xu;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"yu") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_yu_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_yu;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_yu_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_yu;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"zu") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_zu_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_zu;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_zu_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_zu;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"xsu") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_xsu_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_xsu;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_xsu_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_xsu;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"ysu") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_ysu_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_ysu;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_ysu_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_ysu;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"zsu") == 0) {
-      if (domain->triclinic) pack_choice[i] = &DumpCustom::pack_zsu_triclinic;
-      else pack_choice[i] = &DumpCustom::pack_zsu;
-      vtype[i] = Dump::DOUBLE;
+      if (domain->triclinic) pack_choice[iarg] = &DumpCustom::pack_zsu_triclinic;
+      else pack_choice[iarg] = &DumpCustom::pack_zsu;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"ix") == 0) {
-      pack_choice[i] = &DumpCustom::pack_ix;
-      vtype[i] = Dump::INT;
+      pack_choice[iarg] = &DumpCustom::pack_ix;
+      vtype[iarg] = Dump::INT;
     } else if (strcmp(arg[iarg],"iy") == 0) {
-      pack_choice[i] = &DumpCustom::pack_iy;
-      vtype[i] = Dump::INT;
+      pack_choice[iarg] = &DumpCustom::pack_iy;
+      vtype[iarg] = Dump::INT;
     } else if (strcmp(arg[iarg],"iz") == 0) {
-      pack_choice[i] = &DumpCustom::pack_iz;
-      vtype[i] = Dump::INT;
+      pack_choice[iarg] = &DumpCustom::pack_iz;
+      vtype[iarg] = Dump::INT;
 
     } else if (strcmp(arg[iarg],"vx") == 0) {
-      pack_choice[i] = &DumpCustom::pack_vx;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_vx;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"vy") == 0) {
-      pack_choice[i] = &DumpCustom::pack_vy;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_vy;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"vz") == 0) {
-      pack_choice[i] = &DumpCustom::pack_vz;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_vz;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"fx") == 0) {
-      pack_choice[i] = &DumpCustom::pack_fx;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_fx;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"fy") == 0) {
-      pack_choice[i] = &DumpCustom::pack_fy;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_fy;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"fz") == 0) {
-      pack_choice[i] = &DumpCustom::pack_fz;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_fz;
+      vtype[iarg] = Dump::DOUBLE;
 
     } else if (strcmp(arg[iarg],"q") == 0) {
       if (!atom->q_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_q;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_q;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"mux") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_mux;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_mux;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"muy") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_muy;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_muy;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"muz") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_muz;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_muz;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"mu") == 0) {
       if (!atom->mu_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_mu;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_mu;
+      vtype[iarg] = Dump::DOUBLE;
 
     } else if (strcmp(arg[iarg],"radius") == 0) {
       if (!atom->radius_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_radius;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_radius;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"diameter") == 0) {
       if (!atom->radius_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_diameter;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_diameter;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"omegax") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_omegax;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_omegax;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"omegay") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_omegay;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_omegay;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"omegaz") == 0) {
       if (!atom->omega_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_omegaz;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_omegaz;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"angmomx") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_angmomx;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_angmomx;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"angmomy") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_angmomy;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_angmomy;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"angmomz") == 0) {
       if (!atom->angmom_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_angmomz;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_angmomz;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"tqx") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_tqx;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_tqx;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"tqy") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_tqy;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_tqy;
+      vtype[iarg] = Dump::DOUBLE;
     } else if (strcmp(arg[iarg],"tqz") == 0) {
       if (!atom->torque_flag)
         error->all(FLERR,"Dumping an atom property that isn't allocated");
-      pack_choice[i] = &DumpCustom::pack_tqz;
-      vtype[i] = Dump::DOUBLE;
+      pack_choice[iarg] = &DumpCustom::pack_tqz;
+      vtype[iarg] = Dump::DOUBLE;
 
-    // compute value = c_ID
-    // if no trailing [], then arg is set to 0, else arg is int between []
+    } else {
 
-    } else if (strncmp(arg[iarg],"c_",2) == 0) {
-      pack_choice[i] = &DumpCustom::pack_compute;
-      vtype[i] = Dump::DOUBLE;
+      int n,tmp;
+      ArgInfo argi(arg[iarg],ArgInfo::COMPUTE|ArgInfo::FIX|ArgInfo::VARIABLE
+                   |ArgInfo::DNAME|ArgInfo::INAME);
+      argindex[iarg] = argi.get_index1();
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+      switch (argi.get_type()) {
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump custom command");
-        argindex[i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[i] = 0;
+      case ArgInfo::UNKNOWN:
+        error->all(FLERR,"Invalid attribute in dump custom command");
+        break;
 
-      n = modify->find_compute(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump custom compute ID");
-      if (modify->compute[n]->peratom_flag == 0)
-        error->all(FLERR,"Dump custom compute does not compute per-atom info");
-      if (argindex[i] == 0 && modify->compute[n]->size_peratom_cols > 0)
-        error->all(FLERR,
-                   "Dump custom compute does not calculate per-atom vector");
-      if (argindex[i] > 0 && modify->compute[n]->size_peratom_cols == 0)
-        error->all(FLERR,
-                   "Dump custom compute does not calculate per-atom array");
-      if (argindex[i] > 0 &&
-          argindex[i] > modify->compute[n]->size_peratom_cols)
-        error->all(FLERR,"Dump custom compute vector is accessed out-of-range");
+        // compute value = c_ID
+        // if no trailing [], then arg is set to 0, else arg is int between []
 
-      field2index[i] = add_compute(suffix);
-      delete [] suffix;
+      case ArgInfo::COMPUTE:
+        pack_choice[iarg] = &DumpCustom::pack_compute;
+        vtype[iarg] = Dump::DOUBLE;
 
-    // fix value = f_ID
-    // if no trailing [], then arg is set to 0, else arg is between []
+        n = modify->find_compute(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump custom compute ID");
+        if (modify->compute[n]->peratom_flag == 0)
+          error->all(FLERR,"Dump custom compute does not compute per-atom info");
+        if (argi.get_dim() == 0 && modify->compute[n]->size_peratom_cols > 0)
+          error->all(FLERR,
+                     "Dump custom compute does not calculate per-atom vector");
+        if (argi.get_index1() > 0 && modify->compute[n]->size_peratom_cols == 0)
+          error->all(FLERR,
+                     "Dump custom compute does not calculate per-atom array");
+        if (argi.get_index1() > 0 &&
+            argi.get_index1() > modify->compute[n]->size_peratom_cols)
+          error->all(FLERR,"Dump custom compute vector is accessed out-of-range");
 
-    } else if (strncmp(arg[iarg],"f_",2) == 0) {
-      pack_choice[i] = &DumpCustom::pack_fix;
-      vtype[i] = Dump::DOUBLE;
+        field2index[iarg] = add_compute(argi.get_name());
+        break;
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+        // fix value = f_ID
+        // if no trailing [], then arg is set to 0, else arg is between []
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump custom command");
-        argindex[i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[i] = 0;
+      case ArgInfo::FIX:
+        pack_choice[iarg] = &DumpCustom::pack_fix;
+        vtype[iarg] = Dump::DOUBLE;
 
-      n = modify->find_fix(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump custom fix ID");
-      if (modify->fix[n]->peratom_flag == 0)
-        error->all(FLERR,"Dump custom fix does not compute per-atom info");
-      if (argindex[i] == 0 && modify->fix[n]->size_peratom_cols > 0)
-        error->all(FLERR,"Dump custom fix does not compute per-atom vector");
-      if (argindex[i] > 0 && modify->fix[n]->size_peratom_cols == 0)
-        error->all(FLERR,"Dump custom fix does not compute per-atom array");
-      if (argindex[i] > 0 &&
-          argindex[i] > modify->fix[n]->size_peratom_cols)
-        error->all(FLERR,"Dump custom fix vector is accessed out-of-range");
+        n = modify->find_fix(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump custom fix ID");
+        if (modify->fix[n]->peratom_flag == 0)
+          error->all(FLERR,"Dump custom fix does not compute per-atom info");
+        if (argi.get_dim() == 0 && modify->fix[n]->size_peratom_cols > 0)
+          error->all(FLERR,"Dump custom fix does not compute per-atom vector");
+        if (argi.get_index1() > 0 && modify->fix[n]->size_peratom_cols == 0)
+          error->all(FLERR,"Dump custom fix does not compute per-atom array");
+        if (argi.get_index1() > 0 &&
+            argi.get_index1() > modify->fix[n]->size_peratom_cols)
+          error->all(FLERR,"Dump custom fix vector is accessed out-of-range");
 
-      field2index[i] = add_fix(suffix);
-      delete [] suffix;
+        field2index[iarg] = add_fix(argi.get_name());
+        break;
 
-    // variable value = v_name
+        // variable value = v_name
 
-    } else if (strncmp(arg[iarg],"v_",2) == 0) {
-      pack_choice[i] = &DumpCustom::pack_variable;
-      vtype[i] = Dump::DOUBLE;
+      case ArgInfo::VARIABLE:
+        pack_choice[iarg] = &DumpCustom::pack_variable;
+        vtype[iarg] = Dump::DOUBLE;
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+        n = input->variable->find(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump custom variable name");
+        if (input->variable->atomstyle(n) == 0)
+          error->all(FLERR,"Dump custom variable is not atom-style variable");
 
-      argindex[i] = 0;
+        field2index[iarg] = add_variable(argi.get_name());
+        break;
 
-      n = input->variable->find(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump custom variable name");
-      if (input->variable->atomstyle(n) == 0)
-        error->all(FLERR,"Dump custom variable is not atom-style variable");
+        // custom per-atom floating point value = d_ID
 
-      field2index[i] = add_variable(suffix);
-      delete [] suffix;
+      case ArgInfo::DNAME:
+        pack_choice[iarg] = &DumpCustom::pack_custom;
+        vtype[iarg] = Dump::DOUBLE;
 
-    // custom per-atom floating point value = d_ID
+        tmp = -1;
+        n = atom->find_custom(argi.get_name(),tmp);
+        if (n < 0)
+          error->all(FLERR,"Could not find custom per-atom property ID");
 
-    } else if (strncmp(arg[iarg],"d_",2) == 0) {
-      pack_choice[i] = &DumpCustom::pack_custom;
-      vtype[i] = Dump::DOUBLE;
+        if (tmp != 1)
+          error->all(FLERR,"Custom per-atom property ID is not floating point");
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
-      argindex[i] = 0;
+        field2index[iarg] = add_custom(argi.get_name(),1);
+        break;
 
-      int tmp = -1;
-      n = atom->find_custom(suffix,tmp);
-      if (n < 0)
-        error->all(FLERR,"Could not find custom per-atom property ID");
+        // custom per-atom integer value = i_ID
 
-      if (tmp != 1)
-        error->all(FLERR,"Custom per-atom property ID is not floating point");
+      case ArgInfo::INAME:
+        pack_choice[iarg] = &DumpCustom::pack_custom;
+        vtype[iarg] = Dump::INT;
 
-      field2index[i] = add_custom(suffix,1);
-      delete [] suffix;
+        tmp = -1;
+        n = atom->find_custom(argi.get_name(),tmp);
+        if (n < 0)
+          error->all(FLERR,"Could not find custom per-atom property ID");
 
-    // custom per-atom integer value = i_ID
+        if (tmp != 0)
+          error->all(FLERR,"Custom per-atom property ID is not integer");
 
-    } else if (strncmp(arg[iarg],"i_",2) == 0) {
-      pack_choice[i] = &DumpCustom::pack_custom;
-      vtype[i] = Dump::INT;
+        field2index[iarg] = add_custom(argi.get_name(),0);
+        break;
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
-      argindex[i] = 0;
-
-      int tmp = -1;
-      n = atom->find_custom(suffix,tmp);
-      if (n < 0)
-        error->all(FLERR,"Could not find custom per-atom property ID");
-
-      if (tmp != 0)
-        error->all(FLERR,"Custom per-atom property ID is not integer");
-
-      field2index[i] = add_custom(suffix,0);
-      delete [] suffix;
-
-    } else return iarg;
+      default:
+        return iarg;
+        break;
+      }
+    }
   }
 
   return narg;
@@ -1897,149 +1873,113 @@ int DumpCustom::modify_param(int narg, char **arg)
     else if (strcmp(arg[1],"tqy") == 0) thresh_array[nthresh] = TQY;
     else if (strcmp(arg[1],"tqz") == 0) thresh_array[nthresh] = TQZ;
 
-    // compute value = c_ID
-    // if no trailing [], then arg is set to 0, else arg is between []
-    // must grow field2index and argindex arrays, since access is beyond nfield
+    else {
 
-    else if (strncmp(arg[1],"c_",2) == 0) {
-      thresh_array[nthresh] = COMPUTE;
+      // must grow field2index and argindex arrays, since access is beyond nfield
+
       memory->grow(field2index,nfield+nthresh+1,"dump:field2index");
       memory->grow(argindex,nfield+nthresh+1,"dump:argindex");
-      int n = strlen(arg[1]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[1][2]);
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump modify command");
-        argindex[nfield+nthresh] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nfield+nthresh] = 0;
+      int n,tmp;
+      ArgInfo argi(arg[1],ArgInfo::COMPUTE|ArgInfo::FIX|ArgInfo::VARIABLE
+                   |ArgInfo::DNAME|ArgInfo::INAME);
+      argindex[nfield+nthresh] = argi.get_index1();
 
-      n = modify->find_compute(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump modify compute ID");
+      switch (argi.get_type()) {
 
-      if (modify->compute[n]->peratom_flag == 0)
-        error->all(FLERR,
-                   "Dump modify compute ID does not compute per-atom info");
-      if (argindex[nfield+nthresh] == 0 &&
-          modify->compute[n]->size_peratom_cols > 0)
-        error->all(FLERR,
-                   "Dump modify compute ID does not compute per-atom vector");
-      if (argindex[nfield+nthresh] > 0 &&
-          modify->compute[n]->size_peratom_cols == 0)
-        error->all(FLERR,
-                   "Dump modify compute ID does not compute per-atom array");
-      if (argindex[nfield+nthresh] > 0 &&
-          argindex[nfield+nthresh] > modify->compute[n]->size_peratom_cols)
-        error->all(FLERR,"Dump modify compute ID vector is not large enough");
+      case ArgInfo::UNKNOWN:
+        error->all(FLERR,"Invalid attribute in dump modify command");
+        break;
 
-      field2index[nfield+nthresh] = add_compute(suffix);
-      delete [] suffix;
+        // compute value = c_ID
+        // if no trailing [], then arg is set to 0, else arg is between []
 
-    // fix value = f_ID
-    // if no trailing [], then arg is set to 0, else arg is between []
-    // must grow field2index and argindex arrays, since access is beyond nfield
+      case ArgInfo::COMPUTE:
+        thresh_array[nthresh] = COMPUTE;
+        n = modify->find_compute(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump modify compute ID");
 
-    } else if (strncmp(arg[1],"f_",2) == 0) {
-      thresh_array[nthresh] = FIX;
-      memory->grow(field2index,nfield+nthresh+1,"dump:field2index");
-      memory->grow(argindex,nfield+nthresh+1,"dump:argindex");
-      int n = strlen(arg[1]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[1][2]);
+        if (modify->compute[n]->peratom_flag == 0)
+          error->all(FLERR,
+                     "Dump modify compute ID does not compute per-atom info");
+        if (argi.get_dim() == 0 && modify->compute[n]->size_peratom_cols > 0)
+          error->all(FLERR,
+                     "Dump modify compute ID does not compute per-atom vector");
+        if (argi.get_index1() > 0 && modify->compute[n]->size_peratom_cols == 0)
+          error->all(FLERR,
+                     "Dump modify compute ID does not compute per-atom array");
+        if (argi.get_index1() > 0 &&
+            argi.get_index1() > modify->compute[n]->size_peratom_cols)
+          error->all(FLERR,"Dump modify compute ID vector is not large enough");
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump modify command");
-        argindex[nfield+nthresh] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nfield+nthresh] = 0;
+        field2index[nfield+nthresh] = add_compute(argi.get_name());
+        break;
 
-      n = modify->find_fix(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump modify fix ID");
+        // fix value = f_ID
+        // if no trailing [], then arg is set to 0, else arg is between []
 
-      if (modify->fix[n]->peratom_flag == 0)
-        error->all(FLERR,"Dump modify fix ID does not compute per-atom info");
-      if (argindex[nfield+nthresh] == 0 &&
-          modify->fix[n]->size_peratom_cols > 0)
-        error->all(FLERR,"Dump modify fix ID does not compute per-atom vector");
-      if (argindex[nfield+nthresh] > 0 &&
-          modify->fix[n]->size_peratom_cols == 0)
+      case ArgInfo::FIX:
+        thresh_array[nthresh] = FIX;
+        n = modify->find_fix(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump modify fix ID");
+
+        if (modify->fix[n]->peratom_flag == 0)
+          error->all(FLERR,"Dump modify fix ID does not compute per-atom info");
+        if (argi.get_dim() == 0 && modify->fix[n]->size_peratom_cols > 0)
+          error->all(FLERR,"Dump modify fix ID does not compute per-atom vector");
+        if (argi.get_index1() > 0 && modify->fix[n]->size_peratom_cols == 0)
         error->all(FLERR,"Dump modify fix ID does not compute per-atom array");
-      if (argindex[nfield+nthresh] > 0 &&
-          argindex[nfield+nthresh] > modify->fix[n]->size_peratom_cols)
-        error->all(FLERR,"Dump modify fix ID vector is not large enough");
+        if (argi.get_index1() > 0 &&
+            argi.get_index1() > modify->fix[n]->size_peratom_cols)
+          error->all(FLERR,"Dump modify fix ID vector is not large enough");
 
-      field2index[nfield+nthresh] = add_fix(suffix);
-      delete [] suffix;
+        field2index[nfield+nthresh] = add_fix(argi.get_name());
+        break;
 
-    // variable value = v_ID
-    // must grow field2index and argindex arrays, since access is beyond nfield
+        // variable value = v_ID
+        // must grow field2index and argindex arrays, since access is beyond nfield
 
-    } else if (strncmp(arg[1],"v_",2) == 0) {
-      thresh_array[nthresh] = VARIABLE;
-      memory->grow(field2index,nfield+nthresh+1,"dump:field2index");
-      memory->grow(argindex,nfield+nthresh+1,"dump:argindex");
-      int n = strlen(arg[1]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[1][2]);
+      case ArgInfo::VARIABLE:
+        thresh_array[nthresh] = VARIABLE;
+        n = input->variable->find(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump modify variable name");
+        if (input->variable->atomstyle(n) == 0)
+          error->all(FLERR,"Dump modify variable is not atom-style variable");
 
-      argindex[nfield+nthresh] = 0;
+        field2index[nfield+nthresh] = add_variable(argi.get_name());
+        break;
 
-      n = input->variable->find(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump modify variable name");
-      if (input->variable->atomstyle(n) == 0)
-        error->all(FLERR,"Dump modify variable is not atom-style variable");
+        // custom per atom floating point value = d_ID
 
-      field2index[nfield+nthresh] = add_variable(suffix);
-      delete [] suffix;
+      case ArgInfo::DNAME:
+        thresh_array[nthresh] = DNAME;
+        tmp = -1;
+        n = atom->find_custom(argi.get_name(),tmp);
+        if ((n < 0) || (tmp != 1))
+          error->all(FLERR,"Could not find dump modify "
+                     "custom atom floating point property ID");
 
-    // custom per atom floating point value = d_ID
-    // must grow field2index and argindex arrays, since access is beyond nfield
+        field2index[nfield+nthresh] = add_custom(argi.get_name(),1);
+        break;
 
-    } else if (strncmp(arg[1],"d_",2) == 0) {
-      thresh_array[nthresh] = DNAME;
-      memory->grow(field2index,nfield+nthresh+1,"dump:field2index");
-      memory->grow(argindex,nfield+nthresh+1,"dump:argindex");
-      int n = strlen(arg[1]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[1][2]);
-      argindex[nfield+nthresh] = 0;
+        // custom per atom integer value = i_ID
 
-      int tmp = -1;
-      n = atom->find_custom(suffix,tmp);
-      if ((n < 0) || (tmp != 1))
-        error->all(FLERR,"Could not find dump modify "
-                   "custom atom floating point property ID");
+      case ArgInfo::INAME:
+        thresh_array[nthresh] = INAME;
+        tmp = -1;
+        n = atom->find_custom(argi.get_name(),tmp);
+        if ((n < 0) || (tmp != 0))
+          error->all(FLERR,"Could not find dump modify "
+                     "custom atom integer property ID");
 
-      field2index[nfield+nthresh] = add_custom(suffix,1);
-      delete [] suffix;
+        field2index[nfield+nthresh] = add_custom(argi.get_name(),0);
+        break;
 
-    // custom per atom integer value = i_ID
-    // must grow field2index and argindex arrays, since access is beyond nfield
-
-    } else if (strncmp(arg[1],"i_",2) == 0) {
-      thresh_array[nthresh] = INAME;
-      memory->grow(field2index,nfield+nthresh+1,"dump:field2index");
-      memory->grow(argindex,nfield+nthresh+1,"dump:argindex");
-      int n = strlen(arg[1]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[1][2]);
-      argindex[nfield+nthresh] = 0;
-
-      int tmp = -1;
-      n = atom->find_custom(suffix,tmp);
-      if ((n < 0) || (tmp != 0))
-        error->all(FLERR,"Could not find dump modify "
-                   "custom atom integer property ID");
-
-      field2index[nfield+nthresh] = add_custom(suffix,0);
-      delete [] suffix;
-
-    } else error->all(FLERR,"Invalid dump_modify thresh attribute");
+      default:
+        error->all(FLERR,"Invalid dump_modify thresh attribute");
+        break;
+      }
+    }
 
     // set operation type of threshold
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -1584,7 +1584,7 @@ int DumpCustom::parse_fields(int narg, char **arg)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpCustom::add_compute(char *id)
+int DumpCustom::add_compute(const char *id)
 {
   int icompute;
   for (icompute = 0; icompute < ncompute; icompute++)
@@ -1609,7 +1609,7 @@ int DumpCustom::add_compute(char *id)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpCustom::add_fix(char *id)
+int DumpCustom::add_fix(const char *id)
 {
   int ifix;
   for (ifix = 0; ifix < nfix; ifix++)
@@ -1634,7 +1634,7 @@ int DumpCustom::add_fix(char *id)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpCustom::add_variable(char *id)
+int DumpCustom::add_variable(const char *id)
 {
   int ivariable;
   for (ivariable = 0; ivariable < nvariable; ivariable++)
@@ -1663,7 +1663,7 @@ int DumpCustom::add_variable(char *id)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpCustom::add_custom(char *id, int flag)
+int DumpCustom::add_custom(const char *id, int flag)
 {
   int icustom;
   for (icustom = 0; icustom < ncustom; icustom++)

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -1748,14 +1748,13 @@ int DumpCustom::modify_param(int narg, char **arg)
 
   if (strcmp(arg[0],"refresh") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
-    if (strncmp(arg[1],"c_",2) != 0)
+    ArgInfo argi(arg[1],ArgInfo::COMPUTE);
+    if ((argi.get_type() != ArgInfo::COMPUTE) || (argi.get_dim() != 0))
       error->all(FLERR,"Illegal dump_modify command");
     if (refreshflag) error->all(FLERR,"Dump modify can only have one refresh");
 
     refreshflag = 1;
-    int n = strlen(arg[1]);
-    refresh = new char[n];
-    strcpy(refresh,&arg[1][2]);
+    refresh = argi.copy_name();
     return 2;
   }
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -1463,10 +1463,10 @@ int DumpCustom::parse_fields(int narg, char **arg)
         if (argi.get_dim() == 0 && modify->compute[n]->size_peratom_cols > 0)
           error->all(FLERR,
                      "Dump custom compute does not calculate per-atom vector");
-        if (argi.get_index1() > 0 && modify->compute[n]->size_peratom_cols == 0)
+        if (argi.get_dim() > 0 && modify->compute[n]->size_peratom_cols == 0)
           error->all(FLERR,
                      "Dump custom compute does not calculate per-atom array");
-        if (argi.get_index1() > 0 &&
+        if (argi.get_dim() > 0 &&
             argi.get_index1() > modify->compute[n]->size_peratom_cols)
           error->all(FLERR,"Dump custom compute vector is accessed out-of-range");
 
@@ -1486,9 +1486,9 @@ int DumpCustom::parse_fields(int narg, char **arg)
           error->all(FLERR,"Dump custom fix does not compute per-atom info");
         if (argi.get_dim() == 0 && modify->fix[n]->size_peratom_cols > 0)
           error->all(FLERR,"Dump custom fix does not compute per-atom vector");
-        if (argi.get_index1() > 0 && modify->fix[n]->size_peratom_cols == 0)
+        if (argi.get_dim() > 0 && modify->fix[n]->size_peratom_cols == 0)
           error->all(FLERR,"Dump custom fix does not compute per-atom array");
-        if (argi.get_index1() > 0 &&
+        if (argi.get_dim() > 0 &&
             argi.get_index1() > modify->fix[n]->size_peratom_cols)
           error->all(FLERR,"Dump custom fix vector is accessed out-of-range");
 

--- a/src/dump_custom.h
+++ b/src/dump_custom.h
@@ -105,10 +105,10 @@ class DumpCustom : public Dump {
   double memory_usage();
 
   int parse_fields(int, char **);
-  int add_compute(char *);
-  int add_fix(char *);
-  int add_variable(char *);
-  int add_custom(char *, int);
+  int add_compute(const char *);
+  int add_fix(const char *);
+  int add_variable(const char *);
+  int add_custom(const char *, int);
   virtual int modify_param(int, char **);
 
   void header_format_binary();

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -13,6 +13,7 @@
 
 #include "dump_local.h"
 
+#include "arg_info.h"
 #include "compute.h"
 #include "domain.h"
 #include "error.h"
@@ -404,85 +405,70 @@ void DumpLocal::parse_fields(int narg, char **arg)
 
   // customize by adding to if statement
 
-  int i;
   for (int iarg = 0; iarg < narg; iarg++) {
-    i = iarg;
 
     if (strcmp(arg[iarg],"index") == 0) {
-      pack_choice[i] = &DumpLocal::pack_index;
-      vtype[i] = INT;
+      pack_choice[iarg] = &DumpLocal::pack_index;
+      vtype[iarg] = INT;
 
-    // compute value = c_ID
-    // if no trailing [], then arg is set to 0, else arg is int between []
-
-    } else if (strncmp(arg[iarg],"c_",2) == 0) {
+    } else {
+      int n;
+      ArgInfo argi(arg[iarg],ArgInfo::COMPUTE|ArgInfo::FIX);
       computefixflag = 1;
-      pack_choice[i] = &DumpLocal::pack_compute;
-      vtype[i] = DOUBLE;
+      vtype[iarg] = DOUBLE;
+      argindex[iarg] = argi.get_index1();
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+      switch (argi.get_type()) {
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump local command");
-        argindex[i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[i] = 0;
+        // compute value = c_ID
+        // if no trailing [], then arg is set to 0, else arg is int between []
 
-      n = modify->find_compute(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump local compute ID");
-      if (modify->compute[n]->local_flag == 0)
-        error->all(FLERR,"Dump local compute does not compute local info");
-      if (argindex[i] == 0 && modify->compute[n]->size_local_cols > 0)
-        error->all(FLERR,"Dump local compute does not calculate local vector");
-      if (argindex[i] > 0 && modify->compute[n]->size_local_cols == 0)
-        error->all(FLERR,"Dump local compute does not calculate local array");
-      if (argindex[i] > 0 &&
-          argindex[i] > modify->compute[n]->size_local_cols)
-        error->all(FLERR,"Dump local compute vector is accessed out-of-range");
+      case ArgInfo::COMPUTE:
+        pack_choice[iarg] = &DumpLocal::pack_compute;
 
-      field2index[i] = add_compute(suffix);
-      delete [] suffix;
+        n = modify->find_compute(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump local compute ID");
+        if (modify->compute[n]->local_flag == 0)
+          error->all(FLERR,"Dump local compute does not compute local info");
+        if (argi.get_dim() == 0 && modify->compute[n]->size_local_cols > 0)
+          error->all(FLERR,"Dump local compute does not calculate local vector");
+        if (argi.get_index1() > 0 && modify->compute[n]->size_local_cols == 0)
+          error->all(FLERR,"Dump local compute does not calculate local array");
+        if (argi.get_index1() > 0 &&
+            argi.get_index1() > modify->compute[n]->size_local_cols)
+          error->all(FLERR,"Dump local compute vector is accessed out-of-range");
 
-    // fix value = f_ID
-    // if no trailing [], then arg is set to 0, else arg is between []
+        field2index[iarg] = add_compute(argi.get_name());
+        break;
 
-    } else if (strncmp(arg[iarg],"f_",2) == 0) {
-      computefixflag = 1;
-      pack_choice[i] = &DumpLocal::pack_fix;
-      vtype[i] = DOUBLE;
+        // fix value = f_ID
+        // if no trailing [], then arg is set to 0, else arg is between []
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+      case ArgInfo::FIX:
+        pack_choice[iarg] = &DumpLocal::pack_fix;
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Invalid attribute in dump local command");
-        argindex[i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[i] = 0;
+        n = modify->find_fix(argi.get_name());
+        if (n < 0) error->all(FLERR,"Could not find dump local fix ID");
+        if (modify->fix[n]->local_flag == 0)
+          error->all(FLERR,"Dump local fix does not compute local info");
+        if (argi.get_dim() == 0 && modify->fix[n]->size_local_cols > 0)
+          error->all(FLERR,"Dump local fix does not compute local vector");
+        if (argi.get_index1() > 0 && modify->fix[n]->size_local_cols == 0)
+          error->all(FLERR,"Dump local fix does not compute local array");
+        if (argi.get_index1() > 0 &&
+            argi.get_index1() > modify->fix[n]->size_local_cols)
+          error->all(FLERR,"Dump local fix vector is accessed out-of-range");
 
-      n = modify->find_fix(suffix);
-      if (n < 0) error->all(FLERR,"Could not find dump local fix ID");
-      if (modify->fix[n]->local_flag == 0)
-        error->all(FLERR,"Dump local fix does not compute local info");
-      if (argindex[i] == 0 && modify->fix[n]->size_local_cols > 0)
-        error->all(FLERR,"Dump local fix does not compute local vector");
-      if (argindex[i] > 0 && modify->fix[n]->size_local_cols == 0)
-        error->all(FLERR,"Dump local fix does not compute local array");
-      if (argindex[i] > 0 &&
-          argindex[i] > modify->fix[n]->size_local_cols)
-        error->all(FLERR,"Dump local fix vector is accessed out-of-range");
+        field2index[iarg] = add_fix(argi.get_name());
+        break;
 
-      field2index[i] = add_fix(suffix);
-      delete [] suffix;
-
-    } else error->all(FLERR,"Invalid attribute in dump local command");
+      case ArgInfo::NONE:       // fallthrough
+      case ArgInfo::UNKNOWN:    // fallthrough
+      default:
+         error->all(FLERR,"Invalid attribute in dump local command");
+         break;
+      }
+    }
   }
 
   if (computefixflag == 0)

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -481,7 +481,7 @@ void DumpLocal::parse_fields(int narg, char **arg)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpLocal::add_compute(char *id)
+int DumpLocal::add_compute(const char *id)
 {
   int icompute;
   for (icompute = 0; icompute < ncompute; icompute++)
@@ -506,7 +506,7 @@ int DumpLocal::add_compute(char *id)
    if already in list, do not add, just return index, else add to list
 ------------------------------------------------------------------------- */
 
-int DumpLocal::add_fix(char *id)
+int DumpLocal::add_fix(const char *id)
 {
   int ifix;
   for (ifix = 0; ifix < nfix; ifix++)

--- a/src/dump_local.h
+++ b/src/dump_local.h
@@ -62,8 +62,8 @@ class DumpLocal : public Dump {
   virtual void write_data(int, double *);
 
   void parse_fields(int, char **);
-  int add_compute(char *);
-  int add_fix(char *);
+  int add_compute(const char *);
+  int add_fix(const char *);
 
   typedef void (DumpLocal::*FnPtrWrite)(int, double *);
   FnPtrWrite write_choice;             // ptr to write data functions

--- a/src/fix_ave_atom.cpp
+++ b/src/fix_ave_atom.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_ave_atom.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "compute.h"
 #include "error.h"
@@ -26,8 +27,6 @@
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
-
-enum{X,V,F,COMPUTE,FIX,VARIABLE};
 
 #define INVOKED_PERATOM 8
 
@@ -67,60 +66,46 @@ FixAveAtom::FixAveAtom(LAMMPS *lmp, int narg, char **arg) :
     ids[i] = nullptr;
 
     if (strcmp(arg[i],"x") == 0) {
-      which[i] = X;
+      which[i] = ArgInfo::X;
       argindex[i] = 0;
     } else if (strcmp(arg[i],"y") == 0) {
-      which[i] = X;
+      which[i] = ArgInfo::X;
       argindex[i] = 1;
     } else if (strcmp(arg[i],"z") == 0) {
-      which[i] = X;
+      which[i] = ArgInfo::X;
       argindex[i] = 2;
 
     } else if (strcmp(arg[i],"vx") == 0) {
-      which[i] = V;
+      which[i] = ArgInfo::V;
       argindex[i] = 0;
     } else if (strcmp(arg[i],"vy") == 0) {
-      which[i] = V;
+      which[i] = ArgInfo::V;
       argindex[i] = 1;
     } else if (strcmp(arg[i],"vz") == 0) {
-      which[i] = V;
+      which[i] = ArgInfo::V;
       argindex[i] = 2;
 
     } else if (strcmp(arg[i],"fx") == 0) {
-      which[i] = F;
+      which[i] = ArgInfo::F;
       argindex[i] = 0;
     } else if (strcmp(arg[i],"fy") == 0) {
-      which[i] = F;
+      which[i] = ArgInfo::F;
       argindex[i] = 1;
     } else if (strcmp(arg[i],"fz") == 0) {
-      which[i] = F;
+      which[i] = ArgInfo::F;
       argindex[i] = 2;
 
-    } else if (strncmp(arg[i],"c_",2) == 0 ||
-               strncmp(arg[i],"f_",2) == 0 ||
-               strncmp(arg[i],"v_",2) == 0) {
-      if (arg[i][0] == 'c') which[i] = COMPUTE;
-      else if (arg[i][0] == 'f') which[i] = FIX;
-      else if (arg[i][0] == 'v') which[i] = VARIABLE;
+    } else {
+      ArgInfo argi(arg[i]);
 
-      int n = strlen(arg[i]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[i][2]);
+      which[i] = argi.get_type();
+      argindex[i] = argi.get_dim();
+      ids[i] = argi.copy_name();
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal fix ave/atom command");
-        argindex[i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[i] = 0;
-
-      n = strlen(suffix) + 1;
-      ids[i] = new char[n];
-      strcpy(ids[i],suffix);
-      delete [] suffix;
-
-    } else error->all(FLERR,"Illegal fix ave/atom command");
+      if ((which[i] == ArgInfo::UNKNOWN) || (which[i] == ArgInfo::NONE)
+        || (argindex[i] > 1))
+        error->all(FLERR,"Illegal fix ave/atom command");
+    }
   }
 
   // if wildcard expansion occurred, free earg memory from exapnd_args()
@@ -139,7 +124,7 @@ FixAveAtom::FixAveAtom(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,"Illegal fix ave/atom command");
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/atom does not exist");
@@ -157,7 +142,7 @@ FixAveAtom::FixAveAtom(LAMMPS *lmp, int narg, char **arg) :
           argindex[i] > modify->compute[icompute]->size_peratom_cols)
         error->all(FLERR,"Fix ave/atom compute array is accessed out-of-range");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/atom does not exist");
@@ -175,7 +160,7 @@ FixAveAtom::FixAveAtom(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix ave/atom not computed at compatible time");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/atom does not exist");
@@ -248,19 +233,19 @@ void FixAveAtom::init()
   // set indices and check validity of all computes,fixes,variables
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == COMPUTE) {
+    if (which[m] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[m]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/atom does not exist");
       value2index[m] = icompute;
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[m]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/atom does not exist");
       value2index[m] = ifix;
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[m]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/atom does not exist");
@@ -322,24 +307,24 @@ void FixAveAtom::end_of_step()
     n = value2index[m];
     j = argindex[m];
 
-    if (which[m] == X) {
+    if (which[m] == ArgInfo::X) {
       double **x = atom->x;
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) array[i][m] += x[i][j];
 
-    } else if (which[m] == V) {
+    } else if (which[m] == ArgInfo::V) {
       double **v = atom->v;
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) array[i][m] += v[i][j];
 
-    } else if (which[m] == F) {
+    } else if (which[m] == ArgInfo::F) {
       double **f = atom->f;
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit) array[i][m] += f[i][j];
 
     // invoke compute if not previously invoked
 
-    } else if (which[m] == COMPUTE) {
+    } else if (which[m] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[n];
       if (!(compute->invoked_flag & INVOKED_PERATOM)) {
         compute->compute_peratom();
@@ -359,7 +344,7 @@ void FixAveAtom::end_of_step()
 
     // access fix fields, guaranteed to be ready
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       if (j == 0) {
         double *fix_vector = modify->fix[n]->vector_atom;
         for (i = 0; i < nlocal; i++)
@@ -374,7 +359,7 @@ void FixAveAtom::end_of_step()
     // evaluate atom-style variable
     // final argument = 1 sums result to array
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       if (array) input->variable->compute_atom(n,igroup,&array[0][m],nvalues,1);
       else input->variable->compute_atom(n,igroup,nullptr,nvalues,1);
     }

--- a/src/fix_ave_atom.cpp
+++ b/src/fix_ave_atom.cpp
@@ -99,11 +99,11 @@ FixAveAtom::FixAveAtom(LAMMPS *lmp, int narg, char **arg) :
       ArgInfo argi(arg[i]);
 
       which[i] = argi.get_type();
-      argindex[i] = argi.get_dim();
+      argindex[i] = argi.get_index1();
       ids[i] = argi.copy_name();
 
       if ((which[i] == ArgInfo::UNKNOWN) || (which[i] == ArgInfo::NONE)
-        || (argindex[i] > 1))
+        || (argi.get_dim() > 1))
         error->all(FLERR,"Illegal fix ave/atom command");
     }
   }

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -13,27 +13,25 @@
 
 #include "fix_ave_chunk.h"
 
+#include "arg_info.h"
+#include "atom.h"
+#include "compute.h"
+#include "compute_chunk_atom.h"
+#include "domain.h"
+#include "error.h"
+#include "force.h"
+#include "input.h"
+#include "memory.h"
+#include "modify.h"
+#include "update.h"
+#include "variable.h"
 
 #include <cstring>
 #include <unistd.h>
-#include "atom.h"
-#include "update.h"
-#include "force.h"
-#include "domain.h"
-#include "modify.h"
-#include "compute.h"
-#include "compute_chunk_atom.h"
-#include "input.h"
-#include "variable.h"
-#include "memory.h"
-#include "error.h"
-
-
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{V,F,DENSITY_NUMBER,DENSITY_MASS,MASS,TEMPERATURE,COMPUTE,FIX,VARIABLE};
 enum{SCALAR,VECTOR};
 enum{SAMPLE,ALL};
 enum{NOSCALE,ATOM};
@@ -90,67 +88,53 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
     ids[nvalues] = nullptr;
 
     if (strcmp(arg[iarg],"vx") == 0) {
-      which[nvalues] = V;
+      which[nvalues] = ArgInfo::V;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"vy") == 0) {
-      which[nvalues] = V;
+      which[nvalues] = ArgInfo::V;
       argindex[nvalues++] = 1;
     } else if (strcmp(arg[iarg],"vz") == 0) {
-      which[nvalues] = V;
+      which[nvalues] = ArgInfo::V;
       argindex[nvalues++] = 2;
 
     } else if (strcmp(arg[iarg],"fx") == 0) {
-      which[nvalues] = F;
+      which[nvalues] = ArgInfo::F;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"fy") == 0) {
-      which[nvalues] = F;
+      which[nvalues] = ArgInfo::F;
       argindex[nvalues++] = 1;
     } else if (strcmp(arg[iarg],"fz") == 0) {
-      which[nvalues] = F;
+      which[nvalues] = ArgInfo::F;
       argindex[nvalues++] = 2;
 
     } else if (strcmp(arg[iarg],"density/number") == 0) {
       densityflag = 1;
-      which[nvalues] = DENSITY_NUMBER;
+      which[nvalues] = ArgInfo::DENSITY_NUMBER;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"density/mass") == 0) {
       densityflag = 1;
-      which[nvalues] = DENSITY_MASS;
+      which[nvalues] = ArgInfo::DENSITY_MASS;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"mass") == 0) {
-      which[nvalues] = MASS;
+      which[nvalues] = ArgInfo::MASS;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"temp") == 0) {
-      which[nvalues] = TEMPERATURE;
+      which[nvalues] = ArgInfo::TEMPERATURE;
       argindex[nvalues++] = 0;
 
-    } else if (strncmp(arg[iarg],"c_",2) == 0 ||
-               strncmp(arg[iarg],"f_",2) == 0 ||
-               strncmp(arg[iarg],"v_",2) == 0) {
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
+    } else {
+      ArgInfo argi(arg[iarg]);
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+      if (argi.get_type() == ArgInfo::NONE) break;
+      if ((argi.get_type() == ArgInfo::UNKNOWN) || (argi.get_dim() > 1))
+        error->all(FLERR,"Invalid fix ave/chunk command");
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal fix ave/chunk command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
+      which[nvalues] = argi.get_type();
+      argindex[nvalues] = argi.get_index1();
+      ids[nvalues] = argi.copy_name();
 
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
       nvalues++;
-      delete [] suffix;
-
-    } else break;
-
+    }
     iarg++;
   }
 
@@ -285,7 +269,7 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
   }
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/chunk does not exist");
@@ -304,7 +288,7 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix ave/chunk compute vector is accessed out-of-range");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/chunk does not exist");
@@ -319,7 +303,7 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
                    "Fix ave/chunk fix does not calculate a per-atom array");
       if (argindex[i] && argindex[i] > modify->fix[ifix]->size_peratom_cols)
         error->all(FLERR,"Fix ave/chunk fix vector is accessed out-of-range");
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/chunk does not exist");
@@ -514,13 +498,13 @@ void FixAveChunk::init()
   }
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == COMPUTE) {
+    if (which[m] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[m]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/chunk does not exist");
       value2index[m] = icompute;
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[m]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/chunk does not exist");
@@ -530,7 +514,7 @@ void FixAveChunk::init()
         error->all(FLERR,
                    "Fix for fix ave/chunk not computed at compatible time");
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[m]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/chunk does not exist");
@@ -656,9 +640,9 @@ void FixAveChunk::end_of_step()
 
     // V,F adds velocities,forces to values
 
-    if (which[m] == V || which[m] == F) {
+    if (which[m] == ArgInfo::V || which[m] == ArgInfo::F) {
       double **attribute;
-      if (which[m] == V) attribute = atom->v;
+      if (which[m] == ArgInfo::V) attribute = atom->v;
       else attribute = atom->f;
 
       for (i = 0; i < nlocal; i++)
@@ -669,7 +653,7 @@ void FixAveChunk::end_of_step()
 
     // DENSITY_NUMBER adds 1 to values
 
-    } else if (which[m] == DENSITY_NUMBER) {
+    } else if (which[m] == ArgInfo::DENSITY_NUMBER) {
 
       for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit && ichunk[i] > 0) {
@@ -679,7 +663,8 @@ void FixAveChunk::end_of_step()
 
     // DENSITY_MASS or MASS adds mass to values
 
-    } else if (which[m] == DENSITY_MASS || which[m] == MASS) {
+    } else if ((which[m] == ArgInfo::DENSITY_MASS)
+               || (which[m] == ArgInfo::MASS)) {
       int *type = atom->type;
       double *mass = atom->mass;
       double *rmass = atom->rmass;
@@ -701,7 +686,7 @@ void FixAveChunk::end_of_step()
     // TEMPERATURE adds KE to values
     // subtract and restore velocity bias if requested
 
-    } else if (which[m] == TEMPERATURE) {
+    } else if (which[m] == ArgInfo::TEMPERATURE) {
 
       if (biasflag) {
         if (tbias->invoked_scalar != ntimestep) tbias->compute_scalar();
@@ -735,7 +720,7 @@ void FixAveChunk::end_of_step()
     // COMPUTE adds its scalar or vector component to values
     // invoke compute if not previously invoked
 
-    } else if (which[m] == COMPUTE) {
+    } else if (which[m] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[n];
       if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute->compute_peratom();
@@ -755,7 +740,7 @@ void FixAveChunk::end_of_step()
     // FIX adds its scalar or vector component to values
     // access fix fields, guaranteed to be ready
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       double *vector = modify->fix[n]->vector_atom;
       double **array = modify->fix[n]->array_atom;
       int jm1 = j - 1;
@@ -770,7 +755,7 @@ void FixAveChunk::end_of_step()
     // VARIABLE adds its per-atom quantities to values
     // evaluate atom-style variable
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       if (atom->nmax > maxvar) {
         maxvar = atom->nmax;
         memory->destroy(varatom);
@@ -824,14 +809,14 @@ void FixAveChunk::end_of_step()
     for (m = 0; m < nchunk; m++) {
       if (count_many[m] > 0.0)
         for (j = 0; j < nvalues; j++) {
-          if (which[j] == TEMPERATURE) {
+          if (which[j] == ArgInfo::TEMPERATURE) {
             values_many[m][j] += mvv2e*values_one[m][j] /
               ((cdof + adof*count_many[m]) * boltz);
-          } else if (which[j] == DENSITY_NUMBER) {
+          } else if (which[j] == ArgInfo::DENSITY_NUMBER) {
             if (volflag == SCALAR) values_one[m][j] /= chunk_volume_scalar;
             else values_one[m][j] /= chunk_volume_vec[m];
             values_many[m][j] += values_one[m][j];
-          } else if (which[j] == DENSITY_MASS) {
+          } else if (which[j] == ArgInfo::DENSITY_MASS) {
             if (volflag == SCALAR) values_one[m][j] /= chunk_volume_scalar;
             else values_one[m][j] /= chunk_volume_vec[m];
             values_many[m][j] += mv2d*values_one[m][j];
@@ -894,13 +879,13 @@ void FixAveChunk::end_of_step()
     for (m = 0; m < nchunk; m++) {
       if (count_sum[m] > 0.0)
         for (j = 0; j < nvalues; j++) {
-          if (which[j] == TEMPERATURE) {
+          if (which[j] == ArgInfo::TEMPERATURE) {
             values_sum[m][j] *= mvv2e / ((cdof + adof*count_sum[m]) * boltz);
-          } else if (which[j] == DENSITY_NUMBER) {
+          } else if (which[j] == ArgInfo::DENSITY_NUMBER) {
             if (volflag == SCALAR) values_sum[m][j] /= chunk_volume_scalar;
             else values_sum[m][j] /= chunk_volume_vec[m];
             values_sum[m][j] /= repeat;
-          } else if (which[j] == DENSITY_MASS) {
+          } else if (which[j] == ArgInfo::DENSITY_MASS) {
             if (volflag == SCALAR) values_sum[m][j] /= chunk_volume_scalar;
             else values_sum[m][j] /= chunk_volume_vec[m];
             values_sum[m][j] *= mv2d/repeat;

--- a/src/fix_ave_correlate.cpp
+++ b/src/fix_ave_correlate.cpp
@@ -19,6 +19,7 @@
 
 #include "fix_ave_correlate.h"
 
+#include "arg_info.h"
 #include "compute.h"
 #include "error.h"
 #include "input.h"
@@ -33,10 +34,8 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{COMPUTE,FIX,VARIABLE};
 enum{ONE,RUNNING};
 enum{AUTO,UPPER,LOWER,AUTOUPPER,AUTOLOWER,FULL};
-
 
 /* ---------------------------------------------------------------------- */
 
@@ -74,33 +73,18 @@ FixAveCorrelate::FixAveCorrelate(LAMMPS * lmp, int narg, char **arg):
 
   int iarg = 0;
   while (iarg < nargnew) {
-    if (strncmp(arg[iarg],"c_",2) == 0 ||
-        strncmp(arg[iarg],"f_",2) == 0 ||
-        strncmp(arg[iarg],"v_",2) == 0) {
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
+    ArgInfo argi(arg[iarg]);
+    
+    if (argi.get_type() == ArgInfo::NONE) break;
+    if ((argi.get_type() == ArgInfo::UNKNOWN) || (argi.get_dim() > 1))
+      error->all(FLERR,"Invalid fix ave/correlate command");
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+    which[nvalues] = argi.get_type();
+    argindex[nvalues] = argi.get_index1();
+    ids[nvalues] = argi.copy_name();
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal fix ave/correlate command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
-
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
-      delete [] suffix;
-
-      nvalues++;
-      iarg++;
-    } else break;
+    nvalues++;
+    iarg++;
   }
 
   // optional args
@@ -189,7 +173,7 @@ FixAveCorrelate::FixAveCorrelate(LAMMPS * lmp, int narg, char **arg):
     error->all(FLERR,"Illegal fix ave/correlate command");
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/correlate does not exist");
@@ -203,7 +187,7 @@ FixAveCorrelate::FixAveCorrelate(LAMMPS * lmp, int narg, char **arg):
         error->all(FLERR,"Fix ave/correlate compute vector "
                    "is accessed out-of-range");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/correlate does not exist");
@@ -218,7 +202,7 @@ FixAveCorrelate::FixAveCorrelate(LAMMPS * lmp, int narg, char **arg):
         error->all(FLERR,"Fix for fix ave/correlate "
                    "not computed at compatible time");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/correlate does not exist");
@@ -364,19 +348,19 @@ void FixAveCorrelate::init()
   // set current indices for all computes,fixes,variables
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/correlate does not exist");
       value2index[i] = icompute;
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/correlate does not exist");
       value2index[i] = ifix;
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/correlate does not exist");
@@ -435,7 +419,7 @@ void FixAveCorrelate::end_of_step()
 
     // invoke compute if not previously invoked
 
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
@@ -454,7 +438,7 @@ void FixAveCorrelate::end_of_step()
 
     // access fix fields, guaranteed to be ready
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       if (argindex[i] == 0)
         scalar = modify->fix[m]->compute_scalar();
       else
@@ -462,7 +446,7 @@ void FixAveCorrelate::end_of_step()
 
     // evaluate equal-style or vector-style variable
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       if (argindex[i] == 0)
         scalar = input->variable->compute_equal(m);
       else {

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_ave_histo.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "compute.h"
 #include "error.h"
@@ -28,7 +29,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{X,V,F,COMPUTE,FIX,VARIABLE};
 enum{ONE,RUNNING};
 enum{SCALAR,VECTOR,WINDOW};
 enum{DEFAULT,GLOBAL,PERATOM,LOCAL};
@@ -113,67 +113,56 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
 
   for (int i = 0; i < nvalues; i++) {
     if (strcmp(arg[i],"x") == 0) {
-      which[i] = X;
+      which[i] = ArgInfo::X;
       argindex[i] = 0;
       ids[i] = nullptr;
     } else if (strcmp(arg[i],"y") == 0) {
-      which[i] = X;
+      which[i] = ArgInfo::X;
       argindex[i] = 1;
       ids[i] = nullptr;
     } else if (strcmp(arg[i],"z") == 0) {
-      which[i] = X;
+      which[i] = ArgInfo::X;
       argindex[i] = 2;
       ids[i] = nullptr;
 
     } else if (strcmp(arg[i],"vx") == 0) {
-      which[i] = V;
+      which[i] = ArgInfo::V;
       argindex[i] = 0;
       ids[i] = nullptr;
     } else if (strcmp(arg[i],"vy") == 0) {
-      which[i] = V;
+      which[i] = ArgInfo::V;
       argindex[i] = 1;
       ids[i] = nullptr;
     } else if (strcmp(arg[i],"vz") == 0) {
-      which[i] = V;
+      which[i] = ArgInfo::V;
       argindex[i] = 2;
       ids[i] = nullptr;
 
     } else if (strcmp(arg[i],"fx") == 0) {
-      which[i] = F;
+      which[i] = ArgInfo::F;
       argindex[i] = 0;
       ids[i] = nullptr;
     } else if (strcmp(arg[i],"fy") == 0) {
-      which[i] = F;
+      which[i] = ArgInfo::F;
       argindex[i] = 1;
       ids[i] = nullptr;
     } else if (strcmp(arg[i],"fz") == 0) {
-      which[i] = F;
+      which[i] = ArgInfo::F;
       argindex[i] = 2;
       ids[i] = nullptr;
 
-    } else if ((strncmp(arg[i],"c_",2) == 0) ||
-        (strncmp(arg[i],"f_",2) == 0) ||
-        (strncmp(arg[i],"v_",2) == 0)) {
-      if (arg[i][0] == 'c') which[i] = COMPUTE;
-      else if (arg[i][0] == 'f') which[i] = FIX;
-      else if (arg[i][0] == 'v') which[i] = VARIABLE;
+    } else {
+      ArgInfo argi(arg[iarg]);
 
-      int n = strlen(arg[i]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[i][2]);
+      if (argi.get_type() == ArgInfo::NONE) break;
+      if ((argi.get_type() == ArgInfo::UNKNOWN) || (argi.get_dim() > 1))
+        error->all(FLERR,"Invalid fix ave/histo command");
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal fix ave/histo command");
-        argindex[i] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[i] = 0;
+      which[nvalues] = argi.get_type();
+      argindex[nvalues] = argi.get_index1();
+      ids[nvalues] = argi.copy_name();
 
-      n = strlen(suffix) + 1;
-      ids[i] = new char[n];
-      strcpy(ids[i],suffix);
-      delete [] suffix;
+      nvalues++;
     }
   }
 
@@ -201,10 +190,11 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
   for (int i = 0; i < nvalues; i++) {
     kindglobal = kindperatom = kindlocal = 0;
 
-    if (which[i] == X || which[i] == V || which[i] == F) {
+    if ((which[i] == ArgInfo::X) || (which[i] == ArgInfo::V)
+        || (which[i] == ArgInfo::F)) {
       kindperatom = 1;
 
-    } else if (which[i] == COMPUTE) {
+    } else if (which[i] == ArgInfo::COMPUTE) {
       int c_id = modify->find_compute(ids[i]);
       if (c_id < 0) error->all(FLERR,"Fix ave/histo input is invalid compute");
       Compute *compute = modify->compute[c_id];
@@ -214,7 +204,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
       if (compute->peratom_flag) kindperatom = 1;
       if (compute->local_flag) kindlocal = 1;
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int f_id = modify->find_fix(ids[i]);
       if (f_id < 0) error->all(FLERR,"Fix ave/histo input is invalid fix");
       Fix *fix = modify->fix[f_id];
@@ -224,7 +214,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
       if (fix->peratom_flag) kindperatom = 1;
       if (fix->local_flag) kindlocal = 1;
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Fix ave/histo input is invalid variable");
@@ -262,7 +252,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,"Fix ave/histo cannot input local values in scalar mode");
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE && kind == GLOBAL && mode == SCALAR) {
+    if (which[i] == ArgInfo::COMPUTE && kind == GLOBAL && mode == SCALAR) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/histo does not exist");
@@ -276,7 +266,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix ave/histo compute vector is accessed out-of-range");
 
-    } else if (which[i] == COMPUTE && kind == GLOBAL && mode == VECTOR) {
+    } else if (which[i] == ArgInfo::COMPUTE && kind == GLOBAL && mode == VECTOR) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/histo does not exist");
@@ -291,7 +281,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix ave/histo compute array is accessed out-of-range");
 
-    } else if (which[i] == COMPUTE && kind == PERATOM) {
+    } else if (which[i] == ArgInfo::COMPUTE && kind == PERATOM) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/histo does not exist");
@@ -310,7 +300,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix ave/histo compute array is accessed out-of-range");
 
-    } else if (which[i] == COMPUTE && kind == LOCAL) {
+    } else if (which[i] == ArgInfo::COMPUTE && kind == LOCAL) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/histo does not exist");
@@ -329,7 +319,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix ave/histo compute array is accessed out-of-range");
 
-    } else if (which[i] == FIX && kind == GLOBAL && mode == SCALAR) {
+    } else if (which[i] == ArgInfo::FIX && kind == GLOBAL && mode == SCALAR) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/histo does not exist");
@@ -345,7 +335,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix ave/histo not computed at compatible time");
 
-    } else if (which[i] == FIX && kind == GLOBAL && mode == VECTOR) {
+    } else if (which[i] == ArgInfo::FIX && kind == GLOBAL && mode == VECTOR) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/histo does not exist");
@@ -360,7 +350,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix ave/histo not computed at compatible time");
 
-    } else if (which[i] == FIX && kind == PERATOM) {
+    } else if (which[i] == ArgInfo::FIX && kind == PERATOM) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/histo does not exist");
@@ -381,7 +371,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix ave/histo not computed at compatible time");
 
-    } else if (which[i] == FIX && kind == LOCAL) {
+    } else if (which[i] == ArgInfo::FIX && kind == LOCAL) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/histo does not exist");
@@ -401,7 +391,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix ave/histo not computed at compatible time");
 
-    } else if (which[i] == VARIABLE && kind == GLOBAL && mode == SCALAR) {
+    } else if (which[i] == ArgInfo::VARIABLE && kind == GLOBAL && mode == SCALAR) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/histo does not exist");
@@ -410,7 +400,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
       if (argindex[i] && input->variable->vectorstyle(ivariable) == 0)
         error->all(FLERR,"Fix ave/histo variable is not vector-style variable");
 
-    } else if (which[i] == VARIABLE && kind == GLOBAL && mode == VECTOR) {
+    } else if (which[i] == ArgInfo::VARIABLE && kind == GLOBAL && mode == VECTOR) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/histo does not exist");
@@ -419,7 +409,7 @@ FixAveHisto::FixAveHisto(LAMMPS *lmp, int narg, char **arg) :
       if (argindex[i])
         error->all(FLERR,"Fix ave/histo variable cannot be indexed");
 
-    } else if (which[i] == VARIABLE && kind == PERATOM) {
+    } else if (which[i] == ArgInfo::VARIABLE && kind == PERATOM) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/histo does not exist");
@@ -546,19 +536,19 @@ void FixAveHisto::init()
   // set current indices for all computes,fixes,variables
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/histo does not exist");
       value2index[i] = icompute;
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/histo does not exist");
       value2index[i] = ifix;
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/histo does not exist");
@@ -619,16 +609,16 @@ void FixAveHisto::end_of_step()
 
     // atom attributes
 
-    if (which[i] == X)
+    if (which[i] == ArgInfo::X)
       bin_atoms(&atom->x[0][j],3);
-    else if (which[i] == V)
+    else if (which[i] == ArgInfo::V)
       bin_atoms(&atom->v[0][j],3);
-    else if (which[i] == F)
+    else if (which[i] == ArgInfo::F)
       bin_atoms(&atom->f[0][j],3);
 
     // invoke compute if not previously invoked
 
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[m];
 
       if (kind == GLOBAL && mode == SCALAR) {
@@ -686,7 +676,7 @@ void FixAveHisto::end_of_step()
 
       // access fix fields, guaranteed to be ready
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
 
       Fix *fix = modify->fix[m];
 
@@ -717,7 +707,7 @@ void FixAveHisto::end_of_step()
 
     // evaluate equal-style or vector-style or atom-style variable
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       if (kind == GLOBAL && mode == SCALAR) {
         if (j == 0) bin_one(input->variable->compute_equal(m));
         else {
@@ -732,7 +722,7 @@ void FixAveHisto::end_of_step()
         int nvec = input->variable->compute_vector(m,&varvec);
         bin_vector(nvec,varvec,1);
 
-      } else if (which[i] == VARIABLE && kind == PERATOM) {
+      } else if (which[i] == ArgInfo::VARIABLE && kind == PERATOM) {
         if (atom->nmax > maxatom) {
           memory->destroy(vector);
           maxatom = atom->nmax;

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -17,6 +17,7 @@
 
 #include "fix_ave_time.h"
 
+#include "arg_info.h"
 #include "compute.h"
 #include "error.h"
 #include "input.h"
@@ -31,10 +32,8 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{COMPUTE,FIX,VARIABLE};
 enum{ONE,RUNNING,WINDOW};
 enum{SCALAR,VECTOR};
-
 
 /* ---------------------------------------------------------------------- */
 
@@ -97,26 +96,16 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
   ids = new char*[nvalues];
 
   for (int i = 0; i < nvalues; i++) {
-    if (arg[i][0] == 'c') which[i] = COMPUTE;
-    else if (arg[i][0] == 'f') which[i] = FIX;
-    else if (arg[i][0] == 'v') which[i] = VARIABLE;
+    ArgInfo argi(arg[i]);
 
-    int n = strlen(arg[i]);
-    char *suffix = new char[n];
-    strcpy(suffix,&arg[i][2]);
+    if ((argi.get_type() == ArgInfo::NONE)
+        || (argi.get_type() == ArgInfo::UNKNOWN)
+        || (argi.get_dim() > 1))
+      error->all(FLERR,"Invalid fix ave/time command");
 
-    char *ptr = strchr(suffix,'[');
-    if (ptr) {
-      if (suffix[strlen(suffix)-1] != ']')
-        error->all(FLERR,"Illegal fix ave/time command");
-      argindex[i] = atoi(ptr+1);
-      *ptr = '\0';
-    } else argindex[i] = 0;
-
-    n = strlen(suffix) + 1;
-    ids[i] = new char[n];
-    strcpy(ids[i],suffix);
-    delete [] suffix;
+    which[i] = argi.get_type();
+    argindex[i] = argi.get_index1();
+    ids[i] = argi.copy_name();
   }
 
   // set off columns now that nvalues is finalized
@@ -142,7 +131,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
   for (int i = 0; i < nvalues; i++) {
     varlen[i] = 0;
 
-    if (which[i] == COMPUTE && mode == SCALAR) {
+    if (which[i] == ArgInfo::COMPUTE && mode == SCALAR) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/time does not exist");
@@ -157,7 +146,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
       if (argindex[i] && modify->compute[icompute]->size_vector_variable)
         varlen[i] = 1;
 
-    } else if (which[i] == COMPUTE && mode == VECTOR) {
+    } else if (which[i] == ArgInfo::COMPUTE && mode == VECTOR) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/time does not exist");
@@ -173,7 +162,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
       if (argindex[i] && modify->compute[icompute]->size_array_rows_variable)
         varlen[i] = 1;
 
-    } else if (which[i] == FIX && mode == SCALAR) {
+    } else if (which[i] == ArgInfo::FIX && mode == SCALAR) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/time does not exist");
@@ -189,7 +178,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix ave/time not computed at compatible time");
 
-    } else if (which[i] == FIX && mode == VECTOR) {
+    } else if (which[i] == ArgInfo::FIX && mode == VECTOR) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/time does not exist");
@@ -205,7 +194,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix ave/time not computed at compatible time");
 
-    } else if (which[i] == VARIABLE && mode == SCALAR) {
+    } else if (which[i] == ArgInfo::VARIABLE && mode == SCALAR) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/time does not exist");
@@ -214,7 +203,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
       if (argindex[i] && input->variable->vectorstyle(ivariable) == 0)
         error->all(FLERR,"Fix ave/time variable is not vector-style variable");
 
-    } else if (which[i] == VARIABLE && mode == VECTOR) {
+    } else if (which[i] == ArgInfo::VARIABLE && mode == VECTOR) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/time does not exist");
@@ -254,7 +243,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
   if (any_variable_length &&
       (nrepeat > 1 || ave == RUNNING || ave == WINDOW)) {
     for (int i = 0; i < nvalues; i++)
-      if (varlen[i] && which[i] == COMPUTE) {
+      if (varlen[i] && which[i] == ArgInfo::COMPUTE) {
         int icompute = modify->find_compute(ids[i]);
         modify->compute[icompute]->lock_enable();
       }
@@ -323,17 +312,17 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
   if (mode == SCALAR) {
     if (nvalues == 1) {
       scalar_flag = 1;
-      if (which[0] == COMPUTE) {
+      if (which[0] == ArgInfo::COMPUTE) {
         Compute *compute = modify->compute[modify->find_compute(ids[0])];
         if (argindex[0] == 0) extscalar = compute->extscalar;
         else if (compute->extvector >= 0) extscalar = compute->extvector;
         else extscalar = compute->extlist[argindex[0]-1];
-      } else if (which[0] == FIX) {
+      } else if (which[0] == ArgInfo::FIX) {
         Fix *fix = modify->fix[modify->find_fix(ids[0])];
         if (argindex[0] == 0) extscalar = fix->extscalar;
         else if (fix->extvector >= 0) extscalar = fix->extvector;
         else extscalar = fix->extlist[argindex[0]-1];
-      } else if (which[0] == VARIABLE) {
+      } else if (which[0] == ArgInfo::VARIABLE) {
         extscalar = 0;
       }
 
@@ -343,17 +332,17 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
       extvector = -1;
       extlist = new int[nvalues];
       for (int i = 0; i < nvalues; i++) {
-        if (which[i] == COMPUTE) {
+        if (which[i] == ArgInfo::COMPUTE) {
           Compute *compute = modify->compute[modify->find_compute(ids[i])];
           if (argindex[i] == 0) extlist[i] = compute->extscalar;
           else if (compute->extvector >= 0) extlist[i] = compute->extvector;
           else extlist[i] = compute->extlist[argindex[i]-1];
-        } else if (which[i] == FIX) {
+        } else if (which[i] == ArgInfo::FIX) {
           Fix *fix = modify->fix[modify->find_fix(ids[i])];
           if (argindex[i] == 0) extlist[i] = fix->extscalar;
           else if (fix->extvector >= 0) extlist[i] = fix->extvector;
           else extlist[i] = fix->extlist[argindex[i]-1];
-        } else if (which[i] == VARIABLE) {
+        } else if (which[i] == ArgInfo::VARIABLE) {
           extlist[i] = 0;
         }
       }
@@ -364,7 +353,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
       vector_flag = 1;
       size_vector = nrows;
       if (all_variable_length) size_vector_variable = 1;
-      if (which[0] == COMPUTE) {
+      if (which[0] == ArgInfo::COMPUTE) {
         Compute *compute = modify->compute[modify->find_compute(ids[0])];
         if (argindex[0] == 0) {
           extvector = compute->extvector;
@@ -373,7 +362,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
             for (int i = 0; i < nrows; i++) extlist[i] = compute->extlist[i];
           }
         } else extvector = compute->extarray;
-      } else if (which[0] == FIX) {
+      } else if (which[0] == ArgInfo::FIX) {
         Fix *fix = modify->fix[modify->find_fix(ids[0])];
         if (argindex[0] == 0) {
           extvector = fix->extvector;
@@ -382,7 +371,7 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
             for (int i = 0; i < nrows; i++) extlist[i] = fix->extlist[i];
           }
         } else extvector = fix->extarray;
-      } else if (which[0] == VARIABLE) {
+      } else if (which[0] == ArgInfo::VARIABLE) {
         extlist = new int[nrows];
         for (int i = 0; i < nrows; i++) extlist[i] = 0;
       }
@@ -394,15 +383,15 @@ FixAveTime::FixAveTime(LAMMPS *lmp, int narg, char **arg) :
       if (all_variable_length) size_array_rows_variable = 1;
       int value;
       for (int i = 0; i < nvalues; i++) {
-        if (which[i] == COMPUTE) {
+        if (which[i] == ArgInfo::COMPUTE) {
           Compute *compute = modify->compute[modify->find_compute(ids[i])];
           if (argindex[i] == 0) value = compute->extvector;
           else value = compute->extarray;
-        } else if (which[i] == FIX) {
+        } else if (which[i] == ArgInfo::FIX) {
           Fix *fix = modify->fix[modify->find_fix(ids[i])];
           if (argindex[i] == 0) value = fix->extvector;
           else value = fix->extarray;
-        } else if (which[i] == VARIABLE) {
+        } else if (which[i] == ArgInfo::VARIABLE) {
           value = 0;
         }
         if (value == -1)
@@ -495,17 +484,17 @@ void FixAveTime::init()
   // set current indices for all computes,fixes,variables
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix ave/time does not exist");
       value2index[i] = icompute;
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix ave/time does not exist");
       value2index[i] = ifix;
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix ave/time does not exist");
@@ -580,7 +569,7 @@ void FixAveTime::invoke_scalar(bigint ntimestep)
     // invoke compute if not previously invoked
     // insure no out-of-range access to variable-length compute vector
 
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
@@ -600,7 +589,7 @@ void FixAveTime::invoke_scalar(bigint ntimestep)
 
     // access fix fields, guaranteed to be ready
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       if (argindex[i] == 0)
         scalar = modify->fix[m]->compute_scalar();
       else
@@ -609,7 +598,7 @@ void FixAveTime::invoke_scalar(bigint ntimestep)
     // evaluate equal-style or vector-style variable
     // insure no out-of-range access to vector-style variable
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       if (argindex[i] == 0)
         scalar = input->variable->compute_equal(m);
       else {
@@ -737,7 +726,7 @@ void FixAveTime::invoke_vector(bigint ntimestep)
       bigint ntimestep = update->ntimestep;
       int lockforever_flag = 0;
       for (i = 0; i < nvalues; i++) {
-        if (!varlen[i] || which[i] != COMPUTE) continue;
+        if (!varlen[i] || which[i] != ArgInfo::COMPUTE) continue;
         if (nrepeat > 1 && ave == ONE) {
           Compute *compute = modify->compute[value2index[i]];
           compute->lock(this,ntimestep,ntimestep+static_cast<bigint>(nrepeat-1)*nevery);
@@ -764,7 +753,7 @@ void FixAveTime::invoke_vector(bigint ntimestep)
 
     // invoke compute if not previously invoked
 
-    if (which[j] == COMPUTE) {
+    if (which[j] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[m];
 
       if (argindex[j] == 0) {
@@ -789,7 +778,7 @@ void FixAveTime::invoke_vector(bigint ntimestep)
 
     // access fix fields, guaranteed to be ready
 
-    } else if (which[j] == FIX) {
+    } else if (which[j] == ArgInfo::FIX) {
       Fix *fix = modify->fix[m];
       if (argindex[j] == 0)
         for (i = 0; i < nrows; i++)
@@ -804,7 +793,7 @@ void FixAveTime::invoke_vector(bigint ntimestep)
     // insure nvec = nrows, else error
     // could be different on this timestep than when column_length(1) set nrows
 
-    } else if (which[j] == VARIABLE) {
+    } else if (which[j] == ArgInfo::VARIABLE) {
       double *varvec;
       int nvec = input->variable->compute_vector(m,&varvec);
       if (nvec != nrows)
@@ -926,16 +915,16 @@ int FixAveTime::column_length(int dynamic)
     length = 0;
     for (int i = 0; i < nvalues; i++) {
       if (varlen[i]) continue;
-      if (which[i] == COMPUTE) {
+      if (which[i] == ArgInfo::COMPUTE) {
         int icompute = modify->find_compute(ids[i]);
         if (argindex[i] == 0)
           lengthone = modify->compute[icompute]->size_vector;
         else lengthone = modify->compute[icompute]->size_array_rows;
-      } else if (which[i] == FIX) {
+      } else if (which[i] == ArgInfo::FIX) {
         int ifix = modify->find_fix(ids[i]);
         if (argindex[i] == 0) lengthone = modify->fix[ifix]->size_vector;
         else lengthone = modify->fix[ifix]->size_array_rows;
-      } else if (which[i] == VARIABLE) {
+      } else if (which[i] == ArgInfo::VARIABLE) {
         // variables are always varlen = 1, so dynamic
       }
       if (length == 0) length = lengthone;
@@ -954,10 +943,10 @@ int FixAveTime::column_length(int dynamic)
     for (int i = 0; i < nvalues; i++) {
       if (varlen[i] == 0) continue;
       m = value2index[i];
-      if (which[i] == COMPUTE) {
+      if (which[i] == ArgInfo::COMPUTE) {
         Compute *compute = modify->compute[m];
         lengthone = compute->lock_length();
-      } else if (which[i] == VARIABLE) {
+      } else if (which[i] == ArgInfo::VARIABLE) {
         double *varvec;
         lengthone = input->variable->compute_vector(m,&varvec);
       }

--- a/src/fix_controller.cpp
+++ b/src/fix_controller.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_controller.h"
 
+#include "arg_info.h"
 #include "compute.h"
 #include "error.h"
 #include "input.h"
@@ -24,9 +25,6 @@
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
-
-enum{COMPUTE,FIX,VARIABLE};
-
 
 /* ---------------------------------------------------------------------- */
 
@@ -51,37 +49,19 @@ FixController::FixController(LAMMPS *lmp, int narg, char **arg) :
 
   // process variable arg
 
-  int iarg = 8;
-  if (strncmp(arg[iarg],"c_",2) == 0 ||
-      strncmp(arg[iarg],"f_",2) == 0 ||
-      strncmp(arg[iarg],"v_",2) == 0) {
-    if (arg[iarg][0] == 'c') pvwhich = COMPUTE;
-    else if (arg[iarg][0] == 'f') pvwhich = FIX;
-    else if (arg[iarg][0] == 'v') pvwhich = VARIABLE;
+  ArgInfo argi(arg[8]);
+  if ((argi.get_type() == ArgInfo::UNKNOWN)
+      || (argi.get_type() == ArgInfo::NONE)
+      || (argi.get_dim() != 0))
+    error->all(FLERR,"Illegal fix controller command");
 
-    int n = strlen(arg[iarg]);
-    char *suffix = new char[n];
-    strcpy(suffix,&arg[iarg][2]);
-
-    char *ptr = strchr(suffix,'[');
-    if (ptr) {
-      if (suffix[strlen(suffix)-1] != ']')
-        error->all(FLERR,"Illegal fix controller command");
-      pvindex = atoi(ptr+1);
-      *ptr = '\0';
-    } else pvindex = 0;
-
-    n = strlen(suffix) + 1;
-    pvID = new char[n];
-    strcpy(pvID,suffix);
-    delete [] suffix;
-
-    iarg++;
-
-  } else error->all(FLERR,"Illegal fix controller command");
+  pvwhich = argi.get_type();
+  pvindex = argi.get_index1();
+  pvID = argi.copy_name();
 
   // setpoint arg
 
+  int iarg=9;
   setpoint = utils::numeric(FLERR,arg[iarg],false,lmp);
   iarg++;
 
@@ -93,7 +73,7 @@ FixController::FixController(LAMMPS *lmp, int narg, char **arg) :
 
   // error check
 
-  if (pvwhich == COMPUTE) {
+  if (pvwhich == ArgInfo::COMPUTE) {
     int icompute = modify->find_compute(pvID);
     if (icompute < 0)
       error->all(FLERR,"Compute ID for fix controller does not exist");
@@ -106,7 +86,7 @@ FixController::FixController(LAMMPS *lmp, int narg, char **arg) :
     if (pvindex && pvindex > c->size_vector)
       error->all(FLERR,"Fix controller compute vector is "
                  "accessed out-of-range");
-  } else if (pvwhich == FIX) {
+  } else if (pvwhich == ArgInfo::FIX) {
     int ifix = modify->find_fix(pvID);
     if (ifix < 0)
       error->all(FLERR,"Fix ID for fix controller does not exist");
@@ -118,7 +98,7 @@ FixController::FixController(LAMMPS *lmp, int narg, char **arg) :
                           "calculate a global scalar or vector");
     if (pvindex && pvindex > f->size_vector)
       error->all(FLERR,"Fix controller fix vector is accessed out-of-range");
-  } else if (pvwhich == VARIABLE) {
+  } else if (pvwhich == ArgInfo::VARIABLE) {
     int ivariable = input->variable->find(pvID);
     if (ivariable < 0)
       error->all(FLERR,"Variable name for fix controller does not exist");
@@ -157,18 +137,18 @@ int FixController::setmask()
 
 void FixController::init()
 {
-  if (pvwhich == COMPUTE) {
+  if (pvwhich == ArgInfo::COMPUTE) {
     int icompute = modify->find_compute(pvID);
     if (icompute < 0)
       error->all(FLERR,"Compute ID for fix controller does not exist");
     pcompute = modify->compute[icompute];
 
-  } else if (pvwhich == FIX) {
+  } else if (pvwhich == ArgInfo::FIX) {
     int ifix = modify->find_fix(pvID);
     if (ifix < 0) error->all(FLERR,"Fix ID for fix controller does not exist");
     pfix = modify->fix[ifix];
 
-  } else if (pvwhich == VARIABLE) {
+  } else if (pvwhich == ArgInfo::VARIABLE) {
     pvar = input->variable->find(pvID);
     if (pvar < 0)
       error->all(FLERR,"Variable name for fix controller does not exist");
@@ -196,7 +176,7 @@ void FixController::end_of_step()
 
   double current = 0.0;
 
-  if (pvwhich == COMPUTE) {
+  if (pvwhich == ArgInfo::COMPUTE) {
     if (pvindex == 0) {
       if (!(pcompute->invoked_flag & Compute::INVOKED_SCALAR)) {
         pcompute->compute_scalar();
@@ -213,13 +193,13 @@ void FixController::end_of_step()
 
   // access fix field, guaranteed to be ready
 
-  } else if (pvwhich == FIX) {
+  } else if (pvwhich == ArgInfo::FIX) {
     if (pvindex == 0) current = pfix->compute_scalar();
     else current = pfix->compute_vector(pvindex-1);
 
   // evaluate equal-style variable
 
-  } else if (pvwhich == VARIABLE) {
+  } else if (pvwhich == ArgInfo::VARIABLE) {
     current = input->variable->compute_equal(pvar);
   }
 

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_halt.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
@@ -56,16 +57,22 @@ FixHalt::FixHalt(LAMMPS *lmp, int narg, char **arg) :
     strcpy(dlimit_path,".");
   } else if (strcmp(arg[iarg],"bondmax") == 0) {
     attribute = BONDMAX;
-  } else if (strncmp(arg[iarg],"v_",2) == 0) {
+  } else {
+    ArgInfo argi(arg[iarg],ArgInfo::VARIABLE);
+
+    if ((argi.get_type() == ArgInfo::UNKNOWN)
+        || (argi.get_type() == ArgInfo::NONE)
+        || (argi.get_dim() != 0))
+      error->all(FLERR,"Invalid fix halt attribute");
+
     attribute = VARIABLE;
-    int n = strlen(arg[iarg]);
-    idvar = new char[n];
-    strcpy(idvar,&arg[iarg][2]);
+    idvar = argi.copy_name();
     ivar = input->variable->find(idvar);
+
     if (ivar < 0) error->all(FLERR,"Could not find fix halt variable name");
     if (input->variable->equalstyle(ivar) == 0)
       error->all(FLERR,"Fix halt variable is not equal-style variable");
-  } else error->all(FLERR,"Invalid fix halt attribute");
+  }
 
   ++iarg;
   if (strcmp(arg[iarg],"<") == 0) operation = LT;

--- a/src/fix_store_state.cpp
+++ b/src/fix_store_state.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_store_state.h"
 
+#include "arg_info.h"
 #include "atom.h"
 #include "compute.h"
 #include "domain.h"
@@ -29,9 +30,6 @@
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
-
-enum{KEYWORD,COMPUTE,FIX,VARIABLE,DNAME,INAME};
-
 
 /* ---------------------------------------------------------------------- */
 
@@ -62,7 +60,7 @@ FixStoreState::FixStoreState(LAMMPS *lmp, int narg, char **arg) :
 
   int iarg = 4;
   while (iarg < narg) {
-    which[nvalues] = KEYWORD;
+    which[nvalues] = ArgInfo::KEYWORD;
     ids[nvalues] = nullptr;
 
     if (strcmp(arg[iarg],"id") == 0) {
@@ -222,38 +220,19 @@ FixStoreState::FixStoreState(LAMMPS *lmp, int narg, char **arg) :
                    "Fix store/state for atom property that isn't allocated");
       pack_choice[nvalues++] = &FixStoreState::pack_tqz;
 
-    } else if (strncmp(arg[iarg],"c_",2) == 0 ||
-               strncmp(arg[iarg],"d_",2) == 0 ||
-               strncmp(arg[iarg],"f_",2) == 0 ||
-               strncmp(arg[iarg],"i_",2) == 0 ||
-               strncmp(arg[iarg],"v_",2) == 0) {
-      cfv_any = 1;
-      if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-      else if (arg[iarg][0] == 'd') which[nvalues] = DNAME;
-      else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-      else if (arg[iarg][0] == 'i') which[nvalues] = INAME;
-      else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
+    } else {
+      ArgInfo argi(arg[iarg],ArgInfo::COMPUTE|ArgInfo::FIX|ArgInfo::VARIABLE
+                   |ArgInfo::DNAME|ArgInfo::INAME);
 
-      int n = strlen(arg[iarg]);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg][2]);
+      if (argi.get_type() == ArgInfo::NONE) break;
+      if ((argi.get_type() == ArgInfo::UNKNOWN) || (argi.get_dim() > 1))
+        error->all(FLERR,"Illegal fix store/state command");
 
-      char *ptr = strchr(suffix,'[');
-      if (ptr) {
-        if (suffix[strlen(suffix)-1] != ']')
-          error->all(FLERR,"Illegal fix store/state command");
-        argindex[nvalues] = atoi(ptr+1);
-        *ptr = '\0';
-      } else argindex[nvalues] = 0;
-
-      n = strlen(suffix) + 1;
-      ids[nvalues] = new char[n];
-      strcpy(ids[nvalues],suffix);
+      which[nvalues] = argi.get_type();
+      argindex[nvalues] = argi.get_index1();
+      ids[nvalues] = argi.copy_name();
       nvalues++;
-      delete [] suffix;
-
-    } else break;
-
+    }
     iarg++;
   }
 
@@ -274,7 +253,7 @@ FixStoreState::FixStoreState(LAMMPS *lmp, int narg, char **arg) :
   // error check
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix store/state does not exist");
@@ -294,21 +273,21 @@ FixStoreState::FixStoreState(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix store/state compute array is accessed out-of-range");
 
-    } else if (which[i] == INAME) {
+    } else if (which[i] == ArgInfo::INAME) {
       int icustom,iflag;
       icustom = atom->find_custom(ids[i],iflag);
       if ((icustom < 0) || (iflag != 0))
         error->all(FLERR,
                    "Custom integer vector for fix store/state does not exist");
 
-    } else if (which[i] == DNAME) {
+    } else if (which[i] == ArgInfo::DNAME) {
       int icustom,iflag;
       icustom = atom->find_custom(ids[i],iflag);
       if ((icustom < 0) || (iflag != 1))
         error->all(FLERR,
                    "Custom floating point vector for fix store/state does not exist");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,
@@ -329,7 +308,7 @@ FixStoreState::FixStoreState(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix store/state not computed at compatible time");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix store/state does not exist");
@@ -406,13 +385,13 @@ void FixStoreState::init()
   if (!firstflag && nevery == 0) return;
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == COMPUTE) {
+    if (which[m] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[m]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix store/state does not exist");
       value2index[m] = icompute;
 
-    } else if (which[m] == INAME) {
+    } else if (which[m] == ArgInfo::INAME) {
       int icustom,iflag;
       icustom = atom->find_custom(ids[m],iflag);
       if ((icustom < 0) || (iflag != 0))
@@ -420,7 +399,7 @@ void FixStoreState::init()
                    "Custom integer vector for fix store/state does not exist");
       value2index[m] = icustom;
 
-    } else if (which[m] == DNAME) {
+    } else if (which[m] == ArgInfo::DNAME) {
       int icustom,iflag;
       icustom = atom->find_custom(ids[m],iflag);
       if ((icustom < 0) || (iflag != 1))
@@ -428,13 +407,13 @@ void FixStoreState::init()
                    "Custom floating point vector for fix store/state does not exist");
       value2index[m] = icustom;
 
-    } else if (which[m] == FIX) {
+    } else if (which[m] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[m]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix store/state does not exist");
       value2index[m] = ifix;
 
-    } else if (which[m] == VARIABLE) {
+    } else if (which[m] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[m]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix store/state does not exist");
@@ -481,7 +460,7 @@ void FixStoreState::end_of_step()
   else vbuf = nullptr;
 
   for (int m = 0; m < nvalues; m++) {
-    if (which[m] == KEYWORD && kflag) (this->*pack_choice[m])(m);
+    if (which[m] == ArgInfo::KEYWORD && kflag) (this->*pack_choice[m])(m);
 
     else if (cfv_flag) {
       n = value2index[m];
@@ -492,7 +471,7 @@ void FixStoreState::end_of_step()
 
       // invoke compute if not previously invoked
 
-      if (which[m] == COMPUTE) {
+      if (which[m] == ArgInfo::COMPUTE) {
         Compute *compute = modify->compute[n];
         if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
           compute->compute_peratom();
@@ -512,7 +491,7 @@ void FixStoreState::end_of_step()
 
       // access fix fields, guaranteed to be ready
 
-      } else if (which[m] == FIX) {
+      } else if (which[m] == ArgInfo::FIX) {
         if (j == 0) {
           double *fix_vector = modify->fix[n]->vector_atom;
           for (i = 0; i < nlocal; i++)
@@ -526,19 +505,19 @@ void FixStoreState::end_of_step()
 
       // access custom atom property fields
 
-      } else if (which[m] == INAME) {
+      } else if (which[m] == ArgInfo::INAME) {
         int *ivector = atom->ivector[n];
         for (i = 0; i < nlocal; i++)
           if (mask[i] & groupbit) values[i][m] = ivector[i];
 
-      } else if (which[m] == DNAME) {
+      } else if (which[m] == ArgInfo::DNAME) {
         double *dvector = atom->dvector[n];
         for (i = 0; i < nlocal; i++)
           if (mask[i] & groupbit) values[i][m] = dvector[i];
 
       // evaluate atom-style variable
 
-      } else if (which[m] == VARIABLE) {
+      } else if (which[m] == ArgInfo::VARIABLE) {
         input->variable->compute_atom(n,igroup,&values[0][m],nvalues,0);
       }
     }

--- a/src/fix_vector.cpp
+++ b/src/fix_vector.cpp
@@ -13,6 +13,7 @@
 
 #include "fix_vector.h"
 
+#include "arg_info.h"
 #include "compute.h"
 #include "error.h"
 #include "input.h"
@@ -26,7 +27,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{COMPUTE,FIX,VARIABLE};
 enum{ONE,RUNNING,WINDOW};
 enum{SCALAR,VECTOR};
 
@@ -50,27 +50,16 @@ FixVector::FixVector(LAMMPS *lmp, int narg, char **arg) :
 
   nvalues = 0;
   for (int iarg = 4; iarg < narg; iarg++) {
-    if (arg[iarg][0] == 'c') which[nvalues] = COMPUTE;
-    else if (arg[iarg][0] == 'f') which[nvalues] = FIX;
-    else if (arg[iarg][0] == 'v') which[nvalues] = VARIABLE;
-    else error->all(FLERR,"Illegal fix vector command");
+    ArgInfo argi(arg[iarg]);
 
-    int n = strlen(arg[iarg]);
-    char *suffix = new char[n];
-    strcpy(suffix,&arg[iarg][2]);
+    which[nvalues] = argi.get_type();
+    argindex[nvalues] = argi.get_index1();
+    ids[nvalues] = argi.copy_name();
 
-    char *ptr = strchr(suffix,'[');
-    if (ptr) {
-      if (suffix[strlen(suffix)-1] != ']')
-        error->all(FLERR,"Illegal fix vector command");
-      argindex[nvalues] = atoi(ptr+1);
-      *ptr = '\0';
-    } else argindex[nvalues] = 0;
-
-    n = strlen(suffix) + 1;
-    ids[nvalues] = new char[n];
-    strcpy(ids[nvalues],suffix);
-    delete [] suffix;
+    if ((argi.get_type() == ArgInfo::UNKNOWN)
+        || (argi.get_type() == ArgInfo::NONE)
+        || (argi.get_dim() > 1))
+      error->all(FLERR,"Illegal fix vector command");
 
     nvalues++;
   }
@@ -79,7 +68,7 @@ FixVector::FixVector(LAMMPS *lmp, int narg, char **arg) :
   // for fix inputs, check that fix frequency is acceptable
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix vector does not exist");
@@ -91,7 +80,7 @@ FixVector::FixVector(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix vector compute vector is accessed out-of-range");
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix vector does not exist");
@@ -105,7 +94,7 @@ FixVector::FixVector(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Fix for fix vector not computed at compatible time");
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix vector does not exist");
@@ -121,16 +110,16 @@ FixVector::FixVector(LAMMPS *lmp, int narg, char **arg) :
 
   int value,finalvalue;
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[modify->find_compute(ids[i])];
       if (argindex[0] == 0) value = compute->extscalar;
       else if (compute->extvector >= 0) value = compute->extvector;
       else value = compute->extlist[argindex[0]-1];
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       Fix *fix = modify->fix[modify->find_fix(ids[i])];
       if (argindex[i] == 0) value = fix->extvector;
       else value = fix->extarray;
-    } else if (which[i] == VARIABLE) value = 0;
+    } else if (which[i] == ArgInfo::VARIABLE) value = 0;
     if (i == 0) finalvalue = value;
     else if (value != finalvalue)
       error->all(FLERR,"Fix vector cannot set output array "
@@ -201,19 +190,19 @@ void FixVector::init()
   // set current indices for all computes,fixes,variables
 
   for (int i = 0; i < nvalues; i++) {
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       int icompute = modify->find_compute(ids[i]);
       if (icompute < 0)
         error->all(FLERR,"Compute ID for fix vector does not exist");
       value2index[i] = icompute;
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       int ifix = modify->find_fix(ids[i]);
       if (ifix < 0)
         error->all(FLERR,"Fix ID for fix vector does not exist");
       value2index[i] = ifix;
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
       if (ivariable < 0)
         error->all(FLERR,"Variable name for fix vector does not exist");
@@ -265,7 +254,7 @@ void FixVector::end_of_step()
 
     // invoke compute if not previously invoked
 
-    if (which[i] == COMPUTE) {
+    if (which[i] == ArgInfo::COMPUTE) {
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
@@ -284,7 +273,7 @@ void FixVector::end_of_step()
 
     // access fix fields, guaranteed to be ready
 
-    } else if (which[i] == FIX) {
+    } else if (which[i] == ArgInfo::FIX) {
       if (argindex[i] == 0)
         result[i] = modify->fix[m]->compute_scalar();
       else
@@ -292,7 +281,7 @@ void FixVector::end_of_step()
 
     // evaluate equal-style or vector-style variable
 
-    } else if (which[i] == VARIABLE) {
+    } else if (which[i] == ArgInfo::VARIABLE) {
       if (argindex[i] == 0)
         result[i] = input->variable->compute_equal(m);
       else {

--- a/unittest/utils/CMakeLists.txt
+++ b/unittest/utils/CMakeLists.txt
@@ -6,6 +6,10 @@ add_executable(test_mempool test_mempool.cpp)
 target_link_libraries(test_mempool PRIVATE lammps GTest::GMockMain GTest::GMock GTest::GTest)
 add_test(MemPool test_mempool)
 
+add_executable(test_argutils test_argutils.cpp)
+target_link_libraries(test_argutils PRIVATE lammps GTest::GMockMain GTest::GMock GTest::GTest)
+add_test(ArgUtils test_argutils)
+
 add_executable(test_utils test_utils.cpp)
 target_link_libraries(test_utils PRIVATE lammps GTest::GMockMain GTest::GMock GTest::GTest)
 add_test(Utils test_utils)

--- a/unittest/utils/test_argutils.cpp
+++ b/unittest/utils/test_argutils.cpp
@@ -31,7 +31,7 @@ TEST(ArgInfo, plain)
 
 TEST(ArgInfo, copy_name)
 {
-    char *name=nullptr;
+    char *name = nullptr;
     ArgInfo arg("text");
     ASSERT_THAT(arg.get_name(), StrEq("text"));
     name = arg.copy_name();
@@ -129,9 +129,41 @@ TEST(ArgInfo, variable2)
     ASSERT_THAT(arg.get_name(), StrEq("x"));
 }
 
-TEST(ArgInfo, unsupported)
+TEST(ArgInfo, dname0)
+{
+    ArgInfo arg("d_text", ArgInfo::DNAME);
+    ASSERT_EQ(arg.get_dim(), 0);
+    ASSERT_EQ(arg.get_type(), ArgInfo::DNAME);
+    ASSERT_EQ(arg.get_index1(), 0);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, iname0)
+{
+    ArgInfo arg("i_text", ArgInfo::INAME);
+    ASSERT_EQ(arg.get_dim(), 0);
+    ASSERT_EQ(arg.get_type(), ArgInfo::INAME);
+    ASSERT_EQ(arg.get_index1(), 0);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, unsupported1)
 {
     ArgInfo arg("v_text[02][05]", ArgInfo::COMPUTE | ArgInfo::FIX);
+    ASSERT_EQ(arg.get_type(), ArgInfo::NONE);
+}
+
+TEST(ArgInfo, unsupported2)
+{
+    ArgInfo arg("d_text");
+    ASSERT_EQ(arg.get_type(), ArgInfo::NONE);
+}
+
+TEST(ArgInfo, unsupported3)
+{
+    ArgInfo arg("i_text");
     ASSERT_EQ(arg.get_type(), ArgInfo::NONE);
 }
 

--- a/unittest/utils/test_argutils.cpp
+++ b/unittest/utils/test_argutils.cpp
@@ -1,0 +1,172 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://lammps.sandia.gov/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "arg_info.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <string>
+
+using namespace LAMMPS_NS;
+using ::testing::StrEq;
+
+TEST(ArgInfo, plain)
+{
+    ArgInfo arg("text");
+    ASSERT_EQ(arg.get_dim(), 0);
+    ASSERT_EQ(arg.get_type(), ArgInfo::NONE);
+    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, copy_name)
+{
+    char *name=nullptr;
+    ArgInfo arg("text");
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+    name = arg.copy_name();
+    ASSERT_THAT(name, StrEq("text"));
+    delete[] name;
+}
+
+TEST(ArgInfo, compute0)
+{
+    ArgInfo arg("c_text");
+    ASSERT_EQ(arg.get_dim(), 0);
+    ASSERT_EQ(arg.get_type(), ArgInfo::COMPUTE);
+    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, compute1)
+{
+    ArgInfo arg("c_1[5]", ArgInfo::COMPUTE);
+    ASSERT_EQ(arg.get_dim(), 1);
+    ASSERT_EQ(arg.get_type(), ArgInfo::COMPUTE);
+    ASSERT_EQ(arg.get_index1(), 5);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("1"));
+}
+
+TEST(ArgInfo, compute2)
+{
+    ArgInfo arg("c_text[02][05]", ArgInfo::COMPUTE | ArgInfo::FIX);
+    ASSERT_EQ(arg.get_dim(), 2);
+    ASSERT_EQ(arg.get_type(), ArgInfo::COMPUTE);
+    ASSERT_EQ(arg.get_index1(), 2);
+    ASSERT_EQ(arg.get_index2(), 5);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, fix0)
+{
+    ArgInfo arg("f_2");
+    ASSERT_EQ(arg.get_dim(), 0);
+    ASSERT_EQ(arg.get_type(), ArgInfo::FIX);
+    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("2"));
+}
+
+TEST(ArgInfo, fix1)
+{
+    ArgInfo arg("f_text[5]", ArgInfo::FIX | ArgInfo::VARIABLE);
+    ASSERT_EQ(arg.get_dim(), 1);
+    ASSERT_EQ(arg.get_type(), ArgInfo::FIX);
+    ASSERT_EQ(arg.get_index1(), 5);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, fix2)
+{
+    ArgInfo arg("f_text[02][05]", ArgInfo::FIX);
+    ASSERT_EQ(arg.get_dim(), 2);
+    ASSERT_EQ(arg.get_type(), ArgInfo::FIX);
+    ASSERT_EQ(arg.get_index1(), 2);
+    ASSERT_EQ(arg.get_index2(), 5);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, variable0)
+{
+    ArgInfo arg("v_text");
+    ASSERT_EQ(arg.get_dim(), 0);
+    ASSERT_EQ(arg.get_type(), ArgInfo::VARIABLE);
+    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("text"));
+}
+
+TEST(ArgInfo, variable1)
+{
+    ArgInfo arg("v_text_1[5]", ArgInfo::VARIABLE);
+    ASSERT_EQ(arg.get_dim(), 1);
+    ASSERT_EQ(arg.get_type(), ArgInfo::VARIABLE);
+    ASSERT_EQ(arg.get_index1(), 5);
+    ASSERT_EQ(arg.get_index2(), -1);
+    ASSERT_THAT(arg.get_name(), StrEq("text_1"));
+}
+
+TEST(ArgInfo, variable2)
+{
+    ArgInfo arg("v_x[02][05]");
+    ASSERT_EQ(arg.get_dim(), 2);
+    ASSERT_EQ(arg.get_type(), ArgInfo::VARIABLE);
+    ASSERT_EQ(arg.get_index1(), 2);
+    ASSERT_EQ(arg.get_index2(), 5);
+    ASSERT_THAT(arg.get_name(), StrEq("x"));
+}
+
+TEST(ArgInfo, unsupported)
+{
+    ArgInfo arg("v_text[02][05]", ArgInfo::COMPUTE | ArgInfo::FIX);
+    ASSERT_EQ(arg.get_type(), ArgInfo::NONE);
+}
+
+TEST(ArgInfo, no_bracket1)
+{
+    ArgInfo arg("v_text[2");
+    ASSERT_EQ(arg.get_type(), ArgInfo::UNKNOWN);
+}
+
+TEST(ArgInfo, no_bracket2)
+{
+    ArgInfo arg("v_text[2][1");
+    ASSERT_EQ(arg.get_type(), ArgInfo::UNKNOWN);
+}
+
+TEST(ArgInfo, no_bracket3)
+{
+    ArgInfo arg("v_text[2[1]");
+    ASSERT_EQ(arg.get_type(), ArgInfo::UNKNOWN);
+}
+
+TEST(ArgInfo, none)
+{
+    ArgInfo arg("x_text");
+    ASSERT_EQ(arg.get_type(), ArgInfo::NONE);
+}
+
+TEST(ArgInfo, bad_idx1)
+{
+    ArgInfo arg("c_1[a]");
+    ASSERT_EQ(arg.get_type(), ArgInfo::UNKNOWN);
+}
+
+TEST(ArgInfo, bad_idx2)
+{
+    ArgInfo arg("c_1[1][b]");
+    ASSERT_EQ(arg.get_type(), ArgInfo::UNKNOWN);
+}

--- a/unittest/utils/test_argutils.cpp
+++ b/unittest/utils/test_argutils.cpp
@@ -24,7 +24,7 @@ TEST(ArgInfo, plain)
     ArgInfo arg("text");
     ASSERT_EQ(arg.get_dim(), 0);
     ASSERT_EQ(arg.get_type(), ArgInfo::NONE);
-    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index1(), 0);
     ASSERT_EQ(arg.get_index2(), -1);
     ASSERT_THAT(arg.get_name(), StrEq("text"));
 }
@@ -44,7 +44,7 @@ TEST(ArgInfo, compute0)
     ArgInfo arg("c_text");
     ASSERT_EQ(arg.get_dim(), 0);
     ASSERT_EQ(arg.get_type(), ArgInfo::COMPUTE);
-    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index1(), 0);
     ASSERT_EQ(arg.get_index2(), -1);
     ASSERT_THAT(arg.get_name(), StrEq("text"));
 }
@@ -74,7 +74,7 @@ TEST(ArgInfo, fix0)
     ArgInfo arg("f_2");
     ASSERT_EQ(arg.get_dim(), 0);
     ASSERT_EQ(arg.get_type(), ArgInfo::FIX);
-    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index1(), 0);
     ASSERT_EQ(arg.get_index2(), -1);
     ASSERT_THAT(arg.get_name(), StrEq("2"));
 }
@@ -104,7 +104,7 @@ TEST(ArgInfo, variable0)
     ArgInfo arg("v_text");
     ASSERT_EQ(arg.get_dim(), 0);
     ASSERT_EQ(arg.get_type(), ArgInfo::VARIABLE);
-    ASSERT_EQ(arg.get_index1(), -1);
+    ASSERT_EQ(arg.get_index1(), 0);
     ASSERT_EQ(arg.get_index2(), -1);
     ASSERT_THAT(arg.get_name(), StrEq("text"));
 }


### PR DESCRIPTION
**Summary**

This provides a new class `ArgInfo`, which provides an abstraction for the repetitive task of parsing and storing the info for arguments with references to compute or fix IDs or variable names. It also contains a common list of argument type constants.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

For the two example cases, the number of lines of code required are reduced by about a factor of 3.
The old implementation(s) would create false positives with several static code analysis tools.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
