### PR TITLE
Fixed bugs with sph gpu pair styles

### DIFF
--- a/src/GPU/pair_sph_heatconduction_gpu.cpp
+++ b/src/GPU/pair_sph_heatconduction_gpu.cpp
@@ -113,7 +113,7 @@ void PairSPHHeatConductionGPU::compute(int eflag, int vflag)
         neighbor->ago, inum, nall, atom->x, atom->type,
         sublo, subhi, atom->tag, atom->nspecial, atom->special, eflag, vflag,
         eflag_atom, vflag_atom, host_start, &ilist, &numneigh,
-        cpu_time, success, atom->v);
+        cpu_time, success, atom->vest);
   } else {
     inum = list->inum;
     ilist = list->ilist;
@@ -122,7 +122,7 @@ void PairSPHHeatConductionGPU::compute(int eflag, int vflag)
     sph_heatconduction_gpu_compute(neighbor->ago, inum, nall, atom->x, atom->type,
                        ilist, numneigh, firstneigh, eflag, vflag,
                        eflag_atom, vflag_atom, host_start, cpu_time, success,
-                       atom->tag, atom->v);
+                       atom->tag, atom->vest);
   }
   if (!success) error->one(FLERR, "Insufficient memory on accelerator");
 

--- a/src/GPU/pair_sph_taitwater_gpu.cpp
+++ b/src/GPU/pair_sph_taitwater_gpu.cpp
@@ -18,6 +18,7 @@
 #include "pair_sph_taitwater_gpu.h"
 
 #include "atom.h"
+#include "comm.h"
 #include "domain.h"
 #include "error.h"
 #include "force.h"
@@ -85,6 +86,25 @@ void PairSPHTaitwaterGPU::compute(int eflag, int vflag)
 {
   ev_init(eflag, vflag);
 
+  // check consistency of pair coefficients
+
+  if (first) {
+    for (int i = 1; i <= atom->ntypes; i++) {
+      for (int j = 1; i <= atom->ntypes; i++) {
+        if (cutsq[i][j] > 1.e-32) {
+          if (!setflag[i][i] || !setflag[j][j]) {
+            if (comm->me == 0) {
+              printf(
+                  "SPH particle types %d and %d interact with cutoff=%g, but not all of their single particle properties are set.\n",
+                  i, j, sqrt(cutsq[i][j]));
+            }
+          }
+        }
+      }
+    }
+    first = 0;
+  }
+
   int nall = atom->nlocal + atom->nghost;
   int inum, host_start;
 
@@ -110,7 +130,7 @@ void PairSPHTaitwaterGPU::compute(int eflag, int vflag)
     firstneigh = sph_taitwater_gpu_compute_n(
         neighbor->ago, inum, nall, atom->x, atom->type, sublo, subhi, atom->tag, atom->nspecial,
         atom->special, eflag, vflag, eflag_atom, vflag_atom, host_start, &ilist, &numneigh,
-        cpu_time, success, atom->v);
+        cpu_time, success, atom->vest);
   } else {
     inum = list->inum;
     ilist = list->ilist;
@@ -118,7 +138,7 @@ void PairSPHTaitwaterGPU::compute(int eflag, int vflag)
     firstneigh = list->firstneigh;
     sph_taitwater_gpu_compute(neighbor->ago, inum, nall, atom->x, atom->type, ilist, numneigh, firstneigh,
                        eflag, vflag, eflag_atom, vflag_atom, host_start, cpu_time, success,
-                       atom->tag, atom->v);
+                       atom->tag, atom->vest);
   }
   if (!success) error->one(FLERR, "Insufficient memory on accelerator");
 
@@ -131,21 +151,21 @@ void PairSPHTaitwaterGPU::compute(int eflag, int vflag)
   int nlocal = atom->nlocal;
   if (acc_float) {
     auto drhoE_ptr = (float *)drhoE_pinned;
-    int idx = 0;
-    for (int i = 0; i < nlocal; i++) {
-      drho[i] = drhoE_ptr[idx];
-      desph[i] = drhoE_ptr[idx+1];
-      idx += 2;
-    }
+    for (int i = 0; i < nlocal; i++)
+      drho[i] += drhoE_ptr[i];
+
+    drhoE_ptr += nlocal;
+    for (int i = 0; i < nlocal; i++)
+      desph[i] += drhoE_ptr[i];
 
   } else {
     auto drhoE_ptr = (double *)drhoE_pinned;
-    int idx = 0;
-    for (int i = 0; i < nlocal; i++) {
-      drho[i] = drhoE_ptr[idx];
-      desph[i] = drhoE_ptr[idx+1];
-      idx += 2;
-    }
+    for (int i = 0; i < nlocal; i++)
+      drho[i] += drhoE_ptr[i];
+
+    drhoE_ptr += nlocal;
+    for (int i = 0; i < nlocal; i++)
+      desph[i] += drhoE_ptr[i];
   }
 
   if (atom->molecular != Atom::ATOMIC && neighbor->ago == 0)


### PR DESCRIPTION
**Summary**

This PR fixes bugs in the sph gpu pair styles. I found the issues after running the example input script water_collapse.in on multiple procs for a sufficiently large number of time steps.

**Related Issue(s)**

N/A

**Author(s)**

Trung Nguyen (U Chicago)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


