### PR TITLE
Add Kokkos accelerated styles for shear flow simulations (SLLOD)

### DIFF
--- a/doc/src/Commands_compute.rst
+++ b/doc/src/Commands_compute.rst
@@ -152,7 +152,7 @@ KOKKOS, o = OPENMP, t = OPT.
    * :doc:`temp/chunk <compute_temp_chunk>`
    * :doc:`temp/com <compute_temp_com>`
    * :doc:`temp/cs <compute_temp_cs>`
-   * :doc:`temp/deform <compute_temp_deform>`
+   * :doc:`temp/deform (k) <compute_temp_deform>`
    * :doc:`temp/deform/eff <compute_temp_deform_eff>`
    * :doc:`temp/drude <compute_temp_drude>`
    * :doc:`temp/eff <compute_temp_eff>`

--- a/doc/src/Commands_fix.rst
+++ b/doc/src/Commands_fix.rst
@@ -148,7 +148,7 @@ OPT.
    * :doc:`nvt/body <fix_nvt_body>`
    * :doc:`nvt/eff <fix_nh_eff>`
    * :doc:`nvt/manifold/rattle <fix_nvt_manifold_rattle>`
-   * :doc:`nvt/sllod (io) <fix_nvt_sllod>`
+   * :doc:`nvt/sllod (iko) <fix_nvt_sllod>`
    * :doc:`nvt/sllod/eff <fix_nvt_sllod_eff>`
    * :doc:`nvt/sphere (o) <fix_nvt_sphere>`
    * :doc:`nvt/uef <fix_nh_uef>`

--- a/doc/src/compute_temp_deform.rst
+++ b/doc/src/compute_temp_deform.rst
@@ -1,7 +1,10 @@
 .. index:: compute temp/deform
+.. index:: compute temp/deform/kk
 
 compute temp/deform command
 ===========================
+
+Accelerator Variants: *temp/deform/kk*
 
 Syntax
 """"""

--- a/doc/src/fix_nvt_sllod.rst
+++ b/doc/src/fix_nvt_sllod.rst
@@ -1,11 +1,12 @@
 .. index:: fix nvt/sllod
 .. index:: fix nvt/sllod/intel
 .. index:: fix nvt/sllod/omp
+.. index:: fix nvt/sllod/kk
 
 fix nvt/sllod command
 =====================
 
-Accelerator Variants: *nvt/sllod/intel*, *nvt/sllod/omp*
+Accelerator Variants: *nvt/sllod/intel*, *nvt/sllod/omp*, *nvt/sllod/kk*
 
 Syntax
 """"""

--- a/src/KOKKOS/compute_temp_deform_kokkos.cpp
+++ b/src/KOKKOS/compute_temp_deform_kokkos.cpp
@@ -80,6 +80,8 @@ double ComputeTempDeformKokkos<DeviceType>::compute_scalar()
   /**************** EVK ****************/
   // Convert from box coords to lamda coords
   domainKK->x2lamda(nlocal);
+  h_rate = domainKK->h_rate;
+  h_ratelo = domainKK->h_ratelo;
   
   copymode = 1;
   if (atomKK->rmass)
@@ -108,8 +110,6 @@ template<int RMASS>
 KOKKOS_INLINE_FUNCTION
 void ComputeTempDeformKokkos<DeviceType>::operator()(TagComputeTempDeformScalar<RMASS>, const int &i, CTEMP& t_kk) const {
 
-  double *h_rate = domainKK->h_rate;
-  double *h_ratelo = domainKK->h_ratelo;
   double vstream[3],vthermal[3];
 
   vstream[0] = h_rate[0]*x(i,0) + h_rate[5]*x(i,1) + h_rate[4]*x(i,2) + h_ratelo[0];
@@ -154,6 +154,8 @@ void ComputeTempDeformKokkos<DeviceType>::compute_vector()
   /**************** EVK ****************/
   // Convert from box coords to lamda coords
   domainKK->x2lamda(nlocal);
+  h_rate = domainKK->h_rate;
+  h_ratelo = domainKK->h_ratelo;
 
   copymode = 1;
   if (atomKK->rmass)
@@ -182,8 +184,6 @@ template<int RMASS>
 KOKKOS_INLINE_FUNCTION
 void ComputeTempDeformKokkos<DeviceType>::operator()(TagComputeTempDeformVector<RMASS>, const int &i, CTEMP& t_kk) const {
 
-  double *h_rate = domainKK->h_rate;
-  double *h_ratelo = domainKK->h_ratelo;
   double vstream[3],vthermal[3];
 
   vstream[0] = h_rate[0]*x(i,0) + h_rate[5]*x(i,1) + h_rate[4]*x(i,2) + h_ratelo[0];

--- a/src/KOKKOS/compute_temp_deform_kokkos.cpp
+++ b/src/KOKKOS/compute_temp_deform_kokkos.cpp
@@ -1,0 +1,285 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Emily Kahl (UQ)
+------------------------------------------------------------------------- */
+
+#include "compute_temp_deform_kokkos.h"
+
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "update.h"
+#include "memory_kokkos.h"
+
+#include <cstring>
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+ComputeTempDeformKokkos<DeviceType>::ComputeTempDeformKokkos(LAMMPS *lmp, int narg, char **arg) :
+  ComputeTempDeform(lmp, narg, arg)
+{
+  kokkosable = 1;
+  atomKK = (AtomKokkos *) atom;
+  domainKK = (DomainKokkos *) domain;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+
+  datamask_read = V_MASK | MASK_MASK | RMASS_MASK | TYPE_MASK;
+  datamask_modify = EMPTY_MASK;
+
+  maxbias = 0;
+}
+
+template<class DeviceType>
+ComputeTempDeformKokkos<DeviceType>::~ComputeTempDeformKokkos() 
+{
+
+
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+double ComputeTempDeformKokkos<DeviceType>::compute_scalar()
+{
+  atomKK->sync(execution_space,datamask_read);
+  atomKK->k_mass.sync<DeviceType>();
+
+  invoked_scalar = update->ntimestep;
+
+  v = atomKK->k_v.view<DeviceType>();
+  x = atomKK->k_x.view<DeviceType>();
+  if (atomKK->rmass)
+    rmass = atomKK->k_rmass.view<DeviceType>();
+  else
+    mass = atomKK->k_mass.view<DeviceType>();
+  type = atomKK->k_type.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  int nlocal = atom->nlocal;
+
+  double t = 0.0;
+  CTEMP t_kk;
+
+  /**************** EVK ****************/
+  // Convert from box coords to lamda coords
+  domainKK->x2lamda(nlocal);
+  
+  copymode = 1;
+  if (atomKK->rmass)
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagComputeTempDeformScalar<1> >(0,nlocal),*this,t_kk);
+  else
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagComputeTempDeformScalar<0> >(0,nlocal),*this,t_kk);
+  copymode = 0;
+
+  /**************** EVK ****************/
+  // Convert back to box coords
+  domainKK->lamda2x(nlocal);
+
+  t = t_kk.t0; // could make this more efficient
+
+  MPI_Allreduce(&t,&scalar,1,MPI_DOUBLE,MPI_SUM,world);
+  if (dynamic) dof_compute();
+  if (dof < 0.0 && natoms_temp > 0.0)
+    error->all(FLERR,"Temperature compute degrees of freedom < 0");
+  scalar *= tfactor;
+
+  return scalar;
+}
+
+template<class DeviceType>
+template<int RMASS>
+KOKKOS_INLINE_FUNCTION
+void ComputeTempDeformKokkos<DeviceType>::operator()(TagComputeTempDeformScalar<RMASS>, const int &i, CTEMP& t_kk) const {
+
+  double *h_rate = domainKK->h_rate;
+  double *h_ratelo = domainKK->h_ratelo;
+  double vstream[3],vthermal[3];
+
+  vstream[0] = h_rate[0]*x(i,0) + h_rate[5]*x(i,1) + h_rate[4]*x(i,2) + h_ratelo[0];
+  vstream[1] = h_rate[1]*x(i,1) + h_rate[3]*x(i,2) + h_ratelo[1];
+  vstream[2] = h_rate[2]*x(i,2) + h_ratelo[2];
+  vthermal[0] = v(i,0) - vstream[0];
+  vthermal[1] = v(i,1) - vstream[1];
+  vthermal[2] = v(i,2) - vstream[2];
+  if (RMASS) {
+    if (mask[i] & groupbit)
+      t_kk.t0 += (vthermal[0]*vthermal[0] + vthermal[1]*vthermal[1] + vthermal[2]*vthermal[2]) * rmass[i];
+  } else {
+    if (mask[i] & groupbit)
+      t_kk.t0 += (vthermal[0]*vthermal[0] + vthermal[1]*vthermal[1] + vthermal[2]*vthermal[2]) * mass[type[i]];
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+template<class DeviceType>
+void ComputeTempDeformKokkos<DeviceType>::compute_vector()
+{
+  atomKK->sync(execution_space,datamask_read);
+
+  int i;
+
+  invoked_vector = update->ntimestep;
+
+  v = atomKK->k_v.view<DeviceType>();
+  x = atomKK->k_x.view<DeviceType>();
+  if (atomKK->rmass)
+    rmass = atomKK->k_rmass.view<DeviceType>();
+  else
+    mass = atomKK->k_mass.view<DeviceType>();
+  type = atomKK->k_type.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  int nlocal = atom->nlocal;
+
+  double t[6];
+  for (i = 0; i < 6; i++) t[i] = 0.0;
+  CTEMP t_kk;
+
+  /**************** EVK ****************/
+  // Convert from box coords to lamda coords
+  domainKK->x2lamda(nlocal);
+
+  copymode = 1;
+  if (atomKK->rmass)
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagComputeTempDeformVector<1> >(0,nlocal),*this,t_kk);
+  else
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagComputeTempDeformVector<0> >(0,nlocal),*this,t_kk);
+  copymode = 0;
+
+  /**************** EVK ****************/
+  // Convert back to box coords
+  domainKK->lamda2x(nlocal);
+
+  t[0] = t_kk.t0;
+  t[1] = t_kk.t1;
+  t[2] = t_kk.t2;
+  t[3] = t_kk.t3;
+  t[4] = t_kk.t4;
+  t[5] = t_kk.t5;
+
+  MPI_Allreduce(t,vector,6,MPI_DOUBLE,MPI_SUM,world);
+  for (i = 0; i < 6; i++) vector[i] *= force->mvv2e;
+}
+
+template<class DeviceType>
+template<int RMASS>
+KOKKOS_INLINE_FUNCTION
+void ComputeTempDeformKokkos<DeviceType>::operator()(TagComputeTempDeformVector<RMASS>, const int &i, CTEMP& t_kk) const {
+
+  double *h_rate = domainKK->h_rate;
+  double *h_ratelo = domainKK->h_ratelo;
+  double vstream[3],vthermal[3];
+
+  vstream[0] = h_rate[0]*x(i,0) + h_rate[5]*x(i,1) + h_rate[4]*x(i,2) + h_ratelo[0];
+  vstream[1] = h_rate[1]*x(i,1) + h_rate[3]*x(i,2) + h_ratelo[1];
+  vstream[2] = h_rate[2]*x(i,2) + h_ratelo[2];
+  vthermal[0] = v(i,0) - vstream[0];
+  vthermal[1] = v(i,1) - vstream[1];
+  vthermal[2] = v(i,2) - vstream[2];
+
+  if (mask[i] & groupbit) {
+    F_FLOAT massone = 0.0;
+    if (RMASS) massone = rmass[i];
+    else massone = mass[type[i]];
+    t_kk.t0 += massone * vthermal[0]*vthermal[0];
+    t_kk.t1 += massone * vthermal[1]*vthermal[1];
+    t_kk.t2 += massone * vthermal[2]*vthermal[2];
+    t_kk.t3 += massone * vthermal[0]*vthermal[1];
+    t_kk.t4 += massone * vthermal[0]*vthermal[2];
+    t_kk.t5 += massone * vthermal[1]*vthermal[2];
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+template<class DeviceType>
+void ComputeTempDeformKokkos<DeviceType>::remove_bias_all()
+{
+  atomKK->sync(execution_space,datamask_read);
+  v = atomKK->k_v.view<DeviceType>();
+  x = atomKK->k_x.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  int nlocal = atom->nlocal;
+
+  if (atom->nmax > maxbias) {
+    //memoryKK->destroy_kokkos(vbiasall);
+    maxbias = atom->nmax;
+    //memoryKK->create_kokkos(vbiasall,maxbias,"temp/deform/kk:vbiasall");
+    vbiasall = typename ArrayTypes<DeviceType>::t_v_array("temp/deform/kk:vbiasall", maxbias);
+  }
+
+  /**************** EVK ****************/
+  // Convert from box coords to lamda coords
+  domainKK->x2lamda(nlocal);
+
+  h_rate = domain->h_rate;
+  h_ratelo = domain->h_ratelo;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeTempDeformRemoveBias >(0,nlocal),*this);
+  copymode = 0;
+
+  /**************** EVK ****************/
+  // Convert back to box coords
+  domainKK->lamda2x(nlocal);
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void ComputeTempDeformKokkos<DeviceType>::operator()(TagComputeTempDeformRemoveBias, const int &i) const {
+  if (mask[i] & groupbit) {
+    vbiasall(i,0) = h_rate[0]*x(i,0) + h_rate[5]*x(i,1) + h_rate[4]*x(i,2) + h_ratelo[0];
+    vbiasall(i,1) = h_rate[1]*x(i,1) + h_rate[3]*x(i,2) + h_ratelo[1];
+    vbiasall(i,2) = h_rate[2]*x(i,2) + h_ratelo[2];
+    v(i,0) -= vbiasall(i,0);
+    v(i,1) -= vbiasall(i,1);
+    v(i,2) -= vbiasall(i,2);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+template<class DeviceType>
+void ComputeTempDeformKokkos<DeviceType>::restore_bias_all()
+{
+  atomKK->sync(execution_space,datamask_read);
+  v = atomKK->k_v.view<DeviceType>();
+  x = atomKK->k_x.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  int nlocal = atom->nlocal;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeTempDeformRestoreBias >(0,nlocal),*this);
+  copymode = 0;
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void ComputeTempDeformKokkos<DeviceType>::operator()(TagComputeTempDeformRestoreBias, const int &i) const {
+  if (mask[i] & groupbit) {
+    v(i,0) += vbiasall(i,0);
+    v(i,1) += vbiasall(i,1);
+    v(i,2) += vbiasall(i,2);
+  }
+}
+
+namespace LAMMPS_NS {
+template class ComputeTempDeformKokkos<LMPDeviceType>;
+#ifdef LMP_KOKKOS_GPU
+template class ComputeTempDeformKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/compute_temp_deform_kokkos.cpp
+++ b/src/KOKKOS/compute_temp_deform_kokkos.cpp
@@ -13,7 +13,7 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Contributing authors: Emily Kahl (UQ)
+   Contributing authors: Emily Kahl (Uni. of QLD, e.kahl@uq.edu.au)
 ------------------------------------------------------------------------- */
 
 #include "compute_temp_deform_kokkos.h"
@@ -25,6 +25,7 @@
 #include "force.h"
 #include "update.h"
 #include "memory_kokkos.h"
+#include "domain_kokkos.h"
 
 #include <cstring>
 

--- a/src/KOKKOS/compute_temp_deform_kokkos.h
+++ b/src/KOKKOS/compute_temp_deform_kokkos.h
@@ -25,7 +25,6 @@ ComputeStyle(temp/deform/kk/host,ComputeTempDeformKokkos<LMPHostType>);
 
 #include "compute_temp_deform.h"
 #include "kokkos_type.h"
-#include "domain_kokkos.h"
 #include "kokkos_few.h"
 
 namespace LAMMPS_NS {

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
@@ -1,0 +1,171 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/
+   Steve Plimpton, sjplimp@sandia.gov, Sandia National Laboratories
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Emily Kahl (UQ, e.kahl@uq.edu.au)
+------------------------------------------------------------------------- */
+
+#include "fix_nvt_sllod_kokkos.h"
+
+#include "atom.h"
+#include "compute.h"
+#include "domain.h"
+#include "error.h"
+#include "fix.h"
+#include "fix_deform_kokkos.h"
+#include "group.h"
+#include "math_extra.h"
+#include "modify.h"
+#include "atom_kokkos.h"
+#include "atom.h"
+#include "atom_masks.h"
+#include "kokkos_few.h"
+#include "memory_kokkos.h"
+
+#include <cstring>
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+FixNVTSllodKokkos<DeviceType>::FixNVTSllodKokkos(LAMMPS *lmp, int narg, char **arg) :
+  FixNHKokkos<DeviceType>(lmp, narg, arg)
+{
+  /************************ EVK *********************/
+  atomKK = (AtomKokkos *) this->atom;
+  this->kokkosable = 1;
+  this->domainKK = (DomainKokkos *) this->domain;
+
+  if (!this->tstat_flag)
+    this->error->all(FLERR,"Temperature control must be used with fix nvt/kk");
+  if (this->pstat_flag)
+    this->error->all(FLERR,"Pressure control can not be used with fix nvt/kk");
+
+  if (this->mtchain_default_flag) this->mtchain = 1;
+    
+  this->id_temp = utils::strdup(std::string(this->id)+"_temp");
+  this->modify->add_compute(fmt::format("{} all temp/deform/kk",this->id_temp));
+  this->tcomputeflag = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+FixNVTSllodKokkos<DeviceType>::~FixNVTSllodKokkos()
+{
+
+
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixNVTSllodKokkos<DeviceType>::init()
+{
+  FixNHKokkos<DeviceType>::init();
+
+  vdelu = typename ArrayTypes<DeviceType>::t_v_array("nvt/sllod/kk:vdelu", atomKK->nlocal);
+  
+  if (!this->temperature->tempbias)
+    this->error->all(FLERR,"Temperature for fix nvt/sllod does not have a bias");
+
+  nondeformbias = 0;
+  if (strncmp(this->temperature->style,"temp/deform", 11) != 0) nondeformbias = 1;
+
+  // check fix deform remap settings
+
+  int i;
+  for (i = 0; i < this->modify->nfix; i++)
+    if (strncmp(this->modify->fix[i]->style,"deform",6) == 0) {
+      if (((FixDeform *) this->modify->fix[i])->remapflag != Domain::V_REMAP)
+        this->error->all(FLERR,"Using fix nvt/sllod with inconsistent fix deform "
+                   "remap option");
+      break;
+    }
+  if (i == this->modify->nfix)
+    this->error->all(FLERR,"Using fix nvt/sllod with no fix deform defined");
+}
+
+/* ----------------------------------------------------------------------
+   perform half-step scaling of velocities
+-----------------------------------------------------------------------*/
+
+template<class DeviceType>
+void FixNVTSllodKokkos<DeviceType>::nh_v_temp()
+{
+  // remove and restore bias = streaming velocity = Hrate*lamda + Hratelo
+  // thermostat thermal velocity only
+  // vdelu = SLLOD correction = Hrate*Hinv*vthermal
+  // for non temp/deform BIAS:
+  //   calculate temperature since some computes require temp
+  //   computed on current nlocal atoms to remove bias
+  
+  if (nondeformbias){ 
+    atomKK->sync(this->temperature->execution_space,this->temperature->datamask_read);
+    this->temperature->compute_scalar();
+    atomKK->modified(this->temperature->execution_space,this->temperature->datamask_modify);
+  }
+  v = atomKK->k_v.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  int nlocal = atomKK->nlocal;
+  if (this->igroup == atomKK->firstgroup) nlocal = atomKK->nfirst;
+
+  double h_two[6];
+  MathExtra::multiply_shape_shape(this->domain->h_rate,this->domain->h_inv,h_two);
+
+  d_h_two = Few<double, 6>(h_two);
+
+  this->copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixNVTSllod_temp1>(0,nlocal),*this);
+  this->copymode = 0;
+
+  this->temperature->remove_bias_all();
+  
+  this->copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixNVTSllod_temp2>(0,nlocal),*this);
+  this->copymode = 0;
+
+  this->temperature->restore_bias_all();
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void FixNVTSllodKokkos<DeviceType>::operator()(TagFixNVTSllod_temp1, const int &i) const {
+  if (mask[i] & this->groupbit) {
+    vdelu(i,0) = d_h_two[0]*v(i,0) + d_h_two[5]*v(i,1) + d_h_two[4]*v(i,2);
+    vdelu(i,1) = d_h_two[1]*v(i,1) + d_h_two[3]*v(i,2);
+    vdelu(i,2) = d_h_two[2]*v(i,2);
+  }
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void FixNVTSllodKokkos<DeviceType>::operator()(TagFixNVTSllod_temp2, const int &i) const {
+  if (mask[i] & this->groupbit) {
+    v(i,0) = v(i,0)*this->factor_eta - this->dthalf*vdelu(i,0);
+    v(i,1) = v(i,1)*this->factor_eta - this->dthalf*vdelu(i,1);
+    v(i,2) = v(i,2)*this->factor_eta - this->dthalf*vdelu(i,2);
+  }
+}
+
+namespace LAMMPS_NS {
+template class FixNVTSllodKokkos<LMPDeviceType>;
+#ifdef LMP_KOKKOS_GPU
+template class FixNVTSllodKokkos<LMPHostType>;
+#endif
+}
+
+

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
@@ -13,7 +13,7 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Contributing authors: Emily Kahl (UQ, e.kahl@uq.edu.au)
+   Contributing authors: Emily Kahl (Uni. of QLD, e.kahl@uq.edu.au)
 ------------------------------------------------------------------------- */
 
 #include "fix_nvt_sllod_kokkos.h"

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
@@ -44,7 +44,6 @@ template<class DeviceType>
 FixNVTSllodKokkos<DeviceType>::FixNVTSllodKokkos(LAMMPS *lmp, int narg, char **arg) :
   FixNHKokkos<DeviceType>(lmp, narg, arg)
 {
-  /************************ EVK *********************/
   atomKK = (AtomKokkos *) this->atom;
   this->kokkosable = 1;
   this->domainKK = (DomainKokkos *) this->domain;
@@ -55,7 +54,7 @@ FixNVTSllodKokkos<DeviceType>::FixNVTSllodKokkos(LAMMPS *lmp, int narg, char **a
     this->error->all(FLERR,"Pressure control can not be used with fix nvt/kk");
 
   if (this->mtchain_default_flag) this->mtchain = 1;
-    
+
   this->id_temp = utils::strdup(std::string(this->id)+"_temp");
   this->modify->add_compute(fmt::format("{} all temp/deform/kk",this->id_temp));
   this->tcomputeflag = 1;
@@ -78,7 +77,7 @@ void FixNVTSllodKokkos<DeviceType>::init()
   FixNHKokkos<DeviceType>::init();
 
   vdelu = typename ArrayTypes<DeviceType>::t_v_array("nvt/sllod/kk:vdelu", atomKK->nlocal);
-  
+
   if (!this->temperature->tempbias)
     this->error->all(FLERR,"Temperature for fix nvt/sllod does not have a bias");
 
@@ -112,8 +111,8 @@ void FixNVTSllodKokkos<DeviceType>::nh_v_temp()
   // for non temp/deform BIAS:
   //   calculate temperature since some computes require temp
   //   computed on current nlocal atoms to remove bias
-  
-  if (nondeformbias){ 
+
+  if (nondeformbias){
     atomKK->sync(this->temperature->execution_space,this->temperature->datamask_read);
     this->temperature->compute_scalar();
     atomKK->modified(this->temperature->execution_space,this->temperature->datamask_modify);
@@ -133,7 +132,7 @@ void FixNVTSllodKokkos<DeviceType>::nh_v_temp()
   this->copymode = 0;
 
   this->temperature->remove_bias_all();
-  
+
   this->copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixNVTSllod_temp2>(0,nlocal),*this);
   this->copymode = 0;

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.h
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.h
@@ -23,7 +23,6 @@ FixStyle(nvt/sllod/kk/host,FixNVTSllodKokkos<LMPHostType>);
 #define LMP_FIX_NVT_SLLOD_KOKKOS_H
 
 #include "fix_nh_kokkos.h"
-//#include "fix_nvt_sllod.h"
 #include "kokkos_type.h"
 #include "kokkos_few.h"
 
@@ -61,7 +60,7 @@ class FixNVTSllodKokkos : public FixNHKokkos<DeviceType> {
   typename ArrayTypes<DeviceType>::t_int_1d mask;
 
   Few<double, 6> d_h_two;
-  
+
   class DomainKokkos *domainKK;
   class AtomKokkos *atomKK;
 };

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.h
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.h
@@ -1,7 +1,7 @@
 /* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   www.cs.sandia.gov/~sjplimp/lammps.html
-   Steve Plimpton, sjplimp@sandia.gov, Sandia National Laboratories
+   https://www.lammps.org/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.h
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.h
@@ -1,0 +1,97 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   www.cs.sandia.gov/~sjplimp/lammps.html
+   Steve Plimpton, sjplimp@sandia.gov, Sandia National Laboratories
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(nvt/sllod/kk,FixNVTSllodKokkos<LMPDeviceType>);
+FixStyle(nvt/sllod/kk/device,FixNVTSllodKokkos<LMPDeviceType>);
+FixStyle(nvt/sllod/kk/host,FixNVTSllodKokkos<LMPHostType>);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_NVT_SLLOD_KOKKOS_H
+#define LMP_FIX_NVT_SLLOD_KOKKOS_H
+
+#include "fix_nh_kokkos.h"
+//#include "fix_nvt_sllod.h"
+#include "kokkos_type.h"
+#include "kokkos_few.h"
+
+namespace LAMMPS_NS {
+
+struct TagFixNVTSllod_temp1{};
+struct TagFixNVTSllod_temp2{};
+
+template<class DeviceType>
+class FixNVTSllodKokkos : public FixNHKokkos<DeviceType> {
+ public:
+  FixNVTSllodKokkos(class LAMMPS *, int, char **);
+  ~FixNVTSllodKokkos();
+  void init();
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagFixNVTSllod_temp1, const int& i) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagFixNVTSllod_temp2, const int& i) const;
+
+ private:
+  int nondeformbias;
+
+  void nh_v_temp();
+
+ protected:
+  typename ArrayTypes<DeviceType>::t_x_array x;
+  typename ArrayTypes<DeviceType>::t_v_array v;
+  typename ArrayTypes<DeviceType>::t_v_array vdelu;
+  typename ArrayTypes<DeviceType>::t_f_array_const f;
+  typename ArrayTypes<DeviceType>::t_float_1d rmass;
+  typename ArrayTypes<DeviceType>::t_float_1d mass;
+  typename ArrayTypes<DeviceType>::t_int_1d type;
+  typename ArrayTypes<DeviceType>::t_int_1d mask;
+
+  Few<double, 6> d_h_two;
+  
+  class DomainKokkos *domainKK;
+  class AtomKokkos *atomKK;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Temperature control must be used with fix nvt/sllod
+
+Self-explanatory.
+
+E: Pressure control can not be used with fix nvt/sllod
+
+Self-explanatory.
+
+E: Temperature for fix nvt/sllod does not have a bias
+
+The specified compute must compute temperature with a bias.
+
+E: Using fix nvt/sllod with inconsistent fix deform remap option
+
+Fix nvt/sllod requires that deforming atoms have a velocity profile
+provided by "remap v" as a fix deform option.
+
+E: Using fix nvt/sllod with no fix deform defined
+
+Self-explanatory.
+
+*/

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -1,7 +1,6 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   https://www.lammps.org/, Sandia National Laboratories
+   https://lammps.sandia.gov/, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
@@ -31,6 +30,7 @@
 #include "memory_kokkos.h"
 #include "pair.h"
 #include "remap_kokkos.h"
+#include "kokkos_few.h"
 
 #include <cmath>
 
@@ -67,7 +67,7 @@ PPPMKokkos<DeviceType>::PPPMKokkos(LAMMPS *lmp) : PPPM(lmp)
 
   pppmflag = 1;
   group_group_enable = 0;
-  triclinic_support = 0;
+  triclinic_support = 1;
 
   nfactors = 3;
   //factors = new int[nfactors];
@@ -455,80 +455,92 @@ void PPPMKokkos<DeviceType>::operator()(TagPPPM_setup4, const int &n) const
 template<class DeviceType>
 void PPPMKokkos<DeviceType>::setup_triclinic()
 {
-//  int i,j,k,n;
-//  double *prd;
-//
-//  // volume-dependent factors
-//  // adjust z dimension for 2d slab PPPM
-//  // z dimension for 3d PPPM is zprd since slab_volfactor = 1.0
-//
-//  prd = domain->prd;
-//
-//  double xprd = prd[0];
-//  double yprd = prd[1];
-//  double zprd = prd[2];
-//  double zprd_slab = zprd*slab_volfactor;
-//  volume = xprd * yprd * zprd_slab;
-//
-//  // use lamda (0-1) coordinates
-//
-//  delxinv = nx_pppm;
-//  delyinv = ny_pppm;
-//  delzinv = nz_pppm;
-//  delvolinv = delxinv*delyinv*delzinv/volume;
-//
-//  // d_fkx,d_fky,d_fkz for my FFT grid pts
-//
-//  double per_i,per_j,per_k;
-//
-//  n = 0;
-//  for (k = nzlo_fft; k <= nzhi_fft; k++) { // parallel_for
-//    per_k = k - nz_pppm*(2*k/nz_pppm);
-//    for (j = nylo_fft; j <= nyhi_fft; j++) {
-//      per_j = j - ny_pppm*(2*j/ny_pppm);
-//      for (i = nxlo_fft; i <= nxhi_fft; i++) {
-//        per_i = i - nx_pppm*(2*i/nx_pppm);
-//
-//        double unitk_lamda[3];
-//        unitk_lamda[0] = 2.0*MY_PI*per_i;
-//        unitk_lamda[1] = 2.0*MY_PI*per_j;
-//        unitk_lamda[2] = 2.0*MY_PI*per_k;
-//        x2lamdaT(&unitk_lamda[0],&unitk_lamda[0]);
-//        d_fkx[n] = unitk_lamda[0];
-//        d_fky[n] = unitk_lamda[1];
-//        d_fkz[n] = unitk_lamda[2];
-//        n++;
-//      }
-//    }
-//  }
-//
-//  // virial coefficients
-//
-//  double sqk,vterm;
-//
-//  for (n = 0; n < nfft; n++) { // parallel_for
-//    sqk = d_fkx[n]*d_fkx[n] + d_fky[n]*d_fky[n] + d_fkz[n]*d_fkz[n];
-//    if (sqk == 0.0) {
-//      d_vg(n,0) = 0.0;
-//      d_vg(n,1) = 0.0;
-//      d_vg(n,2) = 0.0;
-//      d_vg(n,3) = 0.0;
-//      d_vg(n,4) = 0.0;
-//      d_vg(n,5) = 0.0;
-//    } else {
-//      vterm = -2.0 * (1.0/sqk + 0.25/(g_ewald*g_ewald));
-//      d_vg(n,0) = 1.0 + vterm*d_fkx[n]*d_fkx[n];
-//      d_vg(n,1) = 1.0 + vterm*d_fky[n]*d_fky[n];
-//      d_vg(n,2) = 1.0 + vterm*d_fkz[n]*d_fkz[n];
-//      d_vg(n,3) = vterm*d_fkx[n]*d_fky[n];
-//      d_vg(n,4) = vterm*d_fkx[n]*d_fkz[n];
-//      d_vg(n,5) = vterm*d_fky[n]*d_fkz[n];
-//    }
-//  }
-//
-//  compute_gf_ik_triclinic();
+  int i,j,k,n;
+  double *prd;
+
+  // volume-dependent factors
+  // adjust z dimension for 2d slab PPPM
+  // z dimension for 3d PPPM is zprd since slab_volfactor = 1.0
+
+  prd = domain->prd;
+  // Update simulation box parameters
+  h = Few<double, 6>(domain->h);
+  h_inv = Few<double, 6>(domain->h_inv);
+
+  double xprd = prd[0];
+  double yprd = prd[1];
+  double zprd = prd[2];
+  double zprd_slab = zprd*slab_volfactor;
+  volume = xprd * yprd * zprd_slab;
+
+  // use lamda (0-1) coordinates
+
+  delxinv = nx_pppm;
+  delyinv = ny_pppm;
+  delzinv = nz_pppm;
+  delvolinv = delxinv*delyinv*delzinv/volume;
+
+  // merge three outer loops into one for better threading
+  numz_fft = nzhi_fft-nzlo_fft + 1;
+  numy_fft = nyhi_fft-nylo_fft + 1;
+  numx_fft = nxhi_fft-nxlo_fft + 1;
+  const int inum_fft = numx_fft*numy_fft*numz_fft;
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_setup_triclinic1>(0,inum_fft),*this);
+  copymode = 0;
+
+  // virial coefficients
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_setup_triclinic2>(0,nfft),*this);
+  copymode = 0;
+
+  compute_gf_ik_triclinic();
 }
 
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_setup_triclinic1, const int &n) const
+{
+  const int k = n/(numy_fft*numx_fft);
+  const int j = (n - k*numy_fft*numx_fft) / numx_fft;
+  const int i = n - k*numy_fft*numx_fft - j*numx_fft;
+  double per_k = k - nz_pppm*(2*k/nz_pppm);
+  double per_j = j - ny_pppm*(2*j/ny_pppm);
+  double per_i = i - nx_pppm*(2*i/nx_pppm);
+
+  double unitk_lamda[3];
+  unitk_lamda[0] = 2.0*MY_PI*per_i;
+  unitk_lamda[1] = 2.0*MY_PI*per_j;
+  unitk_lamda[2] = 2.0*MY_PI*per_k;
+  x2lamdaT(&unitk_lamda[0],&unitk_lamda[0]);
+  d_fkx[n] = unitk_lamda[0];
+  d_fky[n] = unitk_lamda[1];
+  d_fkz[n] = unitk_lamda[2];
+}
+
+template<class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_setup_triclinic2, const int &n) const
+{
+    const double sqk = d_fkx[n]*d_fkx[n] + d_fky[n]*d_fky[n] + d_fkz[n]*d_fkz[n];
+    if (sqk == 0.0) {
+      d_vg(n,0) = 0.0;
+      d_vg(n,1) = 0.0;
+      d_vg(n,2) = 0.0;
+      d_vg(n,3) = 0.0;
+      d_vg(n,4) = 0.0;
+      d_vg(n,5) = 0.0;
+    } else {
+      const double vterm = -2.0 * (1.0/sqk + 0.25/(g_ewald*g_ewald));
+      d_vg(n,0) = 1.0 + vterm*d_fkx[n]*d_fkx[n];
+      d_vg(n,1) = 1.0 + vterm*d_fky[n]*d_fky[n];
+      d_vg(n,2) = 1.0 + vterm*d_fkz[n]*d_fkz[n];
+      d_vg(n,3) = vterm*d_fkx[n]*d_fky[n];
+      d_vg(n,4) = vterm*d_fkx[n]*d_fkz[n];
+      d_vg(n,5) = vterm*d_fky[n]*d_fkz[n];
+    }
+}
 /* ----------------------------------------------------------------------
    reset local grid arrays and communication stencils
    called by fix balance b/c it changed sizes of processor sub-domains
@@ -1004,7 +1016,7 @@ void PPPMKokkos<DeviceType>::set_grid_global()
     tmp[0] = nx_pppm;
     tmp[1] = ny_pppm;
     tmp[2] = nz_pppm;
-    x2lamdaT(&tmp[0],&tmp[0]);
+    KSpace::x2lamdaT(&tmp[0],&tmp[0]);
     h_x = 1.0/tmp[0];
     h_y = 1.0/tmp[1];
     h_z = 1.0/tmp[2];
@@ -1311,6 +1323,10 @@ void PPPMKokkos<DeviceType>::compute_gf_ik_triclinic()
   nby = static_cast<int> (tmp[1]);
   nbz = static_cast<int> (tmp[2]);
 
+  // Update the local copy of the domain box tilt 
+  h = Few<double, 6>(domain->h);
+  h_inv = Few<double, 6>(domain->h_inv);
+
   twoorder = 2*order;
 
   copymode = 1;
@@ -1320,71 +1336,71 @@ void PPPMKokkos<DeviceType>::compute_gf_ik_triclinic()
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PPPMKokkos<DeviceType>::operator()(TagPPPM_compute_gf_ik_triclinic, const int &/*m*/) const
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_compute_gf_ik_triclinic, const int &m) const
 {
-  //int n = (m - nzlo_fft)*(nyhi_fft+1 - nylo_fft)*(nxhi_fft+1 - nxlo_fft);
-  //
-  //const int mper = m - nz_pppm*(2*m/nz_pppm);
-  //const double snz = square(sin(MY_PI*mper/nz_pppm));
-  //
-  //for (int l = nylo_fft; l <= nyhi_fft; l++) {
-  //  const int lper = l - ny_pppm*(2*l/ny_pppm);
-  //  const double sny = square(sin(MY_PI*lper/ny_pppm));
-  //
-  //  for (int k = nxlo_fft; k <= nxhi_fft; k++) {
-  //    const int kper = k - nx_pppm*(2*k/nx_pppm);
-  //    const double snx = square(sin(MY_PI*kper/nx_pppm));
-  //
-  //    double unitk_lamda[3];
-  //    unitk_lamda[0] = 2.0*MY_PI*kper;
-  //    unitk_lamda[1] = 2.0*MY_PI*lper;
-  //    unitk_lamda[2] = 2.0*MY_PI*mper;
-  //    x2lamdaT(&unitk_lamda[0],&unitk_lamda[0]);
-  //
-  //    const double sqk = square(unitk_lamda[0]) + square(unitk_lamda[1]) + square(unitk_lamda[2]);
-  //
-  //    if (sqk != 0.0) {
-  //      const double numerator = 12.5663706/sqk;
-  //      const double denominator = gf_denom(snx,sny,snz);
-  //      double sum1 = 0.0;
-  //
-  //      for (int nx = -nbx; nx <= nbx; nx++) {
-  //        const double argx = MY_PI*kper/nx_pppm + MY_PI*nx;
-  //        const double wx = powsinxx(argx,twoorder);
-  //
-  //        for (int ny = -nby; ny <= nby; ny++) {
-  //          const double argy = MY_PI*lper/ny_pppm + MY_PI*ny;
-  //          const double wy = powsinxx(argy,twoorder);
-  //
-  //          for (int nz = -nbz; nz <= nbz; nz++) {
-  //            const double argz = MY_PI*mper/nz_pppm + MY_PI*nz;
-  //            const double wz = powsinxx(argz,twoorder);
-  //
-  //            double b[3];
-  //            b[0] = 2.0*MY_PI*nx_pppm*nx;
-  //            b[1] = 2.0*MY_PI*ny_pppm*ny;
-  //            b[2] = 2.0*MY_PI*nz_pppm*nz;
-  //            x2lamdaT(&b[0],&b[0]);
-  //
-  //            const double qx = unitk_lamda[0]+b[0];
-  //            const double sx = exp(-0.25*square(qx/g_ewald));
-  //
-  //            const double qy = unitk_lamda[1]+b[1];
-  //            const double sy = exp(-0.25*square(qy/g_ewald));
-  //
-  //            const double qz = unitk_lamda[2]+b[2];
-  //            const double sz = exp(-0.25*square(qz/g_ewald));
-  //
-  //            const double dot1 = unitk_lamda[0]*qx + unitk_lamda[1]*qy + unitk_lamda[2]*qz;
-  //            const double dot2 = qx*qx+qy*qy+qz*qz;
-  //            sum1 += (dot1/dot2) * sx*sy*sz * wx*wy*wz;
-  //          }
-  //        }
-  //      }
-  //      d_greensfn[n++] = numerator*sum1/denominator;
-  //    } else d_greensfn[n++] = 0.0;
-  //  }
-  //}
+  int n = (m - nzlo_fft)*(nyhi_fft+1 - nylo_fft)*(nxhi_fft+1 - nxlo_fft);
+  
+  const int mper = m - nz_pppm*(2*m/nz_pppm);
+  const double snz = square(sin(MY_PI*mper/nz_pppm));
+  
+  for (int l = nylo_fft; l <= nyhi_fft; l++) {
+    const int lper = l - ny_pppm*(2*l/ny_pppm);
+    const double sny = square(sin(MY_PI*lper/ny_pppm));
+  
+    for (int k = nxlo_fft; k <= nxhi_fft; k++) {
+      const int kper = k - nx_pppm*(2*k/nx_pppm);
+      const double snx = square(sin(MY_PI*kper/nx_pppm));
+  
+      double unitk_lamda[3];
+      unitk_lamda[0] = 2.0*MY_PI*kper;
+      unitk_lamda[1] = 2.0*MY_PI*lper;
+      unitk_lamda[2] = 2.0*MY_PI*mper;
+      x2lamdaT(&unitk_lamda[0],&unitk_lamda[0]);
+  
+      const double sqk = square(unitk_lamda[0]) + square(unitk_lamda[1]) + square(unitk_lamda[2]);
+  
+      if (sqk != 0.0) {
+        const double numerator = 12.5663706/sqk;
+        const double denominator = gf_denom(snx,sny,snz);
+        double sum1 = 0.0;
+  
+        for (int nx = -nbx; nx <= nbx; nx++) {
+          const double argx = MY_PI*kper/nx_pppm + MY_PI*nx;
+          const double wx = powsinxx(argx,twoorder);
+  
+          for (int ny = -nby; ny <= nby; ny++) {
+            const double argy = MY_PI*lper/ny_pppm + MY_PI*ny;
+            const double wy = powsinxx(argy,twoorder);
+  
+            for (int nz = -nbz; nz <= nbz; nz++) {
+              const double argz = MY_PI*mper/nz_pppm + MY_PI*nz;
+              const double wz = powsinxx(argz,twoorder);
+  
+              double b[3];
+              b[0] = 2.0*MY_PI*nx_pppm*nx;
+              b[1] = 2.0*MY_PI*ny_pppm*ny;
+              b[2] = 2.0*MY_PI*nz_pppm*nz;
+              x2lamdaT(&b[0],&b[0]);
+  
+              const double qx = unitk_lamda[0]+b[0];
+              const double sx = exp(-0.25*square(qx/g_ewald));
+  
+              const double qy = unitk_lamda[1]+b[1];
+              const double sy = exp(-0.25*square(qy/g_ewald));
+  
+              const double qz = unitk_lamda[2]+b[2];
+              const double sz = exp(-0.25*square(qz/g_ewald));
+  
+              const double dot1 = unitk_lamda[0]*qx + unitk_lamda[1]*qy + unitk_lamda[2]*qz;
+              const double dot2 = qx*qx+qy*qy+qz*qz;
+              sum1 += (dot1/dot2) * sx*sy*sz * wx*wy*wz;
+            }
+          }
+        }
+        d_greensfn[n++] = numerator*sum1/denominator;
+      } else d_greensfn[n++] = 0.0;
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -1867,107 +1883,224 @@ void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik10, const int &ii) con
 template<class DeviceType>
 void PPPMKokkos<DeviceType>::poisson_ik_triclinic()
 {
-//  int i,j,k,n;
-//
-//  // compute gradients of V(r) in each of 3 dims by transforming ik*V(k)
-//  // FFT leaves data in 3d brick decomposition
-//  // copy it into inner portion of vdx,vdy,vdz arrays
-//
-//  // x direction gradient
-//
-//  n = 0;
-//  for (i = 0; i < nfft; i++) { // parallel_for1
-//    d_work2[n] = -d_fkx[i]*d_work1[n+1];
-//    d_work2[n+1] = d_fkx[i]*d_work1[n];
-//    n += 2;
-//  }
-//
-//  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
-//
-//  n = 0;
-//  for (k = nzlo_in-nzlo_out; k <= nzhi_in-nzlo_out; k++) // parallel_for2
-//
-//
-//  // y direction gradient
-//
-//  n = 0;
-//  for (i = 0; i < nfft; i++) { // parallel_for3
-//    d_work2[n] = -d_fky[i]*d_work1[n+1];
-//    d_work2[n+1] = d_fky[i]*d_work1[n];
-//    n += 2;
-//  }
-//
-//  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
-//
-//  n = 0;
-//  for (k = nzlo_in-nzlo_out; k <= nzhi_in-nzlo_out; k++) // parallel_for4
-//    for (j = nylo_in-nylo_out; j <= nyhi_in-nylo_out; j++)
-//      for (i = nxlo_in-nxlo_out; i <= nxhi_in-nxlo_out; i++) {
-//        d_vdy_brick(k,j,i) = d_work2[n];
-//        n += 2;
-//      }
-//
-//  // z direction gradient
-//
-//  n = 0;
-//  for (i = 0; i < nfft; i++) { // parallel_for5
-//    d_work2[n] = -d_fkz[i]*d_work1[n+1];
-//    d_work2[n+1] = d_fkz[i]*d_work1[n];
-//    n += 2;
-//  }
-//
-//  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
-//
-//  n = 0;
-//  for (k = nzlo_in-nzlo_out; k <= nzhi_in-nzlo_out; k++) // parallel_for6
-//
+/**************************************************
+  int i,j,k,n;
+
+  // compute gradients of V(r) in each of 3 dims by transforming ik*V(k)
+  // FFT leaves data in 3d brick decomposition
+  // copy it into inner portion of vdx,vdy,vdz arrays
+
+  // x direction gradient
+
+  n = 0;
+  for (i = 0; i < nfft; i++) { // parallel_for1
+    d_work2[n] = -d_fkx[i]*d_work1[n+1];
+    d_work2[n+1] = d_fkx[i]*d_work1[n];
+    n += 2;
+  }
+
+  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
+
+  n = 0;
+  for (k = nzlo_in-nzlo_out; k <= nzhi_in-nzlo_out; k++) // parallel_for2
+
+
+  // y direction gradient
+
+  n = 0;
+  for (i = 0; i < nfft; i++) { // parallel_for3
+    d_work2[n] = -d_fky[i]*d_work1[n+1];
+    d_work2[n+1] = d_fky[i]*d_work1[n];
+    n += 2;
+  }
+
+  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
+
+  n = 0;
+  for (k = nzlo_in-nzlo_out; k <= nzhi_in-nzlo_out; k++) // parallel_for4
+    for (j = nylo_in-nylo_out; j <= nyhi_in-nylo_out; j++)
+      for (i = nxlo_in-nxlo_out; i <= nxhi_in-nxlo_out; i++) {
+        d_vdy_brick(k,j,i) = d_work2[n];
+        n += 2;
+      }
+
+  // z direction gradient
+
+  n = 0;
+  for (i = 0; i < nfft; i++) { // parallel_for5
+    d_work2[n] = -d_fkz[i]*d_work1[n+1];
+    d_work2[n+1] = d_fkz[i]*d_work1[n];
+    n += 2;
+  }
+
+  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
+
+  n = 0;
+  for (k = nzlo_in-nzlo_out; k <= nzhi_in-nzlo_out; k++) // parallel_for6
+******************************/
+  int i,j,k,n;
+
+  // compute gradients of V(r) in each of 3 dims by transforming ik*V(k)
+  // FFT leaves data in 3d brick decomposition
+  // copy it into inner portion of vdx,vdy,vdz arrays
+
+  // x direction gradient
+
+  //n = 0;
+  //for (i = 0; i < nfft; i++) {
+  //  d_work2[n] = -d_fkx[i]*d_work1[n+1];
+  //  d_work2[n+1] = d_fkx[i]*d_work1[n];
+  //  n += 2;
+  //}
+
+  // merge three outer loops into one for better threading
+
+  numz_fft = nzhi_fft-nzlo_fft + 1;
+  numy_fft = nyhi_fft-nylo_fft + 1;
+  numx_fft = nxhi_fft-nxlo_fft + 1;
+  const int inum_fft = numz_fft*numy_fft*numx_fft;
+
+  numz_inout = (nzhi_in-nzlo_out)-(nzlo_in-nzlo_out) + 1;
+  numy_inout = (nyhi_in-nylo_out)-(nylo_in-nylo_out) + 1;
+  numx_inout = (nxhi_in-nxlo_out)-(nxlo_in-nxlo_out) + 1;
+  const int inum_inout = numz_inout*numy_inout*numx_inout;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_poisson_ik_triclinic1>(0,nfft),*this);
+  copymode = 0;
+
+  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
+
+  //n = 0;
+  //for (k = nzlo_in; k <= nzhi_in; k++)
+  //  for (j = nylo_in; j <= nyhi_in; j++)
+  //    for (i = nxlo_in; i <= nxhi_in; i++) {
+  //      d_vdx_brick(k,j,i) = d_work2[n];
+  //      n += 2;
+  //    }
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_poisson_ik_triclinic2>(0,inum_inout),*this);
+  copymode = 0;
+
+  // y direction gradient
+
+  //n = 0;
+  //for (i = 0; i < nfft; i++) {
+  //  d_work2[n] = -d_fky[i]*d_work1[n+1];
+  //  d_work2[n+1] = d_fky[i]*d_work1[n];
+  //  n += 2;
+  //}
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_poisson_ik_triclinic3>(0,nfft),*this);
+  copymode = 0;
+
+  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
+
+  //n = 0;
+  //for (k = nzlo_in; k <= nzhi_in; k++)
+  //  for (j = nylo_in; j <= nyhi_in; j++)
+  //    for (i = nxlo_in; i <= nxhi_in; i++) {
+  //      d_vdy_brick(k,j,i) = d_work2[n];
+  //      n += 2;
+  //    }
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_poisson_ik_triclinic4>(0,inum_inout),*this);
+  copymode = 0;
+
+  // z direction gradient
+
+  //n = 0;
+  //for (i = 0; i < nfft; i++) {
+  //  d_work2[n] = -d_fkz[i]*d_work1[n+1];
+  //  d_work2[n+1] = d_fkz[i]*d_work1[n];
+  //  n += 2;
+  //}
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_poisson_ik_triclinic5>(0,nfft),*this);
+  copymode = 0;
+
+  fft2->compute(d_work2,d_work2,FFT3dKokkos<DeviceType>::BACKWARD);
+
+  //n = 0;
+  //for (k = nzlo_in; k <= nzhi_in; k++)
+  //  for (j = nylo_in; j <= nyhi_in; j++)
+  //    for (i = nxlo_in; i <= nxhi_in; i++) {
+  //      d_vdz_brick(k,j,i) = d_work2[n];
+  //      n += 2;
+  //    }
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPPPM_poisson_ik_triclinic6>(0,inum_inout),*this);
+  copymode = 0;
+
 }
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic1, const int &/*k*/) const
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic1, const int &ii) const
 {
-
+  d_work2[2*ii] = -d_fkx[ii]*d_work1[2*ii+1];
+  d_work2[2*ii+1] = d_fkx[ii]*d_work1[2*ii];
 }
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic2, const int &/*k*/) const
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic2, const int &ii) const
 {
-//    for (j = nylo_in-nylo_out; j <= nyhi_in-nylo_out; j++)
-//      for (i = nxlo_in-nxlo_out; i <= nxhi_in-nxlo_out; i++) {
-//        d_vdx_brick(k,j,i) = d_work2[n];
-//        n += 2;
-//      }
+  const int n = ii*2;
+  int k = ii/(numy_inout*numx_inout);
+  int j = (ii - k*numy_inout*numx_inout) / numx_inout;
+  int i = ii - k*numy_inout*numx_inout - j*numx_inout;
+  k += nzlo_in-nzlo_out;
+  j += nylo_in-nylo_out;
+  i += nxlo_in-nxlo_out;
+  d_vdx_brick(k,j,i) = d_work2[n];
 }
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic3, const int &/*k*/) const
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic3, const int &ii) const
 {
 //  int n = (k - (nzlo_in-nzlo_out))*((nyhi_in-nylo_out) - (nylo_in-nylo_out) + 1)*((nxhi_in-nxlo_out) - (nxlo_in-nxlo_out) + 1)*2;
+  d_work2[2*ii] = -d_fky[ii]*d_work1[2*ii+1];
+  d_work2[2*ii+1] = d_fky[ii]*d_work1[2*ii];
 
 }
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic4, const int &/*k*/) const
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic4, const int &ii) const
 {
 //  int n = (k - (nzlo_in-nzlo_out))*((nyhi_in-nylo_out) - (nylo_in-nylo_out) + 1)*((nxhi_in-nxlo_out) - (nxlo_in-nxlo_out) + 1)*2;
 //
+
+  const int n = ii*2;
+  int k = ii/(numy_inout*numx_inout);
+  int j = (ii - k*numy_inout*numx_inout) / numx_inout;
+  int i = ii - k*numy_inout*numx_inout - j*numx_inout;
+  k += nzlo_in-nzlo_out;
+  j += nylo_in-nylo_out;
+  i += nxlo_in-nxlo_out;
+  d_vdy_brick(k,j,i) = d_work2[n];
 }
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic5, const int &/*k*/) const
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic5, const int &ii) const
 {
 //  int n = (k - (nzlo_in-nzlo_out))*((nyhi_in-nylo_out) - (nylo_in-nylo_out) + 1)*((nxhi_in-nxlo_out) - (nxlo_in-nxlo_out) + 1)*2;
 //
+  d_work2[2*ii] = -d_fkz[ii]*d_work1[2*ii+1];
+  d_work2[2*ii+1] = d_fkz[ii]*d_work1[2*ii];
 }
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic6, const int &/*k*/) const
+void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic6, const int &ii) const
 {
 //  int n = (k - (nzlo_in-nzlo_out))*((nyhi_in-nylo_out) - (nylo_in-nylo_out) + 1)*((nxhi_in-nxlo_out) - (nxlo_in-nxlo_out) + 1)*2;
 //
@@ -1976,6 +2109,14 @@ void PPPMKokkos<DeviceType>::operator()(TagPPPM_poisson_ik_triclinic6, const int
 //      d_vdz_brick(k,j,i) = d_work2[n];
 //      n += 2;
 //    }
+  const int n = ii*2;
+  int k = ii/(numy_inout*numx_inout);
+  int j = (ii - k*numy_inout*numx_inout) / numx_inout;
+  int i = ii - k*numy_inout*numx_inout - j*numx_inout;
+  k += nzlo_in-nzlo_out;
+  j += nylo_in-nylo_out;
+  i += nxlo_in-nxlo_out;
+  d_vdz_brick(k,j,i) = d_work2[n];
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -1,6 +1,6 @@
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   https://lammps.sandia.gov/, Sandia National Laboratories
+   https://lammps.org/, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -1326,7 +1326,7 @@ void PPPMKokkos<DeviceType>::compute_gf_ik_triclinic()
   nby = static_cast<int> (tmp[1]);
   nbz = static_cast<int> (tmp[2]);
 
-  // Update the local copy of the domain box tilt 
+  // Update the local copy of the domain box tilt
   h = Few<double, 6>(domain->h);
   h_inv = Few<double, 6>(domain->h_inv);
 
@@ -1342,58 +1342,58 @@ KOKKOS_INLINE_FUNCTION
 void PPPMKokkos<DeviceType>::operator()(TagPPPM_compute_gf_ik_triclinic, const int &m) const
 {
   int n = (m - nzlo_fft)*(nyhi_fft+1 - nylo_fft)*(nxhi_fft+1 - nxlo_fft);
-  
+
   const int mper = m - nz_pppm*(2*m/nz_pppm);
   const double snz = square(sin(MY_PI*mper/nz_pppm));
-  
+
   for (int l = nylo_fft; l <= nyhi_fft; l++) {
     const int lper = l - ny_pppm*(2*l/ny_pppm);
     const double sny = square(sin(MY_PI*lper/ny_pppm));
-  
+
     for (int k = nxlo_fft; k <= nxhi_fft; k++) {
       const int kper = k - nx_pppm*(2*k/nx_pppm);
       const double snx = square(sin(MY_PI*kper/nx_pppm));
-  
+
       double unitk_lamda[3];
       unitk_lamda[0] = 2.0*MY_PI*kper;
       unitk_lamda[1] = 2.0*MY_PI*lper;
       unitk_lamda[2] = 2.0*MY_PI*mper;
       x2lamdaT(&unitk_lamda[0],&unitk_lamda[0]);
-  
+
       const double sqk = square(unitk_lamda[0]) + square(unitk_lamda[1]) + square(unitk_lamda[2]);
-  
+
       if (sqk != 0.0) {
         const double numerator = 12.5663706/sqk;
         const double denominator = gf_denom(snx,sny,snz);
         double sum1 = 0.0;
-  
+
         for (int nx = -nbx; nx <= nbx; nx++) {
           const double argx = MY_PI*kper/nx_pppm + MY_PI*nx;
           const double wx = powsinxx(argx,twoorder);
-  
+
           for (int ny = -nby; ny <= nby; ny++) {
             const double argy = MY_PI*lper/ny_pppm + MY_PI*ny;
             const double wy = powsinxx(argy,twoorder);
-  
+
             for (int nz = -nbz; nz <= nbz; nz++) {
               const double argz = MY_PI*mper/nz_pppm + MY_PI*nz;
               const double wz = powsinxx(argz,twoorder);
-  
+
               double b[3];
               b[0] = 2.0*MY_PI*nx_pppm*nx;
               b[1] = 2.0*MY_PI*ny_pppm*ny;
               b[2] = 2.0*MY_PI*nz_pppm*nz;
               x2lamdaT(&b[0],&b[0]);
-  
+
               const double qx = unitk_lamda[0]+b[0];
               const double sx = exp(-0.25*square(qx/g_ewald));
-  
+
               const double qy = unitk_lamda[1]+b[1];
               const double sy = exp(-0.25*square(qy/g_ewald));
-  
+
               const double qz = unitk_lamda[2]+b[2];
               const double sz = exp(-0.25*square(qz/g_ewald));
-  
+
               const double dot1 = unitk_lamda[0]*qx + unitk_lamda[1]*qy + unitk_lamda[2]*qz;
               const double dot2 = qx*qx+qy*qy+qz*qz;
               sum1 += (dot1/dot2) * sx*sy*sz * wx*wy*wz;

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -1,7 +1,6 @@
-// clang-format off
 /* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   https://www.lammps.org/, Sandia National Laboratories
+   https://lammps.sandia.gov/, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
@@ -13,11 +12,11 @@
 ------------------------------------------------------------------------- */
 
 #ifdef KSPACE_CLASS
-// clang-format off
-KSpaceStyle(pppm/kk,PPPMKokkos<LMPDeviceType>);
-KSpaceStyle(pppm/kk/device,PPPMKokkos<LMPDeviceType>);
-KSpaceStyle(pppm/kk/host,PPPMKokkos<LMPHostType>);
-// clang-format on
+
+KSpaceStyle(pppm/kk,PPPMKokkos<LMPDeviceType>)
+KSpaceStyle(pppm/kk/device,PPPMKokkos<LMPDeviceType>)
+KSpaceStyle(pppm/kk/host,PPPMKokkos<LMPHostType>)
+
 #else
 
 #ifndef LMP_PPPM_KOKKOS_H
@@ -29,6 +28,7 @@ KSpaceStyle(pppm/kk/host,PPPMKokkos<LMPHostType>);
 #include "kokkos_base_fft.h"
 #include "fftdata_kokkos.h"
 #include "kokkos_type.h"
+#include "kokkos_few.h"
 
 // fix up FFT defines for KOKKOS with CUDA
 
@@ -55,6 +55,8 @@ struct TagPPPM_setup1{};
 struct TagPPPM_setup2{};
 struct TagPPPM_setup3{};
 struct TagPPPM_setup4{};
+struct TagPPPM_setup_triclinic1{};
+struct TagPPPM_setup_triclinic2{};
 struct TagPPPM_compute_gf_ik{};
 struct TagPPPM_compute_gf_ik_triclinic{};
 struct TagPPPM_self1{};
@@ -137,6 +139,12 @@ class PPPMKokkos : public PPPM, public KokkosBaseFFT {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPPPM_setup4, const int&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPPPM_setup_triclinic1, const int&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPPPM_setup_triclinic2, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPPPM_compute_gf_ik, const int&) const;
@@ -308,6 +316,25 @@ class PPPMKokkos : public PPPM, public KokkosBaseFFT {
   int numx_inout,numy_inout,numz_inout;
   int numx_out,numy_out,numz_out;
   int ix,iy,nlocal;
+
+  // Local copies of the domain box tilt etc. 
+  // TODO: Will need to put in a less
+  // hacky solution later, since this needs to be manually updated
+  Few<double,6> h, h_inv;
+
+  KOKKOS_INLINE_FUNCTION
+  void x2lamdaT(double* v, double* lamda) const
+  {
+    double lamda_tmp[3];                                                         
+                                                                                
+    lamda_tmp[0] = h_inv[0]*v[0];                                                
+    lamda_tmp[1] = h_inv[5]*v[0] + h_inv[1]*v[1];                                
+    lamda_tmp[2] = h_inv[4]*v[0] + h_inv[3]*v[1] + h_inv[2]*v[2];                
+                                                                                
+    lamda[0] = lamda_tmp[0];                                                     
+    lamda[1] = lamda_tmp[1];                                                     
+    lamda[2] = lamda_tmp[2];
+  }
 
   int nx,ny,nz;
   typename AT::t_int_1d_um d_list_index;

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -141,7 +141,7 @@ class PPPMKokkos : public PPPM, public KokkosBaseFFT {
   void operator()(TagPPPM_setup4, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPPPM_setup_triclinic1, const int&, const int&, const int&) const;
+  void operator()(TagPPPM_setup_triclinic1, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPPPM_setup_triclinic2, const int&) const;

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -317,22 +317,20 @@ class PPPMKokkos : public PPPM, public KokkosBaseFFT {
   int numx_out,numy_out,numz_out;
   int ix,iy,nlocal;
 
-  // Local copies of the domain box tilt etc. 
-  // TODO: Will need to put in a less
-  // hacky solution later, since this needs to be manually updated
+  // Local copies of the domain box tilt etc.
   Few<double,6> h, h_inv;
 
   KOKKOS_INLINE_FUNCTION
   void x2lamdaT(double* v, double* lamda) const
   {
-    double lamda_tmp[3];                                                         
-                                                                                
-    lamda_tmp[0] = h_inv[0]*v[0];                                                
-    lamda_tmp[1] = h_inv[5]*v[0] + h_inv[1]*v[1];                                
-    lamda_tmp[2] = h_inv[4]*v[0] + h_inv[3]*v[1] + h_inv[2]*v[2];                
-                                                                                
-    lamda[0] = lamda_tmp[0];                                                     
-    lamda[1] = lamda_tmp[1];                                                     
+    double lamda_tmp[3];
+
+    lamda_tmp[0] = h_inv[0]*v[0];
+    lamda_tmp[1] = h_inv[5]*v[0] + h_inv[1]*v[1];
+    lamda_tmp[2] = h_inv[4]*v[0] + h_inv[3]*v[1] + h_inv[2]*v[2];
+
+    lamda[0] = lamda_tmp[0];
+    lamda[1] = lamda_tmp[1];
     lamda[2] = lamda_tmp[2];
   }
 

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -141,7 +141,7 @@ class PPPMKokkos : public PPPM, public KokkosBaseFFT {
   void operator()(TagPPPM_setup4, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPPPM_setup_triclinic1, const int&) const;
+  void operator()(TagPPPM_setup_triclinic1, const int&, const int&, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPPPM_setup_triclinic2, const int&) const;
@@ -623,3 +623,4 @@ accuracy.  This error should not occur for typical problems.  Please
 send an email to the developers.
 
 */
+

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -1,6 +1,7 @@
+// clang-format off
 /* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   https://lammps.sandia.gov/, Sandia National Laboratories
+   https://lammps.org/, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
@@ -12,11 +13,11 @@
 ------------------------------------------------------------------------- */
 
 #ifdef KSPACE_CLASS
-
+// clang-format off
 KSpaceStyle(pppm/kk,PPPMKokkos<LMPDeviceType>)
 KSpaceStyle(pppm/kk/device,PPPMKokkos<LMPDeviceType>)
 KSpaceStyle(pppm/kk/host,PPPMKokkos<LMPHostType>)
-
+// clang-format on
 #else
 
 #ifndef LMP_PPPM_KOKKOS_H

--- a/src/compute_temp_deform.cpp
+++ b/src/compute_temp_deform.cpp
@@ -56,8 +56,11 @@ ComputeTempDeform::ComputeTempDeform(LAMMPS *lmp, int narg, char **arg) :
 
 ComputeTempDeform::~ComputeTempDeform()
 {
-  memory->destroy(vbiasall);
-  delete [] vector;
+  if (!copymode)
+  {
+    memory->destroy(vbiasall);
+    delete [] vector;
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -69,7 +72,7 @@ void ComputeTempDeform::init()
   // check fix deform remap settings
 
   for (i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+    if (strncmp(modify->fix[i]->style,"deform", 6) == 0) {
       if (((FixDeform *) modify->fix[i])->remapflag == Domain::X_REMAP &&
           comm->me == 0)
         error->warning(FLERR,"Using compute temp/deform with inconsistent "


### PR DESCRIPTION
**Summary**
This set of patches introduces two Kokkos accelerated styles, `fix nvt/sllod/kk` and `compute temp/deform/kk`, and modifies Kokkos accelerated PPPM to support triclinic geometries. These modifications allow for simulations of constant-temperature shear-flow, via the SLLOD equations of motion and tilting periodic boundary conditions, to be conducted almost entirely on
the device for simple systems. The new accelerated styles are enabled in the usual fashion by adding via the `/kk` suffix, e.g.

```
...
fix   1 all nvt/sllod/kk temp 1.0 1.0 1.0 tchain 1
fix   2 all deform/kk  1 xy erate 0.01 remap v
compute mytemp all temp/deform/kk
...
```

(I have not made any changes to the already existing `fix deform/kk`).

**Author(s)**
Emily Kahl (The University of Queensland)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Implementation Notes**
- `PPPMKokkos` - Implementation of triclinic calculations hews closely to the non-Kokkos accelerated triclinic routines. I have tried to keep kernel structure and range policies consistent with the rest of the class.
- `FixNVTSllodKokkos` - Implementation is almost identical to the non-accelerated class, with some slight loop refactoring to better work as a Kokkos kernel.
- `ComputeTempDeformKokkos` - I have only implemented overloaded versions of `compute_vector()`, `compute_scalar()` and `remove/restore_bias_all()`. Also made some tweaks to the base `ComputeTempDeform` destructor and `init()` functions to properly handle the derived Kokkos style.
- `ComputeTempKokkos` - moved `s_CTEMP` out of the toplevel LAMMPS namespace and into the class namespace to avoid collisions with `ComputeTempDeform`. This was the easiest way to get it to compile cleanly with the new classes, but I'm not wedded to this solution and am happy to change if there's a better way.

I have tested the new code by manually comparing the results with serial calculations for a simple LJ-fluid, crystalline NaCl, and SPCE water and found it to agree to within numerical uncertainty for both CPU multithreading and GPU offloading. I am happy to provide the input files for these tests, and to run any others if required. I have not written unit tests as there does not yet appear to be full support for Kokkos styles in the test suite.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


