### PR TITLE
Add function to library interfaces to set internal style variable values

### DIFF
--- a/doc/src/Fortran.rst
+++ b/doc/src/Fortran.rst
@@ -1410,7 +1410,7 @@ Procedures Bound to the :f:type:`lammps` Derived Type
 
    .. warning::
 
-      This subroutine is deprecated and :f:subr:`set_string_variable` 
+      This subroutine is deprecated and :f:subr:`set_string_variable`
       should be used instead.
 
    :p character(len=*) name: name of the variable

--- a/doc/src/Fortran.rst
+++ b/doc/src/Fortran.rst
@@ -315,6 +315,10 @@ of the contents of the :f:mod:`LIBLAMMPS` Fortran interface to LAMMPS.
    :ftype extract_variable: function
    :f set_variable: :f:subr:`set_variable`
    :ftype set_variable: subroutine
+   :f set_string_variable: :f:subr:`set_set_string_variable`
+   :ftype set_string_variable: subroutine
+   :f set_internal_variable: :f:subr:`set_internal_variable`
+   :ftype set_internal_variable: subroutine
    :f gather_atoms: :f:subr:`gather_atoms`
    :ftype gather_atoms: subroutine
    :f gather_atoms_concat: :f:subr:`gather_atoms_concat`
@@ -1398,7 +1402,28 @@ Procedures Bound to the :f:type:`lammps` Derived Type
 
    Set the value of a string-style variable.
 
-   .. versionadded:: 3Nov2022
+   .. deprecated:: TBD
+
+   This function assigns a new value from the string *str* to the string-style
+   variable *name*\ . If *name* does not exist or is not a string-style
+   variable, an error is generated.
+
+   .. warning::
+
+      This subroutine is deprecated and :f:subr:`set_string_variable` 
+      should be used instead.
+
+   :p character(len=*) name: name of the variable
+   :p character(len=*) str:  new value to assign to the variable
+   :to: :cpp:func:`lammps_set_variable`
+
+--------
+
+.. f:subroutine:: set_string_variable(name, str)
+
+   Set the value of a string-style variable.
+
+   .. versionadded:: TBD
 
    This function assigns a new value from the string *str* to the string-style
    variable *name*\ . If *name* does not exist or is not a string-style
@@ -1406,7 +1431,23 @@ Procedures Bound to the :f:type:`lammps` Derived Type
 
    :p character(len=*) name: name of the variable
    :p character(len=*) str:  new value to assign to the variable
-   :to: :cpp:func:`lammps_set_variable`
+   :to: :cpp:func:`lammps_set_string_variable`
+
+--------
+
+.. f:subroutine:: set_internal_variable(name, val)
+
+   Set the value of a internal-style variable.
+
+   .. versionadded:: TBD
+
+   This function assigns a new value from the floating-point number *val* to
+   the internal-style variable *name*\ . If *name* does not exist or is not
+   an internal-style variable, an error is generated.
+
+   :p character(len=*) name: name of the variable
+   :p read(c_double) val:  new value to assign to the variable
+   :to: :cpp:func:`lammps_set_internal_variable`
 
 --------
 

--- a/doc/src/Library_objects.rst
+++ b/doc/src/Library_objects.rst
@@ -9,6 +9,8 @@ fixes, or variables in LAMMPS using the following functions:
 - :cpp:func:`lammps_extract_variable_datatype`
 - :cpp:func:`lammps_extract_variable`
 - :cpp:func:`lammps_set_variable`
+- :cpp:func:`lammps_set_string_variable`
+- :cpp:func:`lammps_set_internal_variable`
 - :cpp:func:`lammps_variable_info`
 
 -----------------------
@@ -34,6 +36,16 @@ fixes, or variables in LAMMPS using the following functions:
 -----------------------
 
 .. doxygenfunction:: lammps_set_variable
+   :project: progguide
+
+-----------------------
+
+.. doxygenfunction:: lammps_set_string_variable
+   :project: progguide
+
+-----------------------
+
+.. doxygenfunction:: lammps_set_internal_variable
    :project: progguide
 
 -----------------------

--- a/examples/COUPLE/plugin/liblammpsplugin.c
+++ b/examples/COUPLE/plugin/liblammpsplugin.c
@@ -110,6 +110,8 @@ liblammpsplugin_t *liblammpsplugin_load(const char *lib)
   ADDSYM(extract_variable);
   ADDSYM(extract_variable_datatype);
   ADDSYM(set_variable);
+  ADDSYM(set_string_variable);
+  ADDSYM(set_internal_variable);
   ADDSYM(variable_info);
 
   ADDSYM(gather_atoms);

--- a/examples/COUPLE/plugin/liblammpsplugin.h
+++ b/examples/COUPLE/plugin/liblammpsplugin.h
@@ -152,9 +152,11 @@ struct _liblammpsplugin {
 
   void *(*extract_compute)(void *, const char *, int, int);
   void *(*extract_fix)(void *, const char *, int, int, int, int);
-  void *(*extract_variable)(void *, const char *, char *);
+  void *(*extract_variable)(void *, const char *, const char *);
   int (*extract_variable_datatype)(void *, const char *);
-  int (*set_variable)(void *, char *, char *);
+  int (*set_variable)(void *, const char *, const char *);
+  int (*set_string_variable)(void *, const char *, const char *);
+  int (*set_internal_variable)(void *, const char *, double);
   int (*variable_info)(void *, int, char *, int);
 
   void (*gather_atoms)(void *, const char *, int, int, void *);

--- a/fortran/lammps.f90
+++ b/fortran/lammps.f90
@@ -118,6 +118,8 @@ MODULE LIBLAMMPS
     PROCEDURE :: extract_fix            => lmp_extract_fix
     PROCEDURE :: extract_variable       => lmp_extract_variable
     PROCEDURE :: set_variable           => lmp_set_variable
+    PROCEDURE :: set_string_variable    => lmp_set_string_variable
+    PROCEDURE :: set_internal_variable  => lmp_set_internal_variable
     PROCEDURE, PRIVATE :: lmp_gather_atoms_int
     PROCEDURE, PRIVATE :: lmp_gather_atoms_double
     GENERIC   :: gather_atoms           => lmp_gather_atoms_int, &
@@ -556,6 +558,21 @@ MODULE LIBLAMMPS
       TYPE(c_ptr), VALUE :: handle, name, str
       INTEGER(c_int) :: lammps_set_variable
     END FUNCTION lammps_set_variable
+
+    FUNCTION lammps_set_string_variable(handle, name, str) BIND(C)
+      IMPORT :: c_int, c_ptr
+      IMPLICIT NONE
+      TYPE(c_ptr), VALUE :: handle, name, str
+      INTEGER(c_int) :: lammps_set_string_variable
+    END FUNCTION lammps_set_string_variable
+
+    FUNCTION lammps_set_internal_variable(handle, name, val) BIND(C)
+      IMPORT :: c_int, c_ptr, c_double
+      IMPLICIT NONE
+      TYPE(c_ptr), VALUE :: handle, name
+      REAL(c_double), VALUE :: val
+      INTEGER(c_int) :: lammps_set_internal_variable
+    END FUNCTION lammps_set_internal_variable
 
     SUBROUTINE lammps_gather_atoms(handle, name, type, count, data) BIND(C)
       IMPORT :: c_int, c_ptr
@@ -1630,6 +1647,43 @@ CONTAINS
         // '" [Fortran/set_variable]')
     END IF
   END SUBROUTINE lmp_set_variable
+
+  ! equivalent function to lammps_set_string_variable
+  SUBROUTINE lmp_set_string_variable(self, name, str)
+    CLASS(lammps), INTENT(IN) :: self
+    CHARACTER(LEN=*), INTENT(IN) :: name, str
+    INTEGER :: err
+    TYPE(c_ptr) :: Cstr, Cname
+
+    Cstr = f2c_string(str)
+    Cname = f2c_string(name)
+    err = lammps_set_string_variable(self%handle, Cname, Cstr)
+    CALL lammps_free(Cname)
+    CALL lammps_free(Cstr)
+    IF (err /= 0) THEN
+      CALL lmp_error(self, LMP_ERROR_WARNING + LMP_ERROR_WORLD, &
+        'WARNING: unable to set string variable "' // name &
+        // '" [Fortran/set_variable]')
+    END IF
+  END SUBROUTINE lmp_set_string_variable
+
+  ! equivalent function to lammps_set_internal_variable
+  SUBROUTINE lmp_set_internal_variable(self, name, val)
+    CLASS(lammps), INTENT(IN) :: self
+    CHARACTER(LEN=*), INTENT(IN) :: name
+    REAL(KIND=c_double), INTENT(IN) :: val
+    INTEGER :: err
+    TYPE(c_ptr) :: Cstr, Cname
+
+    Cname = f2c_string(name)
+    err = lammps_set_internal_variable(self%handle, Cname, val)
+    CALL lammps_free(Cname)
+    IF (err /= 0) THEN
+      CALL lmp_error(self, LMP_ERROR_WARNING + LMP_ERROR_WORLD, &
+        'WARNING: unable to set internal variable "' // name &
+        // '" [Fortran/set_variable]')
+    END IF
+  END SUBROUTINE lmp_set_internal_variable
 
   ! equivalent function to lammps_gather_atoms (for integers)
   SUBROUTINE lmp_gather_atoms_int(self, name, count, data)

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -282,6 +282,8 @@ class lammps(object):
     self.lib.lammps_config_accelerator.argtypes = [c_char_p, c_char_p, c_char_p]
 
     self.lib.lammps_set_variable.argtypes = [c_void_p, c_char_p, c_char_p]
+    self.lib.lammps_set_string_variable.argtypes = [c_void_p, c_char_p, c_char_p]
+    self.lib.lammps_set_internal_variable.argtypes = [c_void_p, c_char_p, c_double]
 
     self.lib.lammps_has_style.argtypes = [c_void_p, c_char_p, c_char_p]
 
@@ -1252,6 +1254,8 @@ class lammps(object):
   def set_variable(self,name,value):
     """Set a new value for a LAMMPS string style variable
 
+    .. deprecated:: TBD
+
     This is a wrapper around the :cpp:func:`lammps_set_variable`
     function of the C-library interface.
 
@@ -1268,6 +1272,52 @@ class lammps(object):
     else: return -1
     with ExceptionCheck(self):
       return self.lib.lammps_set_variable(self.lmp,name,value)
+
+  # -------------------------------------------------------------------------
+
+  def set_string_variable(self,name,value):
+    """Set a new value for a LAMMPS string style variable
+
+    .. versionadded:: TBD
+
+    This is a wrapper around the :cpp:func:`lammps_set_string_variable`
+    function of the C-library interface.
+
+    :param name: name of the variable
+    :type name: string
+    :param value: new variable value
+    :type value: any. will be converted to a string
+    :return: either 0 on success or -1 on failure
+    :rtype: int
+    """
+    if name: name = name.encode()
+    else: return -1
+    if value: value = str(value).encode()
+    else: return -1
+    with ExceptionCheck(self):
+      return self.lib.lammps_set_string_variable(self.lmp,name,value)
+
+  # -------------------------------------------------------------------------
+
+  def set_internal_variable(self,name,value):
+    """Set a new value for a LAMMPS internal style variable
+
+    .. versionadded:: TBD
+
+    This is a wrapper around the :cpp:func:`lammps_set_internal_variable`
+    function of the C-library interface.
+
+    :param name: name of the variable
+    :type name: string
+    :param value: new variable value
+    :type value: float or compatible. will be converted to float
+    :return: either 0 on success or -1 on failure
+    :rtype: int
+    """
+    if name: name = name.encode()
+    else: return -1
+    with ExceptionCheck(self):
+      return self.lib.lammps_set_internal_variable(self.lmp,name,value)
 
   # -------------------------------------------------------------------------
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -2460,8 +2460,13 @@ static int set_variable_deprecated_flag = 1;
 .. deprecated:: TBD
 
 This function assigns a new value from the string str to the
-string-style variable *name*. Returns -1 if a variable of that
-name does not exist or is not a string-style variable, otherwise 0.
+string-style variable *name*.  This is a way to directly change the
+string value of a LAMMPS variable that was previous defined with a
+:doc:`variable name string <variable>` command without using any
+LAMMPS commands to delete and redefine the variable.
+
+Returns -1 if a variable of that name does not exist or if it is not
+a string-style variable, otherwise 0.
 
 .. warning::
 
@@ -2493,8 +2498,13 @@ int lammps_set_variable(void *handle, const char *name, const char *str)
 .. versionadded:: TBD
 
 This function assigns a new value from the string str to the
-string-style variable *name*.  Returns -1 if a variable of that
-name does not exist or is not a string-style variable, otherwise 0.
+string-style variable *name*.  This is a way to directly change the
+string value of a LAMMPS variable that was previous defined with a
+:doc:`variable name string <variable>` command without using any
+LAMMPS commands to delete and redefine the variable.
+
+Returns -1 if a variable of that name does not exist or if it is not
+a string-style variable, otherwise 0.
 
 \endverbatim
 
@@ -2521,10 +2531,19 @@ int lammps_set_string_variable(void *handle, const char *name, const char *str)
 
 /** Set the value of an internal-style variable.
  *
- * This function assigns a new value value to an internal-style variable.
- * Returns -1 if a variable of that name does not exist or is not an
- * internal-style variable, otherwise 0.
- *
+\verbatim embed:rst
+
+This function assigns a new value from the floating point number *value*
+to the internal-style variable *name*.  This is a way to directly change
+the numerical value of such a LAMMPS variable that was previous defined
+with a :doc:`variable name internal <variable>` command without using
+any LAMMPS commands to delete and redefine the variable.
+
+Returns -1 if a variable of that name does not exist or is not an
+internal-style variable, otherwise 0.
+
+\endverbatim
+
  * \param  handle  pointer to a previously created LAMMPS instance
  * \param  name    name of the variable
  * \param  value   new value of the variable

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -2451,19 +2451,59 @@ int lammps_extract_variable_datatype(void *handle, const char *name)
 }
 
 /* ---------------------------------------------------------------------- */
+// for printing obsolete function call warning only once
+static int set_variable_deprecated_flag = 1;
 
 /** Set the value of a string-style variable.
- *
- * This function assigns a new value from the string str to the
- * string-style variable name. Returns -1 if a variable of that
- * name does not exist or is not a string-style variable, otherwise 0.
- *
+\verbatim embed:rst
+
+.. deprecated:: TBD
+
+This function assigns a new value from the string str to the
+string-style variable *name*. Returns -1 if a variable of that
+name does not exist or is not a string-style variable, otherwise 0.
+
+.. warning::
+
+   This function is deprecated and :cpp:func:`lammps_set_string_variable`
+   should be used instead.
+
+   \endverbatim
+
+* \param  handle  pointer to a previously created LAMMPS instance
+ * \param  name    name of the variable
+ * \param  str     new value of the variable
+ * \return         0 on success or -1 on failure */
+
+int lammps_set_variable(void *handle, const char *name, const char *str)
+{
+  if (set_variable_deprecated_flag) {
+    fprintf(stderr,"Using the 'lammps_set_variable()' function is deprecated. "
+            "Please use 'lammps_set_string_variable()' instead.\n");
+    set_variable_deprecated_flag = 0;
+  }
+  return lammps_set_string_variable(handle, name, str);
+}
+
+/* ---------------------------------------------------------------------- */
+
+/** Set the value of a string-style variable.
+\verbatim embed:rst
+
+.. versionadded:: TBD
+
+This function assigns a new value from the string str to the
+string-style variable *name*.  Returns -1 if a variable of that
+name does not exist or is not a string-style variable, otherwise 0.
+
+\endverbatim
+
  * \param  handle  pointer to a previously created LAMMPS instance
  * \param  name    name of the variable
  * \param  str     new value of the variable
  * \return         0 on success or -1 on failure
  */
-int lammps_set_variable(void *handle, char *name, char *str)
+int lammps_set_string_variable(void *handle, const char *name, const char *str)
 {
   auto lmp = (LAMMPS *) handle;
   int err = -1;
@@ -2477,6 +2517,35 @@ int lammps_set_variable(void *handle, char *name, char *str)
   return err;
 }
 
+/* ---------------------------------------------------------------------- */
+
+/** Set the value of an internal-style variable.
+ *
+ * This function assigns a new value value to an internal-style variable.
+ * Returns -1 if a variable of that name does not exist or is not an
+ * internal-style variable, otherwise 0.
+ *
+ * \param  handle  pointer to a previously created LAMMPS instance
+ * \param  name    name of the variable
+ * \param  value   new value of the variable
+ * \return         0 on success or -1 on failure
+ */
+int lammps_set_internal_variable(void *handle, const char *name, double value)
+{
+  auto lmp = (LAMMPS *) handle;
+
+  BEGIN_CAPTURE
+  {
+    int ivar = lmp->input->variable->find(name);
+    if (ivar < 0) return -1;
+    if (lmp->input->variable->internalstyle(ivar)) {
+        lmp->input->variable->internal_set(ivar, value);
+        return 0;
+    }
+  }
+  END_CAPTURE
+  return -1;
+}
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/library.h
+++ b/src/library.h
@@ -177,7 +177,9 @@ void *lammps_extract_compute(void *handle, const char *, int, int);
 void *lammps_extract_fix(void *handle, const char *, int, int, int, int);
 void *lammps_extract_variable(void *handle, const char *, const char *);
 int lammps_extract_variable_datatype(void *handle, const char *name);
-int lammps_set_variable(void *handle, char *name, char *str);
+int lammps_set_variable(void *handle, const char *name, const char *str);
+int lammps_set_string_variable(void *handle, const char *name, const char *str);
+int lammps_set_internal_variable(void *handle, const char *name, double value);
 int lammps_variable_info(void *handle, int idx, char *buf, int bufsize);
 
 /* ----------------------------------------------------------------------

--- a/tools/swig/lammps.i
+++ b/tools/swig/lammps.i
@@ -129,11 +129,13 @@ extern void  *lammps_extract_global(void *handle, const char *name);
 extern int    lammps_extract_atom_datatype(void *handle, const char *name);
 extern void  *lammps_extract_atom(void *handle, const char *name);
 
-extern void  *lammps_extract_compute(void *handle, char *id, int, int);
-extern void  *lammps_extract_fix(void *handle, char *, int, int, int, int);
-extern void  *lammps_extract_variable(void *handle, char *, char *);
+extern void  *lammps_extract_compute(void *handle, const char *id, int, int);
+extern void  *lammps_extract_fix(void *handle, const char *, int, int, int, int);
+extern void  *lammps_extract_variable(void *handle, const char *, const char *);
 extern int    lammps_extract_variable_datatype(void *handle, const char *name);
-extern int    lammps_set_variable(void *, char *, char *);
+extern int    lammps_set_variable(void *, const char *, const char *);
+extern int    lammps_set_string_variable(void *, const char *, const char *);
+extern int    lammps_set_internal_variable(void *, const char *, double);
 
 extern void   lammps_gather_atoms(void *, char *, int, int, void *);
 extern void   lammps_gather_atoms_concat(void *, char *, int, int, void *);
@@ -312,11 +314,13 @@ extern void  *lammps_extract_global(void *handle, const char *name);
 extern int    lammps_extract_atom_datatype(void *handle, const char *name);
 extern void  *lammps_extract_atom(void *handle, const char *name);
 
-extern void  *lammps_extract_compute(void *handle, char *id, int, int);
-extern void  *lammps_extract_fix(void *handle, char *, int, int, int, int);
-extern void  *lammps_extract_variable(void *handle, char *, char *);
+extern void  *lammps_extract_compute(void *handle, const char *id, int, int);
+extern void  *lammps_extract_fix(void *handle, const char *, int, int, int, int);
+extern void  *lammps_extract_variable(void *handle, const char *, const char *);
 extern int    lammps_extract_variable_datatype(void *handle, const char *name);
-extern int    lammps_set_variable(void *, char *, char *);
+extern int    lammps_set_variable(void *, const char *, const char *);
+extern int    lammps_set_string_variable(void *, const char *, const char *);
+extern int    lammps_set_internal_variable(void *, const char *, double);
 
 extern void   lammps_gather_atoms(void *, char *, int, int, void *);
 extern void   lammps_gather_atoms_concat(void *, char *, int, int, void *);

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -780,6 +780,25 @@ TEST_F(VariableTest, Format)
     //    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
     //                 command("print \"${f1idx}\""););
 }
+
+TEST_F(VariableTest, Set)
+{
+    BEGIN_HIDE_OUTPUT();
+    command("variable three  string    three");
+    command("variable ten    internal  10.0");
+    END_HIDE_OUTPUT();
+    ASSERT_EQ(variable->nvar, 3);
+    ASSERT_THAT(variable->retrieve("three"), StrEq("three"));
+    ASSERT_THAT(variable->retrieve("ten"), StrEq("10"));
+
+    ASSERT_EQ(variable->internalstyle(variable->find("three")), 0);
+    ASSERT_EQ(variable->internalstyle(variable->find("ten")), 1);
+
+    variable->set_string("three", "new");
+    ASSERT_THAT(variable->retrieve("three"), StrEq("new"));
+    variable->internal_set(variable->find("ten"), -2.5);
+    ASSERT_THAT(variable->retrieve("ten"), StrEq("-2.5"));
+}
 } // namespace LAMMPS_NS
 
 int main(int argc, char **argv)

--- a/unittest/fortran/test_fortran_extract_variable.f90
+++ b/unittest/fortran/test_fortran_extract_variable.f90
@@ -361,15 +361,23 @@ FUNCTION f_lammps_extract_variable_vector(i) BIND(C)
   f_lammps_extract_variable_vector = vector(i)
 END FUNCTION f_lammps_extract_variable_vector
 
-SUBROUTINE f_lammps_set_variable_string() BIND(C)
-  USE, INTRINSIC :: ISO_C_BINDING, ONLY : c_double, c_int
+SUBROUTINE f_lammps_set_string_variable() BIND(C)
   USE LIBLAMMPS
   USE keepstuff, ONLY : lmp, f2c_string
   IMPLICIT NONE
   CHARACTER(LEN=40) :: string
 
   string = "this is the new string"
-  CALL lmp%set_variable('str', string)
-END SUBROUTINE f_lammps_set_variable_string
+  CALL lmp%set_string_variable('str', string)
+END SUBROUTINE f_lammps_set_string_variable
+
+SUBROUTINE f_lammps_set_internal_variable() BIND(C)
+  USE, INTRINSIC :: ISO_C_BINDING, ONLY : c_double
+  USE LIBLAMMPS
+  USE keepstuff, ONLY : lmp, f2c_string
+  IMPLICIT NONE
+
+  CALL lmp%set_internal_variable('int', -2.5_c_double)
+END SUBROUTINE f_lammps_set_internal_variable
 
 ! vim: sts=2 ts=2 sw=2 et

--- a/unittest/fortran/wrap_extract_variable.cpp
+++ b/unittest/fortran/wrap_extract_variable.cpp
@@ -43,7 +43,9 @@ double f_lammps_extract_variable_internal();
 double f_lammps_extract_variable_equal();
 double f_lammps_extract_variable_atom(int);
 double f_lammps_extract_variable_vector(int);
-void f_lammps_set_variable_string();
+void f_lammps_set_string_variable();
+void f_lammps_set_internal_variable();
+
 char *c_path_join(const char *, const char *);
 }
 
@@ -155,7 +157,7 @@ TEST_F(LAMMPS_extract_variable, string)
     char *fstr = f_lammps_extract_variable_string();
     EXPECT_STREQ(fstr, "this is a string");
     std::free(fstr);
-    f_lammps_set_variable_string();
+    f_lammps_set_string_variable();
     fstr = f_lammps_extract_variable_string();
     EXPECT_STREQ(fstr, "this is the new string");
     std::free(fstr);
@@ -254,6 +256,8 @@ TEST_F(LAMMPS_extract_variable, internal)
 {
     f_lammps_setup_extract_variable();
     EXPECT_DOUBLE_EQ(f_lammps_extract_variable_internal(), 4.0);
+    f_lammps_set_internal_variable();
+    EXPECT_DOUBLE_EQ(f_lammps_extract_variable_internal(), -2.5);
 };
 
 TEST_F(LAMMPS_extract_variable, equal)

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -475,6 +475,26 @@ create_atoms 1 single &
         a = self.lmp.extract_variable("a")
         self.assertEqual(a, 3.14)
 
+    def test_extract_variable_stringstyle(self):
+        self.lmp.command("variable a string xxx")
+        a = self.lmp.extract_variable("a")
+        self.assertEqual(a, 'xxx')
+
+        rv = self.lmp.set_string_variable("a","20")
+        a = self.lmp.extract_variable("a")
+        self.assertEqual(a, '20')
+        self.assertEqual(rv, 0)
+
+    def test_extract_variable_internalstyle(self):
+        self.lmp.command("variable a internal 2.0")
+        a = self.lmp.extract_variable("a")
+        self.assertEqual(a, 2.0)
+
+        rv = self.lmp.set_internal_variable("a",-4.5)
+        a = self.lmp.extract_variable("a")
+        self.assertEqual(a, -4.5)
+        self.assertEqual(rv, 0)
+
     def test_extract_variable_atomstyle(self):
         self.lmp.command("units lj")
         self.lmp.command("atom_style atomic")


### PR DESCRIPTION
**Summary**

This adds a function `lammps_set_internal_variable()` to the LAMMPS C-library interface to give access to the `Variable::internal_set()` function. That way it becomes possible to change the value of a LAMMPS variable directly. For consistency, the `lammps_set_variable()` function was renamed to `lammps_set_string_variable()` while retaining a backward compatibility wrapper that prints a one time deprecation warning.

The changes are propagated to all functionality that sits on top of the C-library interface: Fortran module, Python module, Plugin library loader, Swig wrappers.

Also unit tests are included.

**Related Issue(s)**

Implements a feature asked for on MatSci: https://matsci.org/t/fortran-constants-variables-as-lammps-variables/53165

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issue. Calling the function `lammps_set_variable()` will print a deprecation warning as it will be removed in the future.

**Implementation Notes**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
