### PR TITLE
Make warning and info messages vararg compatible and implement "thermo_modify warn"

### DIFF
--- a/doc/src/thermo_modify.rst
+++ b/doc/src/thermo_modify.rst
@@ -76,22 +76,33 @@ are drifting out of the box through a fixed boundary condition (see
 the :doc:`boundary <boundary>` command).  In this case one atom may be
 deleted before the rest of the molecule is, on a later timestep.
 
-The *warn* keyword determines whether LAMMPS will print warning
-messages and how many of them.  Certain warning messages can be
-quite verbose and thus quickly blow up the size of the log file
-and screen output.  Thus a limit of 100 warnings messages is applied
-by default.  If there are more warnings, LAMMPS will print one final
-warning that it will not print any additional warning messages.
+The *warn* keyword allows you to control whether LAMMPS will print
+warning messages and how many of them.  Most warning messages are only
+printed by MPI rank 0.  They are usually pointing out important issues
+that should be investigated, but LAMMPS cannot determine for
+certain whether they are an indication of an error.
+
+Some warning messages are printed during a run (or immediately before)
+each time a specific MPI rank encounters the issue, e.g. bonds that are
+stretched too far or dihedrals in extreme configurations. These can
+become verbose for and thus quickly blow up the size of the log file
+and screen output.  Thus a limit of 100 warning messages is applied
+by default.  The warning count is applied to the entire input unless
+reset with a ``thermo_modify warn reset`` command.  If there are more
+warnings than the limit, LAMMPS will print one final warning that it
+will not print any additional warning messages.
+
 Any number after the keyword *warn* will change the warning limit
 accordingly.  With the value *ignore* all warnings will be suppressed,
 with the value *always* no limit will be applied and warnings will
-always be printed, with the value *reset* the internal warning
-counter will be reset to zero,  and with the value *default*, all
-settings will be reset to their defaults and the counter reset.
-An example usage of this keyword would be that during equilibration
-warnings would be ignored while the system is still adjusting, but
-then one would reset everything to the defaults for the production
-run.
+always be printed, with the value *reset* the internal warning counter
+will be reset to zero, and with the value *default*, the counter is
+reset and the limit set to 100.  An example usage of either *reset* or
+*default* would be to reenable warnings that were disabled or have
+reached the limit during equilibration, where the warnings would be
+accepteable while the system is still adjusting, but then one would want
+to all warnings again for the production run, where they would indicate
+problems that would require a closer look at what is causing them.
 
 The *norm* keyword determines whether various thermodynamic output
 values are normalized by the number of atoms or not, depending on

--- a/doc/src/thermo_modify.rst
+++ b/doc/src/thermo_modify.rst
@@ -201,9 +201,9 @@ Related commands
 Default
 """""""
 
-The option defaults are lost = error, norm = yes for unit style of
-*lj*\ , norm = no for unit style of *real* and *metal*\ , flush = no,
-and temp/press = compute IDs defined by thermo_style.
+The option defaults are lost = error, warn = 100, norm = yes for unit
+style of *lj*\ , norm = no for unit style of *real* and *metal*\ ,
+flush = no, and temp/press = compute IDs defined by thermo_style.
 
 The defaults for the line and format options depend on the thermo
 style.  For styles "one" and "custom", the line and format defaults

--- a/doc/src/thermo_modify.rst
+++ b/doc/src/thermo_modify.rst
@@ -98,9 +98,9 @@ with the value *always* no limit will be applied and warnings will
 always be printed, with the value *reset* the internal warning counter
 will be reset to zero, and with the value *default*, the counter is
 reset and the limit set to 100.  An example usage of either *reset* or
-*default* would be to reenable warnings that were disabled or have
+*default* would be to re-enable warnings that were disabled or have
 reached the limit during equilibration, where the warnings would be
-accepteable while the system is still adjusting, but then one would want
+acceptable while the system is still adjusting, but then one would want
 to all warnings again for the production run, where they would indicate
 problems that would require a closer look at what is causing them.
 

--- a/doc/src/thermo_modify.rst
+++ b/doc/src/thermo_modify.rst
@@ -11,12 +11,13 @@ Syntax
    thermo_modify keyword value ...
 
 * one or more keyword/value pairs may be listed
-* keyword = *lost* or *lost/bond* or *norm* or *flush* or *line* or *format* or *temp* or *press*
+* keyword = *lost* or *lost/bond* or *warn* or *norm* or *flush* or *line* or *format* or *temp* or *press*
 
   .. parsed-literal::
 
        *lost* value = *error* or *warn* or *ignore*
        *lost/bond* value = *error* or *warn* or *ignore*
+       *warn* value = *ignore* or *reset* or *default* or a number
        *norm* value = *yes* or *no*
        *flush* value = *yes* or *no*
        *line* value = *one* or *multi*
@@ -74,6 +75,23 @@ bond, angle, etc.  An example would be when gas molecules in a vapor
 are drifting out of the box through a fixed boundary condition (see
 the :doc:`boundary <boundary>` command).  In this case one atom may be
 deleted before the rest of the molecule is, on a later timestep.
+
+The *warn* keyword determines whether LAMMPS will print warning
+messages and how many of them.  Certain warning messages can be
+quite verbose and thus quickly blow up the size of the log file
+and screen output.  Thus a limit of 100 warnings messages is applied
+by default.  If there are more warnings, LAMMPS will print one final
+warning that it will not print any additional warning messages.
+Any number after the keyword *warn* will change the warning limit
+accordingly.  With the value *ignore* all warnings will be suppressed,
+with the value *always* no limit will be applied and warnings will
+always be printed, with the value *reset* the internal warning
+counter will be reset to zero,  and with the value *default*, all
+settings will be reset to their defaults and the counter reset.
+An example usage of this keyword would be that during equilibration
+warnings would be ignored while the system is still adjusting, but
+then one would reset everything to the defaults for the production
+run.
 
 The *norm* keyword determines whether various thermodynamic output
 values are normalized by the number of atoms or not, depending on

--- a/doc/src/thermo_modify.rst
+++ b/doc/src/thermo_modify.rst
@@ -84,13 +84,22 @@ certain whether they are an indication of an error.
 
 Some warning messages are printed during a run (or immediately before)
 each time a specific MPI rank encounters the issue, e.g. bonds that are
-stretched too far or dihedrals in extreme configurations. These can
-become verbose for and thus quickly blow up the size of the log file
-and screen output.  Thus a limit of 100 warning messages is applied
-by default.  The warning count is applied to the entire input unless
-reset with a ``thermo_modify warn reset`` command.  If there are more
-warnings than the limit, LAMMPS will print one final warning that it
-will not print any additional warning messages.
+stretched too far or dihedrals in extreme configurations. These number
+of these can quickly blow up the size of the log file and screen output.
+Thus a limit of 100 warning messages is applied by default.  The warning
+count is applied to the entire input unless reset with a ``thermo_modify
+warn reset`` command.  If there are more warnings than the limit, LAMMPS
+will print one final warning that it will not print any additional
+warning messages.
+
+.. note::
+
+   The warning limit is enforced on either the per-processor count or
+   the total count across all processors. For efficiency reasons,
+   however, the total count is only updated at steps with thermodynamic
+   output. Thus when running on a large number of processors in
+   parallel, the total number of warnings printed can be significantly
+   larger than the given limit.
 
 Any number after the keyword *warn* will change the warning limit
 accordingly.  With the value *ignore* all warnings will be suppressed,
@@ -100,8 +109,8 @@ will be reset to zero, and with the value *default*, the counter is
 reset and the limit set to 100.  An example usage of either *reset* or
 *default* would be to re-enable warnings that were disabled or have
 reached the limit during equilibration, where the warnings would be
-acceptable while the system is still adjusting, but then one would want
-to all warnings again for the production run, where they would indicate
+acceptable while the system is still adjusting, but then change
+to all warnings for the production run, where they would indicate
 problems that would require a closer look at what is causing them.
 
 The *norm* keyword determines whether various thermodynamic output

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -1024,6 +1024,7 @@ fmag
 fmass
 fmm
 fmt
+fmtlib
 fmx
 fmy
 fmz

--- a/src/CLASS2/dihedral_class2.cpp
+++ b/src/CLASS2/dihedral_class2.cpp
@@ -206,19 +206,8 @@ void DihedralClass2::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-      if (screen) {
-        error->warning(FLERR,fmt::format("Dihedral problem: {} {} {} {} {} {}",
-                                         me,update->ntimestep,
-                                         atom->tag[i1],atom->tag[i2],
-                                         atom->tag[i3],atom->tag[i4]));
-        fmt::print(screen,"  1st atom: {} {} {} {}\n",me,x[i1][0],x[i1][1],x[i1][2]);
-        fmt::print(screen,"  2nd atom: {} {} {} {}\n",me,x[i2][0],x[i2][1],x[i2][2]);
-        fmt::print(screen,"  3rd atom: {} {} {} {}\n",me,x[i3][0],x[i3][1],x[i3][2]);
-        fmt::print(screen,"  4th atom: {} {} {} {}\n",me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/CLASS2/improper_class2.cpp
+++ b/src/CLASS2/improper_class2.cpp
@@ -17,18 +17,17 @@
 
 #include "improper_class2.h"
 
-#include <cmath>
-#include <cstring>
 #include "atom.h"
-#include "neighbor.h"
-#include "update.h"
 #include "comm.h"
+#include "error.h"
 #include "force.h"
 #include "math_const.h"
 #include "memory.h"
-#include "error.h"
+#include "neighbor.h"
+#include "update.h"
 
-
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -153,19 +152,8 @@ void ImproperClass2::compute(int eflag, int vflag)
     // angle error check
 
     for (i = 0; i < 3; i++) {
-      if (costheta[i] == -1.0) {
-        int me = comm->me;
-        if (screen) {
-          error->warning(FLERR,fmt::format("Improper problem: {} {} {} {} {} {}",
-                                           me,update->ntimestep,
-                                           atom->tag[i1],atom->tag[i2],
-                                           atom->tag[i3],atom->tag[i4]));
-          fmt::print(screen,"  1st atom: {} {} {} {}\n",me,x[i1][0],x[i1][1],x[i1][2]);
-          fmt::print(screen,"  2nd atom: {} {} {} {}\n",me,x[i2][0],x[i2][1],x[i2][2]);
-          fmt::print(screen,"  3rd atom: {} {} {} {}\n",me,x[i3][0],x[i3][1],x[i3][2]);
-          fmt::print(screen,"  4th atom: {} {} {} {}\n",me,x[i4][0],x[i4][1],x[i4][2]);
-        }
-      }
+      if (costheta[i] == -1.0)
+        problem(FLERR, i1, i2, i3, i4);
     }
 
     for (i = 0; i < 3; i++) {

--- a/src/COMPRESS/dump_atom_gz.cpp
+++ b/src/COMPRESS/dump_atom_gz.cpp
@@ -72,7 +72,7 @@ void DumpAtomGZ::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/COMPRESS/dump_atom_zstd.cpp
+++ b/src/COMPRESS/dump_atom_zstd.cpp
@@ -80,7 +80,7 @@ void DumpAtomZstd::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/COMPRESS/dump_cfg_gz.cpp
+++ b/src/COMPRESS/dump_cfg_gz.cpp
@@ -74,7 +74,7 @@ void DumpCFGGZ::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/COMPRESS/dump_cfg_zstd.cpp
+++ b/src/COMPRESS/dump_cfg_zstd.cpp
@@ -82,7 +82,7 @@ void DumpCFGZstd::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/COMPRESS/dump_custom_gz.cpp
+++ b/src/COMPRESS/dump_custom_gz.cpp
@@ -72,7 +72,7 @@ void DumpCustomGZ::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/COMPRESS/dump_custom_zstd.cpp
+++ b/src/COMPRESS/dump_custom_zstd.cpp
@@ -79,7 +79,7 @@ void DumpCustomZstd::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/COMPRESS/dump_local_gz.cpp
+++ b/src/COMPRESS/dump_local_gz.cpp
@@ -72,7 +72,7 @@ void DumpLocalGZ::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/COMPRESS/dump_local_zstd.cpp
+++ b/src/COMPRESS/dump_local_zstd.cpp
@@ -79,7 +79,7 @@ void DumpLocalZstd::openfile()
         ++numfiles;
       } else {
         if (remove(nameslist[fileidx]) != 0) {
-          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+          error->warning(FLERR, "Could not delete {}", nameslist[fileidx]);
         }
         delete[] nameslist[fileidx];
         nameslist[fileidx] = utils::strdup(filecurrent);

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -700,7 +700,7 @@ void FixPour::pre_exchange()
   int ninserted_mols = ninserted_atoms / natom;
   ninserted += ninserted_mols;
   if (ninserted_mols < nnew && me == 0)
-    error->warning(FLERR,"Less insertions than requested",0);
+    error->warning(FLERR,"Less insertions than requested");
 
   // reset global natoms,nbonds,etc
   // increment maxtag_all and maxmol_all if necessary

--- a/src/GRANULAR/fix_wall_gran_region.cpp
+++ b/src/GRANULAR/fix_wall_gran_region.cpp
@@ -98,21 +98,17 @@ void FixWallGranRegion::init()
   // check if region properties changed between runs
   // reset if restart info was inconsistent
 
-  if (strcmp(idregion,region->id) != 0 ||
-      strcmp(region_style,region->style) != 0 ||
-      nregion != region->nregion) {
-    char str[256];
-    snprintf(str,256,"Region properties for region %s changed between runs, "
-             "resetting its motion",idregion);
-    error->warning(FLERR,str);
+  if ((strcmp(idregion,region->id) != 0)
+      || (strcmp(region_style,region->style) != 0)
+      || (nregion != region->nregion)) {
+    error->warning(FLERR,"Region properties for region {} changed between "
+                   "runs, resetting its motion",idregion);
     region->reset_vel();
   }
 
   if (motion_resetflag) {
-    char str[256];
-    snprintf(str,256,"Region properties for region %s are inconsistent "
-             "with restart file, resetting its motion",idregion);
-    error->warning(FLERR,str);
+    error->warning(FLERR,"Region properties for region {} are inconsistent "
+                   "with restart file, resetting its motion",idregion);
     region->reset_vel();
   }
 }

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -17,22 +17,22 @@
 
 #include "pair_gran_hooke_history.h"
 
-#include <cmath>
-#include <cstring>
-
 #include "atom.h"
-#include "force.h"
-#include "update.h"
-#include "modify.h"
+#include "comm.h"
+#include "error.h"
 #include "fix.h"
 #include "fix_dummy.h"
 #include "fix_neigh_history.h"
-#include "comm.h"
-#include "neighbor.h"
+#include "force.h"
+#include "memory.h"
+#include "modify.h"
 #include "neigh_list.h"
 #include "neigh_request.h"
-#include "memory.h"
-#include "error.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 
@@ -433,16 +433,10 @@ void PairGranHookeHistory::init_style()
   // it replaces FixDummy, created in the constructor
   // this is so its order in the fix list is preserved
 
-  if (history && fix_history == nullptr) {
-    char dnumstr[16];
-    sprintf(dnumstr,"%d",size_history);
-    char **fixarg = new char*[4];
-    fixarg[0] = (char *) "NEIGH_HISTORY_HH";
-    fixarg[1] = (char *) "all";
-    fixarg[2] = (char *) "NEIGH_HISTORY";
-    fixarg[3] = dnumstr;
-    modify->replace_fix("NEIGH_HISTORY_HH_DUMMY",4,fixarg,1);
-    delete [] fixarg;
+  if (history && (fix_history == nullptr)) {
+    auto cmd = fmt::format("NEIGH_HISTORY_HH all NEIGH_HISTORY {}",
+                           size_history);
+    modify->replace_fix("NEIGH_HISTORY_HH_DUMMY",cmd,1);
     int ifix = modify->find_fix("NEIGH_HISTORY_HH");
     fix_history = (FixNeighHistory *) modify->fix[ifix];
     fix_history->pair = this;

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -1213,13 +1213,10 @@ double PairGranular::init_one(int i, int j)
         (tangential_model[i][i] != tangential_model[j][j]) ||
         (roll_model[i][i] != roll_model[j][j]) ||
         (twist_model[i][i] != twist_model[j][j])) {
-
-      char str[512];
-      sprintf(str,"Granular pair style functional forms are different, "
-              "cannot mix coefficients for types %d and %d. \n"
-              "This combination must be set explicitly "
-              "via pair_coeff command",i,j);
-      error->one(FLERR,str);
+      error->all(FLERR,"Granular pair style functional forms are different, "
+                 "cannot mix coefficients for types {} and {}. \n"
+                 "This combination must be set explicitly via a "
+                 "pair_coeff command",i,j);
     }
 
     if (normal_model[i][j] == HERTZ || normal_model[i][j] == HOOKE)

--- a/src/KOKKOS/bond_fene_kokkos.cpp
+++ b/src/KOKKOS/bond_fene_kokkos.cpp
@@ -29,7 +29,7 @@
 #include <cmath>
 
 using namespace LAMMPS_NS;
-using MathConst::MY_CBRT2;
+using MathConst::MY_CUBEROOT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -200,7 +200,7 @@ void BondFENEKokkos<DeviceType>::operator()(TagBondFENECompute<NEWTON_BOND,EVFLA
   // force from LJ term
 
   F_FLOAT sr6 = 0.0;
-  if (rsq < MY_CBRT2*d_sigma[type]*d_sigma[type]) {
+  if (rsq < MY_CUBEROOT2*d_sigma[type]*d_sigma[type]) {
     const F_FLOAT sr2 = d_sigma[type]*d_sigma[type]/rsq;
     sr6 = sr2*sr2*sr2;
     fbond += 48.0*d_epsilon[type]*sr6*(sr6-0.5)/rsq;
@@ -211,7 +211,7 @@ void BondFENEKokkos<DeviceType>::operator()(TagBondFENECompute<NEWTON_BOND,EVFLA
   F_FLOAT ebond = 0.0;
   if (eflag) {
     ebond = -0.5 * d_k[type]*r0sq*log(rlogarg);
-    if (rsq < MY_CBRT2*d_sigma[type]*d_sigma[type])
+    if (rsq < MY_CUBEROOT2*d_sigma[type]*d_sigma[type])
       ebond += 4.0*d_epsilon[type]*sr6*(sr6-1.0) + d_epsilon[type];
   }
 

--- a/src/KOKKOS/bond_fene_kokkos.cpp
+++ b/src/KOKKOS/bond_fene_kokkos.cpp
@@ -22,13 +22,14 @@
 #include "comm.h"
 #include "error.h"
 #include "force.h"
+#include "math_const.h"
 #include "memory_kokkos.h"
 #include "neighbor_kokkos.h"
 
 #include <cmath>
 
 using namespace LAMMPS_NS;
-
+using MathConst::MY_CBRT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -199,7 +200,7 @@ void BondFENEKokkos<DeviceType>::operator()(TagBondFENECompute<NEWTON_BOND,EVFLA
   // force from LJ term
 
   F_FLOAT sr6 = 0.0;
-  if (rsq < TWO_1_3*d_sigma[type]*d_sigma[type]) {
+  if (rsq < MY_CBRT2*d_sigma[type]*d_sigma[type]) {
     const F_FLOAT sr2 = d_sigma[type]*d_sigma[type]/rsq;
     sr6 = sr2*sr2*sr2;
     fbond += 48.0*d_epsilon[type]*sr6*(sr6-0.5)/rsq;
@@ -210,7 +211,7 @@ void BondFENEKokkos<DeviceType>::operator()(TagBondFENECompute<NEWTON_BOND,EVFLA
   F_FLOAT ebond = 0.0;
   if (eflag) {
     ebond = -0.5 * d_k[type]*r0sq*log(rlogarg);
-    if (rsq < TWO_1_3*d_sigma[type]*d_sigma[type])
+    if (rsq < MY_CBRT2*d_sigma[type]*d_sigma[type])
       ebond += 4.0*d_epsilon[type]*sr6*(sr6-1.0) + d_epsilon[type];
   }
 

--- a/src/KOKKOS/bond_fene_kokkos.cpp
+++ b/src/KOKKOS/bond_fene_kokkos.cpp
@@ -128,7 +128,7 @@ void BondFENEKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_warning_flag.template modify<DeviceType>();
   k_warning_flag.template sync<LMPHostType>();
   if (h_warning_flag())
-    error->warning(FLERR,"FENE bond too long",0);
+    error->warning(FLERR,"FENE bond too long");
 
   k_error_flag.template modify<DeviceType>();
   k_error_flag.template sync<LMPHostType>();

--- a/src/KOKKOS/dihedral_charmm_kokkos.cpp
+++ b/src/KOKKOS/dihedral_charmm_kokkos.cpp
@@ -142,7 +142,7 @@ void DihedralCharmmKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_warning_flag.template modify<DeviceType>();
   k_warning_flag.template sync<LMPHostType>();
   if (h_warning_flag())
-    error->warning(FLERR,"Dihedral problem",0);
+    error->warning(FLERR,"Dihedral problem");
 
   if (eflag_global) {
     energy += evm.emol;

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -165,7 +165,7 @@ void DihedralClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_warning_flag.template modify<DeviceType>();
   k_warning_flag.template sync<LMPHostType>();
   if (h_warning_flag())
-    error->warning(FLERR,"Dihedral problem",0);
+    error->warning(FLERR,"Dihedral problem");
 
   if (eflag_global) energy += ev.evdwl;
   if (vflag_global) {

--- a/src/KOKKOS/dihedral_harmonic_kokkos.cpp
+++ b/src/KOKKOS/dihedral_harmonic_kokkos.cpp
@@ -128,7 +128,7 @@ void DihedralHarmonicKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_warning_flag.template modify<DeviceType>();
   k_warning_flag.template sync<LMPHostType>();
   if (h_warning_flag())
-    error->warning(FLERR,"Dihedral problem",0);
+    error->warning(FLERR,"Dihedral problem");
 
   if (eflag_global) energy += ev.evdwl;
   if (vflag_global) {

--- a/src/KOKKOS/dihedral_opls_kokkos.cpp
+++ b/src/KOKKOS/dihedral_opls_kokkos.cpp
@@ -127,7 +127,7 @@ void DihedralOPLSKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_warning_flag.template modify<DeviceType>();
   k_warning_flag.template sync<LMPHostType>();
   if (h_warning_flag())
-    error->warning(FLERR,"Dihedral problem",0);
+    error->warning(FLERR,"Dihedral problem");
 
   if (eflag_global) energy += ev.evdwl;
   if (vflag_global) {

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -393,7 +393,7 @@ void FixShakeKokkos<DeviceType>::post_force(int vflag)
   Kokkos::deep_copy(h_error_flag,d_error_flag);
 
   if (h_error_flag() == 2)
-    error->warning(FLERR,"Shake determinant < 0.0",0);
+    error->warning(FLERR,"Shake determinant < 0.0");
   else if (h_error_flag() == 3)
     error->one(FLERR,"Shake determinant = 0.0");
 

--- a/src/KOKKOS/improper_class2_kokkos.cpp
+++ b/src/KOKKOS/improper_class2_kokkos.cpp
@@ -141,7 +141,7 @@ void ImproperClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_warning_flag.template modify<DeviceType>();
   k_warning_flag.template sync<LMPHostType>();
   if (h_warning_flag())
-    error->warning(FLERR,"Improper problem",0);
+    error->warning(FLERR,"Improper problem");
 
   // Angle-Angle energy/force
 

--- a/src/KOKKOS/improper_harmonic_kokkos.cpp
+++ b/src/KOKKOS/improper_harmonic_kokkos.cpp
@@ -129,7 +129,7 @@ void ImproperHarmonicKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   k_warning_flag.template modify<DeviceType>();
   k_warning_flag.template sync<LMPHostType>();
   if (h_warning_flag())
-    error->warning(FLERR,"Dihedral problem",0);
+    error->warning(FLERR,"Dihedral problem");
 
   if (eflag_global) energy += ev.evdwl;
   if (vflag_global) {

--- a/src/KOKKOS/neigh_bond_kokkos.cpp
+++ b/src/KOKKOS/neigh_bond_kokkos.cpp
@@ -287,24 +287,16 @@ void NeighBondKokkos<DeviceType>::bond_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Bond atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Bond atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) bond_check();
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Bond atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && me ==0)
+    error->warning(FLERR,"Bond atoms missing at step {}", update->ntimestep);
 
   k_bondlist.modify<DeviceType>();
 }
@@ -382,24 +374,16 @@ void NeighBondKokkos<DeviceType>::bond_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Bond atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Bond atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) bond_check();
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Bond atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && me ==0)
+    error->warning(FLERR,"Bond atoms missing at step {}", update->ntimestep);
 
   k_bondlist.modify<DeviceType>();
 }
@@ -504,24 +488,16 @@ void NeighBondKokkos<DeviceType>::angle_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Angle atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Angle atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) angle_check();
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Angle atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,"Angle atoms missing at step {}", update->ntimestep);
 
   k_anglelist.modify<DeviceType>();
 }
@@ -606,24 +582,16 @@ void NeighBondKokkos<DeviceType>::angle_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Angle atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Angle atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) angle_check();
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Angle atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,"Angle atoms missing at step {}", update->ntimestep);
 
   k_anglelist.modify<DeviceType>();
 }
@@ -748,24 +716,16 @@ void NeighBondKokkos<DeviceType>::dihedral_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Dihedral atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Dihedral atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) dihedral_check(neighbor->ndihedrallist,v_dihedrallist);
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Dihedral atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,"Dihedral atoms missing at step {}", update->ntimestep);
 
   k_dihedrallist.modify<DeviceType>();
 }
@@ -855,24 +815,16 @@ void NeighBondKokkos<DeviceType>::dihedral_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Dihedral atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Dihedral atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) dihedral_check(neighbor->ndihedrallist,v_dihedrallist);
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Dihedral atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,"Dihedral atoms missing at step {}", update->ntimestep);
 
   k_dihedrallist.modify<DeviceType>();
 }
@@ -1019,24 +971,16 @@ void NeighBondKokkos<DeviceType>::improper_all()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Improper atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Improper atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) dihedral_check(neighbor->nimproperlist,v_improperlist);
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Improper atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,"Improper atoms missing at step {}", update->ntimestep);
 
   k_improperlist.modify<DeviceType>();
 }
@@ -1126,24 +1070,16 @@ void NeighBondKokkos<DeviceType>::improper_partial()
     }
   } while (h_fail_flag());
 
-  if (nmissing && lostbond == Thermo::ERROR) {
-    char str[128];
-    sprintf(str,"Improper atoms missing on proc %d at step " BIGINT_FORMAT,
-            me,update->ntimestep);
-    error->one(FLERR,str);
-  }
+  if (nmissing && lostbond == Thermo::ERROR)
+    error->one(FLERR,"Improper atoms missing at step {}", update->ntimestep);
 
   if (neighbor->cluster_check) dihedral_check(neighbor->nimproperlist,v_improperlist);
   if (lostbond == Thermo::IGNORE) return;
 
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
-  if (all) {
-    char str[128];
-    sprintf(str,
-            "Improper atoms missing at step " BIGINT_FORMAT,update->ntimestep);
-    if (me == 0) error->warning(FLERR,str);
-  }
+  if (all && (me == 0))
+    error->warning(FLERR,"Improper atoms missing at step {}", update->ntimestep);
 
   k_improperlist.modify<DeviceType>();
 }

--- a/src/KSPACE/ewald_disp.cpp
+++ b/src/KSPACE/ewald_disp.cpp
@@ -213,11 +213,10 @@ void EwaldDisp::init()
     error->all(FLERR,"Cannot (yet) use 'electron' units with dipoles");
 
   if (qsqsum == 0.0 && bsbsum == 0.0 && M2 == 0.0)
-      error->all(FLERR,"Cannot use Ewald/disp solver "
-                 "on system with no charge, dipole, or LJ particles");
+      error->all(FLERR,"Cannot use Ewald/disp solver on system without "
+                 "charged, dipole, or LJ particles");
   if (fabs(qsum) > SMALL && comm->me == 0)
-    error->warning(FLERR,fmt::format("System is not charge neutral, "
-                                     "net charge = {:.8g}",qsum));
+    error->warning(FLERR,"System is not charge neutral, net charge = {:.8g}",qsum);
 
   if (!function[1] && !function[2]) dispersionflag = 0;
   if (!function[3]) dipoleflag = 0;

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -1085,8 +1085,8 @@ void MSM::set_grid_global()
     *p_cutoff = cutoff;
 
     if (me == 0)
-      error->warning(FLERR,fmt::format("Adjusting Coulombic cutoff for "
-                                       "MSM, new cutoff = {:.8}", cutoff));
+      error->warning(FLERR,"Adjusting Coulombic cutoff for "
+                     "MSM, new cutoff = {:.8}", cutoff);
   }
 
   if (triclinic == 0) {

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -1362,8 +1362,8 @@ void PPPMDisp::init_coeffs()
 
       err =  bmax/amax;
       if (err > 1.0e-4 && comm->me == 0)
-        error->warning(FLERR,fmt::format("Estimated error in splitting of "
-                                         "dispersion coeffs is {}",err));
+        error->warning(FLERR,"Estimated error in splitting of "
+                       "dispersion coeffs is {}",err);
       // set B
 
       B = new double[nsplit*n+nsplit];

--- a/src/MANYBODY/pair_lcbop.cpp
+++ b/src/MANYBODY/pair_lcbop.cpp
@@ -18,8 +18,6 @@
 
 #include "pair_lcbop.h"
 
-#include <cmath>
-#include <cstring>
 #include "atom.h"
 #include "force.h"
 #include "comm.h"
@@ -30,6 +28,8 @@
 #include "memory.h"
 #include "error.h"
 
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 

--- a/src/MC/pair_dsmc.cpp
+++ b/src/MC/pair_dsmc.cpp
@@ -152,9 +152,9 @@ void PairDSMC::compute(int /*eflag*/, int /*vflag*/)
           convert_double_to_equivalent_int(num_of_collisions_double);
 
         if (num_of_collisions > number_of_A)
-          error->warning(FLERR,"Pair dsmc: num_of_collisions > number_of_A",0);
+          error->warning(FLERR,"Pair dsmc: num_of_collisions > number_of_A");
         if (num_of_collisions > number_of_B)
-          error->warning(FLERR,"Pair dsmc: num_of_collisions > number_of_B",0);
+          error->warning(FLERR,"Pair dsmc: num_of_collisions > number_of_B");
 
         // perform collisions on pairs of particles in icell
 

--- a/src/MISC/fix_deposit.cpp
+++ b/src/MISC/fix_deposit.cpp
@@ -593,7 +593,7 @@ void FixDeposit::pre_exchange()
   // warn if not successful b/c too many attempts
 
   if (!success && comm->me == 0)
-    error->warning(FLERR,"Particle deposition was unsuccessful",0);
+    error->warning(FLERR,"Particle deposition was unsuccessful");
 
   // reset global natoms,nbonds,etc
   // increment maxtag_all and maxmol_all if necessary

--- a/src/MISC/fix_deposit.cpp
+++ b/src/MISC/fix_deposit.cpp
@@ -287,8 +287,8 @@ void FixDeposit::init()
 
     double separation = MAX(2.0*maxradinsert,maxradall+maxradinsert);
     if (sqrt(nearsq) < separation && comm->me == 0)
-      error->warning(FLERR,fmt::format("Fix deposit near setting < possible "
-                                       "overlap separation {}",separation));
+      error->warning(FLERR,"Fix deposit near setting < possible "
+                     "overlap separation {}",separation);
   }
 }
 

--- a/src/MISC/fix_ttm.cpp
+++ b/src/MISC/fix_ttm.cpp
@@ -434,7 +434,7 @@ void FixTTM::end_of_step()
     num_inner_timesteps = static_cast<int>(update->dt/inner_dt) + 1;
     inner_dt = update->dt/double(num_inner_timesteps);
     if (num_inner_timesteps > 1000000)
-      error->warning(FLERR,"Too many inner timesteps in fix ttm",0);
+      error->warning(FLERR,"Too many inner timesteps in fix ttm");
   }
 
   for (int ith_inner_timestep = 0; ith_inner_timestep < num_inner_timesteps;

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -254,7 +254,7 @@ double BondFENE::single(int type, double rsq, int /*i*/, int /*j*/,
     char str[128];
     sprintf(str,"FENE bond too long: " BIGINT_FORMAT " %g",
             update->ntimestep,sqrt(rsq));
-    error->warning(FLERR,str,0);
+    error->warning(FLERR,str);
     if (rlogarg <= -3.0) error->one(FLERR,"Bad FENE bond");
     rlogarg = 0.1;
   }

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -13,26 +13,20 @@
 
 #include "bond_fene.h"
 
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neighbor.h"
+#include "update.h"
+
 #include <cmath>
 #include <cstring>
-#include "atom.h"
-#include "neighbor.h"
-#include "comm.h"
-#include "update.h"
-#include "force.h"
-#include "memory.h"
-#include "error.h"
-
-
 
 using namespace LAMMPS_NS;
-
-/* ---------------------------------------------------------------------- */
-
-BondFENE::BondFENE(LAMMPS *lmp) : Bond(lmp)
-{
-  TWO_1_3 = pow(2.0,(1.0/3.0));
-}
+using MathConst::MY_CBRT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -95,7 +89,7 @@ void BondFENE::compute(int eflag, int vflag)
 
     // force from LJ term
 
-    if (rsq < TWO_1_3*sigma[type]*sigma[type]) {
+    if (rsq < MY_CBRT2*sigma[type]*sigma[type]) {
       sr2 = sigma[type]*sigma[type]/rsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*epsilon[type]*sr6*(sr6-0.5)/rsq;
@@ -105,7 +99,7 @@ void BondFENE::compute(int eflag, int vflag)
 
     if (eflag) {
       ebond = -0.5 * k[type]*r0sq*log(rlogarg);
-      if (rsq < TWO_1_3*sigma[type]*sigma[type])
+      if (rsq < MY_CBRT2*sigma[type]*sigma[type])
         ebond += 4.0*epsilon[type]*sr6*(sr6-1.0) + epsilon[type];
     }
 
@@ -251,17 +245,15 @@ double BondFENE::single(int type, double rsq, int /*i*/, int /*j*/,
   // if r > 2*r0 something serious is wrong, abort
 
   if (rlogarg < 0.1) {
-    char str[128];
-    sprintf(str,"FENE bond too long: " BIGINT_FORMAT " %g",
-            update->ntimestep,sqrt(rsq));
-    error->warning(FLERR,str);
+    error->warning(FLERR,"FENE bond too long: {} {:.8}",
+                   update->ntimestep,sqrt(rsq));
     if (rlogarg <= -3.0) error->one(FLERR,"Bad FENE bond");
     rlogarg = 0.1;
   }
 
   double eng = -0.5 * k[type]*r0sq*log(rlogarg);
   fforce = -k[type]/rlogarg;
-  if (rsq < TWO_1_3*sigma[type]*sigma[type]) {
+  if (rsq < MY_CBRT2*sigma[type]*sigma[type]) {
     double sr2,sr6;
     sr2 = sigma[type]*sigma[type]/rsq;
     sr6 = sr2*sr2*sr2;

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -26,7 +26,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-using MathConst::MY_CBRT2;
+using MathConst::MY_CUBEROOT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -89,7 +89,7 @@ void BondFENE::compute(int eflag, int vflag)
 
     // force from LJ term
 
-    if (rsq < MY_CBRT2*sigma[type]*sigma[type]) {
+    if (rsq < MY_CUBEROOT2*sigma[type]*sigma[type]) {
       sr2 = sigma[type]*sigma[type]/rsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*epsilon[type]*sr6*(sr6-0.5)/rsq;
@@ -99,7 +99,7 @@ void BondFENE::compute(int eflag, int vflag)
 
     if (eflag) {
       ebond = -0.5 * k[type]*r0sq*log(rlogarg);
-      if (rsq < MY_CBRT2*sigma[type]*sigma[type])
+      if (rsq < MY_CUBEROOT2*sigma[type]*sigma[type])
         ebond += 4.0*epsilon[type]*sr6*(sr6-1.0) + epsilon[type];
     }
 
@@ -253,7 +253,7 @@ double BondFENE::single(int type, double rsq, int /*i*/, int /*j*/,
 
   double eng = -0.5 * k[type]*r0sq*log(rlogarg);
   fforce = -k[type]/rlogarg;
-  if (rsq < MY_CBRT2*sigma[type]*sigma[type]) {
+  if (rsq < MY_CUBEROOT2*sigma[type]*sigma[type]) {
     double sr2,sr6;
     sr2 = sigma[type]*sigma[type]/rsq;
     sr6 = sr2*sr2*sr2;

--- a/src/MOLECULE/bond_fene.cpp
+++ b/src/MOLECULE/bond_fene.cpp
@@ -85,8 +85,8 @@ void BondFENE::compute(int eflag, int vflag)
     // if r > 2*r0 something serious is wrong, abort
 
     if (rlogarg < 0.1) {
-      error->warning(FLERR,fmt::format("FENE bond too long: {} {} {} {}",
-                     update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq)));
+      error->warning(FLERR,"FENE bond too long: {} {} {} {}",
+                     update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
       if (rlogarg <= -3.0) error->one(FLERR,"Bad FENE bond");
       rlogarg = 0.1;
     }

--- a/src/MOLECULE/bond_fene.h
+++ b/src/MOLECULE/bond_fene.h
@@ -13,7 +13,7 @@
 
 #ifdef BOND_CLASS
 
-BondStyle(fene,BondFENE)
+BondStyle(fene, BondFENE)
 
 #else
 
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class BondFENE : public Bond {
  public:
-  BondFENE(class LAMMPS *);
+  BondFENE(class LAMMPS *lmp) : Bond(lmp) {}
   virtual ~BondFENE();
   virtual void compute(int, int);
   virtual void coeff(int, char **);
@@ -39,18 +39,17 @@ class BondFENE : public Bond {
   virtual void *extract(const char *, int &);
 
  protected:
-  double TWO_1_3;
-  double *k,*r0,*epsilon,*sigma;
+  double *k, *r0, *epsilon, *sigma;
 
   virtual void allocate();
 };
 
-}
+}    // namespace LAMMPS_NS
 
 #endif
 #endif
 
-/* ERROR/WARNING messages:
+    /* ERROR/WARNING messages:
 
 W: FENE bond too long: %ld %d %d %g
 

--- a/src/MOLECULE/bond_fene_expand.cpp
+++ b/src/MOLECULE/bond_fene_expand.cpp
@@ -92,7 +92,7 @@ void BondFENEExpand::compute(int eflag, int vflag)
       sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
               TAGINT_FORMAT " " TAGINT_FORMAT " %g",
               update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
-      error->warning(FLERR,str,0);
+      error->warning(FLERR,str);
       if (rlogarg <= -3.0) error->one(FLERR,"Bad FENE bond");
       rlogarg = 0.1;
     }
@@ -269,7 +269,7 @@ double BondFENEExpand::single(int type, double rsq, int /*i*/, int /*j*/,
     char str[128];
     sprintf(str,"FENE bond too long: " BIGINT_FORMAT " %g",
             update->ntimestep,sqrt(rsq));
-    error->warning(FLERR,str,0);
+    error->warning(FLERR,str);
     if (rlogarg <= -3.0) error->one(FLERR,"Bad FENE bond");
     rlogarg = 0.1;
   }

--- a/src/MOLECULE/bond_fene_expand.cpp
+++ b/src/MOLECULE/bond_fene_expand.cpp
@@ -25,7 +25,7 @@
 #include <cmath>
 
 using namespace LAMMPS_NS;
-using MathConst::MY_CBRT2;
+using MathConst::MY_CUBEROOT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -93,7 +93,7 @@ void BondFENEExpand::compute(int eflag, int vflag)
 
     // force from LJ term
 
-    if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type]) {
+    if (rshiftsq < MY_CUBEROOT2*sigma[type]*sigma[type]) {
       sr2 = sigma[type]*sigma[type]/rshiftsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*epsilon[type]*sr6*(sr6-0.5)/rshift/r;
@@ -103,7 +103,7 @@ void BondFENEExpand::compute(int eflag, int vflag)
 
     if (eflag) {
       ebond = -0.5 * k[type]*r0sq*log(rlogarg);
-      if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type])
+      if (rshiftsq < MY_CUBEROOT2*sigma[type]*sigma[type])
         ebond += 4.0*epsilon[type]*sr6*(sr6-1.0) + epsilon[type];
     }
 
@@ -266,7 +266,7 @@ double BondFENEExpand::single(int type, double rsq, int /*i*/, int /*j*/,
 
   double eng = -0.5 * k[type]*r0sq*log(rlogarg);
   fforce = -k[type]*rshift/rlogarg/r;
-  if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type]) {
+  if (rshiftsq < MY_CUBEROOT2*sigma[type]*sigma[type]) {
     double sr2,sr6;
     sr2 = sigma[type]*sigma[type]/rshiftsq;
     sr6 = sr2*sr2*sr2;

--- a/src/MOLECULE/bond_fene_expand.cpp
+++ b/src/MOLECULE/bond_fene_expand.cpp
@@ -13,24 +13,19 @@
 
 #include "bond_fene_expand.h"
 
-#include <cmath>
 #include "atom.h"
-#include "neighbor.h"
 #include "comm.h"
-#include "update.h"
-#include "force.h"
-#include "memory.h"
 #include "error.h"
+#include "force.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neighbor.h"
+#include "update.h"
 
+#include <cmath>
 
 using namespace LAMMPS_NS;
-
-/* ---------------------------------------------------------------------- */
-
-BondFENEExpand::BondFENEExpand(LAMMPS *lmp) : Bond(lmp)
-{
-  TWO_1_3 = pow(2.0,(1.0/3.0));
-}
+using MathConst::MY_CBRT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -88,11 +83,8 @@ void BondFENEExpand::compute(int eflag, int vflag)
     // if r > 2*r0 something serious is wrong, abort
 
     if (rlogarg < 0.1) {
-      char str[128];
-      sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
-              TAGINT_FORMAT " " TAGINT_FORMAT " %g",
-              update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
-      error->warning(FLERR,str);
+      error->warning(FLERR,"FENE bond too long: {} {} {} {:.8}",
+                     update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
       if (rlogarg <= -3.0) error->one(FLERR,"Bad FENE bond");
       rlogarg = 0.1;
     }
@@ -101,7 +93,7 @@ void BondFENEExpand::compute(int eflag, int vflag)
 
     // force from LJ term
 
-    if (rshiftsq < TWO_1_3*sigma[type]*sigma[type]) {
+    if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type]) {
       sr2 = sigma[type]*sigma[type]/rshiftsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*epsilon[type]*sr6*(sr6-0.5)/rshift/r;
@@ -111,7 +103,7 @@ void BondFENEExpand::compute(int eflag, int vflag)
 
     if (eflag) {
       ebond = -0.5 * k[type]*r0sq*log(rlogarg);
-      if (rshiftsq < TWO_1_3*sigma[type]*sigma[type])
+      if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type])
         ebond += 4.0*epsilon[type]*sr6*(sr6-1.0) + epsilon[type];
     }
 
@@ -266,17 +258,15 @@ double BondFENEExpand::single(int type, double rsq, int /*i*/, int /*j*/,
   // if r > 2*r0 something serious is wrong, abort
 
   if (rlogarg < 0.1) {
-    char str[128];
-    sprintf(str,"FENE bond too long: " BIGINT_FORMAT " %g",
-            update->ntimestep,sqrt(rsq));
-    error->warning(FLERR,str);
+    error->warning(FLERR,"FENE bond too long: {} {:.8}",
+                     update->ntimestep,sqrt(rsq));
     if (rlogarg <= -3.0) error->one(FLERR,"Bad FENE bond");
     rlogarg = 0.1;
   }
 
   double eng = -0.5 * k[type]*r0sq*log(rlogarg);
   fforce = -k[type]*rshift/rlogarg/r;
-  if (rshiftsq < TWO_1_3*sigma[type]*sigma[type]) {
+  if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type]) {
     double sr2,sr6;
     sr2 = sigma[type]*sigma[type]/rshiftsq;
     sr6 = sr2*sr2*sr2;

--- a/src/MOLECULE/bond_fene_expand.h
+++ b/src/MOLECULE/bond_fene_expand.h
@@ -13,7 +13,7 @@
 
 #ifdef BOND_CLASS
 
-BondStyle(fene/expand,BondFENEExpand)
+BondStyle(fene / expand, BondFENEExpand)
 
 #else
 
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class BondFENEExpand : public Bond {
  public:
-  BondFENEExpand(class LAMMPS *);
+  BondFENEExpand(class LAMMPS *lmp) : Bond(lmp) {}
   virtual ~BondFENEExpand();
   virtual void compute(int, int);
   void coeff(int, char **);
@@ -38,18 +38,17 @@ class BondFENEExpand : public Bond {
   double single(int, double, int, int, double &);
 
  protected:
-  double TWO_1_3;
-  double *k,*r0,*epsilon,*sigma,*shift;
+  double *k, *r0, *epsilon, *sigma, *shift;
 
   void allocate();
 };
 
-}
+}    // namespace LAMMPS_NS
 
 #endif
 #endif
 
-/* ERROR/WARNING messages:
+    /* ERROR/WARNING messages:
 
 W: FENE bond too long: %ld %d %d %g
 

--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -378,15 +378,15 @@ void BondTable::read_table(Table *tb, char *file, char *keyword)
   }
 
   if (ferror) {
-    error->warning(FLERR, fmt::format("{} of {} force values in table are inconsistent with -dE/dr.\n"
-                                      "  Should only be flagged at inflection points",ferror,tb->ninput));
+    error->warning(FLERR, "{} of {} force values in table are inconsistent with -dE/dr.\n"
+                   "WARNING:  Should only be flagged at inflection points",ferror,tb->ninput);
   }
 
   // warn if data was read incompletely, e.g. columns were missing
 
   if (cerror) {
-    error->warning(FLERR, fmt::format("{} of {} lines in table were incomplete or could not be"
-                                      " parsed completely",cerror,tb->ninput));
+    error->warning(FLERR, "{} of {} lines in table were incomplete or could not be"
+                   " parsed completely",cerror,tb->ninput);
   }
 }
 

--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -17,19 +17,17 @@
 
 #include "bond_table.h"
 
-#include <cmath>
-
-#include <cstring>
 #include "atom.h"
-#include "neighbor.h"
 #include "comm.h"
+#include "error.h"
 #include "force.h"
 #include "memory.h"
-#include "error.h"
-
-#include "tokenizer.h"
+#include "neighbor.h"
 #include "table_file_reader.h"
+#include "tokenizer.h"
 
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 
@@ -596,18 +594,14 @@ void BondTable::uf_lookup(int type, double x, double &u, double &f)
   }
 
   double fraction,a,b;
-  char estr[128];
   const Table *tb = &tables[tabindex[type]];
   const int itable = static_cast<int> ((x - tb->lo) * tb->invdelta);
-  if (itable < 0) {
-    sprintf(estr,"Bond length < table inner cutoff: "
-            "type %d length %g",type,x);
-    error->one(FLERR,estr);
-  } else if (itable >= tablength) {
-    sprintf(estr,"Bond length > table outer cutoff: "
-            "type %d length %g",type,x);
-    error->one(FLERR,estr);
-  }
+  if (itable < 0)
+    error->one(FLERR,"Bond length < table inner cutoff: "
+               "type {} length {:.8}",type,x);
+  else if (itable >= tablength)
+    error->one(FLERR,"Bond length > table outer cutoff: "
+               "type {} length {:.8}",type,x);
 
   if (tabstyle == LINEAR) {
     fraction = (x - tb->r[itable]) * tb->invdelta;

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -153,7 +153,7 @@ void DihedralCharmm::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -143,27 +143,8 @@ void DihedralCharmm::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -146,27 +146,8 @@ void DihedralCharmmfsw::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -156,7 +156,7 @@ void DihedralCharmmfsw::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/dihedral_harmonic.cpp
+++ b/src/MOLECULE/dihedral_harmonic.cpp
@@ -129,27 +129,8 @@ void DihedralHarmonic::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/dihedral_harmonic.cpp
+++ b/src/MOLECULE/dihedral_harmonic.cpp
@@ -139,7 +139,7 @@ void DihedralHarmonic::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/dihedral_helix.cpp
+++ b/src/MOLECULE/dihedral_helix.cpp
@@ -170,7 +170,7 @@ void DihedralHelix::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/dihedral_helix.cpp
+++ b/src/MOLECULE/dihedral_helix.cpp
@@ -160,27 +160,8 @@ void DihedralHelix::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/dihedral_multi_harmonic.cpp
+++ b/src/MOLECULE/dihedral_multi_harmonic.cpp
@@ -152,27 +152,8 @@ void DihedralMultiHarmonic::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/dihedral_multi_harmonic.cpp
+++ b/src/MOLECULE/dihedral_multi_harmonic.cpp
@@ -162,7 +162,7 @@ void DihedralMultiHarmonic::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/dihedral_opls.cpp
+++ b/src/MOLECULE/dihedral_opls.cpp
@@ -168,7 +168,7 @@ void DihedralOPLS::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/dihedral_opls.cpp
+++ b/src/MOLECULE/dihedral_opls.cpp
@@ -158,27 +158,8 @@ void DihedralOPLS::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/improper_cvff.cpp
+++ b/src/MOLECULE/improper_cvff.cpp
@@ -153,7 +153,7 @@ void ImproperCvff::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/improper_cvff.cpp
+++ b/src/MOLECULE/improper_cvff.cpp
@@ -143,27 +143,8 @@ void ImproperCvff::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/improper_harmonic.cpp
+++ b/src/MOLECULE/improper_harmonic.cpp
@@ -127,7 +127,7 @@ void ImproperHarmonic::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/improper_harmonic.cpp
+++ b/src/MOLECULE/improper_harmonic.cpp
@@ -117,27 +117,8 @@ void ImproperHarmonic::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/MOLECULE/improper_umbrella.cpp
+++ b/src/MOLECULE/improper_umbrella.cpp
@@ -134,7 +134,7 @@ void ImproperUmbrella::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/MOLECULE/improper_umbrella.cpp
+++ b/src/MOLECULE/improper_umbrella.cpp
@@ -124,27 +124,8 @@ void ImproperUmbrella::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/PLUGIN/plugin.cpp
+++ b/src/PLUGIN/plugin.cpp
@@ -171,9 +171,8 @@ namespace LAMMPS_NS
       auto pair_map = lmp->force->pair_map;
       if (pair_map->find(plugin->name) != pair_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in pair "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in pair "
+                              "style {} from plugin",plugin->name);
       }
       (*pair_map)[plugin->name] = (Force::PairCreator)plugin->creator.v1;
 
@@ -181,9 +180,8 @@ namespace LAMMPS_NS
       auto bond_map = lmp->force->bond_map;
       if (bond_map->find(plugin->name) != bond_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in bond "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in bond "
+                              "style {} from plugin",plugin->name);
       }
       (*bond_map)[plugin->name] = (Force::BondCreator)plugin->creator.v1;
 
@@ -191,9 +189,8 @@ namespace LAMMPS_NS
       auto angle_map = lmp->force->angle_map;
       if (angle_map->find(plugin->name) != angle_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in angle "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in angle "
+                              "style {} from plugin",plugin->name);
       }
       (*angle_map)[plugin->name] = (Force::AngleCreator)plugin->creator.v1;
 
@@ -201,9 +198,8 @@ namespace LAMMPS_NS
       auto dihedral_map = lmp->force->dihedral_map;
       if (dihedral_map->find(plugin->name) != dihedral_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in dihedral "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in dihedral "
+                              "style {} from plugin",plugin->name);
       }
       (*dihedral_map)[plugin->name] = (Force::DihedralCreator)plugin->creator.v1;
 
@@ -211,9 +207,8 @@ namespace LAMMPS_NS
       auto improper_map = lmp->force->improper_map;
       if (improper_map->find(plugin->name) != improper_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in improper "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in improper "
+                              "style {} from plugin",plugin->name);
       }
       (*improper_map)[plugin->name] = (Force::ImproperCreator)plugin->creator.v1;
 
@@ -221,9 +216,8 @@ namespace LAMMPS_NS
       auto compute_map = lmp->modify->compute_map;
       if (compute_map->find(plugin->name) != compute_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in compute "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in compute "
+                              "style {} from plugin",plugin->name);
       }
       (*compute_map)[plugin->name] = (Modify::ComputeCreator)plugin->creator.v2;
 
@@ -231,9 +225,8 @@ namespace LAMMPS_NS
       auto fix_map = lmp->modify->fix_map;
       if (fix_map->find(plugin->name) != fix_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in fix "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in fix "
+                              "style {} from plugin",plugin->name);
       }
       (*fix_map)[plugin->name] = (Modify::FixCreator)plugin->creator.v2;
 
@@ -241,9 +234,8 @@ namespace LAMMPS_NS
       auto region_map = lmp->domain->region_map;
       if (region_map->find(plugin->name) != region_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in region "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in region "
+                              "style {} from plugin",plugin->name);
       }
       (*region_map)[plugin->name] = (Domain::RegionCreator)plugin->creator.v2;
 
@@ -251,9 +243,8 @@ namespace LAMMPS_NS
       auto command_map = lmp->input->command_map;
       if (command_map->find(plugin->name) != command_map->end()) {
         if (lmp->comm->me == 0)
-          lmp->error->warning(FLERR,fmt::format("Overriding built-in command "
-                                                "style {} from plugin",
-                                                plugin->name));
+          lmp->error->warning(FLERR,"Overriding built-in command "
+                              "style {} from plugin",plugin->name);
       }
       (*command_map)[plugin->name] = (Input::CommandCreator)plugin->creator.v1;
 

--- a/src/POEMS/fix_poems.cpp
+++ b/src/POEMS/fix_poems.cpp
@@ -941,11 +941,9 @@ void FixPOEMS::readfile(char *file)
 
   if (me == 0) {
     fp = fopen(file,"r");
-    if (fp == nullptr) {
-      char str[128];
-      snprintf(str,128,"Cannot open fix poems file %s",file);
-      error->one(FLERR,str);
-    }
+    if (fp == nullptr)
+      error->one(FLERR,"Cannot open fix poems file {}: {}",
+                 file, utils::getsyserror());
   }
 
   nbody = 0;

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -387,10 +387,9 @@ int FixQEq::CG( double *b, double *x )
   }
 
   if ((comm->me == 0) && (loop >= maxiter))
-    error->warning(FLERR,fmt::format("Fix qeq CG convergence failed ({}) "
-                                     "after {} iterations at step {}",
-                                     sqrt(sig_new)/b_norm,loop,
-                                     update->ntimestep));
+    error->warning(FLERR,"Fix qeq CG convergence failed ({}) after {} "
+                   "iterations at step {}",sqrt(sig_new)/b_norm,loop,
+                   update->ntimestep);
   return loop;
 }
 

--- a/src/QEQ/fix_qeq_dynamic.cpp
+++ b/src/QEQ/fix_qeq_dynamic.cpp
@@ -155,8 +155,8 @@ void FixQEqDynamic::pre_force(int /*vflag*/)
   }
 
   if ((comm->me == 0) && (iloop >= maxiter))
-      error->warning(FLERR,fmt::format("Charges did not converge at step "
-                                       "{}: {}",update->ntimestep,enegchk));
+      error->warning(FLERR,"Charges did not converge at step {}: {}",
+                     update->ntimestep,enegchk);
 
   if (force->kspace) force->kspace->qsum_qsq();
 }

--- a/src/QEQ/fix_qeq_fire.cpp
+++ b/src/QEQ/fix_qeq_fire.cpp
@@ -215,8 +215,8 @@ void FixQEqFire::pre_force(int /*vflag*/)
   }
 
   if ((comm->me == 0) && (iloop >= maxiter))
-    error->warning(FLERR,fmt::format("Charges did not converge at step "
-                                     "{}: {}",update->ntimestep,enegchk));
+    error->warning(FLERR,"Charges did not converge at step {}: {}",
+                   update->ntimestep,enegchk);
 
   if (force->kspace) force->kspace->qsum_qsq();
 }

--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -547,13 +547,11 @@ void NEB::open(char *file)
   if (!compressed) fp = fopen(file,"r");
   else {
 #ifdef LAMMPS_GZIP
-    char gunzip[128];
-    snprintf(gunzip,128,"gzip -c -d %s",file);
-
+    auto gunzip = std::string("gzip -c -d ") + file;
 #ifdef _WIN32
-    fp = _popen(gunzip,"rb");
+    fp = _popen(gunzip.c_str(),"rb");
 #else
-    fp = popen(gunzip,"r");
+    fp = popen(gunzip.c_str(),"r");
 #endif
 
 #else
@@ -561,11 +559,8 @@ void NEB::open(char *file)
 #endif
   }
 
-  if (fp == nullptr) {
-    char str[128];
-    snprintf(str,128,"Cannot open file %s",file);
-    error->one(FLERR,str);
-  }
+  if (fp == nullptr)
+    error->one(FLERR,"Cannot open file {}: {}",file,utils::getsyserror());
 }
 
 /* ----------------------------------------------------------------------

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -697,8 +697,8 @@ void FixRigid::init()
       if (modify->fix[i]->rigid_flag) rflag = 1;
       if (rflag && (modify->fmask[i] & POST_FORCE) &&
           !modify->fix[i]->rigid_flag)
-        error->warning(FLERR,fmt::format("Fix {} alters forces after fix "
-                                         "rigid",modify->fix[i]->id));
+        error->warning(FLERR,"Fix {} alters forces after fix rigid",
+                       modify->fix[i]->id);
     }
   }
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -548,8 +548,8 @@ void FixRigidSmall::init()
       if (modify->fix[i]->rigid_flag) rflag = 1;
       if (rflag && (modify->fmask[i] & POST_FORCE) &&
           !modify->fix[i]->rigid_flag)
-        error->warning(FLERR,fmt::format("Fix {} alters forces after fix "
-                                         "rigid",modify->fix[i]->id));
+        error->warning(FLERR,"Fix {} alters forces after fix rigid",
+                       modify->fix[i]->id);
     }
   }
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -1716,7 +1716,7 @@ void FixShake::shake(int m)
 
   double determ = b*b - 4.0*a*c;
   if (determ < 0.0) {
-    error->warning(FLERR,"Shake determinant < 0.0",0);
+    error->warning(FLERR,"Shake determinant < 0.0");
     determ = 0.0;
   }
 

--- a/src/SPIN/neb_spin.cpp
+++ b/src/SPIN/neb_spin.cpp
@@ -692,13 +692,11 @@ void NEBSpin::open(char *file)
   if (!compressed) fp = fopen(file,"r");
   else {
 #ifdef LAMMPS_GZIP
-    char gunzip[128];
-    snprintf(gunzip,128,"gzip -c -d %s",file);
-
+    auto gunzip = std::string("gzip -c -d ") + file;
 #ifdef _WIN32
-    fp = _popen(gunzip,"rb");
+    fp = _popen(gunzip.c_str(),"rb");
 #else
-    fp = popen(gunzip,"r");
+    fp = popen(gunzip.c_str(),"r");
 #endif
 
 #else
@@ -706,11 +704,8 @@ void NEBSpin::open(char *file)
 #endif
   }
 
-  if (fp == nullptr) {
-    char str[128];
-    snprintf(str,128,"Cannot open file %s",file);
-    error->one(FLERR,str);
-  }
+  if (fp == nullptr)
+    error->one(FLERR,"Cannot open file {}: {}",file,utils::getsyserror());
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-BOCS/fix_bocs.cpp
+++ b/src/USER-BOCS/fix_bocs.cpp
@@ -629,7 +629,7 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
     // NB: LAMMPS coding guidelines prefer cstdio so we are intentionally
     // foregoing  reading with getline
     if (comm->me == 0) {
-        error->message(FLERR, fmt::format("INFO: About to read data file: {}", filename));
+        error->message(FLERR, "INFO: About to read data file: {}", filename);
     }
 
     // Data file lines hold two floating point numbers.
@@ -645,7 +645,7 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
 
     numEntries = inputLines.size();
     if (comm->me == 0) {
-      error->message(FLERR, fmt::format("INFO: Read {} lines from file", numEntries));
+      error->message(FLERR, "INFO: Read {} lines from file", numEntries);
     }
 
 
@@ -670,34 +670,23 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
       test_sscanf = sscanf(inputLines.at(i).c_str()," %f , %f ",&f1, &f2);
       if (test_sscanf == 2)
       {
-        //if (comm->me == 0) {
-        //    error->message(FLERR, fmt::format("INFO: f1 = {}, f2 = {}", f1, f2));
-        //}
         data[VOLUME][i] = (double)f1;
         data[PRESSURE_CORRECTION][i] = (double)f2;
         if (i == 1)
         {
           // second entry is used to compute the validation interval used below
           stdVolumeInterval = data[VOLUME][i] - data[VOLUME][i-1];
-          //if (comm->me == 0) {
-          //    error->message(FLERR, fmt::format("INFO: standard volume interval computed: {}", stdVolumeInterval));
-          //}
         }
         else if (i > 1)
         {
           // after second entry, all intervals are validated
           currVolumeInterval = data[VOLUME][i] - data[VOLUME][i-1];
-          //if (comm->me == 0) {
-          //    error->message(FLERR, fmt::format("INFO: current volume interval: {}", currVolumeInterval));
-          //}
           if (fabs(currVolumeInterval - stdVolumeInterval) > volumeIntervalTolerance) {
-            if (comm->me == 0) {
-                message = fmt::format("Bad volume interval. Spline analysis requires uniform"
-                                      " volume distribution, found inconsistent volume"
-                                      " differential, line {} of file {}\n\tline: {}",
-                                      lineNum, filename, inputLines.at(i));
-                error->warning(FLERR, message);
-            }
+            if (comm->me == 0)
+              error->warning(FLERR,"Bad volume interval. Spline analysis requires uniform"
+                             " volume distribution, found inconsistent volume"
+                             " differential, line {} of file {}\nWARNING:\tline: {}",
+                             lineNum, filename, inputLines.at(i));
             badInput = true;
             numBadVolumeIntervals++;
           }
@@ -706,12 +695,10 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
       }
       else
       {
-        if (comm->me == 0) {
-          message = fmt::format("Bad input format: did not find 2 comma separated numeric"
-                                " values in line {} of file {}\n\tline: {}",
-                                lineNum, filename, inputLines.at(i));
-          error->warning(FLERR, message);
-        }
+        if (comm->me == 0)
+          error->warning(FLERR,"Bad input format: did not find 2 comma separated numeric"
+                         " values in line {} of file {}\nWARNING:\tline: {}",
+                         lineNum, filename, inputLines.at(i));
         badInput = true;
       }
       if (badInput)
@@ -721,7 +708,7 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
     }
 
     if (numBadVolumeIntervals > 0 && comm->me == 0) {
-      error->message(FLERR, fmt::format("INFO: total number bad volume intervals = {}", numBadVolumeIntervals));
+      error->message(FLERR, "INFO: total number bad volume intervals = {}", numBadVolumeIntervals);
     }
   }
   else {
@@ -729,7 +716,7 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
   }
 
   if (badInput && comm->me == 0) {
-    error->warning(FLERR,fmt::format("Bad volume / pressure-correction data: {}\nSee details above", filename));
+    error->warning(FLERR,"Bad volume / pressure-correction data: {}\nSee details above", filename);
   }
 
   if (p_basis_type == BASIS_LINEAR_SPLINE)
@@ -752,9 +739,6 @@ int FixBocs::read_F_table( char *filename, int p_basis_type )
 }
 
 int FixBocs::build_linear_splines(double **data) {
-  //if (comm->me == 0) {
-    //error->message(FLERR, fmt::format("INFO: entering build_linear_splines, spline_length = {}", spline_length));
-  //}
   splines = (double **) calloc(NUM_LINEAR_SPLINE_COLUMNS,sizeof(double *));
   splines[VOLUME] = (double *) calloc(spline_length,sizeof(double));
   splines[PRESSURE_CORRECTION] = (double *) calloc(spline_length,sizeof(double));
@@ -766,7 +750,7 @@ int FixBocs::build_linear_splines(double **data) {
   }
 
   if (comm->me == 0) {
-    error->message(FLERR, fmt::format("INFO: leaving build_linear_splines, spline_length = {}", spline_length));
+    error->message(FLERR, "INFO: leaving build_linear_splines, spline_length = {}", spline_length);
   }
 
   return spline_length;
@@ -774,9 +758,6 @@ int FixBocs::build_linear_splines(double **data) {
 
 int FixBocs::build_cubic_splines(double **data)
 {
-  //if (comm->me == 0) {
-    //error->message(FLERR, fmt::format("INFO: entering build_cubic_splines, spline_length = {}", spline_length));
-  //}
   int n = spline_length;
   double *a, *b, *d, *h, *alpha, *c, *l, *mu, *z;
   // 2020-07-17 ag:
@@ -867,7 +848,7 @@ int FixBocs::build_cubic_splines(double **data)
   memory->destroy(z);
 
   if (comm->me == 0) {
-    error->message(FLERR, fmt::format("INFO: leaving build_cubic_splines, numSplines = {}", numSplines));
+    error->message(FLERR, "INFO: leaving build_cubic_splines, numSplines = {}", numSplines);
   }
 
   // Tell the caller how many splines we created

--- a/src/USER-CGDNA/bond_oxdna_fene.cpp
+++ b/src/USER-CGDNA/bond_oxdna_fene.cpp
@@ -221,7 +221,7 @@ void BondOxdnaFene::compute(int eflag, int vflag)
       sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
               TAGINT_FORMAT " " TAGINT_FORMAT " %g",
               update->ntimestep,atom->tag[a],atom->tag[b],r);
-      error->warning(FLERR,str,0);
+      error->warning(FLERR,str);
       rlogarg = 0.1;
     }
 
@@ -400,7 +400,7 @@ double BondOxdnaFene::single(int type, double rsq, int /*i*/, int /*j*/,
     char str[128];
     sprintf(str,"FENE bond too long: " BIGINT_FORMAT " %g",
             update->ntimestep,sqrt(rsq));
-    error->warning(FLERR,str,0);
+    error->warning(FLERR,str);
     rlogarg = 0.1;
   }
 

--- a/src/USER-INTEL/bond_fene_intel.cpp
+++ b/src/USER-INTEL/bond_fene_intel.cpp
@@ -22,6 +22,7 @@
 #include "comm.h"
 #include "error.h"
 #include "force.h"
+#include "math_const.h"
 #include "memory.h"
 #include "modify.h"
 #include "neighbor.h"
@@ -32,6 +33,7 @@
 #include "omp_compat.h"
 
 using namespace LAMMPS_NS;
+using MathConst::MY_CBRT2;
 
 typedef struct { int a,b,t;  } int3_t;
 
@@ -183,11 +185,8 @@ void BondFENEIntel::eval(const int vflag,
       // if r > 2*r0 something serious is wrong, abort
 
       if (rlogarg < (flt_t)0.1) {
-        char str[128];
-        sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " %g",
-                update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
-        error->warning(FLERR,str);
+        error->warning(FLERR,"FENE bond too long: {} {} {} {:.8}",
+                       update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
         if (rlogarg <= (flt_t)-3.0) error->one(FLERR,"Bad FENE bond");
         rlogarg = (flt_t)0.1;
       }
@@ -197,7 +196,7 @@ void BondFENEIntel::eval(const int vflag,
       // force from LJ term
 
       flt_t sr2,sr6;
-      if (rsq < (flt_t)TWO_1_3*sigmasq) {
+      if (rsq < (flt_t)MY_CBRT2*sigmasq) {
         sr2 = sigmasq * irsq;
         sr6 = sr2 * sr2 * sr2;
         fbond += (flt_t)48.0 * epsilon * sr6 * (sr6 - (flt_t)0.5) * irsq;
@@ -208,7 +207,7 @@ void BondFENEIntel::eval(const int vflag,
       flt_t ebond;
       if (EFLAG) {
         ebond = (flt_t)-0.5 * k / ir0sq * log(rlogarg);
-        if (rsq < (flt_t)TWO_1_3 * sigmasq)
+        if (rsq < (flt_t)MY_CBRT2 * sigmasq)
           ebond += (flt_t)4.0 * epsilon * sr6 * (sr6 - (flt_t)1.0) + epsilon;
       }
 

--- a/src/USER-INTEL/bond_fene_intel.cpp
+++ b/src/USER-INTEL/bond_fene_intel.cpp
@@ -33,7 +33,7 @@
 #include "omp_compat.h"
 
 using namespace LAMMPS_NS;
-using MathConst::MY_CBRT2;
+using MathConst::MY_CUBEROOT2;
 
 typedef struct { int a,b,t;  } int3_t;
 
@@ -196,7 +196,7 @@ void BondFENEIntel::eval(const int vflag,
       // force from LJ term
 
       flt_t sr2,sr6;
-      if (rsq < (flt_t)MY_CBRT2*sigmasq) {
+      if (rsq < (flt_t)MY_CUBEROOT2*sigmasq) {
         sr2 = sigmasq * irsq;
         sr6 = sr2 * sr2 * sr2;
         fbond += (flt_t)48.0 * epsilon * sr6 * (sr6 - (flt_t)0.5) * irsq;
@@ -207,7 +207,7 @@ void BondFENEIntel::eval(const int vflag,
       flt_t ebond;
       if (EFLAG) {
         ebond = (flt_t)-0.5 * k / ir0sq * log(rlogarg);
-        if (rsq < (flt_t)MY_CBRT2 * sigmasq)
+        if (rsq < (flt_t)MY_CUBEROOT2 * sigmasq)
           ebond += (flt_t)4.0 * epsilon * sr6 * (sr6 - (flt_t)1.0) + epsilon;
       }
 

--- a/src/USER-INTEL/bond_fene_intel.cpp
+++ b/src/USER-INTEL/bond_fene_intel.cpp
@@ -187,7 +187,7 @@ void BondFENEIntel::eval(const int vflag,
         sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
                 TAGINT_FORMAT " " TAGINT_FORMAT " %g",
                 update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         if (rlogarg <= (flt_t)-3.0) error->one(FLERR,"Bad FENE bond");
         rlogarg = (flt_t)0.1;
       }

--- a/src/USER-INTEL/dihedral_charmm_intel.cpp
+++ b/src/USER-INTEL/dihedral_charmm_intel.cpp
@@ -245,27 +245,8 @@ void DihedralCharmmIntel::eval(const int vflag,
 
       // error check
       #ifndef LMP_SIMD_COMPILER_TEST
-      if (c > PTOLERANCE || c < MTOLERANCE) {
-        int me = comm->me;
-
-        if (screen) {
-          char str[128];
-          sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT,
-                  me,tid,update->ntimestep,
-                  atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str);
-          fprintf(screen,"  1st atom: %d %g %g %g\n",
-                  me,x[i1].x,x[i1].y,x[i1].z);
-          fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                  me,x[i2].x,x[i2].y,x[i2].z);
-          fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                  me,x[i3].x,x[i3].y,x[i3].z);
-          fprintf(screen,"  4th atom: %d %g %g %g\n",
-                  me,x[i4].x,x[i4].y,x[i4].z);
-        }
-      }
+      if (c > PTOLERANCE || c < MTOLERANCE)
+        problem(FLERR, i1, i2, i3, i4);
       #endif
 
       if (c > (flt_t)1.0) c = (flt_t)1.0;

--- a/src/USER-INTEL/dihedral_charmm_intel.cpp
+++ b/src/USER-INTEL/dihedral_charmm_intel.cpp
@@ -255,7 +255,7 @@ void DihedralCharmmIntel::eval(const int vflag,
                   TAGINT_FORMAT " " TAGINT_FORMAT,
                   me,tid,update->ntimestep,
                   atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str,0);
+          error->warning(FLERR,str);
           fprintf(screen,"  1st atom: %d %g %g %g\n",
                   me,x[i1].x,x[i1].y,x[i1].z);
           fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-INTEL/dihedral_fourier_intel.cpp
+++ b/src/USER-INTEL/dihedral_fourier_intel.cpp
@@ -208,27 +208,8 @@ void DihedralFourierIntel::eval(const int vflag,
 
       // error check
       #ifndef LMP_INTEL_USE_SIMDOFF
-      if (c > PTOLERANCE || c < MTOLERANCE) {
-        int me = comm->me;
-
-        if (screen) {
-          char str[128];
-          sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT,
-                  me,tid,update->ntimestep,
-                  atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str);
-          fprintf(screen,"  1st atom: %d %g %g %g\n",
-                  me,x[i1].x,x[i1].y,x[i1].z);
-          fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                  me,x[i2].x,x[i2].y,x[i2].z);
-          fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                  me,x[i3].x,x[i3].y,x[i3].z);
-          fprintf(screen,"  4th atom: %d %g %g %g\n",
-                  me,x[i4].x,x[i4].y,x[i4].z);
-        }
-      }
+      if (c > PTOLERANCE || c < MTOLERANCE)
+        problem(FLERR, i1, i2, i3, i4);
       #endif
 
       if (c > (flt_t)1.0) c = (flt_t)1.0;

--- a/src/USER-INTEL/dihedral_fourier_intel.cpp
+++ b/src/USER-INTEL/dihedral_fourier_intel.cpp
@@ -218,7 +218,7 @@ void DihedralFourierIntel::eval(const int vflag,
                   TAGINT_FORMAT " " TAGINT_FORMAT,
                   me,tid,update->ntimestep,
                   atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str,0);
+          error->warning(FLERR,str);
           fprintf(screen,"  1st atom: %d %g %g %g\n",
                   me,x[i1].x,x[i1].y,x[i1].z);
           fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-INTEL/dihedral_harmonic_intel.cpp
+++ b/src/USER-INTEL/dihedral_harmonic_intel.cpp
@@ -218,7 +218,7 @@ void DihedralHarmonicIntel::eval(const int vflag,
                   TAGINT_FORMAT " " TAGINT_FORMAT,
                   me,tid,update->ntimestep,
                   atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str,0);
+          error->warning(FLERR,str);
           fprintf(screen,"  1st atom: %d %g %g %g\n",
                   me,x[i1].x,x[i1].y,x[i1].z);
           fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-INTEL/dihedral_harmonic_intel.cpp
+++ b/src/USER-INTEL/dihedral_harmonic_intel.cpp
@@ -208,27 +208,8 @@ void DihedralHarmonicIntel::eval(const int vflag,
 
       // error check
       #ifndef LMP_INTEL_USE_SIMDOFF
-      if (c > PTOLERANCE || c < MTOLERANCE) {
-        int me = comm->me;
-
-        if (screen) {
-          char str[128];
-          sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT,
-                  me,tid,update->ntimestep,
-                  atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str);
-          fprintf(screen,"  1st atom: %d %g %g %g\n",
-                  me,x[i1].x,x[i1].y,x[i1].z);
-          fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                  me,x[i2].x,x[i2].y,x[i2].z);
-          fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                  me,x[i3].x,x[i3].y,x[i3].z);
-          fprintf(screen,"  4th atom: %d %g %g %g\n",
-                  me,x[i4].x,x[i4].y,x[i4].z);
-        }
-      }
+      if (c > PTOLERANCE || c < MTOLERANCE)
+        problem(FLERR, i1, i2, i3, i4);
       #endif
 
       if (c > (flt_t)1.0) c = (flt_t)1.0;

--- a/src/USER-INTEL/dihedral_opls_intel.cpp
+++ b/src/USER-INTEL/dihedral_opls_intel.cpp
@@ -244,7 +244,7 @@ void DihedralOPLSIntel::eval(const int vflag,
                   TAGINT_FORMAT " " TAGINT_FORMAT,
                   me,tid,update->ntimestep,
                   atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str,0);
+          error->warning(FLERR,str);
           fprintf(screen,"  1st atom: %d %g %g %g\n",
                   me,x[i1].x,x[i1].y,x[i1].z);
           fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-INTEL/dihedral_opls_intel.cpp
+++ b/src/USER-INTEL/dihedral_opls_intel.cpp
@@ -234,27 +234,8 @@ void DihedralOPLSIntel::eval(const int vflag,
 
       // error check
       #ifndef LMP_INTEL_USE_SIMDOFF
-      if (c > PTOLERANCE || c < MTOLERANCE) {
-        int me = comm->me;
-
-        if (screen) {
-          char str[128];
-          sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT,
-                  me,tid,update->ntimestep,
-                  atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str);
-          fprintf(screen,"  1st atom: %d %g %g %g\n",
-                  me,x[i1].x,x[i1].y,x[i1].z);
-          fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                  me,x[i2].x,x[i2].y,x[i2].z);
-          fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                  me,x[i3].x,x[i3].y,x[i3].z);
-          fprintf(screen,"  4th atom: %d %g %g %g\n",
-                  me,x[i4].x,x[i4].y,x[i4].z);
-        }
-      }
+      if (c > PTOLERANCE || c < MTOLERANCE)
+        problem(FLERR, i1, i2, i3, i4);
       #endif
 
       if (c > (flt_t)1.0) c = (flt_t)1.0;

--- a/src/USER-INTEL/improper_cvff_intel.cpp
+++ b/src/USER-INTEL/improper_cvff_intel.cpp
@@ -240,7 +240,7 @@ void ImproperCvffIntel::eval(const int vflag,
                   TAGINT_FORMAT " " TAGINT_FORMAT,
                   me,update->ntimestep,
                   atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str,0);
+          error->warning(FLERR,str);
           fprintf(screen,"  1st atom: %d %g %g %g\n",
                   me,x[i1].x,x[i1].y,x[i1].z);
           fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-INTEL/improper_cvff_intel.cpp
+++ b/src/USER-INTEL/improper_cvff_intel.cpp
@@ -230,27 +230,8 @@ void ImproperCvffIntel::eval(const int vflag,
 
       // error check
       #ifndef LMP_INTEL_USE_SIMDOFF_FIX
-      if (c > PTOLERANCE || c < MTOLERANCE) {
-        int me;
-        MPI_Comm_rank(world,&me);
-        if (screen) {
-          char str[128];
-          sprintf(str,"Improper problem: %d " BIGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT,
-                  me,update->ntimestep,
-                  atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str);
-          fprintf(screen,"  1st atom: %d %g %g %g\n",
-                  me,x[i1].x,x[i1].y,x[i1].z);
-          fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                  me,x[i2].x,x[i2].y,x[i2].z);
-          fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                  me,x[i3].x,x[i3].y,x[i3].z);
-          fprintf(screen,"  4th atom: %d %g %g %g\n",
-                  me,x[i4].x,x[i4].y,x[i4].z);
-        }
-      }
+      if (c > PTOLERANCE || c < MTOLERANCE)
+        problem(FLERR, i1, i2, i3, i4);
       #endif
 
       if (c > (flt_t)1.0) c = (flt_t)1.0;

--- a/src/USER-INTEL/improper_harmonic_intel.cpp
+++ b/src/USER-INTEL/improper_harmonic_intel.cpp
@@ -222,27 +222,8 @@ void ImproperHarmonicIntel::eval(const int vflag,
 
       // error check
       #ifndef LMP_INTEL_USE_SIMDOFF
-      if (c > PTOLERANCE || c < MTOLERANCE) {
-        int me;
-        MPI_Comm_rank(world,&me);
-        if (screen) {
-          char str[128];
-          sprintf(str,"Improper problem: %d " BIGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT,
-                  me,update->ntimestep,
-                  atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str);
-          fprintf(screen,"  1st atom: %d %g %g %g\n",
-                  me,x[i1].x,x[i1].y,x[i1].z);
-          fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                  me,x[i2].x,x[i2].y,x[i2].z);
-          fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                  me,x[i3].x,x[i3].y,x[i3].z);
-          fprintf(screen,"  4th atom: %d %g %g %g\n",
-                  me,x[i4].x,x[i4].y,x[i4].z);
-        }
-      }
+      if (c > PTOLERANCE || c < MTOLERANCE)
+        problem(FLERR, i1, i2, i3, i4);
       #endif
 
       if (c > (flt_t)1.0) c = (flt_t)1.0;

--- a/src/USER-INTEL/improper_harmonic_intel.cpp
+++ b/src/USER-INTEL/improper_harmonic_intel.cpp
@@ -232,7 +232,7 @@ void ImproperHarmonicIntel::eval(const int vflag,
                   TAGINT_FORMAT " " TAGINT_FORMAT,
                   me,update->ntimestep,
                   atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str,0);
+          error->warning(FLERR,str);
           fprintf(screen,"  1st atom: %d %g %g %g\n",
                   me,x[i1].x,x[i1].y,x[i1].z);
           fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-MESONT/pair_mesocnt.cpp
+++ b/src/USER-MESONT/pair_mesocnt.cpp
@@ -920,20 +920,17 @@ void PairMesoCNT::read_data(FILE *fp, double **data,
   // warn if data was read incompletely, e.g. columns were missing
 
   if (cerror)
-    error->warning(FLERR,fmt::format("{} of {} lines were incomplete or could "
-                                     "not be parsed completely in pair table: {}",
-                                     cerror,ninput*ninput,file));
+    error->warning(FLERR,"{} of {} lines were incomplete or could not be parsed "
+                   "completely in pair table: {}",cerror,ninput*ninput,file);
 
   // warn if spacing between data points is not constant
 
   if (sxerror)
-    error->warning(FLERR,fmt::format("{} spacings in first column were different "
-                                     " from first spacing in pair table: {}",
-                                     sxerror,file));
+    error->warning(FLERR,"{} spacings in first column were different from "
+                   "first spacing in pair table: {}",sxerror,file);
   if (syerror)
-    error->warning(FLERR,fmt::format("{} spacings in second column were different "
-                                     " from first spacing in pair table: {}",
-                                     syerror,file));
+    error->warning(FLERR,"{} spacings in second column were different from "
+                   "first spacing in pair table: {}",syerror,file);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/USER-MISC/compute_cnp_atom.cpp
+++ b/src/USER-MISC/compute_cnp_atom.cpp
@@ -206,7 +206,7 @@ void ComputeCNPAtom::compute_peratom()
   if (nerrorall && comm->me == 0) {
     char str[128];
     sprintf(str,"Too many neighbors in CNP for %d atoms",nerrorall);
-    error->warning(FLERR,str,0);
+    error->warning(FLERR,str);
   }
 
   // compute CNP value for each atom in group

--- a/src/USER-MISC/dihedral_cosine_shift_exp.cpp
+++ b/src/USER-MISC/dihedral_cosine_shift_exp.cpp
@@ -143,7 +143,7 @@ void DihedralCosineShiftExp::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-MISC/dihedral_cosine_shift_exp.cpp
+++ b/src/USER-MISC/dihedral_cosine_shift_exp.cpp
@@ -133,27 +133,8 @@ void DihedralCosineShiftExp::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-MISC/dihedral_fourier.cpp
+++ b/src/USER-MISC/dihedral_fourier.cpp
@@ -148,7 +148,7 @@ void DihedralFourier::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-MISC/dihedral_fourier.cpp
+++ b/src/USER-MISC/dihedral_fourier.cpp
@@ -138,27 +138,8 @@ void DihedralFourier::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-MISC/dihedral_nharmonic.cpp
+++ b/src/USER-MISC/dihedral_nharmonic.cpp
@@ -153,27 +153,8 @@ void DihedralNHarmonic::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-MISC/dihedral_nharmonic.cpp
+++ b/src/USER-MISC/dihedral_nharmonic.cpp
@@ -163,7 +163,7 @@ void DihedralNHarmonic::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-MISC/dihedral_quadratic.cpp
+++ b/src/USER-MISC/dihedral_quadratic.cpp
@@ -159,27 +159,8 @@ void DihedralQuadratic::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-MISC/dihedral_quadratic.cpp
+++ b/src/USER-MISC/dihedral_quadratic.cpp
@@ -169,7 +169,7 @@ void DihedralQuadratic::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-MISC/dihedral_table_cut.cpp
+++ b/src/USER-MISC/dihedral_table_cut.cpp
@@ -264,7 +264,7 @@ void DihedralTableCut::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-MISC/dihedral_table_cut.cpp
+++ b/src/USER-MISC/dihedral_table_cut.cpp
@@ -254,27 +254,8 @@ void DihedralTableCut::compute(int eflag, int vflag)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me;
-      MPI_Comm_rank(world,&me);
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-MISC/fix_ttm_mod.cpp
+++ b/src/USER-MISC/fix_ttm_mod.cpp
@@ -719,7 +719,7 @@ void FixTTMMod::end_of_step()
     num_inner_timesteps = static_cast<unsigned int>(update->dt/inner_dt) + 1;
     inner_dt = update->dt/double(num_inner_timesteps);
     if (num_inner_timesteps > 1000000)
-      error->warning(FLERR,"Too many inner timesteps in fix ttm/mod",0);
+      error->warning(FLERR,"Too many inner timesteps in fix ttm/mod");
     for (int ith_inner_timestep = 0; ith_inner_timestep < num_inner_timesteps;
          ith_inner_timestep++) {
       for (int ixnode = 0; ixnode < nxnodes; ixnode++)

--- a/src/USER-MISC/improper_cossq.cpp
+++ b/src/USER-MISC/improper_cossq.cpp
@@ -109,7 +109,7 @@ void ImproperCossq::compute(int eflag, int vflag)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",me,x[i1][0],x[i1][1],x[i1][2]);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",me,x[i2][0],x[i2][1],x[i2][2]);
         fprintf(screen,"  3rd atom: %d %g %g %g\n",me,x[i3][0],x[i3][1],x[i3][2]);

--- a/src/USER-MISC/improper_cossq.cpp
+++ b/src/USER-MISC/improper_cossq.cpp
@@ -100,22 +100,8 @@ void ImproperCossq::compute(int eflag, int vflag)
     cosphi = (vb3x*vb1x + vb3y*vb1y + vb3z*vb1z)/(rji * rlk);
 
     /* Check that cos(phi) is in the correct limits. */
-    if (cosphi > 1.0 + TOLERANCE || cosphi < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",me,x[i1][0],x[i1][1],x[i1][2]);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",me,x[i2][0],x[i2][1],x[i2][2]);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",me,x[i3][0],x[i3][1],x[i3][2]);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",me,x[i4][0],x[i4][1],x[i4][2]);
-      }
-    }
+    if (cosphi > 1.0 + TOLERANCE || cosphi < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     /* Apply corrections to round-off errors. */
     if (cosphi > 1.0)  cosphi -= SMALL;

--- a/src/USER-MISC/improper_fourier.cpp
+++ b/src/USER-MISC/improper_fourier.cpp
@@ -159,7 +159,7 @@ void ImproperFourier::addone(const int &i1,const int &i2,const int &i3,const int
               TAGINT_FORMAT " " TAGINT_FORMAT,
               me,update->ntimestep,
               atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-      error->warning(FLERR,str,0);
+      error->warning(FLERR,str);
       fprintf(screen,"  1st atom: %d %g %g %g\n",
               me,x[i1][0],x[i1][1],x[i1][2]);
       fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-MISC/improper_fourier.cpp
+++ b/src/USER-MISC/improper_fourier.cpp
@@ -116,7 +116,6 @@ void ImproperFourier::addone(const int &i1,const int &i2,const int &i3,const int
   double c,c2,a,s,projhfg,dhax,dhay,dhaz,dahx,dahy,dahz,cotphi;
   double ax,ay,az,ra2,rh2,ra,rh,rar,rhr,arx,ary,arz,hrx,hry,hrz;
 
-  double **x = atom->x;
   double **f = atom->f;
   int nlocal = atom->nlocal;
   int newton_bond = force->newton_bond;
@@ -149,27 +148,8 @@ void ImproperFourier::addone(const int &i1,const int &i2,const int &i3,const int
 
   // error check
 
-  if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-    int me;
-    MPI_Comm_rank(world,&me);
-    if (screen) {
-      char str[128];
-      sprintf(str,"Improper problem: %d " BIGINT_FORMAT " "
-              TAGINT_FORMAT " " TAGINT_FORMAT " "
-              TAGINT_FORMAT " " TAGINT_FORMAT,
-              me,update->ntimestep,
-              atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-      error->warning(FLERR,str);
-      fprintf(screen,"  1st atom: %d %g %g %g\n",
-              me,x[i1][0],x[i1][1],x[i1][2]);
-      fprintf(screen,"  2nd atom: %d %g %g %g\n",
-              me,x[i2][0],x[i2][1],x[i2][2]);
-      fprintf(screen,"  3rd atom: %d %g %g %g\n",
-              me,x[i3][0],x[i3][1],x[i3][2]);
-      fprintf(screen,"  4th atom: %d %g %g %g\n",
-              me,x[i4][0],x[i4][1],x[i4][2]);
-    }
-  }
+  if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+    problem(FLERR, i1, i2, i3, i4);
 
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;

--- a/src/USER-MISC/pair_agni.cpp
+++ b/src/USER-MISC/pair_agni.cpp
@@ -349,8 +349,7 @@ void PairAGNI::read_file(char *filename)
               params[curparam].gwidth = 0.0;
             wantdata = curparam;
             curparam = -1;
-          } else error->warning(FLERR,fmt::format("Ignoring unknown tag '{}' "
-                                                  "in AGNI potential file.",tag));
+          } else error->warning(FLERR,"Ignoring unknown tag '{}' in AGNI potential file.",tag);
         } else {
           if (params && wantdata >=0) {
             if ((int)values.count() == params[wantdata].numeta + 2) {

--- a/src/USER-MISC/pair_dpd_ext.cpp
+++ b/src/USER-MISC/pair_dpd_ext.cpp
@@ -476,8 +476,8 @@ void PairDPDExt::write_data_all(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-double PairDPDExt::single(int i, int j, int itype, int jtype, double rsq,
-                       double factor_coul, double factor_dpd, double &fforce)
+double PairDPDExt::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                       double /*factor_coul*/, double factor_dpd, double &fforce)
 {
   double r,rinv,wd,phi;
 

--- a/src/USER-OMP/bond_fene_expand_omp.cpp
+++ b/src/USER-OMP/bond_fene_expand_omp.cpp
@@ -119,7 +119,7 @@ void BondFENEExpandOMP::eval(int nfrom, int nto, ThrData * const thr)
       sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
               TAGINT_FORMAT " " TAGINT_FORMAT " %g",
               update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
-      error->warning(FLERR,str,0);
+      error->warning(FLERR,str);
 
       if (check_error_thr((rlogarg <= -3.0),tid,FLERR,"Bad FENE bond"))
         return;

--- a/src/USER-OMP/bond_fene_expand_omp.cpp
+++ b/src/USER-OMP/bond_fene_expand_omp.cpp
@@ -17,18 +17,20 @@
 
 #include "omp_compat.h"
 #include "bond_fene_expand_omp.h"
+
 #include "atom.h"
 #include "comm.h"
-#include "force.h"
-#include "neighbor.h"
-
 #include "error.h"
+#include "force.h"
+#include "math_const.h"
+#include "neighbor.h"
 #include "update.h"
 
 #include <cmath>
 
 #include "suffix.h"
 using namespace LAMMPS_NS;
+using MathConst::MY_CBRT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -114,12 +116,8 @@ void BondFENEExpandOMP::eval(int nfrom, int nto, ThrData * const thr)
     // if r > 2*r0 something serious is wrong, abort
 
     if (rlogarg < 0.1) {
-      char str[128];
-
-      sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
-              TAGINT_FORMAT " " TAGINT_FORMAT " %g",
-              update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
-      error->warning(FLERR,str);
+      error->warning(FLERR,"FENE bond too long: {} {} {} {:.8}",
+                     update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
 
       if (check_error_thr((rlogarg <= -3.0),tid,FLERR,"Bad FENE bond"))
         return;
@@ -131,7 +129,7 @@ void BondFENEExpandOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // force from LJ term
 
-    if (rshiftsq < TWO_1_3*sigma[type]*sigma[type]) {
+    if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type]) {
       sr2 = sigma[type]*sigma[type]/rshiftsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*epsilon[type]*sr6*(sr6-0.5)/rshift/r;
@@ -141,7 +139,7 @@ void BondFENEExpandOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     if (EFLAG) {
       ebond = -0.5 * k[type]*r0sq*log(rlogarg);
-      if (rshiftsq < TWO_1_3*sigma[type]*sigma[type])
+      if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type])
         ebond += 4.0*epsilon[type]*sr6*(sr6-1.0) + epsilon[type];
     }
 

--- a/src/USER-OMP/bond_fene_expand_omp.cpp
+++ b/src/USER-OMP/bond_fene_expand_omp.cpp
@@ -30,7 +30,7 @@
 
 #include "suffix.h"
 using namespace LAMMPS_NS;
-using MathConst::MY_CBRT2;
+using MathConst::MY_CUBEROOT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -129,7 +129,7 @@ void BondFENEExpandOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // force from LJ term
 
-    if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type]) {
+    if (rshiftsq < MY_CUBEROOT2*sigma[type]*sigma[type]) {
       sr2 = sigma[type]*sigma[type]/rshiftsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*epsilon[type]*sr6*(sr6-0.5)/rshift/r;
@@ -139,7 +139,7 @@ void BondFENEExpandOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     if (EFLAG) {
       ebond = -0.5 * k[type]*r0sq*log(rlogarg);
-      if (rshiftsq < MY_CBRT2*sigma[type]*sigma[type])
+      if (rshiftsq < MY_CUBEROOT2*sigma[type]*sigma[type])
         ebond += 4.0*epsilon[type]*sr6*(sr6-1.0) + epsilon[type];
     }
 

--- a/src/USER-OMP/bond_fene_omp.cpp
+++ b/src/USER-OMP/bond_fene_omp.cpp
@@ -115,7 +115,7 @@ void BondFENEOMP::eval(int nfrom, int nto, ThrData * const thr)
       sprintf(str,"FENE bond too long: " BIGINT_FORMAT " "
               TAGINT_FORMAT " " TAGINT_FORMAT " %g",
               update->ntimestep,atom->tag[i1],atom->tag[i2],sqrt(rsq));
-      error->warning(FLERR,str,0);
+      error->warning(FLERR,str);
 
       if (check_error_thr((rlogarg <= -3.0),tid,FLERR,"Bad FENE bond"))
         return;

--- a/src/USER-OMP/bond_fene_omp.cpp
+++ b/src/USER-OMP/bond_fene_omp.cpp
@@ -30,7 +30,7 @@
 
 #include "suffix.h"
 using namespace LAMMPS_NS;
-using MathConst::MY_CBRT2;
+using MathConst::MY_CUBEROOT2;
 
 /* ---------------------------------------------------------------------- */
 
@@ -124,7 +124,7 @@ void BondFENEOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // force from LJ term
 
-    if (rsq < MY_CBRT2*sigma[type]*sigma[type]) {
+    if (rsq < MY_CUBEROOT2*sigma[type]*sigma[type]) {
       sr2 = sigma[type]*sigma[type]/rsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*epsilon[type]*sr6*(sr6-0.5)/rsq;
@@ -134,7 +134,7 @@ void BondFENEOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     if (EFLAG) {
       ebond = -0.5 * k[type]*r0sq*log(rlogarg);
-      if (rsq < MY_CBRT2*sigma[type]*sigma[type])
+      if (rsq < MY_CUBEROOT2*sigma[type]*sigma[type])
         ebond += 4.0*epsilon[type]*sr6*(sr6-1.0) + epsilon[type];
     }
 

--- a/src/USER-OMP/dihedral_charmm_omp.cpp
+++ b/src/USER-OMP/dihedral_charmm_omp.cpp
@@ -175,7 +175,7 @@ void DihedralCharmmOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_charmm_omp.cpp
+++ b/src/USER-OMP/dihedral_charmm_omp.cpp
@@ -165,27 +165,8 @@ void DihedralCharmmOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_class2_omp.cpp
+++ b/src/USER-OMP/dihedral_class2_omp.cpp
@@ -184,20 +184,8 @@ void DihedralClass2OMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        error->warning(FLERR,fmt::format("Dihedral problem: {} {} {} {} {} {}",
-                                         me,update->ntimestep,
-                                         atom->tag[i1],atom->tag[i2],
-                                         atom->tag[i3],atom->tag[i4]));
-        fmt::print(screen,"  1st atom: {} {} {} {}\n",me,x[i1].x,x[i1].y,x[i1].z);
-        fmt::print(screen,"  2nd atom: {} {} {} {}\n",me,x[i2].x,x[i2].y,x[i2].z);
-        fmt::print(screen,"  3rd atom: {} {} {} {}\n",me,x[i3].x,x[i3].y,x[i3].z);
-        fmt::print(screen,"  4th atom: {} {} {} {}\n",me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_cosine_shift_exp_omp.cpp
+++ b/src/USER-OMP/dihedral_cosine_shift_exp_omp.cpp
@@ -154,27 +154,8 @@ void DihedralCosineShiftExpOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_cosine_shift_exp_omp.cpp
+++ b/src/USER-OMP/dihedral_cosine_shift_exp_omp.cpp
@@ -164,7 +164,7 @@ void DihedralCosineShiftExpOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_fourier_omp.cpp
+++ b/src/USER-OMP/dihedral_fourier_omp.cpp
@@ -149,27 +149,8 @@ void DihedralFourierOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_fourier_omp.cpp
+++ b/src/USER-OMP/dihedral_fourier_omp.cpp
@@ -159,7 +159,7 @@ void DihedralFourierOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_harmonic_omp.cpp
+++ b/src/USER-OMP/dihedral_harmonic_omp.cpp
@@ -163,7 +163,7 @@ void DihedralHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_harmonic_omp.cpp
+++ b/src/USER-OMP/dihedral_harmonic_omp.cpp
@@ -153,27 +153,8 @@ void DihedralHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_helix_omp.cpp
+++ b/src/USER-OMP/dihedral_helix_omp.cpp
@@ -195,7 +195,7 @@ void DihedralHelixOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_helix_omp.cpp
+++ b/src/USER-OMP/dihedral_helix_omp.cpp
@@ -185,27 +185,8 @@ void DihedralHelixOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_multi_harmonic_omp.cpp
+++ b/src/USER-OMP/dihedral_multi_harmonic_omp.cpp
@@ -176,26 +176,8 @@ void DihedralMultiHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_multi_harmonic_omp.cpp
+++ b/src/USER-OMP/dihedral_multi_harmonic_omp.cpp
@@ -185,7 +185,7 @@ void DihedralMultiHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_nharmonic_omp.cpp
+++ b/src/USER-OMP/dihedral_nharmonic_omp.cpp
@@ -185,7 +185,7 @@ void DihedralNHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_nharmonic_omp.cpp
+++ b/src/USER-OMP/dihedral_nharmonic_omp.cpp
@@ -175,27 +175,8 @@ void DihedralNHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_opls_omp.cpp
+++ b/src/USER-OMP/dihedral_opls_omp.cpp
@@ -193,7 +193,7 @@ void DihedralOPLSOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/dihedral_opls_omp.cpp
+++ b/src/USER-OMP/dihedral_opls_omp.cpp
@@ -183,27 +183,8 @@ void DihedralOPLSOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_quadratic_omp.cpp
+++ b/src/USER-OMP/dihedral_quadratic_omp.cpp
@@ -184,27 +184,8 @@ void DihedralQuadraticOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Dihedral problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/dihedral_quadratic_omp.cpp
+++ b/src/USER-OMP/dihedral_quadratic_omp.cpp
@@ -194,7 +194,7 @@ void DihedralQuadraticOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/improper_class2_omp.cpp
+++ b/src/USER-OMP/improper_class2_omp.cpp
@@ -164,26 +164,8 @@ void ImproperClass2OMP::eval(int nfrom, int nto, ThrData * const thr)
     // angle error check
 
     for (i = 0; i < 3; i++) {
-      if (costheta[i] == -1.0) {
-        int me = comm->me;
-        if (screen) {
-          char str[128];
-          sprintf(str,"Improper problem: %d/%d " BIGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT " "
-                  TAGINT_FORMAT " " TAGINT_FORMAT,
-                  me, thr->get_tid(),update->ntimestep,
-                  atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str);
-          fprintf(screen,"  1st atom: %d %g %g %g\n",
-                  me,x[i1].x,x[i1].y,x[i1].z);
-          fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                  me,x[i2].x,x[i2].y,x[i2].z);
-          fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                  me,x[i3].x,x[i3].y,x[i3].z);
-          fprintf(screen,"  4th atom: %d %g %g %g\n",
-                  me,x[i4].x,x[i4].y,x[i4].z);
-        }
-      }
+      if (costheta[i] == -1.0)
+        problem(FLERR, i1, i2, i3, i4);
     }
 
     for (i = 0; i < 3; i++) {

--- a/src/USER-OMP/improper_class2_omp.cpp
+++ b/src/USER-OMP/improper_class2_omp.cpp
@@ -173,7 +173,7 @@ void ImproperClass2OMP::eval(int nfrom, int nto, ThrData * const thr)
                   TAGINT_FORMAT " " TAGINT_FORMAT,
                   me, thr->get_tid(),update->ntimestep,
                   atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-          error->warning(FLERR,str,0);
+          error->warning(FLERR,str);
           fprintf(screen,"  1st atom: %d %g %g %g\n",
                   me,x[i1].x,x[i1].y,x[i1].z);
           fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/improper_cossq_omp.cpp
+++ b/src/USER-OMP/improper_cossq_omp.cpp
@@ -126,26 +126,8 @@ void ImproperCossqOMP::eval(int nfrom, int nto, ThrData * const thr)
     cosphi = (vb3x*vb1x + vb3y*vb1y + vb3z*vb1z)/(rji * rlk);
 
     /* Check that cos(phi) is in the correct limits. */
-    if (cosphi > 1.0 + TOLERANCE || cosphi < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (cosphi > 1.0 + TOLERANCE || cosphi < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     /* Apply corrections to round-off errors. */
     if (cosphi > 1.0)  cosphi -= SMALL;

--- a/src/USER-OMP/improper_cossq_omp.cpp
+++ b/src/USER-OMP/improper_cossq_omp.cpp
@@ -135,7 +135,7 @@ void ImproperCossqOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/improper_cvff_omp.cpp
+++ b/src/USER-OMP/improper_cvff_omp.cpp
@@ -183,7 +183,7 @@ void ImproperCvffOMP::eval(int nfrom, int nto, ThrData * const thr)
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
 
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/improper_cvff_omp.cpp
+++ b/src/USER-OMP/improper_cvff_omp.cpp
@@ -172,28 +172,8 @@ void ImproperCvffOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/improper_fourier_omp.cpp
+++ b/src/USER-OMP/improper_fourier_omp.cpp
@@ -183,28 +183,8 @@ void ImproperFourierOMP::add1_thr(const int i1,const int i2,
 
   // error check
 
-  if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-    int me = comm->me;
-
-    if (screen) {
-      char str[128];
-      sprintf(str,
-              "Improper problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-              me,thr->get_tid(),update->ntimestep,
-              atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-      error->warning(FLERR,str);
-      fprintf(screen,"  1st atom: %d %g %g %g\n",
-              me,atom->x[i1][0],atom->x[i1][1],atom->x[i1][2]);
-      fprintf(screen,"  2nd atom: %d %g %g %g\n",
-              me,atom->x[i2][0],atom->x[i2][1],atom->x[i2][2]);
-      fprintf(screen,"  3rd atom: %d %g %g %g\n",
-              me,atom->x[i3][0],atom->x[i3][1],atom->x[i3][2]);
-      fprintf(screen,"  4th atom: %d %g %g %g\n",
-              me,atom->x[i4][0],atom->x[i4][1],atom->x[i4][2]);
-    }
-  }
+  if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+    problem(FLERR, i1, i2, i3, i4);
 
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/improper_fourier_omp.cpp
+++ b/src/USER-OMP/improper_fourier_omp.cpp
@@ -194,7 +194,7 @@ void ImproperFourierOMP::add1_thr(const int i1,const int i2,
                 TAGINT_FORMAT " " TAGINT_FORMAT,
               me,thr->get_tid(),update->ntimestep,
               atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-      error->warning(FLERR,str,0);
+      error->warning(FLERR,str);
       fprintf(screen,"  1st atom: %d %g %g %g\n",
               me,atom->x[i1][0],atom->x[i1][1],atom->x[i1][2]);
       fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/improper_harmonic_omp.cpp
+++ b/src/USER-OMP/improper_harmonic_omp.cpp
@@ -155,7 +155,7 @@ void ImproperHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/USER-OMP/improper_harmonic_omp.cpp
+++ b/src/USER-OMP/improper_harmonic_omp.cpp
@@ -145,27 +145,8 @@ void ImproperHarmonicOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/improper_umbrella_omp.cpp
+++ b/src/USER-OMP/improper_umbrella_omp.cpp
@@ -147,27 +147,8 @@ void ImproperUmbrellaOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     // error check
 
-    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) {
-      int me = comm->me;
-
-      if (screen) {
-        char str[128];
-        sprintf(str,"Improper problem: %d/%d " BIGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT " "
-                TAGINT_FORMAT " " TAGINT_FORMAT,
-                me,thr->get_tid(),update->ntimestep,
-                atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str);
-        fprintf(screen,"  1st atom: %d %g %g %g\n",
-                me,x[i1].x,x[i1].y,x[i1].z);
-        fprintf(screen,"  2nd atom: %d %g %g %g\n",
-                me,x[i2].x,x[i2].y,x[i2].z);
-        fprintf(screen,"  3rd atom: %d %g %g %g\n",
-                me,x[i3].x,x[i3].y,x[i3].z);
-        fprintf(screen,"  4th atom: %d %g %g %g\n",
-                me,x[i4].x,x[i4].y,x[i4].z);
-      }
-    }
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/USER-OMP/improper_umbrella_omp.cpp
+++ b/src/USER-OMP/improper_umbrella_omp.cpp
@@ -157,7 +157,7 @@ void ImproperUmbrellaOMP::eval(int nfrom, int nto, ThrData * const thr)
                 TAGINT_FORMAT " " TAGINT_FORMAT,
                 me,thr->get_tid(),update->ntimestep,
                 atom->tag[i1],atom->tag[i2],atom->tag[i3],atom->tag[i4]);
-        error->warning(FLERR,str,0);
+        error->warning(FLERR,str);
         fprintf(screen,"  1st atom: %d %g %g %g\n",
                 me,x[i1].x,x[i1].y,x[i1].z);
         fprintf(screen,"  2nd atom: %d %g %g %g\n",

--- a/src/change_box.cpp
+++ b/src/change_box.cpp
@@ -389,9 +389,8 @@ void ChangeBox::command(int narg, char **arg)
   bigint nblocal = atom->nlocal;
   MPI_Allreduce(&nblocal,&natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
   if (natoms != atom->natoms && comm->me == 0)
-    error->warning(FLERR,fmt::format("Lost atoms via change_box: "
-                                     "original {} current {}",
-                                     atom->natoms,natoms));
+    error->warning(FLERR,"Lost atoms via change_box: original {} "
+                   "current {}", atom->natoms,natoms);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -655,18 +655,16 @@ double Comm::get_comm_cutoff()
     maxcommcutoff = MAX(maxcommcutoff,maxbondcutoff);
   } else {
     if ((me == 0) && (maxbondcutoff > maxcommcutoff))
-      error->warning(FLERR,fmt::format("Communication cutoff {} is shorter "
-                                       "than a bond length based estimate of "
-                                       "{}. This may lead to errors.",
-                                       maxcommcutoff,maxbondcutoff));
+      error->warning(FLERR,"Communication cutoff {} is shorter than a bond "
+                     "length based estimate of {}. This may lead to errors.",
+                     maxcommcutoff,maxbondcutoff);
   }
 
   // print warning if neighborlist cutoff overrides user cutoff
 
   if ((me == 0) && (update->setupflag == 1)) {
     if ((cutghostuser > 0.0) && (maxcommcutoff > cutghostuser))
-      error->warning(FLERR,fmt::format("Communication cutoff adjusted to {}",
-                                       maxcommcutoff));
+      error->warning(FLERR,"Communication cutoff adjusted to {}",maxcommcutoff);
   }
 
   return maxcommcutoff;

--- a/src/compute_cna_atom.cpp
+++ b/src/compute_cna_atom.cpp
@@ -187,7 +187,7 @@ void ComputeCNAAtom::compute_peratom()
   MPI_Allreduce(&nerror,&nerrorall,1,MPI_INT,MPI_SUM,world);
   if (nerrorall && comm->me == 0)
     error->warning(FLERR,fmt::format("Too many neighbors in CNA for {} "
-                                     "atoms",nerrorall),0);
+                                     "atoms",nerrorall));
 
   // compute CNA for each atom in group
   // only performed if # of nearest neighbors = 12 or 14 (fcc,hcp)

--- a/src/compute_cna_atom.cpp
+++ b/src/compute_cna_atom.cpp
@@ -186,8 +186,7 @@ void ComputeCNAAtom::compute_peratom()
   int nerrorall;
   MPI_Allreduce(&nerror,&nerrorall,1,MPI_INT,MPI_SUM,world);
   if (nerrorall && comm->me == 0)
-    error->warning(FLERR,fmt::format("Too many neighbors in CNA for {} "
-                                     "atoms",nerrorall));
+    error->warning(FLERR,"Too many neighbors in CNA for {} atoms",nerrorall);
 
   // compute CNA for each atom in group
   // only performed if # of nearest neighbors = 12 or 14 (fcc,hcp)
@@ -345,8 +344,7 @@ void ComputeCNAAtom::compute_peratom()
 
   MPI_Allreduce(&nerror,&nerrorall,1,MPI_INT,MPI_SUM,world);
   if (nerrorall && comm->me == 0)
-    error->warning(FLERR,fmt::format("Too many common neighbors in CNA {} "
-                                     "times", nerrorall));
+    error->warning(FLERR,"Too many common neighbors in CNA: {}x", nerrorall);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -19,6 +19,7 @@
 #include "memory.h"
 #include "error.h"
 #include "suffix.h"
+#include "update.h"
 
 using namespace LAMMPS_NS;
 
@@ -384,6 +385,26 @@ void Dihedral::ev_tally(int i1, int i2, int i3, int i4,
       cvatom[i4][8] += a4[2]*f4[1];
     }
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Dihedral::problem(const char *filename, int lineno,
+                       int i1, int i2, int i3, int i4)
+{
+  const auto x = atom->x;
+  auto warn = fmt::format("Dihedral problem: {} {} {} {} {} {}\n",
+                          comm->me, update->ntimestep, atom->tag[i1],
+                          atom->tag[i2], atom->tag[i3], atom->tag[i4]);
+  warn += fmt::format("WARNING:   1st atom: {} {:.8} {:.8} {:.8}\n",
+                      comm->me,x[i1][0],x[i1][1],x[i1][2]);
+  warn += fmt::format("WARNING:   2nd atom: {} {:.8} {:.8} {:.8}\n",
+                      comm->me,x[i2][0],x[i2][1],x[i2][2]);
+  warn += fmt::format("WARNING:   3rd atom: {} {:.8} {:.8} {:.8}\n",
+                      comm->me,x[i3][0],x[i3][1],x[i3][2]);
+  warn += fmt::format("WARNING:   4th atom: {} {:.8} {:.8} {:.8}",
+                      comm->me,x[i4][0],x[i4][1],x[i4][2]);
+  error->warning(filename, lineno, warn);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/dihedral.h
+++ b/src/dihedral.h
@@ -65,12 +65,14 @@ class Dihedral : protected Pointers {
 
   void ev_init(int eflag, int vflag, int alloc = 1) {
     if (eflag||vflag) ev_setup(eflag, vflag, alloc);
-    else evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom = cvflag_atom = 0;
+    else evflag = eflag_either = eflag_global = eflag_atom
+           = vflag_either = vflag_global = vflag_atom = cvflag_atom = 0;
   }
   void ev_setup(int, int, int alloc = 1);
   void ev_tally(int, int, int, int, int, int, double,
                 double *, double *, double *, double, double, double,
                 double, double, double, double, double, double);
+  void problem(const char *, int, int, int, int, int);
 };
 
 }

--- a/src/displace_atoms.cpp
+++ b/src/displace_atoms.cpp
@@ -354,9 +354,8 @@ void DisplaceAtoms::command(int narg, char **arg)
   bigint nblocal = atom->nlocal;
   MPI_Allreduce(&nblocal,&natoms,1,MPI_LMP_BIGINT,MPI_SUM,world);
   if (natoms != atom->natoms && comm->me == 0)
-    error->warning(FLERR,fmt::format("Lost atoms via displace_atoms: "
-                                     "original {} current {}",
-                                     atom->natoms,natoms));
+    error->warning(FLERR,"Lost atoms via displace_atoms: original {} "
+                   "current {}",atom->natoms,natoms);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -118,8 +118,8 @@ void Error::universe_one(const std::string &file, int line, const std::string &s
 
 void Error::universe_warn(const std::string &file, int line, const std::string &str)
 {
-  if ((allwarn > maxwarn) || (maxwarn < 0)) return;
   ++numwarn;
+  if ((numwarn > maxwarn) || (allwarn > maxwarn) || (maxwarn < 0)) return;
   if (universe->uscreen)
     fmt::print(universe->uscreen,"WARNING on proc {}: {} ({}:{})\n",
                universe->me,str,truncpath(file),line);
@@ -250,8 +250,8 @@ void Error::_one(const std::string &file, int line, fmt::string_view format,
 
 void Error::warning(const std::string &file, int line, const std::string &str)
 {
-  if ((allwarn > maxwarn) || (maxwarn < 0)) return;
   ++numwarn;
+  if ((numwarn > maxwarn) || (allwarn > maxwarn) || (maxwarn < 0)) return;
   std::string mesg = fmt::format("WARNING: {} ({}:{})\n",
                                  str,truncpath(file),line);
   if (screen) fputs(mesg.c_str(),screen);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -249,6 +249,7 @@ void Error::_one(const std::string &file, int line, fmt::string_view format,
 
 void Error::warning(const std::string &file, int line, const std::string &str, int logflag)
 {
+  if ((allwarn > maxwarn) || (maxwarn < 0)) return;
   ++numwarn;
   std::string mesg = fmt::format("WARNING: {} ({}:{})\n",
                                  str,truncpath(file),line);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -36,7 +36,9 @@ static std::string truncpath(const std::string &path)
 
 /* ---------------------------------------------------------------------- */
 
-Error::Error(LAMMPS *lmp) : Pointers(lmp) {
+Error::Error(LAMMPS *lmp)
+  : Pointers(lmp), numwarn(0), maxwarn(100), allwarn(0)
+{
 #ifdef LAMMPS_EXCEPTIONS
   last_error_message.clear();
   last_error_type = ERROR_NONE;
@@ -116,6 +118,7 @@ void Error::universe_one(const std::string &file, int line, const std::string &s
 
 void Error::universe_warn(const std::string &file, int line, const std::string &str)
 {
+  ++numwarn;
   if (universe->uscreen)
     fmt::print(universe->uscreen,"WARNING on proc {}: {} ({}:{})\n",
                universe->me,str,truncpath(file),line);
@@ -246,6 +249,7 @@ void Error::_one(const std::string &file, int line, fmt::string_view format,
 
 void Error::warning(const std::string &file, int line, const std::string &str, int logflag)
 {
+  ++numwarn;
   std::string mesg = fmt::format("WARNING: {} ({}:{})\n",
                                  str,truncpath(file),line);
   if (screen) fputs(mesg.c_str(),screen);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -259,6 +259,20 @@ void Error::warning(const std::string &file, int line, const std::string &str)
 }
 
 /* ----------------------------------------------------------------------
+   forward vararg version to single string version
+------------------------------------------------------------------------- */
+
+void Error::_warning(const std::string &file, int line, fmt::string_view format,
+                     fmt::format_args args)
+{
+  try {
+    warning(file,line,fmt::vformat(format, args));
+  } catch (fmt::format_error &e) {
+    warning(file,line,e.what());
+  }
+}
+
+/* ----------------------------------------------------------------------
    called by one proc in world, typically proc 0
    write message to screen and logfile (if logflag is set)
 ------------------------------------------------------------------------- */
@@ -269,6 +283,20 @@ void Error::message(const std::string &file, int line, const std::string &str)
 
   if (screen) fputs(mesg.c_str(),screen);
   if (logfile) fputs(mesg.c_str(),logfile);
+}
+
+/* ----------------------------------------------------------------------
+   forward vararg version to single string version
+------------------------------------------------------------------------- */
+
+void Error::_message(const std::string &file, int line, fmt::string_view format,
+                     fmt::format_args args)
+{
+  try {
+    message(file,line,fmt::vformat(format, args));
+  } catch (fmt::format_error &e) {
+    message(file,line,e.what());
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -118,6 +118,7 @@ void Error::universe_one(const std::string &file, int line, const std::string &s
 
 void Error::universe_warn(const std::string &file, int line, const std::string &str)
 {
+  if ((allwarn > maxwarn) || (maxwarn < 0)) return;
   ++numwarn;
   if (universe->uscreen)
     fmt::print(universe->uscreen,"WARNING on proc {}: {} ({}:{})\n",
@@ -247,14 +248,14 @@ void Error::_one(const std::string &file, int line, fmt::string_view format,
    only write to screen if non-nullptr on this proc since could be file
 ------------------------------------------------------------------------- */
 
-void Error::warning(const std::string &file, int line, const std::string &str, int logflag)
+void Error::warning(const std::string &file, int line, const std::string &str)
 {
   if ((allwarn > maxwarn) || (maxwarn < 0)) return;
   ++numwarn;
   std::string mesg = fmt::format("WARNING: {} ({}:{})\n",
                                  str,truncpath(file),line);
   if (screen) fputs(mesg.c_str(),screen);
-  if (logflag && logfile) fputs(mesg.c_str(),logfile);
+  if (logfile) fputs(mesg.c_str(),logfile);
 }
 
 /* ----------------------------------------------------------------------
@@ -262,12 +263,12 @@ void Error::warning(const std::string &file, int line, const std::string &str, i
    write message to screen and logfile (if logflag is set)
 ------------------------------------------------------------------------- */
 
-void Error::message(const std::string &file, int line, const std::string &str, int logflag)
+void Error::message(const std::string &file, int line, const std::string &str)
 {
   std::string mesg = fmt::format("{} ({}:{})\n",str,truncpath(file),line);
 
   if (screen) fputs(mesg.c_str(),screen);
-  if (logflag && logfile) fputs(mesg.c_str(),logfile);
+  if (logfile) fputs(mesg.c_str(),logfile);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/error.h
+++ b/src/error.h
@@ -43,8 +43,8 @@ class Error : protected Pointers {
     _one(file, line, format, fmt::make_args_checked<Args...>(format, args...));
   }
 
-  void warning(const std::string &, int, const std::string &, int = 1);
-  void message(const std::string &, int, const std::string &, int = 1);
+  void warning(const std::string &, int, const std::string &);
+  void message(const std::string &, int, const std::string &);
   [[ noreturn ]] void done(int = 0); // 1 would be fully backwards compatible
 
   int get_numwarn() const { return numwarn; }

--- a/src/error.h
+++ b/src/error.h
@@ -61,10 +61,10 @@ class Error : protected Pointers {
  private:
   std::string last_error_message;
   ErrorType last_error_type;
-
-  int numwarn, maxwarn, allwarn;
 #endif
+
  private:
+  int numwarn, maxwarn, allwarn;
   // internal versions that accept explicit fmtlib arguments
   [[ noreturn ]] void _all(const std::string &, int, fmt::string_view,
                            fmt::format_args args);

--- a/src/error.h
+++ b/src/error.h
@@ -47,6 +47,12 @@ class Error : protected Pointers {
   void message(const std::string &, int, const std::string &, int = 1);
   [[ noreturn ]] void done(int = 0); // 1 would be fully backwards compatible
 
+  int get_numwarn() const { return numwarn; }
+  int get_maxwarn() const { return maxwarn; }
+  void set_numwarn(int val) { numwarn = val; }
+  void set_maxwarn(int val) { maxwarn = val; }
+  void set_allwarn(int val) { allwarn = val; }
+
 #ifdef LAMMPS_EXCEPTIONS
   std::string get_last_error() const;
   ErrorType get_last_error_type() const;
@@ -56,6 +62,7 @@ class Error : protected Pointers {
   std::string last_error_message;
   ErrorType last_error_type;
 
+  int numwarn, maxwarn, allwarn;
 #endif
  private:
   // internal versions that accept explicit fmtlib arguments

--- a/src/error.h
+++ b/src/error.h
@@ -31,12 +31,13 @@ class Error : protected Pointers {
   void universe_warn(const std::string &, int, const std::string &);
 
   [[ noreturn ]] void all(const std::string &, int, const std::string &);
-  [[ noreturn ]] void one(const std::string &, int, const std::string &);
   template <typename S, typename... Args>
   void all(const std::string &file, int line, const S &format,
                           Args&&... args) {
     _all(file, line, format, fmt::make_args_checked<Args...>(format, args...));
   }
+
+  [[ noreturn ]] void one(const std::string &, int, const std::string &);
   template <typename S, typename... Args>
   void one(const std::string &file, int line, const S &format,
                           Args&&... args) {
@@ -44,7 +45,16 @@ class Error : protected Pointers {
   }
 
   void warning(const std::string &, int, const std::string &);
+  template <typename S, typename... Args>
+  void warning(const std::string &file, int line, const S &format, Args&&... args) {
+    _warning(file, line, format, fmt::make_args_checked<Args...>(format, args...));
+  }
+
   void message(const std::string &, int, const std::string &);
+  template <typename S, typename... Args>
+  void message(const std::string &file, int line, const S &format, Args&&... args) {
+    _message(file, line, format, fmt::make_args_checked<Args...>(format, args...));
+  }
   [[ noreturn ]] void done(int = 0); // 1 would be fully backwards compatible
 
   int get_numwarn() const { return numwarn; }
@@ -70,6 +80,8 @@ class Error : protected Pointers {
                            fmt::format_args args);
   [[ noreturn ]] void _one(const std::string &, int, fmt::string_view,
                            fmt::format_args args);
+  void _warning(const std::string &, int, fmt::string_view, fmt::format_args args);
+  void _message(const std::string &, int, fmt::string_view, fmt::format_args args);
 };
 
 }

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -12,13 +12,15 @@
 ------------------------------------------------------------------------- */
 
 #include "improper.h"
+
 #include "atom.h"
-#include "comm.h"
-#include "force.h"
-#include "suffix.h"
 #include "atom_masks.h"
-#include "memory.h"
+#include "comm.h"
 #include "error.h"
+#include "force.h"
+#include "memory.h"
+#include "suffix.h"
+#include "update.h"
 
 using namespace LAMMPS_NS;
 
@@ -382,6 +384,27 @@ void Improper::ev_tally(int i1, int i2, int i3, int i4,
       cvatom[i4][8] += a4[2]*f4[1];
     }
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+
+void Improper::problem(const char *filename, int lineno,
+                       int i1, int i2, int i3, int i4)
+{
+  const auto x = atom->x;
+  auto warn = fmt::format("Improper problem: {} {} {} {} {} {}\n",
+                          comm->me, update->ntimestep, atom->tag[i1],
+                          atom->tag[i2], atom->tag[i3], atom->tag[i4]);
+  warn += fmt::format("WARNING:   1st atom: {} {:.8} {:.8} {:.8}\n",
+                      comm->me,x[i1][0],x[i1][1],x[i1][2]);
+  warn += fmt::format("WARNING:   2nd atom: {} {:.8} {:.8} {:.8}\n",
+                      comm->me,x[i2][0],x[i2][1],x[i2][2]);
+  warn += fmt::format("WARNING:   3rd atom: {} {:.8} {:.8} {:.8}\n",
+                      comm->me,x[i3][0],x[i3][1],x[i3][2]);
+  warn += fmt::format("WARNING:   4th atom: {} {:.8} {:.8} {:.8}",
+                      comm->me,x[i4][0],x[i4][1],x[i4][2]);
+  error->warning(filename, lineno, warn);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/improper.h
+++ b/src/improper.h
@@ -71,6 +71,7 @@ class Improper : protected Pointers {
   void ev_tally(int, int, int, int, int, int, double,
                 double *, double *, double *, double, double, double,
                 double, double, double, double, double, double);
+  void problem(const char *, int, int, int, int, int);
 };
 
 }

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -336,7 +336,7 @@ double KSpace::estimate_table_accuracy(double q2_over_sqrt, double spr)
   int nctb = force->pair->ncoultablebits;
   if (comm->me == 0) {
     if (nctb)
-      error->message(FLERR,fmt::format("  using {}-bit tables for long-range coulomb",nctb));
+      error->message(FLERR,"  using {}-bit tables for long-range coulomb",nctb);
     else
       error->message(FLERR,"  using polynomial approximation for long-range coulomb");
   }

--- a/src/math_const.h
+++ b/src/math_const.h
@@ -28,7 +28,7 @@ namespace MathConst {
   static constexpr double MY_PIS = 1.77245385090551602729; // sqrt(pi)
   static constexpr double MY_ISPI4 = 1.12837916709551257389; // 1/sqrt(pi/4)
   static constexpr double MY_SQRT2 = 1.41421356237309504880; // sqrt(2)
-  static constexpr double MY_CBRT2 = 1.25992104989487316476; // 2*(1/3)
+  static constexpr double MY_CUBEROOT2 = 1.25992104989487316476; // 2*(1/3)
 }
 
 }

--- a/src/ntopo_angle_all.cpp
+++ b/src/ntopo_angle_all.cpp
@@ -88,6 +88,5 @@ void NTopoAngleAll::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Angle atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Angle atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_angle_partial.cpp
+++ b/src/ntopo_angle_partial.cpp
@@ -89,6 +89,5 @@ void NTopoAnglePartial::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Angle atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Angle atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_angle_template.cpp
+++ b/src/ntopo_angle_template.cpp
@@ -109,6 +109,5 @@ void NTopoAngleTemplate::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Angle atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Angle atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_bond_all.cpp
+++ b/src/ntopo_bond_all.cpp
@@ -81,6 +81,5 @@ void NTopoBondAll::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Bond atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Bond atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_bond_partial.cpp
+++ b/src/ntopo_bond_partial.cpp
@@ -82,6 +82,5 @@ void NTopoBondPartial::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Bond atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Bond atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_bond_template.cpp
+++ b/src/ntopo_bond_template.cpp
@@ -100,6 +100,5 @@ void NTopoBondTemplate::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Bond atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Bond atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_dihedral_all.cpp
+++ b/src/ntopo_dihedral_all.cpp
@@ -94,6 +94,5 @@ void NTopoDihedralAll::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Dihedral atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Dihedral atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_dihedral_partial.cpp
+++ b/src/ntopo_dihedral_partial.cpp
@@ -96,6 +96,5 @@ void NTopoDihedralPartial::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Dihedral atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Dihedral atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_dihedral_template.cpp
+++ b/src/ntopo_dihedral_template.cpp
@@ -115,6 +115,5 @@ void NTopoDihedralTemplate::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Dihedral atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Dihedral atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_improper_all.cpp
+++ b/src/ntopo_improper_all.cpp
@@ -94,6 +94,5 @@ void NTopoImproperAll::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Improper atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Improper atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_improper_partial.cpp
+++ b/src/ntopo_improper_partial.cpp
@@ -98,6 +98,5 @@ void NTopoImproperPartial::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && me == 0)
-    error->warning(FLERR,fmt::format("Improper atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Improper atoms missing at step {}",update->ntimestep);
 }

--- a/src/ntopo_improper_template.cpp
+++ b/src/ntopo_improper_template.cpp
@@ -115,6 +115,5 @@ void NTopoImproperTemplate::build()
   int all;
   MPI_Allreduce(&nmissing,&all,1,MPI_INT,MPI_SUM,world);
   if (all && (me == 0))
-    error->warning(FLERR,fmt::format("Improper atoms missing at step {}",
-                                     update->ntimestep));
+    error->warning(FLERR,"Improper atoms missing at step {}",update->ntimestep);
 }

--- a/src/pair_table.cpp
+++ b/src/pair_table.cpp
@@ -458,25 +458,23 @@ void PairTable::read_table(Table *tb, char *file, char *keyword)
   }
 
   if (ferror)
-    error->warning(FLERR,fmt::format("{} of {} force values in table {} are "
-                                     "inconsistent with -dE/dr.\n  Should "
-                                     "only be flagged at inflection points",
-                                     ferror,tb->ninput,keyword));
+    error->warning(FLERR,"{} of {} force values in table {} are inconsistent "
+                   "with -dE/dr.\nWARNING:  Should only be flagged at "
+                   "inflection points",ferror,tb->ninput,keyword);
 
   // warn if re-computed distance values differ from file values
 
   if (rerror)
-    error->warning(FLERR,fmt::format("{} of {} distance values in table {} "
-                                     "with relative error\n  over {} to "
-                                     "re-computed values",
-                                     rerror,tb->ninput,EPSILONR,keyword));
+    error->warning(FLERR,"{} of {} distance values in table {} with relative "
+                   "error\nWARNING:  over {} to re-computed values",
+                   rerror,tb->ninput,EPSILONR,keyword);
 
   // warn if data was read incompletely, e.g. columns were missing
 
   if (cerror)
-    error->warning(FLERR,fmt::format("{} of {} lines in table {} were "
-                                     "incomplete\n  or could not be parsed "
-                                     "completely",cerror,tb->ninput,keyword));
+    error->warning(FLERR,"{} of {} lines in table {} were incomplete\n"
+                   "WARNING:  or could not be parsed completely",
+                   cerror,tb->ninput,keyword);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/potential_file_reader.cpp
+++ b/src/potential_file_reader.cpp
@@ -275,8 +275,8 @@ TextFileReader *PotentialFileReader::open_potential(const std::string &path) {
       }
     }
     if (unit_convert != utils::NOCONVERT)
-      lmp->error->warning(FLERR, fmt::format("Converting {} in {} units to {} "
-                                             "units", filetype, units, unit_style));
+      lmp->error->warning(FLERR, "Converting {} in {} units to {} units",
+                          filetype, units, unit_style);
     return new TextFileReader(filepath, filetype);
   }
   return nullptr;

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -694,9 +694,8 @@ void ReadRestart::header()
     } else if (flag == NPROCS) {
       nprocs_file = read_int();
       if (nprocs_file != comm->nprocs && me == 0)
-        error->warning(FLERR,fmt::format("Restart file used different # of "
-                                         "processors: {} vs. {}",nprocs_file,
-                                         comm->nprocs));
+        error->warning(FLERR,"Restart file used different # of processors: "
+                       "{} vs. {}",nprocs_file,comm->nprocs);
 
     // don't set procgrid, warn if different
 

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -415,7 +415,6 @@ bigint Thermo::lost_check()
     error->all(FLERR,"Too many total atoms");
 
   // print notification, if future warnings will be ignored
-  error->set_allwarn(ntotal[1]);
   int maxwarn = error->get_maxwarn();
   if ((maxwarn > 0) && (warnbefore == 0) && (ntotal[1] > maxwarn)) {
     warnbefore = 1;
@@ -423,6 +422,7 @@ bigint Thermo::lost_check()
                                      "future warnings will be suppressed.\n",
                                      ntotal[1],maxwarn),0);
   }
+  error->set_allwarn(ntotal[1]);
 
   // no lost atoms, nothing else to do.
   if (ntotal[0] == atom->natoms) return ntotal[0];
@@ -542,7 +542,7 @@ void Thermo::modify_params(int narg, char **arg)
     } else if (strcmp(arg[iarg],"warn") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal thermo_modify command");
       if (strcmp(arg[iarg+1],"ignore") == 0) error->set_maxwarn(-1);
-      if (strcmp(arg[iarg+1],"always") == 0) error->set_maxwarn(0);
+      else if (strcmp(arg[iarg+1],"always") == 0) error->set_maxwarn(0);
       else if (strcmp(arg[iarg+1],"reset") == 0) {
         error->set_numwarn(0);
         warnbefore = 0;

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -420,7 +420,7 @@ bigint Thermo::lost_check()
     warnbefore = 1;
     error->warning(FLERR,fmt::format("Too many warnings: {} vs {}. All "
                                      "future warnings will be suppressed.\n",
-                                     ntotal[1],maxwarn),0);
+                                     ntotal[1],maxwarn));
   }
   error->set_allwarn(ntotal[1]);
 
@@ -443,7 +443,7 @@ bigint Thermo::lost_check()
 
   if (me == 0)
     error->warning(FLERR,fmt::format("Lost atoms: original {} current {}",
-                                     atom->natoms,ntotal[0]),0);
+                                     atom->natoms,ntotal[0]));
 
   // reset total atom count
 

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -418,9 +418,10 @@ bigint Thermo::lost_check()
   int maxwarn = error->get_maxwarn();
   if ((maxwarn > 0) && (warnbefore == 0) && (ntotal[1] > maxwarn)) {
     warnbefore = 1;
-    error->warning(FLERR,fmt::format("Too many warnings: {} vs {}. All "
-                                     "future warnings will be suppressed.\n",
-                                     ntotal[1],maxwarn));
+    if (comm->me == 0)
+      error->message(FLERR,fmt::format("WARNING: Too many warnings: {} vs {}. All "
+                                       "future warnings will be suppressed",
+                                       ntotal[1],maxwarn));
   }
   error->set_allwarn(ntotal[1]);
 

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -419,9 +419,8 @@ bigint Thermo::lost_check()
   if ((maxwarn > 0) && (warnbefore == 0) && (ntotal[1] > maxwarn)) {
     warnbefore = 1;
     if (comm->me == 0)
-      error->message(FLERR,fmt::format("WARNING: Too many warnings: {} vs {}. All "
-                                       "future warnings will be suppressed",
-                                       ntotal[1],maxwarn));
+      error->message(FLERR,"WARNING: Too many warnings: {} vs {}. All "
+                     "future warnings will be suppressed",ntotal[1],maxwarn);
   }
   error->set_allwarn(ntotal[1]);
 
@@ -438,13 +437,13 @@ bigint Thermo::lost_check()
 
   if (lostflag == Thermo::ERROR)
     error->all(FLERR,"Lost atoms: original {} current {}",
-                                 atom->natoms,ntotal[0]);
+               atom->natoms,ntotal[0]);
 
   // warning message
 
   if (me == 0)
-    error->warning(FLERR,fmt::format("Lost atoms: original {} current {}",
-                                     atom->natoms,ntotal[0]));
+    error->warning(FLERR,"Lost atoms: original {} current {}",
+                   atom->natoms,ntotal[0]);
 
   // reset total atom count
 

--- a/src/thermo.h
+++ b/src/thermo.h
@@ -64,7 +64,7 @@ class Thermo : protected Pointers {
   int normuser;
 
   int firststep;
-  int lostbefore;
+  int lostbefore, warnbefore;
   int flushflag,lineflag;
 
   double last_tpcpu,last_spcpu;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -305,9 +305,8 @@ void Update::set_units(const char *style)
 
   // check if timestep was changed from default value
   if (!dt_default && (comm->me == 0)) {
-    error->warning(FLERR,fmt::format("Changing timestep from {:.6} to {:.6} "
-                                     "due to changing units to {}",
-                                     dt_old, dt, unit_style));
+    error->warning(FLERR,"Changing timestep from {:.6} to {:.6} due to "
+                   "changing units to {}", dt_old, dt, unit_style);
   }
   dt_default = 1;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1200,16 +1200,14 @@ FILE *utils::open_potential(const std::string &name, LAMMPS *lmp,
             && (*auto_convert & REAL2METAL)) {
           *auto_convert = REAL2METAL;
         } else {
-          error->one(FLERR, "Potential file {} requires {} units "
-                                        "but {} units are in use", name,
-                                        units, unit_style);
+          error->one(FLERR, "Potential file {} requires {} units but {} units "
+                     "are in use", name, units, unit_style);
           return nullptr;
         }
       }
       if ((*auto_convert != NOCONVERT) && (me == 0))
-        error->warning(FLERR, fmt::format("Converting potential file in "
-                                          "{} units to {} units",
-                                          units, unit_style));
+        error->warning(FLERR, "Converting potential file in {} units to {} "
+                       "units", units, unit_style);
     }
     return fopen(filepath.c_str(), "r");
   }

--- a/unittest/cplusplus/CMakeLists.txt
+++ b/unittest/cplusplus/CMakeLists.txt
@@ -7,3 +7,7 @@ set_tests_properties(LammpsClass PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1")
 add_executable(test_input_class test_input_class.cpp)
 target_link_libraries(test_input_class PRIVATE lammps GTest::GTest GTest::GTestMain)
 add_test(InputClass test_input_class)
+
+add_executable(test_error_class test_error_class.cpp)
+target_link_libraries(test_error_class PRIVATE lammps GTest::GMock GTest::GTest)
+add_test(ErrorClass test_error_class)

--- a/unittest/cplusplus/test_error_class.cpp
+++ b/unittest/cplusplus/test_error_class.cpp
@@ -39,7 +39,7 @@ TEST_F(Error_class, message)
     auto output = CAPTURE_OUTPUT([&] {
         error->message(FLERR, "one message");
     });
-    EXPECT_THAT(output, MatchesRegex("one message .*test_error_class.cpp:.*"));
+    ASSERT_THAT(output, MatchesRegex("one message .*test_error_class.cpp:.*"));
 };
 
 TEST_F(Error_class, warning)
@@ -48,8 +48,8 @@ TEST_F(Error_class, warning)
     auto output = CAPTURE_OUTPUT([&] {
         error->warning(FLERR, "one warning");
     });
-    EXPECT_THAT(output, MatchesRegex("WARNING: one warning .*test_error_class.cpp:.*"));
-    EXPECT_THAT(error->get_maxwarn(), 100);
+    ASSERT_THAT(output, MatchesRegex("WARNING: one warning .*test_error_class.cpp:.*"));
+    ASSERT_THAT(error->get_maxwarn(), 100);
 
     // warnings disabled
     HIDE_OUTPUT([&] {
@@ -58,7 +58,7 @@ TEST_F(Error_class, warning)
     output = CAPTURE_OUTPUT([&] {
         error->warning(FLERR, "one warning");
     });
-    EXPECT_THAT(error->get_maxwarn(), -1);
+    ASSERT_THAT(error->get_maxwarn(), -1);
 
     BEGIN_HIDE_OUTPUT();
     command("thermo_modify warn 2");
@@ -66,48 +66,48 @@ TEST_F(Error_class, warning)
     error->warning(FLERR, "one warning");
     error->warning(FLERR, "one warning");
     END_HIDE_OUTPUT();
-    EXPECT_THAT(error->get_maxwarn(), 2);
-    EXPECT_THAT(error->get_numwarn(), 4);
+    ASSERT_THAT(error->get_maxwarn(), 2);
+    ASSERT_THAT(error->get_numwarn(), 5);
 
     output = CAPTURE_OUTPUT([&] {
         thermo->lost_check();
     });
-    EXPECT_THAT(output, MatchesRegex("WARNING: Too many warnings: 4 vs 2. All future.*"));
+    ASSERT_THAT(output, MatchesRegex("WARNING: Too many warnings: 5 vs 2. All future.*"));
 
     output = CAPTURE_OUTPUT([&] {
         error->warning(FLERR, "one warning");
     });
 
-    EXPECT_EQ(output, "");
+    ASSERT_EQ(output, "");
 
     BEGIN_HIDE_OUTPUT();
     command("thermo_modify warn reset");
     thermo->lost_check();
     error->warning(FLERR, "one warning");
     END_HIDE_OUTPUT();
-    EXPECT_THAT(error->get_maxwarn(), 2);
-    EXPECT_THAT(error->get_numwarn(), 1);
+    ASSERT_THAT(error->get_maxwarn(), 2);
+    ASSERT_THAT(error->get_numwarn(), 1);
 
     output = CAPTURE_OUTPUT([&] {
         error->warning(FLERR, "one warning");
     });
-    EXPECT_THAT(output, MatchesRegex("WARNING: one warning.*"));
+    ASSERT_THAT(output, MatchesRegex("WARNING: one warning.*"));
 
     BEGIN_HIDE_OUTPUT();
     command("thermo_modify warn default");
     thermo->lost_check();
     error->warning(FLERR, "one warning");
     END_HIDE_OUTPUT();
-    EXPECT_THAT(error->get_maxwarn(), 100);
-    EXPECT_THAT(error->get_numwarn(), 1);
+    ASSERT_THAT(error->get_maxwarn(), 100);
+    ASSERT_THAT(error->get_numwarn(), 1);
 
     BEGIN_HIDE_OUTPUT();
     command("thermo_modify warn always");
     thermo->lost_check();
     error->warning(FLERR, "one warning");
     END_HIDE_OUTPUT();
-    EXPECT_THAT(error->get_maxwarn(), 0);
-    EXPECT_THAT(error->get_numwarn(), 1);
+    ASSERT_THAT(error->get_maxwarn(), 0);
+    ASSERT_THAT(error->get_numwarn(), 2);
 };
 
 TEST_F(Error_class, one)

--- a/unittest/cplusplus/test_error_class.cpp
+++ b/unittest/cplusplus/test_error_class.cpp
@@ -1,0 +1,150 @@
+// unit tests for issuing command to a LAMMPS instance through the Input class
+
+#include "error.h"
+#include "info.h"
+#include "lammps.h"
+#include "output.h"
+#include "thermo.h"
+
+#include "../testing/core.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <string>
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+namespace LAMMPS_NS {
+
+using ::testing::MatchesRegex;
+using utils::split_words;
+
+class Error_class : public LAMMPSTest {
+protected:
+    Error *error;
+    Thermo *thermo;
+
+    void SetUp() override
+    {
+        testbinary = "ErrorClass";
+        LAMMPSTest::SetUp();
+        error  = lmp->error;
+        thermo = lmp->output->thermo;
+    }
+};
+
+TEST_F(Error_class, message)
+{
+    auto output = CAPTURE_OUTPUT([&] {
+        error->message(FLERR, "one message");
+    });
+    EXPECT_THAT(output, MatchesRegex("one message .*test_error_class.cpp:.*"));
+};
+
+TEST_F(Error_class, warning)
+{
+    // standard warning
+    auto output = CAPTURE_OUTPUT([&] {
+        error->warning(FLERR, "one warning");
+    });
+    EXPECT_THAT(output, MatchesRegex("WARNING: one warning .*test_error_class.cpp:.*"));
+    EXPECT_THAT(error->get_maxwarn(), 100);
+
+    // warnings disabled
+    HIDE_OUTPUT([&] {
+        command("thermo_modify warn ignore");
+    });
+    output = CAPTURE_OUTPUT([&] {
+        error->warning(FLERR, "one warning");
+    });
+    EXPECT_THAT(error->get_maxwarn(), -1);
+
+    BEGIN_HIDE_OUTPUT();
+    command("thermo_modify warn 2");
+    error->warning(FLERR, "one warning");
+    error->warning(FLERR, "one warning");
+    error->warning(FLERR, "one warning");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(error->get_maxwarn(), 2);
+    EXPECT_THAT(error->get_numwarn(), 4);
+
+    output = CAPTURE_OUTPUT([&] {
+        thermo->lost_check();
+    });
+    EXPECT_THAT(output, MatchesRegex("WARNING: Too many warnings: 4 vs 2. All future.*"));
+
+    output = CAPTURE_OUTPUT([&] {
+        error->warning(FLERR, "one warning");
+    });
+
+    EXPECT_EQ(output, "");
+
+    BEGIN_HIDE_OUTPUT();
+    command("thermo_modify warn reset");
+    thermo->lost_check();
+    error->warning(FLERR, "one warning");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(error->get_maxwarn(), 2);
+    EXPECT_THAT(error->get_numwarn(), 1);
+
+    output = CAPTURE_OUTPUT([&] {
+        error->warning(FLERR, "one warning");
+    });
+    EXPECT_THAT(output, MatchesRegex("WARNING: one warning.*"));
+
+    BEGIN_HIDE_OUTPUT();
+    command("thermo_modify warn default");
+    thermo->lost_check();
+    error->warning(FLERR, "one warning");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(error->get_maxwarn(), 100);
+    EXPECT_THAT(error->get_numwarn(), 1);
+
+    BEGIN_HIDE_OUTPUT();
+    command("thermo_modify warn always");
+    thermo->lost_check();
+    error->warning(FLERR, "one warning");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(error->get_maxwarn(), 0);
+    EXPECT_THAT(error->get_numwarn(), 1);
+};
+
+TEST_F(Error_class, one)
+{
+    TEST_FAILURE("ERROR on proc 0: one error.*test_error_class.cpp:.*",
+                 error->one(FLERR, "one error"););
+};
+
+TEST_F(Error_class, all)
+{
+    TEST_FAILURE("ERROR: one error.*test_error_class.cpp:.*", error->all(FLERR, "one error"););
+};
+
+} // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    if (Info::get_mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. "
+                     "Death tests will be skipped\n";
+
+    // handle arguments passed via environment variable
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = split_words(var);
+        for (auto arg : env) {
+            if (arg == "-v") {
+                verbose = true;
+            }
+        }
+    }
+
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}


### PR DESCRIPTION
**Summary**

This pull request implements a feature to control the amount of warning messages printed. Warnings are counted and when their total exceeds a given limit a final warning is printed and then all future warnings are suppressed. With the command "thermo_modify warn" the behavior of this feature can be controlled. It is possible to tell LAMMPS to ignore all warnings or print all warnings or change the maximum number of warnings or reset the warning counter or reset everything to default.

With this change some internal APIs are changed that allow using a format string and a variable number of arguments and thus apply the same change that was introduced in PR #2719 also to the `Error::message()` and `Error::warning()` functions.

In the process of updating the parts of the code using the `Error::warning()` function, also the replicated warning message code for dihedral and improper problems was consolidated into a convenience function `problem()` in the respective base classes.

Also multi-line warning messages were reformatted so that each line starts with "WARNING:" and thus making removing them from log or output with grep easier.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No functional changes, but the specific output of logfiles/outputs can change depending on which and how many warnings are printed during a run.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
