### PR TITLE
fix pimd/langevin: improve support for method==pimd

### DIFF
--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -696,6 +696,7 @@ void FixPIMDLangevin::post_force(int /*flag*/)
     inter_replica_comm(x);
     spring_force();
     compute_spring_energy();
+    compute_t_prim();
     if (mapflag) {
       for (int i = 0; i < nlocal; i++) { domain->unmap_inv(x[i], image[i]); }
     }

--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -47,10 +47,10 @@
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
-using MathConst::MY_PI;
 using MathConst::MY_2PI;
-using MathConst::THIRD;
+using MathConst::MY_PI;
 using MathConst::MY_SQRT2;
+using MathConst::THIRD;
 using MathSpecial::powint;
 
 enum { PIMD, NMPIMD };
@@ -475,11 +475,13 @@ void FixPIMDLangevin::init()
 
   c_pe = modify->get_compute_by_id(id_pe);
   if (!c_pe)
-    error->universe_all(FLERR, fmt::format("Could not find fix {} potential energy compute ID {}", style, id_pe));
+    error->universe_all(
+        FLERR, fmt::format("Could not find fix {} potential energy compute ID {}", style, id_pe));
 
   c_press = modify->get_compute_by_id(id_press);
   if (!c_press)
-    error->universe_all(FLERR, fmt::format("Could not find fix {} pressure compute ID {}", style, id_press));
+    error->universe_all(
+        FLERR, fmt::format("Could not find fix {} pressure compute ID {}", style, id_press));
 
   t_prim = t_vir = t_cv = p_prim = p_vir = p_cv = p_md = 0.0;
 }
@@ -741,7 +743,7 @@ void FixPIMDLangevin::collect_xc()
       }
     }
 
-    const double sqrtnp = sqrt((double)np);
+    const double sqrtnp = sqrt((double) np);
     for (int i = 0; i < nlocal; i++) {
       xcall[3 * (tag[i] - 1) + 0] = x[i][0] / sqrtnp;
       xcall[3 * (tag[i] - 1) + 1] = x[i][1] / sqrtnp;
@@ -1048,8 +1050,8 @@ void FixPIMDLangevin::langevin_init()
         c2_k[i] = sqrt(1.0 - c1_k[i] * c1_k[i]);
       }
       for (int i = 0; i < np; i++) {
-        out += fmt::format("      {:d}     {:.8e} {:.8e} {:.8e} {:.8e}\n", i,
-                           _omega_k[i], tau_k[i], c1_k[i], c2_k[i]);
+        out += fmt::format("      {:d}     {:.8e} {:.8e} {:.8e} {:.8e}\n", i, _omega_k[i], tau_k[i],
+                           c1_k[i], c2_k[i]);
       }
     } else if (method == PIMD) {
       for (int i = 0; i < np; i++) {
@@ -1111,7 +1113,7 @@ void FixPIMDLangevin::nmpimd_init()
   }
 
   // Set up eigenvectors for degenerated modes
-  const double sqrtnp = sqrt((double)np);
+  const double sqrtnp = sqrt((double) np);
   for (int j = 0; j < np; j++) {
     for (int i = 1; i < int(np / 2) + 1; i++) {
       M_x2xp[i][j] = MY_SQRT2 * cos(MY_2PI * double(i) * double(j) / double(np)) / sqrtnp;
@@ -1380,8 +1382,7 @@ void FixPIMDLangevin::remove_com_motion()
         }
       }
     }
-  }
-  else if (method == PIMD) {
+  } else if (method == PIMD) {
     double **v = atom->v;
     int *mask = atom->mask;
     int nlocal = atom->nlocal;
@@ -1395,8 +1396,7 @@ void FixPIMDLangevin::remove_com_motion()
         v[i][2] -= vcm[2];
       }
     }
-  }
-  else {
+  } else {
     error->all(FLERR, "Unknown method for fix pimd/langevin. Only nmpimd and pimd are supported!");
   }
 }
@@ -1409,9 +1409,7 @@ void FixPIMDLangevin::compute_xf_vir()
   double xf = 0.0;
   vir_ = 0.0;
   for (int i = 0; i < nlocal; i++) {
-    for (int j = 0; j < 3; j++) {
-      xf += x_unwrap[i][j] * atom->f[i][j];
-    }
+    for (int j = 0; j < 3; j++) { xf += x_unwrap[i][j] * atom->f[i][j]; }
   }
   MPI_Allreduce(&xf, &vir_, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
 }
@@ -1424,9 +1422,7 @@ void FixPIMDLangevin::compute_cvir()
   double xcf = 0.0;
   centroid_vir = 0.0;
   for (int i = 0; i < nlocal; i++) {
-    for (int j = 0; j < 3; j++) {
-      xcf += (x_unwrap[i][j] - xc[i][j]) * atom->f[i][j];
-    }
+    for (int j = 0; j < 3; j++) { xcf += (x_unwrap[i][j] - xc[i][j]) * atom->f[i][j]; }
   }
   MPI_Allreduce(&xcf, &centroid_vir, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
   if (pstyle == ANISO) {
@@ -1591,11 +1587,9 @@ void FixPIMDLangevin::compute_p_cv()
       p_cv = THIRD * inv_volume * ((2.0 * ke_bead - centroid_vir) * force->nktv2p + vir) / np;
     }
     MPI_Bcast(&p_cv, 1, MPI_DOUBLE, 0, universe->uworld);
-  }
-  else if (method == PIMD) {
+  } else if (method == PIMD) {
     p_cv = THIRD * inv_volume * ((2.0 * totke / np - centroid_vir) * force->nktv2p + vir) / np;
-  }
-  else {
+  } else {
     error->universe_all(
         FLERR,
         "Unknown method parameter for fix pimd/langevin. Only nmpimd and pimd are supported!");

--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -667,28 +667,26 @@ void FixPIMDLangevin::post_force(int /*flag*/)
   imageint *image = atom->image;
   tagint *tag = atom->tag;
 
-  if (method == NMPIMD) {
-    if (atom->nmax > maxunwrap) reallocate_x_unwrap();
-    if (atom->nmax > maxxc) reallocate_xc();
-    for (int i = 0; i < nlocal; i++) {
-      x_unwrap[i][0] = x[i][0];
-      x_unwrap[i][1] = x[i][1];
-      x_unwrap[i][2] = x[i][2];
-    }
-    if (mapflag) {
-      for (int i = 0; i < nlocal; i++) { domain->unmap(x_unwrap[i], image[i]); }
-    }
-    for (int i = 0; i < nlocal; i++) {
-      xc[i][0] = xcall[3 * (tag[i] - 1) + 0];
-      xc[i][1] = xcall[3 * (tag[i] - 1) + 1];
-      xc[i][2] = xcall[3 * (tag[i] - 1) + 2];
-    }
-
-    compute_vir();
-    compute_xf_vir();
-    compute_cvir();
-    compute_t_vir();
+  if (atom->nmax > maxunwrap) reallocate_x_unwrap();
+  if (atom->nmax > maxxc) reallocate_xc();
+  for (int i = 0; i < nlocal; i++) {
+    x_unwrap[i][0] = x[i][0];
+    x_unwrap[i][1] = x[i][1];
+    x_unwrap[i][2] = x[i][2];
   }
+  if (mapflag) {
+    for (int i = 0; i < nlocal; i++) { domain->unmap(x_unwrap[i], image[i]); }
+  }
+  for (int i = 0; i < nlocal; i++) {
+    xc[i][0] = xcall[3 * (tag[i] - 1) + 0];
+    xc[i][1] = xcall[3 * (tag[i] - 1) + 1];
+    xc[i][2] = xcall[3 * (tag[i] - 1) + 2];
+  }
+
+  compute_vir();
+  compute_xf_vir();
+  compute_cvir();
+  compute_t_vir();
 
   if (method == PIMD) {
     if (mapflag) {

--- a/src/REPLICA/fix_pimd_langevin.h
+++ b/src/REPLICA/fix_pimd_langevin.h
@@ -176,6 +176,7 @@ class FixPIMDLangevin : public Fix {
   void compute_p_prim();
   void compute_p_cv();    // centroid-virial pressure estimator
   void compute_vir();
+  void compute_xf_vir();
   void compute_cvir();
   void compute_totenthalpy();
 


### PR DESCRIPTION
**Summary**

The previous development was focused on method==nmpimd (normal mode pimd). Therefore, several features for method==pimd were missing. This PR adds support for plain pimd integrator in the following ways:
1. support computing t_prim, t_vir, and t_cv estimators for method==pimd;
2. support method==pimd in the remove_com_motion function by subtracting the centroid velocities from the velocities of all the beads themselves;
3. support computing p_cv estimators for method==pimd. This modification leads to the correct barostating for method=pimd.

Also, this PR splits the compute_cvir function into compute_xf_vir and compute_cvir functions. The compute_xf_vir function will be needed for further development of bosonic pimd by @yotamfe.

**Related Issue(s)**

This is a follow-up for PRs https://github.com/lammps/lammps/pull/3660, https://github.com/lammps/lammps/pull/3949, and https://github.com/lammps/lammps/pull/3970.

**Author(s)**

Yifan Li
[yifanl0716@gmail.com](mailto:yifanl0716@gmail.com)
Graduate Student
Department of Chemistry, Princeton University

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


