### PR TITLE
Fix bug of uf_lookup and u_lookup in angle_table

### DIFF
--- a/src/MOLECULE/angle_table.cpp
+++ b/src/MOLECULE/angle_table.cpp
@@ -635,7 +635,7 @@ void AngleTable::uf_lookup(int type, double x, double &u, double &f)
   int itable = static_cast<int> (x * tb->invdelta);
 
   if (itable < 0) itable = 0;
-  if (itable >= tablength) itable = tablength-1;
+  if (itable >= tablength-1) itable = tablength-2;
 
   if (tabstyle == LINEAR) {
     fraction = (x - tb->ang[itable]) * tb->invdelta;
@@ -670,7 +670,7 @@ void AngleTable::u_lookup(int type, double x, double &u)
   int itable = static_cast<int> ( x * tb->invdelta);
 
   if (itable < 0) itable = 0;
-  if (itable >= tablength) itable = tablength-1;
+  if (itable >= tablength-1) itable = tablength-2;
 
   if (tabstyle == LINEAR) {
     fraction = (x - tb->ang[itable]) * tb->invdelta;


### PR DESCRIPTION
**Summary**

Fix bug of uf_lookup and u_lookup in angle_table.

tb->de and tb->df are array of length tlm1(tablength-1),
but original code tried to read tb->de[itable] and tb->de[itable] even if itable=tlm1.
So, the maximum of itable should be tablength-2.

In my environment, no error has occurred in original code,
but I thought this bug might cause some error in future.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


