### PR TITLE
Implementation of analytical expressions for Born matrix in bond_class2 & bond_gromos

### DIFF
--- a/src/CLASS2/bond_class2.cpp
+++ b/src/CLASS2/bond_class2.cpp
@@ -32,7 +32,10 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-BondClass2::BondClass2(LAMMPS *lmp) : Bond(lmp) {}
+BondClass2::BondClass2(LAMMPS *lmp) : Bond(lmp)
+{
+  born_matrix_enable = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 
@@ -221,6 +224,17 @@ double BondClass2::single(int type, double rsq, int /*i*/, int /*j*/, double &ff
   if (r > 0.0) fforce = -de_bond/r;
   else fforce = 0.0;
   return (k2[type]*dr2 + k3[type]*dr3 + k4[type]*dr4);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondClass2::born_matrix(int type, double rsq, int /*i*/, int /*j*/, double &du, double &du2)
+{
+  double r = sqrt(rsq);
+  double dr = r - r0[type];
+  du = 0.0;
+  du2 = 2*k2[type] + 6*k3[type]*dr + 12*k4[type]*dr*dr;
+  if (r > 0.0) du = 2*k2[type]*dr + 3*k3[type]*dr*dr + 4*k4[type]*dr*dr*dr;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/CLASS2/bond_class2.h
+++ b/src/CLASS2/bond_class2.h
@@ -35,6 +35,7 @@ class BondClass2 : public Bond {
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
   double single(int, double, int, int, double &) override;
+  void born_matrix(int, double, int, int, double &, double &) override;
   void *extract(const char *, int &) override;
 
  protected:

--- a/src/MOLECULE/bond_gromos.cpp
+++ b/src/MOLECULE/bond_gromos.cpp
@@ -30,7 +30,10 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-BondGromos::BondGromos(LAMMPS *_lmp) : Bond(_lmp) {}
+BondGromos::BondGromos(LAMMPS *_lmp) : Bond(_lmp)
+{
+  born_matrix_enable = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 
@@ -189,6 +192,16 @@ double BondGromos::single(int type, double rsq, int /*i*/, int /*j*/, double &ff
   double dr = rsq - r0[type] * r0[type];
   fforce = -4.0 * k[type] * dr;
   return k[type] * dr * dr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondGromos::born_matrix(int type, double rsq, int /*i*/, int /*j*/, double &du, double &du2)
+{
+  double r = sqrt(rsq);
+  du = 0.0;
+  du2 = 4 * k[type] * (3 * rsq - r0[type] * r0[type]);
+  if (r > 0.0) du = 4 * k[type] * r * (rsq - r0[type] * r0[type]);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MOLECULE/bond_gromos.h
+++ b/src/MOLECULE/bond_gromos.h
@@ -35,6 +35,7 @@ class BondGromos : public Bond {
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
   double single(int, double, int, int, double &) override;
+  void born_matrix(int, double, int, int, double &, double &) override;
   void *extract(const char *, int &) override;
 
  protected:


### PR DESCRIPTION
**Summary**

Implementation of analytical first and second order derivatives of potential energy with respect to distance  for bond gromos and bond class 2

**Related Issue(s)**

No related issue

**Author(s)**

E. Voyiatzis - email evoyiatzis@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issue with backward compatibility

**Implementation Notes**

The results with these expressions match the ones obtained with the numerical differentiation using compute born/matrix with numdiff 

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


