### PR TITLE
Added 'max_sep' argument to fix gcmc command

### DIFF
--- a/doc/src/fix_gcmc.rst
+++ b/doc/src/fix_gcmc.rst
@@ -24,7 +24,7 @@ Syntax
 
   .. parsed-literal::
 
-     keyword = *mol*\ , *region*\ , *maxangle*\ , *pressure*\ , *fugacity_coeff*, *full_energy*, *charge*\ , *group*\ , *grouptype*\ , *intra_energy*, *tfac_insert*, or *overlap_cutoff*
+     keyword = *mol*\ , *region*\ , *maxangle*\ , *pressure*\ , *fugacity_coeff*, *full_energy*, *charge*\ , *group*\ , *grouptype*\ , *intra_energy*, *tfac_insert*, *overlap_cutoff*, *max_sep*, *max* or *min*
        *mol* value = template-ID
          template-ID = ID of molecule template specified in a separate :doc:`molecule <molecule>` command
        *mcmoves* values = Patomtrans Pmoltrans Pmolrotate
@@ -50,8 +50,9 @@ Syntax
        *intra_energy* value = intramolecular energy (energy units)
        *tfac_insert* value = scale up/down temperature of inserted atoms (unitless)
        *overlap_cutoff* value = maximum pair distance for overlap rejection (distance units)
-       *max* value = Maximum number of molecules allowed in the system
-       *min* value = Minimum number of molecules allowed in the system
+       *max_sep* value = maximum distance between an atom/molecule and a cluster (distance units)
+       *max* value = maximum number of molecules allowed in the system
+       *min* value = minimum number of molecules allowed in the system
 
 Examples
 """"""""
@@ -384,6 +385,17 @@ assigning an infinite positive energy to all new configurations that
 place any pair of atoms closer than the specified overlap cutoff
 distance.
 
+The *max_sep* option can be used to force the atoms to always have a
+neighbor within this distance. In cluster terms, all atoms/molecules belong
+to a cluster when this keyword in envoked. The clusters are then defined by
+the Stillinger cluster criterion :ref:`(Stillinger) <Stillinger1>` with the
+value as the minimum distance between two clusters. If an atom/molecule does
+not belong to a cluster, the interaction energy is effectively set to infinity.
+
+.. note::
+   If the *max_sep* argument is applied and the initial system is empty,
+   the system will remain empty during the GCMC run.
+
 The *max* and *min* keywords allow for the restriction of the number
 of atoms in the simulation. They automatically reject all insertion
 or deletion moves that would take the system beyond the set boundaries.
@@ -488,3 +500,8 @@ listed above.
 
 **(Frenkel)** Frenkel and Smit, Understanding Molecular Simulation,
 Academic Press, London, 2002.
+
+.. _Stillinger1:
+
+**(Stillinger)** F. H. Stillinger, Rigorous Basis of the Frenkel-Band
+Theory of Association Equilibrium, J. Chem. Phys. 38, 1486, (1963).

--- a/doc/src/fix_gcmc.rst
+++ b/doc/src/fix_gcmc.rst
@@ -50,7 +50,7 @@ Syntax
        *intra_energy* value = intramolecular energy (energy units)
        *tfac_insert* value = scale up/down temperature of inserted atoms (unitless)
        *overlap_cutoff* value = maximum pair distance for overlap rejection (distance units)
-       *max_sep* value = maximum distance between an atom/molecule and a cluster (distance units)
+       *max_sep* value = maximum distance between an added atom/molecule and a cluster (distance units)
        *max* value = maximum number of molecules allowed in the system
        *min* value = minimum number of molecules allowed in the system
 
@@ -385,11 +385,11 @@ assigning an infinite positive energy to all new configurations that
 place any pair of atoms closer than the specified overlap cutoff
 distance.
 
-The *max_sep* option can be used to force the atoms to always have a
-neighbor within this distance. In cluster terms, all atoms/molecules belong
-to a cluster when this keyword in envoked. The clusters are then defined by
+The *max_sep* option can be used to force an added atom/molecule to always have
+a neighbor within this distance. In cluster terms, all atoms/molecules will be
+added to a cluster when this keyword in envoked. The clusters are then defined by
 the Stillinger cluster criterion :ref:`(Stillinger) <Stillinger1>` with the
-value as the minimum distance between two clusters. If an atom/molecule does
+value as the minimum distance between two clusters. If an added atom/molecule does
 not belong to a cluster, the interaction energy is effectively set to infinity.
 
 .. note::

--- a/src/MC/fix_gcmc.h
+++ b/src/MC/fix_gcmc.h
@@ -118,7 +118,9 @@ class FixGCMC : public Fix {
   imageint *molimage;
   imageint imagezero;
   double overlap_cutoffsq;    // square distance cutoff for overlap
+  double max_sepsq;           // square max separation distance
   int overlap_flag;
+  int max_sep_flag;
   int max_ngas;
   int min_ngas;
 


### PR DESCRIPTION
**Summary**

The ´fix gcmc´ command now takes max separation distance, ´max_sep´, as a proposal argument. It makes it possible to force all atoms to be in a cluster according to the Stillinger cluster criterion. If the initial system consists of one cluster, there will never be more than one cluster. 

**Related Issue(s)**

This PR is related to issue #2800. 

**Author(s)**

Even Marius Nordhagen, University of Oslo

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

There is no reason the added code should not be backward compatible with older LAMMPS versions.

**Implementation Notes**

Implementation of the ´max_sep´ argument was more or less copy pasting the implementation of the ´overlap_cutoff´ argument. LAMMPS was compiled with SMALLBIG and BIGBIG. If the initial system is empty, the system will remain empty during the GCMC simulation when this argument is used. This should probably raise an error message.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


