### PR TITLE
Update fmtlib to version 10.1

### DIFF
--- a/lib/python/Makefile.lammps
+++ b/lib/python/Makefile.lammps
@@ -1,7 +1,14 @@
 # Settings that the LAMMPS build will import when this package library is used
 # See the README file for more explanation
-
-python_SYSINC = $(shell which python-config > /dev/null 2>&1 && python-config --includes || :)
-python_SYSLIB = $(shell which python-config > /dev/null 2>&1 && python-config --ldflags --embed > /dev/null 2>&1 && python-config --ldflags --embed || (which python-config > /dev/null 2>&1 && python-config --ldflags || :) )
-python_SYSPATH =
+ifeq ($(shell type python3 >/dev/null 2>&1; echo $$?), 0)
+PYTHON=python3
+PYTHONCONFIG = python3-config
+else
+PYTHONCONFIG = python-config
 PYTHON=python
+endif
+
+
+python_SYSINC = $(shell which $(PYTHONCONFIG) > /dev/null 2>&1 && $(PYTHONCONFIG) --includes || :)
+python_SYSLIB = $(shell which $(PYTHONCONFIG) > /dev/null 2>&1 && $(PYTHONCONFIG) --ldflags --embed > /dev/null 2>&1 && $(PYTHONCONFIG) --ldflags --embed || (which $(PYTHONCONFIG) > /dev/null 2>&1 && $(PYTHONCONFIG) --ldflags || :) )
+python_SYSPATH =

--- a/src/fmt/core.h
+++ b/src/fmt/core.h
@@ -13,11 +13,12 @@
 #include <cstring>  // std::strlen
 #include <iterator>
 #include <limits>
+#include <memory>  // std::addressof
 #include <string>
 #include <type_traits>
 
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
-#define FMT_VERSION 100001
+#define FMT_VERSION 100100
 
 #if defined(__clang__) && !defined(__ibmxl__)
 #  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
@@ -1290,9 +1291,9 @@ template <typename Context> class value {
   FMT_INLINE value(const named_arg_info<char_type>* args, size_t size)
       : named_args{args, size} {}
 
-  template <typename T> FMT_CONSTEXPR FMT_INLINE value(T& val) {
+  template <typename T> FMT_CONSTEXPR20 FMT_INLINE value(T& val) {
     using value_type = remove_const_t<T>;
-    custom.value = const_cast<value_type*>(&val);
+    custom.value = const_cast<value_type*>(std::addressof(val));
     // Get the formatter type through the context to allow different contexts
     // have different extension points, e.g. `formatter<T>` for `format` and
     // `printf_formatter<T>` for `printf`.
@@ -1669,6 +1670,7 @@ template <typename Context> class basic_format_arg {
   ``vis(value)`` will be called with the value of type ``double``.
   \endrst
  */
+// DEPRECATED!
 FMT_EXPORT
 template <typename Visitor, typename Context>
 FMT_CONSTEXPR FMT_INLINE auto visit_format_arg(

--- a/src/fmt/format.h
+++ b/src/fmt/format.h
@@ -920,7 +920,7 @@ class basic_memory_buffer final : public detail::buffer<T> {
  private:
   T store_[SIZE];
 
-  // Don't inherit from Allocator avoid generating type_info for it.
+  // Don't inherit from Allocator to avoid generating type_info for it.
   FMT_NO_UNIQUE_ADDRESS Allocator alloc_;
 
   // Deallocate memory allocated by the buffer.
@@ -3178,7 +3178,8 @@ FMT_CONSTEXPR20 inline void format_dragon(basic_fp<uint128_t> value,
       }
       if (buf[0] == overflow) {
         buf[0] = '1';
-        ++exp10;
+        if ((flags & dragon::fixed) != 0) buf.push_back('0');
+        else ++exp10;
       }
       return;
     }

--- a/tools/singularity/ubuntu20.04.def
+++ b/tools/singularity/ubuntu20.04.def
@@ -54,6 +54,7 @@ From: ubuntu:20.04
         python3-setuptools \
         python3-virtualenv \
         python3-venv \
+        python-is-python3 \
         rsync \
         ssh \
         texlive \

--- a/tools/singularity/ubuntu20.04_amd_rocm.def
+++ b/tools/singularity/ubuntu20.04_amd_rocm.def
@@ -83,6 +83,7 @@ From: ubuntu:20.04
         python3-setuptools \
         python3-virtualenv \
         python3-venv \
+        python-is-python3 \
         rsync \
         ssh \
         vim-nox \

--- a/tools/singularity/ubuntu20.04_gpu.def
+++ b/tools/singularity/ubuntu20.04_gpu.def
@@ -88,6 +88,7 @@ From: ubuntu:20.04
         python3-setuptools \
         python3-virtualenv \
         python3-venv \
+        python-is-python3 \
         rsync \
         ssh \
         vim-nox \

--- a/tools/singularity/ubuntu20.04_intel_opencl.def
+++ b/tools/singularity/ubuntu20.04_intel_opencl.def
@@ -53,6 +53,7 @@ From: ubuntu:20.04
         python3-setuptools \
         python3-virtualenv \
         python3-venv \
+        python-is-python3 \
         rsync \
         ssh \
         vim-nox \

--- a/tools/singularity/ubuntu20.04_nvidia.def
+++ b/tools/singularity/ubuntu20.04_nvidia.def
@@ -56,6 +56,7 @@ From: nvidia/cuda:11.6.2-devel-ubuntu20.04
         python3-setuptools \
         python3-virtualenv \
         python3-venv \
+        python-is-python3 \
         rsync \
         ssh \
         vim-nox \

--- a/tools/singularity/ubuntu20.04_oneapi.def
+++ b/tools/singularity/ubuntu20.04_oneapi.def
@@ -52,6 +52,7 @@ From: ubuntu:20.04
         python3-setuptools \
         python3-virtualenv \
         python3-venv \
+        python-is-python3 \
         rsync \
         ssh \
         texlive \

--- a/tools/singularity/ubuntu22.04.def
+++ b/tools/singularity/ubuntu22.04.def
@@ -54,6 +54,7 @@ From: ubuntu:22.04
         python3-setuptools \
         python3-virtualenv \
         python3-venv \
+        python-is-python3 \
         rsync \
         ssh \
         texlive \


### PR DESCRIPTION
**Summary**

This updates the embedded fmtlib version to the 10.1 release

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

