### PR TITLE
Fix bug in vtk dump

### DIFF
--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -334,13 +334,15 @@ int DumpVTK::count()
 
   // un-choose if not in region
 
-  auto region = domain->get_region_by_id(idregion);
-  if (region) {
-    region->prematch();
-    double **x = atom->x;
-    for (i = 0; i < nlocal; i++)
-      if (choose[i] && region->match(x[i][0],x[i][1],x[i][2]) == 0)
-        choose[i] = 0;
+  if(idregion != nullptr){
+    auto region = domain->get_region_by_id(idregion);
+    if (region) {
+      region->prematch();
+      double **x = atom->x;
+      for (i = 0; i < nlocal; i++)
+        if (choose[i] && region->match(x[i][0],x[i][1],x[i][2]) == 0)
+          choose[i] = 0;
+    }
   }
 
   // un-choose if any threshold criterion isn't met

--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -334,7 +334,7 @@ int DumpVTK::count()
 
   // un-choose if not in region
 
-  if(idregion != nullptr){
+  if (idregion) {
     auto region = domain->get_region_by_id(idregion);
     if (region) {
       region->prematch();


### PR DESCRIPTION
**Summary**

Lammps always segfaulted when dumping into the vtk format and not specifying a region. This was caused by the `idregion` variable being a nullpointer and getting checked against other strings. An extra nullpointer check resolved the bug.

**Related Issue(s)**

NA

**Author(s)**

Ákos Seres

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

Added an extra check for null pointers

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


