### PR TITLE
Remove unused constants

### DIFF
--- a/doc/src/Modify_style.rst
+++ b/doc/src/Modify_style.rst
@@ -96,6 +96,39 @@ list all non-conforming lines.  By adding the `-f` flag to the command
 line, they will modify the flagged files to try to remove the detected
 issues.
 
+Constants (strongly preferred)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Global or per-file constants should be declared as `static constexpr`
+variables rather than via the pre-processor with `#define`.  The name of
+constants should be all uppercase.  This has multiple advantages:
+
+- constants are easily identified as such by their all upper case name
+- rather than a pure text substitution during pre-processing, `constexpr
+  variables` have a type associated with them and are processed later in
+  the parsing process where the syntax checks and type specific
+  processing (e.g. via overloads) can be applied to them.
+- compilers can emit a warning if the constant is not used and thus can
+  be removed (we regularly check for and remove dead code like this)
+- there are no unexpected substitutions and thus confusing syntax errors
+  when compiling leading to, for instance, conflicts so that LAMMPS
+  cannot be compiled with certain combinations of packages (this *has*
+  happened multiple times in the past).
+
+Pre-processor defines should be limited to macros (but consider C++
+templates) and conditional compilation.  If a per-processor define must
+be used, it should be defined at the top of the .cpp file after the
+include statements and at all cost it should be avoided to put them into
+header files.
+
+Some sets of commonly used constants are provided in the ``MathConst``
+and ``EwaldConst`` namespaces and implemented in the files
+``math_const.h`` and ``ewald_const.h``, respectively.
+
+There are always exceptions, special cases, and legacy code in LAMMPS,
+so please contact the LAMMPS developers if you are not sure.
+
+
 Placement of braces (strongly preferred)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/AMOEBA/amoeba_convolution.cpp
+++ b/src/AMOEBA/amoeba_convolution.cpp
@@ -48,7 +48,6 @@ enum{MPOLE_GRID,POLAR_GRID,POLAR_GRIDC,DISP_GRID,INDUCE_GRID,INDUCE_GRIDC};
 #define SCALE 0
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 /* ----------------------------------------------------------------------
    partition an FFT grid across processors

--- a/src/AMOEBA/amoeba_multipole.cpp
+++ b/src/AMOEBA/amoeba_multipole.cpp
@@ -31,16 +31,8 @@ using namespace MathConst;
 
 using MathSpecial::square;
 
-enum{FIELD,ZRSD,TORQUE,UFLD};                          // reverse comm
-enum{VDWL,REPULSE,QFER,DISP,MPOLE,POLAR,USOLV,DISP_LONG,MPOLE_LONG,POLAR_LONG};
-
-#ifdef FFT_SINGLE
-static constexpr FFT_SCALAR ZEROF = 0.0f;
-static constexpr FFT_SCALAR ONEF =  1.0f;
-#else
-static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
-#endif
+enum { FIELD, ZRSD, TORQUE, UFLD };    // reverse comm
+enum { VDWL, REPULSE, QFER, DISP, MPOLE, POLAR, USOLV, DISP_LONG, MPOLE_LONG, POLAR_LONG };
 
 /* ----------------------------------------------------------------------
    multipole = multipole interactions

--- a/src/AMOEBA/improper_amoeba.cpp
+++ b/src/AMOEBA/improper_amoeba.cpp
@@ -28,9 +28,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
-
 /* ---------------------------------------------------------------------- */
 
 ImproperAmoeba::ImproperAmoeba(LAMMPS *lmp) : Improper(lmp)

--- a/src/BODY/body_rounded_polyhedron.cpp
+++ b/src/BODY/body_rounded_polyhedron.cpp
@@ -32,9 +32,9 @@
 using namespace LAMMPS_NS;
 
 static constexpr double EPSILON = 1.0e-7;
-#define MAX_FACE_SIZE 4  // maximum number of vertices per face (for now)
+static constexpr int MAX_FACE_SIZE = 4;  // maximum number of vertices per face (for now)
 
-enum{SPHERE,LINE};       // also in DumpImage
+enum { SPHERE, LINE };       // also in DumpImage
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/BODY/fix_wall_body_polygon.cpp
+++ b/src/BODY/fix_wall_body_polygon.cpp
@@ -44,10 +44,10 @@ enum {FAR=0,XLO,XHI,YLO,YHI};
 
 //#define _POLYGON_DEBUG
 static constexpr int DELTA = 10000;
-static constexpr double EPSILON = 1e-2;    // dimensionless threshold (dot products, end point checks, contact checks)
+static constexpr double EPSILON = 1.0e-2; // dimensionless threshold (dot products, end point checks, contact checks)
 static constexpr double BIG = 1.0e20;
-#define MAX_CONTACTS 4  // maximum number of contacts for 2D models
-#define EFF_CONTACTS 2  // effective contacts for 2D models
+static constexpr int MAX_CONTACTS = 4;    // maximum number of contacts for 2D models
+static constexpr int EFF_CONTACTS = 2;    // effective contacts for 2D models
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/BODY/fix_wall_body_polyhedron.cpp
+++ b/src/BODY/fix_wall_body_polyhedron.cpp
@@ -44,10 +44,9 @@ enum {FAR=0,XLO,XHI,YLO,YHI,ZLO,ZHI};
 
 //#define _POLYHEDRON_DEBUG
 static constexpr int DELTA = 10000;
-static constexpr double EPSILON = 1e-3;    // dimensionless threshold (dot products, end point checks)
+static constexpr double EPSILON = 1.0e-3; // dimensionless threshold (dot products, end point checks)
 static constexpr double BIG = 1.0e20;
-#define MAX_CONTACTS 4  // maximum number of contacts for 2D models
-#define EFF_CONTACTS 2  // effective contacts for 2D models
+static constexpr int MAX_CONTACTS = 4;    // maximum number of contacts for 2D models
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -40,14 +40,14 @@
 using namespace LAMMPS_NS;
 
 static constexpr int DELTA = 10000;
-static constexpr double EPSILON = 1e-3;    // dimensionless threshold (dot products, end point checks, contact checks)
-#define MAX_CONTACTS 4  // maximum number of contacts for 2D models
-#define EFF_CONTACTS 2  // effective contacts for 2D models
+static constexpr double EPSILON = 1.0e-3; // dimensionless threshold (dot products, end point checks, contact checks)
+static constexpr int MAX_CONTACTS = 4;    // maximum number of contacts for 2D models
+static constexpr int EFF_CONTACTS = 2;    // effective contacts for 2D models
 
 //#define _CONVEX_POLYGON
 //#define _POLYGON_DEBUG
 
-enum {INVALID=0,NONE=1,VERTEXI=2,VERTEXJ=3,EDGE=4};
+enum { INVALID=0, NONE=1, VERTEXI=2, VERTEXJ=3, EDGE=4 };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/BODY/pair_body_rounded_polyhedron.cpp
+++ b/src/BODY/pair_body_rounded_polyhedron.cpp
@@ -44,9 +44,9 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 static constexpr int DELTA = 10000;
-static constexpr double EPSILON = 1e-3;     // dimensionless threshold (dot products, end point checks, contact checks)
-#define MAX_FACE_SIZE 4  // maximum number of vertices per face (same as BodyRoundedPolyhedron)
-#define MAX_CONTACTS 32  // for 3D models (including duplicated counts)
+static constexpr double EPSILON = 1.0e-3; // dimensionless threshold (dot products, end point checks, contact checks)
+static constexpr int MAX_FACE_SIZE = 4;   // maximum number of vertices per face (same as BodyRoundedPolyhedron)
+static constexpr int MAX_CONTACTS = 32;   // for 3D models (including duplicated counts)
 
 //#define _POLYHEDRON_DEBUG
 

--- a/src/BPM/fix_update_special_bonds.cpp
+++ b/src/BPM/fix_update_special_bonds.cpp
@@ -28,8 +28,6 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-static constexpr int DELTA = 10000;
-
 /* ---------------------------------------------------------------------- */
 
 FixUpdateSpecialBonds::FixUpdateSpecialBonds(LAMMPS *lmp, int narg, char **arg) :

--- a/src/CG-SPICA/pair_lj_spica_coul_long.cpp
+++ b/src/CG-SPICA/pair_lj_spica_coul_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "memory.h"
@@ -35,14 +36,7 @@
 
 using namespace LAMMPS_NS;
 using namespace LJSPICAParms;
-
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/CLASS2/improper_class2.cpp
+++ b/src/CLASS2/improper_class2.cpp
@@ -32,8 +32,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr double SMALL = 0.001;
-
 /* ---------------------------------------------------------------------- */
 
 ImproperClass2::ImproperClass2(LAMMPS *lmp) : Improper(lmp)

--- a/src/COLVARS/ndx_group.cpp
+++ b/src/COLVARS/ndx_group.cpp
@@ -27,7 +27,6 @@
 
 using namespace LAMMPS_NS;
 static constexpr int BUFLEN = 4096;
-static constexpr int DELTA = 16384;
 
 // read file until next section "name" or any next section if name == ""
 

--- a/src/CORESHELL/pair_born_coul_long_cs.cpp
+++ b/src/CORESHELL/pair_born_coul_long_cs.cpp
@@ -17,25 +17,27 @@
 ------------------------------------------------------------------------- */
 
 #include "pair_born_coul_long_cs.h"
-#include <cmath>
+
 #include "atom.h"
 #include "force.h"
 #include "neigh_list.h"
 
+#include <cmath>
+
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   9.95473818e-1
-#define B0       -0.1335096380159268
-#define B1       -2.57839507e-1
-#define B2       -1.37203639e-1
-#define B3       -8.88822059e-3
-#define B4       -5.80844129e-3
-#define B5        1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/CORESHELL/pair_buck_coul_long_cs.cpp
+++ b/src/CORESHELL/pair_buck_coul_long_cs.cpp
@@ -24,18 +24,18 @@
 
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   9.95473818e-1
-#define B0       -0.1335096380159268
-#define B1       -2.57839507e-1
-#define B2       -1.37203639e-1
-#define B3       -8.88822059e-3
-#define B4       -5.80844129e-3
-#define B5        1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/CORESHELL/pair_coul_long_cs.cpp
+++ b/src/CORESHELL/pair_coul_long_cs.cpp
@@ -24,18 +24,18 @@
 
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   9.95473818e-1
-#define B0       -0.1335096380159268
-#define B1       -2.57839507e-1
-#define B2       -1.37203639e-1
-#define B3       -8.88822059e-3
-#define B4       -5.80844129e-3
-#define B5        1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/CORESHELL/pair_lj_class2_coul_long_cs.cpp
+++ b/src/CORESHELL/pair_lj_class2_coul_long_cs.cpp
@@ -20,18 +20,18 @@
 
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   9.95473818e-1
-#define B0       -0.1335096380159268
-#define B1       -2.57839507e-1
-#define B2       -1.37203639e-1
-#define B3       -8.88822059e-3
-#define B4       -5.80844129e-3
-#define B5        1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/CORESHELL/pair_lj_cut_coul_long_cs.cpp
+++ b/src/CORESHELL/pair_lj_cut_coul_long_cs.cpp
@@ -24,18 +24,18 @@
 
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   9.95473818e-1
-#define B0       -0.1335096380159268
-#define B1       -2.57839507e-1
-#define B2       -1.37203639e-1
-#define B3       -8.88822059e-3
-#define B4       -5.80844129e-3
-#define B5        1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/DIELECTRIC/pppm_dielectric.cpp
+++ b/src/DIELECTRIC/pppm_dielectric.cpp
@@ -38,11 +38,10 @@ using namespace MathSpecial;
 
 static constexpr double SMALL = 0.00001;
 
-enum {REVERSE_RHO};
-enum {FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
+enum { REVERSE_RHO };
+enum { FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/DIELECTRIC/pppm_disp_dielectric.cpp
+++ b/src/DIELECTRIC/pppm_disp_dielectric.cpp
@@ -33,11 +33,8 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr int MAXORDER =   7;
-static constexpr int OFFSET = 16384;
 static constexpr double SMALL = 0.00001;
-static constexpr double LARGE = 10000.0;
-static constexpr double EPS_HOC = 1.0e-7;
+static constexpr FFT_SCALAR ZEROF = 0.0;
 
 enum{REVERSE_RHO,REVERSE_RHO_GEOM,REVERSE_RHO_ARITH,REVERSE_RHO_NONE};
 enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM,
@@ -47,9 +44,6 @@ enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM,
      FORWARD_IK_PERATOM_ARITH,FORWARD_AD_PERATOM_ARITH,
      FORWARD_IK_NONE,FORWARD_AD_NONE,FORWARD_IK_PERATOM_NONE,
      FORWARD_AD_PERATOM_NONE};
-
-static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/DIPOLE/pair_lj_cut_dipole_long.cpp
+++ b/src/DIPOLE/pair_lj_cut_dipole_long.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -30,14 +31,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/DIPOLE/pair_lj_long_dipole_long.cpp
+++ b/src/DIPOLE/pair_lj_long_dipole_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -36,14 +37,7 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathExtra;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 // ----------------------------------------------------------------------
 

--- a/src/DPD-REACT/fix_rx.cpp
+++ b/src/DPD-REACT/fix_rx.cpp
@@ -42,7 +42,6 @@ enum { NONE, HARMONIC };
 enum { LUCY };
 
 static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
 
 #ifdef DBL_EPSILON
 static constexpr double MY_EPSILON = 10.0*DBL_EPSILON;

--- a/src/DPD-REACT/fix_shardlow.cpp
+++ b/src/DPD-REACT/fix_shardlow.cpp
@@ -59,8 +59,7 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace random_external_state;
 
-static constexpr double EPSILON = 1.0e-10;
-#define EPSILON_SQUARED ((EPSILON) * (EPSILON))
+static constexpr double EPSILON_SQUARED = 1.0e-20;
 
 static const char cite_fix_shardlow[] =
   "fix shardlow command: doi:10.1016/j.cpc.2014.03.029, doi:10.1063/1.3660209\n\n"

--- a/src/DPD-REACT/pair_multi_lucy_rx.cpp
+++ b/src/DPD-REACT/pair_multi_lucy_rx.cpp
@@ -45,12 +45,6 @@ enum{ NONE, RLINEAR, RSQ };
 
 static constexpr int MAXLINE = 1024;
 
-#ifdef DBL_EPSILON
-static constexpr double MY_EPSILON = 10.0*DBL_EPSILON;
-#else
-static constexpr double MY_EPSILON = 10.0*2.220446049250313e-16;
-#endif
-
 #define oneFluidParameter (-1)
 #define isOneFluid(_site) ( (_site) == oneFluidParameter )
 

--- a/src/DRUDE/pair_lj_cut_thole_long.cpp
+++ b/src/DRUDE/pair_lj_cut_thole_long.cpp
@@ -37,18 +37,18 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   9.95473818e-1
-#define B0       -0.1335096380159268
-#define B1       -2.57839507e-1
-#define B2       -1.37203639e-1
-#define B3       -8.88822059e-3
-#define B4       -5.80844129e-3
-#define B5        1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EFF/fix_langevin_eff.cpp
+++ b/src/EFF/fix_langevin_eff.cpp
@@ -34,11 +34,8 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{NOBIAS,BIAS};
-enum{CONSTANT,EQUAL,ATOM};
-
-static constexpr double SINERTIA = 0.4;          // moment of inertia prefactor for sphere
-static constexpr double EINERTIA = 0.2;          // moment of inertia prefactor for ellipsoid
+enum { NOBIAS, BIAS };
+enum { CONSTANT, EQUAL, ATOM };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/ELECTRODE/ewald_electrode.cpp
+++ b/src/ELECTRODE/ewald_electrode.cpp
@@ -37,8 +37,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr double SMALL = 0.00001;
-
 /* ---------------------------------------------------------------------- */
 
 EwaldElectrode::EwaldElectrode(LAMMPS *lmp) : Ewald(lmp), boundcorr(nullptr)

--- a/src/ELECTRODE/fix_electrode_thermo.cpp
+++ b/src/ELECTRODE/fix_electrode_thermo.cpp
@@ -29,7 +29,7 @@
 
 using namespace LAMMPS_NS;
 
-#define NUM_GROUPS 2
+static constexpr int NUM_GROUPS = 2;
 static constexpr double SMALL = 0.00001;
 
 /* ----------------------------------------------------------------------- */

--- a/src/ELECTRODE/pppm_electrode.cpp
+++ b/src/ELECTRODE/pppm_electrode.cpp
@@ -47,15 +47,12 @@ using namespace MathSpecial;
 
 static constexpr int MAXORDER = 7;
 static constexpr int OFFSET = 16384;
-static constexpr double LARGE = 10000.0;
-static constexpr double SMALL = 0.00001;
 static constexpr double EPS_HOC = 1.0e-7;
 
 enum { REVERSE_RHO };
 enum { FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF = 1.0;
 
 static const char cite_pppm_electrode[] =
     "kspace_style pppm/electrode command:\n\n"

--- a/src/EXTRA-FIX/fix_ffl.cpp
+++ b/src/EXTRA-FIX/fix_ffl.cpp
@@ -43,8 +43,6 @@ enum {CONSTANT,EQUAL,ATOM};
 enum {NO_FLIP, FLIP_RESCALE, FLIP_HARD, FLIP_SOFT};
 //#define FFL_DEBUG 1
 
-static constexpr int MAXLINE = 1024;
-
 /* syntax for fix_ffl:
  * fix nfix id-group ffl tau Tstart Tstop seed [flip_type]
  *                                                                        */

--- a/src/EXTRA-FIX/fix_filter_corotate.cpp
+++ b/src/EXTRA-FIX/fix_filter_corotate.cpp
@@ -42,7 +42,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace FixConst;
 
-static constexpr double BIG = 1.0e20;
 static constexpr double MASSDELTA = 0.1;
 
 static const char cite_filter_corotate[] =

--- a/src/EXTRA-FIX/fix_gle.cpp
+++ b/src/EXTRA-FIX/fix_gle.cpp
@@ -41,8 +41,6 @@ enum{CONSTANT,EQUAL,ATOM};
 
 //#define GLE_DEBUG 1
 
-static constexpr int MAXLINE = 1024;
-
 /* syntax for fix_gle:
  * fix nfix id-group gle ns Tstart Tstop seed amatrix [noneq cmatrix] [every nmts]
  *

--- a/src/EXTRA-FIX/fix_smd.cpp
+++ b/src/EXTRA-FIX/fix_smd.cpp
@@ -430,7 +430,7 @@ void FixSMD::smd_couple()
 
 void FixSMD::write_restart(FILE *fp)
 {
-#define RESTART_ITEMS 5
+  static constexpr int RESTART_ITEMS = 5;
   double buf[RESTART_ITEMS], fsign;
 
   if (comm->me == 0) {

--- a/src/EXTRA-MOLECULE/angle_fourier.cpp
+++ b/src/EXTRA-MOLECULE/angle_fourier.cpp
@@ -29,11 +29,8 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-static constexpr double SMALL = 0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-MOLECULE/dihedral_cosine_shift_exp.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_cosine_shift_exp.cpp
@@ -31,7 +31,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-MOLECULE/improper_distance.cpp
+++ b/src/EXTRA-MOLECULE/improper_distance.cpp
@@ -27,11 +27,7 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
-
-static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-MOLECULE/improper_ring.cpp
+++ b/src/EXTRA-MOLECULE/improper_ring.cpp
@@ -54,7 +54,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathSpecial;
 
-static constexpr double TOLERANCE = 0.05;
 static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */

--- a/src/EXTRA-PAIR/pair_coul_slater_long.cpp
+++ b/src/EXTRA-PAIR/pair_coul_slater_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "memory.h"
@@ -31,14 +32,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-PAIR/pair_lj_cut_coul_dsf.cpp
+++ b/src/EXTRA-PAIR/pair_lj_cut_coul_dsf.cpp
@@ -34,13 +34,12 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-PAIR/pair_lj_expand_coul_long.cpp
+++ b/src/EXTRA-PAIR/pair_lj_expand_coul_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -35,14 +36,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/EXTRA-PAIR/pair_nm_cut_coul_long.cpp
+++ b/src/EXTRA-PAIR/pair_nm_cut_coul_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -33,14 +34,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/FEP/pair_coul_long_soft.cpp
+++ b/src/FEP/pair_coul_long_soft.cpp
@@ -22,6 +22,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "memory.h"
@@ -32,14 +33,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/FEP/pair_lj_charmm_coul_long_soft.cpp
+++ b/src/FEP/pair_lj_charmm_coul_long_soft.cpp
@@ -22,6 +22,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "memory.h"
@@ -34,14 +35,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/FEP/pair_lj_class2_coul_long_soft.cpp
+++ b/src/FEP/pair_lj_class2_coul_long_soft.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -29,14 +30,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/FEP/pair_lj_cut_coul_long_soft.cpp
+++ b/src/FEP/pair_lj_cut_coul_long_soft.cpp
@@ -22,6 +22,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -36,14 +37,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/FEP/pair_lj_cut_tip4p_long_soft.cpp
+++ b/src/FEP/pair_lj_cut_tip4p_long_soft.cpp
@@ -25,24 +25,18 @@
 #include "bond.h"
 #include "comm.h"
 #include "domain.h"
-#include "force.h"
-#include "neighbor.h"
-#include "neigh_list.h"
-#include "memory.h"
 #include "error.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
 
 #include <cmath>
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/FEP/pair_tip4p_long_soft.cpp
+++ b/src/FEP/pair_tip4p_long_soft.cpp
@@ -25,24 +25,18 @@
 #include "bond.h"
 #include "comm.h"
 #include "domain.h"
-#include "force.h"
-#include "neighbor.h"
-#include "neigh_list.h"
-#include "memory.h"
 #include "error.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
 
 #include <cmath>
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/GPU/pair_born_coul_long_cs_gpu.cpp
+++ b/src/GPU/pair_born_coul_long_cs_gpu.cpp
@@ -33,18 +33,18 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define EWALD_F 1.12837917
-#define EWALD_P 9.95473818e-1
-#define B0 -0.1335096380159268
-#define B1 -2.57839507e-1
-#define B2 -1.37203639e-1
-#define B3 -8.88822059e-3
-#define B4 -5.80844129e-3
-#define B5 1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_born_coul_long_gpu.cpp
+++ b/src/GPU/pair_born_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -30,16 +31,9 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
 using namespace MathConst;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_buck_coul_long_gpu.cpp
+++ b/src/GPU/pair_buck_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_coul_dsf_gpu.cpp
+++ b/src/GPU/pair_coul_dsf_gpu.cpp
@@ -22,22 +22,22 @@
 #include "error.h"
 #include "force.h"
 #include "gpu_extra.h"
+#include "math_const.h"
 #include "neigh_list.h"
 #include "neighbor.h"
 #include "suffix.h"
 
 #include <cmath>
 
-#define MY_PIS 1.77245385090551602729
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 using namespace LAMMPS_NS;
+using MathConst::MY_PIS;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_coul_long_cs_gpu.cpp
+++ b/src/GPU/pair_coul_long_cs_gpu.cpp
@@ -31,18 +31,18 @@
 
 using namespace LAMMPS_NS;
 
-#define EWALD_F 1.12837917
-#define EWALD_P 9.95473818e-1
-#define B0 -0.1335096380159268
-#define B1 -2.57839507e-1
-#define B2 -1.37203639e-1
-#define B3 -8.88822059e-3
-#define B4 -5.80844129e-3
-#define B5 1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_coul_long_gpu.cpp
+++ b/src/GPU/pair_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_coul_slater_long_gpu.cpp
+++ b/src/GPU/pair_coul_slater_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_eam_gpu.cpp
+++ b/src/GPU/pair_eam_gpu.cpp
@@ -29,8 +29,6 @@
 
 #include <cmath>
 
-static constexpr int MAXLINE = 1024;
-
 using namespace LAMMPS_NS;
 
 // External functions from cuda library for atom decomposition

--- a/src/GPU/pair_edpd_gpu.cpp
+++ b/src/GPU/pair_edpd_gpu.cpp
@@ -58,8 +58,6 @@ void edpd_gpu_get_extra_data(double *host_T, double *host_cv);
 void edpd_gpu_update_flux(void **flux_ptr);
 double edpd_gpu_bytes();
 
-static constexpr double EPSILON = 1.0e-10;
-
 /* ---------------------------------------------------------------------- */
 
 PairEDPDGPU::PairEDPDGPU(LAMMPS *lmp) : PairEDPD(lmp), gpu_mode(GPU_FORCE)

--- a/src/GPU/pair_lj_charmm_coul_long_gpu.cpp
+++ b/src/GPU/pair_lj_charmm_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_lj_class2_coul_long_gpu.cpp
+++ b/src/GPU/pair_lj_class2_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_lj_cut_coul_dsf_gpu.cpp
+++ b/src/GPU/pair_lj_cut_coul_dsf_gpu.cpp
@@ -22,22 +22,22 @@
 #include "error.h"
 #include "force.h"
 #include "gpu_extra.h"
+#include "math_const.h"
 #include "neigh_list.h"
 #include "neighbor.h"
 #include "suffix.h"
 
 #include <cmath>
 
-#define MY_PIS 1.77245385090551602729
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using MathConst::MY_PIS;
+
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_lj_cut_coul_long_gpu.cpp
+++ b/src/GPU/pair_lj_cut_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_lj_cut_coul_long_soft_gpu.cpp
+++ b/src/GPU/pair_lj_cut_coul_long_soft_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_lj_cut_tip4p_long_gpu.cpp
+++ b/src/GPU/pair_lj_cut_tip4p_long_gpu.cpp
@@ -23,6 +23,7 @@
 #include "comm.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -33,15 +34,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_lj_expand_coul_long_gpu.cpp
+++ b/src/GPU/pair_lj_expand_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_lj_spica_coul_long_gpu.cpp
+++ b/src/GPU/pair_lj_spica_coul_long_gpu.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "gpu_extra.h"
 #include "kspace.h"
@@ -29,15 +30,8 @@
 
 #include <cmath>
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
-
 using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 // External functions from cuda library for atom decomposition
 

--- a/src/GPU/pair_mdpd_gpu.cpp
+++ b/src/GPU/pair_mdpd_gpu.cpp
@@ -55,8 +55,6 @@ void mdpd_gpu_compute(const int ago, const int inum_full, const int nall, double
 void mdpd_gpu_get_extra_data(double *host_rho);
 double mdpd_gpu_bytes();
 
-static constexpr double EPSILON = 1.0e-10;
-
 /* ---------------------------------------------------------------------- */
 
 PairMDPDGPU::PairMDPDGPU(LAMMPS *lmp) : PairMDPD(lmp), gpu_mode(GPU_FORCE)

--- a/src/GPU/pair_sw_gpu.cpp
+++ b/src/GPU/pair_sw_gpu.cpp
@@ -49,9 +49,6 @@ void sw_gpu_compute(const int ago, const int nloc, const int nall, const int ln,
                     const double cpu_time, bool &success);
 double sw_gpu_bytes();
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-
 /* ---------------------------------------------------------------------- */
 
 PairSWGPU::PairSWGPU(LAMMPS *lmp) : PairSW(lmp), gpu_mode(GPU_FORCE)

--- a/src/GPU/pair_tersoff_gpu.cpp
+++ b/src/GPU/pair_tersoff_gpu.cpp
@@ -54,9 +54,6 @@ void tersoff_gpu_compute(const int ago, const int nlocal, const int nall, const 
                          int &host_start, const double cpu_time, bool &success);
 double tersoff_gpu_bytes();
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-
 /* ---------------------------------------------------------------------- */
 
 PairTersoffGPU::PairTersoffGPU(LAMMPS *lmp) : PairTersoff(lmp), gpu_mode(GPU_FORCE)

--- a/src/GPU/pppm_gpu.cpp
+++ b/src/GPU/pppm_gpu.cpp
@@ -1,4 +1,3 @@
-
 // clang-format off
 /* ----------------------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
@@ -40,17 +39,10 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr int MAXORDER = 7;
-static constexpr int OFFSET = 16384;
-static constexpr double SMALL = 0.00001;
-static constexpr double LARGE = 10000.0;
-static constexpr double EPS_HOC = 1.0e-7;
-
-enum{REVERSE_RHO_GPU,REVERSE_RHO};
-enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
+enum { REVERSE_RHO_GPU, REVERSE_RHO };
+enum { FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 // external functions from cuda library for atom decomposition
 

--- a/src/INTEL/npair_skip_intel.cpp
+++ b/src/INTEL/npair_skip_intel.cpp
@@ -164,8 +164,6 @@ void NPairSkipIntel::build_t(NeighList *list, int *numhalf, int *cnumneigh,
       if (ipage.status())
         error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
     }
-
-    int last_inum = 0, loop_end;
     _inum_counts[tid] = my_inum;
   }
   int inum = _inum_counts[0];
@@ -406,7 +404,6 @@ void NPairSkipTrimIntel::build_t(NeighList *list, int *numhalf, int *cnumneigh,
         error->one(FLERR,"Neighbor list overflow, boost neigh_modify one");
     }
 
-    int last_inum = 0, loop_end;
     _inum_counts[tid] = my_inum;
   }
   int inum = _inum_counts[0];

--- a/src/INTEL/pair_eam_intel.cpp
+++ b/src/INTEL/pair_eam_intel.cpp
@@ -34,8 +34,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
-
 #define FC_PACKED1_T typename ForceConst<flt_t>::fc_packed1
 #define FC_PACKED2_T typename ForceConst<flt_t>::fc_packed2
 

--- a/src/INTEL/pair_sw_intel.cpp
+++ b/src/INTEL/pair_sw_intel.cpp
@@ -475,7 +475,6 @@ void PairSWIntel::eval(const int offload, const int vflag,
             const flt_t r2 = (flt_t)1.0 / std::sqrt(rinvsq2);
             const flt_t rainv2 = (flt_t)1.0 / (r2 - cut);
             const flt_t gsrainv2 = sigma_gamma * rainv2;
-            const flt_t gsrainvsq2 = gsrainv2 * rainv2 / r2;
             const flt_t expgsrainv2 = std::exp(gsrainv2);
 
             const flt_t rinv12 = (flt_t)1.0 / (r1 * r2);
@@ -491,7 +490,6 @@ void PairSWIntel::eval(const int offload, const int vflag,
             const flt_t facexp = expgsrainv1*expgsrainv2*kfactor;
             const flt_t facrad = lambda_epsilon * facexp * delcssq;
             const flt_t frad1 = facrad*gsrainvsq1;
-            const flt_t frad2 = facrad*gsrainvsq2;
             const flt_t facang = lambda_epsilon2 * facexp * delcs;
             const flt_t facang12 = rinv12*facang;
             const flt_t csfacang = cs*facang;
@@ -1270,13 +1268,13 @@ void PairSWIntel::ForceConst<flt_t>::set_ntypes(const int ntypes,
   if (memory != nullptr) _memory = memory;
   if (ntypes != _ntypes) {
     if (_ntypes > 0) {
+
+      #ifdef _LMP_INTEL_OFFLOAD
       fc_packed0 *op2 = p2[0];
       fc_packed1 *op2f = p2f[0];
       fc_packed1p2 *op2f2 = p2f2[0];
       fc_packed2 *op2e = p2e[0];
       fc_packed3 *op3 = p3[0][0];
-
-      #ifdef _LMP_INTEL_OFFLOAD
       if (op2 != nullptr && op2f != nullptr && op2f2 != nullptr && op2e != nullptr &&
           op3 != nullptr && _cop >= 0) {
         #pragma offload_transfer target(mic:_cop) \

--- a/src/INTEL/pair_sw_intel.cpp
+++ b/src/INTEL/pair_sw_intel.cpp
@@ -52,9 +52,6 @@ using namespace LAMMPS_NS;
 #define FC_PACKED2_T typename ForceConst<flt_t>::fc_packed2
 #define FC_PACKED3_T typename ForceConst<flt_t>::fc_packed3
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-
 /* ---------------------------------------------------------------------- */
 
 PairSWIntel::PairSWIntel(LAMMPS *lmp) : PairSW(lmp)

--- a/src/INTEL/pppm_disp_intel.cpp
+++ b/src/INTEL/pppm_disp_intel.cpp
@@ -39,11 +39,8 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathSpecial;
 
-static constexpr int MAXORDER =   7;
 static constexpr int OFFSET = 16384;
-static constexpr double SMALL = 0.00001;
-static constexpr double LARGE = 10000.0;
-static constexpr double EPS_HOC = 1.0e-7;
+static constexpr FFT_SCALAR ZEROF = 0.0;
 
 enum{GEOMETRIC,ARITHMETIC,SIXTHPOWER};
 enum{REVERSE_RHO, REVERSE_RHO_G, REVERSE_RHO_A, REVERSE_RHO_NONE};
@@ -52,9 +49,6 @@ enum{FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM,
      FORWARD_IK_A, FORWARD_AD_A, FORWARD_IK_PERATOM_A, FORWARD_AD_PERATOM_A,
      FORWARD_IK_NONE, FORWARD_AD_NONE, FORWARD_IK_PERATOM_NONE,
      FORWARD_AD_PERATOM_NONE};
-
-static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/INTEL/pppm_electrode_intel.cpp
+++ b/src/INTEL/pppm_electrode_intel.cpp
@@ -48,18 +48,13 @@
 using namespace LAMMPS_NS;
 using namespace std;
 
-static constexpr int MAXORDER = 7;
 static constexpr int OFFSET = 16384;
-static constexpr double LARGE = 10000.0;
-static constexpr double SMALL = 0.00001;
-static constexpr double EPS_HOC = 1.0e-7;
 
 enum { REVERSE_RHO };
 enum { FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 enum : bool { ELECTRODE = true, ELECTROLYTE = false };
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF = 1.0;
 
 static const char cite_pppm_electrode[] =
     "kspace_style pppm/electrode command:\n\n"

--- a/src/INTEL/pppm_intel.cpp
+++ b/src/INTEL/pppm_intel.cpp
@@ -41,17 +41,11 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathSpecial;
 
-static constexpr int MAXORDER = 7;
 static constexpr int OFFSET = 16384;
-static constexpr double LARGE = 10000.0;
-static constexpr double SMALL = 0.00001;
-static constexpr double EPS_HOC = 1.0e-7;
-
-enum{REVERSE_RHO};
-enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
-
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
+
+enum { REVERSE_RHO };
+enum { FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 
 /* ---------------------------------------------------------------------- */
 
@@ -690,8 +684,6 @@ void PPPMIntel::fieldforce_ik(IntelBuffers<flt_t,acc_t> *buffers)
       _alignvar(FFT_SCALAR ekx_arr[INTEL_P3M_ALIGNED_MAXORDER], 64) = {0};
       _alignvar(FFT_SCALAR eky_arr[INTEL_P3M_ALIGNED_MAXORDER], 64) = {0};
       _alignvar(FFT_SCALAR ekz_arr[INTEL_P3M_ALIGNED_MAXORDER], 64) = {0};
-      _alignvar(FFT_SCALAR ekxy_arr[2 * INTEL_P3M_ALIGNED_MAXORDER], 64) = {0};
-      _alignvar(FFT_SCALAR ekz0_arr[2 * INTEL_P3M_ALIGNED_MAXORDER], 64) = {0};
 
       #if defined(LMP_SIMD_COMPILER)
       #pragma loop_count min(2), max(INTEL_P3M_ALIGNED_MAXORDER), avg(7)

--- a/src/INTERLAYER/pair_aip_water_2dm.cpp
+++ b/src/INTERLAYER/pair_aip_water_2dm.cpp
@@ -29,10 +29,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-static constexpr int PGDELTA = 1;
-
 static const char cite_aip_water[] =
     "aip/water/2dm potential doi/10.1021/acs.jpcc.2c08464\n"
     "@Article{Feng2023\n"

--- a/src/INTERLAYER/pair_drip.cpp
+++ b/src/INTERLAYER/pair_drip.cpp
@@ -36,7 +36,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
 static constexpr double HALF = 0.5;
 

--- a/src/INTERLAYER/pair_kolmogorov_crespi_full.cpp
+++ b/src/INTERLAYER/pair_kolmogorov_crespi_full.cpp
@@ -40,7 +40,6 @@
 using namespace LAMMPS_NS;
 using namespace InterLayer;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
 static constexpr int PGDELTA = 1;
 

--- a/src/INTERLAYER/pair_kolmogorov_crespi_z.cpp
+++ b/src/INTERLAYER/pair_kolmogorov_crespi_z.cpp
@@ -37,7 +37,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
 
 /* ---------------------------------------------------------------------- */

--- a/src/INTERLAYER/pair_lebedeva_z.cpp
+++ b/src/INTERLAYER/pair_lebedeva_z.cpp
@@ -39,7 +39,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
 
 /* ---------------------------------------------------------------------- */

--- a/src/INTERLAYER/pair_saip_metal.cpp
+++ b/src/INTERLAYER/pair_saip_metal.cpp
@@ -33,10 +33,6 @@
 using namespace LAMMPS_NS;
 using namespace InterLayer;
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-static constexpr int PGDELTA = 1;
-
 static const char cite_saip[] =
     "saip/metal potential: doi:10.1021/acs.jctc.1c00622\n\n"
     "@Article{Ouyang2021\n"

--- a/src/KOKKOS/angle_cosine_kokkos.cpp
+++ b/src/KOKKOS/angle_cosine_kokkos.cpp
@@ -31,8 +31,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr double SMALL = 0.001;
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -20,13 +20,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr double BUFFACTOR = 1.5;
-static constexpr int BUFMIN = 1000;
-static constexpr int BUFEXTRA = 1000;
-static constexpr double EPSILON = 1.0e-6;
-
-#define DELTA_PROCS 16
-
 /* ---------------------------------------------------------------------- */
 
 CommTiledKokkos::CommTiledKokkos(LAMMPS *_lmp) : CommTiled(_lmp) {}

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -32,7 +32,6 @@ using namespace LAMMPS_NS;
 
 static constexpr double TOLERANCE = 0.05;
 static constexpr double SMALL =     0.001;
-static constexpr double SMALLER =   0.00001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/dihedral_harmonic_kokkos.cpp
+++ b/src/KOKKOS/dihedral_harmonic_kokkos.cpp
@@ -31,8 +31,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
-static constexpr double SMALLER =   0.00001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/domain_kokkos.cpp
+++ b/src/KOKKOS/domain_kokkos.cpp
@@ -23,7 +23,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr double BIG =   1.0e20;
-static constexpr double SMALL = 1.0e-4;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_acks2_reaxff_kokkos.cpp
@@ -38,8 +38,7 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-static constexpr double SMALL = 0.0001;
-#define EV_TO_KCAL_PER_MOL 14.4
+static constexpr double EV_TO_KCAL_PER_MOL = 14.4;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
@@ -25,8 +25,6 @@
 #include <cmath>
 #include "atom_masks.h"
 
-static constexpr int MAXLINE = 1024;
-
 #ifdef DBL_EPSILON
   #define MY_EPSILON (10.0*DBL_EPSILON)
 #else

--- a/src/KOKKOS/fix_langevin_kokkos.cpp
+++ b/src/KOKKOS/fix_langevin_kokkos.cpp
@@ -32,10 +32,8 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{NOBIAS,BIAS};
-enum{CONSTANT,EQUAL,ATOM};
-static constexpr double SINERTIA = 0.4;          // moment of inertia prefactor for sphere
-static constexpr double EINERTIA = 0.2;          // moment of inertia prefactor for ellipsoid
+enum { NOBIAS, BIAS };
+enum { CONSTANT, EQUAL, ATOM };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reaxff_kokkos.cpp
@@ -46,8 +46,7 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-static constexpr double SMALL = 0.0001;
-#define EV_TO_KCAL_PER_MOL 14.4
+static constexpr double EV_TO_KCAL_PER_MOL = 14.4;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -41,11 +41,6 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace MathConst;
 
-static constexpr int RVOUS = 1;   // 0 for irregular, 1 for all2all
-
-static constexpr double BIG = 1.0e20;
-static constexpr double MASSDELTA = 0.1;
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>

--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -58,7 +58,7 @@ using namespace FixConst;
 using namespace random_external_state;
 
 static constexpr double EPSILON = 1.0e-10;
-#define EPSILON_SQUARED ((EPSILON) * (EPSILON))
+static constexpr double EPSILON_SQUARED = EPSILON * EPSILON;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/fix_wall_gran_old.cpp
+++ b/src/KOKKOS/fix_wall_gran_old.cpp
@@ -37,13 +37,13 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace MathConst;
 
-#define PI27SQ 266.47931882941264802866    // 27*PI**2
-#define THREEROOT3 5.19615242270663202362  // 3*sqrt(3)
-#define SIXROOT6 14.69693845669906728801   // 6*sqrt(6)
-#define INVROOT6 0.40824829046386307274    // 1/sqrt(6)
-#define FOURTHIRDS 1.333333333333333       // 4/3
-#define THREEQUARTERS 0.75                 // 3/4
-#define TWOPI 6.28318530717959             // 2*PI
+static constexpr double PI27SQ = 266.47931882941264802866;     // 27*PI**2
+static constexpr double THREEROOT3 = 5.19615242270663202362;   // 3*sqrt(3)
+static constexpr double SIXROOT6 = 14.69693845669906728801;    // 6*sqrt(6)
+static constexpr double INVROOT6 = 0.40824829046386307274;     // 1/sqrt(6)
+static constexpr double FOURTHIRDS = 1.333333333333333;        // 4/3
+static constexpr double THREEQUARTERS = 0.75;                  // 3/4
+static constexpr double TWOPI = 6.28318530717959;              // 2*PI
 
 static constexpr double BIG = 1.0e20;
 static constexpr double EPSILON = 1e-10;
@@ -1704,4 +1704,3 @@ double FixWallGranOld::pulloff_distance(double radius)
   dist = a*a/radius - 2*sqrt(MY_PI*coh*a/E);
   return dist;
 }
-

--- a/src/KOKKOS/improper_class2_kokkos.cpp
+++ b/src/KOKKOS/improper_class2_kokkos.cpp
@@ -27,7 +27,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr double TOLERANCE = 0.05;
 static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/min_cg_kokkos.cpp
+++ b/src/KOKKOS/min_cg_kokkos.cpp
@@ -27,7 +27,7 @@ using namespace LAMMPS_NS;
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
+static constexpr double EPS_ENERGY = 1.0e-8;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/min_linesearch_kokkos.cpp
+++ b/src/KOKKOS/min_linesearch_kokkos.cpp
@@ -38,13 +38,12 @@ using namespace LAMMPS_NS;
 // EMACH = machine accuracy limit of energy changes (1.0e-8)
 // EPS_QUAD = tolerance for quadratic projection
 
-#define ALPHA_MAX 1.0
-#define ALPHA_REDUCE 0.5
-#define BACKTRACK_SLOPE 0.4
-#define QUADRATIC_TOL 0.1
-//#define EMACH 1.0e-8
+static constexpr double ALPHA_MAX = 1.0;
+static constexpr double ALPHA_REDUCE = 0.5;
+static constexpr double BACKTRACK_SLOPE = 0.4;
+static constexpr double QUADRATIC_TOL = 0.1;
 static constexpr double EMACH = 1.0e-8;
-#define EPS_QUAD 1.0e-28
+static constexpr double EPS_QUAD = 1.0e-28;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/mliap_descriptor_so3_kokkos.cpp
+++ b/src/KOKKOS/mliap_descriptor_so3_kokkos.cpp
@@ -31,9 +31,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
-static constexpr int MAXWORD = 3;
-
 /* ---------------------------------------------------------------------- */
 template <class DeviceType>
 MLIAPDescriptorSO3Kokkos<DeviceType>::MLIAPDescriptorSO3Kokkos(LAMMPS *lmp, char *paramfilename)

--- a/src/KOKKOS/nbin_kokkos.cpp
+++ b/src/KOKKOS/nbin_kokkos.cpp
@@ -22,9 +22,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr double SMALL = 1.0e-6;
-#define CUT2BIN_RATIO 100
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>

--- a/src/KOKKOS/pair_buck_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_buck_coul_long_kokkos.cpp
@@ -21,6 +21,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "memory_kokkos.h"
@@ -34,15 +35,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_coul_dsf_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_dsf_kokkos.cpp
@@ -34,13 +34,12 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_long_kokkos.cpp
@@ -21,6 +21,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "memory_kokkos.h"
@@ -34,15 +35,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_charmm_coul_charmm_implicit_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_charmm_coul_charmm_implicit_kokkos.cpp
@@ -21,6 +21,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "memory_kokkos.h"
@@ -33,15 +34,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.cpp
@@ -21,6 +21,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "memory_kokkos.h"
@@ -34,15 +35,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.cpp
@@ -21,6 +21,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "memory_kokkos.h"
@@ -34,15 +35,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_charmmfsw_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_charmmfsw_coul_long_kokkos.cpp
@@ -26,6 +26,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "memory_kokkos.h"
@@ -39,15 +40,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_class2_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_class2_coul_long_kokkos.cpp
@@ -17,6 +17,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "memory_kokkos.h"
@@ -30,15 +31,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.cpp
@@ -35,15 +35,14 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-using namespace MathConst;
+using MathConst::MY_PIS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_cut_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_long_kokkos.cpp
@@ -17,6 +17,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "math_const.h"
@@ -32,15 +33,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_lj_expand_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_expand_coul_long_kokkos.cpp
@@ -21,6 +21,7 @@
 #include "atom_kokkos.h"
 #include "atom_masks.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kokkos.h"
 #include "math_const.h"
@@ -36,15 +37,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
@@ -43,8 +43,6 @@ using MathConst::MY_PI;
 
 enum{NONE,RLINEAR,RSQ};
 
-static constexpr int MAXLINE = 1024;
-
 #ifdef DBL_EPSILON
   #define MY_EPSILON (10.0*DBL_EPSILON)
 #else

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -37,9 +37,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>

--- a/src/KOKKOS/pair_vashishta_kokkos.cpp
+++ b/src/KOKKOS/pair_vashishta_kokkos.cpp
@@ -36,9 +36,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -41,15 +41,12 @@ using namespace MathSpecialKokkos;
 
 static constexpr int MAXORDER = 7;
 static constexpr int OFFSET = 16384;
-static constexpr double LARGE = 10000.0;
 static constexpr double SMALL = 0.00001;
 static constexpr double EPS_HOC = 1.0e-7;
-
-enum{REVERSE_RHO};
-enum{FORWARD_IK,FORWARD_IK_PERATOM};
-
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
+
+enum { REVERSE_RHO };
+enum { FORWARD_IK, FORWARD_IK_PERATOM };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/region_block_kokkos.cpp
+++ b/src/KOKKOS/region_block_kokkos.cpp
@@ -18,12 +18,11 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr double BIG = 1.0e20;
-
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
-RegBlockKokkos<DeviceType>::RegBlockKokkos(LAMMPS *lmp, int narg, char **arg) : RegBlock(lmp, narg, arg)
+RegBlockKokkos<DeviceType>::RegBlockKokkos(LAMMPS *lmp, int narg, char **arg)
+  : RegBlock(lmp, narg, arg)
 {
   atomKK = (AtomKokkos*) atom;
 }

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -30,18 +30,17 @@
 #include "neighbor.h"
 #include "pair.h"
 
-#include <cstring>
 #include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define MAX_LEVELS 10
+static constexpr int MAX_LEVELS = 10;
 static constexpr int OFFSET = 16384;
-static constexpr double SMALL = 0.00001;
 
-enum{REVERSE_RHO,REVERSE_AD,REVERSE_AD_PERATOM};
-enum{FORWARD_RHO,FORWARD_AD,FORWARD_AD_PERATOM};
+enum { REVERSE_RHO, REVERSE_AD, REVERSE_AD_PERATOM };
+enum { FORWARD_RHO, FORWARD_AD, FORWARD_AD_PERATOM };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_born_coul_long.cpp
+++ b/src/KSPACE/pair_born_coul_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -33,14 +34,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_buck_coul_long.cpp
+++ b/src/KSPACE/pair_buck_coul_long.cpp
@@ -17,6 +17,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -29,14 +30,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_buck_long_coul_long.cpp
+++ b/src/KSPACE/pair_buck_long_coul_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_extra.h"
@@ -35,14 +36,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathExtra;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_coul_long.cpp
+++ b/src/KSPACE/pair_coul_long.cpp
@@ -20,6 +20,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "memory.h"
@@ -30,14 +31,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_coul_streitz.cpp
+++ b/src/KSPACE/pair_coul_streitz.cpp
@@ -36,7 +36,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 static constexpr int DELTA = 4;
-static constexpr int PGDELTA = 1;
 static constexpr int MAXNEIGH = 24;
 
 /* ---------------------------------------------------------------------- */

--- a/src/KSPACE/pair_lj_charmm_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmm_coul_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "memory.h"
@@ -33,14 +34,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
@@ -25,6 +25,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "memory.h"
@@ -37,14 +38,7 @@
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_lj_cut_coul_long.cpp
+++ b/src/KSPACE/pair_lj_cut_coul_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -35,14 +36,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_lj_cut_tip4p_long.cpp
+++ b/src/KSPACE/pair_lj_cut_tip4p_long.cpp
@@ -29,19 +29,13 @@
 #include "neigh_list.h"
 #include "memory.h"
 #include "error.h"
+#include "ewald_const.h"
 
 #include <cmath>
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_lj_long_coul_long.cpp
+++ b/src/KSPACE/pair_lj_long_coul_long.cpp
@@ -23,6 +23,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_extra.h"
@@ -37,14 +38,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathExtra;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_lj_long_tip4p_long.cpp
+++ b/src/KSPACE/pair_lj_long_tip4p_long.cpp
@@ -29,19 +29,13 @@
 #include "neigh_list.h"
 #include "memory.h"
 #include "error.h"
+#include "ewald_const.h"
 
 #include <cmath>
 #include <cstring>
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pair_tip4p_long.cpp
+++ b/src/KSPACE/pair_tip4p_long.cpp
@@ -31,17 +31,10 @@
 #include "neigh_list.h"
 #include "memory.h"
 #include "error.h"
-
+#include "ewald_const.h"
 
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -50,12 +50,10 @@ static constexpr int OFFSET = 16384;
 static constexpr double LARGE = 10000.0;
 static constexpr double SMALL = 0.00001;
 static constexpr double EPS_HOC = 1.0e-7;
-
-enum{REVERSE_RHO};
-enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
-
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
+
+enum { REVERSE_RHO };
+enum { FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pppm_dipole.cpp
+++ b/src/KSPACE/pppm_dipole.cpp
@@ -42,15 +42,12 @@ using namespace MathSpecial;
 
 static constexpr int MAXORDER = 7;
 static constexpr int OFFSET = 16384;
-static constexpr double LARGE = 10000.0;
 static constexpr double SMALL = 0.00001;
 static constexpr double EPS_HOC = 1.0e-7;
-
-enum{REVERSE_MU};
-enum{FORWARD_MU,FORWARD_MU_PERATOM};
-
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
+
+enum { REVERSE_MU };
+enum { FORWARD_MU, FORWARD_MU_PERATOM };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pppm_dipole_spin.cpp
+++ b/src/KSPACE/pppm_dipole_spin.cpp
@@ -36,16 +36,11 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 static constexpr int MAXORDER = 7;
-static constexpr int OFFSET = 16384;
-static constexpr double LARGE = 10000.0;
-static constexpr double SMALL = 0.00001;
-static constexpr double EPS_HOC = 1.0e-7;
 
-enum{REVERSE_MU};
-enum{FORWARD_MU,FORWARD_MU_PERATOM};
+enum { REVERSE_MU };
+enum { FORWARD_MU, FORWARD_MU_PERATOM };
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -44,7 +44,7 @@ static constexpr int MAXORDER =   7;
 static constexpr int OFFSET = 16384;
 static constexpr double SMALL = 0.00001;
 static constexpr double LARGE = 10000.0;
-static constexpr double EPS_HOC = 1.0e-7;
+static constexpr FFT_SCALAR ZEROF = 0.0;
 
 enum{REVERSE_RHO,REVERSE_RHO_GEOM,REVERSE_RHO_ARITH,REVERSE_RHO_NONE};
 enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM,
@@ -54,9 +54,6 @@ enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM,
      FORWARD_IK_PERATOM_ARITH,FORWARD_AD_PERATOM_ARITH,
      FORWARD_IK_NONE,FORWARD_AD_NONE,FORWARD_IK_PERATOM_NONE,
      FORWARD_AD_PERATOM_NONE};
-
-static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pppm_disp_tip4p.cpp
+++ b/src/KSPACE/pppm_disp_tip4p.cpp
@@ -30,9 +30,7 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 static constexpr int OFFSET = 16384;
-
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pppm_stagger.cpp
+++ b/src/KSPACE/pppm_stagger.cpp
@@ -35,12 +35,10 @@ using namespace MathSpecial;
 
 static constexpr int OFFSET = 16384;
 static constexpr double EPS_HOC = 1.0e-7;
-
-enum{REVERSE_RHO};
-enum{FORWARD_IK,FORWARD_AD,FORWARD_IK_PERATOM,FORWARD_AD_PERATOM};
-
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
+
+enum{ REVERSE_RHO };
+enum{ FORWARD_IK, FORWARD_AD, FORWARD_IK_PERATOM, FORWARD_AD_PERATOM };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KSPACE/pppm_tip4p.cpp
+++ b/src/KSPACE/pppm_tip4p.cpp
@@ -30,7 +30,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 static constexpr int OFFSET = 16384;
 
 /* ---------------------------------------------------------------------- */

--- a/src/MACHDYN/atom_vec_smd.cpp
+++ b/src/MACHDYN/atom_vec_smd.cpp
@@ -30,8 +30,8 @@
 
 using namespace LAMMPS_NS;
 
-#define NMAT_FULL 9
-#define NMAT_SYMM 6
+static constexpr int NMAT_FULL = 9;
+static constexpr int NMAT_SYMM = 6;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MACHDYN/fix_smd_wall_surface.cpp
+++ b/src/MACHDYN/fix_smd_wall_surface.cpp
@@ -32,7 +32,7 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace Eigen;
 using namespace std;
-static constexpr int DELTA = 16384;
+
 static constexpr double EPSILON = 1.0e-6;
 
 /* ---------------------------------------------------------------------- */

--- a/src/MACHDYN/pair_smd_hertz.cpp
+++ b/src/MACHDYN/pair_smd_hertz.cpp
@@ -43,8 +43,6 @@
 
 using namespace LAMMPS_NS;
 
-#define SQRT2 1.414213562e0
-
 /* ---------------------------------------------------------------------- */
 
 PairHertz::PairHertz(LAMMPS *lmp) :

--- a/src/MACHDYN/pair_smd_tlsph.cpp
+++ b/src/MACHDYN/pair_smd_tlsph.cpp
@@ -51,9 +51,9 @@ using namespace Eigen;
 using namespace LAMMPS_NS;
 using namespace SMD_Math;
 
-#define JAUMANN false
-#define DETF_MIN 0.2 // maximum compression deformation allow
-#define DETF_MAX 2.0 // maximum tension deformation allowed
+static constexpr bool JAUMANN = false;
+static constexpr double DETF_MIN = 0.2; // maximum compression deformation allow
+static constexpr double DETF_MAX = 2.0; // maximum tension deformation allowed
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MACHDYN/pair_smd_triangulated_surface.cpp
+++ b/src/MACHDYN/pair_smd_triangulated_surface.cpp
@@ -46,8 +46,6 @@ using namespace std;
 using namespace LAMMPS_NS;
 using namespace Eigen;
 
-#define SQRT2 1.414213562e0
-
 /* ---------------------------------------------------------------------- */
 
 PairTriSurf::PairTriSurf(LAMMPS *lmp) :

--- a/src/MACHDYN/pair_smd_ulsph.cpp
+++ b/src/MACHDYN/pair_smd_ulsph.cpp
@@ -48,7 +48,6 @@ using namespace SMD_Math;
 #include <Eigen/Eigen>
 using namespace Eigen;
 
-#define ARTIFICIAL_STRESS false
 #define FORMAT1 "%60s : %g\n"
 #define FORMAT2 "\n.............................. %s \n"
 

--- a/src/MANYBODY/pair_comb.cpp
+++ b/src/MANYBODY/pair_comb.cpp
@@ -44,7 +44,6 @@ using namespace MathExtra;
 using namespace MathSpecial;
 
 static constexpr int DELTA = 4;
-static constexpr int PGDELTA = 1;
 static constexpr int MAXNEIGH = 24;
 
 /* ---------------------------------------------------------------------- */

--- a/src/MANYBODY/pair_comb3.cpp
+++ b/src/MANYBODY/pair_comb3.cpp
@@ -44,7 +44,6 @@ using namespace MathExtra;
 using namespace MathSpecial;
 
 static constexpr int DELTA = 4;
-static constexpr int PGDELTA = 1;
 static constexpr int MAXNEIGH = 24;
 
 /* ---------------------------------------------------------------------- */

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -33,8 +33,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
-
 /* ---------------------------------------------------------------------- */
 
 PairEAM::PairEAM(LAMMPS *lmp) : Pair(lmp)

--- a/src/MANYBODY/pair_edip.cpp
+++ b/src/MANYBODY/pair_edip.cpp
@@ -39,9 +39,7 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
-
 static constexpr int GRIDDENSITY = 8000;
 static constexpr double GRIDSTART = 0.1;
 

--- a/src/MANYBODY/pair_edip_multi.cpp
+++ b/src/MANYBODY/pair_edip_multi.cpp
@@ -38,7 +38,6 @@
 using namespace LAMMPS_NS;
 using namespace MathExtra;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
 
 static const char cite_pair_edip[] =

--- a/src/MANYBODY/pair_extep.cpp
+++ b/src/MANYBODY/pair_extep.cpp
@@ -37,7 +37,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathExtra;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
 static constexpr int PGDELTA = 1;
 

--- a/src/MANYBODY/pair_gw_zbl.cpp
+++ b/src/MANYBODY/pair_gw_zbl.cpp
@@ -32,7 +32,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
 
 /* ---------------------------------------------------------------------- */

--- a/src/MANYBODY/pair_local_density.cpp
+++ b/src/MANYBODY/pair_local_density.cpp
@@ -34,8 +34,6 @@
 
 using namespace LAMMPS_NS;
 
-static constexpr int MAXLINE = 1024;
-
 static const char cite_pair_local_density[] =
   "pair_style local/density command: doi:10.1063/1.4958629, doi:10.1021/acs.jpcb.7b12446\n\n"
   "@Article{Sanyal16,\n"

--- a/src/MANYBODY/pair_meam_spline.cpp
+++ b/src/MANYBODY/pair_meam_spline.cpp
@@ -440,8 +440,6 @@ void PairMEAMSpline::coeff(int narg, char **arg)
   }
 }
 
-static constexpr int MAXLINE = 1024;
-
 void PairMEAMSpline::read_file(const char* filename)
 {
   int nmultichoose2; // = (n+1)*n/2;

--- a/src/MANYBODY/pair_meam_sw_spline.cpp
+++ b/src/MANYBODY/pair_meam_sw_spline.cpp
@@ -384,8 +384,6 @@ void PairMEAMSWSpline::coeff(int narg, char **arg)
    set coeffs for one or more type pairs
 ------------------------------------------------------------------------- */
 
-static constexpr int MAXLINE = 1024;
-
 void PairMEAMSWSpline::read_file(const char* filename)
 {
   if (comm->me == 0) {

--- a/src/MANYBODY/pair_polymorphic.cpp
+++ b/src/MANYBODY/pair_polymorphic.cpp
@@ -38,10 +38,6 @@
 using namespace LAMMPS_NS;
 using namespace MathExtra;
 
-static constexpr int MAXLINE = 1024;
-static constexpr int DELTA = 4;
-
-
 /* ---------------------------------------------------------------------- */
 
 PairPolymorphic::PairParameters::PairParameters()

--- a/src/MANYBODY/pair_tersoff_table.cpp
+++ b/src/MANYBODY/pair_tersoff_table.cpp
@@ -41,14 +41,14 @@ using MathConst::MY_PI;
 
 static constexpr int DELTA = 4;
 static constexpr double GRIDSTART = 0.1;
-#define GRIDDENSITY_FCUTOFF 5000
-#define GRIDDENSITY_EXP 12000
-#define GRIDDENSITY_GTETA 12000
-#define GRIDDENSITY_BIJ 7500
+static constexpr int GRIDDENSITY_FCUTOFF = 5000;
+static constexpr int GRIDDENSITY_EXP = 12000;
+static constexpr int GRIDDENSITY_GTETA = 12000;
+static constexpr int GRIDDENSITY_BIJ = 7500;
 
 // max number of interaction per atom for environment potential
 
-#define leadingDimensionInteractionList 64
+static constexpr int leadingDimensionInteractionList = 64;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MANYBODY/pair_tersoff_table.cpp
+++ b/src/MANYBODY/pair_tersoff_table.cpp
@@ -39,9 +39,7 @@
 using namespace LAMMPS_NS;
 using MathConst::MY_PI;
 
-static constexpr int MAXLINE = 1024;
 static constexpr int DELTA = 4;
-
 static constexpr double GRIDSTART = 0.1;
 #define GRIDDENSITY_FCUTOFF 5000
 #define GRIDDENSITY_EXP 12000

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -50,7 +50,6 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using MathConst::MY_2PI;
 
-static constexpr double MAXENERGYTEST = 1.0e50;
 enum { EXCHATOM, EXCHMOL };    // exchmode
 
 /* ---------------------------------------------------------------------- */

--- a/src/MESONT/pair_mesocnt.cpp
+++ b/src/MESONT/pair_mesocnt.cpp
@@ -43,16 +43,16 @@ using namespace MathExtra;
 using MathConst::MY_2PI;
 using MathConst::MY_PI;
 
-#define SELF_CUTOFF 3
+static constexpr int SELF_CUTOFF = 3;
 static constexpr double SMALL = 1.0e-6;
 static constexpr double SWITCH = 1.0e-4;
 static constexpr double RHOMIN = 10.0;
 
-#define QUAD_FINF 129
-#define QUAD_FSEMI 10
+static constexpr int QUAD_FINF = 129;
+static constexpr int QUAD_FSEMI = 10;
 
-#define BISECTION_STEPS 1000000
-#define BISECTION_EPS 1.0e-15
+static constexpr int BISECTION_STEPS = 1000000;
+static constexpr double BISECTION_EPS = 1.0e-15;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MESONT/pair_mesocnt.cpp
+++ b/src/MESONT/pair_mesocnt.cpp
@@ -43,7 +43,6 @@ using namespace MathExtra;
 using MathConst::MY_2PI;
 using MathConst::MY_PI;
 
-static constexpr int MAXLINE = 1024;
 #define SELF_CUTOFF 3
 static constexpr double SMALL = 1.0e-6;
 static constexpr double SWITCH = 1.0e-4;

--- a/src/MESONT/pair_mesocnt_viscous.cpp
+++ b/src/MESONT/pair_mesocnt_viscous.cpp
@@ -35,11 +35,11 @@ using namespace LAMMPS_NS;
 using namespace MathExtra;
 using MathConst::MY_PI;
 
-#define SELF_CUTOFF 3
+static constexpr int SELF_CUTOFF = 3;
 static constexpr double RHOMIN = 10.0;
 
-#define QUAD_FINF 129
-#define QUAD_FSEMI 10
+static constexpr int QUAD_FINF = 129;
+static constexpr int QUAD_FSEMI = 10;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MISC/pair_agni.cpp
+++ b/src/MISC/pair_agni.cpp
@@ -47,9 +47,6 @@ static const char cite_pair_agni[] =
   " year      = {2019},\n"
   "}\n\n";
 
-static constexpr int MAXLINE = 10240;
-static constexpr int MAXWORD = 40;
-
 /* ---------------------------------------------------------------------- */
 
 PairAGNI::PairAGNI(LAMMPS *lmp) : Pair(lmp)

--- a/src/ML-IAP/mliap_descriptor_snap.cpp
+++ b/src/ML-IAP/mliap_descriptor_snap.cpp
@@ -32,7 +32,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr int MAXLINE = 1024;
-static constexpr int MAXWORD = 3;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/ML-IAP/mliap_descriptor_so3.cpp
+++ b/src/ML-IAP/mliap_descriptor_so3.cpp
@@ -31,7 +31,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr int MAXLINE = 1024;
-static constexpr int MAXWORD = 3;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/ML-IAP/mliap_model.cpp
+++ b/src/ML-IAP/mliap_model.cpp
@@ -27,7 +27,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr int MAXLINE = 1024;
-static constexpr int MAXWORD = 3;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/ML-SNAP/pair_snap.cpp
+++ b/src/ML-SNAP/pair_snap.cpp
@@ -30,7 +30,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr int MAXLINE = 1024;
-static constexpr int MAXWORD = 3;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MOFFF/improper_inversion_harmonic.cpp
+++ b/src/MOFFF/improper_inversion_harmonic.cpp
@@ -31,12 +31,8 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/MOFFF/pair_buck6d_coul_gauss_long.cpp
+++ b/src/MOFFF/pair_buck6d_coul_gauss_long.cpp
@@ -36,7 +36,7 @@
 
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
+static constexpr double EWALD_F = 1.12837917;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/angle_cosine_omp.cpp
+++ b/src/OPENMP/angle_cosine_omp.cpp
@@ -24,11 +24,8 @@
 #include "force.h"
 #include "neighbor.h"
 
-
 #include "suffix.h"
 using namespace LAMMPS_NS;
-
-static constexpr double SMALL = 0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/angle_cosine_periodic_omp.cpp
+++ b/src/OPENMP/angle_cosine_periodic_omp.cpp
@@ -30,8 +30,6 @@
 using namespace LAMMPS_NS;
 using namespace MathSpecial;
 
-static constexpr double SMALL = 0.001;
-
 /* ---------------------------------------------------------------------- */
 
 AngleCosinePeriodicOMP::AngleCosinePeriodicOMP(class LAMMPS *lmp)

--- a/src/OPENMP/angle_cosine_squared_omp.cpp
+++ b/src/OPENMP/angle_cosine_squared_omp.cpp
@@ -24,11 +24,8 @@
 #include "force.h"
 #include "neighbor.h"
 
-
 #include "suffix.h"
 using namespace LAMMPS_NS;
-
-static constexpr double SMALL = 0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/angle_dipole_omp.cpp
+++ b/src/OPENMP/angle_dipole_omp.cpp
@@ -25,11 +25,8 @@
 #include "force.h"
 #include "neighbor.h"
 
-
 #include "suffix.h"
 using namespace LAMMPS_NS;
-
-static constexpr double SMALL = 0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/angle_fourier_omp.cpp
+++ b/src/OPENMP/angle_fourier_omp.cpp
@@ -24,11 +24,8 @@
 #include "force.h"
 #include "neighbor.h"
 
-
 #include "suffix.h"
 using namespace LAMMPS_NS;
-
-static constexpr double SMALL = 0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/dihedral_charmm_omp.cpp
+++ b/src/OPENMP/dihedral_charmm_omp.cpp
@@ -31,7 +31,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/dihedral_cosine_shift_exp_omp.cpp
+++ b/src/OPENMP/dihedral_cosine_shift_exp_omp.cpp
@@ -30,7 +30,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/dihedral_harmonic_omp.cpp
+++ b/src/OPENMP/dihedral_harmonic_omp.cpp
@@ -30,7 +30,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/dihedral_table_omp.cpp
+++ b/src/OPENMP/dihedral_table_omp.cpp
@@ -34,9 +34,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathExtra;
 
-static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
-
 // --------------------------------------------
 // ------- Calculate the dihedral angle -------
 // --------------------------------------------

--- a/src/OPENMP/ewald_omp.cpp
+++ b/src/OPENMP/ewald_omp.cpp
@@ -31,8 +31,6 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-static constexpr double SMALL = 0.00001;
-
 /* ---------------------------------------------------------------------- */
 
 EwaldOMP::EwaldOMP(LAMMPS *lmp) : Ewald(lmp), ThrOMP(lmp, THR_KSPACE)

--- a/src/OPENMP/improper_class2_omp.cpp
+++ b/src/OPENMP/improper_class2_omp.cpp
@@ -29,9 +29,6 @@
 #include "suffix.h"
 using namespace LAMMPS_NS;
 
-static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
-
 /* ---------------------------------------------------------------------- */
 
 ImproperClass2OMP::ImproperClass2OMP(class LAMMPS *lmp)

--- a/src/OPENMP/improper_ring_omp.cpp
+++ b/src/OPENMP/improper_ring_omp.cpp
@@ -31,7 +31,6 @@
 using namespace LAMMPS_NS;
 using namespace MathSpecial;
 
-static constexpr double TOLERANCE = 0.05;
 static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */

--- a/src/OPENMP/pair_born_coul_long_omp.cpp
+++ b/src/OPENMP/pair_born_coul_long_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -24,15 +25,9 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_brownian_omp.cpp
+++ b/src/OPENMP/pair_brownian_omp.cpp
@@ -36,8 +36,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathSpecial;
 
-static constexpr double EPSILON = 1.0e-10;
-
 /* ---------------------------------------------------------------------- */
 
 PairBrownianOMP::PairBrownianOMP(LAMMPS *lmp) :

--- a/src/OPENMP/pair_brownian_poly_omp.cpp
+++ b/src/OPENMP/pair_brownian_poly_omp.cpp
@@ -36,8 +36,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathSpecial;
 
-static constexpr double EPSILON = 1.0e-10;
-
 /* ---------------------------------------------------------------------- */
 
 PairBrownianPolyOMP::PairBrownianPolyOMP(LAMMPS *lmp) :

--- a/src/OPENMP/pair_buck_coul_long_omp.cpp
+++ b/src/OPENMP/pair_buck_coul_long_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -25,14 +26,7 @@
 
 #include "omp_compat.h"
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_buck_long_coul_long_omp.cpp
+++ b/src/OPENMP/pair_buck_long_coul_long_omp.cpp
@@ -16,6 +16,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "math_extra.h"
 #include "neigh_list.h"
@@ -27,14 +28,7 @@
 #include "omp_compat.h"
 using namespace LAMMPS_NS;
 using namespace MathExtra;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_coul_dsf_omp.cpp
+++ b/src/OPENMP/pair_coul_dsf_omp.cpp
@@ -24,15 +24,14 @@
 #include "suffix.h"
 #include "math_const.h"
 using namespace LAMMPS_NS;
-using namespace MathConst;
+using MathConst::MY_PIS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_coul_long_omp.cpp
+++ b/src/OPENMP/pair_coul_long_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -24,15 +25,9 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_coul_long_soft_omp.cpp
+++ b/src/OPENMP/pair_coul_long_soft_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -24,15 +25,9 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_class2_coul_long_omp.cpp
+++ b/src/OPENMP/pair_lj_class2_coul_long_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -25,14 +26,7 @@
 
 #include "omp_compat.h"
 using namespace LAMMPS_NS;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_cut_coul_dsf_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_coul_dsf_omp.cpp
@@ -25,16 +25,16 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
-using namespace MathConst;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using MathConst::MY_PIS;
+
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_cut_coul_long_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_coul_long_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -24,15 +25,9 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_cut_coul_long_soft_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_coul_long_soft_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -24,15 +25,9 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_cut_thole_long_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_thole_long_omp.cpp
@@ -34,18 +34,18 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   9.95473818e-1
-#define B0       -0.1335096380159268
-#define B1       -2.57839507e-1
-#define B2       -1.37203639e-1
-#define B3       -8.88822059e-3
-#define B4       -5.80844129e-3
-#define B5        1.14652755e-1
+static constexpr double EWALD_F =  1.12837917;
+static constexpr double EWALD_P =  9.95473818e-1;
+static constexpr double B0      = -0.1335096380159268;
+static constexpr double B1      = -2.57839507e-1;
+static constexpr double B2      = -1.37203639e-1;
+static constexpr double B3      = -8.88822059e-3;
+static constexpr double B4      = -5.80844129e-3;
+static constexpr double B5      =  1.14652755e-1;
 
 static constexpr double EPSILON = 1.0e-20;
-#define EPS_EWALD 1.0e-6
-#define EPS_EWALD_SQR 1.0e-12
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_cut_tip4p_cut_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_tip4p_cut_omp.cpp
@@ -28,14 +28,6 @@
 #include "suffix.h"
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
-
 /* ---------------------------------------------------------------------- */
 
 PairLJCutTIP4PCutOMP::PairLJCutTIP4PCutOMP(LAMMPS *lmp) :

--- a/src/OPENMP/pair_lj_cut_tip4p_long_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_tip4p_long_omp.cpp
@@ -19,22 +19,18 @@
 #include "atom.h"
 #include "domain.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neighbor.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "memory.h"
 #include "neigh_list.h"
 
 #include "suffix.h"
 using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_cut_tip4p_long_soft_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_tip4p_long_soft_omp.cpp
@@ -19,22 +19,18 @@
 #include "atom.h"
 #include "domain.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neighbor.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "memory.h"
 #include "neigh_list.h"
 
 #include "suffix.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_long_coul_long_omp.cpp
+++ b/src/OPENMP/pair_lj_long_coul_long_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "math_extra.h"
 #include "neigh_list.h"
@@ -26,16 +27,10 @@
 #include <cstring>
 
 #include "omp_compat.h"
+
 using namespace LAMMPS_NS;
 using namespace MathExtra;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_lj_long_tip4p_long_omp.cpp
+++ b/src/OPENMP/pair_lj_long_tip4p_long_omp.cpp
@@ -19,6 +19,7 @@
 #include "comm.h"
 #include "domain.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "memory.h"
 #include "neigh_list.h"
@@ -28,15 +29,9 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_nm_cut_coul_long_omp.cpp
+++ b/src/OPENMP/pair_nm_cut_coul_long_omp.cpp
@@ -17,6 +17,7 @@
 
 #include "atom.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 #include "suffix.h"
@@ -24,15 +25,9 @@
 #include <cmath>
 
 #include "omp_compat.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_tersoff_table_omp.cpp
+++ b/src/OPENMP/pair_tersoff_table_omp.cpp
@@ -27,14 +27,14 @@
 using namespace LAMMPS_NS;
 
 static constexpr double GRIDSTART = 0.1;
-#define GRIDDENSITY_FCUTOFF 5000
-#define GRIDDENSITY_EXP 12000
-#define GRIDDENSITY_GTETA 12000
-#define GRIDDENSITY_BIJ 7500
+static constexpr int GRIDDENSITY_FCUTOFF = 5000;
+static constexpr int GRIDDENSITY_EXP = 12000;
+static constexpr int GRIDDENSITY_GTETA = 12000;
+static constexpr int GRIDDENSITY_BIJ = 7500;
 
 // max number of interaction per atom for environment potential
 
-#define leadingDimensionInteractionList 64
+static constexpr int leadingDimensionInteractionList = 64;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_tip4p_cut_omp.cpp
+++ b/src/OPENMP/pair_tip4p_cut_omp.cpp
@@ -26,15 +26,8 @@
 #include "neigh_list.h"
 
 #include "suffix.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_tip4p_long_omp.cpp
+++ b/src/OPENMP/pair_tip4p_long_omp.cpp
@@ -19,22 +19,18 @@
 #include "atom.h"
 #include "domain.h"
 #include "comm.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neighbor.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "memory.h"
 #include "neigh_list.h"
 
 #include "suffix.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pair_tip4p_long_soft_omp.cpp
+++ b/src/OPENMP/pair_tip4p_long_soft_omp.cpp
@@ -22,19 +22,14 @@
 #include "force.h"
 #include "neighbor.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "memory.h"
 #include "neigh_list.h"
 
 #include "suffix.h"
-using namespace LAMMPS_NS;
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/pppm_cg_omp.cpp
+++ b/src/OPENMP/pppm_cg_omp.cpp
@@ -39,8 +39,6 @@ using namespace MathConst;
 using namespace MathSpecial;
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
-
 static constexpr double EPS_HOC = 1.0e-7;
 
 /* ---------------------------------------------------------------------- */

--- a/src/OPENMP/pppm_disp_omp.cpp
+++ b/src/OPENMP/pppm_disp_omp.cpp
@@ -39,7 +39,6 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 static constexpr FFT_SCALAR ZEROF = 0.0;
-static constexpr FFT_SCALAR ONEF =  1.0;
 static constexpr int OFFSET = 16384;
 
 

--- a/src/OPENMP/reaxff_torsion_angles_omp.cpp
+++ b/src/OPENMP/reaxff_torsion_angles_omp.cpp
@@ -34,8 +34,6 @@
 
 #include <cmath>
 
-#define MIN_SINE 1e-10
-
 using namespace LAMMPS_NS;
 
 namespace ReaxFF {

--- a/src/OPT/pair_lj_charmm_coul_long_opt.cpp
+++ b/src/OPT/pair_lj_charmm_coul_long_opt.cpp
@@ -20,21 +20,16 @@
 ------------------------------------------------------------------------- */
 
 #include "pair_lj_charmm_coul_long_opt.h"
-#include <cmath>
 
 #include "atom.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 
-using namespace LAMMPS_NS;
+#include <cmath>
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define EWALD_A1  0.254829592
-#define EWALD_A2 -0.284496736
-#define EWALD_A3  1.421413741
-#define EWALD_A4 -1.453152027
-#define EWALD_A5  1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 
@@ -158,9 +153,7 @@ void PairLJCharmmCoulLongOpt::eval()
               grij = g_ewald * r;
               expm2 = exp(-grij*grij);
               t = 1.0 / (1.0 + EWALD_P*grij);
-              erfc = t *
-                (EWALD_A1+t*(EWALD_A2+t*(EWALD_A3+t*(EWALD_A4+t*EWALD_A5)))) *
-                expm2;
+              erfc = t * (A1 + t*(A2 + t*(A3 + t*(A4 + t*A5)))) * expm2;
               prefactor = qqrd2e * tmp_coef3/r;
               forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
             } else {
@@ -247,9 +240,7 @@ void PairLJCharmmCoulLongOpt::eval()
               grij = g_ewald * r;
               expm2 = exp(-grij*grij);
               t = 1.0 / (1.0 + EWALD_P*grij);
-              erfc = t *
-                (EWALD_A1+t*(EWALD_A2+t*(EWALD_A3+t*(EWALD_A4+t*EWALD_A5)))) *
-                expm2;
+              erfc = t * (A1 + t*(A2 + t*(A3 + t*(A4 + t*A5)))) * expm2;
               prefactor = qqrd2e * tmp_coef3/r;
               forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
               if (factor_coul < 1.0) {

--- a/src/OPT/pair_lj_cut_coul_long_opt.cpp
+++ b/src/OPT/pair_lj_cut_coul_long_opt.cpp
@@ -13,20 +13,16 @@
 ------------------------------------------------------------------------- */
 
 #include "pair_lj_cut_coul_long_opt.h"
-#include <cmath>
+
 #include "atom.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "neigh_list.h"
 
-using namespace LAMMPS_NS;
+#include <cmath>
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPT/pair_lj_cut_tip4p_long_opt.cpp
+++ b/src/OPT/pair_lj_cut_tip4p_long_opt.cpp
@@ -17,24 +17,20 @@
 ------------------------------------------------------------------------- */
 
 #include "pair_lj_cut_tip4p_long_opt.h"
-#include <cmath>
+
 #include "atom.h"
 #include "domain.h"
 #include "force.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "memory.h"
 #include "neighbor.h"
 #include "neigh_list.h"
 
-using namespace LAMMPS_NS;
+#include <cmath>
 
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPT/pair_lj_long_coul_long_opt.cpp
+++ b/src/OPT/pair_lj_long_coul_long_opt.cpp
@@ -19,6 +19,7 @@
 #include "pair_lj_long_coul_long_opt.h"
 
 #include "atom.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "math_extra.h"
 #include "neigh_list.h"
@@ -28,14 +29,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathExtra;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/POEMS/fix_poems.cpp
+++ b/src/POEMS/fix_poems.cpp
@@ -42,7 +42,7 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 
 #define MAXBODY 2    // currently 2 since only linear chains allowed
-static constexpr int DELTA = 128;
+
 static constexpr double TOLERANCE = 1.0e-6;
 static constexpr double EPSILON = 1.0e-7;
 

--- a/src/QEQ/fix_qeq_fire.cpp
+++ b/src/QEQ/fix_qeq_fire.cpp
@@ -35,10 +35,10 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 
 static constexpr int DELAYSTEP = 0;
-#define DT_GROW 1.1
-#define DT_SHRINK 0.5
-#define ALPHA0 0.8
-#define ALPHA_SHRINK 0.10
+static constexpr double DT_GROW = 1.1;
+static constexpr double DT_SHRINK = 0.5;
+static constexpr double ALPHA0 = 0.8;
+static constexpr double ALPHA_SHRINK = 0.10;
 static constexpr double TMAX = 10.0;
 
 /* ---------------------------------------------------------------------- */

--- a/src/REAXFF/fix_reaxff.cpp
+++ b/src/REAXFF/fix_reaxff.cpp
@@ -29,9 +29,8 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-#define MAX_REAX_BONDS      30
-#define MIN_REAX_BONDS      15
-#define MIN_REAX_HBONDS     25
+static constexpr int MIN_REAX_BONDS  = 15;
+static constexpr int MIN_REAX_HBONDS = 25;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/SMTBQ/pair_smtbq.cpp
+++ b/src/SMTBQ/pair_smtbq.cpp
@@ -70,9 +70,6 @@ using namespace MathConst;
 using namespace MathExtra;
 using namespace MathSpecial;
 
-static constexpr int MAXLINE = 2048;
-static constexpr int MAXTOKENS = 2048;
-static constexpr int DELTA = 4;
 static constexpr int PGDELTA = 1;
 static constexpr int MAXNEIGH = 24;
 

--- a/src/SPIN/min_spin.cpp
+++ b/src/SPIN/min_spin.cpp
@@ -36,8 +36,7 @@ using namespace MathConst;
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
-
+static constexpr double EPS_ENERGY = 1.0e-8;
 static constexpr int DELAYSTEP = 5;
 
 /* ---------------------------------------------------------------------- */

--- a/src/SPIN/min_spin_cg.cpp
+++ b/src/SPIN/min_spin_cg.cpp
@@ -54,8 +54,7 @@ static const char cite_minstyle_spin_cg[] =
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
-
+static constexpr double EPS_ENERGY = 1.0e-8;
 static constexpr int DELAYSTEP = 5;
 
 /* ---------------------------------------------------------------------- */

--- a/src/SPIN/min_spin_lbfgs.cpp
+++ b/src/SPIN/min_spin_lbfgs.cpp
@@ -54,8 +54,7 @@ static const char cite_minstyle_spin_lbfgs[] =
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
-
+static constexpr double EPS_ENERGY = 1.0e-8;
 static constexpr int DELAYSTEP = 5;
 
 /* ---------------------------------------------------------------------- */

--- a/src/SPIN/pair_spin_dipole_long.cpp
+++ b/src/SPIN/pair_spin_dipole_long.cpp
@@ -22,6 +22,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -33,14 +34,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/STUBS/mpi.cpp
+++ b/src/STUBS/mpi.cpp
@@ -38,7 +38,8 @@ typedef struct _mpi_double_int double_int;
 
 /* extra MPI_Datatypes registered by MPI_Type_contiguous */
 
-static constexpr int MAXEXTRA_DATATYPE = 16;
+#define MAXEXTRA_DATATYPE 16
+
 int nextra_datatype;
 MPI_Datatype *ptr_datatype[MAXEXTRA_DATATYPE];
 int index_datatype[MAXEXTRA_DATATYPE];

--- a/src/STUBS/mpi.cpp
+++ b/src/STUBS/mpi.cpp
@@ -38,8 +38,7 @@ typedef struct _mpi_double_int double_int;
 
 /* extra MPI_Datatypes registered by MPI_Type_contiguous */
 
-#define MAXEXTRA_DATATYPE 16
-
+static constexpr int MAXEXTRA_DATATYPE = 16;
 int nextra_datatype;
 MPI_Datatype *ptr_datatype[MAXEXTRA_DATATYPE];
 int index_datatype[MAXEXTRA_DATATYPE];

--- a/src/UEF/dump_cfg_uef.cpp
+++ b/src/UEF/dump_cfg_uef.cpp
@@ -27,8 +27,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr double UNWRAPEXPAND = 10.0;
-static constexpr int ONEFIELD = 32;
-static constexpr int DELTA = 1048576;
 
 /* ----------------------------------------------------------------------
  * base method is mostly fine, just need to find the FixNHUef

--- a/src/YAFF/improper_distharm.cpp
+++ b/src/YAFF/improper_distharm.cpp
@@ -28,11 +28,7 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
-
-static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/YAFF/improper_sqdistharm.cpp
+++ b/src/YAFF/improper_sqdistharm.cpp
@@ -28,11 +28,7 @@
 #include "memory.h"
 #include "error.h"
 
-
 using namespace LAMMPS_NS;
-
-static constexpr double TOLERANCE = 0.05;
-static constexpr double SMALL =     0.001;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/YAFF/pair_lj_switch3_coulgauss_long.cpp
+++ b/src/YAFF/pair_lj_switch3_coulgauss_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -33,14 +34,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/YAFF/pair_lj_switch3_coulgauss_long.cpp
+++ b/src/YAFF/pair_lj_switch3_coulgauss_long.cpp
@@ -124,6 +124,7 @@ void PairLJSwitch3CoulGaussLong::compute(int eflag, int vflag)
       jtype = type[j];
 
       if (rsq < cutsq[itype][jtype]) {
+        forcecoul = forcecoul2 = forcelj = 0.0;
         r2inv = 1.0/rsq;
 
         if (rsq < cut_coulsq) {
@@ -149,7 +150,7 @@ void PairLJSwitch3CoulGaussLong::compute(int eflag, int vflag)
               forcecoul -= (1.0-factor_coul)*prefactor;
             }
           }
-        } else forcecoul = 0.0;
+        }
 
         if (rsq < cut_ljsq[itype][jtype]) {
           // Lennard-Jones potential
@@ -160,7 +161,6 @@ void PairLJSwitch3CoulGaussLong::compute(int eflag, int vflag)
           if (lj2[itype][jtype]==0.0) {
             // This means a point charge is considered, so the correction is zero
             erfc2 = 0.0;
-            forcecoul2 = 0.0;
             prefactor2 = 0.0;
           } else {
             rrij = lj2[itype][jtype]*r;
@@ -169,7 +169,7 @@ void PairLJSwitch3CoulGaussLong::compute(int eflag, int vflag)
             prefactor2 = -qqrd2e*qtmp*q[j]/r;
             forcecoul2 = prefactor2*(erfc2+EWALD_F*rrij*expn2);
           }
-        } else forcelj = 0.0;
+        }
 
         if (rsq < cut_coulsq) {
           if (!ncoultablebits || rsq <= tabinnersq)
@@ -580,6 +580,8 @@ double PairLJSwitch3CoulGaussLong::single(int i, int j, int itype, int jtype,
 
   r2inv = 1.0/rsq;
   r = sqrt(rsq);
+  forcecoul = forcecoul2 = 0.0;
+
   if (rsq < cut_coulsq) {
     if (!ncoultablebits || rsq <= tabinnersq) {
       grij = g_ewald * r;
@@ -610,7 +612,6 @@ double PairLJSwitch3CoulGaussLong::single(int i, int j, int itype, int jtype,
     forcelj = r6inv*(12.0*lj3[itype][jtype]*r6inv-6.0*lj4[itype][jtype]);
     if (lj2[itype][jtype] == 0.0) {
       erfc2 = 0.0;
-      forcecoul2 = 0.0;
       prefactor2 = 0.0;
     } else {
       rrij = lj2[itype][jtype]*r;

--- a/src/YAFF/pair_mm3_switch3_coulgauss_long.cpp
+++ b/src/YAFF/pair_mm3_switch3_coulgauss_long.cpp
@@ -21,6 +21,7 @@
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
+#include "ewald_const.h"
 #include "force.h"
 #include "kspace.h"
 #include "math_const.h"
@@ -33,14 +34,7 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-
-#define EWALD_F   1.12837917
-#define EWALD_P   0.3275911
-#define A1        0.254829592
-#define A2       -0.284496736
-#define A3        1.421413741
-#define A4       -1.453152027
-#define A5        1.061405429
+using namespace EwaldConst;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/YAFF/pair_mm3_switch3_coulgauss_long.cpp
+++ b/src/YAFF/pair_mm3_switch3_coulgauss_long.cpp
@@ -124,6 +124,7 @@ void PairMM3Switch3CoulGaussLong::compute(int eflag, int vflag)
       jtype = type[j];
 
       if (rsq < cutsq[itype][jtype]) {
+        forcecoul = forcecoul2 = forcelj = 0.0;
         r2inv = 1.0/rsq;
 
         if (rsq < cut_coulsq) {
@@ -149,7 +150,7 @@ void PairMM3Switch3CoulGaussLong::compute(int eflag, int vflag)
               forcecoul -= (1.0-factor_coul)*prefactor;
             }
           }
-        } else forcecoul = 0.0;
+        }
 
         if (rsq < cut_ljsq[itype][jtype]) {
           // Repulsive exponential part
@@ -164,7 +165,6 @@ void PairMM3Switch3CoulGaussLong::compute(int eflag, int vflag)
             // This means a point charge is considered, so the correction is zero
             expn2 = 0.0;
             erfc2 = 0.0;
-            forcecoul2 = 0.0;
             prefactor2 = 0.0;
           } else {
             rrij = lj2[itype][jtype]*r;
@@ -173,7 +173,7 @@ void PairMM3Switch3CoulGaussLong::compute(int eflag, int vflag)
             prefactor2 = -qqrd2e*qtmp*q[j]/r;
             forcecoul2 = prefactor2*(erfc2+EWALD_F*rrij*expn2);
           }
-        } else forcelj = 0.0;
+        }
 
         if (rsq < cut_coulsq) {
           if (!ncoultablebits || rsq <= tabinnersq)
@@ -581,6 +581,8 @@ double PairMM3Switch3CoulGaussLong::single(int i, int j, int itype, int jtype,
 
   r2inv = 1.0/rsq;
   r = sqrt(rsq);
+  forcecoul = forcecoul2 = 0.0;
+
   if (rsq < cut_coulsq) {
     if (!ncoultablebits || rsq <= tabinnersq) {
       grij = g_ewald * r;
@@ -604,7 +606,7 @@ double PairMM3Switch3CoulGaussLong::single(int i, int j, int itype, int jtype,
         forcecoul -= (1.0-factor_coul)*prefactor;
       }
     }
-  } else forcecoul = 0.0;
+  }
 
   if (rsq < cut_ljsq[itype][jtype]) {
     expb = lj3[itype][jtype]*exp(-lj1[itype][jtype]*r);
@@ -615,7 +617,6 @@ double PairMM3Switch3CoulGaussLong::single(int i, int j, int itype, int jtype,
     if (lj2[itype][jtype] == 0.0) {
       expn2 = 0.0;
       erfc2 = 0.0;
-      forcecoul2 = 0.0;
       prefactor2 = 0.0;
     } else {
       rrij = lj2[itype][jtype]*r;

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -50,7 +50,6 @@ using namespace MathConst;
 
 static constexpr int DELTA = 1;
 static constexpr double EPSILON = 1.0e-6;
-static constexpr int MAXLINE = 256;
 
 /* ----------------------------------------------------------------------
    one instance per AtomVec style in style_atom.h

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -39,8 +39,7 @@ using namespace LAMMPS_NS;
 static constexpr double BUFFACTOR = 1.5;
 static constexpr int BUFMIN = 1024;
 static constexpr double EPSILON = 1.0e-6;
-
-#define DELTA_PROCS 16
+static constexpr int DELTA_PROCS = 16;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -32,7 +32,6 @@
 using namespace LAMMPS_NS;
 
 static constexpr int DELTA = 10000;
-static constexpr double EPSILON = 1.0e-12;
 
 enum{DIST,DX,DY,DZ,VELVIB,OMEGA,ENGTRANS,ENGVIB,ENGROT,ENGPOT,FORCE,FX,FY,FZ,VARIABLE,BN};
 
@@ -374,13 +373,6 @@ int ComputeBondLocal::compute_bonds(int flag)
           omegasq = vrotsq / MathExtra::lensq3(delr1);
 
           engrot = 0.5 * inertia * omegasq;
-
-          // sanity check: engtotal = engtrans + engvib + engrot
-
-          //engtot = 0.5 * (mass1*MathExtra::lensq3(v[atom1]) +
-          //                mass2*MathExtra::lensq3(v[atom2]));
-          //if (fabs(engtot-engtrans-engvib-engrot) > EPSILON)
-          //  error->one(FLERR,"Sanity check on 3 energy components failed");
 
           // scale energies by units
 

--- a/src/compute_dihedral_local.cpp
+++ b/src/compute_dihedral_local.cpp
@@ -31,9 +31,8 @@ using namespace LAMMPS_NS;
 using namespace MathConst;
 
 static constexpr int DELTA = 10000;
-static constexpr double SMALL = 0.001;
 
-enum{PHI,VARIABLE};
+enum { PHI, VARIABLE };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/compute_property_grid.cpp
+++ b/src/compute_property_grid.cpp
@@ -28,8 +28,6 @@ using namespace LAMMPS_NS;
 enum { LOW, CTR };
 enum { UNSCALED, SCALED };
 
-static constexpr int DELTA = 10000;
-
 /* ---------------------------------------------------------------------- */
 
 ComputePropertyGrid::ComputePropertyGrid(LAMMPS *lmp, int narg, char **arg) :

--- a/src/fix_box_relax.cpp
+++ b/src/fix_box_relax.cpp
@@ -35,10 +35,8 @@
 using namespace LAMMPS_NS;
 using namespace FixConst;
 
-enum{NONE,XYZ,XY,YZ,XZ};
-enum{ISO,ANISO,TRICLINIC};
-
-#define MAX_LIFO_DEPTH 2     // 3 box0 arrays in *.h dimensioned to this
+enum { NONE, XYZ, XY, YZ, XZ };
+enum { ISO, ANISO, TRICLINIC };
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/fix_box_relax.h
+++ b/src/fix_box_relax.h
@@ -52,11 +52,12 @@ class FixBoxRelax : public Fix {
   double vmax, pv2e, pflagsum;
   int kspace_flag;
 
-  int current_lifo;       // LIFO stack pointer
-  double boxlo0[2][3];    // box bounds at start of line search
-  double boxhi0[2][3];
-  double boxtilt0[2][3];    // xy,xz,yz tilts at start of line search
-  double ds[6];             // increment in scale matrix
+  static constexpr int MAX_LIFO_DEPTH = 2;
+  int current_lifo;                      // LIFO stack pointer
+  double boxlo0[MAX_LIFO_DEPTH][3];      // low box bounds at start of line search
+  double boxhi0[MAX_LIFO_DEPTH][3];      // high box bounds at start of line search
+  double boxtilt0[MAX_LIFO_DEPTH][3];    // xy,xz,yz tilts at start of line search
+  double ds[6];                          // increment in scale matrix
 
   int scaleyz;    // 1 if yz scaled with lz
   int scalexz;    // 1 if xz scaled with lz

--- a/src/math_special.cpp
+++ b/src/math_special.cpp
@@ -702,7 +702,7 @@ static const double fm_exp2_p[] = {
 };
 
 /* double precision constants */
-#define FM_DOUBLE_LOG2OFE  1.4426950408889634074
+static constexpr double FM_DOUBLE_LOG2OFE = 1.4426950408889634074;
 
 double MathSpecial::exp2_x86(double x)
 {

--- a/src/min_cg.cpp
+++ b/src/min_cg.cpp
@@ -25,7 +25,7 @@ using namespace LAMMPS_NS;
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
+static constexpr double EPS_ENERGY = 1.0e-8;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/min_fire.cpp
+++ b/src/min_fire.cpp
@@ -38,7 +38,7 @@ using namespace LAMMPS_NS;
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
+static constexpr double EPS_ENERGY = 1.0e-8;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/min_linesearch.cpp
+++ b/src/min_linesearch.cpp
@@ -42,13 +42,12 @@ using namespace LAMMPS_NS;
 // EMACH = machine accuracy limit of energy changes (1.0e-8)
 // EPS_QUAD = tolerance for quadratic projection
 
-#define ALPHA_MAX 1.0
-#define ALPHA_REDUCE 0.5
-#define BACKTRACK_SLOPE 0.4
-#define QUADRATIC_TOL 0.1
-//#define EMACH 1.0e-8
+static constexpr double ALPHA_MAX = 1.0;
+static constexpr double ALPHA_REDUCE = 0.5;
+static constexpr double BACKTRACK_SLOPE = 0.4;
+static constexpr double QUADRATIC_TOL = 0.1;
 static constexpr double EMACH = 1.0e-8;
-#define EPS_QUAD 1.0e-28
+static constexpr double EPS_QUAD = 1.0e-28;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/min_quickmin.cpp
+++ b/src/min_quickmin.cpp
@@ -28,8 +28,7 @@ using namespace LAMMPS_NS;
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
-
+static constexpr double EPS_ENERGY = 1.0e-8;
 static constexpr int DELAYSTEP = 5;
 
 /* ---------------------------------------------------------------------- */

--- a/src/min_sd.cpp
+++ b/src/min_sd.cpp
@@ -24,7 +24,7 @@ using namespace LAMMPS_NS;
 
 // EPS_ENERGY = minimum normalization for energy tolerance
 
-#define EPS_ENERGY 1.0e-8
+static constexpr double EPS_ENERGY = 1.0e-8;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/nbin_multi.cpp
+++ b/src/nbin_multi.cpp
@@ -27,7 +27,7 @@
 using namespace LAMMPS_NS;
 
 static constexpr double SMALL = 1.0e-6;
-#define CUT2BIN_RATIO 100
+static constexpr double CUT2BIN_RATIO = 100.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/nbin_standard.cpp
+++ b/src/nbin_standard.cpp
@@ -25,7 +25,7 @@
 using namespace LAMMPS_NS;
 
 static constexpr double SMALL = 1.0e-6;
-#define CUT2BIN_RATIO 100
+static constexpr double CUT2BIN_RATIO = 100.0;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/pair_coul_dsf.cpp
+++ b/src/pair_coul_dsf.cpp
@@ -33,13 +33,12 @@
 using namespace LAMMPS_NS;
 using namespace MathConst;
 
-#define EWALD_F 1.12837917
-#define EWALD_P 0.3275911
-#define A1 0.254829592
-#define A2 -0.284496736
-#define A3 1.421413741
-#define A4 -1.453152027
-#define A5 1.061405429
+static constexpr double EWALD_P = 0.3275911;
+static constexpr double A1 = 0.254829592;
+static constexpr double A2 = -0.284496736;
+static constexpr double A3 = 1.421413741;
+static constexpr double A4 = -1.453152027;
+static constexpr double A5 = 1.061405429;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -93,7 +93,6 @@ static constexpr char id_press[] = "thermo_press";
 static constexpr char id_pe[] = "thermo_pe";
 
 static char fmtbuf[512];
-static constexpr int DELTA = 8;
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -33,13 +33,12 @@
 
 using namespace LAMMPS_NS;
 
-enum{CREATE,SET,SCALE,RAMP,ZERO};
-enum{ALL,LOCAL,GEOM};
-enum{UNIFORM,GAUSSIAN};
-enum{NONE,CONSTANT,EQUAL,ATOM};
+enum { CREATE, SET, SCALE, RAMP, ZERO };
+enum { ALL, LOCAL, GEOM };
+enum { UNIFORM, GAUSSIAN };
+enum { NONE, CONSTANT, EQUAL, ATOM };
 
 static constexpr int WARMUP = 100;
-static constexpr double SMALL =  0.001;
 
 /* ---------------------------------------------------------------------- */
 


### PR DESCRIPTION
**Summary**

This pull request removes unused constants that were previously defines. After conversion to `static constexpr` compilers can now report which ones are not used. A few remaining defines were replaced as well.

**Related Issue(s)**

This is a followup to PR #4051 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
