### PR TITLE
Fix Inconsistent syntax for dump_modify triclinic/general

### DIFF
--- a/src/dump_atom.cpp
+++ b/src/dump_atom.cpp
@@ -166,11 +166,11 @@ int DumpAtom::modify_param(int narg, char **arg)
   }
 
   if (strcmp(arg[0],"triclinic/general") == 0) {
-    triclinic_general = 1;
+    if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
+    triclinic_general = utils::logical(FLERR,arg[1],false,lmp);
     if (triclinic_general && !domain->triclinic_general)
-      error->all(FLERR,"Dump_modify triclinic/general cannot be used "
-                 "if simulation box is not general triclinic");
-    return 1;
+      error->all(FLERR,"Dump_modify triclinic/general invalid b/c simulation box is not");
+    return 2;
   }
 
   return 0;

--- a/src/dump_atom.cpp
+++ b/src/dump_atom.cpp
@@ -169,7 +169,8 @@ int DumpAtom::modify_param(int narg, char **arg)
     if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
     triclinic_general = utils::logical(FLERR,arg[1],false,lmp);
     if (triclinic_general && !domain->triclinic_general)
-      error->all(FLERR,"Dump_modify triclinic/general invalid b/c simulation box is not");
+      error->all(FLERR,"Dump_modify triclinic/general cannot be used "
+                 "if simulation box is not general triclinic");
     return 2;
   }
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -1766,7 +1766,8 @@ int DumpCustom::modify_param(int narg, char **arg)
     if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
     triclinic_general = utils::logical(FLERR,arg[1],false,lmp);
     if (triclinic_general && !domain->triclinic_general)
-      error->all(FLERR,"Dump_modify triclinic/general invalid b/c simulation box is not");
+      error->all(FLERR,"Dump_modify triclinic/general cannot be used "
+                 "if simulation box is not general triclinic");
     return 2;
   }
 


### PR DESCRIPTION
**Summary**

Applying the `dump_modify 1 triclinic/general` setting should work identically for both the atom and the custom dump style. Right now, one needs to set: `dump_modify 1 triclinic/general` when dump 1 references an atom dump style and `dump_modify 1 triclinic/general yes` when using a custom dump style.

This pr fixes this inconsistent syntax and enforces the verbose `dump_modify 1 triclinic/general yes`

**Related Issue(s)**

Fixes #4151 

**Author(s)**

Daniel Utt (utt@ovito.org)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes, this will break backwards comparability with the recently introduced `dump_modify 1 triclinic/general yes` setting. However, it will lead to matching syntax for `custom` and `atomic` dump formats.

One could implement this as a non-breaking change, however, this might lead to confusion on the user side with `dump_modify 1 triclinic/general` and `dump_modify 1 triclinic/general yes` both being valid syntax.

The proposed change enforces a more verbose and clear syntax.  

**Implementation Notes**

Mirror the implementation of the `modify_param` parsing used in `dump_custom.cpp:1765` in `dump_atom.cpp`. 

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

