### PR TITLE
Add support for a dump_modify skip command

### DIFF
--- a/doc/src/dump_modify.rst
+++ b/doc/src/dump_modify.rst
@@ -40,6 +40,8 @@ Syntax
        *every/time* arg = Delta
          Delta = dump every this interval in simulation time (time units)
          Delta can be a variable (see below)
+       *skip* arg = expression
+         expression = equal-style variable expression without blanks or in quotes
        *fileper* arg = Np
          Np = write one file for every this many processors
        *first* arg = *yes* or *no*
@@ -115,6 +117,7 @@ Examples
    dump_modify xtcdump precision 10000 sfactor 0.1
    dump_modify 1 every 1000 nfile 20
    dump_modify 1 every v_myVar
+   dump_modify 1 skip "pe < -4.76"
 
 Description
 """""""""""
@@ -348,6 +351,18 @@ file tmp.times:
    run of length 100 in simulation time, the file should contain the
    values 15,100,101 and you should also use the dump_modify first
    command.  Any final value > 100 could be used in place of 101.
+
+----------
+
+The *skip* keyword can be used with any dump style except the *dcd* and
+*xtc* styles.  It takes an equal-style variable expression as argument
+and evaluates it on every step when there would be a dump frame written
+just before the output would be generated.  If the expression evaluates
+to zero, the dump frame is written as normal, otherwise the writing is
+skipped.  This allows defining a dump with a regular output frequency
+but have the dump only written when some global condition is reached
+like some critical threshold value is crossed.  An argument of "off" or
+"none" will restore the normal dump output frequency.
 
 ----------
 

--- a/src/EXTRA-DUMP/dump_dcd.cpp
+++ b/src/EXTRA-DUMP/dump_dcd.cpp
@@ -264,6 +264,8 @@ int DumpDCD::modify_param(int narg, char **arg)
     if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
     unwrap_flag = utils::logical(FLERR,arg[1],false,lmp);
     return 2;
+  } else if (strcmp(arg[0],"skip") == 0) {
+    error->all(FLERR, "Dump style dcd does not support 'dump_modify skip'");
   }
   return 0;
 }

--- a/src/EXTRA-DUMP/dump_xtc.cpp
+++ b/src/EXTRA-DUMP/dump_xtc.cpp
@@ -309,6 +309,8 @@ int DumpXTC::modify_param(int narg, char **arg)
     if (tfactor <= 0.0)
       error->all(FLERR,"Illegal dump_modify tfactor value (must be > 0.0)");
     return 2;
+  } else if (strcmp(arg[0],"skip") == 0) {
+    error->all(FLERR, "Dump style xtc does not support 'dump_modify skip'");
   }
   return 0;
 }

--- a/src/dump.h
+++ b/src/dump.h
@@ -29,8 +29,10 @@ class Dump : protected Pointers {
   char *filename;          // user-specified file
   int igroup, groupbit;    // group that Dump is performed on
 
-  int first_flag;    // 0 if no initial dump, 1 if yes initial dump
-  int clearstep;     // 1 if dump can invoke computes, 0 if not
+  int first_flag;          // 0 if no initial dump, 1 if yes initial dump
+  int clearstep;           // 1 if dump can invoke computes, 0 if not
+  bool skip_flag;          // true if dump has skip condition to skip writing frames
+  std::string skipexpr;    // text of skip expression to evaluate
 
   int comm_forward;    // size of forward communication (0 if none)
   int comm_reverse;    // size of reverse communication (0 if none)
@@ -44,10 +46,17 @@ class Dump : protected Pointers {
   ~Dump() override;
   void init();
   virtual void write();
+  bool skip_frame();            // check skip condition
 
-  virtual int pack_forward_comm(int, int *, double *, int, int *) { return 0; }
+  virtual int pack_forward_comm(int, int *, double *, int, int *)
+  {
+    return 0;
+  }
   virtual void unpack_forward_comm(int, int, double *) {}
-  virtual int pack_reverse_comm(int, int, double *) { return 0; }
+  virtual int pack_reverse_comm(int, int, double *)
+  {
+    return 0;
+  }
   virtual void unpack_reverse_comm(int, int *, double *) {}
 
   void modify_params(int, char **);
@@ -147,11 +156,17 @@ class Dump : protected Pointers {
 
   virtual void init_style() = 0;
   virtual void openfile();
-  virtual int modify_param(int, char **) { return 0; }
+  virtual int modify_param(int, char **)
+  {
+    return 0;
+  }
   virtual void write_header(bigint) = 0;
   virtual int count();
   virtual void pack(tagint *) = 0;
-  virtual int convert_string(int, double *) { return 0; }
+  virtual int convert_string(int, double *)
+  {
+    return 0;
+  }
   virtual void write_data(int, double *) = 0;
   virtual void write_footer() {}
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -233,7 +233,7 @@ void Output::setup(int memflag)
       // perform dump
 
       if (writeflag) {
-        dump[idump]->write();
+        if (!dump[idump]->skip_frame()) dump[idump]->write();
         last_dump[idump] = ntimestep;
       }
 
@@ -367,7 +367,7 @@ void Output::setup(int memflag)
          // perform dump
          // reset next_dump and next_time_dump, 1 arg for write()
 
-         dump[idump]->write();
+         if (!dump[idump]->skip_frame()) dump[idump]->write();
          last_dump[idump] = ntimestep;
          calculate_next_dump(WRITE,idump,ntimestep);
 
@@ -464,7 +464,7 @@ void Output::setup(int memflag)
  void Output::write_dump(bigint ntimestep)
  {
    for (int idump = 0; idump < ndump; idump++) {
-     dump[idump]->write();
+     if (!dump[idump]->skip_frame()) dump[idump]->write();
      last_dump[idump] = ntimestep;
    }
  }


### PR DESCRIPTION
**Summary**

This adds a 'dump_modify skip' feature to the dump subsystem so that dump frames may be skipped (for most dump styles).
This can be useful for debugging so that the dump output frequency can be set to a high, but output will only be produced if some (evaluated) condition is passed. Unlike with 'dump_modify every' the evaluation happens on the scheduled time step and the dump class will proceed as if the dump happens, but the frame only written if the skip condition evaluates to zero (i.e. false).

This is also in preparation for adding a feature where pair styles can report some quality measure of a calculation and then this can be used to trigger writing dumps or not or even stopping a run.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

This is implemented as part of the Output class and global to all dump styles.  The alternative would be to add the check to the `Dump::write()` function of the individual dump styles, but that applies to many dump styles and thus there is a risk of inconsistent behavior if not all related changes are always propagated. This way all of the relevant behavior is implemented in just one class.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
