### PR TITLE
Rename forward and reverse communication commands for data in classes

### DIFF
--- a/lib/atc/LammpsInterface.cpp
+++ b/lib/atc/LammpsInterface.cpp
@@ -103,7 +103,7 @@ LammpsInterface::LammpsInterface()
 
 MPI_Comm LammpsInterface::world() const { return lammps_->world; }
 void LammpsInterface::set_fix_pointer(LAMMPS_NS::Fix * thisFix) { fixPointer_ = thisFix; }
-void LammpsInterface::forward_comm_fix() const { lammps_->comm->forward_comm_fix(fixPointer_); }
+void LammpsInterface::forward_comm_fix() const { lammps_->comm->forward_comm(fixPointer_); }
 void LammpsInterface::comm_borders() const { lammps_->comm->borders(); }
 
 #ifndef ISOLATE_FE

--- a/src/ATC/fix_atc.cpp
+++ b/src/ATC/fix_atc.cpp
@@ -575,7 +575,7 @@ void FixATC::min_setup(int vflag)
 
 void FixATC::setup(int /* vflag */)
 {
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   try {
     atc_->initialize();
@@ -814,7 +814,7 @@ void FixATC::pre_neighbor()
 {
   try {
     atc_->pre_neighbor();
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
   catch (ATC::ATC_Error& atcError) {
     ATC::LammpsInterface::instance()->print_msg(atcError.error_description());

--- a/src/ATC/fix_atc.h
+++ b/src/ATC/fix_atc.h
@@ -80,12 +80,12 @@ class FixATC : public Fix {
        atom received from another processor. */
   int unpack_exchange(int, double *) override;
 
-  /** pack_comm called from comm->forward_comm_fix and
+  /** pack_comm called from comm->forward_comm and
        packs fix-specific data for a given ghost atom
        from exchange with another proc */
   int pack_forward_comm(int, int *, double *, int, int *) override;
 
-  /** unpack_comm called from comm->forward_comm_fix and
+  /** unpack_comm called from comm->forward_comm and
        unpacks fix-specific data for a given ghost atom
        from exchange with another proc */
   void unpack_forward_comm(int, int, double *) override;

--- a/src/CG-DNA/pair_oxdna_excv.cpp
+++ b/src/CG-DNA/pair_oxdna_excv.cpp
@@ -174,7 +174,7 @@ void PairOxdnaExcv::compute(int eflag, int vflag)
 
   }
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // loop over pair interaction neighbors of my atoms
 

--- a/src/COLLOID/pair_lubricate.cpp
+++ b/src/COLLOID/pair_lubricate.cpp
@@ -148,7 +148,7 @@ void PairLubricate::compute(int eflag, int vflag)
     // copy updated velocity/omega/angmom to the ghost particles
     // no need to do this if not shearing since comm->ghost_velocity is set
 
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   // This section of code adjusts R0/RT0/RS0 if necessary due to changes

--- a/src/COLLOID/pair_lubricateU.cpp
+++ b/src/COLLOID/pair_lubricateU.cpp
@@ -249,7 +249,7 @@ void PairLubricateU::stage_one()
 
   // set velocities for ghost particles
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // Find initial residual
 
@@ -284,7 +284,7 @@ void PairLubricateU::stage_one()
 
     // set velocities for ghost particles
 
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
 
     compute_RU();
 
@@ -343,7 +343,7 @@ void PairLubricateU::stage_one()
 
   // set velocities for ghost particles
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // Find actual particle's velocities from relative velocities
   // Only non-zero component of fluid's vel : vx=gdot*y and wz=-gdot/2
@@ -433,7 +433,7 @@ void PairLubricateU::stage_two(double **x)
 
   // set velocities for ghost particles
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // Find initial residual
 
@@ -468,7 +468,7 @@ void PairLubricateU::stage_two(double **x)
 
     // set velocities for ghost particles
 
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
 
     compute_RU(x);
 
@@ -527,7 +527,7 @@ void PairLubricateU::stage_two(double **x)
 
   // set velocities for ghost particles
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // Compute the viscosity/pressure
 

--- a/src/COLLOID/pair_lubricateU_poly.cpp
+++ b/src/COLLOID/pair_lubricateU_poly.cpp
@@ -198,7 +198,7 @@ void PairLubricateUPoly::iterate(double **x, int stage)
 
   // set velocities for ghost particles
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // Find initial residual
 
@@ -233,7 +233,7 @@ void PairLubricateUPoly::iterate(double **x, int stage)
 
     // set velocities for ghost particles
 
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
 
     compute_RU(x);
 
@@ -292,7 +292,7 @@ void PairLubricateUPoly::iterate(double **x, int stage)
 
   // set velocities for ghost particles
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // compute the viscosity/pressure
 

--- a/src/COLLOID/pair_lubricate_poly.cpp
+++ b/src/COLLOID/pair_lubricate_poly.cpp
@@ -130,7 +130,7 @@ void PairLubricatePoly::compute(int eflag, int vflag)
     // copy updated omega to the ghost particles
     // no need to do this if not shearing since comm->ghost_velocity is set
 
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   // This section of code adjusts R0/RT0/RS0 if necessary due to changes

--- a/src/CORESHELL/compute_temp_cs.cpp
+++ b/src/CORESHELL/compute_temp_cs.cpp
@@ -174,7 +174,7 @@ void ComputeTempCS::setup()
     // reverse comm to acquire unknown partner IDs from ghost atoms
     // only needed if newton_bond = on
 
-    if (force->newton_bond) comm->reverse_comm_compute(this);
+    if (force->newton_bond) comm->reverse_comm(this);
 
     // check that all C/S partners were found
 

--- a/src/DIELECTRIC/compute_efield_atom.cpp
+++ b/src/DIELECTRIC/compute_efield_atom.cpp
@@ -177,7 +177,7 @@ void ComputeEfieldAtom::compute_peratom()
   // communicate ghost efield between neighbor procs
 
   if (force->newton || (force->kspace && force->kspace->tip4pflag))
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
   // zero efield of atoms not in group
   // only do this after comm since ghost contributions must be included

--- a/src/DIELECTRIC/fix_polarize_bem_gmres.cpp
+++ b/src/DIELECTRIC/fix_polarize_bem_gmres.cpp
@@ -322,7 +322,7 @@ void FixPolarizeBEMGMRES::compute_induced_charges()
     if (induced_charge_idx[i] >= 0) q[i] = 0;
   }
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // note here q[i] are the bound charges including area
   // so that kspace solver can be used directly with the charge values
@@ -394,7 +394,7 @@ void FixPolarizeBEMGMRES::compute_induced_charges()
     }
   }
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   if (first) first = 0;
 }
@@ -602,7 +602,7 @@ void FixPolarizeBEMGMRES::apply_operator(double *w, double *Aw, int /*n*/)
     }
   }
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // compute the electrical field due to w*area: y = A (w*area)
 
@@ -672,7 +672,7 @@ void FixPolarizeBEMGMRES::update_residual(double *w, double *r, int /*n*/)
     }
   }
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   force_clear();
   force->pair->compute(eflag, vflag);

--- a/src/DIELECTRIC/fix_polarize_bem_icc.cpp
+++ b/src/DIELECTRIC/fix_polarize_bem_icc.cpp
@@ -251,7 +251,7 @@ void FixPolarizeBEMICC::compute_induced_charges()
     q[i] = q_free + q_bound;
   }
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // iterate
 
@@ -309,7 +309,7 @@ void FixPolarizeBEMICC::compute_induced_charges()
 #endif
     }
 
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     MPI_Allreduce(&tol, &rho, 1, MPI_DOUBLE, MPI_MAX, world);
 #ifdef _POLARIZE_DEBUG

--- a/src/DIELECTRIC/fix_polarize_functional.cpp
+++ b/src/DIELECTRIC/fix_polarize_functional.cpp
@@ -412,7 +412,7 @@ void FixPolarizeFunctional::charge_rescaled(int scaled2real)
       if (induced_charge_idx[i] < 0) q[i] = q_real[i] / epsilon[i];
   }
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/DPD-MESO/pair_mdpd_rhosum.cpp
+++ b/src/DPD-MESO/pair_mdpd_rhosum.cpp
@@ -157,7 +157,7 @@ void PairMDPDRhoSum::compute(int eflag, int vflag) {
   }
 
   // communicate densities
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/DPD-REACT/fix_eos_table_rx.cpp
+++ b/src/DPD-REACT/fix_eos_table_rx.cpp
@@ -203,7 +203,7 @@ void FixEOStableRX::setup(int /*vflag*/)
   }
 
   // Communicate the updated momenta and velocities to all nodes
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit)
@@ -285,7 +285,7 @@ void FixEOStableRX::end_of_step()
     }
 
   // Communicate the updated momenta and velocities to all nodes
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {

--- a/src/DPD-REACT/fix_eos_table_rx.cpp
+++ b/src/DPD-REACT/fix_eos_table_rx.cpp
@@ -274,7 +274,7 @@ void FixEOStableRX::end_of_step()
   double *uCGnew = atom->uCGnew;
 
   // Communicate the ghost uCGnew
-  comm->reverse_comm_fix(this);
+  comm->reverse_comm(this);
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {

--- a/src/DPD-REACT/fix_rx.cpp
+++ b/src/DPD-REACT/fix_rx.cpp
@@ -657,7 +657,7 @@ void FixRX::setup_pre_force(int /*vflag*/)
       }
 
     // Communicate the updated momenta and velocities to all nodes
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     if (localTempFlag) delete [] dpdThetaLocal;
 
     delete [] userData.kFor;
@@ -738,7 +738,7 @@ void FixRX::pre_force(int /*vflag*/)
   TimerType timer_ODE = getTimeStamp();
 
   // Communicate the updated momenta and velocities to all nodes
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   if (localTempFlag) delete [] dpdThetaLocal;
 
   //TimerType timer_stop = getTimeStamp();

--- a/src/DPD-REACT/fix_rx.cpp
+++ b/src/DPD-REACT/fix_rx.cpp
@@ -1768,7 +1768,7 @@ void FixRX::computeLocalTemperature()
       }
     }
   }
-  if (newton_pair) comm->reverse_comm_fix(this);
+  if (newton_pair) comm->reverse_comm(this);
 
   // self-interaction for local temperature
   for (i = 0; i < nlocal; i++) {

--- a/src/DPD-REACT/fix_shardlow.cpp
+++ b/src/DPD-REACT/fix_shardlow.cpp
@@ -607,7 +607,7 @@ void FixShardlow::initial_integrate(int /*vflag*/)
     int workItemCt = ssa_gphaseLen[workPhase];
 
     // Communicate the updated velocities to all nodes
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     if (useDPDE) {
       // Zero out the ghosts' uCond & uMech to be used as delta accumulators

--- a/src/DPD-REACT/fix_shardlow.cpp
+++ b/src/DPD-REACT/fix_shardlow.cpp
@@ -623,7 +623,7 @@ void FixShardlow::initial_integrate(int /*vflag*/)
     }
 
     // Communicate the ghost deltas to the atom owners
-    comm->reverse_comm_fix(this);
+    comm->reverse_comm(this);
 
   }  //End Loop over all directions For airnum = Top, Top-Right, Right, Bottom-Right, Back
 

--- a/src/DPD-REACT/pair_dpd_fdt_energy.cpp
+++ b/src/DPD-REACT/pair_dpd_fdt_energy.cpp
@@ -292,7 +292,7 @@ void PairDPDfdtEnergy::compute(int eflag, int vflag)
       }
     }
     // Communicate the ghost delta energies to the locally owned atoms
-    comm->reverse_comm_pair(this);
+    comm->reverse_comm(this);
   }
   if (vflag_fdotr) virial_fdotr_compute();
 

--- a/src/DPD-REACT/pair_multi_lucy.cpp
+++ b/src/DPD-REACT/pair_multi_lucy.cpp
@@ -774,7 +774,7 @@ void PairMultiLucy::computeLocalDensity()
       }
     }
   }
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
 
   comm->forward_comm(this);
 

--- a/src/DPD-REACT/pair_multi_lucy.cpp
+++ b/src/DPD-REACT/pair_multi_lucy.cpp
@@ -776,7 +776,7 @@ void PairMultiLucy::computeLocalDensity()
   }
   if (newton_pair) comm->reverse_comm_pair(this);
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
 }
 /* ---------------------------------------------------------------------- */

--- a/src/DPD-REACT/pair_multi_lucy_rx.cpp
+++ b/src/DPD-REACT/pair_multi_lucy_rx.cpp
@@ -934,7 +934,7 @@ void PairMultiLucyRX::computeLocalDensity()
 
     rho[i] = rho_i;
   }
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
 
   comm->forward_comm(this);
 

--- a/src/DPD-REACT/pair_multi_lucy_rx.cpp
+++ b/src/DPD-REACT/pair_multi_lucy_rx.cpp
@@ -936,7 +936,7 @@ void PairMultiLucyRX::computeLocalDensity()
   }
   if (newton_pair) comm->reverse_comm_pair(this);
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
 }
 

--- a/src/DRUDE/fix_drude_transform.cpp
+++ b/src/DRUDE/fix_drude_transform.cpp
@@ -107,30 +107,30 @@ void FixDrudeTransform<inverse>::setup(int) {
 namespace LAMMPS_NS { // required for specialization
 template <>
 void FixDrudeTransform<false>::initial_integrate(int) {
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   real_to_reduced();
-  //comm->forward_comm_fix(this); // Normally not needed
+  //comm->forward_comm(this); // Normally not needed
 }
 
 template <>
 void FixDrudeTransform<false>::final_integrate() {
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   real_to_reduced();
-  //comm->forward_comm_fix(this); // Normally not needed
+  //comm->forward_comm(this); // Normally not needed
 }
 
 template <>
 void FixDrudeTransform<true>::initial_integrate(int) {
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   reduced_to_real();
-  //comm->forward_comm_fix(this); // Normally not needed
+  //comm->forward_comm(this); // Normally not needed
 }
 
 template <>
 void FixDrudeTransform<true>::final_integrate() {
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   reduced_to_real();
-  //comm->forward_comm_fix(this); // Normally not needed
+  //comm->forward_comm(this); // Normally not needed
 }
 
 } // end of namespace

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -145,7 +145,7 @@ void ComputeAveSphereAtom::compute_peratom()
 
   // need velocities of ghost atoms
 
-  comm->forward_comm_compute(this);
+  comm->forward_comm(this);
 
   // invoke full neighbor list (will copy or build if necessary)
 

--- a/src/EXTRA-COMPUTE/compute_hma.cpp
+++ b/src/EXTRA-COMPUTE/compute_hma.cpp
@@ -286,7 +286,7 @@ void ComputeHMA::compute_vector()
 
   double phiSum = 0.0;
   if (computeCv>-1) {
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
     double** cutsq = force->pair->cutsq;
     if (force->pair) {
       double **x = atom->x;

--- a/src/EXTRA-FIX/fix_filter_corotate.cpp
+++ b/src/EXTRA-FIX/fix_filter_corotate.cpp
@@ -715,7 +715,7 @@ void FixFilterCorotate::post_force_respa(int /*vflag*/, int ilevel, int /*iloop*
   {
     atom->x = x_store;
 
-    comm->forward_comm_fix(this); //comm forward of forces for outer filter
+    comm->forward_comm(this); //comm forward of forces for outer filter
 
     filter_outer();
   }

--- a/src/GPU/pair_eam_alloy_gpu.cpp
+++ b/src/GPU/pair_eam_alloy_gpu.cpp
@@ -142,7 +142,7 @@ void PairEAMAlloyGPU::compute(int eflag, int vflag)
 
   // communicate derivative of embedding function
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // compute forces on each atom on GPU
   if (gpu_mode != GPU_FORCE)

--- a/src/GPU/pair_eam_fs_gpu.cpp
+++ b/src/GPU/pair_eam_fs_gpu.cpp
@@ -141,7 +141,7 @@ void PairEAMFSGPU::compute(int eflag, int vflag)
 
   // communicate derivative of embedding function
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // compute forces on each atom on GPU
   if (gpu_mode != GPU_FORCE)

--- a/src/GPU/pair_eam_gpu.cpp
+++ b/src/GPU/pair_eam_gpu.cpp
@@ -139,7 +139,7 @@ void PairEAMGPU::compute(int eflag, int vflag)
 
   // communicate derivative of embedding function
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // compute forces on each atom on GPU
   if (gpu_mode != GPU_FORCE)

--- a/src/GRANULAR/compute_contact_atom.cpp
+++ b/src/GRANULAR/compute_contact_atom.cpp
@@ -154,7 +154,7 @@ void ComputeContactAtom::compute_peratom()
 
   // communicate ghost atom counts between neighbor procs if necessary
 
-  if (force->newton_pair) comm->reverse_comm_compute(this);
+  if (force->newton_pair) comm->reverse_comm(this);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/GRANULAR/pair_gran_hertz_history.cpp
+++ b/src/GRANULAR/pair_gran_hertz_history.cpp
@@ -76,7 +76,7 @@ void PairGranHertzHistory::compute(int eflag, int vflag)
     for (i = 0; i < nlocal; i++)
       if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
       else mass_rigid[i] = 0.0;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   double **x = atom->x;

--- a/src/GRANULAR/pair_gran_hooke.cpp
+++ b/src/GRANULAR/pair_gran_hooke.cpp
@@ -69,7 +69,7 @@ void PairGranHooke::compute(int eflag, int vflag)
     for (i = 0; i < nlocal; i++)
       if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
       else mass_rigid[i] = 0.0;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   double **x = atom->x;

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -138,7 +138,7 @@ void PairGranHookeHistory::compute(int eflag, int vflag)
         mass_rigid[i] = mass_body[body[i]];
       else
         mass_rigid[i] = 0.0;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   double **x = atom->x;

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -209,7 +209,7 @@ void PairGranular::compute(int eflag, int vflag)
     for (i = 0; i < nlocal; i++)
       if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
       else mass_rigid[i] = 0.0;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   double **x = atom->x;

--- a/src/INTEL/pair_eam_intel.cpp
+++ b/src/INTEL/pair_eam_intel.cpp
@@ -474,7 +474,7 @@ void PairEAMIntel::eval(const int offload, const int vflag,
       #endif
 
       if (tid == 0)
-        comm->forward_comm_pair(this);
+        comm->forward_comm(this);
 
       #if defined(_OPENMP)
       #pragma omp barrier

--- a/src/INTEL/pair_eam_intel.cpp
+++ b/src/INTEL/pair_eam_intel.cpp
@@ -416,7 +416,7 @@ void PairEAMIntel::eval(const int offload, const int vflag,
 
       if (NEWTON_PAIR) {
         if (tid == 0)
-          comm->reverse_comm_pair(this);
+          comm->reverse_comm(this);
       }
       #if defined(_OPENMP)
       #pragma omp barrier

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -259,7 +259,7 @@ void PairKIM::compute(int eflag, int vflag)
 
   // if newton is off, perform reverse comm
   if (!lmps_using_newton) {
-    comm->reverse_comm_pair(this);
+    comm->reverse_comm(this);
   }
 
   if ((vflag_atom != 0) &&

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -439,10 +439,10 @@ void CommKokkos::forward_comm_device(Fix *fix, int size)
 
 /* ---------------------------------------------------------------------- */
 
-void CommKokkos::reverse_comm_fix(Fix *fix, int size)
+void CommKokkos::reverse_comm(Fix *fix, int size)
 {
   k_sendlist.sync<LMPHostType>();
-  CommBrick::reverse_comm_fix(fix, size);
+  CommBrick::reverse_comm(fix, size);
 }
 
 void CommKokkos::forward_comm(Compute *compute)
@@ -451,10 +451,10 @@ void CommKokkos::forward_comm(Compute *compute)
   CommBrick::forward_comm(compute);
 }
 
-void CommKokkos::reverse_comm_compute(Compute *compute)
+void CommKokkos::reverse_comm(Compute *compute)
 {
   k_sendlist.sync<LMPHostType>();
-  CommBrick::reverse_comm_compute(compute);
+  CommBrick::reverse_comm(compute);
 }
 
 void CommKokkos::forward_comm(Pair *pair)
@@ -543,10 +543,10 @@ void CommKokkos::grow_buf_fix(int n) {
   k_buf_recv_fix.resize(max_buf_fix);
 }
 
-void CommKokkos::reverse_comm_pair(Pair *pair)
+void CommKokkos::reverse_comm(Pair *pair)
 {
   k_sendlist.sync<LMPHostType>();
-  CommBrick::reverse_comm_pair(pair);
+  CommBrick::reverse_comm(pair);
 }
 
 void CommKokkos::forward_comm(Dump *dump)
@@ -555,10 +555,10 @@ void CommKokkos::forward_comm(Dump *dump)
   CommBrick::forward_comm(dump);
 }
 
-void CommKokkos::reverse_comm_dump(Dump *dump)
+void CommKokkos::reverse_comm(Dump *dump)
 {
   k_sendlist.sync<LMPHostType>();
-  CommBrick::reverse_comm_dump(dump);
+  CommBrick::reverse_comm(dump);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -362,19 +362,19 @@ void CommKokkos::reverse_comm_device()
 
 /* ---------------------------------------------------------------------- */
 
-void CommKokkos::forward_comm_fix(Fix *fix, int size)
+void CommKokkos::forward_comm(Fix *fix, int size)
 {
   if (fix->execution_space == Host || !fix->forward_comm_device || forward_fix_comm_classic) {
     k_sendlist.sync<LMPHostType>();
-    CommBrick::forward_comm_fix(fix,size);
+    CommBrick::forward_comm(fix,size);
   } else {
     k_sendlist.sync<LMPDeviceType>();
-    forward_comm_fix_device<LMPDeviceType>(fix);
+    forward_comm_device<LMPDeviceType>(fix);
   }
 }
 
 template<class DeviceType>
-void CommKokkos::forward_comm_fix_device(Fix *fix, int size)
+void CommKokkos::forward_comm_device(Fix *fix, int size)
 {
   int iswap,n,nsize;
   MPI_Request request;
@@ -395,7 +395,7 @@ void CommKokkos::forward_comm_fix_device(Fix *fix, int size)
 
     // pack buffer
 
-    n = fixKKBase->pack_forward_comm_fix_kokkos(sendnum[iswap],k_sendlist,
+    n = fixKKBase->pack_forward_comm_kokkos(sendnum[iswap],k_sendlist,
                                       iswap,k_buf_send_fix,pbc_flag[iswap],pbc[iswap]);
     DeviceType().fence();
 
@@ -432,7 +432,7 @@ void CommKokkos::forward_comm_fix_device(Fix *fix, int size)
 
     // unpack buffer
 
-    fixKKBase->unpack_forward_comm_fix_kokkos(recvnum[iswap],firstrecv[iswap],k_buf_tmp);
+    fixKKBase->unpack_forward_comm_kokkos(recvnum[iswap],firstrecv[iswap],k_buf_tmp);
     DeviceType().fence();
   }
 }
@@ -445,10 +445,10 @@ void CommKokkos::reverse_comm_fix(Fix *fix, int size)
   CommBrick::reverse_comm_fix(fix, size);
 }
 
-void CommKokkos::forward_comm_compute(Compute *compute)
+void CommKokkos::forward_comm(Compute *compute)
 {
   k_sendlist.sync<LMPHostType>();
-  CommBrick::forward_comm_compute(compute);
+  CommBrick::forward_comm(compute);
 }
 
 void CommKokkos::reverse_comm_compute(Compute *compute)
@@ -457,19 +457,19 @@ void CommKokkos::reverse_comm_compute(Compute *compute)
   CommBrick::reverse_comm_compute(compute);
 }
 
-void CommKokkos::forward_comm_pair(Pair *pair)
+void CommKokkos::forward_comm(Pair *pair)
 {
   if (pair->execution_space == Host || forward_pair_comm_classic) {
     k_sendlist.sync<LMPHostType>();
-    CommBrick::forward_comm_pair(pair);
+    CommBrick::forward_comm(pair);
   } else {
     k_sendlist.sync<LMPDeviceType>();
-    forward_comm_pair_device<LMPDeviceType>(pair);
+    forward_comm_device<LMPDeviceType>(pair);
   }
 }
 
 template<class DeviceType>
-void CommKokkos::forward_comm_pair_device(Pair *pair)
+void CommKokkos::forward_comm_device(Pair *pair)
 {
   int iswap,n;
   MPI_Request request;
@@ -549,10 +549,10 @@ void CommKokkos::reverse_comm_pair(Pair *pair)
   CommBrick::reverse_comm_pair(pair);
 }
 
-void CommKokkos::forward_comm_dump(Dump *dump)
+void CommKokkos::forward_comm(Dump *dump)
 {
   k_sendlist.sync<LMPHostType>();
-  CommBrick::forward_comm_dump(dump);
+  CommBrick::forward_comm(dump);
 }
 
 void CommKokkos::reverse_comm_dump(Dump *dump)

--- a/src/KOKKOS/comm_kokkos.h
+++ b/src/KOKKOS/comm_kokkos.h
@@ -43,13 +43,13 @@ class CommKokkos : public CommBrick {
   void borders() override;                      // setup list of atoms to comm
 
   void forward_comm(class Pair *) override;    // forward comm from a Pair
-  void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
+  void reverse_comm(class Pair *) override;    // reverse comm from a Pair
   void forward_comm(class Fix *, int size=0) override;      // forward comm from a Fix
-  void reverse_comm_fix(class Fix *, int size=0) override;      // reverse comm from a Fix
+  void reverse_comm(class Fix *, int size=0) override;      // reverse comm from a Fix
   void forward_comm(class Compute *) override;  // forward from a Compute
-  void reverse_comm_compute(class Compute *) override;  // reverse from a Compute
+  void reverse_comm(class Compute *) override;  // reverse from a Compute
   void forward_comm(class Dump *) override;    // forward comm from a Dump
-  void reverse_comm_dump(class Dump *) override;    // reverse comm from a Dump
+  void reverse_comm(class Dump *) override;    // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;            // forward comm of array
 

--- a/src/KOKKOS/comm_kokkos.h
+++ b/src/KOKKOS/comm_kokkos.h
@@ -42,21 +42,21 @@ class CommKokkos : public CommBrick {
   void exchange() override;                     // move atoms to new procs
   void borders() override;                      // setup list of atoms to comm
 
-  void forward_comm_pair(class Pair *) override;    // forward comm from a Pair
+  void forward_comm(class Pair *) override;    // forward comm from a Pair
   void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
-  void forward_comm_fix(class Fix *, int size=0) override;      // forward comm from a Fix
+  void forward_comm(class Fix *, int size=0) override;      // forward comm from a Fix
   void reverse_comm_fix(class Fix *, int size=0) override;      // reverse comm from a Fix
-  void forward_comm_compute(class Compute *) override;  // forward from a Compute
+  void forward_comm(class Compute *) override;  // forward from a Compute
   void reverse_comm_compute(class Compute *) override;  // reverse from a Compute
-  void forward_comm_dump(class Dump *) override;    // forward comm from a Dump
+  void forward_comm(class Dump *) override;    // forward comm from a Dump
   void reverse_comm_dump(class Dump *) override;    // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;            // forward comm of array
 
   template<class DeviceType> void forward_comm_device(int dummy);
   template<class DeviceType> void reverse_comm_device();
-  template<class DeviceType> void forward_comm_pair_device(Pair *pair);
-  template<class DeviceType> void forward_comm_fix_device(Fix *fix, int size=0);
+  template<class DeviceType> void forward_comm_device(Pair *pair);
+  template<class DeviceType> void forward_comm_device(Fix *fix, int size=0);
   template<class DeviceType> void exchange_device();
   template<class DeviceType> void borders_device();
 

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -147,9 +147,9 @@ void CommTiledKokkos::forward_comm(Pair *pair)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::reverse_comm_pair(Pair *pair)
+void CommTiledKokkos::reverse_comm(Pair *pair)
 {
-  CommTiled::reverse_comm_pair(pair);
+  CommTiled::reverse_comm(pair);
 }
 
 /* ----------------------------------------------------------------------
@@ -175,9 +175,9 @@ void CommTiledKokkos::forward_comm(Fix *fix, int size)
      some are smaller than max stored in its comm_forward
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::reverse_comm_fix(Fix *fix, int size)
+void CommTiledKokkos::reverse_comm(Fix *fix, int size)
 {
-  CommTiled::reverse_comm_fix(fix,size);
+  CommTiled::reverse_comm(fix,size);
 }
 
 /* ----------------------------------------------------------------------
@@ -187,9 +187,9 @@ void CommTiledKokkos::reverse_comm_fix(Fix *fix, int size)
    NOTE: how to setup one big buf recv with correct offsets ??
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::reverse_comm_fix_variable(Fix *fix)
+void CommTiledKokkos::reverse_comm_variable(Fix *fix)
 {
-  CommTiled::reverse_comm_fix_variable(fix);
+  CommTiled::reverse_comm_variable(fix);
 }
 
 /* ----------------------------------------------------------------------
@@ -207,9 +207,9 @@ void CommTiledKokkos::forward_comm(Compute *compute)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::reverse_comm_compute(Compute *compute)
+void CommTiledKokkos::reverse_comm(Compute *compute)
 {
-  CommTiled::reverse_comm_compute(compute);
+  CommTiled::reverse_comm(compute);
 }
 
 /* ----------------------------------------------------------------------
@@ -227,9 +227,9 @@ void CommTiledKokkos::forward_comm(Dump *dump)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::reverse_comm_dump(Dump *dump)
+void CommTiledKokkos::reverse_comm(Dump *dump)
 {
-  CommTiled::reverse_comm_dump(dump);
+  CommTiled::reverse_comm(dump);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -137,9 +137,9 @@ void CommTiledKokkos::borders()
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::forward_comm_pair(Pair *pair)
+void CommTiledKokkos::forward_comm(Pair *pair)
 {
-  CommTiled::forward_comm_pair(pair);
+  CommTiled::forward_comm(pair);
 }
 
 /* ----------------------------------------------------------------------
@@ -161,9 +161,9 @@ void CommTiledKokkos::reverse_comm_pair(Pair *pair)
      some are smaller than max stored in its comm_forward
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::forward_comm_fix(Fix *fix, int size)
+void CommTiledKokkos::forward_comm(Fix *fix, int size)
 {
-  CommTiled::forward_comm_fix(fix,size);
+  CommTiled::forward_comm(fix,size);
 }
 
 /* ----------------------------------------------------------------------
@@ -197,9 +197,9 @@ void CommTiledKokkos::reverse_comm_fix_variable(Fix *fix)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::forward_comm_compute(Compute *compute)
+void CommTiledKokkos::forward_comm(Compute *compute)
 {
-  CommTiled::forward_comm_compute(compute);
+  CommTiled::forward_comm(compute);
 }
 
 /* ----------------------------------------------------------------------
@@ -217,9 +217,9 @@ void CommTiledKokkos::reverse_comm_compute(Compute *compute)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiledKokkos::forward_comm_dump(Dump *dump)
+void CommTiledKokkos::forward_comm(Dump *dump)
 {
-  CommTiled::forward_comm_dump(dump);
+  CommTiled::forward_comm(dump);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/comm_tiled_kokkos.h
+++ b/src/KOKKOS/comm_tiled_kokkos.h
@@ -31,17 +31,17 @@ class CommTiledKokkos : public CommTiled {
   void exchange() override;                     // move atoms to new procs
   void borders() override;                      // setup list of atoms to comm
 
-  void forward_comm_pair(class Pair *) override;    // forward comm from a Pair
+  void forward_comm(class Pair *) override;    // forward comm from a Pair
   void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
-  void forward_comm_fix(class Fix *, int size=0) override;
+  void forward_comm(class Fix *, int size=0) override;
                                                    // forward comm from a Fix
   void reverse_comm_fix(class Fix *, int size=0) override;
                                                    // reverse comm from a Fix
   void reverse_comm_fix_variable(class Fix *) override;
                                      // variable size reverse comm from a Fix
-  void forward_comm_compute(class Compute *) override;  // forward from a Compute
+  void forward_comm(class Compute *) override;  // forward from a Compute
   void reverse_comm_compute(class Compute *) override;  // reverse from a Compute
-  void forward_comm_dump(class Dump *) override;    // forward comm from a Dump
+  void forward_comm(class Dump *) override;    // forward comm from a Dump
   void reverse_comm_dump(class Dump *) override;    // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;          // forward comm of array

--- a/src/KOKKOS/comm_tiled_kokkos.h
+++ b/src/KOKKOS/comm_tiled_kokkos.h
@@ -32,17 +32,17 @@ class CommTiledKokkos : public CommTiled {
   void borders() override;                      // setup list of atoms to comm
 
   void forward_comm(class Pair *) override;    // forward comm from a Pair
-  void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
+  void reverse_comm(class Pair *) override;    // reverse comm from a Pair
   void forward_comm(class Fix *, int size=0) override;
                                                    // forward comm from a Fix
-  void reverse_comm_fix(class Fix *, int size=0) override;
+  void reverse_comm(class Fix *, int size=0) override;
                                                    // reverse comm from a Fix
-  void reverse_comm_fix_variable(class Fix *) override;
+  void reverse_comm_variable(class Fix *) override;
                                      // variable size reverse comm from a Fix
   void forward_comm(class Compute *) override;  // forward from a Compute
-  void reverse_comm_compute(class Compute *) override;  // reverse from a Compute
+  void reverse_comm(class Compute *) override;  // reverse from a Compute
   void forward_comm(class Dump *) override;    // forward comm from a Dump
-  void reverse_comm_dump(class Dump *) override;    // reverse comm from a Dump
+  void reverse_comm(class Dump *) override;    // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;          // forward comm of array
   int exchange_variable(int, double *, double *&) override;  // exchange on neigh stencil

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -97,7 +97,7 @@ void ComputeAveSphereAtomKokkos<DeviceType>::compute_peratom()
   // need velocities of ghost atoms
 
   atomKK->sync(Host,V_MASK);
-  comm->forward_comm_compute(this);
+  comm->forward_comm(this);
   atomKK->modified(Host,V_MASK);
 
   // invoke full neighbor list (will copy or build if necessary)

--- a/src/KOKKOS/compute_coord_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_coord_atom_kokkos.cpp
@@ -119,7 +119,7 @@ void ComputeCoordAtomKokkos<DeviceType>::compute_peratom()
     }
     nqlist = c_orientorder->nqlist;
     normv = c_orientorder->array_atom;
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
 
     if (!c_orientorder->kokkosable)
       error->all(FLERR,"Must use compute orientorder/atom/kk with compute coord/atom/kk");

--- a/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
@@ -403,10 +403,10 @@ void FixACKS2ReaxFFKokkos<DeviceType>::pre_force(int vflag)
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagACKS2InitMatvec>(0,nn),*this);
 
   pack_flag = 2;
-  // comm->forward_comm_fix(this); //Dist_vector( s );
+  // comm->forward_comm(this); //Dist_vector( s );
   k_s.template modify<DeviceType>();
   k_s.template sync<LMPHostType>();
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   more_forward_comm(k_s.h_view.data());
   k_s.template modify<LMPHostType>();
   k_s.template sync<DeviceType>();
@@ -1264,10 +1264,10 @@ int FixACKS2ReaxFFKokkos<DeviceType>::bicgstab_solve()
     }
 
     pack_flag = 1;
-    // comm->forward_comm_fix(this); //Dist_vector( d );
+    // comm->forward_comm(this); //Dist_vector( d );
     k_d.template modify<DeviceType>();
     k_d.template sync<LMPHostType>();
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     more_forward_comm(k_d.h_view.data());
     k_d.template modify<LMPHostType>();
     k_d.template sync<DeviceType>();
@@ -1310,10 +1310,10 @@ int FixACKS2ReaxFFKokkos<DeviceType>::bicgstab_solve()
 
     // sparse_matvec( &H, &X, q_hat, y );
     pack_flag = 3;
-    // comm->forward_comm_fix(this); //Dist_vector( q_hat );
+    // comm->forward_comm(this); //Dist_vector( q_hat );
     k_q_hat.template modify<DeviceType>();
     k_q_hat.template sync<LMPHostType>();
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     more_forward_comm(k_q_hat.h_view.data());
     k_q_hat.template modify<LMPHostType>();
     k_q_hat.template sync<DeviceType>();
@@ -1378,10 +1378,10 @@ void FixACKS2ReaxFFKokkos<DeviceType>::calculate_Q()
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagACKS2CalculateQ1>(0,nn),*this);
 
   pack_flag = 2;
-  //comm->forward_comm_fix( this ); //Dist_vector( s );
+  //comm->forward_comm( this ); //Dist_vector( s );
   k_s.modify<DeviceType>();
   k_s.sync<LMPHostType>();
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   k_s.modify<LMPHostType>();
   k_s.sync<DeviceType>();
 

--- a/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
@@ -385,10 +385,10 @@ void FixACKS2ReaxFFKokkos<DeviceType>::pre_force(int vflag)
 
   if (neighflag != FULL) {
     pack_flag = 4;
-    //comm->reverse_comm_fix(this); //Coll_Vector( X_diag );
+    //comm->reverse_comm(this); //Coll_Vector( X_diag );
     k_X_diag.template modify<DeviceType>();
     k_X_diag.template sync<LMPHostType>();
-    comm->reverse_comm_fix(this);
+    comm->reverse_comm(this);
     k_X_diag.template modify<LMPHostType>();
     k_X_diag.template sync<DeviceType>();
   }
@@ -1215,7 +1215,7 @@ int FixACKS2ReaxFFKokkos<DeviceType>::bicgstab_solve()
   k_d.template modify<DeviceType>();
   k_d.template sync<LMPHostType>();
   if (neighflag != FULL)
-    comm->reverse_comm_fix(this); //Coll_vector( d );
+    comm->reverse_comm(this); //Coll_vector( d );
   more_reverse_comm(k_d.h_view.data());
   k_d.template modify<LMPHostType>();
   k_d.template sync<DeviceType>();
@@ -1279,7 +1279,7 @@ int FixACKS2ReaxFFKokkos<DeviceType>::bicgstab_solve()
     k_z.template modify<DeviceType>();
     k_z.template sync<LMPHostType>();
     if (neighflag != FULL)
-      comm->reverse_comm_fix(this); //Coll_vector( z );
+      comm->reverse_comm(this); //Coll_vector( z );
     more_reverse_comm(k_z.h_view.data());
     k_z.template modify<LMPHostType>();
     k_z.template sync<DeviceType>();
@@ -1324,7 +1324,7 @@ int FixACKS2ReaxFFKokkos<DeviceType>::bicgstab_solve()
     k_y.template modify<DeviceType>();
     k_y.template sync<LMPHostType>();
     if (neighflag != FULL)
-      comm->reverse_comm_fix(this); //Coll_vector( y );
+      comm->reverse_comm(this); //Coll_vector( y );
     more_reverse_comm(k_y.h_view.data());
     k_y.template modify<LMPHostType>();
     k_y.template sync<DeviceType>();

--- a/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
@@ -265,7 +265,7 @@ void FixEOStableRXKokkos<DeviceType>::end_of_step()
 
   // Communicate the ghost uCGnew
   atomKK->sync(Host,UCG_MASK | UCGNEW_MASK);
-  comm->reverse_comm_fix(this);
+  comm->reverse_comm(this);
   atomKK->modified(Host,UCG_MASK | UCGNEW_MASK);
 
   atomKK->sync(execution_space,MASK_MASK | UCHEM_MASK | UCG_MASK | UCGNEW_MASK);

--- a/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
@@ -125,7 +125,7 @@ void FixEOStableRXKokkos<DeviceType>::setup(int /*vflag*/)
 
   // Communicate the updated momenta and velocities to all nodes
   atomKK->sync(Host,UCHEM_MASK | UCG_MASK | UCGNEW_MASK);
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   atomKK->modified(Host,UCHEM_MASK | UCG_MASK | UCGNEW_MASK);
 
   atomKK->sync(execution_space,MASK_MASK | UCOND_MASK | UMECH_MASK | UCHEM_MASK | DPDTHETA_MASK | DVECTOR_MASK);
@@ -274,7 +274,7 @@ void FixEOStableRXKokkos<DeviceType>::end_of_step()
 
   // Communicate the updated momenta and velocities to all nodes
   atomKK->sync(Host,UCHEM_MASK | UCG_MASK | UCGNEW_MASK);
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   atomKK->modified(Host,UCHEM_MASK | UCG_MASK | UCGNEW_MASK);
 
   atomKK->sync(execution_space,MASK_MASK | UCOND_MASK | UMECH_MASK | UCHEM_MASK | DPDTHETA_MASK | DVECTOR_MASK);

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
@@ -264,16 +264,16 @@ void FixQEqReaxFFKokkos<DeviceType>::pre_force(int /*vflag*/)
   FixQEqReaxFFKokkosMatVecFunctor<DeviceType> matvec_functor(this);
   Kokkos::parallel_for(inum,matvec_functor);
 
-  // comm->forward_comm_fix(this); //Dist_vector(s);
+  // comm->forward_comm(this); //Dist_vector(s);
   pack_flag = 2;
   k_s.template modify<DeviceType>();
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   k_s.template sync<DeviceType>();
 
-  // comm->forward_comm_fix(this); //Dist_vector(t);
+  // comm->forward_comm(this); //Dist_vector(t);
   pack_flag = 3;
   k_t.template modify<DeviceType>();
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   k_t.template sync<DeviceType>();
 
   need_dup = lmp->kokkos->need_dup<DeviceType>();
@@ -785,10 +785,10 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve1()
   int loop;
   for (loop = 1; (loop < imax) && (sqrt(sig_new)/b_norm > tolerance); loop++) {
 
-    // comm->forward_comm_fix(this); //Dist_vector(d);
+    // comm->forward_comm(this); //Dist_vector(d);
     pack_flag = 1;
     k_d.template modify<DeviceType>();
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     k_d.template sync<DeviceType>();
 
     // sparse_matvec(&H, d, q);
@@ -915,10 +915,10 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve2()
   int loop;
   for (loop = 1; (loop < imax) && (sqrt(sig_new)/b_norm > tolerance); loop++) {
 
-    // comm->forward_comm_fix(this); //Dist_vector(d);
+    // comm->forward_comm(this); //Dist_vector(d);
     pack_flag = 1;
     k_d.template modify<DeviceType>();
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     k_d.template sync<DeviceType>();
 
     // sparse_matvec(&H, d, q);
@@ -1016,8 +1016,8 @@ void FixQEqReaxFFKokkos<DeviceType>::calculate_q()
   atomKK->modified(execution_space,Q_MASK);
 
   pack_flag = 4;
-  //comm->forward_comm_fix(this); //Dist_vector(atom->q);
-  comm->forward_comm_fix(this);
+  //comm->forward_comm(this); //Dist_vector(atom->q);
+  comm->forward_comm(this);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1347,7 +1347,7 @@ void FixQEqReaxFFKokkos<DeviceType>::calculate_q_item(int ii) const
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-int FixQEqReaxFFKokkos<DeviceType>::pack_forward_comm_fix_kokkos(int n, DAT::tdual_int_2d k_sendlist,
+int FixQEqReaxFFKokkos<DeviceType>::pack_forward_comm_kokkos(int n, DAT::tdual_int_2d k_sendlist,
                                                         int iswap_in, DAT::tdual_xfloat_1d &k_buf,
                                                         int /*pbc_flag*/, int * /*pbc*/)
 {
@@ -1376,7 +1376,7 @@ void FixQEqReaxFFKokkos<DeviceType>::operator()(TagFixQEqReaxFFPackForwardComm, 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-void FixQEqReaxFFKokkos<DeviceType>::unpack_forward_comm_fix_kokkos(int n, int first_in, DAT::tdual_xfloat_1d &buf)
+void FixQEqReaxFFKokkos<DeviceType>::unpack_forward_comm_kokkos(int n, int first_in, DAT::tdual_xfloat_1d &buf)
 {
   first = first_in;
   d_buf = buf.view<DeviceType>();

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
@@ -760,7 +760,7 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve1()
 
   if (neighflag != FULL) {
     k_o.template modify<DeviceType>();
-    comm->reverse_comm_fix(this); //Coll_vector(q);
+    comm->reverse_comm(this); //Coll_vector(q);
     k_o.template sync<DeviceType>();
   }
 
@@ -813,7 +813,7 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve1()
 
     if (neighflag != FULL) {
       k_o.template modify<DeviceType>();
-      comm->reverse_comm_fix(this); //Coll_vector(q);
+      comm->reverse_comm(this); //Coll_vector(q);
       k_o.template sync<DeviceType>();
     }
 
@@ -890,7 +890,7 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve2()
 
   if (neighflag != FULL) {
     k_o.template modify<DeviceType>();
-    comm->reverse_comm_fix(this); //Coll_vector(q);
+    comm->reverse_comm(this); //Coll_vector(q);
     k_o.template sync<DeviceType>();
   }
 
@@ -943,7 +943,7 @@ int FixQEqReaxFFKokkos<DeviceType>::cg_solve2()
 
     if (neighflag != FULL) {
       k_o.template modify<DeviceType>();
-      comm->reverse_comm_fix(this); //Coll_vector(q);
+      comm->reverse_comm(this); //Coll_vector(q);
       k_o.template sync<DeviceType>();
     }
 

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.h
@@ -157,9 +157,9 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
     F_FLOAT chi, eta, gamma;
   };
 
-  int pack_forward_comm_fix_kokkos(int, DAT::tdual_int_2d, int, DAT::tdual_xfloat_1d&,
+  int pack_forward_comm_kokkos(int, DAT::tdual_int_2d, int, DAT::tdual_xfloat_1d&,
                        int, int *) override;
-  void unpack_forward_comm_fix_kokkos(int, int, DAT::tdual_xfloat_1d&) override;
+  void unpack_forward_comm_kokkos(int, int, DAT::tdual_xfloat_1d&) override;
   int pack_forward_comm(int, int *, double *, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;
   int pack_reverse_comm(int, int, double *) override;

--- a/src/KOKKOS/fix_reaxff_species_kokkos.cpp
+++ b/src/KOKKOS/fix_reaxff_species_kokkos.cpp
@@ -102,7 +102,7 @@ void FixReaxFFSpeciesKokkos::FindMolecule()
 
   loop = 0;
   while (1) {
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     loop ++;
 
     change = 0;

--- a/src/KOKKOS/fix_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_rx_kokkos.cpp
@@ -1673,7 +1673,7 @@ void FixRxKokkos<DeviceType>::solve_reactions(const int /*vflag*/, const bool is
   // Communicate the updated species data to all nodes
   atomKK->sync ( Host, DVECTOR_MASK );
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   atomKK->modified ( Host, DVECTOR_MASK );
 

--- a/src/KOKKOS/fix_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_rx_kokkos.cpp
@@ -2162,7 +2162,7 @@ void FixRxKokkos<DeviceType>::computeLocalTemperature()
   k_sumWeights.   template modify<DeviceType>();
 
   // Communicate the sum dpdTheta and the weights on the host.
-  if (NEWTON_PAIR) comm->reverse_comm_fix(this);
+  if (NEWTON_PAIR) comm->reverse_comm(this);
 
   // Update the device view in case they got changed.
   k_dpdThetaLocal.template sync<DeviceType>();

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -341,7 +341,7 @@ void FixShakeKokkos<DeviceType>::post_force(int vflag)
   // communicate results if necessary
 
   unconstrained_update();
-  if (nprocs > 1) comm->forward_comm_fix(this);
+  if (nprocs > 1) comm->forward_comm(this);
   k_xshake.sync<DeviceType>();
 
   // virial setup
@@ -1528,7 +1528,7 @@ int FixShakeKokkos<DeviceType>::unpack_exchange(int nlocal, double *buf)
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-int FixShakeKokkos<DeviceType>::pack_forward_comm_fix_kokkos(int n, DAT::tdual_int_2d k_sendlist,
+int FixShakeKokkos<DeviceType>::pack_forward_comm_kokkos(int n, DAT::tdual_int_2d k_sendlist,
                                                         int iswap_in, DAT::tdual_xfloat_1d &k_buf,
                                                         int pbc_flag, int* pbc)
 {
@@ -1588,7 +1588,7 @@ int FixShakeKokkos<DeviceType>::pack_forward_comm(int n, int *list, double *buf,
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-void FixShakeKokkos<DeviceType>::unpack_forward_comm_fix_kokkos(int n, int first_in, DAT::tdual_xfloat_1d &buf)
+void FixShakeKokkos<DeviceType>::unpack_forward_comm_kokkos(int n, int first_in, DAT::tdual_xfloat_1d &buf)
 {
   first = first_in;
   d_buf = buf.view<DeviceType>();
@@ -1704,7 +1704,7 @@ void FixShakeKokkos<DeviceType>::correct_coordinates(int vflag) {
   xshake = x;
   if (nprocs > 1) {
     forward_comm_device = 0;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     forward_comm_device = 1;
   }
   xshake = xtmp;

--- a/src/KOKKOS/fix_shake_kokkos.h
+++ b/src/KOKKOS/fix_shake_kokkos.h
@@ -62,9 +62,9 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
 
   int pack_exchange(int, double *) override;
   int unpack_exchange(int, double *) override;
-  int pack_forward_comm_fix_kokkos(int, DAT::tdual_int_2d, int, DAT::tdual_xfloat_1d&,
+  int pack_forward_comm_kokkos(int, DAT::tdual_int_2d, int, DAT::tdual_xfloat_1d&,
                        int, int *) override;
-  void unpack_forward_comm_fix_kokkos(int, int, DAT::tdual_xfloat_1d&) override;
+  void unpack_forward_comm_kokkos(int, int, DAT::tdual_xfloat_1d&) override;
   int pack_forward_comm(int, int *, double *, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;
 

--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -642,7 +642,7 @@ void FixShardlowKokkos<DeviceType>::initial_integrate(int /*vflag*/)
 
     // Communicate the updated velocities to all nodes
     atomKK->sync(Host,V_MASK);
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     atomKK->modified(Host,V_MASK);
 
     if (k_pairDPDE) {

--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -672,7 +672,7 @@ void FixShardlowKokkos<DeviceType>::initial_integrate(int /*vflag*/)
 
     // Communicate the ghost deltas to the atom owners
     atomKK->sync(Host,V_MASK | UCOND_MASK | UMECH_MASK);
-    comm->reverse_comm_fix(this);
+    comm->reverse_comm(this);
     atomKK->modified(Host,V_MASK | UCOND_MASK | UMECH_MASK);
 
   }  //End Loop over all directions For airnum = Top, Top-Right, Right, Bottom-Right, Back

--- a/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
+++ b/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
@@ -350,7 +350,7 @@ void PairDPDfdtEnergyKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     k_duCond.template sync<LMPHostType>();
     k_duMech.template modify<DeviceType>();
     k_duMech.template sync<LMPHostType>();
-    comm->reverse_comm_pair(this);
+    comm->reverse_comm(this);
   }
 
   if (eflag_global) eng_vdwl += ev.evdwl;

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -201,7 +201,7 @@ void PairEAMAlloyKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   // communicate derivative of embedding function
 
   k_fp.template modify<DeviceType>();
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   k_fp.template sync<DeviceType>();
 
   // compute kernel C

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -172,7 +172,7 @@ void PairEAMAlloyKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
     if (newton_pair) {
       k_rho.template modify<DeviceType>();
-      comm->reverse_comm_pair(this);
+      comm->reverse_comm(this);
       k_rho.template sync<DeviceType>();
     }
 

--- a/src/KOKKOS/pair_eam_fs_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_fs_kokkos.cpp
@@ -201,7 +201,7 @@ void PairEAMFSKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   // communicate derivative of embedding function (on the device)
 
   k_fp.template modify<DeviceType>();
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   k_fp.template sync<DeviceType>();
 
   // compute kernel C

--- a/src/KOKKOS/pair_eam_fs_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_fs_kokkos.cpp
@@ -172,7 +172,7 @@ void PairEAMFSKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
     if (newton_pair) {
       k_rho.template modify<DeviceType>();
-      comm->reverse_comm_pair(this);
+      comm->reverse_comm(this);
       k_rho.template sync<DeviceType>();
     }
 

--- a/src/KOKKOS/pair_eam_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_kokkos.cpp
@@ -196,7 +196,7 @@ void PairEAMKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   // communicate derivative of embedding function
 
   k_fp.template modify<DeviceType>();
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   k_fp.template sync<DeviceType>();
 
   // compute kernel C

--- a/src/KOKKOS/pair_eam_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_kokkos.cpp
@@ -167,7 +167,7 @@ void PairEAMKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
     if (newton_pair) {
       k_rho.template modify<DeviceType>();
-      comm->reverse_comm_pair(this);
+      comm->reverse_comm(this);
       k_rho.template sync<DeviceType>();
     }
 

--- a/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
@@ -516,7 +516,7 @@ void PairMultiLucyRXKokkos<DeviceType>::computeLocalDensity()
   // communicate and sum densities
 
   if (newton_pair)
-    comm->reverse_comm_pair(this);
+    comm->reverse_comm(this);
 
   comm->forward_comm(this);
   atomKK->sync(execution_space,DPDRHO_MASK);

--- a/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
@@ -518,7 +518,7 @@ void PairMultiLucyRXKokkos<DeviceType>::computeLocalDensity()
   if (newton_pair)
     comm->reverse_comm_pair(this);
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   atomKK->sync(execution_space,DPDRHO_MASK);
 }
 

--- a/src/MACHDYN/fix_smd_move_triangulated_surface.cpp
+++ b/src/MACHDYN/fix_smd_move_triangulated_surface.cpp
@@ -432,7 +432,7 @@ void FixSMDMoveTriSurf::initial_integrate(int /*vflag*/) {
         }
 
         // we changed smd_data_9, x0. perform communication to ghosts
-        comm->forward_comm_fix(this);
+        comm->forward_comm(this);
 
 }
 

--- a/src/MACHDYN/fix_smd_tlsph_reference_configuration.cpp
+++ b/src/MACHDYN/fix_smd_tlsph_reference_configuration.cpp
@@ -185,7 +185,7 @@ void FixSMD_TLSPH_ReferenceConfiguration::pre_exchange() {
 
                 // update of reference config could have changed x0, vfrac, radius
                 // communicate these quantities now to ghosts: x0, vfrac, radius
-                comm->forward_comm_fix(this);
+                comm->forward_comm(this);
 
                 setup(0);
         }

--- a/src/MACHDYN/pair_smd_tlsph.cpp
+++ b/src/MACHDYN/pair_smd_tlsph.cpp
@@ -403,7 +403,7 @@ void PairTlsph::compute(int eflag, int vflag) {
          * QUANTITIES ABOVE HAVE ONLY BEEN CALCULATED FOR NLOCAL PARTICLES.
          * NEED TO DO A FORWARD COMMUNICATION TO GHOST ATOMS NOW
          */
-        comm->forward_comm_pair(this);
+        comm->forward_comm(this);
 
         /*
          * compute forces between particles

--- a/src/MACHDYN/pair_smd_ulsph.cpp
+++ b/src/MACHDYN/pair_smd_ulsph.cpp
@@ -458,7 +458,7 @@ void PairULSPH::compute(int eflag, int vflag) {
          * QUANTITIES ABOVE HAVE ONLY BEEN CALCULATED FOR NLOCAL PARTICLES.
          * NEED TO DO A FORWARD COMMUNICATION TO GHOST ATOMS NOW
          */
-        comm->forward_comm_pair(this);
+        comm->forward_comm(this);
 
         updateFlag = 0;
 

--- a/src/MANYBODY/fix_qeq_comb.cpp
+++ b/src/MANYBODY/fix_qeq_comb.cpp
@@ -228,7 +228,7 @@ void FixQEQComb::post_force(int /*vflag*/)
       }
     }
 
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     enegtot = 0.0;
     if (comb) enegtot = comb->yasu_char(qf,igroup);
     else if (comb3) enegtot = comb3->combqeq(qf,igroup);

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -276,7 +276,7 @@ void PairADP::compute(int eflag, int vflag)
 
   // communicate derivative of embedding function
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // compute forces on each atom
   // loop over neighbors of my atoms

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -246,7 +246,7 @@ void PairADP::compute(int eflag, int vflag)
 
   // communicate and sum densities
 
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
 
   // fp = derivative of embedding energy at each atom
   // phi = embedding energy at each atom

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -1587,7 +1587,7 @@ double PairComb::yasu_char(double *qf_fix, int &igroup)
 
   // communicating charge force to all nodes, first forward then reverse
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // self energy correction term: potal
 

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -1692,7 +1692,7 @@ double PairComb::yasu_char(double *qf_fix, int &igroup)
     }
   }
 
-  comm->reverse_comm_pair(this);
+  comm->reverse_comm(this);
 
   // sum charge force on each node and return it
 

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -777,7 +777,7 @@ void PairComb3::Short_neigh()
 
   // communicating coordination number to all nodes
   pack_flag = 2;
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
 }
 
@@ -3154,7 +3154,7 @@ double PairComb3::combqeq(double *qf_fix, int &igroup)
   // communicating charge force to all nodes, first forward then reverse
 
   pack_flag = 1;
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // self energy correction term: potal
 

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -3265,7 +3265,7 @@ double PairComb3::combqeq(double *qf_fix, int &igroup)
     }
   }
 
-  comm->reverse_comm_pair(this);
+  comm->reverse_comm(this);
 
   // sum charge force on each node and return it
 

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -221,7 +221,7 @@ void PairEAM::compute(int eflag, int vflag)
 
   // communicate and sum densities
 
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
 
   // fp = derivative of embedding energy at each atom
   // phi = embedding energy at each atom

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -248,7 +248,7 @@ void PairEAM::compute(int eflag, int vflag)
 
   // communicate derivative of embedding function
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   embedstep = update->ntimestep;
 
   // compute forces on each atom

--- a/src/MANYBODY/pair_eam_cd.cpp
+++ b/src/MANYBODY/pair_eam_cd.cpp
@@ -171,7 +171,7 @@ void PairEAMCD::compute(int eflag, int vflag)
 
   if (newton_pair) {
     communicationStage = 1;
-    comm->reverse_comm_pair(this);
+    comm->reverse_comm(this);
   }
 
   // fp = derivative of embedding energy at each atom
@@ -269,7 +269,7 @@ void PairEAMCD::compute(int eflag, int vflag)
 
     if (newton_pair) {
       communicationStage = 3;
-      comm->reverse_comm_pair(this);
+      comm->reverse_comm(this);
     }
     communicationStage = 4;
     comm->forward_comm(this);

--- a/src/MANYBODY/pair_eam_cd.cpp
+++ b/src/MANYBODY/pair_eam_cd.cpp
@@ -192,7 +192,7 @@ void PairEAMCD::compute(int eflag, int vflag)
   // and D_values (this for one-site formulation only).
 
   communicationStage = 2;
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // The electron densities may not drop to zero because then the
   // concentration would no longer be defined.  But the concentration
@@ -272,7 +272,7 @@ void PairEAMCD::compute(int eflag, int vflag)
       comm->reverse_comm_pair(this);
     }
     communicationStage = 4;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   // Stage III

--- a/src/MANYBODY/pair_eam_he.cpp
+++ b/src/MANYBODY/pair_eam_he.cpp
@@ -118,7 +118,7 @@ void PairEAMHE::compute(int eflag, int vflag)
 
   // communicate and sum densities
 
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
 
   // fp = derivative of embedding energy at each atom
   // phi = embedding energy at each atom

--- a/src/MANYBODY/pair_eam_he.cpp
+++ b/src/MANYBODY/pair_eam_he.cpp
@@ -157,7 +157,7 @@ void PairEAMHE::compute(int eflag, int vflag)
 
   // communicate derivative of embedding function
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   embedstep = update->ntimestep;
 
   // compute forces on each atom

--- a/src/MANYBODY/pair_eim.cpp
+++ b/src/MANYBODY/pair_eim.cpp
@@ -185,7 +185,7 @@ void PairEIM::compute(int eflag, int vflag)
   // communicate and sum densities
 
   rhofp = 1;
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
   comm->forward_comm(this);
 
   for (ii = 0; ii < inum; ii++) {
@@ -226,7 +226,7 @@ void PairEIM::compute(int eflag, int vflag)
   // communicate and sum modified densities
 
   rhofp = 2;
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
   comm->forward_comm(this);
 
   for (ii = 0; ii < inum; ii++) {

--- a/src/MANYBODY/pair_eim.cpp
+++ b/src/MANYBODY/pair_eim.cpp
@@ -186,7 +186,7 @@ void PairEIM::compute(int eflag, int vflag)
 
   rhofp = 1;
   if (newton_pair) comm->reverse_comm_pair(this);
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];
@@ -227,7 +227,7 @@ void PairEIM::compute(int eflag, int vflag)
 
   rhofp = 2;
   if (newton_pair) comm->reverse_comm_pair(this);
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];

--- a/src/MANYBODY/pair_local_density.cpp
+++ b/src/MANYBODY/pair_local_density.cpp
@@ -237,7 +237,7 @@ void PairLocalDensity::compute(int eflag, int vflag)
   }
 
   // communicate and sum LDs over all procs
-  if (newton_pair) comm->reverse_comm_pair(this);
+  if (newton_pair) comm->reverse_comm(this);
 
   //
 

--- a/src/MANYBODY/pair_local_density.cpp
+++ b/src/MANYBODY/pair_local_density.cpp
@@ -284,7 +284,7 @@ void PairLocalDensity::compute(int eflag, int vflag)
 
   // communicate LD and fp to all procs
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // compute forces on each atom
   // loop over neighbors of my atoms

--- a/src/MANYBODY/pair_meam_spline.cpp
+++ b/src/MANYBODY/pair_meam_spline.cpp
@@ -275,7 +275,7 @@ void PairMEAMSpline::compute(int eflag, int vflag)
 
   // Communicate U'(rho) values
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // Compute two-body pair interactions
   for (int ii = 0; ii < listhalf->inum; ii++) {

--- a/src/MANYBODY/pair_meam_sw_spline.cpp
+++ b/src/MANYBODY/pair_meam_sw_spline.cpp
@@ -289,7 +289,7 @@ void PairMEAMSWSpline::compute(int eflag, int vflag)
 
   // Communicate U'(rho) values
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   int inum_half = listhalf->inum;
   int* ilist_half = listhalf->ilist;

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -378,7 +378,7 @@ int FixAtomSwap::attempt_semi_grand()
     if (modify->n_pre_neighbor) modify->pre_neighbor();
     neighbor->build(1);
   } else {
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   // post-swap energy
@@ -464,7 +464,7 @@ int FixAtomSwap::attempt_swap()
     if (modify->n_pre_neighbor) modify->pre_neighbor();
     neighbor->build(1);
   } else {
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   // post-swap energy

--- a/src/MC/fix_bond_break.cpp
+++ b/src/MC/fix_bond_break.cpp
@@ -259,7 +259,7 @@ void FixBondBreak::post_integrate()
   }
 
   commflag = 1;
-  comm->forward_comm_fix(this,2);
+  comm->forward_comm(this,2);
 
   // break bonds
   // if both atoms list each other as winning bond partner
@@ -338,7 +338,7 @@ void FixBondBreak::post_integrate()
   // 1-2 neighs already reflect broken bonds
 
   commflag = 2;
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // create list of broken bonds that influence my owned atoms
   //   even if between owned-ghost or ghost-ghost atoms

--- a/src/MC/fix_bond_break.cpp
+++ b/src/MC/fix_bond_break.cpp
@@ -247,7 +247,7 @@ void FixBondBreak::post_integrate()
 
   // reverse comm of partner info
 
-  if (force->newton_bond) comm->reverse_comm_fix(this);
+  if (force->newton_bond) comm->reverse_comm(this);
 
   // each atom now knows its winning partner
   // for prob check, generate random value for each atom with a bond partner

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -343,7 +343,7 @@ void FixBondCreate::setup(int /*vflag*/)
   // if newton_bond is set, need to sum bondcount
 
   commflag = 1;
-  if (newton_bond) comm->reverse_comm_fix(this,1);
+  if (newton_bond) comm->reverse_comm(this,1);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -488,7 +488,7 @@ void FixBondCreate::post_integrate()
   // not needed if newton_pair off since I,J pair was seen by both procs
 
   commflag = 2;
-  if (force->newton_pair) comm->reverse_comm_fix(this);
+  if (force->newton_pair) comm->reverse_comm(this);
 
   // each atom now knows its winning partner
   // for prob check, generate random value for each atom with a bond partner

--- a/src/MC/fix_bond_create.cpp
+++ b/src/MC/fix_bond_create.cpp
@@ -374,7 +374,7 @@ void FixBondCreate::post_integrate()
   // forward comm of bondcount, so ghosts have it
 
   commflag = 1;
-  comm->forward_comm_fix(this,1);
+  comm->forward_comm(this,1);
 
   // resize bond partner list and initialize it
   // probability array overlays distsq array
@@ -417,7 +417,7 @@ void FixBondCreate::post_integrate()
     // to correctly handle angle constraints
 
     commflag = 3;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   neighbor->build_one(list,1);
@@ -500,7 +500,7 @@ void FixBondCreate::post_integrate()
   }
 
   commflag = 2;
-  comm->forward_comm_fix(this,2);
+  comm->forward_comm(this,2);
 
   // create bonds for atoms I own
   // only if both atoms list each other as winning bond partner
@@ -597,7 +597,7 @@ void FixBondCreate::post_integrate()
   // 1-2 neighs already reflect created bonds
 
   commflag = 3;
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // create list of broken bonds that influence my owned atoms
   //   even if between owned-ghost or ghost-ghost atoms

--- a/src/MC/fix_mol_swap.cpp
+++ b/src/MC/fix_mol_swap.cpp
@@ -324,7 +324,7 @@ int FixMolSwap::attempt_swap()
     if (modify->n_pre_neighbor) modify->pre_neighbor();
     neighbor->build(1);
   } else {
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   // post-swap energy

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -139,7 +139,7 @@ void PairMEAM::compute(int eflag, int vflag)
     offset += numneigh_half[i];
   }
 
-  comm->reverse_comm_pair(this);
+  comm->reverse_comm(this);
 
   meam_inst->meam_dens_final(nlocal,eflag_either,eflag_global,eflag_atom,
                    &eng_vdwl,eatom,ntype,type,map,scale,errorflag);

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -146,7 +146,7 @@ void PairMEAM::compute(int eflag, int vflag)
   if (errorflag)
     error->one(FLERR,"MEAM library error {}",errorflag);
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   offset = 0;
 

--- a/src/MESONT/compute_mesont.cpp
+++ b/src/MESONT/compute_mesont.cpp
@@ -118,7 +118,7 @@ void ComputeMesoNT::compute_peratom() {
    "compute mesont is allowed only with mesont/tpm pair style");
 
   // communicate ghost energy between neighbor procs
-  if (force->newton) comm->reverse_comm_compute(this);
+  if (force->newton) comm->reverse_comm(this);
 
   // zero energy of atoms not in group
   // only do this after comm since ghost contributions must be included

--- a/src/MESONT/pair_mesont_tpm.cpp
+++ b/src/MESONT/pair_mesont_tpm.cpp
@@ -408,7 +408,7 @@ void PairMESONTTPM::compute(int eflag, int vflag) {
       int idx = ntlist.get_idx(i);
       buckling[idx] = b_sort[i];
     }
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
     for (int i = 0; i < nall; i++) {
       int idx = ntlist.get_idx(i);
       b_sort[i] = buckling[idx];

--- a/src/ML-SNAP/compute_snad_atom.cpp
+++ b/src/ML-SNAP/compute_snad_atom.cpp
@@ -368,7 +368,7 @@ void ComputeSNADAtom::compute_peratom()
 
   // communicate snad contributions between neighbor procs
 
-  comm->reverse_comm_compute(this);
+  comm->reverse_comm(this);
 
 }
 

--- a/src/ML-SNAP/compute_snav_atom.cpp
+++ b/src/ML-SNAP/compute_snav_atom.cpp
@@ -378,7 +378,7 @@ void ComputeSNAVAtom::compute_peratom()
 
   // communicate snav contributions between neighbor procs
 
-  comm->reverse_comm_compute(this);
+  comm->reverse_comm(this);
 
 }
 

--- a/src/OPENMP/fix_neigh_history_omp.cpp
+++ b/src/OPENMP/fix_neigh_history_omp.cpp
@@ -268,7 +268,7 @@ void FixNeighHistoryOMP::pre_exchange_newton()
 #endif
     {
       commflag = NPARTNER;
-      comm->reverse_comm_fix(this,0);
+      comm->reverse_comm(this,0);
     }
 
     // get page chunks to store atom IDs and shear history for my atoms
@@ -345,7 +345,7 @@ void FixNeighHistoryOMP::pre_exchange_newton()
       //   if many touching neighbors for large particle
 
       commflag = PERPARTNER;
-      comm->reverse_comm_fix_variable(this);
+      comm->reverse_comm_variable(this);
     }
 
     // set maxpartner = max # of partners of any owned atom

--- a/src/OPENMP/fix_qeq_comb_omp.cpp
+++ b/src/OPENMP/fix_qeq_comb_omp.cpp
@@ -134,7 +134,7 @@ void FixQEQCombOMP::post_force(int /* vflag */)
         q[i]  += q1[i];
       }
     }
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     if (comb) enegtot = comb->yasu_char(qf,igroup);
     enegtot /= ngroup;

--- a/src/OPENMP/fix_qeq_reaxff_omp.cpp
+++ b/src/OPENMP/fix_qeq_reaxff_omp.cpp
@@ -380,7 +380,7 @@ int FixQEqReaxFFOMP::CG(double *b, double *x)
 
   pack_flag = 1;
   sparse_matvec(&H, x, q);
-  comm->reverse_comm_fix(this); //Coll_Vector(q);
+  comm->reverse_comm(this); //Coll_Vector(q);
 
   double tmp1, tmp2;
   tmp1 = tmp2 = 0.0;
@@ -410,7 +410,7 @@ int FixQEqReaxFFOMP::CG(double *b, double *x)
   for (i = 1; i < imax && sqrt(sig_new) / b_norm > tolerance; ++i) {
     comm->forward_comm(this); //Dist_vector(d);
     sparse_matvec(&H, d, q);
-    comm->reverse_comm_fix(this); //Coll_vector(q);
+    comm->reverse_comm(this); //Coll_vector(q);
 
     tmp1 = 0.0;
 #if defined(_OPENMP)
@@ -644,7 +644,7 @@ int FixQEqReaxFFOMP::dual_CG(double *b1, double *b2, double *x1, double *x2)
 
   pack_flag = 5; // forward 2x d and reverse 2x q
   dual_sparse_matvec(&H, x1, x2, q);
-  comm->reverse_comm_fix(this); //Coll_Vector(q);
+  comm->reverse_comm(this); //Coll_Vector(q);
 
   double tmp1, tmp2, tmp3, tmp4;
   tmp1 = tmp2 = tmp3 = tmp4 = 0.0;
@@ -686,7 +686,7 @@ int FixQEqReaxFFOMP::dual_CG(double *b1, double *b2, double *x1, double *x2)
   for (i = 1; i < imax; ++i) {
     comm->forward_comm(this); //Dist_vector(d);
     dual_sparse_matvec(&H, d, q);
-    comm->reverse_comm_fix(this); //Coll_vector(q);
+    comm->reverse_comm(this); //Coll_vector(q);
 
     tmp1 = tmp2 = 0.0;
 #if defined(_OPENMP)

--- a/src/OPENMP/fix_qeq_reaxff_omp.cpp
+++ b/src/OPENMP/fix_qeq_reaxff_omp.cpp
@@ -363,9 +363,9 @@ void FixQEqReaxFFOMP::init_matvec()
   }
 
   pack_flag = 2;
-  comm->forward_comm_fix(this); //Dist_vector(s);
+  comm->forward_comm(this); //Dist_vector(s);
   pack_flag = 3;
-  comm->forward_comm_fix(this); //Dist_vector(t);
+  comm->forward_comm(this); //Dist_vector(t);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -408,7 +408,7 @@ int FixQEqReaxFFOMP::CG(double *b, double *x)
   sig_new = buf[1];
 
   for (i = 1; i < imax && sqrt(sig_new) / b_norm > tolerance; ++i) {
-    comm->forward_comm_fix(this); //Dist_vector(d);
+    comm->forward_comm(this); //Dist_vector(d);
     sparse_matvec(&H, d, q);
     comm->reverse_comm_fix(this); //Coll_vector(q);
 
@@ -594,7 +594,7 @@ void FixQEqReaxFFOMP::calculate_Q()
   }
 
   pack_flag = 4;
-  comm->forward_comm_fix(this); //Dist_vector(atom->q);
+  comm->forward_comm(this); //Dist_vector(atom->q);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -684,7 +684,7 @@ int FixQEqReaxFFOMP::dual_CG(double *b1, double *b2, double *x1, double *x2)
   sig_new_t = buf[3];
 
   for (i = 1; i < imax; ++i) {
-    comm->forward_comm_fix(this); //Dist_vector(d);
+    comm->forward_comm(this); //Dist_vector(d);
     dual_sparse_matvec(&H, d, q);
     comm->reverse_comm_fix(this); //Coll_vector(q);
 
@@ -782,7 +782,7 @@ int FixQEqReaxFFOMP::dual_CG(double *b1, double *b2, double *x1, double *x2)
   // If only one was converged and there are still iterations left, converge other system
   if ((matvecs_s < imax) && (sqrt(sig_new_s)/b_norm_s > tolerance)) {
     pack_flag = 2;
-    comm->forward_comm_fix(this); // x1 => s
+    comm->forward_comm(this); // x1 => s
 
     int saved_imax = imax;
     imax -= matvecs_s;
@@ -790,7 +790,7 @@ int FixQEqReaxFFOMP::dual_CG(double *b1, double *b2, double *x1, double *x2)
     imax = saved_imax;
   } else if ((matvecs_t < imax) && (sqrt(sig_new_t)/b_norm_t > tolerance)) {
     pack_flag = 3;
-    comm->forward_comm_fix(this); // x2 => t
+    comm->forward_comm(this); // x2 => t
     int saved_imax = imax;
     imax -= matvecs_t;
     matvecs_t += CG(b2, x2);

--- a/src/OPENMP/fix_rigid_small_omp.cpp
+++ b/src/OPENMP/fix_rigid_small_omp.cpp
@@ -90,7 +90,7 @@ void FixRigidSmallOMP::initial_integrate(int vflag)
   // forward communicate updated info of all bodies
 
   commflag = INITIAL;
-  comm->forward_comm_fix(this,26);
+  comm->forward_comm(this,26);
 
   // set coords/orient and velocity/rotation of atoms in rigid bodies
 
@@ -247,7 +247,7 @@ void FixRigidSmallOMP::final_integrate()
   // forward communicate updated info of all bodies
 
   commflag = FINAL;
-  comm->forward_comm_fix(this,10);
+  comm->forward_comm(this,10);
 
   // set velocity/rotation of atoms in rigid bodies
   // virial is already setup from initial_integrate

--- a/src/OPENMP/fix_rigid_small_omp.cpp
+++ b/src/OPENMP/fix_rigid_small_omp.cpp
@@ -177,7 +177,7 @@ void FixRigidSmallOMP::compute_forces_and_torques()
   // reverse communicate fcm, torque of all bodies
 
   commflag = FORCE_TORQUE;
-  comm->reverse_comm_fix(this,6);
+  comm->reverse_comm(this,6);
 
   // include Langevin thermostat forces and torques
 

--- a/src/OPENMP/pair_adp_omp.cpp
+++ b/src/OPENMP/pair_adp_omp.cpp
@@ -262,7 +262,7 @@ void PairADPOMP::eval(int iifrom, int iito, ThrData * const thr)
 #if defined(_OPENMP)
 #pragma omp master
 #endif
-  { comm->forward_comm_pair(this); }
+  { comm->forward_comm(this); }
 
   // wait until master thread is done with communication
   sync_threads();

--- a/src/OPENMP/pair_adp_omp.cpp
+++ b/src/OPENMP/pair_adp_omp.cpp
@@ -213,7 +213,7 @@ void PairADPOMP::eval(int iifrom, int iito, ThrData * const thr)
 #if defined(_OPENMP)
 #pragma omp master
 #endif
-    { comm->reverse_comm_pair(this); }
+    { comm->reverse_comm(this); }
 
     // wait until master thread is done with communication
     sync_threads();

--- a/src/OPENMP/pair_comb_omp.cpp
+++ b/src/OPENMP/pair_comb_omp.cpp
@@ -528,7 +528,7 @@ double PairCombOMP::yasu_char(double *qf_fix, int &igroup)
     }
   }
 
-  comm->reverse_comm_pair(this);
+  comm->reverse_comm(this);
 
   // sum charge force on each node and return it
 

--- a/src/OPENMP/pair_comb_omp.cpp
+++ b/src/OPENMP/pair_comb_omp.cpp
@@ -409,7 +409,7 @@ double PairCombOMP::yasu_char(double *qf_fix, int &igroup)
 
   // communicating charge force to all nodes, first forward then reverse
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // self energy correction term: potal
 

--- a/src/OPENMP/pair_eam_omp.cpp
+++ b/src/OPENMP/pair_eam_omp.cpp
@@ -174,7 +174,7 @@ void PairEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
 #if defined(_OPENMP)
 #pragma omp master
 #endif
-    { comm->reverse_comm_pair(this); }
+    { comm->reverse_comm(this); }
 
     // wait until master thread is done with communication
     sync_threads();

--- a/src/OPENMP/pair_eam_omp.cpp
+++ b/src/OPENMP/pair_eam_omp.cpp
@@ -216,7 +216,7 @@ void PairEAMOMP::eval(int iifrom, int iito, ThrData * const thr)
 #if defined(_OPENMP)
 #pragma omp master
 #endif
-  { comm->forward_comm_pair(this); }
+  { comm->forward_comm(this); }
 
   // wait until master thread is done with communication
   sync_threads();

--- a/src/OPENMP/pair_eim_omp.cpp
+++ b/src/OPENMP/pair_eim_omp.cpp
@@ -174,7 +174,7 @@ void PairEIMOMP::eval(int iifrom, int iito, ThrData * const thr)
 #endif
     {
       rhofp = 1;
-      comm->reverse_comm_pair(this);
+      comm->reverse_comm(this);
     }
 
   } else {
@@ -248,7 +248,7 @@ void PairEIMOMP::eval(int iifrom, int iito, ThrData * const thr)
 #endif
     {
       rhofp = 2;
-      comm->reverse_comm_pair(this);
+      comm->reverse_comm(this);
     }
 
   } else {

--- a/src/OPENMP/pair_eim_omp.cpp
+++ b/src/OPENMP/pair_eim_omp.cpp
@@ -190,7 +190,7 @@ void PairEIMOMP::eval(int iifrom, int iito, ThrData * const thr)
 #endif
   {
     rhofp = 1;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   // wait until master is finished communicating
@@ -264,7 +264,7 @@ void PairEIMOMP::eval(int iifrom, int iito, ThrData * const thr)
 #endif
   {
     rhofp = 2;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   // wait until master is finished communicating

--- a/src/OPENMP/pair_gran_hertz_history_omp.cpp
+++ b/src/OPENMP/pair_gran_hertz_history_omp.cpp
@@ -67,7 +67,7 @@ void PairGranHertzHistoryOMP::compute(int eflag, int vflag)
     for (int i = 0; i < nlocal; i++)
       if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
       else mass_rigid[i] = 0.0;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
 #if defined(_OPENMP)

--- a/src/OPENMP/pair_gran_hooke_history_omp.cpp
+++ b/src/OPENMP/pair_gran_hooke_history_omp.cpp
@@ -64,7 +64,7 @@ void PairGranHookeHistoryOMP::compute(int eflag, int vflag)
     for (int i = 0; i < nlocal; i++)
       if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
       else mass_rigid[i] = 0.0;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
   const int nall = atom->nlocal + atom->nghost;

--- a/src/OPENMP/pair_gran_hooke_omp.cpp
+++ b/src/OPENMP/pair_gran_hooke_omp.cpp
@@ -63,7 +63,7 @@ void PairGranHookeOMP::compute(int eflag, int vflag)
     for (int i = 0; i < nlocal; i++)
       if (body[i] >= 0) mass_rigid[i] = mass_body[body[i]];
       else mass_rigid[i] = 0.0;
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
   }
 
 #if defined(_OPENMP)

--- a/src/OPENMP/pair_lubricate_omp.cpp
+++ b/src/OPENMP/pair_lubricate_omp.cpp
@@ -219,7 +219,7 @@ void PairLubricateOMP::eval(int iifrom, int iito, ThrData * const thr)
 #if defined(_OPENMP)
 #pragma omp master
 #endif
-    { comm->forward_comm_pair(this); }
+    { comm->forward_comm(this); }
 
     sync_threads();
   }

--- a/src/OPENMP/pair_lubricate_poly_omp.cpp
+++ b/src/OPENMP/pair_lubricate_poly_omp.cpp
@@ -219,7 +219,7 @@ void PairLubricatePolyOMP::eval(int iifrom, int iito, ThrData * const thr)
 #if defined(_OPENMP)
 #pragma omp master
 #endif
-    { comm->forward_comm_pair(this); }
+    { comm->forward_comm(this); }
 
     sync_threads();
   }

--- a/src/OPENMP/pair_meam_spline_omp.cpp
+++ b/src/OPENMP/pair_meam_spline_omp.cpp
@@ -268,7 +268,7 @@ void PairMEAMSplineOMP::eval(int iifrom, int iito, ThrData * const thr)
 #if defined(_OPENMP)
 #pragma omp master
 #endif
-  { comm->forward_comm_pair(this); }
+  { comm->forward_comm(this); }
 
   // wait until master thread is done with communication
   sync_threads();

--- a/src/OPENMP/pair_peri_lps_omp.cpp
+++ b/src/OPENMP/pair_peri_lps_omp.cpp
@@ -233,10 +233,10 @@ void PairPeriLPSOMP::eval(int iifrom, int iito, ThrData * const thr)
 #pragma omp master
 #endif
   { // communicate dilatation (theta) of each particle
-    comm->forward_comm_pair(this);
+    comm->forward_comm(this);
     // communicate weighted volume (wvolume) upon every reneighbor
     if (neighbor->ago == 0)
-      comm->forward_comm_fix(fix_peri_neigh);
+      comm->forward_comm(fix_peri_neigh);
   }
 
   sync_threads();

--- a/src/OPENMP/pair_reaxff_omp.cpp
+++ b/src/OPENMP/pair_reaxff_omp.cpp
@@ -223,7 +223,7 @@ void PairReaxFFOMP::compute(int eflag, int vflag)
   // communicate num_bonds once every reneighboring
   // 2 num arrays stored by fix, grab ptr to them
 
-  if (neighbor->ago == 0) comm->forward_comm_fix(fix_reaxff);
+  if (neighbor->ago == 0) comm->forward_comm(fix_reaxff);
   int *num_bonds = fix_reaxff->num_bonds;
   int *num_hbonds = fix_reaxff->num_hbonds;
 

--- a/src/OPT/pair_eam_opt.cpp
+++ b/src/OPT/pair_eam_opt.cpp
@@ -225,7 +225,7 @@ void PairEAMOpt::eval()
 
   // communicate and sum densities
 
-  if (NEWTON_PAIR) comm->reverse_comm_pair(this);
+  if (NEWTON_PAIR) comm->reverse_comm(this);
 
   // fp = derivative of embedding energy at each atom
   // phi = embedding energy at each atom

--- a/src/OPT/pair_eam_opt.cpp
+++ b/src/OPT/pair_eam_opt.cpp
@@ -252,7 +252,7 @@ void PairEAMOpt::eval()
 
   // communicate derivative of embedding function
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   embedstep = update->ntimestep;
 
   // compute forces on each atom

--- a/src/ORIENT/fix_orient_bcc.cpp
+++ b/src/ORIENT/fix_orient_bcc.cpp
@@ -372,7 +372,7 @@ void FixOrientBCC::post_force(int /*vflag*/)
 
   // communicate to acquire nbr data for ghost atoms
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // compute grain boundary force on each owned atom
   // skip atoms not in group

--- a/src/ORIENT/fix_orient_eco.cpp
+++ b/src/ORIENT/fix_orient_eco.cpp
@@ -344,7 +344,7 @@ void FixOrientECO::post_force(int /* vflag */) {
   // potential is not zero
   if (u_0 != 0.0) {
     // communicate to acquire nbr data for ghost atoms
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     // loop over all atoms
     for (ii = 0; ii < inum; ++ii) {

--- a/src/ORIENT/fix_orient_fcc.cpp
+++ b/src/ORIENT/fix_orient_fcc.cpp
@@ -370,7 +370,7 @@ void FixOrientFCC::post_force(int /*vflag*/)
 
   // communicate to acquire nbr data for ghost atoms
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // compute grain boundary force on each owned atom
   // skip atoms not in group

--- a/src/PERI/fix_peri_neigh.cpp
+++ b/src/PERI/fix_peri_neigh.cpp
@@ -372,7 +372,7 @@ void FixPeriNeigh::setup(int /*vflag*/)
 
   // communicate wvolume to ghosts
 
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   // bond statistics
 

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -193,12 +193,12 @@ void PairPeriEPS::compute(int eflag, int vflag)
   compute_dilatation(0,nlocal);
 
   // communicate dilatation (theta) of each particle
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // communicate weighted volume (wvolume) upon every reneighbor
 
   if (neighbor->ago == 0)
-    comm->forward_comm_fix(fix_peri_neigh);
+    comm->forward_comm(fix_peri_neigh);
 
   // volume-dependent part of the energy
 

--- a/src/PERI/pair_peri_lps.cpp
+++ b/src/PERI/pair_peri_lps.cpp
@@ -173,10 +173,10 @@ void PairPeriLPS::compute(int eflag, int vflag)
   compute_dilatation(0,nlocal);
 
   // communicate dilatation (theta) of each particle
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
   // communicate wighted volume (wvolume) upon every reneighbor
   if (neighbor->ago == 0)
-    comm->forward_comm_fix(fix_peri_neigh);
+    comm->forward_comm(fix_peri_neigh);
 
   // Volume-dependent part of the energy
   if (eflag) {

--- a/src/PERI/pair_peri_ves.cpp
+++ b/src/PERI/pair_peri_ves.cpp
@@ -178,12 +178,12 @@ void PairPeriVES::compute(int eflag, int vflag)
   compute_dilatation(0,nlocal);
 
   // communicate dilatation (theta) of each particle
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   // communicate weighted volume (wvolume) upon every reneighbor
 
   if (neighbor->ago == 0)
-    comm->forward_comm_fix(fix_peri_neigh);
+    comm->forward_comm(fix_peri_neigh);
 
   // volume-dependent part of the energy
 

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -399,7 +399,7 @@ int FixQEq::CG(double *b, double *x)
 
   pack_flag = 1;
   sparse_matvec(&H, x, q);
-  comm->reverse_comm_fix(this);
+  comm->reverse_comm(this);
 
   vector_sum(r , 1.,  b, -1., q, inum);
 
@@ -416,7 +416,7 @@ int FixQEq::CG(double *b, double *x)
   for (loop = 1; loop < maxiter && sqrt(sig_new)/b_norm > tolerance; ++loop) {
     comm->forward_comm(this);
     sparse_matvec(&H, d, q);
-    comm->reverse_comm_fix(this);
+    comm->reverse_comm(this);
 
     tmp = parallel_dot(d, q, inum);
     alfa = sig_new / tmp;

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -414,7 +414,7 @@ int FixQEq::CG(double *b, double *x)
   sig_new = parallel_dot(r, d, inum);
 
   for (loop = 1; loop < maxiter && sqrt(sig_new)/b_norm > tolerance; ++loop) {
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     sparse_matvec(&H, d, q);
     comm->reverse_comm_fix(this);
 
@@ -507,7 +507,7 @@ void FixQEq::calculate_Q()
   }
 
   pack_flag = 4;
-  comm->forward_comm_fix(this); //Dist_vector(atom->q);
+  comm->forward_comm(this); //Dist_vector(atom->q);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/QEQ/fix_qeq_dynamic.cpp
+++ b/src/QEQ/fix_qeq_dynamic.cpp
@@ -118,7 +118,7 @@ void FixQEqDynamic::pre_force(int /*vflag*/)
     }
 
     pack_flag = 1;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     enegtot = compute_eneg();
     enegtot /= ngroup;
@@ -184,7 +184,7 @@ double FixQEqDynamic::compute_eneg()
 
   // communicating charge force to all nodes, first forward then reverse
   pack_flag = 2;
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];

--- a/src/QEQ/fix_qeq_dynamic.cpp
+++ b/src/QEQ/fix_qeq_dynamic.cpp
@@ -217,7 +217,7 @@ double FixQEqDynamic::compute_eneg()
   }
 
   pack_flag = 2;
-  comm->reverse_comm_fix(this);
+  comm->reverse_comm(this);
 
   // sum charge force on each node and return it
 

--- a/src/QEQ/fix_qeq_fire.cpp
+++ b/src/QEQ/fix_qeq_fire.cpp
@@ -126,7 +126,7 @@ void FixQEqFire::pre_force(int /*vflag*/)
 
   for (iloop = 0; iloop < maxiter; iloop ++) {
     pack_flag = 1;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     if (comb) {
       comb->yasu_char(qf,igroup);
@@ -245,7 +245,7 @@ double FixQEqFire::compute_eneg()
 
   // communicating charge force to all nodes, first forward then reverse
   pack_flag = 2;
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];

--- a/src/QEQ/fix_qeq_fire.cpp
+++ b/src/QEQ/fix_qeq_fire.cpp
@@ -278,7 +278,7 @@ double FixQEqFire::compute_eneg()
   }
 
   pack_flag = 2;
-  comm->reverse_comm_fix(this);
+  comm->reverse_comm(this);
 
   // sum charge force on each node and return it
 

--- a/src/QEQ/fix_qeq_point.cpp
+++ b/src/QEQ/fix_qeq_point.cpp
@@ -107,9 +107,9 @@ void FixQEqPoint::init_matvec()
   }
 
   pack_flag = 2;
-  comm->forward_comm_fix(this); //Dist_vector(s);
+  comm->forward_comm(this); //Dist_vector(s);
   pack_flag = 3;
-  comm->forward_comm_fix(this); //Dist_vector(t);
+  comm->forward_comm(this); //Dist_vector(t);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/QEQ/fix_qeq_shielded.cpp
+++ b/src/QEQ/fix_qeq_shielded.cpp
@@ -168,9 +168,9 @@ void FixQEqShielded::init_matvec()
   }
 
   pack_flag = 2;
-  comm->forward_comm_fix(this); //Dist_vector(s);
+  comm->forward_comm(this); //Dist_vector(s);
   pack_flag = 3;
-  comm->forward_comm_fix(this); //Dist_vector(t);
+  comm->forward_comm(this); //Dist_vector(t);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/QEQ/fix_qeq_slater.cpp
+++ b/src/QEQ/fix_qeq_slater.cpp
@@ -146,9 +146,9 @@ void FixQEqSlater::init_matvec()
   }
 
   pack_flag = 2;
-  comm->forward_comm_fix(this); //Dist_vector(s);
+  comm->forward_comm(this); //Dist_vector(s);
   pack_flag = 3;
-  comm->forward_comm_fix(this); //Dist_vector(t);
+  comm->forward_comm(this); //Dist_vector(t);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -942,7 +942,7 @@ void FixBondReact::post_integrate()
     // forward comm of partner, so ghosts have it
 
     commflag = 2;
-    comm->forward_comm_fix(this,1);
+    comm->forward_comm(this,1);
 
     // consider for reaction:
     // only if both atoms list each other as winning bond partner
@@ -975,7 +975,7 @@ void FixBondReact::post_integrate()
     // communicate final partner
 
     commflag = 3;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     // add instance to 'attempt' only if this processor
     // owns the atoms with smaller global ID
@@ -1028,7 +1028,7 @@ void FixBondReact::post_integrate()
   // evaluate custom constraint variable values here and forward_comm
   get_customvars();
   commflag = 1;
-  comm->forward_comm_fix(this,ncustomvars);
+  comm->forward_comm(this,ncustomvars);
 
   // run through the superimpose algorithm
   // this checks if simulation topology matches unreacted mol template

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -931,11 +931,11 @@ void FixBondReact::post_integrate()
       // reverse comm of distsq and partner
       // not needed if newton_pair off since I,J pair was seen by both procs
       commflag = 2;
-      if (force->newton_pair) comm->reverse_comm_fix(this);
+      if (force->newton_pair) comm->reverse_comm(this);
     } else {
       close_partner();
       commflag = 2;
-      comm->reverse_comm_fix(this);
+      comm->reverse_comm(this);
     }
 
     // each atom now knows its winning partner

--- a/src/REAXFF/fix_acks2_reaxff.cpp
+++ b/src/REAXFF/fix_acks2_reaxff.cpp
@@ -371,7 +371,7 @@ void FixACKS2ReaxFF::init_matvec()
   /* fill-in X matrix */
   compute_X();
   pack_flag = 4;
-  comm->reverse_comm_fix(this); //Coll_Vector(X_diag);
+  comm->reverse_comm(this); //Coll_Vector(X_diag);
 
   int ii, i;
 
@@ -504,7 +504,7 @@ int FixACKS2ReaxFF::BiCGStab(double *b, double *x)
 
   sparse_matvec_acks2(&H, &X, x, d);
   pack_flag = 1;
-  comm->reverse_comm_fix(this); //Coll_Vector(d);
+  comm->reverse_comm(this); //Coll_Vector(d);
   more_reverse_comm(d);
 
   vector_sum(r , 1.,  b, -1., d, nn);
@@ -547,7 +547,7 @@ int FixACKS2ReaxFF::BiCGStab(double *b, double *x)
     more_forward_comm(d);
     sparse_matvec_acks2(&H, &X, d, z);
     pack_flag = 2;
-    comm->reverse_comm_fix(this); //Coll_vector(z);
+    comm->reverse_comm(this); //Coll_vector(z);
     more_reverse_comm(z);
 
     tmp = parallel_dot(r_hat, z, nn);
@@ -582,7 +582,7 @@ int FixACKS2ReaxFF::BiCGStab(double *b, double *x)
     more_forward_comm(q_hat);
     sparse_matvec_acks2(&H, &X, q_hat, y);
     pack_flag = 3;
-    comm->reverse_comm_fix(this); //Dist_vector(y);
+    comm->reverse_comm(this); //Dist_vector(y);
     more_reverse_comm(y);
 
     sigma = parallel_dot(y, q, nn);

--- a/src/REAXFF/fix_acks2_reaxff.cpp
+++ b/src/REAXFF/fix_acks2_reaxff.cpp
@@ -405,7 +405,7 @@ void FixACKS2ReaxFF::init_matvec()
   }
 
   pack_flag = 2;
-  comm->forward_comm_fix(this); //Dist_vector(s);
+  comm->forward_comm(this); //Dist_vector(s);
   more_forward_comm(s);
 }
 
@@ -543,7 +543,7 @@ int FixACKS2ReaxFF::BiCGStab(double *b, double *x)
     }
 
     pack_flag = 1;
-    comm->forward_comm_fix(this); //Dist_vector(d);
+    comm->forward_comm(this); //Dist_vector(d);
     more_forward_comm(d);
     sparse_matvec_acks2(&H, &X, d, z);
     pack_flag = 2;
@@ -578,7 +578,7 @@ int FixACKS2ReaxFF::BiCGStab(double *b, double *x)
     }
 
     pack_flag = 3;
-    comm->forward_comm_fix(this); //Dist_vector(q_hat);
+    comm->forward_comm(this); //Dist_vector(q_hat);
     more_forward_comm(q_hat);
     sparse_matvec_acks2(&H, &X, q_hat, y);
     pack_flag = 3;
@@ -699,7 +699,7 @@ void FixACKS2ReaxFF::calculate_Q()
   }
 
   pack_flag = 2;
-  comm->forward_comm_fix(this); //Dist_vector(s);
+  comm->forward_comm(this); //Dist_vector(s);
 
   for (int ii = 0; ii < NN; ++ii) {
     i = ilist[ii];

--- a/src/REAXFF/fix_qeq_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_reaxff.cpp
@@ -724,7 +724,7 @@ int FixQEqReaxFF::CG(double *b, double *x)
 
   pack_flag = 1;
   sparse_matvec(&H, x, q);
-  comm->reverse_comm_fix(this); //Coll_Vector(q);
+  comm->reverse_comm(this); //Coll_Vector(q);
 
   vector_sum(r , 1.,  b, -1., q, nn);
 
@@ -740,7 +740,7 @@ int FixQEqReaxFF::CG(double *b, double *x)
   for (i = 1; i < imax && sqrt(sig_new) / b_norm > tolerance; ++i) {
     comm->forward_comm(this); //Dist_vector(d);
     sparse_matvec(&H, d, q);
-    comm->reverse_comm_fix(this); //Coll_vector(q);
+    comm->reverse_comm(this); //Coll_vector(q);
 
     tmp = parallel_dot(d, q, nn);
     alpha = sig_new / tmp;

--- a/src/REAXFF/fix_qeq_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_reaxff.cpp
@@ -625,9 +625,9 @@ void FixQEqReaxFF::init_matvec()
   }
 
   pack_flag = 2;
-  comm->forward_comm_fix(this); //Dist_vector(s);
+  comm->forward_comm(this); //Dist_vector(s);
   pack_flag = 3;
-  comm->forward_comm_fix(this); //Dist_vector(t);
+  comm->forward_comm(this); //Dist_vector(t);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -738,7 +738,7 @@ int FixQEqReaxFF::CG(double *b, double *x)
   sig_new = parallel_dot(r, d, nn);
 
   for (i = 1; i < imax && sqrt(sig_new) / b_norm > tolerance; ++i) {
-    comm->forward_comm_fix(this); //Dist_vector(d);
+    comm->forward_comm(this); //Dist_vector(d);
     sparse_matvec(&H, d, q);
     comm->reverse_comm_fix(this); //Coll_vector(q);
 
@@ -832,7 +832,7 @@ void FixQEqReaxFF::calculate_Q()
   }
 
   pack_flag = 4;
-  comm->forward_comm_fix(this); //Dist_vector(atom->q);
+  comm->forward_comm(this); //Dist_vector(atom->q);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/REAXFF/fix_reaxff_species.cpp
+++ b/src/REAXFF/fix_reaxff_species.cpp
@@ -413,7 +413,7 @@ void FixReaxFFSpecies::FindMolecule ()
 
   loop = 0;
   while (true) {
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
     loop ++;
 
     change = 0;

--- a/src/REAXFF/pair_reaxff.cpp
+++ b/src/REAXFF/pair_reaxff.cpp
@@ -450,7 +450,7 @@ void PairReaxFF::compute(int eflag, int vflag)
   // communicate num_bonds once every reneighboring
   // 2 num arrays stored by fix, grab ptr to them
 
-  if (neighbor->ago == 0) comm->forward_comm_fix(fix_reaxff);
+  if (neighbor->ago == 0) comm->forward_comm(fix_reaxff);
   int *num_bonds = fix_reaxff->num_bonds;
   int *num_hbonds = fix_reaxff->num_hbonds;
 

--- a/src/REPLICA/fix_hyper_local.cpp
+++ b/src/REPLICA/fix_hyper_local.cpp
@@ -529,7 +529,7 @@ void FixHyperLocal::pre_reverse(int /* eflag */, int /* vflag */)
 
   commflag = STRAIN;
   comm->reverse_comm_fix(this);
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   //time3 = platform::walltime();
 
@@ -644,7 +644,7 @@ void FixHyperLocal::pre_reverse(int /* eflag */, int /* vflag */)
 
   commflag = STRAINDOMAIN;
   comm->reverse_comm_fix(this);
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 
   //time5 = platform::walltime();
 
@@ -832,7 +832,7 @@ void FixHyperLocal::pre_reverse(int /* eflag */, int /* vflag */)
 
     commflag = BIASFLAG;
     comm->reverse_comm_fix(this);
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
 
     // loop over Dcut full neighbor list
     // I and J may be ghost atoms

--- a/src/REPLICA/fix_hyper_local.cpp
+++ b/src/REPLICA/fix_hyper_local.cpp
@@ -528,7 +528,7 @@ void FixHyperLocal::pre_reverse(int /* eflag */, int /* vflag */)
   // forward comm acquires maxstrain of all current ghost atoms
 
   commflag = STRAIN;
-  comm->reverse_comm_fix(this);
+  comm->reverse_comm(this);
   comm->forward_comm(this);
 
   //time3 = platform::walltime();
@@ -643,7 +643,7 @@ void FixHyperLocal::pre_reverse(int /* eflag */, int /* vflag */)
   // forward comm acquires maxstrain_domain of all current ghost atoms
 
   commflag = STRAINDOMAIN;
-  comm->reverse_comm_fix(this);
+  comm->reverse_comm(this);
   comm->forward_comm(this);
 
   //time5 = platform::walltime();
@@ -831,7 +831,7 @@ void FixHyperLocal::pre_reverse(int /* eflag */, int /* vflag */)
     // forward comm to set biasflag for all ghost atoms
 
     commflag = BIASFLAG;
-    comm->reverse_comm_fix(this);
+    comm->reverse_comm(this);
     comm->forward_comm(this);
 
     // loop over Dcut full neighbor list
@@ -1018,7 +1018,7 @@ void FixHyperLocal::build_bond_list(int natom)
     }
 
     commflag = BIASCOEFF;
-    comm->reverse_comm_fix_variable(this);
+    comm->reverse_comm_variable(this);
 
     mymax = 0;
     for (i = 0; i < nall; i++) mymax = MAX(mymax,numcoeff[i]);
@@ -1349,7 +1349,7 @@ int FixHyperLocal::pack_reverse_comm(int n, int first, double *buf)
 }
 
 /* ----------------------------------------------------------------------
-   callback by comm->reverse_comm_fix_variable() in build_bond()
+   callback by comm->reverse_comm_variable() in build_bond()
    same logic as BIASCOEFF option in pack_reverse_comm()
    m = returned size of message
 ------------------------------------------------------------------------- */
@@ -1372,7 +1372,7 @@ void FixHyperLocal::unpack_reverse_comm(int n, int *list, double *buf)
 
   // return if n = 0
   // b/c if there are no atoms (n = 0), the message will not have
-  //   been sent by Comm::reverse_comm_fix() or reverse_comm_fix_variable()
+  //   been sent by Comm::reverse_comm() or reverse_comm_variable()
   // so must not read nonzero from first buf location (would be zero anyway)
 
   if (n == 0) return;

--- a/src/REPLICA/fix_pimd.cpp
+++ b/src/REPLICA/fix_pimd.cpp
@@ -502,7 +502,7 @@ void FixPIMD::nmpimd_init()
 void FixPIMD::nmpimd_fill(double **ptr)
 {
   comm_ptr = ptr;
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/RIGID/fix_rattle.cpp
+++ b/src/RIGID/fix_rattle.cpp
@@ -158,7 +158,7 @@ void FixRattle::post_force(int vflag)
 
   if (nprocs > 1) {
     comm_mode = VP;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   // correct the velocity for each molecule accordingly
@@ -190,7 +190,7 @@ void FixRattle::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 
   if (nprocs > 1) {
     comm_mode = VP;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   // correct the velocity for each molecule accordingly
@@ -720,7 +720,7 @@ void FixRattle::shake_end_of_step(int vflag) {
 
   if (nprocs > 1) {
     comm_mode = V;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   comm_mode = XSHAKE;
@@ -761,7 +761,7 @@ void FixRattle::correct_velocities() {
 
   if (nprocs > 1) {
     comm_mode = VP;
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
 
   // correct the velocity for each molecule accordingly
@@ -790,7 +790,7 @@ void FixRattle::end_of_step()
 {
   if (nprocs > 1) {
        comm_mode = V;
-       comm->forward_comm_fix(this);
+       comm->forward_comm(this);
   }
   if (!check_constraints(v, RATTLE_TEST_POS, RATTLE_TEST_VEL) && RATTLE_RAISE_ERROR) {
     error->one(FLERR, "Rattle failed ");

--- a/src/RIGID/fix_rigid_nh_small.cpp
+++ b/src/RIGID/fix_rigid_nh_small.cpp
@@ -551,7 +551,7 @@ void FixRigidNHSmall::initial_integrate(int vflag)
   // forward communicate updated info of all bodies
 
   commflag = INITIAL;
-  comm->forward_comm_fix(this,26);
+  comm->forward_comm(this,26);
 
   // accumulate translational and rotational kinetic energies
 
@@ -699,7 +699,7 @@ void FixRigidNHSmall::final_integrate()
   // forward communicate updated info of all bodies
 
   commflag = FINAL;
-  comm->forward_comm_fix(this,10);
+  comm->forward_comm(this,10);
 
   // accumulate translational and rotational kinetic energies
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -706,7 +706,7 @@ void FixRigidSmall::setup(int vflag)
   // reverse communicate fcm, torque of all bodies
 
   commflag = FORCE_TORQUE;
-  comm->reverse_comm_fix(this,6);
+  comm->reverse_comm(this,6);
 
   // virial setup before call to set_v
 
@@ -970,7 +970,7 @@ void FixRigidSmall::compute_forces_and_torques()
   // reverse communicate fcm, torque of all bodies
 
   commflag = FORCE_TORQUE;
-  comm->reverse_comm_fix(this,6);
+  comm->reverse_comm(this,6);
 
   // include Langevin thermostat forces and torques
 
@@ -1182,7 +1182,7 @@ int FixRigidSmall::dof(int tgroup)
   }
 
   commflag = DOF;
-  comm->reverse_comm_fix(this,3);
+  comm->reverse_comm(this,3);
 
   // nall = count0 = # of point particles in each rigid body
   // mall = count1 = # of finite-size particles in each rigid body
@@ -1958,7 +1958,7 @@ void FixRigidSmall::setup_bodies_static()
   // reverse communicate xcm, mass of all bodies
 
   commflag = XCM_MASS;
-  comm->reverse_comm_fix(this,8);
+  comm->reverse_comm(this,8);
 
   for (ibody = 0; ibody < nlocal_body; ibody++) {
     xcm = body[ibody].xcm;
@@ -2093,7 +2093,7 @@ void FixRigidSmall::setup_bodies_static()
   // reverse communicate inertia tensor of all bodies
 
   commflag = ITENSOR;
-  comm->reverse_comm_fix(this,6);
+  comm->reverse_comm(this,6);
 
   // overwrite Cartesian inertia tensor with file values
 
@@ -2303,7 +2303,7 @@ void FixRigidSmall::setup_bodies_static()
   // reverse communicate inertia tensor of all bodies
 
   commflag = ITENSOR;
-  comm->reverse_comm_fix(this,6);
+  comm->reverse_comm(this,6);
 
   // error check that re-computed moments of inertia match diagonalized ones
   // do not do test for bodies with params read from inpfile
@@ -2442,7 +2442,7 @@ void FixRigidSmall::setup_bodies_dynamic()
   // reverse communicate vcm, angmom of all bodies
 
   commflag = VCM_ANGMOM;
-  comm->reverse_comm_fix(this,6);
+  comm->reverse_comm(this,6);
 
   // normalize velocity of COM
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -721,7 +721,7 @@ void FixRigidSmall::setup(int vflag)
   }
 
   commflag = FINAL;
-  comm->forward_comm_fix(this,10);
+  comm->forward_comm(this,10);
 
   // set velocity/rotation of atoms in rigid bodues
 
@@ -786,7 +786,7 @@ void FixRigidSmall::initial_integrate(int vflag)
   // forward communicate updated info of all bodies
 
   commflag = INITIAL;
-  comm->forward_comm_fix(this,29);
+  comm->forward_comm(this,29);
 
   // set coords/orient and velocity/rotation of atoms in rigid bodies
 
@@ -1036,7 +1036,7 @@ void FixRigidSmall::final_integrate()
   // forward communicate updated info of all bodies
 
   commflag = FINAL;
-  comm->forward_comm_fix(this,10);
+  comm->forward_comm(this,10);
 
   // set velocity/rotation of atoms in rigid bodies
   // virial is already setup from initial_integrate
@@ -1096,7 +1096,7 @@ void FixRigidSmall::pre_neighbor()
 
   nghost_body = 0;
   commflag = FULL_BODY;
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   reset_atom2body();
   //check(4);
 
@@ -1913,7 +1913,7 @@ void FixRigidSmall::setup_bodies_static()
 
   nghost_body = 0;
   commflag = FULL_BODY;
-  comm->forward_comm_fix(this);
+  comm->forward_comm(this);
   reset_atom2body();
 
   // compute mass & center-of-mass of each rigid body
@@ -2168,7 +2168,7 @@ void FixRigidSmall::setup_bodies_static()
   // forward communicate updated info of all bodies
 
   commflag = INITIAL;
-  comm->forward_comm_fix(this,29);
+  comm->forward_comm(this,29);
 
   // displace = initial atom coords in basis of principal axes
   // set displace = 0.0 for atoms not in any rigid body
@@ -3407,7 +3407,7 @@ void FixRigidSmall::zero_momentum()
   // forward communicate of vcm to all ghost copies
 
   commflag = FINAL;
-  comm->forward_comm_fix(this,10);
+  comm->forward_comm(this,10);
 
   // set velocity of atoms in rigid bodues
 
@@ -3433,7 +3433,7 @@ void FixRigidSmall::zero_rotation()
   // forward communicate of omega to all ghost copies
 
   commflag = FINAL;
-  comm->forward_comm_fix(this,10);
+  comm->forward_comm(this,10);
 
   // set velocity of atoms in rigid bodues
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -574,7 +574,7 @@ void FixShake::post_force(int vflag)
   // communicate results if necessary
 
   unconstrained_update();
-  if (nprocs > 1) comm->forward_comm_fix(this);
+  if (nprocs > 1) comm->forward_comm(this);
 
   // virial setup
 
@@ -618,7 +618,7 @@ void FixShake::post_force_respa(int vflag, int ilevel, int iloop)
   // communicate results if necessary
 
   unconstrained_update_respa(ilevel);
-  if (nprocs > 1) comm->forward_comm_fix(this);
+  if (nprocs > 1) comm->forward_comm(this);
 
   // virial setup only needed on last iteration of innermost level
   //   and if pressure is requested
@@ -3110,7 +3110,7 @@ void FixShake::correct_coordinates(int vflag) {
   double **xtmp = xshake;
   xshake = x;
   if (nprocs > 1) {
-    comm->forward_comm_fix(this);
+    comm->forward_comm(this);
   }
   xshake = xtmp;
 }

--- a/src/SMTBQ/pair_smtbq.cpp
+++ b/src/SMTBQ/pair_smtbq.cpp
@@ -3397,7 +3397,7 @@ void PairSMTBQ::forward(double *tab)
 
   for (i=0; i<nlocal+nghost; i++) tab_comm[i] = tab[i];
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   for (i=0; i<nlocal+nghost; i++) tab[i] = tab_comm[i];
 }
@@ -3427,7 +3427,7 @@ void PairSMTBQ::forward_int(int *tab)
 
   for (i=0; i<nlocal+nghost; i++) { tab_comm[i] = static_cast<double>(tab[i]);}
 
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 
   for (i=0; i<nlocal+nghost; i++) {
     if (fabs(tab_comm[i]) > 0.1) tab[i] = int(tab_comm[i]) ; }

--- a/src/SMTBQ/pair_smtbq.cpp
+++ b/src/SMTBQ/pair_smtbq.cpp
@@ -3412,7 +3412,7 @@ void PairSMTBQ::reverse(double *tab)
 
   for (i=0; i<nlocal+nghost; i++)  tab_comm[i] = tab[i];
 
-  comm->reverse_comm_pair(this);
+  comm->reverse_comm(this);
 
   for (i=0; i<nlocal+nghost; i++)  tab[i] = tab_comm[i];
 }
@@ -3443,7 +3443,7 @@ void PairSMTBQ::reverse_int(int *tab)
 
   for (i=0; i<nlocal+nghost; i++) { tab_comm[i] = static_cast<double>(tab[i]);}
 
-  comm->reverse_comm_pair(this);
+  comm->reverse_comm(this);
 
   for (i=0; i<nlocal+nghost; i++) {
     if (fabs(tab_comm[i]) > 0.1) tab[i] = int(tab_comm[i]); }

--- a/src/SPH/pair_sph_rhosum.cpp
+++ b/src/SPH/pair_sph_rhosum.cpp
@@ -196,7 +196,7 @@ void PairSPHRhoSum::compute(int eflag, int vflag) {
   }
 
   // communicate densities
-  comm->forward_comm_pair(this);
+  comm->forward_comm(this);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -775,7 +775,7 @@ void FixSRD::post_force(int /*vflag*/)
   if (bigexist) {
     flocal = f;
     tlocal = torque;
-    comm->reverse_comm_fix(this);
+    comm->reverse_comm(this);
   }
 
   // if any SRD particle has moved too far, trigger reneigh on next step

--- a/src/TALLY/compute_force_tally.cpp
+++ b/src/TALLY/compute_force_tally.cpp
@@ -199,7 +199,7 @@ void ComputeForceTally::compute_peratom()
   // collect contributions from ghost atoms
 
   if (force->newton_pair) {
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
     // clear out ghost atom data after it has been collected to local atoms
     const int nall = atom->nlocal + atom->nghost;

--- a/src/TALLY/compute_heat_flux_tally.cpp
+++ b/src/TALLY/compute_heat_flux_tally.cpp
@@ -210,7 +210,7 @@ void ComputeHeatFluxTally::compute_vector()
   // collect contributions from ghost atoms
 
   if (force->newton_pair) {
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
     const int nall = atom->nlocal + atom->nghost;
     for (int i = atom->nlocal; i < nall; ++i) {

--- a/src/TALLY/compute_heat_flux_virial_tally.cpp
+++ b/src/TALLY/compute_heat_flux_virial_tally.cpp
@@ -216,7 +216,7 @@ void ComputeHeatFluxVirialTally::compute_peratom()
   // collect contributions from ghost atoms
 
   if (force->newton_pair) {
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
     // clear out ghost atom data after it has been collected to local atoms
     const int nall = atom->nlocal + atom->nghost;

--- a/src/TALLY/compute_pe_tally.cpp
+++ b/src/TALLY/compute_pe_tally.cpp
@@ -189,7 +189,7 @@ void ComputePETally::compute_peratom()
   // collect contributions from ghost atoms
 
   if (force->newton_pair) {
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
     // clear out ghost atom data after it has been collected to local atoms
     const int nall = atom->nlocal + atom->nghost;

--- a/src/TALLY/compute_stress_tally.cpp
+++ b/src/TALLY/compute_stress_tally.cpp
@@ -227,7 +227,7 @@ void ComputeStressTally::compute_peratom()
   // collect contributions from ghost atoms
 
   if (force->newton_pair) {
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
     const int nall = atom->nlocal + atom->nghost;
     for (int i = atom->nlocal; i < nall; ++i)

--- a/src/VORONOI/compute_voronoi_atom.cpp
+++ b/src/VORONOI/compute_voronoi_atom.cpp
@@ -332,7 +332,7 @@ void ComputeVoronoi::buildCells()
     input->variable->compute_atom(radvar,0,rfield,1,0);
 
     // communicate values to ghost atoms of neighboring nodes
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
 
     // polydisperse voro++ container
     delete con_poly;

--- a/src/comm.h
+++ b/src/comm.h
@@ -82,14 +82,14 @@ class Comm : protected Pointers {
 
   // forward/reverse comm from a Pair, Fix, Compute, Dump
 
-  virtual void forward_comm_pair(class Pair *) = 0;
+  virtual void forward_comm(class Pair *) = 0;
   virtual void reverse_comm_pair(class Pair *) = 0;
-  virtual void forward_comm_fix(class Fix *, int size = 0) = 0;
+  virtual void forward_comm(class Fix *, int size = 0) = 0;
   virtual void reverse_comm_fix(class Fix *, int size = 0) = 0;
   virtual void reverse_comm_fix_variable(class Fix *) = 0;
-  virtual void forward_comm_compute(class Compute *) = 0;
+  virtual void forward_comm(class Compute *) = 0;
   virtual void reverse_comm_compute(class Compute *) = 0;
-  virtual void forward_comm_dump(class Dump *) = 0;
+  virtual void forward_comm(class Dump *) = 0;
   virtual void reverse_comm_dump(class Dump *) = 0;
 
   // forward comm of an array

--- a/src/comm.h
+++ b/src/comm.h
@@ -83,14 +83,14 @@ class Comm : protected Pointers {
   // forward/reverse comm from a Pair, Fix, Compute, Dump
 
   virtual void forward_comm(class Pair *) = 0;
-  virtual void reverse_comm_pair(class Pair *) = 0;
+  virtual void reverse_comm(class Pair *) = 0;
   virtual void forward_comm(class Fix *, int size = 0) = 0;
-  virtual void reverse_comm_fix(class Fix *, int size = 0) = 0;
-  virtual void reverse_comm_fix_variable(class Fix *) = 0;
+  virtual void reverse_comm(class Fix *, int size = 0) = 0;
+  virtual void reverse_comm_variable(class Fix *) = 0;
   virtual void forward_comm(class Compute *) = 0;
-  virtual void reverse_comm_compute(class Compute *) = 0;
+  virtual void reverse_comm(class Compute *) = 0;
   virtual void forward_comm(class Dump *) = 0;
-  virtual void reverse_comm_dump(class Dump *) = 0;
+  virtual void reverse_comm(class Dump *) = 0;
 
   // forward comm of an array
   // exchange of info on neigh stencil

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -1001,7 +1001,7 @@ void CommBrick::borders()
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommBrick::forward_comm_pair(Pair *pair)
+void CommBrick::forward_comm(Pair *pair)
 {
   int iswap,n;
   double *buf;
@@ -1082,7 +1082,7 @@ void CommBrick::reverse_comm_pair(Pair *pair)
      some are smaller than max stored in its comm_forward
 ------------------------------------------------------------------------- */
 
-void CommBrick::forward_comm_fix(Fix *fix, int size)
+void CommBrick::forward_comm(Fix *fix, int size)
 {
   int iswap,n,nsize;
   double *buf;
@@ -1210,7 +1210,7 @@ void CommBrick::reverse_comm_fix_variable(Fix *fix)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommBrick::forward_comm_compute(Compute *compute)
+void CommBrick::forward_comm(Compute *compute)
 {
   int iswap,n;
   double *buf;
@@ -1287,7 +1287,7 @@ void CommBrick::reverse_comm_compute(Compute *compute)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommBrick::forward_comm_dump(Dump *dump)
+void CommBrick::forward_comm(Dump *dump)
 {
   int iswap,n;
   double *buf;

--- a/src/comm_brick.cpp
+++ b/src/comm_brick.cpp
@@ -1040,7 +1040,7 @@ void CommBrick::forward_comm(Pair *pair)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommBrick::reverse_comm_pair(Pair *pair)
+void CommBrick::reverse_comm(Pair *pair)
 {
   int iswap,n;
   double *buf;
@@ -1126,7 +1126,7 @@ void CommBrick::forward_comm(Fix *fix, int size)
      some are smaller than max stored in its comm_forward
 ------------------------------------------------------------------------- */
 
-void CommBrick::reverse_comm_fix(Fix *fix, int size)
+void CommBrick::reverse_comm(Fix *fix, int size)
 {
   int iswap,n,nsize;
   double *buf;
@@ -1166,7 +1166,7 @@ void CommBrick::reverse_comm_fix(Fix *fix, int size)
    handshake sizes before each Irecv/Send to insure buf_recv is big enough
 ------------------------------------------------------------------------- */
 
-void CommBrick::reverse_comm_fix_variable(Fix *fix)
+void CommBrick::reverse_comm_variable(Fix *fix)
 {
   int iswap,nsend,nrecv;
   double *buf;
@@ -1249,7 +1249,7 @@ void CommBrick::forward_comm(Compute *compute)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommBrick::reverse_comm_compute(Compute *compute)
+void CommBrick::reverse_comm(Compute *compute)
 {
   int iswap,n;
   double *buf;
@@ -1326,7 +1326,7 @@ void CommBrick::forward_comm(Dump *dump)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommBrick::reverse_comm_dump(Dump *dump)
+void CommBrick::reverse_comm(Dump *dump)
 {
   int iswap,n;
   double *buf;

--- a/src/comm_brick.h
+++ b/src/comm_brick.h
@@ -31,20 +31,17 @@ class CommBrick : public Comm {
   void exchange() override;                     // move atoms to new procs
   void borders() override;                      // setup list of atoms to comm
 
-  void forward_comm(class Pair *) override;    // forward comm from a Pair
-  void reverse_comm(class Pair *) override;    // reverse comm from a Pair
-  void forward_comm(class Fix *, int size = 0) override;
-  // forward comm from a Fix
-  void reverse_comm(class Fix *, int size = 0) override;
-  // reverse comm from a Fix
-  void reverse_comm_variable(class Fix *) override;
-  // variable size reverse comm from a Fix
-  void forward_comm(class Compute *) override;    // forward from a Compute
-  void reverse_comm(class Compute *) override;    // reverse from a Compute
-  void forward_comm(class Dump *) override;          // forward comm from a Dump
-  void reverse_comm(class Dump *) override;          // reverse comm from a Dump
+  void forward_comm(class Pair *) override;                 // forward comm from a Pair
+  void reverse_comm(class Pair *) override;                 // reverse comm from a Pair
+  void forward_comm(class Fix *, int size = 0) override;    // forward comm from a Fix
+  void reverse_comm(class Fix *, int size = 0) override;    // reverse comm from a Fix
+  void reverse_comm_variable(class Fix *) override;         // variable size reverse comm from a Fix
+  void forward_comm(class Compute *) override;              // forward from a Compute
+  void reverse_comm(class Compute *) override;              // reverse from a Compute
+  void forward_comm(class Dump *) override;                 // forward comm from a Dump
+  void reverse_comm(class Dump *) override;                 // reverse comm from a Dump
 
-  void forward_comm_array(int, double **) override;    // forward comm of array
+  void forward_comm_array(int, double **) override;            // forward comm of array
   int exchange_variable(int, double *, double *&) override;    // exchange on neigh stencil
   void *extract(const char *, int &) override;
   double memory_usage() override;

--- a/src/comm_brick.h
+++ b/src/comm_brick.h
@@ -31,17 +31,17 @@ class CommBrick : public Comm {
   void exchange() override;                     // move atoms to new procs
   void borders() override;                      // setup list of atoms to comm
 
-  void forward_comm_pair(class Pair *) override;    // forward comm from a Pair
+  void forward_comm(class Pair *) override;    // forward comm from a Pair
   void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
-  void forward_comm_fix(class Fix *, int size = 0) override;
+  void forward_comm(class Fix *, int size = 0) override;
   // forward comm from a Fix
   void reverse_comm_fix(class Fix *, int size = 0) override;
   // reverse comm from a Fix
   void reverse_comm_fix_variable(class Fix *) override;
   // variable size reverse comm from a Fix
-  void forward_comm_compute(class Compute *) override;    // forward from a Compute
+  void forward_comm(class Compute *) override;    // forward from a Compute
   void reverse_comm_compute(class Compute *) override;    // reverse from a Compute
-  void forward_comm_dump(class Dump *) override;          // forward comm from a Dump
+  void forward_comm(class Dump *) override;          // forward comm from a Dump
   void reverse_comm_dump(class Dump *) override;          // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;    // forward comm of array

--- a/src/comm_brick.h
+++ b/src/comm_brick.h
@@ -32,17 +32,17 @@ class CommBrick : public Comm {
   void borders() override;                      // setup list of atoms to comm
 
   void forward_comm(class Pair *) override;    // forward comm from a Pair
-  void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
+  void reverse_comm(class Pair *) override;    // reverse comm from a Pair
   void forward_comm(class Fix *, int size = 0) override;
   // forward comm from a Fix
-  void reverse_comm_fix(class Fix *, int size = 0) override;
+  void reverse_comm(class Fix *, int size = 0) override;
   // reverse comm from a Fix
-  void reverse_comm_fix_variable(class Fix *) override;
+  void reverse_comm_variable(class Fix *) override;
   // variable size reverse comm from a Fix
   void forward_comm(class Compute *) override;    // forward from a Compute
-  void reverse_comm_compute(class Compute *) override;    // reverse from a Compute
+  void reverse_comm(class Compute *) override;    // reverse from a Compute
   void forward_comm(class Dump *) override;          // forward comm from a Dump
-  void reverse_comm_dump(class Dump *) override;          // reverse comm from a Dump
+  void reverse_comm(class Dump *) override;          // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;    // forward comm of array
   int exchange_variable(int, double *, double *&) override;    // exchange on neigh stencil

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -1423,7 +1423,7 @@ void CommTiled::forward_comm(Pair *pair)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiled::reverse_comm_pair(Pair *pair)
+void CommTiled::reverse_comm(Pair *pair)
 {
   int i,irecv,n,nsend,nrecv;
 
@@ -1523,7 +1523,7 @@ void CommTiled::forward_comm(Fix *fix, int size)
      some are smaller than max stored in its comm_forward
 ------------------------------------------------------------------------- */
 
-void CommTiled::reverse_comm_fix(Fix *fix, int size)
+void CommTiled::reverse_comm(Fix *fix, int size)
 {
   int i,irecv,n,nsize,nsend,nrecv;
 
@@ -1571,7 +1571,7 @@ void CommTiled::reverse_comm_fix(Fix *fix, int size)
    NOTE: how to setup one big buf recv with correct offsets ??
 ------------------------------------------------------------------------- */
 
-void CommTiled::reverse_comm_fix_variable(Fix * /*fix*/)
+void CommTiled::reverse_comm_variable(Fix * /*fix*/)
 {
   error->all(FLERR,"Reverse comm fix variable not yet supported by CommTiled");
 }
@@ -1629,7 +1629,7 @@ void CommTiled::forward_comm(Compute *compute)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiled::reverse_comm_compute(Compute *compute)
+void CommTiled::reverse_comm(Compute *compute)
 {
   int i,irecv,n,nsend,nrecv;
 
@@ -1722,7 +1722,7 @@ void CommTiled::forward_comm(Dump *dump)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiled::reverse_comm_dump(Dump *dump)
+void CommTiled::reverse_comm(Dump *dump)
 {
   int i,irecv,n,nsend,nrecv;
 

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -1375,7 +1375,7 @@ void CommTiled::borders()
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiled::forward_comm_pair(Pair *pair)
+void CommTiled::forward_comm(Pair *pair)
 {
   int i,irecv,n,nsend,nrecv;
 
@@ -1472,7 +1472,7 @@ void CommTiled::reverse_comm_pair(Pair *pair)
      some are smaller than max stored in its comm_forward
 ------------------------------------------------------------------------- */
 
-void CommTiled::forward_comm_fix(Fix *fix, int size)
+void CommTiled::forward_comm(Fix *fix, int size)
 {
   int i,irecv,n,nsize,nsend,nrecv;
 
@@ -1581,7 +1581,7 @@ void CommTiled::reverse_comm_fix_variable(Fix * /*fix*/)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiled::forward_comm_compute(Compute *compute)
+void CommTiled::forward_comm(Compute *compute)
 {
   int i,irecv,n,nsend,nrecv;
 
@@ -1675,7 +1675,7 @@ void CommTiled::reverse_comm_compute(Compute *compute)
    nsize used only to set recv buffer limit
 ------------------------------------------------------------------------- */
 
-void CommTiled::forward_comm_dump(Dump *dump)
+void CommTiled::forward_comm(Dump *dump)
 {
   int i,irecv,n,nsend,nrecv;
 

--- a/src/comm_tiled.h
+++ b/src/comm_tiled.h
@@ -25,24 +25,21 @@ class CommTiled : public Comm {
   ~CommTiled() override;
 
   void init() override;
-  void setup() override;                                // setup comm pattern
+  void setup() override;                        // setup comm pattern
   void forward_comm(int dummy = 0) override;    // forward comm of atom coords
   void reverse_comm() override;                 // reverse comm of forces
   void exchange() override;                     // move atoms to new procs
   void borders() override;                      // setup list of atoms to comm
 
-  void forward_comm(class Pair *) override;    // forward comm from a Pair
-  void reverse_comm(class Pair *) override;    // reverse comm from a Pair
-  void forward_comm(class Fix *, int size = 0) override;
-  // forward comm from a Fix
-  void reverse_comm(class Fix *, int size = 0) override;
-  // reverse comm from a Fix
-  void reverse_comm_variable(class Fix *) override;
-  // variable size reverse comm from a Fix
-  void forward_comm(class Compute *) override;    // forward from a Compute
-  void reverse_comm(class Compute *) override;    // reverse from a Compute
-  void forward_comm(class Dump *) override;          // forward comm from a Dump
-  void reverse_comm(class Dump *) override;          // reverse comm from a Dump
+  void forward_comm(class Pair *) override;                 // forward comm from a Pair
+  void reverse_comm(class Pair *) override;                 // reverse comm from a Pair
+  void forward_comm(class Fix *, int size = 0) override;    // forward comm from a Fix
+  void reverse_comm(class Fix *, int size = 0) override;    // reverse comm from a Fix
+  void reverse_comm_variable(class Fix *) override;         // variable size reverse comm from a Fix
+  void forward_comm(class Compute *) override;              // forward from a Compute
+  void reverse_comm(class Compute *) override;              // reverse from a Compute
+  void forward_comm(class Dump *) override;                 // forward comm from a Dump
+  void reverse_comm(class Dump *) override;                 // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;            // forward comm of array
   int exchange_variable(int, double *, double *&) override;    // exchange on neigh stencil

--- a/src/comm_tiled.h
+++ b/src/comm_tiled.h
@@ -32,17 +32,17 @@ class CommTiled : public Comm {
   void borders() override;                      // setup list of atoms to comm
 
   void forward_comm(class Pair *) override;    // forward comm from a Pair
-  void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
+  void reverse_comm(class Pair *) override;    // reverse comm from a Pair
   void forward_comm(class Fix *, int size = 0) override;
   // forward comm from a Fix
-  void reverse_comm_fix(class Fix *, int size = 0) override;
+  void reverse_comm(class Fix *, int size = 0) override;
   // reverse comm from a Fix
-  void reverse_comm_fix_variable(class Fix *) override;
+  void reverse_comm_variable(class Fix *) override;
   // variable size reverse comm from a Fix
   void forward_comm(class Compute *) override;    // forward from a Compute
-  void reverse_comm_compute(class Compute *) override;    // reverse from a Compute
+  void reverse_comm(class Compute *) override;    // reverse from a Compute
   void forward_comm(class Dump *) override;          // forward comm from a Dump
-  void reverse_comm_dump(class Dump *) override;          // reverse comm from a Dump
+  void reverse_comm(class Dump *) override;          // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;            // forward comm of array
   int exchange_variable(int, double *, double *&) override;    // exchange on neigh stencil

--- a/src/comm_tiled.h
+++ b/src/comm_tiled.h
@@ -31,17 +31,17 @@ class CommTiled : public Comm {
   void exchange() override;                     // move atoms to new procs
   void borders() override;                      // setup list of atoms to comm
 
-  void forward_comm_pair(class Pair *) override;    // forward comm from a Pair
+  void forward_comm(class Pair *) override;    // forward comm from a Pair
   void reverse_comm_pair(class Pair *) override;    // reverse comm from a Pair
-  void forward_comm_fix(class Fix *, int size = 0) override;
+  void forward_comm(class Fix *, int size = 0) override;
   // forward comm from a Fix
   void reverse_comm_fix(class Fix *, int size = 0) override;
   // reverse comm from a Fix
   void reverse_comm_fix_variable(class Fix *) override;
   // variable size reverse comm from a Fix
-  void forward_comm_compute(class Compute *) override;    // forward from a Compute
+  void forward_comm(class Compute *) override;    // forward from a Compute
   void reverse_comm_compute(class Compute *) override;    // reverse from a Compute
-  void forward_comm_dump(class Dump *) override;          // forward comm from a Dump
+  void forward_comm(class Dump *) override;          // forward comm from a Dump
   void reverse_comm_dump(class Dump *) override;          // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;            // forward comm of array

--- a/src/compute_aggregate_atom.cpp
+++ b/src/compute_aggregate_atom.cpp
@@ -132,7 +132,7 @@ void ComputeAggregateAtom::compute_peratom()
 
   if (group->dynamic[igroup]) {
     commflag = 0;
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
   }
 
   // each atom starts in its own aggregate,
@@ -167,7 +167,7 @@ void ComputeAggregateAtom::compute_peratom()
   int change,done,anychange;
 
   while (true) {
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
 
     // reverse communication when bonds are not stored on every processor
 

--- a/src/compute_aggregate_atom.cpp
+++ b/src/compute_aggregate_atom.cpp
@@ -172,7 +172,7 @@ void ComputeAggregateAtom::compute_peratom()
     // reverse communication when bonds are not stored on every processor
 
     if (force->newton_bond)
-      comm->reverse_comm_compute(this);
+      comm->reverse_comm(this);
 
     change = 0;
     while (true) {

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -260,7 +260,7 @@ int ComputeBondLocal::compute_bonds(int flag)
 
   // communicate ghost velocities if needed
 
-  if (ghostvelflag && !initflag) comm->forward_comm_compute(this);
+  if (ghostvelflag && !initflag) comm->forward_comm(this);
 
   // loop over all atoms and their bonds
 

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -331,7 +331,7 @@ void ComputeCentroidStressAtom::compute_peratom()
   // communicate ghost virials between neighbor procs
 
   if (force->newton || (force->kspace && force->kspace->tip4pflag && force->kspace->compute_flag))
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
   // zero virial of atoms not in group
   // only do this after comm since ghost contributions must be included

--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -131,14 +131,14 @@ void ComputeClusterAtom::compute_peratom()
 
   if (update->post_integrate) {
     commflag = COORDS;
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
   }
 
   // if group is dynamic, insure ghost atom masks are current
 
   if (group->dynamic[igroup]) {
     commflag = MASK;
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
   }
 
   // every atom starts in its own cluster, with clusterID = atomID
@@ -165,7 +165,7 @@ void ComputeClusterAtom::compute_peratom()
   int change,done,anychange;
 
   while (true) {
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
 
     change = 0;
     while (true) {

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -200,7 +200,7 @@ void ComputeCoordAtom::compute_peratom()
     }
     nqlist = c_orientorder->nqlist;
     normv = c_orientorder->array_atom;
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
   }
 
   // invoke full neighbor list (will copy or build if necessary)

--- a/src/compute_fragment_atom.cpp
+++ b/src/compute_fragment_atom.cpp
@@ -121,7 +121,7 @@ void ComputeFragmentAtom::compute_peratom()
 
   if (group->dynamic[igroup]) {
     commflag = 0;
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
   }
 
   // owned + ghost atoms start with fragmentID = atomID
@@ -153,7 +153,7 @@ void ComputeFragmentAtom::compute_peratom()
   while (true) {
     iteration++;
 
-    comm->forward_comm_compute(this);
+    comm->forward_comm(this);
     done = 1;
 
     // set markflag = 0 for all owned atoms, for new iteration

--- a/src/compute_pe_atom.cpp
+++ b/src/compute_pe_atom.cpp
@@ -159,7 +159,7 @@ void ComputePEAtom::compute_peratom()
   // communicate ghost energy between neighbor procs
 
   if (force->newton || (force->kspace && force->kspace->tip4pflag))
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
   // zero energy of atoms not in group
   // only do this after comm since ghost contributions must be included

--- a/src/compute_stress_atom.cpp
+++ b/src/compute_stress_atom.cpp
@@ -233,7 +233,7 @@ void ComputeStressAtom::compute_peratom()
   // communicate ghost virials between neighbor procs
 
   if (force->newton || (force->kspace && force->kspace->tip4pflag))
-    comm->reverse_comm_compute(this);
+    comm->reverse_comm(this);
 
   // zero virial of atoms not in group
   // only do this after comm since ghost contributions must be included

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -898,7 +898,7 @@ void DumpImage::create_image()
       }
     }
 
-    comm->forward_comm_dump(this);
+    comm->forward_comm(this);
 
     for (i = 0; i < nchoose; i++) {
       atom1 = clist[i];

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -379,7 +379,7 @@ void FixNeighHistory::pre_exchange_newton()
   // perform reverse comm to augment owned npartner counts with ghost counts
 
   commflag = NPARTNER;
-  comm->reverse_comm(this,0);
+  comm->reverse_comm(this);
 
   // get page chunks to store partner IDs and values for owned+ghost atoms
 

--- a/src/fix_neigh_history.cpp
+++ b/src/fix_neigh_history.cpp
@@ -62,7 +62,7 @@ FixNeighHistory::FixNeighHistory(LAMMPS *lmp, int narg, char **arg) :
 
   if (newton_pair) comm_reverse = 1;   // just for single npartner value
                                        // variable-size history communicated via
-                                       // reverse_comm_fix_variable()
+                                       // reverse_comm_variable()
 
   // perform initial allocation of atom-based arrays
   // register with atom class
@@ -379,7 +379,7 @@ void FixNeighHistory::pre_exchange_newton()
   // perform reverse comm to augment owned npartner counts with ghost counts
 
   commflag = NPARTNER;
-  comm->reverse_comm_fix(this,0);
+  comm->reverse_comm(this,0);
 
   // get page chunks to store partner IDs and values for owned+ghost atoms
 
@@ -439,7 +439,7 @@ void FixNeighHistory::pre_exchange_newton()
   //   if many touching neighbors for large particle
 
   commflag = PERPARTNER;
-  comm->reverse_comm_fix_variable(this);
+  comm->reverse_comm_variable(this);
 
   // set maxpartner = max # of partners of any owned atom
   // maxexchange = max # of values for any Comm::exchange() atom
@@ -741,7 +741,7 @@ void FixNeighHistory::set_arrays(int i)
 }
 
 /* ----------------------------------------------------------------------
-   only called by Comm::reverse_comm_fix_variable for PERPARTNER mode
+   only called by Comm::reverse_comm_variable for PERPARTNER mode
 ------------------------------------------------------------------------- */
 
 int FixNeighHistory::pack_reverse_comm_size(int n, int first)


### PR DESCRIPTION
**Summary**

Using `void forward_comm_pair(class Pair *)` seems redundant, so this renames the function call to `void forward_comm(class Pair *)`. The same for Fix, Compute, and Dump and also for reverse communication.

**Related Issue(s)**

See discussion at PR #3146 

**Author(s)**

GNU sed v4.8 and GNU grep 3.6

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No backward compatibility is provided.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
