### PR TITLE
Correct a couple of unit tests for package reorganization

### DIFF
--- a/unittest/force-styles/tests/atomic-pair-lj_relres.yaml
+++ b/unittest/force-styles/tests/atomic-pair-lj_relres.yaml
@@ -3,7 +3,7 @@ lammps_version: 10 Feb 2021
 date_generated: Sun Feb 28 23:32:03 2021
 epsilon: 5e-13
 prerequisites: ! |
-  pair born
+  pair lj/relres
 pre_commands: ! ""
 post_commands: ! ""
 input_file: in.metal

--- a/unittest/formats/test_dump_custom.cpp
+++ b/unittest/formats/test_dump_custom.cpp
@@ -143,6 +143,8 @@ TEST_F(DumpCustomTest, compute_run0)
 
 TEST_F(DumpCustomTest, fix_run0)
 {
+    if (!info->has_style("fix", "numdiff")) GTEST_SKIP();
+
     BEGIN_HIDE_OUTPUT();
     command("fix numdiff all numdiff 1 0.0001");
     END_HIDE_OUTPUT();


### PR DESCRIPTION
**Summary**

This pull request applies a couple of updates to the unittest tree so that tests are properly skipped when prerequisites are not present.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
