### PR TITLE
Fix issue with virtual inheritance in Kokkos deallocate_topo function

### DIFF
--- a/src/KOKKOS/atom_kokkos.h
+++ b/src/KOKKOS/atom_kokkos.h
@@ -168,7 +168,7 @@ class AtomKokkos : public Atom {
   virtual void grow(unsigned int mask);
   int add_custom(const char *, int, int, int border = 0) override;
   void remove_custom(int, int, int) override;
-  virtual void deallocate_topology();
+  void deallocate_topology() override;
 
   void map_set_device();
   void map_set_host();

--- a/src/atom.h
+++ b/src/atom.h
@@ -327,7 +327,7 @@ class Atom : protected Pointers {
 
   int parse_data(const char *);
 
-  void deallocate_topology();
+  virtual void deallocate_topology();
 
   void data_atoms(int, char *, tagint, tagint, int, int, double *, int, int *, int);
   void data_vels(int, char *, tagint);


### PR DESCRIPTION
**Summary**

Fix issue with virtual inheritance in Kokkos deallocate_topo function

**Related Issue(s)**

Fixes #4170 

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes