### PR TITLE
Later than last minute bugfix in EAM density warning for OPENMP package

### DIFF
--- a/src/OPENMP/pair_eam_omp.h
+++ b/src/OPENMP/pair_eam_omp.h
@@ -39,7 +39,7 @@ class PairEAMOMP : public PairEAM, public ThrOMP {
 
  private:
   template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
-  void eval(int iifrom, int iito, ThrData *const thr);
+  void eval(int iifrom, int iito, int *beyond_rhomax, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS


### PR DESCRIPTION

This avoids MPI communication from threaded regions which in turn can lead to LAMMPS hanging or crashing.
