### PR TITLE
Fix Brownian noise scale factor

### DIFF
--- a/src/BROWNIAN/fix_brownian.cpp
+++ b/src/BROWNIAN/fix_brownian.cpp
@@ -45,7 +45,7 @@ void FixBrownian::init()
 {
   FixBrownianBase::init();
   g1 /= gamma_t;
-  g2 *= sqrt(gamma_t);
+  g2 /= sqrt(gamma_t);
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
**Summary**

This corrects the scaling factor of the white noise term in `fix/brownian`. Previously, this factor was:
```
sqrt(2 kT gamma_t/dt)
```
but it should be (https://docs.lammps.org/fix_brownian.html):
```
sqrt(2 kT /(gamma_t*dt))
```

**Related Issue(s)**

Fixes #2948
Fixes #2970 

**Author(s)**

Michael P. Howard, Auburn University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.

**Implementation Notes**

I reran the reproducer in #2970 and verified I got the expected result. I looked quickly at `fix/brownian/sphere` and found that `g2` was computed in the same way as my correction, so I believe that one is OK.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


