### PR TITLE
Automatically load LAMMPS plugins if they are in folders listed in LAMMPS_PLUGIN_PATH environment variable

### DIFF
--- a/doc/src/Developer_plugins.rst
+++ b/doc/src/Developer_plugins.rst
@@ -8,11 +8,20 @@ without recompiling LAMMPS.  The functionality for this and the
 
 Plugins use the operating system's capability to load dynamic shared
 object (DSO) files in a way similar shared libraries and then reference
-specific functions in those DSOs.  Any DSO file with plugins has to include
-an initialization function with a specific name, "lammpsplugin_init", that
-has to follow specific rules described below.  When loading the DSO with
-the "plugin" command, this function is looked up and called and will then
-register the contained plugin(s) with LAMMPS.
+specific functions in those DSOs.  Any DSO file with plugins has to
+include an initialization function with a specific name,
+"lammpsplugin_init", that has to follow specific rules described below.
+When loading the DSO with the "plugin" command, this function is looked
+up and called and will then register the contained plugin(s) with
+LAMMPS.
+
+When the environment variable ``LAMMPS_PLUGIN_PATH`` is set, then LAMMPS
+will search the directory (or directories) listed in this path for files
+with names that end in ``plugin.so`` (e.g. ``helloplugin.so``) and will
+try to load the contained plugins automatically at start-up.  For
+plugins that are loaded this way, the behavior of LAMMPS should be
+identical to a binary where the corresponding code was compiled in
+statically as a package.
 
 From the programmer perspective this can work because of the object
 oriented design of LAMMPS where all pair style commands are derived from
@@ -65,19 +74,18 @@ Members of ``lammpsplugin_t``
    * - handle
      - Pointer to the open DSO file handle
 
-Only one of the three alternate creator entries can be used at a time
-and which of those is determined by the style of plugin. The
-"creator.v1" element is for factory functions of supported styles
-computing forces (i.e.  command, pair, bond, angle, dihedral, or
-improper styles) and the function takes as single argument the pointer
-to the LAMMPS instance. The factory function is cast to the
-``lammpsplugin_factory1`` type before assignment.  The "creator.v2"
-element is for factory functions creating an instance of a fix, compute,
-or region style and takes three arguments: a pointer to the LAMMPS
-instance, an integer with the length of the argument list and a ``char
-**`` pointer to the list of arguments. The factory function pointer
-needs to be cast to the ``lammpsplugin_factory2`` type before
-assignment.
+Only one of the two alternate creator entries can be used at a time and
+which of those is determined by the style of plugin. The "creator.v1"
+element is for factory functions of supported styles computing forces
+(i.e. pair, bond, angle, dihedral, or improper styles) or command styles
+and the function takes as single argument the pointer to the LAMMPS
+instance. The factory function is cast to the ``lammpsplugin_factory1``
+type before assignment.  The "creator.v2" element is for factory
+functions creating an instance of a fix, compute, or region style and
+takes three arguments: a pointer to the LAMMPS instance, an integer with
+the length of the argument list and a ``char **`` pointer to the list of
+arguments. The factory function pointer needs to be cast to the
+``lammpsplugin_factory2`` type before assignment.
 
 Pair style example
 ^^^^^^^^^^^^^^^^^^
@@ -249,3 +257,8 @@ by ``#ifdef PAIR_CLASS`` is not needed, since the mapping of the class
 name to the style name is done by the plugin registration function with
 the information from the ``lammpsplugin_t`` struct.  It may be included
 in case the new code is intended to be later included in LAMMPS directly.
+
+A plugin may be registered under an existing style name.  In that case
+the plugin will override the existing code.  This can be used to modify
+the behavior of existing styles or to debug new versions of them without
+having to recompile/reinstall all of LAMMPS.

--- a/doc/src/Packages_details.rst
+++ b/doc/src/Packages_details.rst
@@ -2154,6 +2154,11 @@ A :doc:`plugin <plugin>` command that can load and unload several
 kind of styles in LAMMPS from shared object files at runtime without
 having to recompile and relink LAMMPS.
 
+When the environment variable ``LAMMPS_PLUGIN_PATH`` is set, then LAMMPS
+will search the directory (or directories) listed in this path for files
+with names that end in ``plugin.so`` (e.g. ``helloplugin.so``) and will
+try to load the contained plugins automatically at start-up.
+
 **Authors:** Axel Kohlmeyer (Temple U)
 
 **Supporting info:**

--- a/doc/src/plugin.rst
+++ b/doc/src/plugin.rst
@@ -56,6 +56,15 @@ styles and names.
 
 The *clear* command will unload all currently loaded plugins.
 
+.. admonition:: Automatic loading of plugins
+   :class: note
+
+   When the environment variable ``LAMMPS_PLUGIN_PATH`` is set, then
+   LAMMPS will search the directory (or directories) listed in this path
+   for files with names that end in ``plugin.so``
+   (e.g. ``helloplugin.so``) and will try to load the contained plugins
+   automatically at start-up.
+
 
 Restrictions
 """"""""""""

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -1926,6 +1926,7 @@ Mayoral
 mbt
 MBytes
 mc
+mcmoves
 McLachlan
 md
 mdf

--- a/src/PLUGIN/plugin.cpp
+++ b/src/PLUGIN/plugin.cpp
@@ -67,10 +67,20 @@ void Plugin::command(int narg, char **arg)
     }
   } else
     error->all(FLERR, "Illegal plugin command");
-#if 0
-  if (comm->me == 0)
-    error->warning(
-        FLERR, "LAMMPS must be built as a shared library for it to work.");
+}
+
+// auto-load DSOs from designated folder(s)
+void plugin_auto_load(LAMMPS *lmp)
+{
+#if defined(LMP_PLUGIN)
+  for (const auto &plugin_dir : platform::list_pathenv("LAMMPS_PLUGIN_PATH")) {
+    if (lmp->comm->me == 0)
+      utils::logmesg(lmp, "Looking for LAMMPS plugins in: {}\n", plugin_dir);
+    for (const auto &file : platform::list_directory(plugin_dir)) {
+      if (utils::strmatch(file, "\\plugin.so$"))
+        plugin_load(platform::path_join(plugin_dir, file).c_str(), lmp);
+    }
+  }
 #endif
 }
 

--- a/src/PLUGIN/plugin.h
+++ b/src/PLUGIN/plugin.h
@@ -32,7 +32,7 @@ class Plugin : public Command {
 };
 
 void plugin_auto_load(LAMMPS *);
-void plugin_load(const char *, LAMMPS *);
+int plugin_load(const char *, LAMMPS *);
 void plugin_register(lammpsplugin_t *, void *);
 
 void plugin_unload(const char *, const char *, LAMMPS *);

--- a/src/PLUGIN/plugin.h
+++ b/src/PLUGIN/plugin.h
@@ -31,6 +31,7 @@ class Plugin : public Command {
   void command(int, char **) override;
 };
 
+void plugin_auto_load(LAMMPS *);
 void plugin_load(const char *, LAMMPS *);
 void plugin_register(lammpsplugin_t *, void *);
 

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -824,6 +824,11 @@ void LAMMPS::create()
   timer = new Timer(this);
 
   python = new Python(this);
+
+  // auto-load plugins
+#if defined(LMP_PLUGIN)
+  plugin_auto_load(this);
+#endif
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

This PR adds automatic loading of LAMMPS plugins if they are located in a directory listed in the
LAMMPS_PLUGIN_PATH environment variable. This is only applied to files whose names end in ``plugin.so`` (on *any* operating system).

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
