### PR TITLE
Eliminate gradforce loops in ML-IAP pair style

### DIFF
--- a/src/KOKKOS/mliap_data_kokkos.cpp
+++ b/src/KOKKOS/mliap_data_kokkos.cpp
@@ -75,19 +75,24 @@ void MLIAPDataKokkos<DeviceType>::generate_neighdata(class NeighList *list_in, i
 
   if (atom->nmax > nmax) {
     nmax = atom->nmax;
-    memoryKK->destroy_kokkos(k_gradforce,gradforce);
-    memoryKK->create_kokkos(k_gradforce, gradforce, nmax, size_gradforce, "mliap_data:gradforce");
+    if (gradgradflag > -1){
+      memoryKK->destroy_kokkos(k_gradforce,gradforce);
+      memoryKK->create_kokkos(k_gradforce, gradforce, nmax, size_gradforce, "mliap_data:gradforce");
+    }
     memoryKK->destroy_kokkos(k_elems,elems);
     memoryKK->create_kokkos(k_elems, elems, nmax, "mliap_data:elems");  }
 
-  // clear gradforce array
+  // clear gradforce and elems arrays
 
   int nall = atom->nlocal + atom->nghost;
   ntotal = nall;
-  auto d_gradforce = k_gradforce.template view<DeviceType>();
-  Kokkos::deep_copy(d_gradforce, 0.);
+  if (gradgradflag > -1){
+    auto d_gradforce = k_gradforce.template view<DeviceType>();
+    Kokkos::deep_copy(d_gradforce, 0.);
+  }
   auto d_elems = k_elems.template view<DeviceType>();
   Kokkos::deep_copy(d_elems, 0.);
+
   // grow arrays if necessary
 
   nlistatoms = list->inum;

--- a/src/KOKKOS/pair_mliap_kokkos.cpp
+++ b/src/KOKKOS/pair_mliap_kokkos.cpp
@@ -278,7 +278,7 @@ void PairMLIAPKokkos<DeviceType>::coeff(int narg, char **arg) {
       h_cutsq(itype,jtype) = descriptor->cutsq[map[itype]][map[jtype]];
   k_cutsq.modify<LMPHostType>();
   k_cutsq.sync<DeviceType>();
-  int gradgradflag = -1;
+  constexpr int gradgradflag = -1;
   delete data;
   data = new MLIAPDataKokkos<DeviceType>(lmp, gradgradflag, map, model, descriptor, this);
   data->init();

--- a/src/ML-IAP/compute_mliap.cpp
+++ b/src/ML-IAP/compute_mliap.cpp
@@ -55,7 +55,7 @@ ComputeMLIAP::ComputeMLIAP(LAMMPS *lmp, int narg, char **arg) :
 
   // default values
 
-  gradgradflag = 1;
+  int gradgradflag = 1;
 
   // set flags for required keywords
 
@@ -230,7 +230,7 @@ void ComputeMLIAP::compute_array()
 
   descriptor->compute_descriptors(data);
 
-  if (gradgradflag == 1) {
+  if (data->gradgradflag == 1) {
 
     // calculate double gradient w.r.t. parameters and descriptors
 
@@ -240,7 +240,7 @@ void ComputeMLIAP::compute_array()
 
     descriptor->compute_force_gradients(data);
 
-  } else if (gradgradflag == 0) {
+  } else if (data->gradgradflag == 0) {
 
     // calculate descriptor gradients
 

--- a/src/ML-IAP/compute_mliap.h
+++ b/src/ML-IAP/compute_mliap.h
@@ -42,7 +42,6 @@ class ComputeMLIAP : public Compute {
   int ndescriptors;    // number of descriptors
   int nparams;         // number of model parameters per element
   int nelements;
-  int gradgradflag;    // 1 for graddesc, 0 for gamma
   class MLIAPModel *model;
   class MLIAPDescriptor *descriptor;
   class MLIAPData *data;

--- a/src/ML-IAP/mliap_data.cpp
+++ b/src/ML-IAP/mliap_data.cpp
@@ -126,15 +126,15 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
   if (atom->nmax > nmax) {
     nmax = atom->nmax;
     memory->grow(elems,nmax,"MLIAPData:elems");
-    if (gradgradflag == 1) memory->grow(gradforce,nmax,size_gradforce,
-                             "MLIAPData:gradforce");
+    if (gradgradflag > -1) memory->grow(gradforce,nmax,size_gradforce,
+                            "MLIAPData:gradforce");
   }
 
   // clear gradforce, elems arrays
 
   for (int i = 0; i < nall; i++) {
     elems[i] = 0;
-    if (gradgradflag == 1){
+    if (gradgradflag > -1){
       for (int j = 0; j < size_gradforce; j++) {
         gradforce[i][j] = 0.0;
       }
@@ -163,6 +163,7 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
   }
 
   grow_neigharrays();
+
   npairs = 0;
   int ij = 0;
   for (int ii = 0; ii < natomneigh; ii++) {

--- a/src/ML-IAP/mliap_data.cpp
+++ b/src/ML-IAP/mliap_data.cpp
@@ -118,24 +118,27 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
   int *numneigh = list->numneigh;
   int **firstneigh = list->firstneigh;
 
+  int nall = atom->nlocal + atom->nghost;
+  ntotal = nall;
+
   // grow nmax gradforce, elems arrays if necessary
 
   if (atom->nmax > nmax) {
     nmax = atom->nmax;
-    memory->grow(gradforce,nmax,size_gradforce,
-                 "MLIAPData:gradforce");
     memory->grow(elems,nmax,"MLIAPData:elems");
- }
+    if (gradgradflag == 1) memory->grow(gradforce,nmax,size_gradforce,
+                             "MLIAPData:gradforce");
+  }
 
   // clear gradforce, elems arrays
 
-  int nall = atom->nlocal + atom->nghost;
-  ntotal = nall;
   for (int i = 0; i < nall; i++) {
-    for (int j = 0; j < size_gradforce; j++) {
-      gradforce[i][j] = 0.0;
-    }
     elems[i] = 0;
+    if (gradgradflag == 1){
+      for (int j = 0; j < size_gradforce; j++) {
+        gradforce[i][j] = 0.0;
+      }
+    }
   }
 
   // grow arrays if necessary
@@ -160,7 +163,6 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
   }
 
   grow_neigharrays();
-
   npairs = 0;
   int ij = 0;
   for (int ii = 0; ii < natomneigh; ii++) {

--- a/src/ML-IAP/mliap_data.cpp
+++ b/src/ML-IAP/mliap_data.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -27,16 +26,14 @@
 
 using namespace LAMMPS_NS;
 
-MLIAPData::MLIAPData(LAMMPS *lmp, int gradgradflag_in, int *map_in,
-                     class MLIAPModel* model_in,
-                     class MLIAPDescriptor* descriptor_in,
-                     class PairMLIAP* pairmliap_in) :
-  Pointers(lmp), f(nullptr), gradforce(nullptr), betas(nullptr),
-  descriptors(nullptr), eatoms(nullptr), gamma(nullptr),
-  gamma_row_index(nullptr), gamma_col_index(nullptr), egradient(nullptr),
-  numneighs(nullptr), iatoms(nullptr), ielems(nullptr), pair_i(nullptr),
-  jatoms(nullptr), jelems(nullptr), elems(nullptr), rij(nullptr),
-  graddesc(nullptr), model(nullptr), descriptor(nullptr), list(nullptr)
+MLIAPData::MLIAPData(LAMMPS *lmp, int gradgradflag_in, int *map_in, class MLIAPModel *model_in,
+                     class MLIAPDescriptor *descriptor_in, class PairMLIAP *pairmliap_in) :
+    Pointers(lmp),
+    f(nullptr), gradforce(nullptr), betas(nullptr), descriptors(nullptr), eatoms(nullptr),
+    gamma(nullptr), gamma_row_index(nullptr), gamma_col_index(nullptr), egradient(nullptr),
+    numneighs(nullptr), iatoms(nullptr), ielems(nullptr), pair_i(nullptr), jatoms(nullptr),
+    jelems(nullptr), elems(nullptr), rij(nullptr), graddesc(nullptr), model(nullptr),
+    descriptor(nullptr), list(nullptr)
 {
   gradgradflag = gradgradflag_in;
   map = map_in;
@@ -51,25 +48,24 @@ MLIAPData::MLIAPData(LAMMPS *lmp, int gradgradflag_in, int *map_in,
   gamma_nnz = model->get_gamma_nnz(this);
   ndims_force = 3;
   ndims_virial = 6;
-  yoffset = nparams*nelements;
-  zoffset = 2*yoffset;
+  yoffset = nparams * nelements;
+  zoffset = 2 * yoffset;
   natoms = atom->natoms;
 
   // must check before assigning bigint expression to regular int
 
-  if (1+ndims_force*natoms+ndims_virial > MAXSMALLINT)
-    error->all(FLERR,"Too many atoms for MLIAP package");
+  if (1 + ndims_force * natoms + ndims_virial > MAXSMALLINT)
+    error->all(FLERR, "Too many atoms for MLIAP package");
 
-  size_array_rows = 1+ndims_force*natoms+ndims_virial;
-  size_array_cols = nparams*nelements+1;
-  size_gradforce = ndims_force*nparams*nelements;
+  size_array_rows = 1 + ndims_force * natoms + ndims_virial;
+  size_array_cols = nparams * nelements + 1;
+  size_gradforce = ndims_force * nparams * nelements;
 
   nlistatoms_max = 0;
   natomneigh_max = 0;
   nneigh_max = 0;
   nmax = 0;
   natomgamma_max = 0;
-
 }
 
 /* ---------------------------------------------------------------------- */
@@ -100,14 +96,14 @@ MLIAPData::~MLIAPData()
 
 void MLIAPData::init()
 {
-  memory->create(egradient,nelements*nparams,"MLIAPData:egradient");
+  memory->create(egradient, nelements * nparams, "MLIAPData:egradient");
 }
 
 /* ----------------------------------------------------------------------
    generate neighbor arrays
 ------------------------------------------------------------------------- */
 
-void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_in)
+void MLIAPData::generate_neighdata(NeighList *list_in, int eflag_in, int vflag_in)
 {
   list = list_in;
   f = atom->f;
@@ -125,19 +121,16 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
 
   if (atom->nmax > nmax) {
     nmax = atom->nmax;
-    memory->grow(elems,nmax,"MLIAPData:elems");
-    if (gradgradflag > -1) memory->grow(gradforce,nmax,size_gradforce,
-                            "MLIAPData:gradforce");
+    memory->grow(elems, nmax, "MLIAPData:elems");
+    if (gradgradflag > -1) memory->grow(gradforce, nmax, size_gradforce, "MLIAPData:gradforce");
   }
 
   // clear gradforce, elems arrays
 
   for (int i = 0; i < nall; i++) {
     elems[i] = 0;
-    if (gradgradflag > -1){
-      for (int j = 0; j < size_gradforce; j++) {
-        gradforce[i][j] = 0.0;
-      }
+    if (gradgradflag > -1) {
+      for (int j = 0; j < size_gradforce; j++) { gradforce[i][j] = 0.0; }
     }
   }
 
@@ -145,9 +138,9 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
 
   nlistatoms = list->inum;
   if (nlistatoms_max < nlistatoms) {
-    memory->grow(betas,nlistatoms,ndescriptors,"MLIAPData:betas");
-    memory->grow(descriptors,nlistatoms,ndescriptors,"MLIAPData:descriptors");
-    memory->grow(eatoms,nlistatoms,"MLIAPData:eatoms");
+    memory->grow(betas, nlistatoms, ndescriptors, "MLIAPData:betas");
+    memory->grow(descriptors, nlistatoms, ndescriptors, "MLIAPData:descriptors");
+    memory->grow(eatoms, nlistatoms, "MLIAPData:eatoms");
     nlistatoms_max = nlistatoms;
   }
 
@@ -155,9 +148,9 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
 
   if (gradgradflag == 1) {
     if (natomgamma_max < nlistatoms) {
-      memory->grow(gamma_row_index,nlistatoms,gamma_nnz,"MLIAPData:gamma_row_index");
-      memory->grow(gamma_col_index,nlistatoms,gamma_nnz,"MLIAPData:gamma_col_index");
-      memory->grow(gamma,nlistatoms,gamma_nnz,"MLIAPData:gamma");
+      memory->grow(gamma_row_index, nlistatoms, gamma_nnz, "MLIAPData:gamma_row_index");
+      memory->grow(gamma_col_index, nlistatoms, gamma_nnz, "MLIAPData:gamma_col_index");
+      memory->grow(gamma, nlistatoms, gamma_nnz, "MLIAPData:gamma");
       natomgamma_max = nlistatoms;
     }
   }
@@ -185,7 +178,7 @@ void MLIAPData::generate_neighdata(NeighList* list_in, int eflag_in, int vflag_i
       const double delx = x[j][0] - xtmp;
       const double dely = x[j][1] - ytmp;
       const double delz = x[j][2] - ztmp;
-      const double rsq = delx*delx + dely*dely + delz*delz;
+      const double rsq = delx * delx + dely * dely + delz * delz;
       int jtype = type[j];
       const int jelem = map[jtype];
 
@@ -224,12 +217,11 @@ void MLIAPData::grow_neigharrays()
 
   // grow neighbor atom arrays if necessary
   natomneigh = list->inum;
-  if (list->ghost == 1)
-    natomneigh += list->gnum;
+  if (list->ghost == 1) natomneigh += list->gnum;
   if (natomneigh_max < natomneigh) {
-    memory->grow(iatoms,natomneigh,"MLIAPData:iatoms");
-    memory->grow(ielems,natomneigh,"MLIAPData:ielems");
-    memory->grow(numneighs,natomneigh,"MLIAPData:numneighs");
+    memory->grow(iatoms, natomneigh, "MLIAPData:iatoms");
+    memory->grow(ielems, natomneigh, "MLIAPData:ielems");
+    memory->grow(numneighs, natomneigh, "MLIAPData:numneighs");
     natomneigh_max = natomneigh;
   }
 
@@ -261,7 +253,7 @@ void MLIAPData::grow_neigharrays()
       const double delx = x[j][0] - xtmp;
       const double dely = x[j][1] - ytmp;
       const double delz = x[j][2] - ztmp;
-      const double rsq = delx*delx + dely*dely + delz*delz;
+      const double rsq = delx * delx + dely * dely + delz * delz;
       int jtype = type[j];
       const int jelem = map[jtype];
       if (rsq < descriptor->cutsq[ielem][jelem]) ninside++;
@@ -270,12 +262,11 @@ void MLIAPData::grow_neigharrays()
   }
 
   if (nneigh_max < nneigh) {
-    memory->grow(pair_i,nneigh,"MLIAPData:pair_i");
-    memory->grow(jatoms,nneigh,"MLIAPData:jatoms");
-    memory->grow(jelems,nneigh,"MLIAPData:jelems");
-    memory->grow(rij,nneigh,3,"MLIAPData:rij");
-    if (gradgradflag == 0)
-      memory->grow(graddesc,nneigh,ndescriptors,3,"MLIAPData:graddesc");
+    memory->grow(pair_i, nneigh, "MLIAPData:pair_i");
+    memory->grow(jatoms, nneigh, "MLIAPData:jatoms");
+    memory->grow(jelems, nneigh, "MLIAPData:jelems");
+    memory->grow(rij, nneigh, 3, "MLIAPData:rij");
+    if (gradgradflag == 0) memory->grow(graddesc, nneigh, ndescriptors, 3, "MLIAPData:graddesc");
     nneigh_max = nneigh;
   }
 }
@@ -284,35 +275,31 @@ double MLIAPData::memory_usage()
 {
   double bytes = 0.0;
 
-  bytes += (double)nelements*nparams*sizeof(double);     // egradient
-  bytes += (double)nmax*size_gradforce*sizeof(double);   // gradforce
-  bytes += (double)nmax*sizeof(int);                     // elems
+  bytes += (double) nelements * nparams * sizeof(double);      // egradient
+  bytes += (double) nmax * size_gradforce * sizeof(double);    // gradforce
+  bytes += (double) nmax * sizeof(int);                        // elems
 
   if (gradgradflag == 1) {
-    bytes += (double)natomgamma_max*
-      gamma_nnz*sizeof(int);                     //gamma_row_index
-    bytes += (double)natomgamma_max*
-      gamma_nnz*sizeof(int);                     // gamma_col_index
-    bytes += (double)natomgamma_max*
-      gamma_nnz*sizeof(double);                  // gamma
+    bytes += (double) natomgamma_max * gamma_nnz * sizeof(int);       //gamma_row_index
+    bytes += (double) natomgamma_max * gamma_nnz * sizeof(int);       // gamma_col_index
+    bytes += (double) natomgamma_max * gamma_nnz * sizeof(double);    // gamma
   }
 
-  bytes += (double)nlistatoms*ndescriptors*sizeof(int);      // betas
-  bytes += (double)nlistatoms*ndescriptors*sizeof(int);      // descriptors
-  bytes += (double)nlistatoms*sizeof(double);                // eatoms
+  bytes += (double) nlistatoms * ndescriptors * sizeof(int);    // betas
+  bytes += (double) nlistatoms * ndescriptors * sizeof(int);    // descriptors
+  bytes += (double) nlistatoms * sizeof(double);                // eatoms
 
-  bytes += (double)natomneigh_max*sizeof(int);               // iatoms
-  bytes += (double)natomneigh_max*sizeof(int);               // ielems
-  bytes += (double)natomneigh_max*sizeof(int);               // numneighs
+  bytes += (double) natomneigh_max * sizeof(int);    // iatoms
+  bytes += (double) natomneigh_max * sizeof(int);    // ielems
+  bytes += (double) natomneigh_max * sizeof(int);    // numneighs
 
-  bytes += (double)nneigh_max*sizeof(int);                   // pair_i
-  bytes += (double)nneigh_max*sizeof(int);                   // jatoms
-  bytes += (double)nneigh_max*sizeof(int);                   // jelems
-  bytes += (double)nneigh_max*3*sizeof(double);              // rij"
+  bytes += (double) nneigh_max * sizeof(int);           // pair_i
+  bytes += (double) nneigh_max * sizeof(int);           // jatoms
+  bytes += (double) nneigh_max * sizeof(int);           // jelems
+  bytes += (double) nneigh_max * 3 * sizeof(double);    // rij"
 
   if (gradgradflag == 0)
-    bytes += (double)nneigh_max*ndescriptors*3*sizeof(double);// graddesc
+    bytes += (double) nneigh_max * ndescriptors * 3 * sizeof(double);    // graddesc
 
   return bytes;
 }
-

--- a/src/ML-IAP/mliap_data.h
+++ b/src/ML-IAP/mliap_data.h
@@ -84,7 +84,7 @@ class MLIAPData : protected Pointers {
   int nmax;
   class NeighList *list;    // LAMMPS neighbor list
   int *map;                 // map LAMMPS types to [0,nelements)
-  int gradgradflag;         // 1 for graddesc, 0 for gamma
+  int gradgradflag;         // 1 for graddesc, 0 for gamma, -1 for pair style
 };
 
 }    // namespace LAMMPS_NS

--- a/src/ML-IAP/mliap_data.h
+++ b/src/ML-IAP/mliap_data.h
@@ -44,6 +44,7 @@ class MLIAPData : protected Pointers {
   int ndescriptors;        // number of descriptors
   int nparams;             // number of model parameters per element
   int nelements;           // number of elements
+  int gradgradflag;        // 1 for graddesc, 0 for gamma, -1 for pair style
 
   // data structures for grad-grad list (gamma)
 
@@ -84,7 +85,6 @@ class MLIAPData : protected Pointers {
   int nmax;
   class NeighList *list;    // LAMMPS neighbor list
   int *map;                 // map LAMMPS types to [0,nelements)
-  int gradgradflag;         // 1 for graddesc, 0 for gamma, -1 for pair style
 };
 
 }    // namespace LAMMPS_NS

--- a/src/ML-IAP/pair_mliap.cpp
+++ b/src/ML-IAP/pair_mliap.cpp
@@ -260,7 +260,7 @@ void PairMLIAP::coeff(int narg, char **arg)
 
   model->init();
   descriptor->init();
-  int gradgradflag = -1;
+  constexpr int gradgradflag = -1;
   delete data;
   data = new MLIAPData(lmp, gradgradflag, map, model, descriptor, this);
   data->init();


### PR DESCRIPTION
**Summary**

ML-IAP has an array `gradforce` for storing gradients of force w.r.t. model parameters. These gradients are used with `compute mliap`, but have no purpose when running MD with `pair_style mliap`.

This PR eliminates an unnecessary double loop over atoms and model parameters when using `pair_style mliap`.

Performance gains when using models with many parameters can be significant, e.g. a NN with 256x256 nodes has a 5x speedup. This will be more significant with larger NNs.

**Related Issue(s)**

None

**Author(s)**

Drew Rohskopf (SNL)
Benjamin Nebgen (LANL)
Nick Lubbers (LANL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Backward compatible

**Implementation Notes**

Use existing `gradgradflag` option to only grow or zero the `gradforce` array when using `compute mliap` (where `gradgradflag > -1` is possible). 

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


