### PR TITLE
Fix bug in Kokkos ReaxFF on GPUs when border comm is on host

### DIFF
--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -980,9 +980,12 @@ void CommKokkos::borders()
   } else {
     atomKK->sync(Host,ALL_MASK);
     k_sendlist.sync<LMPHostType>();
-    k_sendlist.modify<LMPHostType>();
-    atomKK->modified(Host,ALL_MASK); // needed here for atom map
+    int prev_auto_sync = lmp->kokkos->auto_sync;
+    lmp->kokkos->auto_sync = 1;
     CommBrick::borders();
+    lmp->kokkos->auto_sync = prev_auto_sync;
+    k_sendlist.modify<LMPHostType>();
+    atomKK->modified(Host,ALL_MASK);
   }
 
   if (comm->nprocs == 1 && !ghost_velocity && !forward_comm_classic)


### PR DESCRIPTION
**Summary**

Fix bug in Kokkos ReaxFF on GPUs when border comm is on host. The previous attempt (8ef4e93) was insufficient.

**Related Issue(s)**

Fixes #3895

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes