### PR TITLE
adding so3 descriptor support for compute_mliap

### DIFF
--- a/src/ML-IAP/compute_mliap.cpp
+++ b/src/ML-IAP/compute_mliap.cpp
@@ -22,6 +22,7 @@
 #include "mliap_model_linear.h"
 #include "mliap_model_quadratic.h"
 #include "mliap_descriptor_snap.h"
+#include "mliap_descriptor_so3.h"
 #ifdef MLIAP_PYTHON
 #include "mliap_model_python.h"
 #endif
@@ -88,6 +89,10 @@ ComputeMLIAP::ComputeMLIAP(LAMMPS *lmp, int narg, char **arg) :
       if (strcmp(arg[iarg+1],"sna") == 0) {
         if (iarg+3 > narg) error->all(FLERR,"Illegal compute mliap command");
         descriptor = new MLIAPDescriptorSNAP(lmp,arg[iarg+2]);
+        iarg += 3;
+      } else if (strcmp(arg[iarg+1],"so3") == 0) {
+        if (iarg+3 > narg) error->all(FLERR,"Illegal pair_style mliap command");
+        descriptor = new MLIAPDescriptorSO3(lmp,arg[iarg+2]);
         iarg += 3;
       } else error->all(FLERR,"Illegal compute mliap command");
       descriptorflag = 1;

--- a/src/ML-IAP/mliap_descriptor_so3.cpp
+++ b/src/ML-IAP/mliap_descriptor_so3.cpp
@@ -282,25 +282,25 @@ void MLIAPDescriptorSO3::compute_force_gradients(class MLIAPData *data)
     for (int jj = 0; jj < jnum; jj++) {
       int j = data->jatoms[ij];
 
-      for (int inz = 0; inz < data->gamma_nnz; inz++){
-         const int l = data->gamma_row_index[ii][inz];
-         const int k = data->gamma_col_index[ii][inz];
+      for (int inz = 0; inz < data->gamma_nnz; inz++) {
+        const int l = data->gamma_row_index[ii][inz];
+        const int k = data->gamma_col_index[ii][inz];
 
-              data->gradforce[i][l] += data->gamma[ii][inz] * 
-                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
-              data->gradforce[i][l + data->yoffset] += data->gamma[ii][inz] * 
-                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
-              data->gradforce[i][l + data->zoffset] += data->gamma[ii][inz] * 
-                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
-              data->gradforce[j][l] -= data->gamma[ii][inz] * 
-                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
-              data->gradforce[j][l + data->yoffset] -= data->gamma[ii][inz] * 
-                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
-              data->gradforce[j][l + data->zoffset] -= data->gamma[ii][inz] * 
-                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
-         }
+        data->gradforce[i][l] +=
+            data->gamma[ii][inz] * so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
+        data->gradforce[i][l + data->yoffset] +=
+            data->gamma[ii][inz] * so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
+        data->gradforce[i][l + data->zoffset] +=
+            data->gamma[ii][inz] * so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
+        data->gradforce[j][l] -=
+            data->gamma[ii][inz] * so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
+        data->gradforce[j][l + data->yoffset] -=
+            data->gamma[ii][inz] * so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
+        data->gradforce[j][l + data->zoffset] -=
+            data->gamma[ii][inz] * so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
+      }
       ij++;
-     }
+    }
   }
 }
 
@@ -322,9 +322,9 @@ void MLIAPDescriptorSO3::compute_descriptor_gradients(class MLIAPData *data)
         data->graddesc[ij][k][0] = so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
         data->graddesc[ij][k][1] = so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
         data->graddesc[ij][k][2] = so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
-         }
+      }
       ij++;
-     }
+    }
   }
 }
 

--- a/src/ML-IAP/mliap_descriptor_so3.cpp
+++ b/src/ML-IAP/mliap_descriptor_so3.cpp
@@ -263,6 +263,73 @@ void MLIAPDescriptorSO3::compute_forces(class MLIAPData *data)
 
 /* ---------------------------------------------------------------------- */
 
+void MLIAPDescriptorSO3::compute_force_gradients(class MLIAPData *data)
+{
+  bigint npairs = 0;
+  for (int ii = 0; ii < data->nlistatoms; ii++) npairs += data->numneighs[ii];
+
+  so3ptr->spectrum_dxdr(data->nlistatoms, data->numneighs, data->jelems, wjelem, data->rij, nmax,
+                        lmax, rcutfac, alpha, npairs, data->ndescriptors);
+  int ij = 0;
+
+  for (int ii = 0; ii < data->nlistatoms; ii++) {
+    const int i = data->iatoms[ii];
+
+    // insure rij, inside, wj, and rcutij are of size jnum
+
+    const int jnum = data->numneighs[ii];
+
+    for (int jj = 0; jj < jnum; jj++) {
+      int j = data->jatoms[ij];
+
+      for (int inz = 0; inz < data->gamma_nnz; inz++){
+         const int l = data->gamma_row_index[ii][inz];
+         const int k = data->gamma_col_index[ii][inz];
+
+              data->gradforce[i][l] += data->gamma[ii][inz] * 
+                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
+              data->gradforce[i][l + data->yoffset] += data->gamma[ii][inz] * 
+                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
+              data->gradforce[i][l + data->zoffset] += data->gamma[ii][inz] * 
+                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
+              data->gradforce[j][l] -= data->gamma[ii][inz] * 
+                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
+              data->gradforce[j][l + data->yoffset] -= data->gamma[ii][inz] * 
+                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
+              data->gradforce[j][l + data->zoffset] -= data->gamma[ii][inz] * 
+                      so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
+         }
+      ij++;
+     }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void MLIAPDescriptorSO3::compute_descriptor_gradients(class MLIAPData *data)
+{
+  bigint npairs = 0;
+  for (int ii = 0; ii < data->nlistatoms; ii++) npairs += data->numneighs[ii];
+
+  so3ptr->spectrum_dxdr(data->nlistatoms, data->numneighs, data->jelems, wjelem, data->rij, nmax,
+                        lmax, rcutfac, alpha, npairs, data->ndescriptors);
+  int ij = 0;
+
+  for (int ii = 0; ii < data->nlistatoms; ii++) {
+    const int jnum = data->numneighs[ii];
+    for (int jj = 0; jj < jnum; jj++) {
+      for (int k = 0; k < data->ndescriptors; k++) {
+        data->graddesc[ij][k][0] = so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3];
+        data->graddesc[ij][k][1] = so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 1];
+        data->graddesc[ij][k][2] = so3ptr->m_dplist_r[(ij * (data->ndescriptors) + k) * 3 + 2];
+         }
+      ij++;
+     }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
 void MLIAPDescriptorSO3::init()
 {
   so3ptr->init();

--- a/src/ML-IAP/mliap_descriptor_so3.h
+++ b/src/ML-IAP/mliap_descriptor_so3.h
@@ -26,8 +26,8 @@ class MLIAPDescriptorSO3 : public MLIAPDescriptor {
 
   void compute_descriptors(class MLIAPData *) override;
   void compute_forces(class MLIAPData *) override;
-  void compute_force_gradients(class MLIAPData *) override{};
-  void compute_descriptor_gradients(class MLIAPData *) override{};
+  void compute_force_gradients(class MLIAPData *) override;
+  void compute_descriptor_gradients(class MLIAPData *) override;
   void init() override;
   double memory_usage() override;
 


### PR DESCRIPTION
**Summary**

This contribution add the possibility to use the so3 descriptor with the compute_mliap command.

**Related Issue(s)**

None

**Author(s)**

Aloïs Castellano @ university of Liège (alois.castellano@uliege.be)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Is backward compatible.

**Implementation Notes**

Implementation was inspired by the SNAP compute_mliap command. 
To verify the implementation, I checked that by multiplying the descriptors computed with the command by some coefficients, we obtain the same energy, forces and stress that are obtained by using the pair_style mliap with those coefficients. 

**Post Submission Checklist**


- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


