### PR TITLE
Small cleanup and performance tweak for spline evaluation in AIREBO pair style

### DIFF
--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -66,7 +66,6 @@ PairAIREBO::PairAIREBO(LAMMPS *lmp)
   pgsize = oneatom = 0;
 
   nC = nH = nullptr;
-  map = nullptr;
   manybody_flag = 1;
   centroidstressflag = CENTROID_NOTAVAIL;
 
@@ -98,7 +97,6 @@ PairAIREBO::~PairAIREBO()
     memory->destroy(lj2);
     memory->destroy(lj3);
     memory->destroy(lj4);
-    delete[] map;
   }
 }
 
@@ -3628,16 +3626,12 @@ void PairAIREBO::read_file(char *filename)
         }
       }
     } catch (TokenizerException &e) {
-      std::string msg = fmt::format("ERROR reading {} section in {} file\n"
-                                    "REASON: {}\n",
-                                    current_section, potential_name, e.what());
-      error->one(FLERR, msg);
+      error->one(FLERR, "reading {} section in {} file\nREASON: {}\n",
+                 current_section, potential_name, e.what());
+
     } catch (FileReaderException &fre) {
-      error->one(FLERR, fre.what());
-      std::string msg = fmt::format("ERROR reading {} section in {} file\n"
-                                    "REASON: {}\n",
+      error->one(FLERR, "reading {} section in {} file\nREASON: {}\n",
                                     current_section, potential_name, fre.what());
-      error->one(FLERR, msg);
     }
 
     // store read-in values in arrays
@@ -3847,32 +3841,6 @@ void PairAIREBO::read_file(char *filename)
 // ----------------------------------------------------------------------
 // generic Spline functions
 // ----------------------------------------------------------------------
-
-/* ----------------------------------------------------------------------
-   fifth order spline evaluation
-------------------------------------------------------------------------- */
-
-double PairAIREBO::Sp5th(double x, double coeffs[6], double *df)
-{
-  double f, d;
-  const double x2 = x*x;
-  const double x3 = x2*x;
-
-  f  = coeffs[0];
-  f += coeffs[1]*x;
-  d  = coeffs[1];
-  f += coeffs[2]*x2;
-  d += 2.0*coeffs[2]*x;
-  f += coeffs[3]*x3;
-  d += 3.0*coeffs[3]*x2;
-  f += coeffs[4]*x2*x2;
-  d += 4.0*coeffs[4]*x3;
-  f += coeffs[5]*x2*x3;
-  d += 5.0*coeffs[5]*x2*x2;
-
-  *df = d;
-  return f;
-}
 
 /* ----------------------------------------------------------------------
    bicubic spline evaluation
@@ -4493,6 +4461,6 @@ double PairAIREBO::memory_usage()
   for (int i = 0; i < comm->nthreads; i++)
     bytes += ipage[i].size();
 
-  bytes += (double)2*maxlocal * sizeof(double);
+  bytes += 2.0 * maxlocal * sizeof(double);
   return bytes;
 }

--- a/src/MANYBODY/pair_airebo.h
+++ b/src/MANYBODY/pair_airebo.h
@@ -40,8 +40,6 @@ class PairAIREBO : public Pair {
   enum { AIREBO, REBO_2, AIREBO_M };    // for telling class variants apart in shared code
 
  protected:
-  int *map;    // 0 (C), 1 (H), or -1 ("NULL") for each type
-
   int variant;
   int ljflag, torflag;    // 0/1 if LJ/Morse,torsion terms included
   int morseflag;          // 1 if Morse instead of LJ for non-bonded
@@ -110,7 +108,6 @@ class PairAIREBO : public Pair {
 
   void read_file(char *);
 
-  double Sp5th(double, double *, double *);
   double Spbicubic(double, double, double *, double *);
   double Sptricubic(double, double, double, double *, double *);
   void Sptricubic_patch_adjust(double *, double, double, char);
@@ -129,6 +126,33 @@ class PairAIREBO : public Pair {
   // ----------------------------------------------------------------------
 
   /* ----------------------------------------------------------------------
+   fifth order spline evaluation using Horner's rule
+   ------------------------------------------------------------------------- */
+  double Sp5th(const double &x, const double coeffs[6], double *df) const
+  {
+    double f = coeffs[5] * x;
+    double d = 5.0 * coeffs[5] * x;
+    f += coeffs[4];
+    d += 4.0 * coeffs[4];
+    f *= x;
+    d *= x;
+    f += coeffs[3];
+    d += 3.0 * coeffs[3];
+    f *= x;
+    d *= x;
+    f += coeffs[2];
+    d += 2.0 * coeffs[2];
+    f *= x;
+    d *= x;
+    f += coeffs[1];
+    d += coeffs[1];
+    f *= x;
+    f += coeffs[0];
+    *df = d;
+    return f;
+  }
+
+  /* ----------------------------------------------------------------------
      cutoff function Sprime
      return cutoff and dX = derivative
      no side effects
@@ -138,7 +162,7 @@ class PairAIREBO : public Pair {
   {
     double cutoff;
 
-    double t = (Xij - Xmin) / (Xmax - Xmin);
+    const double t = (Xij - Xmin) / (Xmax - Xmin);
     if (t <= 0.0) {
       cutoff = 1.0;
       dX = 0.0;
@@ -162,7 +186,7 @@ class PairAIREBO : public Pair {
   {
     double cutoff;
 
-    double t = (Xij - Xmin) / (Xmax - Xmin);
+    const double t = (Xij - Xmin) / (Xmax - Xmin);
     if (t <= 0.0) {
       cutoff = 1.0;
       dX = 0.0;
@@ -180,7 +204,6 @@ class PairAIREBO : public Pair {
 
   inline double kronecker(const int a, const int b) const { return (a == b) ? 1.0 : 0.0; };
 };
-
 }    // namespace LAMMPS_NS
 
 #endif


### PR DESCRIPTION
**Summary**

This removes some redundant code and optimizes the 5th order spline evaluation by using Horner's rule (which should also improve precision a little bit) and moving it to the class header to have it inlined.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
