### PR TITLE
Add gravity keyword info to fix rigid doc page

### DIFF
--- a/doc/src/fix_rigid.rst
+++ b/doc/src/fix_rigid.rst
@@ -696,9 +696,9 @@ dyamics will be modeled correctly, as explained above.
 
 Third, the *gravity* keyword should be used the with the ID of the
 :doc:`fix gravity <fix_gravity>` command as its argument.  The rigid
-fixes will access gravity fix to extract the current direction of the
-gravity vector at each timestep (which can be static or dynamic).  A
-gravity force will then be applied to each rigid body at its
+fixes will access the gravity fix to extract the current direction of
+the gravity vector at each timestep (which can be static or dynamic).
+A gravity force will then be applied to each rigid body at its
 center-of-mass position using its total mass.
 
 ----------

--- a/doc/src/fix_rigid.rst
+++ b/doc/src/fix_rigid.rst
@@ -692,7 +692,7 @@ bodies, e.g. background particles.
 
 Second, the *infile* keyword should be used to specify the total mass
 and other properties of the rigid bodies with overlaps, so that their
-dyamics will be modeled correctly, as explained above.
+dynamics will be modeled correctly, as explained above.
 
 Third, the *gravity* keyword should be used the with the ID of the
 :doc:`fix gravity <fix_gravity>` command as its argument.  The rigid

--- a/doc/src/fix_rigid.rst
+++ b/doc/src/fix_rigid.rst
@@ -610,10 +610,12 @@ such attributes: the total mass of the rigid body, its center-of-mass
 position, its 6 moments of inertia, its center-of-mass velocity, and
 the 3 image flags of the center-of-mass position.  For rigid bodies
 consisting of point particles or non-overlapping finite-size
-particles, LAMMPS can compute these values accurately.  However, for
-rigid bodies consisting of finite-size particles which overlap each
-other, LAMMPS will ignore the overlaps when computing these 4
-attributes.  The amount of error this induces depends on the amount of
+particles, LAMMPS can compute these values accurately.
+
+However, for rigid bodies consisting of finite-size particles which
+overlap each other, LAMMPS will ignore the overlaps when computing
+these 4 attributes, which means the dynamics of the bodies will be
+incorrect.  The amount of error this induces depends on the amount of
 overlap.  To avoid this issue, the values can be pre-computed
 (e.g. using Monte Carlo integration).
 
@@ -676,6 +678,28 @@ cross periodic boundaries during the simulation.
    using an *infile* keyword and the appropriate filename.  Note that the
    auxiliary file will contain one line for every rigid body, even if the
    original file only listed a subset of the rigid bodies.
+
+If the system has rigid bodies with finite-size overlapping particles
+and the model uses the :doc:`fix gravity <fix_gravity>` command to
+apply a gravitational force to the rigid bodies, then the *gravity*
+keyword should be used in the following manner.
+
+First, the group specified for the :doc:`fix gravity <fix_gravity>`
+command should not include any atoms in rigid bodies which have
+overlapping particles.  It can be empty (see the :doc:`group empty
+<group>` command) or only contain single particles not in rigid
+bodies, e.g. background particles.
+
+Second, the *infile* keyword should be used to specify the total mass
+and other properties of the rigid bodies with overlaps, so that their
+dyamics will be modeled correctly, as explained above.
+
+Third, the *gravity* keyword should be used the with the ID of the
+:doc:`fix gravity <fix_gravity>` command as its argument.  The rigid
+fixes will access gravity fix to extract the current direction of the
+gravity vector at each timestep (which can be static or dynamic).  A
+gravity force will then be applied to each rigid body at its
+center-of-mass position using its total mass.
 
 ----------
 


### PR DESCRIPTION
**Summary**

The fix rigid doc page (for all rigid fixes) does not include an explanation of the "gravity" keyword.
This PR adds it.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


