### PR TITLE
Small bugfixes

### DIFF
--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
@@ -175,8 +175,6 @@ void FixQEqReaxFFKokkos<DeviceType>::init_hist()
 template<class DeviceType>
 void FixQEqReaxFFKokkos<DeviceType>::setup_pre_force(int vflag)
 {
-  //neighbor->build_one(list);
-
   pre_force(vflag);
 }
 

--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -28,8 +28,8 @@ namespace LAMMPS_NS {
 
 /* ---------------------------------------------------------------------- */
 
-template<class DeviceType, int HALF_NEIGH, int GHOST, int TRI, int SIZE>
-NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::NPairKokkos(LAMMPS *lmp) : NPair(lmp) {
+template<class DeviceType, int HALF, int NEWTON, int GHOST, int TRI, int SIZE>
+NPairKokkos<DeviceType,HALF,NEWTON,GHOST,TRI,SIZE>::NPairKokkos(LAMMPS *lmp) : NPair(lmp) {
 
   last_stencil_old = -1;
 
@@ -49,8 +49,8 @@ NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::NPairKokkos(LAMMPS *lmp) : NP
    copy needed info from Neighbor class to this build class
    ------------------------------------------------------------------------- */
 
-template<class DeviceType, int HALF_NEIGH, int GHOST, int TRI, int SIZE>
-void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_neighbor_info()
+template<class DeviceType, int HALF, int NEWTON, int GHOST, int TRI, int SIZE>
+void NPairKokkos<DeviceType,HALF,NEWTON,GHOST,TRI,SIZE>::copy_neighbor_info()
 {
   NPair::copy_neighbor_info();
 
@@ -58,7 +58,6 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_neighbor_info()
 
   // general params
 
-  newton_pair = force->newton_pair;
   k_cutneighsq = neighborKK->k_cutneighsq;
 
   // overwrite per-type Neighbor cutoffs with custom value set by requestor
@@ -93,8 +92,8 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_neighbor_info()
  copy per-atom and per-bin vectors from NBin class to this build class
  ------------------------------------------------------------------------- */
 
-template<class DeviceType, int HALF_NEIGH, int GHOST, int TRI, int SIZE>
-void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_bin_info()
+template<class DeviceType, int HALF, int NEWTON, int GHOST, int TRI, int SIZE>
+void NPairKokkos<DeviceType,HALF,NEWTON,GHOST,TRI,SIZE>::copy_bin_info()
 {
   NPair::copy_bin_info();
 
@@ -110,8 +109,8 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_bin_info()
  copy needed info from NStencil class to this build class
  ------------------------------------------------------------------------- */
 
-template<class DeviceType, int HALF_NEIGH, int GHOST, int TRI, int SIZE>
-void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_stencil_info()
+template<class DeviceType, int HALF, int NEWTON, int GHOST, int TRI, int SIZE>
+void NPairKokkos<DeviceType,HALF,NEWTON,GHOST,TRI,SIZE>::copy_stencil_info()
 {
   NPair::copy_stencil_info();
   nstencil = ns->nstencil;
@@ -145,8 +144,8 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::copy_stencil_info()
 
 /* ---------------------------------------------------------------------- */
 
-template<class DeviceType, int HALF_NEIGH, int GHOST, int TRI, int SIZE>
-void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
+template<class DeviceType, int HALF, int NEWTON, int GHOST, int TRI, int SIZE>
+void NPairKokkos<DeviceType,HALF,NEWTON,GHOST,TRI,SIZE>::build(NeighList *list_)
 {
   NeighListKokkos<DeviceType>* list = (NeighListKokkos<DeviceType>*) list_;
   const int nlocal = includegroup?atom->nfirst:atom->nlocal;
@@ -244,7 +243,7 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
 #endif
 
     if (GHOST) {
-      NPairKokkosBuildFunctorGhost<DeviceType,HALF_NEIGH> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
+      NPairKokkosBuildFunctorGhost<DeviceType,HALF> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
 #ifdef LMP_KOKKOS_GPU
       if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
         int team_size = atoms_per_bin*factor;
@@ -262,82 +261,42 @@ void NPairKokkos<DeviceType,HALF_NEIGH,GHOST,TRI,SIZE>::build(NeighList *list_)
       Kokkos::parallel_for(nall, f);
 #endif
     } else {
-      if (newton_pair) {
-        if (SIZE) {
-          NPairKokkosBuildFunctorSize<DeviceType,TRI?0:HALF_NEIGH,1,TRI> f(data,atoms_per_bin * 6 * sizeof(X_FLOAT) * factor);
+      if (SIZE) {
+        NPairKokkosBuildFunctorSize<DeviceType,TRI?0:HALF,NEWTON,TRI> f(data,atoms_per_bin * 6 * sizeof(X_FLOAT) * factor);
 #ifdef LMP_KOKKOS_GPU
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
-            int team_size = atoms_per_bin*factor;
-            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
-            if (team_size <= team_size_max) {
-              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
-              Kokkos::parallel_for(config, f);
-            } else { // fall back to flat method
-              f.sharedsize = 0;
-              Kokkos::parallel_for(nall, f);
-            }
-          } else
+        if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
+          int team_size = atoms_per_bin*factor;
+          int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
+          if (team_size <= team_size_max) {
+            Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
+            Kokkos::parallel_for(config, f);
+          } else { // fall back to flat method
+            f.sharedsize = 0;
             Kokkos::parallel_for(nall, f);
-#else
+          }
+        } else
           Kokkos::parallel_for(nall, f);
-#endif
-        } else {
-          NPairKokkosBuildFunctor<DeviceType,TRI?0:HALF_NEIGH,1,TRI> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
-#ifdef LMP_KOKKOS_GPU
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
-            int team_size = atoms_per_bin*factor;
-            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
-            if (team_size <= team_size_max) {
-              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
-              Kokkos::parallel_for(config, f);
-            } else { // fall back to flat method
-              f.sharedsize = 0;
-              Kokkos::parallel_for(nall, f);
-            }
-          } else
-            Kokkos::parallel_for(nall, f);
 #else
-          Kokkos::parallel_for(nall, f);
+        Kokkos::parallel_for(nall, f);
 #endif
-        }
       } else {
-        if (SIZE) {
-          NPairKokkosBuildFunctorSize<DeviceType,HALF_NEIGH,0,0> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
+        NPairKokkosBuildFunctor<DeviceType,TRI?0:HALF,NEWTON,TRI> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
 #ifdef LMP_KOKKOS_GPU
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
-            int team_size = atoms_per_bin*factor;
-            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
-            if (team_size <= team_size_max) {
-              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
-              Kokkos::parallel_for(config, f);
-            } else { // fall back to flat method
-              f.sharedsize = 0;
-              Kokkos::parallel_for(nall, f);
-            }
-          } else
+        if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
+          int team_size = atoms_per_bin*factor;
+          int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
+          if (team_size <= team_size_max) {
+            Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
+            Kokkos::parallel_for(config, f);
+          } else { // fall back to flat method
+            f.sharedsize = 0;
             Kokkos::parallel_for(nall, f);
-#else
+          }
+        } else
           Kokkos::parallel_for(nall, f);
-#endif
-        } else {
-          NPairKokkosBuildFunctor<DeviceType,HALF_NEIGH,0,0> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
-#ifdef LMP_KOKKOS_GPU
-          if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
-            int team_size = atoms_per_bin*factor;
-            int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
-            if (team_size <= team_size_max) {
-              Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
-              Kokkos::parallel_for(config, f);
-            } else { // fall back to flat method
-              f.sharedsize = 0;
-              Kokkos::parallel_for(nall, f);
-            }
-          } else
-            Kokkos::parallel_for(nall, f);
 #else
-          Kokkos::parallel_for(nall, f);
+        Kokkos::parallel_for(nall, f);
 #endif
-        }
       }
     }
     Kokkos::deep_copy(h_scalars, d_scalars);
@@ -1402,20 +1361,30 @@ void NeighborKokkosExecute<DeviceType>::build_ItemSizeGPU(typename Kokkos::TeamP
 }
 
 namespace LAMMPS_NS {
-template class NPairKokkos<LMPDeviceType,0,0,0,0>;
-template class NPairKokkos<LMPDeviceType,0,1,0,0>;
-template class NPairKokkos<LMPDeviceType,1,0,0,0>;
-template class NPairKokkos<LMPDeviceType,1,1,0,0>;
-template class NPairKokkos<LMPDeviceType,1,0,1,0>;
-template class NPairKokkos<LMPDeviceType,1,0,0,1>;
-template class NPairKokkos<LMPDeviceType,1,0,1,1>;
+template class NPairKokkos<LMPDeviceType,0,0,0,0,0>;
+template class NPairKokkos<LMPDeviceType,0,0,1,0,0>;
+template class NPairKokkos<LMPDeviceType,1,1,0,0,0>;
+template class NPairKokkos<LMPDeviceType,1,0,0,0,0>;
+template class NPairKokkos<LMPDeviceType,1,1,1,0,0>;
+template class NPairKokkos<LMPDeviceType,1,0,1,0,0>;
+template class NPairKokkos<LMPDeviceType,1,1,0,1,0>;
+template class NPairKokkos<LMPDeviceType,1,0,0,1,0>;
+template class NPairKokkos<LMPDeviceType,1,1,0,0,1>;
+template class NPairKokkos<LMPDeviceType,1,0,0,0,1>;
+template class NPairKokkos<LMPDeviceType,1,1,0,1,1>;
+template class NPairKokkos<LMPDeviceType,1,0,0,1,1>;
 #ifdef LMP_KOKKOS_GPU
-template class NPairKokkos<LMPHostType,0,0,0,0>;
-template class NPairKokkos<LMPHostType,0,1,0,0>;
-template class NPairKokkos<LMPHostType,1,0,0,0>;
-template class NPairKokkos<LMPHostType,1,1,0,0>;
-template class NPairKokkos<LMPHostType,1,0,1,0>;
-template class NPairKokkos<LMPHostType,1,0,0,1>;
-template class NPairKokkos<LMPHostType,1,0,1,1>;
+template class NPairKokkos<LMPHostType,0,0,0,0,0>;
+template class NPairKokkos<LMPHostType,0,0,1,0,0>;
+template class NPairKokkos<LMPHostType,1,1,0,0,0>;
+template class NPairKokkos<LMPHostType,1,0,0,0,0>;
+template class NPairKokkos<LMPHostType,1,1,1,0,0>;
+template class NPairKokkos<LMPHostType,1,0,1,0,0>;
+template class NPairKokkos<LMPHostType,1,1,0,1,0>;
+template class NPairKokkos<LMPHostType,1,0,0,1,0>;
+template class NPairKokkos<LMPHostType,1,1,0,0,1>;
+template class NPairKokkos<LMPHostType,1,0,0,0,1>;
+template class NPairKokkos<LMPHostType,1,1,0,1,1>;
+template class NPairKokkos<LMPHostType,1,0,0,1,1>;
 #endif
 }

--- a/src/KOKKOS/npair_kokkos.h
+++ b/src/KOKKOS/npair_kokkos.h
@@ -13,75 +13,125 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairKokkos<LMPHostType,0,0,0,0> NPairKokkosFullBinHost;
+typedef NPairKokkos<LMPHostType,0,0,0,0,0> NPairKokkosFullBinHost;
 NPairStyle(full/bin/kk/host,
            NPairKokkosFullBinHost,
-           NP_FULL | NP_BIN | NP_KOKKOS_HOST | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
+           NP_BIN | NP_KOKKOS_HOST | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,0,0,0,0> NPairKokkosFullBinDevice;
+typedef NPairKokkos<LMPDeviceType,0,0,0,0,0> NPairKokkosFullBinDevice;
 NPairStyle(full/bin/kk/device,
            NPairKokkosFullBinDevice,
-           NP_FULL | NP_BIN | NP_KOKKOS_DEVICE | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
+           NP_BIN | NP_KOKKOS_DEVICE | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,0,1,0,0> NPairKokkosFullBinGhostHost;
+typedef NPairKokkos<LMPHostType,0,0,1,0,0> NPairKokkosFullBinGhostHost;
 NPairStyle(full/bin/ghost/kk/host,
            NPairKokkosFullBinGhostHost,
-           NP_FULL | NP_BIN | NP_KOKKOS_HOST | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
+           NP_BIN | NP_KOKKOS_HOST | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,0,1,0,0> NPairKokkosFullBinGhostDevice;
+typedef NPairKokkos<LMPDeviceType,0,0,1,0,0> NPairKokkosFullBinGhostDevice;
 NPairStyle(full/bin/ghost/kk/device,
            NPairKokkosFullBinGhostDevice,
-           NP_FULL | NP_BIN | NP_KOKKOS_DEVICE | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
+           NP_BIN | NP_KOKKOS_DEVICE | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,0,0,0> NPairKokkosHalfBinHost;
-NPairStyle(half/bin/kk/host,
-           NPairKokkosHalfBinHost,
-           NP_HALF | NP_BIN | NP_KOKKOS_HOST | NP_NEWTON | NP_NEWTOFF | NP_ORTHO);
+typedef NPairKokkos<LMPHostType,1,1,0,0,0> NPairKokkosHalfBinNewtonHost;
+NPairStyle(half/bin/newton/kk/host,
+           NPairKokkosHalfBinNewtonHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_ORTHO);
 
-typedef NPairKokkos<LMPDeviceType,1,0,0,0> NPairKokkosHalfBinDevice;
-NPairStyle(half/bin/kk/device,
-           NPairKokkosHalfBinDevice,
-           NP_HALF | NP_BIN | NP_KOKKOS_DEVICE | NP_NEWTON | NP_NEWTOFF | NP_ORTHO);
+typedef NPairKokkos<LMPHostType,1,0,0,0,0> NPairKokkosHalfBinNewtoffHost;
+NPairStyle(half/bin/newtoff/kk/host,
+           NPairKokkosHalfBinNewtoffHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_ORTHO);
 
-typedef NPairKokkos<LMPHostType,1,0,1,0> NPairKokkosHalfBinHostTri;
-NPairStyle(half/bin/kk/host,
-           NPairKokkosHalfBinHostTri,
-           NP_HALF | NP_BIN | NP_KOKKOS_HOST | NP_NEWTON | NP_NEWTOFF | NP_TRI);
+typedef NPairKokkos<LMPDeviceType,1,1,0,0,0> NPairKokkosHalfBinNewtonDevice;
+NPairStyle(half/bin/newton/kk/device,
+           NPairKokkosHalfBinNewtonDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_ORTHO);
 
-typedef NPairKokkos<LMPDeviceType,1,0,1,0> NPairKokkosHalfBinDeviceTri;
-NPairStyle(half/bin/kk/device,
-           NPairKokkosHalfBinDeviceTri,
-           NP_HALF | NP_BIN | NP_KOKKOS_DEVICE | NP_NEWTON | NP_NEWTOFF | NP_TRI);
+typedef NPairKokkos<LMPDeviceType,1,0,0,0,0> NPairKokkosHalfBinNewtoffDevice;
+NPairStyle(half/bin/newtoff/kk/device,
+           NPairKokkosHalfBinNewtoffDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_ORTHO);
 
-typedef NPairKokkos<LMPHostType,1,1,0,0> NPairKokkosHalfBinGhostHost;
-NPairStyle(half/bin/ghost/kk/host,
-           NPairKokkosHalfBinGhostHost,
-           NP_HALF | NP_BIN | NP_KOKKOS_HOST | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
+typedef NPairKokkos<LMPHostType,1,1,0,1,0> NPairKokkosHalfBinNewtonTriHost;
+NPairStyle(half/bin/newton/kk/host,
+           NPairKokkosHalfBinNewtonTriHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,1,0,0> NPairKokkosHalfBinGhostDevice;
-NPairStyle(half/bin/ghost/kk/device,
-           NPairKokkosHalfBinGhostDevice,
-           NP_HALF | NP_BIN | NP_KOKKOS_DEVICE | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
+typedef NPairKokkos<LMPHostType,1,0,0,1,0> NPairKokkosHalfBinNewtoffTriHost;
+NPairStyle(half/bin/newtoff/kk/host,
+           NPairKokkosHalfBinNewtoffTriHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,0,0,1> NPairKokkosHalfSizeBinHost;
-NPairStyle(half/size/bin/kk/host,
-           NPairKokkosHalfSizeBinHost,
-           NP_HALF | NP_SIZE | NP_BIN | NP_KOKKOS_HOST | NP_NEWTON | NP_NEWTOFF | NP_ORTHO);
+typedef NPairKokkos<LMPDeviceType,1,1,0,1,0> NPairKokkosHalfBinNewtonTriDevice;
+NPairStyle(half/bin/newton/kk/device,
+           NPairKokkosHalfBinNewtonTriDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,0,0,1> NPairKokkosHalfSizeBinDevice;
-NPairStyle(half/size/bin/kk/device,
-           NPairKokkosHalfSizeBinDevice,
-           NP_HALF | NP_SIZE | NP_BIN | NP_KOKKOS_DEVICE | NP_NEWTON | NP_NEWTOFF | NP_ORTHO);
+typedef NPairKokkos<LMPDeviceType,1,0,0,1,0> NPairKokkosHalfBinNewtoffTriDevice;
+NPairStyle(half/bin/newtoff/kk/device,
+           NPairKokkosHalfBinNewtoffTriDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,0,1,1> NPairKokkosHalfSizeBinHostTri;
-NPairStyle(half/size/bin/kk/host,
-           NPairKokkosHalfSizeBinHostTri,
-           NP_HALF | NP_SIZE | NP_BIN | NP_KOKKOS_HOST | NP_NEWTON | NP_NEWTOFF | NP_TRI);
+typedef NPairKokkos<LMPHostType,1,1,1,0,0> NPairKokkosHalfBinNewtonGhostHost;
+NPairStyle(half/bin/newton/ghost/kk/host,
+           NPairKokkosHalfBinNewtonGhostHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,0,1,1> NPairKokkosHalfSizeBinDeviceTri;
-NPairStyle(half/size/bin/kk/device,
-           NPairKokkosHalfSizeBinDeviceTri,
-           NP_HALF | NP_SIZE | NP_BIN | NP_KOKKOS_DEVICE | NP_NEWTON | NP_NEWTOFF | NP_TRI);
+typedef NPairKokkos<LMPHostType,1,0,1,0,0> NPairKokkosHalfBinNewtoffGhostHost;
+NPairStyle(half/bin/newtoff/ghost/kk/host,
+           NPairKokkosHalfBinNewtoffGhostHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
+
+typedef NPairKokkos<LMPDeviceType,1,1,1,0,0> NPairKokkosHalfBinNewtonGhostDevice;
+NPairStyle(half/bin/newton/ghost/kk/device,
+           NPairKokkosHalfBinNewtonGhostDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_GHOST | NP_ORTHO | NP_TRI);
+
+typedef NPairKokkos<LMPDeviceType,1,0,1,0,0> NPairKokkosHalfBinNewtoffGhostDevice;
+NPairStyle(half/bin/newtoff/ghost/kk/device,
+           NPairKokkosHalfBinNewtoffGhostDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
+
+typedef NPairKokkos<LMPHostType,1,1,0,0,1> NPairKokkosHalfBinNewtonSizeHost;
+NPairStyle(half/bin/newton/size/kk/host,
+           NPairKokkosHalfBinNewtonSizeHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_SIZE | NP_ORTHO);
+
+typedef NPairKokkos<LMPHostType,1,0,0,0,1> NPairKokkosHalfBinNewtoffSizeHost;
+NPairStyle(half/bin/newtoff/size/kk/host,
+           NPairKokkosHalfBinNewtoffSizeHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_SIZE | NP_ORTHO);
+
+typedef NPairKokkos<LMPDeviceType,1,1,0,0,1> NPairKokkosHalfBinNewtonSizeDevice;
+NPairStyle(half/bin/newton/size/kk/device,
+           NPairKokkosHalfBinNewtonSizeDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_SIZE | NP_ORTHO);
+
+typedef NPairKokkos<LMPDeviceType,1,0,0,0,1> NPairKokkosHalfBinNewtoffSizeDevice;
+NPairStyle(half/bin/newtoff/size/kk/device,
+           NPairKokkosHalfBinNewtoffSizeDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_SIZE | NP_ORTHO);
+
+typedef NPairKokkos<LMPHostType,1,1,0,1,1> NPairKokkosHalfBinNewtonSizeTriHost;
+NPairStyle(half/bin/newton/size/kk/host,
+           NPairKokkosHalfBinNewtonSizeTriHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_SIZE | NP_TRI);
+
+typedef NPairKokkos<LMPHostType,1,0,0,1,1> NPairKokkosHalfBinNewtoffSizeTriHost;
+NPairStyle(half/bin/newtoff/size/kk/host,
+           NPairKokkosHalfBinNewtoffSizeTriHost,
+           NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_SIZE | NP_TRI);
+
+typedef NPairKokkos<LMPDeviceType,1,1,0,1,1> NPairKokkosHalfBinNewtonSizeTriDevice;
+NPairStyle(half/bin/newton/size/kk/device,
+           NPairKokkosHalfBinNewtonSizeTriDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_SIZE | NP_TRI);
+
+typedef NPairKokkos<LMPDeviceType,1,0,0,1,1> NPairKokkosHalfBinNewtoffSizeTriDevice;
+NPairStyle(half/bin/newtoff/size/kk/device,
+           NPairKokkosHalfBinNewtoffSizeTriDevice,
+           NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_SIZE | NP_TRI);
 // clang-format on
 #else
 
@@ -94,7 +144,7 @@ NPairStyle(half/size/bin/kk/device,
 
 namespace LAMMPS_NS {
 
-template<class DeviceType, int HALF_NEIGH, int GHOST, int TRI, int SIZE>
+template<class DeviceType, int HALF_NEIGH, int NEWTON, int GHOST, int TRI, int SIZE>
 class NPairKokkos : public NPair {
   typedef ArrayTypes<DeviceType> AT;
 
@@ -379,7 +429,7 @@ class NeighborKokkosExecute
 
 };
 
-template<class DeviceType, int HALF_NEIGH, int GHOST_NEWTON, int TRI>
+template<class DeviceType, int HALF_NEIGH, int NEWTON, int TRI>
 struct NPairKokkosBuildFunctor {
   typedef DeviceType device_type;
 
@@ -392,19 +442,19 @@ struct NPairKokkosBuildFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const int & i) const {
-    c.template build_Item<HALF_NEIGH,GHOST_NEWTON,TRI>(i);
+    c.template build_Item<HALF_NEIGH,NEWTON,TRI>(i);
   }
 #ifdef LMP_KOKKOS_GPU
   LAMMPS_DEVICE_FUNCTION inline
   void operator() (typename Kokkos::TeamPolicy<DeviceType>::member_type dev) const {
-    c.template build_ItemGPU<HALF_NEIGH,GHOST_NEWTON,TRI>(dev, sharedsize);
+    c.template build_ItemGPU<HALF_NEIGH,NEWTON,TRI>(dev, sharedsize);
   }
   size_t team_shmem_size(const int team_size) const { (void) team_size; return sharedsize; }
 #endif
 };
 
-template<int HALF_NEIGH, int GHOST_NEWTON, int TRI>
-struct NPairKokkosBuildFunctor<LMPHostType,HALF_NEIGH,GHOST_NEWTON,TRI> {
+template<int HALF_NEIGH, int NEWTON, int TRI>
+struct NPairKokkosBuildFunctor<LMPHostType,HALF_NEIGH,NEWTON,TRI> {
   typedef LMPHostType device_type;
 
   const NeighborKokkosExecute<LMPHostType> c;
@@ -416,7 +466,7 @@ struct NPairKokkosBuildFunctor<LMPHostType,HALF_NEIGH,GHOST_NEWTON,TRI> {
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const int & i) const {
-    c.template build_Item<HALF_NEIGH,GHOST_NEWTON,TRI>(i);
+    c.template build_Item<HALF_NEIGH,NEWTON,TRI>(i);
   }
 
   void operator() (typename Kokkos::TeamPolicy<LMPHostType>::member_type /*dev*/) const {} // Should error out
@@ -466,7 +516,7 @@ struct NPairKokkosBuildFunctorGhost<LMPHostType,HALF_NEIGH> {
   void operator() (typename Kokkos::TeamPolicy<LMPHostType>::member_type /*dev*/) const {} // Should error out
 };
 
-template <class DeviceType, int HALF_NEIGH, int GHOST_NEWTON, int TRI>
+template <class DeviceType, int HALF_NEIGH, int NEWTON, int TRI>
 struct NPairKokkosBuildFunctorSize {
   typedef DeviceType device_type;
 
@@ -478,20 +528,20 @@ struct NPairKokkosBuildFunctorSize {
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const int & i) const {
-    c.template build_ItemSize<HALF_NEIGH,GHOST_NEWTON,TRI>(i);
+    c.template build_ItemSize<HALF_NEIGH,NEWTON,TRI>(i);
   }
 
 #ifdef LMP_KOKKOS_GPU
   LAMMPS_DEVICE_FUNCTION inline
   void operator() (typename Kokkos::TeamPolicy<DeviceType>::member_type dev) const {
-    c.template build_ItemSizeGPU<HALF_NEIGH,GHOST_NEWTON,TRI>(dev, sharedsize);
+    c.template build_ItemSizeGPU<HALF_NEIGH,NEWTON,TRI>(dev, sharedsize);
   }
   size_t team_shmem_size(const int team_size) const { (void) team_size; return sharedsize; }
 #endif
 };
 
-template <int HALF_NEIGH, int GHOST_NEWTON, int TRI>
-struct NPairKokkosBuildFunctorSize<LMPHostType,HALF_NEIGH,GHOST_NEWTON,TRI> {
+template <int HALF_NEIGH, int NEWTON, int TRI>
+struct NPairKokkosBuildFunctorSize<LMPHostType,HALF_NEIGH,NEWTON,TRI> {
   typedef LMPHostType device_type;
 
   const NeighborKokkosExecute<LMPHostType> c;
@@ -502,7 +552,7 @@ struct NPairKokkosBuildFunctorSize<LMPHostType,HALF_NEIGH,GHOST_NEWTON,TRI> {
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const int & i) const {
-    c.template build_ItemSize<HALF_NEIGH,GHOST_NEWTON,TRI>(i);
+    c.template build_ItemSize<HALF_NEIGH,NEWTON,TRI>(i);
   }
 
   void operator() (typename Kokkos::TeamPolicy<LMPHostType>::member_type /*dev*/) const {} // Should error out

--- a/src/KOKKOS/pair_lj_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_kokkos.cpp
@@ -130,6 +130,7 @@ void PairLJCutKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   if (vflag_fdotr) pair_virial_fdotr_compute(this);
 
+  copymode = 0;
 }
 
 template<class DeviceType>

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -184,6 +184,8 @@ void PairReaxFFKokkos<DeviceType>::init_style()
   if (neighflag == FULL)
     error->all(FLERR,"Must use half neighbor list with pair style reaxff/kk");
 
+  need_dup = lmp->kokkos->need_dup<DeviceType>();
+
   allocate();
   setup();
   init_md();
@@ -196,6 +198,8 @@ void PairReaxFFKokkos<DeviceType>::setup()
 {
   int i,j,k,m;
   int n = atom->ntypes;
+
+  setup_flag = 1;
 
   // general parameters
   for (i = 0; i < 39; i ++)
@@ -577,17 +581,17 @@ void PairReaxFFKokkos<DeviceType>::Deallocate_Lookup_Tables()
     for (j = i; j <= ntypes; ++j) {
       if (map[i] == -1) continue;
       if (LR[i][j].n) {
-        sfree(api->control->error_ptr, LR[i][j].y, "LR[i,j].y");
-        sfree(api->control->error_ptr, LR[i][j].H, "LR[i,j].H");
-        sfree(api->control->error_ptr, LR[i][j].vdW, "LR[i,j].vdW");
-        sfree(api->control->error_ptr, LR[i][j].CEvd, "LR[i,j].CEvd");
-        sfree(api->control->error_ptr, LR[i][j].ele, "LR[i,j].ele");
-        sfree(api->control->error_ptr, LR[i][j].CEclmb, "LR[i,j].CEclmb");
+        sfree(LR[i][j].y, "LR[i,j].y");
+        sfree(LR[i][j].H, "LR[i,j].H");
+        sfree(LR[i][j].vdW, "LR[i,j].vdW");
+        sfree(LR[i][j].CEvd, "LR[i,j].CEvd");
+        sfree(LR[i][j].ele, "LR[i,j].ele");
+        sfree(LR[i][j].CEclmb, "LR[i,j].CEclmb");
       }
     }
-    sfree(api->control->error_ptr, LR[i], "LR[i]");
+    sfree(LR[i], "LR[i]");
   }
-  sfree(api->control->error_ptr, LR, "LR");
+  sfree(LR, "LR");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -737,8 +741,6 @@ void PairReaxFFKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
       d_s = k_s.view<DeviceType>();
     }
   }
-
-  need_dup = lmp->kokkos->need_dup<DeviceType>();
 
   // allocate duplicated memory
   if (need_dup) {

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -199,8 +199,6 @@ void PairReaxFFKokkos<DeviceType>::setup()
   int i,j,k,m;
   int n = atom->ntypes;
 
-  setup_flag = 1;
-
   // general parameters
   for (i = 0; i < 39; i ++)
     gp[i] = api->system->reax_param.gp.l[i];

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -95,6 +95,8 @@ PairReaxFFKokkos<DeviceType>::~PairReaxFFKokkos()
 {
   if (copymode) return;
 
+  DeAllocate_System(api->system);
+
   memoryKK->destroy_kokkos(k_eatom,eatom);
   memoryKK->destroy_kokkos(k_vatom,vatom);
 

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -581,17 +581,17 @@ void PairReaxFFKokkos<DeviceType>::Deallocate_Lookup_Tables()
     for (j = i; j <= ntypes; ++j) {
       if (map[i] == -1) continue;
       if (LR[i][j].n) {
-        sfree(LR[i][j].y, "LR[i,j].y");
-        sfree(LR[i][j].H, "LR[i,j].H");
-        sfree(LR[i][j].vdW, "LR[i,j].vdW");
-        sfree(LR[i][j].CEvd, "LR[i,j].CEvd");
-        sfree(LR[i][j].ele, "LR[i,j].ele");
-        sfree(LR[i][j].CEclmb, "LR[i,j].CEclmb");
+        sfree(LR[i][j].y);
+        sfree(LR[i][j].H);
+        sfree(LR[i][j].vdW);
+        sfree(LR[i][j].CEvd);
+        sfree(LR[i][j].ele);
+        sfree(LR[i][j].CEclmb);
       }
     }
-    sfree(LR[i], "LR[i]");
+    sfree(LR[i]);
   }
-  sfree(LR, "LR");
+  sfree(LR);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -47,7 +47,6 @@ PairSWKokkos<DeviceType>::PairSWKokkos(LAMMPS *lmp) : PairSW(lmp)
 {
   respa_enable = 0;
 
-
   kokkosable = 1;
   atomKK = (AtomKokkos *) atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
@@ -138,6 +137,7 @@ void PairSWKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   }
   if ((int)d_numneigh_short.extent(0) < ignum)
     d_numneigh_short = Kokkos::View<int*,DeviceType>("SW::numneighs_short",ignum*1.2);
+
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairSWComputeShortNeigh>(0,inum), *this);
 
   // loop over neighbor list of my atoms

--- a/src/OPENMP/pair_reaxff_omp.cpp
+++ b/src/OPENMP/pair_reaxff_omp.cpp
@@ -93,7 +93,7 @@ PairReaxFFOMP::~PairReaxFFOMP()
   if (setup_flag) {
     reax_list * bonds = api->lists+BONDS;
     for (int i=0; i<bonds->num_intrs; ++i)
-      sfree(error, bonds->select.bond_list[i].bo_data.CdboReduction, "CdboReduction");
+      sfree(bonds->select.bond_list[i].bo_data.CdboReduction);
   }
   memory->destroy(num_nbrs_offset);
 }

--- a/src/OPENMP/reaxff_bonds_omp.cpp
+++ b/src/OPENMP/reaxff_bonds_omp.cpp
@@ -99,6 +99,7 @@ namespace ReaxFF {
           /* set the pointers */
           type_i = system->my_atoms[i].type;
           type_j = system->my_atoms[j].type;
+          if ((type_i < 0) || (type_j < 0)) continue;
           sbp_i = &(system->reax_param.sbp[type_i]);
           sbp_j = &(system->reax_param.sbp[type_j]);
           twbp = &(system->reax_param.tbp[type_i][type_j]);

--- a/src/OPENMP/reaxff_forces_omp.cpp
+++ b/src/OPENMP/reaxff_forces_omp.cpp
@@ -265,6 +265,7 @@ namespace ReaxFF {
       for (int i = 0; i < system->N; ++i) {
         atom_i = &(system->my_atoms[i]);
         type_i  = atom_i->type;
+        if (type_i < 0) continue;
         sbp_i = &(system->reax_param.sbp[type_i]);
 
         start_i = Start_Index(i, far_nbrs);
@@ -276,6 +277,7 @@ namespace ReaxFF {
             int j = nbr_pj->nbr;
             atom_j = &(system->my_atoms[j]);
             type_j = atom_j->type;
+            if (type_j < 0) continue;
             sbp_j = &(system->reax_param.sbp[type_j]);
             twbp = &(system->reax_param.tbp[type_i][type_j]);
 
@@ -376,6 +378,7 @@ namespace ReaxFF {
         for (int i = 0; i < system->n; ++i) {
           atom_i = &(system->my_atoms[i]);
           type_i  = atom_i->type;
+          if (type_i < 0) continue;
           sbp_i = &(system->reax_param.sbp[type_i]);
           ihb = sbp_i->p_hbond;
 

--- a/src/OPENMP/reaxff_hydrogen_bonds_omp.cpp
+++ b/src/OPENMP/reaxff_hydrogen_bonds_omp.cpp
@@ -98,14 +98,14 @@ namespace ReaxFF {
       //  for (j = 0; j < system->n; ++j)
       for (j = ifrom; j < ito; ++j) {
         /* j has to be of type H */
-        if (system->reax_param.sbp[system->my_atoms[j].type].p_hbond == 1) {
+        type_j     = system->my_atoms[j].type;
+        if (type_j < 0) continue;
+        if (system->reax_param.sbp[type_j].p_hbond == 1) {
           /*set j's variables */
-          type_j     = system->my_atoms[j].type;
           start_j    = Start_Index(j, bonds);
           end_j      = End_Index(j, bonds);
           hb_start_j = Start_Index(system->my_atoms[j].Hindex, hbonds);
           hb_end_j   = End_Index(system->my_atoms[j].Hindex, hbonds);
-          if (type_j < 0) continue;
 
           top = 0;
           for (pi = start_j; pi < end_j; ++pi)  {

--- a/src/REAXFF/pair_reaxff.cpp
+++ b/src/REAXFF/pair_reaxff.cpp
@@ -110,9 +110,7 @@ PairReaxFF::PairReaxFF(LAMMPS *lmp) : Pair(lmp)
 
   setup_flag = 0;
   fixspecies_flag = 0;
-
   nmax = 0;
-
   list_blocking_flag = 0;
 }
 
@@ -130,8 +128,8 @@ PairReaxFF::~PairReaxFF()
     // deallocate reax data-structures
 
     if (api->control->tabulate) Deallocate_Lookup_Tables(api->system);
-
     if (api->control->hbond_cut > 0) Delete_List(api->lists+HBONDS);
+
     Delete_List(api->lists+BONDS);
     Delete_List(api->lists+THREE_BODIES);
     Delete_List(api->lists+FAR_NBRS);
@@ -153,17 +151,16 @@ PairReaxFF::~PairReaxFF()
     memory->destroy(cutsq);
     memory->destroy(cutghost);
 
-    delete [] chi;
-    delete [] eta;
-    delete [] gamma;
-    delete [] bcut_acks2;
+    delete[] chi;
+    delete[] eta;
+    delete[] gamma;
+    delete[] bcut_acks2;
   }
 
   memory->destroy(tmpid);
   memory->destroy(tmpbo);
 
-  delete [] pvector;
-
+  delete[] pvector;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -531,7 +528,6 @@ void PairReaxFF::compute(int eflag, int vflag)
       }
     FindBond();
   }
-
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/REAXFF/pair_reaxff.cpp
+++ b/src/REAXFF/pair_reaxff.cpp
@@ -649,7 +649,7 @@ int PairReaxFF::write_reax_lists()
     jlist = firstneigh[i];
     Set_Start_Index(i, num_nbrs, far_nbrs);
 
-    if (i < inum)
+    if (itr_i < inum)
       cutoff_sqr = SQR(api->control->nonb_cut);
     else
       cutoff_sqr = SQR(api->control->bond_cut);

--- a/src/REAXFF/pair_reaxff.cpp
+++ b/src/REAXFF/pair_reaxff.cpp
@@ -136,7 +136,7 @@ PairReaxFF::~PairReaxFF()
     Delete_List(api->lists+THREE_BODIES);
     Delete_List(api->lists+FAR_NBRS);
 
-    DeAllocate_Workspace(api->control, api->workspace);
+    DeAllocate_Workspace(api->workspace);
     DeAllocate_System(api->system);
   }
 

--- a/src/REAXFF/pair_reaxff.cpp
+++ b/src/REAXFF/pair_reaxff.cpp
@@ -282,11 +282,6 @@ void PairReaxFF::coeff(int nargs, char **args)
   if (nargs != 3 + atom->ntypes)
     error->all(FLERR,"Incorrect args for pair coefficients");
 
-  // ensure I,J args are * *
-
-  if (strcmp(args[0],"*") != 0 || strcmp(args[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
-
   // read ffield file
 
   Read_Force_Field(args[2], &(api->system->reax_param), api->control, world);

--- a/src/REAXFF/reaxff_allocate.cpp
+++ b/src/REAXFF/reaxff_allocate.cpp
@@ -66,7 +66,7 @@ namespace ReaxFF {
     auto memory = system->mem_ptr;
 
     // deallocate the atom list
-    sfree(system->my_atoms, "system->my_atoms");
+    sfree(system->my_atoms);
 
     // deallocate the ffield parameters storage
     memory->destroy(system->reax_param.gp.l);
@@ -87,36 +87,36 @@ namespace ReaxFF {
     auto error = control->error_ptr;
 
     /* bond order storage */
-    sfree(workspace->total_bond_order, "total_bo");
-    sfree(workspace->Deltap, "Deltap");
-    sfree(workspace->Deltap_boc, "Deltap_boc");
-    sfree(workspace->dDeltap_self, "dDeltap_self");
-    sfree(workspace->Delta, "Delta");
-    sfree(workspace->Delta_lp, "Delta_lp");
-    sfree(workspace->Delta_lp_temp, "Delta_lp_temp");
-    sfree(workspace->dDelta_lp, "dDelta_lp");
-    sfree(workspace->dDelta_lp_temp, "dDelta_lp_temp");
-    sfree(workspace->Delta_e, "Delta_e");
-    sfree(workspace->Delta_boc, "Delta_boc");
-    sfree(workspace->Delta_val, "Delta_val");
-    sfree(workspace->nlp, "nlp");
-    sfree(workspace->nlp_temp, "nlp_temp");
-    sfree(workspace->Clp, "Clp");
-    sfree(workspace->vlpex, "vlpex");
-    sfree(workspace->bond_mark, "bond_mark");
+    sfree(workspace->total_bond_order);
+    sfree(workspace->Deltap);
+    sfree(workspace->Deltap_boc);
+    sfree(workspace->dDeltap_self);
+    sfree(workspace->Delta);
+    sfree(workspace->Delta_lp);
+    sfree(workspace->Delta_lp_temp);
+    sfree(workspace->dDelta_lp);
+    sfree(workspace->dDelta_lp_temp);
+    sfree(workspace->Delta_e);
+    sfree(workspace->Delta_boc);
+    sfree(workspace->Delta_val);
+    sfree(workspace->nlp);
+    sfree(workspace->nlp_temp);
+    sfree(workspace->Clp);
+    sfree(workspace->vlpex);
+    sfree(workspace->bond_mark);
 
     /* force related storage */
-    sfree(workspace->f, "f");
-    sfree(workspace->CdDelta, "CdDelta");
+    sfree(workspace->f);
+    sfree(workspace->CdDelta);
 
     /* reductions */
 
     if (workspace->CdDeltaReduction)
-      sfree(workspace->CdDeltaReduction, "cddelta_reduce");
+      sfree(workspace->CdDeltaReduction);
     if (workspace->forceReduction)
-      sfree(workspace->forceReduction, "f_reduce");
+      sfree(workspace->forceReduction);
     if (workspace->valence_angle_atom_myoffset)
-      sfree(workspace->valence_angle_atom_myoffset, "valence_angle_atom_myoffset");
+      sfree(workspace->valence_angle_atom_myoffset);
   }
 
   void Allocate_Workspace(control_params *control, storage *workspace, int total_cap)
@@ -206,7 +206,7 @@ namespace ReaxFF {
 
     if (system->omp_active)
       for (i = 0; i < bonds->num_intrs; ++i)
-        sfree(bonds->select.bond_list[i].bo_data.CdboReduction, "CdboReduction");
+        sfree(bonds->select.bond_list[i].bo_data.CdboReduction);
 
     Delete_List(bonds);
     Make_List(system->total_cap, *total_bonds, TYP_BOND, bonds);
@@ -292,8 +292,7 @@ namespace ReaxFF {
         reax_list *bonds = (*lists)+BONDS;
 
         for (int i = 0; i < bonds->num_intrs; ++i) {
-          sfree(bonds->select.bond_list[i].bo_data.CdboReduction,
-                "CdboReduction");
+          sfree(bonds->select.bond_list[i].bo_data.CdboReduction);
 
           bonds->select.bond_list[i].bo_data.CdboReduction =
             (double*) smalloc(error, sizeof(double)*nthreads, "CdboReduction");

--- a/src/REAXFF/reaxff_allocate.cpp
+++ b/src/REAXFF/reaxff_allocate.cpp
@@ -66,7 +66,7 @@ namespace ReaxFF {
     auto memory = system->mem_ptr;
 
     // deallocate the atom list
-    sfree(error, system->my_atoms, "system->my_atoms");
+    sfree(system->my_atoms, "system->my_atoms");
 
     // deallocate the ffield parameters storage
     memory->destroy(system->reax_param.gp.l);
@@ -87,36 +87,36 @@ namespace ReaxFF {
     auto error = control->error_ptr;
 
     /* bond order storage */
-    sfree(error, workspace->total_bond_order, "total_bo");
-    sfree(error, workspace->Deltap, "Deltap");
-    sfree(error, workspace->Deltap_boc, "Deltap_boc");
-    sfree(error, workspace->dDeltap_self, "dDeltap_self");
-    sfree(error, workspace->Delta, "Delta");
-    sfree(error, workspace->Delta_lp, "Delta_lp");
-    sfree(error, workspace->Delta_lp_temp, "Delta_lp_temp");
-    sfree(error, workspace->dDelta_lp, "dDelta_lp");
-    sfree(error, workspace->dDelta_lp_temp, "dDelta_lp_temp");
-    sfree(error, workspace->Delta_e, "Delta_e");
-    sfree(error, workspace->Delta_boc, "Delta_boc");
-    sfree(error, workspace->Delta_val, "Delta_val");
-    sfree(error, workspace->nlp, "nlp");
-    sfree(error, workspace->nlp_temp, "nlp_temp");
-    sfree(error, workspace->Clp, "Clp");
-    sfree(error, workspace->vlpex, "vlpex");
-    sfree(error, workspace->bond_mark, "bond_mark");
+    sfree(workspace->total_bond_order, "total_bo");
+    sfree(workspace->Deltap, "Deltap");
+    sfree(workspace->Deltap_boc, "Deltap_boc");
+    sfree(workspace->dDeltap_self, "dDeltap_self");
+    sfree(workspace->Delta, "Delta");
+    sfree(workspace->Delta_lp, "Delta_lp");
+    sfree(workspace->Delta_lp_temp, "Delta_lp_temp");
+    sfree(workspace->dDelta_lp, "dDelta_lp");
+    sfree(workspace->dDelta_lp_temp, "dDelta_lp_temp");
+    sfree(workspace->Delta_e, "Delta_e");
+    sfree(workspace->Delta_boc, "Delta_boc");
+    sfree(workspace->Delta_val, "Delta_val");
+    sfree(workspace->nlp, "nlp");
+    sfree(workspace->nlp_temp, "nlp_temp");
+    sfree(workspace->Clp, "Clp");
+    sfree(workspace->vlpex, "vlpex");
+    sfree(workspace->bond_mark, "bond_mark");
 
     /* force related storage */
-    sfree(error, workspace->f, "f");
-    sfree(error, workspace->CdDelta, "CdDelta");
+    sfree(workspace->f, "f");
+    sfree(workspace->CdDelta, "CdDelta");
 
     /* reductions */
 
     if (workspace->CdDeltaReduction)
-      sfree(error, workspace->CdDeltaReduction, "cddelta_reduce");
+      sfree(workspace->CdDeltaReduction, "cddelta_reduce");
     if (workspace->forceReduction)
-      sfree(error, workspace->forceReduction, "f_reduce");
+      sfree(workspace->forceReduction, "f_reduce");
     if (workspace->valence_angle_atom_myoffset)
-      sfree(error, workspace->valence_angle_atom_myoffset, "valence_angle_atom_myoffset");
+      sfree(workspace->valence_angle_atom_myoffset, "valence_angle_atom_myoffset");
   }
 
   void Allocate_Workspace(control_params *control, storage *workspace, int total_cap)
@@ -206,7 +206,7 @@ namespace ReaxFF {
 
     if (system->omp_active)
       for (i = 0; i < bonds->num_intrs; ++i)
-        sfree(system->error_ptr, bonds->select.bond_list[i].bo_data.CdboReduction, "CdboReduction");
+        sfree(bonds->select.bond_list[i].bo_data.CdboReduction, "CdboReduction");
 
     Delete_List(bonds);
     Make_List(system->total_cap, *total_bonds, TYP_BOND, bonds);
@@ -292,7 +292,7 @@ namespace ReaxFF {
         reax_list *bonds = (*lists)+BONDS;
 
         for (int i = 0; i < bonds->num_intrs; ++i) {
-          sfree(error, bonds->select.bond_list[i].bo_data.CdboReduction,
+          sfree(bonds->select.bond_list[i].bo_data.CdboReduction,
                 "CdboReduction");
 
           bonds->select.bond_list[i].bo_data.CdboReduction =

--- a/src/REAXFF/reaxff_allocate.cpp
+++ b/src/REAXFF/reaxff_allocate.cpp
@@ -62,7 +62,6 @@ namespace ReaxFF {
 
   void DeAllocate_System(reax_system *system)
   {
-    auto error = system->error_ptr;
     auto memory = system->mem_ptr;
 
     // deallocate the atom list
@@ -78,13 +77,12 @@ namespace ReaxFF {
   }
 
   /*************       workspace        *************/
-  void DeAllocate_Workspace(control_params *control, storage *workspace)
+  void DeAllocate_Workspace(storage *workspace)
   {
     if (!workspace->allocated)
       return;
 
     workspace->allocated = 0;
-    auto error = control->error_ptr;
 
     /* bond order storage */
     sfree(workspace->total_bond_order);
@@ -245,7 +243,7 @@ namespace ReaxFF {
       system->my_atoms = (reax_atom *)::realloc(system->my_atoms,
         system->total_cap*sizeof(reax_atom));
       /* workspace */
-      DeAllocate_Workspace(control, workspace);
+      DeAllocate_Workspace(workspace);
       Allocate_Workspace(control, workspace, system->total_cap);
     }
 

--- a/src/REAXFF/reaxff_api.h
+++ b/src/REAXFF/reaxff_api.h
@@ -142,7 +142,7 @@ extern void Reset_Workspace(reax_system *, storage *);
 
 extern void *scalloc(LAMMPS_NS::Error *, rc_bigint, rc_bigint, const std::string &);
 extern void *smalloc(LAMMPS_NS::Error *, rc_bigint, const std::string &);
-extern void sfree(void *, const std::string &);
+extern void sfree(void *);
 
 // torsion angles
 

--- a/src/REAXFF/reaxff_api.h
+++ b/src/REAXFF/reaxff_api.h
@@ -41,7 +41,7 @@ struct API {
 
 extern void Allocate_Workspace(control_params *, storage *, int);
 extern void DeAllocate_System(reax_system *);
-extern void DeAllocate_Workspace(control_params *, storage *);
+extern void DeAllocate_Workspace(storage *);
 extern void PreAllocate_Space(reax_system *, storage *);
 extern void ReAllocate(reax_system *, control_params *, simulation_data *, storage *, reax_list **);
 

--- a/src/REAXFF/reaxff_api.h
+++ b/src/REAXFF/reaxff_api.h
@@ -142,7 +142,7 @@ extern void Reset_Workspace(reax_system *, storage *);
 
 extern void *scalloc(LAMMPS_NS::Error *, rc_bigint, rc_bigint, const std::string &);
 extern void *smalloc(LAMMPS_NS::Error *, rc_bigint, const std::string &);
-extern void sfree(LAMMPS_NS::Error *, void *, const std::string &);
+extern void sfree(void *, const std::string &);
 
 // torsion angles
 

--- a/src/REAXFF/reaxff_bonds.cpp
+++ b/src/REAXFF/reaxff_bonds.cpp
@@ -75,6 +75,7 @@ namespace ReaxFF {
         /* set the pointers */
         type_i = system->my_atoms[i].type;
         type_j = system->my_atoms[j].type;
+        if ((type_i < 0) || (type_j < 0)) continue;
         sbp_i = &(system->reax_param.sbp[type_i]);
         sbp_j = &(system->reax_param.sbp[type_j]);
         twbp = &(system->reax_param.tbp[type_i][type_j]);

--- a/src/REAXFF/reaxff_hydrogen_bonds.cpp
+++ b/src/REAXFF/reaxff_hydrogen_bonds.cpp
@@ -154,6 +154,6 @@ namespace ReaxFF {
           }
         }
       }
-    } 
+    }
   }
 }

--- a/src/REAXFF/reaxff_hydrogen_bonds.cpp
+++ b/src/REAXFF/reaxff_hydrogen_bonds.cpp
@@ -59,14 +59,14 @@ namespace ReaxFF {
     hbonds = (*lists) + HBONDS;
     hbond_list = hbonds->select.hbond_list;
 
-    for (j = 0; j < system->n; ++j)
-      if ((system->my_atoms[j].type >= 0) && (system->reax_param.sbp[system->my_atoms[j].type].p_hbond == 1)) {
-        type_j     = system->my_atoms[j].type;
+    for (j = 0; j < system->n; ++j) {
+      type_j = system->my_atoms[j].type;
+      if (type_j < 0) continue;
+      if (system->reax_param.sbp[type_j].p_hbond == 1) {
         start_j    = Start_Index(j, bonds);
         end_j      = End_Index(j, bonds);
         hb_start_j = Start_Index(system->my_atoms[j].Hindex, hbonds);
         hb_end_j   = End_Index(system->my_atoms[j].Hindex, hbonds);
-        if (type_j < 0) continue;
 
         top = 0;
         for (pi = start_j; pi < end_j; ++pi)  {
@@ -154,5 +154,6 @@ namespace ReaxFF {
           }
         }
       }
+    } 
   }
 }

--- a/src/REAXFF/reaxff_hydrogen_bonds.cpp
+++ b/src/REAXFF/reaxff_hydrogen_bonds.cpp
@@ -60,7 +60,7 @@ namespace ReaxFF {
     hbond_list = hbonds->select.hbond_list;
 
     for (j = 0; j < system->n; ++j)
-      if (system->reax_param.sbp[system->my_atoms[j].type].p_hbond == 1) {
+      if ((system->my_atoms[j].type >= 0) && (system->reax_param.sbp[system->my_atoms[j].type].p_hbond == 1)) {
         type_j     = system->my_atoms[j].type;
         start_j    = Start_Index(j, bonds);
         end_j      = End_Index(j, bonds);

--- a/src/REAXFF/reaxff_init_md.cpp
+++ b/src/REAXFF/reaxff_init_md.cpp
@@ -56,7 +56,7 @@ namespace ReaxFF {
     if (control->hbond_cut > 0)
       for (i = 0; i < system->n; ++i) {
         atom = &(system->my_atoms[i]);
-        if (system->reax_param.sbp[atom->type].p_hbond == 1 && atom->type >= 0)
+        if ((atom->type >= 0) && (system->reax_param.sbp[atom->type].p_hbond == 1 && atom->type >= 0))
           atom->Hindex = system->numH++;
         else atom->Hindex = -1;
       }

--- a/src/REAXFF/reaxff_init_md.cpp
+++ b/src/REAXFF/reaxff_init_md.cpp
@@ -56,7 +56,8 @@ namespace ReaxFF {
     if (control->hbond_cut > 0)
       for (i = 0; i < system->n; ++i) {
         atom = &(system->my_atoms[i]);
-        if ((atom->type >= 0) && (system->reax_param.sbp[atom->type].p_hbond == 1 && atom->type >= 0))
+        if ((atom->type >= 0)
+            && (system->reax_param.sbp[atom->type].p_hbond == 1 && atom->type >= 0))
           atom->Hindex = system->numH++;
         else atom->Hindex = -1;
       }

--- a/src/REAXFF/reaxff_list.cpp
+++ b/src/REAXFF/reaxff_list.cpp
@@ -39,8 +39,8 @@ namespace ReaxFF {
     l->n = n;
     l->num_intrs = num_intrs;
 
-    if (l->index) sfree(l->index, "list:index");
-    if (l->end_index) sfree(l->end_index, "list:end_index");
+    if (l->index) sfree(l->index);
+    if (l->end_index) sfree(l->end_index);
     l->index = (int*) smalloc(l->error_ptr, n * sizeof(int), "list:index");
     l->end_index = (int*) smalloc(l->error_ptr, n * sizeof(int), "list:end_index");
 
@@ -48,26 +48,26 @@ namespace ReaxFF {
 
     switch(l->type) {
     case TYP_THREE_BODY:
-      if (l->select.three_body_list) sfree(l->select.three_body_list,"list:three_bodies");
+      if (l->select.three_body_list) sfree(l->select.three_body_list);
       l->select.three_body_list = (three_body_interaction_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(three_body_interaction_data),
                 "list:three_bodies");
       break;
 
     case TYP_BOND:
-      if (l->select.bond_list) sfree(l->select.bond_list,"list:bonds");
+      if (l->select.bond_list) sfree(l->select.bond_list);
       l->select.bond_list = (bond_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(bond_data), "list:bonds");
       break;
 
     case TYP_FAR_NEIGHBOR:
-      if (l->select.far_nbr_list) sfree(l->select.far_nbr_list,"list:far_nbrs");
+      if (l->select.far_nbr_list) sfree(l->select.far_nbr_list);
       l->select.far_nbr_list = (far_neighbor_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(far_neighbor_data), "list:far_nbrs");
       break;
 
     case TYP_HBOND:
-      if (l->select.hbond_list) sfree(l->select.hbond_list,"list:hbonds");
+      if (l->select.hbond_list) sfree(l->select.hbond_list);
       l->select.hbond_list = (hbond_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(hbond_data), "list:hbonds");
       break;
@@ -83,26 +83,26 @@ namespace ReaxFF {
       return;
     l->allocated = 0;
 
-    sfree(l->index, "list:index");
-    sfree(l->end_index, "list:end_index");
+    sfree(l->index);
+    sfree(l->end_index);
     l->index = nullptr;
     l->end_index = nullptr;
 
     switch(l->type) {
     case TYP_HBOND:
-      sfree(l->select.hbond_list, "list:hbonds");
+      sfree(l->select.hbond_list);
       l->select.hbond_list = nullptr;
       break;
     case TYP_FAR_NEIGHBOR:
-      sfree(l->select.far_nbr_list, "list:far_nbrs");
+      sfree(l->select.far_nbr_list);
       l->select.far_nbr_list = nullptr;
       break;
     case TYP_BOND:
-      sfree(l->select.bond_list, "list:bonds");
+      sfree(l->select.bond_list);
       l->select.bond_list = nullptr;
       break;
     case TYP_THREE_BODY:
-      sfree(l->select.three_body_list, "list:three_bodies");
+      sfree(l->select.three_body_list);
       l->select.three_body_list = nullptr;
       break;
 

--- a/src/REAXFF/reaxff_list.cpp
+++ b/src/REAXFF/reaxff_list.cpp
@@ -39,8 +39,8 @@ namespace ReaxFF {
     l->n = n;
     l->num_intrs = num_intrs;
 
-    if (l->index) sfree(l->error_ptr, l->index, "list:index");
-    if (l->end_index) sfree(l->error_ptr, l->end_index, "list:end_index");
+    if (l->index) sfree(l->index, "list:index");
+    if (l->end_index) sfree(l->end_index, "list:end_index");
     l->index = (int*) smalloc(l->error_ptr, n * sizeof(int), "list:index");
     l->end_index = (int*) smalloc(l->error_ptr, n * sizeof(int), "list:end_index");
 
@@ -48,26 +48,26 @@ namespace ReaxFF {
 
     switch(l->type) {
     case TYP_THREE_BODY:
-      if (l->select.three_body_list) sfree(l->error_ptr, l->select.three_body_list,"list:three_bodies");
+      if (l->select.three_body_list) sfree(l->select.three_body_list,"list:three_bodies");
       l->select.three_body_list = (three_body_interaction_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(three_body_interaction_data),
                 "list:three_bodies");
       break;
 
     case TYP_BOND:
-      if (l->select.bond_list) sfree(l->error_ptr, l->select.bond_list,"list:bonds");
+      if (l->select.bond_list) sfree(l->select.bond_list,"list:bonds");
       l->select.bond_list = (bond_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(bond_data), "list:bonds");
       break;
 
     case TYP_FAR_NEIGHBOR:
-      if (l->select.far_nbr_list) sfree(l->error_ptr, l->select.far_nbr_list,"list:far_nbrs");
+      if (l->select.far_nbr_list) sfree(l->select.far_nbr_list,"list:far_nbrs");
       l->select.far_nbr_list = (far_neighbor_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(far_neighbor_data), "list:far_nbrs");
       break;
 
     case TYP_HBOND:
-      if (l->select.hbond_list) sfree(l->error_ptr, l->select.hbond_list,"list:hbonds");
+      if (l->select.hbond_list) sfree(l->select.hbond_list,"list:hbonds");
       l->select.hbond_list = (hbond_data*)
         smalloc(l->error_ptr, (rc_bigint) num_intrs * sizeof(hbond_data), "list:hbonds");
       break;
@@ -83,26 +83,26 @@ namespace ReaxFF {
       return;
     l->allocated = 0;
 
-    sfree(l->error_ptr, l->index, "list:index");
-    sfree(l->error_ptr, l->end_index, "list:end_index");
+    sfree(l->index, "list:index");
+    sfree(l->end_index, "list:end_index");
     l->index = nullptr;
     l->end_index = nullptr;
 
     switch(l->type) {
     case TYP_HBOND:
-      sfree(l->error_ptr, l->select.hbond_list, "list:hbonds");
+      sfree(l->select.hbond_list, "list:hbonds");
       l->select.hbond_list = nullptr;
       break;
     case TYP_FAR_NEIGHBOR:
-      sfree(l->error_ptr, l->select.far_nbr_list, "list:far_nbrs");
+      sfree(l->select.far_nbr_list, "list:far_nbrs");
       l->select.far_nbr_list = nullptr;
       break;
     case TYP_BOND:
-      sfree(l->error_ptr, l->select.bond_list, "list:bonds");
+      sfree(l->select.bond_list, "list:bonds");
       l->select.bond_list = nullptr;
       break;
     case TYP_THREE_BODY:
-      sfree(l->error_ptr, l->select.three_body_list, "list:three_bodies");
+      sfree(l->select.three_body_list, "list:three_bodies");
       l->select.three_body_list = nullptr;
       break;
 

--- a/src/REAXFF/reaxff_lookup.cpp
+++ b/src/REAXFF/reaxff_lookup.cpp
@@ -90,11 +90,11 @@ namespace ReaxFF {
       coef[i-1].a = f[i];
     }
 
-    sfree(a, "cubic_spline:a");
-    sfree(b, "cubic_spline:b");
-    sfree(c, "cubic_spline:c");
-    sfree(d, "cubic_spline:d");
-    sfree(v, "cubic_spline:v");
+    sfree(a);
+    sfree(b);
+    sfree(c);
+    sfree(d);
+    sfree(v);
   }
 
   void Complete_Cubic_Spline(LAMMPS_NS::Error* error_ptr, const double *h,
@@ -138,11 +138,11 @@ namespace ReaxFF {
       coef[i-1].a = f[i];
     }
 
-    sfree(a, "cubic_spline:a");
-    sfree(b, "cubic_spline:b");
-    sfree(c, "cubic_spline:c");
-    sfree(d, "cubic_spline:d");
-    sfree(v, "cubic_spline:v");
+    sfree(a);
+    sfree(b);
+    sfree(c);
+    sfree(d);
+    sfree(v);
   }
 
   void Init_Lookup_Tables(reax_system *system, control_params *control,
@@ -276,16 +276,16 @@ namespace ReaxFF {
     for (i = 0; i < ntypes; ++i) {
       for (j = i; j < ntypes; ++j)
         if (LR[i][j].n) {
-          sfree(LR[i][j].y, "LR[i,j].y");
-          sfree(LR[i][j].H, "LR[i,j].H");
-          sfree(LR[i][j].vdW, "LR[i,j].vdW");
-          sfree(LR[i][j].CEvd, "LR[i,j].CEvd");
-          sfree(LR[i][j].ele, "LR[i,j].ele");
-          sfree(LR[i][j].CEclmb, "LR[i,j].CEclmb");
+          sfree(LR[i][j].y);
+          sfree(LR[i][j].H);
+          sfree(LR[i][j].vdW);
+          sfree(LR[i][j].CEvd);
+          sfree(LR[i][j].ele);
+          sfree(LR[i][j].CEclmb);
         }
-      sfree(LR[i], "LR[i]");
+      sfree(LR[i]);
     }
-    sfree(LR, "LR");
+    sfree(LR);
   }
 }
 

--- a/src/REAXFF/reaxff_lookup.cpp
+++ b/src/REAXFF/reaxff_lookup.cpp
@@ -90,11 +90,11 @@ namespace ReaxFF {
       coef[i-1].a = f[i];
     }
 
-    sfree(error_ptr, a, "cubic_spline:a");
-    sfree(error_ptr, b, "cubic_spline:b");
-    sfree(error_ptr, c, "cubic_spline:c");
-    sfree(error_ptr, d, "cubic_spline:d");
-    sfree(error_ptr, v, "cubic_spline:v");
+    sfree(a, "cubic_spline:a");
+    sfree(b, "cubic_spline:b");
+    sfree(c, "cubic_spline:c");
+    sfree(d, "cubic_spline:d");
+    sfree(v, "cubic_spline:v");
   }
 
   void Complete_Cubic_Spline(LAMMPS_NS::Error* error_ptr, const double *h,
@@ -138,11 +138,11 @@ namespace ReaxFF {
       coef[i-1].a = f[i];
     }
 
-    sfree(error_ptr, a, "cubic_spline:a");
-    sfree(error_ptr, b, "cubic_spline:b");
-    sfree(error_ptr, c, "cubic_spline:c");
-    sfree(error_ptr, d, "cubic_spline:d");
-    sfree(error_ptr, v, "cubic_spline:v");
+    sfree(a, "cubic_spline:a");
+    sfree(b, "cubic_spline:b");
+    sfree(c, "cubic_spline:c");
+    sfree(d, "cubic_spline:d");
+    sfree(v, "cubic_spline:v");
   }
 
   void Init_Lookup_Tables(reax_system *system, control_params *control,
@@ -276,16 +276,16 @@ namespace ReaxFF {
     for (i = 0; i < ntypes; ++i) {
       for (j = i; j < ntypes; ++j)
         if (LR[i][j].n) {
-          sfree(system->error_ptr, LR[i][j].y, "LR[i,j].y");
-          sfree(system->error_ptr, LR[i][j].H, "LR[i,j].H");
-          sfree(system->error_ptr, LR[i][j].vdW, "LR[i,j].vdW");
-          sfree(system->error_ptr, LR[i][j].CEvd, "LR[i,j].CEvd");
-          sfree(system->error_ptr, LR[i][j].ele, "LR[i,j].ele");
-          sfree(system->error_ptr, LR[i][j].CEclmb, "LR[i,j].CEclmb");
+          sfree(LR[i][j].y, "LR[i,j].y");
+          sfree(LR[i][j].H, "LR[i,j].H");
+          sfree(LR[i][j].vdW, "LR[i,j].vdW");
+          sfree(LR[i][j].CEvd, "LR[i,j].CEvd");
+          sfree(LR[i][j].ele, "LR[i,j].ele");
+          sfree(LR[i][j].CEclmb, "LR[i,j].CEclmb");
         }
-      sfree(system->error_ptr, LR[i], "LR[i]");
+      sfree(LR[i], "LR[i]");
     }
-    sfree(system->error_ptr, LR, "LR");
+    sfree(LR, "LR");
   }
 }
 

--- a/src/REAXFF/reaxff_nonbonded.cpp
+++ b/src/REAXFF/reaxff_nonbonded.cpp
@@ -233,8 +233,8 @@ namespace ReaxFF {
         flag = 0;
 
         /* kinetic energy terms */
-        double xcut = 0.5 * ( system->reax_param.sbp[ system->my_atoms[i].type ].bcut_acks2
-                            + system->reax_param.sbp[ system->my_atoms[j].type ].bcut_acks2 );
+        double xcut = 0.5 * (system->reax_param.sbp[system->my_atoms[i].type].bcut_acks2
+                             + system->reax_param.sbp[system->my_atoms[j].type].bcut_acks2);
 
         if(nbr_pj->d <= xcut) {
           if (j < natoms) flag = 1;
@@ -409,8 +409,8 @@ namespace ReaxFF {
         flag = 0;
 
         /* kinetic energy terms */
-        double xcut = 0.5 * ( system->reax_param.sbp[ system->my_atoms[i].type ].bcut_acks2
-                            + system->reax_param.sbp[ system->my_atoms[j].type ].bcut_acks2 );
+        double xcut = 0.5 * (system->reax_param.sbp[ system->my_atoms[i].type ].bcut_acks2
+                             + system->reax_param.sbp[ system->my_atoms[j].type ].bcut_acks2);
 
         if(nbr_pj->d <= xcut) {
           if (j < natoms) flag = 1;

--- a/src/REAXFF/reaxff_tool_box.cpp
+++ b/src/REAXFF/reaxff_tool_box.cpp
@@ -96,7 +96,7 @@ void *scalloc(LAMMPS_NS::Error *error_ptr, rc_bigint n, rc_bigint size, const st
 }
 
 /* safe free */
-void sfree(void *ptr, const std::string &name)
+void sfree(void *ptr)
 {
   if (ptr == nullptr) return;
 

--- a/src/REAXFF/reaxff_tool_box.cpp
+++ b/src/REAXFF/reaxff_tool_box.cpp
@@ -96,16 +96,9 @@ void *scalloc(LAMMPS_NS::Error *error_ptr, rc_bigint n, rc_bigint size, const st
 }
 
 /* safe free */
-void sfree(LAMMPS_NS::Error *error_ptr, void *ptr, const std::string &name)
+void sfree(void *ptr, const std::string &name)
 {
-  if (ptr == nullptr) {
-    auto errmsg = std::string("Trying to free the already free()'d pointer: ") + name;
-    if (error_ptr)
-      error_ptr->one(FLERR, errmsg);
-    else
-      fputs(errmsg.c_str(), stderr);
-    return;
-  }
+  if (ptr == nullptr) return;
 
   free(ptr);
   ptr = nullptr;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -97,7 +97,7 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   tabinner_disp = sqrt(2.0);
   ftable = nullptr;
   fdisptable = nullptr;
-  trim_flag = 0;
+  trim_flag = 1;
 
   allocated = 0;
   suffix_flag = Suffix::NONE;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -97,7 +97,7 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   tabinner_disp = sqrt(2.0);
   ftable = nullptr;
   fdisptable = nullptr;
-  trim_flag = 1;
+  trim_flag = 0;
 
   allocated = 0;
   suffix_flag = Suffix::NONE;

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -304,8 +304,6 @@ void PairHybrid::settings(int narg, char **arg)
   // allocate list of sub-styles as big as possibly needed if no extra args
 
   styles = new Pair *[narg];
-  cutmax_style = new double[narg];
-  memset(cutmax_style, 0.0, narg*sizeof(double));
   keywords = new char *[narg];
   multiple = new int[narg];
 
@@ -346,6 +344,9 @@ void PairHybrid::settings(int narg, char **arg)
     iarg = jarg;
     nstyles++;
   }
+
+  cutmax_style = new double[nstyles];
+  memset(cutmax_style, 0.0, nstyles*sizeof(double));
 
   // multiple[i] = 1 to M if sub-style used multiple times, else 0
 
@@ -582,6 +583,8 @@ void PairHybrid::init_style()
 {
   int i,m,itype,jtype,used,istyle,skip;
 
+  memset(cutmax_style, 0.0, nstyles*sizeof(double));
+
   // error if a sub-style is not used
 
   int ntypes = atom->ntypes;
@@ -750,7 +753,7 @@ double PairHybrid::init_one(int i, int j)
         cutmax_style[istyle] = cut;
 
         for (auto &request : neighbor->get_pair_requests()) {
-          if (styles[istyle] == request->get_requestor() && styles[istyle]->trim_flag) {
+          if (styles[istyle] == request->get_requestor()) {
             request->set_cutoff(cutmax_style[istyle]);
             break;
           }

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -345,8 +345,9 @@ void PairHybrid::settings(int narg, char **arg)
     nstyles++;
   }
 
+  delete[] cutmax_style;
   cutmax_style = new double[nstyles];
-  memset(cutmax_style, 0.0, nstyles*sizeof(double));
+  memset(cutmax_style, 0, nstyles*sizeof(double));
 
   // multiple[i] = 1 to M if sub-style used multiple times, else 0
 
@@ -583,7 +584,7 @@ void PairHybrid::init_style()
 {
   int i,m,itype,jtype,used,istyle,skip;
 
-  memset(cutmax_style, 0.0, nstyles*sizeof(double));
+  memset(cutmax_style, 0, nstyles*sizeof(double));
 
   // error if a sub-style is not used
 
@@ -822,8 +823,9 @@ void PairHybrid::read_restart(FILE *fp)
   delete[] compute_tally;
 
   styles = new Pair*[nstyles];
+  delete[] cutmax_style;
   cutmax_style = new double[nstyles];
-  memset(cutmax_style, 0.0, nstyles*sizeof(double));
+  memset(cutmax_style, 0, nstyles*sizeof(double));
   keywords = new char*[nstyles];
   multiple = new int[nstyles];
 

--- a/src/pair_hybrid_overlay.cpp
+++ b/src/pair_hybrid_overlay.cpp
@@ -23,7 +23,9 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairHybridOverlay::PairHybridOverlay(LAMMPS *lmp) : PairHybrid(lmp) {}
+PairHybridOverlay::PairHybridOverlay(LAMMPS *lmp) : PairHybrid(lmp) {
+  trim_flag = 1;
+}
 
 /* ----------------------------------------------------------------------
    set coeffs for one or more type pairs

--- a/src/pair_hybrid_overlay.cpp
+++ b/src/pair_hybrid_overlay.cpp
@@ -23,9 +23,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairHybridOverlay::PairHybridOverlay(LAMMPS *lmp) : PairHybrid(lmp) {
-  trim_flag = 1;
-}
+PairHybridOverlay::PairHybridOverlay(LAMMPS *lmp) : PairHybrid(lmp) {}
 
 /* ----------------------------------------------------------------------
    set coeffs for one or more type pairs


### PR DESCRIPTION
**Summary**

- Fix reading uninitialized variable in Kokkos ReaxFF
- Fix out of bounds access in pair_vashishta_kokkos with skip list
- Fix memory leak in Kokkos ReaxFF
- Fix memory leak in PairLJCutKokkos
- Fix logic for neigh/trim yes and multiple runs
- Fix invalid memory read in ReaxFF
- Fix bug in ReaxFF with pair hybrid, where it was missing interactions and giving wrong numerics
- Fix bug in Kokkos neigh list build for half list when `newton_pair` was different than the neigh list request (only happens for ReaxFF).

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), Axel Kohlmeyer (Temple)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes