### PR TITLE
Bugfixes

### DIFF
--- a/src/KOKKOS/atom_vec_angle_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_angle_kokkos.cpp
@@ -1391,6 +1391,9 @@ int AtomVecAngleKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int n
                                               int nlocal,int dim,X_FLOAT lo,X_FLOAT hi,
                                               ExecutionSpace space) {
   const size_t elements = 17+atom->maxspecial+2*atom->bond_per_atom+4*atom->angle_per_atom;
+
+  while (nlocal + nrecv/elements >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecAngleKokkos_UnpackExchangeFunctor<LMPHostType>

--- a/src/KOKKOS/atom_vec_atomic_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_atomic_kokkos.cpp
@@ -649,6 +649,8 @@ struct AtomVecAtomicKokkos_UnpackExchangeFunctor {
 /* ---------------------------------------------------------------------- */
 
 int AtomVecAtomicKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int nrecv,int nlocal,int dim,X_FLOAT lo,X_FLOAT hi,ExecutionSpace space) {
+  while (nlocal + nrecv/11 >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecAtomicKokkos_UnpackExchangeFunctor<LMPHostType> f(atomKK,k_buf,k_count,dim,lo,hi);

--- a/src/KOKKOS/atom_vec_bond_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_bond_kokkos.cpp
@@ -845,6 +845,9 @@ int AtomVecBondKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int nr
                                               int nlocal,int dim,X_FLOAT lo,X_FLOAT hi,
                                               ExecutionSpace space) {
   const size_t elements = 16+atomKK->maxspecial+atomKK->bond_per_atom+atomKK->bond_per_atom;
+
+  while (nlocal + nrecv/elements >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecBondKokkos_UnpackExchangeFunctor<LMPHostType>

--- a/src/KOKKOS/atom_vec_charge_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_charge_kokkos.cpp
@@ -774,6 +774,8 @@ struct AtomVecChargeKokkos_UnpackExchangeFunctor {
 int AtomVecChargeKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int nrecv,
                                                 int nlocal,int dim,X_FLOAT lo,X_FLOAT hi,
                                                 ExecutionSpace space) {
+  while (nlocal + nrecv/12 >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecChargeKokkos_UnpackExchangeFunctor<LMPHostType> f(atomKK,k_buf,k_count,dim,lo,hi);

--- a/src/KOKKOS/atom_vec_dpd_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_dpd_kokkos.cpp
@@ -1505,6 +1505,8 @@ struct AtomVecDPDKokkos_UnpackExchangeFunctor {
 /* ---------------------------------------------------------------------- */
 
 int AtomVecDPDKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int nrecv,int nlocal,int dim,X_FLOAT lo,X_FLOAT hi,ExecutionSpace space) {
+  while (nlocal + nrecv/17 >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecDPDKokkos_UnpackExchangeFunctor<LMPHostType> f(atomKK,k_buf,k_count,dim,lo,hi);

--- a/src/KOKKOS/atom_vec_full_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_full_kokkos.cpp
@@ -1186,6 +1186,9 @@ int AtomVecFullKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int nr
                                               ExecutionSpace space) {
   const size_t elements = 20+atom->maxspecial+2*atom->bond_per_atom+4*atom->angle_per_atom+
     5*atom->dihedral_per_atom + 5*atom->improper_per_atom;
+
+  while (nlocal + nrecv/elements >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecFullKokkos_UnpackExchangeFunctor<LMPHostType>

--- a/src/KOKKOS/atom_vec_molecular_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_molecular_kokkos.cpp
@@ -1594,6 +1594,9 @@ int AtomVecMolecularKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,i
                                                    ExecutionSpace space) {
   const size_t elements = 19+atom->maxspecial+2*atom->bond_per_atom+4*atom->angle_per_atom+
     5*atom->dihedral_per_atom + 5*atom->improper_per_atom;
+
+  while (nlocal + nrecv/elements >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecMolecularKokkos_UnpackExchangeFunctor<LMPHostType>

--- a/src/KOKKOS/atom_vec_sphere_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.cpp
@@ -2341,6 +2341,8 @@ struct AtomVecSphereKokkos_UnpackExchangeFunctor {
 /* ---------------------------------------------------------------------- */
 
 int AtomVecSphereKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int nrecv,int nlocal,int dim,X_FLOAT lo,X_FLOAT hi,ExecutionSpace space) {
+  while (nlocal + nrecv/16 >= nmax) grow(0);
+
   if (space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecSphereKokkos_UnpackExchangeFunctor<LMPHostType> f(atomKK,k_buf,k_count,dim,lo,hi);

--- a/src/KOKKOS/atom_vec_spin_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_spin_kokkos.cpp
@@ -863,6 +863,8 @@ struct AtomVecSpinKokkos_UnpackExchangeFunctor {
 int AtomVecSpinKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,int nrecv,
                                                 int nlocal,int dim,X_FLOAT lo,X_FLOAT hi,
                                                 ExecutionSpace space) {
+  while (nlocal + nrecv/15 >= nmax) grow(0);
+
   if(space == Host) {
     k_count.h_view(0) = nlocal;
     AtomVecSpinKokkos_UnpackExchangeFunctor<LMPHostType> f(atomKK,k_buf,k_count,dim,lo,hi);

--- a/src/KOKKOS/min_cg_kokkos.cpp
+++ b/src/KOKKOS/min_cg_kokkos.cpp
@@ -49,6 +49,8 @@ int MinCGKokkos::iterate(int maxiter)
   fix_minimize_kk->k_vectors.sync<LMPDeviceType>();
   fix_minimize_kk->k_vectors.modify<LMPDeviceType>();
 
+  atomKK->sync(Device,F_MASK);
+
   // nlimit = max # of CG iterations before restarting
   // set to ndoftotal unless too big
 

--- a/src/KOKKOS/min_kokkos.cpp
+++ b/src/KOKKOS/min_kokkos.cpp
@@ -79,6 +79,8 @@ void MinKokkos::setup(int flag)
   }
   update->setupflag = 1;
 
+  lmp->kokkos->auto_sync = 1;
+
   // setup extra global dof due to fixes
   // cannot be done in init() b/c update init() is before modify init()
 
@@ -170,7 +172,7 @@ void MinKokkos::setup(int flag)
   }
   else if (force->pair) force->pair->compute_dummy(eflag,vflag);
 
-  if (atomKK->molecular) {
+  if (atom->molecular != Atom::ATOMIC) {
     if (force->bond) {
       atomKK->sync(force->bond->execution_space,force->bond->datamask_read);
       force->bond->compute(eflag,vflag);
@@ -242,6 +244,8 @@ void MinKokkos::setup_minimal(int flag)
   // acquire ghosts
   // build neighbor lists
 
+  lmp->kokkos->auto_sync = 1;
+
   if (flag) {
     modify->setup_pre_exchange();
     if (triclinic) domain->x2lamda(atom->nlocal);
@@ -277,7 +281,7 @@ void MinKokkos::setup_minimal(int flag)
   }
   else if (force->pair) force->pair->compute_dummy(eflag,vflag);
 
-  if (atomKK->molecular) {
+  if (atom->molecular != Atom::ATOMIC) {
     if (force->bond) {
       atomKK->sync(force->bond->execution_space,force->bond->datamask_read);
       force->bond->compute(eflag,vflag);

--- a/src/KOKKOS/min_kokkos.cpp
+++ b/src/KOKKOS/min_kokkos.cpp
@@ -580,6 +580,7 @@ void MinKokkos::force_clear()
 
 double MinKokkos::fnorm_sqr()
 {
+  atomKK->sync(Device,F_MASK);
 
   double local_norm2_sqr = 0.0;
   {
@@ -608,6 +609,7 @@ double MinKokkos::fnorm_sqr()
 
 double MinKokkos::fnorm_inf()
 {
+  atomKK->sync(Device,F_MASK);
 
   double local_norm_inf = 0.0;
   {
@@ -636,6 +638,7 @@ double MinKokkos::fnorm_inf()
 
 double MinKokkos::fnorm_max()
 {
+  atomKK->sync(Device,F_MASK);
 
   double local_norm_max = 0.0;
   {

--- a/src/KOKKOS/min_kokkos.cpp
+++ b/src/KOKKOS/min_kokkos.cpp
@@ -499,6 +499,7 @@ double MinKokkos::energy_force(int resetflag)
   if (force->newton) {
     comm->reverse_comm();
     timer->stamp(Timer::COMM);
+    atomKK->sync(Device,F_MASK);
   }
 
   // update per-atom minimization variables stored by pair styles
@@ -571,7 +572,7 @@ void MinKokkos::force_clear()
       }
     });
   }
-  atomKK->modified(Device,F_MASK);
+  atomKK->modified(Device,F_MASK|TORQUE_MASK);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/min_linesearch_kokkos.cpp
+++ b/src/KOKKOS/min_linesearch_kokkos.cpp
@@ -111,9 +111,6 @@ void MinLineSearchKokkos::reset_vectors()
   x0 = fix_minimize_kk->request_vector_kokkos(0);
   g = fix_minimize_kk->request_vector_kokkos(1);
   h = fix_minimize_kk->request_vector_kokkos(2);
-
-  auto h_fvec = Kokkos::create_mirror_view(fvec);
-  Kokkos::deep_copy(h_fvec,fvec);
 }
 
 /* ----------------------------------------------------------------------
@@ -180,6 +177,8 @@ int MinLineSearchKokkos::linemin_quadratic(double eoriginal, double &alpha)
 
   fix_minimize_kk->k_vectors.sync<LMPDeviceType>();
   fix_minimize_kk->k_vectors.modify<LMPDeviceType>();
+
+  atomKK->sync(Device,X_MASK|F_MASK);
 
   // fdothall = projection of search dir along downhill gradient
   // if search direction is not downhill, exit with error
@@ -364,8 +363,8 @@ double MinLineSearchKokkos::alpha_step(double alpha, int resetflag)
   // reset to starting point
 
   if (nextra_global) modify->min_step(0.0,hextra);
-  atomKK->k_x.clear_sync_state(); // ignore if host positions since device
-                                  //  positions will be reset below
+  atomKK->k_x.clear_sync_state(); // ignore if host positions modified since 
+                                  //  device positions will be reset below
   {
     // local variables for lambda capture
 
@@ -408,6 +407,8 @@ double MinLineSearchKokkos::compute_dir_deriv(double &ff)
 {
   double dot[2],dotall[2];
   double fh;
+
+  atomKK->sync(Device,F_MASK);
 
   // compute new fh, alpha, delfh
 

--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -153,6 +153,9 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
   int nall = nlocal;
   if (GHOST)
     nall += atom->nghost;
+
+  if (nall == 0) return;
+
   list->grow(nall);
 
   NeighborKokkosExecute<DeviceType>

--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -139,7 +139,7 @@ template<class DeviceType, typename real_type, int vector_length>
 void PairSNAPKokkos<DeviceType, real_type, vector_length>::compute(int eflag_in, int vflag_in)
 {
   if (host_flag) {
-    atomKK->sync(Host,X_MASK|TYPE_MASK);
+    atomKK->sync(Host,X_MASK|F_MASK|TYPE_MASK);
     PairSNAP::compute(eflag_in,vflag_in);
     atomKK->modified(Host,F_MASK);
     return;

--- a/src/KOKKOS/pair_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_zbl_kokkos.cpp
@@ -126,8 +126,6 @@ void PairZBLKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
 
   atomKK->sync(execution_space,datamask_read);
-  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
-  else atomKK->modified(execution_space,F_MASK);
 
   x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();
@@ -177,6 +175,9 @@ void PairZBLKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
 
   if (vflag_fdotr) pair_virial_fdotr_compute(this);
+
+  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  else atomKK->modified(execution_space,F_MASK);
 }
 
 template<class DeviceType>

--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -282,8 +282,6 @@ void VerletKokkos::run(int n)
   f_merge_copy = DAT::t_f_array("VerletKokkos::f_merge_copy",atomKK->k_f.extent(0));
 
   atomKK->sync(Device,ALL_MASK);
-  //static double time = 0.0;
-  //Kokkos::Timer ktimer;
 
   timer->init_timeout();
   for (int i = 0; i < n; i++) {
@@ -297,10 +295,8 @@ void VerletKokkos::run(int n)
 
     // initial time integration
 
-    //ktimer.reset();
     timer->stamp();
     modify->initial_integrate(vflag);
-    //time += ktimer.seconds();
     if (n_post_integrate) modify->post_integrate();
     timer->stamp(Timer::MODIFY);
 
@@ -445,7 +441,6 @@ void VerletKokkos::run(int n)
     if (pair_compute_flag) {
       atomKK->sync(force->pair->execution_space,force->pair->datamask_read);
       atomKK->sync(force->pair->execution_space,~(~force->pair->datamask_read|(F_MASK | ENERGY_MASK | VIRIAL_MASK)));
-      Kokkos::Timer ktimer;
       force->pair->compute(eflag,vflag);
       atomKK->modified(force->pair->execution_space,force->pair->datamask_modify);
       atomKK->modified(force->pair->execution_space,~(~force->pair->datamask_modify|(F_MASK | ENERGY_MASK | VIRIAL_MASK)));

--- a/src/ML-SNAP/pair_snap.cpp
+++ b/src/ML-SNAP/pair_snap.cpp
@@ -63,11 +63,8 @@ PairSNAP::~PairSNAP()
   memory->destroy(radelem);
   memory->destroy(wjelem);
   memory->destroy(coeffelem);
-
-  if (switchinnerflag) {
-    memory->destroy(sinnerelem);
-    memory->destroy(dinnerelem);
-  }
+  memory->destroy(sinnerelem);
+  memory->destroy(dinnerelem);
 
   memory->destroy(beta);
   memory->destroy(bispectrum);


### PR DESCRIPTION
**Summary**

- Add missing `atom->grow()` to Kokkos unpack_exchange to avoid segmentation fault
- Fix small memory leak in SNAP
- Prevent view bounds error when building the Kokkos neigh list and a proc has no atoms
- Add missing GPU <--> CPU data transfer in Kokkos minimize, gave wrong results when using `comm no` or `comm/reverse no` running on the GPU

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), Kokkos minimize issue reported by Mary Alice Cusentino (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes