### PR TITLE
SYCL team_reduce to mimic cuda __syncthreads_count

### DIFF
--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -610,7 +610,9 @@ void NeighborKokkosExecute<DeviceType>::build_ItemGPU(typename Kokkos::TeamPolic
 
   if (test) return;
 #else
-  dev.team_barrier();
+  int not_done = (i >= 0 && i <= nlocal);
+  dev.team_reduce(Kokkos::Max<int>(not_done));
+  if(not_done == 0) return;
 #endif
 
   if (i >= 0 && i < nlocal) {
@@ -1053,13 +1055,14 @@ void NeighborKokkosExecute<DeviceType>::build_ItemSizeGPU(typename Kokkos::TeamP
       other_x[MY_II + 4 * atoms_per_bin] = radi;
     }
     other_id[MY_II] = i;
-    // FIXME_SYCL
 #ifndef KOKKOS_ENABLE_SYCL
     int test = (__syncthreads_count(i >= 0 && i <= nlocal) == 0);
 
     if (test) return;
 #else
-    dev.team_barrier();
+    int not_done = (i >= 0 && i <= nlocal);
+    dev.team_reduce(Kokkos::Max<int>(not_done));
+    if(not_done == 0) return;
 #endif
 
     if (i >= 0 && i < nlocal) {


### PR DESCRIPTION
**Summary**

- SYCL alternative for __syncthreads_count in npair_kokkos.cpp

- This fixes a suspected out of bounds error later on in the kernel.

**Author(s)**

@joeatodd (Codeplay)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**


SYCL doesn't have __syncthreads_count. This commit implements the same logic using Kokkos' team_reduce. 

I also suspect this might be a faster alternative to the HIP __syncthreads_count overload at line 547, but I have left this alone.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

**Further Information, Files, and Links**


