### PR TITLE
Fix property/atom tweak

### DIFF
--- a/src/fix_property_atom.h
+++ b/src/fix_property_atom.h
@@ -53,7 +53,7 @@ class FixPropertyAtom : public Fix {
  protected:
   int nvalue, border;
   int molecule_flag, q_flag, rmass_flag;    // flags for specific fields
-  int *style;                               // style of each value, see enum
+  int *styles;                              // style of each value, see enum
   int *index;                               // indices into atom custom data structs
   int *cols;                                // columns per value, for arrays
   char *astyle;                             // atom style at instantiation


### PR DESCRIPTION
**Summary**

Latest upgrade of fix property/atom inadvertently created a local vector "style" which overrides the Fix:: style string.
Change it to "styles" to avoid the conflict.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


