### PR TITLE
Bugfixes for Kokkos minimize

### DIFF
--- a/src/KOKKOS/atom_vec_spin_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_spin_kokkos.cpp
@@ -586,6 +586,38 @@ int AtomVecSpinKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf, int n
   }
 }
 
+/* ----------------------------------------------------------------------
+   clear extra forces starting at atom N
+   nbytes = # of bytes to clear for a per-atom vector
+   include f b/c this is invoked from within SPIN pair styles
+------------------------------------------------------------------------- */
+
+void AtomVecSpinKokkos::force_clear(int n, size_t nbytes)
+{
+  int nzero = nbytes/sizeof(double);
+
+  if (nzero) {
+    atomKK->k_fm.clear_sync_state(); // will be cleared below
+    atomKK->k_fm_long.clear_sync_state(); // will be cleared below
+
+    // local variables for lambda capture
+
+    auto l_fm = atomKK->k_fm.d_view;
+    auto l_fm_long = atomKK->k_fm_long.d_view;
+
+    Kokkos::parallel_for(nzero, LAMMPS_LAMBDA(int i) {
+      l_fm(i,0) = 0.0;
+      l_fm(i,1) = 0.0;
+      l_fm(i,2) = 0.0;
+      l_fm_long(i,0) = 0.0;
+      l_fm_long(i,1) = 0.0;
+      l_fm_long(i,2) = 0.0;
+    });
+
+    atomKK->modified(Device,FM_MASK|FML_MASK);
+  }
+}
+
 /* ---------------------------------------------------------------------- */
 
 void AtomVecSpinKokkos::sync(ExecutionSpace space, unsigned int mask)

--- a/src/KOKKOS/atom_vec_spin_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_spin_kokkos.cpp
@@ -594,7 +594,7 @@ int AtomVecSpinKokkos::unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf, int n
 
 void AtomVecSpinKokkos::force_clear(int n, size_t nbytes)
 {
-  int nzero = nbytes/sizeof(double);
+  int nzero = (double)nbytes/sizeof(double);
 
   if (nzero) {
     atomKK->k_fm.clear_sync_state(); // will be cleared below

--- a/src/KOKKOS/atom_vec_spin_kokkos.h
+++ b/src/KOKKOS/atom_vec_spin_kokkos.h
@@ -34,6 +34,7 @@ class AtomVecSpinKokkos : public AtomVecKokkos, public AtomVecSpin {
   AtomVecSpinKokkos(class LAMMPS *);
   void grow(int) override;
   void grow_pointers() override;
+  void force_clear(int, size_t) override;
   void sort_kokkos(Kokkos::BinSort<KeyViewType, BinOp> &Sorter) override;
   int pack_border_kokkos(int n, DAT::tdual_int_2d k_sendlist,
                          DAT::tdual_xfloat_2d buf,int iswap,

--- a/src/KOKKOS/min_kokkos.cpp
+++ b/src/KOKKOS/min_kokkos.cpp
@@ -72,8 +72,7 @@ void MinKokkos::init()
 void MinKokkos::setup(int flag)
 {
   if (comm->me == 0 && screen) {
-    fmt::print(screen,"Setting up {} style minimization ...\n",
-               update->minimize_style);
+    fmt::print(screen,"Setting up {} style minimization ...\n", update->minimize_style);
     if (flag) {
       fmt::print(screen,"  Unit style    : {}\n", update->unit_style);
       fmt::print(screen,"  Current step  : {}\n", update->ntimestep);
@@ -92,14 +91,13 @@ void MinKokkos::setup(int flag)
     fextra = new double[nextra_global];
     if (comm->me == 0)
       error->warning(FLERR, "Energy due to {} extra global DOFs will"
-                     " be included in minimizer energies\n", nextra_global);
+                     " be included in minimizer energies\n",nextra_global);
   }
 
   // compute for potential energy
 
-  int id = modify->find_compute("thermo_pe");
-  if (id < 0) error->all(FLERR,"Minimization could not find thermo_pe compute");
-  pe_compute = modify->compute[id];
+  pe_compute = modify->get_compute_by_id("thermo_pe");
+  if (!pe_compute) error->all(FLERR,"Minimization could not find thermo_pe compute");
 
   // style-specific setup does two tasks
   // setup extra global dof vectors
@@ -537,6 +535,7 @@ double MinKokkos::energy_force(int resetflag)
     if (resetflag) fix_minimize_kk->reset_coords();
     reset_vectors();
   }
+
   return energy;
 }
 
@@ -575,7 +574,14 @@ void MinKokkos::force_clear()
         l_torque(i,2) = 0.0;
       }
     });
+
+    if (extraflag) {
+      size_t nbytes = sizeof(double) * atom->nlocal;
+      if (force->newton) nbytes += sizeof(double) * atom->nghost;
+      atom->avec->force_clear(0,nbytes);
+    }
   }
+
   atomKK->modified(Device,F_MASK|TORQUE_MASK);
 }
 

--- a/src/KOKKOS/npair_kokkos.cpp
+++ b/src/KOKKOS/npair_kokkos.cpp
@@ -113,7 +113,7 @@ void NPairKokkos<DeviceType,HALF,NEWTON,GHOST,TRI,SIZE>::copy_stencil_info()
   NPair::copy_stencil_info();
   nstencil = ns->nstencil;
 
-  if (ns->last_stencil != last_stencil_old) {
+  if (ns->last_stencil != last_stencil_old || ns->last_stencil == update->ntimestep) {
     // copy stencil to device as it may have changed
 
     last_stencil_old = ns->last_stencil;


### PR DESCRIPTION
**Summary**

Fix bug in Kokkos `minimize` + `fix deform`. The logic for copying the neighbor list stencil did not account for multiple calls in the same timestep, which can happen when minimizing. Also add a `force_clear()` method required for the SPIN package when minimizing.

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL), reported by Meg McCarthy (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes