### PR TITLE
Reduce memory use in Kokkos package

### DIFF
--- a/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
@@ -449,8 +449,24 @@ void FixACKS2ReaxFFKokkos<DeviceType>::allocate_matrix()
   // determine the total space for the H matrix
 
   m_cap = 0;
-  FixACKS2ReaxFFKokkosNumNeighFunctor<DeviceType> neigh_functor(this);
-  Kokkos::parallel_reduce(nn,neigh_functor,m_cap);
+
+  // limit scope of functor to allow deallocation of views
+  {
+    FixACKS2ReaxFFKokkosNumNeighFunctor<DeviceType> neigh_functor(this);
+    Kokkos::parallel_reduce(nn,neigh_functor,m_cap);
+  }
+
+  // deallocate first to reduce memory overhead
+
+  d_firstnbr = typename AT::t_int_1d();
+  d_numnbrs = typename AT::t_int_1d();
+  d_jlist = typename AT::t_int_1d();
+  d_val = typename AT::t_ffloat_1d();
+
+  d_firstnbr_X = typename AT::t_int_1d();
+  d_numnbrs_X = typename AT::t_int_1d();
+  d_jlist_X = typename AT::t_int_1d();
+  d_val_X = typename AT::t_ffloat_1d();
 
   // H matrix
 

--- a/src/KOKKOS/neigh_list_kokkos.cpp
+++ b/src/KOKKOS/neigh_list_kokkos.cpp
@@ -42,6 +42,7 @@ void NeighListKokkos<DeviceType>::grow(int nmax)
   k_ilist = DAT::tdual_int_1d("neighlist:ilist",maxatoms);
   d_ilist = k_ilist.view<DeviceType>();
   d_numneigh = typename ArrayTypes<DeviceType>::t_int_1d("neighlist:numneigh",maxatoms);
+  d_neighbors = typename ArrayTypes<DeviceType>::t_neighbors_2d();
   d_neighbors = typename ArrayTypes<DeviceType>::t_neighbors_2d(Kokkos::NoInit("neighlist:neighbors"),maxatoms,maxneighs);
 }
 

--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -320,7 +320,10 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
 
     if (data.h_resize()) {
       list->maxneighs = data.h_new_maxneighs() * 1.2;
-      list->d_neighbors = typename AT::t_neighbors_2d(Kokkos::NoInit("neighbors"), list->d_neighbors.extent(0), list->maxneighs);
+      int maxatoms = list->d_neighbors.extent(0);
+      data.neigh_list.d_neighbors = typename AT::t_neighbors_2d();
+      list->d_neighbors = typename AT::t_neighbors_2d();
+      list->d_neighbors = typename AT::t_neighbors_2d(Kokkos::NoInit("neighlist:neighbors"), maxatoms, list->maxneighs);
       data.neigh_list.d_neighbors = list->d_neighbors;
       data.neigh_list.maxneighs = list->maxneighs;
     }

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -1121,6 +1121,8 @@ void PairReaxFFKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     //dup_Cdbopi       = decltype(dup_Cdbopi)();
     //dup_Cdbopi2      = decltype(dup_Cdbopi2)();
   }
+
+  d_neighbors = typename AT::t_neighbors_2d();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1503,6 +1505,10 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeTabulatedLJCoulo
 template<class DeviceType>
 void PairReaxFFKokkos<DeviceType>::allocate_array()
 {
+  // deallocate first to reduce memory overhead
+
+  deallocate_array();
+
   if (cut_hbsq > 0.0) {
     d_hb_first = typename AT::t_int_1d("reaxff/kk:hb_first",nmax);
     d_hb_num = typename AT::t_int_1d("reaxff/kk:hb_num",nmax);
@@ -1564,6 +1570,74 @@ void PairReaxFFKokkos<DeviceType>::allocate_array()
   d_abo = typename AT::t_ffloat_2d("reaxff/kk:abo",nmax,maxbo);
   d_neighid = typename AT::t_tagint_2d("reaxff/kk:neighid",nmax,maxbo);
   d_numneigh_bonds = typename AT::t_int_1d("reaxff/kk:numneigh_bonds",nmax);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void PairReaxFFKokkos<DeviceType>::deallocate_array()
+{
+  if (cut_hbsq > 0.0) {
+    d_hb_first = typename AT::t_int_1d();
+    d_hb_num = typename AT::t_int_1d();
+    d_hb_list = typename AT::t_int_1d();
+  }
+  d_bo_first = typename AT::t_int_1d();
+  d_bo_num = typename AT::t_int_1d();
+  d_bo_list = typename AT::t_int_1d();
+
+  d_BO = typename AT::t_ffloat_2d_dl();
+  d_BO_s = typename AT::t_ffloat_2d_dl();
+  d_BO_pi = typename AT::t_ffloat_2d_dl();
+  d_BO_pi2 = typename AT::t_ffloat_2d_dl();
+
+  d_dln_BOp_pix = typename AT::t_ffloat_2d_dl();
+  d_dln_BOp_piy = typename AT::t_ffloat_2d_dl();
+  d_dln_BOp_piz = typename AT::t_ffloat_2d_dl();
+
+  d_dln_BOp_pi2x = typename AT::t_ffloat_2d_dl();
+  d_dln_BOp_pi2y = typename AT::t_ffloat_2d_dl();
+  d_dln_BOp_pi2z = typename AT::t_ffloat_2d_dl();
+
+  d_C1dbo = typename AT::t_ffloat_2d_dl();
+  d_C2dbo = typename AT::t_ffloat_2d_dl();
+  d_C3dbo = typename AT::t_ffloat_2d_dl();
+
+  d_C1dbopi = typename AT::t_ffloat_2d_dl();
+  d_C2dbopi = typename AT::t_ffloat_2d_dl();
+  d_C3dbopi = typename AT::t_ffloat_2d_dl();
+  d_C4dbopi = typename AT::t_ffloat_2d_dl();
+
+  d_C1dbopi2 = typename AT::t_ffloat_2d_dl();
+  d_C2dbopi2 = typename AT::t_ffloat_2d_dl();
+  d_C3dbopi2 = typename AT::t_ffloat_2d_dl();
+  d_C4dbopi2 = typename AT::t_ffloat_2d_dl();
+
+  d_dBOpx = typename AT::t_ffloat_2d_dl();
+  d_dBOpy = typename AT::t_ffloat_2d_dl();
+  d_dBOpz = typename AT::t_ffloat_2d_dl();
+
+  d_dDeltap_self = typename AT::t_ffloat_2d_dl();
+  d_Deltap_boc = typename AT::t_ffloat_1d();
+  d_Deltap = typename AT::t_ffloat_1d();
+  d_total_bo = typename AT::t_ffloat_1d();
+
+  d_Cdbo = typename AT::t_ffloat_2d_dl();
+  d_Cdbopi = typename AT::t_ffloat_2d_dl();
+  d_Cdbopi2 = typename AT::t_ffloat_2d_dl();
+
+  d_Delta = typename AT::t_ffloat_1d();
+  d_Delta_boc = typename AT::t_ffloat_1d();
+  d_dDelta_lp = typename AT::t_ffloat_1d();
+  d_Delta_lp = typename AT::t_ffloat_1d();
+  d_Delta_lp_temp = typename AT::t_ffloat_1d();
+  d_CdDelta = typename AT::t_ffloat_1d();
+  d_sum_ovun = typename AT::t_ffloat_2d_dl();
+
+  // FixReaxFFBonds
+  d_abo = typename AT::t_ffloat_2d();
+  d_neighid = typename AT::t_tagint_2d();
+  d_numneigh_bonds = typename AT::t_int_1d();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -350,6 +350,7 @@ class PairReaxFFKokkos : public PairReaxFF {
  protected:
   void allocate();
   void allocate_array();
+  void deallocate_array();
   void setup();
   void init_md();
   int Init_Lookup_Tables();


### PR DESCRIPTION
**Summary**

Reduce memory use in Kokkos package when resizing views by explicitly deallocating large views (e.g. neighborlist) first to eliminate double allocations.

**Related Issue(s)**

#3158 which removed ghost atoms, which triggered a resize and a corresponding increase in memory

**Author(s)**

Stan Moore (SNL), reported by Nick Curtis (AMD)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes