### PR TITLE
Fix Kokkos "team size too large" issue

### DIFF
--- a/src/KOKKOS/pair_kokkos.h
+++ b/src/KOKKOS/pair_kokkos.h
@@ -950,6 +950,8 @@ EV_FLOAT pair_compute_neighlist (PairStyle* fpair, std::enable_if_t<(NEIGHFLAG&P
 
     static int vectorsize = 0;
     static int atoms_per_team = 0;
+    static int teamsize_max_for = 0;
+    static int teamsize_max_reduce = 0;
 
 #if defined(LMP_KOKKOS_GPU)
     static int lastcall = -1;
@@ -966,7 +968,6 @@ EV_FLOAT pair_compute_neighlist (PairStyle* fpair, std::enable_if_t<(NEIGHFLAG&P
 
       vectorsize = MIN(vectorsize,max_vectorsize);
 
-      int teamsize_max_for,teamsize_max_reduce;
       if (fpair->atom->ntypes > MAX_TYPES_STACKPARAMS) {
         PairComputeFunctor<PairStyle,NEIGHFLAG,false,ZEROFLAG,Specialisation > ff(fpair,list);
         GetMaxTeamSize<typename PairStyle::device_type>(ff, inum, teamsize_max_for, teamsize_max_reduce);
@@ -974,12 +975,12 @@ EV_FLOAT pair_compute_neighlist (PairStyle* fpair, std::enable_if_t<(NEIGHFLAG&P
         PairComputeFunctor<PairStyle,NEIGHFLAG,true,ZEROFLAG,Specialisation > ff(fpair,list);
         GetMaxTeamSize<typename PairStyle::device_type>(ff, inum, teamsize_max_for, teamsize_max_reduce);
       }
-
-      int teamsize_max = teamsize_max_for;
-      if (fpair->eflag || fpair->vflag)
-        teamsize_max = teamsize_max_reduce;
-      atoms_per_team = teamsize_max/vectorsize;
     }
+
+    int teamsize_max = teamsize_max_for;
+    if (fpair->eflag || fpair->vflag)
+      teamsize_max = teamsize_max_reduce;
+    atoms_per_team = teamsize_max/vectorsize;
 #else
     vectorsize = 1;
     atoms_per_team = 1;


### PR DESCRIPTION
**Summary**

When running Kokkos on GPUs with neighbor threading (default for 16k atoms or less) the code sometimes gave an error that the requested team size was too large. The issue was that both a `parallel_for` and `parallel_reduce` could be called between reneighboring which have a different max team size, but the code assumed the team size was fixed between reneighboring.

**Related Issue(s)**

#4003 

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

