### PR TITLE
Brownian package new integrator

### DIFF
--- a/doc/src/fix_brownian.rst
+++ b/doc/src/fix_brownian.rst
@@ -2,7 +2,7 @@
 .. index:: fix brownian/sphere
 .. index:: fix brownian/asphere
 .. index:: fix brownian/dipole
-	   
+
 fix brownian command
 ===========================
 

--- a/doc/src/fix_brownian.rst
+++ b/doc/src/fix_brownian.rst
@@ -92,7 +92,7 @@ For the style *brownian*, only the positions of the particles are
 updated. This is therefore suitable for point particle simulations.
 
 For the style *brownian/sphere*, the positions of the particles are
-updated, and a dipole slaved to the spherical orientation is also
+updated, and a dipole following the spherical orientation is also
 updated. This style therefore requires the hybrid atom style
 :doc:`atom_style dipole <atom_style>` and :doc:`atom_style sphere
 <atom_style>`. The equation of motion for the dipole is
@@ -136,6 +136,8 @@ where :math:`\boldsymbol{\Psi}` has rows :math:`(-q_1,-q_2,-q_3)`,
 friction tensor is diagonal.  See :ref:`(Delong) <Delong1>` for more details of
 a similar algorithm.
 
+..versionadded:: TBD
+
 For the style *brownian/dipole*, the center of mass positions are updated as
 in the *brownian* case, but the dipole moment is updated using a soft
 constraint to keep it near unit magnitude via
@@ -147,10 +149,6 @@ constraint to keep it near unit magnitude via
 
 where :math:`\lambda` is the value specified by *lambda* and sets the energetic
 penalty for having non unit magnitude.
-
-
-
-
 
 ---------
 

--- a/examples/PACKAGES/brownian/dipole_fluctuating/in2d.dipole
+++ b/examples/PACKAGES/brownian/dipole_fluctuating/in2d.dipole
@@ -1,0 +1,45 @@
+##### overdamped dynamics of a sphere (with dipole attached to it) in 2D #####
+
+variable        rng string uniform
+variable        seed string 198098
+variable        temp string 1.0
+variable        gamma_t string 5.0
+variable        gamma_r string 0.7
+variable        params string ${rng}_${temp}_${gamma_r}_${gamma_t}
+
+units           lj
+atom_style      hybrid dipole sphere
+dimension       2
+newton off
+
+lattice         sq 0.4
+region          box block -30 30 -30 30 -0.2 0.2
+create_box      1 box
+create_atoms    1 box
+mass            * 1.0
+set             type  * dipole/random ${seed} 1.0
+velocity        all create 1.0 1 loop geom
+
+neighbor        1.0 bin
+neigh_modify    every 1 delay 1 check yes
+
+pair_style none
+
+fix 1 all brownian/dipole ${temp} ${seed} rng ${rng} gamma_r ${gamma_r} gamma_t ${gamma_t} lambda 100.0
+
+#initialisation for the main run
+
+# MSD
+compute         msd  all msd
+
+thermo_style    custom step ke pe c_msd[*]
+
+#dump            1 all custom 1000 dump_${params}_2d.lammpstrj id type &
+#               x y z xu yu zu mux muy muz fx fy fz
+#dump_modify     1 first yes sort id
+
+timestep        0.00001
+thermo          100
+
+# main run
+run             3000

--- a/examples/PACKAGES/brownian/dipole_fluctuating/in3d.dipole
+++ b/examples/PACKAGES/brownian/dipole_fluctuating/in3d.dipole
@@ -1,0 +1,45 @@
+##### overdamped dynamics of a sphere (with dipole attached to it) in 3D#####
+
+variable        rng string uniform
+variable        seed string 198098
+variable        temp string 1.0
+variable        gamma_t string 5.0
+variable        gamma_r string 0.7
+variable        params string ${rng}_${temp}_${gamma_r}_${gamma_t}
+
+units           lj
+atom_style      hybrid dipole sphere
+dimension       3
+newton off
+
+lattice         sc 0.4
+region          box block -8 8 -8 8 -8 8
+create_box      1 box
+create_atoms    1 box
+mass            * 1.0
+set             type  * dipole/random ${seed} 1.0
+velocity        all create 1.0 1 loop geom
+
+neighbor        1.0 bin
+neigh_modify    every 1 delay 1 check yes
+
+pair_style none
+
+fix 1 all brownian/dipole ${temp} ${seed} rng ${rng} gamma_r ${gamma_r} gamma_t ${gamma_t} lambda 100.0
+
+#initialisation for the main run
+
+# MSD
+compute         msd  all msd
+
+thermo_style    custom step ke pe c_msd[*]
+
+#dump            1 all custom 1000 dump_${params}_3d.lammpstrj id type &
+#                x y z xu yu zu mux muy muz fx fy fz
+#dump_modify     1 first yes sort id
+
+timestep        0.00001
+thermo          100
+
+# main run
+run             3000

--- a/src/BROWNIAN/fix_brownian_base.cpp
+++ b/src/BROWNIAN/fix_brownian_base.cpp
@@ -37,7 +37,8 @@ using namespace FixConst;
 FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg)
 {
   time_integrate = 1;
-
+  dynamic_group_allow = 1;
+  
   noise_flag = 1;
   gaussian_noise_flag = 0;
   gamma_t_flag = gamma_r_flag = 0;
@@ -46,6 +47,7 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, n
   rot_temp_flag = 0;
   planar_rot_flag = 0;
   g2 = 0.0;
+  lambda = 100.0;
 
   if (narg < 5) error->all(FLERR, "Illegal fix brownian command.");
 
@@ -171,6 +173,11 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, n
         error->all(FLERR, "The planar_rotation keyword is not allowed for 2D simulations");
       iarg = iarg + 1;
 
+    } else if (strcmp(arg[iarg], "lambda") == 0) {
+
+      lambda = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
+      if (lambda <= 0) error->all(FLERR, "Fix brownian lambda must be > 0.");
+      iarg = iarg + 2;
     } else {
       error->all(FLERR, "Illegal fix brownian command.");
     }

--- a/src/BROWNIAN/fix_brownian_base.cpp
+++ b/src/BROWNIAN/fix_brownian_base.cpp
@@ -38,7 +38,7 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, n
 {
   time_integrate = 1;
   dynamic_group_allow = 1;
-  
+
   noise_flag = 1;
   gaussian_noise_flag = 0;
   gamma_t_flag = gamma_r_flag = 0;

--- a/src/BROWNIAN/fix_brownian_base.h
+++ b/src/BROWNIAN/fix_brownian_base.h
@@ -44,6 +44,7 @@ class FixBrownianBase : public Fix {
 
   int dipole_flag;        // set if dipole is used for asphere
   double *dipole_body;    // direction dipole is slaved to in body frame
+  double lambda;          // strength of soft constraint on dipole magnitude for brownian/dipole
 
   int noise_flag;             // 0/1 for noise off/on
   int gaussian_noise_flag;    // 0/1 for uniform/gaussian noise

--- a/src/BROWNIAN/fix_brownian_dipole.cpp
+++ b/src/BROWNIAN/fix_brownian_dipole.cpp
@@ -1,7 +1,7 @@
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/ Sandia National Laboratories
-   Steve Plimpton, sjplimp@sandia.gov
+   LAMMPS Development team: developers@lammps.org
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains

--- a/src/BROWNIAN/fix_brownian_dipole.cpp
+++ b/src/BROWNIAN/fix_brownian_dipole.cpp
@@ -1,0 +1,197 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/ Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Originally modified from CG-DNA/fix_nve_dotc_langevin.cpp.
+
+   Contributing author: Sam Cameron (University of Bristol)
+------------------------------------------------------------------------- */
+
+#include "fix_brownian_dipole.h"
+
+#include "atom.h"
+#include "domain.h"
+#include "error.h"
+#include "math_extra.h"
+#include "random_mars.h"
+
+#include <cmath>
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+/* ---------------------------------------------------------------------- */
+
+FixBrownianDipole::FixBrownianDipole(LAMMPS *lmp, int narg, char **arg) :
+    FixBrownianBase(lmp, narg, arg)
+{
+  if (gamma_t_eigen_flag || gamma_r_eigen_flag) {
+    error->all(FLERR, "Illegal fix brownian command.");
+  }
+
+  if (!gamma_t_flag || !gamma_r_flag) { error->all(FLERR, "Illegal fix brownian command."); }
+  if (!atom->mu_flag) error->all(FLERR, "Fix brownian/fluct_dipole requires atom attribute mu");
+  if (!atom->sphere_flag) error->all(FLERR, "Fix brownian/fluct_dipole requires atom style sphere");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixBrownianDipole::init()
+{
+  FixBrownianBase::init();
+
+  g3 = g1 / gamma_r;
+  g4 = g2 * sqrt(rot_temp / gamma_r);
+  g1 /= gamma_t;
+  g2 *= sqrt(temp / gamma_t);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixBrownianDipole::initial_integrate(int /*vflag */)
+{
+  if (domain->dimension == 2) {
+    if (!noise_flag) {
+      initial_integrate_templated<0, 0, 1, 0>();
+    } else if (gaussian_noise_flag) {
+      initial_integrate_templated<0, 1, 1, 0>();
+    } else {
+      initial_integrate_templated<1, 0, 1, 0>();
+    }
+  } else if (planar_rot_flag) {
+    if (!noise_flag) {
+      initial_integrate_templated<0, 0, 0, 1>();
+    } else if (gaussian_noise_flag) {
+      initial_integrate_templated<0, 1, 0, 1>();
+    } else {
+      initial_integrate_templated<1, 0, 0, 1>();
+    }
+  } else {
+    if (!noise_flag) {
+      initial_integrate_templated<0, 0, 0, 0>();
+    } else if (gaussian_noise_flag) {
+      initial_integrate_templated<0, 1, 0, 0>();
+    } else {
+      initial_integrate_templated<1, 0, 0, 0>();
+    }
+  }
+  }
+
+/* ---------------------------------------------------------------------- */
+
+template <int Tp_UNIFORM, int Tp_GAUSS, int Tp_2D, int Tp_2Drot>
+void FixBrownianDipole::initial_integrate_templated()
+{
+  double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+  double wx, wy, wz;
+  double **torque = atom->torque;
+  double **mu = atom->mu;
+  double mulensq;
+
+  if (igroup == atom->firstgroup) nlocal = atom->nfirst;
+
+  double dx, dy, dz;
+
+  for (int i = 0; i < nlocal; i++) {
+    if (mask[i] & groupbit) {
+      if (Tp_2D) {
+        dz = 0;
+	wz = 0;
+        if (Tp_UNIFORM) {
+          dx = dt * (g1 * f[i][0] + g2 * (rng->uniform() - 0.5));
+          dy = dt * (g1 * f[i][1] + g2 * (rng->uniform() - 0.5));
+	  wx = (rng->uniform() - 0.5) * g4;
+	  wy = (rng->uniform() - 0.5) * g4;
+
+        } else if (Tp_GAUSS) {
+          dx = dt * (g1 * f[i][0] + g2 * rng->gaussian());
+          dy = dt * (g1 * f[i][1] + g2 * rng->gaussian());
+          wx = rng->gaussian() * g4;
+          wy = rng->gaussian() * g4;
+        } else {
+          dx = dt * g1 * f[i][0];
+          dy = dt * g1 * f[i][1];
+          wx = 0;
+	  wy = 0;
+        }
+      } else if (Tp_2Drot) {
+        wz = 0;
+        if (Tp_UNIFORM) {
+          dx = dt * (g1 * f[i][0] + g2 * (rng->uniform() - 0.5));
+          dy = dt * (g1 * f[i][1] + g2 * (rng->uniform() - 0.5));
+          dz = dt * (g1 * f[i][2] + g2 * (rng->uniform() - 0.5));
+          wx = (rng->uniform() - 0.5) * g4;
+          wy = (rng->uniform() - 0.5) * g4;
+        } else if (Tp_GAUSS) {
+          dx = dt * (g1 * f[i][0] + g2 * rng->gaussian());
+          dy = dt * (g1 * f[i][1] + g2 * rng->gaussian());
+          dz = dt * (g1 * f[i][2] + g2 * rng->gaussian());
+          wx = rng->gaussian() * g4;
+          wy = rng->gaussian() * g4;
+        } else {
+          dx = dt * g1 * f[i][0];
+          dy = dt * g1 * f[i][1];
+          dz = dt * g1 * f[i][2];
+          wx = 0;
+          wy = 0;
+        }
+      } else {
+        if (Tp_UNIFORM) {
+          dx = dt * (g1 * f[i][0] + g2 * (rng->uniform() - 0.5));
+          dy = dt * (g1 * f[i][1] + g2 * (rng->uniform() - 0.5));
+          dz = dt * (g1 * f[i][2] + g2 * (rng->uniform() - 0.5));
+          wx = (rng->uniform() - 0.5) * g4;
+          wy = (rng->uniform() - 0.5) * g4;
+          wz = (rng->uniform() - 0.5) * g4;
+        } else if (Tp_GAUSS) {
+          dx = dt * (g1 * f[i][0] + g2 * rng->gaussian());
+          dy = dt * (g1 * f[i][1] + g2 * rng->gaussian());
+          dz = dt * (g1 * f[i][2] + g2 * rng->gaussian());
+          wx = rng->gaussian() * g4;
+          wy = rng->gaussian() * g4;
+          wz = rng->gaussian() * g4;
+        } else {
+          dx = dt * g1 * f[i][0];
+          dy = dt * g1 * f[i][1];
+          dz = dt * g1 * f[i][2];
+          wx = wy = wz = 0;
+        }
+      }
+
+      x[i][0] += dx;
+      v[i][0] = dx / dt;
+
+      x[i][1] += dy;
+      v[i][1] = dy / dt;
+
+      x[i][2] += dz;
+      v[i][2] = dz / dt;
+
+      wx += g3 * torque[i][0];
+      wy += g3 * torque[i][1];
+      wz += g3 * torque[i][2];
+
+      mulensq = mu[i][0] * mu[i][0] + mu[i][1] * mu[i][1] + mu[i][2] * mu[i][2];
+
+      mu[i][0] += (mu[i][0]*lambda*(1-mulensq) + wx)*dt;
+      mu[i][1] += (mu[i][1]*lambda*(1-mulensq) + wy)*dt;
+      mu[i][2] += (mu[i][2]*lambda*(1-mulensq) + wz)*dt;
+
+      
+    }
+  }
+}

--- a/src/BROWNIAN/fix_brownian_dipole.cpp
+++ b/src/BROWNIAN/fix_brownian_dipole.cpp
@@ -110,12 +110,12 @@ void FixBrownianDipole::initial_integrate_templated()
     if (mask[i] & groupbit) {
       if (Tp_2D) {
         dz = 0;
-	wz = 0;
+        wz = 0;
         if (Tp_UNIFORM) {
           dx = dt * (g1 * f[i][0] + g2 * (rng->uniform() - 0.5));
           dy = dt * (g1 * f[i][1] + g2 * (rng->uniform() - 0.5));
-	  wx = (rng->uniform() - 0.5) * g4;
-	  wy = (rng->uniform() - 0.5) * g4;
+          wx = (rng->uniform() - 0.5) * g4;
+          wy = (rng->uniform() - 0.5) * g4;
 
         } else if (Tp_GAUSS) {
           dx = dt * (g1 * f[i][0] + g2 * rng->gaussian());
@@ -126,7 +126,7 @@ void FixBrownianDipole::initial_integrate_templated()
           dx = dt * g1 * f[i][0];
           dy = dt * g1 * f[i][1];
           wx = 0;
-	  wy = 0;
+          wy = 0;
         }
       } else if (Tp_2Drot) {
         wz = 0;
@@ -191,7 +191,7 @@ void FixBrownianDipole::initial_integrate_templated()
       mu[i][1] += (mu[i][1]*lambda*(1-mulensq) + wy)*dt;
       mu[i][2] += (mu[i][2]*lambda*(1-mulensq) + wz)*dt;
 
-      
+
     }
   }
 }

--- a/src/BROWNIAN/fix_brownian_dipole.h
+++ b/src/BROWNIAN/fix_brownian_dipole.h
@@ -1,7 +1,7 @@
 /* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    https://www.lammps.org/ Sandia National Laboratories
-   Steve Plimpton, sjplimp@sandia.gov
+   LAMMPS Development team: developers@lammps.org
 
    Copyright (2003) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains

--- a/src/BROWNIAN/fix_brownian_dipole.h
+++ b/src/BROWNIAN/fix_brownian_dipole.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/ Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(brownian/dipole,FixBrownianDipole);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_BROWNIAN_DIPOLE_H
+#define LMP_FIX_BROWNIAN_DIPOLE_H
+
+#include "fix_brownian_base.h"
+
+namespace LAMMPS_NS {
+
+class FixBrownianDipole : public FixBrownianBase {
+ public:
+  FixBrownianDipole(class LAMMPS *, int, char **);
+
+  void init() override;
+  void initial_integrate(int) override;
+
+ private:
+  template <int Tp_UNIFORM, int Tp_GAUSS, int Tp_2D, int Tp_2Drot>
+  void initial_integrate_templated();
+  double g3, g4;
+};
+}    // namespace LAMMPS_NS
+#endif
+#endif


### PR DESCRIPTION
**Summary**

Added a new integrator to the BROWNIAN package, which allows for rotating dipoles with fluctuating magnitudes. Also allowed for dynamic groups to be simulated with all of the integrators (having this turned off previously was an oversight).

**Author(s)**

Sam Cameron samuel.j.m.cameron@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

Tested output of integrator and verified that dipole time correlations were consistent with regular rotational diffusion ( e^{-(d-1)*D_r*t}) in both two and three dimensions. Otherwise the integrator is the same as brownian/sphere.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**



