### PR TITLE
Further refactor parsing of molecule files

### DIFF
--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -730,7 +730,7 @@ void Molecule::types(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 2)
         error->one(FLERR,fmt::format("Invalid line in Types section of "
                                      "molecule file: {}",line));
@@ -769,7 +769,7 @@ void Molecule::molecules(char *line)
   try {
     for (int i = 0; i < natoms; i++) {
       readline(line);
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 2) error->one(FLERR,"Invalid Molecules section in molecule file");
 
       int iatom = values.next_int() - 1;
@@ -804,7 +804,7 @@ void Molecule::fragments(char *line)
     for (int i = 0; i < nfragments; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
 
       if ((int)values.count() > natoms+1)
         error->one(FLERR,"Invalid atom ID in Fragments section of molecule file");
@@ -835,7 +835,7 @@ void Molecule::charges(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if ((int)values.count() != 2) error->one(FLERR,"Invalid Charges section in molecule file");
 
       int iatom = values.next_int() - 1;
@@ -864,7 +864,7 @@ void Molecule::diameters(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 2) error->one(FLERR,"Invalid Diameters section in molecule file");
 
       int iatom = values.next_int() - 1;
@@ -899,7 +899,7 @@ void Molecule::masses(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 2) error->one(FLERR,"Invalid Masses section in molecule file");
 
       int iatom = values.next_int() - 1;
@@ -943,7 +943,7 @@ void Molecule::bonds(int flag, char *line)
     readline(line);
 
     try {
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 4) error->one(FLERR,"Invalid Bonds section in molecule file");
       values.next_int();
       itype = values.next_int();
@@ -1011,7 +1011,7 @@ void Molecule::angles(int flag, char *line)
     readline(line);
 
     try {
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 5) error->one(FLERR,"Invalid Angles section in molecule file");
       values.next_int();
       itype = values.next_int();
@@ -1095,7 +1095,7 @@ void Molecule::dihedrals(int flag, char *line)
     readline(line);
 
     try {
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 6) error->one(FLERR,"Invalid Dihedrals section in molecule file");
       values.next_int();
       itype = values.next_int();
@@ -1194,7 +1194,7 @@ void Molecule::impropers(int flag, char *line)
     readline(line);
 
     try {
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 6) error->one(FLERR,"Invalid Impropers section in molecule file");
       values.next_int();
       itype = values.next_int();
@@ -1287,7 +1287,7 @@ void Molecule::nspecial_read(int flag, char *line)
     int c1, c2, c3;
 
     try {
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       if (values.count() != 4) error->one(FLERR,"Invalid Special Bond Counts section in molecule file");
       values.next_int();
       c1 = values.next_tagint();
@@ -1316,7 +1316,7 @@ void Molecule::special_read(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       int nwords = values.count();
 
       if (nwords != nspecial[i][2]+1)
@@ -1454,7 +1454,7 @@ void Molecule::shakeflag_read(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
 
       if (values.count() != 2)
         error->one(FLERR,"Invalid Shake Flags section in molecule file");
@@ -1483,7 +1483,7 @@ void Molecule::shakeatom_read(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       nmatch = values.count();
 
       switch (shake_flag[i]) {
@@ -1557,7 +1557,7 @@ void Molecule::shaketype_read(char *line)
     for (int i = 0; i < natoms; i++) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       nmatch = values.count();
 
       switch (shake_flag[i]) {
@@ -1635,7 +1635,7 @@ void Molecule::body(int flag, int pflag, char *line)
     while (nword < nparam) {
       readline(line);
 
-      ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      ValueTokenizer values(utils::trim_comment(line));
       int ncount = values.count();
 
       if (ncount == 0)

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -887,8 +887,6 @@ void Molecule::diameters(char *line)
       if (values.count() != 2)
         error->all(FLERR,fmt::format("Invalid line in Diameters section of "
                                      "molecule file: {}",line));
-
-
       int iatom = values.next_int() - 1;
       if (iatom < 0 || iatom >= natoms)
         error->all(FLERR,"Invalid atom index in Diameters section of molecule file");
@@ -924,24 +922,29 @@ void Molecule::masses(char *line)
       readline(line);
 
       ValueTokenizer values(utils::trim_comment(line));
-      if (values.count() != 2) error->all(FLERR,"Invalid Masses section in molecule file");
+      if (values.count() != 2)
+        error->all(FLERR,fmt::format("Invalid line in Masses section of "
+                                     "molecule file: {}",line));
 
       int iatom = values.next_int() - 1;
-      if (iatom < 0 || iatom >= natoms) error->all(FLERR,"Invalid Masses section in molecule file");
+      if (iatom < 0 || iatom >= natoms)
+        error->all(FLERR,"Invalid atom index in Masses section of molecule file");
       count[iatom]++;
       rmass[iatom] = values.next_double();
       rmass[iatom] *= sizescale*sizescale*sizescale;
     }
   } catch (TokenizerException &e) {
-    error->all(FLERR, fmt::format("Invalid Masses section in molecule file\n"
-                                  "{}", e.what()));
+    error->all(FLERR, fmt::format("Invalid line in Masses section of "
+                                  "molecule file: {}\n{}",e.what(),line));
   }
 
-  for (int i = 0; i < natoms; i++)
-    if (count[i] == 0) error->all(FLERR,"Invalid Masses section in molecule file");
-
-  for (int i = 0; i < natoms; i++)
-    if (rmass[i] <= 0.0) error->all(FLERR,"Invalid atom mass in molecule file");
+  for (int i = 0; i < natoms; i++) {
+    if (count[i] == 0)   error->all(FLERR,fmt::format("Atom {} missing in Masses "
+                                                    "section of molecule file",i+1));
+    if (rmass[i] <= 0.0)
+      error->all(FLERR,fmt::format("Invalid atom mass {} for atom {} "
+                                   "in molecule file", radius[i], i+1));
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -968,14 +971,16 @@ void Molecule::bonds(int flag, char *line)
 
     try {
       ValueTokenizer values(utils::trim_comment(line));
-      if (values.count() != 4) error->all(FLERR,"Invalid Bonds section in molecule file");
+      if (values.count() != 4)
+        error->all(FLERR,fmt::format("Invalid line in Bonds section of "
+                                     "molecule file: {}",line));
       values.next_int();
       itype = values.next_int();
       atom1 = values.next_tagint();
       atom2 = values.next_tagint();
     } catch (TokenizerException &e) {
-      error->all(FLERR, fmt::format("Invalid Bonds section in molecule file\n"
-                                    "{}", e.what()));
+      error->all(FLERR, fmt::format("Invalid line in Bonds section of "
+                                  "molecule file: {}\n{}",e.what(),line));
     }
 
     itype += boffset;
@@ -1036,15 +1041,17 @@ void Molecule::angles(int flag, char *line)
 
     try {
       ValueTokenizer values(utils::trim_comment(line));
-      if (values.count() != 5) error->all(FLERR,"Invalid Angles section in molecule file");
+      if (values.count() != 5)
+        error->all(FLERR,fmt::format("Invalid line in Angles section of "
+                                     "molecule file: {}",line));
       values.next_int();
       itype = values.next_int();
       atom1 = values.next_tagint();
       atom2 = values.next_tagint();
       atom3 = values.next_tagint();
     } catch (TokenizerException &e) {
-      error->all(FLERR, fmt::format("Invalid Angles section in molecule file\n"
-                                    "{}", e.what()));
+      error->all(FLERR, fmt::format("Invalid line in Angles section of "
+                                    "molecule file: {}\n{}",e.what(),line));
     }
 
     itype += aoffset;
@@ -1120,7 +1127,10 @@ void Molecule::dihedrals(int flag, char *line)
 
     try {
       ValueTokenizer values(utils::trim_comment(line));
-      if (values.count() != 6) error->all(FLERR,"Invalid Dihedrals section in molecule file");
+      if (values.count() != 6)
+        error->all(FLERR,fmt::format("Invalid line in Dihedrals section of "
+                                     "molecule file: {}",line));
+
       values.next_int();
       itype = values.next_int();
       atom1 = values.next_tagint();
@@ -1128,8 +1138,8 @@ void Molecule::dihedrals(int flag, char *line)
       atom3 = values.next_tagint();
       atom4 = values.next_tagint();
     } catch (TokenizerException &e) {
-      error->all(FLERR, fmt::format("Invalid Dihedrals section in molecule file\n"
-                                    "{}", e.what()));
+      error->all(FLERR, fmt::format("Invalid line in Dihedrals section of "
+                                    "molecule file: {}\n{}",e.what(),line));
     }
 
     itype += doffset;
@@ -1219,7 +1229,9 @@ void Molecule::impropers(int flag, char *line)
 
     try {
       ValueTokenizer values(utils::trim_comment(line));
-      if (values.count() != 6) error->all(FLERR,"Invalid Impropers section in molecule file");
+      if (values.count() != 6)
+                error->all(FLERR,fmt::format("Invalid line in Impropers section of "
+                                     "molecule file: {}",line));
       values.next_int();
       itype = values.next_int();
       atom1 = values.next_tagint();
@@ -1227,8 +1239,8 @@ void Molecule::impropers(int flag, char *line)
       atom3 = values.next_tagint();
       atom4 = values.next_tagint();
     } catch (TokenizerException &e) {
-      error->all(FLERR, fmt::format("Invalid Impropers section in molecule file\n"
-                                    "{}", e.what()));
+      error->all(FLERR, fmt::format("Invalid line in Impropers section of "
+                                    "molecule file: {}\n{}",e.what(),line));
     }
 
     itype += ioffset;
@@ -1312,14 +1324,16 @@ void Molecule::nspecial_read(int flag, char *line)
 
     try {
       ValueTokenizer values(utils::trim_comment(line));
-      if (values.count() != 4) error->all(FLERR,"Invalid Special Bond Counts section in molecule file");
+      if (values.count() != 4)
+        error->all(FLERR,fmt::format("Invalid line in Special Bond Counts section of "
+                                     "molecule file: {}",line));
       values.next_int();
       c1 = values.next_tagint();
       c2 = values.next_tagint();
       c3 = values.next_tagint();
     } catch (TokenizerException &e) {
-      error->all(FLERR, fmt::format("Invalid Special Bond Counts section in molecule file\n"
-                                    "{}", e.what()));
+      error->all(FLERR, fmt::format("Invalid line in Special Bond Counts section of "
+                                    "molecule file: {}\n{}",e.what(),line));
     }
 
     if (flag) {
@@ -1353,12 +1367,13 @@ void Molecule::special_read(char *line)
         special[i][m-1] = values.next_tagint();
         if (special[i][m-1] <= 0 || special[i][m-1] > natoms ||
             special[i][m-1] == i+1)
-          error->all(FLERR,"Invalid special atom index in molecule file");
+          error->all(FLERR,"Invalid atom index in Special Bonds "
+                     "section of molecule file");
       }
     }
   } catch (TokenizerException &e) {
-    error->all(FLERR, fmt::format("Invalid Molecule file special list\n"
-                                  "{}", e.what()));
+    error->all(FLERR, fmt::format("Invalid line in Special Bonds section of "
+                                  "molecule file: {}\n{}",e.what(),line));
   }
 }
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -55,14 +55,10 @@ Molecule::Molecule(LAMMPS *lmp, int narg, char **arg, int &index) :
 
   if (index >= narg) error->all(FLERR,"Illegal molecule command");
 
-  int n = strlen(arg[0]) + 1;
-  id = new char[n];
-  strcpy(id,arg[0]);
-
-  for (int i = 0; i < n-1; i++)
-    if (!isalnum(id[i]) && id[i] != '_')
-      error->all(FLERR,"Molecule template ID must be "
-                 "alphanumeric or underscore characters");
+  id = utils::strdup(arg[0]);
+  if (!utils::is_id(id))
+    error->all(FLERR,"Molecule template ID must be "
+               "alphanumeric or underscore characters");
 
   // parse args until reach unknown arg (next file)
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -725,6 +725,7 @@ void Molecule::types(char *line)
       readline(line);
 
       ValueTokenizer values(utils::trim(utils::trim_comment(line)));
+      if (values.count() != 2)
         error->one(FLERR,fmt::format("Invalid line in Types section of "
                                      "molecule file: {}",line));
 

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -411,15 +411,14 @@ void Molecule::read(int flag)
 
     readline(line);
 
-    // trim anything from '#' onward
-    // if line is blank, continue
+    // trim comments. if line is blank, continue
 
-    if ((ptr = strchr(line,'#'))) *ptr = '\0';
-    if (strspn(line," \t\n\r") == strlen(line)) continue;
+    auto text = utils::trim(utils::trim_comment(line));
+    if (text.empty()) continue;
 
     // search line for header keywords and set corresponding variable
     try {
-      ValueTokenizer values(line);
+      ValueTokenizer values(text);
 
       int nmatch = values.count();
       int nwant = 0;

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -507,98 +507,98 @@ void Molecule::read(int flag)
 
   // grab keyword and skip next line
 
-  parse_keyword(0,line,keyword);
+  std::string keyword = parse_keyword(0,line);
   readline(line);
 
   // loop over sections of molecule file
 
-  while (strlen(keyword) > 0) {
-    if (strcmp(keyword,"Coords") == 0) {
+  while (!keyword.empty()) {
+    if (keyword == "Coords") {
       xflag = 1;
       if (flag) coords(line);
-      else skip_lines(natoms,line);
-    } else if (strcmp(keyword,"Types") == 0) {
+      else skip_lines(natoms,line,keyword);
+    } else if (keyword == "Types") {
       typeflag = 1;
       if (flag) types(line);
-      else skip_lines(natoms,line);
-    } else if (strcmp(keyword,"Molecules") == 0) {
+      else skip_lines(natoms,line,keyword);
+    } else if (keyword == "Molecules") {
       moleculeflag = 1;
       if (flag) molecules(line);
-      else skip_lines(natoms,line);
-    } else if (strcmp(keyword,"Fragments") == 0) {
+      else skip_lines(natoms,line,keyword);
+    } else if (keyword == "Fragments") {
       if (nfragments == 0)
         error->all(FLERR,"Molecule file has fragments but no nfragments setting");
       fragmentflag = 1;
       if (flag) fragments(line);
-      else skip_lines(nfragments,line);
-    } else if (strcmp(keyword,"Charges") == 0) {
+      else skip_lines(nfragments,line,keyword);
+    } else if (keyword == "Charges") {
       qflag = 1;
       if (flag) charges(line);
-      else skip_lines(natoms,line);
-    } else if (strcmp(keyword,"Diameters") == 0) {
+      else skip_lines(natoms,line,keyword);
+    } else if (keyword == "Diameters") {
       radiusflag = 1;
       if (flag) diameters(line);
-      else skip_lines(natoms,line);
-    } else if (strcmp(keyword,"Masses") == 0) {
+      else skip_lines(natoms,line,keyword);
+    } else if (keyword == "Masses") {
       rmassflag = 1;
       if (flag) masses(line);
-      else skip_lines(natoms,line);
+      else skip_lines(natoms,line,keyword);
 
-    } else if (strcmp(keyword,"Bonds") == 0) {
+    } else if (keyword == "Bonds") {
       if (nbonds == 0)
         error->all(FLERR,"Molecule file has bonds but no nbonds setting");
       bondflag = tag_require = 1;
       bonds(flag,line);
-    } else if (strcmp(keyword,"Angles") == 0) {
+    } else if (keyword == "Angles") {
       if (nangles == 0)
         error->all(FLERR,"Molecule file has angles but no nangles setting");
       angleflag = tag_require = 1;
       angles(flag,line);
-    } else if (strcmp(keyword,"Dihedrals") == 0) {
+    } else if (keyword == "Dihedrals") {
       if (ndihedrals == 0) error->all(FLERR,"Molecule file has dihedrals "
                                       "but no ndihedrals setting");
       dihedralflag = tag_require = 1;
       dihedrals(flag,line);
-    } else if (strcmp(keyword,"Impropers") == 0) {
+    } else if (keyword == "Impropers") {
       if (nimpropers == 0) error->all(FLERR,"Molecule file has impropers "
                                       "but no nimpropers setting");
       improperflag = tag_require = 1;
       impropers(flag,line);
 
-    } else if (strcmp(keyword,"Special Bond Counts") == 0) {
+    } else if (keyword == "Special Bond Counts") {
       nspecialflag = 1;
       nspecial_read(flag,line);
-    } else if (strcmp(keyword,"Special Bonds") == 0) {
+    } else if (keyword == "Special Bonds") {
       specialflag = tag_require = 1;
       if (flag) special_read(line);
-      else skip_lines(natoms,line);
+      else skip_lines(natoms,line,keyword);
 
-    } else if (strcmp(keyword,"Shake Flags") == 0) {
+    } else if (keyword == "Shake Flags") {
       shakeflagflag = 1;
       if (flag) shakeflag_read(line);
-      else skip_lines(natoms,line);
-    } else if (strcmp(keyword,"Shake Atoms") == 0) {
+      else skip_lines(natoms,line,keyword);
+    } else if (keyword == "Shake Atoms") {
       shakeatomflag = tag_require = 1;
       if (shaketypeflag) shakeflag = 1;
       if (!shakeflagflag)
         error->all(FLERR,"Molecule file shake flags not before shake atoms");
       if (flag) shakeatom_read(line);
-      else skip_lines(natoms,line);
-    } else if (strcmp(keyword,"Shake Bond Types") == 0) {
+      else skip_lines(natoms,line,keyword);
+    } else if (keyword == "Shake Bond Types") {
       shaketypeflag = 1;
       if (shakeatomflag) shakeflag = 1;
       if (!shakeflagflag)
         error->all(FLERR,"Molecule file shake flags not before shake bonds");
       if (flag) shaketype_read(line);
-      else skip_lines(natoms,line);
+      else skip_lines(natoms,line,keyword);
 
-    } else if (strcmp(keyword,"Body Integers") == 0) {
+    } else if (keyword == "Body Integers") {
       if (bodyflag == 0 || nibody == 0)
         error->all(FLERR,"Molecule file has body params "
                    "but no setting for them");
       ibodyflag = 1;
       body(flag,0,line);
-    } else if (strcmp(keyword,"Body Doubles") == 0) {
+    } else if (keyword == "Body Doubles") {
       if (bodyflag == 0 || ndbody == 0)
         error->all(FLERR,"Molecule file has body params "
                    "but no setting for them");
@@ -608,7 +608,7 @@ void Molecule::read(int flag)
     } else error->one(FLERR,fmt::format("Unknown section '{}' in molecule "
                                         "file", keyword));
 
-    parse_keyword(1,line,keyword);
+    keyword = parse_keyword(1,line);
   }
 
   // error check
@@ -1968,8 +1968,9 @@ void Molecule::readline(char *line)
    flag = 1, line has already been read
 ------------------------------------------------------------------------- */
 
-void Molecule::parse_keyword(int flag, char *line, char *keyword)
+std::string Molecule::parse_keyword(int flag, char *line)
 {
+  char line2[MAXLINE];
   if (flag) {
 
     // read upto non-blank line plus 1 following line
@@ -1981,42 +1982,38 @@ void Molecule::parse_keyword(int flag, char *line, char *keyword)
       while (eof == 0 && strspn(line," \t\n\r") == strlen(line)) {
         if (fgets(line,MAXLINE,fp) == nullptr) eof = 1;
       }
-      if (fgets(keyword,MAXLINE,fp) == nullptr) eof = 1;
+      if (fgets(line2,MAXLINE,fp) == nullptr) eof = 1;
     }
 
     // if eof, set keyword empty and return
 
     MPI_Bcast(&eof,1,MPI_INT,0,world);
     if (eof) {
-      keyword[0] = '\0';
-      return;
+      return std::string("");
     }
 
     // bcast keyword line to all procs
 
-    int n;
-    if (me == 0) n = strlen(line) + 1;
-    MPI_Bcast(&n,1,MPI_INT,0,world);
-    MPI_Bcast(line,n,MPI_CHAR,0,world);
+    MPI_Bcast(line,MAXLINE,MPI_CHAR,0,world);
   }
 
-  // copy non-whitespace and non-comment portion of line into keyword
+  // return non-whitespace and non-comment portion of line
 
-  int start = strspn(line," \t\n\r");
-  int stop = strcspn(line,"#") - 1;
-  while (line[stop] == ' ' || line[stop] == '\t'
-         || line[stop] == '\n' || line[stop] == '\r') stop--;
-  line[stop+1] = '\0';
-  strcpy(keyword,&line[start]);
+  return utils::trim(utils::trim_comment(line));
 }
 
 /* ----------------------------------------------------------------------
-   skip N lines of file
+   skip N lines of file. Check if non-numeric content (e.g. keyword).
 ------------------------------------------------------------------------- */
 
-void Molecule::skip_lines(int n, char *line)
+void Molecule::skip_lines(int n, char *line, const std::string &section)
 {
-  for (int i = 0; i < n; i++) readline(line);
+  for (int i = 0; i < n; i++) {
+    readline(line);
+    if (utils::strmatch(utils::trim(utils::trim_comment(line)),"^[A-Za-z ]+$"))
+      error->one(FLERR,fmt::format("Unexpected line in molecule file while "
+                                   "skipping {} section:\n{}",section,line));
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -125,16 +125,21 @@ Molecule::Molecule(LAMMPS *lmp, int narg, char **arg, int &index) :
 
   initialize();
 
-  // scan file for sizes of all fields and allocate them
+  // scan file for sizes of all fields and allocate storage for them
 
-  if (me == 0) open(arg[ifile]);
+  if (me == 0) {
+    fp = fopen(arg[ifile],"r");
+    if (fp == nullptr)
+      error->one(FLERR,fmt::format("Cannot open molecule file {}: {}",
+                                   arg[ifile], utils::getsyserror()));
+  }
   read(0);
   if (me == 0) fclose(fp);
   allocate();
 
   // read file again to populate all fields
 
-  if (me == 0) open(arg[ifile]);
+  if (me == 0) fp = fopen(arg[ifile],"r");
   read(1);
   if (me == 0) fclose(fp);
 
@@ -1960,18 +1965,6 @@ void Molecule::deallocate()
 
   memory->destroy(ibodyparams);
   memory->destroy(dbodyparams);
-}
-
-/* ----------------------------------------------------------------------
-   open molecule file
-------------------------------------------------------------------------- */
-
-void Molecule::open(char *file)
-{
-  fp = fopen(file,"r");
-  if (fp == nullptr)
-    error->one(FLERR,fmt::format("Cannot open molecule file {}: {}",
-                                 file, utils::getsyserror()));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -480,10 +480,16 @@ void Molecule::read(int flag)
         nibody = values.next_int();
         ndbody = values.next_int();
         nwant = 3;
-      } else break;
-
+      } else {
+        // unknown header keyword
+        if (utils::strmatch(text,"^\\d+\\s+\\S+")) {
+          values.next_int();
+          auto keyword = values.next_string();
+          error->one(FLERR,fmt::format("Invalid header keyword: {}",keyword));
+        } else break;
+      }
       if (nmatch != nwant)
-        error->one(FLERR,"Invalid header in molecule file");
+        error->one(FLERR,"Invalid header line format in molecule file");
     } catch (TokenizerException &e) {
       error->one(FLERR, fmt::format("Invalid header in molecule file\n"
                                     "{}", e.what()));

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -57,7 +57,7 @@ Molecule::Molecule(LAMMPS *lmp, int narg, char **arg, int &index) :
 
   id = utils::strdup(arg[0]);
   if (!utils::is_id(id))
-    error->all(FLERR,"Molecule template ID must be "
+    error->all(FLERR,"Molecule template ID must have only "
                "alphanumeric or underscore characters");
 
   // parse args until reach unknown arg (next file)
@@ -499,7 +499,7 @@ void Molecule::read(int flag)
   // error checks
 
   if (natoms < 1)
-    error->all(FLERR,"No or invalid atom count in molecule file");
+    error->all(FLERR,"No atoms or invalid atom count in molecule file");
   if (nbonds < 0) error->all(FLERR,"Invalid bond count in molecule file");
   if (nangles < 0) error->all(FLERR,"Invalid angle count in molecule file");
   if (ndihedrals < 0)
@@ -533,7 +533,7 @@ void Molecule::read(int flag)
       else skip_lines(natoms,line,keyword);
     } else if (keyword == "Fragments") {
       if (nfragments == 0)
-        error->all(FLERR,"Molecule file has fragments but no nfragments setting");
+        error->all(FLERR,"Found Fragments section but no nfragments setting in header");
       fragmentflag = 1;
       if (flag) fragments(line);
       else skip_lines(nfragments,line,keyword);
@@ -552,22 +552,22 @@ void Molecule::read(int flag)
 
     } else if (keyword == "Bonds") {
       if (nbonds == 0)
-        error->all(FLERR,"Molecule file has bonds but no nbonds setting");
+        error->all(FLERR,"Found Bonds section but no nbonds setting in header");
       bondflag = tag_require = 1;
       bonds(flag,line);
     } else if (keyword == "Angles") {
       if (nangles == 0)
-        error->all(FLERR,"Molecule file has angles but no nangles setting");
+        error->all(FLERR,"Found Angles section but no nangles setting in header");
       angleflag = tag_require = 1;
       angles(flag,line);
     } else if (keyword == "Dihedrals") {
-      if (ndihedrals == 0) error->all(FLERR,"Molecule file has dihedrals "
-                                      "but no ndihedrals setting");
+      if (ndihedrals == 0) error->all(FLERR,"Found Dihedrals section"
+                                      "but no ndihedrals setting in header");
       dihedralflag = tag_require = 1;
       dihedrals(flag,line);
     } else if (keyword == "Impropers") {
-      if (nimpropers == 0) error->all(FLERR,"Molecule file has impropers "
-                                      "but no nimpropers setting");
+      if (nimpropers == 0) error->all(FLERR,"Found Impropers section"
+                                      "but no nimpropers setting in header");
       improperflag = tag_require = 1;
       impropers(flag,line);
 
@@ -587,27 +587,25 @@ void Molecule::read(int flag)
       shakeatomflag = tag_require = 1;
       if (shaketypeflag) shakeflag = 1;
       if (!shakeflagflag)
-        error->all(FLERR,"Molecule file shake flags not before shake atoms");
+        error->all(FLERR,"Shake Flags section must come before Shake Atoms section");
       if (flag) shakeatom_read(line);
       else skip_lines(natoms,line,keyword);
     } else if (keyword == "Shake Bond Types") {
       shaketypeflag = 1;
       if (shakeatomflag) shakeflag = 1;
       if (!shakeflagflag)
-        error->all(FLERR,"Molecule file shake flags not before shake bonds");
+        error->all(FLERR,"Shake Flags section must come before Shake Bonds section");
       if (flag) shaketype_read(line);
       else skip_lines(natoms,line,keyword);
 
     } else if (keyword == "Body Integers") {
       if (bodyflag == 0 || nibody == 0)
-        error->all(FLERR,"Molecule file has body params "
-                   "but no setting for them");
+        error->all(FLERR,"Found Body Integers section but no setting in header");
       ibodyflag = 1;
       body(flag,0,line);
     } else if (keyword == "Body Doubles") {
       if (bodyflag == 0 || ndbody == 0)
-        error->all(FLERR,"Molecule file has body params "
-                   "but no setting for them");
+        error->all(FLERR,"Found Body Doubles section but no setting in header");
       dbodyflag = 1;
       body(flag,1,line);
     } else {
@@ -693,7 +691,7 @@ void Molecule::coords(char *line)
 
       int iatom = values.next_int() - 1;
       if (iatom < 0 || iatom >= natoms)
-        error->one(FLERR,"Invalid Coords section in molecule file");
+        error->one(FLERR,"Invalid atom index in Coords section of molecule file");
       count[iatom]++;
       x[iatom][0] = values.next_double();
       x[iatom][1] = values.next_double();

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -604,10 +604,17 @@ void Molecule::read(int flag)
                    "but no setting for them");
       dbodyflag = 1;
       body(flag,1,line);
+    } else {
 
-    } else error->one(FLERR,fmt::format("Unknown section '{}' in molecule "
-                                        "file", keyword));
+      // Error: Either a too long/short section or a typo in the keyword
 
+      if (utils::strmatch(keyword,"^[A-Za-z ]+$"))
+        error->one(FLERR,fmt::format("Unknown section '{}' in molecule "
+                                     "file\n",keyword));
+      else error->one(FLERR,fmt::format("Unexpected line in molecule file "
+                                        "while looking for the next "
+                                        "section:\n{}",line));
+    }
     keyword = parse_keyword(1,line);
   }
 

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -161,7 +161,6 @@ class Molecule : protected Pointers {
   void allocate();
   void deallocate();
 
-  void open(char *);
   void readline(char *);
   std::string parse_keyword(int, char *);
   void skip_lines(int, char *, const std::string &);

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -163,8 +163,8 @@ class Molecule : protected Pointers {
 
   void open(char *);
   void readline(char *);
-  void parse_keyword(int, char *, char *);
-  void skip_lines(int, char *);
+  std::string parse_keyword(int, char *);
+  void skip_lines(int, char *, const std::string &);
 
   // void print();
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -851,7 +851,7 @@ std::vector<std::string> utils::split_words(const std::string &text)
 ------------------------------------------------------------------------- */
 
 bool utils::is_integer(const std::string &str) {
-  if (str.size() == 0) {
+  if (str.empty()) {
     return false;
   }
 
@@ -867,7 +867,7 @@ bool utils::is_integer(const std::string &str) {
 ------------------------------------------------------------------------- */
 
 bool utils::is_double(const std::string &str) {
-  if (str.size() == 0) {
+  if (str.empty()) {
     return false;
   }
 
@@ -875,6 +875,22 @@ bool utils::is_double(const std::string &str) {
     if (isdigit(c)) continue;
     if (c == '-' || c == '+' || c == '.') continue;
     if (c == 'e' || c == 'E') continue;
+    return false;
+  }
+  return true;
+}
+
+/* ----------------------------------------------------------------------
+   Return whether string is a valid ID string
+------------------------------------------------------------------------- */
+
+bool utils::is_id(const std::string &str) {
+  if (str.empty()) {
+    return false;
+  }
+
+  for (auto c : str) {
+    if (isalnum(c) || (c == '_')) continue;
     return false;
   }
   return true;

--- a/src/utils.h
+++ b/src/utils.h
@@ -335,6 +335,14 @@ namespace LAMMPS_NS {
 
     bool is_double(const std::string &str);
 
+    /** Check if string is a valid ID
+     * ID strings may contain only letters, numbers, and underscores.
+     *
+     * \param str string that should be checked
+     * \return true, if string contains valid id, false otherwise */
+
+    bool is_id(const std::string &str);
+
     /** Try to detect pathname from FILE pointer.
      *
      * Currently only supported on Linux, otherwise will report "(unknown)".

--- a/unittest/formats/CMakeLists.txt
+++ b/unittest/formats/CMakeLists.txt
@@ -7,6 +7,10 @@ add_executable(test_image_flags test_image_flags.cpp)
 target_link_libraries(test_image_flags PRIVATE lammps GTest::GMock GTest::GTest)
 add_test(NAME ImageFlags COMMAND test_image_flags WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+add_executable(test_molecule_file test_molecule_file.cpp)
+target_link_libraries(test_molecule_file PRIVATE lammps GTest::GMock GTest::GTest)
+add_test(NAME MoleculeFile COMMAND test_molecule_file WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(test_pair_unit_convert test_pair_unit_convert.cpp)
 target_link_libraries(test_pair_unit_convert PRIVATE lammps GTest::GMock GTest::GTest)
 add_test(NAME PairUnitConvert COMMAND test_pair_unit_convert WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -11,6 +11,7 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+#include "atom.h"
 #include "info.h"
 #include "input.h"
 #include "lammps.h"
@@ -123,13 +124,13 @@ protected:
     void run_mol_cmd(const std::string &name, const std::string &args, const std::string &content)
     {
         std::string file = name + ".mol";
-        FILE *fp = fopen(file.c_str(), "w");
-        fputs(content.c_str(),fp);
+        FILE *fp         = fopen(file.c_str(), "w");
+        fputs(content.c_str(), fp);
         fclose(fp);
 
-        lmp->input->one(fmt::format("molecule {} {} {}",name,file,args));
+        lmp->input->one(fmt::format("molecule {} {} {}", name, file, args));
         remove(file.c_str());
-    }       
+    }
 };
 
 TEST_F(MoleculeFileTest, nofile)
@@ -148,48 +149,50 @@ TEST_F(MoleculeFileTest, badid)
 TEST_F(MoleculeFileTest, badargs)
 {
     TEST_FAILURE(".*Illegal molecule command.*",
-                 run_mol_cmd(test_name,"offset 1 2 3 4",
+                 run_mol_cmd(test_name, "offset 1 2 3 4",
                              "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
-    TEST_FAILURE(".*Illegal molecule command.*",
-                 run_mol_cmd(test_name,"toff",
-                             "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
-    TEST_FAILURE(".*Illegal molecule command.*",
-                 run_mol_cmd(test_name,"boff",
-                             "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
-    TEST_FAILURE(".*Illegal molecule command.*",
-                 run_mol_cmd(test_name,"aoff",
-                             "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
-    TEST_FAILURE(".*Illegal molecule command.*",
-                 run_mol_cmd(test_name,"doff",
-                             "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
-    TEST_FAILURE(".*Illegal molecule command.*",
-                 run_mol_cmd(test_name,"ioff",
-                             "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
-    TEST_FAILURE(".*Illegal molecule command.*",
-                 run_mol_cmd(test_name,"scale",
-                             "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
+    TEST_FAILURE(
+        ".*Illegal molecule command.*",
+        run_mol_cmd(test_name, "toff", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
+    TEST_FAILURE(
+        ".*Illegal molecule command.*",
+        run_mol_cmd(test_name, "boff", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
+    TEST_FAILURE(
+        ".*Illegal molecule command.*",
+        run_mol_cmd(test_name, "aoff", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
+    TEST_FAILURE(
+        ".*Illegal molecule command.*",
+        run_mol_cmd(test_name, "doff", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
+    TEST_FAILURE(
+        ".*Illegal molecule command.*",
+        run_mol_cmd(test_name, "ioff", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
+    TEST_FAILURE(
+        ".*Illegal molecule command.*",
+        run_mol_cmd(test_name, "scale", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n"););
     remove("badargs.mol");
 }
 
 TEST_F(MoleculeFileTest, noatom)
 {
     TEST_FAILURE(".*ERROR: No atoms or invalid atom count in molecule file.*",
-                 run_mol_cmd(test_name,"","Comment\n0 atoms\n1 bonds\n\n"
-                                    " Coords\n\nBonds\n\n 1 1 2\n"););
+                 run_mol_cmd(test_name, "",
+                             "Comment\n0 atoms\n1 bonds\n\n"
+                             " Coords\n\nBonds\n\n 1 1 2\n"););
     remove("noatom.mol");
 }
 
 TEST_F(MoleculeFileTest, empty)
 {
     TEST_FAILURE(".*ERROR: Unexpected end of molecule file.*",
-                 run_mol_cmd(test_name,"","Comment\n\n"););
+                 run_mol_cmd(test_name, "", "Comment\n\n"););
     remove("empty.mol");
 }
 
 TEST_F(MoleculeFileTest, nospecial)
 {
     TEST_FAILURE(".*ERROR: Cannot auto-generate special bonds before simulation box is defined.*",
-                 run_mol_cmd(test_name,"","Comment\n3 atoms\n\n2 bonds\n\n"
+                 run_mol_cmd(test_name, "",
+                             "Comment\n3 atoms\n\n2 bonds\n\n"
                              " Coords\n\n 1 1.0 1.0 1.0\n 2 1.0 1.0 0.0\n 3 1.0 0.0 1.0\n"
                              " Bonds\n\n 1 1 1 2\n 2 1 1 3\n"););
     remove("nospecial.mol");
@@ -198,22 +201,23 @@ TEST_F(MoleculeFileTest, nospecial)
 TEST_F(MoleculeFileTest, minimal)
 {
     ::testing::internal::CaptureStdout();
-    run_mol_cmd(test_name,"","Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n");
+    run_mol_cmd(test_name, "", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n");
     auto output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
-    ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*1 molecules.*1 atoms.*0 bonds.*"));
+    ASSERT_THAT(output, MatchesRegex(".*Read molecule template.*1 molecules.*1 atoms.*0 bonds.*"));
 }
 
 TEST_F(MoleculeFileTest, twomols)
 {
     ::testing::internal::CaptureStdout();
-    run_mol_cmd(test_name,"","Comment\n2 atoms\n\n"
+    run_mol_cmd(test_name, "",
+                "Comment\n2 atoms\n\n"
                 " Coords\n\n 1 0.0 0.0 0.0\n 2 0.0 0.0 1.0\n"
                 " Molecules\n\n 1 1\n 2 2\n\n Types\n\n 1 1\n 2 2\n\n");
     auto output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
-    ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*2 molecules.*2 atoms "
-                                    "with max type 2.*0 bonds.*"));
+    ASSERT_THAT(output, MatchesRegex(".*Read molecule template.*2 molecules.*2 atoms "
+                                     "with max type 2.*0 bonds.*"));
 }
 
 TEST_F(MoleculeFileTest, twofiles)
@@ -222,12 +226,12 @@ TEST_F(MoleculeFileTest, twofiles)
     lmp->input->one("molecule twomols h2o.mol co2.mol offset 2 1 1 0 0");
     auto output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
-    ASSERT_THAT(output,MatchesRegex(".*Read molecule template twomols:.*1 molecules.*3 atoms "
-                                    "with max type 2.*2 bonds with max type 1.*"
-                                    "1 angles with max type 1.*0 dihedrals.*"
-                                    ".*Read molecule template twomols:.*1 molecules.*3 atoms "
-                                    "with max type 4.*2 bonds with max type 2.*"
-                                    "1 angles with max type 2.*0 dihedrals.*"));
+    ASSERT_THAT(output, MatchesRegex(".*Read molecule template twomols:.*1 molecules.*3 atoms "
+                                     "with max type 2.*2 bonds with max type 1.*"
+                                     "1 angles with max type 1.*0 dihedrals.*"
+                                     ".*Read molecule template twomols:.*1 molecules.*3 atoms "
+                                     "with max type 4.*2 bonds with max type 2.*"
+                                     "1 angles with max type 2.*0 dihedrals.*"));
 }
 
 TEST_F(MoleculeFileTest, bonds)
@@ -237,7 +241,8 @@ TEST_F(MoleculeFileTest, bonds)
     lmp->input->one("region box block 0 1 0 1 0 1");
     lmp->input->one("create_box 2 box bond/types 2 extra/bond/per/atom 2 "
                     "extra/special/per/atom 4");
-    run_mol_cmd(test_name,"","Comment\n"
+    run_mol_cmd(test_name, "",
+                "Comment\n"
                 "4 atoms\n"
                 "2 bonds\n\n"
                 " Coords\n\n"
@@ -255,14 +260,30 @@ TEST_F(MoleculeFileTest, bonds)
                 " 2 2 1 3\n\n");
     auto output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
-    ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*1 molecules.*4 atoms.*type.*2.*"
-                                    "2 bonds.*type.*2.*0 angles.*"));
+    ASSERT_THAT(output, MatchesRegex(".*Read molecule template.*1 molecules.*4 atoms.*type.*2.*"
+                                     "2 bonds.*type.*2.*0 angles.*"));
 
     ::testing::internal::CaptureStdout();
-    lmp->input->one("create_atoms 0 single 0.0 0.0 0.0 mol bonds 67235");
+    lmp->input->one("mass * 2.0");
+    lmp->input->one("create_atoms 0 single 0.5 0.5 0.5 mol bonds 67235");
     output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
-    ASSERT_THAT(output,MatchesRegex(".*Created 4 atoms.*"));
+    ASSERT_THAT(output, MatchesRegex(".*Created 4 atoms.*"));
+
+    ::testing::internal::CaptureStdout();
+    Molecule *mol = lmp->atom->molecules[0];
+    ASSERT_EQ(mol->natoms, 4);
+    ASSERT_EQ(lmp->atom->natoms, 4);
+    mol->compute_mass();
+    mol->compute_com();
+    ASSERT_DOUBLE_EQ(mol->masstotal, 8.0);
+    EXPECT_DOUBLE_EQ(mol->com[0], 1.0);
+    EXPECT_DOUBLE_EQ(mol->com[1], 0.5);
+    EXPECT_DOUBLE_EQ(mol->com[2], 0.5);
+    EXPECT_DOUBLE_EQ(mol->maxextent, sqrt(2));
+    EXPECT_EQ(mol->comatom, 1);
+    output = ::testing::internal::GetCapturedStdout();
+    if (verbose) std::cout << output;
 }
 
 int main(int argc, char **argv)

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -1,0 +1,129 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://lammps.sandia.gov/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "info.h"
+#include "input.h"
+#include "lammps.h"
+#include "molecule.h"
+#include "utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cstdio>
+#include <mpi.h>
+#include <fstream>
+#include <string>
+
+using namespace LAMMPS_NS;
+
+using testing::MatchesRegex;
+using testing::StrEq;
+
+using utils::split_words;
+
+#if defined(OMPI_MAJOR_VERSION)
+const bool have_openmpi = true;
+#else
+const bool have_openmpi = false;
+#endif
+
+#define TEST_FAILURE(errmsg, ...)                                 \
+    if (Info::has_exceptions()) {                                 \
+        ::testing::internal::CaptureStdout();                     \
+        ASSERT_ANY_THROW({__VA_ARGS__});                          \
+        auto mesg = ::testing::internal::GetCapturedStdout();     \
+        ASSERT_THAT(mesg, MatchesRegex(errmsg));                  \
+    } else {                                                      \
+        if (!have_openmpi) {                                      \
+            ::testing::internal::CaptureStdout();                 \
+            ASSERT_DEATH({__VA_ARGS__}, "");                      \
+            auto mesg = ::testing::internal::GetCapturedStdout(); \
+            ASSERT_THAT(mesg, MatchesRegex(errmsg));              \
+        }                                                         \
+    }
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+class MoleculeFileTest : public ::testing::Test {
+protected:
+    LAMMPS *lmp;
+
+    void SetUp() override
+    {
+        const char *args[] = {"MoleculeFileTest", "-log", "none", "-echo", "screen", "-nocite"};
+        char **argv        = (char **)args;
+        int argc           = sizeof(args) / sizeof(char *);
+        if (!verbose) ::testing::internal::CaptureStdout();
+        lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+        if (!verbose) ::testing::internal::GetCapturedStdout();
+        ASSERT_NE(lmp, nullptr);
+    }
+
+    void TearDown() override
+    {
+        if (!verbose) ::testing::internal::CaptureStdout();
+        delete lmp;
+        if (!verbose) ::testing::internal::GetCapturedStdout();
+    }
+
+    void run_mol_cmd(const std::string &name, const std::string &args, const std::string &content)
+    {
+        std::string file = name + ".mol";
+        std::ofstream mol(file, std::ofstream::trunc);
+        mol << content << std::endl;
+        mol.close();
+
+        lmp->input->one(fmt::format("molecule {} {} {}",name,file,args));
+        remove(file.c_str());
+    }       
+};
+
+TEST_F(MoleculeFileTest, minimal)
+{
+    ::testing::internal::CaptureStdout();
+    run_mol_cmd(test_info_->name(),"","Comment\n"
+                "1 atoms\n\n"
+                " Coords\n\n"
+                " 1 0.0 0.0 0.0\n");
+    auto output = ::testing::internal::GetCapturedStdout();
+    if (verbose) std::cout << output;
+    ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*1 molecules"
+                                    ".*1 atoms.*0 bonds.*0. angles.*"));
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    if (have_openmpi && !LAMMPS_NS::Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. "
+                     "Death tests will be skipped\n";
+
+    // handle arguments passed via environment variable
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = split_words(var);
+        for (auto arg : env) {
+            if (arg == "-v") {
+                verbose = true;
+            }
+        }
+    }
+
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -31,6 +31,8 @@ using testing::StrEq;
 
 using utils::split_words;
 
+#define test_name test_info_->name()
+
 #if defined(OMPI_MAJOR_VERSION)
 const bool have_openmpi = true;
 #else
@@ -89,13 +91,23 @@ protected:
     }       
 };
 
+TEST_F(MoleculeFileTest, nofile)
+{
+    TEST_FAILURE(".*Cannot open molecule file nofile.mol.*",
+                 lmp->input->one("molecule 1 nofile.mol"););
+}
+
+TEST_F(MoleculeFileTest, noatom)
+{
+    TEST_FAILURE(".*ERROR: No or invalid atom count in molecule file.*",
+                 run_mol_cmd(test_name,"","Comment\n0 atoms\n1 bonds\n\n"
+                                    " Coords\n\nBonds\n\n 1 1 2\n"););
+}
+
 TEST_F(MoleculeFileTest, minimal)
 {
     ::testing::internal::CaptureStdout();
-    run_mol_cmd(test_info_->name(),"","Comment\n"
-                "1 atoms\n\n"
-                " Coords\n\n"
-                " 1 0.0 0.0 0.0\n");
+    run_mol_cmd(test_name,"","Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n");
     auto output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
     ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*1 molecules.*1 atoms.*0 bonds.*"));

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -235,7 +235,8 @@ TEST_F(MoleculeFileTest, bonds)
     ::testing::internal::CaptureStdout();
     lmp->input->one("atom_style bond");
     lmp->input->one("region box block 0 1 0 1 0 1");
-    lmp->input->one("create_box 2 box bond/types 2 extra/special/per/atom 2");
+    lmp->input->one("create_box 2 box bond/types 2 extra/bond/per/atom 2 "
+                    "extra/special/per/atom 4");
     run_mol_cmd(test_name,"","Comment\n"
                 "4 atoms\n"
                 "2 bonds\n\n"
@@ -249,11 +250,6 @@ TEST_F(MoleculeFileTest, bonds)
                 " 2 1\n"
                 " 3 2\n"
                 " 4 2\n\n"
-                " Masses\n\n"
-                " 1 1.0\n"
-                " 2 2.0\n"
-                " 3 3.0\n"
-                " 4 4.0\n\n"
                 " Bonds\n\n"
                 " 1 1 1 2\n"
                 " 2 2 1 3\n\n");
@@ -261,6 +257,12 @@ TEST_F(MoleculeFileTest, bonds)
     if (verbose) std::cout << output;
     ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*1 molecules.*4 atoms.*type.*2.*"
                                     "2 bonds.*type.*2.*0 angles.*"));
+
+    ::testing::internal::CaptureStdout();
+    lmp->input->one("create_atoms 0 single 0.0 0.0 0.0 mol bonds 67235");
+    output = ::testing::internal::GetCapturedStdout();
+    if (verbose) std::cout << output;
+    ASSERT_THAT(output,MatchesRegex(".*Created 4 atoms.*"));
 }
 
 int main(int argc, char **argv)

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -98,8 +98,7 @@ TEST_F(MoleculeFileTest, minimal)
                 " 1 0.0 0.0 0.0\n");
     auto output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
-    ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*1 molecules"
-                                    ".*1 atoms.*0 bonds.*0. angles.*"));
+    ASSERT_THAT(output,MatchesRegex(".*Read molecule template.*1 molecules.*1 atoms.*0 bonds.*"));
 }
 
 int main(int argc, char **argv)

--- a/unittest/utils/test_utils.cpp
+++ b/unittest/utils/test_utils.cpp
@@ -287,6 +287,61 @@ TEST(Utils, signed_double_and_d_exponential)
     ASSERT_FALSE(utils::is_double("-10D-22"));
 }
 
+TEST(Utils, valid_id1)
+{
+    ASSERT_TRUE(utils::is_id("abc"));
+}
+
+TEST(Utils, valid_id2)
+{
+    ASSERT_TRUE(utils::is_id("123"));
+}
+
+TEST(Utils, valid_id3)
+{
+    ASSERT_TRUE(utils::is_id("abc123"));
+}
+
+TEST(Utils, valid_id4)
+{
+    ASSERT_TRUE(utils::is_id("abc_123"));
+}
+
+TEST(Utils, valid_id5)
+{
+    ASSERT_TRUE(utils::is_id("123_abc"));
+}
+
+TEST(Utils, valid_id6)
+{
+    ASSERT_TRUE(utils::is_id("_123"));
+}
+
+TEST(Utils, valid_id7)
+{
+    ASSERT_TRUE(utils::is_id("___"));
+}
+
+TEST(Utils, invalid_id1)
+{
+    ASSERT_FALSE(utils::is_id("+abc"));
+}
+
+TEST(Utils, invalid_id2)
+{
+    ASSERT_FALSE(utils::is_id("a[1]"));
+}
+
+TEST(Utils, invalid_id3)
+{
+    ASSERT_FALSE(utils::is_id("b(c)"));
+}
+
+TEST(Utils, invalid_id4)
+{
+    ASSERT_FALSE(utils::is_id("a$12"));
+}
+
 TEST(Utils, strmatch_beg)
 {
     ASSERT_TRUE(utils::strmatch("rigid/small/omp", "^rigid"));


### PR DESCRIPTION
**Summary**

This pull request will add further improvements and cleanups to the molecule command.
- comments ('#' to end of line) are going to be supported for the entire file
- while skipping of sections, we'll check for possible section keywords (non-numbers) and error out, if needed
- improved error messages with more specific information (instead of just "Illegal molecule file")
- unit tests for correctly parsing the files
- simplified and more readable code through using more C++ features

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues (yet).

**Implementation Notes**

It also adds a convenience function `utils::is_id()` that allows checking for valid ID strings. The test is rather lose right now, but it could be made more stringent (e.g. letter as first character) and with that also used in other places.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
