### PR TITLE
Add missing portions of a couple doc pages

### DIFF
--- a/doc/src/Howto_amoeba.rst
+++ b/doc/src/Howto_amoeba.rst
@@ -3,8 +3,8 @@ AMOEBA and HIPPO force fields
 
 The AMOEBA and HIPPO polarizable force fields were developed by Jay
 Ponder's group at the U Washington at St Louis.  The LAMMPS
-implementation was done using F90 code provided by the Ponder group
-from their `Tinker MD code <https://dasher.wustl.edu/tinker/>`_.
+implementation is based on Fortran 90 code provided by the Ponder
+group in their `Tinker MD software <https://dasher.wustl.edu/tinker/>`_.
 
 The current implementation (July 2022) of AMOEBA in LAMMPS matches the
 version discussed in :ref:`(Ponder) <amoeba-Ponder>`, :ref:`(Ren)

--- a/doc/src/Howto_amoeba.rst
+++ b/doc/src/Howto_amoeba.rst
@@ -2,9 +2,9 @@ AMOEBA and HIPPO force fields
 =============================
 
 The AMOEBA and HIPPO polarizable force fields were developed by Jay
-Ponder's group at the U Washington at St Louis.  Their implementation
-in LAMMPS was done using F90 code provided by the Ponder group from
-their `Tinker MD code <https://dasher.wustl.edu/tinker/>`_.
+Ponder's group at the U Washington at St Louis.  The LAMMPS
+implementation was done using F90 code provided by the Ponder group
+from their `Tinker MD code <https://dasher.wustl.edu/tinker/>`_.
 
 The current implementation (July 2022) of AMOEBA in LAMMPS matches the
 version discussed in :ref:`(Ponder) <amoeba-Ponder>`, :ref:`(Ren)

--- a/doc/src/Packages_details.rst
+++ b/doc/src/Packages_details.rst
@@ -157,14 +157,28 @@ AMOEBA package
 
 **Contents:**
 
-TODO
+Implementation of the AMOEBA and HIPPO polarized force fields
+orginally developed by Jay Ponder's group at the U Washington at St
+Louis.  The LAMMPS implementation was done using F90 code provided by
+the Ponder group from their `Tinker MD code
+<https://dasher.wustl.edu/tinker/>`_.
+
+**Authors:** Josh Rackers and Steve Plimpton (Sandia), Trung Nguyen (U
+ Chicago)
 
 **Supporting info:**
 
 * src/AMOEBA: filenames -> commands
 * :doc:`AMOEBA and HIPPO howto <Howto_amoeba>`
+* :doc:`pair_style amoeba <pair_amoeba>`
+* :doc:`pair_style hippo <pair_amoeba>`
+* :doc:`atom_style amoeba <atom_style>`
+* :doc:`angle_style amoeba <angle_amoeba>`
+* :doc:`improper_style amoeba <improper_amoeba>`
+* :doc:`fix amoeba/bitorsion <fix_amoeba_bitorsion>`
+* :doc:`fix amoeba/pitorsion <fix_amoeba_pitorsion>`
+* tools/tinker/tinker2lmp.py
 * examples/amoeba
-* TODO
 
 ----------
 
@@ -200,9 +214,10 @@ ATC package
 
 **Contents:**
 
-ATC stands for atoms-to-continuum.  This package implements a :doc:`fix atc <fix_atc>` command to either couple molecular dynamics with
-continuum finite element equations or perform on-the-fly conversion of
-atomic information to continuum fields.
+ATC stands for atoms-to-continuum.  This package implements a
+:doc:`fix atc <fix_atc>` command to either couple molecular dynamics
+with continuum finite element equations or perform on-the-fly
+conversion of atomic information to continuum fields.
 
 **Authors:** Reese Jones, Jeremy Templeton, Jon Zimmerman (Sandia).
 

--- a/doc/src/Packages_details.rst
+++ b/doc/src/Packages_details.rst
@@ -159,9 +159,9 @@ AMOEBA package
 
 Implementation of the AMOEBA and HIPPO polarized force fields
 orginally developed by Jay Ponder's group at the U Washington at St
-Louis.  The LAMMPS implementation was done using F90 code provided by
-the Ponder group from their `Tinker MD code
-<https://dasher.wustl.edu/tinker/>`_.
+Louis.  The LAMMPS implementation is based on Fortran 90 code
+provided by the Ponder group in their
+`Tinker MD software <https://dasher.wustl.edu/tinker/>`_.
 
 **Authors:** Josh Rackers and Steve Plimpton (Sandia), Trung Nguyen (U
  Chicago)

--- a/doc/src/fix_ave_chunk.rst
+++ b/doc/src/fix_ave_chunk.rst
@@ -17,12 +17,12 @@ Syntax
 * Nfreq = calculate averages every this many timesteps
 * chunkID = ID of :doc:`compute chunk/atom <compute_chunk_atom>` command
 * one or more input values can be listed
-* value = vx, vy, vz, fx, fy, fz, density/mass, density/number, temp, c_ID, c_ID[I], f_ID, f_ID[I], v_name
+* value = vx, vy, vz, fx, fy, fz, density/mass, density/number, mass, temp, c_ID, c_ID[I], f_ID, f_ID[I], v_name
 
   .. parsed-literal::
 
-       vx,vy,vz,fx,fy,fz = atom attribute (velocity, force component)
-       density/number, density/mass = number or mass density
+       vx,vy,vz,fx,fy,fz,mass = atom attribute (velocity, force component, mass)
+       density/number, density/mass = number or mass density (per volume)
        temp = temperature
        c_ID = per-atom vector calculated by a compute with ID
        c_ID[I] = Ith column of per-atom array calculated by a compute with ID, I can include wildcard (see below)
@@ -99,29 +99,33 @@ averages can be used by other :doc:`output commands <Howto_output>` such
 as :doc:`thermo_style custom <thermo_style>`, and can also be written to
 a file.
 
-In LAMMPS, chunks are collections of atoms defined by a :doc:`compute chunk/atom <compute_chunk_atom>` command, which assigns each atom
-to a single chunk (or no chunk).  The ID for this command is specified
-as chunkID.  For example, a single chunk could be the atoms in a
-molecule or atoms in a spatial bin.  See the :doc:`compute chunk/atom <compute_chunk_atom>` page and the :doc:`Howto chunk <Howto_chunk>` page for details of how chunks can be
-defined and examples of how they can be used to measure properties of
-a system.
+In LAMMPS, chunks are collections of atoms defined by a :doc:`compute
+chunk/atom <compute_chunk_atom>` command, which assigns each atom to a
+single chunk (or no chunk).  The ID for this command is specified as
+chunkID.  For example, a single chunk could be the atoms in a molecule
+or atoms in a spatial bin.  See the :doc:`compute chunk/atom
+<compute_chunk_atom>` page and the :doc:`Howto chunk <Howto_chunk>`
+page for details of how chunks can be defined and examples of how they
+can be used to measure properties of a system.
 
 Note that only atoms in the specified group contribute to the summing
-and averaging calculations.  The :doc:`compute chunk/atom <compute_chunk_atom>` command defines its own group as
-well as an optional region.  Atoms will have a chunk ID = 0, meaning
-they belong to no chunk, if they are not in that group or region.
-Thus you can specify the "all" group for this command if you simply
-want to use the chunk definitions provided by chunkID.
+and averaging calculations.  The :doc:`compute chunk/atom
+<compute_chunk_atom>` command defines its own group as well as an
+optional region.  Atoms will have a chunk ID = 0, meaning they belong
+to no chunk, if they are not in that group or region.  Thus you can
+specify the "all" group for this command if you simply want to use the
+chunk definitions provided by chunkID.
 
 Each specified per-atom value can be an atom attribute (position,
-velocity, force component), a mass or number density, or the result of
-a :doc:`compute <compute>` or :doc:`fix <fix>` or the evaluation of an
-atom-style :doc:`variable <variable>`.  In the latter cases, the
-compute, fix, or variable must produce a per-atom quantity, not a
-global quantity.  Note that the :doc:`compute property/atom <compute_property_atom>` command provides access to
-any attribute defined and stored by atoms.  If you wish to
-time-average global quantities from a compute, fix, or variable, then
-see the :doc:`fix ave/time <fix_ave_time>` command.
+velocity, force component), a number or mass density, a mass or
+temperature, or the result of a :doc:`compute <compute>` or :doc:`fix
+<fix>` or the evaluation of an atom-style :doc:`variable <variable>`.
+In the latter cases, the compute, fix, or variable must produce a
+per-atom quantity, not a global quantity.  Note that the :doc:`compute
+property/atom <compute_property_atom>` command provides access to any
+attribute defined and stored by atoms.  If you wish to time-average
+global quantities from a compute, fix, or variable, then see the
+:doc:`fix ave/time <fix_ave_time>` command.
 
 The per-atom values of each input vector are summed and averaged
 independently of the per-atom values in other input vectors.
@@ -145,8 +149,9 @@ means all indices from m to n (inclusive).
 
 Using a wildcard is the same as if the individual columns of the array
 had been listed one by one.  E.g. these 2 fix ave/chunk commands are
-equivalent, since the :doc:`compute property/atom <compute_property_atom>` command creates, in this
-case, a per-atom array with 3 columns:
+equivalent, since the :doc:`compute property/atom
+<compute_property_atom>` command creates, in this case, a per-atom
+array with 3 columns:
 
 .. code-block:: LAMMPS
 
@@ -194,28 +199,31 @@ discussed below.
 .. note::
 
    To perform per-chunk averaging within a *Nfreq* time window, the
-   number of chunks *Nchunk* defined by the :doc:`compute chunk/atom <compute_chunk_atom>` command must remain constant.  If
-   the *ave* keyword is set to *running* or *window* then *Nchunk* must
-   remain constant for the duration of the simulation.  This fix forces
-   the chunk/atom compute specified by chunkID to hold *Nchunk* constant
-   for the appropriate time windows, by not allowing it to re-calculate
-   *Nchunk*, which can also affect how it assigns chunk IDs to atoms.
-   This is particularly important to understand if the chunks defined by
-   the :doc:`compute chunk/atom <compute_chunk_atom>` command are spatial
-   bins.  If its *units* keyword is set to *box* or *lattice*, then the
-   number of bins *Nchunk* and size of each bin will be fixed over the
-   *Nfreq* time window, which can affect which atoms are discarded if the
+   number of chunks *Nchunk* defined by the :doc:`compute chunk/atom
+   <compute_chunk_atom>` command must remain constant.  If the *ave*
+   keyword is set to *running* or *window* then *Nchunk* must remain
+   constant for the duration of the simulation.  This fix forces the
+   chunk/atom compute specified by chunkID to hold *Nchunk* constant
+   for the appropriate time windows, by not allowing it to
+   re-calculate *Nchunk*, which can also affect how it assigns chunk
+   IDs to atoms.  This is particularly important to understand if the
+   chunks defined by the :doc:`compute chunk/atom
+   <compute_chunk_atom>` command are spatial bins.  If its *units*
+   keyword is set to *box* or *lattice*, then the number of bins
+   *Nchunk* and size of each bin will be fixed over the *Nfreq* time
+   window, which can affect which atoms are discarded if the
    simulation box size changes.  If its *units* keyword is set to
-   *reduced*, then the number of bins *Nchunk* will still be fixed, but
-   the size of each bin can vary at each timestep if the simulation box
-   size changes, e.g. for an NPT simulation.
+   *reduced*, then the number of bins *Nchunk* will still be fixed,
+   but the size of each bin can vary at each timestep if the
+   simulation box size changes, e.g. for an NPT simulation.
 
 ----------
 
-The atom attribute values (vx,vy,vz,fx,fy,fz) are self-explanatory.
-As noted above, any other atom attributes can be used as input values
-to this fix by using the :doc:`compute property/atom <compute_property_atom>` command and then specifying
-an input value from that compute.
+The atom attribute values (vx,vy,vz,fx,fy,fz,mass) are
+self-explanatory.  As noted above, any other atom attributes can be
+used as input values to this fix by using the :doc:`compute
+property/atom <compute_property_atom>` command and then specifying an
+input value from that compute.
 
 The *density/number* value means the number density is computed for
 each chunk, i.e. number/volume.  The *density/mass* value means the
@@ -243,12 +251,13 @@ Note that currently this temperature only includes translational
 degrees of freedom for each atom.  No rotational degrees of freedom
 are included for finite-size particles.  Also no degrees of freedom
 are subtracted for any velocity bias or constraints that are applied,
-such as :doc:`compute temp/partial <compute_temp_partial>`, or :doc:`fix shake <fix_shake>` or :doc:`fix rigid <fix_rigid>`.  This is because
-those degrees of freedom (e.g. a constrained bond) could apply to sets
-of atoms that are both included and excluded from a specific chunk,
-and hence the concept is somewhat ill-defined.  In some cases, you can
-use the *adof* and *cdof* keywords to adjust the calculated degrees of
-freedom appropriately, as explained below.
+such as :doc:`compute temp/partial <compute_temp_partial>`, or
+:doc:`fix shake <fix_shake>` or :doc:`fix rigid <fix_rigid>`.  This is
+because those degrees of freedom (e.g. a constrained bond) could apply
+to sets of atoms that are both included and excluded from a specific
+chunk, and hence the concept is somewhat ill-defined.  In some cases,
+you can use the *adof* and *cdof* keywords to adjust the calculated
+degrees of freedom appropriately, as explained below.
 
 Also note that a bias can be subtracted from atom velocities before
 they are used in the above formula for KE, by using the *bias*
@@ -256,22 +265,22 @@ keyword.  This allows, for example, a thermal temperature to be
 computed after removal of a flow velocity profile.
 
 Note that the per-chunk temperature calculated by this fix and the
-:doc:`compute temp/chunk <compute_temp_chunk>` command can be different.
-The compute calculates the temperature for each chunk for a single
-snapshot.  This fix can do that but can also time average those values
-over many snapshots, or it can compute a temperature as if the atoms
-in the chunk on different timesteps were collected together as one set
-of atoms to calculate their temperature.  The compute allows the
-center-of-mass velocity of each chunk to be subtracted before
-calculating the temperature; this fix does not.
+:doc:`compute temp/chunk <compute_temp_chunk>` command can be
+different.  The compute calculates the temperature for each chunk for
+a single snapshot.  This fix can do that but can also time average
+those values over many snapshots, or it can compute a temperature as
+if the atoms in the chunk on different timesteps were collected
+together as one set of atoms to calculate their temperature.  The
+compute allows the center-of-mass velocity of each chunk to be
+subtracted before calculating the temperature; this fix does not.
 
 If a value begins with "c\_", a compute ID must follow which has been
 previously defined in the input script.  If no bracketed integer is
 appended, the per-atom vector calculated by the compute is used.  If a
 bracketed integer is appended, the Ith column of the per-atom array
 calculated by the compute is used.  Users can also write code for
-their own compute styles and :doc:`add them to LAMMPS <Modify>`.
-See the discussion above for how I can be specified with a wildcard
+their own compute styles and :doc:`add them to LAMMPS <Modify>`.  See
+the discussion above for how I can be specified with a wildcard
 asterisk to effectively specify multiple values.
 
 If a value begins with "f\_", a fix ID must follow which has been
@@ -307,9 +316,10 @@ atoms in the chunk.  The averaged output value for the chunk on the
 average over atoms across the entire *Nfreq* timescale.  For the
 *density/number* and *density/mass* values, the volume (bin volume or
 system volume) used in the final normalization will be the volume at
-the final *Nfreq* timestep. For the *temp* values, degrees of freedom and
-kinetic energy are summed separately across the entire *Nfreq* timescale, and
-the output value is calculated by dividing those two sums.
+the final *Nfreq* timestep. For the *temp* values, degrees of freedom
+and kinetic energy are summed separately across the entire *Nfreq*
+timescale, and the output value is calculated by dividing those two
+sums.
 
 If the *norm* setting is *sample*, the chunk value is summed over
 atoms for each sample, as is the count, and an "average sample value"
@@ -431,44 +441,50 @@ the first of each section of output.  In the third line the values are
 replaced with the appropriate value names, e.g. fx or c_myCompute[2].
 
 The words in parenthesis only appear with corresponding columns if the
-chunk style specified for the :doc:`compute chunk/atom <compute_chunk_atom>` command supports them.  The OrigID
-column is only used if the *compress* keyword was set to *yes* for the
-:doc:`compute chunk/atom <compute_chunk_atom>` command.  This means that
-the original chunk IDs (e.g. molecule IDs) will have been compressed
-to remove chunk IDs with no atoms assigned to them.  Thus a compressed
-chunk ID of 3 may correspond to an original chunk ID or molecule ID of
+chunk style specified for the :doc:`compute chunk/atom
+<compute_chunk_atom>` command supports them.  The OrigID column is
+only used if the *compress* keyword was set to *yes* for the
+:doc:`compute chunk/atom <compute_chunk_atom>` command.  This means
+that the original chunk IDs (e.g. molecule IDs) will have been
+compressed to remove chunk IDs with no atoms assigned to them.  Thus a
+compressed chunk ID of 3 may correspond to an original chunk ID or
+molecule ID of
 415.  The OrigID column will list 415 for the third chunk.
 
 The CoordN columns only appear if a *binning* style was used in the
 :doc:`compute chunk/atom <compute_chunk_atom>` command.  For *bin/1d*,
 *bin/2d*, and *bin/3d* styles the column values are the center point
 of the bin in the corresponding dimension.  Just Coord1 is used for
-*bin/1d*, Coord2 is added for *bin/2d*, Coord3 is added for *bin/3d*\ .
-For *bin/sphere*, just Coord1 is used, and it is the radial
+*bin/1d*, Coord2 is added for *bin/2d*, Coord3 is added for *bin/3d*\
+.  For *bin/sphere*, just Coord1 is used, and it is the radial
 coordinate.  For *bin/cylinder*, Coord1 and Coord2 are used.  Coord1
 is the radial coordinate (away from the cylinder axis), and coord2 is
 the coordinate along the cylinder axis.
 
-Note that if the value of the *units* keyword used in the :doc:`compute chunk/atom command <compute_chunk_atom>` is *box* or *lattice*, the
-coordinate values will be in distance :doc:`units <units>`.  If the
-value of the *units* keyword is *reduced*, the coordinate values will
-be in unitless reduced units (0-1).  This is not true for the Coord1 value
-of style *bin/sphere* or *bin/cylinder* which both represent radial
-dimensions.  Those values are always in distance :doc:`units <units>`.
+Note that if the value of the *units* keyword used in the
+:doc:`compute chunk/atom command <compute_chunk_atom>` is *box* or
+*lattice*, the coordinate values will be in distance :doc:`units
+<units>`.  If the value of the *units* keyword is *reduced*, the
+coordinate values will be in unitless reduced units (0-1).  This is
+not true for the Coord1 value of style *bin/sphere* or *bin/cylinder*
+which both represent radial dimensions.  Those values are always in
+distance :doc:`units <units>`.
 
 ----------
 
 Restart, fix_modify, output, run start/stop, minimize info
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-No information about this fix is written to :doc:`binary restart files <restart>`.  None of the :doc:`fix_modify <fix_modify>` options
-are relevant to this fix.
+No information about this fix is written to :doc:`binary restart files
+<restart>`.  None of the :doc:`fix_modify <fix_modify>` options are
+relevant to this fix.
 
 This fix computes a global array of values which can be accessed by
 various :doc:`output commands <Howto_output>`.  The values can only be
 accessed on timesteps that are multiples of *Nfreq* since that is when
 averaging is performed.  The global array has # of rows = the number
-of chunks *Nchunk* as calculated by the specified :doc:`compute chunk/atom <compute_chunk_atom>` command.  The # of columns =
+of chunks *Nchunk* as calculated by the specified :doc:`compute
+chunk/atom <compute_chunk_atom>` command.  The # of columns =
 M+1+Nvalues, where M = 1 to 4, depending on whether the optional
 columns for OrigID and CoordN are used, as explained above.  Following
 the optional columns, the next column contains the count of atoms in
@@ -483,7 +499,8 @@ since they are typically already normalized by the count of atoms in
 each chunk.
 
 No parameter of this fix can be used with the *start/stop* keywords of
-the :doc:`run <run>` command.  This fix is not invoked during :doc:`energy minimization <minimize>`.
+the :doc:`run <run>` command.  This fix is not invoked during
+:doc:`energy minimization <minimize>`.
 
 Restrictions
 """"""""""""

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -632,12 +632,7 @@ void FixAveChunk::end_of_step()
       if (which[m] == ArgInfo::V) attribute = atom->v;
       else attribute = atom->f;
 
-      for (i = 0; i < nlocalThe *temp* value means the temperature is computed for each chunk, by
-the formula KE = DOF/2 k T, where KE = total kinetic energy of the
-chunk of atoms (sum of 1/2 m v\^2), DOF = the total number of degrees
-of freedom for all atoms in the chunk, k = Boltzmann constant, and T =
-temperature.
-; i++)
+      for (i = 0; i < nlocal; i++)
         if (mask[i] & groupbit && ichunk[i] > 0) {
           index = ichunk[i]-1;
           values_one[index][m] += attribute[i][j];

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -107,6 +107,9 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
       which[nvalues] = ArgInfo::F;
       argindex[nvalues++] = 2;
 
+    } else if (strcmp(arg[iarg],"mass") == 0) {
+      which[nvalues] = ArgInfo::MASS;
+      argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"density/number") == 0) {
       densityflag = 1;
       which[nvalues] = ArgInfo::DENSITY_NUMBER;
@@ -114,9 +117,6 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"density/mass") == 0) {
       densityflag = 1;
       which[nvalues] = ArgInfo::DENSITY_MASS;
-      argindex[nvalues++] = 0;
-    } else if (strcmp(arg[iarg],"mass") == 0) {
-      which[nvalues] = ArgInfo::MASS;
       argindex[nvalues++] = 0;
     } else if (strcmp(arg[iarg],"temp") == 0) {
       which[nvalues] = ArgInfo::TEMPERATURE;
@@ -632,7 +632,12 @@ void FixAveChunk::end_of_step()
       if (which[m] == ArgInfo::V) attribute = atom->v;
       else attribute = atom->f;
 
-      for (i = 0; i < nlocal; i++)
+      for (i = 0; i < nlocalThe *temp* value means the temperature is computed for each chunk, by
+the formula KE = DOF/2 k T, where KE = total kinetic energy of the
+chunk of atoms (sum of 1/2 m v\^2), DOF = the total number of degrees
+of freedom for all atoms in the chunk, k = Boltzmann constant, and T =
+temperature.
+; i++)
         if (mask[i] & groupbit && ichunk[i] > 0) {
           index = ichunk[i]-1;
           values_one[index][m] += attribute[i][j];


### PR DESCRIPTION
**Summary**

Add two doc page updates.  A package description of the new AMOEBA package was missing.  Also the "mass" keyword for fix ave/chunk.

**Related Issue(s)**

N?Q

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


