### PR TITLE
Kokkos Makefiles

### DIFF
--- a/src/MAKE/MACHINES/Makefile.aurora_kokkos
+++ b/src/MAKE/MACHINES/Makefile.aurora_kokkos
@@ -1,4 +1,4 @@
-# spock_kokkos = KOKKOS/HIP, AMD MI100 GPU and AMD EPYC 7662 "Rome" CPU, Cray MPICH, hipcc compiler, hipFFT
+# aurora_kokkos = KOKKOS/SYCL, Intel Data Center Max (Ponte Vecchio) GPU, Intel Sapphire Rapids CPU, mpicxx compiler
 
 SHELL = /bin/sh
 
@@ -6,14 +6,12 @@ SHELL = /bin/sh
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
 
-KOKKOS_ABSOLUTE_PATH = $(shell cd $(KOKKOS_PATH); pwd)
-
-CC =		hipcc
-CCFLAGS =	-g -O3 -DNDEBUG -DKOKKOS_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS
+CC =		mpicxx
+CCFLAGS =	-g -O3 -DNDEBUG
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
-LINK =		hipcc
+LINK =		mpicxx
 LINKFLAGS =	-g -O3
 LIB = 
 SIZE =		size
@@ -21,8 +19,8 @@ SIZE =		size
 ARCHIVE =	ar
 ARFLAGS =	-rc
 SHLIBFLAGS =	-shared
-KOKKOS_DEVICES = HIP
-KOKKOS_ARCH = Zen2,Vega908
+KOKKOS_DEVICES = SYCL
+KOKKOS_ARCH = PVC,SPR
 
 # ---------------------------------------------------------------------
 # LAMMPS-specific settings, all OPTIONAL
@@ -43,9 +41,9 @@ LMP_INC =	-DLAMMPS_GZIP
 # PATH = path for MPI library
 # LIB = name of MPI library
 
-MPI_INC =       -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1 -I${MPICH_DIR}/include
+MPI_INC =       -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1
 MPI_PATH = 
-MPI_LIB = -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa
+MPI_LIB =
 
 # FFT library
 # see discussion in Section 3.5.2 of manual
@@ -54,12 +52,9 @@ MPI_LIB = -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa
 # PATH = path for FFT library
 # LIB = name of FFT library
 
-MY_HIP_EXE = $(shell which hipcc)
-MY_HIP_PATH = $(dir ${MY_HIP_EXE})
-
-FFT_INC = -DFFT_HIPFFT
+FFT_INC =
 FFT_PATH =
-FFT_LIB = -L${MY_HIP_PATH}../lib -lhipfft
+FFT_LIB =
 
 # JPEG and/or PNG library
 # see discussion in Section 3.5.4 of manual

--- a/src/MAKE/MACHINES/Makefile.frontier_kokkos
+++ b/src/MAKE/MACHINES/Makefile.frontier_kokkos
@@ -1,12 +1,10 @@
-# crusher_kokkos = KOKKOS/HIP, AMD MI250X GPU and AMD EPYC 7A53 "Optimized 3rd Gen EPYC" CPU, Cray MPICH, hipcc compiler, hipFFT
+# frontier_kokkos = KOKKOS/HIP, AMD MI250X GPU and AMD EPYC 7A53 "Optimized 3rd Gen EPYC" CPU, Cray MPICH, hipcc compiler, hipFFT
 
 SHELL = /bin/sh
 
 # ---------------------------------------------------------------------
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
-
-KOKKOS_ABSOLUTE_PATH = $(shell cd $(KOKKOS_PATH); pwd)
 
 CC =		hipcc
 CCFLAGS =	-g -O3 -munsafe-fp-atomics -DNDEBUG -DKOKKOS_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS

--- a/src/MAKE/MACHINES/Makefile.perlmutter_kokkos
+++ b/src/MAKE/MACHINES/Makefile.perlmutter_kokkos
@@ -1,4 +1,4 @@
-# frontier_kokkos = KOKKOS/HIP, AMD MI250X GPU and AMD EPYC 7A53 "Optimized 3rd Gen EPYC" CPU, Cray MPICH, hipcc compiler, hipFFT
+# perlmutter_kokkos = KOKKOS/CUDA, NVIDIA A100 GPU and AMD EPYC 7763 (Milan) CPU, Cray MPICH, nvcc compiler with gcc
 
 SHELL = /bin/sh
 
@@ -6,12 +6,14 @@ SHELL = /bin/sh
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
 
-CC =		hipcc
-CCFLAGS =	-g -O3 -munsafe-fp-atomics -DNDEBUG -DKOKKOS_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS
+KOKKOS_ABSOLUTE_PATH = $(shell cd $(KOKKOS_PATH); pwd)
+
+CC =		$(KOKKOS_ABSOLUTE_PATH)/bin/nvcc_wrapper
+CCFLAGS =	-g -O3 -DNDEBUG -Xcudafe --diag_suppress=unrecognized_pragma
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
-LINK =		hipcc
+LINK =		$(KOKKOS_ABSOLUTE_PATH)/bin/nvcc_wrapper
 LINKFLAGS =	-g -O3
 LIB = 
 SIZE =		size
@@ -19,8 +21,8 @@ SIZE =		size
 ARCHIVE =	ar
 ARFLAGS =	-rc
 SHLIBFLAGS =	-shared
-KOKKOS_DEVICES = HIP
-KOKKOS_ARCH = Vega90A,Zen3
+KOKKOS_DEVICES = Cuda
+KOKKOS_ARCH = Ampere80,Zen3
 
 # ---------------------------------------------------------------------
 # LAMMPS-specific settings, all OPTIONAL
@@ -42,8 +44,8 @@ LMP_INC =	-DLAMMPS_GZIP
 # LIB = name of MPI library
 
 MPI_INC =       -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1 -I${MPICH_DIR}/include
-MPI_PATH = 
-MPI_LIB = -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa
+MPI_PATH =
+MPI_LIB = -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_cuda
 
 # FFT library
 # see discussion in Section 3.5.2 of manual
@@ -52,12 +54,9 @@ MPI_LIB = -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa
 # PATH = path for FFT library
 # LIB = name of FFT library
 
-MY_HIP_EXE = $(shell which hipcc)
-MY_HIP_PATH = $(dir ${MY_HIP_EXE})
-
-FFT_INC = -DFFT_HIPFFT
-FFT_PATH =
-FFT_LIB = -L${MY_HIP_PATH}../lib -lhipfft
+FFT_INC = -DFFT_CUFFT
+FFT_PATH = 
+FFT_LIB = -lcufft
 
 # JPEG and/or PNG library
 # see discussion in Section 3.5.4 of manual
@@ -70,6 +69,11 @@ JPG_INC =
 JPG_PATH =
 JPG_LIB =
 
+#  library for loading shared objects (defaults to -ldl, should be empty on Windows)
+# uncomment to change the default
+
+# override DYN_LIB =
+
 # ---------------------------------------------------------------------
 # build rules and dependencies
 # do not edit this section
@@ -79,7 +83,7 @@ include Makefile.package
 
 EXTRA_INC = $(LMP_INC) $(PKG_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC) $(PKG_SYSINC)
 EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
-EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB) $(DYN_LIB)
 EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
 EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
 


### PR DESCRIPTION
**Summary**

Add `Makefile.aurora_kokkos` for ALCF Aurora, rename `Makefile.crusher_kokkos` to `Makefile.frontier_kokkos` for OLCF Frontier, and delete `Makefile.spock_kokkos`. Also add `Makefile.perlmutter_kokkos` for NERSC Perlmutter.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes