### PR TITLE
More fine grained monitoring if computes were initialized

### DIFF
--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -297,9 +297,10 @@ int DumpVTK::count()
   // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->first_update == 0)
-      error->all(FLERR,"Dump compute cannot be invoked before first run");
     for (i = 0; i < ncompute; i++) {
+      if (!compute[i]->is_initialized())
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+          compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute[i]->compute_peratom();
         compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;

--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -299,7 +299,7 @@ int DumpVTK::count()
   if (ncompute) {
     for (i = 0; i < ncompute; i++) {
       if (!compute[i]->is_initialized())
-        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialization by a run",
           compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute[i]->compute_peratom();

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -74,6 +74,7 @@ Compute::Compute(LAMMPS *lmp, int narg, char **arg) :
   dynamic = 0;
   dynamic_group_allow = 1;
 
+  initialized_flag = 0;
   invoked_scalar = invoked_vector = invoked_array = -1;
   invoked_peratom = invoked_local = -1;
   invoked_flag = INVOKED_NONE;
@@ -107,6 +108,15 @@ Compute::~Compute()
   delete[] id;
   delete[] style;
   memory->destroy(tlist);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Compute::init_flags()
+{
+  initialized_flag = 1;
+  invoked_scalar = invoked_vector = invoked_array = -1;
+  invoked_peratom = invoked_local = -1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute.h
+++ b/src/compute.h
@@ -62,7 +62,7 @@ class Compute : protected Pointers {
   int size_local_rows;    // rows in local vector or array
   int size_local_cols;    // 0 = vector, N = columns in local array
 
-  int pergrid_flag;       // 0/1 if compute_pergrid() function exists
+  int pergrid_flag;    // 0/1 if compute_pergrid() function exists
 
   int extscalar;    // 0/1 if global scalar is intensive/extensive
   int extvector;    // 0/1/-1 if global vector is all int/ext/extlist
@@ -88,6 +88,7 @@ class Compute : protected Pointers {
   int maxtime;      // max # of entries time list can hold
   bigint *tlist;    // list of timesteps the Compute is called on
 
+  int initialized_flag;      // 1 if compute is initialized, 0 if not
   int invoked_flag;          // non-zero if invoked or accessed this step, 0 if not
   bigint invoked_scalar;     // last timestep on which compute_scalar() was invoked
   bigint invoked_vector;     // ditto for compute_vector()
@@ -114,6 +115,7 @@ class Compute : protected Pointers {
   void modify_params(int, char **);
   virtual void reset_extra_dof();
 
+  void init_flags();
   virtual void init() = 0;
   virtual void init_list(int, class NeighList *) {}
   virtual void setup() {}
@@ -160,6 +162,8 @@ class Compute : protected Pointers {
   void addstep(bigint);
   int matchstep(bigint);
   void clearstep();
+
+  bool is_initialized() const { return initialized_flag == 1; }
 
   virtual double memory_usage() { return 0.0; }
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -562,9 +562,10 @@ int DumpCustom::count()
   // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->first_update == 0)
-      error->all(FLERR,"Dump compute cannot be invoked before first run");
     for (i = 0; i < ncompute; i++) {
+      if (!compute[i]->is_initialized())
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+          compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute[i]->compute_peratom();
         compute[i]->invoked_flag |= Compute::INVOKED_PERATOM;

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -564,7 +564,7 @@ int DumpCustom::count()
   if (ncompute) {
     for (i = 0; i < ncompute; i++) {
       if (!compute[i]->is_initialized())
-        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialization by a run",
           compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_PERATOM)) {
         compute[i]->compute_peratom();

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -527,9 +527,10 @@ int DumpGrid::count()
   // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->first_update == 0)
-      error->all(FLERR,"Dump compute cannot be invoked before first run");
     for (i = 0; i < ncompute; i++) {
+      if (!compute[i]->is_initialized())
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+          compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_PERGRID)) {
         compute[i]->compute_pergrid();
         compute[i]->invoked_flag |= Compute::INVOKED_PERGRID;

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -529,7 +529,7 @@ int DumpGrid::count()
   if (ncompute) {
     for (i = 0; i < ncompute; i++) {
       if (!compute[i]->is_initialized())
-        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialization by a run",
           compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_PERGRID)) {
         compute[i]->compute_pergrid();

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -669,7 +669,7 @@ void DumpImage::write()
     if (grid_compute) {
       if (!grid_compute->is_initialized())
         error->all(FLERR,"Grid compute ID {} used in dump image cannot be invoked "
-                   "before initialized by a run", grid_compute->id);
+                   "before initialization by a run", grid_compute->id);
       if (!(grid_compute->invoked_flag & Compute::INVOKED_PERGRID)) {
         grid_compute->compute_pergrid();
         grid_compute->invoked_flag |= Compute::INVOKED_PERGRID;

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -667,8 +667,9 @@ void DumpImage::write()
     // cannot invoke before first run, otherwise invoke if necessary
 
     if (grid_compute) {
-      if (update->first_update == 0)
-        error->all(FLERR,"Grid compute used in dump image cannot be invoked before first run");
+      if (!grid_compute->is_initialized())
+        error->all(FLERR,"Grid compute ID {} used in dump image cannot be invoked "
+                   "before initialized by a run", grid_compute->id);
       if (!(grid_compute->invoked_flag & Compute::INVOKED_PERGRID)) {
         grid_compute->compute_pergrid();
         grid_compute->invoked_flag |= Compute::INVOKED_PERGRID;

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -330,7 +330,7 @@ int DumpLocal::count()
   if (ncompute) {
     for (i = 0; i < ncompute; i++) {
       if (!compute[i]->is_initialized())
-        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialization by a run",
           compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_LOCAL)) {
         compute[i]->compute_local();

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -328,9 +328,10 @@ int DumpLocal::count()
   // cannot invoke before first run, otherwise invoke if necessary
 
   if (ncompute) {
-    if (update->first_update == 0)
-      error->all(FLERR,"Dump compute cannot be invoked before first run");
     for (i = 0; i < ncompute; i++) {
+      if (!compute[i]->is_initialized())
+        error->all(FLERR,"Dump compute ID {} cannot be invoked before initialized by a run",
+          compute[i]->id);
       if (!(compute[i]->invoked_flag & Compute::INVOKED_LOCAL)) {
         compute[i]->compute_local();
         compute[i]->invoked_flag |= Compute::INVOKED_LOCAL;

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -191,11 +191,7 @@ void Modify::init()
 
   for (i = 0; i < ncompute; i++) {
     compute[i]->init();
-    compute[i]->invoked_scalar = -1;
-    compute[i]->invoked_vector = -1;
-    compute[i]->invoked_array = -1;
-    compute[i]->invoked_peratom = -1;
-    compute[i]->invoked_local = -1;
+    compute[i]->init_flags();
   }
   addstep_compute_all(update->ntimestep);
 

--- a/src/reset_atoms_image.cpp
+++ b/src/reset_atoms_image.cpp
@@ -93,23 +93,22 @@ void ResetAtomsImage::command(int narg, char **arg)
                                    "c_ifmax_r_i_f[*] c_ifmin_r_i_f[*]");
 
   // trigger computes
-  // need to ensure update->first_update = 1
-  //   to allow this input script command prior to first run/minimize
-  //   this is b/c internal variables are evaulated which invoke computes
-  //   that will trigger an error unless first_update = 1
-  // reset update->first_update when done
+  // need to first initialize compute flags to allow this input script command prior
+  //   to a first run/minimize.   this is b/c internal variables are evaulated which
+  //   invoke computes that will trigger an error unless they are initialized
 
-  int first_update_saved = update->first_update;
-  update->first_update = 1;
-
+  frags->init_flags();
+  chunk->init_flags();
+  flags->init_flags();
+  ifmin->init_flags();
+  ifmax->init_flags();
+  cdist->init_flags();
   frags->compute_peratom();
   chunk->compute_peratom();
   flags->compute_peratom();
   ifmin->compute_array();
   ifmax->compute_array();
   cdist->compute_peratom();
-
-  update->first_update = first_update_saved;
 
   // reset image flags for atoms in group
 

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -1134,8 +1134,8 @@ void Thermo::check_temp(const std::string &keyword)
   if (!temperature)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init temperature",
                keyword);
-  if (update->first_update == 0)
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before first run",keyword);
+  if (!temperature->is_initialized())
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
   if (!(temperature->invoked_flag & Compute::INVOKED_SCALAR)) {
     temperature->compute_scalar();
     temperature->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1153,8 +1153,8 @@ void Thermo::check_pe(const std::string &keyword)
   if (!pe)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init potential energy",
                keyword);
-  if (update->first_update == 0)
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before first run",keyword);
+  if (!pe->is_initialized())
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
   if (!(pe->invoked_flag & Compute::INVOKED_SCALAR)) {
     pe->compute_scalar();
     pe->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1169,8 +1169,8 @@ void Thermo::check_press_scalar(const std::string &keyword)
 {
   if (!pressure)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init press", keyword);
-  if (update->first_update == 0)
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before first run",keyword);
+  if (!pressure->is_initialized())
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
   if (!(pressure->invoked_flag & Compute::INVOKED_SCALAR)) {
     pressure->compute_scalar();
     pressure->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1185,8 +1185,8 @@ void Thermo::check_press_vector(const std::string &keyword)
 {
   if (!pressure)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init press", keyword);
-  if (update->first_update == 0)
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before first run",keyword);
+  if (!pressure->is_initialized())
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
   if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
     pressure->compute_vector();
     pressure->invoked_flag |= Compute::INVOKED_VECTOR;

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -1135,7 +1135,7 @@ void Thermo::check_temp(const std::string &keyword)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init temperature",
                keyword);
   if (!temperature->is_initialized())
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialization by a run",keyword);
   if (!(temperature->invoked_flag & Compute::INVOKED_SCALAR)) {
     temperature->compute_scalar();
     temperature->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1154,7 +1154,7 @@ void Thermo::check_pe(const std::string &keyword)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init potential energy",
                keyword);
   if (!pe->is_initialized())
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialization by a run",keyword);
   if (!(pe->invoked_flag & Compute::INVOKED_SCALAR)) {
     pe->compute_scalar();
     pe->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1170,7 +1170,7 @@ void Thermo::check_press_scalar(const std::string &keyword)
   if (!pressure)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init press", keyword);
   if (!pressure->is_initialized())
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialization by a run",keyword);
   if (!(pressure->invoked_flag & Compute::INVOKED_SCALAR)) {
     pressure->compute_scalar();
     pressure->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1186,7 +1186,7 @@ void Thermo::check_press_vector(const std::string &keyword)
   if (!pressure)
     error->all(FLERR, "Thermo keyword {} in variable requires thermo to use/init press", keyword);
   if (!pressure->is_initialized())
-    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialized by run",keyword);
+    error->all(FLERR,"Thermo keyword {} cannot be invoked before initialization by a run",keyword);
   if (!(pressure->invoked_flag & Compute::INVOKED_VECTOR)) {
     pressure->compute_vector();
     pressure->invoked_flag |= Compute::INVOKED_VECTOR;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1506,7 +1506,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
         if (nbracket == 0 && compute->scalar_flag && lowercase) {
 
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
             compute->compute_scalar();
             compute->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1528,7 +1529,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
               compute->size_vector_variable == 0)
             print_var_error(FLERR,"Variable formula compute vector is accessed out-of-range",ivar,0);
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
             compute->invoked_flag |= Compute::INVOKED_VECTOR;
@@ -1554,7 +1556,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (index2 > compute->size_array_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
             compute->invoked_flag |= Compute::INVOKED_ARRAY;
@@ -1581,7 +1584,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (compute->size_vector == 0)
             print_var_error(FLERR,"Variable formula compute vector is zero length",ivar);
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
             compute->invoked_flag |= Compute::INVOKED_VECTOR;
@@ -1605,7 +1609,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (compute->size_array_rows == 0)
             print_var_error(FLERR,"Variable formula compute array is zero length",ivar);
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
             compute->invoked_flag |= Compute::INVOKED_ARRAY;
@@ -1624,7 +1629,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
                    compute->size_peratom_cols == 0) {
 
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -1641,7 +1647,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (index2 > compute->size_peratom_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -1664,7 +1671,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (treetype == VECTOR)
             print_var_error(FLERR,"Per-atom compute in vector-style variable formula",ivar);
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -1688,7 +1696,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (index1 > compute->size_peratom_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
           if (!compute->is_initialized())
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                            "initialization by a run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -4164,7 +4173,8 @@ int Variable::special_function(char *word, char *contents, Tree **tree, Tree **t
       }
       if (index == 0 && compute->vector_flag) {
         if (!compute->is_initialized())
-          print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+          print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                          "initialization by a run",ivar);
         if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
           compute->invoked_flag |= Compute::INVOKED_VECTOR;
@@ -4175,7 +4185,8 @@ int Variable::special_function(char *word, char *contents, Tree **tree, Tree **t
         if (index > compute->size_array_cols)
           print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
         if (!compute->is_initialized())
-          print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
+          print_var_error(FLERR,"Variable formula compute cannot be invoked before "
+                          "initialization by a run",ivar);
         if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
           compute->invoked_flag |= Compute::INVOKED_ARRAY;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1505,8 +1505,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
         if (nbracket == 0 && compute->scalar_flag && lowercase) {
 
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_SCALAR)) {
             compute->compute_scalar();
             compute->invoked_flag |= Compute::INVOKED_SCALAR;
@@ -1527,8 +1527,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (index1 > compute->size_vector &&
               compute->size_vector_variable == 0)
             print_var_error(FLERR,"Variable formula compute vector is accessed out-of-range",ivar,0);
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
             compute->invoked_flag |= Compute::INVOKED_VECTOR;
@@ -1553,8 +1553,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
           if (index2 > compute->size_array_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
             compute->invoked_flag |= Compute::INVOKED_ARRAY;
@@ -1580,8 +1580,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Compute global vector in atom-style variable formula",ivar);
           if (compute->size_vector == 0)
             print_var_error(FLERR,"Variable formula compute vector is zero length",ivar);
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
             compute->compute_vector();
             compute->invoked_flag |= Compute::INVOKED_VECTOR;
@@ -1604,8 +1604,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Compute global vector in atom-style variable formula",ivar);
           if (compute->size_array_rows == 0)
             print_var_error(FLERR,"Variable formula compute array is zero length",ivar);
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
             compute->compute_array();
             compute->invoked_flag |= Compute::INVOKED_ARRAY;
@@ -1623,8 +1623,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
         } else if (nbracket == 1 && compute->peratom_flag &&
                    compute->size_peratom_cols == 0) {
 
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -1640,8 +1640,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           if (index2 > compute->size_peratom_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -1663,8 +1663,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Per-atom compute in equal-style variable formula",ivar);
           if (treetype == VECTOR)
             print_var_error(FLERR,"Per-atom compute in vector-style variable formula",ivar);
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -1687,8 +1687,8 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             print_var_error(FLERR,"Per-atom compute in vector-style variable formula",ivar);
           if (index1 > compute->size_peratom_cols)
             print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-          if (update->first_update == 0)
-            print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+          if (!compute->is_initialized())
+            print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
           if (!(compute->invoked_flag & Compute::INVOKED_PERATOM)) {
             compute->compute_peratom();
             compute->invoked_flag |= Compute::INVOKED_PERATOM;
@@ -4163,8 +4163,8 @@ int Variable::special_function(char *word, char *contents, Tree **tree, Tree **t
         print_var_error(FLERR,mesg,ivar);
       }
       if (index == 0 && compute->vector_flag) {
-        if (update->first_update == 0)
-          print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+        if (!compute->is_initialized())
+          print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
         if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
           compute->compute_vector();
           compute->invoked_flag |= Compute::INVOKED_VECTOR;
@@ -4174,8 +4174,8 @@ int Variable::special_function(char *word, char *contents, Tree **tree, Tree **t
       } else if (index && compute->array_flag) {
         if (index > compute->size_array_cols)
           print_var_error(FLERR,"Variable formula compute array is accessed out-of-range",ivar,0);
-        if (update->first_update == 0)
-          print_var_error(FLERR,"Variable formula compute cannot be invoked before first run",ivar);
+        if (!compute->is_initialized())
+          print_var_error(FLERR,"Variable formula compute cannot be invoked before initialized by run",ivar);
         if (!(compute->invoked_flag & Compute::INVOKED_ARRAY)) {
           compute->compute_array();
           compute->invoked_flag |= Compute::INVOKED_ARRAY;


### PR DESCRIPTION
**Summary**

This updates and refactors the changes from PR #3771 to handle cases of computes being created *after* a run.

**Author(s)**

Axel Kohlmeyer and Steve Plimpton, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

This introduces a flag inside the Compute class that tracks whether the compute was initialized by a run or minimize or something else that calls `Modify::init()`. This flag can be queried with a new `Compute::is_initialized()` method.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

