### PR TITLE
Minor bug fix and enhancements for granular heat transfer

### DIFF
--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -655,8 +655,8 @@ For *heat* *radius*, the heat
 
 where :math:`\Delta T` is the difference in the two particles' temperature,
 :math:`k_{s}` is a non-negative numeric value for the conductivity (in units
-of power/(length*temperature)), and :math:`a` is the radius of the contact and 
-depends on the normal force model. This is the model proposed by 
+of power/(length*temperature)), and :math:`a` is the radius of the contact and
+depends on the normal force model. This is the model proposed by
 :ref:`Vargas and McCarthy <VargasMcCarthy2001>`
 
 For *heat* *area*, the heat
@@ -668,7 +668,7 @@ For *heat* *area*, the heat
 
 
 where :math:`\Delta T` is the difference in the two particles' temperature,
-:math:`h_{s}` is a non-negative numeric value for the heat transfer 
+:math:`h_{s}` is a non-negative numeric value for the heat transfer
 coefficient (in units of power/(area*temperature)), and :math:`A=\pi a^2` is
 the area of the contact and depends on the normal force model.
 
@@ -913,7 +913,7 @@ I. Assembling process, geometry, and contact networks. Phys. Rev. E, 76, 061302.
 
 .. _VargasMcCarthy2001:
 
-**(Vargas and McCarthy 2001)** Vargas, W.L. and McCarthy, J.J. (2001). 
-Heat conduction in granular materials. 
+**(Vargas and McCarthy 2001)** Vargas, W.L. and McCarthy, J.J. (2001).
+Heat conduction in granular materials.
 AIChE Journal, 47(5), 1052-1059.
 

--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -763,15 +763,17 @@ The single() function of these pair styles returns 0.0 for the energy
 of a pairwise interaction, since energy is not conserved in these
 dissipative potentials.  It also returns only the normal component of
 the pairwise interaction force.  However, the single() function also
-calculates 12 extra pairwise quantities.  The first 3 are the
+calculates 13 extra pairwise quantities.  The first 3 are the
 components of the tangential force between particles I and J, acting
 on particle I.  The fourth is the magnitude of this tangential force.
 The next 3 (5-7) are the components of the rolling torque acting on
 particle I. The next entry (8) is the magnitude of the rolling torque.
 The next entry (9) is the magnitude of the twisting torque acting
 about the vector connecting the two particle centers.
-The last 3 (10-12) are the components of the vector connecting
-the centers of the two particles (x_I - x_J).
+The next 3 (10-12) are the components of the vector connecting
+the centers of the two particles (x_I - x_J). The last quantity (13)
+is the heat flow between the two particles, set to 0 if no heat model
+is active.
 
 These extra quantities can be accessed by the :doc:`compute pair/local <compute_pair_local>` command, as *p1*, *p2*, ...,
 *p12*\ .

--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -657,7 +657,7 @@ where :math:`\Delta T` is the difference in the two particles' temperature,
 :math:`k_{s}` is a non-negative numeric value for the conductivity (in units
 of power/(length*temperature)), and :math:`a` is the radius of the contact and
 depends on the normal force model. This is the model proposed by
-:ref:`Vargas and McCarthy <VargasMcCarthy2001>`
+:ref:`Vargas and McCarthy <VargasMcCarthy2001>`.
 
 For *heat* *area*, the heat
 :math:`Q` conducted between two particles is given by

--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -641,22 +641,36 @@ The optional *heat* keyword enables heat conduction. The options currently
 supported are:
 
 1. *none*
-2. *area* : :math:`k_{s}`
+2. *radius* : :math:`k_{s}`
+3. *area* : :math:`h_{s}`
 
 If the *heat* keyword is not specified, the model defaults to *none*.
+
+For *heat* *radius*, the heat
+:math:`Q` conducted between two particles is given by
+
+.. math::
+
+   Q = 2 k_{s} a \Delta T
+
+where :math:`\Delta T` is the difference in the two particles' temperature,
+:math:`k_{s}` is a non-negative numeric value for the conductivity (in units
+of power/(length*temperature)), and :math:`a` is the radius of the contact and 
+depends on the normal force model. This is the model proposed by 
+:ref:`Vargas and McCarthy <VargasMcCarthy2001>`
 
 For *heat* *area*, the heat
 :math:`Q` conducted between two particles is given by
 
 .. math::
 
-   Q = k_{s} A \Delta T
-
+   Q = h_{s} A \Delta T
 
 
 where :math:`\Delta T` is the difference in the two particles' temperature,
-:math:`k_{s}` is a non-negative numeric value for the conductivity, and
-:math:`A` is the area of the contact and depends on the normal force model.
+:math:`h_{s}` is a non-negative numeric value for the heat transfer 
+coefficient (in units of power/(area*temperature)), and :math:`A=\pi a^2` is
+the area of the contact and depends on the normal force model.
 
 Note that the option *none* must either be used in all or none of of the
 *pair_coeff* calls. See :doc:`fix heat/flow <fix_heat_flow>` and
@@ -894,3 +908,10 @@ J. Appl. Mech., ASME 20, 327-344.
 **(Agnolin and Roux 2007)** Agnolin, I. & Roux, J-N. (2007).
 Internal states of model isotropic granular packings.
 I. Assembling process, geometry, and contact networks. Phys. Rev. E, 76, 061302.
+
+.. _VargasMcCarthy2001:
+
+**(Vargas and McCarthy 2001)** Vargas, W.L. and McCarthy, J.J. (2001). 
+Heat conduction in granular materials. 
+AIChE Journal, 47(5), 1052-1059.
+

--- a/src/GRANULAR/fix_heat_flow.cpp
+++ b/src/GRANULAR/fix_heat_flow.cpp
@@ -89,23 +89,21 @@ void FixHeatFlow::init()
 
 void FixHeatFlow::setup(int /*vflag*/)
 {
-  // Identify whether this is the first instance of fix heat/flow
-  first_flag = 0;
-
-  int i = 0;
-  auto fixlist = modify->get_fix_by_style("heat/flow");
-  for (const auto &ifix : fixlist) {
-    if (strcmp(ifix->id, id) == 0) break;
-    i++;
-  }
-
-  if (i == 0) first_flag = 1;
 }
 
 /* ---------------------------------------------------------------------- */
 
 void FixHeatFlow::setup_pre_force(int /*vflag*/)
 {
+  // Identify whether this is the first instance of fix heat/flow
+  first_flag = 0;
+  int i = 0;
+  auto fixlist = modify->get_fix_by_style("heat/flow");
+  for (const auto &ifix : fixlist) {
+    if (strcmp(ifix->id, id) == 0) break;
+    i++;
+  }
+  if (i == 0) first_flag = 1;
   pre_force(0);
 }
 

--- a/src/GRANULAR/fix_heat_flow.cpp
+++ b/src/GRANULAR/fix_heat_flow.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 /* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/, Sandia National Laboratories
@@ -26,39 +25,37 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum {NONE, CONSTANT, TYPE};
+enum { NONE, CONSTANT, TYPE };
 
 /* ---------------------------------------------------------------------- */
 
-FixHeatFlow::FixHeatFlow(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg)
+FixHeatFlow::FixHeatFlow(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
 {
-  if (narg < 4) utils::missing_cmd_args(FLERR,"fix heat/flow", error);
+  if (narg < 4) utils::missing_cmd_args(FLERR, "fix heat/flow", error);
 
   cp_style = NONE;
   comm_forward = 1;
   comm_reverse = 1;
 
   int ntypes = atom->ntypes;
-  if (strcmp(arg[3],"constant") == 0) {
-    if (narg != 5) error->all(FLERR,"Illegal fix heat/flow constant command");
+  if (strcmp(arg[3], "constant") == 0) {
+    if (narg != 5) error->all(FLERR, "Illegal fix heat/flow constant command");
     cp_style = CONSTANT;
-    cp = utils::numeric(FLERR,arg[4],false,lmp);
-    if (cp < 0.0) error->all(FLERR,"Illegal fix heat/flow constant command value");
-  } else if (strcmp(arg[3],"type") == 0) {
-    if (narg != 4 + ntypes) error->all(FLERR,"Illegal fix heat/flow type command");
+    cp = utils::numeric(FLERR, arg[4], false, lmp);
+    if (cp < 0.0) error->all(FLERR, "Illegal fix heat/flow constant command value");
+  } else if (strcmp(arg[3], "type") == 0) {
+    if (narg != 4 + ntypes) error->all(FLERR, "Illegal fix heat/flow type command");
     cp_style = TYPE;
-    memory->create(cp_type,ntypes+1,"fix_heat_flow:cp_type");
+    memory->create(cp_type, ntypes + 1, "fix_heat_flow:cp_type");
     for (int i = 1; i <= ntypes; i++) {
-      cp_type[i] = utils::numeric(FLERR,arg[3+i],false,lmp);
-      if (cp_type[i] < 0.0) error->all(FLERR,"Illegal fix heat/flow type command value");
+      cp_type[i] = utils::numeric(FLERR, arg[3 + i], false, lmp);
+      if (cp_type[i] < 0.0) error->all(FLERR, "Illegal fix heat/flow type command value");
     }
   } else {
-    error->all(FLERR,"Unknown fix heat/flow keyword {}", arg[3]);
+    error->all(FLERR, "Unknown fix heat/flow keyword {}", arg[3]);
   }
 
-  if (cp_style == NONE)
-    error->all(FLERR, "Must specify specific heat in fix heat/flow");
+  if (cp_style == NONE) error->all(FLERR, "Must specify specific heat in fix heat/flow");
   dynamic_group_allow = 1;
 }
 
@@ -80,9 +77,9 @@ void FixHeatFlow::init()
   dt = update->dt;
 
   if (!atom->temperature_flag)
-    error->all(FLERR,"Fix heat/flow requires atom style with temperature property");
+    error->all(FLERR, "Fix heat/flow requires atom style with temperature property");
   if (!atom->heatflow_flag)
-    error->all(FLERR,"Fix heat/flow requires atom style with heatflow property");
+    error->all(FLERR, "Fix heat/flow requires atom style with heatflow property");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -130,19 +127,14 @@ void FixHeatFlow::final_integrate()
   if (igroup == atom->firstgroup) nlocal = atom->nfirst;
 
   // add ghost contributions to heatflow if first instance of fix
-  if (first_flag)
-    comm->reverse_comm(this);
+  if (first_flag) comm->reverse_comm(this);
 
   if (rmass) {
     for (int i = 0; i < nlocal; i++)
-      if (mask[i] & groupbit) {
-        temperature[i] += dt * heatflow[i] / (calc_cp(i) * rmass[i]);
-      }
+      if (mask[i] & groupbit) temperature[i] += dt * heatflow[i] / (calc_cp(i) * rmass[i]);
   } else {
     for (int i = 0; i < nlocal; i++)
-      if (mask[i] & groupbit) {
-        temperature[i] += dt * heatflow[i] / (calc_cp(i) * mass[type[i]]);
-      }
+      if (mask[i] & groupbit) temperature[i] += dt * heatflow[i] / (calc_cp(i) * mass[type[i]]);
   }
 }
 
@@ -211,9 +203,7 @@ int FixHeatFlow::pack_reverse_comm(int n, int first, double *buf)
   int last = first + n;
   double *heatflow = atom->heatflow;
 
-  for (int i = first; i < last; i++) {
-    buf[m++] = heatflow[i];
-  }
+  for (int i = first; i < last; i++) { buf[m++] = heatflow[i]; }
 
   return m;
 }
@@ -225,6 +215,5 @@ void FixHeatFlow::unpack_reverse_comm(int n, int *list, double *buf)
   int m = 0;
   double *heatflow = atom->heatflow;
 
-  for (int i = 0; i < n; i++)
-    heatflow[list[i]] += buf[m++];
+  for (int i = 0; i < n; i++) heatflow[list[i]] += buf[m++];
 }

--- a/src/GRANULAR/fix_heat_flow.cpp
+++ b/src/GRANULAR/fix_heat_flow.cpp
@@ -87,12 +87,6 @@ void FixHeatFlow::init()
 
 /* ---------------------------------------------------------------------- */
 
-void FixHeatFlow::setup(int /*vflag*/)
-{
-}
-
-/* ---------------------------------------------------------------------- */
-
 void FixHeatFlow::setup_pre_force(int /*vflag*/)
 {
   // Identify whether this is the first instance of fix heat/flow

--- a/src/GRANULAR/fix_heat_flow.cpp
+++ b/src/GRANULAR/fix_heat_flow.cpp
@@ -33,7 +33,7 @@ enum {NONE, CONSTANT, TYPE};
 FixHeatFlow::FixHeatFlow(LAMMPS *lmp, int narg, char **arg) :
   Fix(lmp, narg, arg)
 {
-  if (narg < 4) error->all(FLERR,"Illegal fix command");
+  if (narg < 4) utils::missing_cmd_args(FLERR,"fix heat/flow", error);
 
   cp_style = NONE;
   comm_forward = 1;
@@ -41,24 +41,24 @@ FixHeatFlow::FixHeatFlow(LAMMPS *lmp, int narg, char **arg) :
 
   int ntypes = atom->ntypes;
   if (strcmp(arg[3],"constant") == 0) {
-    if (narg != 5) error->all(FLERR,"Illegal fix command");
+    if (narg != 5) error->all(FLERR,"Illegal fix heat/flow constant command");
     cp_style = CONSTANT;
     cp = utils::numeric(FLERR,arg[4],false,lmp);
-    if (cp < 0.0) error->all(FLERR,"Illegal fix command");
+    if (cp < 0.0) error->all(FLERR,"Illegal fix heat/flow constant command value");
   } else if (strcmp(arg[3],"type") == 0) {
-    if (narg != 4 + ntypes) error->all(FLERR,"Illegal fix command");
+    if (narg != 4 + ntypes) error->all(FLERR,"Illegal fix heat/flow type command");
     cp_style = TYPE;
-    memory->create(cp_type,ntypes+1,"fix/temp/integrate:cp_type");
+    memory->create(cp_type,ntypes+1,"fix_heat_flow:cp_type");
     for (int i = 1; i <= ntypes; i++) {
       cp_type[i] = utils::numeric(FLERR,arg[3+i],false,lmp);
-      if (cp_type[i] < 0.0) error->all(FLERR,"Illegal fix command");
+      if (cp_type[i] < 0.0) error->all(FLERR,"Illegal fix heat/flow type command value");
     }
   } else {
-    error->all(FLERR,"Illegal fix command");
+    error->all(FLERR,"Unknown fix heat/flow keyword {}", arg[3]);
   }
 
   if (cp_style == NONE)
-    error->all(FLERR, "Must specify specific heat in fix temp/integrate");
+    error->all(FLERR, "Must specify specific heat in fix heat/flow");
   dynamic_group_allow = 1;
 }
 
@@ -80,9 +80,9 @@ void FixHeatFlow::init()
   dt = update->dt;
 
   if (!atom->temperature_flag)
-    error->all(FLERR,"Fix temp/integrate requires atom style with temperature property");
+    error->all(FLERR,"Fix heat/flow requires atom style with temperature property");
   if (!atom->heatflow_flag)
-    error->all(FLERR,"Fix temp/integrate requires atom style with heatflow property");
+    error->all(FLERR,"Fix heat/flow requires atom style with heatflow property");
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/GRANULAR/fix_heat_flow.h
+++ b/src/GRANULAR/fix_heat_flow.h
@@ -30,7 +30,6 @@ class FixHeatFlow : public Fix {
 
   int setmask() override;
   void init() override;
-  void setup(int) override;
   void setup_pre_force(int) override;
   void pre_force(int) override;
   void final_integrate() override;

--- a/src/GRANULAR/gran_sub_mod_heat.cpp
+++ b/src/GRANULAR/gran_sub_mod_heat.cpp
@@ -42,6 +42,33 @@ double GranSubModHeatNone::calculate_heat()
 }
 
 /* ----------------------------------------------------------------------
+   Radius-based heat conduction
+------------------------------------------------------------------------- */
+
+GranSubModHeatRadius::GranSubModHeatRadius(GranularModel *gm, LAMMPS *lmp) : GranSubModHeat(gm, lmp)
+{
+  num_coeffs = 1;
+  contact_radius_flag = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void GranSubModHeatRadius::coeffs_to_local()
+{
+  conductivity = coeffs[0];
+
+  if (conductivity < 0.0) error->all(FLERR, "Illegal radius heat model");
+}
+
+/* ---------------------------------------------------------------------- */
+
+double GranSubModHeatRadius::calculate_heat()
+{
+  return 2 * conductivity * gm->contact_radius * (gm->Tj - gm->Ti);
+}
+
+
+/* ----------------------------------------------------------------------
    Area-based heat conduction
 ------------------------------------------------------------------------- */
 
@@ -55,14 +82,14 @@ GranSubModHeatArea::GranSubModHeatArea(GranularModel *gm, LAMMPS *lmp) : GranSub
 
 void GranSubModHeatArea::coeffs_to_local()
 {
-  conductivity = coeffs[0];
+  heat_transfer_coeff = coeffs[0];
 
-  if (conductivity < 0.0) error->all(FLERR, "Illegal area heat model");
+  if (heat_transfer_coeff < 0.0) error->all(FLERR, "Illegal area heat model");
 }
 
 /* ---------------------------------------------------------------------- */
 
 double GranSubModHeatArea::calculate_heat()
 {
-  return conductivity * MY_PI * gm->contact_radius * gm->contact_radius * (gm->Tj - gm->Ti);
+  return heat_transfer_coeff * MY_PI * gm->contact_radius * gm->contact_radius * (gm->Tj - gm->Ti);
 }

--- a/src/GRANULAR/gran_sub_mod_heat.h
+++ b/src/GRANULAR/gran_sub_mod_heat.h
@@ -14,6 +14,7 @@
 #ifdef GRAN_SUB_MOD_CLASS
 // clang-format off
 GranSubModStyle(none,GranSubModHeatNone,HEAT);
+GranSubModStyle(radius,GranSubModHeatRadius,HEAT);
 GranSubModStyle(area,GranSubModHeatArea,HEAT);
 // clang-format on
 #else
@@ -39,6 +40,18 @@ namespace Granular_NS {
     GranSubModHeatNone(class GranularModel *, class LAMMPS *);
     double calculate_heat() override;
   };
+    
+  /* ---------------------------------------------------------------------- */
+
+  class GranSubModHeatRadius : public GranSubModHeat {
+   public:
+    GranSubModHeatRadius(class GranularModel *, class LAMMPS *);
+    void coeffs_to_local() override;
+    double calculate_heat() override;
+
+   protected:
+    double conductivity;
+  };
 
   /* ---------------------------------------------------------------------- */
 
@@ -49,7 +62,7 @@ namespace Granular_NS {
     double calculate_heat() override;
 
    protected:
-    double conductivity;
+    double heat_transfer_coeff;
   };
 
 }    // namespace Granular_NS

--- a/src/GRANULAR/gran_sub_mod_heat.h
+++ b/src/GRANULAR/gran_sub_mod_heat.h
@@ -40,7 +40,7 @@ namespace Granular_NS {
     GranSubModHeatNone(class GranularModel *, class LAMMPS *);
     double calculate_heat() override;
   };
-    
+
   /* ---------------------------------------------------------------------- */
 
   class GranSubModHeatRadius : public GranSubModHeat {


### PR DESCRIPTION
**Summary**

- Fixes a bug that could cause crashes due to an uninitialized variable in `GRANULAR/fix_heat_flow.cpp`
- Adds a granular heat model that depends on contact radius rather than contact area
- Renames 'thermal conductivity' to 'heat transfer coefficient' in the doc pages for the `heat area` model to be more consistent with literature
- Adds an additional pairwise quantity to the single method of `pair granular` allowing access to the pairwise heat flow between particles


**Author(s)**

Dan Bolintineanu, Sandia National Labs

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



