### PR TITLE
Fix noalias definition so that it compiles with nvc++

### DIFF
--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -256,9 +256,9 @@ union ubuf {
 
 // declaration to lift aliasing restrictions
 
-#if defined(__INTEL_COMPILER) || defined(__PGI)
+#if defined(__INTEL_COMPILER) || (defined(__PGI) && !defined(__NVCOMPILER))
 #define _noalias restrict
-#elif defined(__GNUC__) || defined(__INTEL_LLVM_COMPILER)
+#elif defined(__GNUC__) || defined(__INTEL_LLVM_COMPILER) || defined(__NVCOMPILER)
 #define _noalias __restrict
 #else
 #define _noalias


### PR DESCRIPTION
**Summary**

Fix `_noalias` definition so that it compiles with nvhpc tools.
<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->

**Author(s)**

Vsevolod Nikolskiy (HSE Univeristy)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Keeps

**Implementation Notes**

I ran into a build error on a system with NVHPC toolkit trying to compile LAMMPS with GPU and KOKKOS.
[cmake.log](https://github.com/lammps/lammps/files/9540131/cmake.log)
Minimal demo would be
```
$ cat demo.cpp
#include "lmptype.h"

int main() {
    double * _noalias y;
    return 0;
}

$ nvcc  -ccbin nvc++ -x cu  demo.cpp 
demo.cpp(4): error: expected a ";"

demo.cpp(4): warning: variable "restrict" was declared but never referenced

1 error detected in the compilation of "demo.cpp".
```
This tools combination defines `__PGI`, but does not handle `restrict` in this form, so in the PR I just fix the definition. But the more general question is whether it is the desired behavior that the Kokkos build system passes many unrelated sources (`src/GPU/fix_nh_gpu.cpp` in my example) to`nvcc  -ccbin nvc++ -x cu`?

LAMMPS develop
nvhpc 21.9
cmake 3.22.1
openmpi 4.0.3
gnu7

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->



