### PR TITLE
Fix bug with compute cluster/atom and aggregate/atom when used with fix deform

### DIFF
--- a/src/compute_aggregate_atom.cpp
+++ b/src/compute_aggregate_atom.cpp
@@ -110,6 +110,11 @@ void ComputeAggregateAtom::compute_peratom()
     vector_atom = aggregateID;
   }
 
+  // communicate coords for ghost atoms if box can change, e.g. fix deform
+  // this ensures ghost atom coords are current
+
+  comm->forward_comm();
+
   // invoke full neighbor list (will copy or build if necessary)
   // on the first step of a run, set preflag to one in neighbor->build_one(...)
 

--- a/src/compute_cluster_atom.cpp
+++ b/src/compute_cluster_atom.cpp
@@ -99,6 +99,11 @@ void ComputeClusterAtom::compute_peratom()
     vector_atom = clusterID;
   }
 
+  // communicate coords for ghost atoms if box can change, e.g. fix deform
+  // this ensures ghost atom coords are current
+
+  comm->forward_comm();
+
   // invoke full neighbor list (will copy or build if necessary)
   // on the first step of a run, set preflag to one in neighbor->build_one(...)
 


### PR DESCRIPTION
**Summary**

The algorithm used in compute cluster/atom and compute aggregate/atom to identify clusters depends on ghost atom coords being current (at the end of the timestep).  Fixes which change the box, such as fix deform, will remap atoms to the new box,
but not re-communicate ghost atoms.  This PR adds logic to do that to compute cluster/atom and aggregate atom.

Without this logic, the cluster identification loop can hang, as discussed in 
https://matsci.org/t/clustering-while-deforming-stulls-the-run/51613
Thanks to Yura_Polyachenko for posting the issue and an example script that had the problem.

**Related Issue(s)**

Should fix the issue identified in the MatSci forum:
https://matsci.org/t/clustering-while-deforming-stulls-the-run/51613

**Author(s)**

Steve and Axel

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


