### PR TITLE
Updates to the GPU package

### DIFF
--- a/cmake/Modules/GenerateOpenCLHeader.cmake
+++ b/cmake/Modules/GenerateOpenCLHeader.cmake
@@ -1,3 +1,3 @@
-# utility script to call GenerateOpenCLHeader function
+# utility script to call WriteOpenCLHeader function
 include(${SOURCE_DIR}/Modules/OpenCLUtils.cmake)
 WriteOpenCLHeader(${VARNAME} ${HEADER_FILE} ${SOURCE_FILES})

--- a/cmake/Modules/GenerateOpenCLHeader.cmake
+++ b/cmake/Modules/GenerateOpenCLHeader.cmake
@@ -1,0 +1,3 @@
+# utility script to call GenerateOpenCLHeader function
+include(${SOURCE_DIR}/Modules/OpenCLUtils.cmake)
+WriteOpenCLHeader(${VARNAME} ${HEADER_FILE} ${SOURCE_FILES})

--- a/cmake/Modules/OpenCLUtils.cmake
+++ b/cmake/Modules/OpenCLUtils.cmake
@@ -1,10 +1,8 @@
-function(GenerateOpenCLHeader varname outfile files)
-    message("Creating ${outfile}...")
+function(WriteOpenCLHeader varname outfile files)
     file(WRITE ${outfile} "const char * ${varname} = \n")
-    math(EXPR ARG_END   "${ARGC}-1")
+    separate_arguments(files)
 
-    foreach(IDX RANGE 2 ${ARG_END})
-        list(GET ARGV ${IDX} filename)
+    foreach(filename ${files})
         file(READ ${filename} content)
         string(REGEX REPLACE "\\s*//[^\n]*\n" "\n" content "${content}")
         string(REGEX REPLACE "\\\\" "\\\\\\\\" content "${content}")
@@ -15,4 +13,16 @@ function(GenerateOpenCLHeader varname outfile files)
     endforeach()
 
     file(APPEND ${outfile} ";\n")
+endfunction(WriteOpenCLHeader)
+
+function(GenerateOpenCLHeader varname outfile files)
+    list(REMOVE_AT ARGV 0 1)
+    add_custom_command(OUTPUT ${outfile}
+      COMMAND ${CMAKE_COMMAND} -D SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+                               -D VARNAME=${varname}
+                               -D HEADER_FILE=${outfile}
+                               -D SOURCE_FILES="${ARGV}"
+                               -P ${CMAKE_CURRENT_SOURCE_DIR}/Modules/GenerateOpenCLHeader.cmake
+      DEPENDS ${ARGV}
+      COMMENT "Generating ${outfile}...")
 endfunction(GenerateOpenCLHeader)

--- a/lib/gpu/geryon/nvd_device.h
+++ b/lib/gpu/geryon/nvd_device.h
@@ -24,10 +24,6 @@
 #ifndef NVD_DEVICE
 #define NVD_DEVICE
 
-// workaround after GPU package Feb2021 update
-// todo: make new neighbor code work with CUDA
-#define LAL_USE_OLD_NEIGHBOR
-
 #include <string>
 #include <vector>
 #include <iostream>

--- a/lib/gpu/lal_neighbor_gpu.cu
+++ b/lib/gpu/lal_neighbor_gpu.cu
@@ -115,7 +115,7 @@ __kernel void kernel_calc_cell_counts(const unsigned *restrict cell_id,
 #define tagint int
 #endif
 #ifdef LAMMPS_BIGBIG
-#define tagint long long int
+#define tagint long
 #endif
 #ifdef LAMMPS_SMALLSMALL
 #define tagint int


### PR DESCRIPTION
**Summary**

* Fixes a bug in the GPU neighbor list kernels when compiling with `LAMMPS_BIGBIG` and OpenCL
* Reverts change that causes crash with older CUDA (10.2)
* Changes how OpenCL kernel headers are generated to detect changes and recreate them when necessary

**Related Issue(s)**

#2740 

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

CUDA 10.2  (can use new neighbor code)
CUDA 11.0 (can use new neighbor code)
CUDA 11.1 (can use new neighbor code)
CUDA 11.2 (uses old neighbor code)
CUDA 11.3 (uses old neighbor code)

**Implementation Notes**

`tagint` is a 64bit integer when LAMMPS_BIGBIG is set. The OpenCL equivalent is `long`.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/scalarDataTypes.html


