### PR TITLE
Enable Kokkos Desul atomics in Makefile to match CMake settings

### DIFF
--- a/lib/kokkos/Makefile.kokkos
+++ b/lib/kokkos/Makefile.kokkos
@@ -33,7 +33,7 @@ KOKKOS_DEBUG ?= "no"
 KOKKOS_USE_TPLS ?= ""
 # Options: c++14,c++1y,c++17,c++1z,c++2a
 KOKKOS_CXX_STANDARD ?= "c++14"
-# Options: aggressive_vectorization,disable_profiling,enable_large_mem_tests,disable_complex_align,disable_deprecated_code,enable_deprecation_warnings
+# Options: aggressive_vectorization,disable_profiling,enable_large_mem_tests,disable_complex_align,disable_deprecated_code,enable_deprecation_warnings,enable_desul_atomics
 KOKKOS_OPTIONS ?= "enable_desul_atomics"
 KOKKOS_CMAKE ?= "no"
 KOKKOS_TRIBITS ?= "no"

--- a/lib/kokkos/Makefile.kokkos
+++ b/lib/kokkos/Makefile.kokkos
@@ -34,7 +34,7 @@ KOKKOS_USE_TPLS ?= ""
 # Options: c++14,c++1y,c++17,c++1z,c++2a
 KOKKOS_CXX_STANDARD ?= "c++14"
 # Options: aggressive_vectorization,disable_profiling,enable_large_mem_tests,disable_complex_align,disable_deprecated_code,enable_deprecation_warnings
-KOKKOS_OPTIONS ?= ""
+KOKKOS_OPTIONS ?= "enable_desul_atomics"
 KOKKOS_CMAKE ?= "no"
 KOKKOS_TRIBITS ?= "no"
 KOKKOS_STANDALONE_CMAKE ?= "no"

--- a/src/KOKKOS/bond_fene_kokkos.cpp
+++ b/src/KOKKOS/bond_fene_kokkos.cpp
@@ -190,9 +190,9 @@ void BondFENEKokkos<DeviceType>::operator()(TagBondFENECompute<NEWTON_BOND,EVFLA
 
   if (rlogarg < 0.1) {
     if (!d_warning_flag())
-      Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+      d_warning_flag() = 1;
     if (rlogarg <= -3.0 && !d_error_flag())
-      Kokkos::atomic_fetch_add(&d_error_flag(),1);
+      d_error_flag() = 1;
     rlogarg = 0.1;
   }
 

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -627,7 +627,7 @@ struct BuildExchangeListFunctor {
   KOKKOS_INLINE_FUNCTION
   void operator() (int i) const {
     if (_x(i,_dim) < _lo || _x(i,_dim) >= _hi) {
-      const int mysend=Kokkos::atomic_fetch_add(&_nsend(),1);
+      const int mysend = Kokkos::atomic_fetch_add(&_nsend(),1);
       if (mysend < (int)_sendlist.extent(0)) {
         _sendlist(mysend) = i;
         _sendflag(i) = 1;

--- a/src/KOKKOS/dihedral_charmm_kokkos.cpp
+++ b/src/KOKKOS/dihedral_charmm_kokkos.cpp
@@ -262,7 +262,7 @@ void DihedralCharmmKokkos<DeviceType>::operator()(TagDihedralCharmmCompute<NEWTO
     // error check
 
   if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
-    Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+    d_warning_flag() = 1;
 
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -280,7 +280,7 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   // error check
 
   if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
-    Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+    d_warning_flag() = 1;
 
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;

--- a/src/KOKKOS/dihedral_harmonic_kokkos.cpp
+++ b/src/KOKKOS/dihedral_harmonic_kokkos.cpp
@@ -217,7 +217,7 @@ void DihedralHarmonicKokkos<DeviceType>::operator()(TagDihedralHarmonicCompute<N
   // error check
 
   if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
-    Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+    d_warning_flag() = 1;
 
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;

--- a/src/KOKKOS/dihedral_opls_kokkos.cpp
+++ b/src/KOKKOS/dihedral_opls_kokkos.cpp
@@ -243,7 +243,7 @@ void DihedralOPLSKokkos<DeviceType>::operator()(TagDihedralOPLSCompute<NEWTON_BO
   // error check
 
   if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
-    Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+    d_warning_flag() = 1;
 
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;

--- a/src/KOKKOS/improper_class2_kokkos.cpp
+++ b/src/KOKKOS/improper_class2_kokkos.cpp
@@ -280,10 +280,10 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
 
     /*
     if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
-      Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+      d_warning_flag() = 1;
     */
     if ((costheta[0] == -1.0 || costheta[1] == -1.0 || costheta[2] == -1.0) && !d_warning_flag())
-      Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+      d_warning_flag() = 1;
 
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;

--- a/src/KOKKOS/improper_harmonic_kokkos.cpp
+++ b/src/KOKKOS/improper_harmonic_kokkos.cpp
@@ -208,7 +208,7 @@ void ImproperHarmonicKokkos<DeviceType>::operator()(TagImproperHarmonicCompute<N
   // error check
 
   if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
-    Kokkos::atomic_fetch_add(&d_warning_flag(),1);
+    d_warning_flag() = 1;
 
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;

--- a/src/KOKKOS/nbin_ssa_kokkos.cpp
+++ b/src/KOKKOS/nbin_ssa_kokkos.cpp
@@ -228,12 +228,12 @@ void NBinSSAKokkos<DeviceType>::binIDAtomsItem(const int &i, int &update) const
   binID(i) = ibin;
 
   // Find the bounding box of the local atoms in the bins
-  if (loc[0] < d_lbinxlo()) Kokkos::atomic_fetch_min(&d_lbinxlo(),loc[0]);
-  if (loc[0] >= d_lbinxhi()) Kokkos::atomic_fetch_max(&d_lbinxhi(),loc[0] + 1);
-  if (loc[1] < d_lbinylo()) Kokkos::atomic_fetch_min(&d_lbinylo(),loc[1]);
-  if (loc[1] >= d_lbinyhi()) Kokkos::atomic_fetch_max(&d_lbinyhi(),loc[1] + 1);
-  if (loc[2] < d_lbinzlo()) Kokkos::atomic_fetch_min(&d_lbinzlo(),loc[2]);
-  if (loc[2] >= d_lbinzhi()) Kokkos::atomic_fetch_max(&d_lbinzhi(),loc[2] + 1);
+  if (loc[0] < d_lbinxlo()) Kokkos::atomic_min(&d_lbinxlo(),loc[0]);
+  if (loc[0] >= d_lbinxhi()) Kokkos::atomic_max(&d_lbinxhi(),loc[0] + 1);
+  if (loc[1] < d_lbinylo()) Kokkos::atomic_min(&d_lbinylo(),loc[1]);
+  if (loc[1] >= d_lbinyhi()) Kokkos::atomic_max(&d_lbinyhi(),loc[1] + 1);
+  if (loc[2] < d_lbinzlo()) Kokkos::atomic_min(&d_lbinzlo(),loc[2]);
+  if (loc[2] >= d_lbinzhi()) Kokkos::atomic_max(&d_lbinzhi(),loc[2] + 1);
 
   const int ac = Kokkos::atomic_fetch_add(&(bincount[ibin]), (int)1);
   if (update <= ac) update = ac + 1;

--- a/src/KOKKOS/neigh_bond_kokkos.cpp
+++ b/src/KOKKOS/neigh_bond_kokkos.cpp
@@ -291,7 +291,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondBondAll, const int &i, 
     if (newton_bond || i < atom1) {
       const int nbondlist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (nbondlist >= maxbond && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_bondlist(nbondlist,0) = i;
       v_bondlist(nbondlist,1) = atom1;
@@ -379,7 +379,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondBondPartial, const int 
     if (newton_bond || i < atom1) {
       const int nbondlist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (nbondlist >= maxbond && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_bondlist(nbondlist,0) = i;
       v_bondlist(nbondlist,1) = atom1;
@@ -495,7 +495,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondAngleAll, const int &i,
     if (newton_bond || (i <= atom1 && i <= atom2 && i <= atom3)) {
       const int nanglelist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (nanglelist >= maxangle && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_anglelist(nanglelist,0) = atom1;
       v_anglelist(nanglelist,1) = atom2;
@@ -590,7 +590,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondAnglePartial, const int
     if (newton_bond || (i <= atom1 && i <= atom2 && i <= atom3)) {
       const int nanglelist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (nanglelist >= maxangle && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_anglelist(nanglelist,0) = atom1;
       v_anglelist(nanglelist,1) = atom2;
@@ -725,7 +725,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondDihedralAll, const int 
         (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4)) {
       const int ndihedrallist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (ndihedrallist >= maxdihedral && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_dihedrallist(ndihedrallist,0) = atom1;
       v_dihedrallist(ndihedrallist,1) = atom2;
@@ -825,7 +825,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondDihedralPartial, const 
         (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4)) {
       const int ndihedrallist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (ndihedrallist >= maxdihedral && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_dihedrallist(ndihedrallist,0) = atom1;
       v_dihedrallist(ndihedrallist,1) = atom2;
@@ -979,7 +979,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondImproperAll, const int 
         (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4)) {
       const int nimproperlist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (nimproperlist >= maximproper && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_improperlist(nimproperlist,0) = atom1;
       v_improperlist(nimproperlist,1) = atom2;
@@ -1079,7 +1079,7 @@ void NeighBondKokkos<DeviceType>::operator()(TagNeighBondImproperPartial, const 
         (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4)) {
       const int nimproperlist = Kokkos::atomic_fetch_add(&d_nlist(),1);
       if (nimproperlist >= maximproper && !d_fail_flag())
-        Kokkos::atomic_fetch_add(&d_fail_flag(),1);
+        d_fail_flag() = 1;
       if (d_fail_flag()) continue;
       v_improperlist(nimproperlist,0) = atom1;
       v_improperlist(nimproperlist,1) = atom2;

--- a/src/KOKKOS/npair_ssa_kokkos.cpp
+++ b/src/KOKKOS/npair_ssa_kokkos.cpp
@@ -613,7 +613,7 @@ void NPairSSAKokkosExecute<DeviceType>::build_locals_onePhase(const bool firstTr
           neigh_list.d_ilist(inum++) = i;
           if (n > neigh_list.maxneighs) {
             resize() = 1;
-            if (n > new_maxneighs()) Kokkos::atomic_fetch_max(&new_maxneighs(),n);
+            if (n > new_maxneighs()) Kokkos::atomic_max(&new_maxneighs(),n);
           }
         }
       }
@@ -741,7 +741,7 @@ void NPairSSAKokkosExecute<DeviceType>::build_ghosts_onePhase(int workPhase) con
           neigh_list.d_ilist(gNdx++) = i;
           if (n > neigh_list.maxneighs) {
             resize() = 1;
-            if (n > new_maxneighs()) Kokkos::atomic_fetch_max(&new_maxneighs(),n);
+            if (n > new_maxneighs()) Kokkos::atomic_max(&new_maxneighs(),n);
           }
         }
       }


### PR DESCRIPTION
**Summary**

Enable Kokkos Desul atomics in Makefile to match CMake settings. This was an oversight in Kokkos, should be fixed in upstream Kokkos in a future update.

**Related Issue(s)**

None.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes