### PR TITLE
Fixed a bug with sw/gpu neigh no when used with pair hybrid for systems with multiple atom types

### DIFF
--- a/lib/gpu/lal_sw.cu
+++ b/lib/gpu/lal_sw.cu
@@ -666,8 +666,8 @@ __kernel void k_sw_three_end(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
-        // still need this check because j and k can be ghost atoms
-        //   and short neighbor lists are built for local atoms only
+        // still need this check because this loop apparently iterates
+        //   over neighbors of j that are not intended
         const numtyp cutsq_jk=sw_cut_ik*sw_cut_ik;
         if (!(rsq2>(numtyp)0 && rsq2<cutsq_jk)) continue;
         
@@ -788,8 +788,8 @@ __kernel void k_sw_three_end_vatom(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
-        // still need this check because j and k can be ghost atoms
-        //   and short neighbor lists are built for local atoms only
+        // still need this check because this loop apparently iterates
+        //   over neighbors of j that are not intended
         const numtyp cutsq_jk=sw_cut_ik*sw_cut_ik;
         if (!(rsq2>(numtyp)0 && rsq2<cutsq_jk)) continue;
 

--- a/lib/gpu/lal_sw.cu
+++ b/lib/gpu/lal_sw.cu
@@ -666,8 +666,8 @@ __kernel void k_sw_three_end(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
-        // still need this check because this loop apparently iterates
-        //   over neighbors of j that are not intended
+        // for neigh no within pair hybrid: still need the check below
+        //   this loop apparently iterates over neighbors of j that are not intended
         const numtyp cutsq_jk=sw_cut_ik*sw_cut_ik;
         if (!(rsq2>(numtyp)0 && rsq2<cutsq_jk)) continue;
         
@@ -788,8 +788,8 @@ __kernel void k_sw_three_end_vatom(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
-        // still need this check because this loop apparently iterates
-        //   over neighbors of j that are not intended
+        // for neigh no within pair hybrid: still need the check below
+        //   this loop apparently iterates over neighbors of j that are not intended
         const numtyp cutsq_jk=sw_cut_ik*sw_cut_ik;
         if (!(rsq2>(numtyp)0 && rsq2<cutsq_jk)) continue;
 

--- a/lib/gpu/lal_sw.cu
+++ b/lib/gpu/lal_sw.cu
@@ -666,8 +666,11 @@ __kernel void k_sw_three_end(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
-        if (!(rsq2>(numtyp)0 && rsq2<sw_cut_ik*sw_cut_ik)) continue;
-
+        // still need this check because j and k can be ghost atoms
+        //   and short neighbor lists are built for local atoms only
+        const numtyp cutsq_jk=sw_cut_ik*sw_cut_ik;
+        if (!(rsq2>(numtyp)0 && rsq2<cutsq_jk)) continue;
+        
         #ifndef ONETYPE
         const numtyp sw_sigma_gamma_ik=cut_sig_gamma[mtypek].y;
         const int mtypejik=jtype*ntypes*ntypes+itype+ktype;
@@ -785,7 +788,10 @@ __kernel void k_sw_three_end_vatom(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
-        if (!(rsq2>(numtyp)0 && rsq2<sw_cut_ik*sw_cut_ik)) continue;
+        // still need this check because j and k can be ghost atoms
+        //   and short neighbor lists are built for local atoms only
+        const numtyp cutsq_jk=sw_cut_ik*sw_cut_ik;
+        if (!(rsq2>(numtyp)0 && rsq2<cutsq_jk)) continue;
 
         #ifndef ONETYPE
         const numtyp sw_sigma_gamma_ik=cut_sig_gamma[mtypek].y;

--- a/lib/gpu/lal_sw.cu
+++ b/lib/gpu/lal_sw.cu
@@ -670,20 +670,20 @@ __kernel void k_sw_three_end(const __global numtyp4 *restrict x_,
         //   this loop apparently iterates over neighbors of j that are not intended
         const numtyp cutsq_jk=sw_cut_ik*sw_cut_ik;
         if (!(rsq2>(numtyp)0 && rsq2<cutsq_jk)) continue;
-        
+
         #ifndef ONETYPE
         const numtyp sw_sigma_gamma_ik=cut_sig_gamma[mtypek].y;
         const int mtypejik=jtype*ntypes*ntypes+itype+ktype;
         const numtyp sw_lambda_epsilon_ijk=sw_pre3[mtypejik].x;
         const numtyp sw_costheta_ijk=sw_pre3[mtypejik].y;
         #endif
-       
+
         numtyp fjx, fjy, fjz;
         threebody_half(delr1x,delr1y,delr1z,delr2x,delr2y,delr2z);
-       
+
         f.x += fjx;
         f.y += fjy;
-        f.z += fjz;        
+        f.z += fjz;
       }
     } // for nbor
   } // if ii

--- a/lib/gpu/lal_sw.cu
+++ b/lib/gpu/lal_sw.cu
@@ -658,6 +658,7 @@ __kernel void k_sw_three_end(const __global numtyp4 *restrict x_,
         #ifndef ONETYPE
         const int ktype=kx.w;
         const int mtypek=jtype*ntypes+ktype;
+        const numtyp sw_cut_ik=cut_sig_gamma[mtypek].x;
         #endif
 
         numtyp delr2x = kx.x - jx.x;
@@ -665,20 +666,21 @@ __kernel void k_sw_three_end(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
+        if (!(rsq2>(numtyp)0 && rsq2<sw_cut_ik*sw_cut_ik)) continue;
+
         #ifndef ONETYPE
-        const numtyp sw_cut_ik=cut_sig_gamma[mtypek].x;
         const numtyp sw_sigma_gamma_ik=cut_sig_gamma[mtypek].y;
         const int mtypejik=jtype*ntypes*ntypes+itype+ktype;
         const numtyp sw_lambda_epsilon_ijk=sw_pre3[mtypejik].x;
         const numtyp sw_costheta_ijk=sw_pre3[mtypejik].y;
         #endif
-
+       
         numtyp fjx, fjy, fjz;
         threebody_half(delr1x,delr1y,delr1z,delr2x,delr2y,delr2z);
-
+       
         f.x += fjx;
         f.y += fjy;
-        f.z += fjz;
+        f.z += fjz;        
       }
     } // for nbor
   } // if ii
@@ -775,6 +777,7 @@ __kernel void k_sw_three_end_vatom(const __global numtyp4 *restrict x_,
         #ifndef ONETYPE
         const int ktype=kx.w;
         const int mtypek=jtype*ntypes+ktype;
+        const numtyp sw_cut_ik=cut_sig_gamma[mtypek].x;
         #endif
 
         numtyp delr2x = kx.x - jx.x;
@@ -782,8 +785,9 @@ __kernel void k_sw_three_end_vatom(const __global numtyp4 *restrict x_,
         numtyp delr2z = kx.z - jx.z;
         numtyp rsq2 = delr2x*delr2x + delr2y*delr2y + delr2z*delr2z;
 
+        if (!(rsq2>(numtyp)0 && rsq2<sw_cut_ik*sw_cut_ik)) continue;
+
         #ifndef ONETYPE
-        const numtyp sw_cut_ik=cut_sig_gamma[mtypek].x;
         const numtyp sw_sigma_gamma_ik=cut_sig_gamma[mtypek].y;
         const int mtypejik=jtype*ntypes*ntypes+itype+ktype;
         const numtyp sw_lambda_epsilon_ijk=sw_pre3[mtypejik].x;


### PR DESCRIPTION
**Summary**

This PR is to fix a bug with sw/gpu when used as a sub-style within pair hybrid for systems with multiple atom types. The input script to reproduce the bug was provided in #3109.

**Related Issue(s)**

fixes #3109 

**Author(s)**

Trung Nguyen (U Chicago)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

To be maintained.

**Implementation Notes**

The changes are in the sw_three_end and sw_three_end_vatom kernels: checks for neighbors of j are within the cutoff and greater than zero. In a minimal test case (in.minimal.txt attached), the distance between j and k (rsq2) can even be zero when run with 4 MPI ranks.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**
[in.minimal.txt](https://github.com/lammps/lammps/files/8056652/in.minimal.txt)


<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


