### PR TITLE
Delete atoms exactly by fraction or count

### DIFF
--- a/doc/src/delete_atoms.rst
+++ b/doc/src/delete_atoms.rst
@@ -20,14 +20,14 @@ Syntax
          cutoff = delete one atom from pairs of atoms within the cutoff (distance units)
          group1-ID = one atom in pair must be in this group
          group2-ID = other atom in pair must be in this group
-       *partial* args = pstyle pvalue pflag group-ID region-ID seed
+       *partial* args = pstyle value flag group-ID region-ID seed
          pstyle = *fraction* or *count*
            for *fraction*:
-             pvalue = fraction (0.0 to 1.0) of eligible atoms to delete
-             pflag = 0 for approximate deletion, 1 for exact deletion
+             value = fraction (0.0 to 1.0) of eligible atoms to delete
+             flag = no/off for fast approximate deletion, yes/on for exact deletion
            for *count*:
-             pvalue = number of eligible atoms to delete
-             pflag = 0 for warning if count > eligible atoms, 1 for error
+             value = number of atoms to delete
+             flag = no/off for warning if count > eligible atoms, yes/on for error
          group-ID = group within which to perform deletions
          region-ID = region within which to perform deletions
                      or NULL to only impose the group criterion
@@ -93,27 +93,28 @@ atoms to delete are chosen randomly using the specified random number
 *seed*.  In all cases, which atoms are deleted may vary when running
 on different numbers of processors.
 
-For *pstyle* = *fraction*, the specified *pvalue* fraction (0.0 to
-1.0) of eligible atoms are deleted.  If *pflag* is set to 0, then the
-number deleted will be approximate.  If *pflag* is set to 1, then the
-number deleted will be exactly the requested fraction, but for very
-large systems the selection of deleted atoms may take longer to
-calculate.
+For *pstyle* = *fraction*, the specified fraction *value*(0.0 to 1.0) of
+eligible atoms are deleted.  If the *flag* is set to no/off/0, then the
+number of deleted atoms will be approximate, but the operation will
+always be fast.  If instead the *flag* is set to yes/on/1, then the
+number deleted will be match the requested fraction as close as
+possible, but for very large systems the selection of deleted atoms will
+take additional time to determine.
 
-For *pstyle* = *count*, the specified integer *pvalue* number of
-eligible atoms are deleted.  If *pflag* is set to 0, then if the
-requested number is larger then the number of eligible atoms, a
-warning is issued.  If *pflag* is set to one, an error is triggered
-and LAMMPS will exit.  In both cases exactly the number of requested
-atoms will be deleted (unless larger than eligible count).  For very
-large systems the selection of deleted atoms will require the same
-time as *pstyle* = *fraction* with *pflag* = 1.
+For *pstyle* = *count*, the specified integer *value* is the number of
+eligible atoms are deleted.  If the *flag* is set to no/off/0, then
+if the requested number is larger then the number of eligible atoms,
+a warning is issued and only the eligible atoms are deleted instead of
+the requested *value*.  If the *flag* is set to yes/on/1, an error is
+triggered instead and LAMMPS will exit.  For very large systems the
+selection of atoms to delete may take additional time same as for requesting
+the exact fraction with time as *pstyle* = *fraction*.
 
-Which atoms are eligible for deletion for style *partial* is
-determined by the specified *group-ID* and *region-ID*.  To be
-eligible, an atom must be in both the specified group and region.  If
-*group-ID* = all, there is effectively no group criterion.  If
-*region-ID* is specified as NULL, no region criterion is imposed.
+Which atoms are eligible for deletion for style *partial* is determined
+by the specified *group-ID* and *region-ID*.  To be eligible, an atom
+must be in both the specified group and region.  If *group-ID* = all,
+there is effectively no group criterion.  If *region-ID* is specified as
+NULL, no region criterion is imposed.
 
 For style *variable*, all atoms for which the atom-style variable with
 the given name evaluates to non-zero will be deleted. Additional atoms

--- a/doc/src/delete_atoms.rst
+++ b/doc/src/delete_atoms.rst
@@ -20,8 +20,8 @@ Syntax
          cutoff = delete one atom from pairs of atoms within the cutoff (distance units)
          group1-ID = one atom in pair must be in this group
          group2-ID = other atom in pair must be in this group
-       *partial* args = pstyle value flag group-ID region-ID seed
-         pstyle = *fraction* or *count*
+       *random* args = ranstyle value flag group-ID region-ID seed
+         ranstyle = *fraction* or *count*
            for *fraction*:
              value = fraction (0.0 to 1.0) of eligible atoms to delete
              flag = no/off for fast approximate deletion, yes/on for exact deletion
@@ -52,9 +52,9 @@ Examples
    delete_atoms region sphere compress no
    delete_atoms overlap 0.3 all all
    delete_atoms overlap 0.5 solvent colloid
-   delete_atoms partial fraction 0.1 1 all cube 482793 bond yes
-   delete_atoms partial fraction 0.3 0 polymer NULL 482793 bond yes
-   delete_atoms partial count 500 0 ions NULL 482793
+   delete_atoms random fraction 0.1 1 all cube 482793 bond yes
+   delete_atoms random fraction 0.3 0 polymer NULL 482793 bond yes
+   delete_atoms random count 500 0 ions NULL 482793
    detele_atoms variable checkers
 
 Description
@@ -88,12 +88,12 @@ have occurred that no atom pairs within the cutoff will remain
 minimum number of atoms will be deleted, or that the same atoms will
 be deleted when running on different numbers of processors.
 
-For style *partial* a subset of eligible atoms are deleted.  Which
+For style *random* a subset of eligible atoms are deleted.  Which
 atoms to delete are chosen randomly using the specified random number
 *seed*.  In all cases, which atoms are deleted may vary when running
 on different numbers of processors.
 
-For *pstyle* = *fraction*, the specified fraction *value*(0.0 to 1.0) of
+For *ranstyle* = *fraction*, the specified fraction *value*(0.0 to 1.0) of
 eligible atoms are deleted.  If the *flag* is set to no/off/0, then the
 number of deleted atoms will be approximate, but the operation will
 always be fast.  If instead the *flag* is set to yes/on/1, then the
@@ -101,14 +101,14 @@ number deleted will be match the requested fraction as close as
 possible, but for very large systems the selection of deleted atoms will
 take additional time to determine.
 
-For *pstyle* = *count*, the specified integer *value* is the number of
-eligible atoms are deleted.  If the *flag* is set to no/off/0, then
-if the requested number is larger then the number of eligible atoms,
-a warning is issued and only the eligible atoms are deleted instead of
+For *ranstyle* = *count*, the specified integer *value* is the number
+of eligible atoms are deleted.  If the *flag* is set to no/off/0, then
+if the requested number is larger then the number of eligible atoms, a
+warning is issued and only the eligible atoms are deleted instead of
 the requested *value*.  If the *flag* is set to yes/on/1, an error is
 triggered instead and LAMMPS will exit.  For very large systems the
-selection of atoms to delete may take additional time same as for requesting
-the exact fraction with time as *pstyle* = *fraction*.
+selection of atoms to delete may take additional time same as for
+requesting the exact fraction with time as *pstyle* = *fraction*.
 
 Which atoms are eligible for deletion for style *partial* is determined
 by the specified *group-ID* and *region-ID*.  To be eligible, an atom

--- a/doc/src/delete_atoms.rst
+++ b/doc/src/delete_atoms.rst
@@ -10,7 +10,7 @@ Syntax
 
    delete_atoms style args keyword value ...
 
-* style = *group* or *region* or *overlap* or *partial* or *variable*
+* style = *group* or *region* or *overlap* or *random* or *variable*
 
   .. parsed-literal::
 
@@ -20,14 +20,14 @@ Syntax
          cutoff = delete one atom from pairs of atoms within the cutoff (distance units)
          group1-ID = one atom in pair must be in this group
          group2-ID = other atom in pair must be in this group
-       *random* args = ranstyle value flag group-ID region-ID seed
+       *random* args = ranstyle value eflag group-ID region-ID seed
          ranstyle = *fraction* or *count*
            for *fraction*:
              value = fraction (0.0 to 1.0) of eligible atoms to delete
-             flag = no/off for fast approximate deletion, yes/on for exact deletion
+             eflag =  *no* for fast approximate deletion, *yes* for exact deletion
            for *count*:
              value = number of atoms to delete
-             flag = no/off for warning if count > eligible atoms, yes/on for error
+             eflag = *no* for warning if count > eligible atoms, *yes* for error
          group-ID = group within which to perform deletions
          region-ID = region within which to perform deletions
                      or NULL to only impose the group criterion
@@ -52,9 +52,9 @@ Examples
    delete_atoms region sphere compress no
    delete_atoms overlap 0.3 all all
    delete_atoms overlap 0.5 solvent colloid
-   delete_atoms random fraction 0.1 1 all cube 482793 bond yes
-   delete_atoms random fraction 0.3 0 polymer NULL 482793 bond yes
-   delete_atoms random count 500 0 ions NULL 482793
+   delete_atoms random fraction 0.1 yes all cube 482793 bond yes
+   delete_atoms random fraction 0.3 no polymer NULL 482793 bond yes
+   delete_atoms random count 500 no ions NULL 482793
    detele_atoms variable checkers
 
 Description
@@ -90,31 +90,31 @@ be deleted when running on different numbers of processors.
 
 For style *random* a subset of eligible atoms are deleted.  Which
 atoms to delete are chosen randomly using the specified random number
-*seed*.  In all cases, which atoms are deleted may vary when running
-on different numbers of processors.
+*seed*.  Which atoms are deleted may vary when running on different
+numbers of processors.
 
-For *ranstyle* = *fraction*, the specified fraction *value*(0.0 to 1.0) of
-eligible atoms are deleted.  If the *flag* is set to no/off/0, then the
-number of deleted atoms will be approximate, but the operation will
-always be fast.  If instead the *flag* is set to yes/on/1, then the
-number deleted will be match the requested fraction as close as
-possible, but for very large systems the selection of deleted atoms will
-take additional time to determine.
+For *ranstyle* = *fraction*, the specified fractional *value* (0.0 to
+1.0) of eligible atoms are deleted.  If *eflag* is set to *no*, then
+the number of deleted atoms will be approximate, but the operation
+will be fast.  If *eflag* is set to *yes*, then the number deleted
+will match the requested fraction, but for large systems the selection
+of deleted atoms may take additional time to determine.
 
 For *ranstyle* = *count*, the specified integer *value* is the number
-of eligible atoms are deleted.  If the *flag* is set to no/off/0, then
-if the requested number is larger then the number of eligible atoms, a
+of eligible atoms are deleted.  If *eflag* is set to *no*, then if the
+requested number is larger then the number of eligible atoms, a
 warning is issued and only the eligible atoms are deleted instead of
-the requested *value*.  If the *flag* is set to yes/on/1, an error is
-triggered instead and LAMMPS will exit.  For very large systems the
-selection of atoms to delete may take additional time same as for
-requesting the exact fraction with time as *pstyle* = *fraction*.
+the requested *value*.  If *eflag* is set to *yes*, an error is
+triggered instead and LAMMPS will exit.  For large systems the
+selection of atoms to delete may take additional time to determine,
+the same as for requesting an exact fraction with *pstyle* =
+*fraction*.
 
-Which atoms are eligible for deletion for style *partial* is determined
+Which atoms are eligible for deletion for style *random* is determined
 by the specified *group-ID* and *region-ID*.  To be eligible, an atom
 must be in both the specified group and region.  If *group-ID* = all,
-there is effectively no group criterion.  If *region-ID* is specified as
-NULL, no region criterion is imposed.
+there is effectively no group criterion.  If *region-ID* is specified
+as NULL, no region criterion is imposed.
 
 For style *variable*, all atoms for which the atom-style variable with
 the given name evaluates to non-zero will be deleted. Additional atoms

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -75,7 +75,7 @@ void DeleteAtoms::command(int narg, char **arg)
     delete_overlap(narg, arg);
   else if (strcmp(arg[0], "partial") == 0)
     delete_partial(narg, arg);
-  // deprecated old version of this option
+  // deprecated porosity option, now included in new partial option
   else if (strcmp(arg[0], "porosity") == 0) {
     if (comm->me == 0) {
       printf("Deprecated version: "

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -75,7 +75,18 @@ void DeleteAtoms::command(int narg, char **arg)
     delete_overlap(narg, arg);
   else if (strcmp(arg[0], "partial") == 0)
     delete_partial(narg, arg);
-  else if (strcmp(arg[0], "variable") == 0)
+  // deprecated old version of this option
+  else if (strcmp(arg[0], "porosity") == 0) {
+    if (comm->me == 0) {
+      printf("Deprecated version: "
+             "delete_atoms porosity group-ID region-ID frac seed\n");
+      printf("Equivalent new version: "
+             "delete_atoms partial fraction frac 0 group-ID region-ID seed\n");
+      printf("In both versions 'frac' = numeric fraction 0.0 to 1.0 \n");
+      printf("Change integer arg 0 to 1 if want exact fraction deleted\n");
+    }
+    error->all(FLERR,"Delete_atoms porosity option has been deprecated\n");
+  } else if (strcmp(arg[0], "variable") == 0)
     delete_variable(narg, arg);
   else
     error->all(FLERR, "Unknown delete_atoms sub-command: {}", arg[0]);

--- a/src/delete_atoms.h
+++ b/src/delete_atoms.h
@@ -38,7 +38,7 @@ class DeleteAtoms : public Command {
   void delete_group(int, char **);
   void delete_region(int, char **);
   void delete_overlap(int, char **);
-  void delete_partial(int, char **);
+  void delete_random(int, char **);
   void delete_variable(int, char **);
 
   void delete_bond();

--- a/src/delete_atoms.h
+++ b/src/delete_atoms.h
@@ -38,7 +38,7 @@ class DeleteAtoms : public Command {
   void delete_group(int, char **);
   void delete_region(int, char **);
   void delete_overlap(int, char **);
-  void delete_porosity(int, char **);
+  void delete_partial(int, char **);
   void delete_variable(int, char **);
 
   void delete_bond();

--- a/unittest/commands/test_delete_atoms.cpp
+++ b/unittest/commands/test_delete_atoms.cpp
@@ -70,8 +70,10 @@ protected:
         command("region left block -2.0 -1.0 INF INF INF INF");
         command("region right block 0.5  2.0 INF INF INF INF");
         command("region top block INF INF -2.0 -1.0 INF INF");
+        command("region bottom block INF INF 0.0 4.0 INF INF");
         command("set region left type 2");
         command("set region right type 3");
+        command("group bottom region bottom");
         command("group top region top");
         END_HIDE_OUTPUT();
     }
@@ -109,19 +111,51 @@ TEST_F(DeleteAtomsTest, Simple)
     ASSERT_EQ(atom->natoms, 392);
 
     HIDE_OUTPUT([&] {
-        command("delete_atoms porosity all right 0.5 43252");
+        command("delete_atoms partial fraction 0.5 yes all right 43252");
     });
-    ASSERT_EQ(atom->natoms, 362);
+    ASSERT_EQ(atom->natoms, 364);
 
     HIDE_OUTPUT([&] {
         command("variable checker atom sin(4*PI*x/lx)*sin(4*PI*y/ly)*sin(4*PI*z/lz)>0");
         command("delete_atoms variable checker");
     });
-    ASSERT_EQ(atom->natoms, 177);
+    ASSERT_EQ(atom->natoms, 178);
+
+    HIDE_OUTPUT([&] {
+        command("delete_atoms partial count 3 no bottom right 443252");
+    });
+    ASSERT_EQ(atom->natoms, 175);
+
+    HIDE_OUTPUT([&] {
+        command("delete_atoms partial count 50 no all NULL 434325");
+    });
+    ASSERT_EQ(atom->natoms, 125);
+
+    HIDE_OUTPUT([&] {
+        command("delete_atoms partial fraction 0.2 no all NULL 34325");
+    });
+    ASSERT_EQ(atom->natoms, 104);
+
+    HIDE_OUTPUT([&] {
+        command("delete_atoms partial count 50 no bottom right 77325");
+    });
+    ASSERT_EQ(atom->natoms, 102);
 
     TEST_FAILURE(".*ERROR: Illegal delete_atoms command: missing argument.*",
                  command("delete_atoms"););
     TEST_FAILURE(".*ERROR: Unknown delete_atoms sub-command: xxx.*", command("delete_atoms xxx"););
+    TEST_FAILURE(".*ERROR: The delete_atoms 'porosity' keyword has been removed.*",
+                 command("delete_atoms porosity 0.5 all right 4325234"););
+    TEST_FAILURE(".*ERROR: Illegal delete_atoms partial command: missing argument.*",
+                 command("delete_atoms partial count 50 bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Illegal delete_atoms partial command: missing argument.*",
+                 command("delete_atoms partial fraction 0.4 bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Delete_atoms partial count has invalid value: -5.*",
+                 command("delete_atoms partial count -5 no bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Delete_atoms count of 5 exceeds number of eligible atoms 0.*",
+                 command("delete_atoms partial count 5 yes bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Delete_atoms partial fraction has invalid value: -0.4.*",
+                 command("delete_atoms partial fraction -0.4 no bottom right 77325"););
 }
 } // namespace LAMMPS_NS
 

--- a/unittest/commands/test_delete_atoms.cpp
+++ b/unittest/commands/test_delete_atoms.cpp
@@ -111,7 +111,7 @@ TEST_F(DeleteAtomsTest, Simple)
     ASSERT_EQ(atom->natoms, 392);
 
     HIDE_OUTPUT([&] {
-        command("delete_atoms partial fraction 0.5 yes all right 43252");
+        command("delete_atoms random fraction 0.5 yes all right 43252");
     });
     ASSERT_EQ(atom->natoms, 364);
 
@@ -122,22 +122,22 @@ TEST_F(DeleteAtomsTest, Simple)
     ASSERT_EQ(atom->natoms, 178);
 
     HIDE_OUTPUT([&] {
-        command("delete_atoms partial count 3 no bottom right 443252");
+        command("delete_atoms random count 3 no bottom right 443252");
     });
     ASSERT_EQ(atom->natoms, 175);
 
     HIDE_OUTPUT([&] {
-        command("delete_atoms partial count 50 no all NULL 434325");
+        command("delete_atoms random count 50 no all NULL 434325");
     });
     ASSERT_EQ(atom->natoms, 125);
 
     HIDE_OUTPUT([&] {
-        command("delete_atoms partial fraction 0.2 no all NULL 34325");
+        command("delete_atoms random fraction 0.2 no all NULL 34325");
     });
     ASSERT_EQ(atom->natoms, 104);
 
     HIDE_OUTPUT([&] {
-        command("delete_atoms partial count 50 no bottom right 77325");
+        command("delete_atoms random count 50 no bottom right 77325");
     });
     ASSERT_EQ(atom->natoms, 102);
 
@@ -146,16 +146,16 @@ TEST_F(DeleteAtomsTest, Simple)
     TEST_FAILURE(".*ERROR: Unknown delete_atoms sub-command: xxx.*", command("delete_atoms xxx"););
     TEST_FAILURE(".*ERROR: The delete_atoms 'porosity' keyword has been removed.*",
                  command("delete_atoms porosity 0.5 all right 4325234"););
-    TEST_FAILURE(".*ERROR: Illegal delete_atoms partial command: missing argument.*",
-                 command("delete_atoms partial count 50 bottom right 77325"););
-    TEST_FAILURE(".*ERROR: Illegal delete_atoms partial command: missing argument.*",
-                 command("delete_atoms partial fraction 0.4 bottom right 77325"););
-    TEST_FAILURE(".*ERROR: Delete_atoms partial count has invalid value: -5.*",
-                 command("delete_atoms partial count -5 no bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Illegal delete_atoms random command: missing argument.*",
+                 command("delete_atoms random count 50 bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Illegal delete_atoms random command: missing argument.*",
+                 command("delete_atoms random fraction 0.4 bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Delete_atoms random count has invalid value: -5.*",
+                 command("delete_atoms random count -5 no bottom right 77325"););
     TEST_FAILURE(".*ERROR: Delete_atoms count of 5 exceeds number of eligible atoms 0.*",
-                 command("delete_atoms partial count 5 yes bottom right 77325"););
-    TEST_FAILURE(".*ERROR: Delete_atoms partial fraction has invalid value: -0.4.*",
-                 command("delete_atoms partial fraction -0.4 no bottom right 77325"););
+                 command("delete_atoms random count 5 yes bottom right 77325"););
+    TEST_FAILURE(".*ERROR: Delete_atoms random fraction has invalid value: -0.4.*",
+                 command("delete_atoms random fraction -0.4 no bottom right 77325"););
 }
 } // namespace LAMMPS_NS
 


### PR DESCRIPTION
**Summary**

The previous behavior of delete_atoms porosity was to delete an approximate number of the requested fraction of atoms.  The option has now been renamed delete_atoms partial and now has 3 options.  One of them is the same before.  Another is to delete the exact fraction of atoms requested.  The third is to delete the exact count of atoms requested.

This is similar to the behavior of the 3 set type/fraction variants though the syntax here is a bit different.  The two commands
(delete_atoms and set) use the same logic for flagging exactly the requested number of atoms.

**Related Issue(s)**

See issue #3249 - this addresses that features request and thus closes #3249

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The delete_atoms porosity keyword has changed to partial, as has the syntax that follows the "partial" keyword.  So old
scripts with porosity will break.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.

