### PR TITLE
Fix rare bug in Kokkos with CUDA UVM

### DIFF
--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -492,7 +492,7 @@ void VerletKokkos::run(int n)
       timer->stamp(Timer::KSPACE);
     }
 
-    if (execute_on_host && !std::is_same<LMPHostType,LMPDeviceType>::value) {
+    if (execute_on_host && atomKK->k_f.h_view.data() != atomKK->k_f.d_view.data()) {
       if (f_merge_copy.extent(0)<atomKK->k_f.extent(0)) {
         f_merge_copy = DAT::t_f_array("VerletKokkos::f_merge_copy",atomKK->k_f.extent(0));
       }


### PR DESCRIPTION
**Summary**

Fix rare bug in Kokkos with CUDA UVM when some forces are computed on the host CPU--the forces were double counted when using UVM for this case.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Matt Bettencourt (NVIDIA)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes