### PR TITLE
BUGFIX: address issue with  compilation KOKKOS + pace/extrapolation 

### DIFF
--- a/cmake/Modules/Packages/ML-PACE.cmake
+++ b/cmake/Modules/Packages/ML-PACE.cmake
@@ -1,6 +1,6 @@
-set(PACELIB_URL "https://github.com/ICAMS/lammps-user-pace/archive/refs/tags/v.2022.09.27.tar.gz" CACHE STRING "URL for PACE evaluator library sources")
+set(PACELIB_URL "https://github.com/ICAMS/lammps-user-pace/archive/refs/tags/v.2022.09.27.fix10Oct.tar.gz" CACHE STRING "URL for PACE evaluator library sources")
 
-set(PACELIB_MD5 "ad6c8597076479bd55059f5947d51acc" CACHE STRING "MD5 checksum of PACE evaluator library tarball")
+set(PACELIB_MD5 "766cebcc0e5c4b8430c2f3cd202d9905" CACHE STRING "MD5 checksum of PACE evaluator library tarball")
 mark_as_advanced(PACELIB_URL)
 mark_as_advanced(PACELIB_MD5)
 

--- a/lib/pace/Install.py
+++ b/lib/pace/Install.py
@@ -18,11 +18,11 @@ from install_helpers import fullpath, geturl, checkmd5sum
 # settings
 
 thisdir = fullpath('.')
-version ='v.2022.09.27'
+version ='v.2022.09.27.fix10Oct'
 
 # known checksums for different PACE versions. used to validate the download.
 checksums = { \
-    'v.2022.09.27': 'ad6c8597076479bd55059f5947d51acc'
+    'v.2022.09.27.fix10Oct': '766cebcc0e5c4b8430c2f3cd202d9905'
 }
 
 parser = ArgumentParser(prog='Install.py',


### PR DESCRIPTION
**Summary**

BUGFIX: address issue with  compilation KOKKOS + pace/extrapolation in wigner_3j.hpp) by moving #include "wigner_3j.hpp" from ace_clebsch_gordan.h to .cpp (in https://github.com/ICAMS/lammps-user-pace/commit/c69a9e7041e3dca2cb040d8f26938a56716070a3)

**Related Issue(s)**

Compilation issue with KOKKOS and pace/extrapolation : https://github.com/lammps/lammps/pull/3315#issuecomment-1272147879


**Author(s)**

Yury Lysogorskiy

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**


**Implementation Notes**


**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**




