### PR TITLE
Add utility to print url with link to error message in online manual

### DIFF
--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -211,6 +211,9 @@ Convenience functions
 .. doxygenfunction:: logmesg(LAMMPS *lmp, const std::string &mesg)
    :project: progguide
 
+.. doxygenfunction:: errorurl
+   :project: progguide
+
 .. doxygenfunction:: flush_buffers(LAMMPS *lmp)
    :project: progguide
 

--- a/doc/src/Errors.rst
+++ b/doc/src/Errors.rst
@@ -11,6 +11,7 @@ them.
    :maxdepth: 1
 
    Errors_common
+   Errors_details
    Errors_bugs
    Errors_debug
    Errors_messages

--- a/doc/src/Errors_details.rst
+++ b/doc/src/Errors_details.rst
@@ -1,0 +1,27 @@
+Detailed discussion of errors and warnings
+==========================================
+
+Many errors or warnings are self-explanatory and thus straightforward to
+resolve.  However, there are also cases, where there is no single cause
+and explanation, where LAMMPS can only detect symptoms of an error but
+not the exact cause, or where the explanation needs to be more detailed than
+what can be fit into a message printed by the program.  The following are
+discussions of such cases.
+
+.. _err0001:
+
+Unknown identifier in data file
+-------------------------------
+
+This error happens when LAMMPS encounters a line of text in an unexpected format
+while reading a data file. This is most commonly cause by inconsistent header and
+section data.  The header section informs LAMMPS how many entries or lines are expected in the
+various sections (like Atoms, Masses, Pair Coeffs, *etc.*\ ) of the data file.
+If there is a mismatch, LAMMPS will either keep reading beyond the end of a section
+or stop reading before the section has ended.
+
+Such a mismatch can happen unexpectedly when the first line of the data
+is *not* a comment as required by the format.  That would result in
+LAMMPS expecting, for instance, 0 atoms because the "atoms" header line
+is treated as a comment.
+

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -744,9 +744,9 @@ void ReadData::command(int narg, char **arg)
             break;
           }
         if (i == nfix)
-          error->all(FLERR,"Unknown identifier in data file: {}",keyword);
+          error->all(FLERR,"Unknown identifier in data file: {}{}", keyword, utils::errorurl(1));
 
-      } else error->all(FLERR,"Unknown identifier in data file: {}",keyword);
+      } else error->all(FLERR,"Unknown identifier in data file: {}{}", keyword, utils::errorurl(1));
 
       parse_keyword(0);
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -139,9 +139,7 @@ void utils::fmtargs_logmesg(LAMMPS *lmp, fmt::string_view format, fmt::format_ar
 
 std::string utils::errorurl(int errorcode)
 {
-  return fmt::format(
-      "\nFor more information please go to https://docs.lammps.org/Errors_details.html#err{:04d}",
-      errorcode);
+  return fmt::format("\nFor more information see https://docs.lammps.org/err{:04d}", errorcode);
 }
 
 void utils::flush_buffers(LAMMPS *lmp)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -22,8 +22,8 @@
 #include "memory.h"
 #include "modify.h"
 #include "text_file_reader.h"
-#include "update.h"
 #include "universe.h"
+#include "update.h"
 
 #include <cctype>
 #include <cerrno>
@@ -137,11 +137,18 @@ void utils::fmtargs_logmesg(LAMMPS *lmp, fmt::string_view format, fmt::format_ar
   }
 }
 
+std::string utils::errorurl(int errorcode)
+{
+  return fmt::format(
+      "\nFor more information please go to https://docs.lammps.org/Errors_details.html#err{:04d}",
+      errorcode);
+}
+
 void utils::flush_buffers(LAMMPS *lmp)
 {
   if (lmp->screen) fflush(lmp->screen);
   if (lmp->logfile) fflush(lmp->logfile);
-  if (lmp->universe->uscreen)  fflush(lmp->universe->uscreen);
+  if (lmp->universe->uscreen) fflush(lmp->universe->uscreen);
   if (lmp->universe->ulogfile) fflush(lmp->universe->ulogfile);
 }
 
@@ -805,7 +812,7 @@ std::string utils::star_subst(const std::string &name, bigint step, int pad)
   auto star = name.find('*');
   if (star == std::string::npos) return name;
 
-  return fmt::format("{}{:0{}}{}",name.substr(0,star),step,pad,name.substr(star+1));
+  return fmt::format("{}{:0{}}{}", name.substr(0, star), step, pad, name.substr(star + 1));
 }
 
 /* ----------------------------------------------------------------------

--- a/src/utils.h
+++ b/src/utils.h
@@ -21,7 +21,7 @@
 
 #include <mpi.h>
 
-#include <vector> // IWYU pragma: export
+#include <vector>    // IWYU pragma: export
 
 namespace LAMMPS_NS {
 
@@ -73,6 +73,18 @@ namespace utils {
    *  \param mesg   string with message to be printed */
 
   void logmesg(LAMMPS *lmp, const std::string &mesg);
+
+  /*! Return text redirecting the user to a specific paragraph in the manual
+   *
+   * The LAMMPS manual contains detailed detailed explanations for errors and
+   * warnings where a simple error message may not be sufficient.  These can
+   * be reached through URLs with a numeric code.  This function creates the
+   * corresponding text to be included into the error message that redirects
+   * the user to that URL.
+   *
+   *  \param errorcode   number pointing to a paragraph in the manual */
+
+  std::string errorurl(int errorcode);
 
   /*! Flush output buffers
    *


### PR DESCRIPTION
**Summary**

This PR implements a new utility function that constructs a message pointing to a unique link to the manual.
The link is indexed by a message ID (a number) and thus should be a permanent link.
It also demonstrates how to use this for the `read_data` command and provides a new target file with a suitable explanatory paragraph for the error message at hand.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
