### PR TITLE
Fix deposit var keyword

### DIFF
--- a/doc/src/fix_deposit.rst
+++ b/doc/src/fix_deposit.rst
@@ -17,12 +17,16 @@ Syntax
 * M = insert a single atom or molecule every M steps
 * seed = random # seed (positive integer)
 * one or more keyword/value pairs may be appended to args
-* keyword = *region* or *id* or *global* or *local* or *near* or *gaussian* or *attempt* or *rate* or *vx* or *vy* or *vz* or *target* or *mol* or *molfrac* or *rigid* or *shake* or *orient* or *units*
+* keyword = *region* or *var* or *set* or *id* or *global* or *local* or *near* or *gaussian* or *attempt* or *rate* or *vx* or *vy* or *vz* or *target* or *mol* or *molfrac* or *rigid* or *shake* or *orient* or *units*
 
   .. parsed-literal::
 
        *region* value = region-ID
          region-ID = ID of region to use as insertion volume
+       *var* value = name = variable name to evaluate for test of atom creation
+       *set* values = dim name
+         dim = *x* or *y* or *z*
+         name = name of variable to set with x, y, or z atom position
        *id* value = *max* or *next*
          max = atom ID for new atom(s) is max ID of all current atoms plus one
          next = atom ID for new atom(s) increments by one for every deposition
@@ -193,17 +197,19 @@ simulation that is "nearby" the chosen x,y position.  In this context,
 particles is less than the *delta* setting.
 
 Once a trial x,y,z position has been selected, the insertion is only
-performed if no current atom in the simulation is within a distance R
-of any atom in the new particle, including the effect of periodic
-boundary conditions if applicable.  R is defined by the *near*
-keyword.  Note that the default value for R is 0.0, which will allow
-atoms to strongly overlap if you are inserting where other atoms are
-present.  This distance test is performed independently for each atom
-in an inserted molecule, based on the randomly rotated configuration
-of the molecule.  If this test fails, a new random position within the
-insertion volume is chosen and another trial is made.  Up to Q
-attempts are made.  If the particle is not successfully inserted,
-LAMMPS prints a warning message.
+performed if both the *near* and *var* keywords are satisfied (see below).
+If either the *near* or the *var* keyword is not satisfied, a new random
+position within the insertion volume is chosen and another trial is made.
+Up to Q attempts are made.  If one or more particle insertions are not
+successful, LAMMPS prints a warning message.
+
+The *near* keyword ensures that no current atom in the simulation is within
+a distance R of any atom in the new particle, including the effect of
+periodic boundary conditions if applicable.  Note that the default value
+for R is 0.0, which will allow atoms to strongly overlap if you are
+inserting where other atoms are present.  This distance test is performed
+independently for each atom in an inserted molecule, based on the randomly
+rotated configuration of the molecule.
 
 .. note::
 
@@ -213,6 +219,24 @@ LAMMPS prints a warning message.
    particle may overlap with either a previously inserted particle or an
    existing particle.  LAMMPS will issue a warning if R is smaller than
    this value, based on the radii of existing and inserted particles.
+
+The *var* and *set* keywords can be used together to provide a criterion
+for accepting or rejecting the addition of an individual atom, based on its
+coordinates.  The *name* specified for the *var* keyword is the name of an
+:doc:`equal-style variable <variable>` that should evaluate to a zero or
+non-zero value based on one or two or three variables that will store the
+*x*, *y*, or *z* coordinates of an atom (one variable per coordinate).  If
+used, these other variables must be :doc:`internal-style variables
+<variable>` defined in the input script; their initial numeric value can be
+anything. They must be internal-style variables, because this command
+resets their values directly.  The *set* keyword is used to identify the
+names of these other variables, one variable for the *x*-coordinate of a
+created atom, one for *y*, and one for *z*.  When an atom is created, its
+:math:`(x,y,z)` coordinates become the values for any *set* variable that
+is defined.  The *var* variable is then evaluated.  If the returned value
+is 0.0, the atom is not created.  If it is non-zero, the atom is created.
+For an example of how to use these keywords, see the
+:doc:`create_atoms <create_atoms>`command.
 
 The *rate* option moves the insertion volume in the z direction (3d)
 or y direction (2d).  This enables particles to be inserted from a

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -20,6 +20,7 @@
 #include "domain.h"
 #include "error.h"
 #include "fix.h"
+#include "input.h"
 #include "lattice.h"
 #include "math_const.h"
 #include "math_extra.h"
@@ -29,6 +30,7 @@
 #include "random_park.h"
 #include "region.h"
 #include "update.h"
+#include "variable.h"
 
 #include <cmath>
 #include <cstring>
@@ -209,6 +211,10 @@ FixDeposit::~FixDeposit()
   delete [] idrigid;
   delete [] idshake;
   delete [] idregion;
+  delete [] vstr;
+  delete [] xstr;
+  delete [] ystr;
+  delete [] zstr;
   memory->destroy(coords);
   memory->destroy(imageflags);
 }
@@ -360,6 +366,8 @@ void FixDeposit::pre_exchange()
         coord[2] = zmid + random->gaussian() * sigma;
       } while (iregion->match(coord[0],coord[1],coord[2]) == 0);
     } else error->all(FLERR,"Unknown particle distribution in fix deposit");
+
+    if (varflag && vartest(coord[0],coord[1],coord[2]) == 0) continue;
 
     // adjust vertical coord by offset
 
@@ -583,8 +591,10 @@ void FixDeposit::pre_exchange()
 
   // warn if not successful b/c too many attempts
 
-  if (!success && comm->me == 0)
-    error->warning(FLERR,"Particle deposition was unsuccessful");
+  if (warnflag && !success && comm->me == 0) {
+    error->warning(FLERR,"One or more particle depositions were unsuccessful");
+    warnflag = 0;
+  }
 
   // reset global natoms,nbonds,etc
   // increment maxtag_all and maxmol_all if necessary
@@ -661,6 +671,8 @@ void FixDeposit::options(int narg, char **arg)
 
   iregion = nullptr;
   idregion = nullptr;
+  varflag = 0;
+  vstr = xstr = ystr = zstr = nullptr;
   mode = ATOM;
   molfrac = nullptr;
   rigidflag = 0;
@@ -680,6 +692,7 @@ void FixDeposit::options(int narg, char **arg)
   scaleflag = 1;
   targetflag = 0;
   orientflag = 0;
+  warnflag = 1;
   rx = 0.0;
   ry = 0.0;
   rz = 0.0;
@@ -692,6 +705,27 @@ void FixDeposit::options(int narg, char **arg)
       if (!iregion) error->all(FLERR,"Region ID {} for fix deposit does not exist",arg[iarg+1]);
       idregion = utils::strdup(arg[iarg+1]);
       iarg += 2;
+
+    } else if (strcmp(arg[iarg], "var") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "create_atoms var", error);
+      delete[] vstr;
+      vstr = utils::strdup(arg[iarg + 1]);
+      varflag = 1;
+      iarg += 2;
+    } else if (strcmp(arg[iarg], "set") == 0) {
+      if (iarg + 3 > narg) utils::missing_cmd_args(FLERR, "create_atoms set", error);
+      if (strcmp(arg[iarg + 1], "x") == 0) {
+        delete[] xstr;
+        xstr = utils::strdup(arg[iarg + 2]);
+      } else if (strcmp(arg[iarg + 1], "y") == 0) {
+        delete[] ystr;
+        ystr = utils::strdup(arg[iarg + 2]);
+      } else if (strcmp(arg[iarg + 1], "z") == 0) {
+        delete[] zstr;
+        zstr = utils::strdup(arg[iarg + 2]);
+      } else
+        error->all(FLERR, "Unknown create_atoms set option {}", arg[iarg + 2]);
+      iarg += 3;
 
     } else if (strcmp(arg[iarg],"mol") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix deposit command");
@@ -815,6 +849,39 @@ void FixDeposit::options(int narg, char **arg)
       iarg += 4;
     } else error->all(FLERR,"Illegal fix deposit command");
   }
+
+  // error check and further setup for variable test
+
+  if (!vstr && (xstr || ystr || zstr))
+    error->all(FLERR, "Incomplete use of variables in create_atoms command");
+  if (vstr && (!xstr && !ystr && !zstr))
+    error->all(FLERR, "Incomplete use of variables in create_atoms command");
+
+  if (varflag) {
+    vvar = input->variable->find(vstr);
+    if (vvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", vstr);
+    if (!input->variable->equalstyle(vvar))
+      error->all(FLERR, "Variable for create_atoms is invalid style");
+
+    if (xstr) {
+      xvar = input->variable->find(xstr);
+      if (xvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", xstr);
+      if (!input->variable->internalstyle(xvar))
+        error->all(FLERR, "Variable for create_atoms is invalid style");
+    }
+    if (ystr) {
+      yvar = input->variable->find(ystr);
+      if (yvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", ystr);
+      if (!input->variable->internalstyle(yvar))
+        error->all(FLERR, "Variable for create_atoms is invalid style");
+    }
+    if (zstr) {
+      zvar = input->variable->find(zstr);
+      if (zvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", zstr);
+      if (!input->variable->internalstyle(zvar))
+        error->all(FLERR, "Variable for create_atoms is invalid style");
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -907,4 +974,21 @@ void *FixDeposit::extract(const char *str, int &itype)
   }
 
   return nullptr;
+}
+
+/* ----------------------------------------------------------------------
+   test a generated atom position against variable evaluation
+   first set x,y,z values in internal variables
+------------------------------------------------------------------------- */
+
+int FixDeposit::vartest(double x, double y, double z)
+{
+  if (xstr) input->variable->internal_set(xvar, x);
+  if (ystr) input->variable->internal_set(yvar, y);
+  if (zstr) input->variable->internal_set(zvar, z);
+
+  double value = input->variable->compute_equal(vvar);
+
+  if (value == 0.0) return 0;
+  return 1;
 }

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -707,13 +707,13 @@ void FixDeposit::options(int narg, char **arg)
       iarg += 2;
 
     } else if (strcmp(arg[iarg], "var") == 0) {
-      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "create_atoms var", error);
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "fix deposit var", error);
       delete[] vstr;
       vstr = utils::strdup(arg[iarg + 1]);
       varflag = 1;
       iarg += 2;
     } else if (strcmp(arg[iarg], "set") == 0) {
-      if (iarg + 3 > narg) utils::missing_cmd_args(FLERR, "create_atoms set", error);
+      if (iarg + 3 > narg) utils::missing_cmd_args(FLERR, "fix deposit set", error);
       if (strcmp(arg[iarg + 1], "x") == 0) {
         delete[] xstr;
         xstr = utils::strdup(arg[iarg + 2]);
@@ -724,7 +724,7 @@ void FixDeposit::options(int narg, char **arg)
         delete[] zstr;
         zstr = utils::strdup(arg[iarg + 2]);
       } else
-        error->all(FLERR, "Unknown create_atoms set option {}", arg[iarg + 2]);
+        error->all(FLERR, "Unknown fix deposit set option {}", arg[iarg + 2]);
       iarg += 3;
 
     } else if (strcmp(arg[iarg],"mol") == 0) {
@@ -853,33 +853,33 @@ void FixDeposit::options(int narg, char **arg)
   // error check and further setup for variable test
 
   if (!vstr && (xstr || ystr || zstr))
-    error->all(FLERR, "Incomplete use of variables in create_atoms command");
+    error->all(FLERR, "Incomplete use of variables in fix deposit command");
   if (vstr && (!xstr && !ystr && !zstr))
-    error->all(FLERR, "Incomplete use of variables in create_atoms command");
+    error->all(FLERR, "Incomplete use of variables in fix deposit command");
 
   if (varflag) {
     vvar = input->variable->find(vstr);
-    if (vvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", vstr);
+    if (vvar < 0) error->all(FLERR, "Variable {} for fix deposit does not exist", vstr);
     if (!input->variable->equalstyle(vvar))
-      error->all(FLERR, "Variable for create_atoms is invalid style");
+      error->all(FLERR, "Variable for fix deposit is invalid style");
 
     if (xstr) {
       xvar = input->variable->find(xstr);
-      if (xvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", xstr);
+      if (xvar < 0) error->all(FLERR, "Variable {} for fix deposit does not exist", xstr);
       if (!input->variable->internalstyle(xvar))
-        error->all(FLERR, "Variable for create_atoms is invalid style");
+        error->all(FLERR, "Variable for fix deposit is invalid style");
     }
     if (ystr) {
       yvar = input->variable->find(ystr);
-      if (yvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", ystr);
+      if (yvar < 0) error->all(FLERR, "Variable {} for fix deposit does not exist", ystr);
       if (!input->variable->internalstyle(yvar))
-        error->all(FLERR, "Variable for create_atoms is invalid style");
+        error->all(FLERR, "Variable for fix deposit is invalid style");
     }
     if (zstr) {
       zvar = input->variable->find(zstr);
-      if (zvar < 0) error->all(FLERR, "Variable {} for create_atoms does not exist", zstr);
+      if (zvar < 0) error->all(FLERR, "Variable {} for fix deposit does not exist", zstr);
       if (!input->variable->internalstyle(zvar))
-        error->all(FLERR, "Variable for create_atoms is invalid style");
+        error->all(FLERR, "Variable for fix deposit is invalid style");
     }
   }
 }

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -232,6 +232,8 @@ int FixDeposit::setmask()
 
 void FixDeposit::init()
 {
+  warnflag = 1;
+
   // set index and check validity of region
 
   iregion = domain->get_region_by_id(idregion);

--- a/src/fix_deposit.h
+++ b/src/fix_deposit.h
@@ -40,7 +40,8 @@ class FixDeposit : public Fix {
  private:
   int ninsert, ntype, nfreq, seed;
   int globalflag, localflag, maxattempt, rateflag, scaleflag, targetflag;
-  int mode, rigidflag, shakeflag, idnext, distflag, orientflag;
+  int mode, rigidflag, shakeflag, idnext, distflag, orientflag, warnflag;
+  int varflag, vvar, xvar, yvar, zvar;
   double lo, hi, deltasq, nearsq, rate, sigma;
   double vxlo, vxhi, vylo, vyhi, vzlo, vzhi;
   double xlo, xhi, ylo, yhi, zlo, zhi, xmid, ymid, zmid;
@@ -48,6 +49,8 @@ class FixDeposit : public Fix {
   class Region *iregion;
   char *idregion;
   char *idrigid, *idshake;
+  char *vstr, *xstr, *ystr, *zstr;
+  char *xstr_copy, *ystr_copy, *zstr_copy;
 
   class Molecule **onemols;
   int nmol, natom_max;
@@ -64,6 +67,7 @@ class FixDeposit : public Fix {
 
   void find_maxid();
   void options(int, char **);
+  int vartest(double, double, double); // evaluate a variable with new atom position
 };
 
 }    // namespace LAMMPS_NS


### PR DESCRIPTION
**Summary**

add var and set keywords to fix deposit to allow deposition within an isosurface, same as create_atoms

**Related Issue(s)**

builds on #3957

**Author(s)**

JG

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


