### PR TITLE
Allow compute spin for groups other than `all`

### DIFF
--- a/src/SPIN/compute_spin.cpp
+++ b/src/SPIN/compute_spin.cpp
@@ -215,9 +215,8 @@ void ComputeSpin::compute_vector()
         tempnum += tx*tx+ty*ty+tz*tz;
         tempdenom += sp[i][0]*fm[i][0]+fm[i][1]*sp[i][1]+sp[i][2]*fm[i][2];
         countsp++;
-      }
+      } else error->all(FLERR,"Compute compute/spin requires atom/spin style");
     }
-    else error->all(FLERR,"Compute compute/spin requires atom/spin style");
   }
 
   MPI_Allreduce(mag,magtot,4,MPI_DOUBLE,MPI_SUM,world);


### PR DESCRIPTION
**Summary**

Compute spin currently only works with all atoms.
Replacing `all` with a secific group, results in

`ERROR: Compute compute/spin requires atom/spin style (src/SPIN/compute_spin.cpp:220)`

Even if all atoms have atom/spin style.

This is caused because the "else" statement is attached to the "if" block which tests for the mask and groupbit.

This change moves the "else" statement to the "if" block which tests if the atom has the `sp_flag` set

**Author(s)**

Federico Williamson - federicowilliamson@hotmail.co.uk

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Some inputs that would fail, should now pass.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

Test input file.
```
units          metal
atom_style     spin                                    # !! Use Spin style
atom_modify    map array
region         box block -25 25 -25 25 -25 25 units box
create_box     2 box
group          Fe type 1
group          Ni type 2

lattice bcc 2
region       reg0 sphere 0.0 0.0 0.0  7.5 units box
region       reg1 sphere 0.0 0.0 0.0 15.0 units box
create_atoms 1 region reg1
set            region reg0 type 2
group Fe type 1
group Ni type 2

mass      1   123
mass      2   456
set group Fe  spin 2.00 0 0 1
set group Ni  spin 1.00 0 0 1

compute      out_mag_fe Fe spin                          # !! Compute on Fe group
compute      out_mag_ni Ni spin
variable     magx_fe        equal c_out_mag_fe[1]
variable     magx_ni        equal c_out_mag_ni[1]
thermo_style custom step temp v_magx_fe v_magx_ni        # !! Output result
thermo       10
run          0
```

This is my first PR to lammps, any suggestions are welcome