### PR TITLE
Address minimum image issue when restarting fix rigid/small

### DIFF
--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -2160,7 +2160,7 @@ void FixRigidSmall::setup_bodies_static()
     xgc = body[ibody].xgc;
     double delta[3];
     MathExtra::sub3(xgc,xcm,delta);
-    domain->minimum_image(delta);
+    domain->minimum_image_big(delta);
     MathExtra::transpose_matvec(ex,ey,ez,delta,body[ibody].xgc_body);
     MathExtra::add3(xcm,delta,xgc);
   }

--- a/src/domain.h
+++ b/src/domain.h
@@ -119,6 +119,8 @@ class Domain : protected Pointers {
   void subbox_too_small_check(double);
   void minimum_image(double &, double &, double &) const;
   void minimum_image(double *delta) const { minimum_image(delta[0], delta[1], delta[2]); }
+  void minimum_image_big(double &, double &, double &) const;
+  void minimum_image_big(double *delta) const { minimum_image_big(delta[0], delta[1], delta[2]); }
   int closest_image(int, int);
   int closest_image(const double *const, int);
   void closest_image(const double *const, const double *const, double *const);


### PR DESCRIPTION
**Summary**

When restarting fix rigid/small it uses domain->minimum_image() in a way where they may be a large number of box crossings when the simulation was long and the rigid objects mobile or subject to a flow. This now calls an alternate implementation suitable for this specific case

**Related Issue(s)**

Fixes #4109 
Further discussions are here: https://matsci.org/t/fix-rigid-atoms-have-moved-too-far-apart/53926

**Author(s)**

Axel Kohlmeyer, Temple U, Stan Moore SNL, Steve Plimpton

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Implementation Notes**

This uses the code from PR #3721 but adds it as a new method `minimum_image_big()`.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
