### PR TITLE
Fix bug in some Kokkos fixes' unpack exchange on device

### DIFF
--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -931,6 +931,7 @@ void CommKokkos::exchange_device()
             if (nextrarecv) {
               kkbase->unpack_exchange_kokkos(
                 k_buf_recv,k_indices,nrecv/data_size,
+                nrecv1/data_size,nextrarecv1,
                 ExecutionSpaceFromDevice<DeviceType>::space);
               DeviceType().fence();
             }

--- a/src/KOKKOS/fix_neigh_history_kokkos.cpp
+++ b/src/KOKKOS/fix_neigh_history_kokkos.cpp
@@ -453,8 +453,12 @@ KOKKOS_INLINE_FUNCTION
 void FixNeighHistoryKokkos<DeviceType>::operator()(TagFixNeighHistoryUnpackExchange, const int &i) const
 {
   int index = d_indices(i);
+
   if (index > -1) {
     int m = (int) d_ubuf(d_buf(i)).i;
+    if (i >= nrecv1)
+      m = nextrarecv1 + (int) d_ubuf(d_buf(nextrarecv1 + i - nrecv1)).i;
+
     int n = (int) d_ubuf(d_buf(m++)).i;
     d_npartner(index) = n;
     for (int p = 0; p < n; p++) {
@@ -471,12 +475,16 @@ void FixNeighHistoryKokkos<DeviceType>::operator()(TagFixNeighHistoryUnpackExcha
 template<class DeviceType>
 void FixNeighHistoryKokkos<DeviceType>::unpack_exchange_kokkos(
   DAT::tdual_xfloat_2d &k_buf, DAT::tdual_int_1d &k_indices, int nrecv,
+  int nrecv1, int nextrarecv1,
   ExecutionSpace /*space*/)
 {
   d_buf = typename AT::t_xfloat_1d_um(
     k_buf.template view<DeviceType>().data(),
     k_buf.extent(0)*k_buf.extent(1));
   d_indices = k_indices.view<DeviceType>();
+
+  this->nrecv1 = nrecv1;
+  this->nextrarecv1 = nextrarecv1;
 
   d_npartner = k_npartner.template view<DeviceType>();
   d_partner = k_partner.template view<DeviceType>();

--- a/src/KOKKOS/fix_neigh_history_kokkos.h
+++ b/src/KOKKOS/fix_neigh_history_kokkos.h
@@ -72,12 +72,14 @@ class FixNeighHistoryKokkos : public FixNeighHistory, public KokkosBase {
 
   void unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,
                               DAT::tdual_int_1d &indices,int nrecv,
+                              int nrecv1,int nrecv1extra,
                               ExecutionSpace space) override;
 
   typename DAT::tdual_int_2d k_firstflag;
   typename DAT::tdual_float_2d k_firstvalue;
 
  private:
+  int nrecv1,nextrarecv1;
   int nlocal,nsend,beyond_contact;
 
   typename AT::t_tagint_1d tag;

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
@@ -1416,6 +1416,7 @@ KOKKOS_INLINE_FUNCTION
 void FixQEqReaxFFKokkos<DeviceType>::operator()(TagQEqUnpackExchange, const int &i) const
 {
   int index = d_indices(i);
+
   if (index > -1) {
     for (int m = 0; m < nprev; m++) d_s_hist(index,m) = d_buf(i*nprev*2 + m);
     for (int m = 0; m < nprev; m++) d_t_hist(index,m) = d_buf(i*nprev*2 + nprev+m);
@@ -1427,6 +1428,7 @@ void FixQEqReaxFFKokkos<DeviceType>::operator()(TagQEqUnpackExchange, const int 
 template <class DeviceType>
 void FixQEqReaxFFKokkos<DeviceType>::unpack_exchange_kokkos(
   DAT::tdual_xfloat_2d &k_buf, DAT::tdual_int_1d &k_indices, int nrecv,
+  int /*nrecv1*/, int /*nextrarecv1*/,
   ExecutionSpace /*space*/)
 {
   k_buf.sync<DeviceType>();

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.h
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.h
@@ -143,6 +143,7 @@ class FixQEqReaxFFKokkos : public FixQEqReaxFF, public KokkosBase {
 
   void unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,
                               DAT::tdual_int_1d &indices,int nrecv,
+                              int nrecv1,int nextrarecv1,
                               ExecutionSpace space) override;
 
   struct params_qeq{

--- a/src/KOKKOS/fix_shake_kokkos.h
+++ b/src/KOKKOS/fix_shake_kokkos.h
@@ -112,9 +112,12 @@ class FixShakeKokkos : public FixShake, public KokkosBase {
 
   void unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,
                               DAT::tdual_int_1d &indices,int nrecv,
+                              int nrecv1,int nrecv1extra,
                               ExecutionSpace space) override;
 
  protected:
+  int nrecv1,nextrarecv1;
+
   typename AT::t_x_array d_x;
   typename AT::t_v_array d_v;
   typename AT::t_f_array d_f;
@@ -259,4 +262,3 @@ struct FixShakeKokkosPackExchangeFunctor {
 
 #endif
 #endif
-

--- a/src/KOKKOS/fix_spring_self_kokkos.cpp
+++ b/src/KOKKOS/fix_spring_self_kokkos.cpp
@@ -188,8 +188,8 @@ void FixSpringSelfKokkos<DeviceType>::pack_exchange_item(const int &mysend, int 
 {
   const int i = d_exchange_sendlist(mysend);
 
-  d_buf[mysend] = nsend + offset;
   int m = nsend + offset;
+  d_buf[mysend] = m;
   d_buf[m++] = d_xoriginal(i,0);
   d_buf[m++] = d_xoriginal(i,1);
   d_buf[m++] = d_xoriginal(i,2);
@@ -258,6 +258,8 @@ void FixSpringSelfKokkos<DeviceType>::operator()(TagFixSpringSelfUnpackExchange,
 
   if (index > -1) {
     int m = d_buf[i];
+    if (i >= nrecv1)
+      m = nextrarecv1 + d_buf[nextrarecv1 + i - nrecv1];
 
     d_xoriginal(index,0) = static_cast<tagint> (d_buf[m++]);
     d_xoriginal(index,1) = static_cast<tagint> (d_buf[m++]);
@@ -270,6 +272,7 @@ void FixSpringSelfKokkos<DeviceType>::operator()(TagFixSpringSelfUnpackExchange,
 template <class DeviceType>
 void FixSpringSelfKokkos<DeviceType>::unpack_exchange_kokkos(
   DAT::tdual_xfloat_2d &k_buf, DAT::tdual_int_1d &k_indices, int nrecv,
+  int nrecv1, int nextrarecv1,
   ExecutionSpace /*space*/)
 {
   k_buf.sync<DeviceType>();
@@ -279,6 +282,9 @@ void FixSpringSelfKokkos<DeviceType>::unpack_exchange_kokkos(
     k_buf.template view<DeviceType>().data(),
     k_buf.extent(0)*k_buf.extent(1));
   d_indices = k_indices.view<DeviceType>();
+
+  this->nrecv1 = nrecv1;
+  this->nextrarecv1 = nextrarecv1;
 
   k_xoriginal.template sync<DeviceType>();
 

--- a/src/KOKKOS/fix_spring_self_kokkos.h
+++ b/src/KOKKOS/fix_spring_self_kokkos.h
@@ -58,6 +58,7 @@ class FixSpringSelfKokkos : public FixSpringSelf, public KokkosBase {
 
   void unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,
                               DAT::tdual_int_1d &indices,int nrecv,
+                              int nrecv1,int nrecv1extra,
                               ExecutionSpace space) override;
 
 
@@ -65,6 +66,8 @@ class FixSpringSelfKokkos : public FixSpringSelf, public KokkosBase {
   int unpack_exchange(int, double *) override;
 
  protected:
+  int nrecv1,nextrarecv1;
+
   DAT::tdual_x_array k_xoriginal;
   typename AT::t_x_array d_xoriginal;
 

--- a/src/KOKKOS/fix_wall_gran_kokkos.cpp
+++ b/src/KOKKOS/fix_wall_gran_kokkos.cpp
@@ -419,6 +419,7 @@ void FixWallGranKokkos<DeviceType>::operator()(TagFixWallGranUnpackExchange, con
 template<class DeviceType>
 void FixWallGranKokkos<DeviceType>::unpack_exchange_kokkos(
   DAT::tdual_xfloat_2d &k_buf, DAT::tdual_int_1d &k_indices, int nrecv,
+  int /*nrecv1*/, int /*nextrarecv1*/,
   ExecutionSpace /*space*/)
 {
   d_buf = typename ArrayTypes<DeviceType>::t_xfloat_1d_um(
@@ -429,7 +430,6 @@ void FixWallGranKokkos<DeviceType>::unpack_exchange_kokkos(
   d_history_one = k_history_one.template view<DeviceType>();
 
   copymode = 1;
-
 
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagFixWallGranUnpackExchange>(0,nrecv),*this);
 

--- a/src/KOKKOS/fix_wall_gran_kokkos.h
+++ b/src/KOKKOS/fix_wall_gran_kokkos.h
@@ -62,12 +62,13 @@ class FixWallGranKokkos : public FixWallGranOld, public KokkosBase {
   void operator()(TagFixWallGranUnpackExchange, const int&) const;
 
   int pack_exchange_kokkos(const int &nsend,DAT::tdual_xfloat_2d &buf,
-			   DAT::tdual_int_1d k_sendlist,
-			   DAT::tdual_int_1d k_copylist,
-			   ExecutionSpace space) override;
+                           DAT::tdual_int_1d k_sendlist,
+                           DAT::tdual_int_1d k_copylist,
+                           ExecutionSpace space) override;
 
   void unpack_exchange_kokkos(DAT::tdual_xfloat_2d &k_buf,
                               DAT::tdual_int_1d &indices,int nrecv,
+                              int nrecv1,int nrecv1extra,
                               ExecutionSpace space) override;
 
  private:
@@ -91,6 +92,7 @@ class FixWallGranKokkos : public FixWallGranOld, public KokkosBase {
   typename AT::t_int_1d d_copylist;
   typename AT::t_int_1d d_indices;
 };
+
 }
 
 #endif

--- a/src/KOKKOS/kokkos_base.h
+++ b/src/KOKKOS/kokkos_base.h
@@ -47,6 +47,7 @@ class KokkosBase {
                                    ExecutionSpace /*space*/) { return 0; }
   virtual void unpack_exchange_kokkos(DAT::tdual_xfloat_2d & /*k_buf*/,
                                       DAT::tdual_int_1d & /*indices*/, int /*nrecv*/,
+                                      int /*nrecv1*/, int /*nextrarecv1*/,
                                       ExecutionSpace /*space*/) {}
 
   // Region


### PR DESCRIPTION
**Summary**

Fix bug in some Kokkos fixes' unpack exchange on device when a proc received data from more than 1 other proc in a given direction. Kokkos versions of `fix shake`, `fix neigh/history`, and `fix spring/self` were affected, while Kokkos versions of `fix wall/gran` and `fix qeq/reaxff` were correct and not affected.

The code in comm exchange concatenated buffers from 2 neighbor procs into a single buffer, see https://github.com/lammps/lammps/blob/develop/src/KOKKOS/comm_kokkos.cpp#L923-L925. However the code in `fix shake` and others appended data to front of the buffer in the pack and assumed that the buffer was only from a single proc when unpacking the buffer. Adding an additional offset in the unpack for the data from the second proc fixes the issue.

**Related Issue(s)**

#4037 

**Author(s)**

Stan Moore (SNL), reported by Evan Weinberg (NVIDIA) and Nick Hagerty (ORNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes