### PR TITLE
Refactor fix shake to use `closest_image` instead of `minimum_image_once`

### DIFF
--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -479,6 +479,26 @@ void FixShakeKokkos<DeviceType>::post_force(int vflag)
   }
 }
 
+/* ----------------------------------------------------------------------
+   substitute shake constraints with very strong bonds
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixShakeKokkos<DeviceType>::min_post_force(int vflag)
+{
+  // not yet ported to Kokkos
+
+  atomKK->sync(Host,X_MASK | F_MASK);
+  k_shake_flag.sync_host();
+  k_shake_type.sync_host();
+  k_list.sync_host();
+  k_closest_list.sync_host();
+
+  FixShake::min_post_force(vflag);
+
+  atomKK->modified(Host,F_MASK);
+}
+
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -372,15 +372,8 @@ void FixShakeKokkos<DeviceType>::post_force(int vflag)
   k_list.sync<DeviceType>();
   k_closest_list.sync<DeviceType>();
 
-  if (update->ntimestep == next_output) {
-    atomKK->sync(Host,X_MASK);
-    k_shake_flag.sync_host();
-    k_shake_atom.sync_host();
-    k_shake_type.sync_host();
-    k_list.sync_host();
-    k_closest_list.sync_host();
+  if (update->ntimestep == next_output)
     stats();
-  }
 
   // xshake = unconstrained move with current v,f
   // communicate results if necessary
@@ -1413,6 +1406,23 @@ void FixShakeKokkos<DeviceType>::shake3angle(int ilist, EV_FLOAT& ev) const
 
     v_tally<NEIGHFLAG>(ev,count,atomlist,3.0,v);
   }
+}
+
+/* ----------------------------------------------------------------------
+   print-out bond & angle statistics
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixShakeKokkos<DeviceType>::stats()
+{
+  atomKK->sync(Host,X_MASK);
+  k_shake_flag.sync_host();
+  k_shake_atom.sync_host();
+  k_shake_type.sync_host();
+  k_list.sync_host();
+  k_closest_list.sync_host();
+
+  FixShake::stats();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/fix_shake_kokkos.h
+++ b/src/KOKKOS/fix_shake_kokkos.h
@@ -138,6 +138,7 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
   DAT::tdual_int_scalar k_error_flag;
   DAT::tdual_int_scalar k_nlist;
 
+  void stats() override;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/fix_shake_kokkos.h
+++ b/src/KOKKOS/fix_shake_kokkos.h
@@ -133,7 +133,7 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
   typename AT::t_int_1d d_list; // list of clusters to SHAKE
 
   DAT::tdual_int_2d k_closest_list;
-  typename AT::t_int_2d d_closest_list; // list of closest images in SHAKE clusters
+  typename AT::t_int_2d d_closest_list; // list of closest atom indices in SHAKE clusters
 
   DAT::tdual_int_scalar k_error_flag;
   DAT::tdual_int_scalar k_nlist;

--- a/src/KOKKOS/fix_shake_kokkos.h
+++ b/src/KOKKOS/fix_shake_kokkos.h
@@ -132,6 +132,9 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
   DAT::tdual_int_1d k_list;
   typename AT::t_int_1d d_list; // list of clusters to SHAKE
 
+  DAT::tdual_int_2d k_closest_list;
+  typename AT::t_int_2d d_closest_list; // list of closest images in SHAKE clusters
+
   DAT::tdual_int_scalar k_error_flag;
   DAT::tdual_int_scalar k_nlist;
 
@@ -191,6 +194,8 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
   tagint **shake_atom_tmp;
   int **shake_type_tmp;
 
+  DAT::tdual_int_1d k_sametag;
+  typename AT::t_int_1d d_sametag;
   int map_style;
   DAT::tdual_int_1d k_map_array;
   dual_hash_type k_map_hash;
@@ -198,12 +203,7 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
   // copied from Domain
 
   KOKKOS_INLINE_FUNCTION
-  void minimum_image(double *) const;
-
-  KOKKOS_INLINE_FUNCTION
-  void minimum_image_once(double *) const;
-
-  void update_domain_variables();
+  int closest_image(const int, int) const;
 
   int triclinic;
   int xperiodic,yperiodic,zperiodic;

--- a/src/KOKKOS/fix_shake_kokkos.h
+++ b/src/KOKKOS/fix_shake_kokkos.h
@@ -54,6 +54,7 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
   void min_setup(int) override;
   void pre_neighbor() override;
   void post_force(int) override;
+  void min_post_force(int) override;
 
   void grow_arrays(int) override;
   void copy_arrays(int, int, int) override;

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -627,7 +627,7 @@ void FixShake::post_force(int vflag)
   // communicate results if necessary
 
   unconstrained_update();
-  if (comm->nprocs > 1) comm->forward_comm(this);
+  comm->forward_comm(this);
 
   // virial setup
 
@@ -673,7 +673,7 @@ void FixShake::post_force_respa(int vflag, int ilevel, int iloop)
   // communicate results if necessary
 
   unconstrained_update_respa(ilevel);
-  if (comm->nprocs > 1) comm->forward_comm(this);
+  comm->forward_comm(this);
 
   // virial setup only needed on last iteration of innermost level
   //   and if pressure is requested

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -1767,19 +1767,21 @@ void FixShake::unconstrained_update_respa(int ilevel)
   }
 }
 
-/* ---------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------
+   calculate SHAKE constraint forces for size 2 cluster = single bond
+------------------------------------------------------------------------- */
 
-void FixShake::shake(int i)
+void FixShake::shake(int ilist)
 {
-  int nlist,atomlist[2];
+  int atomlist[2];
   double v[6];
   double invmass0,invmass1;
 
   // local atom IDs and constraint distances
 
-  int m = list[i];
-  int i0 = closest_list[i][0];
-  int i1 = closest_list[i][1];
+  int m = list[ilist];
+  int i0 = closest_list[ilist][0];
+  int i1 = closest_list[ilist][1];
   double bond1 = bond_distance[shake_type[m][0]];
 
   // r01 = distance vec between atoms
@@ -1850,9 +1852,9 @@ void FixShake::shake(int i)
   }
 
   if (evflag) {
-    nlist = 0;
-    if (i0 < nlocal) atomlist[nlist++] = i0;
-    if (i1 < nlocal) atomlist[nlist++] = i1;
+    int count = 0;
+    if (i0 < nlocal) atomlist[count++] = i0;
+    if (i1 < nlocal) atomlist[count++] = i1;
 
     v[0] = lamda*r01[0]*r01[0];
     v[1] = lamda*r01[1]*r01[1];
@@ -1864,24 +1866,26 @@ void FixShake::shake(int i)
     double fpairlist[] = {lamda};
     double dellist[][3]  = {{r01[0], r01[1], r01[2]}};
     int pairlist[][2] = {{i0,i1}};
-    v_tally(nlist,atomlist,2.0,v,nlocal,1,pairlist,fpairlist,dellist);
+    v_tally(count,atomlist,2.0,v,nlocal,1,pairlist,fpairlist,dellist);
   }
 }
 
-/* ---------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------
+   calculate SHAKE constraint forces for size 3 cluster = two bonds
+------------------------------------------------------------------------- */
 
-void FixShake::shake3(int i)
+void FixShake::shake3(int ilist)
 {
-  int nlist,atomlist[3];
+  int atomlist[3];
   double v[6];
   double invmass0,invmass1,invmass2;
 
   // local atom IDs and constraint distances
 
-  int m = list[i];
-  int i0 = closest_list[i][0];
-  int i1 = closest_list[i][1];
-  int i2 = closest_list[i][2];
+  int m = list[ilist];
+  int i0 = closest_list[ilist][0];
+  int i1 = closest_list[ilist][1];
+  int i2 = closest_list[ilist][2];
   double bond1 = bond_distance[shake_type[m][0]];
   double bond2 = bond_distance[shake_type[m][1]];
 
@@ -2020,10 +2024,10 @@ void FixShake::shake3(int i)
   }
 
   if (evflag) {
-    nlist = 0;
-    if (i0 < nlocal) atomlist[nlist++] = i0;
-    if (i1 < nlocal) atomlist[nlist++] = i1;
-    if (i2 < nlocal) atomlist[nlist++] = i2;
+    int count = 0;
+    if (i0 < nlocal) atomlist[count++] = i0;
+    if (i1 < nlocal) atomlist[count++] = i1;
+    if (i2 < nlocal) atomlist[count++] = i2;
 
     v[0] = lamda01*r01[0]*r01[0] + lamda02*r02[0]*r02[0];
     v[1] = lamda01*r01[1]*r01[1] + lamda02*r02[1]*r02[1];
@@ -2036,25 +2040,27 @@ void FixShake::shake3(int i)
     double dellist[][3]  = {{r01[0], r01[1], r01[2]},
                             {r02[0], r02[1], r02[2]}};
     int pairlist[][2] = {{i0,i1}, {i0,i2}};
-    v_tally(nlist,atomlist,3.0,v,nlocal,2,pairlist,fpairlist,dellist);
+    v_tally(count,atomlist,3.0,v,nlocal,2,pairlist,fpairlist,dellist);
   }
 }
 
-/* ---------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------
+   calculate SHAKE constraint forces for size 4 cluster = three bonds
+------------------------------------------------------------------------- */
 
-void FixShake::shake4(int i)
+void FixShake::shake4(int ilist)
 {
- int nlist,atomlist[4];
+ int atomlist[4];
   double v[6];
   double invmass0,invmass1,invmass2,invmass3;
 
   // local atom IDs and constraint distances
 
-  int m = list[i];
-  int i0 = closest_list[i][0];
-  int i1 = closest_list[i][1];
-  int i2 = closest_list[i][2];
-  int i3 = closest_list[i][3];
+  int m = list[ilist];
+  int i0 = closest_list[ilist][0];
+  int i1 = closest_list[ilist][1];
+  int i2 = closest_list[ilist][2];
+  int i3 = closest_list[ilist][3];
   double bond1 = bond_distance[shake_type[m][0]];
   double bond2 = bond_distance[shake_type[m][1]];
   double bond3 = bond_distance[shake_type[m][2]];
@@ -2268,11 +2274,11 @@ void FixShake::shake4(int i)
   }
 
   if (evflag) {
-    nlist = 0;
-    if (i0 < nlocal) atomlist[nlist++] = i0;
-    if (i1 < nlocal) atomlist[nlist++] = i1;
-    if (i2 < nlocal) atomlist[nlist++] = i2;
-    if (i3 < nlocal) atomlist[nlist++] = i3;
+    int count = 0;
+    if (i0 < nlocal) atomlist[count++] = i0;
+    if (i1 < nlocal) atomlist[count++] = i1;
+    if (i2 < nlocal) atomlist[count++] = i2;
+    if (i3 < nlocal) atomlist[count++] = i3;
 
     v[0] = lamda01*r01[0]*r01[0]+lamda02*r02[0]*r02[0]+lamda03*r03[0]*r03[0];
     v[1] = lamda01*r01[1]*r01[1]+lamda02*r02[1]*r02[1]+lamda03*r03[1]*r03[1];
@@ -2286,24 +2292,26 @@ void FixShake::shake4(int i)
                             {r02[0], r02[1], r02[2]},
                             {r03[0], r03[1], r03[2]}};
     int pairlist[][2] = {{i0,i1}, {i0,i2}, {i0,i3}};
-    v_tally(nlist,atomlist,4.0,v,nlocal,3,pairlist,fpairlist,dellist);
+    v_tally(count,atomlist,4.0,v,nlocal,3,pairlist,fpairlist,dellist);
   }
 }
 
-/* ---------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------
+   calculate SHAKE constraint forces for size 3 cluster = two bonds + angle
+------------------------------------------------------------------------- */
 
-void FixShake::shake3angle(int i)
+void FixShake::shake3angle(int ilist)
 {
-  int nlist,atomlist[3];
+  int atomlist[3];
   double v[6];
   double invmass0,invmass1,invmass2;
 
   // local atom IDs and constraint distances
 
-  int m = list[i];
-  int i0 = closest_list[i][0];
-  int i1 = closest_list[i][1];
-  int i2 = closest_list[i][2];
+  int m = list[ilist];
+  int i0 = closest_list[ilist][0];
+  int i1 = closest_list[ilist][1];
+  int i2 = closest_list[ilist][2];
   double bond1 = bond_distance[shake_type[m][0]];
   double bond2 = bond_distance[shake_type[m][1]];
   double bond12 = angle_distance[shake_type[m][2]];
@@ -2510,10 +2518,10 @@ void FixShake::shake3angle(int i)
   }
 
   if (evflag) {
-    nlist = 0;
-    if (i0 < nlocal) atomlist[nlist++] = i0;
-    if (i1 < nlocal) atomlist[nlist++] = i1;
-    if (i2 < nlocal) atomlist[nlist++] = i2;
+    int count = 0;
+    if (i0 < nlocal) atomlist[count++] = i0;
+    if (i1 < nlocal) atomlist[count++] = i1;
+    if (i2 < nlocal) atomlist[count++] = i2;
 
     v[0] = lamda01*r01[0]*r01[0]+lamda02*r02[0]*r02[0]+lamda12*r12[0]*r12[0];
     v[1] = lamda01*r01[1]*r01[1]+lamda02*r02[1]*r02[1]+lamda12*r12[1]*r12[1];
@@ -2527,12 +2535,12 @@ void FixShake::shake3angle(int i)
                             {r02[0], r02[1], r02[2]},
                             {r12[0], r12[1], r12[2]}};
     int pairlist[][2] = {{i0,i1}, {i0,i2}, {i1,i2}};
-    v_tally(nlist,atomlist,3.0,v,nlocal,3,pairlist,fpairlist,dellist);
+    v_tally(count,atomlist,3.0,v,nlocal,3,pairlist,fpairlist,dellist);
   }
 }
 
 /* ----------------------------------------------------------------------
-   apply bond force for minimization
+   apply bond force for minimization between atom indices i1 and i2
 ------------------------------------------------------------------------- */
 
 void FixShake::bond_force(int i1, int i2, double length)
@@ -2552,21 +2560,21 @@ void FixShake::bond_force(int i1, int i2, double length)
   const double rk = kbond * dr;
   const double fbond = (r > 0.0) ? -2.0 * rk / r : 0.0;
   const double eb = rk*dr;
-  int list[2];
-  int nlist = 0;
+  int atomlist[2];
+  int count = 0;
 
   if (i1 < nlocal) {
     f[i1][0] += delx * fbond;
     f[i1][1] += dely * fbond;
     f[i1][2] += delz * fbond;
-    list[nlist++] = i1;
+    atomlist[count++] = i1;
     ebond += 0.5*eb;
   }
   if (i2 < nlocal) {
     f[i2][0] -= delx * fbond;
     f[i2][1] -= dely * fbond;
     f[i2][2] -= delz * fbond;
-    list[nlist++] = i2;
+    atomlist[count++] = i2;
     ebond += 0.5*eb;
   }
   if (evflag) {
@@ -2577,7 +2585,7 @@ void FixShake::bond_force(int i1, int i2, double length)
     v[3] = 0.5 * delx * dely * fbond;
     v[4] = 0.5 * delx * delz * fbond;
     v[5] = 0.5 * dely * delz * fbond;
-    ev_tally(nlist, list, 2.0, eb, v);
+    ev_tally(count, atomlist, 2.0, eb, v);
   }
 }
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -604,7 +604,6 @@ void FixShake::pre_neighbor()
         atom3 = domain->closest_image(i, atom3);
         atom4 = domain->closest_image(i, atom4);
         if (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4) {
-          list[nlist++] = i;
           list[nlist] = i;
           closest_list[nlist][0] = atom1;
           closest_list[nlist][1] = atom2;

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -55,7 +55,7 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
   b_count(nullptr), b_count_all(nullptr), b_ave(nullptr), b_max(nullptr), b_min(nullptr),
   b_ave_all(nullptr), b_max_all(nullptr), b_min_all(nullptr), a_count(nullptr),
   a_count_all(nullptr), a_ave(nullptr), a_max(nullptr), a_min(nullptr), a_ave_all(nullptr),
-  a_max_all(nullptr), a_min_all(nullptr), atommols(nullptr), onemols(nullptr)
+  a_max_all(nullptr), a_min_all(nullptr), atommols(nullptr), onemols(nullptr), closest_list(nullptr)
 {
   energy_global_flag = energy_peratom_flag = 1;
   virial_global_flag = virial_peratom_flag = 1;
@@ -244,6 +244,7 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
 
   maxlist = 0;
   list = nullptr;
+  closest_list = nullptr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -319,6 +320,7 @@ FixShake::~FixShake()
   }
 
   memory->destroy(list);
+  memory->destroy(closest_list);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -546,6 +548,8 @@ void FixShake::pre_neighbor()
     maxlist = nlocal;
     memory->destroy(list);
     memory->create(list,maxlist,"shake:list");
+    memory->destroy(closest_list);
+    memory->create(closest_list,maxlist,4,"shake:closest_list");
   }
 
   // build list of SHAKE clusters I compute
@@ -560,7 +564,14 @@ void FixShake::pre_neighbor()
         if (atom1 == -1 || atom2 == -1)
           error->one(FLERR,"Shake atoms {} {} missing on proc {} at step {}",shake_atom[i][0],
                      shake_atom[i][1],comm->me,update->ntimestep);
-        if (i <= atom1 && i <= atom2) list[nlist++] = i;
+        atom1 = domain->closest_image(i, atom1);
+        atom2 = domain->closest_image(i, atom2);
+        if (i <= atom1 && i <= atom2) {
+          list[nlist] = i;
+          closest_list[nlist][0] = atom1;
+          closest_list[nlist][1] = atom2;
+          nlist++;
+        }
       } else if (shake_flag[i] % 2 == 1) {
         atom1 = atom->map(shake_atom[i][0]);
         atom2 = atom->map(shake_atom[i][1]);
@@ -569,7 +580,16 @@ void FixShake::pre_neighbor()
           error->one(FLERR,"Shake atoms {} {} {} missing on proc {} at step {}",shake_atom[i][0],
                                        shake_atom[i][1],shake_atom[i][2],
                                        comm->me,update->ntimestep);
-        if (i <= atom1 && i <= atom2 && i <= atom3) list[nlist++] = i;
+        atom1 = domain->closest_image(i, atom1);
+        atom2 = domain->closest_image(i, atom2);
+        atom3 = domain->closest_image(i, atom3);
+        if (i <= atom1 && i <= atom2 && i <= atom3) {
+          list[nlist] = i;
+          closest_list[nlist][0] = atom1;
+          closest_list[nlist][1] = atom2;
+          closest_list[nlist][2] = atom3;
+          nlist++;
+        }
       } else {
         atom1 = atom->map(shake_atom[i][0]);
         atom2 = atom->map(shake_atom[i][1]);
@@ -579,8 +599,19 @@ void FixShake::pre_neighbor()
           error->one(FLERR,"Shake atoms {} {} {} {} missing on proc {} at step {}",shake_atom[i][0],
                                        shake_atom[i][1],shake_atom[i][2],
                                        shake_atom[i][3],comm->me,update->ntimestep);
-        if (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4)
+        atom1 = domain->closest_image(i, atom1);
+        atom2 = domain->closest_image(i, atom2);
+        atom3 = domain->closest_image(i, atom3);
+        atom4 = domain->closest_image(i, atom4);
+        if (i <= atom1 && i <= atom2 && i <= atom3 && i <= atom4) {
           list[nlist++] = i;
+          list[nlist] = i;
+          closest_list[nlist][0] = atom1;
+          closest_list[nlist][1] = atom2;
+          closest_list[nlist][2] = atom3;
+          closest_list[nlist][3] = atom4;
+          nlist++;
+        }
       }
     }
 }
@@ -610,10 +641,10 @@ void FixShake::post_force(int vflag)
   int m;
   for (int i = 0; i < nlist; i++) {
     m = list[i];
-    if (shake_flag[m] == 2) shake(m);
-    else if (shake_flag[m] == 3) shake3(m);
-    else if (shake_flag[m] == 4) shake4(m);
-    else shake3angle(m);
+    if (shake_flag[m] == 2) shake(i);
+    else if (shake_flag[m] == 3) shake3(i);
+    else if (shake_flag[m] == 4) shake4(i);
+    else shake3angle(i);
   }
 
   // store vflag for coordinate_constraints_end_of_step()
@@ -658,10 +689,10 @@ void FixShake::post_force_respa(int vflag, int ilevel, int iloop)
   int m;
   for (int i = 0; i < nlist; i++) {
     m = list[i];
-    if (shake_flag[m] == 2) shake(m);
-    else if (shake_flag[m] == 3) shake3(m);
-    else if (shake_flag[m] == 4) shake4(m);
-    else shake3angle(m);
+    if (shake_flag[m] == 2) shake(i);
+    else if (shake_flag[m] == 3) shake3(i);
+    else if (shake_flag[m] == 4) shake4(i);
+    else shake3angle(i);
   }
 
   // store vflag for coordinate_constraints_end_of_step()
@@ -1739,35 +1770,32 @@ void FixShake::unconstrained_update_respa(int ilevel)
 
 /* ---------------------------------------------------------------------- */
 
-void FixShake::shake(int m)
+void FixShake::shake(int i)
 {
-  int nlist,list[2];
+  int nlist,atomlist[2];
   double v[6];
   double invmass0,invmass1;
 
   // local atom IDs and constraint distances
 
-  int i0 = atom->map(shake_atom[m][0]);
-  int i1 = atom->map(shake_atom[m][1]);
+  int m = list[i];
+  int i0 = closest_list[i][0];
+  int i1 = closest_list[i][1];
   double bond1 = bond_distance[shake_type[m][0]];
 
-  // r01 = distance vec between atoms, with PBC
+  // r01 = distance vec between atoms
 
   double r01[3];
   r01[0] = x[i0][0] - x[i1][0];
   r01[1] = x[i0][1] - x[i1][1];
   r01[2] = x[i0][2] - x[i1][2];
-  domain->minimum_image(r01);
 
-  // s01 = distance vec after unconstrained update, with PBC
-  // use Domain::minimum_image_once(), not minimum_image()
-  // b/c xshake values might be huge, due to e.g. fix gcmc
+  // s01 = distance vec after unconstrained update
 
   double s01[3];
   s01[0] = xshake[i0][0] - xshake[i1][0];
   s01[1] = xshake[i0][1] - xshake[i1][1];
   s01[2] = xshake[i0][2] - xshake[i1][2];
-  domain->minimum_image_once(s01);
 
   // scalar distances between atoms
 
@@ -1824,8 +1852,8 @@ void FixShake::shake(int m)
 
   if (evflag) {
     nlist = 0;
-    if (i0 < nlocal) list[nlist++] = i0;
-    if (i1 < nlocal) list[nlist++] = i1;
+    if (i0 < nlocal) atomlist[nlist++] = i0;
+    if (i1 < nlocal) atomlist[nlist++] = i1;
 
     v[0] = lamda*r01[0]*r01[0];
     v[1] = lamda*r01[1]*r01[1];
@@ -1837,55 +1865,50 @@ void FixShake::shake(int m)
     double fpairlist[] = {lamda};
     double dellist[][3]  = {{r01[0], r01[1], r01[2]}};
     int pairlist[][2] = {{i0,i1}};
-    v_tally(nlist,list,2.0,v,nlocal,1,pairlist,fpairlist,dellist);
+    v_tally(nlist,atomlist,2.0,v,nlocal,1,pairlist,fpairlist,dellist);
   }
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixShake::shake3(int m)
+void FixShake::shake3(int i)
 {
-  int nlist,list[3];
+  int nlist,atomlist[3];
   double v[6];
   double invmass0,invmass1,invmass2;
 
   // local atom IDs and constraint distances
 
-  int i0 = atom->map(shake_atom[m][0]);
-  int i1 = atom->map(shake_atom[m][1]);
-  int i2 = atom->map(shake_atom[m][2]);
+  int m = list[i];
+  int i0 = closest_list[i][0];
+  int i1 = closest_list[i][1];
+  int i2 = closest_list[i][2];
   double bond1 = bond_distance[shake_type[m][0]];
   double bond2 = bond_distance[shake_type[m][1]];
 
-  // r01,r02 = distance vec between atoms, with PBC
+  // r01,r02 = distance vec between atoms
 
   double r01[3];
   r01[0] = x[i0][0] - x[i1][0];
   r01[1] = x[i0][1] - x[i1][1];
   r01[2] = x[i0][2] - x[i1][2];
-  domain->minimum_image(r01);
 
   double r02[3];
   r02[0] = x[i0][0] - x[i2][0];
   r02[1] = x[i0][1] - x[i2][1];
   r02[2] = x[i0][2] - x[i2][2];
-  domain->minimum_image(r02);
 
-  // s01,s02 = distance vec after unconstrained update, with PBC
-  // use Domain::minimum_image_once(), not minimum_image()
-  // b/c xshake values might be huge, due to e.g. fix gcmc
+  // s01,s02 = distance vec after unconstrained update
 
   double s01[3];
   s01[0] = xshake[i0][0] - xshake[i1][0];
   s01[1] = xshake[i0][1] - xshake[i1][1];
   s01[2] = xshake[i0][2] - xshake[i1][2];
-  domain->minimum_image_once(s01);
 
   double s02[3];
   s02[0] = xshake[i0][0] - xshake[i2][0];
   s02[1] = xshake[i0][1] - xshake[i2][1];
   s02[2] = xshake[i0][2] - xshake[i2][2];
-  domain->minimum_image_once(s02);
 
   // scalar distances between atoms
 
@@ -1999,9 +2022,9 @@ void FixShake::shake3(int m)
 
   if (evflag) {
     nlist = 0;
-    if (i0 < nlocal) list[nlist++] = i0;
-    if (i1 < nlocal) list[nlist++] = i1;
-    if (i2 < nlocal) list[nlist++] = i2;
+    if (i0 < nlocal) atomlist[nlist++] = i0;
+    if (i1 < nlocal) atomlist[nlist++] = i1;
+    if (i2 < nlocal) atomlist[nlist++] = i2;
 
     v[0] = lamda01*r01[0]*r01[0] + lamda02*r02[0]*r02[0];
     v[1] = lamda01*r01[1]*r01[1] + lamda02*r02[1]*r02[1];
@@ -2014,69 +2037,62 @@ void FixShake::shake3(int m)
     double dellist[][3]  = {{r01[0], r01[1], r01[2]},
                             {r02[0], r02[1], r02[2]}};
     int pairlist[][2] = {{i0,i1}, {i0,i2}};
-    v_tally(nlist,list,3.0,v,nlocal,2,pairlist,fpairlist,dellist);
+    v_tally(nlist,atomlist,3.0,v,nlocal,2,pairlist,fpairlist,dellist);
   }
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixShake::shake4(int m)
+void FixShake::shake4(int i)
 {
- int nlist,list[4];
+ int nlist,atomlist[4];
   double v[6];
   double invmass0,invmass1,invmass2,invmass3;
 
   // local atom IDs and constraint distances
 
-  int i0 = atom->map(shake_atom[m][0]);
-  int i1 = atom->map(shake_atom[m][1]);
-  int i2 = atom->map(shake_atom[m][2]);
-  int i3 = atom->map(shake_atom[m][3]);
+  int m = list[i];
+  int i0 = closest_list[i][0];
+  int i1 = closest_list[i][1];
+  int i2 = closest_list[i][2];
+  int i3 = closest_list[i][3];
   double bond1 = bond_distance[shake_type[m][0]];
   double bond2 = bond_distance[shake_type[m][1]];
   double bond3 = bond_distance[shake_type[m][2]];
 
-  // r01,r02,r03 = distance vec between atoms, with PBC
+  // r01,r02,r03 = distance vec between atoms
 
   double r01[3];
   r01[0] = x[i0][0] - x[i1][0];
   r01[1] = x[i0][1] - x[i1][1];
   r01[2] = x[i0][2] - x[i1][2];
-  domain->minimum_image(r01);
 
   double r02[3];
   r02[0] = x[i0][0] - x[i2][0];
   r02[1] = x[i0][1] - x[i2][1];
   r02[2] = x[i0][2] - x[i2][2];
-  domain->minimum_image(r02);
 
   double r03[3];
   r03[0] = x[i0][0] - x[i3][0];
   r03[1] = x[i0][1] - x[i3][1];
   r03[2] = x[i0][2] - x[i3][2];
-  domain->minimum_image(r03);
 
-  // s01,s02,s03 = distance vec after unconstrained update, with PBC
-  // use Domain::minimum_image_once(), not minimum_image()
-  // b/c xshake values might be huge, due to e.g. fix gcmc
+  // s01,s02,s03 = distance vec after unconstrained update
 
   double s01[3];
   s01[0] = xshake[i0][0] - xshake[i1][0];
   s01[1] = xshake[i0][1] - xshake[i1][1];
   s01[2] = xshake[i0][2] - xshake[i1][2];
-  domain->minimum_image_once(s01);
 
   double s02[3];
   s02[0] = xshake[i0][0] - xshake[i2][0];
   s02[1] = xshake[i0][1] - xshake[i2][1];
   s02[2] = xshake[i0][2] - xshake[i2][2];
-  domain->minimum_image_once(s02);
 
   double s03[3];
   s03[0] = xshake[i0][0] - xshake[i3][0];
   s03[1] = xshake[i0][1] - xshake[i3][1];
   s03[2] = xshake[i0][2] - xshake[i3][2];
-  domain->minimum_image_once(s03);
 
   // scalar distances between atoms
 
@@ -2254,10 +2270,10 @@ void FixShake::shake4(int m)
 
   if (evflag) {
     nlist = 0;
-    if (i0 < nlocal) list[nlist++] = i0;
-    if (i1 < nlocal) list[nlist++] = i1;
-    if (i2 < nlocal) list[nlist++] = i2;
-    if (i3 < nlocal) list[nlist++] = i3;
+    if (i0 < nlocal) atomlist[nlist++] = i0;
+    if (i1 < nlocal) atomlist[nlist++] = i1;
+    if (i2 < nlocal) atomlist[nlist++] = i2;
+    if (i3 < nlocal) atomlist[nlist++] = i3;
 
     v[0] = lamda01*r01[0]*r01[0]+lamda02*r02[0]*r02[0]+lamda03*r03[0]*r03[0];
     v[1] = lamda01*r01[1]*r01[1]+lamda02*r02[1]*r02[1]+lamda03*r03[1]*r03[1];
@@ -2271,68 +2287,61 @@ void FixShake::shake4(int m)
                             {r02[0], r02[1], r02[2]},
                             {r03[0], r03[1], r03[2]}};
     int pairlist[][2] = {{i0,i1}, {i0,i2}, {i0,i3}};
-    v_tally(nlist,list,4.0,v,nlocal,3,pairlist,fpairlist,dellist);
+    v_tally(nlist,atomlist,4.0,v,nlocal,3,pairlist,fpairlist,dellist);
   }
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixShake::shake3angle(int m)
+void FixShake::shake3angle(int i)
 {
-  int nlist,list[3];
+  int nlist,atomlist[3];
   double v[6];
   double invmass0,invmass1,invmass2;
 
   // local atom IDs and constraint distances
 
-  int i0 = atom->map(shake_atom[m][0]);
-  int i1 = atom->map(shake_atom[m][1]);
-  int i2 = atom->map(shake_atom[m][2]);
+  int m = list[i];
+  int i0 = closest_list[i][0];
+  int i1 = closest_list[i][1];
+  int i2 = closest_list[i][2];
   double bond1 = bond_distance[shake_type[m][0]];
   double bond2 = bond_distance[shake_type[m][1]];
   double bond12 = angle_distance[shake_type[m][2]];
 
-  // r01,r02,r12 = distance vec between atoms, with PBC
+  // r01,r02,r12 = distance vec between atoms
 
   double r01[3];
   r01[0] = x[i0][0] - x[i1][0];
   r01[1] = x[i0][1] - x[i1][1];
   r01[2] = x[i0][2] - x[i1][2];
-  domain->minimum_image(r01);
 
   double r02[3];
   r02[0] = x[i0][0] - x[i2][0];
   r02[1] = x[i0][1] - x[i2][1];
   r02[2] = x[i0][2] - x[i2][2];
-  domain->minimum_image(r02);
 
   double r12[3];
   r12[0] = x[i1][0] - x[i2][0];
   r12[1] = x[i1][1] - x[i2][1];
   r12[2] = x[i1][2] - x[i2][2];
-  domain->minimum_image(r12);
 
-  // s01,s02,s12 = distance vec after unconstrained update, with PBC
-  // use Domain::minimum_image_once(), not minimum_image()
-  // b/c xshake values might be huge, due to e.g. fix gcmc
+  // s01,s02,s12 = distance vec after unconstrained update
 
   double s01[3];
   s01[0] = xshake[i0][0] - xshake[i1][0];
   s01[1] = xshake[i0][1] - xshake[i1][1];
   s01[2] = xshake[i0][2] - xshake[i1][2];
-  domain->minimum_image_once(s01);
 
   double s02[3];
   s02[0] = xshake[i0][0] - xshake[i2][0];
   s02[1] = xshake[i0][1] - xshake[i2][1];
   s02[2] = xshake[i0][2] - xshake[i2][2];
-  domain->minimum_image_once(s02);
 
   double s12[3];
   s12[0] = xshake[i1][0] - xshake[i2][0];
   s12[1] = xshake[i1][1] - xshake[i2][1];
   s12[2] = xshake[i1][2] - xshake[i2][2];
-  domain->minimum_image_once(s12);
 
   // scalar distances between atoms
 
@@ -2503,9 +2512,9 @@ void FixShake::shake3angle(int m)
 
   if (evflag) {
     nlist = 0;
-    if (i0 < nlocal) list[nlist++] = i0;
-    if (i1 < nlocal) list[nlist++] = i1;
-    if (i2 < nlocal) list[nlist++] = i2;
+    if (i0 < nlocal) atomlist[nlist++] = i0;
+    if (i1 < nlocal) atomlist[nlist++] = i1;
+    if (i2 < nlocal) atomlist[nlist++] = i2;
 
     v[0] = lamda01*r01[0]*r01[0]+lamda02*r02[0]*r02[0]+lamda12*r12[0]*r12[0];
     v[1] = lamda01*r01[1]*r01[1]+lamda02*r02[1]*r02[1]+lamda12*r12[1]*r12[1];
@@ -2519,7 +2528,7 @@ void FixShake::shake3angle(int m)
                             {r02[0], r02[1], r02[2]},
                             {r12[0], r12[1], r12[2]}};
     int pairlist[][2] = {{i0,i1}, {i0,i2}, {i1,i2}};
-    v_tally(nlist,list,3.0,v,nlocal,3,pairlist,fpairlist,dellist);
+    v_tally(nlist,atomlist,3.0,v,nlocal,3,pairlist,fpairlist,dellist);
   }
 }
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -3258,8 +3258,6 @@ void FixShake::correct_coordinates(int vflag) {
 
   double **xtmp = xshake;
   xshake = x;
-  if (comm->nprocs > 1) {
-    comm->forward_comm(this);
-  }
+  comm->forward_comm(this);
   xshake = xtmp;
 }

--- a/src/RIGID/fix_shake.h
+++ b/src/RIGID/fix_shake.h
@@ -142,7 +142,7 @@ class FixShake : public Fix {
   void shake4(int);
   void shake3angle(int);
   void bond_force(int, int, double);
-  void stats();
+  virtual void stats();
   int bondtype_findset(int, tagint, tagint, int);
   int angletype_findset(int, tagint, tagint, int);
 

--- a/src/RIGID/fix_shake.h
+++ b/src/RIGID/fix_shake.h
@@ -113,6 +113,7 @@ class FixShake : public Fix {
   double dtf_inner, dtf_innerhalf;    // timesteps for rRESPA trial move
 
   int *list;             // list of clusters to SHAKE
+  int **closest_list;    // list of closest images in SHAKE clusters
   int nlist, maxlist;    // size and max-size of list
 
   // stat quantities

--- a/src/RIGID/fix_shake.h
+++ b/src/RIGID/fix_shake.h
@@ -141,7 +141,7 @@ class FixShake : public Fix {
   void shake3(int);
   void shake4(int);
   void shake3angle(int);
-  void bond_force(tagint, tagint, double);
+  void bond_force(int, int, double);
   void stats();
   int bondtype_findset(int, tagint, tagint, int);
   int angletype_findset(int, tagint, tagint, int);

--- a/src/RIGID/fix_shake.h
+++ b/src/RIGID/fix_shake.h
@@ -113,7 +113,7 @@ class FixShake : public Fix {
   double dtf_inner, dtf_innerhalf;    // timesteps for rRESPA trial move
 
   int *list;             // list of clusters to SHAKE
-  int **closest_list;    // list of closest images in SHAKE clusters
+  int **closest_list;    // list of closest atom indices in SHAKE clusters
   int nlist, maxlist;    // size and max-size of list
 
   // stat quantities


### PR DESCRIPTION
**Summary**

The order of ghost atoms in a single swap is random for Kokkos border comm. However the `atom_map` assumes that the closest ghost images have the lowest local atom id, which can cause issues with fix shake when it uses `domain->minimum_image_once`. This PR uses the more robust `domain->closest_image` function that is used elsewhere for this purpose. The closest images are also stored for each reneighbor, which saves a little computation since the minimum image calculation doesn't need to be done every step.

**Related Issue(s)**

#1394 

**Author(s)**

Stan Moore (SNL), discussed with @sjplimp 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes