### PR TITLE
Bugfix: Correctly build argv with nullptr at the end

### DIFF
--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -379,8 +379,9 @@ class lammps(object):
           for i in range(narg):
             if type(cmdargs[i]) is str:
               cmdargs[i] = cmdargs[i].encode()
-          cargs = (c_char_p*narg)(*cmdargs)
-          self.lib.lammps_open.argtypes = [c_int, c_char_p*narg, MPI_Comm, c_void_p]
+          cargs = (c_char_p*(narg+1))(*cmdargs)
+          cargs[narg] = None
+          self.lib.lammps_open.argtypes = [c_int, c_char_p*(narg+1), MPI_Comm, c_void_p]
         else:
           self.lib.lammps_open.argtypes = [c_int, c_char_p, MPI_Comm, c_void_p]
 
@@ -399,8 +400,9 @@ class lammps(object):
           for i in range(narg):
             if type(cmdargs[i]) is str:
               cmdargs[i] = cmdargs[i].encode()
-          cargs = (c_char_p*narg)(*cmdargs)
-          self.lib.lammps_open_no_mpi.argtypes = [c_int, c_char_p*narg, c_void_p]
+          cargs = (c_char_p*(narg+1))(*cmdargs)
+          cargs[narg] = None
+          self.lib.lammps_open_no_mpi.argtypes = [c_int, c_char_p*(narg+1), c_void_p]
           self.lmp = c_void_p(self.lib.lammps_open_no_mpi(narg,cargs,None))
         else:
           self.lib.lammps_open_no_mpi.argtypes = [c_int, c_char_p, c_void_p]

--- a/src/angle_write.cpp
+++ b/src/angle_write.cpp
@@ -123,11 +123,9 @@ void AngleWrite::command(int narg, char **arg)
 
   if (comm->me == 0) {
     // set up new LAMMPS instance with dummy system to evaluate angle potential
-    const char *args[] = {"AngleWrite", "-nocite", "-echo",   "none",
-                          "-log",       "none",    "-screen", "none"};
-    char **argv = (char **) args;
-    int argc = sizeof(args) / sizeof(char *);
-    LAMMPS *writer = new LAMMPS(argc, argv, singlecomm);
+    LAMMPS::argv args = {"AngleWrite", "-nocite", "-echo",   "none",
+                         "-log",       "none",    "-screen", "none"};
+    LAMMPS *writer = new LAMMPS(args, singlecomm);
 
     // create dummy system replicating angle style settings
     writer->input->one(fmt::format("units {}", update->unit_style));

--- a/src/dihedral_write.cpp
+++ b/src/dihedral_write.cpp
@@ -124,12 +124,8 @@ void DihedralWrite::command(int narg, char **arg)
 
   if (comm->me == 0) {
     // set up new LAMMPS instance with dummy system to evaluate dihedral potential
-    //    const char *args[] = {"DihedralWrite", "-nocite", "-echo",   "none",
-    //                          "-log",          "none",    "-screen", "none"};
-    const char *args[] = {"DihedralWrite", "-nocite", "-echo", "screen", "-log", "none"};
-    char **argv = (char **) args;
-    int argc = sizeof(args) / sizeof(char *);
-    LAMMPS *writer = new LAMMPS(argc, argv, singlecomm);
+    LAMMPS::argv args = {"DihedralWrite", "-nocite", "-echo", "screen", "-log", "none"};
+    LAMMPS *writer = new LAMMPS(args, singlecomm);
 
     // create dummy system replicating dihedral style settings
     writer->input->one(fmt::format("units {}", update->unit_style));

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -109,6 +109,15 @@ using namespace LAMMPS_NS;
 
 /** Create a LAMMPS simulation instance
  *
+ * \param args list of arguments
+ * \param communicator MPI communicator used by this LAMMPS instance
+ */
+LAMMPS::LAMMPS(argv & args, MPI_Comm communicator) :
+  LAMMPS(args.size(), argv_pointers(args).data(), communicator) {
+}
+
+/** Create a LAMMPS simulation instance
+ *
  * The LAMMPS constructor starts up a simulation by allocating all
  * fundamental classes in the necessary order, parses input switches
  * and their arguments, initializes communicators, screen and logfile
@@ -1463,4 +1472,18 @@ void LAMMPS::print_config(FILE *fp)
     ncline += ncword + 1;
   }
   fputs("\n\n",fp);
+}
+
+/** Create vector of argv string pointers including terminating nullptr element
+ *
+ * \param args list of arguments
+ */
+std::vector<char*> LAMMPS::argv_pointers(argv & args){
+  std::vector<char*> r;
+  r.reserve(args.size()+1);
+  for(auto & a : args) {
+    r.push_back((char*)a.data());
+  }
+  r.push_back(nullptr);
+  return r;
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -219,7 +219,7 @@ LAMMPS::LAMMPS(int narg, char **arg, MPI_Comm communicator) :
   suffix = suffix2 = nullptr;
   suffix_enable = 0;
   pair_only_flag = 0;
-  if (arg) exename = arg[0];
+  if (arg) exename = utils::strdup(arg[0]);
   else exename = nullptr;
   packargs = nullptr;
   num_package = 0;
@@ -809,6 +809,7 @@ LAMMPS::~LAMMPS() noexcept(false)
   delete memory;
 
   delete pkg_lists;
+  delete[] exename;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -16,6 +16,8 @@
 
 #include <cstdio>
 #include <mpi.h>
+#include <string>
+#include <vector>
 
 namespace LAMMPS_NS {
 
@@ -84,6 +86,10 @@ class LAMMPS {
   static const char *git_branch();
   static const char *git_descriptor();
 
+  using argv = std::vector<std::string>;
+  static std::vector<char*> argv_pointers(argv & args);
+
+  LAMMPS(argv & args, MPI_Comm);
   LAMMPS(int, char **, MPI_Comm);
   ~LAMMPS() noexcept(false);
   void create();

--- a/unittest/c-library/test_library_commands.cpp
+++ b/unittest/c-library/test_library_commands.cpp
@@ -26,10 +26,11 @@ protected:
     void SetUp() override
     {
         const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite",
-                              "-var",        "x",    "2",    "-var",  "zpos",   "1.5"};
+                              "-var",        "x",    "2",    "-var",  "zpos",   "1.5",
+                              nullptr};
 
         char **argv = (char **)args;
-        int argc    = sizeof(args) / sizeof(char *);
+        int argc    = (sizeof(args) / sizeof(char *)) - 1;
 
         ::testing::internal::CaptureStdout();
         lmp                = lammps_open_no_mpi(argc, argv, nullptr);

--- a/unittest/c-library/test_library_config.cpp
+++ b/unittest/c-library/test_library_config.cpp
@@ -29,10 +29,11 @@ protected:
     {
         const char *args[] = {"LAMMPS_test", "-log",      "none",
                               "-echo",       "screen",    "-nocite",
-                              "-var",        "input_dir", STRINGIFY(TEST_INPUT_FOLDER)};
+                              "-var",        "input_dir", STRINGIFY(TEST_INPUT_FOLDER),
+                              nullptr};
 
         char **argv = (char **)args;
-        int argc    = sizeof(args) / sizeof(char *);
+        int argc    = (sizeof(args) / sizeof(char *)) - 1;
 
         ::testing::internal::CaptureStdout();
         lmp = lammps_open_no_mpi(argc, argv, nullptr);

--- a/unittest/c-library/test_library_external.cpp
+++ b/unittest/c-library/test_library_external.cpp
@@ -64,9 +64,9 @@ static void callback(void *handle, step_t timestep, int nlocal, tag_t *, double 
 
 TEST(lammps_external, callback)
 {
-    const char *args[] = {"liblammps", "-log", "none", "-nocite"};
+    const char *args[] = {"liblammps", "-log", "none", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
 
     ::testing::internal::CaptureStdout();
     void *handle       = lammps_open_no_mpi(argc, argv, nullptr);
@@ -131,9 +131,9 @@ TEST(lammps_external, callback)
 
 TEST(lammps_external, array)
 {
-    const char *args[] = {"liblammps", "-log", "none", "-nocite"};
+    const char *args[] = {"liblammps", "-log", "none", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
 
     ::testing::internal::CaptureStdout();
     void *handle       = lammps_open_no_mpi(argc, argv, nullptr);

--- a/unittest/c-library/test_library_mpi.cpp
+++ b/unittest/c-library/test_library_mpi.cpp
@@ -34,9 +34,9 @@ TEST(MPI, global_box)
     int boxflag;
 
     ::testing::internal::CaptureStdout();
-    const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite"};
+    const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
     void *lmp          = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr);
     lammps_command(lmp, "units           lj");
     lammps_command(lmp, "atom_style      atomic");
@@ -77,9 +77,9 @@ TEST(MPI, sub_box)
     int boxflag;
 
     ::testing::internal::CaptureStdout();
-    const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite"};
+    const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
     void *lmp          = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr);
     lammps_command(lmp, "units           lj");
     lammps_command(lmp, "atom_style      atomic");
@@ -143,9 +143,9 @@ TEST(MPI, split_comm)
 
     MPI_Comm_split(MPI_COMM_WORLD, color, key, &newcomm);
 
-    const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite"};
+    const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
     void *lmp          = lammps_open(argc, argv, newcomm, nullptr);
     lammps_command(lmp, "units           lj");
     lammps_command(lmp, "atom_style      atomic");
@@ -173,9 +173,9 @@ TEST(MPI, multi_partition)
     MPI_Comm_rank(MPI_COMM_WORLD, &me);
 
     const char *args[] = {"LAMMPS_test", "-log",   "none",    "-partition", "4x1",
-                          "-echo",       "screen", "-nocite", "-in",        "none"};
+                          "-echo",       "screen", "-nocite", "-in",        "none", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
     void *lmp          = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr);
 
     lammps_command(lmp, "units           lj");
@@ -205,9 +205,9 @@ protected:
 
     void SetUp() override
     {
-        const char *args[] = {testbinary, "-log", "none", "-echo", "screen", "-nocite"};
+        const char *args[] = {testbinary, "-log", "none", "-echo", "screen", "-nocite", nullptr};
         char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        int argc           = (sizeof(args) / sizeof(char *)) - 1;
         if (!verbose) ::testing::internal::CaptureStdout();
         lmp = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr);
         InitSystem();

--- a/unittest/c-library/test_library_open.cpp
+++ b/unittest/c-library/test_library_open.cpp
@@ -39,9 +39,9 @@ TEST(lammps_open, null_args)
 
 TEST(lammps_open, with_args)
 {
-    const char *args[] = {"liblammps", "-log", "none", "-nocite"};
+    const char *args[] = {"liblammps", "-log", "none", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
 
     // MPI is already initialized
     MPI_Comm mycomm;
@@ -78,9 +78,9 @@ TEST(lammps_open, with_args)
 TEST(lammps_open, with_kokkos)
 {
     if (!LAMMPS_NS::LAMMPS::is_installed_pkg("KOKKOS")) GTEST_SKIP();
-    const char *args[] = {"liblammps", "-k", "on", "t", "2", "-sf", "kk", "-log", "none"};
+    const char *args[] = {"liblammps", "-k", "on", "t", "2", "-sf", "kk", "-log", "none", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
 
     ::testing::internal::CaptureStdout();
     void *alt_ptr;
@@ -108,9 +108,9 @@ TEST(lammps_open, with_kokkos)
 
 TEST(lammps_open_no_mpi, no_screen)
 {
-    const char *args[] = {"liblammps", "-log", "none", "-screen", "none", "-nocite"};
+    const char *args[] = {"liblammps", "-log", "none", "-screen", "none", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
 
     ::testing::internal::CaptureStdout();
     void *alt_ptr;
@@ -139,9 +139,9 @@ TEST(lammps_open_no_mpi, with_omp)
 {
     if (!LAMMPS_NS::LAMMPS::is_installed_pkg("OPENMP")) GTEST_SKIP();
     const char *args[] = {"liblammps", "-pk", "omp",  "2",    "neigh",  "no",
-                          "-sf",       "omp", "-log", "none", "-nocite"};
+                          "-sf",       "omp", "-log", "none", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
 
     ::testing::internal::CaptureStdout();
     void *alt_ptr;
@@ -201,9 +201,9 @@ TEST(lammps_open_fortran, no_args)
 
 TEST(lammps_open_no_mpi, lammps_error)
 {
-    const char *args[] = {"liblammps", "-log", "none", "-nocite"};
+    const char *args[] = {"liblammps", "-log", "none", "-nocite", nullptr};
     char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    int argc           = (sizeof(args) / sizeof(char *)) - 1;
 
     ::testing::internal::CaptureStdout();
     void *alt_ptr;

--- a/unittest/c-library/test_library_properties.cpp
+++ b/unittest/c-library/test_library_properties.cpp
@@ -33,10 +33,11 @@ protected:
     {
         const char *args[] = {"LAMMPS_test", "-log",      "none",
                               "-echo",       "screen",    "-nocite",
-                              "-var",        "input_dir", STRINGIFY(TEST_INPUT_FOLDER)};
+                              "-var",        "input_dir", STRINGIFY(TEST_INPUT_FOLDER),
+                              nullptr};
 
         char **argv = (char **)args;
-        int argc    = sizeof(args) / sizeof(char *);
+        int argc    = (sizeof(args) / sizeof(char *)) - 1;
 
         ::testing::internal::CaptureStdout();
         lmp                = lammps_open_no_mpi(argc, argv, nullptr);
@@ -551,10 +552,10 @@ protected:
 
     void SetUp() override
     {
-        const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite"};
+        const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite", nullptr};
 
         char **argv = (char **)args;
-        int argc    = sizeof(args) / sizeof(char *);
+        int argc    = (sizeof(args) / sizeof(char *)) - 1;
 
         ::testing::internal::CaptureStdout();
         lmp                = lammps_open_no_mpi(argc, argv, nullptr);
@@ -632,10 +633,10 @@ TEST(SystemSettings, kokkos)
 
     // clang-format off
     const char *args[] = {"SystemSettings", "-log", "none", "-echo", "screen", "-nocite",
-                          "-k", "on", "t", "4", "-sf", "kk"};
+                          "-k", "on", "t", "4", "-sf", "kk", nullptr};
     // clang-format on
     char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    int argc    = (sizeof(args) / sizeof(char *)) - 1;
 
     ::testing::internal::CaptureStdout();
     void *lmp          = lammps_open_no_mpi(argc, argv, nullptr);

--- a/unittest/c-library/test_library_scatter_gather.cpp
+++ b/unittest/c-library/test_library_scatter_gather.cpp
@@ -32,10 +32,11 @@ protected:
     {
         const char *args[] = {"LAMMPS_test", "-log",      "none",
                               "-echo",       "screen",    "-nocite",
-                              "-var",        "input_dir", STRINGIFY(TEST_INPUT_FOLDER)};
+                              "-var",        "input_dir", STRINGIFY(TEST_INPUT_FOLDER),
+                              nullptr};
 
         char **argv = (char **)args;
-        int argc    = sizeof(args) / sizeof(char *);
+        int argc    = (sizeof(args) / sizeof(char *)) - 1;
 
         ::testing::internal::CaptureStdout();
         lmp                = lammps_open_no_mpi(argc, argv, nullptr);

--- a/unittest/commands/test_mpi_load_balancing.cpp
+++ b/unittest/commands/test_mpi_load_balancing.cpp
@@ -33,11 +33,9 @@ protected:
 
     void SetUp() override
     {
-        const char *args[] = {testbinary, "-log", "none", "-echo", "screen", "-nocite"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        LAMMPS::argv args = {testbinary, "-log", "none", "-echo", "screen", "-nocite"};
         if (!verbose) ::testing::internal::CaptureStdout();
-        lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+        lmp = new LAMMPS(args, MPI_COMM_WORLD);
         InitSystem();
         if (!verbose) ::testing::internal::GetCapturedStdout();
     }

--- a/unittest/cplusplus/test_input_class.cpp
+++ b/unittest/cplusplus/test_input_class.cpp
@@ -8,6 +8,7 @@
 #include <mpi.h>
 #include <string>
 
+#include "../testing/utils.h"
 #include "gtest/gtest.h"
 
 const char *demo_input[] = {"region       box block 0 $x 0 2 0 2", "create_box 1 box",
@@ -21,9 +22,9 @@ protected:
     LAMMPS *lmp;
     Input_commands()
     {
-        const char *args[] = {"LAMMPS_test"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        const char * args[] = {"LAMMPS_test", nullptr};
+        char ** argv = (char**)args;
+        int argc = 1;
 
         int flag;
         MPI_Initialized(&flag);
@@ -33,13 +34,11 @@ protected:
 
     void SetUp() override
     {
-        const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite",
-                              "-var",        "zpos", "1.5",  "-var",  "x",      "2"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        LAMMPS::argv args = {"LAMMPS_test", "-log", "none", "-echo", "screen", "-nocite",
+                             "-var",        "zpos", "1.5",  "-var",  "x",      "2"};
 
         ::testing::internal::CaptureStdout();
-        lmp                = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+        lmp                = new LAMMPS(args, MPI_COMM_WORLD);
         std::string output = ::testing::internal::GetCapturedStdout();
         EXPECT_STREQ(output.substr(0, 8).c_str(), "LAMMPS (");
     }

--- a/unittest/cplusplus/test_lammps_class.cpp
+++ b/unittest/cplusplus/test_lammps_class.cpp
@@ -21,9 +21,9 @@ protected:
     LAMMPS *lmp;
     LAMMPS_plain() : lmp(nullptr)
     {
-        const char *args[] = {"LAMMPS_test"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        const char * args[] = {"LAMMPS_test", nullptr};
+        char ** argv = (char**)args;
+        int argc = 1;
 
         int flag;
         MPI_Initialized(&flag);
@@ -34,12 +34,10 @@ protected:
 
     void SetUp() override
     {
-        const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "both", "-nocite"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        LAMMPS::argv args = {"LAMMPS_test", "-log", "none", "-echo", "both", "-nocite"};
 
         ::testing::internal::CaptureStdout();
-        lmp                = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+        lmp = new LAMMPS(args, MPI_COMM_WORLD);
         std::string output = ::testing::internal::GetCapturedStdout();
         EXPECT_THAT(output, StartsWith("LAMMPS ("));
     }
@@ -159,9 +157,9 @@ protected:
     LAMMPS *lmp;
     LAMMPS_omp() : lmp(nullptr)
     {
-        const char *args[] = {"LAMMPS_test"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        const char * args[] = {"LAMMPS_test", nullptr};
+        char ** argv = (char**)args;
+        int argc = 1;
 
         int flag;
         MPI_Initialized(&flag);
@@ -172,15 +170,13 @@ protected:
 
     void SetUp() override
     {
-        const char *args[] = {"LAMMPS_test", "-log", "none", "-screen", "none", "-echo", "screen",
-                              "-pk",         "omp",  "2",    "neigh",   "yes",  "-sf",   "omp"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        LAMMPS::argv args = {"LAMMPS_test", "-log", "none", "-screen", "none", "-echo", "screen",
+                             "-pk",         "omp",  "2",    "neigh",   "yes",  "-sf",   "omp"};
 
         // only run this test fixture with omp suffix if OPENMP package is installed
 
         if (LAMMPS::is_installed_pkg("OPENMP"))
-            lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+            lmp = new LAMMPS(args, MPI_COMM_WORLD);
         else
             GTEST_SKIP();
     }
@@ -242,9 +238,9 @@ protected:
     LAMMPS *lmp;
     LAMMPS_kokkos() : lmp(nullptr)
     {
-        const char *args[] = {"LAMMPS_test"};
-        char **argv        = (char **)args;
-        int argc           = sizeof(args) / sizeof(char *);
+        const char * args[] = {"LAMMPS_test", nullptr};
+        char ** argv = (char**)args;
+        int argc = 1;
 
         int flag;
         MPI_Initialized(&flag);
@@ -255,15 +251,13 @@ protected:
 
     void SetUp() override
     {
-        const char *args[] = {"LAMMPS_test", "-log", "none", "-echo", "none", "-screen", "none",
-                              "-k",          "on",   "t",    "1",     "-sf",  "kk"};
+        LAMMPS::argv args = {"LAMMPS_test", "-log", "none", "-echo", "none", "-screen", "none",
+                             "-k",          "on",   "t",    "1",     "-sf",  "kk"};
         if (Info::has_accelerator_feature("KOKKOS", "api", "openmp")) args[10] = "2";
-        char **argv = (char **)args;
-        int argc    = sizeof(args) / sizeof(char *);
 
         if (LAMMPS::is_installed_pkg("KOKKOS")) {
             ::testing::internal::CaptureStdout();
-            lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+            lmp = new LAMMPS(args, MPI_COMM_WORLD);
             ::testing::internal::GetCapturedStdout();
         } else
             GTEST_SKIP();
@@ -333,12 +327,10 @@ TEST(LAMMPS_init, OpenMP)
     fputs("\n", fp);
     fclose(fp);
 
-    const char *args[] = {"LAMMPS_init", "-in", "in.lammps_empty", "-log", "none", "-nocite"};
-    char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"LAMMPS_init", "-in", "in.lammps_empty", "-log", "none", "-nocite"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp        = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+    LAMMPS *lmp        = new LAMMPS(args, MPI_COMM_WORLD);
     std::string output = ::testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, ContainsRegex(".*using 2 OpenMP thread.*per MPI task.*"));
 
@@ -366,12 +358,10 @@ TEST(LAMMPS_init, NoOpenMP)
     fclose(fp);
     platform::unsetenv("OMP_NUM_THREADS");
 
-    const char *args[] = {"LAMMPS_init", "-in", "in.lammps_class_noomp", "-log", "none", "-nocite"};
-    char **argv        = (char **)args;
-    int argc           = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"LAMMPS_init", "-in", "in.lammps_class_noomp", "-log", "none", "-nocite"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp        = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+    LAMMPS *lmp        = new LAMMPS(args, MPI_COMM_WORLD);
     std::string output = ::testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, ContainsRegex(
                             ".*OMP_NUM_THREADS environment is not set.*Defaulting to 1 thread.*"));

--- a/unittest/force-styles/test_angle_style.cpp
+++ b/unittest/force-styles/test_angle_style.cpp
@@ -59,11 +59,11 @@ void cleanup_lammps(LAMMPS *lmp, const TestConfig &cfg)
     delete lmp;
 }
 
-LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool newton = true)
+LAMMPS *init_lammps(LAMMPS::argv & args, const TestConfig &cfg, const bool newton = true)
 {
     LAMMPS *lmp;
 
-    lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+    lmp = new LAMMPS(args, MPI_COMM_WORLD);
 
     // check if prerequisite styles are available
     Info *info = new Info(lmp);
@@ -211,11 +211,9 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 void generate_yaml_file(const char *outfile, const TestConfig &config)
 {
     // initialize system geometry
-    const char *args[] = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
+    LAMMPS::argv args = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
-    LAMMPS *lmp = init_lammps(argc, argv, config);
+    LAMMPS *lmp = init_lammps(args, config);
     if (!lmp) {
         std::cerr << "One or more prerequisite styles are not available "
                      "in this LAMMPS configuration:\n";
@@ -303,13 +301,10 @@ TEST(AngleStyle, plain)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -358,7 +353,7 @@ TEST(AngleStyle, plain)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on
@@ -422,14 +417,11 @@ TEST(AngleStyle, omp)
     if (!LAMMPS::is_installed_pkg("OPENMP")) GTEST_SKIP();
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite",
-                          "-pk",        "omp",  "4",    "-sf",   "omp"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite",
+                         "-pk",        "omp",  "4",    "-sf",   "omp"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -482,7 +474,7 @@ TEST(AngleStyle, omp)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on
@@ -525,14 +517,11 @@ TEST(AngleStyle, single)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     // create a LAMMPS instance with standard settings to detect the number of atom types
     if (!verbose) ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config);
+    LAMMPS *lmp = init_lammps(args, test_config);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     if (!lmp) {
@@ -672,13 +661,10 @@ TEST(AngleStyle, extract)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     if (!verbose) ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     if (!lmp) {

--- a/unittest/force-styles/test_bond_style.cpp
+++ b/unittest/force-styles/test_bond_style.cpp
@@ -59,11 +59,11 @@ void cleanup_lammps(LAMMPS *lmp, const TestConfig &cfg)
     delete lmp;
 }
 
-LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool newton = true)
+LAMMPS *init_lammps(LAMMPS::argv & args, const TestConfig &cfg, const bool newton = true)
 {
     LAMMPS *lmp;
 
-    lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+    lmp = new LAMMPS(args, MPI_COMM_WORLD);
 
     // check if prerequisite styles are available
     Info *info = new Info(lmp);
@@ -211,11 +211,9 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 void generate_yaml_file(const char *outfile, const TestConfig &config)
 {
     // initialize system geometry
-    const char *args[] = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
+    LAMMPS::argv args = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
-    LAMMPS *lmp = init_lammps(argc, argv, config);
+    LAMMPS *lmp = init_lammps(args, config);
     if (!lmp) {
         std::cerr << "One or more prerequisite styles are not available "
                      "in this LAMMPS configuration:\n";
@@ -303,13 +301,10 @@ TEST(BondStyle, plain)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -358,7 +353,7 @@ TEST(BondStyle, plain)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on
@@ -424,14 +419,11 @@ TEST(BondStyle, omp)
     if (!LAMMPS::is_installed_pkg("OPENMP")) GTEST_SKIP();
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite",
-                          "-pk",       "omp",  "4",    "-sf",   "omp"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite",
+                         "-pk",       "omp",  "4",    "-sf",   "omp"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -484,7 +476,7 @@ TEST(BondStyle, omp)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on
@@ -527,14 +519,11 @@ TEST(BondStyle, single)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     // create a LAMMPS instance with standard settings to detect the number of atom types
     if (!verbose) ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config);
+    LAMMPS *lmp = init_lammps(args, test_config);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     if (!lmp) {
@@ -785,13 +774,10 @@ TEST(BondStyle, extract)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     if (!verbose) ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     if (!lmp) {

--- a/unittest/force-styles/test_dihedral_style.cpp
+++ b/unittest/force-styles/test_dihedral_style.cpp
@@ -59,11 +59,9 @@ void cleanup_lammps(LAMMPS *lmp, const TestConfig &cfg)
     delete lmp;
 }
 
-LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool newton = true)
+LAMMPS *init_lammps(LAMMPS::argv & args, const TestConfig &cfg, const bool newton = true)
 {
-    LAMMPS *lmp;
-
-    lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+    LAMMPS *lmp = new LAMMPS(args, MPI_COMM_WORLD);
 
     // check if prerequisite styles are available
     Info *info = new Info(lmp);
@@ -220,11 +218,9 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 void generate_yaml_file(const char *outfile, const TestConfig &config)
 {
     // initialize system geometry
-    const char *args[] = {"DihedralStyle", "-log", "none", "-echo", "screen", "-nocite"};
+    LAMMPS::argv args = {"DihedralStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
-    LAMMPS *lmp = init_lammps(argc, argv, config);
+    LAMMPS *lmp = init_lammps(args, config);
     if (!lmp) {
         std::cerr << "One or more prerequisite styles are not available "
                      "in this LAMMPS configuration:\n";
@@ -306,13 +302,10 @@ TEST(DihedralStyle, plain)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"DihedralStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"DihedralStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -361,7 +354,7 @@ TEST(DihedralStyle, plain)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on
@@ -427,14 +420,11 @@ TEST(DihedralStyle, omp)
     if (!LAMMPS::is_installed_pkg("OPENMP")) GTEST_SKIP();
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"DihedralStyle", "-log", "none", "-echo", "screen", "-nocite",
-                          "-pk",           "omp",  "4",    "-sf",   "omp"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"DihedralStyle", "-log", "none", "-echo", "screen", "-nocite",
+                         "-pk",           "omp",  "4",    "-sf",   "omp"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -488,7 +478,7 @@ TEST(DihedralStyle, omp)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on

--- a/unittest/force-styles/test_fix_timestep.cpp
+++ b/unittest/force-styles/test_fix_timestep.cpp
@@ -61,11 +61,11 @@ void cleanup_lammps(LAMMPS *lmp, const TestConfig &cfg)
     delete lmp;
 }
 
-LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool use_respa = false)
+LAMMPS *init_lammps(LAMMPS::argv & args, const TestConfig &cfg, const bool use_respa = false)
 {
     LAMMPS *lmp;
 
-    lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+    lmp = new LAMMPS(args, MPI_COMM_WORLD);
 
     // check if prerequisite styles are available
     Info *info = new Info(lmp);
@@ -169,11 +169,8 @@ void restart_lammps(LAMMPS *lmp, const TestConfig &cfg, bool use_rmass, bool use
 void generate_yaml_file(const char *outfile, const TestConfig &config)
 {
     // initialize system geometry
-    const char *args[] = {"FixIntegrate", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
-    LAMMPS *lmp = init_lammps(argc, argv, config);
+    LAMMPS::argv args = {"FixIntegrate", "-log", "none", "-echo", "screen", "-nocite"};
+    LAMMPS *lmp = init_lammps(args, config);
     if (!lmp) {
         std::cerr << "One or more prerequisite styles are not available "
                      "in this LAMMPS configuration:\n";
@@ -252,13 +249,10 @@ TEST(FixTimestep, plain)
     if (test_config.skip_tests.count("static")) GTEST_SKIP();
 #endif
 
-    const char *args[] = {"FixTimestep", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"FixTimestep", "-log", "none", "-echo", "screen", "-nocite"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp        = init_lammps(argc, argv, test_config);
+    LAMMPS *lmp        = init_lammps(args, test_config);
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
 
@@ -420,7 +414,7 @@ TEST(FixTimestep, plain)
         if (!verbose) ::testing::internal::GetCapturedStdout();
 
         ::testing::internal::CaptureStdout();
-        lmp    = init_lammps(argc, argv, test_config, true);
+        lmp    = init_lammps(args, test_config, true);
         output = ::testing::internal::GetCapturedStdout();
         if (verbose) std::cout << output;
 
@@ -554,14 +548,12 @@ TEST(FixTimestep, omp)
     if (test_config.skip_tests.count("static")) GTEST_SKIP();
 #endif
 
-    const char *args[] = {"FixTimestep", "-log", "none", "-echo", "screen", "-nocite",
-                          "-pk",         "omp",  "4",    "-sf",   "omp"};
+    LAMMPS::argv args = {"FixTimestep", "-log", "none", "-echo", "screen", "-nocite",
+                         "-pk",         "omp",  "4",    "-sf",   "omp"};
 
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp        = init_lammps(argc, argv, test_config);
+    LAMMPS *lmp        = init_lammps(args, test_config);
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
 
@@ -723,7 +715,7 @@ TEST(FixTimestep, omp)
         if (!verbose) ::testing::internal::GetCapturedStdout();
 
         ::testing::internal::CaptureStdout();
-        lmp    = init_lammps(argc, argv, test_config, true);
+        lmp    = init_lammps(args, test_config, true);
         output = ::testing::internal::GetCapturedStdout();
         if (verbose) std::cout << output;
 

--- a/unittest/force-styles/test_improper_style.cpp
+++ b/unittest/force-styles/test_improper_style.cpp
@@ -59,11 +59,11 @@ void cleanup_lammps(LAMMPS *lmp, const TestConfig &cfg)
     delete lmp;
 }
 
-LAMMPS *init_lammps(int argc, char **argv, const TestConfig &cfg, const bool newton = true)
+LAMMPS *init_lammps(LAMMPS::argv & args, const TestConfig &cfg, const bool newton = true)
 {
     LAMMPS *lmp;
 
-    lmp = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+    lmp = new LAMMPS(args, MPI_COMM_WORLD);
 
     // check if prerequisite styles are available
     Info *info = new Info(lmp);
@@ -211,11 +211,9 @@ void data_lammps(LAMMPS *lmp, const TestConfig &cfg)
 void generate_yaml_file(const char *outfile, const TestConfig &config)
 {
     // initialize system geometry
-    const char *args[] = {"ImproperStyle", "-log", "none", "-echo", "screen", "-nocite"};
+    LAMMPS::argv args = {"ImproperStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
-    LAMMPS *lmp = init_lammps(argc, argv, config);
+    LAMMPS *lmp = init_lammps(args, config);
     if (!lmp) {
         std::cerr << "One or more prerequisite styles are not available "
                      "in this LAMMPS configuration:\n";
@@ -297,13 +295,10 @@ TEST(ImproperStyle, plain)
 {
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"ImproperStyle", "-log", "none", "-echo", "screen", "-nocite"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"ImproperStyle", "-log", "none", "-echo", "screen", "-nocite"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -352,7 +347,7 @@ TEST(ImproperStyle, plain)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on
@@ -418,14 +413,11 @@ TEST(ImproperStyle, omp)
     if (!LAMMPS::is_installed_pkg("OPENMP")) GTEST_SKIP();
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
 
-    const char *args[] = {"ImproperStyle", "-log", "none", "-echo", "screen", "-nocite",
-                          "-pk",           "omp",  "4",    "-sf",   "omp"};
-
-    char **argv = (char **)args;
-    int argc    = sizeof(args) / sizeof(char *);
+    LAMMPS::argv args = {"ImproperStyle", "-log", "none", "-echo", "screen", "-nocite",
+                         "-pk",           "omp",  "4",    "-sf",   "omp"};
 
     ::testing::internal::CaptureStdout();
-    LAMMPS *lmp = init_lammps(argc, argv, test_config, true);
+    LAMMPS *lmp = init_lammps(args, test_config, true);
 
     std::string output = ::testing::internal::GetCapturedStdout();
     if (verbose) std::cout << output;
@@ -479,7 +471,7 @@ TEST(ImproperStyle, omp)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     cleanup_lammps(lmp, test_config);
-    lmp = init_lammps(argc, argv, test_config, false);
+    lmp = init_lammps(args, test_config, false);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 
     // skip over these tests if newton bond is forced to be on

--- a/unittest/fortran/wrap_extract_variable.cpp
+++ b/unittest/fortran/wrap_extract_variable.cpp
@@ -71,10 +71,10 @@ protected:
         // clang-format off
         const char *args[] =
             { "LAMMPS_Fortran_test", "-l", "none", "-echo", "screen", "-nocite",
-              "-var", "input_dir", input_dir, "-var", "zpos", "1.5", "-var", "x", "2" };
+              "-var", "input_dir", input_dir, "-var", "zpos", "1.5", "-var", "x", "2", nullptr };
         // clang-format on
         char **argv = (char **)args;
-        int argc    = sizeof(args) / sizeof(const char *);
+        int argc    = (sizeof(args) / sizeof(const char *)) - 1;
         ::testing::internal::CaptureStdout();
         lmp = (LAMMPS_NS::LAMMPS *)f_lammps_with_c_args(argc, argv);
 

--- a/unittest/testing/core.h
+++ b/unittest/testing/core.h
@@ -106,31 +106,21 @@ public:
     }
 
 protected:
-    std::string testbinary        = "LAMMPSTest";
-    std::vector<std::string> args = {"-log", "none", "-echo", "screen", "-nocite"};
+    std::string testbinary = "LAMMPSTest";
+    LAMMPS::argv args = {"-log", "none", "-echo", "screen", "-nocite"};
     LAMMPS *lmp;
     Info *info;
 
     void SetUp() override
     {
-        int argc    = args.size() + 1;
-        char **argv = new char *[argc];
-        argv[0]     = LAMMPS_NS::utils::strdup(testbinary);
-        for (int i = 1; i < argc; i++) {
-            argv[i] = LAMMPS_NS::utils::strdup(args[i - 1]);
-        }
+        LAMMPS::argv full_args = {testbinary};
+        full_args.insert(full_args.end(), args.begin(), args.end());
 
         HIDE_OUTPUT([&] {
-            lmp  = new LAMMPS(argc, argv, MPI_COMM_WORLD);
+            lmp  = new LAMMPS(full_args, MPI_COMM_WORLD);
             info = new Info(lmp);
         });
         InitSystem();
-
-        for (int i = 0; i < argc; i++) {
-            delete[] argv[i];
-            argv[i] = nullptr;
-        }
-        delete[] argv;
     }
 
     virtual void InitSystem() {}


### PR DESCRIPTION
**Summary**

- both C and C++ standards guarantee that `argv[argc]` is a null pointer.
- OpenMPI 5 has [logic](https://github.com/open-mpi/ompi/blob/main/opal/util/argv.c#L300) that depends on this, so not adhering to this convention causes segfaults.
- also fixes another bug due to argv[0] not being copied and therefore could become invalid.

**Related Issue(s)**

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=2246679

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Unchanged.

**Implementation Notes**

Added a new `LAMMPS::LAMMPS` constructor to take a `LAMMPS::argv` (`std::vector<std::string>`) for the common case and does the correct conversion to pass it as `argc` and `argv` to the existing constructor.

This is now used in most tests.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


