### PR TITLE
Address issues detected by static code analysis with clang-tidy

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -104,6 +104,12 @@ endif()
 option(BUILD_TOOLS "Build and install LAMMPS tools (msi2lmp, binary2txt, chain)" OFF)
 option(BUILD_LAMMPS_SHELL "Build and install the LAMMPS shell" OFF)
 
+# allow enabling clang-tidy for C++ files
+set(ENABLE_CLANG_TIDY OFF CACHE BOOL "Include clang-tidy processing when compiling")
+if(ENABLE_CLANG_TIDY)
+  set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=*-header-filter=.*" CACHE LIST "")
+endif()
+
 include(GNUInstallDirs)
 file(GLOB ALL_SOURCES ${LAMMPS_SOURCE_DIR}/[^.]*.cpp)
 file(GLOB MAIN_SOURCES ${LAMMPS_SOURCE_DIR}/main.cpp)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -107,7 +107,7 @@ option(BUILD_LAMMPS_SHELL "Build and install the LAMMPS shell" OFF)
 # allow enabling clang-tidy for C++ files
 set(ENABLE_CLANG_TIDY OFF CACHE BOOL "Include clang-tidy processing when compiling")
 if(ENABLE_CLANG_TIDY)
-  set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=*-header-filter=.*" CACHE LIST "")
+  set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=*-header-filter=.*" CACHE STRING "")
 endif()
 
 include(GNUInstallDirs)

--- a/doc/src/Build_development.rst
+++ b/doc/src/Build_development.rst
@@ -28,6 +28,28 @@ variable VERBOSE set to 1:
 
 ----------
 
+.. _clang-tidy
+
+Enable static code analysis with clang-tidy
+-------------------------------------------
+
+The `clang-tidy tool <https://clang.llvm.org/extra/clang-tidy/>`_ is a
+static code analysis tool to diagnose (and potentially fix) typical
+programming errors or coding style violations.  It has a modular framework
+of tests that can be adjusted to help identifying problems before they
+become bugs and also assist in modernizing large code bases (like LAMMPS).
+It can be enabled for all C++ code with the following CMake flag
+
+.. code-block:: bash
+
+   -D ENABLE_CLANG_TIDY=value    # value = no (default) or yes
+
+With this flag enabled all source files will be processed twice, first to
+be compiled and then to be analyzed. Please note that the analysis can be
+significantly more time consuming than the compilation itself.
+
+----------
+
 .. _iwyu_processing:
 
 Report missing and unneeded '#include' statements

--- a/src/SPIN/compute_spin.cpp
+++ b/src/SPIN/compute_spin.cpp
@@ -58,7 +58,7 @@ ComputeSpin::ComputeSpin(LAMMPS *lmp, int narg, char **arg) :
   long_spin_flag = 0;
   precession_spin_flag = 0;
 
-  init();
+  ComputeSpin::init();
 
   allocate();
 

--- a/src/USER-MISC/compute_gyration_shape.cpp
+++ b/src/USER-MISC/compute_gyration_shape.cpp
@@ -44,7 +44,7 @@ ComputeGyrationShape::ComputeGyrationShape(LAMMPS *lmp, int narg, char **arg) :
   // ID of compute gyration
   id_gyration = utils::strdup(arg[3]);
 
-  init();
+  ComputeGyrationShape::init();
 
   vector = new double[6];
 }

--- a/src/USER-MISC/compute_gyration_shape_chunk.cpp
+++ b/src/USER-MISC/compute_gyration_shape_chunk.cpp
@@ -40,7 +40,7 @@ ComputeGyrationShapeChunk::ComputeGyrationShapeChunk(LAMMPS *lmp, int narg, char
   // ID of compute gyration
   id_gyration_chunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeGyrationShapeChunk::init();
 
   array_flag = 1;
   size_array_cols = 6;

--- a/src/arg_info.cpp
+++ b/src/arg_info.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://lammps.sandia.gov/, Sandia National Laboratories
@@ -14,8 +13,8 @@
 
 #include "arg_info.h"
 
-#include <stdexcept>
 #include <cstring>
+#include <stdexcept>
 
 using namespace LAMMPS_NS;
 
@@ -29,46 +28,51 @@ using namespace LAMMPS_NS;
  * \param arg      string with possible reference
  * \param allowed  integer with bitmap of allowed types of references */
 
-ArgInfo::ArgInfo(const std::string &arg, int allowed)
-  : type(NONE), dim(0), index1(-1), index2(-1)
+ArgInfo::ArgInfo(const std::string &arg, int allowed) : type(NONE), dim(0), index1(-1), index2(-1)
 {
   if ((arg.size() > 2) && (arg[1] == '_')) {
-    if ((arg[0] == 'c') && (allowed & COMPUTE))  type = COMPUTE;
-    else if ((arg[0] == 'f') && (allowed & FIX)) type = FIX;
-    else if ((arg[0] == 'v') && (allowed & VARIABLE)) type = VARIABLE;
-    else if ((arg[0] == 'd') && (allowed & DNAME)) type = DNAME;
-    else if ((arg[0] == 'i') && (allowed & INAME)) type = INAME;
+    if ((arg[0] == 'c') && (allowed & COMPUTE))
+      type = COMPUTE;
+    else if ((arg[0] == 'f') && (allowed & FIX))
+      type = FIX;
+    else if ((arg[0] == 'v') && (allowed & VARIABLE))
+      type = VARIABLE;
+    else if ((arg[0] == 'd') && (allowed & DNAME))
+      type = DNAME;
+    else if ((arg[0] == 'i') && (allowed & INAME))
+      type = INAME;
     else {
       index1 = 0;
       name = arg;
       return;
     }
 
-    std::size_t has_idx1 = arg.find('[',2);
+    std::size_t has_idx1 = arg.find('[', 2);
     if (has_idx1 != std::string::npos) {
-      name = arg.substr(2,has_idx1-2);
+      name = arg.substr(2, has_idx1 - 2);
       dim = 1;
 
-      std::size_t has_idx2 = arg.find('[',has_idx1+1);
+      std::size_t has_idx2 = arg.find('[', has_idx1 + 1);
       if (has_idx2 != std::string::npos) {
         dim = 2;
 
-        if (arg[arg.size()-1] != ']') {
+        if (arg[arg.size() - 1] != ']') {
           type = UNKNOWN;
         } else {
           try {
-            index2 = std::stoi(arg.substr(has_idx2+1,arg.size()-(has_idx2+2)));
+            index2 = std::stoi(arg.substr(has_idx2 + 1, arg.size() - (has_idx2 + 2)));
           } catch (std::invalid_argument &) {
             type = UNKNOWN;
           }
         }
-      } else has_idx2 = arg.size();
+      } else
+        has_idx2 = arg.size();
 
-      if (arg[has_idx2-1] != ']') {
+      if (arg[has_idx2 - 1] != ']') {
         type = UNKNOWN;
       } else {
         try {
-          index1 = std::stoi(arg.substr(has_idx1+1,arg.size()-(has_idx2+2)));
+          index1 = std::stoi(arg.substr(has_idx1 + 1, arg.size() - (has_idx2 + 2)));
         } catch (std::invalid_argument &) {
           type = UNKNOWN;
         }
@@ -97,8 +101,7 @@ ArgInfo::ArgInfo(const std::string &arg, int allowed)
 
 char *ArgInfo::copy_name()
 {
-  char *dest = new char[name.size()+1];
-  strcpy(dest,name.c_str());
+  char *dest = new char[name.size() + 1];
+  strcpy(dest, name.c_str());    // NOLINT
   return dest;
 }
-

--- a/src/compute_angmom_chunk.cpp
+++ b/src/compute_angmom_chunk.cpp
@@ -44,7 +44,7 @@ ComputeAngmomChunk::ComputeAngmomChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeAngmomChunk::init();
 
   // chunk-based data
 

--- a/src/compute_com_chunk.cpp
+++ b/src/compute_com_chunk.cpp
@@ -46,7 +46,7 @@ ComputeCOMChunk::ComputeCOMChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeCOMChunk::init();
 
   // chunk-based data
 

--- a/src/compute_dipole_chunk.cpp
+++ b/src/compute_dipole_chunk.cpp
@@ -60,7 +60,7 @@ ComputeDipoleChunk::ComputeDipoleChunk(LAMMPS *lmp, int narg, char **arg) :
     else error->all(FLERR,"Illegal compute dipole/chunk command");
   }
 
-  init();
+  ComputeDipoleChunk::init();
 
   // chunk-based data
 

--- a/src/compute_gyration_chunk.cpp
+++ b/src/compute_gyration_chunk.cpp
@@ -39,7 +39,7 @@ ComputeGyrationChunk::ComputeGyrationChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeGyrationChunk::init();
 
   // optional args
 

--- a/src/compute_inertia_chunk.cpp
+++ b/src/compute_inertia_chunk.cpp
@@ -44,7 +44,7 @@ ComputeInertiaChunk::ComputeInertiaChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeInertiaChunk::init();
 
   // chunk-based data
 

--- a/src/compute_msd_chunk.cpp
+++ b/src/compute_msd_chunk.cpp
@@ -48,7 +48,7 @@ ComputeMSDChunk::ComputeMSDChunk(LAMMPS *lmp, int narg, char **arg) :
   idchunk = utils::strdup(arg[3]);
 
   firstflag = 1;
-  init();
+  ComputeMSDChunk::init();
 
   // create a new fix STORE style for reference positions
   // id = compute-ID + COMPUTE_STORE, fix group = compute group

--- a/src/compute_omega_chunk.cpp
+++ b/src/compute_omega_chunk.cpp
@@ -48,7 +48,7 @@ ComputeOmegaChunk::ComputeOmegaChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeOmegaChunk::init();
 
   // chunk-based data
 

--- a/src/compute_property_chunk.cpp
+++ b/src/compute_property_chunk.cpp
@@ -36,7 +36,7 @@ ComputePropertyChunk::ComputePropertyChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputePropertyChunk::init();
 
   // parse values
 

--- a/src/compute_temp_chunk.cpp
+++ b/src/compute_temp_chunk.cpp
@@ -48,7 +48,7 @@ ComputeTempChunk::ComputeTempChunk(LAMMPS *lmp, int narg, char **arg) :
   idchunk = utils::strdup(arg[3]);
 
   biasflag = 0;
-  init();
+  ComputeTempChunk::init();
 
   // optional per-chunk values
 

--- a/src/compute_torque_chunk.cpp
+++ b/src/compute_torque_chunk.cpp
@@ -43,7 +43,7 @@ ComputeTorqueChunk::ComputeTorqueChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeTorqueChunk::init();
 
   // chunk-based data
 

--- a/src/compute_vcm_chunk.cpp
+++ b/src/compute_vcm_chunk.cpp
@@ -44,7 +44,7 @@ ComputeVCMChunk::ComputeVCMChunk(LAMMPS *lmp, int narg, char **arg) :
 
   idchunk = utils::strdup(arg[3]);
 
-  init();
+  ComputeVCMChunk::init();
 
   // chunk-based data
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -638,7 +638,7 @@ int utils::expand_args(const char *file, int line, int narg, char **arg, int mod
 char *utils::strdup(const std::string &text)
 {
   char *tmp = new char[text.size() + 1];
-  strcpy(tmp, text.c_str());
+  strcpy(tmp, text.c_str());    // NOLINT
   return tmp;
 }
 


### PR DESCRIPTION
**Summary**

CMake supports static code analysis via clang-tidy out of the box, so this PR adds a "developer" option in the CMake configuration to enable it. Also included are fixes for a few issues detected by it.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No functionality changes are expected.

**Implementation Notes**

The following issues are addressed:
- Virtual function handling does not exist when in the constructor, thus we give virtual functions when called inside a constructor an explicit scope so the intention of which function is supposed to be called becomes (more) obvious.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
