### PR TITLE
Implement scatter load / store mechanism for ulisttot_pack to improve…

### DIFF
--- a/src/KOKKOS/pair_snap_kokkos_impl.h
+++ b/src/KOKKOS/pair_snap_kokkos_impl.h
@@ -858,7 +858,7 @@ void PairSNAPKokkos<DeviceType, real_type, vector_length>::operator() (TagPairSN
       utot_re = -utot_re;
     }
 
-    my_sna.ulisttot_pack(iatom_mod, idxu, ielem, iatom_div) = { utot_re, utot_im };
+    my_sna.scatter_store({ utot_re, utot_im }, iatom_mod, idxu, ielem, iatom_div);
 
     if (mapper.flip_sign == 0) {
       my_sna.ylist_pack_re(iatom_mod, mapper.idxu_half, ielem, iatom_div) = 0.;


### PR DESCRIPTION
… throughput

**Summary**

Implements a new scatter / load store mechanism for the Kokkos/HIP backend only of SNAP.  This yields an ~10% overall speedup on a single GCD of an MI-250 (and ~20% on ComputeYi)

**Related Issue(s)**

N/A

**Author(s)**

Nicholas Curtis

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues anticipated.

**Implementation Notes**

Passes validation compared to unmodified baseline.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

N/A

