### PR TITLE
Add warning message when the callback for a /tally compute was not run

### DIFF
--- a/doc/src/compute_tally.rst
+++ b/doc/src/compute_tally.rst
@@ -187,16 +187,22 @@ Both the scalar and vector values calculated by this compute are
 Restrictions
 """"""""""""
 
-This compute is part of the TALLY package.  It is only enabled if
-LAMMPS was built with that package.  See the :doc:`Build package <Build_package>` page for more info.
+This compute is part of the TALLY package.  It is only enabled if LAMMPS
+was built with that package.  See the :doc:`Build package
+<Build_package>` page for more info.
 
 Not all pair styles can be evaluated in a pairwise mode as required by
-this compute.  For example, 3-body and other many-body potentials,
-such as :doc:`Tersoff <pair_tersoff>` and
-:doc:`Stillinger-Weber <pair_sw>` cannot be used.  :doc:`EAM <pair_eam>`
-potentials only include the pair potential portion of the EAM
-interaction when used by this compute, not the embedding term.  Also
-bonded or Kspace interactions do not contribute to this compute.
+this compute.  For example, 3-body and other many-body potentials, such
+as :doc:`Tersoff <pair_tersoff>` and :doc:`Stillinger-Weber <pair_sw>`
+cannot be used.  :doc:`EAM <pair_eam>` potentials only include the pair
+potential portion of the EAM interaction when used by this compute, not
+the embedding term.  Also bonded or Kspace interactions do not
+contribute to this compute.
+
+These computes are not compatible with accelerated pair styles from the
+GPU, INTEL, KOKKOS, or OPENMP packages. They will either create an error
+or print a warning when required data was not tallied in the required way
+and thus the data acquisition functions from these computes not called.
 
 When used with dynamic groups, a :doc:`run 0 <run>` command needs to
 be inserted in order to initialize the dynamic groups before accessing

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -1562,6 +1562,7 @@ invertibility
 ionicities
 ionizable
 ionocovalent
+iOS
 iostreams
 iparam
 ipi

--- a/src/TALLY/compute_heat_flux_tally.cpp
+++ b/src/TALLY/compute_heat_flux_tally.cpp
@@ -204,7 +204,10 @@ void ComputeHeatFluxTally::compute_vector()
 {
   invoked_vector = update->ntimestep;
   if ((did_setup != invoked_vector) || (update->eflag_global != invoked_vector))
-    error->all(FLERR, "Energy was not tallied on needed timestep");
+    error->all(FLERR, "Stress was not tallied on needed timestep");
+
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Stress was not tallied by pair style");
 
   // collect contributions from ghost atoms
 

--- a/src/TALLY/compute_heat_flux_tally.cpp
+++ b/src/TALLY/compute_heat_flux_tally.cpp
@@ -29,10 +29,11 @@ using namespace LAMMPS_NS;
 ComputeHeatFluxTally::ComputeHeatFluxTally(LAMMPS *lmp, int narg, char **arg) :
     Compute(lmp, narg, arg)
 {
-  if (narg < 4) error->all(FLERR, "Illegal compute heat/flux/tally command");
+  if (narg < 4) utils::missing_cmd_args(FLERR, "compute heat/flux/tally", error);
 
   igroup2 = group->find(arg[3]);
-  if (igroup2 == -1) error->all(FLERR, "Could not find compute heat/flux/tally second group ID");
+  if (igroup2 == -1)
+    error->all(FLERR, "Could not find compute heat/flux/tally second group ID {}", arg[3]);
   groupbit2 = group->bitmask[igroup2];
 
   vector_flag = 1;

--- a/src/TALLY/compute_heat_flux_virial_tally.cpp
+++ b/src/TALLY/compute_heat_flux_virial_tally.cpp
@@ -29,11 +29,11 @@ using namespace LAMMPS_NS;
 ComputeHeatFluxVirialTally::ComputeHeatFluxVirialTally(LAMMPS *lmp, int narg, char **arg) :
     Compute(lmp, narg, arg)
 {
-  if (narg < 4) error->all(FLERR, "Illegal compute heat/flux/virial/tally command");
+  if (narg < 4) utils::missing_cmd_args(FLERR, "compute heat/flux/virial/tally", error);
 
   igroup2 = group->find(arg[3]);
   if (igroup2 == -1)
-    error->all(FLERR, "Could not find compute heat/flux/virial/tally second group ID");
+    error->all(FLERR, "Could not find compute heat/flux/virial/tally second group ID {}", arg[3]);
   groupbit2 = group->bitmask[igroup2];
 
   scalar_flag = 1;

--- a/src/TALLY/compute_heat_flux_virial_tally.cpp
+++ b/src/TALLY/compute_heat_flux_virial_tally.cpp
@@ -191,7 +191,10 @@ double ComputeHeatFluxVirialTally::compute_scalar()
 
   invoked_scalar = update->ntimestep;
   if ((did_setup != invoked_scalar) || (update->eflag_global != invoked_scalar))
-    error->all(FLERR, "Energy was not tallied on needed timestep");
+    error->all(FLERR, "Stress was not tallied on needed timestep");
+
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Stress was not tallied by pair style");
 
   // sum heat flux across procs
   double hflux = 0.0;
@@ -210,7 +213,10 @@ void ComputeHeatFluxVirialTally::compute_peratom()
 {
   invoked_peratom = update->ntimestep;
   if ((did_setup != invoked_peratom) || (update->eflag_global != invoked_peratom))
-    error->all(FLERR, "Energy was not tallied on needed timestep");
+    error->all(FLERR, "Stress was not tallied on needed timestep");
+
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Stress was not tallied by pair style");
 
   // collect contributions from ghost atoms
 

--- a/src/TALLY/compute_pe_mol_tally.cpp
+++ b/src/TALLY/compute_pe_mol_tally.cpp
@@ -127,6 +127,9 @@ void ComputePEMolTally::compute_vector()
   if ((did_setup != invoked_vector) || (update->eflag_global != invoked_vector))
     error->all(FLERR, "Energy was not tallied on needed timestep");
 
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Energy was not tallied by pair style");
+
   // sum accumulated energies across procs
 
   MPI_Allreduce(etotal, vector, size_vector, MPI_DOUBLE, MPI_SUM, world);

--- a/src/TALLY/compute_pe_mol_tally.cpp
+++ b/src/TALLY/compute_pe_mol_tally.cpp
@@ -27,10 +27,11 @@ using namespace LAMMPS_NS;
 
 ComputePEMolTally::ComputePEMolTally(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg)
 {
-  if (narg < 4) error->all(FLERR, "Illegal compute pe/mol/tally command");
+  if (narg < 4) utils::missing_cmd_args(FLERR, "compute pe/mol/tally", error);
 
   igroup2 = group->find(arg[3]);
-  if (igroup2 == -1) error->all(FLERR, "Could not find compute pe/mol/tally second group ID");
+  if (igroup2 == -1)
+    error->all(FLERR, "Could not find compute pe/mol/tally second group ID {}", arg[3]);
   groupbit2 = group->bitmask[igroup2];
 
   vector_flag = 1;

--- a/src/TALLY/compute_pe_tally.cpp
+++ b/src/TALLY/compute_pe_tally.cpp
@@ -28,10 +28,10 @@ using namespace LAMMPS_NS;
 
 ComputePETally::ComputePETally(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg)
 {
-  if (narg < 4) error->all(FLERR, "Illegal compute pe/tally command");
+  if (narg < 4) utils::missing_cmd_args(FLERR, "compute pe/tally", error);
 
   igroup2 = group->find(arg[3]);
-  if (igroup2 == -1) error->all(FLERR, "Could not find compute pe/tally second group ID");
+  if (igroup2 == -1) error->all(FLERR, "Could not find compute pe/tally second group ID {}", arg[3]);
   groupbit2 = group->bitmask[igroup2];
 
   scalar_flag = 1;

--- a/src/TALLY/compute_pe_tally.cpp
+++ b/src/TALLY/compute_pe_tally.cpp
@@ -169,6 +169,9 @@ double ComputePETally::compute_scalar()
   if ((did_setup != invoked_scalar) || (update->eflag_global != invoked_scalar))
     error->all(FLERR, "Energy was not tallied on needed timestep");
 
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Energy was not tallied by pair style");
+
   // sum accumulated energies across procs
 
   MPI_Allreduce(etotal, vector, size_peratom_cols, MPI_DOUBLE, MPI_SUM, world);
@@ -184,6 +187,9 @@ void ComputePETally::compute_peratom()
   invoked_peratom = update->ntimestep;
   if ((did_setup != invoked_peratom) || (update->eflag_global != invoked_peratom))
     error->all(FLERR, "Energy was not tallied on needed timestep");
+
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Energy was not tallied by pair style");
 
   // collect contributions from ghost atoms
 

--- a/src/TALLY/compute_stress_tally.cpp
+++ b/src/TALLY/compute_stress_tally.cpp
@@ -201,7 +201,10 @@ double ComputeStressTally::compute_scalar()
 {
   invoked_scalar = update->ntimestep;
   if ((did_setup != invoked_scalar) || (update->eflag_global != invoked_scalar))
-    error->all(FLERR, "Energy was not tallied on needed timestep");
+    error->all(FLERR, "Stress was not tallied on needed timestep");
+
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Stress was not tallied by pair style");
 
   // sum accumulated forces across procs
 
@@ -221,7 +224,10 @@ void ComputeStressTally::compute_peratom()
 {
   invoked_peratom = update->ntimestep;
   if ((did_setup != invoked_peratom) || (update->eflag_global != invoked_peratom))
-    error->all(FLERR, "Energy was not tallied on needed timestep");
+    error->all(FLERR, "Stress was not tallied on needed timestep");
+
+  if ((comm->me == 0) && !force->pair->did_tally_callback())
+    error->warning(FLERR, "Stress was not tallied by pair style");
 
   // collect contributions from ghost atoms
 

--- a/src/TALLY/compute_stress_tally.cpp
+++ b/src/TALLY/compute_stress_tally.cpp
@@ -29,10 +29,11 @@ using namespace LAMMPS_NS;
 
 ComputeStressTally::ComputeStressTally(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg)
 {
-  if (narg < 4) error->all(FLERR, "Illegal compute stress/tally command");
+  if (narg < 4) utils::missing_cmd_args(FLERR, "compute stress/tally", error);
 
   igroup2 = group->find(arg[3]);
-  if (igroup2 == -1) error->all(FLERR, "Could not find compute stress/tally second group ID");
+  if (igroup2 == -1)
+    error->all(FLERR, "Could not find compute stress/tally second group ID {}", arg[3]);
   groupbit2 = group->bitmask[igroup2];
 
   scalar_flag = 1;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -109,6 +109,7 @@ Pair::Pair(LAMMPS *lmp) :
   maxeatom = maxvatom = maxcvatom = 0;
 
   num_tally_compute = 0;
+  did_tally_flag = 0;
 
   nelements = nparams = maxparam = 0;
 
@@ -295,6 +296,9 @@ void Pair::init()
       utils::logmesg(lmp,"Generated {} of {} mixed pair_coeff terms from {} mixing rule\n",
                      mixed_count, num_mixed_pairs, mixing_rule_names[mix_flag]);
   }
+
+  // for monitoring, if Pair::ev_tally() was called.
+  did_tally_flag = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -1095,6 +1099,7 @@ void Pair::ev_tally(int i, int j, int nlocal, int newton_pair,
   }
 
   if (num_tally_compute > 0) {
+    did_tally_flag = 1;
     for (int k=0; k < num_tally_compute; ++k) {
       Compute *c = list_tally_compute[k];
       c->pair_tally_callback(i, j, nlocal, newton_pair,

--- a/src/pair.h
+++ b/src/pair.h
@@ -230,12 +230,13 @@ class Pair : protected Pointers {
   // management of callbacks to be run from ev_tally()
 
  protected:
-  int num_tally_compute;
+  int num_tally_compute, did_tally_flag;
   class Compute **list_tally_compute;
 
  public:
   virtual void add_tally_callback(class Compute *);
   virtual void del_tally_callback(class Compute *);
+  bool did_tally_callback() const { return did_tally_flag != 0; }
 
  protected:
   int instance_me;      // which Pair class instantiation I am


### PR DESCRIPTION
**Summary**

The compute styles in the TALLY package are dependent on `Pair::ev_tally()` being called, but that is not always the case. This pull request adds a some way to monitor this and uses that information to print a warning when data was not tallied as expected.

**Related Issue(s)**

Fixes #3752 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
