### PR TITLE
Collected small changes and fixes

### DIFF
--- a/doc/src/Build_cmake.rst
+++ b/doc/src/Build_cmake.rst
@@ -177,13 +177,13 @@ configuration is selected with the *-C* flag:
 
    ctest -C Debug
 
-The CMake scripts in LAMMPS have basic support for being compiled using a
-multi-config build system, but not all of it has been ported.  This is in
-particular applicable to compiling packages that require additional libraries
-that would be downloaded and compiled by CMake.  The "windows" preset file
-tries to keep track of which packages can be compiled natively with the
-MSVC compilers out-of-the box.  Not all of those external libraries are
-portable to Windows, either.
+The CMake scripts in LAMMPS have basic support for being compiled using
+a multi-config build system, but not all of it has been ported.  This is
+in particular applicable to compiling packages that require additional
+libraries that would be downloaded and compiled by CMake.  The
+``windows.cmake`` preset file tries to keep track of which packages can
+be compiled natively with the MSVC compilers out-of-the box.  Not all of
+the external libraries are portable to Windows, either.
 
 
 Installing CMake

--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -722,9 +722,10 @@ This list was last updated for version 4.0.1 of the Kokkos library.
       ``cmake/presets`` folder, ``kokkos-serial.cmake``,
       ``kokkos-openmp.cmake``, ``kokkos-cuda.cmake``,
       ``kokkos-hip.cmake``, and ``kokkos-sycl.cmake``.  They will enable
-      the KOKKOS package and enable some hardware choice.  So to compile
-      with CUDA device parallelization (for GPUs with CC 5.0 and up)
-      with some common packages enabled, you can do the following:
+      the KOKKOS package and enable some hardware choices.  For GPU
+      support those preset files must be customized to match the
+      hardware used. So to compile with CUDA device parallelization with
+      some common packages enabled, you can do the following:
 
       .. code-block:: bash
 

--- a/doc/src/Build_package.rst
+++ b/doc/src/Build_package.rst
@@ -182,6 +182,7 @@ make a copy of one of them and modify it to suit your needs.
     cmake -C ../cmake/presets/all_on.cmake   [OPTIONS] ../cmake  # enable all packages
     cmake -C ../cmake/presets/all_off.cmake  [OPTIONS] ../cmake  # disable all packages
     mingw64-cmake -C ../cmake/presets/mingw-cross.cmake [OPTIONS] ../cmake  #  compile with MinGW cross-compilers
+    cmake -C ../cmake/presets/macos-multiarch.cmake [OPTIONS] ../cmake # compile serial multi-arch binaries on macOS
 
 Presets that have names starting with "windows" are specifically for
 compiling LAMMPS :doc:`natively on Windows <Build_windows>` and

--- a/lib/colvars/colvar.cpp
+++ b/lib/colvars/colvar.cpp
@@ -30,6 +30,7 @@ colvar::colvar()
   after_restart = false;
   kinetic_energy = 0.0;
   potential_energy = 0.0;
+  period = 0.0;
 
 #ifdef LEPTON
   dev_null = 0.0;

--- a/src/ELECTRODE/electrode_matrix.cpp
+++ b/src/ELECTRODE/electrode_matrix.cpp
@@ -84,7 +84,7 @@ void ElectrodeMatrix::compute_array(double **array, bool timer_flag)
   electrode_kspace->compute_matrix(&mpos[0], array, timer_flag);
   MPI_Barrier(world);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("KSpace time: {:.4g} s\n", MPI_Wtime() - kspace_time));
+    utils::logmesg(lmp, "KSpace time: {:.4g} s\n", MPI_Wtime() - kspace_time);
   //cout << array[0][0] << ", " << array[0][1] << endl;
   pair_contribution(array);
   //cout << array[0][0] << ", " << array[0][1] << endl;

--- a/src/ELECTRODE/electrode_vector.cpp
+++ b/src/ELECTRODE/electrode_vector.cpp
@@ -60,10 +60,10 @@ ElectrodeVector::~ElectrodeVector()
 {
   if (timer_flag && (comm->me == 0)) {
     try {
-      utils::logmesg(lmp, fmt::format("B time: {:.4g} s\n", b_time_total));
-      utils::logmesg(lmp, fmt::format("B kspace time: {:.4g} s\n", kspace_time_total));
-      utils::logmesg(lmp, fmt::format("B pair time: {:.4g} s\n", pair_time_total));
-      utils::logmesg(lmp, fmt::format("B boundary time: {:.4g} s\n", boundary_time_total));
+      utils::logmesg(lmp, "B time: {:.4g} s\n", b_time_total);
+      utils::logmesg(lmp, "B kspace time: {:.4g} s\n", kspace_time_total);
+      utils::logmesg(lmp, "B pair time: {:.4g} s\n", pair_time_total);
+      utils::logmesg(lmp, "B boundary time: {:.4g} s\n", boundary_time_total);
     } catch (std::exception &) {
     }
   }

--- a/src/ELECTRODE/pppm_electrode.cpp
+++ b/src/ELECTRODE/pppm_electrode.cpp
@@ -136,7 +136,7 @@ void PPPMElectrode::init()
   }
 
   if (order < 2 || order > MAXORDER)
-    error->all(FLERR, fmt::format("PPPM/electrode order cannot be < 2 or > {}", MAXORDER));
+    error->all(FLERR, "PPPM/electrode order cannot be < 2 or > {}", MAXORDER);
 
   // compute two charge force
 
@@ -816,7 +816,7 @@ void PPPMElectrode::one_step_multiplication(bigint *imat, double *greens_real, d
   memory->destroy(rho1d_j);
   MPI_Barrier(world);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("Single step time: {:.4g} s\n", MPI_Wtime() - step1_time));
+    utils::logmesg(lmp, "Single step time: {:.4g} s\n", MPI_Wtime() - step1_time);
 }
 
 /* ----------------------------------------------------------------------*/
@@ -917,7 +917,7 @@ void PPPMElectrode::two_step_multiplication(bigint *imat, double *greens_real, d
   }
   MPI_Barrier(world);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("step 1 time: {:.4g} s\n", MPI_Wtime() - step1_time));
+    utils::logmesg(lmp, "step 1 time: {:.4g} s\n", MPI_Wtime() - step1_time);
 
   // nested loop over electrode atoms i and j and stencil of i
   // in theory could reuse make_rho1d_j here -- but this step is already
@@ -958,7 +958,7 @@ void PPPMElectrode::two_step_multiplication(bigint *imat, double *greens_real, d
   MPI_Barrier(world);
   memory->destroy(gw);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("step 2 time: {:.4g} s\n", MPI_Wtime() - step2_time));
+    utils::logmesg(lmp, "step 2 time: {:.4g} s\n", MPI_Wtime() - step2_time);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/EXTRA-COMPUTE/compute_ackland_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ackland_atom.cpp
@@ -33,6 +33,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <utility>
 
 using namespace LAMMPS_NS;
 
@@ -346,35 +347,24 @@ void ComputeAcklandAtom::compute_peratom()
    2nd routine sorts auxiliary array at same time
 ------------------------------------------------------------------------- */
 
-#define SWAP(a,b)   tmp = a; (a) = b; (b) = tmp;
-#define ISWAP(a,b) itmp = a; (a) = b; (b) = itmp;
-
 void ComputeAcklandAtom::select(int k, int n, double *arr)
   {
   int i,ir,j,l,mid;
-  double a,tmp;
+  double a;
 
   arr--;
   l = 1;
   ir = n;
   while (true) {
     if (ir <= l+1) {
-      if (ir == l+1 && arr[ir] < arr[l]) {
-        SWAP(arr[l],arr[ir])
-      }
+      if (ir == l+1 && arr[ir] < arr[l]) std::swap(arr[l],arr[ir]);
       return;
     } else {
       mid=(l+ir) >> 1;
-      SWAP(arr[mid],arr[l+1])
-      if (arr[l] > arr[ir]) {
-        SWAP(arr[l],arr[ir])
-      }
-      if (arr[l+1] > arr[ir]) {
-        SWAP(arr[l+1],arr[ir])
-      }
-      if (arr[l] > arr[l+1]) {
-        SWAP(arr[l],arr[l+1])
-      }
+      std::swap(arr[mid],arr[l+1]);
+      if (arr[l] > arr[ir]) std::swap(arr[l],arr[ir]);
+      if (arr[l+1] > arr[ir]) std::swap(arr[l+1],arr[ir]);
+      if (arr[l] > arr[l+1]) std::swap(arr[l],arr[l+1]);
       i = l+1;
       j = ir;
       a = arr[l+1];
@@ -382,7 +372,7 @@ void ComputeAcklandAtom::select(int k, int n, double *arr)
         do i++; while (arr[i] < a);
         do j--; while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i],arr[j])
+        std::swap(arr[i],arr[j]);
       }
       arr[l+1] = arr[j];
       arr[j] = a;
@@ -396,8 +386,8 @@ void ComputeAcklandAtom::select(int k, int n, double *arr)
 
 void ComputeAcklandAtom::select2(int k, int n, double *arr, int *iarr)
 {
-  int i,ir,j,l,mid,ia,itmp;
-  double a,tmp;
+  int i,ir,j,l,mid,ia;
+  double a;
 
   arr--;
   iarr--;
@@ -406,25 +396,25 @@ void ComputeAcklandAtom::select2(int k, int n, double *arr, int *iarr)
   while (true) {
     if (ir <= l+1) {
       if (ir == l+1 && arr[ir] < arr[l]) {
-        SWAP(arr[l],arr[ir])
-        ISWAP(iarr[l],iarr[ir])
+        std::swap(arr[l],arr[ir]);
+        std::swap(iarr[l],iarr[ir]);
       }
       return;
     } else {
       mid=(l+ir) >> 1;
-      SWAP(arr[mid],arr[l+1])
-      ISWAP(iarr[mid],iarr[l+1])
+      std::swap(arr[mid],arr[l+1]);
+      std::swap(iarr[mid],iarr[l+1]);
       if (arr[l] > arr[ir]) {
-        SWAP(arr[l],arr[ir])
-        ISWAP(iarr[l],iarr[ir])
+        std::swap(arr[l],arr[ir]);
+        std::swap(iarr[l],iarr[ir]);
       }
       if (arr[l+1] > arr[ir]) {
-        SWAP(arr[l+1],arr[ir])
-        ISWAP(iarr[l+1],iarr[ir])
+        std::swap(arr[l+1],arr[ir]);
+        std::swap(iarr[l+1],iarr[ir]);
       }
       if (arr[l] > arr[l+1]) {
-        SWAP(arr[l],arr[l+1])
-        ISWAP(iarr[l],iarr[l+1])
+        std::swap(arr[l],arr[l+1]);
+        std::swap(iarr[l],iarr[l+1]);
       }
       i = l+1;
       j = ir;
@@ -434,8 +424,8 @@ void ComputeAcklandAtom::select2(int k, int n, double *arr, int *iarr)
         do i++; while (arr[i] < a);
         do j--; while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i],arr[j])
-        ISWAP(iarr[i],iarr[j])
+        std::swap(arr[i],arr[j]);
+        std::swap(iarr[i],iarr[j]);
       }
       arr[l+1] = arr[j];
       arr[j] = a;

--- a/src/EXTRA-COMPUTE/compute_basal_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_basal_atom.cpp
@@ -31,6 +31,7 @@
 #include "update.h"
 
 #include <cmath>
+#include <utility>
 
 using namespace LAMMPS_NS;
 
@@ -431,35 +432,24 @@ void ComputeBasalAtom::compute_peratom()
    2nd routine sorts auxiliary array at same time
 ------------------------------------------------------------------------- */
 
-#define SWAP(a,b)   tmp = a; (a) = b; (b) = tmp;
-#define ISWAP(a,b) itmp = a; (a) = b; (b) = itmp;
-
 void ComputeBasalAtom::select(int k, int n, double *arr)
   {
   int i,ir,j,l,mid;
-  double a,tmp;
+  double a;
 
   arr--;
   l = 1;
   ir = n;
   while (true) {
     if (ir <= l+1) {
-      if (ir == l+1 && arr[ir] < arr[l]) {
-        SWAP(arr[l],arr[ir])
-      }
+      if (ir == l+1 && arr[ir] < arr[l]) std::swap(arr[l],arr[ir]);
       return;
     } else {
       mid=(l+ir) >> 1;
-      SWAP(arr[mid],arr[l+1])
-      if (arr[l] > arr[ir]) {
-        SWAP(arr[l],arr[ir])
-      }
-      if (arr[l+1] > arr[ir]) {
-        SWAP(arr[l+1],arr[ir])
-      }
-      if (arr[l] > arr[l+1]) {
-        SWAP(arr[l],arr[l+1])
-      }
+      std::swap(arr[mid],arr[l+1]);
+      if (arr[l] > arr[ir]) std::swap(arr[l],arr[ir]);
+      if (arr[l+1] > arr[ir]) std::swap(arr[l+1],arr[ir]);
+      if (arr[l] > arr[l+1]) std::swap(arr[l],arr[l+1]);
       i = l+1;
       j = ir;
       a = arr[l+1];
@@ -467,7 +457,7 @@ void ComputeBasalAtom::select(int k, int n, double *arr)
         do i++; while (arr[i] < a);
         do j--; while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i],arr[j])
+        std::swap(arr[i],arr[j]);
       }
       arr[l+1] = arr[j];
       arr[j] = a;
@@ -481,8 +471,8 @@ void ComputeBasalAtom::select(int k, int n, double *arr)
 
 void ComputeBasalAtom::select2(int k, int n, double *arr, int *iarr)
 {
-  int i,ir,j,l,mid,ia,itmp;
-  double a,tmp;
+  int i,ir,j,l,mid,ia;
+  double a;
 
   arr--;
   iarr--;
@@ -491,25 +481,25 @@ void ComputeBasalAtom::select2(int k, int n, double *arr, int *iarr)
   while (true) {
     if (ir <= l+1) {
       if (ir == l+1 && arr[ir] < arr[l]) {
-        SWAP(arr[l],arr[ir])
-        ISWAP(iarr[l],iarr[ir])
+        std::swap(arr[l],arr[ir]);
+        std::swap(iarr[l],iarr[ir]);
       }
       return;
     } else {
       mid=(l+ir) >> 1;
-      SWAP(arr[mid],arr[l+1])
-      ISWAP(iarr[mid],iarr[l+1])
+      std::swap(arr[mid],arr[l+1]);
+      std::swap(iarr[mid],iarr[l+1]);
       if (arr[l] > arr[ir]) {
-        SWAP(arr[l],arr[ir])
-        ISWAP(iarr[l],iarr[ir])
+        std::swap(arr[l],arr[ir]);
+        std::swap(iarr[l],iarr[ir]);
       }
       if (arr[l+1] > arr[ir]) {
-        SWAP(arr[l+1],arr[ir])
-        ISWAP(iarr[l+1],iarr[ir])
+        std::swap(arr[l+1],arr[ir]);
+        std::swap(iarr[l+1],iarr[ir]);
       }
       if (arr[l] > arr[l+1]) {
-        SWAP(arr[l],arr[l+1])
-        ISWAP(iarr[l],iarr[l+1])
+        std::swap(arr[l],arr[l+1]);
+        std::swap(iarr[l],iarr[l+1]);
       }
       i = l+1;
       j = ir;
@@ -519,8 +509,8 @@ void ComputeBasalAtom::select2(int k, int n, double *arr, int *iarr)
         do i++; while (arr[i] < a);
         do j--; while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i],arr[j])
-        ISWAP(iarr[i],iarr[j])
+        std::swap(arr[i],arr[j]);
+        std::swap(iarr[i],iarr[j]);
       }
       arr[l+1] = arr[j];
       arr[j] = a;

--- a/src/EXTRA-COMPUTE/compute_hexorder_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_hexorder_atom.cpp
@@ -33,6 +33,7 @@
 #include <cmath>
 #include <complex>
 #include <cstring>
+#include <utility>
 
 #ifdef DBL_EPSILON
   #define MY_EPSILON (10.0*DBL_EPSILON)
@@ -267,15 +268,12 @@ inline void ComputeHexOrderAtom::calc_qn_trig(double delx, double dely, double &
    sort auxiliary array at same time
 ------------------------------------------------------------------------- */
 
-#define SWAP(a,b)   tmp = a; (a) = b; (b) = tmp;
-#define ISWAP(a,b) itmp = a; (a) = b; (b) = itmp;
-
 /* ---------------------------------------------------------------------- */
 
 void ComputeHexOrderAtom::select2(int k, int n, double *arr, int *iarr)
 {
-  int i,ir,j,l,mid,ia,itmp;
-  double a,tmp;
+  int i,ir,j,l,mid,ia;
+  double a;
 
   arr--;
   iarr--;
@@ -284,25 +282,25 @@ void ComputeHexOrderAtom::select2(int k, int n, double *arr, int *iarr)
   while (true) {
     if (ir <= l+1) {
       if (ir == l+1 && arr[ir] < arr[l]) {
-        SWAP(arr[l],arr[ir])
-        ISWAP(iarr[l],iarr[ir])
+        std::swap(arr[l],arr[ir]);
+        std::swap(iarr[l],iarr[ir]);
       }
       return;
     } else {
       mid=(l+ir) >> 1;
-      SWAP(arr[mid],arr[l+1])
-      ISWAP(iarr[mid],iarr[l+1])
+      std::swap(arr[mid],arr[l+1]);
+      std::swap(iarr[mid],iarr[l+1]);
       if (arr[l] > arr[ir]) {
-        SWAP(arr[l],arr[ir])
-        ISWAP(iarr[l],iarr[ir])
+        std::swap(arr[l],arr[ir]);
+        std::swap(iarr[l],iarr[ir]);
       }
       if (arr[l+1] > arr[ir]) {
-        SWAP(arr[l+1],arr[ir])
-        ISWAP(iarr[l+1],iarr[ir])
+        std::swap(arr[l+1],arr[ir]);
+        std::swap(iarr[l+1],iarr[ir]);
       }
       if (arr[l] > arr[l+1]) {
-        SWAP(arr[l],arr[l+1])
-        ISWAP(iarr[l],iarr[l+1])
+        std::swap(arr[l],arr[l+1]);
+        std::swap(iarr[l],iarr[l+1]);
       }
       i = l+1;
       j = ir;
@@ -312,8 +310,8 @@ void ComputeHexOrderAtom::select2(int k, int n, double *arr, int *iarr)
         do i++; while (arr[i] < a);
         do j--; while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i],arr[j])
-        ISWAP(iarr[i],iarr[j])
+        std::swap(arr[i],arr[j]);
+        std::swap(iarr[i],iarr[j]);
       }
       arr[l+1] = arr[j];
       arr[j] = a;

--- a/src/INTEL/pppm_electrode_intel.cpp
+++ b/src/INTEL/pppm_electrode_intel.cpp
@@ -719,7 +719,7 @@ void PPPMElectrodeIntel::one_step_multiplication(bigint *imat, double *greens_re
   MPI_Barrier(world);
   memory->destroy(rho1d_j);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("Single step time: {:.4g} s\n", MPI_Wtime() - step1_time));
+    utils::logmesg(lmp, "Single step time: {:.4g} s\n", MPI_Wtime() - step1_time);
 }
 
 /* ----------------------------------------------------------------------*/
@@ -844,7 +844,7 @@ void PPPMElectrodeIntel::two_step_multiplication(bigint *imat, double *greens_re
   }
   MPI_Barrier(world);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("step 1 time: {:.4g} s\n", MPI_Wtime() - step1_time));
+    utils::logmesg(lmp, "step 1 time: {:.4g} s\n", MPI_Wtime() - step1_time);
 
   // nested loop over electrode atoms i and j and stencil of i
   double step2_time = MPI_Wtime();
@@ -914,7 +914,7 @@ void PPPMElectrodeIntel::two_step_multiplication(bigint *imat, double *greens_re
   }
   MPI_Barrier(world);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, fmt::format("step 2 time: {:.4g} s\n", MPI_Wtime() - step2_time));
+    utils::logmesg(lmp, "step 2 time: {:.4g} s\n", MPI_Wtime() - step2_time);
 }
 
 template <class flt_t, class acc_t, int use_table>

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -382,8 +382,7 @@ void PairReaxFFKokkos<DeviceType>::init_md()
   if (swb < 0)
     error->one(FLERR,"Negative upper Taper-radius cutoff");
   else if (swb < 5)
-    error->one(FLERR,fmt::format("Warning: very low Taper-radius cutoff: "
-                                 "{}\n", swb));
+    error->one(FLERR,"Warning: very low Taper-radius cutoff: {}\n", swb);
 
   d1 = swb - swa;
   d7 = powint(d1,7);

--- a/src/KSPACE/fix_tune_kspace.cpp
+++ b/src/KSPACE/fix_tune_kspace.cpp
@@ -33,8 +33,8 @@
 #include <cmath>
 #include <cstring>
 #include <limits>
+#include <utility>
 
-#define SWAP(a,b) {temp=(a);(a)=(b);(b)=temp;}
 #define SIGN(a,b) ((b) >= 0.0 ? fabs(a) : -fabs(a))
 static constexpr double GOLD = 1.618034;
 
@@ -302,8 +302,7 @@ void FixTuneKspace::adjust_rcut(double time)
   if (utils::strmatch(force->kspace_style,"^msm")) return;
   if (converged) return;
 
-  double temp;
-  const double TINY = 1.0e-20;
+  constexpr double TINY = 1.0e-20;
 
   // get the current cutoff
   int itmp;
@@ -328,8 +327,8 @@ void FixTuneKspace::adjust_rcut(double time)
       bx_brent = current_cutoff;
       fb_brent = time;
       if (fb_brent > fa_brent) {
-        SWAP(ax_brent,bx_brent);
-        SWAP(fb_brent,fa_brent);
+        std::swap(ax_brent,bx_brent);
+        std::swap(fb_brent,fa_brent);
         pair_cut_coul /= 4;
       } else {
         pair_cut_coul *= 2;

--- a/src/MANYBODY/pair_bop.cpp
+++ b/src/MANYBODY/pair_bop.cpp
@@ -1873,7 +1873,7 @@ void PairBOP::read_table(char *filename)
       reader = new PotentialFileReader(lmp, filename, "BOP");
       bop_types = reader->next_int();
       if (bop_types <= 0)
-        error->one(FLERR,fmt::format("BOP potential file with {} elements",bop_types));
+        error->one(FLERR,"BOP potential file with {} elements",bop_types);
 
       bop_elements = new char*[bop_types];
       bop_masses = new double[bop_types];
@@ -2221,8 +2221,7 @@ void PairBOP::write_tables(int npts)
       int param = elem2param[i][j];
       PairParameters & pair = pairParameters[param];
 
-      filename = fmt::format("{}{}_Pair_SPR_{}",bop_elements[i],
-                             bop_elements[j],comm->me);
+      filename = fmt::format("{}{}_Pair_SPR_{}",bop_elements[i],bop_elements[j],comm->me);
 
       fp = fopen(filename.c_str(), "w");
       xmin = (pair.betaS)->get_xmin();
@@ -2240,8 +2239,7 @@ void PairBOP::write_tables(int npts)
       fclose(fp);
 
       if (pair.cutL != 0) {
-        filename = fmt::format("{}{}_Pair_L_{}",bop_elements[i],
-                               bop_elements[j],comm->me);
+        filename = fmt::format("{}{}_Pair_L_{}",bop_elements[i],bop_elements[j],comm->me);
         fp = fopen(filename.c_str(), "w");
         xmin = (pair.cphi)->get_xmin();
         xmax = (pair.cphi)->get_xmax();
@@ -2254,8 +2252,7 @@ void PairBOP::write_tables(int npts)
         }
         fclose(fp);
       }
-      filename = fmt::format("{}{}_Pair_BO_{}", bop_elements[i],
-                             bop_elements[j], comm->me);
+      filename = fmt::format("{}{}_Pair_BO_{}", bop_elements[i],bop_elements[j], comm->me);
       fp = fopen(filename.c_str(), "w");
       xmin = (pair.bo)->get_xmin();
       xmax = (pair.bo)->get_xmax();

--- a/src/MDI/mdi_engine.cpp
+++ b/src/MDI/mdi_engine.cpp
@@ -240,7 +240,7 @@ MDIEngine::MDIEngine(LAMMPS *_lmp, int narg, char **arg) : Pointers(_lmp)
       break;
 
     } else
-      error->all(FLERR, fmt::format("MDI engine exited with invalid command: {}", mdicmd));
+      error->all(FLERR, "MDI engine exited with invalid command: {}", mdicmd);
   }
 
   // clean up

--- a/src/OPENMP/fix_qeq_reaxff_omp.cpp
+++ b/src/OPENMP/fix_qeq_reaxff_omp.cpp
@@ -224,8 +224,8 @@ void FixQEqReaxFFOMP::compute_H()
   } // omp
 
   if (m_fill >= H.m)
-    error->all(FLERR,fmt::format("Fix qeq/reaxff: H matrix size has been "
-                                   "exceeded: m_fill={} H.m={}\n", m_fill, H.m));
+    error->all(FLERR,"Fix qeq/reaxff: H matrix size has been exceeded: m_fill={} H.m={}\n",
+               m_fill, H.m);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -467,9 +467,8 @@ int FixQEqReaxFFOMP::CG(double *b, double *x)
   }
 
   if ((i >= imax) && maxwarn && (comm->me == 0))
-    error->warning(FLERR,fmt::format("Fix qeq/reaxff/omp CG convergence failed "
-                                     "after {} iterations at step {}",
-                                     i,update->ntimestep));
+    error->warning(FLERR,"Fix qeq/reaxff/omp CG convergence failed after {} iterations at step {}",
+                   i,update->ntimestep);
   return i;
 }
 
@@ -796,9 +795,8 @@ int FixQEqReaxFFOMP::dual_CG(double *b1, double *b2, double *x1, double *x2)
   }
 
   if ((i >= imax) && maxwarn && (comm->me == 0))
-    error->warning(FLERR,fmt::format("Fix qeq/reaxff/omp CG convergence failed "
-                                     "after {} iterations at step {}",
-                                     i,update->ntimestep));
+    error->warning(FLERR,"Fix qeq/reaxff/omp CG convergence failed after {} iterations at step {}",
+                   i,update->ntimestep);
   return matvecs_s + matvecs_t;
 }
 

--- a/src/OPENMP/msm_cg_omp.cpp
+++ b/src/OPENMP/msm_cg_omp.cpp
@@ -138,11 +138,10 @@ void MSMCGOMP::compute(int eflag, int vflag)
                    / static_cast<double>(atom->natoms);
 
     if (me == 0)
-      utils::logmesg(MSM::lmp,fmt::format("  MSM/cg optimization cutoff: {:.8}\n"
-                                          "  Total charged atoms: {:.1f}%\n"
-                                          "  Min/max charged atoms/proc: {:.1f}%"
-                                          " {:.1f}%\n",smallq,
-                                          charged_frac,charged_fmin,charged_fmax));
+      utils::logmesg(MSM::lmp,"  MSM/cg optimization cutoff: {:.8}\n"
+                     "  Total charged atoms: {:.1f}%\n"
+                     "  Min/max charged atoms/proc: {:.1f}%"
+                     " {:.1f}%\n",smallq, charged_frac,charged_fmin,charged_fmax);
   }
 
   // only need to rebuild this list after a neighbor list update

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -810,8 +810,7 @@ void FixQEq::read_file(char *file)
 
     for (int n=1; n <= ntypes; ++n)
       if (setflag[n] == 0)
-        error->one(FLERR,fmt::format("Parameters for atom type {} missing in "
-                                     "qeq parameter file", n));
+        error->one(FLERR,"Parameters for atom type {} missing in qeq parameter file", n);
     delete[] setflag;
   }
 

--- a/src/REAXFF/fix_qeq_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_reaxff.cpp
@@ -697,8 +697,8 @@ void FixQEqReaxFF::compute_H()
   }
 
   if (m_fill >= H.m)
-    error->all(FLERR,fmt::format("Fix qeq/reaxff H matrix size has been "
-                                 "exceeded: m_fill={} H.m={}\n", m_fill, H.m));
+    error->all(FLERR,"Fix qeq/reaxff H matrix size has been exceeded: m_fill={} H.m={}\n",
+               m_fill, H.m);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -772,9 +772,8 @@ int FixQEqReaxFF::CG(double *b, double *x)
   }
 
   if ((i >= imax) && maxwarn && (comm->me == 0))
-    error->warning(FLERR,fmt::format("Fix qeq/reaxff CG convergence failed "
-                                     "after {} iterations at step {}",
-                                     i,update->ntimestep));
+    error->warning(FLERR, "Fix qeq/reaxff CG convergence failed after {} iterations at step {}",
+                   i,update->ntimestep);
   return i;
 }
 

--- a/src/REAXFF/fix_reaxff_bonds.cpp
+++ b/src/REAXFF/fix_reaxff_bonds.cpp
@@ -56,8 +56,8 @@ FixReaxFFBonds::FixReaxFFBonds(LAMMPS *lmp, int narg, char **arg) :
       if (!fp) error->one(FLERR,"Cannot open compressed file");
     } else fp = fopen(arg[4],"w");
 
-    if (!fp) error->one(FLERR,fmt::format("Cannot open fix reaxff/bonds file {}: {}",
-                                          arg[4],utils::getsyserror()));
+    if (!fp) error->one(FLERR,"Cannot open fix reaxff/bonds file {}: {}",
+                        arg[4],utils::getsyserror());
   }
 
   if (atom->tag_consecutive() == 0)

--- a/src/REAXFF/reaxff_allocate.cpp
+++ b/src/REAXFF/reaxff_allocate.cpp
@@ -253,8 +253,8 @@ namespace ReaxFF {
 
     if (Nflag || wsr->num_far >= far_nbrs->num_intrs * DANGER_ZONE) {
       if (wsr->num_far > far_nbrs->num_intrs)
-        error->one(FLERR,fmt::format("step{}: ran out of space on far_nbrs: top={}, max={}",
-                                   data->step, wsr->num_far, far_nbrs->num_intrs));
+        error->one(FLERR, "step{}: ran out of space on far_nbrs: top={}, max={}",
+                   data->step, wsr->num_far, far_nbrs->num_intrs);
 
       newsize = static_cast<int>
         (MAX(wsr->num_far*safezone, mincap*REAX_MIN_NBRS));

--- a/src/REAXFF/reaxff_ffield.cpp
+++ b/src/REAXFF/reaxff_ffield.cpp
@@ -71,8 +71,8 @@ namespace ReaxFF {
     if (control->me == 0) {
       FILE *fp = LAMMPS_NS::utils::open_potential(filename, lmp, nullptr);
       if (!fp)
-        error->one(FLERR,fmt::format("The ReaxFF parameter file {} cannot be opened: {}",
-                                     filename, getsyserror()));
+        error->one(FLERR,"The ReaxFF parameter file {} cannot be opened: {}",
+                   filename, getsyserror());
       LAMMPS_NS::TextFileReader reader(fp, "ReaxFF parameter");
       reader.ignore_comments = false;
 
@@ -241,27 +241,24 @@ namespace ReaxFF {
             // Shielding van der Waals?
             if (sbp[i].gamma_w > 0.5) {
               if (gp.vdw_type != 0 && gp.vdw_type != 3) {
-                const auto errmsg
-                  = fmt::format("Van der Waals parameters for element {} "
-                                "indicate inner wall+shielding, but earlier "
-                                "atoms indicate a different van der Waals "
-                                "method. This may cause division-by-zero "
-                                "errors. Keeping van der Waals setting for "
-                                "earlier atoms.",sbp[i].name);
-                error->warning(FLERR,errmsg);
+                error->warning(FLERR, "Van der Waals parameters for element {} "
+                               "indicate inner wall+shielding, but earlier "
+                               "atoms indicate a different van der Waals "
+                               "method. This may cause division-by-zero "
+                               "errors. Keeping van der Waals setting for "
+                               "earlier atoms.",sbp[i].name);
+
               } else {
                 gp.vdw_type = 3;
               }
             } else {  // No shielding van der Waals parameters present
               if ((gp.vdw_type != 0) && (gp.vdw_type != 2)) {
-                const auto errmsg
-                  = fmt::format("Van der Waals parameters for element {} "
-                                "indicate inner wall withou shielding, but "
-                                "earlier atoms indicate a different van der "
-                                "Waals-method. This may cause division-by-"
-                                "zero errors. Keeping van der Waals setting "
-                                "for earlier atoms.", sbp[i].name);
-                error->warning(FLERR,errmsg);
+                error->warning(FLERR, "Van der Waals parameters for element {} "
+                               "indicate inner wall withou shielding, but "
+                               "earlier atoms indicate a different van der "
+                               "Waals-method. This may cause division-by-"
+                               "zero errors. Keeping van der Waals setting "
+                               "for earlier atoms.", sbp[i].name);
               } else {
                 gp.vdw_type = 2;
               }
@@ -269,22 +266,18 @@ namespace ReaxFF {
           } else { // No Inner wall parameters present
             if (sbp[i].gamma_w > 0.5) { // Shielding vdWaals
               if ((gp.vdw_type != 0) && (gp.vdw_type != 1)) {
-                const auto errmsg
-                  = fmt::format("Van der Waals parameters for element {} "
-                                "indicate shielding without inner wall, but "
-                                "earlier elements indicate a different van der "
-                                "Waals method. This may cause division-by-zero "
-                                "errors. Keeping van der Waals setting for "
-                                "earlier atoms.", sbp[i].name);
-                error->warning(FLERR,errmsg);
+                error->warning(FLERR, "Van der Waals parameters for element {} "
+                               "indicate shielding without inner wall, but "
+                               "earlier elements indicate a different van der "
+                               "Waals method. This may cause division-by-zero "
+                               "errors. Keeping van der Waals setting for "
+                               "earlier atoms.", sbp[i].name);
               } else {
                 gp.vdw_type = 1;
               }
             } else {
-              error->one(FLERR,fmt::format("Inconsistent van der Waals "
-                                           "parameters: No shielding or inner "
-                                           "wall set for element {}",
-                                           sbp[i].name));
+              error->one(FLERR, "Inconsistent van der Waals parameters: "
+                         "No shielding or inner wall set for element {}", sbp[i].name);
             }
           }
         }
@@ -293,8 +286,7 @@ namespace ReaxFF {
         for (i = 0; i < ntypes; i++) {
           if ((sbp[i].mass < 21) &&
               (sbp[i].valency_val != sbp[i].valency_boc)) {
-            error->warning(FLERR,fmt::format("Changed valency_val to valency"
-                                             "_boc for {}", sbp[i].name));
+            error->warning(FLERR, "Changed valency_val to valency_boc for {}", sbp[i].name);
             sbp[i].valency_val = sbp[i].valency_boc;
           }
         }

--- a/src/REAXFF/reaxff_ffield.cpp
+++ b/src/REAXFF/reaxff_ffield.cpp
@@ -335,8 +335,7 @@ namespace ReaxFF {
 
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 8)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(7);
 
           if ((j < ntypes) && (k < ntypes)) {
             tbp[j][k].p_be2 = tbp[k][j].p_be2 = values.next_double();
@@ -345,7 +344,11 @@ namespace ReaxFF {
             values.skip();
             tbp[j][k].p_bo1 = tbp[k][j].p_bo1 = values.next_double();
             tbp[j][k].p_bo2 = tbp[k][j].p_bo2 = values.next_double();
-            tbp[j][k].ovc   = tbp[k][j].ovc   = values.next_double();
+            // if the 8th value is missing use 0.0
+            if (values.has_next())
+              tbp[j][k].ovc   = tbp[k][j].ovc   = values.next_double();
+            else
+              tbp[j][k].ovc   = tbp[k][j].ovc   = 0.0;
           }
         }
 

--- a/src/REAXFF/reaxff_ffield.cpp
+++ b/src/REAXFF/reaxff_ffield.cpp
@@ -60,8 +60,13 @@ namespace ReaxFF {
 
     // read and parse the force field only on rank 0
 
-#define THROW_ERROR(txt)                                                \
-    throw ffield_parser_error(fmt::format("{}:{}: {}",filename,lineno,txt))
+#define THROW_ERROR(txt) throw ffield_parser_error(fmt::format("{}:{}: {}", filename, lineno, txt))
+
+#define CHECK_COLUMNS(want)                                                          \
+  if (values.count() < static_cast<std::size_t>(want))                               \
+    throw ffield_parser_error(fmt::format("{}:{}: Invalid force field file format: " \
+                                          " expected {} columns but found {}",       \
+                                          filename, lineno, want, values.count()))
 
     if (control->me == 0) {
       FILE *fp = LAMMPS_NS::utils::open_potential(filename, lmp, nullptr);
@@ -158,8 +163,7 @@ namespace ReaxFF {
 
           if ((values.count() < 8) && !lgflag)
             THROW_ERROR("This force field file requires using 'lgvdw yes'");
-          if (values.count() < 9)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(9);
 
           // copy element symbol in uppercase and truncate stored element symbol if necessary
           auto element = uppercase(values.next_string());
@@ -180,8 +184,7 @@ namespace ReaxFF {
 
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 8)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(8);
 
           sbp[i].alpha      = values.next_double();
           sbp[i].gamma_w    = values.next_double();
@@ -196,8 +199,7 @@ namespace ReaxFF {
 
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 8)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(8);
 
           sbp[i].r_pi_pi    = values.next_double();
           sbp[i].p_lp2      = values.next_double();
@@ -211,8 +213,7 @@ namespace ReaxFF {
 
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 8)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(8);
 
           sbp[i].p_ovun2    = values.next_double();
           sbp[i].p_val3     = values.next_double();
@@ -228,8 +229,7 @@ namespace ReaxFF {
           if (lgflag) {
             values = reader.next_values(0);
             ++lineno;
-            if (values.count() < 2)
-              THROW_ERROR("Invalid force field file format");
+            CHECK_COLUMNS(2);
             sbp[i].lgcij    = values.next_double();
             sbp[i].lgre     = values.next_double();
           } else sbp[i].lgcij = sbp[i].lgre = 0.0;
@@ -312,8 +312,7 @@ namespace ReaxFF {
 
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 10)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(10);
 
           j = values.next_int() - 1;
           k = values.next_int() - 1;
@@ -387,8 +386,7 @@ namespace ReaxFF {
         for (i = 0; i < n; ++i) {
           values = reader.next_values(0);
           ++lineno;
-          if ((int)values.count() < 8 + lgflag)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(8 + lgflag);
 
           j = values.next_int() - 1;
           k = values.next_int() - 1;
@@ -432,8 +430,7 @@ namespace ReaxFF {
         for (i = 0; i < n; ++i) {
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 10)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(10);
 
           j = values.next_int() - 1;
           k = values.next_int() - 1;
@@ -487,8 +484,7 @@ namespace ReaxFF {
         for (i = 0; i < n; ++i) {
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 9)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(9);
 
           j = values.next_int() - 1;
           k = values.next_int() - 1;
@@ -561,8 +557,7 @@ namespace ReaxFF {
         for (i = 0; i < n; ++i) {
           values = reader.next_values(0);
           ++lineno;
-          if (values.count() < 7)
-            THROW_ERROR("Invalid force field file format");
+          CHECK_COLUMNS(7);
 
           j = values.next_int() - 1;
           k = values.next_int() - 1;
@@ -616,4 +611,5 @@ namespace ReaxFF {
     control->nonb_cut  = reax->gp.l[12];
   }
 #undef THROW_ERROR
+#undef CHECK_COLUMNS
 }

--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -129,9 +129,11 @@ void NEB::command(int narg, char **arg)
   if (nevery <= 0)
     error->universe_all(FLERR, fmt::format("Illegal NEB command every parameter: {}", nevery));
   if (n1steps % nevery)
-    error->all(FLERR, fmt::format("NEB N1 value {} incompatible with every {}", n1steps, nevery));
+    error->universe_all(FLERR, fmt::format("NEB N1 value {} incompatible with every {}",
+                                           n1steps, nevery));
   if (n2steps % nevery)
-    error->all(FLERR, fmt::format("NEB N2 value {} incompatible with every {}", n2steps, nevery));
+    error->universe_all(FLERR, fmt::format("NEB N2 value {} incompatible with every {}",
+                                           n2steps, nevery));
 
   // replica info
 

--- a/src/REPLICA/temper_grem.cpp
+++ b/src/REPLICA/temper_grem.cpp
@@ -97,7 +97,7 @@ void TemperGrem::command(int narg, char **arg)
 
   FixNH *nh = dynamic_cast<FixNH *>(modify->get_fix_by_id(arg[4]));
   if (!nh)
-    error->all(FLERR,fmt::format("Fix {} for Nose-Hoover fix does not exist", arg[4]));
+    error->universe_all(FLERR,fmt::format("Fix {} for Nose-Hoover fix does not exist", arg[4]));
 
   // get result from nvt vs npt check from fix_grem
 

--- a/src/compute_centro_atom.cpp
+++ b/src/compute_centro_atom.cpp
@@ -30,6 +30,7 @@
 #include "update.h"
 
 #include <cstring>
+#include <utility>
 
 using namespace LAMMPS_NS;
 
@@ -319,33 +320,24 @@ void ComputeCentroAtom::compute_peratom()
    2nd routine sorts auxiliary array at same time
 ------------------------------------------------------------------------- */
 
-#define SWAP(a, b) \
-  tmp = a;         \
-  (a) = b;         \
-  (b) = tmp;
-#define ISWAP(a, b) \
-  itmp = a;         \
-  (a) = b;          \
-  (b) = itmp;
-
 void ComputeCentroAtom::select(int k, int n, double *arr)
 {
   int i, ir, j, l, mid;
-  double a, tmp;
+  double a;
 
   arr--;
   l = 1;
   ir = n;
   while (true) {
     if (ir <= l + 1) {
-      if (ir == l + 1 && arr[ir] < arr[l]) { SWAP(arr[l], arr[ir]) }
+      if (ir == l + 1 && arr[ir] < arr[l]) std::swap(arr[l], arr[ir]);
       return;
     } else {
       mid = (l + ir) >> 1;
-      SWAP(arr[mid], arr[l + 1])
-      if (arr[l] > arr[ir]) { SWAP(arr[l], arr[ir]) }
-      if (arr[l + 1] > arr[ir]) { SWAP(arr[l + 1], arr[ir]) }
-      if (arr[l] > arr[l + 1]) { SWAP(arr[l], arr[l + 1]) }
+      std::swap(arr[mid], arr[l + 1]);
+      if (arr[l] > arr[ir]) std::swap(arr[l], arr[ir]);
+      if (arr[l + 1] > arr[ir]) std::swap(arr[l + 1], arr[ir]);
+      if (arr[l] > arr[l + 1]) std::swap(arr[l], arr[l + 1]);
       i = l + 1;
       j = ir;
       a = arr[l + 1];
@@ -355,7 +347,7 @@ void ComputeCentroAtom::select(int k, int n, double *arr)
         do j--;
         while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i], arr[j])
+        std::swap(arr[i], arr[j]);
       }
       arr[l + 1] = arr[j];
       arr[j] = a;
@@ -369,8 +361,8 @@ void ComputeCentroAtom::select(int k, int n, double *arr)
 
 void ComputeCentroAtom::select2(int k, int n, double *arr, int *iarr)
 {
-  int i, ir, j, l, mid, ia, itmp;
-  double a, tmp;
+  int i, ir, j, l, mid, ia;
+  double a;
 
   arr--;
   iarr--;
@@ -379,25 +371,25 @@ void ComputeCentroAtom::select2(int k, int n, double *arr, int *iarr)
   while (true) {
     if (ir <= l + 1) {
       if (ir == l + 1 && arr[ir] < arr[l]) {
-        SWAP(arr[l], arr[ir])
-        ISWAP(iarr[l], iarr[ir])
+        std::swap(arr[l], arr[ir]);
+        std::swap(iarr[l], iarr[ir]);
       }
       return;
     } else {
       mid = (l + ir) >> 1;
-      SWAP(arr[mid], arr[l + 1])
-      ISWAP(iarr[mid], iarr[l + 1])
+      std::swap(arr[mid], arr[l + 1]);
+      std::swap(iarr[mid], iarr[l + 1]);
       if (arr[l] > arr[ir]) {
-        SWAP(arr[l], arr[ir])
-        ISWAP(iarr[l], iarr[ir])
+        std::swap(arr[l], arr[ir]);
+        std::swap(iarr[l], iarr[ir]);
       }
       if (arr[l + 1] > arr[ir]) {
-        SWAP(arr[l + 1], arr[ir])
-        ISWAP(iarr[l + 1], iarr[ir])
+        std::swap(arr[l + 1], arr[ir]);
+        std::swap(iarr[l + 1], iarr[ir]);
       }
       if (arr[l] > arr[l + 1]) {
-        SWAP(arr[l], arr[l + 1])
-        ISWAP(iarr[l], iarr[l + 1])
+        std::swap(arr[l], arr[l + 1]);
+        std::swap(iarr[l], iarr[l + 1]);
       }
       i = l + 1;
       j = ir;
@@ -409,8 +401,8 @@ void ComputeCentroAtom::select2(int k, int n, double *arr, int *iarr)
         do j--;
         while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i], arr[j])
-        ISWAP(iarr[i], iarr[j])
+        std::swap(arr[i], arr[j]);
+        std::swap(iarr[i], iarr[j]);
       }
       arr[l + 1] = arr[j];
       arr[j] = a;

--- a/src/compute_orientorder_atom.cpp
+++ b/src/compute_orientorder_atom.cpp
@@ -36,6 +36,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <utility>
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -331,39 +332,19 @@ double ComputeOrientOrderAtom::memory_usage()
 
 // Use no-op do while to create single statement
 
-#define SWAP(a, b) \
-  do {             \
-    tmp = a;       \
-    (a) = b;       \
-    (b) = tmp;     \
-  } while (0)
-
-#define ISWAP(a, b) \
-  do {              \
-    itmp = a;       \
-    (a) = b;        \
-    (b) = itmp;     \
-  } while (0)
-
-#define SWAP3(a, b)  \
-  do {               \
-    tmp = (a)[0];    \
-    (a)[0] = (b)[0]; \
-    (b)[0] = tmp;    \
-    tmp = (a)[1];    \
-    (a)[1] = (b)[1]; \
-    (b)[1] = tmp;    \
-    tmp = (a)[2];    \
-    (a)[2] = (b)[2]; \
-    (b)[2] = tmp;    \
+#define SWAP3(a, b)            \
+  do {                         \
+    std::swap((a)[0], (b)[0]); \
+    std::swap((a)[1], (b)[1]); \
+    std::swap((a)[2], (b)[2]); \
   } while (0)
 
 /* ---------------------------------------------------------------------- */
 
 void ComputeOrientOrderAtom::select3(int k, int n, double *arr, int *iarr, double **arr3)
 {
-  int i, ir, j, l, mid, ia, itmp;
-  double a, tmp, a3[3];
+  int i, ir, j, l, mid, ia;
+  double a, a3[3];
 
   arr--;
   iarr--;
@@ -373,29 +354,29 @@ void ComputeOrientOrderAtom::select3(int k, int n, double *arr, int *iarr, doubl
   while (true) {
     if (ir <= l + 1) {
       if (ir == l + 1 && arr[ir] < arr[l]) {
-        SWAP(arr[l], arr[ir]);
-        ISWAP(iarr[l], iarr[ir]);
+        std::swap(arr[l], arr[ir]);
+        std::swap(iarr[l], iarr[ir]);
         SWAP3(arr3[l], arr3[ir]);
       }
       return;
     } else {
       mid = (l + ir) >> 1;
-      SWAP(arr[mid], arr[l + 1]);
-      ISWAP(iarr[mid], iarr[l + 1]);
+      std::swap(arr[mid], arr[l + 1]);
+      std::swap(iarr[mid], iarr[l + 1]);
       SWAP3(arr3[mid], arr3[l + 1]);
       if (arr[l] > arr[ir]) {
-        SWAP(arr[l], arr[ir]);
-        ISWAP(iarr[l], iarr[ir]);
+        std::swap(arr[l], arr[ir]);
+        std::swap(iarr[l], iarr[ir]);
         SWAP3(arr3[l], arr3[ir]);
       }
       if (arr[l + 1] > arr[ir]) {
-        SWAP(arr[l + 1], arr[ir]);
-        ISWAP(iarr[l + 1], iarr[ir]);
+        std::swap(arr[l + 1], arr[ir]);
+        std::swap(iarr[l + 1], iarr[ir]);
         SWAP3(arr3[l + 1], arr3[ir]);
       }
       if (arr[l] > arr[l + 1]) {
-        SWAP(arr[l], arr[l + 1]);
-        ISWAP(iarr[l], iarr[l + 1]);
+        std::swap(arr[l], arr[l + 1]);
+        std::swap(iarr[l], iarr[l + 1]);
         SWAP3(arr3[l], arr3[l + 1]);
       }
       i = l + 1;
@@ -411,8 +392,8 @@ void ComputeOrientOrderAtom::select3(int k, int n, double *arr, int *iarr, doubl
         do j--;
         while (arr[j] > a);
         if (j < i) break;
-        SWAP(arr[i], arr[j]);
-        ISWAP(iarr[i], iarr[j]);
+        std::swap(arr[i], arr[j]);
+        std::swap(iarr[i], iarr[j]);
         SWAP3(arr3[i], arr3[j]);
       }
       arr[l + 1] = arr[j];

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -1055,6 +1055,9 @@ void CreateAtoms::add_mesh(const char *filename)
       throw TokenizerException("Invalid STL mesh file format", "");
 
     line += 6;
+    if (utils::strmatch(line, "^binary"))
+      throw TokenizerException("Invalid STL mesh file format", "");
+
     if (comm->me == 0)
       utils::logmesg(lmp, "Reading STL object {} from text file {}\n", utils::trim(line), filename);
 

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -358,7 +358,7 @@ void CreateAtoms::command(int narg, char **arg)
   //   lattice to box, but not consistent with other uses of units=lattice
   // triclinic remapping occurs in add_single()
 
-  if ((style == BOX) || (style == REGION) || (style == MESH)) {
+  if ((style == BOX) || (style == REGION)) {
     if (nbasis == 0) error->all(FLERR, "Cannot create atoms with undefined lattice");
   } else if (scaleflag == 1) {
     xone[0] *= domain->lattice->xlattice;

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -1153,6 +1153,7 @@ void CreateAtoms::add_mesh(const char *filename)
       utils::logmesg(lmp, "  read {} triangles with {:.2f} atoms per triangle added in {} mode\n",
                      ntriangle, ratio, mesh_name[mesh_style]);
   }
+  if (fp) fclose(fp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -530,7 +530,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
       if (infile == nullptr)
         error->one(FLERR,"Cannot open input script {}: {}", arg[inflag], utils::getsyserror());
       if (!helpflag)
-        utils::logmesg(this,fmt::format("LAMMPS ({}{})\n", version, update_string));
+        utils::logmesg(this,"LAMMPS ({}{})\n", version, update_string);
 
      // warn against using I/O redirection in parallel runs
       if ((inflag == 0) && (universe->nprocs > 1))
@@ -626,8 +626,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
     }
 
     if ((me == 0) && (!helpflag))
-      utils::logmesg(this,fmt::format("LAMMPS ({})\nProcessor partition = {}\n",
-                                      version, universe->iworld));
+      utils::logmesg(this,"LAMMPS ({})\nProcessor partition = {}\n", version, universe->iworld);
   }
 
   // check consistency of datatype settings in lmptype.h
@@ -762,8 +761,7 @@ LAMMPS::~LAMMPS() noexcept(false)
     totalclock  = (totalclock - seconds) / 60.0;
     int minutes = fmod(totalclock,60.0);
     int hours = (totalclock - minutes) / 60.0;
-    utils::logmesg(this,fmt::format("Total wall time: {}:{:02d}:{:02d}\n",
-                                    hours, minutes, seconds));
+    utils::logmesg(this, "Total wall time: {}:{:02d}:{:02d}\n", hours, minutes, seconds);
   }
 
   if (universe->nworlds == 1) {

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -239,6 +239,8 @@ std::string platform::os_info()
     buf = "Windows 11 21H2";
   } else if (build == "22621") {
     buf = "Windows 11 22H2";
+  } else if (build == "22631") {
+    buf = "Windows 11 23H2";
   } else {
     const char *entry = "ProductName";
     RegGetValue(HKEY_LOCAL_MACHINE, subkey, entry, RRF_RT_REG_SZ, nullptr, &value,

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -364,7 +364,7 @@ void ReadData::command(int narg, char **arg)
   // check if data file is available and readable
 
   if (!platform::file_is_readable(arg[0]))
-    error->all(FLERR, fmt::format("Cannot open file {}: {}", arg[0], utils::getsyserror()));
+    error->all(FLERR, "Cannot open file {}: {}", arg[0], utils::getsyserror());
 
   // reset so we can warn about reset image flags exactly once per data file
 

--- a/src/special.cpp
+++ b/src/special.cpp
@@ -62,12 +62,11 @@ void Special::build()
   if (me == 0) {
     const double * const special_lj   = force->special_lj;
     const double * const special_coul = force->special_coul;
-    auto mesg = fmt::format("Finding 1-2 1-3 1-4 neighbors ...\n"
-                            "  special bond factors lj:    {:<8} {:<8} {:<8}\n"
-                            "  special bond factors coul:  {:<8} {:<8} {:<8}\n",
-                            special_lj[1],special_lj[2],special_lj[3],
-                            special_coul[1],special_coul[2],special_coul[3]);
-    utils::logmesg(lmp,mesg);
+    utils::logmesg(lmp, "Finding 1-2 1-3 1-4 neighbors ...\n"
+                   "  special bond factors lj:    {:<8} {:<8} {:<8}\n"
+                   "  special bond factors coul:  {:<8} {:<8} {:<8}\n",
+                   special_lj[1],special_lj[2],special_lj[3],
+                   special_coul[1],special_coul[2],special_coul[3]);
   }
 
   // set onefive_flag if special_bonds command set it
@@ -162,7 +161,7 @@ void Special::build()
   if (onefive_flag) {
     onefive_build();
     if (me == 0)
-      utils::logmesg(lmp,fmt::format("{:>6} = max # of 1-5 neighbors\n",maxall));
+      utils::logmesg(lmp,"{:>6} = max # of 1-5 neighbors\n",maxall);
   }
 
   // finish processing the onetwo, onethree, onefour, onefive lists

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -557,7 +557,7 @@ void utils::bounds(const char *file, int line, const std::string &str,
   // check for illegal charcters
   size_t found = str.find_first_not_of("*-0123456789");
   if (found != std::string::npos) {
-    if (error) error->all(file, line, fmt::format("Invalid range string: {}", str));
+    if (error) error->all(file, line, "Invalid range string: {}", str);
     return;
   }
 
@@ -580,17 +580,14 @@ void utils::bounds(const char *file, int line, const std::string &str,
 
   if (error) {
     if ((nlo <= 0) || (nhi <= 0))
-      error->all(file, line, fmt::format("Invalid range string: {}", str));
+      error->all(file, line, "Invalid range string: {}", str);
 
     if (nlo < nmin)
-      error->all(file, line, fmt::format("Numeric index {} is out of bounds ({}-{})",
-                                         nlo, nmin, nmax));
+      error->all(file, line, "Numeric index {} is out of bounds ({}-{})", nlo, nmin, nmax);
     else if (nhi > nmax)
-      error->all(file, line, fmt::format("Numeric index {} is out of bounds ({}-{})",
-                                         nhi, nmin, nmax));
+      error->all(file, line, "Numeric index {} is out of bounds ({}-{})", nhi, nmin, nmax);
     else if (nlo > nhi)
-      error->all(file, line, fmt::format("Numeric index {} is out of bounds ({}-{})",
-                                         nlo, nmin, nhi));
+      error->all(file, line, "Numeric index {} is out of bounds ({}-{})", nlo, nmin, nhi);
   }
 }
 


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes and fixes

**Related Issue(s)**

Avoid the issue reported here: https://matsci.org/t/invalid-force-field-file-format-after-using-a-new-lammps-version/51029

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- replace SWAP and ISWAP macros with calls to std::swap()
- initialize uninitialized colvars member variable
- create_atoms mesh does not require a lattice
- recognize STL files starting with "solid binary" as binary files
- fix memory leak in create_atoms mesh
- support old ReaxFF force field files that have 7 columns instead of 8 for second row of bonds section. use 0.0
- improve error messages when parsing ReaxFF force field files
- remove redundant calls to fmt::format() from calls to `error->all()`, `error->one()`, and `utils::logmesg()`
- add support to identify Windows 11 23H2 by its build number

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
