### PR TITLE
Apply fix for hipfft paths in ROCm >= 6.0

### DIFF
--- a/src/KOKKOS/fftdata_kokkos.h
+++ b/src/KOKKOS/fftdata_kokkos.h
@@ -114,7 +114,7 @@
     typedef cufftDoubleComplex FFT_DATA;
   #endif
 #elif defined(FFT_HIPFFT)
-  #include "hipfft.h"
+  #include <hipfft/hipfft.h>
   #if defined(FFT_SINGLE)
     #define hipfftExec hipfftExecC2C
     #define HIPFFT_TYPE HIPFFT_C2C


### PR DESCRIPTION
**Summary**

According to the [ROCm documentation](https://rocm.docs.amd.com/en/latest/understand/file_reorg.html), the layout of ROCm is changing slightly for 6.0 and beyond.  The most important bit (for us) is:

```
#include<header_file.h> needs to be changed to #include <component/header_file.h>

For example: #include <hip_runtime.hpp> needs to change to #include <hip/hip_runtime.hpp>
```

This particular issue appears in the include for `hipfft.h`: 
https://github.com/lammps/lammps/blob/54286ce4dd498af0e5f4a98d09030d9d2f5ac08f/src/KOKKOS/fftdata_kokkos.h#L117

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

Nick Curtis [AMD]

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

I have tested this with ROCm 5.3.0 and internal builds for the upcoming ROCm 6.0, using both the cmake build system and the Makefile build system.

**Implementation Notes**

Note: I have not verified whether e.g., the GPU/HIP backend needs additional porting at this time.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

N/A
