### PR TITLE
relax "fix deform erate" error if run may be halted

### DIFF
--- a/src/fix_deform.cpp
+++ b/src/fix_deform.cpp
@@ -467,7 +467,10 @@ void FixDeform::init()
       set[i].hi_stop = set[i].hi_start +
         0.5*delt*set[i].rate * (set[i].hi_start-set[i].lo_start);
       if (set[i].hi_stop <= set[i].lo_stop)
-        error->all(FLERR,"Final box dimension due to fix deform is < 0.0");
+        if (modify->find_fix_by_style("^halt") == -1)
+          error->all(FLERR,"Final box dimension due to fix deform is < 0.0");
+        else
+          if (comm->me == 0) error->warning(FLERR,"Final box dimension due to fix deform is < 0.0");
     } else if (set[i].style == TRATE) {
       set[i].lo_stop = 0.5*(set[i].lo_start+set[i].hi_start) -
         0.5*((set[i].hi_start-set[i].lo_start) * exp(set[i].rate*delt));

--- a/src/fix_deform.cpp
+++ b/src/fix_deform.cpp
@@ -928,6 +928,10 @@ void FixDeform::end_of_step()
     if (set[5].style) domain->xy = set[5].tilt_target;
   }
 
+  for (i = 0; i < 3; i++)
+    if (domain->boxhi[i] <= domain->boxlo[i])
+      error->all(FLERR,"Final box dimension due to fix deform is < 0.0");
+
   domain->set_global_box();
   domain->set_local_box();
 


### PR DESCRIPTION
**Summary**

relax "fix deform erate" error to a warning if there is also a "fix halt", which may stop the run before problematic conditions occur

**Related Issue(s)**

none

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


