### PR TITLE
remove defunct LBtype argument from lb/fluid doc

### DIFF
--- a/doc/src/fix_lb_fluid.rst
+++ b/doc/src/fix_lb_fluid.rst
@@ -8,7 +8,7 @@ Syntax
 
 .. parsed-literal::
 
-   fix ID group-ID lb/fluid nevery LBtype viscosity density keyword values ...
+   fix ID group-ID lb/fluid nevery viscosity density keyword values ...
 
 * ID, group-ID are documented in :doc:`fix <fix>` command
 * lb/fluid = style name of this fix command


### PR DESCRIPTION
**Summary**

Minor correction to lb/fluid doc where the LBtype argument got removed in going to new version of lb/fluid but didn't get removed from the doc page.

**Author(s)**

Colin Denniston, University of Western Ontario, cdennist@uwo.ca

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Just fixing doc error in new version of lb/fluid so doesn't change anything in code

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [x] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


