### PR TITLE
Correct typos and clarify fix_controller.rst

### DIFF
--- a/doc/src/fix_controller.rst
+++ b/doc/src/fix_controller.rst
@@ -96,7 +96,7 @@ the following dynamic equation:
 
 .. math::
 
-   \frac{dc}{dt}  = \hat{E} -\alpha (K_p e + K_i \int_0^t e \, dt + K_d \frac{de}{dt} )
+   \frac{dc}{dt}  = -\alpha (K_p e + K_i \int_0^t e \, dt + K_d \frac{de}{dt} )
 
 where *c* is the continuous time analog of the control variable,
 *e* =\ *pvar*\ -\ *setpoint* is the error in the process variable, and
@@ -106,7 +106,7 @@ keywords described above. The discretized version of this equation is:
 
 .. math::
 
-   c_n  = \hat{E} c_{n-1} -\alpha \left( K_p \tau e_n + K_i \tau^2 \sum_{i=1}^n e_i + K_d (e_n - e_{n-1}) \right)
+   c_n  = c_{n-1} -\alpha \left( K_p \tau e_n + K_i \tau^2 \sum_{i=1}^n e_i + K_d (e_n - e_{n-1}) \right)
 
 where :math:`\tau = \mathtt{Nevery} \cdot \mathtt{timestep}` is the time
 interval between updates,
@@ -129,7 +129,7 @@ magnitudes and signs of *pvar* and *cvar*\ .  The magnitude of :math:`K_p`
 should then be tested over a large positive range keeping :math:`K_i = K_d =0`.
 A good value for :math:`K_p` will produce a fast response in *pvar*,
 without overshooting the *setpoint*\ .  For many applications, proportional
-feedback is sufficient, and so :math:`K_i` = K_d =0` can be used. In cases
+feedback is sufficient, and so :math:`K_i = K_d =0` can be used. In cases
 where there is a substantial lag time in the response of *pvar* to a change
 in *cvar*, this can be counteracted by increasing :math:`K_d`. In situations
 where *pvar* plateaus without reaching *setpoint*, this can be
@@ -138,12 +138,12 @@ counteracted by increasing :math:`K_i`.  In the language of Charles Dickens,
 the past, and :math:`K_d` the error yet to come.
 
 Because this fix updates *cvar*, but does not initialize its value,
-the initial value is that assigned by the user in the input script via
+the initial value :math:`c_0` is that assigned by the user in the input script via
 the :doc:`internal-style variable <variable>` command.  This value is
-used (by the other LAMMPS command that used the variable) until this
+used (by every other LAMMPS command that uses the variable) until this
 fix performs its first update of *cvar* after *Nevery* timesteps.  On
 the first update, the value of the derivative term is set to zero,
-because the value of :math:`e_n-1` is not yet defined.
+because the value of :math:`e_{n-1}` is not yet defined.
 
 ----------
 


### PR DESCRIPTION
**Summary**

Fixes some typos and adds math expression c_0 for the initial control variable value; removes the "E-hat" term from equations (which doesn't appear elsewhere in the support doc or the source code)

**Author(s)**

Shern Tee, University of Queensland

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).