### PR TITLE
Update ML-IAP multi-element PyTorch models

### DIFF
--- a/python/lammps/mliap/pytorch.py
+++ b/python/lammps/mliap/pytorch.py
@@ -134,6 +134,9 @@ class TorchWrapper(torch.nn.Module):
         descriptors = torch.from_numpy(descriptors).to(dtype=self.dtype, device=self.device).requires_grad_(True)
         elems = torch.from_numpy(elems).to(dtype=torch.long, device=self.device) - 1
 
+        #print(self.model)
+        #print("ASDFASDF")
+
         with torch.autograd.enable_grad():
 
             energy_nn = self.model(descriptors, elems)
@@ -300,7 +303,7 @@ class ElemwiseModels(torch.nn.Module):
         self.subnets = subnets
         self.n_types = n_types
 
-    def forward(self, descriptors, elems):
+    def forward(self, descriptors, elems, dtype=torch.float64):
         """
         Feeds descriptors to network model after adding zeros into
         descriptor columns relating to different atom types
@@ -319,8 +322,24 @@ class ElemwiseModels(torch.nn.Module):
             Per atom attribute computed by the network model
         """
 
-        per_atom_attributes = torch.zeros(elems.size[0])
+        #print("^^^^^^")
+        #print(elems)
+        #print(elems.size(dim=0))
+        #print(descriptors.dtype)
+
+        self.dtype=dtype
+        self.to(self.dtype)
+        self.subnets[0].to(torch.float64)
+        self.subnets[1].to(torch.float64)
+
+        per_atom_attributes = torch.zeros(elems.size(dim=0), dtype=torch.float64)
+        #print("^^^^^ -----")
+
         given_elems, elem_indices = torch.unique(elems, return_inverse=True)
+        #print(per_atom_attributes.size())
+        #print(elem_indices.size())
         for i, elem in enumerate(given_elems):
-            per_atom_attribute[elem_indices == i] = self.subnets[elem](descriptors[elem_indices == i])
+            #print(descriptors.size())
+            #print(self.subnets[elem](descriptors).flatten().size())
+            per_atom_attributes[elem_indices == i] = self.subnets[elem](descriptors[elem_indices == i]).flatten()
         return per_atom_attributes

--- a/python/lammps/mliap/pytorch.py
+++ b/python/lammps/mliap/pytorch.py
@@ -134,9 +134,6 @@ class TorchWrapper(torch.nn.Module):
         descriptors = torch.from_numpy(descriptors).to(dtype=self.dtype, device=self.device).requires_grad_(True)
         elems = torch.from_numpy(elems).to(dtype=torch.long, device=self.device) - 1
 
-        #print(self.model)
-        #print("ASDFASDF")
-
         with torch.autograd.enable_grad():
 
             energy_nn = self.model(descriptors, elems)

--- a/python/lammps/mliap/pytorch.py
+++ b/python/lammps/mliap/pytorch.py
@@ -322,24 +322,12 @@ class ElemwiseModels(torch.nn.Module):
             Per atom attribute computed by the network model
         """
 
-        #print("^^^^^^")
-        #print(elems)
-        #print(elems.size(dim=0))
-        #print(descriptors.dtype)
-
         self.dtype=dtype
         self.to(self.dtype)
-        self.subnets[0].to(torch.float64)
-        self.subnets[1].to(torch.float64)
 
-        per_atom_attributes = torch.zeros(elems.size(dim=0), dtype=torch.float64)
-        #print("^^^^^ -----")
-
+        per_atom_attributes = torch.zeros(elems.size(dim=0), dtype=self.dtype)
         given_elems, elem_indices = torch.unique(elems, return_inverse=True)
-        #print(per_atom_attributes.size())
-        #print(elem_indices.size())
         for i, elem in enumerate(given_elems):
-            #print(descriptors.size())
-            #print(self.subnets[elem](descriptors).flatten().size())
+            self.subnets[elem].to(self.dtype) 
             per_atom_attributes[elem_indices == i] = self.subnets[elem](descriptors[elem_indices == i]).flatten()
         return per_atom_attributes

--- a/src/ML-IAP/mliap_model_python.cpp
+++ b/src/ML-IAP/mliap_model_python.cpp
@@ -26,6 +26,7 @@
 #include "pair_mliap.h"
 #include "python_compat.h"
 #include "utils.h"
+#include "comm.h"
 
 #include <Python.h>
 
@@ -104,7 +105,7 @@ void MLIAPModelPython::read_coeffs(char *fname)
   if (loaded) {
     this->connect_param_counts();
   } else {
-    utils::logmesg(lmp, "Loading python model deferred.\n");
+    if (comm->me == 0) utils::logmesg(lmp, "Loading python model deferred.\n");
   }
 }
 


### PR DESCRIPTION
**Summary**

This PR ensures working MD simulations using the multi-element PyTorch models that FitSNAP outputs. Also fixed an undeclared variable that prevented the use of multi-element models. The multi-element PyTorch MD examples using LAMMPS are housed in the FitSNAP repo because it's convenient to show how to run MD immediately after training a model.

**Related Issue(s)**

None.

**Author(s)**

Drew Rohskopf (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Does not break backward compatibility.

**Implementation Notes**

Correctness verified by successfully feeding multi-element PyTorch models from FitSNAP, calculating forces, and running MD. Examples are located in the FitSNAP repo https://github.com/FitSNAP/FitSNAP/tree/master/examples

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [x] One or more example input decks are included **(in the FitSNAP repo)**

**Further Information, Files, and Links**

This PR ensures compatibility with the multi-element networks introduced in a recent FitSNAP PR: https://github.com/FitSNAP/FitSNAP/pull/130. These networks have the form 

<img width="612" alt="Picture1" src="https://user-images.githubusercontent.com/11083811/188670047-fd5b460e-618a-4895-bb2c-f3d359058a85.png">





