### PR TITLE
heFFTe integration

### DIFF
--- a/cmake/Modules/Packages/KSPACE.cmake
+++ b/cmake/Modules/Packages/KSPACE.cmake
@@ -46,6 +46,22 @@ else()
   target_compile_definitions(lammps PRIVATE -DFFT_KISS)
 endif()
 
+option(FFT_HEFFTE  "Use heFFTe as the distributed FFT engine."  OFF)
+if(FFT_HEFFTE)
+  # if FFT_HEFFTE is enabled, switch the builtin FFT engine with Heffte
+  if(FFT STREQUAL "FFTW3") # respect the backend choice, FFTW or MKL
+    set(HEFFTE_COMPONENTS "FFTW")
+  elseif(FFT STREQUAL "MKL")
+    set(HEFFTE_COMPONENTS "MKL")
+  else()
+    message(FATAL_ERROR "Using -DFFT_HEFFTE=ON, requires FFT either FFTW or MKL")
+  endif()
+
+  find_package(Heffte 2.1.0 REQUIRED ${HEFFTE_COMPONENTS})
+  target_compile_definitions(lammps PRIVATE -DHEFFTE)
+  target_link_libraries(lammps PRIVATE Heffte::Heffte)
+endif()
+
 set(FFT_PACK "array" CACHE STRING "Optimization for FFT")
 set(FFT_PACK_VALUES array pointer memcpy)
 set_property(CACHE FFT_PACK PROPERTY STRINGS ${FFT_PACK_VALUES})

--- a/src/KSPACE/fft3d_wrap.cpp
+++ b/src/KSPACE/fft3d_wrap.cpp
@@ -27,30 +27,62 @@ FFT3d::FFT3d(LAMMPS *lmp, MPI_Comm comm, int nfast, int nmid, int nslow,
              int out_klo, int out_khi,
              int scaled, int permute, int *nbuf, int usecollective) : Pointers(lmp)
 {
+#ifndef HEFFTE
   plan = fft_3d_create_plan(comm,nfast,nmid,nslow,
                             in_ilo,in_ihi,in_jlo,in_jhi,in_klo,in_khi,
                             out_ilo,out_ihi,out_jlo,out_jhi,out_klo,out_khi,
                             scaled,permute,nbuf,usecollective);
   if (plan == nullptr) error->one(FLERR,"Could not create 3d FFT plan");
+#else
+  heffte::plan_options options = heffte::default_options<heffte_backend>();
+  options.use_alltoall = (usecollective != 0);
+  options.use_reorder = (permute != 0);
+
+  heffte_plan = std::unique_ptr<heffte::fft3d<heffte_backend>>(
+        new heffte::fft3d<heffte_backend>(
+                heffte::box3d<>({in_ilo,in_jlo,in_klo}, {in_ihi, in_jhi, in_khi}),
+                heffte::box3d<>({out_ilo,out_jlo,out_klo}, {out_ihi, out_jhi, out_khi}),
+                comm, options)
+      );
+  heffte_workspace.resize(heffte_plan->size_workspace());
+#endif
 }
 
 /* ---------------------------------------------------------------------- */
 
 FFT3d::~FFT3d()
 {
+#ifndef HEFFTE
   fft_3d_destroy_plan(plan);
+#endif
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FFT3d::compute(FFT_SCALAR *in, FFT_SCALAR *out, int flag)
 {
+#ifndef HEFFTE
   fft_3d((FFT_DATA *) in,(FFT_DATA *) out,flag,plan);
+#else
+  if (flag == 1)
+      heffte_plan->forward(reinterpret_cast<std::complex<FFT_SCALAR>*>(in),
+                           reinterpret_cast<std::complex<FFT_SCALAR>*>(out),
+                           reinterpret_cast<std::complex<FFT_SCALAR>*>(heffte_workspace.data())
+                          );
+  else
+      heffte_plan->backward(reinterpret_cast<std::complex<FFT_SCALAR>*>(in),
+                            reinterpret_cast<std::complex<FFT_SCALAR>*>(out),
+                            reinterpret_cast<std::complex<FFT_SCALAR>*>(heffte_workspace.data()),
+                            heffte::scale::full
+                           );
+#endif
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FFT3d::timing1d(FFT_SCALAR *in, int nsize, int flag)
 {
+#ifndef HEFFTE
   fft_1d_only((FFT_DATA *) in,nsize,flag,plan);
+#endif
 }

--- a/src/KSPACE/fft3d_wrap.h
+++ b/src/KSPACE/fft3d_wrap.h
@@ -17,6 +17,17 @@
 #include "fft3d.h"
 #include "pointers.h"
 
+#ifdef HEFFTE
+#include "heffte.h"
+#ifdef FFT_FFTW3
+using heffte_backend = heffte::backend::fftw;
+#else
+#ifdef FFT_MKL
+using heffte_backend = heffte::backend::mkl;
+#endif
+#endif
+#endif
+
 namespace LAMMPS_NS {
 
 class FFT3d : protected Pointers {
@@ -31,6 +42,12 @@ class FFT3d : protected Pointers {
 
  private:
   struct fft_plan_3d *plan;
+
+  #ifdef HEFFTE
+  std::unique_ptr<heffte::fft3d<heffte_backend>> heffte_plan;
+  std::vector<std::complex<FFT_SCALAR>> heffte_workspace;
+  #endif
+
 };
 
 }    // namespace LAMMPS_NS


### PR DESCRIPTION
**Summary**

Links to the heFFTe library and sets it as an potential FFT engine, while maintaining the current code-structure of LAMMPS. Specifically, the FFTW and MKL backends of heFFTe are enabled.

**Related Issue(s)**

N/A

**Author(s)**

Miroslav Stoyanov @mkstoyanov, Oak Ridge National Laboratory

Alan Ayala, Innovative Computing Laboratory, University of Tennesse

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No compatibility changes, the interface works only through the existing FFT wrapper.

**Implementation Notes**

The current section adds a new CMake option `FFT_HEFFTE` which respects the backend selected using `FFT` but enables the MPI communication algorithms implemented in heFFTe.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

https://bitbucket.org/icl/heffte/src/master/


