### PR TITLE
Introduce compute reduce minabs and maxabs

### DIFF
--- a/doc/src/compute_reduce.rst
+++ b/doc/src/compute_reduce.rst
@@ -71,12 +71,12 @@ vectors.
 The reduction operation is specified by the *mode* setting.  The *sum*
 option adds the values in the vector into a global total.  The *min*
 or *max* options find the minimum or maximum value across all vector
-values.  The *minabs* or *maxabs* options find the minimum or maximum 
-value across all absolute vector values.  The *ave* setting adds the 
-vector values into a global total, then divides by the number of values 
-in the vector.  The *sumsq* option sums the square of the values in the 
-vector into a global total.  The *avesq* setting does the same as *sumsq*, 
-then divides the sum of squares by the number of values.  The last two options 
+values.  The *minabs* or *maxabs* options find the minimum or maximum
+value across all absolute vector values.  The *ave* setting adds the
+vector values into a global total, then divides by the number of values
+in the vector.  The *sumsq* option sums the square of the values in the
+vector into a global total.  The *avesq* setting does the same as *sumsq*,
+then divides the sum of squares by the number of values.  The last two options
 can be useful for calculating the variance of some quantity (e.g., variance =
 sumsq :math:`-` ave\ :math:`^2`).  The *sumabs* option sums the absolute
 values in the vector into a global total.  The *aveabs* setting does the same

--- a/doc/src/compute_reduce.rst
+++ b/doc/src/compute_reduce.rst
@@ -23,7 +23,7 @@ Syntax
        *reduce/region* arg = region-ID
          region-ID = ID of region to use for choosing atoms
 
-* mode = *sum* or *min* or *max* or *ave* or *sumsq* or *avesq* or *sumabs* or *aveabs*
+* mode = *sum* or *min* or *minabs* or *max* or *maxabs* or *ave* or *sumsq* or *avesq* or *sumabs* or *aveabs*
 * one or more inputs can be listed
 * input = *x* or *y* or *z* or *vx* or *vy* or *vz* or *fx* or *fy* or *fz* or c_ID or c_ID[N] or f_ID or f_ID[N] or v_name
 
@@ -71,12 +71,13 @@ vectors.
 The reduction operation is specified by the *mode* setting.  The *sum*
 option adds the values in the vector into a global total.  The *min*
 or *max* options find the minimum or maximum value across all vector
-values.  The *ave* setting adds the vector values into a global total,
-then divides by the number of values in the vector.  The *sumsq*
-option sums the square of the values in the vector into a global
-total.  The *avesq* setting does the same as *sumsq*, then divides the
-sum of squares by the number of values.  The last two options can be
-useful for calculating the variance of some quantity (e.g., variance =
+values.  The *minabs* or *maxabs* options find the minimum or maximum 
+value across all absolute vector values.  The *ave* setting adds the 
+vector values into a global total, then divides by the number of values 
+in the vector.  The *sumsq* option sums the square of the values in the 
+vector into a global total.  The *avesq* setting does the same as *sumsq*, 
+then divides the sum of squares by the number of values.  The last two options 
+can be useful for calculating the variance of some quantity (e.g., variance =
 sumsq :math:`-` ave\ :math:`^2`).  The *sumabs* option sums the absolute
 values in the vector into a global total.  The *aveabs* setting does the same
 as *sumabs*, then divides the sum of absolute values by the number of

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -400,11 +400,13 @@ void ComputeReduce::compute_vector()
   if (mode == SUM || mode == SUMSQ || mode == AVEABS) {
     for (int m = 0; m < nvalues; m++)
       MPI_Allreduce(&onevec[m], &vector[m], 1, MPI_DOUBLE, MPI_SUM, world);
-
+  } else if (mode == MINABS || mode == MAXABS) {
+    for (int m = 0; m < nvalues; m++)
+      MPI_Allreduce(&onevec[m], &vector[m], 1, MPI_DOUBLE, this->scalar_reduction_operation, world);
   } else if (mode == MINN) {
     if (!replace) {
       for (int m = 0; m < nvalues; m++)
-        MPI_Allreduce(&onevec[m], &vector[m], 1, MPI_DOUBLE, MPI_MIN, world);
+        MPI_Allreduce(&onevec[m], &vector[m], 1, MPI_DOUBLE, this->scalar_reduction_operation, world);
 
     } else {
       for (int m = 0; m < nvalues; m++)
@@ -421,11 +423,10 @@ void ComputeReduce::compute_vector()
           MPI_Bcast(&vector[m], 1, MPI_DOUBLE, owner[replace[m]], world);
         }
     }
-
   } else if (mode == MAXX) {
     if (!replace) {
       for (int m = 0; m < nvalues; m++)
-        MPI_Allreduce(&onevec[m], &vector[m], 1, MPI_DOUBLE, MPI_MAX, world);
+        MPI_Allreduce(&onevec[m], &vector[m], 1, MPI_DOUBLE, this->scalar_reduction_operation, world);
 
     } else {
       for (int m = 0; m < nvalues; m++)

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -33,6 +33,34 @@ using namespace LAMMPS_NS;
 
 #define BIG 1.0e20
 
+//----------------------------------------------------------------
+void abs_max(void *in, void *inout, int *len, MPI_Datatype *type)
+{
+  // r is the already reduced value, n is the new value
+  double n = std::fabs(*(double *) in), r = *(double *) inout;
+  double m;
+
+  if (n > r) {
+    m = n;
+  } else {
+    m = r;
+  }
+  *(double *) inout = m;
+}
+void abs_min(void *in, void *inout, int *len, MPI_Datatype *type)
+{
+  // r is the already reduced value, n is the new value
+  double n = std::fabs(*(double *) in), r = *(double *) inout;
+  double m;
+
+  if (n < r) {
+    m = n;
+  } else {
+    m = r;
+  }
+  *(double *) inout = m;
+}
+
 /* ---------------------------------------------------------------------- */
 
 ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
@@ -67,9 +95,27 @@ ComputeReduce::ComputeReduce(LAMMPS *lmp, int narg, char **arg) :
     mode = AVESQ;
   else if (strcmp(arg[iarg], "aveabs") == 0)
     mode = AVEABS;
+  else if (strcmp(arg[iarg], "maxabs") == 0)
+    mode = MAXABS;
+  else if (strcmp(arg[iarg], "minabs") == 0)
+    mode = MINABS;
   else
     error->all(FLERR, "Unknown compute {} mode: {}", style, arg[iarg]);
   iarg++;
+
+  if (mode == SUM || mode == SUMSQ || mode == SUMABS) {
+    this->scalar_reduction_operation = MPI_SUM;
+  } else if (mode == AVE || mode == AVESQ || mode == AVEABS) {
+    this->scalar_reduction_operation = MPI_SUM;
+  } else if (mode == MINN) {
+    this->scalar_reduction_operation = MPI_MIN;
+  } else if (mode == MAXX) {
+    this->scalar_reduction_operation = MPI_MAX;
+  } else if (mode == MAXABS) {
+    MPI_Op_create(&abs_max, 1, &this->scalar_reduction_operation);
+  } else if (mode == MINABS) {
+    MPI_Op_create(&abs_min, 1, &this->scalar_reduction_operation);
+  }
 
   // expand args if any have wildcard character "*"
 
@@ -329,14 +375,9 @@ double ComputeReduce::compute_scalar()
 
   double one = compute_one(0, -1);
 
-  if (mode == SUM || mode == SUMSQ || mode == SUMABS) {
-    MPI_Allreduce(&one, &scalar, 1, MPI_DOUBLE, MPI_SUM, world);
-  } else if (mode == MINN) {
-    MPI_Allreduce(&one, &scalar, 1, MPI_DOUBLE, MPI_MIN, world);
-  } else if (mode == MAXX) {
-    MPI_Allreduce(&one, &scalar, 1, MPI_DOUBLE, MPI_MAX, world);
-  } else if (mode == AVE || mode == AVESQ || mode == AVEABS) {
-    MPI_Allreduce(&one, &scalar, 1, MPI_DOUBLE, MPI_SUM, world);
+  MPI_Allreduce(&one, &scalar, 1, MPI_DOUBLE, this->scalar_reduction_operation, world);
+
+  if (mode == AVE || mode == AVESQ || mode == AVEABS) {
     bigint n = count(0);
     if (n) scalar /= n;
   }
@@ -441,7 +482,7 @@ double ComputeReduce::compute_one(int m, int flag)
   int nlocal = atom->nlocal;
 
   double one = 0.0;
-  if (mode == MINN) one = BIG;
+  if (mode == MINN || mode == MINABS) one = BIG;
   if (mode == MAXX) one = -BIG;
 
   if (val.which == ArgInfo::X) {
@@ -635,6 +676,11 @@ void ComputeReduce::combine(double &one, double two, int i)
   } else if (mode == MAXX) {
     if (two > one) {
       one = two;
+      index = i;
+    }
+  } else if (mode == MAXABS) {
+    if (std::fabs(two) > one) {
+      one = std::fabs(two);
       index = i;
     }
   }

--- a/src/compute_reduce.h
+++ b/src/compute_reduce.h
@@ -26,7 +26,7 @@ namespace LAMMPS_NS {
 
 class ComputeReduce : public Compute {
  public:
-  enum { SUM, SUMSQ, SUMABS, MINN, MAXX, AVE, AVESQ, AVEABS };
+  enum { SUM, SUMSQ, SUMABS, MINN, MAXX, AVE, AVESQ, AVEABS, MINABS, MAXABS };
   enum { PERATOM, LOCAL };
 
   ComputeReduce(class LAMMPS *, int, char **);
@@ -52,6 +52,7 @@ class ComputeReduce : public Compute {
   std::vector<value_t> values;
   double *onevec;
   int *replace, *indices, *owner;
+  MPI_Op scalar_reduction_operation;
 
   int index;
   char *idregion;


### PR DESCRIPTION
**Summary**

This PR introduces two new keywords for the `compute reduce` command, namely a method to reduce to the maximum absolute value, and one to reduce to the minimum absolute value. This can be used e.g. in conjunction with a `compute bond/local dx dy dz`, or similar, where the to-reduce property can be positive or negative, yet only the absolute maxima or minima are desired.

I needed this for a project of mine, and am happy to give back what I implemented, but if there is no general interest, I do not mind if this PR is closed unmerged.

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->
Tim Bernhard, ETH Zürich, tim@bernhard.dev

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
No compatibility break. 

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
I have also changed the way the scalar reduction is called. Naïvely, this should lead to a slightly reduced cycle count as there is no more branching in the hot path, though I could not really measure it, I guess the compiler was smart enough. 

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [?] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included




