### PR TITLE
Fixing bug #3545

### DIFF
--- a/src/region_ellipsoid.cpp
+++ b/src/region_ellipsoid.cpp
@@ -228,9 +228,9 @@ int RegEllipsoid::surface_interior(double *x, double cutoff)
       contact[0].r =
           DistancePointEllipsoid(axes[2], axes[1], axes[0], coords[sorting[2]], coords[sorting[1]],
                                  coords[sorting[0]], x0[2], x0[1], x0[0]);
-      contact[0].delx = copysign(x0[sorting[2]], x[0] - xc) + xc;
-      contact[0].dely = copysign(x0[sorting[1]], x[1] - yc) + yc;
-      contact[0].delz = copysign(x0[sorting[0]], x[2] - zc) + zc;
+      contact[0].delx = x[0] - (copysign(x0[sorting[2]], x[0] - xc) + xc);
+      contact[0].dely = x[1] - (copysign(x0[sorting[1]], x[1] - yc) + yc);
+      contact[0].delz = x[2] - (copysign(x0[sorting[0]], x[2] - zc) + zc);
       //      contact[0].radius = -radius;
       contact[0].iwall = 0;
       contact[0].varflag = 1;
@@ -255,12 +255,12 @@ int RegEllipsoid::surface_interior(double *x, double cutoff)
       double x0, x1;
       if (a >= b) {
         contact[0].r = DistancePointEllipse(a, b, fabs(x[0] - xc), fabs(x[1] - yc), x0, x1);
-        contact[0].delx = copysign(x0, x[0] - xc) + xc;
-        contact[0].dely = copysign(x1, x[1] - yc) + yc;
+        contact[0].delx = x[0] - (copysign(x0, x[0] - xc) + xc);
+        contact[0].dely = x[1] - (copysign(x1, x[1] - yc) + yc);
       } else {
         contact[0].r = DistancePointEllipse(b, a, fabs(x[1] - yc), fabs(x[0] - xc), x0, x1);
-        contact[0].delx = copysign(x1, x[0] - xc) + xc;
-        contact[0].dely = copysign(x0, x[1] - yc) + yc;
+        contact[0].delx = x[0] - (copysign(x1, x[0] - xc) + xc);
+        contact[0].dely = x[1] - (copysign(x0, x[1] - yc) + yc);
       }
       contact[0].delz = 0;
       //     contact[0].radius = -radius;
@@ -329,9 +329,9 @@ int RegEllipsoid::surface_exterior(double *x, double cutoff)
       contact[0].r =
           DistancePointEllipsoid(axes[2], axes[1], axes[0], coords[sorting[2]], coords[sorting[1]],
                                  coords[sorting[0]], x0[2], x0[1], x0[0]);
-      contact[0].delx = copysign(x0[sorting[2]], x[0] - xc) + xc;
-      contact[0].dely = copysign(x0[sorting[1]], x[1] - yc) + yc;
-      contact[0].delz = copysign(x0[sorting[0]], x[2] - zc) + zc;
+      contact[0].delx = x[0] - (copysign(x0[sorting[2]], x[0] - xc) + xc);
+      contact[0].dely = x[1] - (copysign(x0[sorting[1]], x[1] - yc) + yc);
+      contact[0].delz = x[2] - (copysign(x0[sorting[0]], x[2] - zc) + zc);
       //      contact[0].radius = radius;
       contact[0].iwall = 0;
       contact[0].varflag = 1;
@@ -356,12 +356,12 @@ int RegEllipsoid::surface_exterior(double *x, double cutoff)
       double x0, x1;
       if (a >= b) {
         contact[0].r = DistancePointEllipse(a, b, fabs(x[0] - xc), fabs(x[1] - yc), x0, x1);
-        contact[0].delx = copysign(x0, x[0] - xc) + xc;
-        contact[0].dely = copysign(x1, x[1] - yc) + yc;
+        contact[0].delx = x[0] - (copysign(x0, x[0] - xc) + xc);
+        contact[0].dely = x[1] - (copysign(x1, x[1] - yc) + yc);
       } else {
         contact[0].r = DistancePointEllipse(b, a, fabs(x[1] - yc), fabs(x[0] - xc), x0, x1);
-        contact[0].delx = copysign(x1, x[0] - xc) + xc;
-        contact[0].dely = copysign(x0, x[1] - yc) + yc;
+        contact[0].delx = x[0] - (copysign(x1, x[0] - xc) + xc);
+        contact[0].dely = x[1] - (copysign(x0, x[1] - yc) + yc);
       }
       contact[0].delz = 0;
       //    contact[0].radius = radius;

--- a/src/region_ellipsoid.cpp
+++ b/src/region_ellipsoid.cpp
@@ -198,36 +198,30 @@ int RegEllipsoid::surface_interior(double *x, double cutoff)
 
     if (r_r > rc_r) {
       // sort the values
-      int sorting[3] = {0, 1, 2};
-      double axes[3] = {c, b, a};
-      double coords[3] = {fabs(x[2] - zc), fabs(x[1] - yc), fabs(x[0] - xc)};
+      double axes[3] = {a,b,c};
+      double coords[3] = {fabs(x[0] - xc), fabs(x[1] - yc), fabs(x[2] - zc)};
 
-      if (axes[1] < axes[0]) {
-        sorting[0] = 1;
-        sorting[1] = 0;
-        axes[0] = b;
-        axes[1] = c;
-      }
-
-      if (axes[2] < axes[1]) {
-        int ti = sorting[2];
-        sorting[2] = sorting[1];
-        sorting[1] = ti;
-        double td = axes[2];
-        axes[2] = axes[1];
-        axes[1] = td;
-        if (axes[1] < axes[0]) ti = sorting[1];
-        sorting[1] = sorting[0];
-        sorting[0] = ti;
-        td = axes[1];
-        axes[1] = axes[0];
-        axes[0] = td;
-      }
+     int min, max;
+     if (axes[0] < axes[1]) {
+       min = 0;
+       max = 1;
+     } else {
+       min = 1;
+       max = 0;
+     }
+     if (axes[min] > axes[2]) {
+       min = 2;
+     }
+     if (axes[max] < axes[2]) {
+       max = 2;
+     }
+     int mid = 3 - min - max;
+     int sorting[3] = {min, mid, max};
 
       double x0[3];
       contact[0].r =
-          DistancePointEllipsoid(axes[2], axes[1], axes[0], coords[sorting[2]], coords[sorting[1]],
-                                 coords[sorting[0]], x0[2], x0[1], x0[0]);
+          DistancePointEllipsoid(axes[sorting[2]], axes[sorting[1]], axes[sorting[0]], coords[sorting[2]], coords[sorting[1]],
+                                 coords[sorting[0]], x0[sorting[2]], x0[sorting[1]], x0[sorting[0]]);
       contact[0].delx = x[0] - (copysign(x0[sorting[2]], x[0] - xc) + xc);
       contact[0].dely = x[1] - (copysign(x0[sorting[1]], x[1] - yc) + yc);
       contact[0].delz = x[2] - (copysign(x0[sorting[0]], x[2] - zc) + zc);
@@ -299,36 +293,30 @@ int RegEllipsoid::surface_exterior(double *x, double cutoff)
 
     if (r_r < rc_r) {
       // sort the values
-      int sorting[3] = {0, 1, 2};
-      double axes[3] = {c, b, a};
-      double coords[3] = {fabs(x[2] - zc), fabs(x[1] - yc), fabs(x[0] - xc)};
+      double axes[3] = {a,b,c};
+      double coords[3] = {fabs(x[0] - xc), fabs(x[1] - yc), fabs(x[2] - zc)};
 
-      if (axes[1] < axes[0]) {
-        sorting[0] = 1;
-        sorting[1] = 0;
-        axes[0] = b;
-        axes[1] = c;
+      int min, max;
+      if (axes[0] < axes[1]) {
+        min = 0;
+        max = 1;
+      } else {
+        min = 1;
+        max = 0;
       }
-
-      if (axes[2] < axes[1]) {
-        int ti = sorting[2];
-        sorting[2] = sorting[1];
-        sorting[1] = ti;
-        double td = axes[2];
-        axes[2] = axes[1];
-        axes[1] = td;
-        if (axes[1] < axes[0]) ti = sorting[1];
-        sorting[1] = sorting[0];
-        sorting[0] = ti;
-        td = axes[1];
-        axes[1] = axes[0];
-        axes[0] = td;
+      if (axes[min] > axes[2]) {
+        min = 2;
       }
+      if (axes[max] < axes[2]) {
+        max = 2;
+      }
+      int mid = 3 - min - max;
+      int sorting[3] = {min, mid, max};
 
       double x0[3];
       contact[0].r =
-          DistancePointEllipsoid(axes[2], axes[1], axes[0], coords[sorting[2]], coords[sorting[1]],
-                                 coords[sorting[0]], x0[2], x0[1], x0[0]);
+          DistancePointEllipsoid(axes[sorting[2]], axes[sorting[1]], axes[sorting[0]], coords[sorting[2]], coords[sorting[1]],
+                                 coords[sorting[0]], x0[sorting[2]], x0[sorting[1]], x0[sorting[0]]);
       contact[0].delx = x[0] - (copysign(x0[sorting[2]], x[0] - xc) + xc);
       contact[0].dely = x[1] - (copysign(x0[sorting[1]], x[1] - yc) + yc);
       contact[0].delz = x[2] - (copysign(x0[sorting[0]], x[2] - zc) + zc);


### PR DESCRIPTION
Instead of storing the vector from the nearest point of an ellipse to an atom, delxyz was storing the coordinates of the nearest point of the ellipse to the atom.

**Summary**

In region_ellipsoid.cpp, variables that store the vector from the nearest point on ellipsoid region surface to an atom, i.e., contact[0].delx, contact[0].dely and contact[0].delz are calculated with wrong expressions,

contact[0].delx = copysign(x0[sorting[2]], x[0] - xc) + xc
as an example. Obviously those are for the nearest point coordinates on the region surface.
This error may lead to incorrect force calculations when using fix wall/region with ellipsoid style region.

**Related Issue(s)**

Fixes #3545 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Bug fix 
