### PR TITLE
Correcting non-fdotr Virial tensor computation for interlayer potentials

### DIFF
--- a/src/INTERLAYER/pair_ilp_graphene_hbn.cpp
+++ b/src/INTERLAYER/pair_ilp_graphene_hbn.cpp
@@ -482,7 +482,7 @@ void PairILPGrapheneHBN::calc_FRep(int eflag, int /* vflag */)
   double dprodnorm1[3] = {0.0, 0.0, 0.0};
   double fp1[3] = {0.0, 0.0, 0.0};
   double fprod1[3] = {0.0, 0.0, 0.0};
-  double delkj[3] = {0.0, 0.0, 0.0};
+  double delki[3] = {0.0, 0.0, 0.0};
   double fk[3] = {0.0, 0.0, 0.0};
 
   inum = list->inum;
@@ -588,12 +588,12 @@ void PairILPGrapheneHBN::calc_FRep(int eflag, int /* vflag */)
           f[k][0] += fk[0];
           f[k][1] += fk[1];
           f[k][2] += fk[2];
-          delkj[0] = x[k][0] - x[j][0];
-          delkj[1] = x[k][1] - x[j][1];
-          delkj[2] = x[k][2] - x[j][2];
+          delki[0] = x[k][0] - x[i][0];
+          delki[1] = x[k][1] - x[i][1];
+          delki[2] = x[k][2] - x[i][2];
           if (evflag)
-            ev_tally_xyz(k, j, nlocal, newton_pair, 0.0, 0.0, fk[0], fk[1], fk[2], delkj[0],
-                         delkj[1], delkj[2]);
+            ev_tally_xyz(k, i, nlocal, newton_pair, 0.0, 0.0, fk[0], fk[1], fk[2], delki[0],
+                         delki[1], delki[2]);
         }
 
         if (eflag) pvector[1] += evdwl = Tap * Vilp;

--- a/src/INTERLAYER/pair_kolmogorov_crespi_full.cpp
+++ b/src/INTERLAYER/pair_kolmogorov_crespi_full.cpp
@@ -478,7 +478,7 @@ void PairKolmogorovCrespiFull::calc_FRep(int eflag, int /* vflag */)
   double dprodnorm1[3] = {0.0, 0.0, 0.0};
   double fp1[3] = {0.0, 0.0, 0.0};
   double fprod1[3] = {0.0, 0.0, 0.0};
-  double delkj[3] = {0.0, 0.0, 0.0};
+  double delki[3] = {0.0, 0.0, 0.0};
   double fk[3] = {0.0, 0.0, 0.0};
 
   inum = list->inum;
@@ -585,12 +585,12 @@ void PairKolmogorovCrespiFull::calc_FRep(int eflag, int /* vflag */)
           f[k][0] += fk[0];
           f[k][1] += fk[1];
           f[k][2] += fk[2];
-          delkj[0] = x[k][0] - x[j][0];
-          delkj[1] = x[k][1] - x[j][1];
-          delkj[2] = x[k][2] - x[j][2];
+          delki[0] = x[k][0] - x[i][0];
+          delki[1] = x[k][1] - x[i][1];
+          delki[2] = x[k][2] - x[i][2];
           if (evflag)
-            ev_tally_xyz(k, j, nlocal, newton_pair, 0.0, 0.0, fk[0], fk[1], fk[2], delkj[0],
-                         delkj[1], delkj[2]);
+            ev_tally_xyz(k, j, nlocal, newton_pair, 0.0, 0.0, fk[0], fk[1], fk[2], delki[0],
+                         delki[1], delki[2]);
         }
 
         if (eflag) {


### PR DESCRIPTION

**Summary**

I found that `pair/ilp/graphene/hbn` cannot produce similar pressure result with `vflag_fdotr` on/off.

I think the problem is due to incorrect method of calling `ev_tally_xyz` in the for-k loop in the `calc_FRep` function.

A simple proof is described in Implementation Notes.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->
None

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

Xiaohui Duan  (dxhisboy@126.com), National Supercomputing Center in Wuxi
**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

Changes calling `ev_tally` with `fk` and `delkj` to `fk` and `delki`. The proof is as follows:

![image](https://user-images.githubusercontent.com/3888709/130744415-f055026d-744e-4f99-aa70-ca9db974e338.png)

The problem can be addressed as follows:

Giving following input script (which disables intra-layer potential because it produces a large pressure that hides the difference of pressure in inter-layer potential):

```
variable        Kz equal 0.1688
variable        nodotr index 0
units      metal
boundary   p p p
atom_style full

lattice custom 2.4595 a1 1  0  0  a2 0 1.73203 0  a3 0 0 4 &
               basis 0 0 0  basis 0.5 0.16666666666666666 0 &
               basis 0.5 0.5 0 basis 0 0.6666666666666666 0
region van block -10 10 -5 5 0 20 units lattice
region grn0 block -10 10 -5 5 7.5 8.5 units lattice
region grn1 block -10 10 -5 5 8.5 9.5 units lattice
region grn union 2 grn0 grn1
region all union 2 grn van
create_box 1 all
create_atoms 1 region grn0
create_atoms 1 region grn1
set region grn0 mol 1
set region grn1 mol 2
group top region grn1
displace_atoms top random 0.025 0.025 0.5  4123
mass 1 12.0107

pair_style      hybrid/overlay tersoff ilp/graphene/hbn 16.0
pair_coeff              * * tersoff SiC.tersoff C
pair_coeff              * * ilp/graphene/hbn BNCH.ILP C
if "${nofdotr}==1" then "pair_modify     pair ilp/graphene/hbn nofdotr compute yes"
pair_modify     pair tersoff compute no
neighbor                2.0 bin
neigh_modify    one 20000 page 1000000

write_data grn.data
dump            1 all atom 100000 sys.lammpstrj
thermo          1 #1000
thermo_style    custom step temp etotal pxx pyy pzz pxy pxz pyz
thermo_modify   flush yes
min_style cg
minimize  0.0 1.0e-6 1000 1
```

For the six directional pressure tensor `Pxx Pyy Pzz Pxy Pxz Pyz` in the first timestep which is related to Virial stress of the system.

When using `virial_fdotr_compute`, the pressure tensor is:
```
-5.9064665   -5.9056294   -31.284293 -0.0003513579 0.0011400409 -0.00089151243
```

When adding `nofdotr` to `pair_modify`, it is:
```
-5.904713   -5.9001243   -31.291564 0.0029140813 0.0052877203  0.013248622
```

In my modified code, it is:
```
-5.9064665   -5.9056294   -31.284293 -0.0003513579 0.0011400409 -0.00089151243
```

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


