### PR TITLE
Clarify one of the outputs of fix ti/spring

### DIFF
--- a/doc/src/fix_ti_spring.rst
+++ b/doc/src/fix_ti_spring.rst
@@ -120,22 +120,28 @@ increase in computational resources cost.
 Restart, fix_modify, output, run start/stop, minimize info
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-This fix writes the original coordinates of tethered atoms to :doc:`binary restart files <restart>`, so that the spring effect will be the
-same in a restarted simulation. See the :doc:`read restart <read_restart>` command for info on how to re-specify a fix
-in an input script that reads a restart file, so that the operation of
-the fix continues in an uninterrupted fashion.
+This fix writes the original coordinates of tethered atoms to
+:doc:`binary restart files <restart>`, so that the spring effect will
+be the same in a restarted simulation. See the :doc:`read restart
+<read_restart>` command for info on how to re-specify a fix in an
+input script that reads a restart file, so that the operation of the
+fix continues in an uninterrupted fashion.
 
-The :doc:`fix modify <fix_modify>` *energy* option is supported by this
-fix to add the energy stored in the per-atom springs to the system's
-potential energy as part of :doc:`thermodynamic output <thermo_style>`.
+The :doc:`fix modify <fix_modify>` *energy* option is supported by
+this fix to add the energy stored in the per-atom springs to the
+system's potential energy as part of :doc:`thermodynamic output
+<thermo_style>`.
 
 This fix computes a global scalar and a global vector quantities which
 can be accessed by various :doc:`output commands <Howto_output>`. The
 scalar is an energy which is the sum of the spring energy for each
-atom, where the per-atom energy is 0.5 \* k \* r\^2. The vector has 2
-positions, the first one is the coupling parameter lambda and the
-second one is the time derivative of lambda. The scalar and vector
-values calculated by this fix are "extensive".
+atom, where the per-atom energy is 0.5 \* k \* r\^2. The vector stores
+2 values.  The first value is the coupling parameter lambda.  The
+second value is the derivative of lambda with respect to the integer
+timestep *s*, i.e. d lambda / ds.  In order to obtain d lambda / dt,
+where t is simulation time, this 2nd value needs to be divided by the
+timestep size (e.g. 0.5 fs).  The scalar and vector values calculated
+by this fix are "extensive".
 
 No parameter of this fix can be used with the *start/stop* keywords of
 the :doc:`run <run>` command.


### PR DESCRIPTION
**Summary**

As flagged in issue #2574, the doc page for fix ti/spring is unclear on one of its vector outputs.  This PR edits the doc page to make it more clear.  Specifcally the 2nd vector output is not the derivative of lambda wrt time, but wrt to the integer timestep.

**Related Issue(s)**

This closes #2574

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


