### PR TITLE
Update GPU package to allow using CUDA 11.3 drivers

### DIFF
--- a/lib/gpu/geryon/ocl_device.h
+++ b/lib/gpu/geryon/ocl_device.h
@@ -728,6 +728,9 @@ void UCL_Device::print_all(std::ostream &out) {
       out << "\nDevice " << i << ": \"" << name(i).c_str() << "\"\n";
       out << "  Type of device:                                "
           << device_type_name(i).c_str() << std::endl;
+      out << "  Supported OpenCL Version:                      "
+          << _properties[i].cl_device_version / 100 << "."
+	  << _properties[i].cl_device_version % 100 << std::endl;
       out << "  Is a subdevice:                                ";
       if (is_subdevice(i))
 	out << "Yes\n";
@@ -793,6 +796,16 @@ void UCL_Device::print_all(std::ostream &out) {
           << max_sub_devices(i) << std::endl;
       out << "  Shared memory system:                          ";
       if (shared_memory(i))
+        out << "Yes\n";
+      else
+        out << "No\n";
+      out << "  Subgroup support:                              ";
+      if (_properties[i].has_subgroup_support)
+        out << "Yes\n";
+      else
+        out << "No\n";
+      out << "  Shuffle support:                               ";
+      if (_properties[i].has_shuffle_support)
         out << "Yes\n";
       else
         out << "No\n";

--- a/lib/gpu/lal_base_atomic.cpp
+++ b/lib/gpu/lal_base_atomic.cpp
@@ -335,7 +335,7 @@ void BaseAtomicT::compile_kernels(UCL_Device &dev, const void *pair_str,
   _compiled=true;
 
   #if defined(USE_OPENCL) && (defined(CL_VERSION_2_1) || defined(CL_VERSION_3_0))
-  if (dev.cl_device_version() >= 210) {
+  if (dev.has_subgroup_support()) {
     size_t mx_subgroup_sz = k_pair_fast.max_subgroup_size(_block_size);
     #if defined(LAL_OCL_EV_JIT)
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_pair_noev.max_subgroup_size(_block_size));

--- a/lib/gpu/lal_base_charge.cpp
+++ b/lib/gpu/lal_base_charge.cpp
@@ -348,7 +348,7 @@ void BaseChargeT::compile_kernels(UCL_Device &dev, const void *pair_str,
   _compiled=true;
 
   #if defined(USE_OPENCL) && (defined(CL_VERSION_2_1) || defined(CL_VERSION_3_0))
-  if (dev.cl_device_version() >= 210) {
+  if (dev.has_subgroup_support()) {
     size_t mx_subgroup_sz = k_pair_fast.max_subgroup_size(_block_size);
     #if defined(LAL_OCL_EV_JIT)
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_pair_noev.max_subgroup_size(_block_size));

--- a/lib/gpu/lal_base_dipole.cpp
+++ b/lib/gpu/lal_base_dipole.cpp
@@ -356,7 +356,7 @@ void BaseDipoleT::compile_kernels(UCL_Device &dev, const void *pair_str,
   _compiled=true;
 
   #if defined(USE_OPENCL) && (defined(CL_VERSION_2_1) || defined(CL_VERSION_3_0))
-  if (dev.cl_device_version() >= 210) {
+  if (dev.has_subgroup_support()) {
     size_t mx_subgroup_sz = k_pair_fast.max_subgroup_size(_block_size);
     #if defined(LAL_OCL_EV_JIT)
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_pair_noev.max_subgroup_size(_block_size));

--- a/lib/gpu/lal_base_dpd.cpp
+++ b/lib/gpu/lal_base_dpd.cpp
@@ -356,7 +356,7 @@ void BaseDPDT::compile_kernels(UCL_Device &dev, const void *pair_str,
   _compiled=true;
 
   #if defined(USE_OPENCL) && (defined(CL_VERSION_2_1) || defined(CL_VERSION_3_0))
-  if (dev.cl_device_version() >= 210) {
+  if (dev.has_subgroup_support()) {
     size_t mx_subgroup_sz = k_pair_fast.max_subgroup_size(_block_size);
     #if defined(LAL_OCL_EV_JIT)
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_pair_noev.max_subgroup_size(_block_size));

--- a/lib/gpu/lal_base_ellipsoid.cpp
+++ b/lib/gpu/lal_base_ellipsoid.cpp
@@ -554,7 +554,7 @@ void BaseEllipsoidT::compile_kernels(UCL_Device &dev,
   _compiled=true;
 
   #if defined(USE_OPENCL) && (defined(CL_VERSION_2_1) || defined(CL_VERSION_3_0))
-  if (dev.cl_device_version() >= 210) {
+  if (dev.has_subgroup_support()) {
     size_t mx_subgroup_sz = k_lj_fast.max_subgroup_size(_block_size);
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_ellipsoid.max_subgroup_size(_block_size));
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_sphere_ellipsoid.max_subgroup_size(_block_size));

--- a/lib/gpu/lal_base_three.cpp
+++ b/lib/gpu/lal_base_three.cpp
@@ -461,7 +461,7 @@ void BaseThreeT::compile_kernels(UCL_Device &dev, const void *pair_str,
   _compiled=true;
 
   #if defined(USE_OPENCL) && (defined(CL_VERSION_2_1) || defined(CL_VERSION_3_0))
-  if (dev.cl_device_version() >= 210) {
+  if (dev.has_subgroup_support()) {
     size_t mx_subgroup_sz = k_pair.max_subgroup_size(_block_size);
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_three_center.max_subgroup_size(_block_size));
     mx_subgroup_sz = std::min(mx_subgroup_sz, k_three_end.max_subgroup_size(_block_size));

--- a/lib/gpu/lal_neighbor.h
+++ b/lib/gpu/lal_neighbor.h
@@ -26,8 +26,8 @@
 
 #if !defined(USE_OPENCL) && !defined(USE_HIP)
 #ifndef LAL_USE_OLD_NEIGHBOR
-// Issue with incorrect results with CUDA 11.2
-#if (CUDA_VERSION > 11019) && (CUDA_VERSION < 11030)
+// Issue with incorrect results with CUDA >= 11.2
+#if (CUDA_VERSION > 11019)
 #define LAL_USE_OLD_NEIGHBOR
 #endif
 #endif

--- a/lib/gpu/lal_neighbor_gpu.cu
+++ b/lib/gpu/lal_neighbor_gpu.cu
@@ -34,8 +34,8 @@ _texture_2d( pos_tex,int4);
 #endif
 
 #ifdef NV_KERNEL
-#if (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ == 2)
-// Issue with incorrect results in CUDA 11.2
+#if (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)
+// Issue with incorrect results in CUDA >= 11.2
 #define LAL_USE_OLD_NEIGHBOR
 #endif
 #endif


### PR DESCRIPTION
**Summary**

Enables continued use of workaround LAL_USE_OLD_NEIGHBOR in GPU package with CUDA >= 11.2
Also fixes an issue in OpenCL backend. Subgroups are an optional feature that needs to be checked before usage.

**Related Issue(s)**

Closes #2718 

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


