### PR TITLE
Collected small changes

### DIFF
--- a/cmake/Modules/Packages/PLUMED.cmake
+++ b/cmake/Modules/Packages/PLUMED.cmake
@@ -54,8 +54,8 @@ if(DOWNLOAD_PLUMED)
     set(PLUMED_BUILD_BYPRODUCTS "<INSTALL_DIR>/lib/libplumedWrapper.a")
   endif()
 
-  set(PLUMED_URL "https://github.com/plumed/plumed2/releases/download/v2.7.3/plumed-src-2.7.3.tgz" CACHE STRING "URL for PLUMED tarball")
-  set(PLUMED_MD5 "f00cc82edfefe6bb3df934911dbe32fb" CACHE STRING "MD5 checksum of PLUMED tarball")
+  set(PLUMED_URL "https://github.com/plumed/plumed2/releases/download/v2.7.4/plumed-src-2.7.4.tgz" CACHE STRING "URL for PLUMED tarball")
+  set(PLUMED_MD5 "858e0b6aed173748fc85b6bc8a9dcb3e" CACHE STRING "MD5 checksum of PLUMED tarball")
 
   mark_as_advanced(PLUMED_URL)
   mark_as_advanced(PLUMED_MD5)

--- a/doc/src/Developer_comm_ops.rst
+++ b/doc/src/Developer_comm_ops.rst
@@ -90,7 +90,7 @@ For *Fix* classes there is an optional second argument to the
 fix performs multiple modes of communication, with different numbers
 of values per atom.  The fix should set the *comm_forward* and
 *comm_reverse* variables to the maximum value, but can invoke the
-communication for a particulard mode with a smaller value.  For this
+communication for a particular mode with a smaller value.  For this
 to work, the *pack_forward_comm()*, etc methods typically use a class
 member variable to choose which values to pack/unpack into/from the
 buffer.

--- a/doc/src/Modify.rst
+++ b/doc/src/Modify.rst
@@ -1,16 +1,17 @@
 Modifying & extending LAMMPS
 ****************************
 
-LAMMPS is designed in a modular fashion so as to be easy to modify and
+LAMMPS is designed in a modular fashion and to be easy to modify or
 extend with new functionality.  In fact, about 95% of its source code
-is add-on files.  These doc pages give basic instructions on how to do
-this.
+are optional.  The following pages give basic instructions on what
+is required when adding new styles of different kinds to LAMMPS.
 
-If you add a new feature to LAMMPS and think it will be of interest to
-general users, we encourage you to submit it for inclusion in LAMMPS
-as a pull request on our `GitHub site <https://github.com/lammps/lammps>`_,
-after reading about :doc:`how to prepare your code for submission <Modify_contribute>`
-and :doc:`the style requirements and recommendations <Modify_style>`.
+If you add a new feature to LAMMPS and think it will be of general
+interest to other users, we encourage you to submit it for inclusion in
+LAMMPS as a pull request on our `GitHub site
+<https://github.com/lammps/lammps>`_, after reading about :doc:`how to
+prepare your code for submission <Modify_contribute>` and :doc:`the
+style requirements and recommendations <Modify_style>`.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/src/Modify_overview.rst
+++ b/doc/src/Modify_overview.rst
@@ -1,13 +1,14 @@
 Overview
 ========
 
-The best way to add a new feature to LAMMPS is to find a similar
-feature and look at the corresponding source and header files to figure
-out what it does.  You will need some knowledge of C++ to be able to
-understand the high-level structure of LAMMPS and its class
-organization, but functions (class methods) that do actual
-computations are written in vanilla C-style code and operate on simple
-C-style data structures (vectors and arrays).
+The best way to add a new feature to LAMMPS is to find a similar feature
+and look at the corresponding source and header files to figure out what
+it does.  You will need some knowledge of C++ to be able to understand
+the high-level structure of LAMMPS and its class organization, but
+functions (class methods) that do actual computations are mostly written
+in C-style code and operate on simple C-style data structures (vectors
+and arrays).  A high-level overview of the programming style choices in
+LAMMPS is :doc:`given elsewhere <Developer_code_design>`.
 
 Most of the new features described on the :doc:`Modify <Modify>` doc
 page require you to write a new C++ derived class (except for exceptions

--- a/doc/src/Modify_style.rst
+++ b/doc/src/Modify_style.rst
@@ -250,9 +250,11 @@ keep the code readable to programmers that have limited C++ programming
 experience.  C++ constructs are acceptable when they help improving the
 readability and reliability of the code, e.g. when using the
 `std::string` class instead of manipulating pointers and calling the
-string functions of the C library.  In addition and number of convenient
-:doc:`utility functions and classes <Developer_utils>` for recurring
-tasks are provided.
+string functions of the C library.  In addition a collection of
+convenient :doc:`utility functions and classes <Developer_utils>` for
+recurring tasks and a collection of
+:doc:`platform neutral functions <Developer_platform>` for improved
+portability are provided.
 
 Included Fortran code has to be compatible with the Fortran 2003
 standard.  Python code must be compatible with Python 3.5.  Large parts
@@ -261,10 +263,11 @@ compatible with Python 2.7.  Compatibility with Python 2.7 is
 desirable, but compatibility with Python 3.5 is **required**.
 
 Compatibility with these older programming language standards is very
-important to maintain portability, especially with HPC cluster
-environments, which tend to be running older software stacks and LAMMPS
-users may be required to use those older tools or not have the option to
-install newer compilers.
+important to maintain portability and availability of LAMMPS on many
+platforms.  This applies especially to HPC cluster environments, which
+tend to be running older software stacks and LAMMPS users may be
+required to use those older tools for access to advanced hardware
+features or not have the option to install newer compilers or libraries.
 
 Programming conventions (varied)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/plumed/Install.py
+++ b/lib/plumed/Install.py
@@ -17,7 +17,7 @@ parser = ArgumentParser(prog='Install.py',
 
 # settings
 
-version = "2.7.1"
+version = "2.7.4"
 mode = "static"
 
 # help message
@@ -52,10 +52,13 @@ checksums = { \
         '2.6.1' : '89a9a450fc6025299fe16af235957163', \
         '2.6.3' : 'a9f8028fd74528c2024781ea1fdefeee', \
         '2.6.5' : 'b67356f027e5c2747823b0422c3b0ec2', \
+        '2.6.6' : '6b470dcdce04c221ea42d8500b03c49b', \
         '2.7.0' : '95f29dd0c067577f11972ff90dfc7d12', \
         '2.7.1' : '4eac6a462ec84dfe0cec96c82421b8e8', \
         '2.7.2' : 'cfa0b4dd90a81c25d3302e8d97bfeaea', \
         '2.7.3' : 'f00cc82edfefe6bb3df934911dbe32fb', \
+        '2.7.4' : 'f858e0b6aed173748fc85b6bc8a9dcb3', \
+        '2.8.0' : '489b23daba70da78cf0506cbc31689c6', \
         }
 
 # parse and process arguments

--- a/src/INTEL/angle_charmm_intel.cpp
+++ b/src/INTEL/angle_charmm_intel.cpp
@@ -363,13 +363,12 @@ void AngleCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
 template <class flt_t>
 void AngleCharmmIntel::ForceConst<flt_t>::set_ntypes(const int nangletypes,
                                                      Memory *memory) {
+  if (memory != nullptr) _memory = memory;
   if (nangletypes != _nangletypes) {
-    if (_nangletypes > 0)
-      _memory->destroy(fc);
+    _memory->destroy(fc);
 
     if (nangletypes > 0)
       _memory->create(fc,nangletypes,"anglecharmmintel.fc");
   }
   _nangletypes = nangletypes;
-  _memory = memory;
 }

--- a/src/INTEL/angle_charmm_intel.cpp
+++ b/src/INTEL/angle_charmm_intel.cpp
@@ -317,11 +317,8 @@ void AngleCharmmIntel::init_style()
 {
   AngleCharmm::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/angle_charmm_intel.h
+++ b/src/INTEL/angle_charmm_intel.h
@@ -60,7 +60,7 @@ class AngleCharmmIntel : public AngleCharmm {
     } fc_packed1;
 
     fc_packed1 *fc;
-    ForceConst() : _nangletypes(0) {}
+    ForceConst() : fc(nullptr), _nangletypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
     void set_ntypes(const int nangletypes, Memory *memory);

--- a/src/INTEL/angle_harmonic_intel.cpp
+++ b/src/INTEL/angle_harmonic_intel.cpp
@@ -343,13 +343,11 @@ void AngleHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
 template <class flt_t>
 void AngleHarmonicIntel::ForceConst<flt_t>::set_ntypes(const int nangletypes,
                                                      Memory *memory) {
+  if (memory != nullptr) _memory = memory;
   if (nangletypes != _nangletypes) {
-    if (_nangletypes > 0)
-      _memory->destroy(fc);
-
+    _memory->destroy(fc);
     if (nangletypes > 0)
       _memory->create(fc,nangletypes,"anglecharmmintel.fc");
   }
   _nangletypes = nangletypes;
-  _memory = memory;
 }

--- a/src/INTEL/angle_harmonic_intel.cpp
+++ b/src/INTEL/angle_harmonic_intel.cpp
@@ -299,11 +299,8 @@ void AngleHarmonicIntel::init_style()
 {
   AngleHarmonic::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/angle_harmonic_intel.h
+++ b/src/INTEL/angle_harmonic_intel.h
@@ -60,7 +60,7 @@ class AngleHarmonicIntel : public AngleHarmonic {
     } fc_packed1;
 
     fc_packed1 *fc;
-    ForceConst() : _nangletypes(0) {}
+    ForceConst() : fc(nullptr), _nangletypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
     void set_ntypes(const int nangletypes, Memory *memory);

--- a/src/INTEL/bond_fene_intel.cpp
+++ b/src/INTEL/bond_fene_intel.cpp
@@ -323,13 +323,12 @@ void BondFENEIntel::pack_force_const(ForceConst<flt_t> &fc,
 template <class flt_t>
 void BondFENEIntel::ForceConst<flt_t>::set_ntypes(const int nbondtypes,
                                                       Memory *memory) {
+  if (memory != nullptr) _memory = memory;
   if (nbondtypes != _nbondtypes) {
-    if (_nbondtypes > 0)
-      _memory->destroy(fc);
+    _memory->destroy(fc);
 
     if (nbondtypes > 0)
       _memory->create(fc,nbondtypes,"bondfeneintel.fc");
   }
   _nbondtypes = nbondtypes;
-  _memory = memory;
 }

--- a/src/INTEL/bond_fene_intel.cpp
+++ b/src/INTEL/bond_fene_intel.cpp
@@ -277,11 +277,8 @@ void BondFENEIntel::init_style()
 {
   BondFENE::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/bond_fene_intel.h
+++ b/src/INTEL/bond_fene_intel.h
@@ -60,7 +60,7 @@ class BondFENEIntel : public BondFENE {
     } fc_packed1;
     fc_packed1 *fc;
 
-    ForceConst() : _nbondtypes(0) {}
+    ForceConst() : fc(nullptr), _nbondtypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
     void set_ntypes(const int nbondtypes, Memory *memory);

--- a/src/INTEL/bond_harmonic_intel.cpp
+++ b/src/INTEL/bond_harmonic_intel.cpp
@@ -291,13 +291,12 @@ void BondHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
 template <class flt_t>
 void BondHarmonicIntel::ForceConst<flt_t>::set_ntypes(const int nbondtypes,
                                                       Memory *memory) {
+  if (memory != nullptr) _memory = memory;
   if (nbondtypes != _nbondtypes) {
-    if (_nbondtypes > 0)
-      _memory->destroy(fc);
+    _memory->destroy(fc);
 
     if (nbondtypes > 0)
       _memory->create(fc,nbondtypes,"bondharmonicintel.fc");
   }
   _nbondtypes = nbondtypes;
-  _memory = memory;
 }

--- a/src/INTEL/bond_harmonic_intel.cpp
+++ b/src/INTEL/bond_harmonic_intel.cpp
@@ -247,11 +247,8 @@ void BondHarmonicIntel::init_style()
 {
   BondHarmonic::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/bond_harmonic_intel.h
+++ b/src/INTEL/bond_harmonic_intel.h
@@ -60,7 +60,7 @@ class BondHarmonicIntel : public BondHarmonic {
     } fc_packed1;
     fc_packed1 *fc;
 
-    ForceConst() : _nbondtypes(0) {}
+    ForceConst() : fc(nullptr), _nbondtypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
     void set_ntypes(const int nbondtypes, Memory *memory);

--- a/src/INTEL/dihedral_charmm_intel.cpp
+++ b/src/INTEL/dihedral_charmm_intel.cpp
@@ -261,10 +261,10 @@ void DihedralCharmmIntel::eval(const int vflag,
       if (c > (flt_t)1.0) c = (flt_t)1.0;
       if (c < (flt_t)-1.0) c = (flt_t)-1.0;
 
-      const flt_t tcos_shift = fc.bp[type].cos_shift;
-      const flt_t tsin_shift = fc.bp[type].sin_shift;
-      const flt_t tk = fc.bp[type].k;
-      const int m = fc.bp[type].multiplicity;
+      const flt_t tcos_shift = fc.fc[type].cos_shift;
+      const flt_t tsin_shift = fc.fc[type].sin_shift;
+      const flt_t tk = fc.fc[type].k;
+      const int m = fc.fc[type].multiplicity;
 
       flt_t p = (flt_t)1.0;
       flt_t ddf1, df1;
@@ -539,10 +539,10 @@ void DihedralCharmmIntel::eval(const int vflag,
       (int *) neighbor->dihedrallist[0];
     const flt_t * _noalias const weight = &(fc.weight[0]);
     const flt_t * _noalias const x_f = &(x[0].x);
-    const flt_t * _noalias const cos_shift = &(fc.bp[0].cos_shift);
-    const flt_t * _noalias const sin_shift = &(fc.bp[0].sin_shift);
-    const flt_t * _noalias const k = &(fc.bp[0].k);
-    const int * _noalias const multiplicity = &(fc.bp[0].multiplicity);
+    const flt_t * _noalias const cos_shift = &(fc.fc[0].cos_shift);
+    const flt_t * _noalias const sin_shift = &(fc.fc[0].sin_shift);
+    const flt_t * _noalias const k = &(fc.fc[0].k);
+    const int * _noalias const multiplicity = &(fc.fc[0].multiplicity);
     const flt_t * _noalias const plj1 = &(fc.ljp[0][0].lj1);
     const flt_t * _noalias const plj2 = &(fc.ljp[0][0].lj2);
     const flt_t * _noalias const plj3 = &(fc.ljp[0][0].lj3);
@@ -937,8 +937,8 @@ void DihedralCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
 {
 
   const int tp1 = atom->ntypes + 1;
-  const int bp1 = atom->ndihedraltypes + 1;
-  fc.set_ntypes(tp1,bp1,memory);
+  const int dp1 = atom->ndihedraltypes + 1;
+  fc.set_ntypes(tp1,dp1,memory);
   buffers->set_ntypes(tp1);
 
   if (weightflag) {
@@ -952,11 +952,11 @@ void DihedralCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
     }
   }
 
-  for (int i = 1; i < bp1; i++) {
-    fc.bp[i].multiplicity = multiplicity[i];
-    fc.bp[i].cos_shift = cos_shift[i];
-    fc.bp[i].sin_shift = sin_shift[i];
-    fc.bp[i].k = k[i];
+  for (int i = 1; i < dp1; i++) {
+    fc.fc[i].multiplicity = multiplicity[i];
+    fc.fc[i].cos_shift = cos_shift[i];
+    fc.fc[i].sin_shift = sin_shift[i];
+    fc.fc[i].k = k[i];
     fc.weight[i] = weight[i];
   }
 }
@@ -965,27 +965,24 @@ void DihedralCharmmIntel::pack_force_const(ForceConst<flt_t> &fc,
 
 template <class flt_t>
 void DihedralCharmmIntel::ForceConst<flt_t>::set_ntypes(const int npairtypes,
-                                                        const int nbondtypes,
+                                                        const int ndihderaltypes,
                                                         Memory *memory) {
+  if (memory != nullptr) _memory = memory;
   if (npairtypes != _npairtypes) {
-    if (_npairtypes > 0)
-      _memory->destroy(ljp);
+    _memory->destroy(ljp);
     if (npairtypes > 0)
-      memory->create(ljp,npairtypes,npairtypes,"fc.ljp");
+      _memory->create(ljp,npairtypes,npairtypes,"fc.ljp");
   }
 
-  if (nbondtypes != _nbondtypes) {
-    if (_nbondtypes > 0) {
-      _memory->destroy(bp);
-      _memory->destroy(weight);
-    }
+  if (ndihderaltypes != _ndihderaltypes) {
+    _memory->destroy(fc);
+    _memory->destroy(weight);
 
-    if (nbondtypes > 0) {
-      _memory->create(bp,nbondtypes,"dihedralcharmmintel.bp");
-      _memory->create(weight,nbondtypes,"dihedralcharmmintel.weight");
+    if (ndihderaltypes > 0) {
+      _memory->create(fc,ndihderaltypes,"dihedralcharmmintel.fc");
+      _memory->create(weight,ndihderaltypes,"dihedralcharmmintel.weight");
     }
   }
   _npairtypes = npairtypes;
-  _nbondtypes = nbondtypes;
-  _memory = memory;
+  _ndihderaltypes = ndihderaltypes;
 }

--- a/src/INTEL/dihedral_charmm_intel.cpp
+++ b/src/INTEL/dihedral_charmm_intel.cpp
@@ -905,11 +905,8 @@ void DihedralCharmmIntel::init_style()
 {
   DihedralCharmm::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/dihedral_charmm_intel.h
+++ b/src/INTEL/dihedral_charmm_intel.h
@@ -64,16 +64,16 @@ class DihedralCharmmIntel : public DihedralCharmm {
     } fc_packed3;
 
     fc_packed1 **ljp;
-    fc_packed3 *bp;
+    fc_packed3 *fc;
     flt_t *weight;
 
-    ForceConst() : _npairtypes(0), _nbondtypes(0) {}
+    ForceConst() : ljp(nullptr), fc(nullptr), _npairtypes(0), _ndihderaltypes(0) {}
     ~ForceConst() { set_ntypes(0, 0, nullptr); }
 
-    void set_ntypes(const int npairtypes, const int nbondtypes, Memory *memory);
+    void set_ntypes(const int npairtypes, const int ndihderaltypes, Memory *memory);
 
    private:
-    int _npairtypes, _nbondtypes;
+    int _npairtypes, _ndihderaltypes;
     Memory *_memory;
   };
   ForceConst<float> force_const_single;

--- a/src/INTEL/dihedral_fourier_intel.cpp
+++ b/src/INTEL/dihedral_fourier_intel.cpp
@@ -225,10 +225,10 @@ void DihedralFourierIntel::eval(const int vflag,
       if (EFLAG) deng = (flt_t)0.0;
 
       for (int j = 0; j < nterms[type]; j++) {
-        const flt_t tcos_shift = fc.bp[j][type].cos_shift;
-        const flt_t tsin_shift = fc.bp[j][type].sin_shift;
-        const flt_t tk = fc.bp[j][type].k;
-        const int m = fc.bp[j][type].multiplicity;
+        const flt_t tcos_shift = fc.fc[j][type].cos_shift;
+        const flt_t tsin_shift = fc.fc[j][type].sin_shift;
+        const flt_t tk = fc.fc[j][type].k;
+        const int m = fc.fc[j][type].multiplicity;
 
         flt_t p = (flt_t)1.0;
         flt_t ddf1, df1;
@@ -394,16 +394,16 @@ template <class flt_t, class acc_t>
 void DihedralFourierIntel::pack_force_const(ForceConst<flt_t> &fc,
                                             IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
-  const int bp1 = atom->ndihedraltypes + 1;
-  fc.set_ntypes(bp1, setflag, nterms, memory);
+  const int dp1 = atom->ndihedraltypes + 1;
+  fc.set_ntypes(dp1, setflag, nterms, memory);
 
-  for (int i = 1; i < bp1; i++) {
+  for (int i = 1; i < dp1; i++) {
     if (setflag[i]) {
       for (int j = 0; j < nterms[i]; j++) {
-        fc.bp[j][i].cos_shift = cos_shift[i][j];
-        fc.bp[j][i].sin_shift = sin_shift[i][j];
-        fc.bp[j][i].k = k[i][j];
-        fc.bp[j][i].multiplicity = multiplicity[i][j];
+        fc.fc[j][i].cos_shift = cos_shift[i][j];
+        fc.fc[j][i].sin_shift = sin_shift[i][j];
+        fc.fc[j][i].k = k[i][j];
+        fc.fc[j][i].multiplicity = multiplicity[i][j];
       }
     }
   }
@@ -412,22 +412,20 @@ void DihedralFourierIntel::pack_force_const(ForceConst<flt_t> &fc,
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t>
-void DihedralFourierIntel::ForceConst<flt_t>::set_ntypes(const int nbondtypes,
+void DihedralFourierIntel::ForceConst<flt_t>::set_ntypes(const int ndihedraltypes,
                                                          int *setflag,
                                                          int *nterms,
                                                          Memory *memory) {
-  if (nbondtypes != _nbondtypes) {
-    if (_nbondtypes > 0)
-      _memory->destroy(bp);
+  if (memory != nullptr) _memory = memory;
+  if (ndihedraltypes != _ndihedraltypes) {
+    _memory->destroy(fc);
 
-    if (nbondtypes > 0) {
+    if (ndihedraltypes > 0) {
       _maxnterms = 1;
-      for (int i = 1; i <= nbondtypes; i++)
+      for (int i = 1; i < ndihedraltypes; i++)
         if (setflag[i]) _maxnterms = MAX(_maxnterms, nterms[i]);
-
-      _memory->create(bp, _maxnterms, nbondtypes, "dihedralfourierintel.bp");
+      _memory->create(fc, _maxnterms, ndihedraltypes, "dihedralfourierintel.fc");
     }
   }
-  _nbondtypes = nbondtypes;
-  _memory = memory;
+  _ndihedraltypes = ndihedraltypes;
 }

--- a/src/INTEL/dihedral_fourier_intel.cpp
+++ b/src/INTEL/dihedral_fourier_intel.cpp
@@ -364,11 +364,8 @@ void DihedralFourierIntel::init_style()
 {
   DihedralFourier::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/dihedral_fourier_intel.h
+++ b/src/INTEL/dihedral_fourier_intel.h
@@ -60,15 +60,15 @@ class DihedralFourierIntel : public DihedralFourier {
       int multiplicity;
     } fc_packed1;
 
-    fc_packed1 **bp;
+    fc_packed1 **fc;
 
-    ForceConst() : _nbondtypes(0) {}
+    ForceConst() : fc(nullptr), _ndihedraltypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr, nullptr, nullptr); }
 
-    void set_ntypes(const int nbondtypes, int *setflag, int *nterms, Memory *memory);
+    void set_ntypes(const int ndihedraltypes, int *setflag, int *nterms, Memory *memory);
 
    private:
-    int _nbondtypes, _maxnterms;
+    int _ndihedraltypes, _maxnterms;
     Memory *_memory;
   };
   ForceConst<float> force_const_single;

--- a/src/INTEL/dihedral_harmonic_intel.cpp
+++ b/src/INTEL/dihedral_harmonic_intel.cpp
@@ -359,11 +359,8 @@ void DihedralHarmonicIntel::init_style()
 {
   DihedralHarmonic::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/dihedral_harmonic_intel.cpp
+++ b/src/INTEL/dihedral_harmonic_intel.cpp
@@ -220,10 +220,10 @@ void DihedralHarmonicIntel::eval(const int vflag,
       if (c > (flt_t)1.0) c = (flt_t)1.0;
       if (c < (flt_t)-1.0) c = (flt_t)-1.0;
 
-      const flt_t tcos_shift = fc.bp[type].cos_shift;
-      const flt_t tsin_shift = fc.bp[type].sin_shift;
-      const flt_t tk = fc.bp[type].k;
-      const int m = fc.bp[type].multiplicity;
+      const flt_t tcos_shift = fc.fc[type].cos_shift;
+      const flt_t tsin_shift = fc.fc[type].sin_shift;
+      const flt_t tk = fc.fc[type].k;
+      const int m = fc.fc[type].multiplicity;
 
       flt_t p = (flt_t)1.0;
       flt_t ddf1, df1;
@@ -389,29 +389,28 @@ template <class flt_t, class acc_t>
 void DihedralHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
                                              IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
-  const int bp1 = atom->ndihedraltypes + 1;
-  fc.set_ntypes(bp1,memory);
+  const int dp1 = atom->ndihedraltypes + 1;
+  fc.set_ntypes(dp1,memory);
 
-  for (int i = 1; i < bp1; i++) {
-    fc.bp[i].multiplicity = multiplicity[i];
-    fc.bp[i].cos_shift = cos_shift[i];
-    fc.bp[i].sin_shift = sin_shift[i];
-    fc.bp[i].k = k[i];
+  for (int i = 1; i < dp1; i++) {
+    fc.fc[i].multiplicity = multiplicity[i];
+    fc.fc[i].cos_shift = cos_shift[i];
+    fc.fc[i].sin_shift = sin_shift[i];
+    fc.fc[i].k = k[i];
   }
 }
 
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t>
-void DihedralHarmonicIntel::ForceConst<flt_t>::set_ntypes(const int nbondtypes,
+void DihedralHarmonicIntel::ForceConst<flt_t>::set_ntypes(const int ndihderaltypes,
                                                           Memory *memory) {
-  if (nbondtypes != _nbondtypes) {
-    if (_nbondtypes > 0)
-      _memory->destroy(bp);
+  if (memory != nullptr) _memory = memory;
+  if (ndihderaltypes != _ndihderaltypes) {
+    _memory->destroy(fc);
 
-    if (nbondtypes > 0)
-      _memory->create(bp,nbondtypes,"dihedralcharmmintel.bp");
+    if (ndihderaltypes > 0)
+      _memory->create(fc,ndihderaltypes,"dihedralcharmmintel.fc");
   }
-  _nbondtypes = nbondtypes;
-  _memory = memory;
+  _ndihderaltypes = ndihderaltypes;
 }

--- a/src/INTEL/dihedral_harmonic_intel.h
+++ b/src/INTEL/dihedral_harmonic_intel.h
@@ -60,15 +60,15 @@ class DihedralHarmonicIntel : public DihedralHarmonic {
       int multiplicity;
     } fc_packed1;
 
-    fc_packed1 *bp;
+    fc_packed1 *fc;
 
-    ForceConst() : _nbondtypes(0) {}
+    ForceConst() : fc(nullptr), _ndihderaltypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
-    void set_ntypes(const int nbondtypes, Memory *memory);
+    void set_ntypes(const int ndihderaltypes, Memory *memory);
 
    private:
-    int _nbondtypes;
+    int _ndihderaltypes;
     Memory *_memory;
   };
   ForceConst<float> force_const_single;

--- a/src/INTEL/dihedral_opls_intel.cpp
+++ b/src/INTEL/dihedral_opls_intel.cpp
@@ -379,11 +379,8 @@ void DihedralOPLSIntel::init_style()
 {
   DihedralOPLS::init_style();
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/dihedral_opls_intel.cpp
+++ b/src/INTEL/dihedral_opls_intel.cpp
@@ -264,14 +264,14 @@ void DihedralOPLSIntel::eval(const int vflag,
       const flt_t sin_4phim = (flt_t)2.0 * cos_2phi * sin_2phim;
 
       flt_t p, pd;
-      p = fc.bp[type].k1*((flt_t)1.0 + c) +
-          fc.bp[type].k2*((flt_t)1.0 - cos_2phi) +
-          fc.bp[type].k3*((flt_t)1.0 + cos_3phi) +
-          fc.bp[type].k4*((flt_t)1.0 - cos_4phi) ;
-      pd = fc.bp[type].k1 -
-           (flt_t)2.0 * fc.bp[type].k2 * sin_2phim +
-           (flt_t)3.0 * fc.bp[type].k3 * sin_3phim -
-           (flt_t)4.0 * fc.bp[type].k4 * sin_4phim;
+      p = fc.fc[type].k1*((flt_t)1.0 + c) +
+          fc.fc[type].k2*((flt_t)1.0 - cos_2phi) +
+          fc.fc[type].k3*((flt_t)1.0 + cos_3phi) +
+          fc.fc[type].k4*((flt_t)1.0 - cos_4phi) ;
+      pd = fc.fc[type].k1 -
+           (flt_t)2.0 * fc.fc[type].k2 * sin_2phim +
+           (flt_t)3.0 * fc.fc[type].k3 * sin_3phim -
+           (flt_t)4.0 * fc.fc[type].k4 * sin_4phim;
 
       flt_t edihed;
       if (EFLAG) edihed = p;
@@ -409,29 +409,28 @@ template <class flt_t, class acc_t>
 void DihedralOPLSIntel::pack_force_const(ForceConst<flt_t> &fc,
                                          IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
-  const int bp1 = atom->ndihedraltypes + 1;
-  fc.set_ntypes(bp1,memory);
+  const int dp1 = atom->ndihedraltypes + 1;
+  fc.set_ntypes(dp1,memory);
 
-  for (int i = 1; i < bp1; i++) {
-    fc.bp[i].k1 = k1[i];
-    fc.bp[i].k2 = k2[i];
-    fc.bp[i].k3 = k3[i];
-    fc.bp[i].k4 = k4[i];
+  for (int i = 1; i < dp1; i++) {
+    fc.fc[i].k1 = k1[i];
+    fc.fc[i].k2 = k2[i];
+    fc.fc[i].k3 = k3[i];
+    fc.fc[i].k4 = k4[i];
   }
 }
 
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t>
-void DihedralOPLSIntel::ForceConst<flt_t>::set_ntypes(const int nbondtypes,
+void DihedralOPLSIntel::ForceConst<flt_t>::set_ntypes(const int ndihderaltypes,
                                                           Memory *memory) {
-  if (nbondtypes != _nbondtypes) {
-    if (_nbondtypes > 0)
-      _memory->destroy(bp);
+  if (memory != nullptr) _memory = memory;
+  if (ndihderaltypes != _ndihderaltypes) {
+    _memory->destroy(fc);
 
-    if (nbondtypes > 0)
-      _memory->create(bp,nbondtypes,"dihedralcharmmintel.bp");
+    if (ndihderaltypes > 0)
+      _memory->create(fc,ndihderaltypes,"dihedralcharmmintel.fc");
   }
-  _nbondtypes = nbondtypes;
-  _memory = memory;
+  _ndihderaltypes = ndihderaltypes;
 }

--- a/src/INTEL/dihedral_opls_intel.h
+++ b/src/INTEL/dihedral_opls_intel.h
@@ -59,15 +59,15 @@ class DihedralOPLSIntel : public DihedralOPLS {
       flt_t k1, k2, k3, k4;
     } fc_packed1;
 
-    fc_packed1 *bp;
+    fc_packed1 *fc;
 
-    ForceConst() : _nbondtypes(0) {}
+    ForceConst() : fc(nullptr), _ndihderaltypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
-    void set_ntypes(const int nbondtypes, Memory *memory);
+    void set_ntypes(const int ndihderaltypes, Memory *memory);
 
    private:
-    int _nbondtypes;
+    int _ndihderaltypes;
     Memory *_memory;
   };
   ForceConst<float> force_const_single;

--- a/src/INTEL/improper_cvff_intel.cpp
+++ b/src/INTEL/improper_cvff_intel.cpp
@@ -396,11 +396,8 @@ void ImproperCvffIntel::eval(const int vflag,
 
 void ImproperCvffIntel::init_style()
 {
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/improper_cvff_intel.cpp
+++ b/src/INTEL/improper_cvff_intel.cpp
@@ -426,10 +426,10 @@ template <class flt_t, class acc_t>
 void ImproperCvffIntel::pack_force_const(ForceConst<flt_t> &fc,
                                          IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
-  const int bp1 = atom->nimpropertypes + 1;
-  fc.set_ntypes(bp1,memory);
+  const int ip1 = atom->nimpropertypes + 1;
+  fc.set_ntypes(ip1,memory);
 
-  for (int i = 1; i < bp1; i++) {
+  for (int i = 1; i < ip1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].sign = sign[i];
     fc.fc[i].multiplicity = multiplicity[i];
@@ -439,15 +439,14 @@ void ImproperCvffIntel::pack_force_const(ForceConst<flt_t> &fc,
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t>
-void ImproperCvffIntel::ForceConst<flt_t>::set_ntypes(const int nimproper,
+void ImproperCvffIntel::ForceConst<flt_t>::set_ntypes(const int nimpropertypes,
                                                           Memory *memory) {
-  if (nimproper != _nimpropertypes) {
-    if (_nimpropertypes > 0)
-      _memory->destroy(fc);
+  if (memory != nullptr) _memory = memory;
+  if (nimpropertypes != _nimpropertypes) {
+    _memory->destroy(fc);
 
-    if (nimproper > 0)
-      _memory->create(fc,nimproper,"improperharmonicintel.fc");
+    if (nimpropertypes > 0)
+      _memory->create(fc,nimpropertypes,"improperharmonicintel.fc");
   }
-  _nimpropertypes = nimproper;
-  _memory = memory;
+  _nimpropertypes = nimpropertypes;
 }

--- a/src/INTEL/improper_cvff_intel.h
+++ b/src/INTEL/improper_cvff_intel.h
@@ -62,7 +62,7 @@ class ImproperCvffIntel : public ImproperCvff {
 
     fc_packed1 *fc;
 
-    ForceConst() : _nimpropertypes(0) {}
+    ForceConst() : fc(nullptr), _nimpropertypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
     void set_ntypes(const int nimpropertypes, Memory *memory);

--- a/src/INTEL/improper_harmonic_intel.cpp
+++ b/src/INTEL/improper_harmonic_intel.cpp
@@ -379,10 +379,10 @@ template <class flt_t, class acc_t>
 void ImproperHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
                                              IntelBuffers<flt_t,acc_t> * /*buffers*/)
 {
-  const int bp1 = atom->nimpropertypes + 1;
-  fc.set_ntypes(bp1,memory);
+  const int ip1 = atom->nimpropertypes + 1;
+  fc.set_ntypes(ip1,memory);
 
-  for (int i = 1; i < bp1; i++) {
+  for (int i = 1; i < ip1; i++) {
     fc.fc[i].k = k[i];
     fc.fc[i].chi = chi[i];
   }
@@ -391,15 +391,14 @@ void ImproperHarmonicIntel::pack_force_const(ForceConst<flt_t> &fc,
 /* ---------------------------------------------------------------------- */
 
 template <class flt_t>
-void ImproperHarmonicIntel::ForceConst<flt_t>::set_ntypes(const int nimproper,
+void ImproperHarmonicIntel::ForceConst<flt_t>::set_ntypes(const int nimpropertypes,
                                                           Memory *memory) {
-  if (nimproper != _nimpropertypes) {
-    if (_nimpropertypes > 0)
-      _memory->destroy(fc);
+  if (memory != nullptr) _memory = memory;
+  if (nimpropertypes != _nimpropertypes) {
+    _memory->destroy(fc);
 
-    if (nimproper > 0)
-      _memory->create(fc,nimproper,"improperharmonicintel.fc");
+    if (nimpropertypes > 0)
+      _memory->create(fc,nimpropertypes,"improperharmonicintel.fc");
   }
-  _nimpropertypes = nimproper;
-  _memory = memory;
+  _nimpropertypes = nimpropertypes;
 }

--- a/src/INTEL/improper_harmonic_intel.cpp
+++ b/src/INTEL/improper_harmonic_intel.cpp
@@ -349,11 +349,8 @@ void ImproperHarmonicIntel::eval(const int vflag,
 
 void ImproperHarmonicIntel::init_style()
 {
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/improper_harmonic_intel.h
+++ b/src/INTEL/improper_harmonic_intel.h
@@ -61,7 +61,7 @@ class ImproperHarmonicIntel : public ImproperHarmonic {
 
     fc_packed1 *fc;
 
-    ForceConst() : _nimpropertypes(0) {}
+    ForceConst() : fc(nullptr), _nimpropertypes(0) {}
     ~ForceConst() { set_ntypes(0, nullptr); }
 
     void set_ntypes(const int nimpropertypes, Memory *memory);

--- a/src/INTEL/nbin_intel.cpp
+++ b/src/INTEL/nbin_intel.cpp
@@ -30,11 +30,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 NBinIntel::NBinIntel(LAMMPS *lmp) : NBinStandard(lmp) {
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  _fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  _fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!_fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
   _precision_mode = _fix->precision();
   _atombin = nullptr;
   _binpacked = nullptr;

--- a/src/INTEL/npair_halffull_newton_intel.cpp
+++ b/src/INTEL/npair_halffull_newton_intel.cpp
@@ -30,11 +30,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 NPairHalffullNewtonIntel::NPairHalffullNewtonIntel(LAMMPS *lmp) : NPair(lmp) {
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  _fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  _fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!_fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/INTEL/npair_intel.cpp
+++ b/src/INTEL/npair_intel.cpp
@@ -29,10 +29,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 NPairIntel::NPairIntel(LAMMPS *lmp) : NPair(lmp) {
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,"The 'package intel' command is required for /intel styles");
-  _fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  _fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!_fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
   #ifdef _LMP_INTEL_OFFLOAD
   _cop = _fix->coprocessor_number();
   _off_map_stencil = 0;

--- a/src/INTEL/npair_skip_intel.cpp
+++ b/src/INTEL/npair_skip_intel.cpp
@@ -32,11 +32,8 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 NPairSkipIntel::NPairSkipIntel(LAMMPS *lmp) : NPair(lmp) {
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  _fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  _fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!_fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
   _inum_starts = new int[comm->nthreads];
   _inum_counts = new int[comm->nthreads];
   _full_props = 0;

--- a/src/INTEL/pair_airebo_intel.cpp
+++ b/src/INTEL/pair_airebo_intel.cpp
@@ -186,11 +186,8 @@ void PairAIREBOIntel::init_style()
   if (utils::strmatch(force->pair_style,"^hybrid"))
     error->all(FLERR, "Cannot yet use airebo/intel with hybrid.");
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_buck_coul_cut_intel.cpp
+++ b/src/INTEL/pair_buck_coul_cut_intel.cpp
@@ -416,11 +416,8 @@ void PairBuckCoulCutIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_buck_coul_long_intel.cpp
+++ b/src/INTEL/pair_buck_coul_long_intel.cpp
@@ -493,11 +493,8 @@ void PairBuckCoulLongIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_buck_intel.cpp
+++ b/src/INTEL/pair_buck_intel.cpp
@@ -383,11 +383,8 @@ void PairBuckIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_dpd_intel.cpp
+++ b/src/INTEL/pair_dpd_intel.cpp
@@ -492,11 +492,8 @@ void PairDPDIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_eam_intel.cpp
+++ b/src/INTEL/pair_eam_intel.cpp
@@ -674,11 +674,8 @@ void PairEAMIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_gayberne_intel.cpp
+++ b/src/INTEL/pair_gayberne_intel.cpp
@@ -897,11 +897,8 @@ void PairGayBerneIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_lj_charmm_coul_charmm_intel.cpp
+++ b/src/INTEL/pair_lj_charmm_coul_charmm_intel.cpp
@@ -464,11 +464,8 @@ void PairLJCharmmCoulCharmmIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_lj_charmm_coul_long_intel.cpp
+++ b/src/INTEL/pair_lj_charmm_coul_long_intel.cpp
@@ -529,11 +529,8 @@ void PairLJCharmmCoulLongIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_lj_cut_coul_long_intel.cpp
+++ b/src/INTEL/pair_lj_cut_coul_long_intel.cpp
@@ -494,11 +494,8 @@ void PairLJCutCoulLongIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_lj_cut_intel.cpp
+++ b/src/INTEL/pair_lj_cut_intel.cpp
@@ -400,11 +400,8 @@ void PairLJCutIntel::init_style()
   }
   request->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   #ifdef _LMP_INTEL_OFFLOAD

--- a/src/INTEL/pair_lj_long_coul_long_intel.cpp
+++ b/src/INTEL/pair_lj_long_coul_long_intel.cpp
@@ -18,9 +18,14 @@
 
 #include "pair_lj_long_coul_long_intel.h"
 
+#include "fix_intel.h"
+#include "modify.h"
+#include "neigh_request.h"
 #include "suffix.h"
 
 using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
 
 PairLJLongCoulLongIntel::PairLJLongCoulLongIntel(LAMMPS *lmp) :
   PairLJLongCoulLong(lmp)
@@ -30,7 +35,21 @@ PairLJLongCoulLongIntel::PairLJLongCoulLongIntel(LAMMPS *lmp) :
   cut_respa = nullptr;
 }
 
+/* ---------------------------------------------------------------------- */
 
 PairLJLongCoulLongIntel::~PairLJLongCoulLongIntel()
 {
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJLongCoulLongIntel::init_style()
+{
+  PairLJLongCoulLong::init_style();
+  neighbor->find_request(this)->intel = 1;
+
+  auto fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
+
+  fix->pair_init_check();
 }

--- a/src/INTEL/pair_lj_long_coul_long_intel.h
+++ b/src/INTEL/pair_lj_long_coul_long_intel.h
@@ -33,6 +33,7 @@ class PairLJLongCoulLongIntel : public PairLJLongCoulLong {
  public:
   PairLJLongCoulLongIntel(class LAMMPS *);
   ~PairLJLongCoulLongIntel() override;
+  void init_style() override;
 };
 }    // namespace LAMMPS_NS
 #endif

--- a/src/INTEL/pair_sw_intel.cpp
+++ b/src/INTEL/pair_sw_intel.cpp
@@ -1113,10 +1113,8 @@ void PairSWIntel::init_style()
 
   map[0] = map[1];
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,"The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check(true);
 

--- a/src/INTEL/pair_tersoff_intel.cpp
+++ b/src/INTEL/pair_tersoff_intel.cpp
@@ -412,11 +412,8 @@ void PairTersoffIntel::init_style()
   neighbor->requests[irequest]->full = 1;
   neighbor->requests[irequest]->intel = 1;
 
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   fix->pair_init_check();
   fix->three_body_neighbor(1);

--- a/src/INTEL/pppm_disp_intel.cpp
+++ b/src/INTEL/pppm_disp_intel.cpp
@@ -109,11 +109,8 @@ void PPPMDispIntel::init()
 {
 
   PPPMDisp::init();
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/INTEL/pppm_intel.cpp
+++ b/src/INTEL/pppm_intel.cpp
@@ -93,11 +93,8 @@ PPPMIntel::~PPPMIntel()
 void PPPMIntel::init()
 {
   PPPM::init();
-  int ifix = modify->find_fix("package_intel");
-  if (ifix < 0)
-    error->all(FLERR,
-               "The 'package intel' command is required for /intel styles");
-  fix = static_cast<FixIntel *>(modify->fix[ifix]);
+  fix = static_cast<FixIntel *>(modify->get_fix_by_id("package_intel"));
+  if (!fix) error->all(FLERR, "The 'package intel' command is required for /intel styles");
 
   #ifdef _LMP_INTEL_OFFLOAD
   _use_base = 0;

--- a/src/ML-IAP/Install.sh
+++ b/src/ML-IAP/Install.sh
@@ -69,7 +69,7 @@ elif (test $1 = 0) then
   sed -i -e '/^include.*python.*mliap_python.*$/d' ../Makefile.package.settings
 
 elif (test $1 = 2) then
-  if (test "$(type cythonize 2> /dev/null)" != "" && test -e ../python_impl.cpp) then
+  if (type cythonize 2>&1 > /dev/null && test -e ../python_impl.cpp) then
     if (test -e ../Makefile.package) then
       sed -i -e 's/[^ \t]*-DMLIAP_PYTHON[^ \t]* //g' ../Makefile.package
     fi

--- a/src/ML-IAP/Install.sh
+++ b/src/ML-IAP/Install.sh
@@ -29,7 +29,7 @@ action () {
 # enforce package dependency
 if (test $1 = 1 || test $1 = 2) then
   if (test ! -e ../sna.h) then
-     echo "Must install SNAP package to use ML-IAP package"
+     echo "Must install ML-SNAP package to use ML-IAP package"
      exit 1
   fi
 fi
@@ -70,6 +70,21 @@ elif (test $1 = 0) then
 
 elif (test $1 = 2) then
   if (test "$(type cythonize 2> /dev/null)" != "" && test -e ../python_impl.cpp) then
+    if (test -e ../Makefile.package) then
+      sed -i -e 's/[^ \t]*-DMLIAP_PYTHON[^ \t]* //g' ../Makefile.package
+    fi
+    rm -f ../mliap_model_python_couple.cpp ../mliap_model_python_couple.h
+    sed -i -e '/^include.*python.*mliap_python.*$/d' ../Makefile.package.settings
+    if (test -e ../Makefile.package) then
+      sed -i -e 's|^PKG_INC =[ \t]*|&-DMLIAP_PYTHON |' ../Makefile.package
+    fi
+    if (test -e ../Makefile.package.settings) then
+      sed -i -e '/^include.*python.*mliap_python.*$/d' ../Makefile.package.settings
+      # multiline form needed for BSD sed on Macs
+      sed -i -e '4 i \
+include ..\/..\/lib\/python\/Makefile.mliap_python
+' ../Makefile.package.settings
+    fi
     cythonize -3 ../mliap_model_python_couple.pyx
   else
     rm -f ../mliap_model_python_couple.cpp ../mliap_model_python_couple.h

--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -121,7 +121,7 @@ void ReadDump::command(int narg, char **arg)
 
   // reset timestep to nstep
 
-  update->reset_timestep(nstep);
+  update->reset_timestep(nstep, true);
 
   // counters
 

--- a/src/rerun.cpp
+++ b/src/rerun.cpp
@@ -159,7 +159,7 @@ void Rerun::command(int narg, char **arg)
   while (true) {
     ndump++;
     rd->header(firstflag);
-    update->reset_timestep(ntimestep);
+    update->reset_timestep(ntimestep, false);
     rd->atoms();
 
     modify->init();

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -460,7 +460,7 @@ void Update::reset_timestep(int narg, char **arg)
 {
   if (narg != 1) error->all(FLERR, "Illegal reset_timestep command");
   bigint newstep = utils::bnumeric(FLERR, arg[0], false, lmp);
-  reset_timestep(newstep);
+  reset_timestep(newstep, true);
 }
 
 /* ----------------------------------------------------------------------
@@ -468,7 +468,7 @@ void Update::reset_timestep(int narg, char **arg)
    called from input script (indirectly) or rerun command
 ------------------------------------------------------------------------- */
 
-void Update::reset_timestep(bigint newstep)
+void Update::reset_timestep(bigint newstep, bool do_check)
 {
   if (newstep < 0) error->all(FLERR, "Timestep must be >= 0");
 
@@ -490,11 +490,14 @@ void Update::reset_timestep(bigint newstep)
 
   output->reset_timestep(ntimestep);
 
-  // do not allow timestep-dependent fixes to be defined
+  // rerun will not be meaningful with this check active.
+  if (do_check) {
+    // do not allow timestep-dependent fixes to be defined
 
-  for (const auto &ifix : modify->get_fix_list())
-    if (ifix->time_depend)
-      error->all(FLERR, "Cannot reset timestep with time-dependent fix {} defined", ifix->style);
+    for (const auto &ifix : modify->get_fix_list())
+      if (ifix->time_depend)
+        error->all(FLERR, "Cannot reset timestep with time-dependent fix {} defined", ifix->style);
+  }
 
   // reset eflag/vflag global so no commands will think eng/virial are current
 

--- a/src/update.h
+++ b/src/update.h
@@ -66,7 +66,7 @@ class Update : protected Pointers {
   void create_integrate(int, char **, int);
   void create_minimize(int, char **, int);
   void reset_timestep(int, char **);
-  void reset_timestep(bigint);
+  void reset_timestep(bigint, bool);
   void update_time();
   double memory_usage();
 

--- a/src/write_dump.cpp
+++ b/src/write_dump.cpp
@@ -27,7 +27,6 @@
 
 #include <cstring>
 
-
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
@@ -58,7 +57,7 @@ void WriteDump::command(int narg, char **arg)
     dumpargs[i+2] = arg[i];
 
   if (false) {
-    return;         // dummy line to enable else-if macro expansion
+    return;         // dummy branch to enable else-if macro expansion
 
 #define DUMP_CLASS
 #define DumpStyle(key,Class) \
@@ -68,7 +67,6 @@ void WriteDump::command(int narg, char **arg)
 #undef DUMP_CLASS
 
   } else error->all(FLERR,utils::check_packages_for_style("dump",arg[1],lmp));
-  delete[] dumpargs;
 
   if (modindex < narg) dump->modify_params(narg-modindex-1,&arg[modindex+1]);
 
@@ -90,4 +88,5 @@ void WriteDump::command(int narg, char **arg)
   // delete the Dump instance and local storage
 
   delete dump;
+  delete[] dumpargs;
 }


### PR DESCRIPTION
**Summary**

This pull request contains collected small changes and fixes

**Related Issue(s)**

Addresses the problem reported here: https://matsci.org/t/error-building-mpi-shared-lib-liblammps-mpi-so-undefined-reference-to-lammps-ns-connect-param-counts/40793

Addresses the issues reported here: https://matsci.org/t/segmentation-fault-every-time-i-try-to-run-intel-acceleration/40811

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

The following individual changes are included:
- update the detection of `cythonize` for the GNU make build system to be compatible with non-bash Bourne shells (like dash)
- be more careful when updating the settings for the ML-IAP package with the GNU make build system and always delete and restore settings to correctly handle detecting cythonize which also depends on the PYTHON package being installed
- let the `rerun` command bypass the time-dependent fix check when it resets the timestep; otherwise `rerun` would be rather useless for most analysis uses.
- use consistent naming scheme in force constant caching of the INTEL package. small refactor to avoid memory leaks.
- fix off-by-one bug in dihedral style fourier/intel
- fix bug in pair style lj/long/coul/long that wasn't triggering an intel style neighbor list which is required to have force field buffers allocated
- add support for recently released plumed versions 2.6.6, 2.7.4, and 2.8.0 (default is now 2.7.4)
- some refactoring to use newer and more compact APIs

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


