### PR TITLE
Collected small fixes and updates

### DIFF
--- a/cmake/Modules/CodingStandard.cmake
+++ b/cmake/Modules/CodingStandard.cmake
@@ -5,6 +5,10 @@ if(CMAKE_VERSION VERSION_LESS 3.12)
         set(Python3_VERSION ${PYTHON_VERSION_STRING})
     endif()
 else()
+    # use default (or custom) Python executable, if version is sufficient
+    if(Python_VERSION VERSION_GREATER_EQUAL 3.5)
+      set(Python3_EXECUTABLE ${Python_EXECUTABLE})
+    endif()
     find_package(Python3 COMPONENTS Interpreter QUIET)
 endif()
 

--- a/cmake/Modules/Documentation.cmake
+++ b/cmake/Modules/Documentation.cmake
@@ -4,14 +4,18 @@
 option(BUILD_DOC "Build LAMMPS HTML documentation" OFF)
 
 if(BUILD_DOC)
-  # Sphinx 3.x requires at least Python 3.5
+  # Current Sphinx versions require at least Python 3.8
   if(CMAKE_VERSION VERSION_LESS 3.12)
-    find_package(PythonInterp 3.5 REQUIRED)
+    find_package(PythonInterp 3.8 REQUIRED)
     set(VIRTUALENV ${PYTHON_EXECUTABLE} -m venv)
   else()
+    # use default (or custom) Python executable, if version is sufficient
+    if(Python_VERSION VERSION_GREATER_EQUAL 3.8)
+      set(Python3_EXECUTABLE ${Python_EXECUTABLE})
+    endif()
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
-    if(Python3_VERSION VERSION_LESS 3.5)
-      message(FATAL_ERROR "Python 3.5 and up is required to build the HTML documentation")
+    if(Python3_VERSION VERSION_LESS 3.8)
+      message(FATAL_ERROR "Python 3.8 and up is required to build the HTML documentation")
     endif()
     set(VIRTUALENV ${Python3_EXECUTABLE} -m venv)
   endif()

--- a/doc/src/Build_make.rst
+++ b/doc/src/Build_make.rst
@@ -117,8 +117,8 @@ their settings may become outdated, too:
 
 .. code-block:: bash
 
-   make mac             # build serial LAMMPS on a Mac
-   make mac_mpi         # build parallel LAMMPS on a Mac
+   make mac             # build serial LAMMPS on macOS
+   make mac_mpi         # build parallel LAMMPS on macOS
    make intel_cpu       # build with the INTEL package optimized for CPUs
    make knl             # build with the INTEL package optimized for KNLs
    make opt             # build with the OPT package optimized for CPUs

--- a/doc/src/Build_manual.rst
+++ b/doc/src/Build_manual.rst
@@ -52,11 +52,11 @@ can be translated to different output format using the `Sphinx
 incorporates programmer documentation extracted from the LAMMPS C++
 sources through the `Doxygen <https://doxygen.nl/>`_ program.  Currently
 the translation to HTML, PDF (via LaTeX), ePUB (for many e-book readers)
-and MOBI (for Amazon Kindle readers) are supported.  For that to work a
-Python 3 interpreter, the ``doxygen`` tools and internet access to
-download additional files and tools are required.  This download is
-usually only required once or after the documentation folder is returned
-to a pristine state with ``make clean-all``.
+and MOBI (for Amazon Kindle(tm) readers) are supported.  For that to work a
+Python interpreter version 3.8 or later, the ``doxygen`` tools and
+internet access to download additional files and tools are required.
+This download is usually only required once or after the documentation
+folder is returned to a pristine state with ``make clean-all``.
 
 For the documentation build a python virtual environment is set up in
 the folder ``doc/docenv`` and various python packages are installed into

--- a/doc/src/Install_conda.rst
+++ b/doc/src/Install_conda.rst
@@ -1,13 +1,13 @@
-Download an executable for Linux or Mac via Conda
--------------------------------------------------
+Download an executable for Linux or macOS via Conda
+---------------------------------------------------
 
 Pre-compiled LAMMPS binaries are available for macOS and Linux via the
 `Conda <conda_>`_ package management system.
 
-First, one must set up the Conda package manager on your system.  Follow the
-instructions to install `Miniconda <mini_conda_install_>`_, then create a conda
-environment (named `my-lammps-env` or whatever you prefer) for your LAMMPS
-install:
+First, one must set up the Conda package manager on your system.  Follow
+the instructions to install `Miniconda <mini_conda_install_>`_, then
+create a conda environment (named `my-lammps-env` or whatever you
+prefer) for your LAMMPS install:
 
 .. code-block:: bash
 

--- a/doc/src/Install_mac.rst
+++ b/doc/src/Install_mac.rst
@@ -1,12 +1,12 @@
-Download an executable for Mac
-------------------------------
+Download an executable for macOS
+--------------------------------
 
-LAMMPS can be downloaded, built, and configured for OS X on a Mac with
-`Homebrew <homebrew_>`_.  (Alternatively, see the installation
-instructions for :doc:`downloading an executable via Conda
-<Install_conda>`.)  The following LAMMPS packages are unavailable at
-this time because of additional requirements not yet met: GPU, KOKKOS,
-MSCG, MPIIO, POEMS, VORONOI.
+LAMMPS can be downloaded, built, and configured for macOS with `Homebrew
+<homebrew_>`_.  (Alternatively, see the installation instructions for
+:doc:`downloading an executable via Conda <Install_conda>`.)  The
+following LAMMPS packages are unavailable at this time because of
+additional requirements not yet met: GPU, KOKKOS, MSCG, MPIIO, POEMS,
+VORONOI.
 
 After installing Homebrew, you can install LAMMPS on your system with
 the following commands:
@@ -15,8 +15,9 @@ the following commands:
 
    brew install lammps
 
-This will install the executables "lammps_serial" and "lammps_mpi", as well as
-the LAMMPS "doc", "potentials", "tools", "bench", and "examples" directories.
+This will install the executables "lammps_serial" and "lammps_mpi", as
+well as the LAMMPS "doc", "potentials", "tools", "bench", and "examples"
+directories.
 
 Once LAMMPS is installed, you can test the installation with the
 Lennard-Jones benchmark file:

--- a/doc/src/Install_tarball.rst
+++ b/doc/src/Install_tarball.rst
@@ -2,7 +2,7 @@ Download source and documentation as a tarball
 ----------------------------------------------
 
 You can download a current LAMMPS tarball from the `download page <download_>`_
-of the `LAMMPS website <lws_>`_.
+of the `LAMMPS website <lws_>`_ or from GitHub (see below).
 
 .. _download: https://www.lammps.org/download.html
 .. _bug: https://www.lammps.org/bug.html
@@ -17,21 +17,21 @@ tarball occasionally updated.  Feature releases occur every 4 to 8
 weeks.  The new contents in all feature releases are listed on the `bug
 and feature page <bug_>`_ of the LAMMPS homepage.
 
-Both tarballs include LAMMPS documentation (HTML and PDF files)
-corresponding to that version.
-
 Tarballs of older LAMMPS versions can also be downloaded from `this page
 <older_>`_.
 
-Once you have a tarball, unzip and untar it with the following
+Tarballs downloaded from the LAMMPS homepage include the pre-translated
+LAMMPS documentation (HTML and PDF files) corresponding to that version.
+
+Once you have a tarball, uncompress and untar it with the following
 command:
 
 .. code-block:: bash
 
    tar -xzvf lammps*.tar.gz
 
-This will create a LAMMPS directory with the version date
-in its name, e.g. lammps-23Jun18.
+This will create a LAMMPS directory with the version date in its name,
+e.g. lammps-28Mar23.
 
 ----------
 
@@ -45,7 +45,8 @@ with the following command, to create a lammps-<version> directory:
    unzip lammps*.zip
 
 This version corresponds to the selected LAMMPS feature or stable
-release.
+release (as indicated by the matching git tag) and will only contain the
+source code and no pre-built documentation.
 
 .. _git: https://github.com/lammps/lammps/releases
 

--- a/doc/src/dump_molfile.rst
+++ b/doc/src/dump_molfile.rst
@@ -63,7 +63,7 @@ like element names.
 
 The *path* keyword determines which in directories. This is a "path"
 like other search paths, i.e. it can contain multiple directories
-separated by a colon (or semi-colon on windows). This keyword is
+separated by a colon (or semicolon on Windows). This keyword is
 optional and default to ".", the current directory.
 
 The *unwrap* option of the :doc:`dump_modify <dump_modify>` command allows

--- a/doc/src/fix_wall.rst
+++ b/doc/src/fix_wall.rst
@@ -209,7 +209,7 @@ it as a single keyword.
 
 Optionally, the expression may use "rc" to refer to the cutoff distance
 for the given wall.  Further constants in the expression can be defined
-in the same string as additional expressions separated by semi-colons.
+in the same string as additional expressions separated by semicolons.
 The expression "k*(r-rc)^2;k=100.0" represents a repulsive-only harmonic
 spring as in fix *wall/harmonic* with a force constant *K* (same as
 :math:`\epsilon` above) of 100 energy units.  More details on the Lepton

--- a/doc/src/pair_dpd.rst
+++ b/doc/src/pair_dpd.rst
@@ -26,8 +26,8 @@ Syntax
    pair_style dpd T cutoff seed
    pair_style dpd/tstat Tstart Tstop cutoff seed
 
-* T = temperature (temperature units)
-* Tstart,Tstop = desired temperature at start/end of run (temperature units)
+* T = temperature (temperature units) (dpd only)
+* Tstart,Tstop = desired temperature at start/end of run (temperature units) (dpd/tstat only)
 * cutoff = global cutoff for DPD interactions (distance units)
 * seed = random # seed (positive integer)
 
@@ -40,9 +40,9 @@ Examples
    pair_coeff * * 3.0 1.0
    pair_coeff 1 1 3.0 1.0 1.0
 
-   pair_style dpd/tstat 1.0 1.0 2.5 34387
-   pair_coeff * * 1.0
-   pair_coeff 1 1 1.0 1.0
+   pair_style hybrid/overlay lj/cut 2.5 dpd/tstat 1.0 1.0 2.5 34387
+   pair_coeff * * lj/cut 1.0 1.0
+   pair_coeff * * dpd/tstat 1.0
 
 Description
 """""""""""
@@ -53,7 +53,7 @@ Style *dpd* computes a force field for dissipative particle dynamics
 Style *dpd/tstat* invokes a DPD thermostat on pairwise interactions,
 which is equivalent to the non-conservative portion of the DPD force
 field.  This pairwise thermostat can be used in conjunction with any
-:doc:`pair style <pair_style>`, and in leiu of per-particle thermostats
+:doc:`pair style <pair_style>`, and instead of per-particle thermostats
 like :doc:`fix langevin <fix_langevin>` or ensemble thermostats like
 Nose Hoover as implemented by :doc:`fix nvt <fix_nh>`.  To use
 *dpd/tstat* as a thermostat for another pair style, use the
@@ -105,14 +105,18 @@ commands:
 * :math:`\gamma` (force/velocity units)
 * cutoff (distance units)
 
-The last coefficient is optional.  If not specified, the global DPD
+The cutoff coefficient is optional.  If not specified, the global DPD
 cutoff is used.  Note that sigma is set equal to sqrt(2 T gamma),
 where T is the temperature set by the :doc:`pair_style <pair_style>`
 command so it does not need to be specified.
 
 For style *dpd/tstat*, the coefficients defined for each pair of
-atoms types via the :doc:`pair_coeff <pair_coeff>` command is the same,
-except that A is not included.
+atoms types via the :doc:`pair_coeff <pair_coeff>` command are:
+
+* :math:`\gamma` (force/velocity units)
+* cutoff (distance units)
+
+The cutoff coefficient is optional.
 
 The GPU-accelerated versions of these styles are implemented based on
 the work of :ref:`(Afshar) <Afshar>` and :ref:`(Phillips) <Phillips>`.
@@ -134,6 +138,12 @@ the work of :ref:`(Afshar) <Afshar>` and :ref:`(Phillips) <Phillips>`.
    skin distance) will also change the sequence in which the random
    numbers are applied and thus the individual forces and therefore
    also the virial/pressure.
+
+.. note::
+
+   For more consistent time integration and force computation you may
+   consider using :doc:`fix mvv/dpd <fix_mvv_dpd>` instead of :doc:`fix
+   nve <fix_nve>`.
 
 ----------
 
@@ -206,7 +216,9 @@ command for more details.
 Related commands
 """"""""""""""""
 
-:doc:`pair_coeff <pair_coeff>`, :doc:`fix nvt <fix_nh>`, :doc:`fix langevin <fix_langevin>`, :doc:`pair_style srp <pair_srp>`
+:doc:`pair_style dpd/ext <pair_dpd_ext>`, :doc:`pair_coeff <pair_coeff>`,
+:doc:`fix nvt <fix_nh>`, :doc:`fix langevin <fix_langevin>`,
+:doc:`pair_style srp <pair_srp>`, :doc:`fix mvv/dpd <fix_mvv_dpd>`.
 
 Default
 """""""

--- a/doc/src/pair_dpd_ext.rst
+++ b/doc/src/pair_dpd_ext.rst
@@ -18,7 +18,6 @@ Accelerator Variants: dpd/ext/tstat/kk dpd/ext/tstat/omp
 Syntax
 """"""
 
-
 .. code-block:: LAMMPS
 
    pair_style dpd/ext T cutoff seed
@@ -32,16 +31,15 @@ Syntax
 Examples
 """"""""
 
-
 .. code-block:: LAMMPS
 
    pair_style dpd/ext 1.0 2.5 34387
    pair_coeff 1 1 25.0 4.5 4.5 0.5 0.5 1.2
    pair_coeff 1 2 40.0 4.5 4.5 0.5 0.5 1.2
 
-   pair_style dpd/ext/tstat 1.0 1.0 2.5 34387
-   pair_coeff 1 1 4.5 4.5 0.5 0.5 1.2
-   pair_coeff 1 2 4.5 4.5 0.5 0.5 1.2
+   pair_style hybrid/overlay lj/cut 2.5 dpd/ext/tstat 1.0 1.0 2.5 34387
+   pair_coeff * * lj/cut 1.0 1.0
+   pair_coeff * * 4.5 4.5 0.5 0.5 1.2
 
 Description
 """""""""""
@@ -128,20 +126,39 @@ the :doc:`pair_style <pair_style>` command so it does not need to be
 specified.
 
 For the style *dpd/ext/tstat*, the coefficients defined for each pair of
-atoms types via the :doc:`pair_coeff <pair_coeff>` command is the same,
-except that A is not included.
+atoms types via the :doc:`pair_coeff <pair_coeff>` command are:
+
+* :math:`\gamma_{\parallel}` (force/velocity units)
+* :math:`\gamma_{\perp}` (force/velocity units)
+* :math:`s_{\parallel}` (unitless)
+* :math:`s_{\perp}` (unitless)
+* :math:`r_c` (distance units)
+
+The last coefficient is optional.
 
 .. note::
 
    If you are modeling DPD polymer chains, you may want to use the
    :doc:`pair_style srp <pair_srp>` command in conjunction with these pair
-   styles. It is a soft segmental repulsive potential (SRP) that can
+   styles.  It is a soft segmental repulsive potential (SRP) that can
    prevent DPD polymer chains from crossing each other.
 
 .. note::
 
-   The virial calculation for pressure when using this pair style includes
-   all the components of force listed above, including the random force.
+   The virial calculation for pressure when using these pair styles
+   includes all the components of force listed above, including the
+   random force.  Since the random force depends on random numbers,
+   everything that changes the order of atoms in the neighbor list
+   (e.g. different number of MPI ranks or a different neighbor list
+   skin distance) will also change the sequence in which the random
+   numbers are applied and thus the individual forces and therefore
+   also the virial/pressure.
+
+.. note::
+
+   For more consistent time integration and force computation you may
+   consider using :doc:`fix mvv/dpd <fix_mvv_dpd>` instead of :doc:`fix
+   nve <fix_nve>`.
 
 ----------
 
@@ -207,7 +224,7 @@ Related commands
 
 :doc:`pair_style dpd <pair_dpd>`, :doc:`pair_coeff <pair_coeff>`,
 :doc:`fix nvt <fix_nh>`, :doc:`fix langevin <fix_langevin>`,
-:doc:`pair_style srp <pair_srp>`
+:doc:`pair_style srp <pair_srp>`, :doc:`fix mvv/dpd <fix_mvv_dpd>`.
 
 **Default:** none
 

--- a/doc/src/pair_lepton.rst
+++ b/doc/src/pair_lepton.rst
@@ -76,7 +76,7 @@ instead reference the radii of the two atoms of the pair with "radi" and
 :doc:`data files <read_data>` or the :doc:`set command <set>`.
 
 Note that further constants in the expressions can be defined in the
-same string as additional expressions separated by semi-colons as shown
+same string as additional expressions separated by semicolons as shown
 in the examples above.
 
 The expression `"200.0*(r-1.5)^2"` represents a harmonic potential

--- a/doc/src/read_dump.rst
+++ b/doc/src/read_dump.rst
@@ -132,7 +132,7 @@ files can be written by LAMMPS via the :doc:`dump dcd <dump>` command.
 The *path* value specifies a list of directories which LAMMPS will
 search for the molfile plugins appropriate to the specified *style*\ .
 The syntax of the *path* value is like other search paths: it can
-contain multiple directories separated by a colon (or semi-colon on
+contain multiple directories separated by a colon (or semicolon on
 windows).  The *path* keyword is optional and defaults to ".",
 i.e. the current directory.
 

--- a/doc/src/special_bonds.rst
+++ b/doc/src/special_bonds.rst
@@ -92,9 +92,24 @@ The Coulomb factors are applied to any Coulomb (charge interaction)
 term that the potential calculates.  The LJ factors are applied to the
 remaining terms that the potential calculates, whether they represent
 LJ interactions or not.  The weighting factors are a scaling
-prefactor on the energy and force between the pair of atoms.  A value
-of 1.0 means include the full interaction; a value of 0.0 means
-exclude it completely.
+prefactor on the energy and force between the pair of atoms.
+
+A value of 1.0 means include the full interaction without flagging the
+pair as a "special pair"; a value of 0.0 means exclude the pair
+completely from the neighbor list, except for pair styles that require a
+:doc:`kspace style <kspace_style>` and pair styles :doc:`amoeba
+<pair_amoeba>`, :doc:`hippo <pair_amoeba>`, :doc:`thole <pair_thole>`,
+:doc:`coul/exclude <pair_coul>`, and pair styles that include
+"coul/dsf" or "coul/wolf".
+
+.. note::
+
+   To include pairs that would otherwise be excluded (so they are
+   included in the neighbor list for certain analysis compute styles),
+   you can use a very small but non-zero value like 1.0e-100 instead of
+   0.0.  Due to using floating-point math, the computed force, energy,
+   and virial contributions from the pairs will be too small to cause
+   differences.
 
 The first of the 3 coefficients (LJ or Coulombic) is the weighting
 factor on 1-2 atom pairs, which are pairs of atoms directly bonded to

--- a/doc/utils/requirements.txt
+++ b/doc/utils/requirements.txt
@@ -2,7 +2,7 @@ Sphinx >= 5.3.0, <7.1.0
 sphinxcontrib-spelling
 sphinxcontrib-jquery
 git+https://github.com/akohlmey/sphinx-fortran@parallel-read
-sphinx_tabs
+git+https://github.com/executablebooks/sphinx-tabs@v3.4.1
 breathe
 Pygments
 six

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -3736,6 +3736,7 @@ Umin
 un
 unary
 uncomment
+uncompress
 uncompute
 underprediction
 undump

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -226,13 +226,3 @@ void CommTiledKokkos::forward_comm_array(int nsize, double **array)
 {
   CommTiled::forward_comm_array(nsize,array);
 }
-
-/* ----------------------------------------------------------------------
-   exchange info provided with all 6 stencil neighbors
-   NOTE: this method is currently not used
-------------------------------------------------------------------------- */
-
-int CommTiledKokkos::exchange_variable(int n, double *inbuf, double *&outbuf)
-{
-  return CommTiled::exchange_variable(n,inbuf,outbuf);
-}

--- a/src/KOKKOS/comm_tiled_kokkos.h
+++ b/src/KOKKOS/comm_tiled_kokkos.h
@@ -46,13 +46,7 @@ class CommTiledKokkos : public CommTiled {
   void reverse_comm(class Dump *) override;    // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;          // forward comm of array
-  int exchange_variable(int, double *, double *&) override;  // exchange on neigh stencil
-
- private:
-
 };
-
 }
-
 #endif
 

--- a/src/KOKKOS/pair_hybrid_overlay_kokkos.cpp
+++ b/src/KOKKOS/pair_hybrid_overlay_kokkos.cpp
@@ -60,7 +60,7 @@ void PairHybridOverlayKokkos::coeff(int narg, char **arg)
   int none = 0;
   if (m == nstyles) {
     if (strcmp(arg[2],"none") == 0) none = 1;
-    else error->all(FLERR,"Pair coeff for hybrid has invalid style");
+    else error->all(FLERR,"Pair coeff for hybrid has invalid style: {}", arg[2]);
   }
 
   // move 1st/2nd args to 2nd/3rd args

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -823,9 +823,9 @@ void Atom::modify_params(int narg, char **arg)
       if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "atom_modify map", error);
       if (domain->box_exist)
         error->all(FLERR,"Atom_modify map command after simulation box is defined");
-      if (strcmp(arg[iarg+1],"array") == 0) map_user = 1;
-      else if (strcmp(arg[iarg+1],"hash") == 0) map_user = 2;
-      else if (strcmp(arg[iarg+1],"yes") == 0) map_user = 3;
+      if (strcmp(arg[iarg+1],"array") == 0) map_user = MAP_ARRAY;
+      else if (strcmp(arg[iarg+1],"hash") == 0) map_user = MAP_HASH;
+      else if (strcmp(arg[iarg+1],"yes") == 0) map_user = MAP_YES;
       else error->all(FLERR,"Illegal atom_modify map command argument {}", arg[iarg+1]);
       map_style = map_user;
       iarg += 2;

--- a/src/comm.h
+++ b/src/comm.h
@@ -100,11 +100,8 @@ class Comm : protected Pointers {
   virtual void reverse_comm(class Dump *) = 0;
 
   // forward comm of an array
-  // exchange of info on neigh stencil
-  // set processor mapping options
 
   virtual void forward_comm_array(int, double **) = 0;
-  virtual int exchange_variable(int, double *, double *&) = 0;
 
   // map a point to a processor, based on current decomposition
 

--- a/src/comm_brick.h
+++ b/src/comm_brick.h
@@ -45,7 +45,6 @@ class CommBrick : public Comm {
   void reverse_comm(class Dump *) override;                 // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;            // forward comm of array
-  int exchange_variable(int, double *, double *&) override;    // exchange on neigh stencil
   void *extract(const char *, int &) override;
   double memory_usage() override;
 

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -1849,17 +1849,6 @@ void CommTiled::forward_comm_array(int nsize, double **array)
 }
 
 /* ----------------------------------------------------------------------
-   exchange info provided with all 6 stencil neighbors
-   NOTE: this method is currently not used
-------------------------------------------------------------------------- */
-
-int CommTiled::exchange_variable(int n, double * /*inbuf*/, double *& /*outbuf*/)
-{
-  int nrecv = n;
-  return nrecv;
-}
-
-/* ----------------------------------------------------------------------
    determine overlap list of Noverlap procs the lo/hi box overlaps
    overlap = non-zero area in common between box and proc sub-domain
    box is owned by me and extends in dim

--- a/src/comm_tiled.h
+++ b/src/comm_tiled.h
@@ -45,7 +45,6 @@ class CommTiled : public Comm {
   void reverse_comm(class Dump *) override;                 // reverse comm from a Dump
 
   void forward_comm_array(int, double **) override;            // forward comm of array
-  int exchange_variable(int, double *, double *&) override;    // exchange on neigh stencil
 
   void coord2proc_setup() override;
   int coord2proc(double *, int &, int &, int &) override;

--- a/src/pair_hybrid_overlay.cpp
+++ b/src/pair_hybrid_overlay.cpp
@@ -60,7 +60,7 @@ void PairHybridOverlay::coeff(int narg, char **arg)
   int none = 0;
   if (m == nstyles) {
     if (strcmp(arg[2],"none") == 0) none = 1;
-    else error->all(FLERR,"Pair coeff for hybrid has invalid style");
+    else error->all(FLERR,"Pair coeff for hybrid has invalid style: {}", arg[2]);
   }
 
   // move 1st/2nd args to 2nd/3rd args

--- a/src/pair_hybrid_scaled.cpp
+++ b/src/pair_hybrid_scaled.cpp
@@ -516,7 +516,7 @@ void PairHybridScaled::coeff(int narg, char **arg)
     if (strcmp(arg[2], "none") == 0)
       none = 1;
     else
-      error->all(FLERR, "Pair coeff for hybrid has invalid style");
+      error->all(FLERR, "Pair coeff for hybrid has invalid style: {}", arg[2]);
   }
 
   // move 1st/2nd args to 2nd/3rd args

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -249,8 +249,8 @@ void Timer::modify_params(int narg, char **arg)
     // format timeout setting
     std::string timeout = "off";
     if (_timeout >= 0) {
-      std::time_t tv = _timeout;
-      timeout = fmt::format("{:%H:%M:%S}", fmt::gmtime(tv));
+      std::tm tv = fmt::gmtime((std::time_t) _timeout);
+      timeout = fmt::format("{:02d}:{:%M:%S}", tv.tm_yday * 24 + tv.tm_hour, tv);
     }
 
     utils::logmesg(lmp, "New timer settings: style={}  mode={}  timeout={}\n", timer_style[_level],

--- a/tools/swig/lammps.i
+++ b/tools/swig/lammps.i
@@ -18,7 +18,9 @@
 %pointer_cast(void *, double *,  void_p_to_double_p);
 %pointer_cast(void *, double **, void_p_to_double_2d_p);
 
+#if !defined(SWIGLUA)
 %cstring_output_maxsize(char *buffer, int buf_size);
+#endif
 
 %{
 


### PR DESCRIPTION
**Summary**

This pull request collects multiple small bug fixes and updates.

**Related Issue(s)**

Addresses issues mentioned in https://matsci.org/t/bug-in-commbrick-exchange-variable-function-causing-loss-of-intermediate-results-in-buf-recv/48419 and https://matsci.org/t/timer-timeout-command-in-lammps/48391

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues

**Implementation Notes**

The following individual changes are included:
- remove potentially buggy and long unused communication API
- fix timer timout output formatting issue outputting only a subset of the remaining time if it was over 24 hours
- small documentation fixes (spelling and clarifications)
- add note about using very small factor to include pairs in neighbor list that would be excluded with 0.0
- make LAMMPS Swig interface file compatible with Swig 4.1
- Bump python version requirement for building the manual to version 3.8
- When setting a custom python version via -D Python_EXECUTABLE also use it when looking for python3, if a python 3 version.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
