### PR TITLE
Add --break-system-packages to avoid error

### DIFF
--- a/.github/workflows/unittest-macos.yml
+++ b/.github/workflows/unittest-macos.yml
@@ -43,8 +43,8 @@ jobs:
       working-directory: build
       run: |
         ccache -z
-        python3 -m pip install numpy
-        python3 -m pip install pyyaml
+        python3 -m pip install numpy --break-system-packages
+        python3 -m pip install pyyaml --break-system-packages
         cmake -C ../cmake/presets/clang.cmake \
               -C ../cmake/presets/most.cmake \
               -D DOWNLOAD_POTENTIALS=off \


### PR DESCRIPTION

**Summary**

The macos unit test has been failing consistently during setup phase with the following error:

```
Run ccache -z
  ccache -z
  python3 -m pip install numpy
  python3 -m pip install pyyaml
  cmake -C ../cmake/presets/clang.cmake \
        -C ../cmake/presets/most.cmake \
        -D DOWNLOAD_POTENTIALS=off \
        -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
        -D CMAKE_C_COMPILER_LAUNCHER=ccache \
        -D ENABLE_TESTING=on \
        -D BUILD_SHARED_LIBS=on \
        -D LAMMPS_EXCEPTIONS=on \
        ../cmake
  cmake --build . --parallel 2
  ccache -s
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    CCACHE_DIR: /Users/runner/work/lammps/lammps/.ccache
Statistics zeroed
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
    ...
```

See some examples from the past week:
https://github.com/lammps/lammps/actions/runs/8952438293/job/24589820329
https://github.com/lammps/lammps/actions/runs/8890865921/job/24445162516
https://github.com/lammps/lammps/actions/runs/8952438293/job/24589820329
https://github.com/lammps/lammps/actions/runs/8946276753/job/24576650888
https://github.com/lammps/lammps/actions/runs/8919693072/job/24496311044

**Related Issue(s)**

Addresses the failing unit tests in https://github.com/lammps/lammps/pull/4152 .

**Author(s)**

Daniel Utt (utt@ovito.org)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**
Does not apply.

**Implementation Notes**

I don't know why those started failing, however, based on [this discussion](https://github.com/actions/runner-images/issues/8615#issuecomment-1773563573) I added `--break-system-packages` to the pip command and it seems to have fixed the issue.

The macos unit tests still fail during my test runs. This is unrelated to this change and stems from the respective packages, e.g.:

```
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:63: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 5.5846170213849839e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:64: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 5.6512414183738448e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:65: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 5.479222362201464e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:63: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 6.3843544596810075e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:64: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 6.3688281567327638e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:65: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 2.101835426680749e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:63: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 2.35769486314335e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:64: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 2.605527420671821e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:65: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 1.7600272964309155e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:63: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 1.6996257801195325e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:64: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 1.0299208457091245e-10 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:65: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 6.8669068207043797e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:63: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 3.6584678368308311e-11 vs 2.4999999999999998e-12
537: Google Test trace:
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:56: EXPECT_FORCES: run_forces (newton on)
537: /Users/runner/work/lammps/lammps/unittest/force-styles/test_main.cpp:64: Failure
537: Expected: (err) <= (epsilon)
537:   Actual: 5.0680451095739631e-11 vs 2.4999999999999998e-12
537: Google Test trace:
```

