### PR TITLE
Fix bug with v remap option in Kokkos fix deform

### DIFF
--- a/src/KOKKOS/domain_kokkos.cpp
+++ b/src/KOKKOS/domain_kokkos.cpp
@@ -27,14 +27,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DomainKokkos::DomainKokkos(LAMMPS *lmp) : Domain(lmp) {}
-
-/* ---------------------------------------------------------------------- */
-
-void DomainKokkos::init()
-{
+DomainKokkos::DomainKokkos(LAMMPS *lmp) : Domain(lmp) {
   atomKK = (AtomKokkos *) atom;
-  Domain::init();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/domain_kokkos.h
+++ b/src/KOKKOS/domain_kokkos.h
@@ -30,7 +30,6 @@ class DomainKokkos : public Domain {
  public:
   DomainKokkos(class LAMMPS *);
   ~DomainKokkos() {}
-  void init();
   void reset_box();
   void pbc();
   void remap_all();

--- a/src/KOKKOS/fix_deform_kokkos.cpp
+++ b/src/KOKKOS/fix_deform_kokkos.cpp
@@ -38,7 +38,7 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace MathConst;
 
-enum{NONE,FINAL,DELTA,SCALE,VEL,ERATE,TRATE,VOLUME,WIGGLE,VARIABLE};
+enum{NONE=0,FINAL,DELTA,SCALE,VEL,ERATE,TRATE,VOLUME,WIGGLE,VARIABLE};
 enum{ONE_FROM_ONE,ONE_FROM_TWO,TWO_FROM_ONE};
 
 /* ---------------------------------------------------------------------- */
@@ -143,7 +143,7 @@ void FixDeformKokkos::end_of_step()
   // set new box size for VOLUME dims that are linked to other dims
   // NOTE: still need to set h_rate for these dims
 
-  for (int i = 0; i < 3; i++) {
+  for (i = 0; i < 3; i++) {
     if (set[i].style != VOLUME) continue;
 
     if (set[i].substyle == ONE_FROM_ONE) {
@@ -227,7 +227,7 @@ void FixDeformKokkos::end_of_step()
       // tilt_target can be large positive or large negative value
       // add/subtract box lengths until tilt_target is closest to current value
 
-      int idenom;
+      int idenom = 0;
       if (i == 5) idenom = 0;
       else if (i == 4) idenom = 0;
       else if (i == 3) idenom = 1;

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -175,7 +175,7 @@ void Domain::init()
 
   deform_flag = deform_vremap = deform_groupbit = 0;
   for (int i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"deform") == 0) {
+    if (utils::strmatch(modify->fix[i]->style,"^deform")) {
       deform_flag = 1;
       if (((FixDeform *) modify->fix[i])->remapflag == Domain::V_REMAP) {
         deform_vremap = 1;


### PR DESCRIPTION
**Summary**

When `domain.cpp` was checking for `fix deform`, the Kokkos suffix was excluded, and the `v remap` command was therefore ignored when using Kokkos.

**Related Issue(s)**

#2882 

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes