### PR TITLE
Remove deprecated Kokkos code ViewAllocateWithoutInitializing

### DIFF
--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -45,7 +45,7 @@ enum{FULL=1u,HALFTHREAD=2u,HALF=4u};
 static constexpr LAMMPS_NS::bigint LMP_KOKKOS_AV_DELTA = 10;
 
 namespace Kokkos {
-  auto NoInit = [](std::string const& label) {
+  static auto NoInit = [](std::string const& label) {
     return Kokkos::view_alloc(Kokkos::WithoutInitializing, label);
   };
 }

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -45,7 +45,9 @@ enum{FULL=1u,HALFTHREAD=2u,HALF=4u};
 static constexpr LAMMPS_NS::bigint LMP_KOKKOS_AV_DELTA = 10;
 
 namespace Kokkos {
-  using NoInit = ViewAllocateWithoutInitializing;
+  auto NoInit = [](std::string const& label) {
+    return Kokkos::view_alloc(Kokkos::WithoutInitializing, label);
+  };
 }
 
   struct lmp_float3 {


### PR DESCRIPTION
**Summary**

`Kokkos::ViewAllocateWithoutInitializing` is being deprecated, see https://github.com/kokkos/kokkos/pull/3264 and https://github.com/kokkos/kokkos/pull/4155. Add a replacement as suggested here: https://github.com/arborx/ArborX/pull/390#issuecomment-698567511.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes