### PR TITLE
Bond/react: create atoms error check

### DIFF
--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -404,6 +404,12 @@ atoms are present. The velocity of each created atom is initialized in
 a random direction with a magnitude calculated from the instantaneous
 temperature of the reaction site.
 
+.. note::
+
+   The 'Coords' section must be included in the post-reaction template
+   when creating atoms because these coordinates are used to determine
+   where new atoms are inserted.
+
 The handedness of atoms that are chiral centers can be enforced by
 listing their IDs in the ChiralIDs section. A chiral atom must be
 bonded to four atoms with mutually different atom types. This feature

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -4302,7 +4302,7 @@ void FixBondReact::write_restart(FILE *fp)
   set[0].nreacts = nreacts;
   for (int i = 0; i < nreacts; i++) {
     set[i].reaction_count_total = reaction_count_total[i];
-    strncpy(set[i].rxn_name,rxn_name[i],MAXLINE);
+    strncpy(set[i].rxn_name,rxn_name[i],MAXLINE-1);
     set[i].rxn_name[MAXLINE-1] = '\0';
   }
 

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -3937,6 +3937,8 @@ void FixBondReact::CreateAtoms(char *line, int myrxn)
     sscanf(line,"%d",&tmp);
     create_atoms[tmp-1][myrxn] = 1;
   }
+  if (twomol->xflag == 0)
+    error->one(FLERR,"Fix bond/react: 'Coords' section required in post-reaction template when creating new atoms");
 }
 
 void FixBondReact::CustomCharges(int ifragment, int myrxn)

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -287,14 +287,13 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
     groupbits[rxn] = group->bitmask[groupid];
 
     if (strncmp(arg[iarg],"v_",2) == 0) {
-      char *str = utils::strdup(&arg[iarg][2]);
+      const char *str = &arg[iarg][2];
       var_id[NEVERY][rxn] = input->variable->find(str);
       if (var_id[NEVERY][rxn] < 0)
-        error->all(FLERR,"Fix bond/react: Variable name does not exist");
+        error->all(FLERR,"Fix bond/react: Variable name {} does not exist", str);
       if (!input->variable->equalstyle(var_id[NEVERY][rxn]))
-        error->all(FLERR,"Fix bond/react: Variable is not equal-style");
+        error->all(FLERR,"Fix bond/react: Variable {} is not equal-style", str);
       var_flag[NEVERY][rxn] = 1;
-      delete [] str;
     } else {
       nevery[rxn] = utils::inumeric(FLERR,arg[iarg],false,lmp);
       if (nevery[rxn] <= 0) error->all(FLERR,"Illegal fix bond/react command: "
@@ -303,16 +302,15 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
     iarg++;
 
     if (strncmp(arg[iarg],"v_",2) == 0) {
-      char *str = utils::strdup(&arg[iarg][2]);
+      const char *str = &arg[iarg][2];
       var_id[RMIN][rxn] = input->variable->find(str);
       if (var_id[RMIN][rxn] < 0)
-        error->all(FLERR,"Fix bond/react: Variable name does not exist");
+        error->all(FLERR,"Fix bond/react: Variable name {} does not exist", str);
       if (!input->variable->equalstyle(var_id[RMIN][rxn]))
-        error->all(FLERR,"Fix bond/react: Variable is not equal-style");
+        error->all(FLERR,"Fix bond/react: Variable {} is not equal-style", str);
       double cutoff = input->variable->compute_equal(var_id[RMIN][rxn]);
       cutsq[rxn][0] = cutoff*cutoff;
       var_flag[RMIN][rxn] = 1;
-      delete [] str;
     } else {
       double cutoff = utils::numeric(FLERR,arg[iarg],false,lmp);
       if (cutoff < 0.0) error->all(FLERR,"Illegal fix bond/react command: "
@@ -322,16 +320,15 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
     iarg++;
 
     if (strncmp(arg[iarg],"v_",2) == 0) {
-      char *str = utils::strdup(&arg[iarg][2]);
+      const char *str = &arg[iarg][2];
       var_id[RMAX][rxn] = input->variable->find(str);
       if (var_id[RMAX][rxn] < 0)
-        error->all(FLERR,"Fix bond/react: Variable name does not exist");
+        error->all(FLERR,"Fix bond/react: Variable name {} does not exist", str);
       if (!input->variable->equalstyle(var_id[RMAX][rxn]))
-        error->all(FLERR,"Fix bond/react: Variable is not equal-style");
+        error->all(FLERR,"Fix bond/react: Variable is {} not equal-style", str);
       double cutoff = input->variable->compute_equal(var_id[RMAX][rxn]);
       cutsq[rxn][1] = cutoff*cutoff;
       var_flag[RMAX][rxn] = 1;
-      delete [] str;
     } else {
       double cutoff = utils::numeric(FLERR,arg[iarg],false,lmp);
       if (cutoff < 0.0) error->all(FLERR,"Illegal fix bond/react command:"
@@ -347,7 +344,7 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
     if (reacted_mol[rxn] == -1) error->all(FLERR,"Reacted molecule template ID for "
                                            "fix bond/react does not exist");
 
-    //read superimpose file
+    // read superimpose file
     files[rxn] = utils::strdup(arg[iarg]);
     iarg++;
 
@@ -357,15 +354,14 @@ FixBondReact::FixBondReact(LAMMPS *lmp, int narg, char **arg) :
                                       "'prob' keyword has too few arguments");
         // check if probability is a variable
         if (strncmp(arg[iarg+1],"v_",2) == 0) {
-          char *str = utils::strdup(&arg[iarg+1][2]);
+          const char *str = &arg[iarg+1][2];
           var_id[PROB][rxn] = input->variable->find(str);
           if (var_id[PROB][rxn] < 0)
-            error->all(FLERR,"Fix bond/react: Variable name does not exist");
+            error->all(FLERR,"Fix bond/react: Variable name {} does not exist", str);
           if (!input->variable->equalstyle(var_id[PROB][rxn]))
-            error->all(FLERR,"Fix bond/react: Variable is not equal-style");
+            error->all(FLERR,"Fix bond/react: Variable {} is not equal-style", str);
           fraction[rxn] = input->variable->compute_equal(var_id[PROB][rxn]);
           var_flag[PROB][rxn] = 1;
-          delete [] str;
         } else {
           // otherwise probability should be a number
           fraction[rxn] = utils::numeric(FLERR,arg[iarg+1],false,lmp);
@@ -2216,7 +2212,6 @@ double FixBondReact::custom_constraint(const std::string& varstr)
   std::size_t pos,pos1,pos2,pos3;
   int irxnfunc;
   int prev3 = -1;
-  double val;
   std::string argstr,varid,fragid,evlcat;
   std::vector<std::string> evlstr;
 
@@ -2253,11 +2248,7 @@ double FixBondReact::custom_constraint(const std::string& varstr)
   evlstr.push_back(varstr.substr(prev3+1));
 
   for (auto & evl : evlstr) evlcat += evl;
-
-  char *cstr = utils::strdup(evlcat);
-  val = input->variable->compute_equal(cstr);
-  delete [] cstr;
-  return val;
+  return input->variable->compute_equal(evlcat.c_str());
 }
 
 /* ----------------------------------------------------------------------

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -1735,7 +1735,16 @@ void FixBondReact::inner_crosscheck_loop()
   // ...actually, avail_guesses should never be zero here anyway
   if (guess_branch[avail_guesses-1] == 0) guess_branch[avail_guesses-1] = num_choices;
 
-  std::sort(tag_choices, tag_choices + num_choices);
+  for (int i=1; i < num_choices; ++i) {
+    tagint hold = tag_choices[i];
+    int j = i - 1;
+    while ((j >=0) && (tag_choices[j] > hold)) {
+      tag_choices[j+1] = tag_choices[j];
+      --j;
+    }
+    tag_choices[j+1] = hold;
+  }
+
   for (int i = guess_branch[avail_guesses-1]-1; i >= 0; i--) {
     int already_assigned = 0;
     for (int j = 0; j < onemol->natoms; j++) {


### PR DESCRIPTION
**Summary**

add error check to ensure coordinates are included in the post-reaction template when creating atoms. previously, neglecting this would cause segfault

**Related Issue(s)**

none

**Author(s)**

Jake

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


