### PR TITLE
Revert Kokkos CPU SNAP to original code

### DIFF
--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -30,6 +30,7 @@
 #include "neighbor_kokkos.h"
 #include "kokkos.h"
 #include "sna.h"
+#include "comm.h"
 
 #define MAXLINE 1024
 #define MAXWORD 3
@@ -87,7 +88,12 @@ template<class DeviceType, typename real_type, int vector_length>
 void PairSNAPKokkos<DeviceType, real_type, vector_length>::init_style()
 {
   if (host_flag) {
-     PairSNAP::init_style();
+    if (lmp->kokkos->nthreads > 1)
+      if (comm->me == 0)
+        utils::logmesg(lmp,"Pair style snap/kk currently only runs on a single "
+                           "CPU thread, even if more threads are requested\n");
+
+    PairSNAP::init_style();
     return;
   }
 

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -86,6 +86,11 @@ PairSNAPKokkos<DeviceType, real_type, vector_length>::~PairSNAPKokkos()
 template<class DeviceType, typename real_type, int vector_length>
 void PairSNAPKokkos<DeviceType, real_type, vector_length>::init_style()
 {
+  if (host_flag) {
+     PairSNAP::init_style();
+    return;
+  }
+
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style SNAP requires newton pair on");
 
@@ -133,6 +138,13 @@ struct FindMaxNumNeighs {
 template<class DeviceType, typename real_type, int vector_length>
 void PairSNAPKokkos<DeviceType, real_type, vector_length>::compute(int eflag_in, int vflag_in)
 {
+  if (host_flag) {
+    atomKK->sync(Host,X_MASK|TYPE_MASK);
+    PairSNAP::compute(eflag_in,vflag_in);
+    atomKK->modified(Host,F_MASK);
+    return;
+  }
+
   eflag = eflag_in;
   vflag = vflag_in;
 


### PR DESCRIPTION
**Summary**

After years of optimizing Kokkos SNAP for GPUs, the Kokkos CPU performance has suffered and is significantly slower than the original (non-Kokkos) CPU implementation, despite the CPU and GPU code-paths being fully bifurcated. There are future plans to refactor the Kokkos SNAP code to improve CPU performance and re-integrate CPU/GPU code to reduce bifurcation. However, as a quick, temporary measure, this PR reverts the CPU version of Kokkos SNAP to use the better performing original code so that users aren't hurt if they use the Kokkos CPU version of SNAP.

**Related Issue(s)**

None.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes