### PR TITLE
Update .gitignore file in /src

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -883,8 +883,6 @@
 /fix_widom.cpp
 /fix_widom.h
 /gpu_extra.h
-/gridcomm.cpp
-/gridcomm.h
 /group_ndx.cpp
 /group_ndx.h
 /gz_file_writer.cpp

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -205,7 +205,6 @@
 
 /plugin.cpp
 /plugin.h
-/lammpsplugin.h
 
 /atom_vec_spin.cpp
 /atom_vec_spin.h

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -27,6 +27,9 @@
 /*_ssa.h
 /*_ssa.cpp
 
+!accelerator_kokkos.h
+!accelerator_omp.h
+
 /fix_mdi_engine.cpp
 /fix_mdi_engine.h
 /library_mdi.cpp

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -265,8 +265,6 @@
 /fix_drag.h
 /fix_numdiff.cpp
 /fix_numdiff.h
-/fix_nve_noforce.cpp
-/fix_nve_noforce.h
 /fix_spring_rg.cpp
 /fix_spring_rg.h
 /fix_temp_csld.cpp
@@ -367,8 +365,6 @@
 /atom_vec_dpd.h
 /atom_vec_electron.cpp
 /atom_vec_electron.h
-/atom_vec_ellipsoid.cpp
-/atom_vec_ellipsoid.h
 /atom_vec_full.cpp
 /atom_vec_full.h
 /atom_vec_full_hars.cpp
@@ -535,8 +531,6 @@
 /dihedral_harmonic.h
 /dihedral_helix.cpp
 /dihedral_helix.h
-/dihedral_hybrid.cpp
-/dihedral_hybrid.h
 /dihedral_multi_harmonic.cpp
 /dihedral_multi_harmonic.h
 /dihedral_nharmonic.cpp
@@ -907,8 +901,6 @@
 /improper_fourier.h
 /improper_harmonic.cpp
 /improper_harmonic.h
-/improper_hybrid.cpp
-/improper_hybrid.h
 /improper_inversion_harmonic.cpp
 /improper_inversion_harmonic.h
 /improper_ring.cpp
@@ -1330,8 +1322,6 @@
 /thr_data.h
 /verlet_split.cpp
 /verlet_split.h
-/write_dump.cpp
-/write_dump.h
 /xdr_compat.cpp
 /xdr_compat.h
 /zstd_file_writer.cpp


### PR DESCRIPTION
**Summary**

The `/src/.gitignore` file is out of date. Some files were moved out of packages directly into `/src` but are still being ignored, which can lead to weird behavior (i.e. files disappearing).

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Evan Weinberg (NVIDIA), @weinbe2 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes