### PR TITLE
Port hybrid bond topology styles to Kokkos

### DIFF
--- a/doc/src/Commands_bond.rst
+++ b/doc/src/Commands_bond.rst
@@ -72,7 +72,7 @@ OPT.
 
    * :doc:`none <angle_none>`
    * :doc:`zero <angle_zero>`
-   * :doc:`hybrid <angle_hybrid>`
+   * :doc:`hybrid (k) <angle_hybrid>`
    *
    *
    *

--- a/doc/src/bond_hybrid.rst
+++ b/doc/src/bond_hybrid.rst
@@ -1,4 +1,5 @@
 .. index:: bond_style hybrid
+.. index:: bond_style hybrid/kk
 
 bond_style hybrid command
 =========================

--- a/doc/src/bond_hybrid.rst
+++ b/doc/src/bond_hybrid.rst
@@ -3,6 +3,8 @@
 bond_style hybrid command
 =========================
 
+Accelerator Variants: *hybrid/kk*
+
 Syntax
 """"""
 
@@ -15,7 +17,7 @@ Syntax
 Examples
 """"""""
 
-.. code-block: LAMMPS
+.. code-block:: LAMMPS
 
    bond_style hybrid harmonic fene
    bond_coeff 1 harmonic 80.0 1.2
@@ -57,6 +59,10 @@ A bond style of *none* with no additional coefficients can be used in
 place of a bond style, either in a input script bond_coeff command or
 in the data file, if you desire to turn off interactions for specific
 bond types.
+
+----------
+
+.. include:: accel_styles.rst
 
 ----------
 

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -86,6 +86,8 @@ action bond_fene_kokkos.cpp bond_fene.cpp
 action bond_fene_kokkos.h bond_fene.h
 action bond_harmonic_kokkos.cpp bond_harmonic.cpp
 action bond_harmonic_kokkos.h bond_harmonic.h
+action bond_hybrid_kokkos.cpp bond_hybrid.cpp
+action bond_hybrid_kokkos.h bond_hybrid.h
 action comm_kokkos.cpp
 action comm_kokkos.h
 action comm_tiled_kokkos.cpp

--- a/src/KOKKOS/bond_class2_kokkos.cpp
+++ b/src/KOKKOS/bond_class2_kokkos.cpp
@@ -34,6 +34,8 @@ using namespace LAMMPS_NS;
 template<class DeviceType>
 BondClass2Kokkos<DeviceType>::BondClass2Kokkos(LAMMPS *lmp) : BondClass2(lmp)
 {
+  kokkosable = 1;
+
   atomKK = (AtomKokkos *) atom;
   neighborKK = (NeighborKokkos *) neighbor;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
@@ -122,12 +124,12 @@ void BondClass2Kokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   if (eflag_atom) {
     k_eatom.template modify<DeviceType>();
-    k_eatom.template sync<LMPHostType>();
+    k_eatom.sync_host();
   }
 
   if (vflag_atom) {
     k_vatom.template modify<DeviceType>();
-    k_vatom.template sync<LMPHostType>();
+    k_vatom.sync_host();
   }
 
   copymode = 0;
@@ -227,13 +229,13 @@ void BondClass2Kokkos<DeviceType>::coeff(int narg, char **arg)
     k_r0.h_view[i] = r0[i];
   }
 
-  k_k2.template modify<LMPHostType>();
+  k_k2.modify_host();
   k_k2.template sync<DeviceType>();
-  k_k3.template modify<LMPHostType>();
+  k_k3.modify_host();
   k_k3.template sync<DeviceType>();
-  k_k4.template modify<LMPHostType>();
+  k_k4.modify_host();
   k_k4.template sync<DeviceType>();
-  k_r0.template modify<LMPHostType>();
+  k_r0.modify_host();
   k_r0.template sync<DeviceType>();
 }
 
@@ -264,13 +266,13 @@ void BondClass2Kokkos<DeviceType>::read_restart(FILE *fp)
     k_r0.h_view[i] = r0[i];
   }
 
-  k_k2.template modify<LMPHostType>();
+  k_k2.modify_host();
   k_k2.template sync<DeviceType>();
-  k_k3.template modify<LMPHostType>();
+  k_k3.modify_host();
   k_k3.template sync<DeviceType>();
-  k_k4.template modify<LMPHostType>();
+  k_k4.modify_host();
   k_k4.template sync<DeviceType>();
-  k_r0.template modify<LMPHostType>();
+  k_r0.modify_host();
   k_r0.template sync<DeviceType>();
 }
 

--- a/src/KOKKOS/bond_class2_kokkos.h
+++ b/src/KOKKOS/bond_class2_kokkos.h
@@ -59,6 +59,10 @@ class BondClass2Kokkos : public BondClass2 {
       const F_FLOAT &ebond, const F_FLOAT &fbond, const F_FLOAT &delx,
                   const F_FLOAT &dely, const F_FLOAT &delz) const;
 
+  typedef typename KKDevice<DeviceType>::value KKDeviceType;
+  Kokkos::DualView<E_FLOAT*,Kokkos::LayoutRight,KKDeviceType> k_eatom;
+  Kokkos::DualView<F_FLOAT*[6],Kokkos::LayoutRight,KKDeviceType> k_vatom;
+
  protected:
 
   class NeighborKokkos *neighborKK;
@@ -67,9 +71,6 @@ class BondClass2Kokkos : public BondClass2 {
   typename Kokkos::View<double*[3],typename AT::t_f_array::array_layout,typename KKDevice<DeviceType>::value,Kokkos::MemoryTraits<Kokkos::Atomic> > f;
   typename AT::t_int_2d bondlist;
 
-  typedef typename KKDevice<DeviceType>::value KKDeviceType;
-  Kokkos::DualView<E_FLOAT*,Kokkos::LayoutRight,KKDeviceType> k_eatom;
-  Kokkos::DualView<F_FLOAT*[6],Kokkos::LayoutRight,KKDeviceType> k_vatom;
   Kokkos::View<E_FLOAT*,Kokkos::LayoutRight,KKDeviceType,Kokkos::MemoryTraits<Kokkos::Atomic> > d_eatom;
   Kokkos::View<F_FLOAT*[6],Kokkos::LayoutRight,KKDeviceType,Kokkos::MemoryTraits<Kokkos::Atomic> > d_vatom;
 

--- a/src/KOKKOS/bond_fene_kokkos.cpp
+++ b/src/KOKKOS/bond_fene_kokkos.cpp
@@ -37,6 +37,8 @@ using MathConst::MY_CUBEROOT2;
 template<class DeviceType>
 BondFENEKokkos<DeviceType>::BondFENEKokkos(LAMMPS *lmp) : BondFENE(lmp)
 {
+  kokkosable = 1;
+
   atomKK = (AtomKokkos *) atom;
   neighborKK = (NeighborKokkos *) neighbor;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
@@ -135,12 +137,12 @@ void BondFENEKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   if (eflag_atom) {
     k_eatom.template modify<DeviceType>();
-    k_eatom.template sync<LMPHostType>();
+    k_eatom.sync_host();
   }
 
   if (vflag_atom) {
     k_vatom.template modify<DeviceType>();
-    k_vatom.template sync<LMPHostType>();
+    k_vatom.sync_host();
   }
 
   copymode = 0;
@@ -267,10 +269,10 @@ void BondFENEKokkos<DeviceType>::coeff(int narg, char **arg)
     k_sigma.h_view[i] = sigma[i];
   }
 
-  k_k.template modify<LMPHostType>();
-  k_r0.template modify<LMPHostType>();
-  k_epsilon.template modify<LMPHostType>();
-  k_sigma.template modify<LMPHostType>();
+  k_k.modify_host();
+  k_r0.modify_host();
+  k_epsilon.modify_host();
+  k_sigma.modify_host();
 }
 
 
@@ -291,10 +293,10 @@ void BondFENEKokkos<DeviceType>::read_restart(FILE *fp)
     k_sigma.h_view[i] = sigma[i];
   }
 
