### PR TITLE
Add "INSTALL_RPATH_USE_LINK_PATH True" for lmp and lammps targets

### DIFF
--- a/cmake/Modules/Packages/KIM.cmake
+++ b/cmake/Modules/Packages/KIM.cmake
@@ -71,7 +71,11 @@ if(DOWNLOAD_KIM)
 else()
   if(KIM-API_FOUND AND KIM-API_VERSION VERSION_GREATER_EQUAL 2.2.0)
     # For kim-api >= 2.2.0
+    set_target_properties(lammps PROPERTIES INSTALL_RPATH_USE_LINK_PATH True)
+    set_target_properties(lmp    PROPERTIES INSTALL_RPATH_USE_LINK_PATH True)
     find_package(KIM-API 2.2.0 CONFIG REQUIRED)
+    get_target_property(_kim_loc KIM-API::kim-api IMPORT_LOCATION)        # Determine found message
+    find_package_message(KIM-API "Found KIM-API: ${_kim_loc}" "KIM-API")  # since package does not for <=2.2.1; can be removed once 2.2.2 or above is available
     target_link_libraries(lammps PRIVATE KIM-API::kim-api)
   else()
     # For kim-api 2.1.3 (consistent with previous version of this file)


### PR DESCRIPTION
Also add find_packate_message() indicating kim-api found

Closes #2623

**Summary**

Fix rpath cmake settings for kim-api.

**Related Issue(s)**

closes #2623 

**Author(s)**

Ryan S. Elliott (UMN)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


