### PR TITLE
[BUGFIX] Scaling of cdof for fix ave/chunk norm all

### DIFF
--- a/doc/src/fix_ave_chunk.rst
+++ b/doc/src/fix_ave_chunk.rst
@@ -307,7 +307,9 @@ atoms in the chunk.  The averaged output value for the chunk on the
 average over atoms across the entire *Nfreq* timescale.  For the
 *density/number* and *density/mass* values, the volume (bin volume or
 system volume) used in the final normalization will be the volume at
-the final *Nfreq* timestep.
+the final *Nfreq* timestep. For the *temp* values, degrees of freedom and
+kinetic energy are summed separately across the entire *Nfreq* timescale, and
+the output value is calculated by dividing those two sums.
 
 If the *norm* setting is *sample*\ , the chunk value is summed over
 atoms for each sample, as is the count, and an "average sample value"

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -881,7 +881,7 @@ void FixAveChunk::end_of_step()
       if (count_sum[m] > 0.0)
         for (j = 0; j < nvalues; j++) {
           if (which[j] == ArgInfo::TEMPERATURE) {
-            values_sum[m][j] *= mvv2e / ((cdof + adof*count_sum[m]) * boltz);
+            values_sum[m][j] *= mvv2e/((repeat*cdof + adof*count_sum[m])*boltz);
           } else if (which[j] == ArgInfo::DENSITY_NUMBER) {
             if (volflag == SCALAR) values_sum[m][j] /= chunk_volume_scalar;
             else values_sum[m][j] /= chunk_volume_vec[m];


### PR DESCRIPTION
**Summary**

When calculating temperature, fix ave/chunk uses (cdof + Natoms*adof) as the degrees of freedom. However, under norm all, Natoms is the number of atoms summed over all samples, while cdof isn't scaled accordingly. The difference is apparent in the attached input script, which uses a single system-wide chunk to compute temperature, setting cdof to -2 to match the temperature compute used by fix nvt. Using norm sample produces the correct temperature measurement, whereas norm all reports a temperature that is slightly too low (most obvious in smaller systems with long averaging periods). This bugfix adds a scaling factor to cdof of Nrepeats in the case that norm all is used. Running the same input script with this bugfix produces identical temperature output with norm all and norm sample, as would be expected.

**Related Issue(s)**

None.

**Author(s)**

Stephen Sanderson - University of Queensland

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**
Example script with output from old and new versions
[cdof_bug.tar.gz](https://github.com/lammps/lammps/files/6146739/cdof_bug.tar.gz)


