### PR TITLE
Fix vim syntax to handle switching color themes

### DIFF
--- a/tools/vim/README.txt
+++ b/tools/vim/README.txt
@@ -3,50 +3,50 @@
 
 The files provided in this directory will enable syntax highlighting
 for the lammps script syntax in vim. The simulation scripts have to
-end on *.lmp or start with in.* (see mysyntax.vim).  
-By far not all commands are included
-in the syntax file (lammps.vim). You can easily add new ones.
+end on .lmp or .in or start with in. (see mysyntax.vim or filetype.vim).
+By far not all commands are included in the syntax file (lammps.vim).
+You can easily add new ones.
 
 =To enable the highlighting (compatible with old versions of VIM):
 ============================
-(0)   Create a ~/.vimrc
+(1)   Create a ~/.vimrc
       You can have a look in /usr/share/vim/vim*/vimrc_example.vim
-(1)   Insert in ~/.vimrc
+(2)   Insert in ~/.vimrc
          let mysyntaxfile = "~/.vim/mysyntax.vim"
       just before
          syntax on
-(2)   Create directory ~/.vim and place mysyntax.vim and lammps.vim there
+(3)   Create directory ~/.vim and place mysyntax.vim and lammps.vim there
 
 =Here is an alternate method for VIM Version 7.2 and later:
 ===========================================================
 
-(0) Create/edit ~/.vimrc to contain:
+(1) Create/edit ~/.vimrc to contain:
          syntax on
-(1) Create directories ~/.vim/syntax and ~/.vim/ftdetect
-(2) Copy lammps.vim to ~/.vim/syntax/lammps.vim
-(3) Copy filetype.vim to ~/.vim/ftdetect/lammps.vim
-
-
-Gerolf Ziegenhain <gerolf@ziegenhain.com> 2007
+(2) Create directories ~/.vim/syntax and ~/.vim/ftdetect
+(3) Copy lammps.vim to ~/.vim/syntax/lammps.vim
+(4) Copy filetype.vim to ~/.vim/ftdetect/lammps.vim
 
 Distribution Packaging guidelines:
 ==================================
 
-(0) Copy lammps.vim to ${VIMFILES}/syntax/lammps.vim
-(1) Copy filetype.vim as ${VIMFILES}/ftdetect/lammps.vim
+(1) Copy lammps.vim to ${VIMFILES}/syntax/lammps.vim
+(2) Copy filetype.vim as ${VIMFILES}/ftdetect/lammps.vim
 
 ${VIMFILES} is typically /usr/share/vim/vimfiles
 Consult your packaging guidlines for exact location.
+
+Gerolf Ziegenhain <gerolf@ziegenhain.com> 2007
+
+=Disable insertion of <TAB> characters
+========================================
+
+(1) The LAMMPS developers strongly discourage writing
+   files (input and C++ source code) with <TAB> characters.
+   To change the default behavior of vim use in your vimrc:
+       set expandtab
 
 ---------------
 
 updated by Sam Bateman, 11/2010
 updated by Aidan Thompson, 12/2010
-
-Sam Bateman
-Naval Research Laboratory
-Code 7434
-1005 Balch Blvd.
-Stennis Space Center, MS 39529
-Phone: (228) 688-4328
-Email: sam.bateman@nrlssc.navy.mil
+updated by Axel Kohlmeyer, 08/2022

--- a/tools/vim/filetype.vim
+++ b/tools/vim/filetype.vim
@@ -1,4 +1,5 @@
 augroup filetypedetect
  au! BufRead,BufNewFile in.*           setfiletype lammps
  au! BufRead,BufNewFile *.lmp          setfiletype lammps
+ au! BufRead,BufNewFile in.*           setfiletype lammps
 augroup END

--- a/tools/vim/filetype.vim
+++ b/tools/vim/filetype.vim
@@ -1,5 +1,5 @@
 augroup filetypedetect
  au! BufRead,BufNewFile in.*           setfiletype lammps
  au! BufRead,BufNewFile *.lmp          setfiletype lammps
- au! BufRead,BufNewFile in.*           setfiletype lammps
+ au! BufRead,BufNewFile *.in           setfiletype lammps
 augroup END

--- a/tools/vim/lammps.vim
+++ b/tools/vim/lammps.vim
@@ -1,64 +1,64 @@
 " Vim syntax file
-" Language:	         Lammps Simulation Script File
+" Language:              Lammps Simulation Script File
 " Maintainer:        Gerolf Ziegenhain <gerolf@ziegenhain.com>
 " Updates:           Axel Kohlmeyer <akohlmey@gmail.com>, Sam Bateman <sam.bateman@nrlssc.navy.mil>, Daniel Möller Montull <d.moller.m@gmail.com>, Eryk Skalinski <eskalinski@protonmail.com>
 " Latest Revision:   2022-08-17
 
 syn clear
 
-syn keyword	lammpsOutput	log write_data write_dump info shell write_restart restart dump undump thermo thermo_modify thermo_style print timer
-syn keyword	lammpsRead	include read_restart read_data read_dump molecule
-syn keyword	lammpsLattice	boundary units atom_style lattice region create_box create_atoms dielectric
-syn keyword	lammpsLattice	delete_atoms displace_atoms change_box dimension replicate
-syn keyword	lammpsParticle	pair_coeff pair_style pair_modify pair_write mass velocity angle_coeff angle_style
-syn keyword	lammpsParticle	atom_modify atom_style bond_coeff bond_style bond_write create_bonds delete_bonds kspace_style
-syn keyword	lammpsParticle	kspace_modify dihedral_style dihedral_coeff improper_style improper_coeff
-syn keyword	lammpsSetup	min_style fix_modify run_style timestep neighbor neigh_modify fix unfix suffix special_bonds
-syn keyword	lammpsSetup	balance box clear comm_modify comm_style newton package processors reset_ids reset_timestep
-syn keyword	lammpsRun	minimize run rerun tad neb prd quit server temper temper/grem temper/npt
-syn keyword	lammpsRun	min/spin message hyper dynamical_matrix
-syn keyword	lammpsDefine	variable group compute python set uncompute kim_query
+syn keyword     lammpsOutput    log write_data write_dump info shell write_restart restart dump undump thermo thermo_modify thermo_style print timer
+syn keyword     lammpsRead      include read_restart read_data read_dump molecule
+syn keyword     lammpsLattice   boundary units atom_style lattice region create_box create_atoms dielectric
+syn keyword     lammpsLattice   delete_atoms displace_atoms change_box dimension replicate
+syn keyword     lammpsParticle  pair_coeff pair_style pair_modify pair_write mass velocity angle_coeff angle_style
+syn keyword     lammpsParticle  atom_modify atom_style bond_coeff bond_style bond_write create_bonds delete_bonds kspace_style
+syn keyword     lammpsParticle  kspace_modify dihedral_style dihedral_coeff improper_style improper_coeff
+syn keyword     lammpsSetup     min_style fix_modify run_style timestep neighbor neigh_modify fix unfix suffix special_bonds
+syn keyword     lammpsSetup     balance box clear comm_modify comm_style newton package processors reset_ids reset_timestep
+syn keyword     lammpsRun       minimize run rerun tad neb prd quit server temper temper/grem temper/npt
+syn keyword     lammpsRun       min/spin message hyper dynamical_matrix
+syn keyword     lammpsDefine    variable group compute python set uncompute kim_query
 
-syn keyword	lammpsRepeat	jump next loop
+syn keyword     lammpsRepeat    jump next loop
 
-syn keyword	lammpsOperator	equal add sub mult div
+syn keyword     lammpsOperator  equal add sub mult div
 
-syn keyword	lammpsConditional if then elif else
+syn keyword     lammpsConditional if then elif else
 
-syn keyword	lammpsSpecial	EDGE NULL &
+syn keyword     lammpsSpecial   EDGE NULL &
 
-syn region	lammpsString	start=+'+ end=+'+	oneline
-syn region	lammpsString	start=+"+ end=+"+	oneline
+syn region      lammpsString    start=+'+ end=+'+       oneline
+syn region      lammpsString    start=+"+ end=+"+       oneline
 
-syn match	lammpsNumber	"\<[0-9]\+[ij]\=\>"
-syn match	lammpsFloat	"\<[0-9]\+\.[0-9]*\([edED][-+]\=[0-9]\+\)\=[ij]\=\>"
-syn match	lammpsFloat	"\.[0-9]\+\([edED][-+]\=[0-9]\+\)\=[ij]\=\>"
-syn match	lammpsFloat	"\<[0-9]\+[edED][-+]\=[0-9]\+[ij]\=\>"
+syn match       lammpsNumber    "\<[0-9]\+[ij]\=\>"
+syn match       lammpsFloat     "\<[0-9]\+\.[0-9]*\([edED][-+]\=[0-9]\+\)\=[ij]\=\>"
+syn match       lammpsFloat     "\.[0-9]\+\([edED][-+]\=[0-9]\+\)\=[ij]\=\>"
+syn match       lammpsFloat     "\<[0-9]\+[edED][-+]\=[0-9]\+[ij]\=\>"
 
-syn match	lammpsComment	"#\(.*&\s*\n\)*.*$"
+syn match       lammpsComment   "#\(.*&\s*\n\)*.*$"
 
-syn match	lammpsVariable	"\$\({[a-zA-Z0-9_]\+}\)"
-syn match	lammpsVariable	"\$[A-Za-z]"
+syn match       lammpsVariable  "\$\({[a-zA-Z0-9_]\+}\)"
+syn match       lammpsVariable  "\$[A-Za-z]"
 
 if !exists("did_lammps_syntax_inits")
   let did_lammps_syntax_inits = 1
-  hi def link lammpsOutput		Function
-  hi def link lammpsRepeat		Repeat
-  hi def link lammpsRead		Include
-  hi def link lammpsLattice		Typedef
-  hi def link lammpsParticle		Typedef
-  hi def link lammpsSetup		Typedef
-  hi def link lammpsDefine		Define
-  hi def link lammpsRun			Statement
-  hi def link lammpsNumber		Number
-  hi def link lammpsFloat		Float
-  hi def link lammpsString		String
-  hi def link lammpsComment		Comment
-  hi def link lammpsLoop		Repeat
-  hi def link lammpsVariable		Identifier
-  hi def link lammpsConditional		Conditional
-  hi def link lammpsOperator		Operator
-  hi def link lammpsSpecial		Number
+  hi def link lammpsOutput              Function
+  hi def link lammpsRepeat              Repeat
+  hi def link lammpsRead                Include
+  hi def link lammpsLattice             Typedef
+  hi def link lammpsParticle            Typedef
+  hi def link lammpsSetup               Typedef
+  hi def link lammpsDefine              Define
+  hi def link lammpsRun                 Statement
+  hi def link lammpsNumber              Number
+  hi def link lammpsFloat               Float
+  hi def link lammpsString              String
+  hi def link lammpsComment             Comment
+  hi def link lammpsLoop                Repeat
+  hi def link lammpsVariable            Identifier
+  hi def link lammpsConditional         Conditional
+  hi def link lammpsOperator            Operator
+  hi def link lammpsSpecial             Number
 endif
 
 let b:current_syntax = "lammps"

--- a/tools/vim/lammps.vim
+++ b/tools/vim/lammps.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	         Lammps Simulation Script File
 " Maintainer:        Gerolf Ziegenhain <gerolf@ziegenhain.com>
-" Updates:           Axel Kohlmeyer <akohlmey@gmail.com>, Sam Bateman <sam.bateman@nrlssc.navy.mil>, Daniel Möller Montull <d.moller.m@gmail.com>
-" Latest Revision:   2019-06-11
+" Updates:           Axel Kohlmeyer <akohlmey@gmail.com>, Sam Bateman <sam.bateman@nrlssc.navy.mil>, Daniel Möller Montull <d.moller.m@gmail.com>, Eryk Skalinski <eskalinski@protonmail.com>
+" Latest Revision:   2022-08-17
 
 syn clear
 
@@ -42,23 +42,23 @@ syn match	lammpsVariable	"\$[A-Za-z]"
 
 if !exists("did_lammps_syntax_inits")
   let did_lammps_syntax_inits = 1
-  hi link lammpsOutput		Function
-  hi link lammpsRepeat		Repeat
-  hi link lammpsRead		Include
-  hi link lammpsLattice		Typedef
-  hi link lammpsParticle	Typedef
-  hi link lammpsSetup		Typedef
-  hi link lammpsDefine		Define
-  hi link lammpsRun		Statement
-  hi link lammpsNumber		Number
-  hi link lammpsFloat		Float
-  hi link lammpsString		String
-  hi link lammpsComment		Comment
-  hi link lammpsLoop		Repeat
-  hi link lammpsVariable	Identifier
-  hi link lammpsConditional	Conditional
-  hi link lammpsOperator	Operator
-  hi link lammpsSpecial		Number
+  hi def link lammpsOutput		Function
+  hi def link lammpsRepeat		Repeat
+  hi def link lammpsRead		Include
+  hi def link lammpsLattice		Typedef
+  hi def link lammpsParticle		Typedef
+  hi def link lammpsSetup		Typedef
+  hi def link lammpsDefine		Define
+  hi def link lammpsRun			Statement
+  hi def link lammpsNumber		Number
+  hi def link lammpsFloat		Float
+  hi def link lammpsString		String
+  hi def link lammpsComment		Comment
+  hi def link lammpsLoop		Repeat
+  hi def link lammpsVariable		Identifier
+  hi def link lammpsConditional		Conditional
+  hi def link lammpsOperator		Operator
+  hi def link lammpsSpecial		Number
 endif
 
 let b:current_syntax = "lammps"

--- a/tools/vim/mysyntax.vim
+++ b/tools/vim/mysyntax.vim
@@ -1,4 +1,5 @@
 augroup syntax
 au  BufNewFile,BufReadPost *.lmp so ~/.vim/lammps.vim
 au  BufNewFile,BufReadPost in.* so ~/.vim/lammps.vim
+au  BufNewFile,BufReadPost *.in so ~/.vim/lammps.vim
 augroup END

--- a/tools/vim/vimrc
+++ b/tools/vim/vimrc
@@ -1,2 +1,4 @@
 let mysyntaxfile = "~/.vim/mysyntax.vim"
 syntax on
+" do not create <TAB> characters
+set expandtab


### PR DESCRIPTION
**Summary**
- filetype.vim includes *.in files as lammps input files
- syntax.vim defines the syntax links rather than just creating them once

This fix allows switching color schemes in vim while retaining lammps syntax highlighting which was previously not the case. 

**Author(s)**
Eryk Skalinski : eskalinski at protonmail dot com

**Licensing**
By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
No

**Implementation Notes**
Please see summary

**Post Submission Checklist**
- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete