### PR TITLE
Added mliap data structure for message passing models

### DIFF
--- a/src/KOKKOS/mliap_data_kokkos.cpp
+++ b/src/KOKKOS/mliap_data_kokkos.cpp
@@ -177,7 +177,7 @@ void MLIAPDataKokkos<DeviceType>::generate_neighdata(class NeighList *list_in, i
       const int jelem = map(jtype);
       if (rsq < d_cutsq(itype,jtype)) {
         d_jatoms(ij) = j;
-	d_mapped_jatoms(ij) = tag_map[j];
+        d_mapped_jatoms(ij) = tag_map[j];
         d_pair_i(ij) = i;
         d_jelems(ij) = jelem;
         d_rij(ij, 0) = delx;

--- a/src/KOKKOS/mliap_data_kokkos.cpp
+++ b/src/KOKKOS/mliap_data_kokkos.cpp
@@ -56,7 +56,7 @@ MLIAPDataKokkos<DeviceType>::~MLIAPDataKokkos() {
   memoryKK->destroy_kokkos(k_ielems,ielems);
   memoryKK->destroy_kokkos(k_numneighs,numneighs);
   memoryKK->destroy_kokkos(k_jatoms,jatoms);
-  memoryKK->destroy_kokkos(k_mapped_jatoms,mapped_jatoms);
+  memoryKK->destroy_kokkos(k_jtags,jtags);
   memoryKK->destroy_kokkos(k_pair_i,pair_i);
   memoryKK->destroy_kokkos(k_jelems,jelems);
   memoryKK->destroy_kokkos(k_elems,elems);
@@ -134,7 +134,7 @@ void MLIAPDataKokkos<DeviceType>::generate_neighdata(class NeighList *list_in, i
   auto d_ij = k_ij.template view<DeviceType>();
   auto d_numneighs = k_numneighs.template view<DeviceType>();
   auto d_jatoms = k_jatoms.template view<DeviceType>();
-  auto d_mapped_jatoms = k_mapped_jatoms.template view<DeviceType>();
+  auto d_jtags = k_jtags.template view<DeviceType>();
   auto d_pair_i= k_pair_i.template view<DeviceType>();
   auto d_jelems= k_jelems.template view<DeviceType>();
   auto d_rij= k_rij.template view<DeviceType>();
@@ -177,7 +177,7 @@ void MLIAPDataKokkos<DeviceType>::generate_neighdata(class NeighList *list_in, i
       const int jelem = map(jtype);
       if (rsq < d_cutsq(itype,jtype)) {
         d_jatoms(ij) = j;
-        d_mapped_jatoms(ij) = tag_map[j];
+        d_jtags(ij) = tag_map[j];
         d_pair_i(ij) = i;
         d_jelems(ij) = jelem;
         d_rij(ij, 0) = delx;
@@ -193,7 +193,7 @@ void MLIAPDataKokkos<DeviceType>::generate_neighdata(class NeighList *list_in, i
     const int itype = type(i);
     d_elems(i) = map(itype);
   });
-  modified(execution_space, NUMNEIGHS_MASK | IATOMS_MASK | IELEMS_MASK | ELEMS_MASK | MAPPED_JATOMS_MASK | JATOMS_MASK | PAIR_I_MASK | JELEMS_MASK | RIJ_MASK | IJ_MASK );
+  modified(execution_space, NUMNEIGHS_MASK | IATOMS_MASK | IELEMS_MASK | ELEMS_MASK | JTAGS_MASK | JATOMS_MASK | PAIR_I_MASK | JELEMS_MASK | RIJ_MASK | IJ_MASK );
   eflag = eflag_in;
   vflag = vflag_in;
 }
@@ -257,8 +257,8 @@ void MLIAPDataKokkos<DeviceType>::grow_neigharrays() {
   if (nneigh_max < npairs) {
     memoryKK->destroy_kokkos(k_jatoms,jatoms);
     memoryKK->create_kokkos(k_jatoms, jatoms, npairs, "mliap_data:jatoms");
-    memoryKK->destroy_kokkos(k_mapped_jatoms,mapped_jatoms);
-    memoryKK->create_kokkos(k_mapped_jatoms, mapped_jatoms, npairs, "mliap_data:mapped_jatoms");
+    memoryKK->destroy_kokkos(k_jtags,jtags);
+    memoryKK->create_kokkos(k_jtags, jtags, npairs, "mliap_data:jtags");
     memoryKK->destroy_kokkos(k_pair_i,pair_i);
     memoryKK->create_kokkos(k_pair_i, pair_i, npairs, "mliap_data:pair_i");
     memoryKK->destroy_kokkos(k_jelems,jelems);
@@ -282,7 +282,7 @@ void MLIAPDataKokkos<DeviceType>::modified(ExecutionSpace space, unsigned int ma
     if (mask & IATOMS_MASK      ) k_iatoms         .modify<LMPDeviceType>();
     if (mask & IELEMS_MASK      ) k_ielems         .modify<LMPDeviceType>();
     if (mask & JATOMS_MASK      ) k_jatoms         .modify<LMPDeviceType>();
-    if (mask & MAPPED_JATOMS_MASK      ) k_mapped_jatoms  .modify<LMPDeviceType>();
+    if (mask & JTAGS_MASK      ) k_jtags  .modify<LMPDeviceType>();
     if (mask & PAIR_I_MASK      ) k_pair_i         .modify<LMPDeviceType>();
     if (mask & JELEMS_MASK      ) k_jelems         .modify<LMPDeviceType>();
     if (mask & ELEMS_MASK       ) k_elems          .modify<LMPDeviceType>();
@@ -303,7 +303,7 @@ void MLIAPDataKokkos<DeviceType>::modified(ExecutionSpace space, unsigned int ma
     if (mask & IATOMS_MASK      ) k_iatoms         .modify<LMPHostType>();
     if (mask & IELEMS_MASK      ) k_ielems         .modify<LMPHostType>();
     if (mask & JATOMS_MASK      ) k_jatoms         .modify<LMPHostType>();
-    if (mask & MAPPED_JATOMS_MASK      ) k_mapped_jatoms  .modify<LMPHostType>();
+    if (mask & JTAGS_MASK      ) k_jtags  .modify<LMPHostType>();
     if (mask & PAIR_I_MASK      ) k_pair_i         .modify<LMPHostType>();
     if (mask & JELEMS_MASK      ) k_jelems         .modify<LMPHostType>();
     if (mask & ELEMS_MASK       ) k_elems          .modify<LMPHostType>();
@@ -332,7 +332,7 @@ void MLIAPDataKokkos<DeviceType>::sync(ExecutionSpace space, unsigned int mask, 
     if (mask & IATOMS_MASK      ) k_iatoms         .sync<LMPDeviceType>();
     if (mask & IELEMS_MASK      ) k_ielems         .sync<LMPDeviceType>();
     if (mask & JATOMS_MASK      ) k_jatoms         .sync<LMPDeviceType>();
-    if (mask & MAPPED_JATOMS_MASK      ) k_mapped_jatoms  .sync<LMPDeviceType>();
+    if (mask & JTAGS_MASK      ) k_jtags  .sync<LMPDeviceType>();
     if (mask & PAIR_I_MASK      ) k_pair_i         .sync<LMPDeviceType>();
     if (mask & JELEMS_MASK      ) k_jelems         .sync<LMPDeviceType>();
     if (mask & ELEMS_MASK       ) k_elems          .sync<LMPDeviceType>();
@@ -352,7 +352,7 @@ void MLIAPDataKokkos<DeviceType>::sync(ExecutionSpace space, unsigned int mask, 
     if (mask & IATOMS_MASK      ) k_iatoms         .sync<LMPHostType>();
     if (mask & IELEMS_MASK      ) k_ielems         .sync<LMPHostType>();
     if (mask & JATOMS_MASK      ) k_jatoms         .sync<LMPHostType>();
-    if (mask & MAPPED_JATOMS_MASK      ) k_mapped_jatoms  .sync<LMPHostType>();
+    if (mask & JTAGS_MASK      ) k_jtags  .sync<LMPHostType>();
     if (mask & PAIR_I_MASK      ) k_pair_i         .sync<LMPHostType>();
     if (mask & JELEMS_MASK      ) k_jelems         .sync<LMPHostType>();
     if (mask & ELEMS_MASK       ) k_elems          .sync<LMPHostType>();

--- a/src/KOKKOS/mliap_data_kokkos.h
+++ b/src/KOKKOS/mliap_data_kokkos.h
@@ -28,23 +28,25 @@
 namespace LAMMPS_NS {
 // clang-format off
 enum {
-  IATOMS_MASK      = 0x00000001,
-  IELEMS_MASK      = 0x00000002,
-  JATOMS_MASK      = 0x00000004,
-  JELEMS_MASK      = 0x00000008,
-  IJ_MASK          = 0x00000010,
-  BETAS_MASK       = 0x00000020,
-  DESCRIPTORS_MASK = 0x00000040,
-  EATOMS_MASK      = 0x00000080,
-  RIJ_MASK         = 0x00000100,
-  GRADFORCE_MASK   = 0x00000200,
-  GRADDESC_MASK    = 0x00000400,
-  NUMNEIGHS_MASK   = 0x00000800,
-  GAMMA_MASK_MASK  = 0x00001000,
-  GAMMA_ROW_MASK   = 0x00002000,
-  GAMMA_COL_MASK   = 0x00004000,
-  PAIR_I_MASK      = 0x00008000,
-  ELEMS_MASK       = 0x00010000,
+  IATOMS_MASK        = 0x00000001,
+  IELEMS_MASK        = 0x00000002,
+  JATOMS_MASK        = 0x00000004,
+  JELEMS_MASK        = 0x00000008,
+  IJ_MASK            = 0x00000010,
+  BETAS_MASK         = 0x00000020,
+  DESCRIPTORS_MASK   = 0x00000040,
+  EATOMS_MASK        = 0x00000080,
+  RIJ_MASK           = 0x00000100,
+  GRADFORCE_MASK     = 0x00000200,
+  GRADDESC_MASK      = 0x00000400,
+  NUMNEIGHS_MASK     = 0x00000800,
+  GAMMA_MASK_MASK    = 0x00001000,
+  GAMMA_ROW_MASK     = 0x00002000,
+  GAMMA_COL_MASK     = 0x00004000,
+  PAIR_I_MASK        = 0x00008000,
+  ELEMS_MASK         = 0x00010000,
+  MAPPED_JATOMS_MASK = 0x00010002,
+
 };
 // clang-format on
 
@@ -67,6 +69,7 @@ template <class DeviceType> class MLIAPDataKokkos : public MLIAPData {
   DAT::tdual_int_1d k_iatoms;           // index of each atom
   DAT::tdual_int_1d k_ielems;           // element of each atom
   DAT::tdual_int_1d k_jatoms;           // index of each neighbor
+  DAT::tdual_int_1d k_mapped_jatoms;    // index of each neighbor mapped to simulation cell
   DAT::tdual_int_1d k_elems;            // element of each atom in or not in the neighborlist
   DAT::tdual_int_1d k_pair_i;           // index of each i atom for each ij pair
   DAT::tdual_int_1d k_jelems;           // element of each neighbor
@@ -126,6 +129,7 @@ public:
     nneigh_max(base.nneigh_max),
     npairs(base.npairs),
     jatoms(base.k_jatoms.d_view.data()),
+    mapped_jatoms(base.k_mapped_jatoms.d_view.data()),
     jelems(base.k_jelems.d_view.data()),
     elems(base.k_elems.d_view.data()),
     rij(base.k_rij.d_view.data()),
@@ -179,6 +183,7 @@ public:
   const int nneigh_max;
   const int npairs;
   int *jatoms;
+  int *mapped_jatoms;
   int *jelems;
   int *elems;
   double *rij;

--- a/src/KOKKOS/mliap_data_kokkos.h
+++ b/src/KOKKOS/mliap_data_kokkos.h
@@ -45,7 +45,7 @@ enum {
   GAMMA_COL_MASK     = 0x00004000,
   PAIR_I_MASK        = 0x00008000,
   ELEMS_MASK         = 0x00010000,
-  MAPPED_JATOMS_MASK = 0x00010002,
+  MAPPED_JATOMS_MASK = 0x00020000,
 
 };
 // clang-format on

--- a/src/KOKKOS/mliap_data_kokkos.h
+++ b/src/KOKKOS/mliap_data_kokkos.h
@@ -45,7 +45,7 @@ enum {
   GAMMA_COL_MASK     = 0x00004000,
   PAIR_I_MASK        = 0x00008000,
   ELEMS_MASK         = 0x00010000,
-  MAPPED_JATOMS_MASK = 0x00020000,
+  JTAGS_MASK = 0x00020000,
 
 };
 // clang-format on
@@ -69,7 +69,7 @@ template <class DeviceType> class MLIAPDataKokkos : public MLIAPData {
   DAT::tdual_int_1d k_iatoms;           // index of each atom
   DAT::tdual_int_1d k_ielems;           // element of each atom
   DAT::tdual_int_1d k_jatoms;           // index of each neighbor
-  DAT::tdual_int_1d k_mapped_jatoms;    // index of each neighbor mapped to simulation cell
+  DAT::tdual_int_1d k_jtags;            // tag of each neighbor in the simulation cell
   DAT::tdual_int_1d k_elems;            // element of each atom in or not in the neighborlist
   DAT::tdual_int_1d k_pair_i;           // index of each i atom for each ij pair
   DAT::tdual_int_1d k_jelems;           // element of each neighbor
@@ -129,7 +129,7 @@ public:
     nneigh_max(base.nneigh_max),
     npairs(base.npairs),
     jatoms(base.k_jatoms.d_view.data()),
-    mapped_jatoms(base.k_mapped_jatoms.d_view.data()),
+    jtags(base.k_jtags.d_view.data()),
     jelems(base.k_jelems.d_view.data()),
     elems(base.k_elems.d_view.data()),
     rij(base.k_rij.d_view.data()),
@@ -183,7 +183,7 @@ public:
   const int nneigh_max;
   const int npairs;
   int *jatoms;
-  int *mapped_jatoms;
+  int *jtags;
   int *jelems;
   int *elems;
   double *rij;

--- a/src/KOKKOS/mliap_unified_couple_kokkos.pyx
+++ b/src/KOKKOS/mliap_unified_couple_kokkos.pyx
@@ -67,7 +67,7 @@ cdef extern from "mliap_data_kokkos.h" namespace "LAMMPS_NS":
         int nneigh_max          # number of ij neighbors allocated
         int npairs              # number of ij neighbor pairs
         int * jatoms            # index of each neighbor
-        int * mapped_jatoms     # index of each neighbor mapped to the simulation cell
+        int * jtags             # tag of each neighbor in the simulation cell
         int * jelems            # element of each neighbor
         int * elems             # element of each atom in or not in the neighborlist
         double * rij           # distance vector of each neighbor
@@ -329,10 +329,10 @@ cdef class MLIAPDataPy:
         return self.jatoms
 
     @property
-    def mapped_jatoms(self):
-        if self.data.mapped_jatoms is NULL:
+    def jtags(self):
+        if self.data.jtags is NULL:
             return None
-        return create_array(self.data.dev, self.data.mapped_jatoms, [self.npairs],True)
+        return create_array(self.data.dev, self.data.jtags, [self.npairs],True)
 
 
     @property

--- a/src/KOKKOS/mliap_unified_couple_kokkos.pyx
+++ b/src/KOKKOS/mliap_unified_couple_kokkos.pyx
@@ -67,6 +67,7 @@ cdef extern from "mliap_data_kokkos.h" namespace "LAMMPS_NS":
         int nneigh_max          # number of ij neighbors allocated
         int npairs              # number of ij neighbor pairs
         int * jatoms            # index of each neighbor
+        int * mapped_jatoms     # index of each neighbor mapped to the simulation cell
         int * jelems            # element of each neighbor
         int * elems             # element of each atom in or not in the neighborlist
         double * rij           # distance vector of each neighbor
@@ -326,6 +327,13 @@ cdef class MLIAPDataPy:
     @property
     def pair_j(self):
         return self.jatoms
+
+    @property
+    def mapped_jatoms(self):
+        if self.data.mapped_jatoms is NULL:
+            return None
+        return create_array(self.data.dev, self.data.mapped_jatoms, [self.npairs],True)
+
 
     @property
     def jatoms(self):

--- a/src/ML-IAP/compute_mliap.cpp
+++ b/src/ML-IAP/compute_mliap.cpp
@@ -56,6 +56,7 @@ ComputeMLIAP::ComputeMLIAP(LAMMPS *lmp, int narg, char **arg) :
   // default values
 
   int gradgradflag = 1;
+  int jtagsflag = 0; // default is no tags
 
   // set flags for required keywords
 
@@ -119,7 +120,7 @@ ComputeMLIAP::ComputeMLIAP(LAMMPS *lmp, int narg, char **arg) :
   for (int i = 1; i <= atom->ntypes; i++)
     map[i] = i-1;
 
-  data = new MLIAPData(lmp, gradgradflag, map, model, descriptor);
+  data = new MLIAPData(lmp, gradgradflag, jtagsflag, map, model, descriptor);
 
   size_array_rows = data->size_array_rows;
   size_array_cols = data->size_array_cols;

--- a/src/ML-IAP/mliap_data.cpp
+++ b/src/ML-IAP/mliap_data.cpp
@@ -186,7 +186,7 @@ void MLIAPData::generate_neighdata(NeighList *list_in, int eflag_in, int vflag_i
       if (rsq < descriptor->cutsq[ielem][jelem]) {
         pair_i[ij] = i;
         jatoms[ij] = j;
-	mapped_jatoms[ij] = atom->tag[j];
+        mapped_jatoms[ij] = atom->tag[j];
         jelems[ij] = jelem;
         rij[ij][0] = delx;
         rij[ij][1] = dely;

--- a/src/ML-IAP/mliap_data.cpp
+++ b/src/ML-IAP/mliap_data.cpp
@@ -33,7 +33,7 @@ MLIAPData::MLIAPData(LAMMPS *lmp, int gradgradflag_in, int *map_in, class MLIAPM
     gamma(nullptr), gamma_row_index(nullptr), gamma_col_index(nullptr), egradient(nullptr),
     numneighs(nullptr), iatoms(nullptr), ielems(nullptr), pair_i(nullptr), jatoms(nullptr),
     jelems(nullptr), elems(nullptr), rij(nullptr), graddesc(nullptr), model(nullptr),
-    descriptor(nullptr), list(nullptr)
+    descriptor(nullptr), list(nullptr), mapped_jatoms(nullptr)
 {
   gradgradflag = gradgradflag_in;
   map = map_in;
@@ -86,6 +86,7 @@ MLIAPData::~MLIAPData()
   memory->destroy(ielems);
   memory->destroy(numneighs);
   memory->destroy(jatoms);
+  memory->destroy(mapped_jatoms);
   memory->destroy(jelems);
   memory->destroy(elems);
   memory->destroy(rij);
@@ -185,6 +186,7 @@ void MLIAPData::generate_neighdata(NeighList *list_in, int eflag_in, int vflag_i
       if (rsq < descriptor->cutsq[ielem][jelem]) {
         pair_i[ij] = i;
         jatoms[ij] = j;
+	mapped_jatoms[ij] = atom->tag[j];
         jelems[ij] = jelem;
         rij[ij][0] = delx;
         rij[ij][1] = dely;
@@ -264,6 +266,7 @@ void MLIAPData::grow_neigharrays()
   if (nneigh_max < nneigh) {
     memory->grow(pair_i, nneigh, "MLIAPData:pair_i");
     memory->grow(jatoms, nneigh, "MLIAPData:jatoms");
+    memory->grow(mapped_jatoms, nneigh, "MLIAPData:mapped_jatoms");
     memory->grow(jelems, nneigh, "MLIAPData:jelems");
     memory->grow(rij, nneigh, 3, "MLIAPData:rij");
     if (gradgradflag == 0) memory->grow(graddesc, nneigh, ndescriptors, 3, "MLIAPData:graddesc");
@@ -295,6 +298,7 @@ double MLIAPData::memory_usage()
 
   bytes += (double) nneigh_max * sizeof(int);           // pair_i
   bytes += (double) nneigh_max * sizeof(int);           // jatoms
+  bytes += (double) nneigh_max * sizeof(int);           // mapped_jatoms
   bytes += (double) nneigh_max * sizeof(int);           // jelems
   bytes += (double) nneigh_max * 3 * sizeof(double);    // rij"
 

--- a/src/ML-IAP/mliap_data.cpp
+++ b/src/ML-IAP/mliap_data.cpp
@@ -33,7 +33,7 @@ MLIAPData::MLIAPData(LAMMPS *lmp, int gradgradflag_in, int *map_in, class MLIAPM
     gamma(nullptr), gamma_row_index(nullptr), gamma_col_index(nullptr), egradient(nullptr),
     numneighs(nullptr), iatoms(nullptr), ielems(nullptr), pair_i(nullptr), jatoms(nullptr),
     jelems(nullptr), elems(nullptr), rij(nullptr), graddesc(nullptr), model(nullptr),
-    descriptor(nullptr), list(nullptr), mapped_jatoms(nullptr)
+    descriptor(nullptr), list(nullptr), jtags(nullptr)
 {
   gradgradflag = gradgradflag_in;
   map = map_in;
@@ -86,7 +86,7 @@ MLIAPData::~MLIAPData()
   memory->destroy(ielems);
   memory->destroy(numneighs);
   memory->destroy(jatoms);
-  memory->destroy(mapped_jatoms);
+  memory->destroy(jtags);
   memory->destroy(jelems);
   memory->destroy(elems);
   memory->destroy(rij);
@@ -186,7 +186,7 @@ void MLIAPData::generate_neighdata(NeighList *list_in, int eflag_in, int vflag_i
       if (rsq < descriptor->cutsq[ielem][jelem]) {
         pair_i[ij] = i;
         jatoms[ij] = j;
-        mapped_jatoms[ij] = atom->tag[j];
+        jtags[ij] = atom->tag[j];
         jelems[ij] = jelem;
         rij[ij][0] = delx;
         rij[ij][1] = dely;
@@ -266,7 +266,7 @@ void MLIAPData::grow_neigharrays()
   if (nneigh_max < nneigh) {
     memory->grow(pair_i, nneigh, "MLIAPData:pair_i");
     memory->grow(jatoms, nneigh, "MLIAPData:jatoms");
-    memory->grow(mapped_jatoms, nneigh, "MLIAPData:mapped_jatoms");
+    memory->grow(jtags, nneigh, "MLIAPData:jtags");
     memory->grow(jelems, nneigh, "MLIAPData:jelems");
     memory->grow(rij, nneigh, 3, "MLIAPData:rij");
     if (gradgradflag == 0) memory->grow(graddesc, nneigh, ndescriptors, 3, "MLIAPData:graddesc");
@@ -298,7 +298,7 @@ double MLIAPData::memory_usage()
 
   bytes += (double) nneigh_max * sizeof(int);           // pair_i
   bytes += (double) nneigh_max * sizeof(int);           // jatoms
-  bytes += (double) nneigh_max * sizeof(int);           // mapped_jatoms
+  bytes += (double) nneigh_max * sizeof(int);           // jtags
   bytes += (double) nneigh_max * sizeof(int);           // jelems
   bytes += (double) nneigh_max * 3 * sizeof(double);    // rij"
 

--- a/src/ML-IAP/mliap_data.h
+++ b/src/ML-IAP/mliap_data.h
@@ -70,7 +70,7 @@ class MLIAPData : protected Pointers {
   int npairs;                    // number of ij neighbor pairs
   int *pair_i;                   // index of each i atom for each ij pair
   int *jatoms;                   // index of each neighbor
-  int *mapped_jatoms;            // index of each neighbor mapped to simulation cell
+  int *jtags;                    // tag of each neighbor in the simulation cell
   int *jelems;                   // element of each neighbor
   int *elems;                    // element of each atom in or not in the neighborlist
   double **rij;                  // distance vector of each neighbor

--- a/src/ML-IAP/mliap_data.h
+++ b/src/ML-IAP/mliap_data.h
@@ -70,6 +70,7 @@ class MLIAPData : protected Pointers {
   int npairs;                    // number of ij neighbor pairs
   int *pair_i;                   // index of each i atom for each ij pair
   int *jatoms;                   // index of each neighbor
+  int *mapped_jatoms;            // index of each neighbor mapped to simulation cell
   int *jelems;                   // element of each neighbor
   int *elems;                    // element of each atom in or not in the neighborlist
   double **rij;                  // distance vector of each neighbor

--- a/src/ML-IAP/mliap_data.h
+++ b/src/ML-IAP/mliap_data.h
@@ -21,7 +21,8 @@ namespace LAMMPS_NS {
 class MLIAPData : protected Pointers {
 
  public:
-  MLIAPData(class LAMMPS *, int, int *, class MLIAPModel *, class MLIAPDescriptor *,
+  MLIAPData(class LAMMPS *, int, int, int *,
+	    class MLIAPModel *, class MLIAPDescriptor *,
             class PairMLIAP * = nullptr);
   ~MLIAPData() override;
 
@@ -45,6 +46,7 @@ class MLIAPData : protected Pointers {
   int nparams;             // number of model parameters per element
   int nelements;           // number of elements
   int gradgradflag;        // 1 for graddesc, 0 for gamma, -1 for pair style
+  int jtagsflag;           // 0 for no jtags array, 1 for jtags array
 
   // data structures for grad-grad list (gamma)
 

--- a/src/ML-IAP/mliap_unified_couple.pyx
+++ b/src/ML-IAP/mliap_unified_couple.pyx
@@ -62,6 +62,7 @@ cdef extern from "mliap_data.h" namespace "LAMMPS_NS":
         int nneigh_max          # number of ij neighbors allocated
         int npairs              # number of ij neighbor pairs
         int * jatoms            # index of each neighbor
+        int * mapped_jatoms     # index of each neighbor mapped to simulation cell
         int * jelems            # element of each neighbor
         int * elems             # element of each atom in or not in the neighborlist
         double ** rij           # distance vector of each neighbor
@@ -262,6 +263,12 @@ cdef class MLIAPDataPy:
     @property
     def pair_j(self):
         return self.jatoms
+
+    @property
+    def mapped_jatoms(self):
+        if self.data.mapped_jatoms is NULL:
+            return None
+        return np.asarray(<int[:self.npairs]> &self.data.mapped_jatoms[0])
 
     @property
     def jatoms(self):

--- a/src/ML-IAP/mliap_unified_couple.pyx
+++ b/src/ML-IAP/mliap_unified_couple.pyx
@@ -62,7 +62,7 @@ cdef extern from "mliap_data.h" namespace "LAMMPS_NS":
         int nneigh_max          # number of ij neighbors allocated
         int npairs              # number of ij neighbor pairs
         int * jatoms            # index of each neighbor
-        int * mapped_jatoms     # index of each neighbor mapped to simulation cell
+        int * jtags             # tag of each neighbor in the simulation cell
         int * jelems            # element of each neighbor
         int * elems             # element of each atom in or not in the neighborlist
         double ** rij           # distance vector of each neighbor
@@ -265,10 +265,10 @@ cdef class MLIAPDataPy:
         return self.jatoms
 
     @property
-    def mapped_jatoms(self):
-        if self.data.mapped_jatoms is NULL:
+    def jtags(self):
+        if self.data.jtags is NULL:
             return None
-        return np.asarray(<int[:self.npairs]> &self.data.mapped_jatoms[0])
+        return np.asarray(<int[:self.npairs]> &self.data.jtags[0])
 
     @property
     def jatoms(self):

--- a/src/ML-IAP/pair_mliap.cpp
+++ b/src/ML-IAP/pair_mliap.cpp
@@ -261,8 +261,9 @@ void PairMLIAP::coeff(int narg, char **arg)
   model->init();
   descriptor->init();
   constexpr int gradgradflag = -1;
+  constexpr int jtagsflag = 0; // default is no tags
   delete data;
-  data = new MLIAPData(lmp, gradgradflag, map, model, descriptor, this);
+  data = new MLIAPData(lmp, gradgradflag, jtagsflag, map, model, descriptor, this);
   data->init();
 }
 


### PR DESCRIPTION
**Summary**
Modified unified ML-IAP and KOKKOS mliap to include a data structure that stores global tags of neighbors

**Related Issue(s)**
None

**Author(s)**
Dylan Anstine, Carnegie Mellon University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

The included data structures "mapped_jatoms" and "k_mapped_jatoms" are similar to "jatoms" and "k_jatoms", but their contents point to the indices of the real atoms in the simulation cell and not the ghost atom indices.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