-  k_k.template modify<LMPHostType>();
-  k_r0.template modify<LMPHostType>();
-  k_epsilon.template modify<LMPHostType>();
-  k_sigma.template modify<LMPHostType>();
+  k_k.modify_host();
+  k_r0.modify_host();
+  k_epsilon.modify_host();
+  k_sigma.modify_host();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/bond_fene_kokkos.h
+++ b/src/KOKKOS/bond_fene_kokkos.h
@@ -58,6 +58,9 @@ class BondFENEKokkos : public BondFENE {
       const F_FLOAT &ebond, const F_FLOAT &fbond, const F_FLOAT &delx,
                   const F_FLOAT &dely, const F_FLOAT &delz) const;
 
+  DAT::tdual_efloat_1d k_eatom;
+  DAT::tdual_virial_array k_vatom;
+
  protected:
 
   class NeighborKokkos *neighborKK;
@@ -66,8 +69,6 @@ class BondFENEKokkos : public BondFENE {
   typename ArrayTypes<DeviceType>::t_f_array f;
   typename ArrayTypes<DeviceType>::t_int_2d bondlist;
 
-  DAT::tdual_efloat_1d k_eatom;
-  DAT::tdual_virial_array k_vatom;
   typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
   typename ArrayTypes<DeviceType>::t_virial_array d_vatom;
 

--- a/src/KOKKOS/bond_harmonic_kokkos.h
+++ b/src/KOKKOS/bond_harmonic_kokkos.h
@@ -37,6 +37,7 @@ class BondHarmonicKokkos : public BondHarmonic {
  public:
   typedef DeviceType device_type;
   typedef EV_FLOAT value_type;
+  typedef ArrayTypes<DeviceType> AT;
 
   BondHarmonicKokkos(class LAMMPS *);
   ~BondHarmonicKokkos() override;
@@ -62,7 +63,6 @@ class BondHarmonicKokkos : public BondHarmonic {
 
   class NeighborKokkos *neighborKK;
 
-  typedef ArrayTypes<DeviceType> AT;
   typename AT::t_x_array_randomread x;
   typename Kokkos::View<double*[3],typename AT::t_f_array::array_layout,typename KKDevice<DeviceType>::value,Kokkos::MemoryTraits<Kokkos::Atomic> > f;
   typename AT::t_int_2d bondlist;

--- a/src/KOKKOS/bond_hybrid_kokkos.cpp
+++ b/src/KOKKOS/bond_hybrid_kokkos.cpp
@@ -82,6 +82,7 @@ void BondHybridKokkos::compute(int eflag, int vflag)
     k_nbondlist.modify_device();
     k_nbondlist.sync_host();
 
+    maxbond_all = 0;
     for (int m = 0; m < nstyles; m++)
       if (h_nbondlist[m] > maxbond_all)
         maxbond_all = h_nbondlist[m] + EXTRA;

--- a/src/KOKKOS/bond_hybrid_kokkos.cpp
+++ b/src/KOKKOS/bond_hybrid_kokkos.cpp
@@ -1,0 +1,214 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "bond_hybrid_kokkos.h"
+
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "kokkos.h"
+#include "memory_kokkos.h"
+#include "neighbor_kokkos.h"
+
+#include <cstring>
+
+using namespace LAMMPS_NS;
+
+#define EXTRA 1000
+
+/* ---------------------------------------------------------------------- */
+
+BondHybridKokkos::BondHybridKokkos(LAMMPS *lmp) : BondHybrid(lmp)
+{
+  kokkosable = 1;
+
+  atomKK = (AtomKokkos *) atom;
+  neighborKK = (NeighborKokkos *) neighbor;
+
+  execution_space = Device;
+  
+  datamask_read = EMPTY_MASK;
+  datamask_modify = EMPTY_MASK;
+}
+
+/* ---------------------------------------------------------------------- */
+
+BondHybridKokkos::~BondHybridKokkos()
+{
+  deallocate();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondHybridKokkos::compute(int eflag, int vflag)
+{
+  // save ptrs to original bondlist
+
+  int nbondlist_orig = neighbor->nbondlist;
+  neighborKK->k_bondlist.sync_device();
+  auto k_bondlist_orig = neighborKK->k_bondlist;
+  auto d_bondlist_orig = k_bondlist_orig.d_view;
+  auto d_nbondlist = k_nbondlist.d_view;
+  auto h_nbondlist = k_nbondlist.h_view;
+
+  // if this is re-neighbor step, create sub-style bondlists
+  // nbondlist[] = length of each sub-style list
+  // realloc sub-style bondlist if necessary
+  // load sub-style bondlist with 3 values from original bondlist
+
+  if (neighbor->ago == 0) {
+    Kokkos::deep_copy(d_nbondlist,0);
+
+    k_map.sync_device();
+    auto d_map = k_map.d_view;
+
+    Kokkos::parallel_for(nbondlist_orig,LAMMPS_LAMBDA(int i) {
+      const int m = d_map[d_bondlist_orig(i,2)];
+      if (m >= 0) Kokkos::atomic_increment(&d_nbondlist[m]);
+    });
+
+    k_nbondlist.modify_device();
+    k_nbondlist.sync_host();
+
+    for (int m = 0; m < nstyles; m++)
+      if (h_nbondlist[m] > maxbond_all)
+        maxbond_all = h_nbondlist[m] + EXTRA;
+
+    if (k_bondlist.d_view.extent(1) < maxbond_all)
+      MemKK::realloc_kokkos(k_bondlist, "bond_hybrid:bondlist", nstyles, maxbond_all, 3);
+    auto d_bondlist = k_bondlist.d_view;
+
+    Kokkos::deep_copy(d_nbondlist,0);
+
+    Kokkos::parallel_for(nbondlist_orig,LAMMPS_LAMBDA(int i) {
+      const int m = d_map[d_bondlist_orig(i,2)];
+      if (m < 0) return;
+      const int n = Kokkos::atomic_fetch_add(&d_nbondlist[m],1);
+      d_bondlist(m,n,0) = d_bondlist_orig(i,0);
+      d_bondlist(m,n,1) = d_bondlist_orig(i,1);
+      d_bondlist(m,n,2) = d_bondlist_orig(i,2);
+    });
+  }
+
+  // call each sub-style's compute function
+  // set neighbor->bondlist to sub-style bondlist before call
+  // accumulate sub-style global/peratom energy/virial in hybrid
+
+  ev_init(eflag, vflag);
+
+  k_nbondlist.modify_device();
+  k_nbondlist.sync_host();
+
+  for (int m = 0; m < nstyles; m++) {
+    neighbor->nbondlist = h_nbondlist[m];
+    auto k_bondlist_m = Kokkos::subview(k_bondlist,m,Kokkos::ALL,Kokkos::ALL);
+    k_bondlist_m.modify_device();
+    neighborKK->k_bondlist = k_bondlist_m;
+
+    auto style = styles[m];
+    atomKK->sync(style->execution_space,style->datamask_read);
+    style->compute(eflag, vflag);
+    atomKK->modified(style->execution_space,style->datamask_modify);
+
+    if (eflag_global) energy += style->energy;
+    if (vflag_global)
+      for (int n = 0; n < 6; n++) virial[n] += style->virial[n];
+
+    if (eflag_atom) {
+      int n = atom->nlocal;
+      if (force->newton_bond) n += atom->nghost;
+      double *eatom_substyle = styles[m]->eatom;
+      for (int i = 0; i < n; i++) eatom[i] += eatom_substyle[i];
+    }
+    if (vflag_atom) {
+      int n = atom->nlocal;
+      if (force->newton_bond) n += atom->nghost;
+      double **vatom_substyle = styles[m]->vatom;
+      for (int i = 0; i < n; i++)
+        for (int j = 0; j < 6; j++) vatom[i][j] += vatom_substyle[i][j];
+    }
+  }
+
+  // restore ptrs to original bondlist
+
+  neighbor->nbondlist = nbondlist_orig;
+  neighborKK->k_bondlist = k_bondlist_orig;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondHybridKokkos::allocate()
+{
+  allocated = 1;
+  int n = atom->nbondtypes;
+
+  memoryKK->create_kokkos(k_map, map, n + 1, "bond:map");
+  memory->create(setflag, n + 1, "bond:setflag");
+  for (int i = 1; i <= n; i++) setflag[i] = 0;
+
+  k_nbondlist = DAT::tdual_int_1d("bond:nbondlist", nstyles);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondHybridKokkos::deallocate()
+{
+  if (!allocated) return;
+
+  allocated = 0;
+
+  memory->destroy(setflag);
+  memoryKK->destroy_kokkos(k_map,map);
+}
+
+/* ----------------------------------------------------------------------
+   set coeffs for one type
+---------------------------------------------------------------------- */
+
+void BondHybridKokkos::coeff(int narg, char **arg)
+{
+  BondHybrid::coeff(narg,arg);
+
+  k_map.modify_host();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondHybridKokkos::init_style()
+{
+  BondHybrid::init_style();
+
+  for (int m = 0; m < nstyles; m++) {
+    if (!styles[m]->kokkosable)
+      error->all(FLERR,"Must use only Kokkos-enabled bond styles with bond_style hybrid/kk");
+
+    if (styles[m]->execution_space == Host)
+      lmp->kokkos->allow_overlap = 0;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   memory usage
+------------------------------------------------------------------------- */
+
+double BondHybridKokkos::memory_usage()
+{
+  double bytes = (double) maxeatom * sizeof(double);
+  bytes += (double) maxvatom * 6 * sizeof(double);
+  for (int m = 0; m < nstyles; m++) bytes += (double) maxbond_all * 3 * sizeof(int);
+  for (int m = 0; m < nstyles; m++)
+    if (styles[m]) bytes += styles[m]->memory_usage();
+  return bytes;
+}

--- a/src/KOKKOS/bond_hybrid_kokkos.cpp
+++ b/src/KOKKOS/bond_hybrid_kokkos.cpp
@@ -38,7 +38,7 @@ BondHybridKokkos::BondHybridKokkos(LAMMPS *lmp) : BondHybrid(lmp)
   neighborKK = (NeighborKokkos *) neighbor;
 
   execution_space = Device;
-  
+
   datamask_read = EMPTY_MASK;
   datamask_modify = EMPTY_MASK;
 }

--- a/src/KOKKOS/bond_hybrid_kokkos.h
+++ b/src/KOKKOS/bond_hybrid_kokkos.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef BOND_CLASS
+// clang-format off
+BondStyle(hybrid/kk,BondHybridKokkos);
+BondStyle(hybrid/kk/device,BondHybridKokkos);
+BondStyle(hybrid/kk/host,BondHybridKokkos);
+// clang-format on
+#else
+
+// clang-format off
+#ifndef LMP_BOND_HYBRID_KOKKOS_H
+#define LMP_BOND_HYBRID_KOKKOS_H
+
+#include "bond_hybrid.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+class BondHybridKokkos : public BondHybrid {
+  friend class Force;
+
+ public:
+  BondHybridKokkos(class LAMMPS *);
+  ~BondHybridKokkos() override;
+  void compute(int, int) override;
+  void coeff(int, char **) override;
+  void init_style() override;
+  double memory_usage() override;
+
+ private:
+  int maxbond_all;
+
+  class NeighborKokkos *neighborKK;
+
+  DAT::tdual_int_1d k_map;       // which style each bond type points to
+  DAT::tdual_int_1d k_nbondlist; // # of bonds in sub-style bondlists
+  DAT::tdual_int_3d k_bondlist;  // bondlist for each sub-style
+
+  void allocate() override;
+  void deallocate() override;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -1408,6 +1408,7 @@ typedef SNAComplex<SNAreal> SNAcomplex;
 #endif
 
 #define LAMMPS_LAMBDA KOKKOS_LAMBDA
+#define LAMMPS_CLASS_LAMBDA KOKKOS_CLASS_LAMBDA
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 #define LAMMPS_DEVICE_FUNCTION __device__

--- a/src/KOKKOS/pair_hybrid_kokkos.cpp
+++ b/src/KOKKOS/pair_hybrid_kokkos.cpp
@@ -31,9 +31,7 @@ PairHybridKokkos::PairHybridKokkos(LAMMPS *lmp) : PairHybrid(lmp)
   kokkosable = 1;
   atomKK = (AtomKokkos *) atom;
 
- // prevent overlapping host/device computation, which isn't
- //  yet supported by pair_hybrid_kokkos
- execution_space = Device;
+  execution_space = Device;
 
   datamask_read = EMPTY_MASK;
   datamask_modify = EMPTY_MASK;

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -63,8 +63,7 @@ Bond::Bond(LAMMPS *_lmp) : Pointers(_lmp)
   execution_space = Host;
   datamask_read = ALL_MASK;
   datamask_modify = ALL_MASK;
-
-  copymode = 0;
+  copymode = kokkosable = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/bond.h
+++ b/src/bond.h
@@ -49,7 +49,7 @@ class Bond : protected Pointers {
 
   ExecutionSpace execution_space;
   unsigned int datamask_read, datamask_modify;
-  int copymode;
+  int copymode, kokkosable;
 
   Bond(class LAMMPS *);
   ~Bond() override;

--- a/src/bond_hybrid.cpp
+++ b/src/bond_hybrid.cpp
@@ -162,11 +162,11 @@ void BondHybrid::allocate()
 /* ---------------------------------------------------------------------- */
 
 void BondHybrid::deallocate()
-{ 
+{
   if (!allocated) return;
-  
+
   allocated = 0;
-  
+
   memory->destroy(setflag);
   memory->destroy(map);
   delete[] nbondlist;

--- a/src/bond_hybrid.cpp
+++ b/src/bond_hybrid.cpp
@@ -51,14 +51,7 @@ BondHybrid::~BondHybrid()
 
   delete[] svector;
 
-  if (allocated) {
-    memory->destroy(setflag);
-    memory->destroy(map);
-    delete[] nbondlist;
-    delete[] maxbond;
-    for (int i = 0; i < nstyles; i++) memory->destroy(bondlist[i]);
-    delete[] bondlist;
-  }
+  deallocate();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -166,6 +159,22 @@ void BondHybrid::allocate()
   for (int m = 0; m < nstyles; m++) bondlist[m] = nullptr;
 }
 
+/* ---------------------------------------------------------------------- */
+
+void BondHybrid::deallocate()
+{ 
+  if (!allocated) return;
+  
+  allocated = 0;
+  
+  memory->destroy(setflag);
+  memory->destroy(map);
+  delete[] nbondlist;
+  delete[] maxbond;
+  for (int i = 0; i < nstyles; i++) memory->destroy(bondlist[i]);
+  delete[] bondlist;
+}
+
 /* ----------------------------------------------------------------------
    create one bond style for each arg in list
 ------------------------------------------------------------------------- */
@@ -186,15 +195,7 @@ void BondHybrid::settings(int narg, char **arg)
     has_quartic = -1;
   }
 
-  if (allocated) {
-    memory->destroy(setflag);
-    memory->destroy(map);
-    delete[] nbondlist;
-    delete[] maxbond;
-    for (i = 0; i < nstyles; i++) memory->destroy(bondlist[i]);
-    delete[] bondlist;
-  }
-  allocated = 0;
+  deallocate();
 
   // allocate list of sub-styles
 
@@ -400,7 +401,7 @@ void BondHybrid::read_restart(FILE *fp)
     keywords[m] = new char[n];
     if (me == 0) utils::sfread(FLERR, keywords[m], sizeof(char), n, fp, nullptr, error);
     MPI_Bcast(keywords[m], n, MPI_CHAR, 0, world);
-    styles[m] = force->new_bond(keywords[m], 0, dummy);
+    styles[m] = force->new_bond(keywords[m], 1, dummy);
     styles[m]->read_restart_settings(fp);
   }
 }

--- a/src/bond_hybrid.h
+++ b/src/bond_hybrid.h
@@ -44,14 +44,15 @@ class BondHybrid : public Bond {
   double single(int, double, int, int, double &) override;
   double memory_usage() override;
 
- private:
+ protected:
   int *map;           // which style each bond type points to
   int has_quartic;    // which style, if any is a quartic bond style
   int *nbondlist;     // # of bonds in sub-style bondlists
   int *maxbond;       // max # of bonds sub-style lists can store
   int ***bondlist;    // bondlist for each sub-style
 
-  void allocate();
+  virtual void allocate();
+  virtual void deallocate();
   void flags();
 
   virtual void init_svector();


### PR DESCRIPTION
**Summary**

Port hybrid bond topology styles to Kokkos. Currently using hybrid topo with Kokkos gives wrong numerics (bug).

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL)
**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes
