### PR TITLE
Fixed small bug in dump_vtk command for vector names.

### DIFF
--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -1903,7 +1903,12 @@ void DumpVTK::identify_vectors()
        name.count(vector3_starts[v3s]+2) )
     {
       std::string vectorName = name[vector3_starts[v3s]];
-      vectorName.erase(vectorName.find_first_of('x'));
+      std::string::size_t erase_start = vectorName.find_first_of('x');
+      if (erase_start == 0) {
+	vectorName.erase(0,1);
+      } else {
+	vectorName.erase(erase_start);
+      }
       name[vector3_starts[v3s]] = vectorName;
       vector_set.insert(vector3_starts[v3s]);
     }


### PR DESCRIPTION
**Summary**

The VTK package was not correctly naming the PointData for the vector scaled coordinates (xs,ys,zs), unwrapped coordinates (xu,yu,zu) and scaled unwrapped coordinates (xsu,ysu,zsu). The bug was due to erasing all of the string in these vector names, since they start with x (vs e.g. fx which ends with x, and so still leaves the name "f").

**Related Issue(s)**

**Author(s)**

Sam Cameron, University of Bristol

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
No issues.
**Implementation Notes**
N/A
**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


