### PR TITLE
Add -std=c++11 to a number of machine makefiles for the traditional make build system

### DIFF
--- a/src/MAKE/MACHINES/Makefile.aarch64_g++_openmpi_armpl
+++ b/src/MAKE/MACHINES/Makefile.aarch64_g++_openmpi_armpl
@@ -8,12 +8,12 @@ SHELL = /bin/sh
 
 export OMPI_CXX = g++
 CC =		mpicxx
-CCFLAGS =	-O3 -march=native -mcpu=native
+CCFLAGS =	-O3 -march=native -mcpu=native -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-O
+LINKFLAGS =	-O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/MACHINES/Makefile.aarch64_g++_serial_armpl
+++ b/src/MAKE/MACHINES/Makefile.aarch64_g++_serial_armpl
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		g++
-CCFLAGS =	-O3 -march=native -mcpu=native
+CCFLAGS =	-O3 -march=native -mcpu=native -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		g++
-LINKFLAGS =	-O
+LINKFLAGS =	-O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/MACHINES/Makefile.cygwin
+++ b/src/MAKE/MACHINES/Makefile.cygwin
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-O
+CCFLAGS =	-O2  -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-O
+LINKFLAGS =	-O -std=c++11
 LIB =           
 SIZE =		size
 

--- a/src/MAKE/MACHINES/Makefile.mac
+++ b/src/MAKE/MACHINES/Makefile.mac
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		c++
-CCFLAGS =	-O
+CCFLAGS =	-O -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		c++
-LINKFLAGS =	-O
+LINKFLAGS =	-O -std=c++11
 LIB =           
 SIZE =		size
 

--- a/src/MAKE/MACHINES/Makefile.mac_mpi
+++ b/src/MAKE/MACHINES/Makefile.mac_mpi
@@ -8,12 +8,12 @@ SHELL = /bin/sh
 # unless additional compiler/linker flags or libraries needed for your machine
 
 CC =	 	/opt/local/bin/mpicxx-openmpi-mp
-CCFLAGS =	-O3 
+CCFLAGS =	-O3  -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		/opt/local/bin/mpicxx-openmpi-mp
-LINKFLAGS =	-O3
+LINKFLAGS =	-O3 -std=c++11
 LIB =           
 SIZE =		size
 

--- a/src/MAKE/MACHINES/Makefile.ubuntu
+++ b/src/MAKE/MACHINES/Makefile.ubuntu
@@ -11,12 +11,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpic++
-CCFLAGS =	-g -O3 # -Wunused
+CCFLAGS =	-g -O3  -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpic++
-LINKFLAGS =	-g -O3
+LINKFLAGS =	-g -O3 -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/MACHINES/Makefile.ubuntu_simple
+++ b/src/MAKE/MACHINES/Makefile.ubuntu_simple
@@ -10,12 +10,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpic++
-CCFLAGS =	-g -O3 # -Wunused
+CCFLAGS =	-g -O3  -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpic++
-LINKFLAGS =	-g -O3
+LINKFLAGS =	-g -O3 -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/Makefile.mpi
+++ b/src/MAKE/Makefile.mpi
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O3
+LINKFLAGS =	-g -O3 -std=c++11
 LIB =
 SIZE =		size
 

--- a/src/MAKE/Makefile.serial
+++ b/src/MAKE/Makefile.serial
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		g++
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		g++
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB =
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.g++_mpich
+++ b/src/MAKE/OPTIONS/Makefile.g++_mpich
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx -cxx=g++
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx -cxx=g++
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.g++_mpich_link
+++ b/src/MAKE/OPTIONS/Makefile.g++_mpich_link
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		g++
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		g++
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.g++_openmpi_link
+++ b/src/MAKE/OPTIONS/Makefile.g++_openmpi_link
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		g++
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		g++
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.g++_serial
+++ b/src/MAKE/OPTIONS/Makefile.g++_serial
@@ -6,13 +6,13 @@ SHELL = /bin/sh
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
 
-CC =		g++ -std=c++11
-CCFLAGS =	-g -O3
+CC =		g++
+CCFLAGS =	-g -O3 -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
-LINK =		g++ -std=c++11
-LINKFLAGS =	-g -O
+LINK =		g++
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.gpu
+++ b/src/MAKE/OPTIONS/Makefile.gpu
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3 
+CCFLAGS =	-g -O3 -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.icc_mpich
+++ b/src/MAKE/OPTIONS/Makefile.icc_mpich
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx -cxx=icc
-CCFLAGS =	-g -O3 -restrict
+CCFLAGS =	-g -O3 -restrict -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx -cxx=icc
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.icc_mpich_link
+++ b/src/MAKE/OPTIONS/Makefile.icc_mpich_link
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		icc
-CCFLAGS =	-g -O3 -restrict
+CCFLAGS =	-g -O3 -restrict -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		icc
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.icc_openmpi
+++ b/src/MAKE/OPTIONS/Makefile.icc_openmpi
@@ -8,12 +8,12 @@ SHELL = /bin/sh
 
 export OMPI_CXX = icc
 CC =		mpicxx
-CCFLAGS =	-g -O3 -restrict
+CCFLAGS =	-g -O3 -restrict -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.icc_openmpi_link
+++ b/src/MAKE/OPTIONS/Makefile.icc_openmpi_link
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		icc
-CCFLAGS =	-g -O3 -restrict
+CCFLAGS =	-g -O3 -restrict -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		icc
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.icc_serial
+++ b/src/MAKE/OPTIONS/Makefile.icc_serial
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		icc
-CCFLAGS =	-g -O3 -restrict
+CCFLAGS =	-g -O3 -restrict -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		icc
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.jpeg
+++ b/src/MAKE/OPTIONS/Makefile.jpeg
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3 
+CCFLAGS =	-g -O3  -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.omp
+++ b/src/MAKE/OPTIONS/Makefile.omp
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3 -restrict -fopenmp
+CCFLAGS =	-g -O3 -restrict -fopenmp -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O -fopenmp
+LINKFLAGS =	-g -O -fopenmp -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.opt
+++ b/src/MAKE/OPTIONS/Makefile.opt
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3 -restrict
+CCFLAGS =	-g -O3 -restrict -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/MAKE/OPTIONS/Makefile.png
+++ b/src/MAKE/OPTIONS/Makefile.png
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3 
+CCFLAGS =	-g -O3  -std=c++11
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O
+LINKFLAGS =	-g -O -std=c++11
 LIB = 
 SIZE =		size
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -260,12 +260,11 @@ uppercase_internal=$(if $1,$$(subst $(firstword $1),$(call uppercase_internal,$(
 uppercase=$(eval uppercase_RESULT:=$(call uppercase_internal,$(uppercase_TABLE),$1))$(uppercase_RESULT)
 
 PACKAGEUC = $(call uppercase,$(PACKAGE))
-PACKUSERUC = $(call uppercase,$(PACKUSER))
+PACKAGESORTED = $(sort $(PACKAGEUC))
 
 YESDIR = $(call uppercase,$(@:yes-%=%))
 NODIR  = $(call uppercase,$(@:no-%=%))
 LIBDIR = $(@:lib-%=%)
-LIBUSERDIR = $(@:lib-%=%)
 
 # List of all targets
 
@@ -332,7 +331,7 @@ lmpinstalledpkgs.h: $(SRC) $(INC)
 	@echo '#ifndef LMP_INSTALLED_PKGS_H' >  ${TMPNAME}.lmpinstalled
 	@echo '#define LMP_INSTALLED_PKGS_H' >> ${TMPNAME}.lmpinstalled
 	@echo 'const char * LAMMPS_NS::LAMMPS::installed_packages[] = {' >> ${TMPNAME}.lmpinstalled
-	@for p in $(PACKAGEUC) $(PACKUSERUC); do info=$$($(SHELL) Package.sh $$p installed); \
+	@for p in $(PACKAGEUC); do info=$$($(SHELL) Package.sh $$p installed); \
              [ -n "$$info" ] && echo "\"$$info\"" | sed -e 's/".*package \(.*\)"/"\1",/' >> ${TMPNAME}.lmpinstalled || :; done
 	@echo ' NULL };' >> ${TMPNAME}.lmpinstalled
 	@echo '#endif' >> ${TMPNAME}.lmpinstalled
@@ -469,7 +468,7 @@ tar:
 	@cd ..; tar cvzf src/$(ROOT)_src.tar.gz \
 	  src/Make* src/Package.sh src/Depend.sh src/Install.sh src/Fetch.sh \
 	  src/MAKE src/DEPEND src/*.cpp src/*.h src/STUBS \
-	  $(patsubst %,src/%,$(PACKAGEUC)) $(patsubst %,src/%,$(PACKUSERUC)) \
+	  $(patsubst %,src/%,$(PACKAGEUC)) \
           --exclude=*/.svn
 	@cd STUBS; $(MAKE)
 	@echo "Created $(ROOT)_src.tar.gz"
@@ -502,9 +501,7 @@ format-tests:
 # Package management
 
 package:
-	@echo 'Standard packages:' $(PACKAGE)
-	@echo ''
-	@echo 'User-contributed packages:' $(PACKUSER)
+	@echo 'Available packages:' $(PACKAGE)
 	@echo ''
 	@echo 'Packages that need system libraries:' $(PACKSYS)
 	@echo ''
@@ -615,9 +612,6 @@ lib-%:
 	@if [ -e ../lib/$(LIBDIR)/Install.py ]; then \
 	  echo "Installing lib $(@:lib-%=%)"; \
 	  ( cd ../lib/$(LIBDIR); $(PYTHON) Install.py $(args) ); \
-	elif [ -e ../lib/$(LIBUSERDIR)/Install.py ]; then \
-	  echo "Installing lib $(@:lib-%=%)"; \
-	  ( cd ../lib/$(LIBUSERDIR); $(PYTHON) Install.py $(args) ); \
 	else \
 	  echo "Install script for lib $(@:lib-%=%) does not exist"; \
 	fi; touch main.cpp
@@ -630,28 +624,21 @@ lib-%:
 # purge = delete obsolete and auto-generated package files
 
 package-status ps:
-	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p status; done
-	@echo ''
-	@for p in $(PACKUSERUC); do $(SHELL) Package.sh $$p status; done
+	@for p in $(PACKAGESORTED); do $(SHELL) Package.sh $$p status; done
 
 package-installed pi:
-	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p installed; done
-	@for p in $(PACKUSERUC); do $(SHELL) Package.sh $$p installed; done
+	@for p in $(PACKAGESORTED); do $(SHELL) Package.sh $$p installed; done
 
 package-update pu: purge
+	@echo 'Updating installed packages:'
 	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p update; done
-	@echo ''
-	@for p in $(PACKUSERUC); do $(SHELL) Package.sh $$p update; done
 
 package-overwrite: purge
-	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p overwrite; done
-	@echo ''
-	@for p in $(PACKUSERUC); do $(SHELL) Package.sh $$p overwrite; done
+	@echo 'Overwriting installed packages:'
+	@for p in $(PACKAGESORTED); do $(SHELL) Package.sh $$p overwrite; done
 
 package-diff pd:
-	@for p in $(PACKAGEUC); do $(SHELL) Package.sh $$p diff; done
-	@echo ''
-	@for p in $(PACKUSERUC); do $(SHELL) Package.sh $$p diff; done
+	@for p in $(PACKAGESORTED); do $(SHELL) Package.sh $$p diff; done
 
 purge: Purge.list
 	@echo 'Purging obsolete and auto-generated source files'

--- a/src/Package.sh
+++ b/src/Package.sh
@@ -45,9 +45,8 @@ elif (test $2 = "installed") then
 # perform a re-install, but only if the package is already installed
 
 elif (test $2 = "update") then
-  echo "Updating src files from $1 package files"
   if (test $installed = 1) then
-    echo "  updating package $1"
+     echo "Updating src files from $1 package files"
     if (test -e Install.sh) then
       /bin/sh Install.sh 2
     else
@@ -55,16 +54,14 @@ elif (test $2 = "update") then
     fi
     cd ..
     /bin/sh Depend.sh $1
-  else
-    echo "  $1 package is not installed"
   fi
 
 # overwrite, only if installed
 # overwrite package file with src file, if the two are different
 
 elif (test $2 = "overwrite") then
-  echo "Overwriting $1 package files with src files"
   if (test $installed = 1) then
+     echo "Overwriting $1 package files with src files"
     for file in *.cpp *.h; do
       if (test ! -e ../$file) then
         continue


### PR DESCRIPTION
**Summary**

As discussed in issue #1961 there are too many machines and setups that require providing an explicit flag to enable C++11 standard compliance. This adds the flag to a selected number of machine makefiles for use with the traditional make procedure to compile LAMMPS. CMake based compilations are not affected.


**Related Issue(s)**

Fixes #1961 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No. We assume that more people will benefit from this change and will not have to edit makefiles for this than those that have an incompatible compiler.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
