### PR TITLE
plugged memory leaks in ml-rann package. Resolves [2811]

### DIFF
--- a/src/ML-RANN/pair_rann.cpp
+++ b/src/ML-RANN/pair_rann.cpp
@@ -100,45 +100,45 @@ PairRANN::PairRANN(LAMMPS *lmp) : Pair(lmp)
 PairRANN::~PairRANN()
 {
   //clear memory
-  delete [] mass;
+  delete[] mass;
   for (int i=0;i<nelements;i++) {delete [] elements[i];}
-  delete [] elements;
+  delete[] elements;
   for (int i=0;i<nelementsp;i++) {delete [] elementsp[i];}
-  delete [] elementsp;
+  delete[] elementsp;
   for (int i=0;i<=nelements;i++) {
     if (net[i].layers>0) {
       for (int j=0;j<net[i].layers-1;j++) {
-        delete [] net[i].Weights[j];
-        delete [] net[i].Biases[j];
+        delete[] net[i].Weights[j];
+        delete[] net[i].Biases[j];
         delete activation[i][j];
       }
-      delete [] activation[i];
-      delete [] net[i].Weights;
-      delete [] net[i].Biases;
-      delete [] weightdefined[i];
-      delete [] biasdefined[i];
+      delete[] activation[i];
+      delete[] net[i].Weights;
+      delete[] net[i].Biases;
+      delete[] weightdefined[i];
+      delete[] biasdefined[i];
     }
-    delete [] net[i].dimensions;
+    delete[] net[i].dimensions;
   }
-  delete [] net;
-  delete [] map;
+  delete[] net;
+  delete[] map;
   for (int i=0;i<nelementsp;i++) {
     if (fingerprintlength[i]>0) {
       for (int j=0;j<fingerprintperelement[i];j++) {
         delete fingerprints[i][j];
       }
-      delete [] fingerprints[i];
+      delete[] fingerprints[i];
     }
   }
-  delete [] fingerprints;
-  delete [] activation;
-  delete [] weightdefined;
-  delete [] biasdefined;
-  delete [] fingerprintcount;
-  delete [] fingerprintperelement;
-  delete [] fingerprintlength;
-  delete [] screening_min;
-  delete [] screening_max;
+  delete[] fingerprints;
+  delete[] activation;
+  delete[] weightdefined;
+  delete[] biasdefined;
+  delete[] fingerprintcount;
+  delete[] fingerprintperelement;
+  delete[] fingerprintlength;
+  delete[] screening_min;
+  delete[] screening_max;
   memory->destroy(xn);
   memory->destroy(yn);
   memory->destroy(zn);
@@ -207,10 +207,10 @@ void PairRANN::allocate(const std::vector<std::string> &elementwords)
   activation = new RANN::Activation**[nelementsp];
   fingerprints = new RANN::Fingerprint**[nelementsp];
   fingerprintlength = new int[nelementsp];
-  fingerprintperelement = new int [nelementsp];
+  fingerprintperelement = new int[nelementsp];
   fingerprintcount = new int[nelementsp];
-  screening_min = new double [nelements*nelements*nelements];
-  screening_max = new double [nelements*nelements*nelements];
+  screening_min = new double[nelements*nelements*nelements];
+  screening_max = new double[nelements*nelements*nelements];
   for (i=0;i<nelements;i++) {
     for (int j =0;j<nelements;j++) {
       for (int k=0;k<nelements;k++) {
@@ -243,7 +243,7 @@ void PairRANN::settings(int narg, char ** /*arg*/)
 void PairRANN::coeff(int narg, char **arg)
 {
   int i,j;
-  map = new int [atom->ntypes+1];
+  map = new int[atom->ntypes+1];
   if (narg != 3 + atom->ntypes) error->one(FLERR,"Incorrect args for pair coefficients");
   if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0) error->one(FLERR,"Incorrect args for pair coefficients");
   nelements = -1;
@@ -483,10 +483,10 @@ void PairRANN::read_network_layers(std::vector<std::string> line,std::vector<std
     if (line[1].compare(elements[i])==0) {
       net[i].layers = utils::inumeric(filename,linenum,line1[0].c_str(),1,lmp);
       if (net[i].layers < 1)error->one(filename,linenum,"invalid number of network layers");
-      delete [] net[i].dimensions;
+      delete[] net[i].dimensions;
       weightdefined[i] = new bool [net[i].layers];
       biasdefined[i] = new bool [net[i].layers];
-      net[i].dimensions = new int [net[i].layers];
+      net[i].dimensions = new int[net[i].layers];
       net[i].Weights = new double * [net[i].layers-1];
       net[i].Biases = new double * [net[i].layers-1];
       for (j=0;j<net[i].layers;j++) {
@@ -529,7 +529,7 @@ void PairRANN::read_weight(std::vector<std::string> line,std::vector<std::string
       i=utils::inumeric(filename,*linenum,line[2].c_str(),1,lmp);
       if (i>=net[l].layers || i<0)error->one(filename,*linenum-1,"invalid weight layer");
       if (net[l].dimensions[i]==0 || net[l].dimensions[i+1]==0) error->one(filename,*linenum-1,"network layer sizes must be defined before corresponding weight");
-      net[l].Weights[i] = new double [net[l].dimensions[i]*net[l].dimensions[i+1]];
+      net[l].Weights[i] = new double[net[l].dimensions[i]*net[l].dimensions[i+1]];
       weightdefined[l][i] = true;
       nwords = line1.size();
       if (nwords != net[l].dimensions[i])error->one(filename,*linenum,"invalid weights per line");
@@ -564,7 +564,7 @@ void PairRANN::read_bias(std::vector<std::string> line,std::vector<std::string> 
       if (i>=net[l].layers || i<0)error->one(filename,*linenum-1,"invalid bias layer");
       if (net[l].dimensions[i]==0) error->one(filename,*linenum-1,"network layer sizes must be defined before corresponding bias");
       biasdefined[l][i] = true;
-      net[l].Biases[i] = new double [net[l].dimensions[i+1]];
+      net[l].Biases[i] = new double[net[l].dimensions[i+1]];
       net[l].Biases[i][0] = utils::numeric(filename,*linenum,line1[0].c_str(),1,lmp);
       for (j=1;j<net[l].dimensions[i+1];j++) {
         ptr=fgets(linetemp,MAXLINE,fp);
@@ -842,7 +842,7 @@ void PairRANN::compute(int eflag, int vflag)
       }
   }
   if (vflag_fdotr) virial_fdotr_compute();
-  delete [] sims;
+  delete[] sims;
 }
 
 void PairRANN::cull_neighbor_list(int* jnum,int i,int sn) {

--- a/src/ML-RANN/pair_rann.h
+++ b/src/ML-RANN/pair_rann.h
@@ -136,6 +136,7 @@ namespace LAMMPS_NS {
    private:
     //new functions
     void allocate(const std::vector<std::string> &);//called after reading element list, but before reading the rest of the potential
+    void deallocate();
     void read_file(char *);//read potential file
     void read_atom_types(std::vector<std::string>,char*,int);
     void read_fpe(std::vector<std::string>,std::vector<std::string>,char*,int);//fingerprints per element. Count total fingerprints defined for each 1st element in element combinations

--- a/src/ML-RANN/rann_fingerprint_bond.cpp
+++ b/src/ML-RANN/rann_fingerprint_bond.cpp
@@ -282,6 +282,7 @@ void Fingerprint_bond::generate_coefficients() {      //calculates multinomial c
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
+  delete [] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bond.cpp
+++ b/src/ML-RANN/rann_fingerprint_bond.cpp
@@ -156,6 +156,7 @@ void Fingerprint_bond::init(int *i,int _id) {
   rc = 0;
   mlength = 0;
   kmax = 0;
+  delete[] alpha_k;
   alpha_k = new double [1];
   alpha_k[0]=-1;
   empty = false;

--- a/src/ML-RANN/rann_fingerprint_bond.cpp
+++ b/src/ML-RANN/rann_fingerprint_bond.cpp
@@ -40,35 +40,35 @@ Fingerprint_bond::Fingerprint_bond(PairRANN *_pair) : Fingerprint(_pair)
   dr = 0;
   re = 0;
   rc = 0;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0] = -1;
   kmax = 0;
   mlength = 0;
   id = -1;
   style = "bond";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   _pair->allscreen = false;
 }
 
 Fingerprint_bond::~Fingerprint_bond() {
-  delete [] alpha_k;
-  delete [] atomtypes;
-  delete [] expcuttable;
-  delete [] dfctable;
+  delete[] alpha_k;
+  delete[] atomtypes;
+  delete[] expcuttable;
+  delete[] dfctable;
   for (int i=0;i<(mlength*(mlength+1))>>1;i++) {
-    delete [] coeff[i];
-    delete [] coeffx[i];
-    delete [] coeffy[i];
-    delete [] coeffz[i];
-    delete [] Mf[i];
+    delete[] coeff[i];
+    delete[] coeffx[i];
+    delete[] coeffy[i];
+    delete[] coeffz[i];
+    delete[] Mf[i];
   }
-  delete [] coeff;
-  delete [] coeffx;
-  delete [] coeffy;
-  delete [] coeffz;
-  delete [] Mf;
-  delete [] rinvsqrttable;
+  delete[] coeff;
+  delete[] coeffx;
+  delete[] coeffy;
+  delete[] coeffz;
+  delete[] Mf;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_bond::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -81,8 +81,8 @@ bool Fingerprint_bond::parse_values(std::string constant,std::vector<std::string
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alphak")==0) {
-    delete [] alpha_k;
-    alpha_k = new double [nwords];
+    delete[] alpha_k;
+    alpha_k = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha_k[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -157,7 +157,7 @@ void Fingerprint_bond::init(int *i,int _id) {
   mlength = 0;
   kmax = 0;
   delete[] alpha_k;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0]=-1;
   empty = false;
   id = _id;
@@ -181,8 +181,8 @@ void Fingerprint_bond::generate_exp_cut_table() {
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  expcuttable = new double [(res+buf)*(kmax)];
-  dfctable = new double [res+buf];
+  expcuttable = new double[(res+buf)*(kmax)];
+  dfctable = new double[res+buf];
   for (m=0;m<(res+buf);m++) {
     r1 = cutmax*cutmax*(double)(m)/(double)(res);
     for (n=0;n<(kmax);n++) {
@@ -283,7 +283,7 @@ void Fingerprint_bond::generate_coefficients() {      //calculates multinomial c
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
-  delete [] M;
+  delete[] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bondscreened.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondscreened.cpp
@@ -156,6 +156,7 @@ void Fingerprint_bondscreened::init(int *i,int _id) {
   rc = 0;
   mlength = 0;
   kmax = 0;
+  delete[] alpha_k;
   alpha_k = new double [1];
   alpha_k[0]=-1;
   empty = false;

--- a/src/ML-RANN/rann_fingerprint_bondscreened.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondscreened.cpp
@@ -39,36 +39,36 @@ Fingerprint_bondscreened::Fingerprint_bondscreened(PairRANN *_pair) : Fingerprin
   dr = 0;
   re = 0;
   rc = 0;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0] = -1;
   kmax = 0;
   mlength = 0;
   id = -1;
   style = "bondscreened";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   _pair->doscreen = true;
   screen = true;
 }
 
 Fingerprint_bondscreened::~Fingerprint_bondscreened() {
-  delete [] alpha_k;
-  delete [] atomtypes;
-  delete [] expcuttable;
-  delete [] dfctable;
+  delete[] alpha_k;
+  delete[] atomtypes;
+  delete[] expcuttable;
+  delete[] dfctable;
   for (int i=0;i<(mlength*(mlength+1))>>1;i++) {
-    delete [] coeff[i];
-    delete [] coeffx[i];
-    delete [] coeffy[i];
-    delete [] coeffz[i];
-    delete [] Mf[i];
+    delete[] coeff[i];
+    delete[] coeffx[i];
+    delete[] coeffy[i];
+    delete[] coeffz[i];
+    delete[] Mf[i];
   }
-  delete [] coeff;
-  delete [] coeffx;
-  delete [] coeffy;
-  delete [] coeffz;
-  delete [] Mf;
-  delete [] rinvsqrttable;
+  delete[] coeff;
+  delete[] coeffx;
+  delete[] coeffy;
+  delete[] coeffz;
+  delete[] Mf;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_bondscreened::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -81,8 +81,8 @@ bool Fingerprint_bondscreened::parse_values(std::string constant,std::vector<std
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alphak")==0) {
-    delete [] alpha_k;
-    alpha_k = new double [nwords];
+    delete[] alpha_k;
+    alpha_k = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha_k[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -157,7 +157,7 @@ void Fingerprint_bondscreened::init(int *i,int _id) {
   mlength = 0;
   kmax = 0;
   delete[] alpha_k;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0]=-1;
   empty = false;
   id = _id;
@@ -181,8 +181,8 @@ void Fingerprint_bondscreened::generate_exp_cut_table() {
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  expcuttable = new double [(res+buf)*(kmax)];
-  dfctable = new double [res+buf];
+  expcuttable = new double[(res+buf)*(kmax)];
+  dfctable = new double[res+buf];
   for (m=0;m<(res+buf);m++) {
     r1 = cutmax*cutmax*(double)(m)/(double)(res);
     for (n=0;n<(kmax);n++) {
@@ -284,7 +284,7 @@ void Fingerprint_bondscreened::generate_coefficients() {      //calculates multi
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
-  delete [] M;
+  delete[] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bondscreened.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondscreened.cpp
@@ -283,6 +283,7 @@ void Fingerprint_bondscreened::generate_coefficients() {      //calculates multi
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
+  delete [] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bondscreenedspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondscreenedspin.cpp
@@ -158,6 +158,7 @@ void Fingerprint_bondscreenedspin::init(int *i,int _id) {
   rc = 0;
   mlength = 0;
   kmax = 0;
+  delete[] alpha_k;
   alpha_k = new double [1];
   alpha_k[0]=-1;
   empty = false;

--- a/src/ML-RANN/rann_fingerprint_bondscreenedspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondscreenedspin.cpp
@@ -285,6 +285,7 @@ void Fingerprint_bondscreenedspin::generate_coefficients() {      //calculates m
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
+  delete [] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bondscreenedspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondscreenedspin.cpp
@@ -39,13 +39,13 @@ Fingerprint_bondscreenedspin::Fingerprint_bondscreenedspin(PairRANN *_pair) : Fi
   dr = 0;
   re = 0;
   rc = 0;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0] = -1;
   kmax = 0;
   mlength = 0;
   id = -1;
   style = "bondscreenedspin";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   _pair->doscreen = true;
   screen = true;
@@ -54,23 +54,23 @@ Fingerprint_bondscreenedspin::Fingerprint_bondscreenedspin(PairRANN *_pair) : Fi
 }
 
 Fingerprint_bondscreenedspin::~Fingerprint_bondscreenedspin() {
-  delete [] alpha_k;
-  delete [] atomtypes;
-  delete [] expcuttable;
-  delete [] dfctable;
+  delete[] alpha_k;
+  delete[] atomtypes;
+  delete[] expcuttable;
+  delete[] dfctable;
   for (int i=0;i<(mlength*(mlength+1))>>1;i++) {
-    delete [] coeff[i];
-    delete [] coeffx[i];
-    delete [] coeffy[i];
-    delete [] coeffz[i];
-    delete [] Mf[i];
+    delete[] coeff[i];
+    delete[] coeffx[i];
+    delete[] coeffy[i];
+    delete[] coeffz[i];
+    delete[] Mf[i];
   }
-  delete [] coeff;
-  delete [] coeffx;
-  delete [] coeffy;
-  delete [] coeffz;
-  delete [] Mf;
-  delete [] rinvsqrttable;
+  delete[] coeff;
+  delete[] coeffx;
+  delete[] coeffy;
+  delete[] coeffz;
+  delete[] Mf;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_bondscreenedspin::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -83,8 +83,8 @@ bool Fingerprint_bondscreenedspin::parse_values(std::string constant,std::vector
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alphak")==0) {
-    delete [] alpha_k;
-    alpha_k = new double [nwords];
+    delete[] alpha_k;
+    alpha_k = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha_k[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -159,7 +159,7 @@ void Fingerprint_bondscreenedspin::init(int *i,int _id) {
   mlength = 0;
   kmax = 0;
   delete[] alpha_k;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0]=-1;
   empty = false;
   id = _id;
@@ -183,8 +183,8 @@ void Fingerprint_bondscreenedspin::generate_exp_cut_table() {
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  expcuttable = new double [(res+buf)*(kmax)];
-  dfctable = new double [res+buf];
+  expcuttable = new double[(res+buf)*(kmax)];
+  dfctable = new double[res+buf];
   for (m=0;m<(res+buf);m++) {
     r1 = cutmax*cutmax*(double)(m)/(double)(res);
     for (n=0;n<(kmax);n++) {
@@ -286,7 +286,7 @@ void Fingerprint_bondscreenedspin::generate_coefficients() {      //calculates m
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
-  delete [] M;
+  delete[] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bondspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondspin.cpp
@@ -283,6 +283,7 @@ void Fingerprint_bondspin::generate_coefficients() {      //calculates multinomi
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
+  delete [] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bondspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondspin.cpp
@@ -39,13 +39,13 @@ Fingerprint_bondspin::Fingerprint_bondspin(PairRANN *_pair) : Fingerprint(_pair)
   dr = 0;
   re = 0;
   rc = 0;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0] = -1;
   kmax = 0;
   mlength = 0;
   id = -1;
   style = "bondspin";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   _pair->allscreen = false;
   _pair->dospin = true;
@@ -53,23 +53,23 @@ Fingerprint_bondspin::Fingerprint_bondspin(PairRANN *_pair) : Fingerprint(_pair)
 }
 
 Fingerprint_bondspin::~Fingerprint_bondspin() {
-  delete [] alpha_k;
-  delete [] atomtypes;
-  delete [] expcuttable;
-  delete [] dfctable;
+  delete[] alpha_k;
+  delete[] atomtypes;
+  delete[] expcuttable;
+  delete[] dfctable;
   for (int i=0;i<(mlength*(mlength+1))>>1;i++) {
-    delete [] coeff[i];
-    delete [] coeffx[i];
-    delete [] coeffy[i];
-    delete [] coeffz[i];
-    delete [] Mf[i];
+    delete[] coeff[i];
+    delete[] coeffx[i];
+    delete[] coeffy[i];
+    delete[] coeffz[i];
+    delete[] Mf[i];
   }
-  delete [] coeff;
-  delete [] coeffx;
-  delete [] coeffy;
-  delete [] coeffz;
-  delete [] Mf;
-  delete [] rinvsqrttable;
+  delete[] coeff;
+  delete[] coeffx;
+  delete[] coeffy;
+  delete[] coeffz;
+  delete[] Mf;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_bondspin::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -82,8 +82,8 @@ bool Fingerprint_bondspin::parse_values(std::string constant,std::vector<std::st
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alphak")==0) {
-    delete [] alpha_k;
-    alpha_k = new double [nwords];
+    delete[] alpha_k;
+    alpha_k = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha_k[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -158,7 +158,7 @@ void Fingerprint_bondspin::init(int *i,int _id) {
   mlength = 0;
   kmax = 0;
   delete[] alpha_k;
-  alpha_k = new double [1];
+  alpha_k = new double[1];
   alpha_k[0]=-1;
   empty = false;
   id = _id;
@@ -182,8 +182,8 @@ void Fingerprint_bondspin::generate_exp_cut_table() {
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  expcuttable = new double [(res+buf)*(kmax)];
-  dfctable = new double [res+buf];
+  expcuttable = new double[(res+buf)*(kmax)];
+  dfctable = new double[res+buf];
   for (m=0;m<(res+buf);m++) {
     r1 = cutmax*cutmax*(double)(m)/(double)(res);
     for (n=0;n<(kmax);n++) {
@@ -284,7 +284,7 @@ void Fingerprint_bondspin::generate_coefficients() {      //calculates multinomi
       coeff[p1][p] = pair->factorial(p)/pair->factorial(coeffx[p1][p])/pair->factorial(coeffy[p1][p])/pair->factorial(coeffz[p1][p]);
     }
   }
-  delete [] M;
+  delete[] M;
 }
 
 

--- a/src/ML-RANN/rann_fingerprint_bondspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_bondspin.cpp
@@ -157,6 +157,7 @@ void Fingerprint_bondspin::init(int *i,int _id) {
   rc = 0;
   mlength = 0;
   kmax = 0;
+  delete[] alpha_k;
   alpha_k = new double [1];
   alpha_k[0]=-1;
   empty = false;

--- a/src/ML-RANN/rann_fingerprint_radial.cpp
+++ b/src/ML-RANN/rann_fingerprint_radial.cpp
@@ -41,13 +41,13 @@ Fingerprint_radial::Fingerprint_radial(PairRANN *_pair) : Fingerprint(_pair)
   dr = 0;
   re = 0;
   rc = 0;
-  alpha = new double [1];
+  alpha = new double[1];
   alpha[0] = -1;
   nmax = 0;
   omin = 0;
   id = -1;
   style = "radial";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   fullydefined = false;
   _pair->allscreen = false;
@@ -55,11 +55,11 @@ Fingerprint_radial::Fingerprint_radial(PairRANN *_pair) : Fingerprint(_pair)
 
 Fingerprint_radial::~Fingerprint_radial()
 {
-  delete [] atomtypes;
-  delete [] radialtable;
-  delete [] alpha;
-  delete [] dfctable;
-  delete [] rinvsqrttable;
+  delete[] atomtypes;
+  delete[] radialtable;
+  delete[] alpha;
+  delete[] dfctable;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_radial::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -72,8 +72,8 @@ bool Fingerprint_radial::parse_values(std::string constant,std::vector<std::stri
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alpha")==0) {
-    delete [] alpha;
-    alpha = new double [nwords];
+    delete[] alpha;
+    alpha = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -150,8 +150,8 @@ void Fingerprint_radial::allocate()
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  radialtable = new double [(res+buf)*get_length()];
-  dfctable = new double [res+buf];
+  radialtable = new double[(res+buf)*get_length()];
+  dfctable = new double[res+buf];
   for (k=0;k<(res+buf);k++) {
     r1 = cutmax*cutmax*(double)(k)/(double)(res);
     for (m=0;m<=(nmax-omin);m++) {

--- a/src/ML-RANN/rann_fingerprint_radialscreened.cpp
+++ b/src/ML-RANN/rann_fingerprint_radialscreened.cpp
@@ -41,13 +41,13 @@ Fingerprint_radialscreened::Fingerprint_radialscreened(PairRANN *_pair) : Finger
   dr = 0;
   re = 0;
   rc = 0;
-  alpha = new double [1];
+  alpha = new double[1];
   alpha[0] = -1;
   nmax = 0;
   omin = 0;
   id = -1;
   style = "radialscreened";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   fullydefined = false;
   _pair->doscreen = true;
@@ -56,11 +56,11 @@ Fingerprint_radialscreened::Fingerprint_radialscreened(PairRANN *_pair) : Finger
 
 Fingerprint_radialscreened::~Fingerprint_radialscreened()
 {
-  delete [] atomtypes;
-  delete [] radialtable;
-  delete [] alpha;
-  delete [] dfctable;
-  delete [] rinvsqrttable;
+  delete[] atomtypes;
+  delete[] radialtable;
+  delete[] alpha;
+  delete[] dfctable;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_radialscreened::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -73,8 +73,8 @@ bool Fingerprint_radialscreened::parse_values(std::string constant,std::vector<s
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alpha")==0) {
-    delete [] alpha;
-    alpha = new double [nwords];
+    delete[] alpha;
+    alpha = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -151,8 +151,8 @@ void Fingerprint_radialscreened::allocate()
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  radialtable = new double [(res+buf)*get_length()];
-  dfctable = new double [res+buf];
+  radialtable = new double[(res+buf)*get_length()];
+  dfctable = new double[res+buf];
   for (k=0;k<(res+buf);k++) {
     r1 = cutmax*cutmax*(double)(k)/(double)(res);
     for (m=0;m<=(nmax-omin);m++) {

--- a/src/ML-RANN/rann_fingerprint_radialscreenedspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_radialscreenedspin.cpp
@@ -40,13 +40,13 @@ Fingerprint_radialscreenedspin::Fingerprint_radialscreenedspin(PairRANN *_pair) 
   dr = 0;
   re = 0;
   rc = 0;
-  alpha = new double [1];
+  alpha = new double[1];
   alpha[0] = -1;
   nmax = 0;
   omin = 0;
   id = -1;
   style = "radialscreenedspin";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   fullydefined = false;
   _pair->doscreen = true;
@@ -57,11 +57,11 @@ Fingerprint_radialscreenedspin::Fingerprint_radialscreenedspin(PairRANN *_pair) 
 
 Fingerprint_radialscreenedspin::~Fingerprint_radialscreenedspin()
 {
-  delete [] atomtypes;
-  delete [] radialtable;
-  delete [] alpha;
-  delete [] dfctable;
-  delete [] rinvsqrttable;
+  delete[] atomtypes;
+  delete[] radialtable;
+  delete[] alpha;
+  delete[] dfctable;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_radialscreenedspin::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -74,8 +74,8 @@ bool Fingerprint_radialscreenedspin::parse_values(std::string constant,std::vect
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alpha")==0) {
-    delete [] alpha;
-    alpha = new double [nwords];
+    delete[] alpha;
+    alpha = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -152,8 +152,8 @@ void Fingerprint_radialscreenedspin::allocate()
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  radialtable = new double [(res+buf)*get_length()];
-  dfctable = new double [res+buf];
+  radialtable = new double[(res+buf)*get_length()];
+  dfctable = new double[res+buf];
   for (k=0;k<(res+buf);k++) {
     r1 = cutmax*cutmax*(double)(k)/(double)(res);
     for (m=0;m<=(nmax-omin);m++) {

--- a/src/ML-RANN/rann_fingerprint_radialspin.cpp
+++ b/src/ML-RANN/rann_fingerprint_radialspin.cpp
@@ -40,13 +40,13 @@ Fingerprint_radialspin::Fingerprint_radialspin(PairRANN *_pair) : Fingerprint(_p
   dr = 0;
   re = 0;
   rc = 0;
-  alpha = new double [1];
+  alpha = new double[1];
   alpha[0] = -1;
   nmax = 0;
   omin = 0;
   id = -1;
   style = "radialspin";
-  atomtypes = new int [n_body_type];
+  atomtypes = new int[n_body_type];
   empty = true;
   fullydefined = false;
   _pair->allscreen = false;
@@ -56,11 +56,11 @@ Fingerprint_radialspin::Fingerprint_radialspin(PairRANN *_pair) : Fingerprint(_p
 
 Fingerprint_radialspin::~Fingerprint_radialspin()
 {
-  delete [] atomtypes;
-  delete [] radialtable;
-  delete [] alpha;
-  delete [] dfctable;
-  delete [] rinvsqrttable;
+  delete[] atomtypes;
+  delete[] radialtable;
+  delete[] alpha;
+  delete[] dfctable;
+  delete[] rinvsqrttable;
 }
 
 bool Fingerprint_radialspin::parse_values(std::string constant,std::vector<std::string> line1) {
@@ -73,8 +73,8 @@ bool Fingerprint_radialspin::parse_values(std::string constant,std::vector<std::
     rc = strtod(line1[0].c_str(),NULL);
   }
   else if (constant.compare("alpha")==0) {
-    delete [] alpha;
-    alpha = new double [nwords];
+    delete[] alpha;
+    alpha = new double[nwords];
     for (l=0;l<nwords;l++) {
       alpha[l]=strtod(line1[l].c_str(),NULL);
     }
@@ -151,8 +151,8 @@ void Fingerprint_radialspin::allocate()
   int buf = 5;
   int res = pair->res;
   double cutmax = pair->cutmax;
-  radialtable = new double [(res+buf)*get_length()];
-  dfctable = new double [res+buf];
+  radialtable = new double[(res+buf)*get_length()];
+  dfctable = new double[res+buf];
   for (k=0;k<(res+buf);k++) {
     r1 = cutmax*cutmax*(double)(k)/(double)(res);
     for (m=0;m<=(nmax-omin);m++) {


### PR DESCRIPTION
**Summary**

Plugged memory leaks in rann package/

**Related Issue(s)**

resolves #2811

**Author(s)**

Christopher Barrett, barrett@me.msstate.edu

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.

**Implementation Notes**

Valgrind still reports a leak of 16 bytes from alpha_k initialized in rann_fingerprint_bondscreened.cpp line 42. I'm not sure why since it is deleted in line 55.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**


[valgrind.output.txt](https://github.com/lammps/lammps/files/6833678/valgrind.output.txt)
