### PR TITLE
change update of dynamic groups to post_force location in timestep

### DIFF
--- a/doc/src/group.rst
+++ b/doc/src/group.rst
@@ -258,11 +258,17 @@ assignment is made at the beginning of the minimization, but not
 during the iterations of the minimizer.
 
 The point in the timestep at which atoms are assigned to a dynamic
-group is after the initial stage of velocity Verlet time integration
-has been performed, and before neighbor lists or forces are computed.
-This is the point in the timestep where atom positions have just
-changed due to the time integration, so the region criterion should be
-accurate, if applied.
+group is after interatomic forces have been computed, but before any
+fixes which alter forces or otherwise update the system have been
+invoked.  This means that atom positions have been updated, neighbor
+lists and ghost atoms are current, and both intermolecular and
+intramolecular forces have been calculated based on the new
+coordinates.  Thus the region criterion, if applied, should be
+accurate.  Also, any computes invoked by an atom-style variable should
+use updated information for that timestep, e.g. potential energy/atom
+or coordination number/atom.  Similarly, fixes or computes which are
+invoked after that point in the timestep, should operate on the new
+group of atoms.
 
 .. note::
 

--- a/src/INTEL/verlet_lrt_intel.cpp
+++ b/src/INTEL/verlet_lrt_intel.cpp
@@ -215,7 +215,7 @@ void VerletLRTIntel::run(int n)
   int n_pre_neighbor = modify->n_pre_neighbor;
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
-  int n_post_force = modify->n_post_force;
+  int n_post_force = modify->n_post_force_any;
   int n_end_of_step = modify->n_end_of_step;
 
   if (atom->sortfreq > 0) sortflag = 1;

--- a/src/KOKKOS/dynamical_matrix_kokkos.cpp
+++ b/src/KOKKOS/dynamical_matrix_kokkos.cpp
@@ -159,7 +159,7 @@ void DynamicalMatrixKokkos::update_force()
 {
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
-  int n_post_force = modify->n_post_force;
+  int n_post_force = modify->n_post_force_any;
 
   lmp->kokkos->auto_sync = 0;
 

--- a/src/KOKKOS/third_order_kokkos.cpp
+++ b/src/KOKKOS/third_order_kokkos.cpp
@@ -160,7 +160,7 @@ void ThirdOrderKokkos::update_force()
 {
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
-  int n_post_force = modify->n_post_force;
+  int n_post_force = modify->n_post_force_any;
 
   lmp->kokkos->auto_sync = 0;
 

--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -271,7 +271,7 @@ void VerletKokkos::run(int n)
   int n_post_neighbor = modify->n_post_neighbor;
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
-  int n_post_force = modify->n_post_force;
+  int n_post_force = modify->n_post_force_any;
   int n_end_of_step = modify->n_end_of_step;
 
   lmp->kokkos->auto_sync = 0;

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -532,7 +532,7 @@ double FixAtomSwap::energy_full()
 
   if (force->kspace) force->kspace->compute(eflag,vflag);
 
-  if (modify->n_post_force) modify->post_force(vflag);
+  if (modify->n_post_force_any) modify->post_force(vflag);
 
   update->eflag_global = update->ntimestep;
   double total_energy = c_pe->compute_scalar();

--- a/src/MC/fix_charge_regulation.cpp
+++ b/src/MC/fix_charge_regulation.cpp
@@ -1129,7 +1129,7 @@ double FixChargeRegulation::energy_full() {
   if (force->kspace) force->kspace->compute(eflag, vflag);
 
   if (modify->n_pre_reverse) modify->pre_reverse(eflag,vflag);
-  if (modify->n_post_force) modify->post_force(vflag);
+  if (modify->n_post_force_any) modify->post_force(vflag);
 
   update->eflag_global = update->ntimestep;
   double total_energy = c_pe->compute_scalar();

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -2316,7 +2316,7 @@ double FixGCMC::energy_full()
   // but Modify::pre_reverse() is needed for INTEL
 
   if (modify->n_pre_reverse) modify->pre_reverse(eflag,vflag);
-  if (modify->n_post_force) modify->post_force(vflag);
+  if (modify->n_post_force_any) modify->post_force(vflag);
 
   // NOTE: all fixes with energy_global_flag set and which
   //   operate at pre_force() or post_force()

--- a/src/MC/fix_mol_swap.cpp
+++ b/src/MC/fix_mol_swap.cpp
@@ -390,7 +390,7 @@ double FixMolSwap::energy_full()
 
   if (force->kspace) force->kspace->compute(eflag,vflag);
 
-  if (modify->n_post_force) modify->post_force(vflag);
+  if (modify->n_post_force_any) modify->post_force(vflag);
 
   update->eflag_global = update->ntimestep;
   double total_energy = c_pe->compute_scalar();

--- a/src/OPENMP/respa_omp.cpp
+++ b/src/OPENMP/respa_omp.cpp
@@ -77,7 +77,7 @@ void RespaOMP::setup(int flag)
         mesg += fmt::format(" {}:{}", ilevel + 1, step[ilevel]);
 
       mesg += "\n  r-RESPA fixes :";
-      for (int l = 0; l < modify->n_post_force_respa; ++l) {
+      for (int l = 0; l < modify->n_post_force_respa_any; ++l) {
         Fix *f = modify->get_fix_by_index(modify->list_post_force_respa[l]);
         if (f->respa_level >= 0)
           mesg += fmt::format(" {}:{}[{}]", MIN(f->respa_level + 1, nlevels), f->style, f->id);
@@ -420,7 +420,7 @@ void RespaOMP::recurse(int ilevel)
       timer->stamp(Timer::COMM);
     }
     timer->stamp();
-    if (modify->n_post_force_respa)
+    if (modify->n_post_force_respa_any)
       modify->post_force_respa(vflag,ilevel,iloop);
     modify->final_integrate_respa(ilevel,iloop);
     timer->stamp(Timer::MODIFY);

--- a/src/PHONON/dynamical_matrix.cpp
+++ b/src/PHONON/dynamical_matrix.cpp
@@ -431,7 +431,7 @@ void DynamicalMatrix::update_force()
   force_clear();
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
-  int n_post_force = modify->n_post_force;
+  int n_post_force = modify->n_post_force_any;
 
   if (n_pre_force) {
     modify->pre_force(vflag);

--- a/src/PHONON/third_order.cpp
+++ b/src/PHONON/third_order.cpp
@@ -487,7 +487,7 @@ void ThirdOrder::update_force()
   neighbor->ago = 0;
   if (modify->get_fix_by_id("package_intel")) neighbor->decide();
   force_clear();
-  int n_post_force = modify->n_post_force;
+  int n_post_force = modify->n_post_force_any;
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
 

--- a/src/REPLICA/verlet_split.cpp
+++ b/src/REPLICA/verlet_split.cpp
@@ -300,7 +300,7 @@ void VerletSplit::run(int n)
   int n_pre_neighbor = modify->n_pre_neighbor;
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
-  int n_post_force = modify->n_post_force;
+  int n_post_force = modify->n_post_force_any;
   int n_end_of_step = modify->n_end_of_step;
 
   if (atom->sortfreq > 0) sortflag = 1;

--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -30,8 +30,6 @@
 
 using namespace LAMMPS_NS;
 
-enum { CLUSTER, MASK, COORDS };
-
 /* ---------------------------------------------------------------------- */
 
 ComputeClusterAtom::ComputeClusterAtom(LAMMPS *lmp, int narg, char **arg) :
@@ -44,7 +42,7 @@ ComputeClusterAtom::ComputeClusterAtom(LAMMPS *lmp, int narg, char **arg) :
 
   peratom_flag = 1;
   size_peratom_cols = 0;
-  comm_forward = 3;
+  comm_forward = 1;
 
   nmax = 0;
 }
@@ -117,22 +115,6 @@ void ComputeClusterAtom::compute_peratom()
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
 
-  // if update->post_integrate set:
-  // a dynamic group in FixGroup is invoking a variable with this compute
-  // thus ghost atom coords need to be up-to-date after initial_integrate()
-
-  if (update->post_integrate) {
-    commflag = COORDS;
-    comm->forward_comm(this);
-  }
-
-  // if group is dynamic, insure ghost atom masks are current
-
-  if (group->dynamic[igroup]) {
-    commflag = MASK;
-    comm->forward_comm(this);
-  }
-
   // every atom starts in its own cluster, with clusterID = atomID
 
   tagint *tag = atom->tag;
@@ -153,7 +135,6 @@ void ComputeClusterAtom::compute_peratom()
   // iterate until no changes in my atoms
   // then check if any proc made changes
 
-  commflag = CLUSTER;
   double **x = atom->x;
 
   int change, done, anychange;
@@ -203,31 +184,15 @@ void ComputeClusterAtom::compute_peratom()
 
 /* ---------------------------------------------------------------------- */
 
-int ComputeClusterAtom::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/,
-                                          int * /*pbc*/)
+int ComputeClusterAtom::pack_forward_comm(int n, int *list, double *buf, 
+                                          int /*pbc_flag*/, int * /*pbc*/)
 {
   int i, j, m;
 
   m = 0;
-  if (commflag == CLUSTER) {
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = clusterID[j];
-    }
-  } else if (commflag == MASK) {
-    int *mask = atom->mask;
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = ubuf(mask[j]).d;
-    }
-  } else if (commflag == COORDS) {
-    double **x = atom->x;
-    for (i = 0; i < n; i++) {
-      j = list[i];
-      buf[m++] = x[j][0];
-      buf[m++] = x[j][1];
-      buf[m++] = x[j][2];
-    }
+  for (i = 0; i < n; i++) {
+    j = list[i];
+    buf[m++] = clusterID[j];
   }
 
   return m;
@@ -241,19 +206,7 @@ void ComputeClusterAtom::unpack_forward_comm(int n, int first, double *buf)
 
   m = 0;
   last = first + n;
-  if (commflag == CLUSTER) {
-    for (i = first; i < last; i++) clusterID[i] = buf[m++];
-  } else if (commflag == MASK) {
-    int *mask = atom->mask;
-    for (i = first; i < last; i++) mask[i] = (int) ubuf(buf[m++]).i;
-  } else if (commflag == COORDS) {
-    double **x = atom->x;
-    for (i = first; i < last; i++) {
-      x[i][0] = buf[m++];
-      x[i][1] = buf[m++];
-      x[i][2] = buf[m++];
-    }
-  }
+  for (i = first; i < last; i++) clusterID[i] = buf[m++];
 }
 
 /* ----------------------------------------------------------------------

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -259,14 +259,16 @@ void ComputeCoordAtom::compute_peratom()
             j = jlist[jj];
             j &= NEIGHMASK;
 
-            jtype = type[j];
-            delx = xtmp - x[j][0];
-            dely = ytmp - x[j][1];
-            delz = ztmp - x[j][2];
-            rsq = delx * delx + dely * dely + delz * delz;
-            if (rsq < cutsq) {
-              for (m = 0; m < ncol; m++)
-                if (jtype >= typelo[m] && jtype <= typehi[m]) count[m] += 1.0;
+            if (mask[j] & jgroupbit) {
+              jtype = type[j];
+              delx = xtmp - x[j][0];
+              dely = ytmp - x[j][1];
+              delz = ztmp - x[j][2];
+              rsq = delx * delx + dely * dely + delz * delz;
+              if (rsq < cutsq) {
+                for (m = 0; m < ncol; m++)
+                  if (jtype >= typelo[m] && jtype <= typehi[m]) count[m] += 1.0;
+              }
             }
           }
         }
@@ -309,8 +311,8 @@ void ComputeCoordAtom::compute_peratom()
 
 /* ---------------------------------------------------------------------- */
 
-int ComputeCoordAtom::pack_forward_comm(int n, int *list, double *buf, int /*pbc_flag*/,
-                                        int * /*pbc*/)
+int ComputeCoordAtom::pack_forward_comm(int n, int *list, double *buf, 
+                                        int /*pbc_flag*/, int * /*pbc*/)
 {
   int i, m = 0, j;
   for (i = 0; i < n; ++i) {

--- a/src/fix_group.cpp
+++ b/src/fix_group.cpp
@@ -181,9 +181,11 @@ void FixGroup::set_group()
   int nlocal = atom->nlocal;
 
   // invoke atom-style variable if defined
-  // this is for any compute to check if it needs to
-  //   operate differently due to invocation this early in timestep
-  // e.g. perform ghost comm update due to atoms having just moved
+  // NOTE: after variable invocation could reset invoked computes to not-invoked
+  //   this would avoid an issue where other post-force fixes 
+  //   change the compute result since it will not be re-invoked at end-of-step,
+  //   e.g. if compute pe/atom includes pe contributions from fixes
+
 
   double *var = nullptr;
   int *ivector = nullptr;

--- a/src/fix_group.cpp
+++ b/src/fix_group.cpp
@@ -44,6 +44,8 @@ idregion(nullptr), idvar(nullptr), idprop(nullptr)
   gbit = group->bitmask[group->find(dgroupid)];
   gbitinverse = group->inversemask[group->find(dgroupid)];
 
+  comm_forward = 1;
+
   // process optional args
 
   regionflag = 0;
@@ -106,8 +108,6 @@ FixGroup::~FixGroup()
 int FixGroup::setmask()
 {
   int mask = 0;
-  mask |= POST_INTEGRATE;
-  mask |= POST_INTEGRATE_RESPA;
   return mask;
 }
 
@@ -147,29 +147,6 @@ void FixGroup::init()
     if (iprop < 0 || cols)
       error->all(FLERR,"Group dynamic command custom property vector does not exist");
   }
-
-  // warn if any FixGroup is not at tail end of all post_integrate fixes
-
-  Fix **fix = modify->fix;
-  int *fmask = modify->fmask;
-  int nfix = modify->nfix;
-
-  int n = 0;
-  for (int i = 0; i < nfix; i++) if (POST_INTEGRATE & fmask[i]) n++;
-  int warn = 0;
-  for (int i = 0; i < nfix; i++) {
-    if (POST_INTEGRATE & fmask[i]) {
-      for (int j = i+1; j < nfix; j++) {
-        if (POST_INTEGRATE & fmask[j]) {
-          if (strstr(fix[j]->id,"GROUP_") != fix[j]->id) warn = 1;
-        }
-      }
-    }
-  }
-
-  if (warn && comm->me == 0)
-    error->warning(FLERR,"One or more dynamic groups may not be "
-                   "updated at correct point in timestep");
 }
 
 /* ----------------------------------------------------------------------
@@ -183,7 +160,7 @@ void FixGroup::setup(int /*vflag*/)
 
 /* ---------------------------------------------------------------------- */
 
-void FixGroup::post_integrate()
+void FixGroup::post_force(int /*vflag*/)
 {
   // only assign atoms to group on steps that are multiples of nevery
 
@@ -192,9 +169,9 @@ void FixGroup::post_integrate()
 
 /* ---------------------------------------------------------------------- */
 
-void FixGroup::post_integrate_respa(int ilevel, int /*iloop*/)
+void FixGroup::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
-  if (ilevel == nlevels_respa-1) post_integrate();
+  if (ilevel == nlevels_respa-1) post_force(vflag);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -204,7 +181,6 @@ void FixGroup::set_group()
   int nlocal = atom->nlocal;
 
   // invoke atom-style variable if defined
-  // set post_integrate flag to 1, then unset after
   // this is for any compute to check if it needs to
   //   operate differently due to invocation this early in timestep
   // e.g. perform ghost comm update due to atoms having just moved
@@ -214,12 +190,10 @@ void FixGroup::set_group()
   double *dvector = nullptr;
 
   if (varflag) {
-    update->post_integrate = 1;
     modify->clearstep_compute();
-    memory->create(var,nlocal,"fix/group:varvalue");
+    memory->create(var,nlocal,"fix/group:var");
     input->variable->compute_atom(ivar,igroup,var,1,0);
     modify->addstep_compute(update->ntimestep + nevery);
-    update->post_integrate = 0;
   }
 
   // set ptr to custom atom vector
@@ -233,8 +207,6 @@ void FixGroup::set_group()
 
   // set mask for each atom
   // only in group if in parent group, in region, variable is non-zero
-  // if compute, fix, etc needs updated masks of ghost atoms,
-  // it must do forward_comm() to update them
 
   double **x = atom->x;
   int *mask = atom->mask;
@@ -256,6 +228,42 @@ void FixGroup::set_group()
   }
 
   if (varflag) memory->destroy(var);
+
+  // insure ghost atom masks are also updated
+
+  comm->forward_comm(this);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixGroup::pack_forward_comm(int n, int *list, double *buf, 
+                                int /*pbc_flag*/, int * /*pbc*/)
+{
+  int i, j, m;
+
+  int *mask = atom->mask;
+
+  m = 0;
+  for (i = 0; i < n; i++) {
+    j = list[i];
+    buf[m++] = ubuf(mask[j]).d;
+  }
+
+  return m;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixGroup::unpack_forward_comm(int n, int first, double *buf)
+{
+  int i, m, last;
+
+  m = 0;
+  last = first + n;
+ 
+  int *mask = atom->mask;
+  
+  for (i = first; i < last; i++) mask[i] = (int) ubuf(buf[m++]).i;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix_group.cpp
+++ b/src/fix_group.cpp
@@ -186,7 +186,6 @@ void FixGroup::set_group()
   //   change the compute result since it will not be re-invoked at end-of-step,
   //   e.g. if compute pe/atom includes pe contributions from fixes
 
-
   double *var = nullptr;
   int *ivector = nullptr;
   double *dvector = nullptr;

--- a/src/fix_group.h
+++ b/src/fix_group.h
@@ -31,8 +31,10 @@ class FixGroup : public Fix {
   int setmask() override;
   void init() override;
   void setup(int) override;
-  void post_integrate() override;
-  void post_integrate_respa(int, int) override;
+  void post_force(int) override;
+  void post_force_respa(int, int, int) override;
+  int pack_forward_comm(int, int *, double *, int, int *) override;
+  void unpack_forward_comm(int, int, double *) override;
   void *extract(const char *, int &) override;
 
  private:

--- a/src/modify.h
+++ b/src/modify.h
@@ -33,11 +33,11 @@ class Modify : protected Pointers {
  public:
   int n_initial_integrate, n_post_integrate, n_pre_exchange;
   int n_pre_neighbor, n_post_neighbor;
-  int n_pre_force, n_pre_reverse, n_post_force;
+  int n_pre_force, n_pre_reverse, n_post_force_any;
   int n_final_integrate, n_end_of_step;
   int n_energy_couple, n_energy_global, n_energy_atom;
   int n_initial_integrate_respa, n_post_integrate_respa;
-  int n_pre_force_respa, n_post_force_respa, n_final_integrate_respa;
+  int n_pre_force_respa, n_post_force_respa_any, n_final_integrate_respa;
   int n_min_pre_exchange, n_min_pre_neighbor, n_min_post_neighbor;
   int n_min_pre_force, n_min_pre_reverse, n_min_post_force, n_min_energy;
 
@@ -147,11 +147,16 @@ class Modify : protected Pointers {
   double memory_usage();
 
  protected:
+  // internal fix counts
+
+  int n_post_force, n_post_force_group, n_post_force_respa;
+
   // lists of fixes to apply at different stages of timestep
 
   int *list_initial_integrate, *list_post_integrate;
   int *list_pre_exchange, *list_pre_neighbor, *list_post_neighbor;
-  int *list_pre_force, *list_pre_reverse, *list_post_force;
+  int *list_pre_force, *list_pre_reverse;
+  int *list_post_force, *list_post_force_group;
   int *list_final_integrate, *list_end_of_step;
   int *list_energy_couple, *list_energy_global, *list_energy_atom;
   int *list_initial_integrate_respa, *list_post_integrate_respa;
@@ -162,9 +167,6 @@ class Modify : protected Pointers {
   int *list_min_energy;
 
   int *end_of_step_every;
-
-  int n_post_force_group;      // list of fix GROUPs for post_force invocation
-  int *list_post_force_group;
 
   int n_timeflag;    // list of computes that store time invocation
   int *list_timeflag;

--- a/src/modify.h
+++ b/src/modify.h
@@ -163,6 +163,9 @@ class Modify : protected Pointers {
 
   int *end_of_step_every;
 
+  int n_post_force_group;      // list of fix GROUPs for post_force invocation
+  int *list_post_force_group;
+
   int n_timeflag;    // list of computes that store time invocation
   int *list_timeflag;
 
@@ -187,6 +190,8 @@ class Modify : protected Pointers {
   void list_init_energy_couple(int &, int *&);
   void list_init_energy_global(int &, int *&);
   void list_init_energy_atom(int &, int *&);
+  void list_init_post_force_group(int &, int *&);
+  void list_init_post_force_respa_group(int &, int *&);
   void list_init_dofflag(int &, int *&);
   void list_init_compute();
 

--- a/src/respa.cpp
+++ b/src/respa.cpp
@@ -372,7 +372,7 @@ void Respa::setup(int flag)
         mesg += fmt::format(" {}:{}", ilevel + 1, step[ilevel]);
 
       mesg += "\n  r-RESPA fixes :";
-      for (int l = 0; l < modify->n_post_force_respa; ++l) {
+      for (int l = 0; l < modify->n_post_force_respa_any; ++l) {
         Fix *f = modify->get_fix_by_index(modify->list_post_force_respa[l]);
         if (f->respa_level >= 0)
           mesg += fmt::format(" {}:{}[{}]", MIN(f->respa_level + 1, nlevels), f->style, f->id);
@@ -704,7 +704,8 @@ void Respa::recurse(int ilevel)
       timer->stamp(Timer::COMM);
     }
     timer->stamp();
-    if (modify->n_post_force_respa) modify->post_force_respa(vflag, ilevel, iloop);
+    if (modify->n_post_force_respa_any) 
+      modify->post_force_respa(vflag, ilevel, iloop);
     modify->final_integrate_respa(ilevel, iloop);
     timer->stamp(Timer::MODIFY);
   }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -60,7 +60,6 @@ Update::Update(LAMMPS *lmp) : Pointers(lmp)
   beginstep = endstep = 0;
   restrict_output = 0;
   setupflag = 0;
-  post_integrate = 0;
   multireplica = 0;
 
   eflag_global = vflag_global = -1;

--- a/src/update.h
+++ b/src/update.h
@@ -35,7 +35,6 @@ class Update : protected Pointers {
   int max_eval;                  // max force evaluations for minimizer
   int restrict_output;           // 1 if output should not write dump/restart
   int setupflag;                 // set when setup() is computing forces
-  int post_integrate;            // 1 if now at post_integrate() in timestep
   int multireplica;              // 1 if min across replicas, else 0
   int dt_default;                // 1 if dt is at default value, else 0
 

--- a/src/verlet.cpp
+++ b/src/verlet.cpp
@@ -237,7 +237,7 @@ void Verlet::run(int n)
   int n_post_neighbor = modify->n_post_neighbor;
   int n_pre_force = modify->n_pre_force;
   int n_pre_reverse = modify->n_pre_reverse;
-  int n_post_force = modify->n_post_force;
+  int n_post_force_any = modify->n_post_force_any;
   int n_end_of_step = modify->n_end_of_step;
 
   if (atom->sortfreq > 0) sortflag = 1;
@@ -344,7 +344,7 @@ void Verlet::run(int n)
 
     // force modifications, final time integration, diagnostics
 
-    if (n_post_force) modify->post_force(vflag);
+    if (n_post_force_any) modify->post_force(vflag);
     modify->final_integrate();
     if (n_end_of_step) modify->end_of_step();
     timer->stamp(Timer::MODIFY);


### PR DESCRIPTION
**Summary**

For dynamic groups, change the point in the timestep where they are updated.  Previously this was post_intergrate().
Now it is post_force() and before any user-specified fixes which operate at post_force() are invoked.  This simplifies several issues:

(1) use of computes for the dynamic criterion which required ghost atom positions, e.g. compute cluster/atom and other similar computes.  This information is now current w/out the need to any extra communication.  Likewise a compute that uses pe/atom
or virial/atom can be used as a criterion, since pair styles have now been communicated.  There is also no longer an issue with the compute being invoked so early in the timestep that it's info is out-of-date by the end of the timestep.

**Related Issue(s)**

This solves the problem addressed by PR #3018, but in a simpler fashion and thus closes #3018

**Author(s)**

Steve, with an assist from Davie Quigley (U Warwick)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Don't think this will change the behavior of dynamic groups, unless they were invoking computes which should now work correctly.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


