### PR TITLE
Small update for the 28 March 2023 release to recover Sphinx formatting of the Documentation website

### DIFF
--- a/doc/utils/requirements.txt
+++ b/doc/utils/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx < 7.0.0
+Sphinx < 6.0.0
 sphinxcontrib-spelling
 sphinxcontrib-jquery >=3.0.0
 git+https://github.com/akohlmey/sphinx-fortran@parallel-read

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,2 @@
 #define LAMMPS_VERSION "28 Mar 2023"
+#define LAMMPS_UPDATE "Update 1"


### PR DESCRIPTION
When using Sphinx 6.x we need an upgrade of the LAMMPS theme to restore docs.lammps.org to its full glory.
This change requires Sphinx to be a pre-6.x version (for now) until we update the theme for the next feature release

No functional changes are included. This is just to trigger a new build of the online manual.