### PR TITLE
Add missing path to Kokkos Perlmutter Makefile

### DIFF
--- a/src/MAKE/MACHINES/Makefile.perlmutter_kokkos
+++ b/src/MAKE/MACHINES/Makefile.perlmutter_kokkos
@@ -56,7 +56,7 @@ MPI_LIB = -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_cud
 
 FFT_INC = -DFFT_CUFFT
 FFT_PATH = 
-FFT_LIB = -lcufft
+FFT_LIB = ${CRAY_CUDATOOLKIT_POST_LINK_OPTS} -lcufft
 
 # JPEG and/or PNG library
 # see discussion in Section 3.5.4 of manual


### PR DESCRIPTION
**Summary**

Add missing path to Kokkos Perlmutter Makefile

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Rahul Gayatri (NERSC)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes