### PR TITLE
Improve Kokkos sorting

### DIFF
--- a/src/KOKKOS/atom_kokkos.cpp
+++ b/src/KOKKOS/atom_kokkos.cpp
@@ -31,9 +31,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-AtomKokkos::AtomKokkos(LAMMPS *lmp) : Atom(lmp),
-mapBinner(1, 0.0, 1.0), // no default constructor, these values are not used
-mapSorter(d_tag_sorted, 0, 1, mapBinner, true)
+AtomKokkos::AtomKokkos(LAMMPS *lmp) : Atom(lmp)
 {
   avecKK = nullptr;
 

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -88,8 +88,25 @@ class AtomKokkos : public Atom {
   DAT::tdual_int_1d k_map_array;
   dual_hash_type k_map_hash;
 
-  DAT::t_tagint_1d d_tag_sorted;
-  DAT::t_int_1d d_i_sorted;
+  struct KeyValue {
+    int i;
+    bigint tag;
+  };
+
+  typedef Kokkos::View<KeyValue*,LMPDeviceType> t_keyvalue_1d;
+  t_keyvalue_1d d_sorted;
+
+  struct MyComp {
+    KOKKOS_FUNCTION
+    bool operator()(const KeyValue& a, const KeyValue& b) const
+    {
+      if (a.tag < b.tag)
+        return true;
+      if (b.tag < a.tag)
+        return false;
+      return a.i < b.i;
+    }
+  };
 
   typedef Kokkos::DualView<tagint[2], LMPDeviceType::array_layout, LMPDeviceType> tdual_tagint_2;
   typedef tdual_tagint_2::t_dev t_tagint_2;

--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -101,11 +101,6 @@ class AtomKokkos : public Atom {
   DAT::t_tagint_scalar d_tag_min,d_tag_max;
   HAT::t_tagint_scalar h_tag_min,h_tag_max;
 
-  using MapKeyViewType = decltype(d_tag_sorted);
-  using BinOpMap = Kokkos::BinOp1D<MapKeyViewType>;
-  BinOpMap mapBinner;
-  Kokkos::BinSort<MapKeyViewType, BinOpMap> mapSorter;
-
   class AtomVecKokkos* avecKK;
 
   // map lookup function inlined for efficiency

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -880,15 +880,8 @@ void CommKokkos::exchange_device()
 
       // sort exchange_sendlist
 
-      auto d_exchange_sendlist = k_exchange_sendlist.view<DeviceType>();
-      using KeyViewType = decltype(d_exchange_sendlist);
-      using BinOp = Kokkos::BinOp1D<KeyViewType>;
-
-      BinOp binner(count, 0, nlocal);
-      Kokkos::BinSort<KeyViewType, BinOp> Sorter(d_exchange_sendlist, 0, count, binner, true);
-      Sorter.create_permute_vector(DeviceType());
-      Sorter.sort(DeviceType(), d_exchange_sendlist, 0, count);
-
+      auto d_exchange_sendlist = Kokkos::subview(k_exchange_sendlist.view<DeviceType>(),std::make_pair(0,count));
+      Kokkos::sort(DeviceType(), d_exchange_sendlist);
       k_exchange_sendlist.sync<LMPHostType>();
 
       // when atom is deleted, fill it in with last atom


### PR DESCRIPTION
**Summary**

Replace some of the less performant `Kokkos::BinSort` instances in LAMMPS with `Kokkos::sort` which can use fast GPU algorithms from Thrust and rocThrust. 

**Related Issue(s)**

https://github.com/lammps/lammps/issues/4075, https://github.com/lammps/lammps/pull/4079

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes