### PR TITLE
Fix wall region eflag

### DIFF
--- a/doc/src/fix_ave_chunk.rst
+++ b/doc/src/fix_ave_chunk.rst
@@ -541,10 +541,10 @@ Restrictions
 Related commands
 """"""""""""""""
 
-:doc:`compute <compute>`, :doc:`fix ave/atom <fix_ave_atom>`, `fix
-:doc:ave/histo <fix_ave_histo>`, :doc:`fix ave/time <fix_ave_time>`,
-:doc:`variable <variable>`, :doc:`fix ave/correlate
-:doc:<fix_ave_correlate>`, `fix ave/atogrid <fix_ave_grid>`
+:doc:`compute <compute>`, :doc:`fix ave/atom <fix_ave_atom>`,
+:doc:`fix ave/histo <fix_ave_histo>`, :doc:`fix ave/time <fix_ave_time>`,
+:doc:`variable <variable>`, :doc:`fix ave/correlate <fix_ave_correlate>`,
+:doc:`fix ave/grid <fix_ave_grid>`
 
 
 Default

--- a/src/fix_wall.cpp
+++ b/src/fix_wall.cpp
@@ -344,7 +344,7 @@ void FixWall::post_force(int vflag)
   v_init(vflag);
 
   // energy intialize.
-  // eflag is used to track whether wall energies have been communitcated.
+  // eflag is used to track whether wall energies have been communicated.
 
   eflag = 0;
   for (int m = 0; m <= nwall; m++) ewall[m] = 0.0;

--- a/src/fix_wall_region.cpp
+++ b/src/fix_wall_region.cpp
@@ -244,6 +244,7 @@ void FixWallRegion::post_force(int vflag)
   // initilize ewall after region->prematch(),
   //   so a dynamic region can access last timestep values
 
+  eflag = 0;
   ewall[0] = ewall[1] = ewall[2] = ewall[3] = 0.0;
 
   for (i = 0; i < nlocal; i++)


### PR DESCRIPTION
**Summary**

The energy and force output of `fix wall/region` was only computed once because the `eflag` was not reset to zero. This PR  corrects this behavior, and a couple typos.

**Related Issue(s)**

None

**Author(s)**

Jibril B. Coulibaly, Sandia National Laboratories

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Backward compatible

**Implementation Notes**

Added the `eflag = 0` where other `fix wall` styles have it, inside `post_force()`

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

None


