### PR TITLE
Cleanup internally created group in fix gcmc

### DIFF
--- a/src/MC/fix_charge_regulation.cpp
+++ b/src/MC/fix_charge_regulation.cpp
@@ -79,6 +79,8 @@ FixChargeRegulation::FixChargeRegulation(LAMMPS *lmp, int narg, char **arg) :
   c_pe(nullptr), random_equal(nullptr), random_unequal(nullptr),
   idftemp(nullptr)
 {
+  if (narg < 5) utils::missing_cmd_args(FLERR, "fix charge/regulation", error);
+
   if (lmp->citeme) lmp->citeme->add(cite_fix_charge_regulation);
 
   // Region restrictions not yet implemented ..
@@ -221,12 +223,11 @@ void FixChargeRegulation::init() {
 
     // create unique group name for atoms to be excluded
 
-    auto group_id = fmt::format("FixChargeRegulation:exclusion_group:{}",id);
+    auto group_id = std::string("FixChargeRegulation:exclusion_group:") + id;
     group->assign(group_id + " subtract all all");
     exclusion_group = group->find(group_id);
     if (exclusion_group == -1)
-      error->all(FLERR,"Could not find fix charge/regulation exclusion "
-                 "group ID");
+      error->all(FLERR,"Could not find fix charge/regulation exclusion group ID");
     exclusion_group_bit = group->bitmask[exclusion_group];
 
     // neighbor list exclusion setup
@@ -250,8 +251,7 @@ void FixChargeRegulation::init() {
     MPI_Allreduce(&flag, &flagall, 1, MPI_INT, MPI_SUM, world);
 
     if (flagall)
-      error->all(FLERR, "Cannot use fix charge/regulation on atoms "
-                 "in atom_modify first group");
+      error->all(FLERR, "Cannot use fix charge/regulation on atoms in atom_modify first group");
   }
 
   // construct group bitmask for all new atoms

--- a/src/MC/fix_charge_regulation.cpp
+++ b/src/MC/fix_charge_regulation.cpp
@@ -151,6 +151,16 @@ FixChargeRegulation::~FixChargeRegulation() {
   delete[] pHstr;
   delete[] idftemp;
 
+  // delete exclusion group created in init()
+  // unset neighbor exclusion settings made in init()
+  // not necessary if group and neighbor classes already destroyed
+  //   when LAMMPS exits
+
+  if (exclusion_group_bit && group) {
+    auto group_id = std::string("FixChargeRegulation:gcmc_exclusion_group:") + id;
+    group->assign(group_id + " delete");
+  }
+
   if (group) {
     int igroupall = group->find("all");
     neighbor->exclusion_group_group_delete(exclusion_group, igroupall);

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -61,19 +61,19 @@ using namespace MathConst;
 
 #define MAXENERGYTEST 1.0e50
 
-enum{EXCHATOM,EXCHMOL}; // exchmode
-enum{NONE,MOVEATOM,MOVEMOL}; // movemode
+enum { EXCHATOM, EXCHMOL };          // exchmode
+enum { NONE, MOVEATOM, MOVEMOL };    // movemode
 
 /* ---------------------------------------------------------------------- */
 
 FixGCMC::FixGCMC(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg),
-  region(nullptr), idregion(nullptr), full_flag(false), groupstrings(nullptr),
-  grouptypestrings(nullptr), grouptypebits(nullptr), grouptypes(nullptr), local_gas_list(nullptr),
-  molcoords(nullptr), molq(nullptr), molimage(nullptr), random_equal(nullptr), random_unequal(nullptr),
-  fixrigid(nullptr), fixshake(nullptr), idrigid(nullptr), idshake(nullptr)
+    Fix(lmp, narg, arg), region(nullptr), idregion(nullptr), full_flag(false),
+    groupstrings(nullptr), grouptypestrings(nullptr), grouptypebits(nullptr), grouptypes(nullptr),
+    local_gas_list(nullptr), molcoords(nullptr), molq(nullptr), molimage(nullptr),
+    random_equal(nullptr), random_unequal(nullptr), fixrigid(nullptr), fixshake(nullptr),
+    idrigid(nullptr), idshake(nullptr)
 {
-  if (narg < 11) error->all(FLERR,"Illegal fix gcmc command");
+  if (narg < 11) utils::missing_cmd_args(FLERR, "fix gcmc", error);
 
   if (atom->molecular == Atom::TEMPLATE)
     error->all(FLERR,"Fix gcmc does not (yet) work with atom_style template");
@@ -583,8 +583,7 @@ void FixGCMC::init()
     fixshake = modify->fix[ifix];
     int tmp;
     if (&onemols[imol] != (Molecule **) fixshake->extract("onemol",tmp))
-      error->all(FLERR,"Fix gcmc and fix shake not using "
-                 "same molecule template ID");
+      error->all(FLERR,"Fix gcmc and fix shake not using same molecule template ID");
   }
 
   if (domain->dimension == 2)

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -418,12 +418,12 @@ FixGCMC::~FixGCMC()
       delete[] grouptypestrings[igroup];
     memory->sfree(grouptypestrings);
   }
-  
+
   // delete exclusion group created in init()
   // unset neighbor exclusion settings made in init()
   // not necessary if group and neighbor classes already destroyed
   //   when LAMMPS exits
-  
+
   if (full_flag && group && exclusion_group_bit) {
     auto group_id = std::string("FixGCMC:gcmc_exclusion_group:") + id;
     group->assign(group_id + " delete");
@@ -460,14 +460,14 @@ void FixGCMC::init()
 
   if (triclinic) {
     if ((region_xlo < domain->boxlo_bound[0]) || (region_xhi > domain->boxhi_bound[0]) ||
-	(region_ylo < domain->boxlo_bound[1]) || (region_yhi > domain->boxhi_bound[1]) ||
-	(region_zlo < domain->boxlo_bound[2]) || (region_zhi > domain->boxhi_bound[2])) {
+        (region_ylo < domain->boxlo_bound[1]) || (region_yhi > domain->boxhi_bound[1]) ||
+        (region_zlo < domain->boxlo_bound[2]) || (region_zhi > domain->boxhi_bound[2])) {
       error->all(FLERR,"Fix gcmc region extends outside simulation box");
     }
   } else {
     if ((region_xlo < domain->boxlo[0]) || (region_xhi > domain->boxhi[0]) ||
-	(region_ylo < domain->boxlo[1]) || (region_yhi > domain->boxhi[1]) ||
-	(region_zlo < domain->boxlo[2]) || (region_zhi > domain->boxhi[2]))
+        (region_ylo < domain->boxlo[1]) || (region_yhi > domain->boxhi[1]) ||
+        (region_zlo < domain->boxlo[2]) || (region_zhi > domain->boxhi[2]))
       error->all(FLERR,"Fix gcmc region extends outside simulation box");
   }
 

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -418,11 +418,21 @@ FixGCMC::~FixGCMC()
       delete[] grouptypestrings[igroup];
     memory->sfree(grouptypestrings);
   }
-  if (full_flag && group) {
+  
+  // delete exclusion group created in init()
+  // unset neighbor exclusion settings made in init()
+  // not necessary if group and neighbor classes already destroyed
+  //   when LAMMPS exits
+  
+  if (full_flag && group && exclusion_group_bit) {
+    auto group_id = std::string("FixGCMC:gcmc_exclusion_group:") + id;
+    group->assign(group_id + " delete");
+  }
+
+  if (full_flag && group && neighbor) {
     int igroupall = group->find("all");
     neighbor->exclusion_group_group_delete(exclusion_group,igroupall);
   }
-
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -420,12 +420,18 @@ FixGCMC::~FixGCMC()
   }
   
   // delete exclusion group created in init()
+  // delete molecule group created in init()
   // unset neighbor exclusion settings made in init()
   // not necessary if group and neighbor classes already destroyed
   //   when LAMMPS exits
   
-  if (full_flag && group && exclusion_group_bit) {
+  if (exclusion_group_bit && group) {
     auto group_id = std::string("FixGCMC:gcmc_exclusion_group:") + id;
+    group->assign(group_id + " delete");
+  }
+
+  if (molecule_group_bit && group) {
+    auto group_id = std::string("FixGCMC:rotation_gas_atoms:") + id;
     group->assign(group_id + " delete");
   }
 

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -62,7 +62,7 @@ FixWidom::FixWidom(LAMMPS *lmp, int narg, char **arg) :
   if (narg < 8) utils::missing_cmd_args(FLERR, "fix widom", error);
 
   if (atom->molecular == Atom::TEMPLATE)
-    error->all(FLERR,"Fix widom does not (yet) work with atom_style template");
+    error->all(FLERR, "Fix widom does not (yet) work with atom_style template");
 
   dynamic_group_allow = 1;
 
@@ -252,7 +252,7 @@ FixWidom::~FixWidom()
   // unset neighbor exclusion settings made in init()
   // not necessary if group and neighbor classes already destroyed
   //   when LAMMPS exits
-  
+
   if (exclusion_group_bit && group) {
     auto group_id = std::string("FixWidom:widom_exclusion_group:") + id;
     group->assign(group_id + " delete");
@@ -423,7 +423,8 @@ void FixWidom::init()
   // full_flag on molecules on more than one processor.
   // Print error if this is the current mode
   if (full_flag && (exchmode == EXCHMOL) && comm->nprocs > 1)
-    error->all(FLERR,"fix widom does currently not support full_energy option with molecules on more than 1 MPI process.");
+    error->all(FLERR,"fix widom does currently not support full_energy option with "
+               "molecules on more than 1 MPI process.");
 
 }
 

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -247,6 +247,26 @@ FixWidom::~FixWidom()
   memory->destroy(molq);
   memory->destroy(molimage);
 
+  // delete exclusion group created in init()
+  // delete molecule group created in init()
+  // unset neighbor exclusion settings made in init()
+  // not necessary if group and neighbor classes already destroyed
+  //   when LAMMPS exits
+  
+  if (exclusion_group_bit && group) {
+    auto group_id = std::string("FixWidom:widom_exclusion_group:") + id;
+    group->assign(group_id + " delete");
+  }
+
+  if (molecule_group_bit && group) {
+    auto group_id = std::string("FixWidom:rotation_gas_atoms:") + id;
+    group->assign(group_id + " delete");
+  }
+
+  if (full_flag && group && neighbor) {
+    int igroupall = group->find("all");
+    neighbor->exclusion_group_group_delete(exclusion_group,igroupall);
+  }
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
**Summary**

Add code in destructor to delete the exclusion group created by fix gcmc.  Also the rotation group.  Ditto for fix widom.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


