### PR TITLE
Pair SNAP tuning for Kokkos SYCL

### DIFF
--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -1310,9 +1310,13 @@ struct alignas(4 * sizeof(int)) reax_int4 {
 #define SNAP_KOKKOS_HOST_VECLEN 1
 
 #ifdef LMP_KOKKOS_GPU
-#define SNAP_KOKKOS_DEVICE_VECLEN 32
+  #if defined(KOKKOS_ENABLE_SYCL)
+    #define SNAP_KOKKOS_DEVICE_VECLEN 16
+  #else
+    #define SNAP_KOKKOS_DEVICE_VECLEN 32
+  #endif
 #else
-#define SNAP_KOKKOS_DEVICE_VECLEN 1
+  #define SNAP_KOKKOS_DEVICE_VECLEN 1
 #endif
 
 

--- a/src/KOKKOS/pair_snap_kokkos.h
+++ b/src/KOKKOS/pair_snap_kokkos.h
@@ -97,6 +97,17 @@ class PairSNAPKokkos : public PairSNAP {
   static constexpr int tile_size_transform_bi = 2;
   static constexpr int tile_size_compute_yi = 2;
   static constexpr int team_size_compute_fused_deidrj = 2;
+#elif defined(KOKKOS_ENABLE_SYCL)
+  static constexpr int team_size_compute_neigh = 4;
+  static constexpr int tile_size_compute_ck = 4;
+  static constexpr int tile_size_pre_ui = 4;
+  static constexpr int team_size_compute_ui = 4;
+  static constexpr int tile_size_transform_ui = 4;
+  static constexpr int tile_size_compute_zi = 4;
+  static constexpr int tile_size_compute_bi = 4;
+  static constexpr int tile_size_transform_bi = 4;
+  static constexpr int tile_size_compute_yi = 8;
+  static constexpr int team_size_compute_fused_deidrj = 4;
 #else
   static constexpr int team_size_compute_neigh = 4;
   static constexpr int tile_size_compute_ck = 4;

--- a/src/KOKKOS/pair_snap_kokkos.h
+++ b/src/KOKKOS/pair_snap_kokkos.h
@@ -100,9 +100,9 @@ class PairSNAPKokkos : public PairSNAP {
 #elif defined(KOKKOS_ENABLE_SYCL)
   static constexpr int team_size_compute_neigh = 4;
   static constexpr int tile_size_compute_ck = 4;
-  static constexpr int tile_size_pre_ui = 4;
-  static constexpr int team_size_compute_ui = 4;
-  static constexpr int tile_size_transform_ui = 4;
+  static constexpr int tile_size_pre_ui = 8;
+  static constexpr int team_size_compute_ui = 8;
+  static constexpr int tile_size_transform_ui = 8;
   static constexpr int tile_size_compute_zi = 4;
   static constexpr int tile_size_compute_bi = 4;
   static constexpr int tile_size_transform_bi = 4;


### PR DESCRIPTION
**Summary**

Tune SNAP vector length and team/tile size for Kokkos SYCL backend.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), values from Chris Knight (ANL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes