### PR TITLE
Fixed bug in fix np[ht] with runstyle respa

### DIFF
--- a/src/BOCS/fix_bocs.cpp
+++ b/src/BOCS/fix_bocs.cpp
@@ -1100,7 +1100,12 @@ void FixBocs::initial_integrate_respa(int /*vflag*/, int ilevel, int /*iloop*/)
     nve_x();
     if (pstat_flag) remap();
   }
+}
 
+/* ---------------------------------------------------------------------- */
+
+void FixBocs::pre_force_respa(int /*vflag*/, int ilevel, int /*iloop*/)
+{
   // if barostat, redo KSpace coeffs at outermost level,
   // since volume has changed
 

--- a/src/BOCS/fix_bocs.h
+++ b/src/BOCS/fix_bocs.h
@@ -37,6 +37,7 @@ class FixBocs : public Fix {
   virtual void initial_integrate(int);
   virtual void final_integrate();
   void initial_integrate_respa(int, int, int);
+  void pre_force_respa(int, int, int);
   void final_integrate_respa(int, int);
   virtual void pre_exchange();
   double compute_scalar();

--- a/src/DRUDE/fix_tgnh_drude.cpp
+++ b/src/DRUDE/fix_tgnh_drude.cpp
@@ -589,6 +589,7 @@ int FixTGNHDrude::setmask()
   mask |= INITIAL_INTEGRATE;
   mask |= FINAL_INTEGRATE;
   mask |= INITIAL_INTEGRATE_RESPA;
+  mask |= PRE_FORCE_RESPA;
   mask |= FINAL_INTEGRATE_RESPA;
   if (pre_exchange_flag) mask |= PRE_EXCHANGE;
   return mask;
@@ -1023,7 +1024,12 @@ void FixTGNHDrude::initial_integrate_respa(int /*vflag*/, int ilevel, int /*iloo
     nve_x();
     if (pstat_flag) remap();
   }
+}
 
+/* ---------------------------------------------------------------------- */
+
+void FixTGNHDrude::pre_force_respa(int /*vflag*/, int ilevel, int /*iloop*/)
+{
   // if barostat, redo KSpace coeffs at outermost level,
   // since volume has changed
 

--- a/src/DRUDE/fix_tgnh_drude.h
+++ b/src/DRUDE/fix_tgnh_drude.h
@@ -28,6 +28,7 @@ class FixTGNHDrude : public Fix {
   virtual void setup(int);
   virtual void initial_integrate(int);
   virtual void final_integrate();
+  void pre_force_respa(int, int, int);
   void initial_integrate_respa(int, int, int);
   void final_integrate_respa(int, int);
   virtual void pre_exchange();

--- a/src/USER-MISC/fix_npt_cauchy.cpp
+++ b/src/USER-MISC/fix_npt_cauchy.cpp
@@ -671,6 +671,7 @@ int FixNPTCauchy::setmask()
   mask |= INITIAL_INTEGRATE;
   mask |= FINAL_INTEGRATE;
   mask |= INITIAL_INTEGRATE_RESPA;
+  mask |= PRE_FORCE_RESPA;
   mask |= FINAL_INTEGRATE_RESPA;
   if (pre_exchange_flag) mask |= PRE_EXCHANGE;
   return mask;
@@ -1032,7 +1033,12 @@ void FixNPTCauchy::initial_integrate_respa(int /*vflag*/, int ilevel, int /*iloo
     nve_x();
     if (pstat_flag) remap();
   }
+}
 
+/* ---------------------------------------------------------------------- */
+
+void FixNPTCauchy::pre_force_respa(int /*vflag*/, int ilevel, int /*iloop*/)
+{
   // if barostat, redo KSpace coeffs at outermost level,
   // since volume has changed
 

--- a/src/USER-MISC/fix_npt_cauchy.h
+++ b/src/USER-MISC/fix_npt_cauchy.h
@@ -35,6 +35,7 @@ class FixNPTCauchy : public Fix {
   virtual void initial_integrate(int);
   virtual void final_integrate();
   void initial_integrate_respa(int, int, int);
+  void pre_force_respa(int, int, int);
   void final_integrate_respa(int, int);
   virtual void pre_exchange();
   double compute_scalar();

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -635,6 +635,7 @@ int FixNH::setmask()
   mask |= FINAL_INTEGRATE;
   mask |= INITIAL_INTEGRATE_RESPA;
   mask |= FINAL_INTEGRATE_RESPA;
+  mask |= PRE_FORCE_RESPA;
   if (pre_exchange_flag) mask |= PRE_EXCHANGE;
   return mask;
 }
@@ -1006,7 +1007,12 @@ void FixNH::initial_integrate_respa(int /*vflag*/, int ilevel, int /*iloop*/)
     nve_x();
     if (pstat_flag) remap();
   }
+}
 
+/* ---------------------------------------------------------------------- */
+
+void FixNH::pre_force_respa(int /*vflag*/, int ilevel, int /*iloop*/)
+{
   // if barostat, redo KSpace coeffs at outermost level,
   // since volume has changed
 

--- a/src/fix_nh.h
+++ b/src/fix_nh.h
@@ -28,6 +28,7 @@ class FixNH : public Fix {
   virtual void initial_integrate(int);
   virtual void final_integrate();
   void initial_integrate_respa(int, int, int);
+  void pre_force_respa(int, int, int);
   void final_integrate_respa(int, int);
   virtual void pre_exchange();
   double compute_scalar();


### PR DESCRIPTION
**Summary**

Fixes a bug in r-RESPA integration involving volume changes and kspace calculations.

The bug shows up in the following situation:
* Pair stye involves kspace calculations
* MD simulation is isobaric via any `FixNH` child class with `pstat_flag=1`
* r-RESPA integration with at least 2 time scales

In this specific situation, update of kspace parameters is being done before volume changes actually occur.

At the outermost time scale, `initial_integrate_respa` is called from inside the `recurse` function in `respa.cpp`:

https://github.com/lammps/lammps/blob/95792ac9283347d9d5ebca875eb2203a4bac43dd/src/respa.cpp#L609

Then, after all due calculations, kspace parameters are updated:

https://github.com/lammps/lammps/blob/95792ac9283347d9d5ebca875eb2203a4bac43dd/src/fix_nh.cpp#L1013-L1014

Upon return to `recurse`, and before the slowest forces (including the kspace contribution) are computed, a recursive call is made:

https://github.com/lammps/lammps/blob/95792ac9283347d9d5ebca875eb2203a4bac43dd/src/respa.cpp#L669

Because volume will change at the innermost time scale, kspace parameters will be outdated when the slowest forces are actually evaluated.

**Related Issue(s)**

None.

**Author(s)**

Charlles Abreu, Federal University of Rio de Janeiro

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Not backward compatible.

**Implementation Notes**

The bug was solved by moving the lines below from `initial_integrate_respa` to a newly implemented `pre_force_respa` function.

https://github.com/lammps/lammps/blob/95792ac9283347d9d5ebca875eb2203a4bac43dd/src/fix_nh.cpp#L1013-L1014

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

None.
