### PR TITLE
Enable dynamic groups for fix bond/create

### DIFF
--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -51,6 +51,7 @@ FixBondCreate::FixBondCreate(LAMMPS *lmp, int narg, char **arg) :
   nevery = utils::inumeric(FLERR,arg[3],false,lmp);
   if (nevery <= 0) error->all(FLERR,"Illegal fix bond/create command");
 
+  dynamic_group_allow = 1;
   force_reneighbor = 1;
   next_reneighbor = -1;
   vector_flag = 1;


### PR DESCRIPTION
**Summary**

This patch allows the fix bond/create (from the MC package) to be used with dynamic groups.

**Author(s)**

M.J. Riezebos-Hoogerheide, Eindhoven University of Technology
Wouter G. Ellenbroek, Eindhoven University of Technology

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

Fix bond/create does not save anything about which atoms are contained in the group it acts upon in constructor, init() or setup(). The only place where it refers to group membership of atoms is in post_integrate(), where it uses atom->mask() to obtain this information. Therefore, the mechanism with which dynamic groups operate was already fully compatible with this fix and the only thing we did is add dynamic_group_allow=1 to the usual location in the constructor.

We have worked with this modification to the code for a year, first applied to the 3 March 2020 stable version of LAMMPS, later applied to the 29 October 2020 stable version of LAMMPS. Our application was to define a dynamic group using a region, so that only atoms inside this region would be eligible for bond creation. The results of this have been as expected. For the purpose of this pull request, we made a fresh branch off master and applied the same single-line change. There have not been any significant changes to this file since 29 October 2020, so even though technically we have not tested the final submitted patch, we have tested its effect in a recent stable version.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


