### PR TITLE
Fix issue when building Kokkos with CMake

### DIFF
--- a/cmake/Modules/Packages/KOKKOS.cmake
+++ b/cmake/Modules/Packages/KOKKOS.cmake
@@ -74,7 +74,7 @@ else()
   target_link_libraries(lammps PRIVATE kokkos)
   target_link_libraries(lmp PRIVATE kokkos)
 endif()
-target_compile_definitions(lammps PRIVATE -DLMP_KOKKOS)
+target_compile_definitions(lammps PUBLIC -DLMP_KOKKOS)
 
 set(KOKKOS_PKG_SOURCES_DIR ${LAMMPS_SOURCE_DIR}/KOKKOS)
 set(KOKKOS_PKG_SOURCES ${KOKKOS_PKG_SOURCES_DIR}/kokkos.cpp
@@ -127,4 +127,4 @@ endif()
 get_property(KOKKOS_PKG_SOURCES GLOBAL PROPERTY KOKKOS_PKG_SOURCES)
 
 target_sources(lammps PRIVATE ${KOKKOS_PKG_SOURCES})
-target_include_directories(lammps PRIVATE ${KOKKOS_PKG_SOURCES_DIR})
+target_include_directories(lammps PUBLIC ${KOKKOS_PKG_SOURCES_DIR})

--- a/cmake/Modules/Packages/KOKKOS.cmake
+++ b/cmake/Modules/Packages/KOKKOS.cmake
@@ -127,4 +127,4 @@ endif()
 get_property(KOKKOS_PKG_SOURCES GLOBAL PROPERTY KOKKOS_PKG_SOURCES)
 
 target_sources(lammps PRIVATE ${KOKKOS_PKG_SOURCES})
-target_include_directories(lammps PUBLIC ${KOKKOS_PKG_SOURCES_DIR})
+target_include_directories(lammps PUBLIC $<BUILD_INTERFACE:${KOKKOS_PKG_SOURCES_DIR}>)

--- a/cmake/Modules/Packages/KOKKOS.cmake
+++ b/cmake/Modules/Packages/KOKKOS.cmake
@@ -74,7 +74,7 @@ else()
   target_link_libraries(lammps PRIVATE kokkos)
   target_link_libraries(lmp PRIVATE kokkos)
 endif()
-target_compile_definitions(lammps PUBLIC -DLMP_KOKKOS)
+target_compile_definitions(lammps PUBLIC $<BUILD_INTERFACE:LMP_KOKKOS>)
 
 set(KOKKOS_PKG_SOURCES_DIR ${LAMMPS_SOURCE_DIR}/KOKKOS)
 set(KOKKOS_PKG_SOURCES ${KOKKOS_PKG_SOURCES_DIR}/kokkos.cpp


### PR DESCRIPTION
**Summary**

CMake wasn't exporting the `LMP_KOKKOS` define or `/src/KOKKOS` headers to `main.cpp`, so the "dummy" version of Kokkos in `accelerator_kokkos.h` was always being instantiated in `main.cpp`. Therefore, the real `Kokkos::finalize` was never called here: https://github.com/lammps/lammps/blob/master/src/main.cpp#L106, leading to an error from Kokkos and other issues with Kokkos tools.

@junghans @anjohan

**Related Issue(s)**

None

**Author(s)**

Christoph Junghans (LANL), Stan Moore (SNL), reported by Anders Johansson (Harvard)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes