### PR TITLE
Bugfix for body rounded polyhedron and polygon pair styles for non-lj units

### DIFF
--- a/src/BODY/fix_wall_body_polygon.cpp
+++ b/src/BODY/fix_wall_body_polygon.cpp
@@ -44,7 +44,7 @@ enum {FAR=0,XLO,XHI,YLO,YHI};
 
 //#define _POLYGON_DEBUG
 #define DELTA 10000
-#define EPSILON 1e-2
+#define EPSILON 1e-2    // dimensionless threshold (dot products, end point checks, contact checks)
 #define BIG 1.0e20
 #define MAX_CONTACTS 4  // maximum number of contacts for 2D models
 #define EFF_CONTACTS 2  // effective contacts for 2D models

--- a/src/BODY/fix_wall_body_polyhedron.cpp
+++ b/src/BODY/fix_wall_body_polyhedron.cpp
@@ -42,7 +42,7 @@ enum {FAR=0,XLO,XHI,YLO,YHI,ZLO,ZHI};
 
 //#define _POLYHEDRON_DEBUG
 #define DELTA 10000
-#define EPSILON 1e-2
+#define EPSILON 1e-3    // dimensionless threshold (dot products, end point checks)
 #define BIG 1.0e20
 #define MAX_CONTACTS 4  // maximum number of contacts for 2D models
 #define EFF_CONTACTS 2  // effective contacts for 2D models

--- a/src/BODY/pair_body_rounded_polyhedron.cpp
+++ b/src/BODY/pair_body_rounded_polyhedron.cpp
@@ -44,7 +44,7 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 #define DELTA 10000
-#define EPSILON 1e-3
+#define EPSILON 1e-3     // dimensionless threshold (dot products, end point checks, contact checks)
 #define MAX_FACE_SIZE 4  // maximum number of vertices per face (same as BodyRoundedPolyhedron)
 #define MAX_CONTACTS 32  // for 3D models (including duplicated counts)
 
@@ -1186,7 +1186,13 @@ int PairBodyRoundedPolyhedron::interaction_edge_to_edge(int ibody,
 
   // singularity case, ignore interactions
 
-  if (r < EPSILON) return interact;
+  double rmin = MIN(rounded_radius_i, rounded_radius_j);
+  if (r < EPSILON*rmin) {
+    #ifdef _POLYHEDRON_DEBUG
+    printf("ignore interaction: r = %0.16f\n", r);
+    #endif
+    return interact;
+  }
 
   // include the vertices for interactions
 
@@ -1898,10 +1904,12 @@ void PairBodyRoundedPolyhedron::inside_polygon(int ibody, int face_index,
 
 {
   int i,n,ifirst,iffirst,npi1,npi2;
-  double xi1[3],xi2[3],u[3],v[3],costheta,anglesum1,anglesum2,magu,magv;
+  double xi1[3],xi2[3],u[3],v[3],costheta,anglesum1,anglesum2,magu,magv,rradi;
 
   ifirst = dfirst[ibody];
   iffirst = facfirst[ibody];
+  rradi = rounded_radius[ibody];
+  double rradsq = rradi*rradi;
   anglesum1 = anglesum2 = 0;;
   for (i = 0; i < MAX_FACE_SIZE; i++) {
     npi1 = static_cast<int>(face[iffirst+face_index][i]);
@@ -1929,7 +1937,7 @@ void PairBodyRoundedPolyhedron::inside_polygon(int ibody, int face_index,
 
     // the point is at either vertices
 
-    if (magu * magv < EPSILON) inside1 = 1;
+    if (magu * magv < EPSILON*rradsq) inside1 = 1;
     else {
       costheta = MathExtra::dot3(u,v)/(magu*magv);
       anglesum1 += acos(costheta);
@@ -1940,7 +1948,7 @@ void PairBodyRoundedPolyhedron::inside_polygon(int ibody, int face_index,
       MathExtra::sub3(xi2,q2,v);
       magu = MathExtra::len3(u);
       magv = MathExtra::len3(v);
-      if (magu * magv < EPSILON) inside2 = 1;
+      if (magu * magv < EPSILON*rradsq) inside2 = 1;
       else {
         costheta = MathExtra::dot3(u,v)/(magu*magv);
         anglesum2 += acos(costheta);
@@ -2338,7 +2346,12 @@ void PairBodyRoundedPolyhedron::find_unique_contacts(Contact* contact_list,
     for (int j = i + 1; j < n; j++) {
       if (contact_list[i].unique == 0) continue;
       double d = contact_separation(contact_list[i], contact_list[j]);
-      if (d < EPSILON) contact_list[j].unique = 0;
+      int ibody = contact_list[i].ibody;
+      int jbody = contact_list[i].jbody;
+      double rradi = rounded_radius[ibody];
+      double rradj = rounded_radius[jbody];
+      double rmin = MIN(rradi, rradj);
+      if (d < EPSILON*rmin) contact_list[j].unique = 0;
     }
   }
 }


### PR DESCRIPTION
**Summary**

This PR addresses the issue with the non-lj units (si, real) for the body pair styles. Currently, a single value of the threshold EPSILON is used for contact detection, angle between edges, and point overlaps, which is only applicable to lj units. The changes in this PR rescale EPSILON with a certain length scale (i.e. rounded radii) for distance detection and contact separation.

**Related Issue(s)**

The issue was reported on MatSci: https://matsci.org/t/modeling-cubes-with-body-rounded-polyhedron-produces-segmentation-fault/47833/6

**Author(s)**

Trung Nguyen (U Chicago)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Should maintain

**Implementation Notes**

Rescaling EPSILON with a certain length scale (i.e. rounded radii) for distance detection.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


