### PR TITLE
Make ForceConst::set_ntypes() more robust and fix related bug in pair style sw/intel

### DIFF
--- a/src/INTEL/pair_buck_coul_cut_intel.cpp
+++ b/src/INTEL/pair_buck_coul_cut_intel.cpp
@@ -504,7 +504,8 @@ void PairBuckCoulCutIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                            const int ntable,
                                                            Memory *memory,
                                                            const int cop) {
-  if ((ntypes != _ntypes || ntable != _ntable)) {
+  if (memory != nullptr) _memory = memory;
+  if ((ntypes != _ntypes) || (ntable != _ntable)) {
     if (_ntypes > 0) {
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -526,13 +527,12 @@ void PairBuckCoulCutIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
       _memory->destroy(c_force);
       _memory->destroy(c_energy);
       _memory->destroy(c_cut);
-
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(c_force,ntypes,ntypes,"fc.c_force");
-      memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
-      memory->create(c_cut,ntypes,ntypes,"fc.c_cut");
+      _memory->create(c_force,ntypes,ntypes,"fc.c_force");
+      _memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
+      _memory->create(c_cut,ntypes,ntypes,"fc.c_cut");
 
 
       #ifdef _LMP_INTEL_OFFLOAD
@@ -558,5 +558,4 @@ void PairBuckCoulCutIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
   }
   _ntypes=ntypes;
   _ntable=ntable;
-  _memory=memory;
 }

--- a/src/INTEL/pair_buck_coul_long_intel.cpp
+++ b/src/INTEL/pair_buck_coul_long_intel.cpp
@@ -615,7 +615,8 @@ void PairBuckCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                            const int ntable,
                                                            Memory *memory,
                                                            const int cop) {
-  if ((ntypes != _ntypes || ntable != _ntable)) {
+  if (memory != nullptr) _memory = memory;
+  if ((ntypes != _ntypes) || (ntable != _ntable)) {
     if (_ntypes > 0) {
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -652,14 +653,14 @@ void PairBuckCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(c_force,ntypes,ntypes,"fc.c_force");
-      memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
-      memory->create(rho_inv,ntypes,ntypes,"fc.rho_inv");
-      memory->create(table,ntable,"pair:fc.table");
-      memory->create(etable,ntable,"pair:fc.etable");
-      memory->create(detable,ntable,"pair:fc.detable");
-      memory->create(ctable,ntable,"pair:fc.ctable");
-      memory->create(dctable,ntable,"pair:fc.dctable");
+      _memory->create(c_force,ntypes,ntypes,"fc.c_force");
+      _memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
+      _memory->create(rho_inv,ntypes,ntypes,"fc.rho_inv");
+      _memory->create(table,ntable,"pair:fc.table");
+      _memory->create(etable,ntable,"pair:fc.etable");
+      _memory->create(detable,ntable,"pair:fc.detable");
+      _memory->create(ctable,ntable,"pair:fc.ctable");
+      _memory->create(dctable,ntable,"pair:fc.dctable");
 
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -692,7 +693,6 @@ void PairBuckCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
   }
   _ntypes=ntypes;
   _ntable=ntable;
-  _memory=memory;
 }
 
 

--- a/src/INTEL/pair_buck_intel.cpp
+++ b/src/INTEL/pair_buck_intel.cpp
@@ -455,6 +455,7 @@ template <class flt_t>
 void PairBuckIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                   Memory *memory,
                                                   const int cop) {
+  if (memory != nullptr) _memory = memory;
   if ((ntypes != _ntypes )) {
     if (_ntypes > 0) {
       #ifdef _LMP_INTEL_OFFLOAD
@@ -477,9 +478,8 @@ void PairBuckIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(c_force,ntypes,ntypes,"fc.c_force");
-      memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
-
+      _memory->create(c_force,ntypes,ntypes,"fc.c_force");
+      _memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
 
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -499,7 +499,6 @@ void PairBuckIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
   }
   _ntypes=ntypes;
-  _memory=memory;
 }
 
 

--- a/src/INTEL/pair_dpd_intel.cpp
+++ b/src/INTEL/pair_dpd_intel.cpp
@@ -558,6 +558,7 @@ void PairDPDIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                  const int max_nbors,
                                                  Memory *memory,
                                                  const int cop) {
+  if (memory != nullptr) _memory = memory;
   if (ntypes != _ntypes) {
     if (_ntypes > 0) {
       _memory->destroy(param);
@@ -566,15 +567,14 @@ void PairDPDIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(param,ntypes,ntypes,"fc.param");
-      memory->create(rand_buffer_thread, nthreads, max_nbors,
+      _memory->create(param,ntypes,ntypes,"fc.param");
+      _memory->create(rand_buffer_thread, nthreads, max_nbors,
                      "fc.rand_buffer_thread");
-      memory->create(rngi,nthreads,"fc.param");
+      _memory->create(rngi,nthreads,"fc.param");
       for (int i = 0; i < nthreads; i++) rngi[i] = max_nbors;
     }
   }
   _ntypes = ntypes;
-  _memory = memory;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/INTEL/pair_eam_intel.cpp
+++ b/src/INTEL/pair_eam_intel.cpp
@@ -781,7 +781,8 @@ void PairEAMIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                  const int nr, const int nrho,
                                                  Memory *memory,
                                                  const int cop) {
-  if (ntypes != _ntypes || nr + 1 > _nr || nrho + 1 > _nrho) {
+  if (memory != nullptr) _memory = memory;
+  if ((ntypes != _ntypes) || (nr + 1 > _nr) || (nrho + 1 > _nrho)) {
     if (_ntypes > 0) {
       _memory->destroy(rhor_spline_f);
       _memory->destroy(rhor_spline_e);
@@ -794,18 +795,17 @@ void PairEAMIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
       _cop = cop;
       _nr = nr + 1;
       IP_PRE_edge_align(_nr, sizeof(flt_t));
-      memory->create(rhor_spline_f,ntypes*ntypes*_nr,"fc.rhor_spline_f");
-      memory->create(rhor_spline_e,ntypes*ntypes*_nr,"fc.rhor_spline_e");
-      memory->create(z2r_spline_t,ntypes*ntypes*_nr,"fc.z2r_spline_t");
+      _memory->create(rhor_spline_f,ntypes*ntypes*_nr,"fc.rhor_spline_f");
+      _memory->create(rhor_spline_e,ntypes*ntypes*_nr,"fc.rhor_spline_e");
+      _memory->create(z2r_spline_t,ntypes*ntypes*_nr,"fc.z2r_spline_t");
       _nrho = nrho + 1;
       IP_PRE_edge_align(_nrho, sizeof(flt_t));
-      memory->create(frho_spline_f,ntypes*_nrho,"fc.frho_spline_f");
-      memory->create(frho_spline_e,ntypes*_nrho,"fc.frho_spline_e");
-      memory->create(scale_f,ntypes,ntypes,"fc.scale_f");
+      _memory->create(frho_spline_f,ntypes*_nrho,"fc.frho_spline_f");
+      _memory->create(frho_spline_e,ntypes*_nrho,"fc.frho_spline_e");
+      _memory->create(scale_f,ntypes,ntypes,"fc.scale_f");
     }
   }
   _ntypes = ntypes;
-  _memory = memory;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/INTEL/pair_gayberne_intel.cpp
+++ b/src/INTEL/pair_gayberne_intel.cpp
@@ -990,6 +990,7 @@ void PairGayBerneIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                       const int nthreads,
                                                       Memory *memory,
                                                       const int cop) {
+  if (memory != nullptr) _memory = memory;
   if (ntypes != _ntypes) {
     if (_ntypes > 0) {
       fc_packed3 *oic = ic;
@@ -1029,15 +1030,15 @@ void PairGayBerneIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
 
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(ijc, ntypes, ntypes, "fc.ijc");
-      memory->create(lj34, ntypes, ntypes, "fc.lj34");
-      memory->create(ic, ntypes, "fc.ic");
-      memory->create(rsq_form, nthreads, one_length, "rsq_form");
-      memory->create(delx_form, nthreads, one_length, "delx_form");
-      memory->create(dely_form, nthreads, one_length, "dely_form");
-      memory->create(delz_form, nthreads, one_length, "delz_form");
-      memory->create(jtype_form, nthreads, one_length, "jtype_form");
-      memory->create(jlist_form, nthreads, one_length, "jlist_form");
+      _memory->create(ijc, ntypes, ntypes, "fc.ijc");
+      _memory->create(lj34, ntypes, ntypes, "fc.lj34");
+      _memory->create(ic, ntypes, "fc.ic");
+      _memory->create(rsq_form, nthreads, one_length, "rsq_form");
+      _memory->create(delx_form, nthreads, one_length, "delx_form");
+      _memory->create(dely_form, nthreads, one_length, "dely_form");
+      _memory->create(delz_form, nthreads, one_length, "delz_form");
+      _memory->create(jtype_form, nthreads, one_length, "jtype_form");
+      _memory->create(jlist_form, nthreads, one_length, "jlist_form");
 
       for (int zn = 0; zn < nthreads; zn++)
         for (int zo = 0; zo < one_length; zo++) {
@@ -1082,5 +1083,4 @@ void PairGayBerneIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
   }
   _ntypes = ntypes;
-  _memory = memory;
 }

--- a/src/INTEL/pair_lj_charmm_coul_charmm_intel.cpp
+++ b/src/INTEL/pair_lj_charmm_coul_charmm_intel.cpp
@@ -559,6 +559,7 @@ void PairLJCharmmCoulCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
 template <class flt_t>
 void PairLJCharmmCoulCharmmIntel::ForceConst<flt_t>::set_ntypes(
   const int ntypes, Memory *memory, const int cop) {
+  if (memory != nullptr) _memory = memory;
   if (ntypes != _ntypes) {
     if (_ntypes > 0) {
       #ifdef _LMP_INTEL_OFFLOAD
@@ -579,8 +580,8 @@ void PairLJCharmmCoulCharmmIntel::ForceConst<flt_t>::set_ntypes(
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(cutsq,ntypes,ntypes,"fc.cutsq");
-      memory->create(lj,ntypes,ntypes,"fc.lj");
+      _memory->create(cutsq,ntypes,ntypes,"fc.cutsq");
+      _memory->create(lj,ntypes,ntypes,"fc.lj");
 
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -599,5 +600,4 @@ void PairLJCharmmCoulCharmmIntel::ForceConst<flt_t>::set_ntypes(
     }
   }
   _ntypes=ntypes;
-  _memory=memory;
 }

--- a/src/INTEL/pair_lj_charmm_coul_long_intel.cpp
+++ b/src/INTEL/pair_lj_charmm_coul_long_intel.cpp
@@ -654,7 +654,8 @@ void PairLJCharmmCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                               const int ntable,
                                                               Memory *memory,
                                                               const int cop) {
-  if ((ntypes != _ntypes || ntable != _ntable)) {
+  if (memory != nullptr) _memory = memory;
+  if ((ntypes != _ntypes) || (ntable != _ntable)) {
     if (_ntypes > 0) {
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -688,13 +689,13 @@ void PairLJCharmmCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(cutsq,ntypes,ntypes,"fc.cutsq");
-      memory->create(lj,ntypes,ntypes,"fc.lj");
-      memory->create(table,ntable,"pair:fc.table");
-      memory->create(etable,ntable,"pair:fc.etable");
-      memory->create(detable,ntable,"pair:fc.detable");
-      memory->create(ctable,ntable,"pair:fc.ctable");
-      memory->create(dctable,ntable,"pair:fc.dctable");
+      _memory->create(cutsq,ntypes,ntypes,"fc.cutsq");
+      _memory->create(lj,ntypes,ntypes,"fc.lj");
+      _memory->create(table,ntable,"pair:fc.table");
+      _memory->create(etable,ntable,"pair:fc.etable");
+      _memory->create(detable,ntable,"pair:fc.detable");
+      _memory->create(ctable,ntable,"pair:fc.ctable");
+      _memory->create(dctable,ntable,"pair:fc.dctable");
 
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -724,5 +725,4 @@ void PairLJCharmmCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
   }
   _ntypes=ntypes;
   _ntable=ntable;
-  _memory=memory;
 }

--- a/src/INTEL/pair_lj_cut_coul_long_intel.cpp
+++ b/src/INTEL/pair_lj_cut_coul_long_intel.cpp
@@ -610,7 +610,8 @@ void PairLJCutCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                            const int ntable,
                                                            Memory *memory,
                                                            const int cop) {
-  if ((ntypes != _ntypes || ntable != _ntable)) {
+  if (memory != nullptr) _memory = memory;
+  if ((ntypes != _ntypes) || (ntable != _ntable)) {
     if (_ntypes > 0) {
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -644,13 +645,13 @@ void PairLJCutCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(c_force,ntypes,ntypes,"fc.c_force");
-      memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
-      memory->create(table,ntable,"pair:fc.table");
-      memory->create(etable,ntable,"pair:fc.etable");
-      memory->create(detable,ntable,"pair:fc.detable");
-      memory->create(ctable,ntable,"pair:fc.ctable");
-      memory->create(dctable,ntable,"pair:fc.dctable");
+      _memory->create(c_force,ntypes,ntypes,"fc.c_force");
+      _memory->create(c_energy,ntypes,ntypes,"fc.c_energy");
+      _memory->create(table,ntable,"pair:fc.table");
+      _memory->create(etable,ntable,"pair:fc.etable");
+      _memory->create(detable,ntable,"pair:fc.detable");
+      _memory->create(ctable,ntable,"pair:fc.ctable");
+      _memory->create(dctable,ntable,"pair:fc.dctable");
 
       #ifdef _LMP_INTEL_OFFLOAD
       flt_t * ospecial_lj = special_lj;
@@ -681,5 +682,4 @@ void PairLJCutCoulLongIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
   }
   _ntypes=ntypes;
   _ntable=ntable;
-  _memory=memory;
 }

--- a/src/INTEL/pair_lj_cut_intel.cpp
+++ b/src/INTEL/pair_lj_cut_intel.cpp
@@ -471,6 +471,7 @@ template <class flt_t>
 void PairLJCutIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                    Memory *memory,
                                                    const int cop) {
+  if (memory != nullptr) _memory = memory;
   if (ntypes != _ntypes) {
     if (_ntypes > 0) {
       _memory->destroy(ljc12o);
@@ -478,10 +479,9 @@ void PairLJCutIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(ljc12o,ntypes,ntypes,"fc.c12o");
-      memory->create(lj34,ntypes,ntypes,"fc.lj34");
+      _memory->create(ljc12o,ntypes,ntypes,"fc.c12o");
+      _memory->create(lj34,ntypes,ntypes,"fc.lj34");
     }
   }
   _ntypes = ntypes;
-  _memory = memory;
 }

--- a/src/INTEL/pair_sw_intel.cpp
+++ b/src/INTEL/pair_sw_intel.cpp
@@ -1277,6 +1277,7 @@ template <class flt_t>
 void PairSWIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                 Memory *memory,
                                                 const int cop) {
+  if (memory != nullptr) _memory = memory;
   if (ntypes != _ntypes) {
     if (_ntypes > 0) {
       fc_packed0 *op2 = p2[0];
@@ -1293,19 +1294,19 @@ void PairSWIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
       }
       #endif
 
-      memory->destroy(p2);
-      memory->destroy(p2f);
-      memory->destroy(p2f2);
-      memory->destroy(p2e);
-      memory->destroy(p3);
+      _memory->destroy(p2);
+      _memory->destroy(p2f);
+      _memory->destroy(p2f2);
+      _memory->destroy(p2e);
+      _memory->destroy(p3);
     }
     if (ntypes > 0) {
       _cop = cop;
-      memory->create(p2,ntypes,ntypes,"fc.p2");
-      memory->create(p2f,ntypes,ntypes,"fc.p2f");
-      memory->create(p2f2,ntypes,ntypes,"fc.p2f2");
-      memory->create(p2e,ntypes,ntypes,"fc.p2e");
-      memory->create(p3,ntypes,ntypes,ntypes,"fc.p3");
+      _memory->create(p2,ntypes,ntypes,"fc.p2");
+      _memory->create(p2f,ntypes,ntypes,"fc.p2f");
+      _memory->create(p2f2,ntypes,ntypes,"fc.p2f2");
+      _memory->create(p2e,ntypes,ntypes,"fc.p2e");
+      _memory->create(p3,ntypes,ntypes,ntypes,"fc.p3");
 
       #ifdef _LMP_INTEL_OFFLOAD
       fc_packed0 *op2 = p2[0];
@@ -1325,5 +1326,4 @@ void PairSWIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
   }
   _ntypes = ntypes;
-  _memory = memory;
 }

--- a/src/INTEL/pair_tersoff_intel.cpp
+++ b/src/INTEL/pair_tersoff_intel.cpp
@@ -550,6 +550,7 @@ template <class flt_t>
 void PairTersoffIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
                                                            Memory *memory,
                                                            const int cop) {
+  if (memory != nullptr) _memory = memory;
   if ((ntypes != _ntypes)) {
     if (_ntypes > 0) {
       #ifdef _LMP_INTEL_OFFLOAD
@@ -581,13 +582,13 @@ void PairTersoffIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
       _cop = cop;
       size_t VL = 512 / 8 / sizeof(flt_t);
       int ntypes_pad = ntypes + VL - ntypes % VL;
-      memory->create(c_first_loop,ntypes,ntypes,"fc.c_first_loop");
-      memory->create(c_second_loop,ntypes,ntypes,"fc.c_second_loop");
-      memory->create(c_cutoff_outer,ntypes,ntypes,"fc.c_cutoff_outer");
-      memory->create(c_inner_loop,ntypes,ntypes,ntypes,"fc.c_inner_loop");
-      memory->create(c_cutoff_inner,ntypes,ntypes,ntypes_pad,"fc.c_cutoff_inner");
-      memory->create(c_inner,ntypes,ntypes,ntypes,"fc.c_inner");
-      memory->create(c_outer,ntypes,ntypes,"fc.c_outer");
+      _memory->create(c_first_loop,ntypes,ntypes,"fc.c_first_loop");
+      _memory->create(c_second_loop,ntypes,ntypes,"fc.c_second_loop");
+      _memory->create(c_cutoff_outer,ntypes,ntypes,"fc.c_cutoff_outer");
+      _memory->create(c_inner_loop,ntypes,ntypes,ntypes,"fc.c_inner_loop");
+      _memory->create(c_cutoff_inner,ntypes,ntypes,ntypes_pad,"fc.c_cutoff_inner");
+      _memory->create(c_inner,ntypes,ntypes,ntypes,"fc.c_inner");
+      _memory->create(c_outer,ntypes,ntypes,"fc.c_outer");
       #ifdef _LMP_INTEL_OFFLOAD
       c_first_loop_t * oc_first_loop = c_first_loop[0];
       c_second_loop_t * oc_second_loop = c_second_loop[0];
@@ -614,7 +615,6 @@ void PairTersoffIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
     }
   }
   _ntypes=ntypes;
-  _memory=memory;
 }
 
 #ifdef _LMP_INTEL_OFFLOAD


### PR DESCRIPTION
**Summary**

This fixes a bug in pair style sw/intel which triggers a segfault when deleting the pair style instance.
Also refactor the `ForceConst::set_ntypes()` function to be consistent and more robust when passing a null pointer as memory class instance.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
