### PR TITLE
Python package refactor

### DIFF
--- a/src/PYTHON/fix_python_invoke.h
+++ b/src/PYTHON/fix_python_invoke.h
@@ -21,6 +21,7 @@ FixStyle(python,FixPythonInvoke)
 #ifndef LMP_FIX_PYTHON_INVOKE_H
 #define LMP_FIX_PYTHON_INVOKE_H
 
+
 #include "fix.h"
 
 namespace LAMMPS_NS {
@@ -28,12 +29,13 @@ namespace LAMMPS_NS {
 class FixPythonInvoke : public Fix {
  public:
   FixPythonInvoke(class LAMMPS *, int, char **);
-  virtual ~FixPythonInvoke() {}
+  virtual ~FixPythonInvoke();
   int setmask();
   virtual void end_of_step();
   virtual void post_force(int);
 
  private:
+  void * lmpPtr;
   void * pFunc;
   int selected_callback;
 };

--- a/src/PYTHON/fix_python_move.cpp
+++ b/src/PYTHON/fix_python_move.cpp
@@ -21,8 +21,9 @@
 #include "error.h"
 #include "lmppython.h"
 #include "python_compat.h"
+#include "python_utils.h"
 
-#include <cstring>
+#include <string>
 #include <Python.h>   // IWYU pragma: export
 
 using namespace LAMMPS_NS;
@@ -40,7 +41,7 @@ FixPythonMove::FixPythonMove(LAMMPS *lmp, int narg, char **arg) :
 
   py_move = nullptr;
 
-  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyUtils::GIL lock;
 
   // add current directory to PYTHONPATH
   PyObject *py_path = PySys_GetObject((char *)"path");
@@ -48,70 +49,50 @@ FixPythonMove::FixPythonMove(LAMMPS *lmp, int narg, char **arg) :
 
 
   // create integrator instance
-  char *full_cls_name = arg[3];
-  char *lastpos = strrchr(full_cls_name, '.');
+  std::string full_cls_name = arg[3];
+  size_t lastpos = full_cls_name.rfind(".");
 
-  if (lastpos == nullptr) {
+  if (lastpos == std::string::npos) {
     error->all(FLERR,"Fix python/integrate requires fully qualified class name");
   }
 
-  size_t module_name_length = strlen(full_cls_name) - strlen(lastpos);
-  size_t cls_name_length = strlen(lastpos)-1;
+  std::string module_name = full_cls_name.substr(0, lastpos);
+  std::string cls_name = full_cls_name.substr(lastpos+1);
 
-  char *module_name = new char[module_name_length+1];
-  char *cls_name = new char[cls_name_length+1];
-  strncpy(module_name, full_cls_name, module_name_length);
-  module_name[module_name_length] = 0;
-
-  strcpy(cls_name, lastpos+1);
-
-  PyObject *pModule = PyImport_ImportModule(module_name);
+  PyObject *pModule = PyImport_ImportModule(module_name.c_str());
   if (!pModule) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Loading python integrator module failure");
   }
 
   // create LAMMPS atom type to potential file type mapping in python class
   // by calling 'lammps_pair_style.map_coeff(name,type)'
 
-  PyObject *py_move_type = PyObject_GetAttrString(pModule, cls_name);
+  PyObject *py_move_type = PyObject_GetAttrString(pModule, cls_name.c_str());
   if (!py_move_type) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not find integrator class in module'");
   }
 
-  delete [] module_name;
-  delete [] cls_name;
-
   PyObject *ptr = PY_VOID_POINTER(lmp);
-  PyObject *arglist = Py_BuildValue("(O)", ptr);
-  PyObject *py_move_obj = PyObject_CallObject(py_move_type, arglist);
-  Py_DECREF(arglist);
+  PyObject *py_move_obj = PyObject_CallFunction(py_move_type, "O", ptr);
+  Py_CLEAR(ptr);
 
   if (!py_move_obj) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not instantiate instance of integrator class'");
   }
 
   // check object interface
   py_move = (void *) py_move_obj;
-
-  PyGILState_Release(gstate);
 }
 
 /* ---------------------------------------------------------------------- */
 
 FixPythonMove::~FixPythonMove()
 {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-  if (py_move) Py_DECREF((PyObject*) py_move);
-  PyGILState_Release(gstate);
+  PyUtils::GIL lock;
+  Py_CLEAR(py_move);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -130,122 +111,82 @@ int FixPythonMove::setmask()
 
 void FixPythonMove::init()
 {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-  PyObject *py_move_obj = (PyObject *) py_move;
-  PyObject *py_init = PyObject_GetAttrString(py_move_obj,(char *)"init");
-  if (!py_init) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'init()' method'");
+  PyUtils::GIL lock;
+  PyObject * result = PyObject_CallMethod((PyObject *)py_move, "init", nullptr);
+
+  if (!result) {
+    PyUtils::Print_Errors();
+    error->all(FLERR,"Fix python/move init() method failed");
   }
-  PyObject *result = PyEval_CallObject(py_init, nullptr);
-  if (!result && (comm->me == 0)) PyErr_Print();
-  PyGILState_Release(gstate);
-  if (!result) error->all(FLERR,"Fix python/move init() method failed");
+  Py_CLEAR(result);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixPythonMove::initial_integrate(int vflag)
 {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-  PyObject *py_move_obj = (PyObject *) py_move;
-  PyObject *py_initial_integrate = PyObject_GetAttrString(py_move_obj,"initial_integrate");
-  if (!py_initial_integrate) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'initial_integrate' method'");
+  PyUtils::GIL lock;
+  PyObject * result = PyObject_CallMethod((PyObject*)py_move, "initial_integrate", "i", vflag);
+
+  if (!result) {
+    PyUtils::Print_Errors();
+    error->all(FLERR,"Fix python/move initial_integrate() method failed");
   }
-  PyObject *arglist = Py_BuildValue("(i)", vflag);
-  PyObject *result = PyEval_CallObject(py_initial_integrate, arglist);
-  Py_DECREF(arglist);
-  if (!result && (comm->me == 0)) PyErr_Print();
-  PyGILState_Release(gstate);
-  if (!result) error->all(FLERR,"Fix python/move initial_integrate() "
-                          "method failed");
+  Py_CLEAR(result);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixPythonMove::final_integrate()
 {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-  PyObject *py_move_obj = (PyObject *) py_move;
-  PyObject *py_final_integrate = PyObject_GetAttrString(py_move_obj,"final_integrate");
-  if (!py_final_integrate) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'final_integrate' method'");
+  PyUtils::GIL lock;
+  PyObject * result = PyObject_CallMethod((PyObject*)py_move, "final_integrate", nullptr);
+
+  if (!result) {
+    PyUtils::Print_Errors();
+    error->all(FLERR,"Fix python/move final_integrate() method failed");
   }
-  PyObject *result = PyEval_CallObject(py_final_integrate, nullptr);
-  if (!result && (comm->me == 0)) PyErr_Print();
-  PyGILState_Release(gstate);
-  if (!result) error->all(FLERR,"Fix python/move final_integrate() method "
-                          "failed");
+  Py_CLEAR(result);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixPythonMove::initial_integrate_respa(int vflag, int ilevel, int iloop)
 {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-  PyObject *py_move_obj = (PyObject *) py_move;
-  PyObject *py_initial_integrate_respa = PyObject_GetAttrString(py_move_obj,"initial_integrate_respa");
-  if (!py_initial_integrate_respa) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'initial_integrate_respa' method'");
+  PyUtils::GIL lock;
+  PyObject * result = PyObject_CallMethod((PyObject*)py_move, "initial_integrate_respa", "iii", vflag, ilevel, iloop);
+
+  if (!result) {
+    PyUtils::Print_Errors();
+    error->all(FLERR,"Fix python/move initial_integrate_respa() method failed");
   }
-  PyObject *arglist = Py_BuildValue("(iii)", vflag, ilevel, iloop);
-  PyObject *result = PyEval_CallObject(py_initial_integrate_respa, arglist);
-  Py_DECREF(arglist);
-  if (!result && (comm->me == 0)) PyErr_Print();
-  PyGILState_Release(gstate);
-  if (!result) error->all(FLERR,"Fix python/move initial_integrate_respa() "
-                          "method failed");
+  Py_CLEAR(result);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixPythonMove::final_integrate_respa(int ilevel, int iloop)
 {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-  PyObject *py_move_obj = (PyObject *) py_move;
-  PyObject *py_final_integrate_respa = PyObject_GetAttrString(py_move_obj,"final_integrate_respa");
-  if (!py_final_integrate_respa) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'final_integrate_respa' method'");
+  PyUtils::GIL lock;
+  PyObject * result = PyObject_CallMethod((PyObject*)py_move, "final_integrate_respa", "ii", ilevel, iloop);
+
+  if (!result) {
+    PyUtils::Print_Errors();
+    error->all(FLERR,"Fix python/move final_integrate_respa() method failed");
   }
-  PyObject *arglist = Py_BuildValue("(ii)", ilevel, iloop);
-  PyObject *result = PyEval_CallObject(py_final_integrate_respa, arglist);
-  Py_DECREF(arglist);
-  if (!result && (comm->me == 0)) PyErr_Print();
-  PyGILState_Release(gstate);
-  if (!result) error->all(FLERR,"Fix python/move final_integrate_respa() "
-                          "method failed");
+  Py_CLEAR(result);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixPythonMove::reset_dt()
 {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-  PyObject *py_move_obj = (PyObject *) py_move;
-  PyObject *py_reset_dt = PyObject_GetAttrString(py_move_obj,"reset_dt");
-  if (!py_reset_dt) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'reset_dt' method'");
+  PyUtils::GIL lock;
+  PyObject * result = PyObject_CallMethod((PyObject*)py_move, "reset_dt", nullptr);
+
+  if (!result) {
+    PyUtils::Print_Errors();
+    error->all(FLERR,"Fix python/move reset_dt() method failed");
   }
-  PyObject *result = PyEval_CallObject(py_reset_dt, nullptr);
-  if (!result && (comm->me == 0)) PyErr_Print();
-  PyGILState_Release(gstate);
-  if (!result) error->all(FLERR,"Fix python/move reset_dt() method failed");
+  Py_CLEAR(result);
 }

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -24,9 +24,10 @@
 #include "memory.h"
 #include "neigh_list.h"
 #include "python_compat.h"
+#include "python_utils.h"
 #include "update.h"
 
-#include <cstring>
+#include <string>
 #include <Python.h>  // IWYU pragma: export
 
 using namespace LAMMPS_NS;
@@ -50,7 +51,7 @@ PairPython::PairPython(LAMMPS *lmp) : Pair(lmp) {
 
   // add current directory to PYTHONPATH
 
-  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyUtils::GIL lock;
   PyObject *py_path = PySys_GetObject((char *)"path");
   PyList_Append(py_path, PY_STRING_FROM_STRING("."));
 
@@ -61,14 +62,14 @@ PairPython::PairPython(LAMMPS *lmp) : Pair(lmp) {
   if (potentials_path != nullptr) {
     PyList_Append(py_path, PY_STRING_FROM_STRING(potentials_path));
   }
-  PyGILState_Release(gstate);
 }
 
 /* ---------------------------------------------------------------------- */
 
 PairPython::~PairPython()
 {
-  if (py_potential) Py_DECREF((PyObject*) py_potential);
+  PyUtils::GIL lock;
+  Py_CLEAR(py_potential);
   delete[] skip_types;
 
   if (allocated) {
@@ -103,41 +104,31 @@ void PairPython::compute(int eflag, int vflag)
 
   // prepare access to compute_force and compute_energy functions
 
-  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyUtils::GIL lock;
   PyObject *py_pair_instance = (PyObject *) py_potential;
   PyObject *py_compute_force = PyObject_GetAttrString(py_pair_instance,"compute_force");
   if (!py_compute_force) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not find 'compute_force' method'");
   }
   if (!PyCallable_Check(py_compute_force)) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Python 'compute_force' is not callable");
   }
 
   PyObject *py_compute_energy = PyObject_GetAttrString(py_pair_instance,"compute_energy");
   if (!py_compute_energy) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not find 'compute_energy' method'");
   }
   if (!PyCallable_Check(py_compute_energy)) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Python 'compute_energy' is not callable");
   }
 
   PyObject *py_compute_args = PyTuple_New(3);
   if (!py_compute_args) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not create tuple for 'compute' function arguments");
   }
 
@@ -179,13 +170,11 @@ void PairPython::compute(int eflag, int vflag)
         PyTuple_SetItem(py_compute_args,0,py_rsq);
         py_value = PyObject_CallObject(py_compute_force,py_compute_args);
         if (!py_value) {
-          PyErr_Print();
-          PyErr_Clear();
-          PyGILState_Release(gstate);
+          PyUtils::Print_Errors();
           error->all(FLERR,"Calling 'compute_force' function failed");
         }
         fpair = factor_lj*PyFloat_AsDouble(py_value);
-        Py_DECREF(py_value);
+        Py_CLEAR(py_value);
 
         f[i][0] += delx*fpair;
         f[i][1] += dely*fpair;
@@ -198,8 +187,12 @@ void PairPython::compute(int eflag, int vflag)
 
         if (eflag) {
           py_value = PyObject_CallObject(py_compute_energy,py_compute_args);
+          if (!py_value) {
+            PyUtils::Print_Errors();
+            error->all(FLERR,"Calling 'compute_energy' function failed");
+          }
           evdwl = factor_lj*PyFloat_AsDouble(py_value);
-          Py_DECREF(py_value);
+          Py_CLEAR(py_value);
         } else evdwl = 0.0;
 
         if (evflag) ev_tally(i,j,nlocal,newton_pair,
@@ -207,8 +200,7 @@ void PairPython::compute(int eflag, int vflag)
       }
     }
   }
-  Py_DECREF(py_compute_args);
-  PyGILState_Release(gstate);
+  Py_CLEAR(py_compute_args);
 
   if (vflag_fdotr) virial_fdotr_compute();
 }
@@ -261,111 +253,48 @@ void PairPython::coeff(int narg, char **arg)
     error->all(FLERR,"Incorrect args for pair coefficients");
 
   // check if python potential file exists and source it
-  char * full_cls_name = arg[2];
-  char * lastpos = strrchr(full_cls_name, '.');
+  std::string full_cls_name = arg[2];
+  size_t lastpos = full_cls_name.rfind(".");
 
-  if (lastpos == nullptr) {
+  if (lastpos == std::string::npos) {
     error->all(FLERR,"Python pair style requires fully qualified class name");
   }
 
-  size_t module_name_length = strlen(full_cls_name) - strlen(lastpos);
-  size_t cls_name_length = strlen(lastpos)-1;
+  std::string module_name = full_cls_name.substr(0, lastpos);
+  std::string cls_name = full_cls_name.substr(lastpos+1);
 
-  char * module_name = new char[module_name_length+1];
-  char * cls_name = new char[cls_name_length+1];
-  strncpy(module_name, full_cls_name, module_name_length);
-  module_name[module_name_length] = 0;
+  PyUtils::GIL lock;
 
-  strcpy(cls_name, lastpos+1);
-
-  PyGILState_STATE gstate = PyGILState_Ensure();
-
-  PyObject * pModule = PyImport_ImportModule(module_name);
+  PyObject * pModule = PyImport_ImportModule(module_name.c_str());
   if (!pModule) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Loading python pair style module failure");
   }
 
   // create LAMMPS atom type to potential file type mapping in python class
   // by calling 'lammps_pair_style.map_coeff(name,type)'
 
-  PyObject *py_pair_type = PyObject_GetAttrString(pModule, cls_name);
+  PyObject *py_pair_type = PyObject_GetAttrString(pModule, cls_name.c_str());
   if (!py_pair_type) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not find pair style class in module'");
   }
 
-  delete [] module_name;
-  delete [] cls_name;
-
   PyObject * py_pair_instance = PyObject_CallObject(py_pair_type, nullptr);
   if (!py_pair_instance) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not instantiate instance of pair style class'");
   }
 
   py_potential = (void *) py_pair_instance;
 
-  PyObject *py_check_units = PyObject_GetAttrString(py_pair_instance,"check_units");
-  if (!py_check_units) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'check_units' method'");
-  }
-  if (!PyCallable_Check(py_check_units)) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Python 'check_units' is not callable");
-  }
-  PyObject *py_units_args = PyTuple_New(1);
-  if (!py_units_args) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not create tuple for 'check_units' function arguments");
-  }
-
-  PyObject *py_name = PY_STRING_FROM_STRING(update->unit_style);
-  PyTuple_SetItem(py_units_args,0,py_name);
-  PyObject *py_value = PyObject_CallObject(py_check_units,py_units_args);
+  PyObject *py_value = PyObject_CallMethod(py_pair_instance, "check_units", "s", update->unit_style);
   if (!py_value) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Calling 'check_units' function failed");
   }
-  Py_DECREF(py_units_args);
+  Py_CLEAR(py_value);
 
-
-  PyObject *py_map_coeff = PyObject_GetAttrString(py_pair_instance,"map_coeff");
-  if (!py_map_coeff) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'map_coeff' method'");
-  }
-  if (!PyCallable_Check(py_map_coeff)) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Python 'map_coeff' is not callable");
-  }
-
-  PyObject *py_map_args = PyTuple_New(2);
-  if (!py_map_args) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not create tuple for 'map_coeff' function arguments");
-  }
 
   delete[] skip_types;
   skip_types = new int[ntypes+1];
@@ -375,25 +304,20 @@ void PairPython::coeff(int narg, char **arg)
       skip_types[i] = 1;
       continue;
     } else skip_types[i] = 0;
-    PyObject *py_type = PY_INT_FROM_LONG(i);
-    py_name = PY_STRING_FROM_STRING(arg[2+i]);
-    PyTuple_SetItem(py_map_args,0,py_name);
-    PyTuple_SetItem(py_map_args,1,py_type);
-    py_value = PyObject_CallObject(py_map_coeff,py_map_args);
+    const int type = i;
+    const char * name = arg[2+i];
+    py_value = PyObject_CallMethod(py_pair_instance, "map_coeff", "si", name, type);
     if (!py_value) {
-      PyErr_Print();
-      PyErr_Clear();
-      PyGILState_Release(gstate);
+      PyUtils::Print_Errors();
       error->all(FLERR,"Calling 'map_coeff' function failed");
     }
+    Py_CLEAR(py_value);
 
     for (int j = i; j <= ntypes ; j++) {
       setflag[i][j] = 1;
       cutsq[i][j] = cut_global*cut_global;
     }
   }
-  Py_DECREF(py_map_args);
-  PyGILState_Release(gstate);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -417,76 +341,53 @@ double PairPython::single(int /* i */, int /* j */, int itype, int jtype,
 
   // prepare access to compute_force and compute_energy functions
 
-  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyUtils::GIL lock;
   PyObject *py_pair_instance = (PyObject *) py_potential;
-  PyObject *py_compute_force
-    = PyObject_GetAttrString(py_pair_instance,"compute_force");
-  if (!py_compute_force) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'compute_force' method'");
-  }
-  if (!PyCallable_Check(py_compute_force)) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Python 'compute_force' is not callable");
-  }
+  PyObject *py_compute_force = (PyObject *) get_member_function("compute_force");
+  PyObject *py_compute_energy = (PyObject *) get_member_function("compute_energy");
+  PyObject *py_compute_args = Py_BuildValue("(dii)", rsq, itype, jtype);
 
-  PyObject *py_compute_energy
-    = PyObject_GetAttrString(py_pair_instance,"compute_energy");
-  if (!py_compute_energy) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Could not find 'compute_energy' method'");
-  }
-  if (!PyCallable_Check(py_compute_energy)) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
-    error->all(FLERR,"Python 'compute_energy' is not callable");
-  }
-
-  PyObject *py_rsq, *py_itype, *py_jtype, *py_value;
-  PyObject *py_compute_args = PyTuple_New(3);
   if (!py_compute_args) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Could not create tuple for 'compute' function arguments");
   }
 
-  py_itype = PY_INT_FROM_LONG(itype);
-  PyTuple_SetItem(py_compute_args,1,py_itype);
-  py_jtype = PY_INT_FROM_LONG(jtype);
-  PyTuple_SetItem(py_compute_args,2,py_jtype);
-  py_rsq = PyFloat_FromDouble(rsq);
-  PyTuple_SetItem(py_compute_args,0,py_rsq);
-
-  py_value = PyObject_CallObject(py_compute_force,py_compute_args);
+  PyObject * py_value = PyObject_CallObject(py_compute_force, py_compute_args);
   if (!py_value) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Calling 'compute_force' function failed");
   }
   fforce = factor_lj*PyFloat_AsDouble(py_value);
-  Py_DECREF(py_value);
+  Py_CLEAR(py_value);
 
-  py_value = PyObject_CallObject(py_compute_energy,py_compute_args);
+  py_value = PyObject_CallObject(py_compute_energy, py_compute_args);
   if (!py_value) {
-    PyErr_Print();
-    PyErr_Clear();
-    PyGILState_Release(gstate);
+    PyUtils::Print_Errors();
     error->all(FLERR,"Calling 'compute_energy' function failed");
   }
   double evdwl = factor_lj*PyFloat_AsDouble(py_value);
-  Py_DECREF(py_value);
 
-  Py_DECREF(py_compute_args);
-  PyGILState_Release(gstate);
+  Py_CLEAR(py_value);
+  Py_CLEAR(py_compute_args);
 
   return evdwl;
+}
+
+
+/* ---------------------------------------------------------------------- */
+
+void * PairPython::get_member_function(const char * name)
+{
+  PyUtils::GIL lock;
+  PyObject *py_pair_instance = (PyObject *) py_potential;
+  PyObject * py_mfunc = PyObject_GetAttrString(py_pair_instance, name);
+  if (!py_mfunc) {
+    PyUtils::Print_Errors();
+    error->all(FLERR, fmt::format("Could not find '{}' method'", name));
+  }
+  if (!PyCallable_Check(py_mfunc)) {
+    PyUtils::Print_Errors();
+    error->all(FLERR, fmt::format("Python '{}' is not callable", name));
+  }
+  return py_mfunc;
 }

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -342,7 +342,6 @@ double PairPython::single(int /* i */, int /* j */, int itype, int jtype,
   // prepare access to compute_force and compute_energy functions
 
   PyUtils::GIL lock;
-  PyObject *py_pair_instance = (PyObject *) py_potential;
   PyObject *py_compute_force = (PyObject *) get_member_function("compute_force");
   PyObject *py_compute_energy = (PyObject *) get_member_function("compute_energy");
   PyObject *py_compute_args = Py_BuildValue("(dii)", rsq, itype, jtype);

--- a/src/PYTHON/pair_python.h
+++ b/src/PYTHON/pair_python.h
@@ -50,6 +50,7 @@ class PairPython : public Pair {
   int  * skip_types;
 
   virtual void allocate();
+  void * get_member_function(const char *);
 };
 
 }

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -117,7 +117,7 @@ PythonImpl::~PythonImpl()
 
   // shutdown Python interpreter
   if (!external_interpreter) {
-    PyGILState_STATE gstate = PyGILState_Ensure();
+    PyGILState_Ensure();
     Py_Finalize();
   }
 

--- a/src/PYTHON/python_utils.h
+++ b/src/PYTHON/python_utils.h
@@ -1,0 +1,42 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifndef LMP_PYTHON_UTILS_H
+#define LMP_PYTHON_UTILS_H
+
+#include <Python.h>
+
+namespace LAMMPS_NS {
+
+namespace PyUtils {
+
+class GIL {
+  PyGILState_STATE gstate;
+public:
+  GIL() : gstate(PyGILState_Ensure()) {
+  }
+  ~GIL() {
+    PyGILState_Release(gstate);
+  }
+};
+
+static void Print_Errors() {
+  PyErr_Print();
+  PyErr_Clear();
+}
+
+}
+
+}
+
+#endif

--- a/unittest/formats/test_atom_styles.cpp
+++ b/unittest/formats/test_atom_styles.cpp
@@ -40,11 +40,7 @@
 #elif defined(__GNUC__)
 #if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))
 #pragma GCC optimize("no-var-tracking-assignments", "O0")
-#else
-#pragma GCC optimize("no-var-tracking-assignments")
 #endif
-#else
-#define _do_nothing
 #endif
 #endif
 

--- a/unittest/formats/test_potential_file_reader.cpp
+++ b/unittest/formats/test_potential_file_reader.cpp
@@ -42,18 +42,20 @@ using utils::split_words;
 // whether to print verbose output (i.e. not capturing LAMMPS screen output).
 bool verbose = false;
 
-const int LAMMPS_NS::PairSW::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairComb::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairComb3::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairTersoff::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairTersoffMOD::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairTersoffMODC::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairTersoffZBL::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairGW::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairGWZBL::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairNb3bHarmonic::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairVashishta::NPARAMS_PER_LINE;
-const int LAMMPS_NS::PairTersoffTable::NPARAMS_PER_LINE;
+#if __cplusplus < 201703L
+constexpr int LAMMPS_NS::PairSW::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairComb::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairComb3::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairTersoff::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairTersoffMOD::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairTersoffMODC::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairTersoffZBL::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairGW::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairGWZBL::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairNb3bHarmonic::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairVashishta::NPARAMS_PER_LINE;
+constexpr int LAMMPS_NS::PairTersoffTable::NPARAMS_PER_LINE;
+#endif
 
 class PotentialFileReaderTest : public LAMMPSTest {
 };


### PR DESCRIPTION
**Summary**

- introduces `PyUtils::GIL` helper object to acquire/release GIL
- remove `PyEval_`  in favor of `PyObject_Call*` functions (Deprecation warnings with Python 3.9)
- add utility `PyUtils::Print_Errors()`

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

The `PyUtils::GIL` object acquires the Python Global Interpreter Lock (GIL) when created and releases it during destruction. By creating such an object on the stack, the locked resource is automatically released when the current scope is left. This avoids having to hunt down all the cases where the GIL has to be released.

Due to Deprecation warnings in Python 3.9, all function calls to `PyEval_Call*` were replaced with equivalent `PyObject_Call*` functions. Some of the utility functions actually make the code shorter.

`PyUtils::Print_Errors()` performs the common task of printing the Python error messages to the console and clearing them.

Several `Py_DECREF(x)` where replaced with `Py_CLEAR(x)`, which not only allows `x` to be `nullptr`, but also sets the value to `nullptr` after decrementing the reference count them. Several missing `Py_CLEAR/Py_DECREF` were added.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


