### PR TITLE
Fix a bug with removing variables when a vector variable is defined

### DIFF
--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1977,12 +1977,12 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
       } else if (strncmp(word,"v_",2) == 0) {
 
-        int ivar = find(word+2);
-        if (ivar < 0)
+        int jvar = find(word+2);
+        if (jvar < 0)
           print_var_error(FLERR,fmt::format("Invalid variable reference {} in variable formula",word),
-                          ivar);
-        if (eval_in_progress[ivar])
-          print_var_error(FLERR,"has a circular dependency",ivar);
+                          jvar);
+        if (eval_in_progress[jvar])
+          print_var_error(FLERR,"has a circular dependency",jvar);
 
         // parse zero or one trailing brackets
         // point i beyond last bracket
@@ -2006,9 +2006,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           // scalar from internal-style variable
           // access value directly
 
-          if (style[ivar] == INTERNAL) {
+          if (style[jvar] == INTERNAL) {
 
-            value1 = dvalue[ivar];
+            value1 = dvalue[jvar];
             if (tree) {
               auto newtree = new Tree();
               newtree->type = VALUE;
@@ -2019,13 +2019,13 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
             // scalar from any style variable except VECTOR, ATOM, ATOMFILE
             // access value via retrieve()
 
-          } else if (style[ivar] != ATOM && style[ivar] != ATOMFILE && style[ivar] != VECTOR) {
+          } else if (style[jvar] != ATOM && style[jvar] != ATOMFILE && style[jvar] != VECTOR) {
 
             char *var = retrieve(word+2);
             if (var == nullptr)
-              print_var_error(FLERR,"Invalid variable evaluation in variable formula",ivar);
+              print_var_error(FLERR,"Invalid variable evaluation in variable formula",jvar);
             if (!utils::is_double(var))
-              print_var_error(FLERR,"Non-numeric variable value in variable formula",ivar);
+              print_var_error(FLERR,"Non-numeric variable value in variable formula",jvar);
             if (tree) {
               auto newtree = new Tree();
               newtree->type = VALUE;
@@ -2036,15 +2036,15 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           // vector from vector-style variable
           // evaluate the vector-style variable, put result in newtree
 
-          } else if (style[ivar] == VECTOR) {
+          } else if (style[jvar] == VECTOR) {
 
             if (tree == nullptr)
-              print_var_error(FLERR,"Vector-style variable in equal-style variable formula",ivar);
+              print_var_error(FLERR,"Vector-style variable in equal-style variable formula",jvar);
             if (treetype == ATOM)
-              print_var_error(FLERR,"Vector-style variable in atom-style variable formula",ivar);
+              print_var_error(FLERR,"Vector-style variable in atom-style variable formula",jvar);
 
             double *vec;
-            int nvec = compute_vector(ivar,&vec);
+            int nvec = compute_vector(jvar,&vec);
 
             auto newtree = new Tree();
             newtree->type = VECTORARRAY;
@@ -2056,36 +2056,36 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           // vector from atom-style variable
           // evaluate the atom-style variable as newtree
 
-          } else if (style[ivar] == ATOM) {
+          } else if (style[jvar] == ATOM) {
 
             if (tree == nullptr)
-              print_var_error(FLERR,"Atom-style variable in equal-style variable formula",ivar);
+              print_var_error(FLERR,"Atom-style variable in equal-style variable formula",jvar);
             if (treetype == VECTOR)
-              print_var_error(FLERR,"Atom-style variable in vector-style variable formula",ivar);
+              print_var_error(FLERR,"Atom-style variable in vector-style variable formula",jvar);
 
             Tree *newtree = nullptr;
-            evaluate(data[ivar][0],&newtree,ivar);
+            evaluate(data[jvar][0],&newtree,jvar);
             treestack[ntreestack++] = newtree;
 
           // vector from atomfile-style variable
           // point to the values in FixStore instance
 
-          } else if (style[ivar] == ATOMFILE) {
+          } else if (style[jvar] == ATOMFILE) {
 
             if (tree == nullptr)
-              print_var_error(FLERR,"Atomfile-style variable in equal-style variable formula",ivar);
+              print_var_error(FLERR,"Atomfile-style variable in equal-style variable formula",jvar);
             if (treetype == VECTOR)
-              print_var_error(FLERR,"Atomfile-style variable in vector-style variable formula",ivar);
+              print_var_error(FLERR,"Atomfile-style variable in vector-style variable formula",jvar);
 
             auto newtree = new Tree();
             newtree->type = ATOMARRAY;
-            newtree->array = reader[ivar]->fixstore->vstore;
+            newtree->array = reader[jvar]->fixstore->vstore;
             newtree->nstride = 1;
             treestack[ntreestack++] = newtree;
 
           // no other possibilities for variable with no bracket
 
-          } else print_var_error(FLERR,"Mismatched variable in variable formula",ivar);
+          } else print_var_error(FLERR,"Mismatched variable in variable formula",jvar);
 
         // vname[i] with one bracket
 
@@ -2094,12 +2094,12 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           // scalar from vector-style variable
           // compute the vector-style variable, extract single value
 
-          if (style[ivar] == VECTOR) {
+          if (style[jvar] == VECTOR) {
 
             double *vec;
-            int nvec = compute_vector(ivar,&vec);
+            int nvec = compute_vector(jvar,&vec);
             if (index <= 0 || index > nvec)
-              print_var_error(FLERR,"Invalid index into vector-style variable",ivar);
+              print_var_error(FLERR,"Invalid index into vector-style variable",jvar);
             int m = index;   // convert from tagint to int
 
             if (tree) {
@@ -2113,25 +2113,25 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           // compute the per-atom variable in result
           // use peratom2global to extract single value from result
 
-          } else if (style[ivar] == ATOM) {
+          } else if (style[jvar] == ATOM) {
 
             double *result;
             memory->create(result,atom->nlocal,"variable:result");
-            compute_atom(ivar,0,result,1,0);
+            compute_atom(jvar,0,result,1,0);
             peratom2global(1,nullptr,result,1,index,tree,treestack,ntreestack,argstack,nargstack);
             memory->destroy(result);
 
           // scalar from atomfile-style variable
           // use peratom2global to extract single value from FixStore instance
 
-          } else if (style[ivar] == ATOMFILE) {
+          } else if (style[jvar] == ATOMFILE) {
 
-            peratom2global(1,nullptr,reader[ivar]->fixstore->vstore,1,index,
+            peratom2global(1,nullptr,reader[jvar]->fixstore->vstore,1,index,
                            tree,treestack,ntreestack,argstack,nargstack);
 
           // no other possibilities for variable with one bracket
 
-          } else print_var_error(FLERR,"Mismatched variable in variable formula",ivar);
+          } else print_var_error(FLERR,"Mismatched variable in variable formula",jvar);
         }
 
       // ----------------

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1283,10 +1283,10 @@ void Variable::remove(int n)
     dvalue[i-1] = dvalue[i];
 
     // copy VecVar struct from vecs[i] to vecs[i-1]
-    
+
     memcpy(&vecs[i-1],&vecs[i],sizeof(VecVar));
   }
-  
+
   nvar--;
   data[nvar] = nullptr;
   reader[nvar] = nullptr;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1281,7 +1281,12 @@ void Variable::remove(int n)
     reader[i-1] = reader[i];
     data[i-1] = data[i];
     dvalue[i-1] = dvalue[i];
+
+    // copy VecVar struct from vecs[i] to vecs[i-1]
+    
+    memcpy(&vecs[i-1],&vecs[i],sizeof(VecVar));
   }
+  
   nvar--;
   data[nvar] = nullptr;
   reader[nvar] = nullptr;


### PR DESCRIPTION
**Summary**

When vector variables were recently added, the removal of (any kind of) variable needs to compress the data struct used by vector variables.  This was not being done.

**Related Issue(s)**

Addresses issue #4081 

**Author(s)**

Steve
And thanks to @hothello who posted the issue and provided helpful test scripts.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


