### PR TITLE
Un-suppress nvcc warnings: fixes https://github.com/lammps/lammps/issues/4052

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -122,7 +122,7 @@ endif()
 
 # silence nvcc warnings
 if((PKG_KOKKOS) AND (Kokkos_ENABLE_CUDA) AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
-  set(CMAKE_TUNE_DEFAULT "${CMAKE_TUNE_DEFAULT} -Xcudafe --diag_suppress=unrecognized_pragma")
+  set(CMAKE_TUNE_DEFAULT "${CMAKE_TUNE_DEFAULT}")
 endif()
 
 # we require C++11 without extensions. Kokkos requires at least C++17 (currently)


### PR DESCRIPTION
Un-suppress the NVCC warnings and fixes bug in https://github.com/lammps/lammps/issues/4052 during compilation with unittest.

Tested binary should outweigh suppressing warnings if these are not relevant anyway.

Testing > Warnings

fixes https://github.com/lammps/lammps/issues/4052