### PR TITLE
Add support for extracting a few more properties and the Atom::map() function to the library interface

### DIFF
--- a/doc/src/Fortran.rst
+++ b/doc/src/Fortran.rst
@@ -305,6 +305,8 @@ of the contents of the :f:mod:`LIBLAMMPS` Fortran interface to LAMMPS.
    :ftype extract_setting: function
    :f extract_global: :f:func:`extract_global`
    :ftype extract_global: function
+   :f map_atom: :f:func:`map_atom`
+   :ftype map_atom: function
    :f extract_atom: :f:func:`extract_atom`
    :ftype extract_atom: function
    :f extract_compute: :f:func:`extract_compute`

--- a/doc/src/Library_properties.rst
+++ b/doc/src/Library_properties.rst
@@ -13,6 +13,7 @@ This section documents the following functions:
 - :cpp:func:`lammps_extract_setting`
 - :cpp:func:`lammps_extract_global_datatype`
 - :cpp:func:`lammps_extract_global`
+- :cpp:func:`lammps_map_atom`
 
 --------------------
 
@@ -118,5 +119,10 @@ subdomains and processors.
 -----------------------
 
 .. doxygenfunction:: lammps_extract_global
+   :project: progguide
+
+-----------------------
+
+.. doxygenfunction:: lammps_map_atom
    :project: progguide
 

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -992,6 +992,7 @@ emax
 Emax
 Embt
 emi
+Emilie
 Emmrich
 emol
 eN
@@ -1763,6 +1764,7 @@ keflag
 Keir
 Kelchner
 Kelkar
+Kemppainen
 Kemper
 kepler
 keV
@@ -2483,6 +2485,7 @@ Nevery
 newfile
 Newns
 newtype
+nextsort
 Neyts
 Nf
 nfft
@@ -2672,6 +2675,7 @@ nzlo
 ocl
 octahedral
 octants
+Odegard
 Ohara
 O'Hearn
 ohenrich
@@ -3287,6 +3291,7 @@ Saidi
 saip
 Salanne
 Salles
+sametag
 sandia
 Sandia
 sandybrown
@@ -3404,6 +3409,7 @@ sinh
 sinusoid
 sinusoidally
 SiO
+Siochi
 Sirk
 Sival
 sizeI
@@ -3451,6 +3457,7 @@ solvated
 solvation
 someuser
 Sorensen
+sortfreq
 soundspeed
 sourceforge
 Souza
@@ -4149,6 +4156,7 @@ yy
 yz
 Zagaceta
 Zannoni
+Zavada
 Zavattieri
 zbl
 ZBL

--- a/examples/COUPLE/plugin/liblammpsplugin.c
+++ b/examples/COUPLE/plugin/liblammpsplugin.c
@@ -101,6 +101,7 @@ liblammpsplugin_t *liblammpsplugin_load(const char *lib)
   ADDSYM(extract_setting);
   ADDSYM(extract_global_datatype);
   ADDSYM(extract_global);
+  ADDSYM(map_atom);
 
   ADDSYM(extract_atom_datatype);
   ADDSYM(extract_atom);

--- a/examples/COUPLE/plugin/liblammpsplugin.h
+++ b/examples/COUPLE/plugin/liblammpsplugin.h
@@ -146,6 +146,7 @@ struct _liblammpsplugin {
   int (*extract_setting)(void *, const char *);
   int *(*extract_global_datatype)(void *, const char *);
   void *(*extract_global)(void *, const char *);
+  void *(*map_atom)(void *, const void *);
 
   int *(*extract_atom_datatype)(void *, const char *);
   void *(*extract_atom)(void *, const char *);

--- a/fortran/lammps.f90
+++ b/fortran/lammps.f90
@@ -1364,7 +1364,7 @@ CONTAINS
     END IF
     lmp_map_atom_big = lammps_map_atom(self%handle, Cptr) + 1
   END FUNCTION lmp_map_atom_big
-  
+
   ! equivalent function to lammps_extract_atom
   ! the assignment is actually overloaded so as to bind the pointers to
   ! lammps data based on the information available from LAMMPS

--- a/fortran/lammps.f90
+++ b/fortran/lammps.f90
@@ -113,6 +113,9 @@ MODULE LIBLAMMPS
     PROCEDURE :: get_mpi_comm           => lmp_get_mpi_comm
     PROCEDURE :: extract_setting        => lmp_extract_setting
     PROCEDURE :: extract_global         => lmp_extract_global
+    PROCEDURE, PRIVATE :: lmp_map_atom_int
+    PROCEDURE, PRIVATE :: lmp_map_atom_big
+    GENERIC :: map_atom               => lmp_map_atom_int, lmp_map_atom_big
     PROCEDURE :: extract_atom           => lmp_extract_atom
     PROCEDURE :: extract_compute        => lmp_extract_compute
     PROCEDURE :: extract_fix            => lmp_extract_fix
@@ -507,6 +510,13 @@ MODULE LIBLAMMPS
       TYPE(c_ptr), INTENT(IN), VALUE :: handle, name
       TYPE(c_ptr) :: lammps_extract_global
     END FUNCTION lammps_extract_global
+
+    FUNCTION lammps_map_atom(handle, tag) BIND(C)
+      IMPORT :: c_ptr, c_int
+      IMPLICIT NONE
+      TYPE(c_ptr), INTENT(IN), VALUE :: handle, tag
+      INTEGER(c_int) :: lammps_map_atom
+    END FUNCTION lammps_map_atom
 
     FUNCTION lammps_extract_atom_datatype(handle, name) BIND(C)
       IMPORT :: c_ptr, c_int
@@ -1323,6 +1333,38 @@ CONTAINS
     END SELECT
   END FUNCTION
 
+  ! equivalent function to lammps_map_atom (for 32-bit integer tags)
+  INTEGER FUNCTION lmp_map_atom_int(self, id)
+    CLASS(lammps), INTENT(IN) :: self
+    INTEGER(c_int), INTENT(IN), TARGET :: id
+    INTEGER(c_int64_t), TARGET :: id64
+    TYPE(c_ptr) :: Cptr
+
+    IF (SIZE_TAGINT == 8) THEN
+        id64 = id
+        Cptr = C_LOC(id64)
+    ELSE
+        Cptr = C_LOC(id)
+    END IF
+    lmp_map_atom_int = lammps_map_atom(self%handle, Cptr) + 1
+  END FUNCTION lmp_map_atom_int
+
+  ! equivalent function to lammps_map_atom (for 64-bit integer tags)
+  INTEGER FUNCTION lmp_map_atom_big(self, id)
+    CLASS(lammps), INTENT(IN) :: self
+    INTEGER(c_int64_t), INTENT(IN), TARGET :: id
+    INTEGER(c_int), TARGET :: id32
+    TYPE(c_ptr) :: Cptr
+
+    IF (SIZE_TAGINT == 8) THEN
+        Cptr = C_LOC(id)
+    ELSE
+        id32 = id
+        Cptr = C_LOC(id32)
+    END IF
+    lmp_map_atom_big = lammps_map_atom(self%handle, Cptr) + 1
+  END FUNCTION lmp_map_atom_big
+  
   ! equivalent function to lammps_extract_atom
   ! the assignment is actually overloaded so as to bind the pointers to
   ! lammps data based on the information available from LAMMPS

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -893,6 +893,8 @@ class lammps(object):
       veclen = vec_dict[name]
     elif name == 'respa_dt':
       veclen = self.extract_global('respa_levels',LAMMPS_INT)
+    elif name == 'sametag':
+      veclen = self.extract_setting('nall')
     else:
       veclen = 1
 

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -935,7 +935,7 @@ class lammps(object):
   # map global atom ID to local atom index
 
   def map_atom(self, id):
-    """Map a global atom ID (aka tag) to the local atom indx
+    """Map a global atom ID (aka tag) to the local atom index
 
     This is a wrapper around the :cpp:func:`lammps_map_atom`
     function of the C-library interface.

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -269,6 +269,9 @@ class lammps(object):
     self.lib.lammps_extract_global_datatype.restype = c_int
     self.lib.lammps_extract_compute.argtypes = [c_void_p, c_char_p, c_int, c_int]
 
+    self.lib.lammps_map_atom.argtypes = [c_void_p, c_void_p]
+    self.lib.lammps_map_atom.restype = c_int
+
     self.lib.lammps_get_thermo.argtypes = [c_void_p, c_char_p]
     self.lib.lammps_get_thermo.restype = c_double
 
@@ -927,6 +930,24 @@ class lammps(object):
         return result
       else: return target_type(ptr[0])
     return None
+
+  # -------------------------------------------------------------------------
+  # map global atom ID to local atom index
+
+  def map_atom(self, id):
+    """Map a global atom ID (aka tag) to the local atom indx
+
+    This is a wrapper around the :cpp:func:`lammps_map_atom`
+    function of the C-library interface.
+
+    :param id: atom ID
+    :type id:  int
+    :return: local index
+    :rtype: int
+    """
+
+    tag = self.c_tagint(id)
+    return self.lib.lammps_map_atom(self.lmp, pointer(tag))
 
   # -------------------------------------------------------------------------
   # extract per-atom info datatype

--- a/src/library.h
+++ b/src/library.h
@@ -162,6 +162,8 @@ int lammps_extract_setting(void *handle, const char *keyword);
 int lammps_extract_global_datatype(void *handle, const char *name);
 void *lammps_extract_global(void *handle, const char *name);
 
+int lammps_map_atom(void *handle, const void *id);
+
 /* ----------------------------------------------------------------------
  * Library functions to read or modify per-atom data in LAMMPS
  * ---------------------------------------------------------------------- */

--- a/tools/swig/lammps.i
+++ b/tools/swig/lammps.i
@@ -125,6 +125,7 @@ extern int    lammps_get_mpi_comm(void *handle);
 extern int    lammps_extract_setting(void *handle, const char *keyword);
 extern int    lammps_extract_global_datatype(void *handle, const char *name);
 extern void  *lammps_extract_global(void *handle, const char *name);
+extern int    lammps_map_atom(void *handle, const void *id);
 
 extern int    lammps_extract_atom_datatype(void *handle, const char *name);
 extern void  *lammps_extract_atom(void *handle, const char *name);
@@ -310,6 +311,7 @@ extern int    lammps_get_mpi_comm(void *handle);
 extern int    lammps_extract_setting(void *handle, const char *keyword);
 extern int    lammps_extract_global_datatype(void *handle, const char *name);
 extern void  *lammps_extract_global(void *handle, const char *name);
+extern int    lammps_map_atom(void *handle, const void *id);
 
 extern int    lammps_extract_atom_datatype(void *handle, const char *name);
 extern void  *lammps_extract_atom(void *handle, const char *name);

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -609,6 +609,10 @@ create_atoms 1 single &
         self.lmp.command("special_bonds lj/coul 0.0 1.0 1.0")
         self.assertEqual(self.lmp.extract_global("special_lj"), [1.0, 0.0, 1.0, 1.0])
         self.assertEqual(self.lmp.extract_global("special_coul"), [1.0, 0.0, 1.0, 1.0])
+        self.assertEqual(self.lmp.extract_global("map_style"), 0)
+        self.assertEqual(self.lmp.extract_global("map_tag_max"), -1)
+        self.assertEqual(self.lmp.extract_global("sortfreq"), 1000)
+        self.assertEqual(self.lmp.extract_global("nextsort"), 0)
 
         # set and initialize r-RESPA
         self.lmp.command("run_style respa 3 5 2 pair 2 kspace 3")
@@ -660,6 +664,19 @@ create_atoms 1 single &
                 self.assertEqual(vel[i][0:3],result[i][3])
                 self.assertEqual(self.lmp.decode_image_flags(img[i]), result[i][4])
 
+    def test_map_atom(self):
+        self.lmp.command('shell cd ' + os.environ['TEST_INPUT_DIR'])
+        self.lmp.command("newton on on")
+        self.lmp.file("in.fourmol")
+        self.lmp.command("run 4 post no")
+        sometags = [1, 10, 25, 29]
+        tags = self.lmp.extract_atom("id")
+        sametag = self.lmp.extract_global("sametag")
+        for mytag in sometags:
+            myidx = self.lmp.map_atom(mytag)
+            self.assertEqual(mytag, tags[myidx])
+            if sametag[myidx] < 0: continue
+            self.assertEqual(mytag, tags[sametag[myidx]])
 
 ##############################
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**

This adds support for extracting some more properties related to atoms to the LAMMPS library interface.
This includes:
- Atom::map_style
- Atom::map_tag_max
- Atom::sametag
- Atom::sortfreq
- Atom::nextsort

Also add an interface to the Atom::map() function.

**Related Issue(s)**

This addresses the question asked here: https://matsci.org/t/how-to-map-atom-number-or-atom-id/54295/8

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

To have a single interface for the c-library interface, the atom tag is passed as a `void *` argument. This way it doesn't matter for the interface whether the tagint is 32-bit or 64-bit. This is handled with a cast and dereference internally. 
For the Fortran module there is an overload where the tag is cast to the internal 32-bit or 64-bit integer and for the Python module something similar is implemented since Python integers can grow their bitness as needed.

The calling code in C can identify which data type to use with lammps_extract_setting(). Simple example for 32-bit:
```c++
    int *tags;
    int sometags[] = {1, 10, 25, 100};
    int mytag;
    int myidx;
    int *sametag;

    /* check for tagint size and exit if incompatible */
    if (lammps_extract_setting(handle, "tagint") == 8) {
        fprintf(stderr, "Compiling LAMMPS with -DLAMMPS_BIGBIG is not compatible with this\n");
        return 2;
    }

    /* get atom ids and map a few of them and confirm */
    tags = (int *) lammps_extract_atom(handle, "id");
    for (int i = 0; i < sizeof(sometags)/sizeof(mytag); ++i) {
        mytag = sometags[i];
        myidx = lammps_map_atom(handle, (const void *) &mytag);
        sametag = (int *) lammps_extract_global(handle, "sametag");
        printf("%d: tag = %d  idx = %d  check = %d  sametag[%d] = %d  check = %d\n",
               i, mytag, myidx, tags[myidx], myidx, sametag[myidx],
               (sametag[myidx] >= 0) ? tags[sametag[myidx]] : -1);
    }

```
Same example for 64-bit:
```c++
    int64_t *tags;
    int64_t sometags[] = {1L, 10L, 25L, 100L};
    int64_t mytag;
    int myidx;
    int *sametag;

    /* check for tagint size and exit if incompatible */
    if (lammps_extract_setting(handle, "tagint") == 4) {
        fprintf(stderr, "Compiling LAMMPS with -DLAMMPS_BIGBIG is required for this\n");
        return 2;
    }

    /* get atom ids and map a few of them and confirm */
    tags = (int64_t *) lammps_extract_atom(handle, "id");
    for (int i = 0; i < sizeof(sometags)/sizeof(mytag); ++i) {
        mytag = sometags[i];
        myidx = lammps_map_atom(handle, (const void *) &mytag);
        sametag = (int *) lammps_extract_global(handle, "sametag");
        printf("%d: tag = %ld  idx = %d  check = %ld  sametag[%d] = %d  check = %ld\n",
               i, mytag, myidx, tags[myidx], myidx, sametag[myidx],
               (sametag[myidx] >= 0) ? tags[sametag[myidx]] : -1L);
    }
```


**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

