### PR TITLE
Ignore "processors" when nprocs == 1

### DIFF
--- a/doc/src/processors.rst
+++ b/doc/src/processors.rst
@@ -77,7 +77,9 @@ particular dimension over the course of the simulation.
 
 The product of Px, Py, Pz must equal P, the total # of processors
 LAMMPS is running on.  For a :doc:`2d simulation <dimension>`, Pz must
-equal 1.
+equal 1. As an exception, if LAMMPS is running on one processor,
+this command will be ignored, although a warning will be printed to the
+log file.
 
 Note that if you run on a prime number of processors P, then a grid
 such as 1 x P x 1 will be required, which may incur extra
@@ -342,6 +344,9 @@ This command cannot be used after the simulation box is defined by a
 :doc:`read_data <read_data>` or :doc:`create_box <create_box>` command.
 It can be used before a restart file is read to change the 3d
 processor grid from what is specified in the restart file.
+
+This command will be ignored if LAMMPS is running on a single processor.
+A warning will be printed to the log file when this occurs.
 
 The *grid numa* keyword only currently works with the *map cart*
 option.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1739,7 +1739,9 @@ void Input::processors()
 {
   if (domain->box_exist)
     error->all(FLERR,"Processors command after simulation box is defined");
-  comm->set_processors(narg,arg);
+  if (comm->nprocs == 1)
+    error->warning(FLERR,"Processors command ignored on single MPI process");
+  else comm->set_processors(narg,arg);
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
**Summary**

With this PR, LAMMPS ignores `processors` commands when running on a single MPI process. This removes one hurdle to running production scripts in testing or debugging LAMMPS.

**Related Issue(s)**

**Author(s)**

Shern Tee, University of Queensland

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues expected. Previous `processors` commands that would have thrown errors because they came after box definition will still throw errors.

**Implementation Notes**

Added `comm->nprocs` check to `input->processors()` before it calls `comm->set_processors`.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**