### PR TITLE
Small patches to multi neighbor and fix deform/pressure

### DIFF
--- a/doc/src/fix_deform_pressure.rst
+++ b/doc/src/fix_deform_pressure.rst
@@ -91,7 +91,7 @@ corresponding component of the pressure tensor. This option attempts to
 maintain a specified target pressure using a linear controller where the
 box length :math:`L` evolves according to the equation
 
-.. parsed-literal::
+.. math::
 
    \frac{d L(t)}{dt} = L(t) k (P_t - P)
 

--- a/src/EXTRA-FIX/fix_deform_pressure.cpp
+++ b/src/EXTRA-FIX/fix_deform_pressure.cpp
@@ -767,8 +767,7 @@ void FixDeformPressure::apply_box()
       if (fabs(v_rate) > max_h_rate)
         v_rate = max_h_rate * v_rate / fabs(v_rate);
 
-    set_extra[6].cumulative_strain += update->dt * v_rate;
-    scale = (1.0 + set_extra[6].cumulative_strain);
+    scale = (1.0 + update->dt * v_rate);
     for (i = 0; i < 3; i++) {
       shift = 0.5 * (set[i].hi_target - set[i].lo_target) * scale;
       set[i].lo_target = 0.5 * (set[i].lo_start + set[i].hi_start) - shift;
@@ -843,7 +842,6 @@ void FixDeformPressure::restart(char *buf)
     set_extra[i].saved = set_extra_restart[i].saved;
     set_extra[i].prior_rate = set_extra_restart[i].prior_rate;
     set_extra[i].prior_pressure = set_extra_restart[i].prior_pressure;
-    set_extra[i].cumulative_strain = set_extra_restart[i].cumulative_strain;
   }
 }
 

--- a/src/EXTRA-FIX/fix_deform_pressure.h
+++ b/src/EXTRA-FIX/fix_deform_pressure.h
@@ -51,7 +51,6 @@ class FixDeformPressure : public FixDeform {
   struct SetExtra {
     double ptarget, pgain;
     double prior_pressure, prior_rate;
-    double cumulative_strain;
     int saved;
     char *pstr;
     int pvar, pvar_flag;

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -427,6 +427,9 @@ void Neighbor::init()
         }
       }
     } else {
+      if (!force->pair)
+        error->all(FLERR, "Cannot use collection/interval command without defining a pairstyle");
+
       if (force->pair->finitecutflag) {
         finite_cut_flag = 1;
         // If cutoffs depend on finite atom sizes, use radii of intervals to find cutoffs


### PR DESCRIPTION
**Summary**

1) Added error message when using multi collection/interval without a pairstyle to avoid a segfault
2) Fixed a missing math environment in fix_deform_pressure.rst
3) Removed an unused variable in fix deform/pressure, patching the misuse of a cumulative instead of an instantaneous strain to calculate the change in box volume

**Related Issue(s)**

NA

**Author(s)**

Joel Clemmer (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

