### PR TITLE
Collected small changes and bug fixes

### DIFF
--- a/doc/src/Run_options.rst
+++ b/doc/src/Run_options.rst
@@ -14,6 +14,7 @@ letter abbreviation can be used:
 * :ref:`-m or -mpicolor <mpicolor>`
 * :ref:`-c or -cite <cite>`
 * :ref:`-nc or -nocite <nocite>`
+* :ref:`-nb or -nonbuf <nonbuf>`
 * :ref:`-pk or -package <package>`
 * :ref:`-p or -partition <partition>`
 * :ref:`-pl or -plog <plog>`
@@ -254,6 +255,23 @@ how to correctly reference and cite LAMMPS.
 **-nocite**
 
 Disable generating a citation reminder (see above) at all.
+
+----------
+
+.. _nonbuf:
+
+**-nonbuf**
+
+Turn off buffering for screen and logfile output.  For performance
+reasons, output to the screen and logfile is usually buffered, i.e.
+output is only generated if a buffer - typically 4096 bytes - has been
+filled.  However, when LAMMPS crashes, that can mean that there is
+important output missing.  When using this flag, this buffering is
+turned off (only for screen and logfile output).  Note that when running
+in parallel with MPI, the screen output may still be buffered by the MPI
+library which cannot be changed by LAMMPS.  This flag should only be
+used for debugging and not for production simulations as the performance
+impact can be significant, especially for large parallel runs.
 
 ----------
 

--- a/doc/src/Run_options.rst
+++ b/doc/src/Run_options.rst
@@ -264,12 +264,13 @@ Disable generating a citation reminder (see above) at all.
 
 Turn off buffering for screen and logfile output.  For performance
 reasons, output to the screen and logfile is usually buffered, i.e.
-output is only generated if a buffer - typically 4096 bytes - has been
-filled.  However, when LAMMPS crashes, that can mean that there is
-important output missing.  When using this flag, this buffering is
-turned off (only for screen and logfile output).  Note that when running
-in parallel with MPI, the screen output may still be buffered by the MPI
-library which cannot be changed by LAMMPS.  This flag should only be
+output is only written to a file if its buffer - typically 4096 bytes -
+has been filled.  When LAMMPS crashes for some reason, however, that can
+mean that there is important output missing.  With this flag the
+buffering can be turned off (only for screen and logfile output) and any
+output will be committed immediately.  Note that when running in
+parallel with MPI, the screen output may still be buffered by the MPI
+library and this cannot be changed by LAMMPS.  This flag should only be
 used for debugging and not for production simulations as the performance
 impact can be significant, especially for large parallel runs.
 

--- a/examples/neb/in.neb.hop1
+++ b/examples/neb/in.neb.hop1
@@ -1,66 +1,66 @@
 # 2d NEB surface simulation, hop from surface to become adatom
 
-dimension	2
-boundary	p s p
+dimension       2
+boundary        p s p
 
-atom_style	atomic
-neighbor	0.3 bin
-neigh_modify	delay 5
-atom_modify	map array sort 0 0.0
+atom_style      atomic
+neighbor        0.3 bin
+neigh_modify    delay 5
+atom_modify     map array sort 0 0.0
 
-variable	u uloop 20
+variable        u uloop 20
 
 # create geometry with flat surface
 
-lattice		hex 0.9
-region		box block 0 20 0 10 -0.25 0.25
+lattice         hex 0.9
+region          box block 0 20 0 10 -0.25 0.25
 
-#create_box	3 box
-#create_atoms	1 box
-#mass		* 1.0
+#create_box     3 box
+#create_atoms   1 box
+#mass           * 1.0
 #write_data      initial.hop1
 
 read_data        initial.hop1
 
 # LJ potentials
 
-pair_style	lj/cut 2.5
-pair_coeff	* * 1.0 1.0 2.5
-pair_modify	shift yes
+pair_style      lj/cut 2.5
+pair_coeff      * * 1.0 1.0 2.5
+pair_modify     shift yes
 
 # initial minimization to relax surface
 
-minimize	1.0e-6 1.0e-4 1000 10000
-reset_timestep	0
+minimize        1.0e-6 1.0e-4 1000 10000
+reset_timestep  0
 
 # define groups
 
-region	        1 block INF INF INF 1.25 INF INF
-group		lower region 1
-group		mobile subtract all lower
-set		group lower type 2
+region          1 block INF INF INF 1.25 INF INF
+group           lower region 1
+group           mobile subtract all lower
+set             group lower type 2
 
-timestep	0.05
+timestep        0.05
 
 # group of NEB atoms - either block or single atom ID 412
 
-region		surround block 10 18 17 20 0 0 units box
-group		nebatoms region surround
-#group		nebatoms id 412
-set		group nebatoms type 3
-group		nonneb subtract all nebatoms
+region          surround block 10 18 17 20 0 0 units box
+group           nebatoms region surround
+#group          nebatoms id 412
+set             group nebatoms type 3
+group           nonneb subtract all nebatoms
 
-fix		1 lower setforce 0.0 0.0 0.0
-fix		2 nebatoms neb 1.0 parallel ideal
-fix		3 all enforce2d
+fix             1 lower setforce 0.0 0.0 0.0
+fix             2 nebatoms neb 1.0 parallel ideal
+fix             3 all enforce2d
 
-thermo		100
+thermo          100
 
-#dump		1 nebatoms atom 10 dump.neb.$u
-#dump		2 nonneb atom 10 dump.nonneb.$u
+#dump            1 nebatoms atom 10 dump.neb.$u
+#dump            2 nonneb atom 10 dump.nonneb.$u
 
 # run NEB for 2000 steps or to force tolerance
 
-min_style	quickmin
+min_style       quickmin
 
-neb		0.0 0.1 1000 1000 100 final final.hop1
+neb             0.0 0.1 1000 1000 100 final final.hop1

--- a/examples/neb/in.neb.hop1.end
+++ b/examples/neb/in.neb.hop1.end
@@ -1,56 +1,56 @@
 # 2d NEB surface simulation, hop from surface to become adatom
 
-dimension	2
-boundary	p s p
+dimension       2
+boundary        p s p
 
-atom_style	atomic
-neighbor	0.3 bin
-neigh_modify	delay 5
-atom_modify	map array sort 0 0.0
+atom_style      atomic
+neighbor        0.3 bin
+neigh_modify    delay 5
+atom_modify     map array sort 0 0.0
 
-variable	u uloop 20
+variable        u uloop 20
 
 # create geometry with flat surface
 
-lattice		hex 0.9
-region		box block 0 20 0 10 -0.25 0.25
+lattice         hex 0.9
+region          box block 0 20 0 10 -0.25 0.25
 
 read_data        initial.hop1.end
 
 # LJ potentials
 
-pair_style	lj/cut 2.5
-pair_coeff	* * 1.0 1.0 2.5
-pair_modify	shift yes
+pair_style      lj/cut 2.5
+pair_coeff      * * 1.0 1.0 2.5
+pair_modify     shift yes
 
 # define groups
 
-region	        1 block INF INF INF 1.25 INF INF
-group		lower region 1
-group		mobile subtract all lower
-set		group lower type 2
+region          1 block INF INF INF 1.25 INF INF
+group           lower region 1
+group           mobile subtract all lower
+set             group lower type 2
 
-timestep	0.05
+timestep        0.05
 
 # group of NEB atoms - either block or single atom ID 412
 
-region		surround block 10 18 17 20 0 0 units box
-group		nebatoms region surround
-#group		nebatoms id 412
-set		group nebatoms type 3
-group		nonneb subtract all nebatoms
+region          surround block 10 18 17 20 0 0 units box
+group           nebatoms region surround
+#group          nebatoms id 412
+set             group nebatoms type 3
+group           nonneb subtract all nebatoms
 
-fix		1 lower setforce 0.0 0.0 0.0
-fix		2 nebatoms neb 1.0 parallel ideal end first 1.0
-fix		3 all enforce2d
+fix             1 lower setforce 0.0 0.0 0.0
+fix             2 nebatoms neb 1.0 parallel ideal end first 1.0
+fix             3 all enforce2d
 
-thermo		100
+thermo          100
 
-#dump		1 nebatoms atom 10 dump.neb.$u
-#dump		2 nonneb atom 10 dump.nonneb.$u
+#dump            1 nebatoms atom 10 dump.neb.$u
+#dump            2 nonneb atom 10 dump.nonneb.$u
 
 # run NEB for 2000 steps or to force tolerance
 
-min_style	quickmin
+min_style       quickmin
 
-neb		0.0 0.1 1000 1000 100 final final.hop1
+neb             0.0 0.1 1000 1000 100 final final.hop1

--- a/examples/neb/in.neb.hop2
+++ b/examples/neb/in.neb.hop2
@@ -1,68 +1,68 @@
 # 2d NEB surface simulation, hop of adatom on surface
 
-dimension	2
-boundary	p s p
+dimension       2
+boundary        p s p
 
-atom_style	atomic
-neighbor	0.3 bin
-neigh_modify	delay 5
-atom_modify	map array sort 0 0.0
+atom_style      atomic
+neighbor        0.3 bin
+neigh_modify    delay 5
+atom_modify     map array sort 0 0.0
 
-variable	u uloop 20
+variable        u uloop 20
 
 # create geometry with adatom
 
-lattice		hex 0.9
-region		box block 0 20 0 11 -0.25 0.25
-region		box1 block 0 20 0 10 -0.25 0.25
+lattice         hex 0.9
+region          box block 0 20 0 11 -0.25 0.25
+region          box1 block 0 20 0 10 -0.25 0.25
 
-#create_box	3 box
-#create_atoms	1 region box1
-#create_atoms	1 single 11.5 10.5 0
-#mass		* 1.0
+#create_box     3 box
+#create_atoms   1 region box1
+#create_atoms   1 single 11.5 10.5 0
+#mass           * 1.0
 #write_data      initial.hop2
 
 read_data        initial.hop2
 
 # LJ potentials
 
-pair_style	lj/cut 2.5
-pair_coeff	* * 1.0 1.0 2.5
-pair_modify	shift yes
+pair_style      lj/cut 2.5
+pair_coeff      * * 1.0 1.0 2.5
+pair_modify     shift yes
 
 # initial minimization to relax surface
 
-minimize	1.0e-6 1.0e-4 1000 10000
-reset_timestep	0
+minimize        1.0e-6 1.0e-4 1000 10000
+reset_timestep  0
 
 # define groups
 
-region	        1 block INF INF INF 1.25 INF INF
-group		lower region 1
-group		mobile subtract all lower
-set		group lower type 2
+region          1 block INF INF INF 1.25 INF INF
+group           lower region 1
+group           mobile subtract all lower
+set             group lower type 2
 
-timestep	0.05
+timestep        0.05
 
 # group of NEB atoms - either block or single atom ID 421
 
-region		surround block 10 18 17 21 0 0 units box
-group		nebatoms region surround
-#group		nebatoms id 421
-set		group nebatoms type 3
-group		nonneb subtract all nebatoms
+region          surround block 10 18 17 21 0 0 units box
+group           nebatoms region surround
+#group          nebatoms id 421
+set             group nebatoms type 3
+group           nonneb subtract all nebatoms
 
-fix		1 lower setforce 0.0 0.0 0.0
-fix		2 nebatoms neb 1.0 
-fix		3 all enforce2d
+fix             1 lower setforce 0.0 0.0 0.0
+fix             2 nebatoms neb 1.0
+fix             3 all enforce2d
 
-thermo		100
+thermo          100
 
-#dump		1 nebatoms atom 10 dump.neb.$u
-#dump		2 nonneb atom 10 dump.nonneb.$u
+#dump            1 nebatoms atom 10 dump.neb.$u
+#dump            2 nonneb atom 10 dump.nonneb.$u
 
 # run NEB for 2000 steps or to force tolerance
 
-min_style	fire
+min_style       fire
 
-neb		0.0 0.05 1000 1000 100 final final.hop2
+neb             0.0 0.05 1000 1000 100 final final.hop2

--- a/examples/neb/in.neb.sivac
+++ b/examples/neb/in.neb.sivac
@@ -57,14 +57,14 @@ variable	u uloop 20
 
 # only output atoms near vacancy
 
-#dump events vacneigh custom 1000 dump.neb.sivac.$u id type x y z
 
 # initial minimization to relax vacancy
 
 displace_atoms all random 0.1 0.1 0.1 123456
 minimize	1.0e-6 1.0e-4 1000 10000
+reset_timestep  0
 
-reset_timestep	0
+#dump events vacneigh custom 1000 dump.neb.sivac.$u id type x y z
 
 fix		1 all neb 1.0 
 

--- a/examples/neb/in.neb.sivac
+++ b/examples/neb/in.neb.sivac
@@ -5,7 +5,7 @@ units           metal
 atom_style      atomic
 atom_modify     map array
 boundary        p p p
-atom_modify	sort 0 0.0
+atom_modify     sort 0 0.0
 
 # coordination number cutoff
 
@@ -45,7 +45,7 @@ group Si type 1
 group del id 300
 delete_atoms group del compress no
 group vacneigh id 174 175 301 304 306 331 337
- 
+
 # choose potential
 
 pair_style      sw
@@ -53,26 +53,26 @@ pair_coeff * * Si.sw Si
 
 # set up neb run
 
-variable	u uloop 20
-
-# only output atoms near vacancy
-
+variable        u uloop 20
 
 # initial minimization to relax vacancy
 
 displace_atoms all random 0.1 0.1 0.1 123456
-minimize	1.0e-6 1.0e-4 1000 10000
+minimize        1.0e-6 1.0e-4 1000 10000
+
 reset_timestep  0
+
+# only output atoms near vacancy
 
 #dump events vacneigh custom 1000 dump.neb.sivac.$u id type x y z
 
-fix		1 all neb 1.0 
+fix             1 all neb 1.0
 
-thermo		100
+thermo          100
 
 # run NEB for 2000 steps or to force tolerance
 
 timestep        0.01
-min_style	quickmin
+min_style       quickmin
 
-neb		0.0 0.01 100 100 10 final final.sivac
+neb             0.0 0.01 100 100 10 final final.sivac

--- a/src/AMOEBA/amoeba_induce.cpp
+++ b/src/AMOEBA/amoeba_induce.cpp
@@ -369,7 +369,8 @@ void PairAmoeba::induce()
       eps = DEBYE * sqrt(eps/atom->natoms);
 
       if (eps < poleps) done = true;
-      if (eps > epsold) done = true;
+      // also commented out in induce.f of Tinker
+      // if (eps > epsold) done = true;
       if (iter >= politer) done = true;
 
       //  apply a "peek" iteration to the mutual induced dipoles
@@ -390,7 +391,7 @@ void PairAmoeba::induce()
     // terminate the calculation if dipoles failed to converge
     // NOTE: could make this an error
 
-    if (iter >= maxiter || eps > epsold)
+    if (iter >= politer || eps > epsold)
       if (comm->me == 0)
         error->warning(FLERR,"AMOEBA induced dipoles did not converge");
   }

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -68,7 +68,7 @@ ComputePairLocal::ComputePairLocal(LAMMPS *lmp, int narg, char **arg) :
       pstyle[nvalues++] = DZ;
     else if (arg[iarg][0] == 'p') {
       int n = atoi(&arg[iarg][1]);
-      if (n <= 0) error->all(FLERR, "Invalid keyword in compute pair/local command");
+      if (n <= 0) error->all(FLERR, "Invalid keyword {} in compute pair/local command", arg[iarg]);
       pstyle[nvalues] = PN;
       pindex[nvalues++] = n - 1;
 

--- a/src/fmt/format.h
+++ b/src/fmt/format.h
@@ -389,12 +389,11 @@ class uint128_fallback {
       hi_ += (lo_ < n ? 1 : 0);
       return *this;
     }
-// LAMMPS customization: XLCClang does not support __builtin_addcll()
-#if FMT_HAS_BUILTIN(__builtin_addcll) && !(defined(__xlc__) && defined(__clang__))
+#if FMT_HAS_BUILTIN(__builtin_addcll) && !defined(__ibmxl__)
     unsigned long long carry;
     lo_ = __builtin_addcll(lo_, n, 0, &carry);
     hi_ += carry;
-#elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64)
+#elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64) && !defined(__ibmxl__)
     unsigned long long result;
     auto carry = __builtin_ia32_addcarryx_u64(0, lo_, n, &result);
     lo_ = result;

--- a/src/fmt/format.h
+++ b/src/fmt/format.h
@@ -389,7 +389,8 @@ class uint128_fallback {
       hi_ += (lo_ < n ? 1 : 0);
       return *this;
     }
-#if FMT_HAS_BUILTIN(__builtin_addcll)
+// LAMMPS customization: XLCClang does not support __builtin_addcll()
+#if FMT_HAS_BUILTIN(__builtin_addcll) && !(defined(__xlc__) && defined(__clang__))
     unsigned long long carry;
     lo_ = __builtin_addcll(lo_, n, 0, &carry);
     hi_ += carry;

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -545,7 +545,6 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
           screen = fopen(str.c_str(),"w");
           if (screen == nullptr)
             error->one(FLERR,"Cannot open screen file {}: {}",str,utils::getsyserror());
-          setvbuf(screen, NULL, _IONBF, 0);
         } else if (strcmp(arg[screenflag],"none") == 0) {
           screen = nullptr;
         } else {
@@ -569,7 +568,6 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
           logfile = fopen(str.c_str(),"w");
           if (logfile == nullptr)
             error->one(FLERR,"Cannot open logfile {}: {}",str, utils::getsyserror());
-          setbuf(logfile, NULL);
         } else if (strcmp(arg[logflag],"none") == 0) {
           logfile = nullptr;
         } else {

--- a/src/reader_xyz.cpp
+++ b/src/reader_xyz.cpp
@@ -179,8 +179,7 @@ void ReaderXYZ::read_atoms(int n, int nfield, double **fields)
 
     ++nid;
     rv = sscanf(line,"%*s%lg%lg%lg", &myx, &myy, &myz);
-    if (rv != 3)
-      error->one(FLERR,"Dump file is incorrectly formatted");
+    if (rv != 3) error->one(FLERR,"Dump file is incorrectly formatted");
 
     // XXX: we could insert an element2type translation here
     // XXX: for now we flag unrecognized types as type 0,

--- a/tools/python/pizza/dump.py
+++ b/tools/python/pizza/dump.py
@@ -194,6 +194,21 @@ import numpy as np
 try: from DEFAULTS import PIZZA_GUNZIP
 except: PIZZA_GUNZIP = "gunzip"
 
+# --------------------------------------------------------------------
+# wrapper to convert old style comparision function to key function
+
+def cmp2key(oldcmp):
+    class keycmp:
+      def __init__(self, obj, *args):
+        self.obj = obj
+      def __lt__(self, other):
+        return oldcmp(self.obj,other.obj) < 0
+      def __gt__(self, other):
+        return oldcmp(self.obj,other.obj) > 0
+      def __eq__(self, other):
+        return oldcmp(self.obj,other.obj) == 0
+    return keycmp
+
 # Class definition
 
 class dump:
@@ -255,7 +270,7 @@ class dump:
 
     # sort entries by timestep, cull duplicates
 
-    self.snaps.sort(self.compare_time)
+    self.snaps.sort(key=cmp2key(self.compare_time))
     self.cull()
     self.nsnaps = len(self.snaps)
     print("read %d snapshots" % self.nsnaps)

--- a/tools/python/pizza/dump.py
+++ b/tools/python/pizza/dump.py
@@ -189,12 +189,7 @@ import sys, re, glob, types
 from os import popen
 from math import *             # any function could be used by set()
 
-try:
-    import numpy as np
-    oldnumeric = False
-except:
-    import Numeric as np
-    oldnumeric = True
+import numpy as np
 
 try: from DEFAULTS import PIZZA_GUNZIP
 except: PIZZA_GUNZIP = "gunzip"
@@ -379,10 +374,7 @@ class dump:
         for i in range(1,snap.natoms):
           words += f.readline().decode().split()
         floats = map(float,words)
-        if oldnumeric:
-          atom_data = np.array(list(floats),np.Float)
-        else:
-          atom_data = np.array(list(floats),np.float)
+        atom_data = np.array(list(floats),np.float)
 
         snap.atoms = atom_data.reshape((snap.natoms, ncol))
       else:
@@ -858,8 +850,7 @@ class dump:
     self.map(ncol+1,str)
     for snap in self.snaps:
       atoms = snap.atoms
-      if oldnumeric: newatoms = np.zeros((snap.natoms,ncol+1),np.Float)
-      else: newatoms = np.zeros((snap.natoms,ncol+1),np.float)
+      newatoms = np.zeros((snap.natoms,ncol+1),np.float)
       newatoms[:,0:ncol] = snap.atoms
       snap.atoms = newatoms
 
@@ -1018,8 +1009,7 @@ class dump:
 
         # convert values to int and absolute value since can be negative types
 
-        if oldnumeric: bondlist = np.zeros((nbonds,4),np.Int)
-        else: bondlist = np.zeros((nbonds,4),np.int)
+        bondlist = np.zeros((nbonds,4),np.int)
         ints = [abs(int(value)) for value in words]
         start = 0
         stop = 4


### PR DESCRIPTION
**Summary**

This PR combines multiple bugfixes and small changes

**Related Issue(s)**

Fixes #3385 
Fixes #3386 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issue

**Implementation Notes**

The following changes are included:
- Add workaround for IBM's clang based xlc compiler with fmtlib version 9.0.0 to address compilation failure
- address two issues in AMOEBA reported in #3385 and #3386
- replace use of `atoi()` with `utils::inumeric()` when parsing `-kokkos` flag arguments
- fix issue in NEB example input by moving dump command after reset_timestep
- port sorting by timestep in Pizza.py's dump class to Python 3 while retaining compatibility with Python 2.7
- remove support for obsolete "Numeric" python module in Pizza.py's dump class
- add -nonbuf (-nb) command line flag to disable buffering on screen and logfile output for debugging.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

