### PR TITLE
Bond/react performance improvement

### DIFF
--- a/src/USER-REACTION/fix_bond_react.cpp
+++ b/src/USER-REACTION/fix_bond_react.cpp
@@ -1402,10 +1402,7 @@ void FixBondReact::superimpose_algorithm()
   MPI_Bcast(&reaction_count_total[0], nreacts, MPI_INT, 0, world);
   MPI_Bcast(&rxnflag, 1, MPI_INT, 0, world);
 
-  if (!rxnflag) {
-    unlimit_bond();
-    return;
-  }
+  if (!rxnflag) return;
 
   // check if we overstepped our reaction limit
   for (int i = 0; i < nreacts; i++) {


### PR DESCRIPTION
**Summary**

reduce unnecessary calls for reneighboring. significantly faster run times for low-reaction-frequency reactive systems
results in ~1.7x speedup when reactions are infrequent (tested on 200K atoms, 20 procs)

**Related Issue(s)**

none

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


