### PR TITLE
Update ML-PACE installation to v.2021.10.25.fix version

### DIFF
--- a/cmake/Modules/Packages/ML-PACE.cmake
+++ b/cmake/Modules/Packages/ML-PACE.cmake
@@ -1,6 +1,6 @@
-set(PACELIB_URL "https://github.com/ICAMS/lammps-user-pace/archive/refs/tags/v.2021.10.25.tar.gz" CACHE STRING "URL for PACE evaluator library sources")
+set(PACELIB_URL "https://github.com/ICAMS/lammps-user-pace/archive/refs/tags/v.2021.10.25.fix.tar.gz" CACHE STRING "URL for PACE evaluator library sources")
 
-set(PACELIB_MD5 "a2ac3315c41a1a4a5c912bcb1bc9c5cc" CACHE STRING "MD5 checksum of PACE evaluator library tarball")
+set(PACELIB_MD5 "e0572de57039d4afedefb25707b6ceae" CACHE STRING "MD5 checksum of PACE evaluator library tarball")
 mark_as_advanced(PACELIB_URL)
 mark_as_advanced(PACELIB_MD5)
 

--- a/lib/pace/Install.py
+++ b/lib/pace/Install.py
@@ -15,14 +15,15 @@ from install_helpers import fullpath, geturl, checkmd5sum
 # settings
 
 thisdir = fullpath('.')
-version = 'v.2021.10.25'
+version = 'v.2021.10.25.fix'
 
 # known checksums for different PACE versions. used to validate the download.
 checksums = { \
         'v.2021.2.3.upd2' : '8fd1162724d349b930e474927197f20d',
         'v.2021.4.9'      : '4db54962fbd6adcf8c18d46e1798ceb5',
         'v.2021.9.28'     : 'f98363bb98adc7295ea63974738c2a1b',
-        'v.2021.10.25'    : 'a2ac3315c41a1a4a5c912bcb1bc9c5cc'
+        'v.2021.10.25'    : 'a2ac3315c41a1a4a5c912bcb1bc9c5cc',
+	'v.2021.10.25.fix': 'e0572de57039d4afedefb25707b6ceae'
         }
 
 


### PR DESCRIPTION
update of ML-PACE installation to v.2021.10.25.fix version, that include PR: https://github.com/ICAMS/lammps-user-pace/pull/7