### PR TITLE
Fix issues with Kokkos minimize and fix addforce

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -358,18 +358,7 @@ void AtomKokkos::deallocate_topology()
   memoryKK->destroy_kokkos(k_improper_atom4, improper_atom4);
 }
 
-/* ----------------------------------------------------------------------
-   perform sync and modify for each of 2 masks
-   called by individual styles to override default sync/modify calls
-     done at higher levels (Verlet,Modify,etc)
-------------------------------------------------------------------------- */
-
-void AtomKokkos::sync_modify(ExecutionSpace execution_space, unsigned int datamask_read,
-                             unsigned int datamask_modify)
-{
-  sync(execution_space, datamask_read);
-  modified(execution_space, datamask_modify);
-}
+/* ---------------------------------------------------------------------- */
 
 AtomVec *AtomKokkos::new_avec(const std::string &style, int trysuffix, int &sflag)
 {

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -120,7 +120,6 @@ class AtomKokkos : public Atom {
   int add_custom(const char *, int, int) override;
   void remove_custom(int, int, int) override;
   virtual void deallocate_topology();
-  void sync_modify(ExecutionSpace, unsigned int, unsigned int) override;
  private:
   void sort_device();
   class AtomVec *new_avec(const std::string &, int, int &) override;

--- a/src/KOKKOS/fix_minimize_kokkos.cpp
+++ b/src/KOKKOS/fix_minimize_kokkos.cpp
@@ -28,7 +28,6 @@ FixMinimizeKokkos::FixMinimizeKokkos(LAMMPS *lmp, int narg, char **arg) :
   FixMinimize(lmp, narg, arg)
 {
   kokkosable = 1;
-  sort_device = 1;
   atomKK = (AtomKokkos *) atom;
 }
 
@@ -217,21 +216,6 @@ void FixMinimizeKokkos::copy_arrays(int i, int j, int /*delflag*/)
   }
 
   k_vectors.modify<LMPHostType>();
-}
-
-/* ----------------------------------------------------------------------
-   sort local atom-based arrays
-------------------------------------------------------------------------- */
-
-void FixMinimizeKokkos::sort_kokkos(Kokkos::BinSort<KeyViewType, BinOp> &Sorter)
-{
-  // always sort on the device
-
-  k_vectors.sync_device();
-
-  Sorter.sort(LMPDeviceType(), k_vectors.d_view);
-
-  k_vectors.modify_device();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/fix_minimize_kokkos.h
+++ b/src/KOKKOS/fix_minimize_kokkos.h
@@ -39,7 +39,6 @@ class FixMinimizeKokkos : public FixMinimize, public KokkosBase {
 
   void grow_arrays(int) override;
   void copy_arrays(int, int, int) override;
-  void sort_kokkos(Kokkos::BinSort<KeyViewType, BinOp> &Sorter) override;
   int pack_exchange(int, double *) override;
   int unpack_exchange(int, double *) override;
 

--- a/src/atom.h
+++ b/src/atom.h
@@ -366,8 +366,6 @@ class Atom : protected Pointers {
   virtual int add_custom(const char *, int, int);
   virtual void remove_custom(int, int, int);
 
-  virtual void sync_modify(ExecutionSpace, unsigned int, unsigned int) {}
-
   void *extract(const char *);
   int extract_datatype(const char *);
 

--- a/src/fix_addforce.cpp
+++ b/src/fix_addforce.cpp
@@ -103,6 +103,11 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
 
   maxatom = 1;
   memory->create(sforce, maxatom, 4, "addforce:sforce");
+
+  // KOKKOS package
+
+  datamask_read = X_MASK | F_MASK | IMAGE_MASK;
+  datamask_modify = F_MASK;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -121,8 +126,6 @@ FixAddForce::~FixAddForce()
 
 int FixAddForce::setmask()
 {
-  datamask_read = datamask_modify = 0;
-
   int mask = 0;
   mask |= POST_FORCE;
   mask |= POST_FORCE_RESPA;
@@ -237,9 +240,6 @@ void FixAddForce::post_force(int vflag)
   // virial setup
 
   v_init(vflag);
-
-  if (lmp->kokkos)
-    atom->sync_modify(Host, (unsigned int) (F_MASK | MASK_MASK), (unsigned int) F_MASK);
 
   // update region if necessary
 

--- a/src/fix_addforce.cpp
+++ b/src/fix_addforce.cpp
@@ -106,7 +106,7 @@ FixAddForce::FixAddForce(LAMMPS *lmp, int narg, char **arg) :
 
   // KOKKOS package
 
-  datamask_read = X_MASK | F_MASK | IMAGE_MASK;
+  datamask_read = X_MASK | F_MASK | MASK_MASK | IMAGE_MASK;
   datamask_modify = F_MASK;
 }
 


### PR DESCRIPTION
**Summary**

- Fix problems with GPU/CPU data movement in `fix addforce/kk`
- Recently added device sorting for `fix minimize/kk` was broken due to using a non-standard data layout, and was removed in this PR

**Related Issue(s)**

Closes #3759 

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes