### PR TITLE
Fix issues in compute ave/sphere/atom

### DIFF
--- a/doc/src/compute_ave_sphere_atom.rst
+++ b/doc/src/compute_ave_sphere_atom.rst
@@ -35,18 +35,24 @@ Examples
 Description
 """""""""""
 
-Define a computation that calculates the local mass density and temperature
-for each atom and neighbors inside a spherical cutoff. The center-of-mass
-velocity of the atoms in the sphere is subtracted out before computing the
-temperature, which leaves only the thermal velocity, similar to :doc:`compute temp/com <compute_temp_com>`.
+Define a computation that calculates the local mass density and
+temperature for each atom based on its neighbors inside a spherical
+cutoff.  If an atom has M neighbors, then its local mass density is
+calculated as the sum of its mass and its M neighbor masses, divided
+by the volume of the cutoff sphere (or circle in 2d).  The local
+temperature of the atom is calculated as the temperature of the
+collection of M+1 atoms, after subtracting the center-of-mass velocity
+of the M+1 atoms from each of the M+1 atom's velocities.  This is
+effectively the thermal velocity of the neighborhood of the central
+atom, similar to :doc:`compute temp/com <compute_temp_com>`.
 
-The optional keyword *cutoff* defines the distance cutoff
-used when searching for neighbors. The default value is the cutoff
-specified by the pair style. If no pair style is defined, then a cutoff
-must be defined using this keyword. If the specified cutoff is larger than
-that of the pair_style plus neighbor skin (or no pair style is defined),
-the *comm_modify cutoff* option must also be set to match that of the
-*cutoff* keyword.
+The optional keyword *cutoff* defines the distance cutoff used when
+searching for neighbors. The default value is the cutoff specified by
+the pair style. If no pair style is defined, then a cutoff must be
+defined using this keyword. If the specified cutoff is larger than
+that of the pair_style plus neighbor skin (or no pair style is
+defined), the *comm_modify cutoff* option must also be set to match
+that of the *cutoff* keyword.
 
 The neighbor list needed to compute this quantity is constructed each
 time the calculation is performed (i.e. each time a snapshot of atoms
@@ -57,16 +63,16 @@ too frequently.
 
    If you have a bonded system, then the settings of
    :doc:`special_bonds <special_bonds>` command can remove pairwise
-   interactions between atoms in the same bond, angle, or dihedral.  This
-   is the default setting for the :doc:`special_bonds <special_bonds>`
-   command, and means those pairwise interactions do not appear in the
-   neighbor list.  Because this compute uses the neighbor list, it also means
-   those pairs will not be included in the order parameter.  This
-   difficulty can be circumvented by writing a dump file, and using the
-   :doc:`rerun <rerun>` command to compute the order parameter for
-   snapshots in the dump file.  The rerun script can use a
-   :doc:`special_bonds <special_bonds>` command that includes all pairs in
-   the neighbor list.
+   interactions between atoms in the same bond, angle, or dihedral.
+   This is the default setting for the :doc:`special_bonds
+   <special_bonds>` command, and means those pairwise interactions do
+   not appear in the neighbor list.  Because this compute uses the
+   neighbor list, it also means those pairs will not be included in
+   the order parameter.  This difficulty can be circumvented by
+   writing a dump file, and using the :doc:`rerun <rerun>` command to
+   compute the order parameter for snapshots in the dump file.  The
+   rerun script can use a :doc:`special_bonds <special_bonds>` command
+   that includes all pairs in the neighbor list.
 
 ----------
 
@@ -79,18 +85,20 @@ too frequently.
 Output info
 """""""""""
 
-This compute calculates a per-atom array with two columns: mass density in density
-:doc:`units <units>` and temperature in temperature :doc:`units <units>`.
+This compute calculates a per-atom array with two columns: mass
+density in density :doc:`units <units>` and temperature in temperature
+:doc:`units <units>`.
 
 These values can be accessed by any command that uses per-atom values
-from a compute as input.  See the :doc:`Howto output <Howto_output>` doc
-page for an overview of LAMMPS output options.
+from a compute as input.  See the :doc:`Howto output <Howto_output>`
+doc page for an overview of LAMMPS output options.
 
 Restrictions
 """"""""""""
 
-This compute is part of the EXTRA-COMPUTE package.  It is only enabled if
-LAMMPS was built with that package.  See the :doc:`Build package <Build_package>` page for more info.
+This compute is part of the EXTRA-COMPUTE package.  It is only enabled
+if LAMMPS was built with that package.  See the :doc:`Build package
+<Build_package>` page for more info.
 
 Related commands
 """"""""""""""""
@@ -100,5 +108,5 @@ Related commands
 Default
 """""""
 
-The option defaults are *cutoff* = pair style cutoff
+The option defaults are *cutoff* = pair style cutoff.
 

--- a/doc/src/compute_ave_sphere_atom.rst
+++ b/doc/src/compute_ave_sphere_atom.rst
@@ -35,7 +35,7 @@ Examples
 Description
 """""""""""
 
-Define a computation that calculates the local density and temperature
+Define a computation that calculates the local mass density and temperature
 for each atom and neighbors inside a spherical cutoff.
 
 The optional keyword *cutoff* defines the distance cutoff
@@ -58,7 +58,7 @@ too frequently.
    interactions between atoms in the same bond, angle, or dihedral.  This
    is the default setting for the :doc:`special_bonds <special_bonds>`
    command, and means those pairwise interactions do not appear in the
-   neighbor list.  Because this fix uses the neighbor list, it also means
+   neighbor list.  Because this compute uses the neighbor list, it also means
    those pairs will not be included in the order parameter.  This
    difficulty can be circumvented by writing a dump file, and using the
    :doc:`rerun <rerun>` command to compute the order parameter for
@@ -77,7 +77,7 @@ too frequently.
 Output info
 """""""""""
 
-This compute calculates a per-atom array with two columns: density and temperature.
+This compute calculates a per-atom array with two columns: mass density and temperature.
 
 These values can be accessed by any command that uses per-atom values
 from a compute as input.  See the :doc:`Howto output <Howto_output>` doc

--- a/doc/src/compute_ave_sphere_atom.rst
+++ b/doc/src/compute_ave_sphere_atom.rst
@@ -36,7 +36,9 @@ Description
 """""""""""
 
 Define a computation that calculates the local mass density and temperature
-for each atom and neighbors inside a spherical cutoff.
+for each atom and neighbors inside a spherical cutoff. The center-of-mass
+velocity of the atoms in the sphere is subtracted out before computing the
+temperature, which leaves only the thermal velocity, similar to :doc:`compute temp/com <compute_temp_com>`.
 
 The optional keyword *cutoff* defines the distance cutoff
 used when searching for neighbors. The default value is the cutoff
@@ -77,7 +79,8 @@ too frequently.
 Output info
 """""""""""
 
-This compute calculates a per-atom array with two columns: mass density and temperature.
+This compute calculates a per-atom array with two columns: mass density in density
+:doc:`units <units>` and temperature in temperature :doc:`units <units>`.
 
 These values can be accessed by any command that uses per-atom values
 from a compute as input.  See the :doc:`Howto output <Howto_output>` doc

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -160,8 +160,7 @@ void ComputeAveSphereAtom::compute_peratom()
   double *rmass = atom->rmass;
   int *type = atom->type;
   int *mask = atom->mask;
-  double massone_i,massone_j;
-  double totalmass = 0.0;
+  double massone_i,massone_j,totalmass;
 
   double adof = domain->dimension;
   double mvv2e = force->mvv2e;

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -11,6 +11,10 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Contributing author: Stan Moore (SNL)
+------------------------------------------------------------------------- */
+
 #include "compute_ave_sphere_atom.h"
 
 #include "atom.h"

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -229,6 +229,10 @@ void ComputeAveSphereAtom::compute_peratom()
       for (jj = 0; jj < jnum; jj++) {
         j = jlist[jj];
         j &= NEIGHMASK;
+        if (rmass)
+          massone_j = rmass[j];
+        else
+          massone_j = mass[type[j]];
 
         delx = xtmp - x[j][0];
         dely = ytmp - x[j][1];

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -160,7 +160,7 @@ void ComputeAveSphereAtom::compute_peratom()
   double *rmass = atom->rmass;
   int *type = atom->type;
   int *mask = atom->mask;
-  double massone_i,massone_j,totalmass;
+  double massone_i, massone_j, totalmass;
 
   double adof = domain->dimension;
   double mvv2e = force->mvv2e;
@@ -171,8 +171,10 @@ void ComputeAveSphereAtom::compute_peratom()
     i = ilist[ii];
 
     if (mask[i] & groupbit) {
-      if (rmass) massone_i = rmass[i];
-      else massone_i = mass[type[i]];
+      if (rmass)
+        massone_i = rmass[i];
+      else
+        massone_i = mass[type[i]];
 
       xtmp = x[i][0];
       ytmp = x[i][1];
@@ -190,8 +192,10 @@ void ComputeAveSphereAtom::compute_peratom()
       for (jj = 0; jj < jnum; jj++) {
         j = jlist[jj];
         j &= NEIGHMASK;
-        if (rmass) massone_j = rmass[j];
-        else massone_j = mass[type[j]];
+        if (rmass)
+          massone_j = rmass[j];
+        else
+          massone_j = mass[type[j]];
 
         delx = xtmp - x[j][0];
         dely = ytmp - x[j][1];

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -125,7 +125,7 @@ void ComputeAveSphereAtom::compute_peratom()
   double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
   int *ilist, *jlist, *numneigh, **firstneigh;
   int count;
-  double vsum[3], vavg[3], vnet[3];
+  double p[3], vcom[3], vnet[3];
 
   invoked_peratom = update->ntimestep;
 
@@ -185,9 +185,10 @@ void ComputeAveSphereAtom::compute_peratom()
       // i atom contribution
 
       count = 1;
-      vsum[0] = v[i][0];
-      vsum[1] = v[i][1];
-      vsum[2] = v[i][2];
+      totalmass = massone_i;
+      p[0] = v[i][0] * massone_i;
+      p[1] = v[i][1] * massone_i;
+      p[2] = v[i][2] * massone_i;
 
       for (jj = 0; jj < jnum; jj++) {
         j = jlist[jj];
@@ -203,22 +204,22 @@ void ComputeAveSphereAtom::compute_peratom()
         rsq = delx * delx + dely * dely + delz * delz;
         if (rsq < cutsq) {
           count++;
-          vsum[0] += v[j][0];
-          vsum[1] += v[j][1];
-          vsum[2] += v[j][2];
+          totalmass += massone_j;
+          p[0] += v[j][0] * massone_j;
+          p[1] += v[j][1] * massone_j;
+          p[2] += v[j][2] * massone_j;
         }
       }
 
-      vavg[0] = vsum[0] / count;
-      vavg[1] = vsum[1] / count;
-      vavg[2] = vsum[2] / count;
+      vcom[0] = p[0] / totalmass;
+      vcom[1] = p[1] / totalmass;
+      vcom[2] = p[2] / totalmass;
 
       // i atom contribution
 
-      totalmass = massone_i;
-      vnet[0] = v[i][0] - vavg[0];
-      vnet[1] = v[i][1] - vavg[1];
-      vnet[2] = v[i][2] - vavg[2];
+      vnet[0] = v[i][0] - vcom[0];
+      vnet[1] = v[i][1] - vcom[1];
+      vnet[2] = v[i][2] - vcom[2];
       double ke_sum = massone_i * (vnet[0] * vnet[0] + vnet[1] * vnet[1] + vnet[2] * vnet[2]);
 
       for (jj = 0; jj < jnum; jj++) {
@@ -230,10 +231,9 @@ void ComputeAveSphereAtom::compute_peratom()
         delz = ztmp - x[j][2];
         rsq = delx * delx + dely * dely + delz * delz;
         if (rsq < cutsq) {
-          totalmass += massone_j;
-          vnet[0] = v[j][0] - vavg[0];
-          vnet[1] = v[j][1] - vavg[1];
-          vnet[2] = v[j][2] - vavg[2];
+          vnet[0] = v[j][0] - vcom[0];
+          vnet[1] = v[j][1] - vcom[1];
+          vnet[2] = v[j][2] - vcom[2];
           ke_sum += massone_j * (vnet[0] * vnet[0] + vnet[1] * vnet[1] + vnet[2] * vnet[2]);
         }
       }

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -190,8 +190,8 @@ void ComputeAveSphereAtom::compute_peratom()
       for (jj = 0; jj < jnum; jj++) {
         j = jlist[jj];
         j &= NEIGHMASK;
-        if (rmass) massone_j = rmass[i];
-        else massone_j = mass[type[i]];
+        if (rmass) massone_j = rmass[j];
+        else massone_j = mass[type[j]];
 
         delx = xtmp - x[j][0];
         dely = ytmp - x[j][1];

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -215,7 +215,6 @@ void ComputeAveSphereAtom::compute_peratom()
 
       // i atom contribution
 
-      count = 1;
       totalmass = massone_i;
       vnet[0] = v[i][0] - vavg[0];
       vnet[1] = v[i][1] - vavg[1];
@@ -231,7 +230,6 @@ void ComputeAveSphereAtom::compute_peratom()
         delz = ztmp - x[j][2];
         rsq = delx * delx + dely * dely + delz * delz;
         if (rsq < cutsq) {
-          count++;
           totalmass += massone_j;
           vnet[0] = v[j][0] - vavg[0];
           vnet[1] = v[j][1] - vavg[1];

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.h
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.h
@@ -37,7 +37,7 @@ class ComputeAveSphereAtom : public Compute {
 
  protected:
   int nmax;
-  double cutoff, cutsq, sphere_vol;
+  double cutoff, cutsq, volume;
   class NeighList *list;
 
   double **result;

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -188,8 +188,8 @@ void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtom,
     for (int jj = 0; jj < jnum; jj++) {
       int j = d_neighbors(i,jj);
       j &= NEIGHMASK;
-      if (rmass.data()) massone_j = rmass[i];
-      else massone_j = mass[type[i]];
+      if (rmass.data()) massone_j = rmass[j];
+      else massone_j = mass[type[j]];
 
       const F_FLOAT delx = x(j,0) - xtmp;
       const F_FLOAT dely = x(j,1) - ytmp;

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -138,7 +138,7 @@ template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtom, const int &ii) const
 {
-  double massone_i,massone_j,totalmass;
+  double massone_i,massone_j;
 
   const int i = d_ilist[ii];
   if (mask[i] & groupbit) {
@@ -183,7 +183,6 @@ void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtom,
 
     // i atom contribution
 
-    totalmass = massone_i;
     double vnet[3];
     vnet[0] = v(i,0) - vcom[0];
     vnet[1] = v(i,1) - vcom[1];

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -11,6 +11,10 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Contributing author: Stan Moore (SNL)
+------------------------------------------------------------------------- */
+
 #include "compute_ave_sphere_atom_kokkos.h"
 
 #include "atom_kokkos.h"

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -177,7 +177,6 @@ void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtom,
 
     // i atom contribution
 
-    count = 1;
     totalmass = massone_i;
     double vnet[3];
     vnet[0] = v(i,0) - vavg[0];
@@ -196,7 +195,6 @@ void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtom,
       const F_FLOAT delz = x(j,2) - ztmp;
       const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
       if (rsq < cutsq) {
-        count++;
         totalmass += massone_j;
         vnet[0] = v(j,0) - vavg[0];
         vnet[1] = v(j,1) - vavg[1];

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -162,6 +162,8 @@ void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtom,
     for (int jj = 0; jj < jnum; jj++) {
       int j = d_neighbors(i,jj);
       j &= NEIGHMASK;
+      if (rmass.data()) massone_j = rmass[j];
+      else massone_j = mass[type[j]];
 
       const F_FLOAT delx = x(j,0) - xtmp;
       const F_FLOAT dely = x(j,1) - ytmp;

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.h
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.h
@@ -46,13 +46,18 @@ template <class DeviceType> class ComputeAveSphereAtomKokkos : public ComputeAve
   void operator()(TagComputeAveSphereAtom, const int &) const;
 
  private:
-  typename AT::t_x_array_randomread x;
-  typename AT::t_v_array_randomread v;
+  double adof,mvv2e,mv2d,boltz;
+
+  typename AT::t_x_array x;
+  typename AT::t_v_array v;
+  typename ArrayTypes<DeviceType>::t_float_1d rmass;
+  typename ArrayTypes<DeviceType>::t_float_1d mass;
+  typename ArrayTypes<DeviceType>::t_int_1d type;
   typename ArrayTypes<DeviceType>::t_int_1d mask;
 
   typename AT::t_neighbors_2d d_neighbors;
-  typename AT::t_int_1d_randomread d_ilist;
-  typename AT::t_int_1d_randomread d_numneigh;
+  typename AT::t_int_1d d_ilist;
+  typename AT::t_int_1d d_numneigh;
 
   DAT::tdual_float_2d k_result;
   typename AT::t_float_2d d_result;


### PR DESCRIPTION
**Summary**

- Add neglected unit conversions
- Take into account 2D vs 3D
- Use mass instead of number density
- Use COM velocity

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes