### PR TITLE
Minor improvements and bugfixes to the mdi/qm fix

### DIFF
--- a/src/MDI/fix_mdi_qm.cpp
+++ b/src/MDI/fix_mdi_qm.cpp
@@ -242,14 +242,28 @@ void FixMDIQM::init()
 
   reallocate();
 
-  int ierr = MDI_Send_command(">NATOMS", mdicomm);
-  if (ierr) error->all(FLERR, "MDI: >NATOMS command");
-  int n = static_cast<int> (atom->natoms);
-  ierr = MDI_Send(&n, 1, MDI_INT, mdicomm);
-  if (ierr) error->all(FLERR, "MDI: >NATOMS data");
+  int natoms_exists;
+  int ierr = MDI_Check_command_exists("@DEFAULT", ">NATOMS", mdicomm, &natoms_exists);
+  if (ierr) error->all(FLERR, "MDI: >NATOMS command check");
+  if ( natoms_exists ) {
+    ierr = MDI_Send_command(">NATOMS", mdicomm);
+    if (ierr) error->all(FLERR, "MDI: >NATOMS command");
+    int n = static_cast<int> (atom->natoms);
+    ierr = MDI_Send(&n, 1, MDI_INT, mdicomm);
+    if (ierr) error->all(FLERR, "MDI: >NATOMS data");
+  }
 
-  if (elements) send_elements();
-  else send_types();
+  int elements_exists;
+  int types_exists;
+  ierr = MDI_Check_command_exists("@DEFAULT", ">ELEMENTS", mdicomm, &elements_exists);
+  if (ierr) error->all(FLERR, "MDI: >ELEMENTS command check");
+  ierr = MDI_Check_command_exists("@DEFAULT", ">TYPES", mdicomm, &types_exists);
+  if (ierr) error->all(FLERR, "MDI: >TYPES command check");
+  if ( elements && elements_exists ) {
+      send_elements();
+  } else if ( types_exists ) {
+      send_types();
+  }
   send_box();
 }
 
@@ -502,13 +516,18 @@ void FixMDIQM::send_box()
 {
   double cell[9];
 
-  int ierr = MDI_Send_command(">CELL_DISPL", mdicomm);
-  if (ierr) error->all(FLERR, "MDI: >CELL_DISPL command");
-  cell[0] = domain->boxlo[0] * lmp2mdi_length;
-  cell[1] = domain->boxlo[1] * lmp2mdi_length;
-  cell[2] = domain->boxlo[2] * lmp2mdi_length;
-  ierr = MDI_Send(cell, 3, MDI_DOUBLE, mdicomm);
-  if (ierr) error->all(FLERR, "MDI: >CELL_DISPL data");
+  int celldispl_exists;
+  int ierr = MDI_Check_command_exists("@DEFAULT", ">NATOMS", mdicomm, &celldispl_exists);
+  if (ierr) error->all(FLERR, "MDI: >CELL_DISPL command check");
+  if ( celldispl_exists ) {
+    ierr = MDI_Send_command(">CELL_DISPL", mdicomm);
+    if (ierr) error->all(FLERR, "MDI: >CELL_DISPL command");
+    cell[0] = domain->boxlo[0] * lmp2mdi_length;
+    cell[1] = domain->boxlo[1] * lmp2mdi_length;
+    cell[2] = domain->boxlo[2] * lmp2mdi_length;
+    ierr = MDI_Send(cell, 3, MDI_DOUBLE, mdicomm);
+    if (ierr) error->all(FLERR, "MDI: >CELL_DISPL data");
+  }
 
   ierr = MDI_Send_command(">CELL", mdicomm);
   if (ierr) error->all(FLERR, "MDI: >CELL command");
@@ -521,6 +540,10 @@ void FixMDIQM::send_box()
   cell[6] = domain->xz;
   cell[7] = domain->yz;
   cell[8] = domain->boxhi[2] - domain->boxlo[2];
+
+  // convert the cell units to bohr
+  for (int icell = 0; icell < 9; icell++) cell[icell] *= lmp2mdi_length;
+
   ierr = MDI_Send(cell, 9, MDI_DOUBLE, mdicomm);
   if (ierr) error->all(FLERR, "MDI: >CELL data");
 }

--- a/src/MDI/fix_mdi_qm.cpp
+++ b/src/MDI/fix_mdi_qm.cpp
@@ -380,9 +380,6 @@ void FixMDIQM::post_force(int vflag)
     if (ierr) error->all(FLERR, "MDI: <STRESS command");
     ierr = MDI_Recv(qm_virial, 9, MDI_DOUBLE, mdicomm);
     if (ierr) error->all(FLERR, "MDI: <STRESS data");
-    //for (int i = 0; i < 9; i++) {
-    //  qm_virial[i] = 0.0;
-    //}
     MPI_Bcast(qm_virial, 9, MPI_DOUBLE, 0, world);
 
     qm_virial_symmetric[0] = qm_virial[0] * mdi2lmp_pressure;


### PR DESCRIPTION
**Summary**

I've been running some tests with the updated `mdi/qm` fix, and have noticed a few bugs and/or portions of the code that could be made more general.  This PR makes the following changes to `fix_mdi_qm.cpp`:

- The use of the `>NATOMS`, `>ELEMENTS`, and `>TYPES` commands are now conditional on the engine having support for these commands.  The code checks whether the driver supports these commands with a call to `MDI_Check_command_exists`.  If the code does not support one of these commands, that command is not sent to the engine.  This allows the `mdi/qm` fix to be used with QM codes that do not support changing the number/types of atoms on-the-fly, as long as no atoms are added or removed over the course of the simulation.
- Similarly, I've made the `>CELL_DISPL` command conditional on the engine having support for it, as many QM codes have hardcoded values for this.  You can typically assume that if the driver sends coordinates to an engine that has a different value of CELL_DISPL, the engine will simply shift any atoms that fall outside of its box by an appropriate lattice vector.  The primary disadvantage to not sending `>CELL_DISPL` to the engine is that if the driver at some point requests coordinates from the engine (i.e., with `<COORDS`), some of those coordinates may need to be shifted back into the driver's box.  Because the `mdi/qm` fix doesn't use `<COORDS`, there shouldn't be much need for `>CELL_DISPL` anyway.
- The values sent alongside the `>CELL` command were not being converted to MDI units.  I've added the conversion.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

Taylor Barnes, MolSSI

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


