### PR TITLE
fix bug in expression implementation in pair_coul_slater_long.cpp

### DIFF
--- a/src/EXTRA-PAIR/pair_coul_slater_long.cpp
+++ b/src/EXTRA-PAIR/pair_coul_slater_long.cpp
@@ -326,7 +326,7 @@ double PairCoulSlaterLong::single(int i, int j, int /*itype*/, int /*jtype*/, do
   fforce = forcecoul * r2inv;
 
   phicoul = prefactor*(erfc - (1 + r/lamda)*exp(-2*r/lamda));
-  if (factor_coul < 1.0) phicoul -= (1.0-factor_coul)*prefactor;
+  if (factor_coul < 1.0) phicoul -= (1.0-factor_coul)*prefactor*(1.0-(1 + r/lamda)*exp(-2*r/lamda));
 
   return phicoul;
 }

--- a/src/EXTRA-PAIR/pair_coul_slater_long.cpp
+++ b/src/EXTRA-PAIR/pair_coul_slater_long.cpp
@@ -117,7 +117,7 @@ void PairCoulSlaterLong::compute(int eflag, int vflag)
         erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
         slater_term = exp(-2*r/lamda)*(1 + (2*r/lamda*(1+r/lamda)));
         prefactor = qqrd2e * scale[itype][jtype] * qtmp*q[j]/r;
-        forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - slater_term);
+        forcecoul = prefactor * (erfc + EWALD_F*grij*expm2)*(1 - slater_term);
         if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor*(1-slater_term);
 
         fpair = forcecoul * r2inv;
@@ -132,7 +132,7 @@ void PairCoulSlaterLong::compute(int eflag, int vflag)
         }
 
         if (eflag) {
-          ecoul = prefactor*(erfc - (1 + r/lamda)*exp(-2*r/lamda));
+          ecoul = prefactor*erfc*(1 - (1 + r/lamda)*exp(-2*r/lamda));
           if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor*(1.0-(1 + r/lamda)*exp(-2*r/lamda));
         }
 
@@ -321,12 +321,12 @@ double PairCoulSlaterLong::single(int i, int j, int /*itype*/, int /*jtype*/, do
   erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
   slater_term = exp(-2*r/lamda)*(1 + (2*r/lamda*(1+r/lamda)));
   prefactor = force->qqrd2e * atom->q[i]*atom->q[j]/r;
-  forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - slater_term);
+  forcecoul = prefactor * (erfc + EWALD_F*grij*expm2)*(1 - slater_term);
   if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
   fforce = forcecoul * r2inv;
 
-  phicoul = prefactor*(erfc - (1 + r/lamda)*exp(-2*r/lamda));
-  if (factor_coul < 1.0) phicoul -= (1.0-factor_coul)*prefactor*(1.0-(1 + r/lamda)*exp(-2*r/lamda));
+  phicoul = prefactor*erfc*(1 - (1 + r/lamda)*exp(-2*r/lamda));
+  if (factor_coul < 1.0) phicoul -= (1.0-factor_coul)*prefactor*(1 - (1 + r/lamda)*exp(-2*r/lamda));
 
   return phicoul;
 }


### PR DESCRIPTION
**Summary**

The expressions in previous pair_coul_slater_long.cpp were implemented wrong. The Slater correction should not be reduced from the erfc term. Instead it should be used as a fractional correction for forcecoul and ecoul. If you measure the pair interaction energy using the previous implementation, two opposite charges would give you a positive pair interaction energy, which is apparently wrong. 

**Author(s)**

Yinhan Wang, Johns Hopkins University, ywang268@jhu.edu

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Implementation Notes**
corrected forcecoul and ecoul computation in ::compute, and forcecoul and phicoul in ::single. Added an missing correction term in line 329 for phicoul.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

Please use the following script for measuring the pair interaction energy:

input.data
```

2 atoms
1 atom types

-30 30 xlo xhi
-30 30 ylo yhi
-30 30 zlo zhi

Masses

1 1

Atoms

1 1 1 1 0 0 0
2 2 1 -1 0.5 0 0
```

test.lmps
```
units lj
atom_style full
boundary p p p

pair_style coul/slater/long 1.185307217552 2.0
bond_style harmonic
angle_style cosine/squared
dihedral_style charmm
improper_style harmonic
kspace_style pppm 1.0e-2

read_data input.data
pair_coeff * * coul/slater/long
velocity all create 1.0 4580 dist gaussian
comm_modify vel yes
group g1 id 1
group g2 id 2
neigh_modify delay 0 check yes

thermo 1000
thermo_modify lost warn flush yes
thermo_style custom step ke pe epair etotal temp press

timestep 0.01
run_style verlet

fix 1 all nve
fix 2 all rigid/nvt single temp 1.0 1.0 0.1 reinit no

compute 1 g1 group/group g2 molecule inter
variable e1 equal c_1
fix 1000 all ave/time 1000 1 1000 v_e1 file energy.out

run 2000
unfix 1
unfix 2
```

