### PR TITLE
fix bug in the reaxff HNS benchmark

### DIFF
--- a/examples/reaxff/HNS/in.reaxc.hns
+++ b/examples/reaxff/HNS/in.reaxc.hns
@@ -37,4 +37,4 @@ velocity          all create 300.0 41279 loop geom
 fix               1 all nve
 fix               2 all qeq/reax 1 0.0 10.0 1e-6 reax/c
 
-run               100
+run               $t


### PR DESCRIPTION
**Summary**

A bug in the input file for the reaxff HNS benchmark is fixed.

**Related Issue(s)**

No

**Author(s)**

Dr. Xin Wu
E-Mail: xin.wu@uni-paderborn.de
Paderborn University, Paderborn Center for Parallel Computing

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

**Implementation Notes**

The variable `t` is set in the input file, but never used in the `run` command.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [x] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**

no further information

