### PR TITLE
Tightened up the consistency checks on SNAP elements and LAMMPS types

### DIFF
--- a/doc/src/pair_snap.rst
+++ b/doc/src/pair_snap.rst
@@ -88,9 +88,12 @@ that will be used with other potentials.
 
 The name of the SNAP coefficient file usually ends in the
 ".snapcoeff" extension. It may contain coefficients
-for many SNAP elements. The only requirement is that it
-contain at least those element names appearing in the
-LAMMPS mapping list.
+for many SNAP elements. The only requirement is that
+each of the unique element names appearing in the
+LAMMPS pair_coeff command appear exactly once in
+the SNAP coefficient file. It is okay if the SNAP coefficient file
+contains additional elements not in the pair_coeff command,
+except when using *chemflag* (see below).
 The name of the SNAP parameter file usually ends in the ".snapparam"
 extension. It contains a small number
 of parameters that define the overall form of the SNAP potential.
@@ -129,7 +132,7 @@ line must contain two integers:
 This is followed by one block for each of the *nelem* elements.
 The first line of each block contains three entries:
 
-* Element symbol (text string)
+* Element name (text string)
 * R = Element radius (distance units)
 * w = Element weight (dimensionless)
 
@@ -166,8 +169,8 @@ where :math:`\mathbf{B}_i` is the *K*-vector of bispectrum components,
 :math:`\boldsymbol{\beta}^{\mu_i}` is the *K*-vector of linear coefficients
 for element :math:`\mu_i`, and :math:`\boldsymbol{\alpha}^{\mu_i}`
 is the symmetric *K* by *K* matrix of quadratic coefficients.
-The SNAP element file should contain *K*\ (\ *K*\ +1)/2 additional coefficients
-for each element, the upper-triangular elements of :math:`\boldsymbol{\alpha}^{\mu_i}`.
+The SNAP coefficient file should contain *K*\ (\ *K*\ +1)/2 additional coefficients
+in each element block, the upper-triangular elements of :math:`\boldsymbol{\alpha}^{\mu_i}`.
 
 If *chemflag* is set to 1, then the energy expression is written in terms of explicit multi-element bispectrum
 components indexed on ordered triplets of elements, which has been shown to increase the ability of the SNAP
@@ -181,8 +184,12 @@ at the expense of a significant increase in computational cost :ref:`(Cusentino)
 where :math:`\mathbf{B}^{\kappa\lambda\mu}_i` is the *K*-vector of bispectrum components
 for neighbors of elements :math:`\kappa`, :math:`\lambda`, and :math:`\mu` and
 :math:`\boldsymbol{\beta}^{\kappa\lambda\mu}_{\mu_i}` is the corresponding *K*-vector
-of linear coefficients for element :math:`\mu_i`. The SNAP element file should contain
-a total of :math:`K N_{elem}^3` coefficients for each of the :math:`N_{elem}` elements.
+of linear coefficients for element :math:`\mu_i`. The SNAP coefficient file should contain
+a total of :math:`K N_{elem}^3` coefficients in each element block,
+where :math:`N_{elem}` is the number of elements in the SNAP coefficient file,
+which must equal the number of unique elements appearing in the
+LAMMPS pair_coeff command, to avoid ambiguity in the 
+number of coefficients.
 
 The keyword *chunksize* is only applicable when using the
 pair style *snap* with the KOKKOS package and is ignored otherwise.

--- a/doc/src/pair_snap.rst
+++ b/doc/src/pair_snap.rst
@@ -188,7 +188,7 @@ of linear coefficients for element :math:`\mu_i`. The SNAP coefficient file shou
 a total of :math:`K N_{elem}^3` coefficients in each element block,
 where :math:`N_{elem}` is the number of elements in the SNAP coefficient file,
 which must equal the number of unique elements appearing in the
-LAMMPS pair_coeff command, to avoid ambiguity in the 
+LAMMPS pair_coeff command, to avoid ambiguity in the
 number of coefficients.
 
 The keyword *chunksize* is only applicable when using the

--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -782,6 +782,9 @@ void PairSNAP::read_files(char *coefffilename, char *paramfilename)
   if (rcutfacflag == 0 || twojmaxflag == 0)
     error->all(FLERR,"Incorrect SNAP parameter file");
 
+  if (chemflag && nelemtmp != nelements)
+    error->all(FLERR,"Incorrect SNAP parameter file");
+
 }
 
 /* ----------------------------------------------------------------------

--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -622,20 +622,20 @@ void PairSNAP::read_files(char *coefffilename, char *paramfilename)
       if (strcmp(words[0],elements[jelem]) == 0) break;
 
     // if this element not needed, skip this block
-  
+
     if (jelem == nelements) {
       if (comm->me == 0) {
-	for (int icoeff = 0; icoeff < ncoeffall; icoeff++) {
-	  ptr = fgets(line,MAXLINE,fpcoeff);
-	  if (ptr == nullptr) {
-	    eof = 1;
-	    fclose(fpcoeff);
-	  }
-	}
+        for (int icoeff = 0; icoeff < ncoeffall; icoeff++) {
+          ptr = fgets(line,MAXLINE,fpcoeff);
+          if (ptr == nullptr) {
+            eof = 1;
+            fclose(fpcoeff);
+          }
+        }
       }
       MPI_Bcast(&eof,1,MPI_INT,0,world);
       if (eof)
-	error->all(FLERR,"Incorrect format in SNAP coefficient file");
+        error->all(FLERR,"Incorrect format in SNAP coefficient file");
       continue;
     }
 
@@ -647,31 +647,28 @@ void PairSNAP::read_files(char *coefffilename, char *paramfilename)
     radelem[jelem] = atof(words[1]);
     wjelem[jelem] = atof(words[2]);
 
-    if (comm->me == 0) {
-      if (screen) fprintf(screen,"SNAP Element = %s, Radius %g, Weight %g \n",
-			  elements[jelem], radelem[jelem], wjelem[jelem]);
-      if (logfile) fprintf(logfile,"SNAP Element = %s, Radius %g, Weight %g \n",
-			   elements[jelem], radelem[jelem], wjelem[jelem]);
-    }
+    if (comm->me == 0)
+      utils::logmesg(lmp,fmt::format("SNAP Element = {}, Radius {}, Weight {}\n",
+                                     elements[jelem], radelem[jelem], wjelem[jelem]);
 
     for (int icoeff = 0; icoeff < ncoeffall; icoeff++) {
       if (comm->me == 0) {
-	ptr = fgets(line,MAXLINE,fpcoeff);
-	if (ptr == nullptr) {
-	  eof = 1;
-	  fclose(fpcoeff);
-	} else n = strlen(line) + 1;
+        ptr = fgets(line,MAXLINE,fpcoeff);
+        if (ptr == nullptr) {
+          eof = 1;
+          fclose(fpcoeff);
+        } else n = strlen(line) + 1;
       }
 
       MPI_Bcast(&eof,1,MPI_INT,0,world);
       if (eof)
-	error->all(FLERR,"Incorrect format in SNAP coefficient file");
+        error->all(FLERR,"Incorrect format in SNAP coefficient file");
       MPI_Bcast(&n,1,MPI_INT,0,world);
       MPI_Bcast(line,n,MPI_CHAR,0,world);
 
       nwords = utils::trim_and_count_words(line);
       if (nwords != 1)
-	error->all(FLERR,"Incorrect format in SNAP coefficient file");
+        error->all(FLERR,"Incorrect format in SNAP coefficient file");
 
       iword = 0;
       words[iword] = strtok(line,"' \t\n\r\f");

--- a/src/SNAP/pair_snap.cpp
+++ b/src/SNAP/pair_snap.cpp
@@ -13,19 +13,19 @@
 
 #include "pair_snap.h"
 
-#include <cmath>
-
-#include <cstring>
 #include "atom.h"
-#include "force.h"
 #include "comm.h"
-#include "neighbor.h"
+#include "error.h"
+#include "force.h"
+#include "memory.h"
 #include "neigh_list.h"
 #include "neigh_request.h"
+#include "neighbor.h"
 #include "sna.h"
-#include "memory.h"
-#include "error.h"
+#include "tokenizer.h"
 
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 


### PR DESCRIPTION
**Summary**

Tightened up the consistency checks for mapping of LAMMPS atom types to SNAP elements

Previously there was no checking for mismatches in number of elements names appearing
in the pair_coeff command, nor was their checking to see that all unique element names
appeared exactly once in the SNAP coefficient file.

This now also checks whether valid numbers are entered and avoids temporary or global string buffers.

**Author(s)**

Aidan Thompson

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Some old scripts might fail because they were quietly incorrect

**Implementation Notes**

None

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


