### PR TITLE
Bug fixes for fix srd

### DIFF
--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -674,7 +674,7 @@ void FixSRD::pre_neighbor()
           hi = nbin2z - 1;
         }
 
-        for (iz = lo; iz < hi; iz++)
+        for (iz = lo; iz <= hi; iz++)
           for (ix = 0; ix < nbin2x; ix++)
             for (iy = 0; iy < nbin2y; iy++) {
               ibin = iz * nbin2y * nbin2x + iy * nbin2x + ix;
@@ -1423,6 +1423,7 @@ void FixSRD::collisions_multi()
   tagint *tag = atom->tag;
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
+  Big* bigfirst;
 
   for (i = 0; i < nlocal; i++) {
     if (!(mask[i] & groupbit)) continue;
@@ -1443,8 +1444,8 @@ void FixSRD::collisions_multi()
         k = binbig[ibin][m];
         big = &biglist[k];
         j = big->index;
-        if (j == jlast) continue;
         type = big->type;
+        if ((j == jlast) && (type == typefirst)) continue;
 
         if (type == SPHERE)
           inside = inside_sphere(x[i], x[j], big);
@@ -1498,6 +1499,7 @@ void FixSRD::collisions_multi()
             t_first = t_remain;
             jfirst = j;
             typefirst = type;
+            bigfirst = big;
             xscollfirst[0] = xscoll[0];
             xscollfirst[1] = xscoll[1];
             xscollfirst[2] = xscoll[2];
@@ -1514,6 +1516,7 @@ void FixSRD::collisions_multi()
       if (t_first == 0.0) break;
       j = jlast = jfirst;
       type = typefirst;
+      big = bigfirst;
       xscoll[0] = xscollfirst[0];
       xscoll[1] = xscollfirst[1];
       xscoll[2] = xscollfirst[2];


### PR DESCRIPTION
**Summary**

Fixes several bugs for fix srd:
- When an SRD particle undergoes multiple collisions with a sphere and a wall in the same streaming step, collisions were sometimes not handled correctly
- Collisions with fix wall/srd walls in the z-direction could be completely missed due to search bins being excluded (`<` instead of `<=` in bin range search for z-direction walls)

**Author(s)**

Dan Bolintineanu, Sandia, dsbolin@sandia.gov

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

None


**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
