### PR TITLE
getters for fix property/atom

### DIFF
--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -948,3 +948,21 @@ int FixPropertyAtom::size_restart(int /*nlocal*/)
 {
   return values_peratom + 1;
 }
+
+/* ----------------------------------------------------------------------
+   utility getters
+------------------------------------------------------------------------- */
+
+int FixPropertyAtom::get_nvalue() { return nvalue; }
+
+int FixPropertyAtom::get_style(int n) {
+  if (n >= nvalue)
+    error->all(FLERR, "Invalid fix property/atom style request");
+  return styles[n];
+}
+
+int FixPropertyAtom::get_index(int n) {
+  if (n >= nvalue)
+    error->all(FLERR, "Invalid fix property/atom index request");
+  return index[n];
+}

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -966,3 +966,5 @@ int FixPropertyAtom::get_index(int n) {
     error->all(FLERR, "Invalid fix property/atom index request");
   return index[n];
 }
+
+int FixPropertyAtom::get_border() { return border; }

--- a/src/fix_property_atom.h
+++ b/src/fix_property_atom.h
@@ -56,6 +56,7 @@ class FixPropertyAtom : public Fix {
   int get_nvalue();    // utility getters to list
   int get_style(int);  // which variables are managed
   int get_index(int);  // by a fix property/atom
+  int get_border();    // and if it communicates to ghosts
 
  protected:
   int nvalue, border;

--- a/src/fix_property_atom.h
+++ b/src/fix_property_atom.h
@@ -53,6 +53,10 @@ class FixPropertyAtom : public Fix {
   int maxsize_restart() override;
   double memory_usage() override;
 
+  int get_nvalue();    // utility getters to list
+  int get_style(int);  // which variables are managed
+  int get_index(int);  // by a fix property/atom
+
  protected:
   int nvalue, border;
   int molecule_flag, q_flag, rmass_flag;    // flags for specific fields


### PR DESCRIPTION
**Summary**

Adds public functions to `fix property/atom` that get the total number of variables managed, their styles, corresponding index numbers, and whether it communicates properties to ghosts (`get_border`).

This lets other code check what properties are managed by a particular `fix property/atom`. As a use case, a fix may rely on a custom atom property being communicated for ghost atoms. Currently it is not obvious how to do this: we can `find_custom` to locate the variable-name's index, but we cannot know for sure if the `fix property/atom` managing it has `ghost yes`. With this PR, a fix can loop through all `fix property/atom` instances, determine which one manages the property of interest, and determine whether the property is communicated for ghost atoms using `get_border()`.

**Related Issue(s)**

**Author(s)**

Shern Tee, Griffith University (Brisbane)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No changes to results from user scripts and no documentation changes needed

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system