### PR TITLE
Refactor access to molecule templates

### DIFF
--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -131,7 +131,7 @@ FixPour::FixPour(LAMMPS *lmp, int narg, char **arg) :
 
       if (atom->molecular == Atom::TEMPLATE && onemols != atom->avec->onemols)
         error->all(FLERR, "Fix pour molecule template ID must be same as atom style template ID");
-      onemols[i]->check_attributes(0);
+      onemols[i]->check_attributes();
 
       // fix pour uses geoemetric center of molecule for insertion
 

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -177,7 +177,7 @@ FixGCMC::FixGCMC(LAMMPS *lmp, int narg, char **arg) :
     if (atom->molecular == Atom::TEMPLATE && onemols != atom->avec->onemols)
       error->all(FLERR,"Fix gcmc molecule template ID must be same "
                  "as atom_style template ID");
-    onemols[imol]->check_attributes(0);
+    onemols[imol]->check_attributes();
   }
 
   if (charge_flag && atom->q == nullptr)

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -153,7 +153,7 @@ FixWidom::FixWidom(LAMMPS *lmp, int narg, char **arg) :
     if (atom->molecular == Atom::TEMPLATE && onemols != atom->avec->onemols)
       error->all(FLERR,"Fix widom molecule template ID must be same "
                  "as atom_style template ID");
-    onemols[imol]->check_attributes(0);
+    onemols[imol]->check_attributes();
   }
 
   if (charge_flag && atom->q == nullptr)

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -471,8 +471,8 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
     open(files[i]);
     onemol = atom->molecules[unreacted_mol[i]];
     twomol = atom->molecules[reacted_mol[i]];
-    onemol->check_attributes(0);
-    twomol->check_attributes(0);
+    onemol->check_attributes();
+    twomol->check_attributes();
     get_molxspecials();
     read(i);
     fclose(fp);

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1901,6 +1901,18 @@ int Atom::find_molecule(char *id)
 }
 
 /* ----------------------------------------------------------------------
+   return vector of molecules which match template ID
+------------------------------------------------------------------------- */
+
+std::vector<Molecule *>Atom::get_molecule_by_id(const std::string &id)
+{
+  std::vector<Molecule *> result;
+  for (int imol = 0; imol < nmolecule; ++imol)
+    if (id == molecules[imol]->id) result.push_back(molecules[imol]);
+  return result;
+}
+
+/* ----------------------------------------------------------------------
    add info to current atom ilocal from molecule template onemol and its iatom
    offset = atom ID preceding IDs of atoms in this molecule
    called by fixes and commands that add molecules
@@ -1912,8 +1924,7 @@ void Atom::add_molecule_atom(Molecule *onemol, int iatom, int ilocal, tagint off
   if (onemol->radiusflag && radius_flag) radius[ilocal] = onemol->radius[iatom];
   if (onemol->rmassflag && rmass_flag) rmass[ilocal] = onemol->rmass[iatom];
   else if (rmass_flag)
-    rmass[ilocal] = 4.0*MY_PI/3.0 *
-      radius[ilocal]*radius[ilocal]*radius[ilocal];
+    rmass[ilocal] = 4.0*MY_PI/3.0 * radius[ilocal]*radius[ilocal]*radius[ilocal];
   if (onemol->bodyflag) {
     body[ilocal] = 0;     // as if a body read from data file
     onemol->avec_body->data_body(ilocal,onemol->nibody,onemol->ndbody,
@@ -1923,10 +1934,8 @@ void Atom::add_molecule_atom(Molecule *onemol, int iatom, int ilocal, tagint off
 
   // initialize custom per-atom properties to zero if present
 
-  for (int i = 0; i < nivector; ++i)
-    ivector[i][ilocal] = 0;
-  for (int i = 0; i < ndvector; ++i)
-    dvector[i][ilocal] = 0.0;
+  for (int i = 0; i < nivector; ++i) ivector[i][ilocal] = 0;
+  for (int i = 0; i < ndvector; ++i) dvector[i][ilocal] = 0.0;
   for (int i = 0; i < niarray; ++i)
     for (int j = 0; j < icols[i]; ++j)
       iarray[i][ilocal][j] = 0;

--- a/src/atom.h
+++ b/src/atom.h
@@ -345,6 +345,7 @@ class Atom : protected Pointers {
 
   void add_molecule(int, char **);
   int find_molecule(char *);
+  std::vector<Molecule *>get_molecule_by_id(const std::string &);
   void add_molecule_atom(class Molecule *, int, int, tagint);
 
   void first_reorder();

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -299,7 +299,7 @@ void CreateAtoms::command(int narg, char **arg)
     if (onemol->tag_require && !atom->tag_enable)
       error->all(FLERR, "Create_atoms molecule has atom IDs, but system does not");
 
-    onemol->check_attributes(0);
+    onemol->check_attributes();
 
     // use geometric center of molecule for insertion
     // molecule random number generator, different for each proc

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -117,7 +117,7 @@ FixDeposit::FixDeposit(LAMMPS *lmp, int narg, char **arg) :
       if (atom->molecular == Atom::TEMPLATE && onemols != atom->avec->onemols)
         error->all(FLERR,"Fix deposit molecule template ID must be same "
                    "as atom_style template ID");
-      onemols[i]->check_attributes(0);
+      onemols[i]->check_attributes();
 
       // fix deposit uses geoemetric center of molecule for insertion
 

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -125,7 +125,7 @@ class Molecule : protected Pointers {
   void compute_com();
   void compute_inertia();
   int findfragment(const char *);
-  void check_attributes(int);
+  void check_attributes();
 
  private:
   int me;

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -866,7 +866,10 @@ void ReadData::command(int narg, char **arg)
   // insure nbondtypes,etc are still consistent with template molecules,
   //   in case data file re-defined them
 
-  if (atom->molecular == Atom::TEMPLATE) atom->avec->onemols[0]->check_attributes(1);
+  if (atom->molecular == Atom::TEMPLATE) {
+    int nset = MAX(1, atom->avec->onemols[0]->nset);
+    for (int i = 0; i < nset; ++i) atom->avec->onemols[i]->check_attributes();
+  }
 
   // if adding atoms, migrate atoms to new processors
   // use irregular() b/c box size could have changed dramaticaly

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -216,6 +216,9 @@ TEST_F(MoleculeFileTest, twomols)
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output, ContainsRegex(".*Read molecule template.*\n.*2 molecules.*\n"
                                       ".*0 fragments.*\n.*2 atoms with max type 2.*\n.*0 bonds.*"));
+    ASSERT_EQ(lmp->atom->nmolecule, 1);
+    auto mols = lmp->atom->get_molecule_by_id(test_name);
+    ASSERT_EQ(mols.size(), 1);
 }
 
 TEST_F(MoleculeFileTest, twofiles)
@@ -231,6 +234,17 @@ TEST_F(MoleculeFileTest, twofiles)
                       ".*Read molecule template twomols:.*\n.*1 molecules.*\n"
                       ".*0 fragments.*\n.*3 atoms with max type 4.*\n.*2 bonds with max type 2.*\n"
                       ".*1 angles with max type 2.*\n.*0 dihedrals.*"));
+    BEGIN_CAPTURE_OUTPUT();
+    command("molecule h2o moltest.h2o.mol");
+    command("molecule co2 moltest.co2.mol");
+    output = END_CAPTURE_OUTPUT();
+    ASSERT_EQ(lmp->atom->nmolecule, 4);
+    auto mols = lmp->atom->get_molecule_by_id("twomols");
+    ASSERT_EQ(mols.size(), 2);
+    mols = lmp->atom->get_molecule_by_id("h2o");
+    ASSERT_EQ(mols.size(), 1);
+    mols = lmp->atom->get_molecule_by_id("co2");
+    ASSERT_EQ(mols.size(), 1);
 }
 
 TEST_F(MoleculeFileTest, bonds)


### PR DESCRIPTION
**Summary**

This pull request modernizes the access to molecule data structures as loaded into LAMMPS with the molecule command.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

Currently there are some inconsistencies in how data referred to by a molecule ID is processed. Also it requires to access internal data of the molecule data structure to determine whether one or more entries in the list of molecules needs to be used.
The intent of this pull request is to make this consistent and use C++ data structures instead of accessing internal lists.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
