### PR TITLE
Small bugfixes for Kokkos

### DIFF
--- a/src/KOKKOS/fix_nvt_kokkos.cpp
+++ b/src/KOKKOS/fix_nvt_kokkos.cpp
@@ -39,7 +39,7 @@ FixNVTKokkos<DeviceType>::FixNVTKokkos(LAMMPS *lmp, int narg, char **arg) :
   // id = fix-ID + temp
 
   this->id_temp = utils::strdup(std::string(this->id)+"_temp");
-  this->modify->add_compute(fmt::format("{} all temp/kk",this->id_temp));
+  this->modify->add_compute(fmt::format("{} {} temp/kk",this->id_temp,this->group->names[this->igroup]));
   this->tcomputeflag = 1;
 }
 

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
@@ -67,7 +67,7 @@ FixNVTSllodKokkos<DeviceType>::FixNVTSllodKokkos(LAMMPS *lmp, int narg, char **a
   }
 
   this->id_temp = utils::strdup(std::string(this->id)+"_temp");
-  this->modify->add_compute(fmt::format("{} {} temp/deform/kk",id_temp,group->names[igroup]));
+  this->modify->add_compute(fmt::format("{} {} temp/deform/kk",this->id_temp,this->group->names[this->igroup]));
   this->tcomputeflag = 1;
   this->nondeformbias = 0;
 }

--- a/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
+++ b/src/KOKKOS/fix_nvt_sllod_kokkos.cpp
@@ -67,7 +67,7 @@ FixNVTSllodKokkos<DeviceType>::FixNVTSllodKokkos(LAMMPS *lmp, int narg, char **a
   }
 
   this->id_temp = utils::strdup(std::string(this->id)+"_temp");
-  this->modify->add_compute(fmt::format("{} all temp/deform/kk",this->id_temp));
+  this->modify->add_compute(fmt::format("{} {} temp/deform/kk",id_temp,group->names[igroup]));
   this->tcomputeflag = 1;
   this->nondeformbias = 0;
 }

--- a/src/KOKKOS/fix_setforce_kokkos.cpp
+++ b/src/KOKKOS/fix_setforce_kokkos.cpp
@@ -77,9 +77,8 @@ void FixSetForceKokkos<DeviceType>::init()
 template<class DeviceType>
 void FixSetForceKokkos<DeviceType>::post_force(int /*vflag*/)
 {
-  atomKK->sync(execution_space, X_MASK | F_MASK | MASK_MASK);
+  atomKK->sync(execution_space, F_MASK | MASK_MASK);
 
-  x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();
   mask = atomKK->k_mask.view<DeviceType>();
 
@@ -88,6 +87,8 @@ void FixSetForceKokkos<DeviceType>::post_force(int /*vflag*/)
   // update region if necessary
 
   if (region) {
+    if (!utils::strmatch(region->style, "^block"))
+      error->all(FLERR,"Cannot (yet) use {}-style region with fix setforce/kk",style);
     region->prematch();
     DAT::tdual_int_1d k_match = DAT::tdual_int_1d("setforce:k_match",nlocal);
     KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);

--- a/src/KOKKOS/fix_setforce_kokkos.cpp
+++ b/src/KOKKOS/fix_setforce_kokkos.cpp
@@ -88,7 +88,7 @@ void FixSetForceKokkos<DeviceType>::post_force(int /*vflag*/)
 
   if (region) {
     if (!utils::strmatch(region->style, "^block"))
-      error->all(FLERR,"Cannot (yet) use {}-style region with fix setforce/kk",style);
+      error->all(FLERR,"Cannot (yet) use {}-style region with fix setforce/kk",region->style);
     region->prematch();
     DAT::tdual_int_1d k_match = DAT::tdual_int_1d("setforce:k_match",nlocal);
     KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);

--- a/src/KOKKOS/min_kokkos.cpp
+++ b/src/KOKKOS/min_kokkos.cpp
@@ -513,6 +513,7 @@ double MinKokkos::energy_force(int resetflag)
   if (modify->n_min_post_force) {
      timer->stamp();
      modify->min_post_force(vflag);
+     atomKK->sync(Device,F_MASK);
      timer->stamp(Timer::MODIFY);
   }
 

--- a/src/KOKKOS/region_block_kokkos.cpp
+++ b/src/KOKKOS/region_block_kokkos.cpp
@@ -48,7 +48,7 @@ void RegBlockKokkos<DeviceType>::match_all_kokkos(int groupbit_in, DAT::tdual_in
   groupbit = groupbit_in;
   d_match = k_match_in.template view<DeviceType>();
 
-  auto execution_space = ExecutionSpaceFromDevice<DeviceType>::space; 
+  auto execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
   atomKK->sync(execution_space, X_MASK | MASK_MASK);
 
   x = atomKK->k_x.view<DeviceType>();

--- a/src/KOKKOS/region_block_kokkos.cpp
+++ b/src/KOKKOS/region_block_kokkos.cpp
@@ -48,7 +48,8 @@ void RegBlockKokkos<DeviceType>::match_all_kokkos(int groupbit_in, DAT::tdual_in
   groupbit = groupbit_in;
   d_match = k_match_in.template view<DeviceType>();
 
-  atomKK->sync(Device, X_MASK | MASK_MASK);
+  auto execution_space = ExecutionSpaceFromDevice<DeviceType>::space; 
+  atomKK->sync(execution_space, X_MASK | MASK_MASK);
 
   x = atomKK->k_x.view<DeviceType>();
   mask = atomKK->k_mask.view<DeviceType>();


### PR DESCRIPTION
**Summary**

Fix some rare bugs in Kokkos:
- Add missing CPU <--> GPU data transfer for Kokkos minimize when using `fix setforce` and `pair/only on`
- Error out if not using `block` region for `fix setforce/kk`
- Also fix `execution_space` for data transfer in Kokkos region
- Update `fix nvt/kk` to use `igroup`

**Related Issue(s)**

Fixes #3616 

**Author(s)**

Stan Moore (SNL), Kokkos minimize issue reported by Danny Perez (LANL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes