### PR TITLE
fix deposit: per atom property bug

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -2130,15 +2130,15 @@ void Atom::add_molecule_atom(Molecule *onemol, int iatom, int ilocal, tagint off
   // initialize custom per-atom properties to zero if present
 
   for (int i = 0; i < nivector; ++i)
-    if (ivname[i] != nullptr) ivector[i][ilocal] = 0;
+    if (ivname[i]) ivector[i][ilocal] = 0;
   for (int i = 0; i < ndvector; ++i)
-    if (dvname[i] != nullptr) dvector[i][ilocal] = 0.0;
+    if (dvname[i]) dvector[i][ilocal] = 0.0;
   for (int i = 0; i < niarray; ++i)
-    if (ianame[i] != nullptr)
+    if (ianame[i])
       for (int j = 0; j < icols[i]; ++j)
         iarray[i][ilocal][j] = 0;
   for (int i = 0; i < ndarray; ++i)
-    if (daname[i] != nullptr)
+    if (daname[i])
       for (int j = 0; j < dcols[i]; ++j)
         darray[i][ilocal][j] = 0.0;
 

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -2131,13 +2131,16 @@ void Atom::add_molecule_atom(Molecule *onemol, int iatom, int ilocal, tagint off
 
   for (int i = 0; i < nivector; ++i)
     if (ivname[i] != nullptr) ivector[i][ilocal] = 0;
-  for (int i = 0; i < ndvector; ++i) dvector[i][ilocal] = 0.0;
+  for (int i = 0; i < ndvector; ++i)
+    if (dvname[i] != nullptr) dvector[i][ilocal] = 0.0;
   for (int i = 0; i < niarray; ++i)
-    for (int j = 0; j < icols[i]; ++j)
-      iarray[i][ilocal][j] = 0;
+    if (ianame[i] != nullptr)
+      for (int j = 0; j < icols[i]; ++j)
+        iarray[i][ilocal][j] = 0;
   for (int i = 0; i < ndarray; ++i)
-    for (int j = 0; j < dcols[i]; ++j)
-      darray[i][ilocal][j] = 0.0;
+    if (daname[i] != nullptr)
+      for (int j = 0; j < dcols[i]; ++j)
+        darray[i][ilocal][j] = 0.0;
 
   if (molecular != Atom::MOLECULAR) return;
 

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -2129,7 +2129,8 @@ void Atom::add_molecule_atom(Molecule *onemol, int iatom, int ilocal, tagint off
 
   // initialize custom per-atom properties to zero if present
 
-  for (int i = 0; i < nivector; ++i) ivector[i][ilocal] = 0;
+  for (int i = 0; i < nivector; ++i)
+    if (ivname[i] != nullptr) ivector[i][ilocal] = 0;
   for (int i = 0; i < ndvector; ++i) dvector[i][ilocal] = 0.0;
   for (int i = 0; i < niarray; ++i)
     for (int j = 0; j < icols[i]; ++j)


### PR DESCRIPTION
**Summary**

previously, fix deposit tried to initialize per-atom properties that had been deleted 

**Related Issue(s)**

closes #3798

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


