### PR TITLE
Add option to balance dump file output

### DIFF
--- a/doc/src/dump_modify.rst
+++ b/doc/src/dump_modify.rst
@@ -674,7 +674,7 @@ keyword determines whether the number of lines in each processor
 snapshot are balanced to be nearly the same. A balance value of *no*
 means no balancing will be done, while *yes* means balancing will be
 performed. This balancing preserves dump sorting order. For a serial
-run, this option is ignored since the output is already balanced. 
+run, this option is ignored since the output is already balanced.
 
 .. note::
 

--- a/doc/src/dump_modify.rst
+++ b/doc/src/dump_modify.rst
@@ -661,10 +661,11 @@ order.
 
 In a parallel run, the per-processor dump file pieces can have
 significant imbalance in number of lines of per-atom info. The *balance*
-keyword determines whether lines of per-atom output for each processor
-snapshot in a parallel run are balanced to be nearly the same. A balance
-value of *no* means no balancing will be done, while *yes* means
-balancing will be performed. For a serial run, this option is ignored.
+keyword determines whether the number of lines in each processor
+snapshot are balanced to be nearly the same. A balance value of *no*
+means no balancing will be done, while *yes* means balancing will be
+performed.  For a serial run, this option is ignored since the output is
+already balanced. Dump sorting must be enabled to use balancing.
 
 The dump *local* style cannot be sorted by atom ID, since there are
 typically multiple lines of output per atom.  Some dump styles, such

--- a/doc/src/dump_modify.rst
+++ b/doc/src/dump_modify.rst
@@ -17,13 +17,14 @@ Syntax
 * one or more keyword/value pairs may be appended
 
 * these keywords apply to various dump styles
-* keyword = *append* or *at* or *buffer* or *delay* or *element* or *every* or *every/time* or *fileper* or *first* or *flush* or *format* or *header* or *image* or *label* or *maxfiles* or *nfile* or *pad* or *pbc* or *precision* or *region* or *refresh* or *scale* or *sfactor* or *sort* or *tfactor* or *thermo* or *thresh* or *time* or *units* or *unwrap*
+* keyword = *append* or *at* or *balance* or *buffer* or *delay* or *element* or *every* or *every/time* or *fileper* or *first* or *flush* or *format* or *header* or *image* or *label* or *maxfiles* or *nfile* or *pad* or *pbc* or *precision* or *region* or *refresh* or *scale* or *sfactor* or *sort* or *tfactor* or *thermo* or *thresh* or *time* or *units* or *unwrap*
 
   .. parsed-literal::
 
        *append* arg = *yes* or *no*
        *at* arg = N
          N = index of frame written upon first dump
+       *balance* arg = *yes* or *no*
        *buffer* arg = *yes* or *no*
        *delay* arg = Dstep
          Dstep = delay output until this timestep
@@ -658,6 +659,13 @@ atom ID.  A sort value of N or -N means sort the output by the value
 in the Nth column of per-atom info in either ascending or descending
 order.
 
+In a parallel run, the per-processor dump file pieces can have
+significant imbalance in number of lines of per-atom info. The *balance*
+keyword determines whether lines of per-atom output for each processor
+snapshot in a parallel run are balanced to be nearly the same. A balance
+value of *no* means no balancing will be done, while *yes* means
+balancing will be performed. For a serial run, this option is ignored.
+
 The dump *local* style cannot be sorted by atom ID, since there are
 typically multiple lines of output per atom.  Some dump styles, such
 as *dcd* and *xtc*, require sorting by atom ID to format the output
@@ -832,6 +840,7 @@ Default
 The option defaults are
 
 * append = no
+* balance = no
 * buffer = yes for dump styles *atom*, *custom*, *loca*, and *xyz*
 * element = "C" for every atom type
 * every = whatever it was set to via the :doc:`dump <dump>` command

--- a/doc/src/dump_modify.rst
+++ b/doc/src/dump_modify.rst
@@ -659,14 +659,6 @@ atom ID.  A sort value of N or -N means sort the output by the value
 in the Nth column of per-atom info in either ascending or descending
 order.
 
-In a parallel run, the per-processor dump file pieces can have
-significant imbalance in number of lines of per-atom info. The *balance*
-keyword determines whether the number of lines in each processor
-snapshot are balanced to be nearly the same. A balance value of *no*
-means no balancing will be done, while *yes* means balancing will be
-performed.  For a serial run, this option is ignored since the output is
-already balanced. Dump sorting must be enabled to use balancing.
-
 The dump *local* style cannot be sorted by atom ID, since there are
 typically multiple lines of output per atom.  Some dump styles, such
 as *dcd* and *xtc*, require sorting by atom ID to format the output
@@ -675,6 +667,14 @@ the "%" wildcard in the dump filename and the *nfile* or *fileper*
 keywords are set to non-default values (i.e. the number of dump file
 pieces is not equal to the number of procs), then sorting cannot be
 performed.
+
+In a parallel run, the per-processor dump file pieces can have
+significant imbalance in number of lines of per-atom info. The *balance*
+keyword determines whether the number of lines in each processor
+snapshot are balanced to be nearly the same. A balance value of *no*
+means no balancing will be done, while *yes* means balancing will be
+performed.  For a serial run, this option is ignored since the output is
+already balanced. 
 
 .. note::
 

--- a/doc/src/dump_modify.rst
+++ b/doc/src/dump_modify.rst
@@ -673,8 +673,8 @@ significant imbalance in number of lines of per-atom info. The *balance*
 keyword determines whether the number of lines in each processor
 snapshot are balanced to be nearly the same. A balance value of *no*
 means no balancing will be done, while *yes* means balancing will be
-performed.  For a serial run, this option is ignored since the output is
-already balanced. 
+performed. This balancing preserves dump sorting order. For a serial
+run, this option is ignored since the output is already balanced. 
 
 .. note::
 

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -939,11 +939,14 @@ void Dump::balance()
 
   int nmax;
   MPI_Allreduce(&nme_balance,&nmax,1,MPI_INT,MPI_MAX,world);
+  if (nmax > maxbuf) {
+    maxbuf = nmax;
+  }
 
   // allocate a second buffer for balanced data
 
   double* buf_balance;
-  memory->create(buf_balance,nmax*size_one,"dump:buf_balance");
+  memory->create(buf_balance,maxbuf*size_one,"dump:buf_balance");
 
   // compute from which procs I am receiving atoms
   // post recvs first

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -223,9 +223,6 @@ void Dump::init()
     ids = idsort = nullptr;
     index = proclist = nullptr;
     irregular = nullptr;
-
-    if (balance_flag)
-      error->all(FLERR,"Cannot balance dump output without sorting enabled");
   }
 
   if (sort_flag) {

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -936,12 +936,11 @@ void Dump::balance()
 
   // reset buf size to largest of any post-balance nme values
   // this insures proc 0 can receive everyone's info
+  // cannot shrink buf to nme_balance, must use previous maxbuf value
 
   int nmax;
   MPI_Allreduce(&nme_balance,&nmax,1,MPI_INT,MPI_MAX,world);
-  if (nmax > maxbuf) {
-    maxbuf = nmax;
-  }
+  if (nmax > maxbuf) maxbuf = nmax;
 
   // allocate a second buffer for balanced data
 

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -1270,7 +1270,8 @@ void Dump::modify_params(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"balance") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal dump_modify command");
-      balance_flag = utils::logical(FLERR,arg[iarg+1],false,lmp);
+      if (nprocs > 1)
+        balance_flag = utils::logical(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"time") == 0) {

--- a/src/dump.h
+++ b/src/dump.h
@@ -176,6 +176,10 @@ E: Dump file MPI-IO output not allowed with % in filename
 This is because a % signifies one file per processor and MPI-IO
 creates one large file for all processors.
 
+E: Cannot balance dump output without sorting enabled
+
+Self-explanatory.
+
 E: Cannot dump sort when 'nfile' or 'fileper' keywords are set to non-default values
 
 Can only dump sort when the number of dump file pieces using % in filename equals the number of processors

--- a/src/dump.h
+++ b/src/dump.h
@@ -176,10 +176,6 @@ E: Dump file MPI-IO output not allowed with % in filename
 This is because a % signifies one file per processor and MPI-IO
 creates one large file for all processors.
 
-E: Cannot balance dump output without sorting enabled
-
-Self-explanatory.
-
 E: Cannot dump sort when 'nfile' or 'fileper' keywords are set to non-default values
 
 Can only dump sort when the number of dump file pieces using % in filename equals the number of processors

--- a/src/dump.h
+++ b/src/dump.h
@@ -67,6 +67,7 @@ class Dump : protected Pointers {
   int header_flag;          // 0 = item, 2 = xyz
   int flush_flag;           // 0 if no flush, 1 if flush every dump
   int sort_flag;            // 1 if sorted output
+  int balance_flag;         // 1 if load balanced output
   int append_flag;          // 1 if open file in append mode, 0 if not
   int buffer_allow;         // 1 if style allows for buffer_flag, 0 if not
   int buffer_flag;          // 1 if buffer output as one big string, 0 if not
@@ -161,6 +162,7 @@ class Dump : protected Pointers {
   static int bufcompare(const int, const int, void *);
   static int bufcompare_reverse(const int, const int, void *);
 #endif
+  void balance();
 };
 
 }    // namespace LAMMPS_NS


### PR DESCRIPTION
**Summary**

When the dump file is sorted by column, the per-processor files can have significant imbalance in number of lines. This can give post-processing or visualization tools trouble (e.g. running out of memory). This PR adds an option to balance the dump file per-proc output.

**Related Issue(s)**

None.

**Author(s)**

Stan Moore (SNL), with helpful discussion from Steve Plimpton (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes