### PR TITLE
Bugfix fix_efield.cpp for atom-style energy

### DIFF
--- a/src/fix_efield.cpp
+++ b/src/fix_efield.cpp
@@ -395,7 +395,7 @@ void FixEfield::post_force(int vflag)
           }
           f[i][2] += fz;
           fsum[3] += fz;
-          if (estyle == ATOM) fsum[0] += efield[0][3];
+          if (estyle == ATOM) fsum[0] += efield[i][3];
         }
     }
 


### PR DESCRIPTION
**Summary**

Fixes a very old bug in using atom-style energies with `fix efield`.

**Author(s)**

Shern Tee, UQ

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Changes energy outputs with `fix efield` with `fix_modify [efield] energy yes`, to the correct values.

**Implementation Notes**

Verify correctness with the following script: (Both thermo PE values should be identical, but this is not the case with current LAMMPS).

```
units real
atom_style charge
atom_modify map yes
region mybox block 0 30 0 30 0 30
create_box 1 mybox
pair_style coul/cut 20
pair_coeff * *
mass 1 1
create_atoms 1 single 1 1 1
create_atoms 1 single 1 1 5
set atom 1 charge 1
set atom 2 charge -1
variable fz1 equal fz[1]
variable fz2 equal fz[2]
thermo_style custom pe v_fz1 v_fz2
variable z equal 24 # adjust to different values for fun and profit
# automatically calculated energy
fix efield all efield 0 0 $z
fix_modify efield energy yes
run 0 post no
unfix efield
# manually specified energy
variable q atom q
variable eng atom -v_q*z*v_z*23.060549 # convert eV to kcal/mol
fix efield all efield 0 0 v_z energy v_eng
fix_modify efield energy yes
run 0 post no
```



