### PR TITLE
Fix bug when atoms are added after run

### DIFF
--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -441,10 +441,12 @@ void CreateAtoms::command(int narg, char **arg)
   MPI_Barrier(world);
   double time1 = platform::walltime();
 
+  // clear global->local map for owned and ghost atoms
   // clear ghost count and any ghost bonus data internal to AtomVec
   // same logic as beginning of Comm::exchange()
   // do it now b/c creating atoms will overwrite ghost atoms
 
+  if (atom->map_style != Atom::MAP_NONE) atom->map_clear();
   atom->nghost = 0;
   atom->avec->clear_bonus();
 

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -375,6 +375,14 @@ void ReadData::command(int narg, char **arg)
   if (addflag == NONE) {
     domain->box_exist = 1;
     update->ntimestep = 0;
+  } else {
+
+    // clear ghost count and any ghost bonus data internal to AtomVec
+    // same logic as beginning of Comm::exchange()
+    // do it now b/c creating atoms will overwrite ghost atoms
+
+    atom->nghost = 0;
+    atom->avec->clear_bonus();
   }
 
   // compute atomID and optionally moleculeID offset for addflag = APPEND

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -377,10 +377,12 @@ void ReadData::command(int narg, char **arg)
     update->ntimestep = 0;
   } else {
 
+    // clear global->local map for owned and ghost atoms
     // clear ghost count and any ghost bonus data internal to AtomVec
     // same logic as beginning of Comm::exchange()
-    // do it now b/c creating atoms will overwrite ghost atoms
+    // do it now b/c adding atoms will overwrite ghost atoms
 
+    if (atom->map_style != Atom::MAP_NONE) atom->map_clear();
     atom->nghost = 0;
     atom->avec->clear_bonus();
   }


### PR DESCRIPTION
**Summary**

- Prevent segfault when atoms are added with `read_data` command after a run, by zeroing out ghost atoms. Without this change, `atom->map_set()` could read uninitialized data in the `atom->tag` when velocities are read in, leading to a crash.
- Also clear atom map for `create_atoms` and `read_data`

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), issue reported by Jonathan Willman (USF)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes