### PR TITLE
Update documentation for revised release and branch names

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,17 +32,21 @@ for unicode characters and only all-ASCII source code is accepted.
 
 LAMMPS follows a continuous release development model.  We aim to keep
 the development version (`develop` branch) always fully functional and
-employ a variety of automatic testing procedures to detect failures
-of existing functionality from adding or modifying features.  Most of
-those tests are run on pull requests *before* merging to the `develop`
-branch.  The `develop` branch is protected, so all changes *must* be
-submitted as a pull request and thus cannot avoid the automated tests.
+employ a variety of automatic testing procedures to detect failures of
+existing functionality from adding or modifying features.  Most of those
+tests are run on pull requests and must be passed *before* merging to
+the `develop` branch.  The `develop` branch is protected, so all changes
+*must* be submitted as a pull request and thus cannot avoid the
+automated tests.
 
 Additional tests are run *after* merging.  Before releases are made
 *all* tests must have cleared.  Then a release tag is applied and the
-`release` branch is fast-forwarded to that tag.  This is often referred
-to as a patch release. Bug fixes and updates are
-applied first to the `develop` branch.  Later, they appear in the `release`
-branch when the next patch release occurs.
-For stable releases, selected bug fixes, updates, and new functionality
-are pushed to the `stable` branch and a new stable tag is applied.
+`release` branch is fast-forwarded to that tag.  This is referred to to
+as a "feature release".  Bug fixes and updates are applied first to the
+`develop` branch.  Later, they appear in the `release` branch when the
+next patch release occurs.  For stable releases, backported bug fixes
+and infrastructure updates are first applied to the `maintenance` branch
+and then merged to `stable` and published as "updates".  For a new
+stable release the `stable` branch is updated to the corresponding state
+of the `release` branch and a new stable tag is applied in addition to
+the release tag.

--- a/doc/github-development-workflow.md
+++ b/doc/github-development-workflow.md
@@ -27,42 +27,45 @@ should doing the merging itself.  This is currently
 assignment needs to be changed, it shall be done right after a stable
 release.  If the currently assigned developer cannot merge outstanding
 pull requests in a timely manner, or in other extenuating circumstances,
-other core LAMMPS developers with merge rights can merge pull requests,
-when necessary.
+other core LAMMPS developers with merge permissons may merge pull
+requests.
 
 ## Pull Requests
 
-ALL changes to the LAMMPS code and documentation, however trivial, MUST
-be submitted as a pull request to GitHub. All changes to the "develop"
-branch must be made exclusively through merging pull requests. The
+*ALL* changes to the LAMMPS code and documentation, however trivial, MUST
+be submitted as a pull request to GitHub.  All changes to the "develop"
+branch must be made exclusively through merging pull requests.  The
 "release" and "stable" branches, respectively are only to be updated
-upon patch or stable releases with fast-forward merges based on the
-associated tags. Pull requests may also be submitted to (long-running)
-feature branches created by LAMMPS developers inside the LAMMPS project,
-if needed. Those are not subject to the merge and review restrictions
-discussed in this document, though, but get managed as needed on a
-case-by-case basis.
+upon feature or stable releases based on the associated tags. Updates to
+stable release in between stable releases (e.g. backported bugfixes)
+are first merged into the "maintenance" branch and then into the "stable"
+branch as update releases.
+
+Pull requests may also be submitted to (long-running) feature branches
+created by LAMMPS developers inside the LAMMPS project, if needed. Those
+are not subject to the merge and review restrictions discussed in this
+document, though, but get managed as needed on a case-by-case basis.
 
 ### Pull Request Assignments
 
 Pull requests can be "chaperoned" by one of the LAMMPS core developers.
-This is indicated by who the pull request is assigned to. LAMMPS core
+This is indicated by who the pull request is assigned to.  LAMMPS core
 developers can self-assign or they can decide to assign a pull request
 to a different LAMMPS developer. Being assigned to a pull request means,
 that this pull request may need some work and the assignee is tasked to
 determine whether this might be needed or not, and may either implement
-the required changes or ask the submitter of the pull request to implement
-them.  Even though, all LAMMPS developers may have write access to pull
-requests (if enabled by the submitter, which is the default), only the
-submitter or the assignee of a pull request may do so.  During this
-period the `work_in_progress` label may be applied to the pull
-request.  The assignee gets to decide what happens to the pull request
-next, e.g. whether it should be assigned to a different developer for
-additional checks and changes, or is recommended to be merged.  Removing
-the `work_in_progress` label and assigning the pull request to the
-developer tasked with merging signals that a pull request is ready to be
-merged. In addition, a `ready_for_merge` label may also be assigned
-to signal urgency to merge this pull request quickly.
+the required changes or ask the submitter of the pull request to
+implement them.  Even though, all LAMMPS developers may have write
+access to pull requests (if enabled by the submitter, which is the
+default), only the submitter or the assignee of a pull request may do
+so.  During this period the `work_in_progress` label may be applied to
+the pull request.  The assignee gets to decide what happens to the pull
+request next, e.g. whether it should be assigned to a different
+developer for additional checks and changes, or is recommended to be
+merged.  Removing the `work_in_progress` label and assigning the pull
+request to the developer tasked with merging signals that a pull request
+is ready to be merged. In addition, a `ready_for_merge` label may also
+be assigned to signal urgency to merge this pull request quickly.
 
 ### Pull Request Reviews
 
@@ -126,22 +129,26 @@ changes, i.e. significant effort is made - including automated pre-merge
 testing - that the code in the branch "develop" does not get easily
 broken.  These tests are run after every update to a pull request.  More
 extensive and time consuming tests (including regression testing) are
-performed after code is merged to the "develop" branch. There are patch
-releases of LAMMPS every 3-5 weeks at a point, when the LAMMPS
-developers feel, that a sufficient amount of changes have happened, and
-the post-merge testing has been successful. These patch releases are
+performed after code is merged to the "develop" branch.  There are feature
+releases of LAMMPS made about every 4-6 weeks at a point, when the LAMMPS
+developers feel, that a sufficient amount of changes have been included,
+and all post-merge testing has been successful.  These feature releases are
 marked with a `patch_<version date>` tag and the "release" branch
-follows only these versions (and thus is always supposed to be of
-production quality, unlike "develop", which may be temporary broken, in
-the case of larger change sets or unexpected incompatibilities or side
-effects.
+follows only these versions with fast forward merges.  While "develop" may
+be temporary broken through issues only detected by the post-merge tests,
+The "release" branch is always supposed to be of production quality.
 
-About 1-2 times each year, there are going to be "stable" releases of
+About once each year, there are going to be "stable" releases of
 LAMMPS.  These have seen additional, manual testing and review of
 results from testing with instrumented code and static code analysis.
-Also, the last 1-3 patch releases before a stable release are "release
-candidate" versions which only contain bugfixes and documentation
-updates.  For release planning and the information of code contributors,
-issues and pull requests being actively worked on are assigned a
-"milestone", which corresponds to the next stable release or the stable
-release after that, with a tentative release date.
+Also, the last few feature releases before a stable release are "release
+candidate" versions which only contain bugfixes, feature additions to
+peripheral functionality, and documentation updates.  In between stable
+releases, bugfixes and infrastructure updates are backported from the
+"develop" branch to the "maintenance" branch and occasionally merged
+into "stable" and published as update releases.
+
+For release planning and the information of code contributors, issues
+and pull requests being actively worked on are assigned a "milestone",
+which corresponds to the next stable release or the stable release after
+that, with a tentative release date.

--- a/doc/github-development-workflow.md
+++ b/doc/github-development-workflow.md
@@ -1,12 +1,12 @@
 # Outline of the GitHub Development Workflow
 
-This purpose of this document is to provide a point of reference for the
+The purpose of this document is to provide a point of reference for the
 core LAMMPS developers and other LAMMPS contributors to understand the
 choices the LAMMPS developers have agreed on. Git and GitHub provide the
 tools, but do not set policies, so it is up to the developers to come to
 an agreement as to how to define and interpret policies. This document
-is likely to change as our experiences and needs change and we try to
-adapt accordingly. Last change 2021-09-02.
+is likely to change as our experiences and needs change, and we try to
+adapt it accordingly. Last change 2023-02-10.
 
 ## Table of Contents
 
@@ -22,24 +22,24 @@ adapt accordingly. Last change 2021-09-02.
 ## GitHub Merge Management
 
 In the interest of consistency, ONLY ONE of the core LAMMPS developers
-should doing the merging itself.  This is currently
+should do the merging.  This is currently
 [@akohlmey](https://github.com/akohlmey) (Axel Kohlmeyer).  If this
 assignment needs to be changed, it shall be done right after a stable
 release.  If the currently assigned developer cannot merge outstanding
 pull requests in a timely manner, or in other extenuating circumstances,
-other core LAMMPS developers with merge permissons may merge pull
+other core LAMMPS developers with merge permission may merge pull
 requests.
 
 ## Pull Requests
 
-*ALL* changes to the LAMMPS code and documentation, however trivial, MUST
-be submitted as a pull request to GitHub.  All changes to the "develop"
-branch must be made exclusively through merging pull requests.  The
-"release" and "stable" branches, respectively are only to be updated
-upon feature or stable releases based on the associated tags. Updates to
-stable release in between stable releases (e.g. backported bugfixes)
-are first merged into the "maintenance" branch and then into the "stable"
-branch as update releases.
+*ALL* changes to the LAMMPS code and documentation, however trivial,
+MUST be submitted as a pull request to GitHub.  All changes to the
+"develop" branch must be made exclusively through merging pull requests.
+The "release" and "stable" branches, respectively, are only to be
+updated upon feature or stable releases based on the associated
+tags.  Updates to the stable release in between stable releases
+(for example, back-ported bug fixes) are first merged into the "maintenance"
+branch and then into the "stable" branch as update releases.
 
 Pull requests may also be submitted to (long-running) feature branches
 created by LAMMPS developers inside the LAMMPS project, if needed. Those
@@ -49,16 +49,16 @@ document, though, but get managed as needed on a case-by-case basis.
 ### Pull Request Assignments
 
 Pull requests can be "chaperoned" by one of the LAMMPS core developers.
-This is indicated by who the pull request is assigned to.  LAMMPS core
-developers can self-assign or they can decide to assign a pull request
+This is indicated by whom the pull request is assigned to.  LAMMPS core
+developers can self-assign, or they can decide to assign a pull request
 to a different LAMMPS developer. Being assigned to a pull request means,
 that this pull request may need some work and the assignee is tasked to
-determine whether this might be needed or not, and may either implement
-the required changes or ask the submitter of the pull request to
-implement them.  Even though, all LAMMPS developers may have write
-access to pull requests (if enabled by the submitter, which is the
-default), only the submitter or the assignee of a pull request may do
-so.  During this period the `work_in_progress` label may be applied to
+determine whether this might be needed or not. The assignee may either
+choose to implement required changes or ask the submitter of the pull
+request to implement them.  Even though, all LAMMPS developers may have
+write access to pull requests (if enabled by the submitter, which is the
+default), only the submitter or the assignee of a pull request should do
+so.  During this period, the `work_in_progress` label may be applied to
 the pull request.  The assignee gets to decide what happens to the pull
 request next, e.g. whether it should be assigned to a different
 developer for additional checks and changes, or is recommended to be
@@ -73,32 +73,33 @@ People can be assigned to review a pull request in two ways:
 
   * They can be assigned manually to review a pull request
     by the submitter or a LAMMPS developer
-  * They can be automatically assigned, because a developers matches
-    a file pattern in the `.github/CODEOWNERS` file, which associates
-    developers with the code they contributed and maintain.
+  * They can be automatically assigned, because a developer's GitHub
+    handle matches a file pattern in the `.github/CODEOWNERS` file,
+    which associates developers with the code they contributed and
+    maintain.
 
 Reviewers are requested to state their appraisal of the proposed changes
 and either approve or request changes. People may unassign themselves
 from review, if they feel not competent about the changes proposed. At
-least two approvals from LAMMPS developers with write access are required
-before merging in addition to the automated compilation tests.
-Merging counts as implicit approval, so does submission of a pull request
-(by a LAMMPS developer). So the person doing the merge may not also submit
-an approving review. The feature, that reviews from code owners are "hard"
-reviews (i.e. they must all be approved before merging is allowed), is
-currently disabled and it is in the discretion of the merge maintainer to
-assess when a sufficient degree of approval, especially from external
-contributors, has been reached in these cases.  Reviews may be
-(automatically) dismissed, when the reviewed code has been changed,
-and then approval is required a second time.
+least two approvals from LAMMPS developers with write access are
+required before merging, in addition to passing all automated
+compilation and unit tests.  Merging counts as implicit approval, so
+does submission of a pull request (by a LAMMPS developer). So the person
+doing the merge may not also submit an approving review.  The GitHub
+feature, that reviews from code owners are "hard" reviews (i.e. they
+must all approve before merging is allowed), is currently disabled.
+It is in the discretion of the merge maintainer to assess when a
+sufficient degree of approval has been reached, especially from external
+collaborators.  Reviews may be (automatically) dismissed, when the
+reviewed code has been changed. Review may be requested a second time.
 
 ### Pull Request Discussions
 
 All discussions about a pull request should be kept as much as possible
 on the pull request discussion page on GitHub, so that other developers
 can later review the entire discussion after the fact and understand the
-rationale behind choices made.  Exceptions to this policy are technical
-discussions, that are centered on tools or policies themselves
+rationale behind choices that were made.  Exceptions to this policy are
+technical discussions, that are centered on tools or policies themselves
 (git, GitHub, c++) rather than on the content of the pull request.
 
 ## GitHub Issues
@@ -112,39 +113,39 @@ marker in the subject. This is automatically done when using the
 corresponding template for submitting an issue.  Issues may be assigned
 to one or more developers, if they are working on this feature or
 working to resolve an issue.  Issues that have nobody working
-on them at the moment or in the near future, have the label
+on them at the moment, or in the near future, have the label
 `volunteer needed` attached.
 
-When an issue, say `#125` is resolved by a specific pull request,
-the comment for the pull request shall contain the text `closes #125`
-or `fixes #125`, so that the issue is automatically deleted when
-the pull request is merged.  The template for pull requests includes
-a header where connections between pull requests and issues can be listed
-and thus were this comment should be placed.
+When an issue, say `#125` is resolved by a specific pull request, the
+comment for the pull request shall contain the text `closes #125` or
+`fixes #125`, so that the issue is automatically deleted when the pull
+request is merged.  The template for pull requests includes a header
+where connections between pull requests and issues can be listed, and
+thus where this comment should be placed.
 
 ## Milestones and Release Planning
 
 LAMMPS uses a continuous release development model with incremental
-changes, i.e. significant effort is made - including automated pre-merge
-testing - that the code in the branch "develop" does not get easily
+changes, i.e. significant effort is made -- including automated pre-merge
+testing -- that the code in the branch "develop" does not get easily
 broken.  These tests are run after every update to a pull request.  More
-extensive and time consuming tests (including regression testing) are
+extensive and time-consuming tests (including regression testing) are
 performed after code is merged to the "develop" branch.  There are feature
 releases of LAMMPS made about every 4-6 weeks at a point, when the LAMMPS
-developers feel, that a sufficient amount of changes have been included,
+developers feel, that a sufficient number of changes has been included
 and all post-merge testing has been successful.  These feature releases are
 marked with a `patch_<version date>` tag and the "release" branch
-follows only these versions with fast forward merges.  While "develop" may
-be temporary broken through issues only detected by the post-merge tests,
+follows only these versions with fast-forward merges.  While "develop" may
+be temporarily broken through issues only detected by the post-merge tests,
 The "release" branch is always supposed to be of production quality.
 
-About once each year, there are going to be "stable" releases of
-LAMMPS.  These have seen additional, manual testing and review of
+About once each year, there is a "stable" release of LAMMPS.
+These have seen additional, manual testing and review of
 results from testing with instrumented code and static code analysis.
 Also, the last few feature releases before a stable release are "release
-candidate" versions which only contain bugfixes, feature additions to
+candidate" versions which only contain bug fixes, feature additions to
 peripheral functionality, and documentation updates.  In between stable
-releases, bugfixes and infrastructure updates are backported from the
+releases, bug fixes and infrastructure updates are back-ported from the
 "develop" branch to the "maintenance" branch and occasionally merged
 into "stable" and published as update releases.
 

--- a/doc/src/Build_manual.rst
+++ b/doc/src/Build_manual.rst
@@ -33,7 +33,7 @@ various tools and files.  Some of them have to be installed (see below).  For
 the rest the build process will attempt to download and install them into
 a python virtual environment and local folders.
 
-A current version of the manual (latest patch release, that is the state
+A current version of the manual (latest feature release, that is the state
 of the *release* branch) is is available online at:
 `https://docs.lammps.org/ <https://docs.lammps.org/>`_.
 A version of the manual corresponding to the ongoing development (that is

--- a/doc/src/Howto_github.rst
+++ b/doc/src/Howto_github.rst
@@ -476,16 +476,25 @@ to your remote(s) as well:
 
 **Recent changes in the workflow**
 
-Some changes to the workflow are not captured in this tutorial.  For
-example, in addition to the *develop* branch, to which all new features
-should be submitted, there is also a *release* and a *stable* branch;
-these have the same content as *develop*, but are only updated after a
-patch release or stable release was made.  Furthermore, the naming of
-the patches now follow the pattern "patch_<Day><Month><Year>" to
-simplify comparisons between releases.  Finally, all patches and
-submissions are subject to automatic testing and code checks to make
-sure they at the very least compile.
+Some recent changes to the workflow are not captured in this tutorial.
+For example, in addition to the *develop* branch, to which all new
+features should be submitted, there is also a *release*, a *stable*, and
+a *maintenance* branch; the *release* branch is updated from the
+*develop* as part of a feature release, and *stable* (together with
+*release*) are updated from *develop* when a stable release is made. In
+between stable releases, selected bug fixes and infrastructure updates
+are back-ported from the *develop* branch to the *maintenance* branch
+and occasionally merged to *stable* as an update release.
 
-A discussion of the LAMMPS developer GitHub workflow can be found in the
-file `doc/github-development-workflow.md
+Furthermore, the naming of the release tags now follow the pattern
+"patch_<Day><Month><Year>" to simplify comparisons between releases.
+For stable releases additional "stable_<Day><Month><Year>" tags are
+applied and update releases are tagged with
+"stable_<Day><Month><Year>_update<Number>", Finally, all releases and
+submissions are subject to automatic testing and code checks to make
+sure they compile with a variety of compilers and popular operating
+systems.  Some unit and regression testing is applied as well.
+
+A detailed discussion of the LAMMPS developer GitHub workflow can be
+found in the file `doc/github-development-workflow.md
 <https://github.com/lammps/lammps/blob/develop/doc/github-development-workflow.md>`_

--- a/doc/src/Install_git.rst
+++ b/doc/src/Install_git.rst
@@ -26,15 +26,18 @@ provides `limited support for subversion clients <svn_>`_.
 .. _git: https://git-scm.com
 .. _svn: https://help.github.com/en/github/importing-your-projects-to-github/working-with-subversion-on-github
 
-You can follow the LAMMPS development on 3 different git branches:
+You can follow the LAMMPS development on 4 different git branches:
 
-* **stable**   :  this branch is updated from the *release* branch with
-  every stable release version and also has selected bug fixes and updates
-  back-ported from the *develop* branch
 * **release**  :  this branch is updated with every patch or feature release;
   updates are always "fast-forward" merges from *develop*
 * **develop**  :  this branch follows the ongoing development and
   is updated with every merge commit of a pull request
+* **stable**   :  this branch is updated from the *release* branch with
+  every stable release version and also has selected bug fixes with every
+  update release when the *maintenance* branch is merged into it
+* **maintenance**  :  this branch collects back-ported bug fixes from the
+  *develop* branch to the *stable* branch. It is used to update *stable*
+  for update releases and it synchronized with *stable* at each stable release.
 
 To access the git repositories on your box, use the clone command to
 create a local copy of the LAMMPS repository with a command like:
@@ -60,17 +63,17 @@ between them at any time using "git checkout <branch name>".)
    *--depth* git command line flag.  That will create a "shallow clone"
    of the repository, which contains only a subset of the git history.
    Using a depth of 1000 is usually sufficient to include the head
-   commits of the *develop* and the *release* branches.  To include the
-   head commit of the *stable* branch you may need a depth of up
-   to 10000.  If you later need more of the git history, you can always
-   convert the shallow clone into a "full clone".
+   commits of the *develop*, the *release*, and the *maintenance*
+   branches.  To include the head commit of the *stable* branch you may
+   need a depth of up to 10000.  If you later need more of the git
+   history, you can always convert the shallow clone into a "full
+   clone".
 
 Once the command completes, your directory will contain the same files
 as if you unpacked a current LAMMPS tarball, with the exception, that
-the HTML documentation files are not included.  They can be fetched
-from the LAMMPS website by typing ``make fetch`` in the doc directory.
-Or they can be generated from the content provided in ``doc/src`` by
-typing ``make html`` from the ``doc`` directory.
+the HTML documentation files are not included. They can be generated
+from the content provided in ``doc/src`` by typing ``make html`` from
+the ``doc`` directory.
 
 After initial cloning, as bug fixes and new features are added to
 LAMMPS you can stay up-to-date by typing the following git commands
@@ -79,8 +82,9 @@ from within the "mylammps" directory:
 .. code-block:: bash
 
    git checkout release      # not needed if you always stay in this branch
-   git checkout stable       # use one of these 3 checkout commands
+   git checkout stable       # use one of these 4 checkout commands
    git checkout develop      # to choose the branch to follow
+   git checkout maintenance
    git pull
 
 Doing a "pull" will not change any files you have added to the LAMMPS
@@ -145,7 +149,7 @@ changed.  How to do this depends on the build system you are using.
       to enforce consistency of the source between the src folder
       and package directories.  This is OK to do even if you don't
       use any packages. The ``make purge`` command removes any deprecated
-      src files if they were removed by the patch from a package
+      src files if they were removed by the update from a package
       subdirectory.
 
       .. warning::

--- a/doc/src/Install_linux.rst
+++ b/doc/src/Install_linux.rst
@@ -3,6 +3,7 @@ Download an executable for Linux
 
 Binaries are available for different versions of Linux:
 
+- :ref:`Pre-built static Linux x86_64 executables <static>`
 - :ref:`Pre-built Ubuntu and Debian Linux executables <ubuntu>`
 - :ref:`Pre-built Fedora Linux executables <fedora>`
 - :ref:`Pre-built EPEL Linux executables (RHEL, CentOS) <epel>`
@@ -18,6 +19,33 @@ Binaries are available for different versions of Linux:
    packages and when they update them.  They may only provide packages
    for stable release versions and not always update the packages in a
    timely fashion after a new LAMMPS release is made.
+
+----------
+
+.. _static:
+
+Pre-built static Linux x86_64 executables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pre-built LAMMPS executables for Linux, that are statically linked and
+compiled for 64-bit x86 CPUs (x86_64 or AMD64) are available for download
+at `https://download.lammps.org/static/ <https://download.lammps.org/static/>`_.
+Because of that static linkage (and unlike the Linux distribution specific
+packages listed below), they do not depend on any installed software and
+thus should run on *any* 64-bit x86 machine with *any* Linux version.
+
+These executable include most of the available packages and multi-thread
+parallelization (via INTEL, KOKKOS, or OPENMP package).  They are **not**
+compatible with MPI.  Several of the LAMMPS tools executables (e.g. ``msi2lmp``)
+and the ``lammps-shell`` program are included as well.  Because of the
+static linkage, there is no ``liblammps.so`` library file and thus also the
+LAMMPS python module, which depends on it, is not included.
+
+The compressed tar archives available for download have names following
+the pattern `lammps-linux-x86_64-<version>.tar.gz` and will all unpack
+into a ``lammps-static`` folder.  The executables are then in the
+``lammps-static/bin/`` folder.  Since they do not depend on any other
+software, they may be freely moved or copied around.
 
 ----------
 
@@ -232,7 +260,7 @@ There are three scripts available, named `lammps
 <https://aur.archlinux.org/packages/lammps>`_, `lammps-beta
 <https://aur.archlinux.org/packages/lammps>`_ and `lammps-git
 <https://aur.archlinux.org/packages/lammps>`_.  They respectively
-package the stable, patch and git releases.
+package the stable, feature, and git releases.
 
 To install, you will need to have the git package installed. You may use
 any of the above names in-place of lammps.

--- a/doc/src/Install_tarball.rst
+++ b/doc/src/Install_tarball.rst
@@ -10,15 +10,15 @@ of the `LAMMPS website <lws_>`_.
 .. _lws: https://www.lammps.org
 
 You have two choices of tarballs, either the most recent stable release
-or the most current patch or feature release.  Stable releases occur a
-few times per year, and undergo more testing before release.  Feature
-releases occur every 4 to 8 weeks.  The new contents in all feature
-releases are listed on the `bug and feature page <bug_>`_ of the LAMMPS
-homepage.
+or the most recent feature release.  Stable releases occur a few times
+per year, and undergo more testing before release.  Also, between stable
+releases bug fixes from the feature releases are back-ported and the
+tarball occasionally updated.  Feature releases occur every 4 to 8
+weeks.  The new contents in all feature releases are listed on the `bug
+and feature page <bug_>`_ of the LAMMPS homepage.
 
 Both tarballs include LAMMPS documentation (HTML and PDF files)
-corresponding to that version.  The download page also has an option
-to download the current-version LAMMPS documentation by itself.
+corresponding to that version.
 
 Tarballs of older LAMMPS versions can also be downloaded from `this page
 <older_>`_.
@@ -44,7 +44,8 @@ with the following command, to create a lammps-<version> directory:
 
    unzip lammps*.zip
 
-This version corresponds to the selected LAMMPS patch or stable release.
+This version corresponds to the selected LAMMPS feature or stable
+release.
 
 .. _git: https://github.com/lammps/lammps/releases
 

--- a/doc/src/Manual_version.rst
+++ b/doc/src/Manual_version.rst
@@ -12,13 +12,12 @@ into pull requests.  Pull requests will be merged into the *develop*
 branch of the git repository after they pass automated testing and code
 review by the LAMMPS developers.  When a sufficient number of changes
 have accumulated *and* the *develop* branch version passes an extended
-set of automated tests, we release it as a *feature release* (or patch
-release), which are currently made every 4 to 8 weeks.  The *release*
-branch of the git repository is updated with every such release.  A
-summary of the most important changes of the patch releases are on `this
-website page <https://www.lammps.org/bug.html>`_.  More detailed release
-notes are `available on GitHub
-<https://github.com/lammps/lammps/releases/>`_.
+set of automated tests, we release it as a *feature release*, which are
+currently made every 4 to 8 weeks.  The *release* branch of the git
+repository is updated with every such release.  A summary of the most
+important changes of the patch releases are on `this website page
+<https://www.lammps.org/bug.html>`_.  More detailed release notes are
+`available on GitHub <https://github.com/lammps/lammps/releases/>`_.
 
 Once or twice a year, we have a "stabilization period" where we apply
 only bug fixes and small, non-intrusive changes to the *develop*
@@ -28,13 +27,14 @@ several variants of static code analysis are run to improve the overall
 code quality, consistency, and compliance with programming standards,
 best practices and style conventions.
 
-The latest patch release after such a period is then also labeled as a
-*stable* version and the *stable* branch is updated with it.  Between
-stable releases, we occasionally release updates to the stable release
-containing only bug fixes and updates back-ported from the *develop*
-branch and update the *stable* branch accordingly.
+The release after such a stabilization period is called a *stable*
+version and both, the *release* and the *stable* branches are updated
+with it.  Between stable releases, we collect back-ported bug fixes and
+updates from the *develop* branch in the *maintenance* branch.  From the
+*maintenance* branch we make occasional update releases and update the
+*stable* branch accordingly.
 
-Each version of LAMMPS contains all the documented features up to and
+Each version of LAMMPS contains all the documented *features* up to and
 including its version date.  For recently added features, we add markers
 to the documentation at which specific LAMMPS version a feature or
 keyword was added or significantly changed.
@@ -45,7 +45,7 @@ directory name created when you unpack a tarball.  And it is on the
 first page of the :doc:`manual <Manual>`.
 
 * If you browse the HTML pages of the online version of the LAMMPS
-  manual, they will by default describe the most current patch release
+  manual, they will by default describe the most current feature release
   version of LAMMPS.  In the navigation bar on the bottom left, there is
   the option to view instead the documentation for the most recent
   *stable* version or the documentation corresponding to the state of

--- a/doc/src/Modify_contribute.rst
+++ b/doc/src/Modify_contribute.rst
@@ -80,8 +80,8 @@ integrated via pull requests on GitHub and cannot be merged without
 passing the automated testing and an approving review by a LAMMPS core
 developer.  Thus before submitting your contribution, you should first
 make certain, that your added or modified code compiles and works
-correctly with the latest patch-level or development version of LAMMPS
-and contains all bug fixes from it.
+correctly with the latest development version of LAMMPS and contains all
+bug fixes from it.
 
 Once you have prepared everything, see the :doc:`LAMMPS GitHub Tutorial
 <Howto_github>` page for instructions on how to submit your changes or


### PR DESCRIPTION
**Summary**

Patch releases are now called feature releases and the "maintenance" branch is used to collect bugfixes and back-ports for the stable branch.

**Author(s)**

Axel Kohlmeyer,  Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
