### PR TITLE
Temporarily disable team policy for Kokkos ghost neigh list build due to kno…

### DIFF
--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -240,22 +240,25 @@ void NPairKokkos<DeviceType,HALF,NEWTON,GHOST,TRI,SIZE>::build(NeighList *list_)
       // assumes newton off
 
       NPairKokkosBuildFunctorGhost<DeviceType,HALF> f(data,atoms_per_bin * 5 * sizeof(X_FLOAT) * factor);
-#ifdef LMP_KOKKOS_GPU
-      if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
-        int team_size = atoms_per_bin*factor;
-        int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
-        if (team_size <= team_size_max) {
-          Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
-          Kokkos::parallel_for(config, f);
-        } else { // fall back to flat method
-          f.sharedsize = 0;
-          Kokkos::parallel_for(nall, f);
-        }
-      } else
-        Kokkos::parallel_for(nall, f);
-#else
+
+// temporarily disable team policy for ghost due to known bug
+
+//#ifdef LMP_KOKKOS_GPU
+//      if (ExecutionSpaceFromDevice<DeviceType>::space == Device) {
+//        int team_size = atoms_per_bin*factor;
+//        int team_size_max = Kokkos::TeamPolicy<DeviceType>(team_size,Kokkos::AUTO).team_size_max(f,Kokkos::ParallelForTag());
+//        if (team_size <= team_size_max) {
+//          Kokkos::TeamPolicy<DeviceType> config((mbins+factor-1)/factor,team_size);
+//          Kokkos::parallel_for(config, f);
+//        } else { // fall back to flat method
+//          f.sharedsize = 0;
+//          Kokkos::parallel_for(nall, f);
+//        }
+//      } else
+//        Kokkos::parallel_for(nall, f);
+//#else
       Kokkos::parallel_for(nall, f);
-#endif
+//#endif
     } else {
       if (SIZE) {
         NPairKokkosBuildFunctorSize<DeviceType,HALF,NEWTON,TRI> f(data,atoms_per_bin * 6 * sizeof(X_FLOAT) * factor);


### PR DESCRIPTION
…wn bug

**Summary**

There is a bug in the team policy code for Kokkos ghost neigh list build. This code path is currently not used anywhere in the main LAMMPS code, but has been encountered by at least two external projects. Fixing the bug is not trivial, so this is a temporary workaround with an (expected) small performance impact on the neigh list build. The workaround simply falls back to a flat range policy instead of team policy.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Chuck Witt (Cambridge)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes