### PR TITLE
Move definition of INVOKED_* constants as enumerator to compute.h

### DIFF
--- a/src/KOKKOS/compute_coord_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_coord_atom_kokkos.cpp
@@ -27,7 +27,6 @@
 
 using namespace LAMMPS_NS;
 
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -113,9 +112,9 @@ void ComputeCoordAtomKokkos<DeviceType>::compute_peratom()
   }
 
   if (cstyle == ORIENT) {
-    if (!(c_orientorder->invoked_flag & INVOKED_PERATOM)) {
+    if (!(c_orientorder->invoked_flag & Compute::INVOKED_PERATOM)) {
       c_orientorder->compute_peratom();
-      c_orientorder->invoked_flag |= INVOKED_PERATOM;
+      c_orientorder->invoked_flag |= Compute::INVOKED_PERATOM;
     }
     nqlist = c_orientorder->nqlist;
     normv = c_orientorder->array_atom;

--- a/src/LATTE/fix_latte.cpp
+++ b/src/LATTE/fix_latte.cpp
@@ -49,7 +49,6 @@ extern "C" {
 // difficult to debug crashes or memory corruption.
 
 #define LATTE_ABIVERSION 20180622
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -248,9 +247,9 @@ void FixLatte::post_force(int vflag)
   if (coulomb) {
     modify->clearstep_compute();
 
-    if (!(c_pe->invoked_flag & INVOKED_PERATOM)) {
+    if (!(c_pe->invoked_flag & Compute::INVOKED_PERATOM)) {
       c_pe->compute_peratom();
-      c_pe->invoked_flag |= INVOKED_PERATOM;
+      c_pe->invoked_flag |= Compute::INVOKED_PERATOM;
     }
 
     modify->addstep_compute(update->ntimestep+1);

--- a/src/REPLICA/compute_event_displace.cpp
+++ b/src/REPLICA/compute_event_displace.cpp
@@ -28,7 +28,6 @@
 
 using namespace LAMMPS_NS;
 
-#define INVOKED_SCALAR 1
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/USER-DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/USER-DIFFRACTION/fix_saed_vtk.cpp
@@ -35,7 +35,6 @@ enum{COMPUTE};
 enum{ONE,RUNNING,WINDOW};
 enum{FIRST,MULTI};
 
-#define INVOKED_VECTOR 2
 
 /* ---------------------------------------------------------------------- */
 
@@ -357,9 +356,9 @@ void FixSAEDVTK::invoke_vector(bigint ntimestep)
 
   Compute *compute = modify->compute[icompute];
 
-  if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+  if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
     compute->compute_vector();
-    compute->invoked_flag |= INVOKED_VECTOR;
+    compute->invoked_flag |= Compute::INVOKED_VECTOR;
   }
 
   double *vector = compute->vector;

--- a/src/USER-MISC/fix_ave_correlate_long.cpp
+++ b/src/USER-MISC/fix_ave_correlate_long.cpp
@@ -42,9 +42,6 @@ using namespace FixConst;
 enum{COMPUTE,FIX,VARIABLE};
 enum{AUTO,UPPER,LOWER,AUTOUPPER,AUTOLOWER,FULL};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
 
 static const char cite_fix_ave_correlate_long[] =
 "fix ave/correlate/long command:\n\n"
@@ -448,15 +445,15 @@ void FixAveCorrelateLong::end_of_step()
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
-        if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
           compute->compute_scalar();
-          compute->invoked_flag |= INVOKED_SCALAR;
+          compute->invoked_flag |= Compute::INVOKED_SCALAR;
         }
         scalar = compute->scalar;
       } else {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         scalar = compute->vector[argindex[i]-1];
       }

--- a/src/USER-PHONON/fix_phonon.cpp
+++ b/src/USER-PHONON/fix_phonon.cpp
@@ -42,8 +42,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
 #define MAXLINE 512
 
 enum{FORWARD=-1,BACKWARD=1};
@@ -338,7 +336,7 @@ void FixPhonon::end_of_step()
   double xcur[3];
 
   // to get the current temperature
-  if (!(temperature->invoked_flag & INVOKED_VECTOR)) temperature->compute_vector();
+  if (!(temperature->invoked_flag & Compute::INVOKED_VECTOR)) temperature->compute_vector();
   for (idim = 0; idim < sysdim; ++idim) TempSum[idim] += temperature->vector[idim];
 
   // evaluate R(r) on local proc

--- a/src/USER-PLUMED/fix_plumed.cpp
+++ b/src/USER-PLUMED/fix_plumed.cpp
@@ -49,7 +49,6 @@ static char plumed_default_kernel[] = "PLUMED_KERNEL=" PLUMED_QUOTE(__PLUMED_DEF
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-#define INVOKED_SCALAR 1
 
 FixPlumed::FixPlumed(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg),

--- a/src/USER-VTK/dump_vtk.cpp
+++ b/src/USER-VTK/dump_vtk.cpp
@@ -89,7 +89,6 @@ enum{X,Y,Z, // required for vtk, must come first
 enum{LT,LE,GT,GE,EQ,NEQ};
 enum{VTK,VTP,VTU,PVTP,PVTU}; // file formats
 
-#define INVOKED_PERATOM 8
 #define ONEFIELD 32
 #define DELTA 1048576
 
@@ -302,9 +301,9 @@ int DumpVTK::count()
           error->all(FLERR,"Compute used in dump between runs is not current");
     } else {
       for (i = 0; i < ncompute; i++) {
-        if (!(compute[i]->invoked_flag & INVOKED_PERATOM)) {
+        if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
           compute[i]->compute_peratom();
-          compute[i]->invoked_flag |= INVOKED_PERATOM;
+          compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;
         }
       }
     }

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -84,7 +84,7 @@ Compute::Compute(LAMMPS *lmp, int narg, char **arg) :
 
   invoked_scalar = invoked_vector = invoked_array = -1;
   invoked_peratom = invoked_local = -1;
-  invoked_flag = 0;
+  invoked_flag = INVOKED_NONE;
 
   // set modify defaults
 

--- a/src/compute.h
+++ b/src/compute.h
@@ -20,6 +20,14 @@ namespace LAMMPS_NS {
 
 class Compute : protected Pointers {
  public:
+  enum {
+    INVOKED_NONE    = 0,
+    INVOKED_SCALAR  = 1<<0,
+    INVOKED_VECTOR  = 1<<1,
+    INVOKED_ARRAY   = 1<<2,
+    INVOKED_PERATOM = 1<<3,
+    INVOKED_LOCAL   = 1<<4,
+  };
   static int instance_total;     // # of Compute classes ever instantiated
 
   char *id,*style;

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -48,7 +48,6 @@ enum{ONCE,NFREQ,EVERY};              // used in several files
 enum{LIMITMAX,LIMITEXACT};
 
 #define IDMAX 1024*1024
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -958,9 +957,9 @@ void ComputeChunkAtom::assign_chunk_ids()
     }
 
   } else if (which == COMPUTE) {
-    if (!(cchunk->invoked_flag & INVOKED_PERATOM)) {
+    if (!(cchunk->invoked_flag & Compute::INVOKED_PERATOM)) {
       cchunk->compute_peratom();
-      cchunk->invoked_flag |= INVOKED_PERATOM;
+      cchunk->invoked_flag |= Compute::INVOKED_PERATOM;
     }
 
     if (argindex == 0) {

--- a/src/compute_chunk_spread_atom.cpp
+++ b/src/compute_chunk_spread_atom.cpp
@@ -28,9 +28,6 @@ using namespace LAMMPS_NS;
 
 enum{COMPUTE,FIX};
 
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -275,9 +272,9 @@ void ComputeChunkSpreadAtom::compute_peratom()
       Compute *compute = modify->compute[n];
 
       if (argindex[m] == 0) {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         double *cvector = compute->vector;
         for (i = 0; i < nlocal; i++, ptr += nstride) {
@@ -289,9 +286,9 @@ void ComputeChunkSpreadAtom::compute_peratom()
         }
 
       } else {
-        if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
-          compute->invoked_flag |= INVOKED_ARRAY;
+          compute->invoked_flag |= Compute::INVOKED_ARRAY;
         }
         int icol = argindex[m]-1;
         double **carray = compute->array;

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -32,7 +32,6 @@
 
 using namespace LAMMPS_NS;
 
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -198,9 +197,9 @@ void ComputeCoordAtom::compute_peratom()
   }
 
   if (cstyle == ORIENT) {
-    if (!(c_orientorder->invoked_flag & INVOKED_PERATOM)) {
+    if (!(c_orientorder->invoked_flag & Compute::INVOKED_PERATOM)) {
       c_orientorder->compute_peratom();
-      c_orientorder->invoked_flag |= INVOKED_PERATOM;
+      c_orientorder->invoked_flag |= Compute::INVOKED_PERATOM;
     }
     nqlist = c_orientorder->nqlist;
     normv = c_orientorder->array_atom;

--- a/src/compute_global_atom.cpp
+++ b/src/compute_global_atom.cpp
@@ -29,9 +29,6 @@ using namespace LAMMPS_NS;
 enum{COMPUTE,FIX,VARIABLE};
 enum{VECTOR,ARRAY};
 
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
-#define INVOKED_PERATOM 8
 
 #define BIG 1.0e20
 
@@ -340,9 +337,9 @@ void ComputeGlobalAtom::compute_peratom()
   if (whichref == COMPUTE) {
     Compute *compute = modify->compute[ref2index];
 
-    if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+    if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
       compute->compute_peratom();
-      compute->invoked_flag |= INVOKED_PERATOM;
+      compute->invoked_flag |= Compute::INVOKED_PERATOM;
     }
 
     if (indexref == 0) {
@@ -397,9 +394,9 @@ void ComputeGlobalAtom::compute_peratom()
       if (which[m] == COMPUTE) {
         Compute *compute = modify->compute[value2index[m]];
 
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
 
         source = compute->vector;
@@ -455,9 +452,9 @@ void ComputeGlobalAtom::compute_peratom()
       if (which[m] == COMPUTE) {
         Compute *compute = modify->compute[value2index[m]];
 
-        if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
-          compute->invoked_flag |= INVOKED_ARRAY;
+          compute->invoked_flag |= Compute::INVOKED_ARRAY;
         }
 
         double **compute_array = compute->array;

--- a/src/compute_heat_flux.cpp
+++ b/src/compute_heat_flux.cpp
@@ -27,7 +27,6 @@
 
 using namespace LAMMPS_NS;
 
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -108,17 +107,17 @@ void ComputeHeatFlux::compute_vector()
 
   // invoke 3 computes if they haven't been already
 
-  if (!(c_ke->invoked_flag & INVOKED_PERATOM)) {
+  if (!(c_ke->invoked_flag & Compute::INVOKED_PERATOM)) {
     c_ke->compute_peratom();
-    c_ke->invoked_flag |= INVOKED_PERATOM;
+    c_ke->invoked_flag |= Compute::INVOKED_PERATOM;
   }
-  if (!(c_pe->invoked_flag & INVOKED_PERATOM)) {
+  if (!(c_pe->invoked_flag & Compute::INVOKED_PERATOM)) {
     c_pe->compute_peratom();
-    c_pe->invoked_flag |= INVOKED_PERATOM;
+    c_pe->invoked_flag |= Compute::INVOKED_PERATOM;
   }
-  if (!(c_stress->invoked_flag & INVOKED_PERATOM)) {
+  if (!(c_stress->invoked_flag & Compute::INVOKED_PERATOM)) {
     c_stress->compute_peratom();
-    c_stress->invoked_flag |= INVOKED_PERATOM;
+    c_stress->invoked_flag |= Compute::INVOKED_PERATOM;
   }
 
   // heat flux vector = jc[3] + jv[3]

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -33,10 +33,6 @@ enum{SUM,SUMSQ,MINN,MAXX,AVE,AVESQ};             // also in ComputeReduceRegion
 enum{UNKNOWN=-1,X,V,F,COMPUTE,FIX,VARIABLE};
 enum{PERATOM,LOCAL};
 
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
-#define INVOKED_PERATOM 8
-#define INVOKED_LOCAL 16
 
 #define BIG 1.0e20
 
@@ -513,9 +509,9 @@ double ComputeReduce::compute_one(int m, int flag)
     Compute *compute = modify->compute[vidx];
 
     if (flavor[m] == PERATOM) {
-      if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute->compute_peratom();
-        compute->invoked_flag |= INVOKED_PERATOM;
+        compute->invoked_flag |= Compute::INVOKED_PERATOM;
       }
 
       if (aidx == 0) {
@@ -536,9 +532,9 @@ double ComputeReduce::compute_one(int m, int flag)
       }
 
     } else if (flavor[m] == LOCAL) {
-      if (!(compute->invoked_flag & INVOKED_LOCAL)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_LOCAL)) {
         compute->compute_local();
-        compute->invoked_flag |= INVOKED_LOCAL;
+        compute->invoked_flag |= Compute::INVOKED_LOCAL;
       }
 
       if (aidx == 0) {

--- a/src/compute_reduce_chunk.cpp
+++ b/src/compute_reduce_chunk.cpp
@@ -32,7 +32,6 @@ using namespace LAMMPS_NS;
 enum{SUM,MINN,MAXX};
 enum{UNKNOWN=-1,COMPUTE,FIX,VARIABLE};
 
-#define INVOKED_PERATOM 8
 
 #define BIG 1.0e20
 
@@ -374,9 +373,9 @@ void ComputeReduceChunk::compute_one(int m, double *vchunk, int nstride)
   if (which[m] == COMPUTE) {
     Compute *compute = modify->compute[vidx];
 
-    if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+    if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
       compute->compute_peratom();
-      compute->invoked_flag |= INVOKED_PERATOM;
+      compute->invoked_flag |= Compute::INVOKED_PERATOM;
     }
 
     if (argindex[m] == 0) {

--- a/src/compute_reduce_region.cpp
+++ b/src/compute_reduce_region.cpp
@@ -31,10 +31,6 @@ enum{SUM,SUMSQ,MINN,MAXX,AVE,AVESQ};             // also in ComputeReduce
 enum{UNKNOWN=-1,X,V,F,COMPUTE,FIX,VARIABLE};
 enum{PERATOM,LOCAL};
 
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
-#define INVOKED_PERATOM 8
-#define INVOKED_LOCAL 16
 
 #define BIG 1.0e20
 
@@ -110,9 +106,9 @@ double ComputeReduceRegion::compute_one(int m, int flag)
     Compute *compute = modify->compute[n];
 
     if (flavor[m] == PERATOM) {
-      if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute->compute_peratom();
-        compute->invoked_flag |= INVOKED_PERATOM;
+        compute->invoked_flag |= Compute::INVOKED_PERATOM;
       }
 
       if (j == 0) {
@@ -135,9 +131,9 @@ double ComputeReduceRegion::compute_one(int m, int flag)
       }
 
     } else if (flavor[m] == LOCAL) {
-      if (!(compute->invoked_flag & INVOKED_LOCAL)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_LOCAL)) {
         compute->compute_local();
-        compute->invoked_flag |= INVOKED_LOCAL;
+        compute->invoked_flag |= Compute::INVOKED_LOCAL;
       }
 
       if (j == 0) {

--- a/src/compute_slice.cpp
+++ b/src/compute_slice.cpp
@@ -27,8 +27,6 @@ using namespace LAMMPS_NS;
 
 enum{COMPUTE,FIX,VARIABLE};
 
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
 
 /* ---------------------------------------------------------------------- */
 
@@ -290,9 +288,9 @@ void ComputeSlice::extract_one(int m, double *vec, int stride)
     Compute *compute = modify->compute[value2index[m]];
 
     if (argindex[m] == 0) {
-      if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
         compute->compute_vector();
-        compute->invoked_flag |= INVOKED_VECTOR;
+        compute->invoked_flag |= Compute::INVOKED_VECTOR;
       }
       double *cvector = compute->vector;
       j = 0;
@@ -302,9 +300,9 @@ void ComputeSlice::extract_one(int m, double *vec, int stride)
       }
 
     } else {
-      if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
         compute->compute_array();
-        compute->invoked_flag |= INVOKED_ARRAY;
+        compute->invoked_flag |= Compute::INVOKED_ARRAY;
       }
       double **carray = compute->array;
       int icol = argindex[m]-1;

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -45,7 +45,6 @@ enum{ID,MOL,PROC,PROCP1,TYPE,ELEMENT,MASS,
      COMPUTE,FIX,VARIABLE,INAME,DNAME};
 enum{LT,LE,GT,GE,EQ,NEQ,XOR};
 
-#define INVOKED_PERATOM 8
 #define ONEFIELD 32
 #define DELTA 1048576
 
@@ -584,9 +583,9 @@ int DumpCustom::count()
           error->all(FLERR,"Compute used in dump between runs is not current");
     } else {
       for (i = 0; i < ncompute; i++) {
-        if (!(compute[i]->invoked_flag & INVOKED_PERATOM)) {
+        if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
           compute[i]->compute_peratom();
-          compute[i]->invoked_flag |= INVOKED_PERATOM;
+          compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;
         }
       }
     }

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -27,7 +27,6 @@ using namespace LAMMPS_NS;
 
 enum{INT,DOUBLE};
 
-#define INVOKED_LOCAL 16
 #define ONEFIELD 32
 #define DELTA 1048576
 
@@ -297,9 +296,9 @@ int DumpLocal::count()
           error->all(FLERR,"Compute used in dump between runs is not current");
     } else {
       for (i = 0; i < ncompute; i++) {
-        if (!(compute[i]->invoked_flag & INVOKED_LOCAL)) {
+        if (!(compute[i]->invoked_flag & Compute::INVOKED_LOCAL)) {
           compute[i]->compute_local();
-          compute[i]->invoked_flag |= INVOKED_LOCAL;
+          compute[i]->invoked_flag |= Compute::INVOKED_LOCAL;
         }
       }
     }

--- a/src/fix_ave_atom.cpp
+++ b/src/fix_ave_atom.cpp
@@ -29,7 +29,6 @@ using namespace FixConst;
 
 enum{X,V,F,COMPUTE,FIX,VARIABLE};
 
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -341,9 +340,9 @@ void FixAveAtom::end_of_step()
 
     } else if (which[m] == COMPUTE) {
       Compute *compute = modify->compute[n];
-      if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute->compute_peratom();
-        compute->invoked_flag |= INVOKED_PERATOM;
+        compute->invoked_flag |= Compute::INVOKED_PERATOM;
       }
 
       if (j == 0) {

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -39,7 +39,6 @@ enum{SAMPLE,ALL};
 enum{NOSCALE,ATOM};
 enum{ONE,RUNNING,WINDOW};
 
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -738,9 +737,9 @@ void FixAveChunk::end_of_step()
 
     } else if (which[m] == COMPUTE) {
       Compute *compute = modify->compute[n];
-      if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute->compute_peratom();
-        compute->invoked_flag |= INVOKED_PERATOM;
+        compute->invoked_flag |= Compute::INVOKED_PERATOM;
       }
       double *vector = compute->vector_atom;
       double **array = compute->array_atom;

--- a/src/fix_ave_correlate.cpp
+++ b/src/fix_ave_correlate.cpp
@@ -37,9 +37,6 @@ enum{COMPUTE,FIX,VARIABLE};
 enum{ONE,RUNNING};
 enum{AUTO,UPPER,LOWER,AUTOUPPER,AUTOLOWER,FULL};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
 
 /* ---------------------------------------------------------------------- */
 
@@ -442,15 +439,15 @@ void FixAveCorrelate::end_of_step()
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
-        if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
           compute->compute_scalar();
-          compute->invoked_flag |= INVOKED_SCALAR;
+          compute->invoked_flag |= Compute::INVOKED_SCALAR;
         }
         scalar = compute->scalar;
       } else {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         scalar = compute->vector[argindex[i]-1];
       }

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -34,11 +34,6 @@ enum{SCALAR,VECTOR,WINDOW};
 enum{DEFAULT,GLOBAL,PERATOM,LOCAL};
 enum{IGNORE,END,EXTRA};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
-#define INVOKED_PERATOM 8
-#define INVOKED_LOCAL 16
 
 #define BIG 1.0e20
 /* ---------------------------------------------------------------------- */
@@ -638,29 +633,29 @@ void FixAveHisto::end_of_step()
 
       if (kind == GLOBAL && mode == SCALAR) {
         if (j == 0) {
-          if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+          if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
             compute->compute_scalar();
-            compute->invoked_flag |= INVOKED_SCALAR;
+            compute->invoked_flag |= Compute::INVOKED_SCALAR;
           }
           bin_one(compute->scalar);
         } else {
-          if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+          if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
-            compute->invoked_flag |= INVOKED_VECTOR;
+            compute->invoked_flag |= Compute::INVOKED_VECTOR;
           }
           bin_one(compute->vector[j-1]);
         }
       } else if (kind == GLOBAL && mode == VECTOR) {
         if (j == 0) {
-          if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+          if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
-            compute->invoked_flag |= INVOKED_VECTOR;
+            compute->invoked_flag |= Compute::INVOKED_VECTOR;
           }
           bin_vector(compute->size_vector,compute->vector,1);
         } else {
-          if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+          if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
-            compute->invoked_flag |= INVOKED_ARRAY;
+            compute->invoked_flag |= Compute::INVOKED_ARRAY;
           }
           if (compute->array)
             bin_vector(compute->size_array_rows,&compute->array[0][j-1],
@@ -668,9 +663,9 @@ void FixAveHisto::end_of_step()
         }
 
       } else if (kind == PERATOM) {
-        if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
           compute->compute_peratom();
-          compute->invoked_flag |= INVOKED_PERATOM;
+          compute->invoked_flag |= Compute::INVOKED_PERATOM;
         }
         if (j == 0)
           bin_atoms(compute->vector_atom,1);
@@ -678,9 +673,9 @@ void FixAveHisto::end_of_step()
           bin_atoms(&compute->array_atom[0][j-1],compute->size_peratom_cols);
 
       } else if (kind == LOCAL) {
-        if (!(compute->invoked_flag & INVOKED_LOCAL)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_LOCAL)) {
           compute->compute_local();
-          compute->invoked_flag |= INVOKED_LOCAL;
+          compute->invoked_flag |= Compute::INVOKED_LOCAL;
         }
         if (j == 0)
           bin_vector(compute->size_local_rows,compute->vector_local,1);

--- a/src/fix_ave_histo_weight.cpp
+++ b/src/fix_ave_histo_weight.cpp
@@ -37,11 +37,6 @@ enum{DEFAULT,GLOBAL,PERATOM,LOCAL};
 enum{IGNORE,END,EXTRA};
 enum{SINGLE,VALUE};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
-#define INVOKED_PERATOM 8
-#define INVOKED_LOCAL 16
 
 #define BIG 1.0e20
 
@@ -155,38 +150,38 @@ void FixAveHistoWeight::end_of_step()
 
     if (kind == GLOBAL && mode == SCALAR) {
       if (j == 0) {
-        if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
           compute->compute_scalar();
-          compute->invoked_flag |= INVOKED_SCALAR;
+          compute->invoked_flag |= Compute::INVOKED_SCALAR;
         }
         weight = compute->scalar;
       } else {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         weight = compute->vector[j-1];
       }
     } else if (kind == GLOBAL && mode == VECTOR) {
       if (j == 0) {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         weights = compute->vector;
         stride = 1;
       } else {
-        if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
-          compute->invoked_flag |= INVOKED_ARRAY;
+          compute->invoked_flag |= Compute::INVOKED_ARRAY;
         }
         if (compute->array) weights = &compute->array[0][j-1];
         stride = compute->size_array_cols;
       }
     } else if (kind == PERATOM) {
-      if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute->compute_peratom();
-        compute->invoked_flag |= INVOKED_PERATOM;
+        compute->invoked_flag |= Compute::INVOKED_PERATOM;
       }
       if (j == 0) {
         weights = compute->vector_atom;
@@ -196,9 +191,9 @@ void FixAveHistoWeight::end_of_step()
         stride = compute->size_peratom_cols;
       }
     } else if (kind == LOCAL) {
-      if (!(compute->invoked_flag & INVOKED_LOCAL)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_LOCAL)) {
         compute->compute_local();
-        compute->invoked_flag |= INVOKED_LOCAL;
+        compute->invoked_flag |= Compute::INVOKED_LOCAL;
       }
       if (j == 0) {
         weights = compute->vector_local;
@@ -283,30 +278,30 @@ void FixAveHistoWeight::end_of_step()
     Compute *compute = modify->compute[m];
     if (kind == GLOBAL && mode == SCALAR) {
       if (j == 0) {
-        if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
           compute->compute_scalar();
-          compute->invoked_flag |= INVOKED_SCALAR;
+          compute->invoked_flag |= Compute::INVOKED_SCALAR;
         }
         bin_one_weights(compute->scalar,weight);
       } else {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         bin_one_weights(compute->vector[j-1],weight);
       }
     } else if (kind == GLOBAL && mode == VECTOR) {
       if (j == 0) {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         bin_vector_weights(compute->size_vector,compute->vector,1,
                            weights,stride);
       } else {
-        if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
-          compute->invoked_flag |= INVOKED_ARRAY;
+          compute->invoked_flag |= Compute::INVOKED_ARRAY;
         }
         if (compute->array)
           bin_vector_weights(compute->size_array_rows,&compute->array[0][j-1],
@@ -314,9 +309,9 @@ void FixAveHistoWeight::end_of_step()
       }
 
     } else if (kind == PERATOM) {
-      if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute->compute_peratom();
-        compute->invoked_flag |= INVOKED_PERATOM;
+        compute->invoked_flag |= Compute::INVOKED_PERATOM;
       }
       if (j == 0)
         bin_atoms_weights(compute->vector_atom,1,weights, stride);
@@ -325,9 +320,9 @@ void FixAveHistoWeight::end_of_step()
                           compute->size_peratom_cols,weights,stride);
 
     } else if (kind == LOCAL) {
-      if (!(compute->invoked_flag & INVOKED_LOCAL)) {
+      if (!(compute->invoked_flag & Compute::INVOKED_LOCAL)) {
         compute->compute_local();
-        compute->invoked_flag |= INVOKED_LOCAL;
+        compute->invoked_flag |= Compute::INVOKED_LOCAL;
       }
       if (j == 0)
         bin_vector_weights(compute->size_local_rows,

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -35,9 +35,6 @@ enum{COMPUTE,FIX,VARIABLE};
 enum{ONE,RUNNING,WINDOW};
 enum{SCALAR,VECTOR};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
 
 /* ---------------------------------------------------------------------- */
 
@@ -587,15 +584,15 @@ void FixAveTime::invoke_scalar(bigint ntimestep)
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
-        if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
           compute->compute_scalar();
-          compute->invoked_flag |= INVOKED_SCALAR;
+          compute->invoked_flag |= Compute::INVOKED_SCALAR;
         }
         scalar = compute->scalar;
       } else {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         if (varlen[i] && compute->size_vector < argindex[i]) scalar = 0.0;
         else scalar = compute->vector[argindex[i]-1];
@@ -771,18 +768,18 @@ void FixAveTime::invoke_vector(bigint ntimestep)
       Compute *compute = modify->compute[m];
 
       if (argindex[j] == 0) {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         double *cvector = compute->vector;
         for (i = 0; i < nrows; i++)
           column[i] = cvector[i];
 
       } else {
-        if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
-          compute->invoked_flag |= INVOKED_ARRAY;
+          compute->invoked_flag |= Compute::INVOKED_ARRAY;
         }
         double **carray = compute->array;
         int icol = argindex[j]-1;

--- a/src/fix_controller.cpp
+++ b/src/fix_controller.cpp
@@ -27,8 +27,6 @@ using namespace FixConst;
 
 enum{COMPUTE,FIX,VARIABLE};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
 
 /* ---------------------------------------------------------------------- */
 
@@ -200,15 +198,15 @@ void FixController::end_of_step()
 
   if (pvwhich == COMPUTE) {
     if (pvindex == 0) {
-      if (!(pcompute->invoked_flag & INVOKED_SCALAR)) {
+      if (!(pcompute->invoked_flag & Compute::INVOKED_SCALAR)) {
         pcompute->compute_scalar();
-        pcompute->invoked_flag |= INVOKED_SCALAR;
+        pcompute->invoked_flag |= Compute::INVOKED_SCALAR;
       }
       current = pcompute->scalar;
     } else {
-      if (!(pcompute->invoked_flag & INVOKED_VECTOR)) {
+      if (!(pcompute->invoked_flag & Compute::INVOKED_VECTOR)) {
         pcompute->compute_vector();
-        pcompute->invoked_flag |= INVOKED_VECTOR;
+        pcompute->invoked_flag |= Compute::INVOKED_VECTOR;
       }
       current = pcompute->vector[pvindex-1];
     }

--- a/src/fix_store_state.cpp
+++ b/src/fix_store_state.cpp
@@ -32,7 +32,6 @@ using namespace FixConst;
 
 enum{KEYWORD,COMPUTE,FIX,VARIABLE,DNAME,INAME};
 
-#define INVOKED_PERATOM 8
 
 /* ---------------------------------------------------------------------- */
 
@@ -495,9 +494,9 @@ void FixStoreState::end_of_step()
 
       if (which[m] == COMPUTE) {
         Compute *compute = modify->compute[n];
-        if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
           compute->compute_peratom();
-          compute->invoked_flag |= INVOKED_PERATOM;
+          compute->invoked_flag |= Compute::INVOKED_PERATOM;
         }
 
         if (j == 0) {

--- a/src/fix_vector.cpp
+++ b/src/fix_vector.cpp
@@ -30,9 +30,6 @@ enum{COMPUTE,FIX,VARIABLE};
 enum{ONE,RUNNING,WINDOW};
 enum{SCALAR,VECTOR};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
 
 /* ---------------------------------------------------------------------- */
 
@@ -272,15 +269,15 @@ void FixVector::end_of_step()
       Compute *compute = modify->compute[m];
 
       if (argindex[i] == 0) {
-        if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
           compute->compute_scalar();
-          compute->invoked_flag |= INVOKED_SCALAR;
+          compute->invoked_flag |= Compute::INVOKED_SCALAR;
         }
         result[i] = compute->scalar;
       } else {
-        if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         result[i] = compute->vector[argindex[i]-1];
       }

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -1345,7 +1345,7 @@ int Modify::find_compute(const std::string &id)
 void Modify::clearstep_compute()
 {
   for (int icompute = 0; icompute < ncompute; icompute++)
-    compute[icompute]->invoked_flag = 0;
+    compute[icompute]->invoked_flag = Compute::INVOKED_NONE;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -73,9 +73,6 @@ enum{ONELINE,MULTILINE};
 enum{INT,FLOAT,BIGINT};
 enum{SCALAR,VECTOR,ARRAY};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
 
 #define DELTA 8
 
@@ -339,19 +336,19 @@ void Thermo::compute(int flag)
 
   for (i = 0; i < ncompute; i++)
     if (compute_which[i] == SCALAR) {
-      if (!(computes[i]->invoked_flag & INVOKED_SCALAR)) {
+      if (!(computes[i]->invoked_flag & Compute::INVOKED_SCALAR)) {
         computes[i]->compute_scalar();
-        computes[i]->invoked_flag |= INVOKED_SCALAR;
+        computes[i]->invoked_flag |= Compute::INVOKED_SCALAR;
       }
     } else if (compute_which[i] == VECTOR) {
-      if (!(computes[i]->invoked_flag & INVOKED_VECTOR)) {
+      if (!(computes[i]->invoked_flag & Compute::INVOKED_VECTOR)) {
         computes[i]->compute_vector();
-        computes[i]->invoked_flag |= INVOKED_VECTOR;
+        computes[i]->invoked_flag |= Compute::INVOKED_VECTOR;
       }
     } else if (compute_which[i] == ARRAY) {
-      if (!(computes[i]->invoked_flag & INVOKED_ARRAY)) {
+      if (!(computes[i]->invoked_flag & Compute::INVOKED_ARRAY)) {
         computes[i]->compute_array();
-        computes[i]->invoked_flag |= INVOKED_ARRAY;
+        computes[i]->invoked_flag |= Compute::INVOKED_ARRAY;
       }
     }
 
@@ -1161,9 +1158,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (temperature->invoked_scalar != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(temperature->invoked_flag & INVOKED_SCALAR)) {
+    } else if (!(temperature->invoked_flag & Compute::INVOKED_SCALAR)) {
       temperature->compute_scalar();
-      temperature->invoked_flag |= INVOKED_SCALAR;
+      temperature->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     compute_temp();
 
@@ -1175,9 +1172,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_scalar != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_SCALAR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_SCALAR)) {
       pressure->compute_scalar();
-      pressure->invoked_flag |= INVOKED_SCALAR;
+      pressure->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     compute_press();
 
@@ -1191,7 +1188,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
                    "is not current");
     } else {
       pe->compute_scalar();
-      pe->invoked_flag |= INVOKED_SCALAR;
+      pe->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     compute_pe();
 
@@ -1203,9 +1200,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (temperature->invoked_scalar != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(temperature->invoked_flag & INVOKED_SCALAR)) {
+    } else if (!(temperature->invoked_flag & Compute::INVOKED_SCALAR)) {
       temperature->compute_scalar();
-      temperature->invoked_flag |= INVOKED_SCALAR;
+      temperature->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     compute_ke();
 
@@ -1219,7 +1216,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
                    "is not current");
     } else {
       pe->compute_scalar();
-      pe->invoked_flag |= INVOKED_SCALAR;
+      pe->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     if (!temperature)
       error->all(FLERR,"Thermo keyword in variable requires "
@@ -1228,9 +1225,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (temperature->invoked_scalar != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(temperature->invoked_flag & INVOKED_SCALAR)) {
+    } else if (!(temperature->invoked_flag & Compute::INVOKED_SCALAR)) {
       temperature->compute_scalar();
-      temperature->invoked_flag |= INVOKED_SCALAR;
+      temperature->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     compute_etotal();
 
@@ -1244,7 +1241,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
                    "is not current");
     } else {
       pe->compute_scalar();
-      pe->invoked_flag |= INVOKED_SCALAR;
+      pe->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     if (!temperature)
       error->all(FLERR,"Thermo keyword in variable requires "
@@ -1253,9 +1250,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (temperature->invoked_scalar != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(temperature->invoked_flag & INVOKED_SCALAR)) {
+    } else if (!(temperature->invoked_flag & Compute::INVOKED_SCALAR)) {
       temperature->compute_scalar();
-      temperature->invoked_flag |= INVOKED_SCALAR;
+      temperature->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     if (!pressure)
       error->all(FLERR,"Thermo keyword in variable requires "
@@ -1264,9 +1261,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_scalar != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_SCALAR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_SCALAR)) {
       pressure->compute_scalar();
-      pressure->invoked_flag |= INVOKED_SCALAR;
+      pressure->invoked_flag |= Compute::INVOKED_SCALAR;
     }
     compute_enthalpy();
 
@@ -1276,7 +1273,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_evdwl();
 
   } else if (strcmp(word,"ecoul") == 0) {
@@ -1285,7 +1282,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_ecoul();
 
   } else if (strcmp(word,"epair") == 0) {
@@ -1294,7 +1291,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_epair();
 
   } else if (strcmp(word,"ebond") == 0) {
@@ -1303,7 +1300,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_ebond();
 
   } else if (strcmp(word,"eangle") == 0) {
@@ -1312,7 +1309,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_eangle();
 
   } else if (strcmp(word,"edihed") == 0) {
@@ -1321,7 +1318,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_edihed();
 
   } else if (strcmp(word,"eimp") == 0) {
@@ -1330,7 +1327,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_eimp();
 
   } else if (strcmp(word,"emol") == 0) {
@@ -1339,7 +1336,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_emol();
 
   } else if (strcmp(word,"elong") == 0) {
@@ -1348,7 +1345,7 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
     if (!pe)
       error->all(FLERR,
                  "Thermo keyword in variable requires thermo to use/init pe");
-    pe->invoked_flag |= INVOKED_SCALAR;
+    pe->invoked_flag |= Compute::INVOKED_SCALAR;
     compute_elong();
 
   } else if (strcmp(word,"etail") == 0) {
@@ -1385,9 +1382,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_vector != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_VECTOR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
       pressure->compute_vector();
-      pressure->invoked_flag |= INVOKED_VECTOR;
+      pressure->invoked_flag |= Compute::INVOKED_VECTOR;
     }
     compute_pxx();
 
@@ -1399,9 +1396,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_vector != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_VECTOR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
       pressure->compute_vector();
-      pressure->invoked_flag |= INVOKED_VECTOR;
+      pressure->invoked_flag |= Compute::INVOKED_VECTOR;
     }
     compute_pyy();
 
@@ -1413,9 +1410,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_vector != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_VECTOR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
       pressure->compute_vector();
-      pressure->invoked_flag |= INVOKED_VECTOR;
+      pressure->invoked_flag |= Compute::INVOKED_VECTOR;
     }
     compute_pzz();
 
@@ -1427,9 +1424,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_vector != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_VECTOR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
       pressure->compute_vector();
-      pressure->invoked_flag |= INVOKED_VECTOR;
+      pressure->invoked_flag |= Compute::INVOKED_VECTOR;
     }
     compute_pxy();
 
@@ -1441,9 +1438,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_vector != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_VECTOR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
       pressure->compute_vector();
-      pressure->invoked_flag |= INVOKED_VECTOR;
+      pressure->invoked_flag |= Compute::INVOKED_VECTOR;
     }
     compute_pxz();
 
@@ -1455,9 +1452,9 @@ int Thermo::evaluate_keyword(const char *word, double *answer)
       if (pressure->invoked_vector != update->ntimestep)
         error->all(FLERR,"Compute used in variable thermo keyword between runs "
                    "is not current");
-    } else if (!(pressure->invoked_flag & INVOKED_VECTOR)) {
+    } else if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
       pressure->compute_vector();
-      pressure->invoked_flag |= INVOKED_VECTOR;
+      pressure->invoked_flag |= Compute::INVOKED_VECTOR;
     }
     compute_pyz();
   }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -72,10 +72,6 @@ enum{DONE,ADD,SUBTRACT,MULTIPLY,DIVIDE,CARAT,MODULO,UNARY,
 
 enum{SUM,XMIN,XMAX,AVE,TRAP,SLOPE};
 
-#define INVOKED_SCALAR 1
-#define INVOKED_VECTOR 2
-#define INVOKED_ARRAY 4
-#define INVOKED_PERATOM 8
 
 #define BIG 1.0e20
 
@@ -1380,9 +1376,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_scalar != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable between "
                               "runs is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_SCALAR)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
             compute->compute_scalar();
-            compute->invoked_flag |= INVOKED_SCALAR;
+            compute->invoked_flag |= Compute::INVOKED_SCALAR;
           }
 
           value1 = compute->scalar;
@@ -1407,9 +1403,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_vector != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable between runs "
                               "is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
-            compute->invoked_flag |= INVOKED_VECTOR;
+            compute->invoked_flag |= Compute::INVOKED_VECTOR;
           }
 
           if (compute->size_vector_variable &&
@@ -1439,9 +1435,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_array != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable between runs "
                               "is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
-            compute->invoked_flag |= INVOKED_ARRAY;
+            compute->invoked_flag |= Compute::INVOKED_ARRAY;
           }
 
           if (compute->size_array_rows_variable &&
@@ -1473,9 +1469,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_vector != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable between "
                               "runs is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
-            compute->invoked_flag |= INVOKED_VECTOR;
+            compute->invoked_flag |= Compute::INVOKED_VECTOR;
           }
 
           Tree *newtree = new Tree();
@@ -1505,9 +1501,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_array != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable between "
                               "runs is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
-            compute->invoked_flag |= INVOKED_ARRAY;
+            compute->invoked_flag |= Compute::INVOKED_ARRAY;
           }
 
           Tree *newtree = new Tree();
