### PR TITLE
update fix nvt/sllod doc page with more accurate SLLOD citations

### DIFF
--- a/doc/src/fix_nvt_sllod.rst
+++ b/doc/src/fix_nvt_sllod.rst
@@ -67,16 +67,16 @@ equivalent to Newton's equations of motion for shear flow by
 the desired velocity gradient and the correct production of work by
 stresses for all forms of homogeneous flow by :ref:`(Daivis and Todd)
 <Daivis>`.
-The LAMMPS implementation corresponds to the p-SLLOD variant
-of SLLOD. :ref:`(Edwards) <Edwards>`.
-The equations of motion are coupled to a
-Nose/Hoover chain thermostat in a velocity Verlet formulation, closely
-following the implementation used for the :doc:`fix nvt <fix_nh>`
-command.
+
+The LAMMPS implementation corresponds to the standard SLLOD equations
+of motion by :ref:`(Evans and Morriss) <Evans3>`.  The equations of
+motion are coupled to a Nose/Hoover chain thermostat in a velocity
+Verlet formulation, closely following the implementation used for the
+:doc:`fix nvt <fix_nh>` command.
 
 .. note::
 
-   A recent (2017) book by :ref:`(Daivis and Todd) <Daivis-sllod>`
+   A recent (2017) book by :ref:`(Todd and Daivis) <Todd-sllod>`
    discusses use of the SLLOD method and non-equilibrium MD (NEMD)
    thermostatting generally, for both simple and complex fluids,
    e.g. molecular systems.  The latter can be tricky to do correctly.
@@ -183,11 +183,8 @@ Same as :doc:`fix nvt <fix_nh>`, except tchain = 1.
 
 **(Daivis and Todd)** Daivis and Todd, J Chem Phys, 124, 194103 (2006).
 
-.. _Edwards:
+.. _Todd-sllod:
 
-**(Edwards)** Edwards, Baig, and Keffer, J Chem Phys 124, 194104 (2006).
-
-.. _Daivis-sllod:
-
-**(Daivis and Todd)** Daivis and Todd, Nonequilibrium Molecular Dynamics (book),
-Cambridge University Press, https://doi.org/10.1017/9781139017848, (2017).
+**(Todd and Daivis)** Todd and Daivis, Nonequilibrium Molecular
+Dynamics (book), Cambridge University Press,
+https://doi.org/10.1017/9781139017848, (2017).


### PR DESCRIPTION
**Summary**

Improve fix nvt/sllod doc page to be more clear about which SLLOD variant is implemented in LAMMPS.

**Related Issue(s)**

N/A

**Author(s)**

Pieter in 't Veld (BASF)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


