### PR TITLE
Enable `fix qeq/reaxff` with variable `fix efield` 

### DIFF
--- a/doc/src/fix_efield.rst
+++ b/doc/src/fix_efield.rst
@@ -136,10 +136,10 @@ due to the electric field were a spring-like F = kx, then the energy
 formula should be E = -0.5kx\^2.  If you don't do this correctly, the
 minimization will not converge properly.
 
-The *potential* keyword can be used as an alternative to the *energy*
-keyword to specify the name of an atom-style variable, which is used to compute
-the added electric potential to each atom as a function of its position.
-The variable should have units of electric field times distance (that is,
+The *potential* keyword can be used as an alternative to the *energy* keyword
+to specify the name of an atom-style variable, which is used to compute the
+added electric potential to each atom as a function of its position.  The
+variable should have units of electric field multiplied by distance (that is,
 in `units real`, the potential should be in volts). As with the *energy*
 keyword, the variable name is specified as "v_name". The energy added by this
 fix is then calculated as the electric potential multiplied by charge.
@@ -149,7 +149,7 @@ in simulations with :doc:`fix qeq/reaxff<fix_qeq_reaxff>`, since with variable
 charges the electric potential can be known beforehand but the energy cannot.
 A small additional benefit is that the *energy* keyword requires an additional
 conversion to energy units which the *potential* keyword avoids. Thus, when the
-*potential* keyword is specified the *energy* keyword is ignored (the simulation
+*potential* keyword is specified, the *energy* keyword is ignored (the simulation
 will proceed but with a warning issued). As with *energy*, the *potential*
 keyword is not allowed if the added field is a constant vector.
 

--- a/doc/src/fix_efield.rst
+++ b/doc/src/fix_efield.rst
@@ -19,7 +19,7 @@ Syntax
 * ex,ey,ez = E-field component values (electric field units)
 * any of ex,ey,ez can be a variable (see below)
 * zero or more keyword/value pairs may be appended to args
-* keyword = *region* or *energy*
+* keyword = *region* or *energy* or *potential*
 
   .. parsed-literal::
 
@@ -27,6 +27,8 @@ Syntax
          region-ID = ID of region atoms must be in to have added force
        *energy* value = v_name
          v_name = variable with name that calculates the potential energy of each atom in the added E-field
+       *potential* value = v_name
+         v_name = variable with name that calculates the electric potential of each atom in the added E-field (overrides *energy*)
 
 Examples
 """"""""
@@ -112,7 +114,8 @@ one or more variables, and if you are performing dynamics via the
 :doc:`run <run>` command.  If the keyword is not used, LAMMPS will set
 the energy to 0.0, which is typically fine for dynamics.
 
-The *energy* keyword is required if the added force is defined with
+The *energy* keyword (or *potential* keyword, described below)
+is required if the added force is defined with
 one or more variables, and you are performing energy minimization via
 the "minimize" command for charged particles.  It is not required for
 point-dipoles, but a warning is issued since the minimizer in LAMMPS
@@ -122,7 +125,7 @@ minimize the orientation of dipoles in an applied electric field.
 The *energy* keyword specifies the name of an atom-style
 :doc:`variable <variable>` which is used to compute the energy of each
 atom as function of its position.  Like variables used for *ex*,
-*ey*, *ez*, the energy variable is specified as v_name, where name
+*ey*, *ez*, the energy variable is specified as "v_name", where "name"
 is the variable name.
 
 Note that when the *energy* keyword is used during an energy
@@ -132,6 +135,23 @@ variable formulas, i.e. that -Grad(E) = F.  For example, if the force
 due to the electric field were a spring-like F = kx, then the energy
 formula should be E = -0.5kx\^2.  If you don't do this correctly, the
 minimization will not converge properly.
+
+The *potential* keyword can be used as an alternative to the *energy*
+keyword to specify the name of an atom-style variable, which is used to compute
+the added electric potential to each atom as a function of its position.
+The variable should have units of electric field times distance (that is,
+in `units real`, the potential should be in volts). As with the *energy*
+keyword, the variable name is specified as "v_name". The energy added by this
+fix is then calculated as the electric potential multiplied by charge.
+
+The *potential* keyword is mainly intended for correct charge equilibration
+in simulations with :doc:`fix qeq/reaxff<fix_qeq_reaxff>`, since with variable
+charges the electric potential can be known beforehand but the energy cannot.
+A small additional benefit is that the *energy* keyword requires an additional
+conversion to energy units which the *potential* keyword avoids. Thus, when the
+*potential* keyword is specified the *energy* keyword is ignored (the simulation
+will proceed but with a warning issued). As with *energy*, the *potential*
+keyword is not allowed if the added field is a constant vector.
 
 ----------
 

--- a/doc/src/fix_efield.rst
+++ b/doc/src/fix_efield.rst
@@ -28,7 +28,7 @@ Syntax
        *energy* value = v_name
          v_name = variable with name that calculates the potential energy of each atom in the added E-field
        *potential* value = v_name
-         v_name = variable with name that calculates the electric potential of each atom in the added E-field (overrides *energy*)
+         v_name = variable with name that calculates the electric potential of each atom in the added E-field
 
 Examples
 """"""""
@@ -136,6 +136,8 @@ due to the electric field were a spring-like F = kx, then the energy
 formula should be E = -0.5kx\^2.  If you don't do this correctly, the
 minimization will not converge properly.
 
+.. versionadded:: TBD
+
 The *potential* keyword can be used as an alternative to the *energy* keyword
 to specify the name of an atom-style variable, which is used to compute the
 added electric potential to each atom as a function of its position.  The
@@ -144,14 +146,16 @@ in `units real`, the potential should be in volts). As with the *energy*
 keyword, the variable name is specified as "v_name". The energy added by this
 fix is then calculated as the electric potential multiplied by charge.
 
-The *potential* keyword is mainly intended for correct charge equilibration
-in simulations with :doc:`fix qeq/reaxff<fix_qeq_reaxff>`, since with variable
-charges the electric potential can be known beforehand but the energy cannot.
-A small additional benefit is that the *energy* keyword requires an additional
-conversion to energy units which the *potential* keyword avoids. Thus, when the
-*potential* keyword is specified, the *energy* keyword is ignored (the simulation
-will proceed but with a warning issued). As with *energy*, the *potential*
-keyword is not allowed if the added field is a constant vector.
+The *potential* keyword is mainly intended for correct charge
+equilibration in simulations with :doc:`fix qeq/reaxff<fix_qeq_reaxff>`,
+since with variable charges the electric potential can be known
+beforehand but the energy cannot.  A small additional benefit is that
+the *energy* keyword requires an additional conversion to energy units
+which the *potential* keyword avoids.  Thus, when the *potential*
+keyword is specified, the *energy* keyword must not be used.  As with
+*energy*, the *potential* keyword is not allowed if the added field is a
+constant vector.  The *potential* keyword is not supported by *fix
+efield/tip4p*.
 
 ----------
 

--- a/doc/src/fix_qeq_reaxff.rst
+++ b/doc/src/fix_qeq_reaxff.rst
@@ -128,9 +128,13 @@ periodic cell dimensions less than 10 Angstroms.
 
 This fix may be used in combination with :doc:`fix efield <fix_efield>`
 and will apply the external electric field during charge equilibration,
-but there may be only one fix efield instance used, it may only use a
-constant electric field, and the electric field vector may only have
-components in non-periodic directions.
+but there may be only one fix efield instance used and the electric field
+vector may only have components in non-periodic directions. Equal-style
+variables can be used for electric field vector components without any further
+settings. Atom-style variables can be used for spatially-varying electric field
+vector components, but the resulting electric potential must be specified
+as an atom-style variable using the (new) *potential* keyword for 
+`fix efield`.
 
 Related commands
 """"""""""""""""

--- a/doc/src/fix_qeq_reaxff.rst
+++ b/doc/src/fix_qeq_reaxff.rst
@@ -133,8 +133,7 @@ vector may only have components in non-periodic directions. Equal-style
 variables can be used for electric field vector components without any further
 settings. Atom-style variables can be used for spatially-varying electric field
 vector components, but the resulting electric potential must be specified
-as an atom-style variable using the (new) *potential* keyword for 
-`fix efield`.
+as an atom-style variable using the *potential* keyword for `fix efield`.
 
 Related commands
 """"""""""""""""

--- a/src/EXTRA-FIX/fix_efield_tip4p.cpp
+++ b/src/EXTRA-FIX/fix_efield_tip4p.cpp
@@ -47,6 +47,7 @@ void FixEfieldTIP4P::init()
   if (atom->tag_enable == 0) error->all(FLERR, "Fix efield/tip4p requires atom IDs");
   if (!atom->q_flag) error->all(FLERR, "Fix efield/tip4p requires atom attribute q");
   if (!force->pair) error->all(FLERR, "A TIP4P pair style must be defined fix efield/tip4p");
+  if (pstr) error->all(FLERR, "Fix efield/tip4p does not support the potential keyword");
 
   int itmp;
   double *p_qdist = (double *) force->pair->extract("qdist", itmp);

--- a/src/REAXFF/fix_qeq_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_reaxff.cpp
@@ -408,6 +408,11 @@ void FixQEqReaxFF::init()
     if (efield->varflag == FixEfield::ATOM && efield->pstyle != FixEfield::ATOM)
       error->all(FLERR,"Atom-style external electric field requires atom-style "
                        "potential variable when used with fix {}", style);
+    if (((efield->xstyle != FixEfield::CONSTANT) && domain->xperiodic) ||
+         ((efield->ystyle != FixEfield::CONSTANT) && domain->yperiodic) ||
+         ((efield->zstyle != FixEfield::CONSTANT) && domain->zperiodic))
+      error->all(FLERR,"Must not have electric field component in direction of periodic "
+                       "boundary when using charge equilibration with ReaxFF.");
     if (((fabs(efield->ex) > SMALL) && domain->xperiodic) ||
          ((fabs(efield->ey) > SMALL) && domain->yperiodic) ||
          ((fabs(efield->ez) > SMALL) && domain->zperiodic))

--- a/src/REAXFF/fix_qeq_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_reaxff.cpp
@@ -1111,9 +1111,8 @@ void FixQEqReaxFF::get_chi_field()
   const double factor = -1.0/qe2f;
 
 
-  if (efield->varflag != FixEfield::CONSTANT) {
+  if (efield->varflag != FixEfield::CONSTANT)
     efield->update_efield_variables();
-  }
 
   // atom selection is for the group of fix efield
 

--- a/src/fix_efield.cpp
+++ b/src/fix_efield.cpp
@@ -238,8 +238,10 @@ void FixEfield::init()
 
   if (varflag == CONSTANT && estyle != NONE)
     error->all(FLERR, "Cannot use variable energy with constant efield in fix {}", style);
-  if ((varflag == EQUAL || varflag == ATOM) && update->whichflag == 2 && estyle == NONE)
-    error->all(FLERR, "Must use variable energy with fix {}", style);
+  if (varflag == CONSTANT && pstyle != NONE)
+    error->all(FLERR, "Cannot use variable potential with constant efield in fix {}", style);
+  if ((varflag == EQUAL || varflag == ATOM) && update->whichflag == 2 && estyle == NONE && pstyle == NONE)
+    error->all(FLERR, "Must use variable energy or potential with fix {} during minimization", style);
 
   if (utils::strmatch(update->integrate_style, "^respa")) {
     ilevel_respa = (dynamic_cast<Respa *>(update->integrate))->nlevels - 1;

--- a/src/fix_efield.cpp
+++ b/src/fix_efield.cpp
@@ -346,26 +346,7 @@ void FixEfield::post_force(int vflag)
 
   } else {
 
-    modify->clearstep_compute();
-
-    if (xstyle == EQUAL) {
-      ex = qe2f * input->variable->compute_equal(xvar);
-    } else if (xstyle == ATOM) {
-      input->variable->compute_atom(xvar, igroup, &efield[0][0], 4, 0);
-    }
-    if (ystyle == EQUAL) {
-      ey = qe2f * input->variable->compute_equal(yvar);
-    } else if (ystyle == ATOM) {
-      input->variable->compute_atom(yvar, igroup, &efield[0][1], 4, 0);
-    }
-    if (zstyle == EQUAL) {
-      ez = qe2f * input->variable->compute_equal(zvar);
-    } else if (zstyle == ATOM) {
-      input->variable->compute_atom(zvar, igroup, &efield[0][2], 4, 0);
-    }
-    if (estyle == ATOM) input->variable->compute_atom(evar, igroup, &efield[0][3], 4, 0);
-
-    modify->addstep_compute(update->ntimestep + 1);
+    update_efield_variables();
 
     // charge interactions
     // force = qE
@@ -469,4 +450,33 @@ double FixEfield::compute_vector(int n)
     force_flag = 1;
   }
   return fsum_all[n + 1];
+}
+
+/* ----------------------------------------------------------------------
+   update efield variables without doing anything else
+   called by fix_qeq_reaxff
+------------------------------------------------------------------------- */
+
+void FixEfield::update_efield_variables()
+{
+  modify->clearstep_compute();
+
+  if (xstyle == EQUAL) {
+    ex = qe2f * input->variable->compute_equal(xvar);
+  } else if (xstyle == ATOM) {
+    input->variable->compute_atom(xvar, igroup, &efield[0][0], 4, 0);
+  }
+  if (ystyle == EQUAL) {
+    ey = qe2f * input->variable->compute_equal(yvar);
+  } else if (ystyle == ATOM) {
+    input->variable->compute_atom(yvar, igroup, &efield[0][1], 4, 0);
+  }
+  if (zstyle == EQUAL) {
+    ez = qe2f * input->variable->compute_equal(zvar);
+  } else if (zstyle == ATOM) {
+    input->variable->compute_atom(zvar, igroup, &efield[0][2], 4, 0);
+  }
+  if (estyle == ATOM) input->variable->compute_atom(evar, igroup, &efield[0][3], 4, 0);
+
+  modify->addstep_compute(update->ntimestep + 1);
 }

--- a/src/fix_efield.h
+++ b/src/fix_efield.h
@@ -46,10 +46,11 @@ class FixEfield : public Fix {
  protected:
   double ex, ey, ez;
   int varflag;
-  char *xstr, *ystr, *zstr, *estr;
+  char *xstr, *ystr, *zstr, *estr, *pstr;
   char *idregion;
   class Region *region;
-  int xvar, yvar, zvar, evar, xstyle, ystyle, zstyle, estyle;
+  int xvar, yvar, zvar, xstyle, ystyle, zstyle;
+  int evar, pvar, estyle, pstyle;
   int ilevel_respa;
   double qe2f;
   int qflag, muflag;

--- a/src/fix_efield.h
+++ b/src/fix_efield.h
@@ -59,6 +59,7 @@ class FixEfield : public Fix {
 
   int force_flag;
   double fsum[4], fsum_all[4];
+  void update_efield_variables();
 };
 }    // namespace LAMMPS_NS
 #endif


### PR DESCRIPTION
**Summary**

Allows `fix qeq/reaxff` to be used with `fix efield` when the latter has equal- or atom-style variable fields; implements a `potential` keyword for `fix efield` to specify the atomwise electric potential instead of electric potential energy.

**Author(s)**

Shern Tee, University of Queensland

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues expected (only new keywords and functionalities implemented)

**Implementation Notes**

Correctness of `potential` keyword checked by comparing constant, equal-style, and atom-style `efield`s in a modified version of script from #3780 ; correctness of `fix qeq/reaxff` with variable `efield`s checked by modifying `examples/qeq/in.qeq.reaxc` to be non-periodic in `z` and then comparing the output for 10 steps using constant, equal-style, and atom-style `fix efield`.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.