### PR TITLE
Initialize ADIOS dumps only the first time when used in multiple runs (for custom/adios dump style)

### DIFF
--- a/src/ADIOS/dump_atom_adios.cpp
+++ b/src/ADIOS/dump_atom_adios.cpp
@@ -281,8 +281,8 @@ void DumpAtomADIOS::init_style()
       auto nstreams = std::to_string(num_aggregators);
       internal->io.SetParameters({{"substreams", nstreams}});
       if (me == 0)
-        utils::logmesg(lmp, "ADIOS method for {} is n-to-m (aggregation with {} writers)\n", filename,
-                       nstreams);
+        utils::logmesg(lmp, "ADIOS method for {} is n-to-m (aggregation with {} writers)\n",
+                       filename, nstreams);
     }
 
     internal->io.DefineVariable<uint64_t>("ntimestep");
@@ -325,6 +325,6 @@ void DumpAtomADIOS::init_style()
     // it will be correctly defined at the moment of write
     size_t UnknownSizeYet = 1;
     internal->varAtoms = internal->io.DefineVariable<double>(
-      "atoms", {UnknownSizeYet, nColumns}, {UnknownSizeYet, 0}, {UnknownSizeYet, nColumns});
+        "atoms", {UnknownSizeYet, nColumns}, {UnknownSizeYet, 0}, {UnknownSizeYet, nColumns});
   }
 }

--- a/src/ADIOS/dump_custom_adios.cpp
+++ b/src/ADIOS/dump_custom_adios.cpp
@@ -290,58 +290,60 @@ void DumpCustomADIOS::init_style()
 
   /* Define the group of variables for the atom style here since it's a fixed
    * set */
-  internal->io = internal->ad->DeclareIO(internal->ioName);
-  if (!internal->io.InConfigFile()) {
-    // if not defined by user, we can change the default settings
-    // BPFile is the default writer
-    internal->io.SetEngine("BPFile");
-    int num_aggregators = multiproc;
-    if (num_aggregators == 0) num_aggregators = 1;
-    auto nstreams = std::to_string(num_aggregators);
-    internal->io.SetParameters({{"substreams", nstreams}});
-    if (me == 0)
-      utils::logmesg(lmp, "ADIOS method for {} is n-to-m (aggregation with {} writers)\n", filename,
-                     nstreams);
+  if (!internal->io) {
+    internal->io = internal->ad->DeclareIO(internal->ioName);
+    if (!internal->io.InConfigFile()) {
+      // if not defined by user, we can change the default settings
+      // BPFile is the default writer
+      internal->io.SetEngine("BPFile");
+      int num_aggregators = multiproc;
+      if (num_aggregators == 0) num_aggregators = 1;
+      auto nstreams = std::to_string(num_aggregators);
+      internal->io.SetParameters({{"substreams", nstreams}});
+      if (me == 0)
+        utils::logmesg(lmp, "ADIOS method for {} is n-to-m (aggregation with {} writers)\n",
+                       filename, nstreams);
+    }
+
+    internal->io.DefineVariable<uint64_t>("ntimestep");
+    internal->io.DefineVariable<uint64_t>("natoms");
+
+    internal->io.DefineVariable<int>("nprocs");
+    internal->io.DefineVariable<int>("ncolumns");
+
+    internal->io.DefineVariable<double>("boxxlo");
+    internal->io.DefineVariable<double>("boxxhi");
+    internal->io.DefineVariable<double>("boxylo");
+    internal->io.DefineVariable<double>("boxyhi");
+    internal->io.DefineVariable<double>("boxzlo");
+    internal->io.DefineVariable<double>("boxzhi");
+
+    internal->io.DefineVariable<double>("boxxy");
+    internal->io.DefineVariable<double>("boxxz");
+    internal->io.DefineVariable<double>("boxyz");
+
+    internal->io.DefineAttribute<int>("triclinic", domain->triclinic);
+
+    int *boundaryptr = reinterpret_cast<int *>(domain->boundary);
+    internal->io.DefineAttribute<int>("boundary", boundaryptr, 6);
+
+    auto nColumns = static_cast<size_t>(size_one);
+    internal->io.DefineAttribute<std::string>("columns", internal->columnNames.data(), nColumns);
+    internal->io.DefineAttribute<std::string>("columnstr", columns);
+    internal->io.DefineAttribute<std::string>("boundarystr", boundstr);
+    internal->io.DefineAttribute<std::string>("LAMMPS/dump_style", "custom");
+    internal->io.DefineAttribute<std::string>("LAMMPS/version", lmp->version);
+    internal->io.DefineAttribute<std::string>("LAMMPS/num_ver", std::to_string(lmp->num_ver));
+
+    internal->io.DefineVariable<uint64_t>("nme",
+                                          {adios2::LocalValueDim});    // local dimension variable
+    internal->io.DefineVariable<uint64_t>("offset",
+                                          {adios2::LocalValueDim});    // local dimension variable
+
+    // atom table size is not known at the moment
+    // it will be correctly defined at the moment of write
+    size_t UnknownSizeYet = 1;
+    internal->varAtoms = internal->io.DefineVariable<double>(
+        "atoms", {UnknownSizeYet, nColumns}, {UnknownSizeYet, 0}, {UnknownSizeYet, nColumns});
   }
-
-  internal->io.DefineVariable<uint64_t>("ntimestep");
-  internal->io.DefineVariable<uint64_t>("natoms");
-
-  internal->io.DefineVariable<int>("nprocs");
-  internal->io.DefineVariable<int>("ncolumns");
-
-  internal->io.DefineVariable<double>("boxxlo");
-  internal->io.DefineVariable<double>("boxxhi");
-  internal->io.DefineVariable<double>("boxylo");
-  internal->io.DefineVariable<double>("boxyhi");
-  internal->io.DefineVariable<double>("boxzlo");
-  internal->io.DefineVariable<double>("boxzhi");
-
-  internal->io.DefineVariable<double>("boxxy");
-  internal->io.DefineVariable<double>("boxxz");
-  internal->io.DefineVariable<double>("boxyz");
-
-  internal->io.DefineAttribute<int>("triclinic", domain->triclinic);
-
-  int *boundaryptr = reinterpret_cast<int *>(domain->boundary);
-  internal->io.DefineAttribute<int>("boundary", boundaryptr, 6);
-
-  auto nColumns = static_cast<size_t>(size_one);
-  internal->io.DefineAttribute<std::string>("columns", internal->columnNames.data(), nColumns);
-  internal->io.DefineAttribute<std::string>("columnstr", columns);
-  internal->io.DefineAttribute<std::string>("boundarystr", boundstr);
-  internal->io.DefineAttribute<std::string>("LAMMPS/dump_style", "custom");
-  internal->io.DefineAttribute<std::string>("LAMMPS/version", lmp->version);
-  internal->io.DefineAttribute<std::string>("LAMMPS/num_ver", std::to_string(lmp->num_ver));
-
-  internal->io.DefineVariable<uint64_t>("nme",
-                                        {adios2::LocalValueDim});    // local dimension variable
-  internal->io.DefineVariable<uint64_t>("offset",
-                                        {adios2::LocalValueDim});    // local dimension variable
-
-  // atom table size is not known at the moment
-  // it will be correctly defined at the moment of write
-  size_t UnknownSizeYet = 1;
-  internal->varAtoms = internal->io.DefineVariable<double>(
-      "atoms", {UnknownSizeYet, nColumns}, {UnknownSizeYet, 0}, {UnknownSizeYet, nColumns});
 }


### PR DESCRIPTION
Initialize ADIOS dumps only the first time when used in multiple runs (for custom/adios dump style)

**Summary**

For dump style `atom/adios` ADIOS is initialized only once, but for style `custom/adios` this wasn't so.
This causes runtime error like
```
[ADIOS2 EXCEPTION] <Core> <ADIOS> <DeclareIO> : IO atom declared twice
```
when one ADIOS-dump used for several `run` commands.
For style `atom/adios` this problem was fixed by commit `dc4301d`.

**Related Issue(s)**

There was an related issue on matsci forum [https://matsci.org/t/problems-with-adios-dump-style/45327](url)

**Author(s)**

Egor Perevoshchikov

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

There will be no backward compatibility problems

**Implementation Notes**

This change was tested by running LAMMPS with `custom/adios` dump style with multiple runs, no issues were found.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**


