### PR TITLE
Fix deform doc page edit

### DIFF
--- a/doc/src/fix_deform.rst
+++ b/doc/src/fix_deform.rst
@@ -70,7 +70,7 @@ Syntax
 
        *remap* value = *x* or *v* or *none*
          x = remap coords of atoms in group into deforming box
-         v = remap velocities of all atoms when they cross periodic boundaries
+         v = remap velocities of atoms in group when they cross periodic boundaries
          none = no remapping of x or v
        *flip* value = *yes* or *no*
          allow or disallow box flips when it becomes highly skewed


### PR DESCRIPTION
**Summary**

Doc page incorrectly states that fix deform remap v is applied to all atoms, rather than group atoms.  Later on the page it is explained correctly.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


