### PR TITLE
Collected small fixes and updates

### DIFF
--- a/doc/utils/sphinx-config/conf.py.in
+++ b/doc/utils/sphinx-config/conf.py.in
@@ -327,6 +327,7 @@ latex_elements = {
 % Make ToC number fields wider to accommodate sections with >= 100 subsections
 %   or >= 10 subsections with >= 10 subsubsections
 \makeatletter
+\@addtoreset{chapter}{part}
 \renewcommand*{\sphinxtableofcontentshook}{%
   \renewcommand*\l@section{\@dottedtocline{1}{1.5em}{3.1em}}
   \renewcommand*\l@subsection{\@dottedtocline{2}{4.6em}{4.5em}}

--- a/src/ASPHERE/pair_resquared.cpp
+++ b/src/ASPHERE/pair_resquared.cpp
@@ -778,7 +778,7 @@ double PairRESquared::resquared_analytic(const int i, const int j, const RE2Vars
 
   // torque on j
 
-  if (!(force->newton_pair || j < atom->nlocal)) return Ua + Ur;
+  if (!force->newton_pair && j >= atom->nlocal) return Ua + Ur;
 
   MathExtra::vecmat(fourw, wj.aTe, fwae);
 

--- a/src/ASPHERE/pair_ylz.h
+++ b/src/ASPHERE/pair_ylz.h
@@ -28,18 +28,18 @@ namespace LAMMPS_NS {
 class PairYLZ : public Pair {
  public:
   PairYLZ(LAMMPS *lmp);
-  virtual ~PairYLZ();
-  virtual void compute(int, int);
-  virtual void settings(int, char **);
+  ~PairYLZ() override;
+  void compute(int, int) override;
+  void settings(int, char **) override;
   void coeff(int, char **);
-  virtual void init_style();
-  double init_one(int, int);
-  void write_restart(FILE *);
-  void read_restart(FILE *);
-  void write_restart_settings(FILE *);
-  void read_restart_settings(FILE *);
-  void write_data(FILE *);
-  void write_data_all(FILE *);
+  void init_style() override;
+  double init_one(int, int) override;
+  void write_restart(FILE *) override;
+  void read_restart(FILE *) override;
+  void write_restart_settings(FILE *) override;
+  void read_restart_settings(FILE *) override;
+  void write_data(FILE *) override;
+  void write_data_all(FILE *) override;
 
  protected:
   double cut_global;

--- a/src/BPM/bond_bpm.cpp
+++ b/src/BPM/bond_bpm.cpp
@@ -332,7 +332,7 @@ void BondBPM::read_restart(FILE *fp)
 
 void BondBPM::process_broken(int i, int j)
 {
-  if (break_flag)
+  if (!break_flag)
     error->one(FLERR, "BPM bond broke with break/no option");
   if (fix_store_local) {
     for (int n = 0; n < nvalues; n++) (this->*pack_choice[n])(n, i, j);

--- a/src/COLLOID/fix_wall_colloid.cpp
+++ b/src/COLLOID/fix_wall_colloid.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -20,22 +19,22 @@
 
 #include "atom.h"
 #include "error.h"
+#include "math_special.h"
 
 #include <cmath>
 
 using namespace LAMMPS_NS;
+using MathSpecial::powint;
 
 /* ---------------------------------------------------------------------- */
 
-FixWallColloid::FixWallColloid(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg) {}
+FixWallColloid::FixWallColloid(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, narg, arg) {}
 
 /* ---------------------------------------------------------------------- */
 
 void FixWallColloid::init()
 {
-  if (!atom->sphere_flag)
-    error->all(FLERR,"Fix wall/colloid requires atom style sphere");
+  if (!atom->sphere_flag) error->all(FLERR, "Fix wall/colloid requires atom style sphere");
 
   // ensure all particles in group are extended particles
 
@@ -49,8 +48,8 @@ void FixWallColloid::init()
       if (radius[i] == 0.0) flag = 1;
 
   int flagall;
-  MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
-  if (flagall) error->all(FLERR,"Fix wall/colloid requires extended particles");
+  MPI_Allreduce(&flag, &flagall, 1, MPI_INT, MPI_SUM, world);
+  if (flagall) error->all(FLERR, "Fix wall/colloid requires extended particles");
 
   FixWall::init();
 }
@@ -59,10 +58,10 @@ void FixWallColloid::init()
 
 void FixWallColloid::precompute(int m)
 {
-  coeff1[m] = 4.0/315.0 * epsilon[m] * pow(sigma[m],6.0);
-  coeff2[m] = 2.0/3.0 * epsilon[m];
-  coeff3[m] = epsilon[m] * pow(sigma[m],6.0)/7560.0;
-  coeff4[m] = epsilon[m]/6.0;
+  coeff1[m] = 4.0 / 315.0 * epsilon[m] * powint(sigma[m], 6);
+  coeff2[m] = 2.0 / 3.0 * epsilon[m];
+  coeff3[m] = epsilon[m] * powint(sigma[m], 6) / 7560.0;
+  coeff4[m] = epsilon[m] / 6.0;
 }
 
 /* ----------------------------------------------------------------------
@@ -74,10 +73,10 @@ void FixWallColloid::precompute(int m)
 
 void FixWallColloid::wall_particle(int m, int which, double coord)
 {
-  double delta,delta2,rinv,r2inv,r4inv,r8inv,fwall;
-  double r2,rinv2,r2inv2,r4inv2;
-  double r3,rinv3,r2inv3,r4inv3;
-  double rad,rad2,rad4,rad8,diam,new_coeff2;
+  double delta, delta2, rinv, r2inv, r4inv, r8inv, fwall;
+  double r2, rinv2, r2inv2, r4inv2;
+  double r3, rinv3, r2inv3, r4inv3;
+  double rad, rad2, rad4, rad8, diam, new_coeff2;
   double eoffset;
   double vn;
 
@@ -87,7 +86,7 @@ void FixWallColloid::wall_particle(int m, int which, double coord)
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
 
-  int dim = which  / 2;
+  int dim = which / 2;
   int side = which % 2;
   if (side == 0) side = -1;
 
@@ -95,8 +94,10 @@ void FixWallColloid::wall_particle(int m, int which, double coord)
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      if (side < 0) delta = x[i][dim] - coord;
-      else delta = coord - x[i][dim];
+      if (side < 0)
+        delta = x[i][dim] - coord;
+      else
+        delta = coord - x[i][dim];
       if (delta >= cutoff[m]) continue;
       rad = radius[i];
       if (rad >= delta) {
@@ -104,59 +105,67 @@ void FixWallColloid::wall_particle(int m, int which, double coord)
         continue;
       }
 
-      new_coeff2 = coeff2[m]*rad*rad*rad;
-      diam = 2.0*rad;
-      rad2 = rad*rad;
-      rad4 = rad2*rad2;
-      rad8 = rad4*rad4;
-      delta2 = rad2 - delta*delta;
-      rinv = 1.0/delta2;
-      r2inv = rinv*rinv;
-      r4inv = r2inv*r2inv;
-      r8inv = r4inv*r4inv;
-      fwall = side * (coeff1[m]*(rad8*rad + 27.0*rad4*rad2*rad*pow(delta,2.0)
-                                 + 63.0*rad4*rad*pow(delta,4.0)
-                                 + 21.0*rad2*rad*pow(delta,6.0))*r8inv -
+      new_coeff2 = coeff2[m] * rad * rad * rad;
+      diam = 2.0 * rad;
+      rad2 = rad * rad;
+      rad4 = rad2 * rad2;
+      rad8 = rad4 * rad4;
+      delta2 = rad2 - delta * delta;
+      rinv = 1.0 / delta2;
+      r2inv = rinv * rinv;
+      r4inv = r2inv * r2inv;
+      r8inv = r4inv * r4inv;
+      // clang-format off
+      fwall = side * (coeff1[m]*(rad8*rad + 27.0*rad4*rad2*rad*powint(delta,2)
+                                 + 63.0*rad4*rad*powint(delta,4)
+                                 + 21.0*rad2*rad*powint(delta,6))*r8inv -
                       new_coeff2*r2inv);
       f[i][dim] -= fwall;
+      // clang-format on
 
       r2 = rad - delta;
-      rinv2 = 1.0/r2;
-      r2inv2 = rinv2*rinv2;
-      r4inv2 = r2inv2*r2inv2;
+      rinv2 = 1.0 / r2;
+      r2inv2 = rinv2 * rinv2;
+      r4inv2 = r2inv2 * r2inv2;
       r3 = delta + rad;
-      rinv3 = 1.0/r3;
-      r2inv3 = rinv3*rinv3;
-      r4inv3 = r2inv3*r2inv3;
+      rinv3 = 1.0 / r3;
+      r2inv3 = rinv3 * rinv3;
+      r4inv3 = r2inv3 * r2inv3;
+      // clang-format off
       ewall[0] += coeff3[m]*((-3.5*diam+delta)*r4inv2*r2inv2*rinv2
                              + (3.5*diam+delta)*r4inv3*r2inv3*rinv3) -
         coeff4[m]*((diam*delta-r2*r3*(log(-r2)-log(r3)))*
                    (-rinv2)*rinv3);
+      // clang-format on
 
       // offset depends on particle size
 
       r2 = rad - cutoff[m];
-      rinv2 = 1.0/r2;
-      r2inv2 = rinv2*rinv2;
-      r4inv2 = r2inv2*r2inv2;
+      rinv2 = 1.0 / r2;
+      r2inv2 = rinv2 * rinv2;
+      r4inv2 = r2inv2 * r2inv2;
       r3 = cutoff[m] + rad;
-      rinv3 = 1.0/r3;
-      r2inv3 = rinv3*rinv3;
-      r4inv3 = r2inv3*r2inv3;
+      rinv3 = 1.0 / r3;
+      r2inv3 = rinv3 * rinv3;
+      r4inv3 = r2inv3 * r2inv3;
+      // clang-format off
       eoffset = coeff3[m]*((-3.5*diam+cutoff[m])*r4inv2*r2inv2*rinv2
                            + (3.5*diam+cutoff[m])*r4inv3*r2inv3*rinv3) -
         coeff4[m]*((diam*cutoff[m]-r2*r3*(log(-r2)-log(r3)))*
                    (-rinv2)*rinv3);
       ewall[0] -= eoffset;
+      // clang-format on
 
-      ewall[m+1] += fwall;
+      ewall[m + 1] += fwall;
 
       if (evflag) {
-        if (side < 0) vn = -fwall*delta;
-        else vn = fwall*delta;
-        v_tally(dim,i,vn);
+        if (side < 0)
+          vn = -fwall * delta;
+        else
+          vn = fwall * delta;
+        v_tally(dim, i, vn);
       }
     }
 
-  if (onflag) error->one(FLERR,"Particle on or inside fix wall surface");
+  if (onflag) error->one(FLERR, "Particle on or inside fix wall surface");
 }

--- a/src/DIFFRACTION/compute_xrd.cpp
+++ b/src/DIFFRACTION/compute_xrd.cpp
@@ -125,7 +125,7 @@ ComputeXRD::ComputeXRD(LAMMPS *lmp, int narg, char **arg) :
       if (iarg+2 > narg) error->all(FLERR,"Illegal Compute XRD Command");
       LP = utils::numeric(FLERR,arg[iarg+1],false,lmp);
 
-      if (!(LP == 1 || LP == 0))
+      if (LP != 1 && LP != 0)
          error->all(FLERR,"Compute XRD: LP must have value of 0 or 1");
       iarg += 2;
 

--- a/src/ELECTRODE/electrode_matrix.cpp
+++ b/src/ELECTRODE/electrode_matrix.cpp
@@ -158,7 +158,7 @@ void ElectrodeMatrix::pair_contribution(double **array)
         aij *= ElectrodeMath::safe_erfc(g_ewald * r);
         aij -= ElectrodeMath::safe_erfc(etaij * r) * rinv;
         // newton on or off?
-        if (!(newton_pair || j < nlocal)) aij *= 0.5;
+        if (!newton_pair && j >= nlocal) aij *= 0.5;
         bigint jpos = tag_to_iele[tag[j]];
         array[ipos][jpos] += aij;
         array[jpos][ipos] += aij;

--- a/src/ELECTRODE/fix_electrode_conp.cpp
+++ b/src/ELECTRODE/fix_electrode_conp.cpp
@@ -124,7 +124,7 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
     if ((strcmp(arg[iarg], "couple") == 0)) {
       if (iarg + 3 > narg) error->all(FLERR, "Need two arguments after couple keyword");
       int id = group->find(arg[++iarg]);
-      if (id < 0) error->all(FLERR, "Group does not exist");
+      if (id < 0) error->all(FLERR, "Group {} does not exist", arg[iarg]);
       groups.push_back(id);
       group_bits.push_back(group->bitmask[id]);
       ++iarg;
@@ -140,7 +140,7 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
         group_psi.push_back(utils::numeric(FLERR, arg[iarg], false, lmp));
       }
     } else if ((strcmp(arg[iarg], "algo") == 0)) {
-      if (!default_algo) error->one(FLERR, fmt::format("Algorithm can be set once, only"));
+      if (!default_algo) error->one(FLERR, "Algorithm can be set only once");
       default_algo = false;
       if (iarg + 2 > narg) error->all(FLERR, "Need one argument after algo command");
       char *algo_arg = arg[++iarg];
@@ -157,7 +157,7 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
         matrix_algo = false;
         cg_algo = true;
       } else {
-        error->all(FLERR, "Invalid argument after algo keyword");
+        error->all(FLERR, "Unknown algo keyword {}", algo_arg);
       }
       if (cg_algo) {
         if (iarg + 2 > narg) error->all(FLERR, "Need one argument after algo *cg command");
@@ -175,7 +175,7 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
         write_vec = true;
         output_file_vec = arg[++iarg];
       } else {
-        error->all(FLERR, "Illegal fix electrode/conp command with write");
+        error->all(FLERR, "Illegal fix {} command with write", style);
       }
     } else if ((strncmp(arg[iarg], "read", 4) == 0)) {
       if (iarg + 2 > narg) error->all(FLERR, "Need one argument after read command");
@@ -186,12 +186,12 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
         read_mat = true;
         input_file_mat = arg[++iarg];
       } else {
-        error->all(FLERR, "Illegal fix electrode/conp command with read");
+        error->all(FLERR, "Illegal fix {} command with read", style);
       }
     } else if ((strcmp(arg[iarg], "temp") == 0)) {
       if (iarg + 4 > narg) error->all(FLERR, "Need three arguments after temp command");
-      if (strcmp(this->style, "electrode/thermo") != 0)
-        error->all(FLERR, "temp keyword not available for this electrode fix");
+      if (!utils::strmatch(style, "electrode/thermo"))
+        error->all(FLERR, "temp keyword not available for fix {}", style);
       thermo_temp = force->boltz / force->qe2f * utils::numeric(FLERR, arg[++iarg], false, lmp);
       thermo_time = utils::numeric(FLERR, arg[++iarg], false, lmp);
       thermo_init = utils::inumeric(FLERR, arg[++iarg], false, lmp);
@@ -203,7 +203,7 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
     } else if ((strcmp(arg[iarg], "ffield") == 0)) {
       ffield = utils::logical(FLERR, arg[++iarg], false, lmp);
     } else {
-      error->all(FLERR, "Illegal fix electrode/conp command");
+      error->all(FLERR, "Unknown keyword {} for fix {} command", arg[iarg], style);
     }
     iarg++;
   }
@@ -241,9 +241,7 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
   }
   if (read_inv && read_mat) error->all(FLERR, "Cannot read matrix from two files");
   if (write_mat && read_inv)
-    error->all(FLERR,
-               "Cannot write elastance matrix if reading capacitance matrix "
-               "from file");
+    error->all(FLERR, "Cannot write elastance matrix if reading capacitance matrix from file");
   num_of_groups = static_cast<int>(groups.size());
   size_vector = num_of_groups;
   array_flag = !!(algo == Algo::MATRIX_INV);
@@ -291,7 +289,7 @@ FixElectrodeConp::FixElectrodeConp(LAMMPS *lmp, int narg, char **arg) :
 int FixElectrodeConp::modify_param(int narg, char **arg)
 {
   if (strcmp(arg[0], "tf") == 0) {
-    if (narg < 4) error->all(FLERR, fmt::format("Incorrect number of arguments for fix_modify tf"));
+    if (narg < 4) error->all(FLERR, "Incorrect number of arguments for fix_modify {}", style);
     tfflag = true;
     // read atom type, Thomas-Fermi length, and voronoi volume (reciprocal
     // number density)
@@ -323,13 +321,12 @@ int FixElectrodeConp::modify_param(int narg, char **arg)
     return 4;
 
   } else if (strcmp(arg[0], "timer") == 0) {
-    if (narg < 2)
-      error->all(FLERR, fmt::format("Incorrect number of arguments for fix_modify timer"));
+    if (narg < 2) error->all(FLERR, "Incorrect number of arguments for fix_modify {} timer", style);
     timer_flag = utils::logical(FLERR, arg[1], false, lmp);
     return 2;
 
   } else
-    error->all(FLERR, "Invalid argument for fix_modify electrode");
+    error->all(FLERR, "Unknown argument {} for fix_modify {}", arg[0], style);
   return 0;
 }
 
@@ -351,11 +348,11 @@ int FixElectrodeConp::modify_param(const std::string &param_str)
 int FixElectrodeConp::groupnum_from_name(char *groupname)
 {
   int id = group->find(groupname);
-  if (id < 0) error->all(FLERR, fmt::format("Group {} does not exist", groupname));
+  if (id < 0) error->all(FLERR, "Group {} does not exist", groupname);
   for (int g = 0; g < num_of_groups; g++) {
     if (groups[g] == id) return g;
   }
-  error->all(FLERR, fmt::format("Group {} is not coupled by fix electrode", groupname));
+  error->all(FLERR, "Group {} is not coupled by fix electrode", groupname);
   return -1;    // dummy return value
 }
 
@@ -445,7 +442,7 @@ void FixElectrodeConp::setup_post_neighbor()
     }
     MPI_Allreduce(MPI_IN_PLACE, &unset_tf, 1, MPI_INT, MPI_SUM, world);
     if (unset_tf)
-      error->all(FLERR, fmt::format("Thomas-Fermi parameters not set for all types in electrode"));
+      error->all(FLERR, "Thomas-Fermi parameters not set for all types in fix {}", style);
   }
 
   // get equal-style variable ids:
@@ -454,11 +451,9 @@ void FixElectrodeConp::setup_post_neighbor()
     if (group_psi_var_styles[g] == VarStyle::CONST) continue;
     const char *var_name = group_psi_var_names[g].c_str();
     int var_id = input->variable->find(var_name);
-    if (var_id < 0)
-      error->all(FLERR, fmt::format("Variable '{}' for fix electrode does not exist", var_name));
+    if (var_id < 0) error->all(FLERR, "Variable '{}' for fix {} does not exist", var_name, style);
     if (!input->variable->equalstyle(var_id))
-      error->all(FLERR,
-                 fmt::format("Variable '{}' for fix electrode is not equal-style", var_name));
+      error->all(FLERR, "Variable '{}' for fix {} is not equal-style", var_name, style);
     group_psi_var_ids[g] = var_id;
   }
 
@@ -508,9 +503,8 @@ void FixElectrodeConp::setup_post_neighbor()
     if (comm->me == 0 && write_mat) {
       auto f_mat = fopen(output_file_mat.c_str(), "w");
       if (f_mat == nullptr)
-        error->one(FLERR,
-                   fmt::format("Cannot open elastance matrix file {}: {}", output_file_mat,
-                               utils::getsyserror()));
+        error->one(FLERR, "Cannot open elastance matrix file {}: {}", output_file_mat,
+                   utils::getsyserror());
       write_to_file(f_mat, taglist_bygroup, order_matrix(group_idx, elastance));
       fclose(f_mat);
     }
@@ -534,8 +528,7 @@ void FixElectrodeConp::setup_post_neighbor()
       compute_macro_matrices();
       MPI_Barrier(world);
       if (timer_flag && (comm->me == 0))
-        utils::logmesg(
-            lmp, fmt::format("SD-vector and macro matrices time: {:.4g} s\n", MPI_Wtime() - start));
+        utils::logmesg(lmp, "SD-vector and macro matrices time: {:.4g} s\n", MPI_Wtime() - start);
     }
   }
   // initial charges and b vector
@@ -550,11 +543,9 @@ void FixElectrodeConp::setup_post_neighbor()
     if (comm->me == 0) {
       auto f_vec = fopen(output_file_vec.c_str(), "w");
       if (f_vec == nullptr)
-        error->one(
-            FLERR,
-            fmt::format("Cannot open vector file {}: {}", output_file_vec, utils::getsyserror()));
+        error->one(FLERR, "Cannot open vector file {}: {}", output_file_vec, utils::getsyserror());
       std::vector<std::vector<double>> vec(ngroup, std::vector<double>(1));
-      for (int i = 0; i < ngroup; i++) { vec[group_idx[i]][0] = potential_iele[i]; }
+      for (int i = 0; i < ngroup; i++) vec[group_idx[i]][0] = potential_iele[i];
       write_to_file(f_vec, taglist_bygroup, vec);
       fclose(f_vec);
     }
@@ -564,9 +555,8 @@ void FixElectrodeConp::setup_post_neighbor()
     if (comm->me == 0) {
       auto f_inv = fopen(output_file_inv.c_str(), "w");
       if (f_inv == nullptr)
-        error->one(FLERR,
-                   fmt::format("Cannot open capacitance matrix file {}: {}", output_file_inv,
-                               utils::getsyserror()));
+        error->one(FLERR, "Cannot open capacitance matrix file {}: {}", output_file_inv,
+                   utils::getsyserror());
       write_to_file(f_inv, taglist_bygroup, order_matrix(group_idx, capacitance));
       fclose(f_inv);
     }
@@ -603,7 +593,7 @@ void FixElectrodeConp::invert()
   if (info_rf != 0 || info_ri != 0) error->all(FLERR, "CONP matrix inversion failed!");
   MPI_Barrier(world);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("Invert time: {:.4g} s\n", MPI_Wtime() - invert_time));
+    utils::logmesg(lmp, "Invert time: {:.4g} s\n", MPI_Wtime() - invert_time);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -694,9 +684,9 @@ void FixElectrodeConp::setup_pre_exchange()    // create_taglist
   mem_needed /= (1024 * 1024 * 1024);    // convert to GiB
   if (mem_needed > 0.5 && comm->me == 0)
     error->warning(FLERR,
-                   fmt::format("Please ensure there is sufficient memory for fix electrode "
-                               "(anticipated usage is at least {:.1f} GiB per proc)",
-                               mem_needed));
+                   "Please ensure there is sufficient memory for fix electrode "
+                   "(anticipated usage is at least {:.1f} GiB per proc)",
+                   mem_needed);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -867,7 +857,7 @@ void FixElectrodeConp::update_charges()
   update_time += MPI_Wtime() - start;
 }
 
-std::vector<double> FixElectrodeConp::ele_ele_interaction(const std::vector<double>& q_local)
+std::vector<double> FixElectrodeConp::ele_ele_interaction(const std::vector<double> &q_local)
 {
   assert(q_local.size() == nlocalele);
   assert(algo == Algo::CG || algo == Algo::MATRIX_CG);
@@ -1211,13 +1201,11 @@ FixElectrodeConp::~FixElectrodeConp()
   if (comm->me == 0) {
     try {
       if (timer_flag) {
-        utils::logmesg(lmp, fmt::format("Multiplication time: {:.4g} s\n", mult_time));
-        utils::logmesg(lmp, fmt::format("Update time: {:.4g} s\n", update_time));
+        utils::logmesg(lmp, "Multiplication time: {:.4g} s\n", mult_time);
+        utils::logmesg(lmp, "Update time: {:.4g} s\n", update_time);
       }
       if (algo == Algo::CG || algo == Algo::MATRIX_CG)
-        utils::logmesg(
-            lmp,
-            fmt::format("Average conjugate gradient steps: {:.4g}\n", n_cg_step * 1. / n_call));
+        utils::logmesg(lmp, "Average conjugate gradient steps: {:.4g}\n", n_cg_step * 1. / n_call);
     } catch (std::exception &) {
     }
   }
@@ -1304,7 +1292,7 @@ void FixElectrodeConp::read_from_file(const std::string &input_file, double **ar
       }
     }
     if ((bigint) idx.size() != ngroup)
-      error->all(FLERR, fmt::format("Read tags do not match taglist of electrode/conp"));
+      error->all(FLERR, "Read tags do not match taglist of fix {}", style);
     for (bigint i = 0; i < ngroup; i++) {
       bigint const ii = idx[i];
       for (bigint j = 0; j < ngroup; j++) array[i][j] = matrix[ii][idx[j]];

--- a/src/ELECTRODE/fix_electrode_conp.cpp
+++ b/src/ELECTRODE/fix_electrode_conp.cpp
@@ -1225,7 +1225,6 @@ FixElectrodeConp::~FixElectrodeConp()
   memory->destroy(elastance);
   memory->destroy(capacitance);
   if (need_elec_vector) delete elec_vector;
-  if (algo == Algo::MATRIX_INV) memory->destroy(capacitance);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/ELECTRODE/fix_electrode_conp.cpp
+++ b/src/ELECTRODE/fix_electrode_conp.cpp
@@ -859,7 +859,7 @@ void FixElectrodeConp::update_charges()
 
 std::vector<double> FixElectrodeConp::ele_ele_interaction(const std::vector<double> &q_local)
 {
-  assert(q_local.size() == nlocalele);
+  assert((int)q_local.size() == nlocalele);
   assert(algo == Algo::CG || algo == Algo::MATRIX_CG);
   if (algo == Algo::CG) {
     set_charges(q_local);
@@ -873,7 +873,7 @@ std::vector<double> FixElectrodeConp::ele_ele_interaction(const std::vector<doub
 
 void FixElectrodeConp::set_charges(std::vector<double> q_local)
 {
-  assert(q_local.size() == nlocalele);
+  assert((int)q_local.size() == nlocalele);
   double *q = atom->q;
   for (int i = 0; i < nlocalele; i++) q[atom->map(taglist_local[i])] = q_local[i];
   comm->forward_comm(this);
@@ -942,7 +942,7 @@ std::vector<double> FixElectrodeConp::scale_vector(double alpha, std::vector<dou
 
 std::vector<double> FixElectrodeConp::add_nlocalele(std::vector<double> a, std::vector<double> b)
 {
-  assert(a.size() == nlocalele && b.size() == nlocalele);
+  assert(((int)a.size() == nlocalele) && ((int)b.size() == nlocalele));
   for (int i = 0; i < nlocalele; i++) a[i] += b[i];
   return a;
 }
@@ -951,7 +951,7 @@ std::vector<double> FixElectrodeConp::add_nlocalele(std::vector<double> a, std::
 
 double FixElectrodeConp::dot_nlocalele(std::vector<double> a, std::vector<double> b)
 {
-  assert(a.size() == nlocalele && b.size() == nlocalele);
+  assert(((int)a.size() == nlocalele) && ((int)b.size() == nlocalele));
   double out = 0.;
   for (int i = 0; i < nlocalele; i++) out += a[i] * b[i];
   MPI_Allreduce(MPI_IN_PLACE, &out, 1, MPI_DOUBLE, MPI_SUM, world);
@@ -962,7 +962,7 @@ double FixElectrodeConp::dot_nlocalele(std::vector<double> a, std::vector<double
 
 std::vector<double> FixElectrodeConp::times_elastance(std::vector<double> x)
 {
-  assert(x.size() == ngroup);
+  assert((int)x.size() == ngroup);
   auto out = std::vector<double>(nlocalele, 0.);
   for (int i = 0; i < nlocalele; i++) {
     double *_noalias row = elastance[list_iele[i]];
@@ -1413,7 +1413,7 @@ void FixElectrodeConp::gather_list_iele()
     }
   }
   nlocalele = static_cast<int>(taglist_local.size());    // just for safety
-  assert(iele_to_group_local.size() == nlocalele);
+  assert((int)iele_to_group_local.size() == nlocalele);
 
   if (matrix_algo) {
     MPI_Allgather(&nlocalele, 1, MPI_INT, recvcounts, 1, MPI_INT, world);

--- a/src/EXTRA-FIX/fix_wall_ees.cpp
+++ b/src/EXTRA-FIX/fix_wall_ees.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -18,40 +17,40 @@
 
 #include "fix_wall_ees.h"
 
-#include "math_extra.h"
 #include "atom.h"
 #include "atom_vec_ellipsoid.h"
 #include "error.h"
+#include "math_extra.h"
+#include "math_special.h"
 
 #include <cmath>
 
 using namespace LAMMPS_NS;
+using MathSpecial::powint;
 
 /* ---------------------------------------------------------------------- */
 
-FixWallEES::FixWallEES(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg) {}
+FixWallEES::FixWallEES(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, narg, arg) {}
 
 /* ---------------------------------------------------------------------- */
 
 void FixWallEES::precompute(int m)
 {
-  coeff1[m] = ( 2. / 4725. ) * epsilon[m] * pow(sigma[m],12.0);
-  coeff2[m] = ( 1. / 24. ) * epsilon[m] * pow(sigma[m],6.0);
+  coeff1[m] = (2.0 / 4725.0) * epsilon[m] * powint(sigma[m], 12);
+  coeff2[m] = (1.0 / 24.0) * epsilon[m] * powint(sigma[m], 6);
 
-  coeff3[m] = ( 2. / 315. ) * epsilon[m] * pow(sigma[m],12.0);
-  coeff4[m] = ( 1. / 3. ) * epsilon[m] * pow(sigma[m],6.0);
+  coeff3[m] = (2.0 / 315.0) * epsilon[m] * powint(sigma[m], 12);
+  coeff4[m] = (1.0 / 3.0) * epsilon[m] * powint(sigma[m], 6);
 
-  coeff5[m] = ( 4. / 315. ) * epsilon[m] * pow(sigma[m],12.0);
-  coeff6[m] = ( 1. / 12. )  * epsilon[m] * pow(sigma[m],6.0);
+  coeff5[m] = (4.0 / 315.0) * epsilon[m] * powint(sigma[m], 12);
+  coeff6[m] = (1.0 / 12.0) * epsilon[m] * powint(sigma[m], 6);
 }
 
 /* ---------------------------------------------------------------------- */
 void FixWallEES::init()
 {
   avec = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
-  if (!avec)
-    error->all(FLERR,"Fix wall/ees requires atom style ellipsoid");
+  if (!avec) error->all(FLERR, "Fix wall/ees requires atom style ellipsoid");
 
   // check that all particles are finite-size ellipsoids
   // no point particles allowed, spherical is OK
@@ -62,12 +61,12 @@ void FixWallEES::init()
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit)
-      if (ellipsoid[i] < 0)
-        error->one(FLERR,"Fix wall/ees requires extended particles");
+      if (ellipsoid[i] < 0) error->one(FLERR, "Fix wall/ees requires extended particles");
 
   FixWall::init();
 }
 
+// clang-format off
 
 /* ----------------------------------------------------------------------
    interaction of all particles in group with a wall

--- a/src/GPU/pair_eam_alloy_gpu.cpp
+++ b/src/GPU/pair_eam_alloy_gpu.cpp
@@ -138,8 +138,7 @@ void PairEAMAlloyGPU::compute(int eflag, int vflag)
     eam_alloy_gpu_compute_force(nullptr, eflag, vflag, eflag_atom, vflag_atom);
   else
     eam_alloy_gpu_compute_force(ilist, eflag, vflag, eflag_atom, vflag_atom);
-  if (atom->molecular != Atom::ATOMIC && neighbor->ago == 0)
-    neighbor->build_topology();
+  if (atom->molecular != Atom::ATOMIC && neighbor->ago == 0) neighbor->build_topology();
 }
 
 /* ----------------------------------------------------------------------
@@ -282,12 +281,8 @@ void PairEAMAlloyGPU::coeff(int narg, char **arg)
 
   if (!allocated) allocate();
 
-  if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
-
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0], "*") != 0 || strcmp(arg[1], "*") != 0)
-    error->all(FLERR, "Incorrect args for pair coefficients");
+  if (narg != 3 + atom->ntypes)
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM setfl file
 

--- a/src/GPU/pair_eam_fs_gpu.cpp
+++ b/src/GPU/pair_eam_fs_gpu.cpp
@@ -138,8 +138,7 @@ void PairEAMFSGPU::compute(int eflag, int vflag)
     eam_fs_gpu_compute_force(nullptr, eflag, vflag, eflag_atom, vflag_atom);
   else
     eam_fs_gpu_compute_force(ilist, eflag, vflag, eflag_atom, vflag_atom);
-  if (atom->molecular != Atom::ATOMIC && neighbor->ago == 0)
-    neighbor->build_topology();
+  if (atom->molecular != Atom::ATOMIC && neighbor->ago == 0) neighbor->build_topology();
 }
 
 /* ----------------------------------------------------------------------
@@ -282,12 +281,8 @@ void PairEAMFSGPU::coeff(int narg, char **arg)
 
   if (!allocated) allocate();
 
-  if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
-
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0], "*") != 0 || strcmp(arg[1], "*") != 0)
-    error->all(FLERR, "Incorrect args for pair coefficients");
+  if (narg != 3 + atom->ntypes)
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM Finnis-Sinclair file
 

--- a/src/GPU/pair_eam_gpu.cpp
+++ b/src/GPU/pair_eam_gpu.cpp
@@ -136,8 +136,7 @@ void PairEAMGPU::compute(int eflag, int vflag)
     eam_gpu_compute_force(nullptr, eflag, vflag, eflag_atom, vflag_atom);
   else
     eam_gpu_compute_force(ilist, eflag, vflag, eflag_atom, vflag_atom);
-  if (atom->molecular != Atom::ATOMIC && neighbor->ago == 0)
-    neighbor->build_topology();
+  if (atom->molecular != Atom::ATOMIC && neighbor->ago == 0) neighbor->build_topology();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/GRANULAR/fix_wall_gran_region.cpp
+++ b/src/GRANULAR/fix_wall_gran_region.cpp
@@ -124,10 +124,8 @@ void FixWallGranRegion::init()
 void FixWallGranRegion::post_force(int /*vflag*/)
 {
   int i, m, nc, iwall;
-  double dx, dy, dz, meff;
   double *forces, *torquesi;
-  double vwall[3];
-  double w0[3] = {0.0};
+  double meff, vwall[3], w0[3] = {0.0, 0.0, 0.0};
   bool touchflag = false;
 
   // do not update shear history during setup
@@ -283,9 +281,9 @@ void FixWallGranRegion::post_force(int /*vflag*/)
         array_atom[i][1] = forces[0];
         array_atom[i][2] = forces[1];
         array_atom[i][3] = forces[2];
-        array_atom[i][4] = x[i][0] - dx;
-        array_atom[i][5] = x[i][1] - dy;
-        array_atom[i][6] = x[i][2] - dz;
+        array_atom[i][4] = x[i][0] - model->dx[0];
+        array_atom[i][5] = x[i][1] - model->dx[1];
+        array_atom[i][6] = x[i][2] - model->dx[2];
         array_atom[i][7] = radius[i];
       }
     }

--- a/src/INTEL/pair_eam_alloy_intel.cpp
+++ b/src/INTEL/pair_eam_alloy_intel.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -43,24 +42,19 @@ PairEAMAlloyIntel::PairEAMAlloyIntel(LAMMPS *lmp) : PairEAMIntel(lmp)
 
 void PairEAMAlloyIntel::coeff(int narg, char **arg)
 {
-  int i,j;
+  int i, j;
 
   if (!allocated) allocate();
 
   if (narg != 3 + atom->ntypes)
-    error->all(FLERR,"Incorrect args for pair coefficients");
-
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM setfl file
 
   if (setfl) {
-    for (i = 0; i < setfl->nelements; i++) delete [] setfl->elements[i];
-    delete [] setfl->elements;
-    delete [] setfl->mass;
+    for (i = 0; i < setfl->nelements; i++) delete[] setfl->elements[i];
+    delete[] setfl->elements;
+    delete[] setfl->mass;
     memory->destroy(setfl->frho);
     memory->destroy(setfl->rhor);
     memory->destroy(setfl->z2r);
@@ -73,22 +67,23 @@ void PairEAMAlloyIntel::coeff(int narg, char **arg)
   // map[i] = which element the Ith atom type is, -1 if "NULL"
 
   for (i = 3; i < narg; i++) {
-    if (strcmp(arg[i],"NULL") == 0) {
-      map[i-2] = -1;
+    if (strcmp(arg[i], "NULL") == 0) {
+      map[i - 2] = -1;
       continue;
     }
     for (j = 0; j < setfl->nelements; j++)
-      if (strcmp(arg[i],setfl->elements[j]) == 0) break;
-    if (j < setfl->nelements) map[i-2] = j;
-    else error->all(FLERR,"No matching element in EAM potential file");
+      if (strcmp(arg[i], setfl->elements[j]) == 0) break;
+    if (j < setfl->nelements)
+      map[i - 2] = j;
+    else
+      error->all(FLERR, "No matching element in EAM potential file");
   }
 
   // clear setflag since coeff() called once with I,J = * *
 
   int n = atom->ntypes;
   for (i = 1; i <= n; i++)
-    for (j = i; j <= n; j++)
-      setflag[i][j] = 0;
+    for (j = i; j <= n; j++) setflag[i][j] = 0;
 
   // set setflag i,j for type pairs where both are mapped to elements
   // set mass of atom type if i = j
@@ -98,14 +93,14 @@ void PairEAMAlloyIntel::coeff(int narg, char **arg)
     for (j = i; j <= n; j++) {
       if (map[i] >= 0 && map[j] >= 0) {
         setflag[i][j] = 1;
-        if (i == j) atom->set_mass(FLERR,i,setfl->mass[map[i]]);
+        if (i == j) atom->set_mass(FLERR, i, setfl->mass[map[i]]);
         count++;
       }
       scale[i][j] = 1.0;
     }
   }
 
-  if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
+  if (count == 0) error->all(FLERR, "Incorrect args for pair coefficients");
 }
 
 /* ----------------------------------------------------------------------
@@ -123,8 +118,7 @@ void PairEAMAlloyIntel::read_file(char *filename)
     // transparently convert units for supported conversions
 
     int unit_convert = reader.get_unit_convert();
-    double conversion_factor = utils::get_conversion_factor(utils::ENERGY,
-                                                            unit_convert);
+    double conversion_factor = utils::get_conversion_factor(utils::ENERGY, unit_convert);
     try {
       reader.skip_line();
       reader.skip_line();
@@ -135,21 +129,21 @@ void PairEAMAlloyIntel::read_file(char *filename)
       file->nelements = values.next_int();
 
       if (values.count() != file->nelements + 1)
-        error->one(FLERR,"Incorrect element names in EAM potential file");
+        error->one(FLERR, "Incorrect element names in EAM potential file");
 
-      file->elements = new char*[file->nelements];
+      file->elements = new char *[file->nelements];
       for (int i = 0; i < file->nelements; i++)
         file->elements[i] = utils::strdup(values.next_string());
 
       values = reader.next_values(5);
       file->nrho = values.next_int();
       file->drho = values.next_double();
-      file->nr   = values.next_int();
-      file->dr   = values.next_double();
-      file->cut  = values.next_double();
+      file->nr = values.next_int();
+      file->dr = values.next_double();
+      file->cut = values.next_double();
 
       if ((file->nrho <= 0) || (file->nr <= 0) || (file->dr <= 0.0))
-        error->one(FLERR,"Invalid EAM potential file");
+        error->one(FLERR, "Invalid EAM potential file");
 
       memory->create(file->mass, file->nelements, "pair:mass");
       memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -158,14 +152,13 @@ void PairEAMAlloyIntel::read_file(char *filename)
 
       for (int i = 0; i < file->nelements; i++) {
         values = reader.next_values(2);
-        values.next_int(); // ignore
+        values.next_int();    // ignore
         file->mass[i] = values.next_double();
 
         reader.next_dvector(&file->frho[i][1], file->nrho);
         reader.next_dvector(&file->rhor[i][1], file->nr);
         if (unit_convert) {
-          for (int j = 1; j < file->nrho; ++j)
-            file->frho[i][j] *= conversion_factor;
+          for (int j = 1; j < file->nrho; ++j) file->frho[i][j] *= conversion_factor;
         }
       }
 
@@ -173,8 +166,7 @@ void PairEAMAlloyIntel::read_file(char *filename)
         for (int j = 0; j <= i; j++) {
           reader.next_dvector(&file->z2r[i][j][1], file->nr);
           if (unit_convert) {
-            for (int k = 1; k < file->nr; ++k)
-              file->z2r[i][j][k] *= conversion_factor;
+            for (int k = 1; k < file->nr; ++k) file->z2r[i][j][k] *= conversion_factor;
           }
         }
       }
@@ -194,7 +186,7 @@ void PairEAMAlloyIntel::read_file(char *filename)
 
   // allocate memory on other procs
   if (comm->me != 0) {
-    file->elements = new char*[file->nelements];
+    file->elements = new char *[file->nelements];
     for (int i = 0; i < file->nelements; i++) file->elements[i] = nullptr;
     memory->create(file->mass, file->nelements, "pair:mass");
     memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -220,9 +212,7 @@ void PairEAMAlloyIntel::read_file(char *filename)
 
   // broadcast file->z2r
   for (int i = 0; i < file->nelements; i++) {
-    for (int j = 0; j <= i; j++) {
-      MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world);
-    }
+    for (int j = 0; j <= i; j++) { MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world); }
   }
 }
 
@@ -232,7 +222,7 @@ void PairEAMAlloyIntel::read_file(char *filename)
 
 void PairEAMAlloyIntel::file2array()
 {
-  int i,j,m,n;
+  int i, j, m, n;
   int ntypes = atom->ntypes;
 
   // set function params directly from setfl file
@@ -241,7 +231,7 @@ void PairEAMAlloyIntel::file2array()
   nr = setfl->nr;
   drho = setfl->drho;
   dr = setfl->dr;
-  rhomax = (nrho-1) * drho;
+  rhomax = (nrho - 1) * drho;
 
   // ------------------------------------------------------------------
   // setup frho arrays
@@ -252,7 +242,7 @@ void PairEAMAlloyIntel::file2array()
 
   nfrho = setfl->nelements + 1;
   memory->destroy(frho);
-  memory->create(frho,nfrho,nrho+1,"pair:frho");
+  memory->create(frho, nfrho, nrho + 1, "pair:frho");
 
   // copy each element's frho to global frho
 
@@ -262,15 +252,17 @@ void PairEAMAlloyIntel::file2array()
   // add extra frho of zeroes for non-EAM types to point to (pair hybrid)
   // this is necessary b/c fp is still computed for non-EAM atoms
 
-  for (m = 1; m <= nrho; m++) frho[nfrho-1][m] = 0.0;
+  for (m = 1; m <= nrho; m++) frho[nfrho - 1][m] = 0.0;
 
   // type2frho[i] = which frho array (0 to nfrho-1) each atom type maps to
   // if atom type doesn't point to element (non-EAM atom in pair hybrid)
   // then map it to last frho array of zeroes
 
   for (i = 1; i <= ntypes; i++)
-    if (map[i] >= 0) type2frho[i] = map[i];
-    else type2frho[i] = nfrho-1;
+    if (map[i] >= 0)
+      type2frho[i] = map[i];
+    else
+      type2frho[i] = nfrho - 1;
 
   // ------------------------------------------------------------------
   // setup rhor arrays
@@ -281,7 +273,7 @@ void PairEAMAlloyIntel::file2array()
 
   nrhor = setfl->nelements;
   memory->destroy(rhor);
-  memory->create(rhor,nrhor,nr+1,"pair:rhor");
+  memory->create(rhor, nrhor, nr + 1, "pair:rhor");
 
   // copy each element's rhor to global rhor
 
@@ -293,8 +285,7 @@ void PairEAMAlloyIntel::file2array()
   // OK if map = -1 (non-EAM atom in pair hybrid) b/c type2rhor not used
 
   for (i = 1; i <= ntypes; i++)
-    for (j = 1; j <= ntypes; j++)
-      type2rhor[i][j] = map[i];
+    for (j = 1; j <= ntypes; j++) type2rhor[i][j] = map[i];
 
   // ------------------------------------------------------------------
   // setup z2r arrays
@@ -303,9 +294,9 @@ void PairEAMAlloyIntel::file2array()
   // allocate z2r arrays
   // nz2r = N*(N+1)/2 where N = # of setfl elements
 
-  nz2r = setfl->nelements * (setfl->nelements+1) / 2;
+  nz2r = setfl->nelements * (setfl->nelements + 1) / 2;
   memory->destroy(z2r);
-  memory->create(z2r,nz2r,nr+1,"pair:z2r");
+  memory->create(z2r, nz2r, nr + 1, "pair:z2r");
 
   // copy each element pair z2r to global z2r, only for I >= J
 
@@ -324,7 +315,7 @@ void PairEAMAlloyIntel::file2array()
   //   type2z2r is not used by non-opt
   //   but set type2z2r to 0 since accessed by opt
 
-  int irow,icol;
+  int irow, icol;
   for (i = 1; i <= ntypes; i++) {
     for (j = 1; j <= ntypes; j++) {
       irow = map[i];

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -919,19 +919,14 @@ void PairEAMAlloyKokkos<DeviceType>::coeff(int narg, char **arg)
   if (!allocated) allocate();
 
   if (narg != 3 + atom->ntypes)
-    error->all(FLERR,"Incorrect args for pair coefficients");
-
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM setfl file
 
   if (setfl) {
-    for (i = 0; i < setfl->nelements; i++) delete [] setfl->elements[i];
-    delete [] setfl->elements;
-    delete [] setfl->mass;
+    for (i = 0; i < setfl->nelements; i++) delete[] setfl->elements[i];
+    delete[] setfl->elements;
+    delete[] setfl->mass;
     memory->destroy(setfl->frho);
     memory->destroy(setfl->rhor);
     memory->destroy(setfl->z2r);

--- a/src/KOKKOS/pair_eam_fs_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_fs_kokkos.cpp
@@ -920,19 +920,14 @@ void PairEAMFSKokkos<DeviceType>::coeff(int narg, char **arg)
   if (!allocated) allocate();
 
   if (narg != 3 + atom->ntypes)
-    error->all(FLERR,"Incorrect args for pair coefficients");
-
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM Finnis-Sinclair file
 
   if (fs) {
-    for (i = 0; i < fs->nelements; i++) delete [] fs->elements[i];
-    delete [] fs->elements;
-    delete [] fs->mass;
+    for (i = 0; i < fs->nelements; i++) delete[] fs->elements[i];
+    delete[] fs->elements;
+    delete[] fs->mass;
     memory->destroy(fs->frho);
     memory->destroy(fs->rhor);
     memory->destroy(fs->z2r);

--- a/src/KSPACE/remap.cpp
+++ b/src/KSPACE/remap.cpp
@@ -637,7 +637,7 @@ void remap_3d_destroy_plan(struct remap_plan_3d *plan)
 {
   // free MPI communicator
 
-  if (!((plan->usecollective) && (plan->commringlen == 0)))
+  if (!(plan->usecollective) || (plan->commringlen != 0))
     MPI_Comm_free(&plan->comm);
 
   if (plan->usecollective) {

--- a/src/LEPTON/angle_lepton.cpp
+++ b/src/LEPTON/angle_lepton.cpp
@@ -320,7 +320,7 @@ void AngleLepton::read_restart(FILE *fp)
       utils::sfread(FLERR, buf, sizeof(char), len, fp, nullptr, error);
     }
     MPI_Bcast(buf, maxlen, MPI_CHAR, 0, world);
-    expressions.push_back(buf);
+    expressions.emplace_back(buf);
   }
 
   delete[] buf;

--- a/src/LEPTON/bond_lepton.cpp
+++ b/src/LEPTON/bond_lepton.cpp
@@ -275,7 +275,7 @@ void BondLepton::read_restart(FILE *fp)
       utils::sfread(FLERR, buf, sizeof(char), len, fp, nullptr, error);
     }
     MPI_Bcast(buf, maxlen, MPI_CHAR, 0, world);
-    expressions.push_back(buf);
+    expressions.emplace_back(buf);
   }
 
   delete[] buf;

--- a/src/LEPTON/dihedral_lepton.cpp
+++ b/src/LEPTON/dihedral_lepton.cpp
@@ -441,7 +441,7 @@ void DihedralLepton::read_restart(FILE *fp)
       utils::sfread(FLERR, buf, sizeof(char), len, fp, nullptr, error);
     }
     MPI_Bcast(buf, maxlen, MPI_CHAR, 0, world);
-    expressions.push_back(buf);
+    expressions.emplace_back(buf);
   }
 
   delete[] buf;

--- a/src/LEPTON/pair_lepton.cpp
+++ b/src/LEPTON/pair_lepton.cpp
@@ -356,7 +356,7 @@ void PairLepton::read_restart(FILE *fp)
       utils::sfread(FLERR, buf, sizeof(char), len, fp, nullptr, error);
     }
     MPI_Bcast(buf, maxlen, MPI_CHAR, 0, world);
-    expressions.push_back(buf);
+    expressions.emplace_back(buf);
   }
 
   delete[] buf;

--- a/src/LEPTON/pair_lepton_coul.cpp
+++ b/src/LEPTON/pair_lepton_coul.cpp
@@ -86,7 +86,7 @@ template <int EVFLAG, int EFLAG, int NEWTON_PAIR> void PairLeptonCoul::eval()
       pairforce.emplace_back(parsed.differentiate("r").createCompiledExpression());
       if (EFLAG) pairpot.emplace_back(parsed.createCompiledExpression());
       pairforce.back().getVariableReference("r");
-      have_q.emplace_back(std::make_pair(true, true));
+      have_q.emplace_back(true, true);
 
       // check if there are references to charges
       try {

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -1775,7 +1775,7 @@ double PairAIREBO::bondorder(int i, int j, double rij[3], double rijmag, double 
             atoml = REBO_neighs_j[l];
             atom4 = atoml;
             ltype = map[type[atoml]];
-            if (!(atoml == atomi || atoml == atomk)) {
+            if (atoml != atomi && atoml != atomk) {
               r34[0] = x[atom3][0]-x[atom4][0];
               r34[1] = x[atom3][1]-x[atom4][1];
               r34[2] = x[atom3][2]-x[atom4][2];
@@ -2284,7 +2284,7 @@ double PairAIREBO::bondorderLJ(int i, int j, double /* rij_mod */[3], double rij
             atoml = REBO_neighs_j[l];
             atom4 = atoml;
             ltype = map[type[atoml]];
-            if (!(atoml == atomi || atoml == atomk)) {
+            if (atoml != atomi && atoml != atomk) {
               r34[0] = x[atom3][0]-x[atom4][0];
               r34[1] = x[atom3][1]-x[atom4][1];
               r34[2] = x[atom3][2]-x[atom4][2];
@@ -2732,7 +2732,7 @@ double PairAIREBO::bondorderLJ(int i, int j, double /* rij_mod */[3], double rij
               atoml = REBO_neighs_j[l];
               atom4 = atoml;
               ltype = map[type[atoml]];
-              if (!(atoml == atomi || atoml == atomk)) {
+              if (atoml != atomi && atoml != atomk) {
                 r34[0] = x[atom3][0]-x[atom4][0];
                 r34[1] = x[atom3][1]-x[atom4][1];
                 r34[2] = x[atom3][2]-x[atom4][2];

--- a/src/MANYBODY/pair_airebo_morse.cpp
+++ b/src/MANYBODY/pair_airebo_morse.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -18,7 +17,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairAIREBOMorse::PairAIREBOMorse(LAMMPS *lmp) : PairAIREBO(lmp) {
+PairAIREBOMorse::PairAIREBOMorse(LAMMPS *lmp) : PairAIREBO(lmp)
+{
   variant = AIREBO_M;
 }
 
@@ -28,7 +28,7 @@ PairAIREBOMorse::PairAIREBOMorse(LAMMPS *lmp) : PairAIREBO(lmp) {
 
 void PairAIREBOMorse::settings(int narg, char **arg)
 {
-  PairAIREBO::settings(narg,arg);
+  PairAIREBO::settings(narg, arg);
 
   morseflag = 1;
 }

--- a/src/MANYBODY/pair_eam_alloy.cpp
+++ b/src/MANYBODY/pair_eam_alloy.cpp
@@ -50,11 +50,6 @@ void PairEAMAlloy::coeff(int narg, char **arg)
   if (narg != 3 + atom->ntypes)
     error->all(FLERR,"Incorrect args for pair coefficients");
 
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
-
   // read EAM setfl file
 
   if (setfl) {

--- a/src/MANYBODY/pair_eam_alloy.cpp
+++ b/src/MANYBODY/pair_eam_alloy.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -43,18 +42,18 @@ PairEAMAlloy::PairEAMAlloy(LAMMPS *lmp) : PairEAM(lmp)
 
 void PairEAMAlloy::coeff(int narg, char **arg)
 {
-  int i,j;
+  int i, j;
 
   if (!allocated) allocate();
 
   if (narg != 3 + atom->ntypes)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM setfl file
 
   if (setfl) {
-    for (i = 0; i < setfl->nelements; i++) delete [] setfl->elements[i];
-    delete [] setfl->elements;
+    for (i = 0; i < setfl->nelements; i++) delete[] setfl->elements[i];
+    delete[] setfl->elements;
     memory->destroy(setfl->mass);
     memory->destroy(setfl->frho);
     memory->destroy(setfl->rhor);
@@ -68,22 +67,23 @@ void PairEAMAlloy::coeff(int narg, char **arg)
   // map[i] = which element the Ith atom type is, -1 if "NULL"
 
   for (i = 3; i < narg; i++) {
-    if (strcmp(arg[i],"NULL") == 0) {
-      map[i-2] = -1;
+    if (strcmp(arg[i], "NULL") == 0) {
+      map[i - 2] = -1;
       continue;
     }
     for (j = 0; j < setfl->nelements; j++)
-      if (strcmp(arg[i],setfl->elements[j]) == 0) break;
-    if (j < setfl->nelements) map[i-2] = j;
-    else error->all(FLERR,"No matching element in EAM potential file");
+      if (strcmp(arg[i], setfl->elements[j]) == 0) break;
+    if (j < setfl->nelements)
+      map[i - 2] = j;
+    else
+      error->all(FLERR, "No matching element in EAM potential file");
   }
 
   // clear setflag since coeff() called once with I,J = * *
 
   int n = atom->ntypes;
   for (i = 1; i <= n; i++)
-    for (j = i; j <= n; j++)
-      setflag[i][j] = 0;
+    for (j = i; j <= n; j++) setflag[i][j] = 0;
 
   // set setflag i,j for type pairs where both are mapped to elements
   // set mass of atom type if i = j
@@ -93,14 +93,14 @@ void PairEAMAlloy::coeff(int narg, char **arg)
     for (j = i; j <= n; j++) {
       if (map[i] >= 0 && map[j] >= 0) {
         setflag[i][j] = 1;
-        if (i == j) atom->set_mass(FLERR,i,setfl->mass[map[i]]);
+        if (i == j) atom->set_mass(FLERR, i, setfl->mass[map[i]]);
         count++;
       }
       scale[i][j] = 1.0;
     }
   }
 
-  if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
+  if (count == 0) error->all(FLERR, "Incorrect args for pair coefficients");
 }
 
 /* ----------------------------------------------------------------------
@@ -118,8 +118,7 @@ void PairEAMAlloy::read_file(char *filename)
     // transparently convert units for supported conversions
 
     int unit_convert = reader.get_unit_convert();
-    double conversion_factor = utils::get_conversion_factor(utils::ENERGY,
-                                                            unit_convert);
+    double conversion_factor = utils::get_conversion_factor(utils::ENERGY, unit_convert);
     try {
       reader.skip_line();
       reader.skip_line();
@@ -129,22 +128,22 @@ void PairEAMAlloy::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if ((int)values.count() != file->nelements + 1)
-        error->one(FLERR,"Incorrect element names in EAM potential file");
+      if ((int) values.count() != file->nelements + 1)
+        error->one(FLERR, "Incorrect element names in EAM potential file");
 
-      file->elements = new char*[file->nelements];
+      file->elements = new char *[file->nelements];
       for (int i = 0; i < file->nelements; i++)
         file->elements[i] = utils::strdup(values.next_string());
 
       values = reader.next_values(5);
       file->nrho = values.next_int();
       file->drho = values.next_double();
-      file->nr   = values.next_int();
-      file->dr   = values.next_double();
-      file->cut  = values.next_double();
+      file->nr = values.next_int();
+      file->dr = values.next_double();
+      file->cut = values.next_double();
 
       if ((file->nrho <= 0) || (file->nr <= 0) || (file->dr <= 0.0))
-        error->one(FLERR,"Invalid EAM potential file");
+        error->one(FLERR, "Invalid EAM potential file");
 
       memory->create(file->mass, file->nelements, "pair:mass");
       memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -153,14 +152,13 @@ void PairEAMAlloy::read_file(char *filename)
 
       for (int i = 0; i < file->nelements; i++) {
         values = reader.next_values(2);
-        values.next_int(); // ignore
+        values.next_int();    // ignore
         file->mass[i] = values.next_double();
 
         reader.next_dvector(&file->frho[i][1], file->nrho);
         reader.next_dvector(&file->rhor[i][1], file->nr);
         if (unit_convert) {
-          for (int j = 1; j < file->nrho; ++j)
-            file->frho[i][j] *= conversion_factor;
+          for (int j = 1; j < file->nrho; ++j) file->frho[i][j] *= conversion_factor;
         }
       }
 
@@ -168,8 +166,7 @@ void PairEAMAlloy::read_file(char *filename)
         for (int j = 0; j <= i; j++) {
           reader.next_dvector(&file->z2r[i][j][1], file->nr);
           if (unit_convert) {
-            for (int k = 1; k < file->nr; ++k)
-              file->z2r[i][j][k] *= conversion_factor;
+            for (int k = 1; k < file->nr; ++k) file->z2r[i][j][k] *= conversion_factor;
           }
         }
       }
@@ -189,7 +186,7 @@ void PairEAMAlloy::read_file(char *filename)
 
   // allocate memory on other procs
   if (comm->me != 0) {
-    file->elements = new char*[file->nelements];
+    file->elements = new char *[file->nelements];
     for (int i = 0; i < file->nelements; i++) file->elements[i] = nullptr;
     memory->create(file->mass, file->nelements, "pair:mass");
     memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -215,9 +212,7 @@ void PairEAMAlloy::read_file(char *filename)
 
   // broadcast file->z2r
   for (int i = 0; i < file->nelements; i++) {
-    for (int j = 0; j <= i; j++) {
-      MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world);
-    }
+    for (int j = 0; j <= i; j++) { MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world); }
   }
 }
 
@@ -227,7 +222,7 @@ void PairEAMAlloy::read_file(char *filename)
 
 void PairEAMAlloy::file2array()
 {
-  int i,j,m,n;
+  int i, j, m, n;
   int ntypes = atom->ntypes;
 
   // set function params directly from setfl file
@@ -236,7 +231,7 @@ void PairEAMAlloy::file2array()
   nr = setfl->nr;
   drho = setfl->drho;
   dr = setfl->dr;
-  rhomax = (nrho-1) * drho;
+  rhomax = (nrho - 1) * drho;
 
   // ------------------------------------------------------------------
   // setup frho arrays
@@ -247,7 +242,7 @@ void PairEAMAlloy::file2array()
 
   nfrho = setfl->nelements + 1;
   memory->destroy(frho);
-  memory->create(frho,nfrho,nrho+1,"pair:frho");
+  memory->create(frho, nfrho, nrho + 1, "pair:frho");
 
   // copy each element's frho to global frho
 
@@ -257,15 +252,17 @@ void PairEAMAlloy::file2array()
   // add extra frho of zeroes for non-EAM types to point to (pair hybrid)
   // this is necessary b/c fp is still computed for non-EAM atoms
 
-  for (m = 1; m <= nrho; m++) frho[nfrho-1][m] = 0.0;
+  for (m = 1; m <= nrho; m++) frho[nfrho - 1][m] = 0.0;
 
   // type2frho[i] = which frho array (0 to nfrho-1) each atom type maps to
   // if atom type doesn't point to element (non-EAM atom in pair hybrid)
   // then map it to last frho array of zeroes
 
   for (i = 1; i <= ntypes; i++)
-    if (map[i] >= 0) type2frho[i] = map[i];
-    else type2frho[i] = nfrho-1;
+    if (map[i] >= 0)
+      type2frho[i] = map[i];
+    else
+      type2frho[i] = nfrho - 1;
 
   // ------------------------------------------------------------------
   // setup rhor arrays
@@ -276,7 +273,7 @@ void PairEAMAlloy::file2array()
 
   nrhor = setfl->nelements;
   memory->destroy(rhor);
-  memory->create(rhor,nrhor,nr+1,"pair:rhor");
+  memory->create(rhor, nrhor, nr + 1, "pair:rhor");
 
   // copy each element's rhor to global rhor
 
@@ -288,8 +285,7 @@ void PairEAMAlloy::file2array()
   // OK if map = -1 (non-EAM atom in pair hybrid) b/c type2rhor not used
 
   for (i = 1; i <= ntypes; i++)
-    for (j = 1; j <= ntypes; j++)
-      type2rhor[i][j] = map[i];
+    for (j = 1; j <= ntypes; j++) type2rhor[i][j] = map[i];
 
   // ------------------------------------------------------------------
   // setup z2r arrays
@@ -298,9 +294,9 @@ void PairEAMAlloy::file2array()
   // allocate z2r arrays
   // nz2r = N*(N+1)/2 where N = # of setfl elements
 
-  nz2r = setfl->nelements * (setfl->nelements+1) / 2;
+  nz2r = setfl->nelements * (setfl->nelements + 1) / 2;
   memory->destroy(z2r);
-  memory->create(z2r,nz2r,nr+1,"pair:z2r");
+  memory->create(z2r, nz2r, nr + 1, "pair:z2r");
 
   // copy each element pair z2r to global z2r, only for I >= J
 
@@ -319,7 +315,7 @@ void PairEAMAlloy::file2array()
   //   type2z2r is not used by non-opt
   //   but set type2z2r to 0 since accessed by opt
 
-  int irow,icol;
+  int irow, icol;
   for (i = 1; i <= ntypes; i++) {
     for (j = 1; j <= ntypes; j++) {
       irow = map[i];

--- a/src/MANYBODY/pair_eam_fs.cpp
+++ b/src/MANYBODY/pair_eam_fs.cpp
@@ -51,11 +51,6 @@ void PairEAMFS::coeff(int narg, char **arg)
   if (narg != 3 + atom->ntypes)
     error->all(FLERR,"Incorrect args for pair coefficients");
 
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
-
   // read EAM Finnis-Sinclair file
 
   if (fs) {

--- a/src/MANYBODY/pair_eam_fs.cpp
+++ b/src/MANYBODY/pair_eam_fs.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -44,18 +43,18 @@ PairEAMFS::PairEAMFS(LAMMPS *lmp) : PairEAM(lmp)
 
 void PairEAMFS::coeff(int narg, char **arg)
 {
-  int i,j;
+  int i, j;
 
   if (!allocated) allocate();
 
   if (narg != 3 + atom->ntypes)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM Finnis-Sinclair file
 
   if (fs) {
-    for (i = 0; i < fs->nelements; i++) delete [] fs->elements[i];
-    delete [] fs->elements;
+    for (i = 0; i < fs->nelements; i++) delete[] fs->elements[i];
+    delete[] fs->elements;
     memory->destroy(fs->mass);
     memory->destroy(fs->frho);
     memory->destroy(fs->rhor);
@@ -69,22 +68,23 @@ void PairEAMFS::coeff(int narg, char **arg)
   // map[i] = which element the Ith atom type is, -1 if "NULL"
 
   for (i = 3; i < narg; i++) {
-    if (strcmp(arg[i],"NULL") == 0) {
-      map[i-2] = -1;
+    if (strcmp(arg[i], "NULL") == 0) {
+      map[i - 2] = -1;
       continue;
     }
     for (j = 0; j < fs->nelements; j++)
-      if (strcmp(arg[i],fs->elements[j]) == 0) break;
-    if (j < fs->nelements) map[i-2] = j;
-    else error->all(FLERR,"No matching element in EAM potential file");
+      if (strcmp(arg[i], fs->elements[j]) == 0) break;
+    if (j < fs->nelements)
+      map[i - 2] = j;
+    else
+      error->all(FLERR, "No matching element in EAM potential file");
   }
 
   // clear setflag since coeff() called once with I,J = * *
 
   int n = atom->ntypes;
   for (i = 1; i <= n; i++)
-    for (j = i; j <= n; j++)
-      setflag[i][j] = 0;
+    for (j = i; j <= n; j++) setflag[i][j] = 0;
 
   // set setflag i,j for type pairs where both are mapped to elements
   // set mass of atom type if i = j
@@ -94,14 +94,14 @@ void PairEAMFS::coeff(int narg, char **arg)
     for (j = i; j <= n; j++) {
       if (map[i] >= 0 && map[j] >= 0) {
         setflag[i][j] = 1;
-        if (i == j) atom->set_mass(FLERR,i,fs->mass[map[i]]);
+        if (i == j) atom->set_mass(FLERR, i, fs->mass[map[i]]);
         count++;
       }
       scale[i][j] = 1.0;
     }
   }
 
-  if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
+  if (count == 0) error->all(FLERR, "Incorrect args for pair coefficients");
 }
 
 /* ----------------------------------------------------------------------
@@ -114,14 +114,12 @@ void PairEAMFS::read_file(char *filename)
 
   // read potential file
   if (comm->me == 0) {
-    PotentialFileReader reader(lmp, filename, he_flag ? "eam/he" : "eam/fs",
-                               unit_convert_flag);
+    PotentialFileReader reader(lmp, filename, he_flag ? "eam/he" : "eam/fs", unit_convert_flag);
 
     // transparently convert units for supported conversions
 
     int unit_convert = reader.get_unit_convert();
-    double conversion_factor = utils::get_conversion_factor(utils::ENERGY,
-                                                            unit_convert);
+    double conversion_factor = utils::get_conversion_factor(utils::ENERGY, unit_convert);
     try {
       reader.skip_line();
       reader.skip_line();
@@ -131,24 +129,26 @@ void PairEAMFS::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if ((int)values.count() != file->nelements + 1)
-        error->one(FLERR,"Incorrect element names in EAM potential file");
+      if ((int) values.count() != file->nelements + 1)
+        error->one(FLERR, "Incorrect element names in EAM potential file");
 
-      file->elements = new char*[file->nelements];
+      file->elements = new char *[file->nelements];
       for (int i = 0; i < file->nelements; i++)
         file->elements[i] = utils::strdup(values.next_string());
 
-      if (he_flag) values = reader.next_values(6);
-      else values = reader.next_values(5);
+      if (he_flag)
+        values = reader.next_values(6);
+      else
+        values = reader.next_values(5);
       file->nrho = values.next_int();
       file->drho = values.next_double();
-      file->nr   = values.next_int();
-      file->dr   = values.next_double();
-      file->cut  = values.next_double();
+      file->nr = values.next_int();
+      file->dr = values.next_double();
+      file->cut = values.next_double();
       if (he_flag) rhomax = values.next_double();
 
       if ((file->nrho <= 0) || (file->nr <= 0) || (file->dr <= 0.0))
-        error->one(FLERR,"Invalid EAM potential file");
+        error->one(FLERR, "Invalid EAM potential file");
 
       memory->create(file->mass, file->nelements, "pair:mass");
       memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -157,13 +157,12 @@ void PairEAMFS::read_file(char *filename)
 
       for (int i = 0; i < file->nelements; i++) {
         values = reader.next_values(2);
-        values.next_int(); // ignore
+        values.next_int();    // ignore
         file->mass[i] = values.next_double();
 
         reader.next_dvector(&file->frho[i][1], file->nrho);
         if (unit_convert) {
-          for (int j = 1; j <= file->nrho; ++j)
-            file->frho[i][j] *= conversion_factor;
+          for (int j = 1; j <= file->nrho; ++j) file->frho[i][j] *= conversion_factor;
         }
 
         for (int j = 0; j < file->nelements; j++) {
@@ -175,8 +174,7 @@ void PairEAMFS::read_file(char *filename)
         for (int j = 0; j <= i; j++) {
           reader.next_dvector(&file->z2r[i][j][1], file->nr);
           if (unit_convert) {
-            for (int k = 1; k <= file->nr; ++k)
-              file->z2r[i][j][k] *= conversion_factor;
+            for (int k = 1; k <= file->nr; ++k) file->z2r[i][j][k] *= conversion_factor;
           }
         }
       }
@@ -197,7 +195,7 @@ void PairEAMFS::read_file(char *filename)
 
   // allocate memory on other procs
   if (comm->me != 0) {
-    file->elements = new char*[file->nelements];
+    file->elements = new char *[file->nelements];
     for (int i = 0; i < file->nelements; i++) file->elements[i] = nullptr;
     memory->create(file->mass, file->nelements, "pair:mass");
     memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -226,9 +224,7 @@ void PairEAMFS::read_file(char *filename)
 
   // broadcast file->z2r
   for (int i = 0; i < file->nelements; i++) {
-    for (int j = 0; j <= i; j++) {
-      MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world);
-    }
+    for (int j = 0; j <= i; j++) { MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world); }
   }
 }
 
@@ -238,7 +234,7 @@ void PairEAMFS::read_file(char *filename)
 
 void PairEAMFS::file2array()
 {
-  int i,j,m,n;
+  int i, j, m, n;
   int ntypes = atom->ntypes;
 
   // set function params directly from fs file
@@ -247,8 +243,10 @@ void PairEAMFS::file2array()
   nr = fs->nr;
   drho = fs->drho;
   dr = fs->dr;
-  if (he_flag) rhomin = rhomax - (nrho-1) * drho;
-  else rhomax = (nrho-1) * drho;
+  if (he_flag)
+    rhomin = rhomax - (nrho - 1) * drho;
+  else
+    rhomax = (nrho - 1) * drho;
 
   // ------------------------------------------------------------------
   // setup frho arrays
@@ -259,7 +257,7 @@ void PairEAMFS::file2array()
 
   nfrho = fs->nelements + 1;
   memory->destroy(frho);
-  memory->create(frho,nfrho,nrho+1,"pair:frho");
+  memory->create(frho, nfrho, nrho + 1, "pair:frho");
 
   // copy each element's frho to global frho
 
@@ -269,15 +267,17 @@ void PairEAMFS::file2array()
   // add extra frho of zeroes for non-EAM types to point to (pair hybrid)
   // this is necessary b/c fp is still computed for non-EAM atoms
 
-  for (m = 1; m <= nrho; m++) frho[nfrho-1][m] = 0.0;
+  for (m = 1; m <= nrho; m++) frho[nfrho - 1][m] = 0.0;
 
   // type2frho[i] = which frho array (0 to nfrho-1) each atom type maps to
   // if atom type doesn't point to element (non-EAM atom in pair hybrid)
   // then map it to last frho array of zeroes
 
   for (i = 1; i <= ntypes; i++)
-    if (map[i] >= 0) type2frho[i] = map[i];
-    else type2frho[i] = nfrho-1;
+    if (map[i] >= 0)
+      type2frho[i] = map[i];
+    else
+      type2frho[i] = nfrho - 1;
 
   // ------------------------------------------------------------------
   // setup rhor arrays
@@ -288,7 +288,7 @@ void PairEAMFS::file2array()
 
   nrhor = fs->nelements * fs->nelements;
   memory->destroy(rhor);
-  memory->create(rhor,nrhor,nr+1,"pair:rhor");
+  memory->create(rhor, nrhor, nr + 1, "pair:rhor");
 
   // copy each element pair rhor to global rhor
 
@@ -304,8 +304,7 @@ void PairEAMFS::file2array()
   // OK if map = -1 (non-EAM atom in pair hybrid) b/c type2rhor not used
 
   for (i = 1; i <= ntypes; i++)
-    for (j = 1; j <= ntypes; j++)
-      type2rhor[i][j] = map[i] * fs->nelements + map[j];
+    for (j = 1; j <= ntypes; j++) type2rhor[i][j] = map[i] * fs->nelements + map[j];
 
   // ------------------------------------------------------------------
   // setup z2r arrays
@@ -314,9 +313,9 @@ void PairEAMFS::file2array()
   // allocate z2r arrays
   // nz2r = N*(N+1)/2 where N = # of fs elements
 
-  nz2r = fs->nelements * (fs->nelements+1) / 2;
+  nz2r = fs->nelements * (fs->nelements + 1) / 2;
   memory->destroy(z2r);
-  memory->create(z2r,nz2r,nr+1,"pair:z2r");
+  memory->create(z2r, nz2r, nr + 1, "pair:z2r");
 
   // copy each element pair z2r to global z2r, only for I >= J
 
@@ -335,7 +334,7 @@ void PairEAMFS::file2array()
   //   type2z2r is not used by non-opt
   //   but set type2z2r to 0 since accessed by opt
 
-  int irow,icol;
+  int irow, icol;
   for (i = 1; i <= ntypes; i++) {
     for (j = 1; j <= ntypes; j++) {
       irow = map[i];

--- a/src/MANYBODY/pair_eam_he.cpp
+++ b/src/MANYBODY/pair_eam_he.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -38,14 +37,14 @@ PairEAMHE::PairEAMHE(LAMMPS *lmp) : PairEAM(lmp), PairEAMFS(lmp)
 
 void PairEAMHE::compute(int eflag, int vflag)
 {
-  int i,j,ii,jj,m,inum,jnum,itype,jtype;
-  double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
-  double rsq,r,p,rhoip,rhojp,z2,z2p,recip,phip,psip,phi;
+  int i, j, ii, jj, m, inum, jnum, itype, jtype;
+  double xtmp, ytmp, ztmp, delx, dely, delz, evdwl, fpair;
+  double rsq, r, p, rhoip, rhojp, z2, z2p, recip, phip, psip, phi;
   double *coeff;
-  int *ilist,*jlist,*numneigh,**firstneigh;
+  int *ilist, *jlist, *numneigh, **firstneigh;
 
   evdwl = 0.0;
-  ev_init(eflag,vflag);
+  ev_init(eflag, vflag);
 
   // grow energy and fp arrays if necessary
   // need to be atom->nmax in length
@@ -55,9 +54,9 @@ void PairEAMHE::compute(int eflag, int vflag)
     memory->destroy(fp);
     memory->destroy(numforce);
     nmax = atom->nmax;
-    memory->create(rho,nmax,"pair:rho");
-    memory->create(fp,nmax,"pair:fp");
-    memory->create(numforce,nmax,"pair:numforce");
+    memory->create(rho, nmax, "pair:rho");
+    memory->create(fp, nmax, "pair:fp");
+    memory->create(numforce, nmax, "pair:numforce");
   }
 
   double **x = atom->x;
@@ -76,7 +75,8 @@ void PairEAMHE::compute(int eflag, int vflag)
 
   if (newton_pair) {
     for (i = 0; i < nall; i++) rho[i] = 0.0;
-  } else for (i = 0; i < nlocal; i++) rho[i] = 0.0;
+  } else
+    for (i = 0; i < nlocal; i++) rho[i] = 0.0;
 
   // rho = density at each atom
   // loop over neighbors of my atoms
@@ -97,20 +97,20 @@ void PairEAMHE::compute(int eflag, int vflag)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      rsq = delx*delx + dely*dely + delz*delz;
+      rsq = delx * delx + dely * dely + delz * delz;
 
       if (rsq < cutforcesq) {
         jtype = type[j];
-        p = sqrt(rsq)*rdr + 1.0;
-        m = static_cast<int> (p);
-        m = MIN(m,nr-1);
+        p = sqrt(rsq) * rdr + 1.0;
+        m = static_cast<int>(p);
+        m = MIN(m, nr - 1);
         p -= m;
-        p = MIN(p,1.0);
+        p = MIN(p, 1.0);
         coeff = rhor_spline[type2rhor[jtype][itype]][m];
-        rho[i] += ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
+        rho[i] += ((coeff[3] * p + coeff[4]) * p + coeff[5]) * p + coeff[6];
         if (newton_pair || j < nlocal) {
           coeff = rhor_spline[type2rhor[itype][jtype]][m];
-          rho[j] += ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
+          rho[j] += ((coeff[3] * p + coeff[4]) * p + coeff[5]) * p + coeff[6];
         }
       }
     }
@@ -127,12 +127,12 @@ void PairEAMHE::compute(int eflag, int vflag)
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];
-    p = (rho[i]-rhomin)*rdrho + 1.0;
-    m = static_cast<int> (p);
+    p = (rho[i] - rhomin) * rdrho + 1.0;
+    m = static_cast<int>(p);
     if (m < 2) {
       m = 2;
-    } else if (m > nrho-1) {
-      m = nrho-1;
+    } else if (m > nrho - 1) {
+      m = nrho - 1;
     }
     p -= m;
     if (p < -1.0) {
@@ -141,13 +141,13 @@ void PairEAMHE::compute(int eflag, int vflag)
       p = 1.0;
     }
     coeff = frho_spline[type2frho[type[i]]][m];
-    fp[i] = (coeff[0]*p + coeff[1])*p + coeff[2];
+    fp[i] = (coeff[0] * p + coeff[1]) * p + coeff[2];
     if (eflag) {
-      phi = ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
+      phi = ((coeff[3] * p + coeff[4]) * p + coeff[5]) * p + coeff[6];
       if (rho[i] < rhomin) {
-        phi += fp[i] * (rho[i]-rhomin);
+        phi += fp[i] * (rho[i] - rhomin);
       } else if (rho[i] > rhomax) {
-        phi += fp[i] * (rho[i]-rhomax);
+        phi += fp[i] * (rho[i] - rhomax);
       }
       phi *= scale[type[i]][type[i]];
       if (eflag_global) eng_vdwl += phi;
@@ -181,17 +181,17 @@ void PairEAMHE::compute(int eflag, int vflag)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      rsq = delx*delx + dely*dely + delz*delz;
+      rsq = delx * delx + dely * dely + delz * delz;
 
       if (rsq < cutforcesq) {
         ++numforce[i];
         jtype = type[j];
         r = sqrt(rsq);
-        p = r*rdr + 1.0;
-        m = static_cast<int> (p);
-        m = MIN(m,nr-1);
+        p = r * rdr + 1.0;
+        m = static_cast<int>(p);
+        m = MIN(m, nr - 1);
         p -= m;
-        p = MIN(p,1.0);
+        p = MIN(p, 1.0);
 
         // rhoip = derivative of (density at atom j due to atom i)
         // rhojp = derivative of (density at atom i due to atom j)
@@ -205,35 +205,33 @@ void PairEAMHE::compute(int eflag, int vflag)
         // scale factor can be applied by thermodynamic integration
 
         coeff = rhor_spline[type2rhor[itype][jtype]][m];
-        rhoip = (coeff[0]*p + coeff[1])*p + coeff[2];
+        rhoip = (coeff[0] * p + coeff[1]) * p + coeff[2];
         coeff = rhor_spline[type2rhor[jtype][itype]][m];
-        rhojp = (coeff[0]*p + coeff[1])*p + coeff[2];
+        rhojp = (coeff[0] * p + coeff[1]) * p + coeff[2];
         coeff = z2r_spline[type2z2r[itype][jtype]][m];
-        z2p = (coeff[0]*p + coeff[1])*p + coeff[2];
-        z2 = ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
+        z2p = (coeff[0] * p + coeff[1]) * p + coeff[2];
+        z2 = ((coeff[3] * p + coeff[4]) * p + coeff[5]) * p + coeff[6];
 
-        recip = 1.0/r;
-        phi = z2*recip;
-        phip = z2p*recip - phi*recip;
-        psip = fp[i]*rhojp + fp[j]*rhoip + phip;
-        fpair = -scale[itype][jtype]*psip*recip;
+        recip = 1.0 / r;
+        phi = z2 * recip;
+        phip = z2p * recip - phi * recip;
+        psip = fp[i] * rhojp + fp[j] * rhoip + phip;
+        fpair = -scale[itype][jtype] * psip * recip;
 
-        f[i][0] += delx*fpair;
-        f[i][1] += dely*fpair;
-        f[i][2] += delz*fpair;
+        f[i][0] += delx * fpair;
+        f[i][1] += dely * fpair;
+        f[i][2] += delz * fpair;
         if (newton_pair || j < nlocal) {
-          f[j][0] -= delx*fpair;
-          f[j][1] -= dely*fpair;
-          f[j][2] -= delz*fpair;
+          f[j][0] -= delx * fpair;
+          f[j][1] -= dely * fpair;
+          f[j][2] -= delz * fpair;
         }
 
-        if (eflag) evdwl = scale[itype][jtype]*phi;
-        if (evflag) ev_tally(i,j,nlocal,newton_pair,
-                             evdwl,0.0,fpair,delx,dely,delz);
+        if (eflag) evdwl = scale[itype][jtype] * phi;
+        if (evflag) ev_tally(i, j, nlocal, newton_pair, evdwl, 0.0, fpair, delx, dely, delz);
       }
     }
   }
 
   if (vflag_fdotr) virial_fdotr_compute();
 }
-

--- a/src/MANYBODY/pair_rebo.cpp
+++ b/src/MANYBODY/pair_rebo.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -19,7 +18,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairREBO::PairREBO(LAMMPS *lmp) : PairAIREBO(lmp) {
+PairREBO::PairREBO(LAMMPS *lmp) : PairAIREBO(lmp)
+{
   variant = REBO_2;
 }
 
@@ -29,7 +29,7 @@ PairREBO::PairREBO(LAMMPS *lmp) : PairAIREBO(lmp) {
 
 void PairREBO::settings(int narg, char ** /* arg */)
 {
-  if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+  if (narg != 0) error->all(FLERR, "Illegal pair_style command");
 
   cutlj = 0.0;
   ljflag = torflag = 0;
@@ -39,29 +39,30 @@ void PairREBO::settings(int narg, char ** /* arg */)
    initialize spline knot values
 ------------------------------------------------------------------------- */
 
-void PairREBO::spline_init() {
+void PairREBO::spline_init()
+{
   PairAIREBO::spline_init();
 
   PCCf[0][2] = 0.007860700254745;
   PCCf[0][3] = 0.016125364564267;
   PCCf[1][1] = 0.003026697473481;
   PCCf[1][2] = 0.006326248241119;
-  PCCf[2][0] = 0.;
+  PCCf[2][0] = 0.0;
   PCCf[2][1] = 0.003179530830731;
 
   for (int nH = 0; nH < 4; nH++) {
     for (int nC = 0; nC < 4; nC++) {
       double y[4] = {0}, y1[4] = {0}, y2[4] = {0};
       y[0] = PCCf[nC][nH];
-      y[1] = PCCf[nC][nH+1];
-      y[2] = PCCf[nC+1][nH];
-      y[3] = PCCf[nC+1][nH+1];
-      Spbicubic_patch_coeffs(nC, nC+1, nH, nH+1, y, y1, y2, &pCC[nC][nH][0]);
+      y[1] = PCCf[nC][nH + 1];
+      y[2] = PCCf[nC + 1][nH];
+      y[3] = PCCf[nC + 1][nH + 1];
+      Spbicubic_patch_coeffs(nC, nC + 1, nH, nH + 1, y, y1, y2, &pCC[nC][nH][0]);
       y[0] = PCHf[nC][nH];
-      y[1] = PCHf[nC][nH+1];
-      y[2] = PCHf[nC+1][nH];
-      y[3] = PCHf[nC+1][nH+1];
-      Spbicubic_patch_coeffs(nC, nC+1, nH, nH+1, y, y1, y2, &pCH[nC][nH][0]);
+      y[1] = PCHf[nC][nH + 1];
+      y[2] = PCHf[nC + 1][nH];
+      y[3] = PCHf[nC + 1][nH + 1];
+      Spbicubic_patch_coeffs(nC, nC + 1, nH, nH + 1, y, y1, y2, &pCH[nC][nH][0]);
     }
   }
 }

--- a/src/MDI/fix_mdi_qm.cpp
+++ b/src/MDI/fix_mdi_qm.cpp
@@ -440,7 +440,7 @@ void FixMDIQM::post_neighbor()
 
 void FixMDIQM::post_force(int vflag)
 {
-  int index, ierr;
+  int ierr;
 
   // skip if timestep is not a multiple of every
 
@@ -761,7 +761,7 @@ void FixMDIQM::create_qm_list()
     else if (!(mask[i] & excludebit)) qmIDs_mine[nqm_mine++] = tag[i];
   }
 
-  int *recvcounts,*displs,*listall;
+  int *recvcounts, *displs;
   memory->create(recvcounts,nprocs,"mdi/qm:recvcounts");
   memory->create(displs,nprocs,"mdi/qm:displs");
 

--- a/src/MDI/fix_mdi_qmmm.cpp
+++ b/src/MDI/fix_mdi_qmmm.cpp
@@ -583,7 +583,7 @@ void FixMDIQMMM::post_neighbor()
 
 void FixMDIQMMM::pre_force(int vflag)
 {
-  int ilocal,jlocal;
+  int ilocal;
   double rsq;
   double delta[3];
 
@@ -1360,7 +1360,7 @@ void FixMDIQMMM::create_qm_list()
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) qmIDs_mine[nqm_mine++] = tag[i];
 
-  int *recvcounts,*displs,*listall;
+  int *recvcounts, *displs;
   memory->create(recvcounts,nprocs,"mdi/qmmm:recvcounts");
   memory->create(displs,nprocs,"mdi/qmmm:displs");
 
@@ -1427,7 +1427,7 @@ void FixMDIQMMM::create_mm_list()
   for (int i = 0; i < nlocal; i++)
     if (!(mask[i] & groupbit)) mmIDs_mine[nmm_mine++] = tag[i];
 
-  int *recvcounts,*displs,*listall;
+  int *recvcounts, *displs;
   memory->create(recvcounts,nprocs,"mdi/qmmm:recvcounts");
   memory->create(displs,nprocs,"mdi/qmmm:displs");
 

--- a/src/MESONT/pair_mesocnt.cpp
+++ b/src/MESONT/pair_mesocnt.cpp
@@ -481,7 +481,7 @@ void PairMesoCNT::compute(int eflag, int vflag)
           geometry(r1, r2, p1, p2, nullptr, p, m, param, basis);
 
           if (param[0] > cutoff) continue;
-          if (!(param[2] < 0 && param[3] > 0)) {
+          if (param[2] >= 0 || param[3] <= 0) {
             double salpha = sin(param[1]);
             double sxi1 = salpha * param[2];
             double sxi2 = salpha * param[3];
@@ -503,7 +503,7 @@ void PairMesoCNT::compute(int eflag, int vflag)
             geometry(r1, r2, p2, p1, qe, p, m, param, basis);
 
           if (param[0] > cutoff) continue;
-          if (!(param[2] < 0 && param[3] > 0)) {
+          if (param[2] >= 0 || param[3] <= 0) {
             double hsq = param[0] * param[0];
             double calpha = cos(param[1]);
             double etamin = calpha * param[2];

--- a/src/MESONT/pair_mesocnt_viscous.cpp
+++ b/src/MESONT/pair_mesocnt_viscous.cpp
@@ -485,7 +485,7 @@ void PairMesoCNTViscous::compute(int eflag, int vflag)
           geometry(r1, r2, p1, p2, nullptr, p, m, param, basis);
 
           if (param[0] > cutoff) continue;
-          if (!(param[2] < 0 && param[3] > 0)) {
+          if (param[2] >= 0 || param[3] <= 0) {
             double salpha = sin(param[1]);
             double sxi1 = salpha * param[2];
             double sxi2 = salpha * param[3];
@@ -508,7 +508,7 @@ void PairMesoCNTViscous::compute(int eflag, int vflag)
             geometry(r1, r2, p2, p1, qe, p, m, param, basis);
 
           if (param[0] > cutoff) continue;
-          if (!(param[2] < 0 && param[3] > 0)) {
+          if (param[2] >= 0 || param[3] <= 0) {
             double hsq = param[0] * param[0];
             double calpha = cos(param[1]);
             double etamin = calpha * param[2];

--- a/src/MISC/pair_tracker.cpp
+++ b/src/MISC/pair_tracker.cpp
@@ -514,7 +514,7 @@ double PairTracker::single(int /*i*/, int /*j*/, int /*itype*/, int /*jtype*/, d
    only needed if any history entries i-j are not just negative of j-i entries
 ------------------------------------------------------------------------- */
 
-void PairTracker::transfer_history(double *source, double *target, int itype, int jtype)
+void PairTracker::transfer_history(double *source, double *target, int /*itype*/, int /*jtype*/)
 {
   for (int i = 0; i < size_history; i++) target[i] = source[i];
 }

--- a/src/OPENMP/pair_airebo_morse_omp.cpp
+++ b/src/OPENMP/pair_airebo_morse_omp.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -18,7 +17,8 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairAIREBOMorseOMP::PairAIREBOMorseOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp) {
+PairAIREBOMorseOMP::PairAIREBOMorseOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp)
+{
   variant = AIREBO_M;
 }
 
@@ -28,7 +28,7 @@ PairAIREBOMorseOMP::PairAIREBOMorseOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp) {
 
 void PairAIREBOMorseOMP::settings(int narg, char **arg)
 {
-  PairAIREBOOMP::settings(narg,arg);
+  PairAIREBOOMP::settings(narg, arg);
 
   morseflag = 1;
 }

--- a/src/OPENMP/pair_airebo_omp.cpp
+++ b/src/OPENMP/pair_airebo_omp.cpp
@@ -1546,7 +1546,7 @@ double PairAIREBOOMP::bondorder_thr(int i, int j, double rij[3], double rijmag,
             atoml = REBO_neighs_j[l];
             atom4 = atoml;
             ltype = map[type[atoml]];
-            if (!(atoml == atomi || atoml == atomk)) {
+            if (atoml != atomi && atoml != atomk) {
               r34[0] = x[atom3][0]-x[atom4][0];
               r34[1] = x[atom3][1]-x[atom4][1];
               r34[2] = x[atom3][2]-x[atom4][2];
@@ -2048,7 +2048,7 @@ double PairAIREBOOMP::bondorderLJ_thr(int i, int j, double /* rij_mod */[3], dou
             atoml = REBO_neighs_j[l];
             atom4 = atoml;
             ltype = map[type[atoml]];
-            if (!(atoml == atomi || atoml == atomk)) {
+            if (atoml != atomi && atoml != atomk) {
               r34[0] = x[atom3][0]-x[atom4][0];
               r34[1] = x[atom3][1]-x[atom4][1];
               r34[2] = x[atom3][2]-x[atom4][2];
@@ -2496,7 +2496,7 @@ double PairAIREBOOMP::bondorderLJ_thr(int i, int j, double /* rij_mod */[3], dou
               atoml = REBO_neighs_j[l];
               atom4 = atoml;
               ltype = map[type[atoml]];
-              if (!(atoml == atomi || atoml == atomk)) {
+              if (atoml != atomi && atoml != atomk) {
                 r34[0] = x[atom3][0]-x[atom4][0];
                 r34[1] = x[atom3][1]-x[atom4][1];
                 r34[2] = x[atom3][2]-x[atom4][2];

--- a/src/OPENMP/pair_eam_alloy_omp.cpp
+++ b/src/OPENMP/pair_eam_alloy_omp.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -42,24 +41,23 @@ PairEAMAlloyOMP::PairEAMAlloyOMP(LAMMPS *lmp) : PairEAMOMP(lmp)
 
 void PairEAMAlloyOMP::coeff(int narg, char **arg)
 {
-  int i,j;
+  int i, j;
 
   if (!allocated) allocate();
 
-  if (narg != 3 + atom->ntypes)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+  if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
 
   // ensure I,J args are * *
 
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+  if (strcmp(arg[0], "*") != 0 || strcmp(arg[1], "*") != 0)
+    error->all(FLERR, "Incorrect args for pair coefficients");
 
   // read EAM setfl file
 
   if (setfl) {
-    for (i = 0; i < setfl->nelements; i++) delete [] setfl->elements[i];
-    delete [] setfl->elements;
-    delete [] setfl->mass;
+    for (i = 0; i < setfl->nelements; i++) delete[] setfl->elements[i];
+    delete[] setfl->elements;
+    delete[] setfl->mass;
     memory->destroy(setfl->frho);
     memory->destroy(setfl->rhor);
     memory->destroy(setfl->z2r);
@@ -72,22 +70,23 @@ void PairEAMAlloyOMP::coeff(int narg, char **arg)
   // map[i] = which element the Ith atom type is, -1 if "NULL"
 
   for (i = 3; i < narg; i++) {
-    if (strcmp(arg[i],"NULL") == 0) {
-      map[i-2] = -1;
+    if (strcmp(arg[i], "NULL") == 0) {
+      map[i - 2] = -1;
       continue;
     }
     for (j = 0; j < setfl->nelements; j++)
-      if (strcmp(arg[i],setfl->elements[j]) == 0) break;
-    if (j < setfl->nelements) map[i-2] = j;
-    else error->all(FLERR,"No matching element in EAM potential file");
+      if (strcmp(arg[i], setfl->elements[j]) == 0) break;
+    if (j < setfl->nelements)
+      map[i - 2] = j;
+    else
+      error->all(FLERR, "No matching element in EAM potential file");
   }
 
   // clear setflag since coeff() called once with I,J = * *
 
   int n = atom->ntypes;
   for (i = 1; i <= n; i++)
-    for (j = i; j <= n; j++)
-      setflag[i][j] = 0;
+    for (j = i; j <= n; j++) setflag[i][j] = 0;
 
   // set setflag i,j for type pairs where both are mapped to elements
   // set mass of atom type if i = j
@@ -97,14 +96,14 @@ void PairEAMAlloyOMP::coeff(int narg, char **arg)
     for (j = i; j <= n; j++) {
       if (map[i] >= 0 && map[j] >= 0) {
         setflag[i][j] = 1;
-        if (i == j) atom->set_mass(FLERR,i,setfl->mass[map[i]]);
+        if (i == j) atom->set_mass(FLERR, i, setfl->mass[map[i]]);
         count++;
       }
       scale[i][j] = 1.0;
     }
   }
 
-  if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
+  if (count == 0) error->all(FLERR, "Incorrect args for pair coefficients");
 }
 
 /* ----------------------------------------------------------------------
@@ -117,14 +116,12 @@ void PairEAMAlloyOMP::read_file(char *filename)
 
   // read potential file
   if (comm->me == 0) {
-    PotentialFileReader reader(PairEAM::lmp, filename,
-                               "eam/alloy", unit_convert_flag);
+    PotentialFileReader reader(PairEAM::lmp, filename, "eam/alloy", unit_convert_flag);
 
     // transparently convert units for supported conversions
 
     int unit_convert = reader.get_unit_convert();
-    double conversion_factor = utils::get_conversion_factor(utils::ENERGY,
-                                                            unit_convert);
+    double conversion_factor = utils::get_conversion_factor(utils::ENERGY, unit_convert);
     try {
       reader.skip_line();
       reader.skip_line();
@@ -134,22 +131,22 @@ void PairEAMAlloyOMP::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if ((int)values.count() != file->nelements + 1)
-        error->one(FLERR,"Incorrect element names in EAM potential file");
+      if ((int) values.count() != file->nelements + 1)
+        error->one(FLERR, "Incorrect element names in EAM potential file");
 
-      file->elements = new char*[file->nelements];
+      file->elements = new char *[file->nelements];
       for (int i = 0; i < file->nelements; i++)
         file->elements[i] = utils::strdup(values.next_string());
 
       values = reader.next_values(5);
       file->nrho = values.next_int();
       file->drho = values.next_double();
-      file->nr   = values.next_int();
-      file->dr   = values.next_double();
-      file->cut  = values.next_double();
+      file->nr = values.next_int();
+      file->dr = values.next_double();
+      file->cut = values.next_double();
 
       if ((file->nrho <= 0) || (file->nr <= 0) || (file->dr <= 0.0))
-        error->one(FLERR,"Invalid EAM potential file");
+        error->one(FLERR, "Invalid EAM potential file");
 
       memory->create(file->mass, file->nelements, "pair:mass");
       memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -158,14 +155,13 @@ void PairEAMAlloyOMP::read_file(char *filename)
 
       for (int i = 0; i < file->nelements; i++) {
         values = reader.next_values(2);
-        values.next_int(); // ignore
+        values.next_int();    // ignore
         file->mass[i] = values.next_double();
 
         reader.next_dvector(&file->frho[i][1], file->nrho);
         reader.next_dvector(&file->rhor[i][1], file->nr);
         if (unit_convert) {
-          for (int j = 1; j < file->nrho; ++j)
-            file->frho[i][j] *= conversion_factor;
+          for (int j = 1; j < file->nrho; ++j) file->frho[i][j] *= conversion_factor;
         }
       }
 
@@ -173,8 +169,7 @@ void PairEAMAlloyOMP::read_file(char *filename)
         for (int j = 0; j <= i; j++) {
           reader.next_dvector(&file->z2r[i][j][1], file->nr);
           if (unit_convert) {
-            for (int k = 1; k < file->nr; ++k)
-              file->z2r[i][j][k] *= conversion_factor;
+            for (int k = 1; k < file->nr; ++k) file->z2r[i][j][k] *= conversion_factor;
           }
         }
       }
@@ -194,7 +189,7 @@ void PairEAMAlloyOMP::read_file(char *filename)
 
   // allocate memory on other procs
   if (comm->me != 0) {
-    file->elements = new char*[file->nelements];
+    file->elements = new char *[file->nelements];
     for (int i = 0; i < file->nelements; i++) file->elements[i] = nullptr;
     memory->create(file->mass, file->nelements, "pair:mass");
     memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -220,9 +215,7 @@ void PairEAMAlloyOMP::read_file(char *filename)
 
   // broadcast file->z2r
   for (int i = 0; i < file->nelements; i++) {
-    for (int j = 0; j <= i; j++) {
-      MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world);
-    }
+    for (int j = 0; j <= i; j++) { MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world); }
   }
 }
 
@@ -232,7 +225,7 @@ void PairEAMAlloyOMP::read_file(char *filename)
 
 void PairEAMAlloyOMP::file2array()
 {
-  int i,j,m,n;
+  int i, j, m, n;
   int ntypes = atom->ntypes;
 
   // set function params directly from setfl file
@@ -241,7 +234,7 @@ void PairEAMAlloyOMP::file2array()
   nr = setfl->nr;
   drho = setfl->drho;
   dr = setfl->dr;
-  rhomax = (nrho-1) * drho;
+  rhomax = (nrho - 1) * drho;
 
   // ------------------------------------------------------------------
   // setup frho arrays
@@ -252,7 +245,7 @@ void PairEAMAlloyOMP::file2array()
 
   nfrho = setfl->nelements + 1;
   memory->destroy(frho);
-  memory->create(frho,nfrho,nrho+1,"pair:frho");
+  memory->create(frho, nfrho, nrho + 1, "pair:frho");
 
   // copy each element's frho to global frho
 
@@ -262,15 +255,17 @@ void PairEAMAlloyOMP::file2array()
   // add extra frho of zeroes for non-EAM types to point to (pair hybrid)
   // this is necessary b/c fp is still computed for non-EAM atoms
 
-  for (m = 1; m <= nrho; m++) frho[nfrho-1][m] = 0.0;
+  for (m = 1; m <= nrho; m++) frho[nfrho - 1][m] = 0.0;
 
   // type2frho[i] = which frho array (0 to nfrho-1) each atom type maps to
   // if atom type doesn't point to element (non-EAM atom in pair hybrid)
   // then map it to last frho array of zeroes
 
   for (i = 1; i <= ntypes; i++)
-    if (map[i] >= 0) type2frho[i] = map[i];
-    else type2frho[i] = nfrho-1;
+    if (map[i] >= 0)
+      type2frho[i] = map[i];
+    else
+      type2frho[i] = nfrho - 1;
 
   // ------------------------------------------------------------------
   // setup rhor arrays
@@ -281,7 +276,7 @@ void PairEAMAlloyOMP::file2array()
 
   nrhor = setfl->nelements;
   memory->destroy(rhor);
-  memory->create(rhor,nrhor,nr+1,"pair:rhor");
+  memory->create(rhor, nrhor, nr + 1, "pair:rhor");
 
   // copy each element's rhor to global rhor
 
@@ -293,8 +288,7 @@ void PairEAMAlloyOMP::file2array()
   // OK if map = -1 (non-EAM atom in pair hybrid) b/c type2rhor not used
 
   for (i = 1; i <= ntypes; i++)
-    for (j = 1; j <= ntypes; j++)
-      type2rhor[i][j] = map[i];
+    for (j = 1; j <= ntypes; j++) type2rhor[i][j] = map[i];
 
   // ------------------------------------------------------------------
   // setup z2r arrays
@@ -303,9 +297,9 @@ void PairEAMAlloyOMP::file2array()
   // allocate z2r arrays
   // nz2r = N*(N+1)/2 where N = # of setfl elements
 
-  nz2r = setfl->nelements * (setfl->nelements+1) / 2;
+  nz2r = setfl->nelements * (setfl->nelements + 1) / 2;
   memory->destroy(z2r);
-  memory->create(z2r,nz2r,nr+1,"pair:z2r");
+  memory->create(z2r, nz2r, nr + 1, "pair:z2r");
 
   // copy each element pair z2r to global z2r, only for I >= J
 
@@ -324,7 +318,7 @@ void PairEAMAlloyOMP::file2array()
   //   type2z2r is not used by non-opt
   //   but set type2z2r to 0 since accessed by opt
 
-  int irow,icol;
+  int irow, icol;
   for (i = 1; i <= ntypes; i++) {
     for (j = 1; j <= ntypes; j++) {
       irow = map[i];

--- a/src/OPENMP/pair_eam_alloy_omp.cpp
+++ b/src/OPENMP/pair_eam_alloy_omp.cpp
@@ -45,7 +45,8 @@ void PairEAMAlloyOMP::coeff(int narg, char **arg)
 
   if (!allocated) allocate();
 
-  if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
+  if (narg != 3 + atom->ntypes)
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM setfl file
 

--- a/src/OPENMP/pair_eam_alloy_omp.cpp
+++ b/src/OPENMP/pair_eam_alloy_omp.cpp
@@ -47,11 +47,6 @@ void PairEAMAlloyOMP::coeff(int narg, char **arg)
 
   if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
 
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0], "*") != 0 || strcmp(arg[1], "*") != 0)
-    error->all(FLERR, "Incorrect args for pair coefficients");
-
   // read EAM setfl file
 
   if (setfl) {

--- a/src/OPENMP/pair_eam_fs_omp.cpp
+++ b/src/OPENMP/pair_eam_fs_omp.cpp
@@ -47,11 +47,6 @@ void PairEAMFSOMP::coeff(int narg, char **arg)
 
   if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
 
-  // ensure I,J args are * *
-
-  if (strcmp(arg[0], "*") != 0 || strcmp(arg[1], "*") != 0)
-    error->all(FLERR, "Incorrect args for pair coefficients");
-
   // read EAM Finnis-Sinclair file
 
   if (fs) {

--- a/src/OPENMP/pair_eam_fs_omp.cpp
+++ b/src/OPENMP/pair_eam_fs_omp.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -42,24 +41,23 @@ PairEAMFSOMP::PairEAMFSOMP(LAMMPS *lmp) : PairEAMOMP(lmp)
 
 void PairEAMFSOMP::coeff(int narg, char **arg)
 {
-  int i,j;
+  int i, j;
 
   if (!allocated) allocate();
 
-  if (narg != 3 + atom->ntypes)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+  if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
 
   // ensure I,J args are * *
 
-  if (strcmp(arg[0],"*") != 0 || strcmp(arg[1],"*") != 0)
-    error->all(FLERR,"Incorrect args for pair coefficients");
+  if (strcmp(arg[0], "*") != 0 || strcmp(arg[1], "*") != 0)
+    error->all(FLERR, "Incorrect args for pair coefficients");
 
   // read EAM Finnis-Sinclair file
 
   if (fs) {
-    for (i = 0; i < fs->nelements; i++) delete [] fs->elements[i];
-    delete [] fs->elements;
-    delete [] fs->mass;
+    for (i = 0; i < fs->nelements; i++) delete[] fs->elements[i];
+    delete[] fs->elements;
+    delete[] fs->mass;
     memory->destroy(fs->frho);
     memory->destroy(fs->rhor);
     memory->destroy(fs->z2r);
@@ -72,22 +70,23 @@ void PairEAMFSOMP::coeff(int narg, char **arg)
   // map[i] = which element the Ith atom type is, -1 if "NULL"
 
   for (i = 3; i < narg; i++) {
-    if (strcmp(arg[i],"NULL") == 0) {
-      map[i-2] = -1;
+    if (strcmp(arg[i], "NULL") == 0) {
+      map[i - 2] = -1;
       continue;
     }
     for (j = 0; j < fs->nelements; j++)
-      if (strcmp(arg[i],fs->elements[j]) == 0) break;
-    if (j < fs->nelements) map[i-2] = j;
-    else error->all(FLERR,"No matching element in EAM potential file");
+      if (strcmp(arg[i], fs->elements[j]) == 0) break;
+    if (j < fs->nelements)
+      map[i - 2] = j;
+    else
+      error->all(FLERR, "No matching element in EAM potential file");
   }
 
   // clear setflag since coeff() called once with I,J = * *
 
   int n = atom->ntypes;
   for (i = 1; i <= n; i++)
-    for (j = i; j <= n; j++)
-      setflag[i][j] = 0;
+    for (j = i; j <= n; j++) setflag[i][j] = 0;
 
   // set setflag i,j for type pairs where both are mapped to elements
   // set mass of atom type if i = j
@@ -97,14 +96,14 @@ void PairEAMFSOMP::coeff(int narg, char **arg)
     for (j = i; j <= n; j++) {
       if (map[i] >= 0 && map[j] >= 0) {
         setflag[i][j] = 1;
-        if (i == j) atom->set_mass(FLERR,i,fs->mass[map[i]]);
+        if (i == j) atom->set_mass(FLERR, i, fs->mass[map[i]]);
         count++;
       }
       scale[i][j] = 1.0;
     }
   }
 
-  if (count == 0) error->all(FLERR,"Incorrect args for pair coefficients");
+  if (count == 0) error->all(FLERR, "Incorrect args for pair coefficients");
 }
 
 /* ----------------------------------------------------------------------
@@ -117,14 +116,12 @@ void PairEAMFSOMP::read_file(char *filename)
 
   // read potential file
   if (comm->me == 0) {
-    PotentialFileReader reader(PairEAM::lmp, filename,
-                               "eam/fs", unit_convert_flag);
+    PotentialFileReader reader(PairEAM::lmp, filename, "eam/fs", unit_convert_flag);
 
     // transparently convert units for supported conversions
 
     int unit_convert = reader.get_unit_convert();
-    double conversion_factor = utils::get_conversion_factor(utils::ENERGY,
-                                                            unit_convert);
+    double conversion_factor = utils::get_conversion_factor(utils::ENERGY, unit_convert);
     try {
       reader.skip_line();
       reader.skip_line();
@@ -134,22 +131,22 @@ void PairEAMFSOMP::read_file(char *filename)
       ValueTokenizer values = reader.next_values(1);
       file->nelements = values.next_int();
 
-      if ((int)values.count() != file->nelements + 1)
-        error->one(FLERR,"Incorrect element names in EAM potential file");
+      if ((int) values.count() != file->nelements + 1)
+        error->one(FLERR, "Incorrect element names in EAM potential file");
 
-      file->elements = new char*[file->nelements];
+      file->elements = new char *[file->nelements];
       for (int i = 0; i < file->nelements; i++)
         file->elements[i] = utils::strdup(values.next_string());
 
       values = reader.next_values(5);
       file->nrho = values.next_int();
       file->drho = values.next_double();
-      file->nr   = values.next_int();
-      file->dr   = values.next_double();
-      file->cut  = values.next_double();
+      file->nr = values.next_int();
+      file->dr = values.next_double();
+      file->cut = values.next_double();
 
       if ((file->nrho <= 0) || (file->nr <= 0) || (file->dr <= 0.0))
-        error->one(FLERR,"Invalid EAM potential file");
+        error->one(FLERR, "Invalid EAM potential file");
 
       memory->create(file->mass, file->nelements, "pair:mass");
       memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -158,13 +155,12 @@ void PairEAMFSOMP::read_file(char *filename)
 
       for (int i = 0; i < file->nelements; i++) {
         values = reader.next_values(2);
-        values.next_int(); // ignore
+        values.next_int();    // ignore
         file->mass[i] = values.next_double();
 
         reader.next_dvector(&file->frho[i][1], file->nrho);
         if (unit_convert) {
-          for (int j = 1; j <= file->nrho; ++j)
-            file->frho[i][j] *= conversion_factor;
+          for (int j = 1; j <= file->nrho; ++j) file->frho[i][j] *= conversion_factor;
         }
 
         for (int j = 0; j < file->nelements; j++) {
@@ -176,8 +172,7 @@ void PairEAMFSOMP::read_file(char *filename)
         for (int j = 0; j <= i; j++) {
           reader.next_dvector(&file->z2r[i][j][1], file->nr);
           if (unit_convert) {
-            for (int k = 1; k <= file->nr; ++k)
-              file->z2r[i][j][k] *= conversion_factor;
+            for (int k = 1; k <= file->nr; ++k) file->z2r[i][j][k] *= conversion_factor;
           }
         }
       }
@@ -197,7 +192,7 @@ void PairEAMFSOMP::read_file(char *filename)
 
   // allocate memory on other procs
   if (comm->me != 0) {
-    file->elements = new char*[file->nelements];
+    file->elements = new char *[file->nelements];
     for (int i = 0; i < file->nelements; i++) file->elements[i] = nullptr;
     memory->create(file->mass, file->nelements, "pair:mass");
     memory->create(file->frho, file->nelements, file->nrho + 1, "pair:frho");
@@ -226,9 +221,7 @@ void PairEAMFSOMP::read_file(char *filename)
 
   // broadcast file->z2r
   for (int i = 0; i < file->nelements; i++) {
-    for (int j = 0; j <= i; j++) {
-      MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world);
-    }
+    for (int j = 0; j <= i; j++) { MPI_Bcast(&file->z2r[i][j][1], file->nr, MPI_DOUBLE, 0, world); }
   }
 }
 
@@ -238,7 +231,7 @@ void PairEAMFSOMP::read_file(char *filename)
 
 void PairEAMFSOMP::file2array()
 {
-  int i,j,m,n;
+  int i, j, m, n;
   int ntypes = atom->ntypes;
 
   // set function params directly from fs file
@@ -247,7 +240,7 @@ void PairEAMFSOMP::file2array()
   nr = fs->nr;
   drho = fs->drho;
   dr = fs->dr;
-  rhomax = (nrho-1) * drho;
+  rhomax = (nrho - 1) * drho;
 
   // ------------------------------------------------------------------
   // setup frho arrays
@@ -258,7 +251,7 @@ void PairEAMFSOMP::file2array()
 
   nfrho = fs->nelements + 1;
   memory->destroy(frho);
-  memory->create(frho,nfrho,nrho+1,"pair:frho");
+  memory->create(frho, nfrho, nrho + 1, "pair:frho");
 
   // copy each element's frho to global frho
 
@@ -268,15 +261,17 @@ void PairEAMFSOMP::file2array()
   // add extra frho of zeroes for non-EAM types to point to (pair hybrid)
   // this is necessary b/c fp is still computed for non-EAM atoms
 
-  for (m = 1; m <= nrho; m++) frho[nfrho-1][m] = 0.0;
+  for (m = 1; m <= nrho; m++) frho[nfrho - 1][m] = 0.0;
 
   // type2frho[i] = which frho array (0 to nfrho-1) each atom type maps to
   // if atom type doesn't point to element (non-EAM atom in pair hybrid)
   // then map it to last frho array of zeroes
 
   for (i = 1; i <= ntypes; i++)
-    if (map[i] >= 0) type2frho[i] = map[i];
-    else type2frho[i] = nfrho-1;
+    if (map[i] >= 0)
+      type2frho[i] = map[i];
+    else
+      type2frho[i] = nfrho - 1;
 
   // ------------------------------------------------------------------
   // setup rhor arrays
@@ -287,7 +282,7 @@ void PairEAMFSOMP::file2array()
 
   nrhor = fs->nelements * fs->nelements;
   memory->destroy(rhor);
-  memory->create(rhor,nrhor,nr+1,"pair:rhor");
+  memory->create(rhor, nrhor, nr + 1, "pair:rhor");
 
   // copy each element pair rhor to global rhor
 
@@ -303,8 +298,7 @@ void PairEAMFSOMP::file2array()
   // OK if map = -1 (non-EAM atom in pair hybrid) b/c type2rhor not used
 
   for (i = 1; i <= ntypes; i++)
-    for (j = 1; j <= ntypes; j++)
-      type2rhor[i][j] = map[i] * fs->nelements + map[j];
+    for (j = 1; j <= ntypes; j++) type2rhor[i][j] = map[i] * fs->nelements + map[j];
 
   // ------------------------------------------------------------------
   // setup z2r arrays
@@ -313,9 +307,9 @@ void PairEAMFSOMP::file2array()
   // allocate z2r arrays
   // nz2r = N*(N+1)/2 where N = # of fs elements
 
-  nz2r = fs->nelements * (fs->nelements+1) / 2;
+  nz2r = fs->nelements * (fs->nelements + 1) / 2;
   memory->destroy(z2r);
-  memory->create(z2r,nz2r,nr+1,"pair:z2r");
+  memory->create(z2r, nz2r, nr + 1, "pair:z2r");
 
   // copy each element pair z2r to global z2r, only for I >= J
 
@@ -334,7 +328,7 @@ void PairEAMFSOMP::file2array()
   //   type2z2r is not used by non-opt
   //   but set type2z2r to 0 since accessed by opt
 
-  int irow,icol;
+  int irow, icol;
   for (i = 1; i <= ntypes; i++) {
     for (j = 1; j <= ntypes; j++) {
       irow = map[i];

--- a/src/OPENMP/pair_eam_fs_omp.cpp
+++ b/src/OPENMP/pair_eam_fs_omp.cpp
@@ -45,7 +45,8 @@ void PairEAMFSOMP::coeff(int narg, char **arg)
 
   if (!allocated) allocate();
 
-  if (narg != 3 + atom->ntypes) error->all(FLERR, "Incorrect args for pair coefficients");
+  if (narg != 3 + atom->ntypes)
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   // read EAM Finnis-Sinclair file
 

--- a/src/OPENMP/pair_lepton_coul_omp.cpp
+++ b/src/OPENMP/pair_lepton_coul_omp.cpp
@@ -108,7 +108,7 @@ void PairLeptonCoulOMP::eval(int iifrom, int iito, ThrData *const thr)
       pairforce.emplace_back(parsed.differentiate("r").createCompiledExpression());
       if (EFLAG) pairpot.emplace_back(parsed.createCompiledExpression());
       pairforce.back().getVariableReference("r");
-      have_q.emplace_back(std::make_pair(true, true));
+      have_q.emplace_back(true, true);
 
       // check if there are references to charges
       try {

--- a/src/OPENMP/pair_rebo_omp.cpp
+++ b/src/OPENMP/pair_rebo_omp.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,13 +12,15 @@
 ------------------------------------------------------------------------- */
 
 #include "pair_rebo_omp.h"
+
 #include "error.h"
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairREBOOMP::PairREBOOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp) {
+PairREBOOMP::PairREBOOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp)
+{
   variant = REBO_2;
 }
 
@@ -29,7 +30,7 @@ PairREBOOMP::PairREBOOMP(LAMMPS *lmp) : PairAIREBOOMP(lmp) {
 
 void PairREBOOMP::settings(int narg, char ** /* arg */)
 {
-  if (narg != 0) error->all(FLERR,"Illegal pair_style command");
+  if (narg != 0) error->all(FLERR, "Illegal pair_style command");
 
   cutlj = 0.0;
   ljflag = torflag = 0;
@@ -39,29 +40,30 @@ void PairREBOOMP::settings(int narg, char ** /* arg */)
    initialize spline knot values
 ------------------------------------------------------------------------- */
 
-void PairREBOOMP::spline_init() {
+void PairREBOOMP::spline_init()
+{
   PairAIREBO::spline_init();
 
   PCCf[0][2] = 0.007860700254745;
   PCCf[0][3] = 0.016125364564267;
   PCCf[1][1] = 0.003026697473481;
   PCCf[1][2] = 0.006326248241119;
-  PCCf[2][0] = 0.;
+  PCCf[2][0] = 0.0;
   PCCf[2][1] = 0.003179530830731;
 
   for (int nH = 0; nH < 4; nH++) {
     for (int nC = 0; nC < 4; nC++) {
       double y[4] = {0}, y1[4] = {0}, y2[4] = {0};
       y[0] = PCCf[nC][nH];
-      y[1] = PCCf[nC][nH+1];
-      y[2] = PCCf[nC+1][nH];
-      y[3] = PCCf[nC+1][nH+1];
-      Spbicubic_patch_coeffs(nC, nC+1, nH, nH+1, y, y1, y2, &pCC[nC][nH][0]);
+      y[1] = PCCf[nC][nH + 1];
+      y[2] = PCCf[nC + 1][nH];
+      y[3] = PCCf[nC + 1][nH + 1];
+      Spbicubic_patch_coeffs(nC, nC + 1, nH, nH + 1, y, y1, y2, &pCC[nC][nH][0]);
       y[0] = PCHf[nC][nH];
-      y[1] = PCHf[nC][nH+1];
-      y[2] = PCHf[nC+1][nH];
-      y[3] = PCHf[nC+1][nH+1];
-      Spbicubic_patch_coeffs(nC, nC+1, nH, nH+1, y, y1, y2, &pCH[nC][nH][0]);
+      y[1] = PCHf[nC][nH + 1];
+      y[2] = PCHf[nC + 1][nH];
+      y[3] = PCHf[nC + 1][nH + 1];
+      Spbicubic_patch_coeffs(nC, nC + 1, nH, nH + 1, y, y1, y2, &pCH[nC][nH][0]);
     }
   }
 }

--- a/src/OPT/pair_eam_alloy_opt.cpp
+++ b/src/OPT/pair_eam_alloy_opt.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -31,5 +30,4 @@ using namespace LAMMPS_NS;
    inherit everything else from PairEAMAlloy
 ------------------------------------------------------------------------- */
 
-PairEAMAlloyOpt::PairEAMAlloyOpt(LAMMPS *lmp) :
-  PairEAM(lmp), PairEAMAlloy(lmp), PairEAMOpt(lmp) {}
+PairEAMAlloyOpt::PairEAMAlloyOpt(LAMMPS *lmp) : PairEAM(lmp), PairEAMAlloy(lmp), PairEAMOpt(lmp) {}

--- a/src/OPT/pair_eam_fs_opt.cpp
+++ b/src/OPT/pair_eam_fs_opt.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -31,5 +30,4 @@ using namespace LAMMPS_NS;
    inherit everything else from PairEAMFS
 ------------------------------------------------------------------------- */
 
-PairEAMFSOpt::PairEAMFSOpt(LAMMPS *lmp) :
-  PairEAM(lmp), PairEAMFS(lmp), PairEAMOpt(lmp) {}
+PairEAMFSOpt::PairEAMFSOpt(LAMMPS *lmp) : PairEAM(lmp), PairEAMFS(lmp), PairEAMOpt(lmp) {}

--- a/src/OPT/pair_eam_opt.cpp
+++ b/src/OPT/pair_eam_opt.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -21,14 +20,15 @@
 ------------------------------------------------------------------------- */
 
 #include "pair_eam_opt.h"
-#include <cmath>
 
 #include "atom.h"
 #include "comm.h"
 #include "force.h"
-#include "neigh_list.h"
 #include "memory.h"
+#include "neigh_list.h"
 #include "update.h"
+
+#include <cmath>
 
 using namespace LAMMPS_NS;
 
@@ -40,44 +40,51 @@ PairEAMOpt::PairEAMOpt(LAMMPS *lmp) : PairEAM(lmp) {}
 
 void PairEAMOpt::compute(int eflag, int vflag)
 {
-  ev_init(eflag,vflag);
+  ev_init(eflag, vflag);
 
   if (evflag) {
     if (eflag) {
-      if (force->newton_pair) return eval<1,1,1>();
-      else return eval<1,1,0>();
+      if (force->newton_pair)
+        return eval<1, 1, 1>();
+      else
+        return eval<1, 1, 0>();
     } else {
-      if (force->newton_pair) return eval<1,0,1>();
-      else return eval<1,0,0>();
+      if (force->newton_pair)
+        return eval<1, 0, 1>();
+      else
+        return eval<1, 0, 0>();
     }
   } else {
-    if (force->newton_pair) return eval<0,0,1>();
-    else return eval<0,0,0>();
+    if (force->newton_pair)
+      return eval<0, 0, 1>();
+    else
+      return eval<0, 0, 0>();
   }
 }
 
 /* ---------------------------------------------------------------------- */
 
-template < int EVFLAG, int EFLAG, int NEWTON_PAIR >
-void PairEAMOpt::eval()
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR> void PairEAMOpt::eval()
 {
-  typedef struct { double x,y,z; } vec3_t;
+  typedef struct {
+    double x, y, z;
+  } vec3_t;
 
   typedef struct {
-    double rhor0i,rhor1i,rhor2i,rhor3i;
-    double rhor0j,rhor1j,rhor2j,rhor3j;
+    double rhor0i, rhor1i, rhor2i, rhor3i;
+    double rhor0j, rhor1j, rhor2j, rhor3j;
   } fast_alpha_t;
 
   typedef struct {
-    double rhor4i,rhor5i,rhor6i;
-    double rhor4j,rhor5j,rhor6j;
-    double z2r0,z2r1,z2r2,z2r3,z2r4,z2r5,z2r6;
+    double rhor4i, rhor5i, rhor6i;
+    double rhor4j, rhor5j, rhor6j;
+    double z2r0, z2r1, z2r2, z2r3, z2r4, z2r5, z2r6;
     double _pad[3];
   } fast_gamma_t;
 
-  int i,j,ii,jj,inum,jnum,itype,jtype;
+  int i, j, ii, jj, inum, jnum, itype, jtype;
   double evdwl = 0.0;
-  double* _noalias coeff;
+  double *_noalias coeff;
 
   // grow energy array if necessary
 
@@ -86,94 +93,97 @@ void PairEAMOpt::eval()
     memory->destroy(fp);
     memory->destroy(numforce);
     nmax = atom->nmax;
-    memory->create(rho,nmax,"pair:rho");
-    memory->create(fp,nmax,"pair:fp");
-    memory->create(numforce,nmax,"pair:numforce");
+    memory->create(rho, nmax, "pair:rho");
+    memory->create(fp, nmax, "pair:fp");
+    memory->create(numforce, nmax, "pair:numforce");
   }
 
-  double** _noalias x = atom->x;
-  double** _noalias f = atom->f;
-  int* _noalias type = atom->type;
+  double **_noalias x = atom->x;
+  double **_noalias f = atom->f;
+  int *_noalias type = atom->type;
   int nlocal = atom->nlocal;
 
-  auto * _noalias xx = (vec3_t*)x[0];
-  auto * _noalias ff = (vec3_t*)f[0];
+  auto *_noalias xx = (vec3_t *) x[0];
+  auto *_noalias ff = (vec3_t *) f[0];
 
   double tmp_cutforcesq = cutforcesq;
   double tmp_rdr = rdr;
-  int nr2 = nr-2;
-  int nr1 = nr-1;
+  int nr2 = nr - 2;
+  int nr1 = nr - 1;
 
   inum = list->inum;
-  int* _noalias ilist = list->ilist;
-  int** _noalias firstneigh = list->firstneigh;
-  int* _noalias numneigh = list->numneigh;
+  int *_noalias ilist = list->ilist;
+  int **_noalias firstneigh = list->firstneigh;
+  int *_noalias numneigh = list->numneigh;
 
   int ntypes = atom->ntypes;
-  int ntypes2 = ntypes*ntypes;
+  int ntypes2 = ntypes * ntypes;
 
-  auto * _noalias fast_alpha =
-    (fast_alpha_t*) malloc((size_t)ntypes2*(nr+1)*sizeof(fast_alpha_t));
-  for (i = 0; i < ntypes; i++) for (j = 0; j < ntypes; j++) {
-    auto * _noalias tab = &fast_alpha[i*ntypes*nr+j*nr];
-    if (type2rhor[i+1][j+1] >= 0) {
-      for (int m = 1; m <= nr; m++) {
-        tab[m].rhor0i =  rhor_spline[type2rhor[i+1][j+1]][m][6];
-        tab[m].rhor1i =  rhor_spline[type2rhor[i+1][j+1]][m][5];
-        tab[m].rhor2i =  rhor_spline[type2rhor[i+1][j+1]][m][4];
-        tab[m].rhor3i =  rhor_spline[type2rhor[i+1][j+1]][m][3];
+  auto *_noalias fast_alpha =
+      (fast_alpha_t *) malloc((size_t) ntypes2 * (nr + 1) * sizeof(fast_alpha_t));
+  for (i = 0; i < ntypes; i++)
+    for (j = 0; j < ntypes; j++) {
+      auto *_noalias tab = &fast_alpha[i * ntypes * nr + j * nr];
+      if (type2rhor[i + 1][j + 1] >= 0) {
+        for (int m = 1; m <= nr; m++) {
+          tab[m].rhor0i = rhor_spline[type2rhor[i + 1][j + 1]][m][6];
+          tab[m].rhor1i = rhor_spline[type2rhor[i + 1][j + 1]][m][5];
+          tab[m].rhor2i = rhor_spline[type2rhor[i + 1][j + 1]][m][4];
+          tab[m].rhor3i = rhor_spline[type2rhor[i + 1][j + 1]][m][3];
+        }
+      }
+      if (type2rhor[j + 1][i + 1] >= 0) {
+        for (int m = 1; m <= nr; m++) {
+          tab[m].rhor0j = rhor_spline[type2rhor[j + 1][i + 1]][m][6];
+          tab[m].rhor1j = rhor_spline[type2rhor[j + 1][i + 1]][m][5];
+          tab[m].rhor2j = rhor_spline[type2rhor[j + 1][i + 1]][m][4];
+          tab[m].rhor3j = rhor_spline[type2rhor[j + 1][i + 1]][m][3];
+        }
       }
     }
-    if (type2rhor[j+1][i+1] >= 0) {
-      for (int m = 1; m <= nr; m++) {
-        tab[m].rhor0j =  rhor_spline[type2rhor[j+1][i+1]][m][6];
-        tab[m].rhor1j =  rhor_spline[type2rhor[j+1][i+1]][m][5];
-        tab[m].rhor2j =  rhor_spline[type2rhor[j+1][i+1]][m][4];
-        tab[m].rhor3j =  rhor_spline[type2rhor[j+1][i+1]][m][3];
-      }
-    }
-  }
-  auto * _noalias tabeight = fast_alpha;
+  auto *_noalias tabeight = fast_alpha;
 
-  auto * _noalias fast_gamma =
-    (fast_gamma_t*) malloc((size_t)ntypes2*(nr+1)*sizeof(fast_gamma_t));
-  for (i = 0; i < ntypes; i++) for (j = 0; j < ntypes; j++) {
-    auto * _noalias tab = &fast_gamma[i*ntypes*nr+j*nr];
-    if (type2rhor[i+1][j+1] >= 0) {
-      for (int m = 1; m <= nr; m++) {
-        tab[m].rhor4i =  rhor_spline[type2rhor[i+1][j+1]][m][2];
-        tab[m].rhor5i =  rhor_spline[type2rhor[i+1][j+1]][m][1];
-        tab[m].rhor6i =  rhor_spline[type2rhor[i+1][j+1]][m][0];
+  auto *_noalias fast_gamma =
+      (fast_gamma_t *) malloc((size_t) ntypes2 * (nr + 1) * sizeof(fast_gamma_t));
+  for (i = 0; i < ntypes; i++)
+    for (j = 0; j < ntypes; j++) {
+      auto *_noalias tab = &fast_gamma[i * ntypes * nr + j * nr];
+      if (type2rhor[i + 1][j + 1] >= 0) {
+        for (int m = 1; m <= nr; m++) {
+          tab[m].rhor4i = rhor_spline[type2rhor[i + 1][j + 1]][m][2];
+          tab[m].rhor5i = rhor_spline[type2rhor[i + 1][j + 1]][m][1];
+          tab[m].rhor6i = rhor_spline[type2rhor[i + 1][j + 1]][m][0];
+        }
+      }
+      if (type2rhor[j + 1][i + 1] >= 0) {
+        for (int m = 1; m <= nr; m++) {
+          tab[m].rhor4j = rhor_spline[type2rhor[j + 1][i + 1]][m][2];
+          tab[m].rhor5j = rhor_spline[type2rhor[j + 1][i + 1]][m][1];
+          tab[m].rhor6j = rhor_spline[type2rhor[j + 1][i + 1]][m][0];
+          tab[m].z2r6 = z2r_spline[type2z2r[i + 1][j + 1]][m][0];
+        }
+      }
+      if (type2z2r[i + 1][j + 1] >= 0) {
+        for (int m = 1; m <= nr; m++) {
+          tab[m].z2r0 = z2r_spline[type2z2r[i + 1][j + 1]][m][6];
+          tab[m].z2r1 = z2r_spline[type2z2r[i + 1][j + 1]][m][5];
+          tab[m].z2r2 = z2r_spline[type2z2r[i + 1][j + 1]][m][4];
+          tab[m].z2r3 = z2r_spline[type2z2r[i + 1][j + 1]][m][3];
+          tab[m].z2r4 = z2r_spline[type2z2r[i + 1][j + 1]][m][2];
+          tab[m].z2r5 = z2r_spline[type2z2r[i + 1][j + 1]][m][1];
+          tab[m].z2r6 = z2r_spline[type2z2r[i + 1][j + 1]][m][0];
+        }
       }
     }
-    if (type2rhor[j+1][i+1] >= 0) {
-      for (int m = 1; m <= nr; m++) {
-        tab[m].rhor4j =  rhor_spline[type2rhor[j+1][i+1]][m][2];
-        tab[m].rhor5j =  rhor_spline[type2rhor[j+1][i+1]][m][1];
-        tab[m].rhor6j =  rhor_spline[type2rhor[j+1][i+1]][m][0];
-        tab[m].z2r6 =  z2r_spline[type2z2r[i+1][j+1]][m][0];
-      }
-    }
-    if (type2z2r[i+1][j+1] >= 0) {
-      for (int m = 1; m <= nr; m++) {
-        tab[m].z2r0 =  z2r_spline[type2z2r[i+1][j+1]][m][6];
-        tab[m].z2r1 =  z2r_spline[type2z2r[i+1][j+1]][m][5];
-        tab[m].z2r2 =  z2r_spline[type2z2r[i+1][j+1]][m][4];
-        tab[m].z2r3 =  z2r_spline[type2z2r[i+1][j+1]][m][3];
-        tab[m].z2r4 =  z2r_spline[type2z2r[i+1][j+1]][m][2];
-        tab[m].z2r5 =  z2r_spline[type2z2r[i+1][j+1]][m][1];
-        tab[m].z2r6 =  z2r_spline[type2z2r[i+1][j+1]][m][0];
-      }
-    }
-  }
-  auto * _noalias tabss = fast_gamma;
+  auto *_noalias tabss = fast_gamma;
 
   // zero out density
 
   if (NEWTON_PAIR) {
     int m = nlocal + atom->nghost;
     for (i = 0; i < m; i++) rho[i] = 0.0;
-  } else for (i = 0; i < nlocal; i++) rho[i] = 0.0;
+  } else
+    for (i = 0; i < nlocal; i++) rho[i] = 0.0;
 
   // rho = density at each atom
   // loop over neighbors of my atoms
@@ -184,11 +194,11 @@ void PairEAMOpt::eval()
     double ytmp = xx[i].y;
     double ztmp = xx[i].z;
     itype = type[i] - 1;
-    int* _noalias jlist = firstneigh[i];
+    int *_noalias jlist = firstneigh[i];
     jnum = numneigh[i];
 
     double tmprho = rho[i];
-    auto * _noalias tabeighti = &tabeight[itype*ntypes*nr];
+    auto *_noalias tabeighti = &tabeight[itype * ntypes * nr];
 
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
@@ -197,26 +207,24 @@ void PairEAMOpt::eval()
       double delx = xtmp - xx[j].x;
       double dely = ytmp - xx[j].y;
       double delz = ztmp - xx[j].z;
-      double rsq = delx*delx + dely*dely + delz*delz;
+      double rsq = delx * delx + dely * dely + delz * delz;
 
       if (rsq < tmp_cutforcesq) {
         jtype = type[j] - 1;
 
-        double p = sqrt(rsq)*tmp_rdr;
-        if ((int)p <= nr2) {
-          int m = (int)p + 1;
-          p -= (double)((int)p);
-          fast_alpha_t& a = tabeighti[jtype*nr+m];
-          tmprho += ((a.rhor3j*p+a.rhor2j)*p+a.rhor1j)*p+a.rhor0j;
+        double p = sqrt(rsq) * tmp_rdr;
+        if ((int) p <= nr2) {
+          int m = (int) p + 1;
+          p -= (double) ((int) p);
+          fast_alpha_t &a = tabeighti[jtype * nr + m];
+          tmprho += ((a.rhor3j * p + a.rhor2j) * p + a.rhor1j) * p + a.rhor0j;
           if (NEWTON_PAIR || j < nlocal) {
-            rho[j] += ((a.rhor3i*p+a.rhor2i)*p+a.rhor1i)*p+a.rhor0i;
+            rho[j] += ((a.rhor3i * p + a.rhor2i) * p + a.rhor1i) * p + a.rhor0i;
           }
         } else {
-          fast_alpha_t& a = tabeighti[jtype*nr+nr1];
-          tmprho += a.rhor3j+a.rhor2j+a.rhor1j+a.rhor0j;
-          if (NEWTON_PAIR || j < nlocal) {
-            rho[j] += a.rhor3i+a.rhor2i+a.rhor1i+a.rhor0i;
-          }
+          fast_alpha_t &a = tabeighti[jtype * nr + nr1];
+          tmprho += a.rhor3j + a.rhor2j + a.rhor1j + a.rhor0j;
+          if (NEWTON_PAIR || j < nlocal) { rho[j] += a.rhor3i + a.rhor2i + a.rhor1i + a.rhor0i; }
         }
       }
     }
@@ -234,16 +242,16 @@ void PairEAMOpt::eval()
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];
-    double p = rho[i]*rdrho + 1.0;
-    int m = static_cast<int> (p);
-    m = MAX(1,MIN(m,nrho-1));
+    double p = rho[i] * rdrho + 1.0;
+    int m = static_cast<int>(p);
+    m = MAX(1, MIN(m, nrho - 1));
     p -= m;
-    p = MIN(p,1.0);
+    p = MIN(p, 1.0);
     coeff = frho_spline[type2frho[type[i]]][m];
-    fp[i] = (coeff[0]*p + coeff[1])*p + coeff[2];
+    fp[i] = (coeff[0] * p + coeff[1]) * p + coeff[2];
     if (EFLAG) {
-      double phi = ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
-      if (rho[i] > rhomax) phi += fp[i] * (rho[i]-rhomax);
+      double phi = ((coeff[3] * p + coeff[4]) * p + coeff[5]) * p + coeff[6];
+      if (rho[i] > rhomax) phi += fp[i] * (rho[i] - rhomax);
       phi *= scale[type[i]][type[i]];
       if (eflag_global) eng_vdwl += phi;
       if (eflag_atom) eatom[i] += phi;
@@ -264,15 +272,15 @@ void PairEAMOpt::eval()
     double ytmp = xx[i].y;
     double ztmp = xx[i].z;
     int itype1 = type[i] - 1;
-    int* _noalias jlist = firstneigh[i];
+    int *_noalias jlist = firstneigh[i];
     jnum = numneigh[i];
 
     double tmpfx = 0.0;
     double tmpfy = 0.0;
     double tmpfz = 0.0;
 
-    auto * _noalias tabssi = &tabss[itype1*ntypes*nr];
-    double* _noalias scale_i = scale[itype1+1]+1;
+    auto *_noalias tabssi = &tabss[itype1 * ntypes * nr];
+    double *_noalias scale_i = scale[itype1 + 1] + 1;
     numforce[i] = 0;
 
     for (jj = 0; jj < jnum; jj++) {
@@ -282,29 +290,29 @@ void PairEAMOpt::eval()
       double delx = xtmp - xx[j].x;
       double dely = ytmp - xx[j].y;
       double delz = ztmp - xx[j].z;
-      double rsq = delx*delx + dely*dely + delz*delz;
+      double rsq = delx * delx + dely * dely + delz * delz;
 
       if (rsq < tmp_cutforcesq) {
         ++numforce[i];
         jtype = type[j] - 1;
         double r = sqrt(rsq);
-        double rhoip,rhojp,z2,z2p;
-        double p = r*tmp_rdr;
-        if ((int)p <= nr2) {
+        double rhoip, rhojp, z2, z2p;
+        double p = r * tmp_rdr;
+        if ((int) p <= nr2) {
           int m = (int) p + 1;
-          m = MIN(m,nr-1);
-          p -= (double)((int) p);
-          p = MIN(p,1.0);
+          m = MIN(m, nr - 1);
+          p -= (double) ((int) p);
+          p = MIN(p, 1.0);
 
-          fast_gamma_t& a = tabssi[jtype*nr+m];
-          rhoip = (a.rhor6i*p + a.rhor5i)*p + a.rhor4i;
-          rhojp = (a.rhor6j*p + a.rhor5j)*p + a.rhor4j;
-          z2 = ((a.z2r3*p + a.z2r2)*p + a.z2r1)*p + a.z2r0;
-          z2p = (a.z2r6*p + a.z2r5)*p + a.z2r4;
+          fast_gamma_t &a = tabssi[jtype * nr + m];
+          rhoip = (a.rhor6i * p + a.rhor5i) * p + a.rhor4i;
+          rhojp = (a.rhor6j * p + a.rhor5j) * p + a.rhor4j;
+          z2 = ((a.z2r3 * p + a.z2r2) * p + a.z2r1) * p + a.z2r0;
+          z2p = (a.z2r6 * p + a.z2r5) * p + a.z2r4;
 
         } else {
 
-          fast_gamma_t& a = tabssi[jtype*nr+nr1];
+          fast_gamma_t &a = tabssi[jtype * nr + nr1];
           rhoip = a.rhor6i + a.rhor5i + a.rhor4i;
           rhojp = a.rhor6j + a.rhor5j + a.rhor4j;
           z2 = a.z2r3 + a.z2r2 + a.z2r1 + a.z2r0;
@@ -322,25 +330,24 @@ void PairEAMOpt::eval()
         //   hence embed' = Fi(sum rho_ij) rhojp + Fj(sum rho_ji) rhoip
         // scale factor can be applied by thermodynamic integration
 
-        double recip = 1.0/r;
-        double phi = z2*recip;
-        double phip = z2p*recip - phi*recip;
-        double psip = fp[i]*rhojp + fp[j]*rhoip + phip;
-        double fpair = -scale_i[jtype]*psip*recip;
+        double recip = 1.0 / r;
+        double phi = z2 * recip;
+        double phip = z2p * recip - phi * recip;
+        double psip = fp[i] * rhojp + fp[j] * rhoip + phip;
+        double fpair = -scale_i[jtype] * psip * recip;
 
-        tmpfx += delx*fpair;
-        tmpfy += dely*fpair;
-        tmpfz += delz*fpair;
+        tmpfx += delx * fpair;
+        tmpfy += dely * fpair;
+        tmpfz += delz * fpair;
         if (NEWTON_PAIR || j < nlocal) {
-          ff[j].x -= delx*fpair;
-          ff[j].y -= dely*fpair;
-          ff[j].z -= delz*fpair;
+          ff[j].x -= delx * fpair;
+          ff[j].y -= dely * fpair;
+          ff[j].z -= delz * fpair;
         }
 
-        if (EFLAG) evdwl = scale_i[jtype]*phi;
+        if (EFLAG) evdwl = scale_i[jtype] * phi;
 
-        if (EVFLAG) ev_tally(i,j,nlocal,NEWTON_PAIR,
-                             evdwl,0.0,fpair,delx,dely,delz);
+        if (EVFLAG) ev_tally(i, j, nlocal, NEWTON_PAIR, evdwl, 0.0, fpair, delx, dely, delz);
       }
     }
 
@@ -349,8 +356,10 @@ void PairEAMOpt::eval()
     ff[i].z += tmpfz;
   }
 
-  free(fast_alpha); fast_alpha = nullptr;
-  free(fast_gamma); fast_gamma = nullptr;
+  free(fast_alpha);
+  fast_alpha = nullptr;
+  free(fast_gamma);
+  fast_gamma = nullptr;
 
   if (vflag_fdotr) virial_fdotr_compute();
 }

--- a/src/PHONON/fix_phonon.cpp
+++ b/src/PHONON/fix_phonon.cpp
@@ -126,6 +126,8 @@ FixPhonon::FixPhonon(LAMMPS *lmp,  int narg, char **arg) : Fix(lmp, narg, arg)
   surf2tag.clear();
 
   // get the mapping between lattice indices and atom IDs
+
+  atom->map_init();
   readmap();
   delete[] mapfile;
   if (nucell == 1) nasr = MIN(1,nasr);

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -1358,7 +1358,7 @@ void FixBondReact::superimpose_algorithm()
 
 
       int hang_catch = 0;
-      while (!(status == ACCEPT || status == REJECT)) {
+      while (status != ACCEPT && status != REJECT) {
 
         for (int i = 0; i < max_natoms; i++) {
           pioneers[i] = 0;
@@ -4176,7 +4176,7 @@ void FixBondReact::ReadConstraints(char *line, int myrxn)
       tmp[3] = 182.0;
       rv = sscanf(line,"%*s %s %s %s %s %lg %lg %lg %lg",strargs[0],strargs[1],
              strargs[2],strargs[3],&tmp[0],&tmp[1],&tmp[2],&tmp[3]);
-      if (!(rv == 6 || rv == 8)) error->one(FLERR, "Dihedral constraint is incorrectly formatted");
+      if (rv != 6 && rv != 8) error->one(FLERR, "Dihedral constraint is incorrectly formatted");
       readID(strargs[0], i, myrxn, 0);
       readID(strargs[1], i, myrxn, 1);
       readID(strargs[2], i, myrxn, 2);
@@ -4198,7 +4198,7 @@ void FixBondReact::ReadConstraints(char *line, int myrxn)
       constraints[i][myrxn].type = RMSD;
       strcpy(strargs[0],"0");
       rv = sscanf(line,"%*s %lg %s",&tmp[0],strargs[0]);
-      if (!(rv == 1 || rv == 2)) error->one(FLERR, "RMSD constraint is incorrectly formatted");
+      if (rv != 1 && rv != 2) error->one(FLERR, "RMSD constraint is incorrectly formatted");
       constraints[i][myrxn].par[0] = tmp[0]; // RMSDmax
       constraints[i][myrxn].id[0] = -1; // optional molecule fragment
       if (isalpha(strargs[0][0])) {

--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -804,7 +804,7 @@ Calculate ideal positions for parallel "ideal" or "equal"
 void FixNEB::calculate_ideal_positions()
 {
   // Skip unless "ideal" or "equal"
-  if (!((neb_mode == IDEAL) || (neb_mode == EQUAL))) return;
+  if ((neb_mode != IDEAL) && (neb_mode != EQUAL)) return;
 
   double lentot, lenuntilClimber;
   double meanDist, meanDistBeforeClimber, meanDistAfterClimber;

--- a/src/RIGID/fix_rattle.cpp
+++ b/src/RIGID/fix_rattle.cpp
@@ -831,10 +831,10 @@ bool FixRattle::check2(double **v, int m, bool checkr, bool checkv)
   domain->minimum_image(r01);
   MathExtra::sub3(v[i1],v[i0],v01);
 
-  stat = !(checkr && (fabs(sqrt(MathExtra::dot3(r01,r01)) - bond1) > tol));
+  stat = !checkr || (fabs(sqrt(MathExtra::dot3(r01,r01)) - bond1) <= tol);
   if (!stat) error->one(FLERR,"Coordinate constraints are not satisfied up to desired tolerance ");
 
-  stat = !(checkv && (fabs(MathExtra::dot3(r01,v01)) > tol));
+  stat = !checkv || (fabs(MathExtra::dot3(r01,v01)) <= tol);
   if (!stat) error->one(FLERR,"Velocity constraints are not satisfied up to desired tolerance ");
   return stat;
 }
@@ -863,12 +863,12 @@ bool FixRattle::check3(double **v, int m, bool checkr, bool checkv)
   MathExtra::sub3(v[i1],v[i0],v01);
   MathExtra::sub3(v[i2],v[i0],v02);
 
-  stat = !(checkr && (fabs(sqrt(MathExtra::dot3(r01,r01)) - bond1) > tol ||
-                      fabs(sqrt(MathExtra::dot3(r02,r02))-bond2) > tol));
+  stat = !checkr || (fabs(sqrt(MathExtra::dot3(r01,r01)) - bond1) <= tol &&
+                      fabs(sqrt(MathExtra::dot3(r02,r02))-bond2) <= tol);
   if (!stat) error->one(FLERR,"Coordinate constraints are not satisfied up to desired tolerance ");
 
-  stat = !(checkv && (fabs(MathExtra::dot3(r01,v01)) > tol ||
-                      fabs(MathExtra::dot3(r02,v02)) > tol));
+  stat = !checkv || (fabs(MathExtra::dot3(r01,v01)) <= tol &&
+                      fabs(MathExtra::dot3(r02,v02)) <= tol);
   if (!stat) error->one(FLERR,"Velocity constraints are not satisfied up to desired tolerance ");
   return stat;
 }
@@ -901,14 +901,14 @@ bool FixRattle::check4(double **v, int m, bool checkr, bool checkv)
   MathExtra::sub3(v[i2],v[i0],v02);
   MathExtra::sub3(v[i3],v[i0],v03);
 
-  stat = !(checkr && (fabs(sqrt(MathExtra::dot3(r01,r01)) - bond1) > tol ||
-                      fabs(sqrt(MathExtra::dot3(r02,r02))-bond2) > tol ||
-                      fabs(sqrt(MathExtra::dot3(r03,r03))-bond3) > tol));
+  stat = !checkr || (fabs(sqrt(MathExtra::dot3(r01,r01)) - bond1) <= tol &&
+                      fabs(sqrt(MathExtra::dot3(r02,r02))-bond2) <= tol &&
+                      fabs(sqrt(MathExtra::dot3(r03,r03))-bond3) <= tol);
   if (!stat) error->one(FLERR,"Coordinate constraints are not satisfied up to desired tolerance ");
 
-  stat = !(checkv && (fabs(MathExtra::dot3(r01,v01)) > tol ||
-                      fabs(MathExtra::dot3(r02,v02)) > tol ||
-                      fabs(MathExtra::dot3(r03,v03)) > tol));
+  stat = !checkv || (fabs(MathExtra::dot3(r01,v01)) <= tol &&
+                      fabs(MathExtra::dot3(r02,v02)) <= tol &&
+                      fabs(MathExtra::dot3(r03,v03)) <= tol);
   if (!stat) error->one(FLERR,"Velocity constraints are not satisfied up to desired tolerance ");
   return stat;
 }
@@ -944,7 +944,7 @@ bool FixRattle::check3angle(double **v, int m, bool checkr, bool checkv)
   double db2 = fabs(sqrt(MathExtra::dot3(r02,r02))-bond2);
   double db12 = fabs(sqrt(MathExtra::dot3(r12,r12))-bond12);
 
-  stat = !(checkr && (db1 > tol || db2 > tol || db12 > tol));
+  stat = !checkr || (db1 <= tol && db2 <= tol && db12 <= tol);
 
   if (derr_max < db1/bond1)    derr_max = db1/bond1;
   if (derr_max < db2/bond2)    derr_max = db2/bond2;
@@ -962,7 +962,7 @@ bool FixRattle::check3angle(double **v, int m, bool checkr, bool checkv)
   if (verr_max < dv2)    verr_max = dv2;
   if (verr_max < dv12)   verr_max = dv12;
 
-  stat = !(checkv && (dv1 > tol || dv2 > tol || dv12> tol));
+  stat = !checkv || (dv1 <= tol && dv2 <= tol && dv12<= tol);
 
 #if RATTLE_RAISE_ERROR
   if (!stat) error->one(FLERR,"Velocity constraints are not satisfied up to desired tolerance!");

--- a/src/atom_vec_ellipsoid.cpp
+++ b/src/atom_vec_ellipsoid.cpp
@@ -225,8 +225,7 @@ int AtomVecEllipsoid::unpack_border_bonus(int n, int first, double *buf)
   m = 0;
   last = first + n;
   for (i = first; i < last; i++) {
-    ellipsoid[i] = (int) ubuf(buf[m++]).i;
-    if (ellipsoid[i] == 0)
+    if (ubuf(buf[m++]).i == 0)
       ellipsoid[i] = -1;
     else {
       j = nlocal_bonus + nghost_bonus;
@@ -283,8 +282,7 @@ int AtomVecEllipsoid::unpack_exchange_bonus(int ilocal, double *buf)
 {
   int m = 0;
 
-  ellipsoid[ilocal] = (int) ubuf(buf[m++]).i;
-  if (ellipsoid[ilocal] == 0)
+  if (ubuf(buf[m++]).i == 0)
     ellipsoid[ilocal] = -1;
   else {
     if (nlocal_bonus == nmax_bonus) grow_bonus();

--- a/src/citeme.cpp
+++ b/src/citeme.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -16,26 +15,24 @@
 #include "comm.h"
 #include "universe.h"
 
-#include <functional>           // IWYU pragma: keep
+#include <functional>    // IWYU pragma: keep
 
 using namespace LAMMPS_NS;
 
 static const char cite_separator[] =
-  "CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE\n\n";
+    "CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE\n\n";
 
 static const char cite_nagline[] =
-  "Your simulation uses code contributions which should be cited:\n";
+    "Your simulation uses code contributions which should be cited:\n";
 
-static const char cite_file[] = "The {} {} lists these citations in "
-                                "BibTeX format.\n\n";
+static const char cite_file[] = "The {} {} lists these citations in BibTeX format.\n\n";
 
 // define hash function
 static std::hash<std::string> get_hash;
 
 /* ---------------------------------------------------------------------- */
 
-CiteMe::CiteMe(LAMMPS *lmp, int _screen, int _logfile, const char *_file)
-  : Pointers(lmp)
+CiteMe::CiteMe(LAMMPS *lmp, int _screen, int _logfile, const char *_file) : Pointers(lmp)
 {
   fp = nullptr;
   cs = new citeset();
@@ -47,13 +44,13 @@ CiteMe::CiteMe(LAMMPS *lmp, int _screen, int _logfile, const char *_file)
 
   if (_file && universe->me == 0) {
     citefile = _file;
-    fp = fopen(_file,"w");
+    fp = fopen(_file, "w");
     if (fp) {
-      fputs(cite_nagline,fp);
+      fputs(cite_nagline, fp);
       fflush(fp);
     } else {
-      utils::logmesg(lmp, "Unable to open citation file '" + citefile
-                     + "': " + utils::getsyserror() + "\n");
+      utils::logmesg(
+          lmp, "Unable to open citation file '" + citefile + "': " + utils::getsyserror() + "\n");
     }
   }
 }
@@ -83,7 +80,7 @@ void CiteMe::add(const std::string &reference)
   cs->insert(crc);
 
   if (fp) {
-    fputs(reference.c_str(),fp);
+    fputs(reference.c_str(), fp);
     fflush(fp);
   }
 
@@ -102,7 +99,7 @@ void CiteMe::add(const std::string &reference)
   }
 
   std::size_t found = reference.find_first_of('\n');
-  std::string header = reference.substr(0,found+1);
+  std::string header = reference.substr(0, found + 1);
   if (screen_flag == VERBOSE) scrbuffer += "- " + reference;
   if (screen_flag == TERSE) scrbuffer += "- " + header;
   if (logfile_flag == VERBOSE) logbuffer += "- " + reference;
@@ -113,23 +110,18 @@ void CiteMe::flush()
 {
   if (comm->me == 0) {
     if (!scrbuffer.empty()) {
-      if (!citefile.empty())
-        scrbuffer += fmt::format(cite_file,"file",citefile);
-      if (logfile_flag == VERBOSE)
-        scrbuffer += fmt::format(cite_file,"log","file");
+      if (!citefile.empty()) scrbuffer += fmt::format(cite_file, "file", citefile);
+      if (logfile_flag == VERBOSE) scrbuffer += fmt::format(cite_file, "log", "file");
       scrbuffer += cite_separator;
-      if (screen) fputs(scrbuffer.c_str(),screen);
+      if (screen) fputs(scrbuffer.c_str(), screen);
       scrbuffer.clear();
     }
     if (!logbuffer.empty()) {
-      if (!citefile.empty())
-        logbuffer += fmt::format(cite_file,"file",citefile);
-      if (screen_flag == VERBOSE)
-        logbuffer += fmt::format(cite_file,"screen","output");
+      if (!citefile.empty()) logbuffer += fmt::format(cite_file, "file", citefile);
+      if (screen_flag == VERBOSE) logbuffer += fmt::format(cite_file, "screen", "output");
       logbuffer += cite_separator;
-      if (logfile) fputs(logbuffer.c_str(),logfile);
+      if (logfile) fputs(logbuffer.c_str(), logfile);
       logbuffer.clear();
     }
   }
 }
-

--- a/src/compute_chunk.cpp
+++ b/src/compute_chunk.cpp
@@ -115,7 +115,7 @@ void ComputeChunk::lock_enable()
 void ComputeChunk::lock_disable()
 {
   cchunk = dynamic_cast<ComputeChunkAtom *>(modify->get_compute_by_id(idchunk));
-  if (!cchunk) cchunk->lockcount--;
+  if (cchunk) cchunk->lockcount--;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/compute_erotate_sphere_atom.cpp
+++ b/src/compute_erotate_sphere_atom.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories

--- a/src/compute_gyration.cpp
+++ b/src/compute_gyration.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -14,20 +13,19 @@
 
 #include "compute_gyration.h"
 
-#include "update.h"
 #include "atom.h"
-#include "group.h"
 #include "domain.h"
 #include "error.h"
+#include "group.h"
+#include "update.h"
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-ComputeGyration::ComputeGyration(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+ComputeGyration::ComputeGyration(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg)
 {
-  if (narg != 3) error->all(FLERR,"Illegal compute gyration command");
+  if (narg != 3) error->all(FLERR, "Illegal compute gyration command");
 
   scalar_flag = vector_flag = 1;
   size_vector = 6;
@@ -41,7 +39,7 @@ ComputeGyration::ComputeGyration(LAMMPS *lmp, int narg, char **arg) :
 
 ComputeGyration::~ComputeGyration()
 {
-  delete [] vector;
+  delete[] vector;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -59,8 +57,8 @@ double ComputeGyration::compute_scalar()
 
   double xcm[3];
   if (group->dynamic[igroup]) masstotal = group->mass(igroup);
-  group->xcm(igroup,masstotal,xcm);
-  scalar = group->gyration(igroup,masstotal,xcm);
+  group->xcm(igroup, masstotal, xcm);
+  scalar = group->gyration(igroup, masstotal, xcm);
   return scalar;
 }
 
@@ -75,7 +73,7 @@ void ComputeGyration::compute_vector()
   invoked_vector = update->ntimestep;
 
   double xcm[3];
-  group->xcm(igroup,masstotal,xcm);
+  group->xcm(igroup, masstotal, xcm);
 
   double **x = atom->x;
   int *mask = atom->mask;
@@ -85,7 +83,7 @@ void ComputeGyration::compute_vector()
   double *rmass = atom->rmass;
   int nlocal = atom->nlocal;
 
-  double dx,dy,dz,massone;
+  double dx, dy, dz, massone;
   double unwrap[3];
 
   double rg[6];
@@ -93,24 +91,25 @@ void ComputeGyration::compute_vector()
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      if (rmass) massone = rmass[i];
-      else massone = mass[type[i]];
+      if (rmass)
+        massone = rmass[i];
+      else
+        massone = mass[type[i]];
 
-      domain->unmap(x[i],image[i],unwrap);
+      domain->unmap(x[i], image[i], unwrap);
       dx = unwrap[0] - xcm[0];
       dy = unwrap[1] - xcm[1];
       dz = unwrap[2] - xcm[2];
 
-      rg[0] += dx*dx * massone;
-      rg[1] += dy*dy * massone;
-      rg[2] += dz*dz * massone;
-      rg[3] += dx*dy * massone;
-      rg[4] += dx*dz * massone;
-      rg[5] += dy*dz * massone;
+      rg[0] += dx * dx * massone;
+      rg[1] += dy * dy * massone;
+      rg[2] += dz * dz * massone;
+      rg[3] += dx * dy * massone;
+      rg[4] += dx * dz * massone;
+      rg[5] += dy * dz * massone;
     }
-  MPI_Allreduce(rg,vector,6,MPI_DOUBLE,MPI_SUM,world);
+  MPI_Allreduce(rg, vector, 6, MPI_DOUBLE, MPI_SUM, world);
 
   if (masstotal > 0.0)
-    for (int i = 0; i < 6; i++)
-      vector[i] /= masstotal;
+    for (int i = 0; i < 6; i++) vector[i] /= masstotal;
 }

--- a/src/compute_ke_atom.cpp
+++ b/src/compute_ke_atom.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,24 +12,23 @@
 ------------------------------------------------------------------------- */
 
 #include "compute_ke_atom.h"
-#include <cstring>
 #include "atom.h"
-#include "update.h"
-#include "modify.h"
 #include "comm.h"
+#include "error.h"
 #include "force.h"
 #include "memory.h"
-#include "error.h"
+#include "modify.h"
+#include "update.h"
+#include <cstring>
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
 ComputeKEAtom::ComputeKEAtom(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg),
-  ke(nullptr)
+    Compute(lmp, narg, arg), ke(nullptr)
 {
-  if (narg != 3) error->all(FLERR,"Illegal compute ke/atom command");
+  if (narg != 3) error->all(FLERR, "Illegal compute ke/atom command");
 
   peratom_flag = 1;
   size_peratom_cols = 0;
@@ -51,9 +49,8 @@ void ComputeKEAtom::init()
 {
   int count = 0;
   for (int i = 0; i < modify->ncompute; i++)
-    if (strcmp(modify->compute[i]->style,"ke/atom") == 0) count++;
-  if (count > 1 && comm->me == 0)
-    error->warning(FLERR,"More than one compute ke/atom");
+    if (strcmp(modify->compute[i]->style, "ke/atom") == 0) count++;
+  if (count > 1 && comm->me == 0) error->warning(FLERR, "More than one compute ke/atom");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -67,7 +64,7 @@ void ComputeKEAtom::compute_peratom()
   if (atom->nmax > nmax) {
     memory->destroy(ke);
     nmax = atom->nmax;
-    memory->create(ke,nmax,"ke/atom:ke");
+    memory->create(ke, nmax, "ke/atom:ke");
     vector_atom = ke;
   }
 
@@ -84,17 +81,19 @@ void ComputeKEAtom::compute_peratom()
   if (rmass)
     for (int i = 0; i < nlocal; i++) {
       if (mask[i] & groupbit) {
-        ke[i] = 0.5 * mvv2e * rmass[i] *
-          (v[i][0]*v[i][0] + v[i][1]*v[i][1] + v[i][2]*v[i][2]);
-      } else ke[i] = 0.0;
+        ke[i] =
+            0.5 * mvv2e * rmass[i] * (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]);
+      } else
+        ke[i] = 0.0;
     }
 
   else
     for (int i = 0; i < nlocal; i++) {
       if (mask[i] & groupbit) {
         ke[i] = 0.5 * mvv2e * mass[type[i]] *
-          (v[i][0]*v[i][0] + v[i][1]*v[i][1] + v[i][2]*v[i][2]);
-      } else ke[i] = 0.0;
+            (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]);
+      } else
+        ke[i] = 0.0;
     }
 }
 
@@ -104,6 +103,6 @@ void ComputeKEAtom::compute_peratom()
 
 double ComputeKEAtom::memory_usage()
 {
-  double bytes = (double)nmax * sizeof(double);
+  double bytes = (double) nmax * sizeof(double);
   return bytes;
 }

--- a/src/compute_pair.cpp
+++ b/src/compute_pair.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -24,15 +23,14 @@
 
 using namespace LAMMPS_NS;
 
-enum{EPAIR,EVDWL,ECOUL};
+enum { EPAIR, EVDWL, ECOUL };
 
 /* ---------------------------------------------------------------------- */
 
 ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg),
-  pstyle(nullptr), pair(nullptr), one(nullptr)
+    Compute(lmp, narg, arg), pstyle(nullptr), pair(nullptr), one(nullptr)
 {
-  if (narg < 4) error->all(FLERR,"Illegal compute pair command");
+  if (narg < 4) error->all(FLERR, "Illegal compute pair command");
 
   scalar_flag = 1;
   extscalar = 1;
@@ -41,8 +39,9 @@ ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
 
   // copy with suffix so we can later chop it off, if needed
   if (lmp->suffix)
-    pstyle = utils::strdup(fmt::format("{}/{}",arg[3],lmp->suffix));
-  else pstyle = utils::strdup(arg[3]);
+    pstyle = utils::strdup(fmt::format("{}/{}", arg[3], lmp->suffix));
+  else
+    pstyle = utils::strdup(arg[3]);
 
   int iarg = 4;
   nsub = 0;
@@ -50,31 +49,33 @@ ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
 
   if (narg > iarg) {
     if (isdigit(arg[iarg][0])) {
-      nsub = utils::inumeric(FLERR,arg[iarg],false,lmp);
+      nsub = utils::inumeric(FLERR, arg[iarg], false, lmp);
       ++iarg;
-      if (nsub <= 0)
-        error->all(FLERR,"Illegal compute pair command");
+      if (nsub <= 0) error->all(FLERR, "Illegal compute pair command");
     }
   }
 
-  if  (narg > iarg) {
-    if (strcmp(arg[iarg],"epair") == 0) evalue = EPAIR;
-    else if (strcmp(arg[iarg],"evdwl") == 0) evalue = EVDWL;
-    else if (strcmp(arg[iarg],"ecoul") == 0) evalue = ECOUL;
-    else error->all(FLERR, "Illegal compute pair command");
+  if (narg > iarg) {
+    if (strcmp(arg[iarg], "epair") == 0)
+      evalue = EPAIR;
+    else if (strcmp(arg[iarg], "evdwl") == 0)
+      evalue = EVDWL;
+    else if (strcmp(arg[iarg], "ecoul") == 0)
+      evalue = ECOUL;
+    else
+      error->all(FLERR, "Illegal compute pair command");
     ++iarg;
   }
 
   // check if pair style with and without suffix exists
 
-  pair = force->pair_match(pstyle,1,nsub);
+  pair = force->pair_match(pstyle, 1, nsub);
   if (!pair && lmp->suffix) {
     pstyle[strlen(pstyle) - strlen(lmp->suffix) - 1] = '\0';
-    pair = force->pair_match(pstyle,1,nsub);
+    pair = force->pair_match(pstyle, 1, nsub);
   }
 
-  if (!pair)
-    error->all(FLERR,"Unrecognized pair style in compute pair command");
+  if (!pair) error->all(FLERR, "Unrecognized pair style in compute pair command");
   npair = pair->nextra;
 
   if (npair) {
@@ -83,7 +84,8 @@ ComputePair::ComputePair(LAMMPS *lmp, int narg, char **arg) :
     extvector = 1;
     one = new double[npair];
     vector = new double[npair];
-  } else one = vector = nullptr;
+  } else
+    one = vector = nullptr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -101,9 +103,8 @@ void ComputePair::init()
 {
   // recheck for pair style in case it has been deleted
 
-  pair = force->pair_match(pstyle,1,nsub);
-  if (!pair)
-    error->all(FLERR,"Unrecognized pair style in compute pair command");
+  pair = force->pair_match(pstyle, 1, nsub);
+  if (!pair) error->all(FLERR, "Unrecognized pair style in compute pair command");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -112,14 +113,17 @@ double ComputePair::compute_scalar()
 {
   invoked_scalar = update->ntimestep;
   if (update->eflag_global != invoked_scalar)
-    error->all(FLERR,"Energy was not tallied on needed timestep");
+    error->all(FLERR, "Energy was not tallied on needed timestep");
 
   double eng;
-  if (evalue == EPAIR) eng = pair->eng_vdwl + pair->eng_coul;
-  else if (evalue == EVDWL) eng = pair->eng_vdwl;
-  else if (evalue == ECOUL) eng = pair->eng_coul;
+  if (evalue == EPAIR)
+    eng = pair->eng_vdwl + pair->eng_coul;
+  else if (evalue == EVDWL)
+    eng = pair->eng_vdwl;
+  else if (evalue == ECOUL)
+    eng = pair->eng_coul;
 
-  MPI_Allreduce(&eng,&scalar,1,MPI_DOUBLE,MPI_SUM,world);
+  MPI_Allreduce(&eng, &scalar, 1, MPI_DOUBLE, MPI_SUM, world);
   return scalar;
 }
 
@@ -129,9 +133,8 @@ void ComputePair::compute_vector()
 {
   invoked_vector = update->ntimestep;
   if (update->eflag_global != invoked_vector)
-    error->all(FLERR,"Energy was not tallied on needed timestep");
+    error->all(FLERR, "Energy was not tallied on needed timestep");
 
-  for (int i = 0; i < npair; i++)
-    one[i] = pair->pvector[i];
-  MPI_Allreduce(one,vector,npair,MPI_DOUBLE,MPI_SUM,world);
+  for (int i = 0; i < npair; i++) one[i] = pair->pvector[i];
+  MPI_Allreduce(one, vector, npair, MPI_DOUBLE, MPI_SUM, world);
 }

--- a/src/compute_temp.cpp
+++ b/src/compute_temp.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -15,20 +14,19 @@
 #include "compute_temp.h"
 
 #include "atom.h"
-#include "update.h"
-#include "force.h"
 #include "domain.h"
-#include "group.h"
 #include "error.h"
+#include "force.h"
+#include "group.h"
+#include "update.h"
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-ComputeTemp::ComputeTemp(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg)
+ComputeTemp::ComputeTemp(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg)
 {
-  if (narg != 3) error->all(FLERR,"Illegal compute temp command");
+  if (narg != 3) error->all(FLERR, "Illegal compute temp command");
 
   scalar_flag = vector_flag = 1;
   size_vector = 6;
@@ -43,8 +41,7 @@ ComputeTemp::ComputeTemp(LAMMPS *lmp, int narg, char **arg) :
 
 ComputeTemp::~ComputeTemp()
 {
-  if (!copymode)
-    delete [] vector;
+  if (!copymode) delete[] vector;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -64,8 +61,10 @@ void ComputeTemp::dof_compute()
   natoms_temp = group->count(igroup);
   dof = domain->dimension * natoms_temp;
   dof -= extra_dof + fix_dof;
-  if (dof > 0.0) tfactor = force->mvv2e / (dof * force->boltz);
-  else tfactor = 0.0;
+  if (dof > 0.0)
+    tfactor = force->mvv2e / (dof * force->boltz);
+  else
+    tfactor = 0.0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -86,18 +85,17 @@ double ComputeTemp::compute_scalar()
   if (rmass) {
     for (int i = 0; i < nlocal; i++)
       if (mask[i] & groupbit)
-        t += (v[i][0]*v[i][0] + v[i][1]*v[i][1] + v[i][2]*v[i][2]) * rmass[i];
+        t += (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]) * rmass[i];
   } else {
     for (int i = 0; i < nlocal; i++)
       if (mask[i] & groupbit)
-        t += (v[i][0]*v[i][0] + v[i][1]*v[i][1] + v[i][2]*v[i][2]) *
-          mass[type[i]];
+        t += (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]) * mass[type[i]];
   }
 
-  MPI_Allreduce(&t,&scalar,1,MPI_DOUBLE,MPI_SUM,world);
+  MPI_Allreduce(&t, &scalar, 1, MPI_DOUBLE, MPI_SUM, world);
   if (dynamic) dof_compute();
   if (dof < 0.0 && natoms_temp > 0.0)
-    error->all(FLERR,"Temperature compute degrees of freedom < 0");
+    error->all(FLERR, "Temperature compute degrees of freedom < 0");
   scalar *= tfactor;
   return scalar;
 }
@@ -117,21 +115,23 @@ void ComputeTemp::compute_vector()
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
 
-  double massone,t[6];
+  double massone, t[6];
   for (i = 0; i < 6; i++) t[i] = 0.0;
 
   for (i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      if (rmass) massone = rmass[i];
-      else massone = mass[type[i]];
-      t[0] += massone * v[i][0]*v[i][0];
-      t[1] += massone * v[i][1]*v[i][1];
-      t[2] += massone * v[i][2]*v[i][2];
-      t[3] += massone * v[i][0]*v[i][1];
-      t[4] += massone * v[i][0]*v[i][2];
-      t[5] += massone * v[i][1]*v[i][2];
+      if (rmass)
+        massone = rmass[i];
+      else
+        massone = mass[type[i]];
+      t[0] += massone * v[i][0] * v[i][0];
+      t[1] += massone * v[i][1] * v[i][1];
+      t[2] += massone * v[i][2] * v[i][2];
+      t[3] += massone * v[i][0] * v[i][1];
+      t[4] += massone * v[i][0] * v[i][2];
+      t[5] += massone * v[i][1] * v[i][2];
     }
 
-  MPI_Allreduce(t,vector,6,MPI_DOUBLE,MPI_SUM,world);
+  MPI_Allreduce(t, vector, 6, MPI_DOUBLE, MPI_SUM, world);
   for (i = 0; i < 6; i++) vector[i] *= force->mvv2e;
 }

--- a/src/compute_vacf.cpp
+++ b/src/compute_vacf.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -15,20 +14,20 @@
 #include "compute_vacf.h"
 
 #include "atom.h"
-#include "update.h"
+#include "error.h"
+#include "fix_store_atom.h"
 #include "group.h"
 #include "modify.h"
-#include "fix_store_atom.h"
-#include "error.h"
+#include "update.h"
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
 ComputeVACF::ComputeVACF(LAMMPS *lmp, int narg, char **arg) :
-  Compute(lmp, narg, arg), id_fix(nullptr)
+    Compute(lmp, narg, arg), id_fix(nullptr)
 {
-  if (narg < 3) error->all(FLERR,"Illegal compute vacf command");
+  if (narg < 3) error->all(FLERR, "Illegal compute vacf command");
 
   vector_flag = 1;
   size_vector = 4;
@@ -40,12 +39,13 @@ ComputeVACF::ComputeVACF(LAMMPS *lmp, int narg, char **arg) :
 
   id_fix = utils::strdup(id + std::string("_COMPUTE_STORE"));
   fix = dynamic_cast<FixStoreAtom *>(
-    modify->add_fix(fmt::format("{} {} STORE/ATOM 3 0 0 1", id_fix, group->names[igroup])));
+      modify->add_fix(fmt::format("{} {} STORE/ATOM 3 0 0 1", id_fix, group->names[igroup])));
 
   // store current velocities in fix store array
   // skip if reset from restart file
 
-  if (fix->restart_reset) fix->restart_reset = 0;
+  if (fix->restart_reset)
+    fix->restart_reset = 0;
   else {
     double **voriginal = fix->astore;
 
@@ -58,7 +58,8 @@ ComputeVACF::ComputeVACF(LAMMPS *lmp, int narg, char **arg) :
         voriginal[i][0] = v[i][0];
         voriginal[i][1] = v[i][1];
         voriginal[i][2] = v[i][2];
-      } else voriginal[i][0] = voriginal[i][1] = voriginal[i][2] = 0.0;
+      } else
+        voriginal[i][0] = voriginal[i][1] = voriginal[i][2] = 0.0;
   }
 
   // displacement vector
@@ -74,8 +75,8 @@ ComputeVACF::~ComputeVACF()
 
   if (modify->nfix) modify->delete_fix(id_fix);
 
-  delete [] id_fix;
-  delete [] vector;
+  delete[] id_fix;
+  delete[] vector;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -85,7 +86,7 @@ void ComputeVACF::init()
   // set fix which stores original atom velocities
 
   fix = dynamic_cast<FixStoreAtom *>(modify->get_fix_by_id(id_fix));
-  if (!fix) error->all(FLERR,"Could not find compute vacf fix ID {}", id_fix);
+  if (!fix) error->all(FLERR, "Could not find compute vacf fix ID {}", id_fix);
 
   // nvacf = # of atoms in group
 
@@ -104,7 +105,7 @@ void ComputeVACF::compute_vector()
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
 
-  double vxsq,vysq,vzsq;
+  double vxsq, vysq, vzsq;
   double vacf[4];
   vacf[0] = vacf[1] = vacf[2] = vacf[3] = 0.0;
 
@@ -119,7 +120,7 @@ void ComputeVACF::compute_vector()
       vacf[3] += vxsq + vysq + vzsq;
     }
 
-  MPI_Allreduce(vacf,vector,4,MPI_DOUBLE,MPI_SUM,world);
+  MPI_Allreduce(vacf, vector, 4, MPI_DOUBLE, MPI_SUM, world);
   if (nvacf) {
     vector[0] /= nvacf;
     vector[1] /= nvacf;
@@ -140,4 +141,3 @@ void ComputeVACF::set_arrays(int i)
   voriginal[i][1] = v[i][1];
   voriginal[i][2] = v[i][2];
 }
-

--- a/src/dihedral_zero.cpp
+++ b/src/dihedral_zero.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -37,28 +36,27 @@ DihedralZero::DihedralZero(LAMMPS *lmp) : Dihedral(lmp), coeffflag(1)
 
 DihedralZero::~DihedralZero()
 {
-  if (allocated && !copymode) {
-    memory->destroy(setflag);
-  }
+  if (allocated && !copymode) memory->destroy(setflag);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void DihedralZero::compute(int eflag, int vflag)
 {
-  ev_init(eflag,vflag);
+  ev_init(eflag, vflag);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void DihedralZero::settings(int narg, char **arg)
 {
-  if ((narg != 0) && (narg != 1))
-    error->all(FLERR,"Illegal dihedral_style command");
+  if ((narg != 0) && (narg != 1)) error->all(FLERR, "Illegal dihedral_style command");
 
   if (narg == 1) {
-    if (strcmp("nocoeff",arg[0]) == 0) coeffflag=0;
-    else error->all(FLERR,"Illegal dihedral_style command");
+    if (strcmp("nocoeff", arg[0]) == 0)
+      coeffflag = 0;
+    else
+      error->all(FLERR, "Illegal dihedral_style command");
   }
 }
 
@@ -69,7 +67,7 @@ void DihedralZero::allocate()
   allocated = 1;
   int n = atom->ndihedraltypes;
 
-  memory->create(setflag,n+1,"dihedral:setflag");
+  memory->create(setflag, n + 1, "dihedral:setflag");
   for (int i = 1; i <= n; i++) setflag[i] = 0;
 }
 
@@ -80,12 +78,12 @@ void DihedralZero::allocate()
 void DihedralZero::coeff(int narg, char **arg)
 {
   if ((narg < 1) || (coeffflag && narg > 1))
-    error->all(FLERR,"Incorrect args for dihedral coefficients");
+    error->all(FLERR, "Incorrect args for dihedral coefficients");
 
   if (!allocated) allocate();
 
-  int ilo,ihi;
-  utils::bounds(FLERR,arg[0],1,atom->ndihedraltypes,ilo,ihi,error);
+  int ilo, ihi;
+  utils::bounds(FLERR, arg[0], 1, atom->ndihedraltypes, ilo, ihi, error);
 
   int count = 0;
   for (int i = ilo; i <= ihi; i++) {
@@ -93,7 +91,7 @@ void DihedralZero::coeff(int narg, char **arg)
     count++;
   }
 
-  if (count == 0) error->all(FLERR,"Incorrect args for dihedral coefficients");
+  if (count == 0) error->all(FLERR, "Incorrect args for dihedral coefficients");
 }
 
 /* ----------------------------------------------------------------------
@@ -116,7 +114,7 @@ void DihedralZero::read_restart(FILE * /*fp*/)
    proc 0 writes to data file
 ------------------------------------------------------------------------- */
 
-void DihedralZero::write_data(FILE *fp) {
-  for (int i = 1; i <= atom->ndihedraltypes; i++)
-    fprintf(fp,"%d\n",i);
+void DihedralZero::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->ndihedraltypes; i++) fprintf(fp, "%d\n", i);
 }

--- a/src/dump_movie.cpp
+++ b/src/dump_movie.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -27,11 +26,9 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-DumpMovie::DumpMovie(LAMMPS *lmp, int narg, char **arg) :
-  DumpImage(lmp, narg, arg)
+DumpMovie::DumpMovie(LAMMPS *lmp, int narg, char **arg) : DumpImage(lmp, narg, arg)
 {
-  if (multiproc || compressed || multifile)
-    error->all(FLERR,"Invalid dump movie filename");
+  if (multiproc || compressed || multifile) error->all(FLERR, "Invalid dump movie filename");
 
   filetype = PPM;
   bitrate = 2000;
@@ -55,15 +52,15 @@ void DumpMovie::openfile()
 
 #ifdef LAMMPS_FFMPEG
     auto moviecmd = fmt::format("ffmpeg -v error -y -r {:.2f} -f image2pipe -c:v ppm -i - "
-                                "-r 24.0 -b:v {}k {}", framerate, bitrate, filename);
-    fp = platform::popen(moviecmd,"w");
+                                "-r 24.0 -b:v {}k {}",
+                                framerate, bitrate, filename);
+    fp = platform::popen(moviecmd, "w");
 #else
     fp = nullptr;
-    error->one(FLERR,"Support for writing movies not included");
+    error->one(FLERR, "Support for writing movies not included");
 #endif
 
-    if (fp == nullptr)
-      error->one(FLERR,"Failed to open FFmpeg pipeline to file {}",filename);
+    if (fp == nullptr) error->one(FLERR, "Failed to open FFmpeg pipeline to file {}", filename);
   }
 }
 /* ---------------------------------------------------------------------- */
@@ -81,21 +78,21 @@ void DumpMovie::init_style()
 
 int DumpMovie::modify_param(int narg, char **arg)
 {
-  int n = DumpImage::modify_param(narg,arg);
+  int n = DumpImage::modify_param(narg, arg);
   if (n) return n;
 
-  if (strcmp(arg[0],"bitrate") == 0) {
-    if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
-    bitrate = utils::inumeric(FLERR,arg[1],false,lmp);
-    if (bitrate <= 0.0) error->all(FLERR,"Illegal dump_modify command");
+  if (strcmp(arg[0], "bitrate") == 0) {
+    if (narg < 2) error->all(FLERR, "Illegal dump_modify command");
+    bitrate = utils::inumeric(FLERR, arg[1], false, lmp);
+    if (bitrate <= 0.0) error->all(FLERR, "Illegal dump_modify command");
     return 2;
   }
 
-  if (strcmp(arg[0],"framerate") == 0) {
-    if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
-    framerate = utils::numeric(FLERR,arg[1],false,lmp);
+  if (strcmp(arg[0], "framerate") == 0) {
+    if (narg < 2) error->all(FLERR, "Illegal dump_modify command");
+    framerate = utils::numeric(FLERR, arg[1], false, lmp);
     if ((framerate <= 0.1) || (framerate > 24.0))
-      error->all(FLERR,"Illegal dump_modify framerate command");
+      error->all(FLERR, "Illegal dump_modify framerate command");
     return 2;
   }
 

--- a/src/fix_lineforce.cpp
+++ b/src/fix_lineforce.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -26,18 +25,17 @@ using namespace FixConst;
 
 /* ---------------------------------------------------------------------- */
 
-FixLineForce::FixLineForce(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg)
+FixLineForce::FixLineForce(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
 {
   dynamic_group_allow = 1;
 
-  if (narg != 6) error->all(FLERR,"Illegal fix lineforce command");
-  xdir = utils::numeric(FLERR,arg[3],false,lmp);
-  ydir = utils::numeric(FLERR,arg[4],false,lmp);
-  zdir = utils::numeric(FLERR,arg[5],false,lmp);
+  if (narg != 6) error->all(FLERR, "Illegal fix lineforce command");
+  xdir = utils::numeric(FLERR, arg[3], false, lmp);
+  ydir = utils::numeric(FLERR, arg[4], false, lmp);
+  zdir = utils::numeric(FLERR, arg[5], false, lmp);
 
-  double len = sqrt(xdir*xdir + ydir*ydir + zdir*zdir);
-  if (len == 0.0) error->all(FLERR,"Illegal fix lineforce command");
+  double len = sqrt(xdir * xdir + ydir * ydir + zdir * zdir);
+  if (len == 0.0) error->all(FLERR, "Illegal fix lineforce command");
 
   xdir /= len;
   ydir /= len;
@@ -59,13 +57,13 @@ int FixLineForce::setmask()
 
 void FixLineForce::setup(int vflag)
 {
-  if (utils::strmatch(update->integrate_style,"^verlet"))
+  if (utils::strmatch(update->integrate_style, "^verlet"))
     post_force(vflag);
   else {
     int nlevels_respa = (dynamic_cast<Respa *>(update->integrate))->nlevels;
     for (int ilevel = 0; ilevel < nlevels_respa; ilevel++) {
       (dynamic_cast<Respa *>(update->integrate))->copy_flevel_f(ilevel);
-      post_force_respa(vflag,ilevel,0);
+      post_force_respa(vflag, ilevel, 0);
       (dynamic_cast<Respa *>(update->integrate))->copy_f_flevel(ilevel);
     }
   }
@@ -89,7 +87,7 @@ void FixLineForce::post_force(int /*vflag*/)
   double dot;
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      dot = f[i][0]*xdir + f[i][1]*ydir + f[i][2]*zdir;
+      dot = f[i][0] * xdir + f[i][1] * ydir + f[i][2] * zdir;
       f[i][0] = dot * xdir;
       f[i][1] = dot * ydir;
       f[i][2] = dot * zdir;

--- a/src/fix_planeforce.cpp
+++ b/src/fix_planeforce.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -26,18 +25,17 @@ using namespace FixConst;
 
 /* ---------------------------------------------------------------------- */
 
-FixPlaneForce::FixPlaneForce(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg)
+FixPlaneForce::FixPlaneForce(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
 {
   dynamic_group_allow = 1;
 
-  if (narg != 6) error->all(FLERR,"Illegal fix planeforce command");
-  xdir = utils::numeric(FLERR,arg[3],false,lmp);
-  ydir = utils::numeric(FLERR,arg[4],false,lmp);
-  zdir = utils::numeric(FLERR,arg[5],false,lmp);
+  if (narg != 6) error->all(FLERR, "Illegal fix planeforce command");
+  xdir = utils::numeric(FLERR, arg[3], false, lmp);
+  ydir = utils::numeric(FLERR, arg[4], false, lmp);
+  zdir = utils::numeric(FLERR, arg[5], false, lmp);
 
-  double len = sqrt(xdir*xdir + ydir*ydir + zdir*zdir);
-  if (len == 0.0) error->all(FLERR,"Illegal fix planeforce command");
+  double len = sqrt(xdir * xdir + ydir * ydir + zdir * zdir);
+  if (len == 0.0) error->all(FLERR, "Illegal fix planeforce command");
 
   xdir /= len;
   ydir /= len;
@@ -59,13 +57,13 @@ int FixPlaneForce::setmask()
 
 void FixPlaneForce::setup(int vflag)
 {
-  if (utils::strmatch(update->integrate_style,"^verlet"))
+  if (utils::strmatch(update->integrate_style, "^verlet"))
     post_force(vflag);
   else {
     int nlevels_respa = (dynamic_cast<Respa *>(update->integrate))->nlevels;
     for (int ilevel = 0; ilevel < nlevels_respa; ilevel++) {
       (dynamic_cast<Respa *>(update->integrate))->copy_flevel_f(ilevel);
-      post_force_respa(vflag,ilevel,0);
+      post_force_respa(vflag, ilevel, 0);
       (dynamic_cast<Respa *>(update->integrate))->copy_f_flevel(ilevel);
     }
   }
@@ -89,7 +87,7 @@ void FixPlaneForce::post_force(int /*vflag*/)
   double dot;
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      dot = f[i][0]*xdir + f[i][1]*ydir + f[i][2]*zdir;
+      dot = f[i][0] * xdir + f[i][1] * ydir + f[i][2] * zdir;
       f[i][0] -= dot * xdir;
       f[i][1] -= dot * ydir;
       f[i][2] -= dot * zdir;

--- a/src/fix_read_restart.cpp
+++ b/src/fix_read_restart.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -23,11 +22,10 @@ using namespace FixConst;
 /* ---------------------------------------------------------------------- */
 
 FixReadRestart::FixReadRestart(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg),
-  count(nullptr), extra(nullptr)
+    Fix(lmp, narg, arg), count(nullptr), extra(nullptr)
 {
-  nextra = utils::inumeric(FLERR,arg[3],false,lmp);
-  int nfix = utils::inumeric(FLERR,arg[4],false,lmp);
+  nextra = utils::inumeric(FLERR, arg[3], false, lmp);
+  int nfix = utils::inumeric(FLERR, arg[4], false, lmp);
 
   // perform initial allocation of atom-based array
   // register with Atom class
@@ -39,11 +37,11 @@ FixReadRestart::FixReadRestart(LAMMPS *lmp, int narg, char **arg) :
 
   double **atom_extra = atom->extra;
   int nlocal = atom->nlocal;
-  int i,j,m;
+  int i, j, m;
 
   for (i = 0; i < nlocal; i++) {
     m = 0;
-    for (j = 0; j < nfix; j++) m += static_cast<int> (atom_extra[i][m]);
+    for (j = 0; j < nfix; j++) m += static_cast<int>(atom_extra[i][m]);
     count[i] = m;
     for (j = 0; j < m; j++) extra[i][j] = atom_extra[i][j];
   }
@@ -55,7 +53,7 @@ FixReadRestart::~FixReadRestart()
 {
   // unregister callback to this fix from Atom class
 
-  atom->delete_callback(id,Atom::GROW);
+  atom->delete_callback(id, Atom::GROW);
 
   // delete locally stored arrays
 
@@ -77,8 +75,8 @@ int FixReadRestart::setmask()
 
 double FixReadRestart::memory_usage()
 {
-  double bytes = (double)atom->nmax*nextra * sizeof(double);
-  bytes += (double)atom->nmax * sizeof(int);
+  double bytes = (double) atom->nmax * nextra * sizeof(double);
+  bytes += (double) atom->nmax * sizeof(int);
   return bytes;
 }
 
@@ -88,8 +86,8 @@ double FixReadRestart::memory_usage()
 
 void FixReadRestart::grow_arrays(int nmax)
 {
-  memory->grow(count,nmax,"read_restart:count");
-  memory->grow(extra,nmax,nextra,"read_restart:extra");
+  memory->grow(count, nmax, "read_restart:count");
+  memory->grow(extra, nmax, nextra, "read_restart:extra");
 }
 
 /* ----------------------------------------------------------------------
@@ -109,8 +107,8 @@ void FixReadRestart::copy_arrays(int i, int j, int /*delflag*/)
 int FixReadRestart::pack_exchange(int i, double *buf)
 {
   buf[0] = count[i];
-  for (int m = 0; m < count[i]; m++) buf[m+1] = extra[i][m];
-  return count[i]+1;
+  for (int m = 0; m < count[i]; m++) buf[m + 1] = extra[i][m];
+  return count[i] + 1;
 }
 
 /* ----------------------------------------------------------------------
@@ -119,7 +117,7 @@ int FixReadRestart::pack_exchange(int i, double *buf)
 
 int FixReadRestart::unpack_exchange(int nlocal, double *buf)
 {
-  count[nlocal] = static_cast<int> (buf[0]);
-  for (int m = 0; m < count[nlocal]; m++) extra[nlocal][m] = buf[m+1];
-  return count[nlocal]+1;
+  count[nlocal] = static_cast<int>(buf[0]);
+  for (int m = 0; m < count[nlocal]; m++) extra[nlocal][m] = buf[m + 1];
+  return count[nlocal] + 1;
 }

--- a/src/fix_store_force.cpp
+++ b/src/fix_store_force.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -26,25 +25,23 @@ using namespace FixConst;
 /* ---------------------------------------------------------------------- */
 
 FixStoreForce::FixStoreForce(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg),
-  foriginal(nullptr)
+    Fix(lmp, narg, arg), foriginal(nullptr)
 {
-  if (narg < 3) error->all(FLERR,"Illegal fix store/force command");
+  if (narg < 3) error->all(FLERR, "Illegal fix store/force command");
 
   peratom_flag = 1;
   size_peratom_cols = 3;
   peratom_freq = 1;
 
   nmax = atom->nmax;
-  memory->create(foriginal,nmax,3,"store/force:foriginal");
+  memory->create(foriginal, nmax, 3, "store/force:foriginal");
   array_atom = foriginal;
 
   // zero the array since dump may access it on timestep 0
   // zero the array since a variable may access it before first run
 
   int nlocal = atom->nlocal;
-  for (int i = 0; i < nlocal; i++)
-    foriginal[i][0] = foriginal[i][1] = foriginal[i][2] = 0.0;
+  for (int i = 0; i < nlocal; i++) foriginal[i][0] = foriginal[i][1] = foriginal[i][2] = 0.0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -69,7 +66,7 @@ int FixStoreForce::setmask()
 
 void FixStoreForce::init()
 {
-  if (utils::strmatch(update->integrate_style,"^respa"))
+  if (utils::strmatch(update->integrate_style, "^respa"))
     nlevels_respa = (dynamic_cast<Respa *>(update->integrate))->nlevels;
 }
 
@@ -77,12 +74,12 @@ void FixStoreForce::init()
 
 void FixStoreForce::setup(int vflag)
 {
-  if (utils::strmatch(update->integrate_style,"^verlet"))
+  if (utils::strmatch(update->integrate_style, "^verlet"))
     post_force(vflag);
   else {
-    (dynamic_cast<Respa *>(update->integrate))->copy_flevel_f(nlevels_respa-1);
-    post_force_respa(vflag,nlevels_respa-1,0);
-    (dynamic_cast<Respa *>(update->integrate))->copy_f_flevel(nlevels_respa-1);
+    (dynamic_cast<Respa *>(update->integrate))->copy_flevel_f(nlevels_respa - 1);
+    post_force_respa(vflag, nlevels_respa - 1, 0);
+    (dynamic_cast<Respa *>(update->integrate))->copy_f_flevel(nlevels_respa - 1);
   }
 }
 
@@ -100,7 +97,7 @@ void FixStoreForce::post_force(int /*vflag*/)
   if (atom->nmax > nmax) {
     nmax = atom->nmax;
     memory->destroy(foriginal);
-    memory->create(foriginal,nmax,3,"store/force:foriginal");
+    memory->create(foriginal, nmax, 3, "store/force:foriginal");
     array_atom = foriginal;
   }
 
@@ -113,14 +110,15 @@ void FixStoreForce::post_force(int /*vflag*/)
       foriginal[i][0] = f[i][0];
       foriginal[i][1] = f[i][1];
       foriginal[i][2] = f[i][2];
-    } else foriginal[i][0] = foriginal[i][1] = foriginal[i][2] = 0.0;
+    } else
+      foriginal[i][0] = foriginal[i][1] = foriginal[i][2] = 0.0;
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixStoreForce::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
-  if (ilevel == nlevels_respa-1) post_force(vflag);
+  if (ilevel == nlevels_respa - 1) post_force(vflag);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -136,6 +134,6 @@ void FixStoreForce::min_post_force(int vflag)
 
 double FixStoreForce::memory_usage()
 {
-  double bytes = (double)atom->nmax*3 * sizeof(double);
+  double bytes = (double) atom->nmax * 3 * sizeof(double);
   return bytes;
 }

--- a/src/fix_viscous.cpp
+++ b/src/fix_viscous.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -26,31 +25,29 @@ using namespace FixConst;
 
 /* ---------------------------------------------------------------------- */
 
-FixViscous::FixViscous(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg),
-  gamma(nullptr)
+FixViscous::FixViscous(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg), gamma(nullptr)
 {
   dynamic_group_allow = 1;
 
-  if (narg < 4) error->all(FLERR,"Illegal fix viscous command");
+  if (narg < 4) error->all(FLERR, "Illegal fix viscous command");
 
-  double gamma_one = utils::numeric(FLERR,arg[3],false,lmp);
-  gamma = new double[atom->ntypes+1];
+  double gamma_one = utils::numeric(FLERR, arg[3], false, lmp);
+  gamma = new double[atom->ntypes + 1];
   for (int i = 1; i <= atom->ntypes; i++) gamma[i] = gamma_one;
 
   // optional args
 
   int iarg = 4;
   while (iarg < narg) {
-    if (strcmp(arg[iarg],"scale") == 0) {
-      if (iarg+3 > narg) error->all(FLERR,"Illegal fix viscous command");
-      int itype = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
-      double scale = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      if (itype <= 0 || itype > atom->ntypes)
-        error->all(FLERR,"Illegal fix viscous command");
+    if (strcmp(arg[iarg], "scale") == 0) {
+      if (iarg + 3 > narg) error->all(FLERR, "Illegal fix viscous command");
+      int itype = utils::inumeric(FLERR, arg[iarg + 1], false, lmp);
+      double scale = utils::numeric(FLERR, arg[iarg + 2], false, lmp);
+      if (itype <= 0 || itype > atom->ntypes) error->all(FLERR, "Illegal fix viscous command");
       gamma[itype] = gamma_one * scale;
       iarg += 3;
-    } else error->all(FLERR,"Illegal fix viscous command");
+    } else
+      error->all(FLERR, "Illegal fix viscous command");
   }
 
   respa_level_support = 1;
@@ -63,7 +60,7 @@ FixViscous::~FixViscous()
 {
   if (copymode) return;
 
-  delete [] gamma;
+  delete[] gamma;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -83,9 +80,9 @@ void FixViscous::init()
 {
   int max_respa = 0;
 
-  if (utils::strmatch(update->integrate_style,"^respa")) {
-    ilevel_respa = max_respa = (dynamic_cast<Respa *>(update->integrate))->nlevels-1;
-    if (respa_level >= 0) ilevel_respa = MIN(respa_level,max_respa);
+  if (utils::strmatch(update->integrate_style, "^respa")) {
+    ilevel_respa = max_respa = (dynamic_cast<Respa *>(update->integrate))->nlevels - 1;
+    if (respa_level >= 0) ilevel_respa = MIN(respa_level, max_respa);
   }
 }
 
@@ -93,11 +90,11 @@ void FixViscous::init()
 
 void FixViscous::setup(int vflag)
 {
-  if (utils::strmatch(update->integrate_style,"^verlet"))
+  if (utils::strmatch(update->integrate_style, "^verlet"))
     post_force(vflag);
   else {
     (dynamic_cast<Respa *>(update->integrate))->copy_flevel_f(ilevel_respa);
-    post_force_respa(vflag,ilevel_respa,0);
+    post_force_respa(vflag, ilevel_respa, 0);
     (dynamic_cast<Respa *>(update->integrate))->copy_f_flevel(ilevel_respa);
   }
 }
@@ -128,9 +125,9 @@ void FixViscous::post_force(int /*vflag*/)
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
       drag = gamma[type[i]];
-      f[i][0] -= drag*v[i][0];
-      f[i][1] -= drag*v[i][1];
-      f[i][2] -= drag*v[i][2];
+      f[i][0] -= drag * v[i][0];
+      f[i][1] -= drag * v[i][1];
+      f[i][2] -= drag * v[i][2];
     }
 }
 

--- a/src/fix_wall_lj1043.cpp
+++ b/src/fix_wall_lj1043.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -17,17 +16,18 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_wall_lj1043.h"
-#include <cmath>
+
 #include "atom.h"
 #include "math_const.h"
+
+#include <cmath>
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
 /* ---------------------------------------------------------------------- */
 
-FixWallLJ1043::FixWallLJ1043(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg)
+FixWallLJ1043::FixWallLJ1043(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, narg, arg)
 {
   dynamic_group_allow = 1;
 }
@@ -36,26 +36,26 @@ FixWallLJ1043::FixWallLJ1043(LAMMPS *lmp, int narg, char **arg) :
 
 void FixWallLJ1043::precompute(int m)
 {
-  coeff1[m] = MY_2PI * 2.0/5.0 * epsilon[m] * pow(sigma[m],10.0);
-  coeff2[m] = MY_2PI * epsilon[m] * pow(sigma[m],4.0);
-  coeff3[m] = MY_2PI * pow(2.0,1/2.0) / 3 * epsilon[m] * pow(sigma[m],3.0);
-  coeff4[m] = 0.61 / pow(2.0,1/2.0) * sigma[m];
+  coeff1[m] = MY_2PI * 2.0 / 5.0 * epsilon[m] * pow(sigma[m], 10.0);
+  coeff2[m] = MY_2PI * epsilon[m] * pow(sigma[m], 4.0);
+  coeff3[m] = MY_2PI * pow(2.0, 1 / 2.0) / 3 * epsilon[m] * pow(sigma[m], 3.0);
+  coeff4[m] = 0.61 / pow(2.0, 1 / 2.0) * sigma[m];
   coeff5[m] = coeff1[m] * 10.0;
   coeff6[m] = coeff2[m] * 4.0;
   coeff7[m] = coeff3[m] * 3.0;
 
-  double rinv = 1.0/cutoff[m];
-  double r2inv = rinv*rinv;
-  double r4inv = r2inv*r2inv;
-  offset[m] = coeff1[m]*r4inv*r4inv*r2inv - coeff2[m]*r4inv -
-        coeff3[m]*pow(cutoff[m]+coeff4[m],-3.0);
+  double rinv = 1.0 / cutoff[m];
+  double r2inv = rinv * rinv;
+  double r4inv = r2inv * r2inv;
+  offset[m] = coeff1[m] * r4inv * r4inv * r2inv - coeff2[m] * r4inv -
+      coeff3[m] * pow(cutoff[m] + coeff4[m], -3.0);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixWallLJ1043::wall_particle(int m, int which, double coord)
 {
-  double delta,rinv,r2inv,r4inv,r10inv,fwall;
+  double delta, rinv, r2inv, r4inv, r10inv, fwall;
   double vn;
 
   double **x = atom->x;
@@ -69,25 +69,30 @@ void FixWallLJ1043::wall_particle(int m, int which, double coord)
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      if (side < 0) delta = x[i][dim] - coord;
-      else delta = coord - x[i][dim];
+      if (side < 0)
+        delta = x[i][dim] - coord;
+      else
+        delta = coord - x[i][dim];
       if (delta <= 0.0) continue;
       if (delta > cutoff[m]) continue;
-      rinv = 1.0/delta;
-      r2inv = rinv*rinv;
-      r4inv = r2inv*r2inv;
-      r10inv = r4inv*r4inv*r2inv;
+      rinv = 1.0 / delta;
+      r2inv = rinv * rinv;
+      r4inv = r2inv * r2inv;
+      r10inv = r4inv * r4inv * r2inv;
 
-      fwall = side * (coeff5[m]*r10inv*rinv - coeff6[m]*r4inv*rinv -
-        coeff7[m]*pow(delta+coeff4[m],-4.0));
+      fwall = side *
+          (coeff5[m] * r10inv * rinv - coeff6[m] * r4inv * rinv -
+           coeff7[m] * pow(delta + coeff4[m], -4.0));
       f[i][dim] -= fwall;
-      ewall[0] += coeff1[m]*r10inv - coeff2[m]*r4inv -
-        coeff3[m]*pow(delta+coeff4[m],-3.0) - offset[m];
-      ewall[m+1] += fwall;
+      ewall[0] += coeff1[m] * r10inv - coeff2[m] * r4inv -
+          coeff3[m] * pow(delta + coeff4[m], -3.0) - offset[m];
+      ewall[m + 1] += fwall;
 
       if (evflag) {
-        if (side < 0) vn = -fwall*delta;
-        else vn = fwall*delta;
+        if (side < 0)
+          vn = -fwall * delta;
+        else
+          vn = fwall * delta;
         v_tally(dim, i, vn);
       }
     }

--- a/src/fix_wall_lj1043.cpp
+++ b/src/fix_wall_lj1043.cpp
@@ -19,11 +19,13 @@
 
 #include "atom.h"
 #include "math_const.h"
+#include "math_special.h"
 
 #include <cmath>
 
 using namespace LAMMPS_NS;
-using namespace MathConst;
+using MathConst::MY_2PI;
+using MathSpecial::powint;
 
 /* ---------------------------------------------------------------------- */
 
@@ -36,9 +38,9 @@ FixWallLJ1043::FixWallLJ1043(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, n
 
 void FixWallLJ1043::precompute(int m)
 {
-  coeff1[m] = MY_2PI * 2.0 / 5.0 * epsilon[m] * pow(sigma[m], 10.0);
-  coeff2[m] = MY_2PI * epsilon[m] * pow(sigma[m], 4.0);
-  coeff3[m] = MY_2PI * pow(2.0, 1 / 2.0) / 3 * epsilon[m] * pow(sigma[m], 3.0);
+  coeff1[m] = MY_2PI * 2.0 / 5.0 * epsilon[m] * powint(sigma[m], 10);
+  coeff2[m] = MY_2PI * epsilon[m] * powint(sigma[m], 4);
+  coeff3[m] = MY_2PI * pow(2.0, 1 / 2.0) / 3 * epsilon[m] * powint(sigma[m], 3);
   coeff4[m] = 0.61 / pow(2.0, 1 / 2.0) * sigma[m];
   coeff5[m] = coeff1[m] * 10.0;
   coeff6[m] = coeff2[m] * 4.0;
@@ -48,7 +50,7 @@ void FixWallLJ1043::precompute(int m)
   double r2inv = rinv * rinv;
   double r4inv = r2inv * r2inv;
   offset[m] = coeff1[m] * r4inv * r4inv * r2inv - coeff2[m] * r4inv -
-      coeff3[m] * pow(cutoff[m] + coeff4[m], -3.0);
+      coeff3[m] * powint(cutoff[m] + coeff4[m], -3);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -82,10 +84,10 @@ void FixWallLJ1043::wall_particle(int m, int which, double coord)
 
       fwall = side *
           (coeff5[m] * r10inv * rinv - coeff6[m] * r4inv * rinv -
-           coeff7[m] * pow(delta + coeff4[m], -4.0));
+           coeff7[m] * powint(delta + coeff4[m], -4));
       f[i][dim] -= fwall;
       ewall[0] += coeff1[m] * r10inv - coeff2[m] * r4inv -
-          coeff3[m] * pow(delta + coeff4[m], -3.0) - offset[m];
+          coeff3[m] * powint(delta + coeff4[m], -3) - offset[m];
       ewall[m + 1] += fwall;
 
       if (evflag) {

--- a/src/fix_wall_lj126.cpp
+++ b/src/fix_wall_lj126.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,16 +12,15 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_wall_lj126.h"
-#include <cmath>
 #include "atom.h"
 #include "error.h"
+#include <cmath>
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-FixWallLJ126::FixWallLJ126(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg)
+FixWallLJ126::FixWallLJ126(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, narg, arg)
 {
   dynamic_group_allow = 1;
 }
@@ -31,14 +29,14 @@ FixWallLJ126::FixWallLJ126(LAMMPS *lmp, int narg, char **arg) :
 
 void FixWallLJ126::precompute(int m)
 {
-  coeff1[m] = 48.0 * epsilon[m] * pow(sigma[m],12.0);
-  coeff2[m] = 24.0 * epsilon[m] * pow(sigma[m],6.0);
-  coeff3[m] = 4.0 * epsilon[m] * pow(sigma[m],12.0);
-  coeff4[m] = 4.0 * epsilon[m] * pow(sigma[m],6.0);
+  coeff1[m] = 48.0 * epsilon[m] * pow(sigma[m], 12.0);
+  coeff2[m] = 24.0 * epsilon[m] * pow(sigma[m], 6.0);
+  coeff3[m] = 4.0 * epsilon[m] * pow(sigma[m], 12.0);
+  coeff4[m] = 4.0 * epsilon[m] * pow(sigma[m], 6.0);
 
-  double r2inv = 1.0/(cutoff[m]*cutoff[m]);
-  double r6inv = r2inv*r2inv*r2inv;
-  offset[m] = r6inv*(coeff3[m]*r6inv - coeff4[m]);
+  double r2inv = 1.0 / (cutoff[m] * cutoff[m]);
+  double r6inv = r2inv * r2inv * r2inv;
+  offset[m] = r6inv * (coeff3[m] * r6inv - coeff4[m]);
 }
 
 /* ----------------------------------------------------------------------
@@ -50,7 +48,7 @@ void FixWallLJ126::precompute(int m)
 
 void FixWallLJ126::wall_particle(int m, int which, double coord)
 {
-  double delta,rinv,r2inv,r6inv,fwall;
+  double delta, rinv, r2inv, r6inv, fwall;
   double vn;
 
   double **x = atom->x;
@@ -66,27 +64,31 @@ void FixWallLJ126::wall_particle(int m, int which, double coord)
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      if (side < 0) delta = x[i][dim] - coord;
-      else delta = coord - x[i][dim];
+      if (side < 0)
+        delta = x[i][dim] - coord;
+      else
+        delta = coord - x[i][dim];
       if (delta >= cutoff[m]) continue;
       if (delta <= 0.0) {
         onflag = 1;
         continue;
       }
-      rinv = 1.0/delta;
-      r2inv = rinv*rinv;
-      r6inv = r2inv*r2inv*r2inv;
-      fwall = side * r6inv*(coeff1[m]*r6inv - coeff2[m]) * rinv;
+      rinv = 1.0 / delta;
+      r2inv = rinv * rinv;
+      r6inv = r2inv * r2inv * r2inv;
+      fwall = side * r6inv * (coeff1[m] * r6inv - coeff2[m]) * rinv;
       f[i][dim] -= fwall;
-      ewall[0] += r6inv*(coeff3[m]*r6inv - coeff4[m]) - offset[m];
-      ewall[m+1] += fwall;
+      ewall[0] += r6inv * (coeff3[m] * r6inv - coeff4[m]) - offset[m];
+      ewall[m + 1] += fwall;
 
       if (evflag) {
-        if (side < 0) vn = -fwall*delta;
-        else vn = fwall*delta;
+        if (side < 0)
+          vn = -fwall * delta;
+        else
+          vn = fwall * delta;
         v_tally(dim, i, vn);
       }
     }
 
-  if (onflag) error->one(FLERR,"Particle on or inside fix wall surface");
+  if (onflag) error->one(FLERR, "Particle on or inside fix wall surface");
 }

--- a/src/fix_wall_lj126.cpp
+++ b/src/fix_wall_lj126.cpp
@@ -12,11 +12,15 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_wall_lj126.h"
+
 #include "atom.h"
 #include "error.h"
+#include "math_special.h"
+
 #include <cmath>
 
 using namespace LAMMPS_NS;
+using MathSpecial::powint;
 
 /* ---------------------------------------------------------------------- */
 
@@ -29,10 +33,10 @@ FixWallLJ126::FixWallLJ126(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, nar
 
 void FixWallLJ126::precompute(int m)
 {
-  coeff1[m] = 48.0 * epsilon[m] * pow(sigma[m], 12.0);
-  coeff2[m] = 24.0 * epsilon[m] * pow(sigma[m], 6.0);
-  coeff3[m] = 4.0 * epsilon[m] * pow(sigma[m], 12.0);
-  coeff4[m] = 4.0 * epsilon[m] * pow(sigma[m], 6.0);
+  coeff1[m] = 48.0 * epsilon[m] * powint(sigma[m], 12);
+  coeff2[m] = 24.0 * epsilon[m] * powint(sigma[m], 6);
+  coeff3[m] = 4.0 * epsilon[m] * powint(sigma[m], 12);
+  coeff4[m] = 4.0 * epsilon[m] * powint(sigma[m], 6);
 
   double r2inv = 1.0 / (cutoff[m] * cutoff[m]);
   double r6inv = r2inv * r2inv * r2inv;

--- a/src/fix_wall_lj93.cpp
+++ b/src/fix_wall_lj93.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,16 +12,17 @@
 ------------------------------------------------------------------------- */
 
 #include "fix_wall_lj93.h"
-#include <cmath>
+
 #include "atom.h"
 #include "error.h"
+
+#include <cmath>
 
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-FixWallLJ93::FixWallLJ93(LAMMPS *lmp, int narg, char **arg) :
-  FixWall(lmp, narg, arg)
+FixWallLJ93::FixWallLJ93(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, narg, arg)
 {
   dynamic_group_allow = 1;
 }
@@ -31,15 +31,15 @@ FixWallLJ93::FixWallLJ93(LAMMPS *lmp, int narg, char **arg) :
 
 void FixWallLJ93::precompute(int m)
 {
-  coeff1[m] = 6.0/5.0 * epsilon[m] * pow(sigma[m],9.0);
-  coeff2[m] = 3.0 * epsilon[m] * pow(sigma[m],3.0);
-  coeff3[m] = 2.0/15.0 * epsilon[m] * pow(sigma[m],9.0);
-  coeff4[m] = epsilon[m] * pow(sigma[m],3.0);
+  coeff1[m] = 6.0 / 5.0 * epsilon[m] * pow(sigma[m], 9.0);
+  coeff2[m] = 3.0 * epsilon[m] * pow(sigma[m], 3.0);
+  coeff3[m] = 2.0 / 15.0 * epsilon[m] * pow(sigma[m], 9.0);
+  coeff4[m] = epsilon[m] * pow(sigma[m], 3.0);
 
-  double rinv = 1.0/cutoff[m];
-  double r2inv = rinv*rinv;
-  double r4inv = r2inv*r2inv;
-  offset[m] = coeff3[m]*r4inv*r4inv*rinv - coeff4[m]*r2inv*rinv;
+  double rinv = 1.0 / cutoff[m];
+  double r2inv = rinv * rinv;
+  double r4inv = r2inv * r2inv;
+  offset[m] = coeff3[m] * r4inv * r4inv * rinv - coeff4[m] * r2inv * rinv;
 }
 
 /* ----------------------------------------------------------------------
@@ -51,7 +51,7 @@ void FixWallLJ93::precompute(int m)
 
 void FixWallLJ93::wall_particle(int m, int which, double coord)
 {
-  double delta,rinv,r2inv,r4inv,r10inv,fwall;
+  double delta, rinv, r2inv, r4inv, r10inv, fwall;
   double vn;
 
   double **x = atom->x;
@@ -67,29 +67,32 @@ void FixWallLJ93::wall_particle(int m, int which, double coord)
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      if (side < 0) delta = x[i][dim] - coord;
-      else delta = coord - x[i][dim];
+      if (side < 0)
+        delta = x[i][dim] - coord;
+      else
+        delta = coord - x[i][dim];
       if (delta >= cutoff[m]) continue;
       if (delta <= 0.0) {
         onflag = 1;
         continue;
       }
-      rinv = 1.0/delta;
-      r2inv = rinv*rinv;
-      r4inv = r2inv*r2inv;
-      r10inv = r4inv*r4inv*r2inv;
-      fwall = side * (coeff1[m]*r10inv - coeff2[m]*r4inv);
+      rinv = 1.0 / delta;
+      r2inv = rinv * rinv;
+      r4inv = r2inv * r2inv;
+      r10inv = r4inv * r4inv * r2inv;
+      fwall = side * (coeff1[m] * r10inv - coeff2[m] * r4inv);
       f[i][dim] -= fwall;
-      ewall[0] += coeff3[m]*r4inv*r4inv*rinv -
-        coeff4[m]*r2inv*rinv - offset[m];
-      ewall[m+1] += fwall;
+      ewall[0] += coeff3[m] * r4inv * r4inv * rinv - coeff4[m] * r2inv * rinv - offset[m];
+      ewall[m + 1] += fwall;
 
       if (evflag) {
-        if (side < 0) vn = -fwall*delta;
-        else vn = fwall*delta;
+        if (side < 0)
+          vn = -fwall * delta;
+        else
+          vn = fwall * delta;
         v_tally(dim, i, vn);
       }
     }
 
-  if (onflag) error->one(FLERR,"Particle on or inside fix wall surface");
+  if (onflag) error->one(FLERR, "Particle on or inside fix wall surface");
 }

--- a/src/fix_wall_lj93.cpp
+++ b/src/fix_wall_lj93.cpp
@@ -15,10 +15,12 @@
 
 #include "atom.h"
 #include "error.h"
+#include "math_special.h"
 
 #include <cmath>
 
 using namespace LAMMPS_NS;
+using MathSpecial::powint;
 
 /* ---------------------------------------------------------------------- */
 
@@ -31,10 +33,10 @@ FixWallLJ93::FixWallLJ93(LAMMPS *lmp, int narg, char **arg) : FixWall(lmp, narg,
 
 void FixWallLJ93::precompute(int m)
 {
-  coeff1[m] = 6.0 / 5.0 * epsilon[m] * pow(sigma[m], 9.0);
-  coeff2[m] = 3.0 * epsilon[m] * pow(sigma[m], 3.0);
-  coeff3[m] = 2.0 / 15.0 * epsilon[m] * pow(sigma[m], 9.0);
-  coeff4[m] = epsilon[m] * pow(sigma[m], 3.0);
+  coeff1[m] = 6.0 / 5.0 * epsilon[m] * powint(sigma[m], 9);
+  coeff2[m] = 3.0 * epsilon[m] * powint(sigma[m], 3);
+  coeff3[m] = 2.0 / 15.0 * epsilon[m] * powint(sigma[m], 9);
+  coeff4[m] = epsilon[m] * powint(sigma[m], 3);
 
   double rinv = 1.0 / cutoff[m];
   double r2inv = rinv * rinv;

--- a/src/improper_zero.cpp
+++ b/src/improper_zero.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -37,28 +36,27 @@ ImproperZero::ImproperZero(LAMMPS *lmp) : Improper(lmp), coeffflag(1)
 
 ImproperZero::~ImproperZero()
 {
-  if (allocated && !copymode) {
-    memory->destroy(setflag);
-  }
+  if (allocated && !copymode) memory->destroy(setflag);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void ImproperZero::compute(int eflag, int vflag)
 {
-  ev_init(eflag,vflag);
+  ev_init(eflag, vflag);
 }
 
 /* ---------------------------------------------------------------------- */
 
 void ImproperZero::settings(int narg, char **arg)
 {
-  if ((narg != 0) && (narg != 1))
-    error->all(FLERR,"Illegal improper_style command");
+  if ((narg != 0) && (narg != 1)) error->all(FLERR, "Illegal improper_style command");
 
   if (narg == 1) {
-    if (strcmp("nocoeff",arg[0]) == 0) coeffflag=0;
-    else error->all(FLERR,"Illegal improper_style command");
+    if (strcmp("nocoeff", arg[0]) == 0)
+      coeffflag = 0;
+    else
+      error->all(FLERR, "Illegal improper_style command");
   }
 }
 
@@ -69,7 +67,7 @@ void ImproperZero::allocate()
   allocated = 1;
   int n = atom->nimpropertypes;
 
-  memory->create(setflag,n+1,"improper:setflag");
+  memory->create(setflag, n + 1, "improper:setflag");
   for (int i = 1; i <= n; i++) setflag[i] = 0;
 }
 
@@ -80,12 +78,12 @@ void ImproperZero::allocate()
 void ImproperZero::coeff(int narg, char **arg)
 {
   if ((narg < 1) || (coeffflag && narg > 1))
-    error->all(FLERR,"Incorrect args for improper coefficients");
+    error->all(FLERR, "Incorrect args for improper coefficients");
 
   if (!allocated) allocate();
 
-  int ilo,ihi;
-  utils::bounds(FLERR,arg[0],1,atom->nimpropertypes,ilo,ihi,error);
+  int ilo, ihi;
+  utils::bounds(FLERR, arg[0], 1, atom->nimpropertypes, ilo, ihi, error);
 
   int count = 0;
   for (int i = ilo; i <= ihi; i++) {
@@ -93,7 +91,7 @@ void ImproperZero::coeff(int narg, char **arg)
     count++;
   }
 
-  if (count == 0) error->all(FLERR,"Incorrect args for improper coefficients");
+  if (count == 0) error->all(FLERR, "Incorrect args for improper coefficients");
 }
 
 /* ----------------------------------------------------------------------
@@ -116,8 +114,7 @@ void ImproperZero::read_restart(FILE * /*fp*/)
    proc 0 writes to data file
 ------------------------------------------------------------------------- */
 
-void ImproperZero::write_data(FILE *fp) {
-  for (int i = 1; i <= atom->nimpropertypes; i++)
-    fprintf(fp,"%d\n",i);
+void ImproperZero::write_data(FILE *fp)
+{
+  for (int i = 1; i <= atom->nimpropertypes; i++) fprintf(fp, "%d\n", i);
 }
-

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -607,7 +607,7 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
         paren_count = 0;
         i = 0;
 
-        while (var[i] != '\0' && !(var[i] == ')' && paren_count == 0)) {
+        while (var[i] != '\0' && (var[i] != ')' || paren_count != 0)) {
           switch (var[i]) {
           case '(': paren_count++; break;
           case ')': paren_count--; break;

--- a/src/math_eigen.cpp
+++ b/src/math_eigen.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -23,23 +22,23 @@
 #include <utility>
 #include <vector>
 
-using std::vector;
 using std::array;
+using std::vector;
 using namespace MathEigen;
 
 // Special case: 3x3 matrices
 
-typedef Jacobi<double,double*,double(*)[3],double const(*)[3]>  Jacobi_v1;
-typedef Jacobi<double,double*,double**,double const*const*> Jacobi_v2;
+typedef Jacobi<double, double *, double (*)[3], double const (*)[3]> Jacobi_v1;
+typedef Jacobi<double, double *, double **, double const *const *> Jacobi_v2;
 
 int MathEigen::jacobi3(double const mat[3][3], double *eval, double evec[3][3])
 {
   // make copy of const matrix
 
-  double mat_cpy[3][3] = { {mat[0][0], mat[0][1], mat[0][2]},
-                           {mat[1][0], mat[1][1], mat[1][2]},
-                           {mat[2][0], mat[2][1], mat[2][2]} };
-  double *M[3] = { &(mat_cpy[0][0]),  &(mat_cpy[1][0]), &(mat_cpy[2][0]) };
+  double mat_cpy[3][3] = {{mat[0][0], mat[0][1], mat[0][2]},
+                          {mat[1][0], mat[1][1], mat[1][2]},
+                          {mat[2][0], mat[2][1], mat[2][2]}};
+  double *M[3] = {&(mat_cpy[0][0]), &(mat_cpy[1][0]), &(mat_cpy[2][0])};
   int midx[3];
 
   // create instance of generic Jacobi class and get eigenvalues and -vectors
@@ -49,21 +48,20 @@ int MathEigen::jacobi3(double const mat[3][3], double *eval, double evec[3][3])
 
   // transpose the evec matrix
 
-  for (int i=0; i<3; i++)
-    for (int j=i+1; j<3; j++)
-      std::swap(evec[i][j], evec[j][i]);
+  for (int i = 0; i < 3; i++)
+    for (int j = i + 1; j < 3; j++) std::swap(evec[i][j], evec[j][i]);
 
   return ierror;
 }
 
-int MathEigen::jacobi3(double const* const* mat, double *eval, double **evec)
+int MathEigen::jacobi3(double const *const *mat, double *eval, double **evec)
 {
   // make copy of const matrix
 
-  double mat_cpy[3][3] = { {mat[0][0], mat[0][1], mat[0][2]},
-                           {mat[1][0], mat[1][1], mat[1][2]},
-                           {mat[2][0], mat[2][1], mat[2][2]} };
-  double *M[3] = { &(mat_cpy[0][0]),  &(mat_cpy[1][0]), &(mat_cpy[2][0]) };
+  double mat_cpy[3][3] = {{mat[0][0], mat[0][1], mat[0][2]},
+                          {mat[1][0], mat[1][1], mat[1][2]},
+                          {mat[2][0], mat[2][1], mat[2][2]}};
+  double *M[3] = {&(mat_cpy[0][0]), &(mat_cpy[1][0]), &(mat_cpy[2][0])};
   int midx[3];
 
   // create instance of generic Jacobi class and get eigenvalues and -vectors
@@ -73,9 +71,8 @@ int MathEigen::jacobi3(double const* const* mat, double *eval, double **evec)
 
   // transpose the evec matrix
 
-  for (int i=0; i<3; i++)
-    for (int j=i+1; j<3; j++)
-      std::swap(evec[i][j], evec[j][i]);
+  for (int i = 0; i < 3; i++)
+    for (int j = i + 1; j < 3; j++) std::swap(evec[i][j], evec[j][i]);
 
   return ierror;
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -16,8 +16,7 @@
 
 #include "error.h"
 
-#if defined(LMP_INTEL) && \
-  ((defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)))
+#if defined(LMP_INTEL) && ((defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)))
 #ifndef LMP_INTEL_NO_TBB
 #define LMP_USE_TBB_ALLOCATOR
 #include "tbb/scalable_allocator.h"
@@ -127,6 +126,5 @@ void Memory::sfree(void *ptr)
 
 void Memory::fail(const char *name)
 {
-  error->one(FLERR,"Cannot create/grow a vector/array of "
-                               "pointers for {}",name);
+  error->one(FLERR,"Cannot create/grow a vector/array of pointers for {}",name);
 }

--- a/src/min_sd.cpp
+++ b/src/min_sd.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -37,9 +36,9 @@ MinSD::MinSD(LAMMPS *lmp) : MinLineSearch(lmp) {}
 
 int MinSD::iterate(int maxiter)
 {
-  int i,m,n,fail,ntimestep;
+  int i, m, n, fail, ntimestep;
   double fdotf;
-  double *fatom,*hatom;
+  double *fatom, *hatom;
 
   // initialize working vectors
 
@@ -56,8 +55,7 @@ int MinSD::iterate(int maxiter)
 
   for (int iter = 0; iter < maxiter; iter++) {
 
-    if (timer->check_timeout(niter))
-      return TIMEOUT;
+    if (timer->check_timeout(niter)) return TIMEOUT;
 
     ntimestep = ++update->ntimestep;
     niter++;
@@ -66,7 +64,7 @@ int MinSD::iterate(int maxiter)
     // h = downhill gradient direction
 
     eprevious = ecurrent;
-    fail = (this->*linemin)(ecurrent,alpha_final);
+    fail = (this->*linemin)(ecurrent, alpha_final);
     if (fail) return fail;
 
     // function evaluation criterion
@@ -75,19 +73,23 @@ int MinSD::iterate(int maxiter)
 
     // energy tolerance criterion
 
-    if (fabs(ecurrent-eprevious) <
-        update->etol * 0.5*(fabs(ecurrent) + fabs(eprevious) + EPS_ENERGY))
+    if (fabs(ecurrent - eprevious) <
+        update->etol * 0.5 * (fabs(ecurrent) + fabs(eprevious) + EPS_ENERGY))
       return ETOL;
 
     // force tolerance criterion
 
     fdotf = 0.0;
     if (update->ftol > 0.0) {
-      if (normstyle == MAX) fdotf = fnorm_max();        // max force norm
-      else if (normstyle == INF) fdotf = fnorm_inf();   // infinite force norm
-      else if (normstyle == TWO) fdotf = fnorm_sqr();   // Euclidean force 2-norm
-      else error->all(FLERR,"Illegal min_modify command");
-      if (fdotf < update->ftol*update->ftol) return FTOL;
+      if (normstyle == MAX)
+        fdotf = fnorm_max();    // max force norm
+      else if (normstyle == INF)
+        fdotf = fnorm_inf();    // infinite force norm
+      else if (normstyle == TWO)
+        fdotf = fnorm_sqr();    // Euclidean force 2-norm
+      else
+        error->all(FLERR, "Illegal min_modify command");
+      if (fdotf < update->ftol * update->ftol) return FTOL;
     }
 
     // set new search direction h to f = -Grad(x)

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -80,6 +80,7 @@ Modify::Modify(LAMMPS *lmp) : Pointers(lmp)
 
   list_timeflag = nullptr;
 
+  restart_pbc_any = 0;
   nfix_restart_global = 0;
   id_restart_global = style_restart_global = nullptr;
   state_restart_global = nullptr;

--- a/src/npair_full_bin.cpp
+++ b/src/npair_full_bin.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,13 +12,14 @@
 ------------------------------------------------------------------------- */
 
 #include "npair_full_bin.h"
-#include "neigh_list.h"
+
 #include "atom.h"
 #include "atom_vec.h"
-#include "molecule.h"
 #include "domain.h"
-#include "my_page.h"
 #include "error.h"
+#include "molecule.h"
+#include "my_page.h"
+#include "neigh_list.h"
 
 using namespace LAMMPS_NS;
 
@@ -34,9 +34,9 @@ NPairFullBin::NPairFullBin(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairFullBin::build(NeighList *list)
 {
-  int i,j,k,n,itype,jtype,ibin,which,imol,iatom,moltemplate;
+  int i, j, k, n, itype, jtype, ibin, which, imol, iatom, moltemplate;
   tagint tagprev;
-  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
+  double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
   int *neighptr;
 
   double **x = atom->x;
@@ -52,8 +52,10 @@ void NPairFullBin::build(NeighList *list)
   int *molindex = atom->molindex;
   int *molatom = atom->molatom;
   Molecule **onemols = atom->avec->onemols;
-  if (molecular == Atom::TEMPLATE) moltemplate = 1;
-  else moltemplate = 0;
+  if (molecular == Atom::TEMPLATE)
+    moltemplate = 1;
+  else
+    moltemplate = 0;
 
   int *ilist = list->ilist;
   int *numneigh = list->numneigh;
@@ -83,31 +85,35 @@ void NPairFullBin::build(NeighList *list)
     ibin = atom2bin[i];
 
     for (k = 0; k < nstencil; k++) {
-      for (j = binhead[ibin+stencil[k]]; j >= 0; j = bins[j]) {
+      for (j = binhead[ibin + stencil[k]]; j >= 0; j = bins[j]) {
         if (i == j) continue;
 
         jtype = type[j];
-        if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+        if (exclude && exclusion(i, j, itype, jtype, mask, molecule)) continue;
 
         delx = xtmp - x[j][0];
         dely = ytmp - x[j][1];
         delz = ztmp - x[j][2];
-        rsq = delx*delx + dely*dely + delz*delz;
+        rsq = delx * delx + dely * dely + delz * delz;
 
         if (rsq <= cutneighsq[itype][jtype]) {
           if (molecular != Atom::ATOMIC) {
-            if (!moltemplate)
-              which = find_special(special[i],nspecial[i],tag[j]);
-            else if (imol >= 0)
-              which = find_special(onemols[imol]->special[iatom],
-                                   onemols[imol]->nspecial[iatom],
-                                   tag[j]-tagprev);
-            else which = 0;
-            if (which == 0) neighptr[n++] = j;
-            else if (domain->minimum_image_check(delx,dely,delz))
+            if (!moltemplate) {
+              which = find_special(special[i], nspecial[i], tag[j]);
+            } else if (imol >= 0) {
+              const auto mol = onemols[imol];
+              which = find_special(mol->special[iatom], mol->nspecial[iatom], tag[j] - tagprev);
+            } else {
+              which = 0;
+            }
+            if (which == 0)
               neighptr[n++] = j;
-            else if (which > 0) neighptr[n++] = j ^ (which << SBBITS);
-          } else neighptr[n++] = j;
+            else if (domain->minimum_image_check(delx, dely, delz))
+              neighptr[n++] = j;
+            else if (which > 0)
+              neighptr[n++] = j ^ (which << SBBITS);
+          } else
+            neighptr[n++] = j;
         }
       }
     }
@@ -116,8 +122,7 @@ void NPairFullBin::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
 
   list->inum = inum;

--- a/src/npair_full_nsq.cpp
+++ b/src/npair_full_nsq.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,14 +12,15 @@
 ------------------------------------------------------------------------- */
 
 #include "npair_full_nsq.h"
-#include "neigh_list.h"
+
 #include "atom.h"
 #include "atom_vec.h"
+#include "domain.h"
+#include "error.h"
 #include "group.h"
 #include "molecule.h"
-#include "domain.h"
 #include "my_page.h"
-#include "error.h"
+#include "neigh_list.h"
 
 using namespace LAMMPS_NS;
 
@@ -35,9 +35,9 @@ NPairFullNsq::NPairFullNsq(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairFullNsq::build(NeighList *list)
 {
-  int i,j,n,itype,jtype,which,bitmask,imol,iatom,moltemplate;
+  int i, j, n, itype, jtype, which, bitmask, imol, iatom, moltemplate;
   tagint tagprev;
-  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
+  double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
   int *neighptr;
 
   double **x = atom->x;
@@ -57,8 +57,10 @@ void NPairFullNsq::build(NeighList *list)
   int *molindex = atom->molindex;
   int *molatom = atom->molatom;
   Molecule **onemols = atom->avec->onemols;
-  if (molecular == Atom::TEMPLATE) moltemplate = 1;
-  else moltemplate = 0;
+  if (molecular == Atom::TEMPLATE)
+    moltemplate = 1;
+  else
+    moltemplate = 0;
 
   int *ilist = list->ilist;
   int *numneigh = list->numneigh;
@@ -89,26 +91,31 @@ void NPairFullNsq::build(NeighList *list)
       if (includegroup && !(mask[j] & bitmask)) continue;
       if (i == j) continue;
       jtype = type[j];
-      if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+      if (exclude && exclusion(i, j, itype, jtype, mask, molecule)) continue;
 
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      rsq = delx*delx + dely*dely + delz*delz;
+      rsq = delx * delx + dely * dely + delz * delz;
       if (rsq <= cutneighsq[itype][jtype]) {
         if (molecular != Atom::ATOMIC) {
-          if (!moltemplate)
-            which = find_special(special[i],nspecial[i],tag[j]);
-          else if (imol >= 0)
-            which = find_special(onemols[imol]->special[iatom],
-                                 onemols[imol]->nspecial[iatom],
-                                 tag[j]-tagprev);
-          else which = 0;
-          if (which == 0) neighptr[n++] = j;
-          else if (domain->minimum_image_check(delx,dely,delz))
+          if (!moltemplate) {
+            which = find_special(special[i], nspecial[i], tag[j]);
+          } else if (imol >= 0) {
+            const auto mol = onemols[imol];
+            which = find_special(mol->special[iatom], mol->nspecial[iatom], tag[j] - tagprev);
+          } else {
+            which = 0;
+          }
+
+          if (which == 0)
             neighptr[n++] = j;
-          else if (which > 0) neighptr[n++] = j ^ (which << SBBITS);
-        } else neighptr[n++] = j;
+          else if (domain->minimum_image_check(delx, dely, delz))
+            neighptr[n++] = j;
+          else if (which > 0)
+            neighptr[n++] = j ^ (which << SBBITS);
+        } else
+          neighptr[n++] = j;
       }
     }
 
@@ -116,8 +123,7 @@ void NPairFullNsq::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
 
   list->inum = inum;

--- a/src/npair_half_bin_atomonly_newton.cpp
+++ b/src/npair_half_bin_atomonly_newton.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -23,8 +22,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-NPairHalfBinAtomonlyNewton::NPairHalfBinAtomonlyNewton(LAMMPS *lmp) :
-  NPair(lmp) {}
+NPairHalfBinAtomonlyNewton::NPairHalfBinAtomonlyNewton(LAMMPS *lmp) : NPair(lmp) {}
 
 /* ----------------------------------------------------------------------
    binned neighbor list construction with full Newton's 3rd law
@@ -34,8 +32,8 @@ NPairHalfBinAtomonlyNewton::NPairHalfBinAtomonlyNewton(LAMMPS *lmp) :
 
 void NPairHalfBinAtomonlyNewton::build(NeighList *list)
 {
-  int i,j,k,n,itype,jtype,ibin;
-  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
+  int i, j, k, n, itype, jtype, ibin;
+  double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
   int *neighptr;
 
   double **x = atom->x;
@@ -76,12 +74,12 @@ void NPairHalfBinAtomonlyNewton::build(NeighList *list)
       }
 
       jtype = type[j];
-      if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+      if (exclude && exclusion(i, j, itype, jtype, mask, molecule)) continue;
 
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      rsq = delx*delx + dely*dely + delz*delz;
+      rsq = delx * delx + dely * dely + delz * delz;
 
       if (rsq <= cutneighsq[itype][jtype]) neighptr[n++] = j;
     }
@@ -91,14 +89,14 @@ void NPairHalfBinAtomonlyNewton::build(NeighList *list)
     ibin = atom2bin[i];
 
     for (k = 0; k < nstencil; k++) {
-      for (j = binhead[ibin+stencil[k]]; j >= 0; j = bins[j]) {
+      for (j = binhead[ibin + stencil[k]]; j >= 0; j = bins[j]) {
         jtype = type[j];
-        if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+        if (exclude && exclusion(i, j, itype, jtype, mask, molecule)) continue;
 
         delx = xtmp - x[j][0];
         dely = ytmp - x[j][1];
         delz = ztmp - x[j][2];
-        rsq = delx*delx + dely*dely + delz*delz;
+        rsq = delx * delx + dely * dely + delz * delz;
 
         if (rsq <= cutneighsq[itype][jtype]) neighptr[n++] = j;
       }
@@ -108,8 +106,7 @@ void NPairHalfBinAtomonlyNewton::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
 
   list->inum = inum;

--- a/src/npair_half_bin_newtoff.cpp
+++ b/src/npair_half_bin_newtoff.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,13 +12,14 @@
 ------------------------------------------------------------------------- */
 
 #include "npair_half_bin_newtoff.h"
-#include "neigh_list.h"
+
 #include "atom.h"
 #include "atom_vec.h"
-#include "molecule.h"
 #include "domain.h"
-#include "my_page.h"
 #include "error.h"
+#include "molecule.h"
+#include "my_page.h"
+#include "neigh_list.h"
 
 using namespace LAMMPS_NS;
 
@@ -36,9 +36,9 @@ NPairHalfBinNewtoff::NPairHalfBinNewtoff(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairHalfBinNewtoff::build(NeighList *list)
 {
-  int i,j,k,n,itype,jtype,ibin,which,imol,iatom,moltemplate;
+  int i, j, k, n, itype, jtype, ibin, which, imol, iatom, moltemplate;
   tagint tagprev;
-  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
+  double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
   int *neighptr;
 
   double **x = atom->x;
@@ -54,8 +54,10 @@ void NPairHalfBinNewtoff::build(NeighList *list)
   int *molindex = atom->molindex;
   int *molatom = atom->molatom;
   Molecule **onemols = atom->avec->onemols;
-  if (molecular == Atom::TEMPLATE) moltemplate = 1;
-  else moltemplate = 0;
+  if (molecular == Atom::TEMPLATE)
+    moltemplate = 1;
+  else
+    moltemplate = 0;
 
   int *ilist = list->ilist;
   int *numneigh = list->numneigh;
@@ -87,32 +89,35 @@ void NPairHalfBinNewtoff::build(NeighList *list)
     ibin = atom2bin[i];
 
     for (k = 0; k < nstencil; k++) {
-      for (j = binhead[ibin+stencil[k]]; j >= 0; j = bins[j]) {
+      for (j = binhead[ibin + stencil[k]]; j >= 0; j = bins[j]) {
         if (j <= i) continue;
 
         jtype = type[j];
-        if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+        if (exclude && exclusion(i, j, itype, jtype, mask, molecule)) continue;
 
         delx = xtmp - x[j][0];
         dely = ytmp - x[j][1];
         delz = ztmp - x[j][2];
-        rsq = delx*delx + dely*dely + delz*delz;
+        rsq = delx * delx + dely * dely + delz * delz;
 
         if (rsq <= cutneighsq[itype][jtype]) {
           if (molecular != Atom::ATOMIC) {
             if (!moltemplate)
-              which = find_special(special[i],nspecial[i],tag[j]);
+              which = find_special(special[i], nspecial[i], tag[j]);
             else if (imol >= 0)
-              which = find_special(onemols[imol]->special[iatom],
-                                   onemols[imol]->nspecial[iatom],
-                                   tag[j]-tagprev);
-            else which = 0;
-            if (which == 0) neighptr[n++] = j;
-            else if (domain->minimum_image_check(delx,dely,delz))
+              which = find_special(onemols[imol]->special[iatom], onemols[imol]->nspecial[iatom],
+                                   tag[j] - tagprev);
+            else
+              which = 0;
+            if (which == 0)
               neighptr[n++] = j;
-            else if (which > 0) neighptr[n++] = j ^ (which << SBBITS);
+            else if (domain->minimum_image_check(delx, dely, delz))
+              neighptr[n++] = j;
+            else if (which > 0)
+              neighptr[n++] = j ^ (which << SBBITS);
             // OLD: if (which >= 0) neighptr[n++] = j ^ (which << SBBITS);
-          } else neighptr[n++] = j;
+          } else
+            neighptr[n++] = j;
         }
       }
     }
@@ -121,9 +126,7 @@ void NPairHalfBinNewtoff::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
-
   list->inum = inum;
 }

--- a/src/npair_half_nsq_newtoff.cpp
+++ b/src/npair_half_nsq_newtoff.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -13,14 +12,15 @@
 ------------------------------------------------------------------------- */
 
 #include "npair_half_nsq_newtoff.h"
-#include "neigh_list.h"
+
 #include "atom.h"
 #include "atom_vec.h"
+#include "domain.h"
+#include "error.h"
 #include "group.h"
 #include "molecule.h"
-#include "domain.h"
 #include "my_page.h"
-#include "error.h"
+#include "neigh_list.h"
 
 using namespace LAMMPS_NS;
 
@@ -36,9 +36,9 @@ NPairHalfNsqNewtoff::NPairHalfNsqNewtoff(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairHalfNsqNewtoff::build(NeighList *list)
 {
-  int i,j,n,itype,jtype,which,bitmask,imol,iatom,moltemplate;
+  int i, j, n, itype, jtype, which, bitmask, imol, iatom, moltemplate;
   tagint tagprev;
-  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
+  double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
   int *neighptr;
 
   double **x = atom->x;
@@ -58,8 +58,10 @@ void NPairHalfNsqNewtoff::build(NeighList *list)
   int *molindex = atom->molindex;
   int *molatom = atom->molatom;
   Molecule **onemols = atom->avec->onemols;
-  if (molecular == Atom::TEMPLATE) moltemplate = 1;
-  else moltemplate = 0;
+  if (molecular == Atom::TEMPLATE)
+    moltemplate = 1;
+  else
+    moltemplate = 0;
 
   int *ilist = list->ilist;
   int *numneigh = list->numneigh;
@@ -86,30 +88,33 @@ void NPairHalfNsqNewtoff::build(NeighList *list)
     // loop over remaining atoms, owned and ghost
     // only store pair if i < j
 
-    for (j = i+1; j < nall; j++) {
+    for (j = i + 1; j < nall; j++) {
       if (includegroup && !(mask[j] & bitmask)) continue;
       jtype = type[j];
-      if (exclude && exclusion(i,j,itype,jtype,mask,molecule)) continue;
+      if (exclude && exclusion(i, j, itype, jtype, mask, molecule)) continue;
 
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      rsq = delx*delx + dely*dely + delz*delz;
+      rsq = delx * delx + dely * dely + delz * delz;
 
       if (rsq <= cutneighsq[itype][jtype]) {
         if (molecular != Atom::ATOMIC) {
           if (!moltemplate)
-            which = find_special(special[i],nspecial[i],tag[j]);
+            which = find_special(special[i], nspecial[i], tag[j]);
           else if (imol >= 0)
-            which = find_special(onemols[imol]->special[iatom],
-                                 onemols[imol]->nspecial[iatom],
-                                 tag[j]-tagprev);
-          else which = 0;
-          if (which == 0) neighptr[n++] = j;
-          else if (domain->minimum_image_check(delx,dely,delz))
+            which = find_special(onemols[imol]->special[iatom], onemols[imol]->nspecial[iatom],
+                                 tag[j] - tagprev);
+          else
+            which = 0;
+          if (which == 0)
             neighptr[n++] = j;
-          else if (which > 0) neighptr[n++] = j ^ (which << SBBITS);
-        } else neighptr[n++] = j;
+          else if (domain->minimum_image_check(delx, dely, delz))
+            neighptr[n++] = j;
+          else if (which > 0)
+            neighptr[n++] = j ^ (which << SBBITS);
+        } else
+          neighptr[n++] = j;
       }
     }
 
@@ -117,9 +122,7 @@ void NPairHalfNsqNewtoff::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
-
   list->inum = inum;
 }

--- a/src/npair_half_size_nsq_newtoff.cpp
+++ b/src/npair_half_size_nsq_newtoff.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -18,8 +17,8 @@
 #include "atom_vec.h"
 #include "domain.h"
 #include "error.h"
-#include "molecule.h"
 #include "group.h"
+#include "molecule.h"
 #include "my_page.h"
 #include "neigh_list.h"
 
@@ -38,10 +37,10 @@ NPairHalfSizeNsqNewtoff::NPairHalfSizeNsqNewtoff(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairHalfSizeNsqNewtoff::build(NeighList *list)
 {
-  int i,j,jh,n,bitmask,which,imol,iatom,moltemplate;
+  int i, j, jh, n, bitmask, which, imol, iatom, moltemplate;
   tagint tagprev;
-  double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
-  double radi,radsum,cutsq;
+  double xtmp, ytmp, ztmp, delx, dely, delz, rsq;
+  double radi, radsum, cutsq;
   int *neighptr;
 
   double **x = atom->x;
@@ -62,8 +61,10 @@ void NPairHalfSizeNsqNewtoff::build(NeighList *list)
   int *molindex = atom->molindex;
   int *molatom = atom->molatom;
   Molecule **onemols = atom->avec->onemols;
-  if (molecular == Atom::TEMPLATE) moltemplate = 1;
-  else moltemplate = 0;
+  if (molecular == Atom::TEMPLATE)
+    moltemplate = 1;
+  else
+    moltemplate = 0;
 
   int history = list->history;
   int *ilist = list->ilist;
@@ -92,35 +93,37 @@ void NPairHalfSizeNsqNewtoff::build(NeighList *list)
 
     // loop over remaining atoms, owned and ghost
 
-    for (j = i+1; j < nall; j++) {
+    for (j = i + 1; j < nall; j++) {
       if (includegroup && !(mask[j] & bitmask)) continue;
-      if (exclude && exclusion(i,j,type[i],type[j],mask,molecule)) continue;
+      if (exclude && exclusion(i, j, type[i], type[j], mask, molecule)) continue;
 
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      rsq = delx*delx + dely*dely + delz*delz;
+      rsq = delx * delx + dely * dely + delz * delz;
       radsum = radi + radius[j];
-      cutsq = (radsum+skin) * (radsum+skin);
+      cutsq = (radsum + skin) * (radsum + skin);
 
       if (rsq <= cutsq) {
         jh = j;
-        if (history && rsq < radsum*radsum)
-          jh = jh ^ mask_history;
+        if (history && rsq < radsum * radsum) jh = jh ^ mask_history;
 
         if (molecular != Atom::ATOMIC) {
           if (!moltemplate)
-            which = find_special(special[i],nspecial[i],tag[j]);
+            which = find_special(special[i], nspecial[i], tag[j]);
           else if (imol >= 0)
-            which = find_special(onemols[imol]->special[iatom],
-                                 onemols[imol]->nspecial[iatom],
-                                 tag[j]-tagprev);
-          else which = 0;
-          if (which == 0) neighptr[n++] = jh;
-          else if (domain->minimum_image_check(delx,dely,delz))
+            which = find_special(onemols[imol]->special[iatom], onemols[imol]->nspecial[iatom],
+                                 tag[j] - tagprev);
+          else
+            which = 0;
+          if (which == 0)
             neighptr[n++] = jh;
-          else if (which > 0) neighptr[n++] = jh ^ (which << SBBITS);
-        } else neighptr[n++] = jh;
+          else if (domain->minimum_image_check(delx, dely, delz))
+            neighptr[n++] = jh;
+          else if (which > 0)
+            neighptr[n++] = jh ^ (which << SBBITS);
+        } else
+          neighptr[n++] = jh;
       }
     }
 
@@ -128,9 +131,7 @@ void NPairHalfSizeNsqNewtoff::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
-
   list->inum = inum;
 }

--- a/src/npair_halffull_newton.cpp
+++ b/src/npair_halffull_newton.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -34,9 +33,9 @@ NPairHalffullNewton::NPairHalffullNewton(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairHalffullNewton::build(NeighList *list)
 {
-  int i,j,ii,jj,n,jnum,joriginal;
-  int *neighptr,*jlist;
-  double xtmp,ytmp,ztmp;
+  int i, j, ii, jj, n, jnum, joriginal;
+  int *neighptr, *jlist;
+  double xtmp, ytmp, ztmp;
 
   double **x = atom->x;
   int nlocal = atom->nlocal;
@@ -89,9 +88,7 @@ void NPairHalffullNewton::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
-
   list->inum = inum;
 }

--- a/src/npair_halffull_newton_trim.cpp
+++ b/src/npair_halffull_newton_trim.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -34,10 +33,10 @@ NPairHalffullNewtonTrim::NPairHalffullNewtonTrim(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairHalffullNewtonTrim::build(NeighList *list)
 {
-  int i,j,ii,jj,n,jnum,joriginal;
-  int *neighptr,*jlist;
-  double xtmp,ytmp,ztmp;
-  double delx,dely,delz,rsq;
+  int i, j, ii, jj, n, jnum, joriginal;
+  int *neighptr, *jlist;
+  double xtmp, ytmp, ztmp;
+  double delx, dely, delz, rsq;
 
   double **x = atom->x;
   int nlocal = atom->nlocal;
@@ -100,9 +99,7 @@ void NPairHalffullNewtonTrim::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
-
   list->inum = inum;
 }

--- a/src/npair_skip.cpp
+++ b/src/npair_skip.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -35,8 +34,8 @@ NPairSkip::NPairSkip(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairSkip::build(NeighList *list)
 {
-  int i,j,ii,jj,n,itype,jnum,joriginal;
-  int *neighptr,*jlist;
+  int i, j, ii, jj, n, itype, jnum, joriginal;
+  int *neighptr, *jlist;
 
   int *type = atom->type;
   int nlocal = atom->nlocal;
@@ -86,16 +85,17 @@ void NPairSkip::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
 
   list->inum = inum;
   if (list->ghost) {
     int num = 0;
     for (i = 0; i < inum; i++)
-      if (ilist[i] < nlocal) num++;
-      else break;
+      if (ilist[i] < nlocal)
+        num++;
+      else
+        break;
     list->inum = num;
     list->gnum = inum - num;
   }

--- a/src/npair_skip_size_off2on.cpp
+++ b/src/npair_skip_size_off2on.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -33,9 +32,9 @@ NPairSkipSizeOff2on::NPairSkipSizeOff2on(LAMMPS *lmp) : NPair(lmp) {}
 
 void NPairSkipSizeOff2on::build(NeighList *list)
 {
-  int i,j,ii,jj,n,itype,jnum,joriginal;
-  tagint itag,jtag;
-  int *neighptr,*jlist;
+  int i, j, ii, jj, n, itype, jnum, joriginal;
+  tagint itag, jtag;
+  int *neighptr, *jlist;
 
   tagint *tag = atom->tag;
   int *type = atom->type;
@@ -92,9 +91,7 @@ void NPairSkipSizeOff2on::build(NeighList *list)
     firstneigh[i] = neighptr;
     numneigh[i] = n;
     ipage->vgot(n);
-    if (ipage->status())
-      error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
+    if (ipage->status()) error->one(FLERR, "Neighbor list overflow, boost neigh_modify one");
   }
-
   list->inum = inum;
 }

--- a/src/nstencil_full_multi_3d.cpp
+++ b/src/nstencil_full_multi_3d.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -51,7 +50,6 @@ void NStencilFullMulti3d::create()
   int n = ncollections;
   double cutsq;
 
-
   for (icollection = 0; icollection < n; icollection++) {
     for (jcollection = 0; jcollection < n; jcollection++) {
       if (flag_skip_multi[icollection][jcollection]) {
@@ -76,9 +74,8 @@ void NStencilFullMulti3d::create()
       for (k = -sz; k <= sz; k++)
         for (j = -sy; j <= sy; j++)
           for (i = -sx; i <= sx; i++)
-                if (bin_distance_multi(i,j,k,bin_collection) < cutsq)
-                  stencil_multi[icollection][jcollection][ns++] =
-                      k*mbiny*mbinx + j*mbinx + i;
+            if (bin_distance_multi(i, j, k, bin_collection) < cutsq)
+              stencil_multi[icollection][jcollection][ns++] = k * mbiny * mbinx + j * mbinx + i;
 
       nstencil_multi[icollection][jcollection] = ns;
     }

--- a/src/nstencil_half_multi_2d.cpp
+++ b/src/nstencil_half_multi_2d.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -20,8 +19,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-NStencilHalfMulti2d::NStencilHalfMulti2d(LAMMPS *lmp) :
-  NStencil(lmp) {}
+NStencilHalfMulti2d::NStencilHalfMulti2d(LAMMPS *lmp) : NStencil(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 
@@ -37,11 +35,11 @@ void NStencilHalfMulti2d::set_stencil_properties()
 
   for (i = 0; i < n; i++) {
     for (j = 0; j < n; j++) {
-      if(cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
+      if (cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
 
       flag_skip_multi[i][j] = false;
 
-      if(cutcollectionsq[i][i] == cutcollectionsq[j][j]){
+      if (cutcollectionsq[i][i] == cutcollectionsq[j][j]) {
         flag_half_multi[i][j] = true;
         bin_collection_multi[i][j] = i;
       } else {
@@ -61,7 +59,6 @@ void NStencilHalfMulti2d::create()
   int icollection, jcollection, bin_collection, i, j, ns;
   int n = ncollections;
   double cutsq;
-
 
   for (icollection = 0; icollection < n; icollection++) {
     for (jcollection = 0; jcollection < n; jcollection++) {
@@ -86,18 +83,16 @@ void NStencilHalfMulti2d::create()
         for (j = 0; j <= sy; j++)
           for (i = -sx; i <= sx; i++)
             if (j > 0 || (j == 0 && i > 0)) {
-              if (bin_distance_multi(i,j,0,bin_collection) < cutsq)
-                  stencil_multi[icollection][jcollection][ns++] = j*mbinx + i;
-                }
+              if (bin_distance_multi(i, j, 0, bin_collection) < cutsq)
+                stencil_multi[icollection][jcollection][ns++] = j * mbinx + i;
+            }
       } else {
-          for (j = -sy; j <= sy; j++)
-            for (i = -sx; i <= sx; i++)
-              if (bin_distance_multi(i,j,0,bin_collection) < cutsq)
-                    stencil_multi[icollection][jcollection][ns++] = j*mbinx + i;
+        for (j = -sy; j <= sy; j++)
+          for (i = -sx; i <= sx; i++)
+            if (bin_distance_multi(i, j, 0, bin_collection) < cutsq)
+              stencil_multi[icollection][jcollection][ns++] = j * mbinx + i;
       }
-
       nstencil_multi[icollection][jcollection] = ns;
     }
   }
 }
-

--- a/src/nstencil_half_multi_2d_tri.cpp
+++ b/src/nstencil_half_multi_2d_tri.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -20,8 +19,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-NStencilHalfMulti2dTri::NStencilHalfMulti2dTri(LAMMPS *lmp) :
-  NStencil(lmp) {}
+NStencilHalfMulti2dTri::NStencilHalfMulti2dTri(LAMMPS *lmp) : NStencil(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 
@@ -37,11 +35,11 @@ void NStencilHalfMulti2dTri::set_stencil_properties()
 
   for (i = 0; i < n; i++) {
     for (j = 0; j < n; j++) {
-      if(cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
+      if (cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
 
       flag_skip_multi[i][j] = false;
 
-      if(cutcollectionsq[i][i] == cutcollectionsq[j][j]){
+      if (cutcollectionsq[i][i] == cutcollectionsq[j][j]) {
         flag_half_multi[i][j] = true;
         bin_collection_multi[i][j] = i;
       } else {
@@ -61,7 +59,6 @@ void NStencilHalfMulti2dTri::create()
   int icollection, jcollection, bin_collection, i, j, ns;
   int n = ncollections;
   double cutsq;
-
 
   for (icollection = 0; icollection < n; icollection++) {
     for (jcollection = 0; jcollection < n; jcollection++) {
@@ -85,15 +82,14 @@ void NStencilHalfMulti2dTri::create()
       if (flag_half_multi[icollection][jcollection]) {
         for (j = 0; j <= sy; j++)
           for (i = -sx; i <= sx; i++)
-            if (bin_distance_multi(i,j,0,bin_collection) < cutsq)
-                  stencil_multi[icollection][jcollection][ns++] = j*mbinx + i;
+            if (bin_distance_multi(i, j, 0, bin_collection) < cutsq)
+              stencil_multi[icollection][jcollection][ns++] = j * mbinx + i;
       } else {
         for (j = -sy; j <= sy; j++)
           for (i = -sx; i <= sx; i++)
-                if (bin_distance_multi(i,j,0,bin_collection) < cutsq)
-                  stencil_multi[icollection][jcollection][ns++] = j*mbinx + i;
+            if (bin_distance_multi(i, j, 0, bin_collection) < cutsq)
+              stencil_multi[icollection][jcollection][ns++] = j * mbinx + i;
       }
-
       nstencil_multi[icollection][jcollection] = ns;
     }
   }

--- a/src/nstencil_half_multi_3d.cpp
+++ b/src/nstencil_half_multi_3d.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -20,8 +19,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-NStencilHalfMulti3d::NStencilHalfMulti3d(LAMMPS *lmp) :
-  NStencil(lmp) {}
+NStencilHalfMulti3d::NStencilHalfMulti3d(LAMMPS *lmp) : NStencil(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 
@@ -37,11 +35,11 @@ void NStencilHalfMulti3d::set_stencil_properties()
 
   for (i = 0; i < n; i++) {
     for (j = 0; j < n; j++) {
-      if(cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
+      if (cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
 
       flag_skip_multi[i][j] = false;
 
-      if(cutcollectionsq[i][i] == cutcollectionsq[j][j]){
+      if (cutcollectionsq[i][i] == cutcollectionsq[j][j]) {
         flag_half_multi[i][j] = true;
         bin_collection_multi[i][j] = i;
       } else {
@@ -61,7 +59,6 @@ void NStencilHalfMulti3d::create()
   int icollection, jcollection, bin_collection, i, j, k, ns;
   int n = ncollections;
   double cutsq;
-
 
   for (icollection = 0; icollection < n; icollection++) {
     for (jcollection = 0; jcollection < n; jcollection++) {
@@ -88,22 +85,18 @@ void NStencilHalfMulti3d::create()
         for (k = 0; k <= sz; k++)
           for (j = -sy; j <= sy; j++)
             for (i = -sx; i <= sx; i++)
-                  if (k > 0 || j > 0 || (j == 0 && i > 0)) {
-                    if (bin_distance_multi(i,j,k,bin_collection) < cutsq)
-                      stencil_multi[icollection][jcollection][ns++] =
-                          k*mbiny*mbinx + j*mbinx + i;
-                  }
+              if (k > 0 || j > 0 || (j == 0 && i > 0)) {
+                if (bin_distance_multi(i, j, k, bin_collection) < cutsq)
+                  stencil_multi[icollection][jcollection][ns++] = k * mbiny * mbinx + j * mbinx + i;
+              }
       } else {
         for (k = -sz; k <= sz; k++)
           for (j = -sy; j <= sy; j++)
             for (i = -sx; i <= sx; i++)
-                  if (bin_distance_multi(i,j,k,bin_collection) < cutsq)
-                    stencil_multi[icollection][jcollection][ns++] =
-                        k*mbiny*mbinx + j*mbinx + i;
+              if (bin_distance_multi(i, j, k, bin_collection) < cutsq)
+                stencil_multi[icollection][jcollection][ns++] = k * mbiny * mbinx + j * mbinx + i;
       }
-
       nstencil_multi[icollection][jcollection] = ns;
     }
   }
 }
-

--- a/src/nstencil_half_multi_3d_tri.cpp
+++ b/src/nstencil_half_multi_3d_tri.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -20,8 +19,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-NStencilHalfMulti3dTri::NStencilHalfMulti3dTri(LAMMPS *lmp) :
-  NStencil(lmp) {}
+NStencilHalfMulti3dTri::NStencilHalfMulti3dTri(LAMMPS *lmp) : NStencil(lmp) {}
 
 /* ---------------------------------------------------------------------- */
 
@@ -37,11 +35,11 @@ void NStencilHalfMulti3dTri::set_stencil_properties()
 
   for (i = 0; i < n; i++) {
     for (j = 0; j < n; j++) {
-      if(cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
+      if (cutcollectionsq[i][i] > cutcollectionsq[j][j]) continue;
 
       flag_skip_multi[i][j] = false;
 
-      if(cutcollectionsq[i][i] == cutcollectionsq[j][j]){
+      if (cutcollectionsq[i][i] == cutcollectionsq[j][j]) {
         flag_half_multi[i][j] = true;
         bin_collection_multi[i][j] = i;
       } else {
@@ -62,7 +60,6 @@ void NStencilHalfMulti3dTri::create()
   int n = ncollections;
   double cutsq;
 
-
   for (icollection = 0; icollection < n; icollection++) {
     for (jcollection = 0; jcollection < n; jcollection++) {
       if (flag_skip_multi[icollection][jcollection]) {
@@ -81,25 +78,21 @@ void NStencilHalfMulti3dTri::create()
       mbinz = stencil_mbinz_multi[icollection][jcollection];
 
       bin_collection = bin_collection_multi[icollection][jcollection];
-
       cutsq = cutcollectionsq[icollection][jcollection];
 
       if (flag_half_multi[icollection][jcollection]) {
         for (k = 0; k <= sz; k++)
           for (j = -sy; j <= sy; j++)
             for (i = -sx; i <= sx; i++)
-              if (bin_distance_multi(i,j,k,bin_collection) < cutsq)
-                    stencil_multi[icollection][jcollection][ns++] =
-                        k*mbiny*mbinx + j*mbinx + i;
+              if (bin_distance_multi(i, j, k, bin_collection) < cutsq)
+                stencil_multi[icollection][jcollection][ns++] = k * mbiny * mbinx + j * mbinx + i;
       } else {
         for (k = -sz; k <= sz; k++)
           for (j = -sy; j <= sy; j++)
             for (i = -sx; i <= sx; i++)
-                  if (bin_distance_multi(i,j,k,bin_collection) < cutsq)
-                    stencil_multi[icollection][jcollection][ns++] =
-                        k*mbiny*mbinx + j*mbinx + i;
+              if (bin_distance_multi(i, j, k, bin_collection) < cutsq)
+                stencil_multi[icollection][jcollection][ns++] = k * mbiny * mbinx + j * mbinx + i;
       }
-
       nstencil_multi[icollection][jcollection] = ns;
     }
   }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -76,6 +76,8 @@ Output::Output(LAMMPS *lmp) : Pointers(lmp)
 
   ndump = 0;
   max_dump = 0;
+  any_time_dumps = 0;
+  next_dump_any = next_time_dump_any = MAXBIGINT;
   mode_dump = nullptr;
   every_dump = nullptr;
   every_time_dump = nullptr;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -821,7 +821,7 @@ void Pair::map_element2type(int narg, char **arg, bool update_setflag)
   // elements = list of element names
 
   if (narg != ntypes)
-    error->all(FLERR,"Number of element to type mappings does not match number of atom types");
+    error->all(FLERR, "Number of element to type mappings does not match number of atom types");
 
   if (elements) {
     for (i = 0; i < nelements; i++) delete[] elements[i];

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -32,16 +31,17 @@
 #include "suffix.h"
 #include "update.h"
 
-#include <cfloat>    // IWYU pragma: keep
-#include <climits>   // IWYU pragma: keep
+#include <cfloat>     // IWYU pragma: keep
+#include <climits>    // IWYU pragma: keep
 #include <cmath>
 #include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-enum{NONE,RLINEAR,RSQ,BMP};
-static const std::string mixing_rule_names[Pair::SIXTHPOWER+1] = {"geometric", "arithmetic", "sixthpower" };
+enum { NONE, RLINEAR, RSQ, BMP };
+static const std::string mixing_rule_names[Pair::SIXTHPOWER + 1] = {"geometric", "arithmetic",
+                                                                    "sixthpower"};
 
 // allocate space for static class instance variable and initialize it
 
@@ -49,7 +49,15 @@ int Pair::instance_total = 0;
 
 /* ---------------------------------------------------------------------- */
 
-Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
+Pair::Pair(LAMMPS *lmp) :
+    Pointers(lmp), eatom(nullptr), vatom(nullptr), cvatom(nullptr), cutsq(nullptr),
+    setflag(nullptr), cutghost(nullptr), rtable(nullptr), drtable(nullptr), ftable(nullptr),
+    dftable(nullptr), ctable(nullptr), dctable(nullptr), etable(nullptr), detable(nullptr),
+    ptable(nullptr), dptable(nullptr), vtable(nullptr), dvtable(nullptr), rdisptable(nullptr),
+    drdisptable(nullptr), fdisptable(nullptr), dfdisptable(nullptr), edisptable(nullptr),
+    dedisptable(nullptr), pvector(nullptr), svector(nullptr), list(nullptr), listhalf(nullptr),
+    listfull(nullptr), list_tally_compute(nullptr), elements(nullptr), elem1param(nullptr),
+    elem2param(nullptr), elem3param(nullptr), map(nullptr)
 {
   instance_me = instance_total++;
 
@@ -71,12 +79,7 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   did_mix = false;
 
   nextra = 0;
-  pvector = nullptr;
   single_extra = 0;
-  svector = nullptr;
-
-  setflag = nullptr;
-  cutsq = nullptr;
 
   ewaldflag = pppmflag = msmflag = dispersionflag = tip4pflag = dipoleflag = spinflag = 0;
   reinitflag = 1;
@@ -95,27 +98,16 @@ Pair::Pair(LAMMPS *lmp) : Pointers(lmp)
   ndisptablebits = 12;
   tabinner = sqrt(2.0);
   tabinner_disp = sqrt(2.0);
-  ftable = nullptr;
-  fdisptable = nullptr;
   trim_flag = 1;
 
   allocated = 0;
   suffix_flag = Suffix::NONE;
 
   maxeatom = maxvatom = maxcvatom = 0;
-  eatom = nullptr;
-  vatom = nullptr;
-  cvatom = nullptr;
 
   num_tally_compute = 0;
-  list_tally_compute = nullptr;
 
   nelements = nparams = maxparam = 0;
-  elements = nullptr;
-  elem1param = nullptr;
-  elem2param = nullptr;
-  elem3param = nullptr;
-  map = nullptr;
 
   nondefault_history_transfer = 0;
   beyond_contact = 0;
@@ -150,6 +142,8 @@ Pair::~Pair()
   memory->destroy(vatom);
   memory->destroy(cvatom);
 }
+
+// clang-format off
 
 /* ----------------------------------------------------------------------
    modify parameters of the pair style

--- a/src/random_park.cpp
+++ b/src/random_park.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -15,14 +14,16 @@
 // Park/Miller RNG
 
 #include "random_park.h"
-#include <cmath>
+
 #include "error.h"
+
+#include <cmath>
 
 using namespace LAMMPS_NS;
 
 #define IA 16807
 #define IM 2147483647
-#define AM (1.0/IM)
+#define AM (1.0 / IM)
 #define IQ 127773
 #define IR 2836
 
@@ -30,8 +31,7 @@ using namespace LAMMPS_NS;
 
 RanPark::RanPark(LAMMPS *lmp, int seed_init) : Pointers(lmp)
 {
-  if (seed_init <= 0)
-    error->one(FLERR,"Invalid seed for Park random # generator");
+  if (seed_init <= 0) error->one(FLERR, "Invalid seed for Park random # generator");
   seed = seed_init;
   save = 0;
 }
@@ -42,10 +42,10 @@ RanPark::RanPark(LAMMPS *lmp, int seed_init) : Pointers(lmp)
 
 double RanPark::uniform()
 {
-  int k = seed/IQ;
-  seed = IA*(seed-k*IQ) - IR*k;
+  int k = seed / IQ;
+  seed = IA * (seed - k * IQ) - IR * k;
   if (seed < 0) seed += IM;
-  double ans = AM*seed;
+  double ans = AM * seed;
   return ans;
 }
 
@@ -55,17 +55,17 @@ double RanPark::uniform()
 
 double RanPark::gaussian()
 {
-  double first,v1,v2,rsq,fac;
+  double first, v1, v2, rsq, fac;
 
   if (!save) {
     do {
-      v1 = 2.0*uniform()-1.0;
-      v2 = 2.0*uniform()-1.0;
-      rsq = v1*v1 + v2*v2;
+      v1 = 2.0 * uniform() - 1.0;
+      v2 = 2.0 * uniform() - 1.0;
+      rsq = v1 * v1 + v2 * v2;
     } while ((rsq >= 1.0) || (rsq == 0.0));
-    fac = sqrt(-2.0*log(rsq)/rsq);
-    second = v1*fac;
-    first = v2*fac;
+    fac = sqrt(-2.0 * log(rsq) / rsq);
+    second = v1 * fac;
+    first = v2 * fac;
     save = 1;
   } else {
     first = second;
@@ -78,8 +78,7 @@ double RanPark::gaussian()
 
 void RanPark::reset(int seed_init)
 {
-  if (seed_init <= 0)
-    error->all(FLERR,"Invalid seed for Park random # generator");
+  if (seed_init <= 0) error->all(FLERR, "Invalid seed for Park random # generator");
   seed = seed_init;
   save = 0;
 }

--- a/src/region_plane.cpp
+++ b/src/region_plane.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -22,22 +21,23 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-RegPlane::RegPlane(LAMMPS *lmp, int narg, char **arg) :
-  Region(lmp, narg, arg)
+RegPlane::RegPlane(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg)
 {
-  options(narg-8,&arg[8]);
+  options(narg - 8, &arg[8]);
 
-  xp = xscale*utils::numeric(FLERR,arg[2],false,lmp);
-  yp = yscale*utils::numeric(FLERR,arg[3],false,lmp);
-  zp = zscale*utils::numeric(FLERR,arg[4],false,lmp);
-  normal[0] = xscale*utils::numeric(FLERR,arg[5],false,lmp);
-  normal[1] = yscale*utils::numeric(FLERR,arg[6],false,lmp);
-  normal[2] = zscale*utils::numeric(FLERR,arg[7],false,lmp);
+  xp = xscale * utils::numeric(FLERR, arg[2], false, lmp);
+  yp = yscale * utils::numeric(FLERR, arg[3], false, lmp);
+  zp = zscale * utils::numeric(FLERR, arg[4], false, lmp);
+  normal[0] = xscale * utils::numeric(FLERR, arg[5], false, lmp);
+  normal[1] = yscale * utils::numeric(FLERR, arg[6], false, lmp);
+  normal[2] = zscale * utils::numeric(FLERR, arg[7], false, lmp);
 
   // enforce unit normal
 
-  double rsq = normal[0]*normal[0] + normal[1]*normal[1] + normal[2]*normal[2];
-  if (rsq == 0.0) error->all(FLERR,"Illegal region plane normal vector: {} {} {}", normal[0], normal[1], normal[2]);
+  double rsq = normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2];
+  if (rsq == 0.0)
+    error->all(FLERR, "Illegal region plane normal vector: {} {} {}", normal[0], normal[1],
+               normal[2]);
   normal[0] /= sqrt(rsq);
   normal[1] /= sqrt(rsq);
   normal[2] /= sqrt(rsq);
@@ -54,7 +54,7 @@ RegPlane::RegPlane(LAMMPS *lmp, int narg, char **arg) :
 
 RegPlane::~RegPlane()
 {
-  delete [] contact;
+  delete[] contact;
 }
 
 /* ----------------------------------------------------------------------
@@ -65,7 +65,7 @@ RegPlane::~RegPlane()
 
 int RegPlane::inside(double x, double y, double z)
 {
-  double dot = (x-xp)*normal[0] + (y-yp)*normal[1] + (z-zp)*normal[2];
+  double dot = (x - xp) * normal[0] + (y - yp) * normal[1] + (z - zp) * normal[2];
 
   if (dot >= 0.0) return 1;
   return 0;
@@ -79,12 +79,12 @@ int RegPlane::inside(double x, double y, double z)
 
 int RegPlane::surface_interior(double *x, double cutoff)
 {
-  double dot = (x[0]-xp)*normal[0] + (x[1]-yp)*normal[1] + (x[2]-zp)*normal[2];
+  double dot = (x[0] - xp) * normal[0] + (x[1] - yp) * normal[1] + (x[2] - zp) * normal[2];
   if (dot < cutoff && dot >= 0.0) {
     contact[0].r = dot;
-    contact[0].delx = dot*normal[0];
-    contact[0].dely = dot*normal[1];
-    contact[0].delz = dot*normal[2];
+    contact[0].delx = dot * normal[0];
+    contact[0].dely = dot * normal[1];
+    contact[0].delz = dot * normal[2];
     contact[0].radius = 0;
     contact[0].iwall = 0;
     return 1;
@@ -100,13 +100,13 @@ int RegPlane::surface_interior(double *x, double cutoff)
 
 int RegPlane::surface_exterior(double *x, double cutoff)
 {
-  double dot = (x[0]-xp)*normal[0] + (x[1]-yp)*normal[1] + (x[2]-zp)*normal[2];
+  double dot = (x[0] - xp) * normal[0] + (x[1] - yp) * normal[1] + (x[2] - zp) * normal[2];
   dot = -dot;
   if (dot < cutoff && dot >= 0.0) {
     contact[0].r = dot;
-    contact[0].delx = -dot*normal[0];
-    contact[0].dely = -dot*normal[1];
-    contact[0].delz = -dot*normal[2];
+    contact[0].delx = -dot * normal[0];
+    contact[0].dely = -dot * normal[1];
+    contact[0].delz = -dot * normal[2];
     contact[0].radius = 0;
     contact[0].iwall = 0;
     return 1;

--- a/unittest/commands/test_groups.cpp
+++ b/unittest/commands/test_groups.cpp
@@ -249,7 +249,7 @@ TEST_F(GroupTest, Molecular)
     ASSERT_DOUBLE_EQ(group->mass(group->find("half")), 40);
     ASSERT_DOUBLE_EQ(group->mass(group->find("half"), domain->get_region_by_id("top")), 10);
     ASSERT_NEAR(group->charge(group->find("top")), 0, 1.0e-14);
-    ASSERT_NEAR(group->charge(group->find("right"), domain->get_region_by_id("top")), 0, 1.0e-14);
+    ASSERT_NEAR(group->charge(group->find("three"), domain->get_region_by_id("top")), 0, 1.0e-14);
 
     TEST_FAILURE(".*ERROR: Unknown group include keyword xxx.*",
                  command("group three include xxx"););


### PR DESCRIPTION
**Summary**

This pull request combines multiple small bug fixes and updates.

**Related Issue(s)**

Addresses concerns from https://matsci.org/t/questions-and-improvements-about-the-pair-ylz-cpp-file/47676/
Fixes #3708 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- fix typo in recently added ComputChunk class
- fix uninitialized data access bug in fix wall/gran/region
- plug memory leaks, improve error message, and remove redundant calls to fmt::format()  in fix electrode/conp
- remove redundant code and improve error message in EAM pair style variants
- move check for non-ellipsoid atoms in pair style ylz to compute() function so it is compatible with hybrid pair styles where not all pair styles use ellipsoids
- initialize *all* pointers of Pair class to null and move the initialization to the initializer list of the constructor
- enable and apply clang-format for a few more files
- apply logic simplifications and modernizations suggested by clang-tidy
- use MathSpecial::powint() instead of pow() for integer powers in wall fixes and Pair class
- tweak sphinx settings so the HTML and PDF manual have the same chapter numbers

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
