### PR TITLE
Command table split into two tables

### DIFF
--- a/doc/src/Commands_all.rst
+++ b/doc/src/Commands_all.rst
@@ -66,7 +66,6 @@ An alphabetic list of general LAMMPS commands.
    * :doc:`minimize <minimize>`
    * :doc:`min_modify <min_modify>`
    * :doc:`min_style <min_style>`
-   * :doc:`min_style spin <min_spin>`
    * :doc:`molecule <molecule>`
    * :doc:`neigh_modify <neigh_modify>`
    * :doc:`neighbor <neighbor>`
@@ -80,7 +79,6 @@ An alphabetic list of general LAMMPS commands.
    * :doc:`partition <partition>`
    * :doc:`print <print>`
    * :doc:`processors <processors>`
-   * :doc:`python <python>`
    * :doc:`quit <quit>`
    * :doc:`read_data <read_data>`
    * :doc:`read_dump <read_dump>`
@@ -114,9 +112,9 @@ An alphabetic list of general LAMMPS commands.
    * :doc:`write_dump <write_dump>`
    * :doc:`write_restart <write_restart>`
 
-An alphabetic list of additional general LAMMPS commands provided by
-packages.  A few commands have accelerated versions.  This is
-indicated by an additional letter in parenthesis: k = KOKKOS.
+Additional general LAMMPS commands provided by packages.  A few
+commands have accelerated versions.  This is indicated by an
+additional letter in parenthesis: k = KOKKOS.
 
 .. table_from_list::
    :columns: 5
@@ -131,6 +129,7 @@ indicated by an additional letter in parenthesis: k = KOKKOS.
    * :doc:`neb/spin <neb_spin>`
    * :doc:`plugin <plugin>`
    * :doc:`prd <prd>`
+   * :doc:`python <python>`
    * :doc:`tad <tad>`
    * :doc:`temper <temper>`
    * :doc:`temper/grem <temper_grem>`

--- a/doc/src/Commands_all.rst
+++ b/doc/src/Commands_all.rst
@@ -14,7 +14,7 @@
 General commands
 ================
 
-An alphabetic list of all general LAMMPS commands.
+An alphabetic list of general LAMMPS commands.
 
 .. table_from_list::
    :columns: 5
@@ -47,35 +47,27 @@ An alphabetic list of all general LAMMPS commands.
    * :doc:`displace_atoms <displace_atoms>`
    * :doc:`dump <dump>`
    * :doc:`dump_modify <dump_modify>`
-   * :doc:`dynamical_matrix (k) <dynamical_matrix>`
    * :doc:`echo <echo>`
    * :doc:`fix <fix>`
    * :doc:`fix_modify <fix_modify>`
    * :doc:`group <group>`
-   * :doc:`group2ndx <group2ndx>`
-   * :doc:`hyper <hyper>`
    * :doc:`if <if>`
    * :doc:`improper_coeff <improper_coeff>`
    * :doc:`improper_style <improper_style>`
    * :doc:`include <include>`
    * :doc:`info <info>`
    * :doc:`jump <jump>`
-   * :doc:`kim <kim_commands>`
    * :doc:`kspace_modify <kspace_modify>`
    * :doc:`kspace_style <kspace_style>`
    * :doc:`label <label>`
    * :doc:`lattice <lattice>`
    * :doc:`log <log>`
    * :doc:`mass <mass>`
-   * :doc:`mdi <mdi>`
    * :doc:`minimize <minimize>`
    * :doc:`min_modify <min_modify>`
    * :doc:`min_style <min_style>`
    * :doc:`min_style spin <min_spin>`
    * :doc:`molecule <molecule>`
-   * :doc:`ndx2group <group2ndx>`
-   * :doc:`neb <neb>`
-   * :doc:`neb/spin <neb_spin>`
    * :doc:`neigh_modify <neigh_modify>`
    * :doc:`neighbor <neighbor>`
    * :doc:`newton <newton>`
@@ -86,8 +78,6 @@ An alphabetic list of all general LAMMPS commands.
    * :doc:`pair_style <pair_style>`
    * :doc:`pair_write <pair_write>`
    * :doc:`partition <partition>`
-   * :doc:`plugin <plugin>`
-   * :doc:`prd <prd>`
    * :doc:`print <print>`
    * :doc:`processors <processors>`
    * :doc:`python <python>`
@@ -108,14 +98,9 @@ An alphabetic list of all general LAMMPS commands.
    * :doc:`shell <shell>`
    * :doc:`special_bonds <special_bonds>`
    * :doc:`suffix <suffix>`
-   * :doc:`tad <tad>`
-   * :doc:`temper <temper>`
-   * :doc:`temper/grem <temper_grem>`
-   * :doc:`temper/npt <temper_npt>`
    * :doc:`thermo <thermo>`
    * :doc:`thermo_modify <thermo_modify>`
    * :doc:`thermo_style <thermo_style>`
-   * :doc:`third_order (k) <third_order>`
    * :doc:`timer <timer>`
    * :doc:`timestep <timestep>`
    * :doc:`uncompute <uncompute>`
@@ -128,3 +113,26 @@ An alphabetic list of all general LAMMPS commands.
    * :doc:`write_data <write_data>`
    * :doc:`write_dump <write_dump>`
    * :doc:`write_restart <write_restart>`
+
+An alphabetic list of additional general LAMMPS commands provided by
+packages.  A few commands have accelerated versions.  This is
+indicated by an additional letter in parenthesis: k = KOKKOS.
+
+.. table_from_list::
+   :columns: 5
+
+   * :doc:`dynamical_matrix (k) <dynamical_matrix>`
+   * :doc:`group2ndx <group2ndx>`
+   * :doc:`hyper <hyper>`
+   * :doc:`kim <kim_commands>`
+   * :doc:`mdi <mdi>`
+   * :doc:`ndx2group <group2ndx>`
+   * :doc:`neb <neb>`
+   * :doc:`neb/spin <neb_spin>`
+   * :doc:`plugin <plugin>`
+   * :doc:`prd <prd>`
+   * :doc:`tad <tad>`
+   * :doc:`temper <temper>`
+   * :doc:`temper/grem <temper_grem>`
+   * :doc:`temper/npt <temper_npt>`
+   * :doc:`third_order (k) <third_order>`

--- a/doc/src/min_spin.rst
+++ b/doc/src/min_spin.rst
@@ -98,6 +98,10 @@ see their implementation reported in :ref:`(Ivanov) <Ivanov1>`.
 Restrictions
 """"""""""""
 
+The *spin*, *spin/cg*, and *spin/lbfgps* styles are part of the SPIN
+package.  They are only enabled if LAMMPS was built with that package.
+See the :doc:`Build package <Build_package>` page for more info.
+
 This minimization procedure is only applied to spin degrees of
 freedom for a frozen lattice configuration.
 

--- a/doc/src/min_style.rst
+++ b/doc/src/min_style.rst
@@ -3,14 +3,29 @@
 min_style command
 =================
 
+:doc:`min_style spin <min_spin>` command
+==================================
+
+:doc:`min_style spin/cg <min_spin>` command
+==================================
+
+:doc:`min_style spin/lbfgs <min_spin>` command
+==================================
+
 Syntax
 """"""
 
-.. code-block:: LAMMPS
+.. parsed-literal::
 
    min_style style
 
 * style = *cg* or *hftn* or *sd* or *quickmin* or *fire* or *fire/old* or *spin* or *spin/cg* or *spin/lbfgs*
+
+  .. parsed-literal::
+
+       *spin* is discussed briefly here and fully on :doc:`min_style spin <min_spin>` doc page
+       *spin/cg* is discussed briefly here and fully on :doc:`min_style spin <min_spin>` doc page
+       *spin/lbfgs* is discussed briefly here and fully on :doc:`min_style spin <min_spin>` doc page
 
 Examples
 """"""""
@@ -18,8 +33,8 @@ Examples
 .. code-block:: LAMMPS
 
    min_style cg
-   min_style spin
    min_style fire
+   min_style spin
 
 Description
 """""""""""
@@ -124,7 +139,9 @@ calculations via the :doc:`neb/spin <neb_spin>` command.
 Restrictions
 """"""""""""
 
-none
+The *spin*, *spin/cg*, and *spin/lbfgps* styles are part of the SPIN
+package.  They are only enabled if LAMMPS was built with that package.
+See the :doc:`Build package <Build_package>` page for more info.
 
 Related commands
 """"""""""""""""


### PR DESCRIPTION
**Summary**

Split the doc page with an alphbetic list of commands in a large table into 2 tables.  One for standard LAMMPS commands,
the other for commands provided by packages.

**Related Issue(s)**

N?A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


