### PR TITLE
CMake build option for installing KOKKOS headers

### DIFF
--- a/cmake/Modules/Packages/KOKKOS.cmake
+++ b/cmake/Modules/Packages/KOKKOS.cmake
@@ -26,6 +26,8 @@ endif()
 ########################################################################
 
 option(EXTERNAL_KOKKOS "Build against external kokkos library" OFF)
+option(Kokkos_INSTALL_HEADER "Intall kokkos header files" OFF)
+mark_as_advanced(Kokkos_INSTALL_HEADER)
 option(DOWNLOAD_KOKKOS "Download the KOKKOS library instead of using the bundled one" OFF)
 if(DOWNLOAD_KOKKOS)
   # extract Kokkos-related variables and values so we can forward them to the Kokkos library build
@@ -89,7 +91,11 @@ else()
   if(CMAKE_REQUEST_PIC)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   endif()
-  add_subdirectory(${LAMMPS_LIB_KOKKOS_SRC_DIR} ${LAMMPS_LIB_KOKKOS_BIN_DIR} EXCLUDE_FROM_ALL)
+  if(Kokkos_INSTALL_HEADER)
+    add_subdirectory(${LAMMPS_LIB_KOKKOS_SRC_DIR} ${LAMMPS_LIB_KOKKOS_BIN_DIR})
+  else()
+    add_subdirectory(${LAMMPS_LIB_KOKKOS_SRC_DIR} ${LAMMPS_LIB_KOKKOS_BIN_DIR} EXCLUDE_FROM_ALL)
+  endif()
 
   set(Kokkos_INCLUDE_DIRS ${LAMMPS_LIB_KOKKOS_SRC_DIR}/core/src
                           ${LAMMPS_LIB_KOKKOS_SRC_DIR}/containers/src


### PR DESCRIPTION
**Summary**

This PR added an optional cmake variable (`Kokkos_INSTALL_HEADER`) that allows installing KOKKOS header and lib (off by default). By default, the change preserves the behavior made by commit  5878040f26b273c7ff9f56fe6c70c6d194b5d80c "skip undesired 'make install' targets from bundled Kokkos library". 

This feature, when turned on, enables users to build LAMMPS as a shared lib with KOKKOS support and then have direct access to LAMMPS KOKKOS API. An example use cases is the `lammps dlext` package (https://github.com/SSAGESLabs/lammps-dlext)

**Related Issue(s)**

N/A

**Author(s)**

Trung Nguyen (U Chicago)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Should maintain backward compatibility.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


