### PR TITLE
Update pair_threebody_table.cpp

### DIFF
--- a/src/MANYBODY/pair_threebody_table.cpp
+++ b/src/MANYBODY/pair_threebody_table.cpp
@@ -708,7 +708,7 @@ void PairThreebodyTable::uf_lookup(Param *pm, double r12, double r13, double the
     if (r13 == (pm->mltable->rmin - 0.5 * dr)) nr13 = 0;
     nr13 -= nr12;
     ntheta = (theta - 0.00000001) / dtheta;
-    if (theta == 180.0) ntheta = (pm->mltable->ninput * 2) - 1;
+    if (theta >= 180.0) ntheta = (pm->mltable->ninput * 2) - 1;
     itable = 0;
     for (i = 0; i < nr12; i++) itable += (pm->mltable->ninput - i);
     itable += nr13;
@@ -721,7 +721,7 @@ void PairThreebodyTable::uf_lookup(Param *pm, double r12, double r13, double the
     nr13 = (r13 - pm->mltable->rmin + 0.5 * dr - 0.00000001) / dr;
     if (r13 == (pm->mltable->rmin - 0.5 * dr)) nr13 = 0;
     ntheta = (theta - 0.00000001) / dtheta;
-    if (theta == 180.0) ntheta = (pm->mltable->ninput * 2) - 1;
+    if (theta >= 180.0) ntheta = (pm->mltable->ninput * 2) - 1;
     itable = nr12 * (pm->mltable->ninput);
     itable += nr13;
     itable *= (pm->mltable->ninput * 2);

--- a/src/MANYBODY/pair_threebody_table.cpp
+++ b/src/MANYBODY/pair_threebody_table.cpp
@@ -445,7 +445,7 @@ void PairThreebodyTable::read_table(Table *tb, char *file, char *keyword, bool s
 
   char *line = reader.find_section_start(keyword);
 
-  if (!line) { error->one(FLERR, "Did not find keyword in table file"); }
+  if (!line) error->one(FLERR, "Did not find keyword in table file");
 
   // read args on 2nd line of section
   // allocate table arrays for file values
@@ -703,25 +703,25 @@ void PairThreebodyTable::uf_lookup(Param *pm, double r12, double r13, double the
   // if it is a symmetric threebody interaction, less table entries are required
   if (pm->symmetric) {
     nr12 = (r12 - pm->mltable->rmin + 0.5 * dr - 0.00000001) / dr;
-    if (r12 == (pm->mltable->rmin - 0.5 * dr)) { nr12 = 0; }
+    if (r12 == (pm->mltable->rmin - 0.5 * dr)) nr12 = 0;
     nr13 = (r13 - pm->mltable->rmin + 0.5 * dr - 0.00000001) / dr;
-    if (r13 == (pm->mltable->rmin - 0.5 * dr)) { nr13 = 0; }
+    if (r13 == (pm->mltable->rmin - 0.5 * dr)) nr13 = 0;
     nr13 -= nr12;
     ntheta = (theta - 0.00000001) / dtheta;
-    if (theta == 180.0) { ntheta = (pm->mltable->ninput * 2)-1; }
+    if (theta == 180.0) ntheta = (pm->mltable->ninput * 2) - 1;
     itable = 0;
-    for (i = 0; i < nr12; i++) { itable += (pm->mltable->ninput - i); }
+    for (i = 0; i < nr12; i++) itable += (pm->mltable->ninput - i);
     itable += nr13;
     itable *= (pm->mltable->ninput * 2);
     itable += ntheta;
   } else {
     // else, more (full) table entries are required
     nr12 = (r12 - pm->mltable->rmin + 0.5 * dr - 0.00000001) / dr;
-    if (r12 == (pm->mltable->rmin - 0.5 * dr)) { nr12 = 0; }
+    if (r12 == (pm->mltable->rmin - 0.5 * dr)) nr12 = 0;
     nr13 = (r13 - pm->mltable->rmin + 0.5 * dr - 0.00000001) / dr;
-    if (r13 == (pm->mltable->rmin - 0.5 * dr)) { nr13 = 0; }
+    if (r13 == (pm->mltable->rmin - 0.5 * dr)) nr13 = 0;
     ntheta = (theta - 0.00000001) / dtheta;
-    if (theta == 180.0) { ntheta = (pm->mltable->ninput * 2)-1; }
+    if (theta == 180.0) ntheta = (pm->mltable->ninput * 2) - 1;
     itable = nr12 * (pm->mltable->ninput);
     itable += nr13;
     itable *= (pm->mltable->ninput * 2);

--- a/src/MANYBODY/pair_threebody_table.cpp
+++ b/src/MANYBODY/pair_threebody_table.cpp
@@ -708,7 +708,7 @@ void PairThreebodyTable::uf_lookup(Param *pm, double r12, double r13, double the
     if (r13 == (pm->mltable->rmin - 0.5 * dr)) { nr13 = 0; }
     nr13 -= nr12;
     ntheta = (theta - 0.00000001) / dtheta;
-    if (theta == 180.0) { ntheta = 79; }
+    if (theta == 180.0) { ntheta = (pm->mltable->ninput * 2)-1; }
     itable = 0;
     for (i = 0; i < nr12; i++) { itable += (pm->mltable->ninput - i); }
     itable += nr13;
@@ -721,7 +721,7 @@ void PairThreebodyTable::uf_lookup(Param *pm, double r12, double r13, double the
     nr13 = (r13 - pm->mltable->rmin + 0.5 * dr - 0.00000001) / dr;
     if (r13 == (pm->mltable->rmin - 0.5 * dr)) { nr13 = 0; }
     ntheta = (theta - 0.00000001) / dtheta;
-    if (theta == 180.0) { ntheta = 79; }
+    if (theta == 180.0) { ntheta = (pm->mltable->ninput * 2)-1; }
     itable = nr12 * (pm->mltable->ninput);
     itable += nr13;
     itable *= (pm->mltable->ninput * 2);


### PR DESCRIPTION
Correcting for hard coded ntheta = 79 in the extreme case that theta is exactly equal to 180.0 degrees.

**Summary**

I have been made aware that in the extreme case of theta exactly being equal to 180.0 degrees the bin number still had been hard coded into the code. I corrected for it now.

**Related Issue(s)**

As far as I know there is no related issue

**Author(s)**

Christoph Scherer, Max Planck Institute for Polymer Research, Mainz

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

To my knowledge this correction will not break any backward compatibility

**Implementation Notes**

Implementation has been done by me by hand and has been tested.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


