### PR TITLE
Fixing typos in fix_nh_uef.rst

### DIFF
--- a/doc/src/fix_nh_uef.rst
+++ b/doc/src/fix_nh_uef.rst
@@ -23,7 +23,7 @@ Syntax
   .. parsed-literal::
 
      keyword = *erate* or *ext* or *strain* or *temp* or *iso* or *x* or *y* or *z* or *tchain* or *pchain* or *tloop* or *ploop* or *mtk*
-       *erate* values = e_x e_y = engineering strain rates (required)
+       *erate* values = e_x e_y = true strain rates (required)
        *ext* value = *x* or *y* or *z* or *xy* or *yz* or *xz* = external dimensions
          sets the external dimensions used to calculate the scalar pressure
        *strain* values = e_x e_y = initial strain
@@ -62,7 +62,7 @@ performed using the :doc:`fix deform <fix_deform>`, :doc:`fix nvt/sllod
 <fix_nvt_sllod>`, and :doc:`compute temp/deform <compute_temp_deform>`
 commands.
 
-The applied flow field is set by the *eps* keyword. The values
+The applied flow field is set by the *erate* keyword. The values
 *edot_x* and *edot_y* correspond to the strain rates in the xx and yy
 directions.  It is implicitly assumed that the flow field is
 traceless, and therefore the strain rate in the zz direction is eqal


### PR DESCRIPTION
Fixing typo

**Summary**

Corrected typos in documentation fix_nh_uef.rst: eps -> erate, engineering strain rate -> true strain rate.

**Related Issue(s)**


**Author(s)**
Danyang Chen, Duke University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Do not apply

**Implementation Notes**

Do not apply

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

Related to discussions in the forum
https://matsci.org/t/question-about-strain-rates-in-fix-nvt-uef/52172/5


