### PR TITLE
Fix compiling the SNAP module with Kokkos and SYCL

### DIFF
--- a/src/KOKKOS/sna_kokkos.h
+++ b/src/KOKKOS/sna_kokkos.h
@@ -23,6 +23,10 @@
 #include <Kokkos_Core.hpp>
 #include "kokkos_type.h"
 
+#ifdef __SYCL_DEVICE_ONLY__
+#include <CL/sycl.hpp>
+#endif
+
 namespace LAMMPS_NS {
 
 template<typename real_type_, int vector_length_>
@@ -161,9 +165,21 @@ inline
   void compute_s_dsfac(const real_type, const real_type, real_type&, real_type&); // compute_cayley_klein
 
   static KOKKOS_FORCEINLINE_FUNCTION
-  void sincos_wrapper(double x, double* sin_, double *cos_) { sincos(x, sin_, cos_); }
+  void sincos_wrapper(double x, double* sin_, double *cos_) {
+#ifdef __SYCL_DEVICE_ONLY__
+    *sin_ = sycl::sincos(x, cos_);
+#else
+    sincos(x, sin_, cos_);
+#endif
+  }
   static KOKKOS_FORCEINLINE_FUNCTION
-  void sincos_wrapper(float x, float* sin_, float *cos_) { sincosf(x, sin_, cos_); }
+  void sincos_wrapper(float x, float* sin_, float *cos_) {
+#ifdef __SYCL_DEVICE_ONLY__
+    *sin_ = sycl::sincos(x, cos_);
+#else
+    sincosf(x, sin_, cos_);
+#endif
+  }
 
 #ifdef TIMING_INFO
   double* timers;


### PR DESCRIPTION
**Summary**

SYCL requires a different namespace for math functions invoked on the device. Since `sincos` is non-standard we don't provide it in `Kokkos` yet. This is needed for compiling the `SNAP` module with `Kokkos` and `SYCL`.

**Author(s)**

Daniel Arndt, ORNL.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The changes should be backward-compatible. They only affect compiling with an `SYCL` compiler.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system




