### PR TITLE
Fixing some references to MISC package in documentation

### DIFF
--- a/doc/src/dump.rst
+++ b/doc/src/dump.rst
@@ -708,8 +708,9 @@ are part of the MPIIO package.  They are only enabled if LAMMPS was
 built with that package.  See the :doc:`Build package <Build_package>`
 doc page for more info.
 
-The *xtc* style is part of the MISC package.  It is only enabled if
-LAMMPS was built with that package.  See the :doc:`Build package <Build_package>` page for more info.
+The *xtc* and *dcd* styles are part of the EXTRA-DUMP package.  They
+are only enabled if LAMMPS was built with that package.  See the
+:doc:`Build package <Build_package>` page for more info.
 
 Related commands
 """"""""""""""""

--- a/doc/src/fix_addtorque.rst
+++ b/doc/src/fix_addtorque.rst
@@ -99,7 +99,7 @@ invoked by the :doc:`minimize <minimize>` command.
 Restrictions
 """"""""""""
 
-This fix is part of the MISC package.  It is only enabled if
+This fix is part of the EXTRA-FIX package.  It is only enabled if
 LAMMPS was built with that package.  See the :doc:`Build package
 <Build_package>` page for more info.
 

--- a/doc/src/fix_oneway.rst
+++ b/doc/src/fix_oneway.rst
@@ -51,7 +51,7 @@ the :doc:`run <run>` command.  This fix is not invoked during :doc:`energy minim
 Restrictions
 """"""""""""
 
-This fix is part of the MISC package.  It is only enabled if LAMMPS
+This fix is part of the EXTRA-FIX package.  It is only enabled if LAMMPS
 was built with that package.  See the :doc:`Build package <Build_package>` page for more info.
 
 Related commands

--- a/doc/src/fix_smd.rst
+++ b/doc/src/fix_smd.rst
@@ -144,7 +144,7 @@ the :doc:`run <run>` command.  This fix is not invoked during
 Restrictions
 """"""""""""
 
-This fix is part of the MISC package.  It is only enabled if
+This fix is part of the EXTRA-FIX package.  It is only enabled if
 LAMMPS was built with that package.  See the :doc:`Build package <Build_package>` page for more info.
 
 Related commands


### PR DESCRIPTION
**Summary**

I fixed some instances in the documentation where commands were listed under the MISC package but were moved to an EXTRA-X package.

**Related Issue(s)**

NA

**Author(s)**

Joel Clemmer (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).


