### PR TITLE
More fixes and small changes for the stable release

### DIFF
--- a/doc/src/Howto_structured_data.rst
+++ b/doc/src/Howto_structured_data.rst
@@ -184,7 +184,7 @@ frame.
 
 .. code-block:: python
 
-   import re, yaml
+   import yaml
    import pandas as pd
 
    try:
@@ -193,7 +193,7 @@ frame.
        from yaml import SafeLoader as Loader
 
    with open("ave.yaml") as f:
-       ave = yaml.load(docs, Loader=Loader)
+       ave = yaml.load(f, Loader=Loader)
 
    keys = ave['keywords']
    df = {}

--- a/doc/src/Speed_measure.rst
+++ b/doc/src/Speed_measure.rst
@@ -42,5 +42,4 @@ inaccurate relative timing data, because processors have to wait when
 communication occurs for other processors to catch up.  Thus the
 reported times for "Communication" or "Other" may be higher than they
 really are, due to load-imbalance.  If this is an issue, you can
-uncomment the MPI_Barrier() lines in src/timer.cpp, and re-compile
-LAMMPS, to obtain synchronized timings.
+use the :doc:`timer sync <timer>` command to obtain synchronized timings.

--- a/doc/src/read_restart.rst
+++ b/doc/src/read_restart.rst
@@ -11,7 +11,7 @@ Syntax
    read_restart file flag
 
 * file = name of binary restart file to read in
-* flag = remap (optional)
+* flag = noremap (optional)
 
 Examples
 """"""""
@@ -19,39 +19,36 @@ Examples
 .. code-block:: LAMMPS
 
    read_restart save.10000
-   read_restart save.10000 remap
+   read_restart save.10000 noremap
    read_restart restart.*
    read_restart restart.*.mpiio
-   read_restart poly.*.% remap
+   read_restart poly.*.% noremap
 
 Description
 """""""""""
 
 Read in a previously saved system configuration from a restart file.
 This allows continuation of a previous run.  Details about what
-information is stored (and not stored) in a restart file is given
-below.  Basically this operation will re-create the simulation box
-with all its atoms and their attributes as well as some related global
-settings, at the point in time it was written to the restart file by a
-previous simulation.  The simulation box will be partitioned into a
-regular 3d grid of rectangular bricks, one per processor, based on the
-number of processors in the current simulation and the settings of the
+information is stored (and not stored) in a restart file is given below.
+Basically this operation will re-create the simulation box with all its
+atoms and their attributes as well as some related global settings, at
+the point in time it was written to the restart file by a previous
+simulation.  The simulation box will be partitioned into a regular 3d
+grid of rectangular bricks, one per processor, based on the number of
+processors in the current simulation and the settings of the
 :doc:`processors <processors>` command.  The partitioning can later be
-changed by the :doc:`balance <balance>` or :doc:`fix balance <fix_balance>` commands.
+changed by the :doc:`balance <balance>` or :doc:`fix balance
+<fix_balance>` commands.
 
 .. note::
 
-   Normally, restart files are written by the
-   :doc:`restart <restart>` or :doc:`write_restart <write_restart>` commands
-   so that all atoms in the restart file are inside the simulation box.
-   If this is not the case, the read_restart command will print an error
-   that atoms were "lost" when the file is read.  This error should be
-   reported to the LAMMPS developers so the invalid writing of the
-   restart file can be fixed.  If you still wish to use the restart file,
-   the optional *remap* flag can be appended to the read_restart command.
-   This should avoid the error, by explicitly remapping each atom back
-   into the simulation box, updating image flags for the atom
-   appropriately.
+   When restart files are read, atoms are explicitly remapped back into
+   the simulation box and image flags updated accordingly.  In most
+   cases this will not make a difference since writing a restart file
+   will also trigger a rebuild of the neighbor lists and remapping of
+   atoms into the simulation box.  This extra remap results in some
+   overhead that can be avoided by appending the optional *noremap* flag
+   to the read_restart command.
 
 Restart files are saved in binary format to enable exact restarts,
 meaning that the trajectories of a restarted run will precisely match
@@ -65,7 +62,8 @@ certain settings such as those set by the :doc:`newton <newton>` or
 these cases.
 
 Certain fixes will not restart exactly, though they should provide
-statistically similar results.  These include :doc:`fix shake <fix_shake>` and :doc:`fix langevin <fix_langevin>`.
+statistically similar results.  These include :doc:`fix shake
+<fix_shake>` and :doc:`fix langevin <fix_langevin>`.
 
 Certain pair styles will not restart exactly, though they should
 provide statistically similar results.  This is because the forces
@@ -81,18 +79,19 @@ produced the restart file, it could be a LAMMPS bug, so consider
 :doc:`reporting it <Errors_bugs>` if you think the behavior is a bug.
 
 Because restart files are binary, they may not be portable to other
-machines.  In this case, you can use the :doc:`-restart command-line switch <Run_options>` to convert a restart file to a data file.
+machines.  In this case, you can use the :doc:`-restart command-line
+switch <Run_options>` to convert a restart file to a data file.
 
-Similar to how restart files are written (see the
-:doc:`write_restart <write_restart>` and :doc:`restart <restart>`
-commands), the restart filename can contain two wild-card characters.
-If a "\*" appears in the filename, the directory is searched for all
-filenames that match the pattern where "\*" is replaced with a timestep
-value.  The file with the largest timestep value is read in.  Thus,
-this effectively means, read the latest restart file.  It's useful if
-you want your script to continue a run from where it left off.  See
-the :doc:`run <run>` command and its "upto" option for how to specify
-the run command so it does not need to be changed either.
+Similar to how restart files are written (see the :doc:`write_restart
+<write_restart>` and :doc:`restart <restart>` commands), the restart
+filename can contain two wild-card characters.  If a "\*" appears in the
+filename, the directory is searched for all filenames that match the
+pattern where "\*" is replaced with a timestep value.  The file with the
+largest timestep value is read in.  Thus, this effectively means, read
+the latest restart file.  It's useful if you want your script to
+continue a run from where it left off.  See the :doc:`run <run>` command
+and its "upto" option for how to specify the run command so it does not
+need to be changed either.
 
 If a "%" character appears in the restart filename, LAMMPS expects a
 set of multiple files to exist.  The :doc:`restart <restart>` and

--- a/doc/src/read_restart.rst
+++ b/doc/src/read_restart.rst
@@ -11,7 +11,6 @@ Syntax
    read_restart file flag
 
 * file = name of binary restart file to read in
-* flag = noremap (optional)
 
 Examples
 """"""""
@@ -19,10 +18,8 @@ Examples
 .. code-block:: LAMMPS
 
    read_restart save.10000
-   read_restart save.10000 noremap
    read_restart restart.*
    read_restart restart.*.mpiio
-   read_restart poly.*.% noremap
 
 Description
 """""""""""
