### PR TITLE
Possibly fix a typo (or be shown a misunderstanding)

### DIFF
--- a/doc/src/fix_press_berendsen.rst
+++ b/doc/src/fix_press_berendsen.rst
@@ -61,7 +61,7 @@ unchanged and controlling the pressure of a surrounding fluid.
    atoms.  This fix can be used in conjunction with thermostatting fixes
    to control the temperature, such as :doc:`fix nvt <fix_nh>` or :doc:`fix langevin <fix_langevin>` or :doc:`fix temp/berendsen <fix_temp_berendsen>`.
 
-See the :doc:`Howto baroostat <Howto_barostat>` page for a
+See the :doc:`Howto barostat <Howto_barostat>` page for a
 discussion of different ways to perform barostatting.
 
 ----------

--- a/src/BROWNIAN/fix_brownian_base.cpp
+++ b/src/BROWNIAN/fix_brownian_base.cpp
@@ -217,10 +217,8 @@ void FixBrownianBase::init()
   g1 = force->ftm2v;
   if (noise_flag == 0) {
     g2 = 0.0;
-  } else if (gaussian_noise_flag == 1) {
-    g2 = sqrt(2 * force->boltz / dt / force->mvv2e);
   } else {
-    g2 = sqrt(24 * force->boltz / dt / force->mvv2e);
+    g2 = sqrt(2 * force->boltz / dt / force->mvv2e);
   }
 }
 


### PR DESCRIPTION
Fix issue where brownian motion with uniform distribution had overpowered random noise

**Summary**

As I understand it, the Brownian motion with a uniform random generator had its random noise overpowered by a factor of sqrt(12):

https://github.com/lammps/lammps/blob/a67d82c183857531a70af3397848fddbcd4b8264/src/BROWNIAN/fix_brownian_base.cpp#L220-L223

This PR either fixes this probably-typo, or kindly requests an explanation of where that factor is coming from.

**Author(s)**

Tim Bernhard, tim@bernhard.site
<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Well, all the inputs will still run, but the resulting values definitely change.
<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

