### PR TITLE
Add special variable functions sort() and rsort() for sorting vectors by value

### DIFF
--- a/doc/src/variable.rst
+++ b/doc/src/variable.rst
@@ -67,7 +67,7 @@ Syntax
                            bound(group,dir,region), gyration(group,region), ke(group,reigon),
                            angmom(group,dim,region), torque(group,dim,region),
                            inertia(group,dimdim,region), omega(group,dim,region)
-         special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), gmask(x), rmask(x), grmask(x,y), next(x), is_file(name), is_os(name), extract_setting(name), label2type(kind,label), is_typelabel(kind,label)
+         special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), sort(x), rsort(x), gmask(x), rmask(x), grmask(x,y), next(x), is_file(name), is_os(name), extract_setting(name), label2type(kind,label), is_typelabel(kind,label)
          feature functions = is_available(category,feature), is_active(category,feature), is_defined(category,id)
          atom value = id[i], mass[i], type[i], mol[i], x[i], y[i], z[i], vx[i], vy[i], vz[i], fx[i], fy[i], fz[i], q[i]
          atom vector = id, mass, type, mol, radius, q, x, y, z, vx, vy, vz, fx, fy, fz
@@ -547,7 +547,7 @@ variables.
 +------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Region functions       | count(ID,IDR), mass(ID,IDR), charge(ID,IDR), xcm(ID,dim,IDR), vcm(ID,dim,IDR), fcm(ID,dim,IDR), bound(ID,dir,IDR), gyration(ID,IDR), ke(ID,IDR), angmom(ID,dim,IDR), torque(ID,dim,IDR), inertia(ID,dimdim,IDR), omega(ID,dim,IDR)                                                                                                                |
 +------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Special functions      | sum(x), min(x), max(x), ave(x), trap(x), slope(x), gmask(x), rmask(x), grmask(x,y), next(x), is_file(name), is_os(name), extract_setting(name), label2type(kind,label), is_typelabel(kind,label)                                                                                                                                                  |
+| Special functions      | sum(x), min(x), max(x), ave(x), trap(x), slope(x), sort(x), rsort(x), gmask(x), rmask(x), grmask(x,y), next(x), is_file(name), is_os(name), extract_setting(name), label2type(kind,label), is_typelabel(kind,label)                                                                                                                               |
 +------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Feature functions      | is_available(category,feature), is_active(category,feature), is_defined(category,id)                                                                                                                                                                                                                                                              |
 +------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -913,23 +913,27 @@ Special Functions
 Special functions take specific kinds of arguments, meaning their
 arguments cannot be formulas themselves.
 
-The sum(x), min(x), max(x), ave(x), trap(x), and slope(x) functions
-each take 1 argument which is of the form "c_ID" or "c_ID[N]" or
-"f_ID" or "f_ID[N]" or "v_name".  The first two are computes and the
-second two are fixes; the ID in the reference should be replaced by
-the ID of a compute or fix defined elsewhere in the input script.  The
-compute or fix must produce either a global vector or array.  If it
-produces a global vector, then the notation without "[N]" should be
-used.  If it produces a global array, then the notation with "[N]"
-should be used, when N is an integer, to specify which column of the
-global array is being referenced.  The last form of argument "v_name"
-is for a vector-style variable where "name" is replaced by the name of
-the variable.
+The sum(x), min(x), max(x), ave(x), trap(x), slope(x), sort(x), and
+rsort(x) functions each take 1 argument which is of the form "c_ID" or
+"c_ID[N]" or "f_ID" or "f_ID[N]" or "v_name".  The first two are
+computes and the second two are fixes; the ID in the reference should be
+replaced by the ID of a compute or fix defined elsewhere in the input
+script.  The compute or fix must produce either a global vector or
+array.  If it produces a global vector, then the notation without "[N]"
+should be used.  If it produces a global array, then the notation with
+"[N]" should be used, where N is an integer, to specify which column of
+the global array is being referenced.  The last form of argument
+"v_name" is for a vector-style variable where "name" is replaced by the
+name of the variable.
 
-These functions operate on a global vector of inputs and reduce it to
-a single scalar value.  This is analogous to the operation of the
-:doc:`compute reduce <compute_reduce>` command, which performs similar
-operations on per-atom and local vectors.
+The sum(x), min(x), max(x), ave(x), trap(x), and slope(x) functions
+operate on a global vector of inputs and reduce it to a single scalar
+value.  This is analogous to the operation of the :doc:`compute reduce
+<compute_reduce>` command, which performs similar operations on per-atom
+and local vectors.
+
+The sort(x) and rsort(x) functions operate on a global vector of inputs
+and return a global vector of the same length.
 
 The sum() function calculates the sum of all the vector elements.  The
 min() and max() functions find the minimum and maximum element
@@ -952,6 +956,10 @@ of points, equally spaced by 1 in their x coordinate: (1,V1), (2,V2),
 ..., (N,VN), where the Vi are the values in the global vector of
 length N.  The returned value is the slope of the line.  If the line
 has a single point or is vertical, it returns 1.0e20.
+
+The sort(x) and rsort(x) functions sort the data of the input vector by
+their numeric value: sort(x) sorts in ascending order, rsort(x) sorts
+in descending order.
 
 The gmask(x) function takes 1 argument which is a group ID.  It
 can only be used in atom-style variables.  It returns a 1 for

--- a/doc/src/variable.rst
+++ b/doc/src/variable.rst
@@ -957,6 +957,8 @@ of points, equally spaced by 1 in their x coordinate: (1,V1), (2,V2),
 length N.  The returned value is the slope of the line.  If the line
 has a single point or is vertical, it returns 1.0e20.
 
+.. versionadded:: TBD
+
 The sort(x) and rsort(x) functions sort the data of the input vector by
 their numeric value: sort(x) sorts in ascending order, rsort(x) sorts
 in descending order.

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -3252,6 +3252,7 @@ rRESPA
 Rsi
 Rso
 Rspace
+rsort
 rsq
 rst
 rstyle

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -110,12 +110,6 @@ static const int STYLES = ATOM_STYLES | INTEGRATE_STYLES | MINIMIZE_STYLES
 
 using namespace LAMMPS_NS;
 
-// must match enumerator in variable.h
-static const char *varstyles[] = {
-  "index", "loop", "world", "universe", "uloop", "string", "getenv",
-  "file", "atomfile", "format", "equal", "atom", "vector", "python",
-  "timer", "internal", "(unknown)"};
-
 static const char *mapstyles[] = { "none", "array", "hash", "yes" };
 
 static const char *commstyles[] = { "brick", "tiled" };
@@ -1401,7 +1395,7 @@ std::string Info::get_variable_info(int num) {
   std::string text;
   int ndata = 1;
   text = fmt::format("Variable[{:3d}]: {:16}  style = {:16}  def =", num,
-                     std::string(names[num]) + ',', std::string(varstyles[style[num]]) + ',');
+                     std::string(names[num]) + ',', Variable::varstyles[style[num]] + ',');
   if (style[num] == Variable::INTERNAL) {
     text += fmt::format("{:.8}\n",input->variable->dvalue[num]);
     return text;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -54,6 +54,12 @@ static constexpr int MAXLINE = 256;
 static constexpr int CHUNK = 1024;
 static constexpr int MAXFUNCARG = 6;
 
+// must match enumerator in variable.h
+const std::vector<std::string> Variable::varstyles = {
+  "index", "loop", "world", "universe", "uloop", "string", "getenv",
+  "file", "atomfile", "format", "equal", "atom", "vector", "python",
+  "timer", "internal", "(unknown)"};
+
 static inline double MYROUND(double a) { return ((a - floor(a)) >= 0.5) ? ceil(a) : floor(a); }
 
 enum{ARG,OP};

--- a/src/variable.h
+++ b/src/variable.h
@@ -143,7 +143,8 @@ class Variable : protected Pointers {
   int math_function(char *, char *, Tree **, Tree **, int &, double *, int &, int);
   int group_function(char *, char *, Tree **, Tree **, int &, double *, int &, int);
   Region *region_function(char *, int);
-  int special_function(const std::string &, char *, Tree **, Tree **, int &, double *, int &, int);
+  int special_function(const std::string &, char *, Tree **, Tree **, int &, double *, int &,
+                       int, char *, int &, char *&);
   int feature_function(char *, char *, Tree **, Tree **, int &, double *, int &, int);
   void peratom2global(int, char *, double *, int, tagint, Tree **, Tree **, int &, double *, int &);
   void custom2global(int *, double *, int, tagint, Tree **, Tree **, int &, double *, int &);

--- a/src/variable.h
+++ b/src/variable.h
@@ -56,7 +56,7 @@ class Variable : protected Pointers {
   int nvar;        // # of defined variables
   char **names;    // name of each variable
 
-  // must match "varstyles" array in info.cpp
+  // must match "varstyles" array in variables.cpp, UNKNOWN must be last.
   enum {
     INDEX,
     LOOP,
@@ -73,9 +73,11 @@ class Variable : protected Pointers {
     VECTOR,
     PYTHON,
     TIMER,
-    INTERNAL
+    INTERNAL,
+    UNKNOWN
   };
   static constexpr int VALUELENGTH = 64;
+  static const std::vector<std::string> varstyles;
 
  private:
   int me;

--- a/src/variable.h
+++ b/src/variable.h
@@ -143,7 +143,7 @@ class Variable : protected Pointers {
   int math_function(char *, char *, Tree **, Tree **, int &, double *, int &, int);
   int group_function(char *, char *, Tree **, Tree **, int &, double *, int &, int);
   Region *region_function(char *, int);
-  int special_function(char *, char *, Tree **, Tree **, int &, double *, int &, int);
+  int special_function(const std::string &, char *, Tree **, Tree **, int &, double *, int &, int);
   int feature_function(char *, char *, Tree **, Tree **, int &, double *, int &, int);
   void peratom2global(int, char *, double *, int, tagint, Tree **, Tree **, int &, double *, int &);
   void custom2global(int *, double *, int, tagint, Tree **, Tree **, int &, double *, int &);

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -340,6 +340,9 @@ TEST_F(VariableTest, Expressions)
     command("variable vec4   vector    '[1, 5, 2.5, -10, -5, 20, 120, 4, 3, 3]'");
     command("variable sort   vector    sort(v_vec4)");
     command("variable rsrt   vector    rsort(v_vec4)");
+    command("variable max2   equal     sort(v_vec4)[2]");
+    command("variable rmax   equal     rsort(v_vec4)[1]");
+    command("variable xxxl   equal     rsort(v_vec4)[11]");
     command("variable isrt   vector    sort(v_one)");
     variable->set("dummy  index     1 2");
     END_HIDE_OUTPUT();
@@ -372,6 +375,8 @@ TEST_F(VariableTest, Expressions)
     ASSERT_DOUBLE_EQ(variable->compute_equal("v_vec3"), 0.5);
     EXPECT_THAT(variable->retrieve("sort"), StrEq("[-10,-5,1,2.5,3,3,4,5,20,120]"));
     EXPECT_THAT(variable->retrieve("rsrt"), StrEq("[120,20,5,4,3,3,2.5,1,-5,-10]"));
+    ASSERT_DOUBLE_EQ(variable->compute_equal("v_max2"), -5);
+    ASSERT_DOUBLE_EQ(variable->compute_equal("v_rmax"), 120);
 
     TEST_FAILURE(".*ERROR: Variable six: Invalid thermo keyword 'XXX' in variable formula.*",
                  command("print \"${six}\""););
@@ -385,6 +390,8 @@ TEST_F(VariableTest, Expressions)
                  command("print \"${err3}\""););
     TEST_FAILURE(".*ERROR: Variable one: Mis-matched special function variable in variable formula.*",
                  command("print \"${isrt}\""););
+    TEST_FAILURE(".*ERROR: Variable vec4: index 11 exceeds vector size of 10.*",
+                 command("print \"${xxxl}\""););
 }
 
 TEST_F(VariableTest, Functions)

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -337,6 +337,10 @@ TEST_F(VariableTest, Expressions)
     command("variable vec1   vector    \"[-2, 0, 1,2 ,3, 5 ,	7\n]\"");
     command("variable vec2   vector    v_vec1*0.5");
     command("variable vec3   equal     v_vec2[3]");
+    command("variable vec4   vector    '[1, 5, 2.5, -10, -5, 20, 120, 4, 3, 3]'");
+    command("variable sort   vector    sort(v_vec4)");
+    command("variable rsrt   vector    rsort(v_vec4)");
+    command("variable isrt   vector    sort(v_one)");
     variable->set("dummy  index     1 2");
     END_HIDE_OUTPUT();
 
@@ -366,6 +370,8 @@ TEST_F(VariableTest, Expressions)
     EXPECT_THAT(variable->retrieve("vec1"), StrEq("[-2,0,1,2,3,5,7]"));
     EXPECT_THAT(variable->retrieve("vec2"), StrEq("[-1,0,0.5,1,1.5,2.5,3.5]"));
     ASSERT_DOUBLE_EQ(variable->compute_equal("v_vec3"), 0.5);
+    EXPECT_THAT(variable->retrieve("sort"), StrEq("[-10,-5,1,2.5,3,3,4,5,20,120]"));
+    EXPECT_THAT(variable->retrieve("rsrt"), StrEq("[120,20,5,4,3,3,2.5,1,-5,-10]"));
 
     TEST_FAILURE(".*ERROR: Variable six: Invalid thermo keyword 'XXX' in variable formula.*",
                  command("print \"${six}\""););
@@ -377,6 +383,8 @@ TEST_F(VariableTest, Expressions)
                  command("print \"${err2}\""););
     TEST_FAILURE(".*ERROR on proc 0: Variable err3: Invalid power expression in variable formula.*",
                  command("print \"${err3}\""););
+    TEST_FAILURE(".*ERROR: Variable one: Mis-matched special function variable in variable formula.*",
+                 command("print \"${isrt}\""););
 }
 
 TEST_F(VariableTest, Functions)


### PR DESCRIPTION
**Summary**

This pull request implements two new special functions for variables: sort(x) and rsort(x). The function sort(x) returns a vector sorted in ascending numeric value from either a compute or fix output or a vector style variable. The function rsort(x) does the same but by descending numeric value.

**Related Issue(s)**

Addresses the feature request from https://matsci.org/t/sorting-a-vector-in-lammps/55496

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

Outside of the new feature, there is also some minor refactoring done to make code simpler and (hopefully) more readable.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
