### PR TITLE
Add dx, dy and dz computes to compute bond/local and property/local

### DIFF
--- a/doc/src/compute_bond_local.rst
+++ b/doc/src/compute_bond_local.rst
@@ -13,7 +13,7 @@ Syntax
 * ID, group-ID are documented in :doc:`compute <compute>` command
 * bond/local = style name of this compute command
 * one or more values may be appended
-* value = *dist* or *engpot* or *force* or *fx* or *fy* or *fz* or *engvib* or *engrot* or *engtrans* or *omega* or *velvib* or *v_name*
+* value = *dist* or *dx* or *dy* or *dz* or *engpot* or *force* or *fx* or *fy* or *fz* or *engvib* or *engrot* or *engtrans* or *omega* or *velvib* or *v_name*
 
 .. parsed-literal::
 
@@ -21,6 +21,7 @@ Syntax
      *engpot* = bond potential energy
      *force* = bond force
 
+     *dx*,\ *dy*,\ *dz* = components of pairwise distance
      *fx*,\ *fy*,\ *fz* = components of bond force
      *engvib* = bond kinetic energy of vibration
      *engrot* = bond kinetic energy of rotation
@@ -63,6 +64,9 @@ whether the 2 atoms represent a simple diatomic molecule, or are part
 of some larger molecule.
 
 The value *dist* is the current length of the bond.
+The values *dx*, *dy*, and *dz* are the xyz components of the
+*distance* between the pair of atoms. This value is always the 
+distance from the atom of lower to the one of higher id.
 
 The value *engpot* is the potential energy for the bond,
 based on the current separation of the pair of atoms in the bond.

--- a/doc/src/compute_bond_local.rst
+++ b/doc/src/compute_bond_local.rst
@@ -66,7 +66,7 @@ of some larger molecule.
 The value *dist* is the current length of the bond.
 The values *dx*, *dy*, and *dz* are the xyz components of the
 *distance* between the pair of atoms. This value is always the 
-distance from the atom of lower to the one of higher id.
+distance from the atom of lower to the one with the higher id.
 
 The value *engpot* is the potential energy for the bond,
 based on the current separation of the pair of atoms in the bond.

--- a/doc/src/compute_pair_local.rst
+++ b/doc/src/compute_pair_local.rst
@@ -13,11 +13,12 @@ Syntax
 * ID, group-ID are documented in :doc:`compute <compute>` command
 * pair/local = style name of this compute command
 * one or more values may be appended
-* value = *dist* or *eng* or *force* or *fx* or *fy* or *fz* or *pN*
+* value = *dist* or *dx* or *dy* or *dz* or *eng* or *force* or *fx* or *fy* or *fz* or *pN*
 
   .. parsed-literal::
 
        *dist* = pairwise distance
+       *dx*,\ *dy*,\ *dz* = components of pairwise distance
        *eng* = pairwise energy
        *force* = pairwise force
        *fx*,\ *fy*,\ *fz* = components of pairwise force
@@ -56,6 +57,9 @@ force cutoff distance for that interaction, as defined by the
 commands.
 
 The value *dist* is the distance between the pair of atoms.
+The values *dx*, *dy*, and *dz* are the xyz components of the
+*distance* between the pair of atoms. This value can be inconsistent
+due to changing interactions and neighbor list orders.
 
 The value *eng* is the interaction energy for the pair of atoms.
 
@@ -89,10 +93,10 @@ from the second of the two sub-styles.  If the referenced *pN*
 is not computed for the specific pairwise interaction (based on
 atom types), then the output will be 0.0.
 
-The value *dist* will be in distance :doc:`units <units>`.  The value
-*eng* will be in energy :doc:`units <units>`.  The values *force*, *fx*,
-*fy*, and *fz* will be in force :doc:`units <units>`.  The values *pN*
-will be in whatever units the pair style defines.
+The value *dist*, *dx*, *dy* and *dz* will be in distance :doc:`units <units>`.  
+The value *eng* will be in energy :doc:`units <units>`.  
+The values *force*, *fx*, *fy*, and *fz* will be in force :doc:`units <units>`.  
+The values *pN* will be in whatever units the pair style defines.
 
 The optional *cutoff* keyword determines how the force cutoff distance
 for an interaction is determined.  For the default setting of *type*,

--- a/doc/src/compute_pair_local.rst
+++ b/doc/src/compute_pair_local.rst
@@ -58,8 +58,8 @@ commands.
 
 The value *dist* is the distance between the pair of atoms.
 The values *dx*, *dy*, and *dz* are the xyz components of the
-*distance* between the pair of atoms. This value can be inconsistent
-due to changing interactions and neighbor list orders.
+*distance* between the pair of atoms. This value is always the 
+distance from the atom of lower to the one with the higher id.
 
 The value *eng* is the interaction energy for the pair of atoms.
 

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -388,7 +388,7 @@ int ComputeBondLocal::compute_bonds(int flag)
         }
 
         // to make sure dx, dy and dz are always from the lower to the higher id
-        double directionCorrection = atom1 > atom2 ? -1.0 : 1.0;
+        double directionCorrection = tag[atom1] > tag[atom2] ? -1.0 : 1.0;
 
         for (int n = 0; n < nvalues; n++) {
           switch (bstyle[n]) {

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -34,7 +34,7 @@ using namespace LAMMPS_NS;
 #define DELTA 10000
 #define EPSILON 1.0e-12
 
-enum{DIST,VELVIB,OMEGA,ENGTRANS,ENGVIB,ENGROT,ENGPOT,FORCE,FX,FY,FZ,VARIABLE};
+enum{DIST,DX,DY,DZ,VELVIB,OMEGA,ENGTRANS,ENGVIB,ENGROT,ENGPOT,FORCE,FX,FY,FZ,VARIABLE};
 
 /* ---------------------------------------------------------------------- */
 
@@ -63,6 +63,9 @@ ComputeBondLocal::ComputeBondLocal(LAMMPS *lmp, int narg, char **arg) :
   int iarg;
   for (iarg = 3; iarg < narg; iarg++) {
     if (strcmp(arg[iarg],"dist") == 0) bstyle[nvalues++] = DIST;
+    else if (strcmp(arg[iarg],"dx") == 0) bstyle[nvalues++] = DX;
+    else if (strcmp(arg[iarg],"dy") == 0) bstyle[nvalues++] = DY;
+    else if (strcmp(arg[iarg],"dz") == 0) bstyle[nvalues++] = DZ;
     else if (strcmp(arg[iarg],"engpot") == 0) bstyle[nvalues++] = ENGPOT;
     else if (strcmp(arg[iarg],"force") == 0) bstyle[nvalues++] = FORCE;
     else if (strcmp(arg[iarg],"fx") == 0) bstyle[nvalues++] = FX;
@@ -384,10 +387,22 @@ int ComputeBondLocal::compute_bonds(int flag)
           if (dstr) input->variable->internal_set(dvar,sqrt(rsq));
         }
 
+        // to make sure dx, dy and dz are always from the lower to the higher id
+        double directionCorrection = atom1 > atom2 ? -1.0 : 1.0;
+
         for (int n = 0; n < nvalues; n++) {
           switch (bstyle[n]) {
           case DIST:
             ptr[n] = sqrt(rsq);
+            break;
+          case DX:
+            ptr[n] = dx*directionCorrection;
+            break;
+          case DY:
+            ptr[n] = dy*directionCorrection;
+            break;
+          case DZ:
+            ptr[n] = dz*directionCorrection;
             break;
           case ENGPOT:
             ptr[n] = engpot;

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -268,7 +268,7 @@ int ComputePairLocal::compute_pairs(int flag)
         else ptr = alocal[m];
 
         // to make sure dx, dy and dz are always from the lower to the higher id
-        double directionCorrection = i > j ? -1.0 : 1.0;
+        double directionCorrection = itag > jtag ? -1.0 : 1.0;
 
         for (n = 0; n < nvalues; n++) {
           switch (pstyle[n]) {

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -31,7 +31,7 @@ using namespace LAMMPS_NS;
 
 #define DELTA 10000
 
-enum{DIST,ENG,FORCE,FX,FY,FZ,PN};
+enum{DIST,ENG,FORCE,FX,FY,FZ,PN,DX,DY,DZ};
 enum{TYPE,RADIUS};
 
 /* ---------------------------------------------------------------------- */
@@ -56,6 +56,9 @@ ComputePairLocal::ComputePairLocal(LAMMPS *lmp, int narg, char **arg) :
     else if (strcmp(arg[iarg],"fx") == 0) pstyle[nvalues++] = FX;
     else if (strcmp(arg[iarg],"fy") == 0) pstyle[nvalues++] = FY;
     else if (strcmp(arg[iarg],"fz") == 0) pstyle[nvalues++] = FZ;
+    else if (strcmp(arg[iarg],"dx") == 0) pstyle[nvalues++] = DX;
+    else if (strcmp(arg[iarg],"dy") == 0) pstyle[nvalues++] = DY;
+    else if (strcmp(arg[iarg],"dz") == 0) pstyle[nvalues++] = DZ;
     else if (arg[iarg][0] == 'p') {
       int n = atoi(&arg[iarg][1]);
       if (n <= 0) error->all(FLERR,
@@ -92,7 +95,7 @@ ComputePairLocal::ComputePairLocal(LAMMPS *lmp, int narg, char **arg) :
 
   singleflag = 0;
   for (int i = 0; i < nvalues; i++)
-    if (pstyle[i] != DIST) singleflag = 1;
+    if (pstyle[i] != DIST && pstyle[i] != DX && pstyle[i] != DY && pstyle[i] != DZ) singleflag = 1;
 
   if (nvalues == 1) size_local_cols = 0;
   else size_local_cols = nvalues;
@@ -269,6 +272,12 @@ int ComputePairLocal::compute_pairs(int flag)
           case DIST:
             ptr[n] = sqrt(rsq);
             break;
+          case DX:
+            ptr[n] = delx;
+          case DY:
+            ptr[n] = dely;
+          case DZ:
+            ptr[n] = delz;
           case ENG:
             ptr[n] = eng;
             break;

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -267,17 +267,20 @@ int ComputePairLocal::compute_pairs(int flag)
         if (nvalues == 1) ptr = &vlocal[m];
         else ptr = alocal[m];
 
+        // to make sure dx, dy and dz are always from the lower to the higher id
+        double directionCorrection = i > j ? -1.0 : 1.0;
+
         for (n = 0; n < nvalues; n++) {
           switch (pstyle[n]) {
           case DIST:
             ptr[n] = sqrt(rsq);
             break;
           case DX:
-            ptr[n] = delx;
+            ptr[n] = delx*directionCorrection;
           case DY:
-            ptr[n] = dely;
+            ptr[n] = dely*directionCorrection;
           case DZ:
-            ptr[n] = delz;
+            ptr[n] = delz*directionCorrection;
           case ENG:
             ptr[n] = eng;
             break;


### PR DESCRIPTION
**Summary**

<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->
This PR enables outputting not only the norm of the distance between two atoms in a bond or pair, but also the three directional components.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->
Me: Tim Bernhard, ETH Zürich, tim@bernhard.dev

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
No break.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
The important note and possible request for feedback concerns the direction of the components. As I understand it, for the compute bond/local, the check on line 391 (and 271 for pair/local) should be sufficient to assert that the direction goes from the atom with the lower to the higher id. Is this correct?
Otherwise, the implementation relies on calculations that were already done, so not much room for error I guess.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->
The motivation to implement this feature is to measure end-to-end vectors (using the *new* `compute bond/local dx dy dz` with some "ghostbonds").
