### PR TITLE
Make QM wrappers more MDI-compatible with QM energy

### DIFF
--- a/examples/QUANTUM/LATTE/latte_mdi.py
+++ b/examples/QUANTUM/LATTE/latte_mdi.py
@@ -153,7 +153,7 @@ def mdi_engine(other_options):
 
   # engine --> driver
 
-  mdi.MDI_Register_Command("@DEFAULT","<PE")
+  mdi.MDI_Register_Command("@DEFAULT","<ENERGY")
   mdi.MDI_Register_Command("@DEFAULT","<FORCES")
   mdi.MDI_Register_Command("@DEFAULT",">LATTICE_FORCES")
   mdi.MDI_Register_Command("@DEFAULT","<STRESS")
@@ -232,10 +232,10 @@ def execute_command(command,mdicomm,object_ptr):
   # MDI commands which retreive quantum results
   # each may also trigger the quantum calculation
   
-  elif command == "<PE":
+  elif command == "<ENERGY":
     evaluate()
     ierr = mdi.MDI_Send(qm_pe,1,mdi.MDI_DOUBLE,mdicomm)
-    if ierr: error("MDI: <PE data")
+    if ierr: error("MDI: <ENERGY data")
     
   elif command == "<FORCES":
     evaluate()

--- a/examples/QUANTUM/NWChem/nwchem_mdi.py
+++ b/examples/QUANTUM/NWChem/nwchem_mdi.py
@@ -159,7 +159,7 @@ def mdi_engine(other_options):
 
   # engine --> driver
 
-  mdi.MDI_Register_Command("@DEFAULT","<PE")
+  mdi.MDI_Register_Command("@DEFAULT","<ENERGY")
   mdi.MDI_Register_Command("@DEFAULT","<FORCES")
   mdi.MDI_Register_Command("@DEFAULT",">LATTICE_FORCES")
   #mdi.MDI_Register_Command("@DEFAULT","<STRESS")
@@ -236,10 +236,10 @@ def execute_command(command,mdicomm,object_ptr):
   # MDI commands which retreive quantum results
   # each may also trigger the quantum calculation
   
-  elif command == "<PE":
+  elif command == "<ENERGY":
     evaluate()
     ierr = mdi.MDI_Send(qm_pe,1,mdi.MDI_DOUBLE,mdicomm)
-    if ierr: error("MDI: <PE data")
+    if ierr: error("MDI: <ENERGY data")
     
   elif command == "<FORCES":
     evaluate()

--- a/examples/QUANTUM/PySCF/pyscf_mdi.py
+++ b/examples/QUANTUM/PySCF/pyscf_mdi.py
@@ -189,7 +189,7 @@ def mdi_engine(other_options):
 
   # engine --> driver
 
-  mdi.MDI_Register_Command("@DEFAULT","<PE")
+  mdi.MDI_Register_Command("@DEFAULT","<ENERGY")
   mdi.MDI_Register_Command("@DEFAULT","<FORCES")
   mdi.MDI_Register_Command("@DEFAULT","<LATTICE_FORCES")
   #mdi.MDI_Register_Command("@DEFAULT","<STRESS")
@@ -262,10 +262,10 @@ def execute_command(command,mdicomm,object_ptr):
   # MDI commands which retreive quantum results
   # each may also trigger the quantum calculation
 
-  elif command == "<PE":
+  elif command == "<ENERGY":
     evaluate()
     ierr = mdi.MDI_Send(qm_pe,1,mdi.MDI_DOUBLE,mdicomm)
-    if ierr: error("MDI: <PE data")
+    if ierr: error("MDI: <ENERGY data")
 
   elif command == "<FORCES":
     evaluate()


### PR DESCRIPTION
**Summary**

LAMMPS is using the MDI communication library to connect with QM codes.
The Python wrapper scripts for this need to use a <ENERGY MDI command instead of <PE
to be compatible with the MDI distinctions between full energy and potential energy only
(w/out electron kinetic energy).

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


