### PR TITLE
Correct some inconsistencies

### DIFF
--- a/examples/SPIN/nickel/in.spin.nickel
+++ b/examples/SPIN/nickel/in.spin.nickel
@@ -1,6 +1,6 @@
 # fcc nickel in a 3d periodic box
 
-clear 
+clear
 units           metal
 atom_style      spin
 
@@ -8,7 +8,7 @@ dimension       3
 boundary        p p p
 
 # necessary for the serial algorithm (sametag)
-atom_modify     map array 
+atom_modify     map array
 
 lattice         fcc 3.524
 region          box block 0.0 5.0 0.0 5.0 0.0 5.0
@@ -20,7 +20,7 @@ create_atoms    1 box
 mass            1 58.69
 
 set             group all spin/random 31 0.63
-#set            group all spin 0.63 0.0 0.0 1.0 
+#set            group all spin 0.63 0.0 0.0 1.0
 velocity        all create 100 4928459 rot yes dist gaussian
 
 pair_style      hybrid/overlay eam/alloy spin/exchange 4.0
@@ -31,7 +31,7 @@ neighbor        0.1 bin
 neigh_modify    every 10 check yes delay 20
 
 fix             1 all precession/spin zeeman 0.0 0.0 0.0 1.0
-fix_modify 	1 energy yes
+fix_modify      1 energy yes
 fix             2 all langevin/spin 0.0 0.0 21
 
 fix             3 all nve/spin lattice moving

--- a/examples/SPIN/nickel/in.spin.nickel_cubic
+++ b/examples/SPIN/nickel/in.spin.nickel_cubic
@@ -1,60 +1,60 @@
 # fcc nickel in a 3d periodic box
 
-clear 
-units 		metal
-atom_style 	spin
+clear
+units           metal
+atom_style      spin
 
-dimension 	3
-boundary 	p p p
+dimension       3
+boundary        p p p
 
 # necessary for the serial algorithm (sametag)
-atom_modify 	map array 
+atom_modify     map array
 
-lattice 	fcc 3.524
-region 		box block 0.0 5.0 0.0 5.0 0.0 5.0
-create_box 	1 box
-create_atoms 	1 box
+lattice         fcc 3.524
+region          box block 0.0 5.0 0.0 5.0 0.0 5.0
+create_box      1 box
+create_atoms    1 box
 
 # setting mass, mag. moments, and interactions for cobalt
 
-mass		1 58.69
+mass            1 58.69
 
-set 		group all spin/random 31 0.63
-#set 		group all spin 0.63 0.0 0.0 1.0 
-velocity 	all create 100 4928459 rot yes dist gaussian
+set             group all spin/random 31 0.63
+#set            group all spin 0.63 0.0 0.0 1.0
+velocity        all create 100 4928459 rot yes dist gaussian
 
-pair_style 	hybrid/overlay eam/alloy spin/exchange 4.0
-pair_coeff 	* * eam/alloy Ni99.eam.alloy Ni
-pair_coeff 	* * spin/exchange exchange 4.0 0.50 0.2280246862 1.229983475
+pair_style      hybrid/overlay eam/alloy spin/exchange 4.0
+pair_coeff      * * eam/alloy Ni99.eam.alloy Ni
+pair_coeff      * * spin/exchange exchange 4.0 0.50 0.2280246862 1.229983475
 
-neighbor 	0.1 bin
-neigh_modify 	every 10 check yes delay 20
+neighbor        0.1 bin
+neigh_modify    every 10 check yes delay 20
 
-fix 		1 all precession/spin cubic -0.0001 0.0 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0 &
-				      zeeman 0.0 0.0 0.0 1.0
-fix_modify 	1 energy yes
-fix 		2 all langevin/spin 0.0 0.0 21
+fix             1 all precession/spin cubic -0.0001 0.0 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0 &
+                                      zeeman 0.0 0.0 0.0 1.0
+fix_modify      1 energy yes
+fix             2 all langevin/spin 0.0 0.0 21
 
-fix 		3 all nve/spin lattice moving
-timestep	0.0001
+fix             3 all nve/spin lattice moving
+timestep        0.0001
 
 # compute and output options
 
-compute 	out_mag    all spin
-compute 	out_pe     all pe
-compute 	out_ke     all ke
-compute 	out_temp   all temp
+compute         out_mag    all spin
+compute         out_pe     all pe
+compute         out_ke     all ke
+compute         out_temp   all temp
 
-variable 	magz      equal c_out_mag[3]
-variable 	magnorm   equal c_out_mag[4]
-variable 	emag      equal c_out_mag[5]
-variable 	tmag      equal c_out_mag[6]
+variable        magz      equal c_out_mag[3]
+variable        magnorm   equal c_out_mag[4]
+variable        emag      equal c_out_mag[5]
+variable        tmag      equal c_out_mag[6]
 
 thermo_style    custom step time v_magnorm pe v_emag temp v_tmag etotal
 thermo          50
 
-compute 	outsp all property/atom spx spy spz sp fmx fmy fmz
-dump 		1 all custom 50 dump.lammpstrj type x y z c_outsp[1] c_outsp[2] c_outsp[3] c_outsp[4] c_outsp[5] c_outsp[6] c_outsp[7]
+compute         outsp all property/atom spx spy spz sp fmx fmy fmz
+dump            1 all custom 50 dump.lammpstrj type x y z c_outsp[1] c_outsp[2] c_outsp[3] c_outsp[4] c_outsp[5] c_outsp[6] c_outsp[7]
 
-run 		1000
+run             1000
 

--- a/examples/USER/misc/gle/in.h2o-quantum
+++ b/examples/USER/misc/gle/in.h2o-quantum
@@ -1,12 +1,12 @@
-units		real
-atom_style	full 
+units           real
+atom_style      full 
 
-pair_style	lj/cut/tip4p/long 1 2 1 1 0.14714951 8
-bond_style	class2
-angle_style	harmonic
-kspace_style	pppm/tip4p 0.0001
+pair_style      lj/cut/tip4p/long 1 2 1 1 0.14714951 8
+bond_style      class2
+angle_style     harmonic
+kspace_style    pppm/tip4p 0.0001
 
-read_data	data.h2o-quantum
+read_data       data.h2o-quantum
 
 pair_coeff  * 2  0.0     0.0
 pair_coeff  1 1  0.1852  3.1589022
@@ -15,7 +15,7 @@ pair_coeff  1 1  0.1852  3.1589022
 bond_coeff      1 0.9419 607.19354  -1388.6516 1852.577
 angle_coeff     1 43.93  107.4
 
-timestep	0.5
+timestep        0.5
 
 # mean velocity is higher than target T because of zero point energy
 velocity        all create 800.0 1112 dist gaussian mom yes
@@ -24,18 +24,17 @@ thermo          100
 thermo_style    custom step temp pe ke etotal
 
 # some problem
-fix	 1 all gle 6 300.0 300.0 31415 qt-300k.A noneq qt-300k.C
-fix_modify 1 energy no
+fix      1 all gle 6 300.0 300.0 31415 qt-300k.A noneq qt-300k.C
 
-#dump		1 all atom 100 h2o-smart.lammpstrj
+#dump           1 all atom 100 h2o-smart.lammpstrj
 
-#dump		2 all image 1000 h2o-smart.*.jpg element element &
-#		zoom 1.4
-#dump_modify	2 pad 5 element O H
+#dump           2 all image 1000 h2o-smart.*.jpg element element &
+#               zoom 1.4
+#dump_modify    2 pad 5 element O H
 
-#dump		3 all movie 100 movie.mp4 element element &
-#		zoom 1.4
-#dump_modify	3 pad 5 element O H
+#dump           3 all movie 100 movie.mp4 element element &
+#               zoom 1.4
+#dump_modify    3 pad 5 element O H
 
-run		10000
+run             10000
 

--- a/examples/USER/misc/gle/in.h2o-smart
+++ b/examples/USER/misc/gle/in.h2o-smart
@@ -1,12 +1,12 @@
-units		real
-atom_style	full 
+units           real
+atom_style      full 
 
-pair_style	lj/cut/tip4p/long 1 2 1 1 0.14714951 8
-bond_style	class2
-angle_style	harmonic
-kspace_style	pppm/tip4p 0.0001
+pair_style      lj/cut/tip4p/long 1 2 1 1 0.14714951 8
+bond_style      class2
+angle_style     harmonic
+kspace_style    pppm/tip4p 0.0001
 
-read_data	data.h2o-smart
+read_data       data.h2o-smart
 
 pair_coeff  * 2  0.0     0.0
 pair_coeff  1 1  0.1852  3.1589022
@@ -15,27 +15,26 @@ pair_coeff  1 1  0.1852  3.1589022
 bond_coeff      1 0.9419 607.19354  -1388.6516 1852.577
 angle_coeff     1 43.93  107.4
 
-timestep	0.5
+timestep        0.5
 
-velocity	all create 300.0 1112 dist gaussian mom yes
+velocity        all create 300.0 1112 dist gaussian mom yes
 
 thermo          100
 thermo_style    custom step temp pe ke etotal
 
 # smart sampling with GLE: best efficiency on slow diffusive modes, 
 # and as good as possible on higher-frequency modes
-fix		1 all gle 6 300.0 300.0 31415 smart.A
-fix_modify	1 energy no
+fix             1 all gle 6 300.0 300.0 31415 smart.A
 
-#dump		1 all atom 100 h2o-smart.lammpstrj
+#dump           1 all atom 100 h2o-smart.lammpstrj
 
-#dump		2 all image 1000 h2o-smart.*.jpg element element &
-#		zoom 1.4
-#dump_modify	2 pad 5 element O H
+#dump           2 all image 1000 h2o-smart.*.jpg element element &
+#               zoom 1.4
+#dump_modify    2 pad 5 element O H
 
-#dump		3 all movie 100 movie.mp4 element element &
-#		zoom 1.4
-#dump_modify	3 pad 5 element O H
+#dump           3 all movie 100 movie.mp4 element element &
+#               zoom 1.4
+#dump_modify    3 pad 5 element O H
 
-run		10000
+run             10000
 

--- a/examples/USER/qtb/alpha_quartz_qbmsst/in.alpha_quartz_qbmsst
+++ b/examples/USER/qtb/alpha_quartz_qbmsst/in.alpha_quartz_qbmsst
@@ -23,13 +23,12 @@ include                 alpha_quartz_qtb.mod
 reset_timestep          0
 #Beta is the number of time steps between each update of the quantum bath temperature. Setting a larger beta can reduce thermal flactuations.
 fix                     shock all qbmsst z ${v_msst} q ${q_msst} tscale ${tscale_msst} damp ${damp_qtb} f_max 120 N_f 100 seed 35082 eta ${eta_qbmsst} beta 5 T_init ${temperature}
-fix_modify              shock energy yes
 variable                dhug equal f_shock[1]
 variable                dray equal f_shock[2]
 variable                lgr_vel equal f_shock[3]
 variable                lgr_pos equal f_shock[4]
 variable                T_qm equal f_shock[5]                                                                   #Temperature with quantum nuclear correction
-thermo_style            custom step v_T_qm press etotal vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
+thermo_style            custom step v_T_qm press econserve vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
 thermo                  200
 timestep                ${delta_t}
 run                     1000
@@ -42,14 +41,14 @@ read_restart            restart.1000
 include                 alpha_quartz_potential.mod
 #Use the same fix id and add no tscale if the system is already compressed
 fix                     shock all qbmsst z ${v_msst} q ${q_msst} tscale 0.0 damp ${damp_qtb} f_max 120 N_f 100 seed 35082 eta ${eta_qbmsst} beta 5 T_init ${temperature}
-fix_modify              shock energy yes
 variable                dhug equal f_shock[1]
 variable                dray equal f_shock[2]
 variable                lgr_vel equal f_shock[3]
 variable                lgr_pos equal f_shock[4]
 variable                T_qm equal f_shock[5]                                                                   #Temperature with quantum nuclear correction
-thermo_style            custom step v_T_qm press etotal vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
+thermo_style            custom step v_T_qm press econserve vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
 thermo                  500
 timestep                ${delta_t}
-restart                 1000 restart
+#restart                 1000 restart
 run                     10000                                                                                   #10 ps
+shell rm restart.1000

--- a/examples/USER/qtb/alpha_quartz_qbmsst/log.09Feb21.alpha_quartz_qbmsst.g++.1
+++ b/examples/USER/qtb/alpha_quartz_qbmsst/log.09Feb21.alpha_quartz_qbmsst.g++.1
@@ -1,4 +1,4 @@
-LAMMPS (15 Jun 2020)
+LAMMPS (24 Dec 2020)
   using 1 OpenMP thread(s) per MPI task
 ## This script first uses fix qtb to equilibrate alpha quartz structure to an initial state with quantum nuclear correction and then simulate shock induced phase transition through the quantum thermal bath multi-scale shock technique
 variable                x_rep equal 2   #plot is made with x_rep = 8                                            #x-direction replication number
@@ -29,12 +29,12 @@ atom_style              charge
 
 #Lattice
 lattice                 custom 1.0                         a1      4.916000 0.000000 0.000000                         a2      -2.45800 4.257381 0.000000                         a3      0.000000 0.000000 5.405400                                                 basis   0.469700 0.000000 0.000000                         basis   0.000000 0.469700 0.666667                         basis   0.530300 0.530300 0.333333                                                 basis   0.413500 0.266900 0.119100                         basis   0.266900 0.413500 0.547567                         basis   0.733100 0.146600 0.785767                         basis   0.586500 0.853400 0.214233                         basis   0.853400 0.586500 0.452433                         basis   0.146600 0.733100 0.880900                                                      #American Mineralogist 65 920 1980 (Space Group 154)
-Lattice spacing in x,y,z = 7.374 4.25738 5.4054
+Lattice spacing in x,y,z = 7.3740000 4.2573810 5.4054000
 
 #Computational Cell
 region                  orthorhombic_unit_cell block 0 4.916000 0 8.514762 0 5.405400 units box
 create_box              2 orthorhombic_unit_cell
-Created orthogonal box = (0.0 0.0 0.0) to (4.916 8.514762 5.4054)
+Created orthogonal box = (0.0000000 0.0000000 0.0000000) to (4.9160000 8.5147620 5.4054000)
   1 by 1 by 1 MPI processor grid
 create_atoms            1 box                         basis   1 1                         basis   2 1                         basis   3 1                         basis   4 2                         basis   5 2                         basis   6 2                         basis   7 2                         basis   8 2                         basis   9 2
 Created 18 atoms
@@ -43,17 +43,20 @@ replicate               ${x_rep} ${y_rep} ${z_rep}
 replicate               2 ${y_rep} ${z_rep}
 replicate               2 1 ${z_rep}
 replicate               2 1 4
-  orthogonal box = (0.0 0.0 0.0) to (9.832 8.514762 21.6216)
+Replicating atoms ...
+  orthogonal box = (0.0000000 0.0000000 0.0000000) to (9.8320000 8.5147620 21.621600)
   1 by 1 by 1 MPI processor grid
   144 atoms
-  replicate CPU = 0.000271082 secs
+  replicate CPU = 0.001 seconds
 
 #Atomic Information
 mass                    1 28.085500
 mass                    2 15.999400
 set                     type 1 charge +2.4
+Setting atom values ...
   48 settings made for charge
 set                     type 2 charge -1.2
+Setting atom values ...
   96 settings made for charge
 
 
@@ -72,8 +75,8 @@ pair_coeff              1 2 table potential_SiO2.TPF Si-O ${cut_off}
 pair_coeff              1 2 table potential_SiO2.TPF Si-O 10
 pair_coeff              2 2 table potential_SiO2.TPF O-O ${cut_off}                                             #See the potential file for more information
 pair_coeff              2 2 table potential_SiO2.TPF O-O 10                                             
-WARNING: 1 of 39901 force values in table are inconsistent with -dE/dr.
-  Should only be flagged at inflection points (src/pair_table.cpp:471)
+WARNING: 1 of 39901 force values in table O-O are inconsistent with -dE/dr.
+  Should only be flagged at inflection points (src/pair_table.cpp:461)
 kspace_style            pppm 1.0e-4
 
 #Neighbor style
@@ -96,12 +99,12 @@ thermo_style            custom step temp press etotal vol lx ly lz pxx pyy pzz p
 thermo                  200
 run                     2000                                                                                    # 2 ps
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.301598
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30159814
   grid = 9 8 15
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.00117056
-  estimated relative force accuracy = 8.12908e-05
+  estimated absolute RMS force accuracy = 0.0011705589
+  estimated relative force accuracy = 8.1290814e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 5280 1080
 Neighbor list info ...
@@ -123,42 +126,42 @@ Neighbor list info ...
       bin: none
 Per MPI rank memory allocation (min/avg/max) = 80.09 | 80.09 | 80.09 Mbytes
 Step Temp Press TotEng Volume Lx Ly Lz Pxx Pyy Pzz Pxy Pyz Pxz 
-       0            0   -34026.791   -2793.6042    1810.0985        9.832     8.514762      21.6216   -37470.578   -37470.432   -27139.363 -6.4345368e-12   0.94245783 4.2212262e-10 
+       0            0   -34026.791   -2793.6042    1810.0985        9.832     8.514762      21.6216   -37470.578   -37470.432   -27139.363 3.7975984e-11   0.94245783 8.5085457e-11 
      200     170.7381    43248.332   -2790.8398     1879.164    9.9554912    8.6217086     21.89317    39337.624    42979.126    47428.246    324.91326    454.85872   -2034.6053 
-     400    258.09921     -28257.8   -2788.3487    1856.1432    9.9146707    8.5863569    21.803402   -19478.873   -29571.375   -35723.152    4633.9026    8487.8103   -626.12005 
-     600    277.77032   -22751.351   -2786.2715    1866.9783    9.9339253    8.6030319    21.845744   -21727.335   -29200.027   -17326.692   -4327.8571   -8218.4965    252.30681 
-     800     349.8665    30508.003   -2784.2204    1873.4953    9.9454706    8.6130304    21.871134    29929.055    33562.672    28032.281   -3188.5605    12329.482    7558.5678 
-    1000    373.67651   -18839.569   -2783.2178    1855.5937    9.9136922    8.5855095     21.80125   -18063.486   -22288.321   -16166.902   -416.09547   -10368.975    9030.4208 
-    1200     423.3474    6846.9905   -2781.9271    1896.2131    9.9855083    8.6477041    21.959181    2147.3938    11765.857    6627.7202   -7627.6782   -1297.6517   -4758.4746 
-    1400    418.54527   -6416.7506   -2781.4358    1834.2719    9.8755745    8.5524986    21.717425    5693.0543   -19487.901    -5455.405    827.66513    -523.1508   -3890.9919 
-    1600    429.42796    3939.8836   -2780.5861    1895.8859     9.984934    8.6472068    21.957918    3755.6959   -1326.4343    9390.3893    1948.1153    4489.8629    1466.0914 
-    1800     447.7623   -8344.6306   -2780.1071    1858.4925    9.9188518    8.5899779    21.812596   -17549.498    3336.8135   -10821.208    1643.4226   -644.56065   -8935.9666 
-    2000     438.1306   -6691.4691   -2780.7407    1871.3547    9.9416812    8.6097487    21.862801   -6959.2196   -8486.8466    -4628.341   -1019.9006    443.03694    -2751.917 
-Loop time of 2.46815 on 1 procs for 2000 steps with 144 atoms
+     400    258.09921     -28257.8   -2788.3487    1856.1432    9.9146707    8.5863569    21.803402   -19478.873   -29571.375   -35723.151    4633.9025    8487.8103   -626.12008 
+     600    277.77032   -22751.351   -2786.2715    1866.9783    9.9339253    8.6030319    21.845744   -21727.333   -29200.028   -17326.691   -4327.8577   -8218.4994    252.30614 
+     800     349.8665    30508.004   -2784.2204    1873.4953    9.9454706    8.6130304    21.871134    29929.053    33562.675    28032.284   -3188.5636    12329.485    7558.5604 
+    1000    373.67652   -18839.562   -2783.2178    1855.5937    9.9136922    8.5855095     21.80125   -18063.481    -22288.32   -16166.887   -416.09489   -10368.975    9030.4151 
+    1200    423.34739    6846.9842   -2781.9271    1896.2131    9.9855083    8.6477041    21.959181    2147.3919    11765.847    6627.7141   -7627.6762    -1297.649   -4758.4757 
+    1400    418.54526   -6416.7547   -2781.4358    1834.2719    9.8755745    8.5524986    21.717425    5693.0508   -19487.901   -5455.4139    827.66188    -523.1469   -3890.9904 
+    1600    429.42798     3939.889   -2780.5861    1895.8859     9.984934    8.6472068    21.957918    3755.6972   -1326.4252     9390.395    1948.1084    4489.8536     1466.083 
+    1800    447.76215   -8344.6447   -2780.1071    1858.4925    9.9188519    8.5899779    21.812596   -17549.502    3336.8092   -10821.241    1643.4315   -644.54621     -8935.98 
+    2000     438.1305   -6691.4324   -2780.7407    1871.3547    9.9416812    8.6097487      21.8628   -6959.1834   -8486.8262   -4628.2877   -1019.8998    443.04638   -2751.9173 
+Loop time of 11.2763 on 1 procs for 2000 steps with 144 atoms
 
-Performance: 70.012 ns/day, 0.343 hours/ns, 810.323 timesteps/s
-99.8% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 15.324 ns/day, 1.566 hours/ns, 177.363 timesteps/s
+99.5% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 2.0003     | 2.0003     | 2.0003     |   0.0 | 81.04
-Kspace  | 0.20006    | 0.20006    | 0.20006    |   0.0 |  8.11
+Pair    | 7.9085     | 7.9085     | 7.9085     |   0.0 | 70.13
+Kspace  | 2.0339     | 2.0339     | 2.0339     |   0.0 | 18.04
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.023753   | 0.023753   | 0.023753   |   0.0 |  0.96
-Output  | 0.0001986  | 0.0001986  | 0.0001986  |   0.0 |  0.01
-Modify  | 0.23896    | 0.23896    | 0.23896    |   0.0 |  9.68
-Other   |            | 0.004907   |            |       |  0.20
+Comm    | 0.15276    | 0.15276    | 0.15276    |   0.0 |  1.35
+Output  | 0.00036049 | 0.00036049 | 0.00036049 |   0.0 |  0.00
+Modify  | 1.1706     | 1.1706     | 1.1706     |   0.0 | 10.38
+Other   |            | 0.01023    |            |       |  0.09
 
-Nlocal:    144 ave 144 max 144 min
+Nlocal:        144.000 ave         144 max         144 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Nghost:    3943 ave 3943 max 3943 min
+Nghost:        3943.00 ave        3943 max        3943 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Neighs:    41952 ave 41952 max 41952 min
+Neighs:        41952.0 ave       41952 max       41952 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
 
 Total # of neighbors = 41952
-Ave neighs/atom = 291.333
+Ave neighs/atom = 291.33333
 Neighbor list builds = 0
 Dangerous builds = 0
 unfix                   quartz_qtb
@@ -185,24 +188,23 @@ QBMSST parameters:
   Initial pressure calculated on first step
   Initial volume calculated on first step
   Initial energy calculated on first step
-fix_modify              shock energy yes
 variable                dhug equal f_shock[1]
 variable                dray equal f_shock[2]
 variable                lgr_vel equal f_shock[3]
 variable                lgr_pos equal f_shock[4]
 variable                T_qm equal f_shock[5]                                                                   #Temperature with quantum nuclear correction
-thermo_style            custom step v_T_qm press etotal vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
+thermo_style            custom step v_T_qm press econserve vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
 thermo                  200
 timestep                ${delta_t}
 timestep                0.001
 run                     1000
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.303132
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30313178
   grid = 9 8 16
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.00104699
-  estimated relative force accuracy = 7.27093e-05
+  estimated absolute RMS force accuracy = 0.0010469888
+  estimated relative force accuracy = 7.2709348e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 5520 1152
 Neighbor list info ...
@@ -223,52 +225,53 @@ Neighbor list info ...
       stencil: none
       bin: none
 Fix QBMSST v0 =  1.87135e+03
-Fix QBMSST p0 = -4.62948e+03
+Fix QBMSST p0 = -4.62942e+03
 Fix QBMSST e0 = to be -2.78074e+03
-Fix QBMSST initial strain rate of -4.01096e-01 established by reducing temperature by factor of  5.00000e-02
-Per MPI rank memory allocation (min/avg/max) = 80.1 | 80.1 | 80.1 Mbytes
-Step v_T_qm Press TotEng Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
-       0          300   -6922.9433   -2780.7394    1871.3547    9.9416812    8.6097487    21.862801   -4819.9907    10.953265   -190.51273            0            0 
-     200    294.95797    54876.416   -2779.2988    1723.7621    9.9416812    8.6097487    20.138495    108897.19   -29.773973   -9271.7281    6.1518102   -15.057867 
-     400     288.3711    139521.03   -2778.7321    1628.5574    9.9416812    8.6097487    19.026231    222107.71    8.0682073    24727.575    10.120041   -28.714693 
-     600    280.56521    98070.281   -2779.8934    1687.2434    9.9416812    8.6097487    19.711852    164558.51    2.6076928    16005.656    7.6739491   -42.705007 
-     800    274.94701    106060.26   -2779.2916    1651.0723    9.9416812    8.6097487    19.289269     176842.6   -39.645354   -1804.9466    9.1815975   -56.628078 
-    1000    268.47106    189695.34   -2779.4951    1492.6355    9.9416812    8.6097487    17.438272     277351.5   -84.834482   -33116.996    15.785409   -69.870519 
-Loop time of 2.05219 on 1 procs for 1000 steps with 144 atoms
+Fix QBMSST initial strain rate of -4.01095e-01 established by reducing temperature by factor of  5.00000e-02
+Per MPI rank memory allocation (min/avg/max) = 80.10 | 80.10 | 80.10 Mbytes
+Step v_T_qm Press Econserve Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
+       0          300   -6922.9066   -2780.7394    1871.3547    9.9416812    8.6097487      21.8628   -4819.9374    10.953262    -190.5127            0            0 
+     200    294.95802    54876.628   -2779.2988    1723.7617    9.9416812    8.6097487     20.13849    108897.62   -29.773363   -9271.7016    6.1518278   -15.057866 
+     400    288.37122    139520.66   -2778.7321    1628.5573    9.9416812    8.6097487     19.02623    222107.14    8.0673735    24726.892    10.120044   -28.714689 
+     600    280.56538    98072.818   -2779.8934    1687.2396    9.9416812    8.6097487    19.711808    164562.57    2.6099747    16006.563    7.6741039   -42.704989 
+     800     274.9472    106058.35   -2779.2916    1651.0755    9.9416812    8.6097487    19.289307    176839.13   -39.647552   -1805.8176    9.1814643   -56.628046 
+    1000     268.4714    189679.65   -2779.4952    1492.6558    9.9416812    8.6097487     17.43851    277332.66   -84.846841   -33118.917    15.784559   -69.870561 
+Loop time of 8.7779 on 1 procs for 1000 steps with 144 atoms
 
-Performance: 42.101 ns/day, 0.570 hours/ns, 487.284 timesteps/s
-99.8% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 9.843 ns/day, 2.438 hours/ns, 113.922 timesteps/s
+99.2% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 1.6815     | 1.6815     | 1.6815     |   0.0 | 81.94
-Kspace  | 0.10373    | 0.10373    | 0.10373    |   0.0 |  5.05
-Neigh   | 0.0061183  | 0.0061183  | 0.0061183  |   0.0 |  0.30
-Comm    | 0.012444   | 0.012444   | 0.012444   |   0.0 |  0.61
-Output  | 0.00014687 | 0.00014687 | 0.00014687 |   0.0 |  0.01
-Modify  | 0.24529    | 0.24529    | 0.24529    |   0.0 | 11.95
-Other   |            | 0.002948   |            |       |  0.14
+Pair    | 6.8031     | 6.8031     | 6.8031     |   0.0 | 77.50
+Kspace  | 1.0505     | 1.0505     | 1.0505     |   0.0 | 11.97
+Neigh   | 0.024976   | 0.024976   | 0.024976   |   0.0 |  0.28
+Comm    | 0.082612   | 0.082612   | 0.082612   |   0.0 |  0.94
+Output  | 0.00032592 | 0.00032592 | 0.00032592 |   0.0 |  0.00
+Modify  | 0.8108     | 0.8108     | 0.8108     |   0.0 |  9.24
+Other   |            | 0.005632   |            |       |  0.06
 
-Nlocal:    144 ave 144 max 144 min
+Nlocal:        144.000 ave         144 max         144 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Nghost:    4243 ave 4243 max 4243 min
+Nghost:        4243.00 ave        4243 max        4243 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Neighs:    48210 ave 48210 max 48210 min
+Neighs:        48210.0 ave       48210 max       48210 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
 
 Total # of neighbors = 48210
-Ave neighs/atom = 334.792
+Ave neighs/atom = 334.79167
 Neighbor list builds = 8
 Dangerous builds = 0
 write_restart           restart.1000
+System init for write_restart ...
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.306435
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30643517
   grid = 9 8 15
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.000955688
-  estimated relative force accuracy = 6.63689e-05
+  estimated absolute RMS force accuracy = 0.0009556927
+  estimated relative force accuracy = 6.6369185e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 5280 1080
 Neighbor list info ...
@@ -294,12 +297,14 @@ Neighbor list info ...
 clear
   using 1 OpenMP thread(s) per MPI task
 read_restart            restart.1000
+Reading restart file ...
+  restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style charge from restart
-  orthogonal box = (-0.05484062286382799 -0.04749337384227555 2.0916641327653274) to (9.886840622863804 8.562255373842252 19.52993586723476)
+  orthogonal box = (-0.054840605 -0.047493358 2.0915450) to (9.8868406 8.5622554 19.530055)
   1 by 1 by 1 MPI processor grid
   restoring pair style hybrid/overlay from restart
   144 atoms
-  read_restart CPU = 0.0002563 secs
+  read_restart CPU = 0.001 seconds
 include                 alpha_quartz_potential.mod
 #This script implements the BKS pair potential for various silicon dioxide compounds. Inner part is fixed with a harmonic potential. Long range Coulomb interactions are evaluated with the pppm method.
 
@@ -314,8 +319,8 @@ pair_coeff              1 2 table potential_SiO2.TPF Si-O ${cut_off}
 pair_coeff              1 2 table potential_SiO2.TPF Si-O 10
 pair_coeff              2 2 table potential_SiO2.TPF O-O ${cut_off}                                             #See the potential file for more information
 pair_coeff              2 2 table potential_SiO2.TPF O-O 10                                             
-WARNING: 1 of 39901 force values in table are inconsistent with -dE/dr.
-  Should only be flagged at inflection points (src/pair_table.cpp:471)
+WARNING: 1 of 39901 force values in table O-O are inconsistent with -dE/dr.
+  Should only be flagged at inflection points (src/pair_table.cpp:461)
 kspace_style            pppm 1.0e-4
 
 #Neighbor style
@@ -338,25 +343,24 @@ QBMSST parameters:
   Initial energy calculated on first step
 Resetting global fix info from restart file:
   fix style: qbmsst, fix ID: shock
-fix_modify              shock energy yes
 variable                dhug equal f_shock[1]
 variable                dray equal f_shock[2]
 variable                lgr_vel equal f_shock[3]
 variable                lgr_pos equal f_shock[4]
 variable                T_qm equal f_shock[5]                                                                   #Temperature with quantum nuclear correction
-thermo_style            custom step v_T_qm press etotal vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
+thermo_style            custom step v_T_qm press econserve vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
 thermo                  500
 timestep                ${delta_t}
 timestep                0.001
-restart                 1000 restart
+#restart                 1000 restart
 run                     10000                                                                                   #10 ps
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.306435
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30643517
   grid = 9 8 15
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.000955688
-  estimated relative force accuracy = 6.63689e-05
+  estimated absolute RMS force accuracy = 0.0009556927
+  estimated relative force accuracy = 6.6369185e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 5280 1080
 All restart file global fix info was re-assigned
@@ -378,53 +382,54 @@ Neighbor list info ...
       stencil: none
       bin: none
 Per MPI rank memory allocation (min/avg/max) = 80.12 | 80.12 | 80.12 Mbytes
-Step v_T_qm Press TotEng Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
-    1000    268.47106    189686.77   -2781.5194    1492.6355    9.9416812    8.6097487    17.438272    277378.37   -84.692548   -33090.129    15.785409            0 
-    1500    362.13476    692245.96   -2800.9352    1011.2037    9.9416812    8.6097487    11.813766    661095.53    188.71833   -49928.712    35.851981    -24.11484 
-    2000    860.78914     714816.8    -2830.893    997.64749    9.9416812    8.6097487     11.65539    653537.64    852.68158   -68765.537     36.41702   -44.978484 
-    2500    1620.8281    709511.19   -2840.8217    1000.3425    9.9416812    8.6097487    11.686875    660030.01    1184.3105   -60030.892    36.304689    -65.69966 
-    3000    2395.6824    649526.84   -2832.6859    995.56591    9.9416812    8.6097487    11.631071    660984.37    939.07209   -63050.693    36.503782   -86.383242 
-    3500    3034.6774    715794.56   -2822.6098     995.8622    9.9416812    8.6097487    11.634532    712849.74    1055.7295   -10938.816    36.491433   -106.99315 
-    4000    3487.9039    736791.25   -2804.1216    994.13867    9.9416812    8.6097487    11.614397    765817.85    943.15747    40595.305    36.563271   -127.76315 
-    4500    3718.6279     813775.8   -2788.1942    995.82514    9.9416812    8.6097487    11.634099    881961.06    1370.5559    158141.68    36.492977   -148.68649 
-    5000    3691.4947    750146.58   -2770.5541    1018.4785    9.9416812    8.6097487    11.898756    770500.36     196.2793    65528.786    35.548762    -169.8589 
-    5500    3585.8602    831522.51   -2766.0198    1005.6834    9.9416812    8.6097487    11.749273    916093.67    1088.1987    200476.48    36.082073   -190.89436 
-    6000    3431.6405    749891.94   -2771.6404    1011.9077    9.9416812    8.6097487     11.82199    781321.11    268.24344     70882.55     35.82264   -212.20913 
-    6500    3350.2876    666113.16   -2780.4124    1028.8353    9.9416812    8.6097487    12.019753    749294.32    371.38231    52939.676    35.117081   -233.59556 
-    7000    3339.2397     675783.2   -2782.7559    1022.6541    9.9416812    8.6097487    11.947539    690109.39   -26.949124   -11388.054    35.374719   -254.95868 
-    7500     3395.582    726601.74   -2784.7652    1018.1439    9.9416812    8.6097487    11.894846    759167.86     506.5811    53917.852     35.56271   -276.24361 
-    8000    3393.2372    625141.93   -2771.6398    1035.4915    9.9416812    8.6097487    12.097517    598674.46   -895.80046   -92142.112    34.839641   -297.61681 
-    8500    3272.9752    659367.77    -2776.608    1031.8188    9.9416812    8.6097487    12.054609    688358.42   -142.30814   -5513.8593    34.992722   -318.94541 
-    9000    3277.8848    724828.76   -2777.6502    1017.6314    9.9416812    8.6097487    11.888859    724452.11    58.574942    18775.738     35.58407    -340.1718 
-    9500    3273.7854    620652.38   -2780.0794    1023.5922    9.9416812    8.6097487    11.958499    747175.42     317.3826    46458.505    35.335617   -361.41643 
-   10000    3329.1766    668606.38   -2786.3493    1022.9534    9.9416812    8.6097487    11.951035    703351.81    168.14538      2103.38    35.362244   -382.64609 
-   10500    3398.9956    642919.16   -2784.2833    1016.2587    9.9416812    8.6097487    11.872822    661298.16   -230.03577    -45520.34    35.641287   -403.78721 
-   11000    3418.7053    675754.06   -2782.6318    1005.7483    9.9416812    8.6097487     11.75003    689789.84   -136.97148   -25773.422    36.079372   -424.97556 
-Loop time of 32.4277 on 1 procs for 10000 steps with 144 atoms
+Step v_T_qm Press Econserve Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
+    1000     268.4714    189671.09   -2781.5189    1492.6558    9.9416812    8.6097487     17.43851    277359.52   -84.704915   -33092.054    15.784559            0 
+    1500    362.24943    690690.88   -2801.3189    1013.1871    9.9416812    8.6097487    11.836938    660912.81    210.15736   -48461.278     35.76931   -24.117097 
+    2000    851.29288    687202.75     -2829.28    998.92158    9.9416812    8.6097487    11.670275    702779.72     1177.175   -18463.457    36.363914   -45.102068 
+    2500    1584.7231     702373.6   -2840.9926    998.47448    9.9416812    8.6097487    11.665052    685551.65    1366.7769   -36063.512    36.382549   -65.966813 
+    3000    2369.1915    765783.04   -2835.3495    994.53954    9.9416812    8.6097487     11.61908    742616.98    1609.2532    17727.912    36.546562   -86.541922 
+    3500    3092.3052    829161.44   -2827.8974    977.82563    9.9416812    8.6097487    11.423814    768559.05    1500.9858     29763.85    37.243215   -107.10048 
+    4000    3627.1538    773057.81    -2813.687    988.31955    9.9416812    8.6097487    11.546413    738541.81    959.39292    8477.6525    36.805818   -127.75274 
+    4500    3910.5455    753799.74   -2790.7863     1002.749    9.9416812    8.6097487     11.71499    763069.75     602.0127    45010.991    36.204385   -148.51594 
+    5000    3976.7913    761978.62   -2782.0448    998.85434    9.9416812    8.6097487    11.669489     780709.6    482.34112    59410.482    36.366717   -169.42341 
+    5500    3928.0113    702739.91   -2765.8379     1008.695    9.9416812    8.6097487    11.784456    632171.28    -991.2791   -80940.344    35.956549   -190.30951 
+    6000    3731.5486    654300.14   -2763.1253    1032.1476    9.9416812    8.6097487     12.05845    642590.19    -832.8417   -51008.602    34.979018   -211.41573 
+    6500    3505.5984    713092.19   -2767.3169    1010.6873    9.9416812    8.6097487    11.807732    735218.98    -176.4579    23764.995    35.873507   -232.57305 
+    7000    3348.5047    762624.48   -2769.0996    1010.8032    9.9416812    8.6097487    11.809086    662703.98   -667.90587   -48653.562    35.868676   -253.64668 
+    7500    3197.2839    689038.79   -2770.7583     1036.994    9.9416812    8.6097487     12.11507    679188.92   -330.37222   -10377.635    34.777016   -275.06425 
+    8000    3117.1867    765531.79   -2775.0143    1023.9741    9.9416812    8.6097487     11.96296    681640.02   -288.82226   -18759.215    35.319699   -296.38453 
+    8500    3053.5599    667992.24    -2772.057    1027.6458    9.9416812    8.6097487    12.005857    657921.43   -507.92809   -39422.884    35.166657   -317.64367 
+    9000    2997.4957    704542.99   -2780.9279     1020.074    9.9416812    8.6097487    11.917396    647510.98    -398.1601   -56133.168    35.482259    -338.8598 
+    9500    2990.5818     810181.5   -2783.2413    1002.8927    9.9416812    8.6097487    11.716669    859476.58    1107.5241    141537.42    36.198393   -359.85577 
+   10000    3055.8298    792271.02   -2786.5277    991.62826    9.9416812    8.6097487    11.585068    847298.17    1051.5369    119986.89    36.667907   -380.83279 
+   10500    3159.7134    706528.08   -2793.5555    1009.9173    9.9416812    8.6097487    11.798737    673106.83     67.67511   -38987.761    35.905599   -401.74903 
+   11000    3261.7609    748345.85   -2783.0699    1017.8806    9.9416812    8.6097487    11.891771    656140.32    -267.8786   -49328.779    35.573683   -422.65593 
+Loop time of 130.289 on 1 procs for 10000 steps with 144 atoms
 
-Performance: 26.644 ns/day, 0.901 hours/ns, 308.378 timesteps/s
-99.5% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 6.631 ns/day, 3.619 hours/ns, 76.752 timesteps/s
+99.6% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 28.397     | 28.397     | 28.397     |   0.0 | 87.57
-Kspace  | 1.0225     | 1.0225     | 1.0225     |   0.0 |  3.15
-Neigh   | 0.27594    | 0.27594    | 0.27594    |   0.0 |  0.85
-Comm    | 0.1797     | 0.1797     | 0.1797     |   0.0 |  0.55
-Output  | 0.10409    | 0.10409    | 0.10409    |   0.0 |  0.32
-Modify  | 2.4112     | 2.4112     | 2.4112     |   0.0 |  7.44
-Other   |            | 0.03707    |            |       |  0.11
+Pair    | 109.8      | 109.8      | 109.8      |   0.0 | 84.27
+Kspace  | 10.328     | 10.328     | 10.328     |   0.0 |  7.93
+Neigh   | 1.0855     | 1.0855     | 1.0855     |   0.0 |  0.83
+Comm    | 1.2041     | 1.2041     | 1.2041     |   0.0 |  0.92
+Output  | 0.0012848  | 0.0012848  | 0.0012848  |   0.0 |  0.00
+Modify  | 7.8094     | 7.8094     | 7.8094     |   0.0 |  5.99
+Other   |            | 0.06511    |            |       |  0.05
 
-Nlocal:    144 ave 144 max 144 min
+Nlocal:        144.000 ave         144 max         144 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Nghost:    5541 ave 5541 max 5541 min
+Nghost:        5430.00 ave        5430 max        5430 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Neighs:    74662 ave 74662 max 74662 min
+Neighs:        72807.0 ave       72807 max       72807 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
 
-Total # of neighbors = 74662
-Ave neighs/atom = 518.486
-Neighbor list builds = 207
+Total # of neighbors = 72807
+Ave neighs/atom = 505.60417
+Neighbor list builds = 206
 Dangerous builds = 0
-Total wall time: 0:00:37
+shell rm restart.1000
+Total wall time: 0:02:32

--- a/examples/USER/qtb/alpha_quartz_qbmsst/log.09Feb21.alpha_quartz_qbmsst.g++.4
+++ b/examples/USER/qtb/alpha_quartz_qbmsst/log.09Feb21.alpha_quartz_qbmsst.g++.4
@@ -1,4 +1,4 @@
-LAMMPS (15 Jun 2020)
+LAMMPS (24 Dec 2020)
   using 1 OpenMP thread(s) per MPI task
 ## This script first uses fix qtb to equilibrate alpha quartz structure to an initial state with quantum nuclear correction and then simulate shock induced phase transition through the quantum thermal bath multi-scale shock technique
 variable                x_rep equal 2   #plot is made with x_rep = 8                                            #x-direction replication number
@@ -29,12 +29,12 @@ atom_style              charge
 
 #Lattice
 lattice                 custom 1.0                         a1      4.916000 0.000000 0.000000                         a2      -2.45800 4.257381 0.000000                         a3      0.000000 0.000000 5.405400                                                 basis   0.469700 0.000000 0.000000                         basis   0.000000 0.469700 0.666667                         basis   0.530300 0.530300 0.333333                                                 basis   0.413500 0.266900 0.119100                         basis   0.266900 0.413500 0.547567                         basis   0.733100 0.146600 0.785767                         basis   0.586500 0.853400 0.214233                         basis   0.853400 0.586500 0.452433                         basis   0.146600 0.733100 0.880900                                                      #American Mineralogist 65 920 1980 (Space Group 154)
-Lattice spacing in x,y,z = 7.374 4.25738 5.4054
+Lattice spacing in x,y,z = 7.3740000 4.2573810 5.4054000
 
 #Computational Cell
 region                  orthorhombic_unit_cell block 0 4.916000 0 8.514762 0 5.405400 units box
 create_box              2 orthorhombic_unit_cell
-Created orthogonal box = (0.0 0.0 0.0) to (4.916 8.514762 5.4054)
+Created orthogonal box = (0.0000000 0.0000000 0.0000000) to (4.9160000 8.5147620 5.4054000)
   1 by 2 by 2 MPI processor grid
 create_atoms            1 box                         basis   1 1                         basis   2 1                         basis   3 1                         basis   4 2                         basis   5 2                         basis   6 2                         basis   7 2                         basis   8 2                         basis   9 2
 Created 18 atoms
@@ -43,17 +43,20 @@ replicate               ${x_rep} ${y_rep} ${z_rep}
 replicate               2 ${y_rep} ${z_rep}
 replicate               2 1 ${z_rep}
 replicate               2 1 4
-  orthogonal box = (0.0 0.0 0.0) to (9.832 8.514762 21.6216)
+Replicating atoms ...
+  orthogonal box = (0.0000000 0.0000000 0.0000000) to (9.8320000 8.5147620 21.621600)
   1 by 1 by 4 MPI processor grid
   144 atoms
-  replicate CPU = 0.000225782 secs
+  replicate CPU = 0.001 seconds
 
 #Atomic Information
 mass                    1 28.085500
 mass                    2 15.999400
 set                     type 1 charge +2.4
+Setting atom values ...
   48 settings made for charge
 set                     type 2 charge -1.2
+Setting atom values ...
   96 settings made for charge
 
 
@@ -72,8 +75,8 @@ pair_coeff              1 2 table potential_SiO2.TPF Si-O ${cut_off}
 pair_coeff              1 2 table potential_SiO2.TPF Si-O 10
 pair_coeff              2 2 table potential_SiO2.TPF O-O ${cut_off}                                             #See the potential file for more information
 pair_coeff              2 2 table potential_SiO2.TPF O-O 10                                             
-WARNING: 1 of 39901 force values in table are inconsistent with -dE/dr.
-  Should only be flagged at inflection points (src/pair_table.cpp:471)
+WARNING: 1 of 39901 force values in table O-O are inconsistent with -dE/dr.
+  Should only be flagged at inflection points (src/pair_table.cpp:461)
 kspace_style            pppm 1.0e-4
 
 #Neighbor style
@@ -96,12 +99,12 @@ thermo_style            custom step temp press etotal vol lx ly lz pxx pyy pzz p
 thermo                  200
 run                     2000                                                                                    # 2 ps
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.301598
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30159814
   grid = 9 8 15
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.00117056
-  estimated relative force accuracy = 8.12908e-05
+  estimated absolute RMS force accuracy = 0.0011705589
+  estimated relative force accuracy = 8.1290814e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 2400 288
 Neighbor list info ...
@@ -121,44 +124,44 @@ Neighbor list info ...
       pair build: skip
       stencil: none
       bin: none
-Per MPI rank memory allocation (min/avg/max) = 79.7 | 79.7 | 79.7 Mbytes
+Per MPI rank memory allocation (min/avg/max) = 79.70 | 79.70 | 79.70 Mbytes
 Step Temp Press TotEng Volume Lx Ly Lz Pxx Pyy Pzz Pxy Pyz Pxz 
-       0            0   -34026.791   -2793.6042    1810.0985        9.832     8.514762      21.6216   -37470.578   -37470.432   -27139.363 1.0530512e-10   0.94245783 4.0087238e-10 
+       0            0   -34026.791   -2793.6042    1810.0985        9.832     8.514762      21.6216   -37470.578   -37470.432   -27139.363 -3.2012455e-11   0.94245783 1.6892124e-10 
      200    153.57631    45538.205   -2790.8177    1873.0866    9.9447472     8.612404    21.869543    41721.016    44095.248    50798.351   -3961.4596     1223.325     2871.656 
      400    234.74785   -34404.175   -2789.0189    1850.2127       9.9041    8.5772024    21.780156   -28329.333   -39376.313    -35506.88   -1154.5043   -5411.1071    2246.6749 
-     600    265.24833   -20905.145   -2786.2727    1874.9981     9.948129    8.6153326     21.87698   -22753.886   -21091.083   -18870.468   -4645.5548    2968.2945    1415.0311 
-     800    297.79035     32990.58   -2784.8247    1853.6946     9.910309    8.5825796     21.79381    30061.364     35359.18    33551.195   -3092.2971      1525.52   -6461.0249 
-    1000    367.71884   -27539.239   -2783.0102    1864.7161    9.9299114    8.5995557    21.836917   -20273.387   -38720.429   -23623.901    7639.0334   -866.35665    543.52723 
-    1200    399.77109    3807.7814    -2781.511    1893.4978    9.9807399    8.6435745    21.948695    1625.8226    7441.2236     2356.298   -4057.1674    3814.9305    1528.4567 
-    1400    466.57962    -4148.235   -2780.1546    1851.5925    9.9065614    8.5793341    21.785568    -10883.19     1816.768   -3378.2828    896.25296    -7208.541   -42.253127 
-    1600    497.86539     14505.31   -2778.9409    1882.2616    9.9609584    8.6264432    21.905193    8268.1103    20614.738    14633.082   -2690.5669    6807.3187    11995.878 
-    1800    557.31182   -108.04462   -2778.1875     1875.514    9.9490413    8.6161228    21.878986    948.68308   -1929.7575    656.94053   -1628.2172   -6594.5909   -4423.4368 
-    2000    480.39449   -8852.2243   -2778.4963    1862.9552    9.9267847     8.596848    21.830042   -18274.307    3038.8369   -11321.203   -5002.1016    12023.282    6845.2769 
-Loop time of 1.42181 on 4 procs for 2000 steps with 144 atoms
+     600    265.24834   -20905.145   -2786.2727    1874.9981     9.948129    8.6153326     21.87698   -22753.885   -21091.083   -18870.467   -4645.5539    2968.2936    1415.0335 
+     800    297.79036    32990.577   -2784.8247    1853.6946     9.910309    8.5825796     21.79381    30061.366    35359.175    33551.191   -3092.2938     1525.518    -6461.029 
+    1000    367.71885   -27539.237   -2783.0102    1864.7161    9.9299114    8.5995557    21.836917   -20273.384    -38720.43   -23623.895    7639.0325   -866.34777     543.5312 
+    1200     399.7711     3807.785    -2781.511    1893.4978    9.9807399    8.6435745    21.948695    1625.8297    7441.2317    2356.2937   -4057.1659    3814.9292    1528.4637 
+    1400    466.57958   -4148.2231   -2780.1546    1851.5925    9.9065614    8.5793341    21.785568   -10883.182     1816.778   -3378.2653    896.24645   -7208.5417   -42.262464 
+    1600    497.86536    14505.308   -2778.9409    1882.2616    9.9609584    8.6264432    21.905193    8268.1088     20614.74    14633.075   -2690.5703    6807.3188    11995.875 
+    1800    557.31178   -108.02787   -2778.1875     1875.514    9.9490413    8.6161228    21.878986    948.70277    -1929.753    656.96663   -1628.2124   -6594.6026   -4423.4256 
+    2000    480.39444   -8852.2282   -2778.4963    1862.9552    9.9267847     8.596848    21.830042   -18274.302    3038.8276    -11321.21   -5002.1095    12023.298    6845.2631 
+Loop time of 4.1373 on 4 procs for 2000 steps with 144 atoms
 
-Performance: 121.535 ns/day, 0.197 hours/ns, 1406.656 timesteps/s
-87.5% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 41.766 ns/day, 0.575 hours/ns, 483.407 timesteps/s
+96.8% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.72578    | 0.80093    | 0.87518    |   6.1 | 56.33
-Kspace  | 0.33737    | 0.41245    | 0.48642    |   8.4 | 29.01
+Pair    | 2.2821     | 2.4503     | 2.7881     |  12.7 | 59.22
+Kspace  | 0.81032    | 1.1413     | 1.306      |  18.2 | 27.59
 Neigh   | 0          | 0          | 0          |   0.0 |  0.00
-Comm    | 0.066098   | 0.071334   | 0.076039   |   1.6 |  5.02
-Output  | 0.00021172 | 0.00039291 | 0.00093484 |   0.0 |  0.03
-Modify  | 0.090105   | 0.1077     | 0.11384    |   3.1 |  7.58
-Other   |            | 0.029      |            |       |  2.04
+Comm    | 0.16143    | 0.16964    | 0.17659    |   1.3 |  4.10
+Output  | 0.00026584 | 0.00061899 | 0.0016773  |   0.0 |  0.01
+Modify  | 0.29943    | 0.33639    | 0.34927    |   3.7 |  8.13
+Other   |            | 0.03911    |            |       |  0.95
 
-Nlocal:    36 ave 36 max 36 min
+Nlocal:        36.0000 ave          36 max          36 min
 Histogram: 4 0 0 0 0 0 0 0 0 0
-Nghost:    2614 ave 2614 max 2614 min
+Nghost:        2614.00 ave        2614 max        2614 min
 Histogram: 4 0 0 0 0 0 0 0 0 0
-Neighs:    10488 ave 11326 max 9404 min
+Neighs:        10488.0 ave       11326 max        9404 min
 Histogram: 1 0 0 0 0 0 2 0 0 1
 
 Total # of neighbors = 41952
-Ave neighs/atom = 291.333
+Ave neighs/atom = 291.33333
 Neighbor list builds = 0
 Dangerous builds = 0
 unfix                   quartz_qtb
@@ -185,24 +188,23 @@ QBMSST parameters:
   Initial pressure calculated on first step
   Initial volume calculated on first step
   Initial energy calculated on first step
-fix_modify              shock energy yes
 variable                dhug equal f_shock[1]
 variable                dray equal f_shock[2]
 variable                lgr_vel equal f_shock[3]
 variable                lgr_pos equal f_shock[4]
 variable                T_qm equal f_shock[5]                                                                   #Temperature with quantum nuclear correction
-thermo_style            custom step v_T_qm press etotal vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
+thermo_style            custom step v_T_qm press econserve vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
 thermo                  200
 timestep                ${delta_t}
 timestep                0.001
 run                     1000
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.30088
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30087967
   grid = 9 8 15
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.00120534
-  estimated relative force accuracy = 8.37062e-05
+  estimated absolute RMS force accuracy = 0.0012053392
+  estimated relative force accuracy = 8.3706174e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 2400 288
 Neighbor list info ...
@@ -225,50 +227,51 @@ Neighbor list info ...
 Fix QBMSST v0 =  1.86296e+03
 Fix QBMSST p0 = -1.13219e+04
 Fix QBMSST e0 = to be -2.77850e+03
-Fix QBMSST initial strain rate of -4.21890e-01 established by reducing temperature by factor of  5.00000e-02
-Per MPI rank memory allocation (min/avg/max) = 79.7 | 79.7 | 79.7 Mbytes
-Step v_T_qm Press TotEng Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
-       0          300    -9106.318   -2778.4963    1862.9552    9.9267847     8.596848    21.830042   -11562.002    12.009862    -240.0699            0            0 
-     200    296.47213    25984.111   -2777.5178    1770.2164    9.9267847     8.596848    20.743332    64970.204   -25.305765   -1564.7673    3.8828772    -15.16768 
-     400    291.06707    69977.517   -2777.6325     1684.893    9.9267847     8.596848    19.743515    144833.82   -12.184734     6667.384    7.4552796   -29.607028 
-     600    287.21118    39706.699   -2778.0322    1716.9533    9.9267847     8.596848    20.119196    87971.152   -38.593844   -23279.741    6.1129484   -43.751298 
-     800    284.33611    18833.281   -2778.1637    1792.7576    9.9267847     8.596848    21.007468    43725.433   -8.1267799   -3885.5802    2.9391022   -58.454556 
-    1000    281.98328   -6030.6935   -2778.3314    1881.8369    9.9267847     8.596848    22.051297   -14118.602    1.3183874    13055.078  -0.79055793   -73.780965 
-Loop time of 1.25215 on 4 procs for 1000 steps with 144 atoms
+Fix QBMSST initial strain rate of -4.21889e-01 established by reducing temperature by factor of  5.00000e-02
+Per MPI rank memory allocation (min/avg/max) = 79.70 | 79.70 | 79.70 Mbytes
+Step v_T_qm Press Econserve Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
+       0          300   -9106.3219   -2778.4963    1862.9552    9.9267847     8.596848    21.830042   -11562.009    12.009861   -240.06987            0            0 
+     200    296.47212    25984.099   -2777.5178    1770.2165    9.9267847     8.596848    20.743332    64970.178   -25.305804   -1564.7427    3.8828751    -15.16768 
+     400    291.06704    69977.415   -2777.6325    1684.8932    9.9267847     8.596848    19.743517    144833.61    -12.18477    6667.3264    7.4552723   -29.607029 
+     600    287.21114    39706.769   -2778.0322    1716.9533    9.9267847     8.596848    20.119196    87971.211   -38.594057   -23279.705    6.1129499     -43.7513 
+     800    284.33606    18833.325   -2778.1637    1792.7575    9.9267847     8.596848    21.007467    43725.516   -8.1270751   -3885.5508    2.9391052   -58.454557 
+    1000    281.98323   -6030.7047   -2778.3314    1881.8368    9.9267847     8.596848    22.051295   -14118.589    1.3182589    13054.989  -0.79055248   -73.780966 
+Loop time of 3.32539 on 4 procs for 1000 steps with 144 atoms
 
-Performance: 69.001 ns/day, 0.348 hours/ns, 798.628 timesteps/s
-90.6% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 25.982 ns/day, 0.924 hours/ns, 300.717 timesteps/s
+97.0% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.67979    | 0.73665    | 0.8091     |   5.4 | 58.83
-Kspace  | 0.18687    | 0.25893    | 0.31544    |   9.1 | 20.68
-Neigh   | 0.0011306  | 0.0012404  | 0.0013735  |   0.3 |  0.10
-Comm    | 0.040339   | 0.041345   | 0.042296   |   0.4 |  3.30
-Output  | 0.00020051 | 0.00035506 | 0.00081801 |   0.0 |  0.03
-Modify  | 0.19595    | 0.2007     | 0.20253    |   0.6 | 16.03
-Other   |            | 0.01292    |            |       |  1.03
+Pair    | 1.9626     | 2.0842     | 2.2541     |   7.9 | 62.68
+Kspace  | 0.44255    | 0.61231    | 0.73369    |  14.5 | 18.41
+Neigh   | 0.0050733  | 0.0052404  | 0.0053804  |   0.2 |  0.16
+Comm    | 0.077084   | 0.077385   | 0.077714   |   0.1 |  2.33
+Output  | 0.00029039 | 0.00046909 | 0.0010037  |   0.0 |  0.01
+Modify  | 0.50853    | 0.52962    | 0.53724    |   1.7 | 15.93
+Other   |            | 0.01615    |            |       |  0.49
 
-Nlocal:    36 ave 38 max 34 min
+Nlocal:        36.0000 ave          38 max          34 min
 Histogram: 1 0 1 0 0 0 0 1 0 1
-Nghost:    2527.75 ave 2547 max 2518 min
+Nghost:        2527.75 ave        2547 max        2518 min
 Histogram: 2 0 0 1 0 0 0 0 0 1
-Neighs:    10194.8 ave 11177 max 9437 min
+Neighs:        10194.8 ave       11177 max        9437 min
 Histogram: 2 0 0 0 0 0 1 0 0 1
 
 Total # of neighbors = 40779
-Ave neighs/atom = 283.188
+Ave neighs/atom = 283.18750
 Neighbor list builds = 6
 Dangerous builds = 0
 write_restart           restart.1000
+System init for write_restart ...
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.302953
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30295266
   grid = 9 8 16
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.00105569
-  estimated relative force accuracy = 7.33134e-05
+  estimated absolute RMS force accuracy = 0.0010556863
+  estimated relative force accuracy = 7.3313358e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 2640 288
 Neighbor list info ...
@@ -294,12 +297,14 @@ Neighbor list info ...
 clear
   using 1 OpenMP thread(s) per MPI task
 read_restart            restart.1000
+Reading restart file ...
+  restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style charge from restart
-  orthogonal box = (-0.04739235907204603 -0.041042988010289584 -0.21484841641189512) to (9.879392359072014 8.555804988010294 21.83644841641206)
+  orthogonal box = (-0.047392358 -0.041042987 -0.21484765) to (9.8793924 8.5558050 21.836448)
   1 by 1 by 4 MPI processor grid
   restoring pair style hybrid/overlay from restart
   144 atoms
-  read_restart CPU = 0.000472307 secs
+  read_restart CPU = 0.009 seconds
 include                 alpha_quartz_potential.mod
 #This script implements the BKS pair potential for various silicon dioxide compounds. Inner part is fixed with a harmonic potential. Long range Coulomb interactions are evaluated with the pppm method.
 
@@ -314,8 +319,8 @@ pair_coeff              1 2 table potential_SiO2.TPF Si-O ${cut_off}
 pair_coeff              1 2 table potential_SiO2.TPF Si-O 10
 pair_coeff              2 2 table potential_SiO2.TPF O-O ${cut_off}                                             #See the potential file for more information
 pair_coeff              2 2 table potential_SiO2.TPF O-O 10                                             
-WARNING: 1 of 39901 force values in table are inconsistent with -dE/dr.
-  Should only be flagged at inflection points (src/pair_table.cpp:471)
+WARNING: 1 of 39901 force values in table O-O are inconsistent with -dE/dr.
+  Should only be flagged at inflection points (src/pair_table.cpp:461)
 kspace_style            pppm 1.0e-4
 
 #Neighbor style
@@ -338,25 +343,24 @@ QBMSST parameters:
   Initial energy calculated on first step
 Resetting global fix info from restart file:
   fix style: qbmsst, fix ID: shock
-fix_modify              shock energy yes
 variable                dhug equal f_shock[1]
 variable                dray equal f_shock[2]
 variable                lgr_vel equal f_shock[3]
 variable                lgr_pos equal f_shock[4]
 variable                T_qm equal f_shock[5]                                                                   #Temperature with quantum nuclear correction
-thermo_style            custom step v_T_qm press etotal vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
+thermo_style            custom step v_T_qm press econserve vol lx ly lz pzz v_dhug v_dray v_lgr_vel v_lgr_pos
 thermo                  500
 timestep                ${delta_t}
 timestep                0.001
-restart                 1000 restart
+#restart                 1000 restart
 run                     10000                                                                                   #10 ps
 PPPM initialization ...
-  using 12-bit tables for long-range coulomb (src/kspace.cpp:332)
-  G vector (1/distance) = 0.302953
+  using 12-bit tables for long-range coulomb (src/kspace.cpp:339)
+  G vector (1/distance) = 0.30295266
   grid = 9 8 16
   stencil order = 5
-  estimated absolute RMS force accuracy = 0.00105569
-  estimated relative force accuracy = 7.33134e-05
+  estimated absolute RMS force accuracy = 0.0010556863
+  estimated relative force accuracy = 7.3313358e-05
   using double precision FFTW3
   3d grid and FFT values/proc = 2640 288
 All restart file global fix info was re-assigned
@@ -378,53 +382,54 @@ Neighbor list info ...
       stencil: none
       bin: none
 Per MPI rank memory allocation (min/avg/max) = 79.71 | 79.71 | 79.71 Mbytes
-Step v_T_qm Press TotEng Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
-    1000    281.98328   -6031.2395   -2778.6227    1881.8369    9.9267847     8.596848    22.051297   -14113.621    1.3373278    13060.059  -0.79055793            0 
-    1500    266.12746    44405.573   -2777.9815    1739.6543    9.9267847     8.596848    20.385206    92590.239    -12.06041    397.47049    5.1624821   -37.823748 
-    2000    255.79411    17620.408   -2777.9685    1785.7619    9.9267847     8.596848    20.925494    48670.364   -16.082827   -4813.6764    3.2320016   -73.974437 
-    2500     256.8887    40153.833   -2778.4337    1752.9461    9.9267847     8.596848    20.540959    79665.002    7.7413878   -1368.8927    4.6059671   -112.35254 
-    3000    261.55251    5315.4799   -2779.0755    1834.3375    9.9267847     8.596848      21.4947    15896.368    22.588205     3192.882    1.1981949   -148.36068 
-    3500    261.57101    57911.809   -2778.1223    1713.3956    9.9267847     8.596848    20.077507     110996.8   -9.4471543   -3240.9018    6.2619064   -186.41261 
-    4000    254.88665     13952.95   -2778.4816    1818.2782    9.9267847     8.596848    21.306518    26833.588    2.2818412    647.88057    1.8705799   -222.72504 
-    4500    240.08908    73322.997   -2776.7382    1668.6666    9.9267847     8.596848    19.553375    151978.11   -43.917346     189.1572    8.1346613   -260.52885 
-    5000    214.49084    1925.2557   -2777.0657    1890.0985    9.9267847     8.596848    22.148106   -5218.7292     -44.5537    28890.787   -1.1364617   -297.26329 
-    5500     194.6515    71804.842   -2777.3417    1669.7297    9.9267847     8.596848    19.565832    146911.42   -34.911593   -3985.0635    8.0901523    -334.1879 
-    6000    186.23814    10196.007   -2777.1394    1837.3793    9.9267847     8.596848    21.530344    23550.907   -18.381207    13401.096    1.0708382    -371.9208 
-    6500    172.53603    5474.3725   -2777.4502    1818.0038    9.9267847     8.596848    21.303303    18389.825    -22.65951   -8026.2088    1.8820667   -407.83084 
-    7000    160.91186    107908.64   -2777.6746    1621.7378    9.9267847     8.596848    19.003464    196841.27   -8.6606903    5654.1938    10.099523    -444.9925 
-    7500    146.01905    147030.69   -2777.2543    1539.7536    9.9267847     8.596848    18.042777    253089.02   -43.928324   -6926.1018    13.532114   -478.63113 
-    8000    207.17758     837859.1   -2796.8957    989.32874    9.9267847     8.596848    11.592918    811765.11    1172.3778    89652.363    36.577833   -503.41923 
-    8500    725.15657    853732.89   -2832.3144    974.18299    9.9267847     8.596848    11.415441    773926.64    1749.5702    39098.598     37.21197   -524.17835 
-    9000    1554.6089    807867.74   -2843.0063    990.10922    9.9267847     8.596848    11.602064    749697.22    1959.0322     28239.71    36.545155   -544.77354 
-    9500    2440.1194    748145.05   -2839.2364    992.38871    9.9267847     8.596848    11.628775    691503.58    1437.0708   -28040.223    36.449715   -565.41198 
-   10000    3112.1817    823862.43   -2820.0495    982.35471    9.9267847     8.596848    11.511197    754954.89    1330.6807    26987.244    36.869828   -586.12357 
-   10500    3550.0273    868916.79   -2803.7678    983.70386    9.9267847     8.596848    11.527006    867368.45    1727.9058    140533.46    36.813341   -607.00946 
-   11000    3839.7527    830581.55   -2795.3804    995.31485    9.9267847     8.596848    11.663063       811740    1150.0462    94652.768    36.327201   -628.02229 
-Loop time of 15.1476 on 4 procs for 10000 steps with 144 atoms
+Step v_T_qm Press Econserve Volume Lx Ly Lz Pzz v_dhug v_dray v_lgr_vel v_lgr_pos 
+    1000    281.98323   -6031.2507   -2778.6227    1881.8368    9.9267847     8.596848    22.051295   -14113.608    1.3371988     13059.97  -0.79055248            0 
+    1500    266.12743    44405.252   -2777.9815    1739.6551    9.9267847     8.596848    20.385215    92589.619   -12.060756    397.55607    5.1624473   -37.823753 
+    2000    255.79412     17620.89   -2777.9685    1785.7605    9.9267847     8.596848    20.925477     48671.42   -16.082485   -4813.8454    3.2320631   -73.974438 
+    2500    257.13592    39692.462   -2778.6986    1751.4095    9.9267847     8.596848    20.522952    80667.315    15.746345   -1656.6275    4.6703047   -112.35088 
+    3000    248.95332    9617.5633    -2778.937    1830.5557    9.9267847     8.596848    21.450385    25275.769    19.730704    9397.3972    1.3565331   -148.37113 
+    3500    247.70025    100159.87   -2778.0604    1610.8047    9.9267847     8.596848    18.875351    189849.69   -33.726976   -10516.027    10.557281   -185.61862 
+    4000    266.07224    848367.31   -2787.9052    992.46097    9.9267847     8.596848    11.629622    880163.37    1477.3994    160680.23     36.44669   -213.83067 
+    4500    645.86948    789169.63   -2822.9559    992.40405    9.9267847     8.596848    11.628955    696879.41    1039.4139   -22651.518    36.449073   -234.79958 
+    5000    1369.4257    735014.89   -2838.4571    1002.6048    9.9267847     8.596848    11.748487    648785.76    1170.3517   -62181.314    36.021977   -255.55776 
+    5500    2156.7632    768865.28   -2835.9297    995.94989    9.9267847     8.596848    11.670505    678013.94     1271.734   -38540.152    36.300612   -276.42588 
+    6000    2864.2837    773631.53   -2828.0627    993.01727    9.9267847     8.596848     11.63614    749067.81    1567.7659    30051.708    36.423398   -297.26898 
+    6500     3422.632    861319.73   -2810.1415    985.48363    9.9267847     8.596848    11.547861    816792.18    1535.8348    91451.363    36.738824   -318.12934 
+    7000    3798.2073    791521.73   -2801.7757     993.1961    9.9267847     8.596848    11.638236    677215.78    330.09854   -41650.204    36.415911   -338.86015 
+    7500    4060.7728    836165.25   -2789.6215    984.13658    9.9267847     8.596848    11.532077     780101.5    698.84908    53629.791    36.795223   -359.64284 
+    8000    4122.5641    754871.86   -2776.0049    1006.6266    9.9267847     8.596848    11.795613    699610.84   -124.86381   -7979.8848    35.853592   -380.58907 
+    8500    4087.3529    769727.63   -2775.3629    1018.2197    9.9267847     8.596848    11.931461    767853.09     415.9984    69995.141    35.368199   -401.90058 
+    9000    3958.4459    615996.33   -2758.7864    1058.0696    9.9267847     8.596848    12.398422    641295.34   -689.82578   -23107.426    33.699723   -423.43203 
+    9500    3746.2013    643366.31   -2767.1851    1043.1232    9.9267847     8.596848     12.22328    610176.19   -767.67823   -66774.534    34.325515   -445.14544 
+   10000    3723.8623    659730.11   -2781.6634    1034.0441    9.9267847     8.596848    12.116891    671355.25  0.037615796   -13217.642    34.705647    -466.9448 
+   10500      3705.48    637406.18   -2776.4898    1041.5851    9.9267847     8.596848    12.205256     725619.7    274.78304    47377.665    34.389914   -488.75102 
+   11000    3678.0139    648116.35   -2779.0968    1049.9523    9.9267847     8.596848    12.303303    723144.21    382.51198     51926.71    34.039587   -510.63944 
+Loop time of 51.3151 on 4 procs for 10000 steps with 144 atoms
 
-Performance: 57.039 ns/day, 0.421 hours/ns, 660.171 timesteps/s
-91.3% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 16.837 ns/day, 1.425 hours/ns, 194.874 timesteps/s
+94.1% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 7.7228     | 9.085      | 10.626     |  36.0 | 59.98
-Kspace  | 1.6343     | 3.1795     | 4.5467     |  61.0 | 20.99
-Neigh   | 0.02063    | 0.027076   | 0.034395   |   3.1 |  0.18
-Comm    | 0.54719    | 0.57781    | 0.60468    |   2.8 |  3.81
-Output  | 0.10128    | 0.1019     | 0.10373    |   0.3 |  0.67
-Modify  | 2.0819     | 2.1159     | 2.1495     |   1.8 | 13.97
-Other   |            | 0.06035    |            |       |  0.40
+Pair    | 26.662     | 32.362     | 38.05      |  70.9 | 63.07
+Kspace  | 5.8733     | 11.582     | 17.302     | 118.9 | 22.57
+Neigh   | 0.18541    | 0.22229    | 0.25113    |   5.0 |  0.43
+Comm    | 1.4273     | 1.4501     | 1.483      |   1.9 |  2.83
+Output  | 0.0011935  | 0.0018681  | 0.003891   |   2.7 |  0.00
+Modify  | 5.4539     | 5.5056     | 5.5294     |   1.3 | 10.73
+Other   |            | 0.1916     |            |       |  0.37
 
-Nlocal:    36 ave 38 max 33 min
+Nlocal:        36.0000 ave          37 max          35 min
+Histogram: 1 0 0 0 0 2 0 0 0 1
+Nghost:        4159.50 ave        4171 max        4140 min
 Histogram: 1 0 0 0 0 0 1 0 1 1
-Nghost:    4267 ave 4304 max 4239 min
-Histogram: 1 0 1 0 1 0 0 0 0 1
-Neighs:    18859.2 ave 25108 max 12333 min
-Histogram: 1 0 0 1 0 0 1 0 0 1
+Neighs:        17967.8 ave       20291 max       15710 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
 
-Total # of neighbors = 75437
-Ave neighs/atom = 523.868
-Neighbor list builds = 95
+Total # of neighbors = 71871
+Ave neighs/atom = 499.10417
+Neighbor list builds = 161
 Dangerous builds = 0
-Total wall time: 0:00:17
+shell rm restart.1000
+Total wall time: 0:01:01

--- a/examples/tersoff/in.hBN_shift
+++ b/examples/tersoff/in.hBN_shift
@@ -23,9 +23,9 @@ neigh_modify    delay 0
 neigh_modify    check yes
 
 #### Simulation settings ####
-timestep  	0.001
-velocity  	all create 300.0 4928459 loop geom
-fix       	thermostat all nve
+timestep        0.001
+velocity        all create 300.0 4928459 loop geom
+fix             thermostat all nve
 
 ############# Output ###############
 thermo          100
@@ -34,4 +34,4 @@ thermo_style    custom step etotal pe ke temp
 thermo_modify   line one format float %20.16g lost warn
 
 ###### Run molecular dynamics ######
-run 		1000
+run             1000

--- a/examples/tersoff/in.tersoff
+++ b/examples/tersoff/in.tersoff
@@ -7,7 +7,7 @@ units           metal
 atom_style      atomic
 atom_modify     map array
 boundary        p p p
-atom_modify	sort 0 0.0
+atom_modify     sort 0 0.0
 
 # temperature
 
@@ -35,45 +35,45 @@ region          myreg block     0 4 &
 
 create_box      8 myreg
 create_atoms    1 region myreg &
-		basis 1 1  &
-		basis 2 2  &
-		basis 3 3  &
-		basis 4 4  &
-		basis 5 5  &
-		basis 6 6  &
-		basis 7 7  &
-		basis 8 8
+                basis 1 1  &
+                basis 2 2  &
+                basis 3 3  &
+                basis 4 4  &
+                basis 5 5  &
+                basis 6 6  &
+                basis 7 7  &
+                basis 8 8
 
 mass            *       28.06
 
-velocity 	all create $t 5287287 loop geom
+velocity        all create $t 5287287 loop geom
 
 # Equilibrate using Tersoff model for silicon
 
 pair_style      tersoff
-pair_coeff 	* * Si.tersoff Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff Si Si Si Si Si Si Si Si
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
 run             100
 
-write_restart	restart.equil
+write_restart   restart.equil
 
 # Test Tersoff/Mod model for Si
 
 clear
-read_restart	restart.equil
+read_restart    restart.equil
 
 pair_style      tersoff/mod
-pair_coeff 	* * Si.tersoff.mod Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff.mod Si Si Si Si Si Si Si Si
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -82,14 +82,14 @@ run             100
 # Test Tersoff/Mod/C model for Si
 
 clear
-read_restart	restart.equil
+read_restart    restart.equil
 newton on on
 pair_style      tersoff/mod/c
-pair_coeff 	* * Si.tersoff.modc Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff.modc Si Si Si Si Si Si Si Si
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -98,17 +98,17 @@ run             100
 # Test Tersoff model for B/N/C 
 
 clear
-read_restart	restart.equil
+read_restart    restart.equil
 
-variable	fac equal 0.6
-change_box 	all x scale ${fac} y scale ${fac} z scale ${fac} remap
+variable        fac equal 0.6
+change_box      all x scale ${fac} y scale ${fac} z scale ${fac} remap
 
 pair_style      tersoff
-pair_coeff 	* * BNC.tersoff N N N C B B C B
+pair_coeff      * * BNC.tersoff N N N C B B C B
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -117,19 +117,20 @@ run             100
 # Test Tersoff model for B/N/C 
 
 clear
-read_restart	restart.equil
+read_restart    restart.equil
 
-variable	fac equal 0.6
-change_box 	all x scale ${fac} y scale ${fac} z scale ${fac} remap
+variable        fac equal 0.6
+change_box      all x scale ${fac} y scale ${fac} z scale ${fac} remap
 
 pair_style      tersoff shift 0.05
-pair_coeff 	* * BNC.tersoff N N N C B B C B
+pair_coeff      * * BNC.tersoff N N N C B B C B
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
 run             100
 
+shell rm restart.equil

--- a/examples/tersoff/log.09Feb21.tersoff.g++.1
+++ b/examples/tersoff/log.09Feb21.tersoff.g++.1
@@ -1,5 +1,4 @@
 LAMMPS (24 Dec 2020)
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
 # Simple regression tests for Tersoff potentials
 
@@ -10,7 +9,7 @@ units           metal
 atom_style      atomic
 atom_modify     map array
 boundary        p p p
-atom_modify	sort 0 0.0
+atom_modify     sort 0 0.0
 
 # temperature
 
@@ -28,26 +27,26 @@ region          myreg block     0 4                                 0 4         
 create_box      8 myreg
 Created orthogonal box = (0.0000000 0.0000000 0.0000000) to (21.724000 21.724000 21.724000)
   1 by 1 by 1 MPI processor grid
-create_atoms    1 region myreg 		basis 1 1  		basis 2 2  		basis 3 3  		basis 4 4  		basis 5 5  		basis 6 6  		basis 7 7  		basis 8 8
+create_atoms    1 region myreg                 basis 1 1                  basis 2 2                  basis 3 3                  basis 4 4                  basis 5 5                  basis 6 6                  basis 7 7                  basis 8 8
 Created 512 atoms
-  create_atoms CPU = 0.000 seconds
+  create_atoms CPU = 0.001 seconds
 
 mass            *       28.06
 
-velocity 	all create $t 5287287 loop geom
-velocity 	all create 1800 5287287 loop geom
+velocity        all create $t 5287287 loop geom
+velocity        all create 1800 5287287 loop geom
 
 # Equilibrate using Tersoff model for silicon
 
 pair_style      tersoff
-pair_coeff 	* * Si.tersoff Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff Si Si Si Si Si Si Si Si
 Reading tersoff potential file Si.tersoff with DATE: 2007-10-25
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -65,32 +64,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.985 | 2.985 | 2.985 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-       0         1800    -2370.771            0   -2251.8775    12511.419 
-      10    1144.7447   -2327.3227            0   -2251.7759    21852.599 
-      20    770.19243   -2302.1547            0   -2251.7633    22286.587 
-      30    1059.4324   -2320.1988            0   -2251.8159     6242.222 
-      40     1000.972   -2314.6531            0    -2251.796   -3069.9273 
-      50    803.91758   -2300.1702            0   -2251.7834   -7154.1383 
-      60    761.38639   -2296.1731            0   -2251.7928   -14520.921 
-      70    750.57677   -2294.3086            0   -2251.7965   -21400.198 
-      80    676.66672   -2288.2634            0   -2251.7899   -23480.201 
-      90    640.24103   -2284.6678            0   -2251.7848   -20659.983 
-     100    742.67188   -2290.0616            0   -2251.7855   -16211.799 
-Loop time of 0.107338 on 1 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+       0         1800    -2370.771   -2251.8775   -2251.8775    12511.419 
+      10    1144.7447   -2327.3227   -2251.7101   -2251.7759    21852.599 
+      20    770.19243   -2302.1547    -2251.282   -2251.7633    22286.587 
+      30    1059.4324   -2320.1988   -2250.2213   -2251.8159     6242.222 
+      40     1000.972   -2314.6531   -2248.5369    -2251.796   -3069.9273 
+      50    803.91758   -2300.1702   -2247.0699   -2251.7834   -7154.1383 
+      60    761.38639   -2296.1731    -2245.882   -2251.7928   -14520.921 
+      70    750.57677   -2294.3086   -2244.7316   -2251.7965   -21400.198 
+      80    676.66672   -2288.2634   -2243.5683   -2251.7899   -23480.201 
+      90    640.24103   -2284.6678   -2242.3786   -2251.7848   -20659.983 
+     100    742.67188   -2290.0616   -2241.0067   -2251.7855   -16211.799 
+Loop time of 0.447105 on 1 procs for 100 steps with 512 atoms
 
-Performance: 80.493 ns/day, 0.298 hours/ns, 931.637 timesteps/s
-98.6% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 19.324 ns/day, 1.242 hours/ns, 223.661 timesteps/s
+99.9% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.10455    | 0.10455    | 0.10455    |   0.0 | 97.40
-Neigh   | 0.001115   | 0.001115   | 0.001115   |   0.0 |  1.04
-Comm    | 0.000482   | 0.000482   | 0.000482   |   0.0 |  0.45
-Output  | 0.000194   | 0.000194   | 0.000194   |   0.0 |  0.18
-Modify  | 0.000787   | 0.000787   | 0.000787   |   0.0 |  0.73
-Other   |            | 0.000209   |            |       |  0.19
+Pair    | 0.4373     | 0.4373     | 0.4373     |   0.0 | 97.81
+Neigh   | 0.0021279  | 0.0021279  | 0.0021279  |   0.0 |  0.48
+Comm    | 0.0021732  | 0.0021732  | 0.0021732  |   0.0 |  0.49
+Output  | 0.00020552 | 0.00020552 | 0.00020552 |   0.0 |  0.05
+Modify  | 0.0047524  | 0.0047524  | 0.0047524  |   0.0 |  1.06
+Other   |            | 0.0005488  |            |       |  0.12
 
 Nlocal:        512.000 ave         512 max         512 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
@@ -106,15 +105,14 @@ Ave neighs/atom = 16.414062
 Neighbor list builds = 2
 Dangerous builds = 0
 
-write_restart	restart.equil
+write_restart   restart.equil
 System init for write_restart ...
 
 # Test Tersoff/Mod model for Si
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -122,19 +120,19 @@ Reading restart file ...
   1 by 1 by 1 MPI processor grid
   pair style tersoff stores no restart info
   512 atoms
-  read_restart CPU = 0.006 seconds
+  read_restart CPU = 0.001 seconds
 
 pair_style      tersoff/mod
-pair_coeff 	* * Si.tersoff.mod Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff.mod Si Si Si Si Si Si Si Si
 Reading tersoff/mod potential file Si.tersoff.mod with DATE: 2013-07-26
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -153,32 +151,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.979 | 2.979 | 2.979 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -2210.6446            0   -2172.3685   -6444.2163 
-     110    1135.5853   -2234.6974            0   -2172.3908    113.80404 
-     120    1462.8415   -2253.8186            0   -2172.3853    10922.229 
-     130    1755.9617   -2270.5152            0   -2172.3964    18780.707 
-     140    1895.1939   -2277.1484            0   -2172.3965    22357.106 
-     150    1869.5375   -2273.2734            0   -2172.3851    22616.492 
-     160    1824.0448   -2268.4342            0    -2172.393    19254.299 
-     170    1637.9038   -2254.5219            0   -2172.3815    15904.928 
-     180    1451.9871   -2240.7199            0   -2172.3771    12064.754 
-     190    1362.8248   -2233.1942            0   -2172.3789     7970.534 
-     200    1341.1467   -2229.8951            0   -2172.3717    6244.8542 
-Loop time of 0.128972 on 1 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -2210.6446   -2161.5897   -2172.3685   -6444.2163 
+     110    1135.5853   -2234.6974   -2159.6898   -2172.3908    113.80404 
+     120    1462.8415   -2253.8186   -2157.1951   -2172.3853    10922.229 
+     130    1755.9617   -2270.5152   -2154.5306   -2172.3964    18780.707 
+     140    1895.1939   -2277.1484   -2151.9672   -2172.3965    22357.106 
+     150    1869.5375   -2273.2734   -2149.7868   -2172.3851    22616.492 
+     160    1824.0448   -2268.4342   -2147.9525    -2172.393    19254.299 
+     170    1637.9038   -2254.5219   -2146.3352   -2172.3815    15904.928 
+     180    1451.9871   -2240.7199   -2144.8134   -2172.3771    12064.754 
+     190    1362.8248   -2233.1942    -2143.177   -2172.3789     7970.534 
+     200    1341.1467   -2229.8951   -2141.3097   -2172.3717    6244.8542 
+Loop time of 0.428851 on 1 procs for 100 steps with 512 atoms
 
-Performance: 66.991 ns/day, 0.358 hours/ns, 775.362 timesteps/s
-98.6% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 20.147 ns/day, 1.191 hours/ns, 233.181 timesteps/s
+99.9% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.12498    | 0.12498    | 0.12498    |   0.0 | 96.91
-Neigh   | 0.002322   | 0.002322   | 0.002322   |   0.0 |  1.80
-Comm    | 0.000537   | 0.000537   | 0.000537   |   0.0 |  0.42
-Output  | 0.000177   | 0.000177   | 0.000177   |   0.0 |  0.14
-Modify  | 0.000761   | 0.000761   | 0.000761   |   0.0 |  0.59
-Other   |            | 0.000192   |            |       |  0.15
+Pair    | 0.41656    | 0.41656    | 0.41656    |   0.0 | 97.13
+Neigh   | 0.0043387  | 0.0043387  | 0.0043387  |   0.0 |  1.01
+Comm    | 0.0025339  | 0.0025339  | 0.0025339  |   0.0 |  0.59
+Output  | 0.00019503 | 0.00019503 | 0.00019503 |   0.0 |  0.05
+Modify  | 0.0047224  | 0.0047224  | 0.0047224  |   0.0 |  1.10
+Other   |            | 0.0004995  |            |       |  0.12
 
 Nlocal:        512.000 ave         512 max         512 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
@@ -197,9 +195,8 @@ Dangerous builds = 0
 # Test Tersoff/Mod/C model for Si
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -210,16 +207,16 @@ Reading restart file ...
   read_restart CPU = 0.001 seconds
 newton on on
 pair_style      tersoff/mod/c
-pair_coeff 	* * Si.tersoff.modc Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff.modc Si Si Si Si Si Si Si Si
 Reading tersoff/mod/c potential file Si.tersoff.modc with DATE: 2016-11-09
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -238,32 +235,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.976 | 2.976 | 2.976 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -2221.9308            0   -2183.6547   -11721.269 
-     110     1106.895   -2244.1196            0   -2183.6843   -2359.7819 
-     120    1327.6674   -2256.3155            0   -2183.6767    7904.6604 
-     130    1487.0219   -2264.3656            0   -2183.6707    14660.783 
-     140    1709.1746   -2276.4761            0   -2183.6886    19298.791 
-     150    1710.6528   -2274.1129            0   -2183.6764    22026.559 
-     160    1651.0659   -2267.9877            0   -2183.6699    20916.722 
-     170    1632.7705   -2264.7081            0   -2183.6777    17339.031 
-     180     1477.693   -2252.4683            0   -2183.6706    12563.594 
-     190    1310.8768   -2239.5419            0   -2183.6581    9591.0484 
-     200    1356.7172   -2240.5315            0    -2183.668    5584.6734 
-Loop time of 0.133106 on 1 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -2221.9308   -2172.8759   -2183.6547   -11721.269 
+     110     1106.895   -2244.1196    -2171.007   -2183.6843   -2359.7819 
+     120    1327.6674   -2256.3155   -2168.6205   -2183.6767    7904.6604 
+     130    1487.0219   -2264.3656   -2166.1449   -2183.6707    14660.783 
+     140    1709.1746   -2276.4761   -2163.5818   -2183.6886    19298.791 
+     150    1710.6528   -2274.1129   -2161.1209   -2183.6764    22026.559 
+     160    1651.0659   -2267.9877   -2158.9316   -2183.6699    20916.722 
+     170    1632.7705   -2264.7081   -2156.8605   -2183.6777    17339.031 
+     180     1477.693   -2252.4683   -2154.8638   -2183.6706    12563.594 
+     190    1310.8768   -2239.5419   -2152.9559   -2183.6581    9591.0484 
+     200    1356.7172   -2240.5315   -2150.9177    -2183.668    5584.6734 
+Loop time of 0.444872 on 1 procs for 100 steps with 512 atoms
 
-Performance: 64.911 ns/day, 0.370 hours/ns, 751.281 timesteps/s
-96.0% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 19.421 ns/day, 1.236 hours/ns, 224.784 timesteps/s
+99.9% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.1291     | 0.1291     | 0.1291     |   0.0 | 96.99
-Neigh   | 0.002343   | 0.002343   | 0.002343   |   0.0 |  1.76
-Comm    | 0.0005     | 0.0005     | 0.0005     |   0.0 |  0.38
-Output  | 0.000186   | 0.000186   | 0.000186   |   0.0 |  0.14
-Modify  | 0.000786   | 0.000786   | 0.000786   |   0.0 |  0.59
-Other   |            | 0.000191   |            |       |  0.14
+Pair    | 0.43275    | 0.43275    | 0.43275    |   0.0 | 97.28
+Neigh   | 0.0042851  | 0.0042851  | 0.0042851  |   0.0 |  0.96
+Comm    | 0.0024009  | 0.0024009  | 0.0024009  |   0.0 |  0.54
+Output  | 0.00019312 | 0.00019312 | 0.00019312 |   0.0 |  0.04
+Modify  | 0.0047414  | 0.0047414  | 0.0047414  |   0.0 |  1.07
+Other   |            | 0.0004966  |            |       |  0.11
 
 Nlocal:        512.000 ave         512 max         512 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
@@ -282,9 +279,8 @@ Dangerous builds = 0
 # Test Tersoff model for B/N/C
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -294,27 +290,27 @@ Reading restart file ...
   512 atoms
   read_restart CPU = 0.001 seconds
 
-variable	fac equal 0.6
-change_box 	all x scale ${fac} y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale 0.6 remap
+variable        fac equal 0.6
+change_box      all x scale ${fac} y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale 0.6 remap
 Changing box ...
   orthogonal box = (4.3448000 0.0000000 0.0000000) to (17.379200 21.724000 21.724000)
   orthogonal box = (4.3448000 4.3448000 0.0000000) to (17.379200 17.379200 21.724000)
   orthogonal box = (4.3448000 4.3448000 4.3448000) to (17.379200 17.379200 17.379200)
 
 pair_style      tersoff
-pair_coeff 	* * BNC.tersoff N N N C B B C B
+pair_coeff      * * BNC.tersoff N N N C B B C B
 Reading tersoff potential file BNC.tersoff with DATE: 2013-03-21
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -333,32 +329,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.985 | 2.985 | 2.985 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -2973.8527            0   -2935.5766    3438975.9 
-     110    4061.1085   -3183.2489            0   -2930.1208    2211712.7 
-     120    4120.3231   -3187.0108            0   -2928.3047    2166764.3 
-     130    3602.7602   -3158.5939            0   -2926.6167    2244475.7 
-     140    3222.7773   -3141.7275            0   -2925.5369      2161607 
-     150    3487.4703   -3163.7495            0   -2921.2462    2222150.2 
-     160    3436.3009   -3169.4234            0   -2920.8775    2144368.7 
-     170    3308.1796   -3170.3773            0   -2920.8967    2223612.9 
-     180    3304.3776   -3178.7805            0    -2920.102    2072546.6 
-     190    3217.3561   -3180.7963            0   -2918.4548    2118776.2 
-     200    3041.6832   -3176.1794            0   -2916.5787    2130124.6 
-Loop time of 0.134621 on 1 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -2973.8527   -2924.7978   -2935.5766    3438975.9 
+     110    4061.1085   -3183.2489   -2915.0049   -2930.1208    2211712.7 
+     120    4120.3231   -3187.0108   -2914.8555   -2928.3047    2166764.3 
+     130    3602.7602   -3158.5939   -2920.6246   -2926.6167    2244475.7 
+     140    3222.7773   -3141.7275   -2928.8568   -2925.5369      2161607 
+     150    3487.4703   -3163.7495   -2933.3954   -2921.2462    2222150.2 
+     160    3436.3009   -3169.4234    -2942.449   -2920.8775    2144368.7 
+     170    3308.1796   -3170.3773   -2951.8656   -2920.8967    2223612.9 
+     180    3304.3776   -3178.7805     -2960.52    -2920.102    2072546.6 
+     190    3217.3561   -3180.7963   -2968.2837   -2918.4548    2118776.2 
+     200    3041.6832   -3176.1794   -2975.2703   -2916.5787    2130124.6 
+Loop time of 0.55964 on 1 procs for 100 steps with 512 atoms
 
-Performance: 64.180 ns/day, 0.374 hours/ns, 742.826 timesteps/s
-98.6% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 15.438 ns/day, 1.555 hours/ns, 178.686 timesteps/s
+99.9% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.12837    | 0.12837    | 0.12837    |   0.0 | 95.35
-Neigh   | 0.004553   | 0.004553   | 0.004553   |   0.0 |  3.38
-Comm    | 0.000601   | 0.000601   | 0.000601   |   0.0 |  0.45
-Output  | 0.000177   | 0.000177   | 0.000177   |   0.0 |  0.13
-Modify  | 0.000742   | 0.000742   | 0.000742   |   0.0 |  0.55
-Other   |            | 0.000181   |            |       |  0.13
+Pair    | 0.54187    | 0.54187    | 0.54187    |   0.0 | 96.83
+Neigh   | 0.0087171  | 0.0087171  | 0.0087171  |   0.0 |  1.56
+Comm    | 0.0036685  | 0.0036685  | 0.0036685  |   0.0 |  0.66
+Output  | 0.00019526 | 0.00019526 | 0.00019526 |   0.0 |  0.03
+Modify  | 0.0047348  | 0.0047348  | 0.0047348  |   0.0 |  0.85
+Other   |            | 0.0004504  |            |       |  0.08
 
 Nlocal:        512.000 ave         512 max         512 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
@@ -377,9 +373,8 @@ Dangerous builds = 0
 # Test Tersoff model for B/N/C
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -389,27 +384,27 @@ Reading restart file ...
   512 atoms
   read_restart CPU = 0.001 seconds
 
-variable	fac equal 0.6
-change_box 	all x scale ${fac} y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale 0.6 remap
+variable        fac equal 0.6
+change_box      all x scale ${fac} y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale 0.6 remap
 Changing box ...
   orthogonal box = (4.3448000 0.0000000 0.0000000) to (17.379200 21.724000 21.724000)
   orthogonal box = (4.3448000 4.3448000 0.0000000) to (17.379200 17.379200 21.724000)
   orthogonal box = (4.3448000 4.3448000 4.3448000) to (17.379200 17.379200 17.379200)
 
 pair_style      tersoff shift 0.05
-pair_coeff 	* * BNC.tersoff N N N C B B C B
+pair_coeff      * * BNC.tersoff N N N C B B C B
 Reading tersoff potential file BNC.tersoff with DATE: 2013-03-21
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -428,32 +423,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.985 | 2.985 | 2.985 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -3294.0266            0   -3255.7505    1615779.4 
-     110    2870.7114   -3432.8485            0    -3257.629    1053310.6 
-     120    2898.0798   -3431.4968            0   -3256.6851    1223402.3 
-     130    2708.4483   -3419.0142            0    -3256.436    1105893.8 
-     140    2307.8661   -3394.1268            0   -3256.1686    1148075.8 
-     150    2215.3423   -3390.1427            0   -3255.8733      1138540 
-     160     2515.488   -3412.6704            0   -3255.1731    1122902.8 
-     170    2485.7109   -3415.0402            0   -3255.3787    1097748.5 
-     180     2327.476   -3408.2463            0   -3254.6537    1061602.6 
-     190    2339.5966   -3413.3961            0   -3254.7496      1088059 
-     200    2260.5961    -3411.477            0   -3254.0771    1104581.5 
-Loop time of 0.120764 on 1 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -3294.0266   -3244.9717   -3255.7505    1615779.4 
+     110    2870.7114   -3432.8485   -3243.2324    -3257.629    1053310.6 
+     120    2898.0798   -3431.4968   -3240.0731   -3256.6851    1223402.3 
+     130    2708.4483   -3419.0142   -3240.1159    -3256.436    1105893.8 
+     140    2307.8661   -3394.1268   -3241.6877   -3256.1686    1148075.8 
+     150    2215.3423   -3390.1427   -3243.8151   -3255.8733      1138540 
+     160     2515.488   -3412.6704   -3246.5175   -3255.1731    1122902.8 
+     170    2485.7109   -3415.0402   -3250.8542   -3255.3787    1097748.5 
+     180     2327.476   -3408.2463    -3254.512   -3254.6537    1061602.6 
+     190    2339.5966   -3413.3961   -3258.8612   -3254.7496      1088059 
+     200    2260.5961    -3411.477   -3262.1603   -3254.0771    1104581.5 
+Loop time of 0.511812 on 1 procs for 100 steps with 512 atoms
 
-Performance: 71.545 ns/day, 0.335 hours/ns, 828.061 timesteps/s
-98.6% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 16.881 ns/day, 1.422 hours/ns, 195.384 timesteps/s
+99.9% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.11521    | 0.11521    | 0.11521    |   0.0 | 95.40
-Neigh   | 0.003874   | 0.003874   | 0.003874   |   0.0 |  3.21
-Comm    | 0.000542   | 0.000542   | 0.000542   |   0.0 |  0.45
-Output  | 0.000177   | 0.000177   | 0.000177   |   0.0 |  0.15
-Modify  | 0.000774   | 0.000774   | 0.000774   |   0.0 |  0.64
-Other   |            | 0.00019    |            |       |  0.16
+Pair    | 0.49628    | 0.49628    | 0.49628    |   0.0 | 96.96
+Neigh   | 0.0072167  | 0.0072167  | 0.0072167  |   0.0 |  1.41
+Comm    | 0.0029061  | 0.0029061  | 0.0029061  |   0.0 |  0.57
+Output  | 0.00019026 | 0.00019026 | 0.00019026 |   0.0 |  0.04
+Modify  | 0.0047674  | 0.0047674  | 0.0047674  |   0.0 |  0.93
+Other   |            | 0.0004566  |            |       |  0.09
 
 Nlocal:        512.000 ave         512 max         512 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
@@ -469,4 +464,4 @@ Ave neighs/atom = 28.664062
 Neighbor list builds = 5
 Dangerous builds = 0
 
-Total wall time: 0:00:00
+Total wall time: 0:00:02

--- a/examples/tersoff/log.09Feb21.tersoff.g++.4
+++ b/examples/tersoff/log.09Feb21.tersoff.g++.4
@@ -1,5 +1,4 @@
 LAMMPS (24 Dec 2020)
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
 # Simple regression tests for Tersoff potentials
 
@@ -10,7 +9,7 @@ units           metal
 atom_style      atomic
 atom_modify     map array
 boundary        p p p
-atom_modify	sort 0 0.0
+atom_modify     sort 0 0.0
 
 # temperature
 
@@ -28,26 +27,26 @@ region          myreg block     0 4                                 0 4         
 create_box      8 myreg
 Created orthogonal box = (0.0000000 0.0000000 0.0000000) to (21.724000 21.724000 21.724000)
   1 by 2 by 2 MPI processor grid
-create_atoms    1 region myreg 		basis 1 1  		basis 2 2  		basis 3 3  		basis 4 4  		basis 5 5  		basis 6 6  		basis 7 7  		basis 8 8
+create_atoms    1 region myreg                 basis 1 1                  basis 2 2                  basis 3 3                  basis 4 4                  basis 5 5                  basis 6 6                  basis 7 7                  basis 8 8
 Created 512 atoms
-  create_atoms CPU = 0.000 seconds
+  create_atoms CPU = 0.001 seconds
 
 mass            *       28.06
 
-velocity 	all create $t 5287287 loop geom
-velocity 	all create 1800 5287287 loop geom
+velocity        all create $t 5287287 loop geom
+velocity        all create 1800 5287287 loop geom
 
 # Equilibrate using Tersoff model for silicon
 
 pair_style      tersoff
-pair_coeff 	* * Si.tersoff Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff Si Si Si Si Si Si Si Si
 Reading tersoff potential file Si.tersoff with DATE: 2007-10-25
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -65,32 +64,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.958 | 2.958 | 2.958 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-       0         1800    -2370.771            0   -2251.8775    12511.419 
-      10    1144.7447   -2327.3227            0   -2251.7759    21852.599 
-      20    770.19243   -2302.1547            0   -2251.7633    22286.587 
-      30    1059.4324   -2320.1988            0   -2251.8159     6242.222 
-      40     1000.972   -2314.6531            0    -2251.796   -3069.9273 
-      50    803.91758   -2300.1702            0   -2251.7834   -7154.1383 
-      60    761.38639   -2296.1731            0   -2251.7928   -14520.921 
-      70    750.57677   -2294.3086            0   -2251.7965   -21400.198 
-      80    676.66672   -2288.2634            0   -2251.7899   -23480.201 
-      90    640.24103   -2284.6678            0   -2251.7848   -20659.983 
-     100    742.67188   -2290.0616            0   -2251.7855   -16211.799 
-Loop time of 0.0321762 on 4 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+       0         1800    -2370.771   -2251.8775   -2251.8775    12511.419 
+      10    1144.7447   -2327.3227   -2251.7101   -2251.7759    21852.599 
+      20    770.19243   -2302.1547    -2251.282   -2251.7633    22286.587 
+      30    1059.4324   -2320.1988   -2250.2213   -2251.8159     6242.222 
+      40     1000.972   -2314.6531   -2248.5369    -2251.796   -3069.9273 
+      50    803.91758   -2300.1702   -2247.0699   -2251.7834   -7154.1383 
+      60    761.38639   -2296.1731    -2245.882   -2251.7928   -14520.921 
+      70    750.57677   -2294.3086   -2244.7316   -2251.7965   -21400.198 
+      80    676.66672   -2288.2634   -2243.5683   -2251.7899   -23480.201 
+      90    640.24103   -2284.6678   -2242.3786   -2251.7848   -20659.983 
+     100    742.67188   -2290.0616   -2241.0067   -2251.7855   -16211.799 
+Loop time of 0.130429 on 4 procs for 100 steps with 512 atoms
 
-Performance: 268.521 ns/day, 0.089 hours/ns, 3107.882 timesteps/s
-98.4% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 66.243 ns/day, 0.362 hours/ns, 766.701 timesteps/s
+96.2% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.026599   | 0.02712    | 0.027602   |   0.2 | 84.28
-Neigh   | 0.000285   | 0.00028875 | 0.000294   |   0.0 |  0.90
-Comm    | 0.003471   | 0.0039375  | 0.004446   |   0.6 | 12.24
-Output  | 0.000112   | 0.00013675 | 0.000203   |   0.0 |  0.43
-Modify  | 0.000443   | 0.0004555  | 0.000471   |   0.0 |  1.42
-Other   |            | 0.000238   |            |       |  0.74
+Pair    | 0.10994    | 0.11386    | 0.11991    |   1.1 | 87.30
+Neigh   | 0.0005877  | 0.00059474 | 0.00059915 |   0.0 |  0.46
+Comm    | 0.0072911  | 0.013476   | 0.017439   |   3.4 | 10.33
+Output  | 0.00014305 | 0.00022113 | 0.00045156 |   0.0 |  0.17
+Modify  | 0.0015786  | 0.0016485  | 0.0017092  |   0.1 |  1.26
+Other   |            | 0.0006239  |            |       |  0.48
 
 Nlocal:        128.000 ave         131 max         126 min
 Histogram: 2 0 0 0 0 0 1 0 0 1
@@ -106,15 +105,14 @@ Ave neighs/atom = 16.414062
 Neighbor list builds = 2
 Dangerous builds = 0
 
-write_restart	restart.equil
+write_restart   restart.equil
 System init for write_restart ...
 
 # Test Tersoff/Mod model for Si
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -122,19 +120,19 @@ Reading restart file ...
   1 by 2 by 2 MPI processor grid
   pair style tersoff stores no restart info
   512 atoms
-  read_restart CPU = 0.002 seconds
+  read_restart CPU = 0.001 seconds
 
 pair_style      tersoff/mod
-pair_coeff 	* * Si.tersoff.mod Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff.mod Si Si Si Si Si Si Si Si
 Reading tersoff/mod potential file Si.tersoff.mod with DATE: 2013-07-26
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -153,32 +151,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.949 | 2.950 | 2.950 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -2210.6446            0   -2172.3685   -6444.2163 
-     110    1135.5853   -2234.6974            0   -2172.3908    113.80404 
-     120    1462.8415   -2253.8186            0   -2172.3853    10922.229 
-     130    1755.9617   -2270.5152            0   -2172.3964    18780.707 
-     140    1895.1939   -2277.1484            0   -2172.3965    22357.106 
-     150    1869.5375   -2273.2734            0   -2172.3851    22616.492 
-     160    1824.0448   -2268.4342            0    -2172.393    19254.299 
-     170    1637.9038   -2254.5219            0   -2172.3815    15904.928 
-     180    1451.9871   -2240.7199            0   -2172.3771    12064.754 
-     190    1362.8248   -2233.1942            0   -2172.3789     7970.534 
-     200    1341.1467   -2229.8951            0   -2172.3717    6244.8542 
-Loop time of 0.0389003 on 4 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -2210.6446   -2161.5897   -2172.3685   -6444.2163 
+     110    1135.5853   -2234.6974   -2159.6898   -2172.3908    113.80404 
+     120    1462.8415   -2253.8186   -2157.1951   -2172.3853    10922.229 
+     130    1755.9617   -2270.5152   -2154.5306   -2172.3964    18780.707 
+     140    1895.1939   -2277.1484   -2151.9672   -2172.3965    22357.106 
+     150    1869.5375   -2273.2734   -2149.7868   -2172.3851    22616.492 
+     160    1824.0448   -2268.4342   -2147.9525    -2172.393    19254.299 
+     170    1637.9038   -2254.5219   -2146.3352   -2172.3815    15904.928 
+     180    1451.9871   -2240.7199   -2144.8134   -2172.3771    12064.754 
+     190    1362.8248   -2233.1942    -2143.177   -2172.3789     7970.534 
+     200    1341.1467   -2229.8951   -2141.3097   -2172.3717    6244.8542 
+Loop time of 0.128801 on 4 procs for 100 steps with 512 atoms
 
-Performance: 222.107 ns/day, 0.108 hours/ns, 2570.678 timesteps/s
-98.6% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 67.080 ns/day, 0.358 hours/ns, 776.389 timesteps/s
+97.2% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.031362   | 0.032656   | 0.033605   |   0.5 | 83.95
-Neigh   | 0.000575   | 0.000599   | 0.000613   |   0.0 |  1.54
-Comm    | 0.003768   | 0.004733   | 0.006014   |   1.2 | 12.17
-Output  | 0.000207   | 0.00022525 | 0.000276   |   0.0 |  0.58
-Modify  | 0.000445   | 0.00047975 | 0.0005     |   0.0 |  1.23
-Other   |            | 0.0002077  |            |       |  0.53
+Pair    | 0.10866    | 0.11135    | 0.1163     |   0.9 | 86.45
+Neigh   | 0.0011961  | 0.001219   | 0.0012498  |   0.1 |  0.95
+Comm    | 0.0087612  | 0.013886   | 0.016597   |   2.6 | 10.78
+Output  | 0.00013447 | 0.00028586 | 0.000736   |   0.0 |  0.22
+Modify  | 0.0014391  | 0.0015088  | 0.0015388  |   0.1 |  1.17
+Other   |            | 0.0005538  |            |       |  0.43
 
 Nlocal:        128.000 ave         135 max         123 min
 Histogram: 1 1 0 0 0 1 0 0 0 1
@@ -197,9 +195,8 @@ Dangerous builds = 0
 # Test Tersoff/Mod/C model for Si
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -210,16 +207,16 @@ Reading restart file ...
   read_restart CPU = 0.001 seconds
 newton on on
 pair_style      tersoff/mod/c
-pair_coeff 	* * Si.tersoff.modc Si Si Si Si Si Si Si Si
+pair_coeff      * * Si.tersoff.modc Si Si Si Si Si Si Si Si
 Reading tersoff/mod/c potential file Si.tersoff.modc with DATE: 2016-11-09
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -238,32 +235,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.949 | 2.949 | 2.949 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -2221.9308            0   -2183.6547   -11721.269 
-     110     1106.895   -2244.1196            0   -2183.6843   -2359.7819 
-     120    1327.6674   -2256.3155            0   -2183.6767    7904.6604 
-     130    1487.0219   -2264.3656            0   -2183.6707    14660.783 
-     140    1709.1746   -2276.4761            0   -2183.6886    19298.791 
-     150    1710.6528   -2274.1129            0   -2183.6764    22026.559 
-     160    1651.0659   -2267.9877            0   -2183.6699    20916.722 
-     170    1632.7705   -2264.7081            0   -2183.6777    17339.031 
-     180     1477.693   -2252.4683            0   -2183.6706    12563.594 
-     190    1310.8768   -2239.5419            0   -2183.6581    9591.0484 
-     200    1356.7172   -2240.5315            0    -2183.668    5584.6734 
-Loop time of 0.039244 on 4 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -2221.9308   -2172.8759   -2183.6547   -11721.269 
+     110     1106.895   -2244.1196    -2171.007   -2183.6843   -2359.7819 
+     120    1327.6674   -2256.3155   -2168.6205   -2183.6767    7904.6604 
+     130    1487.0219   -2264.3656   -2166.1449   -2183.6707    14660.783 
+     140    1709.1746   -2276.4761   -2163.5818   -2183.6886    19298.791 
+     150    1710.6528   -2274.1129   -2161.1209   -2183.6764    22026.559 
+     160    1651.0659   -2267.9877   -2158.9316   -2183.6699    20916.722 
+     170    1632.7705   -2264.7081   -2156.8605   -2183.6777    17339.031 
+     180     1477.693   -2252.4683   -2154.8638   -2183.6706    12563.594 
+     190    1310.8768   -2239.5419   -2152.9559   -2183.6581    9591.0484 
+     200    1356.7172   -2240.5315   -2150.9177    -2183.668    5584.6734 
+Loop time of 0.131975 on 4 procs for 100 steps with 512 atoms
 
-Performance: 220.161 ns/day, 0.109 hours/ns, 2548.160 timesteps/s
-98.5% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 65.467 ns/day, 0.367 hours/ns, 757.717 timesteps/s
+97.2% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.03126    | 0.032782   | 0.033915   |   0.5 | 83.53
-Neigh   | 0.000599   | 0.000707   | 0.000821   |   0.0 |  1.80
-Comm    | 0.00363    | 0.004893   | 0.006493   |   1.5 | 12.47
-Output  | 0.000122   | 0.0001425  | 0.000192   |   0.0 |  0.36
-Modify  | 0.000497   | 0.00050925 | 0.000522   |   0.0 |  1.30
-Other   |            | 0.0002105  |            |       |  0.54
+Pair    | 0.11186    | 0.11507    | 0.11812    |   0.7 | 87.19
+Neigh   | 0.0011823  | 0.0011939  | 0.0012088  |   0.0 |  0.90
+Comm    | 0.010214   | 0.0134     | 0.016663   |   2.0 | 10.15
+Output  | 0.000139   | 0.000296   | 0.00076294 |   0.0 |  0.22
+Modify  | 0.0014501  | 0.0014552  | 0.0014606  |   0.0 |  1.10
+Other   |            | 0.0005632  |            |       |  0.43
 
 Nlocal:        128.000 ave         133 max         124 min
 Histogram: 1 0 1 0 0 1 0 0 0 1
@@ -282,9 +279,8 @@ Dangerous builds = 0
 # Test Tersoff model for B/N/C
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -292,29 +288,29 @@ Reading restart file ...
   1 by 2 by 2 MPI processor grid
   pair style tersoff stores no restart info
   512 atoms
-  read_restart CPU = 0.001 seconds
+  read_restart CPU = 0.007 seconds
 
-variable	fac equal 0.6
-change_box 	all x scale ${fac} y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale 0.6 remap
+variable        fac equal 0.6
+change_box      all x scale ${fac} y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale 0.6 remap
 Changing box ...
   orthogonal box = (4.3448000 0.0000000 0.0000000) to (17.379200 21.724000 21.724000)
   orthogonal box = (4.3448000 4.3448000 0.0000000) to (17.379200 17.379200 21.724000)
   orthogonal box = (4.3448000 4.3448000 4.3448000) to (17.379200 17.379200 17.379200)
 
 pair_style      tersoff
-pair_coeff 	* * BNC.tersoff N N N C B B C B
+pair_coeff      * * BNC.tersoff N N N C B B C B
 Reading tersoff potential file BNC.tersoff with DATE: 2013-03-21
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -333,32 +329,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.952 | 2.952 | 2.952 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -2973.8527            0   -2935.5766    3438975.9 
-     110    4061.1085   -3183.2489            0   -2930.1208    2211712.7 
-     120    4120.3231   -3187.0108            0   -2928.3047    2166764.3 
-     130    3602.7602   -3158.5939            0   -2926.6167    2244475.7 
-     140    3222.7773   -3141.7275            0   -2925.5369      2161607 
-     150    3487.4703   -3163.7495            0   -2921.2462    2222150.2 
-     160    3436.3009   -3169.4234            0   -2920.8775    2144368.7 
-     170    3308.1796   -3170.3773            0   -2920.8967    2223612.9 
-     180    3304.3776   -3178.7805            0    -2920.102    2072546.6 
-     190    3217.3561   -3180.7963            0   -2918.4548    2118776.2 
-     200    3041.6832   -3176.1794            0   -2916.5787    2130124.6 
-Loop time of 0.0488862 on 4 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -2973.8527   -2924.7978   -2935.5766    3438975.9 
+     110    4061.1085   -3183.2489   -2915.0049   -2930.1208    2211712.7 
+     120    4120.3231   -3187.0108   -2914.8555   -2928.3047    2166764.3 
+     130    3602.7602   -3158.5939   -2920.6246   -2926.6167    2244475.7 
+     140    3222.7773   -3141.7275   -2928.8568   -2925.5369      2161607 
+     150    3487.4703   -3163.7495   -2933.3954   -2921.2462    2222150.2 
+     160    3436.3009   -3169.4234    -2942.449   -2920.8775    2144368.7 
+     170    3308.1796   -3170.3773   -2951.8656   -2920.8967    2223612.9 
+     180    3304.3776   -3178.7805     -2960.52    -2920.102    2072546.6 
+     190    3217.3561   -3180.7963   -2968.2837   -2918.4548    2118776.2 
+     200    3041.6832   -3176.1794   -2975.2703   -2916.5787    2130124.6 
+Loop time of 0.171186 on 4 procs for 100 steps with 512 atoms
 
-Performance: 176.737 ns/day, 0.136 hours/ns, 2045.565 timesteps/s
-93.6% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 50.471 ns/day, 0.476 hours/ns, 584.160 timesteps/s
+96.4% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.037364   | 0.039346   | 0.041066   |   0.8 | 80.49
-Neigh   | 0.001207   | 0.0012568  | 0.00136    |   0.2 |  2.57
-Comm    | 0.005218   | 0.007064   | 0.009117   |   1.9 | 14.45
-Output  | 0.000173   | 0.00020325 | 0.000277   |   0.0 |  0.42
-Modify  | 0.000709   | 0.000715   | 0.000723   |   0.0 |  1.46
-Other   |            | 0.0003008  |            |       |  0.62
+Pair    | 0.14009    | 0.14402    | 0.15181    |   1.2 | 84.13
+Neigh   | 0.0023134  | 0.0024782  | 0.0026977  |   0.3 |  1.45
+Comm    | 0.013972   | 0.02211    | 0.026362   |   3.3 | 12.92
+Output  | 0.00015235 | 0.0003258  | 0.00084186 |   0.0 |  0.19
+Modify  | 0.0016432  | 0.0017257  | 0.0018435  |   0.2 |  1.01
+Other   |            | 0.0005236  |            |       |  0.31
 
 Nlocal:        128.000 ave         132 max         123 min
 Histogram: 1 0 0 0 1 0 0 1 0 1
@@ -377,9 +373,8 @@ Dangerous builds = 0
 # Test Tersoff model for B/N/C
 
 clear
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:94)
   using 1 OpenMP thread(s) per MPI task
-read_restart	restart.equil
+read_restart    restart.equil
 Reading restart file ...
   restart file = 24 Dec 2020, LAMMPS = 24 Dec 2020
   restoring atom style atomic from restart
@@ -389,27 +384,27 @@ Reading restart file ...
   512 atoms
   read_restart CPU = 0.001 seconds
 
-variable	fac equal 0.6
-change_box 	all x scale ${fac} y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale ${fac} z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale ${fac} remap
-change_box 	all x scale 0.6 y scale 0.6 z scale 0.6 remap
+variable        fac equal 0.6
+change_box      all x scale ${fac} y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale ${fac} z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale ${fac} remap
+change_box      all x scale 0.6 y scale 0.6 z scale 0.6 remap
 Changing box ...
   orthogonal box = (4.3448000 0.0000000 0.0000000) to (17.379200 21.724000 21.724000)
   orthogonal box = (4.3448000 4.3448000 0.0000000) to (17.379200 17.379200 21.724000)
   orthogonal box = (4.3448000 4.3448000 4.3448000) to (17.379200 17.379200 17.379200)
 
 pair_style      tersoff shift 0.05
-pair_coeff 	* * BNC.tersoff N N N C B B C B
+pair_coeff      * * BNC.tersoff N N N C B B C B
 Reading tersoff potential file BNC.tersoff with DATE: 2013-03-21
 
+thermo_style    custom step temp epair etotal econserve press
 thermo          10
 fix             1 all nvt temp $t $t 0.1
 fix             1 all nvt temp 1800 $t 0.1
 fix             1 all nvt temp 1800 1800 0.1
 Resetting global fix info from restart file:
   fix style: nvt, fix ID: 1
-fix_modify 	1 energy yes
 timestep        1.0e-3
 neighbor        1.0 bin
 neigh_modify    every 1 delay 10 check yes
@@ -428,32 +423,32 @@ Neighbor list info ...
       stencil: full/bin/3d
       bin: standard
 Per MPI rank memory allocation (min/avg/max) = 2.952 | 2.952 | 2.952 Mbytes
-Step Temp E_pair E_mol TotEng Press 
-     100    742.67188   -3294.0266            0   -3255.7505    1615779.4 
-     110    2870.7114   -3432.8485            0    -3257.629    1053310.6 
-     120    2898.0798   -3431.4968            0   -3256.6851    1223402.3 
-     130    2708.4483   -3419.0142            0    -3256.436    1105893.8 
-     140    2307.8661   -3394.1268            0   -3256.1686    1148075.8 
-     150    2215.3423   -3390.1427            0   -3255.8733      1138540 
-     160     2515.488   -3412.6704            0   -3255.1731    1122902.8 
-     170    2485.7109   -3415.0402            0   -3255.3787    1097748.5 
-     180     2327.476   -3408.2463            0   -3254.6537    1061602.6 
-     190    2339.5966   -3413.3961            0   -3254.7496      1088059 
-     200    2260.5961    -3411.477            0   -3254.0771    1104581.5 
-Loop time of 0.0409132 on 4 procs for 100 steps with 512 atoms
+Step Temp E_pair TotEng Econserve Press 
+     100    742.67188   -3294.0266   -3244.9717   -3255.7505    1615779.4 
+     110    2870.7114   -3432.8485   -3243.2324    -3257.629    1053310.6 
+     120    2898.0798   -3431.4968   -3240.0731   -3256.6851    1223402.3 
+     130    2708.4483   -3419.0142   -3240.1159    -3256.436    1105893.8 
+     140    2307.8661   -3394.1268   -3241.6877   -3256.1686    1148075.8 
+     150    2215.3423   -3390.1427   -3243.8151   -3255.8733      1138540 
+     160     2515.488   -3412.6704   -3246.5175   -3255.1731    1122902.8 
+     170    2485.7109   -3415.0402   -3250.8542   -3255.3787    1097748.5 
+     180     2327.476   -3408.2463    -3254.512   -3254.6537    1061602.6 
+     190    2339.5966   -3413.3961   -3258.8612   -3254.7496      1088059 
+     200    2260.5961    -3411.477   -3262.1603   -3254.0771    1104581.5 
+Loop time of 0.15156 on 4 procs for 100 steps with 512 atoms
 
-Performance: 211.179 ns/day, 0.114 hours/ns, 2444.196 timesteps/s
-97.1% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 57.007 ns/day, 0.421 hours/ns, 659.806 timesteps/s
+96.9% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.03285    | 0.033327   | 0.03406    |   0.3 | 81.46
-Neigh   | 0.000975   | 0.0010677  | 0.001184   |   0.2 |  2.61
-Comm    | 0.004915   | 0.005528   | 0.006044   |   0.7 | 13.51
-Output  | 0.000129   | 0.0001535  | 0.000226   |   0.0 |  0.38
-Modify  | 0.000564   | 0.0005885  | 0.000604   |   0.0 |  1.44
-Other   |            | 0.0002483  |            |       |  0.61
+Pair    | 0.12637    | 0.13067    | 0.13398    |   0.8 | 86.22
+Neigh   | 0.0019262  | 0.0020029  | 0.0021148  |   0.2 |  1.32
+Comm    | 0.012843   | 0.01629    | 0.020752   |   2.2 | 10.75
+Output  | 0.00014877 | 0.00030798 | 0.00078011 |   0.0 |  0.20
+Modify  | 0.0015197  | 0.0016043  | 0.0017824  |   0.3 |  1.06
+Other   |            | 0.0006804  |            |       |  0.45
 
 Nlocal:        128.000 ave         133 max         123 min
 Histogram: 1 0 0 1 0 0 0 1 0 1

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -654,7 +654,6 @@ void MSM::allocate()
       npergrid = 1;
       memory->create(gc_buf1[n],npergrid*ngc_buf1[n],"msm:gc_buf1");
       memory->create(gc_buf2[n],npergrid*ngc_buf2[n],"msm:gc_buf2");
-
     } else {
       delete gc[n];
       memory->destroy(gc_buf1[n]);
@@ -808,6 +807,10 @@ void MSM::allocate_levels()
 
   for (int n=0; n<levels; n++) {
     gc[n] = nullptr;
+
+    gc_buf1[n] = nullptr;
+    gc_buf2[n] = nullptr;
+
     world_levels[n] = MPI_COMM_NULL;
 
     qgrid[n] = nullptr;

--- a/src/SPIN/pair_spin_dipole_cut.cpp
+++ b/src/SPIN/pair_spin_dipole_cut.cpp
@@ -167,9 +167,8 @@ void PairSpinDipoleCut::compute(int eflag, int vflag)
   double rinv,r2inv,r3inv,rsq,local_cut2,evdwl,ecoul;
   double xi[3],rij[3],eij[3],spi[4],spj[4],fi[3],fmi[3];
 
+  ev_init(eflag,vflag);
   evdwl = ecoul = 0.0;
-  if (eflag || vflag) ev_setup(eflag,vflag);
-  else evflag = vflag_fdotr = 0;
 
   int *type = atom->type;
   int nlocal = atom->nlocal;

--- a/src/USER-MISC/pair_cosine_squared.cpp
+++ b/src/USER-MISC/pair_cosine_squared.cpp
@@ -344,11 +344,8 @@ void PairCosineSquared::compute(int eflag, int vflag)
   double r, rsq, r2inv, r6inv;
   double factor_lj, force_lj, force_cos, cosone;
 
+  ev_init(eflag, vflag);
   evdwl = 0.0;
-  if (eflag || vflag)
-    ev_setup(eflag, vflag);
-  else
-    evflag = vflag_fdotr = 0;
 
   double **x = atom->x;
   double **f = atom->f;

--- a/src/USER-MISC/pair_coul_slater_cut.cpp
+++ b/src/USER-MISC/pair_coul_slater_cut.cpp
@@ -40,9 +40,8 @@ void PairCoulSlaterCut::compute(int eflag, int vflag)
   double rsq,r2inv,r,rinv,forcecoul,factor_coul,bracket_term;
   int *ilist,*jlist,*numneigh,**firstneigh;
 
+  ev_init(eflag,vflag);
   ecoul = 0.0;
-  if (eflag || vflag) ev_setup(eflag,vflag);
-  else evflag = vflag_fdotr = 0;
 
   double **x = atom->x;
   double **f = atom->f;

--- a/src/USER-MISC/pair_coul_slater_long.cpp
+++ b/src/USER-MISC/pair_coul_slater_long.cpp
@@ -59,7 +59,6 @@ PairCoulSlaterLong::~PairCoulSlaterLong()
 
       memory->destroy(scale);
     }
-    //if (ftable) free_tables();
   }
 }
 
@@ -69,17 +68,14 @@ void PairCoulSlaterLong::compute(int eflag, int vflag)
 {
   int i,j,ii,jj,inum,jnum,itype,jtype;
   double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
-//  double fraction,table;
   double r,r2inv,forcecoul,factor_coul;
   double grij,expm2,prefactor,t,erfc;
   int *ilist,*jlist,*numneigh,**firstneigh;
   double rsq;
   double slater_term;
-//  int itable;
 
+  ev_init(eflag,vflag);
   ecoul = 0.0;
-  if (eflag || vflag) ev_setup(eflag,vflag);
-  else evflag = vflag_fdotr = 0;
 
   double **x = atom->x;
   double **f = atom->f;

--- a/src/USER-MISC/pair_e3b.cpp
+++ b/src/USER-MISC/pair_e3b.cpp
@@ -97,13 +97,12 @@ void PairE3B::compute(int eflag, int vflag)
   if (natoms != atom->natoms)
     error->all(FLERR,"pair E3B requires a fixed number of atoms");
 
+  ev_init(eflag,vflag);
   //clear sumExp array
   memset(sumExp,0.0,nbytes);
 
   evdwl = 0.0;
   pvector[0]=pvector[1]=pvector[2]=pvector[3]=0.0;
-  if (eflag || vflag) ev_setup(eflag,vflag);
-  else evflag = vflag_fdotr = 0;
 
   double **x = atom->x;
   double **f = atom->f;

--- a/src/USER-MISC/pair_local_density.cpp
+++ b/src/USER-MISC/pair_local_density.cpp
@@ -139,10 +139,8 @@ void PairLocalDensity::compute(int eflag, int vflag)
   double p, *coeff;
   int *ilist,*jlist,*numneigh,**firstneigh;
 
+  ev_init(eflag,vflag);
   phi = uLD = evdwl = fpair = rsqinv = 0.0;
-
-  if (eflag || vflag) ev_setup(eflag,vflag);
-  else evflag = vflag_fdotr = eflag_global = eflag_atom = 0;
 
   /* localrho = LD at each atom
      fp = derivative of embedding energy at each atom for each LD potential

--- a/src/USER-MISC/pair_wf_cut.cpp
+++ b/src/USER-MISC/pair_wf_cut.cpp
@@ -70,9 +70,8 @@ void PairWFCut::compute(int eflag, int vflag)
   double forcenm,rminv, rm, rn;
   int *ilist,*jlist,*numneigh,**firstneigh;
 
+  ev_init(eflag,vflag);
   evdwl = 0.0;
-  if (eflag || vflag) ev_setup(eflag,vflag);
-  else evflag = vflag_fdotr = 0;
 
   double **x = atom->x;
   double **f = atom->f;

--- a/src/USER-OMP/pair_buck_long_coul_long_omp.cpp
+++ b/src/USER-OMP/pair_buck_long_coul_long_omp.cpp
@@ -367,9 +367,7 @@ void PairBuckLongCoulLongOMP::compute_middle()
 
 void PairBuckLongCoulLongOMP::compute_outer(int eflag, int vflag)
 {
-  if (eflag || vflag) {
-    ev_setup(eflag,vflag);
-  } else evflag = vflag_fdotr = 0;
+  ev_init(eflag,vflag);
   const int order1 = ewald_order&(1<<1);
   const int order6 = ewald_order&(1<<6);
 

--- a/src/USER-OMP/pair_lj_long_coul_long_omp.cpp
+++ b/src/USER-OMP/pair_lj_long_coul_long_omp.cpp
@@ -366,9 +366,7 @@ void PairLJLongCoulLongOMP::compute_middle()
 
 void PairLJLongCoulLongOMP::compute_outer(int eflag, int vflag)
 {
-  if (eflag || vflag) {
-    ev_setup(eflag,vflag);
-  } else evflag = vflag_fdotr = 0;
+  ev_init(eflag,vflag);
   const int order1 = ewald_order&(1<<1);
   const int order6 = ewald_order&(1<<6);
 

--- a/src/USER-OMP/pair_lj_long_tip4p_long_omp.cpp
+++ b/src/USER-OMP/pair_lj_long_tip4p_long_omp.cpp
@@ -425,9 +425,7 @@ void PairLJLongTIP4PLongOMP::compute_middle()
 
 void PairLJLongTIP4PLongOMP::compute_outer(int eflag, int vflag)
 {
-  if (eflag || vflag) {
-    ev_setup(eflag,vflag);
-  } else evflag = vflag_fdotr = 0;
+  ev_init(eflag,vflag);
   const int order1 = ewald_order&(1<<1);
   const int order6 = ewald_order&(1<<6);
 


### PR DESCRIPTION
**Summary**

This PR correct a few inconsistencies due to recent changes in the core of LAMMPS.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following changes are include:
- consistently use `ev_init()` instead of `ev_setup()` plus explicit variable initialization in pair styles
- update input examples and log files where `fix_modify energy yes` has been replaced with using the "econserve" thermo keyword.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
