### PR TITLE
Refactor of set command and compute property/atom

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -760,6 +760,23 @@ void Atom::setup()
   if (sortfreq > 0) setup_sort_bins();
 }
 
+/* ---------------------------------------------------------------------- */
+
+std::string Atom::get_style()
+{
+  std::string retval = atom_style;
+  if (retval == "hybrid") {
+    retval += "<";
+    auto avec_hybrid = dynamic_cast<AtomVecHybrid *>(avec);
+    for (int i = 0; i < avec_hybrid->nstyles; i++) {
+      retval += avec_hybrid->keywords[i];
+      retval += ' ';
+    }
+    retval.back() = '>';
+  }
+  return retval;
+}
+
 /* ----------------------------------------------------------------------
    return ptr to AtomVec class if matches style or to matching hybrid sub-class
    return nullptr if no match

--- a/src/atom.h
+++ b/src/atom.h
@@ -311,6 +311,7 @@ class Atom : protected Pointers {
   void init();
   void setup();
 
+  std::string get_style();
   AtomVec *style_match(const char *);
   void modify_params(int, char **);
   void tag_check();

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -402,7 +402,7 @@ void Info::command(int narg, char **arg)
   if (flags & SYSTEM) {
     fputs("\nSystem information:\n",out);
     fmt::print(out,"Units         = {}\n", update->unit_style);
-    fmt::print(out,"Atom style    = {}\n", atom->atom_style);
+    fmt::print(out,"Atom style    = {}\n", atom->get_style());
     fmt::print(out,"Atom map      = {}\n", mapstyles[atom->map_style]);
     if (atom->molecular != Atom::ATOMIC) {
       const char *msg;

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -46,9 +46,9 @@ enum{ATOM_SELECT,MOL_SELECT,TYPE_SELECT,GROUP_SELECT,REGION_SELECT};
 
 enum{TYPE,TYPE_FRACTION,TYPE_RATIO,TYPE_SUBSET,
      MOLECULE,X,Y,Z,VX,VY,VZ,CHARGE,MASS,SHAPE,LENGTH,TRI,
-     DIPOLE,DIPOLE_RANDOM,SPIN,SPIN_RANDOM,QUAT,QUAT_RANDOM,
-     THETA,THETA_RANDOM,ANGMOM,OMEGA,
-     DIAMETER,DENSITY,VOLUME,IMAGE,BOND,ANGLE,DIHEDRAL,IMPROPER,
+     DIPOLE,DIPOLE_RANDOM,SPIN_ATOM,SPIN_RANDOM,SPIN_ELECTRON,RADIUS_ELECTRON,
+     QUAT,QUAT_RANDOM,THETA,THETA_RANDOM,ANGMOM,OMEGA,
+     DIAMETER,RADIUS_ATOM,DENSITY,VOLUME,IMAGE,BOND,ANGLE,DIHEDRAL,IMPROPER,
      SPH_E,SPH_CV,SPH_RHO,EDPD_TEMP,EDPD_CV,CC,SMD_MASS_DENSITY,
      SMD_CONTACT_RADIUS,DPDTHETA,EPSILON,IVEC,DVEC,IARRAY,DARRAY};
 
@@ -61,8 +61,8 @@ void Set::command(int narg, char **arg)
   if (domain->box_exist == 0)
     error->all(FLERR,"Set command before simulation box is defined");
   if (atom->natoms == 0)
-    error->all(FLERR,"Set command with no atoms existing");
-  if (narg < 3) error->all(FLERR,"Illegal set command");
+    error->all(FLERR,"Set command on system without atoms");
+  if (narg < 4) error->all(FLERR,"Illegal set command: need at least four arguments");
 
   // style and ID info
 
@@ -71,7 +71,7 @@ void Set::command(int narg, char **arg)
   else if (strcmp(arg[0],"type") == 0) style = TYPE_SELECT;
   else if (strcmp(arg[0],"group") == 0) style = GROUP_SELECT;
   else if (strcmp(arg[0],"region") == 0) style = REGION_SELECT;
-  else error->all(FLERR,"Illegal set command");
+  else error->all(FLERR,"Unknown set command style: {}", arg[0]);
 
   id = utils::strdup(arg[1]);
   select = nullptr;
@@ -91,125 +91,125 @@ void Set::command(int narg, char **arg)
     origarg = iarg;
 
     if (strcmp(arg[iarg],"type") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set type", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       set(TYPE);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"type/fraction") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set type/fraction", error);
       newtype = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       fraction = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       ivalue = utils::inumeric(FLERR,arg[iarg+3],false,lmp);
       if (newtype <= 0 || newtype > atom->ntypes)
-        error->all(FLERR,"Invalid value in set command");
+        error->all(FLERR,"Invalid type value {} in set type/fraction command", newtype);
       if (fraction < 0.0 || fraction > 1.0)
-        error->all(FLERR,"Invalid value in set command");
+        error->all(FLERR,"Invalid fraction value {} in set type/fraction command", fraction);
       if (ivalue <= 0)
-        error->all(FLERR,"Invalid random number seed in set command");
+        error->all(FLERR,"Invalid random number seed {} in set type/fraction command", ivalue);
       setrandom(TYPE_FRACTION);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"type/ratio") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set type/ratio", error);
       newtype = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       fraction = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       ivalue = utils::inumeric(FLERR,arg[iarg+3],false,lmp);
       if (newtype <= 0 || newtype > atom->ntypes)
-        error->all(FLERR,"Invalid value in set command");
+        error->all(FLERR,"Invalid type value {} in set type/ratio command", newtype);
       if (fraction < 0.0 || fraction > 1.0)
-        error->all(FLERR,"Invalid value in set command");
+        error->all(FLERR,"Invalid fraction value {} in set type/ratio command", fraction);
       if (ivalue <= 0)
-        error->all(FLERR,"Invalid random number seed in set command");
+        error->all(FLERR,"Invalid random number seed {} in set type/ratio command", ivalue);
       setrandom(TYPE_RATIO);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"type/subset") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set type/subset", error);
       newtype = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       nsubset = utils::bnumeric(FLERR,arg[iarg+2],false,lmp);
       ivalue = utils::inumeric(FLERR,arg[iarg+3],false,lmp);
       if (newtype <= 0 || newtype > atom->ntypes)
-        error->all(FLERR,"Invalid value in set command");
+        error->all(FLERR,"Invalid type value {} in set type/subset command", newtype);
       if (nsubset < 0)
-        error->all(FLERR,"Invalid value in set command");
+        error->all(FLERR,"Invalid subset size {} in set type/subset command", nsubset);
       if (ivalue <= 0)
-        error->all(FLERR,"Invalid random number seed in set command");
+        error->all(FLERR,"Invalid random number seed {} in set type/subset command", ivalue);
       setrandom(TYPE_SUBSET);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"mol") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set mol", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->molecule_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(MOLECULE);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"x") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set x", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(X);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"y") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set y", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(Y);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"z") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set z", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(Z);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"vx") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set vx", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(VX);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"vy") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set vy", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(VY);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"vz") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set vz", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       set(VZ);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"charge") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set charge", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->q_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(CHARGE);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"mass") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set mass", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->rmass_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(MASS);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"shape") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set shape", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
@@ -217,30 +217,30 @@ void Set::command(int narg, char **arg)
       if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->ellipsoid_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(SHAPE);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"length") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set length", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->line_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(LENGTH);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"tri") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set tri", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->tri_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(TRI);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"dipole") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set dipole", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
@@ -248,16 +248,16 @@ void Set::command(int narg, char **arg)
       if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->mu_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(DIPOLE);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"dipole/random") == 0) {
-      if (iarg+3 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+3 > narg) utils::missing_cmd_args(FLERR, "set dipole/random", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       dvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       if (!atom->mu_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0)
         error->all(FLERR,"Invalid random number seed in set command");
       if (dvalue <= 0.0)
@@ -265,8 +265,10 @@ void Set::command(int narg, char **arg)
       setrandom(DIPOLE_RANDOM);
       iarg += 3;
 
-    } else if (strcmp(arg[iarg],"spin") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+    } else if ((strcmp(arg[iarg],"spin") == 0) || (strcmp(arg[iarg],"spin/atom") == 0)) {
+      if ((strcmp(arg[iarg],"spin") == 0) && (comm->me == 0))
+        error->warning(FLERR, "Set attribute spin is deprecated. Please use spin/atom instead.");
+      if (iarg+5 > narg) utils::missing_cmd_args(FLERR, "set spin/atom", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
@@ -276,8 +278,8 @@ void Set::command(int narg, char **arg)
       if (utils::strmatch(arg[iarg+4],"^v_")) varparse(arg[iarg+4],4);
       else zvalue = utils::numeric(FLERR,arg[iarg+4],false,lmp);
       if (!atom->sp_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
-      set(SPIN);
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
+      set(SPIN_ATOM);
       iarg += 5;
 
     } else if (strcmp(arg[iarg],"spin/random") == 0) {
@@ -285,16 +287,16 @@ void Set::command(int narg, char **arg)
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       dvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
       if (!atom->sp_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0)
-        error->all(FLERR,"Invalid random number seed in set command");
+        error->all(FLERR,"Invalid random number seed in set {} command: {}", arg[iarg], ivalue);
       if (dvalue <= 0.0)
-        error->all(FLERR,"Invalid dipole length in set command");
+        error->all(FLERR,"Invalid dipole length in set {} command: {}", arg[iarg], dvalue);
       setrandom(SPIN_RANDOM);
       iarg += 3;
 
     } else if (strcmp(arg[iarg],"quat") == 0) {
-      if (iarg+5 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+5 > narg) utils::missing_cmd_args(FLERR, "set quat", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
@@ -304,41 +306,41 @@ void Set::command(int narg, char **arg)
       if (utils::strmatch(arg[iarg+4],"^v_")) varparse(arg[iarg+4],4);
       else wvalue = utils::numeric(FLERR,arg[iarg+4],false,lmp);
       if (!atom->ellipsoid_flag && !atom->tri_flag && !atom->body_flag && !atom->quat_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(QUAT);
       iarg += 5;
 
     } else if (strcmp(arg[iarg],"quat/random") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set quat/random", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->ellipsoid_flag && !atom->tri_flag && !atom->body_flag && !atom->quat_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0)
         error->all(FLERR,"Invalid random number seed in set command");
       setrandom(QUAT_RANDOM);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"theta") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set theta", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = DEG2RAD * utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->line_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(THETA);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"theta/random") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set theta/random", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->line_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0)
         error->all(FLERR,"Invalid random number seed in set command");
       set(THETA_RANDOM);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"angmom") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set angmom", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
@@ -346,12 +348,12 @@ void Set::command(int narg, char **arg)
       if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->angmom_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(ANGMOM);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"omega") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set omega", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else xvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (utils::strmatch(arg[iarg+2],"^v_")) varparse(arg[iarg+2],2);
@@ -359,26 +361,26 @@ void Set::command(int narg, char **arg)
       if (utils::strmatch(arg[iarg+3],"^v_")) varparse(arg[iarg+3],3);
       else zvalue = utils::numeric(FLERR,arg[iarg+3],false,lmp);
       if (!atom->omega_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(OMEGA);
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"diameter") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set diameter", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->radius_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(DIAMETER);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"density") == 0 ||
                (strcmp(arg[iarg],"density/disc") == 0)) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set density", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->rmass_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (dvalue <= 0.0) error->all(FLERR,"Invalid density in set command");
       discflag = 0;
       if (strcmp(arg[iarg],"density/disc") == 0) {
@@ -390,17 +392,17 @@ void Set::command(int narg, char **arg)
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"volume") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set volume", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->vfrac_flag)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (dvalue <= 0.0) error->all(FLERR,"Invalid volume in set command");
       set(VOLUME);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"image") == 0) {
-      if (iarg+4 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+4 > narg) utils::missing_cmd_args(FLERR, "set image", error);
       ximageflag = yimageflag = zimageflag = 0;
       if (strcmp(arg[iarg+1],"NULL") != 0) {
         ximageflag = 1;
@@ -430,74 +432,74 @@ void Set::command(int narg, char **arg)
       iarg += 4;
 
     } else if (strcmp(arg[iarg],"bond") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set bond", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (atom->avec->bonds_allow == 0)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0 || ivalue > atom->nbondtypes)
         error->all(FLERR,"Invalid value in set command");
       topology(BOND);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"angle") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set angle", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (atom->avec->angles_allow == 0)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0 || ivalue > atom->nangletypes)
         error->all(FLERR,"Invalid value in set command");
       topology(ANGLE);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"dihedral") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set dihedral", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (atom->avec->dihedrals_allow == 0)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0 || ivalue > atom->ndihedraltypes)
         error->all(FLERR,"Invalid value in set command");
       topology(DIHEDRAL);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"improper") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set improper", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       if (atom->avec->impropers_allow == 0)
-        error->all(FLERR,"Cannot set this attribute for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0 || ivalue > atom->nimpropertypes)
         error->all(FLERR,"Invalid value in set command");
       topology(IMPROPER);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"sph/e") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set sph/e", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->esph_flag)
-        error->all(FLERR,"Cannot set meso/e for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(SPH_E);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"sph/cv") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set sph/cv", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->cv_flag)
-            error->all(FLERR,"Cannot set meso/cv for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(SPH_CV);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"sph/rho") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set sph/rho", error);
       if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       if (!atom->rho_flag)
-        error->all(FLERR,"Cannot set meso/rho for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(SPH_RHO);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"edpd/temp") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set edpd/temp", error);
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
       else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
@@ -505,12 +507,12 @@ void Set::command(int narg, char **arg)
         if (dvalue < 0.0) error->all(FLERR,"Illegal set command");
       }
       if (!atom->edpd_flag)
-        error->all(FLERR,"Cannot set edpd/temp for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(EDPD_TEMP);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"edpd/cv") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set edpd/cv", error);
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
       else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
@@ -518,12 +520,12 @@ void Set::command(int narg, char **arg)
         if (dvalue < 0.0) error->all(FLERR,"Illegal set command");
       }
       if (!atom->edpd_flag)
-        error->all(FLERR,"Cannot set edpd/cv for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(EDPD_CV);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"cc") == 0) {
-      if (iarg+3 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+3 > narg) utils::missing_cmd_args(FLERR, "set cc", error);
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
       else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
@@ -532,31 +534,30 @@ void Set::command(int narg, char **arg)
         if (cc_index < 1) error->all(FLERR,"Illegal set command");
       }
       if (!atom->tdpd_flag)
-        error->all(FLERR,"Cannot set cc for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(CC);
       iarg += 3;
 
     } else if (strcmp(arg[iarg],"smd/mass/density") == 0) {
-          if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+          if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set smd/mass/density", error);
           if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
           else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
           if (!atom->smd_flag)
-            error->all(FLERR,"Cannot set smd/mass/density for this atom style");
+            error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
           set(SMD_MASS_DENSITY);
           iarg += 2;
 
     } else if (strcmp(arg[iarg],"smd/contact/radius") == 0) {
-          if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+          if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set smd/contact/radius", error);
           if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
           else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
           if (!atom->smd_flag)
-            error->all(FLERR,"Cannot set smd/contact/radius "
-                       "for this atom style");
+            error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
           set(SMD_CONTACT_RADIUS);
           iarg += 2;
 
     } else if (strcmp(arg[iarg],"dpd/theta") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set dpd/theta", error);
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
       else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
@@ -564,12 +565,12 @@ void Set::command(int narg, char **arg)
         if (dvalue < 0.0) error->all(FLERR,"Illegal set command");
       }
       if (!atom->dpd_flag)
-        error->all(FLERR,"Cannot set dpd/theta for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(DPDTHETA);
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"epsilon") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set epsilon", error);
       if (strcmp(arg[iarg+1],"NULL") == 0) dvalue = -1.0;
       else if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
       else {
@@ -577,7 +578,7 @@ void Set::command(int narg, char **arg)
         if (dvalue < 0.0) error->all(FLERR,"Illegal set command");
       }
       if (!atom->dielectric_flag)
-        error->all(FLERR,"Cannot set epsilon for this atom style");
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(EPSILON);
       iarg += 2;
 
@@ -588,16 +589,17 @@ void Set::command(int narg, char **arg)
       int flag,cols;
       ArgInfo argi(arg[iarg],ArgInfo::DNAME|ArgInfo::INAME);
       const char *pname = argi.get_name();
-      if (iarg+2 > narg) error->all(FLERR,"Illegal set command");
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set", error);
       index_custom = atom->find_custom(argi.get_name(),flag,cols);
-      if (index_custom < 0) error->all(FLERR,"Custom property {} does not exist",pname);
+      if (index_custom < 0)
+        error->all(FLERR,"Set keyword or custom property {} does not exist",pname);
 
       switch (argi.get_type()) {
 
       case ArgInfo::INAME:
         if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
         else ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
-        if (flag != 0) error->all(FLERR,"Custom property {} is not integer",pname);
+        if (flag != 0) error->all(FLERR,"Set command custom property {} is not integer",pname);
 
         if (argi.get_dim() == 0) {
           if (cols > 0)
@@ -621,14 +623,15 @@ void Set::command(int narg, char **arg)
 
         if (argi.get_dim() == 0) {
           if (cols > 0)
-            error->all(FLERR,"Set command custom floating-point property is not a vector");
+            error->all(FLERR,"Set command custom double property {} is not a vector",pname);
           set(DVEC);
         } else if (argi.get_dim() == 1) {
           if (cols == 0)
-            error->all(FLERR,"Set command custom floating-point property is not an array");
+            error->all(FLERR,"Set command custom double property {} is not an array",pname);
           icol_custom = argi.get_index1();
           if (icol_custom <= 0 || icol_custom > cols)
-            error->all(FLERR,"Set command per-atom custom integer array is accessed out-of-range");
+            error->all(FLERR,"Set command per-atom custom double array {} is "
+                       "accessed out-of-range",pname);
           set(DARRAY);
         } else error->all(FLERR,"Illegal set command");
         break;
@@ -657,8 +660,8 @@ void Set::command(int narg, char **arg)
 
   // free local memory
 
-  delete [] id;
-  delete [] select;
+  delete[] id;
+  delete[] select;
 }
 
 /* ----------------------------------------------------------------------
@@ -668,7 +671,7 @@ void Set::command(int narg, char **arg)
 
 void Set::selection(int n)
 {
-  delete [] select;
+  delete[] select;
   select = new int[n];
   int nlo,nhi;
 
@@ -1457,9 +1460,9 @@ void Set::varparse(const char *name, int m)
   int ivar = input->variable->find(name+2);
 
   if (ivar < 0)
-    error->all(FLERR,"Variable name for set command does not exist");
+    error->all(FLERR,"Variable name {} for set command does not exist", name);
   if (!input->variable->atomstyle(ivar))
-    error->all(FLERR,"Variable for set command is invalid style");
+    error->all(FLERR,"Variable {} for set command is invalid style", name);
 
   if (m == 1) {
     varflag1 = 1; ivar1 = ivar;

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -282,10 +282,14 @@ void Set::command(int narg, char **arg)
       set(SPIN_ATOM);
       iarg += 5;
 
-    } else if (strcmp(arg[iarg],"spin/random") == 0) {
-      if (iarg+3 > narg) error->all(FLERR,"Illegal set command");
+    } else if ((strcmp(arg[iarg],"spin/random") == 0) ||
+               (strcmp(arg[iarg],"spin/atom/random") == 0)) {
+      if (iarg+3 > narg) utils::missing_cmd_args(FLERR, "set spin/atom/random", error);
       ivalue = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       dvalue = utils::numeric(FLERR,arg[iarg+2],false,lmp);
+      if ((strcmp(arg[iarg],"spin/random") == 0) && (comm->me == 0))
+        error->warning(FLERR, "Set attribute spin/random is deprecated. "
+                       "Please use spin/atom/random instead.");
       if (!atom->sp_flag)
         error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       if (ivalue <= 0)
@@ -294,6 +298,24 @@ void Set::command(int narg, char **arg)
         error->all(FLERR,"Invalid dipole length in set {} command: {}", arg[iarg], dvalue);
       setrandom(SPIN_RANDOM);
       iarg += 3;
+
+    } else if (strcmp(arg[iarg],"radius/electron") == 0) {
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set radius/electron", error);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
+      else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
+      if (!atom->eradius_flag)
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
+      set(RADIUS_ELECTRON);
+      iarg += 2;
+
+    } else if (strcmp(arg[iarg],"spin/electron") == 0) {
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set spin/electron", error);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
+      else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
+      if (!atom->spin_flag)
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
+      set(SPIN_ELECTRON);
+      iarg += 2;
 
     } else if (strcmp(arg[iarg],"quat") == 0) {
       if (iarg+5 > narg) utils::missing_cmd_args(FLERR, "set quat", error);
@@ -364,6 +386,15 @@ void Set::command(int narg, char **arg)
         error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
       set(OMEGA);
       iarg += 4;
+
+    } else if (strcmp(arg[iarg],"radius/atom") == 0) {
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set radius/atom", error);
+      if (utils::strmatch(arg[iarg+1],"^v_")) varparse(arg[iarg+1],1);
+      else dvalue = utils::numeric(FLERR,arg[iarg+1],false,lmp);
+      if (!atom->radius_flag)
+        error->all(FLERR,"Cannot set attribute {} for atom style {}", arg[iarg], atom->get_style());
+      set(RADIUS_ATOM);
+      iarg += 2;
 
     } else if (strcmp(arg[iarg],"diameter") == 0) {
       if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "set diameter", error);
@@ -940,7 +971,7 @@ void Set::set(int keyword)
 
     // set magnetic moments
 
-    else if (keyword == SPIN) {
+    else if (keyword == SPIN_ATOM) {
       double **sp = atom->sp;
       double inorm = 1.0/sqrt(xvalue*xvalue+yvalue*yvalue+zvalue*zvalue);
       sp[i][0] = inorm*xvalue;

--- a/unittest/commands/CMakeLists.txt
+++ b/unittest/commands/CMakeLists.txt
@@ -29,6 +29,10 @@ add_executable(test_delete_atoms test_delete_atoms.cpp)
 target_link_libraries(test_delete_atoms PRIVATE lammps GTest::GMock)
 add_test(NAME DeleteAtoms COMMAND test_delete_atoms)
 
+add_executable(test_set_property test_set_property.cpp)
+target_link_libraries(test_set_property PRIVATE lammps GTest::GMock)
+add_test(NAME SetProperty COMMAND test_set_property)
+
 add_executable(test_variables test_variables.cpp)
 target_link_libraries(test_variables PRIVATE lammps GTest::GMock)
 add_test(NAME Variables COMMAND test_variables)

--- a/unittest/commands/test_set_property.cpp
+++ b/unittest/commands/test_set_property.cpp
@@ -1,0 +1,193 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "lammps.h"
+
+#include "atom.h"
+#include "compute.h"
+#include "domain.h"
+#include "math_const.h"
+
+#include "../testing/core.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+using LAMMPS_NS::MathConst::MY_PI;
+using LAMMPS_NS::utils::split_words;
+
+namespace LAMMPS_NS {
+using ::testing::ContainsRegex;
+using ::testing::ExitedWithCode;
+using ::testing::StrEq;
+
+class SetTest : public LAMMPSTest {
+protected:
+    Atom *atom;
+    Domain *domain;
+    void SetUp() override
+    {
+        testbinary = "SetTest";
+        args       = {"-log", "none", "-echo", "screen", "-nocite", "-v", "num", "1"};
+        LAMMPSTest::SetUp();
+        atom   = lmp->atom;
+        domain = lmp->domain;
+    }
+
+    void TearDown() override { LAMMPSTest::TearDown(); }
+
+    void atomic_system(const std::string &atom_style, const std::string units = "real")
+    {
+        BEGIN_HIDE_OUTPUT();
+        command("atom_style " + atom_style);
+        command("atom_modify map array");
+        command("units " + units);
+        command("lattice sc 1.0 origin 0.125 0.125 0.125");
+        command("region box block 0 2 0 2 0 2");
+        command("create_box 8 box");
+        command("create_atoms 1 box");
+        command("mass * 1.0");
+        command("region left block 0.0 1.0 INF INF INF INF");
+        command("region right block 1.0 2.0 INF INF INF INF");
+        command("region top block INF INF 0.0 1.0 INF INF");
+        command("region bottom block INF INF 1.0 2.0 INF INF");
+        command("region front block INF INF INF INF 0.0 1.0");
+        command("region back block INF INF INF 1.0 2.0 INF");
+        command("group top region top");
+        command("group bottom region bottom");
+        END_HIDE_OUTPUT();
+    }
+};
+
+TEST_F(SetTest, NoBoxNoAtoms)
+{
+    ASSERT_EQ(atom->natoms, 0);
+    ASSERT_EQ(domain->box_exist, 0);
+    TEST_FAILURE(".*ERROR: Set command before simulation box is.*", command("set type 1 x 0.0"););
+
+    BEGIN_HIDE_OUTPUT();
+    command("region box block 0 2 0 2 0 2");
+    command("create_box 1 box");
+    END_HIDE_OUTPUT();
+    TEST_FAILURE(".*ERROR: Set command on system without atoms.*", command("set type 1 x 0.0"););
+
+    BEGIN_HIDE_OUTPUT();
+    command("create_atoms 1 single 0.5 0.5 0.5");
+    END_HIDE_OUTPUT();
+    TEST_FAILURE(".*ERROR: Illegal set command: need at least four.*", command("set type 1 x"););
+    TEST_FAILURE(".*ERROR: Unknown set command style: xxx.*", command("set xxx 1 x 0.0"););
+    TEST_FAILURE(".*ERROR: Set keyword or custom property yyy does not exist.*",
+                 command("set type 1 yyy 0.0"););
+}
+
+TEST_F(SetTest, StylesTypes)
+{
+    atomic_system("molecular");
+    ASSERT_EQ(atom->natoms, 8);
+
+    BEGIN_HIDE_OUTPUT();
+    command("set group all mol 1");
+    command("set group top type 2");
+    command("set region back type 3");
+    command("set region left mol 2");
+    END_HIDE_OUTPUT();
+    ASSERT_EQ(atom->type[0], 2);
+    ASSERT_EQ(atom->type[1], 2);
+    ASSERT_EQ(atom->type[2], 1);
+    ASSERT_EQ(atom->type[3], 1);
+    ASSERT_EQ(atom->type[4], 2);
+    ASSERT_EQ(atom->type[5], 2);
+    ASSERT_EQ(atom->type[6], 1);
+    ASSERT_EQ(atom->type[7], 1);
+
+    BEGIN_HIDE_OUTPUT();
+    command("set mol 1 type 4");
+    command("set atom 4*7 type 5");
+    END_HIDE_OUTPUT();
+    ASSERT_EQ(atom->type[0], 2);
+    ASSERT_EQ(atom->type[1], 4);
+    ASSERT_EQ(atom->type[2], 1);
+    ASSERT_EQ(atom->type[3], 5);
+    ASSERT_EQ(atom->type[4], 5);
+    ASSERT_EQ(atom->type[5], 5);
+    ASSERT_EQ(atom->type[6], 5);
+    ASSERT_EQ(atom->type[7], 4);
+
+    BEGIN_HIDE_OUTPUT();
+    command("variable rev atom 9-id");
+    command("set group all type v_rev");
+    END_HIDE_OUTPUT();
+    ASSERT_EQ(atom->type[0], 8);
+    ASSERT_EQ(atom->type[1], 7);
+    ASSERT_EQ(atom->type[2], 6);
+    ASSERT_EQ(atom->type[3], 5);
+    ASSERT_EQ(atom->type[4], 4);
+    ASSERT_EQ(atom->type[5], 3);
+    ASSERT_EQ(atom->type[6], 2);
+    ASSERT_EQ(atom->type[7], 1);
+
+    BEGIN_HIDE_OUTPUT();
+    command("set group all type 1");
+    command("set group all type/fraction 2 0.5 453246");
+    END_HIDE_OUTPUT();
+    int sum = 0;
+    for (int i = 0; i < 8; ++i)
+        sum += (atom->type[i] == 2) ? 1 : 0;
+    ASSERT_EQ(sum, 4);
+
+    BEGIN_HIDE_OUTPUT();
+    command("set group all type 1");
+    command("set group all type/ratio 2 0.5 5784536");
+    END_HIDE_OUTPUT();
+    sum = 0;
+    for (int i = 0; i < 8; ++i)
+        sum += (atom->type[i] == 2) ? 1 : 0;
+    ASSERT_EQ(sum, 4);
+
+    BEGIN_HIDE_OUTPUT();
+    command("set group all type 1");
+    command("set group all type/subset 2 4 784536");
+    END_HIDE_OUTPUT();
+    sum = 0;
+    for (int i = 0; i < 8; ++i)
+        sum += (atom->type[i] == 2) ? 1 : 0;
+    ASSERT_EQ(sum, 4);
+}
+} // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
+
+    // handle arguments passed via environment variable
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = split_words(var);
+        for (auto arg : env) {
+            if (arg == "-v") {
+                verbose = true;
+            }
+        }
+    }
+
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -576,8 +576,7 @@ int main(int argc, char **argv)
     ::testing::InitGoogleMock(&argc, argv);
 
     if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {


### PR DESCRIPTION
**Summary**

This pull request will make some keywords and settings more consistent (with backward compatibility where possible) in the set command and the compute property/atom command. It also contains a new unittest executable for testing the two commands.

**Related Issue(s)**

This supersedes and thus closes #3294 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes.

**Implementation Notes**

Also implements a new method `Atom::get_style()` to provide a current atom style string suitable for error and informational messages.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
