### PR TITLE
Fix bug in Kokkos PACE

### DIFF
--- a/src/KOKKOS/pair_pace_extrapolation_kokkos.h
+++ b/src/KOKKOS/pair_pace_extrapolation_kokkos.h
@@ -219,7 +219,7 @@ class PairPACEExtrapolationKokkos : public PairPACEExtrapolation {
   typedef Kokkos::View<complex****, DeviceType> t_ace_4c;
   typedef Kokkos::View<complex***[3], DeviceType> t_ace_4c3;
 
-  typedef Kokkos::View<double*>::HostMirror th_ace_1d;
+  typedef typename Kokkos::View<double*, DeviceType>::HostMirror th_ace_1d;
 
   t_ace_3d A_rank1;
   t_ace_4c A;

--- a/src/KOKKOS/pair_pace_kokkos.cpp
+++ b/src/KOKKOS/pair_pace_kokkos.cpp
@@ -584,6 +584,7 @@ void PairPACEKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     Kokkos::deep_copy(A, 0.0);
     Kokkos::deep_copy(A_rank1, 0.0);
     Kokkos::deep_copy(rhos, 0.0);
+    Kokkos::deep_copy(rho_core, 0.0);
 
     EV_FLOAT ev_tmp;
 


### PR DESCRIPTION
**Summary**

An array wasn't initialized to zero, leading to reading uninitialized memory. Also fix compile error with UVM.

**Related Issue(s)**

Closes #3732 

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes