### PR TITLE
Small fixes to GRANULAR

### DIFF
--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -650,13 +650,13 @@ For *heat* *area*, the heat
 
 .. math::
 
-   Q = k_{s} a \Delta T
+   Q = k_{s} A \Delta T
 
 
 
 where :math:`\Delta T` is the difference in the two particles' temperature,
 :math:`k_{s}` is a non-negative numeric value for the conductivity, and
-:math:`a` is the area of the contact and depends on the normal force model.
+:math:`A` is the area of the contact and depends on the normal force model.
 
 Note that the option *none* must either be used in all or none of of the
 *pair_coeff* calls. See :doc:`fix heat/flow <fix_heat_flow>` and

--- a/src/GRANULAR/fix_wall_gran.cpp
+++ b/src/GRANULAR/fix_wall_gran.cpp
@@ -52,7 +52,7 @@ enum {NONE,CONSTANT,EQUAL};
 /* ---------------------------------------------------------------------- */
 
 FixWallGran::FixWallGran(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg), idregion(nullptr), history_one(nullptr),
+  Fix(lmp, narg, arg), idregion(nullptr), tstr(nullptr), history_one(nullptr),
   fix_rigid(nullptr), mass_rigid(nullptr)
 {
   if (narg < 4) error->all(FLERR,"Illegal fix wall/gran command");
@@ -126,9 +126,6 @@ FixWallGran::FixWallGran(LAMMPS *lmp, int narg, char **arg) :
   else use_history = restart_peratom = 1;
 
   // wallstyle args
-
-  idregion = nullptr;
-  tstr = nullptr;
 
   if (iarg >= narg) error->all(FLERR, "Illegal fix wall/gran command");
 
@@ -247,13 +244,11 @@ FixWallGran::FixWallGran(LAMMPS *lmp, int narg, char **arg) :
   // perform initial allocation of atom-based arrays
   // register with Atom class
 
-  history_one = nullptr;
   FixWallGran::grow_arrays(atom->nmax);
   atom->add_callback(Atom::GROW);
   atom->add_callback(Atom::RESTART);
 
   nmax = 0;
-  mass_rigid = nullptr;
 
   // initialize history as if particle is not touching region
   // history_one will be a null pointer for wallstyle = REGION
@@ -323,7 +318,6 @@ void FixWallGran::init()
 
   // check for FixRigid so can extract rigid body masses
 
-  fix_rigid = nullptr;
   for (i = 0; i < modify->nfix; i++)
     if (modify->fix[i]->rigid_flag) break;
   if (i < modify->nfix) fix_rigid = modify->fix[i];
@@ -452,7 +446,7 @@ void FixWallGran::post_force(int /*vflag*/)
   }
 
   for (int i = 0; i < nlocal; i++) {
-    if ((!mask[i]) & groupbit) continue;
+    if (!(mask[i] & groupbit)) continue;
 
     dx = dy = dz = 0.0;
 
@@ -548,7 +542,10 @@ void FixWallGran::post_force(int /*vflag*/)
   }
 }
 
-void FixWallGran::clear_stored_contacts() {
+/* ---------------------------------------------------------------------- */
+
+void FixWallGran::clear_stored_contacts()
+{
   const int nlocal = atom->nlocal;
   for (int i = 0; i < nlocal; i++) {
     for (int m = 0; m < size_peratom_cols; m++) {

--- a/src/GRANULAR/fix_wall_gran_region.cpp
+++ b/src/GRANULAR/fix_wall_gran_region.cpp
@@ -59,9 +59,6 @@ FixWallGranRegion::FixWallGranRegion(LAMMPS *lmp, int narg, char **arg) :
   memory->destroy(history_one);
   history_one = nullptr;
 
-  ncontact = nullptr;
-  walls = nullptr;
-  history_many = nullptr;
   FixWallGranRegion::grow_arrays(atom->nmax);
 
   // initialize shear history as if particle is not touching region
@@ -193,7 +190,7 @@ void FixWallGranRegion::post_force(int /*vflag*/)
   }
 
   for (i = 0; i < nlocal; i++) {
-    if ((!mask[i]) & groupbit) continue;
+    if (!(mask[i] & groupbit)) continue;
     if (! region->match(x[i][0], x[i][1], x[i][2])) continue;
 
     nc = region->surface(x[i][0], x[i][1], x[i][2], radius[i] + model->pulloff_distance(radius[i], 0.0));


### PR DESCRIPTION
**Summary**

This PR includes a patch for the bug reported in issue #3742 affecting fix gran/wall/(region) as well as various minor clean ups of the code (location of brackets, excess nullptr assignments in the constructor, etc). 

The variable _a_ was also used twice in the documentation for pair granular (once for contact area and once for contact radius), so I renamed the contact area to _A_.

**Related Issue(s)**

Fixes #3742 

**Author(s)**

Joel Clemmer (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).


