### PR TITLE
Bugfix fep tools

### DIFF
--- a/tools/fep/fdti.py
+++ b/tools/fep/fdti.py
@@ -10,7 +10,7 @@ if len(sys.argv) < 3:
     print("usage: fdti.py temperature hderiv < out.fep")
     sys.exit()
 
-rt = 0.008314 / 4.184 * float(sys.argv[1])
+rt = 0.008314 / 4.184 * float(sys.argv[1]) # in kcal/mol
 hderiv = float(sys.argv[2])
 
 line = sys.stdin.readline()
@@ -21,7 +21,7 @@ v = 1.0
 tok = line.split()
 if len(tok) == 4:
     v = float(tok[3])
-lo = -rt * math.log(float(tok[2]) / v)
+lo = -rt * math.log(float(tok[2])) / v
     
 i = 0
 sum = 0.0
@@ -29,9 +29,9 @@ for line in sys.stdin:
     tok = line.split()
     if len(tok) == 4:
         v = float(tok[3])
-    hi = - rt * math.log(float(tok[2]) / v)
+    hi = - rt * math.log(float(tok[2])) / v
     sum += (hi + lo) / (2 * hderiv)
     lo = hi
     i += 1
 
-print(sum/(i - 1))    # int_0^1: divide by i - 1 == multiply by delta
+print(sum/i)    # int_0^1: divide by i == multiply by delta

--- a/tools/fep/fep.py
+++ b/tools/fep/fep.py
@@ -9,7 +9,7 @@ if len(sys.argv) < 2:
     print("usage: fep.py temperature < out.fep")
     sys.exit()
 
-rt = 0.008314 / 4.184 * float(sys.argv[1])
+rt = 0.008314 / 4.184 * float(sys.argv[1]) # in kcal/mol
 
 v = 1.0
 sum = 0.0
@@ -19,6 +19,6 @@ for line in sys.stdin:
     tok = line.split()
     if len(tok) == 4:
         v = float(tok[3])
-    sum += math.log(float(tok[2]) / v)
+    sum += math.log(float(tok[2])) / v
 
 print(-rt * sum)


### PR DESCRIPTION
If the free energy is divided by the volume, this should be done outside the logarithm. `tok[2]` is an average over $exp(-k_b T \Delta U)$, i.e., division with the volume outside the logarithm is equivalent to averaging over $exp(-k_b T \Delta U / v)$.
In fdti.py the sum is divided by `i` instead of `i-1` because `i=0` after the first contribution to the sum.

**Summary**

Fixed two bugs in tools/fep/fdti.py and tools/fep/fep.py.
One regarding the averaging over the volume and one regarding the weights in the trapezoidal integration.

**Related Issue(s)**

None.

**Author(s)**

Ludwig Ahrens-Iwers (TUHH)
ludwig.ahiw@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None.

**Implementation Notes**

See description of this PR.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**




