### PR TITLE
Add set diameter/range command

### DIFF
--- a/doc/src/set.rst
+++ b/doc/src/set.rst
@@ -16,7 +16,7 @@ Syntax
 * keyword = *type* or *type/fraction* or *type/ratio* or *type/subset*
   or *mol* or *x* or *y* or *z* or *charge* or *dipole* or
   *dipole/random* or *quat* or *spin* or *spin/random* or
-  *quat* or *quat/random* or *diameter* or *shape* or
+  *quat* or *quat/random* or *diameter* or *diameter/range* or *shape* or
   *length* or *tri* or *theta* or *theta/random* or *angmom* or
   *omega* or *mass* or *density* or *density/disc* or
   *volume* or *image* or *bond* or *angle* or *dihedral* or
@@ -70,6 +70,9 @@ Syntax
          seed = random # seed (positive integer) for quaternion orientations
        *diameter* value = diameter of spherical particle (distance units)
          value can be an atom-style variable (see below)
+       *diameter/range* values = seed Dlo Dhi
+         seed = random # seed (positive integer) for diameters of spherical particles
+         Dlo,Dhi = range of diameters for affected particles (distance units)
        *shape* value = Sx Sy Sz
          Sx,Sy,Sz = 3 diameters of ellipsoid (distance units)
        *length* value = len

--- a/src/set.h
+++ b/src/set.h
@@ -36,7 +36,7 @@ class Set : public Command {
   int ximage, yimage, zimage, ximageflag, yimageflag, zimageflag;
   int cc_index;
   bigint nsubset;
-  double dvalue, xvalue, yvalue, zvalue, wvalue, fraction;
+  double dvalue, dlovalue, dhivalue, xvalue, yvalue, zvalue, wvalue, fraction;
 
   int varflag, varflag1, varflag2, varflag3, varflag4;
   int ivar1, ivar2, ivar3, ivar4;


### PR DESCRIPTION
**Summary**

In my granular material simulations, I needed polydisperse spherical grains so I added the `diameter/range` option to the `set` command, which can be used to give a __random diameter to each particle within a range__.

Example usage:
```
set type 1 diameter/range 353423 0.5 1.5
```
This assigns a random diameter to each particle of type `1` between `0.5` and `1.5` with uniform distribution. `353423` is the seed.

I also added an entry to the documentation regarding the new option.

**Related Issue(s)**

None

**Author(s)**

Ákos Seres

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No changes

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

There are other options for the `set` command for setting random properties, so implementing this feature was straightforward based on the pattern of the other options.

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

With the example command, I could create the following system:

<img width="522" alt="Screenshot 2022-07-18 at 10 56 32" src="https://user-images.githubusercontent.com/11257907/179477560-845d2785-f696-4323-b207-c0b45c2342c6.png">

This random size distribution is needed because I want to avoid the crystallization of the sheared material which occurs when the spheres are the same size or too similar in size.

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


