### PR TITLE
Small bug fix for fixes to fix deposit and fix pour

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 GNU GENERAL PUBLIC LICENSE
 
-Version 2, June 1991 
+Version 2, June 1991
 
 Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
@@ -301,9 +301,8 @@ one line to give the program's name and an idea of what it does.
 Copyright (C) yyyy  name of author
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or (at
-your option) any later version.
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
 
 This program is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -375,7 +375,8 @@ void FixPour::init()
 
 void FixPour::setup_pre_exchange()
 {
-  next_reneighbor = update->ntimestep + 1;
+  if (ninserted < ninsert) next_reneighbor = update->ntimestep + 1;
+  else next_reneighbor = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MISC/fix_deposit.cpp
+++ b/src/MISC/fix_deposit.cpp
@@ -296,7 +296,8 @@ void FixDeposit::init()
 
 void FixDeposit::setup_pre_exchange()
 {
-  next_reneighbor = update->ntimestep+1;
+  if (ninserted < ninsert) next_reneighbor = update->ntimestep+1;
+  else next_reneighbor = 0;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -49,14 +49,19 @@ PairPython::PairPython(LAMMPS *lmp) : Pair(lmp) {
   python->init();
 
   // add current directory to PYTHONPATH
-  PyObject * py_path = PySys_GetObject((char *)"path");
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyObject *py_path = PySys_GetObject((char *)"path");
   PyList_Append(py_path, PY_STRING_FROM_STRING("."));
 
-  // if LAMMPS_POTENTIALS environment variable is set, add it to PYTHONPATH as well
-  const char * potentials_path = getenv("LAMMPS_POTENTIALS");
+  // if LAMMPS_POTENTIALS environment variable is set,
+  // add it to PYTHONPATH as well
+
+  const char *potentials_path = getenv("LAMMPS_POTENTIALS");
   if (potentials_path != nullptr) {
     PyList_Append(py_path, PY_STRING_FROM_STRING(potentials_path));
   }
+  PyGILState_Release(gstate);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,9 +64,15 @@ int main(int argc, char **argv)
     exit(1);
   }
 #else
-  LAMMPS *lammps = new LAMMPS(argc,argv,MPI_COMM_WORLD);
-  lammps->input->file();
-  delete lammps;
+  try {
+    LAMMPS *lammps = new LAMMPS(argc,argv,MPI_COMM_WORLD);
+    lammps->input->file();
+    delete lammps;
+  } catch(fmt::format_error &fe) {
+    fprintf(stderr,"fmt::format_error: %s\n", fe.what());
+    MPI_Abort(MPI_COMM_WORLD, 1);
+    exit(1);
+  }
 #endif
   MPI_Barrier(MPI_COMM_WORLD);
   MPI_Finalize();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -691,7 +691,7 @@ std::string utils::utf8_subst(const std::string &line)
           out += ' ', i += 2;
       }
     // UTF-8 4-byte character
-    } else if ((in[i] & 0xe8U) == 0xf0U) {
+    } else if ((in[i] & 0xf8U) == 0xf0U) {
       if ((i+3) < len) {
         ;
       }


### PR DESCRIPTION
**Summary**

The previous fix would re-enable particle insertion even if already completed when starting a new run and thus could cause segmentation faults when trying to communicate when there is nothing to communicate. The changes in the PR prevent that.

**Related Issue(s)**

PR #2637 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

