### PR TITLE
Corrections for fix cmap to be compatible with CMAP files created by CHARMM-GUI

### DIFF
--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -86,6 +86,7 @@ FixCMAP::FixCMAP(LAMMPS *lmp, int narg, char **arg) :
   wd_section = 1;
   respa_level_support = 1;
   ilevel_respa = 0;
+  eflag_caller = 1;
 
   // allocate memory for CMAP data
 

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -49,15 +49,14 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace MathConst;
 
-#define MAXLINE 256
-#define LISTDELTA 10000
-#define LB_FACTOR 1.5
+static constexpr int LISTDELTA = 10000;
+static constexpr double LB_FACTOR = 1.5;
 
-#define CMAPMAX 6   // max # of CMAP terms stored by one atom
-#define CMAPDIM 24  // grid map dimension is 24 x 24
-#define CMAPXMIN -360.0
-#define CMAPXMIN2 -180.0
-#define CMAPDX 15.0 // 360/CMAPDIM
+static constexpr int CMAPMAX = 6;   // max # of CMAP terms stored by one atom
+static constexpr int CMAPDIM = 24;  // grid map dimension is 24 x 24
+static constexpr double CMAPXMIN = -360.0;
+static constexpr double CMAPXMIN2 = -180.0;
+static constexpr double CMAPDX = 15.0; // 360/CMAPDIM
 
 /* ---------------------------------------------------------------------- */
 
@@ -90,10 +89,10 @@ FixCMAP::FixCMAP(LAMMPS *lmp, int narg, char **arg) :
   // allocate memory for CMAP data
 
   memory->create(g_axis,CMAPDIM,"cmap:g_axis");
-  memory->create(cmapgrid,6,CMAPDIM,CMAPDIM,"cmap:grid");
-  memory->create(d1cmapgrid,6,CMAPDIM,CMAPDIM,"cmap:d1grid");
-  memory->create(d2cmapgrid,6,CMAPDIM,CMAPDIM,"cmap:d2grid");
-  memory->create(d12cmapgrid,6,CMAPDIM,CMAPDIM,"cmap:d12grid");
+  memory->create(cmapgrid,CMAPMAX,CMAPDIM,CMAPDIM,"cmap:grid");
+  memory->create(d1cmapgrid,CMAPMAX,CMAPDIM,CMAPDIM,"cmap:d1grid");
+  memory->create(d2cmapgrid,CMAPMAX,CMAPDIM,CMAPDIM,"cmap:d2grid");
+  memory->create(d12cmapgrid,CMAPMAX,CMAPDIM,CMAPDIM,"cmap:d12grid");
 
   // read and setup CMAP data
 
@@ -231,6 +230,8 @@ void FixCMAP::min_setup(int vflag)
 void FixCMAP::pre_neighbor()
 {
   int i,m,atom1,atom2,atom3,atom4,atom5;
+  const int me = comm->me;
+  const int nprocs = comm->nprocs;
 
   // guesstimate initial length of local crossterm list
   // if ncmap was not set (due to read_restart, no read_data),

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -946,10 +946,10 @@ void FixCMAP::read_data_section(char * /*keyword*/, int /*n*/, char *buf,
 
   // loop over lines of CMAP crossterms
   // tokenize the line into values
-  // add crossterm to one of my atoms, depending on newton_bond
+  // add crossterm to one of my atoms
 
   for (const auto &line : lines) {
-    ValueTokenizer values(line);
+    ValueTokenizer values(utils::trim_comment(line));
     try {
       values.skip();
       itype = values.next_int();

--- a/src/MOLECULE/fix_cmap.cpp
+++ b/src/MOLECULE/fix_cmap.cpp
@@ -87,9 +87,6 @@ FixCMAP::FixCMAP(LAMMPS *lmp, int narg, char **arg) :
   respa_level_support = 1;
   ilevel_respa = 0;
 
-  MPI_Comm_rank(world,&me);
-  MPI_Comm_size(world,&nprocs);
-
   // allocate memory for CMAP data
 
   memory->create(g_axis,CMAPDIM,"cmap:g_axis");
@@ -183,10 +180,6 @@ void FixCMAP::init()
 
   for (i = 0; i < 6; i++)
     set_map_derivatives(cmapgrid[i],d1cmapgrid[i],d2cmapgrid[i],d12cmapgrid[i]);
-
-  // define newton_bond here in case restart file was read (not data file)
-
-  newton_bond = force->newton_bond;
 
   if (utils::strmatch(update->integrate_style,"^respa")) {
     ilevel_respa = (dynamic_cast<Respa *>(update->integrate))->nlevels-1;
@@ -934,10 +927,6 @@ void FixCMAP::read_data_header(char *line)
   } catch (std::exception &e) {
     error->all(FLERR,"Invalid read data header line for fix cmap: {}", e.what());
   }
-
-  // not set in constructor because this fix could be defined before newton command
-
-  newton_bond = force->newton_bond;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/MOLECULE/fix_cmap.h
+++ b/src/MOLECULE/fix_cmap.h
@@ -65,8 +65,7 @@ class FixCMAP : public Fix {
   double memory_usage() override;
 
  private:
-  int nprocs, me;
-  int newton_bond, eflag_caller;
+  int eflag_caller;
   int ctype, ilevel_respa;
   int ncrosstermtypes, crossterm_per_atom, maxcrossterm;
   int ncrosstermlist;

--- a/src/potential_file_reader.cpp
+++ b/src/potential_file_reader.cpp
@@ -144,6 +144,8 @@ void PotentialFileReader::next_dvector(double *list, int n)
 {
   try {
     return reader->next_dvector(list, n);
+  } catch (EOFException &) {
+    throw EOFException("EOF reached");
   } catch (FileReaderException &e) {
     error->one(FLERR, e.what());
   }

--- a/src/text_file_reader.cpp
+++ b/src/text_file_reader.cpp
@@ -189,8 +189,9 @@ void TextFileReader::next_dvector(double *list, int n)
     char *ptr = next_line();
 
     if (ptr == nullptr) {
-      // EOF
-      if (i < n) {
+      if (i == 0) { // EOF without any records
+        throw EOFException("EOF reached");
+      } else if (i < n) { // EOF with incomplete data
         throw FileReaderException(
             fmt::format("Incorrect format in {} file! {}/{} values", filetype, i, n));
       }


### PR DESCRIPTION
**Summary**

LAMMPS data and CMAP files created by LAMMPS-GUI trigger errors in fix cmap. This pull request tries to address them while maintaining backward compatibility with the examples included in LAMMPS.

**Related Issue(s)**

https://matsci.org/t/creating-data-file-using-charmm2lammps/52268/5

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Implementation Notes**

Some small change to the TextFileReader and PotentialFileReader class is included. The "next_dvector()" method throws an EOF exception when no data has yet been read and EOF is reached. This is a different case from EOF with a partial read, which triggers an error exception.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


