### PR TITLE
Collected small changes and bugfixes

### DIFF
--- a/.github/workflows/unittest-macos.yml
+++ b/.github/workflows/unittest-macos.yml
@@ -41,6 +41,7 @@ jobs:
       working-directory: build
       run: |
         ccache -z
+        python3 -m pip install numpy
         python3 -m pip install pyyaml
         cmake -C ../cmake/presets/clang.cmake \
               -C ../cmake/presets/most.cmake \

--- a/doc/src/delete_atoms.rst
+++ b/doc/src/delete_atoms.rst
@@ -169,7 +169,7 @@ part of molecules.
 
 .. note::
 
-   The molecule deletion operation in invoked after all individual
+   The molecule deletion operation is invoked after all individual
    atoms have been deleted using the rules described above for each
    style.  This means additional atoms may be deleted that are not in the
    group or region, that are not required by the overlap cutoff

--- a/src/CLASS2/pair_lj_class2.cpp
+++ b/src/CLASS2/pair_lj_class2.cpp
@@ -513,6 +513,7 @@ double PairLJClass2::init_one(int i, int j)
         pow(sigma[j][j], 3.0) / (pow(sigma[i][i], 6.0) + pow(sigma[j][j], 6.0));
     sigma[i][j] = pow((0.5 * (pow(sigma[i][i], 6.0) + pow(sigma[j][j], 6.0))), 1.0 / 6.0);
     cut[i][j] = mix_distance(cut[i][i], cut[j][j]);
+    did_mix = true;
   }
 
   lj1[i][j] = 18.0 * epsilon[i][j] * pow(sigma[i][j], 9.0);

--- a/src/CLASS2/pair_lj_class2_coul_cut.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_cut.cpp
@@ -277,6 +277,7 @@ double PairLJClass2CoulCut::init_one(int i, int j)
     sigma[i][j] = pow((0.5 * (pow(sigma[i][i], 6.0) + pow(sigma[j][j], 6.0))), 1.0 / 6.0);
     cut_lj[i][j] = mix_distance(cut_lj[i][i], cut_lj[j][j]);
     cut_coul[i][j] = mix_distance(cut_coul[i][i], cut_coul[j][j]);
+    did_mix = true;
   }
 
   double cut = MAX(cut_lj[i][j], cut_coul[i][j]);

--- a/src/CLASS2/pair_lj_class2_coul_long.cpp
+++ b/src/CLASS2/pair_lj_class2_coul_long.cpp
@@ -711,6 +711,7 @@ double PairLJClass2CoulLong::init_one(int i, int j)
         pow(sigma[j][j], 3.0) / (pow(sigma[i][i], 6.0) + pow(sigma[j][j], 6.0));
     sigma[i][j] = pow((0.5 * (pow(sigma[i][i], 6.0) + pow(sigma[j][j], 6.0))), 1.0 / 6.0);
     cut_lj[i][j] = mix_distance(cut_lj[i][i], cut_lj[j][j]);
+    did_mix = true;
   }
 
   double cut = MAX(cut_lj[i][j], cut_coul);

--- a/src/create_bonds.cpp
+++ b/src/create_bonds.cpp
@@ -298,6 +298,7 @@ void CreateBonds::many()
       }
     }
   }
+  neighbor->init();
 
   // recount bonds
 

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -282,9 +282,11 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
   double cutsq = cut * cut;
 
   int igroup1 = group->find(arg[2]);
+  if (igroup1 < 0)
+    error->all(FLERR, "Could not find delete_atoms overlap first group ID {}", arg[2]);
   int igroup2 = group->find(arg[3]);
-  if (igroup1 < 0 || igroup2 < 0)
-    error->all(FLERR, "Could not find delete_atoms group ID {}", arg[1]);
+  if (igroup2 < 0)
+    error->all(FLERR, "Could not find delete_atoms overlap second group ID {}", arg[3]);
   options(narg - 4, &arg[4]);
 
   int group1bit = group->bitmask[igroup1];

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -420,6 +420,7 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
       break;
     }
   }
+  neighbor->init();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -278,8 +278,8 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
 
   // read args
 
-  double cut = utils::numeric(FLERR, arg[1], false, lmp);
-  double cutsq = cut * cut;
+  const double cut = utils::numeric(FLERR, arg[1], false, lmp);
+  const double cutsq = cut * cut;
 
   int igroup1 = group->find(arg[2]);
   if (igroup1 < 0)
@@ -289,8 +289,8 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
     error->all(FLERR, "Could not find delete_atoms overlap second group ID {}", arg[3]);
   options(narg - 4, &arg[4]);
 
-  int group1bit = group->bitmask[igroup1];
-  int group2bit = group->bitmask[igroup2];
+  const int group1bit = group->bitmask[igroup1];
+  const int group2bit = group->bitmask[igroup2];
 
   if (comm->me == 0) utils::logmesg(lmp, "System init for delete_atoms ...\n");
 
@@ -358,6 +358,7 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];
+    if (!(mask[i] & (group1bit|group2bit))) continue;
     xtmp = x[i][0];
     ytmp = x[i][1];
     ztmp = x[i][2];
@@ -369,6 +370,7 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
       factor_lj = special_lj[sbmask(j)];
       factor_coul = special_coul[sbmask(j)];
       j &= NEIGHMASK;
+      if (!(mask[j] & (group1bit|group2bit))) continue;
 
       // if both weighting factors are 0, skip this pair
       // could be 0 and still be in neigh list for long-range Coulombics

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -658,7 +658,7 @@ void Neighbor::init()
   for (i = 0; i < nlist; i++)
     if (neigh_pair[i]) neigh_pair[i]->copy_neighbor_info();
 
-  if (!same && comm->me == 0) print_pairwise_info();
+  if (!same && (nrequest > 0) && (comm->me == 0)) print_pairwise_info();
 
   // can now delete requests so next run can make new ones
   // print_pairwise_info() made use of requests
@@ -2152,7 +2152,7 @@ int Neighbor::choose_pair(NeighRequest *rq)
 }
 
 /* ----------------------------------------------------------------------
-   called by other classes to request a pairwise neighbor list
+   called internally to request a pairwise neighbor list
 ------------------------------------------------------------------------- */
 
 int Neighbor::request(void *requestor, int instance)

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -290,8 +290,13 @@ void Pair::init()
 
   if (!manybody_flag && (comm->me == 0)) {
     const int num_mixed_pairs = atom->ntypes * (atom->ntypes - 1) / 2;
-    utils::logmesg(lmp,"Generated {} of {} mixed pair_coeff terms from {} mixing rule\n",
-                   mixed_count, num_mixed_pairs, mixing_rule_names[mix_flag]);
+    // CLASS2 always applies sixthpower mixing to epsilon/sigma
+    if (utils::strmatch(force->pair_style,"^lj/class2"))
+      utils::logmesg(lmp,"Generated {} of {} mixed pair_coeff terms from {}/{} mixing rule\n",
+                     mixed_count, num_mixed_pairs, "sixthpower", mixing_rule_names[mix_flag]);
+    else
+      utils::logmesg(lmp,"Generated {} of {} mixed pair_coeff terms from {} mixing rule\n",
+                     mixed_count, num_mixed_pairs, mixing_rule_names[mix_flag]);
   }
 }
 

--- a/unittest/commands/test_compute_global.cpp
+++ b/unittest/commands/test_compute_global.cpp
@@ -304,7 +304,7 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
         std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable

--- a/unittest/commands/test_delete_atoms.cpp
+++ b/unittest/commands/test_delete_atoms.cpp
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
         std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable

--- a/unittest/commands/test_groups.cpp
+++ b/unittest/commands/test_groups.cpp
@@ -316,9 +316,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/commands/test_kim_commands.cpp
+++ b/unittest/commands/test_kim_commands.cpp
@@ -683,9 +683,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/commands/test_lattice_region.cpp
+++ b/unittest/commands/test_lattice_region.cpp
@@ -634,9 +634,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/commands/test_regions.cpp
+++ b/unittest/commands/test_regions.cpp
@@ -279,7 +279,7 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
         std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable

--- a/unittest/commands/test_reset_ids.cpp
+++ b/unittest/commands/test_reset_ids.cpp
@@ -685,9 +685,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/commands/test_simple_commands.cpp
+++ b/unittest/commands/test_simple_commands.cpp
@@ -552,9 +552,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -585,9 +585,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/cplusplus/test_advanced_utils.cpp
+++ b/unittest/cplusplus/test_advanced_utils.cpp
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
         std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable

--- a/unittest/cplusplus/test_error_class.cpp
+++ b/unittest/cplusplus/test_error_class.cpp
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
         std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable

--- a/unittest/formats/test_file_operations.cpp
+++ b/unittest/formats/test_file_operations.cpp
@@ -494,8 +494,7 @@ int main(int argc, char **argv)
     ::testing::InitGoogleMock(&argc, argv);
 
     if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -303,9 +303,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/formats/test_potential_file_reader.cpp
+++ b/unittest/formats/test_potential_file_reader.cpp
@@ -325,9 +325,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/formats/test_text_file_reader.cpp
+++ b/unittest/formats/test_text_file_reader.cpp
@@ -166,9 +166,8 @@ int main(int argc, char **argv)
     MPI_Init(&argc, &argv);
     ::testing::InitGoogleMock(&argc, argv);
 
-    if (platform::mpi_vendor() == "Open MPI" && !LAMMPS_NS::Info::has_exceptions())
-        std::cout << "Warning: using OpenMPI without exceptions. "
-                     "Death tests will be skipped\n";
+    if (platform::mpi_vendor() == "Open MPI" && !Info::has_exceptions())
+        std::cout << "Warning: using OpenMPI without exceptions. Death tests will be skipped\n";
 
     // handle arguments passed via environment variable
     if (const char *var = getenv("TEST_ARGS")) {

--- a/unittest/python/python-pizza.py
+++ b/unittest/python/python-pizza.py
@@ -120,6 +120,7 @@ class PythonDump(unittest.TestCase):
         self.lmp.command("dump 1 all custom 2 " + dumpfile + " id type mol q x y z vx vy vz")
         self.lmp.command("dump_modify 1 time yes units yes")
         self.lmp.command("run 4 post no")
+        self.lmp.command("undump 1")
         d = dump.dump(dumpfile)
         id1, id2 = d.minmax("id")
         self.assertEqual(id1,1)


### PR DESCRIPTION
**Summary**

This pull request combines multiple small fixes and changes.

**Related Issue(s)**

Addresses incorrectly reported mixing for class 2 pair styles discussed on [MatSci](https://matsci.org/t/question-about-mixed-pair-coeff-terms-from-sixthpower-mixing-rule-in-pcff/44142)

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

The following individual changes are included:
- Unit testing for Python styles on MacOS now requires numpy
- Correct testing for dump class from pizza.py to avoid file access errors on Windows
- Correctly flag and report pair coeff mixing for class 2 pair styles 
- Re-initialize neighbor lists after commands requiring an occasional neighbor list. This avoids passing corrupted neighborlist data if the command is issued multiple times
- Loop optimizations for delete_atoms overlap
- Programming style updates in unit tests for more consistency

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
