### PR TITLE
Add nprocs keyword to thermo output

### DIFF
--- a/doc/src/thermo_style.rst
+++ b/doc/src/thermo_style.rst
@@ -20,7 +20,8 @@ Syntax
        *yaml* args = none
        *custom* args = list of keywords
          possible keywords = step, elapsed, elaplong, dt, time,
-                             cpu, tpcpu, spcpu, cpuremain, part, timeremain,
+                             cpu, tpcpu, spcpu, cpuremain, 
+                             nprocs, part, timeremain,
                              atoms, temp, press, pe, ke, etotal,
                              evdwl, ecoul, epair, ebond, eangle, edihed, eimp,
                              emol, elong, etail,
@@ -43,8 +44,9 @@ Syntax
            tpcpu = time per CPU second
            spcpu = timesteps per CPU second
            cpuremain = estimated CPU time remaining in run
+           nprocs = # of processors (MPI tasks) simulation is running on
            part = which partition (0 to Npartition-1) this is
-           timeremain = remaining time in seconds on timer timeout.
+           timeremain = remaining time in seconds on timer timeout
            atoms = # of atoms
            temp = temperature
            press = pressure

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -54,7 +54,7 @@ using namespace MathConst;
 // CUSTOMIZATION: add a new keyword by adding it to this list:
 
 // step, elapsed, elaplong, dt, time, cpu, tpcpu, spcpu, cpuremain,
-// part, timeremain
+// nprocs, part, timeremain
 // atoms, temp, press, pe, ke, etotal
 // evdwl, ecoul, epair, ebond, eangle, edihed, eimp, emol, elong, etail
 // enthalpy, ecouple, econserve
@@ -810,6 +810,8 @@ void Thermo::parse_fields(const std::string &str)
       addfield("S/CPU", &Thermo::compute_spcpu, FLOAT);
     } else if (word == "cpuremain") {
       addfield("CPULeft", &Thermo::compute_cpuremain, FLOAT);
+    } else if (word == "nprocs") {
+      addfield("Nprocs", &Thermo::compute_nprocs, INT);
     } else if (word == "part") {
       addfield("Part", &Thermo::compute_part, INT);
     } else if (word == "timeremain") {
@@ -1252,6 +1254,10 @@ int Thermo::evaluate_keyword(const std::string &word, double *answer)
       error->all(FLERR, "This variable thermo keyword cannot be used between runs");
     compute_cpuremain();
 
+  } else if (word == "nprocs") {
+    compute_nprocs();
+    dvalue = ivalue;
+
   } else if (word == "part") {
     compute_part();
     dvalue = ivalue;
@@ -1643,6 +1649,13 @@ void Thermo::compute_cpuremain()
   else
     dvalue = timer->elapsed(Timer::TOTAL) * (update->laststep - update->ntimestep) /
         (update->ntimestep - update->firststep);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Thermo::compute_nprocs()
+{
+  ivalue = comm->nprocs;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/thermo.h
+++ b/src/thermo.h
@@ -132,6 +132,7 @@ class Thermo : protected Pointers {
   void compute_tpcpu();
   void compute_spcpu();
   void compute_cpuremain();
+  void compute_nprocs();
   void compute_part();
   void compute_timeremain();
 


### PR DESCRIPTION
**Summary**

Add a "nprocs" keyword to thermo output.  The real motivation is not so much to include it with thermo output, but to make it accessible in input scripts in a variable.  E.g. to use in a filename or print statements or other variable calculations.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


