### PR TITLE
Bugfix amoeba doc header

### DIFF
--- a/doc/src/improper_amoeba.rst
+++ b/doc/src/improper_amoeba.rst
@@ -1,7 +1,7 @@
 .. index:: improper_style amoeba
 
-improper_style harmonic command
-===============================
+improper_style amoeba command
+=============================
 
 Syntax
 """"""


### PR DESCRIPTION
**Summary**

Title of improper style 'amoeba' in documentation is fixed.
This fixes a bug that currently shows the amoeba style as "improper_style harmonic command" in the overview: https://docs.lammps.org/impropers.html

**Related Issue(s)**

**Author(s)**

Ludwig Ahrens-Iwers
ludwig.ahiw@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


