### PR TITLE
Modernize parsing of topology data sections of data files

### DIFF
--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -56,11 +56,11 @@ String to number conversions with validity check
 
 These functions should be used to convert strings to numbers. They are
 are strongly preferred over C library calls like ``atoi()`` or
-``atof()`` since they check if the **entire** provided string is a valid
+``atof()`` since they check if the **entire** string is a valid
 (floating-point or integer) number, and will error out instead of
 silently returning the result of a partial conversion or zero in cases
-where the string is not a valid number.  This behavior allows to more
-easily detect typos or issues when processing input files.
+where the string is not a valid number.  This behavior improves
+detecting typos or issues when processing input files.
 
 Similarly the :cpp:func:`logical() <LAMMPS_NS::utils::logical>` function
 will convert a string into a boolean and will only accept certain words.
@@ -76,19 +76,34 @@ strings for compliance without conversion.
 
 ----------
 
-.. doxygenfunction:: numeric
+.. doxygenfunction:: numeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp)
    :project: progguide
 
-.. doxygenfunction:: inumeric
+.. doxygenfunction:: numeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
    :project: progguide
 
-.. doxygenfunction:: bnumeric
+.. doxygenfunction:: inumeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp)
    :project: progguide
 
-.. doxygenfunction:: tnumeric
+.. doxygenfunction:: inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
    :project: progguide
 
-.. doxygenfunction:: logical
+.. doxygenfunction:: bnumeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp)
+   :project: progguide
+
+.. doxygenfunction:: bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+   :project: progguide
+
+.. doxygenfunction:: tnumeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp)
+   :project: progguide
+
+.. doxygenfunction:: tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+   :project: progguide
+
+.. doxygenfunction:: logical(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp)
+   :project: progguide
+
+.. doxygenfunction:: logical(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
    :project: progguide
 
 

--- a/doc/src/Developer_write.rst
+++ b/doc/src/Developer_write.rst
@@ -55,7 +55,7 @@ of each timestep. First of all, implement a constructor:
      if (narg < 4)
        error->all(FLERR,"Illegal fix print/vel command");
 
-     nevery = utils::inumeric(FLERR,arg[3]);
+     nevery = utils::inumeric(FLERR,arg[3],false,lmp);
      if (nevery <= 0)
        error->all(FLERR,"Illegal fix print/vel command");
    }

--- a/doc/src/Developer_write.rst
+++ b/doc/src/Developer_write.rst
@@ -55,7 +55,7 @@ of each timestep. First of all, implement a constructor:
      if (narg < 4)
        error->all(FLERR,"Illegal fix print/vel command");
 
-     nevery = force->inumeric(FLERR,arg[3]);
+     nevery = utils::inumeric(FLERR,arg[3]);
      if (nevery <= 0)
        error->all(FLERR,"Illegal fix print/vel command");
    }

--- a/src/KOKKOS/atom_vec_angle_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_angle_kokkos.cpp
@@ -1630,7 +1630,7 @@ void AtomVecAngleKokkos::create_atom(int itype, double *coord)
 ------------------------------------------------------------------------- */
 
 void AtomVecAngleKokkos::data_atom(double *coord, imageint imagetmp,
-                                  char **values)
+                                  const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
@@ -1663,9 +1663,10 @@ void AtomVecAngleKokkos::data_atom(double *coord, imageint imagetmp,
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecAngleKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecAngleKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                         int offset)
 {
-  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[offset],true,lmp);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   return 1;

--- a/src/KOKKOS/atom_vec_angle_kokkos.h
+++ b/src/KOKKOS/atom_vec_angle_kokkos.h
@@ -51,8 +51,8 @@ class AtomVecAngleKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, tagint, char **);
-  int data_atom_hybrid(int, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_atomic_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_atomic_kokkos.cpp
@@ -821,8 +821,8 @@ void AtomVecAtomicKokkos::create_atom(int itype, double *coord)
    initialize other atom quantities
 ------------------------------------------------------------------------- */
 
-void AtomVecAtomicKokkos::data_atom(double *coord, tagint imagetmp,
-                                    char **values)
+void AtomVecAtomicKokkos::data_atom(double *coord, imageint imagetmp,
+                                    const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);

--- a/src/KOKKOS/atom_vec_atomic_kokkos.h
+++ b/src/KOKKOS/atom_vec_atomic_kokkos.h
@@ -44,7 +44,7 @@ class AtomVecAtomicKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, tagint, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
   void pack_data(double **);
   void write_data(FILE *, int, double **);
   double memory_usage();

--- a/src/KOKKOS/atom_vec_bond_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_bond_kokkos.cpp
@@ -1056,7 +1056,7 @@ void AtomVecBondKokkos::create_atom(int itype, double *coord)
 ------------------------------------------------------------------------- */
 
 void AtomVecBondKokkos::data_atom(double *coord, imageint imagetmp,
-                                  char **values)
+                                  const std::vector<std::string> &values)
 {
   int nlocal = atomKK->nlocal;
   if (nlocal == nmax) grow(0);
@@ -1088,9 +1088,10 @@ void AtomVecBondKokkos::data_atom(double *coord, imageint imagetmp,
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecBondKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecBondKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                        int offset)
 {
-  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[offset],true,lmp);
   h_num_bond(nlocal) = 0;
   return 1;
 }

--- a/src/KOKKOS/atom_vec_bond_kokkos.h
+++ b/src/KOKKOS/atom_vec_bond_kokkos.h
@@ -45,8 +45,8 @@ class AtomVecBondKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, tagint, char **);
-  int data_atom_hybrid(int, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_charge_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_charge_kokkos.cpp
@@ -955,7 +955,7 @@ void AtomVecChargeKokkos::create_atom(int itype, double *coord)
 ------------------------------------------------------------------------- */
 
 void AtomVecChargeKokkos::data_atom(double *coord, imageint imagetmp,
-                                    char **values)
+                                    const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
@@ -987,9 +987,10 @@ void AtomVecChargeKokkos::data_atom(double *coord, imageint imagetmp,
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecChargeKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecChargeKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                          int offset)
 {
-  h_q[nlocal] = utils::numeric(FLERR,values[0],true,lmp);
+  h_q[nlocal] = utils::numeric(FLERR,values[offset],true,lmp);
 
   return 1;
 }

--- a/src/KOKKOS/atom_vec_charge_kokkos.h
+++ b/src/KOKKOS/atom_vec_charge_kokkos.h
@@ -46,8 +46,8 @@ class AtomVecChargeKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, tagint, char **);
-  int data_atom_hybrid(int , char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int , const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_dpd_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.cpp
@@ -1716,8 +1716,8 @@ void AtomVecDPDKokkos::create_atom(int itype, double *coord)
    initialize other atom quantities
 ------------------------------------------------------------------------- */
 
-void AtomVecDPDKokkos::data_atom(double *coord, tagint imagetmp,
-                                    char **values)
+void AtomVecDPDKokkos::data_atom(double *coord, imageint imagetmp,
+                                 const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
@@ -1759,9 +1759,10 @@ void AtomVecDPDKokkos::data_atom(double *coord, tagint imagetmp,
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecDPDKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecDPDKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                       int offset)
 {
-  h_dpdTheta(nlocal) = utils::numeric(FLERR,values[0],true,lmp);
+  h_dpdTheta(nlocal) = utils::numeric(FLERR,values[offset],true,lmp);
 
   atomKK->modified(Host,DPDTHETA_MASK);
 

--- a/src/KOKKOS/atom_vec_dpd_kokkos.h
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.h
@@ -54,8 +54,8 @@ class AtomVecDPDKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, tagint, char **);
-  int data_atom_hybrid(int, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_full_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_full_kokkos.cpp
@@ -1488,7 +1488,7 @@ void AtomVecFullKokkos::create_atom(int itype, double *coord)
 ------------------------------------------------------------------------- */
 
 void AtomVecFullKokkos::data_atom(double *coord, imageint imagetmp,
-                                       char **values)
+                                  const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
@@ -1525,10 +1525,11 @@ void AtomVecFullKokkos::data_atom(double *coord, imageint imagetmp,
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecFullKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecFullKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                        int offset)
 {
-  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
-  h_q(nlocal) = utils::numeric(FLERR,values[1],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[offset],true,lmp);
+  h_q(nlocal) = utils::numeric(FLERR,values[offset+1],true,lmp);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   h_num_dihedral(nlocal) = 0;

--- a/src/KOKKOS/atom_vec_full_kokkos.h
+++ b/src/KOKKOS/atom_vec_full_kokkos.h
@@ -45,8 +45,8 @@ class AtomVecFullKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, tagint, char **);
-  int data_atom_hybrid(int, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
@@ -970,7 +970,8 @@ void AtomVecHybridKokkos::create_atom(int itype, double *coord)
    grow() occurs here so arrays for all sub-styles are grown
 ------------------------------------------------------------------------- */
 
-void AtomVecHybridKokkos::data_atom(double *coord, imageint imagetmp, char **values)
+void AtomVecHybridKokkos::data_atom(double *coord, imageint imagetmp,
+                                    const std::vector<std::string> &values)
 {
   atomKK->sync(Host,X_MASK|TAG_MASK|TYPE_MASK|IMAGE_MASK|MASK_MASK|V_MASK|OMEGA_MASK/*|ANGMOM_MASK*/);
 
@@ -1009,7 +1010,7 @@ void AtomVecHybridKokkos::data_atom(double *coord, imageint imagetmp, char **val
 
   int m = 5;
   for (int k = 0; k < nstyles; k++)
-    m += styles[k]->data_atom_hybrid(nlocal,&values[m]);
+    m += styles[k]->data_atom_hybrid(nlocal,values,m);
 
   atom->nlocal++;
 }

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.cpp
@@ -1019,21 +1019,21 @@ void AtomVecHybridKokkos::data_atom(double *coord, imageint imagetmp,
    unpack one line from Velocities section of data file
 ------------------------------------------------------------------------- */
 
-void AtomVecHybridKokkos::data_vel(int m, char **values)
+void AtomVecHybridKokkos::data_vel(int m, const std::vector<std::string> &values)
 {
   atomKK->sync(Host,V_MASK);
 
-  h_v(m,0) = utils::numeric(FLERR,values[0],true,lmp);
-  h_v(m,1) = utils::numeric(FLERR,values[1],true,lmp);
-  h_v(m,2) = utils::numeric(FLERR,values[2],true,lmp);
+  int ivalue = 1;
+  h_v(m,0) = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  h_v(m,1) = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  h_v(m,2) = utils::numeric(FLERR,values[ivalue++],true,lmp);
 
   atomKK->modified(Host,V_MASK);
 
   // each sub-style parses sub-style specific values
 
-  int n = 3;
   for (int k = 0; k < nstyles; k++)
-    n += styles[k]->data_vel_hybrid(m,&values[n]);
+    ivalue += styles[k]->data_vel_hybrid(m,values,ivalue);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.h
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.h
@@ -57,8 +57,8 @@ class AtomVecHybridKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, imageint, char **);
-  int data_atom_hybrid(int, char **) {return 0;}
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int) {return 0;}
   void data_vel(int, char **);
   void pack_data(double **);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_hybrid_kokkos.h
+++ b/src/KOKKOS/atom_vec_hybrid_kokkos.h
@@ -59,7 +59,7 @@ class AtomVecHybridKokkos : public AtomVecKokkos {
   void create_atom(int, double *);
   void data_atom(double *, imageint, const std::vector<std::string> &);
   int data_atom_hybrid(int, const std::vector<std::string> &, int) {return 0;}
-  void data_vel(int, char **);
+  void data_vel(int, const std::vector<std::string> &);
   void pack_data(double **);
   void write_data(FILE *, int, double **);
   void pack_vel(double **);

--- a/src/KOKKOS/atom_vec_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_kokkos.cpp
@@ -1016,12 +1016,13 @@ void AtomVecKokkos::unpack_reverse(int n, int *list, double *buf)
  *    unpack one line from Velocities section of data file
  *    ------------------------------------------------------------------------- */
 
-void AtomVecKokkos::data_vel(int m, char **values)
+void AtomVecKokkos::data_vel(int m, const std::vector<std::string> &values)
 {
   double **v = atom->v;
-  v[m][0] = utils::numeric(FLERR,values[0],true,lmp);
-  v[m][1] = utils::numeric(FLERR,values[1],true,lmp);
-  v[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  int ivalue = 1;
+  v[m][0] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  v[m][1] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  v[m][2] = utils::numeric(FLERR,values[ivalue++],true,lmp);
 
   atomKK->modified(Host,V_MASK);
 }

--- a/src/KOKKOS/atom_vec_kokkos.h
+++ b/src/KOKKOS/atom_vec_kokkos.h
@@ -44,7 +44,7 @@ class AtomVecKokkos : public AtomVec {
   virtual void unpack_comm_vel(int, int, double *);
   virtual int pack_reverse(int, int, double *);
   virtual void unpack_reverse(int, int *, double *);
-  virtual void data_vel(int, char **);
+  virtual void data_vel(int, const std::vector<std::string> &);
   virtual void pack_vel(double **);
   virtual void write_vel(FILE *, int, double **);
 

--- a/src/KOKKOS/atom_vec_molecular_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_molecular_kokkos.cpp
@@ -1889,7 +1889,7 @@ void AtomVecMolecularKokkos::create_atom(int itype, double *coord)
 ------------------------------------------------------------------------- */
 
 void AtomVecMolecularKokkos::data_atom(double *coord, imageint imagetmp,
-                                       char **values)
+                                       const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
@@ -1924,9 +1924,10 @@ void AtomVecMolecularKokkos::data_atom(double *coord, imageint imagetmp,
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecMolecularKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecMolecularKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                             int offset)
 {
-  h_molecule(nlocal) = utils::inumeric(FLERR,values[0],true,lmp);
+  h_molecule(nlocal) = utils::inumeric(FLERR,values[offset],true,lmp);
   h_num_bond(nlocal) = 0;
   h_num_angle(nlocal) = 0;
   h_num_dihedral(nlocal) = 0;

--- a/src/KOKKOS/atom_vec_molecular_kokkos.h
+++ b/src/KOKKOS/atom_vec_molecular_kokkos.h
@@ -51,8 +51,8 @@ class AtomVecMolecularKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, tagint, char **);
-  int data_atom_hybrid(int, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_sphere_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.cpp
@@ -2617,15 +2617,16 @@ int AtomVecSphereKokkos::data_atom_hybrid(int nlocal, const std::vector<std::str
    unpack one line from Velocities section of data file
 ------------------------------------------------------------------------- */
 
-void AtomVecSphereKokkos::data_vel(int m, char **values)
+void AtomVecSphereKokkos::data_vel(int m, const std::vector<std::string> &values)
 {
+  int ivalue = 1;
   atomKK->sync(Host,V_MASK|OMEGA_MASK);
-  h_v(m,0) = utils::numeric(FLERR,values[0],true,lmp);
-  h_v(m,1) = utils::numeric(FLERR,values[1],true,lmp);
-  h_v(m,2) = utils::numeric(FLERR,values[2],true,lmp);
-  h_omega(m,0) = utils::numeric(FLERR,values[3],true,lmp);
-  h_omega(m,1) = utils::numeric(FLERR,values[4],true,lmp);
-  h_omega(m,2) = utils::numeric(FLERR,values[5],true,lmp);
+  h_v(m,0) = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  h_v(m,1) = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  h_v(m,2) = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  h_omega(m,0) = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  h_omega(m,1) = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  h_omega(m,2) = utils::numeric(FLERR,values[ivalue++],true,lmp);
   atomKK->modified(Host,V_MASK|OMEGA_MASK);
 }
 
@@ -2633,12 +2634,13 @@ void AtomVecSphereKokkos::data_vel(int m, char **values)
    unpack hybrid quantities from one line in Velocities section of data file
 ------------------------------------------------------------------------- */
 
-int AtomVecSphereKokkos::data_vel_hybrid(int m, char **values)
+int AtomVecSphereKokkos::data_vel_hybrid(int m, const std::vector<std::string> &values,
+                                         int offset)
 {
   atomKK->sync(Host,OMEGA_MASK);
-  omega[m][0] = utils::numeric(FLERR,values[0],true,lmp);
-  omega[m][1] = utils::numeric(FLERR,values[1],true,lmp);
-  omega[m][2] = utils::numeric(FLERR,values[2],true,lmp);
+  omega[m][0] = utils::numeric(FLERR,values[offset],true,lmp);
+  omega[m][1] = utils::numeric(FLERR,values[offset+1],true,lmp);
+  omega[m][2] = utils::numeric(FLERR,values[offset+2],true,lmp);
   atomKK->modified(Host,OMEGA_MASK);
   return 3;
 }

--- a/src/KOKKOS/atom_vec_sphere_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.cpp
@@ -2543,7 +2543,8 @@ void AtomVecSphereKokkos::create_atom(int itype, double *coord)
    initialize other atom quantities
 ------------------------------------------------------------------------- */
 
-void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp, char **values)
+void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp,
+                                    const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
@@ -2590,13 +2591,14 @@ void AtomVecSphereKokkos::data_atom(double *coord, imageint imagetmp, char **val
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecSphereKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecSphereKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                          int offset)
 {
-  radius[nlocal] = 0.5 * utils::numeric(FLERR,values[0],true,lmp);
+  radius[nlocal] = 0.5 * utils::numeric(FLERR,values[offset],true,lmp);
   if (radius[nlocal] < 0.0)
     error->one(FLERR,"Invalid radius in Atoms section of data file");
 
-  double density = utils::numeric(FLERR,values[1],true,lmp);
+  double density = utils::numeric(FLERR,values[offset+1],true,lmp);
   if (density <= 0.0)
     error->one(FLERR,"Invalid density in Atoms section of data file");
 

--- a/src/KOKKOS/atom_vec_sphere_kokkos.h
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.h
@@ -58,8 +58,8 @@ class AtomVecSphereKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, imageint, char **);
-  int data_atom_hybrid(int, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int);
   void data_vel(int, char **);
   int data_vel_hybrid(int, char **);
   void pack_data(double **);

--- a/src/KOKKOS/atom_vec_sphere_kokkos.h
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.h
@@ -60,8 +60,8 @@ class AtomVecSphereKokkos : public AtomVecKokkos {
   void create_atom(int, double *);
   void data_atom(double *, imageint, const std::vector<std::string> &);
   int data_atom_hybrid(int, const std::vector<std::string> &, int);
-  void data_vel(int, char **);
-  int data_vel_hybrid(int, char **);
+  void data_vel(int, const std::vector<std::string> &);
+  int data_vel_hybrid(int, const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/KOKKOS/atom_vec_spin_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_spin_kokkos.cpp
@@ -1056,7 +1056,7 @@ void AtomVecSpinKokkos::create_atom(int itype, double *coord)
 ------------------------------------------------------------------------- */
 
 void AtomVecSpinKokkos::data_atom(double *coord, imageint imagetmp,
-                                    char **values)
+                                  const std::vector<std::string> &values)
 {
   int nlocal = atom->nlocal;
   if (nlocal == nmax) grow(0);
@@ -1098,12 +1098,13 @@ void AtomVecSpinKokkos::data_atom(double *coord, imageint imagetmp,
    initialize other atom quantities for this sub-style
 ------------------------------------------------------------------------- */
 
-int AtomVecSpinKokkos::data_atom_hybrid(int nlocal, char **values)
+int AtomVecSpinKokkos::data_atom_hybrid(int nlocal, const std::vector<std::string> &values,
+                                        int offset)
 {
-  h_sp(nlocal,3) = utils::numeric(FLERR,values[0],true,lmp);
-  h_sp(nlocal,0) = utils::numeric(FLERR,values[1],true,lmp);
-  h_sp(nlocal,1) = utils::numeric(FLERR,values[2],true,lmp);
-  h_sp(nlocal,2) = utils::numeric(FLERR,values[3],true,lmp);
+  h_sp(nlocal,3) = utils::numeric(FLERR,values[offset],true,lmp);
+  h_sp(nlocal,0) = utils::numeric(FLERR,values[offset+1],true,lmp);
+  h_sp(nlocal,1) = utils::numeric(FLERR,values[offset+2],true,lmp);
+  h_sp(nlocal,2) = utils::numeric(FLERR,values[offset+3],true,lmp);
   double inorm = 1.0/sqrt(sp[nlocal][0]*sp[nlocal][0] +
                           sp[nlocal][1]*sp[nlocal][1] +
                           sp[nlocal][2]*sp[nlocal][2]);

--- a/src/KOKKOS/atom_vec_spin_kokkos.h
+++ b/src/KOKKOS/atom_vec_spin_kokkos.h
@@ -45,8 +45,8 @@ class AtomVecSpinKokkos : public AtomVecKokkos {
   int pack_restart(int, double *);
   int unpack_restart(double *);
   void create_atom(int, double *);
-  void data_atom(double *, imageint, char **);
-  int data_atom_hybrid(int, char **);
+  void data_atom(double *, imageint, const std::vector<std::string> &);
+  int data_atom_hybrid(int, const std::vector<std::string> &, int);
   void pack_data(double **);
   int pack_data_hybrid(int, double *);
   void write_data(FILE *, int, double **);

--- a/src/ML-IAP/mliap_descriptor_so3.cpp
+++ b/src/ML-IAP/mliap_descriptor_so3.cpp
@@ -125,28 +125,27 @@ void MLIAPDescriptorSO3::read_paramfile(char *paramfilename)
 
     // check for keywords with one value per element
 
-    if (strcmp(skeywd.c_str(), "elems") == 0 || strcmp(skeywd.c_str(), "radelems") == 0 ||
-        strcmp(skeywd.c_str(), "welems") == 0) {
+    if ((skeywd == "elems") || (skeywd == "radelems") || (skeywd == "welems"))  {
 
       if (nelementsflag == 0 || nwords != nelements + 1)
         error->all(FLERR, "Incorrect SO3 parameter file");
 
-      if (strcmp(skeywd.c_str(), "elems") == 0) {
+      if (skeywd == "elems") {
         for (int ielem = 0; ielem < nelements; ielem++) {
           elements[ielem] = utils::strdup(skeyval);
           if (ielem < nelements - 1) skeyval = p.next();
         }
 
         elementsflag = 1;
-      } else if (strcmp(skeywd.c_str(), "radelems") == 0) {
+      } else if (skeywd == "radelems")  {
         for (int ielem = 0; ielem < nelements; ielem++) {
-          radelem[ielem] = utils::numeric(FLERR, skeyval.c_str(), false, lmp);
+          radelem[ielem] = utils::numeric(FLERR, skeyval, false, lmp);
           if (ielem < nelements - 1) skeyval = p.next();
         }
         radelemflag = 1;
-      } else if (strcmp(skeywd.c_str(), "welems") == 0) {
+      } else if (skeywd == "welems") {
         for (int ielem = 0; ielem < nelements; ielem++) {
-          wjelem[ielem] = utils::numeric(FLERR, skeyval.c_str(), false, lmp);
+          wjelem[ielem] = utils::numeric(FLERR, skeyval, false, lmp);
           if (ielem < nelements - 1) skeyval = p.next();
         }
         wjelemflag = 1;
@@ -158,23 +157,23 @@ void MLIAPDescriptorSO3::read_paramfile(char *paramfilename)
 
       if (nwords != 2) error->all(FLERR, "Incorrect SO3 parameter file");
 
-      if (strcmp(skeywd.c_str(), "nelems") == 0) {
-        nelements = utils::inumeric(FLERR, skeyval.c_str(), false, lmp);
+      if (skeywd == "nelems") {
+        nelements = utils::inumeric(FLERR, skeyval, false, lmp);
         elements = new char *[nelements];
         memory->create(radelem, nelements, "mliap_so3_descriptor:radelem");
         memory->create(wjelem, nelements, "mliap_so3_descriptor:wjelem");
         nelementsflag = 1;
-      } else if (strcmp(skeywd.c_str(), "rcutfac") == 0) {
-        rcutfac = utils::numeric(FLERR, skeyval.c_str(), false, lmp);
+      } else if (skeywd == "rcutfac") {
+        rcutfac = utils::numeric(FLERR, skeyval, false, lmp);
         rcutfacflag = 1;
-      } else if (strcmp(skeywd.c_str(), "nmax") == 0) {
-        nmax = utils::inumeric(FLERR, skeyval.c_str(), false, lmp);
+      } else if (skeywd == "nmax") {
+        nmax = utils::inumeric(FLERR, skeyval, false, lmp);
         nmaxflag = 1;
-      } else if (strcmp(skeywd.c_str(), "lmax") == 0) {
-        lmax = utils::inumeric(FLERR, skeyval.c_str(), false, lmp);
+      } else if (skeywd == "lmax") {
+        lmax = utils::inumeric(FLERR, skeyval, false, lmp);
         lmaxflag = 1;
-      } else if (strcmp(skeywd.c_str(), "alpha") == 0) {
-        alpha = utils::numeric(FLERR, skeyval.c_str(), false, lmp);
+      } else if (skeywd == "alpha") {
+        alpha = utils::numeric(FLERR, skeyval, false, lmp);
         alphaflag = 1;
       } else
         error->all(FLERR, "Incorrect SO3 parameter file");

--- a/src/ML-RANN/pair_rann.cpp
+++ b/src/ML-RANN/pair_rann.cpp
@@ -440,7 +440,7 @@ void PairRANN::read_mass(const std::vector<std::string> &line1, const std::vecto
   if (nelements == -1)error->one(filename,linenum-1,"atom types must be defined before mass in potential file.");
   for (int i=0;i<nelements;i++) {
     if (line1[1].compare(elements[i])==0) {
-      mass[i]=utils::numeric(filename,linenum,line2[0].c_str(),true,lmp);
+      mass[i]=utils::numeric(filename,linenum,line2[0],true,lmp);
       return;
     }
   }
@@ -452,7 +452,7 @@ void PairRANN::read_fpe(std::vector<std::string> line,std::vector<std::string> l
   if (nelements == -1)error->one(filename,linenum-1,"atom types must be defined before fingerprints per element in potential file.");
   for (i=0;i<nelementsp;i++) {
     if (line[1].compare(elementsp[i])==0) {
-      fingerprintperelement[i] = utils::inumeric(filename,linenum,line1[0].c_str(),true,lmp);
+      fingerprintperelement[i] = utils::inumeric(filename,linenum,line1[0],true,lmp);
       fingerprints[i] = new RANN::Fingerprint *[fingerprintperelement[i]];
       for (int j=0;j<fingerprintperelement[i];j++) {
         fingerprints[i][j]=new RANN::Fingerprint(this);
@@ -491,7 +491,7 @@ void PairRANN::read_fingerprints(std::vector<std::string> line,std::vector<std::
     fingerprints[i][i1] = create_fingerprint(line1[k].c_str());
     if (fingerprints[i][i1]->n_body_type!=nwords-1) {error->one(filename,linenum,"invalid fingerprint for element combination");}
     k++;
-    fingerprints[i][i1]->init(atomtypes,utils::inumeric(filename,linenum,line1[k++].c_str(),true,lmp));
+    fingerprints[i][i1]->init(atomtypes,utils::inumeric(filename,linenum,line1[k++],true,lmp));
     fingerprintcount[i]++;
   }
   delete[] atomtypes;
@@ -523,7 +523,7 @@ void PairRANN::read_fingerprint_constants(std::vector<std::string> line,std::vec
     for (j=0;j<n_body_type;j++) {
       if (fingerprints[i][k]->atomtypes[j]!=atomtypes[j]) {break;}
       if (j==n_body_type-1) {
-        if (line[nwords-3].compare(fingerprints[i][k]->style)==0 && utils::inumeric(filename,linenum,line[nwords-2].c_str(),true,lmp)==fingerprints[i][k]->id) {
+        if (line[nwords-3].compare(fingerprints[i][k]->style)==0 && utils::inumeric(filename,linenum,line[nwords-2],true,lmp)==fingerprints[i][k]->id) {
           found=true;
           i1 = k;
           break;
@@ -542,7 +542,7 @@ void PairRANN::read_network_layers(std::vector<std::string> line,std::vector<std
   if (nelements == -1)error->one(filename,linenum-1,"atom types must be defined before network layers in potential file.");
   for (i=0;i<nelements;i++) {
     if (line[1].compare(elements[i])==0) {
-      net[i].layers = utils::inumeric(filename,linenum,line1[0].c_str(),true,lmp);
+      net[i].layers = utils::inumeric(filename,linenum,line1[0],true,lmp);
       if (net[i].layers < 1)error->one(filename,linenum,"invalid number of network layers");
       delete[] net[i].dimensions;
       weightdefined[i] = new bool [net[i].layers];
@@ -570,9 +570,9 @@ void PairRANN::read_layer_size(std::vector<std::string> line,std::vector<std::st
   for (i=0;i<nelements;i++) {
     if (line[1].compare(elements[i])==0) {
       if (net[i].layers==0)error->one(filename,linenum-1,"networklayers for each atom type must be defined before the corresponding layer sizes.");
-      int j = utils::inumeric(filename,linenum,line[2].c_str(),true,lmp);
+      int j = utils::inumeric(filename,linenum,line[2],true,lmp);
       if (j>=net[i].layers || j<0) {error->one(filename,linenum,"invalid layer in layer size definition");};
-      net[i].dimensions[j]= utils::inumeric(filename,linenum,line1[0].c_str(),true,lmp);
+      net[i].dimensions[j]= utils::inumeric(filename,linenum,line1[0],true,lmp);
       return;
     }
   }
@@ -587,7 +587,7 @@ void PairRANN::read_weight(std::vector<std::string> line,std::vector<std::string
   for (l=0;l<nelements;l++) {
     if (line[1].compare(elements[l])==0) {
       if (net[l].layers==0)error->one(filename,*linenum-1,"networklayers must be defined before weights.");
-      i=utils::inumeric(filename,*linenum,line[2].c_str(),true,lmp);
+      i=utils::inumeric(filename,*linenum,line[2],true,lmp);
       if (i>=net[l].layers || i<0)error->one(filename,*linenum-1,"invalid weight layer");
       if (net[l].dimensions[i]==0 || net[l].dimensions[i+1]==0) error->one(filename,*linenum-1,"network layer sizes must be defined before corresponding weight");
       net[l].Weights[i] = new double[net[l].dimensions[i]*net[l].dimensions[i+1]];
@@ -595,7 +595,7 @@ void PairRANN::read_weight(std::vector<std::string> line,std::vector<std::string
       nwords = line1.size();
       if (nwords != net[l].dimensions[i])error->one(filename,*linenum,"invalid weights per line");
       for (k=0;k<net[l].dimensions[i];k++) {
-        net[l].Weights[i][k] = utils::numeric(filename,*linenum,line1[k].c_str(),true,lmp);
+        net[l].Weights[i][k] = utils::numeric(filename,*linenum,line1[k],true,lmp);
       }
       for (j=1;j<net[l].dimensions[i+1];j++) {
         ptr = fgets(linetemp,longline,fp);
@@ -606,7 +606,7 @@ void PairRANN::read_weight(std::vector<std::string> line,std::vector<std::string
         nwords = line1.size();
         if (nwords != net[l].dimensions[i])error->one(filename,*linenum,"invalid weights per line");
         for (k=0;k<net[l].dimensions[i];k++) {
-          net[l].Weights[i][j*net[l].dimensions[i]+k] = utils::numeric(filename,*linenum,line1[k].c_str(),true,lmp);
+          net[l].Weights[i][j*net[l].dimensions[i]+k] = utils::numeric(filename,*linenum,line1[k],true,lmp);
         }
       }
       return;
@@ -621,19 +621,19 @@ void PairRANN::read_bias(std::vector<std::string> line,std::vector<std::string> 
   for (l=0;l<nelements;l++) {
     if (line[1].compare(elements[l])==0) {
       if (net[l].layers==0)error->one(filename,*linenum-1,"networklayers must be defined before biases.");
-      i=utils::inumeric(filename,*linenum,line[2].c_str(),true,lmp);
+      i=utils::inumeric(filename,*linenum,line[2],true,lmp);
       if (i>=net[l].layers || i<0)error->one(filename,*linenum-1,"invalid bias layer");
       if (net[l].dimensions[i]==0) error->one(filename,*linenum-1,"network layer sizes must be defined before corresponding bias");
       biasdefined[l][i] = true;
       net[l].Biases[i] = new double[net[l].dimensions[i+1]];
-      net[l].Biases[i][0] = utils::numeric(filename,*linenum,line1[0].c_str(),true,lmp);
+      net[l].Biases[i][0] = utils::numeric(filename,*linenum,line1[0],true,lmp);
       for (j=1;j<net[l].dimensions[i+1];j++) {
         ptr=fgets(linetemp,MAXLINE,fp);
         if (ptr==nullptr)error->one(filename,*linenum,"unexpected end of potential file!");
         (*linenum)++;
         Tokenizer values1 = Tokenizer(linetemp,": ,\t_\n");
         line1 = values1.as_vector();
-        net[l].Biases[i][j] = utils::numeric(filename,*linenum,line1[0].c_str(),true,lmp);
+        net[l].Biases[i][j] = utils::numeric(filename,*linenum,line1[0],true,lmp);
       }
       return;
     }
@@ -680,10 +680,10 @@ void PairRANN::read_screening(std::vector<std::string> line,std::vector<std::str
   k = atomtypes[2];
   int index = i*nelements*nelements+j*nelements+k;
   if (line[4].compare("Cmin")==0)  {
-    screening_min[index] = utils::numeric(filename,linenum,line1[0].c_str(),true,lmp);
+    screening_min[index] = utils::numeric(filename,linenum,line1[0],true,lmp);
   }
   else if (line[4].compare("Cmax")==0) {
-    screening_max[index] = utils::numeric(filename,linenum,line1[0].c_str(),true,lmp);
+    screening_max[index] = utils::numeric(filename,linenum,line1[0],true,lmp);
   }
   else error->one(filename,linenum-1,"unrecognized screening keyword");
   delete[] atomtypes;

--- a/src/ML-SNAP/pair_snap.cpp
+++ b/src/ML-SNAP/pair_snap.cpp
@@ -570,8 +570,8 @@ void PairSNAP::read_files(char *coefffilename, char *paramfilename)
     else
       elementflags[jelem] = 1;
 
-    radelem[jelem] = utils::numeric(FLERR,words[1].c_str(),false,lmp);
-    wjelem[jelem] = utils::numeric(FLERR,words[2].c_str(),false,lmp);
+    radelem[jelem] = utils::numeric(FLERR,words[1],false,lmp);
+    wjelem[jelem] = utils::numeric(FLERR,words[2],false,lmp);
 
     if (comm->me == 0)
       utils::logmesg(lmp,"SNAP Element = {}, Radius {}, Weight {}\n",
@@ -672,34 +672,33 @@ void PairSNAP::read_files(char *coefffilename, char *paramfilename)
       utils::logmesg(lmp,"SNAP keyword {} {}\n",keywd,keyval);
 
     if (keywd == "rcutfac") {
-      rcutfac = utils::numeric(FLERR,keyval.c_str(),false,lmp);
+      rcutfac = utils::numeric(FLERR,keyval,false,lmp);
       rcutfacflag = 1;
     } else if (keywd == "twojmax") {
-      twojmax = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      twojmax = utils::inumeric(FLERR,keyval,false,lmp);
       twojmaxflag = 1;
     } else if (keywd == "rfac0")
-      rfac0 = utils::numeric(FLERR,keyval.c_str(),false,lmp);
+      rfac0 = utils::numeric(FLERR,keyval,false,lmp);
     else if (keywd == "rmin0")
-      rmin0 = utils::numeric(FLERR,keyval.c_str(),false,lmp);
+      rmin0 = utils::numeric(FLERR,keyval,false,lmp);
     else if (keywd == "switchflag")
-      switchflag = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      switchflag = utils::inumeric(FLERR,keyval,false,lmp);
     else if (keywd == "bzeroflag")
-      bzeroflag = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      bzeroflag = utils::inumeric(FLERR,keyval,false,lmp);
     else if (keywd == "quadraticflag")
-      quadraticflag = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      quadraticflag = utils::inumeric(FLERR,keyval,false,lmp);
     else if (keywd == "chemflag")
-      chemflag = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      chemflag = utils::inumeric(FLERR,keyval,false,lmp);
     else if (keywd == "bnormflag")
-      bnormflag = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      bnormflag = utils::inumeric(FLERR,keyval,false,lmp);
     else if (keywd == "wselfallflag")
-      wselfallflag = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      wselfallflag = utils::inumeric(FLERR,keyval,false,lmp);
     else if (keywd == "chunksize")
-      chunksize = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      chunksize = utils::inumeric(FLERR,keyval,false,lmp);
     else if (keywd == "parallelthresh")
-      parallel_thresh = utils::inumeric(FLERR,keyval.c_str(),false,lmp);
+      parallel_thresh = utils::inumeric(FLERR,keyval,false,lmp);
     else
-      error->all(FLERR,"Unknown parameter '{}' in SNAP "
-                                   "parameter file", keywd);
+      error->all(FLERR,"Unknown parameter '{}' in SNAP parameter file", keywd);
   }
 
   if (rcutfacflag == 0 || twojmaxflag == 0)

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1144,9 +1144,9 @@ void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
 
     int imx = 0, imy = 0, imz = 0;
     if (imageflag) {
-      imx = utils::inumeric(FLERR,values[iptr].c_str(),false,lmp);
-      imy = utils::inumeric(FLERR,values[iptr+1].c_str(),false,lmp);
-      imz = utils::inumeric(FLERR,values[iptr+2].c_str(),false,lmp);
+      imx = utils::inumeric(FLERR,values[iptr],false,lmp);
+      imy = utils::inumeric(FLERR,values[iptr+1],false,lmp);
+      imz = utils::inumeric(FLERR,values[iptr+2],false,lmp);
       if ((domain->dimension == 2) && (imz != 0))
         error->all(FLERR,"Z-direction image flag must be 0 for 2d-systems");
       if ((!domain->xperiodic) && (imx != 0)) { reset_image_flag[0] = true; imx = 0; }
@@ -1157,9 +1157,9 @@ void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
         (((imageint) (imy + IMGMAX) & IMGMASK) << IMGBITS) |
         (((imageint) (imz + IMGMAX) & IMGMASK) << IMG2BITS);
 
-    xdata[0] = utils::numeric(FLERR,values[xptr].c_str(),false,lmp);
-    xdata[1] = utils::numeric(FLERR,values[xptr+1].c_str(),false,lmp);
-    xdata[2] = utils::numeric(FLERR,values[xptr+2].c_str(),false,lmp);
+    xdata[0] = utils::numeric(FLERR,values[xptr],false,lmp);
+    xdata[1] = utils::numeric(FLERR,values[xptr+1],false,lmp);
+    xdata[2] = utils::numeric(FLERR,values[xptr+2],false,lmp);
     if (shiftflag) {
       xdata[0] += shift[0];
       xdata[1] += shift[1];

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -29,6 +29,7 @@
 #include "modify.h"
 #include "molecule.h"
 #include "neighbor.h"
+#include "tokenizer.h"
 #include "update.h"
 #include "variable.h"
 
@@ -1252,18 +1253,25 @@ void Atom::data_vels(int n, char *buf, tagint id_offset)
 void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
                       int type_offset)
 {
-  int m,tmp,itype,rv;
+  int m,itype;
   tagint atom1,atom2;
   char *next;
   int newton_bond = force->newton_bond;
+  const std::string errtxt = "Bonds section of data file: ";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
     *next = '\0';
-    rv = sscanf(buf,"%d %d " TAGINT_FORMAT " " TAGINT_FORMAT,
-                &tmp,&itype,&atom1,&atom2);
-    if (rv != 4)
-      error->one(FLERR,"Incorrect format of Bonds section in data file");
+    try {
+      ValueTokenizer values(utils::trim_comment(buf));
+      values.next_int();
+      itype = values.next_int();
+      atom1 = values.next_tagint();
+      atom2 = values.next_tagint();
+      if (values.has_next()) throw TokenizerException("Too many tokens","");
+    } catch (TokenizerException &e) {
+      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+    }
     if (id_offset) {
       atom1 += id_offset;
       atom2 += id_offset;
@@ -1272,9 +1280,9 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
 
     if ((atom1 <= 0) || (atom1 > map_tag_max) ||
         (atom2 <= 0) || (atom2 > map_tag_max) || (atom1 == atom2))
-      error->one(FLERR,"Invalid atom ID in Bonds section of data file");
+      error->one(FLERR,"Invalid atom ID in " + errtxt + utils::trim(buf));
     if (itype <= 0 || itype > nbondtypes)
-      error->one(FLERR,"Invalid bond type in Bonds section of data file");
+      error->one(FLERR,"Invalid bond type in " + errtxt + utils::trim(buf));
     if ((m = map(atom1)) >= 0) {
       if (count) count[m]++;
       else {
@@ -1309,18 +1317,26 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
 void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
                        int type_offset)
 {
-  int m,tmp,itype,rv;
+  int m,itype;
   tagint atom1,atom2,atom3;
   char *next;
   int newton_bond = force->newton_bond;
+  const std::string errtxt = "Angles section of data file: ";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
     *next = '\0';
-    rv = sscanf(buf,"%d %d " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT,
-                &tmp,&itype,&atom1,&atom2,&atom3);
-    if (rv != 5)
-      error->one(FLERR,"Incorrect format of Angles section in data file");
+    try {
+      ValueTokenizer values(utils::trim_comment(buf));
+      values.next_int();
+      itype = values.next_int();
+      atom1 = values.next_tagint();
+      atom2 = values.next_tagint();
+      atom3 = values.next_tagint();
+      if (values.has_next()) throw TokenizerException("Too many tokens","");
+    } catch (TokenizerException &e) {
+      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+    }
     if (id_offset) {
       atom1 += id_offset;
       atom2 += id_offset;
@@ -1332,9 +1348,9 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
         (atom2 <= 0) || (atom2 > map_tag_max) ||
         (atom3 <= 0) || (atom3 > map_tag_max) ||
         (atom1 == atom2) || (atom1 == atom3) || (atom2 == atom3))
-      error->one(FLERR,"Invalid atom ID in Angles section of data file");
+      error->one(FLERR,"Invalid atom ID in " + errtxt + utils::trim(buf));
     if (itype <= 0 || itype > nangletypes)
-      error->one(FLERR,"Invalid angle type in Angles section of data file");
+      error->one(FLERR,"Invalid angle type in " + errtxt + utils::trim(buf));
     if ((m = map(atom2)) >= 0) {
       if (count) count[m]++;
       else {
@@ -1381,19 +1397,27 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
 void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
                           int type_offset)
 {
-  int m,tmp,itype,rv;
+  int m,itype;
   tagint atom1,atom2,atom3,atom4;
   char *next;
   int newton_bond = force->newton_bond;
+  const std::string errtxt = "Dihedrals section of data file: ";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
     *next = '\0';
-    rv = sscanf(buf,"%d %d " TAGINT_FORMAT " " TAGINT_FORMAT
-                " " TAGINT_FORMAT " " TAGINT_FORMAT,
-                &tmp,&itype,&atom1,&atom2,&atom3,&atom4);
-    if (rv != 6)
-      error->one(FLERR,"Incorrect format of Dihedrals section in data file");
+    try {
+      ValueTokenizer values(utils::trim_comment(buf));
+      values.next_int();
+      itype = values.next_int();
+      atom1 = values.next_tagint();
+      atom2 = values.next_tagint();
+      atom3 = values.next_tagint();
+      atom4 = values.next_tagint();
+      if (values.has_next()) throw TokenizerException("Too many tokens","");
+    } catch (TokenizerException &e) {
+      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+    }
     if (id_offset) {
       atom1 += id_offset;
       atom2 += id_offset;
@@ -1408,10 +1432,9 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
         (atom4 <= 0) || (atom4 > map_tag_max) ||
         (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
         (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
-      error->one(FLERR,"Invalid atom ID in Dihedrals section of data file");
+      error->one(FLERR, "Invalid atom ID in " + errtxt + utils::trim(buf));
     if (itype <= 0 || itype > ndihedraltypes)
-      error->one(FLERR,
-                 "Invalid dihedral type in Dihedrals section of data file");
+      error->one(FLERR, "Invalid dihedral type in " + errtxt + utils::trim(buf));
     if ((m = map(atom2)) >= 0) {
       if (count) count[m]++;
       else {
@@ -1472,19 +1495,27 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
 void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
                           int type_offset)
 {
-  int m,tmp,itype,rv;
+  int m,itype;
   tagint atom1,atom2,atom3,atom4;
   char *next;
   int newton_bond = force->newton_bond;
+  const std::string errtxt = "Impropers section of data file: ";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
     *next = '\0';
-    rv = sscanf(buf,"%d %d "
-                TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT " " TAGINT_FORMAT,
-                &tmp,&itype,&atom1,&atom2,&atom3,&atom4);
-    if (rv != 6)
-      error->one(FLERR,"Incorrect format of Impropers section in data file");
+    try {
+      ValueTokenizer values(utils::trim_comment(buf));
+      values.next_int();
+      itype = values.next_int();
+      atom1 = values.next_tagint();
+      atom2 = values.next_tagint();
+      atom3 = values.next_tagint();
+      atom4 = values.next_tagint();
+      if (values.has_next()) throw TokenizerException("Too many tokens","");
+    } catch (TokenizerException &e) {
+      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+    }
     if (id_offset) {
       atom1 += id_offset;
       atom2 += id_offset;
@@ -1499,10 +1530,9 @@ void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
         (atom4 <= 0) || (atom4 > map_tag_max) ||
         (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
         (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
-      error->one(FLERR,"Invalid atom ID in Impropers section of data file");
+      error->one(FLERR, "Invalid atom ID in " + errtxt + utils::trim(buf));
     if (itype <= 0 || itype > nimpropertypes)
-      error->one(FLERR,
-                 "Invalid improper type in Impropers section of data file");
+      error->one(FLERR, "Invalid improper type in " + errtxt + utils::trim(buf));
     if ((m = map(atom2)) >= 0) {
       if (count) count[m]++;
       else {

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1643,18 +1643,10 @@ void Atom::data_bodies(int n, char *buf, AtomVec *avec_body, tagint id_offset)
     ninteger = utils::inumeric(FLERR,values[1],false,lmp);
     ndouble = utils::inumeric(FLERR,values[2],false,lmp);
 
-    if (tagdata <= 0 || tagdata > map_tag_max)
-      error->one(FLERR,"Invalid atom ID in Bodies section of data file");
-
     if (unique_tags->find(tagdata) == unique_tags->end())
       unique_tags->insert(tagdata);
     else
       error->one(FLERR,"Duplicate atom ID in Bodies section of data file");
-
-    if (ninteger < 0)
-      error->one(FLERR,"Invalid number of integers in Bodies section of data file");
-    if (ndouble < 0)
-      error->one(FLERR,"Invalid number of doubles in Bodies section of data file");
 
     buf = next + 1;
     m = map(tagdata);

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1242,7 +1242,7 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
   tagint atom1,atom2;
   char *next;
   int newton_bond = force->newton_bond;
-  const std::string errtxt = "Bonds section of data file: ";
+  auto location = "Bonds section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1255,7 +1255,7 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
       atom2 = values.next_tagint();
       if (values.has_next()) throw TokenizerException("Too many tokens","");
     } catch (TokenizerException &e) {
-      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+      error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
     }
     if (id_offset) {
       atom1 += id_offset;
@@ -1265,9 +1265,9 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
 
     if ((atom1 <= 0) || (atom1 > map_tag_max) ||
         (atom2 <= 0) || (atom2 > map_tag_max) || (atom1 == atom2))
-      error->one(FLERR,"Invalid atom ID in " + errtxt + utils::trim(buf));
+      error->one(FLERR,"Invalid atom ID in {}: {}", location, utils::trim(buf));
     if (itype <= 0 || itype > nbondtypes)
-      error->one(FLERR,"Invalid bond type in " + errtxt + utils::trim(buf));
+      error->one(FLERR,"Invalid bond type in {}: {}", location, utils::trim(buf));
     if ((m = map(atom1)) >= 0) {
       if (count) count[m]++;
       else {
@@ -1306,7 +1306,7 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
   tagint atom1,atom2,atom3;
   char *next;
   int newton_bond = force->newton_bond;
-  const std::string errtxt = "Angles section of data file: ";
+  auto location = "Angles section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1320,7 +1320,7 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
       atom3 = values.next_tagint();
       if (values.has_next()) throw TokenizerException("Too many tokens","");
     } catch (TokenizerException &e) {
-      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+      error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
     }
     if (id_offset) {
       atom1 += id_offset;
@@ -1333,9 +1333,9 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
         (atom2 <= 0) || (atom2 > map_tag_max) ||
         (atom3 <= 0) || (atom3 > map_tag_max) ||
         (atom1 == atom2) || (atom1 == atom3) || (atom2 == atom3))
-      error->one(FLERR,"Invalid atom ID in " + errtxt + utils::trim(buf));
+      error->one(FLERR,"Invalid atom ID in {}: {}", location, utils::trim(buf));
     if (itype <= 0 || itype > nangletypes)
-      error->one(FLERR,"Invalid angle type in " + errtxt + utils::trim(buf));
+      error->one(FLERR,"Invalid angle type in {}: {}", location, utils::trim(buf));
     if ((m = map(atom2)) >= 0) {
       if (count) count[m]++;
       else {
@@ -1386,7 +1386,7 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
   tagint atom1,atom2,atom3,atom4;
   char *next;
   int newton_bond = force->newton_bond;
-  const std::string errtxt = "Dihedrals section of data file: ";
+  auto location = "Dihedrals section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1401,7 +1401,7 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
       atom4 = values.next_tagint();
       if (values.has_next()) throw TokenizerException("Too many tokens","");
     } catch (TokenizerException &e) {
-      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+      error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
     }
     if (id_offset) {
       atom1 += id_offset;
@@ -1417,9 +1417,9 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
         (atom4 <= 0) || (atom4 > map_tag_max) ||
         (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
         (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
-      error->one(FLERR, "Invalid atom ID in " + errtxt + utils::trim(buf));
+      error->one(FLERR, "Invalid atom ID in {}: {}", location, utils::trim(buf));
     if (itype <= 0 || itype > ndihedraltypes)
-      error->one(FLERR, "Invalid dihedral type in " + errtxt + utils::trim(buf));
+      error->one(FLERR, "Invalid dihedral type in {}: {}", location, utils::trim(buf));
     if ((m = map(atom2)) >= 0) {
       if (count) count[m]++;
       else {
@@ -1484,7 +1484,7 @@ void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
   tagint atom1,atom2,atom3,atom4;
   char *next;
   int newton_bond = force->newton_bond;
-  const std::string errtxt = "Impropers section of data file: ";
+  auto location = "Impropers section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1499,7 +1499,7 @@ void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
       atom4 = values.next_tagint();
       if (values.has_next()) throw TokenizerException("Too many tokens","");
     } catch (TokenizerException &e) {
-      error->one(FLERR,e.what() + std::string(" in ") + errtxt + utils::trim(buf));
+      error->one(FLERR,"{} in {}: {}", e.what(), location, utils::trim(buf));
     }
     if (id_offset) {
       atom1 += id_offset;
@@ -1515,9 +1515,9 @@ void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
         (atom4 <= 0) || (atom4 > map_tag_max) ||
         (atom1 == atom2) || (atom1 == atom3) || (atom1 == atom4) ||
         (atom2 == atom3) || (atom2 == atom4) || (atom3 == atom4))
-      error->one(FLERR, "Invalid atom ID in " + errtxt + utils::trim(buf));
+      error->one(FLERR, "Invalid atom ID in {}: {}", location, utils::trim(buf));
     if (itype <= 0 || itype > nimpropertypes)
-      error->one(FLERR, "Invalid improper type in " + errtxt + utils::trim(buf));
+      error->one(FLERR, "Invalid improper type in {}: {}", location, utils::trim(buf));
     if ((m = map(atom2)) >= 0) {
       if (count) count[m]++;
       else {

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1694,6 +1694,7 @@ void Atom::data_bodies(int n, char *buf, AtomVec *avec_body, tagint id_offset)
         buf += strlen(buf)+1;
       }
     }
+    buf += strspn(buf," \t\n\r\f");
   }
 
   delete[] ivalues;

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -1890,18 +1890,18 @@ void AtomVec::write_data(FILE *fp, int n, double **buf)
    unpack one line from Velocities section of data file
 ------------------------------------------------------------------------- */
 
-void AtomVec::data_vel(int ilocal, char **values)
+void AtomVec::data_vel(int ilocal, const std::vector<std::string> &values)
 {
   int m,n,datatype,cols;
   void *pdata;
 
   double **v = atom->v;
-  v[ilocal][0] = utils::numeric(FLERR,values[0],true,lmp);
-  v[ilocal][1] = utils::numeric(FLERR,values[1],true,lmp);
-  v[ilocal][2] = utils::numeric(FLERR,values[2],true,lmp);
+  int ivalue = 1;
+  v[ilocal][0] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  v[ilocal][1] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  v[ilocal][2] = utils::numeric(FLERR,values[ivalue++],true,lmp);
 
   if (ndata_vel > 2) {
-    int ivalue = 3;
     for (n = 2; n < ndata_vel; n++) {
       pdata = mdata_vel.pdata[n];
       datatype = mdata_vel.datatype[n];

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -1732,7 +1732,7 @@ void AtomVec::data_atom(double *coord, imageint imagetmp, const std::vector<std:
     if (datatype == Atom::DOUBLE) {
       if (cols == 0) {
         double *vec = *((double **) pdata);
-        vec[nlocal] = utils::numeric(FLERR,values[ivalue++].c_str(),true,lmp);
+        vec[nlocal] = utils::numeric(FLERR,values[ivalue++],true,lmp);
       } else {
         double **array = *((double ***) pdata);
         if (array == atom->x) {      // x was already set by coord arg
@@ -1740,25 +1740,25 @@ void AtomVec::data_atom(double *coord, imageint imagetmp, const std::vector<std:
           continue;
         }
         for (m = 0; m < cols; m++)
-          array[nlocal][m] = utils::numeric(FLERR,values[ivalue++].c_str(),true,lmp);
+          array[nlocal][m] = utils::numeric(FLERR,values[ivalue++],true,lmp);
       }
     } else if (datatype == Atom::INT) {
       if (cols == 0) {
         int *vec = *((int **) pdata);
-        vec[nlocal] = utils::inumeric(FLERR,values[ivalue++].c_str(),true,lmp);
+        vec[nlocal] = utils::inumeric(FLERR,values[ivalue++],true,lmp);
       } else {
         int **array = *((int ***) pdata);
         for (m = 0; m < cols; m++)
-          array[nlocal][m] = utils::inumeric(FLERR,values[ivalue++].c_str(),true,lmp);
+          array[nlocal][m] = utils::inumeric(FLERR,values[ivalue++],true,lmp);
       }
     } else if (datatype == Atom::BIGINT) {
       if (cols == 0) {
         bigint *vec = *((bigint **) pdata);
-        vec[nlocal] = utils::bnumeric(FLERR,values[ivalue++].c_str(),true,lmp);
+        vec[nlocal] = utils::bnumeric(FLERR,values[ivalue++],true,lmp);
       } else {
         bigint **array = *((bigint ***) pdata);
         for (m = 0; m < cols; m++)
-          array[nlocal][m] = utils::bnumeric(FLERR,values[ivalue++].c_str(),true,lmp);
+          array[nlocal][m] = utils::bnumeric(FLERR,values[ivalue++],true,lmp);
       }
     }
   }

--- a/src/atom_vec.cpp
+++ b/src/atom_vec.cpp
@@ -1707,7 +1707,7 @@ void AtomVec::create_atom(int itype, double *coord)
    initialize other peratom quantities
 ------------------------------------------------------------------------- */
 
-void AtomVec::data_atom(double *coord, imageint imagetmp, char **values)
+void AtomVec::data_atom(double *coord, imageint imagetmp, const std::vector<std::string> &values)
 {
   int m,n,datatype,cols;
   void *pdata;
@@ -1732,7 +1732,7 @@ void AtomVec::data_atom(double *coord, imageint imagetmp, char **values)
     if (datatype == Atom::DOUBLE) {
       if (cols == 0) {
         double *vec = *((double **) pdata);
-        vec[nlocal] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+        vec[nlocal] = utils::numeric(FLERR,values[ivalue++].c_str(),true,lmp);
       } else {
         double **array = *((double ***) pdata);
         if (array == atom->x) {      // x was already set by coord arg
@@ -1740,25 +1740,25 @@ void AtomVec::data_atom(double *coord, imageint imagetmp, char **values)
           continue;
         }
         for (m = 0; m < cols; m++)
-          array[nlocal][m] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+          array[nlocal][m] = utils::numeric(FLERR,values[ivalue++].c_str(),true,lmp);
       }
     } else if (datatype == Atom::INT) {
       if (cols == 0) {
         int *vec = *((int **) pdata);
-        vec[nlocal] = utils::inumeric(FLERR,values[ivalue++],true,lmp);
+        vec[nlocal] = utils::inumeric(FLERR,values[ivalue++].c_str(),true,lmp);
       } else {
         int **array = *((int ***) pdata);
         for (m = 0; m < cols; m++)
-          array[nlocal][m] = utils::inumeric(FLERR,values[ivalue++],true,lmp);
+          array[nlocal][m] = utils::inumeric(FLERR,values[ivalue++].c_str(),true,lmp);
       }
     } else if (datatype == Atom::BIGINT) {
       if (cols == 0) {
         bigint *vec = *((bigint **) pdata);
-        vec[nlocal] = utils::bnumeric(FLERR,values[ivalue++],true,lmp);
+        vec[nlocal] = utils::bnumeric(FLERR,values[ivalue++].c_str(),true,lmp);
       } else {
         bigint **array = *((bigint ***) pdata);
         for (m = 0; m < cols; m++)
-          array[nlocal][m] = utils::bnumeric(FLERR,values[ivalue++],true,lmp);
+          array[nlocal][m] = utils::bnumeric(FLERR,values[ivalue++].c_str(),true,lmp);
       }
     }
   }

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -126,7 +126,7 @@ class AtomVec : protected Pointers {
 
   virtual void data_atom(double *, imageint, const std::vector<std::string> &);
   virtual void data_atom_post(int) {}
-  virtual void data_atom_bonus(int, char **) {}
+  virtual void data_atom_bonus(int, const std::vector<std::string> &) {}
   virtual void data_body(int, int, int, int *, double *) {}
 
   virtual void data_bonds_post(int, int, tagint, tagint, tagint) {}

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -124,7 +124,7 @@ class AtomVec : protected Pointers {
   virtual void create_atom(int, double *);
   virtual void create_atom_post(int) {}
 
-  virtual void data_atom(double *, imageint, char **);
+  virtual void data_atom(double *, imageint, const std::vector<std::string> &);
   virtual void data_atom_post(int) {}
   virtual void data_atom_bonus(int, char **) {}
   virtual void data_body(int, int, int, int *, double *) {}

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -166,7 +166,7 @@ class AtomVec : protected Pointers {
   virtual int unpack_reverse_hybrid(int, int *, double *) { return 0; }
   virtual int pack_border_hybrid(int, int *, double *) { return 0; }
   virtual int unpack_border_hybrid(int, int, double *) { return 0; }
-  virtual int data_atom_hybrid(int, char **) { return 0; }
+  virtual int data_atom_hybrid(int, const std::vector<std::string> &, int) { return 0; }
   virtual int data_vel_hybrid(int, char **) { return 0; }
   virtual int pack_data_hybrid(int, double *) { return 0; }
   virtual int write_data_hybrid(FILE *, double *) { return 0; }

--- a/src/atom_vec.h
+++ b/src/atom_vec.h
@@ -136,7 +136,7 @@ class AtomVec : protected Pointers {
   virtual void pack_data_pre(int) {}
   virtual void pack_data_post(int) {}
 
-  virtual void data_vel(int, char **);
+  virtual void data_vel(int, const std::vector<std::string> &);
   virtual void pack_vel(double **);
   virtual void write_vel(FILE *, int, double **);
 
@@ -167,7 +167,7 @@ class AtomVec : protected Pointers {
   virtual int pack_border_hybrid(int, int *, double *) { return 0; }
   virtual int unpack_border_hybrid(int, int, double *) { return 0; }
   virtual int data_atom_hybrid(int, const std::vector<std::string> &, int) { return 0; }
-  virtual int data_vel_hybrid(int, char **) { return 0; }
+  virtual int data_vel_hybrid(int, const std::vector<std::string> &, int) { return 0; }
   virtual int pack_data_hybrid(int, double *) { return 0; }
   virtual int write_data_hybrid(FILE *, double *) { return 0; }
   virtual int pack_vel_hybrid(int, double *) { return 0; }

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -381,7 +381,7 @@ int AtomVecEllipsoid::unpack_restart_bonus(int ilocal, double *buf)
    unpack one line from Ellipsoids section of data file
 ------------------------------------------------------------------------- */
 
-void AtomVecEllipsoid::data_atom_bonus(int m, char **values)
+void AtomVecEllipsoid::data_atom_bonus(int m, const std::vector<std::string> & values)
 {
   if (ellipsoid[m])
     error->one(FLERR,"Assigning ellipsoid parameters to non-ellipsoid atom");
@@ -389,17 +389,18 @@ void AtomVecEllipsoid::data_atom_bonus(int m, char **values)
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
   double *shape = bonus[nlocal_bonus].shape;
-  shape[0] = 0.5 * utils::numeric(FLERR,values[0],true,lmp);
-  shape[1] = 0.5 * utils::numeric(FLERR,values[1],true,lmp);
-  shape[2] = 0.5 * utils::numeric(FLERR,values[2],true,lmp);
+  int ivalue = 1;
+  shape[0] = 0.5 * utils::numeric(FLERR,values[ivalue++],true,lmp);
+  shape[1] = 0.5 * utils::numeric(FLERR,values[ivalue++],true,lmp);
+  shape[2] = 0.5 * utils::numeric(FLERR,values[ivalue++],true,lmp);
   if (shape[0] <= 0.0 || shape[1] <= 0.0 || shape[2] <= 0.0)
     error->one(FLERR,"Invalid shape in Ellipsoids section of data file");
 
   double *quat = bonus[nlocal_bonus].quat;
-  quat[0] = utils::numeric(FLERR,values[3],true,lmp);
-  quat[1] = utils::numeric(FLERR,values[4],true,lmp);
-  quat[2] = utils::numeric(FLERR,values[5],true,lmp);
-  quat[3] = utils::numeric(FLERR,values[6],true,lmp);
+  quat[0] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  quat[1] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  quat[2] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  quat[3] = utils::numeric(FLERR,values[ivalue++],true,lmp);
   MathExtra::qnormalize(quat);
 
   // reset ellipsoid mass

--- a/src/atom_vec_ellipsoid.h
+++ b/src/atom_vec_ellipsoid.h
@@ -48,7 +48,7 @@ class AtomVecEllipsoid : public AtomVec {
   int size_restart_bonus();
   int pack_restart_bonus(int, double *);
   int unpack_restart_bonus(int, double *);
-  void data_atom_bonus(int, char **);
+  void data_atom_bonus(int, const std::vector<std::string> &);
   double memory_usage_bonus();
 
   void create_atom_post(int);

--- a/src/atom_vec_line.cpp
+++ b/src/atom_vec_line.cpp
@@ -337,16 +337,17 @@ int AtomVecLine::unpack_restart_bonus(int ilocal, double *buf)
    unpack one line from Lines section of data file
 ------------------------------------------------------------------------- */
 
-void AtomVecLine::data_atom_bonus(int m, char **values)
+void AtomVecLine::data_atom_bonus(int m, const std::vector<std::string> &values)
 {
   if (line[m]) error->one(FLERR,"Assigning line parameters to non-line atom");
 
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
-  double x1 = utils::numeric(FLERR,values[0],true,lmp);
-  double y1 = utils::numeric(FLERR,values[1],true,lmp);
-  double x2 = utils::numeric(FLERR,values[2],true,lmp);
-  double y2 = utils::numeric(FLERR,values[3],true,lmp);
+  int ivalue = 1;
+  double x1 = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  double y1 = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  double x2 = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  double y2 = utils::numeric(FLERR,values[ivalue++],true,lmp);
   double dx = x2 - x1;
   double dy = y2 - y1;
   double length = sqrt(dx*dx + dy*dy);

--- a/src/atom_vec_line.h
+++ b/src/atom_vec_line.h
@@ -48,7 +48,7 @@ class AtomVecLine : public AtomVec {
   int size_restart_bonus();
   int pack_restart_bonus(int, double *);
   int unpack_restart_bonus(int, double *);
-  void data_atom_bonus(int, char **);
+  void data_atom_bonus(int, const std::vector<std::string> &);
   double memory_usage_bonus();
 
   void create_atom_post(int);

--- a/src/atom_vec_tri.cpp
+++ b/src/atom_vec_tri.cpp
@@ -470,22 +470,23 @@ int AtomVecTri::unpack_restart_bonus(int ilocal, double *buf)
    unpack one line from Tris section of data file
 ------------------------------------------------------------------------- */
 
-void AtomVecTri::data_atom_bonus(int m, char **values)
+void AtomVecTri::data_atom_bonus(int m, const std::vector<std::string> &values)
 {
   if (tri[m]) error->one(FLERR,"Assigning tri parameters to non-tri atom");
 
   if (nlocal_bonus == nmax_bonus) grow_bonus();
 
   double c1[3],c2[3],c3[3];
-  c1[0] = utils::numeric(FLERR,values[0],true,lmp);
-  c1[1] = utils::numeric(FLERR,values[1],true,lmp);
-  c1[2] = utils::numeric(FLERR,values[2],true,lmp);
-  c2[0] = utils::numeric(FLERR,values[3],true,lmp);
-  c2[1] = utils::numeric(FLERR,values[4],true,lmp);
-  c2[2] = utils::numeric(FLERR,values[5],true,lmp);
-  c3[0] = utils::numeric(FLERR,values[6],true,lmp);
-  c3[1] = utils::numeric(FLERR,values[7],true,lmp);
-  c3[2] = utils::numeric(FLERR,values[8],true,lmp);
+  int ivalue = 1;
+  c1[0] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c1[1] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c1[2] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c2[0] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c2[1] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c2[2] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c3[0] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c3[1] = utils::numeric(FLERR,values[ivalue++],true,lmp);
+  c3[2] = utils::numeric(FLERR,values[ivalue++],true,lmp);
 
   // check for duplicate points
 

--- a/src/atom_vec_tri.h
+++ b/src/atom_vec_tri.h
@@ -50,7 +50,7 @@ class AtomVecTri : public AtomVec {
   int size_restart_bonus();
   int pack_restart_bonus(int, double *);
   int unpack_restart_bonus(int, double *);
-  void data_atom_bonus(int, char **);
+  void data_atom_bonus(int, const std::vector<std::string> &);
   double memory_usage_bonus();
 
   void create_atom_post(int);

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -1089,37 +1089,32 @@ void ReadData::header(int firstpass)
     } else if (utils::strmatch(line,"^\\s*\\d+\\s+atom\\s+types\\s")) {
       rv = sscanf(line,"%d",&ntypes);
       if (rv != 1)
-        error->all(FLERR,"Could not parse 'atom types' line "
-                   "in data file header");
+        error->all(FLERR,"Could not parse 'atom types' line in data file header");
       if (addflag == NONE) atom->ntypes = ntypes + extra_atom_types;
 
     } else if (utils::strmatch(line,"\\s*\\d+\\s+bond\\s+types\\s")) {
       rv = sscanf(line,"%d",&nbondtypes);
       if (rv != 1)
-        error->all(FLERR,"Could not parse 'bond types' line "
-                   "in data file header");
+        error->all(FLERR,"Could not parse 'bond types' line in data file header");
       if (addflag == NONE) atom->nbondtypes = nbondtypes + extra_bond_types;
 
     } else if (utils::strmatch(line,"^\\s*\\d+\\s+angle\\s+types\\s")) {
       rv = sscanf(line,"%d",&nangletypes);
       if (rv != 1)
-        error->all(FLERR,"Could not parse 'angle types' line "
-                   "in data file header");
+        error->all(FLERR,"Could not parse 'angle types' line in data file header");
       if (addflag == NONE) atom->nangletypes = nangletypes + extra_angle_types;
 
     } else if (utils::strmatch(line,"^\\s*\\d+\\s+dihedral\\s+types\\s")) {
       rv = sscanf(line,"%d",&ndihedraltypes);
       if (rv != 1)
-        error->all(FLERR,"Could not parse 'dihedral types' line "
-                   "in data file header");
+        error->all(FLERR,"Could not parse 'dihedral types' line in data file header");
       if (addflag == NONE)
         atom->ndihedraltypes = ndihedraltypes + extra_dihedral_types;
 
     } else if (utils::strmatch(line,"^\\s*\\d+\\s+improper\\s+types\\s")) {
       rv = sscanf(line,"%d",&nimpropertypes);
       if (rv != 1)
-        error->all(FLERR,"Could not parse 'improper types' line "
-                   "in data file header");
+        error->all(FLERR,"Could not parse 'improper types' line in data file header");
       if (addflag == NONE)
         atom->nimpropertypes = nimpropertypes + extra_improper_types;
 

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -1677,11 +1677,11 @@ void ReadData::bodies(int firstpass, AtomVec *ptr)
   // nchunk = actual # read
 
   bigint nread = 0;
-  bigint natoms = nbodies;
+  bigint nblocks = nbodies;
 
-  while (nread < natoms) {
-    if (natoms-nread > CHUNK) nmax = CHUNK;
-    else nmax = natoms-nread;
+  while (nread < nblocks) {
+    if (nblocks-nread > CHUNK) nmax = CHUNK;
+    else nmax = nblocks-nread;
 
     if (me == 0) {
       nchunk = 0;
@@ -1754,7 +1754,7 @@ void ReadData::bodies(int firstpass, AtomVec *ptr)
   }
 
   if (me == 0 && firstpass)
-    utils::logmesg(lmp,"  {} bodies\n",natoms);
+    utils::logmesg(lmp,"  {} bodies\n",nblocks);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -422,7 +422,7 @@ int utils::inumeric(const char *file, int line, const std::string &str, bool do_
    wrapper for inumeric() that accepts a char pointer instead of a string
 ------------------------------------------------------------------------- */
 
-double utils::inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+int utils::inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
 {
   if (str)
     return inumeric(file, line, std::string(str), do_abort, lmp);
@@ -467,7 +467,7 @@ bigint utils::bnumeric(const char *file, int line, const std::string &str, bool 
    wrapper for bnumeric() that accepts a char pointer instead of a string
 ------------------------------------------------------------------------- */
 
-double utils::bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+bigint utils::bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
 {
   if (str)
     return bnumeric(file, line, std::string(str), do_abort, lmp);
@@ -512,7 +512,7 @@ tagint utils::tnumeric(const char *file, int line, const std::string &str, bool 
    wrapper for tnumeric() that accepts a char pointer instead of a string
 ------------------------------------------------------------------------- */
 
-double utils::tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+tagint utils::tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
 {
   if (str)
     return tnumeric(file, line, std::string(str), do_abort, lmp);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -298,12 +298,9 @@ std::string utils::check_packages_for_style(const std::string &style, const std:
    called by various commands to check validity of their arguments
 ------------------------------------------------------------------------- */
 
-int utils::logical(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+int utils::logical(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp)
 {
-  int n = 0;
-
-  if (str) n = strlen(str);
-  if (n == 0) {
+  if (str.empty()) {
     const char msg[] = "Expected boolean parameter instead of NULL or empty string "
                        "in input script or data file";
     if (do_abort)
@@ -333,17 +330,27 @@ int utils::logical(const char *file, int line, const char *str, bool do_abort, L
 }
 
 /* ----------------------------------------------------------------------
+   wrapper for logical() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+int utils::logical(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+{
+  if (str)
+    return logical(file, line, std::string(str), do_abort, lmp);
+  else
+    return logical(file, line, std::string(""), do_abort, lmp);
+}
+
+/* ----------------------------------------------------------------------
    read a floating point value from a string
    generate an error if not a legitimate floating point value
    called by various commands to check validity of their arguments
 ------------------------------------------------------------------------- */
 
-double utils::numeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+double utils::numeric(const char *file, int line, const std::string &str, bool do_abort,
+                      LAMMPS *lmp)
 {
-  int n = 0;
-
-  if (str) n = strlen(str);
-  if (n == 0) {
+  if (str.empty()) {
     const char msg[] = "Expected floating point parameter instead of"
                        " NULL or empty string in input script or data file";
     if (do_abort)
@@ -368,17 +375,26 @@ double utils::numeric(const char *file, int line, const char *str, bool do_abort
 }
 
 /* ----------------------------------------------------------------------
+   wrapper for numeric() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+double utils::numeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+{
+  if (str)
+    return numeric(file, line, std::string(str), do_abort, lmp);
+  else
+    return numeric(file, line, std::string(""), do_abort, lmp);
+}
+
+/* ----------------------------------------------------------------------
    read an integer value from a string
    generate an error if not a legitimate integer value
    called by various commands to check validity of their arguments
 ------------------------------------------------------------------------- */
 
-int utils::inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+int utils::inumeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp)
 {
-  int n = 0;
-
-  if (str) n = strlen(str);
-  if (n == 0) {
+  if (str.empty()) {
     const char msg[] = "Expected integer parameter instead of"
                        " NULL or empty string in input script or data file";
     if (do_abort)
@@ -403,17 +419,27 @@ int utils::inumeric(const char *file, int line, const char *str, bool do_abort, 
 }
 
 /* ----------------------------------------------------------------------
+   wrapper for inumeric() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+double utils::inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+{
+  if (str)
+    return inumeric(file, line, std::string(str), do_abort, lmp);
+  else
+    return inumeric(file, line, std::string(""), do_abort, lmp);
+}
+
+/* ----------------------------------------------------------------------
    read a big integer value from a string
    generate an error if not a legitimate integer value
    called by various commands to check validity of their arguments
 ------------------------------------------------------------------------- */
 
-bigint utils::bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+bigint utils::bnumeric(const char *file, int line, const std::string &str, bool do_abort,
+                       LAMMPS *lmp)
 {
-  int n = 0;
-
-  if (str) n = strlen(str);
-  if (n == 0) {
+  if (str.empty()) {
     const char msg[] = "Expected integer parameter instead of"
                        " NULL or empty string in input script or data file";
     if (do_abort)
@@ -438,17 +464,27 @@ bigint utils::bnumeric(const char *file, int line, const char *str, bool do_abor
 }
 
 /* ----------------------------------------------------------------------
+   wrapper for bnumeric() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+double utils::bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+{
+  if (str)
+    return bnumeric(file, line, std::string(str), do_abort, lmp);
+  else
+    return bnumeric(file, line, std::string(""), do_abort, lmp);
+}
+
+/* ----------------------------------------------------------------------
    read a tag integer value from a string
    generate an error if not a legitimate integer value
    called by various commands to check validity of their arguments
 ------------------------------------------------------------------------- */
 
-tagint utils::tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+tagint utils::tnumeric(const char *file, int line, const std::string &str, bool do_abort,
+                       LAMMPS *lmp)
 {
-  int n = 0;
-
-  if (str) n = strlen(str);
-  if (n == 0) {
+  if (str.empty()) {
     const char msg[] = "Expected integer parameter instead of"
                        " NULL or empty string in input script or data file";
     if (do_abort)
@@ -470,6 +506,18 @@ tagint utils::tnumeric(const char *file, int line, const char *str, bool do_abor
   }
 
   return ATOTAGINT(buf.c_str());
+}
+
+/* ----------------------------------------------------------------------
+   wrapper for tnumeric() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+double utils::tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp)
+{
+  if (str)
+    return tnumeric(file, line, std::string(str), do_abort, lmp);
+  else
+    return tnumeric(file, line, std::string(""), do_abort, lmp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/utils.h
+++ b/src/utils.h
@@ -169,10 +169,32 @@ namespace utils {
    *  \param lmp      pointer to top-level LAMMPS class instance
    *  \return         1 if string resolves to "true", otherwise 0 */
 
+  int logical(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to logical
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param lmp      pointer to top-level LAMMPS class instance
+   *  \return         1 if string resolves to "true", otherwise 0 */
+
   int logical(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
 
   /*! Convert a string to a floating point number while checking
    *  if it is a valid floating point or integer number
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param lmp      pointer to top-level LAMMPS class instance
+   *  \return         double precision floating point number */
+
+  double numeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp);
+
+  /*! \overload
    *
    *  \param file     name of source file for error message
    *  \param line     line number in source file for error message
@@ -193,7 +215,18 @@ namespace utils {
    *  \param lmp      pointer to top-level LAMMPS class instance
    *  \return         integer number (regular int)  */
 
-  int inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
+  int inumeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param lmp      pointer to top-level LAMMPS class instance
+   *  \return         double precision floating point number */
+
+  double inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
 
   /*! Convert a string to an integer number while checking
    *  if it is a valid integer number (bigint)
@@ -205,7 +238,18 @@ namespace utils {
    *  \param lmp      pointer to top-level LAMMPS class instance
    *  \return         integer number (bigint) */
 
-  bigint bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
+  bigint bnumeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param lmp      pointer to top-level LAMMPS class instance
+   *  \return         double precision floating point number */
+
+  double bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
 
   /*! Convert a string to an integer number while checking
    *  if it is a valid integer number (tagint)
@@ -217,7 +261,18 @@ namespace utils {
    * \param lmp      pointer to top-level LAMMPS class instance
    * \return         integer number (tagint) */
 
-  tagint tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
+  tagint tnumeric(const char *file, int line, const std::string &str, bool do_abort, LAMMPS *lmp);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param lmp      pointer to top-level LAMMPS class instance
+   *  \return         double precision floating point number */
+
+  double tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
 
   /*! Compute index bounds derived from a string with a possible wildcard
    *

--- a/src/utils.h
+++ b/src/utils.h
@@ -226,7 +226,7 @@ namespace utils {
    *  \param lmp      pointer to top-level LAMMPS class instance
    *  \return         double precision floating point number */
 
-  double inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
+  int inumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
 
   /*! Convert a string to an integer number while checking
    *  if it is a valid integer number (bigint)
@@ -249,7 +249,7 @@ namespace utils {
    *  \param lmp      pointer to top-level LAMMPS class instance
    *  \return         double precision floating point number */
 
-  double bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
+  bigint bnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
 
   /*! Convert a string to an integer number while checking
    *  if it is a valid integer number (tagint)
@@ -272,7 +272,7 @@ namespace utils {
    *  \param lmp      pointer to top-level LAMMPS class instance
    *  \return         double precision floating point number */
 
-  double tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
+  tagint tnumeric(const char *file, int line, const char *str, bool do_abort, LAMMPS *lmp);
 
   /*! Compute index bounds derived from a string with a possible wildcard
    *

--- a/unittest/formats/test_input_convert.cpp
+++ b/unittest/formats/test_input_convert.cpp
@@ -49,6 +49,15 @@ TEST_F(InputConvertTest, logical)
     EXPECT_EQ(utils::logical(FLERR, "off", false, lmp), 0);
     EXPECT_EQ(utils::logical(FLERR, "0", false, lmp), 0);
 
+    EXPECT_EQ(utils::logical(FLERR, std::string("yes"), false, lmp), 1);
+    EXPECT_EQ(utils::logical(FLERR, std::string("true"), false, lmp), 1);
+    EXPECT_EQ(utils::logical(FLERR, std::string("on"), false, lmp), 1);
+    EXPECT_EQ(utils::logical(FLERR, std::string("1"), false, lmp), 1);
+    EXPECT_EQ(utils::logical(FLERR, std::string("no"), false, lmp), 0);
+    EXPECT_EQ(utils::logical(FLERR, std::string("false"), false, lmp), 0);
+    EXPECT_EQ(utils::logical(FLERR, std::string("off"), false, lmp), 0);
+    EXPECT_EQ(utils::logical(FLERR, std::string("0"), false, lmp), 0);
+
     TEST_FAILURE(".*ERROR: Expected boolean parameter instead of.*",
                  utils::logical(FLERR, "YES", false, lmp););
     TEST_FAILURE(".*ERROR: Expected boolean parameter instead of.*",
@@ -94,6 +103,15 @@ TEST_F(InputConvertTest, numeric)
     EXPECT_DOUBLE_EQ(utils::numeric(FLERR, "10000000000", false, lmp), 1e10);
     EXPECT_DOUBLE_EQ(utils::numeric(FLERR, "2.56E+3", false, lmp), 2560);
 
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string("0"), false, lmp), 0);
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string("0.1"), false, lmp), 0.1);
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string("-.232"), false, lmp), -0.232);
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string(".2e5"), false, lmp), 20000.0);
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string("2.5e-10"), false, lmp), 2.5e-10);
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string("+0.3"), false, lmp), 0.3);
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string("10000000000"), false, lmp), 1e10);
+    EXPECT_DOUBLE_EQ(utils::numeric(FLERR, std::string("2.56E+3"), false, lmp), 2560);
+
     TEST_FAILURE(".*ERROR: Expected floating point.*", utils::numeric(FLERR, "yay", false, lmp););
     TEST_FAILURE(".*ERROR: Expected floating point.*", utils::numeric(FLERR, "", false, lmp););
     TEST_FAILURE(".*ERROR: Expected floating point.*", utils::numeric(FLERR, nullptr, false, lmp););
@@ -109,6 +127,13 @@ TEST_F(InputConvertTest, inumeric)
     EXPECT_EQ(utils::inumeric(FLERR, "-532410", false, lmp), -532410);
     EXPECT_EQ(utils::inumeric(FLERR, "-0", false, lmp), 0);
     EXPECT_EQ(utils::inumeric(FLERR, "0100", false, lmp), 100);
+
+    EXPECT_EQ(utils::inumeric(FLERR, std::string("0"), false, lmp), 0);
+    EXPECT_EQ(utils::inumeric(FLERR, std::string("-1"), false, lmp), -1);
+    EXPECT_EQ(utils::inumeric(FLERR, std::string("10000"), false, lmp), 10000);
+    EXPECT_EQ(utils::inumeric(FLERR, std::string("-532410"), false, lmp), -532410);
+    EXPECT_EQ(utils::inumeric(FLERR, std::string("-0"), false, lmp), 0);
+    EXPECT_EQ(utils::inumeric(FLERR, std::string("0100"), false, lmp), 100);
 
     TEST_FAILURE(".*ERROR: Expected integer.*", utils::inumeric(FLERR, "yay", false, lmp););
     TEST_FAILURE(".*ERROR: Expected integer.*", utils::inumeric(FLERR, "0.1", false, lmp););
@@ -128,6 +153,13 @@ TEST_F(InputConvertTest, bnumeric)
     EXPECT_EQ(utils::bnumeric(FLERR, "-0", false, lmp), 0);
     EXPECT_EQ(utils::bnumeric(FLERR, "0100", false, lmp), 100);
 
+    EXPECT_EQ(utils::bnumeric(FLERR, std::string("0"), false, lmp), 0);
+    EXPECT_EQ(utils::bnumeric(FLERR, std::string("-1"), false, lmp), -1);
+    EXPECT_EQ(utils::bnumeric(FLERR, std::string("10000"), false, lmp), 10000);
+    EXPECT_EQ(utils::bnumeric(FLERR, std::string("-532410"), false, lmp), -532410);
+    EXPECT_EQ(utils::bnumeric(FLERR, std::string("-0"), false, lmp), 0);
+    EXPECT_EQ(utils::bnumeric(FLERR, std::string("0100"), false, lmp), 100);
+
     TEST_FAILURE(".*ERROR: Expected integer.*", utils::bnumeric(FLERR, "yay", false, lmp););
     TEST_FAILURE(".*ERROR: Expected integer.*", utils::bnumeric(FLERR, "0.1", false, lmp););
     TEST_FAILURE(".*ERROR: Expected integer.*", utils::bnumeric(FLERR, "1.1", false, lmp););
@@ -145,6 +177,13 @@ TEST_F(InputConvertTest, tnumeric)
     EXPECT_EQ(utils::tnumeric(FLERR, "-532410", false, lmp), -532410);
     EXPECT_EQ(utils::tnumeric(FLERR, "-0", false, lmp), 0);
     EXPECT_EQ(utils::tnumeric(FLERR, "0100", false, lmp), 100);
+
+    EXPECT_EQ(utils::tnumeric(FLERR, std::string("0"), false, lmp), 0);
+    EXPECT_EQ(utils::tnumeric(FLERR, std::string("-1"), false, lmp), -1);
+    EXPECT_EQ(utils::tnumeric(FLERR, std::string("10000"), false, lmp), 10000);
+    EXPECT_EQ(utils::tnumeric(FLERR, std::string("-532410"), false, lmp), -532410);
+    EXPECT_EQ(utils::tnumeric(FLERR, std::string("-0"), false, lmp), 0);
+    EXPECT_EQ(utils::tnumeric(FLERR, std::string("0100"), false, lmp), 100);
 
     TEST_FAILURE(".*ERROR: Expected integer.*", utils::tnumeric(FLERR, "yay", false, lmp););
     TEST_FAILURE(".*ERROR: Expected integer.*", utils::tnumeric(FLERR, "0.1", false, lmp););


### PR DESCRIPTION
**Summary**

This modernizes the parsing of several sections of data files using the ValueTokenizer class.
This enables stricter checking of the format (the number of tokens/words was previously only checked on the first line) and better reporting of errors since the error message now includes the offending line of text.
The parsing of the following sections is updated:
- Atoms
- Velocites
- Masses
- Bodies
- Bonus
- Bonds
- Angles
- Dihedrals
- Impropers

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues. Automated unit and regression tests pass.

**Implementation Notes**

The loop over the char buffer is unchanged instead of using `utils::split_lines()` to avoid extra copies of the data buffer.

To simplify parsing using the `utils::*numeric()` functions the handling of `char *` arguments (which  may be NULL) is now put in an overloaded function that will then call the original function with an empty string in that case. That way the original functions can safely use a `const std::string &` argument and thus avoid using the `c_str()` member function when converting of C++ strings.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
