### PR TITLE
Reduce number of visible symbols in LAMMPS library by removing factory function templates from class definition

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -54,6 +54,15 @@ using namespace MathConst;
 #define DELTA_PERATOM 64
 #define EPSILON 1.0e-6
 
+/* ----------------------------------------------------------------------
+   one instance per AtomVec style in style_atom.h
+------------------------------------------------------------------------- */
+
+template <typename T> static AtomVec *avec_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
 /* ---------------------------------------------------------------------- */
 
 /** \class LAMMPS_NS::Atom
@@ -741,16 +750,6 @@ AtomVec *Atom::new_avec(const std::string &style, int trysuffix, int &sflag)
 
   error->all(FLERR,utils::check_packages_for_style("atom",style,lmp));
   return nullptr;
-}
-
-/* ----------------------------------------------------------------------
-   one instance per AtomVec style in style_atom.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-AtomVec *Atom::avec_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/atom.h
+++ b/src/atom.h
@@ -416,9 +416,6 @@ class Atom : protected Pointers {
   void set_atomflag_defaults();
   void setup_sort_bins();
   int next_prime(int);
-
- private:
-  template <typename T> static AtomVec *avec_creator(LAMMPS *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -48,6 +48,15 @@ using namespace LAMMPS_NS;
 #define BONDSTRETCH 1.1
 
 /* ----------------------------------------------------------------------
+   one instance per region style in style_region.h
+------------------------------------------------------------------------- */
+
+template <typename T> static Region *region_creator(LAMMPS *lmp, int narg, char ** arg)
+{
+  return new T(lmp, narg, arg);
+}
+
+/* ----------------------------------------------------------------------
    default is periodic
 ------------------------------------------------------------------------- */
 
@@ -1795,16 +1804,6 @@ void Domain::add_region(int narg, char **arg)
 
   regions[nregion]->init();
   nregion++;
-}
-
-/* ----------------------------------------------------------------------
-   one instance per region style in style_region.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Region *Domain::region_creator(LAMMPS *lmp, int narg, char ** arg)
-{
-  return new T(lmp, narg, arg);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/domain.h
+++ b/src/domain.h
@@ -175,9 +175,6 @@ class Domain : protected Pointers {
 
  protected:
   double small[3];    // fractions of box lengths
-
- private:
-  template <typename T> static Region *region_creator(LAMMPS *, int, char **);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -25,8 +24,8 @@
 #include "bond_hybrid.h"
 #include "dihedral_hybrid.h"
 #include "improper_hybrid.h"
-#include "pair_hybrid.h"
 #include "kspace.h"
+#include "pair_hybrid.h"
 
 #include "atom.h"
 #include "comm.h"
@@ -57,8 +56,8 @@ Force::Force(LAMMPS *lmp) : Pointers(lmp)
   special_extra = 0;
 
   dielectric = 1.0;
-  qqr2e_lammps_real = 332.06371;          // these constants are toggled
-  qqr2e_charmm_real = 332.0716;           // by new CHARMM pair styles
+  qqr2e_lammps_real = 332.06371;    // these constants are toggled
+  qqr2e_charmm_real = 332.0716;     // by new CHARMM pair styles
 
   pair = nullptr;
   bond = nullptr;
@@ -85,54 +84,48 @@ void _noopt Force::create_factories()
   pair_map = new PairCreatorMap();
 
 #define PAIR_CLASS
-#define PairStyle(key,Class) \
-  (*pair_map)[#key] = &style_creator<Pair, Class>;
-#include "style_pair.h"  // IWYU pragma: keep
+#define PairStyle(key, Class) (*pair_map)[#key] = &style_creator<Pair, Class>;
+#include "style_pair.h"    // IWYU pragma: keep
 #undef PairStyle
 #undef PAIR_CLASS
 
   bond_map = new BondCreatorMap();
 
 #define BOND_CLASS
-#define BondStyle(key,Class) \
-  (*bond_map)[#key] = &style_creator<Bond, Class>;
-#include "style_bond.h"  // IWYU pragma: keep
+#define BondStyle(key, Class) (*bond_map)[#key] = &style_creator<Bond, Class>;
+#include "style_bond.h"    // IWYU pragma: keep
 #undef BondStyle
 #undef BOND_CLASS
 
   angle_map = new AngleCreatorMap();
 
 #define ANGLE_CLASS
-#define AngleStyle(key,Class) \
-  (*angle_map)[#key] = &style_creator<Angle, Class>;
-#include "style_angle.h"  // IWYU pragma: keep
+#define AngleStyle(key, Class) (*angle_map)[#key] = &style_creator<Angle, Class>;
+#include "style_angle.h"    // IWYU pragma: keep
 #undef AngleStyle
 #undef ANGLE_CLASS
 
   dihedral_map = new DihedralCreatorMap();
 
 #define DIHEDRAL_CLASS
-#define DihedralStyle(key,Class) \
-  (*dihedral_map)[#key] = &style_creator<Dihedral, Class>;
-#include "style_dihedral.h"  // IWYU pragma: keep
+#define DihedralStyle(key, Class) (*dihedral_map)[#key] = &style_creator<Dihedral, Class>;
+#include "style_dihedral.h"    // IWYU pragma: keep
 #undef DihedralStyle
 #undef DIHEDRAL_CLASS
 
   improper_map = new ImproperCreatorMap();
 
 #define IMPROPER_CLASS
-#define ImproperStyle(key,Class) \
-  (*improper_map)[#key] = &style_creator<Improper, Class>;
-#include "style_improper.h"  // IWYU pragma: keep
+#define ImproperStyle(key, Class) (*improper_map)[#key] = &style_creator<Improper, Class>;
+#include "style_improper.h"    // IWYU pragma: keep
 #undef ImproperStyle
 #undef IMPROPER_CLASS
 
   kspace_map = new KSpaceCreatorMap();
 
 #define KSPACE_CLASS
-#define KSpaceStyle(key,Class) \
-  (*kspace_map)[#key] = &style_creator<KSpace, Class>;
-#include "style_kspace.h"  // IWYU pragma: keep
+#define KSpaceStyle(key, Class) (*kspace_map)[#key] = &style_creator<KSpace, Class>;
+#include "style_kspace.h"    // IWYU pragma: keep
 #undef KSpaceStyle
 #undef KSPACE_CLASS
 }
@@ -176,17 +169,17 @@ Force::~Force()
 
 void Force::init()
 {
-  qqrd2e = qqr2e/dielectric;
+  qqrd2e = qqr2e / dielectric;
 
   // check if pair style must be specified after restart
   if (pair_restart) {
     if (!pair)
-      error->all(FLERR,"Must re-specify non-restarted pair style "
-                                   "({}) after read_restart", pair_restart);
+      error->all(FLERR, "Must re-specify non-restarted pair style ({}) after read_restart",
+                 pair_restart);
   }
 
-  if (kspace) kspace->init();         // kspace must come before pair
-  if (pair) pair->init();             // so g_ewald is defined
+  if (kspace) kspace->init();    // kspace must come before pair
+  if (pair) pair->init();        // so g_ewald is defined
   if (bond) bond->init();
   if (angle) angle->init();
   if (dihedral) dihedral->init();
@@ -196,22 +189,22 @@ void Force::init()
 
   if (comm->me == 0) {
     if (!bond && (atom->nbonds > 0)) {
-      error->warning(FLERR,"Bonds are defined but no bond style is set");
+      error->warning(FLERR, "Bonds are defined but no bond style is set");
       if ((special_lj[1] != 1.0) || (special_coul[1] != 1.0))
-        error->warning(FLERR,"Likewise 1-2 special neighbor interactions != 1.0");
+        error->warning(FLERR, "Likewise 1-2 special neighbor interactions != 1.0");
     }
     if (!angle && (atom->nangles > 0)) {
-      error->warning(FLERR,"Angles are defined but no angle style is set");
+      error->warning(FLERR, "Angles are defined but no angle style is set");
       if ((special_lj[2] != 1.0) || (special_coul[2] != 1.0))
-        error->warning(FLERR,"Likewise 1-3 special neighbor interactions != 1.0");
+        error->warning(FLERR, "Likewise 1-3 special neighbor interactions != 1.0");
     }
     if (!dihedral && (atom->ndihedrals > 0)) {
-      error->warning(FLERR,"Dihedrals are defined but no dihedral style is set");
+      error->warning(FLERR, "Dihedrals are defined but no dihedral style is set");
       if ((special_lj[3] != 1.0) || (special_coul[3] != 1.0))
-        error->warning(FLERR,"Likewise 1-4 special neighbor interactions != 1.0");
+        error->warning(FLERR, "Likewise 1-4 special neighbor interactions != 1.0");
     }
     if (!improper && (atom->nimpropers > 0))
-      error->warning(FLERR,"Impropers are defined but no improper style is set");
+      error->warning(FLERR, "Impropers are defined but no improper style is set");
   }
 }
 
@@ -236,8 +229,8 @@ void Force::create_pair(const std::string &style, int trysuffix)
   pair_restart = nullptr;
 
   int sflag;
-  pair = new_pair(style,trysuffix,sflag);
-  pair_style = store_style(style,sflag);
+  pair = new_pair(style, trysuffix, sflag);
+  pair_style = store_style(style, sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -283,7 +276,7 @@ Pair *Force::new_pair(const std::string &style, int trysuffix, int &sflag)
     return pair_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("pair",style,lmp));
+  error->all(FLERR, utils::check_packages_for_style("pair", style, lmp));
 
   return nullptr;
 }
@@ -298,16 +291,18 @@ Pair *Force::new_pair(const std::string &style, int trysuffix, int &sflag)
 
 Pair *Force::pair_match(const std::string &word, int exact, int nsub)
 {
-  int iwhich,count;
+  int iwhich, count;
 
-  if (exact && (word == pair_style)) return pair;
-  else if (!exact && utils::strmatch(pair_style,word)) return pair;
-  else if (utils::strmatch(pair_style,"^hybrid")) {
+  if (exact && (word == pair_style))
+    return pair;
+  else if (!exact && utils::strmatch(pair_style, word))
+    return pair;
+  else if (utils::strmatch(pair_style, "^hybrid")) {
     PairHybrid *hybrid = (PairHybrid *) pair;
     count = 0;
     for (int i = 0; i < hybrid->nstyles; i++)
       if ((exact && (word == hybrid->keywords[i])) ||
-          (!exact && utils::strmatch(hybrid->keywords[i],word))) {
+          (!exact && utils::strmatch(hybrid->keywords[i], word))) {
         iwhich = i;
         count++;
         if (nsub == count) return hybrid->styles[iwhich];
@@ -328,7 +323,7 @@ char *Force::pair_match_ptr(Pair *ptr)
 {
   if (ptr == pair) return pair_style;
 
-  if (utils::strmatch(pair_style,"^hybrid")) {
+  if (utils::strmatch(pair_style, "^hybrid")) {
     PairHybrid *hybrid = (PairHybrid *) pair;
     for (int i = 0; i < hybrid->nstyles; i++)
       if (ptr == hybrid->styles[i]) return hybrid->keywords[i];
@@ -347,8 +342,8 @@ void Force::create_bond(const std::string &style, int trysuffix)
   if (bond) delete bond;
 
   int sflag;
-  bond = new_bond(style,trysuffix,sflag);
-  bond_style = store_style(style,sflag);
+  bond = new_bond(style, trysuffix, sflag);
+  bond_style = store_style(style, sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -384,7 +379,7 @@ Bond *Force::new_bond(const std::string &style, int trysuffix, int &sflag)
     return bond_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("bond",style,lmp));
+  error->all(FLERR, utils::check_packages_for_style("bond", style, lmp));
 
   return nullptr;
 }
@@ -395,8 +390,9 @@ Bond *Force::new_bond(const std::string &style, int trysuffix, int &sflag)
 
 Bond *Force::bond_match(const std::string &style)
 {
-  if (style == bond_style) return bond;
-  else if (strcmp(bond_style,"hybrid") == 0) {
+  if (style == bond_style)
+    return bond;
+  else if (strcmp(bond_style, "hybrid") == 0) {
     BondHybrid *hybrid = (BondHybrid *) bond;
     for (int i = 0; i < hybrid->nstyles; i++)
       if (style == hybrid->keywords[i]) return hybrid->styles[i];
@@ -414,8 +410,8 @@ void Force::create_angle(const std::string &style, int trysuffix)
   if (angle) delete angle;
 
   int sflag;
-  angle = new_angle(style,trysuffix,sflag);
-  angle_style = store_style(style,sflag);
+  angle = new_angle(style, trysuffix, sflag);
+  angle_style = store_style(style, sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -451,7 +447,7 @@ Angle *Force::new_angle(const std::string &style, int trysuffix, int &sflag)
     return angle_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("angle",style,lmp));
+  error->all(FLERR, utils::check_packages_for_style("angle", style, lmp));
 
   return nullptr;
 }
@@ -462,8 +458,9 @@ Angle *Force::new_angle(const std::string &style, int trysuffix, int &sflag)
 
 Angle *Force::angle_match(const std::string &style)
 {
-  if (style == angle_style) return angle;
-  else if (utils::strmatch(angle_style,"^hybrid")) {
+  if (style == angle_style)
+    return angle;
+  else if (utils::strmatch(angle_style, "^hybrid")) {
     AngleHybrid *hybrid = (AngleHybrid *) angle;
     for (int i = 0; i < hybrid->nstyles; i++)
       if (style == hybrid->keywords[i]) return hybrid->styles[i];
@@ -481,8 +478,8 @@ void Force::create_dihedral(const std::string &style, int trysuffix)
   if (dihedral) delete dihedral;
 
   int sflag;
-  dihedral = new_dihedral(style,trysuffix,sflag);
-  dihedral_style = store_style(style,sflag);
+  dihedral = new_dihedral(style, trysuffix, sflag);
+  dihedral_style = store_style(style, sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -518,7 +515,7 @@ Dihedral *Force::new_dihedral(const std::string &style, int trysuffix, int &sfla
     return dihedral_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("dihedral",style,lmp));
+  error->all(FLERR, utils::check_packages_for_style("dihedral", style, lmp));
 
   return nullptr;
 }
@@ -529,8 +526,9 @@ Dihedral *Force::new_dihedral(const std::string &style, int trysuffix, int &sfla
 
 Dihedral *Force::dihedral_match(const std::string &style)
 {
-  if (style == dihedral_style) return dihedral;
-  else if (utils::strmatch(dihedral_style,"^hybrid")) {
+  if (style == dihedral_style)
+    return dihedral;
+  else if (utils::strmatch(dihedral_style, "^hybrid")) {
     DihedralHybrid *hybrid = (DihedralHybrid *) dihedral;
     for (int i = 0; i < hybrid->nstyles; i++)
       if (style == hybrid->keywords[i]) return hybrid->styles[i];
@@ -548,8 +546,8 @@ void Force::create_improper(const std::string &style, int trysuffix)
   if (improper) delete improper;
 
   int sflag;
-  improper = new_improper(style,trysuffix,sflag);
-  improper_style = store_style(style,sflag);
+  improper = new_improper(style, trysuffix, sflag);
+  improper_style = store_style(style, sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -585,7 +583,7 @@ Improper *Force::new_improper(const std::string &style, int trysuffix, int &sfla
     return improper_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("improper",style,lmp));
+  error->all(FLERR, utils::check_packages_for_style("improper", style, lmp));
 
   return nullptr;
 }
@@ -596,8 +594,9 @@ Improper *Force::new_improper(const std::string &style, int trysuffix, int &sfla
 
 Improper *Force::improper_match(const std::string &style)
 {
-  if (style == improper_style) return improper;
-  else if (utils::strmatch(improper_style,"^hybrid")) {
+  if (style == improper_style)
+    return improper;
+  else if (utils::strmatch(improper_style, "^hybrid")) {
     ImproperHybrid *hybrid = (ImproperHybrid *) improper;
     for (int i = 0; i < hybrid->nstyles; i++)
       if (style == hybrid->keywords[i]) return hybrid->styles[i];
@@ -615,8 +614,8 @@ void Force::create_kspace(const std::string &style, int trysuffix)
   if (kspace) delete kspace;
 
   int sflag;
-  kspace = new_kspace(style,trysuffix,sflag);
-  kspace_style = store_style(style,sflag);
+  kspace = new_kspace(style, trysuffix, sflag);
+  kspace_style = store_style(style, sflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -652,7 +651,7 @@ KSpace *Force::new_kspace(const std::string &style, int trysuffix, int &sflag)
     return kspace_creator(lmp);
   }
 
-  error->all(FLERR,utils::check_packages_for_style("kspace",style,lmp));
+  error->all(FLERR, utils::check_packages_for_style("kspace", style, lmp));
 
   return nullptr;
 }
@@ -666,8 +665,10 @@ KSpace *Force::new_kspace(const std::string &style, int trysuffix, int &sflag)
 
 KSpace *Force::kspace_match(const std::string &word, int exact)
 {
-  if (exact && (word == kspace_style)) return kspace;
-  else if (!exact && utils::strmatch(kspace_style,word)) return kspace;
+  if (exact && (word == kspace_style))
+    return kspace;
+  else if (!exact && utils::strmatch(kspace_style, word))
+    return kspace;
   return nullptr;
 }
 
@@ -681,9 +682,12 @@ char *Force::store_style(const std::string &style, int sflag)
 {
   std::string estyle = style;
 
-  if (sflag == 1) estyle += std::string("/") + lmp->suffix;
-  else if (sflag == 2) estyle += std::string("/") + lmp->suffix2;
-  else if (sflag == 3) estyle += std::string("/") + lmp->suffixp;
+  if (sflag == 1)
+    estyle += std::string("/") + lmp->suffix;
+  else if (sflag == 2)
+    estyle += std::string("/") + lmp->suffix2;
+  else if (sflag == 3)
+    estyle += std::string("/") + lmp->suffixp;
   return utils::strdup(estyle);
 }
 
@@ -693,7 +697,7 @@ char *Force::store_style(const std::string &style, int sflag)
 
 void Force::set_special(int narg, char **arg)
 {
-  if (narg == 0) error->all(FLERR,"Illegal special_bonds command");
+  if (narg == 0) error->all(FLERR, "Illegal special_bonds command");
 
   // defaults, but do not reset special_extra
 
@@ -703,17 +707,17 @@ void Force::set_special(int narg, char **arg)
 
   int iarg = 0;
   while (iarg < narg) {
-    if (strcmp(arg[iarg],"amber") == 0) {
-      if (iarg+1 > narg) error->all(FLERR,"Illegal special_bonds command");
+    if (strcmp(arg[iarg], "amber") == 0) {
+      if (iarg + 1 > narg) error->all(FLERR, "Illegal special_bonds command");
       special_lj[1] = 0.0;
       special_lj[2] = 0.0;
       special_lj[3] = 0.5;
       special_coul[1] = 0.0;
       special_coul[2] = 0.0;
-      special_coul[3] = 5.0/6.0;
+      special_coul[3] = 5.0 / 6.0;
       iarg += 1;
-    } else if (strcmp(arg[iarg],"charmm") == 0) {
-      if (iarg+1 > narg) error->all(FLERR,"Illegal special_bonds command");
+    } else if (strcmp(arg[iarg], "charmm") == 0) {
+      if (iarg + 1 > narg) error->all(FLERR, "Illegal special_bonds command");
       special_lj[1] = 0.0;
       special_lj[2] = 0.0;
       special_lj[3] = 0.0;
@@ -721,8 +725,8 @@ void Force::set_special(int narg, char **arg)
       special_coul[2] = 0.0;
       special_coul[3] = 0.0;
       iarg += 1;
-    } else if (strcmp(arg[iarg],"dreiding") == 0) {
-      if (iarg+1 > narg) error->all(FLERR,"Illegal special_bonds command");
+    } else if (strcmp(arg[iarg], "dreiding") == 0) {
+      if (iarg + 1 > narg) error->all(FLERR, "Illegal special_bonds command");
       special_lj[1] = 0.0;
       special_lj[2] = 0.0;
       special_lj[3] = 1.0;
@@ -730,8 +734,8 @@ void Force::set_special(int narg, char **arg)
       special_coul[2] = 0.0;
       special_coul[3] = 1.0;
       iarg += 1;
-    } else if (strcmp(arg[iarg],"fene") == 0) {
-      if (iarg+1 > narg) error->all(FLERR,"Illegal special_bonds command");
+    } else if (strcmp(arg[iarg], "fene") == 0) {
+      if (iarg + 1 > narg) error->all(FLERR, "Illegal special_bonds command");
       special_lj[1] = 0.0;
       special_lj[2] = 1.0;
       special_lj[3] = 1.0;
@@ -739,39 +743,40 @@ void Force::set_special(int narg, char **arg)
       special_coul[2] = 1.0;
       special_coul[3] = 1.0;
       iarg += 1;
-    } else if (strcmp(arg[iarg],"lj/coul") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal special_bonds command");
-      special_lj[1] = special_coul[1] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      special_lj[2] = special_coul[2] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      special_lj[3] = special_coul[3] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
+    } else if (strcmp(arg[iarg], "lj/coul") == 0) {
+      if (iarg + 4 > narg) error->all(FLERR, "Illegal special_bonds command");
+      special_lj[1] = special_coul[1] = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
+      special_lj[2] = special_coul[2] = utils::numeric(FLERR, arg[iarg + 2], false, lmp);
+      special_lj[3] = special_coul[3] = utils::numeric(FLERR, arg[iarg + 3], false, lmp);
       iarg += 4;
-    } else if (strcmp(arg[iarg],"lj") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal special_bonds command");
-      special_lj[1] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      special_lj[2] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      special_lj[3] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
+    } else if (strcmp(arg[iarg], "lj") == 0) {
+      if (iarg + 4 > narg) error->all(FLERR, "Illegal special_bonds command");
+      special_lj[1] = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
+      special_lj[2] = utils::numeric(FLERR, arg[iarg + 2], false, lmp);
+      special_lj[3] = utils::numeric(FLERR, arg[iarg + 3], false, lmp);
       iarg += 4;
-    } else if (strcmp(arg[iarg],"coul") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal special_bonds command");
-      special_coul[1] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      special_coul[2] = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      special_coul[3] = utils::numeric(FLERR,arg[iarg+3],false,lmp);
+    } else if (strcmp(arg[iarg], "coul") == 0) {
+      if (iarg + 4 > narg) error->all(FLERR, "Illegal special_bonds command");
+      special_coul[1] = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
+      special_coul[2] = utils::numeric(FLERR, arg[iarg + 2], false, lmp);
+      special_coul[3] = utils::numeric(FLERR, arg[iarg + 3], false, lmp);
       iarg += 4;
-    } else if (strcmp(arg[iarg],"angle") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal special_bonds command");
-      special_angle = utils::logical(FLERR,arg[iarg+1],false,lmp);
+    } else if (strcmp(arg[iarg], "angle") == 0) {
+      if (iarg + 2 > narg) error->all(FLERR, "Illegal special_bonds command");
+      special_angle = utils::logical(FLERR, arg[iarg + 1], false, lmp);
       iarg += 2;
-    } else if (strcmp(arg[iarg],"dihedral") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal special_bonds command");
-      special_dihedral = utils::logical(FLERR,arg[iarg+1],false,lmp);
+    } else if (strcmp(arg[iarg], "dihedral") == 0) {
+      if (iarg + 2 > narg) error->all(FLERR, "Illegal special_bonds command");
+      special_dihedral = utils::logical(FLERR, arg[iarg + 1], false, lmp);
       iarg += 2;
-    } else error->all(FLERR,"Illegal special_bonds command");
+    } else
+      error->all(FLERR, "Illegal special_bonds command");
   }
 
   for (int i = 1; i <= 3; i++)
-    if (special_lj[i] < 0.0 || special_lj[i] > 1.0 ||
-        special_coul[i] < 0.0 || special_coul[i] > 1.0)
-      error->all(FLERR,"Illegal special_bonds command");
+    if (special_lj[i] < 0.0 || special_lj[i] > 1.0 || special_coul[i] < 0.0 ||
+        special_coul[i] > 1.0)
+      error->all(FLERR, "Illegal special_bonds command");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -36,6 +36,39 @@
 
 using namespace LAMMPS_NS;
 
+// templates for factory functions:
+// there will be one instance for each style keyword in the style_xxx.h file
+
+template <typename T> static Pair *pair_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
+template <typename T> static Bond *bond_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
+template <typename T> static Angle *angle_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
+template <typename T> static Dihedral *dihedral_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
+template <typename T> static Improper *improper_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
+template <typename T> static KSpace *kspace_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
 /* ---------------------------------------------------------------------- */
 
 Force::Force(LAMMPS *lmp) : Pointers(lmp)
@@ -281,16 +314,6 @@ Pair *Force::new_pair(const std::string &style, int trysuffix, int &sflag)
 }
 
 /* ----------------------------------------------------------------------
-   one instance per pair style in style_pair.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Pair *Force::pair_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-/* ----------------------------------------------------------------------
    return ptr to Pair class if matches word or matches hybrid sub-style
    if exact, then style name must be exact match to word
    if not exact, style name must contain word
@@ -392,16 +415,6 @@ Bond *Force::new_bond(const std::string &style, int trysuffix, int &sflag)
 }
 
 /* ----------------------------------------------------------------------
-   one instance per bond style in style_bond.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Bond *Force::bond_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-/* ----------------------------------------------------------------------
    return ptr to current bond class or hybrid sub-class if matches style
 ------------------------------------------------------------------------- */
 
@@ -466,16 +479,6 @@ Angle *Force::new_angle(const std::string &style, int trysuffix, int &sflag)
   error->all(FLERR,utils::check_packages_for_style("angle",style,lmp));
 
   return nullptr;
-}
-
-/* ----------------------------------------------------------------------
-   one instance per angle style in style_angle.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Angle *Force::angle_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
 }
 
 /* ----------------------------------------------------------------------
@@ -546,16 +549,6 @@ Dihedral *Force::new_dihedral(const std::string &style, int trysuffix, int &sfla
 }
 
 /* ----------------------------------------------------------------------
-   one instance per dihedral style in style_dihedral.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Dihedral *Force::dihedral_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-/* ----------------------------------------------------------------------
    return ptr to current angle class or hybrid sub-class if matches style
 ------------------------------------------------------------------------- */
 
@@ -623,16 +616,6 @@ Improper *Force::new_improper(const std::string &style, int trysuffix, int &sfla
 }
 
 /* ----------------------------------------------------------------------
-   one instance per improper style in style_improper.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Improper *Force::improper_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-/* ----------------------------------------------------------------------
    return ptr to current improper class or hybrid sub-class if matches style
 ------------------------------------------------------------------------- */
 
@@ -697,16 +680,6 @@ KSpace *Force::new_kspace(const std::string &style, int trysuffix, int &sflag)
   error->all(FLERR,utils::check_packages_for_style("kspace",style,lmp));
 
   return nullptr;
-}
-
-/* ----------------------------------------------------------------------
-   one instance per kspace style in style_kspace.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-KSpace *Force::kspace_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/force.cpp
+++ b/src/force.cpp
@@ -36,35 +36,10 @@
 
 using namespace LAMMPS_NS;
 
-// templates for factory functions:
-// there will be one instance for each style keyword in the style_xxx.h file
+// template for factory functions:
+// there will be one instance for each style keyword in the respective style_xxx.h files
 
-template <typename T> static Pair *pair_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-template <typename T> static Bond *bond_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-template <typename T> static Angle *angle_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-template <typename T> static Dihedral *dihedral_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-template <typename T> static Improper *improper_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-template <typename T> static KSpace *kspace_creator(LAMMPS *lmp)
+template <typename S, typename T> static S *style_creator(LAMMPS *lmp)
 {
   return new T(lmp);
 }
@@ -111,7 +86,7 @@ void _noopt Force::create_factories()
 
 #define PAIR_CLASS
 #define PairStyle(key,Class) \
-  (*pair_map)[#key] = &pair_creator<Class>;
+  (*pair_map)[#key] = &style_creator<Pair, Class>;
 #include "style_pair.h"  // IWYU pragma: keep
 #undef PairStyle
 #undef PAIR_CLASS
@@ -120,7 +95,7 @@ void _noopt Force::create_factories()
 
 #define BOND_CLASS
 #define BondStyle(key,Class) \
-  (*bond_map)[#key] = &bond_creator<Class>;
+  (*bond_map)[#key] = &style_creator<Bond, Class>;
 #include "style_bond.h"  // IWYU pragma: keep
 #undef BondStyle
 #undef BOND_CLASS
@@ -129,7 +104,7 @@ void _noopt Force::create_factories()
 
 #define ANGLE_CLASS
 #define AngleStyle(key,Class) \
-  (*angle_map)[#key] = &angle_creator<Class>;
+  (*angle_map)[#key] = &style_creator<Angle, Class>;
 #include "style_angle.h"  // IWYU pragma: keep
 #undef AngleStyle
 #undef ANGLE_CLASS
@@ -138,7 +113,7 @@ void _noopt Force::create_factories()
 
 #define DIHEDRAL_CLASS
 #define DihedralStyle(key,Class) \
-  (*dihedral_map)[#key] = &dihedral_creator<Class>;
+  (*dihedral_map)[#key] = &style_creator<Dihedral, Class>;
 #include "style_dihedral.h"  // IWYU pragma: keep
 #undef DihedralStyle
 #undef DIHEDRAL_CLASS
@@ -147,7 +122,7 @@ void _noopt Force::create_factories()
 
 #define IMPROPER_CLASS
 #define ImproperStyle(key,Class) \
-  (*improper_map)[#key] = &improper_creator<Class>;
+  (*improper_map)[#key] = &style_creator<Improper, Class>;
 #include "style_improper.h"  // IWYU pragma: keep
 #undef ImproperStyle
 #undef IMPROPER_CLASS
@@ -156,7 +131,7 @@ void _noopt Force::create_factories()
 
 #define KSPACE_CLASS
 #define KSpaceStyle(key,Class) \
-  (*kspace_map)[#key] = &kspace_creator<Class>;
+  (*kspace_map)[#key] = &style_creator<KSpace, Class>;
 #include "style_kspace.h"  // IWYU pragma: keep
 #undef KSpaceStyle
 #undef KSPACE_CLASS

--- a/src/force.h
+++ b/src/force.h
@@ -153,12 +153,6 @@ class Force : protected Pointers {
 
  private:
   void create_factories();
-  template <typename T> static Pair *pair_creator(LAMMPS *);
-  template <typename T> static Bond *bond_creator(LAMMPS *);
-  template <typename T> static Angle *angle_creator(LAMMPS *);
-  template <typename T> static Dihedral *dihedral_creator(LAMMPS *);
-  template <typename T> static Improper *improper_creator(LAMMPS *);
-  template <typename T> static KSpace *kspace_creator(LAMMPS *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -57,6 +57,15 @@ using namespace LAMMPS_NS;
 #define DELTALINE 256
 #define DELTA 4
 
+/* ----------------------------------------------------------------------
+   one instance per command in style_command.h
+------------------------------------------------------------------------- */
+
+template <typename T> static Command *command_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
 /* ---------------------------------------------------------------------- */
 
 /** \class LAMMPS_NS::Input
@@ -808,16 +817,6 @@ int Input::execute_command()
   // unrecognized command
 
   return -1;
-}
-
-/* ----------------------------------------------------------------------
-   one instance per command in style_command.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Command *Input::command_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/input.h
+++ b/src/input.h
@@ -64,9 +64,6 @@ class Input : protected Pointers {
   typedef std::map<std::string, CommandCreator> CommandCreatorMap;
   CommandCreatorMap *command_map;
 
- protected:
-  template <typename T> static Command *command_creator(LAMMPS *);
-
  private:
   void parse();                            // parse an input text line
   char *nextword(char *, char **);         // find next word in string with quotes

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -37,15 +37,10 @@ using namespace FixConst;
 #define DELTA 4
 #define BIG 1.0e20
 
-// templates for factory functions:
-// there will be one instance for each style keyword in the style_xxx.h file
+// template for factory function:
+// there will be one instance for each style keyword in the respective style_xxx.h files
 
-template <typename T> static Fix *fix_creator(LAMMPS *lmp, int narg, char **arg)
-{
-  return new T(lmp,narg,arg);
-}
-
-template <typename T> static Compute *compute_creator(LAMMPS *lmp, int narg, char **arg)
+template <typename S, typename T> static S *style_creator(LAMMPS *lmp, int narg, char **arg)
 {
   return new T(lmp,narg,arg);
 }
@@ -106,7 +101,7 @@ void _noopt Modify::create_factories()
 
 #define FIX_CLASS
 #define FixStyle(key,Class) \
-  (*fix_map)[#key] = &fix_creator<Class>;
+  (*fix_map)[#key] = &style_creator<Fix, Class>;
 #include "style_fix.h"  // IWYU pragma: keep
 #undef FixStyle
 #undef FIX_CLASS
@@ -117,7 +112,7 @@ void _noopt Modify::create_factories()
 
 #define COMPUTE_CLASS
 #define ComputeStyle(key,Class) \
-  (*compute_map)[#key] = &compute_creator<Class>;
+  (*compute_map)[#key] = &style_creator<Compute, Class>;
 #include "style_compute.h"  // IWYU pragma: keep
 #undef ComputeStyle
 #undef COMPUTE_CLASS

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,15 +12,15 @@
 ------------------------------------------------------------------------- */
 
 #include "modify.h"
-#include "style_compute.h"      // IWYU pragma: keep
-#include "style_fix.h"          // IWYU pragma: keep
+#include "style_compute.h"    // IWYU pragma: keep
+#include "style_fix.h"        // IWYU pragma: keep
 
 #include "atom.h"
 #include "comm.h"
-#include "compute.h"            // IWYU pragma: keep
+#include "compute.h"    // IWYU pragma: keep
 #include "domain.h"
 #include "error.h"
-#include "fix.h"                // IWYU pragma: keep
+#include "fix.h"    // IWYU pragma: keep
 #include "group.h"
 #include "input.h"
 #include "memory.h"
@@ -42,7 +41,7 @@ using namespace FixConst;
 
 template <typename S, typename T> static S *style_creator(LAMMPS *lmp, int narg, char **arg)
 {
-  return new T(lmp,narg,arg);
+  return new T(lmp, narg, arg);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -100,9 +99,8 @@ void _noopt Modify::create_factories()
   fix_map = new FixCreatorMap();
 
 #define FIX_CLASS
-#define FixStyle(key,Class) \
-  (*fix_map)[#key] = &style_creator<Fix, Class>;
-#include "style_fix.h"  // IWYU pragma: keep
+#define FixStyle(key, Class) (*fix_map)[#key] = &style_creator<Fix, Class>;
+#include "style_fix.h"    // IWYU pragma: keep
 #undef FixStyle
 #undef FIX_CLASS
 
@@ -111,9 +109,8 @@ void _noopt Modify::create_factories()
   compute_map = new ComputeCreatorMap();
 
 #define COMPUTE_CLASS
-#define ComputeStyle(key,Class) \
-  (*compute_map)[#key] = &style_creator<Compute, Class>;
-#include "style_compute.h"  // IWYU pragma: keep
+#define ComputeStyle(key, Class) (*compute_map)[#key] = &style_creator<Compute, Class>;
+#include "style_compute.h"    // IWYU pragma: keep
 #undef ComputeStyle
 #undef COMPUTE_CLASS
 }
@@ -134,34 +131,34 @@ Modify::~Modify()
   for (int i = 0; i < ncompute; i++) delete compute[i];
   memory->sfree(compute);
 
-  delete [] list_initial_integrate;
-  delete [] list_post_integrate;
-  delete [] list_pre_exchange;
-  delete [] list_pre_neighbor;
-  delete [] list_post_neighbor;
-  delete [] list_pre_force;
-  delete [] list_pre_reverse;
-  delete [] list_post_force;
-  delete [] list_final_integrate;
-  delete [] list_end_of_step;
-  delete [] list_energy_couple;
-  delete [] list_energy_global;
-  delete [] list_energy_atom;
-  delete [] list_initial_integrate_respa;
-  delete [] list_post_integrate_respa;
-  delete [] list_pre_force_respa;
-  delete [] list_post_force_respa;
-  delete [] list_final_integrate_respa;
-  delete [] list_min_pre_exchange;
-  delete [] list_min_pre_neighbor;
-  delete [] list_min_post_neighbor;
-  delete [] list_min_pre_force;
-  delete [] list_min_pre_reverse;
-  delete [] list_min_post_force;
-  delete [] list_min_energy;
+  delete[] list_initial_integrate;
+  delete[] list_post_integrate;
+  delete[] list_pre_exchange;
+  delete[] list_pre_neighbor;
+  delete[] list_post_neighbor;
+  delete[] list_pre_force;
+  delete[] list_pre_reverse;
+  delete[] list_post_force;
+  delete[] list_final_integrate;
+  delete[] list_end_of_step;
+  delete[] list_energy_couple;
+  delete[] list_energy_global;
+  delete[] list_energy_atom;
+  delete[] list_initial_integrate_respa;
+  delete[] list_post_integrate_respa;
+  delete[] list_pre_force_respa;
+  delete[] list_post_force_respa;
+  delete[] list_final_integrate_respa;
+  delete[] list_min_pre_exchange;
+  delete[] list_min_pre_neighbor;
+  delete[] list_min_post_neighbor;
+  delete[] list_min_pre_force;
+  delete[] list_min_pre_reverse;
+  delete[] list_min_post_force;
+  delete[] list_min_energy;
 
-  delete [] end_of_step_every;
-  delete [] list_timeflag;
+  delete[] end_of_step_every;
+  delete[] list_timeflag;
 
   restart_deallocate(0);
 
@@ -175,7 +172,7 @@ Modify::~Modify()
 
 void Modify::init()
 {
-  int i,j;
+  int i, j;
 
   // delete storage of restart info since it is not valid after 1st run
 
@@ -216,33 +213,33 @@ void Modify::init()
   // needs to happen after init() of computes
   //   b/c a compute::init() can delete a fix, e.g. compute chunk/atom
 
-  list_init(INITIAL_INTEGRATE,n_initial_integrate,list_initial_integrate);
-  list_init(POST_INTEGRATE,n_post_integrate,list_post_integrate);
-  list_init(PRE_EXCHANGE,n_pre_exchange,list_pre_exchange);
-  list_init(PRE_NEIGHBOR,n_pre_neighbor,list_pre_neighbor);
-  list_init(POST_NEIGHBOR,n_post_neighbor,list_post_neighbor);
-  list_init(PRE_FORCE,n_pre_force,list_pre_force);
-  list_init(PRE_REVERSE,n_pre_reverse,list_pre_reverse);
-  list_init(POST_FORCE,n_post_force,list_post_force);
-  list_init(FINAL_INTEGRATE,n_final_integrate,list_final_integrate);
-  list_init_end_of_step(END_OF_STEP,n_end_of_step,list_end_of_step);
-  list_init_energy_couple(n_energy_couple,list_energy_couple);
-  list_init_energy_global(n_energy_global,list_energy_global);
-  list_init_energy_atom(n_energy_atom,list_energy_atom);
+  list_init(INITIAL_INTEGRATE, n_initial_integrate, list_initial_integrate);
+  list_init(POST_INTEGRATE, n_post_integrate, list_post_integrate);
+  list_init(PRE_EXCHANGE, n_pre_exchange, list_pre_exchange);
+  list_init(PRE_NEIGHBOR, n_pre_neighbor, list_pre_neighbor);
+  list_init(POST_NEIGHBOR, n_post_neighbor, list_post_neighbor);
+  list_init(PRE_FORCE, n_pre_force, list_pre_force);
+  list_init(PRE_REVERSE, n_pre_reverse, list_pre_reverse);
+  list_init(POST_FORCE, n_post_force, list_post_force);
+  list_init(FINAL_INTEGRATE, n_final_integrate, list_final_integrate);
+  list_init_end_of_step(END_OF_STEP, n_end_of_step, list_end_of_step);
+  list_init_energy_couple(n_energy_couple, list_energy_couple);
+  list_init_energy_global(n_energy_global, list_energy_global);
+  list_init_energy_atom(n_energy_atom, list_energy_atom);
 
-  list_init(INITIAL_INTEGRATE_RESPA,n_initial_integrate_respa,list_initial_integrate_respa);
-  list_init(POST_INTEGRATE_RESPA,n_post_integrate_respa,list_post_integrate_respa);
-  list_init(POST_FORCE_RESPA,n_post_force_respa,list_post_force_respa);
-  list_init(PRE_FORCE_RESPA,n_pre_force_respa,list_pre_force_respa);
-  list_init(FINAL_INTEGRATE_RESPA,n_final_integrate_respa,list_final_integrate_respa);
+  list_init(INITIAL_INTEGRATE_RESPA, n_initial_integrate_respa, list_initial_integrate_respa);
+  list_init(POST_INTEGRATE_RESPA, n_post_integrate_respa, list_post_integrate_respa);
+  list_init(POST_FORCE_RESPA, n_post_force_respa, list_post_force_respa);
+  list_init(PRE_FORCE_RESPA, n_pre_force_respa, list_pre_force_respa);
+  list_init(FINAL_INTEGRATE_RESPA, n_final_integrate_respa, list_final_integrate_respa);
 
-  list_init(MIN_PRE_EXCHANGE,n_min_pre_exchange,list_min_pre_exchange);
-  list_init(MIN_PRE_NEIGHBOR,n_min_pre_neighbor,list_min_pre_neighbor);
-  list_init(MIN_POST_NEIGHBOR,n_min_post_neighbor,list_min_post_neighbor);
-  list_init(MIN_PRE_FORCE,n_min_pre_force,list_min_pre_force);
-  list_init(MIN_PRE_REVERSE,n_min_pre_reverse,list_min_pre_reverse);
-  list_init(MIN_POST_FORCE,n_min_post_force,list_min_post_force);
-  list_init(MIN_ENERGY,n_min_energy,list_min_energy);
+  list_init(MIN_PRE_EXCHANGE, n_min_pre_exchange, list_min_pre_exchange);
+  list_init(MIN_PRE_NEIGHBOR, n_min_pre_neighbor, list_min_pre_neighbor);
+  list_init(MIN_POST_NEIGHBOR, n_min_post_neighbor, list_min_post_neighbor);
+  list_init(MIN_PRE_FORCE, n_min_pre_force, list_min_pre_force);
+  list_init(MIN_PRE_REVERSE, n_min_pre_reverse, list_min_pre_reverse);
+  list_init(MIN_POST_FORCE, n_min_post_force, list_min_post_force);
+  list_init(MIN_ENERGY, n_min_energy, list_min_energy);
 
   // create list of computes that store invocation times
 
@@ -252,14 +249,11 @@ void Modify::init()
 
   for (i = 0; i < nfix; i++)
     if (!fix[i]->dynamic_group_allow && group->dynamic[fix[i]->igroup])
-      error->all(FLERR,"Fix {} does not allow use with a "
-                                   "dynamic group",fix[i]->id);
+      error->all(FLERR, "Fix {} does not allow use with a dynamic group", fix[i]->id);
 
   for (i = 0; i < ncompute; i++)
-    if (!compute[i]->dynamic_group_allow &&
-        group->dynamic[compute[i]->igroup])
-      error->all(FLERR,"Compute {} does not allow use with a "
-                                   "dynamic group",compute[i]->id);
+    if (!compute[i]->dynamic_group_allow && group->dynamic[compute[i]->igroup])
+      error->all(FLERR, "Compute {} does not allow use with a dynamic group", compute[i]->id);
 
   // warn if any particle is time integrated more than once
 
@@ -281,13 +275,12 @@ void Modify::init()
   for (i = 0; i < nlocal; i++)
     if (flag[i] > 1) check = 1;
 
-  delete [] flag;
+  delete[] flag;
 
   int checkall;
-  MPI_Allreduce(&check,&checkall,1,MPI_INT,MPI_SUM,world);
+  MPI_Allreduce(&check, &checkall, 1, MPI_INT, MPI_SUM, world);
   if (comm->me == 0 && checkall)
-    error->warning(FLERR,
-                   "One or more atoms are time integrated more than once");
+    error->warning(FLERR, "One or more atoms are time integrated more than once");
 }
 
 /* ----------------------------------------------------------------------
@@ -303,7 +296,7 @@ void Modify::setup(int vflag)
   //   needs to be done before temperature compute setup
 
   for (int i = 0; i < nfix; i++)
-    if (strcmp(fix[i]->style,"GROUP") == 0) fix[i]->setup(vflag);
+    if (strcmp(fix[i]->style, "GROUP") == 0) fix[i]->setup(vflag);
 
   for (int i = 0; i < ncompute; i++) compute[i]->setup();
 
@@ -321,8 +314,7 @@ void Modify::setup(int vflag)
 void Modify::setup_pre_exchange()
 {
   if (update->whichflag <= 1)
-    for (int i = 0; i < n_pre_exchange; i++)
-      fix[list_pre_exchange[i]]->setup_pre_exchange();
+    for (int i = 0; i < n_pre_exchange; i++) fix[list_pre_exchange[i]]->setup_pre_exchange();
   else if (update->whichflag == 2)
     for (int i = 0; i < n_min_pre_exchange; i++)
       fix[list_min_pre_exchange[i]]->setup_pre_exchange();
@@ -336,8 +328,7 @@ void Modify::setup_pre_exchange()
 void Modify::setup_pre_neighbor()
 {
   if (update->whichflag == 1)
-    for (int i = 0; i < n_pre_neighbor; i++)
-      fix[list_pre_neighbor[i]]->setup_pre_neighbor();
+    for (int i = 0; i < n_pre_neighbor; i++) fix[list_pre_neighbor[i]]->setup_pre_neighbor();
   else if (update->whichflag == 2)
     for (int i = 0; i < n_min_pre_neighbor; i++)
       fix[list_min_pre_neighbor[i]]->setup_pre_neighbor();
@@ -351,8 +342,7 @@ void Modify::setup_pre_neighbor()
 void Modify::setup_post_neighbor()
 {
   if (update->whichflag == 1)
-    for (int i = 0; i < n_post_neighbor; i++)
-      fix[list_post_neighbor[i]]->setup_post_neighbor();
+    for (int i = 0; i < n_post_neighbor; i++) fix[list_post_neighbor[i]]->setup_post_neighbor();
   else if (update->whichflag == 2)
     for (int i = 0; i < n_min_post_neighbor; i++)
       fix[list_min_post_neighbor[i]]->setup_post_neighbor();
@@ -366,11 +356,9 @@ void Modify::setup_post_neighbor()
 void Modify::setup_pre_force(int vflag)
 {
   if (update->whichflag == 1)
-    for (int i = 0; i < n_pre_force; i++)
-      fix[list_pre_force[i]]->setup_pre_force(vflag);
+    for (int i = 0; i < n_pre_force; i++) fix[list_pre_force[i]]->setup_pre_force(vflag);
   else if (update->whichflag == 2)
-    for (int i = 0; i < n_min_pre_force; i++)
-      fix[list_min_pre_force[i]]->setup_pre_force(vflag);
+    for (int i = 0; i < n_min_pre_force; i++) fix[list_min_pre_force[i]]->setup_pre_force(vflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -382,10 +370,10 @@ void Modify::setup_pre_reverse(int eflag, int vflag)
 {
   if (update->whichflag == 1)
     for (int i = 0; i < n_pre_reverse; i++)
-      fix[list_pre_reverse[i]]->setup_pre_reverse(eflag,vflag);
+      fix[list_pre_reverse[i]]->setup_pre_reverse(eflag, vflag);
   else if (update->whichflag == 2)
     for (int i = 0; i < n_min_pre_reverse; i++)
-      fix[list_min_pre_reverse[i]]->setup_pre_reverse(eflag,vflag);
+      fix[list_min_pre_reverse[i]]->setup_pre_reverse(eflag, vflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -404,8 +392,7 @@ void Modify::initial_integrate(int vflag)
 
 void Modify::post_integrate()
 {
-  for (int i = 0; i < n_post_integrate; i++)
-    fix[list_post_integrate[i]]->post_integrate();
+  for (int i = 0; i < n_post_integrate; i++) fix[list_post_integrate[i]]->post_integrate();
 }
 
 /* ----------------------------------------------------------------------
@@ -414,8 +401,7 @@ void Modify::post_integrate()
 
 void Modify::pre_exchange()
 {
-  for (int i = 0; i < n_pre_exchange; i++)
-    fix[list_pre_exchange[i]]->pre_exchange();
+  for (int i = 0; i < n_pre_exchange; i++) fix[list_pre_exchange[i]]->pre_exchange();
 }
 
 /* ----------------------------------------------------------------------
@@ -424,8 +410,7 @@ void Modify::pre_exchange()
 
 void Modify::pre_neighbor()
 {
-  for (int i = 0; i < n_pre_neighbor; i++)
-    fix[list_pre_neighbor[i]]->pre_neighbor();
+  for (int i = 0; i < n_pre_neighbor; i++) fix[list_pre_neighbor[i]]->pre_neighbor();
 }
 
 /* ----------------------------------------------------------------------
@@ -434,8 +419,7 @@ void Modify::pre_neighbor()
 
 void Modify::post_neighbor()
 {
-  for (int i = 0; i < n_post_neighbor; i++)
-    fix[list_post_neighbor[i]]->post_neighbor();
+  for (int i = 0; i < n_post_neighbor; i++) fix[list_post_neighbor[i]]->post_neighbor();
 }
 
 /* ----------------------------------------------------------------------
@@ -444,8 +428,7 @@ void Modify::post_neighbor()
 
 void Modify::pre_force(int vflag)
 {
-  for (int i = 0; i < n_pre_force; i++)
-    fix[list_pre_force[i]]->pre_force(vflag);
+  for (int i = 0; i < n_pre_force; i++) fix[list_pre_force[i]]->pre_force(vflag);
 }
 /* ----------------------------------------------------------------------
    pre_reverse call, only for relevant fixes
@@ -453,8 +436,7 @@ void Modify::pre_force(int vflag)
 
 void Modify::pre_reverse(int eflag, int vflag)
 {
-  for (int i = 0; i < n_pre_reverse; i++)
-    fix[list_pre_reverse[i]]->pre_reverse(eflag,vflag);
+  for (int i = 0; i < n_pre_reverse; i++) fix[list_pre_reverse[i]]->pre_reverse(eflag, vflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -463,8 +445,7 @@ void Modify::pre_reverse(int eflag, int vflag)
 
 void Modify::post_force(int vflag)
 {
-  for (int i = 0; i < n_post_force; i++)
-    fix[list_post_force[i]]->post_force(vflag);
+  for (int i = 0; i < n_post_force; i++) fix[list_post_force[i]]->post_force(vflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -473,8 +454,7 @@ void Modify::post_force(int vflag)
 
 void Modify::final_integrate()
 {
-  for (int i = 0; i < n_final_integrate; i++)
-    fix[list_final_integrate[i]]->final_integrate();
+  for (int i = 0; i < n_final_integrate; i++) fix[list_final_integrate[i]]->final_integrate();
 }
 
 /* ----------------------------------------------------------------------
@@ -485,8 +465,7 @@ void Modify::final_integrate()
 void Modify::end_of_step()
 {
   for (int i = 0; i < n_end_of_step; i++)
-    if (update->ntimestep % end_of_step_every[i] == 0)
-      fix[list_end_of_step[i]]->end_of_step();
+    if (update->ntimestep % end_of_step_every[i] == 0) fix[list_end_of_step[i]]->end_of_step();
 }
 
 /* ----------------------------------------------------------------------
@@ -498,8 +477,7 @@ void Modify::end_of_step()
 double Modify::energy_couple()
 {
   double energy = 0.0;
-  for (int i = 0; i < n_energy_couple; i++)
-    energy += fix[list_energy_couple[i]]->compute_scalar();
+  for (int i = 0; i < n_energy_couple; i++) energy += fix[list_energy_couple[i]]->compute_scalar();
   return energy;
 }
 
@@ -512,8 +490,7 @@ double Modify::energy_couple()
 double Modify::energy_global()
 {
   double energy = 0.0;
-  for (int i = 0; i < n_energy_global; i++)
-    energy += fix[list_energy_global[i]]->compute_scalar();
+  for (int i = 0; i < n_energy_global; i++) energy += fix[list_energy_global[i]]->compute_scalar();
   return energy;
 }
 
@@ -524,7 +501,7 @@ double Modify::energy_global()
 
 void Modify::energy_atom(int nlocal, double *energy)
 {
-  int i,j;
+  int i, j;
   double *eatom;
 
   for (i = 0; i < n_energy_atom; i++) {
@@ -573,7 +550,7 @@ void Modify::create_attribute(int n)
 void Modify::setup_pre_force_respa(int vflag, int ilevel)
 {
   for (int i = 0; i < n_pre_force_respa; i++)
-    fix[list_pre_force_respa[i]]->setup_pre_force_respa(vflag,ilevel);
+    fix[list_pre_force_respa[i]]->setup_pre_force_respa(vflag, ilevel);
 }
 
 /* ----------------------------------------------------------------------
@@ -583,8 +560,7 @@ void Modify::setup_pre_force_respa(int vflag, int ilevel)
 void Modify::initial_integrate_respa(int vflag, int ilevel, int iloop)
 {
   for (int i = 0; i < n_initial_integrate_respa; i++)
-    fix[list_initial_integrate_respa[i]]->
-      initial_integrate_respa(vflag,ilevel,iloop);
+    fix[list_initial_integrate_respa[i]]->initial_integrate_respa(vflag, ilevel, iloop);
 }
 
 /* ----------------------------------------------------------------------
@@ -594,7 +570,7 @@ void Modify::initial_integrate_respa(int vflag, int ilevel, int iloop)
 void Modify::post_integrate_respa(int ilevel, int iloop)
 {
   for (int i = 0; i < n_post_integrate_respa; i++)
-    fix[list_post_integrate_respa[i]]->post_integrate_respa(ilevel,iloop);
+    fix[list_post_integrate_respa[i]]->post_integrate_respa(ilevel, iloop);
 }
 
 /* ----------------------------------------------------------------------
@@ -604,7 +580,7 @@ void Modify::post_integrate_respa(int ilevel, int iloop)
 void Modify::pre_force_respa(int vflag, int ilevel, int iloop)
 {
   for (int i = 0; i < n_pre_force_respa; i++)
-    fix[list_pre_force_respa[i]]->pre_force_respa(vflag,ilevel,iloop);
+    fix[list_pre_force_respa[i]]->pre_force_respa(vflag, ilevel, iloop);
 }
 
 /* ----------------------------------------------------------------------
@@ -614,7 +590,7 @@ void Modify::pre_force_respa(int vflag, int ilevel, int iloop)
 void Modify::post_force_respa(int vflag, int ilevel, int iloop)
 {
   for (int i = 0; i < n_post_force_respa; i++)
-    fix[list_post_force_respa[i]]->post_force_respa(vflag,ilevel,iloop);
+    fix[list_post_force_respa[i]]->post_force_respa(vflag, ilevel, iloop);
 }
 
 /* ----------------------------------------------------------------------
@@ -624,7 +600,7 @@ void Modify::post_force_respa(int vflag, int ilevel, int iloop)
 void Modify::final_integrate_respa(int ilevel, int iloop)
 {
   for (int i = 0; i < n_final_integrate_respa; i++)
-    fix[list_final_integrate_respa[i]]->final_integrate_respa(ilevel,iloop);
+    fix[list_final_integrate_respa[i]]->final_integrate_respa(ilevel, iloop);
 }
 
 /* ----------------------------------------------------------------------
@@ -633,8 +609,7 @@ void Modify::final_integrate_respa(int ilevel, int iloop)
 
 void Modify::min_pre_exchange()
 {
-  for (int i = 0; i < n_min_pre_exchange; i++)
-    fix[list_min_pre_exchange[i]]->min_pre_exchange();
+  for (int i = 0; i < n_min_pre_exchange; i++) fix[list_min_pre_exchange[i]]->min_pre_exchange();
 }
 
 /* ----------------------------------------------------------------------
@@ -643,8 +618,7 @@ void Modify::min_pre_exchange()
 
 void Modify::min_pre_neighbor()
 {
-  for (int i = 0; i < n_min_pre_neighbor; i++)
-    fix[list_min_pre_neighbor[i]]->min_pre_neighbor();
+  for (int i = 0; i < n_min_pre_neighbor; i++) fix[list_min_pre_neighbor[i]]->min_pre_neighbor();
 }
 
 /* ----------------------------------------------------------------------
@@ -653,8 +627,7 @@ void Modify::min_pre_neighbor()
 
 void Modify::min_post_neighbor()
 {
-  for (int i = 0; i < n_min_post_neighbor; i++)
-    fix[list_min_post_neighbor[i]]->min_post_neighbor();
+  for (int i = 0; i < n_min_post_neighbor; i++) fix[list_min_post_neighbor[i]]->min_post_neighbor();
 }
 
 /* ----------------------------------------------------------------------
@@ -663,8 +636,7 @@ void Modify::min_post_neighbor()
 
 void Modify::min_pre_force(int vflag)
 {
-  for (int i = 0; i < n_min_pre_force; i++)
-    fix[list_min_pre_force[i]]->min_pre_force(vflag);
+  for (int i = 0; i < n_min_pre_force; i++) fix[list_min_pre_force[i]]->min_pre_force(vflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -674,7 +646,7 @@ void Modify::min_pre_force(int vflag)
 void Modify::min_pre_reverse(int eflag, int vflag)
 {
   for (int i = 0; i < n_min_pre_reverse; i++)
-    fix[list_min_pre_reverse[i]]->min_pre_reverse(eflag,vflag);
+    fix[list_min_pre_reverse[i]]->min_pre_reverse(eflag, vflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -683,8 +655,7 @@ void Modify::min_pre_reverse(int eflag, int vflag)
 
 void Modify::min_post_force(int vflag)
 {
-  for (int i = 0; i < n_min_post_force; i++)
-    fix[list_min_post_force[i]]->min_post_force(vflag);
+  for (int i = 0; i < n_min_post_force; i++) fix[list_min_post_force[i]]->min_post_force(vflag);
 }
 
 /* ----------------------------------------------------------------------
@@ -694,7 +665,7 @@ void Modify::min_post_force(int vflag)
 
 double Modify::min_energy(double *fextra)
 {
-  int ifix,index;
+  int ifix, index;
 
   index = 0;
   double eng = 0.0;
@@ -712,8 +683,7 @@ double Modify::min_energy(double *fextra)
 
 void Modify::min_store()
 {
-  for (int i = 0; i < n_min_energy; i++)
-    fix[list_min_energy[i]]->min_store();
+  for (int i = 0; i < n_min_energy; i++) fix[list_min_energy[i]]->min_store();
 }
 
 /* ----------------------------------------------------------------------
@@ -722,20 +692,17 @@ void Modify::min_store()
 
 void Modify::min_clearstore()
 {
-  for (int i = 0; i < n_min_energy; i++)
-    fix[list_min_energy[i]]->min_clearstore();
+  for (int i = 0; i < n_min_energy; i++) fix[list_min_energy[i]]->min_clearstore();
 }
 
 void Modify::min_pushstore()
 {
-  for (int i = 0; i < n_min_energy; i++)
-    fix[list_min_energy[i]]->min_pushstore();
+  for (int i = 0; i < n_min_energy; i++) fix[list_min_energy[i]]->min_pushstore();
 }
 
 void Modify::min_popstore()
 {
-  for (int i = 0; i < n_min_energy; i++)
-    fix[list_min_energy[i]]->min_popstore();
+  for (int i = 0; i < n_min_energy; i++) fix[list_min_energy[i]]->min_popstore();
 }
 
 /* ----------------------------------------------------------------------
@@ -744,12 +711,12 @@ void Modify::min_popstore()
 
 void Modify::min_step(double alpha, double *hextra)
 {
-  int ifix,index;
+  int ifix, index;
 
   index = 0;
   for (int i = 0; i < n_min_energy; i++) {
     ifix = list_min_energy[i];
-    fix[ifix]->min_step(alpha,&hextra[index]);
+    fix[ifix]->min_step(alpha, &hextra[index]);
     index += fix[ifix]->min_dof();
   }
 }
@@ -760,14 +727,14 @@ void Modify::min_step(double alpha, double *hextra)
 
 double Modify::max_alpha(double *hextra)
 {
-  int ifix,index;
+  int ifix, index;
 
   double alpha = BIG;
   index = 0;
   for (int i = 0; i < n_min_energy; i++) {
     ifix = list_min_energy[i];
     double alpha_one = fix[ifix]->max_alpha(&hextra[index]);
-    alpha = MIN(alpha,alpha_one);
+    alpha = MIN(alpha, alpha_one);
     index += fix[ifix]->min_dof();
   }
   return alpha;
@@ -780,8 +747,7 @@ double Modify::max_alpha(double *hextra)
 int Modify::min_dof()
 {
   int ndof = 0;
-  for (int i = 0; i < n_min_energy; i++)
-    ndof += fix[list_min_energy[i]]->min_dof();
+  for (int i = 0; i < n_min_energy; i++) ndof += fix[list_min_energy[i]]->min_dof();
   return ndof;
 }
 
@@ -791,7 +757,7 @@ int Modify::min_dof()
 
 int Modify::min_reset_ref()
 {
-  int itmp,itmpall;
+  int itmp, itmpall;
   itmpall = 0;
   for (int i = 0; i < n_min_energy; i++) {
     itmp = fix[list_min_energy[i]]->min_reset_ref();
@@ -806,7 +772,7 @@ int Modify::min_reset_ref()
 
 Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
 {
-  if (narg < 3) error->all(FLERR,"Illegal fix command");
+  if (narg < 3) error->all(FLERR, "Illegal fix command");
 
   // cannot define fix before box exists unless style is in exception list
   // don't like this way of checking for exceptions by adding fixes to list,
@@ -815,21 +781,20 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
   //   since some fixes access domain settings in their constructor
   // nullptr must be last entry in this list
 
-  const char *exceptions[] = {"GPU", "OMP", "INTEL", "property/atom", "cmap", "cmap3", "rx",
-    "deprecated", "STORE/KIM", nullptr};
+  const char *exceptions[] = {"GPU",   "OMP", "INTEL",      "property/atom", "cmap",
+                              "cmap3", "rx",  "deprecated", "STORE/KIM",     nullptr};
 
   if (domain->box_exist == 0) {
     int m;
     for (m = 0; exceptions[m] != nullptr; m++)
-      if (strcmp(arg[2],exceptions[m]) == 0) break;
-    if (exceptions[m] == nullptr)
-      error->all(FLERR,"Fix command before simulation box is defined");
+      if (strcmp(arg[2], exceptions[m]) == 0) break;
+    if (exceptions[m] == nullptr) error->all(FLERR, "Fix command before simulation box is defined");
   }
 
   // check group ID
 
   int igroup = group->find(arg[1]);
-  if (igroup == -1) error->all(FLERR,"Could not find fix group ID {}", arg[1]);
+  if (igroup == -1) error->all(FLERR, "Could not find fix group ID {}", arg[1]);
 
   // if fix ID exists:
   //   set newflag = 0 so create new fix in same location in fix list
@@ -844,15 +809,15 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
   //   set newflag = 1 so create new fix
   //   extend fix and fmask lists as necessary
 
-  int ifix,newflag;
+  int ifix, newflag;
   for (ifix = 0; ifix < nfix; ifix++)
-    if (strcmp(arg[0],fix[ifix]->id) == 0) break;
+    if (strcmp(arg[0], fix[ifix]->id) == 0) break;
 
   if (ifix < nfix) {
     newflag = 0;
 
     int match = 0;
-    if (strcmp(arg[2],fix[ifix]->style) == 0) match = 1;
+    if (strcmp(arg[2], fix[ifix]->style) == 0) match = 1;
     if (!match && trysuffix && lmp->suffix_enable) {
       if (lmp->suffix) {
         std::string estyle = arg[2] + std::string("/") + lmp->suffix;
@@ -863,10 +828,10 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
         if (estyle == fix[ifix]->style) match = 1;
       }
     }
-    if (!match) error->all(FLERR,"Replacing a fix, but new style != old style");
+    if (!match) error->all(FLERR, "Replacing a fix, but new style != old style");
 
     if (fix[ifix]->igroup != igroup && comm->me == 0)
-      error->warning(FLERR,"Replacing a fix, but new group != old group");
+      error->warning(FLERR, "Replacing a fix, but new group != old group");
     delete fix[ifix];
     fix[ifix] = nullptr;
 
@@ -874,8 +839,8 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
     newflag = 1;
     if (nfix == maxfix) {
       maxfix += DELTA;
-      fix = (Fix **) memory->srealloc(fix,maxfix*sizeof(Fix *),"modify:fix");
-      memory->grow(fmask,maxfix,"modify:fmask");
+      fix = (Fix **) memory->srealloc(fix, maxfix * sizeof(Fix *), "modify:fix");
+      memory->grow(fmask, maxfix, "modify:fmask");
     }
   }
 
@@ -889,7 +854,7 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
       std::string estyle = arg[2] + std::string("/") + lmp->suffix;
       if (fix_map->find(estyle) != fix_map->end()) {
         FixCreator &fix_creator = (*fix_map)[estyle];
-        fix[ifix] = fix_creator(lmp,narg,arg);
+        fix[ifix] = fix_creator(lmp, narg, arg);
         delete[] fix[ifix]->style;
         fix[ifix]->style = utils::strdup(estyle);
       }
@@ -898,7 +863,7 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
       std::string estyle = arg[2] + std::string("/") + lmp->suffix2;
       if (fix_map->find(estyle) != fix_map->end()) {
         FixCreator &fix_creator = (*fix_map)[estyle];
-        fix[ifix] = fix_creator(lmp,narg,arg);
+        fix[ifix] = fix_creator(lmp, narg, arg);
         delete[] fix[ifix]->style;
         fix[ifix]->style = utils::strdup(estyle);
       }
@@ -907,17 +872,16 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
 
   if (fix[ifix] == nullptr && fix_map->find(arg[2]) != fix_map->end()) {
     FixCreator &fix_creator = (*fix_map)[arg[2]];
-    fix[ifix] = fix_creator(lmp,narg,arg);
+    fix[ifix] = fix_creator(lmp, narg, arg);
   }
 
-  if (fix[ifix] == nullptr)
-    error->all(FLERR,utils::check_packages_for_style("fix",arg[2],lmp));
+  if (fix[ifix] == nullptr) error->all(FLERR, utils::check_packages_for_style("fix", arg[2], lmp));
 
   // increment nfix and update fix_list vector (if new)
 
   if (newflag) {
     nfix++;
-    fix_list = std::vector<Fix *>(fix, fix+nfix);
+    fix_list = std::vector<Fix *>(fix, fix + nfix);
   }
 
   // post_constructor() can call virtual methods in parent or child
@@ -932,31 +896,32 @@ Fix *Modify::add_fix(int narg, char **arg, int trysuffix)
   // if yes, pass state info to the Fix so it can reset itself
 
   for (int i = 0; i < nfix_restart_global; i++)
-    if (strcmp(id_restart_global[i],fix[ifix]->id) == 0 &&
-        strcmp(style_restart_global[i],fix[ifix]->style) == 0) {
+    if (strcmp(id_restart_global[i], fix[ifix]->id) == 0 &&
+        strcmp(style_restart_global[i], fix[ifix]->style) == 0) {
       fix[ifix]->restart(state_restart_global[i]);
       used_restart_global[i] = 1;
       fix[ifix]->restart_reset = 1;
       if (comm->me == 0)
-        utils::logmesg(lmp,"Resetting global fix info from restart file:\n"
+        utils::logmesg(lmp,
+                       "Resetting global fix info from restart file:\n"
                        "  fix style: {}, fix ID: {}\n",
-                       fix[ifix]->style,fix[ifix]->id);
+                       fix[ifix]->style, fix[ifix]->id);
     }
 
   // check if Fix is in restart_peratom list
   // if yes, loop over atoms so they can extract info from atom->extra array
 
   for (int i = 0; i < nfix_restart_peratom; i++)
-    if (strcmp(id_restart_peratom[i],fix[ifix]->id) == 0 &&
-        strcmp(style_restart_peratom[i],fix[ifix]->style) == 0) {
+    if (strcmp(id_restart_peratom[i], fix[ifix]->id) == 0 &&
+        strcmp(style_restart_peratom[i], fix[ifix]->style) == 0) {
       used_restart_peratom[i] = 1;
-      for (int j = 0; j < atom->nlocal; j++)
-        fix[ifix]->unpack_restart(j,index_restart_peratom[i]);
+      for (int j = 0; j < atom->nlocal; j++) fix[ifix]->unpack_restart(j, index_restart_peratom[i]);
       fix[ifix]->restart_reset = 1;
       if (comm->me == 0)
-        utils::logmesg(lmp,"Resetting peratom fix info from restart file:\n"
+        utils::logmesg(lmp,
+                       "Resetting peratom fix info from restart file:\n"
                        "  fix style: {}, fix ID: {}\n",
-                       fix[ifix]->style,fix[ifix]->id);
+                       fix[ifix]->style, fix[ifix]->id);
     }
 
   // set fix mask values
@@ -977,10 +942,8 @@ Fix *Modify::add_fix(const std::string &fixcmd, int trysuffix)
   auto args = utils::split_words(fixcmd);
   std::vector<char *> newarg(args.size());
   int i = 0;
-  for (const auto &arg : args) {
-    newarg[i++] = (char *)arg.c_str();
-  }
-  return add_fix(args.size(),newarg.data(),trysuffix);
+  for (const auto &arg : args) { newarg[i++] = (char *) arg.c_str(); }
+  return add_fix(args.size(), newarg.data(), trysuffix);
 }
 
 /* ----------------------------------------------------------------------
@@ -993,19 +956,19 @@ Fix *Modify::add_fix(const std::string &fixcmd, int trysuffix)
 Fix *Modify::replace_fix(const char *replaceID, int narg, char **arg, int trysuffix)
 {
   auto oldfix = get_fix_by_id(replaceID);
-  if (!oldfix) error->all(FLERR,"Modify replace_fix ID {} could not be found", replaceID);
+  if (!oldfix) error->all(FLERR, "Modify replace_fix ID {} could not be found", replaceID);
 
   // change ID, igroup, style of fix being replaced to match new fix
   // requires some error checking on arguments for new fix
 
-  if (narg < 3) error->all(FLERR,"Illegal replace_fix invocation");
-  if (get_fix_by_id(arg[0])) error->all(FLERR,"Replace_fix ID {} is already in use",arg[0]);
+  if (narg < 3) error->all(FLERR, "Illegal replace_fix invocation");
+  if (get_fix_by_id(arg[0])) error->all(FLERR, "Replace_fix ID {} is already in use", arg[0]);
 
   delete[] oldfix->id;
   oldfix->id = utils::strdup(arg[0]);
 
   int jgroup = group->find(arg[1]);
-  if (jgroup == -1) error->all(FLERR,"Could not find replace_fix group ID {}", arg[1]);
+  if (jgroup == -1) error->all(FLERR, "Could not find replace_fix group ID {}", arg[1]);
   oldfix->igroup = jgroup;
 
   delete[] oldfix->style;
@@ -1014,7 +977,7 @@ Fix *Modify::replace_fix(const char *replaceID, int narg, char **arg, int trysuf
   // invoke add_fix
   // it will find and overwrite the replaceID fix
 
-  return add_fix(narg,arg,trysuffix);
+  return add_fix(narg, arg, trysuffix);
 }
 
 /* ----------------------------------------------------------------------
@@ -1026,10 +989,8 @@ Fix *Modify::replace_fix(const std::string &oldfix, const std::string &fixcmd, i
   auto args = utils::split_words(fixcmd);
   std::vector<char *> newarg(args.size());
   int i = 0;
-  for (const auto &arg : args) {
-    newarg[i++] = (char *)arg.c_str();
-  }
-  return replace_fix(oldfix.c_str(),args.size(),newarg.data(),trysuffix);
+  for (const auto &arg : args) { newarg[i++] = (char *) arg.c_str(); }
+  return replace_fix(oldfix.c_str(), args.size(), newarg.data(), trysuffix);
 }
 
 /* ----------------------------------------------------------------------
@@ -1038,16 +999,16 @@ Fix *Modify::replace_fix(const std::string &oldfix, const std::string &fixcmd, i
 
 void Modify::modify_fix(int narg, char **arg)
 {
-  if (narg < 2) error->all(FLERR,"Illegal fix_modify command");
+  if (narg < 2) error->all(FLERR, "Illegal fix_modify command");
 
   // lookup Fix ID
 
   int ifix;
   for (ifix = 0; ifix < nfix; ifix++)
-    if (strcmp(arg[0],fix[ifix]->id) == 0) break;
-  if (ifix == nfix) error->all(FLERR,"Could not find fix_modify ID {}", arg[0]);
+    if (strcmp(arg[0], fix[ifix]->id) == 0) break;
+  if (ifix == nfix) error->all(FLERR, "Could not find fix_modify ID {}", arg[0]);
 
-  fix[ifix]->modify_params(narg-1,&arg[1]);
+  fix[ifix]->modify_params(narg - 1, &arg[1]);
 }
 
 /* ----------------------------------------------------------------------
@@ -1058,7 +1019,7 @@ void Modify::modify_fix(int narg, char **arg)
 void Modify::delete_fix(const std::string &id)
 {
   int ifix = find_fix(id);
-  if (ifix < 0) error->all(FLERR,"Could not find fix ID {} to delete", id);
+  if (ifix < 0) error->all(FLERR, "Could not find fix ID {} to delete", id);
   delete_fix(ifix);
 }
 
@@ -1071,10 +1032,10 @@ void Modify::delete_fix(int ifix)
   delete fix[ifix];
   atom->update_callback(ifix);
 
-  for (int i = ifix+1; i < nfix; i++) fix[i-1] = fix[i];
-  for (int i = ifix+1; i < nfix; i++) fmask[i-1] = fmask[i];
+  for (int i = ifix + 1; i < nfix; i++) fix[i - 1] = fix[i];
+  for (int i = ifix + 1; i < nfix; i++) fmask[i - 1] = fmask[i];
   nfix--;
-  fix_list = std::vector<Fix *>(fix, fix+nfix);
+  fix_list = std::vector<Fix *>(fix, fix + nfix);
 }
 
 /* ----------------------------------------------------------------------
@@ -1114,7 +1075,7 @@ const std::vector<Fix *> Modify::get_fix_by_style(const std::string &style) cons
   if (style.empty()) return matches;
 
   for (int ifix = 0; ifix < nfix; ifix++)
-    if (utils::strmatch(fix[ifix]->style,style)) matches.push_back(fix[ifix]);
+    if (utils::strmatch(fix[ifix]->style, style)) matches.push_back(fix[ifix]);
 
   return matches;
 }
@@ -1125,7 +1086,7 @@ const std::vector<Fix *> Modify::get_fix_by_style(const std::string &style) cons
 
 const std::vector<Fix *> &Modify::get_fix_list()
 {
-  fix_list = std::vector<Fix *>(fix, fix+nfix);
+  fix_list = std::vector<Fix *>(fix, fix + nfix);
   return fix_list;
 }
 
@@ -1149,23 +1110,23 @@ int Modify::check_package(const char *package_fix_name)
 
 int Modify::check_rigid_group_overlap(int groupbit)
 {
-  const int * const mask = atom->mask;
+  const int *const mask = atom->mask;
   const int nlocal = atom->nlocal;
   int dim;
 
   int n = 0;
   for (int ifix = 0; ifix < nfix; ifix++) {
-    if (utils::strmatch(fix[ifix]->style,"^rigid")) {
-      const int * const body = (const int *)fix[ifix]->extract("body",dim);
+    if (utils::strmatch(fix[ifix]->style, "^rigid")) {
+      const int *const body = (const int *) fix[ifix]->extract("body", dim);
       if ((body == nullptr) || (dim != 1)) break;
 
-      for (int i=0; (i < nlocal) && (n == 0); ++i)
+      for (int i = 0; (i < nlocal) && (n == 0); ++i)
         if ((mask[i] & groupbit) && (body[i] >= 0)) ++n;
     }
   }
 
   int n_all = 0;
-  MPI_Allreduce(&n,&n_all,1,MPI_INT,MPI_SUM,world);
+  MPI_Allreduce(&n, &n_all, 1, MPI_INT, MPI_SUM, world);
 
   if (n_all > 0) return 1;
   return 0;
@@ -1179,26 +1140,25 @@ int Modify::check_rigid_group_overlap(int groupbit)
 
 int Modify::check_rigid_region_overlap(int groupbit, Region *reg)
 {
-  const int * const mask = atom->mask;
-  const double * const * const x = atom->x;
+  const int *const mask = atom->mask;
+  const double *const *const x = atom->x;
   const int nlocal = atom->nlocal;
   int dim;
 
   int n = 0;
   reg->prematch();
   for (int ifix = 0; ifix < nfix; ifix++) {
-    if (strncmp("rigid",fix[ifix]->style,5) == 0) {
-      const int * const body = (const int *)fix[ifix]->extract("body",dim);
+    if (strncmp("rigid", fix[ifix]->style, 5) == 0) {
+      const int *const body = (const int *) fix[ifix]->extract("body", dim);
       if ((body == nullptr) || (dim != 1)) break;
 
-      for (int i=0; (i < nlocal) && (n == 0); ++i)
-        if ((mask[i] & groupbit) && (body[i] >= 0)
-            && reg->match(x[i][0],x[i][1],x[i][2])) ++n;
+      for (int i = 0; (i < nlocal) && (n == 0); ++i)
+        if ((mask[i] & groupbit) && (body[i] >= 0) && reg->match(x[i][0], x[i][1], x[i][2])) ++n;
     }
   }
 
   int n_all = 0;
-  MPI_Allreduce(&n,&n_all,1,MPI_INT,MPI_SUM,world);
+  MPI_Allreduce(&n, &n_all, 1, MPI_INT, MPI_SUM, world);
 
   if (n_all > 0) return 1;
   return 0;
@@ -1217,17 +1177,17 @@ int Modify::check_rigid_list_overlap(int *select)
 
   int n = 0;
   for (int ifix = 0; ifix < nfix; ifix++) {
-    if (utils::strmatch(fix[ifix]->style,"^rigid")) {
-      const int * const body = (const int *)fix[ifix]->extract("body",dim);
+    if (utils::strmatch(fix[ifix]->style, "^rigid")) {
+      const int *const body = (const int *) fix[ifix]->extract("body", dim);
       if ((body == nullptr) || (dim != 1)) break;
 
-      for (int i=0; (i < nlocal) && (n == 0); ++i)
+      for (int i = 0; (i < nlocal) && (n == 0); ++i)
         if ((body[i] >= 0) && select[i]) ++n;
     }
   }
 
   int n_all = 0;
-  MPI_Allreduce(&n,&n_all,1,MPI_INT,MPI_SUM,world);
+  MPI_Allreduce(&n, &n_all, 1, MPI_INT, MPI_SUM, world);
 
   if (n_all > 0) return 1;
   return 0;
@@ -1239,19 +1199,20 @@ int Modify::check_rigid_list_overlap(int *select)
 
 Compute *Modify::add_compute(int narg, char **arg, int trysuffix)
 {
-  if (narg < 3) error->all(FLERR,"Illegal compute command");
+  if (narg < 3) error->all(FLERR, "Illegal compute command");
 
   // error check
 
   for (int icompute = 0; icompute < ncompute; icompute++)
-    if (strcmp(arg[0],compute[icompute]->id) == 0)
-      error->all(FLERR,"Reuse of compute ID '{}'",arg[0]);
+    if (strcmp(arg[0], compute[icompute]->id) == 0)
+      error->all(FLERR, "Reuse of compute ID '{}'", arg[0]);
 
   // extend Compute list if necessary
 
   if (ncompute == maxcompute) {
     maxcompute += DELTA;
-    compute = (Compute **) memory->srealloc(compute,maxcompute*sizeof(Compute *),"modify:compute");
+    compute =
+        (Compute **) memory->srealloc(compute, maxcompute * sizeof(Compute *), "modify:compute");
   }
 
   // create the Compute
@@ -1264,7 +1225,7 @@ Compute *Modify::add_compute(int narg, char **arg, int trysuffix)
       std::string estyle = arg[2] + std::string("/") + lmp->suffix;
       if (compute_map->find(estyle) != compute_map->end()) {
         ComputeCreator &compute_creator = (*compute_map)[estyle];
-        compute[ncompute] = compute_creator(lmp,narg,arg);
+        compute[ncompute] = compute_creator(lmp, narg, arg);
         delete[] compute[ncompute]->style;
         compute[ncompute]->style = utils::strdup(estyle);
       }
@@ -1273,23 +1234,22 @@ Compute *Modify::add_compute(int narg, char **arg, int trysuffix)
       std::string estyle = arg[2] + std::string("/") + lmp->suffix2;
       if (compute_map->find(estyle) != compute_map->end()) {
         ComputeCreator &compute_creator = (*compute_map)[estyle];
-        compute[ncompute] = compute_creator(lmp,narg,arg);
+        compute[ncompute] = compute_creator(lmp, narg, arg);
         delete[] compute[ncompute]->style;
         compute[ncompute]->style = utils::strdup(estyle);
       }
     }
   }
 
-  if (compute[ncompute] == nullptr &&
-      compute_map->find(arg[2]) != compute_map->end()) {
+  if (compute[ncompute] == nullptr && compute_map->find(arg[2]) != compute_map->end()) {
     ComputeCreator &compute_creator = (*compute_map)[arg[2]];
-    compute[ncompute] = compute_creator(lmp,narg,arg);
+    compute[ncompute] = compute_creator(lmp, narg, arg);
   }
 
   if (compute[ncompute] == nullptr)
-    error->all(FLERR,utils::check_packages_for_style("compute",arg[2],lmp));
+    error->all(FLERR, utils::check_packages_for_style("compute", arg[2], lmp));
 
-  compute_list = std::vector<Compute *>(compute, compute+ncompute+1);
+  compute_list = std::vector<Compute *>(compute, compute + ncompute + 1);
   return compute[ncompute++];
 }
 
@@ -1300,12 +1260,10 @@ Compute *Modify::add_compute(int narg, char **arg, int trysuffix)
 Compute *Modify::add_compute(const std::string &computecmd, int trysuffix)
 {
   auto args = utils::split_words(computecmd);
-  std::vector<char *>newarg(args.size());
-  int i=0;
-  for (const auto &arg : args) {
-    newarg[i++] = (char *)arg.c_str();
-  }
-  return add_compute(args.size(),newarg.data(),trysuffix);
+  std::vector<char *> newarg(args.size());
+  int i = 0;
+  for (const auto &arg : args) { newarg[i++] = (char *) arg.c_str(); }
+  return add_compute(args.size(), newarg.data(), trysuffix);
 }
 
 /* ----------------------------------------------------------------------
@@ -1314,17 +1272,16 @@ Compute *Modify::add_compute(const std::string &computecmd, int trysuffix)
 
 void Modify::modify_compute(int narg, char **arg)
 {
-  if (narg < 2) error->all(FLERR,"Illegal compute_modify command");
+  if (narg < 2) error->all(FLERR, "Illegal compute_modify command");
 
   // lookup Compute ID
 
   int icompute;
   for (icompute = 0; icompute < ncompute; icompute++)
-    if (strcmp(arg[0],compute[icompute]->id) == 0) break;
-  if (icompute == ncompute)
-    error->all(FLERR,"Could not find compute_modify ID {}", arg[0]);
+    if (strcmp(arg[0], compute[icompute]->id) == 0) break;
+  if (icompute == ncompute) error->all(FLERR, "Could not find compute_modify ID {}", arg[0]);
 
-  compute[icompute]->modify_params(narg-1,&arg[1]);
+  compute[icompute]->modify_params(narg - 1, &arg[1]);
 }
 
 /* ----------------------------------------------------------------------
@@ -1334,7 +1291,7 @@ void Modify::modify_compute(int narg, char **arg)
 void Modify::delete_compute(const std::string &id)
 {
   int icompute = find_compute(id);
-  if (icompute < 0) error->all(FLERR,"Could not find compute ID {} to delete", id);
+  if (icompute < 0) error->all(FLERR, "Could not find compute ID {} to delete", id);
   delete_compute(icompute);
 }
 
@@ -1345,9 +1302,9 @@ void Modify::delete_compute(int icompute)
   // delete and move other Computes down in list one slot
 
   delete compute[icompute];
-  for (int i = icompute+1; i < ncompute; i++) compute[i-1] = compute[i];
+  for (int i = icompute + 1; i < ncompute; i++) compute[i - 1] = compute[i];
   ncompute--;
-  compute_list = std::vector<Compute *>(compute, compute+ncompute);
+  compute_list = std::vector<Compute *>(compute, compute + ncompute);
 }
 
 /* ----------------------------------------------------------------------
@@ -1387,7 +1344,7 @@ const std::vector<Compute *> Modify::get_compute_by_style(const std::string &sty
   if (style.empty()) return matches;
 
   for (int icompute = 0; icompute < ncompute; icompute++)
-    if (utils::strmatch(compute[icompute]->style,style)) matches.push_back(compute[icompute]);
+    if (utils::strmatch(compute[icompute]->style, style)) matches.push_back(compute[icompute]);
 
   return matches;
 }
@@ -1398,7 +1355,7 @@ const std::vector<Compute *> Modify::get_compute_by_style(const std::string &sty
 
 const std::vector<Compute *> &Modify::get_compute_list()
 {
-  compute_list = std::vector<Compute *>(compute, compute+ncompute);
+  compute_list = std::vector<Compute *>(compute, compute + ncompute);
   return compute_list;
 }
 
@@ -1427,8 +1384,8 @@ void Modify::addstep_compute(bigint newstep)
   // initialized, thus defer to addstep_compute_all() instead
 
   if (n_timeflag < 0) {
-     addstep_compute_all(newstep);
-     return;
+    addstep_compute_all(newstep);
+    return;
   }
 
   for (int icompute = 0; icompute < n_timeflag; icompute++)
@@ -1463,18 +1420,18 @@ void Modify::write_restart(FILE *fp)
   for (int i = 0; i < nfix; i++)
     if (fix[i]->restart_global) count++;
 
-  if (me == 0) fwrite(&count,sizeof(int),1,fp);
+  if (me == 0) fwrite(&count, sizeof(int), 1, fp);
 
   int n;
   for (int i = 0; i < nfix; i++)
     if (fix[i]->restart_global) {
       if (me == 0) {
         n = strlen(fix[i]->id) + 1;
-        fwrite(&n,sizeof(int),1,fp);
-        fwrite(fix[i]->id,sizeof(char),n,fp);
+        fwrite(&n, sizeof(int), 1, fp);
+        fwrite(fix[i]->id, sizeof(char), n, fp);
         n = strlen(fix[i]->style) + 1;
-        fwrite(&n,sizeof(int),1,fp);
-        fwrite(fix[i]->style,sizeof(char),n,fp);
+        fwrite(&n, sizeof(int), 1, fp);
+        fwrite(fix[i]->style, sizeof(char), n, fp);
       }
       fix[i]->write_restart(fp);
     }
@@ -1483,19 +1440,19 @@ void Modify::write_restart(FILE *fp)
   for (int i = 0; i < nfix; i++)
     if (fix[i]->restart_peratom) count++;
 
-  if (me == 0) fwrite(&count,sizeof(int),1,fp);
+  if (me == 0) fwrite(&count, sizeof(int), 1, fp);
 
   for (int i = 0; i < nfix; i++)
     if (fix[i]->restart_peratom) {
       int maxsize_restart = fix[i]->maxsize_restart();
       if (me == 0) {
         n = strlen(fix[i]->id) + 1;
-        fwrite(&n,sizeof(int),1,fp);
-        fwrite(fix[i]->id,sizeof(char),n,fp);
+        fwrite(&n, sizeof(int), 1, fp);
+        fwrite(fix[i]->id, sizeof(char), n, fp);
         n = strlen(fix[i]->style) + 1;
-        fwrite(&n,sizeof(int),1,fp);
-        fwrite(fix[i]->style,sizeof(char),n,fp);
-        fwrite(&maxsize_restart,sizeof(int),1,fp);
+        fwrite(&n, sizeof(int), 1, fp);
+        fwrite(fix[i]->style, sizeof(char), n, fp);
+        fwrite(&maxsize_restart, sizeof(int), 1, fp);
       }
     }
 }
@@ -1512,15 +1469,15 @@ int Modify::read_restart(FILE *fp)
   // nfix_restart_global = # of restart entries with global state info
 
   int me = comm->me;
-  if (me == 0) utils::sfread(FLERR,&nfix_restart_global,sizeof(int),1,fp,nullptr,error);
-  MPI_Bcast(&nfix_restart_global,1,MPI_INT,0,world);
+  if (me == 0) utils::sfread(FLERR, &nfix_restart_global, sizeof(int), 1, fp, nullptr, error);
+  MPI_Bcast(&nfix_restart_global, 1, MPI_INT, 0, world);
 
   // allocate space for each entry
 
   if (nfix_restart_global) {
-    id_restart_global = new char*[nfix_restart_global];
-    style_restart_global = new char*[nfix_restart_global];
-    state_restart_global = new char*[nfix_restart_global];
+    id_restart_global = new char *[nfix_restart_global];
+    style_restart_global = new char *[nfix_restart_global];
+    state_restart_global = new char *[nfix_restart_global];
     used_restart_global = new int[nfix_restart_global];
   }
 
@@ -1529,23 +1486,23 @@ int Modify::read_restart(FILE *fp)
 
   int n;
   for (int i = 0; i < nfix_restart_global; i++) {
-    if (me == 0) utils::sfread(FLERR,&n,sizeof(int),1,fp,nullptr,error);
-    MPI_Bcast(&n,1,MPI_INT,0,world);
+    if (me == 0) utils::sfread(FLERR, &n, sizeof(int), 1, fp, nullptr, error);
+    MPI_Bcast(&n, 1, MPI_INT, 0, world);
     id_restart_global[i] = new char[n];
-    if (me == 0) utils::sfread(FLERR,id_restart_global[i],sizeof(char),n,fp,nullptr,error);
-    MPI_Bcast(id_restart_global[i],n,MPI_CHAR,0,world);
+    if (me == 0) utils::sfread(FLERR, id_restart_global[i], sizeof(char), n, fp, nullptr, error);
+    MPI_Bcast(id_restart_global[i], n, MPI_CHAR, 0, world);
 
-    if (me == 0) utils::sfread(FLERR,&n,sizeof(int),1,fp,nullptr,error);
-    MPI_Bcast(&n,1,MPI_INT,0,world);
+    if (me == 0) utils::sfread(FLERR, &n, sizeof(int), 1, fp, nullptr, error);
+    MPI_Bcast(&n, 1, MPI_INT, 0, world);
     style_restart_global[i] = new char[n];
-    if (me == 0) utils::sfread(FLERR,style_restart_global[i],sizeof(char),n,fp,nullptr,error);
-    MPI_Bcast(style_restart_global[i],n,MPI_CHAR,0,world);
+    if (me == 0) utils::sfread(FLERR, style_restart_global[i], sizeof(char), n, fp, nullptr, error);
+    MPI_Bcast(style_restart_global[i], n, MPI_CHAR, 0, world);
 
-    if (me == 0) utils::sfread(FLERR,&n,sizeof(int),1,fp,nullptr,error);
-    MPI_Bcast(&n,1,MPI_INT,0,world);
+    if (me == 0) utils::sfread(FLERR, &n, sizeof(int), 1, fp, nullptr, error);
+    MPI_Bcast(&n, 1, MPI_INT, 0, world);
     state_restart_global[i] = new char[n];
-    if (me == 0) utils::sfread(FLERR,state_restart_global[i],sizeof(char),n,fp,nullptr,error);
-    MPI_Bcast(state_restart_global[i],n,MPI_CHAR,0,world);
+    if (me == 0) utils::sfread(FLERR, state_restart_global[i], sizeof(char), n, fp, nullptr, error);
+    MPI_Bcast(state_restart_global[i], n, MPI_CHAR, 0, world);
 
     used_restart_global[i] = 0;
   }
@@ -1554,14 +1511,14 @@ int Modify::read_restart(FILE *fp)
 
   int maxsize = 0;
 
-  if (me == 0) utils::sfread(FLERR,&nfix_restart_peratom,sizeof(int),1,fp,nullptr,error);
-  MPI_Bcast(&nfix_restart_peratom,1,MPI_INT,0,world);
+  if (me == 0) utils::sfread(FLERR, &nfix_restart_peratom, sizeof(int), 1, fp, nullptr, error);
+  MPI_Bcast(&nfix_restart_peratom, 1, MPI_INT, 0, world);
 
   // allocate space for each entry
 
   if (nfix_restart_peratom) {
-    id_restart_peratom = new char*[nfix_restart_peratom];
-    style_restart_peratom = new char*[nfix_restart_peratom];
+    id_restart_peratom = new char *[nfix_restart_peratom];
+    style_restart_peratom = new char *[nfix_restart_peratom];
     index_restart_peratom = new int[nfix_restart_peratom];
     used_restart_peratom = new int[nfix_restart_peratom];
   }
@@ -1571,20 +1528,21 @@ int Modify::read_restart(FILE *fp)
   // set index = which set of extra data this fix represents
 
   for (int i = 0; i < nfix_restart_peratom; i++) {
-    if (me == 0) utils::sfread(FLERR,&n,sizeof(int),1,fp,nullptr,error);
-    MPI_Bcast(&n,1,MPI_INT,0,world);
+    if (me == 0) utils::sfread(FLERR, &n, sizeof(int), 1, fp, nullptr, error);
+    MPI_Bcast(&n, 1, MPI_INT, 0, world);
     id_restart_peratom[i] = new char[n];
-    if (me == 0) utils::sfread(FLERR,id_restart_peratom[i],sizeof(char),n,fp,nullptr,error);
-    MPI_Bcast(id_restart_peratom[i],n,MPI_CHAR,0,world);
+    if (me == 0) utils::sfread(FLERR, id_restart_peratom[i], sizeof(char), n, fp, nullptr, error);
+    MPI_Bcast(id_restart_peratom[i], n, MPI_CHAR, 0, world);
 
-    if (me == 0) utils::sfread(FLERR,&n,sizeof(int),1,fp,nullptr,error);
-    MPI_Bcast(&n,1,MPI_INT,0,world);
+    if (me == 0) utils::sfread(FLERR, &n, sizeof(int), 1, fp, nullptr, error);
+    MPI_Bcast(&n, 1, MPI_INT, 0, world);
     style_restart_peratom[i] = new char[n];
-    if (me == 0) utils::sfread(FLERR,style_restart_peratom[i],sizeof(char),n,fp,nullptr,error);
-    MPI_Bcast(style_restart_peratom[i],n,MPI_CHAR,0,world);
+    if (me == 0)
+      utils::sfread(FLERR, style_restart_peratom[i], sizeof(char), n, fp, nullptr, error);
+    MPI_Bcast(style_restart_peratom[i], n, MPI_CHAR, 0, world);
 
-    if (me == 0) utils::sfread(FLERR,&n,sizeof(int),1,fp,nullptr,error);
-    MPI_Bcast(&n,1,MPI_INT,0,world);
+    if (me == 0) utils::sfread(FLERR, &n, sizeof(int), 1, fp, nullptr, error);
+    MPI_Bcast(&n, 1, MPI_INT, 0, world);
     maxsize += n;
 
     index_restart_peratom[i] = i;
@@ -1607,26 +1565,26 @@ void Modify::restart_deallocate(int flag)
       for (i = 0; i < nfix_restart_global; i++)
         if (used_restart_global[i] == 0) break;
       if (i == nfix_restart_global) {
-        utils::logmesg(lmp,"All restart file global fix info was re-assigned\n");
+        utils::logmesg(lmp, "All restart file global fix info was re-assigned\n");
       } else {
-        utils::logmesg(lmp,"Unused restart file global fix info:\n");
+        utils::logmesg(lmp, "Unused restart file global fix info:\n");
         for (i = 0; i < nfix_restart_global; i++) {
           if (used_restart_global[i]) continue;
-          utils::logmesg(lmp,"  fix style: {}, fix ID: {}\n",
-                         style_restart_global[i],id_restart_global[i]);
+          utils::logmesg(lmp, "  fix style: {}, fix ID: {}\n", style_restart_global[i],
+                         id_restart_global[i]);
         }
       }
     }
 
     for (int i = 0; i < nfix_restart_global; i++) {
-      delete [] id_restart_global[i];
-      delete [] style_restart_global[i];
-      delete [] state_restart_global[i];
+      delete[] id_restart_global[i];
+      delete[] style_restart_global[i];
+      delete[] state_restart_global[i];
     }
-    delete [] id_restart_global;
-    delete [] style_restart_global;
-    delete [] state_restart_global;
-    delete [] used_restart_global;
+    delete[] id_restart_global;
+    delete[] style_restart_global;
+    delete[] state_restart_global;
+    delete[] used_restart_global;
   }
 
   if (nfix_restart_peratom) {
@@ -1635,25 +1593,25 @@ void Modify::restart_deallocate(int flag)
       for (i = 0; i < nfix_restart_peratom; i++)
         if (used_restart_peratom[i] == 0) break;
       if (i == nfix_restart_peratom) {
-        utils::logmesg(lmp,"All restart file peratom fix info was re-assigned\n");
+        utils::logmesg(lmp, "All restart file peratom fix info was re-assigned\n");
       } else {
-        utils::logmesg(lmp,"Unused restart file peratom fix info:\n");
+        utils::logmesg(lmp, "Unused restart file peratom fix info:\n");
         for (i = 0; i < nfix_restart_peratom; i++) {
           if (used_restart_peratom[i]) continue;
-          utils::logmesg(lmp,"  fix style: {}, fix ID: {}\n",
-                         style_restart_peratom[i],id_restart_peratom[i]);
+          utils::logmesg(lmp, "  fix style: {}, fix ID: {}\n", style_restart_peratom[i],
+                         id_restart_peratom[i]);
         }
       }
     }
 
     for (int i = 0; i < nfix_restart_peratom; i++) {
-      delete [] id_restart_peratom[i];
-      delete [] style_restart_peratom[i];
+      delete[] id_restart_peratom[i];
+      delete[] style_restart_peratom[i];
     }
-    delete [] id_restart_peratom;
-    delete [] style_restart_peratom;
-    delete [] index_restart_peratom;
-    delete [] used_restart_peratom;
+    delete[] id_restart_peratom;
+    delete[] style_restart_peratom;
+    delete[] index_restart_peratom;
+    delete[] used_restart_peratom;
   }
 
   nfix_restart_global = nfix_restart_peratom = 0;
@@ -1665,14 +1623,16 @@ void Modify::restart_deallocate(int flag)
 
 void Modify::list_init(int mask, int &n, int *&list)
 {
-  delete [] list;
+  delete[] list;
 
   n = 0;
-  for (int i = 0; i < nfix; i++) if (fmask[i] & mask) n++;
+  for (int i = 0; i < nfix; i++)
+    if (fmask[i] & mask) n++;
   list = new int[n];
 
   n = 0;
-  for (int i = 0; i < nfix; i++) if (fmask[i] & mask) list[n++] = i;
+  for (int i = 0; i < nfix; i++)
+    if (fmask[i] & mask) list[n++] = i;
 }
 
 /* ----------------------------------------------------------------------
@@ -1682,11 +1642,12 @@ void Modify::list_init(int mask, int &n, int *&list)
 
 void Modify::list_init_end_of_step(int mask, int &n, int *&list)
 {
-  delete [] list;
-  delete [] end_of_step_every;
+  delete[] list;
+  delete[] end_of_step_every;
 
   n = 0;
-  for (int i = 0; i < nfix; i++) if (fmask[i] & mask) n++;
+  for (int i = 0; i < nfix; i++)
+    if (fmask[i] & mask) n++;
   list = new int[n];
   end_of_step_every = new int[n];
 
@@ -1705,7 +1666,7 @@ void Modify::list_init_end_of_step(int mask, int &n, int *&list)
 
 void Modify::list_init_energy_couple(int &n, int *&list)
 {
-  delete [] list;
+  delete[] list;
 
   n = 0;
   for (int i = 0; i < nfix; i++)
@@ -1724,7 +1685,7 @@ void Modify::list_init_energy_couple(int &n, int *&list)
 
 void Modify::list_init_energy_global(int &n, int *&list)
 {
-  delete [] list;
+  delete[] list;
 
   n = 0;
   for (int i = 0; i < nfix; i++)
@@ -1743,7 +1704,7 @@ void Modify::list_init_energy_global(int &n, int *&list)
 
 void Modify::list_init_energy_atom(int &n, int *&list)
 {
-  delete [] list;
+  delete[] list;
 
   n = 0;
   for (int i = 0; i < nfix; i++)
@@ -1761,7 +1722,7 @@ void Modify::list_init_energy_atom(int &n, int *&list)
 
 void Modify::list_init_compute()
 {
-  delete [] list_timeflag;
+  delete[] list_timeflag;
 
   n_timeflag = 0;
   for (int i = 0; i < ncompute; i++)
@@ -1780,9 +1741,7 @@ void Modify::list_init_compute()
 double Modify::memory_usage()
 {
   double bytes = 0;
-  for (int i = 0; i < nfix; i++)
-    bytes += fix[i]->memory_usage();
-  for (int i = 0; i < ncompute; i++)
-    bytes += compute[i]->memory_usage();
+  for (int i = 0; i < nfix; i++) bytes += fix[i]->memory_usage();
+  for (int i = 0; i < ncompute; i++) bytes += compute[i]->memory_usage();
   return bytes;
 }

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -37,6 +37,19 @@ using namespace FixConst;
 #define DELTA 4
 #define BIG 1.0e20
 
+// templates for factory functions:
+// there will be one instance for each style keyword in the style_xxx.h file
+
+template <typename T> static Fix *fix_creator(LAMMPS *lmp, int narg, char **arg)
+{
+  return new T(lmp,narg,arg);
+}
+
+template <typename T> static Compute *compute_creator(LAMMPS *lmp, int narg, char **arg)
+{
+  return new T(lmp,narg,arg);
+}
+
 /* ---------------------------------------------------------------------- */
 
 Modify::Modify(LAMMPS *lmp) : Pointers(lmp)
@@ -1025,16 +1038,6 @@ Fix *Modify::replace_fix(const std::string &oldfix, const std::string &fixcmd, i
 }
 
 /* ----------------------------------------------------------------------
-   one instance per fix in style_fix.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Fix *Modify::fix_creator(LAMMPS *lmp, int narg, char **arg)
-{
-  return new T(lmp,narg,arg);
-}
-
-/* ----------------------------------------------------------------------
    modify a Fix's parameters
 ------------------------------------------------------------------------- */
 
@@ -1308,17 +1311,6 @@ Compute *Modify::add_compute(const std::string &computecmd, int trysuffix)
     newarg[i++] = (char *)arg.c_str();
   }
   return add_compute(args.size(),newarg.data(),trysuffix);
-}
-
-
-/* ----------------------------------------------------------------------
-   one instance per compute in style_compute.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Compute *Modify::compute_creator(LAMMPS *lmp, int narg, char **arg)
-{
-  return new T(lmp,narg,arg);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/modify.h
+++ b/src/modify.h
@@ -201,8 +201,6 @@ class Modify : protected Pointers {
 
  protected:
   void create_factories();
-  template <typename T> static Compute *compute_creator(LAMMPS *, int, char **);
-  template <typename T> static Fix *fix_creator(LAMMPS *, int, char **);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -100,6 +100,14 @@ static const char cite_neigh_multi[] =
   " year = {2020}\n"
   "}\n\n";
 
+// template for factory functions:
+// there will be one instance for each style keyword in the respective style_xxx.h files
+
+template <typename S, typename T> static S *style_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
+
 //#define NEIGH_LIST_DEBUG 1
 
 /* ---------------------------------------------------------------------- */
@@ -693,7 +701,7 @@ void Neighbor::init_styles()
 #define NBIN_CLASS
 #define NBinStyle(key,Class,bitmasks) \
   binnames[nbclass] = (char *) #key; \
-  binclass[nbclass] = &bin_creator<Class>; \
+  binclass[nbclass] = &style_creator<NBin, Class>;   \
   binmasks[nbclass++] = bitmasks;
 #include "style_nbin.h"  // IWYU pragma: keep
 #undef NBinStyle
@@ -717,7 +725,7 @@ void Neighbor::init_styles()
 #define NSTENCIL_CLASS
 #define NStencilStyle(key,Class,bitmasks) \
   stencilnames[nsclass] = (char *) #key; \
-  stencilclass[nsclass] = &stencil_creator<Class>; \
+  stencilclass[nsclass] = &style_creator<NStencil, Class>;   \
   stencilmasks[nsclass++] = bitmasks;
 #include "style_nstencil.h"  // IWYU pragma: keep
 #undef NStencilStyle
@@ -741,7 +749,7 @@ void Neighbor::init_styles()
 #define NPAIR_CLASS
 #define NPairStyle(key,Class,bitmasks) \
   pairnames[npclass] = (char *) #key; \
-  pairclass[npclass] = &pair_creator<Class>; \
+  pairclass[npclass] = &style_creator<NPair, Class>;  \
   pairmasks[npclass++] = bitmasks;
 #include "style_npair.h"  // IWYU pragma: keep
 #undef NPairStyle
@@ -2026,36 +2034,6 @@ int Neighbor::request(void *requestor, int instance)
   requests[nrequest]->requestor_instance = instance;
   nrequest++;
   return nrequest-1;
-}
-
-/* ----------------------------------------------------------------------
-   one instance per entry in style_neigh_bin.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-NBin *Neighbor::bin_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-/* ----------------------------------------------------------------------
-   one instance per entry in style_neigh_stencil.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-NStencil *Neighbor::stencil_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
-}
-
-/* ----------------------------------------------------------------------
-   one instance per entry in style_neigh_pair.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-NPair *Neighbor::pair_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/neighbor.h
+++ b/src/neighbor.h
@@ -231,10 +231,6 @@ class Neighbor : protected Pointers {
   int choose_stencil(class NeighRequest *);
   int choose_pair(class NeighRequest *);
 
-  template <typename T> static NBin *bin_creator(class LAMMPS *);
-  template <typename T> static NStencil *stencil_creator(class LAMMPS *);
-  template <typename T> static NPair *pair_creator(class LAMMPS *);
-
   // dummy functions provided by NeighborKokkos, called in init()
   // otherwise NeighborKokkos would have to overwrite init()
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -44,6 +44,15 @@ using namespace LAMMPS_NS;
 enum {SETUP, WRITE, RESET_DT};
 
 /* ----------------------------------------------------------------------
+   one instance per dump style in style_dump.h
+------------------------------------------------------------------------- */
+
+template <typename T> static Dump *dump_creator(LAMMPS *lmp, int narg, char ** arg)
+{
+  return new T(lmp, narg, arg);
+}
+
+/* ----------------------------------------------------------------------
    initialize all output
 ------------------------------------------------------------------------- */
 
@@ -782,16 +791,6 @@ void Output::add_dump(int narg, char **arg)
   ivar_dump[ndump] = -1;
 
   ndump++;
-}
-
-/* ----------------------------------------------------------------------
-   one instance per dump style in style_dump.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Dump *Output::dump_creator(LAMMPS *lmp, int narg, char ** arg)
-{
-  return new T(lmp, narg, arg);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/output.h
+++ b/src/output.h
@@ -93,7 +93,6 @@ class Output : protected Pointers {
   void memory_usage();    // print out memory usage
 
  private:
-  template <typename T> static Dump *dump_creator(LAMMPS *, int, char **);
   void calculate_next_dump(int, int, bigint);
 };
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -14,15 +13,15 @@
 
 #include "update.h"
 
-#include "style_integrate.h"  // IWYU pragma: keep
-#include "style_minimize.h"   // IWYU pragma: keep
+#include "style_integrate.h"    // IWYU pragma: keep
+#include "style_minimize.h"     // IWYU pragma: keep
 
 #include "comm.h"
 #include "compute.h"
-#include "integrate.h"
 #include "error.h"
 #include "fix.h"
 #include "force.h"
+#include "integrate.h"
 #include "min.h"
 #include "modify.h"
 #include "neighbor.h"
@@ -31,6 +30,19 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
+
+// template for factory functions:
+// there will be one instance for each style keyword in the respective style_xxx.h files
+
+template <typename T> static Integrate *integrate_creator(LAMMPS *lmp, int narg, char **arg)
+{
+  return new T(lmp, narg, arg);
+}
+
+template <typename T> static Min *minimize_creator(LAMMPS *lmp)
+{
+  return new T(lmp);
+}
 
 /* ---------------------------------------------------------------------- */
 
@@ -67,38 +79,36 @@ Update::Update(LAMMPS *lmp) : Pointers(lmp)
   integrate_map = new IntegrateCreatorMap();
 
 #define INTEGRATE_CLASS
-#define IntegrateStyle(key,Class) \
-  (*integrate_map)[#key] = &integrate_creator<Class>;
-#include "style_integrate.h"   // IWYU pragma: keep
+#define IntegrateStyle(key, Class) (*integrate_map)[#key] = &integrate_creator<Class>;
+#include "style_integrate.h"    // IWYU pragma: keep
 #undef IntegrateStyle
 #undef INTEGRATE_CLASS
 
   minimize_map = new MinimizeCreatorMap();
 
 #define MINIMIZE_CLASS
-#define MinimizeStyle(key,Class) \
-  (*minimize_map)[#key] = &minimize_creator<Class>;
+#define MinimizeStyle(key, Class) (*minimize_map)[#key] = &minimize_creator<Class>;
 #include "style_minimize.h"    // IWYU pragma: keep
 #undef MinimizeStyle
 #undef MINIMIZE_CLASS
 
   str = (char *) "verlet";
-  create_integrate(1,&str,1);
+  create_integrate(1, &str, 1);
 
   str = (char *) "cg";
-  create_minimize(1,&str,1);
+  create_minimize(1, &str, 1);
 }
 
 /* ---------------------------------------------------------------------- */
 
 Update::~Update()
 {
-  delete [] unit_style;
+  delete[] unit_style;
 
-  delete [] integrate_style;
+  delete[] integrate_style;
   delete integrate;
 
-  delete [] minimize_style;
+  delete[] minimize_style;
   delete minimize;
 
   delete integrate_map;
@@ -113,8 +123,10 @@ void Update::init()
   // if neither (e.g. from write_restart) then just return
 
   if (whichflag == 0) return;
-  if (whichflag == 1) integrate->init();
-  else if (whichflag == 2) minimize->init();
+  if (whichflag == 1)
+    integrate->init();
+  else if (whichflag == 2)
+    minimize->init();
 
   // only set first_update if a run or minimize is being performed
 
@@ -131,7 +143,7 @@ void Update::set_units(const char *style)
 
   double dt_old = dt;
 
-  if (strcmp(style,"lj") == 0) {
+  if (strcmp(style, "lj") == 0) {
     force->boltz = 1.0;
     force->hplanck = 1.0;
     force->mvv2e = 1.0;
@@ -152,18 +164,18 @@ void Update::set_units(const char *style)
     dt = 0.005;
     neighbor->skin = 0.3;
 
-  } else if (strcmp(style,"real") == 0) {
+  } else if (strcmp(style, "real") == 0) {
     force->boltz = 0.0019872067;
     force->hplanck = 95.306976368;
     force->mvv2e = 48.88821291 * 48.88821291;
     force->ftm2v = 1.0 / 48.88821291 / 48.88821291;
     force->mv2d = 1.0 / 0.602214129;
     force->nktv2p = 68568.415;
-    force->qqr2e = 332.06371;     // see also force->qqr2d_lammps_real
+    force->qqr2e = 332.06371;    // see also force->qqr2d_lammps_real
     force->qe2f = 23.060549;
     force->vxmu2f = 1.4393264316e4;
     force->xxt2kmu = 0.1;
-    force->e_mass = 1.0/1836.1527556560675;
+    force->e_mass = 1.0 / 1836.1527556560675;
     force->hhmrr2e = 0.0957018663603261;
     force->mvh2r = 1.5339009481951;
     force->angstrom = 1.0;
@@ -173,7 +185,7 @@ void Update::set_units(const char *style)
     dt = 1.0;
     neighbor->skin = 2.0;
 
-  } else if (strcmp(style,"metal") == 0) {
+  } else if (strcmp(style, "metal") == 0) {
     force->boltz = 8.617343e-5;
     force->hplanck = 4.135667403e-3;
     force->mvv2e = 1.0364269e-4;
@@ -194,7 +206,7 @@ void Update::set_units(const char *style)
     dt = 0.001;
     neighbor->skin = 2.0;
 
-  } else if (strcmp(style,"si") == 0) {
+  } else if (strcmp(style, "si") == 0) {
     force->boltz = 1.3806504e-23;
     force->hplanck = 6.62606896e-34;
     force->mvv2e = 1.0;
@@ -215,7 +227,7 @@ void Update::set_units(const char *style)
     dt = 1.0e-8;
     neighbor->skin = 0.001;
 
-  } else if (strcmp(style,"cgs") == 0) {
+  } else if (strcmp(style, "cgs") == 0) {
     force->boltz = 1.3806504e-16;
     force->hplanck = 6.62606896e-27;
     force->mvv2e = 1.0;
@@ -236,7 +248,7 @@ void Update::set_units(const char *style)
     dt = 1.0e-8;
     neighbor->skin = 0.1;
 
-  } else if (strcmp(style,"electron") == 0) {
+  } else if (strcmp(style, "electron") == 0) {
     force->boltz = 3.16681534e-6;
     force->hplanck = 0.1519829846;
     force->mvv2e = 1.06657236;
@@ -257,7 +269,7 @@ void Update::set_units(const char *style)
     dt = 0.001;
     neighbor->skin = 2.0;
 
-  } else if (strcmp(style,"micro") == 0) {
+  } else if (strcmp(style, "micro") == 0) {
     force->boltz = 1.3806504e-8;
     force->hplanck = 6.62606896e-13;
     force->mvv2e = 1.0;
@@ -278,7 +290,7 @@ void Update::set_units(const char *style)
     dt = 2.0;
     neighbor->skin = 0.1;
 
-  } else if (strcmp(style,"nano") == 0) {
+  } else if (strcmp(style, "nano") == 0) {
     force->boltz = 0.013806504;
     force->hplanck = 6.62606896e-4;
     force->mvv2e = 1.0;
@@ -299,15 +311,16 @@ void Update::set_units(const char *style)
     dt = 0.00045;
     neighbor->skin = 0.1;
 
-  } else error->all(FLERR,"Illegal units command");
+  } else
+    error->all(FLERR, "Illegal units command");
 
-  delete [] unit_style;
+  delete[] unit_style;
   unit_style = utils::strdup(style);
 
   // check if timestep was changed from default value
   if (!dt_default && (comm->me == 0)) {
-    error->warning(FLERR,"Changing timestep from {:.6} to {:.6} due to "
-                   "changing units to {}", dt_old, dt, unit_style);
+    error->warning(FLERR, "Changing timestep from {:.6} to {:.6} due to changing units to {}",
+                   dt_old, dt, unit_style);
   }
   dt_default = 1;
 }
@@ -316,24 +329,26 @@ void Update::set_units(const char *style)
 
 void Update::create_integrate(int narg, char **arg, int trysuffix)
 {
-  if (narg < 1) error->all(FLERR,"Illegal run_style command");
+  if (narg < 1) error->all(FLERR, "Illegal run_style command");
 
-  delete [] integrate_style;
+  delete[] integrate_style;
   delete integrate;
 
   int sflag;
 
-  if (narg-1 > 0) {
-    new_integrate(arg[0],narg-1,&arg[1],trysuffix,sflag);
+  if (narg - 1 > 0) {
+    new_integrate(arg[0], narg - 1, &arg[1], trysuffix, sflag);
   } else {
-    new_integrate(arg[0],0,nullptr,trysuffix,sflag);
+    new_integrate(arg[0], 0, nullptr, trysuffix, sflag);
   }
 
   std::string estyle = arg[0];
   if (sflag) {
     estyle += "/";
-    if (sflag == 1) estyle += lmp->suffix;
-    else  estyle += lmp->suffix2;
+    if (sflag == 1)
+      estyle += lmp->suffix;
+    else
+      estyle += lmp->suffix2;
   }
   integrate_style = utils::strdup(estyle);
 }
@@ -342,8 +357,7 @@ void Update::create_integrate(int narg, char **arg, int trysuffix)
    create the Integrate style, first with suffix appended
 ------------------------------------------------------------------------- */
 
-void Update::new_integrate(char *style, int narg, char **arg,
-                           int trysuffix, int &sflag)
+void Update::new_integrate(char *style, int narg, char **arg, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
@@ -374,36 +388,28 @@ void Update::new_integrate(char *style, int narg, char **arg,
     return;
   }
 
-  error->all(FLERR,"Illegal integrate style");
-}
-
-/* ----------------------------------------------------------------------
-   one instance per integrate style in style_integrate.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Integrate *Update::integrate_creator(LAMMPS *lmp, int narg, char ** arg)
-{
-  return new T(lmp, narg, arg);
+  error->all(FLERR, "Illegal integrate style");
 }
 
 /* ---------------------------------------------------------------------- */
 
 void Update::create_minimize(int narg, char **arg, int trysuffix)
 {
-  if (narg < 1) error->all(FLERR,"Illegal run_style command");
+  if (narg < 1) error->all(FLERR, "Illegal run_style command");
 
-  delete [] minimize_style;
+  delete[] minimize_style;
   delete minimize;
 
   int sflag;
-  new_minimize(arg[0],narg-1,&arg[1],trysuffix,sflag);
+  new_minimize(arg[0], narg - 1, &arg[1], trysuffix, sflag);
 
   std::string estyle = arg[0];
   if (sflag) {
     estyle += "/";
-    if (sflag == 1) estyle += lmp->suffix;
-    else estyle += lmp->suffix2;
+    if (sflag == 1)
+      estyle += lmp->suffix;
+    else
+      estyle += lmp->suffix2;
   }
   minimize_style = utils::strdup(estyle);
 }
@@ -412,8 +418,7 @@ void Update::create_minimize(int narg, char **arg, int trysuffix)
    create the Minimize style, first with suffix appended
 ------------------------------------------------------------------------- */
 
-void Update::new_minimize(char *style, int /* narg */, char ** /* arg */,
-                           int trysuffix, int &sflag)
+void Update::new_minimize(char *style, int /* narg */, char ** /* arg */, int trysuffix, int &sflag)
 {
   if (trysuffix && lmp->suffix_enable) {
     if (lmp->suffix) {
@@ -444,17 +449,7 @@ void Update::new_minimize(char *style, int /* narg */, char ** /* arg */,
     return;
   }
 
-  error->all(FLERR,"Illegal minimize style");
-}
-
-/* ----------------------------------------------------------------------
-   one instance per minimize style in style_minimize.h
-------------------------------------------------------------------------- */
-
-template <typename T>
-Min *Update::minimize_creator(LAMMPS *lmp)
-{
-  return new T(lmp);
+  error->all(FLERR, "Illegal minimize style");
 }
 
 /* ----------------------------------------------------------------------
@@ -463,8 +458,8 @@ Min *Update::minimize_creator(LAMMPS *lmp)
 
 void Update::reset_timestep(int narg, char **arg)
 {
-  if (narg != 1) error->all(FLERR,"Illegal reset_timestep command");
-  bigint newstep = utils::bnumeric(FLERR,arg[0],false,lmp);
+  if (narg != 1) error->all(FLERR, "Illegal reset_timestep command");
+  bigint newstep = utils::bnumeric(FLERR, arg[0], false, lmp);
   reset_timestep(newstep);
 }
 
@@ -475,7 +470,7 @@ void Update::reset_timestep(int narg, char **arg)
 
 void Update::reset_timestep(bigint newstep)
 {
-  if (newstep < 0) error->all(FLERR,"Timestep must be >= 0");
+  if (newstep < 0) error->all(FLERR, "Timestep must be >= 0");
 
   bigint oldstep = ntimestep;
   ntimestep = newstep;
@@ -499,7 +494,7 @@ void Update::reset_timestep(bigint newstep)
 
   for (const auto &ifix : modify->get_fix_list())
     if (ifix->time_depend)
-      error->all(FLERR, "Cannot reset timestep with time-dependent fix {} defined",ifix->style);
+      error->all(FLERR, "Cannot reset timestep with time-dependent fix {} defined", ifix->style);
 
   // reset eflag/vflag global so no commands will think eng/virial are current
 
@@ -529,7 +524,7 @@ void Update::reset_timestep(bigint newstep)
 
 void Update::update_time()
 {
-  atime += (ntimestep-atimestep) * dt;
+  atime += (ntimestep - atimestep) * dt;
   atimestep = ntimestep;
 }
 
@@ -540,7 +535,9 @@ void Update::update_time()
 double Update::memory_usage()
 {
   double bytes = 0;
-  if (whichflag == 1) bytes += integrate->memory_usage();
-  else if (whichflag == 2) bytes += minimize->memory_usage();
+  if (whichflag == 1)
+    bytes += integrate->memory_usage();
+  else if (whichflag == 2)
+    bytes += minimize->memory_usage();
   return bytes;
 }

--- a/src/update.h
+++ b/src/update.h
@@ -73,9 +73,6 @@ class Update : protected Pointers {
  private:
   void new_integrate(char *, int, char **, int, int &);
   void new_minimize(char *, int, char **, int, int &);
-
-  template <typename T> static Integrate *integrate_creator(LAMMPS *, int, char **);
-  template <typename T> static Min *minimize_creator(LAMMPS *);
 };
 
 }    // namespace LAMMPS_NS


### PR DESCRIPTION
**Summary**

The factory functions to create the various style class instances in LAMMPS are not accessed outside their respective implementation file. This PR makes them static local function of the translation units and thus should significantly reduce the
number of visible symbols in the LAMMPS library. This should help to speed up linking and to work around some linker limitations. We have over 1500 styles when LAMMPS is compiled with all features included.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

