### PR TITLE
Change how variables check if computes are current

### DIFF
--- a/doc/src/variable.rst
+++ b/doc/src/variable.rst
@@ -1402,7 +1402,7 @@ commands
 
 .. code-block:: LAMMPS
 
-   # delete_atoms random fraction 0.5 yes all NULL 49839 
+   # delete_atoms random fraction 0.5 yes all NULL 49839
    # run 0
    variable t equal temp    # this thermo keyword invokes a temperature compute
    print "Temperature of system = $t"

--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -294,21 +294,15 @@ int DumpVTK::count()
   }
 
   // invoke Computes for per-atom quantities
-  // only if within a run or minimize
-  // else require that computes are current
-  // this prevents a compute from being invoked by the WriteDump class
+  // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->whichflag == 0) {
-      for (i = 0; i < ncompute; i++)
-        if (compute[i]->invoked_peratom != update->ntimestep)
-          error->all(FLERR,"Compute used in dump between runs is not current");
-    } else {
-      for (i = 0; i < ncompute; i++) {
-        if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
-          compute[i]->compute_peratom();
-          compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;
-        }
+    if (update->first_update == 0)
+      error->all(FLERR,"Dump compute cannot be invoked before first run");
+    for (i = 0; i < ncompute; i++) {
+      if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
+        compute[i]->compute_peratom();
+        compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;
       }
     }
   }

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -556,21 +556,15 @@ int DumpCustom::count()
   }
 
   // invoke Computes for per-atom quantities
-  // only if within a run or minimize
-  // else require that computes are current
-  // this prevents a compute from being invoked by the WriteDump class
+  // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->whichflag == 0) {
-      for (i = 0; i < ncompute; i++)
-        if (compute[i]->invoked_peratom != update->ntimestep)
-          error->all(FLERR,"Compute used in dump between runs is not current");
-    } else {
-      for (i = 0; i < ncompute; i++) {
-        if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
-          compute[i]->compute_peratom();
-          compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;
-        }
+    if (update->first_update == 0)
+      error->all(FLERR,"Dump compute cannot be invoked before first run");
+    for (i = 0; i < ncompute; i++) {
+      if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
+        compute[i]->compute_peratom();
+        compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;
       }
     }
   }

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -522,21 +522,15 @@ int DumpGrid::count()
   }
 
   // invoke Computes for per-grid quantities
-  // only if within a run or minimize
-  // else require that computes are current
-  // this prevents a compute from being invoked by the WriteDump class
+  // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->whichflag == 0) {
-      for (i = 0; i < ncompute; i++)
-        if (compute[i]->invoked_pergrid != update->ntimestep)
-          error->all(FLERR,"Compute {} used in dump between runs is not current", compute[i]->id);
-    } else {
-      for (i = 0; i < ncompute; i++) {
-        if (!(compute[i]->invoked_flag & Compute::INVOKED_PERGRID)) {
-          compute[i]->compute_pergrid();
-          compute[i]->invoked_flag |= Compute::INVOKED_PERGRID;
-        }
+    if (update->first_update == 0)
+      error->all(FLERR,"Dump compute cannot be invoked before first run");
+    for (i = 0; i < ncompute; i++) {
+      if (!(compute[i]->invoked_flag & Compute::INVOKED_PERGRID)) {
+        compute[i]->compute_pergrid();
+        compute[i]->invoked_flag |= Compute::INVOKED_PERGRID;
       }
     }
   }

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -664,20 +664,14 @@ void DumpImage::write()
     }
 
     // invoke Compute for per-grid quantities
-    // only if within a run or minimize
-    // else require the compute is current
-    // this prevents the compute from being invoked by the WriteDump class
+    // cannot invoke before first run, otherwise invoke if necessary
 
     if (grid_compute) {
-      if (update->whichflag == 0) {
-        if (grid_compute->invoked_pergrid != update->ntimestep)
-          error->all(FLERR,"Grid compute {} used in dump image between runs is not current",
-                     grid_compute->id);
-      } else {
-        if (!(grid_compute->invoked_flag & Compute::INVOKED_PERGRID)) {
-          grid_compute->compute_pergrid();
-          grid_compute->invoked_flag |= Compute::INVOKED_PERGRID;
-        }
+      if (update->first_update == 0)
+        error->all(FLERR,"Grid compute used in dump image cannot be invoked before first run");
+      if (!(grid_compute->invoked_flag & Compute::INVOKED_PERGRID)) {
+        grid_compute->compute_pergrid();
+        grid_compute->invoked_flag |= Compute::INVOKED_PERGRID;
       }
     }
 

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -325,21 +325,15 @@ int DumpLocal::count()
   int i;
 
   // invoke Computes for local quantities
-  // only if within a run or minimize
-  // else require that computes are current
-  // this prevents a compute from being invoked by the WriteDump class
+  // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->whichflag == 0) {
-      for (i = 0; i < ncompute; i++)
-        if (compute[i]->invoked_local != update->ntimestep)
-          error->all(FLERR,"Compute used in dump between runs is not current");
-    } else {
-      for (i = 0; i < ncompute; i++) {
-        if (!(compute[i]->invoked_flag & Compute::INVOKED_LOCAL)) {
-          compute[i]->compute_local();
-          compute[i]->invoked_flag |= Compute::INVOKED_LOCAL;
-        }
+    if (update->first_update == 0)
+      error->all(FLERR,"Dump compute cannot be invoked before first run");
+    for (i = 0; i < ncompute; i++) {
+      if (!(compute[i]->invoked_flag & Compute::INVOKED_LOCAL)) {
+        compute[i]->compute_local();
+        compute[i]->invoked_flag |= Compute::INVOKED_LOCAL;
       }
     }
   }

--- a/src/reset_atoms_image.cpp
+++ b/src/reset_atoms_image.cpp
@@ -93,10 +93,11 @@ void ResetAtomsImage::command(int narg, char **arg)
                                    "c_ifmax_r_i_f[*] c_ifmin_r_i_f[*]");
 
   // trigger computes
-  // need to ensure update->first_update = 1, even if prior to first run/minimize
-  //   b/c variables internal to this command are evaulated which invoke computes
-  //   error will be triggered unless first_update = 1
-  //   reset update->first_update when done
+  // need to ensure update->first_update = 1
+  //   to allow this input script command prior to first run/minimize
+  //   this is b/c internal variables are evaulated which invoke computes
+  //   that will trigger an error unless first_update = 1
+  // reset update->first_update when done
   
   int first_update_saved = update->first_update;
   update->first_update = 1;

--- a/src/reset_atoms_image.cpp
+++ b/src/reset_atoms_image.cpp
@@ -22,6 +22,7 @@
 #include "group.h"
 #include "input.h"
 #include "modify.h"
+#include "update.h"
 #include "variable.h"
 
 #include <cmath>
@@ -62,7 +63,10 @@ void ResetAtomsImage::command(int narg, char **arg)
 
   // initialize system since comm->borders() will be invoked
 
+  int old_whichflag = update->whichflag;
+  update->whichflag = 1;
   lmp->init();
+  update->whichflag = old_whichflag;
 
   // setup domain, communication
   // exchange will clear map, borders will reset

--- a/src/reset_atoms_image.cpp
+++ b/src/reset_atoms_image.cpp
@@ -63,10 +63,7 @@ void ResetAtomsImage::command(int narg, char **arg)
 
   // initialize system since comm->borders() will be invoked
 
-  int old_whichflag = update->whichflag;
-  update->whichflag = 1;
   lmp->init();
-  update->whichflag = old_whichflag;
 
   // setup domain, communication
   // exchange will clear map, borders will reset
@@ -96,6 +93,13 @@ void ResetAtomsImage::command(int narg, char **arg)
                                    "c_ifmax_r_i_f[*] c_ifmin_r_i_f[*]");
 
   // trigger computes
+  // need to ensure update->first_update = 1, even if prior to first run/minimize
+  //   b/c variables internal to this command are evaulated which invoke computes
+  //   error will be triggered unless first_update = 1
+  //   reset update->first_update when done
+  
+  int first_update_saved = update->first_update;
+  update->first_update = 1;
 
   frags->compute_peratom();
   chunk->compute_peratom();
@@ -103,6 +107,8 @@ void ResetAtomsImage::command(int narg, char **arg)
   ifmin->compute_array();
   ifmax->compute_array();
   cdist->compute_peratom();
+
+  update->first_update = first_update_saved;
 
   // reset image flags for atoms in group
 

--- a/src/reset_atoms_image.cpp
+++ b/src/reset_atoms_image.cpp
@@ -98,7 +98,7 @@ void ResetAtomsImage::command(int narg, char **arg)
   //   this is b/c internal variables are evaulated which invoke computes
   //   that will trigger an error unless first_update = 1
   // reset update->first_update when done
-  
+
   int first_update_saved = update->first_update;
   update->first_update = 1;
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1440,10 +1440,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
         if (nbracket == 0 && compute->scalar_flag && lowercase) {
 
-          if (update->whichflag == 0) {
-            if (compute->invoked_scalar != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
             compute->compute_scalar();
             compute->invoked_flag |= Compute::INVOKED_SCALAR;
           }
@@ -1463,10 +1462,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (index1 > compute->size_vector &&
               compute->size_vector_variable == 0)
             print_var_error(FLERR,"Variable formula compute vector is accessed out-of-range",ivar,0);
-          if (update->whichflag == 0) {
-            if (compute->invoked_vector != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
             compute->invoked_flag |= Compute::INVOKED_VECTOR;
           }
@@ -1490,10 +1488,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
           if (index2 > compute->size_array_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-          if (update->whichflag == 0) {
-            if (compute->invoked_array != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
             compute->invoked_flag |= Compute::INVOKED_ARRAY;
           }
@@ -1518,10 +1515,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Compute global vector in atom-style variable formula",ivar);
           if (compute->size_vector == 0)
             print_var_error(FLERR,"Variable formula compute vector is zero length",ivar);
-          if (update->whichflag == 0) {
-            if (compute->invoked_vector != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
             compute->invoked_flag |= Compute::INVOKED_VECTOR;
           }
@@ -1543,10 +1539,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Compute global vector in atom-style variable formula",ivar);
           if (compute->size_array_rows == 0)
             print_var_error(FLERR,"Variable formula compute array is zero length",ivar);
-          if (update->whichflag == 0) {
-            if (compute->invoked_array != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
             compute->invoked_flag |= Compute::INVOKED_ARRAY;
           }
@@ -1563,10 +1558,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
         } else if (nbracket == 1 && compute->peratom_flag &&
                    compute->size_peratom_cols == 0) {
 
-          if (update->whichflag == 0) {
-            if (compute->invoked_peratom != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
@@ -1581,10 +1575,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           if (index2 > compute->size_peratom_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-          if (update->whichflag == 0) {
-            if (compute->invoked_peratom != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
@@ -1605,10 +1598,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Per-atom compute in equal-style variable formula",ivar);
           if (treetype == VECTOR)
             print_var_error(FLERR,"Per-atom compute in vector-style variable formula",ivar);
-          if (update->whichflag == 0) {
-            if (compute->invoked_peratom != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
@@ -1630,10 +1622,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Per-atom compute in vector-style variable formula",ivar);
           if (index1 > compute->size_peratom_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-          if (update->whichflag == 0) {
-            if (compute->invoked_peratom != update->ntimestep)
-              print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-          } else if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
+          if (update->first_update == 0)
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
           }
@@ -4050,10 +4041,9 @@ int Variable::special_function(char *word, char *contents, Tree **tree, Tree **t
         print_var_error(FLERR,mesg,ivar);
       }
       if (index == 0 && compute->vector_flag) {
-        if (update->whichflag == 0) {
-          if (compute->invoked_vector != update->ntimestep)
-            print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-        } else if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
+        if (update->first_update == 0)
+          print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+        if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
           compute->invoked_flag |= Compute::INVOKED_VECTOR;
         }
@@ -4062,10 +4052,9 @@ int Variable::special_function(char *word, char *contents, Tree **tree, Tree **t
       } else if (index && compute->array_flag) {
         if (index > compute->size_array_cols)
           print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-        if (update->whichflag == 0) {
-          if (compute->invoked_array != update->ntimestep)
-            print_var_error(FLERR,"Compute used in variable between runs is not current",ivar);
-        } else if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
+        if (update->first_update == 0)
+          print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+        if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
           compute->invoked_flag |= Compute::INVOKED_ARRAY;
         }

--- a/tools/swig/lammps.i
+++ b/tools/swig/lammps.i
@@ -18,7 +18,9 @@
 %pointer_cast(void *, double *,  void_p_to_double_p);
 %pointer_cast(void *, double **, void_p_to_double_2d_p);
 
+#if !defined(SWIGLUA)
 %cstring_output_maxsize(char *buffer, int buf_size);
+#endif
 
 %{
 


### PR DESCRIPTION
**Summary**

The aim of this PR is to eliminate error messages when variables are evaluated saying that a compute "is not current".  It does this by more aggressively evaluating computes when they are needed in between runs.  There are still two cases when a variable evaluation (which requires a compute either directly or indirectly via a thermo keyword) when errors may occur.

(a) evaluating such a variable before the first run - an error is generated
(b) evaluating such a variable between runs, but after also changing the system (after the previous run, but before the variable evaluation), e.g. deleting atoms - the evaluated variable value may be incorrect

Both of these special cases are explained on the variable doc page.  The solution to both is to perfrom a "run 0" command
before evaluating the variable.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

I think the only effect of this should be to not trigger error message that were triggered previously.  The two cases mentioned above (error and incorrect) were also the behavior previously.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


