### PR TITLE
Add info for on-line manual versions to Manaul home page

### DIFF
--- a/doc/src/Manual.rst
+++ b/doc/src/Manual.rst
@@ -23,10 +23,23 @@ coordinated.
 
 ----------
 
-The content for this manual is part of the LAMMPS distribution.  The
-online version always corresponds to the latest feature release version.
-If needed, you can build a local copy of the manual as HTML pages or a
-PDF file by following the steps on the :doc:`Build_manual` page.  If you
+The content for this manual is part of the LAMMPS distribution in its
+doc directory.
+
+* The version of the manual on the LAMMPS website corresponds to the
+  latest LAMMPS feature release.  It is available at:
+  `https://docs.lammps.org/ <https://docs.lammps.org/>`_.
+* A version of the manual corresponding to the latest LAMMPS stable
+  release (state of the *stable* branch on GitHub) is available online
+  at: `https://docs.lammps.org/stable/
+  <https://docs.lammps.org/stable/>`_
+* A version of the manual with the features most recently added to
+  LAMMPS (state of the *develop* branch on GitHub) is available at:
+  `https://docs.lammps.org/latest/ <https://docs.lammps.org/latest/>`_
+
+If needed, you can build a copy on your local machine of the manual
+(HTML pages or PDF file) for the version of LAMMPS you have
+downloaded.  Follow the steps on the :doc:`Build_manual` page.  If you
 have difficulties viewing the pages, please :ref:`see this note
 <webbrowser>`.
 


### PR DESCRIPTION
**Summary**

Add info from the Build_manual page to the Manual home page as well

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


