### PR TITLE
[BUGFIX] Correct return values for FixNH::extract()

### DIFF
--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -1754,13 +1754,13 @@ void *FixNH::extract(const char *str, int &dim)
   } else if (tstat_flag && strcmp(str,"mtchain") == 0) {
     return &mtchain;
   } else if (pstat_flag && strcmp(str,"mpchain") == 0) {
-    return &mtchain;
+    return &mpchain;
   }
   dim=1;
   if (tstat_flag && strcmp(str,"eta") == 0) {
     return &eta;
   } else if (pstat_flag && strcmp(str,"etap") == 0) {
-    return &eta;
+    return &etap;
   } else if (pstat_flag && strcmp(str,"p_flag") == 0) {
     return &p_flag;
   } else if (pstat_flag && strcmp(str,"p_start") == 0) {


### PR DESCRIPTION
**Summary**

FixNH::extract() was returning mtchain when asked for mpchain, and eta when asked for etap.

**Related Issue(s)**

None

**Author(s)**

Stephen Sanderson, University of Queensland

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

I expect nothing will be broken unless it relied on the bugged behaviour

**Implementation Notes**

Noticed this while implementing a related feature and assumed it must be a bug - please reject if that's not the case.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

None


