### PR TITLE
BUGFIX: pppm_kokkos.cpp: for triclinic case,  initialize h_inv on dev…

### DIFF
--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -1016,6 +1016,7 @@ void PPPMKokkos<DeviceType>::set_grid_global()
     tmp[0] = nx_pppm;
     tmp[1] = ny_pppm;
     tmp[2] = nz_pppm;
+    h_inv = Few<double, 6>(domain->h_inv);
     x2lamdaT(&tmp[0],&tmp[0]);
     h_x = 1.0/tmp[0];
     h_y = 1.0/tmp[1];


### PR DESCRIPTION
**Summary**

BUGFIX: pppm_kokkos.cpp: for triclinic case,  initialize h_inv on device to compute h_x, h_y, h_z

**Related Issue(s)**
pppm/kk  with triclinic cell  show
ERROR: Could not compute g_ewald (src/KOKKOS/pppm_kokkos.cpp:1103)

**Author(s)**

Yury Lysogorskiy

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

Move h_inv to device before calling x2lamdaT

```
h_inv = Few<double, 6>(domain->h_inv);
x2lamdaT(&tmp[0],&tmp[0]);
```

**Post Submission Checklist**

- [X] The feature or features in this pull request is complete
- [X] Licensing information is complete
- [X] Corresponding author information is complete
- [X] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [X] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


