### PR TITLE
Allow setting canonical URL in doc build

### DIFF
--- a/doc/utils/sphinx-config/_themes/lammps_theme/breadcrumbs.html
+++ b/doc/utils/sphinx-config/_themes/lammps_theme/breadcrumbs.html
@@ -65,7 +65,7 @@
           {% elif show_source and has_source and sourcename %}
             <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>
           {% endif %}
-          <a href="http://lammps.sandia.gov">Website</a>
+          <a href="https://www.lammps.org">Website</a>
           <a href="Commands_all.html">Commands</a>
         {% endif %}
       </li>

--- a/doc/utils/sphinx-config/_themes/lammps_theme/layout.html
+++ b/doc/utils/sphinx-config/_themes/lammps_theme/layout.html
@@ -38,10 +38,11 @@
   {% if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
   {% endif %}
-  {# CANONICAL URL #}
-  {% if theme_canonical_url %}
-    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
-  {% endif %}
+
+  {#- CANONICAL URL #}
+  {%- if pageurl %}
+    <link rel="canonical" href="{{ pageurl|e }}" />
+  {%- endif -%}
 
   {# JAVASCRIPTS #}
   {%- block scripts %}

--- a/doc/utils/sphinx-config/_themes/lammps_theme/theme.conf
+++ b/doc/utils/sphinx-config/_themes/lammps_theme/theme.conf
@@ -4,7 +4,6 @@ stylesheet = css/theme.css
 pygments_style = default
 
 [options]
-canonical_url =
 analytics_id =
 collapse_navigation = False
 sticky_navigation = False

--- a/doc/utils/sphinx-config/conf.py.in
+++ b/doc/utils/sphinx-config/conf.py.in
@@ -76,7 +76,7 @@ master_doc = 'Manual'
 
 # General information about the project.
 project = 'LAMMPS'
-copyright = '2003-2020 Sandia Corporation'
+copyright = '2003-2021 Sandia Corporation'
 
 def get_lammps_version():
     import os

--- a/doc/utils/sphinx-config/conf.py.in
+++ b/doc/utils/sphinx-config/conf.py.in
@@ -255,6 +255,8 @@ htmlhelp_basename = 'LAMMPSdoc'
 
 html_permalinks = True
 
+html_baseurl = os.environ.get('LAMMPS_WEBSITE_BASEURL', '')
+
 if 'epub' in sys.argv:
   html_math_renderer = 'imgmath'
 else:

--- a/doc/utils/sphinx-config/conf.py.in
+++ b/doc/utils/sphinx-config/conf.py.in
@@ -15,6 +15,7 @@
 
 import sys
 import os
+from datetime import date
 
 has_enchant = False
 try:
@@ -76,7 +77,7 @@ master_doc = 'Manual'
 
 # General information about the project.
 project = 'LAMMPS'
-copyright = '2003-2021 Sandia Corporation'
+copyright = '2003-{} Sandia Corporation'.format(date.today().year)
 
 def get_lammps_version():
     import os


### PR DESCRIPTION
**Summary**

Use the environment variable `LAMMPS_WEBSITE_BASEURL` to set the base URL for the HTML documentation.
We will use this in our CI set the necessary link tag in:

https://docs.lammps.org
https://docs.lammps.org/stable/
https://docs.lammps.org/latest/

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


