### PR TITLE
Rigid output vector

### DIFF
--- a/examples/rigid/in.rigid.tnr
+++ b/examples/rigid/in.rigid.tnr
@@ -41,6 +41,8 @@ fix	1	rods	rigid molecule
 fix	2	tethers	nve
 fix	3	all	langevin 1.4 1.4 1.0 437624
 
+thermo_style custom step temp pe etotal press enthalpy lx ly lz pxx pyy pzz f_1[1] f_1[2] f_1[3]
+
 run	5000
 
 # Replace fix rigid and fix langevin with new ones
@@ -54,11 +56,23 @@ fix	3	tethers langevin 1.4 1.4 1.0 198450
 
 fix	1 rods	rigid/nve molecule
 print 	"rigid/nve"
+
+run	1000
+unfix	1
+
+fix	1 rods	rigid/nve/small molecule
+print 	"rigid/nve/small"
+
 run	1000
 unfix	1
 
 fix	1 rods	rigid/nvt molecule temp 1.4 1.4 1.0
 print 	"rigid/nvt"
+run	1000
+unfix	1
+
+fix	1 rods	rigid/nvt/small molecule temp 1.4 1.4 1.0
+print 	"rigid/nvt/small"
 run	1000
 unfix	1
 

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -2667,42 +2667,21 @@ int FixRigid::modify_param(int narg, char **arg)
 }
 
 /* ----------------------------------------------------------------------
-   return temperature of collection of rigid bodies
-   non-active DOF are removed by fflag/tflag and in tfactor
+   return energy added by the fix
+   TODO: add Langevin thermostat energy if applied
 ------------------------------------------------------------------------- */
 
 double FixRigid::compute_scalar()
 {
-  double wbody[3],rot[3][3];
-
-  double t = 0.0;
-  for (int i = 0; i < nbody; i++) {
-    t += masstotal[i] * (fflag[i][0]*vcm[i][0]*vcm[i][0] +
-                         fflag[i][1]*vcm[i][1]*vcm[i][1] +
-                         fflag[i][2]*vcm[i][2]*vcm[i][2]);
-
-    // wbody = angular velocity in body frame
-
-    MathExtra::quat_to_mat(quat[i],rot);
-    MathExtra::transpose_matvec(rot,angmom[i],wbody);
-    if (inertia[i][0] == 0.0) wbody[0] = 0.0;
-    else wbody[0] /= inertia[i][0];
-    if (inertia[i][1] == 0.0) wbody[1] = 0.0;
-    else wbody[1] /= inertia[i][1];
-    if (inertia[i][2] == 0.0) wbody[2] = 0.0;
-    else wbody[2] /= inertia[i][2];
-
-    t += tflag[i][0]*inertia[i][0]*wbody[0]*wbody[0] +
-      tflag[i][1]*inertia[i][1]*wbody[1]*wbody[1] +
-      tflag[i][2]*inertia[i][2]*wbody[2]*wbody[2];
-  }
-
-  t *= tfactor;
-  return t;
+  return 0;
 }
 
 /* ----------------------------------------------------------------------
-   return temperature
+   return temperature of collection of rigid bodies
+   non-active DOF are removed by fflag/tflag and in tfactor
+   n = 0: temperature
+   n = 1: temperature associated with the translational dofs
+   n = 2: temperature associated with the translational dofs
 ------------------------------------------------------------------------- */
 
 double FixRigid::compute_vector(int n)

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -774,7 +774,7 @@ void FixRigid::init()
     ndof_t += fflag[ibody][0] + fflag[ibody][1] + fflag[ibody][2];
     ndof_r += tflag[ibody][0] + tflag[ibody][1] + tflag[ibody][2];
   }
-  ndof_t -= nlinear;
+  ndof_r -= nlinear;
   ndof = ndof_t + ndof_r;
   if (ndof > 0.0) tfactor = force->mvv2e / (ndof * force->boltz);
   else tfactor = 0.0;

--- a/src/RIGID/fix_rigid.h
+++ b/src/RIGID/fix_rigid.h
@@ -38,6 +38,7 @@ class FixRigid : public Fix {
   void final_integrate_respa(int, int);
   void write_restart_file(const char *);
   virtual double compute_scalar();
+  virtual double compute_vector(int);
 
   double memory_usage();
   void grow_arrays(int);
@@ -79,7 +80,9 @@ class FixRigid : public Fix {
   int *mol2body;    // convert mol-ID to rigid body index
   int *body2mol;    // convert rigid body index to mol-ID
   int maxmol;       // size of mol2body = max mol-ID
-
+  double ndof;      // total degrees of freedom of the bodies
+  double ndof_t;    // total translational degrees of freedom of the bodies
+  double ndof_r;    // total rotational degrees of freedom of the bodies
   int *body;            // which body each atom is part of (-1 if none)
   double **displace;    // displacement of each atom in body coords
 
@@ -114,6 +117,8 @@ class FixRigid : public Fix {
   double **dorient;      // orientation of dipole mu wrt rigid body
 
   double tfactor;    // scale factor on temperature of rigid bodies
+  double tfactor_t;  // scale factor on translational temperature of rigid bodies
+  double tfactor_r;  // scale factor on rotational temperature of rigid bodies
   int langflag;      // 0/1 = no/yes Langevin thermostat
 
   int tstat_flag;    // NVT settings

--- a/src/RIGID/fix_rigid_nh.cpp
+++ b/src/RIGID/fix_rigid_nh.cpp
@@ -889,8 +889,8 @@ void FixRigidNH::nhc_press_integrate()
 }
 
 /* ----------------------------------------------------------------------
-   compute kinetic energy in the extended Hamiltonian
-   conserved quantity = sum of returned energy and potential energy
+   compute the energy added by the fix
+     the extended Hamiltonian = this energy + potential energy
 -----------------------------------------------------------------------*/
 
 double FixRigidNH::compute_scalar()

--- a/src/RIGID/fix_rigid_small.h
+++ b/src/RIGID/fix_rigid_small.h
@@ -65,6 +65,7 @@ class FixRigidSmall : public Fix {
   double extract_ke();
   double extract_erotational();
   double compute_scalar();
+  virtual double compute_vector(int);
   double memory_usage();
 
  protected:

--- a/src/RIGID/fix_rigid_small.h
+++ b/src/RIGID/fix_rigid_small.h
@@ -64,7 +64,7 @@ class FixRigidSmall : public Fix {
   void *extract(const char *, int &);
   double extract_ke();
   double extract_erotational();
-  double compute_scalar();
+  virtual double compute_scalar();
   virtual double compute_vector(int);
   double memory_usage();
 


### PR DESCRIPTION
**Summary**

This PR adds compute_vector() for fix rigid variants that allow monitoring temperatures of the rigid bodies, and redefine compute_scalar() for these fixes to be consistent with other fixes. Further tests are underway, and welcome from interested users.

**Related Issue(s)**

N/A

**Author(s)**

Trung Nguyen (Northwestern)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

compute_scalar() of the fix rigid variants change their output quantities, and may be deprecated in the future. These fix rigid  variants will also output a global vector of size 3 (for now) to monitor overall/translational/rotational temperatures of the bodies. Updates to the doc page are needed.

**Implementation Notes**

The translational and rotational DOFs are added as member variables. Most fix rigid variants inherit from FixRigid and FixRigidSmall, so most of the changes in this PR are isolated to these parent classes. 

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


