### PR TITLE
Append suffix to pstyle (pair style name) of compute fep

### DIFF
--- a/src/FEP/compute_fep.cpp
+++ b/src/FEP/compute_fep.cpp
@@ -198,8 +198,12 @@ void ComputeFEP::init()
 
     if (pert->which == PAIR) {
       pairflag = 1;
+      Pair *pair = nullptr;
 
-      Pair *pair = force->pair_match(pert->pstyle, 1);
+      if (lmp->suffix_enable)
+        pair = force->pair_match(std::string(pert->pstyle)+"/"+lmp->suffix,1);
+
+      if (pair == nullptr) pair = force->pair_match(pert->pstyle,1);
       if (pair == nullptr)
         error->all(FLERR,
                    "compute fep pair style "


### PR DESCRIPTION
**Summary**

Append suffix to pstyle (pair style name) of compute fep

**Related Issue(s)**

N/A

**Author(s)**

Shifeng Ke, Zhejiang University ([3160104230@zju.edu.cn](mailto:3160104230@zju.edu.cn))

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


