### PR TITLE
Recover Kokkos compilation

### DIFF
--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -163,8 +163,8 @@ action fix_dpd_energy_kokkos.cpp fix_dpd_energy.cpp
 action fix_dpd_energy_kokkos.h fix_dpd_energy.h
 action fix_rx_kokkos.cpp fix_rx.cpp
 action fix_rx_kokkos.h fix_rx.h
-action gridcomm_kokkos.cpp gridcomm.cpp
-action gridcomm_kokkos.h gridcomm.h
+action gridcomm_kokkos.cpp fft3d.h
+action gridcomm_kokkos.h fft3d.h
 action improper_class2_kokkos.cpp improper_class2.cpp
 action improper_class2_kokkos.h improper_class2.h
 action improper_harmonic_kokkos.cpp improper_harmonic.cpp


### PR DESCRIPTION
**Summary**

The Kokkos compile is currently broken due to changes to the parent `GridComm` class. The `gridcomm_kokkos.h` file depends on `fftdata_kokkos.h` which is only installed with the `KSPACE` package. This PR adds a requirement that the `KSPACE` package be installed to use `gridcomm_kokkos`. The long-term solution is to extract raw pointers from the views and pass those around as `void*` to support other use cases of the gridcomm class (outside the scope of this PR).

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes