### PR TITLE
Pair kim refactor

### DIFF
--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -877,7 +877,7 @@ void PairKIM::kim_init()
     &modelWillNotRequestNeighborsOfNoncontributingParticles);
   if (neighborLists) {
     delete [] neighborLists;
-    neighborLists = nulptr;
+    neighborLists = nullptr;
   }
   neighborLists = new NeighList*[kim_number_of_neighbor_lists];
 

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -540,6 +540,19 @@ void PairKIM::coeff(int narg, char **arg)
     kimerror = KIM_Model_ClearThenRefresh(pkim);
     if (kimerror)
       error->all(FLERR,"KIM KIM_Model_ClearThenRefresh returned error");
+
+    // Update cached quantities that may have changed due to Refresh
+    KIM_Model_GetInfluenceDistance(pkim, &kim_global_influence_distance);
+    KIM_Model_GetNeighborListPointers(
+        pkim,
+        &kim_number_of_neighbor_lists,
+        &kim_cutoff_values,
+        &modelWillNotRequestNeighborsOfNoncontributingParticles);
+    if (neighborLists) {
+      delete [] neighborLists;
+      neighborLists = 0;
+    }
+    neighborLists = new NeighList*[kim_number_of_neighbor_lists];
   }
 }
 
@@ -809,6 +822,8 @@ void PairKIM::kim_free()
       error->all(FLERR,"Unable to destroy Compute Arguments Object");
 
     KIM_Model_Destroy(&pkim);
+
+    lmps_maxalloc = 0;
   }
   kim_init_ok = false;
 }

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -550,7 +550,7 @@ void PairKIM::coeff(int narg, char **arg)
         &modelWillNotRequestNeighborsOfNoncontributingParticles);
     if (neighborLists) {
       delete [] neighborLists;
-      neighborLists = 0;
+      neighborLists = nullptr;
     }
     neighborLists = new NeighList*[kim_number_of_neighbor_lists];
   }
@@ -604,6 +604,9 @@ void PairKIM::init_style()
     neighbor->requests[irequest]->cutoff
       = kim_cutoff_values[i] + neighbor->skin;
   }
+  // increment instance_me in case of need to change the neighbor list
+  // request settings
+  instance_me += 1;
 }
 
 /* ----------------------------------------------------------------------
@@ -823,7 +826,7 @@ void PairKIM::kim_free()
 
     KIM_Model_Destroy(&pkim);
 
-    lmps_maxalloc = 0;
+    lmps_maxalloc = 0;  // reinitialize member variable
   }
   kim_init_ok = false;
 }
@@ -874,7 +877,7 @@ void PairKIM::kim_init()
     &modelWillNotRequestNeighborsOfNoncontributingParticles);
   if (neighborLists) {
     delete [] neighborLists;
-    neighborLists = 0;
+    neighborLists = nulptr;
   }
   neighborLists = new NeighList*[kim_number_of_neighbor_lists];
 

--- a/unittest/commands/test_kim_commands.cpp
+++ b/unittest/commands/test_kim_commands.cpp
@@ -219,6 +219,20 @@ TEST_F(KimCommandsTest, kim_interactions)
 
     int ifix = lmp->modify->find_fix("KIM_MODEL_STORE");
     ASSERT_GE(ifix, 0);
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("clear");
+    lmp->input->one("kim_init LennardJones_Ar real");
+    lmp->input->one("lattice fcc 4.4300");
+    lmp->input->one("region box block 0 10 0 10 0 10");
+    lmp->input->one("create_box 1 box");
+    lmp->input->one("create_atoms 1 box");
+    lmp->input->one("kim_interactions Ar");
+    lmp->input->one("mass 1 39.95");
+    lmp->input->one("run 1");
+    lmp->input->one("kim_interactions Ar");
+    lmp->input->one("run 1");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
 }
 
 TEST_F(KimCommandsTest, kim_param)


### PR DESCRIPTION
**Summary**

Fix up some behavior of pair_kim to better support changing parameters of a KIM model and to correctly support the use of multiple calls to `pair_style kim`
**Related Issue(s)**

n/a

**Author(s)**

Ryan S. Elliott (UMinn)
Yaser Afshar (UMinn)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

no issues

**Implementation Notes**

use increments of `instance_me` to ensure neighbor list requests are updated appropriately.
