### PR TITLE
fix ids once bug in compute chunk/atom

### DIFF
--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -691,9 +691,10 @@ void ComputeChunkAtom::compute_ichunk()
   if (invoked_ichunk == update->ntimestep) return;
 
   // if old IDs persist via storage in fixstore, then just retrieve them
-  // yes if idsflag = ONCE, and already done once
+  // restore = yes if idsflag = ONCE, and already done once
   //   or if idsflag = NFREQ and lock is in place and are on later timestep
   // else proceed to recalculate per-atom chunk assignments
+  // if restoring, update invoked_ichunk only for NFREQ case
 
   const int nlocal = atom->nlocal;
   int restore = 0;
@@ -701,7 +702,7 @@ void ComputeChunkAtom::compute_ichunk()
   if (idsflag == NFREQ && lockfix && update->ntimestep > lockstart) restore = 1;
 
   if (restore) {
-    invoked_ichunk = update->ntimestep;
+    if (idsflag == NFREQ) invoked_ichunk = update->ntimestep;
     double *vstore = fixstore->vstore;
     for (i = 0; i < nlocal; i++) ichunk[i] = static_cast<int>(vstore[i]);
     return;


### PR DESCRIPTION
**Summary**

Fix a bug in compute chunk/atom for the "ids once" option where the chunk IDs were mistakenly re-computed at the beginning of subsequent runs when they should not be.

**Related Issue(s)**

Fixes #3627

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A, except in cases where "ids once" was being used and the mistaken re-calculation of chunk IDs produced different IDs which then led to incorrect answers, e.g. via fix ave/chunk

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


