### PR TITLE
[BUGFIX] compute chunk/atom bound xxx upper

### DIFF
--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -245,7 +245,6 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
       else maxflag[idim] = COORD;
       if (maxflag[idim] == COORD)
         maxvalue[idim] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
-      else error->all(FLERR,"Illegal compute chunk/atom command");
       iarg += 4;
     } else if (strcmp(arg[iarg],"units") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal compute chunk/atom command");

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -237,14 +237,12 @@ ComputeChunkAtom::ComputeChunkAtom(LAMMPS *lmp, int narg, char **arg) :
       else if (strcmp(arg[iarg+1],"y") == 0) idim = 1;
       else if (strcmp(arg[iarg+1],"z") == 0) idim = 2;
       else error->all(FLERR,"Illegal compute chunk/atom command");
+      minflag[idim] = COORD;
       if (strcmp(arg[iarg+2],"lower") == 0) minflag[idim] = LOWER;
-      else minflag[idim] = COORD;
-      if (minflag[idim] == COORD)
-        minvalue[idim] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
+      else minvalue[idim] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
+      maxflag[idim] = COORD;
       if (strcmp(arg[iarg+3],"upper") == 0) maxflag[idim] = UPPER;
-      else maxflag[idim] = COORD;
-      if (maxflag[idim] == COORD)
-        maxvalue[idim] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
+      else maxvalue[idim] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       iarg += 4;
     } else if (strcmp(arg[iarg],"units") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal compute chunk/atom command");


### PR DESCRIPTION
**Summary**

Compute chunk/atom was throwing an "illegal command" error when using the "bound" keyword with the "upper" option.

Both of the following commands would cause an error (now fixed):
`compute chunk/atom 1 all bin/1d y lower 0.1 units reduced bound y lower upper`
`compute chunk/atom 1 all bin/1d y lower 0.1 units reduced bound y 0.5 upper`

While the below commands had no problems:
`compute chunk/atom 1 all bin/1d y lower 0.1 units reduced bound y lower 1`
`compute chunk/atom 1 all bin/1d y lower 0.1 units reduced bound y 0.5 1`

**Related Issue(s)**

None

**Author(s)**

Stephen Sanderson (UQ)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


