### PR TITLE
Refactor python source command and error reporting

### DIFF
--- a/doc/src/python.rst
+++ b/doc/src/python.rst
@@ -87,15 +87,15 @@ Examples
 Description
 """""""""""
 
-The *python* command allows to interface LAMMPS with an embedded Python
+The *python* command allows interfacing LAMMPS with an embedded Python
 interpreter and enables either executing arbitrary python code in that
 interpreter, registering a Python function for future execution (as a
-python style variable, from a fix interfaced with python or for direct
+python style variable, from a fix interfaced with python, or for direct
 invocation), or invoking such a previously registered function.
 
 Arguments, including LAMMPS variables, can be passed to the function
 from the LAMMPS input script and a value returned by the Python function
-to a LAMMPS variable.  The Python code for the function can be included
+assigned to a LAMMPS variable.  The Python code for the function can be included
 directly in the input script or in a separate Python file.  The function
 can be standard Python code or it can make "callbacks" to LAMMPS through
 its library interface to query or set internal values within LAMMPS.
@@ -132,14 +132,16 @@ of the python command.
 If the *source* keyword is used, it is followed by either a file name or
 the *here* keyword.  No other keywords can be used.  The *here* keyword
 is followed by a string with python commands, either on a single line
-enclosed in quotes, or as multiple lines enclosed in triple
-quotes.  These Python commands will be passed to the python interpreter
-and executed immediately without registering a Python function for
-future execution.  This allows to run arbitrary Python code at any
-time while processing the LAMMPS input file.  This can be used to pre-load
-Python modules, initialize global variables or perform operations
-using the python programming language.  The Python code will be executed
-in parallel on all MPI processes.  No arguments can be passed.
+enclosed in quotes, or as multiple lines enclosed in triple quotes.
+These Python commands will be passed to the python interpreter and
+executed immediately without registering a Python function for future
+execution.  The code will be loaded into and run in the "main" module of
+the Python interpreter.  This allows running arbitrary Python code at
+any time while processing the LAMMPS input file.  This can be used to
+pre-load Python modules, initialize global variables, define functions
+or classes, or perform operations using the python programming language.
+The Python code will be executed in parallel on all MPI processes.  No
+arguments can be passed.
 
 In all other cases, the first argument is the name of a Python function
 that will be registered with LAMMPS for future execution.  The function
@@ -225,7 +227,8 @@ one of them.  These keywords specify what Python code to load into the
 Python interpreter.  The *file* keyword gives the name of a file
 containing Python code, which should end with a ".py" suffix.  The code
 will be immediately loaded into and run in the "main" module of the
-Python interpreter.  Note that Python code which contains a function
+Python interpreter.  The Python code will be executed in parallel on all
+MPI processes.  Note that Python code which contains a function
 definition does not "execute" the function when it is run; it simply
 defines the function so that it can be invoked later.
 

--- a/doc/src/python.rst
+++ b/doc/src/python.rst
@@ -88,10 +88,10 @@ Description
 """""""""""
 
 The *python* command allows to interface LAMMPS with an embedded Python
-interpreter and enabled to either execute arbitrary python code in that
-interpreter, register a Python function for future execution (as a python
-style variable, from a fix interfaced with python or for direct
-invocation), or invoke such a previously registered function.
+interpreter and enables either executing arbitrary python code in that
+interpreter, registering a Python function for future execution (as a
+python style variable, from a fix interfaced with python or for direct
+invocation), or invoking such a previously registered function.
 
 Arguments, including LAMMPS variables, can be passed to the function
 from the LAMMPS input script and a value returned by the Python function

--- a/doc/src/python.rst
+++ b/doc/src/python.rst
@@ -8,14 +8,24 @@ Syntax
 
 .. parsed-literal::
 
-   python func keyword args ...
+   python function keyword args ...
 
-* func = name of Python function
-* one or more keyword/args pairs must be appended
+* function = *source* or name of Python function
+
+  if function is *source*:
 
   .. parsed-literal::
 
-     keyword = *invoke* or *input* or *return* or *format* or *length* or *file* or *here* or *exists* or *source*
+     keyword = *inline* or name of a Python file
+         inline = one or more lines of Python code which will be executed immediately
+                  must be a single argument, typically enclosed in triple quotes
+         Python file = name of a file with Python code which will be executed immediately
+
+* if function is the name of a Python function, one or more keyword/args pairs must be appended
+
+  .. parsed-literal::
+
+     keyword = *invoke* or *input* or *return* or *format* or *length* or *file* or *here* or *exists*
        *invoke* arg = none = invoke the previously defined Python function
        *input* args = N i1 i2 ... iN
          N = # of inputs to function
@@ -38,10 +48,6 @@ Syntax
          inline = one or more lines of Python code which defines func
                   must be a single argument, typically enclosed between triple quotes
        *exists* arg = none = Python code has been loaded by previous python command
-       *source* arg = *filename* or *inline*
-         filename = file of Python code which will be executed immediately
-         inline = one or more lines of Python code which will be executed immediately
-                  must be a single argument, typically enclosed between triple quotes
 
 Examples
 """"""""
@@ -70,80 +76,89 @@ Examples
        lmp.command("pair_style lj/cut ${cut}")   # LAMMPS commands
        lmp.command("pair_coeff * * 1.0 1.0")
        lmp.command("run 100")
-    """
+   """
+
+   python source funcdef.py
+
+   python source inline "from lammps import lammps"
+
 
 Description
 """""""""""
 
 Define a Python function or execute a previously defined function or
-execute some arbitrary python code.
-Arguments, including LAMMPS variables, can be passed to the function
-from the LAMMPS input script and a value returned by the Python
-function to a LAMMPS variable.  The Python code for the function can
-be included directly in the input script or in a separate Python file.
-The function can be standard Python code or it can make "callbacks" to
-LAMMPS through its library interface to query or set internal values
-within LAMMPS.  This is a powerful mechanism for performing complex
-operations in a LAMMPS input script that are not possible with the
-simple input script and variable syntax which LAMMPS defines.  Thus
-your input script can operate more like a true programming language.
+execute some arbitrary python code.  Arguments, including LAMMPS
+variables, can be passed to the function from the LAMMPS input script
+and a value returned by the Python function to a LAMMPS variable.  The
+Python code for the function can be included directly in the input
+script or in a separate Python file.  The function can be standard
+Python code or it can make "callbacks" to LAMMPS through its library
+interface to query or set internal values within LAMMPS.  This is a
+powerful mechanism for performing complex operations in a LAMMPS input
+script that are not possible with the simple input script and variable
+syntax which LAMMPS defines.  Thus your input script can operate more
+like a true programming language.
 
 Use of this command requires building LAMMPS with the PYTHON package
 which links to the Python library so that the Python interpreter is
 embedded in LAMMPS.  More details about this process are given below.
 
-There are two ways to invoke a Python function once it has been
-defined.  One is using the *invoke* keyword.  The other is to assign
-the function to a :doc:`python-style variable <variable>` defined in
-your input script.  Whenever the variable is evaluated, it will
-execute the Python function to assign a value to the variable.  Note
-that variables can be evaluated in many different ways within LAMMPS.
-They can be substituted for directly in an input script.  Or they can
-be passed to various commands as arguments, so that the variable is
-evaluated during a simulation run.
+There are two ways to invoke a Python function once it has been defined.
+One is using the *invoke* keyword.  The other is to assign the function
+to a :doc:`python-style variable <variable>` defined in your input
+script.  Whenever the variable is evaluated, it will execute the Python
+function to assign a value to the variable.  Note that variables can be
+evaluated in many different ways within LAMMPS.  They can be substituted
+with their result directly in an input script, or they can be passed to
+various commands as arguments, so that the variable is evaluated during
+a simulation run.
 
-A broader overview of how Python can be used with LAMMPS is given on
-the :doc:`Python <Python_head>` doc page.  There is an examples/python
-directory which illustrates use of the python command.
+A broader overview of how Python can be used with LAMMPS is given in the
+:doc:`Use Python with LAMMPS <Python_head>` section of the
+documentation.  There is an ``examples/python`` directory which
+illustrates use of the python command.
 
 ----------
 
-The *func* setting specifies the name of the Python function.  The
-code for the function is defined using the *file* or *here* keywords
-as explained below. In case of the *source* keyword, the name of
-the function is ignored.
+The first argument of the *python* command is either the *source*
+keyword or the name of a Python function.
+
+If the *source* keyword is used, no other keywords can be used.  The
+argument either can be a filename or the keyword *inline* followed by a
+string with python commands, either on a single line enclosed in quotes,
+or as multiple lines enclosed in triple quotes. These python commands
+will be passed to the python interpreter and executed immediately
+without registering a python function for future execution.
+
+In all other cases, the first argument is the name of a Python function
+that will be registered with LAMMPS for future execution.  The function
+may already be defined (see *exists* keyword) or must be defined using
+the *file* or *here* keywords as explained below.
 
 If the *invoke* keyword is used, no other keywords can be used, and a
-previous python command must have defined the Python function
+previous python command must have registered the Python function
 referenced by this command.  This invokes the Python function with the
-previously defined arguments and return value processed as explained
-below.  You can invoke the function as many times as you wish in your
-input script.
-
-If the *source* keyword is used, no other keywords can be used.
-The argument can be a filename or a string with python commands,
-either on a single line enclosed in quotes, or as multiple lines
-enclosed in triple quotes. These python commands will be passed
-to the python interpreter and executed immediately without registering
-a python function for future execution.
+previously defined arguments and the return value is processed as
+explained below.  You can invoke the function as many times as you wish
+in your input script.
 
 The *input* keyword defines how many arguments *N* the Python function
-expects.  If it takes no arguments, then the *input* keyword should
-not be used.  Each argument can be specified directly as a value,
-e.g. 6 or 3.14159 or abc (a string of characters).  The type of each
-argument is specified by the *format* keyword as explained below, so
-that Python will know how to interpret the value.  If the word SELF is
-used for an argument it has a special meaning.  A pointer is passed to
-the Python function which it converts into a reference to LAMMPS
-itself.  This enables the function to call back to LAMMPS through its
-library interface as explained below.  This allows the Python function
-to query or set values internal to LAMMPS which can affect the
-subsequent execution of the input script.  A LAMMPS variable can also
-be used as an argument, specified as v_name, where "name" is the name
-of the variable.  Any style of LAMMPS variable can be used, as defined
-by the :doc:`variable <variable>` command.  Each time the Python
-function is invoked, the LAMMPS variable is evaluated and its value is
-passed to the Python function.
+expects.  If it takes no arguments, then the *input* keyword should not
+be used.  Each argument can be specified directly as a value, e.g. 6 or
+3.14159 or abc (a string of characters).  The type of each argument is
+specified by the *format* keyword as explained below, so that Python
+will know how to interpret the value.  If the word SELF is used for an
+argument it has a special meaning.  A pointer is passed to the Python
+function which it converts into a reference to LAMMPS itself.  This
+enables the function to call back to LAMMPS through its library
+interface as explained below.  This allows the Python function to query
+or set values internal to LAMMPS which can affect the subsequent
+execution of the input script.  A LAMMPS variable can also be used as an
+argument, specified as v_name, where "name" is the name of the variable.
+Any style of LAMMPS variable can be used, as defined by the
+:doc:`variable <variable>` command.  Each time the Python function is
+invoked, the LAMMPS variable is evaluated and its value is passed to the
+Python function.
 
 The *return* keyword is only needed if the Python function returns a
 value.  The specified *varReturn* must be of the form v_name, where
@@ -165,19 +180,19 @@ The two commands can appear in either order in the input script so
 long as both are specified before the Python function is invoked for
 the first time.
 
-The *format* keyword must be used if the *input* or *return* keyword
-is used.  It defines an *fstring* with M characters, where M = sum of
+The *format* keyword must be used if the *input* or *return* keyword is
+used.  It defines an *fstring* with M characters, where M = sum of
 number of inputs and outputs.  The order of characters corresponds to
 the N inputs, followed by the return value (if it exists).  Each
 character must be one of the following: "i" for integer, "f" for
-floating point, "s" for string, or "p" for SELF.  Each character
-defines the type of the corresponding input or output value of the
-Python function and affects the type conversion that is performed
-internally as data is passed back and forth between LAMMPS and Python.
-Note that it is permissible to use a :doc:`python-style variable <variable>` in a LAMMPS command that allows for an
-equal-style variable as an argument, but only if the output of the
-Python function is flagged as a numeric value ("i" or "f") via the
-*format* keyword.
+floating point, "s" for string, or "p" for SELF.  Each character defines
+the type of the corresponding input or output value of the Python
+function and affects the type conversion that is performed internally as
+data is passed back and forth between LAMMPS and Python.  Note that it
+is permissible to use a :doc:`python-style variable <variable>` in a
+LAMMPS command that allows for an equal-style variable as an argument,
+but only if the output of the Python function is flagged as a numeric
+value ("i" or "f") via the *format* keyword.
 
 If the *return* keyword is used and the *format* keyword specifies the
 output as a string, then the default maximum length of that string is
@@ -192,12 +207,12 @@ truncated.
 
 Either the *file*, *here*, or *exists* keyword must be used, but only
 one of them.  These keywords specify what Python code to load into the
-Python interpreter.  The *file* keyword gives the name of a file,
-which should end with a ".py" suffix, which contains Python code.  The
-code will be immediately loaded into and run in the "main" module of
-the Python interpreter.  Note that Python code which contains a
-function definition does not "execute" the function when it is run; it
-simply defines the function so that it can be invoked later.
+Python interpreter.  The *file* keyword gives the name of a file
+containing Python code, which should end with a ".py" suffix.  The code
+will be immediately loaded into and run in the "main" module of the
+Python interpreter.  Note that Python code which contains a function
+definition does not "execute" the function when it is run; it simply
+defines the function so that it can be invoked later.
 
 The *here* keyword does the same thing, except that the Python code
 follows as a single argument to the *here* keyword.  This can be done
@@ -208,14 +223,15 @@ proper indentation, blank lines, and comments, as desired.  See the
 how triple quotes can be used as part of input script syntax.
 
 The *exists* keyword takes no argument.  It means that Python code
-containing the required Python function defined by the *func* setting,
-is assumed to have been previously loaded by another python command.
+containing the required Python function with the given name has already
+been executed, for example by a *python source* command or in the same
+file that was used previously with the *file* keyword.
 
-Note that the Python code that is loaded and run must contain a
-function with the specified *func* name.  To operate properly when
-later invoked, the function code must match the *input* and
-*return* and *format* keywords specified by the python command.
-Otherwise Python will generate an error.
+Note that the Python code that is loaded and run must contain a function
+with the specified function name.  To operate properly when later
+invoked, the function code must match the *input* and *return* and
+*format* keywords specified by the python command.  Otherwise Python
+will generate an error.
 
 ----------
 
@@ -225,19 +241,18 @@ LAMMPS.
 Whether you load Python code from a file or directly from your input
 script, via the *file* and *here* keywords, the code can be identical.
 It must be indented properly as Python requires.  It can contain
-comments or blank lines.  If the code is in your input script, it
-cannot however contain triple-quoted Python strings, since that will
-conflict with the triple-quote parsing that the LAMMPS input script
-performs.
+comments or blank lines.  If the code is in your input script, it cannot
+however contain triple-quoted Python strings, since that will conflict
+with the triple-quote parsing that the LAMMPS input script performs.
 
 All the Python code you specify via one or more python commands is
 loaded into the Python "main" module, i.e. __main__.  The code can
 define global variables or statements that are outside of function
 definitions.  It can contain multiple functions, only one of which
 matches the *func* setting in the python command.  This means you can
-use the *file* keyword once to load several functions, and the
-*exists* keyword thereafter in subsequent python commands to access
-the other functions previously loaded.
+use the *file* keyword once to load several functions, and the *exists*
+keyword thereafter in subsequent python commands to access the other
+functions previously loaded.
 
 A Python function you define (or more generally, the code you load)
 can import other Python modules or classes, it can make calls to other
@@ -495,23 +510,34 @@ Restrictions
 """"""""""""
 
 This command is part of the PYTHON package.  It is only enabled if
-LAMMPS was built with that package.  See the :doc:`Build package <Build_package>` page for more info.
+LAMMPS was built with that package.  See the :doc:`Build package
+<Build_package>` page for more info.
 
-Building LAMMPS with the PYTHON package will link LAMMPS with the
-Python library on your system.  Settings to enable this are in the
+Building LAMMPS with the PYTHON package will link LAMMPS with the Python
+library on your system.  Settings to enable this are in the
 lib/python/Makefile.lammps file.  See the lib/python/README file for
 information on those settings.
 
-If you use Python code which calls back to LAMMPS, via the SELF input argument
-explained above, there is an extra step required when building LAMMPS.  LAMMPS
-must also be built as a shared library and your Python function must be able to
-load the :doc:`"lammps" Python module <Python_module>` that wraps the LAMMPS
-library interface.  These are the same steps required to use Python by itself
-to wrap LAMMPS.  Details on these steps are explained on the :doc:`Python
-<Python_head>` doc page.  Note that it is important that the stand-alone LAMMPS
-executable and the LAMMPS shared library be consistent (built from the same
-source code files) in order for this to work.  If the two have been built at
+If you use Python code which calls back to LAMMPS, via the SELF input
+argument explained above, there is an extra step required when building
+LAMMPS.  LAMMPS must also be built as a shared library and your Python
+function must be able to load the :doc:`"lammps" Python module
+<Python_module>` that wraps the LAMMPS library interface.  These are the
+same steps required to use Python by itself to wrap LAMMPS.  Details on
+these steps are explained on the :doc:`Python <Python_head>` doc page.
+Note that it is important that the stand-alone LAMMPS executable and the
+LAMMPS shared library be consistent (built from the same source code
+files) in order for this to work.  If the two have been built at
 different times using different source files, problems may occur.
+
+Another limitation of calling back to Python from the LAMMPS module
+using the *python* command in a LAMMPS input is that both, the Python
+interpreter and LAMMPS, must be linked to the same Python runtime as a
+shared library.  If the Python interpreter is linked to Python
+statically (which seems to happen with Conda) then loading the shared
+LAMMPS library will create a second python "main" module that hides the
+one from the Python interpreter and all previous defined function and
+global variables will become invisible.
 
 Related commands
 """"""""""""""""

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -2248,6 +2248,7 @@ MxN
 myCompute
 myIndex
 mylammps
+myMultiply
 MyPool
 mysocket
 mySpin
@@ -2473,7 +2474,7 @@ nsq
 Nstart
 nstats
 Nstep
-Nsteplast
+nsteplast
 Nstop
 nsub
 Nsw
@@ -2503,7 +2504,7 @@ numpy
 Numpy
 Nurdin
 Nvalue
-Nvaluelast
+nvaluelast
 Nvalues
 nvc
 nvcc

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -112,18 +112,18 @@ PythonImpl::~PythonImpl()
 
 void PythonImpl::command(int narg, char **arg)
 {
-  if (narg < 2) error->all(FLERR, "Invalid python command");
+  if (narg < 2) utils::missing_cmd_args(FLERR, "python", error);
 
   // if invoke is only keyword, invoke the previously defined function
 
   if (narg == 2 && strcmp(arg[1], "invoke") == 0) {
     int ifunc = find(arg[0]);
-    if (ifunc < 0) error->all(FLERR, "Python invoke of undefined function");
+    if (ifunc < 0) error->all(FLERR, "Python invoke of undefined function: {}", arg[0]);
 
     char *str = nullptr;
     if (pfuncs[ifunc].noutput) {
       str = input->variable->pythonstyle(pfuncs[ifunc].ovarname, pfuncs[ifunc].name);
-      if (!str) error->all(FLERR, "Python variable does not match Python function");
+      if (!str) error->all(FLERR, "Python variable {} does not match variable {} registered with Python function {}",arg[0], pfuncs[ifunc].ovarname, pfuncs[ifunc].name);
     }
 
     invoke_function(ifunc, str);
@@ -363,9 +363,9 @@ int PythonImpl::variable_match(const char *name, const char *varname, int numeri
 {
   int ifunc = find(name);
   if (ifunc < 0) return -1;
-  if (pfuncs[ifunc].noutput == 0) return -1;
-  if (strcmp(pfuncs[ifunc].ovarname, varname) != 0) return -1;
-  if (numeric && pfuncs[ifunc].otype == STRING) return -1;
+  if (pfuncs[ifunc].noutput == 0) return -2;
+  if (strcmp(pfuncs[ifunc].ovarname, varname) != 0) return -3;
+  if (numeric && pfuncs[ifunc].otype == STRING) return -4;
   return ifunc;
 }
 

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -139,7 +139,7 @@ void PythonImpl::command(int narg, char **arg)
   if ((narg > 1) && (strcmp(arg[0], "source") == 0)) {
     int err = -1;
 
-    if ((narg > 2) && (strcmp(arg[1], "inline") == 0)) {
+    if ((narg > 2) && (strcmp(arg[1], "here") == 0)) {
       err = execute_string(arg[2]);
     } else {
       if (platform::file_is_readable(arg[1]))

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -118,12 +118,16 @@ void PythonImpl::command(int narg, char **arg)
 
   if (narg == 2 && strcmp(arg[1], "invoke") == 0) {
     int ifunc = find(arg[0]);
-    if (ifunc < 0) error->all(FLERR, "Python invoke of undefined function: {}", arg[0]);
+    if (ifunc < 0) error->all(FLERR, "Python invoke of unknown function: {}", arg[0]);
 
     char *str = nullptr;
     if (pfuncs[ifunc].noutput) {
       str = input->variable->pythonstyle(pfuncs[ifunc].ovarname, pfuncs[ifunc].name);
-      if (!str) error->all(FLERR, "Python variable {} does not match variable {} registered with Python function {}",arg[0], pfuncs[ifunc].ovarname, pfuncs[ifunc].name);
+      if (!str)
+        error->all(FLERR,
+                   "Python variable {} does not match variable {} "
+                   "registered with Python function {}",
+                   arg[0], pfuncs[ifunc].ovarname, pfuncs[ifunc].name);
     }
 
     invoke_function(ifunc, str);
@@ -138,9 +142,12 @@ void PythonImpl::command(int narg, char **arg)
     if ((narg > 2) && (strcmp(arg[1], "inline") == 0)) {
       err = execute_string(arg[2]);
     } else {
-      if (platform::file_is_readable(arg[1])) err = execute_file(arg[1]);
+      if (platform::file_is_readable(arg[1]))
+        err = execute_file(arg[1]);
+      else
+        error->all(FLERR, "Could not open python source file {} for processing", arg[1]);
     }
-    if (err) error->warning(FLERR, "Could not process Python source command. Error code: {}", err);
+    if (err) error->all(FLERR, "Failure in python source command");
 
     return;
   }
@@ -160,48 +167,51 @@ void PythonImpl::command(int narg, char **arg)
   int iarg = 1;
   while (iarg < narg) {
     if (strcmp(arg[iarg], "input") == 0) {
-      if (iarg + 2 > narg) error->all(FLERR, "Invalid python command");
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python input", error);
       ninput = utils::inumeric(FLERR, arg[iarg + 1], false, lmp);
-      if (ninput < 0) error->all(FLERR, "Invalid python command");
+      if (ninput < 0) error->all(FLERR, "Invalid number of python input arguments: {}", ninput);
       iarg += 2;
       delete[] istr;
       istr = new char *[ninput];
-      if (iarg + ninput > narg) error->all(FLERR, "Invalid python command");
+      if (iarg + ninput > narg) utils::missing_cmd_args(FLERR, "python input", error);
       for (int i = 0; i < ninput; i++) istr[i] = arg[iarg + i];
       iarg += ninput;
     } else if (strcmp(arg[iarg], "return") == 0) {
-      if (iarg + 2 > narg) error->all(FLERR, "Invalid python command");
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python return", error);
       noutput = 1;
       ostr = arg[iarg + 1];
       iarg += 2;
     } else if (strcmp(arg[iarg], "format") == 0) {
-      if (iarg + 2 > narg) error->all(FLERR, "Invalid python command");
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python format", error);
       format = utils::strdup(arg[iarg + 1]);
       iarg += 2;
     } else if (strcmp(arg[iarg], "length") == 0) {
-      if (iarg + 2 > narg) error->all(FLERR, "Invalid python command");
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python length", error);
       length_longstr = utils::inumeric(FLERR, arg[iarg + 1], false, lmp);
-      if (length_longstr <= 0) error->all(FLERR, "Invalid python command");
+      if (length_longstr <= 0) error->all(FLERR, "Invalid python return value length");
       iarg += 2;
     } else if (strcmp(arg[iarg], "file") == 0) {
-      if (iarg + 2 > narg) error->all(FLERR, "Invalid python command");
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python file", error);
       delete[] pyfile;
       pyfile = utils::strdup(arg[iarg + 1]);
       iarg += 2;
     } else if (strcmp(arg[iarg], "here") == 0) {
-      if (iarg + 2 > narg) error->all(FLERR, "Invalid python command");
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python here", error);
       herestr = arg[iarg + 1];
       iarg += 2;
     } else if (strcmp(arg[iarg], "exists") == 0) {
       existflag = 1;
       iarg++;
     } else
-      error->all(FLERR, "Invalid python command");
+      error->all(FLERR, "Unknown python command keyword: {}", arg[iarg]);
   }
 
-  if (pyfile && herestr) error->all(FLERR, "Invalid python command");
-  if (pyfile && existflag) error->all(FLERR, "Invalid python command");
-  if (herestr && existflag) error->all(FLERR, "Invalid python command");
+  if (pyfile && herestr)
+    error->all(FLERR, "Must not use python 'file' and 'here' keywords at the same time");
+  if (pyfile && existflag)
+    error->all(FLERR, "Must not use python 'file' and 'exists' keywords at the same time");
+  if (herestr && existflag)
+    error->all(FLERR, "Must not use python 'here' and 'exists' keywords at the same time");
 
   // create or overwrite entry in pfuncs vector with name = arg[0]
 
@@ -219,23 +229,21 @@ void PythonImpl::command(int narg, char **arg)
 
     if (fp == nullptr) {
       PyUtils::Print_Errors();
-      error->all(FLERR, "Could not open Python file");
+      error->all(FLERR, "Could not open Python file: {}", pyfile);
     }
 
     int err = PyRun_SimpleFile(fp, pyfile);
-
     if (err) {
       PyUtils::Print_Errors();
-      error->all(FLERR, "Could not process Python file");
+      error->all(FLERR, "Could not process Python file: {}", pyfile);
     }
-
     fclose(fp);
+
   } else if (herestr) {
     int err = PyRun_SimpleString(herestr);
-
     if (err) {
       PyUtils::Print_Errors();
-      error->all(FLERR, "Could not process Python string");
+      error->all(FLERR, "Could not process Python string: {}", herestr);
     }
   }
 
@@ -278,14 +286,17 @@ void PythonImpl::invoke_function(int ifunc, char *result)
   int ninput = pfuncs[ifunc].ninput;
   PyObject *pArgs = PyTuple_New(ninput);
 
-  if (!pArgs) { error->all(FLERR, "Could not create Python function arguments"); }
+  if (!pArgs)
+    error->all(FLERR, "Could not prepare arguments for Python function {}", pfuncs[ifunc].name);
 
   for (int i = 0; i < ninput; i++) {
     int itype = pfuncs[ifunc].itype[i];
     if (itype == INT) {
       if (pfuncs[ifunc].ivarflag[i]) {
         str = input->variable->retrieve(pfuncs[ifunc].svalue[i]);
-        if (!str) { error->all(FLERR, "Could not evaluate Python function input variable"); }
+        if (!str)
+          error->all(FLERR, "Could not evaluate Python function {} input variable: {}",
+                     pfuncs[ifunc].name, pfuncs[ifunc].svalue[i]);
         pValue = PY_INT_FROM_LONG(atoi(str));
       } else {
         pValue = PY_INT_FROM_LONG(pfuncs[ifunc].ivalue[i]);
@@ -293,7 +304,9 @@ void PythonImpl::invoke_function(int ifunc, char *result)
     } else if (itype == DOUBLE) {
       if (pfuncs[ifunc].ivarflag[i]) {
         str = input->variable->retrieve(pfuncs[ifunc].svalue[i]);
-        if (!str) { error->all(FLERR, "Could not evaluate Python function input variable"); }
+        if (!str)
+          error->all(FLERR, "Could not evaluate Python function {} input variable: {}",
+                     pfuncs[ifunc].name, pfuncs[ifunc].svalue[i]);
         pValue = PyFloat_FromDouble(atof(str));
       } else {
         pValue = PyFloat_FromDouble(pfuncs[ifunc].dvalue[i]);
@@ -301,7 +314,9 @@ void PythonImpl::invoke_function(int ifunc, char *result)
     } else if (itype == STRING) {
       if (pfuncs[ifunc].ivarflag[i]) {
         str = input->variable->retrieve(pfuncs[ifunc].svalue[i]);
-        if (!str) { error->all(FLERR, "Could not evaluate Python function input variable"); }
+        if (!str)
+          error->all(FLERR, "Could not evaluate Python function {} input variable: {}",
+                     pfuncs[ifunc].name, pfuncs[ifunc].svalue[i]);
         pValue = PY_STRING_FROM_STRING(str);
       } else {
         pValue = PY_STRING_FROM_STRING(pfuncs[ifunc].svalue[i]);
@@ -309,7 +324,7 @@ void PythonImpl::invoke_function(int ifunc, char *result)
     } else if (itype == PTR) {
       pValue = PY_VOID_POINTER(lmp);
     } else {
-      error->all(FLERR, "Unsupported variable type");
+      error->all(FLERR, "Unsupported variable type: {}", itype);
     }
     PyTuple_SetItem(pArgs, i, pValue);
   }
@@ -322,7 +337,7 @@ void PythonImpl::invoke_function(int ifunc, char *result)
 
   if (!pValue) {
     PyUtils::Print_Errors();
-    error->one(FLERR, "Python function evaluation failed");
+    error->one(FLERR, "Python evaluation of function {} failed", pfuncs[ifunc].name);
   }
 
   // function returned a value
@@ -398,9 +413,10 @@ int PythonImpl::create_entry(char *name, int ninput, int noutput, int length_lon
   pfuncs[ifunc].noutput = noutput;
 
   if (!format && ninput + noutput)
-    error->all(FLERR, "Invalid python command");
+    error->all(FLERR, "Missing python format keyword");
   else if (format && ((int) strlen(format) != ninput + noutput))
-    error->all(FLERR, "Invalid python command");
+    error->all(FLERR, "Input/output arguments ({}) and format characters ({}) are inconsistent",
+               (ninput + noutput), strlen(format));
 
   // process inputs as values or variables
 
@@ -446,7 +462,7 @@ int PythonImpl::create_entry(char *name, int ninput, int noutput, int length_lon
       if (strcmp(istr[i], "SELF") != 0) error->all(FLERR, "Invalid python command");
 
     } else
-      error->all(FLERR, "Invalid python command");
+      error->all(FLERR, "Invalid python format character: {}", type);
   }
 
   // process output as value or variable
@@ -463,7 +479,7 @@ int PythonImpl::create_entry(char *name, int ninput, int noutput, int length_lon
   else if (type == 's')
     pfuncs[ifunc].otype = STRING;
   else
-    error->all(FLERR, "Invalid python command");
+    error->all(FLERR, "Invalid python return format character: {}", type);
 
   if (length_longstr) {
     if (pfuncs[ifunc].otype != STRING)
@@ -484,7 +500,9 @@ int PythonImpl::create_entry(char *name, int ninput, int noutput, int length_lon
 int PythonImpl::execute_string(char *cmd)
 {
   PyUtils::GIL lock;
-  return PyRun_SimpleString(cmd);
+  int err = PyRun_SimpleString(cmd);
+  if (err) PyUtils::Print_Errors();
+  return err;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -496,6 +514,7 @@ int PythonImpl::execute_file(char *fname)
 
   PyUtils::GIL lock;
   int err = PyRun_SimpleFile(fp, fname);
+  if (err) PyUtils::Print_Errors();
 
   if (fp) fclose(fp);
   return err;

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -130,19 +130,17 @@ void PythonImpl::command(int narg, char **arg)
     return;
   }
 
-  // if source is only keyword, execute the python code
+  // if source is only keyword, execute the python code in file
 
-  if (narg == 3 && strcmp(arg[1], "source") == 0) {
-    int err;
+  if ((narg > 1) && (strcmp(arg[0], "source") == 0)) {
+    int err = -1;
 
-    FILE *fp = fopen(arg[2], "r");
-    if (fp == nullptr)
+    if ((narg > 2) && (strcmp(arg[1], "inline") == 0)) {
       err = execute_string(arg[2]);
-    else
-      err = execute_file(arg[2]);
-
-    if (fp) fclose(fp);
-    if (err) error->all(FLERR, "Could not process Python source command");
+    } else {
+      if (platform::file_is_readable(arg[1])) err = execute_file(arg[1]);
+    }
+    if (err) error->warning(FLERR, "Could not process Python source command. Error code: {}", err);
 
     return;
   }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -985,8 +985,21 @@ char *Variable::retrieve(const char *name)
     str = data[ivar][1] = utils::strdup(result);
   } else if (style[ivar] == PYTHON) {
     int ifunc = python->variable_match(data[ivar][0],name,0);
-    if (ifunc < 0)
-      error->all(FLERR,"Python variable {} does not match Python function {}", name, data[ivar][0]);
+    if (ifunc < 0) {
+      if (ifunc == -1) {
+        error->all(FLERR, "Could not find Python function {} linked to variable {}",
+                   data[ivar][0], name);
+      } else if (ifunc == -2) {
+        error->all(FLERR, "Python function {} for variable {} does not have a return value",
+                   data[ivar][0], name);
+      } else if (ifunc == -3) {
+        error->all(FLERR,"Python variable {} does not match variable name registered with "
+                   "Python function {}", name, data[ivar][0]);
+      } else {
+        error->all(FLERR, "Unknown error verifying function {} linked to python style variable {}",
+                   data[ivar][0],name);
+      }
+    }
     python->invoke_function(ifunc,data[ivar][1]);
     str = data[ivar][1];
     // if Python func returns a string longer than VALUELENGTH

--- a/unittest/python/test_python_package.cpp
+++ b/unittest/python/test_python_package.cpp
@@ -276,7 +276,7 @@ TEST_F(PythonPackageTest, RunSource)
 {
     // execute python script from file
     auto output = CAPTURE_OUTPUT([&] {
-        command("python xyz source ${input_dir}/run.py");
+        command("python source ${input_dir}/run.py");
     });
 
     ASSERT_THAT(output, HasSubstr(LOREM_IPSUM));
@@ -286,7 +286,7 @@ TEST_F(PythonPackageTest, RunSourceInline)
 {
     // execute inline python script
     auto output = CAPTURE_OUTPUT([&] {
-        command("python xyz source \"\"\"\n"
+        command("python source inline \"\"\"\n"
                 "from __future__ import print_function\n"
                 "print(2+2)\n"
                 "\"\"\"");

--- a/unittest/python/test_python_package.cpp
+++ b/unittest/python/test_python_package.cpp
@@ -286,7 +286,7 @@ TEST_F(PythonPackageTest, RunSourceInline)
 {
     // execute inline python script
     auto output = CAPTURE_OUTPUT([&] {
-        command("python source inline \"\"\"\n"
+        command("python source here \"\"\"\n"
                 "from __future__ import print_function\n"
                 "print(2+2)\n"
                 "\"\"\"");


### PR DESCRIPTION
**Summary**

This changes the processing of the `python source` command to be more obvious and avoid using dummy function names.
Also, the error reporting is improved and the documentation more detailed about limitations when the python interpreter is linked to the Python runtime statically when calling back to LAMMPS via the LAMMPS python module.

**Related Issue(s)**

closes #3520 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The syntax of the `python source` command is changed.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
