### PR TITLE
Add new utils::strfind() function and update mini-regex code

### DIFF
--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -104,6 +104,9 @@ and parsing files or arguments.
 .. doxygenfunction:: strmatch
    :project: progguide
 
+.. doxygenfunction:: strfind
+   :project: progguide
+
 .. doxygenfunction:: is_integer
    :project: progguide
 

--- a/doc/src/Packages_details.rst
+++ b/doc/src/Packages_details.rst
@@ -367,7 +367,7 @@ KIM package
 
 **Contents:**
 
-This package contains a command with a set of subcommands that serve as a
+This package contains a command with a set of sub-commands that serve as a
 wrapper on the
 `Open Knowledgebase of Interatomic Models (OpenKIM) <https://openkim.org>`_
 repository of interatomic models (IMs) enabling compatible ones to be used in

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -2367,6 +2367,7 @@ parmin
 Parrinello
 Partay
 Particuology
+Pascuet
 pastewka
 Pastewka
 pathangle

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -110,7 +110,7 @@ bool utils::strmatch(const std::string &text, const std::string &pattern)
 
 /** This function is a companion function to utils::strmatch(). Arguments
  *  and logic is the same, but instead of a boolean, it returns the
- *  substring that matches the regex pattern.  There can be only one match.
+ *  sub-string that matches the regex pattern.  There can be only one match.
  *  This can be used as a more flexible alternative to strstr().
  */
 std::string utils::strfind(const std::string &text, const std::string &pattern)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -108,6 +108,21 @@ bool utils::strmatch(const std::string &text, const std::string &pattern)
   return (pos >= 0);
 }
 
+/** This function is a companion function to utils::strmatch(). Arguments
+ *  and logic is the same, but instead of a boolean, it returns the
+ *  substring that matches the regex pattern.  There can be only one match.
+ *  This can be used as a more flexible alternative to strstr().
+ */
+std::string utils::strfind(const std::string &text, const std::string &pattern)
+{
+  int matchlen;
+  const int pos = re_find(text.c_str(),pattern.c_str(),&matchlen);
+  if ((pos >=0) && (matchlen > 0))
+    return text.substr(pos,matchlen);
+  else
+    return "";
+}
+
 /** This function simplifies the repetitive task of outputting some
  * message to both the screen and/or the log file. In combination
  * with using fmt::format(), which returns the formatted text

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,7 +37,7 @@ namespace LAMMPS_NS {
 
     bool strmatch(const std::string &text, const std::string &pattern);
 
-    /** Find substring that matches a simplified regex pattern
+    /** Find sub-string that matches a simplified regex pattern
      *
      *  \param text the text to be matched against the pattern
      *  \param pattern the search pattern, which may contain regexp markers

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,6 +37,14 @@ namespace LAMMPS_NS {
 
     bool strmatch(const std::string &text, const std::string &pattern);
 
+    /** Find substring that matches a simplified regex pattern
+     *
+     *  \param text the text to be matched against the pattern
+     *  \param pattern the search pattern, which may contain regexp markers
+     *  \return the string that matches the patters or an empty one */
+
+    std::string strfind(const std::string &text, const std::string &pattern);
+
     /** Send message to screen and logfile, if available
      *
      *  \param lmp   pointer to LAMMPS class instance

--- a/unittest/utils/test_utils.cpp
+++ b/unittest/utils/test_utils.cpp
@@ -35,11 +35,11 @@ TEST(Utils, strdup)
     std::string original("some_text");
     const char *copy = utils::strdup(original);
     ASSERT_THAT(original, StrEq(copy));
-    ASSERT_NE(copy,original.c_str());
+    ASSERT_NE(copy, original.c_str());
 
     const char *copy2 = utils::strdup(copy);
     ASSERT_THAT(original, StrEq(copy2));
-    ASSERT_NE(copy,copy2);
+    ASSERT_NE(copy, copy2);
 
     delete[] copy;
     delete[] copy2;
@@ -72,7 +72,7 @@ TEST(Utils, trim_comment)
 TEST(Utils, has_utf8)
 {
     const char ascii_string[] = " -2";
-    const char utf8_string[] = " −2";
+    const char utf8_string[]  = " −2";
     ASSERT_FALSE(utils::has_utf8(ascii_string));
     ASSERT_TRUE(utils::has_utf8(utf8_string));
 }
@@ -80,9 +80,9 @@ TEST(Utils, has_utf8)
 TEST(Utils, utf8_subst)
 {
     const char ascii_string[] = " -2";
-    const char utf8_string[] = " −2";
-    auto ascii = utils::utf8_subst(ascii_string);
-    auto utf8  = utils::utf8_subst(utf8_string);
+    const char utf8_string[]  = " −2";
+    auto ascii                = utils::utf8_subst(ascii_string);
+    auto utf8                 = utils::utf8_subst(utf8_string);
     ASSERT_TRUE(ascii == utf8);
 }
 
@@ -397,6 +397,91 @@ TEST(Utils, strmatch_float_nonfloat)
 TEST(Utils, strmatch_whitespace_nonwhitespace)
 {
     ASSERT_TRUE(utils::strmatch(" 5.0  angles\n", "^\\s*\\S+\\s+\\S+\\s"));
+}
+
+TEST(Utils, strfind_beg)
+{
+    ASSERT_THAT(utils::strfind("rigid/small/omp", "^rigid"), StrEq("rigid"));
+}
+
+TEST(Utils, strfind_mid1)
+{
+    ASSERT_THAT(utils::strfind("rigid/small/omp", ".small."), StrEq("/small/"));
+}
+
+TEST(Utils, strfind_mid2)
+{
+    ASSERT_THAT(utils::strfind("rigid/small/ompXXX", "omp"), StrEq("omp"));
+}
+
+TEST(Utils, strfind_end)
+{
+    ASSERT_THAT(utils::strfind("rigid/small/omp", "/omp$"), StrEq("/omp"));
+}
+
+TEST(Utils, no_strfind_beg)
+{
+    ASSERT_THAT(utils::strfind("rigid/small/omp", "^small"), StrEq(""));
+}
+
+TEST(Utils, no_strfind_mid)
+{
+    ASSERT_THAT(utils::strfind("rigid/small/omp", "none"), StrEq(""));
+}
+
+TEST(Utils, no_strfind_end)
+{
+    ASSERT_THAT(utils::strfind("rigid/small/omp", "/opt$"), StrEq(""));
+}
+
+TEST(Utils, strfind_whole_line)
+{
+    ASSERT_THAT(utils::strfind("ITEM: UNITS\n", "^\\s*ITEM: UNITS\\s*$"), StrEq("ITEM: UNITS\n"));
+}
+
+TEST(Utils, no_strfind_whole_line)
+{
+    ASSERT_THAT(utils::strfind("ITEM: UNITS\n", "^\\s*ITEM: UNIT\\s*$"), StrEq(""));
+}
+
+TEST(Utils, strfind_char_range)
+{
+    ASSERT_THAT(utils::strfind("rigidXXX", "^[ip-s]+gid"), StrEq("rigid"));
+}
+
+TEST(Utils, strfind_notchar_range)
+{
+    ASSERT_THAT(utils::strfind("rigidYYY", "^[^a-g]+gid"), StrEq("rigid"));
+}
+
+TEST(Utils, strfind_backslash)
+{
+    ASSERT_THAT(utils::strfind("\\rigidZZZ", "^\\W\\w+gid"), StrEq("\\rigid"));
+}
+
+TEST(Utils, strfind_opt_range)
+{
+    ASSERT_THAT(utils::strfind("rigidAAA", "^[0-9]*[\\Wp-s]igid"), StrEq("rigid"));
+}
+
+TEST(Utils, strfind_opt_char)
+{
+    ASSERT_THAT(utils::strfind("rigid111", "^r?igid"), StrEq("rigid"));
+    ASSERT_THAT(utils::strfind("igid222", "^r?igid"), StrEq("igid"));
+}
+
+TEST(Utils, strfind_dot)
+{
+    ASSERT_THAT(utils::strfind("AAArigidBBB", ".igid"), StrEq("rigid"));
+    ASSERT_THAT(utils::strfind("000Rigid111", ".igid"), StrEq("Rigid"));
+}
+
+TEST(Utils, strfind_kim)
+{
+    ASSERT_THAT(utils::strfind("n3409jfse MO_004835508849_000 aslfjiaf",
+                               "[MS][MO]_\\d\\d\\d+_\\d\\d\\d"), StrEq("MO_004835508849_000"));
+    ASSERT_THAT(utils::strfind("VanDuinChakraborty_2003_CHNO__SM_107643900657_000",
+                               "[MS][MO]_\\d\\d\\d+_\\d\\d\\d"), StrEq("SM_107643900657_000"));
 }
 
 TEST(Utils, bounds_case1)


### PR DESCRIPTION
**Summary**

This updates the mini-regex code in the utils namespace to the current version with a few portability and bug fixes and indication of the length of a match. The latter is needed for the new utils::strfind() function that may replace the use of (not yet) fully portable use of std::regex across our range of supported machines.

**Related Issue(s)**

Needed for PR #2625 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. Existing unit tests for `utils::strmatch()` pass.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.

**Further Information, Files, and Links**

https://github.com/kokke/tiny-regex-c


