### PR TITLE
Create atoms template check

### DIFF
--- a/doc/src/create_atoms.rst
+++ b/doc/src/create_atoms.rst
@@ -268,6 +268,12 @@ molecule can be specified in the molecule file.  See the
 required to be in this file are the coordinates and types of atoms in
 the molecule.
 
+.. note::
+
+  If you are using the :doc:`atom style template <atom_style>` command, 
+  the molecule template-ID of the atom style must be the same as the 
+  template-ID argument to this command.
+
 Using a lattice to add molecules, e.g. via the *box* or *region* or
 *single* styles, is exactly the same as adding atoms on lattice
 points, except that entire molecules are added at each point, i.e. on

--- a/doc/src/create_atoms.rst
+++ b/doc/src/create_atoms.rst
@@ -270,9 +270,9 @@ the molecule.
 
 .. note::
 
-  If you are using the :doc:`atom style template <atom_style>` command, 
-  the molecule template-ID of the atom style must be the same as the 
-  template-ID argument to this command.
+  If you are using the *mol* keyword in combination with the
+  :doc:`atom style template <atom_style>` command, they must use
+  the same molecule template-ID.
 
 Using a lattice to add molecules, e.g. via the *box* or *region* or
 *single* styles, is exactly the same as adding atoms on lattice

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -175,7 +175,6 @@ void CreateAtoms::command(int narg, char **arg)
       iarg += 2;
     } else if (strcmp(arg[iarg], "mol") == 0) {
       if (iarg + 3 > narg) utils::missing_cmd_args(FLERR, "create_atoms mol", error);
-      int molecular = atom->molecular;
       int imol = atom->find_molecule(arg[iarg + 1]);
       if (imol == -1)
         error->all(FLERR, "Molecule template ID {} for create_atoms does not exist", arg[iarg + 1]);
@@ -184,9 +183,8 @@ void CreateAtoms::command(int narg, char **arg)
                        "Only the first set will be used.");
       mode = MOLECULE;
       onemol = atom->molecules[imol];
-      if ((molecular == Atom::TEMPLATE) && (onemol != atom->avec->onemols[0]))
-        error->all(FLERR, "When using atom style template, create_atoms must use the same "
-                   "molecule template as the atom style");
+      if (atom->molecular == Atom::TEMPLATE && onemol != atom->avec->onemols[0])
+        error->all(FLERR, "create_atoms molecule template ID must be same as atom style template ID");
       molseed = utils::inumeric(FLERR, arg[iarg + 2], false, lmp);
       iarg += 3;
     } else if (strcmp(arg[iarg], "units") == 0) {

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -183,8 +183,6 @@ void CreateAtoms::command(int narg, char **arg)
                        "Only the first set will be used.");
       mode = MOLECULE;
       onemol = atom->molecules[imol];
-      if (atom->molecular == Atom::TEMPLATE && onemol != atom->avec->onemols[0])
-        error->all(FLERR, "create_atoms molecule template ID must be same as atom style template ID");
       molseed = utils::inumeric(FLERR, arg[iarg + 2], false, lmp);
       iarg += 3;
     } else if (strcmp(arg[iarg], "units") == 0) {
@@ -303,6 +301,8 @@ void CreateAtoms::command(int narg, char **arg)
       error->all(FLERR, "Invalid atom type in create_atoms mol command");
     if (onemol->tag_require && !atom->tag_enable)
       error->all(FLERR, "Create_atoms molecule has atom IDs, but system does not");
+    if (atom->molecular == Atom::TEMPLATE && onemol != atom->avec->onemols[0])
+      error->all(FLERR, "Create_atoms molecule template ID must be same as atom style template ID");
 
     onemol->check_attributes();
 

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -175,6 +175,7 @@ void CreateAtoms::command(int narg, char **arg)
       iarg += 2;
     } else if (strcmp(arg[iarg], "mol") == 0) {
       if (iarg + 3 > narg) utils::missing_cmd_args(FLERR, "create_atoms mol", error);
+      int molecular = atom->molecular;
       int imol = atom->find_molecule(arg[iarg + 1]);
       if (imol == -1)
         error->all(FLERR, "Molecule template ID {} for create_atoms does not exist", arg[iarg + 1]);
@@ -183,6 +184,9 @@ void CreateAtoms::command(int narg, char **arg)
                        "Only the first set will be used.");
       mode = MOLECULE;
       onemol = atom->molecules[imol];
+      if ((molecular == Atom::TEMPLATE) && (onemol != atom->avec->onemols[0]))
+        error->all(FLERR, "When using atom style template, create_atoms must use the same "
+                   "molecule template as the atom style");
       molseed = utils::inumeric(FLERR, arg[iarg + 2], false, lmp);
       iarg += 3;
     } else if (strcmp(arg[iarg], "units") == 0) {


### PR DESCRIPTION
**Summary**
This adds a check in `create_atoms` to ensure that if `atom_style template` is used, the same molecule template is used in the atom style as in the `create_atoms` command. I saw that this check is already performed in `fix pour` and `fix deposit`, but not yet in `create_atoms`.

**Related Issue(s)**

**Author(s)**
Sieds Lykles (TU Delft)


**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**


**Implementation Notes**

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**
