### PR TITLE
Small refactor to better handle diamflag in fix adapt and fix adapt/fep

### DIFF
--- a/src/BPM/atom_vec_bpm_sphere.cpp
+++ b/src/BPM/atom_vec_bpm_sphere.cpp
@@ -98,11 +98,12 @@ void AtomVecBPMSphere::init()
 
   // check if optional radvary setting should have been set to 1
 
-  for (auto ifix : modify->get_fix_by_style("^adapt")) {
-    if (ifix->diam_flag && (radvary == 0))
-      error->all(FLERR, "Fix {} changes atom radii but atom_style bpm/sphere is not dynamic",
-        ifix->style);
-  }
+  if (radvary == 0)
+    for (const auto &ifix : modify->get_fix_by_style("^adapt")) {
+      if (ifix->diam_flag)
+        error->all(FLERR, "Fix {} changes atom radii but atom_style bpm/sphere is not dynamic",
+                   ifix->style);
+    }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/BPM/atom_vec_bpm_sphere.cpp
+++ b/src/BPM/atom_vec_bpm_sphere.cpp
@@ -17,7 +17,6 @@
 #include "comm.h"
 #include "error.h"
 #include "fix.h"
-#include "fix_adapt.h"
 #include "math_const.h"
 #include "modify.h"
 
@@ -99,14 +98,9 @@ void AtomVecBPMSphere::init()
   // check if optional radvary setting should have been set to 1
 
   for (auto ifix : modify->get_fix_by_style("^adapt")) {
-    if (radvary == 0) {
-      if ((strcmp(ifix->style, "adapt") == 0) && (dynamic_cast<FixAdapt *>(ifix)->diamflag))
-        error->all(FLERR, "Fix adapt changes atom radii but atom_style bpm/sphere is not dynamic");
-      // cannot properly check for fix adapt/fep since its header is optional
-      if ((strcmp(ifix->style, "adapt/fep") == 0) && (comm->me == 0))
-        error->warning(
-            FLERR, "Fix adapt/fep may change atom radii but atom_style bpm/sphere is not dynamic");
-    }
+    if (ifix->diam_flag && (radvary == 0))
+      error->all(FLERR, "Fix {} changes atom radii but atom_style bpm/sphere is not dynamic",
+        ifix->style);
   }
 }
 

--- a/src/BPM/atom_vec_bpm_sphere.cpp
+++ b/src/BPM/atom_vec_bpm_sphere.cpp
@@ -32,6 +32,7 @@ AtomVecBPMSphere::AtomVecBPMSphere(LAMMPS *_lmp) : AtomVec(_lmp)
   mass_type = PER_ATOM;
   molecular = Atom::MOLECULAR;
   bonds_allow = 1;
+  radvary = 0;
 
   atom->molecule_flag = 1;
   atom->sphere_flag = 1;

--- a/src/FEP/fix_adapt_fep.cpp
+++ b/src/FEP/fix_adapt_fep.cpp
@@ -82,7 +82,6 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
   // parse keywords
 
   nadapt = 0;
-  diamflag = 0;
   chgflag = 0;
 
   iarg = 4;
@@ -114,7 +113,7 @@ FixAdaptFEP::FixAdaptFEP(LAMMPS *lmp, int narg, char **arg) :
       adapt[nadapt].which = ATOM;
       if (strcmp(arg[iarg+1],"diameter") == 0) {
         adapt[nadapt].aparam = DIAMETER;
-        diamflag = 1;
+        diam_flag = 1;
       } else if (strcmp(arg[iarg+1],"charge") == 0) {
         adapt[nadapt].aparam = CHARGE;
         chgflag = 1;
@@ -201,7 +200,7 @@ int FixAdaptFEP::setmask()
 void FixAdaptFEP::post_constructor()
 {
   if (!resetflag) return;
-  if (!diamflag && !chgflag) return;
+  if (!diam_flag && !chgflag) return;
 
   // new id = fix-ID + FIX_STORE_ATTRIBUTE
   // new fix group = group for this fix
@@ -209,7 +208,7 @@ void FixAdaptFEP::post_constructor()
   id_fix_diam = nullptr;
   id_fix_chg = nullptr;
 
-  if (diamflag) {
+  if (diam_flag) {
     id_fix_diam = utils::strdup(id + std::string("_FIX_STORE_DIAM"));
     fix_diam = dynamic_cast<FixStoreAtom *>(
       modify->add_fix(fmt::format("{} {} STORE/ATOM 1 0 0 1", id_fix_diam,group->names[igroup])));
@@ -513,7 +512,7 @@ void FixAdaptFEP::restore_settings()
       *kspace_scale = 1.0;
 
     } else if (ad->which == ATOM) {
-      if (diamflag) {
+      if (diam_flag) {
         double density;
 
         double *vec = fix_diam->vstore;

--- a/src/FEP/fix_adapt_fep.h
+++ b/src/FEP/fix_adapt_fep.h
@@ -26,7 +26,6 @@ namespace LAMMPS_NS {
 
 class FixAdaptFEP : public Fix {
  public:
-  int diamflag;    // 1 if atom diameters will vary, for AtomVecGranular
   int chgflag;
 
   FixAdaptFEP(class LAMMPS *, int, char **);

--- a/src/KOKKOS/atom_vec_sphere_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_sphere_kokkos.cpp
@@ -20,7 +20,6 @@
 #include "domain.h"
 #include "error.h"
 #include "fix.h"
-#include "fix_adapt.h"
 #include "math_const.h"
 #include "memory.h"
 #include "memory_kokkos.h"

--- a/src/atom_vec_sphere.cpp
+++ b/src/atom_vec_sphere.cpp
@@ -30,6 +30,7 @@ AtomVecSphere::AtomVecSphere(LAMMPS *lmp) : AtomVec(lmp)
 {
   mass_type = PER_ATOM;
   molecular = Atom::ATOMIC;
+  radvary = 0;
 
   atom->sphere_flag = 1;
   atom->radius_flag = atom->rmass_flag = atom->omega_flag = atom->torque_flag = 1;

--- a/src/atom_vec_sphere.cpp
+++ b/src/atom_vec_sphere.cpp
@@ -16,8 +16,6 @@
 #include "atom.h"
 #include "error.h"
 #include "fix.h"
-#include "fix_adapt.h"
-#include "fix_adapt_fep.h"
 #include "math_const.h"
 #include "modify.h"
 
@@ -90,16 +88,9 @@ void AtomVecSphere::init()
   // check if optional radvary setting should have been set to 1
 
   for (auto &ifix : modify->get_fix_by_style("^adapt")) {
-    if (utils::strmatch(ifix->style, "^adapt$")) {
-      auto fix = dynamic_cast<FixAdapt *>(ifix);
-      if (fix && fix->diamflag && radvary == 0)
-        error->all(FLERR, "Fix adapt changes particle radii but atom_style sphere is not dynamic");
-    }
-    if (utils::strmatch(ifix->style, "^adapt/fep$")) {
-      auto fix = dynamic_cast<FixAdaptFEP *>(ifix);
-      if (fix && fix->diamflag && radvary == 0)
-        error->all(FLERR, "Fix adapt/fep changes particle radii but atom_style sphere is not dynamic");
-    }
+    if (ifix->diam_flag && (radvary == 0))
+      error->all(FLERR, "Fix {} changes atom radii but atom_style sphere is not dynamic",
+        ifix->style);
   }
 }
 

--- a/src/atom_vec_sphere.cpp
+++ b/src/atom_vec_sphere.cpp
@@ -88,11 +88,12 @@ void AtomVecSphere::init()
 
   // check if optional radvary setting should have been set to 1
 
-  for (auto &ifix : modify->get_fix_by_style("^adapt")) {
-    if (ifix->diam_flag && (radvary == 0))
-      error->all(FLERR, "Fix {} changes atom radii but atom_style sphere is not dynamic",
-        ifix->style);
-  }
+  if (radvary == 0)
+    for (const auto &ifix : modify->get_fix_by_style("^adapt")) {
+      if (ifix->diam_flag)
+        error->all(FLERR, "Fix {} changes atom radii but atom_style sphere is not dynamic",
+                   ifix->style);
+    }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -79,6 +79,7 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   maxexchange_dynamic = 0;
   pre_exchange_migrate = 0;
   stores_ids = 0;
+  diam_flag = 0;
 
   scalar_flag = vector_flag = array_flag = 0;
   peratom_flag = local_flag = pergrid_flag = 0;

--- a/src/fix.h
+++ b/src/fix.h
@@ -79,6 +79,7 @@ class Fix : protected Pointers {
   int maxexchange_dynamic;     // 1 if fix sets maxexchange dynamically
   int pre_exchange_migrate;    // 1 if fix migrates atoms in pre_exchange()
   int stores_ids;              // 1 if fix stores atom IDs
+  int diam_flag;               // 1 if fix may change partical diameter
 
   int scalar_flag;                 // 0/1 if compute_scalar() function exists
   int vector_flag;                 // 0/1 if compute_vector() function exists

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -90,7 +90,6 @@ FixAdapt::FixAdapt(LAMMPS *lmp, int narg, char **arg) :
   // parse keywords
 
   nadapt = 0;
-  diamflag = 0;
   chgflag = 0;
 
   iarg = 4;
@@ -149,7 +148,7 @@ FixAdapt::FixAdapt(LAMMPS *lmp, int narg, char **arg) :
       if (strcmp(arg[iarg+1],"diameter") == 0 ||
           strcmp(arg[iarg+1],"diameter/disc") == 0) {
         adapt[nadapt].atomparam = DIAMETER;
-        diamflag = 1;
+        diam_flag = 1;
         discflag = 0;
         if (strcmp(arg[iarg+1],"diameter/disc") == 0) discflag = 1;
       } else if (strcmp(arg[iarg+1],"charge") == 0) {
@@ -190,7 +189,7 @@ FixAdapt::FixAdapt(LAMMPS *lmp, int narg, char **arg) :
   // then previous step scale factors are written to restart file
   // initialize them here in case one is used and other is never defined
 
-  if (scaleflag && (diamflag || chgflag)) restart_global = 1;
+  if (scaleflag && (diam_flag || chgflag)) restart_global = 1;
   previous_diam_scale = previous_chg_scale = 1.0;
 
   // allocate pair style arrays
@@ -260,7 +259,7 @@ int FixAdapt::setmask()
 void FixAdapt::post_constructor()
 {
   if (!resetflag) return;
-  if (!diamflag && !chgflag) return;
+  if (!diam_flag && !chgflag) return;
 
   // new id = fix-ID + FIX_STORE_ATTRIBUTE
   // new fix group = group for this fix
@@ -268,7 +267,7 @@ void FixAdapt::post_constructor()
   id_fix_diam = nullptr;
   id_fix_chg = nullptr;
 
-  if (diamflag && atom->radius_flag) {
+  if (diam_flag && atom->radius_flag) {
     id_fix_diam = utils::strdup(id + std::string("_FIX_STORE_DIAM"));
     fix_diam = dynamic_cast<FixStoreAtom *>(
       modify->add_fix(fmt::format("{} {} STORE/ATOM 1 0 0 1", id_fix_diam,group->names[igroup])));
@@ -707,7 +706,7 @@ void FixAdapt::restore_settings()
       *kspace_scale = 1.0;
 
     } else if (ad->which == ATOM) {
-      if (diamflag) {
+      if (diam_flag) {
         double scale;
 
         double *vec = fix_diam->vstore;

--- a/src/fix_adapt.h
+++ b/src/fix_adapt.h
@@ -26,7 +26,6 @@ namespace LAMMPS_NS {
 
 class FixAdapt : public Fix {
  public:
-  int diamflag;    // 1 if atom diameters will vary, for AtomVecGranular
   int chgflag;
 
   FixAdapt(class LAMMPS *, int, char **);


### PR DESCRIPTION
**Summary**

Simplify the handling of the diamflag setting in fix adapt and fix adapt/fep by moving the flag to the base class.
This avoids some code complexity and complications from fix adapt/fep being optional.

**Related Issue(s)**

This fixes a bug introduced in PR #3855 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
