### PR TITLE
force all memory methods to return nullptr if requested size <= 0

### DIFF
--- a/src/memory.h
+++ b/src/memory.h
@@ -42,7 +42,8 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE *create(TYPE *&array, int n, const char *name)
   {
-    if (n <= 0) return nullptr;
+    // POSSIBLE future change
+    //if (n <= 0) return nullptr;
 
     bigint nbytes = ((bigint) sizeof(TYPE)) * n;
     array = (TYPE *) smalloc(nbytes, name);
@@ -61,10 +62,11 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE *grow(TYPE *&array, int n, const char *name)
   {
-    if (n <= 0) {
-      destroy(array);
-      return nullptr;
-    }
+    // POSSIBLE future change
+    //if (n <= 0) {
+    //  destroy(array);
+    //  return nullptr;
+    // }
 
     if (array == nullptr) return create(array, n, name);
 
@@ -96,7 +98,8 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE *create1d_offset(TYPE *&array, int nlo, int nhi, const char *name)
   {
-    if (nlo > nhi) return nullptr;
+    // POSSIBLE future change
+    // if (nlo > nhi) return nullptr;
 
     bigint nbytes = ((bigint) sizeof(TYPE)) * (nhi - nlo + 1);
     array = (TYPE *) smalloc(nbytes, name);
@@ -127,7 +130,8 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE **create(TYPE **&array, int n1, int n2, const char *name)
   {
-    if (n1 <= 0 || n2 <= 0) return nullptr;
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2 <= 0) return nullptr;
 
     bigint nbytes = ((bigint) sizeof(TYPE)) * n1 * n2;
     TYPE *data = (TYPE *) smalloc(nbytes, name);
@@ -156,10 +160,11 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE **grow(TYPE **&array, int n1, int n2, const char *name)
   {
-    if (n1 <= 0 || n2 <= 0) {
-      destroy(array);
-      return nullptr;
-    }
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2 <= 0) {
+    //  destroy(array);
+    //  return nullptr;
+    // }
 
     if (array == nullptr) return create(array, n1, n2, name);
 
@@ -201,7 +206,8 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE **create_ragged(TYPE **&array, int n1, int *n2, const char *name)
   {
-    if (n1 <= 0) return nullptr;
+    // POSSIBLE future change
+    //if (n1 <= 0) return nullptr;
 
     bigint n2sum = 0;
     for (int i = 0; i < n1; i++) n2sum += n2[i];
@@ -234,7 +240,8 @@ class Memory : protected Pointers {
   template <typename TYPE>
   TYPE **create2d_offset(TYPE **&array, int n1, int n2lo, int n2hi, const char *name)
   {
-    if (n1 <= 0 || n2lo > n2hi) return nullptr;
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2lo > n2hi) return nullptr;
 
     int n2 = n2hi - n2lo + 1;
     create(array, n1, n2, name);
@@ -268,7 +275,8 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE ***create(TYPE ***&array, int n1, int n2, int n3, const char *name)
   {
-    if (n1 <= 0 || n2 <= 0 || n3 <= 0) return nullptr;
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2 <= 0 || n3 <= 0) return nullptr;
 
     bigint nbytes = ((bigint) sizeof(TYPE)) * n1 * n2 * n3;
     TYPE *data = (TYPE *) smalloc(nbytes, name);
@@ -305,10 +313,11 @@ class Memory : protected Pointers {
 
   template <typename TYPE> TYPE ***grow(TYPE ***&array, int n1, int n2, int n3, const char *name)
   {
-    if (n1 <= 0 || n2 <= 0 || n3 <= 0) {
-      destroy(array);
-      return nullptr;
-    };
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2 <= 0 || n3 <= 0) {
+    //  destroy(array);
+    //  return nullptr;
+    //};
 
     if (array == nullptr) return create(array, n1, n2, n3, name);
 
@@ -445,7 +454,8 @@ class Memory : protected Pointers {
   template <typename TYPE>
   TYPE ****create(TYPE ****&array, int n1, int n2, int n3, int n4, const char *name)
   {
-    if (n1 <= 0 || n2 <= 0 || n3 <= 0 || n4 <= 0) return nullptr;
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2 <= 0 || n3 <= 0 || n4 <= 0) return nullptr;
 
     bigint nbytes = ((bigint) sizeof(TYPE)) * n1 * n2 * n3 * n4;
     TYPE *data = (TYPE *) smalloc(nbytes, name);
@@ -492,10 +502,11 @@ class Memory : protected Pointers {
   template <typename TYPE>
   TYPE ****grow(TYPE ****&array, int n1, int n2, int n3, int n4, const char *name)
   {
-    if (n1 <= 0 || n2 <= 0 || n3 <= 0 || n4 <= 0) {
-      destroy(array);
-      return nullptr;
-    }
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2 <= 0 || n3 <= 0 || n4 <= 0) {
+    //  destroy(array);
+    //  return nullptr;
+    // }
 
     if (array == nullptr) return create(array, n1, n2, n3, n4, name);
 
@@ -607,7 +618,8 @@ class Memory : protected Pointers {
   template <typename TYPE>
   TYPE *****create(TYPE *****&array, int n1, int n2, int n3, int n4, int n5, const char *name)
   {
-    if (n1 <= 0 || n2 <= 0 || n3 <= 0 || n4 <= 0 || n5 <= 0) return nullptr;
+    // POSSIBLE future change
+    //if (n1 <= 0 || n2 <= 0 || n3 <= 0 || n4 <= 0 || n5 <= 0) return nullptr;
 
     bigint nbytes = ((bigint) sizeof(TYPE)) * n1 * n2 * n3 * n4 * n5;
     TYPE *data = (TYPE *) smalloc(nbytes, name);


### PR DESCRIPTION
**Summary**

Force all 1d/2d/3d/4d/5d memory requests via memory.h to return a nullptr if the size of the request is <= zero.
Previously the data portion would be zero, but the memory for pointers to pointers, etc was still sometimes allocated
and thus a non-NULL prt was returned. This caused a couple bugs with destroying the array.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Hopefully no issues introduced with this.  It should be the caller's job to check for a zero-size request or a NULL return.
Sometimes a zero-sized array is a valid request, so the caller can decide what to do in that case.  E.g. not read/write to it.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


