### PR TITLE
Fuse some Kokkos kernels to reduce launch latency for small systems

### DIFF
--- a/src/KOKKOS/fix_langevin_kokkos.cpp
+++ b/src/KOKKOS/fix_langevin_kokkos.cpp
@@ -44,6 +44,7 @@ FixLangevinKokkos<DeviceType>::FixLangevinKokkos(LAMMPS *lmp, int narg, char **a
   FixLangevin(lmp, narg, arg),rand_pool(seed + comm->me)
 {
   kokkosable = 1;
+  fuse_integrate_flag = 1;
   atomKK = (AtomKokkos *) atom;
   int ntypes = atomKK->ntypes;
 
@@ -165,6 +166,14 @@ void FixLangevinKokkos<DeviceType>::initial_integrate_item(int i) const
     v(i,1) = d_lv(i,1);
     v(i,2) = d_lv(i,2);
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixLangevinKokkos<DeviceType>::fused_integrate(int vflag)
+{
+  initial_integrate(vflag);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/fix_langevin_kokkos.h
+++ b/src/KOKKOS/fix_langevin_kokkos.h
@@ -69,6 +69,7 @@ namespace LAMMPS_NS {
     void cleanup_copy();
     void init() override;
     void initial_integrate(int) override;
+    void fused_integrate(int) override;
     void post_force(int) override;
     void reset_dt() override;
     void grow_arrays(int) override;

--- a/src/KOKKOS/fix_nve_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_kokkos.cpp
@@ -177,7 +177,6 @@ template<class DeviceType>
 void FixNVEKokkos<DeviceType>::fused_integrate()
 {
   atomKK->sync(execution_space,datamask_read);
-  atomKK->modified(execution_space,datamask_modify);
 
   x = atomKK->k_x.view<DeviceType>();
   v = atomKK->k_v.view<DeviceType>();
@@ -196,6 +195,8 @@ void FixNVEKokkos<DeviceType>::fused_integrate()
     FixNVEKokkosFusedIntegrateFunctor<DeviceType,0> functor(this);
     Kokkos::parallel_for(nlocal,functor);
   }
+
+  atomKK->modified(execution_space,datamask_modify);
 }
 
 namespace LAMMPS_NS {

--- a/src/KOKKOS/fix_nve_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_kokkos.cpp
@@ -224,7 +224,7 @@ void FixNVEKokkos<DeviceType>::fused_integrate_rmass_item(int i) const
 
 template<class DeviceType>
 void FixNVEKokkos<DeviceType>::cleanup_copy()
-{ 
+{
   id = style = nullptr;
   vatom = nullptr;
 }

--- a/src/KOKKOS/fix_nve_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_kokkos.cpp
@@ -193,8 +193,8 @@ void FixNVEKokkos<DeviceType>::fused_integrate(int /*vflag*/)
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 void FixNVEKokkos<DeviceType>::fused_integrate_item(int i) const
-{ 
-  if (mask[i] & groupbit) { 
+{
+  if (mask[i] & groupbit) {
     const double dtfm = 2.0 * dtf / mass[type[i]];
     v(i,0) += dtfm * f(i,0);
     v(i,1) += dtfm * f(i,1);

--- a/src/KOKKOS/fix_nve_kokkos.h
+++ b/src/KOKKOS/fix_nve_kokkos.h
@@ -46,6 +46,7 @@ class FixNVEKokkos : public FixNVE {
   void init() override;
   void initial_integrate(int) override;
   void final_integrate() override;
+  void fused_integrate() override;
 
   KOKKOS_INLINE_FUNCTION
   void initial_integrate_item(int) const;
@@ -93,6 +94,25 @@ struct FixNVEKokkosFinalIntegrateFunctor  {
   void operator()(const int i) const {
     if (RMass) c.final_integrate_rmass_item(i);
     else c.final_integrate_item(i);
+  }
+};
+
+template <class DeviceType, int RMass>
+struct FixNVEKokkosFusedIntegrateFunctor  {
+  typedef DeviceType  device_type ;
+  FixNVEKokkos<DeviceType> c;
+
+  FixNVEKokkosFusedIntegrateFunctor(FixNVEKokkos<DeviceType>* c_ptr):
+  c(*c_ptr) {c.cleanup_copy();};
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i) const {
+    if (RMass) {
+      c.final_integrate_rmass_item(i);
+      c.initial_integrate_rmass_item(i);
+    } else {
+      c.final_integrate_item(i);
+      c.initial_integrate_item(i);
+    }
   }
 };
 

--- a/src/KOKKOS/fix_nve_kokkos.h
+++ b/src/KOKKOS/fix_nve_kokkos.h
@@ -46,7 +46,7 @@ class FixNVEKokkos : public FixNVE {
   void init() override;
   void initial_integrate(int) override;
   void final_integrate() override;
-  void fused_integrate() override;
+  void fused_integrate(int) override;
 
   KOKKOS_INLINE_FUNCTION
   void initial_integrate_item(int) const;
@@ -56,6 +56,10 @@ class FixNVEKokkos : public FixNVE {
   void final_integrate_item(int) const;
   KOKKOS_INLINE_FUNCTION
   void final_integrate_rmass_item(int) const;
+  KOKKOS_INLINE_FUNCTION
+  void fused_integrate_item(int) const;
+  KOKKOS_INLINE_FUNCTION
+  void fused_integrate_rmass_item(int) const;
 
  private:
 
@@ -106,13 +110,10 @@ struct FixNVEKokkosFusedIntegrateFunctor  {
   c(*c_ptr) {c.cleanup_copy();};
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i) const {
-    if (RMass) {
-      c.final_integrate_rmass_item(i);
-      c.initial_integrate_rmass_item(i);
-    } else {
-      c.final_integrate_item(i);
-      c.initial_integrate_item(i);
-    }
+    if (RMass)
+      c.fused_integrate_rmass_item(i);
+    else
+      c.fused_integrate_item(i);
   }
 };
 

--- a/src/KOKKOS/fix_nve_sphere_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_sphere_kokkos.cpp
@@ -28,6 +28,7 @@ FixNVESphereKokkos<DeviceType>::FixNVESphereKokkos(LAMMPS *lmp, int narg, char *
   FixNVESphere(lmp, narg, arg)
 {
   kokkosable = 1;
+  fuse_integrate_flag = 1;
   atomKK = (AtomKokkos *)atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
 
@@ -161,6 +162,72 @@ void FixNVESphereKokkos<DeviceType>::final_integrate_item(const int i) const
     omega(i,0) += dtirotate * torque(i,0);
     omega(i,1) += dtirotate * torque(i,1);
     omega(i,2) += dtirotate * torque(i,2);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void FixNVESphereKokkos<DeviceType>::fused_integrate(int /*vflag*/)
+{
+  if (extra == DIPOLE)
+    atomKK->sync(execution_space, X_MASK | V_MASK | OMEGA_MASK| F_MASK | TORQUE_MASK | RMASS_MASK | RADIUS_MASK | MASK_MASK | MU_MASK);
+  else
+    atomKK->sync(execution_space, X_MASK | V_MASK | OMEGA_MASK| F_MASK | TORQUE_MASK | RMASS_MASK | RADIUS_MASK | MASK_MASK);
+
+  v = atomKK->k_v.view<DeviceType>();
+  omega = atomKK->k_omega.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  torque = atomKK->k_torque.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  rmass = atomKK->k_rmass.view<DeviceType>();
+  radius = atomKK->k_radius.view<DeviceType>();
+  mu = atomKK->k_mu.view<DeviceType>();
+
+  int nlocal = atom->nlocal;
+  if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  FixNVESphereKokkosFusedIntegrateFunctor<DeviceType> f(this);
+  Kokkos::parallel_for(nlocal,f);
+
+  if (extra == DIPOLE)
+    atomKK->modified(execution_space,  X_MASK | V_MASK | OMEGA_MASK | MU_MASK);
+  else
+    atomKK->modified(execution_space,  X_MASK | V_MASK | OMEGA_MASK);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <class DeviceType>
+KOKKOS_INLINE_FUNCTION
+void FixNVESphereKokkos<DeviceType>::fused_integrate_item(const int i) const
+{
+  const double dtfrotate = dtf / inertia;
+
+  if (mask(i) & groupbit) {
+    const double dtfm = 2.0 * dtf / rmass(i);
+    v(i,0) += dtfm * f(i,0);
+    v(i,1) += dtfm * f(i,1);
+    v(i,2) += dtfm * f(i,2);
+    x(i,0) += dtv * v(i,0);
+    x(i,1) += dtv * v(i,1);
+    x(i,2) += dtv * v(i,2);
+
+    const double dtirotate = 2.0 * dtfrotate / (radius(i)*radius(i)*rmass(i));
+    omega(i,0) += dtirotate * torque(i,0);
+    omega(i,1) += dtirotate * torque(i,1);
+    omega(i,2) += dtirotate * torque(i,2);
+
+    if (extra == DIPOLE) {
+      const double g0 = mu(i,0) + dtv * (omega(i,1) * mu(i,2) - omega(i,2) * mu(i,1));
+      const double g1 = mu(i,1) + dtv * (omega(i,2) * mu(i,0) - omega(i,0) * mu(i,2));
+      const double g2 = mu(i,2) + dtv * (omega(i,0) * mu(i,1) - omega(i,1) * mu(i,0));
+      const double msq = g0*g0 + g1*g1 + g2*g2;
+      const double scale = mu(i,3)/sqrt(msq);
+      mu(i,0) = g0*scale;
+      mu(i,1) = g1*scale;
+      mu(i,2) = g2*scale;
+    }
   }
 }
 

--- a/src/KOKKOS/fix_nve_sphere_kokkos.cpp
+++ b/src/KOKKOS/fix_nve_sphere_kokkos.cpp
@@ -175,6 +175,7 @@ void FixNVESphereKokkos<DeviceType>::fused_integrate(int /*vflag*/)
   else
     atomKK->sync(execution_space, X_MASK | V_MASK | OMEGA_MASK| F_MASK | TORQUE_MASK | RMASS_MASK | RADIUS_MASK | MASK_MASK);
 
+  x = atomKK->k_x.view<DeviceType>();
   v = atomKK->k_v.view<DeviceType>();
   omega = atomKK->k_omega.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();

--- a/src/KOKKOS/fix_nve_sphere_kokkos.h
+++ b/src/KOKKOS/fix_nve_sphere_kokkos.h
@@ -37,11 +37,14 @@ class FixNVESphereKokkos : public FixNVESphere {
     void init() override;
     void initial_integrate(int) override;
     void final_integrate() override;
+    void fused_integrate(int) override;
 
     KOKKOS_INLINE_FUNCTION
     void initial_integrate_item(const int i) const;
     KOKKOS_INLINE_FUNCTION
     void final_integrate_item(const int i) const;
+    KOKKOS_INLINE_FUNCTION
+    void fused_integrate_item(int) const;
 
   private:
     typename ArrayTypes<DeviceType>::t_x_array x;
@@ -74,6 +77,17 @@ struct FixNVESphereKokkosFinalIntegrateFunctor {
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i) const {
     c.final_integrate_item(i);
+  }
+};
+
+template <class DeviceType>
+struct FixNVESphereKokkosFusedIntegrateFunctor {
+  typedef DeviceType device_type;
+  FixNVESphereKokkos<DeviceType> c;
+  FixNVESphereKokkosFusedIntegrateFunctor(FixNVESphereKokkos<DeviceType> *c_ptr): c(*c_ptr) { c.cleanup_copy(); }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i) const {
+    c.fused_integrate_item(i);
   }
 };
 

--- a/src/KOKKOS/modify_kokkos.cpp
+++ b/src/KOKKOS/modify_kokkos.cpp
@@ -396,14 +396,14 @@ void ModifyKokkos::final_integrate()
    fused initial and final integrate call, only for relevant fixes
 ------------------------------------------------------------------------- */
 
-void ModifyKokkos::fused_integrate()
+void ModifyKokkos::fused_integrate(int vflag)
 {
   for (int i = 0; i < n_final_integrate; i++) {
     atomKK->sync(fix[list_final_integrate[i]]->execution_space,
                  fix[list_final_integrate[i]]->datamask_read);
     int prev_auto_sync = lmp->kokkos->auto_sync;
     if (!fix[list_final_integrate[i]]->kokkosable) lmp->kokkos->auto_sync = 1;
-    fix[list_final_integrate[i]]->fused_integrate();
+    fix[list_final_integrate[i]]->fused_integrate(vflag);
     lmp->kokkos->auto_sync = prev_auto_sync;
     atomKK->modified(fix[list_final_integrate[i]]->execution_space,
                      fix[list_final_integrate[i]]->datamask_modify);

--- a/src/KOKKOS/modify_kokkos.cpp
+++ b/src/KOKKOS/modify_kokkos.cpp
@@ -394,7 +394,7 @@ void ModifyKokkos::final_integrate()
 
 
 /* ----------------------------------------------------------------------
-   2nd half of integrate call, only for relevant fixes
+   fused initial and final integrate call, only for relevant fixes
 ------------------------------------------------------------------------- */
 
 void ModifyKokkos::fused_integrate()
@@ -899,4 +899,23 @@ int ModifyKokkos::min_reset_ref()
                      fix[list_min_energy[i]]->datamask_modify);
   }
   return itmpall;
+}
+
+/* ----------------------------------------------------------------------
+   check if initial and final integrate can be fused
+------------------------------------------------------------------------- */
+
+int ModifyKokkos::check_fuse_integrate()
+{
+  int fuse_integrate_flag = 1;
+
+  for (int i = 0; i < n_initial_integrate; i++)
+    if (!fix[list_initial_integrate[i]]->fuse_integrate_flag)
+      fuse_integrate_flag = 0;
+
+  for (int i = 0; i < n_final_integrate; i++)
+    if (!fix[list_final_integrate[i]]->fuse_integrate_flag)
+      fuse_integrate_flag = 0;
+
+  return fuse_integrate_flag;
 }

--- a/src/KOKKOS/modify_kokkos.cpp
+++ b/src/KOKKOS/modify_kokkos.cpp
@@ -392,7 +392,6 @@ void ModifyKokkos::final_integrate()
   }
 }
 
-
 /* ----------------------------------------------------------------------
    fused initial and final integrate call, only for relevant fixes
 ------------------------------------------------------------------------- */

--- a/src/KOKKOS/modify_kokkos.h
+++ b/src/KOKKOS/modify_kokkos.h
@@ -39,7 +39,7 @@ class ModifyKokkos : public Modify {
   void pre_reverse(int,int) override;
   void post_force(int) override;
   void final_integrate() override;
-  void fused_integrate() override;
+  void fused_integrate(int) override;
   void end_of_step() override;
   double energy_couple() override;
   double energy_global() override;

--- a/src/KOKKOS/modify_kokkos.h
+++ b/src/KOKKOS/modify_kokkos.h
@@ -39,6 +39,7 @@ class ModifyKokkos : public Modify {
   void pre_reverse(int,int) override;
   void post_force(int) override;
   void final_integrate() override;
+  void fused_integrate() override;
   void end_of_step() override;
   double energy_couple() override;
   double energy_global() override;

--- a/src/KOKKOS/modify_kokkos.h
+++ b/src/KOKKOS/modify_kokkos.h
@@ -70,6 +70,8 @@ class ModifyKokkos : public Modify {
   int min_dof() override;
   int min_reset_ref() override;
 
+  int check_fuse_integrate();
+
  protected:
 
 };

--- a/src/KOKKOS/pair_kokkos.h
+++ b/src/KOKKOS/pair_kokkos.h
@@ -280,6 +280,12 @@ struct PairComputeFunctor  {
       const X_FLOAT ztmp = c.x(i,2);
       const int itype = c.type(i);
 
+      Kokkos::single(Kokkos::PerThread(team), [&] (){
+        f(i,0) = 0.0;
+        f(i,1) = 0.0;
+        f(i,2) = 0.0;
+      });
+
       const AtomNeighborsConst neighbors_i = list.get_neighbors_const(i);
       const int jnum = list.d_numneigh[i];
 
@@ -336,6 +342,12 @@ struct PairComputeFunctor  {
       const X_FLOAT ztmp = c.x(i,2);
       const int itype = c.type(i);
       const F_FLOAT qtmp = c.q(i);
+
+      Kokkos::single(Kokkos::PerThread(team), [&] (){
+        f(i,0) = 0.0;
+        f(i,1) = 0.0;
+        f(i,2) = 0.0;
+      });
 
       const AtomNeighborsConst neighbors_i = list.get_neighbors_const(i);
       const int jnum = list.d_numneigh[i];
@@ -399,6 +411,12 @@ struct PairComputeFunctor  {
       const X_FLOAT ztmp = c.x(i,2);
       const int itype = c.type(i);
 
+      Kokkos::single(Kokkos::PerThread(team), [&] (){
+        f(i,0) = 0.0;
+        f(i,1) = 0.0;
+        f(i,2) = 0.0;
+      });
+    
       const AtomNeighborsConst neighbors_i = list.get_neighbors_const(i);
       const int jnum = list.d_numneigh[i];
 
@@ -494,6 +512,12 @@ struct PairComputeFunctor  {
       const X_FLOAT ztmp = c.x(i,2);
       const int itype = c.type(i);
       const F_FLOAT qtmp = c.q(i);
+
+      Kokkos::single(Kokkos::PerThread(team), [&] (){
+        f(i,0) = 0.0;
+        f(i,1) = 0.0;
+        f(i,2) = 0.0;
+      });
 
       const AtomNeighborsConst neighbors_i = list.get_neighbors_const(i);
       const int jnum = list.d_numneigh[i];
@@ -743,6 +767,8 @@ EV_FLOAT pair_compute_neighlist (PairStyle* fpair, typename std::enable_if<(NEIG
       fpair->lmp->kokkos->neigh_thread = 1;
 
   if (fpair->lmp->kokkos->neigh_thread) {
+    fpair->fuse_force_clear_flag = 1;
+
     int vector_length = 8;
     int atoms_per_team = 32;
 

--- a/src/KOKKOS/pair_kokkos.h
+++ b/src/KOKKOS/pair_kokkos.h
@@ -416,7 +416,7 @@ struct PairComputeFunctor  {
         f(i,1) = 0.0;
         f(i,2) = 0.0;
       });
-    
+ 
       const AtomNeighborsConst neighbors_i = list.get_neighbors_const(i);
       const int jnum = list.d_numneigh[i];
 

--- a/src/KOKKOS/pair_kokkos.h
+++ b/src/KOKKOS/pair_kokkos.h
@@ -416,7 +416,7 @@ struct PairComputeFunctor  {
         f(i,1) = 0.0;
         f(i,2) = 0.0;
       });
- 
+
       const AtomNeighborsConst neighbors_i = list.get_neighbors_const(i);
       const int jnum = list.d_numneigh[i];
 

--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -276,6 +276,9 @@ void VerletKokkos::run(int n)
 
   lmp->kokkos->auto_sync = 0;
 
+  fuse_integrate = 0;
+  fuse_force_clear = 0;
+
   if (atomKK->sortfreq > 0) sortflag = 1;
   else sortflag = 0;
 

--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -358,12 +358,15 @@ void VerletKokkos::run(int n)
       }
     }
 
+    // check if kernels can be fused, must come after initial_integrate
+
+    fuse_check(i,n);
+
     // force computations
     // important for pair to come before bonded contributions
     // since some bonded potentials tally pairwise energy/virial
     // and Pair:ev_tally() needs to be called before any tallying
 
-    fuse_check(i,n);
     if (!fuse_force_clear)
       force_clear();
 

--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -618,13 +618,13 @@ void VerletKokkos::force_clear()
 
 void VerletKokkos::fuse_check(int i, int n)
 {
-  fuse_force_clear = 0;
+  fuse_force_clear = 1;
   if (modify->n_pre_force) fuse_force_clear = 0;
   if (torqueflag || extraflag || neighbor->includegroup) fuse_force_clear = 0;
   if (!pair_compute_flag) fuse_force_clear = 0;
   if (!force->pair->fuse_force_clear_flag) fuse_force_clear = 0;
 
-  fuse_integrate = 0;
+  fuse_integrate = 1;
   if (modify->n_end_of_step) fuse_integrate = 0;
   if (i == 0 || i == n-1) fuse_integrate = 0;
   if (update->ntimestep == output->next) fuse_integrate = 0;

--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -498,7 +498,7 @@ void VerletKokkos::run(int n)
 
     if (n_post_force) modify->post_force(vflag);
 
-    if (fuse_integrate) modify->fused_integrate();
+    if (fuse_integrate) modify->fused_integrate(vflag);
     else modify->final_integrate();
 
     if (n_end_of_step) modify->end_of_step();

--- a/src/KOKKOS/verlet_kokkos.cpp
+++ b/src/KOKKOS/verlet_kokkos.cpp
@@ -27,7 +27,7 @@
 #include "kspace.h"
 #include "output.h"
 #include "update.h"
-#include "modify.h"
+#include "modify_kokkos.h"
 #include "timer.h"
 #include "memory_kokkos.h"
 #include "kokkos.h"
@@ -629,5 +629,5 @@ void VerletKokkos::fuse_check(int i, int n)
   if (i == 0 || i == n-1) fuse_integrate = 0;
   if (update->ntimestep == output->next) fuse_integrate = 0;
   if (timer->has_timeout()) fuse_integrate = 0;
-  if (!modify->check_fuse_integrate()) fuse_integrate = 0;
+  if (!((ModifyKokkos*)modify)->check_fuse_integrate()) fuse_integrate = 0;
 }

--- a/src/KOKKOS/verlet_kokkos.h
+++ b/src/KOKKOS/verlet_kokkos.h
@@ -46,6 +46,9 @@ class VerletKokkos : public Verlet {
 
  protected:
   DAT::t_f_array f_merge_copy,f;
+  int fuse_force_clear,fuse_integrate;
+
+  void fuse_check(int, int);
 };
 }
 

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -102,15 +102,15 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   vflag_atom = cvflag_atom = 0;
   centroidstressflag = CENTROID_SAME;
 
-  // KOKKOS per-fix data masks
+  // KOKKOS package
 
   execution_space = Host;
   datamask_read = ALL_MASK;
   datamask_modify = ALL_MASK;
 
-  kokkosable = 0;
+  kokkosable = copymode = 0;
   forward_comm_device = exchange_comm_device = 0;
-  copymode = 0;
+  fuse_integrate_flag = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix.h
+++ b/src/fix.h
@@ -127,11 +127,12 @@ class Fix : protected Pointers {
 
   int restart_reset;    // 1 if restart just re-initialized fix
 
-  // KOKKOS host/device flag and data masks
+  // KOKKOS flags and variables
 
   int kokkosable;             // 1 if Kokkos fix
   int forward_comm_device;    // 1 if forward comm on Device
   int exchange_comm_device;   // 1 if exchange comm on Device
+  int fuse_integrate_flag;    // 1 if can fuse initial integrate with final integrate
   ExecutionSpace execution_space;
   unsigned int datamask_read, datamask_modify;
 
@@ -152,6 +153,7 @@ class Fix : protected Pointers {
   virtual void setup_pre_reverse(int, int) {}
   virtual void min_setup(int) {}
   virtual void initial_integrate(int) {}
+  virtual void fused_integrate() {}
   virtual void post_integrate() {}
   virtual void pre_exchange() {}
   virtual void pre_neighbor() {}

--- a/src/fix.h
+++ b/src/fix.h
@@ -153,7 +153,6 @@ class Fix : protected Pointers {
   virtual void setup_pre_reverse(int, int) {}
   virtual void min_setup(int) {}
   virtual void initial_integrate(int) {}
-  virtual void fused_integrate() {}
   virtual void post_integrate() {}
   virtual void pre_exchange() {}
   virtual void pre_neighbor() {}
@@ -162,6 +161,7 @@ class Fix : protected Pointers {
   virtual void pre_reverse(int, int) {}
   virtual void post_force(int) {}
   virtual void final_integrate() {}
+  virtual void fused_integrate(int) {}
   virtual void end_of_step() {}
   virtual void post_run() {}
   virtual void write_restart(FILE *) {}

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -475,6 +475,17 @@ void Modify::final_integrate()
   for (int i = 0; i < n_final_integrate; i++) fix[list_final_integrate[i]]->final_integrate();
 }
 
+
+/* ----------------------------------------------------------------------
+   2nd half of integrate call, only for relevant fixes
+------------------------------------------------------------------------- */
+
+void Modify::fused_integrate()
+{
+  for (int i = 0; i < n_final_integrate; i++)
+    fix[list_final_integrate[i]]->fused_integrate();
+}
+
 /* ----------------------------------------------------------------------
    end-of-timestep call, only for relevant fixes
    only call fix->end_of_step() on timesteps that are multiples of nevery
@@ -1798,4 +1809,23 @@ double Modify::memory_usage()
   for (int i = 0; i < nfix; i++) bytes += fix[i]->memory_usage();
   for (int i = 0; i < ncompute; i++) bytes += compute[i]->memory_usage();
   return bytes;
+}
+
+/* ----------------------------------------------------------------------
+   check if initial and final integrate can be fused
+------------------------------------------------------------------------- */
+
+int Modify::check_fuse_integrate()
+{
+  int fuse_integrate_flag = 1;
+
+  for (int i = 0; i < n_initial_integrate; i++)
+    if (!fix[list_initial_integrate[i]]->fuse_integrate_flag)
+      fuse_integrate_flag = 0;
+
+  for (int i = 0; i < n_final_integrate; i++)
+    if (!fix[list_final_integrate[i]]->fuse_integrate_flag)
+      fuse_integrate_flag = 0;
+
+  return fuse_integrate_flag;
 }

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -475,17 +475,6 @@ void Modify::final_integrate()
   for (int i = 0; i < n_final_integrate; i++) fix[list_final_integrate[i]]->final_integrate();
 }
 
-
-/* ----------------------------------------------------------------------
-   2nd half of integrate call, only for relevant fixes
-------------------------------------------------------------------------- */
-
-void Modify::fused_integrate()
-{
-  for (int i = 0; i < n_final_integrate; i++)
-    fix[list_final_integrate[i]]->fused_integrate();
-}
-
 /* ----------------------------------------------------------------------
    end-of-timestep call, only for relevant fixes
    only call fix->end_of_step() on timesteps that are multiples of nevery
@@ -1809,23 +1798,4 @@ double Modify::memory_usage()
   for (int i = 0; i < nfix; i++) bytes += fix[i]->memory_usage();
   for (int i = 0; i < ncompute; i++) bytes += compute[i]->memory_usage();
   return bytes;
-}
-
-/* ----------------------------------------------------------------------
-   check if initial and final integrate can be fused
-------------------------------------------------------------------------- */
-
-int Modify::check_fuse_integrate()
-{
-  int fuse_integrate_flag = 1;
-
-  for (int i = 0; i < n_initial_integrate; i++)
-    if (!fix[list_initial_integrate[i]]->fuse_integrate_flag)
-      fuse_integrate_flag = 0;
-
-  for (int i = 0; i < n_final_integrate; i++)
-    if (!fix[list_final_integrate[i]]->fuse_integrate_flag)
-      fuse_integrate_flag = 0;
-
-  return fuse_integrate_flag;
 }

--- a/src/modify.h
+++ b/src/modify.h
@@ -61,7 +61,7 @@ class Modify : protected Pointers {
   virtual void setup_pre_force(int);
   virtual void setup_pre_reverse(int, int);
   virtual void initial_integrate(int);
-  virtual void fused_integrate();
+  virtual void fused_integrate() {}
   virtual void post_integrate();
   virtual void pre_exchange();
   virtual void pre_neighbor();
@@ -150,8 +150,6 @@ class Modify : protected Pointers {
   void restart_deallocate(int);
 
   double memory_usage();
-
-  int check_fuse_integrate();
 
  protected:
   // internal fix counts

--- a/src/modify.h
+++ b/src/modify.h
@@ -61,6 +61,7 @@ class Modify : protected Pointers {
   virtual void setup_pre_force(int);
   virtual void setup_pre_reverse(int, int);
   virtual void initial_integrate(int);
+  virtual void fused_integrate();
   virtual void post_integrate();
   virtual void pre_exchange();
   virtual void pre_neighbor();
@@ -149,6 +150,8 @@ class Modify : protected Pointers {
   void restart_deallocate(int);
 
   double memory_usage();
+
+  int check_fuse_integrate();
 
  protected:
   // internal fix counts

--- a/src/modify.h
+++ b/src/modify.h
@@ -61,7 +61,6 @@ class Modify : protected Pointers {
   virtual void setup_pre_force(int);
   virtual void setup_pre_reverse(int, int);
   virtual void initial_integrate(int);
-  virtual void fused_integrate() {}
   virtual void post_integrate();
   virtual void pre_exchange();
   virtual void pre_neighbor();
@@ -70,6 +69,7 @@ class Modify : protected Pointers {
   virtual void pre_reverse(int, int);
   virtual void post_force(int);
   virtual void final_integrate();
+  virtual void fused_integrate(int) {}
   virtual void end_of_step();
   virtual double energy_couple();
   virtual double energy_global();

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -116,15 +116,14 @@ Pair::Pair(LAMMPS *lmp) :
   nondefault_history_transfer = 0;
   beyond_contact = 0;
 
-  // KOKKOS per-fix data masks
+  // KOKKOS package
 
   execution_space = Host;
   datamask_read = ALL_MASK;
   datamask_modify = ALL_MASK;
 
-  kokkosable = 0;
-  reverse_comm_device = 0;
-  copymode = 0;
+  kokkosable = copymode = 0;
+  reverse_comm_device = fuse_force_clear_flag = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/pair.h
+++ b/src/pair.h
@@ -119,12 +119,13 @@ class Pair : protected Pointers {
 
   int beyond_contact, nondefault_history_transfer;    // for granular styles
 
-  // KOKKOS host/device flag and data masks
+  // KOKKOS flags and variables
 
   ExecutionSpace execution_space;
   unsigned int datamask_read, datamask_modify;
   int kokkosable;             // 1 if Kokkos pair
   int reverse_comm_device;    // 1 if reverse comm on Device
+  int fuse_force_clear_flag;   // 1 if can fuse force clear with force compute
 
   Pair(class LAMMPS *);
   ~Pair() override;

--- a/src/timer.h
+++ b/src/timer.h
@@ -63,6 +63,7 @@ class Timer : protected Pointers {
   bool has_normal() const { return (_level >= NORMAL); }
   bool has_full() const { return (_level >= FULL); }
   bool has_sync() const { return (_sync != OFF); }
+  bool has_timeout() const { return (_timeout >= 0.0); }
 
   // flag if wallclock time is expired
   bool is_timeout() const { return (_timeout == 0.0); }


### PR DESCRIPTION
**Summary**

Fuse some Kokkos kernels to reduce launch latency for small systems. Gives ~20% speedup for 1k atom LJ benchmark on a single V100 GPU.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes