### PR TITLE
Simplify some internal string processing

### DIFF
--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -71,6 +71,9 @@ and parsing files or arguments.
 
 ----------
 
+.. doxygenfunction:: strdup
+   :project: progguide
+
 .. doxygenfunction:: trim
    :project: progguide
 

--- a/src/BODY/compute_body_local.cpp
+++ b/src/BODY/compute_body_local.cpp
@@ -226,6 +226,6 @@ void ComputeBodyLocal::reallocate(int n)
 
 double ComputeBodyLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -793,6 +793,6 @@ void PairGranHookeHistory::unpack_forward_comm(int n, int first, double *buf)
 
 double PairGranHookeHistory::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -1759,7 +1759,7 @@ void PairGranular::unpack_forward_comm(int n, int first, double *buf)
 
 double PairGranular::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }
 

--- a/src/KIM/kim_init.cpp
+++ b/src/KIM/kim_init.cpp
@@ -86,10 +86,8 @@ void KimInit::command(int narg, char **arg)
   if (domain->box_exist)
     error->all(FLERR,"Must use 'kim_init' command before "
                      "simulation box is defined");
-  char *model_name = new char[strlen(arg[0])+1];
-  strcpy(model_name,arg[0]);
-  char *user_units = new char[strlen(arg[1])+1];
-  strcpy(user_units,arg[1]);
+  char *model_name = utils::strdup(arg[0]);
+  char *user_units = utils::strdup(arg[1]);
   if (narg == 3) {
     if (strcmp(arg[2],"unit_conversion_mode")==0) unit_conversion_mode = true;
     else {
@@ -214,8 +212,7 @@ void KimInit::determine_model_type_and_units(char * model_name,
     if (units_accepted) {
       logID = fmt::format("{}_Model", comm->me);
       KIM_Model_SetLogID(pkim, logID.c_str());
-      *model_units = new char[strlen(user_units)+1];
-      strcpy(*model_units,user_units);
+      *model_units = utils::strdup(user_units);
       return;
     } else if (unit_conversion_mode) {
       KIM_Model_Destroy(&pkim);
@@ -237,8 +234,7 @@ void KimInit::determine_model_type_and_units(char * model_name,
         if (units_accepted) {
           logID = fmt::format("{}_Model", comm->me);
           KIM_Model_SetLogID(pkim, logID.c_str());
-          *model_units = new char[strlen(systems[i])+1];
-          strcpy(*model_units,systems[i]);
+          *model_units = utils::strdup(systems[i]);
           return;
         }
         KIM_Model_Destroy(&pkim);
@@ -272,9 +268,7 @@ void KimInit::determine_model_type_and_units(char * model_name,
       if (0 == strcmp(sim_field,"units")) {
         KIM_SimulatorModel_GetSimulatorFieldLine(
           simulatorModel, i, 0, &sim_value);
-        int len=strlen(sim_value)+1;
-        *model_units = new char[len];
-        strcpy(*model_units,sim_value);
+        *model_units = utils::strdup(sim_value);
         break;
       }
     }

--- a/src/KOKKOS/fix_neigh_history_kokkos.cpp
+++ b/src/KOKKOS/fix_neigh_history_kokkos.cpp
@@ -243,7 +243,7 @@ void FixNeighHistoryKokkos<DeviceType>::post_neighbor_item(const int &ii) const
 template<class DeviceType>
 double FixNeighHistoryKokkos<DeviceType>::memory_usage()
 {
-  double bytes = d_firstflag.extent(0)*d_firstflag.extent(1)*sizeof(int);
+  double bytes = (double)d_firstflag.extent(0)*d_firstflag.extent(1)*sizeof(int);
   bytes += (double)d_firstvalue.extent(0)*d_firstvalue.extent(1)*sizeof(double);
   bytes += (double)2*k_npartner.extent(0)*sizeof(int);
   bytes += (double)2*k_partner.extent(0)*k_partner.extent(1)*sizeof(int);

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -2873,7 +2873,7 @@ int PPPMKokkos<DeviceType>::timing_3d(int n, double &time3d)
 template<class DeviceType>
 double PPPMKokkos<DeviceType>::memory_usage()
 {
-  double bytes = nmax*3 * sizeof(double);
+  double bytes = (double)nmax*3 * sizeof(double);
   int nbrick = (nxhi_out-nxlo_out+1) * (nyhi_out-nylo_out+1) *
     (nzhi_out-nzlo_out+1);
   bytes += (double)4 * nbrick * sizeof(FFT_SCALAR);

--- a/src/KSPACE/pair_lj_cut_tip4p_long.cpp
+++ b/src/KSPACE/pair_lj_cut_tip4p_long.cpp
@@ -603,7 +603,7 @@ void *PairLJCutTIP4PLong::extract(const char *str, int &dim)
 
 double PairLJCutTIP4PLong::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/KSPACE/pair_lj_long_tip4p_long.cpp
+++ b/src/KSPACE/pair_lj_long_tip4p_long.cpp
@@ -1636,7 +1636,7 @@ void *PairLJLongTIP4PLong::extract(const char *str, int &dim)
 
 double PairLJLongTIP4PLong::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/KSPACE/pair_tip4p_long.cpp
+++ b/src/KSPACE/pair_tip4p_long.cpp
@@ -523,7 +523,7 @@ void *PairTIP4PLong::extract(const char *str, int &dim)
 
 double PairTIP4PLong::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -3057,7 +3057,7 @@ int PPPM::timing_3d(int n, double &time3d)
 
 double PPPM::memory_usage()
 {
-  double bytes = nmax*3 * sizeof(double);
+  double bytes = (double)nmax*3 * sizeof(double);
 
   int nbrick = (nxhi_out-nxlo_out+1) * (nyhi_out-nylo_out+1) *
     (nzhi_out-nzlo_out+1);

--- a/src/KSPACE/pppm_dipole.cpp
+++ b/src/KSPACE/pppm_dipole.cpp
@@ -2507,7 +2507,7 @@ int PPPMDipole::timing_3d(int n, double &time3d)
 
 double PPPMDipole::memory_usage()
 {
-  double bytes = nmax*3 * sizeof(double);
+  double bytes = (double)nmax*3 * sizeof(double);
 
   int nbrick = (nxhi_out-nxlo_out+1) * (nyhi_out-nylo_out+1) *
     (nzhi_out-nzlo_out+1);

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -8298,7 +8298,7 @@ int PPPMDisp::timing_3d(int n, double &time3d)
 
 double PPPMDisp::memory_usage()
 {
-  double bytes = nmax*3 * sizeof(double);
+  double bytes = (double)nmax*3 * sizeof(double);
 
   int mixing = 1;
   int diff = 3;     //depends on differentiation

--- a/src/MANYBODY/fix_qeq_comb.cpp
+++ b/src/MANYBODY/fix_qeq_comb.cpp
@@ -284,7 +284,7 @@ void FixQEQComb::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 
 double FixQEQComb::memory_usage()
 {
-  double bytes = atom->nmax*3 * sizeof(double);
+  double bytes = (double)atom->nmax*3 * sizeof(double);
   return bytes;
 }
 /* ---------------------------------------------------------------------- */

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -2098,7 +2098,7 @@ void PairComb::Short_neigh()
 
 double PairComb::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)nmax * sizeof(int);
   bytes += (double)nmax * sizeof(int *);

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -3850,7 +3850,7 @@ void PairComb3::unpack_reverse_comm(int n, int *list, double *buf)
 
 double PairComb3::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)nmax * sizeof(int);
   bytes += (double)nmax * 8.0 * sizeof(double);

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -913,7 +913,7 @@ void PairEAM::unpack_reverse_comm(int n, int *list, double *buf)
 
 double PairEAM::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/MANYBODY/pair_eim.cpp
+++ b/src/MANYBODY/pair_eim.cpp
@@ -1044,7 +1044,7 @@ void PairEIM::unpack_reverse_comm(int n, int *list, double *buf)
 
 double PairEIM::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -753,7 +753,7 @@ double FixAtomSwap::compute_vector(int n)
 
 double FixAtomSwap::memory_usage()
 {
-  double bytes = atom_swap_nmax * sizeof(int);
+  double bytes = (double)atom_swap_nmax * sizeof(int);
   return bytes;
 }
 

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -1427,7 +1427,7 @@ double FixBondCreate::compute_vector(int n)
 double FixBondCreate::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes = 2*nmax * sizeof(tagint);
   bytes += (double)nmax * sizeof(double);
   return bytes;

--- a/src/MC/fix_bond_swap.cpp
+++ b/src/MC/fix_bond_swap.cpp
@@ -727,6 +727,6 @@ double FixBondSwap::compute_vector(int n)
 
 double FixBondSwap::memory_usage()
 {
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   return bytes;
 }

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -2515,7 +2515,7 @@ double FixGCMC::compute_vector(int n)
 
 double FixGCMC::memory_usage()
 {
-  double bytes = gcmc_nmax * sizeof(int);
+  double bytes = (double)gcmc_nmax * sizeof(int);
   return bytes;
 }
 

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -1177,7 +1177,7 @@ double FixWidom::compute_vector(int n)
 
 double FixWidom::memory_usage()
 {
-  double bytes = widom_nmax * sizeof(int);
+  double bytes = (double)widom_nmax * sizeof(int);
   return bytes;
 }
 

--- a/src/MISC/fix_efield.cpp
+++ b/src/MISC/fix_efield.cpp
@@ -60,27 +60,21 @@ FixEfield::FixEfield(LAMMPS *lmp, int narg, char **arg) :
   xstr = ystr = zstr = nullptr;
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    xstr = new char[n];
-    strcpy(xstr,&arg[3][2]);
+    xstr = utils::strdup(arg[3]+2);
   } else {
     ex = qe2f * utils::numeric(FLERR,arg[3],false,lmp);
     xstyle = CONSTANT;
   }
 
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(&arg[4][2]) + 1;
-    ystr = new char[n];
-    strcpy(ystr,&arg[4][2]);
+    ystr = utils::strdup(arg[4]+2);
   } else {
     ey = qe2f * utils::numeric(FLERR,arg[4],false,lmp);
     ystyle = CONSTANT;
   }
 
   if (utils::strmatch(arg[5],"^v_")) {
-    int n = strlen(&arg[5][2]) + 1;
-    zstr = new char[n];
-    strcpy(zstr,&arg[5][2]);
+    zstr = utils::strdup(arg[5]+2);
   } else {
     ez = qe2f * utils::numeric(FLERR,arg[5],false,lmp);
     zstyle = CONSTANT;
@@ -99,16 +93,12 @@ FixEfield::FixEfield(LAMMPS *lmp, int narg, char **arg) :
       iregion = domain->find_region(arg[iarg+1]);
       if (iregion == -1)
         error->all(FLERR,"Region ID for fix efield does not exist");
-      int n = strlen(arg[iarg+1]) + 1;
-      idregion = new char[n];
-      strcpy(idregion,arg[iarg+1]);
+      idregion = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else if (strcmp(arg[iarg],"energy") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix efield command");
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        estr = new char[n];
-        strcpy(estr,&arg[iarg+1][2]);
+        estr = utils::strdup(arg[iarg+1]+2);
       } else error->all(FLERR,"Illegal fix efield command");
       iarg += 2;
     } else error->all(FLERR,"Illegal fix efield command");

--- a/src/MISC/fix_efield.cpp
+++ b/src/MISC/fix_efield.cpp
@@ -59,7 +59,7 @@ FixEfield::FixEfield(LAMMPS *lmp, int narg, char **arg) :
   qe2f = force->qe2f;
   xstr = ystr = zstr = nullptr;
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     xstr = new char[n];
     strcpy(xstr,&arg[3][2]);
@@ -68,7 +68,7 @@ FixEfield::FixEfield(LAMMPS *lmp, int narg, char **arg) :
     xstyle = CONSTANT;
   }
 
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(&arg[4][2]) + 1;
     ystr = new char[n];
     strcpy(ystr,&arg[4][2]);
@@ -77,7 +77,7 @@ FixEfield::FixEfield(LAMMPS *lmp, int narg, char **arg) :
     ystyle = CONSTANT;
   }
 
-  if (strstr(arg[5],"v_") == arg[5]) {
+  if (utils::strmatch(arg[5],"^v_")) {
     int n = strlen(&arg[5][2]) + 1;
     zstr = new char[n];
     strcpy(zstr,&arg[5][2]);
@@ -105,7 +105,7 @@ FixEfield::FixEfield(LAMMPS *lmp, int narg, char **arg) :
       iarg += 2;
     } else if (strcmp(arg[iarg],"energy") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix efield command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         estr = new char[n];
         strcpy(estr,&arg[iarg+1][2]);

--- a/src/MISC/fix_gld.cpp
+++ b/src/MISC/fix_gld.cpp
@@ -487,7 +487,7 @@ void FixGLD::reset_dt()
 
 double FixGLD::memory_usage()
 {
-  double bytes = atom->nmax*3*prony_terms*sizeof(double);
+  double bytes = (double)atom->nmax*3*prony_terms*sizeof(double);
   return bytes;
 }
 

--- a/src/MISC/fix_orient_bcc.cpp
+++ b/src/MISC/fix_orient_bcc.cpp
@@ -596,7 +596,7 @@ int FixOrientBCC::compare(const void *pi, const void *pj)
 
 double FixOrientBCC::memory_usage()
 {
-  double bytes = nmax * sizeof(Nbr);
+  double bytes = (double)nmax * sizeof(Nbr);
   bytes += (double)2*nmax * sizeof(double);
   return bytes;
 }

--- a/src/MISC/fix_orient_fcc.cpp
+++ b/src/MISC/fix_orient_fcc.cpp
@@ -594,7 +594,7 @@ int FixOrientFCC::compare(const void *pi, const void *pj)
 
 double FixOrientFCC::memory_usage()
 {
-  double bytes = nmax * sizeof(Nbr);
+  double bytes = (double)nmax * sizeof(Nbr);
   bytes += (double)2*nmax * sizeof(double);
   return bytes;
 }

--- a/src/MLIAP/compute_mliap.cpp
+++ b/src/MLIAP/compute_mliap.cpp
@@ -357,7 +357,7 @@ void ComputeMLIAP::compute_array()
 double ComputeMLIAP::memory_usage()
 {
 
-  double bytes = size_array_rows*size_array_cols *
+  double bytes = (double)size_array_rows*size_array_cols *
     sizeof(double);                                   // mliaparray
   bytes += (double)size_array_rows*size_array_cols *
     sizeof(double);                                   // mliaparrayall

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -1440,7 +1440,7 @@ int FixCMAP::unpack_exchange(int nlocal, double *buf)
 double FixCMAP::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);        // num_crossterm
+  double bytes = (double)nmax * sizeof(int);        // num_crossterm
   bytes += (double)nmax*CMAPMAX * sizeof(int);      // crossterm_type
   bytes += (double)5*nmax*CMAPMAX * sizeof(int);    // crossterm_atom 12345
   bytes += (double)maxcrossterm*6 * sizeof(int);    // crosstermlist

--- a/src/MOLECULE/pair_lj_cut_tip4p_cut.cpp
+++ b/src/MOLECULE/pair_lj_cut_tip4p_cut.cpp
@@ -748,7 +748,7 @@ void *PairLJCutTIP4PCut::extract(const char *str, int &dim)
 
 double PairLJCutTIP4PCut::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/MOLECULE/pair_tip4p_cut.cpp
+++ b/src/MOLECULE/pair_tip4p_cut.cpp
@@ -550,7 +550,7 @@ void PairTIP4PCut::compute_newsite(double *xO,  double *xH1,
 
 double PairTIP4PCut::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/PERI/compute_damage_atom.cpp
+++ b/src/PERI/compute_damage_atom.cpp
@@ -120,6 +120,6 @@ void ComputeDamageAtom::compute_peratom()
 
 double ComputeDamageAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/PERI/compute_dilatation_atom.cpp
+++ b/src/PERI/compute_dilatation_atom.cpp
@@ -117,6 +117,6 @@ void ComputeDilatationAtom::compute_peratom()
 
 double ComputeDilatationAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/PERI/compute_plasticity_atom.cpp
+++ b/src/PERI/compute_plasticity_atom.cpp
@@ -103,6 +103,6 @@ void ComputePlasticityAtom::compute_peratom()
 
 double ComputePlasticityAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/PERI/pair_peri_pmb.cpp
+++ b/src/PERI/pair_peri_pmb.cpp
@@ -493,6 +493,6 @@ double PairPeriPMB::single(int i, int j, int itype, int jtype, double rsq,
 
 double PairPeriPMB::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/POEMS/fix_poems.cpp
+++ b/src/POEMS/fix_poems.cpp
@@ -1525,7 +1525,7 @@ void FixPOEMS::copy_arrays(int i, int j, int /* delflag */)
 double FixPOEMS::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes += (double)nmax*MAXBODY * sizeof(int);
   bytes += (double)nmax*3 * sizeof(double);
   return bytes;

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -184,9 +184,7 @@ void PythonImpl::command(int narg, char **arg)
       iarg += 2;
     } else if (strcmp(arg[iarg],"format") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Invalid python command");
-      int n = strlen(arg[iarg+1]) + 1;
-      format = new char[n];
-      strcpy(format,arg[iarg+1]);
+      format = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else if (strcmp(arg[iarg],"length") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Invalid python command");
@@ -196,9 +194,7 @@ void PythonImpl::command(int narg, char **arg)
     } else if (strcmp(arg[iarg],"file") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Invalid python command");
       delete[] pyfile;
-      int n = strlen(arg[iarg+1]) + 1;
-      pyfile = new char[n];
-      strcpy(pyfile,arg[iarg+1]);
+      pyfile = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else if (strcmp(arg[iarg],"here") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Invalid python command");
@@ -424,9 +420,7 @@ int PythonImpl::create_entry(char *name)
     nfunc++;
     pfuncs = (PyFunc *)
       memory->srealloc(pfuncs,nfunc*sizeof(struct PyFunc),"python:pfuncs");
-    int n = strlen(name) + 1;
-    pfuncs[ifunc].name = new char[n];
-    strcpy(pfuncs[ifunc].name,name);
+    pfuncs[ifunc].name = utils::strdup(name);
   } else deallocate(ifunc);
 
   pfuncs[ifunc].ninput = ninput;
@@ -452,9 +446,7 @@ int PythonImpl::create_entry(char *name)
       pfuncs[ifunc].itype[i] = INT;
       if (utils::strmatch(istr[i],"^v_")) {
         pfuncs[ifunc].ivarflag[i] = 1;
-        int n = strlen(&istr[i][2]) + 1;
-        pfuncs[ifunc].svalue[i] = new char[n];
-        strcpy(pfuncs[ifunc].svalue[i],&istr[i][2]);
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i]+2);
       } else {
         pfuncs[ifunc].ivarflag[i] = 0;
         pfuncs[ifunc].ivalue[i] = utils::inumeric(FLERR,istr[i],false,lmp);
@@ -463,9 +455,7 @@ int PythonImpl::create_entry(char *name)
       pfuncs[ifunc].itype[i] = DOUBLE;
       if (utils::strmatch(istr[i],"^v_")) {
         pfuncs[ifunc].ivarflag[i] = 1;
-        int n = strlen(&istr[i][2]) + 1;
-        pfuncs[ifunc].svalue[i] = new char[n];
-        strcpy(pfuncs[ifunc].svalue[i],&istr[i][2]);
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i]+2);
       } else {
         pfuncs[ifunc].ivarflag[i] = 0;
         pfuncs[ifunc].dvalue[i] = utils::numeric(FLERR,istr[i],false,lmp);
@@ -474,14 +464,10 @@ int PythonImpl::create_entry(char *name)
       pfuncs[ifunc].itype[i] = STRING;
       if (utils::strmatch(istr[i],"^v_")) {
         pfuncs[ifunc].ivarflag[i] = 1;
-        int n = strlen(&istr[i][2]) + 1;
-        pfuncs[ifunc].svalue[i] = new char[n];
-        strcpy(pfuncs[ifunc].svalue[i],&istr[i][2]);
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i]+2);
       } else {
         pfuncs[ifunc].ivarflag[i] = 0;
-        int n = strlen(istr[i]) + 1;
-        pfuncs[ifunc].svalue[i] = new char[n];
-        strcpy(pfuncs[ifunc].svalue[i],istr[i]);
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i]);
       }
     } else if (type == 'p') {
       pfuncs[ifunc].ivarflag[i] = 0;
@@ -513,9 +499,7 @@ int PythonImpl::create_entry(char *name)
   }
 
   if (strstr(ostr,"v_") != ostr) error->all(FLERR,"Invalid python command");
-  int n = strlen(&ostr[2]) + 1;
-  pfuncs[ifunc].ovarname = new char[n];
-  strcpy(pfuncs[ifunc].ovarname,&ostr[2]);
+  pfuncs[ifunc].ovarname = utils::strdup(ostr+2);
 
   return ifunc;
 }

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -450,7 +450,7 @@ int PythonImpl::create_entry(char *name)
     char type = format[i];
     if (type == 'i') {
       pfuncs[ifunc].itype[i] = INT;
-      if (strstr(istr[i],"v_") == istr[i]) {
+      if (utils::strmatch(istr[i],"^v_")) {
         pfuncs[ifunc].ivarflag[i] = 1;
         int n = strlen(&istr[i][2]) + 1;
         pfuncs[ifunc].svalue[i] = new char[n];
@@ -461,7 +461,7 @@ int PythonImpl::create_entry(char *name)
       }
     } else if (type == 'f') {
       pfuncs[ifunc].itype[i] = DOUBLE;
-      if (strstr(istr[i],"v_") == istr[i]) {
+      if (utils::strmatch(istr[i],"^v_")) {
         pfuncs[ifunc].ivarflag[i] = 1;
         int n = strlen(&istr[i][2]) + 1;
         pfuncs[ifunc].svalue[i] = new char[n];
@@ -472,7 +472,7 @@ int PythonImpl::create_entry(char *name)
       }
     } else if (type == 's') {
       pfuncs[ifunc].itype[i] = STRING;
-      if (strstr(istr[i],"v_") == istr[i]) {
+      if (utils::strmatch(istr[i],"^v_")) {
         pfuncs[ifunc].ivarflag[i] = 1;
         int n = strlen(&istr[i][2]) + 1;
         pfuncs[ifunc].svalue[i] = new char[n];

--- a/src/REPLICA/fix_hyper_global.cpp
+++ b/src/REPLICA/fix_hyper_global.cpp
@@ -559,6 +559,6 @@ double FixHyperGlobal::query(int i)
 
 double FixHyperGlobal::memory_usage()
 {
-  double bytes = maxbond * sizeof(OneBond);    // blist
+  double bytes = (double)maxbond * sizeof(OneBond);    // blist
   return bytes;
 }

--- a/src/REPLICA/fix_hyper_local.cpp
+++ b/src/REPLICA/fix_hyper_local.cpp
@@ -1731,7 +1731,7 @@ double FixHyperLocal::query(int i)
 
 double FixHyperLocal::memory_usage()
 {
-  double bytes = maxbond * sizeof(OneBond);       // blist
+  double bytes = (double)maxbond * sizeof(OneBond);       // blist
   bytes = maxbond * sizeof(double);               // per-bond bias coeffs
   bytes += (double)3*maxlocal * sizeof(int);              // numbond,maxhalf,eligible
   bytes += (double)maxlocal * sizeof(double);             // maxhalfstrain

--- a/src/REPLICA/verlet_split.cpp
+++ b/src/REPLICA/verlet_split.cpp
@@ -582,6 +582,6 @@ void VerletSplit::k2r_comm()
 
 double VerletSplit::memory_usage()
 {
-  double bytes = maxatom*3 * sizeof(double);
+  double bytes = (double)maxatom*3 * sizeof(double);
   return bytes;
 }

--- a/src/RIGID/compute_rigid_local.cpp
+++ b/src/RIGID/compute_rigid_local.cpp
@@ -315,6 +315,6 @@ void ComputeRigidLocal::reallocate(int n)
 
 double ComputeRigidLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -129,7 +129,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
 
       // determine whether atom-style variable or atom property is used
 
-      if (strstr(arg[4],"i_") == arg[4]) {
+      if (utils::strmatch(arg[4],"^i_")) {
         int is_double=0;
         int custom_index = atom->find_custom(arg[4]+2,is_double);
         if (custom_index == -1)
@@ -151,7 +151,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
           else
             molecule[i] = 0;
 
-      } else if (strstr(arg[4],"v_") == arg[4]) {
+      } else if (utils::strmatch(arg[4],"^v_")) {
         int ivariable = input->variable->find(arg[4]+2);
         if (ivariable < 0)
           error->all(FLERR,"Variable name for fix rigid custom does not exist");

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -502,9 +502,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
       else {
         allremap = 0;
         delete [] id_dilate;
-        int n = strlen(arg[iarg+1]) + 1;
-        id_dilate = new char[n];
-        strcpy(id_dilate,arg[iarg+1]);
+        id_dilate = utils::strdup(arg[iarg+1]);
         int idilate = group->find(id_dilate);
         if (idilate == -1)
           error->all(FLERR,
@@ -531,9 +529,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"infile") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix rigid command");
       delete [] inpfile;
-      int n = strlen(arg[iarg+1]) + 1;
-      inpfile = new char[n];
-      strcpy(inpfile,arg[iarg+1]);
+      inpfile = utils::strdup(arg[iarg+1]);
       restart_file = 1;
       reinitflag = 0;
       iarg += 2;
@@ -548,9 +544,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"gravity") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix rigid command");
       delete [] id_gravity;
-      int n = strlen(arg[iarg+1]) + 1;
-      id_gravity = new char[n];
-      strcpy(id_gravity,arg[iarg+1]);
+      id_gravity = utils::strdup(arg[iarg+1]);
       iarg += 2;
 
     } else error->all(FLERR,"Illegal fix rigid command");

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -2452,7 +2452,7 @@ void FixRigid::write_restart_file(const char *file)
 double FixRigid::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes += (double)nmax * sizeof(imageint);
   bytes += (double)nmax*3 * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);    // vatom

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -13,37 +13,34 @@
 
 #include "fix_rigid_small.h"
 
-#include <cmath>
-
-#include <cstring>
-#include <utility>
-#include "math_extra.h"
-#include "math_eigen.h"
 #include "atom.h"
 #include "atom_vec_ellipsoid.h"
 #include "atom_vec_line.h"
 #include "atom_vec_tri.h"
-#include "molecule.h"
-#include "domain.h"
-#include "update.h"
-#include "respa.h"
-#include "modify.h"
-#include "group.h"
 #include "comm.h"
-#include "neighbor.h"
-#include "force.h"
-#include "input.h"
-#include "variable.h"
-#include "random_mars.h"
-#include "math_const.h"
-#include "hashlittle.h"
-#include "memory.h"
+#include "domain.h"
 #include "error.h"
+#include "force.h"
+#include "group.h"
+#include "hashlittle.h"
+#include "input.h"
+#include "math_const.h"
+#include "math_eigen.h"
+#include "math_extra.h"
+#include "memory.h"
+#include "modify.h"
+#include "molecule.h"
+#include "neighbor.h"
+#include "random_mars.h"
+#include "respa.h"
 #include "rigid_const.h"
+#include "update.h"
+#include "variable.h"
 
-
-
+#include <cmath>
+#include <cstring>
 #include <map>
+#include <utility>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -223,9 +220,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"infile") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix rigid/small command");
       delete [] inpfile;
-      int n = strlen(arg[iarg+1]) + 1;
-      inpfile = new char[n];
-      strcpy(inpfile,arg[iarg+1]);
+      inpfile = utils::strdup(arg[iarg+1]);
       restart_file = 1;
       reinitflag = 0;
       iarg += 2;
@@ -336,9 +331,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
       else {
         allremap = 0;
         delete [] id_dilate;
-        int n = strlen(arg[iarg+1]) + 1;
-        id_dilate = new char[n];
-        strcpy(id_dilate,arg[iarg+1]);
+        id_dilate = utils::strdup(arg[iarg+1]);
         int idilate = group->find(id_dilate);
         if (idilate == -1)
           error->all(FLERR,"Fix rigid/small nvt/npt/nph dilate group ID "
@@ -365,9 +358,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"gravity") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix rigid/small command");
       delete [] id_gravity;
-      int n = strlen(arg[iarg+1]) + 1;
-      id_gravity = new char[n];
-      strcpy(id_gravity,arg[iarg+1]);
+      id_gravity = utils::strdup(arg[iarg+1]);
       iarg += 2;
 
     } else error->all(FLERR,"Illegal fix rigid/small command");

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -3567,7 +3567,7 @@ double FixRigidSmall::compute_scalar()
 double FixRigidSmall::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax*2 * sizeof(int);
+  double bytes = (double)nmax*2 * sizeof(int);
   bytes += (double)nmax * sizeof(imageint);
   bytes += (double)nmax*3 * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);     // vatom

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -113,7 +113,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
 
       // determine whether atom-style variable or atom property is used
 
-      if (strstr(arg[4],"i_") == arg[4]) {
+      if (utils::strmatch(arg[4],"^i_")) {
         int is_double=0;
         int custom_index = atom->find_custom(arg[4]+2,is_double);
         if (custom_index == -1)
@@ -135,7 +135,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
             bodyID[i] = (tagint)(value[i] - minval + 1);
           else bodyID[i] = 0;
 
-      } else if (strstr(arg[4],"v_") == arg[4]) {
+      } else if (utils::strmatch(arg[4],"^v_")) {
         int ivariable = input->variable->find(arg[4]+2);
         if (ivariable < 0)
           error->all(FLERR,"Variable name for fix rigid/small custom "

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -2678,7 +2678,7 @@ int FixShake::angletype_findset(int i, tagint n1, tagint n2, int setflag)
 double FixShake::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes += (double)nmax*4 * sizeof(int);
   bytes += (double)nmax*3 * sizeof(int);
   bytes += (double)nmax*3 * sizeof(double);

--- a/src/SHOCK/fix_append_atoms.cpp
+++ b/src/SHOCK/fix_append_atoms.cpp
@@ -122,14 +122,8 @@ FixAppendAtoms::FixAppendAtoms(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,
                    "Bad fix ID in fix append/atoms command");
       spatflag = 1;
-      int n = strlen(arg[iarg+1]);
+      spatialid = utils::strdup(arg[iarg+1]+2);
       spatlead = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      char *suffix = new char[n];
-      strcpy(suffix,&arg[iarg+1][2]);
-      n = strlen(suffix) + 1;
-      spatialid = new char[n];
-      strcpy(spatialid,suffix);
-      delete [] suffix;
       iarg += 3;
     } else if (strcmp(arg[iarg],"basis") == 0) {
       if (iarg+3 > narg) error->all(FLERR,"Illegal fix append/atoms command");

--- a/src/SNAP/compute_sna_atom.cpp
+++ b/src/SNAP/compute_sna_atom.cpp
@@ -306,7 +306,7 @@ void ComputeSNAAtom::compute_peratom()
 
 double ComputeSNAAtom::memory_usage()
 {
-  double bytes = nmax*size_peratom_cols * sizeof(double); // sna
+  double bytes = (double)nmax*size_peratom_cols * sizeof(double); // sna
   bytes += snaptr->memory_usage();                        // SNA object
 
   return bytes;

--- a/src/SNAP/compute_snad_atom.cpp
+++ b/src/SNAP/compute_snad_atom.cpp
@@ -406,7 +406,7 @@ void ComputeSNADAtom::unpack_reverse_comm(int n, int *list, double *buf)
 double ComputeSNADAtom::memory_usage()
 {
 
-  double bytes = nmax*size_peratom_cols * sizeof(double); // snad
+  double bytes = (double)nmax*size_peratom_cols * sizeof(double); // snad
   bytes += snaptr->memory_usage();                        // SNA object
 
   return bytes;

--- a/src/SNAP/compute_snap.cpp
+++ b/src/SNAP/compute_snap.cpp
@@ -529,7 +529,7 @@ void ComputeSnap::dbdotr_compute()
 double ComputeSnap::memory_usage()
 {
 
-  double bytes = size_array_rows*size_array_cols *
+  double bytes = (double)size_array_rows*size_array_cols *
     sizeof(double);                                     // snap
   bytes += (double)size_array_rows*size_array_cols *
     sizeof(double);                                     // snapall

--- a/src/SNAP/compute_snav_atom.cpp
+++ b/src/SNAP/compute_snav_atom.cpp
@@ -415,7 +415,7 @@ void ComputeSNAVAtom::unpack_reverse_comm(int n, int *list, double *buf)
 
 double ComputeSNAVAtom::memory_usage()
 {
-  double bytes = nmax*size_peratom_cols * sizeof(double); // snav
+  double bytes = (double)nmax*size_peratom_cols * sizeof(double); // snav
   bytes += snaptr->memory_usage();                        // SNA object
 
   return bytes;

--- a/src/SRD/fix_wall_srd.cpp
+++ b/src/SRD/fix_wall_srd.cpp
@@ -69,7 +69,7 @@ FixWallSRD::FixWallSRD(LAMMPS *lmp, int narg, char **arg) :
         int side = wallwhich[nwall] % 2;
         if (side == 0) coord0[nwall] = domain->boxlo[dim];
         else coord0[nwall] = domain->boxhi[dim];
-      } else if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      } else if (utils::strmatch(arg[iarg+1],"^v_")) {
         wallstyle[nwall] = VARIABLE;
         int n = strlen(&arg[iarg+1][2]) + 1;
         varstr[nwall] = new char[n];

--- a/src/SRD/fix_wall_srd.cpp
+++ b/src/SRD/fix_wall_srd.cpp
@@ -71,9 +71,7 @@ FixWallSRD::FixWallSRD(LAMMPS *lmp, int narg, char **arg) :
         else coord0[nwall] = domain->boxhi[dim];
       } else if (utils::strmatch(arg[iarg+1],"^v_")) {
         wallstyle[nwall] = VARIABLE;
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        varstr[nwall] = new char[n];
-        strcpy(varstr[nwall],&arg[iarg+1][2]);
+        varstr[nwall] = utils::strdup(arg[iarg+1]+2);
       } else {
         wallstyle[nwall] = CONSTANT;
         coord0[nwall] = utils::numeric(FLERR,arg[iarg+1],false,lmp);

--- a/src/USER-ATC/fix_atc.cpp
+++ b/src/USER-ATC/fix_atc.cpp
@@ -627,7 +627,7 @@ void FixATC::min_pre_exchange()
 
 double FixATC::memory_usage()
 {
-  double bytes = (double) atc_->memory_usage() * sizeof(double);
+  double bytes =  atc_->memory_usage() * sizeof(double);
   return bytes;
 }
 

--- a/src/USER-AWPMD/pair_awpmd_cut.cpp
+++ b/src/USER-AWPMD/pair_awpmd_cut.cpp
@@ -734,7 +734,7 @@ void PairAWPMDCut::min_x_set(int /* ignore */)
 
 double PairAWPMDCut::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/USER-DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/USER-DIFFRACTION/fix_saed_vtk.cpp
@@ -386,15 +386,12 @@ void FixSAEDVTK::invoke_vector(bigint ntimestep)
     if (nOutput > 0) {
       fclose(fp);
 
-      char nName [128];
-      snprintf(nName,128,"%s.%d.vtk",filename,nOutput);
-      fp = fopen(nName,"w");
+      std::string nName = fmt::format("{}.{}.vtk",filename,nOutput);
+      fp = fopen(nName.c_str(),"w");
 
-      if (fp == nullptr) {
-        char str[128];
-        snprintf(str,128,"Cannot open fix saed/vtk file %s",nName);
-        error->one(FLERR,str);
-      }
+      if (fp == nullptr)
+        error->one(FLERR,fmt::format("Cannot open fix saed/vtk file {}: {}",
+                                     nName,utils::getsyserror()));
     }
 
     fprintf(fp,"# vtk DataFile Version 3.0 c_%s\n",ids);
@@ -508,20 +505,15 @@ void FixSAEDVTK::options(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix saed/vtk command");
       if (comm->me == 0) {
 
-         nOutput = 0;
-         int n = strlen(arg[iarg+1]) + 1;
-         filename = new char[n];
-         strcpy(filename,arg[iarg+1]);
+        nOutput = 0;
+        filename = utils::strdup(arg[iarg+1]);
 
-         char nName [128];
-         snprintf(nName,128,"%s.%d.vtk",filename,nOutput);
-         fp = fopen(nName,"w");
+        std::string nName = fmt::format("{}.{}.vtk",filename,nOutput);
+        fp = fopen(nName.c_str(),"w");
 
-        if (fp == nullptr) {
-          char str[128];
-          snprintf(str,128,"Cannot open fix saed/vtk file %s",nName);
-          error->one(FLERR,str);
-        }
+        if (fp == nullptr)
+          error->one(FLERR,fmt::format("Cannot open fix saed/vtk file {}: {}",
+                                       nName,utils::getsyserror()));
       }
       iarg += 2;
     } else if (strcmp(arg[iarg],"ave") == 0) {

--- a/src/USER-DPD/compute_dpd_atom.cpp
+++ b/src/USER-DPD/compute_dpd_atom.cpp
@@ -97,6 +97,6 @@ void ComputeDpdAtom::compute_peratom()
 
 double ComputeDpdAtom::memory_usage()
 {
-  double bytes = size_peratom_cols * nmax * sizeof(double);
+  double bytes = (double)size_peratom_cols * nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-DRUDE/fix_langevin_drude.cpp
+++ b/src/USER-DRUDE/fix_langevin_drude.cpp
@@ -12,21 +12,22 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_langevin_drude.h"
+#include "fix_drude.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "compute.h"
+#include "domain.h"
+#include "error.h"
+#include "force.h"
+#include "input.h"
+#include "modify.h"
+#include "random_mars.h"
+#include "update.h"
+#include "variable.h"
 
 #include <cstring>
 #include <cmath>
-#include "fix_drude.h"
-#include "atom.h"
-#include "force.h"
-#include "comm.h"
-#include "input.h"
-#include "variable.h"
-#include "random_mars.h"
-#include "update.h"
-#include "modify.h"
-#include "compute.h"
-#include "error.h"
-#include "domain.h"
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -50,9 +51,7 @@ FixLangevinDrude::FixLangevinDrude(LAMMPS *lmp, int narg, char **arg) :
   // core temperature
   tstr_core = nullptr;
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    tstr_core = new char[n];
-    strcpy(tstr_core,&arg[3][2]);
+    tstr_core = utils::strdup(arg[3]+2);
     tstyle_core = EQUAL;
   } else {
     t_start_core = utils::numeric(FLERR,arg[3],false,lmp);
@@ -65,9 +64,7 @@ FixLangevinDrude::FixLangevinDrude(LAMMPS *lmp, int narg, char **arg) :
   // drude temperature
   tstr_drude = nullptr;
   if (strstr(arg[7],"v_") == arg[6]) {
-    int n = strlen(&arg[6][2]) + 1;
-    tstr_drude = new char[n];
-    strcpy(tstr_drude,&arg[6][2]);
+    tstr_drude = utils::strdup(arg[6]+2);
     tstyle_drude = EQUAL;
   } else {
     t_start_drude = utils::numeric(FLERR,arg[6],false,lmp);
@@ -184,9 +181,7 @@ int FixLangevinDrude::modify_param(int narg, char **arg)
   if (strcmp(arg[0],"temp") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal fix_modify command");
     delete [] id_temp;
-    int n = strlen(arg[1]) + 1;
-    id_temp = new char[n];
-    strcpy(id_temp,arg[1]);
+    id_temp = utils::strdup(arg[1]);
 
     int icompute = modify->find_compute(id_temp);
     if (icompute < 0)

--- a/src/USER-DRUDE/fix_langevin_drude.cpp
+++ b/src/USER-DRUDE/fix_langevin_drude.cpp
@@ -49,7 +49,7 @@ FixLangevinDrude::FixLangevinDrude(LAMMPS *lmp, int narg, char **arg) :
 
   // core temperature
   tstr_core = nullptr;
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     tstr_core = new char[n];
     strcpy(tstr_core,&arg[3][2]);

--- a/src/USER-EFF/compute_ke_atom_eff.cpp
+++ b/src/USER-EFF/compute_ke_atom_eff.cpp
@@ -110,6 +110,6 @@ void ComputeKEAtomEff::compute_peratom()
 
 double ComputeKEAtomEff::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-EFF/compute_temp_deform_eff.cpp
+++ b/src/USER-EFF/compute_temp_deform_eff.cpp
@@ -319,6 +319,6 @@ void ComputeTempDeformEff::restore_bias_all()
 
 double ComputeTempDeformEff::memory_usage()
 {
-  double bytes = maxbias * sizeof(double);
+  double bytes = (double)maxbias * sizeof(double);
   return bytes;
 }

--- a/src/USER-EFF/compute_temp_region_eff.cpp
+++ b/src/USER-EFF/compute_temp_region_eff.cpp
@@ -291,6 +291,6 @@ void ComputeTempRegionEff::restore_bias_all()
 
 double ComputeTempRegionEff::memory_usage()
 {
-  double bytes = maxbias * sizeof(double);
+  double bytes = (double)maxbias * sizeof(double);
   return bytes;
 }

--- a/src/USER-EFF/pair_eff_cut.cpp
+++ b/src/USER-EFF/pair_eff_cut.cpp
@@ -1078,7 +1078,7 @@ void PairEffCut::min_x_set(int /*ignore*/)
 
 double PairEffCut::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/USER-FEP/compute_fep.cpp
+++ b/src/USER-FEP/compute_fep.cpp
@@ -99,7 +99,7 @@ ComputeFEP::ComputeFEP(LAMMPS *lmp, int narg, char **arg) :
                     perturb[npert].ilo,perturb[npert].ihi,error);
       utils::bounds(FLERR,arg[iarg+4],1,atom->ntypes,
                     perturb[npert].jlo,perturb[npert].jhi,error);
-      if (strstr(arg[iarg+5],"v_") == arg[iarg+5]) {
+      if (utils::strmatch(arg[iarg+5],"^v_")) {
         n = strlen(&arg[iarg+5][2]) + 1;
         perturb[npert].var = new char[n];
         strcpy(perturb[npert].var,&arg[iarg+5][2]);
@@ -114,7 +114,7 @@ ComputeFEP::ComputeFEP(LAMMPS *lmp, int narg, char **arg) :
       } else error->all(FLERR,"Illegal atom argument in compute fep");
       utils::bounds(FLERR,arg[iarg+2],1,atom->ntypes,
                     perturb[npert].ilo,perturb[npert].ihi,error);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+      if (utils::strmatch(arg[iarg+3],"^v_")) {
         int n = strlen(&arg[iarg+3][2]) + 1;
         perturb[npert].var = new char[n];
         strcpy(perturb[npert].var,&arg[iarg+3][2]);

--- a/src/USER-FEP/compute_fep.cpp
+++ b/src/USER-FEP/compute_fep.cpp
@@ -16,25 +16,25 @@
 ------------------------------------------------------------------------- */
 
 #include "compute_fep.h"
-#include <cstring>
-#include <cmath>
 
-#include "comm.h"
-#include "update.h"
 #include "atom.h"
+#include "comm.h"
 #include "domain.h"
+#include "error.h"
+#include "fix.h"
 #include "force.h"
+#include "input.h"
+#include "kspace.h"
+#include "memory.h"
+#include "modify.h"
 #include "pair.h"
 #include "pair_hybrid.h"
-#include "kspace.h"
-#include "input.h"
-#include "fix.h"
-#include "modify.h"
-#include "variable.h"
 #include "timer.h"
-#include "memory.h"
-#include "error.h"
+#include "update.h"
+#include "variable.h"
 
+#include <cstring>
+#include <cmath>
 
 using namespace LAMMPS_NS;
 
@@ -89,20 +89,14 @@ ComputeFEP::ComputeFEP(LAMMPS *lmp, int narg, char **arg) :
   while (iarg < narg) {
     if (strcmp(arg[iarg],"pair") == 0) {
       perturb[npert].which = PAIR;
-      int n = strlen(arg[iarg+1]) + 1;
-      perturb[npert].pstyle = new char[n];
-      strcpy(perturb[npert].pstyle,arg[iarg+1]);
-      n = strlen(arg[iarg+2]) + 1;
-      perturb[npert].pparam = new char[n];
-      strcpy(perturb[npert].pparam,arg[iarg+2]);
+      perturb[npert].pstyle = utils::strdup(arg[iarg+1]);
+      perturb[npert].pparam = utils::strdup(arg[iarg+2]);
       utils::bounds(FLERR,arg[iarg+3],1,atom->ntypes,
                     perturb[npert].ilo,perturb[npert].ihi,error);
       utils::bounds(FLERR,arg[iarg+4],1,atom->ntypes,
                     perturb[npert].jlo,perturb[npert].jhi,error);
       if (utils::strmatch(arg[iarg+5],"^v_")) {
-        n = strlen(&arg[iarg+5][2]) + 1;
-        perturb[npert].var = new char[n];
-        strcpy(perturb[npert].var,&arg[iarg+5][2]);
+        perturb[npert].var = utils::strdup(arg[iarg+5]+2);
       } else error->all(FLERR,"Illegal variable in compute fep");
       npert++;
       iarg += 6;
@@ -115,9 +109,7 @@ ComputeFEP::ComputeFEP(LAMMPS *lmp, int narg, char **arg) :
       utils::bounds(FLERR,arg[iarg+2],1,atom->ntypes,
                     perturb[npert].ilo,perturb[npert].ihi,error);
       if (utils::strmatch(arg[iarg+3],"^v_")) {
-        int n = strlen(&arg[iarg+3][2]) + 1;
-        perturb[npert].var = new char[n];
-        strcpy(perturb[npert].var,&arg[iarg+3][2]);
+        perturb[npert].var = utils::strdup(arg[iarg+3]+2);
       } else error->all(FLERR,"Illegal variable in compute fep");
       npert++;
       iarg += 4;

--- a/src/USER-FEP/fix_adapt_fep.cpp
+++ b/src/USER-FEP/fix_adapt_fep.cpp
@@ -98,7 +98,7 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
       utils::bounds(FLERR,arg[iarg+4],1,atom->ntypes,
                     adapt[nadapt].jlo,adapt[nadapt].jhi,error);
-      if (strstr(arg[iarg+5],"v_") == arg[iarg+5]) {
+      if (utils::strmatch(arg[iarg+5],"^v_")) {
         n = strlen(&arg[iarg+5][2]) + 1;
         adapt[nadapt].var = new char[n];
         strcpy(adapt[nadapt].var,&arg[iarg+5][2]);
@@ -108,7 +108,7 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"kspace") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix adapt/fep command");
       adapt[nadapt].which = KSPACE;
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         adapt[nadapt].var = new char[n];
         strcpy(adapt[nadapt].var,&arg[iarg+1][2]);
@@ -127,7 +127,7 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
       } else error->all(FLERR,"Illegal fix adapt/fep command");
       utils::bounds(FLERR,arg[iarg+2],1,atom->ntypes,
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+      if (utils::strmatch(arg[iarg+3],"^v_")) {
         int n = strlen(&arg[iarg+3][2]) + 1;
         adapt[nadapt].var = new char[n];
         strcpy(adapt[nadapt].var,&arg[iarg+3][2]);

--- a/src/USER-FEP/fix_adapt_fep.cpp
+++ b/src/USER-FEP/fix_adapt_fep.cpp
@@ -16,23 +16,24 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_adapt_fep.h"
-#include <cstring>
+
 #include "atom.h"
-#include "update.h"
-#include "group.h"
-#include "modify.h"
-#include "force.h"
-#include "pair.h"
-#include "pair_hybrid.h"
-#include "kspace.h"
+#include "error.h"
 #include "fix_store.h"
+#include "force.h"
+#include "group.h"
 #include "input.h"
-#include "variable.h"
-#include "respa.h"
+#include "kspace.h"
 #include "math_const.h"
 #include "memory.h"
-#include "error.h"
+#include "modify.h"
+#include "pair.h"
+#include "pair_hybrid.h"
+#include "respa.h"
+#include "update.h"
+#include "variable.h"
 
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -88,20 +89,14 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
     if (strcmp(arg[iarg],"pair") == 0) {
       if (iarg+6 > narg) error->all(FLERR,"Illegal fix adapt/fep command");
       adapt[nadapt].which = PAIR;
-      int n = strlen(arg[iarg+1]) + 1;
-      adapt[nadapt].pstyle = new char[n];
-      strcpy(adapt[nadapt].pstyle,arg[iarg+1]);
-      n = strlen(arg[iarg+2]) + 1;
-      adapt[nadapt].pparam = new char[n];
-      strcpy(adapt[nadapt].pparam,arg[iarg+2]);
+      adapt[nadapt].pstyle = utils::strdup(arg[iarg+1]);
+      adapt[nadapt].pparam = utils::strdup(arg[iarg+2]);
       utils::bounds(FLERR,arg[iarg+3],1,atom->ntypes,
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
       utils::bounds(FLERR,arg[iarg+4],1,atom->ntypes,
                     adapt[nadapt].jlo,adapt[nadapt].jhi,error);
       if (utils::strmatch(arg[iarg+5],"^v_")) {
-        n = strlen(&arg[iarg+5][2]) + 1;
-        adapt[nadapt].var = new char[n];
-        strcpy(adapt[nadapt].var,&arg[iarg+5][2]);
+        adapt[nadapt].var = utils::strdup(arg[iarg+5]+2);
       } else error->all(FLERR,"Illegal fix adapt/fep command");
       nadapt++;
       iarg += 6;
@@ -109,9 +104,7 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix adapt/fep command");
       adapt[nadapt].which = KSPACE;
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        adapt[nadapt].var = new char[n];
-        strcpy(adapt[nadapt].var,&arg[iarg+1][2]);
+        adapt[nadapt].var = utils::strdup(arg[iarg+1]+2);
       } else error->all(FLERR,"Illegal fix adapt/fep command");
       nadapt++;
       iarg += 2;
@@ -128,9 +121,7 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
       utils::bounds(FLERR,arg[iarg+2],1,atom->ntypes,
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
       if (utils::strmatch(arg[iarg+3],"^v_")) {
-        int n = strlen(&arg[iarg+3][2]) + 1;
-        adapt[nadapt].var = new char[n];
-        strcpy(adapt[nadapt].var,&arg[iarg+3][2]);
+        adapt[nadapt].var = utils::strdup(arg[iarg+3]+2);
       } else error->all(FLERR,"Illegal fix adapt/fep command");
       nadapt++;
       iarg += 4;
@@ -223,20 +214,10 @@ void FixAdaptFEP::post_constructor()
   id_fix_diam = nullptr;
   id_fix_chg = nullptr;
 
-  char **newarg = new char*[6];
-  newarg[1] = group->names[igroup];
-  newarg[2] = (char *) "STORE";
-  newarg[3] = (char *) "peratom";
-  newarg[4] = (char *) "1";
-  newarg[5] = (char *) "1";
-
   if (diamflag) {
-    int n = strlen(id) + strlen("_FIX_STORE_DIAM") + 1;
-    id_fix_diam = new char[n];
-    strcpy(id_fix_diam,id);
-    strcat(id_fix_diam,"_FIX_STORE_DIAM");
-    newarg[0] = id_fix_diam;
-    modify->add_fix(6,newarg);
+    auto cmd = fmt::format("{}_FIX_STORE_DIAM {} STORE peratom 1 1",
+                           group->names[igroup]);
+    modify->add_fix(cmd);
     fix_diam = (FixStore *) modify->fix[modify->nfix-1];
 
     if (fix_diam->restart_reset) fix_diam->restart_reset = 0;
@@ -254,12 +235,9 @@ void FixAdaptFEP::post_constructor()
   }
 
   if (chgflag) {
-    int n = strlen(id) + strlen("_FIX_STORE_CHG") + 1;
-    id_fix_chg = new char[n];
-    strcpy(id_fix_chg,id);
-    strcat(id_fix_chg,"_FIX_STORE_CHG");
-    newarg[0] = id_fix_chg;
-    modify->add_fix(6,newarg);
+    auto cmd = fmt::format("{}_FIX_STORE_CHG {} STORE peratom 1 1",
+                           group->names[igroup]);
+    modify->add_fix(cmd);
     fix_chg = (FixStore *) modify->fix[modify->nfix-1];
 
     if (fix_chg->restart_reset) fix_chg->restart_reset = 0;
@@ -275,8 +253,6 @@ void FixAdaptFEP::post_constructor()
       }
     }
   }
-
-  delete [] newarg;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-FEP/pair_lj_cut_tip4p_long_soft.cpp
+++ b/src/USER-FEP/pair_lj_cut_tip4p_long_soft.cpp
@@ -588,7 +588,7 @@ void *PairLJCutTIP4PLongSoft::extract(const char *str, int &dim)
 
 double PairLJCutTIP4PLongSoft::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/USER-FEP/pair_tip4p_long_soft.cpp
+++ b/src/USER-FEP/pair_tip4p_long_soft.cpp
@@ -510,7 +510,7 @@ void *PairTIP4PLongSoft::extract(const char *str, int &dim)
 
 double PairTIP4PLongSoft::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;

--- a/src/USER-LB/fix_lb_rigid_pc_sphere.cpp
+++ b/src/USER-LB/fix_lb_rigid_pc_sphere.cpp
@@ -1430,7 +1430,7 @@ int FixLbRigidPCSphere::dof(int igroup)
 double FixLbRigidPCSphere::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes += (double)nmax*3 * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
 

--- a/src/USER-MESODPD/compute_edpd_temp_atom.cpp
+++ b/src/USER-MESODPD/compute_edpd_temp_atom.cpp
@@ -91,6 +91,6 @@ void ComputeEDPDTempAtom::compute_peratom()
 
 double ComputeEDPDTempAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-MESODPD/compute_tdpd_cc_atom.cpp
+++ b/src/USER-MESODPD/compute_tdpd_cc_atom.cpp
@@ -94,6 +94,6 @@ void ComputeTDPDCCAtom::compute_peratom()
 
 double ComputeTDPDCCAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-MESONT/compute_mesont.cpp
+++ b/src/USER-MESONT/compute_mesont.cpp
@@ -151,6 +151,6 @@ void ComputeMesoNT::unpack_reverse_comm(int n, int *list, double *buf) {
 ------------------------------------------------------------------------- */
 
 double ComputeMesoNT::memory_usage() {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-MISC/compute_ackland_atom.cpp
+++ b/src/USER-MISC/compute_ackland_atom.cpp
@@ -462,6 +462,6 @@ void ComputeAcklandAtom::select2(int k, int n, double *arr, int *iarr)
 
 double ComputeAcklandAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-MISC/compute_cnp_atom.cpp
+++ b/src/USER-MISC/compute_cnp_atom.cpp
@@ -323,7 +323,7 @@ void ComputeCNPAtom::compute_peratom()
 
 double ComputeCNPAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes += (double)nmax * MAXNEAR * sizeof(int);
   bytes += (double)nmax * sizeof(double);
   return bytes;

--- a/src/USER-MISC/compute_hma.cpp
+++ b/src/USER-MISC/compute_hma.cpp
@@ -497,6 +497,6 @@ void ComputeHMA::set_arrays(int i)
 
 double ComputeHMA::memory_usage()
 {
-  double bytes = nmax * 3 * sizeof(double);
+  double bytes = (double)nmax * 3 * sizeof(double);
   return bytes;
 }

--- a/src/USER-MISC/compute_temp_rotate.cpp
+++ b/src/USER-MISC/compute_temp_rotate.cpp
@@ -294,6 +294,6 @@ void ComputeTempRotate::restore_bias_all()
 
 double ComputeTempRotate::memory_usage()
 {
-  double bytes = maxbias * sizeof(double);
+  double bytes = (double)maxbias * sizeof(double);
   return bytes;
 }

--- a/src/USER-MISC/fix_addtorque.cpp
+++ b/src/USER-MISC/fix_addtorque.cpp
@@ -53,7 +53,7 @@ FixAddTorque::FixAddTorque(LAMMPS *lmp, int narg, char **arg) :
 
   xstr = ystr = zstr = nullptr;
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     xstr = new char[n];
     strcpy(xstr,&arg[3][2]);
@@ -61,7 +61,7 @@ FixAddTorque::FixAddTorque(LAMMPS *lmp, int narg, char **arg) :
     xvalue = utils::numeric(FLERR,arg[3],false,lmp);
     xstyle = CONSTANT;
   }
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(&arg[4][2]) + 1;
     ystr = new char[n];
     strcpy(ystr,&arg[4][2]);
@@ -69,7 +69,7 @@ FixAddTorque::FixAddTorque(LAMMPS *lmp, int narg, char **arg) :
     yvalue = utils::numeric(FLERR,arg[4],false,lmp);
     ystyle = CONSTANT;
   }
-  if (strstr(arg[5],"v_") == arg[5]) {
+  if (utils::strmatch(arg[5],"^v_")) {
     int n = strlen(&arg[5][2]) + 1;
     zstr = new char[n];
     strcpy(zstr,&arg[5][2]);

--- a/src/USER-MISC/fix_addtorque.cpp
+++ b/src/USER-MISC/fix_addtorque.cpp
@@ -17,17 +17,18 @@
 
 #include "fix_addtorque.h"
 
-#include <cstring>
 #include "atom.h"
-#include "update.h"
-#include "modify.h"
 #include "domain.h"
-#include "respa.h"
-#include "input.h"
-#include "variable.h"
 #include "error.h"
-#include "group.h"
 #include "force.h"
+#include "group.h"
+#include "input.h"
+#include "modify.h"
+#include "respa.h"
+#include "update.h"
+#include "variable.h"
+
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -54,25 +55,19 @@ FixAddTorque::FixAddTorque(LAMMPS *lmp, int narg, char **arg) :
   xstr = ystr = zstr = nullptr;
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    xstr = new char[n];
-    strcpy(xstr,&arg[3][2]);
+    xstr = utils::strdup(arg[3]+2);
   } else {
     xvalue = utils::numeric(FLERR,arg[3],false,lmp);
     xstyle = CONSTANT;
   }
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(&arg[4][2]) + 1;
-    ystr = new char[n];
-    strcpy(ystr,&arg[4][2]);
+    ystr = utils::strdup(arg[4]+2);
   } else {
     yvalue = utils::numeric(FLERR,arg[4],false,lmp);
     ystyle = CONSTANT;
   }
   if (utils::strmatch(arg[5],"^v_")) {
-    int n = strlen(&arg[5][2]) + 1;
-    zstr = new char[n];
-    strcpy(zstr,&arg[5][2]);
+    zstr = utils::strdup(arg[5]+2);
   } else {
     zvalue = utils::numeric(FLERR,arg[5],false,lmp);
     zstyle = CONSTANT;

--- a/src/USER-MISC/fix_ffl.cpp
+++ b/src/USER-MISC/fix_ffl.cpp
@@ -455,7 +455,7 @@ void FixFFL::reset_dt() {
 ------------------------------------------------------------------------- */
 
 double FixFFL::memory_usage() {
-  double bytes = atom->nmax*(3*2)*sizeof(double);
+  double bytes = (double)atom->nmax*(3*2)*sizeof(double);
   return bytes;
 }
 

--- a/src/USER-MISC/fix_gle.cpp
+++ b/src/USER-MISC/fix_gle.cpp
@@ -762,7 +762,7 @@ void FixGLE::reset_dt()
 
 double FixGLE::memory_usage()
 {
-  double bytes = atom->nmax*(3*ns+2*3*(ns+1))*sizeof(double);
+  double bytes = (double)atom->nmax*(3*ns+2*3*(ns+1))*sizeof(double);
   return bytes;
 }
 

--- a/src/USER-MISC/fix_orient_eco.cpp
+++ b/src/USER-MISC/fix_orient_eco.cpp
@@ -474,7 +474,7 @@ void FixOrientECO::unpack_forward_comm(int n, int first, double *buf) {
  ------------------------------------------------------------------------- */
 
 double FixOrientECO::memory_usage() {
-  double bytes = nmax * sizeof(Nbr);
+  double bytes = (double)nmax * sizeof(Nbr);
   bytes += (double)2 * nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-MISC/fix_propel_self.cpp
+++ b/src/USER-MISC/fix_propel_self.cpp
@@ -130,7 +130,7 @@ int FixPropelSelf::setmask()
 double FixPropelSelf::memory_usage()
 {
   // magnitude + thermostat_orient + mode + n_types_filter + apply_to_type
-  double bytes = sizeof(double) + 3*sizeof(int) + sizeof(int*);
+  double bytes = (double)sizeof(double) + 3*sizeof(int) + sizeof(int*);
   bytes += (double)sizeof(int)*atom->ntypes*n_types_filter;
 
   return bytes;

--- a/src/USER-MISC/fix_srp.cpp
+++ b/src/USER-MISC/fix_srp.cpp
@@ -379,7 +379,7 @@ void FixSRP::pre_exchange()
 
 double FixSRP::memory_usage()
 {
-  double bytes = atom->nmax*2 * sizeof(double);
+  double bytes = (double)atom->nmax*2 * sizeof(double);
   return bytes;
 }
 

--- a/src/USER-MISC/fix_ti_spring.cpp
+++ b/src/USER-MISC/fix_ti_spring.cpp
@@ -261,7 +261,7 @@ double FixTISpring::compute_vector(int n)
 
 double FixTISpring::memory_usage()
 {
-  double bytes = atom->nmax*3 * sizeof(double);
+  double bytes = (double)atom->nmax*3 * sizeof(double);
   return bytes;
 }
 

--- a/src/USER-MISC/pair_list.cpp
+++ b/src/USER-MISC/pair_list.cpp
@@ -409,7 +409,7 @@ double PairList::init_one(int, int)
 
 double PairList::memory_usage()
 {
-  double bytes = npairs * sizeof(int);
+  double bytes = (double)npairs * sizeof(int);
   bytes += (double)npairs * sizeof(list_parm_t);
   const int n = atom->ntypes+1;
   bytes += (double)n*(n*sizeof(int) + sizeof(int *));

--- a/src/USER-MISC/pair_local_density.cpp
+++ b/src/USER-MISC/pair_local_density.cpp
@@ -881,7 +881,7 @@ void PairLocalDensity::unpack_reverse_comm(int n, int *list, double *buf) {
 
 double PairLocalDensity::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)2 * (nmax*nLD) * sizeof(double);
   return bytes;

--- a/src/USER-PHONON/fix_phonon.cpp
+++ b/src/USER-PHONON/fix_phonon.cpp
@@ -424,7 +424,7 @@ void FixPhonon::end_of_step()
 
 double FixPhonon::memory_usage()
 {
-  double bytes = sizeof(double)*2*mynq
+  double bytes = (double)sizeof(double)*2*mynq
                + sizeof(std::map<int,int>)*2*ngroup
                + sizeof(double)*(ngroup*(3*sysdim+2)+mynpt*fft_dim*2)
                + sizeof(std::complex<double>)*MAX(1,mynq)*fft_dim *(1+2*fft_dim)

--- a/src/USER-PTM/compute_ptm_atom.cpp
+++ b/src/USER-PTM/compute_ptm_atom.cpp
@@ -333,7 +333,7 @@ void ComputePTMAtom::compute_peratom() {
 ------------------------------------------------------------------------- */
 
 double ComputePTMAtom::memory_usage() {
-  double bytes = nmax * NUM_COLUMNS * sizeof(double);
+  double bytes = (double)nmax * NUM_COLUMNS * sizeof(double);
   bytes += (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -3743,7 +3743,7 @@ memory usage of local atom-based arrays
 double FixBondReact::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes = 2*nmax * sizeof(tagint);
   bytes += (double)nmax * sizeof(double);
   return bytes;

--- a/src/USER-REAXC/compute_spec_atom.cpp
+++ b/src/USER-REAXC/compute_spec_atom.cpp
@@ -172,7 +172,7 @@ void ComputeSpecAtom::compute_peratom()
 
 double ComputeSpecAtom::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }
 

--- a/src/USER-REAXC/fix_reaxc.cpp
+++ b/src/USER-REAXC/fix_reaxc.cpp
@@ -83,7 +83,7 @@ int FixReaxC::setmask()
 double FixReaxC::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * 2 * sizeof(int);
+  double bytes = (double)nmax * 2 * sizeof(int);
   return bytes;
 }
 

--- a/src/USER-REAXC/reaxc_init_md.cpp
+++ b/src/USER-REAXC/reaxc_init_md.cpp
@@ -77,7 +77,7 @@ int Init_Simulation_Data(reax_system *system, control_params *control,
 
   /* initialize the timer(s) */
   if (system->my_rank == MASTER_NODE) {
-    data->timing.start = Get_Time();
+    data->timing.start = MPI_Wtime();
   }
 
   data->step = data->prev_steps = 0;

--- a/src/USER-REAXC/reaxc_reset_tools.cpp
+++ b/src/USER-REAXC/reaxc_reset_tools.cpp
@@ -25,7 +25,6 @@
   ----------------------------------------------------------------------*/
 
 #include "reaxc_reset_tools.h"
-#include <cstring>
 #include "reaxc_defs.h"
 #include "reaxc_list.h"
 #include "reaxc_tool_box.h"
@@ -33,6 +32,8 @@
 
 #include "error.h"
 
+#include <mpi.h>
+#include <cstring>
 
 void Reset_Atoms( reax_system* system, control_params *control )
 {
@@ -102,7 +103,7 @@ void Reset_Simulation_Data( simulation_data* data, int /*virial*/ )
 
 void Reset_Timing( reax_timing *rt )
 {
-  rt->total = Get_Time();
+  rt->total = MPI_Wtime();
   rt->comm = 0;
   rt->nbrs = 0;
   rt->init_forces = 0;

--- a/src/USER-REAXC/reaxc_tool_box.cpp
+++ b/src/USER-REAXC/reaxc_tool_box.cpp
@@ -30,28 +30,7 @@
 #include <cstring>
 #include "reaxc_defs.h"
 
-#if !defined(_MSC_VER)
-#include <sys/time.h>
-#endif
-
 #include "error.h"
-
-struct timeval tim;
-double t_end;
-
-double Get_Time( )
-{
-#if defined(_MSC_VER)
-  double t;
-
-  t = GetTickCount();
-  t /= 1000.0;
-  return t;
-#else
-  gettimeofday(&tim, nullptr );
-  return( tim.tv_sec + (tim.tv_usec / 1000000.0) );
-#endif
-}
 
 int Tokenize( char* s, char*** tok )
 {

--- a/src/USER-REAXC/reaxc_tool_box.h
+++ b/src/USER-REAXC/reaxc_tool_box.h
@@ -30,9 +30,6 @@
 #include "reaxc_types.h"
 namespace LAMMPS_NS { class Error; }
 
-/* from system_props.h */
-double Get_Time( );
-
 /* from io_tools.h */
 int   Tokenize( char*, char*** );
 

--- a/src/USER-SDPD/fix_meso_move.cpp
+++ b/src/USER-SDPD/fix_meso_move.cpp
@@ -127,37 +127,37 @@ FixMesoMove::FixMesoMove (LAMMPS *lmp, int narg, char **arg) :
     iarg = 10;
     mstyle = VARIABLE;
     if (strcmp(arg[4],"NULL") == 0) xvarstr = nullptr;
-    else if (strstr(arg[4],"v_") == arg[4]) {
+    else if (utils::strmatch(arg[4],"^v_")) {
       int n = strlen(&arg[4][2]) + 1;
       xvarstr = new char[n];
       strcpy(xvarstr,&arg[4][2]);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[5],"NULL") == 0) yvarstr = nullptr;
-    else if (strstr(arg[5],"v_") == arg[5]) {
+    else if (utils::strmatch(arg[5],"^v_")) {
       int n = strlen(&arg[5][2]) + 1;
       yvarstr = new char[n];
       strcpy(yvarstr,&arg[5][2]);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[6],"NULL") == 0) zvarstr = nullptr;
-    else if (strstr(arg[6],"v_") == arg[6]) {
+    else if (utils::strmatch(arg[6],"^v_")) {
       int n = strlen(&arg[6][2]) + 1;
       zvarstr = new char[n];
       strcpy(zvarstr,&arg[6][2]);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[7],"NULL") == 0) vxvarstr = nullptr;
-    else if (strstr(arg[7],"v_") == arg[7]) {
+    else if (utils::strmatch(arg[7],"^v_")) {
       int n = strlen(&arg[7][2]) + 1;
       vxvarstr = new char[n];
       strcpy(vxvarstr,&arg[7][2]);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[8],"NULL") == 0) vyvarstr = nullptr;
-    else if (strstr(arg[8],"v_") == arg[8]) {
+    else if (utils::strmatch(arg[8],"^v_")) {
       int n = strlen(&arg[8][2]) + 1;
       vyvarstr = new char[n];
       strcpy(vyvarstr,&arg[8][2]);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[9],"NULL") == 0) vzvarstr = nullptr;
-    else if (strstr(arg[9],"v_") == arg[9]) {
+    else if (utils::strmatch(arg[9],"^v_")) {
       int n = strlen(&arg[9][2]) + 1;
       vzvarstr = new char[n];
       strcpy(vzvarstr,&arg[9][2]);

--- a/src/USER-SDPD/fix_meso_move.cpp
+++ b/src/USER-SDPD/fix_meso_move.cpp
@@ -17,20 +17,22 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_meso_move.h"
-#include <cstring>
-#include <cmath>
+
 #include "atom.h"
-#include "update.h"
-#include "modify.h"
-#include "force.h"
-#include "domain.h"
-#include "lattice.h"
 #include "comm.h"
+#include "domain.h"
+#include "error.h"
+#include "force.h"
 #include "input.h"
-#include "variable.h"
+#include "lattice.h"
 #include "math_const.h"
 #include "memory.h"
-#include "error.h"
+#include "modify.h"
+#include "update.h"
+#include "variable.h"
+
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -128,39 +130,27 @@ FixMesoMove::FixMesoMove (LAMMPS *lmp, int narg, char **arg) :
     mstyle = VARIABLE;
     if (strcmp(arg[4],"NULL") == 0) xvarstr = nullptr;
     else if (utils::strmatch(arg[4],"^v_")) {
-      int n = strlen(&arg[4][2]) + 1;
-      xvarstr = new char[n];
-      strcpy(xvarstr,&arg[4][2]);
+      xvarstr = utils::strdup(arg[4]+2);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[5],"NULL") == 0) yvarstr = nullptr;
     else if (utils::strmatch(arg[5],"^v_")) {
-      int n = strlen(&arg[5][2]) + 1;
-      yvarstr = new char[n];
-      strcpy(yvarstr,&arg[5][2]);
+      yvarstr = utils::strdup(arg[5]+2);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[6],"NULL") == 0) zvarstr = nullptr;
     else if (utils::strmatch(arg[6],"^v_")) {
-      int n = strlen(&arg[6][2]) + 1;
-      zvarstr = new char[n];
-      strcpy(zvarstr,&arg[6][2]);
+      zvarstr = utils::strdup(arg[6]+2);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[7],"NULL") == 0) vxvarstr = nullptr;
     else if (utils::strmatch(arg[7],"^v_")) {
-      int n = strlen(&arg[7][2]) + 1;
-      vxvarstr = new char[n];
-      strcpy(vxvarstr,&arg[7][2]);
+      vxvarstr = utils::strdup(arg[7]+2);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[8],"NULL") == 0) vyvarstr = nullptr;
     else if (utils::strmatch(arg[8],"^v_")) {
-      int n = strlen(&arg[8][2]) + 1;
-      vyvarstr = new char[n];
-      strcpy(vyvarstr,&arg[8][2]);
+      vyvarstr = utils::strdup(arg[8]+2);
     } else error->all(FLERR,"Illegal fix meso/move command");
     if (strcmp(arg[9],"NULL") == 0) vzvarstr = nullptr;
     else if (utils::strmatch(arg[9],"^v_")) {
-      int n = strlen(&arg[9][2]) + 1;
-      vzvarstr = new char[n];
-      strcpy(vzvarstr,&arg[9][2]);
+      vzvarstr = utils::strdup(arg[9]+2);
     } else error->all(FLERR,"Illegal fix meso/move command");
 
   } else error->all(FLERR,"Illegal fix meso/move command");

--- a/src/USER-SDPD/fix_meso_move.cpp
+++ b/src/USER-SDPD/fix_meso_move.cpp
@@ -799,7 +799,7 @@ void FixMesoMove::final_integrate () {
 ------------------------------------------------------------------------- */
 
 double FixMesoMove::memory_usage () {
-  double bytes = atom->nmax*3 * sizeof(double);
+  double bytes = (double)atom->nmax*3 * sizeof(double);
   if (displaceflag) bytes += (double)atom->nmax*3 * sizeof(double);
   if (velocityflag) bytes += (double)atom->nmax*3 * sizeof(double);
   return bytes;

--- a/src/USER-SMD/compute_smd_contact_radius.cpp
+++ b/src/USER-SMD/compute_smd_contact_radius.cpp
@@ -103,6 +103,6 @@ void ComputeSMDContactRadius::compute_peratom()
 
 double ComputeSMDContactRadius::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-SMD/compute_smd_damage.cpp
+++ b/src/USER-SMD/compute_smd_damage.cpp
@@ -103,6 +103,6 @@ void ComputeSMDDamage::compute_peratom()
 
 double ComputeSMDDamage::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-SMD/compute_smd_hourglass_error.cpp
+++ b/src/USER-SMD/compute_smd_hourglass_error.cpp
@@ -107,6 +107,6 @@ void ComputeSMDHourglassError::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDHourglassError::memory_usage() {
-        double bytes = nmax * sizeof(double);
+        double bytes = (double)nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_internal_energy.cpp
+++ b/src/USER-SMD/compute_smd_internal_energy.cpp
@@ -103,6 +103,6 @@ void ComputeSMDInternalEnergy::compute_peratom()
 
 double ComputeSMDInternalEnergy::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-SMD/compute_smd_plastic_strain.cpp
+++ b/src/USER-SMD/compute_smd_plastic_strain.cpp
@@ -103,6 +103,6 @@ void ComputeSMDPlasticStrain::compute_peratom()
 
 double ComputeSMDPlasticStrain::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-SMD/compute_smd_plastic_strain_rate.cpp
+++ b/src/USER-SMD/compute_smd_plastic_strain_rate.cpp
@@ -103,6 +103,6 @@ void ComputeSMDPlasticStrainRate::compute_peratom()
 
 double ComputeSMDPlasticStrainRate::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-SMD/compute_smd_rho.cpp
+++ b/src/USER-SMD/compute_smd_rho.cpp
@@ -101,6 +101,6 @@ void ComputeSMDRho::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDRho::memory_usage() {
-        double bytes = nmax * sizeof(double);
+        double bytes = (double)nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_tlsph_defgrad.cpp
+++ b/src/USER-SMD/compute_smd_tlsph_defgrad.cpp
@@ -130,6 +130,6 @@ void ComputeSMDTLSPHDefgrad::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDTLSPHDefgrad::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_tlsph_dt.cpp
+++ b/src/USER-SMD/compute_smd_tlsph_dt.cpp
@@ -110,6 +110,6 @@ void ComputeSMDTlsphDt::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDTlsphDt::memory_usage() {
-        double bytes = nmax * sizeof(double);
+        double bytes = (double)nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_tlsph_num_neighs.cpp
+++ b/src/USER-SMD/compute_smd_tlsph_num_neighs.cpp
@@ -102,6 +102,6 @@ void ComputeSMDTLSPHNumNeighs::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDTLSPHNumNeighs::memory_usage() {
-    double bytes = nmax * sizeof(double);
+    double bytes = (double)nmax * sizeof(double);
     return bytes;
 }

--- a/src/USER-SMD/compute_smd_tlsph_shape.cpp
+++ b/src/USER-SMD/compute_smd_tlsph_shape.cpp
@@ -130,6 +130,6 @@ void ComputeSmdTlsphShape::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSmdTlsphShape::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_tlsph_strain.cpp
+++ b/src/USER-SMD/compute_smd_tlsph_strain.cpp
@@ -139,6 +139,6 @@ void ComputeSMDTLSPHstrain::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDTLSPHstrain::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_tlsph_strain_rate.cpp
+++ b/src/USER-SMD/compute_smd_tlsph_strain_rate.cpp
@@ -112,6 +112,6 @@ void ComputeSMDTLSPHStrainRate::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDTLSPHStrainRate::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_tlsph_stress.cpp
+++ b/src/USER-SMD/compute_smd_tlsph_stress.cpp
@@ -129,6 +129,6 @@ void ComputeSMDTLSPHStress::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDTLSPHStress::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_triangle_vertices.cpp
+++ b/src/USER-SMD/compute_smd_triangle_vertices.cpp
@@ -118,6 +118,6 @@ void ComputeSMDTriangleVertices::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDTriangleVertices::memory_usage() {
-    double bytes = size_peratom_cols * nmax * sizeof(double);
+    double bytes = (double)size_peratom_cols * nmax * sizeof(double);
     return bytes;
 }

--- a/src/USER-SMD/compute_smd_ulsph_effm.cpp
+++ b/src/USER-SMD/compute_smd_ulsph_effm.cpp
@@ -110,6 +110,6 @@ void ComputeSMD_Ulsph_Effm::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMD_Ulsph_Effm::memory_usage() {
-        double bytes = nmax * sizeof(double);
+        double bytes = (double)nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_ulsph_num_neighs.cpp
+++ b/src/USER-SMD/compute_smd_ulsph_num_neighs.cpp
@@ -102,6 +102,6 @@ void ComputeSMDULSPHNumNeighs::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDULSPHNumNeighs::memory_usage() {
-    double bytes = nmax * sizeof(double);
+    double bytes = (double)nmax * sizeof(double);
     return bytes;
 }

--- a/src/USER-SMD/compute_smd_ulsph_strain.cpp
+++ b/src/USER-SMD/compute_smd_ulsph_strain.cpp
@@ -108,6 +108,6 @@ void ComputeSMDULSPHstrain::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDULSPHstrain::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_ulsph_strain_rate.cpp
+++ b/src/USER-SMD/compute_smd_ulsph_strain_rate.cpp
@@ -119,6 +119,6 @@ void ComputeSMDULSPHStrainRate::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDULSPHStrainRate::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMD/compute_smd_ulsph_stress.cpp
+++ b/src/USER-SMD/compute_smd_ulsph_stress.cpp
@@ -130,7 +130,7 @@ void ComputeSMDULSPHStress::compute_peratom() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDULSPHStress::memory_usage() {
-        double bytes = size_peratom_cols * nmax * sizeof(double);
+        double bytes = (double)size_peratom_cols * nmax * sizeof(double);
         return bytes;
 }
 

--- a/src/USER-SMD/compute_smd_vol.cpp
+++ b/src/USER-SMD/compute_smd_vol.cpp
@@ -125,6 +125,6 @@ double ComputeSMDVol::compute_scalar() {
  ------------------------------------------------------------------------- */
 
 double ComputeSMDVol::memory_usage() {
-        double bytes = nmax * sizeof(double);
+        double bytes = (double)nmax * sizeof(double);
         return bytes;
 }

--- a/src/USER-SMTBQ/pair_smtbq.cpp
+++ b/src/USER-SMTBQ/pair_smtbq.cpp
@@ -3524,7 +3524,7 @@ void PairSMTBQ::reverse_int(int *tab)
 
 double PairSMTBQ::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)nmax * sizeof(int);
   bytes += (double)MAXNEIGH * nmax * sizeof(int);

--- a/src/USER-SPH/compute_sph_e_atom.cpp
+++ b/src/USER-SPH/compute_sph_e_atom.cpp
@@ -93,6 +93,6 @@ void ComputeSPHEAtom::compute_peratom()
 
 double ComputeSPHEAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-SPH/compute_sph_rho_atom.cpp
+++ b/src/USER-SPH/compute_sph_rho_atom.cpp
@@ -94,6 +94,6 @@ void ComputeSPHRhoAtom::compute_peratom()
 
 double ComputeSPHRhoAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/USER-SPH/compute_sph_t_atom.cpp
+++ b/src/USER-SPH/compute_sph_t_atom.cpp
@@ -96,6 +96,6 @@ void ComputeSPHTAtom::compute_peratom()
 
 double ComputeSPHTAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/VORONOI/compute_voronoi_atom.cpp
+++ b/src/VORONOI/compute_voronoi_atom.cpp
@@ -614,7 +614,7 @@ void ComputeVoronoi::processCell(voronoicell_neighbor &c, int i)
 
 double ComputeVoronoi::memory_usage()
 {
-  double bytes = size_peratom_cols * nmax * sizeof(double);
+  double bytes = (double)size_peratom_cols * nmax * sizeof(double);
   // estimate based on average coordination of 12
   if (faces_flag) bytes += (double)12 * size_local_cols * nmax * sizeof(double);
   return bytes;

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -350,7 +350,7 @@ void Angle::ev_tally(int i, int j, int k, int nlocal, int newton_bond,
 
 double Angle::memory_usage()
 {
-  double bytes = comm->nthreads*maxeatom * sizeof(double);
+  double bytes = (double)comm->nthreads*maxeatom * sizeof(double);
   bytes += (double)comm->nthreads*maxvatom*6 * sizeof(double);
   bytes += (double)comm->nthreads*maxcvatom*9 * sizeof(double);
   return bytes;

--- a/src/angle_hybrid.cpp
+++ b/src/angle_hybrid.cpp
@@ -391,7 +391,7 @@ double AngleHybrid::single(int type, int i1, int i2, int i3)
 
 double AngleHybrid::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)maxcvatom*9 * sizeof(double);
   for (int m = 0; m < nstyles; m++) bytes += (double)maxangle[m]*4 * sizeof(int);

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -329,7 +329,7 @@ void Bond::write_file(int narg, char **arg)
 
 double Bond::memory_usage()
 {
-  double bytes = comm->nthreads*maxeatom * sizeof(double);
+  double bytes = (double)comm->nthreads*maxeatom * sizeof(double);
   bytes += (double)comm->nthreads*maxvatom*6 * sizeof(double);
   return bytes;
 }

--- a/src/bond_hybrid.cpp
+++ b/src/bond_hybrid.cpp
@@ -386,7 +386,7 @@ double BondHybrid::single(int type, double rsq, int i, int j,
 
 double BondHybrid::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   for (int m = 0; m < nstyles; m++) bytes += (double)maxbond[m]*3 * sizeof(int);
   for (int m = 0; m < nstyles; m++)

--- a/src/compute_aggregate_atom.cpp
+++ b/src/compute_aggregate_atom.cpp
@@ -312,6 +312,6 @@ void ComputeAggregateAtom::unpack_reverse_comm(int n, int *list, double *buf)
 
 double ComputeAggregateAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_angle_local.cpp
+++ b/src/compute_angle_local.cpp
@@ -343,6 +343,6 @@ void ComputeAngleLocal::reallocate(int n)
 
 double ComputeAngleLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -498,6 +498,6 @@ void ComputeBondLocal::reallocate(int n)
 
 double ComputeBondLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/compute_centro_atom.cpp
+++ b/src/compute_centro_atom.cpp
@@ -436,7 +436,7 @@ void ComputeCentroAtom::select2(int k, int n, double *arr, int *iarr)
 
 double ComputeCentroAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   if (axes_flag) bytes += (double)size_peratom_cols*nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -464,6 +464,6 @@ void ComputeCentroidStressAtom::unpack_reverse_comm(int n, int *list, double *bu
 
 double ComputeCentroidStressAtom::memory_usage()
 {
-  double bytes = nmax*9 * sizeof(double);
+  double bytes = (double)nmax*9 * sizeof(double);
   return bytes;
 }

--- a/src/compute_chunk_spread_atom.cpp
+++ b/src/compute_chunk_spread_atom.cpp
@@ -322,6 +322,6 @@ void ComputeChunkSpreadAtom::compute_peratom()
 
 double ComputeChunkSpreadAtom::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -267,6 +267,6 @@ void ComputeClusterAtom::unpack_forward_comm(int n, int first, double *buf)
 
 double ComputeClusterAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_cna_atom.cpp
+++ b/src/compute_cna_atom.cpp
@@ -355,7 +355,7 @@ void ComputeCNAAtom::compute_peratom()
 
 double ComputeCNAAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(int);
+  double bytes = (double)nmax * sizeof(int);
   bytes += (double)nmax * MAXNEAR * sizeof(int);
   bytes += (double)nmax * sizeof(double);
   return bytes;

--- a/src/compute_contact_atom.cpp
+++ b/src/compute_contact_atom.cpp
@@ -188,6 +188,6 @@ void ComputeContactAtom::unpack_reverse_comm(int n, int *list, double *buf)
 
 double ComputeContactAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -53,9 +53,7 @@ ComputeCoordAtom::ComputeCoordAtom(LAMMPS *lmp, int narg, char **arg) :
 
     int iarg = 5;
     if ((narg > 6) && (strcmp(arg[5],"group") == 0)) {
-      int len = strlen(arg[6])+1;
-      group2 = new char[len];
-      strcpy(group2,arg[6]);
+      group2 = utils::strdup(arg[6]);
       iarg += 2;
       jgroup = group->find(group2);
       if (jgroup == -1)

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -355,6 +355,6 @@ void ComputeCoordAtom::unpack_forward_comm(int n, int first, double *buf)
 
 double ComputeCoordAtom::memory_usage()
 {
-  double bytes = ncol*nmax * sizeof(double);
+  double bytes = (double)ncol*nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_dihedral_local.cpp
+++ b/src/compute_dihedral_local.cpp
@@ -353,6 +353,6 @@ void ComputeDihedralLocal::reallocate(int n)
 
 double ComputeDihedralLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/compute_displace_atom.cpp
+++ b/src/compute_displace_atom.cpp
@@ -247,7 +247,7 @@ void ComputeDisplaceAtom::refresh()
 
 double ComputeDisplaceAtom::memory_usage()
 {
-  double bytes = nmax*4 * sizeof(double);
+  double bytes = (double)nmax*4 * sizeof(double);
   bytes += (double)nvmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_erotate_sphere_atom.cpp
+++ b/src/compute_erotate_sphere_atom.cpp
@@ -105,6 +105,6 @@ void ComputeErotateSphereAtom::compute_peratom()
 
 double ComputeErotateSphereAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_fragment_atom.cpp
+++ b/src/compute_fragment_atom.cpp
@@ -285,7 +285,7 @@ void ComputeFragmentAtom::unpack_forward_comm(int n, int first, double *buf)
 
 double ComputeFragmentAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   bytes += (double)3*nmax * sizeof(int);
   return bytes;
 }

--- a/src/compute_global_atom.cpp
+++ b/src/compute_global_atom.cpp
@@ -483,7 +483,7 @@ void ComputeGlobalAtom::compute_peratom()
 
 double ComputeGlobalAtom::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   bytes += (double)nmax * sizeof(int);                    // indices
   if (varatom) bytes += (double)nmax * sizeof(double);    // varatom
   bytes += (double)maxvector * sizeof(double);            // vecglobal

--- a/src/compute_hexorder_atom.cpp
+++ b/src/compute_hexorder_atom.cpp
@@ -338,7 +338,7 @@ void ComputeHexOrderAtom::select2(int k, int n, double *arr, int *iarr)
 
 double ComputeHexOrderAtom::memory_usage()
 {
-  double bytes = ncol*nmax * sizeof(double);
+  double bytes = (double)ncol*nmax * sizeof(double);
   bytes += (double)maxneigh * sizeof(double);
   bytes += (double)maxneigh * sizeof(int);
 

--- a/src/compute_improper_local.cpp
+++ b/src/compute_improper_local.cpp
@@ -251,6 +251,6 @@ void ComputeImproperLocal::reallocate(int n)
 
 double ComputeImproperLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/compute_ke_atom.cpp
+++ b/src/compute_ke_atom.cpp
@@ -103,6 +103,6 @@ void ComputeKEAtom::compute_peratom()
 
 double ComputeKEAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_orientorder_atom.cpp
+++ b/src/compute_orientorder_atom.cpp
@@ -331,7 +331,7 @@ void ComputeOrientOrderAtom::compute_peratom()
 
 double ComputeOrientOrderAtom::memory_usage()
 {
-  double bytes = ncol*nmax * sizeof(double);
+  double bytes = (double)ncol*nmax * sizeof(double);
   bytes += (double)(qmax*(2*qmax+1)+maxneigh*4) * sizeof(double);
   bytes += (double)(nqlist+maxneigh) * sizeof(int);
   return bytes;

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -322,6 +322,6 @@ void ComputePairLocal::reallocate(int n)
 
 double ComputePairLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }

--- a/src/compute_pe_atom.cpp
+++ b/src/compute_pe_atom.cpp
@@ -200,6 +200,6 @@ void ComputePEAtom::unpack_reverse_comm(int n, int *list, double *buf)
 
 double ComputePEAtom::memory_usage()
 {
-  double bytes = nmax * sizeof(double);
+  double bytes = (double)nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_property_atom.cpp
+++ b/src/compute_property_atom.cpp
@@ -453,7 +453,7 @@ void ComputePropertyAtom::compute_peratom()
 
 double ComputePropertyAtom::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   return bytes;
 }
 

--- a/src/compute_property_atom.cpp
+++ b/src/compute_property_atom.cpp
@@ -361,14 +361,14 @@ ComputePropertyAtom::ComputePropertyAtom(LAMMPS *lmp, int narg, char **arg) :
                    "atom property that isn't allocated");
       pack_choice[i] = &ComputePropertyAtom::pack_nbonds;
 
-    } else if (strstr(arg[iarg],"i_") == arg[iarg]) {
+    } else if (utils::strmatch(arg[iarg],"^i_")) {
       int flag;
       index[i] = atom->find_custom(&arg[iarg][2],flag);
       if (index[i] < 0 || flag != 0)
         error->all(FLERR,"Compute property/atom integer "
                    "vector does not exist");
       pack_choice[i] = &ComputePropertyAtom::pack_iname;
-    } else if (strstr(arg[iarg],"d_") == arg[iarg]) {
+    } else if (utils::strmatch(arg[iarg],"^d_")) {
       int flag;
       index[i] = atom->find_custom(&arg[iarg][2],flag);
       if (index[i] < 0 || flag != 1)

--- a/src/compute_property_atom.cpp
+++ b/src/compute_property_atom.cpp
@@ -12,20 +12,22 @@
 ------------------------------------------------------------------------- */
 
 #include "compute_property_atom.h"
-#include <cmath>
-#include <cstring>
-#include "math_extra.h"
+
 #include "atom.h"
 #include "atom_vec.h"
+#include "atom_vec_body.h"
 #include "atom_vec_ellipsoid.h"
 #include "atom_vec_line.h"
 #include "atom_vec_tri.h"
-#include "atom_vec_body.h"
-#include "update.h"
-#include "domain.h"
 #include "comm.h"
-#include "memory.h"
+#include "domain.h"
 #include "error.h"
+#include "math_extra.h"
+#include "memory.h"
+#include "update.h"
+
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 

--- a/src/compute_property_local.cpp
+++ b/src/compute_property_local.cpp
@@ -650,7 +650,7 @@ void ComputePropertyLocal::reallocate(int n)
 
 double ComputePropertyLocal::memory_usage()
 {
-  double bytes = nmax*nvalues * sizeof(double);
+  double bytes = (double)nmax*nvalues * sizeof(double);
   bytes += (double)nmax*2 * sizeof(int);
   return bytes;
 }

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -662,6 +662,6 @@ void ComputeReduce::combine(double &one, double two, int i)
 
 double ComputeReduce::memory_usage()
 {
-  double bytes = maxatom * sizeof(double);
+  double bytes = (double)maxatom * sizeof(double);
   return bytes;
 }

--- a/src/compute_stress_atom.cpp
+++ b/src/compute_stress_atom.cpp
@@ -382,6 +382,6 @@ void ComputeStressAtom::unpack_reverse_comm(int n, int *list, double *buf)
 
 double ComputeStressAtom::memory_usage()
 {
-  double bytes = nmax*6 * sizeof(double);
+  double bytes = (double)nmax*6 * sizeof(double);
   return bytes;
 }

--- a/src/compute_temp_profile.cpp
+++ b/src/compute_temp_profile.cpp
@@ -577,7 +577,7 @@ void ComputeTempProfile::bin_assign()
 
 double ComputeTempProfile::memory_usage()
 {
-  double bytes = maxatom * sizeof(int);
+  double bytes = (double)maxatom * sizeof(int);
   bytes += (double)nbins*ncount * sizeof(double);
   return bytes;
 }

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -390,7 +390,7 @@ void Dihedral::ev_tally(int i1, int i2, int i3, int i4,
 
 double Dihedral::memory_usage()
 {
-  double bytes = comm->nthreads*maxeatom * sizeof(double);
+  double bytes = (double)comm->nthreads*maxeatom * sizeof(double);
   bytes += (double)comm->nthreads*maxvatom*6 * sizeof(double);
   bytes += (double)comm->nthreads*maxcvatom*9 * sizeof(double);
   return bytes;

--- a/src/dihedral_hybrid.cpp
+++ b/src/dihedral_hybrid.cpp
@@ -354,7 +354,7 @@ void DihedralHybrid::read_restart(FILE *fp)
 
 double DihedralHybrid::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)maxcvatom*9 * sizeof(double);
   for (int m = 0; m < nstyles; m++) bytes += (double)maxdihedral[m]*5 * sizeof(int);

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -13,29 +13,29 @@
 
 #include "dump_image.h"
 
+#include "atom.h"
+#include "atom_vec.h"
+#include "atom_vec_body.h"
+#include "atom_vec_line.h"
+#include "atom_vec_tri.h"
+#include "body.h"
+#include "comm.h"
+#include "domain.h"
+#include "error.h"
+#include "fix.h"
+#include "force.h"
+#include "image.h"
+#include "input.h"
+#include "math_const.h"
+#include "math_extra.h"
+#include "memory.h"
+#include "modify.h"
+#include "molecule.h"
+#include "variable.h"
+
 #include <cmath>
 #include <cctype>
 #include <cstring>
-#include "image.h"
-#include "atom.h"
-#include "atom_vec.h"
-#include "atom_vec_line.h"
-#include "atom_vec_tri.h"
-#include "atom_vec_body.h"
-#include "body.h"
-#include "molecule.h"
-#include "domain.h"
-#include "force.h"
-#include "comm.h"
-#include "modify.h"
-#include "fix.h"
-#include "input.h"
-#include "variable.h"
-#include "math_const.h"
-#include "math_extra.h"
-#include "error.h"
-#include "memory.h"
-
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -226,9 +226,7 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"view") == 0) {
       if (iarg+3 > narg) error->all(FLERR,"Illegal dump image command");
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        thetastr = new char[n];
-        strcpy(thetastr,&arg[iarg+1][2]);
+        thetastr = utils::strdup(arg[iarg+1]+2);
       } else {
         double theta = utils::numeric(FLERR,arg[iarg+1],false,lmp);
         if (theta < 0.0 || theta > 180.0)
@@ -237,9 +235,7 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
         image->theta = theta;
       }
       if (utils::strmatch(arg[iarg+2],"^v_")) {
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        phistr = new char[n];
-        strcpy(phistr,&arg[iarg+2][2]);
+        phistr = utils::strdup(arg[iarg+2]+2);
       } else {
         double phi = utils::numeric(FLERR,arg[iarg+2],false,lmp);
         phi *= MY_PI/180.0;
@@ -253,21 +249,15 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
       else if (strcmp(arg[iarg+1],"d") == 0) cflag = DYNAMIC;
       else error->all(FLERR,"Illegal dump image command");
       if (utils::strmatch(arg[iarg+2],"^v_")) {
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        cxstr = new char[n];
-        strcpy(cxstr,&arg[iarg+2][2]);
+        cxstr = utils::strdup(arg[iarg+2]+2);
         cflag = DYNAMIC;
       } else cx = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       if (utils::strmatch(arg[iarg+3],"^v_")) {
-        int n = strlen(&arg[iarg+3][2]) + 1;
-        cystr = new char[n];
-        strcpy(cystr,&arg[iarg+3][2]);
+        cystr = utils::strdup(arg[iarg+3]+2);
         cflag = DYNAMIC;
       } else cy = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (utils::strmatch(arg[iarg+4],"^v_")) {
-        int n = strlen(&arg[iarg+4][2]) + 1;
-        czstr = new char[n];
-        strcpy(czstr,&arg[iarg+4][2]);
+        czstr = utils::strdup(arg[iarg+4]+2);
         cflag = DYNAMIC;
       } else cz = utils::numeric(FLERR,arg[iarg+4],false,lmp);
       iarg += 5;
@@ -275,28 +265,20 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"up") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal dump image command");
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        upxstr = new char[n];
-        strcpy(upxstr,&arg[iarg+1][2]);
+        upxstr = utils::strdup(arg[iarg+1]+2);
       } else image->up[0] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) {
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        upystr = new char[n];
-        strcpy(upystr,&arg[iarg+2][2]);
+        upystr = utils::strdup(arg[iarg+2]+2);
       } else image->up[1] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       if (utils::strmatch(arg[iarg+3],"^v_")) {
-        int n = strlen(&arg[iarg+3][2]) + 1;
-        upzstr = new char[n];
-        strcpy(upzstr,&arg[iarg+3][2]);
+        upzstr = utils::strdup(arg[iarg+3]+2);
       } else image->up[2] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"zoom") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal dump image command");
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        zoomstr = new char[n];
-        strcpy(zoomstr,&arg[iarg+1][2]);
+        zoomstr = utils::strdup(arg[iarg+1]+2);
       } else {
         double zoom = utils::numeric(FLERR,arg[iarg+1],false,lmp);
         if (zoom <= 0.0) error->all(FLERR,"Illegal dump image command");

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -225,7 +225,7 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
 
     } else if (strcmp(arg[iarg],"view") == 0) {
       if (iarg+3 > narg) error->all(FLERR,"Illegal dump image command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         thetastr = new char[n];
         strcpy(thetastr,&arg[iarg+1][2]);
@@ -236,7 +236,7 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
         theta *= MY_PI/180.0;
         image->theta = theta;
       }
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+      if (utils::strmatch(arg[iarg+2],"^v_")) {
         int n = strlen(&arg[iarg+2][2]) + 1;
         phistr = new char[n];
         strcpy(phistr,&arg[iarg+2][2]);
@@ -252,19 +252,19 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
       if (strcmp(arg[iarg+1],"s") == 0) cflag = STATIC;
       else if (strcmp(arg[iarg+1],"d") == 0) cflag = DYNAMIC;
       else error->all(FLERR,"Illegal dump image command");
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+      if (utils::strmatch(arg[iarg+2],"^v_")) {
         int n = strlen(&arg[iarg+2][2]) + 1;
         cxstr = new char[n];
         strcpy(cxstr,&arg[iarg+2][2]);
         cflag = DYNAMIC;
       } else cx = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+      if (utils::strmatch(arg[iarg+3],"^v_")) {
         int n = strlen(&arg[iarg+3][2]) + 1;
         cystr = new char[n];
         strcpy(cystr,&arg[iarg+3][2]);
         cflag = DYNAMIC;
       } else cy = utils::numeric(FLERR,arg[iarg+3],false,lmp);
-      if (strstr(arg[iarg+4],"v_") == arg[iarg+4]) {
+      if (utils::strmatch(arg[iarg+4],"^v_")) {
         int n = strlen(&arg[iarg+4][2]) + 1;
         czstr = new char[n];
         strcpy(czstr,&arg[iarg+4][2]);
@@ -274,17 +274,17 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
 
     } else if (strcmp(arg[iarg],"up") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal dump image command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         upxstr = new char[n];
         strcpy(upxstr,&arg[iarg+1][2]);
       } else image->up[0] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+      if (utils::strmatch(arg[iarg+2],"^v_")) {
         int n = strlen(&arg[iarg+2][2]) + 1;
         upystr = new char[n];
         strcpy(upystr,&arg[iarg+2][2]);
       } else image->up[1] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+      if (utils::strmatch(arg[iarg+3],"^v_")) {
         int n = strlen(&arg[iarg+3][2]) + 1;
         upzstr = new char[n];
         strcpy(upzstr,&arg[iarg+3][2]);
@@ -293,7 +293,7 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
 
     } else if (strcmp(arg[iarg],"zoom") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal dump image command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         zoomstr = new char[n];
         strcpy(zoomstr,&arg[iarg+1][2]);

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -102,7 +102,7 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
       utils::bounds(FLERR,arg[iarg+4],1,atom->ntypes,
                     adapt[nadapt].jlo,adapt[nadapt].jhi,error);
-      if (strstr(arg[iarg+5],"v_") == arg[iarg+5]) {
+      if (utils::strmatch(arg[iarg+5],"^v_")) {
         n = strlen(&arg[iarg+5][2]) + 1;
         adapt[nadapt].var = new char[n];
         strcpy(adapt[nadapt].var,&arg[iarg+5][2]);
@@ -122,7 +122,7 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
       strcpy(adapt[nadapt].bparam,arg[iarg+2]);
       utils::bounds(FLERR,arg[iarg+3],1,atom->nbondtypes,
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
-      if (strstr(arg[iarg+4],"v_") == arg[iarg+4]) {
+      if (utils::strmatch(arg[iarg+4],"^v_")) {
         n = strlen(&arg[iarg+4][2]) + 1;
         adapt[nadapt].var = new char[n];
         strcpy(adapt[nadapt].var,&arg[iarg+4][2]);
@@ -133,7 +133,7 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
     } else if (strcmp(arg[iarg],"kspace") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix adapt command");
       adapt[nadapt].which = KSPACE;
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         adapt[nadapt].var = new char[n];
         strcpy(adapt[nadapt].var,&arg[iarg+1][2]);
@@ -154,7 +154,7 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
         adapt[nadapt].aparam = CHARGE;
         chgflag = 1;
       } else error->all(FLERR,"Illegal fix adapt command");
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+      if (utils::strmatch(arg[iarg+2],"^v_")) {
         int n = strlen(&arg[iarg+2][2]) + 1;
         adapt[nadapt].var = new char[n];
         strcpy(adapt[nadapt].var,&arg[iarg+2][2]);

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -12,26 +12,26 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_adapt.h"
-#include <cstring>
+
 #include "atom.h"
 #include "bond.h"
 #include "domain.h"
-#include "update.h"
-#include "group.h"
-#include "modify.h"
-#include "force.h"
-#include "pair.h"
-#include "pair_hybrid.h"
-#include "kspace.h"
+#include "error.h"
 #include "fix_store.h"
+#include "force.h"
+#include "group.h"
 #include "input.h"
-#include "variable.h"
-#include "respa.h"
+#include "kspace.h"
 #include "math_const.h"
 #include "memory.h"
-#include "error.h"
+#include "modify.h"
+#include "pair.h"
+#include "pair_hybrid.h"
+#include "respa.h"
+#include "update.h"
+#include "variable.h"
 
-
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -91,21 +91,15 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
     if (strcmp(arg[iarg],"pair") == 0) {
       if (iarg+6 > narg) error->all(FLERR,"Illegal fix adapt command");
       adapt[nadapt].which = PAIR;
-      int n = strlen(arg[iarg+1]) + 1;
-      adapt[nadapt].pstyle = new char[n];
-      strcpy(adapt[nadapt].pstyle,arg[iarg+1]);
-      n = strlen(arg[iarg+2]) + 1;
-      adapt[nadapt].pparam = new char[n];
       adapt[nadapt].pair = nullptr;
-      strcpy(adapt[nadapt].pparam,arg[iarg+2]);
+      adapt[nadapt].pstyle = utils::strdup(arg[iarg+1]);
+      adapt[nadapt].pparam = utils::strdup(arg[iarg+2]);
       utils::bounds(FLERR,arg[iarg+3],1,atom->ntypes,
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
       utils::bounds(FLERR,arg[iarg+4],1,atom->ntypes,
                     adapt[nadapt].jlo,adapt[nadapt].jhi,error);
       if (utils::strmatch(arg[iarg+5],"^v_")) {
-        n = strlen(&arg[iarg+5][2]) + 1;
-        adapt[nadapt].var = new char[n];
-        strcpy(adapt[nadapt].var,&arg[iarg+5][2]);
+        adapt[nadapt].var = utils::strdup(arg[iarg+5]+2);
       } else error->all(FLERR,"Illegal fix adapt command");
       nadapt++;
       iarg += 6;
@@ -113,19 +107,13 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
     } else if (strcmp(arg[iarg],"bond") == 0) {
       if (iarg+5 > narg) error->all(FLERR, "Illegal fix adapt command");
       adapt[nadapt].which = BOND;
-      int n = strlen(arg[iarg+1]) + 1;
-      adapt[nadapt].bstyle = new char[n];
-      strcpy(adapt[nadapt].bstyle,arg[iarg+1]);
-      n = strlen(arg[iarg+2]) + 1;
-      adapt[nadapt].bparam = new char[n];
       adapt[nadapt].bond = nullptr;
-      strcpy(adapt[nadapt].bparam,arg[iarg+2]);
+      adapt[nadapt].bstyle = utils::strdup(arg[iarg+1]);
+      adapt[nadapt].bparam = utils::strdup(arg[iarg+2]);
       utils::bounds(FLERR,arg[iarg+3],1,atom->nbondtypes,
                     adapt[nadapt].ilo,adapt[nadapt].ihi,error);
       if (utils::strmatch(arg[iarg+4],"^v_")) {
-        n = strlen(&arg[iarg+4][2]) + 1;
-        adapt[nadapt].var = new char[n];
-        strcpy(adapt[nadapt].var,&arg[iarg+4][2]);
+        adapt[nadapt].var = utils::strdup(arg[iarg+4]+2);
       } else error->all(FLERR,"Illegal fix adapt command");
       nadapt++;
       iarg += 5;
@@ -134,9 +122,7 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix adapt command");
       adapt[nadapt].which = KSPACE;
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        adapt[nadapt].var = new char[n];
-        strcpy(adapt[nadapt].var,&arg[iarg+1][2]);
+        adapt[nadapt].var = utils::strdup(arg[iarg+1]+2);
       } else error->all(FLERR,"Illegal fix adapt command");
       nadapt++;
       iarg += 2;
@@ -155,9 +141,7 @@ nadapt(0), id_fix_diam(nullptr), id_fix_chg(nullptr), adapt(nullptr)
         chgflag = 1;
       } else error->all(FLERR,"Illegal fix adapt command");
       if (utils::strmatch(arg[iarg+2],"^v_")) {
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        adapt[nadapt].var = new char[n];
-        strcpy(adapt[nadapt].var,&arg[iarg+2][2]);
+        adapt[nadapt].var = utils::strdup(arg[iarg+2]+2);
       } else error->all(FLERR,"Illegal fix adapt command");
       nadapt++;
       iarg += 3;
@@ -268,8 +252,7 @@ void FixAdapt::post_constructor()
 
   if (diamflag && atom->radius_flag) {
     std::string fixcmd = id + std::string("_FIX_STORE_DIAM");
-    id_fix_diam = new char[fixcmd.size()+1];
-    strcpy(id_fix_diam,fixcmd.c_str());
+    id_fix_diam = utils::strdup(fixcmd);
     fixcmd += fmt::format(" {} STORE peratom 1 1",group->names[igroup]);
     modify->add_fix(fixcmd);
     fix_diam = (FixStore *) modify->fix[modify->nfix-1];
@@ -290,8 +273,7 @@ void FixAdapt::post_constructor()
 
   if (chgflag && atom->q_flag) {
     std::string fixcmd = id + std::string("_FIX_STORE_CHG");
-    id_fix_chg = new char[fixcmd.size()+1];
-    strcpy(id_fix_chg,fixcmd.c_str());
+    id_fix_chg = utils::strdup(fixcmd);
     fixcmd += fmt::format(" {} STORE peratom 1 1",group->names[igroup]);
     modify->add_fix(fixcmd);
     fix_chg = (FixStore *) modify->fix[modify->nfix-1];
@@ -346,10 +328,7 @@ void FixAdapt::init()
       //   strip it for pstyle arg to pair_match() and set nsub = N
       // this should work for appended suffixes as well
 
-      int n = strlen(ad->pstyle) + 1;
-      char *pstyle = new char[n];
-      strcpy(pstyle,ad->pstyle);
-
+      char *pstyle = strdup(ad->pstyle);
       char *cptr;
       int nsub = 0;
       if ((cptr = strchr(pstyle,':'))) {
@@ -399,10 +378,7 @@ void FixAdapt::init()
       ad->bond = nullptr;
       anybond = 1;
 
-      int n = strlen(ad->bstyle) + 1;
-      char *bstyle = new char[n];
-      strcpy(bstyle,ad->bstyle);
-
+      char *bstyle = utils::strdup(ad->bstyle);
       if (lmp->suffix_enable) {
         int len = 2 + strlen(bstyle) + strlen(lmp->suffix);
         char *bsuffix = new char[len];

--- a/src/fix_addforce.cpp
+++ b/src/fix_addforce.cpp
@@ -54,7 +54,7 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
 
   xstr = ystr = zstr = nullptr;
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     xstr = new char[n];
     strcpy(xstr,&arg[3][2]);
@@ -62,7 +62,7 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
     xvalue = utils::numeric(FLERR,arg[3],false,lmp);
     xstyle = CONSTANT;
   }
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(&arg[4][2]) + 1;
     ystr = new char[n];
     strcpy(ystr,&arg[4][2]);
@@ -70,7 +70,7 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
     yvalue = utils::numeric(FLERR,arg[4],false,lmp);
     ystyle = CONSTANT;
   }
-  if (strstr(arg[5],"v_") == arg[5]) {
+  if (utils::strmatch(arg[5],"^v_")) {
     int n = strlen(&arg[5][2]) + 1;
     zstr = new char[n];
     strcpy(zstr,&arg[5][2]);
@@ -102,7 +102,7 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
       iarg += 2;
     } else if (strcmp(arg[iarg],"energy") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix addforce command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         estr = new char[n];
         strcpy(estr,&arg[iarg+1][2]);

--- a/src/fix_addforce.cpp
+++ b/src/fix_addforce.cpp
@@ -55,25 +55,19 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
   xstr = ystr = zstr = nullptr;
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    xstr = new char[n];
-    strcpy(xstr,&arg[3][2]);
+    xstr = utils::strdup(arg[3]+2);
   } else {
     xvalue = utils::numeric(FLERR,arg[3],false,lmp);
     xstyle = CONSTANT;
   }
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(&arg[4][2]) + 1;
-    ystr = new char[n];
-    strcpy(ystr,&arg[4][2]);
+    ystr = utils::strdup(arg[4]+2);
   } else {
     yvalue = utils::numeric(FLERR,arg[4],false,lmp);
     ystyle = CONSTANT;
   }
   if (utils::strmatch(arg[5],"^v_")) {
-    int n = strlen(&arg[5][2]) + 1;
-    zstr = new char[n];
-    strcpy(zstr,&arg[5][2]);
+    zstr = utils::strdup(arg[5]+2);
   } else {
     zvalue = utils::numeric(FLERR,arg[5],false,lmp);
     zstyle = CONSTANT;
@@ -96,16 +90,12 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
       iregion = domain->find_region(arg[iarg+1]);
       if (iregion == -1)
         error->all(FLERR,"Region ID for fix addforce does not exist");
-      int n = strlen(arg[iarg+1]) + 1;
-      idregion = new char[n];
-      strcpy(idregion,arg[iarg+1]);
+      idregion = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else if (strcmp(arg[iarg],"energy") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix addforce command");
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        estr = new char[n];
-        strcpy(estr,&arg[iarg+1][2]);
+        estr = utils::strdup(arg[iarg+1]+2);
       } else error->all(FLERR,"Illegal fix addforce command");
       iarg += 2;
     } else error->all(FLERR,"Illegal fix addforce command");

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -1131,7 +1131,7 @@ bigint FixAveChunk::nextvalid()
 
 double FixAveChunk::memory_usage()
 {
-  double bytes = maxvar * sizeof(double);         // varatom
+  double bytes = (double)maxvar * sizeof(double);         // varatom
   bytes += (double)4*maxchunk * sizeof(double);           // count one,many,sum,total
   bytes += (double)nvalues*maxchunk * sizeof(double);     // values one,many,sum,total
   bytes += (double)nwindow*maxchunk * sizeof(double);          // count_list

--- a/src/fix_aveforce.cpp
+++ b/src/fix_aveforce.cpp
@@ -49,9 +49,7 @@ FixAveForce::FixAveForce(LAMMPS *lmp, int narg, char **arg) :
   xstr = ystr = zstr = nullptr;
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    xstr = new char[n];
-    strcpy(xstr,&arg[3][2]);
+    xstr = utils::strdup(arg[3]+2);
   } else if (strcmp(arg[3],"NULL") == 0) {
     xstyle = NONE;
   } else {
@@ -59,9 +57,7 @@ FixAveForce::FixAveForce(LAMMPS *lmp, int narg, char **arg) :
     xstyle = CONSTANT;
   }
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(&arg[4][2]) + 1;
-    ystr = new char[n];
-    strcpy(ystr,&arg[4][2]);
+    ystr = utils::strdup(arg[4]+2);
   } else if (strcmp(arg[4],"NULL") == 0) {
     ystyle = NONE;
   } else {
@@ -69,9 +65,7 @@ FixAveForce::FixAveForce(LAMMPS *lmp, int narg, char **arg) :
     ystyle = CONSTANT;
   }
   if (utils::strmatch(arg[5],"^v_")) {
-    int n = strlen(&arg[5][2]) + 1;
-    zstr = new char[n];
-    strcpy(zstr,&arg[5][2]);
+    zstr = utils::strdup(arg[5]+2);
   } else if (strcmp(arg[5],"NULL") == 0) {
     zstyle = NONE;
   } else {
@@ -91,9 +85,7 @@ FixAveForce::FixAveForce(LAMMPS *lmp, int narg, char **arg) :
       iregion = domain->find_region(arg[iarg+1]);
       if (iregion == -1)
         error->all(FLERR,"Region ID for fix aveforce does not exist");
-      int n = strlen(arg[iarg+1]) + 1;
-      idregion = new char[n];
-      strcpy(idregion,arg[iarg+1]);
+      idregion = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else error->all(FLERR,"Illegal fix aveforce command");
 

--- a/src/fix_aveforce.cpp
+++ b/src/fix_aveforce.cpp
@@ -48,7 +48,7 @@ FixAveForce::FixAveForce(LAMMPS *lmp, int narg, char **arg) :
 
   xstr = ystr = zstr = nullptr;
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     xstr = new char[n];
     strcpy(xstr,&arg[3][2]);
@@ -58,7 +58,7 @@ FixAveForce::FixAveForce(LAMMPS *lmp, int narg, char **arg) :
     xvalue = utils::numeric(FLERR,arg[3],false,lmp);
     xstyle = CONSTANT;
   }
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(&arg[4][2]) + 1;
     ystr = new char[n];
     strcpy(ystr,&arg[4][2]);
@@ -68,7 +68,7 @@ FixAveForce::FixAveForce(LAMMPS *lmp, int narg, char **arg) :
     yvalue = utils::numeric(FLERR,arg[4],false,lmp);
     ystyle = CONSTANT;
   }
-  if (strstr(arg[5],"v_") == arg[5]) {
+  if (utils::strmatch(arg[5],"^v_")) {
     int n = strlen(&arg[5][2]) + 1;
     zstr = new char[n];
     strcpy(zstr,&arg[5][2]);

--- a/src/fix_gravity.cpp
+++ b/src/fix_gravity.cpp
@@ -53,9 +53,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
   mstyle = vstyle = pstyle = tstyle = xstyle = ystyle = zstyle = CONSTANT;
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    mstr = new char[n];
-    strcpy(mstr,&arg[3][2]);
+    mstr = utils::strdup(arg[3]+2);
     mstyle = EQUAL;
   } else {
     magnitude = utils::numeric(FLERR,arg[3],false,lmp);
@@ -68,9 +66,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
     if (narg < 6) error->all(FLERR,"Illegal fix gravity command");
     style = CHUTE;
     if (utils::strmatch(arg[5],"^v_")) {
-      int n = strlen(&arg[5][2]) + 1;
-      vstr = new char[n];
-      strcpy(vstr,&arg[5][2]);
+      vstr = utils::strdup(arg[5]+2);
       vstyle = EQUAL;
     } else {
       vert = utils::numeric(FLERR,arg[5],false,lmp);
@@ -82,18 +78,14 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
     if (narg < 7) error->all(FLERR,"Illegal fix gravity command");
     style = SPHERICAL;
     if (utils::strmatch(arg[5],"^v_")) {
-      int n = strlen(&arg[5][2]) + 1;
-      pstr = new char[n];
-      strcpy(pstr,&arg[5][2]);
+      pstr = utils::strdup(arg[5]+2);
       pstyle = EQUAL;
     } else {
       phi = utils::numeric(FLERR,arg[5],false,lmp);
       pstyle = CONSTANT;
     }
     if (utils::strmatch(arg[6],"^v_")) {
-      int n = strlen(&arg[6][2]) + 1;
-      tstr = new char[n];
-      strcpy(tstr,&arg[6][2]);
+      tstr = utils::strdup(arg[6]+2);
       tstyle = EQUAL;
     } else {
       theta = utils::numeric(FLERR,arg[6],false,lmp);
@@ -105,27 +97,21 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
     if (narg < 8) error->all(FLERR,"Illegal fix gravity command");
     style = VECTOR;
     if (utils::strmatch(arg[5],"^v_")) {
-      int n = strlen(&arg[5][2]) + 1;
-      xstr = new char[n];
-      strcpy(xstr,&arg[5][2]);
+      xstr = utils::strdup(arg[5]+2);
       xstyle = EQUAL;
     } else {
       xdir = utils::numeric(FLERR,arg[5],false,lmp);
       xstyle = CONSTANT;
     }
     if (utils::strmatch(arg[6],"^v_")) {
-      int n = strlen(&arg[6][2]) + 1;
-      ystr = new char[n];
-      strcpy(ystr,&arg[6][2]);
+      ystr = utils::strdup(arg[6]+2);
       ystyle = EQUAL;
     } else {
       ydir = utils::numeric(FLERR,arg[6],false,lmp);
       ystyle = CONSTANT;
     }
     if (utils::strmatch(arg[7],"^v_")) {
-      int n = strlen(&arg[7][2]) + 1;
-      zstr = new char[n];
-      strcpy(zstr,&arg[7][2]);
+      zstr = utils::strdup(arg[7]+2);
       zstyle = EQUAL;
     } else {
       zdir = utils::numeric(FLERR,arg[7],false,lmp);

--- a/src/fix_gravity.cpp
+++ b/src/fix_gravity.cpp
@@ -52,7 +52,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
   mstr = vstr = pstr = tstr = xstr = ystr = zstr = nullptr;
   mstyle = vstyle = pstyle = tstyle = xstyle = ystyle = zstyle = CONSTANT;
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     mstr = new char[n];
     strcpy(mstr,&arg[3][2]);
@@ -67,7 +67,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
   if (strcmp(arg[4],"chute") == 0) {
     if (narg < 6) error->all(FLERR,"Illegal fix gravity command");
     style = CHUTE;
-    if (strstr(arg[5],"v_") == arg[5]) {
+    if (utils::strmatch(arg[5],"^v_")) {
       int n = strlen(&arg[5][2]) + 1;
       vstr = new char[n];
       strcpy(vstr,&arg[5][2]);
@@ -81,7 +81,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
   } else if (strcmp(arg[4],"spherical") == 0) {
     if (narg < 7) error->all(FLERR,"Illegal fix gravity command");
     style = SPHERICAL;
-    if (strstr(arg[5],"v_") == arg[5]) {
+    if (utils::strmatch(arg[5],"^v_")) {
       int n = strlen(&arg[5][2]) + 1;
       pstr = new char[n];
       strcpy(pstr,&arg[5][2]);
@@ -90,7 +90,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
       phi = utils::numeric(FLERR,arg[5],false,lmp);
       pstyle = CONSTANT;
     }
-    if (strstr(arg[6],"v_") == arg[6]) {
+    if (utils::strmatch(arg[6],"^v_")) {
       int n = strlen(&arg[6][2]) + 1;
       tstr = new char[n];
       strcpy(tstr,&arg[6][2]);
@@ -104,7 +104,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
   } else if (strcmp(arg[4],"vector") == 0) {
     if (narg < 8) error->all(FLERR,"Illegal fix gravity command");
     style = VECTOR;
-    if (strstr(arg[5],"v_") == arg[5]) {
+    if (utils::strmatch(arg[5],"^v_")) {
       int n = strlen(&arg[5][2]) + 1;
       xstr = new char[n];
       strcpy(xstr,&arg[5][2]);
@@ -113,7 +113,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
       xdir = utils::numeric(FLERR,arg[5],false,lmp);
       xstyle = CONSTANT;
     }
-    if (strstr(arg[6],"v_") == arg[6]) {
+    if (utils::strmatch(arg[6],"^v_")) {
       int n = strlen(&arg[6][2]) + 1;
       ystr = new char[n];
       strcpy(ystr,&arg[6][2]);
@@ -122,7 +122,7 @@ FixGravity::FixGravity(LAMMPS *lmp, int narg, char **arg) :
       ydir = utils::numeric(FLERR,arg[6],false,lmp);
       ystyle = CONSTANT;
     }
-    if (strstr(arg[7],"v_") == arg[7]) {
+    if (utils::strmatch(arg[7],"^v_")) {
       int n = strlen(&arg[7][2]) + 1;
       zstr = new char[n];
       strcpy(zstr,&arg[7][2]);

--- a/src/fix_heat.cpp
+++ b/src/fix_heat.cpp
@@ -52,7 +52,7 @@ idregion(nullptr), hstr(nullptr), vheat(nullptr), vscale(nullptr)
 
   hstr = nullptr;
 
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(&arg[4][2]) + 1;
     hstr = new char[n];
     strcpy(hstr,&arg[4][2]);

--- a/src/fix_heat.cpp
+++ b/src/fix_heat.cpp
@@ -17,19 +17,20 @@
 
 #include "fix_heat.h"
 
-#include <cmath>
-#include <cstring>
 #include "atom.h"
 #include "domain.h"
-#include "region.h"
-#include "group.h"
-#include "force.h"
-#include "update.h"
-#include "modify.h"
-#include "input.h"
-#include "variable.h"
-#include "memory.h"
 #include "error.h"
+#include "force.h"
+#include "group.h"
+#include "input.h"
+#include "memory.h"
+#include "modify.h"
+#include "region.h"
+#include "update.h"
+#include "variable.h"
+
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -53,9 +54,7 @@ idregion(nullptr), hstr(nullptr), vheat(nullptr), vscale(nullptr)
   hstr = nullptr;
 
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(&arg[4][2]) + 1;
-    hstr = new char[n];
-    strcpy(hstr,&arg[4][2]);
+    hstr = utils::strdup(arg[4]+2);
   } else {
     heat_input = utils::numeric(FLERR,arg[4],false,lmp);
     hstyle = CONSTANT;
@@ -72,9 +71,7 @@ idregion(nullptr), hstr(nullptr), vheat(nullptr), vscale(nullptr)
       iregion = domain->find_region(arg[iarg+1]);
       if (iregion == -1)
         error->all(FLERR,"Region ID for fix heat does not exist");
-      int n = strlen(arg[iarg+1]) + 1;
-      idregion = new char[n];
-      strcpy(idregion,arg[iarg+1]);
+      idregion = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else error->all(FLERR,"Illegal fix heat command");
   }

--- a/src/fix_indent.cpp
+++ b/src/fix_indent.cpp
@@ -418,24 +418,16 @@ void FixIndent::options(int narg, char **arg)
       if (iarg+5 > narg) error->all(FLERR,"Illegal fix indent command");
 
       if (utils::strmatch(arg[iarg+1],"^v_")) {
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        xstr = new char[n];
-        strcpy(xstr,&arg[iarg+1][2]);
+        xstr = utils::strdup(arg[iarg+1]+2);
       } else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) {
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        ystr = new char[n];
-        strcpy(ystr,&arg[iarg+2][2]);
+        ystr = utils::strdup(arg[iarg+2]+2);
       } else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       if (utils::strmatch(arg[iarg+3],"^v_")) {
-        int n = strlen(&arg[iarg+3][2]) + 1;
-        zstr = new char[n];
-        strcpy(zstr,&arg[iarg+3][2]);
+        zstr = utils::strdup(arg[iarg+3]+2);
       } else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (utils::strmatch(arg[iarg+4],"^v_")) {
-        int n = strlen(&arg[iarg+4][2]) + 1;
-        rstr = new char[n];
-        strcpy(rstr,&arg[iarg+4][2]);
+        rstr = utils::strdup(arg[iarg+4]+2);
       } else rvalue = utils::numeric(FLERR,arg[iarg+4],false,lmp);
 
       istyle = SPHERE;
@@ -447,45 +439,31 @@ void FixIndent::options(int narg, char **arg)
       if (strcmp(arg[iarg+1],"x") == 0) {
         cdim = 0;
         if (utils::strmatch(arg[iarg+2],"^v_")) {
-          int n = strlen(&arg[iarg+2][2]) + 1;
-          ystr = new char[n];
-          strcpy(ystr,&arg[iarg+2][2]);
+          ystr = utils::strdup(arg[iarg+2]+2);
         } else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
         if (utils::strmatch(arg[iarg+3],"^v_")) {
-          int n = strlen(&arg[iarg+3][2]) + 1;
-          zstr = new char[n];
-          strcpy(zstr,&arg[iarg+3][2]);
+          zstr = utils::strdup(arg[iarg+3]+2);
         } else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       } else if (strcmp(arg[iarg+1],"y") == 0) {
         cdim = 1;
         if (utils::strmatch(arg[iarg+2],"^v_")) {
-          int n = strlen(&arg[iarg+2][2]) + 1;
-          xstr = new char[n];
-          strcpy(xstr,&arg[iarg+2][2]);
+          xstr = utils::strdup(arg[iarg+2]+2);
         } else xvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
         if (utils::strmatch(arg[iarg+3],"^v_")) {
-          int n = strlen(&arg[iarg+3][2]) + 1;
-          zstr = new char[n];
-          strcpy(zstr,&arg[iarg+3][2]);
+          zstr = utils::strdup(arg[iarg+3]+2);
         } else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       } else if (strcmp(arg[iarg+1],"z") == 0) {
         cdim = 2;
         if (utils::strmatch(arg[iarg+2],"^v_")) {
-          int n = strlen(&arg[iarg+2][2]) + 1;
-          xstr = new char[n];
-          strcpy(xstr,&arg[iarg+2][2]);
+          xstr = utils::strdup(arg[iarg+2]+2);
         } else xvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
         if (utils::strmatch(arg[iarg+3],"^v_")) {
-          int n = strlen(&arg[iarg+3][2]) + 1;
-          ystr = new char[n];
-          strcpy(ystr,&arg[iarg+3][2]);
+          ystr = utils::strdup(arg[iarg+3]+2);
         } else yvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       } else error->all(FLERR,"Illegal fix indent command");
 
       if (utils::strmatch(arg[iarg+4],"^v_")) {
-        int n = strlen(&arg[iarg+4][2]) + 1;
-        rstr = new char[n];
-        strcpy(rstr,&arg[iarg+4][2]);
+        rstr = utils::strdup(arg[iarg+4]+2);
       } else rvalue = utils::numeric(FLERR,arg[iarg+4],false,lmp);
 
       istyle = CYLINDER;
@@ -499,9 +477,7 @@ void FixIndent::options(int narg, char **arg)
       else error->all(FLERR,"Illegal fix indent command");
 
       if (utils::strmatch(arg[iarg+2],"^v_")) {
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        pstr = new char[n];
-        strcpy(pstr,&arg[iarg+2][2]);
+        pstr = utils::strdup(arg[iarg+2]+2);
       } else pvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
 
       if (strcmp(arg[iarg+3],"lo") == 0) planeside = -1;

--- a/src/fix_indent.cpp
+++ b/src/fix_indent.cpp
@@ -417,22 +417,22 @@ void FixIndent::options(int narg, char **arg)
     if (strcmp(arg[iarg],"sphere") == 0) {
       if (iarg+5 > narg) error->all(FLERR,"Illegal fix indent command");
 
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      if (utils::strmatch(arg[iarg+1],"^v_")) {
         int n = strlen(&arg[iarg+1][2]) + 1;
         xstr = new char[n];
         strcpy(xstr,&arg[iarg+1][2]);
       } else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+      if (utils::strmatch(arg[iarg+2],"^v_")) {
         int n = strlen(&arg[iarg+2][2]) + 1;
         ystr = new char[n];
         strcpy(ystr,&arg[iarg+2][2]);
       } else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+      if (utils::strmatch(arg[iarg+3],"^v_")) {
         int n = strlen(&arg[iarg+3][2]) + 1;
         zstr = new char[n];
         strcpy(zstr,&arg[iarg+3][2]);
       } else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
-      if (strstr(arg[iarg+4],"v_") == arg[iarg+4]) {
+      if (utils::strmatch(arg[iarg+4],"^v_")) {
         int n = strlen(&arg[iarg+4][2]) + 1;
         rstr = new char[n];
         strcpy(rstr,&arg[iarg+4][2]);
@@ -446,43 +446,43 @@ void FixIndent::options(int narg, char **arg)
 
       if (strcmp(arg[iarg+1],"x") == 0) {
         cdim = 0;
-        if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+        if (utils::strmatch(arg[iarg+2],"^v_")) {
           int n = strlen(&arg[iarg+2][2]) + 1;
           ystr = new char[n];
           strcpy(ystr,&arg[iarg+2][2]);
         } else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-        if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+        if (utils::strmatch(arg[iarg+3],"^v_")) {
           int n = strlen(&arg[iarg+3][2]) + 1;
           zstr = new char[n];
           strcpy(zstr,&arg[iarg+3][2]);
         } else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       } else if (strcmp(arg[iarg+1],"y") == 0) {
         cdim = 1;
-        if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+        if (utils::strmatch(arg[iarg+2],"^v_")) {
           int n = strlen(&arg[iarg+2][2]) + 1;
           xstr = new char[n];
           strcpy(xstr,&arg[iarg+2][2]);
         } else xvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-        if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+        if (utils::strmatch(arg[iarg+3],"^v_")) {
           int n = strlen(&arg[iarg+3][2]) + 1;
           zstr = new char[n];
           strcpy(zstr,&arg[iarg+3][2]);
         } else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       } else if (strcmp(arg[iarg+1],"z") == 0) {
         cdim = 2;
-        if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+        if (utils::strmatch(arg[iarg+2],"^v_")) {
           int n = strlen(&arg[iarg+2][2]) + 1;
           xstr = new char[n];
           strcpy(xstr,&arg[iarg+2][2]);
         } else xvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-        if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+        if (utils::strmatch(arg[iarg+3],"^v_")) {
           int n = strlen(&arg[iarg+3][2]) + 1;
           ystr = new char[n];
           strcpy(ystr,&arg[iarg+3][2]);
         } else yvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       } else error->all(FLERR,"Illegal fix indent command");
 
-      if (strstr(arg[iarg+4],"v_") == arg[iarg+4]) {
+      if (utils::strmatch(arg[iarg+4],"^v_")) {
         int n = strlen(&arg[iarg+4][2]) + 1;
         rstr = new char[n];
         strcpy(rstr,&arg[iarg+4][2]);
@@ -498,7 +498,7 @@ void FixIndent::options(int narg, char **arg)
       else if (strcmp(arg[iarg+1],"z") == 0) cdim = 2;
       else error->all(FLERR,"Illegal fix indent command");
 
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+      if (utils::strmatch(arg[iarg+2],"^v_")) {
         int n = strlen(&arg[iarg+2][2]) + 1;
         pstr = new char[n];
         strcpy(pstr,&arg[iarg+2][2]);

--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -64,7 +64,7 @@ FixLangevin::FixLangevin(LAMMPS *lmp, int narg, char **arg) :
   extscalar = 1;
   nevery = 1;
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     tstr = new char[n];
     strcpy(tstr,&arg[3][2]);

--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -21,24 +21,24 @@
 
 #include "fix_langevin.h"
 
-#include <cmath>
-#include <cstring>
-#include "math_extra.h"
 #include "atom.h"
 #include "atom_vec_ellipsoid.h"
-#include "force.h"
-#include "update.h"
-#include "modify.h"
-#include "compute.h"
-#include "respa.h"
 #include "comm.h"
-#include "input.h"
-#include "variable.h"
-#include "random_mars.h"
-#include "memory.h"
+#include "compute.h"
 #include "error.h"
+#include "force.h"
 #include "group.h"
+#include "input.h"
+#include "math_extra.h"
+#include "memory.h"
+#include "modify.h"
+#include "random_mars.h"
+#include "respa.h"
+#include "update.h"
+#include "variable.h"
 
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -65,9 +65,7 @@ FixLangevin::FixLangevin(LAMMPS *lmp, int narg, char **arg) :
   nevery = 1;
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    tstr = new char[n];
-    strcpy(tstr,&arg[3][2]);
+    tstr = utils::strdup(arg[3]+2);
   } else {
     t_start = utils::numeric(FLERR,arg[3],false,lmp);
     t_target = t_start;
@@ -1032,9 +1030,7 @@ int FixLangevin::modify_param(int narg, char **arg)
   if (strcmp(arg[0],"temp") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal fix_modify command");
     delete [] id_temp;
-    int n = strlen(arg[1]) + 1;
-    id_temp = new char[n];
-    strcpy(id_temp,arg[1]);
+    id_temp = utils::strdup(arg[1]);
 
     int icompute = modify->find_compute(id_temp);
     if (icompute < 0)

--- a/src/fix_move.cpp
+++ b/src/fix_move.cpp
@@ -12,26 +12,28 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_move.h"
-#include <cstring>
-#include <cmath>
+
 #include "atom.h"
-#include "update.h"
-#include "modify.h"
-#include "force.h"
-#include "domain.h"
-#include "lattice.h"
-#include "comm.h"
-#include "respa.h"
-#include "input.h"
-#include "variable.h"
+#include "atom_vec_body.h"
 #include "atom_vec_ellipsoid.h"
 #include "atom_vec_line.h"
 #include "atom_vec_tri.h"
-#include "atom_vec_body.h"
+#include "comm.h"
+#include "domain.h"
+#include "error.h"
+#include "force.h"
+#include "input.h"
+#include "lattice.h"
 #include "math_const.h"
 #include "math_extra.h"
 #include "memory.h"
-#include "error.h"
+#include "modify.h"
+#include "respa.h"
+#include "update.h"
+#include "variable.h"
+
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -129,39 +131,27 @@ FixMove::FixMove(LAMMPS *lmp, int narg, char **arg) :
     mstyle = VARIABLE;
     if (strcmp(arg[4],"NULL") == 0) xvarstr = nullptr;
     else if (utils::strmatch(arg[4],"^v_")) {
-      int n = strlen(&arg[4][2]) + 1;
-      xvarstr = new char[n];
-      strcpy(xvarstr,&arg[4][2]);
+      xvarstr = utils::strdup(arg[4]+2);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[5],"NULL") == 0) yvarstr = nullptr;
     else if (utils::strmatch(arg[5],"^v_")) {
-      int n = strlen(&arg[5][2]) + 1;
-      yvarstr = new char[n];
-      strcpy(yvarstr,&arg[5][2]);
+      yvarstr = utils::strdup(arg[5]+2);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[6],"NULL") == 0) zvarstr = nullptr;
     else if (utils::strmatch(arg[6],"^v_")) {
-      int n = strlen(&arg[6][2]) + 1;
-      zvarstr = new char[n];
-      strcpy(zvarstr,&arg[6][2]);
+      zvarstr = utils::strdup(arg[6]+2);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[7],"NULL") == 0) vxvarstr = nullptr;
     else if (utils::strmatch(arg[7],"^v_")) {
-      int n = strlen(&arg[7][2]) + 1;
-      vxvarstr = new char[n];
-      strcpy(vxvarstr,&arg[7][2]);
+      vxvarstr = utils::strdup(arg[7]+2);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[8],"NULL") == 0) vyvarstr = nullptr;
     else if (utils::strmatch(arg[8],"^v_")) {
-      int n = strlen(&arg[8][2]) + 1;
-      vyvarstr = new char[n];
-      strcpy(vyvarstr,&arg[8][2]);
+      vyvarstr = utils::strdup(arg[8]+2);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[9],"NULL") == 0) vzvarstr = nullptr;
     else if (utils::strmatch(arg[9],"^v_")) {
-      int n = strlen(&arg[9][2]) + 1;
-      vzvarstr = new char[n];
-      strcpy(vzvarstr,&arg[9][2]);
+      vzvarstr = utils::strdup(arg[9]+2);
     } else error->all(FLERR,"Illegal fix move command");
 
   } else error->all(FLERR,"Illegal fix move command");

--- a/src/fix_move.cpp
+++ b/src/fix_move.cpp
@@ -128,37 +128,37 @@ FixMove::FixMove(LAMMPS *lmp, int narg, char **arg) :
     iarg = 10;
     mstyle = VARIABLE;
     if (strcmp(arg[4],"NULL") == 0) xvarstr = nullptr;
-    else if (strstr(arg[4],"v_") == arg[4]) {
+    else if (utils::strmatch(arg[4],"^v_")) {
       int n = strlen(&arg[4][2]) + 1;
       xvarstr = new char[n];
       strcpy(xvarstr,&arg[4][2]);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[5],"NULL") == 0) yvarstr = nullptr;
-    else if (strstr(arg[5],"v_") == arg[5]) {
+    else if (utils::strmatch(arg[5],"^v_")) {
       int n = strlen(&arg[5][2]) + 1;
       yvarstr = new char[n];
       strcpy(yvarstr,&arg[5][2]);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[6],"NULL") == 0) zvarstr = nullptr;
-    else if (strstr(arg[6],"v_") == arg[6]) {
+    else if (utils::strmatch(arg[6],"^v_")) {
       int n = strlen(&arg[6][2]) + 1;
       zvarstr = new char[n];
       strcpy(zvarstr,&arg[6][2]);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[7],"NULL") == 0) vxvarstr = nullptr;
-    else if (strstr(arg[7],"v_") == arg[7]) {
+    else if (utils::strmatch(arg[7],"^v_")) {
       int n = strlen(&arg[7][2]) + 1;
       vxvarstr = new char[n];
       strcpy(vxvarstr,&arg[7][2]);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[8],"NULL") == 0) vyvarstr = nullptr;
-    else if (strstr(arg[8],"v_") == arg[8]) {
+    else if (utils::strmatch(arg[8],"^v_")) {
       int n = strlen(&arg[8][2]) + 1;
       vyvarstr = new char[n];
       strcpy(vyvarstr,&arg[8][2]);
     } else error->all(FLERR,"Illegal fix move command");
     if (strcmp(arg[9],"NULL") == 0) vzvarstr = nullptr;
-    else if (strstr(arg[9],"v_") == arg[9]) {
+    else if (utils::strmatch(arg[9],"^v_")) {
       int n = strlen(&arg[9][2]) + 1;
       vzvarstr = new char[n];
       strcpy(vzvarstr,&arg[9][2]);

--- a/src/fix_move.cpp
+++ b/src/fix_move.cpp
@@ -964,7 +964,7 @@ void FixMove::final_integrate_respa(int ilevel, int /*iloop*/)
 
 double FixMove::memory_usage()
 {
-  double bytes = atom->nmax*3 * sizeof(double);
+  double bytes = (double)atom->nmax*3 * sizeof(double);
   if (theta_flag) bytes += (double)atom->nmax * sizeof(double);
   if (quat_flag) bytes += (double)atom->nmax*4 * sizeof(double);
   if (displaceflag) bytes += (double)atom->nmax*3 * sizeof(double);

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -672,7 +672,7 @@ void FixNeighHistory::post_run()
 double FixNeighHistory::memory_usage()
 {
   int nmax = atom->nmax;
-  double bytes = nmax * sizeof(int);    // npartner
+  double bytes = (double)nmax * sizeof(int);    // npartner
   bytes += (double)nmax * sizeof(tagint *);     // partner
   bytes += (double)nmax * sizeof(double *);     // valuepartner
   bytes += (double)maxatom * sizeof(int *);     // firstflag

--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -33,9 +33,7 @@ FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
 {
   if (narg < 5) error->all(FLERR,"Illegal fix print command");
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    var_print = new char[n];
-    strcpy(var_print,&arg[3][2]);
+    var_print = utils::strdup(arg[3]+2);
     nevery = 1;
   } else {
     nevery = utils::inumeric(FLERR,arg[3],false,lmp);
@@ -79,9 +77,7 @@ FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"title") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix print command");
       delete [] title;
-      int n = strlen(arg[iarg+1]) + 1;
-      title = new char[n];
-      strcpy(title,arg[iarg+1]);
+      title = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else error->all(FLERR,"Illegal fix print command");
   }

--- a/src/fix_print.cpp
+++ b/src/fix_print.cpp
@@ -32,7 +32,7 @@ FixPrint::FixPrint(LAMMPS *lmp, int narg, char **arg) :
   fp(nullptr), string(nullptr), copy(nullptr), work(nullptr), var_print(nullptr)
 {
   if (narg < 5) error->all(FLERR,"Illegal fix print command");
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     var_print = new char[n];
     strcpy(var_print,&arg[3][2]);

--- a/src/fix_print.h
+++ b/src/fix_print.h
@@ -36,7 +36,7 @@ class FixPrint : public Fix {
  private:
   int me,screenflag;
   FILE *fp;
-  char *string,*copy,*work;
+  char *text,*copy,*work;
   int maxcopy,maxwork;
   char *var_print;
   int ivar_print;

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -75,7 +75,7 @@ FixPropertyAtom::FixPropertyAtom(LAMMPS *lmp, int narg, char **arg) :
       style[nvalue] = RMASS;
       atom->rmass_flag = rmass_flag = 1;
       nvalue++;
-    } else if (strstr(arg[iarg],"i_") == arg[iarg]) {
+    } else if (utils::strmatch(arg[iarg],"^i_")) {
       style[nvalue] = INTEGER;
       int tmp;
       index[nvalue] = atom->find_custom(&arg[iarg][2],tmp);
@@ -83,7 +83,7 @@ FixPropertyAtom::FixPropertyAtom(LAMMPS *lmp, int narg, char **arg) :
         error->all(FLERR,"Fix property/atom vector name already exists");
       index[nvalue] = atom->add_custom(&arg[iarg][2],0);
       nvalue++;
-    } else if (strstr(arg[iarg],"d_") == arg[iarg]) {
+    } else if (utils::strmatch(arg[iarg],"^d_")) {
       style[nvalue] = DOUBLE;
       int tmp;
       index[nvalue] = atom->find_custom(&arg[iarg][2],tmp);

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -13,13 +13,12 @@
 
 #include "fix_property_atom.h"
 
-#include <cstring>
 #include "atom.h"
 #include "comm.h"
-#include "memory.h"
 #include "error.h"
+#include "memory.h"
 
-
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -126,9 +125,7 @@ FixPropertyAtom::FixPropertyAtom(LAMMPS *lmp, int narg, char **arg) :
 
   // store current atom style
 
-  int n = strlen(atom->atom_style) + 1;
-  astyle = new char[n];
-  strcpy(astyle,atom->atom_style);
+  astyle = utils::strdup(atom->atom_style);
 
   // perform initial allocation of atom-based array
   // register with Atom class

--- a/src/fix_read_restart.cpp
+++ b/src/fix_read_restart.cpp
@@ -76,7 +76,7 @@ int FixReadRestart::setmask()
 
 double FixReadRestart::memory_usage()
 {
-  double bytes = atom->nmax*nextra * sizeof(double);
+  double bytes = (double)atom->nmax*nextra * sizeof(double);
   bytes += (double)atom->nmax * sizeof(int);
   return bytes;
 }

--- a/src/fix_respa.cpp
+++ b/src/fix_respa.cpp
@@ -74,7 +74,7 @@ int FixRespa::setmask()
 
 double FixRespa::memory_usage()
 {
-  double bytes = atom->nmax*nlevels*3 * sizeof(double);
+  double bytes = (double)atom->nmax*nlevels*3 * sizeof(double);
   if (store_torque) bytes += (double)atom->nmax*nlevels*3 * sizeof(double);
   return bytes;
 }

--- a/src/fix_setforce.cpp
+++ b/src/fix_setforce.cpp
@@ -48,7 +48,7 @@ FixSetForce::FixSetForce(LAMMPS *lmp, int narg, char **arg) :
   ilevel_respa = nlevels_respa = 0;
   xstr = ystr = zstr = nullptr;
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     xstr = new char[n];
     strcpy(xstr,&arg[3][2]);
@@ -58,7 +58,7 @@ FixSetForce::FixSetForce(LAMMPS *lmp, int narg, char **arg) :
     xvalue = utils::numeric(FLERR,arg[3],false,lmp);
     xstyle = CONSTANT;
   }
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(&arg[4][2]) + 1;
     ystr = new char[n];
     strcpy(ystr,&arg[4][2]);
@@ -68,7 +68,7 @@ FixSetForce::FixSetForce(LAMMPS *lmp, int narg, char **arg) :
     yvalue = utils::numeric(FLERR,arg[4],false,lmp);
     ystyle = CONSTANT;
   }
-  if (strstr(arg[5],"v_") == arg[5]) {
+  if (utils::strmatch(arg[5],"^v_")) {
     int n = strlen(&arg[5][2]) + 1;
     zstr = new char[n];
     strcpy(zstr,&arg[5][2]);

--- a/src/fix_setforce.cpp
+++ b/src/fix_setforce.cpp
@@ -49,9 +49,7 @@ FixSetForce::FixSetForce(LAMMPS *lmp, int narg, char **arg) :
   xstr = ystr = zstr = nullptr;
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    xstr = new char[n];
-    strcpy(xstr,&arg[3][2]);
+    xstr = utils::strdup(arg[3]+2);
   } else if (strcmp(arg[3],"NULL") == 0) {
     xstyle = NONE;
   } else {
@@ -59,9 +57,7 @@ FixSetForce::FixSetForce(LAMMPS *lmp, int narg, char **arg) :
     xstyle = CONSTANT;
   }
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(&arg[4][2]) + 1;
-    ystr = new char[n];
-    strcpy(ystr,&arg[4][2]);
+    ystr = utils::strdup(arg[4]+2);
   } else if (strcmp(arg[4],"NULL") == 0) {
     ystyle = NONE;
   } else {
@@ -69,9 +65,7 @@ FixSetForce::FixSetForce(LAMMPS *lmp, int narg, char **arg) :
     ystyle = CONSTANT;
   }
   if (utils::strmatch(arg[5],"^v_")) {
-    int n = strlen(&arg[5][2]) + 1;
-    zstr = new char[n];
-    strcpy(zstr,&arg[5][2]);
+    zstr = utils::strdup(arg[5]+2);
   } else if (strcmp(arg[5],"NULL") == 0) {
     zstyle = NONE;
   } else {
@@ -91,9 +85,7 @@ FixSetForce::FixSetForce(LAMMPS *lmp, int narg, char **arg) :
       iregion = domain->find_region(arg[iarg+1]);
       if (iregion == -1)
         error->all(FLERR,"Region ID for fix setforce does not exist");
-      int n = strlen(arg[iarg+1]) + 1;
-      idregion = new char[n];
-      strcpy(idregion,arg[iarg+1]);
+      idregion = utils::strdup(arg[iarg+1]);
       iarg += 2;
     } else error->all(FLERR,"Illegal fix setforce command");
   }

--- a/src/fix_spring_self.cpp
+++ b/src/fix_spring_self.cpp
@@ -210,7 +210,7 @@ double FixSpringSelf::compute_scalar()
 
 double FixSpringSelf::memory_usage()
 {
-  double bytes = atom->nmax*3 * sizeof(double);
+  double bytes = (double)atom->nmax*3 * sizeof(double);
   return bytes;
 }
 

--- a/src/fix_store_force.cpp
+++ b/src/fix_store_force.cpp
@@ -135,6 +135,6 @@ void FixStoreForce::min_post_force(int vflag)
 
 double FixStoreForce::memory_usage()
 {
-  double bytes = atom->nmax*3 * sizeof(double);
+  double bytes = (double)atom->nmax*3 * sizeof(double);
   return bytes;
 }

--- a/src/fix_store_state.cpp
+++ b/src/fix_store_state.cpp
@@ -537,7 +537,7 @@ void FixStoreState::end_of_step()
 
 double FixStoreState::memory_usage()
 {
-  double bytes = atom->nmax*nvalues * sizeof(double);
+  double bytes = (double)atom->nmax*nvalues * sizeof(double);
   return bytes;
 }
 

--- a/src/fix_temp_berendsen.cpp
+++ b/src/fix_temp_berendsen.cpp
@@ -12,20 +12,20 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_temp_berendsen.h"
-#include <cstring>
 
-#include <cmath>
 #include "atom.h"
-#include "force.h"
 #include "comm.h"
-#include "input.h"
-#include "variable.h"
-#include "group.h"
-#include "update.h"
-#include "modify.h"
 #include "compute.h"
 #include "error.h"
+#include "force.h"
+#include "group.h"
+#include "input.h"
+#include "modify.h"
+#include "update.h"
+#include "variable.h"
 
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -52,9 +52,7 @@ FixTempBerendsen::FixTempBerendsen(LAMMPS *lmp, int narg, char **arg) :
 
   tstr = nullptr;
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    tstr = new char[n];
-    strcpy(tstr,&arg[3][2]);
+    tstr = utils::strdup(arg[3]+2);
     tstyle = EQUAL;
   } else {
     t_start = utils::numeric(FLERR,arg[3],false,lmp);
@@ -74,9 +72,7 @@ FixTempBerendsen::FixTempBerendsen(LAMMPS *lmp, int narg, char **arg) :
   // id = fix-ID + temp, compute group = fix group
 
   std::string cmd = id + std::string("_temp");
-  id_temp = new char[cmd.size()+1];
-  strcpy(id_temp,cmd.c_str());
-
+  id_temp = utils::strdup(cmd);
   cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;

--- a/src/fix_temp_berendsen.cpp
+++ b/src/fix_temp_berendsen.cpp
@@ -51,7 +51,7 @@ FixTempBerendsen::FixTempBerendsen(LAMMPS *lmp, int narg, char **arg) :
   extscalar = 1;
 
   tstr = nullptr;
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     tstr = new char[n];
     strcpy(tstr,&arg[3][2]);

--- a/src/fix_temp_csld.cpp
+++ b/src/fix_temp_csld.cpp
@@ -57,7 +57,7 @@ FixTempCSLD::FixTempCSLD(LAMMPS *lmp, int narg, char **arg) :
   extscalar = 1;
 
   tstr = nullptr;
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     tstr = new char[n];
     strcpy(tstr,&arg[3][2]);

--- a/src/fix_temp_csld.cpp
+++ b/src/fix_temp_csld.cpp
@@ -16,22 +16,22 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_temp_csld.h"
-#include <cstring>
+
+#include "atom.h"
+#include "comm.h"
+#include "compute.h"
+#include "error.h"
+#include "force.h"
+#include "group.h"
+#include "input.h"
+#include "memory.h"
+#include "modify.h"
+#include "random_mars.h"
+#include "update.h"
+#include "variable.h"
 
 #include <cmath>
-#include "atom.h"
-#include "force.h"
-#include "memory.h"
-#include "comm.h"
-#include "input.h"
-#include "variable.h"
-#include "group.h"
-#include "update.h"
-#include "modify.h"
-#include "compute.h"
-#include "random_mars.h"
-#include "error.h"
-
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -58,9 +58,7 @@ FixTempCSLD::FixTempCSLD(LAMMPS *lmp, int narg, char **arg) :
 
   tstr = nullptr;
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    tstr = new char[n];
-    strcpy(tstr,&arg[3][2]);
+    tstr = utils::strdup(arg[3]+2);
     tstyle = EQUAL;
   } else {
     t_start = utils::numeric(FLERR,arg[3],false,lmp);
@@ -83,9 +81,7 @@ FixTempCSLD::FixTempCSLD(LAMMPS *lmp, int narg, char **arg) :
   // id = fix-ID + temp, compute group = fix group
 
   std::string cmd = id + std::string("_temp");
-  id_temp = new char[cmd.size()+1];
-  strcpy(id_temp,cmd.c_str());
-
+  id_temp = utils::strdup(cmd);
   cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;

--- a/src/fix_temp_csvr.cpp
+++ b/src/fix_temp_csvr.cpp
@@ -18,21 +18,20 @@
 
 #include "fix_temp_csvr.h"
 
+#include "atom.h"
+#include "comm.h"
+#include "compute.h"
+#include "error.h"
+#include "force.h"
+#include "group.h"
+#include "input.h"
+#include "modify.h"
+#include "random_mars.h"
+#include "update.h"
+#include "variable.h"
+
 #include <cstring>
 #include <cmath>
-
-#include "atom.h"
-#include "force.h"
-#include "comm.h"
-#include "input.h"
-#include "variable.h"
-#include "group.h"
-#include "update.h"
-#include "modify.h"
-#include "compute.h"
-#include "random_mars.h"
-#include "error.h"
-
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -135,9 +134,7 @@ FixTempCSVR::FixTempCSVR(LAMMPS *lmp, int narg, char **arg) :
 
   tstr = nullptr;
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(&arg[3][2]) + 1;
-    tstr = new char[n];
-    strcpy(tstr,&arg[3][2]);
+    tstr = utils::strdup(arg[3]+2);
     tstyle = EQUAL;
   } else {
     t_start = utils::numeric(FLERR,arg[3],false,lmp);
@@ -160,9 +157,7 @@ FixTempCSVR::FixTempCSVR(LAMMPS *lmp, int narg, char **arg) :
   // id = fix-ID + temp, compute group = fix group
 
   std::string cmd = id + std::string("_temp");
-  id_temp = new char[cmd.size()+1];
-  strcpy(id_temp,cmd.c_str());
-
+  id_temp = utils::strdup(cmd);
   cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;

--- a/src/fix_temp_csvr.cpp
+++ b/src/fix_temp_csvr.cpp
@@ -134,7 +134,7 @@ FixTempCSVR::FixTempCSVR(LAMMPS *lmp, int narg, char **arg) :
   extscalar = 1;
 
   tstr = nullptr;
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(&arg[3][2]) + 1;
     tstr = new char[n];
     strcpy(tstr,&arg[3][2]);

--- a/src/fix_temp_rescale.cpp
+++ b/src/fix_temp_rescale.cpp
@@ -51,7 +51,7 @@ FixTempRescale::FixTempRescale(LAMMPS *lmp, int narg, char **arg) :
   dynamic_group_allow = 1;
 
   tstr = nullptr;
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(&arg[4][2]) + 1;
     tstr = new char[n];
     strcpy(tstr,&arg[4][2]);

--- a/src/fix_temp_rescale.cpp
+++ b/src/fix_temp_rescale.cpp
@@ -12,20 +12,20 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_temp_rescale.h"
-#include <cstring>
 
-#include <cmath>
 #include "atom.h"
-#include "force.h"
-#include "group.h"
-#include "update.h"
 #include "comm.h"
-#include "input.h"
-#include "variable.h"
-#include "modify.h"
 #include "compute.h"
 #include "error.h"
+#include "force.h"
+#include "group.h"
+#include "input.h"
+#include "modify.h"
+#include "update.h"
+#include "variable.h"
 
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
@@ -52,9 +52,7 @@ FixTempRescale::FixTempRescale(LAMMPS *lmp, int narg, char **arg) :
 
   tstr = nullptr;
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(&arg[4][2]) + 1;
-    tstr = new char[n];
-    strcpy(tstr,&arg[4][2]);
+    tstr = utils::strdup(arg[4]+2);
     tstyle = EQUAL;
   } else {
     t_start = utils::numeric(FLERR,arg[4],false,lmp);
@@ -70,9 +68,7 @@ FixTempRescale::FixTempRescale(LAMMPS *lmp, int narg, char **arg) :
   // id = fix-ID + temp, compute group = fix group
 
   std::string cmd = id + std::string("_temp");
-  id_temp = new char[cmd.size()+1];
-  strcpy(id_temp,cmd.c_str());
-
+  id_temp = utils::strdup(cmd);
   cmd += fmt::format(" {} temp",group->names[igroup]);
   modify->add_compute(cmd);
   tflag = 1;

--- a/src/fix_wall.cpp
+++ b/src/fix_wall.cpp
@@ -79,7 +79,7 @@ FixWall::FixWall(LAMMPS *lmp, int narg, char **arg) :
         int side = wallwhich[nwall] % 2;
         if (side == 0) coord0[nwall] = domain->boxlo[dim];
         else coord0[nwall] = domain->boxhi[dim];
-      } else if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      } else if (utils::strmatch(arg[iarg+1],"^v_")) {
         xstyle[nwall] = VARIABLE;
         int n = strlen(&arg[iarg+1][2]) + 1;
         xstr[nwall] = new char[n];
@@ -89,7 +89,7 @@ FixWall::FixWall(LAMMPS *lmp, int narg, char **arg) :
         coord0[nwall] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       }
 
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) {
+      if (utils::strmatch(arg[iarg+2],"^v_")) {
         int n = strlen(&arg[iarg+2][2]) + 1;
         estr[nwall] = new char[n];
         strcpy(estr[nwall],&arg[iarg+2][2]);
@@ -100,7 +100,7 @@ FixWall::FixWall(LAMMPS *lmp, int narg, char **arg) :
       }
 
       if (utils::strmatch(style,"^wall/morse")) {
-        if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+        if (utils::strmatch(arg[iarg+3],"^v_")) {
           int n = strlen(&arg[iarg+3][2]) + 1;
           astr[nwall] = new char[n];
           strcpy(astr[nwall],&arg[iarg+3][2]);
@@ -112,7 +112,7 @@ FixWall::FixWall(LAMMPS *lmp, int narg, char **arg) :
         ++iarg;
       }
 
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) {
+      if (utils::strmatch(arg[iarg+3],"^v_")) {
         int n = strlen(&arg[iarg+3][2]) + 1;
         sstr[nwall] = new char[n];
         strcpy(sstr[nwall],&arg[iarg+3][2]);

--- a/src/fix_wall.cpp
+++ b/src/fix_wall.cpp
@@ -81,18 +81,14 @@ FixWall::FixWall(LAMMPS *lmp, int narg, char **arg) :
         else coord0[nwall] = domain->boxhi[dim];
       } else if (utils::strmatch(arg[iarg+1],"^v_")) {
         xstyle[nwall] = VARIABLE;
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        xstr[nwall] = new char[n];
-        strcpy(xstr[nwall],&arg[iarg+1][2]);
+        xstr[nwall] = utils::strdup(arg[iarg+1]+2);
       } else {
         xstyle[nwall] = CONSTANT;
         coord0[nwall] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       }
 
       if (utils::strmatch(arg[iarg+2],"^v_")) {
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        estr[nwall] = new char[n];
-        strcpy(estr[nwall],&arg[iarg+2][2]);
+        estr[nwall] = utils::strdup(arg[iarg+2]+2);
         estyle[nwall] = VARIABLE;
       } else {
         epsilon[nwall] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
@@ -101,9 +97,7 @@ FixWall::FixWall(LAMMPS *lmp, int narg, char **arg) :
 
       if (utils::strmatch(style,"^wall/morse")) {
         if (utils::strmatch(arg[iarg+3],"^v_")) {
-          int n = strlen(&arg[iarg+3][2]) + 1;
-          astr[nwall] = new char[n];
-          strcpy(astr[nwall],&arg[iarg+3][2]);
+          astr[nwall] = utils::strdup(arg[iarg+3]+2);
           astyle[nwall] = VARIABLE;
         } else {
           alpha[nwall] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
@@ -113,9 +107,7 @@ FixWall::FixWall(LAMMPS *lmp, int narg, char **arg) :
       }
 
       if (utils::strmatch(arg[iarg+3],"^v_")) {
-        int n = strlen(&arg[iarg+3][2]) + 1;
-        sstr[nwall] = new char[n];
-        strcpy(sstr[nwall],&arg[iarg+3][2]);
+        sstr[nwall] = utils::strdup(arg[iarg+3]+2);
         sstyle[nwall] = VARIABLE;
       } else {
         sigma[nwall] = utils::numeric(FLERR,arg[iarg+3],false,lmp);

--- a/src/fix_wall_reflect.cpp
+++ b/src/fix_wall_reflect.cpp
@@ -75,9 +75,7 @@ FixWallReflect::FixWallReflect(LAMMPS *lmp, int narg, char **arg) :
         else coord0[nwall] = domain->boxhi[dim];
       } else if (utils::strmatch(arg[iarg+1],"^v_")) {
         wallstyle[nwall] = VARIABLE;
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        varstr[nwall] = new char[n];
-        strcpy(varstr[nwall],&arg[iarg+1][2]);
+        varstr[nwall] = utils::strdup(arg[iarg+1]+2);
       } else {
         wallstyle[nwall] = CONSTANT;
         coord0[nwall] = utils::numeric(FLERR,arg[iarg+1],false,lmp);

--- a/src/fix_wall_reflect.cpp
+++ b/src/fix_wall_reflect.cpp
@@ -73,7 +73,7 @@ FixWallReflect::FixWallReflect(LAMMPS *lmp, int narg, char **arg) :
         int side = wallwhich[nwall] % 2;
         if (side == 0) coord0[nwall] = domain->boxlo[dim];
         else coord0[nwall] = domain->boxhi[dim];
-      } else if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) {
+      } else if (utils::strmatch(arg[iarg+1],"^v_")) {
         wallstyle[nwall] = VARIABLE;
         int n = strlen(&arg[iarg+1][2]) + 1;
         varstr[nwall] = new char[n];

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -388,7 +388,7 @@ void Improper::ev_tally(int i1, int i2, int i3, int i4,
 
 double Improper::memory_usage()
 {
-  double bytes = comm->nthreads*maxeatom * sizeof(double);
+  double bytes = (double)comm->nthreads*maxeatom * sizeof(double);
   bytes += (double)comm->nthreads*maxvatom*6 * sizeof(double);
   return bytes;
 }

--- a/src/improper_hybrid.cpp
+++ b/src/improper_hybrid.cpp
@@ -350,7 +350,7 @@ void ImproperHybrid::read_restart(FILE *fp)
 
 double ImproperHybrid::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)maxcvatom*9 * sizeof(double);
   for (int m = 0; m < nstyles; m++) bytes += (double)maximproper[m]*5 * sizeof(int);

--- a/src/my_pool_chunk.cpp
+++ b/src/my_pool_chunk.cpp
@@ -211,7 +211,7 @@ void MyPoolChunk<T>::allocate(int ibin) {
 
 template <class T>
 double MyPoolChunk<T>::size() const {
-  double bytes = npage*chunkperpage*sizeof(int);
+  double bytes = (double)npage*chunkperpage*sizeof(int);
   bytes += (double)npage*sizeof(T *);
   bytes += (double)npage*sizeof(int);
   for (int i=0; i < npage; ++i)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -664,7 +664,7 @@ void Output::set_thermo(int narg, char **arg)
   delete [] var_thermo;
   var_thermo = nullptr;
 
-  if (strstr(arg[0],"v_") == arg[0]) {
+  if (utils::strmatch(arg[0],"^v_")) {
     int n = strlen(&arg[0][2]) + 1;
     var_thermo = new char[n];
     strcpy(var_thermo,&arg[0][2]);
@@ -712,7 +712,7 @@ void Output::create_restart(int narg, char **arg)
   int every = 0;
   int varflag = 0;
 
-  if (strstr(arg[0],"v_") == arg[0]) varflag = 1;
+  if (utils::strmatch(arg[0],"^v_")) varflag = 1;
   else every = utils::inumeric(FLERR,arg[0],false,lmp);
 
   if (!varflag && every == 0) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -665,9 +665,7 @@ void Output::set_thermo(int narg, char **arg)
   var_thermo = nullptr;
 
   if (utils::strmatch(arg[0],"^v_")) {
-    int n = strlen(&arg[0][2]) + 1;
-    var_thermo = new char[n];
-    strcpy(var_thermo,&arg[0][2]);
+    var_thermo = utils::strdup(arg[0]+2);
   } else {
     thermo_every = utils::inumeric(FLERR,arg[0],false,lmp);
     if (thermo_every < 0) error->all(FLERR,"Illegal thermo command");
@@ -745,9 +743,7 @@ void Output::create_restart(int narg, char **arg)
 
     if (varflag) {
       delete [] var_restart_single;
-      int n = strlen(&arg[0][2]) + 1;
-      var_restart_single = new char[n];
-      strcpy(var_restart_single,&arg[0][2]);
+      var_restart_single = utils::strdup(arg[0]+2);
       restart_every_single = 0;
     } else restart_every_single = every;
 
@@ -763,9 +759,7 @@ void Output::create_restart(int narg, char **arg)
 
     if (varflag) {
       delete [] var_restart_double;
-      int n = strlen(&arg[0][2]) + 1;
-      var_restart_double = new char[n];
-      strcpy(var_restart_double,&arg[0][2]);
+      var_restart_double = utils::strdup(arg[0]+2);
       restart_every_double = 0;
     } else restart_every_double = every;
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -1836,7 +1836,7 @@ void Pair::hessian_twobody(double fforce, double dfac, double delr[3], double ph
 
 double Pair::memory_usage()
 {
-  double bytes = comm->nthreads*maxeatom * sizeof(double);
+  double bytes = (double)comm->nthreads*maxeatom * sizeof(double);
   bytes += (double)comm->nthreads*maxvatom*6 * sizeof(double);
   bytes += (double)comm->nthreads*maxcvatom*9 * sizeof(double);
   return bytes;

--- a/src/pair_coul_streitz.cpp
+++ b/src/pair_coul_streitz.cpp
@@ -736,7 +736,7 @@ void PairCoulStreitz::ewald_sum(double qi, double qj, double zj, double r,
 
 double PairCoulStreitz::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)nmax * sizeof(int);
   bytes += (double)MAXNEIGH * nmax * sizeof(int);

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -1078,7 +1078,7 @@ int PairHybrid::check_ijtype(int itype, int jtype, char *substyle)
 
 double PairHybrid::memory_usage()
 {
-  double bytes = maxeatom * sizeof(double);
+  double bytes = (double)maxeatom * sizeof(double);
   bytes += (double)maxvatom*6 * sizeof(double);
   bytes += (double)maxcvatom*9 * sizeof(double);
   for (int m = 0; m < nstyles; m++) bytes += styles[m]->memory_usage();

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -44,7 +44,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
   axis = arg[2][0];
 
   if (axis == 'x') {
-    if (strstr(arg[3],"v_") == arg[3]) {
+    if (utils::strmatch(arg[3],"^v_")) {
       int n = strlen(arg[3]+2) + 1;
       c1str = new char[n];
       strcpy(c1str,arg[3]+2);
@@ -55,7 +55,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1 = yscale*utils::numeric(FLERR,arg[3],false,lmp);
       c1style = CONSTANT;
     }
-    if (strstr(arg[4],"v_") == arg[4]) {
+    if (utils::strmatch(arg[4],"^v_")) {
       int n = strlen(arg[4]+2) + 1;
       c2str = new char[n];
       strcpy(c2str,arg[4]+2);
@@ -67,7 +67,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c2style = CONSTANT;
     }
   } else if (axis == 'y') {
-    if (strstr(arg[3],"v_") == arg[3]) {
+    if (utils::strmatch(arg[3],"^v_")) {
       int n = strlen(arg[3]+2) + 1;
       c1str = new char[n];
       strcpy(c1str,arg[3]+2);
@@ -78,7 +78,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1 = xscale*utils::numeric(FLERR,arg[3],false,lmp);
       c1style = CONSTANT;
     }
-    if (strstr(arg[4],"v_") == arg[4]) {
+    if (utils::strmatch(arg[4],"^v_")) {
       int n = strlen(arg[4]+2) + 1;
       c2str = new char[n];
       strcpy(c2str,arg[4]+2);
@@ -90,7 +90,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c2style = CONSTANT;
     }
   } else if (axis == 'z') {
-    if (strstr(arg[3],"v_") == arg[3]) {
+    if (utils::strmatch(arg[3],"^v_")) {
       int n = strlen(arg[3]+2) + 1;
       c1str = new char[n];
       strcpy(c1str,arg[3]+2);
@@ -101,7 +101,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1 = xscale*utils::numeric(FLERR,arg[3],false,lmp);
       c1style = CONSTANT;
     }
-    if (strstr(arg[4],"v_") == arg[4]) {
+    if (utils::strmatch(arg[4],"^v_")) {
       int n = strlen(arg[4]+2) + 1;
       c2str = new char[n];
       strcpy(c2str,arg[4]+2);
@@ -114,7 +114,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
     }
   }
 
-  if (strstr(arg[5],"v_") == arg[5]) {
+  if (utils::strmatch(arg[5],"^v_")) {
     int n = strlen(&arg[5][2]) + 1;
     rstr = new char[n];
     strcpy(rstr,&arg[5][2]);

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -45,9 +45,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
 
   if (axis == 'x') {
     if (utils::strmatch(arg[3],"^v_")) {
-      int n = strlen(arg[3]+2) + 1;
-      c1str = new char[n];
-      strcpy(c1str,arg[3]+2);
+      c1str = utils::strdup(arg[3]+2);
       c1 = 0.0;
       c1style = VARIABLE;
       varshape = 1;
@@ -56,9 +54,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1style = CONSTANT;
     }
     if (utils::strmatch(arg[4],"^v_")) {
-      int n = strlen(arg[4]+2) + 1;
-      c2str = new char[n];
-      strcpy(c2str,arg[4]+2);
+      c2str = utils::strdup(arg[4]+2);
       c2 = 0.0;
       c2style = VARIABLE;
       varshape = 1;
@@ -68,9 +64,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
     }
   } else if (axis == 'y') {
     if (utils::strmatch(arg[3],"^v_")) {
-      int n = strlen(arg[3]+2) + 1;
-      c1str = new char[n];
-      strcpy(c1str,arg[3]+2);
+      c1str = utils::strdup(arg[3]+2);
       c1 = 0.0;
       c1style = VARIABLE;
       varshape = 1;
@@ -79,9 +73,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1style = CONSTANT;
     }
     if (utils::strmatch(arg[4],"^v_")) {
-      int n = strlen(arg[4]+2) + 1;
-      c2str = new char[n];
-      strcpy(c2str,arg[4]+2);
+      c2str = utils::strdup(arg[4]+2);
       c2 = 0.0;
       c2style = VARIABLE;
       varshape = 1;
@@ -91,9 +83,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
     }
   } else if (axis == 'z') {
     if (utils::strmatch(arg[3],"^v_")) {
-      int n = strlen(arg[3]+2) + 1;
-      c1str = new char[n];
-      strcpy(c1str,arg[3]+2);
+      c1str = utils::strdup(arg[3]+2);
       c1 = 0.0;
       c1style = VARIABLE;
       varshape = 1;
@@ -102,9 +92,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1style = CONSTANT;
     }
     if (utils::strmatch(arg[4],"^v_")) {
-      int n = strlen(arg[4]+2) + 1;
-      c2str = new char[n];
-      strcpy(c2str,arg[4]+2);
+      c2str = utils::strdup(arg[4]+2);
       c2 = 0.0;
       c2style = VARIABLE;
       varshape = 1;
@@ -115,9 +103,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
   }
 
   if (utils::strmatch(arg[5],"^v_")) {
-    int n = strlen(&arg[5][2]) + 1;
-    rstr = new char[n];
-    strcpy(rstr,&arg[5][2]);
+    rstr = utils::strdup(arg[5]+2);
     radius = 0.0;
     rstyle = VARIABLE;
     varshape = 1;

--- a/src/region_sphere.cpp
+++ b/src/region_sphere.cpp
@@ -33,9 +33,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
   options(narg-6,&arg[6]);
 
   if (utils::strmatch(arg[2],"^v_")) {
-    int n = strlen(arg[2]+2) + 1;
-    xstr = new char[n];
-    strcpy(xstr,arg[2]+2);
+    xstr = utils::strdup(arg[2]+2);
     xc = 0.0;
     xstyle = VARIABLE;
     varshape = 1;
@@ -45,9 +43,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
   }
 
   if (utils::strmatch(arg[3],"^v_")) {
-    int n = strlen(arg[3]+2) + 1;
-    ystr = new char[n];
-    strcpy(ystr,arg[3]+2);
+    ystr = utils::strdup(arg[3]+2);
     yc = 0.0;
     ystyle = VARIABLE;
     varshape = 1;
@@ -57,9 +53,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
   }
 
   if (utils::strmatch(arg[4],"^v_")) {
-    int n = strlen(arg[4]+2) + 1;
-    zstr = new char[n];
-    strcpy(zstr,arg[4]+2);
+    zstr = utils::strdup(arg[4]+2);
     zc = 0.0;
     zstyle = VARIABLE;
     varshape = 1;
@@ -69,9 +63,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
   }
 
   if (utils::strmatch(arg[5],"^v_")) {
-    int n = strlen(&arg[5][2]) + 1;
-    rstr = new char[n];
-    strcpy(rstr,&arg[5][2]);
+    rstr = utils::strdup(arg[5]+2);
     radius = 0.0;
     rstyle = VARIABLE;
     varshape = 1;

--- a/src/region_sphere.cpp
+++ b/src/region_sphere.cpp
@@ -32,7 +32,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
 {
   options(narg-6,&arg[6]);
 
-  if (strstr(arg[2],"v_") == arg[2]) {
+  if (utils::strmatch(arg[2],"^v_")) {
     int n = strlen(arg[2]+2) + 1;
     xstr = new char[n];
     strcpy(xstr,arg[2]+2);
@@ -44,7 +44,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
     xstyle = CONSTANT;
   }
 
-  if (strstr(arg[3],"v_") == arg[3]) {
+  if (utils::strmatch(arg[3],"^v_")) {
     int n = strlen(arg[3]+2) + 1;
     ystr = new char[n];
     strcpy(ystr,arg[3]+2);
@@ -56,7 +56,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
     ystyle = CONSTANT;
   }
 
-  if (strstr(arg[4],"v_") == arg[4]) {
+  if (utils::strmatch(arg[4],"^v_")) {
     int n = strlen(arg[4]+2) + 1;
     zstr = new char[n];
     strcpy(zstr,arg[4]+2);
@@ -68,7 +68,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
     zstyle = CONSTANT;
   }
 
-  if (strstr(arg[5],"v_") == arg[5]) {
+  if (utils::strmatch(arg[5],"^v_")) {
     int n = strlen(&arg[5][2]) + 1;
     rstr = new char[n];
     strcpy(rstr,&arg[5][2]);

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -71,9 +71,7 @@ void Set::command(int narg, char **arg)
   else if (strcmp(arg[0],"region") == 0) style = REGION_SELECT;
   else error->all(FLERR,"Illegal set command");
 
-  int n = strlen(arg[1]) + 1;
-  id = new char[n];
-  strcpy(id,arg[1]);
+  id = utils::strdup(arg[1]);
   select = nullptr;
   selection(atom->nlocal);
 

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -92,7 +92,7 @@ void Set::command(int narg, char **arg)
 
     if (strcmp(arg[iarg],"type") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       set(TYPE);
       iarg += 2;
@@ -141,7 +141,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"mol") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->molecule_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -150,49 +150,49 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"x") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(X);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"y") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(Y);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"z") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(Z);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"vx") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(VX);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"vy") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(VY);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"vz") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(VZ);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"charge") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->q_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -201,7 +201,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"mass") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->rmass_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -210,11 +210,11 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"shape") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) varparse(arg[iarg+2],2);
+      if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
       else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) varparse(arg[iarg+3],3);
+      if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->ellipsoid_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -223,7 +223,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"length") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->line_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -232,7 +232,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"tri") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->tri_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -241,11 +241,11 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"dipole") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) varparse(arg[iarg+2],2);
+      if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
       else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) varparse(arg[iarg+3],3);
+      if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->mu_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -267,13 +267,13 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"spin") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) varparse(arg[iarg+2],2);
+      if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
       else xvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) varparse(arg[iarg+3],3);
+      if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else yvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
-      if (strstr(arg[iarg+4],"v_") == arg[iarg+4]) varparse(arg[iarg+4],4);
+      if (utils::strmatch(arg[iarg+4],"^v_")) varparse(arg[iarg+4],4);
       else zvalue = utils::numeric(FLERR,arg[iarg+4],false,lmp);
       if (!atom->sp_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -295,13 +295,13 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"quat") == 0) {
       if (iarg+5 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) varparse(arg[iarg+2],2);
+      if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
       else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) varparse(arg[iarg+3],3);
+      if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
-      if (strstr(arg[iarg+4],"v_") == arg[iarg+4]) varparse(arg[iarg+4],4);
+      if (utils::strmatch(arg[iarg+4],"^v_")) varparse(arg[iarg+4],4);
       else wvalue = utils::numeric(FLERR,arg[iarg+4],false,lmp);
       if (!atom->ellipsoid_flag && !atom->tri_flag && !atom->body_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -320,7 +320,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"theta") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
         dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
         dvalue *= MY_PI/180.0;
@@ -342,11 +342,11 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"angmom") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) varparse(arg[iarg+2],2);
+      if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
       else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) varparse(arg[iarg+3],3);
+      if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->angmom_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -355,11 +355,11 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"omega") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) varparse(arg[iarg+2],2);
+      if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
       else yvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) varparse(arg[iarg+3],3);
+      if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->omega_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -368,7 +368,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"diameter") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->radius_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -378,7 +378,7 @@ void Set::command(int narg, char **arg)
     } else if (strcmp(arg[iarg],"density") == 0 ||
                (strcmp(arg[iarg],"density/disc") == 0)) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->rmass_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -394,7 +394,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"volume") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->vfrac_flag)
         error->all(FLERR,"Cannot set this attribute for this atom style");
@@ -407,17 +407,17 @@ void Set::command(int narg, char **arg)
       ximageflag = yimageflag = zimageflag = 0;
       if (strcmp(arg[iarg+1],"NULL") != 0) {
         ximageflag = 1;
-        if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+        if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
         else ximage = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       }
       if (strcmp(arg[iarg+2],"NULL") != 0) {
         yimageflag = 1;
-        if (strstr(arg[iarg+2],"v_") == arg[iarg+2]) varparse(arg[iarg+2],2);
+        if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
         else yimage = utils::inumeric(FLERR,arg[iarg+2],false,lmp);
       }
       if (strcmp(arg[iarg+3],"NULL") != 0) {
         zimageflag = 1;
-        if (strstr(arg[iarg+3],"v_") == arg[iarg+3]) varparse(arg[iarg+3],3);
+        if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
         else zimage = utils::inumeric(FLERR,arg[iarg+3],false,lmp);
       }
       if (ximageflag && ximage && !domain->xperiodic)
@@ -474,7 +474,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"sph/e") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->esph_flag)
         error->all(FLERR,"Cannot set meso/e for this atom style");
@@ -483,7 +483,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"sph/cv") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->cv_flag)
             error->all(FLERR,"Cannot set meso/cv for this atom style");
@@ -492,7 +492,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"sph/rho") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->rho_flag)
         error->all(FLERR,"Cannot set meso/rho for this atom style");
@@ -502,7 +502,7 @@ void Set::command(int narg, char **arg)
     } else if (strcmp(arg[iarg],"edpd/temp") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
-      else if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
         dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
         if (dvalue < 0.0) error->all(FLERR,"Illegal set command");
@@ -515,7 +515,7 @@ void Set::command(int narg, char **arg)
     } else if (strcmp(arg[iarg],"edpd/cv") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
-      else if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
         dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
         if (dvalue < 0.0) error->all(FLERR,"Illegal set command");
@@ -528,7 +528,7 @@ void Set::command(int narg, char **arg)
     } else if (strcmp(arg[iarg],"cc") == 0) {
       if (iarg+3 > narg) error->all(FLERR,"Illegal set command");
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
-      else if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
         cc_index = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
         dvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
@@ -541,7 +541,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"smd/mass/density") == 0) {
           if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-          if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+          if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
           else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
           if (!atom->smd_flag)
             error->all(FLERR,"Cannot set smd/mass/density for this atom style");
@@ -550,7 +550,7 @@ void Set::command(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"smd/contact/radius") == 0) {
           if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-          if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+          if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
           else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
           if (!atom->smd_flag)
             error->all(FLERR,"Cannot set smd/contact/radius "
@@ -561,7 +561,7 @@ void Set::command(int narg, char **arg)
     } else if (strcmp(arg[iarg],"dpd/theta") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
-      else if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
         dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
         if (dvalue < 0.0) error->all(FLERR,"Illegal set command");
@@ -571,9 +571,9 @@ void Set::command(int narg, char **arg)
       set(DPDTHETA);
       iarg += 2;
 
-    } else if (strstr(arg[iarg],"i_") == arg[iarg]) {
+    } else if (utils::strmatch(arg[iarg],"^i_")) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       int flag;
       index_custom = atom->find_custom(&arg[iarg][2],flag);
@@ -582,9 +582,9 @@ void Set::command(int narg, char **arg)
       set(INAME);
       iarg += 2;
 
-    } else if (strstr(arg[iarg],"d_") == arg[iarg]) {
+    } else if (utils::strmatch(arg[iarg],"^d_")) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
-      if (strstr(arg[iarg+1],"v_") == arg[iarg+1]) varparse(arg[iarg+1],1);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       int flag;
       index_custom = atom->find_custom(&arg[iarg][2],flag);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -547,6 +547,18 @@ int utils::expand_args(const char *file, int line, int narg, char **arg,
 }
 
 /* ----------------------------------------------------------------------
+   Make copy of string in new storage. Works like the (non-portable)
+   C-style strdup() but also accepts a C++ string as argument.
+------------------------------------------------------------------------- */
+
+char *utils::strdup(const std::string &text)
+{
+  char *tmp = new char[text.size()+1];
+  strcpy(tmp,text.c_str());
+  return tmp;
+}
+
+/* ----------------------------------------------------------------------
    Return string without leading or trailing whitespace
 ------------------------------------------------------------------------- */
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -195,6 +195,17 @@ namespace LAMMPS_NS {
     int expand_args(const char *file, int line, int narg, char **arg,
                     int mode, char **&earg, LAMMPS *lmp);
 
+    /** Make C-style copy of string in new storage
+     *
+     * This allocates a storage buffer and copies the C-style or
+     * C++ style string into it.  The buffer is allocated with "new"
+     * and thus needs to be deallocated with "delete[]".
+     *
+     * \param text  string that should be copied
+     * \return new buffer with copy of string */
+
+    char *strdup(const std::string &text);
+
     /** Trim leading and trailing whitespace. Like TRIM() in Fortran.
      *
      * \param line  string that should be trimmed

--- a/src/utils.h
+++ b/src/utils.h
@@ -235,7 +235,6 @@ namespace LAMMPS_NS {
 
     inline bool has_utf8(const std::string &line)
     {
-      const unsigned char * const in = (const unsigned char *)line.c_str();
       for (auto c : line) if (c & 0x80U) return true;
       return false;
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -287,9 +287,9 @@ namespace LAMMPS_NS {
      *
      * This can handle strings with single and double quotes, escaped quotes,
      * and escaped codes within quotes, but due to using an STL container and
-     * STL strings is rather slow because of making copies. Designed for parsing
-     * command lines and similar text and not for time critical processing.
-     * Use a tokenizer class for that.
+     * STL strings is rather slow because of making copies. Designed for
+     * parsing command lines and similar text and not for time critical
+     * processing.  Use a tokenizer class if performance matters.
      *
 \verbatim embed:rst
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -236,7 +236,7 @@ namespace LAMMPS_NS {
     inline bool has_utf8(const std::string &line)
     {
       const unsigned char * const in = (const unsigned char *)line.c_str();
-      for (int i=0; i < line.size(); ++i) if (in[i] & 0x80U) return true;
+      for (auto c : line) if (c & 0x80U) return true;
       return false;
     }
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3309,7 +3309,7 @@ tagint Variable::int_between_brackets(char *&ptr, int varallow)
 
   char *start = ++ptr;
 
-  if (varallow && strstr(ptr,"v_") == ptr) {
+  if (varallow && utils::strmatch(ptr,"^v_")) {
     varflag = 1;
     while (*ptr && *ptr != ']') {
       if (!isalnum(*ptr) && *ptr != '_')
@@ -4112,7 +4112,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
 
     // argument is compute
 
-    if (strstr(args[0],"c_") == args[0]) {
+    if (utils::strmatch(args[0],"^c_")) {
       ptr1 = strchr(args[0],'[');
       if (ptr1) {
         ptr2 = ptr1;
@@ -4157,7 +4157,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
 
     // argument is fix
 
-    } else if (strstr(args[0],"f_") == args[0]) {
+    } else if (utils::strmatch(args[0],"^f_")) {
       ptr1 = strchr(args[0],'[');
       if (ptr1) {
         ptr2 = ptr1;
@@ -4195,7 +4195,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
 
     // argument is vector-style variable
 
-    } else if (strstr(args[0],"v_") == args[0]) {
+    } else if (utils::strmatch(args[0],"^v_")) {
       ptr1 = strchr(args[0],'[');
       if (ptr1) {
         ptr2 = ptr1;

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -419,21 +419,21 @@ void Velocity::set(int /*narg*/, char **arg)
   xstyle = ystyle = zstyle = CONSTANT;
   xstr = ystr = zstr = nullptr;
 
-  if (strstr(arg[0],"v_") == arg[0]) {
+  if (utils::strmatch(arg[0],"^v_")) {
     int n = strlen(&arg[0][2]) + 1;
     xstr = new char[n];
     strcpy(xstr,&arg[0][2]);
   } else if (strcmp(arg[0],"NULL") == 0) xstyle = NONE;
   else vx = utils::numeric(FLERR,arg[0],false,lmp);
 
-  if (strstr(arg[1],"v_") == arg[1]) {
+  if (utils::strmatch(arg[1],"^v_")) {
     int n = strlen(&arg[1][2]) + 1;
     ystr = new char[n];
     strcpy(ystr,&arg[1][2]);
   } else if (strcmp(arg[1],"NULL") == 0) ystyle = NONE;
   else vy = utils::numeric(FLERR,arg[1],false,lmp);
 
-  if (strstr(arg[2],"v_") == arg[2]) {
+  if (utils::strmatch(arg[2],"^v_")) {
     int n = strlen(&arg[2][2]) + 1;
     zstr = new char[n];
     strcpy(zstr,&arg[2][2]);

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -420,23 +420,17 @@ void Velocity::set(int /*narg*/, char **arg)
   xstr = ystr = zstr = nullptr;
 
   if (utils::strmatch(arg[0],"^v_")) {
-    int n = strlen(&arg[0][2]) + 1;
-    xstr = new char[n];
-    strcpy(xstr,&arg[0][2]);
+    xstr = utils::strdup(arg[0]+2);
   } else if (strcmp(arg[0],"NULL") == 0) xstyle = NONE;
   else vx = utils::numeric(FLERR,arg[0],false,lmp);
 
   if (utils::strmatch(arg[1],"^v_")) {
-    int n = strlen(&arg[1][2]) + 1;
-    ystr = new char[n];
-    strcpy(ystr,&arg[1][2]);
+    ystr = utils::strdup(arg[1]+2);
   } else if (strcmp(arg[1],"NULL") == 0) ystyle = NONE;
   else vy = utils::numeric(FLERR,arg[1],false,lmp);
 
   if (utils::strmatch(arg[2],"^v_")) {
-    int n = strlen(&arg[2][2]) + 1;
-    zstr = new char[n];
-    strcpy(zstr,&arg[2][2]);
+    zstr = utils::strdup(arg[2]+2);
   } else if (strcmp(arg[2],"NULL") == 0) zstyle = NONE;
   else vz = utils::numeric(FLERR,arg[2],false,lmp);
 

--- a/unittest/utils/test_utils.cpp
+++ b/unittest/utils/test_utils.cpp
@@ -30,6 +30,21 @@ using ::testing::StrEq;
 #define FLERR __FILE__, __LINE__
 #endif
 
+TEST(Utils, strdup)
+{
+    std::string original("some_text");
+    const char *copy = utils::strdup(original);
+    ASSERT_THAT(original, StrEq(copy));
+    ASSERT_NE(copy,original.c_str());
+
+    const char *copy2 = utils::strdup(copy);
+    ASSERT_THAT(original, StrEq(copy2));
+    ASSERT_NE(copy,copy2);
+
+    delete[] copy;
+    delete[] copy2;
+}
+
 TEST(Utils, trim)
 {
     auto trimmed = utils::trim("\t some text");


### PR DESCRIPTION
**Summary**

This PR replaces uses of `strstr(text,"x_") == text` with the more obvious `utils::strmatch(text,"^x_")`.
Also it introduces a new utility function `utils::strdup()` that works similar to the POSIX `strdup()` function, only it accepts both, C-style strings and C++ style strings (std::string) as argument, but always returns a copy (allocated with `new char[]`) as a C-style string. This reduces frequent cases of 3 lines of code following many of the strmatch() calls from above (that also often confuse static code analysis tools) with one line of code.

For technical reasons, the PR contains a large part of PR #2580 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. 

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.

