### PR TITLE
Redoing groups in compute contact/atom

### DIFF
--- a/doc/src/compute_contact_atom.rst
+++ b/doc/src/compute_contact_atom.rst
@@ -8,10 +8,11 @@ Syntax
 
 .. parsed-literal::
 
-   compute ID group-ID contact/atom
+   compute ID group-ID contact/atom group2-ID
 
 * ID, group-ID are documented in :doc:`compute <compute>` command
 * contact/atom = style name of this compute command
+* group2-ID = optional argument to restrict which atoms to consider for contacts (see below)
 
 Examples
 """"""""
@@ -19,6 +20,7 @@ Examples
 .. code-block:: LAMMPS
 
    compute 1 all contact/atom
+   compute 1 all contact/atom mygroup
 
 Description
 """""""""""
@@ -45,6 +47,9 @@ overview of LAMMPS output options.
 The per-atom vector values will be a number >= 0.0, as explained
 above.
 
+The optional *group2-ID* argument allows to specify from which group atoms
+contribute to the coordination number. Default setting is group 'all'.
+
 Restrictions
 """"""""""""
 
@@ -62,5 +67,8 @@ Related commands
 
 Default
 """""""
+
+*group2-ID* = all
+
 
 none

--- a/src/GRANULAR/compute_contact_atom.cpp
+++ b/src/GRANULAR/compute_contact_atom.cpp
@@ -18,6 +18,7 @@
 #include "comm.h"
 #include "error.h"
 #include "force.h"
+#include "group.h"
 #include "memory.h"
 #include "modify.h"
 #include "neigh_list.h"
@@ -34,7 +35,16 @@ ComputeContactAtom::ComputeContactAtom(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg),
   contact(nullptr)
 {
-  if (narg != 3) error->all(FLERR,"Illegal compute contact/atom command");
+  if (narg != 3 && narg != 4) error->all(FLERR,"Illegal compute contact/atom command");
+
+  jgroup = group->find("all");
+  jgroupbit = group->bitmask[jgroup];
+  if (narg == 4) {
+    group2 = utils::strdup(arg[3]);
+    jgroup = group->find(group2);
+    if (jgroup == -1) error->all(FLERR, "Compute contact/atom group2 ID does not exist");
+    jgroupbit = group->bitmask[jgroup];
+  }
 
   peratom_flag = 1;
   size_peratom_cols = 0;
@@ -120,28 +130,28 @@ void ComputeContactAtom::compute_peratom()
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];
-    if (mask[i] & groupbit) {
-      xtmp = x[i][0];
-      ytmp = x[i][1];
-      ztmp = x[i][2];
-      radi = radius[i];
-      jlist = firstneigh[i];
-      jnum = numneigh[i];
 
-      for (jj = 0; jj < jnum; jj++) {
-        j = jlist[jj];
-        j &= NEIGHMASK;
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    radi = radius[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
 
-        delx = xtmp - x[j][0];
-        dely = ytmp - x[j][1];
-        delz = ztmp - x[j][2];
-        rsq = delx*delx + dely*dely + delz*delz;
-        radsum = radi + radius[j];
-        radsumsq = radsum*radsum;
-        if (rsq <= radsumsq) {
-          contact[i] += 1.0;
-          contact[j] += 1.0;
-        }
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx * delx + dely * dely + delz * delz;
+      radsum = radi + radius[j];
+      radsumsq = radsum * radsum;
+      if (rsq <= radsumsq) {
+        // Only tally for atoms in compute group (groupbit) if neighbor is in group2 (jgroupbit)
+        if ((mask[i] & groupbit) && (mask[j] & jgroupbit)) contact[i] += 1.0;
+        if ((mask[j] & groupbit) && (mask[i] & jgroupbit)) contact[j] += 1.0;
       }
     }
   }

--- a/src/GRANULAR/compute_contact_atom.cpp
+++ b/src/GRANULAR/compute_contact_atom.cpp
@@ -133,34 +133,33 @@ void ComputeContactAtom::compute_peratom()
     i = ilist[ii];
 
     // Only proceed if i is either part of the compute group or will contribute to contacts
-    if ((mask[i] & groupbit) || (mask[i] & jgroupbit)) {
-      xtmp = x[i][0];
-      ytmp = x[i][1];
-      ztmp = x[i][2];
-      radi = radius[i];
-      jlist = firstneigh[i];
-      jnum = numneigh[i];
+    if (! (mask[i] & groupbit) && ! (mask[i] & jgroupbit)) continue;
 
-      for (jj = 0; jj < jnum; jj++) {
-        j = jlist[jj];
-        j &= NEIGHMASK;
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    radi = radius[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
 
-        // Only tally for atoms in compute group (groupbit) if neighbor is in group2 (jgroupbit)
-        update_i_flag = (mask[i] & groupbit) && (mask[j] & jgroupbit);
-        update_j_flag = (mask[j] & groupbit) && (mask[i] & jgroupbit);
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      j &= NEIGHMASK;
 
-        if (update_i_flag || update_j_flag) {
-          delx = xtmp - x[j][0];
-          dely = ytmp - x[j][1];
-          delz = ztmp - x[j][2];
-          rsq = delx * delx + dely * dely + delz * delz;
-          radsum = radi + radius[j];
-          radsumsq = radsum * radsum;
-          if (rsq <= radsumsq) {
-            if (update_i_flag) contact[i] += 1.0;
-            if (update_j_flag) contact[j] += 1.0;
-          }
-        }
+      // Only tally for atoms in compute group (groupbit) if neighbor is in group2 (jgroupbit)
+      update_i_flag = (mask[i] & groupbit) && (mask[j] & jgroupbit);
+      update_j_flag = (mask[j] & groupbit) && (mask[i] & jgroupbit);
+      if (! update_i_flag && ! update_j_flag) continue;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx * delx + dely * dely + delz * delz;
+      radsum = radi + radius[j];
+      radsumsq = radsum * radsum;
+      if (rsq <= radsumsq) {
+        if (update_i_flag) contact[i] += 1.0;
+        if (update_j_flag) contact[j] += 1.0;
       }
     }
   }

--- a/src/GRANULAR/compute_contact_atom.h
+++ b/src/GRANULAR/compute_contact_atom.h
@@ -37,10 +37,10 @@ class ComputeContactAtom : public Compute {
 
  private:
   int nmax;
-  
+
   char *group2;
-  int jgroup, jgroupbit;  
-  
+  int jgroup, jgroupbit;
+
   class NeighList *list;
   double *contact;
 };

--- a/src/GRANULAR/compute_contact_atom.h
+++ b/src/GRANULAR/compute_contact_atom.h
@@ -37,6 +37,10 @@ class ComputeContactAtom : public Compute {
 
  private:
   int nmax;
+  
+  char *group2;
+  int jgroup, jgroupbit;  
+  
   class NeighList *list;
   double *contact;
 };


### PR DESCRIPTION
**Summary**

This pull request fixes the incorrect cross-group handling incompute contact/atom when the compute group is not _all_ as reported in [issue #3338](https://github.com/lammps/lammps/issues/3338).

While fixing the bug, I also extended the functionality of compute contact/atom to match that of compute coord/atom allowing the user to specify a second group ID. The second ID, defaulted to _all_, restricts which atoms contribute to the contact number. 

**Related Issue(s)**

Fixes [#3338](https://github.com/lammps/lammps/issues/3338).

**Author(s)**

Joel Clemmer (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

NA

**Implementation Notes**

I debated whether the input arguments should be:
`compute 1 all contact/atom mygroupID` (as implemented)
versus
`compute 1 all contact/atom group mygroupID` (as in compute coord/atom)
I'm not sure which is preferred.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [x] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

NA

