### PR TITLE
Use correct RST heading syntax

### DIFF
--- a/doc/src/fix_sgcmc.rst
+++ b/doc/src/fix_sgcmc.rst
@@ -131,7 +131,7 @@ the parameter *window_moves* (see Sect. III.B in :ref:`Sadigh1
 ------------
 
 Restart, fix_modify, output, run start/stop, minimize info
-==========================================================
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 No information about this fix is written to restart files.
 
@@ -149,7 +149,7 @@ components of the vector represent the following quantities:
 * N+2: The current global concentration of species *X* (= number of atoms of type *N* / total number of atoms)
 
 Restrictions
-============
+""""""""""""
 
 This fix is part of the MC package. It is only enabled if LAMMPS was
 built with that package.  See the :doc:`Build package <Build_package>`
@@ -169,7 +169,7 @@ execution i.e. it only works with a single MPI process.
 ------------
 
 Default
-=======
+"""""""
 
 The optional parameters default to the following values:
 


### PR DESCRIPTION
**Summary**

The headings inside of documentation file `fix sgcmc` were specified incorrectly, causing extra entries in the table of contents.

**Author(s)**

Reza Rastak, PhD

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

This is the screenshot from the existing documentation table of content. This PR removes the extra entries.
<img width="287" alt="image" src="https://user-images.githubusercontent.com/13493279/210137551-6096c544-ff80-4f48-9f84-2b621701ebe9.png">


