### PR TITLE
Eliminated bad torsion forces for sin(theta) = 0

### DIFF
--- a/src/REAXFF/reaxff_torsion_angles.cpp
+++ b/src/REAXFF/reaxff_torsion_angles.cpp
@@ -52,6 +52,11 @@ namespace ReaxFF {
     sin_jkl = sin(p_jkl->theta);
     cos_jkl = cos(p_jkl->theta);
 
+    if (sin_ijk >= 0 && sin_ijk <= MIN_SINE) sin_ijk = MIN_SINE;
+    else if (sin_ijk <= 0 && sin_ijk >= -MIN_SINE) sin_ijk = -MIN_SINE;
+    if (sin_jkl >= 0 && sin_jkl <= MIN_SINE) sin_jkl = MIN_SINE;
+    else if (sin_jkl <= 0 && sin_jkl >= -MIN_SINE) sin_jkl = -MIN_SINE;
+
     /* omega */
     unnorm_cos_omega = -rvec_Dot(dvec_ij, dvec_jk) * rvec_Dot(dvec_jk, dvec_kl) +
       SQR(r_jk) *  rvec_Dot(dvec_ij, dvec_kl);
@@ -71,21 +76,15 @@ namespace ReaxFF {
     hnhd = r_ij * r_kl * cos_ijk * sin_jkl;
     hnhe = r_ij * r_kl * sin_ijk * cos_jkl;
 
-    poem = 2.0 * r_ij * r_kl * sin_ijk * sin_jkl;
-    if (poem < 1e-20) poem = 1e-20;
-
     tel  = SQR(r_ij) + SQR(r_jk) + SQR(r_kl) - SQR(r_li) -
       2.0 * (r_ij * r_jk * cos_ijk - r_ij * r_kl * cos_ijk * cos_jkl +
               r_jk * r_kl * cos_jkl);
 
+    poem = 2.0 * r_ij * r_kl * sin_ijk * sin_jkl;
+
     arg  = tel / poem;
     if (arg >  1.0) arg =  1.0;
     if (arg < -1.0) arg = -1.0;
-
-    if (sin_ijk >= 0 && sin_ijk <= MIN_SINE) sin_ijk = MIN_SINE;
-    else if (sin_ijk <= 0 && sin_ijk >= -MIN_SINE) sin_ijk = -MIN_SINE;
-    if (sin_jkl >= 0 && sin_jkl <= MIN_SINE) sin_jkl = MIN_SINE;
-    else if (sin_jkl <= 0 && sin_jkl >= -MIN_SINE) sin_jkl = -MIN_SINE;
 
     // dcos_omega_di
     rvec_ScaledSum(dcos_omega_di, (htra-arg*hnra)/r_ij, dvec_ij, -1., dvec_li);


### PR DESCRIPTION
**Summary**

Eliminated bad torsion forces when sin(theta) is zero. This occurs for any perfect crystal with centrosymmetry.

**Related Issue(s)**

All existing tests appear to be unaffected.

**Author(s)**

Aidan Thompson, SNL

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


