### PR TITLE
Adding tests and updating error messages for fixes that calculate diagnostics

### DIFF
--- a/unittest/commands/CMakeLists.txt
+++ b/unittest/commands/CMakeLists.txt
@@ -58,3 +58,7 @@ add_executable(test_mpi_load_balancing test_mpi_load_balancing.cpp)
 target_link_libraries(test_mpi_load_balancing PRIVATE lammps GTest::GMock)
 target_compile_definitions(test_mpi_load_balancing PRIVATE ${TEST_CONFIG_DEFS})
 add_mpi_test(NAME MPILoadBalancing NUM_PROCS 4 COMMAND $<TARGET_FILE:test_mpi_load_balancing>)
+
+add_executable(test_fix_diagnostic test_fix_diagnostic.cpp)
+target_link_libraries(test_fix_diagnostic PRIVATE lammps GTest::GMockMain GTest::GMock GTest::GTest)
+add_test(NAME FixDiagnostic COMMAND test_fix_diagnostic)

--- a/unittest/commands/test_fix_diagnostic.cpp
+++ b/unittest/commands/test_fix_diagnostic.cpp
@@ -1,0 +1,105 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "../testing/core.h"
+#include "info.h"
+#include "input.h"
+#include "lammps.h"
+#include "variable.h"
+#include "library.h"
+#include "utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cstdio>
+#include <mpi.h>
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+using LAMMPS_NS::utils::split_words;
+
+namespace LAMMPS_NS {
+
+#define STRINGIFY(val) XSTR(val)
+#define XSTR(val) #val
+
+class FixDiagnosticTest : public LAMMPSTest {
+protected:
+    Variable *variable;
+    void SetUp() override
+    {
+        testbinary = "FixDiagnosticTest";
+        args       = {"-log", "none", "-echo", "screen", "-nocite", "-v", "num", "1"};
+        LAMMPSTest::SetUp();
+        variable = lmp->input->variable;
+    }
+
+    void TearDown() override
+    {
+        LAMMPSTest::TearDown();
+    }
+
+    void atomic_system()
+    {
+        BEGIN_HIDE_OUTPUT();
+        command("units real");
+        command("lattice sc 1.0 origin 0.125 0.125 0.125");
+        command("region box block -2 2 -2 2 -2 2");
+        command("create_box 8 box");
+        command("create_atoms 1 box");
+        command("mass * 1.0");
+        END_HIDE_OUTPUT();
+    }
+};
+
+TEST_F(FixDiagnosticTest, FixAveAtom)
+{
+    atomic_system();
+    BEGIN_HIDE_OUTPUT();
+    command("variable step atom id<=step");
+    command("fix steps all ave/atom 1 10 10 v_step");
+    command("compute 1 all reduce sum f_steps");
+    command("variable pstep equal c_1");
+    command("thermo_style custom step temp c_1");
+    command("run 10 post no");
+    END_HIDE_OUTPUT();
+
+    ASSERT_DOUBLE_EQ(variable->compute_equal("v_pstep"), 5.5);
+}
+
+} //LAMMPS_NS
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
+
+    // handle arguments passed via environment variable
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = split_words(var);
+        for (auto arg : env) {
+            if (arg == "-v") {
+                verbose = true;
+            }
+        }
+    }
+
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}


### PR DESCRIPTION
**Summary**

This PR contains tests for fixes such as "fix ave/atom" that only calculate diagnostic values and do not alter forces in the simulation.

**Author(s)**

Vaibhav Palkar, Clemson University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


