### PR TITLE
Align fix_controller.cpp with documentation

### DIFF
--- a/src/EXTRA-FIX/fix_controller.cpp
+++ b/src/EXTRA-FIX/fix_controller.cpp
@@ -215,8 +215,8 @@ void FixController::end_of_step()
     deltaerr = sumerr = 0.0;
   } else {
     deltaerr = err - olderr;
-    sumerr += err;
   }
+  sumerr += err;
 
   // 3 terms of PID equation
 


### PR DESCRIPTION
**Summary**

Documentation for `fix controller` says that the first calculation of error contributes to the integral term (in equation 2, at $n = 1$). Either the code should be changed to reflect this, or the documentation should be changed to reflect what the code currently does (i.e. start from $n = 2$ in the finite-difference integral term).

**Author(s)**

Shern Tee, University of Queensland

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This change slightly changes the integral term in `fix controller` output. The impact of the term scales inversely with the number of timesteps in the simulation and should be minimal for any statistically acceptable production run.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

