### PR TITLE
Trim models list returned by "kim query ... get_available_models ..." to those installed on user's system

### DIFF
--- a/src/KIM/kim_query.cpp
+++ b/src/KIM/kim_query.cpp
@@ -222,7 +222,8 @@ void KimQuery::command(int narg, char **arg)
 
     if (available.empty())
       error->all(FLERR,
-        fmt::format("There is no OpenKIM model installed on the system"));
+        fmt::format(
+            "There are no matching OpenKIM models installed on the system"));
 
     // replace results with available
     strcpy(value, available.c_str());  // available guaranteed to fit

--- a/src/KIM/kim_query.cpp
+++ b/src/KIM/kim_query.cpp
@@ -223,8 +223,6 @@ void KimQuery::command(int narg, char **arg)
     if (available.empty())
       error->all(FLERR,
         fmt::format("There is no OpenKIM model installed on the system"));
-    input->write_echo(
-      fmt::format("# Installed OpenKIM models: {}\n\n", available));
 
     // replace results with available
     strcpy(value, available.c_str());  // available guaranteed to fit


### PR DESCRIPTION
**Summary**

Trim models list returned by "kim query ... get_available_models ..." to those installed on user's system
Print list of OpenKIM models not found install (missing) to the log file.

**Author(s)**

Ryan S. Elliott (UMN)
Yaser Afshar (UMN)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

