### PR TITLE
Fix bug in Kokkos minimize on GPUs

### DIFF
--- a/src/KOKKOS/min_linesearch_kokkos.cpp
+++ b/src/KOKKOS/min_linesearch_kokkos.cpp
@@ -376,10 +376,14 @@ double MinLineSearchKokkos::alpha_step(double alpha, int resetflag)
     });
   }
 
+  atomKK->modified(Device,X_MASK);
+
   // step forward along h
 
   if (alpha > 0.0) {
     if (nextra_global) modify->min_step(alpha,hextra);
+
+  atomKK->sync(Device,X_MASK); // positions can be modified by fix box/relax
 
     // local variables for lambda capture
 


### PR DESCRIPTION
**Summary**

Fix bug in Kokkos minimize on GPUs. Data transfer between GPU and CPU was missing, so the atom positions were not updated correctly, which led to `Stopping criterion = linesearch alpha is zero` when it should be `Stopping criterion = energy tolerance`. 

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Megan McCarthy (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes