### PR TITLE
debug fix_modify press for press/berendsen

### DIFF
--- a/src/compute_chunk_spread_atom.cpp
+++ b/src/compute_chunk_spread_atom.cpp
@@ -106,7 +106,7 @@ ComputeChunkSpreadAtom(LAMMPS *lmp, int narg, char **arg) :
 
     } else if (val.which == ArgInfo::FIX) {
       auto ifix = modify->get_fix_by_id(val.id);
-      if (ifix)
+      if (!ifix)
         error->all(FLERR,"Fix ID {} for compute chunk/spread/atom does not exist", val.id);
       if (val.argindex == 0) {
         if (!ifix->vector_flag)

--- a/src/fix_press_berendsen.cpp
+++ b/src/fix_press_berendsen.cpp
@@ -491,7 +491,7 @@ int FixPressBerendsen::modify_param(int narg, char **arg)
     id_press = utils::strdup(arg[1]);
 
     pressure = modify->get_compute_by_id(arg[1]);
-    if (pressure) error->all(FLERR,"Could not find fix_modify pressure compute ID: {}", arg[1]);
+    if (!pressure) error->all(FLERR,"Could not find fix_modify pressure compute ID: {}", arg[1]);
     if (pressure->pressflag == 0)
       error->all(FLERR,"Fix_modify pressure compute {} does not compute pressure", arg[1]);
     return 2;


### PR DESCRIPTION
**Summary**

 `fix press/berendsen` had a bug preventing it from accepting a valid pressure compute via `fix_modify press`. This PR fixes it. See https://matsci.org/t/a-disconnect-between-compute-pressure-and-press-berendsen-when-bpm-package-is-used-in-2023-feature-lammps/49034/26 for bug in action.

**Author(s)**

Shern Tee (Griffith University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system


