### PR TITLE
Explcitly state that fix nve uses velocity-Verlet integrator

### DIFF
--- a/doc/src/fix_nve.rst
+++ b/doc/src/fix_nve.rst
@@ -35,9 +35,13 @@ consistent with the microcanonical ensemble (NVE) provided there
 are (full) periodic boundary conditions and no other "manipulations"
 of the system (e.g. fixes that modify forces or velocities).
 
+By default, this fix invokes the velocity form of the
+Störmer-Verlet time integration algorithm (velocity-Verlet). Other schemes
+can be invoked using the :doc:`run_style <run_style>` command.
+
 ----------
 
-.. include:: accel_styles.rst
+.. Include:: accel_styles.rst
 
 ----------
 
@@ -57,7 +61,7 @@ Restrictions
 Related commands
 """"""""""""""""
 
-:doc:`fix nvt <fix_nh>`, :doc:`fix npt <fix_nh>`
+:doc:`fix nvt <fix_nh>`, :doc:`fix npt <fix_nh>`, :doc:`run_style <run_style>`
 
 Default
 """""""

--- a/doc/src/fix_nve.rst
+++ b/doc/src/fix_nve.rst
@@ -41,7 +41,7 @@ time integration options can be invoked using the :doc:`run_style <run_style>` c
 
 ----------
 
-.. Include:: accel_styles.rst
+.. include:: accel_styles.rst
 
 ----------
 

--- a/doc/src/fix_nve.rst
+++ b/doc/src/fix_nve.rst
@@ -35,9 +35,9 @@ consistent with the microcanonical ensemble (NVE) provided there
 are (full) periodic boundary conditions and no other "manipulations"
 of the system (e.g. fixes that modify forces or velocities).
 
-By default, this fix invokes the velocity form of the
-Störmer-Verlet time integration algorithm (velocity-Verlet). Other schemes
-can be invoked using the :doc:`run_style <run_style>` command.
+This fix invokes the velocity form of the
+Störmer-Verlet time integration algorithm (velocity-Verlet). Other 
+time integration options can be invoked using the :doc:`run_style <run_style>` command.
 
 ----------
 

--- a/doc/src/run_style.rst
+++ b/doc/src/run_style.rst
@@ -67,7 +67,8 @@ Description
 Choose the style of time integrator used for molecular dynamics
 simulations performed by LAMMPS.
 
-The *verlet* style is a standard velocity-Verlet integrator.
+The *verlet* style is the velocity form of the
+Störmer-Verlet time integration algorithm (velocity-Verlet)
 
 ----------
 


### PR DESCRIPTION
**Summary**

Doc page for `fix nve` provided no information on time integration algorithm.
 
**Related Issue(s)**

Noted by Gary Grest

**Author(s)**

Aidan Thompson, SNL

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

n/a

**Implementation Notes**

Added note to `fix nve` doc page and also `run-style` doc page, even including the umlaut in Störmer-Verlet.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


