### PR TITLE
[BUGFIX] Wrong block reading in ReaderNative::read_atoms when binary is True and natom > 1024

### DIFF
--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -469,12 +469,10 @@ void ReaderNative::read_atoms(int n, int nfield, double **fields)
 
     // read chunk and write as size_one values per line 
     // until end of timestep or end of the reading buffer
-    int i_atom = 0;
-    int m;
-    bool continue_reading = true;
-    bool continue_chunks = true;
-    while (continue_reading && continue_chunks){
-
+    int m=size_one*iatom_chunk;
+    bool continue_reading = (n>0);
+    bool continue_chunks = (ichunk<nchunk);
+    for (int i = 0; i < n; i++){
       // if the last chunk has finished
       if (iatom_chunk == 0) {
           read_buf(&natom_chunk, sizeof(int), 1);
@@ -485,12 +483,12 @@ void ReaderNative::read_atoms(int n, int nfield, double **fields)
 
       // read one line of atom
       double *words = &databuf[m];
+
       for (int k = 0; k < nfield; k++)
-        fields[i_atom][k] = words[fieldindex[k]];
+        fields[i][k] = words[fieldindex[k]];
       m+=size_one;
 
       iatom_chunk++;
-      i_atom++;
 
       // hit the end of current chunk 
       if (iatom_chunk == natom_chunk) 
@@ -498,14 +496,7 @@ void ReaderNative::read_atoms(int n, int nfield, double **fields)
         iatom_chunk = 0; 
         ichunk++;
       }
-
-      // hit the end of atom block
-      if (ichunk == nchunk) continue_chunks = false; 
-
-      // hit the end of the reading buffer
-      if (i_atom == n) continue_reading = false;
     }
-
   } else {
     int i,m;
     char *eof;
@@ -565,6 +556,7 @@ void ReaderNative::read_buf(void * ptr, size_t size, size_t count)
 
 void ReaderNative::read_double_chunk(size_t count)
 {
+  if (count < 0) return;
   // extend buffer to fit chunk size
   if (count > maxbuf) {
     memory->grow(databuf,count,"reader:databuf");

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -144,13 +144,7 @@ void ReaderNative::skip()
     int n;
     for (int i = 0; i < nchunk; i++) {
       read_buf(&n, sizeof(int), 1);
-      int nremain = n;
-      int nbuf;
-      while (nremain){
-        nbuf = MIN(nremain,MAXSMALLINT);
-        skip_buf(nbuf*sizeof(double));
-        nremain -= nbuf;
-      }
+      skip_buf(n*sizeof(double));
     }
 
   } else {

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -486,10 +486,9 @@ void ReaderNative::read_atoms(int n, int nfield, double **fields)
 
       iatom_chunk++;
 
-      // hit the end of current chunk 
-      if (iatom_chunk == natom_chunk) 
-      {
-        iatom_chunk = 0; 
+      // hit the end of current chunk
+      if (iatom_chunk == natom_chunk) {
+        iatom_chunk = 0;
         ichunk++;
       }
     }

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -126,9 +126,8 @@ int ReaderNative::read_time(bigint &ntimestep)
 void ReaderNative::skip()
 {
   if (binary) {
-    bigint natoms;
     int triclinic;
-    read_buf(&natoms, sizeof(bigint), 1);
+    skip_buf(sizeof(bigint));
     read_buf(&triclinic, sizeof(int), 1);
     skip_buf((sizeof(int)+sizeof(double))*6);
     if (triclinic) {
@@ -145,7 +144,13 @@ void ReaderNative::skip()
     int n;
     for (int i = 0; i < nchunk; i++) {
       read_buf(&n, sizeof(int), 1);
-      skip_buf(n*sizeof(double));
+      int nremain = n;
+      int nbuf;
+      while (nremain){
+        nbuf = MIN(nremain,MAXSMALLINT);
+        skip_buf(nbuf*sizeof(double));
+        nremain -= nbuf;
+      }
     }
 
   } else {

--- a/src/reader_native.h
+++ b/src/reader_native.h
@@ -46,12 +46,16 @@ class ReaderNative : public Reader {
   char *unit_style;
   int *fieldindex;
 
-  char *line;                   // line read from dump file
-  double *databuf;              // buffer for binary data
-  int nwords;                   // # of per-atom columns in dump file
+  char *line;         // line read from dump file
+  double *databuf;    // buffer for binary data
+  int nwords;         // # of per-atom columns in dump file
 
-  int size_one;                 // number of double for one atom
-  int maxbuf;                   // maximum buffer size
+  int size_one;       // number of double for one atom
+  int maxbuf;         // maximum buffer size
+  int nchunk;         // number of chunks in the binary file
+  int ichunk;         // index of current reading chunk
+  int natom_chunk;    // number of atoms in the current chunks
+  int iatom_chunk;    // index of current atom in the current chunk
 
   int find_label(const std::string &label, const std::map<std::string, int> &labels);
   void read_lines(int);


### PR DESCRIPTION
**Summary**

<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->
The previous pull #3054 made one mistake in reading custom binary format in ReaderNative class. My apology that I did not understand that Readers::read_atoms() can be called multiple times in one single configuration. Therefore, my last pull will lead to `Segmentation Fault` when the number of atoms exceeds 1024.

This pull has fixed this mistake. It records the stopping point when the last read_atoms() was called.

TODO: scale the unit test to >1024 atoms so that this boundary condition can be tested. I need some help here. @akohlmey @rbberger 

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

Lixin Sun (Harvard University), email: nw13mifaso@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

- Private attributes `ichunk`, `nchunk`, `iatom_chunk`, `natom_chunk` are added to record which chunk and which atom the reading has stopped on.
  - the `ichunk` and `iatom_chunk` are initialized as 0 at `read_time`.
  - they are increased in `read_atoms()`
- In `read_atoms()`, only requested lines are read, (instead of reading the whole configuration)

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


