### PR TITLE
fix ttm_mod

### DIFF
--- a/src/EXTRA-FIX/fix_ttm.cpp
+++ b/src/EXTRA-FIX/fix_ttm.cpp
@@ -463,7 +463,7 @@ void FixTTM::read_electron_temperatures(const std::string &filename)
   if (comm->me == 0) {
 
     int ***T_initial_set;
-    memory->create(T_initial_set,nxgrid,nygrid,nzgrid,"ttm:T_initial_set");
+    memory->create(T_initial_set,nzgrid,nygrid,nxgrid,"ttm:T_initial_set");
     memset(&T_initial_set[0][0][0],0,ngridtotal*sizeof(int));
 
     // read initial electron temperature values from file

--- a/src/EXTRA-FIX/fix_ttm_mod.cpp
+++ b/src/EXTRA-FIX/fix_ttm_mod.cpp
@@ -614,8 +614,8 @@ void FixTTMMod::read_electron_temperatures(const std::string &filename)
         if (T_tmp < 0.0)
           throw TokenizerException("Fix ttm electron temperatures must be > 0.0","");
 
-        T_electron[iz][iy][ix] = T_tmp;
-        T_initial_set[iz][iy][ix] = 1;
+        T_electron[ix][iy][iz] = T_tmp;
+        T_initial_set[ix][iy][iz] = 1;
       }
     } catch (std::exception &e) {
       error->one(FLERR, e.what());
@@ -626,7 +626,7 @@ void FixTTMMod::read_electron_temperatures(const std::string &filename)
     for (int iz = 0; iz < nzgrid; iz++)
       for (int iy = 0; iy < nygrid; iy++)
         for (int ix = 0; ix < nxgrid; ix++)
-          if (T_initial_set[iz][iy][ix] == 0)
+          if (T_initial_set[ix][iy][iz] == 0)
             error->all(FLERR,"Fix ttm/mod infile did not set all temperatures");
 
     memory->destroy(T_initial_set);


### PR DESCRIPTION
**Summary**

The indexing of T_element in ttm/mod must be ordered as [ix][iy][iz].

**Related Issue(s)**

None

**Author(s)**

Kiyoto Kawai, Yamagata U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.
In older version, input TTM grid through `infile` keyword makes illigal grid data or segmentation fault.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



