### PR TITLE
Collected small code refactoring changes

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1114,13 +1114,13 @@ void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
 
-    values[0] = strtok(buf," \t\n\r\f");
-    if (values[0] == nullptr)
-      error->all(FLERR,"Incorrect atom format in data file");
-    for (m = 1; m < nwords; m++) {
-      values[m] = strtok(nullptr," \t\n\r\f");
-      if (values[m] == nullptr)
+    for (m = 0; m < nwords; m++) {
+      buf += strspn(buf," \t\n\r\f");
+      buf[strcspn(buf," \t\n\r\f")] = '\0';
+      if (strlen(buf) == 0)
         error->all(FLERR,"Incorrect atom format in data file");
+      values[m] = buf;
+      buf += strlen(buf)+1;
     }
 
     int imx = 0, imy = 0, imz = 0;
@@ -1217,9 +1217,12 @@ void Atom::data_vels(int n, char *buf, tagint id_offset)
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
 
-    values[0] = strtok(buf," \t\n\r\f");
-    for (j = 1; j < nwords; j++)
-      values[j] = strtok(nullptr," \t\n\r\f");
+    for (j = 0; j < nwords; j++) {
+      buf += strspn(buf," \t\n\r\f");
+      buf[strcspn(buf," \t\n\r\f")] = '\0';
+      values[j] = buf;
+      buf += strlen(buf)+1;
+    }
 
     tagdata = ATOTAGINT(values[0]) + id_offset;
     if (tagdata <= 0 || tagdata > map_tag_max)
@@ -1569,9 +1572,12 @@ void Atom::data_bonus(int n, char *buf, AtomVec *avec_bonus, tagint id_offset)
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
 
-    values[0] = strtok(buf," \t\n\r\f");
-    for (j = 1; j < nwords; j++)
-      values[j] = strtok(nullptr," \t\n\r\f");
+    for (j = 0; j < nwords; j++) {
+      buf += strspn(buf," \t\n\r\f");
+      buf[strcspn(buf," \t\n\r\f")] = '\0';
+      values[j] = buf;
+      buf += strlen(buf)+1;
+    }
 
     tagdata = ATOTAGINT(values[0]) + id_offset;
     if (tagdata <= 0 || tagdata > map_tag_max)
@@ -1611,8 +1617,10 @@ void Atom::data_bodies(int n, char *buf, AtomVec *avec_body, tagint id_offset)
   // else skip values
 
   for (int i = 0; i < n; i++) {
-    if (i == 0) tagdata = ATOTAGINT(strtok(buf," \t\n\r\f")) + id_offset;
-    else tagdata = ATOTAGINT(strtok(nullptr," \t\n\r\f")) + id_offset;
+    buf += strspn(buf," \t\n\r\f");
+    buf[strcspn(buf," \t\n\r\f")] = '\0';
+    tagdata = utils::tnumeric(FLERR,buf,false,lmp) + id_offset;
+    buf += strlen(buf)+1;
 
     if (tagdata <= 0 || tagdata > map_tag_max)
       error->one(FLERR,"Invalid atom ID in Bodies section of data file");
@@ -1622,8 +1630,15 @@ void Atom::data_bodies(int n, char *buf, AtomVec *avec_body, tagint id_offset)
     else
       error->one(FLERR,"Duplicate atom ID in Bodies section of data file");
 
-    ninteger = utils::inumeric(FLERR,strtok(nullptr," \t\n\r\f"),false,lmp);
-    ndouble = utils::inumeric(FLERR,strtok(nullptr," \t\n\r\f"),false,lmp);
+    buf += strspn(buf," \t\n\r\f");
+    buf[strcspn(buf," \t\n\r\f")] = '\0';
+    ninteger = utils::inumeric(FLERR,buf,false,lmp);
+    buf += strlen(buf)+1;
+
+    buf += strspn(buf," \t\n\r\f");
+    buf[strcspn(buf," \t\n\r\f")] = '\0';
+    ndouble = utils::inumeric(FLERR,buf,false,lmp);
+    buf += strlen(buf)+1;
 
     if ((m = map(tagdata)) >= 0) {
       if (ninteger > maxint) {
@@ -1637,17 +1652,29 @@ void Atom::data_bodies(int n, char *buf, AtomVec *avec_body, tagint id_offset)
         dvalues = new double[maxdouble];
       }
 
-      for (j = 0; j < ninteger; j++)
-        ivalues[j] = utils::inumeric(FLERR,strtok(nullptr," \t\n\r\f"),false,lmp);
-      for (j = 0; j < ndouble; j++)
-        dvalues[j] = utils::numeric(FLERR,strtok(nullptr," \t\n\r\f"),false,lmp);
+      for (j = 0; j < ninteger; j++) {
+        buf += strspn(buf," \t\n\r\f");
+        buf[strcspn(buf," \t\n\r\f")] = '\0';
+        ivalues[j] = utils::inumeric(FLERR,buf,false,lmp);
+        buf += strlen(buf)+1;
+      }
+
+      for (j = 0; j < ndouble; j++) {
+        buf += strspn(buf," \t\n\r\f");
+        buf[strcspn(buf," \t\n\r\f")] = '\0';
+        dvalues[j] = utils::numeric(FLERR,buf,false,lmp);
+        buf += strlen(buf)+1;
+      }
 
       avec_body->data_body(m,ninteger,ndouble,ivalues,dvalues);
 
     } else {
       nvalues = ninteger + ndouble;    // number of values to skip
-      for (j = 0; j < nvalues; j++)
-        strtok(nullptr," \t\n\r\f");
+      for (j = 0; j < nvalues; j++) {
+        buf += strspn(buf," \t\n\r\f");
+        buf[strcspn(buf," \t\n\r\f")] = '\0';
+        buf += strlen(buf)+1;
+      }
     }
   }
 

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -341,11 +341,8 @@ void Atom::settings(Atom *old)
   map_style = old->map_style;
   sortfreq = old->sortfreq;
   userbinsize = old->userbinsize;
-  if (old->firstgroupname) {
-    int n = strlen(old->firstgroupname) + 1;
-    firstgroupname = new char[n];
-    strcpy(firstgroupname,old->firstgroupname);
-  }
+  if (old->firstgroupname)
+    firstgroupname = utils::strdup(old->firstgroupname);
 }
 
 /* ----------------------------------------------------------------------
@@ -532,9 +529,7 @@ void Atom::add_peratom(const char *name, void *address,
       memory->srealloc(peratom,maxperatom*sizeof(PerAtom),"atom:peratom");
   }
 
-  int n = strlen(name) + 1;
-  peratom[nperatom].name = new char[n];
-  strcpy(peratom[nperatom].name,name);
+  peratom[nperatom].name = utils::strdup(name);
   peratom[nperatom].address = address;
   peratom[nperatom].datatype = datatype;
   peratom[nperatom].cols = cols;
@@ -582,9 +577,7 @@ void Atom::add_peratom_vary(const char *name, void *address,
       memory->srealloc(peratom,maxperatom*sizeof(PerAtom),"atom:peratom");
   }
 
-  int n = strlen(name) + 1;
-  peratom[nperatom].name = new char[n];
-  strcpy(peratom[nperatom].name,name);
+  peratom[nperatom].name = utils::strdup(name);
   peratom[nperatom].address = address;
   peratom[nperatom].datatype = datatype;
   peratom[nperatom].cols = -1;
@@ -815,9 +808,7 @@ void Atom::modify_params(int narg, char **arg)
         delete [] firstgroupname;
         firstgroupname = nullptr;
       } else {
-        int n = strlen(arg[iarg+1]) + 1;
-        firstgroupname = new char[n];
-        strcpy(firstgroupname,arg[iarg+1]);
+        firstgroupname = utils::strdup(arg[iarg+1]);
         sortfreq = 0;
       }
       iarg += 2;
@@ -2427,9 +2418,7 @@ int Atom::add_custom(const char *name, int flag)
     nivector++;
     iname = (char **) memory->srealloc(iname,nivector*sizeof(char *),
                                        "atom:iname");
-    int n = strlen(name) + 1;
-    iname[index] = new char[n];
-    strcpy(iname[index],name);
+    iname[index] = utils::strdup(name);
     ivector = (int **) memory->srealloc(ivector,nivector*sizeof(int *),
                                         "atom:ivector");
     memory->create(ivector[index],nmax,"atom:ivector");
@@ -2438,9 +2427,7 @@ int Atom::add_custom(const char *name, int flag)
     ndvector++;
     dname = (char **) memory->srealloc(dname,ndvector*sizeof(char *),
                                        "atom:dname");
-    int n = strlen(name) + 1;
-    dname[index] = new char[n];
-    strcpy(dname[index],name);
+    dname[index] = utils::strdup(name);
     dvector = (double **) memory->srealloc(dvector,ndvector*sizeof(double *),
                                            "atom:dvector");
     memory->create(dvector[index],nmax,"atom:dvector");

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -154,11 +154,8 @@ void AtomVec::store_args(int narg, char **arg)
   nargcopy = narg;
   if (nargcopy) argcopy = new char*[nargcopy];
   else argcopy = nullptr;
-  for (int i = 0; i < nargcopy; i++) {
-    int n = strlen(arg[i]) + 1;
-    argcopy[i] = new char[n];
-    strcpy(argcopy[i],arg[i]);
-  }
+  for (int i = 0; i < nargcopy; i++)
+    argcopy[i] = utils::strdup(arg[i]);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/atom_vec_hybrid.cpp
+++ b/src/atom_vec_hybrid.cpp
@@ -109,8 +109,7 @@ void AtomVecHybrid::process_args(int narg, char **arg)
       if (strcmp(arg[iarg],keywords[i]) == 0)
         error->all(FLERR,"Atom style hybrid cannot use same atom style twice");
     styles[nstyles] = atom->new_avec(arg[iarg],1,dummy);
-    keywords[nstyles] = new char[strlen(arg[iarg])+1];
-    strcpy(keywords[nstyles],arg[iarg]);
+    keywords[nstyles] = utils::strdup(arg[iarg]);
     jarg = iarg + 1;
     while (jarg < narg && !known_style(arg[jarg])) jarg++;
     styles[nstyles]->process_args(jarg-iarg-1,&arg[iarg+1]);
@@ -601,13 +600,10 @@ void AtomVecHybrid::build_styles()
 
   allstyles = new char*[nallstyles];
 
-  int n;
   nallstyles = 0;
 #define ATOM_CLASS
-#define AtomStyle(key,Class)                \
-  n = strlen(#key) + 1;                     \
-  allstyles[nallstyles] = new char[n];      \
-  strcpy(allstyles[nallstyles],#key);       \
+#define AtomStyle(key,Class)                   \
+  allstyles[nallstyles] = utils::strdup(#key); \
   nallstyles++;
 #include "style_atom.h"  // IWYU pragma: keep
 #undef AtomStyle

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -20,9 +20,7 @@ using namespace LAMMPS_NS;
 
 Body::Body(LAMMPS *lmp, int /*narg*/, char **arg) : Pointers(lmp)
 {
-  int n = strlen(arg[0]) + 1;
-  style = new char[n];
-  strcpy(style,arg[0]);
+  style = utils::strdup(arg[0]);
   icp = nullptr;
   dcp = nullptr;
 }

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -149,16 +149,11 @@ void Comm::copy_arrays(Comm *oldcomm)
     memcpy(cutusermulti,oldcomm->cutusermulti,atom->ntypes+1);
   }
 
-  if (customfile) {
-    int n = strlen(oldcomm->customfile) + 1;
-    customfile = new char[n];
-    strcpy(customfile,oldcomm->customfile);
-  }
-  if (outfile) {
-    int n = strlen(oldcomm->outfile) + 1;
-    outfile = new char[n];
-    strcpy(outfile,oldcomm->outfile);
-  }
+  if (customfile)
+    customfile = utils::strdup(oldcomm->customfile);
+
+  if (outfile)
+    outfile = utils::strdup(oldcomm->outfile);
 }
 
 /* ----------------------------------------------------------------------
@@ -391,9 +386,7 @@ void Comm::set_processors(int narg, char **arg)
         if (iarg+3 > narg) error->all(FLERR,"Illegal processors command");
         gridflag = CUSTOM;
         delete [] customfile;
-        int n = strlen(arg[iarg+2]) + 1;
-        customfile = new char[n];
-        strcpy(customfile,arg[iarg+2]);
+        customfile = utils::strdup(arg[iarg+2]);
         iarg += 1;
 
       } else error->all(FLERR,"Illegal processors command");
@@ -453,9 +446,7 @@ void Comm::set_processors(int narg, char **arg)
     } else if (strcmp(arg[iarg],"file") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal processors command");
       delete [] outfile;
-      int n = strlen(arg[iarg+1]) + 1;
-      outfile = new char[n];
-      strcpy(outfile,arg[iarg+1]);
+      outfile = utils::strdup(arg[iarg+1]);
       iarg += 2;
 
     } else error->all(FLERR,"Illegal processors command");

--- a/src/dump_atom.cpp
+++ b/src/dump_atom.cpp
@@ -51,9 +51,8 @@ void DumpAtom::init_style()
   if (format_line_user) {
     format = utils::strdup(std::string(format_line_user) + "\n");
   } else {
-    char *str;
-    if (image_flag == 0) format = utils::strdup(TAGINT_FORMAT " %d %g %g %g");
-    else format = utils::strdup(TAGINT_FORMAT " %d %g %g %g %d %d %d");
+    if (image_flag == 0) format = utils::strdup(TAGINT_FORMAT " %d %g %g %g\n");
+    else format = utils::strdup(TAGINT_FORMAT " %d %g %g %g %d %d %d\n");
   }
 
   // setup boundary string

--- a/src/dump_atom.cpp
+++ b/src/dump_atom.cpp
@@ -47,20 +47,13 @@ void DumpAtom::init_style()
   // format = copy of default or user-specified line format
   // default depends on image flags
 
-  delete [] format;
+  delete[] format;
   if (format_line_user) {
-    int n = strlen(format_line_user) + 2;
-    format = new char[n];
-    strcpy(format,format_line_user);
-    strcat(format,"\n");
+    format = utils::strdup(std::string(format_line_user) + "\n");
   } else {
     char *str;
-    if (image_flag == 0) str = (char *) TAGINT_FORMAT " %d %g %g %g";
-    else str = (char *) TAGINT_FORMAT " %d %g %g %g %d %d %d";
-    int n = strlen(str) + 2;
-    format = new char[n];
-    strcpy(format,str);
-    strcat(format,"\n");
+    if (image_flag == 0) format = utils::strdup(TAGINT_FORMAT " %d %g %g %g");
+    else format = utils::strdup(TAGINT_FORMAT " %d %g %g %g %d %d %d");
   }
 
   // setup boundary string

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -31,6 +31,7 @@
 #include "memory.h"
 #include "modify.h"
 #include "molecule.h"
+#include "tokenizer.h"
 #include "variable.h"
 
 #include <cmath>
@@ -1207,32 +1208,19 @@ int DumpImage::modify_param(int narg, char **arg)
     int nlo,nhi;
     utils::bounds(FLERR,arg[1],1,atom->ntypes,nlo,nhi,error);
 
-    // ptrs = list of ncount colornames separated by '/'
+    // get list of colors
+    auto colors = Tokenizer(arg[2],"/").as_vector();
+    const int ncolors = colors.size();
 
-    int ncount = 1;
-    char *nextptr;
-    char *ptr = arg[2];
-    while ((nextptr = strchr(ptr,'/'))) {
-      ptr = nextptr + 1;
-      ncount++;
-    }
-    char **ptrs = new char*[ncount+1];
-    ncount = 0;
-    ptrs[ncount++] = strtok(arg[2],"/");
-    while ((ptrs[ncount++] = strtok(nullptr,"/")));
-    ncount--;
-
-    // assign each of ncount colors in round-robin fashion to types
+    // assign colors in round-robin fashion to types
 
     int m = 0;
     for (int i = nlo; i <= nhi; i++) {
-      colortype[i] = image->color2rgb(ptrs[m%ncount]);
+      colortype[i] = image->color2rgb(colors[m%ncolors].c_str());
       if (colortype[i] == nullptr)
         error->all(FLERR,"Invalid color in dump_modify command");
       m++;
     }
-
-    delete [] ptrs;
     return 3;
   }
 

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -26,8 +26,6 @@
 
 using namespace LAMMPS_NS;
 
-enum{INT,DOUBLE};
-
 #define ONEFIELD 32
 #define DELTA 1048576
 
@@ -93,8 +91,8 @@ DumpLocal::DumpLocal(LAMMPS *lmp, int narg, char **arg) :
   format_default[0] = '\0';
 
   for (int i = 0; i < size_one; i++) {
-    if (vtype[i] == INT) strcat(format_default,"%d ");
-    else if (vtype[i] == DOUBLE) strcat(format_default,"%g ");
+    if (vtype[i] == Dump::INT) strcat(format_default,"%d ");
+    else if (vtype[i] == Dump::DOUBLE) strcat(format_default,"%g ");
     vformat[i] = nullptr;
   }
 
@@ -177,11 +175,12 @@ void DumpLocal::init_style()
 
     if (format_column_user[i])
       vformat[i] = utils::strdup(std::string(format_column_user[i]) + " ");
-    else if (vtype[i] == INT && format_int_user)
+    else if (vtype[i] == Dump::INT && format_int_user)
       vformat[i] = utils::strdup(std::string(format_int_user) + " ");
-    else if (vtype[i] == DOUBLE && format_float_user)
+    else if (vtype[i] == Dump::DOUBLE && format_float_user)
       vformat[i] = utils::strdup(std::string(format_float_user) + " ");
     else vformat[i] = utils::strdup(word + " ");
+    ++i;
   }
 
   // setup boundary string
@@ -334,7 +333,7 @@ int DumpLocal::convert_string(int n, double *mybuf)
     }
 
     for (j = 0; j < size_one; j++) {
-      if (vtype[j] == INT)
+      if (vtype[j] == Dump::INT)
         offset += sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
       else
         offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
@@ -369,7 +368,7 @@ void DumpLocal::write_lines(int n, double *mybuf)
   int m = 0;
   for (i = 0; i < n; i++) {
     for (j = 0; j < size_one; j++) {
-      if (vtype[j] == INT) fprintf(fp,vformat[j],static_cast<int> (mybuf[m]));
+      if (vtype[j] == Dump::INT) fprintf(fp,vformat[j],static_cast<int> (mybuf[m]));
       else fprintf(fp,vformat[j],mybuf[m]);
       m++;
     }
@@ -389,13 +388,13 @@ void DumpLocal::parse_fields(int narg, char **arg)
 
     if (strcmp(arg[iarg],"index") == 0) {
       pack_choice[iarg] = &DumpLocal::pack_index;
-      vtype[iarg] = INT;
+      vtype[iarg] = Dump::INT;
 
     } else {
       int n;
       ArgInfo argi(arg[iarg],ArgInfo::COMPUTE|ArgInfo::FIX);
       computefixflag = 1;
-      vtype[iarg] = DOUBLE;
+      vtype[iarg] = Dump::DOUBLE;
       argindex[iarg] = argi.get_index1();
 
       switch (argi.get_type()) {

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -327,8 +327,9 @@ void FixPropertyAtom::write_data_section_pack(int /*mth*/, double **buf)
 }
 
 /* ----------------------------------------------------------------------
-   write section keyword for Mth data section to file
-   use Molecules or Charges if that is only field, else use fix ID
+   write a Molecules or Charges section if that is only field
+   manages by this fix instance. Otherwise write everything
+   to the section labeled by the fix ID
    only called by proc 0
 ------------------------------------------------------------------------- */
 
@@ -336,7 +337,18 @@ void FixPropertyAtom::write_data_section_keyword(int /*mth*/, FILE *fp)
 {
   if (nvalue == 1 && style[0] == MOLECULE) fprintf(fp,"\nMolecules\n\n");
   else if (nvalue == 1 && style[0] == CHARGE) fprintf(fp,"\nCharges\n\n");
-  else fprintf(fp,"\n%s\n\n",id);
+  else {
+    fprintf(fp,"\n%s #",id);
+    // write column hint as comment
+    for (int i = 0; i < nvalue; ++i) {
+      if (style[i] == MOLECULE) fputs(" mol",fp);
+      else if (style[i] == CHARGE) fputs(" q",fp);
+      else if (style[i] == RMASS) fputs(" rmass",fp);
+      else if (style[i] == INTEGER) fprintf(fp," i_%s", atom->iname[index[i]]);
+      else if (style[i] == DOUBLE) fprintf(fp, " d_%s", atom->dname[index[i]]);
+    }
+    fputs("\n\n",fp);
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -311,11 +311,11 @@ void Group::assign(int narg, char **arg)
         try {
           ValueTokenizer values(arg[iarg],":");
           start = values.next_tagint();
-          if (utils::strmatch(arg[iarg],"^\\d+$")) {
+          if (utils::strmatch(arg[iarg],"^-?\\d+$")) {
             stop = start;
-          } else if (utils::strmatch(arg[iarg],"^\\d+:\\d+$")) {
+          } else if (utils::strmatch(arg[iarg],"^-?\\d+:-?\\d+$")) {
             stop = values.next_tagint();
-          } else if (utils::strmatch(arg[iarg],"^\\d+:\\d+:\\d+$")) {
+          } else if (utils::strmatch(arg[iarg],"^-?\\d+:-?\\d+:\\d+$")) {
             stop = values.next_tagint();
             delta = values.next_tagint();
           } else throw TokenizerException("Syntax error","");

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -303,18 +303,21 @@ void Group::assign(int narg, char **arg)
       else if (category == MOLECULE) tattribute = atom->molecule;
       else if (category == ID) tattribute = atom->tag;
 
-      char *ptr;
+      char *ptr,*end;
       tagint start,stop,delta;
 
       for (int iarg = 2; iarg < narg; iarg++) {
         delta = 1;
-        if (strchr(arg[iarg],':')) {
-          ptr = strtok(arg[iarg],":");
+        ptr = arg[iarg];
+        end = ptr + strlen(ptr)+1;
+        if (strchr(ptr,':')) {
+          ptr[strcspn(ptr,":")] = '\0';
           start = utils::tnumeric(FLERR,ptr,false,lmp);
-          ptr = strtok(nullptr,":");
+          ptr += strlen(ptr)+1;
+          if (strchr(ptr,':')) ptr[strcspn(ptr,":")] = '\0';
           stop = utils::tnumeric(FLERR,ptr,false,lmp);
-          ptr = strtok(nullptr,":");
-          if (ptr) delta = utils::tnumeric(FLERR,ptr,false,lmp);
+          ptr += strlen(ptr)+1;
+          if (ptr < end) delta = utils::tnumeric(FLERR,ptr,false,lmp);
         } else {
           start = stop = utils::tnumeric(FLERR,arg[iarg],false,lmp);
         }

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -312,7 +312,7 @@ void Group::assign(int narg, char **arg)
           ValueTokenizer values(arg[iarg],":");
           start = values.next_tagint();
           if (utils::strmatch(arg[iarg],"^\\d+$")) {
-            start = stop;
+            stop = start;
           } else if (utils::strmatch(arg[iarg],"^\\d+:\\d+$")) {
             stop = values.next_tagint();
           } else if (utils::strmatch(arg[iarg],"^\\d+:\\d+:\\d+$")) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1076,22 +1076,20 @@ void Input::partition()
   int ilo,ihi;
   utils::bounds(FLERR,arg[1],1,universe->nworlds,ilo,ihi,error);
 
-  // copy original line to copy, since will use strtok() on it
-  // ptr = start of 4th word
+  // new command starts at the 3rd argument,
+  // which must not be another partition command
 
-  strcpy(copy,line);
-  char *ptr = strtok(copy," \t\n\r\f");
-  ptr = strtok(nullptr," \t\n\r\f");
-  ptr = strtok(nullptr," \t\n\r\f");
-  ptr += strlen(ptr) + 1;
-  ptr += strspn(ptr," \t\n\r\f");
+  if (strcmp(arg[2],"partition") == 0)
+    error->all(FLERR,"Illegal partition command");
+
+  char *cmd = strstr(line,arg[2]);
 
   // execute the remaining command line on requested partitions
 
   if (yesflag) {
-    if (universe->iworld+1 >= ilo && universe->iworld+1 <= ihi) one(ptr);
+    if (universe->iworld+1 >= ilo && universe->iworld+1 <= ihi) one(cmd);
   } else {
-    if (universe->iworld+1 < ilo || universe->iworld+1 > ihi) one(ptr);
+    if (universe->iworld+1 < ilo || universe->iworld+1 > ihi) one(cmd);
   }
 }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -445,26 +445,14 @@ is passed to :cpp:func:`lammps_commands_string` for processing.
 void lammps_commands_list(void *handle, int ncmd, const char **cmds)
 {
   LAMMPS *lmp = (LAMMPS *) handle;
-
-  int n = ncmd+1;
-  for (int i = 0; i < ncmd; i++) n += strlen(cmds[i]);
-
-  char *str = (char *) lmp->memory->smalloc(n,"lib/commands/list:str");
-  str[0] = '\0';
-  n = 0;
+  std::string allcmds;
 
   for (int i = 0; i < ncmd; i++) {
-    strcpy(&str[n],cmds[i]);
-    n += strlen(cmds[i]);
-    if (str[n-1] != '\n') {
-      str[n] = '\n';
-      str[n+1] = '\0';
-      n++;
-    }
+    allcmds.append(cmds[i]);
+    if (allcmds.back() != '\n') allcmds.append(1,'\n');
   }
 
-  lammps_commands_string(handle,str);
-  lmp->memory->sfree(str);
+  lammps_commands_string(handle,allcmds.c_str());
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -995,18 +995,14 @@ void Modify::replace_fix(const char *replaceID,
   if (jfix >= 0) error->all(FLERR,"Replace_fix ID is already in use");
 
   delete [] fix[ifix]->id;
-  int n = strlen(arg[0]) + 1;
-  fix[ifix]->id = new char[n];
-  strcpy(fix[ifix]->id,arg[0]);
+  fix[ifix]->id = utils::strdup(arg[0]);
 
   int jgroup = group->find(arg[1]);
   if (jgroup == -1) error->all(FLERR,"Could not find replace_fix group ID");
   fix[ifix]->igroup = jgroup;
 
   delete [] fix[ifix]->style;
-  n = strlen(arg[2]) + 1;
-  fix[ifix]->style = new char[n];
-  strcpy(fix[ifix]->style,arg[2]);
+  fix[ifix]->style = utils::strdup(arg[2]);
 
   // invoke add_fix
   // it will find and overwrite the replaceID fix

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -766,12 +766,8 @@ void Output::create_restart(int narg, char **arg)
     delete [] restart2a;
     delete [] restart2b;
     restart_toggle = 0;
-    int n = strlen(arg[1]) + 3;
-    restart2a = new char[n];
-    strcpy(restart2a,arg[1]);
-    n = strlen(arg[2]) + 1;
-    restart2b = new char[n];
-    strcpy(restart2b,arg[2]);
+    restart2a = utils::strdup(arg[1]);
+    restart2b = utils::strdup(arg[2]);
   }
 
   // check for multiproc output and an MPI-IO filename

--- a/src/pair_coul_streitz.cpp
+++ b/src/pair_coul_streitz.cpp
@@ -164,9 +164,7 @@ void PairCoulStreitz::coeff(int narg, char **arg)
       if (strcmp(arg[i],elements[j]) == 0) break;
     map[i-2] = j;
     if (j == nelements) {
-      n = strlen(arg[i]) + 1;
-      elements[j] = new char[n];
-      strcpy(elements[j],arg[i]);
+      elements[j] = utils::strdup(arg[i]);
       nelements++;
     }
   }

--- a/src/procmap.cpp
+++ b/src/procmap.cpp
@@ -22,6 +22,7 @@
 #include "error.h"
 #include "math_extra.h"
 #include "memory.h"
+#include "tokenizer.h"
 #include "universe.h"
 
 #include <cmath>
@@ -300,12 +301,16 @@ void ProcMap::custom_grid(char *cfile, int nprocs,
     }
   }
 
-  int n = strlen(line) + 1;
-  MPI_Bcast(&n,1,MPI_INT,0,world);
-  MPI_Bcast(line,n,MPI_CHAR,0,world);
-
-  int rv = sscanf(line,"%d %d %d",&procgrid[0],&procgrid[1],&procgrid[2]);
-  if (rv != 3) error->all(FLERR,"Processors custom grid file is inconsistent");
+  MPI_Bcast(line,MAXLINE,MPI_CHAR,0,world);
+  try {
+    ValueTokenizer procs(line);
+    procgrid[0] = procs.next_int();
+    procgrid[1] = procs.next_int();
+    procgrid[2] = procs.next_int();
+  } catch (TokenizerException &e) {
+    error->all(FLERR,fmt::format("Processors custom grid file "
+                                 "is inconsistent: {}", e.what()));
+  }
 
   int flag = 0;
   if (procgrid[0]*procgrid[1]*procgrid[2] != nprocs) flag = 1;
@@ -324,10 +329,17 @@ void ProcMap::custom_grid(char *cfile, int nprocs,
     for (int i = 0; i < nprocs; i++) {
       if (!fgets(line,MAXLINE,fp))
         error->one(FLERR,"Unexpected end of custom file");
-      rv = sscanf(line,"%d %d %d %d",
-                  &cmap[i][0],&cmap[i][1],&cmap[i][2],&cmap[i][3]);
-      if (rv != 4)
-        error->one(FLERR,"Processors custom grid file is inconsistent");
+
+      try {
+        ValueTokenizer pmap(line);
+        cmap[i][0] = pmap.next_int();
+        cmap[i][1] = pmap.next_int();
+        cmap[i][2] = pmap.next_int();
+        cmap[i][3] = pmap.next_int();
+      } catch (TokenizerException &e) {
+        error->one(FLERR,fmt::format("Processors custom grid file is "
+                                     "inconsistent: {}", e.what()));
+      }
     }
     fclose(fp);
   }

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -2053,7 +2053,7 @@ void ReadData::skip_lines(bigint n)
 }
 
 /* ----------------------------------------------------------------------
-   parse a line of coeffs into words, storing them in narg,arg
+   parse a line of coeffs into words, storing them in ncoeffarg,coeffarg
    trim anything from '#' onward
    word strings remain in line, are not copied
    if addstr != nullptr, add addstr as extra arg for class2 angle/dihedral/improper
@@ -2069,33 +2069,38 @@ void ReadData::parse_coeffs(char *line, const char *addstr,
   char *ptr;
   if ((ptr = strchr(line,'#'))) *ptr = '\0';
 
-  narg = 0;
-  char *word = strtok(line," \t\n\r\f");
-  while (word) {
-    if (narg == maxarg) {
-      maxarg += DELTA;
-      arg = (char **)
-        memory->srealloc(arg,maxarg*sizeof(char *),"read_data:arg");
+  ncoeffarg = 0;
+  char *word = line;
+  char *end = line + strlen(line)+1;
+
+  while (word < end) {
+    word += strspn(word," \t\r\n\f");
+    word[strcspn(word," \t\r\n\f")] = '\0';
+    if (strlen(word) == 0) break;
+    if (ncoeffarg == maxcoeffarg) {
+      maxcoeffarg += DELTA;
+      coeffarg = (char **)
+        memory->srealloc(coeffarg,maxcoeffarg*sizeof(char *),"read_data:coeffarg");
     }
-    if (addstr && narg == 1 && !islower(word[0])) arg[narg++] = (char *) addstr;
-    arg[narg++] = word;
-    if (addstr && narg == 2 && islower(word[0])) arg[narg++] = (char *) addstr;
-    if (dupflag && narg == 1) arg[narg++] = word;
-    word = strtok(nullptr," \t\n\r\f");
+    if (addstr && ncoeffarg == 1 && !islower(word[0])) coeffarg[ncoeffarg++] = (char *) addstr;
+    coeffarg[ncoeffarg++] = word;
+    if (addstr && ncoeffarg == 2 && islower(word[0])) coeffarg[ncoeffarg++] = (char *) addstr;
+    if (dupflag && ncoeffarg == 1) coeffarg[ncoeffarg++] = word;
+    word += strlen(word)+1;
   }
 
   // to avoid segfaults on empty lines
 
-  if (narg == 0) return;
+  if (ncoeffarg == 0) return;
 
   if (noffset) {
-    int value = utils::inumeric(FLERR,arg[0],false,lmp);
+    int value = utils::inumeric(FLERR,coeffarg[0],false,lmp);
     sprintf(argoffset1,"%d",value+offset);
-    arg[0] = argoffset1;
+    coeffarg[0] = argoffset1;
     if (noffset == 2) {
-      value = utils::inumeric(FLERR,arg[1],false,lmp);
+      value = utils::inumeric(FLERR,coeffarg[1],false,lmp);
       sprintf(argoffset2,"%d",value+offset);
-      arg[1] = argoffset2;
+      coeffarg[1] = argoffset2;
     }
   }
 }

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -73,8 +73,8 @@ ReadData::ReadData(LAMMPS *lmp) : Pointers(lmp)
   keyword = new char[MAXLINE];
   style = new char[MAXLINE];
   buffer = new char[CHUNK*MAXLINE];
-  narg = maxarg = 0;
-  arg = nullptr;
+  ncoeffarg = maxcoeffarg = 0;
+  coeffarg = nullptr;
   fp = nullptr;
 
   // customize for new sections
@@ -98,7 +98,7 @@ ReadData::~ReadData()
   delete [] keyword;
   delete [] style;
   delete [] buffer;
-  memory->sfree(arg);
+  memory->sfree(coeffarg);
 
   for (int i = 0; i < nfix; i++) {
     delete [] fix_header[i];
@@ -1760,9 +1760,9 @@ void ReadData::paircoeffs()
     next = strchr(buf,'\n');
     *next = '\0';
     parse_coeffs(buf,nullptr,1,2,toffset);
-    if (narg == 0)
+    if (ncoeffarg == 0)
       error->all(FLERR,"Unexpected empty line in PairCoeffs section");
-    force->pair->coeff(narg,arg);
+    force->pair->coeff(ncoeffarg,coeffarg);
     buf = next + 1;
   }
   delete [] original;
@@ -1787,9 +1787,9 @@ void ReadData::pairIJcoeffs()
       next = strchr(buf,'\n');
       *next = '\0';
       parse_coeffs(buf,nullptr,0,2,toffset);
-      if (narg == 0)
+      if (ncoeffarg == 0)
         error->all(FLERR,"Unexpected empty line in PairCoeffs section");
-      force->pair->coeff(narg,arg);
+      force->pair->coeff(ncoeffarg,coeffarg);
       buf = next + 1;
     }
   delete [] original;
@@ -1812,9 +1812,9 @@ void ReadData::bondcoeffs()
     next = strchr(buf,'\n');
     *next = '\0';
     parse_coeffs(buf,nullptr,0,1,boffset);
-    if (narg == 0)
+    if (ncoeffarg == 0)
       error->all(FLERR,"Unexpected empty line in BondCoeffs section");
-    force->bond->coeff(narg,arg);
+    force->bond->coeff(ncoeffarg,coeffarg);
     buf = next + 1;
   }
   delete [] original;
@@ -1839,8 +1839,8 @@ void ReadData::anglecoeffs(int which)
     if (which == 0) parse_coeffs(buf,nullptr,0,1,aoffset);
     else if (which == 1) parse_coeffs(buf,"bb",0,1,aoffset);
     else if (which == 2) parse_coeffs(buf,"ba",0,1,aoffset);
-    if (narg == 0) error->all(FLERR,"Unexpected empty line in AngleCoeffs section");
-    force->angle->coeff(narg,arg);
+    if (ncoeffarg == 0) error->all(FLERR,"Unexpected empty line in AngleCoeffs section");
+    force->angle->coeff(ncoeffarg,coeffarg);
     buf = next + 1;
   }
   delete [] original;
@@ -1868,9 +1868,9 @@ void ReadData::dihedralcoeffs(int which)
     else if (which == 3) parse_coeffs(buf,"at",0,1,doffset);
     else if (which == 4) parse_coeffs(buf,"aat",0,1,doffset);
     else if (which == 5) parse_coeffs(buf,"bb13",0,1,doffset);
-    if (narg == 0)
+    if (ncoeffarg == 0)
       error->all(FLERR,"Unexpected empty line in DihedralCoeffs section");
-    force->dihedral->coeff(narg,arg);
+    force->dihedral->coeff(ncoeffarg,coeffarg);
     buf = next + 1;
   }
   delete [] original;
@@ -1894,8 +1894,8 @@ void ReadData::impropercoeffs(int which)
     *next = '\0';
     if (which == 0) parse_coeffs(buf,nullptr,0,1,ioffset);
     else if (which == 1) parse_coeffs(buf,"aa",0,1,ioffset);
-    if (narg == 0) error->all(FLERR,"Unexpected empty line in ImproperCoeffs section");
-    force->improper->coeff(narg,arg);
+    if (ncoeffarg == 0) error->all(FLERR,"Unexpected empty line in ImproperCoeffs section");
+    force->improper->coeff(ncoeffarg,coeffarg);
     buf = next + 1;
   }
   delete [] original;

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -278,14 +278,8 @@ void ReadData::command(int narg, char **arg)
       if (fix_index[nfix] < 0)
         error->all(FLERR,"Fix ID for read_data does not exist");
       if (strcmp(arg[iarg+2],"NULL") == 0) fix_header[nfix] = nullptr;
-      else {
-        int n = strlen(arg[iarg+2]) + 1;
-        fix_header[nfix] = new char[n];
-        strcpy(fix_header[nfix],arg[iarg+2]);
-      }
-      int n = strlen(arg[iarg+3]) + 1;
-      fix_section[nfix] = new char[n];
-      strcpy(fix_section[nfix],arg[iarg+3]);
+      else fix_header[nfix] = utils::strdup(arg[iarg+2]);
+      fix_section[nfix] = utils::strdup(arg[iarg+3]);
       nfix++;
       iarg += 4;
 

--- a/src/read_data.h
+++ b/src/read_data.h
@@ -34,8 +34,8 @@ class ReadData : protected Pointers {
   int me,compressed;
   char *line,*keyword,*buffer,*style;
   FILE *fp;
-  char **arg;
-  int narg,maxarg;
+  char **coeffarg;
+  int ncoeffarg,maxcoeffarg;
   char argoffset1[8],argoffset2[8];
 
   bigint id_offset, mol_offset;

--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -64,9 +64,7 @@ ReadDump::ReadDump(LAMMPS *lmp) : Pointers(lmp)
   fields = nullptr;
   buf = nullptr;
 
-  int n = strlen("native") + 1;
-  readerstyle = new char[n];
-  strcpy(readerstyle,"native");
+  readerstyle = utils::strdup("native");
 
   nreader = 0;
   readers = nullptr;
@@ -182,9 +180,7 @@ void ReadDump::store_files(int nstr, char **str)
   // either all or none of files must have '%' wild-card
 
   for (int i = 0; i < nfile; i++) {
-    int n = strlen(str[i]) + 1;
-    files[i] = new char[n];
-    strcpy(files[i],str[i]);
+    files[i] = utils::strdup(str[i]);
 
     if (i == 0) {
       if (strchr(files[i],'%')) multiproc = 1;
@@ -1258,9 +1254,7 @@ int ReadDump::fields_and_keywords(int narg, char **arg)
       for (i = 0; i < nfield; i++)
         if (type == fieldtype[i]) break;
       if (i == nfield) error->all(FLERR,"Illegal read_dump command");
-      int n = strlen(arg[iarg+2]) + 1;
-      fieldlabel[i] = new char[n];
-      strcpy(fieldlabel[i],arg[iarg+2]);
+      fieldlabel[i] = utils::strdup(arg[iarg+2]);
       iarg += 3;
     } else if (strcmp(arg[iarg],"scaled") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal read_dump command");
@@ -1277,9 +1271,7 @@ int ReadDump::fields_and_keywords(int narg, char **arg)
     } else if (strcmp(arg[iarg],"format") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal read_dump command");
       delete [] readerstyle;
-      int n = strlen(arg[iarg+1]) + 1;
-      readerstyle = new char[n];
-      strcpy(readerstyle,arg[iarg+1]);
+      readerstyle = utils::strdup(arg[iarg+1]);
       iarg += 2;
       break;
     } else error->all(FLERR,"Illegal read_dump command");

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -33,13 +33,8 @@ Region::Region(LAMMPS *lmp, int /*narg*/, char **arg) :
   id(nullptr), style(nullptr), contact(nullptr), list(nullptr),
   xstr(nullptr), ystr(nullptr), zstr(nullptr), tstr(nullptr)
 {
-  int n = strlen(arg[0]) + 1;
-  id = new char[n];
-  strcpy(id,arg[0]);
-
-  n = strlen(arg[1]) + 1;
-  style = new char[n];
-  strcpy(style,arg[1]);
+  id = utils::strdup(arg[0]);
+  style = utils::strdup(arg[1]);
 
   varshape = 0;
   xstr = ystr = zstr = tstr = nullptr;
@@ -338,23 +333,17 @@ void Region::options(int narg, char **arg)
       if (strcmp(arg[iarg+1],"NULL") != 0) {
         if (strstr(arg[iarg+1],"v_") != arg[iarg+1])
           error->all(FLERR,"Illegal region command");
-        int n = strlen(&arg[iarg+1][2]) + 1;
-        xstr = new char[n];
-        strcpy(xstr,&arg[iarg+1][2]);
+        xstr = utils::strdup(&arg[iarg+1][2]);
       }
       if (strcmp(arg[iarg+2],"NULL") != 0) {
         if (strstr(arg[iarg+2],"v_") != arg[iarg+2])
           error->all(FLERR,"Illegal region command");
-        int n = strlen(&arg[iarg+2][2]) + 1;
-        ystr = new char[n];
-        strcpy(ystr,&arg[iarg+2][2]);
+        ystr = utils::strdup(&arg[iarg+2][2]);
       }
       if (strcmp(arg[iarg+3],"NULL") != 0) {
         if (strstr(arg[iarg+3],"v_") != arg[iarg+3])
           error->all(FLERR,"Illegal region command");
-        int n = strlen(&arg[iarg+3][2]) + 1;
-        zstr = new char[n];
-        strcpy(zstr,&arg[iarg+3][2]);
+        zstr = utils::strdup(&arg[iarg+3][2]);
       }
       moveflag = 1;
       iarg += 4;
@@ -363,9 +352,7 @@ void Region::options(int narg, char **arg)
       if (iarg+8 > narg) error->all(FLERR,"Illegal region command");
       if (strstr(arg[iarg+1],"v_") != arg[iarg+1])
         error->all(FLERR,"Illegal region command");
-      int n = strlen(&arg[iarg+1][2]) + 1;
-      tstr = new char[n];
-      strcpy(tstr,&arg[iarg+1][2]);
+      tstr = utils::strdup(&arg[iarg+1][2]);
       point[0] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       point[1] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       point[2] = utils::numeric(FLERR,arg[iarg+4],false,lmp);

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -39,12 +39,9 @@ RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
   list = new int[n];
   nregion = 0;
 
-  int m,iregion;
   for (int iarg = 0; iarg < n; iarg++) {
-    m = strlen(arg[iarg+3]) + 1;
-    idsub[nregion] = new char[m];
-    strcpy(idsub[nregion],arg[iarg+3]);
-    iregion = domain->find_region(idsub[nregion]);
+    idsub[nregion] = utils::strdup(arg[iarg+3]);
+    int iregion = domain->find_region(idsub[nregion]);
     if (iregion == -1)
       error->all(FLERR,"Region intersect region ID does not exist");
     list[nregion++] = iregion;
@@ -123,9 +120,8 @@ void RegIntersect::init()
   // re-build list of sub-regions in case other regions were deleted
   // error if a sub-region was deleted
 
-  int iregion;
   for (int ilist = 0; ilist < nregion; ilist++) {
-    iregion = domain->find_region(idsub[ilist]);
+    int iregion = domain->find_region(idsub[ilist]);
     if (iregion == -1)
       error->all(FLERR,"Region union region ID does not exist");
     list[ilist] = iregion;

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -40,12 +40,9 @@ RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg),
   list = new int[n];
   nregion = 0;
 
-  int m,iregion;
   for (int iarg = 0; iarg < n; iarg++) {
-    m = strlen(arg[iarg+3]) + 1;
-    idsub[nregion] = new char[m];
-    strcpy(idsub[nregion],arg[iarg+3]);
-    iregion = domain->find_region(idsub[nregion]);
+    idsub[nregion] = utils::strdup(arg[iarg+3]);
+    int iregion = domain->find_region(idsub[nregion]);
     if (iregion == -1)
       error->all(FLERR,"Region union region ID does not exist");
     list[nregion++] = iregion;
@@ -117,9 +114,8 @@ void RegUnion::init()
   // re-build list of sub-regions in case other regions were deleted
   // error if a sub-region was deleted
 
-  int iregion;
   for (int ilist = 0; ilist < nregion; ilist++) {
-    iregion = domain->find_region(idsub[ilist]);
+    int iregion = domain->find_region(idsub[ilist]);
     if (iregion == -1)
       error->all(FLERR,"Region union region ID does not exist");
     list[ilist] = iregion;

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -145,9 +145,7 @@ void Run::command(int narg, char **arg)
     commands = new char*[ncommands];
     ncommands = 0;
     for (int i = first; i <= last; i++) {
-      int n = strlen(arg[i]) + 1;
-      commands[ncommands] = new char[n];
-      strcpy(commands[ncommands],arg[i]);
+      commands[ncommands] = utils::strdup(arg[i]);
       ncommands++;
     }
   }

--- a/src/text_file_reader.cpp
+++ b/src/text_file_reader.cpp
@@ -96,10 +96,7 @@ char *TextFileReader::next_line(int nparams) {
   if (ignore_comments && (ptr = strchr(line, '#'))) *ptr = '\0';
 
   nwords = utils::count_words(line);
-
-  if (nwords > 0) {
-    n = strlen(line);
-  }
+  if (nwords > 0) n = strlen(line);
 
   while (nwords == 0 || nwords < nparams) {
     char *ptr = fgets(&line[n], MAXLINE - n, fp);

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -125,12 +125,12 @@ Thermo::Thermo(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
     int nvalues = utils::expand_args(FLERR,narg-1,&arg[1],0,earg,lmp);
     if (earg != &arg[1]) expand = 1;
 
-    std::string concat;
+    line = new char[256+nvalues*64];
+    line[0] = '\0';
     for (int iarg = 0; iarg < nvalues; iarg++) {
-      concat += earg[iarg];
-      concat += " ";
+      strcat(line,earg[iarg]);
+      strcat(line," ");
     }
-    line = utils::strdup(concat);
     line[strlen(line)-1] = '\0';
 
     // if wildcard expansion occurred, free earg memory from exapnd_args()

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -200,7 +200,7 @@ std::string ValueTokenizer::next_string() {
     if (has_next()) {
         std::string value = tokens.next();
         return value;
-    }
+    } throw TokenizerException("Not enough tokens","");
     return "";
 }
 
@@ -216,7 +216,7 @@ int ValueTokenizer::next_int() {
         }
         int value = atoi(current.c_str());
         return value;
-    }
+    } throw TokenizerException("Not enough tokens","");
     return 0;
 }
 
@@ -232,7 +232,7 @@ bigint ValueTokenizer::next_bigint() {
         }
         bigint value = ATOBIGINT(current.c_str());
         return value;
-    }
+    } throw TokenizerException("Not enough tokens","");
     return 0;
 }
 
@@ -248,7 +248,7 @@ tagint ValueTokenizer::next_tagint() {
         }
         tagint value = ATOTAGINT(current.c_str());
         return value;
-    }
+    } throw TokenizerException("Not enough tokens","");
     return 0;
 }
 
@@ -264,7 +264,7 @@ double ValueTokenizer::next_double() {
         }
         double value = atof(current.c_str());
         return value;
-    }
+    } throw TokenizerException("Not enough tokens","");
     return 0.0;
 }
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -301,9 +301,7 @@ void Update::set_units(const char *style)
   } else error->all(FLERR,"Illegal units command");
 
   delete [] unit_style;
-  int n = strlen(style) + 1;
-  unit_style = new char[n];
-  strcpy(unit_style,style);
+  unit_style = utils::strdup(style);
 
   // check if timestep was changed from default value
   if (!dt_default && (comm->me == 0)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -418,13 +418,13 @@ void utils::bounds(const char *file, int line, const std::string &str,
       error->all(file,line,fmt::format("Invalid range string: {}",str));
 
     if (nlo < nmin)
-      error->all(file,line,fmt::format("Numeric index {} is out of bounds"
+      error->all(file,line,fmt::format("Numeric index {} is out of bounds "
                                        "({}-{})",nlo,nmin,nmax));
     else if (nhi > nmax)
-      error->all(file,line,fmt::format("Numeric index {} is out of bounds"
+      error->all(file,line,fmt::format("Numeric index {} is out of bounds "
                                        "({}-{})",nhi,nmin,nmax));
     else if (nlo > nhi)
-      error->all(file,line,fmt::format("Numeric index {} is out of bounds"
+      error->all(file,line,fmt::format("Numeric index {} is out of bounds "
                                        "({}-{})",nlo,nmin,nhi));
   }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -554,9 +554,7 @@ int utils::expand_args(const char *file, int line, int narg, char **arg,
         earg = (char **)
           lmp->memory->srealloc(earg,maxarg*sizeof(char *),"input:earg");
       }
-      n = strlen(arg[iarg]) + 1;
-      earg[newarg] = new char[n];
-      strcpy(earg[newarg],arg[iarg]);
+      earg[newarg] = utils::strdup(arg[iarg]);
       newarg++;
     }
   }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -186,9 +186,7 @@ void Variable::set(int narg, char **arg)
       nlast = utils::inumeric(FLERR,arg[2],false,lmp);
       if (nlast <= 0) error->all(FLERR,"Illegal variable command");
       if (narg == 4 && strcmp(arg[3],"pad") == 0) {
-        char digits[12];
-        sprintf(digits,"%d",nlast);
-        pad[nvar] = strlen(digits);
+        pad[nvar] = fmt::format("{}",nlast).size();
       } else pad[nvar] = 0;
     } else if (narg == 4 || (narg == 5 && strcmp(arg[4],"pad") == 0)) {
       nfirst = utils::inumeric(FLERR,arg[2],false,lmp);
@@ -196,9 +194,7 @@ void Variable::set(int narg, char **arg)
       if (nfirst > nlast || nlast < 0)
         error->all(FLERR,"Illegal variable command");
       if (narg == 5 && strcmp(arg[4],"pad") == 0) {
-        char digits[12];
-        sprintf(digits,"%d",nlast);
-        pad[nvar] = strlen(digits);
+        pad[nvar] = fmt::format("{}",nlast).size();
       } else pad[nvar] = 0;
     } else error->all(FLERR,"Illegal variable command");
     num[nvar] = nlast;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -5117,8 +5117,10 @@ int VarReader::read_scalar(char *str)
       if (n == 0) break;                                 // end of file
       str[n-1] = '\0';                                   // strip newline
       if ((ptr = strchr(str,'#'))) *ptr = '\0';          // strip comment
-      if (strtok(str," \t\n\r\f") == nullptr) continue;     // skip if blank
+      str += strspn(" \t\n\r\f");                        // strip whitespace
+      str[strcspn(str," \t\n\r\f")] = '\0';
       n = strlen(str) + 1;
+      if (n == 1) continue;                              // skip if blank
       break;
     }
   }
@@ -5160,8 +5162,10 @@ int VarReader::read_peratom()
       if (n == 0) break;                                 // end of file
       str[n-1] = '\0';                                   // strip newline
       if ((ptr = strchr(str,'#'))) *ptr = '\0';          // strip comment
-      if (strtok(str," \t\n\r\f") == nullptr) continue;     // skip if blank
+      str += strspn(" \t\n\r\f");                        // strip whitespace
+      str[strcspn(str," \t\n\r\f")] = '\0';
       n = strlen(str) + 1;
+      if (n == 1) continue;                              // skip if blank
       break;
     }
   }

--- a/src/write_coeff.cpp
+++ b/src/write_coeff.cpp
@@ -43,11 +43,7 @@ void WriteCoeff::command(int narg, char **arg)
 
   if (narg != 1) error->all(FLERR,"Illegal write_coeff command");
 
-  int n = strlen(arg[0]) + 5;
-  char *file = new char[n];
-
-  strcpy(file,"tmp.");
-  strcat(file,arg[0]);
+  char *file = utils::strdup(fmt::format("tmp.{}",arg[0]));
 
   // initialize relevant styles
   lmp->init();
@@ -114,7 +110,7 @@ void WriteCoeff::command(int narg, char **arg)
       const char *section = (const char *)"";
       fputs(str,two);      // style
       utils::sfgets(FLERR,str,256,one,file,error);  // coeff
-      n = strlen(str);
+      int n = strlen(str);
       strcpy(coeff,str);
       coeff[n-1] = '\0';
       utils::sfgets(FLERR,str,256,one,file,error);

--- a/unittest/commands/test_simple_commands.cpp
+++ b/unittest/commands/test_simple_commands.cpp
@@ -192,6 +192,29 @@ TEST_F(SimpleCommandsTest, Newton)
     ASSERT_EQ(lmp->force->newton_bond, 1);
 }
 
+TEST_F(SimpleCommandsTest, Partition)
+{
+    if (!verbose) ::testing::internal::CaptureStdout();
+    lmp->input->one("echo none");
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+    TEST_FAILURE(".*ERROR: Illegal partition command .*",
+                 lmp->input->one("partition xxx 1 echo none"););
+    TEST_FAILURE(".*ERROR: Numeric index 2 is out of bounds.*",
+                 lmp->input->one("partition yes 2 echo none"););
+
+    ::testing::internal::CaptureStdout();
+    lmp->input->one("partition yes 1 print 'test'");
+    auto text = ::testing::internal::GetCapturedStdout();
+    if (verbose) std::cout << text;
+    ASSERT_THAT(text, StrEq("test\n"));
+
+    ::testing::internal::CaptureStdout();
+    lmp->input->one("partition no 1 print 'test'");
+    text = ::testing::internal::GetCapturedStdout();
+    if (verbose) std::cout << text;
+    ASSERT_THAT(text, StrEq(""));
+}
+
 TEST_F(SimpleCommandsTest, Quit)
 {
     ::testing::internal::CaptureStdout();

--- a/unittest/utils/test_tokenizer.cpp
+++ b/unittest/utils/test_tokenizer.cpp
@@ -102,12 +102,35 @@ TEST(Tokenizer, default_separators)
     ASSERT_EQ(t.count(), 2);
 }
 
-TEST(Tokenizer, as_vector)
+TEST(Tokenizer, as_vector1)
 {
     Tokenizer t(" \r\n test \t word \f");
     std::vector<std::string> list = t.as_vector();
     ASSERT_THAT(list[0], Eq("test"));
     ASSERT_THAT(list[1], Eq("word"));
+}
+
+TEST(Tokenizer, as_vector2)
+{
+    auto list = Tokenizer("a\\b\\c","\\").as_vector();
+    ASSERT_THAT(list[0], Eq("a"));
+    ASSERT_THAT(list[1], Eq("b"));
+    ASSERT_THAT(list[2], Eq("c"));
+    ASSERT_EQ(list.size(), 3);
+}
+
+TEST(Tokenizer, as_vector3)
+{
+    auto list = Tokenizer ("a\\","\\").as_vector();
+    ASSERT_THAT(list[0], Eq("a"));
+    ASSERT_EQ(list.size(), 1);
+}
+
+TEST(Tokenizer, as_vector4)
+{
+    auto list = Tokenizer ("\\a","\\").as_vector();
+    ASSERT_THAT(list[0], Eq("a"));
+    ASSERT_EQ(list.size(), 1);
 }
 
 TEST(ValueTokenizer, empty_string)

--- a/unittest/utils/test_tokenizer.cpp
+++ b/unittest/utils/test_tokenizer.cpp
@@ -170,3 +170,31 @@ TEST(ValueTokenizer, not_contains)
     ValueTokenizer values("test word");
     ASSERT_FALSE(values.contains("test2"));
 }
+
+TEST(ValueTokenizer, missing_int)
+{
+    ValueTokenizer values("10");
+    ASSERT_EQ(values.next_int(), 10);
+    ASSERT_THROW(values.next_int(), TokenizerException);
+}
+
+TEST(ValueTokenizer, missing_tagint)
+{
+    ValueTokenizer values("42");
+    ASSERT_EQ(values.next_tagint(), 42);
+    ASSERT_THROW(values.next_tagint(), TokenizerException);
+}
+
+TEST(ValueTokenizer, missing_bigint)
+{
+    ValueTokenizer values("42");
+    ASSERT_EQ(values.next_bigint(), 42);
+    ASSERT_THROW(values.next_bigint(), TokenizerException);
+}
+
+TEST(ValueTokenizer, missing_double)
+{
+    ValueTokenizer values("3.14");
+    ASSERT_DOUBLE_EQ(values.next_double(), 3.14);
+    ASSERT_THROW(values.next_double(), TokenizerException);
+}


### PR DESCRIPTION
**Summary**

This pull request combines multiple small refactoring changes that adapt the LAMMPS code to avoid certain operations (e.g. calling `strtok()`) and make better use of convenience functions in the utils namespace or the tokenizer classes.
With this pull request merged, there are no more uses of `strtok()` in the core LAMMPS code in `src`. Only in packages and libraries.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

The following individual changes are included:
- avoid calling `strtok()` when parsing the "partition" command; simplify the code
- avoid calling `strtok()` when reading data files with `read_data`
- avoid calling `strtok()` in `group` command
- avoid calling `strtok()` when reading *file* and *atomfile* style variables and use ValueTokenizer for the latter
- avoid calling `strtok()` from various dump styles. simplify string processing using `std::string` and `utils::strdup()`
- refactor `utils::expand_args()` to use c++ string tools and fmtlib to recombine the expanded string.
- let ValueTokenizer throw an exception, if the next value is requested but there is no token left.
- add unit tests for out of token exceptions thrown by ValueTokenizer
- add unit test for partition command

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
