### PR TITLE
support kspace style plugin

### DIFF
--- a/doc/src/Developer_plugins.rst
+++ b/doc/src/Developer_plugins.rst
@@ -68,7 +68,7 @@ Members of ``lammpsplugin_t``
    * - author
      - String with the name and email of the author
    * - creator.v1
-     - Pointer to factory function for pair, bond, angle, dihedral, improper or command styles
+     - Pointer to factory function for pair, bond, angle, dihedral, improper, command or kspace styles
    * - creator.v2
      - Pointer to factory function for compute, fix, or region styles
    * - handle

--- a/doc/src/plugin.rst
+++ b/doc/src/plugin.rst
@@ -17,7 +17,7 @@ Syntax
 
      *load* file = load plugin(s) from shared object in *file*
      *unload* style name = unload plugin *name* of style *style*
-         *style* = *pair* or *bond* or *angle* or *dihedral* or *improper* or *compute* or *fix* or *region* or *command*
+         *style* = *pair* or *bond* or *angle* or *dihedral* or *improper* or *compute* or *fix* or *region* or *command* or *kspace*
      *list* = print a list of currently loaded plugins
      *clear* = unload all currently loaded plugins
 


### PR DESCRIPTION
**Summary**

Add kspace style plugin support to PLUGIN package. I need such feature during the development of deepmd-kit.

**Related Issue(s)**

https://github.com/deepmodeling/deepmd-kit/issues/1567

**Author(s)**

Jinzhe Zeng, Rutgers University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None

**Implementation Notes**

I have tested it with the DeePMD-kit - everything works fine.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


