### PR TITLE
Fix bug in atom sorting with triclinic boxes

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -165,6 +165,10 @@ void AtomKokkos::sort()
 
   if (nlocal == nmax) avec->grow(0);
 
+  // for triclinic, atoms must be in box coords (not lamda) to match bbox
+
+  if (domain->triclinic) domain->lamda2x(nlocal);
+
   sync(Host, ALL_MASK);
   modified(Host, ALL_MASK);
 
@@ -187,6 +191,10 @@ void AtomKokkos::sort()
     next[i] = binhead[ibin];
     binhead[ibin] = i;
   }
+
+  // convert back to lamda coords
+
+  if (domain->triclinic) domain->x2lamda(nlocal);
 
   // permute = desired permutation of atoms
   // permute[I] = J means Ith new atom will be Jth old atom

--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -170,7 +170,6 @@ void AtomKokkos::sort()
   if (domain->triclinic) domain->lamda2x(nlocal);
 
   sync(Host, ALL_MASK);
-  modified(Host, ALL_MASK);
 
   // bin atoms in reverse order so linked list will be in forward order
 
@@ -191,10 +190,6 @@ void AtomKokkos::sort()
     next[i] = binhead[ibin];
     binhead[ibin] = i;
   }
-
-  // convert back to lamda coords
-
-  if (domain->triclinic) domain->x2lamda(nlocal);
 
   // permute = desired permutation of atoms
   // permute[I] = J means Ith new atom will be Jth old atom
@@ -241,6 +236,12 @@ void AtomKokkos::sort()
   //int flagall;
   //MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
   //if (flagall) errorX->all(FLERR,"Atom sort did not operate correctly");
+
+  modified(Host, ALL_MASK);
+
+ //  convert back to lamda coords
+ 
+ if (domain->triclinic) domain->x2lamda(nlocal);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -240,7 +240,7 @@ void AtomKokkos::sort()
   modified(Host, ALL_MASK);
 
  //  convert back to lamda coords
- 
+
  if (domain->triclinic) domain->x2lamda(nlocal);
 }
 

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -2271,6 +2271,10 @@ void Atom::sort()
 
   for (i = 0; i < nbins; i++) binhead[i] = -1;
 
+  // for triclinic, atoms must be in box coords (not lamda) to match bbox
+
+  if (domain->triclinic) domain->lamda2x(nlocal);
+
   for (i = nlocal-1; i >= 0; i--) {
     ix = static_cast<int> ((x[i][0]-bboxlo[0])*bininvx);
     iy = static_cast<int> ((x[i][1]-bboxlo[1])*bininvy);
@@ -2285,6 +2289,10 @@ void Atom::sort()
     next[i] = binhead[ibin];
     binhead[ibin] = i;
   }
+
+  // convert back to lamda coords
+
+  if (domain->triclinic) domain->x2lamda(nlocal);
 
   // permute = desired permutation of atoms
   // permute[I] = J means Ith new atom will be Jth old atom


### PR DESCRIPTION
**Summary**

Atom sorting for triclinic boxes is currently broken because atom positions are in 0...1 "lamda" coords but the bounding box and binsize are in regular box coords. This makes sorting a no-op for many cases since all atoms end up in the same bin. This PR fixes the issue by temporarily converting the atom positions back to box coords for sorting.

Alternatively the bounding box and binsize could be converted to lambda coords, but that seems more complex and would require many more changes to the code. We could consider this path though if other developers think it is better.

**Related Issue(s)**

#3740

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes