### PR TITLE
Bug fix: pair lj/cubic with more than one component.

### DIFF
--- a/src/EXTRA-PAIR/pair_lj_cubic.cpp
+++ b/src/EXTRA-PAIR/pair_lj_cubic.cpp
@@ -102,6 +102,7 @@ void PairLJCubic::compute(int eflag, int vflag)
       delz = ztmp - x[j][2];
       rsq = delx*delx + dely*dely + delz*delz;
       jtype = type[j];
+
       if (rsq < cutsq[itype][jtype]) {
         r2inv = 1.0/rsq;
         if (rsq <= cut_inner_sq[itype][jtype]) {

--- a/src/EXTRA-PAIR/pair_lj_cubic.cpp
+++ b/src/EXTRA-PAIR/pair_lj_cubic.cpp
@@ -102,7 +102,6 @@ void PairLJCubic::compute(int eflag, int vflag)
       delz = ztmp - x[j][2];
       rsq = delx*delx + dely*dely + delz*delz;
       jtype = type[j];
-
       if (rsq < cutsq[itype][jtype]) {
         r2inv = 1.0/rsq;
         if (rsq <= cut_inner_sq[itype][jtype]) {
@@ -241,6 +240,8 @@ double PairLJCubic::init_one(int i, int j)
   lj2[j][i] = lj2[i][j];
   lj3[j][i] = lj3[i][j];
   lj4[j][i] = lj4[i][j];
+  epsilon[j][i] = epsilon[i][j];
+  sigma[j][i] = sigma[i][j];
 
   return cut[i][j];
 }


### PR DESCRIPTION
**Summary**
Pair lj/cubic had a bug where the matrices for epsilon and sigma where not symmetric. This would cause the code to crash when there were two or more particle types. For example, epsilon[2][1] was undeclared, while epsilon[1][2] was equal to 1. This is fixed. This is likely because for other pair styles epsilon and sigma are not used in the compute function, and do not need to be symmetric.

**Related Issue(s)**
Not previously reported as far as I know.

**Author(s)**

Olav Galteland, PoreLab, Department of Chemistry, Norwegian University of Science and Technology, [olav.galteland@ntnu.no](mailto:olav.galteland@ntnu.no), [olav.galteland@gmail.com](mailto:olav.galteland@gmail.com)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None that I am aware of

**Implementation Notes**
Tested with the in.melt code, but changed to the lj/cubic potential with two particle types.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


