### PR TITLE
Updated i-pi example

### DIFF
--- a/examples/PACKAGES/ipi/README.md
+++ b/examples/PACKAGES/ipi/README.md
@@ -1,17 +1,17 @@
 i-PI path integral interface examples
 =====================================
 
-This folder contains a couple of examples to run LAMMPS as a client,
+This folder contains an example to run LAMMPS as a client,
 exchanging information on the atomic configurations, energy and forces
-with the i-PI Python interface
-[http://epfl-cosmo.github.io/gle4md/index.html?page=ipi].  These
+with the [http://ipi-code.org](i-PI Python interface).  These
 examples require a working copy of i-PI and compiling LAMMPS in a UNIX
-environment.  Note that a copy of i-PI is provided with LAMMPS, in the
-tools/i-pi directory.
+environment. 
+i-PI can be installed from source or from `pip`. Please refer to the
+documentation for up-to-date installation instruction.
 
-Note that the i-PI examples listed here are designed for the public V1.0
-version of i-PI. Refer to the LAMMPS examples distributed with i-PI if you
-are using a development version.
+Note that the i-PI examples listed here have been tested to work with the
+3.0 version of i-PI. Refer to the LAMMPS examples distributed with i-PI if you
+are using a different version.
 
 Path integral simulation of graphene
 ------------------------------------
@@ -25,7 +25,7 @@ and the format of the output.
 How to run i-PI
 ---------------
 
-You should have a relatively recent (>=2.5) version of Python and Numpy,
+You should have a relatively recent (>=3.5) version of Python and Numpy,
 and the public version of i-PI. You can then run i-PI by executing
 
 ```bash
@@ -33,7 +33,7 @@ and the public version of i-PI. You can then run i-PI by executing
 ```
 
 In a separate terminal, then, you should run LAMMPS compiled to provide 
-fix_ipi functionalities.
+`fix_ipi` functionalities.
 
 ```bash
    $LAMMPS -in in.graphene
@@ -41,6 +41,3 @@ fix_ipi functionalities.
 
 You can run multiple instances of LAMMPS if you want to exploit the 
 parallelism over the path integral beads.
-
-
-

--- a/examples/PACKAGES/ipi/i-pi_input.xml
+++ b/examples/PACKAGES/ipi/i-pi_input.xml
@@ -1,31 +1,37 @@
-<simulation verbosity="medium">
-   <initialize nbeads='8'>
-      <file mode='xyz' units="angstrom"> i-pi_positions.xyz  </file>
-      <cell mode='manual' units="angstrom"> [ 51.8,0,0,0, 49.84,0,0,0, 200 ] </cell> 
-      <velocities mode='thermal' units='kelvin'> 300 </velocities>
-   </initialize>
-   <output prefix='graphene'>
-      <properties stride='5' filename='out' flush="10" >  [ step, time{picosecond}, conserved{electronvolt}, temperature{kelvin}, kinetic_cv{electronvolt}, potential{electronvolt}, pressure_cv{megapascal}] </properties>
+<simulation verbosity='medium'>
+  <output prefix='simulation'>
+      <properties stride='5' filename='out' flush="10" >  [ step, time{picosecond}, conserved{kelvin}, temperature{kelvin}, kinetic_cv{kelvin}, potential{kelvin}, pressure_cv{megapascal}] </properties>
       <properties stride='5' filename='iso' flush="10" >  [ isotope_tdfep(1.167;C), isotope_scfep(1.167;0) ] </properties>
-      <trajectory stride='20' filename='pos' flush="100"> positions{angstrom}</trajectory>
-      <checkpoint stride='2000' />
-   </output>
-   <total_steps>1000</total_steps>
-   <total_time>128000</total_time>
-   <prng><seed>8417</seed></prng>
-   <forces>
-      <socket mode="unix">
-         <address>graphene</address>
-      </socket>
-   </forces>
-   <ensemble mode='nvt'>
-  <thermostat mode='gle'>
-    <A shape='(5,5)'>
-      [   1.124524713863e-3,     1.648702679619e-6,     6.970075857471e-5,    -2.202066291263e-4,     1.401342873485e-3,    -1.681700567912e-6,    5.197673899653e-10,     4.365423872046e-6,    -1.200041116490e-6,     2.564577183580e-6,    -8.965478630849e-5,    -4.365423872046e-6,     8.218704940997e-6,     3.114246791997e-5,    -6.044142906315e-5,    -6.272281358913e-5,     1.200041116490e-6,    -3.114246791997e-5,     1.612301941566e-4,     6.958958085115e-5,     1.318373360752e-3,    -2.564577183580e-6,     6.044142906315e-5,    -6.958958085115e-5,     1.872119364197e-3]
-    </A>
-  </thermostat>
-      <timestep units="femtosecond">1.0</timestep>
-      <temperature units='kelvin'>300</temperature>
-      <fixcom> True </fixcom>
-   </ensemble>
+      <properties stride='1' filename='kc'> [ kinetic_cv{kelvin}(C) ] </properties> 
+      <trajectory stride='5' filename='pos' flush="100">positions{angstrom}</trajectory>
+      <trajectory stride='5' filename='kin' flush="100"> kinetic_cv </trajectory>
+    <checkpoint stride='20000'/>
+  </output>
+  <total_steps>1000000</total_steps>
+  <prng>
+    <seed>31415</seed>
+  </prng>
+  <ffsocket name='lammps' mode='unix'>
+    <address> graphene </address>
+  </ffsocket>
+  <system>
+    <initialize nbeads='8'>
+      <file mode='xyz'> i-pi_positions.xyz </file>
+      <velocities mode='thermal' units='kelvin'> 300 </velocities>
+    </initialize>
+    <forces>
+      <force forcefield='lammps'> </force>
+    </forces>
+    <motion mode='dynamics'>
+      <dynamics mode='nvt'>
+        <timestep units='femtosecond'> 1.0 </timestep>
+        <thermostat mode='langevin'>
+          <tau units='femtosecond'> 100 </tau>
+        </thermostat>
+      </dynamics>
+    </motion>
+    <ensemble>
+      <temperature units='kelvin'> 300 </temperature>
+    </ensemble>
+  </system>
 </simulation>


### PR DESCRIPTION
**Summary**

This is just addressing a leftover from #4176 - the example bundled with LAMMPS is incompatible with a modern version of i-PI. This small PR fixes the example and updates the README to reflect the new state of affairs where i-PI is not bundled.

**Author(s)**

Michele Ceriotti  <michele.ceriotti@gmail.com>

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This clearly will make the example not work with i-PI 1.0 but that is 10 years old so I think it's time to move on. A reference to the version it has been tested with is included, and installation instructions are delegated to the i-PI documentation to reduce the risk of obsolescence. 
**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] A package specific README file has been included or updated
- [x] One or more example input decks are included