### PR TITLE
Portability improvements

### DIFF
--- a/doc/src/Developer_platform.rst
+++ b/doc/src/Developer_platform.rst
@@ -118,6 +118,9 @@ Environment variable functions
 .. doxygenfunction:: putenv
    :project: progguide
 
+.. doxygenfunction:: unsetenv
+   :project: progguide
+
 .. doxygenfunction:: list_pathenv
    :project: progguide
 

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -446,11 +446,11 @@ int platform::putenv(const std::string &vardef)
 
   auto found = vardef.find_first_of('=');
 #ifdef _WIN32
-  // must assign a value to variable with _putenv()
+  // must assign a value to variable with _putenv_s()
   if (found == std::string::npos)
-    return _putenv(utils::strdup(vardef + "=1"));
+    return _putenv_s(vardef.c_str(), "1");
   else
-    return _putenv(utils::strdup(vardef));
+    return _putenv_s(vardef.substr(0, found).c_str(), vardef.substr(found+1).c_str());
 #else
   if (found == std::string::npos)
     return setenv(vardef.c_str(), "", 1);
@@ -458,6 +458,24 @@ int platform::putenv(const std::string &vardef)
     return setenv(vardef.substr(0, found).c_str(), vardef.substr(found + 1).c_str(), 1);
 #endif
   return -1;
+}
+
+/* ----------------------------------------------------------------------
+   unset environment variable
+------------------------------------------------------------------------- */
+
+int platform::unsetenv(const std::string &variable)
+{
+  if (variable.size() == 0) return -1;
+#ifdef _WIN32
+  // emulate POSIX semantics by returning -1 on trying to unset non-existing variable
+  const char *ptr = getenv(variable.c_str());
+  if (!ptr) return -1;
+  // empty _putenv_s() definition deletes variable
+  return _putenv_s(variable.c_str(),"");
+#else
+  return ::unsetenv(variable.c_str());
+#endif
 }
 
 /* ----------------------------------------------------------------------

--- a/src/platform.h
+++ b/src/platform.h
@@ -125,6 +125,13 @@ namespace platform {
 
   int putenv(const std::string &vardef);
 
+  /*! Delete variable from the environment
+   *
+   * \param  variable  variable name
+   * \return -1 if failure otherwise 0 */
+
+  int unsetenv(const std::string &variable);
+
   /*! Get list of entries in a path environment variable
    *
    * This provides a list of strings of the entries in an environment

--- a/unittest/commands/test_simple_commands.cpp
+++ b/unittest/commands/test_simple_commands.cpp
@@ -384,7 +384,12 @@ TEST_F(SimpleCommandsTest, Units)
 #if defined(LMP_PLUGIN)
 TEST_F(SimpleCommandsTest, Plugin)
 {
-    std::string loadfmt("plugin load {}plugin.so");
+    const char *bindir = getenv("LAMMPS_PLUGIN_BIN_DIR");
+    const char *config = getenv("CMAKE_CONFIG_TYPE");
+    if (!bindir) GTEST_SKIP();
+    std::string loadfmt = platform::path_join("plugin load ", bindir);
+    if (config) loadfmt = platform::path_join(loadfmt, config);
+    loadfmt = platform::path_join(loadfmt, "{}plugin.so");
     ::testing::internal::CaptureStdout();
     lmp->input->one(fmt::format(loadfmt, "hello"));
     auto text = ::testing::internal::GetCapturedStdout();
@@ -395,7 +400,7 @@ TEST_F(SimpleCommandsTest, Plugin)
     lmp->input->one(fmt::format(loadfmt, "xxx"));
     text = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << text;
-    ASSERT_THAT(text, MatchesRegex(".*Open of file xxx.* failed.*"));
+    ASSERT_THAT(text, MatchesRegex(".*Open of file .*xxx.* failed.*"));
 
     ::testing::internal::CaptureStdout();
     lmp->input->one(fmt::format(loadfmt, "nve2"));
@@ -426,8 +431,7 @@ TEST_F(SimpleCommandsTest, Plugin)
     lmp->input->one("plugin unload pair nve2");
     text = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << text;
-    ASSERT_THAT(text, MatchesRegex(".*Ignoring unload of pair style nve2: "
-                                   "not loaded from a plugin.*"));
+    ASSERT_THAT(text, MatchesRegex(".*Ignoring unload of pair style nve2: not from a plugin.*"));
 
     ::testing::internal::CaptureStdout();
     lmp->input->one("plugin unload fix nve2");
@@ -439,8 +443,7 @@ TEST_F(SimpleCommandsTest, Plugin)
     lmp->input->one("plugin unload fix nve");
     text = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << text;
-    ASSERT_THAT(text, MatchesRegex(".*Ignoring unload of fix style nve: "
-                                   "not loaded from a plugin.*"));
+    ASSERT_THAT(text, MatchesRegex(".*Ignoring unload of fix style nve: not from a plugin.*"));
 
     ::testing::internal::CaptureStdout();
     lmp->input->one("plugin list");

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -59,8 +59,8 @@ protected:
     void TearDown() override
     {
         LAMMPSTest::TearDown();
-        unlink("test_variable.file");
-        unlink("test_variable.atomfile");
+        platform::unlink("test_variable.file");
+        platform::unlink("test_variable.atomfile");
     }
 
     void atomic_system()
@@ -165,7 +165,7 @@ TEST_F(VariableTest, CreateDelete)
     fputs(" ", fp);
     fclose(fp);
     ASSERT_THAT(variable->retrieve("file"), StrEq("1"));
-    unlink("MYFILE");
+    platform::unlink("MYFILE");
     ASSERT_THAT(variable->retrieve("file"), StrEq("0"));
 
     BEGIN_HIDE_OUTPUT();

--- a/unittest/cplusplus/test_lammps_class.cpp
+++ b/unittest/cplusplus/test_lammps_class.cpp
@@ -363,11 +363,7 @@ TEST(LAMMPS_init, NoOpenMP)
     FILE *fp = fopen("in.lammps_class_noomp", "w");
     fputs("\n", fp);
     fclose(fp);
-#if defined(__WIN32)
-    _putenv("OMP_NUM_THREADS");
-#else
-    unsetenv("OMP_NUM_THREADS");
-#endif
+    platform::unsetenv("OMP_NUM_THREADS");
 
     const char *args[] = {"LAMMPS_init", "-in", "in.lammps_class_noomp", "-log", "none", "-nocite"};
     char **argv        = (char **)args;

--- a/unittest/force-styles/test_error_stats.cpp
+++ b/unittest/force-styles/test_error_stats.cpp
@@ -9,6 +9,11 @@
 #include "fmtlib_format.cpp"
 #include "fmtlib_os.cpp"
 
+// Windows may define this as a macro
+#if defined(max)
+#undef max
+#endif
+
 TEST(ErrorStats, test)
 {
     ErrorStats stats;

--- a/unittest/force-styles/tests/atomic-pair-eim.yaml
+++ b/unittest/force-styles/tests/atomic-pair-eim.yaml
@@ -1,7 +1,7 @@
 ---
 lammps_version: 10 Feb 2021
 date_generated: Fri Feb 26 23:09:02 2021
-epsilon: 1e-11
+epsilon: 2e-11
 prerequisites: ! |
   pair eim
 pre_commands: ! ""

--- a/unittest/force-styles/tests/manybody-pair-meam.yaml
+++ b/unittest/force-styles/tests/manybody-pair-meam.yaml
@@ -1,7 +1,7 @@
 ---
 lammps_version: 10 Feb 2021
 date_generated: Fri Feb 26 23:09:15 2021
-epsilon: 7.5e-12
+epsilon: 1e-10
 prerequisites: ! |
   pair meam
 pre_commands: ! |

--- a/unittest/formats/test_text_file_reader.cpp
+++ b/unittest/formats/test_text_file_reader.cpp
@@ -35,8 +35,8 @@ class TextFileReaderTest : public ::testing::Test {
 protected:
     void TearDown() override
     {
-        unlink("text_reader_one.file");
-        unlink("text_reader_two.file");
+        platform::unlink("text_reader_one.file");
+        platform::unlink("text_reader_two.file");
     }
 
     void test_files()
@@ -73,7 +73,7 @@ TEST_F(TextFileReaderTest, permissions)
     chmod("text_reader_noperms.file", 0);
     ASSERT_THROW({ TextFileReader reader("text_reader_noperms.file", "test"); },
                  FileReaderException);
-    unlink("text_reader_noperms.file");
+    platform::unlink("text_reader_noperms.file");
 }
 
 TEST_F(TextFileReaderTest, nofp)

--- a/unittest/formats/test_text_file_reader.cpp
+++ b/unittest/formats/test_text_file_reader.cpp
@@ -65,9 +65,14 @@ TEST_F(TextFileReaderTest, nofile)
                  FileReaderException);
 }
 
+// this test cannot work on windows due to its non unix-like permission system
+
+#if !defined(_WIN32)
 TEST_F(TextFileReaderTest, permissions)
 {
+    platform::unlink("text_reader_noperms.file");
     FILE *fp = fopen("text_reader_noperms.file", "w");
+    ASSERT_NE(fp,nullptr);
     fputs("word\n", fp);
     fclose(fp);
     chmod("text_reader_noperms.file", 0);
@@ -75,6 +80,7 @@ TEST_F(TextFileReaderTest, permissions)
                  FileReaderException);
     platform::unlink("text_reader_noperms.file");
 }
+#endif
 
 TEST_F(TextFileReaderTest, nofp)
 {

--- a/unittest/utils/test_math_eigen_impl.cpp
+++ b/unittest/utils/test_math_eigen_impl.cpp
@@ -48,7 +48,7 @@ inline static bool SimilarVec(Vector a, Vector b, int n, Scalar eps = 1.0e-06,
                               Scalar ratio = 1.0e-06, Scalar ratio_denom = 1.0)
 {
     for (int i = 0; i < n; i++)
-        if (not Similar(a[i], b[i], eps, ratio, ratio_denom)) return false;
+        if (! Similar(a[i], b[i], eps, ratio, ratio_denom)) return false;
     return true;
 }
 
@@ -61,7 +61,7 @@ inline static bool SimilarVecUnsigned(Vector a, Vector b, int n, Scalar eps = 1.
         return true;
     else {
         for (int i = 0; i < n; i++)
-            if (not Similar(a[i], -b[i], eps, ratio, ratio_denom)) return false;
+            if (! Similar(a[i], -b[i], eps, ratio, ratio_denom)) return false;
         return true;
     }
 }

--- a/unittest/utils/test_platform.cpp
+++ b/unittest/utils/test_platform.cpp
@@ -37,7 +37,7 @@ TEST(Platform, clock)
     ASSERT_GT(ct_used, 1e-4);
 }
 
-TEST(Platform, putenv)
+TEST(Platform, putenv_unsetenv)
 {
     const char *var = getenv("UNITTEST_VAR1");
     ASSERT_EQ(var, nullptr);
@@ -65,6 +65,14 @@ TEST(Platform, putenv)
     ASSERT_THAT(var, StrEq("one=two"));
 
     ASSERT_EQ(platform::putenv(""), -1);
+
+    ASSERT_EQ(platform::unsetenv(""), -1);
+    ASSERT_EQ(platform::unsetenv("UNITTEST_VAR3=two"), -1);
+    var    = getenv("UNITTEST_VAR1");
+    ASSERT_NE(var, nullptr);
+    ASSERT_EQ(platform::unsetenv("UNITTEST_VAR1"), 0);
+    var    = getenv("UNITTEST_VAR1");
+    ASSERT_EQ(var, nullptr);
 }
 
 TEST(Platform, list_pathenv)


### PR DESCRIPTION
**Summary**

This PR implements some portability improvements required to compile the unit test tree natively on Windows

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

This (still) will only works if CMake is used with a single config generator like GNU make. The default build tools of Visual Studio (native or ninja) require multi-config support which is being worked on in PR #2940. This PR has the changes that were needed in the process but are unrelated to multi-config support.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
