### PR TITLE
Only added amoeba_convolution_gpu.* to the list of GPU source files w…

### DIFF
--- a/cmake/Modules/Packages/GPU.cmake
+++ b/cmake/Modules/Packages/GPU.cmake
@@ -3,9 +3,7 @@ set(GPU_SOURCES ${GPU_SOURCES_DIR}/gpu_extra.h
                 ${GPU_SOURCES_DIR}/fix_gpu.h
                 ${GPU_SOURCES_DIR}/fix_gpu.cpp
                 ${GPU_SOURCES_DIR}/fix_nh_gpu.h
-                ${GPU_SOURCES_DIR}/fix_nh_gpu.cpp
-                ${GPU_SOURCES_DIR}/amoeba_convolution_gpu.h
-                ${GPU_SOURCES_DIR}/amoeba_convolution_gpu.cpp)
+                ${GPU_SOURCES_DIR}/fix_nh_gpu.cpp)
 target_compile_definitions(lammps PRIVATE -DLMP_GPU)
 
 set(GPU_API "opencl" CACHE STRING "API used by GPU package")
@@ -33,6 +31,12 @@ mark_as_advanced(GPU_DEBUG)
 
 if(PKG_AMOEBA AND FFT_SINGLE)
   message(FATAL_ERROR "GPU acceleration of AMOEBA is not (yet) compatible with single precision FFT")
+endif()
+
+if (PKG_AMOEBA)
+  list(APPEND GPU_SOURCES
+              ${GPU_SOURCES_DIR}/amoeba_convolution_gpu.h
+              ${GPU_SOURCES_DIR}/amoeba_convolution_gpu.cpp)
 endif()
 
 file(GLOB GPU_LIB_SOURCES ${CONFIGURE_DEPENDS} ${LAMMPS_LIB_SOURCE_DIR}/gpu/[^.]*.cpp)


### PR DESCRIPTION
…hen PKG_AMOEBA is on

**Summary**

This PR makes sure that two source files amoeba_convolution_gpu.cpp and .h are only appended to the GPU source file list when PKG_AMOEBA is on during cmake.

**Related Issue(s)**

cmake will complain missing files (amoeba_convolution.h) with PKG_AMOEBA=off and PKG_GPU=on

**Author(s)**

Trung Nguyen (U Chicago)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Should maintain

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


