### PR TITLE
Revert some changes in 7960a2d

### DIFF
--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.h
@@ -30,6 +30,7 @@ FixStyle(qeq/reax/kk/host,FixQEqReaxFFKokkos<LMPHostType>);
 #include "kokkos_type.h"
 #include "neigh_list.h"
 #include "neigh_list_kokkos.h"
+#include "kokkos_base.h"
 
 namespace LAMMPS_NS {
 
@@ -41,7 +42,7 @@ struct TagFixQEqReaxFFPackForwardComm {};
 struct TagFixQEqReaxFFUnpackForwardComm {};
 
 template<class DeviceType>
-class FixQEqReaxFFKokkos : public FixQEqReaxFF {
+class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
  public:
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;


### PR DESCRIPTION
**Summary**

Some changes in 7960a2d are causing a segmentation fault for Kokkos ReaxFF on GPUs (`-pk kokkos comm device/host`). The inheritance from the `KokkosBase` class should not have been removed from `fix qeq/reaxff/kk` since it is needed when packing/unpacking communication buffers on the device.

**Related Issue(s)**

#2997

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes