### PR TITLE
BUGFIX:  fix pair  and empty spatial domains

### DIFF
--- a/doc/src/pair_pace.rst
+++ b/doc/src/pair_pace.rst
@@ -112,7 +112,7 @@ requests to compute `gamma`, as shown in example below:
     compute max_pace_gamma all reduce max f_pace_gamma
     variable dump_skip equal "c_max_pace_gamma < 5"
 
-    dump pace_dump all custom 20 extrapolative_structures.dump id x y z f_pace_gamma
+    dump pace_dump all custom 20 extrapolative_structures.dump id type x y z f_pace_gamma
     dump_modify pace_dump skip v_dump_skip
 
     variable max_pace_gamma equal c_max_pace_gamma

--- a/src/fix_pair.cpp
+++ b/src/fix_pair.cpp
@@ -247,7 +247,8 @@ void FixPair::post_force(int /*vflag*/)
 
   for (int ifield = 0; ifield < nfield; ifield++) {
     void *pvoid = pstyle->extract_peratom(fieldname[ifield],columns);
-    if (pvoid == nullptr)
+    //pvoid could return nullptr if no atoms in current spatial domain
+    if (pvoid == nullptr && nlocal>0)
       error->all(FLERR,"Fix pair pair style cannot extract {}",fieldname[ifield]);
 
     if (columns == 0) {

--- a/src/fix_pair.cpp
+++ b/src/fix_pair.cpp
@@ -240,16 +240,19 @@ void FixPair::post_force(int /*vflag*/)
   // extract pair style fields one by one
   // store their values in this fix
 
-  int nlocal = atom->nlocal;
+  const int nlocal = atom->nlocal;
 
   int icol = 0;
   int columns;
 
   for (int ifield = 0; ifield < nfield; ifield++) {
     void *pvoid = pstyle->extract_peratom(fieldname[ifield],columns);
-    //pvoid could return nullptr if no atoms in current spatial domain
-    if (pvoid == nullptr && nlocal>0)
-      error->all(FLERR,"Fix pair pair style cannot extract {}",fieldname[ifield]);
+
+    // Pair::extract_peratom() may return a null pointer if there are no atoms the sub-domain
+    // so returning null is only an error if there are local atoms.
+
+    if ((pvoid == nullptr) && (nlocal > 0))
+      error->one(FLERR, "Fix pair cannot extract property {} from pair style", fieldname[ifield]);
 
     if (columns == 0) {
       double *pvector = (double *) pvoid;


### PR DESCRIPTION
**Summary**

Currently  `fix pair` try to raise error when current spatial domain has no atoms  
BUGFIX: raise error only if  nlocal>0  in current spatial domain but extracted per-atom array is still nullptr

**Related Issue(s)**

**Author(s)**

Yury Lysogorskiy

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

in FixPair::post_force  raise error only if  nlocal>0  in current spatial domain but extracted per-atom array is still nullptr

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


