### PR TITLE
Use a 64-bit hash in the CiteMe class to identify unique citations

### DIFF
--- a/src/citeme.cpp
+++ b/src/citeme.cpp
@@ -77,7 +77,7 @@ void CiteMe::add(const std::string &reference)
 {
   if (comm->me != 0) return;
 
-  unsigned int crc = get_hash(reference);
+  std::size_t crc = get_hash(reference);
   if (cs->find(crc) != cs->end()) return;
   cs->insert(crc);
 

--- a/src/citeme.cpp
+++ b/src/citeme.cpp
@@ -15,7 +15,7 @@
 #include "comm.h"
 #include "universe.h"
 
-#include <cstdint>
+#include <functional>
 
 using namespace LAMMPS_NS;
 
@@ -28,23 +28,8 @@ static const char cite_nagline[] =
 static const char cite_file[] = "The {} {} lists these citations in "
                                 "BibTeX format.\n\n";
 
-// for crc32 checksums
-static uint32_t crc32_table[0x100];
-static uint32_t crc32_for_byte(uint32_t r)
-{
-  for(int j = 0; j < 8; ++j)
-    r = (r & 1? 0: (uint32_t)0xEDB88320L) ^ r >> 1;
-  return r ^ (uint32_t)0xFF000000L;
-}
-
-// compute crc32 for string
-static unsigned int get_crc32(const std::string &text)
-{
-  uint32_t crc = 0;
-  for (auto c : text)
-    crc = crc32_table[(uint8_t)crc ^ (uint8_t)c] ^ crc >> 8;
-  return crc;
-}
+// define hash function
+static std::hash<std::string> get_hash;
 
 /* ---------------------------------------------------------------------- */
 
@@ -53,10 +38,6 @@ CiteMe::CiteMe(LAMMPS *lmp, int _screen, int _logfile, const char *_file)
 {
   fp = nullptr;
   cs = new citeset();
-
-  // fill crc32 table
-  for(size_t i = 0; i < 0x100; ++i)
-    crc32_table[i] = crc32_for_byte(i);
 
   screen_flag = _screen;
   scrbuffer.clear();
@@ -96,7 +77,7 @@ void CiteMe::add(const std::string &reference)
 {
   if (comm->me != 0) return;
 
-  unsigned int crc = get_crc32(reference);
+  unsigned int crc = get_hash(reference);
   if (cs->find(crc) != cs->end()) return;
   cs->insert(crc);
 

--- a/src/citeme.h
+++ b/src/citeme.h
@@ -34,7 +34,7 @@ class CiteMe : protected Pointers {
   int logfile_flag;            // determine whether verbose or terse output
   std::string scrbuffer;       // output buffer for screen
   std::string logbuffer;       // output buffer for logfile
-  typedef std::set<unsigned int> citeset;
+  typedef std::set<std::size_t> citeset;
   citeset *cs;                 // registered set of publications
 };
 }

--- a/src/citeme.h
+++ b/src/citeme.h
@@ -23,8 +23,8 @@ class CiteMe : protected Pointers {
  public:
   CiteMe(class LAMMPS *, int, int, const char *);
   virtual ~CiteMe();
-  void add(const char *);       // register publication for output
-  void flush();                 // flush buffers to screen and logfile
+  void add(const std::string &); // register publication for output
+  void flush();                  // flush buffers to screen and logfile
   enum {VERBOSE, TERSE};
 
  private:
@@ -34,7 +34,7 @@ class CiteMe : protected Pointers {
   int logfile_flag;            // determine whether verbose or terse output
   std::string scrbuffer;       // output buffer for screen
   std::string logbuffer;       // output buffer for logfile
-  typedef std::set<const char *> citeset;
+  typedef std::set<unsigned int> citeset;
   citeset *cs;                 // registered set of publications
 };
 }


### PR DESCRIPTION
**Summary**

The CiteMe class was using a set from the used char pointer addresses to determine whether a citation had been added before and thus not output it a second time. That however will break if we have citation strings that are not compiled in constants, but are generated on the fly and then may be using recycled pointers from reused allocated memory.

This pull request changes the procedure to now compute a 64-bit hash via `std::hash` and store that hash instead.

As a bonus we can use a `const std::string &` argument to `CiteMe::add()` now.

This also adds a simple unit test to confirm the intended behavior.

**Related Issue(s)**

Needed for PR #2625 to work properly.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This is internal to the CiteMe class and thus no compatibility issues expected.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