@@ -1529,9 +1525,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_peratom != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable "
                               "between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
-            compute->invoked_flag |= INVOKED_PERATOM;
+            compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
 
           peratom2global(1,nullptr,compute->vector_atom,1,index1,
@@ -1549,9 +1545,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_peratom != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable "
                               "between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
-            compute->invoked_flag |= INVOKED_PERATOM;
+            compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
 
           if (compute->array_atom)
@@ -1578,9 +1574,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_peratom != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable "
                               "between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
-            compute->invoked_flag |= INVOKED_PERATOM;
+            compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
 
           Tree *newtree = new Tree();
@@ -1610,9 +1606,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             if (compute->invoked_peratom != update->ntimestep)
               print_var_error(FLERR,"Compute used in variable "
                               "between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & INVOKED_PERATOM)) {
+          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
-            compute->invoked_flag |= INVOKED_PERATOM;
+            compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
 
           Tree *newtree = new Tree();
@@ -4137,9 +4133,9 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
           if (compute->invoked_vector != update->ntimestep)
             print_var_error(FLERR,"Compute used in variable between runs "
                             "is not current",ivar);
-        } else if (!(compute->invoked_flag & INVOKED_VECTOR)) {
+        } else if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
-          compute->invoked_flag |= INVOKED_VECTOR;
+          compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
         nvec = compute->size_vector;
         nstride = 1;
@@ -4151,9 +4147,9 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
           if (compute->invoked_array != update->ntimestep)
             print_var_error(FLERR,"Compute used in variable between runs "
                             "is not current",ivar);
-        } else if (!(compute->invoked_flag & INVOKED_ARRAY)) {
+        } else if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
-          compute->invoked_flag |= INVOKED_ARRAY;
+          compute->invoked_flag |= Compute::INVOKED_ARRAY;
         }
         nvec = compute->size_array_rows;
         nstride = compute->size_array_cols;


### PR DESCRIPTION
**Summary**

This avoids inconsistencies and having to make redundant definitions of the various "invoked" bitmap constants by defining them in the `compute.h` header file as enumerator. That also puts those into the Compute:: scope. In addition a `INVOKED_NONE` constant was defined to clear the bitmap.

**Related Issue(s)**

This is another item addressing issue #325

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

 All replacements were done automatically with
```
sed -i -e '/^#define INVOKED_.*$/d' -e 's/INVOKED_\([A-Z]\+\)/Compute::INVOKED_\1/g' $(grep -l INVOKED_ src/*.cpp src/*/*.cpp)
```

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