@@ -40,19 +37,20 @@ processors in the current simulation and the settings of the
 changed by the :doc:`balance <balance>` or :doc:`fix balance
 <fix_balance>` commands.
 
-.. note::
-
-   When restart files are read, atoms are explicitly remapped back into
-   the simulation box and image flags updated accordingly.  In most
-   cases this will not make a difference since writing a restart file
-   will also trigger a rebuild of the neighbor lists and remapping of
-   atoms into the simulation box.  This extra remap results in some
-   overhead that can be avoided by appending the optional *noremap* flag
-   to the read_restart command.
-
 Restart files are saved in binary format to enable exact restarts,
 meaning that the trajectories of a restarted run will precisely match
 those produced by the original run had it continued on.
+
+The binary restart file format was not designed with backward, forward,
+or cross-platform compatibility in mind, so the files are only expected
+to be read correctly by the same LAMMPS executable on the same platform.
+Changes to the architecture, compilation settings, or LAMMPS version can
+render a restart file unreadable or it may read the data incorrectly.
+If you want a more portable format, you can use the data file format as
+created by the :doc:`write_data <write_data>` command.  Binary restart
+files can also be converted into a data file from the command line by
+the LAMMPS executable that wrote them using the :ref:`-restart2data
+<restart2data>` command line flag.
 
 Several things can prevent exact restarts due to round-off effects, in
 which case the trajectories in the 2 runs will slowly diverge.  These
@@ -221,17 +219,17 @@ its calculations in a consistent manner.
 
 .. note::
 
-   There are a handful of commands which can be used before or
-   between runs which may require a system initialization.  Examples
-   include the "balance", "displace_atoms", "delete_atoms", "set" (some
-   options), and "velocity" (some options) commands.  This is because
-   they can migrate atoms to new processors.  Thus they will also discard
-   unused "state" information from fixes.  You will know the discard has
+   There are a handful of commands which can be used before or between
+   runs which may require a system initialization.  Examples include the
+   "balance", "displace_atoms", "delete_atoms", "set" (some options),
+   and "velocity" (some options) commands.  This is because they can
+   migrate atoms to new processors.  Thus they will also discard unused
+   "state" information from fixes.  You will know the discard has
    occurred because a list of discarded fixes will be printed to the
    screen and log file, as explained above.  This means that if you wish
    to retain that info in a restarted run, you must re-specify the
-   relevant fixes and computes (which create fixes) before those commands
-   are used.
+   relevant fixes and computes (which create fixes) before those
+   commands are used.
 
 Some pair styles, like the :doc:`granular pair styles <pair_gran>`, also
 use a fix to store "state" information that persists from timestep to
@@ -244,18 +242,19 @@ LAMMPS allows bond interactions (angle, etc) to be turned off or
 deleted in various ways, which can affect how their info is stored in
 a restart file.
 
-If bonds (angles, etc) have been turned off by the :doc:`fix shake <fix_shake>` or :doc:`delete_bonds <delete_bonds>` command,
-their info will be written to a restart file as if they are turned on.
-This means they will need to be turned off again in a new run after
-the restart file is read.
+If bonds (angles, etc) have been turned off by the :doc:`fix shake
+<fix_shake>` or :doc:`delete_bonds <delete_bonds>` command, their info
+will be written to a restart file as if they are turned on.  This means
+they will need to be turned off again in a new run after the restart
+file is read.
 
 Bonds that are broken (e.g. by a bond-breaking potential) are written
 to the restart file as broken bonds with a type of 0.  Thus these
 bonds will still be broken when the restart file is read.
 
-Bonds that have been broken by the :doc:`fix bond/break <fix_bond_break>` command have disappeared from the
-system.  No information about these bonds is written to the restart
-file.
+Bonds that have been broken by the :doc:`fix bond/break
+<fix_bond_break>` command have disappeared from the system.  No
+information about these bonds is written to the restart file.
 
 ----------
 

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -2369,6 +2369,7 @@ nopreliminary
 Nord
 norder
 Nordlund
+noremap
 normals
 normx
 normy

--- a/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
+++ b/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
@@ -12,8 +12,8 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
-                          University of Tennessee, Knoxville (USA), 2012
+    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
+                          University of Missouri (USA), 2012
 ------------------------------------------------------------------------- */
 
 /* This is set of "wrapper" functions to assist LAMMPS.F90, which itself

--- a/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
+++ b/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
@@ -12,7 +12,7 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
+    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
                           University of Tennessee, Knoxville (USA), 2012
 ------------------------------------------------------------------------- */
 

--- a/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
+++ b/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
@@ -23,6 +23,7 @@
 
 #include <mpi.h>
 #include "LAMMPS-wrapper.h"
+#define LAMMPS_LIB_MPI 1
 #include <library.h>
 #include <lammps.h>
 #include <atom.h>

--- a/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
+++ b/examples/COUPLE/fortran2/LAMMPS-wrapper.cpp
@@ -57,181 +57,40 @@ void lammps_error_all (void *ptr, const char *file, int line, const char *str)
 
 int lammps_extract_compute_vectorsize (void *ptr, char *id, int style)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int icompute = lmp->modify->find_compute(id);
-   if ( icompute < 0 ) return 0;
-   class Compute *compute = lmp->modify->compute[icompute];
-
-   if ( style == 0 )
-   {
-      if ( !compute->vector_flag )
-         return 0;
-      else
-         return compute->size_vector;
-   }
-   else if ( style == 1 )
-   {
-      return lammps_get_natoms (ptr);
-   }
-   else if ( style == 2 )
-   {
-      if ( !compute->local_flag )
-         return 0;
-      else
-         return compute->size_local_rows;
-   }
-   else
-      return 0;
+   int *size;
+   size = (int *) lammps_extract_compute(ptr, id, style, LMP_SIZE_VECTOR);
+   if (size) return *size;
+   return 0;
 }
 
 void lammps_extract_compute_arraysize (void *ptr, char *id, int style,
       int *nrows, int *ncols)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int icompute = lmp->modify->find_compute(id);
-   if ( icompute < 0 )
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-   class Compute *compute = lmp->modify->compute[icompute];
-
-   if ( style == 0 )
-   {
-      if ( !compute->array_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = compute->size_array_rows;
-         *ncols = compute->size_array_cols;
-      }
-   }
-   else if ( style == 1 )
-   {
-      if ( !compute->peratom_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = lammps_get_natoms (ptr);
-         *ncols = compute->size_peratom_cols;
-      }
-   }
-   else if ( style == 2 )
-   {
-      if ( !compute->local_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = compute->size_local_rows;
-         *ncols = compute->size_local_cols;
-      }
-   }
-   else
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-
+   int *tmp;
+   tmp = (int *) lammps_extract_compute(ptr, id, style, LMP_SIZE_ROWS);
+   if (tmp) *nrows = *tmp;
+   tmp = (int *) lammps_extract_compute(ptr, id, style, LMP_SIZE_COLS);
+   if (tmp) *ncols = *tmp;
    return;
 }
 
 int lammps_extract_fix_vectorsize (void *ptr, char *id, int style)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int ifix = lmp->modify->find_fix(id);
-   if ( ifix < 0 ) return 0;
-   class Fix *fix = lmp->modify->fix[ifix];
-
-   if ( style == 0 )
-   {
-      if ( !fix->vector_flag )
-         return 0;
-      else
-         return fix->size_vector;
-   }
-   else if ( style == 1 )
-   {
-      return lammps_get_natoms (ptr);
-   }
-   else if ( style == 2 )
-   {
-      if ( !fix->local_flag )
-         return 0;
-      else
-         return fix->size_local_rows;
-   }
-   else
-      return 0;
+   int *size;
+   size = (int *) lammps_extract_fix(ptr, id, style, LMP_SIZE_VECTOR, 0, 0);
+   if (size) return *size;
+   return 0;
 }
 
 void lammps_extract_fix_arraysize (void *ptr, char *id, int style,
       int *nrows, int *ncols)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int ifix = lmp->modify->find_fix(id);
-   if ( ifix < 0 )
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-   class Fix *fix = lmp->modify->fix[ifix];
-
-   if ( style == 0 )
-   {
-      if ( !fix->array_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = fix->size_array_rows;
-         *ncols = fix->size_array_cols;
-      }
-   }
-   else if ( style == 1 )
-   {
-      if ( !fix->peratom_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = lammps_get_natoms (ptr);
-         *ncols = fix->size_peratom_cols;
-      }
-   }
-   else if ( style == 2 )
-   {
-      if ( !fix->local_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = fix->size_local_rows;
-         *ncols = fix->size_local_cols;
-      }
-   }
-   else
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-
+   int *tmp;
+   tmp = (int *) lammps_extract_fix(ptr, id, style, LMP_SIZE_ROWS, 0, 0);
+   if (tmp) *nrows = *tmp;
+   tmp = (int *) lammps_extract_fix(ptr, id, style, LMP_SIZE_COLS, 0, 0);
+   if (tmp) *ncols = *tmp;
    return;
-
 }
 
 /* vim: set ts=3 sts=3 expandtab: */

--- a/examples/COUPLE/fortran2/LAMMPS-wrapper.h
+++ b/examples/COUPLE/fortran2/LAMMPS-wrapper.h
@@ -12,8 +12,8 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
-                          University of Tennessee, Knoxville (USA), 2012
+    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
+                          University of Missouri (USA), 2012
 ------------------------------------------------------------------------- */
 
 /* This is set of "wrapper" functions to assist LAMMPS.F90, which itself

--- a/examples/COUPLE/fortran2/LAMMPS-wrapper.h
+++ b/examples/COUPLE/fortran2/LAMMPS-wrapper.h
@@ -12,7 +12,7 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
+    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
                           University of Tennessee, Knoxville (USA), 2012
 ------------------------------------------------------------------------- */
 

--- a/examples/COUPLE/fortran2/LAMMPS.F90
+++ b/examples/COUPLE/fortran2/LAMMPS.F90
@@ -1292,7 +1292,7 @@ contains !! Wrapper functions local to this module {{{1
       Cname = string2Cstring (name)
       Ccount = size(data) / natoms
       if ( Ccount /= 1 .and. Ccount /= 3 ) &
-         call lammps_error_all (ptr, FLERR, 'lammps_gather_atoms requires&
+         call lammps_error_all (ptr, FLERR, 'lammps_scatter_atoms requires&
             & count to be either 1 or 3')
       Fdata = data
       Cdata = C_loc (Fdata(1))

--- a/examples/COUPLE/fortran2/LAMMPS.F90
+++ b/examples/COUPLE/fortran2/LAMMPS.F90
@@ -1292,7 +1292,7 @@ contains !! Wrapper functions local to this module {{{1
       Cname = string2Cstring (name)
       Ccount = size(data) / natoms
       if ( Ccount /= 1 .and. Ccount /= 3 ) &
-         call lammps_error_all (ptr, FLERR, 'lammps_gather_atoms requires&
+         call lammps_error_all (ptr, FLERR, 'lammps_scatter_atoms requires&
             & count to be either 1 or 3')
       Fdata = data
       Cdata = C_loc (Fdata(1))
@@ -1355,7 +1355,7 @@ contains !! Wrapper functions local to this module {{{1
       Cname = string2Cstring (name)
       Ccount = size(data) / ndata
       if ( Ccount /= 1 .and. Ccount /= 3 ) &
-         call lammps_error_all (ptr, FLERR, 'lammps_gather_atoms requires&
+         call lammps_error_all (ptr, FLERR, 'lammps_scatter_atoms requires&
             & count to be either 1 or 3')
       Fdata = data
       Cdata = C_loc (Fdata(1))

--- a/examples/COUPLE/fortran2/Makefile
+++ b/examples/COUPLE/fortran2/Makefile
@@ -14,7 +14,7 @@ CXXLIB = -lstdc++    # replace with your C++ runtime libs
 # Flags for Fortran compiler, C++ compiler, and C preprocessor, respectively
 FFLAGS = -O2 -fPIC
 CXXFLAGS = -O2 -fPIC
-CPPFLAGS = -DOMPI_SKIP_MPICXX=1 -DMPICH_SKIP_MPICXX -DLAMMPS_LIB_MPI
+CPPFLAGS = -DOMPI_SKIP_MPICXX=1 -DMPICH_SKIP_MPICXX
 
 all : liblammps_fortran.a liblammps_fortran.so
 

--- a/examples/COUPLE/fortran2/README
+++ b/examples/COUPLE/fortran2/README
@@ -11,9 +11,8 @@ This interface was created by Karl Hammond who you can contact with
 questions:
 
 Karl D. Hammond
-University of Tennessee, Knoxville
-karlh at ugcs.caltech.edu
-karlh at utk.edu
+University of Missouri
+hammondkd at missouri.edu
 
 -------------------------------------
 

--- a/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.cpp
+++ b/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.cpp
@@ -12,8 +12,8 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
-                          University of Tennessee, Knoxville (USA), 2012
+    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
+                          University of Missouri (USA), 2012
 ------------------------------------------------------------------------- */
 
 /* This is set of "wrapper" functions to assist LAMMPS.F90, which itself

--- a/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.cpp
+++ b/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.cpp
@@ -23,6 +23,7 @@
 
 #include <mpi.h>
 #include "LAMMPS-wrapper.h"
+#define LAMMPS_LIB_MPI 1
 #include <library.h>
 #include <lammps.h>
 #include <atom.h>

--- a/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.cpp
+++ b/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.cpp
@@ -57,181 +57,40 @@ void lammps_error_all (void *ptr, const char *file, int line, const char *str)
 
 int lammps_extract_compute_vectorsize (void *ptr, char *id, int style)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int icompute = lmp->modify->find_compute(id);
-   if ( icompute < 0 ) return 0;
-   class Compute *compute = lmp->modify->compute[icompute];
-
-   if ( style == 0 )
-   {
-      if ( !compute->vector_flag )
-         return 0;
-      else
-         return compute->size_vector;
-   }
-   else if ( style == 1 )
-   {
-      return lammps_get_natoms (ptr);
-   }
-   else if ( style == 2 )
-   {
-      if ( !compute->local_flag )
-         return 0;
-      else
-         return compute->size_local_rows;
-   }
-   else
-      return 0;
+   int *size;
+   size = (int *) lammps_extract_compute(ptr, id, style, LMP_SIZE_VECTOR);
+   if (size) return *size;
+   return 0;
 }
 
 void lammps_extract_compute_arraysize (void *ptr, char *id, int style,
       int *nrows, int *ncols)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int icompute = lmp->modify->find_compute(id);
-   if ( icompute < 0 )
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-   class Compute *compute = lmp->modify->compute[icompute];
-
-   if ( style == 0 )
-   {
-      if ( !compute->array_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = compute->size_array_rows;
-         *ncols = compute->size_array_cols;
-      }
-   }
-   else if ( style == 1 )
-   {
-      if ( !compute->peratom_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = lammps_get_natoms (ptr);
-         *ncols = compute->size_peratom_cols;
-      }
-   }
-   else if ( style == 2 )
-   {
-      if ( !compute->local_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = compute->size_local_rows;
-         *ncols = compute->size_local_cols;
-      }
-   }
-   else
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-
+   int *tmp;
+   tmp = (int *) lammps_extract_compute(ptr, id, style, LMP_SIZE_ROWS);
+   if (tmp) *nrows = *tmp;
+   tmp = (int *) lammps_extract_compute(ptr, id, style, LMP_SIZE_COLS);
+   if (tmp) *ncols = *tmp;
    return;
 }
 
 int lammps_extract_fix_vectorsize (void *ptr, char *id, int style)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int ifix = lmp->modify->find_fix(id);
-   if ( ifix < 0 ) return 0;
-   class Fix *fix = lmp->modify->fix[ifix];
-
-   if ( style == 0 )
-   {
-      if ( !fix->vector_flag )
-         return 0;
-      else
-         return fix->size_vector;
-   }
-   else if ( style == 1 )
-   {
-      return lammps_get_natoms (ptr);
-   }
-   else if ( style == 2 )
-   {
-      if ( !fix->local_flag )
-         return 0;
-      else
-         return fix->size_local_rows;
-   }
-   else
-      return 0;
+   int *size;
+   size = (int *) lammps_extract_fix(ptr, id, style, LMP_SIZE_VECTOR, 0, 0);
+   if (size) return *size;
+   return 0;
 }
 
 void lammps_extract_fix_arraysize (void *ptr, char *id, int style,
       int *nrows, int *ncols)
 {
-   class LAMMPS *lmp = (class LAMMPS *) ptr;
-   int ifix = lmp->modify->find_fix(id);
-   if ( ifix < 0 )
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-   class Fix *fix = lmp->modify->fix[ifix];
-
-   if ( style == 0 )
-   {
-      if ( !fix->array_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = fix->size_array_rows;
-         *ncols = fix->size_array_cols;
-      }
-   }
-   else if ( style == 1 )
-   {
-      if ( !fix->peratom_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = lammps_get_natoms (ptr);
-         *ncols = fix->size_peratom_cols;
-      }
-   }
-   else if ( style == 2 )
-   {
-      if ( !fix->local_flag )
-      {
-         *nrows = 0;
-         *ncols = 0;
-      }
-      else
-      {
-         *nrows = fix->size_local_rows;
-         *ncols = fix->size_local_cols;
-      }
-   }
-   else
-   {
-      *nrows = 0;
-      *ncols = 0;
-   }
-
+   int *tmp;
+   tmp = (int *) lammps_extract_fix(ptr, id, style, LMP_SIZE_ROWS, 0, 0);
+   if (tmp) *nrows = *tmp;
+   tmp = (int *) lammps_extract_fix(ptr, id, style, LMP_SIZE_COLS, 0, 0);
+   if (tmp) *ncols = *tmp;
    return;
-
 }
 
 /* vim: set ts=3 sts=3 expandtab: */

--- a/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.h
+++ b/examples/COUPLE/fortran_dftb/LAMMPS-wrapper.h
@@ -12,8 +12,8 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
-                          University of Tennessee, Knoxville (USA), 2012
+    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
+                          University of Missouri (USA), 2012
 ------------------------------------------------------------------------- */
 
 /* This is set of "wrapper" functions to assist LAMMPS.F90, which itself

--- a/examples/COUPLE/fortran_dftb/LAMMPS-wrapper2.cpp
+++ b/examples/COUPLE/fortran_dftb/LAMMPS-wrapper2.cpp
@@ -12,8 +12,8 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
-                          University of Tennessee, Knoxville (USA), 2012
+    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
+                          University of Missouri (USA), 2012
 ------------------------------------------------------------------------- */
 
 /* This is set of "wrapper" functions to assist LAMMPS.F90, which itself

--- a/examples/COUPLE/fortran_dftb/LAMMPS-wrapper2.cpp
+++ b/examples/COUPLE/fortran_dftb/LAMMPS-wrapper2.cpp
@@ -12,8 +12,7 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
-                          University of Missouri (USA), 2012
+    Contributing author:  Nir Goldman, LLNL <ngoldman@llnl.gov>, 2016
 ------------------------------------------------------------------------- */
 
 /* This is set of "wrapper" functions to assist LAMMPS.F90, which itself

--- a/examples/COUPLE/fortran_dftb/LAMMPS-wrapper2.h
+++ b/examples/COUPLE/fortran_dftb/LAMMPS-wrapper2.h
@@ -12,7 +12,7 @@
 ------------------------------------------------------------------------- */
 
 /* ------------------------------------------------------------------------
-    Contributing author:  Nir Goldman, ngoldman@llnl.gov, Oct. 19th, 2016
+    Contributing author:  Nir Goldman, LLNL <ngoldman@llnl.gov>, 2016
 ------------------------------------------------------------------------- */
 
 /* This is set of "wrapper" functions to assist LAMMPS.F90, which itself

--- a/examples/COUPLE/fortran_dftb/LAMMPS.F90
+++ b/examples/COUPLE/fortran_dftb/LAMMPS.F90
@@ -12,8 +12,8 @@
 !--------------------------------------------------------------------------
 
 !! ------------------------------------------------------------------------
-!   Contributing author:  Karl D. Hammond <karlh@ugcs.caltech.edu>
-!                         University of Tennessee, Knoxville (USA), 2012
+!   Contributing author:  Karl D. Hammond <hammondkd@missouri.edu>
+!                         University of Missouri (USA), 2012
 !--------------------------------------------------------------------------
 
 !! LAMMPS, a Fortran 2003 module containing an interface between Fortran

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -188,20 +188,17 @@ class lammps(object):
       [c_void_p,POINTER(c_double),POINTER(c_double),c_double,c_double,c_double]
     self.lib.lammps_reset_box.restype = None
 
-    self.lib.lammps_gather_atoms.argtypes = \
-      [c_void_p,c_char_p,c_int,c_int,c_void_p]
+    self.lib.lammps_gather_atoms.argtypes = [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_gather_atoms.restype = None
 
-    self.lib.lammps_gather_atoms_concat.argtypes = \
-      [c_void_p,c_char_p,c_int,c_int,c_void_p]
+    self.lib.lammps_gather_atoms_concat.argtypes = [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_gather_atoms_concat.restype = None
 
     self.lib.lammps_gather_atoms_subset.argtypes = \
       [c_void_p,c_char_p,c_int,c_int,c_int,POINTER(c_int),c_void_p]
     self.lib.lammps_gather_atoms_subset.restype = None
 
-    self.lib.lammps_scatter_atoms.argtypes = \
-      [c_void_p,c_char_p,c_int,c_int,c_void_p]
+    self.lib.lammps_scatter_atoms.argtypes = [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_scatter_atoms.restype = None
 
     self.lib.lammps_scatter_atoms_subset.argtypes = \
@@ -211,20 +208,17 @@ class lammps(object):
     self.lib.lammps_gather_bonds.argtypes = [c_void_p,c_void_p]
     self.lib.lammps_gather_bonds.restype = None
 
-    self.lib.lammps_gather.argtypes = \
-      [c_void_p,c_char_p,c_int,c_int,c_void_p]
+    self.lib.lammps_gather.argtypes = [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_gather.restype = None
 
-    self.lib.lammps_gather_concat.argtypes = \
-      [c_void_p,c_char_p,c_int,c_int,c_void_p]
+    self.lib.lammps_gather_concat.argtypes = [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_gather_concat.restype = None
 
     self.lib.lammps_gather_subset.argtypes = \
       [c_void_p,c_char_p,c_int,c_int,c_int,POINTER(c_int),c_void_p]
     self.lib.lammps_gather_subset.restype = None
 
-    self.lib.lammps_scatter.argtypes = \
-      [c_void_p,c_char_p,c_int,c_int,c_void_p]
+    self.lib.lammps_scatter.argtypes = [c_void_p,c_char_p,c_int,c_int,c_void_p]
     self.lib.lammps_scatter.restype = None
 
     self.lib.lammps_scatter_subset.argtypes = \
@@ -244,7 +238,8 @@ class lammps(object):
     self.lib.lammps_neighlist_num_elements.argtypes = [c_void_p, c_int]
     self.lib.lammps_neighlist_num_elements.restype  = c_int
 
-    self.lib.lammps_neighlist_element_neighbors.argtypes = [c_void_p, c_int, c_int, POINTER(c_int), POINTER(c_int), POINTER(POINTER(c_int))]
+    self.lib.lammps_neighlist_element_neighbors.argtypes = \
+      [c_void_p, c_int, c_int, POINTER(c_int), POINTER(c_int), POINTER(POINTER(c_int))]
     self.lib.lammps_neighlist_element_neighbors.restype  = None
 
     self.lib.lammps_is_running.argtypes = [c_void_p]
@@ -368,11 +363,9 @@ class lammps(object):
             if type(cmdargs[i]) is str:
               cmdargs[i] = cmdargs[i].encode()
           cargs = (c_char_p*narg)(*cmdargs)
-          self.lib.lammps_open.argtypes = [c_int, c_char_p*narg, \
-                                           MPI_Comm, c_void_p]
+          self.lib.lammps_open.argtypes = [c_int, c_char_p*narg, MPI_Comm, c_void_p]
         else:
-          self.lib.lammps_open.argtypes = [c_int, c_char_p, \
-                                           MPI_Comm, c_void_p]
+          self.lib.lammps_open.argtypes = [c_int, c_char_p, MPI_Comm, c_void_p]
 
         self.opened = 1
         comm_ptr = self.MPI._addressof(comm)
@@ -390,8 +383,7 @@ class lammps(object):
             if type(cmdargs[i]) is str:
               cmdargs[i] = cmdargs[i].encode()
           cargs = (c_char_p*narg)(*cmdargs)
-          self.lib.lammps_open_no_mpi.argtypes = [c_int, c_char_p*narg, \
-                                                  c_void_p]
+          self.lib.lammps_open_no_mpi.argtypes = [c_int, c_char_p*narg, c_void_p]
           self.lmp = c_void_p(self.lib.lammps_open_no_mpi(narg,cargs,None))
         else:
           self.lib.lammps_open_no_mpi.argtypes = [c_int, c_char_p, c_void_p]
@@ -963,17 +955,14 @@ class lammps(object):
       return ptr
 
     elif ctype == LMP_SIZE_COLS:
-      if cstyle == LMP_STYLE_GLOBAL  \
-         or cstyle == LMP_STYLE_ATOM \
-         or cstyle == LMP_STYLE_LOCAL:
+      if cstyle == LMP_STYLE_GLOBAL or cstyle == LMP_STYLE_ATOM or cstyle == LMP_STYLE_LOCAL:
         self.lib.lammps_extract_compute.restype = POINTER(c_int)
         with ExceptionCheck(self):
           ptr = self.lib.lammps_extract_compute(self.lmp,cid,cstyle,ctype)
         return ptr[0]
 
     elif ctype == LMP_SIZE_VECTOR or ctype == LMP_SIZE_ROWS:
-      if cstyle == LMP_STYLE_GLOBAL  \
-         or cstyle == LMP_STYLE_LOCAL:
+      if cstyle == LMP_STYLE_GLOBAL or cstyle == LMP_STYLE_LOCAL:
         self.lib.lammps_extract_compute.restype = POINTER(c_int)
         with ExceptionCheck(self):
           ptr = self.lib.lammps_extract_compute(self.lmp,cid,cstyle,ctype)

--- a/python/lammps/numpy_wrapper.py
+++ b/python/lammps/numpy_wrapper.py
@@ -165,13 +165,20 @@ class numpy_wrapper:
     """
     value = self.lmp.extract_compute(cid, cstyle, ctype)
 
-    if cstyle in (LMP_STYLE_GLOBAL, LMP_STYLE_LOCAL):
+    if cstyle == LMP_STYLE_GLOBAL:
       if ctype == LMP_TYPE_VECTOR:
         nrows = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_VECTOR)
         return self.darray(value, nrows)
       elif ctype == LMP_TYPE_ARRAY:
         nrows = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_ROWS)
         ncols = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_COLS)
+        return self.darray(value, nrows, ncols)
+    elif cstyle == LMP_STYLE_LOCAL:
+      nrows = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_ROWS)
+      ncols = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_COLS)
+      if ncols == 0:
+        return self.darray(value, nrows)
+      else:
         return self.darray(value, nrows, ncols)
     elif cstyle == LMP_STYLE_ATOM:
       if ctype == LMP_TYPE_VECTOR:

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
@@ -266,7 +266,7 @@ void ComputeStressCartesian::compute_array()
   Pair *pair = force->pair;
   double **cutsq = force->pair->cutsq;
 
-  double xi1, xi2, xj1, xj2;
+  double xi1, xi2;
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];
@@ -305,9 +305,6 @@ void ComputeStressCartesian::compute_array()
           }
         }
       }
-      xj1 = x[j][dir1];
-      xj2 = x[j][dir2];
-
       delx = x[j][0] - xtmp;
       dely = x[j][1] - ytmp;
       delz = x[j][2] - ztmp;

--- a/src/EXTRA-DUMP/dump_yaml.cpp
+++ b/src/EXTRA-DUMP/dump_yaml.cpp
@@ -124,6 +124,12 @@ void DumpYAML::write_data(int n, double *mybuf)
     }
     fputs("]\n", fp);
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpYAML::write_footer()
+{
   fputs("...\n", fp);
 }
 

--- a/src/EXTRA-DUMP/dump_yaml.h
+++ b/src/EXTRA-DUMP/dump_yaml.h
@@ -35,6 +35,7 @@ class DumpYAML : public DumpCustom {
   void write() override;
   void write_header(bigint) override;
   void write_data(int, double *) override;
+  void write_footer() override;
 
   int modify_param(int, char **) override;
 };

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -517,6 +517,8 @@ void Dump::write()
 
   if (refreshflag) modify->compute[irefresh]->refresh();
 
+  if (filewriter && fp != nullptr) write_footer();
+
   // if file per timestep, close file if I am filewriter
 
   if (multifile) {

--- a/src/dump.h
+++ b/src/dump.h
@@ -153,6 +153,8 @@ class Dump : protected Pointers {
   virtual void pack(tagint *) = 0;
   virtual int convert_string(int, double *) { return 0; }
   virtual void write_data(int, double *) = 0;
+  virtual void write_footer() {}
+
   void pbc_allocate();
   double compute_time();
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1749,6 +1749,7 @@ void *lammps_extract_compute(void *handle, const char *id, int style, int type)
       if (type == LMP_TYPE_SCALAR) return (void *) &compute->size_local_rows;  /* for backward compatibility */
       if (type == LMP_TYPE_VECTOR) return (void *) compute->vector_local;
       if (type == LMP_TYPE_ARRAY) return (void *) compute->array_local;
+      if (type == LMP_SIZE_VECTOR) return (void *) &compute->size_local_rows;  /* alias for LMP_SIZE_ROWS */
       if (type == LMP_SIZE_ROWS) return (void *) &compute->size_local_rows;
       if (type == LMP_SIZE_COLS) return (void *) &compute->size_local_cols;
     }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1660,13 +1660,17 @@ lists the available options.
      - ``double **``
      - Local data array
    * - LMP_STYLE_LOCAL
+     - LMP_SIZE_VECTOR
+     - ``int *``
+     - Alias for using LMP_SIZE_ROWS
+   * - LMP_STYLE_LOCAL
      - LMP_SIZE_ROWS
      - ``int *``
-     - Number of local data rows
+     - Number of local array rows or length of vector
    * - LMP_STYLE_LOCAL
      - LMP_SIZE_COLS
      - ``int *``
-     - Number of local data columns
+     - Number of local array columns, 0 if vector
 
 .. warning::
 

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -61,9 +61,10 @@ void ReadRestart::command(int narg, char **arg)
 
   // check for remap option
 
-  int remapflag = 0;
+  int remapflag = 1;
   if (narg == 2) {
-    if (strcmp(arg[1],"remap") == 0) remapflag = 1;
+    if (strcmp(arg[1],"noremap") == 0) remapflag = 0;
+    else if (strcmp(arg[1],"remap") == 0) remapflag = 1; // for backward compatibility
     else error->all(FLERR,"Illegal read_restart command");
   }
 
@@ -643,8 +644,7 @@ void ReadRestart::header()
       int dimension = read_int();
       domain->dimension = dimension;
       if (domain->dimension == 2 && domain->zperiodic == 0)
-        error->all(FLERR,
-                   "Cannot run 2d simulation with non-periodic Z dimension");
+        error->all(FLERR, "Cannot run 2d simulation with non-periodic Z dimension");
 
     // read nprocs from restart file, warn if different
 

--- a/tools/msi2lmp/src/msi2lmp.c
+++ b/tools/msi2lmp/src/msi2lmp.c
@@ -66,9 +66,9 @@
 *  The program is started by supplying information at the command prompt
 * according to the usage described below.
 *
-*  USAGE: msi2lmp3 ROOTNAME {-print #} {-class #} {-frc FRC_FILE} {-ignore} {-nocenter} {-oldstyle}
+*  USAGE: msi2lmp ROOTNAME {-print #} {-class #} {-frc FRC_FILE} {-ignore} {-nocenter} {-oldstyle}
 *
-*  -- msi2lmp3 is the name of the executable
+*  -- msi2lmp is the name of the executable
 *  -- ROOTNAME is the base name of the .car and .mdf files
 *  -- all opther flags are optional and can be abbreviated (e.g. -p instead of -print)
 *

--- a/unittest/force-styles/tests/manybody-pair-pace_product.yaml
+++ b/unittest/force-styles/tests/manybody-pair-pace_product.yaml
@@ -1,7 +1,7 @@
 ---
 lammps_version: 17 Feb 2022
 date_generated: Fri Mar 18 22:17:48 2022
-epsilon: 1e-12
+epsilon: 5e-12
 skip_tests:
 prerequisites: ! |
   pair pace

--- a/unittest/force-styles/tests/manybody-pair-pace_recursive.yaml
+++ b/unittest/force-styles/tests/manybody-pair-pace_recursive.yaml
@@ -1,7 +1,7 @@
 ---
 lammps_version: 10 Mar 2021
 date_generated: Wed Apr  7 19:30:07 2021
-epsilon: 1e-12
+epsilon: 5e-12
 prerequisites: ! |
   pair pace
 pre_commands: ! |

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -1,6 +1,8 @@
 
 import sys,os,unittest,ctypes
-from lammps import lammps, LMP_VAR_ATOM, LMP_STYLE_GLOBAL, LMP_TYPE_VECTOR, LAMMPS_DOUBLE_2D, LAMMPS_AUTODETECT
+from lammps import lammps, LMP_VAR_ATOM, LMP_STYLE_GLOBAL, LMP_STYLE_LOCAL
+from lammps import LMP_TYPE_VECTOR, LMP_SIZE_VECTOR, LMP_SIZE_ROWS, LMP_SIZE_COLS
+from lammps import LAMMPS_DOUBLE_2D, LAMMPS_AUTODETECT
 
 has_manybody=False
 try:
@@ -310,6 +312,14 @@ create_atoms 1 single &
         self.assertEqual(nskip,0)
         self.assertEqual(minval,1.0)
         self.assertEqual(maxval,2.1)
+
+        ndist1 = self.lmp.extract_compute("dist",LMP_STYLE_LOCAL,LMP_SIZE_VECTOR)
+        ndist2 = self.lmp.extract_compute("dist",LMP_STYLE_LOCAL,LMP_SIZE_ROWS)
+        ndist3 = self.lmp.extract_compute("dist",LMP_STYLE_LOCAL,LMP_SIZE_COLS)
+
+        self.assertEqual(ndist1,21)
+        self.assertEqual(ndist2,21)
+        self.assertEqual(ndist3,0)
 
         self.assertNotEqual(self.lmp.find_pair_neighlist("lj/cut"),-1)
         self.assertNotEqual(self.lmp.find_compute_neighlist("dist"),-1)

--- a/unittest/python/python-numpy.py
+++ b/unittest/python/python-numpy.py
@@ -93,17 +93,39 @@ class PythonNumpy(unittest.TestCase):
         # TODO
         pass
 
-    def testExtractComputeLocalScalar(self):
-        # TODO
-        pass
-
     def testExtractComputeLocalVector(self):
-        # TODO
-        pass
+        self.lmp.command("region       box block 0 2 0 2 0 2")
+        self.lmp.command("create_box 1 box")
+        self.lmp.command("create_atoms 1 single 1.0 1.0 1.0")
+        self.lmp.command("create_atoms 1 single 1.0 1.0 1.5")
+        self.lmp.command("mass 1 1.0")
+        self.lmp.command("pair_style lj/cut 1.9")
+        self.lmp.command("pair_coeff 1 1 1.0 1.0")
+        self.lmp.command("compute r0 all pair/local dist")
+        self.lmp.command("run 0 post no")
+        values = self.lmp.numpy.extract_compute("r0", LMP_STYLE_LOCAL, LMP_TYPE_VECTOR)
+        self.assertEqual(values.ndim, 1)
+        self.assertEqual(values.size, 2)
+        self.assertEqual(values[0], 0.5)
+        self.assertEqual(values[1], 1.5)
 
     def testExtractComputeLocalArray(self):
-        # TODO
-        pass
+        self.lmp.command("region       box block 0 2 0 2 0 2")
+        self.lmp.command("create_box 1 box")
+        self.lmp.command("create_atoms 1 single 1.0 1.0 1.0")
+        self.lmp.command("create_atoms 1 single 1.0 1.0 1.5")
+        self.lmp.command("mass 1 1.0")
+        self.lmp.command("pair_style lj/cut 1.9")
+        self.lmp.command("pair_coeff 1 1 1.0 1.0")
+        self.lmp.command("compute r0 all pair/local dist dx dy dz")
+        self.lmp.command("run 0 post no")
+        values = self.lmp.numpy.extract_compute("r0", LMP_STYLE_LOCAL, LMP_TYPE_ARRAY)
+        self.assertEqual(values.ndim, 2)
+        self.assertEqual(values.size, 8)
+        self.assertEqual(values[0,0], 0.5)
+        self.assertEqual(values[0,3], -0.5)
+        self.assertEqual(values[1,0], 1.5)
+        self.assertEqual(values[1,3], 1.5)
 
     def testExtractAtomDeprecated(self):
         self.lmp.command("units lj")


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes and bugfixes to get LAMMPS ready for the next stable release

**Related Issue(s)**

Fixes #3308 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following changes are include:
- add support for a `Dump::write_footer()` function, required by `dump style yaml`, that will print closing data for a dump file frame. Fixes #3308 
- Change "remap semantics" for the read_restart command to always use the remap option by default and offer an "noremap" option to be able to change to the old behavior.  Closes #3078
- correct NumPy interface to `extract_compute()` for local computes. Add support for `LMP_SIZE_VECTOR` as alias for `LMP_SIZE_ROWS`. Update docs and add unit test. Addresses [this issue reported on MatSci.org](https://matsci.org/t/sizeof-vector-extract-compute-for-pair-local-dist/42979/)
- updates and corrections to the "Fortran2" and "Fortran_dftb" Fortran interfaces (from PR #3312)

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [x] A package specific README file has been included or updated
- [ ] One or more example input decks are included

