### PR TITLE
Small patch to BPM package

### DIFF
--- a/doc/src/bond_bpm_rotational.rst
+++ b/doc/src/bond_bpm_rotational.rst
@@ -67,7 +67,7 @@ which is proportional to the tangential shear displacement with a
 stiffness of :math:`k_s`. This tangential force also induces a torque.
 In addition, bending and twisting torques are also applied to
 particles which are proportional to angular bending and twisting
-displacements with stiffnesses of :math`k_b` and :math:`k_t',
+displacements with stiffnesses of :math:`k_b` and :math:`k_t`,
 respectively.  Details on the calculations of shear displacements and
 angular displacements can be found in :ref:`(Wang) <Wang2009>` and
 :ref:`(Wang and Mora) <Wang2009b>`.

--- a/src/fix_bond_history.cpp
+++ b/src/fix_bond_history.cpp
@@ -264,6 +264,9 @@ void FixBondHistory::write_restart(FILE *fp)
   double list[1];
   list[n++] = stored_flag;
 
+  // Update stored values if needed
+  pre_exchange();
+
   if (comm->me == 0) {
     int size = n * sizeof(double);
     fwrite(&size, sizeof(int), 1, fp);

--- a/src/fix_update_special_bonds.cpp
+++ b/src/fix_update_special_bonds.cpp
@@ -15,6 +15,7 @@
 
 #include "atom.h"
 #include "atom_vec.h"
+#include "comm.h"
 #include "error.h"
 #include "force.h"
 #include "modify.h"
@@ -35,6 +36,8 @@ FixUpdateSpecialBonds::FixUpdateSpecialBonds(LAMMPS *lmp, int narg, char **arg) 
     Fix(lmp, narg, arg)
 {
   if (narg != 3) error->all(FLERR, "Illegal fix update/special/bonds command");
+
+  restart_global = 1;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -240,4 +243,19 @@ void FixUpdateSpecialBonds::add_created_bond(int i, int j)
   auto tag_pair = std::make_pair(atom->tag[i], atom->tag[j]);
   new_created_pairs.push_back(tag_pair);
   created_pairs.push_back(tag_pair);
+}
+
+/* ----------------------------------------------------------------------
+   Use write_restart to invoke pre_exchange
+------------------------------------------------------------------------- */
+
+void FixUpdateSpecialBonds::write_restart(FILE *fp)
+{
+  // Call pre-exchange to process any broken/created bonds
+
+  pre_exchange();
+  if (comm->me == 0) {
+    int size = 0;
+    fwrite(&size,sizeof(int),1,fp);
+  }
 }

--- a/src/fix_update_special_bonds.cpp
+++ b/src/fix_update_special_bonds.cpp
@@ -70,12 +70,6 @@ void FixUpdateSpecialBonds::setup(int /*vflag*/)
       force->special_coul[3] != 1.0)
     error->all(FLERR, "Fix update/special/bonds requires special Coulomb weights = 1,1,1");
   // Implies neighbor->special_flag = [X, 2, 1, 1]
-
-  new_broken_pairs.clear();
-  broken_pairs.clear();
-
-  new_created_pairs.clear();
-  created_pairs.clear();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/fix_update_special_bonds.h
+++ b/src/fix_update_special_bonds.h
@@ -36,6 +36,7 @@ class FixUpdateSpecialBonds : public Fix {
   void pre_force(int) override;
   void add_broken_bond(int, int);
   void add_created_bond(int, int);
+  void write_restart(FILE *) override;
 
  protected:
   // Create two arrays to store bonds broken this timestep (new)


### PR DESCRIPTION
**Summary**

This PR fixes an incorrect formatting in the doc page for bpm/rotational bonds and also removes some unnecessary clears in fix update/special/bonds. Clearing the arrays of broken bonds in FixUpdateSpecialBonds->setup() could prevent some broken bonds from being properly processed if they break after the last neighbor list build of a run command (such that pre_exchange() never processes the bonds). If another run statement is then called, the information that these bonds broke is then wiped from arrays before special bonds are updated.

**Related Issue(s)**

NA

**Author(s)**

Joel Clemmer (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

NA

**Implementation Notes**

NA

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [x] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**

NA


