### PR TITLE
Fix (the fix) for _MM_SCALE preprocessor defines for future Intel compilers

### DIFF
--- a/src/INTEL/intel_preprocess.h
+++ b/src/INTEL/intel_preprocess.h
@@ -20,10 +20,6 @@
 #define USE_OMP_SIMD
 #define __INTEL_COMPILER __INTEL_LLVM_COMPILER
 #define __INTEL_COMPILER_BUILD_DATE __INTEL_LLVM_COMPILER
-#define _MM_SCALE_1 1
-#define _MM_SCALE_2 2
-#define _MM_SCALE_4 4
-#define _MM_SCALE_8 8
 #endif
 
 #ifdef __INTEL_COMPILER

--- a/src/INTEL/intel_simd.h
+++ b/src/INTEL/intel_simd.h
@@ -35,6 +35,13 @@ authors for more details.
 
 #ifdef __AVX512F__
 
+#ifndef _MM_SCALE_1
+#define _MM_SCALE_1 1
+#define _MM_SCALE_2 2
+#define _MM_SCALE_4 4
+#define _MM_SCALE_8 8
+#endif
+
 namespace ip_simd {
 
   typedef __mmask16 SIMD_mask;


### PR DESCRIPTION
**Summary**

Simple change in two of the Intel package files to handle _MM_SCALE_* preprocessor defines correctly (that might or might not be defined in compiler depending on version and variant).

**Related Issue(s)**

**Author(s)**

Mike Brown (Intel)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


