### PR TITLE
Correcting a small bug in fix nve/spin

### DIFF
--- a/src/SPIN/fix_nve_spin.cpp
+++ b/src/SPIN/fix_nve_spin.cpp
@@ -176,6 +176,7 @@ void FixNVESpin::init()
 
   // loop 1: obtain # of Pairs, and # of Pair/Spin styles
 
+  npairspin = 0;
   PairHybrid *hybrid = (PairHybrid *)force->pair_match("^hybrid",0);
   if (force->pair_match("^spin",0,0)) {        // only one Pair/Spin style
     pair = force->pair_match("^spin",0,0);
@@ -232,6 +233,7 @@ void FixNVESpin::init()
   // loop 1: obtain # of fix precession/spin styles
 
   int iforce;
+  nprecspin = 0;
   for (iforce = 0; iforce < modify->nfix; iforce++) {
     if (utils::strmatch(modify->fix[iforce]->style,"^precession/spin")) {
       nprecspin++;
@@ -264,6 +266,7 @@ void FixNVESpin::init()
 
   // loop 1: obtain # of fix langevin/spin styles
 
+  nlangspin = 0;
   for (iforce = 0; iforce < modify->nfix; iforce++) {
     if (utils::strmatch(modify->fix[iforce]->style,"^langevin/spin")) {
       nlangspin++;


### PR DESCRIPTION
**Summary**

Correction of a small bug in fix nve/spin. The "nprecspin" and "nlangspin" variables need to be reset to 0 before counting the number of corresponding fixes (fix langevin/spin and fix precession/spin). 

**Related Issue(s)**

Without this correction, two or more different "run" of "minimize" commands cannot run consecutively in the same input script. 

**Author(s)**

Julien Tranchida, julien.tranchida1@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Those changes will not affect backward compatibility.

**Implementation Notes**

The changes are minor and limited to the SPIN package.

**Post Submission Checklist**


- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

