### PR TITLE
Propagate Barostat fixes to BOCS user package - see Lammps PR 1259

### DIFF
--- a/src/BOCS/fix_bocs.cpp
+++ b/src/BOCS/fix_bocs.cpp
@@ -1024,7 +1024,10 @@ void FixBocs::final_integrate()
 
   if (pstat_flag) {
     if (pstyle == ISO) pressure->compute_scalar();
-    else pressure->compute_vector();
+    else {
+	    temperature->compute_vector();
+	    pressure->compute_vector();
+    }
     couple();
     pressure->addstep(update->ntimestep+1);
   }
@@ -1961,7 +1964,7 @@ void FixBocs::nhc_press_integrate()
   int ich,i,pdof;
   double expfac,factor_etap,kecurrent;
   double kt = boltz * t_target;
-
+  double lkt_press;
   // Update masses, to preserve initial freq, if flag set
 
   if (omega_mass_flag) {
@@ -2006,7 +2009,8 @@ void FixBocs::nhc_press_integrate()
     }
   }
 
-  double lkt_press = pdof * kt;
+  if (pstyle == ISO) lkt_press = kt;
+  else lkt_press = pdof * kt;
   etap_dotdot[0] = (kecurrent - lkt_press)/etap_mass[0];
 
   double ncfac = 1.0/nc_pchain;

--- a/src/BOCS/fix_bocs.cpp
+++ b/src/BOCS/fix_bocs.cpp
@@ -1025,8 +1025,8 @@ void FixBocs::final_integrate()
   if (pstat_flag) {
     if (pstyle == ISO) pressure->compute_scalar();
     else {
-	    temperature->compute_vector();
-	    pressure->compute_vector();
+      temperature->compute_vector();
+      pressure->compute_vector();
     }
     couple();
     pressure->addstep(update->ntimestep+1);
@@ -1965,6 +1965,7 @@ void FixBocs::nhc_press_integrate()
   double expfac,factor_etap,kecurrent;
   double kt = boltz * t_target;
   double lkt_press;
+
   // Update masses, to preserve initial freq, if flag set
 
   if (omega_mass_flag) {


### PR DESCRIPTION
**Summary**

Bugfix - User Package - BOCS (incorrect fluctuations in Barostat)

**Related Issue(s)**
Propagates [Pull Request 1259 ](https://github.com/lammps/lammps/pull/1259) to BOCS 
**Author(s)**
Maria Lesniewski and Ryan Szukalo (Noid Lab Penn State University)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
The included changes should not break backward compatibility
**Implementation Notes**

The BOCS package allows users to include a pressure correction inside of the MTTK barostat. See  [PR#879](https://github.com/lammps/lammps/pull/879). 

Recently we discovered that the volume fluctuations inside of this barostat were not consistent with fix NPT. 
When there is no pressure correction being set in fix bocs (psi1 = psi2 = 0), the two should reproduce the same distribution of volumes. 

To test this, we simulated 1000 Lennard Jones particles using fix NPT and fix BOCS with no pressure correction implemented for 10 ns. 
We then discarded the first 2 ns as an equilibration period, and analyzed the pressure and volume distributions using the attached python script on the last 8 ns of the output vol.dat and press.dat files. 
The python script is attached in Info_for_Pull_Request_and_Bug_Recreation\input_files\Analysis_Notes/xvg_distro.py.

We then made changes to this script analogous to changes we saw made in [PR#942](https://github.com/lammps/lammps/pull/942) and [PR#1259](https://github.com/lammps/lammps/pull/1259)

Following these changes fix npt and fix bocs reproduce the same distribution of pressures and volumes when no pressure correction is implemented in fix bocs

Results from before the code change are included in: Info_for_Pull_Request_and_Bug_Recreation\Output + Results of Bugfix\test_lammps_default_build
Results from after the code change are included in: Info_for_Pull_Request_and_Bug_Recreation\Output + Results of Bugfix\test_lammps_edited_build
.jpg comparisons of the distributions are included in: Info_for_Pull_Request_and_Bug_Recreation.zip\Info_for_Pull_Request_and_Bug_Recreation\Images_Agr_Files_Results

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks 


**Further Information, Files, and Links**

Here I have attached our initial test of LAMMPS 2023, and the test of the edited code 

[Info_for_Pull_Request_and_Bug_Recreation.zip](https://github.com/lammps/lammps/files/13032106/Info_for_Pull_Request_and_Bug_Recreation.zip)

