### PR TITLE
fixing indexing bug

### DIFF
--- a/src/EXTRA-COMPUTE/compute_gyration_shape.cpp
+++ b/src/EXTRA-COMPUTE/compute_gyration_shape.cpp
@@ -92,8 +92,8 @@ void ComputeGyrationShape::compute_vector()
   ione[1][1] = gyration_tensor[1];
   ione[2][2] = gyration_tensor[2];
   ione[0][1] = ione[1][0] = gyration_tensor[3];
-  ione[1][2] = ione[2][1] = gyration_tensor[4];
-  ione[0][2] = ione[2][0] = gyration_tensor[5];
+  ione[0][2] = ione[2][0] = gyration_tensor[4];
+  ione[1][2] = ione[2][1] = gyration_tensor[5];
 
   int ierror = MathEigen::jacobi3(ione,evalues,evectors);
   if (ierror) error->all(FLERR, "Insufficient Jacobi rotations "

--- a/src/OPT/Install.sh
+++ b/src/OPT/Install.sh
@@ -46,5 +46,5 @@ action pair_lj_long_coul_long_opt.cpp pair_lj_long_coul_long.cpp
 action pair_lj_long_coul_long_opt.h pair_lj_long_coul_long.cpp
 action pair_morse_opt.cpp
 action pair_morse_opt.h
-action pair_ufm_opt.cpp
-action pair_ufm_opt.h
+action pair_ufm_opt.cpp pair_ufm.cpp
+action pair_ufm_opt.h pair_ufm.h


### PR DESCRIPTION
The gyration_tensor[4] element  as computed by "compute gyration" corresponds to the xz component of the gyration tensor and the gyration_tensor[5] to the yz component. The  code  in "gyration/shape" assumed that gyration_tensor[4] corresponds to the yz component and the gyration_tensor[5] to the xz.

**Summary**

It is a bug fix due to access wrong elements of the gyration tensor as returned from the "compute gyration" command


**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


