### PR TITLE
Added simple cubic

### DIFF
--- a/doc/src/pair_meam.rst
+++ b/doc/src/pair_meam.rst
@@ -238,6 +238,7 @@ The recognized keywords for the parameter file are as follows:
                    lin = linear structure (180 degree angle)
                    zig = zigzag structure with a uniform angle
                    tri = H2O-like structure that has an angle
+				   sc = simple cubic
    nn2(I,J)    = turn on second-nearest neighbor MEAM formulation for
                  I-J pair (see for example :ref:`(Lee) <Lee>`).
                    0 = second-nearest neighbor formulation off

--- a/src/MEAM/meam.h
+++ b/src/MEAM/meam.h
@@ -22,7 +22,7 @@
 namespace LAMMPS_NS {
 class Memory;
 
-typedef enum { FCC, BCC, HCP, DIM, DIA, DIA3, B1, C11, L12, B2, CH4, LIN, ZIG, TRI } lattice_t;
+typedef enum { FCC, BCC, HCP, DIM, DIA, DIA3, B1, C11, L12, B2, CH4, LIN, ZIG, TRI, SC } lattice_t;
 
 class MEAM {
  public:
@@ -263,6 +263,7 @@ class MEAM {
     else if (str == "lin") lat = LIN;
     else if (str == "zig") lat = ZIG;
     else if (str == "tri") lat = TRI;
+    else if (str == "sc") lat = SC;
     else {
       if (single)
         return false;

--- a/src/MEAM/meam_funcs.cpp
+++ b/src/MEAM/meam_funcs.cpp
@@ -208,6 +208,7 @@ MEAM::get_shpfcn(const lattice_t latt, const double sthe, const double cthe, dou
     case BCC:
     case B1:
     case B2:
+    case SC:
       s[0] = 0.0;
       s[1] = 0.0;
       s[2] = 0.0;
@@ -267,6 +268,7 @@ MEAM::get_Zij(const lattice_t latt)
     case DIM:
       return 1;
     case B1:
+	case SC:
       return 6;
     case C11:
       return 10;
@@ -320,6 +322,7 @@ MEAM::get_Zij2(const lattice_t latt, const double cmin, const double cmax,
     break;
 
   case B1:
+  case SC:
     Zij2 = 12;
     a = sqrt(2.0);
     numscr = 2;

--- a/src/MEAM/meam_setup_done.cpp
+++ b/src/MEAM/meam_setup_done.cpp
@@ -615,6 +615,7 @@ void MEAM::get_tavref(double* t11av, double* t21av, double* t31av, double* t12av
     case LIN:
     case ZIG:
     case TRI:
+    case SC:
       //     all neighbors are of the opposite type
       *t11av = t12;
       *t21av = t22;
@@ -698,6 +699,7 @@ void MEAM::get_densref(double r, int a, int b, double* rho01, double* rho11, dou
       *rho02 = 8.0 * rhoa01;
       break;
     case B1:
+    case SC:
       *rho01 = 6.0 * rhoa02;
       *rho02 = 6.0 * rhoa01;
       break;

--- a/src/MEAM/meam_setup_global.cpp
+++ b/src/MEAM/meam_setup_global.cpp
@@ -76,6 +76,7 @@ MEAM::meam_setup_global(int nelt, lattice_t* lat, int* ielement, double* /*atwt*
       case LIN:
       case ZIG:
       case TRI:
+      case SC:
         this->re_meam[i][i] = tmplat[i];
         break;
       case DIA:


### PR DESCRIPTION
Summary

With the recent publication of bismuth potential, the simple cubic was added as the MEAM reference structure. This code is the modified MEAM package based on the stable LAMMPS version released on 29 September 2021.

Related Issue(s)

MEAM interaction for Bi.

Author(s)

Henan Zhou [hz185@msstate.edu]
Doyl Dickel [doyl@me.msstate.edu]
Sungkwang Mun [sungkwan@cavs.msstate.edu]

Licensing

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

Backward Compatibility

Yes, the modification was only added to the MEAM package.

Implementation Notes
Followed standard compilation procedure.

It was tested using example bismuth MEAM potential.


Post Submission Checklist

[x] The feature or features in this pull request is complete
[x]Licensing information is complete
[x]Corresponding author information is complete
[x] The source code follows the LAMMPS formatting guidelines
[x] Suitable new documentation files and/or updates to the existing docs are included
[x] The added/updated documentation is integrated and tested with the documentation build system
[x] The feature has been verified to work with the conventional build system
[x] The feature has been verified to work with the CMake based build system
[x] Suitable tests have been added to the unittest tree.
[x] One or more example input decks are included

Further Information, Files, and Links
[MEAM_sc_Bi_testfile.zip](https://github.com/lammps/lammps/files/9404229/MEAM_sc_Bi_testfile.zip)
