### PR TITLE
Fix the doc for fix/accelerate/cos

### DIFF
--- a/doc/src/compute_viscosity_cos.rst
+++ b/doc/src/compute_viscosity_cos.rst
@@ -21,12 +21,13 @@ Examples
 
 .. code-block:: LAMMPS
 
+   units    real
    compute  cos all viscosity/cos
    variable V equal c_cos[7]
-   variable A equal 0.02E-5
+   variable A equal 0.02E-5  # A/fs^2
    variable density equal density
    variable lz equal lz
-   variable reciprocalViscosity equal v_V/${A}/v_density*39.4784/v_lz/v_lz*100
+   variable reciprocalViscosity equal v_V/${A}/v_density*39.4784/v_lz/v_lz*100  # 1/(Pa*s)
 
 Description
 """""""""""

--- a/doc/src/fix_accelerate_cos.rst
+++ b/doc/src/fix_accelerate_cos.rst
@@ -13,7 +13,7 @@ Syntax
 
 * ID, group-ID are documented in :doc:`fix <fix>` command
 * accelerate/cos = style name of this fix command
-* value = amplitude of acceleration (in unit of force/mass)
+* value = amplitude of acceleration (in unit of velocity/time)
 
 
 Examples


### PR DESCRIPTION
**Summary**

This pull request fixes a mistake in the doc for _fix/accelerate/cos_.
In the doc, it says that the acceleration is in the unit of force/mass, while it's actually velocity/time. 
That is, for units real, the acceleration is in _Angstrom/fs^2_, instead of _kCal/mol/Angstrom/dalton_.

**Related Issue(s)**

None

**Author(s)**

Zheng Gong (z.gong@outlook.com)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



