### PR TITLE
Bugfix/parallel ipi

### DIFF
--- a/src/MISC/fix_ipi.cpp
+++ b/src/MISC/fix_ipi.cpp
@@ -188,6 +188,7 @@ FixIPI::FixIPI(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg), irregul
   master = (comm->me == 0) ? 1 : 0;
   inet = 1;
   reset_flag = 0;
+  firsttime = 1;
 
   int iarg = 5;
   while (iarg < narg) {
@@ -253,6 +254,7 @@ void FixIPI::init()
     ipisock = 0;
   // TODO: should check for success in socket opening,
   // but the current open_socket routine dies brutally if unsuccessful
+
   // tell lammps we have assigned a socket
   socketflag = 1;
 
@@ -382,7 +384,11 @@ void FixIPI::initial_integrate(int /*vflag*/)
   // snapshot at neighbor list creation, minimizing the
   // number of neighbor list updates
   auto xhold = neighbor->get_xhold();
-  if (xhold != NULL) { // don't wrap if xhold is not used in the NL
+  if (xhold != NULL && !firsttime) {
+    // don't wrap if xhold is not used in the NL, or the
+    // first call (because the NL is initialized from the
+    // data file that might have nothing to do with the
+    // current structure
     for (int i = 0; i < nlocal; i++) {
       if (mask[i] & groupbit) {
         auto delx = x[i][0] - xhold[i][0];
@@ -397,6 +403,7 @@ void FixIPI::initial_integrate(int /*vflag*/)
       }
     }
   }
+  firsttime = 0;
 
   // check if kspace solver is used
   if (reset_flag && kspace_flag) {

--- a/src/MISC/fix_ipi.cpp
+++ b/src/MISC/fix_ipi.cpp
@@ -373,6 +373,9 @@ void FixIPI::initial_integrate(int /*vflag*/)
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
   domain->pbc();
   domain->reset_box();
+  // move atoms to new processors via irregular()
+  // only needed if migrate_check() says an atom moves to far
+  if (irregular->migrate_check()) irregular->migrate_atoms();
   if (domain->triclinic) domain->lamda2x(atom->nlocal);
 
   // ensures continuity of trajectories relative to the
@@ -394,11 +397,6 @@ void FixIPI::initial_integrate(int /*vflag*/)
       }
     }
   }
-  // move atoms to new processors via irregular()
-  // only needed if migrate_check() says an atom moves to far
-  if (domain->triclinic) domain->x2lamda(atom->nlocal);
-  if (irregular->migrate_check()) irregular->migrate_atoms();
-  if (domain->triclinic) domain->lamda2x(atom->nlocal);
 
   // check if kspace solver is used
   if (reset_flag && kspace_flag) {

--- a/src/MISC/fix_ipi.h
+++ b/src/MISC/fix_ipi.h
@@ -42,6 +42,7 @@ class FixIPI : public Fix {
   long bsize;
   int kspace_flag;
   int reset_flag;
+  int firsttime;
 
  private:
   class Irregular *irregular;


### PR DESCRIPTION
**Summary**

We found an issue when running with a relative high number of MPI processes (more than 8) on relatively small systems. 
We tested this fix quite extensively scaling up to 256 MPI processes and it seems solid, but advice from someone with a deeper understanding of domain decomposition in LAMMPS would be welcome. 

**Author(s)**

Michele Ceriotti (EPFL), @ceriottm: [michele.ceriotti@gmail.com](mailto:michele.ceriotti@gmail.com)
Davide Tisi (EPFL), @DavideTisi: [davide.tisi@epfl.ch](mailto:davide.tisi@epfl.ch)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This fix change nothing outside the i-PI communication.

**Further Information, Files, and Links**

See [i-pi](http://ipi-code.org/) for a discussion of the background and what fix_ipi does.


