### PR TITLE
Fix bug in MDI time integration logic

### DIFF
--- a/src/MDI/mdi_engine.cpp
+++ b/src/MDI/mdi_engine.cpp
@@ -695,7 +695,7 @@ void MDIEngine::mdi_md()
   if (strcmp(mdicmd, "EXIT") == 0) return;
 
   // run one step at a time forever
-  // driver triggers exit with @ command other than @COORDS,@FORCES,@ENDSTEP
+  // driver triggers exit with @ command other than @COORDS,@FORCES,@ENDSTEP,@
 
   update->integrate->setup(1);
 
@@ -711,7 +711,7 @@ void MDIEngine::mdi_md()
     update->integrate->run(1);
 
     if (strcmp(mdicmd, "@COORDS") != 0 && strcmp(mdicmd, "@FORCES") != 0 &&
-        strcmp(mdicmd, "@ENDSTEP") != 0)
+        strcmp(mdicmd, "@ENDSTEP") != 0 && strcmp(mdicmd, "@") != 0)
       break;
   }
 


### PR DESCRIPTION
**Summary**

This is a very small bugfix for an error in the LAMMPS MDI code.  Normally, when LAMMPS runs as an MDI engine and initiates a molecular dynamics simulation, it should not terminate the molecular dynamics simulation until the driver instructs it to do so.  There is an oversight that can cause LAMMPS to terminate the simulation when it receives the `@` command, which should not cause this behavior.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->
Taylor Barnes, MolSSI

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


