### PR TITLE
Relax error check on accessing fixes that produce variable size vectors/arrays

### DIFF
--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -1515,15 +1515,16 @@ void Thermo::compute_fix()
   int m = field2index[ifield];
   Fix *fix = fixes[m];
 
-  // check for out-of-range access if vector/array is variable length
-
   if (argindex1[ifield] == 0) {
     dvalue = fix->compute_scalar();
     if (normflag && fix->extscalar) dvalue /= natoms;
   } else if (argindex2[ifield] == 0) {
-    if (fix->size_vector_variable && argindex1[ifield] > fix->size_vector)
-      error->all(FLERR, "Thermo fix vector is accessed out-of-range");
-    dvalue = fix->compute_vector(argindex1[ifield] - 1);
+
+    // if index exceeds variable vector length, use a zero value
+    // this can be useful if vector length is not known a priori
+
+    if (fix->size_vector_variable && argindex1[ifield] > fix->size_vector) dvalue = 0.0;
+    else dvalue = fix->compute_vector(argindex1[ifield] - 1);
     if (normflag) {
       if (fix->extvector == 0)
         return;
@@ -1533,9 +1534,12 @@ void Thermo::compute_fix()
         dvalue /= natoms;
     }
   } else {
-    if (fix->size_array_rows_variable && argindex1[ifield] > fix->size_array_rows)
-      error->all(FLERR, "Thermo fix array is accessed out-of-range");
-    dvalue = fix->compute_array(argindex1[ifield] - 1, argindex2[ifield] - 1);
+
+    // if index exceeds variable array rows, use a zero value
+    // this can be useful if array size is not known a priori
+
+    if (fix->size_array_rows_variable && argindex1[ifield] > fix->size_array_rows) dvalue = 0.0;
+    else dvalue = fix->compute_array(argindex1[ifield] - 1, argindex2[ifield] - 1);
     if (normflag && fix->extarray) dvalue /= natoms;
   }
 }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1807,12 +1807,16 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
             if (!fix->vector_flag)
               print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
-            if (index1 > fix->size_vector)
+            if (index1 > fix->size_vector && fix->size_vector_variable == 0)
               print_var_error(FLERR,"Variable formula fix vector is accessed out-of-range",ivar,0);
             if (update->whichflag > 0 && update->ntimestep % fix->global_freq)
               print_var_error(FLERR,"Fix in variable not computed at a compatible time",ivar);
 
-            value1 = fix->compute_vector(index1-1);
+            // if index exceeds variable vector length, use a zero value
+            // this can be useful if vector length is not known a priori
+
+            if (fix->size_vector_variable && index1 > fix->size_vector) value1 = 0.0;
+            else value1 = fix->compute_vector(index1-1);
             argstack[nargstack++] = value1;
 
           // f_ID[i][j] = scalar from global array
@@ -1821,14 +1825,18 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
             if (!fix->array_flag)
               print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
-            if (index1 > fix->size_array_rows)
+            if (index1 > fix->size_array_rows && fix->size_array_rows_variable == 0)
               print_var_error(FLERR,"Variable formula fix array is accessed out-of-range",ivar,0);
             if (index2 > fix->size_array_cols)
               print_var_error(FLERR,"Variable formula fix array is accessed out-of-range",ivar,0);
             if (update->whichflag > 0 && update->ntimestep % fix->global_freq)
               print_var_error(FLERR,"Fix in variable not computed at a compatible time",ivar);
 
-            value1 = fix->compute_array(index1-1,index2-1);
+            // if index exceeds variable array rows, use a zero value
+            // this can be useful if array size is not known a priori
+
+            if (fix->size_array_rows_variable && index1 > fix->size_array_rows) value1 = 0.0;
+            else value1 = fix->compute_array(index1-1,index2-1);
             argstack[nargstack++] = value1;
 
           // F_ID[i] = scalar element of per-atom vector, note uppercase "F"


### PR DESCRIPTION
**Summary**

A recent PR #4122 was too aggressive in error checking when a global vector or array that is variable size is accessed out of bounds.  A few of the examples that compute viscosity and heat capacity do this on step 0 before fix ave/chunk have knows the # of chunks.  So they depend on zero values being returned.  This change allows that again, although other use cases are still treated more agressively with error checking.

**Related Issue(s)**

N/A

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


