### PR TITLE
Changes for processors grid numa style

### DIFF
--- a/doc/src/processors.rst
+++ b/doc/src/processors.rst
@@ -25,6 +25,8 @@ Syntax
            *numa* params = none
            *custom* params = infile
              infile = file containing grid layout
+       *numa_nodes* arg = Nn
+             Nn = number of numa domains per node
        *map* arg = *cart* or *cart/reorder* or *xyz* or *xzy* or *yxz* or *yzx* or *zxy* or *zyx*
           cart = use MPI_Cart() methods to map processors to 3d grid with reorder = 0
           cart/reorder = use MPI_Cart() methods to map processors to 3d grid with reorder = 1
@@ -159,24 +161,28 @@ surface-to-volume ratio of each processor's subdomain.
 
 The *numa* style operates similar to the *twolevel* keyword except
 that it auto-detects which cores are running on which nodes.
-Currently, it does this in only 2 levels, but it may be extended in
-the future to account for socket topology and other non-uniform memory
-access (NUMA) costs.  It also uses a different algorithm than the
-*twolevel* keyword for doing the two-level factorization of the
-simulation box into a 3d processor grid to minimize off-node
-communication, and it does its own MPI-based mapping of nodes and
+It will also subdivide the cores into numa domains. Currently, the
+number of numa domains is not autodetected and must be specified using
+the *numa_nodes* keyword; otherwise, the default value is used. The
+*numa* style uses a different algorithm than the *twolevel* keyword for
+doing the two-level factorization of the simulation box into a 3d
+processor grid to minimize off-node communication and communication
+across numa domains. It does its own MPI-based mapping of nodes and
 cores to the regular 3d grid.  Thus it may produce a different layout
 of the processors than the *twolevel* options.
 
 The *numa* style will give an error if the number of MPI processes is
 not divisible by the number of cores used per node, or any of the Px
-or Py of Pz values is greater than 1.
+or Py or Pz values is greater than 1.
 
 .. note::
 
    Unlike the *twolevel* style, the *numa* style does not require
-   any particular ordering of MPI ranks i norder to work correctly.  This
+   any particular ordering of MPI ranks in order to work correctly. This
    is because it auto-detects which processes are running on which nodes.
+   However, it assumes that the lowest ranks are in the first numa
+   domain, and so forth. MPI rank orderings that do not preserve this
+   property might result in more intranode communication between CPUs.
 
 The *custom* style uses the file *infile* to define both the 3d
 factorization and the mapping of processors to the grid.
@@ -204,6 +210,14 @@ where ID is a processor ID (from 0 to P-1) and I,J,K are the
 processors location in the 3d grid.  I must be a number from 1 to Px
 (inclusive) and similarly for J and K.  The P lines can be listed in
 any order, but no processor ID should appear more than once.
+
+----------
+
+The *numa_nodes* keyword is used to specifiy the number of numa domains
+per node. It is currently only used by the *numa* style for two-level
+factorization to reduce the amount of MPI communications between CPUs.
+A good setting for this will typically be equal to the number of CPU
+sockets per node.
 
 ----------
 
@@ -356,5 +370,5 @@ Related commands
 Default
 """""""
 
-The option defaults are Px Py Pz = \* \* \*, grid = onelevel, and map =
-cart.
+The option defaults are Px Py Pz = \* \* \*, grid = onelevel, map =
+cart, and numa_nodes = 2.

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -420,6 +420,7 @@ void Comm::set_processors(int narg, char **arg)
     error->all(FLERR,"Specified processors != physical processors");
 
   int iarg = 3;
+  numa_nodes = 2;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"grid") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal processors command");
@@ -514,6 +515,12 @@ void Comm::set_processors(int narg, char **arg)
       outfile = utils::strdup(arg[iarg+1]);
       iarg += 2;
 
+    } else if (strcmp(arg[iarg],"numa_nodes") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal processors command");
+      numa_nodes = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
+      if (numa_nodes < 1) numa_nodes = 2;
+      iarg += 2;
+
     } else error->all(FLERR,"Illegal processors command");
   }
 
@@ -565,7 +572,7 @@ void Comm::set_proc_grid(int outflag)
                         otherflag,other_style,other_procgrid,other_coregrid);
 
   } else if (gridflag == NUMA) {
-    pmap->numa_grid(nprocs,user_procgrid,procgrid,coregrid);
+    pmap->numa_grid(numa_nodes,nprocs,user_procgrid,procgrid,coregrid);
 
   } else if (gridflag == CUSTOM) {
     pmap->custom_grid(customfile,nprocs,user_procgrid,procgrid);

--- a/src/comm.h
+++ b/src/comm.h
@@ -146,6 +146,7 @@ class Comm : protected Pointers {
   char xyz[4];         // xyz mapping of procs to 3d grid
   char *customfile;    // file with custom proc map
   char *outfile;       // proc grid/map output file
+  int numa_nodes;      // Number of numa domains per socket for 3d grid
 
   int otherflag;            // 1 if this partition dependent on another
   int other_style;          // style of dependency

--- a/src/procmap.h
+++ b/src/procmap.h
@@ -24,7 +24,7 @@ class ProcMap : protected Pointers {
 
   void onelevel_grid(int, int *, int *, int, int, int *, int *);
   void twolevel_grid(int, int *, int *, int, int *, int *, int, int, int *, int *);
-  void numa_grid(int, int *, int *, int *);
+  void numa_grid(int, int, int *, int *, int *);
   void custom_grid(char *, int, int *, int *);
   void cart_map(int, int *, int *, int[3][2], int ***);
   void cart_map(int, int *, int, int *, int *, int[3][2], int ***);


### PR DESCRIPTION
As core counts per socket and data movement bottlenecks increase, it can be better to optimize the numa mapping within a node. This adds a processors option to specify the number of numa domains for the processors grid numa style, with the default being 2. It also simplifies the numa mapping algorithm with more aggressive optimization to reduce comm between numa domains.

**Summary**

**Related Issue(s)**

**Author(s)**

Mike Brown, Intel

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

I chose the numa domains option to be a separate keyword for processors, preserving backward compatibility. Of course, the other option, that might be more natural to the LAMMPS command style but break compatibility, would be to make this an argument for 'numa'.

**Implementation Notes**


**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**



