### PR TITLE
Fix reaxff/species update for dynamic groups and empty groups

### DIFF
--- a/src/REAXFF/fix_reaxff_species.cpp
+++ b/src/REAXFF/fix_reaxff_species.cpp
@@ -68,6 +68,7 @@ FixReaxFFSpecies::FixReaxFFSpecies(LAMMPS *lmp, int narg, char **arg) : Fix(lmp,
   nevery = utils::inumeric(FLERR, arg[3], false, lmp);
   nrepeat = utils::inumeric(FLERR, arg[4], false, lmp);
   global_freq = nfreq = utils::inumeric(FLERR, arg[5], false, lmp);
+  if (nrepeat == 1) dynamic_group_allow = 1;
 
   comm_forward = 4;
 

--- a/src/REAXFF/fix_reaxff_species.cpp
+++ b/src/REAXFF/fix_reaxff_species.cpp
@@ -26,6 +26,7 @@
 #include "error.h"
 #include "fix_ave_atom.h"
 #include "force.h"
+#include "group.h"
 #include "memory.h"
 #include "modify.h"
 #include "neigh_list.h"
@@ -395,9 +396,7 @@ void FixReaxFFSpecies::Output_ReaxFF_Bonds(bigint ntimestep, FILE * /*fp*/)
   Nmole = Nspec = 0;
 
   FindMolecule();
-
   SortMolecule(Nmole);
-
   FindSpecies(Nmole, Nspec);
 
   vector_nmole = Nmole;
@@ -522,16 +521,21 @@ void FixReaxFFSpecies::SortMolecule(int &Nmole)
     hi = MAX(hi, nint(clusterID[n]));
   }
   int flagall;
-  MPI_Allreduce(&flag, &flagall, 1, MPI_INT, MPI_SUM, world);
-  if (flagall && me == 0)
-    error->warning(FLERR, "Atom with cluster ID = 0 included in fix reaxff/species group");
   MPI_Allreduce(&lo, &idlo, 1, MPI_INT, MPI_MIN, world);
   MPI_Allreduce(&hi, &idhi, 1, MPI_INT, MPI_MAX, world);
+  int nlen = idhi - idlo + 1;
+  if (nlen <= 0) {  // no atoms in group
+    Nmole = 0;
+    return;
+  }
   if (idlo == ntotal)
     if (me == 0)
-      error->warning(FLERR, "Atom with cluster ID = maxmol included in fix reaxff/species group");
+      error->warning(FLERR, "Atom with cluster ID = maxmol included in fix reaxff/species group {}",group->names[igroup]);
 
-  int nlen = idhi - idlo + 1;
+  MPI_Allreduce(&flag, &flagall, 1, MPI_INT, MPI_SUM, world);
+  if (flagall && me == 0)
+    error->warning(FLERR, "Atom with cluster ID = 0 included in fix reaxff/species group {}", group->names[igroup]);
+
   memory->create(molmap, nlen, "reaxff/species:molmap");
   for (n = 0; n < nlen; n++) molmap[n] = 0;
 


### PR DESCRIPTION
**Summary**

With these changes, fix reaxff/species may be used with dynamics groups (must use nevery==1 for that) and with empty groups (which would previously stop with an obscure error).

**Related Issue(s)**

Issue reported at: https://matsci.org/t/problem-with-memory-allocation-in-reaxff-calculations/43902

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
