### PR TITLE
Fix issues in Kokkos Tersoff and Stillinger-Weber pair styles

### DIFF
--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -136,10 +136,10 @@ void PairSWKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   if (((int) d_neighbors_short.extent(1) < max_neighs) ||
       ((int) d_neighbors_short.extent(0) < ignum)) {
-    d_neighbors_short = Kokkos::View<int**,DeviceType>("SW::neighbors_short",ignum,max_neighs);
+    d_neighbors_short = Kokkos::View<int**,DeviceType>("SW::neighbors_short",ignum*1.2,max_neighs);
   }
   if ((int)d_numneigh_short.extent(0) < ignum)
-    d_numneigh_short = Kokkos::View<int*,DeviceType>("SW::numneighs_short",ignum);
+    d_numneigh_short = Kokkos::View<int*,DeviceType>("SW::numneighs_short",ignum*1.2);
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairSWComputeShortNeigh>(0,neighflag==FULL?ignum:inum), *this);
 
   // loop over neighbor list of my atoms

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -138,7 +138,7 @@ void PairSWKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
       ((int) d_neighbors_short.extent(0) < ignum)) {
     d_neighbors_short = Kokkos::View<int**,DeviceType>("SW::neighbors_short",ignum,max_neighs);
   }
-  if ((int)d_numneigh_short.extent(0) , ignum)
+  if ((int)d_numneigh_short.extent(0) < ignum)
     d_numneigh_short = Kokkos::View<int*,DeviceType>("SW::numneighs_short",ignum);
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairSWComputeShortNeigh>(0,neighflag==FULL?ignum:inum), *this);
 

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -78,8 +78,6 @@ void PairSWKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   eflag = eflag_in;
   vflag = vflag_in;
 
-  if (neighflag == FULL) no_virial_fdotr_compute = 1;
-
   ev_init(eflag,vflag,0);
 
   // reallocate per-atom arrays if necessary
@@ -140,33 +138,21 @@ void PairSWKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
   if ((int)d_numneigh_short.extent(0) < ignum)
     d_numneigh_short = Kokkos::View<int*,DeviceType>("SW::numneighs_short",ignum*1.2);
-  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairSWComputeShortNeigh>(0,neighflag==FULL?ignum:inum), *this);
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairSWComputeShortNeigh>(0,inum), *this);
 
   // loop over neighbor list of my atoms
 
   if (neighflag == HALF) {
     if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairSWComputeHalf<HALF,1> >(0,inum),*this,ev);
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairSWCompute<HALF,1> >(0,inum),*this,ev);
     else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairSWComputeHalf<HALF,0> >(0,inum),*this);
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairSWCompute<HALF,0> >(0,inum),*this);
     ev_all += ev;
   } else if (neighflag == HALFTHREAD) {
     if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairSWComputeHalf<HALFTHREAD,1> >(0,inum),*this,ev);
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairSWCompute<HALFTHREAD,1> >(0,inum),*this,ev);
     else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairSWComputeHalf<HALFTHREAD,0> >(0,inum),*this);
-    ev_all += ev;
-  } else if (neighflag == FULL) {
-    if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairSWComputeFullA<FULL,1> >(0,inum),*this,ev);
-    else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairSWComputeFullA<FULL,0> >(0,inum),*this);
-    ev_all += ev;
-
-    if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairSWComputeFullB<FULL,1> >(0,ignum),*this,ev);
-    else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairSWComputeFullB<FULL,0> >(0,ignum),*this);
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairSWCompute<HALFTHREAD,0> >(0,inum),*this);
     ev_all += ev;
   }
 
@@ -244,7 +230,7 @@ void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeShortNeigh, const int&
 template<class DeviceType>
 template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeHalf<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
+void PairSWKokkos<DeviceType>::operator()(TagPairSWCompute<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
 
   // The f array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
@@ -373,203 +359,9 @@ void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeHalf<NEIGHFLAG,EVFLAG>
 template<class DeviceType>
 template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeHalf<NEIGHFLAG,EVFLAG>, const int &ii) const {
+void PairSWKokkos<DeviceType>::operator()(TagPairSWCompute<NEIGHFLAG,EVFLAG>, const int &ii) const {
   EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairSWComputeHalf<NEIGHFLAG,EVFLAG>(), ii, ev);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeFullA<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
-
-  F_FLOAT delr1[3],delr2[3],fj[3],fk[3];
-  F_FLOAT evdwl = 0.0;
-  F_FLOAT fpair = 0.0;
-
-  const int i = d_ilist[ii];
-
-  const int itype = d_map[type[i]];
-  const X_FLOAT xtmp = x(i,0);
-  const X_FLOAT ytmp = x(i,1);
-  const X_FLOAT ztmp = x(i,2);
-
-  // two-body interactions
-
-  const int jnum = d_numneigh_short[ii];
-
-  F_FLOAT fxtmpi = 0.0;
-  F_FLOAT fytmpi = 0.0;
-  F_FLOAT fztmpi = 0.0;
-
-  for (int jj = 0; jj < jnum; jj++) {
-    int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
-
-    const int jtype = d_map[type[j]];
-
-    const X_FLOAT delx = xtmp - x(j,0);
-    const X_FLOAT dely = ytmp - x(j,1);
-    const X_FLOAT delz = ztmp - x(j,2);
-    const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-
-    const int ijparam = d_elem3param(itype,jtype,jtype);
-
-    if (rsq >= d_params[ijparam].cutsq) continue;
-
-    twobody(d_params[ijparam],rsq,fpair,eflag,evdwl);
-
-    fxtmpi += delx*fpair;
-    fytmpi += dely*fpair;
-    fztmpi += delz*fpair;
-
-    if (EVFLAG) {
-      if (eflag) ev.evdwl += 0.5*evdwl;
-      if (vflag_either || eflag_atom) this->template ev_tally<NEIGHFLAG>(ev,i,j,evdwl,fpair,delx,dely,delz);
-    }
-  }
-
-  const int jnumm1 = jnum - 1;
-
-  for (int jj = 0; jj < jnumm1; jj++) {
-    int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
-    const int jtype = d_map[type[j]];
-    const int ijparam = d_elem3param(itype,jtype,jtype);
-    delr1[0] = x(j,0) - xtmp;
-    delr1[1] = x(j,1) - ytmp;
-    delr1[2] = x(j,2) - ztmp;
-    const F_FLOAT rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
-
-    if (rsq1 >= d_params[ijparam].cutsq) continue;
-
-    for (int kk = jj+1; kk < jnum; kk++) {
-      int k = d_neighbors_short(ii,kk);
-      k &= NEIGHMASK;
-      const int ktype = d_map[type[k]];
-      const int ikparam = d_elem3param(itype,ktype,ktype);
-      const int ijkparam = d_elem3param(itype,jtype,ktype);
-
-      delr2[0] = x(k,0) - xtmp;
-      delr2[1] = x(k,1) - ytmp;
-      delr2[2] = x(k,2) - ztmp;
-      const F_FLOAT rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
-
-      if (rsq2 >= d_params[ikparam].cutsq) continue;
-
-      threebody_kk(d_params[ijparam],d_params[ikparam],d_params[ijkparam],
-                rsq1,rsq2,delr1,delr2,fj,fk,eflag,evdwl);
-
-      fxtmpi -= fj[0] + fk[0];
-      fytmpi -= fj[1] + fk[1];
-      fztmpi -= fj[2] + fk[2];
-
-      if (EVFLAG) {
-        if (eflag) ev.evdwl += evdwl;
-        if (vflag_either || eflag_atom) this->template ev_tally3<NEIGHFLAG>(ev,i,j,k,evdwl,0.0,fj,fk,delr1,delr2);
-      }
-    }
-  }
-
-  f(i,0) += fxtmpi;
-  f(i,1) += fytmpi;
-  f(i,2) += fztmpi;
-}
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeFullA<NEIGHFLAG,EVFLAG>, const int &ii) const {
-  EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairSWComputeFullA<NEIGHFLAG,EVFLAG>(), ii, ev);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeFullB<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
-
-  F_FLOAT delr1[3],delr2[3],fj[3],fk[3];
-  F_FLOAT evdwl = 0.0;
-
-  const int i = d_ilist[ii];
-
-  const int itype = d_map[type[i]];
-  const X_FLOAT xtmpi = x(i,0);
-  const X_FLOAT ytmpi = x(i,1);
-  const X_FLOAT ztmpi = x(i,2);
-
-  const int jnum = d_numneigh_short[ii];
-
-  F_FLOAT fxtmpi = 0.0;
-  F_FLOAT fytmpi = 0.0;
-  F_FLOAT fztmpi = 0.0;
-
-  for (int jj = 0; jj < jnum; jj++) {
-    int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
-    if (j >= nlocal) continue;
-    const int jtype = d_map[type[j]];
-    const int jiparam = d_elem3param(jtype,itype,itype);
-    const X_FLOAT xtmpj = x(j,0);
-    const X_FLOAT ytmpj = x(j,1);
-    const X_FLOAT ztmpj = x(j,2);
-
-    delr1[0] = xtmpi - xtmpj;
-    delr1[1] = ytmpi - ytmpj;
-    delr1[2] = ztmpi - ztmpj;
-    const F_FLOAT rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
-
-    if (rsq1 >= d_params[jiparam].cutsq) continue;
-
-    const int j_jnum = d_numneigh_short[jj];
-
-    for (int kk = 0; kk < j_jnum; kk++) {
-      int k = d_neighbors_short(jj,kk);
-      k &= NEIGHMASK;
-      if (k == i) continue;
-      const int ktype = d_map[type[k]];
-      const int jkparam = d_elem3param(jtype,ktype,ktype);
-      const int jikparam = d_elem3param(jtype,itype,ktype);
-
-      delr2[0] = x(k,0) - xtmpj;
-      delr2[1] = x(k,1) - ytmpj;
-      delr2[2] = x(k,2) - ztmpj;
-      const F_FLOAT rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
-
-      if (rsq2 >= d_params[jkparam].cutsq) continue;
-
-      if (vflag_atom)
-        threebody_kk(d_params[jiparam],d_params[jkparam],d_params[jikparam],
-                  rsq1,rsq2,delr1,delr2,fj,fk,eflag,evdwl);
-      else
-        threebodyj(d_params[jiparam],d_params[jkparam],d_params[jikparam],
-                  rsq1,rsq2,delr1,delr2,fj);
-
-      fxtmpi += fj[0];
-      fytmpi += fj[1];
-      fztmpi += fj[2];
-
-      if (EVFLAG)
-        if (vflag_atom || eflag_atom) ev_tally3_atom(ev,i,evdwl,0.0,fj,fk,delr1,delr2);
-    }
-  }
-
-  f(i,0) += fxtmpi;
-  f(i,1) += fytmpi;
-  f(i,2) += fztmpi;
-}
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairSWKokkos<DeviceType>::operator()(TagPairSWComputeFullB<NEIGHFLAG,EVFLAG>, const int &ii) const {
-  EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairSWComputeFullB<NEIGHFLAG,EVFLAG>(), ii, ev);
+  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairSWCompute<NEIGHFLAG,EVFLAG>(), ii, ev);
 }
 
 /* ----------------------------------------------------------------------
@@ -615,7 +407,9 @@ void PairSWKokkos<DeviceType>::init_style()
   request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
   // always request a full neighbor list
   request->enable_full();
-  if (neighflag == FULL) request->enable_ghost();
+
+  if (neighflag == FULL)
+    error->all(FLERR,"Must use half neighbor list style with pair sw/kk");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -785,7 +579,6 @@ void PairSWKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const int &j
       const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
                 const F_FLOAT &dely, const F_FLOAT &delz) const
 {
-  const int VFLAG = vflag_either;
 
   // The eatom and vatom arrays are duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
@@ -798,11 +591,10 @@ void PairSWKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const int &j
   if (eflag_atom) {
     const E_FLOAT epairhalf = 0.5 * epair;
     a_eatom[i] += epairhalf;
-    if (NEIGHFLAG != FULL)
-      a_eatom[j] += epairhalf;
+    a_eatom[j] += epairhalf;
   }
 
-  if (VFLAG) {
+  if (vflag_either) {
     const E_FLOAT v0 = delx*delx*fpair;
     const E_FLOAT v1 = dely*dely*fpair;
     const E_FLOAT v2 = delz*delz*fpair;
@@ -811,21 +603,12 @@ void PairSWKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const int &j
     const E_FLOAT v5 = dely*delz*fpair;
 
     if (vflag_global) {
-      if (NEIGHFLAG != FULL) {
-        ev.v[0] += v0;
-        ev.v[1] += v1;
-        ev.v[2] += v2;
-        ev.v[3] += v3;
-        ev.v[4] += v4;
-        ev.v[5] += v5;
-      } else {
-        ev.v[0] += 0.5*v0;
-        ev.v[1] += 0.5*v1;
-        ev.v[2] += 0.5*v2;
-        ev.v[3] += 0.5*v3;
-        ev.v[4] += 0.5*v4;
-        ev.v[5] += 0.5*v5;
-      }
+      ev.v[0] += v0;
+      ev.v[1] += v1;
+      ev.v[2] += v2;
+      ev.v[3] += v3;
+      ev.v[4] += v4;
+      ev.v[5] += v5;
     }
 
     if (vflag_atom) {
@@ -836,14 +619,12 @@ void PairSWKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const int &j
       a_vatom(i,4) += 0.5*v4;
       a_vatom(i,5) += 0.5*v5;
 
-      if (NEIGHFLAG != FULL) {
-        a_vatom(j,0) += 0.5*v0;
-        a_vatom(j,1) += 0.5*v1;
-        a_vatom(j,2) += 0.5*v2;
-        a_vatom(j,3) += 0.5*v3;
-        a_vatom(j,4) += 0.5*v4;
-        a_vatom(j,5) += 0.5*v5;
-      }
+      a_vatom(j,0) += 0.5*v0;
+      a_vatom(j,1) += 0.5*v1;
+      a_vatom(j,2) += 0.5*v2;
+      a_vatom(j,3) += 0.5*v3;
+      a_vatom(j,4) += 0.5*v4;
+      a_vatom(j,5) += 0.5*v5;
     }
   }
 }
@@ -863,8 +644,6 @@ void PairSWKokkos<DeviceType>::ev_tally3(EV_FLOAT &ev, const int &i, const int &
 {
   F_FLOAT epairthird,v[6];
 
-  const int VFLAG = vflag_either;
-
   // The eatom and vatom arrays are duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
   auto v_eatom = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_eatom),decltype(ndup_eatom)>::get(dup_eatom,ndup_eatom);
@@ -876,13 +655,11 @@ void PairSWKokkos<DeviceType>::ev_tally3(EV_FLOAT &ev, const int &i, const int &
   if (eflag_atom) {
     epairthird = THIRD * (evdwl + ecoul);
     a_eatom[i] += epairthird;
-    if (NEIGHFLAG != FULL) {
-      a_eatom[j] += epairthird;
-      a_eatom[k] += epairthird;
-    }
+    a_eatom[j] += epairthird;
+    a_eatom[k] += epairthird;
   }
 
-  if (VFLAG) {
+  if (vflag_either) {
     v[0] = drji[0]*fj[0] + drki[0]*fk[0];
     v[1] = drji[1]*fj[1] + drki[1]*fk[1];
     v[2] = drji[2]*fj[2] + drki[2]*fk[2];
@@ -904,15 +681,13 @@ void PairSWKokkos<DeviceType>::ev_tally3(EV_FLOAT &ev, const int &i, const int &
       a_vatom(i,2) += THIRD*v[2]; a_vatom(i,3) += THIRD*v[3];
       a_vatom(i,4) += THIRD*v[4]; a_vatom(i,5) += THIRD*v[5];
 
-      if (NEIGHFLAG != FULL) {
-        a_vatom(j,0) += THIRD*v[0]; a_vatom(j,1) += THIRD*v[1];
-        a_vatom(j,2) += THIRD*v[2]; a_vatom(j,3) += THIRD*v[3];
-        a_vatom(j,4) += THIRD*v[4]; a_vatom(j,5) += THIRD*v[5];
+      a_vatom(j,0) += THIRD*v[0]; a_vatom(j,1) += THIRD*v[1];
+      a_vatom(j,2) += THIRD*v[2]; a_vatom(j,3) += THIRD*v[3];
+      a_vatom(j,4) += THIRD*v[4]; a_vatom(j,5) += THIRD*v[5];
 
-        a_vatom(k,0) += THIRD*v[0]; a_vatom(k,1) += THIRD*v[1];
-        a_vatom(k,2) += THIRD*v[2]; a_vatom(k,3) += THIRD*v[3];
-        a_vatom(k,4) += THIRD*v[4]; a_vatom(k,5) += THIRD*v[5];
-      }
+      a_vatom(k,0) += THIRD*v[0]; a_vatom(k,1) += THIRD*v[1];
+      a_vatom(k,2) += THIRD*v[2]; a_vatom(k,3) += THIRD*v[3];
+      a_vatom(k,4) += THIRD*v[4]; a_vatom(k,5) += THIRD*v[5];
     }
   }
 }
@@ -931,14 +706,12 @@ void PairSWKokkos<DeviceType>::ev_tally3_atom(EV_FLOAT & /*ev*/, const int &i,
 {
   F_FLOAT epairthird,v[6];
 
-  const int VFLAG = vflag_either;
-
   if (eflag_atom) {
     epairthird = THIRD * (evdwl + ecoul);
     d_eatom[i] += epairthird;
   }
 
-  if (VFLAG) {
+  if (vflag_either) {
     v[0] = drji[0]*fj[0] + drki[0]*fk[0];
     v[1] = drji[1]*fj[1] + drki[1]*fk[1];
     v[2] = drji[2]*fj[2] + drki[2]*fk[2];

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -401,8 +401,6 @@ void PairSWKokkos<DeviceType>::init_style()
   request->set_kokkos_host(std::is_same<DeviceType,LMPHostType>::value &&
                            !std::is_same<DeviceType,LMPDeviceType>::value);
   request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
-  // always request a full neighbor list
-  request->enable_full();
 
   if (neighflag == FULL)
     error->all(FLERR,"Must use half neighbor list style with pair sw/kk");

--- a/src/KOKKOS/pair_sw_kokkos.h
+++ b/src/KOKKOS/pair_sw_kokkos.h
@@ -158,7 +158,7 @@ class PairSWKokkos : public PairSW {
 
 /* ERROR/WARNING messages:
 
-E: Cannot use chosen neighbor list style with pair sw/kk
+E: Must use half neighbor list style with pair sw/kk
 
 Self-explanatory.
 

--- a/src/KOKKOS/pair_sw_kokkos.h
+++ b/src/KOKKOS/pair_sw_kokkos.h
@@ -27,13 +27,7 @@ PairStyle(sw/kk/host,PairSWKokkos<LMPHostType>);
 #include "pair_kokkos.h"
 
 template<int NEIGHFLAG, int EVFLAG>
-struct TagPairSWComputeHalf{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairSWComputeFullA{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairSWComputeFullB{};
+struct TagPairSWCompute{};
 
 struct TagPairSWComputeShortNeigh{};
 
@@ -42,7 +36,7 @@ namespace LAMMPS_NS {
 template<class DeviceType>
 class PairSWKokkos : public PairSW {
  public:
-  enum {EnabledNeighFlags=FULL};
+  enum {EnabledNeighFlags=HALF|HALFTHREAD};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -56,27 +50,11 @@ class PairSWKokkos : public PairSW {
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairSWComputeHalf<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
+  void operator()(TagPairSWCompute<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairSWComputeHalf<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairSWComputeFullA<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairSWComputeFullA<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairSWComputeFullB<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairSWComputeFullB<NEIGHFLAG,EVFLAG>, const int&) const;
+  void operator()(TagPairSWCompute<NEIGHFLAG,EVFLAG>, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPairSWComputeShortNeigh, const int&) const;

--- a/src/KOKKOS/pair_sw_kokkos.h
+++ b/src/KOKKOS/pair_sw_kokkos.h
@@ -99,10 +99,6 @@ class PairSWKokkos : public PairSW {
   void threebody_kk(const Param&, const Param&, const Param&, const F_FLOAT&, const F_FLOAT&, F_FLOAT *, F_FLOAT *,
                     F_FLOAT *, F_FLOAT *, const int&, F_FLOAT&) const;
 
-  KOKKOS_INLINE_FUNCTION
-  void threebodyj(const Param&, const Param&, const Param&, const F_FLOAT&, const F_FLOAT&, F_FLOAT *, F_FLOAT *,
-                 F_FLOAT *) const;
-
   typename AT::t_x_array_randomread x;
   typename AT::t_f_array f;
   typename AT::t_tagint_1d tag;

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -116,8 +116,6 @@ void PairTersoffKokkos<DeviceType>::init_style()
   request->set_kokkos_host(std::is_same<DeviceType,LMPHostType>::value &&
                            !std::is_same<DeviceType,LMPDeviceType>::value);
   request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
-  // always request a full neighbor list
-  request->enable_full();
 
   if (neighflag == FULL)
     error->all(FLERR,"Must use half neighbor list style with pair tersoff/kk");
@@ -769,6 +767,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthb(
 
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
@@ -837,6 +836,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthbj(
   dfc = ters_dfc(param,rik);
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
@@ -898,6 +898,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthbk(
   dfc = ters_dfc(param,rik);
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -868,7 +868,7 @@ double PairTersoffKokkos<DeviceType>::bondorder(Param *param,
 
   const F_FLOAT costheta = (dx1*dx2 + dy1*dy2 + dz1*dz2)/(rij*rik);
 
-  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  const F_FLOAT paramtmp = param->lam3 * (rij-rik);
   if (int(param->powerm) == 3) arg = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
   else arg = paramtmp;
 
@@ -1079,7 +1079,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthb(
 
   ters_fc_k_and_ters_dfc(param,rik,fc,dfc);
 
-  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  const F_FLOAT paramtmp = param->lam3 * (rij-rik);
   if (int(param->powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
@@ -1147,7 +1147,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthbj(
 
   fc = ters_fc_k(param,rik);
   dfc = ters_dfc(param,rik);
-  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  const F_FLOAT paramtmp = param->lam3 * (rij-rik);
   if (int(param->powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
@@ -1208,7 +1208,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthbk(
 
   fc = ters_fc_k(param,rik);
   dfc = ters_dfc(param,rik);
-  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  const F_FLOAT paramtmp = param->lam3 * (rij-rik);
   if (int(param->powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -343,7 +343,6 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffCompute<NEIGHFLAG,E
 
   for (int jj = 0; jj < jnum; jj++) {
     int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
     const int jtype = d_map(type(j));
 
     const F_FLOAT delx1 = xtmp - x(j,0);
@@ -360,7 +359,6 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffCompute<NEIGHFLAG,E
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
       int k = d_neighbors_short(ii,kk);
-      k &= NEIGHMASK;
       const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
@@ -402,7 +400,6 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffCompute<NEIGHFLAG,E
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
       int k = d_neighbors_short(ii,kk);
-      k &= NEIGHMASK;
       const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -686,7 +686,7 @@ double PairTersoffKokkos<DeviceType>::ters_dbij(const Param& param, const F_FLOA
     return param.beta * (factor *
            // error in negligible 2nd term fixed 2/21/2022
            // (1.0 - 0.5*(1.0 +  1.0/(2.0*param.powern)) *
-           (1.0 - (1.0 +  1.0/(2.0*param.powern)) *
+           (1.0 - (1.0 + 1.0/(2.0*param.powern)) *
            pow(tmp,-param.powern)));
   if (tmp < param.c4) return 0.0;
   if (tmp < param.c3)
@@ -936,8 +936,6 @@ void PairTersoffKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const i
       const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
                 const F_FLOAT &dely, const F_FLOAT &delz) const
 {
-  const int VFLAG = vflag_either;
-
   // The eatom and vatom arrays are duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
   auto v_eatom = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_eatom),decltype(ndup_eatom)>::get(dup_eatom,ndup_eatom);
@@ -952,7 +950,7 @@ void PairTersoffKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const i
     a_eatom[j] += epairhalf;
   }
 
-  if (VFLAG) {
+  if (vflag_either) {
     const E_FLOAT v0 = delx*delx*fpair;
     const E_FLOAT v1 = dely*dely*fpair;
     const E_FLOAT v2 = delz*delz*fpair;
@@ -1043,7 +1041,8 @@ void PairTersoffKokkos<DeviceType>::v_tally3(EV_FLOAT &ev,
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffKokkos<DeviceType>::v_tally3_atom(EV_FLOAT &ev, const int &i, const int & /*j*/,
-                                                  const int & /*k*/, F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const
+                                                  const int & /*k*/, F_FLOAT *fj, F_FLOAT *fk,
+                                                  F_FLOAT *drji, F_FLOAT *drjk) const
 {
   F_FLOAT v[6];
 

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -219,10 +219,10 @@ void PairTersoffKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   if (((int)d_neighbors_short.extent(1) < max_neighs) ||
      ((int)d_neighbors_short.extent(0) < ignum)) {
-    d_neighbors_short = Kokkos::View<int**,DeviceType>("Tersoff::neighbors_short",ignum,max_neighs);
+    d_neighbors_short = Kokkos::View<int**,DeviceType>("Tersoff::neighbors_short",ignum*1.2,max_neighs);
   }
   if ((int)d_numneigh_short.extent(0) < ignum)
-    d_numneigh_short = Kokkos::View<int*,DeviceType>("Tersoff::numneighs_short",ignum);
+    d_numneigh_short = Kokkos::View<int*,DeviceType>("Tersoff::numneighs_short",ignum*1.2);
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairTersoffComputeShortNeigh>(0,neighflag==FULL?ignum:inum), *this);
 
   if (neighflag == HALF) {

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -75,18 +75,29 @@ PairTersoffKokkos<DeviceType>::~PairTersoffKokkos()
   }
 }
 
-/* ---------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------
+   set coeffs for one or more type pairs
+------------------------------------------------------------------------- */
 
 template<class DeviceType>
-void PairTersoffKokkos<DeviceType>::allocate()
+void PairTersoffKokkos<DeviceType>::coeff(int narg, char **arg)
 {
-  PairTersoff::allocate();
+  PairTersoff::coeff(narg,arg);
+
+  // sync map
 
   int n = atom->ntypes;
 
-  k_params = Kokkos::DualView<params_ters***,Kokkos::LayoutRight,DeviceType>
-          ("PairTersoff::paramskk",n+1,n+1,n+1);
-  paramskk = k_params.template view<DeviceType>();
+  DAT::tdual_int_1d k_map = DAT::tdual_int_1d("pair:map",n+1);
+  HAT::t_int_1d h_map = k_map.h_view;
+
+  for (int i = 1; i <= n; i++)
+    h_map[i] = map[i];
+
+  k_map.template modify<LMPHostType>();
+  k_map.template sync<DeviceType>();
+
+  d_map = k_map.template view<DeviceType>();
 }
 
 /* ----------------------------------------------------------------------
@@ -117,35 +128,29 @@ void PairTersoffKokkos<DeviceType>::setup_params()
 {
   PairTersoff::setup_params();
 
-  int i,j,k,m;
-  int n = atom->ntypes;
+  // sync elem3param and params
 
-  for (i = 1; i <= n; i++)
-    for (j = 1; j <= n; j++)
-      for (k = 1; k <= n; k++) {
-        m = elem3param[map[i]][map[j]][map[k]];
-        k_params.h_view(i,j,k).powerm = params[m].powerm;
-        k_params.h_view(i,j,k).gamma = params[m].gamma;
-        k_params.h_view(i,j,k).lam3 = params[m].lam3;
-        k_params.h_view(i,j,k).c = params[m].c;
-        k_params.h_view(i,j,k).d = params[m].d;
-        k_params.h_view(i,j,k).h = params[m].h;
-        k_params.h_view(i,j,k).powern = params[m].powern;
-        k_params.h_view(i,j,k).beta = params[m].beta;
-        k_params.h_view(i,j,k).lam2 = params[m].lam2;
-        k_params.h_view(i,j,k).bigb = params[m].bigb;
-        k_params.h_view(i,j,k).bigr = params[m].bigr;
-        k_params.h_view(i,j,k).bigd = params[m].bigd;
-        k_params.h_view(i,j,k).lam1 = params[m].lam1;
-        k_params.h_view(i,j,k).biga = params[m].biga;
-        k_params.h_view(i,j,k).cutsq = params[m].cutsq;
-        k_params.h_view(i,j,k).c1 = params[m].c1;
-        k_params.h_view(i,j,k).c2 = params[m].c2;
-        k_params.h_view(i,j,k).c3 = params[m].c3;
-        k_params.h_view(i,j,k).c4 = params[m].c4;
-      }
+  tdual_int_3d k_elem3param = tdual_int_3d("pair:elem3param",nelements,nelements,nelements);
+  t_host_int_3d h_elem3param = k_elem3param.h_view;
 
-  k_params.template modify<LMPHostType>();
+  tdual_param_1d k_params = tdual_param_1d("pair:params",nparams);
+  t_host_param_1d h_params = k_params.h_view;
+
+  for (int i = 0; i < nelements; i++)
+    for (int j = 0; j < nelements; j++)
+      for (int k = 0; k < nelements; k++)
+        h_elem3param(i,j,k) = elem3param[i][j][k];
+
+  for (int m = 0; m < nparams; m++)
+    h_params[m] = params[m];
+
+  k_elem3param.modify_host();
+  k_elem3param.template sync<DeviceType>();
+  k_params.modify_host();
+  k_params.template sync<DeviceType>();
+
+  d_elem3param = k_elem3param.template view<DeviceType>();
+  d_params = k_params.template view<DeviceType>();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -174,7 +179,6 @@ void PairTersoffKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
 
   atomKK->sync(execution_space,datamask_read);
-  k_params.template sync<DeviceType>();
   if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
   else atomKK->modified(execution_space,F_MASK);
 
@@ -213,11 +217,11 @@ void PairTersoffKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   int max_neighs = d_neighbors.extent(1);
 
-  if (((int)d_neighbors_short.extent(1) != max_neighs) ||
-     ((int)d_neighbors_short.extent(0) != ignum)) {
+  if (((int)d_neighbors_short.extent(1) < max_neighs) ||
+     ((int)d_neighbors_short.extent(0) < ignum)) {
     d_neighbors_short = Kokkos::View<int**,DeviceType>("Tersoff::neighbors_short",ignum,max_neighs);
   }
-  if ((int)d_numneigh_short.extent(0)!=ignum)
+  if ((int)d_numneigh_short.extent(0) < ignum)
     d_numneigh_short = Kokkos::View<int*,DeviceType>("Tersoff::numneighs_short",ignum);
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairTersoffComputeShortNeigh>(0,neighflag==FULL?ignum:inum), *this);
 
@@ -309,11 +313,11 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeShortNeigh, 
       const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
       if (rsq < cutmax_sq) {
-        d_neighbors_short(i,inside) = j;
+        d_neighbors_short(ii,inside) = j;
         inside++;
       }
     }
-    d_numneigh_short(i) = inside;
+    d_numneigh_short(ii) = inside;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -333,13 +337,13 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
   const X_FLOAT xtmp = x(i,0);
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
+  const int itype = d_map(type(i));
   const tagint itag = tag(i);
 
   F_FLOAT fi[3], fj[3], fk[3];
 
   //const AtomNeighborsConst d_neighbors_i = k_list.get_neighbors_const(i);
-  const int jnum = d_numneigh_short[i];
+  const int jnum = d_numneigh_short[ii];
 
   // repulsive
 
@@ -350,15 +354,16 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
   // attractive: bond order
 
   for (int jj = 0; jj < jnum; jj++) {
-    int j = d_neighbors_short(i,jj);
+    int j = d_neighbors_short(ii,jj);
     j &= NEIGHMASK;
-    const int jtype = type(j);
+    const int jtype = d_map(type(j));
 
     const F_FLOAT delx1 = xtmp - x(j,0);
     const F_FLOAT dely1 = ytmp - x(j,1);
     const F_FLOAT delz1 = ztmp - x(j,2);
     const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    const F_FLOAT cutsq1 = paramskk(itype,jtype,jtype).cutsq;
+    const int iparam_ij = d_elem3param(itype,jtype,jtype);
+    const F_FLOAT cutsq1 = d_params(iparam_ij).cutsq;
 
     F_FLOAT bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
@@ -366,26 +371,27 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      int k = d_neighbors_short(i,kk);
+      int k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      const int ktype = type(k);
+      const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
       const F_FLOAT dely2 = ytmp - x(k,1);
       const F_FLOAT delz2 = ztmp - x(k,2);
       const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      const F_FLOAT cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       const F_FLOAT rik = sqrt(rsq2);
-      bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
+      bo_ij += bondorder(&d_params(iparam_ijk),rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
     // attractive: pairwise potential and force
 
     F_FLOAT fa, dfa, bij, prefactor;
-    ters_fa_k_and_ters_dfa(itype,jtype,jtype,rij,fa,dfa);
-    ters_bij_k_and_ters_dbij(itype,jtype,jtype,bo_ij,bij,prefactor);
+    ters_fa_k_and_ters_dfa(&d_params(iparam_ij),rij,fa,dfa);
+    ters_bij_k_and_ters_dbij(&d_params(iparam_ij),bo_ij,bij,prefactor);
     const F_FLOAT fatt = -0.5*bij * dfa / rij;
     prefactor = 0.5*fa * prefactor;
 
@@ -407,19 +413,20 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      int k = d_neighbors_short(i,kk);
+      int k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      const int ktype = type(k);
+      const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
       const F_FLOAT dely2 = ytmp - x(k,1);
       const F_FLOAT delz2 = ztmp - x(k,2);
       const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      const F_FLOAT cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       const F_FLOAT rik = sqrt(rsq2);
-      ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
+      ters_dthb(&d_params(iparam_ijk),prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
       f_x += fi[0];
@@ -456,12 +463,12 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
     }
     if (!continue_flag) {
        F_FLOAT tmp_fce, tmp_fcd;
-       ters_fc_k_and_ters_dfc(itype,jtype,jtype,rij,tmp_fce,tmp_fcd);
+       ters_fc_k_and_ters_dfc(&d_params[iparam_ij],rij,tmp_fce,tmp_fcd);
 
-       const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * rij);
-       const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
-                          (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / rij;
-       const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
+       const F_FLOAT tmp_exp = exp(-d_params[iparam_ij].lam1 * rij);
+       const F_FLOAT frep = -d_params[iparam_ij].biga * tmp_exp *
+                          (tmp_fcd - tmp_fce*d_params[iparam_ij].lam1) / rij;
+       const F_FLOAT eng = tmp_fce * d_params[iparam_ij].biga * tmp_exp;
 
        f_x += delx1*frep;
        fj_x -= delx1*frep;
@@ -506,7 +513,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
   const X_FLOAT xtmp = x(i,0);
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
+  const int itype = d_map(type(i));
   const tagint itag = tag(i);
 
   int j,k,jj,kk,jtype,ktype;
@@ -515,7 +522,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
   X_FLOAT delx1, dely1, delz1, delx2, dely2, delz2;
 
   //const AtomNeighborsConst d_neighbors_i = k_list.get_neighbors_const(i);
-  const int jnum = d_numneigh_short[i];
+  const int jnum = d_numneigh_short[ii];
 
   F_FLOAT f_x = 0.0;
   F_FLOAT f_y = 0.0;
@@ -524,15 +531,16 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
   // attractive: bond order
 
   for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
+    j = d_neighbors_short(ii,jj);
     j &= NEIGHMASK;
-    jtype = type(j);
+    jtype = d_map(type(j));
 
     delx1 = xtmp - x(j,0);
     dely1 = ytmp - x(j,1);
     delz1 = ztmp - x(j,2);
     rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    cutsq1 = paramskk(itype,jtype,jtype).cutsq;
+    const int iparam_ij = d_elem3param(itype,jtype,jtype);
+    cutsq1 = d_params[iparam_ij].cutsq;
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
@@ -540,26 +548,27 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
 
     for (kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      k = d_neighbors_short(i,kk);
+      k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      ktype = type(k);
+      ktype = d_map(type(k));
 
       delx2 = xtmp - x(k,0);
       dely2 = ytmp - x(k,1);
       delz2 = ztmp - x(k,2);
       rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       rik = sqrt(rsq2);
-      bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
+      bo_ij += bondorder(&d_params(iparam_ijk),rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
     // attractive: pairwise potential and force
 
     F_FLOAT fa, dfa, bij, prefactor;
-    ters_fa_k_and_ters_dfa(itype,jtype,jtype,rij,fa,dfa);
-    ters_bij_k_and_ters_dbij(itype,jtype,jtype, bo_ij, bij, prefactor);
+    ters_fa_k_and_ters_dfa(&d_params(iparam_ij),rij,fa,dfa);
+    ters_bij_k_and_ters_dbij(&d_params(iparam_ij), bo_ij, bij, prefactor);
     const F_FLOAT fatt = -0.5*bij * dfa / rij;
     prefactor = 0.5*fa * prefactor;
     const F_FLOAT eng = 0.5*bij * fa;
@@ -578,19 +587,20 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
 
     for (kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      k = d_neighbors_short(i,kk);
+      k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      ktype = type(k);
+      ktype = d_map(type(k));
 
       delx2 = xtmp - x(k,0);
       dely2 = ytmp - x(k,1);
       delz2 = ztmp - x(k,2);
       rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       rik = sqrt(rsq2);
-      ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
+      ters_dthb(&d_params(iparam_ijk),prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
       f_x += fi[0];
@@ -621,12 +631,12 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
     }
     if (!continue_flag) {
       F_FLOAT tmp_fce, tmp_fcd;
-      ters_fc_k_and_ters_dfc(itype,jtype,jtype,rij,tmp_fce,tmp_fcd);
+      ters_fc_k_and_ters_dfc(&d_params(iparam_ij),rij,tmp_fce,tmp_fcd);
 
-      const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * rij);
-      const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
-                        (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / rij;
-      const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
+      const F_FLOAT tmp_exp = exp(-d_params(iparam_ij).lam1 * rij);
+      const F_FLOAT frep = -d_params(iparam_ij).biga * tmp_exp *
+                        (tmp_fcd - tmp_fce*d_params(iparam_ij).lam1) / rij;
+      const F_FLOAT eng = tmp_fce * d_params(iparam_ij).biga * tmp_exp;
 
       f_x += delx1*frep;
       f_y += dely1*frep;
@@ -662,14 +672,14 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
   const X_FLOAT xtmp = x(i,0);
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
+  const int itype = d_map(type(i));
 
   int j,k,jj,kk,jtype,ktype,j_jnum;
   F_FLOAT rsq1, cutsq1, rsq2, cutsq2, rij, rik, bo_ij;
   F_FLOAT fj[3], fk[3];
   X_FLOAT delx1, dely1, delz1, delx2, dely2, delz2;
 
-  const int jnum = d_numneigh_short[i];
+  const int jnum = d_numneigh_short[ii];
 
   F_FLOAT f_x = 0.0;
   F_FLOAT f_y = 0.0;
@@ -678,46 +688,49 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
   // attractive: bond order
 
   for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
+    j = d_neighbors_short(ii,jj);
     j &= NEIGHMASK;
     if (j >= nlocal) continue;
-    jtype = type(j);
+    jtype = d_map(type(j));
 
     delx1 = x(j,0) - xtmp;
     dely1 = x(j,1) - ytmp;
     delz1 = x(j,2) - ztmp;
     rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    cutsq1 = paramskk(jtype,itype,itype).cutsq;
+    const int iparam_ji = d_elem3param(jtype,itype,itype);
+    cutsq1 = d_params(iparam_ji).cutsq;
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
     rij = sqrt(rsq1);
 
-    j_jnum = d_numneigh_short[j];
+    j_jnum = d_numneigh_short[jj];
 
     for (kk = 0; kk < j_jnum; kk++) {
-      k = d_neighbors_short(j,kk);
+      k = d_neighbors_short(jj,kk);
       if (k == i) continue;
       k &= NEIGHMASK;
-      ktype = type(k);
+      ktype = d_map(type(k));
 
       delx2 = x(j,0) - x(k,0);
       dely2 = x(j,1) - x(k,1);
       delz2 = x(j,2) - x(k,2);
       rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(jtype,itype,ktype).cutsq;
+      const int iparam_jik = d_elem3param(jtype,itype,ktype);
+      cutsq2 = d_params(iparam_jik).cutsq;
 
       if (rsq2 > cutsq2) continue;
       rik = sqrt(rsq2);
-      bo_ij += bondorder(jtype,itype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
+      bo_ij += bondorder(&d_params(iparam_jik),rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
 
     }
 
     // attractive: pairwise potential and force
 
     F_FLOAT fa, dfa, bij, prefactor;
-    ters_fa_k_and_ters_dfa(itype,jtype,jtype,rij,fa,dfa);
-    ters_bij_k_and_ters_dbij(itype,jtype,jtype, bo_ij, bij, prefactor);
+    const int iparam_ij = d_elem3param(itype,jtype,jtype);
+    ters_fa_k_and_ters_dfa(&d_params(iparam_ij),rij,fa,dfa);
+    ters_bij_k_and_ters_dbij(&d_params(iparam_ij), bo_ij, bij, prefactor);
     const F_FLOAT fatt = -0.5*bij * dfa / rij;
     prefactor = 0.5*fa * prefactor;
     const F_FLOAT eng = 0.5*bij * fa;
@@ -736,20 +749,21 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
     // attractive: three-body force
 
     for (kk = 0; kk < j_jnum; kk++) {
-      k = d_neighbors_short(j,kk);
+      k = d_neighbors_short(jj,kk);
       if (k == i) continue;
       k &= NEIGHMASK;
-      ktype = type(k);
+      ktype = d_map(type(k));
 
       delx2 = x(j,0) - x(k,0);
       dely2 = x(j,1) - x(k,1);
       delz2 = x(j,2) - x(k,2);
       rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(jtype,itype,ktype).cutsq;
+      const int iparam_jik = d_elem3param(jtype,itype,ktype);
+      cutsq2 = d_params(iparam_jik).cutsq;
 
       if (rsq2 > cutsq2) continue;
       rik = sqrt(rsq2);
-      ters_dthbj(jtype,itype,ktype,prefactor,rij,delx1,dely1,delz1,
+      ters_dthbj(&d_params(iparam_jik),prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fj,fk);
       f_x += fj[0];
       f_y += fj[1];
@@ -762,9 +776,10 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
         if (vflag_either) v_tally3_atom(ev,i,j,k,fj,fk,delrji,delrjk);
       }
 
-      const F_FLOAT fa_jk = ters_fa_k(jtype,ktype,itype,rik);
-      const F_FLOAT prefactor_jk = 0.5*fa_jk * ters_dbij(jtype,ktype,itype,bo_ij);
-      ters_dthbk(jtype,ktype,itype,prefactor_jk,rik,delx2,dely2,delz2,
+      const int iparam_jki = d_elem3param(jtype,ktype,itype);
+      const F_FLOAT fa_jk = ters_fa_k(&d_params(iparam_jki),rik);
+      const F_FLOAT prefactor_jk = 0.5*fa_jk * ters_dbij(&d_params(iparam_jki),bo_ij);
+      ters_dthbk(&d_params(iparam_jki),prefactor_jk,rik,delx2,dely2,delz2,
                 rij,delx1,dely1,delz1,fk);
       f_x += fk[0];
       f_y += fk[1];
@@ -788,11 +803,10 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffKokkos<DeviceType>::ters_fc_k(Param *param, const F_FLOAT &r) const
 {
-  const F_FLOAT ters_R = paramskk(i,j,k).bigr;
-  const F_FLOAT ters_D = paramskk(i,j,k).bigd;
+  const F_FLOAT ters_R = param->bigr;
+  const F_FLOAT ters_D = param->bigd;
 
   if (r < ters_R-ters_D) return 1.0;
   if (r > ters_R+ters_D) return 0.0;
@@ -803,11 +817,10 @@ double PairTersoffKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffKokkos<DeviceType>::ters_dfc(Param *param, const F_FLOAT &r) const
 {
-  const F_FLOAT ters_R = paramskk(i,j,k).bigr;
-  const F_FLOAT ters_D = paramskk(i,j,k).bigd;
+  const F_FLOAT ters_R = param->bigr;
+  const F_FLOAT ters_D = param->bigd;
 
   if (r < ters_R-ters_D) return 0.0;
   if (r > ters_R+ters_D) return 0.0;
@@ -818,11 +831,10 @@ double PairTersoffKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffKokkos<DeviceType>::ters_fc_k_and_ters_dfc(const int &i, const int &j,
-                const int &k, const F_FLOAT &r, double& fc, double& dfc) const
+void PairTersoffKokkos<DeviceType>::ters_fc_k_and_ters_dfc(Param *param, const F_FLOAT &r, double& fc, double& dfc) const
 {
-  const F_FLOAT ters_R = paramskk(i,j,k).bigr;
-  const F_FLOAT ters_D = paramskk(i,j,k).bigd;
+  const F_FLOAT ters_R = param->bigr;
+  const F_FLOAT ters_D = param->bigd;
 
   if (r < ters_R-ters_D) {
      fc = 1.0;
@@ -848,7 +860,7 @@ void PairTersoffKokkos<DeviceType>::ters_fc_k_and_ters_dfc(const int &i, const i
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffKokkos<DeviceType>::bondorder(const int &i, const int &j, const int &k,
+double PairTersoffKokkos<DeviceType>::bondorder(Param *param,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const
 {
@@ -856,15 +868,15 @@ double PairTersoffKokkos<DeviceType>::bondorder(const int &i, const int &j, cons
 
   const F_FLOAT costheta = (dx1*dx2 + dy1*dy2 + dz1*dz2)/(rij*rik);
 
-  const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) arg = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else arg = param;
+  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  if (int(param->powerm) == 3) arg = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
+  else arg = paramtmp;
 
   if (arg > 69.0776) ex_delr = 1.e30;
   else if (arg < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(arg);
 
-  return ters_fc_k(i,j,k,rik) * ters_gijk(i,j,k,costheta) * ex_delr;
+  return ters_fc_k(param,rik) * ters_gijk(param,costheta) * ex_delr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -872,13 +884,13 @@ double PairTersoffKokkos<DeviceType>::bondorder(const int &i, const int &j, cons
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 double PairTersoffKokkos<DeviceType>::
-        ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const
+        ters_gijk(Param *param, const F_FLOAT &cos) const
 {
-  const F_FLOAT ters_c = paramskk(i,j,k).c * paramskk(i,j,k).c;
-  const F_FLOAT ters_d = paramskk(i,j,k).d * paramskk(i,j,k).d;
-  const F_FLOAT hcth = paramskk(i,j,k).h - cos;
+  const F_FLOAT ters_c = param->c * param->c;
+  const F_FLOAT ters_d = param->d * param->d;
+  const F_FLOAT hcth = param->h - cos;
 
-  return paramskk(i,j,k).gamma*(1.0 + ters_c/ters_d - ters_c/(ters_d+hcth*hcth));
+  return param->gamma*(1.0 + ters_c/ters_d - ters_c/(ters_d+hcth*hcth));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -886,14 +898,14 @@ double PairTersoffKokkos<DeviceType>::
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 double PairTersoffKokkos<DeviceType>::
-        ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const
+        ters_dgijk(Param *param, const F_FLOAT &cos) const
 {
-  const F_FLOAT ters_c = paramskk(i,j,k).c * paramskk(i,j,k).c;
-  const F_FLOAT ters_d = paramskk(i,j,k).d * paramskk(i,j,k).d;
-  const F_FLOAT hcth = paramskk(i,j,k).h - cos;
+  const F_FLOAT ters_c = param->c * param->c;
+  const F_FLOAT ters_d = param->d * param->d;
+  const F_FLOAT hcth = param->h - cos;
   const F_FLOAT numerator = -2.0 * ters_c * hcth;
   const F_FLOAT denominator = 1.0/(ters_d + hcth*hcth);
-  return paramskk(i,j,k).gamma * numerator * denominator * denominator;
+  return param->gamma * numerator * denominator * denominator;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -901,59 +913,56 @@ double PairTersoffKokkos<DeviceType>::
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffKokkos<DeviceType>::
-        ters_gijk_and_ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos, double &gijk, double &dgijk) const
+        ters_gijk_and_ters_dgijk(Param *param, const F_FLOAT &cos, double &gijk, double &dgijk) const
 {
-  const F_FLOAT ters_c = paramskk(i,j,k).c * paramskk(i,j,k).c;
-  const F_FLOAT ters_d = paramskk(i,j,k).d * paramskk(i,j,k).d;
-  const F_FLOAT hcth = paramskk(i,j,k).h - cos;
+  const F_FLOAT ters_c = param->c * param->c;
+  const F_FLOAT ters_d = param->d * param->d;
+  const F_FLOAT hcth = param->h - cos;
 
   const F_FLOAT numerator = -2.0 * ters_c * hcth;
   const F_FLOAT denominator = 1.0/(ters_d + hcth*hcth);
 
-  gijk = paramskk(i,j,k).gamma*(1.0 + ters_c/ters_d - ters_c*denominator);
-  dgijk = paramskk(i,j,k).gamma * numerator * denominator * denominator;
+  gijk = param->gamma*(1.0 + ters_c/ters_d - ters_c*denominator);
+  dgijk = param->gamma * numerator * denominator * denominator;
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffKokkos<DeviceType>::ters_fa_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffKokkos<DeviceType>::ters_fa_k(Param *param, const F_FLOAT &r) const
 {
-  if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return -paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r)
-          * ters_fc_k(i,j,k,r);
+  if (r > param->bigr + param->bigd) return 0.0;
+  return -param->bigb * exp(-param->lam2 * r)
+          * ters_fc_k(param,r);
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffKokkos<DeviceType>::ters_dfa(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffKokkos<DeviceType>::ters_dfa(Param *param, const F_FLOAT &r) const
 {
-  if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r) *
-    (paramskk(i,j,k).lam2 * ters_fc_k(i,j,k,r) - ters_dfc(i,j,k,r));
+  if (r > param->bigr + param->bigd) return 0.0;
+  return param->bigb * exp(-param->lam2 * r) *
+    (param->lam2 * ters_fc_k(param,r) - ters_dfc(param,r));
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffKokkos<DeviceType>::ters_fa_k_and_ters_dfa(const int &i, const int &j,
-                const int &k, const F_FLOAT &r, double &fa, double &dfa) const
+void PairTersoffKokkos<DeviceType>::ters_fa_k_and_ters_dfa(Param *param, const F_FLOAT &r, double &fa, double &dfa) const
 {
-  if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) {
+  if (r > param->bigr + param->bigd) {
      fa = 0.0;
      dfa = 0.0;
   } else {
-    double tmp1 = paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r);
+    double tmp1 = param->bigb * exp(-param->lam2 * r);
     F_FLOAT fc_k, dfc;
-    ters_fc_k_and_ters_dfc(i,j,k,r,fc_k,dfc);
+    ters_fc_k_and_ters_dfc(param,r,fc_k,dfc);
     fa = -tmp1 * fc_k;
-    dfa = tmp1 * (paramskk(i,j,k).lam2 * fc_k - dfc);
+    dfa = tmp1 * (param->lam2 * fc_k - dfc);
   }
 }
 
@@ -961,82 +970,79 @@ void PairTersoffKokkos<DeviceType>::ters_fa_k_and_ters_dfa(const int &i, const i
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffKokkos<DeviceType>::ters_bij_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &bo) const
+double PairTersoffKokkos<DeviceType>::ters_bij_k(Param *param, const F_FLOAT &bo) const
 {
-  const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).c1) return 1.0/sqrt(tmp);
-  if (tmp > paramskk(i,j,k).c2)
-    return (1.0 - pow(tmp,-paramskk(i,j,k).powern) / (2.0*paramskk(i,j,k).powern))/sqrt(tmp);
-  if (tmp < paramskk(i,j,k).c4) return 1.0;
-  if (tmp < paramskk(i,j,k).c3)
-    return 1.0 - pow(tmp,paramskk(i,j,k).powern)/(2.0*paramskk(i,j,k).powern);
-  return pow(1.0 + pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern));
+  const F_FLOAT tmp = param->beta * bo;
+  if (tmp > param->c1) return 1.0/sqrt(tmp);
+  if (tmp > param->c2)
+    return (1.0 - pow(tmp,-param->powern) / (2.0*param->powern))/sqrt(tmp);
+  if (tmp < param->c4) return 1.0;
+  if (tmp < param->c3)
+    return 1.0 - pow(tmp,param->powern)/(2.0*param->powern);
+  return pow(1.0 + pow(tmp,param->powern), -1.0/(2.0*param->powern));
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
-                const int &k, const F_FLOAT &bo) const
+double PairTersoffKokkos<DeviceType>::ters_dbij(Param *param, const F_FLOAT &bo) const
 {
-  const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
+  const F_FLOAT tmp = param->beta * bo;
   const F_FLOAT factor = -0.5/sqrt(tmp*tmp*tmp); //pow(tmp,-1.5)
-  if (tmp > paramskk(i,j,k).c1) return paramskk(i,j,k).beta * factor;
-  if (tmp > paramskk(i,j,k).c2)
-    return paramskk(i,j,k).beta * (factor *
+  if (tmp > param->c1) return param->beta * factor;
+  if (tmp > param->c2)
+    return param->beta * (factor *
            // error in negligible 2nd term fixed 2/21/2022
-           // (1.0 - 0.5*(1.0 +  1.0/(2.0*paramskk(i,j,k).powern)) *
-           (1.0 - (1.0 +  1.0/(2.0*paramskk(i,j,k).powern)) *
-           pow(tmp,-paramskk(i,j,k).powern)));
-  if (tmp < paramskk(i,j,k).c4) return 0.0;
-  if (tmp < paramskk(i,j,k).c3)
-    return -0.5*paramskk(i,j,k).beta * pow(tmp,paramskk(i,j,k).powern-1.0);
+           // (1.0 - 0.5*(1.0 +  1.0/(2.0*param->powern)) *
+           (1.0 - (1.0 +  1.0/(2.0*param->powern)) *
+           pow(tmp,-param->powern)));
+  if (tmp < param->c4) return 0.0;
+  if (tmp < param->c3)
+    return -0.5*param->beta * pow(tmp,param->powern-1.0);
 
-  const F_FLOAT tmp_n = pow(tmp,paramskk(i,j,k).powern);
-  return -0.5 * pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern)))*tmp_n / bo;
+  const F_FLOAT tmp_n = pow(tmp,param->powern);
+  return -0.5 * pow(1.0+tmp_n, -1.0-(1.0/(2.0*param->powern)))*tmp_n / bo;
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffKokkos<DeviceType>::ters_bij_k_and_ters_dbij(const int &i, const int &j,
-                const int &k, const F_FLOAT &bo, double& bij, double& prefactor) const
+void PairTersoffKokkos<DeviceType>::ters_bij_k_and_ters_dbij(Param *param, const F_FLOAT &bo, double& bij, double& prefactor) const
 {
-  const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
+  const F_FLOAT tmp = param->beta * bo;
   const F_FLOAT factor = -0.5/sqrt(tmp*tmp*tmp); //pow(tmp,-1.5)
-  if (tmp > paramskk(i,j,k).c1) {
+  if (tmp > param->c1) {
       bij =  1.0/sqrt(tmp);
-      prefactor = paramskk(i,j,k).beta * factor;
+      prefactor = param->beta * factor;
       return;
   }
 
-  auto prm_ijk_pn = paramskk(i,j,k).powern;
+  auto prm_ijk_pn = param->powern;
 
-  if (tmp > paramskk(i,j,k).c2) {
+  if (tmp > param->c2) {
     auto tmp_pow_neg_prm_ijk_pn =  pow(tmp,-prm_ijk_pn);
     bij =  (1.0 - tmp_pow_neg_prm_ijk_pn / (2.0*prm_ijk_pn))/sqrt(tmp);
-    prefactor =  paramskk(i,j,k).beta * (factor *
+    prefactor =  param->beta * (factor *
            (1.0 - 0.5*(1.0 +  1.0/(2.0*prm_ijk_pn)) *
            tmp_pow_neg_prm_ijk_pn));
     return;
   }
 
-  if (tmp < paramskk(i,j,k).c4) {
+  if (tmp < param->c4) {
     bij = 1.0;
     prefactor = 0.0;
     return;
   }
-  if (tmp < paramskk(i,j,k).c3) {
+  if (tmp < param->c3) {
     auto tmp_pow_prm_ijk_pn_less_one =  pow(tmp,prm_ijk_pn-1.0);
     bij =  1.0 - tmp_pow_prm_ijk_pn_less_one*tmp/(2.0*prm_ijk_pn);
-    prefactor = -0.5*paramskk(i,j,k).beta * tmp_pow_prm_ijk_pn_less_one;
+    prefactor = -0.5*param->beta * tmp_pow_prm_ijk_pn_less_one;
     return;
   }
 
-  const F_FLOAT tmp_n = pow(tmp,paramskk(i,j,k).powern);
+  const F_FLOAT tmp_n = pow(tmp,param->powern);
   bij = pow(1.0 + tmp_n, -1.0/(2.0*prm_ijk_pn));
   prefactor =  -0.5 * pow(1.0+tmp_n, -1.0-(1.0/(2.0*prm_ijk_pn)))*tmp_n / bo;
 }
@@ -1046,7 +1052,7 @@ void PairTersoffKokkos<DeviceType>::ters_bij_k_and_ters_dbij(const int &i, const
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffKokkos<DeviceType>::ters_dthb(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        Param *param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const
@@ -1071,23 +1077,22 @@ void PairTersoffKokkos<DeviceType>::ters_dthb(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  ters_fc_k_and_ters_dfc(i,j,k,rik,fc,dfc);
+  ters_fc_k_and_ters_dfc(param,rik,fc,dfc);
 
-  const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = param;
+  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  if (int(param->powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param->powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param->lam3*ex_delr;//pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param->lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
 
-  ters_gijk_and_ters_dgijk(i,j,k,cos,gijk,dgijk);
+  ters_gijk_and_ters_dgijk(param,cos,gijk,dgijk);
 
   // from PairTersoff::costheta_d
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
@@ -1119,7 +1124,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthb(
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffKokkos<DeviceType>::ters_dthbj(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        Param *param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fj, F_FLOAT *fk) const
@@ -1140,23 +1145,22 @@ void PairTersoffKokkos<DeviceType>::ters_dthbj(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = param;//paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  if (int(param->powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param->powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param->lam3*ex_delr;//pow(param->lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param->lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
   vec3_scale(rijinv,dcosfj,dcosfj);
@@ -1181,7 +1185,7 @@ void PairTersoffKokkos<DeviceType>::ters_dthbj(
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffKokkos<DeviceType>::ters_dthbk(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        Param *param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fk) const
@@ -1202,23 +1206,22 @@ void PairTersoffKokkos<DeviceType>::ters_dthbk(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = param;//paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+  F_FLOAT paramtmp = param->lam3 * (rij-rik);
+  if (int(param->powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param->lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param->powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param->lam3*ex_delr;//pow(param->lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param->lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
   vec3_scale(rijinv,dcosfj,dcosfj);
@@ -1309,7 +1312,8 @@ void PairTersoffKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, const i
 template<class DeviceType>
 template<int NEIGHFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffKokkos<DeviceType>::v_tally3(EV_FLOAT &ev, const int &i, const int &j, const int &k,
+void PairTersoffKokkos<DeviceType>::v_tally3(EV_FLOAT &ev,
+        const int &i, const int &j, const int &k,
         F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const
 {
   // The vatom array is duplicated for OpenMP, atomic for CUDA, and neither for Serial

--- a/src/KOKKOS/pair_tersoff_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_kokkos.h
@@ -30,20 +30,14 @@ PairStyle(tersoff/kk/host,PairTersoffKokkos<LMPHostType>);
 namespace LAMMPS_NS {
 
 template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffComputeHalf{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffComputeFullA{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffComputeFullB{};
+struct TagPairTersoffCompute{};
 
 struct TagPairTersoffComputeShortNeigh{};
 
 template<class DeviceType>
 class PairTersoffKokkos : public PairTersoff {
  public:
-  enum {EnabledNeighFlags=FULL};
+  enum {EnabledNeighFlags=HALF|HALFTHREAD};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -57,27 +51,11 @@ class PairTersoffKokkos : public PairTersoff {
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffComputeHalf<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
+  void operator()(TagPairTersoffCompute<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffComputeHalf<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffComputeFullA<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffComputeFullA<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffComputeFullB<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffComputeFullB<NEIGHFLAG,EVFLAG>, const int&) const;
+  void operator()(TagPairTersoffCompute<NEIGHFLAG,EVFLAG>, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPairTersoffComputeShortNeigh, const int&) const;

--- a/src/KOKKOS/pair_tersoff_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_kokkos.h
@@ -61,60 +61,60 @@ class PairTersoffKokkos : public PairTersoff {
   void operator()(TagPairTersoffComputeShortNeigh, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_fc_k(Param *param, const F_FLOAT &r) const;
+  double ters_fc_k(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfc(Param *param, const F_FLOAT &r) const;
+  double ters_dfc(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_fc_k_and_ters_dfc(Param *param, const F_FLOAT &r, double &fc, double &dfc) const;
+  void ters_fc_k_and_ters_dfc(const Param& param, const F_FLOAT &r, double &fc, double &dfc) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_fa_k(Param *param, const F_FLOAT &r) const;
+  double ters_fa_k(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfa(Param *param, const F_FLOAT &r) const;
+  double ters_dfa(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_fa_k_and_ters_dfa(Param *param, const F_FLOAT &r, double &fa, double &dfa) const;
+  void ters_fa_k_and_ters_dfa(const Param& param, const F_FLOAT &r, double &fa, double &dfa) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_bij_k(Param *param, const F_FLOAT &bo) const;
+  double ters_bij_k(const Param& param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dbij(Param *param, const F_FLOAT &bo) const;
+  double ters_dbij(const Param& param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_bij_k_and_ters_dbij(Param *param, const F_FLOAT &bo, double &bij, double &prefactor) const;
+  void ters_bij_k_and_ters_dbij(const Param& param, const F_FLOAT &bo, double &bij, double &prefactor) const;
 
   KOKKOS_INLINE_FUNCTION
-  double bondorder(Param *param,
+  double bondorder(const Param& param,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_gijk(Param *param, const F_FLOAT &cos) const;
+  double ters_gijk(const Param& param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dgijk(Param *param, const F_FLOAT &cos) const;
+  double ters_dgijk(const Param& param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_gijk_and_ters_dgijk(Param *param, const F_FLOAT &cos, double& gijk, double& dgijk) const;
+  void ters_gijk_and_ters_dgijk(const Param& param, const F_FLOAT &cos, double& gijk, double& dgijk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthb(Param *param, const F_FLOAT &prefactor,
+  void ters_dthb(const Param& param, const F_FLOAT &prefactor,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
               F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbj(Param *param, const F_FLOAT &prefactor,
+  void ters_dthbj(const Param& param, const F_FLOAT &prefactor,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
               F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbk(Param *param, const F_FLOAT &prefactor,
+  void ters_dthbk(const Param& param, const F_FLOAT &prefactor,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
               F_FLOAT *fk) const;

--- a/src/KOKKOS/pair_tersoff_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_kokkos.h
@@ -52,6 +52,7 @@ class PairTersoffKokkos : public PairTersoff {
   PairTersoffKokkos(class LAMMPS *);
   ~PairTersoffKokkos() override;
   void compute(int, int) override;
+  void coeff(int, char **) override;
   void init_style() override;
 
   template<int NEIGHFLAG, int EVFLAG>
@@ -82,60 +83,60 @@ class PairTersoffKokkos : public PairTersoff {
   void operator()(TagPairTersoffComputeShortNeigh, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_fc_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_fc_k(Param *param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfc(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_dfc(Param *param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_fc_k_and_ters_dfc(const int &i, const int &j, const int &k, const F_FLOAT &r, double &fc, double &dfc) const;
+  void ters_fc_k_and_ters_dfc(Param *param, const F_FLOAT &r, double &fc, double &dfc) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_fa_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_fa_k(Param *param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfa(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_dfa(Param *param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_fa_k_and_ters_dfa(const int &i, const int &j, const int &k, const F_FLOAT &r, double &fa, double &dfa) const;
+  void ters_fa_k_and_ters_dfa(Param *param, const F_FLOAT &r, double &fa, double &dfa) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_bij_k(const int &i, const int &j, const int &k, const F_FLOAT &bo) const;
+  double ters_bij_k(Param *param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dbij(const int &i, const int &j, const int &k, const F_FLOAT &bo) const;
+  double ters_dbij(Param *param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_bij_k_and_ters_dbij(const int &i, const int &j, const int &k, const F_FLOAT &bo, double &bij, double &prefactor) const;
+  void ters_bij_k_and_ters_dbij(Param *param, const F_FLOAT &bo, double &bij, double &prefactor) const;
 
   KOKKOS_INLINE_FUNCTION
-  double bondorder(const int &i, const int &j, const int &k,
+  double bondorder(Param *param,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
+  double ters_gijk(Param *param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
+  double ters_dgijk(Param *param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_gijk_and_ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos, double& gijk, double& dgijk) const;
+  void ters_gijk_and_ters_dgijk(Param *param, const F_FLOAT &cos, double& gijk, double& dgijk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthb(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+  void ters_dthb(Param *param, const F_FLOAT &prefactor,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
               F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbj(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+  void ters_dthbj(Param *param, const F_FLOAT &prefactor,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
               F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbk(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+  void ters_dthbk(Param *param, const F_FLOAT &prefactor,
               const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
               const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
               F_FLOAT *fk) const;
@@ -163,17 +164,6 @@ class PairTersoffKokkos : public PairTersoff {
   KOKKOS_INLINE_FUNCTION
   int sbmask(const int& j) const;
 
-  struct params_ters{
-    KOKKOS_INLINE_FUNCTION
-    params_ters() {powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
-                  bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;};
-    KOKKOS_INLINE_FUNCTION
-    params_ters(int /*i*/) {powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
-                  bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;};
-    F_FLOAT powerm, gamma, lam3, c, d, h, powern, beta, lam2, bigb, bigr,
-            bigd, lam1, biga, cutsq, c1, c2, c3, c4;
-  };
-
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void ev_tally(EV_FLOAT &ev, const int &i, const int &j,
@@ -189,16 +179,21 @@ class PairTersoffKokkos : public PairTersoff {
   void v_tally3_atom(EV_FLOAT &ev, const int &i, const int &j, const int &k,
                 F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
 
-  void allocate() override;
   void setup_params() override;
 
  protected:
   typedef Kokkos::DualView<int***,DeviceType> tdual_int_3d;
-  Kokkos::DualView<params_ters***,Kokkos::LayoutRight,DeviceType> k_params;
-  typename Kokkos::DualView<params_ters***,
-    Kokkos::LayoutRight,DeviceType>::t_dev_const_um paramskk;
-  // hardwired to space for 12 atom types
-  //params_ters m_params[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];
+  typedef typename tdual_int_3d::t_dev_const_randomread t_int_3d_randomread;
+  typedef typename tdual_int_3d::t_host t_host_int_3d;
+
+  t_int_3d_randomread d_elem3param;
+  typename AT::t_int_1d_randomread d_map;
+
+  typedef Kokkos::DualView<Param*,DeviceType> tdual_param_1d;
+  typedef typename tdual_param_1d::t_dev t_param_1d;
+  typedef typename tdual_param_1d::t_host t_host_param_1d;
+
+  t_param_1d d_params;
 
   int inum;
   typename AT::t_x_array_randomread x;

--- a/src/KOKKOS/pair_tersoff_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_kokkos.h
@@ -227,11 +227,7 @@ class PairTersoffKokkos : public PairTersoff {
 
 /* ERROR/WARNING messages:
 
-E: Cannot (yet) use full neighbor list style with tersoff/kk
-
-Self-explanatory.
-
-E: Cannot use chosen neighbor list style with tersoff/kk
+E: Must use half neighbor list style with pair tersoff/kk
 
 Self-explanatory.
 

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
@@ -65,18 +65,29 @@ PairTersoffMODKokkos<DeviceType>::~PairTersoffMODKokkos()
   }
 }
 
-/* ---------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------
+   set coeffs for one or more type pairs
+------------------------------------------------------------------------- */
 
 template<class DeviceType>
-void PairTersoffMODKokkos<DeviceType>::allocate()
+void PairTersoffMODKokkos<DeviceType>::coeff(int narg, char **arg)
 {
-  PairTersoffMOD::allocate();
+  PairTersoffMOD::coeff(narg,arg);
+
+  // sync map
 
   int n = atom->ntypes;
 
-  k_params = Kokkos::DualView<params_ters***,Kokkos::LayoutRight,DeviceType>
-          ("PairTersoffMOD::paramskk",n+1,n+1,n+1);
-  paramskk = k_params.template view<DeviceType>();
+  DAT::tdual_int_1d k_map = DAT::tdual_int_1d("pair:map",n+1);
+  HAT::t_int_1d h_map = k_map.h_view;
+
+  for (int i = 1; i <= n; i++)
+    h_map[i] = map[i];
+
+  k_map.template modify<LMPHostType>();
+  k_map.template sync<DeviceType>();
+
+  d_map = k_map.template view<DeviceType>();
 }
 
 /* ----------------------------------------------------------------------
@@ -95,8 +106,11 @@ void PairTersoffMODKokkos<DeviceType>::init_style()
   request->set_kokkos_host(std::is_same<DeviceType,LMPHostType>::value &&
                            !std::is_same<DeviceType,LMPDeviceType>::value);
   request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
+  // always request a full neighbor list
+  request->enable_full();
+
   if (neighflag == FULL)
-    error->all(FLERR,"Cannot (yet) use full neighbor list style with tersoff/mod/kk");
+    error->all(FLERR,"Must use half neighbor list style with pair tersoff/kk");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -106,37 +120,29 @@ void PairTersoffMODKokkos<DeviceType>::setup_params()
 {
   PairTersoffMOD::setup_params();
 
-  int i,j,k,m;
-  int n = atom->ntypes;
+  // sync elem3param and params
 
-  for (i = 1; i <= n; i++)
-    for (j = 1; j <= n; j++)
-      for (k = 1; k <= n; k++) {
-        m = elem3param[map[i]][map[j]][map[k]];
-        k_params.h_view(i,j,k).powerm = params[m].powerm;
-        k_params.h_view(i,j,k).lam3 = params[m].lam3;
-        k_params.h_view(i,j,k).h = params[m].h;
-        k_params.h_view(i,j,k).powern = params[m].powern;
-        k_params.h_view(i,j,k).beta = params[m].beta;
-        k_params.h_view(i,j,k).lam2 = params[m].lam2;
-        k_params.h_view(i,j,k).bigb = params[m].bigb;
-        k_params.h_view(i,j,k).bigr = params[m].bigr;
-        k_params.h_view(i,j,k).bigd = params[m].bigd;
-        k_params.h_view(i,j,k).lam1 = params[m].lam1;
-        k_params.h_view(i,j,k).biga = params[m].biga;
-        k_params.h_view(i,j,k).cutsq = params[m].cutsq;
-        k_params.h_view(i,j,k).c1 = params[m].c1;
-        k_params.h_view(i,j,k).c2 = params[m].c2;
-        k_params.h_view(i,j,k).c3 = params[m].c3;
-        k_params.h_view(i,j,k).c4 = params[m].c4;
-        k_params.h_view(i,j,k).c5 = params[m].c5;
-        k_params.h_view(i,j,k).ca1 = params[m].ca1;
-        k_params.h_view(i,j,k).ca4 = params[m].ca4;
-        k_params.h_view(i,j,k).powern_del = params[m].powern_del;
-      }
+  tdual_int_3d k_elem3param = tdual_int_3d("pair:elem3param",nelements,nelements,nelements);
+  t_host_int_3d h_elem3param = k_elem3param.h_view;
 
-  k_params.template modify<LMPHostType>();
+  tdual_param_1d k_params = tdual_param_1d("pair:params",nparams);
+  t_host_param_1d h_params = k_params.h_view;
 
+  for (int i = 0; i < nelements; i++)
+    for (int j = 0; j < nelements; j++)
+      for (int k = 0; k < nelements; k++)
+        h_elem3param(i,j,k) = elem3param[i][j][k];
+
+  for (int m = 0; m < nparams; m++)
+    h_params[m] = params[m];
+
+  k_elem3param.modify_host();
+  k_elem3param.template sync<DeviceType>();
+  k_params.modify_host();
+  k_params.template sync<DeviceType>();
+
+  d_elem3param = k_elem3param.template view<DeviceType>();
+  d_params = k_params.template view<DeviceType>();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -146,8 +152,6 @@ void PairTersoffMODKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 {
   eflag = eflag_in;
   vflag = vflag_in;
-
-  if (neighflag == FULL) no_virial_fdotr_compute = 1;
 
   ev_init(eflag,vflag,0);
 
@@ -165,7 +169,6 @@ void PairTersoffMODKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
 
   atomKK->sync(execution_space,datamask_read);
-  k_params.template sync<DeviceType>();
   if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
   else atomKK->modified(execution_space,F_MASK);
 
@@ -204,37 +207,25 @@ void PairTersoffMODKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   int max_neighs = d_neighbors.extent(1);
 
-  if (((int)d_neighbors_short.extent(1) != max_neighs) ||
-     ((int)d_neighbors_short.extent(0) != ignum)) {
-    d_neighbors_short = Kokkos::View<int**,DeviceType>("Tersoff::neighbors_short",ignum,max_neighs);
+  if (((int)d_neighbors_short.extent(1) < max_neighs) ||
+     ((int)d_neighbors_short.extent(0) < ignum)) {
+    d_neighbors_short = Kokkos::View<int**,DeviceType>("Tersoff::neighbors_short",ignum*1.2,max_neighs);
   }
-  if ((int)d_numneigh_short.extent(0)!=ignum)
-    d_numneigh_short = Kokkos::View<int*,DeviceType>("Tersoff::numneighs_short",ignum);
-  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairTersoffMODComputeShortNeigh>(0,neighflag==FULL?ignum:inum), *this);
+  if ((int)d_numneigh_short.extent(0) < ignum)
+    d_numneigh_short = Kokkos::View<int*,DeviceType>("Tersoff::numneighs_short",ignum*1.2);
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairTersoffMODComputeShortNeigh>(0,inum), *this);
 
   if (neighflag == HALF) {
     if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeHalf<HALF,1> >(0,inum),*this,ev);
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODCompute<HALF,1> >(0,inum),*this,ev);
     else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeHalf<HALF,0> >(0,inum),*this);
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODCompute<HALF,0> >(0,inum),*this);
     ev_all += ev;
   } else if (neighflag == HALFTHREAD) {
     if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeHalf<HALFTHREAD,1> >(0,inum),*this,ev);
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODCompute<HALFTHREAD,1> >(0,inum),*this,ev);
     else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeHalf<HALFTHREAD,0> >(0,inum),*this);
-    ev_all += ev;
-  } else if (neighflag == FULL) {
-    if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeFullA<FULL,1> >(0,inum),*this,ev);
-    else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeFullA<FULL,0> >(0,inum),*this);
-    ev_all += ev;
-
-    if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeFullB<FULL,1> >(0,ignum),*this,ev);
-    else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODComputeFullB<FULL,0> >(0,ignum),*this);
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffMODCompute<HALFTHREAD,0> >(0,inum),*this);
     ev_all += ev;
   }
 
@@ -286,6 +277,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeShortN
     const X_FLOAT xtmp = x(i,0);
     const X_FLOAT ytmp = x(i,1);
     const X_FLOAT ztmp = x(i,2);
+    const F_FLOAT cutmax_sq = cutmax*cutmax;
 
     const int jnum = d_numneigh[i];
     int inside = 0;
@@ -298,12 +290,12 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeShortN
       const X_FLOAT delz = ztmp - x(j,2);
       const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
-      if (rsq < cutmax*cutmax) {
-        d_neighbors_short(i,inside) = j;
+      if (rsq < cutmax_sq) {
+        d_neighbors_short(ii,inside) = j;
         inside++;
       }
     }
-    d_numneigh_short(i) = inside;
+    d_numneigh_short(ii) = inside;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -311,25 +303,25 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeShortN
 template<class DeviceType>
 template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
+void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODCompute<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
 
   // The f array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
-  auto v_f = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
-  auto a_f = v_f.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
+  const auto v_f = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
+  const auto a_f = v_f.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
 
   const int i = d_ilist[ii];
   if (i >= nlocal) return;
   const X_FLOAT xtmp = x(i,0);
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
+  const int itype = d_map(type(i));
   const tagint itag = tag(i);
 
   F_FLOAT fi[3], fj[3], fk[3];
 
   //const AtomNeighborsConst d_neighbors_i = k_list.get_neighbors_const(i);
-  const int jnum = d_numneigh_short[i];
+  const int jnum = d_numneigh_short[ii];
 
   // repulsive
 
@@ -338,9 +330,9 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
   F_FLOAT f_z = 0.0;
 
   for (int jj = 0; jj < jnum; jj++) {
-    int j = d_neighbors_short(i,jj);
+    int j = d_neighbors_short(ii,jj);
     j &= NEIGHMASK;
-    const int jtype = type(j);
+    const int jtype = d_map(type(j));
     const tagint jtag = tag(j);
 
     if (itag > jtag) {
@@ -357,17 +349,18 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
     const X_FLOAT dely = ytmp - x(j,1);
     const X_FLOAT delz = ztmp - x(j,2);
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-    const F_FLOAT cutsq = paramskk(itype,jtype,jtype).cutsq;
+    const int iparam_ij = d_elem3param(itype,jtype,jtype);
+    const F_FLOAT cutsq = d_params(iparam_ij).cutsq;
 
     if (rsq > cutsq) continue;
 
     const F_FLOAT r = sqrt(rsq);
-    const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
-    const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
-    const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
-                          (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / r;
-    const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
+    const F_FLOAT tmp_fce = ters_fc_k(d_params(iparam_ij),r);
+    const F_FLOAT tmp_fcd = ters_dfc(d_params(iparam_ij),r);
+    const F_FLOAT tmp_exp = exp(-d_params(iparam_ij).lam1 * r);
+    const F_FLOAT frep = -d_params(iparam_ij).biga * tmp_exp *
+                          (tmp_fcd - tmp_fce*d_params(iparam_ij).lam1) / r;
+    const F_FLOAT eng = tmp_fce * d_params(iparam_ij).biga * tmp_exp;
 
     f_x += delx*frep;
     f_y += dely*frep;
@@ -385,15 +378,16 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
   // attractive: bond order
 
   for (int jj = 0; jj < jnum; jj++) {
-    int j = d_neighbors_short(i,jj);
+    int j = d_neighbors_short(ii,jj);
     j &= NEIGHMASK;
-    const int jtype = type(j);
+    const int jtype = d_map(type(j));
 
     const F_FLOAT delx1 = xtmp - x(j,0);
     const F_FLOAT dely1 = ytmp - x(j,1);
     const F_FLOAT delz1 = ztmp - x(j,2);
     const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    const F_FLOAT cutsq1 = paramskk(itype,jtype,jtype).cutsq;
+    const int iparam_ij = d_elem3param(itype,jtype,jtype);
+    const F_FLOAT cutsq1 = d_params(iparam_ij).cutsq;
 
     F_FLOAT bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
@@ -401,28 +395,29 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      int k = d_neighbors_short(i,kk);
+      int k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      const int ktype = type(k);
+      const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
       const F_FLOAT dely2 = ytmp - x(k,1);
       const F_FLOAT delz2 = ztmp - x(k,2);
       const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      const F_FLOAT cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       const F_FLOAT rik = sqrt(rsq2);
-      bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
+      bo_ij += bondorder(d_params(iparam_ijk),rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
     // attractive: pairwise potential and force
 
-    const F_FLOAT fa = ters_fa_k(itype,jtype,jtype,rij);
-    const F_FLOAT dfa = ters_dfa(itype,jtype,jtype,rij);
-    const F_FLOAT bij = ters_bij_k(itype,jtype,jtype,bo_ij);
+    const F_FLOAT fa = ters_fa_k(d_params(iparam_ij),rij);
+    const F_FLOAT dfa = ters_dfa(d_params(iparam_ij),rij);
+    const F_FLOAT bij = ters_bij_k(d_params(iparam_ij),bo_ij);
     const F_FLOAT fatt = -0.5*bij * dfa / rij;
-    const F_FLOAT prefactor = 0.5*fa * ters_dbij(itype,jtype,jtype,bo_ij);
+    const F_FLOAT prefactor = 0.5*fa * ters_dbij(d_params(iparam_ij),bo_ij);
 
     f_x += delx1*fatt;
     f_y += dely1*fatt;
@@ -435,26 +430,27 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
       const F_FLOAT eng = 0.5*bij * fa;
       if (eflag) ev.evdwl += eng;
       if (vflag_either || eflag_atom)
-          this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,fatt,delx1,dely1,delz1);
+        this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,fatt,delx1,dely1,delz1);
     }
 
     // attractive: three-body force
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      int k = d_neighbors_short(i,kk);
+      int k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      const int ktype = type(k);
+      const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
       const F_FLOAT dely2 = ytmp - x(k,1);
       const F_FLOAT delz2 = ztmp - x(k,2);
       const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      const F_FLOAT cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       const F_FLOAT rik = sqrt(rsq2);
-      ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
+      ters_dthb(d_params(iparam_ijk),prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
       f_x += fi[0];
@@ -474,6 +470,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
         if (vflag_either) this->template v_tally3<NEIGHFLAG>(ev,i,j,k,fj,fk,delrij,delrik);
       }
     }
+
     a_f(j,0) += fj_x;
     a_f(j,1) += fj_y;
     a_f(j,2) += fj_z;
@@ -486,309 +483,19 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
 template<class DeviceType>
 template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<NEIGHFLAG,EVFLAG>, const int &ii) const {
+void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODCompute<NEIGHFLAG,EVFLAG>, const int &ii) const {
   EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffMODComputeHalf<NEIGHFLAG,EVFLAG>(), ii, ev);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullA<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
-
-  const int i = d_ilist[ii];
-  const X_FLOAT xtmp = x(i,0);
-  const X_FLOAT ytmp = x(i,1);
-  const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
-
-  int j,k,jj,kk,jtype,ktype;
-  F_FLOAT rsq1, cutsq1, rsq2, cutsq2, rij, rik, bo_ij;
-  F_FLOAT fi[3], fj[3], fk[3];
-  X_FLOAT delx1, dely1, delz1, delx2, dely2, delz2;
-
-  //const AtomNeighborsConst d_neighbors_i = k_list.get_neighbors_const(i);
-  const int jnum = d_numneigh_short[i];
-
-  // repulsive
-
-  F_FLOAT f_x = 0.0;
-  F_FLOAT f_y = 0.0;
-  F_FLOAT f_z = 0.0;
-  for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
-    j &= NEIGHMASK;
-    const int jtype = type(j);
-
-    const X_FLOAT delx = xtmp - x(j,0);
-    const X_FLOAT dely = ytmp - x(j,1);
-    const X_FLOAT delz = ztmp - x(j,2);
-    const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-    const F_FLOAT cutsq = paramskk(itype,jtype,jtype).cutsq;
-
-    if (rsq > cutsq) continue;
-
-    const F_FLOAT r = sqrt(rsq);
-    const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
-    const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
-    const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
-                          (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / r;
-    const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
-
-    f_x += delx*frep;
-    f_y += dely*frep;
-    f_z += delz*frep;
-
-    if (EVFLAG) {
-      if (eflag)
-        ev.evdwl += 0.5*eng;
-      if (vflag_either || eflag_atom)
-        this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,frep,delx,dely,delz);
-    }
-  }
-
-  // attractive: bond order
-
-  for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
-    j &= NEIGHMASK;
-    jtype = type(j);
-
-    delx1 = xtmp - x(j,0);
-    dely1 = ytmp - x(j,1);
-    delz1 = ztmp - x(j,2);
-    rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    cutsq1 = paramskk(itype,jtype,jtype).cutsq;
-
-    bo_ij = 0.0;
-    if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
-
-    for (kk = 0; kk < jnum; kk++) {
-      if (jj == kk) continue;
-      k = d_neighbors_short(i,kk);
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = xtmp - x(k,0);
-      dely2 = ytmp - x(k,1);
-      delz2 = ztmp - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(itype,jtype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
-    }
-
-    // attractive: pairwise potential and force
-
-    const F_FLOAT fa = ters_fa_k(itype,jtype,jtype,rij);
-    const F_FLOAT dfa = ters_dfa(itype,jtype,jtype,rij);
-    const F_FLOAT bij = ters_bij_k(itype,jtype,jtype,bo_ij);
-    const F_FLOAT fatt = -0.5*bij * dfa / rij;
-    const F_FLOAT prefactor = 0.5*fa * ters_dbij(itype,jtype,jtype,bo_ij);
-    const F_FLOAT eng = 0.5*bij * fa;
-
-    f_x += delx1*fatt;
-    f_y += dely1*fatt;
-    f_z += delz1*fatt;
-
-    if (EVFLAG) {
-      if (eflag) ev.evdwl += 0.5*eng;
-      if (vflag_either || eflag_atom)
-        this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,fatt,delx1,dely1,delz1);
-    }
-
-    // attractive: three-body force
-
-    for (kk = 0; kk < jnum; kk++) {
-      if (jj == kk) continue;
-      k = d_neighbors_short(i,kk);
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = xtmp - x(k,0);
-      dely2 = ytmp - x(k,1);
-      delz2 = ztmp - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(itype,jtype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
-                rik,delx2,dely2,delz2,fi,fj,fk);
-
-      f_x += fi[0];
-      f_y += fi[1];
-      f_z += fi[2];
-
-      if (vflag_either) {
-        F_FLOAT delrij[3], delrik[3];
-        delrij[0] = -delx1; delrij[1] = -dely1; delrij[2] = -delz1;
-        delrik[0] = -delx2; delrik[1] = -dely2; delrik[2] = -delz2;
-        if (vflag_either) this->template v_tally3<NEIGHFLAG>(ev,i,j,k,fj,fk,delrij,delrik);
-      }
-    }
-  }
-  f(i,0) += f_x;
-  f(i,1) += f_y;
-  f(i,2) += f_z;
-}
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullA<NEIGHFLAG,EVFLAG>, const int &ii) const {
-  EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffMODComputeFullA<NEIGHFLAG,EVFLAG>(), ii, ev);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullB<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
-
-  const int i = d_ilist[ii];
-  const X_FLOAT xtmp = x(i,0);
-  const X_FLOAT ytmp = x(i,1);
-  const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
-
-  int j,k,jj,kk,jtype,ktype,j_jnum;
-  F_FLOAT rsq1, cutsq1, rsq2, cutsq2, rij, rik, bo_ij;
-  F_FLOAT fj[3], fk[3];
-  X_FLOAT delx1, dely1, delz1, delx2, dely2, delz2;
-
-  const int jnum = d_numneigh_short[i];
-
-  F_FLOAT f_x = 0.0;
-  F_FLOAT f_y = 0.0;
-  F_FLOAT f_z = 0.0;
-
-  // attractive: bond order
-
-  for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
-    j &= NEIGHMASK;
-    if (j >= nlocal) continue;
-    jtype = type(j);
-
-    delx1 = x(j,0) - xtmp;
-    dely1 = x(j,1) - ytmp;
-    delz1 = x(j,2) - ztmp;
-    rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    cutsq1 = paramskk(jtype,itype,itype).cutsq;
-
-    bo_ij = 0.0;
-    if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
-
-    j_jnum = d_numneigh_short[j];
-
-    for (kk = 0; kk < j_jnum; kk++) {
-      k = d_neighbors_short(j,kk);
-      if (k == i) continue;
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = x(j,0) - x(k,0);
-      dely2 = x(j,1) - x(k,1);
-      delz2 = x(j,2) - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(jtype,itype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      bo_ij += bondorder(jtype,itype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
-
-    }
-
-    // attractive: pairwise potential and force
-
-    const F_FLOAT fa = ters_fa_k(jtype,itype,itype,rij);
-    const F_FLOAT dfa = ters_dfa(jtype,itype,itype,rij);
-    const F_FLOAT bij = ters_bij_k(jtype,itype,itype,bo_ij);
-    const F_FLOAT fatt = -0.5*bij * dfa / rij;
-    const F_FLOAT prefactor = 0.5*fa * ters_dbij(jtype,itype,itype,bo_ij);
-    const F_FLOAT eng = 0.5*bij * fa;
-
-    f_x -= delx1*fatt;
-    f_y -= dely1*fatt;
-    f_z -= delz1*fatt;
-
-    if (EVFLAG) {
-      if (eflag)
-        ev.evdwl += 0.5 * eng;
-      if (vflag_either || eflag_atom)
-        this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,fatt,delx1,dely1,delz1);
-    }
-
-    // attractive: three-body force
-
-    for (kk = 0; kk < j_jnum; kk++) {
-      k = d_neighbors_short(j,kk);
-      if (k == i) continue;
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = x(j,0) - x(k,0);
-      dely2 = x(j,1) - x(k,1);
-      delz2 = x(j,2) - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(jtype,itype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      ters_dthbj(jtype,itype,ktype,prefactor,rij,delx1,dely1,delz1,
-                rik,delx2,dely2,delz2,fj,fk);
-      f_x += fj[0];
-      f_y += fj[1];
-      f_z += fj[2];
-
-      if (vflag_either) {
-        F_FLOAT delrji[3], delrjk[3];
-        delrji[0] = -delx1; delrji[1] = -dely1; delrji[2] = -delz1;
-        delrjk[0] = -delx2; delrjk[1] = -dely2; delrjk[2] = -delz2;
-        if (vflag_either) v_tally3_atom(ev,i,j,k,fj,fk,delrji,delrjk);
-      }
-
-      const F_FLOAT fa_jk = ters_fa_k(jtype,ktype,itype,rik);
-      const F_FLOAT prefactor_jk = 0.5*fa_jk * ters_dbij(jtype,ktype,itype,bo_ij);
-      ters_dthbk(jtype,ktype,itype,prefactor_jk,rik,delx2,dely2,delz2,
-                rij,delx1,dely1,delz1,fk);
-      f_x += fk[0];
-      f_y += fk[1];
-      f_z += fk[2];
-    }
-  }
-  f(i,0) += f_x;
-  f(i,1) += f_y;
-  f(i,2) += f_z;
-}
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullB<NEIGHFLAG,EVFLAG>, const int &ii) const {
-  EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffMODComputeFullB<NEIGHFLAG,EVFLAG>(), ii, ev);
+  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffMODCompute<NEIGHFLAG,EVFLAG>(), ii, ev);
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffMODKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffMODKokkos<DeviceType>::ters_fc_k(const Param& param, const F_FLOAT &r) const
 {
-  const F_FLOAT ters_R = paramskk(i,j,k).bigr;
-  const F_FLOAT ters_D = paramskk(i,j,k).bigd;
+  const F_FLOAT ters_R = param.bigr;
+  const F_FLOAT ters_D = param.bigd;
 
   if (r < ters_R-ters_D) return 1.0;
   if (r > ters_R+ters_D) return 0.0;
@@ -800,11 +507,10 @@ double PairTersoffMODKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffMODKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffMODKokkos<DeviceType>::ters_dfc(const Param& param, const F_FLOAT &r) const
 {
-  const F_FLOAT ters_R = paramskk(i,j,k).bigr;
-  const F_FLOAT ters_D = paramskk(i,j,k).bigd;
+  const F_FLOAT ters_R = param.bigr;
+  const F_FLOAT ters_D = param.bigd;
 
   if (r < ters_R-ters_D) return 0.0;
   if (r > ters_R+ters_D) return 0.0;
@@ -816,7 +522,7 @@ double PairTersoffMODKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffMODKokkos<DeviceType>::bondorder(const int &i, const int &j, const int &k,
+double PairTersoffMODKokkos<DeviceType>::bondorder(const Param& param,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const
 {
@@ -824,14 +530,15 @@ double PairTersoffMODKokkos<DeviceType>::bondorder(const int &i, const int &j, c
 
   const F_FLOAT costheta = (dx1*dx2 + dy1*dy2 + dz1*dz2)/(rij*rik);
 
-  if (int(paramskk(i,j,k).powerm) == 3) arg = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else arg = paramskk(i,j,k).lam3 * (rij-rik);
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) arg = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else arg = paramtmp;
 
   if (arg > 69.0776) ex_delr = 1.e30;
   else if (arg < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(arg);
 
-  return ters_fc_k(i,j,k,rik) * ters_gijk(i,j,k,costheta) * ex_delr;
+  return ters_fc_k(param,rik) * ters_gijk(param,costheta) * ex_delr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -839,14 +546,14 @@ double PairTersoffMODKokkos<DeviceType>::bondorder(const int &i, const int &j, c
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 double PairTersoffMODKokkos<DeviceType>::
-        ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const
+        ters_gijk(const Param& param, const F_FLOAT &cos) const
 {
-  const F_FLOAT ters_c1 = paramskk(i,j,k).c1;
-  const F_FLOAT ters_c2 = paramskk(i,j,k).c2;
-  const F_FLOAT ters_c3 = paramskk(i,j,k).c3;
-  const F_FLOAT ters_c4 = paramskk(i,j,k).c4;
-  const F_FLOAT ters_c5 = paramskk(i,j,k).c5;
-  const F_FLOAT tmp_h = (paramskk(i,j,k).h - cos)*(paramskk(i,j,k).h - cos);
+  const F_FLOAT ters_c1 = param.c1;
+  const F_FLOAT ters_c2 = param.c2;
+  const F_FLOAT ters_c3 = param.c3;
+  const F_FLOAT ters_c4 = param.c4;
+  const F_FLOAT ters_c5 = param.c5;
+  const F_FLOAT tmp_h = (param.h - cos)*(param.h - cos);
 
   return ters_c1 + (ters_c2*tmp_h/(ters_c3 + tmp_h)) *
       (1.0 + ters_c4*exp(-ters_c5*tmp_h));
@@ -858,17 +565,17 @@ double PairTersoffMODKokkos<DeviceType>::
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 double PairTersoffMODKokkos<DeviceType>::
-        ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const
+        ters_dgijk(const Param& param, const F_FLOAT &cos) const
 {
-  const F_FLOAT ters_c2 = paramskk(i,j,k).c2;
-  const F_FLOAT ters_c3 = paramskk(i,j,k).c3;
-  const F_FLOAT ters_c4 = paramskk(i,j,k).c4;
-  const F_FLOAT ters_c5 = paramskk(i,j,k).c5;
-  const F_FLOAT tmp_h = (paramskk(i,j,k).h - cos)*(paramskk(i,j,k).h - cos);
-  const F_FLOAT g1 = (paramskk(i,j,k).h - cos)/(ters_c3 + tmp_h);
+  const F_FLOAT ters_c2 = param.c2;
+  const F_FLOAT ters_c3 = param.c3;
+  const F_FLOAT ters_c4 = param.c4;
+  const F_FLOAT ters_c5 = param.c5;
+  const F_FLOAT tmp_h = (param.h - cos)*(param.h - cos);
+  const F_FLOAT g1 = (param.h - cos)/(ters_c3 + tmp_h);
   const F_FLOAT g2 = exp(-ters_c5*tmp_h);
 
-  return -2.0*ters_c2*g1*((1 + ters_c4*g2)*(1 + g1*(cos - paramskk(i,j,k).h)) -
+  return -2.0*ters_c2*g1*((1 + ters_c4*g2)*(1 + g1*(cos - param.h)) -
                             tmp_h*ters_c4*ters_c5*g2);
 }
 
@@ -876,58 +583,54 @@ double PairTersoffMODKokkos<DeviceType>::
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffMODKokkos<DeviceType>::ters_fa_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffMODKokkos<DeviceType>::ters_fa_k(const Param& param, const F_FLOAT &r) const
 {
-  if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return -paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r)
-          * ters_fc_k(i,j,k,r);
+  if (r > param.bigr + param.bigd) return 0.0;
+  return -param.bigb * exp(-param.lam2 * r)
+          * ters_fc_k(param,r);
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffMODKokkos<DeviceType>::ters_dfa(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffMODKokkos<DeviceType>::ters_dfa(const Param& param, const F_FLOAT &r) const
 {
-  if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r) *
-    (paramskk(i,j,k).lam2 * ters_fc_k(i,j,k,r) - ters_dfc(i,j,k,r));
+  if (r > param.bigr + param.bigd) return 0.0;
+  return param.bigb * exp(-param.lam2 * r) *
+    (param.lam2 * ters_fc_k(param,r) - ters_dfc(param,r));
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffMODKokkos<DeviceType>::ters_bij_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &bo) const
+double PairTersoffMODKokkos<DeviceType>::ters_bij_k(const Param& param, const F_FLOAT &bo) const
 {
-  const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).ca1)
-    return pow(tmp, -paramskk(i,j,k).powern/(2.0*paramskk(i,j,k).powern_del));
-  if (tmp < paramskk(i,j,k).ca4)
+  const F_FLOAT tmp = param.beta * bo;
+  if (tmp > param.ca1)
+    return pow(tmp, -param.powern/(2.0*param.powern_del));
+  if (tmp < param.ca4)
     return 1.0;
-  return pow(1.0 + pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern_del));
+  return pow(1.0 + pow(tmp,param.powern), -1.0/(2.0*param.powern_del));
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffMODKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
-                const int &k, const F_FLOAT &bo) const
+double PairTersoffMODKokkos<DeviceType>::ters_dbij(const Param& param, const F_FLOAT &bo) const
 {
-  const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).ca1)
-    return -0.5*(paramskk(i,j,k).powern/paramskk(i,j,k).powern_del)*
-          pow(tmp,-0.5*(paramskk(i,j,k).powern/paramskk(i,j,k).powern_del)) / bo;
-  if (tmp < paramskk(i,j,k).ca4)
+  const F_FLOAT tmp = param.beta * bo;
+  if (tmp > param.ca1)
+    return -0.5*(param.powern/param.powern_del)*
+          pow(tmp,-0.5*(param.powern/param.powern_del)) / bo;
+  if (tmp < param.ca4)
     return 0.0;
 
-  const F_FLOAT tmp_n = pow(tmp,paramskk(i,j,k).powern);
-  return -0.5 *(paramskk(i,j,k).powern/paramskk(i,j,k).powern_del)*
-          pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern_del)))*tmp_n / bo;
+  const F_FLOAT tmp_n = pow(tmp,param.powern);
+  return -0.5 *(param.powern/param.powern_del)*
+          pow(1.0+tmp_n, -1.0-(1.0/(2.0*param.powern_del)))*tmp_n / bo;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -935,7 +638,7 @@ double PairTersoffMODKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffMODKokkos<DeviceType>::ters_dthb(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        const Param& param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const
@@ -960,22 +663,23 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthb(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param.powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param.lam3*ex_delr;//pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param.lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   // from PairTersoffMOD::costheta_d
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
@@ -1007,7 +711,7 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthb(
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffMODKokkos<DeviceType>::ters_dthbj(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        const Param& param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fj, F_FLOAT *fk) const
@@ -1028,22 +732,23 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbj(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = param.lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param.powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param.lam3*ex_delr;//pow(param.lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param.lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
   vec3_scale(rijinv,dcosfj,dcosfj);
@@ -1068,7 +773,7 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbj(
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffMODKokkos<DeviceType>::ters_dthbk(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        const Param& param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fk) const
@@ -1089,22 +794,22 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbk(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param.powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param.lam3*ex_delr;//pow(param.lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param.lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
   vec3_scale(rijinv,dcosfj,dcosfj);
@@ -1117,7 +822,6 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbk(
   vec3_scaleadd(fc*dgijk*ex_delr,dcosfk,fk,fk);
   vec3_scaleadd(-fc*gijk*dex_delr,rik_hat,fk,fk);
   vec3_scale(prefactor,fk,fk);
-
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1129,8 +833,6 @@ void PairTersoffMODKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
       const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
                 const F_FLOAT &dely, const F_FLOAT &delz) const
 {
-  const int VFLAG = vflag_either;
-
   // The eatom and vatom arrays are duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
   auto v_eatom = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_eatom),decltype(ndup_eatom)>::get(dup_eatom,ndup_eatom);
@@ -1142,10 +844,10 @@ void PairTersoffMODKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
   if (eflag_atom) {
     const E_FLOAT epairhalf = 0.5 * epair;
     a_eatom[i] += epairhalf;
-    if (NEIGHFLAG != FULL) a_eatom[j] += epairhalf;
+    a_eatom[j] += epairhalf;
   }
 
-  if (VFLAG) {
+  if (vflag_either) {
     const E_FLOAT v0 = delx*delx*fpair;
     const E_FLOAT v1 = dely*dely*fpair;
     const E_FLOAT v2 = delz*delz*fpair;
@@ -1154,21 +856,12 @@ void PairTersoffMODKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
     const E_FLOAT v5 = dely*delz*fpair;
 
     if (vflag_global) {
-      if (NEIGHFLAG != FULL) {
-        ev.v[0] += v0;
-        ev.v[1] += v1;
-        ev.v[2] += v2;
-        ev.v[3] += v3;
-        ev.v[4] += v4;
-        ev.v[5] += v5;
-      } else {
-        ev.v[0] += 0.5*v0;
-        ev.v[1] += 0.5*v1;
-        ev.v[2] += 0.5*v2;
-        ev.v[3] += 0.5*v3;
-        ev.v[4] += 0.5*v4;
-        ev.v[5] += 0.5*v5;
-      }
+      ev.v[0] += v0;
+      ev.v[1] += v1;
+      ev.v[2] += v2;
+      ev.v[3] += v3;
+      ev.v[4] += v4;
+      ev.v[5] += v5;
     }
 
     if (vflag_atom) {
@@ -1179,14 +872,12 @@ void PairTersoffMODKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
       a_vatom(i,4) += 0.5*v4;
       a_vatom(i,5) += 0.5*v5;
 
-      if (NEIGHFLAG != FULL) {
-        a_vatom(j,0) += 0.5*v0;
-        a_vatom(j,1) += 0.5*v1;
-        a_vatom(j,2) += 0.5*v2;
-        a_vatom(j,3) += 0.5*v3;
-        a_vatom(j,4) += 0.5*v4;
-        a_vatom(j,5) += 0.5*v5;
-      }
+      a_vatom(j,0) += 0.5*v0;
+      a_vatom(j,1) += 0.5*v1;
+      a_vatom(j,2) += 0.5*v2;
+      a_vatom(j,3) += 0.5*v3;
+      a_vatom(j,4) += 0.5*v4;
+      a_vatom(j,5) += 0.5*v5;
     }
   }
 }
@@ -1232,14 +923,13 @@ void PairTersoffMODKokkos<DeviceType>::v_tally3(EV_FLOAT &ev, const int &i, cons
 
     a_vatom(i,0) += v[0]; a_vatom(i,1) += v[1]; a_vatom(i,2) += v[2];
     a_vatom(i,3) += v[3]; a_vatom(i,4) += v[4]; a_vatom(i,5) += v[5];
-    if (NEIGHFLAG != FULL) {
-      a_vatom(j,0) += v[0]; a_vatom(j,1) += v[1]; a_vatom(j,2) += v[2];
-      a_vatom(j,3) += v[3]; a_vatom(j,4) += v[4]; a_vatom(j,5) += v[5];
-      a_vatom(k,0) += v[0]; a_vatom(k,1) += v[1]; a_vatom(k,2) += v[2];
-      a_vatom(k,3) += v[3]; a_vatom(k,4) += v[4]; a_vatom(k,5) += v[5];
-    }
-  }
 
+    a_vatom(j,0) += v[0]; a_vatom(j,1) += v[1]; a_vatom(j,2) += v[2];
+    a_vatom(j,3) += v[3]; a_vatom(j,4) += v[4]; a_vatom(j,5) += v[5];
+
+    a_vatom(k,0) += v[0]; a_vatom(k,1) += v[1]; a_vatom(k,2) += v[2];
+    a_vatom(k,3) += v[3]; a_vatom(k,4) += v[4]; a_vatom(k,5) += v[5];
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1289,4 +979,3 @@ template class PairTersoffMODKokkos<LMPDeviceType>;
 template class PairTersoffMODKokkos<LMPHostType>;
 #endif
 }
-

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
@@ -106,8 +106,6 @@ void PairTersoffMODKokkos<DeviceType>::init_style()
   request->set_kokkos_host(std::is_same<DeviceType,LMPHostType>::value &&
                            !std::is_same<DeviceType,LMPDeviceType>::value);
   request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
-  // always request a full neighbor list
-  request->enable_full();
 
   if (neighflag == FULL)
     error->all(FLERR,"Must use half neighbor list style with pair tersoff/kk");
@@ -351,7 +349,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODCompute<NEIGH
     const int iparam_ij = d_elem3param(itype,jtype,jtype);
     const F_FLOAT cutsq = d_params(iparam_ij).cutsq;
 
-    if (rsq > cutsq) continue;
+    if (rsq >= cutsq) continue;
 
     const F_FLOAT r = sqrt(rsq);
     const F_FLOAT tmp_fce = ters_fc_k(d_params(iparam_ij),r);
@@ -664,6 +662,7 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthb(
 
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
@@ -732,7 +731,7 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbj(
   dfc = ters_dfc(param,rik);
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
-  else tmp = param.lam3 * (rij-rik);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
@@ -794,6 +793,7 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbk(
   dfc = ters_dfc(param,rik);
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
@@ -331,7 +331,6 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODCompute<NEIGH
 
   for (int jj = 0; jj < jnum; jj++) {
     int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
     const int jtype = d_map(type(j));
     const tagint jtag = tag(j);
 
@@ -379,7 +378,6 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODCompute<NEIGH
 
   for (int jj = 0; jj < jnum; jj++) {
     int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
     const int jtype = d_map(type(j));
 
     const F_FLOAT delx1 = xtmp - x(j,0);
@@ -396,7 +394,6 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODCompute<NEIGH
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
       int k = d_neighbors_short(ii,kk);
-      k &= NEIGHMASK;
       const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
@@ -438,7 +435,6 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODCompute<NEIGH
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
       int k = d_neighbors_short(ii,kk);
-      k &= NEIGHMASK;
       const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.h
@@ -30,20 +30,14 @@ PairStyle(tersoff/mod/kk/host,PairTersoffMODKokkos<LMPHostType>);
 namespace LAMMPS_NS {
 
 template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffMODComputeHalf{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffMODComputeFullA{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffMODComputeFullB{};
+struct TagPairTersoffMODCompute{};
 
 struct TagPairTersoffMODComputeShortNeigh{};
 
 template<class DeviceType>
 class PairTersoffMODKokkos : public PairTersoffMOD {
  public:
-  enum {EnabledNeighFlags=FULL};
+  enum {EnabledNeighFlags=HALF|HALFTHREAD};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -52,81 +46,66 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
   PairTersoffMODKokkos(class LAMMPS *);
   ~PairTersoffMODKokkos() override;
   void compute(int, int) override;
+  void coeff(int, char **) override;
   void init_style() override;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffMODComputeHalf<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
+  void operator()(TagPairTersoffMODCompute<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffMODComputeHalf<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffMODComputeFullA<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffMODComputeFullA<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffMODComputeFullB<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffMODComputeFullB<NEIGHFLAG,EVFLAG>, const int&) const;
+  void operator()(TagPairTersoffMODCompute<NEIGHFLAG,EVFLAG>, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPairTersoffMODComputeShortNeigh, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_fc_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_fc_k(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfc(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_dfc(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_fa_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_fa_k(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfa(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_dfa(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_bij_k(const int &i, const int &j, const int &k, const F_FLOAT &bo) const;
+  double ters_bij_k(const Param& param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dbij(const int &i, const int &j, const int &k, const F_FLOAT &bo) const;
+  double ters_dbij(const Param& param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  double bondorder(const int &i, const int &j, const int &k,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
+  double bondorder(const Param& param,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
+  double ters_gijk(const Param& param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
+  double ters_dgijk(const Param& param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthb(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-        F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
+  void ters_dthb(const Param& param, const F_FLOAT &prefactor,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+              F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbj(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-        F_FLOAT *fj, F_FLOAT *fk) const;
+  void ters_dthbj(const Param& param, const F_FLOAT &prefactor,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+              F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbk(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-        F_FLOAT *fk) const;
+  void ters_dthbk(const Param& param, const F_FLOAT &prefactor,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+              F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   double vec3_dot(const F_FLOAT x[3], const double y[3]) const {
@@ -151,17 +130,6 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
   KOKKOS_INLINE_FUNCTION
   int sbmask(const int& j) const;
 
-  struct params_ters {
-    KOKKOS_INLINE_FUNCTION
-    params_ters() {powerm=0;lam3=0;h=0;powern=0;beta=0;lam2=0;bigb=0;bigr=0;bigd=0;
-      lam1=0;biga=0;powern_del=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;c5=0;ca1=0;ca4=0;};
-    KOKKOS_INLINE_FUNCTION
-    params_ters(int /*i*/) {powerm=0;lam3=0;h=0;powern=0;beta=0;lam2=0;bigb=0;bigr=0;bigd=0;
-      lam1=0;biga=0;powern_del=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;c5=0;ca1=0;ca4=0;};
-    F_FLOAT powerm, lam3, h, powern, beta, lam2, bigb, bigr, bigd,
-      lam1, biga, powern_del, cutsq, c1, c2, c3, c4, c5, ca1, ca4;
-  };
-
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void ev_tally(EV_FLOAT &ev, const int &i, const int &j,
@@ -171,24 +139,27 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void v_tally3(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
+                F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
 
   KOKKOS_INLINE_FUNCTION
   void v_tally3_atom(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
+                F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
 
-  void allocate() override;
   void setup_params() override;
 
  protected:
-  using KKDeviceType = typename KKDevice<DeviceType>::value;
-
   typedef Kokkos::DualView<int***,DeviceType> tdual_int_3d;
-  Kokkos::DualView<params_ters***,Kokkos::LayoutRight,DeviceType> k_params;
-  typename Kokkos::DualView<params_ters***,
-    Kokkos::LayoutRight,DeviceType>::t_dev_const_um paramskk;
-  // hardwired to space for 12 atom types
-  //params_ters m_params[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];
+  typedef typename tdual_int_3d::t_dev_const_randomread t_int_3d_randomread;
+  typedef typename tdual_int_3d::t_host t_host_int_3d;
+
+  t_int_3d_randomread d_elem3param;
+  typename AT::t_int_1d_randomread d_map;
+
+  typedef Kokkos::DualView<Param*,DeviceType> tdual_param_1d;
+  typedef typename tdual_param_1d::t_dev t_param_1d;
+  typedef typename tdual_param_1d::t_host t_host_param_1d;
+
+  t_param_1d d_params;
 
   int inum;
   typename AT::t_x_array_randomread x;
@@ -203,6 +174,7 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
 
   int need_dup;
 
+  using KKDeviceType = typename KKDevice<DeviceType>::value;
 
   template<typename DataType, typename Layout>
   using DupScatterView = KKScatterView<DataType, Layout, KKDeviceType, KKScatterSum, KKScatterDuplicated>;
@@ -213,6 +185,7 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
   DupScatterView<F_FLOAT*[3], typename DAT::t_f_array::array_layout> dup_f;
   DupScatterView<E_FLOAT*, typename DAT::t_efloat_1d::array_layout> dup_eatom;
   DupScatterView<F_FLOAT*[6], typename DAT::t_virial_array::array_layout> dup_vatom;
+
   NonDupScatterView<F_FLOAT*[3], typename DAT::t_f_array::array_layout> ndup_f;
   NonDupScatterView<E_FLOAT*, typename DAT::t_efloat_1d::array_layout> ndup_eatom;
   NonDupScatterView<F_FLOAT*[6], typename DAT::t_virial_array::array_layout> ndup_vatom;

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.h
@@ -215,11 +215,7 @@ class PairTersoffMODKokkos : public PairTersoffMOD {
 
 /* ERROR/WARNING messages:
 
-E: Cannot (yet) use full neighbor list style with tersoff/mod/kk
-
-Self-explanatory.
-
-E: Cannot use chosen neighbor list style with tersoff/mod/kk
+E: Must use half neighbor list style with pair tersoff/mod/kk
 
 Self-explanatory.
 

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
@@ -119,8 +119,6 @@ void PairTersoffZBLKokkos<DeviceType>::init_style()
   request->set_kokkos_host(std::is_same<DeviceType,LMPHostType>::value &&
                            !std::is_same<DeviceType,LMPDeviceType>::value);
   request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
-  // always request a full neighbor list
-  request->enable_full();
 
   if (neighflag == FULL)
     error->all(FLERR,"Must use half neighbor list style with pair tersoff/kk");
@@ -705,6 +703,7 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthb(
 
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
@@ -773,7 +772,7 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbj(
   dfc = ters_dfc(param,rik);
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
-  else tmp = param.lam3 * (rij-rik);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
@@ -835,6 +834,7 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbk(
   dfc = ters_dfc(param,rik);
   const F_FLOAT paramtmp = param.lam3 * (rij-rik);
   if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = paramtmp;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
@@ -78,18 +78,29 @@ PairTersoffZBLKokkos<DeviceType>::~PairTersoffZBLKokkos()
   }
 }
 
-/* ---------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------
+   set coeffs for one or more type pairs
+------------------------------------------------------------------------- */
 
 template<class DeviceType>
-void PairTersoffZBLKokkos<DeviceType>::allocate()
+void PairTersoffZBLKokkos<DeviceType>::coeff(int narg, char **arg)
 {
-  PairTersoffZBL::allocate();
+  PairTersoff::coeff(narg,arg);
+
+  // sync map
 
   int n = atom->ntypes;
 
-  k_params = Kokkos::DualView<params_ters***,Kokkos::LayoutRight,DeviceType>
-          ("PairTersoffZBL::paramskk",n+1,n+1,n+1);
-  paramskk = k_params.template view<DeviceType>();
+  DAT::tdual_int_1d k_map = DAT::tdual_int_1d("pair:map",n+1);
+  HAT::t_int_1d h_map = k_map.h_view;
+
+  for (int i = 1; i <= n; i++)
+    h_map[i] = map[i];
+
+  k_map.template modify<LMPHostType>();
+  k_map.template sync<DeviceType>();
+
+  d_map = k_map.template view<DeviceType>();
 }
 
 /* ----------------------------------------------------------------------
@@ -108,9 +119,11 @@ void PairTersoffZBLKokkos<DeviceType>::init_style()
   request->set_kokkos_host(std::is_same<DeviceType,LMPHostType>::value &&
                            !std::is_same<DeviceType,LMPDeviceType>::value);
   request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
+  // always request a full neighbor list
   request->enable_full();
+
   if (neighflag == FULL)
-    error->all(FLERR,"Cannot (yet) use full neighbor list style with tersoff/zbl/kk");
+    error->all(FLERR,"Must use half neighbor list style with pair tersoff/kk");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -120,40 +133,29 @@ void PairTersoffZBLKokkos<DeviceType>::setup_params()
 {
   PairTersoffZBL::setup_params();
 
-  int i,j,k,m;
-  int n = atom->ntypes;
+  // sync elem3param and params
 
-  for (i = 1; i <= n; i++)
-    for (j = 1; j <= n; j++)
-      for (k = 1; k <= n; k++) {
-        m = elem3param[map[i]][map[j]][map[k]];
-        k_params.h_view(i,j,k).powerm = params[m].powerm;
-        k_params.h_view(i,j,k).gamma = params[m].gamma;
-        k_params.h_view(i,j,k).lam3 = params[m].lam3;
-        k_params.h_view(i,j,k).c = params[m].c;
-        k_params.h_view(i,j,k).d = params[m].d;
-        k_params.h_view(i,j,k).h = params[m].h;
-        k_params.h_view(i,j,k).powern = params[m].powern;
-        k_params.h_view(i,j,k).beta = params[m].beta;
-        k_params.h_view(i,j,k).lam2 = params[m].lam2;
-        k_params.h_view(i,j,k).bigb = params[m].bigb;
-        k_params.h_view(i,j,k).bigr = params[m].bigr;
-        k_params.h_view(i,j,k).bigd = params[m].bigd;
-        k_params.h_view(i,j,k).lam1 = params[m].lam1;
-        k_params.h_view(i,j,k).biga = params[m].biga;
-        k_params.h_view(i,j,k).cutsq = params[m].cutsq;
-        k_params.h_view(i,j,k).c1 = params[m].c1;
-        k_params.h_view(i,j,k).c2 = params[m].c2;
-        k_params.h_view(i,j,k).c3 = params[m].c3;
-        k_params.h_view(i,j,k).c4 = params[m].c4;
-        k_params.h_view(i,j,k).Z_i = params[m].Z_i;
-        k_params.h_view(i,j,k).Z_j = params[m].Z_j;
-        k_params.h_view(i,j,k).ZBLcut = params[m].ZBLcut;
-        k_params.h_view(i,j,k).ZBLexpscale = params[m].ZBLexpscale;
-      }
+  tdual_int_3d k_elem3param = tdual_int_3d("pair:elem3param",nelements,nelements,nelements);
+  t_host_int_3d h_elem3param = k_elem3param.h_view;
 
-  k_params.template modify<LMPHostType>();
+  tdual_param_1d k_params = tdual_param_1d("pair:params",nparams);
+  t_host_param_1d h_params = k_params.h_view;
 
+  for (int i = 0; i < nelements; i++)
+    for (int j = 0; j < nelements; j++)
+      for (int k = 0; k < nelements; k++)
+        h_elem3param(i,j,k) = elem3param[i][j][k];
+
+  for (int m = 0; m < nparams; m++)
+    h_params[m] = params[m];
+
+  k_elem3param.modify_host();
+  k_elem3param.template sync<DeviceType>();
+  k_params.modify_host();
+  k_params.template sync<DeviceType>();
+
+  d_elem3param = k_elem3param.template view<DeviceType>();
+  d_params = k_params.template view<DeviceType>();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -163,8 +165,6 @@ void PairTersoffZBLKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 {
   eflag = eflag_in;
   vflag = vflag_in;
-
-  if (neighflag == FULL) no_virial_fdotr_compute = 1;
 
   ev_init(eflag,vflag,0);
 
@@ -182,7 +182,6 @@ void PairTersoffZBLKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
 
   atomKK->sync(execution_space,datamask_read);
-  k_params.template sync<DeviceType>();
   if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
   else atomKK->modified(execution_space,F_MASK);
 
@@ -221,37 +220,25 @@ void PairTersoffZBLKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   int max_neighs = d_neighbors.extent(1);
 
-  if (((int)d_neighbors_short.extent(1) != max_neighs) ||
-     ((int)d_neighbors_short.extent(0) != ignum)) {
-    d_neighbors_short = Kokkos::View<int**,DeviceType>("Tersoff::neighbors_short",ignum,max_neighs);
+  if (((int)d_neighbors_short.extent(1) < max_neighs) ||
+     ((int)d_neighbors_short.extent(0) < ignum)) {
+    d_neighbors_short = Kokkos::View<int**,DeviceType>("Tersoff::neighbors_short",ignum*1.2,max_neighs);
   }
-  if ((int)d_numneigh_short.extent(0)!=ignum)
-    d_numneigh_short = Kokkos::View<int*,DeviceType>("Tersoff::numneighs_short",ignum);
-  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairTersoffZBLComputeShortNeigh>(0,neighflag==FULL?ignum:inum), *this);
+  if ((int)d_numneigh_short.extent(0) < ignum)
+    d_numneigh_short = Kokkos::View<int*,DeviceType>("Tersoff::numneighs_short",ignum*1.2);
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairTersoffZBLComputeShortNeigh>(0,inum), *this);
 
   if (neighflag == HALF) {
     if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeHalf<HALF,1> >(0,inum),*this,ev);
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLCompute<HALF,1> >(0,inum),*this,ev);
     else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeHalf<HALF,0> >(0,inum),*this);
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLCompute<HALF,0> >(0,inum),*this);
     ev_all += ev;
   } else if (neighflag == HALFTHREAD) {
     if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeHalf<HALFTHREAD,1> >(0,inum),*this,ev);
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLCompute<HALFTHREAD,1> >(0,inum),*this,ev);
     else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeHalf<HALFTHREAD,0> >(0,inum),*this);
-    ev_all += ev;
-  } else if (neighflag == FULL) {
-    if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeFullA<FULL,1> >(0,inum),*this,ev);
-    else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeFullA<FULL,0> >(0,inum),*this);
-    ev_all += ev;
-
-    if (evflag)
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeFullB<FULL,1> >(0,ignum),*this,ev);
-    else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLComputeFullB<FULL,0> >(0,ignum),*this);
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagPairTersoffZBLCompute<HALFTHREAD,0> >(0,inum),*this);
     ev_all += ev;
   }
 
@@ -303,6 +290,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeShortN
     const X_FLOAT xtmp = x(i,0);
     const X_FLOAT ytmp = x(i,1);
     const X_FLOAT ztmp = x(i,2);
+    const F_FLOAT cutmax_sq = cutmax*cutmax;
 
     const int jnum = d_numneigh[i];
     int inside = 0;
@@ -315,12 +303,12 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeShortN
       const X_FLOAT delz = ztmp - x(j,2);
       const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
-      if (rsq < cutmax*cutmax) {
-        d_neighbors_short(i,inside) = j;
+      if (rsq < cutmax_sq) {
+        d_neighbors_short(ii,inside) = j;
         inside++;
       }
     }
-    d_numneigh_short(i) = inside;
+    d_numneigh_short(ii) = inside;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -328,25 +316,25 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeShortN
 template<class DeviceType>
 template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
+void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLCompute<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
 
   // The f array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
-  auto v_f = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
-  auto a_f = v_f.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
+  const auto v_f = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
+  const auto a_f = v_f.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
 
   const int i = d_ilist[ii];
   if (i >= nlocal) return;
   const X_FLOAT xtmp = x(i,0);
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
+  const int itype = d_map(type(i));
   const tagint itag = tag(i);
 
   F_FLOAT fi[3], fj[3], fk[3];
 
   //const AtomNeighborsConst d_neighbors_i = k_list.get_neighbors_const(i);
-  const int jnum = d_numneigh_short[i];
+  const int jnum = d_numneigh_short[ii];
 
   // repulsive
 
@@ -355,9 +343,9 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
   F_FLOAT f_z = 0.0;
 
   for (int jj = 0; jj < jnum; jj++) {
-    int j = d_neighbors_short(i,jj);
+    int j = d_neighbors_short(ii,jj);
     j &= NEIGHMASK;
-    const int jtype = type(j);
+    const int jtype = d_map(type(j));
     const tagint jtag = tag(j);
 
     if (itag > jtag) {
@@ -374,26 +362,27 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
     const X_FLOAT dely = ytmp - x(j,1);
     const X_FLOAT delz = ztmp - x(j,2);
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-    const F_FLOAT cutsq = paramskk(itype,jtype,jtype).cutsq;
+    const int iparam_ij = d_elem3param(itype,jtype,jtype);
+    const F_FLOAT cutsq = d_params(iparam_ij).cutsq;
 
     if (rsq > cutsq) continue;
 
     // Tersoff repulsive portion
 
     const F_FLOAT r = sqrt(rsq);
-    const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
-    const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
-    const F_FLOAT frep_t = paramskk(itype,jtype,jtype).biga * tmp_exp *
-                          (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1);
-    const F_FLOAT eng_t = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
+    const F_FLOAT tmp_fce = ters_fc_k(d_params(iparam_ij),r);
+    const F_FLOAT tmp_fcd = ters_dfc(d_params(iparam_ij),r);
+    const F_FLOAT tmp_exp = exp(-d_params(iparam_ij).lam1 * r);
+    const F_FLOAT frep_t = d_params(iparam_ij).biga * tmp_exp *
+                          (tmp_fcd - tmp_fce*d_params(iparam_ij).lam1);
+    const F_FLOAT eng_t = tmp_fce * d_params(iparam_ij).biga * tmp_exp;
 
     // ZBL repulsive portion
 
     const F_FLOAT esq = pow(global_e,2.0);
     const F_FLOAT a_ij = (0.8854*global_a_0) /
-            (pow(paramskk(itype,jtype,jtype).Z_i,0.23) + pow(paramskk(itype,jtype,jtype).Z_j,0.23));
-    const F_FLOAT premult = (paramskk(itype,jtype,jtype).Z_i * paramskk(itype,jtype,jtype).Z_j * esq)/
+            (pow(d_params(iparam_ij).Z_i,0.23) + pow(d_params(iparam_ij).Z_j,0.23));
+    const F_FLOAT premult = (d_params(iparam_ij).Z_i * d_params(iparam_ij).Z_j * esq)/
             (4.0*MY_PI*global_epsilon_0);
     const F_FLOAT r_ov_a = r/a_ij;
     const F_FLOAT phi = 0.1818*exp(-3.2*r_ov_a) + 0.5099*exp(-0.9423*r_ov_a) +
@@ -408,13 +397,13 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
     // combine two parts with smoothing by Fermi-like function
 
     F_FLOAT frep, eng;
-    frep = -(-fermi_d_k(itype,jtype,jtype,r) * eng_z +
-             (1.0 - fermi_k(itype,jtype,jtype,r))*frep_z +
-             fermi_d_k(itype,jtype,jtype,r)*eng_t + fermi_k(itype,jtype,jtype,r)*frep_t) / r;
+    frep = -(-fermi_d_k(d_params(iparam_ij),r) * eng_z +
+             (1.0 - fermi_k(d_params(iparam_ij),r))*frep_z +
+             fermi_d_k(d_params(iparam_ij),r)*eng_t + fermi_k(d_params(iparam_ij),r)*frep_t) / r;
 
     if (eflag)
-      eng = (1.0 - fermi_k(itype,jtype,jtype,r)) * eng_z +
-              fermi_k(itype,jtype,jtype,r) * eng_t;
+      eng = (1.0 - fermi_k(d_params(iparam_ij),r)) * eng_z +
+              fermi_k(d_params(iparam_ij),r) * eng_t;
 
     f_x += delx*frep;
     f_y += dely*frep;
@@ -432,15 +421,16 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
   // attractive: bond order
 
   for (int jj = 0; jj < jnum; jj++) {
-    int j = d_neighbors_short(i,jj);
+    int j = d_neighbors_short(ii,jj);
     j &= NEIGHMASK;
-    const int jtype = type(j);
+    const int jtype = d_map(type(j));
 
     const F_FLOAT delx1 = xtmp - x(j,0);
     const F_FLOAT dely1 = ytmp - x(j,1);
     const F_FLOAT delz1 = ztmp - x(j,2);
     const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    const F_FLOAT cutsq1 = paramskk(itype,jtype,jtype).cutsq;
+    const int iparam_ij = d_elem3param(itype,jtype,jtype);
+    const F_FLOAT cutsq1 = d_params(iparam_ij).cutsq;
 
     F_FLOAT bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
@@ -448,28 +438,29 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      int k = d_neighbors_short(i,kk);
+      int k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      const int ktype = type(k);
+      const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
       const F_FLOAT dely2 = ytmp - x(k,1);
       const F_FLOAT delz2 = ztmp - x(k,2);
       const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      const F_FLOAT cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       const F_FLOAT rik = sqrt(rsq2);
-      bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
+      bo_ij += bondorder(d_params(iparam_ijk),rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
     // attractive: pairwise potential and force
 
-    const F_FLOAT fa = ters_fa_k(itype,jtype,jtype,rij);
-    const F_FLOAT dfa = ters_dfa(itype,jtype,jtype,rij);
-    const F_FLOAT bij = ters_bij_k(itype,jtype,jtype,bo_ij);
+    const F_FLOAT fa = ters_fa_k(d_params(iparam_ij),rij);
+    const F_FLOAT dfa = ters_dfa(d_params(iparam_ij),rij);
+    const F_FLOAT bij = ters_bij_k(d_params(iparam_ij),bo_ij);
     const F_FLOAT fatt = -0.5*bij * dfa / rij;
-    const F_FLOAT prefactor = 0.5*fa * ters_dbij(itype,jtype,jtype,bo_ij);
+    const F_FLOAT prefactor = 0.5*fa * ters_dbij(d_params(iparam_ij),bo_ij);
 
     f_x += delx1*fatt;
     f_y += dely1*fatt;
@@ -489,19 +480,20 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
-      int k = d_neighbors_short(i,kk);
+      int k = d_neighbors_short(ii,kk);
       k &= NEIGHMASK;
-      const int ktype = type(k);
+      const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
       const F_FLOAT dely2 = ytmp - x(k,1);
       const F_FLOAT delz2 = ztmp - x(k,2);
       const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
+      const int iparam_ijk = d_elem3param(itype,jtype,ktype);
+      const F_FLOAT cutsq2 = d_params(iparam_ijk).cutsq;
 
       if (rsq2 > cutsq2) continue;
       const F_FLOAT rik = sqrt(rsq2);
-      ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
+      ters_dthb(d_params(iparam_ijk),prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
       f_x += fi[0];
@@ -521,6 +513,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
         if (vflag_either) this->template v_tally3<NEIGHFLAG>(ev,i,j,k,fj,fk,delrij,delrik);
       }
     }
+
     a_f(j,0) += fj_x;
     a_f(j,1) += fj_y;
     a_f(j,2) += fj_z;
@@ -533,339 +526,19 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
 template<class DeviceType>
 template<int NEIGHFLAG, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<NEIGHFLAG,EVFLAG>, const int &ii) const {
+void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLCompute<NEIGHFLAG,EVFLAG>, const int &ii) const {
   EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffZBLComputeHalf<NEIGHFLAG,EVFLAG>(), ii, ev);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullA<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
-
-  const int i = d_ilist[ii];
-  const X_FLOAT xtmp = x(i,0);
-  const X_FLOAT ytmp = x(i,1);
-  const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
-
-  int j,k,jj,kk,jtype,ktype;
-  F_FLOAT rsq1, cutsq1, rsq2, cutsq2, rij, rik, bo_ij;
-  F_FLOAT fi[3], fj[3], fk[3];
-  X_FLOAT delx1, dely1, delz1, delx2, dely2, delz2;
-
-  //const AtomNeighborsConst d_neighbors_i = k_list.get_neighbors_const(i);
-  const int jnum = d_numneigh[i];
-
-  // repulsive
-
-  F_FLOAT f_x = 0.0;
-  F_FLOAT f_y = 0.0;
-  F_FLOAT f_z = 0.0;
-  for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
-    j &= NEIGHMASK;
-    const int jtype = type(j);
-
-    const X_FLOAT delx = xtmp - x(j,0);
-    const X_FLOAT dely = ytmp - x(j,1);
-    const X_FLOAT delz = ztmp - x(j,2);
-    const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-    const F_FLOAT cutsq = paramskk(itype,jtype,jtype).cutsq;
-
-    if (rsq > cutsq) continue;
-
-    // Tersoff repulsive portion
-
-    const F_FLOAT r = sqrt(rsq);
-    const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
-    const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
-    const F_FLOAT frep_t = paramskk(itype,jtype,jtype).biga * tmp_exp *
-                          (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1);
-    const F_FLOAT eng_t = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
-
-    // ZBL repulsive portion
-
-    const F_FLOAT esq = pow(global_e,2.0);
-    const F_FLOAT a_ij = (0.8854*global_a_0) /
-            (pow(paramskk(itype,jtype,jtype).Z_i,0.23) + pow(paramskk(itype,jtype,jtype).Z_j,0.23));
-    const F_FLOAT premult = (paramskk(itype,jtype,jtype).Z_i * paramskk(itype,jtype,jtype).Z_j * esq)/
-            (4.0*MY_PI*global_epsilon_0);
-    const F_FLOAT r_ov_a = r/a_ij;
-    const F_FLOAT phi = 0.1818*exp(-3.2*r_ov_a) + 0.5099*exp(-0.9423*r_ov_a) +
-            0.2802*exp(-0.4029*r_ov_a) + 0.02817*exp(-0.2016*r_ov_a);
-    const F_FLOAT dphi = (1.0/a_ij) * (-3.2*0.1818*exp(-3.2*r_ov_a) -
-                              0.9423*0.5099*exp(-0.9423*r_ov_a) -
-                              0.4029*0.2802*exp(-0.4029*r_ov_a) -
-                              0.2016*0.02817*exp(-0.2016*r_ov_a));
-    const F_FLOAT frep_z = premult*-phi/rsq + premult*dphi/r;
-    const F_FLOAT eng_z = premult*(1.0/r)*phi;
-
-    // combine two parts with smoothing by Fermi-like function
-
-    F_FLOAT frep, eng;
-    frep = -(-fermi_d_k(itype,jtype,jtype,r) * eng_z +
-             (1.0 - fermi_k(itype,jtype,jtype,r))*frep_z +
-             fermi_d_k(itype,jtype,jtype,r)*eng_t + fermi_k(itype,jtype,jtype,r)*frep_t) / r;
-
-    if (eflag)
-      eng = (1.0 - fermi_k(itype,jtype,jtype,r)) * eng_z +
-              fermi_k(itype,jtype,jtype,r) * eng_t;
-
-    f_x += delx*frep;
-    f_y += dely*frep;
-    f_z += delz*frep;
-
-    if (EVFLAG) {
-      if (eflag)
-        ev.evdwl += 0.5*eng;
-      if (vflag_either || eflag_atom)
-        this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,frep,delx,dely,delz);
-    }
-  }
-
-  // attractive: bond order
-
-  for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
-    j &= NEIGHMASK;
-    jtype = type(j);
-
-    delx1 = xtmp - x(j,0);
-    dely1 = ytmp - x(j,1);
-    delz1 = ztmp - x(j,2);
-    rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    cutsq1 = paramskk(itype,jtype,jtype).cutsq;
-
-    bo_ij = 0.0;
-    if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
-
-    for (kk = 0; kk < jnum; kk++) {
-      if (jj == kk) continue;
-      k = d_neighbors_short(i,kk);
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = xtmp - x(k,0);
-      dely2 = ytmp - x(k,1);
-      delz2 = ztmp - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(itype,jtype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
-    }
-
-    // attractive: pairwise potential and force
-
-    const F_FLOAT fa = ters_fa_k(itype,jtype,jtype,rij);
-    const F_FLOAT dfa = ters_dfa(itype,jtype,jtype,rij);
-    const F_FLOAT bij = ters_bij_k(itype,jtype,jtype,bo_ij);
-    const F_FLOAT fatt = -0.5*bij * dfa / rij;
-    const F_FLOAT prefactor = 0.5*fa * ters_dbij(itype,jtype,jtype,bo_ij);
-    const F_FLOAT eng = 0.5*bij * fa;
-
-    f_x += delx1*fatt;
-    f_y += dely1*fatt;
-    f_z += delz1*fatt;
-
-    if (EVFLAG) {
-      if (eflag) ev.evdwl += 0.5*eng;
-      if (vflag_either || eflag_atom)
-        this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,fatt,delx1,dely1,delz1);
-    }
-
-    // attractive: three-body force
-
-    for (kk = 0; kk < jnum; kk++) {
-      if (jj == kk) continue;
-      k = d_neighbors_short(i,kk);
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = xtmp - x(k,0);
-      dely2 = ytmp - x(k,1);
-      delz2 = ztmp - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(itype,jtype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
-                rik,delx2,dely2,delz2,fi,fj,fk);
-
-      f_x += fi[0];
-      f_y += fi[1];
-      f_z += fi[2];
-
-      if (vflag_either) {
-        F_FLOAT delrij[3], delrik[3];
-        delrij[0] = -delx1; delrij[1] = -dely1; delrij[2] = -delz1;
-        delrik[0] = -delx2; delrik[1] = -dely2; delrik[2] = -delz2;
-        if (vflag_either) this->template v_tally3<NEIGHFLAG>(ev,i,j,k,fj,fk,delrij,delrik);
-      }
-    }
-  }
-  f(i,0) += f_x;
-  f(i,1) += f_y;
-  f(i,2) += f_z;
-}
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullA<NEIGHFLAG,EVFLAG>, const int &ii) const {
-  EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffZBLComputeFullA<NEIGHFLAG,EVFLAG>(), ii, ev);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullB<NEIGHFLAG,EVFLAG>, const int &ii, EV_FLOAT& ev) const {
-
-  const int i = d_ilist[ii];
-  const X_FLOAT xtmp = x(i,0);
-  const X_FLOAT ytmp = x(i,1);
-  const X_FLOAT ztmp = x(i,2);
-  const int itype = type(i);
-
-  int j,k,jj,kk,jtype,ktype,j_jnum;
-  F_FLOAT rsq1, cutsq1, rsq2, cutsq2, rij, rik, bo_ij;
-  F_FLOAT fj[3], fk[3];
-  X_FLOAT delx1, dely1, delz1, delx2, dely2, delz2;
-
-  const int jnum = d_numneigh_short[i];
-
-  F_FLOAT f_x = 0.0;
-  F_FLOAT f_y = 0.0;
-  F_FLOAT f_z = 0.0;
-
-  // attractive: bond order
-
-  for (jj = 0; jj < jnum; jj++) {
-    j = d_neighbors_short(i,jj);
-    j &= NEIGHMASK;
-    if (j >= nlocal) continue;
-    jtype = type(j);
-
-    delx1 = x(j,0) - xtmp;
-    dely1 = x(j,1) - ytmp;
-    delz1 = x(j,2) - ztmp;
-    rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-    cutsq1 = paramskk(jtype,itype,itype).cutsq;
-
-    bo_ij = 0.0;
-    if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
-
-    j_jnum = d_numneigh_short[j];
-
-    for (kk = 0; kk < j_jnum; kk++) {
-      k = d_neighbors_short(j,kk);
-      if (k == i) continue;
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = x(j,0) - x(k,0);
-      dely2 = x(j,1) - x(k,1);
-      delz2 = x(j,2) - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(jtype,itype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      bo_ij += bondorder(jtype,itype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
-
-    }
-
-    // attractive: pairwise potential and force
-
-    const F_FLOAT fa = ters_fa_k(jtype,itype,itype,rij);
-    const F_FLOAT dfa = ters_dfa(jtype,itype,itype,rij);
-    const F_FLOAT bij = ters_bij_k(jtype,itype,itype,bo_ij);
-    const F_FLOAT fatt = -0.5*bij * dfa / rij;
-    const F_FLOAT prefactor = 0.5*fa * ters_dbij(jtype,itype,itype,bo_ij);
-    const F_FLOAT eng = 0.5*bij * fa;
-
-    f_x -= delx1*fatt;
-    f_y -= dely1*fatt;
-    f_z -= delz1*fatt;
-
-    if (EVFLAG) {
-      if (eflag)
-        ev.evdwl += 0.5 * eng;
-      if (vflag_either || eflag_atom)
-        this->template ev_tally<NEIGHFLAG>(ev,i,j,eng,fatt,delx1,dely1,delz1);
-    }
-
-    // attractive: three-body force
-
-    for (kk = 0; kk < j_jnum; kk++) {
-      k = d_neighbors_short(j,kk);
-      if (k == i) continue;
-      k &= NEIGHMASK;
-      ktype = type(k);
-
-      delx2 = x(j,0) - x(k,0);
-      dely2 = x(j,1) - x(k,1);
-      delz2 = x(j,2) - x(k,2);
-      rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-      cutsq2 = paramskk(jtype,itype,ktype).cutsq;
-
-      if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
-      ters_dthbj(jtype,itype,ktype,prefactor,rij,delx1,dely1,delz1,
-                rik,delx2,dely2,delz2,fj,fk);
-      f_x += fj[0];
-      f_y += fj[1];
-      f_z += fj[2];
-
-      if (vflag_either) {
-        F_FLOAT delrji[3], delrjk[3];
-        delrji[0] = -delx1; delrji[1] = -dely1; delrji[2] = -delz1;
-        delrjk[0] = -delx2; delrjk[1] = -dely2; delrjk[2] = -delz2;
-        if (vflag_either) v_tally3_atom(ev,i,j,k,fj,fk,delrji,delrjk);
-      }
-
-      const F_FLOAT fa_jk = ters_fa_k(jtype,ktype,itype,rik);
-      const F_FLOAT prefactor_jk = 0.5*fa_jk * ters_dbij(jtype,ktype,itype,bo_ij);
-      ters_dthbk(jtype,ktype,itype,prefactor_jk,rik,delx2,dely2,delz2,
-                rij,delx1,dely1,delz1,fk);
-      f_x += fk[0];
-      f_y += fk[1];
-      f_z += fk[2];
-    }
-  }
-  f(i,0) += f_x;
-  f(i,1) += f_y;
-  f(i,2) += f_z;
-}
-
-template<class DeviceType>
-template<int NEIGHFLAG, int EVFLAG>
-KOKKOS_INLINE_FUNCTION
-void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullB<NEIGHFLAG,EVFLAG>, const int &ii) const {
-  EV_FLOAT ev;
-  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffZBLComputeFullB<NEIGHFLAG,EVFLAG>(), ii, ev);
+  this->template operator()<NEIGHFLAG,EVFLAG>(TagPairTersoffZBLCompute<NEIGHFLAG,EVFLAG>(), ii, ev);
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffZBLKokkos<DeviceType>::ters_fc_k(const Param& param, const F_FLOAT &r) const
 {
-  const F_FLOAT ters_R = paramskk(i,j,k).bigr;
-  const F_FLOAT ters_D = paramskk(i,j,k).bigd;
+  const F_FLOAT ters_R = param.bigr;
+  const F_FLOAT ters_D = param.bigd;
 
   if (r < ters_R-ters_D) return 1.0;
   if (r > ters_R+ters_D) return 0.0;
@@ -876,11 +549,10 @@ double PairTersoffZBLKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffZBLKokkos<DeviceType>::ters_dfc(const Param& param, const F_FLOAT &r) const
 {
-  const F_FLOAT ters_R = paramskk(i,j,k).bigr;
-  const F_FLOAT ters_D = paramskk(i,j,k).bigd;
+  const F_FLOAT ters_R = param.bigr;
+  const F_FLOAT ters_D = param.bigd;
 
   if (r < ters_R-ters_D) return 0.0;
   if (r > ters_R+ters_D) return 0.0;
@@ -891,7 +563,7 @@ double PairTersoffZBLKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::bondorder(const int &i, const int &j, const int &k,
+double PairTersoffZBLKokkos<DeviceType>::bondorder(const Param& param,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const
 {
@@ -899,14 +571,15 @@ double PairTersoffZBLKokkos<DeviceType>::bondorder(const int &i, const int &j, c
 
   const F_FLOAT costheta = (dx1*dx2 + dy1*dy2 + dz1*dz2)/(rij*rik);
 
-  if (int(paramskk(i,j,k).powerm) == 3) arg = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else arg = paramskk(i,j,k).lam3 * (rij-rik);
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) arg = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else arg = paramtmp;
 
   if (arg > 69.0776) ex_delr = 1.e30;
   else if (arg < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(arg);
 
-  return ters_fc_k(i,j,k,rik) * ters_gijk(i,j,k,costheta) * ex_delr;
+  return ters_fc_k(param,rik) * ters_gijk(param,costheta) * ex_delr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -914,13 +587,13 @@ double PairTersoffZBLKokkos<DeviceType>::bondorder(const int &i, const int &j, c
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 double PairTersoffZBLKokkos<DeviceType>::
-        ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const
+        ters_gijk(const Param& param, const F_FLOAT &cos) const
 {
-  const F_FLOAT ters_c = paramskk(i,j,k).c * paramskk(i,j,k).c;
-  const F_FLOAT ters_d = paramskk(i,j,k).d * paramskk(i,j,k).d;
-  const F_FLOAT hcth = paramskk(i,j,k).h - cos;
+  const F_FLOAT ters_c = param.c * param.c;
+  const F_FLOAT ters_d = param.d * param.d;
+  const F_FLOAT hcth = param.h - cos;
 
-  return paramskk(i,j,k).gamma*(1.0 + ters_c/ters_d - ters_c/(ters_d+hcth*hcth));
+  return param.gamma*(1.0 + ters_c/ters_d - ters_c/(ters_d+hcth*hcth));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -928,81 +601,77 @@ double PairTersoffZBLKokkos<DeviceType>::
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 double PairTersoffZBLKokkos<DeviceType>::
-        ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const
+        ters_dgijk(const Param& param, const F_FLOAT &cos) const
 {
-
-  const F_FLOAT ters_c = paramskk(i,j,k).c * paramskk(i,j,k).c;
-  const F_FLOAT ters_d = paramskk(i,j,k).d * paramskk(i,j,k).d;
-  const F_FLOAT hcth = paramskk(i,j,k).h - cos;
+  const F_FLOAT ters_c = param.c * param.c;
+  const F_FLOAT ters_d = param.d * param.d;
+  const F_FLOAT hcth = param.h - cos;
   const F_FLOAT numerator = -2.0 * ters_c * hcth;
   const F_FLOAT denominator = 1.0/(ters_d + hcth*hcth);
-  return paramskk(i,j,k).gamma * numerator * denominator * denominator;
+  return param.gamma * numerator * denominator * denominator;
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::ters_fa_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffZBLKokkos<DeviceType>::ters_fa_k(const Param& param, const F_FLOAT &r) const
 {
-  if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return -paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r)
-          * ters_fc_k(i,j,k,r) * fermi_k(i,j,k,r);
+  if (r > param.bigr + param.bigd) return 0.0;
+  return -param.bigb * exp(-param.lam2 * r)
+          * ters_fc_k(param,r) * fermi_k(param,r);
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::ters_dfa(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffZBLKokkos<DeviceType>::ters_dfa(const Param& param, const F_FLOAT &r) const
 {
-  if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r) *
-    (paramskk(i,j,k).lam2 * ters_fc_k(i,j,k,r) * fermi_k(i,j,k,r) -
-     ters_dfc(i,j,k,r) * fermi_k(i,j,k,r) - ters_fc_k(i,j,k,r) *
-     fermi_d_k(i,j,k,r));
+  if (r > param.bigr + param.bigd) return 0.0;
+  return param.bigb * exp(-param.lam2 * r) *
+    (param.lam2 * ters_fc_k(param,r) * fermi_k(param,r) -
+     ters_dfc(param,r) * fermi_k(param,r) - ters_fc_k(param,r) *
+     fermi_d_k(param,r));
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::ters_bij_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &bo) const
+double PairTersoffZBLKokkos<DeviceType>::ters_bij_k(const Param& param, const F_FLOAT &bo) const
 {
-  const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).c1) return 1.0/sqrt(tmp);
-  if (tmp > paramskk(i,j,k).c2)
-    return (1.0 - pow(tmp,-paramskk(i,j,k).powern) / (2.0*paramskk(i,j,k).powern))/sqrt(tmp);
-  if (tmp < paramskk(i,j,k).c4) return 1.0;
-  if (tmp < paramskk(i,j,k).c3)
-    return 1.0 - pow(tmp,paramskk(i,j,k).powern)/(2.0*paramskk(i,j,k).powern);
-  return pow(1.0 + pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern));
+  const F_FLOAT tmp = param.beta * bo;
+  if (tmp > param.c1) return 1.0/sqrt(tmp);
+  if (tmp > param.c2)
+    return (1.0 - pow(tmp,-param.powern) / (2.0*param.powern))/sqrt(tmp);
+  if (tmp < param.c4) return 1.0;
+  if (tmp < param.c3)
+    return 1.0 - pow(tmp,param.powern)/(2.0*param.powern);
+  return pow(1.0 + pow(tmp,param.powern), -1.0/(2.0*param.powern));
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
-                const int &k, const F_FLOAT &bo) const
+double PairTersoffZBLKokkos<DeviceType>::ters_dbij(const Param& param, const F_FLOAT &bo) const
 {
-  const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).c1) return paramskk(i,j,k).beta * -0.5*pow(tmp,-1.5);
-  if (tmp > paramskk(i,j,k).c2)
-    return paramskk(i,j,k).beta * (-0.5*pow(tmp,-1.5) *
+  const F_FLOAT tmp = param.beta * bo;
+  const F_FLOAT factor = -0.5/sqrt(tmp*tmp*tmp); //pow(tmp,-1.5)
+  if (tmp > param.c1) return param.beta * factor;
+  if (tmp > param.c2)
+    return param.beta * (factor *
            // error in negligible 2nd term fixed 2/21/2022
-           //(1.0 - 0.5*(1.0 + 1.0/(2.0*paramskk(i,j,k).powern)) *
-           (1.0 - (1.0 + 1.0/(2.0*paramskk(i,j,k).powern)) *
-           pow(tmp,-paramskk(i,j,k).powern)));
-  if (tmp < paramskk(i,j,k).c4) return 0.0;
-  if (tmp < paramskk(i,j,k).c3)
-    return -0.5*paramskk(i,j,k).beta * pow(tmp,paramskk(i,j,k).powern-1.0);
+           // (1.0 - 0.5*(1.0 +  1.0/(2.0*param.powern)) *
+           (1.0 - (1.0 + 1.0/(2.0*param.powern)) *
+           pow(tmp,-param.powern)));
+  if (tmp < param.c4) return 0.0;
+  if (tmp < param.c3)
+    return -0.5*param.beta * pow(tmp,param.powern-1.0);
 
-  const F_FLOAT tmp_n = pow(tmp,paramskk(i,j,k).powern);
-  return -0.5 * pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern)))*tmp_n / bo;
+  const F_FLOAT tmp_n = pow(tmp,param.powern);
+  return -0.5 * pow(1.0+tmp_n, -1.0-(1.0/(2.0*param.powern)))*tmp_n / bo;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1010,7 +679,7 @@ double PairTersoffZBLKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffZBLKokkos<DeviceType>::ters_dthb(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        const Param& param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const
@@ -1035,22 +704,23 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthb(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param.powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param.lam3*ex_delr;//pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param.lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   // from PairTersoffZBL::costheta_d
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
@@ -1082,7 +752,7 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthb(
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffZBLKokkos<DeviceType>::ters_dthbj(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        const Param& param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fj, F_FLOAT *fk) const
@@ -1103,22 +773,23 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbj(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
+  else tmp = param.lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param.powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param.lam3*ex_delr;//pow(param.lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param.lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
   vec3_scale(rijinv,dcosfj,dcosfj);
@@ -1143,7 +814,7 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbj(
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void PairTersoffZBLKokkos<DeviceType>::ters_dthbk(
-        const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
+        const Param& param, const F_FLOAT &prefactor,
         const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
         const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
         F_FLOAT *fk) const
@@ -1164,22 +835,22 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbk(
   F_FLOAT gijk,dgijk,ex_delr,dex_delr,fc,dfc,cos,tmp;
   F_FLOAT dcosfi[3],dcosfj[3],dcosfk[3];
 
-  fc = ters_fc_k(i,j,k,rik);
-  dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
-  else tmp = paramskk(i,j,k).lam3 * (rij-rik);
+  fc = ters_fc_k(param,rik);
+  dfc = ters_dfc(param,rik);
+  const F_FLOAT paramtmp = param.lam3 * (rij-rik);
+  if (int(param.powerm) == 3) tmp = paramtmp*paramtmp*paramtmp;//pow(param.lam3 * (rij-rik),3.0);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
   else ex_delr = exp(tmp);
 
-  if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
-  else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
+  if (int(param.powerm) == 3)
+    dex_delr = 3.0*paramtmp*paramtmp*param.lam3*ex_delr;//pow(param.lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+  else dex_delr = param.lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
-  gijk = ters_gijk(i,j,k,cos);
-  dgijk = ters_dgijk(i,j,k,cos);
+  gijk = ters_gijk(param,cos);
+  dgijk = ters_dgijk(param,cos);
 
   vec3_scaleadd(-cos,rij_hat,rik_hat,dcosfj);
   vec3_scale(rijinv,dcosfj,dcosfj);
@@ -1199,24 +870,22 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbk(
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::fermi_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffZBLKokkos<DeviceType>::fermi_k(const Param& param, const F_FLOAT &r) const
 {
-  return 1.0 / (1.0 + exp(-paramskk(i,j,k).ZBLexpscale *
-                          (r - paramskk(i,j,k).ZBLcut)));
+  return 1.0 / (1.0 + exp(-param.ZBLexpscale *
+                          (r - param.ZBLcut)));
 }
 
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-double PairTersoffZBLKokkos<DeviceType>::fermi_d_k(const int &i, const int &j,
-                const int &k, const F_FLOAT &r) const
+double PairTersoffZBLKokkos<DeviceType>::fermi_d_k(const Param& param, const F_FLOAT &r) const
 {
-  return paramskk(i,j,k).ZBLexpscale * exp(-paramskk(i,j,k).ZBLexpscale *
-         (r - paramskk(i,j,k).ZBLcut)) /
-         pow(1.0 + exp(-paramskk(i,j,k).ZBLexpscale *
-         (r - paramskk(i,j,k).ZBLcut)),2.0);
+  return param.ZBLexpscale * exp(-param.ZBLexpscale *
+         (r - param.ZBLcut)) /
+         pow(1.0 + exp(-param.ZBLexpscale *
+         (r - param.ZBLcut)),2.0);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1228,8 +897,6 @@ void PairTersoffZBLKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
       const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
                 const F_FLOAT &dely, const F_FLOAT &delz) const
 {
-  const int VFLAG = vflag_either;
-
   // The eatom and vatom arrays are duplicated for OpenMP, atomic for CUDA, and neither for Serial
 
   auto v_eatom = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_eatom),decltype(ndup_eatom)>::get(dup_eatom,ndup_eatom);
@@ -1241,10 +908,10 @@ void PairTersoffZBLKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
   if (eflag_atom) {
     const E_FLOAT epairhalf = 0.5 * epair;
     a_eatom[i] += epairhalf;
-    if (NEIGHFLAG != FULL) a_eatom[j] += epairhalf;
+    a_eatom[j] += epairhalf;
   }
 
-  if (VFLAG) {
+  if (vflag_either) {
     const E_FLOAT v0 = delx*delx*fpair;
     const E_FLOAT v1 = dely*dely*fpair;
     const E_FLOAT v2 = delz*delz*fpair;
@@ -1253,21 +920,12 @@ void PairTersoffZBLKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
     const E_FLOAT v5 = dely*delz*fpair;
 
     if (vflag_global) {
-      if (NEIGHFLAG != FULL) {
-        ev.v[0] += v0;
-        ev.v[1] += v1;
-        ev.v[2] += v2;
-        ev.v[3] += v3;
-        ev.v[4] += v4;
-        ev.v[5] += v5;
-      } else {
-        ev.v[0] += 0.5*v0;
-        ev.v[1] += 0.5*v1;
-        ev.v[2] += 0.5*v2;
-        ev.v[3] += 0.5*v3;
-        ev.v[4] += 0.5*v4;
-        ev.v[5] += 0.5*v5;
-      }
+      ev.v[0] += v0;
+      ev.v[1] += v1;
+      ev.v[2] += v2;
+      ev.v[3] += v3;
+      ev.v[4] += v4;
+      ev.v[5] += v5;
     }
 
     if (vflag_atom) {
@@ -1278,14 +936,12 @@ void PairTersoffZBLKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
       a_vatom(i,4) += 0.5*v4;
       a_vatom(i,5) += 0.5*v5;
 
-      if (NEIGHFLAG != FULL) {
-        a_vatom(j,0) += 0.5*v0;
-        a_vatom(j,1) += 0.5*v1;
-        a_vatom(j,2) += 0.5*v2;
-        a_vatom(j,3) += 0.5*v3;
-        a_vatom(j,4) += 0.5*v4;
-        a_vatom(j,5) += 0.5*v5;
-      }
+      a_vatom(j,0) += 0.5*v0;
+      a_vatom(j,1) += 0.5*v1;
+      a_vatom(j,2) += 0.5*v2;
+      a_vatom(j,3) += 0.5*v3;
+      a_vatom(j,4) += 0.5*v4;
+      a_vatom(j,5) += 0.5*v5;
     }
   }
 }
@@ -1295,7 +951,8 @@ void PairTersoffZBLKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int &i, cons
 template<class DeviceType>
 template<int NEIGHFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairTersoffZBLKokkos<DeviceType>::v_tally3(EV_FLOAT &ev, const int &i, const int &j, const int &k,
+void PairTersoffZBLKokkos<DeviceType>::v_tally3(EV_FLOAT &ev,
+        const int &i, const int &j, const int &k,
         F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const
 {
   // The vatom array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
@@ -1331,14 +988,13 @@ void PairTersoffZBLKokkos<DeviceType>::v_tally3(EV_FLOAT &ev, const int &i, cons
 
     a_vatom(i,0) += v[0]; a_vatom(i,1) += v[1]; a_vatom(i,2) += v[2];
     a_vatom(i,3) += v[3]; a_vatom(i,4) += v[4]; a_vatom(i,5) += v[5];
-    if (NEIGHFLAG != FULL) {
-      a_vatom(j,0) += v[0]; a_vatom(j,1) += v[1]; a_vatom(j,2) += v[2];
-      a_vatom(j,3) += v[3]; a_vatom(j,4) += v[4]; a_vatom(j,5) += v[5];
-      a_vatom(k,0) += v[0]; a_vatom(k,1) += v[1]; a_vatom(k,2) += v[2];
-      a_vatom(k,3) += v[3]; a_vatom(k,4) += v[4]; a_vatom(k,5) += v[5];
-    }
-  }
 
+    a_vatom(j,0) += v[0]; a_vatom(j,1) += v[1]; a_vatom(j,2) += v[2];
+    a_vatom(j,3) += v[3]; a_vatom(j,4) += v[4]; a_vatom(j,5) += v[5];
+
+    a_vatom(k,0) += v[0]; a_vatom(k,1) += v[1]; a_vatom(k,2) += v[2];
+    a_vatom(k,3) += v[3]; a_vatom(k,4) += v[4]; a_vatom(k,5) += v[5];
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1387,4 +1043,3 @@ template class PairTersoffZBLKokkos<LMPDeviceType>;
 template class PairTersoffZBLKokkos<LMPHostType>;
 #endif
 }
-

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
@@ -85,7 +85,7 @@ PairTersoffZBLKokkos<DeviceType>::~PairTersoffZBLKokkos()
 template<class DeviceType>
 void PairTersoffZBLKokkos<DeviceType>::coeff(int narg, char **arg)
 {
-  PairTersoff::coeff(narg,arg);
+  PairTersoffZBL::coeff(narg,arg);
 
   // sync map
 
@@ -344,7 +344,6 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLCompute<NEIGH
 
   for (int jj = 0; jj < jnum; jj++) {
     int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
     const int jtype = d_map(type(j));
     const tagint jtag = tag(j);
 
@@ -422,7 +421,6 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLCompute<NEIGH
 
   for (int jj = 0; jj < jnum; jj++) {
     int j = d_neighbors_short(ii,jj);
-    j &= NEIGHMASK;
     const int jtype = d_map(type(j));
 
     const F_FLOAT delx1 = xtmp - x(j,0);
@@ -439,7 +437,6 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLCompute<NEIGH
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
       int k = d_neighbors_short(ii,kk);
-      k &= NEIGHMASK;
       const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);
@@ -481,7 +478,6 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLCompute<NEIGH
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
       int k = d_neighbors_short(ii,kk);
-      k &= NEIGHMASK;
       const int ktype = d_map(type(k));
 
       const F_FLOAT delx2 = xtmp - x(k,0);

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.h
@@ -30,20 +30,14 @@ PairStyle(tersoff/zbl/kk/host,PairTersoffZBLKokkos<LMPHostType>);
 namespace LAMMPS_NS {
 
 template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffZBLComputeHalf{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffZBLComputeFullA{};
-
-template<int NEIGHFLAG, int EVFLAG>
-struct TagPairTersoffZBLComputeFullB{};
+struct TagPairTersoffZBLCompute{};
 
 struct TagPairTersoffZBLComputeShortNeigh{};
 
 template<class DeviceType>
 class PairTersoffZBLKokkos : public PairTersoffZBL {
  public:
-  enum {EnabledNeighFlags=FULL};
+  enum {EnabledNeighFlags=HALF|HALFTHREAD};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -52,80 +46,66 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
   PairTersoffZBLKokkos(class LAMMPS *);
   ~PairTersoffZBLKokkos() override;
   void compute(int, int) override;
+  void coeff(int, char **) override;
   void init_style() override;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffZBLComputeHalf<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
+  void operator()(TagPairTersoffZBLCompute<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffZBLComputeHalf<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffZBLComputeFullA<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffZBLComputeFullA<NEIGHFLAG,EVFLAG>, const int&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffZBLComputeFullB<NEIGHFLAG,EVFLAG>, const int&, EV_FLOAT&) const;
-
-  template<int NEIGHFLAG, int EVFLAG>
-  KOKKOS_INLINE_FUNCTION
-  void operator()(TagPairTersoffZBLComputeFullB<NEIGHFLAG,EVFLAG>, const int&) const;
+  void operator()(TagPairTersoffZBLCompute<NEIGHFLAG,EVFLAG>, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPairTersoffZBLComputeShortNeigh, const int&) const;
-  KOKKOS_INLINE_FUNCTION
-  double ters_fc_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfc(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_fc_k(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_fa_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_dfc(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dfa(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double ters_fa_k(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_bij_k(const int &i, const int &j, const int &k, const F_FLOAT &bo) const;
+  double ters_dfa(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dbij(const int &i, const int &j, const int &k, const F_FLOAT &bo) const;
+  double ters_bij_k(const Param& param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  double bondorder(const int &i, const int &j, const int &k,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
+  double ters_dbij(const Param& param, const F_FLOAT &bo) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_gijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
+  double bondorder(const Param& param,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2) const;
 
   KOKKOS_INLINE_FUNCTION
-  double ters_dgijk(const int &i, const int &j, const int &k, const F_FLOAT &cos) const;
+  double ters_gijk(const Param& param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthb(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-        F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
+  double ters_dgijk(const Param& param, const F_FLOAT &cos) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbj(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-        F_FLOAT *fj, F_FLOAT *fk) const;
+  void ters_dthb(const Param& param, const F_FLOAT &prefactor,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+              F_FLOAT *fi, F_FLOAT *fj, F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
-  void ters_dthbk(const int &i, const int &j, const int &k, const F_FLOAT &prefactor,
-        const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
-        const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
-        F_FLOAT *fk) const;
+  void ters_dthbj(const Param& param, const F_FLOAT &prefactor,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+              F_FLOAT *fj, F_FLOAT *fk) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void ters_dthbk(const Param& param, const F_FLOAT &prefactor,
+              const F_FLOAT &rij, const F_FLOAT &dx1, const F_FLOAT &dy1, const F_FLOAT &dz1,
+              const F_FLOAT &rik, const F_FLOAT &dx2, const F_FLOAT &dy2, const F_FLOAT &dz2,
+              F_FLOAT *fk) const;
 
   KOKKOS_INLINE_FUNCTION
   double vec3_dot(const F_FLOAT x[3], const double y[3]) const {
@@ -150,17 +130,6 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
   KOKKOS_INLINE_FUNCTION
   int sbmask(const int& j) const;
 
-  struct params_ters {
-    KOKKOS_INLINE_FUNCTION
-    params_ters() {powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
-          bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;Z_i=0;Z_j=0;ZBLcut=0;ZBLexpscale=0;};
-    KOKKOS_INLINE_FUNCTION
-    params_ters(int /*i*/) {powerm=0;gamma=0;lam3=0;c=0;d=0;h=0;powern=0;beta=0;lam2=0;bigb=0;
-          bigr=0;bigd=0;lam1=0;biga=0;cutsq=0;c1=0;c2=0;c3=0;c4=0;Z_i=0;Z_j=0;ZBLcut=0;ZBLexpscale=0;};
-    F_FLOAT powerm, gamma, lam3, c, d, h, powern, beta, lam2, bigb, bigr,
-      bigd, lam1, biga, cutsq, c1, c2, c3, c4, Z_i, Z_j, ZBLcut, ZBLexpscale;
-  };
-
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void ev_tally(EV_FLOAT &ev, const int &i, const int &j,
@@ -170,28 +139,33 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
   void v_tally3(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
+                F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drij, F_FLOAT *drik) const;
 
   KOKKOS_INLINE_FUNCTION
   void v_tally3_atom(EV_FLOAT &ev, const int &i, const int &j, const int &k,
-    F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
+                F_FLOAT *fj, F_FLOAT *fk, F_FLOAT *drji, F_FLOAT *drjk) const;
 
-  void allocate() override;
   void setup_params() override;
 
   KOKKOS_INLINE_FUNCTION
-  double fermi_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double fermi_k(const Param& param, const F_FLOAT &r) const;
 
   KOKKOS_INLINE_FUNCTION
-  double fermi_d_k(const int &i, const int &j, const int &k, const F_FLOAT &r) const;
+  double fermi_d_k(const Param& param, const F_FLOAT &r) const;
 
  protected:
   typedef Kokkos::DualView<int***,DeviceType> tdual_int_3d;
-  Kokkos::DualView<params_ters***,Kokkos::LayoutRight,DeviceType> k_params;
-  typename Kokkos::DualView<params_ters***,
-    Kokkos::LayoutRight,DeviceType>::t_dev_const_um paramskk;
-  // hardwired to space for 12 atom types
-  //params_ters m_params[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];
+  typedef typename tdual_int_3d::t_dev_const_randomread t_int_3d_randomread;
+  typedef typename tdual_int_3d::t_host t_host_int_3d;
+
+  t_int_3d_randomread d_elem3param;
+  typename AT::t_int_1d_randomread d_map;
+
+  typedef Kokkos::DualView<Param*,DeviceType> tdual_param_1d;
+  typedef typename tdual_param_1d::t_dev t_param_1d;
+  typedef typename tdual_param_1d::t_host t_host_param_1d;
+
+  t_param_1d d_params;
 
   int inum;
   typename AT::t_x_array_randomread x;
@@ -238,7 +212,7 @@ class PairTersoffZBLKokkos : public PairTersoffZBL {
   Kokkos::View<int*,DeviceType> d_numneigh_short;
 
   // ZBL
-  F_FLOAT global_a_0;                // Bohr radius for Coulomb repulsion
+  F_FLOAT global_a_0;              // Bohr radius for Coulomb repulsion
   F_FLOAT global_epsilon_0;        // permittivity of vacuum for Coulomb repulsion
   F_FLOAT global_e;                // proton charge (negative of electron charge)
 

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.h
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.h
@@ -230,11 +230,7 @@ E: Pair tersoff/zbl/kk requires metal or real units
 
 This is a current restriction of this pair potential.
 
-E: Cannot (yet) use full neighbor list style with tersoff/zbl/kk
-
-Self-explanatory.
-
-E: Cannot use chosen neighbor list style with tersoff/zbl/kk
+E: Must use half neighbor list style with pair tersoff/zlb/kk
 
 Self-explanatory.
 

--- a/src/MANYBODY/pair_tersoff.h
+++ b/src/MANYBODY/pair_tersoff.h
@@ -38,7 +38,6 @@ class PairTersoff : public Pair {
 
   static constexpr int NPARAMS_PER_LINE = 17;
 
- protected:
   struct Param {
     double lam1, lam2, lam3;
     double c, d, h;
@@ -56,6 +55,7 @@ class PairTersoff : public Pair {
     double c0;    // added for TersoffMODC
   };
 
+ protected:
   Param *params;      // parameter set for an I-J-K interaction
   double cutmax;      // max cutoff for all elements
   int maxshort;       // size of short neighbor list array


### PR DESCRIPTION
**Summary**

- Fix a bug in Kokkos Tersoff and SW pair styles when using skip lists that led to an out of bounds access
- Fix a bug in Kokkos Tersoff with indexing atom types that led to a segfault

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Evan Weinberg (NVIDIA) @weinbe2 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes