### PR TITLE
Collected small changes and fixes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -339,7 +339,6 @@ pkg_depends(ML-IAP ML-SNAP)
 pkg_depends(MPIIO MPI)
 pkg_depends(ATC MANYBODY)
 pkg_depends(LATBOLTZ MPI)
-pkg_depends(PHONON KSPACE)
 pkg_depends(SCAFACOS MPI)
 pkg_depends(DIELECTRIC KSPACE)
 pkg_depends(DIELECTRIC EXTRA-PAIR)
@@ -609,7 +608,7 @@ endif()
 # packages which selectively include variants based on enabled styles
 # e.g. accelerator packages
 ######################################################################
-foreach(PKG_WITH_INCL CORESHELL QEQ OPENMP DPD-SMOOTH KOKKOS OPT INTEL GPU)
+foreach(PKG_WITH_INCL CORESHELL DPD-SMOOTH PHONON QEQ OPENMP KOKKOS OPT INTEL GPU)
   if(PKG_${PKG_WITH_INCL})
     include(Packages/${PKG_WITH_INCL})
   endif()

--- a/cmake/Modules/Packages/PHONON.cmake
+++ b/cmake/Modules/Packages/PHONON.cmake
@@ -1,0 +1,9 @@
+# fix phonon may only be installed if also the FFT wrappers from KSPACE are installed
+if(NOT PKG_KSPACE)
+  get_property(LAMMPS_FIX_HEADERS GLOBAL PROPERTY FIX)
+  list(REMOVE_ITEM LAMMPS_FIX_HEADERS ${LAMMPS_SOURCE_DIR}/PHONON/fix_phonon.h)
+  set_property(GLOBAL PROPERTY FIX "${LAMMPS_FIX_HEADERS}")
+  get_target_property(LAMMPS_SOURCES lammps SOURCES)
+  list(REMOVE_ITEM LAMMPS_SOURCES ${LAMMPS_SOURCE_DIR}/PHONON/fix_phonon.cpp)
+  set_property(TARGET lammps PROPERTY SOURCES "${LAMMPS_SOURCES}")
+endif()

--- a/doc/src/Packages_details.rst
+++ b/doc/src/Packages_details.rst
@@ -1880,6 +1880,12 @@ MPIIO library.  It adds :doc:`dump styles <dump>` with a "mpiio" in
 their style name.  Restart files with an ".mpiio" suffix are also
 written and read in parallel.
 
+.. warning::
+
+   The MPIIO package is currently unmaintained and has become
+   unreliable. Use with caution.
+
+
 **Install:**
 
 The MPIIO package requires that LAMMPS is build in :ref:`MPI parallel mode <serial>`.

--- a/doc/src/dump.rst
+++ b/doc/src/dump.rst
@@ -137,7 +137,7 @@ Examples
    dump myDump all atom/gz 100 dump.atom.gz
    dump myDump all atom/zstd 100 dump.atom.zst
    dump 2 subgroup atom 50 dump.run.bin
-   dump 2 subgroup atom 50 dump.run.mpiio.bin
+   dump 2 subgroup atom/mpiio 50 dump.run.mpiio.bin
    dump 4a all custom 100 dump.myforce.* id type x y vx fx
    dump 4b flow custom 100 dump.%.myforce id type c_myF[3] v_ke
    dump 4b flow custom 100 dump.%.myforce id type c_myF[*] v_ke
@@ -218,6 +218,11 @@ parallel via the MPI-IO library.  For the remainder of this doc page,
 you should thus consider the *atom* and *atom/mpiio* styles (etc) to
 be inter-changeable.  The one exception is how the filename is
 specified for the MPI-IO styles, as explained below.
+
+.. warning::
+
+   The MPIIO package is currently unmaintained and has become
+   unreliable. Use with caution.
 
 The precision of values output to text-based dump files can be
 controlled by the :doc:`dump_modify format <dump_modify>` command and
@@ -451,6 +456,11 @@ counterparts.  This means you can write a dump file using MPI-IO and
 use the :doc:`read_dump <read_dump>` command or perform other
 post-processing, just as if the dump file was not written using
 MPI-IO.
+
+.. warning::
+
+   The MPIIO package is currently unmaintained and has become
+   unreliable. Use with caution.
 
 Note that MPI-IO dump files are one large file which all processors
 write to.  You thus cannot use the "%" wildcard character described

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -504,8 +504,7 @@ void FixGCMC::init()
     int flagall;
     MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
     if (flagall && comm->me == 0)
-      error->all(FLERR,
-       "Fix gcmc cannot exchange individual atoms belonging to a molecule");
+      error->all(FLERR, "Fix gcmc cannot exchange individual atoms belonging to a molecule");
   }
 
   // if molecules are exchanged or moved, check for unset mol IDs
@@ -520,16 +519,13 @@ void FixGCMC::init()
     int flagall;
     MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
     if (flagall && comm->me == 0)
-      error->all(FLERR,
-       "All mol IDs should be set for fix gcmc group atoms");
+      error->all(FLERR, "All mol IDs should be set for fix gcmc group atoms");
   }
 
   if (exchmode == EXCHMOL || movemode == MOVEMOL)
     if (atom->molecule_flag == 0 || !atom->tag_enable
         || (atom->map_style == Atom::MAP_NONE))
-      error->all(FLERR,
-       "Fix gcmc molecule command requires that "
-       "atoms have molecule attributes");
+      error->all(FLERR, "Fix gcmc molecule command requires that atoms have molecule attributes");
 
   // if rigidflag defined, check for rigid/small fix
   // its molecule template must be same as this one
@@ -541,9 +537,7 @@ void FixGCMC::init()
     fixrigid = modify->fix[ifix];
     int tmp;
     if (&onemols[imol] != (Molecule **) fixrigid->extract("onemol",tmp))
-      error->all(FLERR,
-                 "Fix gcmc and fix rigid/small not using "
-                 "same molecule template ID");
+      error->all(FLERR, "Fix gcmc and fix rigid/small not using same molecule template ID");
   }
 
   // if shakeflag defined, check for SHAKE fix

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -310,16 +310,13 @@ void FixWidom::init()
     int flagall;
     MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
     if (flagall && comm->me == 0)
-      error->all(FLERR,
-       "All mol IDs should be set for fix widom group atoms");
+      error->all(FLERR, "All mol IDs should be set for fix widom group atoms");
   }
 
   if (exchmode == EXCHMOL)
     if (atom->molecule_flag == 0 || !atom->tag_enable
         || (atom->map_style == Atom::MAP_NONE))
-      error->all(FLERR,
-       "Fix widom molecule command requires that "
-       "atoms have molecule attributes");
+      error->all(FLERR, "Fix widom molecule command requires that atoms have molecule attributes");
 
   if (domain->dimension == 2)
     error->all(FLERR,"Cannot use fix widom in a 2d simulation");

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -1072,10 +1072,10 @@ void FixCMAP::read_data_header(char *line)
    store CMAP interactions as if newton_bond = OFF, even if actually ON
 ------------------------------------------------------------------------- */
 
-void FixCMAP::read_data_section(char *keyword, int n, char *buf,
+void FixCMAP::read_data_section(char * /*keyword*/, int /*n*/, char *buf,
                                  tagint id_offset)
 {
-  int m,tmp,itype;
+  int m,itype;
   tagint atom1,atom2,atom3,atom4,atom5;
 
   auto lines = utils::split_lines(buf);

--- a/src/MPIIO/dump_atom_mpiio.cpp
+++ b/src/MPIIO/dump_atom_mpiio.cpp
@@ -38,7 +38,12 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DumpAtomMPIIO::DumpAtomMPIIO(LAMMPS *lmp, int narg, char **arg) : DumpAtom(lmp, narg, arg) {}
+DumpAtomMPIIO::DumpAtomMPIIO(LAMMPS *lmp, int narg, char **arg)
+  : DumpAtom(lmp, narg, arg)
+{
+  if (me == 0)
+    error->warning(FLERR,"MPI-IO output is unmaintained and unreliable. Use with caution.");
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MPIIO/dump_cfg_mpiio.cpp
+++ b/src/MPIIO/dump_cfg_mpiio.cpp
@@ -51,7 +51,11 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 DumpCFGMPIIO::DumpCFGMPIIO(LAMMPS *lmp, int narg, char **arg) :
-  DumpCFG(lmp, narg, arg) {}
+  DumpCFG(lmp, narg, arg)
+{
+  if (me == 0)
+    error->warning(FLERR,"MPI-IO output is unmaintained and unreliable. Use with caution.");
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MPIIO/dump_custom_mpiio.cpp
+++ b/src/MPIIO/dump_custom_mpiio.cpp
@@ -53,7 +53,12 @@ enum{ LT, LE, GT, GE, EQ, NEQ };
 // clang-format on
 /* ---------------------------------------------------------------------- */
 
-DumpCustomMPIIO::DumpCustomMPIIO(LAMMPS *lmp, int narg, char **arg) : DumpCustom(lmp, narg, arg) {}
+DumpCustomMPIIO::DumpCustomMPIIO(LAMMPS *lmp, int narg, char **arg)
+  : DumpCustom(lmp, narg, arg)
+{
+  if (me == 0)
+    error->warning(FLERR,"MPI-IO output is unmaintained and unreliable. Use with caution.");
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MPIIO/dump_xyz_mpiio.cpp
+++ b/src/MPIIO/dump_xyz_mpiio.cpp
@@ -52,7 +52,10 @@ enum{LT,LE,GT,GE,EQ,NEQ};
 /* ---------------------------------------------------------------------- */
 
 DumpXYZMPIIO::DumpXYZMPIIO(LAMMPS *lmp, int narg, char **arg) :
-  DumpXYZ(lmp, narg, arg) {}
+  DumpXYZ(lmp, narg, arg) {
+  if (me == 0)
+    error->warning(FLERR,"MPI-IO output is unmaintained and unreliable. Use with caution.");
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/PHONON/Install.sh
+++ b/src/PHONON/Install.sh
@@ -26,16 +26,6 @@ action () {
   fi
 }
 
-# PHONON uses the parallel FFT wrapper used in PPPM,
-# so we must require the KSPACE package to be installed.
-
-if (test $1 = 1) then
-  if (test ! -e ../fft3d_wrap.h) then
-    echo "Must install KSPACE package with PHONON"
-    exit 1
-  fi
-fi
-
 # list of files with optional dependcies
 
 action fix_phonon.cpp fft3d_wrap.h

--- a/src/REAXFF/fix_reaxff_species.cpp
+++ b/src/REAXFF/fix_reaxff_species.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -247,8 +246,8 @@ FixReaxFFSpecies::~FixReaxFFSpecies()
     if (posflag && multipos_opened) fclose(pos);
   }
 
-  modify->delete_compute("SPECATOM");
-  modify->delete_fix("SPECBOND");
+  modify->delete_compute(fmt::format("SPECATOM_{}",id));
+  modify->delete_fix(fmt::format("SPECBOND_{}",id));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -288,22 +287,16 @@ void FixReaxFFSpecies::init()
   if (nvalid != update->ntimestep)
     nvalid = update->ntimestep+nfreq;
 
-  // check if this fix has been called twice
-  int count = 0;
-  for (int i = 0; i < modify->nfix; i++)
-    if (strcmp(modify->fix[i]->style,"reaxff/species") == 0) count++;
-  if (count > 1 && comm->me == 0)
-    error->warning(FLERR,"More than one fix reaxff/species");
-
   if (!setupflag) {
     // create a compute to store properties
-    modify->add_compute("SPECATOM all SPEC/ATOM q x y z vx vy vz abo01 abo02 abo03 abo04 "
-                        "abo05 abo06 abo07 abo08 abo09 abo10 abo11 abo12 abo13 abo14 "
-                        "abo15 abo16 abo17 abo18 abo19 abo20 abo21 abo22 abo23 abo24");
+    modify->add_compute(fmt::format("SPECATOM_{} all SPEC/ATOM q x y z vx vy vz abo01 abo02 "
+                                    "abo03 abo04 abo05 abo06 abo07 abo08 abo09 abo10 abo11 "
+                                    "abo12 abo13 abo14 abo15 abo16 abo17 abo18 abo19 abo20 "
+                                    "abo21 abo22 abo23 abo24",id));
 
     // create a fix to point to fix_ave_atom for averaging stored properties
-    auto fixcmd = fmt::format("SPECBOND all ave/atom {} {} {}",nevery,nrepeat,nfreq);
-    for (int i = 1; i < 32; ++i) fixcmd += " c_SPECATOM[" + std::to_string(i) + "]";
+    auto fixcmd = fmt::format("SPECBOND_{} all ave/atom {} {} {}",id,nevery,nrepeat,nfreq);
+    for (int i = 1; i < 32; ++i) fixcmd += fmt::format(" c_SPECATOM_{}[{}]",id,i);
     f_SPECBOND = (FixAveAtom *) modify->add_fix(fixcmd);
     setupflag = 1;
   }

--- a/src/REAXFF/reaxff_ffield.cpp
+++ b/src/REAXFF/reaxff_ffield.cpp
@@ -583,6 +583,7 @@ namespace ReaxFF {
       } catch (std::exception &e) {
         error->one(FLERR,e.what());
       }
+      fclose(fp);
     }
 
     // broadcast global parameters and allocate list on ranks != 0

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -128,8 +128,7 @@ Dump::Dump(LAMMPS *lmp, int /*narg*/, char **arg) : Pointers(lmp)
   char *ptr;
   if ((ptr = strchr(filename,'%'))) {
     if (strstr(style,"mpiio"))
-      error->all(FLERR,
-                 "Dump file MPI-IO output not allowed with % in filename");
+      error->all(FLERR,"Dump file MPI-IO output not allowed with % in filename");
     multiproc = 1;
     nclusterprocs = 1;
     filewriter = 1;

--- a/src/fix_nve_sphere.cpp
+++ b/src/fix_nve_sphere.cpp
@@ -294,7 +294,6 @@ void FixNVESphere::final_integrate()
   // update v,omega for all particles
   // d_omega/dt = torque / inertia
 
-  double rke = 0.0;
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
       dtfm = dtf / rmass[i];
@@ -306,8 +305,5 @@ void FixNVESphere::final_integrate()
       omega[i][0] += dtirotate * torque[i][0];
       omega[i][1] += dtirotate * torque[i][1];
       omega[i][2] += dtirotate * torque[i][2];
-      rke += (omega[i][0]*omega[i][0] + omega[i][1]*omega[i][1] +
-              omega[i][2]*omega[i][2])*radius[i]*radius[i]*rmass[i];
     }
-
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1059,8 +1059,9 @@ static void print_columns(FILE *fp, std::map<std::string, ValueType> *styles)
   for (typename std::map<std::string, ValueType>::iterator it = styles->begin(); it != styles->end(); ++it) {
     const std::string &style_name = it->first;
 
-    // skip "secret" styles
-    if (isupper(style_name[0])) continue;
+    // skip "internal" styles
+    if (isupper(style_name[0]) || utils::strmatch(style_name,"/kk/host$")
+        || utils::strmatch(style_name,"/kk/device$")) continue;
 
     int len = style_name.length();
     if (pos + len > 80) {

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -1305,12 +1305,14 @@ void _noopt LAMMPS::help()
 
 /* ----------------------------------------------------------------------
    print style names in columns
-   skip any style that starts with upper-case letter, since internal
+   skip any internal style that starts with an upper-case letter
+   also skip "redundant" KOKKOS styles ending in kk/host or kk/device
 ------------------------------------------------------------------------- */
 
 void print_style(FILE *fp, const char *str, int &pos)
 {
-  if (isupper(str[0])) return;
+  if (isupper(str[0]) || utils::strmatch(str,"/kk/host$")
+      || utils::strmatch(str,"/kk/device$")) return;
 
   int len = strlen(str);
   if (pos+len > 80) {

--- a/src/min_linesearch.cpp
+++ b/src/min_linesearch.cpp
@@ -328,7 +328,7 @@ int MinLineSearch::linemin_quadratic(double eoriginal, double &alpha)
   int i,m,n;
   double fdothall,fdothme,hme,hmax,hmaxall;
   double de_ideal,de;
-  double delfh,engprev,relerr,alphaprev,fhprev,ff,fh,alpha0;
+  double delfh,engprev,relerr,alphaprev,fhprev,fh,alpha0;
   double dot[2],dotall[2];
   double *xatom,*x0atom,*fatom,*hatom;
   double alphamax;
@@ -439,12 +439,8 @@ int MinLineSearch::linemin_quadratic(double eoriginal, double &alpha)
         dotall[1] += fextra[i]*hextra[i];
       }
     }
-    ff = dotall[0];
     fh = dotall[1];
-    if (output->thermo->normflag) {
-      ff /= atom->natoms;
-      fh /= atom->natoms;
-    }
+    if (output->thermo->normflag) fh /= atom->natoms;
 
     delfh = fh - fhprev;
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -782,12 +782,12 @@ void Output::create_restart(int narg, char **arg)
   }
 
   int mpiioflag;
-  if (strstr(arg[1],".mpi")) mpiioflag = 1;
+  if (utils::strmatch(arg[1],"\\.mpiio$")) mpiioflag = 1;
   else mpiioflag = 0;
   if (nfile == 2) {
-    if (mpiioflag && !strstr(arg[2],".mpi"))
+    if (mpiioflag && !utils::strmatch(arg[2],"\\.mpiio$"))
       error->all(FLERR,"Both restart files must use MPI-IO or neither");
-    if (!mpiioflag && strstr(arg[2],".mpi"))
+    if (!mpiioflag && utils::strmatch(arg[2],"\\.mpiio$"))
       error->all(FLERR,"Both restart files must use MPI-IO or neither");
   }
 

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -63,10 +63,10 @@ int ReaderNative::read_time(bigint &ntimestep)
     magic_string = "";
     unit_style = "";
 
-    fread(&ntimestep, sizeof(bigint), 1, fp);
+    auto ret = fread(&ntimestep, sizeof(bigint), 1, fp);
 
     // detect end-of-file
-    if (feof(fp)) return 1;
+    if (ret != 1 || feof(fp)) return 1;
 
     // detect newer format
     if (ntimestep < 0) {
@@ -485,12 +485,8 @@ void ReaderNative::read_atoms(int n, int nfield, double **fields)
       }
     }
   } else {
-    int i,m;
-    char *eof;
-
-    for (i = 0; i < n; i++) {
-      eof = fgets(line,MAXLINE,fp);
-      if (eof == nullptr) error->one(FLERR,"Unexpected end of dump file");
+    for (int i = 0; i < n; i++) {
+      utils::sfgets(FLERR, line, MAXLINE, fp, nullptr, error);
 
       // tokenize the line
       std::vector<std::string> words = Tokenizer(line).as_vector();
@@ -499,7 +495,7 @@ void ReaderNative::read_atoms(int n, int nfield, double **fields)
 
       // convert selected fields to floats
 
-      for (m = 0; m < nfield; m++)
+      for (int m = 0; m < nfield; m++)
         fields[i][m] = atof(words[fieldindex[m]].c_str());
     }
   }
@@ -527,18 +523,14 @@ int ReaderNative::find_label(const std::string &label, const std::map<std::strin
 
 void ReaderNative::read_lines(int n)
 {
-  char *eof = nullptr;
-  if (n <= 0) return;
-  for (int i = 0; i < n; i++) eof = fgets(line,MAXLINE,fp);
-  if (eof == nullptr) error->one(FLERR,"Unexpected end of dump file");
+  for (int i = 0; i < n; i++) {
+    utils::sfgets(FLERR, line, MAXLINE, fp, nullptr, error);
+  }
 }
 
 void ReaderNative::read_buf(void * ptr, size_t size, size_t count)
 {
-  fread(ptr, size, count, fp);
-
-  // detect end-of-file
-  if (feof(fp)) error->one(FLERR,"Unexpected end of dump file");
+  utils::sfread(FLERR, ptr, size, count, fp, nullptr, error);
 }
 
 std::string ReaderNative::read_binary_str(size_t size)

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -542,7 +542,6 @@ std::string ReaderNative::read_binary_str(size_t size)
 
 void ReaderNative::read_double_chunk(size_t count)
 {
-  if (count < 0) return;
   // extend buffer to fit chunk size
   if (count > maxbuf) {
     memory->grow(databuf,count,"reader:databuf");

--- a/src/reader_native.h
+++ b/src/reader_native.h
@@ -52,7 +52,7 @@ class ReaderNative : public Reader {
   int nwords;         // # of per-atom columns in dump file
 
   int size_one;       // number of double for one atom
-  int maxbuf;         // maximum buffer size
+  size_t maxbuf;      // maximum buffer size
   int nchunk;         // number of chunks in the binary file
   int ichunk;         // index of current reading chunk
   int natom_chunk;    // number of atoms in the current chunks

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -73,8 +73,11 @@ void WriteRestart::command(int narg, char **arg)
 
   if (strchr(arg[0],'%')) multiproc = nprocs;
   else multiproc = 0;
-  if (strstr(arg[0],".mpiio")) mpiioflag = 1;
+  if (utils::strmatch(arg[0],"\\.mpiio$")) mpiioflag = 1;
   else mpiioflag = 0;
+
+  if ((comm->me == 0) && mpiioflag)
+    error->warning(FLERR,"MPI-IO output is unmaintained and unreliable. Use with caution.");
 
   // setup output style and process optional args
   // also called by Output class for periodic restart files


### PR DESCRIPTION
**Summary**

* Make use of `utils::sfread` and `utils::sfgets` in `reader_native.cpp`
* Make PHONON package consistently only a "soft" dependency on KSPACE for both build systems
* Don't output redundant '*/kk/host' or '*/kk/device' KOKKOS styles in help or info output for improved readability
* Add warnings that MPIIO is unreliable and unmaintained
* Update `fix reaxff/species` so it can be invoked multiple times
* Fix a memory and file descriptor leak in REAXFF

**Related Issue(s)**

**Author(s)**

Richard Berger and Axel Kohlmeyer (Temple U)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

