### PR TITLE
Fix file reader bug in fix ttm/mod

### DIFF
--- a/doc/src/fix_ttm.rst
+++ b/doc/src/fix_ttm.rst
@@ -214,7 +214,7 @@ generate an error. LAMMPS will check if a "UNITS:" tag is in the first
 line and stop with an error, if there is a mismatch with the current
 units used.
 
-..note::
+.. note::
 
   The electronic temperature at each grid point must be a non-zero
   positive value, both initially, and as the temperature evovles over

--- a/examples/ttm/Si.sw
+++ b/examples/ttm/Si.sw
@@ -1,0 +1,1 @@
+../../potentials/Si.sw

--- a/examples/ttm/Si.ttm_mod
+++ b/examples/ttm/Si.ttm_mod
@@ -1,0 +1,44 @@
+a_0, energy/(temperature*electron) units
+-0.00012899
+a_1, energy/(temperature^2*electron) units
+-0.0000000293276
+a_2, energy/(temperature^3*electron) units
+-0.0000229991
+a_3, energy/(temperature^4*electron) units
+-0.000000927036
+a_4, energy/(temperature^5*electron) units
+-0.0000011747
+C_0, energy/(temperature*electron) units
+0.000129
+A, 1/temperature units
+0.180501
+rho_e, electrons/volume units
+0.05
+D_e, length^2/time units
+20000
+gamma_p, mass/time units
+39.235
+gamma_s, mass/time units
+24.443
+v_0, length/time units
+79.76
+I_0, energy/(time*length^2) units
+0
+lsurface, electron grid units (positive integer)
+0
+rsurface, electron grid units (positive integer)
+1
+l_skin, length units
+1
+tau, time units
+0
+B, dimensionless
+0
+lambda, length units
+0
+n_ion, ions/volume units
+0.05
+surface_movement: 0 to disable tracking of surface motion, 1 to enable
+0
+T_e_min, temperature units
+0

--- a/examples/ttm/in.ttm.mod
+++ b/examples/ttm/in.ttm.mod
@@ -1,0 +1,29 @@
+units           metal
+atom_style      atomic
+boundary        p p p
+
+lattice diamond 5.4309
+region box block 0 10 0 10 0 10
+create_box 1 box
+mass 1 28.0855
+create_atoms 1 box basis 1 1 basis 2 1 basis 3 1 basis 4 1 basis 5 1 basis 6 1 basis 7 1 basis 8 1
+
+pair_style      sw
+pair_coeff      * * Si.sw Si
+
+neighbor        2.0 bin
+neigh_modify    every 5 delay 0 check yes
+
+fix             1 all nve
+fix             twotemp all ttm/mod 1354684 Si.ttm_mod 10 10 10 set 1000.0 # outfile 100 T_out.txt
+
+compute         pe all pe/atom
+compute         ke all ke/atom
+
+timestep        0.0001
+thermo          100
+
+thermo_style    custom step temp etotal f_twotemp[1] f_twotemp[2]
+                thermo_modify format float "%20.16g"
+
+run             1000

--- a/examples/ttm/log.20Apr22.ttm.mod.g++.1
+++ b/examples/ttm/log.20Apr22.ttm.mod.g++.1
@@ -1,0 +1,122 @@
+LAMMPS (24 Mar 2022)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+units           metal
+atom_style      atomic
+boundary        p p p
+
+lattice diamond 5.4309
+Lattice spacing in x,y,z = 5.4309 5.4309 5.4309
+region box block 0 10 0 10 0 10
+create_box 1 box
+Created orthogonal box = (0 0 0) to (54.309 54.309 54.309)
+  1 by 1 by 1 MPI processor grid
+mass 1 28.0855
+create_atoms 1 box basis 1 1 basis 2 1 basis 3 1 basis 4 1 basis 5 1 basis 6 1 basis 7 1 basis 8 1
+Created 8000 atoms
+  using lattice units in orthogonal box = (0 0 0) to (54.309 54.309 54.309)
+  create_atoms CPU = 0.001 seconds
+
+pair_style      sw
+pair_coeff      * * Si.sw Si
+Reading sw potential file Si.sw with DATE: 2007-06-11
+
+neighbor        2.0 bin
+neigh_modify    every 5 delay 0 check yes
+
+fix             1 all nve
+fix             twotemp all ttm/mod 1354684 Si.ttm_mod 10 10 10 set 1000.0 # outfile 100 T_out.txt
+
+compute         pe all pe/atom
+compute         ke all ke/atom
+
+timestep        0.0001
+thermo          100
+
+thermo_style    custom step temp etotal f_twotemp[1] f_twotemp[2]
+                thermo_modify format float "%20.16g"
+
+run             1000
+
+CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE
+
+Your simulation uses code contributions which should be cited:
+
+- fix ttm/mod command:
+
+@article{Pisarev2014,
+author = {Pisarev, V. V. and Starikov, S. V.},
+title = {{Atomistic simulation of ion track formation in UO2.}},
+journal = {J.~Phys.:~Condens.~Matter},
+volume = {26},
+number = {47},
+pages = {475401},
+year = {2014}
+}
+
+@article{Norman2013,
+author = {Norman, G. E. and Starikov, S. V. and Stegailov, V. V. and Saitov, I. M. and Zhilyaev, P. A.},
+title = {{Atomistic Modeling of Warm Dense Matter in the Two-Temperature State}},
+journal = {Contrib.~Plasm.~Phys.},
+number = {2},
+volume = {53},
+pages = {129--139},
+year = {2013}
+}
+
+CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE
+
+Neighbor list info ...
+  update every 5 steps, delay 0 steps, check yes
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 5.77118
+  ghost atom cutoff = 5.77118
+  binsize = 2.88559, bins = 19 19 19
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair sw, perpetual
+      attributes: full, newton on
+      pair build: full/bin/atomonly
+      stencil: full/bin/3d
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 4.433 | 4.433 | 4.433 Mbytes
+   Step          Temp          TotEng      f_twotemp[1]   f_twotemp[2] 
+         0                     0   -34692.79996100604   -52.79390940511979                    0
+       100     2.004897156140836   -34690.27961013186   -55.34997305431884  0.01301140393178354
+       200     2.837118035232607   -34687.74741132015   -57.93445748841878  0.02696025968760173
+       300     4.263087164947482   -34684.98084093686   -60.75945453846786  0.02175636603841567
+       400     5.568003854939066   -34682.25271040963   -63.56896518300501   0.0300061848347275
+       500     6.225602451570786   -34679.49948952029   -66.40897551884576  0.02768827702656702
+       600     7.608847536264781   -34676.69728436362   -69.32060611557266  0.05579466731854093
+       700     9.049471241531297   -34674.00093206036   -72.10055094219446 0.004335980559879027
+       800     9.826796099683211   -34671.27720242751    -74.9501061086213  0.02371649678091513
+       900      11.8609224958918   -34668.35091308811   -77.98544170794551 0.004658649791374929
+      1000     13.88037467640968   -34665.35025858006   -81.16445160194114  0.07684078334464739
+Loop time of 4.85247 on 1 procs for 1000 steps with 8000 atoms
+
+Performance: 1.781 ns/day, 13.479 hours/ns, 206.081 timesteps/s
+99.8% CPU use with 1 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 4.1286     | 4.1286     | 4.1286     |   0.0 | 85.08
+Neigh   | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.030972   | 0.030972   | 0.030972   |   0.0 |  0.64
+Output  | 0.0026351  | 0.0026351  | 0.0026351  |   0.0 |  0.05
+Modify  | 0.67848    | 0.67848    | 0.67848    |   0.0 | 13.98
+Other   |            | 0.01182    |            |       |  0.24
+
+Nlocal:           8000 ave        8000 max        8000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Nghost:           6725 ave        6725 max        6725 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Neighs:              0 ave           0 max           0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+FullNghs:       272000 ave      272000 max      272000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 272000
+Ave neighs/atom = 34
+Neighbor list builds = 0
+Dangerous builds = 0
+Total wall time: 0:00:04

--- a/examples/ttm/log.20Apr22.ttm.mod.g++.4
+++ b/examples/ttm/log.20Apr22.ttm.mod.g++.4
@@ -1,0 +1,122 @@
+LAMMPS (24 Mar 2022)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+units           metal
+atom_style      atomic
+boundary        p p p
+
+lattice diamond 5.4309
+Lattice spacing in x,y,z = 5.4309 5.4309 5.4309
+region box block 0 10 0 10 0 10
+create_box 1 box
+Created orthogonal box = (0 0 0) to (54.309 54.309 54.309)
+  1 by 2 by 2 MPI processor grid
+mass 1 28.0855
+create_atoms 1 box basis 1 1 basis 2 1 basis 3 1 basis 4 1 basis 5 1 basis 6 1 basis 7 1 basis 8 1
+Created 8000 atoms
+  using lattice units in orthogonal box = (0 0 0) to (54.309 54.309 54.309)
+  create_atoms CPU = 0.000 seconds
+
+pair_style      sw
+pair_coeff      * * Si.sw Si
+Reading sw potential file Si.sw with DATE: 2007-06-11
+
+neighbor        2.0 bin
+neigh_modify    every 5 delay 0 check yes
+
+fix             1 all nve
+fix             twotemp all ttm/mod 1354684 Si.ttm_mod 10 10 10 set 1000.0 # outfile 100 T_out.txt
+
+compute         pe all pe/atom
+compute         ke all ke/atom
+
+timestep        0.0001
+thermo          100
+
+thermo_style    custom step temp etotal f_twotemp[1] f_twotemp[2]
+                thermo_modify format float "%20.16g"
+
+run             1000
+
+CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE
+
+Your simulation uses code contributions which should be cited:
+
+- fix ttm/mod command:
+
+@article{Pisarev2014,
+author = {Pisarev, V. V. and Starikov, S. V.},
+title = {{Atomistic simulation of ion track formation in UO2.}},
+journal = {J.~Phys.:~Condens.~Matter},
+volume = {26},
+number = {47},
+pages = {475401},
+year = {2014}
+}
+
+@article{Norman2013,
+author = {Norman, G. E. and Starikov, S. V. and Stegailov, V. V. and Saitov, I. M. and Zhilyaev, P. A.},
+title = {{Atomistic Modeling of Warm Dense Matter in the Two-Temperature State}},
+journal = {Contrib.~Plasm.~Phys.},
+number = {2},
+volume = {53},
+pages = {129--139},
+year = {2013}
+}
+
+CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE
+
+Neighbor list info ...
+  update every 5 steps, delay 0 steps, check yes
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 5.77118
+  ghost atom cutoff = 5.77118
+  binsize = 2.88559, bins = 19 19 19
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair sw, perpetual
+      attributes: full, newton on
+      pair build: full/bin/atomonly
+      stencil: full/bin/3d
+      bin: standard
+Per MPI rank memory allocation (min/avg/max) = 3.436 | 3.436 | 3.436 Mbytes
+   Step          Temp          TotEng      f_twotemp[1]   f_twotemp[2] 
+         0                     0   -34692.79996100361   -52.79390940511979                    0
+       100     1.852689977101411   -34690.49204900486   -55.14271612882062    0.027261886765771
+       200     2.735750477179192   -34688.11139028054   -57.57110998717796  0.03387986355513582
+       300     3.931848271449558   -34685.54667417785   -60.18684521127226  0.02261256315262404
+       400     5.462009198576365   -34682.74455105668   -63.05420336037231 0.002402241637719583
+       500     6.267811692893873   -34679.96493887379   -65.93304222280049  0.02448378880218699
+       600      7.21148216150661   -34677.41455784726   -68.58391420045932  0.04114045759945373
+       700      8.84660534187052   -34674.40610468235   -71.68798344296847   0.0237298402743454
+       800      10.1748456457686   -34671.08749605772   -75.11943618276236 0.007538225788030298
+       900     11.27479036162859    -34668.4118066423   -77.92921692176769  0.02537529314475071
+      1000     13.26881394868076   -34665.56617589539   -80.91544540266329  0.03112665440209921
+Loop time of 1.60214 on 4 procs for 1000 steps with 8000 atoms
+
+Performance: 5.393 ns/day, 4.450 hours/ns, 624.165 timesteps/s
+99.7% CPU use with 4 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 1.0424     | 1.0558     | 1.0696     |   1.0 | 65.90
+Neigh   | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.05072    | 0.063773   | 0.079458   |   4.9 |  3.98
+Output  | 0.0024362  | 0.0024703  | 0.0025297  |   0.1 |  0.15
+Modify  | 0.47018    | 0.47332    | 0.48004    |   0.6 | 29.54
+Other   |            | 0.006786   |            |       |  0.42
+
+Nlocal:           2000 ave        2000 max        2000 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Nghost:           3165 ave        3165 max        3165 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Neighs:              0 ave           0 max           0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+FullNghs:        68000 ave       68000 max       68000 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+Total # of neighbors = 272000
+Ave neighs/atom = 34
+Neighbor list builds = 0
+Dangerous builds = 0
+Total wall time: 0:00:01

--- a/src/EXTRA-FIX/fix_ttm_mod.cpp
+++ b/src/EXTRA-FIX/fix_ttm_mod.cpp
@@ -435,121 +435,146 @@ void FixTTMMod::reset_dt()
 
 void FixTTMMod::read_parameters(const std::string &filename)
 {
-  try {
-    PotentialFileReader reader(lmp, filename, "ttm/mod parameter");
+  if (comm->me == 0) {
 
-    // C0 (metal)
+    try {
+      PotentialFileReader reader(lmp, filename, "ttm/mod parameter");
 
-    reader.next_line();
-    esheat_0 = reader.next_values(1).next_double();
+      // C0 (metal)
 
-    // C1 (metal*10^3)
+      reader.next_line();
+      esheat_0 = reader.next_values(1).next_double();
 
-    reader.next_line();
-    esheat_1 = reader.next_values(1).next_double();
+      // C1 (metal*10^3)
 
-    // C2 (metal*10^6)
+      reader.next_line();
+      esheat_1 = reader.next_values(1).next_double();
 
-    reader.next_line();
-    esheat_2 = reader.next_values(1).next_double();
+      // C2 (metal*10^6)
 
-    // C3 (metal*10^9)
+      reader.next_line();
+      esheat_2 = reader.next_values(1).next_double();
 
-    reader.next_line();
-    esheat_3 = reader.next_values(1).next_double();
+      // C3 (metal*10^9)
 
-    // C4 (metal*10^12)
+      reader.next_line();
+      esheat_3 = reader.next_values(1).next_double();
 
-    reader.next_line();
-    esheat_4 = reader.next_values(1).next_double();
+      // C4 (metal*10^12)
 
-    // C_limit
+      reader.next_line();
+      esheat_4 = reader.next_values(1).next_double();
 
-    reader.next_line();
-    C_limit = reader.next_values(1).next_double();
+      // C_limit
 
-    // Temperature damping factor
+      reader.next_line();
+      C_limit = reader.next_values(1).next_double();
 
-    reader.next_line();
-    T_damp = reader.next_values(1).next_double();
+      // Temperature damping factor
 
-    // rho_e
+      reader.next_line();
+      T_damp = reader.next_values(1).next_double();
 
-    reader.next_line();
-    electronic_density = reader.next_values(1).next_double();
+      // rho_e
 
-    // thermal_diffusion
+      reader.next_line();
+      electronic_density = reader.next_values(1).next_double();
 
-    reader.next_line();
-    el_th_diff = reader.next_values(1).next_double();
+      // thermal_diffusion
 
-    // gamma_p
+      reader.next_line();
+      el_th_diff = reader.next_values(1).next_double();
 
-    reader.next_line();
-    gamma_p = reader.next_values(1).next_double();
+      // gamma_p
 
-    // gamma_s
+      reader.next_line();
+      gamma_p = reader.next_values(1).next_double();
 
-    reader.next_line();
-    gamma_s = reader.next_values(1).next_double();
+      // gamma_s
 
-    // v0
+      reader.next_line();
+      gamma_s = reader.next_values(1).next_double();
 
-    reader.next_line();
-    v_0 = reader.next_values(1).next_double();
+      // v0
 
-    // average intensity of pulse (source of energy) (metal units)
+      reader.next_line();
+      v_0 = reader.next_values(1).next_double();
 
-    reader.next_line();
-    intensity = reader.next_values(1).next_double();
+      // average intensity of pulse (source of energy) (metal units)
 
-    // coordinate of 1st surface in x-direction (in box units) - constant
+      reader.next_line();
+      intensity = reader.next_values(1).next_double();
 
-    reader.next_line();
-    surface_l = reader.next_values(1).next_int();
+      // coordinate of 1st surface in x-direction (in box units) - constant
 
-    // coordinate of 2nd surface in x-direction (in box units) - constant
+      reader.next_line();
+      surface_l = reader.next_values(1).next_int();
 
-    reader.next_line();
-    surface_r = reader.next_values(1).next_int();
+      // coordinate of 2nd surface in x-direction (in box units) - constant
 
-    // skin_layer = intensity is reduced (I=I0*exp[-x/skin_layer])
+      reader.next_line();
+      surface_r = reader.next_values(1).next_int();
 
-    reader.next_line();
-    skin_layer =  reader.next_values(1).next_int();
+      // skin_layer = intensity is reduced (I=I0*exp[-x/skin_layer])
 
-    // width of pulse (picoseconds)
+      reader.next_line();
+      skin_layer =  reader.next_values(1).next_int();
 
-    reader.next_line();
-    width = reader.next_values(1).next_double();
+      // width of pulse (picoseconds)
 
-    // factor of electronic pressure (PF) Pe = PF*Ce*Te
+      reader.next_line();
+      width = reader.next_values(1).next_double();
 
-    reader.next_line();
-    pres_factor = reader.next_values(1).next_double();
+      // factor of electronic pressure (PF) Pe = PF*Ce*Te
 
-    // effective free path of electrons (angstrom)
+      reader.next_line();
+      pres_factor = reader.next_values(1).next_double();
 
-    reader.next_line();
-    free_path = reader.next_values(1).next_double();
+      // effective free path of electrons (angstrom)
 
-    // ionic density (ions*angstrom^{-3})
+      reader.next_line();
+      free_path = reader.next_values(1).next_double();
 
-    reader.next_line();
-    ionic_density = reader.next_values(1).next_double();
+      // ionic density (ions*angstrom^{-3})
 
-    // if movsur = 0: surface is frozen
+      reader.next_line();
+      ionic_density = reader.next_values(1).next_double();
 
-    reader.next_line();
-    movsur = reader.next_values(1).next_int();
+      // if movsur = 0: surface is frozen
 
-    // electron_temperature_min
+      reader.next_line();
+      movsur = reader.next_values(1).next_int();
 
-    reader.next_line();
-    electron_temperature_min = reader.next_values(1).next_double();
-  } catch (std::exception &e) {
-    error->one(FLERR,e.what());
+      // electron_temperature_min
+
+      reader.next_line();
+      electron_temperature_min = reader.next_values(1).next_double();
+    } catch (std::exception &e) {
+      error->one(FLERR,e.what());
+    }
   }
+  MPI_Bcast(&esheat_0, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&esheat_1, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&esheat_2, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&esheat_3, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&esheat_4, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&C_limit, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&T_damp, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&electronic_density, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&el_th_diff, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&gamma_p, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&gamma_s, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&v_0, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&intensity, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&surface_l, 1, MPI_INT, 0, world);
+  MPI_Bcast(&surface_r, 1, MPI_INT, 0, world);
+  MPI_Bcast(&skin_layer, 1, MPI_INT, 0, world);
+  MPI_Bcast(&width, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&pres_factor, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&free_path, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&ionic_density, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&movsur, 1, MPI_INT, 0, world);
+  MPI_Bcast(&electron_temperature_min, 1, MPI_DOUBLE, 0, world);
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

The potential file reader class must only be called on MPI rank 0.
This also adds an example input for fix ttm/mod.

**Related Issue(s)**

Addresses issue reported on MatSci: https://matsci.org/t/parallel-computing-ttm-mod-only-running-with-single-processor/41837

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
