### PR TITLE
Delete last mol

### DIFF
--- a/doc/src/fix_gcmc.rst
+++ b/doc/src/fix_gcmc.rst
@@ -451,6 +451,11 @@ When using fix gcmc in combination with fix shake or fix rigid,
 only GCMC exchange moves are supported, so the argument
 *M* must be zero.
 
+When using fix gcmc in combination with fix rigid, deletion
+of the last remaining molecule is not allowed for technical reasons,
+and so the molecule count will never drop below 1, regardless of the
+specified chemical potential.
+
 Note that very lengthy simulations involving insertions/deletions of
 billions of gas molecules may run out of atom or molecule IDs and
 trigger an error, so it is better to run multiple shorter-duration

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -1230,7 +1230,7 @@ void FixGCMC::attempt_molecule_deletion()
 
   // work-around to avoid n=0 problem with fix rigid/nvt/small
 
-  if (ngas == natoms_per_molecule) return;
+  if (rigidflag && ngas == natoms_per_molecule) return;
 
   tagint deletion_molecule = pick_random_gas_molecule();
   if (deletion_molecule == -1) return;
@@ -1900,7 +1900,7 @@ void FixGCMC::attempt_molecule_deletion_full()
 
   // work-around to avoid n=0 problem with fix rigid/nvt/small
 
-  if (ngas == natoms_per_molecule) return;
+  if (rigidflag && ngas == natoms_per_molecule) return;
 
   tagint deletion_molecule = pick_random_gas_molecule();
   if (deletion_molecule == -1) return;


### PR DESCRIPTION
**Summary**

Updated fix gcmc to allow deletion of last molecule, except in the case of fix rigid

**Related Issue(s)**

It was noticed that molecular count never dropped to zero for molecules, even if molecule was a LJ atom

**Author(s)**

Aidan Thompson

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

n/a

**Implementation Notes**

Very small change, testing was performed on in.gcmc.lj and in.gcmc.h2o.  For LJ , reference log about was reproduced exactly, for H2O, the results were similar, but not exactly the same.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


