### PR TITLE
Centroid atomic stress for shake, rattle and rigid/small

### DIFF
--- a/doc/src/Bibliography.rst
+++ b/doc/src/Bibliography.rst
@@ -1123,8 +1123,11 @@ Bibliography
 **(Sun)**
    Sun, J. Phys. Chem. B, 102, 7338-7364 (1998).
 
-**(Surblys)**
+**(Surblys2019)**
    Surblys, Matsubara, Kikugawa, Ohara, Phys Rev E, 99, 051301(R) (2019).
+
+**(Surblys2021)**
+   Surblys, Matsubara, Kikugawa, Ohara, J Appl Phys 130, 215104 (2021).
 
 **(Sutmann)**
    Sutmann, Arnold, Fahrenberger, et. al., Physical review / E 88(6), 063308 (2013)

--- a/doc/src/compute_heat_flux.rst
+++ b/doc/src/compute_heat_flux.rst
@@ -89,12 +89,19 @@ included in the calculation.
 .. warning::
 
    The compute *heat/flux* has been reported to produce unphysical
-   values for angle, dihedral and improper contributions
+   values for angle, dihedral, improper and constraint force contributions
    when used with :doc:`compute stress/atom <compute_stress_atom>`,
-   as discussed in :ref:`(Surblys) <Surblys2>` and :ref:`(Boone) <Boone>`.
-   You are strongly advised to
+   as discussed in :ref:`(Surblys2019) <Surblys3>`, :ref:`(Boone) <Boone>`
+   and :ref:`(Surblys2021) <Surblys4>`. You are strongly advised to
    use :doc:`compute centroid/stress/atom <compute_stress_atom>`,
    which has been implemented specifically for such cases.
+
+.. warning::
+
+   Due to an implementation detail, the :math:`y` and :math:`z`
+   components of heat flux from :doc:`fix rigid <fix_rigid>`
+   contribution when computed via :doc:`compute stress/atom <compute_stress_atom>`
+   are highly unphysical and should not be used.
 
 The Green-Kubo formulas relate the ensemble average of the
 auto-correlation of the heat flux :math:`\mathbf{J}`
@@ -232,10 +239,14 @@ none
 
 ----------
 
-.. _Surblys2:
+.. _Surblys3:
 
-**(Surblys)** Surblys, Matsubara, Kikugawa, Ohara, Phys Rev E, 99, 051301(R) (2019).
+**(Surblys2019)** Surblys, Matsubara, Kikugawa, Ohara, Phys Rev E, 99, 051301(R) (2019).
 
 .. _Boone:
 
 **(Boone)** Boone, Babaei, Wilmer, J Chem Theory Comput, 15, 5579--5587 (2019).
+
+.. _Surblys4:
+
+**(Surblys2021)** Surblys, Matsubara, Kikugawa, Ohara, J Appl Phys 130, 215104 (2021).

--- a/doc/src/compute_stress_atom.rst
+++ b/doc/src/compute_stress_atom.rst
@@ -87,6 +87,10 @@ Tersoff 3-body interaction) is assigned in equal portions to each atom
 in the set.  E.g. 1/4 of the dihedral virial to each of the 4 atoms,
 or 1/3 of the fix virial due to SHAKE constraints applied to atoms in
 a water molecule via the :doc:`fix shake <fix_shake>` command.
+As an exception, the virial contribution from
+constraint forces in :doc:`fix rigid <fix_rigid>` on each atom
+is computed from the constraint force acting on the corresponding atom
+and its position, i.e. the total virial is not equally distributed.
 
 In case of compute *centroid/stress/atom*, the virial contribution is:
 
@@ -103,13 +107,25 @@ atom :math:`I` due to the interaction and the relative position
 :math:`\mathbf{r}_{I0}` of the atom :math:`I` to the geometric center
 of the interacting atoms, i.e. centroid, is used.  As the geometric
 center is different for each interaction, the :math:`\mathbf{r}_{I0}`
-also differs.  The sixth and seventh terms, Kspace and :doc:`fix
-<fix>` contribution respectively, are computed identical to compute
-*stress/atom*.  Although the total system virial is the same as
+also differs. The sixth term, Kspace contribution,
+is computed identically to compute *stress/atom*.
+The seventh term is handed differently depending on
+if the constraint forces are due to :doc:`fix shake <fix_shake>`
+or :doc:`fix rigid <fix_rigid>`.
+In case of SHAKE constraints, each distance constraint is
+handed as a pairwise interaction.
+E.g. in case of a water molecule, two OH and one HH distance
+constraints are treated as three pairwise interactions.
+In case of :doc:`fix rigid <fix_rigid>`,
+all constraint forces in the molecule are treated
+as a single many-body interaction with a single centroid position.
+In case of water molecule, the formula expression would become
+identical to that of the three-body angle interaction.
+Although the total system virial is the same as
 compute *stress/atom*, compute *centroid/stress/atom* is know to
-result in more consistent heat flux values for angle, dihedrals and
-improper contributions when computed via :doc:`compute heat/flux
-<compute_heat_flux>`.
+result in more consistent heat flux values for angle, dihedrals,
+improper and constraint force contributions
+when computed via :doc:`compute heat/flux <compute_heat_flux>`.
 
 If no extra keywords are listed, the kinetic contribution all of the
 virial contribution terms are included in the per-atom stress tensor.
@@ -134,7 +150,8 @@ contribution for the cluster interaction is divided evenly among those
 atoms.
 
 Details of how compute *centroid/stress/atom* obtains the virial for
-individual atoms is given in :ref:`(Surblys) <Surblys1>`, where the
+individual atoms are given in :ref:`(Surblys2019) <Surblys1>` and
+:ref:`(Surblys2021) <Surblys2>`, where the
 idea is that the virial of the atom :math:`I` is the result of only
 the force :math:`\mathbf{F}_I` on the atom due to the interaction and
 its positional vector :math:`\mathbf{r}_{I0}`, relative to the
@@ -235,10 +252,10 @@ between the pair of particles.  All bond styles are supported.  All
 angle, dihedral, improper styles are supported with the exception of
 INTEL and KOKKOS variants of specific styles.  It also does not
 support models with long-range Coulombic or dispersion forces,
-i.e. the kspace_style command in LAMMPS.  It also does not support the
-following fixes which add rigid-body constraints: :doc:`fix shake
-<fix_shake>`, :doc:`fix rattle <fix_shake>`, :doc:`fix rigid
-<fix_rigid>`, :doc:`fix rigid/small <fix_rigid>`.
+i.e. the kspace_style command in LAMMPS.  It also does not implement the
+following fixes which add rigid-body constraints:
+:doc:`fix rigid/* <fix_rigid>` and the OpenMP accelerated version of :doc:`fix rigid/small <fix_rigid>`,
+while all other :doc:`fix rigid/*/small <fix_rigid>` are implemented.
 
 LAMMPS will generate an error if one of these options is included in
 your model.  Extension of centroid stress calculations to these force
@@ -270,4 +287,8 @@ none
 
 .. _Surblys1:
 
-**(Surblys)** Surblys, Matsubara, Kikugawa, Ohara, Phys Rev E, 99, 051301(R) (2019).
+**(Surblys2019)** Surblys, Matsubara, Kikugawa, Ohara, Phys Rev E, 99, 051301(R) (2019).
+
+.. _Surblys2:
+
+**(Surblys2021)** Surblys, Matsubara, Kikugawa, Ohara, J Appl Phys 130, 215104 (2021).

--- a/src/OPENMP/fix_rigid_small_omp.h
+++ b/src/OPENMP/fix_rigid_small_omp.h
@@ -21,12 +21,16 @@ FixStyle(rigid/small/omp,FixRigidSmallOMP);
 #define LMP_FIX_RIGID_SMALL_OMP_H
 
 #include "fix_rigid_small.h"
+#include "force.h"
 
 namespace LAMMPS_NS {
 
 class FixRigidSmallOMP : public FixRigidSmall {
  public:
-  FixRigidSmallOMP(class LAMMPS *lmp, int narg, char **args) : FixRigidSmall(lmp, narg, args){};
+  FixRigidSmallOMP(class LAMMPS *lmp, int narg, char **args) : FixRigidSmall(lmp, narg, args)
+  {
+    centroidstressflag = CENTROID_NOTAVAIL;
+  }
   virtual ~FixRigidSmallOMP(){};
 
   virtual void initial_integrate(int);

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -68,6 +68,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
   create_attribute = 1;
   dof_flag = 1;
   enforce2d_flag = 1;
+  centroidstressflag = CENTROID_NOTAVAIL;
 
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -785,7 +785,7 @@ void FixRigidSmall::initial_integrate(int vflag)
   // forward communicate updated info of all bodies
 
   commflag = INITIAL;
-  comm->forward_comm_fix(this,26);
+  comm->forward_comm_fix(this,29);
 
   // set coords/orient and velocity/rotation of atoms in rigid bodies
 
@@ -879,6 +879,7 @@ void FixRigidSmall::enforce2d()
     b->xcm[2] = 0.0;
     b->vcm[2] = 0.0;
     b->fcm[2] = 0.0;
+    b->xgc[2] = 0.0;
     b->torque[0] = 0.0;
     b->torque[1] = 0.0;
     b->angmom[0] = 0.0;
@@ -1351,6 +1352,16 @@ void FixRigidSmall::set_xv()
 
       v_tally(1,&i,1.0,vr);
     }
+  }
+
+  // update the position of geometric center
+  for (int ibody = 0; ibody < nlocal_body + nghost_body; ibody++) {
+    Body *b = &body[ibody];
+    MathExtra::matvec(b->ex_space,b->ey_space,b->ez_space,
+                      b->xgc_body,b->xgc);
+    b->xgc[0] += b->xcm[0];
+    b->xgc[1] += b->xcm[1];
+    b->xgc[2] += b->xcm[2];
   }
 
   // set orientation, omega, angmom of each extended particle
@@ -1905,11 +1916,15 @@ void FixRigidSmall::setup_bodies_static()
   double **x = atom->x;
 
   double *xcm;
+  double *xgc;
 
   for (ibody = 0; ibody < nlocal_body+nghost_body; ibody++) {
     xcm = body[ibody].xcm;
+    xgc = body[ibody].xgc;
     xcm[0] = xcm[1] = xcm[2] = 0.0;
+    xgc[0] = xgc[1] = xgc[2] = 0.0;
     body[ibody].mass = 0.0;
+    body[ibody].natoms = 0;
   }
 
   double unwrap[3];
@@ -1924,22 +1939,31 @@ void FixRigidSmall::setup_bodies_static()
 
     domain->unmap(x[i],xcmimage[i],unwrap);
     xcm = b->xcm;
+    xgc = b->xgc;
     xcm[0] += unwrap[0] * massone;
     xcm[1] += unwrap[1] * massone;
     xcm[2] += unwrap[2] * massone;
+    xgc[0] += unwrap[0];
+    xgc[1] += unwrap[1];
+    xgc[2] += unwrap[2];
     b->mass += massone;
+    b->natoms++;
   }
 
   // reverse communicate xcm, mass of all bodies
 
   commflag = XCM_MASS;
-  comm->reverse_comm_fix(this,4);
+  comm->reverse_comm_fix(this,8);
 
   for (ibody = 0; ibody < nlocal_body; ibody++) {
     xcm = body[ibody].xcm;
+    xgc = body[ibody].xgc;
     xcm[0] /= body[ibody].mass;
     xcm[1] /= body[ibody].mass;
     xcm[2] /= body[ibody].mass;
+    xgc[0] /= body[ibody].natoms;
+    xgc[1] /= body[ibody].natoms;
+    xgc[2] /= body[ibody].natoms;
   }
 
   // set vcm, angmom = 0.0 in case inpfile is used
@@ -2124,12 +2148,22 @@ void FixRigidSmall::setup_bodies_static()
     // create initial quaternion
 
     MathExtra::exyz_to_q(ex,ey,ez,body[ibody].quat);
+
+    // convert geometric center position to principal axis coordinates
+    // xcm is wrapped, but xgc is not initially
+    xcm = body[ibody].xcm;
+    xgc = body[ibody].xgc;
+    double delta[3];
+    MathExtra::sub3(xgc,xcm,delta);
+    domain->minimum_image(delta);
+    MathExtra::transpose_matvec(ex,ey,ez,delta,body[ibody].xgc_body);
+    MathExtra::add3(xcm,delta,xgc);
   }
 
   // forward communicate updated info of all bodies
 
   commflag = INITIAL;
-  comm->forward_comm_fix(this,26);
+  comm->forward_comm_fix(this,29);
 
   // displace = initial atom coords in basis of principal axes
   // set displace = 0.0 for atoms not in any rigid body
@@ -2807,6 +2841,10 @@ void FixRigidSmall::set_molecule(int nlocalprev, tagint tagprev, int imol,
       if (nlocal_body == nmax_body) grow_body();
       Body *b = &body[nlocal_body];
       b->mass = onemols[imol]->masstotal;
+      b->natoms = onemols[imol]->natoms;
+      b->xgc[0] = xgeom[0];
+      b->xgc[1] = xgeom[1];
+      b->xgc[2] = xgeom[2];
 
       // new COM = Q (onemols[imol]->xcm - onemols[imol]->center) + xgeom
       // Q = rotation matrix associated with quat
@@ -2828,6 +2866,12 @@ void FixRigidSmall::set_molecule(int nlocalprev, tagint tagprev, int imol,
 
       MathExtra::quatquat(quat,onemols[imol]->quat,b->quat);
       MathExtra::q_to_exyz(b->quat,b->ex_space,b->ey_space,b->ez_space);
+
+      MathExtra::transpose_matvec(b->ex_space,b->ey_space,b->ez_space,
+                                  ctr2com_rotate,b->xgc_body);
+      b->xgc_body[0] *= -1;
+      b->xgc_body[1] *= -1;
+      b->xgc_body[2] *= -1;
 
       b->angmom[0] = b->angmom[1] = b->angmom[2] = 0.0;
       b->omega[0] = b->omega[1] = b->omega[2] = 0.0;
@@ -2961,7 +3005,7 @@ int FixRigidSmall::pack_forward_comm(int n, int *list, double *buf,
                                      int /*pbc_flag*/, int * /*pbc*/)
 {
   int i,j;
-  double *xcm,*vcm,*quat,*omega,*ex_space,*ey_space,*ez_space,*conjqm;
+  double *xcm,*xgc,*vcm,*quat,*omega,*ex_space,*ey_space,*ez_space,*conjqm;
 
   int m = 0;
 
@@ -2973,6 +3017,10 @@ int FixRigidSmall::pack_forward_comm(int n, int *list, double *buf,
       buf[m++] = xcm[0];
       buf[m++] = xcm[1];
       buf[m++] = xcm[2];
+      xgc = body[bodyown[j]].xgc;
+      buf[m++] = xgc[0];
+      buf[m++] = xgc[1];
+      buf[m++] = xgc[2];
       vcm = body[bodyown[j]].vcm;
       buf[m++] = vcm[0];
       buf[m++] = vcm[1];
@@ -3048,7 +3096,7 @@ int FixRigidSmall::pack_forward_comm(int n, int *list, double *buf,
 void FixRigidSmall::unpack_forward_comm(int n, int first, double *buf)
 {
   int i,j,last;
-  double *xcm,*vcm,*quat,*omega,*ex_space,*ey_space,*ez_space,*conjqm;
+  double *xcm,*xgc,*vcm,*quat,*omega,*ex_space,*ey_space,*ez_space,*conjqm;
 
   int m = 0;
   last = first + n;
@@ -3060,6 +3108,10 @@ void FixRigidSmall::unpack_forward_comm(int n, int first, double *buf)
       xcm[0] = buf[m++];
       xcm[1] = buf[m++];
       xcm[2] = buf[m++];
+      xgc = body[bodyown[i]].xgc;
+      xgc[0] = buf[m++];
+      xgc[1] = buf[m++];
+      xgc[2] = buf[m++];
       vcm = body[bodyown[i]].vcm;
       vcm[0] = buf[m++];
       vcm[1] = buf[m++];
@@ -3135,7 +3187,7 @@ void FixRigidSmall::unpack_forward_comm(int n, int first, double *buf)
 int FixRigidSmall::pack_reverse_comm(int n, int first, double *buf)
 {
   int i,j,m,last;
-  double *fcm,*torque,*vcm,*angmom,*xcm;
+  double *fcm,*torque,*vcm,*angmom,*xcm, *xgc;
 
   m = 0;
   last = first + n;
@@ -3170,10 +3222,15 @@ int FixRigidSmall::pack_reverse_comm(int n, int first, double *buf)
     for (i = first; i < last; i++) {
       if (bodyown[i] < 0) continue;
       xcm = body[bodyown[i]].xcm;
+      xgc = body[bodyown[i]].xgc;
       buf[m++] = xcm[0];
       buf[m++] = xcm[1];
       buf[m++] = xcm[2];
+      buf[m++] = xgc[0];
+      buf[m++] = xgc[1];
+      buf[m++] = xgc[2];
       buf[m++] = body[bodyown[i]].mass;
+      buf[m++] = static_cast<double>(body[bodyown[i]].natoms);
     }
 
   } else if (commflag == ITENSOR) {
@@ -3208,7 +3265,7 @@ int FixRigidSmall::pack_reverse_comm(int n, int first, double *buf)
 void FixRigidSmall::unpack_reverse_comm(int n, int *list, double *buf)
 {
   int i,j,k;
-  double *fcm,*torque,*vcm,*angmom,*xcm;
+  double *fcm,*torque,*vcm,*angmom,*xcm, *xgc;
 
   int m = 0;
 
@@ -3245,10 +3302,15 @@ void FixRigidSmall::unpack_reverse_comm(int n, int *list, double *buf)
       j = list[i];
       if (bodyown[j] < 0) continue;
       xcm = body[bodyown[j]].xcm;
+      xgc = body[bodyown[j]].xgc;
       xcm[0] += buf[m++];
       xcm[1] += buf[m++];
       xcm[2] += buf[m++];
+      xgc[0] += buf[m++];
+      xgc[1] += buf[m++];
+      xgc[2] += buf[m++];
       body[bodyown[j]].mass += buf[m++];
+      body[bodyown[j]].natoms += static_cast<int>(buf[m++]);
     }
 
   } else if (commflag == ITENSOR) {

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -73,6 +73,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
   dof_flag = 1;
   enforce2d_flag = 1;
   stores_ids = 1;
+  centroidstressflag = CENTROID_AVAIL;
 
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
@@ -1350,7 +1351,9 @@ void FixRigidSmall::set_xv()
       vr[4] = 0.5*x0*fc2;
       vr[5] = 0.5*x1*fc2;
 
-      v_tally(1,&i,1.0,vr);
+      double rlist[][3] = {x0, x1, x2};
+      double flist[][3] = {0.5*fc0, 0.5*fc1, 0.5*fc2};
+      v_tally(1,&i,1.0,vr,rlist,flist,b->xgc);
     }
   }
 
@@ -1510,7 +1513,9 @@ void FixRigidSmall::set_v()
       vr[4] = 0.5*x0*fc2;
       vr[5] = 0.5*x1*fc2;
 
-      v_tally(1,&i,1.0,vr);
+      double rlist[][3] = {x0, x1, x2};
+      double flist[][3] = {0.5*fc0, 0.5*fc1, 0.5*fc2};
+      v_tally(1,&i,1.0,vr,rlist,flist,b->xgc);
     }
   }
 

--- a/src/RIGID/fix_rigid_small.h
+++ b/src/RIGID/fix_rigid_small.h
@@ -85,7 +85,9 @@ class FixRigidSmall : public Fix {
 
   struct Body {
     double mass;           // total mass of body
+    int natoms;            // total number of atoms in body
     double xcm[3];         // COM position
+    double xgc[3];         // geometric center position
     double vcm[3];         // COM velocity
     double fcm[3];         // force on COM
     double torque[3];      // torque around COM
@@ -94,6 +96,7 @@ class FixRigidSmall : public Fix {
     double ex_space[3];    // principal axes in space coords
     double ey_space[3];
     double ez_space[3];
+    double xgc_body[3];    // geometric center relative to xcm in body coords
     double angmom[3];    // space-frame angular momentum of body
     double omega[3];     // space-frame omega of body
     double conjqm[4];    // conjugate quaternion momentum

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -66,6 +66,7 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
   create_attribute = 1;
   dof_flag = 1;
   stores_ids = 1;
+  centroidstressflag = CENTROID_AVAIL;
 
   // error check
 
@@ -1764,7 +1765,10 @@ void FixShake::shake(int m)
     v[4] = lamda*r01[0]*r01[2];
     v[5] = lamda*r01[1]*r01[2];
 
-    v_tally(nlist,list,2.0,v);
+    double fpairlist[] = {lamda};
+    double dellist[][3]  = {{r01[0], r01[1], r01[2]}};
+    int pairlist[][2] = {{i0,i1}};
+    v_tally(nlist,list,2.0,v,nlocal,1,pairlist,fpairlist,dellist);
   }
 }
 
@@ -1937,7 +1941,11 @@ void FixShake::shake3(int m)
     v[4] = lamda01*r01[0]*r01[2] + lamda02*r02[0]*r02[2];
     v[5] = lamda01*r01[1]*r01[2] + lamda02*r02[1]*r02[2];
 
-    v_tally(nlist,list,3.0,v);
+    double fpairlist[] = {lamda01, lamda02};
+    double dellist[][3]  = {{r01[0], r01[1], r01[2]},
+                            {r02[0], r02[1], r02[2]}};
+    int pairlist[][2] = {{i0,i1}, {i0,i2}};
+    v_tally(nlist,list,3.0,v,nlocal,2,pairlist,fpairlist,dellist);
   }
 }
 
@@ -2189,7 +2197,12 @@ void FixShake::shake4(int m)
     v[4] = lamda01*r01[0]*r01[2]+lamda02*r02[0]*r02[2]+lamda03*r03[0]*r03[2];
     v[5] = lamda01*r01[1]*r01[2]+lamda02*r02[1]*r02[2]+lamda03*r03[1]*r03[2];
 
-    v_tally(nlist,list,4.0,v);
+    double fpairlist[] = {lamda01, lamda02, lamda03};
+    double dellist[][3]  = {{r01[0], r01[1], r01[2]},
+                            {r02[0], r02[1], r02[2]},
+                            {r03[0], r03[1], r03[2]}};
+    int pairlist[][2] = {{i0,i1}, {i0,i2}, {i0,i3}};
+    v_tally(nlist,list,4.0,v,nlocal,3,pairlist,fpairlist,dellist);
   }
 }
 
@@ -2432,7 +2445,12 @@ void FixShake::shake3angle(int m)
     v[4] = lamda01*r01[0]*r01[2]+lamda02*r02[0]*r02[2]+lamda12*r12[0]*r12[2];
     v[5] = lamda01*r01[1]*r01[2]+lamda02*r02[1]*r02[2]+lamda12*r12[1]*r12[2];
 
-    v_tally(nlist,list,3.0,v);
+    double fpairlist[] = {lamda01, lamda02, lamda12};
+    double dellist[][3]  = {{r01[0], r01[1], r01[2]},
+                            {r02[0], r02[1], r02[2]},
+                            {r12[0], r12[1], r12[2]}};
+    int pairlist[][2] = {{i0,i1}, {i0,i2}, {i1,i2}};
+    v_tally(nlist,list,3.0,v,nlocal,3,pairlist,fpairlist,dellist);
   }
 }
 

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -16,6 +16,7 @@
 #include "angle.h"
 #include "atom.h"
 #include "bond.h"
+#include "citeme.h"
 #include "comm.h"
 #include "dihedral.h"
 #include "error.h"
@@ -33,6 +34,36 @@
 using namespace LAMMPS_NS;
 
 enum { NOBIAS, BIAS };
+
+static const char cite_centroid_angle_improper_dihedral[] =
+    "compute centroid/stress/atom for angles, impropers and dihedrals:\n\n"
+    "@article{PhysRevE.99.051301,\n"
+    " title = {Application of atomic stress to compute heat flux via molecular dynamics for "
+    "systems with many-body interactions},\n"
+    " author = {Surblys, Donatas and Matsubara, Hiroki and Kikugawa, Gota and Ohara, Taku},\n"
+    " journal = {Physical Review E},\n"
+    " volume = {99},\n"
+    " issue = {5},\n"
+    " pages = {051301},\n"
+    " year = {2019},\n"
+    " doi = {10.1103/PhysRevE.99.051301},\n"
+    " url = {https://link.aps.org/doi/10.1103/PhysRevE.99.051301}\n"
+    "}\n\n";
+
+static const char cite_centroid_shake_rigid[] =
+    "compute centroid/stress/atom for constrained dynamics:\n\n"
+    "@article{doi:10.1063/5.0070930,\n"
+    " author = {Surblys, Donatas and Matsubara, Hiroki and Kikugawa, Gota and Ohara, Taku},\n"
+    " journal = {Journal of Applied Physics},\n"
+    " title = {Methodology and meaning of computing heat flux via atomic stress in systems with "
+    "constraint dynamics},\n"
+    " volume = {130},\n"
+    " number = {21},\n"
+    " pages = {215104},\n"
+    " year = {2021},\n"
+    " doi = {10.1063/5.0070930},\n"
+    " url = {https://doi.org/10.1063/5.0070930},\n"
+    "}\n\n";
 
 /* ---------------------------------------------------------------------- */
 
@@ -105,6 +136,12 @@ ComputeCentroidStressAtom::ComputeCentroidStressAtom(LAMMPS *lmp, int narg, char
   }
 
   nmax = 0;
+
+  if (lmp->citeme) {
+    if (angleflag || dihedralflag || improperflag)
+      lmp->citeme->add(cite_centroid_angle_improper_dihedral);
+    if (fixflag) lmp->citeme->add(cite_centroid_shake_rigid);
+  }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -268,19 +268,26 @@ void ComputeCentroidStressAtom::compute_peratom()
   // possible during setup phase if fix has not initialized its vatom yet
   // e.g. fix ave/spatial defined before fix shake,
   //   and fix ave/spatial uses a per-atom stress from this compute as input
-  // fix styles are CENTROID_SAME or CENTROID_NOTAVAIL
+  // fix styles are CENTROID_SAME, CENTROID_AVAIL or CENTROID_NOTAVAIL
 
   if (fixflag) {
     Fix **fix = modify->fix;
     int nfix = modify->nfix;
     for (int ifix = 0; ifix < nfix; ifix++)
       if (fix[ifix]->virial_peratom_flag && fix[ifix]->thermo_virial) {
-        double **vatom = fix[ifix]->vatom;
-        if (vatom)
-          for (i = 0; i < nlocal; i++) {
-            for (j = 0; j < 6; j++) stress[i][j] += vatom[i][j];
-            for (j = 6; j < 9; j++) stress[i][j] += vatom[i][j - 3];
-          }
+        if (modify->fix[ifix]->centroidstressflag == CENTROID_AVAIL) {
+          double **cvatom = modify->fix[ifix]->cvatom;
+          if (cvatom)
+            for (i = 0; i < nlocal; i++)
+              for (j = 0; j < 9; j++) stress[i][j] += cvatom[i][j];
+        } else {
+          double **vatom = modify->fix[ifix]->vatom;
+          if (vatom)
+            for (i = 0; i < nlocal; i++) {
+              for (j = 0; j < 6; j++) stress[i][j] += vatom[i][j];
+              for (j = 6; j < 9; j++) stress[i][j] += vatom[i][j - 3];
+            }
+        }
       }
   }
 

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -35,7 +35,8 @@ int Fix::instance_total = 0;
 Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   Pointers(lmp),
   id(nullptr), style(nullptr), extlist(nullptr), vector_atom(nullptr), array_atom(nullptr),
-  vector_local(nullptr), array_local(nullptr), eatom(nullptr), vatom(nullptr)
+  vector_local(nullptr), array_local(nullptr), eatom(nullptr), vatom(nullptr),
+  cvatom(nullptr)
 {
   instance_me = instance_total++;
 
@@ -97,8 +98,8 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   // set vflag_atom = 0 b/c some fixes grow vatom in grow_arrays()
   //   which may occur outside of timestepping
 
-  maxeatom = maxvatom = 0;
-  vflag_atom = 0;
+  maxeatom = maxvatom = maxcvatom = 0;
+  vflag_atom = cvflag_atom = 0;
   centroidstressflag = CENTROID_SAME;
 
   // KOKKOS per-fix data masks
@@ -122,6 +123,7 @@ Fix::~Fix()
   delete [] style;
   memory->destroy(eatom);
   memory->destroy(vatom);
+  memory->destroy(cvatom);
 }
 
 /* ----------------------------------------------------------------------
@@ -197,7 +199,13 @@ void Fix::ev_setup(int eflag, int vflag)
   else {
     vflag_either = vflag;
     vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
-    vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
+    if (centroidstressflag != CENTROID_AVAIL) {
+      vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
+      cvflag_atom = 0;
+    } else {
+      vflag_atom = vflag & VIRIAL_ATOM;
+      cvflag_atom = vflag & VIRIAL_CENTROID;
+    }
   }
 
   // reallocate per-atom arrays if necessary
@@ -211,6 +219,11 @@ void Fix::ev_setup(int eflag, int vflag)
     maxvatom = atom->nmax;
     memory->destroy(vatom);
     memory->create(vatom,maxvatom,6,"fix:vatom");
+  }
+  if (cvflag_atom && atom->nlocal > maxcvatom) {
+    maxcvatom = atom->nmax;
+    memory->destroy(cvatom);
+    memory->create(cvatom,maxcvatom,9,"fix:cvatom");
   }
 
   // zero accumulators
@@ -233,6 +246,20 @@ void Fix::ev_setup(int eflag, int vflag)
       vatom[i][5] = 0.0;
     }
   }
+  if (cvflag_atom) {
+    n = atom->nlocal;
+    for (i = 0; i < n; i++) {
+      cvatom[i][0] = 0.0;
+      cvatom[i][1] = 0.0;
+      cvatom[i][2] = 0.0;
+      cvatom[i][3] = 0.0;
+      cvatom[i][4] = 0.0;
+      cvatom[i][5] = 0.0;
+      cvatom[i][6] = 0.0;
+      cvatom[i][7] = 0.0;
+      cvatom[i][8] = 0.0;
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -248,7 +275,13 @@ void Fix::v_setup(int vflag)
 
   evflag = 1;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
-  vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
+  if (centroidstressflag != CENTROID_AVAIL) {
+    vflag_atom = vflag & (VIRIAL_ATOM | VIRIAL_CENTROID);
+    cvflag_atom = 0;
+  } else {
+    vflag_atom = vflag & VIRIAL_ATOM;
+    cvflag_atom = vflag & VIRIAL_CENTROID;
+  }
 
   // reallocate per-atom array if necessary
 
@@ -256,6 +289,11 @@ void Fix::v_setup(int vflag)
     maxvatom = atom->nmax;
     memory->destroy(vatom);
     memory->create(vatom,maxvatom,6,"fix:vatom");
+  }
+  if (cvflag_atom && atom->nlocal > maxcvatom) {
+    maxcvatom = atom->nmax;
+    memory->destroy(cvatom);
+    memory->create(cvatom,maxcvatom,9,"fix:cvatom");
   }
 
   // zero accumulators
@@ -270,6 +308,20 @@ void Fix::v_setup(int vflag)
       vatom[i][3] = 0.0;
       vatom[i][4] = 0.0;
       vatom[i][5] = 0.0;
+    }
+  }
+  if (cvflag_atom) {
+    n = atom->nlocal;
+    for (i = 0; i < n; i++) {
+      cvatom[i][0] = 0.0;
+      cvatom[i][1] = 0.0;
+      cvatom[i][2] = 0.0;
+      cvatom[i][3] = 0.0;
+      cvatom[i][4] = 0.0;
+      cvatom[i][5] = 0.0;
+      cvatom[i][6] = 0.0;
+      cvatom[i][7] = 0.0;
+      cvatom[i][8] = 0.0;
     }
   }
 }
@@ -334,6 +386,66 @@ void Fix::v_tally(int n, int *list, double total, double *v)
       vatom[m][3] += fraction*v[3];
       vatom[m][4] += fraction*v[4];
       vatom[m][5] += fraction*v[5];
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   tally virial into global and per-atom accumulators
+   n = # of local owned atoms involved, with local indices in list
+   vtot = total virial for the interaction involving total atoms
+   npair = # of atom pairs with forces beween them
+   pairlist = indice list of pairs
+   fpairlist = forces between pairs
+   dellist = displacement vectors between pairs
+   increment global virial by n/total fraction
+   increment per-atom virial of each atom in list by 1/total fraction
+   add centroid form atomic virial contribution for each atom if available
+   this method can be used when fix computes forces in post_force()
+     e.g. fix shake, fix rigid: compute virial only on owned atoms
+       whether newton_bond is on or off
+     other procs will tally left-over fractions for atoms they own
+------------------------------------------------------------------------- */
+
+void Fix::v_tally(int n, int *list, double total, double *vtot, int nlocal,
+    int npair, int pairlist[][2], double *fpairlist, double dellist[][3])
+{
+
+  v_tally(n, list, total, vtot);
+
+  if (cvflag_atom) {
+    double v[6];
+    for (int i = 0; i < npair; i++) {
+      v[0] = 0.5*dellist[i][0]*dellist[i][0]*fpairlist[i];
+      v[1] = 0.5*dellist[i][1]*dellist[i][1]*fpairlist[i];
+      v[2] = 0.5*dellist[i][2]*dellist[i][2]*fpairlist[i];
+      v[3] = 0.5*dellist[i][0]*dellist[i][1]*fpairlist[i];
+      v[4] = 0.5*dellist[i][0]*dellist[i][2]*fpairlist[i];
+      v[5] = 0.5*dellist[i][1]*dellist[i][2]*fpairlist[i];
+      const int i0 = pairlist[i][0];
+      const int i1 = pairlist[i][1];
+      if (i0 < nlocal) {
+        cvatom[i0][0] += v[0];
+        cvatom[i0][1] += v[1];
+        cvatom[i0][2] += v[2];
+        cvatom[i0][3] += v[3];
+        cvatom[i0][4] += v[4];
+        cvatom[i0][5] += v[5];
+        cvatom[i0][6] += v[3];
+        cvatom[i0][7] += v[4];
+        cvatom[i0][8] += v[5];
+      }
+      if (i1 < nlocal) {
+        cvatom[i1][0] += v[0];
+        cvatom[i1][1] += v[1];
+        cvatom[i1][2] += v[2];
+        cvatom[i1][3] += v[3];
+        cvatom[i1][4] += v[4];
+        cvatom[i1][5] += v[5];
+        cvatom[i1][6] += v[3];
+        cvatom[i1][7] += v[4];
+        cvatom[i1][8] += v[5];
+      }
     }
   }
 }

--- a/src/fix.h
+++ b/src/fix.h
@@ -279,6 +279,7 @@ class Fix : protected Pointers {
   void v_setup(int);
   void v_tally(int, int *, double, double *);
   void v_tally(int,int*,double,double*,int,int,int[][2],double*,double[][3]);
+  void v_tally(int,int*,double,double*,double[][3],double[][3],double[]);
   void v_tally(int, double *);
   void v_tally(int, int, double);
 };

--- a/src/fix.h
+++ b/src/fix.h
@@ -278,6 +278,7 @@ class Fix : protected Pointers {
   }
   void v_setup(int);
   void v_tally(int, int *, double, double *);
+  void v_tally(int,int*,double,double*,int,int,int[][2],double*,double[][3]);
   void v_tally(int, double *);
   void v_tally(int, int, double);
 };

--- a/src/fix.h
+++ b/src/fix.h
@@ -113,6 +113,7 @@ class Fix : protected Pointers {
 
   double virial[6];          // virial for this timestep
   double *eatom, **vatom;    // per-atom energy/virial for this timestep
+  double **cvatom;           // per-atom centroid virial for this timestep
 
   int centroidstressflag;    // centroid stress compared to two-body stress
                              // CENTROID_SAME = same as two-body stress
@@ -249,8 +250,8 @@ class Fix : protected Pointers {
 
   int evflag;
   int eflag_either, eflag_global, eflag_atom;
-  int vflag_either, vflag_global, vflag_atom;
-  int maxeatom, maxvatom;
+  int vflag_either, vflag_global, vflag_atom, cvflag_atom;
+  int maxeatom, maxvatom, maxcvatom;
 
   int copymode;    // if set, do not deallocate during destruction
                    // required when classes are used as functors by Kokkos
@@ -263,7 +264,7 @@ class Fix : protected Pointers {
       ev_setup(eflag, vflag);
     else
       evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom =
-          0;
+          cvflag_atom = 0;
   }
   void ev_setup(int, int);
   void ev_tally(int, int *, double, double, double *);
@@ -273,7 +274,7 @@ class Fix : protected Pointers {
     if (vflag && thermo_virial)
       v_setup(vflag);
     else
-      evflag = vflag_either = vflag_global = vflag_atom = 0;
+      evflag = vflag_either = vflag_global = vflag_atom = cvflag_atom = 0;
   }
   void v_setup(int);
   void v_tally(int, int *, double, double *);


### PR DESCRIPTION
**Summary**

This implements the centroid form atomic stress for constrained dynamics via shake and rattle fixes, as well as rigid body dynamics for fix rigid/small. The centroid form provides strictly correct heat flux values when used with the heat/flux compute for the whole system, and gives good approximation of local heat flux over control volumes. Without the centroid form, the original implementation gives heat flux values that don't quite match the input/output of thermal baths, like langevin and ehex fixes. Details can be found in our recently published paper [1].

If the changes look OK, I can also go on to update the documentation.

**Related Issue(s)**

This is a continuation of work done in  PR #1704.

**Author(s)**

Donatas Surblys (Tohoku University) surblys.donatas at gmail dot com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This might change the heat flux values obtained from shake, rattle, and rigid/small fixes if somebody was trying to use centroid/stress/atom and LAMMPS didn't properly error out.

**Implementation Notes**

New v_tally functions are defined for shake/rigid and rigid/small in fix.cpp, that internally call the original v_tally functions, and then do additional centroid stress computations if necessary.

For shake/rigid:
Constraint forces are treated as pair interactions and handled respectively.

For rigid/small:
The Body structure in fix_rigid_small.h is updated to the following variables:
```
    int natoms;            // total number of atoms in body
    double xgc[3];         // geometric center position
    double xgc_body[3];    // geometric center relative to xcm in body coords
```
This allows computation of the centroid position, enabling easily obtaining centroid form atomic stress, even when not all atoms are owned by the process. I'd like some feedback if I approached in an acceptable way, and have some slight doubts if wrapping was handled correctly.

What's still missing:
- fix rigid: Haven't really looked into it, but might be possible to use same approach as fix rigid/small. Don't know if there's much need.
- TIP4P: Need quite an involved approach. A naive implementation was not successful.
- Many-body potentials.

Notes about the original implementation of rigid/small:
Currently, fix rigid/small gives unphysical results for y an z components when used with the heat/flux compute. This is because the atomic stress virial is not averaged over all atoms in the molecule, i.e. the atomic stress tensor is not symmetric, but only the upper triangular is stored. Because of this

> jv[0]  = rijx fijx vjx + rijx fijy vjy + rijx fijz vjz
> jv[1]  = rijy fijx vjx + rijy fijy vjy + rijy fijz vjz
> jv[2]  = rijz fijx vjx + rijz fijy vjy + rijz fijz vjz

becomes

> jv[0]  = rijx fijx vjx + rijx fijy vjy + rijx fijz vjz
> jv[1]  = rijx fijy vjx + rijy fijy vjy + rijy fijz vjz
> jv[2]  = rijx fijz vjx + rijy fijz vjy + rijz fijz vjz

As you can see, only the x component is correct. In practice, the other components give obviously unphysical values.
I strongly believe there should be at least a warning cautioning against such use.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

[1] https://doi.org/10.1063/5.0070930 


