### PR TITLE
Encode improper symmetries

### DIFF
--- a/src/AMOEBA/improper_amoeba.cpp
+++ b/src/AMOEBA/improper_amoeba.cpp
@@ -36,6 +36,10 @@ using namespace MathConst;
 ImproperAmoeba::ImproperAmoeba(LAMMPS *lmp) : Improper(lmp)
 {
   writedata = 1;
+
+  // the second atom in the quadruplet is the atom of symmetry
+
+  symmatoms[1] = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/CLASS2/improper_class2.cpp
+++ b/src/CLASS2/improper_class2.cpp
@@ -39,6 +39,10 @@ using namespace MathConst;
 ImproperClass2::ImproperClass2(LAMMPS *lmp) : Improper(lmp)
 {
   writedata = 1;
+
+  // the second atom in the quadruplet is the atom of symmetry
+
+  symmatoms[1] = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/EXTRA-MOLECULE/improper_cossq.cpp
+++ b/src/EXTRA-MOLECULE/improper_cossq.cpp
@@ -37,7 +37,12 @@ using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-ImproperCossq::ImproperCossq(LAMMPS *lmp) : Improper(lmp) {}
+ImproperCossq::ImproperCossq(LAMMPS *lmp) : Improper(lmp)
+{
+  // the first atom in the quadruplet is the atom of symmetry
+
+  symmatoms[0] = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-MOLECULE/improper_distance.cpp
+++ b/src/EXTRA-MOLECULE/improper_distance.cpp
@@ -35,7 +35,12 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-ImproperDistance::ImproperDistance(LAMMPS *lmp) : Improper(lmp) {}
+ImproperDistance::ImproperDistance(LAMMPS *lmp) : Improper(lmp)
+{
+  // the first atom in the quadruplet is the atom of symmetry
+
+  symmatoms[0] = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-MOLECULE/improper_fourier.cpp
+++ b/src/EXTRA-MOLECULE/improper_fourier.cpp
@@ -35,7 +35,13 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-ImproperFourier::ImproperFourier(LAMMPS *lmp) : Improper(lmp) {}
+ImproperFourier::ImproperFourier(LAMMPS *lmp) : Improper(lmp)
+{
+  // the first and fourth atoms in the quadruplet are the atoms of symmetry
+
+  symmatoms[0] = 1;
+  symmatoms[3] = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-MOLECULE/improper_fourier.cpp
+++ b/src/EXTRA-MOLECULE/improper_fourier.cpp
@@ -40,7 +40,7 @@ ImproperFourier::ImproperFourier(LAMMPS *lmp) : Improper(lmp)
   // the first and fourth atoms in the quadruplet are the atoms of symmetry
 
   symmatoms[0] = 1;
-  symmatoms[3] = 1;
+  symmatoms[3] = 2;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/EXTRA-MOLECULE/improper_ring.cpp
+++ b/src/EXTRA-MOLECULE/improper_ring.cpp
@@ -59,7 +59,12 @@ using namespace MathSpecial;
 
 /* ---------------------------------------------------------------------- */
 
-ImproperRing::ImproperRing(LAMMPS *lmp) : Improper(lmp) {}
+ImproperRing::ImproperRing(LAMMPS *lmp) : Improper(lmp)
+{
+  // the second atom in the quadruplet is the atom of symmetry
+
+  symmatoms[1] = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MOFFF/improper_inversion_harmonic.cpp
+++ b/src/MOFFF/improper_inversion_harmonic.cpp
@@ -43,6 +43,10 @@ using namespace MathConst;
 ImproperInversionHarmonic::ImproperInversionHarmonic(LAMMPS *lmp) : Improper(lmp)
 {
   writedata = 1;
+
+  // the first atom in the quadruplet is the atom of symmetry
+
+  symmatoms[0] = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/improper_cvff.cpp
+++ b/src/MOLECULE/improper_cvff.cpp
@@ -32,6 +32,10 @@ static constexpr double SMALL = 0.001;
 ImproperCvff::ImproperCvff(LAMMPS *_lmp) : Improper(_lmp)
 {
   writedata = 1;
+
+  // the first atom in the quadruplet is the atom of symmetry
+
+  symmatoms[0] = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/improper_harmonic.cpp
+++ b/src/MOLECULE/improper_harmonic.cpp
@@ -35,6 +35,10 @@ static constexpr double SMALL = 0.001;
 ImproperHarmonic::ImproperHarmonic(LAMMPS *_lmp) : Improper(_lmp)
 {
   writedata = 1;
+
+  // the first atom in the quadruplet is the atom of symmetry
+
+  symmatoms[0] = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/improper_umbrella.cpp
+++ b/src/MOLECULE/improper_umbrella.cpp
@@ -43,7 +43,7 @@ ImproperUmbrella::ImproperUmbrella(LAMMPS *_lmp) : Improper(_lmp)
   // the first and fourth atoms in the quadruplet are the atoms of symmetry
 
   symmatoms[0] = 1;
-  symmatoms[3] = 1;
+  symmatoms[3] = 2;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MOLECULE/improper_umbrella.cpp
+++ b/src/MOLECULE/improper_umbrella.cpp
@@ -39,6 +39,11 @@ static constexpr double SMALL = 0.001;
 ImproperUmbrella::ImproperUmbrella(LAMMPS *_lmp) : Improper(_lmp)
 {
   writedata = 1;
+
+  // the first and fourth atoms in the quadruplet are the atoms of symmetry
+
+  symmatoms[0] = 1;
+  symmatoms[3] = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/YAFF/improper_distharm.cpp
+++ b/src/YAFF/improper_distharm.cpp
@@ -37,6 +37,11 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 ImproperDistHarm::ImproperDistHarm(LAMMPS *lmp) : Improper(lmp) {}
+{
+  // the fourth atom in the quadruplet is the atom of symmetry
+
+  symmatoms[3] = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/YAFF/improper_distharm.cpp
+++ b/src/YAFF/improper_distharm.cpp
@@ -36,7 +36,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-ImproperDistHarm::ImproperDistHarm(LAMMPS *lmp) : Improper(lmp) {}
+ImproperDistHarm::ImproperDistHarm(LAMMPS *lmp) : Improper(lmp)
 {
   // the fourth atom in the quadruplet is the atom of symmetry
 

--- a/src/YAFF/improper_sqdistharm.cpp
+++ b/src/YAFF/improper_sqdistharm.cpp
@@ -36,7 +36,12 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-ImproperSQDistHarm::ImproperSQDistHarm(LAMMPS *lmp) : Improper(lmp) {}
+ImproperSQDistHarm::ImproperSQDistHarm(LAMMPS *lmp) : Improper(lmp)
+{
+  // the fourth atom in the quadruplet is the atom of symmetry
+
+  symmatoms[3] = 1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -30,6 +30,7 @@ Improper::Improper(LAMMPS *_lmp) : Pointers(_lmp)
 {
   energy = 0.0;
   writedata = 0;
+  for (int i = 0; i < 4; i++) symmatoms[i] = 0;
 
   allocated = 0;
   suffix_flag = Suffix::NONE;

--- a/src/improper.h
+++ b/src/improper.h
@@ -27,7 +27,6 @@ class Improper : protected Pointers {
   int *setflag;
   int writedata;    // 1 if writes coeffs to data file
   int born_matrix_enable;
-  int symmatoms[4];          // symmetry atom(s) of improper style
   double energy;             // accumulated energies
   double virial[6];          // accumulated virial: xx,yy,zz,xy,xz,yz
   double *eatom, **vatom;    // accumulated per-atom energy/virial
@@ -37,6 +36,11 @@ class Improper : protected Pointers {
                              // CENTROID_SAME = same as two-body stress
                              // CENTROID_AVAIL = different and implemented
                              // CENTROID_NOTAVAIL = different, not yet implemented
+                             
+  int symmatoms[4];          // symmetry atom(s) of improper style
+                             // value of 0: interchangable atoms
+                             // value of 1: central atom
+                             // values >1: additional atoms of symmetry                             
 
   // KOKKOS host/device flag and data masks
 

--- a/src/improper.h
+++ b/src/improper.h
@@ -27,6 +27,7 @@ class Improper : protected Pointers {
   int *setflag;
   int writedata;    // 1 if writes coeffs to data file
   int born_matrix_enable;
+  int symmatoms[4];          // symmetry atom(s) of improper style
   double energy;             // accumulated energies
   double virial[6];          // accumulated virial: xx,yy,zz,xy,xz,yz
   double *eatom, **vatom;    // accumulated per-atom energy/virial


### PR DESCRIPTION
**Summary**

Encode 'symmetry atoms' of improper styles, as described by the docs. This feature will be used to infer improper types from a set of four atoms (example of such a function is attached). Submitting this PR first and separately because significant review of the various impropers will be needed to ensure symmetry atoms are identified correctly. Symmetry atoms are defined as those that cannot be interchanged with others, whereas non-symmetry atoms are interchangable. For example, for a simple out-of-plane improper where atom J is out of the IKL plane, the symmetry atom is the second atom J.

This PR is related to the type labels PR to enable some of the envisioned functionality of type labels.

**Related Issue(s)**

eventually to be utilized by 'fix bond/react' and OpenKIM, for example

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

example of a function to infer improper type:

[infer_improper_example.txt](https://github.com/lammps/lammps/files/10938177/infer_improper_example.txt)



