### PR TITLE
Fix for building GPU backend on ROCm 5.1+

### DIFF
--- a/cmake/Modules/Packages/GPU.cmake
+++ b/cmake/Modules/Packages/GPU.cmake
@@ -347,6 +347,10 @@ elseif(GPU_API STREQUAL "HIP")
   target_link_libraries(gpu PRIVATE hip::host)
 
   if(HIP_USE_DEVICE_SORT)
+    if(HIP_PLATFORM STREQUAL "amd")
+      # newer version of ROCm (5.1+) require c++14 for rocprim
+      set_property(TARGET gpu PROPERTY CXX_STANDARD 14)
+    endif()
     # add hipCUB
     target_include_directories(gpu PRIVATE ${HIP_ROOT_DIR}/../include)
     target_compile_definitions(gpu PRIVATE -DUSE_HIP_DEVICE_SORT)

--- a/lib/gpu/Makefile.hip
+++ b/lib/gpu/Makefile.hip
@@ -28,6 +28,11 @@ HIP_HOST_INCLUDE += -I./
 # path to hipcub
 HIP_HOST_INCLUDE += -I$(HIP_PATH)/../include
 
+ifeq (amd,$(HIP_PLATFORM))
+	# newer version of ROCm (5.1+) require c++14 for rocprim
+	HIP_OPTS += -std=c++14
+endif
+
 # use mpi
 HIP_HOST_OPTS += -DMPI_GERYON -DUCL_NO_EXIT
 # this settings should match LAMMPS Makefile


### PR DESCRIPTION
**Summary**

Minor fix for GPU backend compilation w/ rocprim on ROCm 5.1+.  I also got the rocPRIM devs to update the requirement list: https://github.com/ROCmSoftwarePlatform/rocPRIM/commit/437ae04ed4ec4cd452ce47a99a1ccb7f06bb6d54

**Related Issue(s)**

N/A

**Author(s)**

Nick Curtis

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Should be fine, all HIP-Clang versions support C++14.

**Implementation Notes**

Built and tested on Crusher

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


