### PR TITLE
Fix issues with trim lists

### DIFF
--- a/src/KOKKOS/neighbor_kokkos.cpp
+++ b/src/KOKKOS/neighbor_kokkos.cpp
@@ -308,7 +308,8 @@ void NeighborKokkos::build_kokkos(int topoflag)
   for (i = 0; i < npair_perpetual; i++) {
     m = plist[i];
     if (!lists[m]->kokkos) atomKK->sync(Host,ALL_MASK);
-    if (!lists[m]->copy) lists[m]->grow(nlocal,nall);
+    if (!lists[m]->copy || lists[m]->trim || lists[m]->kk2cpu)
+      lists[m]->grow(nlocal,nall);
     neigh_pair[m]->build_setup();
     neigh_pair[m]->build(lists[m]);
   }

--- a/src/KOKKOS/npair_trim_kokkos.cpp
+++ b/src/KOKKOS/npair_trim_kokkos.cpp
@@ -62,8 +62,8 @@ void NPairTrimKokkos<DeviceType>::trim_to_kokkos(NeighList *list)
   d_ilist_copy = k_list_copy->d_ilist;
   d_numneigh_copy = k_list_copy->d_numneigh;
   d_neighbors_copy = k_list_copy->d_neighbors;
-  int inum_copy = list->listcopy->inum;
-  if (list->ghost) inum_copy += list->listcopy->gnum;
+  int inum_trim = list->listcopy->inum;
+  if (list->ghost) inum_trim += list->listcopy->gnum;
 
   NeighListKokkos<DeviceType>* k_list = static_cast<NeighListKokkos<DeviceType>*>(list);
   k_list->maxneighs = k_list_copy->maxneighs; // simple, but could be made more memory efficient
@@ -75,7 +75,7 @@ void NPairTrimKokkos<DeviceType>::trim_to_kokkos(NeighList *list)
   // loop over parent list and trim
 
   copymode = 1;
-  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagNPairTrim>(0,inum_copy),*this);
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagNPairTrim>(0,inum_trim),*this);
   copymode = 0;
 
   list->inum = k_list_copy->inum;
@@ -132,8 +132,8 @@ void NPairTrimKokkos<DeviceType>::trim_to_cpu(NeighList *list)
 
   int inum = listcopy->inum;
   int gnum = listcopy->gnum;
-  int inum_all = inum;
-  if (list->ghost) inum_all += gnum;
+  int inum_trim = inum;
+  if (list->ghost) inum_trim += gnum;
   auto h_ilist = listcopy_kk->k_ilist.h_view;
   auto h_numneigh = Kokkos::create_mirror_view_and_copy(LMPHostType(),listcopy_kk->d_numneigh);
   auto h_neighbors = Kokkos::create_mirror_view_and_copy(LMPHostType(),listcopy_kk->d_neighbors);
@@ -151,7 +151,7 @@ void NPairTrimKokkos<DeviceType>::trim_to_cpu(NeighList *list)
   MyPage<int> *ipage = list->ipage;
   ipage->reset();
 
-  for (int ii = 0; ii < inum_all; ii++) {
+  for (int ii = 0; ii < inum_trim; ii++) {
     int n = 0;
     neighptr = ipage->vget();
 

--- a/src/MANYBODY/pair_airebo.cpp
+++ b/src/MANYBODY/pair_airebo.cpp
@@ -59,7 +59,6 @@ PairAIREBO::PairAIREBO(LAMMPS *lmp)
   nextra = 3;
   pvector = new double[nextra];
 
-  trim_flag = 0; // workaround
   maxlocal = 0;
   REBO_numneigh = nullptr;
   REBO_firstneigh = nullptr;

--- a/src/npair_trim.cpp
+++ b/src/npair_trim.cpp
@@ -50,11 +50,15 @@ void NPairTrim::build(NeighList *list)
   int *numneigh_copy = listcopy->numneigh;
   int **firstneigh_copy = listcopy->firstneigh;
   int inum = listcopy->inum;
+  int gnum = listcopy->gnum;
 
   list->inum = inum;
-  list->gnum = listcopy->gnum;
+  list->gnum = gnum;
 
-  for (ii = 0; ii < inum; ii++) {
+  int inum_trim = inum;
+  if (list->ghost) inum_trim += gnum;
+
+  for (ii = 0; ii < inum_trim; ii++) {
     n = 0;
     neighptr = ipage->vget();
 


### PR DESCRIPTION
**Summary**

Fix issues with trim lists. The CPU version wasn't looping over ghost atoms. The Kokkos version wasn't growing the trim list leading to a crash.

**Related Issue(s)**

Fixes https://github.com/lammps/lammps/issues/3940

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes