### PR TITLE
Fix Kokkos compile error with NVIDIA Hopper GPU

### DIFF
--- a/lib/kokkos/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/lib/kokkos/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -290,7 +290,8 @@ KOKKOS_INLINE_FUNCTION
 // Go in this branch if CUDA version is >= 11.0.0 and less than 11.1.0 or if the
 // architecture is not Ampere
 #if CUDA_VERSION >= 11000 && \
-    (CUDA_VERSION < 11010 || !defined(KOKKOS_ARCH_AMPERE))
+    (CUDA_VERSION < 11010 || \
+     !(defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_HOPPER)))
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 


### PR DESCRIPTION
**Summary**

One change got missed to compile with NVIDIA Hopper GPU in #3532

**Related Issue(s)**

#3532

**Author(s)**

Stan Moore (SNL), reported by Evan Weinberg (NVIDIA), @weinbe2 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes