### PR TITLE
Fix buffer overflow in compute reaxff/atom

### DIFF
--- a/src/REAXFF/compute_reaxff_atom.cpp
+++ b/src/REAXFF/compute_reaxff_atom.cpp
@@ -43,7 +43,7 @@ ComputeReaxFFAtom::ComputeReaxFFAtom(LAMMPS *lmp, int narg, char **arg) :
 
   // initialize output
 
-  nlocal = -1;
+  nmax = -1;
   nbonds = 0;
   prev_nbonds = -1;
 
@@ -162,19 +162,21 @@ void ComputeReaxFFAtom::compute_bonds()
 {
   invoked_bonds = update->ntimestep;
 
-  if (atom->nlocal > nlocal) {
+  if (atom->nmax > nmax) {
     memory->destroy(abo);
     memory->destroy(neighid);
     memory->destroy(bondcount);
     memory->destroy(array_atom);
-    nlocal = atom->nlocal;
+    nmax = atom->nmax;
     if (store_bonds) {
-      memory->create(abo, nlocal, MAXREAXBOND, "reaxff/atom:abo");
-      memory->create(neighid, nlocal, MAXREAXBOND, "reaxff/atom:neighid");
+      memory->create(abo, nmax, MAXREAXBOND, "reaxff/atom:abo");
+      memory->create(neighid, nmax, MAXREAXBOND, "reaxff/atom:neighid");
     }
-    memory->create(bondcount, nlocal, "reaxff/atom:bondcount");
-    memory->create(array_atom, nlocal, 3, "reaxff/atom:array_atom");
+    memory->create(bondcount, nmax, "reaxff/atom:bondcount");
+    memory->create(array_atom, nmax, 3, "reaxff/atom:array_atom");
   }
+
+  const int nlocal = atom->nlocal;
 
   for (int i = 0; i < nlocal; i++) {
     bondcount[i] = 0;
@@ -208,6 +210,8 @@ void ComputeReaxFFAtom::compute_local()
 
   int b = 0;
 
+  const int nlocal = atom->nlocal;
+
   for (int i = 0; i < nlocal; ++i) {
     const int numbonds = bondcount[i];
 
@@ -230,6 +234,8 @@ void ComputeReaxFFAtom::compute_peratom()
     compute_bonds();
   }
 
+  const int nlocal = atom->nlocal;
+
   for (int i = 0; i < nlocal; ++i) {
     auto ptr = array_atom[i];
     ptr[0] = reaxff->api->workspace->total_bond_order[i];
@@ -244,10 +250,10 @@ void ComputeReaxFFAtom::compute_peratom()
 
 double ComputeReaxFFAtom::memory_usage()
 {
-  double bytes = (double)(nlocal*3) * sizeof(double);
-  bytes += (double)(nlocal) * sizeof(int);
+  double bytes = (double)(nmax*3) * sizeof(double);
+  bytes += (double)(nmax) * sizeof(int);
   if (store_bonds) {
-    bytes += (double)(2*nlocal*MAXREAXBOND) * sizeof(double);
+    bytes += (double)(2*nmax*MAXREAXBOND) * sizeof(double);
     bytes += (double)(nbonds*3) * sizeof(double);
   }
   return bytes;

--- a/src/REAXFF/compute_reaxff_atom.h
+++ b/src/REAXFF/compute_reaxff_atom.h
@@ -40,7 +40,7 @@ class ComputeReaxFFAtom : public Compute {
 
  protected:
   bigint invoked_bonds;     // last timestep on which compute_bonds() was invoked
-  int nlocal;
+  int nmax;
   int nbonds;
   int prev_nbonds;
   int nsub;


### PR DESCRIPTION
**Summary**

Some arrays in `compute reaxff/atom` were sized based on `nlocal` and parts of the code kept on using the old `nlocal` value even if current value was smaller, causing overflows and corrupted data, specifically in the Kokkos case.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


