### PR TITLE
Add functionality to change and manage atom types through LAMMPS Pyth…

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -314,7 +314,8 @@ set(STANDARD_PACKAGES
   UEF
   VORONOI
   VTK
-  YAFF)
+  YAFF
+  VERSIONS)
 
 set(SUFFIX_PACKAGES CORESHELL GPU KOKKOS OPT INTEL OPENMP)
 
@@ -683,6 +684,10 @@ endif()
 
 if(PKG_H5MD)
   include(Packages/H5MD)
+endif()
+
+if(PKG_VERSIONS)
+  target_compile_definitions(lammps PUBLIC -DPKG_VERSIONS)
 endif()
 
 ######################################################################

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -333,6 +333,9 @@ class lammps(object):
     self.lib.lammps_fix_external_set_vector_length.argtypes = [c_void_p, c_char_p, c_int]
     self.lib.lammps_fix_external_set_vector.argtypes = [c_void_p, c_char_p, c_int, c_double]
 
+    self.lib.lammps_check_symbol.argtypes = [c_char_p]
+    self.lib.lammps_check_symbol.restype = c_int
+
     #Type sets
     self.lib.lammps_change_typeset.argtypes = [c_void_p, c_int]
     self.lib.lammps_change_typeset.restype = c_int
@@ -1744,8 +1747,27 @@ class lammps(object):
     with ExceptionCheck(self):
       return self.lib.lammps_create_atoms(self.lmp, n, id_lmp, type_lmp, x_lmp, v_lmp, img_lmp, se_lmp)
 
+    
+
   #----------------------------------------------------------------
   #The follosing section provides a bridge to lammps functionality governing type sets' behavior
+
+  def check_symbol(self, symname):
+    """
+    Check if a specific preprocessor symbol is defined.
+
+    This function is a wrapper around the :cpp:func:`lammps_check_symbol`
+    function of the C-library interface.
+
+    It returns `True` if the symbol is defined, otherwise it returns `False`.
+
+    :param symbol: a string representing the preprocessor symbol to check
+    :type symbol: str
+
+    :return: `True` if the symbol is defined; `False` otherwise
+    :rtype: bool
+    """
+    return bool(self.lib.lammps_check_symbol(symname.encode()))
 
   def add_typeset(self, type_list):
     """
@@ -2488,3 +2510,4 @@ class lammps(object):
     computeid = computeid.encode()
     idx = self.lib.lammps_find_compute_neighlist(self.lmp, computeid, reqid)
     return idx
+

--- a/src/VERSIONS/version_storage.cpp
+++ b/src/VERSIONS/version_storage.cpp
@@ -1,0 +1,52 @@
+#include "version_storage.h"
+#include "atom.h"
+#include "memory.h"
+
+using namespace LAMMPS_NS;
+VStorage::VStorage(LAMMPS *lmp) : Pointers(lmp){
+    current_typeset = 0;
+    ntype_sets = 0;
+    nactive_typesets = 0;
+    }
+
+VStorage::~VStorage(){
+  for (int i = 0; i < ntype_sets; i++){
+      memory->destroy(typeset_map[i]);
+  }
+}
+
+//Create a new type set. On the first call type set 0 (existing atom types) and type set 1 (new types) are created
+int VStorage::add_typeset(const int *types){
+	if(!ntype_sets){
+		int *initial_replacement = nullptr;
+    	initial_replacement = memory->grow(initial_replacement, lmp->atom->nmax, "atom:typeset");
+    	for(int i = 0; i < lmp->atom->nmax; i++){
+			initial_replacement[i] = lmp->atom->type[i];
+    		}
+		    typeset_map[ntype_sets++] = initial_replacement;
+			nactive_typesets++;
+		}
+
+	int *sub_types = nullptr;
+ 	int m;
+	sub_types = memory->grow(sub_types, lmp->atom->nmax, "atom:typeset");
+	for(int i = 0; i < lmp->atom->natoms; i++){
+        if((m = lmp->atom->map(i+1)) >= 0){
+      	    sub_types[m] = types[i];
+            }
+        }
+	typeset_map[ntype_sets] = sub_types;
+	nactive_typesets++;
+	return ntype_sets++;
+	}
+
+//Delete a particular type set
+int VStorage::delete_typeset(int typeset_id){
+	int res = -1;
+	if(typeset_id != current_typeset){
+    	memory->destroy(typeset_map[typeset_id]);
+    	nactive_typesets--;
+    	res = 0;
+    	}
+	return res;
+	}

--- a/src/VERSIONS/version_storage.h
+++ b/src/VERSIONS/version_storage.h
@@ -1,0 +1,24 @@
+#ifndef LMP_VERSION_STORAGE_H
+#define LMP_VERSION_STORAGE_H
+#endif
+
+#include "pointers.h"
+#include "atom.h"
+
+#include <map>
+
+namespace LAMMPS_NS{
+
+class VStorage : protected Pointers{
+    public:
+        std::map<int, int*> typeset_map;
+        int current_typeset;
+        int ntype_sets;
+        int nactive_typesets;
+
+        VStorage(class LAMMPS*);
+        ~VStorage() override;
+        int add_typeset(const int *types);
+        int delete_typeset(int typeset_id);
+    };
+    }

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -3272,19 +3272,24 @@ double Atom::memory_usage()
 int Atom::add_typeset(const int *types){
   if(!ntype_sets){
     int *initial_replacement = nullptr;
-    initial_replacement = memory->grow(initial_replacement, natoms, "atom:typeset");
-    for(int i = 0; i < natoms; i++){
+    initial_replacement = memory->grow(initial_replacement, nmax, "atom:typeset");
+    for(int i = 0; i < nmax; i++){
       initial_replacement[i] = type[i];
       }
     typeset_map[ntype_sets++] = initial_replacement;
     nactive_typesets++;
   }
-  int *new_types = nullptr;
-  new_types = memory->grow(new_types, natoms, "atom:typeset");
+
+  int *sub_types = nullptr;
+  int m;
+  sub_types = memory->grow(sub_types, nmax, "atom:typeset");
   for(int i = 0; i < natoms; i++){
-    new_types[i] = types[i];
-    }
-  typeset_map[ntype_sets] = new_types;
+    if((m = map(i+1)) >= 0){
+      sub_types[m] = types[i];
+      }
+  }
+
+  typeset_map[ntype_sets] = sub_types;
   nactive_typesets++;
   return ntype_sets++;
 }

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -276,11 +276,6 @@ Atom::Atom(LAMMPS *_lmp) : Pointers(_lmp), atom_style(nullptr), avec(nullptr), a
 
   avec_map = new AtomVecCreatorMap();
 
-  //Type sets
-  ntype_sets = 0;
-  current_typeset = 0;
-  nactive_typesets = 0;
-
 #define ATOM_CLASS
 #define AtomStyle(key,Class) \
   (*avec_map)[#key] = &avec_creator<Class>;
@@ -328,10 +323,6 @@ Atom::~Atom()
   for (int i = 0; i < ndarray; i++) {
     delete[] daname[i];
     memory->destroy(darray[i]);
-  }
-
-  for (int i = 0; i < ntype_sets; i++){
-      memory->destroy(typeset_map[i]);
   }
 
   memory->sfree(ivname);
@@ -3266,41 +3257,3 @@ double Atom::memory_usage()
 }
 
 
-//Type sets
-
-//Create a new type set. On the first call type set 0 (existing atom types) and type set 1 (new types) are created
-int Atom::add_typeset(const int *types){
-  if(!ntype_sets){
-    int *initial_replacement = nullptr;
-    initial_replacement = memory->grow(initial_replacement, nmax, "atom:typeset");
-    for(int i = 0; i < nmax; i++){
-      initial_replacement[i] = type[i];
-      }
-    typeset_map[ntype_sets++] = initial_replacement;
-    nactive_typesets++;
-  }
-
-  int *sub_types = nullptr;
-  int m;
-  sub_types = memory->grow(sub_types, nmax, "atom:typeset");
-  for(int i = 0; i < natoms; i++){
-    if((m = map(i+1)) >= 0){
-      sub_types[m] = types[i];
-      }
-  }
-
-  typeset_map[ntype_sets] = sub_types;
-  nactive_typesets++;
-  return ntype_sets++;
-}
-
-//Delete a particular type set
-int Atom::delete_typeset(int typeset_id){
-  int res = -1;
-  if(typeset_id != current_typeset){
-    memory->destroy(typeset_map[typeset_id]);
-    nactive_typesets--;
-    res = 0;
-    }    
-  return res;
-}

--- a/src/atom.h
+++ b/src/atom.h
@@ -110,11 +110,6 @@ class Atom : protected Pointers {
   int **improper_type;
   tagint **improper_atom1, **improper_atom2, **improper_atom3, **improper_atom4;
 
-  //Type sets
-  std::map<int, int*> typeset_map;
-  int current_typeset;
-  int ntype_sets;
-  int nactive_typesets;
 
   // PERI package
 
@@ -319,9 +314,6 @@ class Atom : protected Pointers {
   void create_avec(const std::string &, int, char **, int);
   virtual AtomVec *new_avec(const std::string &, int, int &);
 
-  //Type sets
-  int add_typeset(const int *types);
-  int delete_typeset(int typeset_id);
 
   virtual void init();
   void setup();

--- a/src/atom.h
+++ b/src/atom.h
@@ -110,6 +110,12 @@ class Atom : protected Pointers {
   int **improper_type;
   tagint **improper_atom1, **improper_atom2, **improper_atom3, **improper_atom4;
 
+  //Type sets
+  std::map<int, int*> typeset_map;
+  int current_typeset;
+  int ntype_sets;
+  int nactive_typesets;
+
   // PERI package
 
   double *vfrac, *s0;
@@ -312,6 +318,10 @@ class Atom : protected Pointers {
   void add_peratom_vary(const std::string &, void *, int, int *, void *, int collength = 0);
   void create_avec(const std::string &, int, char **, int);
   virtual AtomVec *new_avec(const std::string &, int, int &);
+
+  //Type sets
+  int add_typeset(const int *types);
+  int delete_typeset(int typeset_id);
 
   virtual void init();
   void setup();

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -67,11 +67,16 @@
 #include "lmpinstalledpkgs.h"
 #include "lmpgitversion.h"
 
+#if defined(PKG_VERSIONS)
+#include "version_storage.h"
+#endif
+
 #if defined(LAMMPS_UPDATE)
 #define UPDATE_STRING " - " LAMMPS_UPDATE
 #else
 #define UPDATE_STRING ""
 #endif
+
 
 static void print_style(FILE *fp, const char *str, int &pos);
 
@@ -868,6 +873,10 @@ void LAMMPS::create()
 #if defined(LMP_PLUGIN)
   plugin_auto_load(this);
 #endif
+#if defined(PKG_VERSIONS)
+  vstorage = new VStorage(this);
+#endif
+
 }
 
 /* ----------------------------------------------------------------------

--- a/src/lammps.h
+++ b/src/lammps.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+
+
 namespace LAMMPS_NS {
 
 class LAMMPS {
@@ -85,6 +87,10 @@ class LAMMPS {
   static const char *git_commit();
   static const char *git_branch();
   static const char *git_descriptor();
+
+#if defined(PKG_VERSIONS)
+  class VStorage *vstorage;
+#endif
 
   using argv = std::vector<std::string>;
   static std::vector<char*> argv_pointers(argv & args);

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -5453,12 +5453,16 @@ int lammps_add_typeset(void *handle, const int *types){
   int res = -1;
   BEGIN_CAPTURE
   {
+#if defined(LAMMPS_BIGBIG)
+    lmp->error->all(FLERR,"Library type set interface is not compatible with -DLAMMPS_BIGBIG");
+#else
     if (lmp->atom->map_style == Atom::MAP_NONE){
       lmp->error->all(FLERR, "lammps_add_typeset(): Atoms must be mapped");
       return res;
     }
     // Add the new type set
     res = lmp->atom->add_typeset(types);
+#endif
   }
   END_CAPTURE;
   return res;
@@ -5533,7 +5537,7 @@ int lammps_delete_typeset(void *handle, int typeset_id){
     int flag = 0;
 
     // Check if the type set ID is valid
-    if(typeset_id > lmp->atom->ntype_sets || typeset_id < 0){
+    if(typeset_id > lmp->atom->ntype_sets || typeset_id <= 0){
       flag = 1;
     } else {
       if(lmp->atom->typeset_map[typeset_id] == nullptr) flag = 1;
@@ -5577,21 +5581,24 @@ int lammps_reset_typesets(void *handle){
   BEGIN_CAPTURE
   {
 
-    //Reset atoms to original type values
-    for (int i = 0; i < lmp->atom->nmax; i++){
-      lmp->atom->type[i] = lmp->atom->typeset_map[0][i];
-    }
+    if(lmp->atom->ntype_sets){
 
-    // Delete all type sets
-    for(int i = 0; i < lmp->atom->ntype_sets; i++){
-      lmp->atom->delete_typeset(i);
-    }
+      //Reset atoms to original type values
+      for (int i = 0; i < lmp->atom->nmax; i++){
+        lmp->atom->type[i] = lmp->atom->typeset_map[0][i];
+      }
 
-    // Reset type set counters
-    lmp->atom->ntype_sets = 0;
-    lmp->atom->current_typeset = 0;
-    lmp->atom->nactive_typesets = 0;
-    res = 0;
+      // Delete all type sets
+      for(int i = 0; i < lmp->atom->ntype_sets; i++){
+        lmp->atom->delete_typeset(i);
+      }
+
+      // Reset type set counters
+      lmp->atom->ntype_sets = 0;
+      lmp->atom->current_typeset = 0;
+      lmp->atom->nactive_typesets = 0;
+      res = 0;
+    }
   }
   END_CAPTURE;
   return res;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -5453,6 +5453,10 @@ int lammps_add_typeset(void *handle, const int *types){
   int res = -1;
   BEGIN_CAPTURE
   {
+    if (lmp->atom->map_style == Atom::MAP_NONE){
+      lmp->error->all(FLERR, "lammps_add_typeset(): Atoms must be mapped");
+      return res;
+    }
     // Add the new type set
     res = lmp->atom->add_typeset(types);
   }
@@ -5489,20 +5493,13 @@ int lammps_change_typeset(void *handle, int typeset_id){
       if(lmp->atom->typeset_map[typeset_id] == nullptr) flag = 1;
     }
     if(flag){
-      std::string msg("Type set id does not exist");
+      std::string msg("lammps_change_typeset(): Type set id does not exist");
       lmp->error->all(FLERR, msg);
       return -1;
     }
 
     // Change the atom types to the new type set
-    Domain *domain = lmp->domain;
-    int n = lmp->atom->natoms;
-    double xdata[3];
-    for(int i = 0; i < n; i++){
-      xdata[0] = lmp->atom->x[i][0];
-      xdata[1] = lmp->atom->x[i][1];
-      xdata[2] = lmp->atom->x[i][2];
-      if (!domain->ownatom(lmp->atom->tag[i], xdata, &(lmp->atom->image[i]), 0)) continue;
+    for (int i = 0; i < lmp->atom->nmax; i++){
       lmp->atom->type[i] = lmp->atom->typeset_map[typeset_id][i];
     }
 
@@ -5579,16 +5576,9 @@ int lammps_reset_typesets(void *handle){
   int res = -1;
   BEGIN_CAPTURE
   {
-    Domain *domain = lmp->domain;
-    int n = lmp->atom->natoms;
-    double xdata[3];
 
-    // Reset atom types to initial values
-    for(int i = 0; i < n; i++){
-      xdata[0] = lmp->atom->x[i][0];
-      xdata[1] = lmp->atom->x[i][1];
-      xdata[2] = lmp->atom->x[i][2];
-      if (!domain->ownatom(lmp->atom->tag[i], xdata, &(lmp->atom->image[i]), 0)) continue;
+    //Reset atoms to original type values
+    for (int i = 0; i < lmp->atom->nmax; i++){
       lmp->atom->type[i] = lmp->atom->typeset_map[0][i];
     }
 

--- a/src/library.h
+++ b/src/library.h
@@ -164,6 +164,8 @@ void *lammps_extract_global(void *handle, const char *name);
 
 int lammps_map_atom(void *handle, const void *id);
 
+int lammps_check_symbol(const char* symbol);
+
 //Type sets
 int lammps_add_typeset(void *handle, const int *types);
 int lammps_change_typeset(void *handle, int typeset_id);

--- a/src/library.h
+++ b/src/library.h
@@ -164,6 +164,12 @@ void *lammps_extract_global(void *handle, const char *name);
 
 int lammps_map_atom(void *handle, const void *id);
 
+//Type sets
+int lammps_add_typeset(void *handle, const int *types);
+int lammps_change_typeset(void *handle, int typeset_id);
+int lammps_reset_typesets(void *hanle);
+int lammps_delete_typeset(void *handle, int typeset_id);
+
 /* ----------------------------------------------------------------------
  * Library functions to read or modify per-atom data in LAMMPS
  * ---------------------------------------------------------------------- */

--- a/tools/swig/lammps.i
+++ b/tools/swig/lammps.i
@@ -127,6 +127,12 @@ extern int    lammps_extract_global_datatype(void *handle, const char *name);
 extern void  *lammps_extract_global(void *handle, const char *name);
 extern int    lammps_map_atom(void *handle, const void *id);
 
+extern int    lammps_add_typeset(void *handle, const int *types);
+extern int    lammps_change_typeset(void *handle, int typeset_id);
+extern int    lammps_reset_typesets(void *hanle);
+extern int    lammps_delete_typeset(void *handle, int typeset_id);
+
+
 extern int    lammps_extract_atom_datatype(void *handle, const char *name);
 extern void  *lammps_extract_atom(void *handle, const char *name);
 
@@ -312,6 +318,11 @@ extern int    lammps_extract_setting(void *handle, const char *keyword);
 extern int    lammps_extract_global_datatype(void *handle, const char *name);
 extern void  *lammps_extract_global(void *handle, const char *name);
 extern int    lammps_map_atom(void *handle, const void *id);
+
+extern int    lammps_add_typeset(void *handle, const int *types);
+extern int    lammps_change_typeset(void *handle, int typeset_id);
+extern int    lammps_reset_typesets(void *hanle);
+extern int    lammps_delete_typeset(void *handle, int typeset_id);
 
 extern int    lammps_extract_atom_datatype(void *handle, const char *name);
 extern void  *lammps_extract_atom(void *handle, const char *name);

--- a/unittest/c-library/test_library_properties.cpp
+++ b/unittest/c-library/test_library_properties.cpp
@@ -475,8 +475,8 @@ TEST_F(LibraryProperties, global)
     int natoms = 100;
     int *atom_types = new int[natoms];
     int ntype_sets, current_typeset, new_typeset_id, i;
-    std::vector<int> type2s(100, 2);
-    std::vector<int> type3s(100, 3);
+    std::vector<int> type2s(natoms, 2);
+    std::vector<int> type3s(natoms, 3);
 
     if (!verbose) ::testing::internal::CaptureStdout();
     lammps_command(lmp, "clear");
@@ -488,6 +488,7 @@ TEST_F(LibraryProperties, global)
 
     if (!verbose) ::testing::internal::CaptureStdout();
     lammps_command(lmp, "clear");
+    lammps_command(lmp, "atom_modify map yes");
     lammps_command(lmp, "region box block 1 10 0 10 0 10");
     lammps_command(lmp, "create_box 3 box");
     lammps_command(lmp, "create_atoms 1 random 100 12345 box");

--- a/unittest/c-library/test_library_properties.cpp
+++ b/unittest/c-library/test_library_properties.cpp
@@ -469,6 +469,7 @@ TEST_F(LibraryProperties, global)
 
     //Type sets
 
+#if !defined(LAMMPS_BIGBIG)
     EXPECT_EQ(lammps_extract_global_datatype(lmp, "ntype_sets"), LAMMPS_INT);
     EXPECT_EQ(lammps_extract_global_datatype(lmp, "current_typeset"), LAMMPS_INT);
 
@@ -561,6 +562,7 @@ TEST_F(LibraryProperties, global)
     for(i = 0; i < natoms; i++){
         EXPECT_EQ(atom_types[i], 1);
         }
+#endif
 
 };
 

--- a/unittest/c-library/test_library_properties.cpp
+++ b/unittest/c-library/test_library_properties.cpp
@@ -469,6 +469,7 @@ TEST_F(LibraryProperties, global)
 
     //Type sets
 
+#if defined(PKG_VERSIONS)
 #if !defined(LAMMPS_BIGBIG)
     EXPECT_EQ(lammps_extract_global_datatype(lmp, "ntype_sets"), LAMMPS_INT);
     EXPECT_EQ(lammps_extract_global_datatype(lmp, "current_typeset"), LAMMPS_INT);
@@ -562,6 +563,7 @@ TEST_F(LibraryProperties, global)
     for(i = 0; i < natoms; i++){
         EXPECT_EQ(atom_types[i], 1);
         }
+#endif
 #endif
 
 };

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -685,7 +685,7 @@ create_atoms 1 single &
             self.assertEqual(mytag, tags[sametag[myidx]])
 
     def test_type_sets(self):
-        if self.lmp.extract_global_datatype("map_tag_max") != LAMMPS_INT64:
+        if self.lmp.check_symbol("PKG_VERSIONS") and not self.lmp.check_symbol("LAMMPS_BIGBIG"):
             type2s = np.full(100, 2)
             type3s = np.full(100, 3)
             self.lmp.command('shell cd ' + os.environ['TEST_INPUT_DIR'])

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -688,6 +688,7 @@ create_atoms 1 single &
         type3s = np.full(100, 3)
         self.lmp.command('shell cd ' + os.environ['TEST_INPUT_DIR'])
         self.lmp.command("clear")
+        self.lmp.command("atom_modify map yes")
         
         self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
         self.assertEqual(self.lmp.extract_global("current_typeset"), 0)

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -3,6 +3,7 @@ import sys,os,unittest,ctypes
 from lammps import lammps, LMP_VAR_ATOM, LMP_STYLE_GLOBAL, LMP_STYLE_LOCAL
 from lammps import LMP_TYPE_VECTOR, LMP_SIZE_VECTOR, LMP_SIZE_ROWS, LMP_SIZE_COLS
 from lammps import LAMMPS_DOUBLE_2D, LAMMPS_AUTODETECT
+from lammps import LAMMPS_INT64
 import numpy as np
 
 has_manybody=False
@@ -684,66 +685,67 @@ create_atoms 1 single &
             self.assertEqual(mytag, tags[sametag[myidx]])
 
     def test_type_sets(self):
-        type2s = np.full(100, 2)
-        type3s = np.full(100, 3)
-        self.lmp.command('shell cd ' + os.environ['TEST_INPUT_DIR'])
-        self.lmp.command("clear")
-        self.lmp.command("atom_modify map yes")
-        
-        self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
-        self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
-        
-        self.lmp.command("region box block 0 10 0 10 0 10")
-        self.lmp.command("create_box 3 box")
-        self.lmp.command("create_atoms 1 random 100 12345 box")
-        self.lmp.command("set group all type 1")
-        
-        self.lmp.command("mass 1 1.0")
-        self.lmp.command("mass 2 1.5")
-        self.lmp.command("mass 3 2.5")
-        
-        # Initially there should be no type sets.
-        self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
-        self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
-        
-        # Adding a new type set where all atoms have type 2.
-        new_typeset_id = self.lmp.add_typeset(type2s)
-        # Two type sets should have been created - initial and new (all type 2).
-        self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
-        self.assertEqual(new_typeset_id, 1)
-        
-        # Changing to type set with id 1 (all type 2).
-        self.lmp.change_typeset(new_typeset_id)
-        # Check that all the types have been assigned correctly
-        self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
-        self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
-        
-        # Adding another type set (all atoms type 3) which would have an id 2.
-        new_typeset_id = self.lmp.add_typeset(type3s)
-        self.assertEqual(self.lmp.extract_global("ntype_sets"), 3)
-        self.assertEqual(new_typeset_id, 2)
-        
-        # Switching to the type set with id 2 (all type 3).
-        self.lmp.change_typeset(new_typeset_id)
-        # Check that all the types have been assigned correctly
-        self.assertEqual(np.array_equal(type3s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
-        self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
-        
-        # Switching back to the type set with id 1 (all type 2).
-        self.lmp.change_typeset(1)
-        self.assertEqual(self.lmp.extract_global("current_typeset"), 1)
-        # Check that all the types have been assigned correctly
-        self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
-        
-        # Deleting a type set with id 2 (all type 3).
-        self.lmp.delete_typeset(2)
-        self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
-        
-        # Deleting all type sets and going back to the initial state.
-        self.lmp.reset_typesets()
-        self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
-        self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
-        self.assertEqual(np.array_equal(np.full(100, 1), np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+        if self.lmp.extract_global_datatype("map_tag_max") != LAMMPS_INT64:
+            type2s = np.full(100, 2)
+            type3s = np.full(100, 3)
+            self.lmp.command('shell cd ' + os.environ['TEST_INPUT_DIR'])
+            self.lmp.command("clear")
+            self.lmp.command("atom_modify map yes")
+            
+            self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
+            self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
+            
+            self.lmp.command("region box block 0 10 0 10 0 10")
+            self.lmp.command("create_box 3 box")
+            self.lmp.command("create_atoms 1 random 100 12345 box")
+            self.lmp.command("set group all type 1")
+            
+            self.lmp.command("mass 1 1.0")
+            self.lmp.command("mass 2 1.5")
+            self.lmp.command("mass 3 2.5")
+            
+            # Initially there should be no type sets.
+            self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
+            self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
+            
+            # Adding a new type set where all atoms have type 2.
+            new_typeset_id = self.lmp.add_typeset(type2s)
+            # Two type sets should have been created - initial and new (all type 2).
+            self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
+            self.assertEqual(new_typeset_id, 1)
+            
+            # Changing to type set with id 1 (all type 2).
+            self.lmp.change_typeset(new_typeset_id)
+            # Check that all the types have been assigned correctly
+            self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+            self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
+            
+            # Adding another type set (all atoms type 3) which would have an id 2.
+            new_typeset_id = self.lmp.add_typeset(type3s)
+            self.assertEqual(self.lmp.extract_global("ntype_sets"), 3)
+            self.assertEqual(new_typeset_id, 2)
+            
+            # Switching to the type set with id 2 (all type 3).
+            self.lmp.change_typeset(new_typeset_id)
+            # Check that all the types have been assigned correctly
+            self.assertEqual(np.array_equal(type3s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+            self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
+            
+            # Switching back to the type set with id 1 (all type 2).
+            self.lmp.change_typeset(1)
+            self.assertEqual(self.lmp.extract_global("current_typeset"), 1)
+            # Check that all the types have been assigned correctly
+            self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+            
+            # Deleting a type set with id 2 (all type 3).
+            self.lmp.delete_typeset(2)
+            self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
+            
+            # Deleting all type sets and going back to the initial state.
+            self.lmp.reset_typesets()
+            self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
+            self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
+            self.assertEqual(np.array_equal(np.full(100, 1), np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
 
 
 if __name__ == "__main__":

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -3,6 +3,7 @@ import sys,os,unittest,ctypes
 from lammps import lammps, LMP_VAR_ATOM, LMP_STYLE_GLOBAL, LMP_STYLE_LOCAL
 from lammps import LMP_TYPE_VECTOR, LMP_SIZE_VECTOR, LMP_SIZE_ROWS, LMP_SIZE_COLS
 from lammps import LAMMPS_DOUBLE_2D, LAMMPS_AUTODETECT
+import numpy as np
 
 has_manybody=False
 try:
@@ -683,65 +684,65 @@ create_atoms 1 single &
             self.assertEqual(mytag, tags[sametag[myidx]])
 
     def test_type_sets(self):
-	type2s = np.full(100, 2)
-	type3s = np.full(100, 3)
-	self.lmp.command('shell cd ' + os.environ['TEST_INPUT_DIR'])
-	self.lmp.command("clear")
-
-	self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
-	self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
-
-	self.lmp.command("region box block 0 10 0 10 0 10")
-	self.lmp.command("create_box 3 box")
-	self.lmp.command("create_atoms 1 random 100 12345 box")
-	self.lmp.command("set group all type 1")
-
-	self.lmp.command("mass 1 1.0")
-	self.lmp.command("mass 2 1.5")
-	self.lmp.command("mass 3 2.5")
-
-	# Initially there should be no type sets.
-	self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
-	self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
-
-	# Adding a new type set where all atoms have type 2.
-	new_typeset_id = self.lmp.add_typeset(type2s)
-	# Two type sets should have been created - initial and new (all type 2).
-	self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
-	self.assertEqual(new_typeset_id, 1)
-
-	# Changing to type set with id 1 (all type 2).
-	self.lmp.change_typeset(new_typeset_id)
-	# Check that all the types have been assigned correctly
-	self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
-	self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
-
-	# Adding another type set (all atoms type 3) which would have an id 2.
-	new_typeset_id = self.lmp.add_typeset(type3s)
-	self.assertEqual(self.lmp.extract_global("ntype_sets"), 3)
-	self.assertEqual(new_typeset_id, 2)
-
-	# Switching to the type set with id 2 (all type 3).
-	self.lmp.change_typeset(new_typeset_id)
-	# Check that all the types have been assigned correctly
-	self.assertEqual(np.array_equal(type3s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
-	self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
-
-	# Switching back to the type set with id 1 (all type 2).
-	self.lmp.change_typeset(1)
-	self.assertEqual(self.lmp.extract_global("current_typeset"), 1)
-	# Check that all the types have been assigned correctly
-	self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
-
-	# Deleting a type set with id 2 (all type 3).
-	self.lmp.delete_typeset(2)
-	self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
-
-	# Deleting all type sets and going back to the initial state.
-	self.lmp.reset_typesets()
-	self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
-	self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
-	self.assertEqual(np.array_equal(np.full(100, 1), np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+        type2s = np.full(100, 2)
+        type3s = np.full(100, 3)
+        self.lmp.command('shell cd ' + os.environ['TEST_INPUT_DIR'])
+        self.lmp.command("clear")
+        
+        self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
+        self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
+        
+        self.lmp.command("region box block 0 10 0 10 0 10")
+        self.lmp.command("create_box 3 box")
+        self.lmp.command("create_atoms 1 random 100 12345 box")
+        self.lmp.command("set group all type 1")
+        
+        self.lmp.command("mass 1 1.0")
+        self.lmp.command("mass 2 1.5")
+        self.lmp.command("mass 3 2.5")
+        
+        # Initially there should be no type sets.
+        self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
+        self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
+        
+        # Adding a new type set where all atoms have type 2.
+        new_typeset_id = self.lmp.add_typeset(type2s)
+        # Two type sets should have been created - initial and new (all type 2).
+        self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
+        self.assertEqual(new_typeset_id, 1)
+        
+        # Changing to type set with id 1 (all type 2).
+        self.lmp.change_typeset(new_typeset_id)
+        # Check that all the types have been assigned correctly
+        self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+        self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
+        
+        # Adding another type set (all atoms type 3) which would have an id 2.
+        new_typeset_id = self.lmp.add_typeset(type3s)
+        self.assertEqual(self.lmp.extract_global("ntype_sets"), 3)
+        self.assertEqual(new_typeset_id, 2)
+        
+        # Switching to the type set with id 2 (all type 3).
+        self.lmp.change_typeset(new_typeset_id)
+        # Check that all the types have been assigned correctly
+        self.assertEqual(np.array_equal(type3s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+        self.assertEqual(new_typeset_id, self.lmp.extract_global("current_typeset"))
+        
+        # Switching back to the type set with id 1 (all type 2).
+        self.lmp.change_typeset(1)
+        self.assertEqual(self.lmp.extract_global("current_typeset"), 1)
+        # Check that all the types have been assigned correctly
+        self.assertEqual(np.array_equal(type2s, np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
+        
+        # Deleting a type set with id 2 (all type 3).
+        self.lmp.delete_typeset(2)
+        self.assertEqual(self.lmp.extract_global("ntype_sets"), 2)
+        
+        # Deleting all type sets and going back to the initial state.
+        self.lmp.reset_typesets()
+        self.assertEqual(self.lmp.extract_global("ntype_sets"), 0)
+        self.assertEqual(self.lmp.extract_global("current_typeset"), 0)
+        self.assertEqual(np.array_equal(np.full(100, 1), np.array(self.lmp.gather_atoms("type", 0, 1), dtype=ctypes.c_int)), True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**

This pull request adds functionality to create, delete, switch between, and reset type sets in the LAMMPS Python module. A type set is a collection of types assigned to each atom in LAMMPS, originally stored in the `Atom::type` array. The new functionality allows for multiple versions of this array to be stored and switched between efficiently. This includes:
- Addition of type sets (versions of the `Atom::type` array)
- Deletion of type sets
- Switching between type sets
- Resetting type sets to their original values

Additionally, two new global properties are introduced: `ntype_sets` and `current_typeset`. This functionality is particularly useful for evaluating global properties of specific structures in LAMMPS without the need for molecular dynamics simulations, enabling memory and complexity-efficient probing of type modifications on particular structures.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->
This enhancement does not address a specific open GitHub issue but introduces new capabilities based on user needs and research requirements.

**Author(s)**

The functionality has been developed by Vasilii Maksimov, a member of the Wilkinson Glass Group at Alfred University.

**Licensing**

By submitting this pull request, I agree that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
The changes introduced in this pull request are backward compatible with existing inputs. The new functionality is additive and does not alter existing behavior.

**Implementation Notes**

The new functionality has been implemented by extending the LAMMPS Python module to support operations on type sets. The correctness of the implementation has been verified through unit tests and integration tests with the existing LAMMPS framework. The addition of `ntype_sets` and `current_typeset` global properties allows users to manage and query the state of type sets efficiently.

**Post Submission Checklist**

- [ ] The feature or features in this pull request are complete.
- [ ] Licensing information is complete.
- [ ] Corresponding author information is complete.
- [ ] The source code follows the LAMMPS formatting guidelines.
- [ ] Suitable new documentation files and/or updates to the existing docs are included.
- [ ] The added/updated documentation is integrated and tested with the documentation build system.
- [ ] The feature has been verified to work with the conventional build system.
- [ ] The feature has been verified to work with the CMake-based build system.
- [ ] Suitable tests have been added to the unittest tree.
- [ ] One or more example input decks are included.

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->
For more details and usage examples, please refer to the included documentation and example input decks.
P.S. This is my first attempt at modifying LAMMPS source code, so any commentary, critique, and suggestions from developers are more than welcome.