### PR TITLE
Add Lammps extension for vscode to the tools section of the documentation 

### DIFF
--- a/doc/src/Tools.rst
+++ b/doc/src/Tools.rst
@@ -97,7 +97,7 @@ Miscellaneous tools
    * :ref:`singularity <singularity_tool>`
    * :ref:`SWIG interface <swig>`
    * :ref:`vim <vim>`
-   * :ref:`VSCODE Extension <lammps_vscode>`
+   * :ref:`Visual Studio Code Extension <lammps_vscode>`
 
 ----------
 

--- a/doc/src/Tools.rst
+++ b/doc/src/Tools.rst
@@ -97,6 +97,7 @@ Miscellaneous tools
    * :ref:`singularity <singularity_tool>`
    * :ref:`SWIG interface <swig>`
    * :ref:`vim <vim>`
+   * :ref:`VSCODE Extension <lammps_vscode>`
 
 ----------
 
@@ -1141,3 +1142,28 @@ simulation.
 See the README file for details.
 
 These files were provided by Vikas Varshney (vv0210 at gmail.com)
+
+----------
+
+.. _lammps_vscode:
+
+Extension for vscode
+--------------------
+
+An extension for the `vscode <https://code.visualstudio.com/>`_ editor is provided 
+through the editors embedded extension system, or alternatively through the 
+`vs-marketplace <https://marketplace.visualstudio.com/items?itemName=thfriedrich.lammps>`_ 
+or `GitHub <https://github.com/ThFriedrich/lammps_vscode/releases>`_.
+
+The extension features: 
+
+* Keywords/Syntax highlighting 
+* Embedded offline documentation pages
+* Autocompletion suggestions
+* Hover information
+* Task provider for running LAMMPS simulations in the editors terminal
+* Runs some checks on the input files (e.g. syntax, missing files, etc.)
+* Dashboard for interactive plots of logs and atomic dumps
+  
+See `https://thfriedrich.github.io/lammps_vscode/ <https://thfriedrich.github.io/lammps_vscode/>`_ 
+for more details

--- a/doc/src/pair_lj_cut_coul.rst
+++ b/doc/src/pair_lj_cut_coul.rst
@@ -59,7 +59,7 @@ Syntax
 
    pair_style style args
 
-* style = *lj/cut/coul/cut* or *lj/cut/coul/debye* or *lj/cut/coul/dsf* or *lj/cut/coul/long* *lj/cut/coul/msm* or *lj/cut/coul/wolf*
+* style = *lj/cut/coul/cut* or *lj/cut/coul/debye* or *lj/cut/coul/dsf* or *lj/cut/coul/long* or *lj/cut/coul/msm* or *lj/cut/coul/wolf*
 * args = list of arguments for a particular style
 
 .. parsed-literal::


### PR DESCRIPTION
**Summary**

This PR adds [Lammps extension for vscode](https://thfriedrich.github.io/lammps_vscode/) to the tools section of the documentation and fixes a typo in doc/src/pair_lj_cut_coul.rst

**Author(s)**

Thomas Friedrich, University of Antwerp
thomas.friedrich@uantwerpen.be

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
 - No known compatibility issues

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
 - verified the docs build using `make`

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



