### PR TITLE
Fix SPH shock tube 2d example input deck

### DIFF
--- a/examples/PACKAGES/sph/shock_tube/shock2d.lmp
+++ b/examples/PACKAGES/sph/shock_tube/shock2d.lmp
@@ -22,7 +22,7 @@ pair_style         hybrid/overlay sph/rhosum 1 sph/idealgas
 pair_coeff         * * sph/rhosum 4.0
 pair_coeff         * * sph/idealgas 0.75 4.0
 
-compute            rhoatom all shp/rho/atom
+compute            rhoatom all sph/rho/atom
 compute            ieatom all sph/e/atom
 compute            esph all reduce sum c_ieatom # total internal energy
 compute            ke all ke


### PR DESCRIPTION
**Summary**

This fixes a misspelling bug in the 2d shock tube input deck of the LAMMPS SPH package

**Related Issue(s)**


**Author(s)**

Tim Teichmann (KIT)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Input deck was not valid before.

**Implementation Notes**

Trivial

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] One or more example input decks are included
