### PR TITLE
flag output for compute count/type as intensive vs extensive

### DIFF
--- a/.github/workflows/unittest-macos.yml
+++ b/.github/workflows/unittest-macos.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: MacOS Unit Test
     if: ${{ github.repository == 'lammps/lammps' }}
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
 

--- a/.github/workflows/unittest-macos.yml
+++ b/.github/workflows/unittest-macos.yml
@@ -43,8 +43,10 @@ jobs:
       working-directory: build
       run: |
         ccache -z
-        python3 -m pip install --user numpy
-        python3 -m pip install --user pyyaml
+        python3 -m venv macosenv
+        source macosenv/bin/activate
+        python3 -m pip install numpy
+        python3 -m pip install pyyaml
         cmake -C ../cmake/presets/clang.cmake \
               -C ../cmake/presets/most.cmake \
               -D DOWNLOAD_POTENTIALS=off \

--- a/.github/workflows/unittest-macos.yml
+++ b/.github/workflows/unittest-macos.yml
@@ -43,8 +43,8 @@ jobs:
       working-directory: build
       run: |
         ccache -z
-        python3 -m pip install numpy
-        python3 -m pip install pyyaml
+        python3 -m pip install --user numpy
+        python3 -m pip install --user pyyaml
         cmake -C ../cmake/presets/clang.cmake \
               -C ../cmake/presets/most.cmake \
               -D DOWNLOAD_POTENTIALS=off \

--- a/doc/src/compute_count_type.rst
+++ b/doc/src/compute_count_type.rst
@@ -12,7 +12,7 @@ Syntax
 
 * ID, group-ID are documented in :doc:`compute <compute>` command
 * count/type = style name of this compute command
-* mode = {atom} or {bond} or {angle} or {dihedral} or {improper}
+* mode = *atom* or *bond* or *angle* or *dihedral* or *improper*
 
 Examples
 """"""""
@@ -69,29 +69,29 @@ for each type:
 
 ----------
 
-If the {mode} setting is {atom} then the count of atoms for each atom
+If the *mode* setting is *atom* then the count of atoms for each atom
 type is tallied.  Only atoms in the specified group are counted.
 
-If the {mode} setting is {bond} then the count of bonds for each bond
+If the *mode* setting is *bond* then the count of bonds for each bond
 type is tallied.  Only bonds with both atoms in the specified group
 are counted.
 
-For {mode} = {bond}, broken bonds with a bond type of zero are also
+For *mode* = *bond*, broken bonds with a bond type of zero are also
 counted.  The :doc:`bond_style quartic <bond_quartic>` and :doc:`BPM
 bond styles <Howto_bpm>` break bonds by doing this.  See the :doc:`
 Howto broken bonds <Howto_broken_bonds>` doc page for more details.
 Note that the group setting is ignored for broken bonds; all broken
 bonds in the system are counted.
 
-If the {mode} setting is {angle} then the count of angles for each
+If the *mode* setting is *angle* then the count of angles for each
 angle type is tallied.  Only angles with all 3 atoms in the specified
 group are counted.
 
-If the {mode} setting is {dihedral} then the count of dihedrals for
+If the *mode* setting is *dihedral* then the count of dihedrals for
 each dihedral type is tallied.  Only dihedrals with all 4 atoms in the
 specified group are counted.
 
-If the {mode} setting is {improper} then the count of impropers for
+If the *mode* setting is *improper* then the count of impropers for
 each improper type is tallied.  Only impropers with all 4 atoms in the
 specified group are counted.
 
@@ -101,11 +101,11 @@ Output info
 """""""""""
 
 This compute calculates a global vector of counts.  If the mode is
-{atom} or {bond} or {angle} or {dihedral} or {improper}, then the
+*atom* or *bond* or *angle* or *dihedral* or *improper*, then the
 vector length is the number of atom types or bond types or angle types
 or dihedral types or improper types, respectively.
 
-If the mode is {bond} this compute also calculates a global scalar
+If the mode is *bond* this compute also calculates a global scalar
 which is the number of broken bonds with type = 0, as explained above.
 
 These values can be used by any command that uses global scalar or

--- a/doc/src/compute_count_type.rst
+++ b/doc/src/compute_count_type.rst
@@ -78,8 +78,8 @@ are counted.
 
 For *mode* = *bond*, broken bonds with a bond type of zero are also
 counted.  The :doc:`bond_style quartic <bond_quartic>` and :doc:`BPM
-bond styles <Howto_bpm>` break bonds by doing this.  See the :doc:`
-Howto broken bonds <Howto_broken_bonds>` doc page for more details.
+bond styles <Howto_bpm>` break bonds by doing this.  See the
+:doc:`Howto broken bonds <Howto_broken_bonds>` doc page for more details.
 Note that the group setting is ignored for broken bonds; all broken
 bonds in the system are counted.
 

--- a/doc/src/compute_count_type.rst
+++ b/doc/src/compute_count_type.rst
@@ -80,7 +80,7 @@ atoms like so:
    compute typevec all count/type atom # number of atoms of each type
    variable normtypes vector c_typevec/atoms # divide by total number of atoms
    variable ntypes equal extract_setting(ntypes) # number of atom types
-   thermo_style custom step v_normtypes[*$(v_ntypes)] # vector variable needs upper limit
+   thermo_style custom step v_normtypes[*${ntypes}] # vector variable needs upper limit
 
 Similarly, bond counts can be normalized by the total number of bonds.
 The same goes for angles, dihedrals, and impropers (see below).

--- a/doc/src/compute_count_type.rst
+++ b/doc/src/compute_count_type.rst
@@ -112,7 +112,8 @@ These values can be used by any command that uses global scalar or
 vector values from a compute as input.  See the :doc:`Howto output
 <Howto_output>` page for an overview of LAMMPS output options.
 
-The scalar and vector values calculated by this compute are "extensive".
+The scalar and vector values returned by this compute are non-negative
+integers.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_count_type.rst
+++ b/doc/src/compute_count_type.rst
@@ -72,6 +72,19 @@ for each type:
 If the *mode* setting is *atom* then the count of atoms for each atom
 type is tallied.  Only atoms in the specified group are counted.
 
+The atom count for each type can be normalized by the total number of
+atoms like so:
+
+.. code-block:: LAMMPS
+
+   compute typevec all count/type atom # number of atoms of each type
+   variable normtypes vector c_typevec/atoms # divide by total number of atoms
+   variable ntypes equal extract_setting(ntypes) # number of atom types
+   thermo_style custom step v_normtypes[*$(v_ntypes)] # vector variable needs upper limit
+
+Similarly, bond counts can be normalized by the total number of bonds.
+The same goes for angles, dihedrals, and impropers (see below).
+
 If the *mode* setting is *bond* then the count of bonds for each bond
 type is tallied.  Only bonds with both atoms in the specified group
 are counted.
@@ -112,8 +125,8 @@ These values can be used by any command that uses global scalar or
 vector values from a compute as input.  See the :doc:`Howto output
 <Howto_output>` page for an overview of LAMMPS output options.
 
-The scalar and vector values returned by this compute are non-negative
-integers.
+The scalar and vector values calculated by this compute are both
+"intensive".
 
 Restrictions
 """"""""""""

--- a/doc/src/fix_atom_swap.rst
+++ b/doc/src/fix_atom_swap.rst
@@ -168,7 +168,7 @@ the following global cumulative quantities:
 * 1 = swap attempts
 * 2 = swap accepts
 
-The vector values calculated by this fix are "extensive".
+The vector values calculated by this fix are "intensive".
 
 No parameter of this fix can be used with the *start/stop* keywords of
 the :doc:`run <run>` command.  This fix is not invoked during

--- a/doc/src/fix_gcmc.rst
+++ b/doc/src/fix_gcmc.rst
@@ -427,7 +427,7 @@ the following global cumulative quantities:
 * 7 = rotation attempts
 * 8 = rotation successes
 
-The vector values calculated by this fix are "extensive".
+The vector values calculated by this fix are "intensive".
 
 No parameter of this fix can be used with the *start/stop* keywords of
 the :doc:`run <run>` command.  This fix is not invoked during

--- a/doc/src/fix_hyper_local.rst
+++ b/doc/src/fix_hyper_local.rst
@@ -512,8 +512,7 @@ Value 27 computes the average boost for biased bonds only on this step.
 Value 28 is the count of bonds with an absolute value of strain >= q
 on this step.
 
-The scalar value is an "extensive" quantity since it grows with the
-system size; the vector values are all "intensive".
+The scalar value and vector values are all "intensive".
 
 This fix also computes a local vector of length the number of bonds
 currently in the system.  The value for each bond is its :math:`C_{ij}`

--- a/doc/src/fix_mol_swap.rst
+++ b/doc/src/fix_mol_swap.rst
@@ -146,7 +146,7 @@ the following global cumulative quantities:
 * 1 = swap attempts
 * 2 = swap accepts
 
-The vector values calculated by this fix are "extensive".
+The vector values calculated by this fix are "intensive".
 
 No parameter of this fix can be used with the *start/stop* keywords of
 the :doc:`run <run>` command.  This fix is not invoked during

--- a/doc/src/fix_sgcmc.rst
+++ b/doc/src/fix_sgcmc.rst
@@ -148,6 +148,8 @@ components of the vector represent the following quantities:
 * ...
 * N+2: The current global concentration of species *X* (= number of atoms of type *N* / total number of atoms)
 
+The vector values calculated by this fix are "intensive".
+
 Restrictions
 """"""""""""
 

--- a/doc/src/fix_widom.rst
+++ b/doc/src/fix_widom.rst
@@ -179,7 +179,7 @@ the following global cumulative quantities:
 * 2 = average difference in potential energy on each timestep
 * 3 = volume of the insertion region
 
-The vector values calculated by this fix are "extensive".
+The vector values calculated by this fix are "intensive".
 
 No parameter of this fix can be used with the *start/stop* keywords of
 the :doc:`run <run>` command.  This fix is not invoked during

--- a/src/EXTRA-FIX/fix_spring_rg.cpp
+++ b/src/EXTRA-FIX/fix_spring_rg.cpp
@@ -46,6 +46,7 @@ FixSpringRG::FixSpringRG(LAMMPS *lmp, int narg, char **arg) :
 
   restart_global = 1;
   scalar_flag = 1;
+  extscalar = 0;
   restart_global = 1;
   dynamic_group_allow = 1;
   respa_level_support = 1;

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -59,6 +59,7 @@ FixPour::FixPour(LAMMPS *lmp, int narg, char **arg) :
   if (lmp->kokkos) error->all(FLERR, "Cannot yet use fix pour with the KOKKOS package");
 
   scalar_flag = 1;
+  extscalar = 0;
   time_depend = 1;
 
   if (!atom->radius_flag || !atom->rmass_flag)

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -63,6 +63,7 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
   create_attribute = 1;
   dof_flag = 1;
   scalar_flag = 1;
+  extscalar = 1;
   stores_ids = 1;
   centroidstressflag = CENTROID_AVAIL;
   next_output = -1;

--- a/src/VORONOI/compute_voronoi_atom.cpp
+++ b/src/VORONOI/compute_voronoi_atom.cpp
@@ -126,6 +126,7 @@ ComputeVoronoi::ComputeVoronoi(LAMMPS *lmp, int narg, char **arg) :
 
   if (maxedge > 0) {
     vector_flag = 1;
+    extvector = 0;
     size_vector = maxedge+1;
     memory->create(edge,maxedge+1,"voronoi/atom:edge");
     memory->create(sendvector,maxedge+1,"voronoi/atom:sendvector");

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -121,8 +121,8 @@ void Compute::init_flags()
   if (scalar_flag && (extscalar < 0))
     error->all(FLERR, "Must set 'extscalar' when setting 'scalar_flag' for compute {}.  "
                "Contact the developer.", style);
-  if (vector_flag && (extvector < 0))
-    error->all(FLERR, "Must set 'extvector' when setting 'vector_flag' for compute {}.  "
+  if (vector_flag && (extvector < 0) && !extlist)
+    error->all(FLERR, "Must set 'extvector' or 'extlist' when setting 'vector_flag' for compute {}.  "
                "Contact the developer.", style);
   if (array_flag && (extarray < 0))
     error->all(FLERR, "Must set 'extarray' when setting 'array_flag' for compute {}.  "

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -59,6 +59,7 @@ Compute::Compute(LAMMPS *lmp, int narg, char **arg) :
   // set child class defaults
 
   scalar_flag = vector_flag = array_flag = 0;
+  extscalar = extvector = extarray = -1;
   peratom_flag = local_flag = pergrid_flag = 0;
   size_vector_variable = size_array_rows_variable = 0;
 
@@ -116,6 +117,16 @@ void Compute::init_flags()
   initialized_flag = 1;
   invoked_scalar = invoked_vector = invoked_array = -1;
   invoked_peratom = invoked_local = -1;
+
+  if (scalar_flag && (extscalar < 0))
+    error->all(FLERR, "Must set 'extscalar' when setting 'scalar_flag' for compute {}.  "
+               "Contact the developer.", style);
+  if (vector_flag && (extvector < 0))
+    error->all(FLERR, "Must set 'extvector' when setting 'vector_flag' for compute {}.  "
+               "Contact the developer.", style);
+  if (array_flag && (extarray < 0))
+    error->all(FLERR, "Must set 'extarray' when setting 'array_flag' for compute {}.  "
+               "Contact the developer.", style);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_count_type.cpp
+++ b/src/compute_count_type.cpp
@@ -62,24 +62,24 @@ ComputeCountType::ComputeCountType(LAMMPS *lmp, int narg, char **arg) :
   if (mode == ATOM) {
     vector_flag = 1;
     size_vector = atom->ntypes;
-    extvector = 1;
+    extvector = 0;
   } else if (mode == BOND) {
     scalar_flag = vector_flag = 1;
     size_vector = atom->nbondtypes;
-    extscalar = 1;
-    extvector = 1;
+    extscalar = 0;
+    extvector = 0;
   } else if (mode == ANGLE) {
     vector_flag = 1;
     size_vector = atom->nangletypes;
-    extvector = 1;
+    extvector = 0;
   } else if (mode == DIHEDRAL) {
     vector_flag = 1;
     size_vector = atom->ndihedraltypes;
-    extvector = 1;
+    extvector = 0;
   } else if (mode == IMPROPER) {
     vector_flag = 1;
     size_vector = atom->nimpropertypes;
-    extvector = 1;
+    extvector = 0;
   }
 
   // output vector

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -134,8 +134,8 @@ void Fix::init_flags()
    if (scalar_flag && (extscalar < 0))
     error->all(FLERR, "Must set 'extscalar' when setting 'scalar_flag' for fix {}.  "
                "Contact the developer.", style);
-  if (vector_flag && (extvector < 0))
-    error->all(FLERR, "Must set 'extvector' when setting 'vector_flag' for fix {}.  "
+  if (vector_flag && (extvector < 0) && !extlist)
+    error->all(FLERR, "Must set 'extvector' or 'extlist' when setting 'vector_flag' for fix {}.  "
                "Contact the developer.", style);
   if (array_flag && (extarray < 0))
     error->all(FLERR, "Must set 'extarray' when setting 'array_flag' for fix {}.  "

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -81,6 +81,7 @@ Fix::Fix(LAMMPS *lmp, int /*narg*/, char **arg) :
   diam_flag = 0;
 
   scalar_flag = vector_flag = array_flag = 0;
+  extscalar = extvector = extarray = -1;
   peratom_flag = local_flag = pergrid_flag = 0;
   global_freq = local_freq = peratom_freq = pergrid_freq = -1;
   size_vector_variable = size_array_rows_variable = 0;
@@ -119,11 +120,26 @@ Fix::~Fix()
 {
   if (copymode) return;
 
-  delete [] id;
-  delete [] style;
+  delete[] id;
+  delete[] style;
   memory->destroy(eatom);
   memory->destroy(vatom);
   memory->destroy(cvatom);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Fix::init_flags()
+{
+   if (scalar_flag && (extscalar < 0))
+    error->all(FLERR, "Must set 'extscalar' when setting 'scalar_flag' for fix {}.  "
+               "Contact the developer.", style);
+  if (vector_flag && (extvector < 0))
+    error->all(FLERR, "Must set 'extvector' when setting 'vector_flag' for fix {}.  "
+               "Contact the developer.", style);
+  if (array_flag && (extarray < 0))
+    error->all(FLERR, "Must set 'extarray' when setting 'array_flag' for fix {}.  "
+               "Contact the developer.", style);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/fix.h
+++ b/src/fix.h
@@ -145,6 +145,7 @@ class Fix : protected Pointers {
 
   virtual void post_constructor() {}
   virtual void init() {}
+  void init_flags();
   virtual void init_list(int, class NeighList *) {}
   virtual void setup(int) {}
   virtual void setup_pre_exchange() {}

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -54,6 +54,7 @@ FixDeposit::FixDeposit(LAMMPS *lmp, int narg, char **arg) :
   if (narg < 7) error->all(FLERR,"Illegal fix deposit command");
 
   scalar_flag = 1;
+  extscalar = 0;
   restart_global = 1;
   time_depend = 1;
 

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -188,6 +188,8 @@ void Modify::init()
   //   since any of them may be invoked by initial thermo
   // do not clear out invocation times stored within a compute,
   //   b/c some may be holdovers from previous run, like for ave fixes
+  // perform check whether extscalar, extvector, and extarray have been
+  //   set when scalar_flag, vector_flag, or array_flag are true.
 
   for (i = 0; i < ncompute; i++) {
     compute[i]->init();
@@ -200,8 +202,13 @@ void Modify::init()
   //   used to b/c temperature computes called fix->dof() in their init,
   //   and fix rigid required its own init before its dof() could be called,
   //   but computes now do their DOF in setup()
+  // perform check whether extscalar, extvector, and extarray have been
+  //   set when scalar_flag, vector_flag, or array_flag are true.
 
-  for (i = 0; i < nfix; i++) fix[i]->init();
+  for (i = 0; i < nfix; i++) {
+    fix[i]->init();
+    fix[i]->init_flags();
+  }
 
   // set global flag if any fix has its restart_pbc flag set
 

--- a/unittest/cplusplus/test_advanced_utils.cpp
+++ b/unittest/cplusplus/test_advanced_utils.cpp
@@ -121,6 +121,7 @@ TEST_F(Advanced_utils, expand_args)
     command("fix 2 all nve");
     command("run 1 post no");
     auto output = END_CAPTURE_OUTPUT();
+    if (verbose) std::cout << output << std::endl;
 
     char **args, **earg;
     constexpr int oarg = 9;

--- a/unittest/cplusplus/test_advanced_utils.cpp
+++ b/unittest/cplusplus/test_advanced_utils.cpp
@@ -110,16 +110,31 @@ TEST_F(Advanced_utils, expand_args)
 {
     atomic_system();
     BEGIN_CAPTURE_OUTPUT();
-    command("compute temp all temp");
-    command("variable temp vector c_temp");
-    command("variable step equal step");
-    command("variable pe equal pe");
-    command("variable pe equal pe");
-    command("variable epair equal epair");
-    command("compute gofr all rdf 20 1 1 1 2");
-    command("fix 1 all ave/time 1 1 1 v_step v_pe v_epair");
-    command("fix 2 all nve");
-    command("run 1 post no");
+    try {
+        command("compute temp all temp");
+        command("variable temp vector c_temp");
+        command("variable step equal step");
+        command("variable pe equal pe");
+        command("variable pe equal pe");
+        command("variable epair equal epair");
+        command("compute gofr all rdf 20 1 1 1 2");
+        command("fix 1 all ave/time 1 1 1 v_step v_pe v_epair");
+        command("fix 2 all nve");
+        command("run 1 post no");
+    } catch (LAMMPSAbortException &ae) {
+        fprintf(stderr, "LAMMPS Error: %s\n", ae.what());
+        exit(2);
+    } catch (LAMMPSException &e) {
+        fprintf(stderr, "LAMMPS Error: %s\n", e.what());
+        exit(3);
+    } catch (fmt::format_error &fe) {
+        fprintf(stderr, "fmt::format_error: %s\n", fe.what());
+        exit(4);
+    } catch (std::exception &e) {
+        fprintf(stderr, "General exception: %s\n", e.what());
+        exit(5);
+    }
+
     auto output = END_CAPTURE_OUTPUT();
     if (verbose) std::cout << output << std::endl;
 


### PR DESCRIPTION
**Summary**

flag output for compute count/type as intensive so that non-negative integers are printed by the 'thermo' command when counting atom, bond, etc. types when using LJ units

**Related Issue(s)**

none

**Author(s)**

Jake

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No. Previously, atom, bond, angles, dihedral and improper counts were normalized by natoms when using LJ units.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


