### PR TITLE
Apply clang-tidy and clang-format to update/modernize/simplify recently modified code

### DIFF
--- a/src/COLVARS/colvarproxy_lammps.cpp
+++ b/src/COLVARS/colvarproxy_lammps.cpp
@@ -117,7 +117,7 @@ void colvarproxy_lammps::init(const char *conf_file)
   if (_lmp->update->ntimestep != 0) {
     cvm::log("Setting initial step number from LAMMPS: "+
              cvm::to_str(_lmp->update->ntimestep)+"\n");
-    colvars->it = colvars->it_restart =
+    colvarmodule::it = colvarmodule::it_restart =
       static_cast<cvm::step_number>(_lmp->update->ntimestep);
   }
 
@@ -174,7 +174,7 @@ double colvarproxy_lammps::compute()
   } else {
     // Use the time step number from LAMMPS Update object
     if (_lmp->update->ntimestep - previous_step == 1) {
-      colvars->it++;
+      colvarmodule::it++;
       b_simulation_continuing = false;
     } else {
       // Cases covered by this condition:
@@ -209,7 +209,7 @@ double colvarproxy_lammps::compute()
 
   if (cvm::debug()) {
     cvm::log(std::string(cvm::line_marker)+
-             "colvarproxy_lammps, step no. "+cvm::to_str(colvars->it)+"\n"+
+             "colvarproxy_lammps, step no. "+cvm::to_str(colvarmodule::it)+"\n"+
              "Updating internal data.\n");
   }
 
@@ -269,7 +269,7 @@ cvm::rvector colvarproxy_lammps::position_distance(cvm::atom_pos const &pos1,
   double ytmp = pos2.y - pos1.y;
   double ztmp = pos2.z - pos1.z;
   _lmp->domain->minimum_image(xtmp,ytmp,ztmp);
-  return cvm::rvector(xtmp, ytmp, ztmp);
+  return {xtmp, ytmp, ztmp};
 }
 
 

--- a/src/COLVARS/fix_colvars.cpp
+++ b/src/COLVARS/fix_colvars.cpp
@@ -135,8 +135,6 @@ static void rebuild_table_int(inthash_t *tptr) {
 
   /* free memory used by old table */
   free(old_bucket);
-
-  return;
 }
 
 /*
@@ -166,8 +164,6 @@ void inthash_init(inthash_t *tptr, int buckets) {
 
   /* allocate memory for table */
   tptr->bucket=(inthash_node_t **) calloc(tptr->size, sizeof(inthash_node_t *));
-
-  return;
 }
 
 /*
@@ -847,7 +843,6 @@ void FixColvars::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   /* only process colvar forces on the outmost RESPA level. */
   if (ilevel == nlevels_respa-1) post_force(vflag);
-  return;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -939,7 +934,7 @@ void FixColvars::end_of_step()
 void FixColvars::write_restart(FILE *fp)
 {
   if (me == 0) {
-    std::string rest_text("");
+    std::string rest_text;
     proxy->serialize_status(rest_text);
     // TODO call write_output_files()
     const char *cvm_state = rest_text.c_str();

--- a/src/COLVARS/ndx_group.cpp
+++ b/src/COLVARS/ndx_group.cpp
@@ -76,7 +76,7 @@ void Ndx2Group::command(int narg, char **arg)
   int len;
   bigint num;
   FILE *fp;
-  std::string name = "", next;
+  std::string name, next;
 
   if (narg < 1) error->all(FLERR,"Illegal ndx2group command");
   if (atom->tag_enable == 0)

--- a/src/ELECTRODE/ewald_electrode.cpp
+++ b/src/ELECTRODE/ewald_electrode.cpp
@@ -40,7 +40,7 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-EwaldElectrode::EwaldElectrode(LAMMPS *lmp) : Ewald(lmp), ElectrodeKSpace()
+EwaldElectrode::EwaldElectrode(LAMMPS *lmp) : Ewald(lmp)
 {
   eikr_step = -1;
 }

--- a/src/ELECTRODE/pppm_electrode.cpp
+++ b/src/ELECTRODE/pppm_electrode.cpp
@@ -65,8 +65,7 @@ enum { FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 /* ---------------------------------------------------------------------- */
 
 PPPMElectrode::PPPMElectrode(LAMMPS *lmp) :
-    PPPM(lmp), ElectrodeKSpace(), electrolyte_density_brick(nullptr),
-    electrolyte_density_fft(nullptr)
+    PPPM(lmp), electrolyte_density_brick(nullptr), electrolyte_density_fft(nullptr)
 {
   group_group_enable = 0;
   electrolyte_density_brick = nullptr;

--- a/unittest/c-library/test_library_commands.cpp
+++ b/unittest/c-library/test_library_commands.cpp
@@ -104,7 +104,7 @@ TEST_F(LibraryCommands, from_list)
 
 TEST_F(LibraryCommands, from_string)
 {
-    std::string cmds("");
+    std::string cmds;
 
     for (auto &inp : demo_input) {
         cmds += inp;

--- a/unittest/force-styles/test_angle_style.cpp
+++ b/unittest/force-styles/test_angle_style.cpp
@@ -32,8 +32,8 @@
 #include "input.h"
 #include "lammps.h"
 #include "modify.h"
-#include "universe.h"
 #include "platform.h"
+#include "universe.h"
 
 #include <cctype>
 #include <cstdio>
@@ -90,7 +90,7 @@ LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool new
 
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -133,7 +133,7 @@ void run_lammps(LAMMPS *lmp)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("fix 1 all nve");
@@ -148,7 +148,7 @@ void restart_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("clear");
@@ -175,7 +175,7 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -226,7 +226,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     }
 
     const int natoms = lmp->atom->natoms;
-    std::string block("");
+    std::string block;
 
     YamlWriter writer(outfile);
 
@@ -285,7 +285,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     // run_stress
     stress = lmp->force->angle->virial;
     block  = fmt::format("{:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e}", stress[0],
-                         stress[1], stress[2], stress[3], stress[4], stress[5]);
+                        stress[1], stress[2], stress[3], stress[4], stress[5]);
     writer.emit_block("run_stress", block);
 
     block.clear();
@@ -297,9 +297,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     writer.emit_block("run_forces", block);
 
     cleanup_lammps(lmp, config);
-    return;
 }
-
 
 TEST(AngleStyle, plain)
 {
@@ -335,7 +333,7 @@ TEST(AngleStyle, plain)
     double epsilon = test_config.epsilon;
 
     ErrorStats stats;
-    auto angle  = lmp->force->angle;
+    auto angle = lmp->force->angle;
 
     EXPECT_FORCES("init_forces (newton on)", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("init_stress (newton on)", angle->virial, test_config.init_stress, epsilon);
@@ -365,10 +363,11 @@ TEST(AngleStyle, plain)
 
     // skip over these tests if newton bond is forced to be on
     if (lmp->force->newton_bond == 0) {
-        angle  = lmp->force->angle;
+        angle = lmp->force->angle;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", angle->virial, test_config.init_stress, 2*epsilon);
+        EXPECT_STRESS("init_stress (newton off)", angle->virial, test_config.init_stress,
+                      2 * epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(angle->energy, test_config.init_energy, epsilon);
@@ -393,7 +392,7 @@ TEST(AngleStyle, plain)
     restart_lammps(lmp, test_config);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
-    angle  = lmp->force->angle;
+    angle = lmp->force->angle;
     EXPECT_FORCES("restart_forces", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("restart_stress", angle->virial, test_config.init_stress, epsilon);
 
@@ -405,7 +404,7 @@ TEST(AngleStyle, plain)
     data_lammps(lmp, test_config);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
-    angle  = lmp->force->angle;
+    angle = lmp->force->angle;
     EXPECT_FORCES("data_forces", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("data_stress", angle->virial, test_config.init_stress, epsilon);
 
@@ -455,7 +454,7 @@ TEST(AngleStyle, omp)
     double epsilon = 5.0 * test_config.epsilon;
 
     ErrorStats stats;
-    auto angle  = lmp->force->angle;
+    auto angle = lmp->force->angle;
 
     EXPECT_FORCES("init_forces (newton on)", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("init_stress (newton on)", angle->virial, test_config.init_stress, 10 * epsilon);
@@ -488,10 +487,11 @@ TEST(AngleStyle, omp)
 
     // skip over these tests if newton bond is forced to be on
     if (lmp->force->newton_bond == 0) {
-        angle  = lmp->force->angle;
+        angle = lmp->force->angle;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", angle->virial, test_config.init_stress, 10 * epsilon);
+        EXPECT_STRESS("init_stress (newton off)", angle->virial, test_config.init_stress,
+                      10 * epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(angle->energy, test_config.init_energy, epsilon);
@@ -502,7 +502,8 @@ TEST(AngleStyle, omp)
         if (!verbose) ::testing::internal::GetCapturedStdout();
 
         EXPECT_FORCES("run_forces (newton off)", lmp->atom, test_config.run_forces, 10 * epsilon);
-        EXPECT_STRESS("run_stress (newton off)", angle->virial, test_config.run_stress, 10 * epsilon);
+        EXPECT_STRESS("run_stress (newton off)", angle->virial, test_config.run_stress,
+                      10 * epsilon);
 
         stats.reset();
         id     = lmp->modify->find_compute("sum");
@@ -556,7 +557,7 @@ TEST(AngleStyle, single)
 
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     // now start over

--- a/unittest/force-styles/test_bond_style.cpp
+++ b/unittest/force-styles/test_bond_style.cpp
@@ -32,8 +32,8 @@
 #include "input.h"
 #include "lammps.h"
 #include "modify.h"
-#include "universe.h"
 #include "platform.h"
+#include "universe.h"
 
 #include <cctype>
 #include <cstdio>
@@ -90,7 +90,7 @@ LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool new
 
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -133,7 +133,7 @@ void run_lammps(LAMMPS *lmp)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("fix 1 all nve");
@@ -148,7 +148,7 @@ void restart_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("clear");
@@ -175,7 +175,7 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -226,7 +226,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     }
 
     const int natoms = lmp->atom->natoms;
-    std::string block("");
+    std::string block;
 
     YamlWriter writer(outfile);
 
@@ -285,7 +285,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     // run_stress
     stress = lmp->force->bond->virial;
     block  = fmt::format("{:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e}", stress[0],
-                         stress[1], stress[2], stress[3], stress[4], stress[5]);
+                        stress[1], stress[2], stress[3], stress[4], stress[5]);
     writer.emit_block("run_stress", block);
 
     block.clear();
@@ -297,7 +297,6 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     writer.emit_block("run_forces", block);
 
     cleanup_lammps(lmp, config);
-    return;
 }
 
 TEST(BondStyle, plain)
@@ -334,7 +333,7 @@ TEST(BondStyle, plain)
     double epsilon = test_config.epsilon;
 
     ErrorStats stats;
-    auto bond   = lmp->force->bond;
+    auto bond = lmp->force->bond;
 
     EXPECT_FORCES("init_forces (newton on)", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("init_stress (newton on)", bond->virial, test_config.init_stress, epsilon);
@@ -364,10 +363,11 @@ TEST(BondStyle, plain)
 
     // skip over these tests if newton bond is forced to be on
     if (lmp->force->newton_bond == 0) {
-        bond   = lmp->force->bond;
+        bond = lmp->force->bond;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", bond->virial, test_config.init_stress, 2 * epsilon);
+        EXPECT_STRESS("init_stress (newton off)", bond->virial, test_config.init_stress,
+                      2 * epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(bond->energy, test_config.init_energy, epsilon);
@@ -392,7 +392,7 @@ TEST(BondStyle, plain)
     restart_lammps(lmp, test_config);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
-    bond   = lmp->force->bond;
+    bond = lmp->force->bond;
 
     EXPECT_FORCES("restart_forces", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("restart_stress", bond->virial, test_config.init_stress, epsilon);
@@ -405,7 +405,7 @@ TEST(BondStyle, plain)
     data_lammps(lmp, test_config);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
-    bond   = lmp->force->bond;
+    bond = lmp->force->bond;
 
     EXPECT_FORCES("data_forces", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("data_stress", bond->virial, test_config.init_stress, epsilon);
@@ -456,7 +456,7 @@ TEST(BondStyle, omp)
     double epsilon = 5.0 * test_config.epsilon;
 
     ErrorStats stats;
-    auto bond   = lmp->force->bond;
+    auto bond = lmp->force->bond;
 
     EXPECT_FORCES("init_forces (newton on)", lmp->atom, test_config.init_forces, epsilon);
     EXPECT_STRESS("init_stress (newton on)", bond->virial, test_config.init_stress, 10 * epsilon);
@@ -489,10 +489,11 @@ TEST(BondStyle, omp)
 
     // skip over these tests if newton bond is forced to be on
     if (lmp->force->newton_bond == 0) {
-        bond   = lmp->force->bond;
+        bond = lmp->force->bond;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", bond->virial, test_config.init_stress, 10 * epsilon);
+        EXPECT_STRESS("init_stress (newton off)", bond->virial, test_config.init_stress,
+                      10 * epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(bond->energy, test_config.init_energy, epsilon);
@@ -503,7 +504,8 @@ TEST(BondStyle, omp)
         if (!verbose) ::testing::internal::GetCapturedStdout();
 
         EXPECT_FORCES("run_forces (newton off)", lmp->atom, test_config.run_forces, 10 * epsilon);
-        EXPECT_STRESS("run_stress (newton off)", bond->virial, test_config.run_stress, 10 * epsilon);
+        EXPECT_STRESS("run_stress (newton off)", bond->virial, test_config.run_stress,
+                      10 * epsilon);
 
         stats.reset();
         id     = lmp->modify->find_compute("sum");
@@ -557,7 +559,7 @@ TEST(BondStyle, single)
 
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     // now start over

--- a/unittest/force-styles/test_config.h
+++ b/unittest/force-styles/test_config.h
@@ -15,8 +15,8 @@
 #define TEST_CONFIG_H
 
 #include <set>
-#include <string>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -96,23 +96,21 @@ public:
         restart_vel.clear();
         global_vector.clear();
     }
-    virtual ~TestConfig(){};
+    TestConfig(const TestConfig &) = delete;
+    TestConfig &operator=(const TestConfig &) = delete;
 
     std::string tags_line() const
     {
-      if(tags.size() > 0) {
-          std::stringstream line;
-          line << tags[0];
-          for(size_t i = 1; i < tags.size(); i++) {
-            line << ", " << tags[i];
-          }
-          return line.str();
-      }
-      return "generated";
+        if (tags.size() > 0) {
+            std::stringstream line;
+            line << tags[0];
+            for (size_t i = 1; i < tags.size(); i++) {
+                line << ", " << tags[i];
+            }
+            return line.str();
+        }
+        return "generated";
     }
-
-private:
-    TestConfig(const TestConfig &){};
 };
 
 #endif

--- a/unittest/force-styles/test_config_reader.cpp
+++ b/unittest/force-styles/test_config_reader.cpp
@@ -29,7 +29,7 @@
 using LAMMPS_NS::utils::split_words;
 using LAMMPS_NS::utils::trim;
 
-TestConfigReader::TestConfigReader(TestConfig &config) : YamlReader(), config(config)
+TestConfigReader::TestConfigReader(TestConfig &config) : config(config)
 {
     consumers["lammps_version"] = &TestConfigReader::lammps_version;
     consumers["tags"]           = &TestConfigReader::tags;

--- a/unittest/force-styles/test_config_reader.h
+++ b/unittest/force-styles/test_config_reader.h
@@ -22,6 +22,8 @@ class TestConfigReader : public YamlReader<TestConfigReader> {
 
 public:
     TestConfigReader(TestConfig &config);
+    TestConfigReader() = delete;
+    const TestConfigReader & operator=(TestConfig &) = delete;
 
     void skip_tests(const yaml_event_t &event);
     void prerequisites(const yaml_event_t &event);

--- a/unittest/force-styles/test_dihedral_style.cpp
+++ b/unittest/force-styles/test_dihedral_style.cpp
@@ -32,8 +32,8 @@
 #include "input.h"
 #include "lammps.h"
 #include "modify.h"
-#include "universe.h"
 #include "platform.h"
+#include "universe.h"
 
 #include <cctype>
 #include <cstdio>
@@ -90,7 +90,7 @@ LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool new
 
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -133,7 +133,7 @@ void run_lammps(LAMMPS *lmp)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("fix 1 all nve");
@@ -148,7 +148,7 @@ void restart_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("clear");
@@ -175,7 +175,7 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -235,7 +235,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     }
 
     const int natoms = lmp->atom->natoms;
-    std::string block("");
+    std::string block;
 
     YamlWriter writer(outfile);
 
@@ -288,7 +288,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     // run_stress
     stress = lmp->force->dihedral->virial;
     block  = fmt::format("{:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e}", stress[0],
-                         stress[1], stress[2], stress[3], stress[4], stress[5]);
+                        stress[1], stress[2], stress[3], stress[4], stress[5]);
     writer.emit_block("run_stress", block);
 
     block.clear();
@@ -300,7 +300,6 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     writer.emit_block("run_forces", block);
 
     cleanup_lammps(lmp, config);
-    return;
 }
 
 TEST(DihedralStyle, plain)
@@ -370,7 +369,8 @@ TEST(DihedralStyle, plain)
         dihedral = lmp->force->dihedral;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", dihedral->virial, test_config.init_stress, epsilon);
+        EXPECT_STRESS("init_stress (newton off)", dihedral->virial, test_config.init_stress,
+                      epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(dihedral->energy, test_config.init_energy, epsilon);
@@ -462,7 +462,8 @@ TEST(DihedralStyle, omp)
     auto dihedral = lmp->force->dihedral;
 
     EXPECT_FORCES("init_forces (newton on)", lmp->atom, test_config.init_forces, epsilon);
-    EXPECT_STRESS("init_stress (newton on)", dihedral->virial, test_config.init_stress, 10 * epsilon);
+    EXPECT_STRESS("init_stress (newton on)", dihedral->virial, test_config.init_stress,
+                  10 * epsilon);
 
     stats.reset();
     EXPECT_FP_LE_WITH_EPS(dihedral->energy, test_config.init_energy, epsilon);
@@ -495,7 +496,8 @@ TEST(DihedralStyle, omp)
         dihedral = lmp->force->dihedral;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", dihedral->virial, test_config.init_stress, 10 * epsilon);
+        EXPECT_STRESS("init_stress (newton off)", dihedral->virial, test_config.init_stress,
+                      10 * epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(dihedral->energy, test_config.init_energy, epsilon);
@@ -506,7 +508,8 @@ TEST(DihedralStyle, omp)
         if (!verbose) ::testing::internal::GetCapturedStdout();
 
         EXPECT_FORCES("run_forces (newton off)", lmp->atom, test_config.run_forces, 10 * epsilon);
-        EXPECT_STRESS("run_stress (newton off)", dihedral->virial, test_config.run_stress, 10 * epsilon);
+        EXPECT_STRESS("run_stress (newton off)", dihedral->virial, test_config.run_stress,
+                      10 * epsilon);
 
         stats.reset();
         id     = lmp->modify->find_compute("sum");

--- a/unittest/force-styles/test_fix_timestep.cpp
+++ b/unittest/force-styles/test_fix_timestep.cpp
@@ -203,9 +203,8 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
         // run_stress, if enabled
         if (fix->thermo_virial) {
             auto stress = fix->virial;
-            block       = fmt::format("{:23.16e} {:23.16e} {:23.16e} "
-                                "{:23.16e} {:23.16e} {:23.16e}",
-                                stress[0], stress[1], stress[2], stress[3], stress[4], stress[5]);
+            block       = fmt::format("{:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e}",
+                                      stress[0], stress[1], stress[2], stress[3], stress[4], stress[5]);
             writer.emit_block("run_stress", block);
         }
 

--- a/unittest/force-styles/test_fix_timestep.cpp
+++ b/unittest/force-styles/test_fix_timestep.cpp
@@ -34,10 +34,10 @@
 #include "lammps.h"
 #include "modify.h"
 #include "pair.h"
+#include "platform.h"
 #include "universe.h"
 #include "utils.h"
 #include "variable.h"
-#include "platform.h"
 
 #include <cctype>
 #include <cstdio>
@@ -92,7 +92,7 @@ LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool use
 
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("variable input_dir index " + INPUT_FOLDER);
@@ -143,7 +143,7 @@ void restart_lammps(LAMMPS *lmp, const TestConfig &cfg, bool use_rmass, bool use
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("clear");
@@ -184,7 +184,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     }
 
     const int natoms = lmp->atom->natoms;
-    std::string block("");
+    std::string block;
     YamlWriter writer(outfile);
 
     // write yaml header
@@ -204,8 +204,8 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
         if (fix->thermo_virial) {
             auto stress = fix->virial;
             block       = fmt::format("{:23.16e} {:23.16e} {:23.16e} "
-                                            "{:23.16e} {:23.16e} {:23.16e}",
-                                      stress[0], stress[1], stress[2], stress[3], stress[4], stress[5]);
+                                "{:23.16e} {:23.16e} {:23.16e}",
+                                stress[0], stress[1], stress[2], stress[3], stress[4], stress[5]);
             writer.emit_block("run_stress", block);
         }
 
@@ -243,7 +243,6 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     }
     writer.emit_block("run_vel", block);
     cleanup_lammps(lmp, config);
-    return;
 }
 
 TEST(FixTimestep, plain)
@@ -293,7 +292,8 @@ TEST(FixTimestep, plain)
     } else {
         Fix *fix = lmp->modify->fix[ifix];
         if (fix->thermo_virial) {
-            EXPECT_STRESS("run_stress (normal run, verlet)", fix->virial, test_config.run_stress, epsilon);
+            EXPECT_STRESS("run_stress (normal run, verlet)", fix->virial, test_config.run_stress,
+                          epsilon);
         }
 
         stats.reset();
@@ -342,7 +342,8 @@ TEST(FixTimestep, plain)
     } else {
         Fix *fix = lmp->modify->fix[ifix];
         if (fix->thermo_virial) {
-            EXPECT_STRESS("run_stress (restart, verlet)", fix->virial, test_config.run_stress, epsilon);
+            EXPECT_STRESS("run_stress (restart, verlet)", fix->virial, test_config.run_stress,
+                          epsilon);
         }
 
         stats.reset();
@@ -380,7 +381,8 @@ TEST(FixTimestep, plain)
         } else {
             Fix *fix = lmp->modify->fix[ifix];
             if (fix->thermo_virial) {
-                EXPECT_STRESS("run_stress (rmass, verlet)", fix->virial, test_config.run_stress, epsilon);
+                EXPECT_STRESS("run_stress (rmass, verlet)", fix->virial, test_config.run_stress,
+                              epsilon);
             }
 
             stats.reset();
@@ -432,7 +434,8 @@ TEST(FixTimestep, plain)
         } else {
             Fix *fix = lmp->modify->fix[ifix];
             if (fix->thermo_virial) {
-                EXPECT_STRESS("run_stress (normal run, respa)", fix->virial, test_config.run_stress, 1000 * epsilon);
+                EXPECT_STRESS("run_stress (normal run, respa)", fix->virial, test_config.run_stress,
+                              1000 * epsilon);
             }
 
             stats.reset();
@@ -469,7 +472,8 @@ TEST(FixTimestep, plain)
         } else {
             Fix *fix = lmp->modify->fix[ifix];
             if (fix->thermo_virial) {
-                EXPECT_STRESS("run_stress (restart, respa)", fix->virial, test_config.run_stress, 1000 * epsilon);
+                EXPECT_STRESS("run_stress (restart, respa)", fix->virial, test_config.run_stress,
+                              1000 * epsilon);
             }
 
             stats.reset();
@@ -507,7 +511,8 @@ TEST(FixTimestep, plain)
             } else {
                 Fix *fix = lmp->modify->fix[ifix];
                 if (fix->thermo_virial) {
-                    EXPECT_STRESS("run_stress (rmass, respa)", fix->virial, test_config.run_stress, 1000 * epsilon);
+                    EXPECT_STRESS("run_stress (rmass, respa)", fix->virial, test_config.run_stress,
+                                  1000 * epsilon);
                 }
 
                 stats.reset();
@@ -587,7 +592,8 @@ TEST(FixTimestep, omp)
     } else {
         Fix *fix = lmp->modify->fix[ifix];
         if (fix->thermo_virial) {
-            EXPECT_STRESS("run_stress (normal run, verlet)", fix->virial, test_config.run_stress, epsilon);
+            EXPECT_STRESS("run_stress (normal run, verlet)", fix->virial, test_config.run_stress,
+                          epsilon);
         }
 
         stats.reset();
@@ -636,7 +642,8 @@ TEST(FixTimestep, omp)
     } else {
         Fix *fix = lmp->modify->fix[ifix];
         if (fix->thermo_virial) {
-            EXPECT_STRESS("run_stress (restart, verlet)", fix->virial, test_config.run_stress, epsilon);
+            EXPECT_STRESS("run_stress (restart, verlet)", fix->virial, test_config.run_stress,
+                          epsilon);
         }
 
         stats.reset();
@@ -674,7 +681,8 @@ TEST(FixTimestep, omp)
         } else {
             Fix *fix = lmp->modify->fix[ifix];
             if (fix->thermo_virial) {
-                EXPECT_STRESS("run_stress (rmass, verlet)", fix->virial, test_config.run_stress, epsilon);
+                EXPECT_STRESS("run_stress (rmass, verlet)", fix->virial, test_config.run_stress,
+                              epsilon);
             }
 
             stats.reset();
@@ -725,7 +733,8 @@ TEST(FixTimestep, omp)
         } else {
             Fix *fix = lmp->modify->fix[ifix];
             if (fix->thermo_virial) {
-                EXPECT_STRESS("run_stress (normal run, respa)", fix->virial, test_config.run_stress, 1000 * epsilon);
+                EXPECT_STRESS("run_stress (normal run, respa)", fix->virial, test_config.run_stress,
+                              1000 * epsilon);
             }
 
             stats.reset();
@@ -762,7 +771,8 @@ TEST(FixTimestep, omp)
         } else {
             Fix *fix = lmp->modify->fix[ifix];
             if (fix->thermo_virial) {
-                EXPECT_STRESS("run_stress (restart, respa)", fix->virial, test_config.run_stress, 1000 * epsilon);
+                EXPECT_STRESS("run_stress (restart, respa)", fix->virial, test_config.run_stress,
+                              1000 * epsilon);
             }
 
             stats.reset();
@@ -800,7 +810,8 @@ TEST(FixTimestep, omp)
             } else {
                 Fix *fix = lmp->modify->fix[ifix];
                 if (fix->thermo_virial) {
-                    EXPECT_STRESS("run_stress (rmass, respa)", fix->virial, test_config.run_stress, 1000 * epsilon);
+                    EXPECT_STRESS("run_stress (rmass, respa)", fix->virial, test_config.run_stress,
+                                  1000 * epsilon);
                 }
 
                 stats.reset();

--- a/unittest/force-styles/test_improper_style.cpp
+++ b/unittest/force-styles/test_improper_style.cpp
@@ -32,8 +32,8 @@
 #include "input.h"
 #include "lammps.h"
 #include "modify.h"
-#include "universe.h"
 #include "platform.h"
+#include "universe.h"
 
 #include <cctype>
 #include <cstdio>
@@ -90,7 +90,7 @@ LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool new
 
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -133,7 +133,7 @@ void run_lammps(LAMMPS *lmp)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("fix 1 all nve");
@@ -148,7 +148,7 @@ void restart_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("clear");
@@ -175,7 +175,7 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -226,7 +226,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     }
 
     const int natoms = lmp->atom->natoms;
-    std::string block("");
+    std::string block;
 
     YamlWriter writer(outfile);
 
@@ -279,7 +279,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     // run_stress
     stress = lmp->force->improper->virial;
     block  = fmt::format("{:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e} {:23.16e}", stress[0],
-                         stress[1], stress[2], stress[3], stress[4], stress[5]);
+                        stress[1], stress[2], stress[3], stress[4], stress[5]);
     writer.emit_block("run_stress", block);
 
     block.clear();
@@ -291,7 +291,6 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     writer.emit_block("run_forces", block);
 
     cleanup_lammps(lmp, config);
-    return;
 }
 
 TEST(ImproperStyle, plain)
@@ -361,7 +360,8 @@ TEST(ImproperStyle, plain)
         improper = lmp->force->improper;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", improper->virial, test_config.init_stress, 2 * epsilon);
+        EXPECT_STRESS("init_stress (newton off)", improper->virial, test_config.init_stress,
+                      2 * epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(improper->energy, test_config.init_energy, epsilon);
@@ -453,7 +453,8 @@ TEST(ImproperStyle, omp)
     auto improper = lmp->force->improper;
 
     EXPECT_FORCES("init_forces (newton on)", lmp->atom, test_config.init_forces, epsilon);
-    EXPECT_STRESS("init_stress (newton on)", improper->virial, test_config.init_stress, 10 * epsilon);
+    EXPECT_STRESS("init_stress (newton on)", improper->virial, test_config.init_stress,
+                  10 * epsilon);
 
     stats.reset();
     EXPECT_FP_LE_WITH_EPS(improper->energy, test_config.init_energy, epsilon);
@@ -486,7 +487,8 @@ TEST(ImproperStyle, omp)
         improper = lmp->force->improper;
 
         EXPECT_FORCES("init_forces (newton off)", lmp->atom, test_config.init_forces, epsilon);
-        EXPECT_STRESS("init_stress (newton off)", improper->virial, test_config.init_stress, 10 * epsilon);
+        EXPECT_STRESS("init_stress (newton off)", improper->virial, test_config.init_stress,
+                      10 * epsilon);
 
         stats.reset();
         EXPECT_FP_LE_WITH_EPS(improper->energy, test_config.init_energy, epsilon);
@@ -497,7 +499,8 @@ TEST(ImproperStyle, omp)
         if (!verbose) ::testing::internal::GetCapturedStdout();
 
         EXPECT_FORCES("run_forces (newton off)", lmp->atom, test_config.run_forces, 10 * epsilon);
-        EXPECT_STRESS("run_stress (newton off)", improper->virial, test_config.run_stress, 10 * epsilon);
+        EXPECT_STRESS("run_stress (newton off)", improper->virial, test_config.run_stress,
+                      10 * epsilon);
 
         stats.reset();
         id     = lmp->modify->find_compute("sum");

--- a/unittest/force-styles/test_pair_style.cpp
+++ b/unittest/force-styles/test_pair_style.cpp
@@ -91,7 +91,7 @@ LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool new
 
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -142,7 +142,7 @@ void run_lammps(LAMMPS *lmp)
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("fix 1 all nve");
@@ -157,7 +157,7 @@ void restart_lammps(LAMMPS *lmp, const TestConfig &cfg, bool nofdotr = false, bo
 {
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("clear");
@@ -188,7 +188,7 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 {
     // utility lambdas to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
     auto parse_input_script = [&](const std::string &filename) {
         lmp->input->file(filename.c_str());
@@ -239,7 +239,7 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     }
 
     const int natoms = lmp->atom->natoms;
-    std::string block("");
+    std::string block;
 
     YamlWriter writer(outfile);
 
@@ -316,7 +316,6 @@ void generate_yaml_file(const char *outfile, const TestConfig &config)
     writer.emit_block("run_forces", block);
 
     cleanup_lammps(lmp, config);
-    return;
 }
 
 TEST(PairStyle, plain)
@@ -1085,7 +1084,7 @@ TEST(PairStyle, single)
 
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     command("clear");
@@ -1317,7 +1316,7 @@ TEST(PairStyle, extract)
 
     // utility lambda to improve readability
     auto command = [&](const std::string &line) {
-        lmp->input->one(line.c_str());
+        lmp->input->one(line);
     };
 
     if (!verbose) ::testing::internal::CaptureStdout();

--- a/unittest/force-styles/yaml_writer.h
+++ b/unittest/force-styles/yaml_writer.h
@@ -22,6 +22,9 @@ class YamlWriter {
 public:
     YamlWriter(const char *outfile);
     virtual ~YamlWriter();
+    YamlWriter() = delete;
+    YamlWriter(const YamlWriter &) = delete;
+    const YamlWriter & operator=(const YamlWriter &) = delete;
 
     // emitters
     void emit(const std::string &key, const double value);
@@ -34,10 +37,6 @@ private:
     FILE *fp;
     yaml_emitter_t emitter;
     yaml_event_t event;
-
-private:
-    YamlWriter(){};
-    YamlWriter(const YamlWriter &){};
 };
 
 #endif

--- a/unittest/formats/test_dump_atom.cpp
+++ b/unittest/formats/test_dump_atom.cpp
@@ -39,22 +39,23 @@ public:
         END_HIDE_OUTPUT();
     }
 
-    std::string dump_filename(std::string ident)
+    std::string dump_filename(const std::string &ident)
     {
         return fmt::format("dump_{}_{}.melt", dump_style, ident);
     }
 
-    std::string text_dump_filename(std::string ident)
+    std::string text_dump_filename(const std::string &ident)
     {
         return fmt::format("dump_{}_text_{}.melt", dump_style, ident);
     }
 
-    std::string binary_dump_filename(std::string ident)
+    std::string binary_dump_filename(const std::string &ident)
     {
         return fmt::format("dump_{}_binary_{}.melt.bin", dump_style, ident);
     }
 
-    void generate_dump(std::string dump_file, std::string dump_modify_options, int ntimesteps)
+    void generate_dump(const std::string &dump_file, const std::string &dump_modify_options,
+                       int ntimesteps)
     {
         BEGIN_HIDE_OUTPUT();
         command(fmt::format("dump id all {} 1 {}", dump_style, dump_file));
@@ -81,8 +82,8 @@ public:
         END_HIDE_OUTPUT();
     }
 
-    void generate_text_and_binary_dump(std::string text_file, std::string binary_file,
-                                       std::string dump_modify_options, int ntimesteps)
+    void generate_text_and_binary_dump(const std::string &text_file, const std::string &binary_file,
+                                       const std::string &dump_modify_options, int ntimesteps)
     {
         BEGIN_HIDE_OUTPUT();
         command(fmt::format("dump id0 all {} 1 {}", dump_style, text_file));
@@ -97,7 +98,7 @@ public:
         END_HIDE_OUTPUT();
     }
 
-    std::string convert_binary_to_text(std::string binary_file)
+    std::string convert_binary_to_text(const std::string &binary_file)
     {
         BEGIN_HIDE_OUTPUT();
         std::string cmdline = fmt::format("\"{}\" {}", BINARY2TXT_EXECUTABLE, binary_file);

--- a/unittest/formats/test_dump_cfg.cpp
+++ b/unittest/formats/test_dump_cfg.cpp
@@ -27,8 +27,8 @@ class DumpCfgTest : public MeltTest {
     std::string dump_style = "cfg";
 
 public:
-    void generate_dump(std::string dump_file, std::string fields, std::string dump_modify_options,
-                       int ntimesteps)
+    void generate_dump(const std::string &dump_file, const std::string &fields,
+                       const std::string &dump_modify_options, int ntimesteps)
     {
         BEGIN_HIDE_OUTPUT();
         command(fmt::format("dump id all {} 1 {} {}", dump_style, dump_file, fields));

--- a/unittest/formats/test_dump_custom.cpp
+++ b/unittest/formats/test_dump_custom.cpp
@@ -37,23 +37,23 @@ public:
         END_HIDE_OUTPUT();
     }
 
-    std::string dump_filename(std::string ident)
+    std::string dump_filename(const std::string &ident)
     {
         return fmt::format("dump_{}_{}.melt", dump_style, ident);
     }
 
-    std::string text_dump_filename(std::string ident)
+    std::string text_dump_filename(const std::string &ident)
     {
         return fmt::format("dump_{}_text_{}.melt", dump_style, ident);
     }
 
-    std::string binary_dump_filename(std::string ident)
+    std::string binary_dump_filename(const std::string &ident)
     {
         return fmt::format("dump_{}_binary_{}.melt.bin", dump_style, ident);
     }
 
-    void generate_dump(std::string dump_file, std::string fields, std::string dump_modify_options,
-                       int ntimesteps)
+    void generate_dump(const std::string &dump_file, const std::string &fields,
+                       const std::string &dump_modify_options, int ntimesteps)
     {
         BEGIN_HIDE_OUTPUT();
         command(fmt::format("dump id all {} 1 {} {}", dump_style, dump_file, fields));
@@ -80,9 +80,9 @@ public:
         END_HIDE_OUTPUT();
     }
 
-    void generate_text_and_binary_dump(std::string text_file, std::string binary_file,
-                                       std::string fields, std::string dump_modify_options,
-                                       int ntimesteps)
+    void generate_text_and_binary_dump(const std::string &text_file, const std::string &binary_file,
+                                       const std::string &fields,
+                                       const std::string &dump_modify_options, int ntimesteps)
     {
         BEGIN_HIDE_OUTPUT();
         command(fmt::format("dump id0 all {} 1 {} {}", dump_style, text_file, fields));
@@ -97,7 +97,7 @@ public:
         END_HIDE_OUTPUT();
     }
 
-    std::string convert_binary_to_text(std::string binary_file)
+    std::string convert_binary_to_text(const std::string &binary_file)
     {
         BEGIN_HIDE_OUTPUT();
         std::string cmdline = fmt::format("\"{}\" {}", BINARY2TXT_EXECUTABLE, binary_file);

--- a/unittest/formats/test_dump_local.cpp
+++ b/unittest/formats/test_dump_local.cpp
@@ -39,8 +39,8 @@ public:
         END_HIDE_OUTPUT();
     }
 
-    void generate_dump(std::string dump_file, std::string dump_options,
-                       std::string dump_modify_options, int ntimesteps)
+    void generate_dump(const std::string &dump_file, const std::string &dump_options,
+                       const std::string &dump_modify_options, int ntimesteps)
     {
         BEGIN_HIDE_OUTPUT();
         command(fmt::format("dump id all {} 1 {} {}", dump_style, dump_file, dump_options));

--- a/unittest/formats/test_file_operations.cpp
+++ b/unittest/formats/test_file_operations.cpp
@@ -322,7 +322,7 @@ TEST_F(FileOperationsTest, write_restart)
     command("write_restart multi-%.restart");
     command("write_restart multi2-%.restart fileper 2");
     command("write_restart multi3-%.restart nfile 1");
-    if (info->has_package("MPIIO")) command("write_restart test.restart.mpiio");
+    if (Info::has_package("MPIIO")) command("write_restart test.restart.mpiio");
     END_HIDE_OUTPUT();
 
     ASSERT_FILE_EXISTS("noinit.restart");
@@ -334,11 +334,11 @@ TEST_F(FileOperationsTest, write_restart)
     ASSERT_FILE_EXISTS("multi2-0.restart");
     ASSERT_FILE_EXISTS("multi3-base.restart");
     ASSERT_FILE_EXISTS("multi3-0.restart");
-    if (info->has_package("MPIIO")) {
+    if (Info::has_package("MPIIO")) {
         ASSERT_FILE_EXISTS("test.restart.mpiio");
     }
 
-    if (!info->has_package("MPIIO")) {
+    if (!Info::has_package("MPIIO")) {
         TEST_FAILURE(".*ERROR: Writing to MPI-IO filename when MPIIO package is not inst.*",
                      command("write_restart test.restart.mpiio"););
     } else {
@@ -395,7 +395,7 @@ TEST_F(FileOperationsTest, write_restart)
     delete_file("multi3-base.restart");
     delete_file("multi3-0.restart");
     delete_file("triclinic.restart");
-    if (info->has_package("MPIIO")) delete_file("test.restart.mpiio");
+    if (Info::has_package("MPIIO")) delete_file("test.restart.mpiio");
 }
 
 TEST_F(FileOperationsTest, write_data)
@@ -492,7 +492,7 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
         std::cout << "Warning: using OpenMPI without exceptions. "
                      "Death tests will be skipped\n";
 

--- a/unittest/python/test_python_package.cpp
+++ b/unittest/python/test_python_package.cpp
@@ -52,7 +52,7 @@ class PythonPackageTest : public LAMMPSTest {
 protected:
     void InitSystem() override
     {
-        if (!info->has_package("PYTHON")) GTEST_SKIP();
+        if (!Info::has_package("PYTHON")) GTEST_SKIP();
 
         HIDE_OUTPUT([&] {
             command("units real");
@@ -73,7 +73,7 @@ class FixPythonInvokeTest : public MeltTest {
 protected:
     void InitSystem() override
     {
-        if (!info->has_package("PYTHON")) GTEST_SKIP();
+        if (!Info::has_package("PYTHON")) GTEST_SKIP();
 
         MeltTest::InitSystem();
     }
@@ -309,7 +309,7 @@ TEST_F(FixPythonInvokeTest, end_of_step)
     auto output = CAPTURE_OUTPUT([&] {
         command("run 50");
     });
-    fprintf(stderr,"lines: %s\n",output.c_str());
+    fprintf(stderr, "lines: %s\n", output.c_str());
     auto lines = utils::split_lines(output);
     int count  = 0;
 


### PR DESCRIPTION
**Summary**

This PR includes changes suggested by clang-tidy with selected settings and clang-format to make code more consistent.
