### PR TITLE
Explicit symmetrization of cutoff in pair_ylz

### DIFF
--- a/src/ASPHERE/pair_ylz.cpp
+++ b/src/ASPHERE/pair_ylz.cpp
@@ -300,6 +300,7 @@ double PairYLZ::init_one(int i, int j)
   zeta[j][i] = zeta[i][j];
   mu[j][i] = mu[i][j];
   beta[j][i] = beta[i][j];
+  cut[j][i] = cut[i][j];
 
   return cut[i][j];
 }
@@ -409,7 +410,7 @@ void PairYLZ::write_data_all(FILE *fp)
 {
   for (int i = 1; i <= atom->ntypes; i++)
     for (int j = i; j <= atom->ntypes; j++)
-      fprintf(fp, "%d %d %g %g %g %g %g %g\n", i, j, epsilon[i][i], sigma[i][i], cut[i][j],
+      fprintf(fp, "%d %d %g %g %g %g %g %g\n", i, j, epsilon[i][j], sigma[i][j], cut[i][j],
               zeta[i][j], mu[i][j], beta[i][j]);
 }
 


### PR DESCRIPTION
**Summary**

Added explicit symmetrization of the interaction cutoff for I != J in for pair_style ylz. Symmetrization is necessary to correctly compute the potential. 

**Related Issue(s)**

Fixes #4119

**Author(s)**

Maitane Muñoz-Basagoiti
Institute of Science and Technology Austria (ISTA)
maitane.munoz-basagoiti@ist.ac.at

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Backward compatible.

**Implementation Notes**

Explicit symmetrization of the interaction cutoff, i.e., `cut[j][i] = cut[i][j]` is added to the `init_one` function in the pair_style. The non-squared version, which is never initializated for i>j, is needed in `PairYLZ::ylz_analytic()`.

Implementation solves issue #4119: trajectories for the two systems described therein are identical after the fix. Additionally, I checked that the bug disappears when simulating a fluid membrane composed of two particles types that are identical with respect to the pair_style. In the absence of the fix, the two types demix on the surface of the membrane. Being identical particles, this is unphysical behavior. Adding the symmetrization of the cutoff leads to a well-mixed membrane, as expected. Codes to reproduce membrane simulations are attached below. 

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

Membrane example:
[Membrane.zip](https://github.com/lammps/lammps/files/14874771/Membrane.zip)


