### PR TITLE
Remove incorrect error check in ReaxFF

### DIFF
--- a/src/OPENMP/pair_reaxff_omp.cpp
+++ b/src/OPENMP/pair_reaxff_omp.cpp
@@ -115,18 +115,12 @@ void PairReaxFFOMP::init_style()
 
   api->system->n = atom->nlocal; // my atoms
   api->system->N = atom->nlocal + atom->nghost; // mine + ghosts
-  api->system->bigN = static_cast<int> (atom->natoms);  // all atoms in the system
   api->system->wsize = comm->nprocs;
 
   if (atom->tag_enable == 0)
     error->all(FLERR,"Pair style reaxff/omp requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style reaxff/omp requires newton pair on");
-
-  // because system->bigN is an int, we cannot have more atoms than MAXSMALLINT
-
-  if (atom->natoms > MAXSMALLINT)
-    error->all(FLERR,"Too many atoms for pair style reaxff/omp");
 
   // need a half neighbor list w/ Newton off and ghost neighbors
   // built whenever re-neighboring occurs
@@ -157,7 +151,6 @@ void PairReaxFFOMP::setup()
   api->system->n = atom->nlocal; // my atoms
   api->system->N = atom->nlocal + atom->nghost; // mine + ghosts
   oldN = api->system->N;
-  api->system->bigN = static_cast<int> (atom->natoms);  // all atoms in the system
 
   if (api->system->N > nmax) {
     memory->destroy(num_nbrs_offset);
@@ -238,7 +231,6 @@ void PairReaxFFOMP::compute(int eflag, int vflag)
 
   api->system->n = atom->nlocal; // my atoms
   api->system->N = atom->nlocal + atom->nghost; // mine + ghosts
-  api->system->bigN = static_cast<int> (atom->natoms);  // all atoms in the system
   const int nall = api->system->N;
 
 #if defined(_OPENMP)

--- a/src/REAXFF/pair_reaxff.cpp
+++ b/src/REAXFF/pair_reaxff.cpp
@@ -90,7 +90,6 @@ PairReaxFF::PairReaxFF(LAMMPS *lmp) : Pair(lmp)
   api->system->num_nbrs = 0;
   api->system->n = 0;                // my atoms
   api->system->N = 0;                // mine + ghosts
-  api->system->bigN = 0;             // all atoms in the system
   api->system->local_cap = 0;
   api->system->total_cap = 0;
   api->system->my_atoms = nullptr;
@@ -352,18 +351,12 @@ void PairReaxFF::init_style()
 
   api->system->n = atom->nlocal; // my atoms
   api->system->N = atom->nlocal + atom->nghost; // mine + ghosts
-  api->system->bigN = static_cast<int> (atom->natoms);  // all atoms in the system
   api->system->wsize = comm->nprocs;
 
   if (atom->tag_enable == 0)
     error->all(FLERR,"Pair style reaxff requires atom IDs");
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style reaxff requires newton pair on");
-
-  // because system->bigN is an int, we cannot have more atoms than MAXSMALLINT
-
-  if (atom->natoms > MAXSMALLINT)
-    error->all(FLERR,"Too many atoms for pair style reaxff");
 
   // need a half neighbor list w/ Newton off and ghost neighbors
   // built whenever re-neighboring occurs
@@ -392,7 +385,6 @@ void PairReaxFF::setup()
   api->system->n = atom->nlocal; // my atoms
   api->system->N = atom->nlocal + atom->nghost; // mine + ghosts
   oldN = api->system->N;
-  api->system->bigN = static_cast<int> (atom->natoms);  // all atoms in the system
 
   if (setup_flag == 0) {
 
@@ -473,7 +465,6 @@ void PairReaxFF::compute(int eflag, int vflag)
 
   api->system->n = atom->nlocal; // my atoms
   api->system->N = atom->nlocal + atom->nghost; // mine + ghosts
-  api->system->bigN = static_cast<int> (atom->natoms);  // all atoms in the system
 
   if (api->system->acks2_flag) {
     int ifix = modify->find_fix_by_style("^acks2/reax");

--- a/src/REAXFF/reaxff_types.h
+++ b/src/REAXFF/reaxff_types.h
@@ -196,7 +196,6 @@ struct LR_lookup_table;    // forward declaration
 struct reax_system {
   reax_interaction reax_param;
 
-  rc_bigint bigN;
   int n, N, numH;
   int local_cap, total_cap, Hcap;
   int wsize, my_rank, num_nbrs;


### PR DESCRIPTION
**Summary**

https://github.com/lammps/lammps/commit/42e8a7613e144e86b8ce0eac302b5fc87323779e prevents running more than 2 billion atoms with ReaxFF, however:

- `bigN` is actually is defined as a `bigint` in `reax_types.h`, so the static_cast to `int` is wrong (and misleading)
- `bigN` actually isn't used anywhere and can just be removed

**Related Issue(s)**

https://github.com/lammps/lammps/commit/42e8a7613e144e86b8ce0eac302b5fc87323779e

**Author(s)**

Stan Moore (SNL), reported by Nick Curtis (AMD), @arghdos 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes