### PR TITLE
Verbose object-level option for PyLammps

### DIFF
--- a/python/lammps/pylammps.py
+++ b/python/lammps/pylammps.py
@@ -449,6 +449,8 @@ class PyLammps(object):
   :type  ptr: pointer
   :param comm: MPI communicator (as provided by `mpi4py <mpi4py_docs_>`_). ``None`` means use ``MPI_COMM_WORLD`` implicitly.
   :type  comm: MPI_Comm
+  :param verbose: print all LAMMPS output to stdout
+  :type  verbose: bool
 
   :ivar lmp:  instance of original LAMMPS Python interface
   :vartype lmp: :py:class:`lammps`

--- a/python/lammps/pylammps.py
+++ b/python/lammps/pylammps.py
@@ -457,8 +457,9 @@ class PyLammps(object):
   :vartype run: list
   """
 
-  def __init__(self, name="", cmdargs=None, ptr=None, comm=None):
+  def __init__(self, name="", cmdargs=None, ptr=None, comm=None, verbose=False):
     self.has_echo = False
+    self.verbose = verbose
 
     if cmdargs:
       if '-echo' in cmdargs:
@@ -869,8 +870,8 @@ class PyLammps(object):
       if comm:
         output = self.lmp.comm.bcast(output, root=0)
 
-      if 'verbose' in kwargs and kwargs['verbose']:
-        print(output)
+      if self.verbose or ('verbose' in kwargs and kwargs['verbose']):
+        print(output, end = '')
 
       lines = output.splitlines()
 


### PR DESCRIPTION
**Summary**

Pretty self-explanatory, I just added a "verbose" option at object initiation that would cause all "captured" LAMMPS output to be printed out to stdout. So far this was available only on command-level which means one would have to add ```verbose = True``` in every command (that is ```__getattr__```) call separately.

Also, I removed extra empty lines printed out to stdout between LAMMPS outputs (since LAMMPS already takes care of all necessary new lines, this output just looked ugly).

**Author(s)**

Eugen Rožić (erozic@zoho.eu)
Ruder Boskovic Institute, Zagreb, Croatia

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No backward compatibility problems expected (just a new named option, assumed false if not explicited)

**Implementation Notes**

Just an object-level boolean field ```self.verbose``` that is set in ```__init__``` and checked in ```__getattr__``` along with the previous conditions for printing to stdout.

And a small change in the print to stdout of removing extra, unnecessary (ugly) empty lines.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
