### PR TITLE
Fixed a bug (xz and yz reversed) in LAMMPS.F90 and changed mpif90 to …

### DIFF
--- a/examples/COUPLE/fortran2/LAMMPS.F90
+++ b/examples/COUPLE/fortran2/LAMMPS.F90
@@ -1105,7 +1105,7 @@ contains !! Wrapper functions local to this module {{{1
       C_xy = xy
       C_xz = xz
       C_yz = yz
-      call lammps_actual_reset_box (ptr, C_boxlo, C_boxhi, C_xy, C_xz, C_yz)
+      call lammps_actual_reset_box (ptr, C_boxlo, C_boxhi, C_xy, C_yz, C_xz)
    end subroutine lammps_reset_box
 
 ! lammps_gather_atoms {{{2

--- a/examples/COUPLE/fortran2/README
+++ b/examples/COUPLE/fortran2/README
@@ -40,7 +40,7 @@ the dynamically-linkable library (liblammps_fortran.so).
  (2) Copy said library to your Fortran program's source directory or replace
      ${LAMMPS_LIB} with its full path in the instructions below.
  (3) Compile (but don't link!) LAMMPS.F90.  Example:
-        mpif90 -c LAMMPS.f90
+        mpifort -c LAMMPS.f90
      OR
         gfortran -c LAMMPS.F90
      NOTE:  you may get a warning such as,
@@ -72,8 +72,8 @@ the dynamically-linkable library (liblammps_fortran.so).
      were part of the usual LAMMPS library interface (if you have the module
      file visible to the compiler, that is).
  (6) Compile (but don't link) your Fortran program.  Example:
-        mpif90 -c myfreeformatfile.f90
-        mpif90 -c myfixedformatfile.f
+        mpifort -c myfreeformatfile.f90
+        mpifort -c myfixedformatfile.f
      OR
         gfortran -c myfreeformatfile.f90
         gfortran -c myfixedformatfile.f
@@ -83,12 +83,12 @@ the dynamically-linkable library (liblammps_fortran.so).
      IMPORTANT:  If the Fortran module from part (3) is not in the current
      directory or in one searched by the compiler for module files, you will
      need to include that location via the -I flag to the compiler, like so:
-        mpif90 -I${LAMMPS_SRC}/examples/COUPLE/fortran2 -c myfreeformatfile.f90
+        mpifort -I${LAMMPS_SRC}/examples/COUPLE/fortran2 -c myfreeformatfile.f90
 
  (7) Link everything together, including any libraries needed by LAMMPS (such
      as the C++ standard library, the C math library, the JPEG library, fftw,
      etc.)  For example,
-        mpif90 LAMMPS.o LAMMPS-wrapper.o ${my_object_files} \
+        mpifort LAMMPS.o LAMMPS-wrapper.o ${my_object_files} \
             ${LAMMPS_LIB} -lmpi_cxx -lstdc++ -lm
      OR
         gfortran LAMMPS.o LAMMPS-wrapper.o ${my_object_files} \
@@ -105,17 +105,17 @@ You should now have a working executable.
  (1) Compile LAMMPS as a dynamic library
      (make makeshlib && make -f Makefile.shlib [targetname]).
  (2) Compile, but don't link, LAMMPS.F90 using the -fPIC flag, such as
-        mpif90 -fPIC -c LAMMPS.f90
+        mpifort -fPIC -c LAMMPS.f90
  (3) Compile, but don't link, LAMMPS-wrapper.cpp in the same manner, e.g.
         mpicxx -fPIC -c LAMMPS-wrapper.cpp
  (4) Make the dynamic library, like so:
-        mpif90 -fPIC -shared -o liblammps_fortran.so LAMMPS.o LAMMPS-wrapper.o
+        mpifort -fPIC -shared -o liblammps_fortran.so LAMMPS.o LAMMPS-wrapper.o
  (5) Compile your program, such as,
-        mpif90 -I${LAMMPS_SRC}/examples/COUPLE/fortran2 -c myfreeformatfile.f90
+        mpifort -I${LAMMPS_SRC}/examples/COUPLE/fortran2 -c myfreeformatfile.f90
      where ${LAMMPS_SRC}/examples/COUPLE/fortran2 contains the .mod file from
      step (3)
  (6) Link everything together, such as
-        mpif90 ${my_object_files} -L${LAMMPS_SRC} \
+        mpifort ${my_object_files} -L${LAMMPS_SRC} \
             -L${LAMMPS_SRC}/examples/COUPLE/fortran2 -llammps_fortran \
             -llammps_openmpi -lmpi_cxx -lstdc++ -lm
 


### PR DESCRIPTION
…mpifort in README for files in examples/COUPLE/fortran2

**Summary**

One bug fix (xz and yz in the wrong order in the call to the C library) in LAMMPS.F90 and changed "mpif90" to "mpifort" in the README in examples/COUPLE/fortran2

**Author(s)**

Karl Hammond
University of Missouri

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



