### PR TITLE
Avoid assertions in PythonCapabilities check when using external KOKKOS

### DIFF
--- a/unittest/python/python-capabilities.py
+++ b/unittest/python/python-capabilities.py
@@ -166,9 +166,9 @@ class PythonCapabilities(unittest.TestCase):
                  self.assertIn('single',settings['GPU']['precision'])
 
         if self.cmake_cache['PKG_KOKKOS']:
-            if self.cmake_cache['Kokkos_ENABLE_OPENMP']:
+            if 'Kokkos_ENABLE_OPENMP' in self.cmake_cache and self.cmake_cache['Kokkos_ENABLE_OPENMP']:
                 self.assertIn('openmp',settings['KOKKOS']['api'])
-            if self.cmake_cache['Kokkos_ENABLE_SERIAL']:
+            if 'Kokkos_ENABLE_SERIAL' in self.cmake_cache and self.cmake_cache['Kokkos_ENABLE_SERIAL']:
                 self.assertIn('serial',settings['KOKKOS']['api'])
             self.assertIn('double',settings['KOKKOS']['precision'])
 


### PR DESCRIPTION
**Summary**

When an external KOKKOS installation is used with CMake, the CMakeCache doesn't contain all of the `Kokkos_` configuration variables. Since the PythonCapabilities check uses these variables for making assertions, this PR disables them in case that information is not available.

**Related Issue(s)**

Closes #2974

**Author(s)**

@rbberger (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


