### PR TITLE
Initial refactor of view allocation in Kokkos package

### DIFF
--- a/src/KOKKOS/memory_kokkos.h
+++ b/src/KOKKOS/memory_kokkos.h
@@ -284,7 +284,6 @@ template <typename TYPE>
 static void realloc_kokkos(TYPE &data, const char *name, int n1)
 {
   data = TYPE();
-  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1);
 }
 
@@ -292,7 +291,6 @@ template <typename TYPE>
 static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2)
 {
   data = TYPE();
-  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2);
 }
 
@@ -300,7 +298,6 @@ template <typename TYPE>
 static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3)
 {
   data = TYPE();
-  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3);
 }
 
@@ -308,7 +305,6 @@ template <typename TYPE>
 static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4)
 {
   data = TYPE();
-  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4);
 }
 
@@ -316,7 +312,6 @@ template <typename TYPE>
 static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5)
 {
   data = TYPE();
-  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4,n5);
 }
 
@@ -324,7 +319,6 @@ template <typename TYPE>
 static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5, int n6)
 {
   data = TYPE();
-  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4,n5,n6);
 }
 

--- a/src/KOKKOS/memory_kokkos.h
+++ b/src/KOKKOS/memory_kokkos.h
@@ -20,6 +20,8 @@
 
 namespace LAMMPS_NS {
 
+typedef MemoryKokkos MemKK;
+
 class MemoryKokkos : public Memory {
  public:
   MemoryKokkos(class LAMMPS *lmp) : Memory(lmp) {}
@@ -279,44 +281,50 @@ void destroy_kokkos(TYPE data, typename TYPE::value_type** &array)
 ------------------------------------------------------------------------- */
 
 template <typename TYPE>
-void realloc_kokkos(TYPE &data, const char *name, int n1)
+static void realloc_kokkos(TYPE &data, const char *name, int n1)
 {
   data = TYPE();
+  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1);
 }
 
 template <typename TYPE>
-void realloc_kokkos(TYPE &data, const char *name, int n1, int n2)
+static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2)
 {
   data = TYPE();
+  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2);
 }
 
 template <typename TYPE>
-void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3)
+static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3)
 {
   data = TYPE();
+  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3);
 }
 
 template <typename TYPE>
-void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4)
+static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4)
 {
   data = TYPE();
+  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4);
 }
 
 template <typename TYPE>
-void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5)
+static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5)
 {
   data = TYPE();
+  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4,n5);
 }
 
 template <typename TYPE>
-void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5, int n6)
+static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5, int n6)
 {
   data = TYPE();
+  assert(data.use_count() == 0);
   data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4,n5,n6);
 }
 
@@ -325,7 +333,7 @@ void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4
 ------------------------------------------------------------------------- */
 
 template <typename TYPE>
-double memory_usage(TYPE &data)
+static double memory_usage(TYPE &data)
 {
   return data.span() * sizeof(typename TYPE::value_type);
 }

--- a/src/KOKKOS/memory_kokkos.h
+++ b/src/KOKKOS/memory_kokkos.h
@@ -280,46 +280,11 @@ void destroy_kokkos(TYPE data, typename TYPE::value_type** &array)
    deallocate first to reduce memory use
 ------------------------------------------------------------------------- */
 
-template <typename TYPE>
-static void realloc_kokkos(TYPE &data, const char *name, int n1)
+template <typename TYPE, typename... Indices>
+static void realloc_kokkos(TYPE &data, const char *name, Indices... ns)
 {
   data = TYPE();
-  data = TYPE(Kokkos::NoInit(std::string(name)),n1);
-}
-
-template <typename TYPE>
-static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2)
-{
-  data = TYPE();
-  data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2);
-}
-
-template <typename TYPE>
-static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3)
-{
-  data = TYPE();
-  data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3);
-}
-
-template <typename TYPE>
-static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4)
-{
-  data = TYPE();
-  data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4);
-}
-
-template <typename TYPE>
-static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5)
-{
-  data = TYPE();
-  data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4,n5);
-}
-
-template <typename TYPE>
-static void realloc_kokkos(TYPE &data, const char *name, int n1, int n2, int n3, int n4, int n5, int n6)
-{
-  data = TYPE();
-  data = TYPE(Kokkos::NoInit(std::string(name)),n1,n2,n3,n4,n5,n6);
+  data = TYPE(Kokkos::NoInit(std::string(name)), ns...);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/pair_pace_kokkos.cpp
+++ b/src/KOKKOS/pair_pace_kokkos.cpp
@@ -104,55 +104,55 @@ void PairPACEKokkos<DeviceType>::grow(int natom, int maxneigh)
 
   if ((int)A.extent(0) < natom) {
 
-    memoryKK->realloc_kokkos(A, "pace:A", natom, nelements, nradmax + 1, (lmax + 1) * (lmax + 1));
-    memoryKK->realloc_kokkos(A_rank1, "pace:A_rank1", natom, nelements, nradbase);
+    MemKK::realloc_kokkos(A, "pace:A", natom, nelements, nradmax + 1, (lmax + 1) * (lmax + 1));
+    MemKK::realloc_kokkos(A_rank1, "pace:A_rank1", natom, nelements, nradbase);
 
-    memoryKK->realloc_kokkos(A_list, "pace:A_list", natom, idx_rho_max, basis_set->rankmax);
+    MemKK::realloc_kokkos(A_list, "pace:A_list", natom, idx_rho_max, basis_set->rankmax);
     //size is +1 of max to avoid out-of-boundary array access in double-triangular scheme
-    memoryKK->realloc_kokkos(A_forward_prod, "pace:A_forward_prod", natom, idx_rho_max, basis_set->rankmax + 1);
+    MemKK::realloc_kokkos(A_forward_prod, "pace:A_forward_prod", natom, idx_rho_max, basis_set->rankmax + 1);
 
-    memoryKK->realloc_kokkos(e_atom, "pace:e_atom", natom);
-    memoryKK->realloc_kokkos(rhos, "pace:rhos", natom, basis_set->ndensitymax + 1); // +1 density for core repulsion
-    memoryKK->realloc_kokkos(dF_drho, "pace:dF_drho", natom, basis_set->ndensitymax + 1); // +1 density for core repulsion
+    MemKK::realloc_kokkos(e_atom, "pace:e_atom", natom);
+    MemKK::realloc_kokkos(rhos, "pace:rhos", natom, basis_set->ndensitymax + 1); // +1 density for core repulsion
+    MemKK::realloc_kokkos(dF_drho, "pace:dF_drho", natom, basis_set->ndensitymax + 1); // +1 density for core repulsion
 
-    memoryKK->realloc_kokkos(weights, "pace:weights", natom, nelements, nradmax + 1, (lmax + 1) * (lmax + 1));
-    memoryKK->realloc_kokkos(weights_rank1, "pace:weights_rank1", natom, nelements, nradbase);
+    MemKK::realloc_kokkos(weights, "pace:weights", natom, nelements, nradmax + 1, (lmax + 1) * (lmax + 1));
+    MemKK::realloc_kokkos(weights_rank1, "pace:weights_rank1", natom, nelements, nradbase);
 
     // hard-core repulsion
-    memoryKK->realloc_kokkos(rho_core, "pace:rho_core", natom);
-    memoryKK->realloc_kokkos(dF_drho_core, "pace:dF_drho_core", natom);
-    memoryKK->realloc_kokkos(dB_flatten, "pace:dB_flatten", natom, idx_rho_max, basis_set->rankmax);
+    MemKK::realloc_kokkos(rho_core, "pace:rho_core", natom);
+    MemKK::realloc_kokkos(dF_drho_core, "pace:dF_drho_core", natom);
+    MemKK::realloc_kokkos(dB_flatten, "pace:dB_flatten", natom, idx_rho_max, basis_set->rankmax);
   }
 
   if (((int)ylm.extent(0) < natom) || ((int)ylm.extent(1) < maxneigh)) {
 
     // radial functions
-    memoryKK->realloc_kokkos(fr, "pace:fr", natom, maxneigh, nradmax, lmax + 1);
-    memoryKK->realloc_kokkos(dfr, "pace:dfr", natom, maxneigh, nradmax, lmax + 1);
-    memoryKK->realloc_kokkos(gr, "pace:gr", natom, maxneigh, nradbase);
-    memoryKK->realloc_kokkos(dgr, "pace:dgr", natom, maxneigh, nradbase);
+    MemKK::realloc_kokkos(fr, "pace:fr", natom, maxneigh, nradmax, lmax + 1);
+    MemKK::realloc_kokkos(dfr, "pace:dfr", natom, maxneigh, nradmax, lmax + 1);
+    MemKK::realloc_kokkos(gr, "pace:gr", natom, maxneigh, nradbase);
+    MemKK::realloc_kokkos(dgr, "pace:dgr", natom, maxneigh, nradbase);
     const int max_num_functions = MAX(nradbase, nradmax*(lmax + 1));
-    memoryKK->realloc_kokkos(d_values, "pace:d_values", natom, maxneigh, max_num_functions);
-    memoryKK->realloc_kokkos(d_derivatives, "pace:d_derivatives", natom, maxneigh, max_num_functions);
+    MemKK::realloc_kokkos(d_values, "pace:d_values", natom, maxneigh, max_num_functions);
+    MemKK::realloc_kokkos(d_derivatives, "pace:d_derivatives", natom, maxneigh, max_num_functions);
 
     // hard-core repulsion
-    memoryKK->realloc_kokkos(cr, "pace:cr", natom, maxneigh);
-    memoryKK->realloc_kokkos(dcr, "pace:dcr", natom, maxneigh);
+    MemKK::realloc_kokkos(cr, "pace:cr", natom, maxneigh);
+    MemKK::realloc_kokkos(dcr, "pace:dcr", natom, maxneigh);
 
     // spherical harmonics
-    memoryKK->realloc_kokkos(plm, "pace:plm", natom, maxneigh, (lmax + 1) * (lmax + 1));
-    memoryKK->realloc_kokkos(dplm, "pace:dplm", natom, maxneigh, (lmax + 1) * (lmax + 1));
-    memoryKK->realloc_kokkos(ylm, "pace:ylm", natom, maxneigh, (lmax + 1) * (lmax + 1));
-    memoryKK->realloc_kokkos(dylm, "pace:dylm", natom, maxneigh, (lmax + 1) * (lmax + 1));
+    MemKK::realloc_kokkos(plm, "pace:plm", natom, maxneigh, (lmax + 1) * (lmax + 1));
+    MemKK::realloc_kokkos(dplm, "pace:dplm", natom, maxneigh, (lmax + 1) * (lmax + 1));
+    MemKK::realloc_kokkos(ylm, "pace:ylm", natom, maxneigh, (lmax + 1) * (lmax + 1));
+    MemKK::realloc_kokkos(dylm, "pace:dylm", natom, maxneigh, (lmax + 1) * (lmax + 1));
 
     // short neigh list
-    memoryKK->realloc_kokkos(d_ncount, "pace:ncount", natom);
-    memoryKK->realloc_kokkos(d_mu, "pace:mu", natom, maxneigh);
-    memoryKK->realloc_kokkos(d_rhats, "pace:rhats", natom, maxneigh);
-    memoryKK->realloc_kokkos(d_rnorms, "pace:rnorms", natom, maxneigh);
-    memoryKK->realloc_kokkos(d_nearest, "pace:nearest", natom, maxneigh);
+    MemKK::realloc_kokkos(d_ncount, "pace:ncount", natom);
+    MemKK::realloc_kokkos(d_mu, "pace:mu", natom, maxneigh);
+    MemKK::realloc_kokkos(d_rhats, "pace:rhats", natom, maxneigh);
+    MemKK::realloc_kokkos(d_rnorms, "pace:rnorms", natom, maxneigh);
+    MemKK::realloc_kokkos(d_nearest, "pace:nearest", natom, maxneigh);
 
-    memoryKK->realloc_kokkos(f_ij, "pace:f_ij", natom, maxneigh);
+    MemKK::realloc_kokkos(f_ij, "pace:f_ij", natom, maxneigh);
   }
 }
 
@@ -163,11 +163,11 @@ void PairPACEKokkos<DeviceType>::copy_pertype()
 {
   auto basis_set = aceimpl->basis_set;
 
-  memoryKK->realloc_kokkos(d_rho_core_cutoff, "pace:rho_core_cutoff", nelements);
-  memoryKK->realloc_kokkos(d_drho_core_cutoff, "pace:drho_core_cutoff", nelements);
-  memoryKK->realloc_kokkos(d_E0vals, "pace:E0vals", nelements);
-  memoryKK->realloc_kokkos(d_ndensity, "pace:ndensity", nelements);
-  memoryKK->realloc_kokkos(d_npoti, "pace:npoti", nelements);
+  MemKK::realloc_kokkos(d_rho_core_cutoff, "pace:rho_core_cutoff", nelements);
+  MemKK::realloc_kokkos(d_drho_core_cutoff, "pace:drho_core_cutoff", nelements);
+  MemKK::realloc_kokkos(d_E0vals, "pace:E0vals", nelements);
+  MemKK::realloc_kokkos(d_ndensity, "pace:ndensity", nelements);
+  MemKK::realloc_kokkos(d_npoti, "pace:npoti", nelements);
 
   auto h_rho_core_cutoff = Kokkos::create_mirror_view(d_rho_core_cutoff);
   auto h_drho_core_cutoff = Kokkos::create_mirror_view(d_drho_core_cutoff);
@@ -196,8 +196,8 @@ void PairPACEKokkos<DeviceType>::copy_pertype()
   Kokkos::deep_copy(d_ndensity, h_ndensity);
   Kokkos::deep_copy(d_npoti, h_npoti);
 
-  memoryKK->realloc_kokkos(d_wpre, "pace:wpre", nelements, basis_set->ndensitymax);
-  memoryKK->realloc_kokkos(d_mexp, "pace:mexp", nelements, basis_set->ndensitymax);
+  MemKK::realloc_kokkos(d_wpre, "pace:wpre", nelements, basis_set->ndensitymax);
+  MemKK::realloc_kokkos(d_mexp, "pace:mexp", nelements, basis_set->ndensitymax);
 
   auto h_wpre = Kokkos::create_mirror_view(d_wpre);
   auto h_mexp = Kokkos::create_mirror_view(d_mexp);
@@ -266,7 +266,7 @@ void PairPACEKokkos<DeviceType>::copy_tilde()
   idx_rho_max = 0;
   int total_basis_size_max = 0;
 
-  memoryKK->realloc_kokkos(d_idx_rho_count, "pace:idx_rho_count", nelements);
+  MemKK::realloc_kokkos(d_idx_rho_count, "pace:idx_rho_count", nelements);
   auto h_idx_rho_count = Kokkos::create_mirror_view(d_idx_rho_count);
 
   for (int n = 0; n < nelements; n++) {
@@ -295,14 +295,14 @@ void PairPACEKokkos<DeviceType>::copy_tilde()
 
   Kokkos::deep_copy(d_idx_rho_count, h_idx_rho_count);
 
-  memoryKK->realloc_kokkos(d_rank, "pace:rank", nelements, total_basis_size_max);
-  memoryKK->realloc_kokkos(d_num_ms_combs, "pace:num_ms_combs", nelements, total_basis_size_max);
-  memoryKK->realloc_kokkos(d_offsets, "pace:offsets", nelements, idx_rho_max);
-  memoryKK->realloc_kokkos(d_mus, "pace:mus", nelements, total_basis_size_max, basis_set->rankmax);
-  memoryKK->realloc_kokkos(d_ns, "pace:ns", nelements, total_basis_size_max, basis_set->rankmax);
-  memoryKK->realloc_kokkos(d_ls, "pace:ls", nelements, total_basis_size_max, basis_set->rankmax);
-  memoryKK->realloc_kokkos(d_ms_combs, "pace:ms_combs", nelements, idx_rho_max, basis_set->rankmax);
-  memoryKK->realloc_kokkos(d_ctildes, "pace:ctildes", nelements, idx_rho_max, basis_set->ndensitymax);
+  MemKK::realloc_kokkos(d_rank, "pace:rank", nelements, total_basis_size_max);
+  MemKK::realloc_kokkos(d_num_ms_combs, "pace:num_ms_combs", nelements, total_basis_size_max);
+  MemKK::realloc_kokkos(d_offsets, "pace:offsets", nelements, idx_rho_max);
+  MemKK::realloc_kokkos(d_mus, "pace:mus", nelements, total_basis_size_max, basis_set->rankmax);
+  MemKK::realloc_kokkos(d_ns, "pace:ns", nelements, total_basis_size_max, basis_set->rankmax);
+  MemKK::realloc_kokkos(d_ls, "pace:ls", nelements, total_basis_size_max, basis_set->rankmax);
+  MemKK::realloc_kokkos(d_ms_combs, "pace:ms_combs", nelements, idx_rho_max, basis_set->rankmax);
+  MemKK::realloc_kokkos(d_ctildes, "pace:ctildes", nelements, idx_rho_max, basis_set->ndensitymax);
 
   auto h_rank = Kokkos::create_mirror_view(d_rank);
   auto h_num_ms_combs = Kokkos::create_mirror_view(d_num_ms_combs);
@@ -418,10 +418,10 @@ void PairPACEKokkos<DeviceType>::init_style()
 
   // spherical harmonics
 
-  memoryKK->realloc_kokkos(alm, "pace:alm", (lmax + 1) * (lmax + 1));
-  memoryKK->realloc_kokkos(blm, "pace:blm", (lmax + 1) * (lmax + 1));
-  memoryKK->realloc_kokkos(cl, "pace:cl", lmax + 1);
-  memoryKK->realloc_kokkos(dl, "pace:dl", lmax + 1);
+  MemKK::realloc_kokkos(alm, "pace:alm", (lmax + 1) * (lmax + 1));
+  MemKK::realloc_kokkos(blm, "pace:blm", (lmax + 1) * (lmax + 1));
+  MemKK::realloc_kokkos(cl, "pace:cl", lmax + 1);
+  MemKK::realloc_kokkos(dl, "pace:dl", lmax + 1);
 
   pre_compute_harmonics(lmax);
   copy_pertype();
@@ -474,12 +474,12 @@ void PairPACEKokkos<DeviceType>::allocate()
   PairPACE::allocate();
 
   int n = atom->ntypes + 1;
-  memoryKK->realloc_kokkos(d_map, "pace:map", n);
+  MemKK::realloc_kokkos(d_map, "pace:map", n);
 
-  memoryKK->realloc_kokkos(k_cutsq, "pace:cutsq", n, n);
+  MemKK::realloc_kokkos(k_cutsq, "pace:cutsq", n, n);
   d_cutsq = k_cutsq.template view<DeviceType>();
 
-  memoryKK->realloc_kokkos(k_scale, "pace:scale", n, n);
+  MemKK::realloc_kokkos(k_scale, "pace:scale", n, n);
   d_scale = k_scale.template view<DeviceType>();
 }
 
@@ -1651,56 +1651,56 @@ double PairPACEKokkos<DeviceType>::memory_usage()
 {
   double bytes = 0;
 
-  bytes += memoryKK->memory_usage(A);
-  bytes += memoryKK->memory_usage(A_rank1);
-  bytes += memoryKK->memory_usage(A_list);
-  bytes += memoryKK->memory_usage(A_forward_prod);
-  bytes += memoryKK->memory_usage(e_atom);
-  bytes += memoryKK->memory_usage(rhos);
-  bytes += memoryKK->memory_usage(dF_drho);
-  bytes += memoryKK->memory_usage(weights);
-  bytes += memoryKK->memory_usage(weights_rank1);
-  bytes += memoryKK->memory_usage(rho_core);
-  bytes += memoryKK->memory_usage(dF_drho_core);
-  bytes += memoryKK->memory_usage(dB_flatten);
-  bytes += memoryKK->memory_usage(fr);
-  bytes += memoryKK->memory_usage(dfr);
-  bytes += memoryKK->memory_usage(gr);
-  bytes += memoryKK->memory_usage(dgr);
-  bytes += memoryKK->memory_usage(d_values);
-  bytes += memoryKK->memory_usage(d_derivatives);
-  bytes += memoryKK->memory_usage(cr);
-  bytes += memoryKK->memory_usage(dcr);
-  bytes += memoryKK->memory_usage(plm);
-  bytes += memoryKK->memory_usage(dplm);
-  bytes += memoryKK->memory_usage(ylm);
-  bytes += memoryKK->memory_usage(dylm);
-  bytes += memoryKK->memory_usage(d_ncount);
-  bytes += memoryKK->memory_usage(d_mu);
-  bytes += memoryKK->memory_usage(d_rhats);
-  bytes += memoryKK->memory_usage(d_rnorms);
-  bytes += memoryKK->memory_usage(d_nearest);
-  bytes += memoryKK->memory_usage(f_ij);
-  bytes += memoryKK->memory_usage(d_rho_core_cutoff);
-  bytes += memoryKK->memory_usage(d_drho_core_cutoff);
-  bytes += memoryKK->memory_usage(d_E0vals);
-  bytes += memoryKK->memory_usage(d_ndensity);
-  bytes += memoryKK->memory_usage(d_npoti);
-  bytes += memoryKK->memory_usage(d_wpre);
-  bytes += memoryKK->memory_usage(d_mexp);
-  bytes += memoryKK->memory_usage(d_idx_rho_count);
-  bytes += memoryKK->memory_usage(d_rank);
-  bytes += memoryKK->memory_usage(d_num_ms_combs);
-  bytes += memoryKK->memory_usage(d_offsets);
-  bytes += memoryKK->memory_usage(d_mus);
-  bytes += memoryKK->memory_usage(d_ns);
-  bytes += memoryKK->memory_usage(d_ls);
-  bytes += memoryKK->memory_usage(d_ms_combs);
-  bytes += memoryKK->memory_usage(d_ctildes);
-  bytes += memoryKK->memory_usage(alm);
-  bytes += memoryKK->memory_usage(blm);
-  bytes += memoryKK->memory_usage(cl);
-  bytes += memoryKK->memory_usage(dl);
+  bytes += MemKK::memory_usage(A);
+  bytes += MemKK::memory_usage(A_rank1);
+  bytes += MemKK::memory_usage(A_list);
+  bytes += MemKK::memory_usage(A_forward_prod);
+  bytes += MemKK::memory_usage(e_atom);
+  bytes += MemKK::memory_usage(rhos);
+  bytes += MemKK::memory_usage(dF_drho);
+  bytes += MemKK::memory_usage(weights);
+  bytes += MemKK::memory_usage(weights_rank1);
+  bytes += MemKK::memory_usage(rho_core);
+  bytes += MemKK::memory_usage(dF_drho_core);
+  bytes += MemKK::memory_usage(dB_flatten);
+  bytes += MemKK::memory_usage(fr);
+  bytes += MemKK::memory_usage(dfr);
+  bytes += MemKK::memory_usage(gr);
+  bytes += MemKK::memory_usage(dgr);
+  bytes += MemKK::memory_usage(d_values);
+  bytes += MemKK::memory_usage(d_derivatives);
+  bytes += MemKK::memory_usage(cr);
+  bytes += MemKK::memory_usage(dcr);
+  bytes += MemKK::memory_usage(plm);
+  bytes += MemKK::memory_usage(dplm);
+  bytes += MemKK::memory_usage(ylm);
+  bytes += MemKK::memory_usage(dylm);
+  bytes += MemKK::memory_usage(d_ncount);
+  bytes += MemKK::memory_usage(d_mu);
+  bytes += MemKK::memory_usage(d_rhats);
+  bytes += MemKK::memory_usage(d_rnorms);
+  bytes += MemKK::memory_usage(d_nearest);
+  bytes += MemKK::memory_usage(f_ij);
+  bytes += MemKK::memory_usage(d_rho_core_cutoff);
+  bytes += MemKK::memory_usage(d_drho_core_cutoff);
+  bytes += MemKK::memory_usage(d_E0vals);
+  bytes += MemKK::memory_usage(d_ndensity);
+  bytes += MemKK::memory_usage(d_npoti);
+  bytes += MemKK::memory_usage(d_wpre);
+  bytes += MemKK::memory_usage(d_mexp);
+  bytes += MemKK::memory_usage(d_idx_rho_count);
+  bytes += MemKK::memory_usage(d_rank);
+  bytes += MemKK::memory_usage(d_num_ms_combs);
+  bytes += MemKK::memory_usage(d_offsets);
+  bytes += MemKK::memory_usage(d_mus);
+  bytes += MemKK::memory_usage(d_ns);
+  bytes += MemKK::memory_usage(d_ls);
+  bytes += MemKK::memory_usage(d_ms_combs);
+  bytes += MemKK::memory_usage(d_ctildes);
+  bytes += MemKK::memory_usage(alm);
+  bytes += MemKK::memory_usage(blm);
+  bytes += MemKK::memory_usage(cl);
+  bytes += MemKK::memory_usage(dl);
 
   if (k_splines_gk.h_view.data()) {
     for (int i = 0; i < nelements; i++) {

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -36,6 +36,7 @@
 #include "kokkos.h"
 #include "math_const.h"
 #include "math_special.h"
+#include "memory_kokkos.h"
 #include "neigh_request.h"
 #include "neighbor.h"
 
@@ -78,8 +79,8 @@ PairReaxFFKokkos<DeviceType>::PairReaxFFKokkos(LAMMPS *lmp) : PairReaxFF(lmp)
   k_error_flag = DAT::tdual_int_scalar("pair:error_flag");
   k_nbuf_local = DAT::tdual_int_scalar("pair:nbuf_local");
 
-  d_torsion_pack = t_reax_int4_2d("reaxff:torsion_pack",1,2);
-  d_angular_pack = t_reax_int4_2d("reaxff:angular_pack",1,2);
+  MemKK::realloc_kokkos(d_torsion_pack,"reaxff:torsion_pack",1,2);
+  MemKK::realloc_kokkos(d_angular_pack,"reaxff:angular_pack",1,2);
 
   k_count_angular_torsion = DAT::tdual_int_1d("PairReaxFF::count_angular_torsion",2);
   d_count_angular_torsion = k_count_angular_torsion.template view<DeviceType>();
@@ -959,9 +960,9 @@ void PairReaxFFKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   count_torsion = h_count_angular_torsion(1);
 
   if (count_angular > (int)d_angular_pack.extent(0))
-    d_angular_pack = t_reax_int4_2d("reaxff:angular_pack",(int)(count_angular * 1.1),2);
+    MemKK::realloc_kokkos(d_angular_pack,"reaxff:angular_pack",(int)(count_angular * 1.1),2);
   if (count_torsion > (int)d_torsion_pack.extent(0))
-    d_torsion_pack = t_reax_int4_2d("reaxff:torsion_pack",(int)(count_torsion * 1.1),2);
+    MemKK::realloc_kokkos(d_torsion_pack,"reaxff:torsion_pack",(int)(count_torsion * 1.1),2);
 
   // need to zero to re-count
   h_count_angular_torsion(0) = 0;
@@ -1512,131 +1513,63 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeTabulatedLJCoulo
 template<class DeviceType>
 void PairReaxFFKokkos<DeviceType>::allocate_array()
 {
-  // deallocate first to reduce memory overhead
-
-  deallocate_array();
-
   if (cut_hbsq > 0.0) {
-    d_hb_first = typename AT::t_int_1d("reaxff/kk:hb_first",nmax);
-    d_hb_num = typename AT::t_int_1d("reaxff/kk:hb_num",nmax);
-    d_hb_list = typename AT::t_int_1d("reaxff/kk:hb_list",nmax*maxhb);
+    MemKK::realloc_kokkos(d_hb_first,"reaxff/kk:hb_first",nmax);
+    MemKK::realloc_kokkos(d_hb_num,"reaxff/kk:hb_num",nmax);
+    MemKK::realloc_kokkos(d_hb_list,"reaxff/kk:hb_list",nmax*maxhb);
   }
-  d_bo_first = typename AT::t_int_1d("reaxff/kk:bo_first",nmax);
-  d_bo_num = typename AT::t_int_1d("reaxff/kk:bo_num",nmax);
-  d_bo_list = typename AT::t_int_1d("reaxff/kk:bo_list",nmax*maxbo);
+  MemKK::realloc_kokkos(d_bo_first,"reaxff/kk:bo_first",nmax);
+  MemKK::realloc_kokkos(d_bo_num,"reaxff/kk:bo_num",nmax);
+  MemKK::realloc_kokkos(d_bo_list,"reaxff/kk:bo_list",nmax*maxbo);
 
-  d_BO = typename AT::t_ffloat_2d_dl("reaxff/kk:BO",nmax,maxbo);
-  d_BO_s = typename AT::t_ffloat_2d_dl("reaxff/kk:BO",nmax,maxbo);
-  d_BO_pi = typename AT::t_ffloat_2d_dl("reaxff/kk:BO_pi",nmax,maxbo);
-  d_BO_pi2 = typename AT::t_ffloat_2d_dl("reaxff/kk:BO_pi2",nmax,maxbo);
+  MemKK::realloc_kokkos(d_BO,"reaxff/kk:BO",nmax,maxbo);
+  MemKK::realloc_kokkos(d_BO_s,"reaxff/kk:BO",nmax,maxbo);
+  MemKK::realloc_kokkos(d_BO_pi,"reaxff/kk:BO_pi",nmax,maxbo);
+  MemKK::realloc_kokkos(d_BO_pi2,"reaxff/kk:BO_pi2",nmax,maxbo);
 
-  d_dln_BOp_pi = typename AT::t_ffloat_2d_dl("reaxff/kk:d_dln_BOp_pi",nmax,maxbo);
-  d_dln_BOp_pi2 = typename AT::t_ffloat_2d_dl("reaxff/kk:d_dln_BOp_pi2",nmax,maxbo);
+  MemKK::realloc_kokkos(d_dln_BOp_pi,"reaxff/kk:d_dln_BOp_pi",nmax,maxbo);
+  MemKK::realloc_kokkos(d_dln_BOp_pi2,"reaxff/kk:d_dln_BOp_pi2",nmax,maxbo);
 
-  d_C1dbo = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C1dbo",nmax,maxbo);
-  d_C2dbo = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C2dbo",nmax,maxbo);
-  d_C3dbo = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C3dbo",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C1dbo,"reaxff/kk:d_C1dbo",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C2dbo,"reaxff/kk:d_C2dbo",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C3dbo,"reaxff/kk:d_C3dbo",nmax,maxbo);
 
-  d_C1dbopi = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C1dbopi",nmax,maxbo);
-  d_C2dbopi = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C2dbopi",nmax,maxbo);
-  d_C3dbopi = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C3dbopi",nmax,maxbo);
-  d_C4dbopi = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C4dbopi",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C1dbopi,"reaxff/kk:d_C1dbopi",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C2dbopi,"reaxff/kk:d_C2dbopi",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C3dbopi,"reaxff/kk:d_C3dbopi",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C4dbopi,"reaxff/kk:d_C4dbopi",nmax,maxbo);
 
-  d_C1dbopi2 = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C1dbopi2",nmax,maxbo);
-  d_C2dbopi2 = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C2dbopi2",nmax,maxbo);
-  d_C3dbopi2 = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C3dbopi2",nmax,maxbo);
-  d_C4dbopi2 = typename AT::t_ffloat_2d_dl("reaxff/kk:d_C4dbopi2",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C1dbopi2,"reaxff/kk:d_C1dbopi2",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C2dbopi2,"reaxff/kk:d_C2dbopi2",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C3dbopi2,"reaxff/kk:d_C3dbopi2",nmax,maxbo);
+  MemKK::realloc_kokkos(d_C4dbopi2,"reaxff/kk:d_C4dbopi2",nmax,maxbo);
 
-  d_dBOp = typename AT::t_ffloat_2d_dl("reaxff/kk:dBOp",nmax,maxbo);
+  MemKK::realloc_kokkos(d_dBOp,"reaxff/kk:dBOp",nmax,maxbo);
 
-  d_dDeltap_self = typename AT::t_ffloat_2d_dl("reaxff/kk:dDeltap_self",nmax,3);
-  d_Deltap_boc = typename AT::t_ffloat_1d("reaxff/kk:Deltap_boc",nmax);
-  d_Deltap = typename AT::t_ffloat_1d("reaxff/kk:Deltap",nmax);
-  d_total_bo = typename AT::t_ffloat_1d("reaxff/kk:total_bo",nmax);
+  MemKK::realloc_kokkos(d_dDeltap_self,"reaxff/kk:dDeltap_self",nmax,3);
+  MemKK::realloc_kokkos(d_Deltap_boc,"reaxff/kk:Deltap_boc",nmax);
+  MemKK::realloc_kokkos(d_Deltap,"reaxff/kk:Deltap",nmax);
+  MemKK::realloc_kokkos(d_total_bo,"reaxff/kk:total_bo",nmax);
 
-  d_Cdbo = typename AT::t_ffloat_2d_dl("reaxff/kk:Cdbo",nmax,3*maxbo);
-  d_Cdbopi = typename AT::t_ffloat_2d_dl("reaxff/kk:Cdbopi",nmax,3*maxbo);
-  d_Cdbopi2 = typename AT::t_ffloat_2d_dl("reaxff/kk:Cdbopi2",nmax,3*maxbo);
+  MemKK::realloc_kokkos(d_Cdbo,"reaxff/kk:Cdbo",nmax,3*maxbo);
+  MemKK::realloc_kokkos(d_Cdbopi,"reaxff/kk:Cdbopi",nmax,3*maxbo);
+  MemKK::realloc_kokkos(d_Cdbopi2,"reaxff/kk:Cdbopi2",nmax,3*maxbo);
 
-  d_Delta = typename AT::t_ffloat_1d("reaxff/kk:Delta",nmax);
-  d_Delta_boc = typename AT::t_ffloat_1d("reaxff/kk:Delta_boc",nmax);
-  d_dDelta_lp = typename AT::t_ffloat_1d("reaxff/kk:dDelta_lp",nmax);
-  d_Delta_lp = typename AT::t_ffloat_1d("reaxff/kk:Delta_lp",nmax);
-  d_Delta_lp_temp = typename AT::t_ffloat_1d("reaxff/kk:Delta_lp_temp",nmax);
-  d_CdDelta = typename AT::t_ffloat_1d("reaxff/kk:CdDelta",nmax);
-  d_sum_ovun = typename AT::t_ffloat_2d_dl("reaxff/kk:sum_ovun",nmax,3);
+  MemKK::realloc_kokkos(d_Delta,"reaxff/kk:Delta",nmax);
+  MemKK::realloc_kokkos(d_Delta_boc,"reaxff/kk:Delta_boc",nmax);
+  MemKK::realloc_kokkos(d_dDelta_lp,"reaxff/kk:dDelta_lp",nmax);
+  MemKK::realloc_kokkos(d_Delta_lp,"reaxff/kk:Delta_lp",nmax);
+  MemKK::realloc_kokkos(d_Delta_lp_temp,"reaxff/kk:Delta_lp_temp",nmax);
+  MemKK::realloc_kokkos(d_CdDelta,"reaxff/kk:CdDelta",nmax);
+  MemKK::realloc_kokkos(d_sum_ovun,"reaxff/kk:sum_ovun",nmax,3);
 
   // FixReaxFFBonds
-  d_abo = typename AT::t_ffloat_2d("reaxff/kk:abo",nmax,maxbo);
-  d_neighid = typename AT::t_tagint_2d("reaxff/kk:neighid",nmax,maxbo);
-  d_numneigh_bonds = typename AT::t_int_1d("reaxff/kk:numneigh_bonds",nmax);
+  MemKK::realloc_kokkos(d_abo,"reaxff/kk:abo",nmax,maxbo);
+  MemKK::realloc_kokkos(d_neighid,"reaxff/kk:neighid",nmax,maxbo);
+  MemKK::realloc_kokkos(d_numneigh_bonds,"reaxff/kk:numneigh_bonds",nmax);
 
   // ComputeAngular intermediates
-  d_angular_intermediates = typename AT::t_ffloat_2d("reaxff/kk:angular_intermediates",nmax,4);
-}
-
-/* ---------------------------------------------------------------------- */
-
-template<class DeviceType>
-void PairReaxFFKokkos<DeviceType>::deallocate_array()
-{
-  if (cut_hbsq > 0.0) {
-    d_hb_first = typename AT::t_int_1d();
-    d_hb_num = typename AT::t_int_1d();
-    d_hb_list = typename AT::t_int_1d();
-  }
-  d_bo_first = typename AT::t_int_1d();
-  d_bo_num = typename AT::t_int_1d();
-  d_bo_list = typename AT::t_int_1d();
-
-  d_BO = typename AT::t_ffloat_2d_dl();
-  d_BO_s = typename AT::t_ffloat_2d_dl();
-  d_BO_pi = typename AT::t_ffloat_2d_dl();
-  d_BO_pi2 = typename AT::t_ffloat_2d_dl();
-
-  d_dln_BOp_pi = typename AT::t_ffloat_2d_dl();
-  d_dln_BOp_pi2 = typename AT::t_ffloat_2d_dl();
-
-  d_C1dbo = typename AT::t_ffloat_2d_dl();
-  d_C2dbo = typename AT::t_ffloat_2d_dl();
-  d_C3dbo = typename AT::t_ffloat_2d_dl();
-
-  d_C1dbopi = typename AT::t_ffloat_2d_dl();
-  d_C2dbopi = typename AT::t_ffloat_2d_dl();
-  d_C3dbopi = typename AT::t_ffloat_2d_dl();
-  d_C4dbopi = typename AT::t_ffloat_2d_dl();
-
-  d_C1dbopi2 = typename AT::t_ffloat_2d_dl();
-  d_C2dbopi2 = typename AT::t_ffloat_2d_dl();
-  d_C3dbopi2 = typename AT::t_ffloat_2d_dl();
-  d_C4dbopi2 = typename AT::t_ffloat_2d_dl();
-
-  d_dBOp = typename AT::t_ffloat_2d_dl();
-
-  d_dDeltap_self = typename AT::t_ffloat_2d_dl();
-  d_Deltap_boc = typename AT::t_ffloat_1d();
-  d_Deltap = typename AT::t_ffloat_1d();
-  d_total_bo = typename AT::t_ffloat_1d();
-
-  d_Cdbo = typename AT::t_ffloat_2d_dl();
-  d_Cdbopi = typename AT::t_ffloat_2d_dl();
-  d_Cdbopi2 = typename AT::t_ffloat_2d_dl();
-
-  d_Delta = typename AT::t_ffloat_1d();
-  d_Delta_boc = typename AT::t_ffloat_1d();
-  d_dDelta_lp = typename AT::t_ffloat_1d();
-  d_Delta_lp = typename AT::t_ffloat_1d();
-  d_Delta_lp_temp = typename AT::t_ffloat_1d();
-  d_CdDelta = typename AT::t_ffloat_1d();
-  d_sum_ovun = typename AT::t_ffloat_2d_dl();
-
-  // FixReaxFFBonds
-  d_abo = typename AT::t_ffloat_2d();
-  d_neighid = typename AT::t_tagint_2d();
-  d_numneigh_bonds = typename AT::t_int_1d();
-
-  // ComputeAngular intermediates
-  d_angular_intermediates = typename AT::t_ffloat_2d();
+  MemKK::realloc_kokkos(d_angular_intermediates,"reaxff/kk:angular_intermediates",nmax,4);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -384,7 +384,6 @@ class PairReaxFFKokkos : public PairReaxFF {
  protected:
   void allocate();
   void allocate_array();
-  void deallocate_array();
   void setup();
   void init_md();
   int Init_Lookup_Tables();

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -435,6 +435,8 @@ class PairReaxFFKokkos : public PairReaxFF {
   typename AT::t_ffloat_2d_dl d_C1dbopi2, d_C2dbopi2, d_C3dbopi2, d_C4dbopi2;
   typename AT::t_ffloat_2d_dl d_Cdbo, d_Cdbopi, d_Cdbopi2, d_dDeltap_self;
 
+  int need_dup;
+
   using KKDeviceType = typename KKDevice<DeviceType>::value;
 
   template<typename DataType, typename Layout>
@@ -443,27 +445,19 @@ class PairReaxFFKokkos : public PairReaxFF {
   template<typename DataType, typename Layout>
   using NonDupScatterView = KKScatterView<DataType, Layout, KKDeviceType, KKScatterSum, KKScatterNonDuplicated>;
 
-  DupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> dup_total_bo;
-  DupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> dup_CdDelta;
-  DupScatterView<E_FLOAT*, typename DAT::t_efloat_1d::array_layout> dup_eatom;
   DupScatterView<F_FLOAT*[3], typename DAT::t_f_array::array_layout> dup_f;
+  DupScatterView<E_FLOAT*, typename DAT::t_efloat_1d::array_layout> dup_eatom;
   DupScatterView<F_FLOAT*[6], typename DAT::t_virial_array::array_layout> dup_vatom;
   DupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> dup_dDeltap_self;
-  DupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> dup_Cdbo;
-  DupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> dup_Cdbopi;
-  DupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> dup_Cdbopi2;
+  DupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> dup_total_bo;
+  DupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> dup_CdDelta;
 
-  NonDupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> ndup_total_bo;
-  NonDupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> ndup_CdDelta;
-  NonDupScatterView<E_FLOAT*, typename DAT::t_efloat_1d::array_layout> ndup_eatom;
   NonDupScatterView<F_FLOAT*[3], typename DAT::t_f_array::array_layout> ndup_f;
+  NonDupScatterView<E_FLOAT*, typename DAT::t_efloat_1d::array_layout> ndup_eatom;
   NonDupScatterView<F_FLOAT*[6], typename DAT::t_virial_array::array_layout> ndup_vatom;
   NonDupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> ndup_dDeltap_self;
-  NonDupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> ndup_Cdbo;
-  NonDupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> ndup_Cdbopi;
-  NonDupScatterView<F_FLOAT**, typename DAT::t_ffloat_2d_dl::array_layout> ndup_Cdbopi2;
-
-  int need_dup;
+  NonDupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> ndup_total_bo;
+  NonDupScatterView<F_FLOAT*, typename DAT::t_float_1d::array_layout> ndup_CdDelta;
 
   typedef Kokkos::DualView<F_FLOAT**[7],typename DeviceType::array_layout,DeviceType> tdual_ffloat_2d_n7;
   typedef typename tdual_ffloat_2d_n7::t_dev_const_randomread t_ffloat_2d_n7_randomread;

--- a/src/KOKKOS/pair_snap_kokkos.h
+++ b/src/KOKKOS/pair_snap_kokkos.h
@@ -238,44 +238,14 @@ class PairSNAPKokkos : public PairSNAP {
   typename AT::t_efloat_1d d_eatom;
   typename AT::t_virial_array d_vatom;
 
-  typedef Kokkos::View<F_FLOAT**> t_bvec;
-  t_bvec bvec;
-  typedef Kokkos::View<F_FLOAT***> t_dbvec;
-  t_dbvec dbvec;
   SNAKokkos<DeviceType, real_type, vector_length> snaKK;
 
   int inum,max_neighs,chunk_size,chunk_offset;
-  int host_flag;
+  int host_flag,neighflag;
 
   int eflag,vflag;
 
   void allocate() override;
-  //void read_files(char *, char *);
-  /*template<class DeviceType>
-  inline int equal(double* x,double* y);
-  template<class DeviceType>
-  inline double dist2(double* x,double* y);
-  double extra_cutoff();
-  void load_balance();
-  void set_sna_to_shared(int snaid,int i);
-  void build_per_atom_arrays();*/
-
-  int neighflag;
-
-  Kokkos::View<T_INT*, DeviceType> ilistmast;
-  Kokkos::View<T_INT*, DeviceType> ghostilist;
-  Kokkos::View<T_INT*, DeviceType> ghostnumneigh;
-  Kokkos::View<T_INT*, DeviceType> ghostneighs;
-  Kokkos::View<T_INT*, DeviceType> ghostfirstneigh;
-
-  Kokkos::View<T_INT**, Kokkos::LayoutRight, DeviceType> i_pairs;
-  Kokkos::View<T_INT***, Kokkos::LayoutRight, DeviceType> i_rij;
-  Kokkos::View<T_INT**, Kokkos::LayoutRight, DeviceType> i_inside;
-  Kokkos::View<F_FLOAT**, Kokkos::LayoutRight, DeviceType> i_wj;
-  Kokkos::View<F_FLOAT***, Kokkos::LayoutRight, DeviceType>i_rcutij;
-  Kokkos::View<T_INT*, DeviceType> i_ninside;
-  Kokkos::View<F_FLOAT****, Kokkos::LayoutRight, DeviceType> i_uarraytot_r, i_uarraytot_i;
-  Kokkos::View<F_FLOAT******, Kokkos::LayoutRight, DeviceType> i_zarray_r, i_zarray_i;
 
   Kokkos::View<real_type*, DeviceType> d_radelem;              // element radii
   Kokkos::View<real_type*, DeviceType> d_wjelem;               // elements weights
@@ -286,7 +256,6 @@ class PairSNAPKokkos : public PairSNAP {
   Kokkos::View<T_INT*, DeviceType> d_ninside;                // ninside for all atoms in list
   Kokkos::View<real_type**, DeviceType> d_beta;                // betas for all atoms in list
   Kokkos::View<real_type***, Kokkos::LayoutLeft, DeviceType> d_beta_pack;          // betas for all atoms in list, GPU
-  Kokkos::View<real_type**, DeviceType> d_bispectrum;          // bispectrum components for all atoms in list
 
   typedef Kokkos::DualView<F_FLOAT**, DeviceType> tdual_fparams;
   tdual_fparams k_cutsq;

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -206,10 +206,10 @@ void PairSNAPKokkos<DeviceType, real_type, vector_length>::compute(int eflag_in,
 
   if (beta_max < inum) {
     beta_max = inum;
-    d_beta = Kokkos::View<real_type**, DeviceType>("PairSNAPKokkos:beta",ncoeff,inum);
+    MemKK::realloc_kokkos(d_beta,"PairSNAPKokkos:beta",ncoeff,inum);
     if (!host_flag)
-      d_beta_pack = Kokkos::View<real_type***, Kokkos::LayoutLeft, DeviceType>("PairSNAPKokkos:beta_pack",vector_length,ncoeff,(inum + vector_length - 1) / vector_length);
-    d_ninside = Kokkos::View<int*, DeviceType>("PairSNAPKokkos:ninside",inum);
+      MemKK::realloc_kokkos(d_beta_pack,"PairSNAPKokkos:beta_pack",vector_length,ncoeff,(inum + vector_length - 1) / vector_length);
+    MemKK::realloc_kokkos(d_ninside,"PairSNAPKokkos:ninside",inum);
   }
 
   chunk_size = MIN(chunksize,inum); // "chunksize" variable is set by user
@@ -545,7 +545,7 @@ void PairSNAPKokkos<DeviceType, real_type, vector_length>::allocate()
   PairSNAP::allocate();
 
   int n = atom->ntypes;
-  d_map = Kokkos::View<T_INT*, DeviceType>("PairSNAPKokkos::map",n+1);
+  MemKK::realloc_kokkos(d_map,"PairSNAPKokkos::map",n+1);
 }
 
 
@@ -574,11 +574,11 @@ void PairSNAPKokkos<DeviceType, real_type, vector_length>::coeff(int narg, char 
 
   // Set up element lists
 
-  d_radelem = Kokkos::View<real_type*, DeviceType>("pair:radelem",nelements);
-  d_wjelem = Kokkos::View<real_type*, DeviceType>("pair:wjelem",nelements);
-  d_coeffelem = Kokkos::View<real_type**, Kokkos::LayoutRight, DeviceType>("pair:coeffelem",nelements,ncoeffall);
-  d_sinnerelem = Kokkos::View<real_type*, DeviceType>("pair:sinnerelem",nelements);
-  d_dinnerelem = Kokkos::View<real_type*, DeviceType>("pair:dinnerelem",nelements);
+  MemKK::realloc_kokkos(d_radelem,"pair:radelem",nelements);
+  MemKK::realloc_kokkos(d_wjelem,"pair:wjelem",nelements);
+  MemKK::realloc_kokkos(d_coeffelem,"pair:coeffelem",nelements,ncoeffall);
+  MemKK::realloc_kokkos(d_sinnerelem,"pair:sinnerelem",nelements);
+  MemKK::realloc_kokkos(d_dinnerelem,"pair:dinnerelem",nelements);
 
   auto h_radelem = Kokkos::create_mirror_view(d_radelem);
   auto h_wjelem = Kokkos::create_mirror_view(d_wjelem);
@@ -1411,12 +1411,16 @@ template<class DeviceType, typename real_type, int vector_length>
 double PairSNAPKokkos<DeviceType, real_type, vector_length>::memory_usage()
 {
   double bytes = Pair::memory_usage();
-  int n = atom->ntypes+1;
-  bytes += n*n*sizeof(int);
-  bytes += n*n*sizeof(real_type);
-  bytes += (2*ncoeffall)*sizeof(real_type);
-  bytes += (ncoeff*3)*sizeof(real_type);
-  bytes += snaKK.memory_usage();
+  bytes += MemKK::memory_usage(d_beta);
+  if (!host_flag)
+    bytes += MemKK::memory_usage(d_beta_pack);
+  bytes += MemKK::memory_usage(d_ninside);
+  bytes += MemKK::memory_usage(d_map);
+  bytes += MemKK::memory_usage(d_radelem);
+  bytes += MemKK::memory_usage(d_wjelem);
+  bytes += MemKK::memory_usage(d_coeffelem);
+  bytes += MemKK::memory_usage(d_sinnerelem);
+  bytes += MemKK::memory_usage(d_dinnerelem);
   return bytes;
 }
 

--- a/src/KOKKOS/sna_kokkos_impl.h
+++ b/src/KOKKOS/sna_kokkos_impl.h
@@ -17,6 +17,7 @@
 ------------------------------------------------------------------------- */
 
 #include "sna_kokkos.h"
+#include "memory_kokkos.h"
 #include <cmath>
 #include <cstring>
 #include <cstdlib>
@@ -62,12 +63,12 @@ SNAKokkos<DeviceType, real_type, vector_length>::SNAKokkos(real_type rfac0_in,
   build_indexlist();
 
   int jdimpq = twojmax + 2;
-  rootpqarray = t_sna_2d("SNAKokkos::rootpqarray",jdimpq,jdimpq);
+  MemKK::realloc_kokkos(rootpqarray,"SNAKokkos::rootpqarray",jdimpq,jdimpq);
 
-  cglist = t_sna_1d("SNAKokkos::cglist",idxcg_max);
+  MemKK::realloc_kokkos(cglist,"SNAKokkos::cglist",idxcg_max);
 
   if (bzero_flag) {
-    bzero = Kokkos::View<real_type*, Kokkos::LayoutRight, DeviceType>("sna:bzero",twojmax+1);
+    MemKK::realloc_kokkos(bzero,"sna:bzero",twojmax+1);
     auto h_bzero = Kokkos::create_mirror_view(bzero);
 
     double www = wself*wself*wself;
@@ -95,7 +96,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
   // index list for cglist
 
   int jdim = twojmax + 1;
-  idxcg_block = Kokkos::View<int***, DeviceType>(Kokkos::NoInit("SNAKokkos::idxcg_block"),jdim,jdim,jdim);
+  MemKK::realloc_kokkos(idxcg_block,"SNAKokkos::idxcg_block",jdim,jdim,jdim);
   auto h_idxcg_block = Kokkos::create_mirror_view(idxcg_block);
 
   int idxcg_count = 0;
@@ -113,7 +114,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
   // index list for uarray
   // need to include both halves
 
-  idxu_block = Kokkos::View<int*, DeviceType>(Kokkos::NoInit("SNAKokkos::idxu_block"),jdim);
+  MemKK::realloc_kokkos(idxu_block,"SNAKokkos::idxu_block",jdim);
   auto h_idxu_block = Kokkos::create_mirror_view(idxu_block);
 
   int idxu_count = 0;
@@ -128,7 +129,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
   Kokkos::deep_copy(idxu_block,h_idxu_block);
 
   // index list for half uarray
-  idxu_half_block = Kokkos::View<int*, DeviceType>(Kokkos::NoInit("SNAKokkos::idxu_half_block"),jdim);
+  MemKK::realloc_kokkos(idxu_half_block,"SNAKokkos::idxu_half_block",jdim);
   auto h_idxu_half_block = Kokkos::create_mirror_view(idxu_half_block);
 
   int idxu_half_count = 0;
@@ -142,7 +143,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
   Kokkos::deep_copy(idxu_half_block, h_idxu_half_block);
 
   // mapping between full and half indexing, encoding flipping
-  idxu_full_half = Kokkos::View<FullHalfMapper*, DeviceType>(Kokkos::NoInit("SNAKokkos::idxu_full_half"),idxu_max);
+  MemKK::realloc_kokkos(idxu_full_half,"SNAKokkos::idxu_full_half",idxu_max);
   auto h_idxu_full_half = Kokkos::create_mirror_view(idxu_full_half);
 
   idxu_count = 0;
@@ -169,7 +170,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
   // index list for "cache" uarray
   // this is the GPU scratch memory requirements
   // applied the CPU structures
-  idxu_cache_block = Kokkos::View<int*, DeviceType>(Kokkos::NoInit("SNAKokkos::idxu_cache_block"),jdim);
+  MemKK::realloc_kokkos(idxu_cache_block,"SNAKokkos::idxu_cache_block",jdim);
   auto h_idxu_cache_block = Kokkos::create_mirror_view(idxu_cache_block);
 
   int idxu_cache_count = 0;
@@ -191,7 +192,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
         if (j >= j1) idxb_count++;
 
   idxb_max = idxb_count;
-  idxb = Kokkos::View<int*[3], DeviceType>(Kokkos::NoInit("SNAKokkos::idxb"),idxb_max);
+  MemKK::realloc_kokkos(idxb,"SNAKokkos::idxb",idxb_max);
   auto h_idxb = Kokkos::create_mirror_view(idxb);
 
   idxb_count = 0;
@@ -208,7 +209,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
 
   // reverse index list for beta and b
 
-  idxb_block = Kokkos::View<int***, DeviceType>(Kokkos::NoInit("SNAKokkos::idxb_block"),jdim,jdim,jdim);
+  MemKK::realloc_kokkos(idxb_block,"SNAKokkos::idxb_block",jdim,jdim,jdim);
   auto h_idxb_block = Kokkos::create_mirror_view(idxb_block);
 
   idxb_count = 0;
@@ -234,10 +235,10 @@ void SNAKokkos<DeviceType, real_type, vector_length>::build_indexlist()
             idxz_count++;
 
   idxz_max = idxz_count;
-  idxz = Kokkos::View<int*[10], DeviceType>(Kokkos::NoInit("SNAKokkos::idxz"),idxz_max);
+  MemKK::realloc_kokkos(idxz,"SNAKokkos::idxz",idxz_max);
   auto h_idxz = Kokkos::create_mirror_view(idxz);
 
-  idxz_block = Kokkos::View<int***, DeviceType>(Kokkos::NoInit("SNAKokkos::idxz_block"), jdim,jdim,jdim);
+  MemKK::realloc_kokkos(idxz_block,"SNAKokkos::idxz_block", jdim,jdim,jdim);
   auto h_idxz_block = Kokkos::create_mirror_view(idxz_block);
 
   idxz_count = 0;
@@ -294,59 +295,59 @@ void SNAKokkos<DeviceType, real_type, vector_length>::grow_rij(int newnatom, int
   natom = newnatom;
   nmax = newnmax;
 
-  rij = t_sna_3d(Kokkos::NoInit("sna:rij"),natom,nmax,3);
-  wj = t_sna_2d(Kokkos::NoInit("sna:wj"),natom,nmax);
-  rcutij = t_sna_2d(Kokkos::NoInit("sna:rcutij"),natom,nmax);
-  sinnerij = t_sna_2d(Kokkos::NoInit("sna:sinnerij"),natom,nmax);
-  dinnerij = t_sna_2d(Kokkos::NoInit("sna:dinnerij"),natom,nmax);
-  inside = t_sna_2i(Kokkos::NoInit("sna:inside"),natom,nmax);
-  element = t_sna_2i(Kokkos::NoInit("sna:element"),natom,nmax);
-  dedr = t_sna_3d(Kokkos::NoInit("sna:dedr"),natom,nmax,3);
+  MemKK::realloc_kokkos(rij,"sna:rij",natom,nmax,3);
+  MemKK::realloc_kokkos(wj,"sna:wj",natom,nmax);
+  MemKK::realloc_kokkos(rcutij,"sna:rcutij",natom,nmax);
+  MemKK::realloc_kokkos(sinnerij,"sna:sinnerij",natom,nmax);
+  MemKK::realloc_kokkos(dinnerij,"sna:dinnerij",natom,nmax);
+  MemKK::realloc_kokkos(inside,"sna:inside",natom,nmax);
+  MemKK::realloc_kokkos(element,"sna:element",natom,nmax);
+  MemKK::realloc_kokkos(dedr,"sna:dedr",natom,nmax,3);
 
 #ifdef LMP_KOKKOS_GPU
   if (!host_flag) {
     const int natom_div = (natom + vector_length - 1) / vector_length;
 
-    a_pack = t_sna_3c_ll(Kokkos::NoInit("sna:a_pack"),vector_length,nmax,natom_div);
-    b_pack = t_sna_3c_ll(Kokkos::NoInit("sna:b_pack"),vector_length,nmax,natom_div);
-    da_pack = t_sna_4c_ll(Kokkos::NoInit("sna:da_pack"),vector_length,nmax,natom_div,3);
-    db_pack = t_sna_4c_ll(Kokkos::NoInit("sna:db_pack"),vector_length,nmax,natom_div,3);
-    sfac_pack = t_sna_4d_ll(Kokkos::NoInit("sna:sfac_pack"),vector_length,nmax,natom_div,4);
-    ulisttot = t_sna_3c_ll(Kokkos::NoInit("sna:ulisttot"),1,1,1); // dummy allocation
-    ulisttot_full = t_sna_3c_ll(Kokkos::NoInit("sna:ulisttot"),1,1,1);
-    ulisttot_re_pack = t_sna_4d_ll(Kokkos::NoInit("sna:ulisttot_re_pack"),vector_length,idxu_half_max,nelements,natom_div);
-    ulisttot_im_pack = t_sna_4d_ll(Kokkos::NoInit("sna:ulisttot_im_pack"),vector_length,idxu_half_max,nelements,natom_div);
-    ulisttot_pack = t_sna_4c_ll(Kokkos::NoInit("sna:ulisttot_pack"),vector_length,idxu_max,nelements,natom_div);
-    ulist = t_sna_3c_ll(Kokkos::NoInit("sna:ulist"),1,1,1);
-    zlist = t_sna_3c_ll(Kokkos::NoInit("sna:zlist"),1,1,1);
-    zlist_pack = t_sna_4c_ll(Kokkos::NoInit("sna:zlist_pack"),vector_length,idxz_max,ndoubles,natom_div);
-    blist = t_sna_3d(Kokkos::NoInit("sna:blist"),natom,ntriples,idxb_max);
-    blist_pack = t_sna_4d_ll(Kokkos::NoInit("sna:blist_pack"),vector_length,idxb_max,ntriples,natom_div);
-    ylist = t_sna_3c_ll(Kokkos::NoInit("sna:ylist"),1,1,1);
-    ylist_pack_re = t_sna_4d_ll(Kokkos::NoInit("sna:ylist_pack_re"),vector_length,idxu_half_max,nelements,natom_div);
-    ylist_pack_im = t_sna_4d_ll(Kokkos::NoInit("sna:ylist_pack_im"),vector_length,idxu_half_max,nelements,natom_div);
-    dulist = t_sna_4c3_ll(Kokkos::NoInit("sna:dulist"),1,1,1);
+    MemKK::realloc_kokkos(a_pack,"sna:a_pack",vector_length,nmax,natom_div);
+    MemKK::realloc_kokkos(b_pack,"sna:b_pack",vector_length,nmax,natom_div);
+    MemKK::realloc_kokkos(da_pack,"sna:da_pack",vector_length,nmax,natom_div,3);
+    MemKK::realloc_kokkos(db_pack,"sna:db_pack",vector_length,nmax,natom_div,3);
+    MemKK::realloc_kokkos(sfac_pack,"sna:sfac_pack",vector_length,nmax,natom_div,4);
+    MemKK::realloc_kokkos(ulisttot,"sna:ulisttot",1,1,1); // dummy allocation
+    MemKK::realloc_kokkos(ulisttot_full,"sna:ulisttot",1,1,1);
+    MemKK::realloc_kokkos(ulisttot_re_pack,"sna:ulisttot_re_pack",vector_length,idxu_half_max,nelements,natom_div);
+    MemKK::realloc_kokkos(ulisttot_im_pack,"sna:ulisttot_im_pack",vector_length,idxu_half_max,nelements,natom_div);
+    MemKK::realloc_kokkos(ulisttot_pack,"sna:ulisttot_pack",vector_length,idxu_max,nelements,natom_div);
+    MemKK::realloc_kokkos(ulist,"sna:ulist",1,1,1);
+    MemKK::realloc_kokkos(zlist,"sna:zlist",1,1,1);
+    MemKK::realloc_kokkos(zlist_pack,"sna:zlist_pack",vector_length,idxz_max,ndoubles,natom_div);
+    MemKK::realloc_kokkos(blist,"sna:blist",natom,ntriples,idxb_max);
+    MemKK::realloc_kokkos(blist_pack,"sna:blist_pack",vector_length,idxb_max,ntriples,natom_div);
+    MemKK::realloc_kokkos(ylist,"sna:ylist",1,1,1);
+    MemKK::realloc_kokkos(ylist_pack_re,"sna:ylist_pack_re",vector_length,idxu_half_max,nelements,natom_div);
+    MemKK::realloc_kokkos(ylist_pack_im,"sna:ylist_pack_im",vector_length,idxu_half_max,nelements,natom_div);
+    MemKK::realloc_kokkos(dulist,"sna:dulist",1,1,1);
   } else {
 #endif
-    a_pack = t_sna_3c_ll(Kokkos::NoInit("sna:a_pack"),1,1,1);
-    b_pack = t_sna_3c_ll(Kokkos::NoInit("sna:b_pack"),1,1,1);
-    da_pack = t_sna_4c_ll(Kokkos::NoInit("sna:da_pack"),1,1,1,1);
-    db_pack = t_sna_4c_ll(Kokkos::NoInit("sna:db_pack"),1,1,1,1);
-    sfac_pack = t_sna_4d_ll(Kokkos::NoInit("sna:sfac_pack"),1,1,1,1);
-    ulisttot = t_sna_3c_ll(Kokkos::NoInit("sna:ulisttot"),idxu_half_max,nelements,natom);
-    ulisttot_full = t_sna_3c_ll(Kokkos::NoInit("sna:ulisttot_full"),idxu_max,nelements,natom);
-    ulisttot_re_pack = t_sna_4d_ll(Kokkos::NoInit("sna:ulisttot_re"),1,1,1,1);
-    ulisttot_im_pack = t_sna_4d_ll(Kokkos::NoInit("sna:ulisttot_im"),1,1,1,1);
-    ulisttot_pack = t_sna_4c_ll(Kokkos::NoInit("sna:ulisttot_pack"),1,1,1,1);
-    ulist = t_sna_3c_ll(Kokkos::NoInit("sna:ulist"),idxu_cache_max,natom,nmax);
-    zlist = t_sna_3c_ll(Kokkos::NoInit("sna:zlist"),idxz_max,ndoubles,natom);
-    zlist_pack = t_sna_4c_ll(Kokkos::NoInit("sna:zlist_pack"),1,1,1,1);
-    blist = t_sna_3d(Kokkos::NoInit("sna:blist"),natom,ntriples,idxb_max);
-    blist_pack = t_sna_4d_ll(Kokkos::NoInit("sna:blist_pack"),1,1,1,1);
-    ylist = t_sna_3c_ll(Kokkos::NoInit("sna:ylist"),idxu_half_max,nelements,natom);
-    ylist_pack_re = t_sna_4d_ll(Kokkos::NoInit("sna:ylist_pack_re"),1,1,1,1);
-    ylist_pack_im = t_sna_4d_ll(Kokkos::NoInit("sna:ylist_pack_im"),1,1,1,1);
-    dulist = t_sna_4c3_ll(Kokkos::NoInit("sna:dulist"),idxu_cache_max,natom,nmax);
+    MemKK::realloc_kokkos(a_pack,"sna:a_pack",1,1,1);
+    MemKK::realloc_kokkos(b_pack,"sna:b_pack",1,1,1);
+    MemKK::realloc_kokkos(da_pack,"sna:da_pack",1,1,1,1);
+    MemKK::realloc_kokkos(db_pack,"sna:db_pack",1,1,1,1);
+    MemKK::realloc_kokkos(sfac_pack,"sna:sfac_pack",1,1,1,1);
+    MemKK::realloc_kokkos(ulisttot,"sna:ulisttot",idxu_half_max,nelements,natom);
+    MemKK::realloc_kokkos(ulisttot_full,"sna:ulisttot_full",idxu_max,nelements,natom);
+    MemKK::realloc_kokkos(ulisttot_re_pack,"sna:ulisttot_re",1,1,1,1);
+    MemKK::realloc_kokkos(ulisttot_im_pack,"sna:ulisttot_im",1,1,1,1);
+    MemKK::realloc_kokkos(ulisttot_pack,"sna:ulisttot_pack",1,1,1,1);
+    MemKK::realloc_kokkos(ulist,"sna:ulist",idxu_cache_max,natom,nmax);
+    MemKK::realloc_kokkos(zlist,"sna:zlist",idxz_max,ndoubles,natom);
+    MemKK::realloc_kokkos(zlist_pack,"sna:zlist_pack",1,1,1,1);
+    MemKK::realloc_kokkos(blist,"sna:blist",natom,ntriples,idxb_max);
+    MemKK::realloc_kokkos(blist_pack,"sna:blist_pack",1,1,1,1);
+    MemKK::realloc_kokkos(ylist,"sna:ylist",idxu_half_max,nelements,natom);
+    MemKK::realloc_kokkos(ylist_pack_re,"sna:ylist_pack_re",1,1,1,1);
+    MemKK::realloc_kokkos(ylist_pack_im,"sna:ylist_pack_im",1,1,1,1);
+    MemKK::realloc_kokkos(dulist,"sna:dulist",idxu_cache_max,natom,nmax);
 
 #ifdef LMP_KOKKOS_GPU
   }
@@ -2356,74 +2357,68 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_s_dsfac(const real
 template<class DeviceType, typename real_type, int vector_length>
 double SNAKokkos<DeviceType, real_type, vector_length>::memory_usage()
 {
-  int jdimpq = twojmax + 2;
-  int jdim = twojmax + 1;
-  double bytes;
+  double bytes = 0;
 
-  bytes = 0;
-
-  bytes += jdimpq*jdimpq * sizeof(real_type);               // pqarray
-  bytes += idxcg_max * sizeof(real_type);                   // cglist
+  bytes += MemKK::memory_usage(rootpqarray);
+  bytes += MemKK::memory_usage(cglist);
 
 #ifdef LMP_KOKKOS_GPU
   if (!host_flag) {
 
-    auto natom_pad = (natom+vector_length-1)/vector_length;
-
-    bytes += natom_pad * nmax * sizeof(real_type) * 2;     // a_pack
-    bytes += natom_pad * nmax * sizeof(real_type) * 2;     // b_pack
-    bytes += natom_pad * nmax * 3 * sizeof(real_type) * 2; // da_pack
-    bytes += natom_pad * nmax * 3 * sizeof(real_type) * 2; // db_pack
-    bytes += natom_pad * nmax * 4 * sizeof(real_type);     // sfac_pack
+    bytes += MemKK::memory_usage(a_pack);
+    bytes += MemKK::memory_usage(b_pack);
+    bytes += MemKK::memory_usage(da_pack);
+    bytes += MemKK::memory_usage(db_pack);
+    bytes += MemKK::memory_usage(sfac_pack);
 
 
-    bytes += natom_pad * idxu_half_max * nelements * sizeof(real_type);     // ulisttot_re_pack
-    bytes += natom_pad * idxu_half_max * nelements * sizeof(real_type);     // ulisttot_im_pack
-    bytes += natom_pad * idxu_max * nelements * sizeof(real_type) * 2;      // ulisttot_pack
+    bytes += MemKK::memory_usage(ulisttot_re_pack);
+    bytes += MemKK::memory_usage(ulisttot_im_pack);
+    bytes += MemKK::memory_usage(ulisttot_pack);
 
-    bytes += natom_pad * idxz_max * ndoubles * sizeof(real_type) * 2;   // zlist_pack
-    bytes += natom_pad * idxb_max * ntriples * sizeof(real_type);       // blist_pack
+    bytes += MemKK::memory_usage(zlist_pack);
+    bytes += MemKK::memory_usage(blist_pack);
 
-    bytes += natom_pad * idxu_half_max * nelements * sizeof(real_type); // ylist_pack_re
-    bytes += natom_pad * idxu_half_max * nelements * sizeof(real_type); // ylist_pack_im
+    bytes += MemKK::memory_usage(ylist_pack_re);
+    bytes += MemKK::memory_usage(ylist_pack_im);
   } else {
 #endif
 
-    bytes += natom * nmax * idxu_cache_max * sizeof(real_type) * 2;     // ulist
-    bytes += natom * idxu_half_max * nelements * sizeof(real_type) * 2; // ulisttot
-    bytes += natom * idxu_max * nelements * sizeof(real_type) * 2;      // ulisttot_full
+    bytes += MemKK::memory_usage(ulist);
+    bytes += MemKK::memory_usage(ulisttot);
+    bytes += MemKK::memory_usage(ulisttot_full);
 
-    bytes += natom * idxz_max * ndoubles * sizeof(real_type) * 2;       // zlist
-    bytes += natom * idxb_max * ntriples * sizeof(real_type);           // blist
+    bytes += MemKK::memory_usage(zlist);
+    bytes += MemKK::memory_usage(blist);
 
-    bytes += natom * idxu_half_max * nelements * sizeof(real_type) * 2; // ylist
+    bytes += MemKK::memory_usage(ylist);
 
-    bytes += natom * nmax * idxu_cache_max * 3 * sizeof(real_type) * 2; // dulist
+    bytes += MemKK::memory_usage(dulist);
 #ifdef LMP_KOKKOS_GPU
   }
 #endif
 
-  bytes += natom * nmax * 3 * sizeof(real_type);            // dedr
+  bytes += MemKK::memory_usage(dedr);
 
-  bytes += jdim * jdim * jdim * sizeof(int);             // idxcg_block
-  bytes += jdim * sizeof(int);                           // idxu_block
-  bytes += jdim * sizeof(int);                           // idxu_half_block
-  bytes += idxu_max * sizeof(FullHalfMapper);            // idxu_full_half
-  bytes += jdim * sizeof(int);                           // idxu_cache_block
-  bytes += jdim * jdim * jdim * sizeof(int);             // idxz_block
-  bytes += jdim * jdim * jdim * sizeof(int);             // idxb_block
+  bytes += MemKK::memory_usage(idxcg_block);
+  bytes += MemKK::memory_usage(idxu_block);
+  bytes += MemKK::memory_usage(idxu_half_block);
+  bytes += MemKK::memory_usage(idxu_full_half);
+  bytes += MemKK::memory_usage(idxu_cache_block);
+  bytes += MemKK::memory_usage(idxz_block);
+  bytes += MemKK::memory_usage(idxb_block);
 
-  bytes += idxz_max * 10 * sizeof(int);                  // idxz
-  bytes += idxb_max * 3 * sizeof(int);                   // idxb
+  bytes += MemKK::memory_usage(idxz);
+  bytes += MemKK::memory_usage(idxb);
 
-  bytes += jdim * sizeof(real_type);                        // bzero
+  bytes += MemKK::memory_usage(bzero);
 
-  bytes += natom * nmax * 3 * sizeof(real_type);            // rij
-  bytes += natom * nmax * sizeof(real_type);                // inside
-  bytes += natom * nmax * sizeof(real_type);                // wj
-  bytes += natom * nmax * sizeof(real_type);                // rcutij
-  bytes += natom * nmax * sizeof(real_type);                // sinnerij
-  bytes += natom * nmax * sizeof(real_type);                // dinnerij
+  bytes += MemKK::memory_usage(rij);
+  bytes += MemKK::memory_usage(inside);
+  bytes += MemKK::memory_usage(wj);
+  bytes += MemKK::memory_usage(rcutij);
+  bytes += MemKK::memory_usage(sinnerij);
+  bytes += MemKK::memory_usage(dinnerij);
 
   return bytes;
 }


### PR DESCRIPTION
**Summary**

Initial refactor of view allocation in Kokkos package to use convenient `MemoryKokkos` helper functions. This prevents double allocations when realloc'ing, reducing memory footprint in pair styles that use a lot of memory (SNAP, ReaxFF), and also prevents unnecessary view initialization.

**Related Issue(s)**

Started in #3264.

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes