### PR TITLE
Dynamic group membership based on orientorder compute

### DIFF
--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -233,29 +233,29 @@ int ComputeClusterAtom::pack_forward_comm(int n, int *list, double *buf,
     double **x = atom->x;
     if (pbc_flag == 0) {
       for (i = 0; i < n; i++) {
-	j = list[i];
-	buf[m++] = x[j][0];
-	buf[m++] = x[j][1];
-	buf[m++] = x[j][2];
+        j = list[i];
+        buf[m++] = x[j][0];
+        buf[m++] = x[j][1];
+        buf[m++] = x[j][2];
       }
     } else {
       if (domain->triclinic == 0) {
-	dx = pbc[0]*domain->xprd;
-	dy = pbc[1]*domain->yprd;
-	dz = pbc[2]*domain->zprd;
+        dx = pbc[0]*domain->xprd;
+        dy = pbc[1]*domain->yprd;
+        dz = pbc[2]*domain->zprd;
       } else {
-	dx = pbc[0]*domain->xprd + pbc[5]*domain->xy + pbc[4]*domain->xz;
-	dy = pbc[1]*domain->yprd + pbc[3]*domain->yz;
-	dz = pbc[2]*domain->zprd;
+        dx = pbc[0]*domain->xprd + pbc[5]*domain->xy + pbc[4]*domain->xz;
+        dy = pbc[1]*domain->yprd + pbc[3]*domain->yz;
+        dz = pbc[2]*domain->zprd;
       }
       for (i = 0; i < n; i++) {
-	j = list[i];
-	buf[m++] = x[j][0] + dx;
-	buf[m++] = x[j][1] + dy;
-	buf[m++] = x[j][2] + dz;
+        j = list[i];
+        buf[m++] = x[j][0] + dx;
+        buf[m++] = x[j][1] + dy;
+        buf[m++] = x[j][2] + dz;
       }
     }  
-
+    
   }
 
   return m;

--- a/src/compute_orientorder_atom.cpp
+++ b/src/compute_orientorder_atom.cpp
@@ -362,26 +362,26 @@ int ComputeOrientOrderAtom::pack_forward_comm(int n, int *list, double *buf,
   
     if (pbc_flag == 0) {
       for (i = 0; i < n; i++) {
-	j = list[i];
-	buf[m++] = x[j][0];
-	buf[m++] = x[j][1];
-	buf[m++] = x[j][2];
+        j = list[i];
+        buf[m++] = x[j][0];
+        buf[m++] = x[j][1];
+        buf[m++] = x[j][2];
       }
     } else {
       if (domain->triclinic == 0) {
-	dx = pbc[0]*domain->xprd;
-	dy = pbc[1]*domain->yprd;
-	dz = pbc[2]*domain->zprd;
+        dx = pbc[0]*domain->xprd;
+        dy = pbc[1]*domain->yprd;
+        dz = pbc[2]*domain->zprd;
       } else {
-	dx = pbc[0]*domain->xprd + pbc[5]*domain->xy + pbc[4]*domain->xz;
-	dy = pbc[1]*domain->yprd + pbc[3]*domain->yz;
-	dz = pbc[2]*domain->zprd;
+        dx = pbc[0]*domain->xprd + pbc[5]*domain->xy + pbc[4]*domain->xz;
+        dy = pbc[1]*domain->yprd + pbc[3]*domain->yz;
+        dz = pbc[2]*domain->zprd;
       }
       for (i = 0; i < n; i++) {
-	j = list[i];
-	buf[m++] = x[j][0] + dx;
-	buf[m++] = x[j][1] + dy;
-	buf[m++] = x[j][2] + dz;
+        j = list[i];
+        buf[m++] = x[j][0] + dx;
+        buf[m++] = x[j][1] + dy;
+        buf[m++] = x[j][2] + dz;
       }
     }
   }

--- a/src/compute_orientorder_atom.h
+++ b/src/compute_orientorder_atom.h
@@ -31,6 +31,8 @@ class ComputeOrientOrderAtom : public Compute {
   virtual void init();
   void init_list(int, class NeighList *);
   virtual void compute_peratom();
+  int pack_forward_comm(int, int *, double *, int, int *);
+  void unpack_forward_comm(int, int, double *);
   double memory_usage();
   double cutsq;
   int iqlcomp, qlcomp, qlcompflag, wlflag, wlhatflag;
@@ -38,7 +40,7 @@ class ComputeOrientOrderAtom : public Compute {
   int nqlist;
 
  protected:
-  int nmax, maxneigh, ncol, nnn;
+  int nmax,commflag,maxneigh,ncol,nnn;
   class NeighList *list;
   double *distsq;
   int *nearest;


### PR DESCRIPTION
**Summary**

This follows on from a post to the mailing list

https://sourceforge.net/p/lammps/mailman/message/37244072/

and is an implementation of the fix suggested by @akohlmey in his response. Apologies it has taken me this long to share this. 

In brief - when using compute/orientorder to determine connectivity and hence coordination, dynamic group membership was out of sync with the atom style variable used to determine inclusion in that group.  

**Related Issue(s)**

None I'm aware of.

**Author(s)**

Just myself, although I can't claim much credit here! Just adapting the relevant code sections from other fixes as suggested and then testing.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Restarting from previous versions will produce different group membership at the first step is some cases.

**Implementation Notes**

Code in cluster/atom which ensures per atom quantities are updated for ghost atoms before calculation of dynamic group membership was adapted to orientorder/atom and cluster/atom. 

If I've understood correctly (no guarantee of that) then cluster/atom was also missing application of PBCs in pack_forward_comm. This needed to be rectified to give the desired behaviour of c_nsolid1 matching v_nsolid2 in the enclosed test case.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

[in.test.txt](https://github.com/lammps/lammps/files/7476952/in.test.txt) : Test case demonstrating the original inconsistency which this PR fixes.



