### PR TITLE
cmake: remove pip install from install target

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -856,35 +856,6 @@ else()
     ${CMAKE_COMMAND} -E echo "Must build LAMMPS as a shared library to use the Python module")
 endif()
 
-###############################################################################
-# Add LAMMPS python module to "install" target. This is taylored for building
-# LAMMPS for package managers and with different prefix settings.
-# This requires either a shared library or that the PYTHON package is included.
-###############################################################################
-if(BUILD_SHARED_LIBS OR PKG_PYTHON)
-  if(CMAKE_VERSION VERSION_LESS 3.12)
-    # adjust so we find Python 3 versions before Python 2 on old systems with old CMake
-    set(Python_ADDITIONAL_VERSIONS 3.12 3.11 3.10 3.9 3.8 3.7 3.6)
-    find_package(PythonInterp) # Deprecated since version 3.12
-    if(PYTHONINTERP_FOUND)
-      set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
-    endif()
-  else()
-    # backward compatibility
-    if(PYTHON_EXECUTABLE)
-      set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
-    endif()
-    find_package(Python COMPONENTS Interpreter)
-  endif()
-  if(Python_EXECUTABLE)
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/python/lib)
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/python/src)
-    file(COPY ${LAMMPS_SOURCE_DIR}/version.h  DESTINATION ${CMAKE_BINARY_DIR}/python/src)
-    file(COPY ${LAMMPS_PYTHON_DIR}/README ${LAMMPS_PYTHON_DIR}/pyproject.toml ${LAMMPS_PYTHON_DIR}/setup.py ${LAMMPS_PYTHON_DIR}/lammps  DESTINATION ${CMAKE_BINARY_DIR}/python/lib)
-    install(CODE "if(\"\$ENV{DESTDIR}\" STREQUAL \"\")\n execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -v ${CMAKE_BINARY_DIR}/python/lib --prefix=${CMAKE_INSTALL_PREFIX})\n else()\n execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -v ${CMAKE_BINARY_DIR}/python/lib --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR})\n endif()")
-  endif()
-endif()
-
 include(Testing)
 include(CodeCoverage)
 include(CodingStandard)

--- a/doc/src/Python_install.rst
+++ b/doc/src/Python_install.rst
@@ -27,124 +27,19 @@ interpreter can find it and installing the LAMMPS shared library into a
 folder that the dynamic loader searches or inside of the installed
 ``lammps`` package folder.  There are multiple ways to achieve this.
 
-#. Do a full LAMMPS installation of libraries, executables, selected
-   headers, documentation (if enabled), and supporting files (only
-   available via CMake), which can also be either system-wide or into
-   user specific folders.
-
 #. Install both components into a Python ``site-packages`` folder, either
    system-wide or in the corresponding user-specific folder. This way no
    additional environment variables need to be set, but the shared
    library is otherwise not accessible.
 
-#. Do an installation into a virtual environment. This can either be an
-   installation of the Python package only or a full installation of LAMMPS.
+#. Do an installation into a virtual environment.
 
 #. Leave the files where they are in the source/development tree and
    adjust some environment variables.
 
 .. tabs::
 
-   .. tab:: Full install (CMake-only)
-
-      :ref:`Build the LAMMPS executable and library <library>` with
-      ``-DBUILD_SHARED_LIBS=on``, ``-DLAMMPS_EXCEPTIONS=on`` and
-      ``-DPKG_PYTHON=on`` (The first option is required, the other two
-      are optional by recommended).  The exact file name of the shared
-      library depends on the platform (Unix/Linux, macOS, Windows) and
-      the build configuration being used.  The installation base folder
-      is already set by default to the ``$HOME/.local`` directory, but
-      it can be changed to a custom location defined by the
-      ``CMAKE_INSTALL_PREFIX`` CMake variable.  This uses a folder
-      called ``build`` to store files generated during compilation.
-
-      .. code-block:: bash
-
-         # create build folder
-         mkdir build
-         cd build
-
-         # configure LAMMPS compilation
-         cmake -C ../cmake/presets/basic.cmake -D BUILD_SHARED_LIBS=on \
-               -D LAMMPS_EXCEPTIONS=on -D PKG_PYTHON=on ../cmake
-
-         # compile LAMMPS
-         cmake --build .
-
-         # install LAMMPS into $HOME/.local
-         cmake --install .
-
-
-      This leads to an installation to the following locations:
-
-      +------------------------+-----------------------------------------------------------------+-------------------------------------------------------------+
-      | File                   | Location                                                        | Notes                                                       |
-      +========================+=================================================================+=============================================================+
-      | LAMMPS Python package  | * ``$HOME/.local/lib/pythonX.Y/site-packages/lammps`` (32bit)   | ``X.Y`` depends on the installed Python version             |
-      |                        | * ``$HOME/.local/lib64/pythonX.Y/site-packages/lammps`` (64bit) |                                                             |
-      +------------------------+-----------------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS shared library  | * ``$HOME/.local/lib/`` (32bit)                                 | Set shared loader environment variable to this path         |
-      |                        | * ``$HOME/.local/lib64/`` (64bit)                               | (see below for more info on this)                           |
-      +------------------------+-----------------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS executable      | * ``$HOME/.local/bin/``                                         |                                                             |
-      +------------------------+-----------------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS potential files | * ``$HOME/.local/share/lammps/potentials/``                     | Set ``LAMMPS_POTENTIALS`` environment variable to this path |
-      +------------------------+-----------------------------------------------------------------+-------------------------------------------------------------+
-
-      For a system-wide installation you need to set
-      ``CMAKE_INSTALL_PREFIX`` to a system folder like ``/usr`` (or
-      ``/usr/local``); the default is ``${HOME}/.local``.  The
-      installation step for a system folder installation (**not** the
-      configuration/compilation) needs to be done with superuser
-      privilege, e.g. by using ``sudo cmake --install .``.  The
-      installation folders will then be changed to (assuming ``/usr`` as
-      prefix):
-
-      +------------------------+---------------------------------------------------------+-------------------------------------------------------------+
-      | File                   | Location                                                | Notes                                                       |
-      +========================+=========================================================+=============================================================+
-      | LAMMPS Python package  | * ``/usr/lib/pythonX.Y/site-packages/lammps`` (32bit)   | ``X.Y`` depends on the installed Python version             |
-      |                        | * ``/usr/lib64/pythonX.Y/site-packages/lammps`` (64bit) |                                                             |
-      +------------------------+---------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS shared library  | * ``/usr/lib/`` (32bit)                                 |                                                             |
-      |                        | * ``/usr/lib64/`` (64bit)                               |                                                             |
-      +------------------------+---------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS executable      | * ``/usr/bin/``                                         |                                                             |
-      +------------------------+---------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS potential files | * ``/usr/share/lammps/potentials/``                     |                                                             |
-      +------------------------+---------------------------------------------------------+-------------------------------------------------------------+
-
-      To be able to use the "user" installation you have to ensure that
-      the folder containing the LAMMPS shared library is either included
-      in a path searched by the shared linker (e.g. like
-      ``/usr/lib64/``) or part of the ``LD_LIBRARY_PATH`` environment
-      variable (or ``DYLD_LIBRARY_PATH`` on macOS).  Otherwise you will
-      get an error when trying to create a LAMMPS object through the
-      Python module.
-
-      .. code-block:: bash
-
-         # Unix/Linux
-         export LD_LIBRARY_PATH=$HOME/.local/lib:$LD_LIBRARY_PATH
-
-         # macOS
-         export DYLD_LIBRARY_PATH=$HOME/.local/lib:$DYLD_LIBRARY_PATH
-
-      If you plan to use the LAMMPS executable (e.g., ``lmp``), you may
-      also need to adjust the ``PATH`` environment variable (but many
-      newer Linux distributions already have ``$HOME/.local/bin``
-      included). Example:
-
-      .. code-block:: bash
-
-         export PATH=$HOME/.local/bin:$PATH
-
-      To make those changes permanent, you can add the commands to your
-      ``$HOME/.bashrc`` file.  For a system-wide installation is is not
-      necessary due to files installed in system folders that are loaded
-      automatically when a login shell is started.
-
-   .. tab:: Python package only
+   .. tab:: Python package
 
       Compile LAMMPS with either :doc:`CMake <Build_cmake>` or the
       :doc:`traditional make <Build_make>` procedure in :ref:`shared
@@ -271,38 +166,6 @@ folder that the dynamic loader searches or inside of the installed
       +------------------------+--------------------------------------------------------+-------------------------------------------------------------+
       | LAMMPS shared library  | * ``$VIRTUAL_ENV/lib/pythonX.Y/site-packages/lammps``  | ``X.Y`` depends on the installed Python version             |
       +------------------------+--------------------------------------------------------+-------------------------------------------------------------+
-
-      If you do a full installation (CMake only) with "install", this
-      leads to the following installation locations:
-
-      +------------------------+--------------------------------------------------------+-------------------------------------------------------------+
-      | File                   | Location                                               | Notes                                                       |
-      +========================+========================================================+=============================================================+
-      | LAMMPS Python Module   | * ``$VIRTUAL_ENV/lib/pythonX.Y/site-packages/lammps``  | ``X.Y`` depends on the installed Python version             |
-      +------------------------+--------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS shared library  | * ``$VIRTUAL_ENV/lib/`` (32bit)                        | Set shared loader environment variable to this path         |
-      |                        | * ``$VIRTUAL_ENV/lib64/`` (64bit)                      | (see below for more info on this)                           |
-      +------------------------+--------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS executable      | * ``$VIRTUAL_ENV/bin/``                                |                                                             |
-      +------------------------+--------------------------------------------------------+-------------------------------------------------------------+
-      | LAMMPS potential files | * ``$VIRTUAL_ENV/share/lammps/potentials/``            | Set ``LAMMPS_POTENTIALS`` environment variable to this path |
-      +------------------------+--------------------------------------------------------+-------------------------------------------------------------+
-
-      In that case you need to modify the ``$HOME/myenv/bin/activate``
-      script in a similar fashion you need to update your
-      ``$HOME/.bashrc`` file to include the shared library and
-      executable locations in ``LD_LIBRARY_PATH`` (or
-      ``DYLD_LIBRARY_PATH`` on macOS) and ``PATH``, respectively.
-
-      For example with:
-
-      .. code-block:: bash
-
-         # Unix/Linux
-         echo 'export LD_LIBRARY_PATH=$VIRTUAL_ENV/lib:$LD_LIBRARY_PATH' >> $HOME/myenv/bin/activate
-
-         # macOS
-         echo 'export DYLD_LIBRARY_PATH=$VIRTUAL_ENV/lib:$DYLD_LIBRARY_PATH' >> $HOME/myenv/bin/activate
 
    .. tab:: In place usage
 


### PR DESCRIPTION
**Summary**

The current `make install` uses pip to download dependencies and built the LAMMPS Python package, which is not something reasonable to do in certain packaging scenarios (what this part of our CMake was originally meant for) since you can't rely on internet access.

This drops the Python package install via pip from `make install`.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

@rbberger

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

To install the LAMMPS Python package you will now have to use `make install-python` or manually build it through some other means by using the package `python/setup.py` (pip wheel, pyproject, etc.).

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


