### PR TITLE
Collected small changes and fixes

### DIFF
--- a/doc/src/Developer_org.rst
+++ b/doc/src/Developer_org.rst
@@ -225,7 +225,7 @@ follows:
   commands in an input script.
 
 - The Force class computes various forces between atoms.  The Pair
-  parent class is for non-bonded or pair-wise forces, which in LAMMPS
+  parent class is for non-bonded or pairwise forces, which in LAMMPS
   also includes many-body forces such as the Tersoff 3-body potential if
   those are computed by walking pairwise neighbor lists.  The Bond,
   Angle, Dihedral, Improper parent classes are styles for bonded

--- a/doc/src/Errors_warnings.rst
+++ b/doc/src/Errors_warnings.rst
@@ -416,7 +416,7 @@ This will most likely cause errors in kinetic fluctuations.
    not defined for the specified atom style.
 
 *Molecule has bond topology but no special bond settings*
-   This means the bonded atoms will not be excluded in pair-wise
+   This means the bonded atoms will not be excluded in pairwise
    interactions.
 
 *Molecule template for create_atoms has multiple molecules*

--- a/doc/src/Run_output.rst
+++ b/doc/src/Run_output.rst
@@ -106,7 +106,7 @@ individual ranks. Here is an example output for this section:
 ----------
 
 The third section above lists the number of owned atoms (Nlocal),
-ghost atoms (Nghost), and pair-wise neighbors stored per processor.
+ghost atoms (Nghost), and pairwise neighbors stored per processor.
 The max and min values give the spread of these values across
 processors with a 10-bin histogram showing the distribution. The total
 number of histogram counts is equal to the number of processors.
@@ -114,7 +114,7 @@ number of histogram counts is equal to the number of processors.
 ----------
 
 The last section gives aggregate statistics (across all processors)
-for pair-wise neighbors and special neighbors that LAMMPS keeps track
+for pairwise neighbors and special neighbors that LAMMPS keeps track
 of (see the :doc:`special_bonds <special_bonds>` command).  The number
 of times neighbor lists were rebuilt is tallied, as is the number of
 potentially *dangerous* rebuilds.  If atom movement triggered neighbor

--- a/doc/src/Speed_kokkos.rst
+++ b/doc/src/Speed_kokkos.rst
@@ -214,7 +214,7 @@ threads/task as Nt. The product of these two values should be N, i.e.
    The default for the :doc:`package kokkos <package>` command when
    running on KNL is to use "half" neighbor lists and set the Newton flag
    to "on" for both pairwise and bonded interactions. This will typically
-   be best for many-body potentials. For simpler pair-wise potentials, it
+   be best for many-body potentials. For simpler pairwise potentials, it
    may be faster to use a "full" neighbor list with Newton flag to "off".
    Use the "-pk kokkos" :doc:`command-line switch <Run_options>` to change
    the default :doc:`package kokkos <package>` options. See its page for

--- a/doc/src/balance.rst
+++ b/doc/src/balance.rst
@@ -383,7 +383,7 @@ multiple groups, its weight is the product of the weight factors.
 
 This weight style is useful in combination with pair style
 :doc:`hybrid <pair_hybrid>`, e.g. when combining a more costly many-body
-potential with a fast pair-wise potential.  It is also useful when
+potential with a fast pairwise potential.  It is also useful when
 using :doc:`run_style respa <run_style>` where some portions of the
 system have many bonded interactions and others none.  It assumes that
 the computational cost for each group remains constant over time.

--- a/doc/src/compute_pressure_cylinder.rst
+++ b/doc/src/compute_pressure_cylinder.rst
@@ -61,7 +61,7 @@ Restrictions
 This compute currently calculates the pressure tensor contributions
 for pair styles only (i.e. no bond, angle, dihedral, etc. contributions
 and in the presence of bonded interactions, the result will be incorrect
-due to exclusions for special bonds)  and requires pair-wise force
+due to exclusions for special bonds)  and requires pairwise force
 calculations not available for most many-body pair styles. K-space
 calculations are also excluded. Note that this pressure compute outputs
 the configurational terms only; the kinetic contribution is not included

--- a/doc/src/package.rst
+++ b/doc/src/package.rst
@@ -460,7 +460,7 @@ using *neigh/thread* *on*, a full neighbor list must also be used. Using
 is turned on by default only when there are 16K atoms or less owned by
 an MPI rank and when using a full neighbor list. Not all KOKKOS-enabled
 potentials support this keyword yet, and only thread over atoms. Many
-simple pair-wise potentials such as Lennard-Jones do support threading
+simple pairwise potentials such as Lennard-Jones do support threading
 over both atoms and neighbors.
 
 The *newton* keyword sets the Newton flags for pairwise and bonded

--- a/doc/src/pair_charmm.rst
+++ b/doc/src/pair_charmm.rst
@@ -119,7 +119,7 @@ name are the older, original LAMMPS implementations.  They compute the
 LJ and Coulombic interactions with an energy switching function (esw,
 shown in the formula below as S(r)), which ramps the energy smoothly
 to zero between the inner and outer cutoff.  This can cause
-irregularities in pair-wise forces (due to the discontinuous second
+irregularities in pairwise forces (due to the discontinuous second
 derivative of energy at the boundaries of the switching region), which
 in some cases can result in detectable artifacts in an MD simulation.
 

--- a/doc/src/pair_dpd.rst
+++ b/doc/src/pair_dpd.rst
@@ -50,7 +50,7 @@ Style *dpd* computes a force field for dissipative particle dynamics
 
 Style *dpd/tstat* invokes a DPD thermostat on pairwise interactions,
 which is equivalent to the non-conservative portion of the DPD force
-field.  This pair-wise thermostat can be used in conjunction with any
+field.  This pairwise thermostat can be used in conjunction with any
 :doc:`pair style <pair_style>`, and in leiu of per-particle thermostats
 like :doc:`fix langevin <fix_langevin>` or ensemble thermostats like
 Nose Hoover as implemented by :doc:`fix nvt <fix_nh>`.  To use

--- a/doc/src/pair_python.rst
+++ b/doc/src/pair_python.rst
@@ -164,7 +164,7 @@ Following the *LJCutMelt* example, here are the two functions:
 .. note::
 
    The evaluation of scripted python code will slow down the
-   computation pair-wise interactions quite significantly. However, this
+   computation pairwise interactions quite significantly. However, this
    can be largely worked around through using the python pair style not
    for the actual simulation, but to generate tabulated potentials on the
    fly using the :doc:`pair_write <pair_write>` command. Please see below

--- a/doc/src/pair_style.rst
+++ b/doc/src/pair_style.rst
@@ -154,10 +154,10 @@ accelerated styles exist.
 * :doc:`coul/wolf/cs <pair_cs>` - Coulomb via Wolf potential with core/shell adjustments
 * :doc:`dpd <pair_dpd>` - dissipative particle dynamics (DPD)
 * :doc:`dpd/ext <pair_dpd_ext>` - generalized force field for DPD
-* :doc:`dpd/ext/tstat <pair_dpd_ext>` - pair-wise DPD thermostatting  with generalized force field
+* :doc:`dpd/ext/tstat <pair_dpd_ext>` - pairwise DPD thermostatting  with generalized force field
 * :doc:`dpd/fdt <pair_dpd_fdt>` - DPD for constant temperature and pressure
 * :doc:`dpd/fdt/energy <pair_dpd_fdt>` - DPD for constant energy and enthalpy
-* :doc:`dpd/tstat <pair_dpd>` - pair-wise DPD thermostatting
+* :doc:`dpd/tstat <pair_dpd>` - pairwise DPD thermostatting
 * :doc:`dsmc <pair_dsmc>` - Direct Simulation Monte Carlo (DSMC)
 * :doc:`e3b <pair_e3b>` - Explicit-three body (E3B) water model
 * :doc:`drip <pair_drip>` - Dihedral-angle-corrected registry-dependent interlayer potential (DRIP)

--- a/doc/src/pair_sw.rst
+++ b/doc/src/pair_sw.rst
@@ -202,7 +202,7 @@ elements are the same.  Thus the two-body parameters for Si
 interacting with C, comes from the SiCC entry.  The three-body
 parameters can in principle be specific to the three elements of the
 configuration. In the literature, however, the three-body parameters
-are usually defined by simple formulas involving two sets of pair-wise
+are usually defined by simple formulas involving two sets of pairwise
 parameters, corresponding to the ij and ik pairs, where i is the
 center atom. The user must ensure that the correct combining rule is
 used to calculate the values of the three-body parameters for

--- a/doc/src/pair_write.rst
+++ b/doc/src/pair_write.rst
@@ -76,8 +76,10 @@ must be set before this command can be invoked.
 Due to how the pairwise force is computed, an inner value > 0.0 must
 be specified even if the potential has a finite value at r = 0.0.
 
-For EAM potentials, the pair_write command only tabulates the
-pairwise portion of the potential, not the embedding portion.
+The *pair_write* command can only be used for pairwise additive
+interactions for which a `Pair::single()` function can be and has
+been implemented.  This excludes for example manybody potentials
+or TIP4P coulomb styles.
 
 Related commands
 """"""""""""""""

--- a/doc/src/run_style.rst
+++ b/doc/src/run_style.rst
@@ -89,7 +89,7 @@ in its 3d FFTs.  In this scenario, splitting your P total processors
 into 2 subsets of processors, P1 in the first partition and P2 in the
 second partition, can enable your simulation to run faster.  This is
 because the long-range forces in PPPM can be calculated at the same
-time as pair-wise and bonded forces are being calculated, and the FFTs
+time as pairwise and bonded forces are being calculated, and the FFTs
 can actually speed up when running on fewer processors.
 
 To use this style, you must define 2 partitions where P1 is a multiple

--- a/src/ASPHERE/pair_gayberne.cpp
+++ b/src/ASPHERE/pair_gayberne.cpp
@@ -18,18 +18,18 @@
 
 #include "pair_gayberne.h"
 
-#include <cmath>
-#include "math_extra.h"
 #include "atom.h"
 #include "atom_vec_ellipsoid.h"
-#include "comm.h"
-#include "force.h"
-#include "neighbor.h"
-#include "neigh_list.h"
 #include "citeme.h"
-#include "memory.h"
+#include "comm.h"
 #include "error.h"
+#include "force.h"
+#include "math_extra.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
 
+#include <cmath>
 
 using namespace LAMMPS_NS;
 

--- a/src/EXTRA-FIX/fix_gle.cpp
+++ b/src/EXTRA-FIX/fix_gle.cpp
@@ -211,6 +211,8 @@ FixGLE::FixGLE(LAMMPS *lmp, int narg, char **arg) :
   S  = new double[ns1sq];
   TT = new double[ns1sq];
   ST = new double[ns1sq];
+  memset(A,0,sizeof(double)*ns1sq);
+  memset(C,0,sizeof(double)*ns1sq);
 
   // start temperature (t ramp)
   t_start = utils::numeric(FLERR,arg[4],false,lmp);
@@ -223,7 +225,6 @@ FixGLE::FixGLE(LAMMPS *lmp, int narg, char **arg) :
 
   // LOADING A matrix
   char *fname = arg[7];
-  memset(A, ns1sq, sizeof(double));
   if (comm->me == 0) {
     PotentialFileReader reader(lmp,fname,"fix gle A matrix");
     try {
@@ -256,14 +257,12 @@ FixGLE::FixGLE(LAMMPS *lmp, int narg, char **arg) :
   if (fnoneq == 0) {
     t_target=t_start;
     const double kT = t_target * force->boltz / force->mvv2e;
-    memset(C,0,sizeof(double)*ns1sq);
     for (int i=0; i<ns1sq; i+=(ns+2))
       C[i]=kT;
 
   } else {
 
     // LOADING C matrix
-    memset(C, ns1sq, sizeof(double));
     if (comm->me == 0) {
       PotentialFileReader reader(lmp,fname,"fix gle C matrix");
       try {

--- a/src/EXTRA-MOLECULE/bond_fene_nm.cpp
+++ b/src/EXTRA-MOLECULE/bond_fene_nm.cpp
@@ -29,7 +29,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-BondFENENM::BondFENENM(LAMMPS *lmp) : BondFENE(lmp) {}
+BondFENENM::BondFENENM(LAMMPS *lmp) : BondFENE(lmp), nn(nullptr), mm(nullptr) {}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-MOLECULE/bond_fene_nm.h
+++ b/src/EXTRA-MOLECULE/bond_fene_nm.h
@@ -38,7 +38,6 @@ class BondFENENM : public BondFENE {
   virtual void *extract(const char *, int &);
 
  protected:
-  double TWO_1_3;
   double *nn, *mm;
 
   virtual void allocate();

--- a/src/EXTRA-PAIR/pair_e3b.cpp
+++ b/src/EXTRA-PAIR/pair_e3b.cpp
@@ -99,7 +99,7 @@ void PairE3B::compute(int eflag, int vflag)
 
   ev_init(eflag, vflag);
   //clear sumExp array
-  memset(sumExp, 0.0, nbytes);
+  memset(sumExp, 0, sizeof(double)*maxID);
 
   evdwl = 0.0;
   pvector[0] = pvector[1] = pvector[2] = pvector[3] = 0.0;
@@ -364,7 +364,6 @@ void PairE3B::allocateE3B()
   maxID = find_maxID();
   if (!natoms) error->all(FLERR, "No atoms found");
   memory->create(sumExp, maxID, "pair:sumExp");
-  nbytes = sizeof(double) * maxID;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/EXTRA-PAIR/pair_e3b.h
+++ b/src/EXTRA-PAIR/pair_e3b.h
@@ -50,7 +50,6 @@ class PairE3B : public Pair {
   int **pairO, ***pairH;       // pair lists
   double ***exps, ****del3, ***fpair3, *sumExp;
   int maxID;        //size of global sumExp array
-  size_t nbytes;    //size of sumExp array in bytes
   int natoms;       //to make sure number of atoms is constant
 
   virtual void allocate();

--- a/src/EXTRA-PAIR/pair_harmonic_cut.cpp
+++ b/src/EXTRA-PAIR/pair_harmonic_cut.cpp
@@ -35,7 +35,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-PairHarmonicCut::PairHarmonicCut(LAMMPS *lmp) : Pair(lmp)
+PairHarmonicCut::PairHarmonicCut(LAMMPS *lmp) : Pair(lmp), k(nullptr), cut(nullptr)
 {
   writedata = 1;
 }

--- a/src/INTEL/fix_intel.cpp
+++ b/src/INTEL/fix_intel.cpp
@@ -43,7 +43,7 @@ using namespace FixConst;
 
 #ifdef __INTEL_OFFLOAD
 #ifndef _LMP_INTEL_OFFLOAD
-#warning "Not building Intel package with Xeon Phi offload support."
+#warning "Not building INTEL package with Xeon Phi offload support."
 #endif
 #endif
 
@@ -303,7 +303,7 @@ void FixIntel::init()
   if (force->pair_match("^hybrid", 0) != nullptr) {
     _pair_hybrid_flag = 1;
     if (force->newton_pair != 0 && force->pair->no_virial_fdotr_compute)
-      error->all(FLERR,"Intel package requires fdotr virial with newton on.");
+      error->all(FLERR,"INTEL package requires fdotr virial with newton on.");
   } else
     _pair_hybrid_flag = 0;
 
@@ -354,12 +354,12 @@ void FixIntel::init()
 void FixIntel::setup(int vflag)
 {
   if (neighbor->style != Neighbor::BIN)
-    error->all(FLERR,"Currently, neighbor style BIN must be used with Intel package.");
+    error->all(FLERR,"Currently, neighbor style BIN must be used with INTEL package.");
   if (vflag > 3)
-   error->all(FLERR,"Cannot currently get per-atom virials with Intel package.");
+   error->all(FLERR,"Cannot currently get per-atom virials with INTEL package.");
   #ifdef _LMP_INTEL_OFFLOAD
   if (neighbor->exclude_setting() != 0)
-    error->all(FLERR,"Currently, cannot use neigh_modify exclude with Intel package offload.");
+    error->all(FLERR,"Currently, cannot use neigh_modify exclude with INTEL package offload.");
   post_force(vflag);
   #endif
 }
@@ -512,8 +512,7 @@ void FixIntel::bond_init_check()
   }
 
   if (intel_pair == 0)
-    error->all(FLERR,"Intel styles for bond/angle/dihedral/improper "
-      "require intel pair style.");
+    error->all(FLERR,"Intel styles for bond/angle/dihedral/improper require intel pair style.");
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/INTEL/fix_intel.cpp
+++ b/src/INTEL/fix_intel.cpp
@@ -447,7 +447,7 @@ void FixIntel::pair_init_check(const bool cdmessage)
   #endif
 
   int need_tag = 0;
-  if (atom->molecular != Atom::ATOMIC) need_tag = 1;
+  if (atom->molecular != Atom::ATOMIC || three_body_neighbor()) need_tag = 1;
 
   // Clear buffers used for pair style
   char kmode[80];

--- a/src/INTEL/fix_intel.cpp
+++ b/src/INTEL/fix_intel.cpp
@@ -469,27 +469,28 @@ void FixIntel::pair_init_check(const bool cdmessage)
   #endif
 
   if (_print_pkg_info && comm->me == 0) {
-    if (screen) {
-      fprintf(screen,
-              "----------------------------------------------------------\n");
-      if (_offload_balance != 0.0) {
-        fprintf(screen,"Using Intel Coprocessor with %d threads per core, ",
-                _offload_tpc);
-        fprintf(screen,"%d threads per task\n",_offload_threads);
-      } else {
-        fprintf(screen,"Using Intel Package without Coprocessor.\n");
-      }
-      fprintf(screen,"Precision: %s\n",kmode);
-      if (cdmessage) {
-        #ifdef LMP_USE_AVXCD
-        fprintf(screen,"AVX512 CD Optimizations: Enabled\n");
-        #else
-        fprintf(screen,"AVX512 CD Optimizations: Disabled\n");
-        #endif
-      }
-      fprintf(screen,
-              "----------------------------------------------------------\n");
+    utils::logmesg(lmp, "----------------------------------------------------------\n");
+    if (_offload_balance != 0.0) {
+      utils::logmesg(lmp,"Using Intel Coprocessor with {} threads per core, "
+                     "{} threads per task\n",_offload_tpc, _offload_threads);
+    } else {
+      utils::logmesg(lmp,"Using INTEL Package without Coprocessor.\n");
     }
+    utils::logmesg(lmp,"Compiler: {}\n",platform::compiler_info());
+    #ifdef LMP_SIMD_COMPILER
+    utils::logmesg(lmp,"SIMD compiler directives: Enabled\n");
+    #else
+    utils::logmesg(lmp,"SIMD compiler directives: Disabled\n");
+    #endif
+    utils::logmesg(lmp,"Precision: {}\n",kmode);
+    if (cdmessage) {
+      #ifdef LMP_USE_AVXCD
+      utils::logmesg(lmp,"AVX512 CD Optimizations: Enabled\n");
+      #else
+      utils::logmesg(lmp,"AVX512 CD Optimizations: Disabled\n");
+      #endif
+    }
+    utils::logmesg(lmp, "----------------------------------------------------------\n");
   }
   _print_pkg_info = 0;
 }

--- a/src/INTEL/fix_intel.cpp
+++ b/src/INTEL/fix_intel.cpp
@@ -303,8 +303,7 @@ void FixIntel::init()
   if (force->pair_match("^hybrid", 0) != nullptr) {
     _pair_hybrid_flag = 1;
     if (force->newton_pair != 0 && force->pair->no_virial_fdotr_compute)
-      error->all(FLERR,
-                 "Intel package requires fdotr virial with newton on.");
+      error->all(FLERR,"Intel package requires fdotr virial with newton on.");
   } else
     _pair_hybrid_flag = 0;
 
@@ -325,8 +324,7 @@ void FixIntel::init()
     _pair_hybrid_zero = 0;
     if (force->newton_pair == 0) _pair_hybrid_flag = 0;
     if (nstyles > 1)
-      error->all(FLERR,
-        "Currently, cannot offload more than one intel style with hybrid.");
+      error->all(FLERR,"Currently, cannot offload more than one intel style with hybrid.");
   }
   #endif
 
@@ -356,15 +354,12 @@ void FixIntel::init()
 void FixIntel::setup(int vflag)
 {
   if (neighbor->style != Neighbor::BIN)
-    error->all(FLERR,
-            "Currently, neighbor style BIN must be used with Intel package.");
+    error->all(FLERR,"Currently, neighbor style BIN must be used with Intel package.");
   if (vflag > 3)
-   error->all(FLERR,
-               "Cannot currently get per-atom virials with Intel package.");
+   error->all(FLERR,"Cannot currently get per-atom virials with Intel package.");
   #ifdef _LMP_INTEL_OFFLOAD
   if (neighbor->exclude_setting() != 0)
-    error->all(FLERR,
-     "Currently, cannot use neigh_modify exclude with Intel package offload.");
+    error->all(FLERR,"Currently, cannot use neigh_modify exclude with Intel package offload.");
   post_force(vflag);
   #endif
 }
@@ -425,14 +420,14 @@ void FixIntel::pair_init_check(const bool cdmessage)
 
   if (_offload_balance != 0.0 && comm->me == 0) {
     #ifndef __INTEL_COMPILER_BUILD_DATE
-    error->warning(FLERR, "Unknown Intel Compiler Version\n");
+    error->warning(FLERR,"Unknown Intel Compiler Version\n");
     #else
     if (__INTEL_COMPILER_BUILD_DATE != 20131008 &&
         __INTEL_COMPILER_BUILD_DATE < 20141023)
-      error->warning(FLERR, "Unsupported Intel Compiler.");
+      error->warning(FLERR,"Unsupported Intel Compiler.");
     #endif
     #if !defined(__INTEL_COMPILER)
-    error->warning(FLERR, "Unsupported Intel Compiler.");
+    error->warning(FLERR,"Unsupported Intel Compiler.");
     #endif
   }
 
@@ -505,8 +500,7 @@ void FixIntel::bond_init_check()
 {
   if ((_offload_balance != 0.0) && (atom->molecular != Atom::ATOMIC)
       && (force->newton_pair != force->newton_bond))
-    error->all(FLERR,
-      "INTEL package requires same setting for newton bond and non-bond.");
+    error->all(FLERR,"INTEL package requires same setting for newton bond and non-bond.");
 
   int intel_pair = 0;
   if (force->pair_match("/intel$", 0) != nullptr)
@@ -517,7 +511,7 @@ void FixIntel::bond_init_check()
   }
 
   if (intel_pair == 0)
-    error->all(FLERR, "Intel styles for bond/angle/dihedral/improper "
+    error->all(FLERR,"Intel styles for bond/angle/dihedral/improper "
       "require intel pair style.");
 }
 
@@ -534,7 +528,7 @@ void FixIntel::kspace_init_check()
   }
 
   if (intel_pair == 0)
-    error->all(FLERR, "Intel styles for kspace require intel pair style.");
+    error->all(FLERR,"Intel styles for kspace require intel pair style.");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -551,7 +545,7 @@ void FixIntel::check_neighbor_intel()
       _offload_noghost = 0;
     }
     if (neighbor->requests[i]->skip && _offload_balance != 0.0)
-      error->all(FLERR, "Cannot yet use hybrid styles with Intel offload.");
+      error->all(FLERR,"Cannot yet use hybrid styles with Intel offload.");
 
     // avoid flagging a neighbor list as both INTEL and OPENMP
     if (neighbor->requests[i]->intel)
@@ -786,8 +780,7 @@ void FixIntel::add_oresults(const ft * _noalias const f_in,
       if (f_in[1].w == 1)
         error->all(FLERR,"Bad matrix inversion in mldivide3");
       else
-        error->all(FLERR,
-                   "Sphere particles not yet supported for gayberne/intel");
+        error->all(FLERR,"Sphere particles not yet supported for gayberne/intel");
     }
   }
 
@@ -926,7 +919,7 @@ void FixIntel::add_off_results(const ft * _noalias const f_in,
   int nlocal = atom->nlocal;
   if (neighbor->ago == 0) {
     if (_off_overflow_flag[LMP_OVERFLOW])
-      error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
+      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
     _offload_nlocal = _off_overflow_flag[LMP_LOCAL_MAX] + 1;
     _offload_min_ghost = _off_overflow_flag[LMP_GHOST_MIN];
     _offload_nghost = _off_overflow_flag[LMP_GHOST_MAX] + 1 -
@@ -938,7 +931,7 @@ void FixIntel::add_off_results(const ft * _noalias const f_in,
 
   if (atom->torque)
     if (f_in[1].w < 0.0)
-      error->all(FLERR, "Bad matrix inversion in mldivide3");
+      error->all(FLERR,"Bad matrix inversion in mldivide3");
   add_results(f_in, ev_global, _off_results_eatom, _off_results_vatom, 1);
 
   // Load balance?
@@ -1043,8 +1036,7 @@ void FixIntel::output_timing_data() {
           timers[TIME_OFFLOAD_PAIR];
         double tt = MAX(ht,ct);
         if (timers[TIME_OFFLOAD_LATENCY] / tt > 0.07 && _separate_coi == 0)
-          error->warning(FLERR,
-                 "Leaving a core free can improve performance for offload");
+          error->warning(FLERR,"Leaving a core free can improve performance for offload");
       }
       fprintf(_tscreen, "------------------------------------------------\n");
     }
@@ -1109,7 +1101,7 @@ void FixIntel::set_offload_affinity()
   int ppn = get_ppn(node_rank);
 
   if (ppn % _ncops != 0)
-    error->all(FLERR, "MPI tasks per node must be multiple of offload_cards");
+    error->all(FLERR,"MPI tasks per node must be multiple of offload_cards");
   ppn = ppn / _ncops;
   _cop = node_rank / ppn;
   node_rank = node_rank % ppn;
@@ -1214,8 +1206,7 @@ int FixIntel::set_host_affinity(const int nomp)
   int subscription = nthreads * ppn;
   if (subscription > ncores) {
     if (rank == 0)
-      error->warning(FLERR,
-                     "More MPI tasks/OpenMP threads than available cores");
+      error->warning(FLERR,"More MPI tasks/OpenMP threads than available cores");
     return 0;
   }
   if (subscription == ncores)

--- a/src/INTEL/intel_buffers.cpp
+++ b/src/INTEL/intel_buffers.cpp
@@ -296,9 +296,7 @@ void IntelBuffers<flt_t, acc_t>::free_list_ptrs()
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t, class acc_t>
-void IntelBuffers<flt_t, acc_t>::grow_data3(NeighList *list,
-                                            int *&numneighhalf,
-                                            int *&cnumneigh)
+void IntelBuffers<flt_t, acc_t>::grow_data3(NeighList *list, int *&numneighhalf, int *&cnumneigh)
 {
   const int size = list->get_maxlocal();
   int list_num;
@@ -321,10 +319,8 @@ void IntelBuffers<flt_t, acc_t>::grow_data3(NeighList *list,
       lmp->memory->destroy(_neigh_list_ptrs[list_num].cnumneigh);
       lmp->memory->destroy(_neigh_list_ptrs[list_num].numneighhalf);
     }
-    lmp->memory->create(_neigh_list_ptrs[list_num].cnumneigh, size,
-                        "_cnumneigh");
-    lmp->memory->create(_neigh_list_ptrs[list_num].numneighhalf, size,
-                        "_cnumneigh");
+    lmp->memory->create(_neigh_list_ptrs[list_num].cnumneigh, size, "_cnumneigh");
+    lmp->memory->create(_neigh_list_ptrs[list_num].numneighhalf, size, "_cnumneigh");
     _neigh_list_ptrs[list_num].size = size;
   }
   numneighhalf = _neigh_list_ptrs[list_num].numneighhalf;
@@ -334,8 +330,7 @@ void IntelBuffers<flt_t, acc_t>::grow_data3(NeighList *list,
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t, class acc_t>
-void IntelBuffers<flt_t, acc_t>::_grow_list_local(NeighList *list,
-                                                  const int three_body,
+void IntelBuffers<flt_t, acc_t>::_grow_list_local(NeighList *list, const int three_body,
                                                   const int offload_end)
 {
   free_list_local();

--- a/src/INTEL/intel_buffers.cpp
+++ b/src/INTEL/intel_buffers.cpp
@@ -207,8 +207,6 @@ void IntelBuffers<flt_t, acc_t>::free_nmax()
 template <class flt_t, class acc_t>
 void IntelBuffers<flt_t, acc_t>::_grow_nmax(const int offload_end)
 {
-  if (lmp->atom->molecular) _need_tag = 1;
-  else _need_tag = 0;
   #ifdef _LMP_INTEL_OFFLOAD
   free_nmax();
   int size = lmp->atom->nmax;

--- a/src/INTEL/nbin_intel.cpp
+++ b/src/INTEL/nbin_intel.cpp
@@ -161,10 +161,8 @@ void NBinIntel::bin_atoms(IntelBuffers<flt_t,acc_t> * buffers) {
     const flt_t dx = (INTEL_BIGP - bboxhi[0]);
     const flt_t dy = (INTEL_BIGP - bboxhi[1]);
     const flt_t dz = (INTEL_BIGP - bboxhi[2]);
-    if (dx * dx + dy * dy + dz * dz <
-        static_cast<flt_t>(neighbor->cutneighmaxsq))
-      error->one(FLERR,
-        "Intel package expects no atoms within cutoff of {1e15,1e15,1e15}.");
+    if (dx * dx + dy * dy + dz * dz < static_cast<flt_t>(neighbor->cutneighmaxsq))
+      error->one(FLERR,"INTEL package expects no atoms within cutoff of (1e15,1e15,1e15).");
   }
 
   // ---------- Grow and cast/pack buffers -------------

--- a/src/INTEL/npair_intel.cpp
+++ b/src/INTEL/npair_intel.cpp
@@ -367,7 +367,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
             ty[u] = x[j].y;
             tz[u] = x[j].z;
             tjtype[u] = x[j].w;
-            if (THREE) ttag[u] = tag[j];
+            if (THREE && ttag) ttag[u] = tag[j];
           }
 
           if (FULL == 0 && TRI != 1) {
@@ -515,7 +515,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
           }
 
           if (THREE) {
-            const tagint jtag = ttag[u];
+            const tagint jtag = ttag ? ttag[u] : tag[j];
             int flist = 0;
             if (itag > jtag) {
               if (((itag+jtag) & 1) == 0) flist = 1;

--- a/src/INTEL/npair_intel.cpp
+++ b/src/INTEL/npair_intel.cpp
@@ -31,8 +31,7 @@ using namespace LAMMPS_NS;
 NPairIntel::NPairIntel(LAMMPS *lmp) : NPair(lmp) {
   int ifix = modify->find_fix("package_intel");
   if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
+    error->all(FLERR,"The 'package intel' command is required for /intel styles");
   _fix = static_cast<FixIntel *>(modify->fix[ifix]);
   #ifdef _LMP_INTEL_OFFLOAD
   _cop = _fix->coprocessor_number();
@@ -657,6 +656,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
           ns += n2 - pack_offset - maxnbors;
 
           #ifdef LMP_INTEL_3BODY_FAST
+          int alln = n;
           n = lane;
           for (int u = pack_offset; u < alln; u++) {
             neighptr[n] = neighptr2[u];

--- a/src/INTEL/npair_intel.cpp
+++ b/src/INTEL/npair_intel.cpp
@@ -310,7 +310,6 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
       flt_t * _noalias const tz = ncachez + toffs;
       int * _noalias const tj = ncachej + toffs;
       int * _noalias const tjtype = ncachejtype + toffs;
-      tagint * _noalias const ttag = ncachetag + toffs;
 
       flt_t * _noalias itx;
       flt_t * _noalias ity;
@@ -367,7 +366,6 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
             ty[u] = x[j].y;
             tz[u] = x[j].z;
             tjtype[u] = x[j].w;
-            if (THREE && ttag) ttag[u] = tag[j];
           }
 
           if (FULL == 0 && TRI != 1) {
@@ -515,7 +513,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
           }
 
           if (THREE) {
-            const tagint jtag = ttag ? ttag[u] : tag[j];
+            const tagint jtag = tag[j];
             int flist = 0;
             if (itag > jtag) {
               if (((itag+jtag) & 1) == 0) flist = 1;

--- a/src/INTEL/npair_intel.cpp
+++ b/src/INTEL/npair_intel.cpp
@@ -309,6 +309,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
       flt_t * _noalias const tz = ncachez + toffs;
       int * _noalias const tj = ncachej + toffs;
       int * _noalias const tjtype = ncachejtype + toffs;
+      tagint * _noalias const ttag = ncachetag + toffs;
 
       flt_t * _noalias itx;
       flt_t * _noalias ity;
@@ -365,6 +366,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
             ty[u] = x[j].y;
             tz[u] = x[j].z;
             tjtype[u] = x[j].w;
+            if (THREE) ttag[u] = tag[j];
           }
 
           if (FULL == 0 && TRI != 1) {
@@ -512,7 +514,7 @@ void NPairIntel::bin_newton(const int offload, NeighList *list,
           }
 
           if (THREE) {
-            const tagint jtag = tag[j];
+            const tagint jtag = ttag[u];
             int flist = 0;
             if (itag > jtag) {
               if (((itag+jtag) & 1) == 0) flist = 1;

--- a/src/INTEL/pair_sw_intel.cpp
+++ b/src/INTEL/pair_sw_intel.cpp
@@ -1115,8 +1115,7 @@ void PairSWIntel::init_style()
 
   int ifix = modify->find_fix("package_intel");
   if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
+    error->all(FLERR,"The 'package intel' command is required for /intel styles");
   fix = static_cast<FixIntel *>(modify->fix[ifix]);
 
   fix->pair_init_check(true);

--- a/src/INTEL/verlet_lrt_intel.cpp
+++ b/src/INTEL/verlet_lrt_intel.cpp
@@ -71,7 +71,7 @@ void VerletLRTIntel::init()
 
   #ifndef LMP_INTEL_USELRT
   error->all(FLERR,
-             "LRT otion for Intel package disabled at compile time");
+             "LRT otion for INTEL package disabled at compile time");
   #endif
 }
 

--- a/src/MC/fix_bond_swap.cpp
+++ b/src/MC/fix_bond_swap.cpp
@@ -39,7 +39,7 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 
 static const char cite_fix_bond_swap[] =
-  "neighbor multi command:\n\n"
+  "fix bond/swap command:\n\n"
   "@Article{Auhl03,\n"
   " author = {R. Auhl, R. Everaers, G. S. Grest, K. Kremer, S. J. Plimpton},\n"
   " title = {Equilibration of long chain polymer melts in computer simulations},\n"

--- a/src/MISC/pair_list.cpp
+++ b/src/MISC/pair_list.cpp
@@ -232,6 +232,7 @@ void PairList::settings(int narg, char **arg)
       while ((line = reader.next_line())) {
         ValueTokenizer values(line);
         list_param oneparam;
+        oneparam.offset = 0.0;
         oneparam.id1 = values.next_tagint();
         oneparam.id2 = values.next_tagint();
         oneparam.style = stylename[values.next_string()];

--- a/src/MOLECULE/bond_quartic.cpp
+++ b/src/MOLECULE/bond_quartic.cpp
@@ -18,24 +18,25 @@
 
 #include "bond_quartic.h"
 
-#include <cmath>
 #include "atom.h"
-#include "neighbor.h"
 #include "comm.h"
-#include "force.h"
-#include "pair.h"
-#include "memory.h"
 #include "error.h"
+#include "force.h"
+#include "memory.h"
+#include "neighbor.h"
+#include "pair.h"
 
+#include <cmath>
+
+#include "math_const.h"
 
 using namespace LAMMPS_NS;
+using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-BondQuartic::BondQuartic(LAMMPS *lmp) : Bond(lmp)
-{
-  TWO_1_3 = pow(2.0,(1.0/3.0));
-}
+BondQuartic::BondQuartic(LAMMPS *lmp) : Bond(lmp), k(nullptr),
+  b1(nullptr), b2(nullptr), rc(nullptr), u0(nullptr) {}
 
 /* ---------------------------------------------------------------------- */
 
@@ -120,7 +121,7 @@ void BondQuartic::compute(int eflag, int vflag)
     rb = dr - b2[type];
     fbond = -k[type]/r * (r2*(ra+rb) + 2.0*dr*ra*rb);
 
-    if (rsq < TWO_1_3) {
+    if (rsq < MY_CUBEROOT2) {
       sr2 = 1.0/rsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*sr6*(sr6-0.5)/rsq;
@@ -128,7 +129,7 @@ void BondQuartic::compute(int eflag, int vflag)
 
     if (eflag) {
       ebond = k[type]*r2*ra*rb + u0[type];
-      if (rsq < TWO_1_3) ebond += 4.0*sr6*(sr6-1.0) + 1.0;
+      if (rsq < MY_CUBEROOT2) ebond += 4.0*sr6*(sr6-1.0) + 1.0;
     }
 
     // apply force to each of 2 atoms
@@ -336,7 +337,7 @@ double BondQuartic::single(int type, double rsq, int i, int j,
   eng += k[type]*r2*ra*rb + u0[type];
   fforce = -k[type]/r * (r2*(ra+rb) + 2.0*dr*ra*rb);
 
-  if (rsq < TWO_1_3) {
+  if (rsq < MY_CUBEROOT2) {
     sr2 = 1.0/rsq;
     sr6 = sr2*sr2*sr2;
     eng += 4.0*sr6*(sr6-1.0) + 1.0;

--- a/src/MOLECULE/bond_quartic.h
+++ b/src/MOLECULE/bond_quartic.h
@@ -38,7 +38,6 @@ class BondQuartic : public Bond {
   double single(int, double, int, int, double &);
 
  protected:
-  double TWO_1_3;
   double *k, *b1, *b2, *rc, *u0;
 
   void allocate();

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -637,7 +637,7 @@ void FixCMAP::read_grid_map(char *cmapfile)
 {
   if (comm->me == 0) {
     try {
-      memset(&cmapgrid[0][0][0], 6*CMAPDIM*CMAPDIM, sizeof(double));
+      memset(&cmapgrid[0][0][0], 0, 6*CMAPDIM*CMAPDIM*sizeof(double));
       PotentialFileReader reader(lmp, cmapfile, "cmap grid");
 
       // there are six maps in this order.

--- a/src/OPENMP/bond_quartic_omp.cpp
+++ b/src/OPENMP/bond_quartic_omp.cpp
@@ -22,13 +22,15 @@
 #include "comm.h"
 #include "force.h"
 #include "neighbor.h"
-
 #include "pair.h"
 
 #include <cmath>
 
 #include "suffix.h"
+#include "math_const.h"
+
 using namespace LAMMPS_NS;
+using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
@@ -143,7 +145,7 @@ void BondQuarticOMP::eval(int nfrom, int nto, ThrData * const thr)
     rb = dr - b2[type];
     fbond = -k[type]/r * (r2*(ra+rb) + 2.0*dr*ra*rb);
 
-    if (rsq < TWO_1_3) {
+    if (rsq < MY_CUBEROOT2) {
       sr2 = 1.0/rsq;
       sr6 = sr2*sr2*sr2;
       fbond += 48.0*sr6*(sr6-0.5)/rsq;
@@ -151,7 +153,7 @@ void BondQuarticOMP::eval(int nfrom, int nto, ThrData * const thr)
 
     if (EFLAG) {
       ebond = k[type]*r2*ra*rb + u0[type];
-      if (rsq < TWO_1_3) ebond += 4.0*sr6*(sr6-1.0) + 1.0;
+      if (rsq < MY_CUBEROOT2) ebond += 4.0*sr6*(sr6-1.0) + 1.0;
     }
 
     // apply force to each of 2 atoms

--- a/src/REAXFF/fix_acks2_reaxff.cpp
+++ b/src/REAXFF/fix_acks2_reaxff.cpp
@@ -429,7 +429,7 @@ void FixACKS2ReaxFF::compute_X()
   double **x = atom->x;
   int *mask = atom->mask;
 
-  memset(X_diag,0.0,atom->nmax*sizeof(double));
+  memset(X_diag,0,atom->nmax*sizeof(double));
 
   // fill in the X matrix
   m_fill = 0;

--- a/src/REAXFF/fix_qeq_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_reaxff.cpp
@@ -1084,7 +1084,7 @@ void FixQEqReaxFF::vector_add(double* dest, double c, double* v, int k)
 
 void FixQEqReaxFF::get_chi_field()
 {
-  memset(&chi_field[0],0.0,atom->nmax*sizeof(double));
+  memset(&chi_field[0],0,atom->nmax*sizeof(double));
   if (!efield) return;
 
   const double * const *x = (const double * const *)atom->x;

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -220,7 +220,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
 
     } else if (strcmp(arg[iarg],"infile") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix rigid/small command");
-      delete [] inpfile;
+      delete[] inpfile;
       inpfile = utils::strdup(arg[iarg+1]);
       restart_file = 1;
       reinitflag = 0;
@@ -327,7 +327,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
       if (strcmp(arg[iarg+1],"all") == 0) allremap = 1;
       else {
         allremap = 0;
-        delete [] id_dilate;
+        delete[] id_dilate;
         id_dilate = utils::strdup(arg[iarg+1]);
         int idilate = group->find(id_dilate);
         if (idilate == -1)
@@ -354,7 +354,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
 
     } else if (strcmp(arg[iarg],"gravity") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix rigid/small command");
-      delete [] id_gravity;
+      delete[] id_gravity;
       id_gravity = utils::strdup(arg[iarg+1]);
       iarg += 2;
 
@@ -395,7 +395,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
   double time1 = platform::walltime();
 
   create_bodies(bodyID);
-  if (customflag) delete [] bodyID;
+  if (customflag) delete[] bodyID;
 
   if (comm->me == 0)
     utils::logmesg(lmp,"  create bodies CPU = {:.3f} seconds\n",
@@ -501,9 +501,9 @@ FixRigidSmall::~FixRigidSmall()
   memory->destroy(dorient);
 
   delete random;
-  delete [] inpfile;
-  delete [] id_dilate;
-  delete [] id_gravity;
+  delete[] inpfile;
+  delete[] id_dilate;
+  delete[] id_gravity;
 
   memory->destroy(langextra);
   memory->destroy(mass_body);
@@ -2578,8 +2578,8 @@ void FixRigidSmall::readfile(int which, double **array, int *inbody)
 
   if (me == 0) fclose(fp);
 
-  delete [] buffer;
-  delete [] values;
+  delete[] buffer;
+  delete[] values;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/RIGID/fix_rigid_small.h
+++ b/src/RIGID/fix_rigid_small.h
@@ -84,8 +84,9 @@ class FixRigidSmall : public Fix {
   double maxextent;    // furthest distance from body owner to body atom
 
   struct Body {
-    double mass;           // total mass of body
     int natoms;            // total number of atoms in body
+    int ilocal;            // index of owning atom
+    double mass;           // total mass of body
     double xcm[3];         // COM position
     double xgc[3];         // geometric center position
     double vcm[3];         // COM velocity
@@ -97,12 +98,12 @@ class FixRigidSmall : public Fix {
     double ey_space[3];
     double ez_space[3];
     double xgc_body[3];    // geometric center relative to xcm in body coords
-    double angmom[3];    // space-frame angular momentum of body
-    double omega[3];     // space-frame omega of body
-    double conjqm[4];    // conjugate quaternion momentum
-    imageint image;      // image flags of xcm
-    int remapflag[4];    // PBC remap flags
-    int ilocal;          // index of owning atom
+    double angmom[3];      // space-frame angular momentum of body
+    double omega[3];       // space-frame omega of body
+    double conjqm[4];      // conjugate quaternion momentum
+    int remapflag[4];      // PBC remap flags
+    imageint image;        // image flags of xcm
+    imageint dummy;        // dummy entry for better alignment
   };
 
   Body *body;         // list of rigid bodies, owned and ghost

--- a/src/angle_hybrid.cpp
+++ b/src/angle_hybrid.cpp
@@ -240,7 +240,7 @@ void AngleHybrid::settings(int narg, char **arg)
       error->all(FLERR, "Angle style hybrid cannot have none as an argument");
 
     styles[nstyles] = force->new_angle(arg[i], 1, dummy);
-    force->store_style(keywords[nstyles], arg[i], 0);
+    keywords[nstyles] = force->store_style(arg[i], 0);
 
     istyle = i;
     if (strcmp(arg[i], "table") == 0) i++;

--- a/src/bond_hybrid.cpp
+++ b/src/bond_hybrid.cpp
@@ -242,7 +242,7 @@ void BondHybrid::settings(int narg, char **arg)
     if (strncmp(arg[i], "quartic", 7) == 0) has_quartic = m;
 
     styles[nstyles] = force->new_bond(arg[i], 1, dummy);
-    force->store_style(keywords[nstyles], arg[i], 0);
+    keywords[nstyles] = force->store_style(arg[i], 0);
 
     istyle = i;
     if (strcmp(arg[i], "table") == 0) i++;

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -277,10 +277,13 @@ int ComputePairLocal::compute_pairs(int flag)
             break;
           case DX:
             ptr[n] = delx*directionCorrection;
+            break;
           case DY:
             ptr[n] = dely*directionCorrection;
+            break;
           case DZ:
             ptr[n] = delz*directionCorrection;
+            break;
           case ENG:
             ptr[n] = eng;
             break;

--- a/src/dihedral_hybrid.cpp
+++ b/src/dihedral_hybrid.cpp
@@ -241,7 +241,7 @@ void DihedralHybrid::settings(int narg, char **arg)
       error->all(FLERR, "Dihedral style hybrid cannot have none as an argument");
 
     styles[nstyles] = force->new_dihedral(arg[i], 1, dummy);
-    force->store_style(keywords[nstyles], arg[i], 0);
+    keywords[nstyles] = force->store_style(arg[i], 0);
 
     istyle = i;
     if (strcmp(arg[i], "table") == 0) i++;

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -13,20 +13,22 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_balance.h"
-#include <cstring>
-#include "balance.h"
-#include "update.h"
+
 #include "atom.h"
+#include "balance.h"
 #include "comm.h"
 #include "domain.h"
-#include "neighbor.h"
-#include "irregular.h"
+#include "error.h"
+#include "fix_store.h"
 #include "force.h"
+#include "irregular.h"
 #include "kspace.h"
 #include "modify.h"
-#include "fix_store.h"
+#include "neighbor.h"
 #include "rcb.h"
-#include "error.h"
+#include "update.h"
+
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace FixConst;

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -133,14 +133,14 @@ void _noopt Force::create_factories()
 
 Force::~Force()
 {
-  delete [] pair_style;
-  delete [] bond_style;
-  delete [] angle_style;
-  delete [] dihedral_style;
-  delete [] improper_style;
-  delete [] kspace_style;
+  delete[] pair_style;
+  delete[] bond_style;
+  delete[] angle_style;
+  delete[] dihedral_style;
+  delete[] improper_style;
+  delete[] kspace_style;
 
-  delete [] pair_restart;
+  delete[] pair_restart;
 
   if (pair) delete pair;
   if (bond) delete bond;
@@ -220,9 +220,9 @@ void Force::setup()
 
 void Force::create_pair(const std::string &style, int trysuffix)
 {
-  delete [] pair_style;
+  delete[] pair_style;
   if (pair) delete pair;
-  if (pair_restart) delete [] pair_restart;
+  if (pair_restart) delete[] pair_restart;
   pair_style = nullptr;
   pair = nullptr;
   pair_restart = nullptr;
@@ -345,7 +345,7 @@ char *Force::pair_match_ptr(Pair *ptr)
 
 void Force::create_bond(const std::string &style, int trysuffix)
 {
-  delete [] bond_style;
+  delete[] bond_style;
   if (bond) delete bond;
 
   int sflag;
@@ -422,7 +422,7 @@ Bond *Force::bond_match(const std::string &style)
 
 void Force::create_angle(const std::string &style, int trysuffix)
 {
-  delete [] angle_style;
+  delete[] angle_style;
   if (angle) delete angle;
 
   int sflag;
@@ -499,7 +499,7 @@ Angle *Force::angle_match(const std::string &style)
 
 void Force::create_dihedral(const std::string &style, int trysuffix)
 {
-  delete [] dihedral_style;
+  delete[] dihedral_style;
   if (dihedral) delete dihedral;
 
   int sflag;
@@ -576,7 +576,7 @@ Dihedral *Force::dihedral_match(const std::string &style)
 
 void Force::create_improper(const std::string &style, int trysuffix)
 {
-  delete [] improper_style;
+  delete[] improper_style;
   if (improper) delete improper;
 
   int sflag;
@@ -653,7 +653,7 @@ Improper *Force::improper_match(const std::string &style)
 
 void Force::create_kspace(const std::string &style, int trysuffix)
 {
-  delete [] kspace_style;
+  delete[] kspace_style;
   if (kspace) delete kspace;
 
   int sflag;

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -229,7 +229,7 @@ void Force::create_pair(const std::string &style, int trysuffix)
 
   int sflag;
   pair = new_pair(style,trysuffix,sflag);
-  store_style(pair_style,style,sflag);
+  pair_style = store_style(style,sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -350,7 +350,7 @@ void Force::create_bond(const std::string &style, int trysuffix)
 
   int sflag;
   bond = new_bond(style,trysuffix,sflag);
-  store_style(bond_style,style,sflag);
+  bond_style = store_style(style,sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -427,7 +427,7 @@ void Force::create_angle(const std::string &style, int trysuffix)
 
   int sflag;
   angle = new_angle(style,trysuffix,sflag);
-  store_style(angle_style,style,sflag);
+  angle_style = store_style(style,sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -504,7 +504,7 @@ void Force::create_dihedral(const std::string &style, int trysuffix)
 
   int sflag;
   dihedral = new_dihedral(style,trysuffix,sflag);
-  store_style(dihedral_style,style,sflag);
+  dihedral_style = store_style(style,sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -581,7 +581,7 @@ void Force::create_improper(const std::string &style, int trysuffix)
 
   int sflag;
   improper = new_improper(style,trysuffix,sflag);
-  store_style(improper_style,style,sflag);
+  improper_style = store_style(style,sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -658,7 +658,7 @@ void Force::create_kspace(const std::string &style, int trysuffix)
 
   int sflag;
   kspace = new_kspace(style,trysuffix,sflag);
-  store_style(kspace_style,style,sflag);
+  kspace_style = store_style(style,sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -729,14 +729,14 @@ KSpace *Force::kspace_match(const std::string &word, int exact)
    if sflag = 1/2/3, append suffix or suffix2 or suffixp to style
 ------------------------------------------------------------------------- */
 
-void Force::store_style(char *&str, const std::string &style, int sflag)
+char *Force::store_style(const std::string &style, int sflag)
 {
   std::string estyle = style;
 
   if (sflag == 1) estyle += std::string("/") + lmp->suffix;
   else if (sflag == 2) estyle += std::string("/") + lmp->suffix2;
   else if (sflag == 3) estyle += std::string("/") + lmp->suffixp;
-  str = utils::strdup(estyle);
+  return utils::strdup(estyle);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/force.h
+++ b/src/force.h
@@ -146,7 +146,7 @@ class Force : protected Pointers {
   KSpace *new_kspace(const std::string &, int, int &);
   KSpace *kspace_match(const std::string &, int);
 
-  void store_style(char *&, const std::string &, int);
+  char *store_style(const std::string &, int);
   void set_special(int, char **);
 
   double memory_usage();

--- a/src/improper_hybrid.cpp
+++ b/src/improper_hybrid.cpp
@@ -241,7 +241,7 @@ void ImproperHybrid::settings(int narg, char **arg)
       error->all(FLERR, "Improper style hybrid cannot have none as an argument");
 
     styles[nstyles] = force->new_improper(arg[i], 1, dummy);
-    force->store_style(keywords[nstyles], arg[i], 0);
+    keywords[nstyles] = force->store_style(arg[i], 0);
 
     istyle = i;
     if (strcmp(arg[i], "table") == 0) i++;

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -322,7 +322,7 @@ void PairHybrid::settings(int narg, char **arg)
       error->all(FLERR,"Pair style hybrid cannot have none as an argument");
 
     styles[nstyles] = force->new_pair(arg[iarg],1,dummy);
-    force->store_style(keywords[nstyles],arg[iarg],0);
+    keywords[nstyles] = force->store_style(arg[iarg],0);
     special_lj[nstyles] = special_coul[nstyles] = nullptr;
     compute_tally[nstyles] = 1;
 

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -50,20 +50,20 @@ PairHybrid::~PairHybrid()
   if (nstyles > 0) {
     for (int m = 0; m < nstyles; m++) {
       delete styles[m];
-      delete [] keywords[m];
-      if (special_lj[m])   delete [] special_lj[m];
-      if (special_coul[m]) delete [] special_coul[m];
+      delete[] keywords[m];
+      if (special_lj[m])   delete[] special_lj[m];
+      if (special_coul[m]) delete[] special_coul[m];
     }
   }
-  delete [] styles;
-  delete [] keywords;
-  delete [] multiple;
+  delete[] styles;
+  delete[] keywords;
+  delete[] multiple;
 
-  delete [] special_lj;
-  delete [] special_coul;
-  delete [] compute_tally;
+  delete[] special_lj;
+  delete[] special_coul;
+  delete[] compute_tally;
 
-  delete [] svector;
+  delete[] svector;
 
   if (allocated) {
     memory->destroy(setflag);
@@ -187,7 +187,7 @@ void PairHybrid::compute(int eflag, int vflag)
 
   }
 
-  delete [] saved_special;
+  delete[] saved_special;
 
   if (vflag_fdotr) virial_fdotr_compute();
 }
@@ -274,9 +274,9 @@ void PairHybrid::settings(int narg, char **arg)
   if (nstyles > 0) {
     for (int m = 0; m < nstyles; m++) {
       delete styles[m];
-      delete [] keywords[m];
-      if (special_lj[m])   delete [] special_lj[m];
-      if (special_coul[m]) delete [] special_coul[m];
+      delete[] keywords[m];
+      if (special_lj[m])   delete[] special_lj[m];
+      if (special_coul[m]) delete[] special_coul[m];
     }
     delete[] styles;
     delete[] keywords;
@@ -297,8 +297,8 @@ void PairHybrid::settings(int narg, char **arg)
 
   // allocate list of sub-styles as big as possibly needed if no extra args
 
-  styles = new Pair*[narg];
-  keywords = new char*[narg];
+  styles = new Pair *[narg];
+  keywords = new char *[narg];
   multiple = new int[narg];
 
   special_lj = new double*[narg];
@@ -454,7 +454,7 @@ void PairHybrid::init_svector()
     single_extra = MAX(single_extra,styles[m]->single_extra);
 
   if (single_extra) {
-    delete [] svector;
+    delete[] svector;
     svector = new double[single_extra];
   }
 }
@@ -667,7 +667,7 @@ void PairHybrid::init_style()
       neighbor->requests[i]->iskip = iskip;
       neighbor->requests[i]->ijskip = ijskip;
     } else {
-      delete [] iskip;
+      delete[] iskip;
       memory->destroy(ijskip);
     }
   }

--- a/src/pair_hybrid_scaled.cpp
+++ b/src/pair_hybrid_scaled.cpp
@@ -328,7 +328,7 @@ void PairHybridScaled::settings(int narg, char **arg)
       error->all(FLERR, "Pair style hybrid/scaled cannot have none as an argument");
 
     styles[nstyles] = force->new_pair(arg[iarg], 1, dummy);
-    force->store_style(keywords[nstyles], arg[iarg], 0);
+    keywords[nstyles] = force->store_style(arg[iarg], 0);
     special_lj[nstyles] = special_coul[nstyles] = nullptr;
     compute_tally[nstyles] = 1;
 

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -903,23 +903,28 @@ void ReadData::command(int narg, char **arg)
   // restore old styles, when reading with nocoeff flag given
 
   if (coeffflag == 0) {
-    if (force->pair) delete force->pair;
+    delete force->pair;
+    delete[] force->pair_style;
     force->pair = saved_pair;
     force->pair_style = saved_pair_style;
 
-    if (force->bond) delete force->bond;
+    delete force->bond;
+    delete[] force->bond_style;
     force->bond = saved_bond;
     force->bond_style = saved_bond_style;
 
-    if (force->angle) delete force->angle;
+    delete force->angle;
+    delete[] force->angle_style;
     force->angle = saved_angle;
     force->angle_style = saved_angle_style;
 
-    if (force->dihedral) delete force->dihedral;
+    delete force->dihedral;
+    delete[] force->dihedral_style;
     force->dihedral = saved_dihedral;
     force->dihedral_style = saved_dihedral_style;
 
-    if (force->improper) delete force->improper;
+    delete force->improper;
+    delete[] force->improper_style;
     force->improper = saved_improper;
     force->improper_style = saved_improper_style;
 

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -142,8 +142,7 @@ void ReaderNative::skip()
     read_lines(2);
     bigint natoms;
     int rv = sscanf(line,BIGINT_FORMAT,&natoms);
-    if (rv != 1)
-      error->one(FLERR,"Dump file is incorrectly formatted");
+    if (rv != 1) error->one(FLERR,"Dump file is incorrectly formatted");
 
     read_lines(5);
 
@@ -164,20 +163,17 @@ void ReaderNative::skip_reading_magic_str()
   if (is_known_magic_str() && revision > 0x0001) {
     int len;
     read_buf(&len, sizeof(int), 1);
+    if (len < 0) error->one(FLERR,"Dump file is invalid or corrupted");
 
-    if (len > 0) {
-      // has units
-      skip_buf(sizeof(char)*len);
-    }
+    // has units
+    if (len > 0) skip_buf(sizeof(char)*len);
 
     char flag = 0;
     read_buf(&flag, sizeof(char), 1);
-
-    if (flag) {
-      skip_buf(sizeof(double));
-    }
+    if (flag) skip_buf(sizeof(double));
 
     read_buf(&len, sizeof(int), 1);
+    if (len < 0) error->one(FLERR,"Dump file is invalid or corrupted");
     skip_buf(sizeof(char)*len);
   }
 }

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -130,6 +130,7 @@ void ReaderNative::skip()
     // read chunk and skip them
 
     read_buf(&nchunk, sizeof(int), 1);
+    if (nchunk < 0) error->one(FLERR,"Dump file is invalid or corrupted");
 
     int n;
     for (int i = 0; i < nchunk; i++) {

--- a/src/tabular_function.cpp
+++ b/src/tabular_function.cpp
@@ -1,6 +1,6 @@
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
-   https://www.lammps.org/ Sandia National Laboratories
+   https://www.lammps.org/, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract


### PR DESCRIPTION
**Summary**

This pull request collect multiple small changes and bugfixes

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

The following individual changes are included:
- fix a few bugs where memset() was called incorrectly
- fix bug in compute pair/local with dx, dy, dz keywords due to missing "break" statements
- plug a small memory leak which `read_data` was called with the "nocoeff" option
- address multiple uninitialized pointer warnings flagged by coverity scan
- simplify the API of `Force::store_style()` and make it more C/C++ like
- implement a workaround for segfaults with INTEL package manybody styles used with pair style hybrid. fixes #3094

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
