### PR TITLE
add support for wildcards in variable vectors

### DIFF
--- a/doc/src/fix_ave_correlate.rst
+++ b/doc/src/fix_ave_correlate.rst
@@ -25,7 +25,7 @@ Syntax
        f_ID = global scalar calculated by a fix with ID
        f_ID[I] = Ith component of global vector calculated by a fix with ID, I can include wildcard (see below)
        v_name = global value calculated by an equal-style variable with name
-       v_name[I] = Ith component of a vector-style variable with name
+       v_name[I] = Ith component of a vector-style variable with name, I can include wildcard (see below)
 
 * zero or more keyword/arg pairs may be appended
 * keyword = *type* or *ave* or *start* or *prefactor* or *file* or *overwrite* or *title1* or *title2* or *title3*
@@ -105,15 +105,17 @@ individual fixes for info on which ones produce such values.
 ones that can be used with this fix.  Variables of style *atom* cannot
 be used, since they produce per-atom values.
 
-Note that for values from a compute or fix, the bracketed index I can
-be specified using a wildcard asterisk with the index to effectively
-specify multiple values.  This takes the form "\*" or "\*n" or "n\*" or
-"m\*n".  If N = the size of the vector (for *mode* = scalar) or the
-number of columns in the array (for *mode* = vector), then an asterisk
-with no numeric values means all indices from 1 to N.  A leading
-asterisk means all indices from 1 to n (inclusive).  A trailing
-asterisk means all indices from n to N (inclusive).  A middle asterisk
-means all indices from m to n (inclusive).
+----------
+
+For input values from a compute or fix or variable , the bracketed
+index I can be specified using a wildcard asterisk with the index to
+effectively specify multiple values.  This takes the form "\*" or
+"\*n" or "n\*" or "m\*n".  If N = the size of the vector (for *mode* =
+scalar) or the number of columns in the array (for *mode* = vector),
+then an asterisk with no numeric values means all indices from 1 to N.
+A leading asterisk means all indices from 1 to n (inclusive).  A
+trailing asterisk means all indices from n to N (inclusive).  A middle
+asterisk means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual elements of the
 vector had been listed one by one.  E.g. these 2 fix ave/correlate
@@ -127,6 +129,14 @@ values.
    fix 1 all ave/correlate 1 50 10000 &
              c_myPress[1] c_myPress[2] c_myPress[3] &
              c_myPress[4] c_myPress[5] c_myPress[6]
+
+.. note::
+
+   For a vector-style variable, only the wildcard forms "\*n" or
+   "m\*n" are allowed.  You must specify the upper bound, because
+   vector-style variable lengths are not determined until the variable
+   is evaluated.  If n is specified larger than the vector length
+   turns out to be, zeroes are output for missing vector values.
 
 ----------
 

--- a/doc/src/fix_ave_correlate.rst
+++ b/doc/src/fix_ave_correlate.rst
@@ -110,17 +110,16 @@ be used, since they produce per-atom values.
 For input values from a compute or fix or variable , the bracketed
 index I can be specified using a wildcard asterisk with the index to
 effectively specify multiple values.  This takes the form "\*" or
-"\*n" or "n\*" or "m\*n".  If N = the size of the vector (for *mode* =
-scalar) or the number of columns in the array (for *mode* = vector),
-then an asterisk with no numeric values means all indices from 1 to N.
-A leading asterisk means all indices from 1 to n (inclusive).  A
+"\*n" or "n\*" or "m\*n".  If N = the size of the vector, then an
+asterisk with no numeric values means all indices from 1 to N.  A
+leading asterisk means all indices from 1 to n (inclusive).  A
 trailing asterisk means all indices from n to N (inclusive).  A middle
 asterisk means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual elements of the
 vector had been listed one by one.  E.g. these 2 fix ave/correlate
-commands are equivalent, since the :doc:`compute pressure <compute_pressure>` command creates a global vector with 6
-values.
+commands are equivalent, since the :doc:`compute pressure
+<compute_pressure>` command creates a global vector with 6 values.
 
 .. code-block:: LAMMPS
 

--- a/doc/src/fix_ave_histo.rst
+++ b/doc/src/fix_ave_histo.rst
@@ -144,8 +144,9 @@ asterisk means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual elements of the
 vector or columns of the array had been listed one by one.  E.g. these
-2 fix ave/histo commands are equivalent, since the :doc:`compute com/chunk <compute_com_chunk>` command creates a global array with
-3 columns:
+2 fix ave/histo commands are equivalent, since the :doc:`compute
+com/chunk <compute_com_chunk>` command creates a global array with 3
+columns:
 
 .. code-block:: LAMMPS
 
@@ -158,9 +159,8 @@ vector or columns of the array had been listed one by one.  E.g. these
    For a vector-style variable, only the wildcard forms "\*n" or
    "m\*n" are allowed.  You must specify the upper bound, because
    vector-style variable lengths are not determined until the variable
-   is evaluated.  If n is specified larger than the vector length"\*n"
-   or "n\*" or "m\*n".  turns out to be, zeroes are output for missing
-   vector values.
+   is evaluated.  If n is specified larger than the vector length
+   turns out to be, zeroes are output for missing vector values.
 
 ----------
 

--- a/doc/src/fix_ave_histo.rst
+++ b/doc/src/fix_ave_histo.rst
@@ -32,7 +32,7 @@ Syntax
        f_ID = scalar or vector calculated by a fix with ID
        f_ID[I] = Ith component of vector or Ith column of array calculated by a fix with ID, I can include wildcard (see below)
        v_name = value(s) calculated by an equal-style or vector-style or atom-style variable with name
-       v_name[I] = value calculated by a vector-style variable with name
+       v_name[I] = value calculated by a vector-style variable with name, I can include wildcard (see below)
 
 * zero or more keyword/arg pairs may be appended
 * keyword = *mode* or *file* or *ave* or *start* or *beyond* or *overwrite* or *title1* or *title2* or *title3*
@@ -120,15 +120,27 @@ If *mode* = vector, then the input values must be vectors, or arrays
 with a bracketed term appended, indicating the Ith column of the array
 is used.
 
-Note that for values from a compute or fix, the bracketed index I can
-be specified using a wildcard asterisk with the index to effectively
-specify multiple values.  This takes the form "\*" or "\*n" or "n\*" or
-"m\*n".  If N = the size of the vector (for *mode* = scalar) or the
-number of columns in the array (for *mode* = vector), then an asterisk
-with no numeric values means all indices from 1 to N.  A leading
-asterisk means all indices from 1 to n (inclusive).  A trailing
-asterisk means all indices from n to N (inclusive).  A middle asterisk
-means all indices from m to n (inclusive).
+If the fix ave/histo/weight command is used, exactly two values must
+be specified.  If the values are vectors, they must be the same
+length.  The first value (a scalar or vector) is what is histogrammed
+into bins, in the same manner the fix ave/histo command operates.  The
+second value (a scalar or vector) is used as a "weight".  This means
+that instead of each value tallying a "1" to its bin, the
+corresponding weight is tallied.  E.g. The Nth entry (weight) in the
+second vector is tallied to the bin corresponding to the Nth entry in
+the first vector.
+
+----------
+
+For input values from a compute or fix or variable, the bracketed
+index I can be specified using a wildcard asterisk with the index to
+effectively specify multiple values.  This takes the form "\*" or
+"\*n" or "n\*" or "m\*n".  If N = the size of the vector (for *mode* =
+scalar) or the number of columns in the array (for *mode* = vector),
+then an asterisk with no numeric values means all indices from 1 to N.
+A leading asterisk means all indices from 1 to n (inclusive).  A
+trailing asterisk means all indices from n to N (inclusive).  A middle
+asterisk means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual elements of the
 vector or columns of the array had been listed one by one.  E.g. these
@@ -141,15 +153,14 @@ vector or columns of the array had been listed one by one.  E.g. these
    fix 1 all ave/histo 100 1 100 -10.0 10.0 100 c_myCOM[*] file tmp1.com mode vector
    fix 2 all ave/histo 100 1 100 -10.0 10.0 100 c_myCOM[1] c_myCOM[2] c_myCOM[3] file tmp2.com mode vector
 
-If the fix ave/histo/weight command is used, exactly two values must
-be specified.  If the values are vectors, they must be the same
-length.  The first value (a scalar or vector) is what is histogrammed
-into bins, in the same manner the fix ave/histo command operates.  The
-second value (a scalar or vector) is used as a "weight".  This means
-that instead of each value tallying a "1" to its bin, the
-corresponding weight is tallied.  E.g. The Nth entry (weight) in the
-second vector is tallied to the bin corresponding to the Nth entry in
-the first vector.
+.. note::
+
+   For a vector-style variable, only the wildcard forms "\*n" or
+   "m\*n" are allowed.  You must specify the upper bound, because
+   vector-style variable lengths are not determined until the variable
+   is evaluated.  If n is specified larger than the vector length"\*n"
+   or "n\*" or "m\*n".  turns out to be, zeroes are output for missing
+   vector values.
 
 ----------
 

--- a/doc/src/fix_ave_time.rst
+++ b/doc/src/fix_ave_time.rst
@@ -127,8 +127,9 @@ asterisk means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual elements of the
 vector or columns of the array had been listed one by one.  E.g. these
-2 fix ave/time commands are equivalent, since the :doc:`compute rdf <compute_rdf>` command creates, in this case, a global array
-with 3 columns, each of length 50:
+2 fix ave/time commands are equivalent, since the :doc:`compute rdf
+<compute_rdf>` command creates, in this case, a global array with 3
+columns, each of length 50:
 
 .. code-block:: LAMMPS
 
@@ -141,9 +142,8 @@ with 3 columns, each of length 50:
    For a vector-style variable, only the wildcard forms "\*n" or
    "m\*n" are allowed.  You must specify the upper bound, because
    vector-style variable lengths are not determined until the variable
-   is evaluated.  If n is specified larger than the vector length"\*n"
-   or "n\*" or "m\*n".  turns out to be, zeroes are output for missing
-   vector values.
+   is evaluated.  If n is specified larger than the vector length
+   turns out to be, zeroes are output for missing vector values.
 
 ----------
 
@@ -180,9 +180,12 @@ asterisk to effectively specify multiple values.
 Note that there is a :doc:`compute reduce <compute_reduce>` command
 which can sum per-atom quantities into a global scalar or vector which
 can thus be accessed by fix ave/time.  Or it can be a compute defined
-not in your input script, but by :doc:`thermodynamic output <thermo_style>` or other fixes such as :doc:`fix nvt <fix_nh>` or :doc:`fix temp/rescale <fix_temp_rescale>`.  See
-the doc pages for these commands which give the IDs of these computes.
-Users can also write code for their own compute styles and :doc:`add them to LAMMPS <Modify>`.
+not in your input script, but by :doc:`thermodynamic output
+<thermo_style>` or other fixes such as :doc:`fix nvt <fix_nh>` or
+:doc:`fix temp/rescale <fix_temp_rescale>`.  See the doc pages for
+these commands which give the IDs of these computes.  Users can also
+write code for their own compute styles and :doc:`add them to LAMMPS
+<Modify>`.
 
 If a value begins with "f\_", a fix ID must follow which has been
 previously defined in the input script.  If *mode* = scalar, then if

--- a/doc/src/fix_ave_time.rst
+++ b/doc/src/fix_ave_time.rst
@@ -25,7 +25,7 @@ Syntax
        f_ID = global scalar or vector calculated by a fix with ID
        f_ID[I] = Ith component of global vector or Ith column of global array calculated by a fix with ID, I can include wildcard (see below)
        v_name = value(s) calculated by an equal-style or vector-style variable with name
-       v_name[I] = value calculated by a vector-style variable with name
+       v_name[I] = value calculated by a vector-style variable with name, I can include wildcard (see below)
 
 * zero or more keyword/arg pairs may be appended
 * keyword = *mode* or *file* or *ave* or *start* or *off* or *overwrite* or *title1* or *title2* or *title3*
@@ -113,15 +113,17 @@ with a bracketed term appended, indicating the Ith column of the array
 is used.  All vectors must be the same length, which is the length of
 the vector or number of rows in the array.
 
-Note that for values from a compute or fix, the bracketed index I can
-be specified using a wildcard asterisk with the index to effectively
-specify multiple values.  This takes the form "\*" or "\*n" or "n\*" or
-"m\*n".  If N = the size of the vector (for *mode* = scalar) or the
-number of columns in the array (for *mode* = vector), then an asterisk
-with no numeric values means all indices from 1 to N.  A leading
-asterisk means all indices from 1 to n (inclusive).  A trailing
-asterisk means all indices from n to N (inclusive).  A middle asterisk
-means all indices from m to n (inclusive).
+----------
+
+For input values from a compute or fix or variable, the bracketed
+index I can be specified using a wildcard asterisk with the index to
+effectively specify multiple values.  This takes the form "\*" or
+"\*n" or "n\*" or "m\*n".  If N = the size of the vector (for *mode* =
+scalar) or the number of columns in the array (for *mode* = vector),
+then an asterisk with no numeric values means all indices from 1 to N.
+A leading asterisk means all indices from 1 to n (inclusive).  A
+trailing asterisk means all indices from n to N (inclusive).  A middle
+asterisk means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual elements of the
 vector or columns of the array had been listed one by one.  E.g. these
@@ -133,6 +135,15 @@ with 3 columns, each of length 50:
    compute myRDF all rdf 50 1 2
    fix 1 all ave/time 100 1 100 c_myRDF[*] file tmp1.rdf mode vector
    fix 2 all ave/time 100 1 100 c_myRDF[1] c_myRDF[2] c_myRDF[3] file tmp2.rdf mode vector
+
+.. note::
+
+   For a vector-style variable, only the wildcard forms "\*n" or
+   "m\*n" are allowed.  You must specify the upper bound, because
+   vector-style variable lengths are not determined until the variable
+   is evaluated.  If n is specified larger than the vector length"\*n"
+   or "n\*" or "m\*n".  turns out to be, zeroes are output for missing
+   vector values.
 
 ----------
 

--- a/doc/src/thermo_style.rst
+++ b/doc/src/thermo_style.rst
@@ -85,7 +85,7 @@ Syntax
            f_ID[I] = Ith component of global vector calculated by a fix with ID, I can include wildcard (see below)
            f_ID[I][J] = I,J component of global array calculated by a fix with ID
            v_name = value calculated by an equal-style variable with name
-           v_name[I] = value calculated by a vector-style variable with name
+           v_name[I] = value calculated by a vector-style variable with name, I can include wildcard (see below)
 
 Examples
 """"""""
@@ -348,16 +348,16 @@ dimensions *lx*, *ly*, *lz*, *yz*, *xz*, *xy*\ .
 
 ----------
 
-For output values from a compute or fix, the bracketed index I used to
-index a vector, as in *c_ID[I]* or *f_ID[I]*, can be specified
-using a wildcard asterisk with the index to effectively specify
-multiple values.  This takes the form "\*" or "\*n" or "n\*" or "m\*n".
-If N = the size of the vector (for *mode* = scalar) or the number of
-columns in the array (for *mode* = vector), then an asterisk with no
-numeric values means all indices from 1 to N.  A leading asterisk
-means all indices from 1 to n (inclusive).  A trailing asterisk means
-all indices from n to N (inclusive).  A middle asterisk means all
-indices from m to n (inclusive).
+For output values from a compute or fix or variable, the bracketed
+index I used to index a vector, as in *c_ID[I]* or *f_ID[I]* or
+*v_name[I]*, can be specified using a wildcard asterisk with the index
+to effectively specify multiple values.  This takes the form "\*" or
+"\*n" or "n\*" or "m\*n".  If N = the size of the vector (for *mode* =
+scalar) or the number of columns in the array (for *mode* = vector),
+then an asterisk with no numeric values means all indices from 1 to N.
+A leading asterisk means all indices from 1 to n (inclusive).  A
+trailing asterisk means all indices from n to N (inclusive).  A middle
+asterisk means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual elements of the
 vector had been listed one by one.  E.g. these 2 thermo_style commands
@@ -371,6 +371,15 @@ creates a global vector with 6 values.
    thermo_style custom step temp etotal &
                 c_myTemp[1] c_myTemp[2] c_myTemp[3] &
                 c_myTemp[4] c_myTemp[5] c_myTemp[6]
+
+
+.. note::
+
+   For a vector-style variable, only the wildcard forms "\*n" or
+   "m\*n" are allowed.  You must specify the upper bound, because
+   vector-style variable lengths are not determined until the variable
+   is evaluated.  If n is specified larger than the vector length
+   turns out to be, zeroes are output for missing vector values.
 
 ----------
 

--- a/doc/src/thermo_style.rst
+++ b/doc/src/thermo_style.rst
@@ -352,10 +352,9 @@ For output values from a compute or fix or variable, the bracketed
 index I used to index a vector, as in *c_ID[I]* or *f_ID[I]* or
 *v_name[I]*, can be specified using a wildcard asterisk with the index
 to effectively specify multiple values.  This takes the form "\*" or
-"\*n" or "n\*" or "m\*n".  If N = the size of the vector (for *mode* =
-scalar) or the number of columns in the array (for *mode* = vector),
-then an asterisk with no numeric values means all indices from 1 to N.
-A leading asterisk means all indices from 1 to n (inclusive).  A
+"\*n" or "n\*" or "m\*n".  If N = the size of the vector, then an
+asterisk with no numeric values means all indices from 1 to N.  A
+leading asterisk means all indices from 1 to n (inclusive).  A
 trailing asterisk means all indices from n to N (inclusive).  A middle
 asterisk means all indices from m to n (inclusive).
 

--- a/examples/ELASTIC_T/BORN_MATRIX/Silicon/output.in
+++ b/examples/ELASTIC_T/BORN_MATRIX/Silicon/output.in
@@ -136,5 +136,6 @@ variable C46 equal v_F46+v_B[20]
 variable C56 equal v_F56+v_B[21]
 
 thermo		${nthermo}
-thermo_style custom step temp pe press density f_avt f_avp f_avpe v_F11 v_F22 v_F33 v_F44 v_F55 v_F66 v_F12 v_F13 v_F23 v_B[1] v_B[2] v_B[3] v_B[4] v_B[5] v_B[6] v_B[7] v_B[8] v_B[12]
+thermo_style custom step temp pe press density f_avt f_avp f_avpe v_F11 v_F22 v_F33 v_F44 v_F55 v_F66 v_F12 v_F13 v_F23 v_B[*8] v_B[12]
+
 thermo_modify norm no

--- a/unittest/cplusplus/test_advanced_utils.cpp
+++ b/unittest/cplusplus/test_advanced_utils.cpp
@@ -125,55 +125,98 @@ TEST_F(Advanced_utils, expand_args)
 
     char **args, **earg;
     constexpr int oarg = 9;
-    args    = new char *[oarg];
-    args[0] = utils::strdup("v_step");
-    args[1] = utils::strdup("c_temp");
-    args[2] = utils::strdup("f_1[2*]");
-    args[3] = utils::strdup("c_temp[2*4]");
-    args[4] = utils::strdup("v_temp[*4]");
-    args[5] = utils::strdup("c_rdf[*]");
-    args[6] = utils::strdup("c_rdf[1][*]");
-    args[7] = utils::strdup("c_rdf[*][2]");
-    args[8] = utils::strdup("c_rdf[*][*]");
+    args               = new char *[oarg];
+    args[0]            = utils::strdup("v_step");
+    args[1]            = utils::strdup("c_temp");
+    args[2]            = utils::strdup("f_1[*]");
+    args[3]            = utils::strdup("c_temp[2*4]");
+    args[4]            = utils::strdup("v_temp[*4]");
+    args[5]            = utils::strdup("c_gofr[3*]");
+    args[6]            = utils::strdup("c_gofr[1][*]");
+    args[7]            = utils::strdup("c_gofr[*2][2]");
+    args[8]            = utils::strdup("c_gofr[*][*]");
 
     auto narg = utils::expand_args(FLERR, oarg, args, 0, earg, lmp);
-    EXPECT_EQ(narg, 12);
+    EXPECT_EQ(narg, 16);
     EXPECT_STREQ(earg[0], "v_step");
     EXPECT_STREQ(earg[1], "c_temp");
-    EXPECT_STREQ(earg[2], "f_1[2]");
-    EXPECT_STREQ(earg[3], "f_1[3]");
-    EXPECT_STREQ(earg[4], "c_temp[2]");
-    EXPECT_STREQ(earg[5], "c_temp[3]");
-    EXPECT_STREQ(earg[6], "c_temp[4]");
-    EXPECT_STREQ(earg[7], "v_temp[*4]");
-    EXPECT_STREQ(earg[8], "c_rdf[*]");
-    EXPECT_STREQ(earg[9], "c_rdf[1][*]");
-    EXPECT_STREQ(earg[10], "c_rdf[*][2]");
-    EXPECT_STREQ(earg[11], "c_rdf[*][*]");
+    EXPECT_STREQ(earg[2], "f_1[1]");
+    EXPECT_STREQ(earg[3], "f_1[2]");
+    EXPECT_STREQ(earg[4], "f_1[3]");
+    EXPECT_STREQ(earg[5], "c_temp[2]");
+    EXPECT_STREQ(earg[6], "c_temp[3]");
+    EXPECT_STREQ(earg[7], "c_temp[4]");
+    EXPECT_STREQ(earg[8], "v_temp[1]");
+    EXPECT_STREQ(earg[9], "v_temp[2]");
+    EXPECT_STREQ(earg[10], "v_temp[3]");
+    EXPECT_STREQ(earg[11], "v_temp[4]");
+    EXPECT_STREQ(earg[12], "c_gofr[3*]");
+    EXPECT_STREQ(earg[13], "c_gofr[1][*]");
+    EXPECT_STREQ(earg[14], "c_gofr[*2][2]");
+    EXPECT_STREQ(earg[15], "c_gofr[*][*]");
 
     for (int i = 0; i < narg; ++i)
         delete[] earg[i];
     lmp->memory->sfree(earg);
 
     narg = utils::expand_args(FLERR, oarg, args, 1, earg, lmp);
-    EXPECT_EQ(narg, oarg);
+    EXPECT_EQ(narg, 16);
     EXPECT_NE(args, earg);
     EXPECT_STREQ(earg[0], "v_step");
     EXPECT_STREQ(earg[1], "c_temp");
-    EXPECT_STREQ(earg[2], "f_1[2*]");
+    EXPECT_STREQ(earg[2], "f_1[*]");
     EXPECT_STREQ(earg[3], "c_temp[2*4]");
     EXPECT_STREQ(earg[4], "v_temp[*4]");
-    EXPECT_STREQ(earg[5], "c_rdf[*]");
-    EXPECT_STREQ(earg[6], "c_rdf[1][*]");
-    EXPECT_STREQ(earg[7], "c_rdf[*][2]");
-    EXPECT_STREQ(earg[8], "c_rdf[*][*]");
+    EXPECT_STREQ(earg[5], "c_gofr[3]");
+    EXPECT_STREQ(earg[6], "c_gofr[4]");
+    EXPECT_STREQ(earg[7], "c_gofr[5]");
+    EXPECT_STREQ(earg[8], "c_gofr[1][*]");
+    EXPECT_STREQ(earg[9], "c_gofr[1][2]");
+    EXPECT_STREQ(earg[10], "c_gofr[2][2]");
+    EXPECT_STREQ(earg[11], "c_gofr[1][*]");
+    EXPECT_STREQ(earg[12], "c_gofr[2][*]");
+    EXPECT_STREQ(earg[13], "c_gofr[3][*]");
+    EXPECT_STREQ(earg[14], "c_gofr[4][*]");
+    EXPECT_STREQ(earg[15], "c_gofr[5][*]");
 
-    for (int i = 0; i < oarg; ++i)
-        delete[] args[i];
-    delete[] args;
     for (int i = 0; i < narg; ++i)
         delete[] earg[i];
     lmp->memory->sfree(earg);
+
+    args[3][9] = '9';
+    TEST_FAILURE("ERROR: Numeric index 9 is out of bounds \\(1-6\\).*",
+                 utils::expand_args(FLERR, oarg, args, 0, earg, lmp););
+
+    args[3][9] = '4';
+    args[5][7] = '9';
+    TEST_FAILURE("ERROR: Numeric index 9 is out of bounds \\(1-5\\).*",
+                 utils::expand_args(FLERR, oarg, args, 1, earg, lmp););
+
+    args[5][7] = '3';
+    delete[] args[4];
+    args[4] = utils::strdup("v_temp[2*]");
+    narg    = utils::expand_args(FLERR, oarg, args, 0, earg, lmp);
+    EXPECT_EQ(narg, 13);
+    EXPECT_STREQ(earg[0], "v_step");
+    EXPECT_STREQ(earg[1], "c_temp");
+    EXPECT_STREQ(earg[2], "f_1[1]");
+    EXPECT_STREQ(earg[3], "f_1[2]");
+    EXPECT_STREQ(earg[4], "f_1[3]");
+    EXPECT_STREQ(earg[5], "c_temp[2]");
+    EXPECT_STREQ(earg[6], "c_temp[3]");
+    EXPECT_STREQ(earg[7], "c_temp[4]");
+    EXPECT_STREQ(earg[8], "v_temp[2*]");
+    EXPECT_STREQ(earg[9], "c_gofr[3*]");
+    EXPECT_STREQ(earg[10], "c_gofr[1][*]");
+    EXPECT_STREQ(earg[11], "c_gofr[*2][2]");
+    EXPECT_STREQ(earg[12], "c_gofr[*][*]");
+
+    for (int i = 0; i < narg; ++i)
+        delete[] earg[i];
+    lmp->memory->sfree(earg);
+    for (int i = 0; i < oarg; ++i)
+        delete[] args[i];
+    delete[] args;
 }
 
 } // namespace LAMMPS_NS


### PR DESCRIPTION
**Summary**

Similar to computes and fixes, allow commands that take inputs from vector-style variables to use a wildcard asterisk character.
This can simplify input syntax if the vector length is large.  E.g. the thermo_style custom command can output all the vector values with one keyword instead of N.

This expands the inputs to encompass the wildcard range via utils::expand_args().  One difference is that vector-style variable lengths are not know until after they are evaluated, and the argument expansion is done much earlier.  So fully general wildcards are not allowed.  The user must specify a trailing number.  Commands that process vector-style variable typically use a zero value if the user has specified a vector index that exceeds the actual length.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


