### PR TITLE
Add package dependency handling for pair style srp/react

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -648,7 +648,7 @@ endif()
 # packages which selectively include variants based on enabled styles
 # e.g. accelerator packages
 ######################################################################
-foreach(PKG_WITH_INCL CORESHELL DPD-SMOOTH PHONON QEQ OPENMP KOKKOS OPT INTEL GPU)
+foreach(PKG_WITH_INCL CORESHELL DPD-SMOOTH MISC PHONON QEQ OPENMP KOKKOS OPT INTEL GPU)
   if(PKG_${PKG_WITH_INCL})
     include(Packages/${PKG_WITH_INCL})
   endif()

--- a/cmake/Modules/Packages/MISC.cmake
+++ b/cmake/Modules/Packages/MISC.cmake
@@ -1,0 +1,13 @@
+# pair style and fix srp/react depend on the fixes bond/break and bond/create from the MC package
+if(NOT PKG_MC)
+  get_property(LAMMPS_FIX_HEADERS GLOBAL PROPERTY FIX)
+  list(REMOVE_ITEM LAMMPS_FIX_HEADERS ${LAMMPS_SOURCE_DIR}/MISC/fix_srp_react.h)
+  set_property(GLOBAL PROPERTY FIX "${LAMMPS_FIX_HEADERS}")
+  get_property(LAMMPS_PAIR_HEADERS GLOBAL PROPERTY PAIR)
+  list(REMOVE_ITEM LAMMPS_PAIR_HEADERS ${LAMMPS_SOURCE_DIR}/MISC/pair_srp_react.h)
+  set_property(GLOBAL PROPERTY PAIR "${LAMMPS_PAIR_HEADERS}")
+  get_target_property(LAMMPS_SOURCES lammps SOURCES)
+  list(REMOVE_ITEM LAMMPS_SOURCES ${LAMMPS_SOURCE_DIR}/MISC/fix_srp_react.cpp)
+  list(REMOVE_ITEM LAMMPS_SOURCES ${LAMMPS_SOURCE_DIR}/MISC/pair_srp_react.cpp)
+  set_property(TARGET lammps PROPERTY SOURCES "${LAMMPS_SOURCES}")
+endif()

--- a/src/Depend.sh
+++ b/src/Depend.sh
@@ -128,6 +128,10 @@ if (test $1 = "MANYBODY") then
   depend OPENMP
 fi
 
+if (test $1 = "MC") then
+  depend MISC
+fi
+
 if (test $1 = "MEAM") then
   depend KOKKOS
 fi

--- a/src/MISC/Install.sh
+++ b/src/MISC/Install.sh
@@ -1,0 +1,55 @@
+# Install/Uninstall package files in LAMMPS
+# mode = 0/1/2 for uninstall/install/update
+
+mode=$1
+
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
+# arg1 = file, arg2 = file it depends on
+
+action () {
+  if (test $mode = 0) then
+    rm -f ../$1
+  elif (! cmp -s $1 ../$1) then
+    if (test -z "$2" || test -e ../$2) then
+      cp $1 ..
+      if (test $mode = 2) then
+        echo "  updating src/$1"
+      fi
+    fi
+  elif (test -n "$2") then
+    if (test ! -e ../$2) then
+      rm -f ../$1
+    fi
+  fi
+}
+
+# package files without dependencies
+action bond_special.cpp
+action bond_special.h
+action compute_viscosity_cos.cpp
+action compute_viscosity_cos.h
+action fix_accelerate_cos.cpp
+action fix_accelerate_cos.h
+action fix_imd.cpp
+action fix_imd.h
+action fix_ipi.cpp
+action fix_ipi.h
+action fix_srp.cpp
+action fix_srp.h
+action pair_agni.cpp
+action pair_agni.h
+action pair_list.cpp
+action pair_list.h
+action pair_srp.cpp
+action pair_srp.h
+action pair_tracker.cpp
+action pair_tracker.h
+
+# package files with dependencies
+action pair_srp_react.cpp fix_bond_break.h
+action pair_srp_react.h fix_bond_break.h
+action fix_srp_react.cpp fix_bond_break.h
+action fix_srp_react.h fix_bond_break.h


### PR DESCRIPTION
**Summary**

This change adds support for installing the pair srp/react style only when also fix bond/break (and fix bond/create) are installed.

**Related Issue(s)**

Fixes #3357 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
