### PR TITLE
bugfix shell mkdir

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1194,9 +1194,7 @@ void Input::shell()
     if (narg < 2) error->all(FLERR,"Illegal shell mkdir command");
     if (me == 0) {
       for (int i = 1; i < narg; i++) {
-        rv = (platform::mkdir(arg[i]) < 0) ? errno : 0;
-        MPI_Reduce(&rv,&err,1,MPI_INT,MPI_MAX,0,world);
-        errno = err;
+        err = (platform::mkdir(arg[i]) < 0) ? errno : 0;
         if (err != 0)
           error->warning(FLERR, "Shell command 'mkdir {}' failed with error '{}'",
                          arg[i],utils::getsyserror());


### PR DESCRIPTION
**Summary**

Command `shell mkdir` had a bug (MPI_Reduce only reached by proc 0), causing any multi-proc LAMMPS run to hang after proc 0 had successfully created a directory. I believe this PR fixes that bug. A minimal example is:

```
shell mkdir test
print "I made a directory"
```

The unpatched LAMMPS version running on more than 1 processor makes the `test` directory but does not print the subsequent message and waits without exiting.

**Related Issue(s)**

**Author(s)**

Shern Tee, University of Queensland

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

Since the previous `mkdir` operation, if it errors, sets `errno` correctly, I don't think we need to set it again. 

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**