### PR TITLE
Fix typo in MVAPICH flag for Kokkos CUDA-Aware MPI

### DIFF
--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -266,7 +266,7 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
 #if defined(MPICH) && defined(MVAPICH2_VERSION)
       char* str;
       gpu_aware_flag = 0;
-      if ((str = getenv("MV2_ENABLE_CUDA")))
+      if ((str = getenv("MV2_USE_CUDA")))
         if ((strcmp(str,"1") == 0))
           gpu_aware_flag = 1;
 


### PR DESCRIPTION
**Summary**

Fix typo in MVAPICH flag for Kokkos preventing the use of CUDA-Aware MPI

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes