### PR TITLE
fix pair bugfix

### DIFF
--- a/doc/src/fix_pair.rst
+++ b/doc/src/fix_pair.rst
@@ -85,7 +85,7 @@ columns 4-6 will store the "uinp" values.
 .. code-block:: LAMMPS
 
    pair_style amoeba
-   fix ex all pair amoeba 10 uind 0 uinp 0
+   fix ex all pair 10 amoeba uind 0 uinp 0
 
 Restart, fix_modify, output, run start/stop, minimize info
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/src/fix_pair.cpp
+++ b/src/fix_pair.cpp
@@ -283,11 +283,14 @@ void FixPair::post_force(int /*vflag*/)
 
     } else {
       double **parray = (double **) pvoid;
-      for (int i = 0; i < nlocal; i++)
+      int icoltmp = icol;
+      for (int i = 0; i < nlocal; i++) {
+        icol = icoltmp;
         for (int m = 0; m < columns; m++) {
           array[i][icol] = parray[i][m];
           icol++;
         }
+      }
     }
   }
 


### PR DESCRIPTION
**Summary**

This pull request fixes a bug that can cause crashes/incorrect results when using fix pair to extract a per atom array. A small typo in the fix pair documentation is also corrected.

**Related Issue(s)**

None

**Author(s)**

John Lucas

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


