### PR TITLE
Add missing Kokkos sync-to-host to fix false-positive warning

### DIFF
--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -1315,3 +1315,13 @@ void CommKokkos::grow_swap(int n)
   memory->grow(maxsendlist,n,"comm:maxsendlist");
   for (int i=0;i<maxswap;i++) maxsendlist[i]=size;
 }
+
+/* ----------------------------------------------------------------------
+   forward communication of N values in per-atom array
+------------------------------------------------------------------------- */
+
+void CommKokkos::forward_comm_array(int nsize, double **array)
+{
+  k_sendlist.sync<LMPHostType>();
+  CommBrick::forward_comm_array(nsize,array);
+}

--- a/src/KOKKOS/comm_kokkos.h
+++ b/src/KOKKOS/comm_kokkos.h
@@ -51,6 +51,8 @@ class CommKokkos : public CommBrick {
   void forward_comm_dump(class Dump *);    // forward comm from a Dump
   void reverse_comm_dump(class Dump *);    // reverse comm from a Dump
 
+  void forward_comm_array(int, double **);            // forward comm of array
+
   template<class DeviceType> void forward_comm_device(int dummy);
   template<class DeviceType> void reverse_comm_device();
   template<class DeviceType> void forward_comm_pair_device(Pair *pair);

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -238,6 +238,7 @@ void CommTiledKokkos::reverse_comm_dump(Dump *dump)
 
 void CommTiledKokkos::forward_comm_array(int nsize, double **array)
 {
+  k_sendlist.sync<LMPHostType>();
   CommTiled::forward_comm_array(nsize,array);
 }
 

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -238,7 +238,6 @@ void CommTiledKokkos::reverse_comm_dump(Dump *dump)
 
 void CommTiledKokkos::forward_comm_array(int nsize, double **array)
 {
-  k_sendlist.sync<LMPHostType>();
   CommTiled::forward_comm_array(nsize,array);
 }
 

--- a/src/comm_brick.h
+++ b/src/comm_brick.h
@@ -44,7 +44,7 @@ class CommBrick : public Comm {
   virtual void forward_comm_dump(class Dump *);          // forward comm from a Dump
   virtual void reverse_comm_dump(class Dump *);          // reverse comm from a Dump
 
-  void forward_comm_array(int, double **);            // forward comm of array
+  virtual void forward_comm_array(int, double **);            // forward comm of array
   int exchange_variable(int, double *, double *&);    // exchange on neigh stencil
   void *extract(const char *, int &);
   virtual double memory_usage();

--- a/src/comm_brick.h
+++ b/src/comm_brick.h
@@ -44,7 +44,7 @@ class CommBrick : public Comm {
   virtual void forward_comm_dump(class Dump *);          // forward comm from a Dump
   virtual void reverse_comm_dump(class Dump *);          // reverse comm from a Dump
 
-  virtual void forward_comm_array(int, double **);            // forward comm of array
+  virtual void forward_comm_array(int, double **);    // forward comm of array
   int exchange_variable(int, double *, double *&);    // exchange on neigh stencil
   void *extract(const char *, int &);
   virtual double memory_usage();


### PR DESCRIPTION
**Summary**

Add missing Kokkos sync-to-host for `forward_comm_array()` method, fixes a false positive `"WARNING: Inconsistent image flags (../domain.cpp:814)` when running on GPUs with more than 1 MPI rank. Dynamics were correct, it just gave a false warning.

**Related Issue(s)**

This is the remaining issue mentioned in #2900.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes