### PR TITLE
Bugfix: Respect thermo_modify warn always

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -122,7 +122,8 @@ void Error::universe_one(const std::string &file, int line, const std::string &s
 void Error::universe_warn(const std::string &file, int line, const std::string &str)
 {
   ++numwarn;
-  if ((numwarn > maxwarn) || (allwarn > maxwarn) || (maxwarn < 0)) return;
+  if (maxwarn < 0) return;
+  if (maxwarn != 0 && ((numwarn > maxwarn) || (allwarn > maxwarn))) return;
   if (universe->uscreen)
     fmt::print(universe->uscreen,"WARNING on proc {}: {} ({}:{})\n",
                universe->me,str,truncpath(file),line);
@@ -254,7 +255,8 @@ void Error::_one(const std::string &file, int line, fmt::string_view format,
 void Error::warning(const std::string &file, int line, const std::string &str)
 {
   ++numwarn;
-  if ((numwarn > maxwarn) || (allwarn > maxwarn) || (maxwarn < 0)) return;
+  if (maxwarn < 0) return;
+  if (maxwarn != 0 && ((numwarn > maxwarn) || (allwarn > maxwarn))) return;
   std::string mesg = fmt::format("WARNING: {} ({}:{})\n",
                                  str,truncpath(file),line);
   if (screen) fputs(mesg.c_str(),screen);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -122,8 +122,7 @@ void Error::universe_one(const std::string &file, int line, const std::string &s
 void Error::universe_warn(const std::string &file, int line, const std::string &str)
 {
   ++numwarn;
-  if (maxwarn < 0) return;
-  if (maxwarn != 0 && ((numwarn > maxwarn) || (allwarn > maxwarn))) return;
+  if ((maxwarn != 0) && ((numwarn > maxwarn) || (allwarn > maxwarn) || (maxwarn < 0))) return;
   if (universe->uscreen)
     fmt::print(universe->uscreen,"WARNING on proc {}: {} ({}:{})\n",
                universe->me,str,truncpath(file),line);
@@ -255,8 +254,7 @@ void Error::_one(const std::string &file, int line, fmt::string_view format,
 void Error::warning(const std::string &file, int line, const std::string &str)
 {
   ++numwarn;
-  if (maxwarn < 0) return;
-  if (maxwarn != 0 && ((numwarn > maxwarn) || (allwarn > maxwarn))) return;
+  if ((maxwarn != 0) && ((numwarn > maxwarn) || (allwarn > maxwarn) || (maxwarn < 0))) return;
   std::string mesg = fmt::format("WARNING: {} ({}:{})\n",
                                  str,truncpath(file),line);
   if (screen) fputs(mesg.c_str(),screen);


### PR DESCRIPTION
**Summary**

LAMMPS currently does not display any warnings if `thermo_modify warn always` is specified, when it is expected that all warnings should be shown. This is flagged by an `error->maxwarn` value of 0, but isn't checked when warnings are skipped. This PR adds a check.

Minimal example:
```
units		lj
atom_style	atomic

lattice		fcc 0.8
region		box block 0 10 0 10 0 10
create_box	1 box
create_atoms	1 box
mass		1 1.0

group some id 1:10
compute temp_some some temp

# This should issue the warning "Temperature for thermo pressure is not for group all"
thermo_modify warn always temp temp_some
```

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->
None

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->
Stephen Sanderson (UQ)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
No issues expected.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


