### PR TITLE
Clean stress cartesian

### DIFF
--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
@@ -443,5 +443,5 @@ memory usage of data
 
 double ComputeStressCartesian::memory_usage()
 {
-  return (14.0 + dims + 10) * (double) (nbins1 * nbins2) * sizeof(double);
+  return (14.0 + dims + 7) * (double) (nbins1 * nbins2) * sizeof(double);
 }

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
@@ -136,9 +136,6 @@ ComputeStressCartesian::ComputeStressCartesian(LAMMPS *lmp, int narg, char **arg
   size_array_cols = 7 + dims;    // dir1, dir2, number density, pkxx, pkyy, pkzz, pcxx, pcyy, pczz
   size_array_rows = nbins1 * nbins2;
 
-  memory->create(v0x, nbins1 * nbins2, "v0x");
-  memory->create(v0y, nbins1 * nbins2, "v0y");
-  memory->create(v0z, nbins1 * nbins2, "v0z");
   memory->create(dens, nbins1 * nbins2, "dens");
   memory->create(pkxx, nbins1 * nbins2, "pkxx");
   memory->create(pkyy, nbins1 * nbins2, "pkyy");
@@ -161,9 +158,6 @@ ComputeStressCartesian::ComputeStressCartesian(LAMMPS *lmp, int narg, char **arg
 ComputeStressCartesian::~ComputeStressCartesian()
 {
   memory->destroy(dens);
-  memory->destroy(v0x);
-  memory->destroy(v0y);
-  memory->destroy(v0z);
   memory->destroy(pkxx);
   memory->destroy(pkyy);
   memory->destroy(pkzz);
@@ -240,9 +234,6 @@ void ComputeStressCartesian::compute_array()
   // Zero arrays
   for (bin = 0; bin < nbins1 * nbins2; bin++) {
     tdens[bin] = 0;
-    v0x[bin] = 0;
-    v0y[bin] = 0;
-    v0z[bin] = 0;
     tpkxx[bin] = 0;
     tpkyy[bin] = 0;
     tpkzz[bin] = 0;
@@ -259,9 +250,9 @@ void ComputeStressCartesian::compute_array()
 
     j = bin1 + bin2 * nbins1;
     tdens[j] += 1;
-    tpkxx[j] += mass[type[i]] * (v[i][0]-v0x[j]) * (v[i][0]-v0x[j]);
-    tpkyy[j] += mass[type[i]] * (v[i][1]-v0y[j]) * (v[i][1]-v0y[j]);
-    tpkzz[j] += mass[type[i]] * (v[i][2]-v0z[j]) * (v[i][2]-v0z[j]);
+    tpkxx[j] += mass[type[i]] * v[i][0] * v[i][0];
+    tpkyy[j] += mass[type[i]] * v[i][1] * v[i][1];
+    tpkzz[j] += mass[type[i]] * v[i][2] * v[i][2];
   }
 
   // loop over neighbors of my atoms

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
@@ -80,22 +80,22 @@ ComputeStressCartesian::ComputeStressCartesian(LAMMPS *lmp, int narg, char **arg
 
   dir2 = 0;
   bin_width1 = utils::numeric(FLERR, arg[4], false, lmp);
-  bin_width2 = domain->boxhi[dir2]-domain->boxlo[dir2];
+  bin_width2 = domain->boxhi[dir2] - domain->boxlo[dir2];
   nbins1 = (int) ((domain->boxhi[dir1] - domain->boxlo[dir1]) / bin_width1);
   nbins2 = 1;
-  
+
   // adjust bin width if not a perfect match
   double tmp_binwidth = (domain->boxhi[dir1] - domain->boxlo[dir1]) / nbins1;
   if ((fabs(tmp_binwidth - bin_width1) > SMALL) && (comm->me == 0))
-    utils::logmesg(lmp, "Adjusting second bin width for compute {} from {:.6f} to {:.6f}\n",
-                   style, bin_width1, tmp_binwidth);
+    utils::logmesg(lmp, "Adjusting second bin width for compute {} from {:.6f} to {:.6f}\n", style,
+                   bin_width1, tmp_binwidth);
   bin_width1 = tmp_binwidth;
 
   if (bin_width1 <= 0.0)
     error->all(FLERR, "Illegal compute stress/cartesian command. Bin width must be > 0");
   else if (bin_width1 > domain->boxhi[dir1] - domain->boxlo[dir1])
     error->all(FLERR, "Illegal compute stress/cartesian command. Bin width larger than box.");
-  
+
   invV = bin_width1;
   if (dims == 2) {
     if (strcmp(arg[5], "x") == 0)
@@ -109,7 +109,7 @@ ComputeStressCartesian::ComputeStressCartesian(LAMMPS *lmp, int narg, char **arg
 
     bin_width2 = utils::numeric(FLERR, arg[6], false, lmp);
     nbins2 = (int) ((domain->boxhi[dir2] - domain->boxlo[dir2]) / bin_width2);
-    
+
     // adjust bin width if not a perfect match
     tmp_binwidth = (domain->boxhi[dir2] - domain->boxlo[dir2]) / nbins2;
     if ((fabs(tmp_binwidth - bin_width2) > SMALL) && (comm->me == 0))
@@ -241,7 +241,7 @@ void ComputeStressCartesian::compute_array()
     tpcyy[bin] = 0;
     tpczz[bin] = 0;
   }
-  
+
   // calculate number density and kinetic contribution to pressure
   for (i = 0; i < nlocal; i++) {
     bin1 = (int) (x[i][dir1] / bin_width1) % nbins1;
@@ -356,9 +356,8 @@ void ComputeStressCartesian::compute_array()
   }
 }
 
-
 void ComputeStressCartesian::compute_pressure(double fpair, double xi, double yi, double xj,
-                                                 double yj, double delx, double dely, double delz)
+                                              double yj, double delx, double dely, double delz)
 {
   int bin1, bin2, next_bin1, next_bin2;
   double la = 0.0, lb = 0.0, l_sum = 0.0;
@@ -369,7 +368,7 @@ void ComputeStressCartesian::compute_pressure(double fpair, double xi, double yi
 
   next_bin1 = (int) floor(xi / bin_width1);
   next_bin2 = (int) floor(yi / bin_width2);
-  
+
   // Integrating along line
   while (lb < 1.0) {
     bin1 = next_bin1;

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.h
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.h
@@ -38,7 +38,7 @@ class ComputeStressCartesian : public Compute {
   double bin_width1, bin_width2, invV;
 
   // Number density, kinetic and configurational contribution to the pressure.
-  double *v0x, *v0y, *v0z, *dens, *pkxx, *pkyy, *pkzz, *pcxx, *pcyy, *pczz;
+  double *dens, *pkxx, *pkyy, *pkzz, *pcxx, *pcyy, *pczz;
   double *tdens, *tpkxx, *tpkyy, *tpkzz, *tpcxx, *tpcyy, *tpczz;
   class NeighList *list;
   void compute_pressure(double, double, double, double, double, double, double, double);

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.h
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.h
@@ -38,14 +38,32 @@ class ComputeStressCartesian : public Compute {
   double bin_width1, bin_width2, invV;
 
   // Number density, kinetic and configurational contribution to the pressure.
-  double *dens, *pkxx, *pkyy, *pkzz, *pcxx, *pcyy, *pczz;
+  double *v0x, *v0y, *v0z, *dens, *pkxx, *pkyy, *pkzz, *pcxx, *pcyy, *pczz;
   double *tdens, *tpkxx, *tpkyy, *tpkzz, *tpcxx, *tpcyy, *tpczz;
   class NeighList *list;
-  void compute_pressure_1d(double, double, double, double, double, double);
-  void compute_pressure_2d(double, double, double, double, double, double, double, double);
+  void compute_pressure(double, double, double, double, double, double, double, double);
 };
 
 }    // namespace LAMMPS_NS
 
 #endif
 #endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: No pair style is defined for compute stress/cartesian
+
+Self-explanatory.
+
+E: Pair style does not support compute stress/cartesian
+
+The pair style does not have a single() function, so it can
+not be invoked by compute stress/cartesian.
+
+*/

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.h
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.h
@@ -48,22 +48,3 @@ class ComputeStressCartesian : public Compute {
 
 #endif
 #endif
-
-/* ERROR/WARNING messages:
-
-E: Illegal ... command
-
-Self-explanatory.  Check the input script syntax and compare to the
-documentation for the command.  You can use -echo screen as a
-command-line option when running LAMMPS to see the offending line.
-
-E: No pair style is defined for compute stress/cartesian
-
-Self-explanatory.
-
-E: Pair style does not support compute stress/cartesian
-
-The pair style does not have a single() function, so it can
-not be invoked by compute stress/cartesian.
-
-*/


### PR DESCRIPTION
**Summary**

Bug fix. Removed the unnecessary function "compute_pressure_1d" in compute stress/cartesian, which also contained a bug and did not calculate the correct pressure for one-dimensional cases.

**Related Issue(s)**

Not as far as I know

**Author(s)**

Olav Galteland, SINTEF Energy Research, olav.galteland@sintef.no

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Tested back to 29Sep2021

**Implementation Notes**

Tested with example/PACKAGES/stressprofiles/in.flat and checked for momentum balance to hold

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


