### PR TITLE
core files: replace sprintf with snprintf

### DIFF
--- a/src/dump_atom.cpp
+++ b/src/dump_atom.cpp
@@ -674,7 +674,9 @@ int DumpAtom::convert_image(int n, double *mybuf)
       memory->grow(sbuf,maxsbuf,"dump:sbuf");
     }
 
-    offset += sprintf(&sbuf[offset],format,
+    offset += snprintf(&sbuf[offset],
+                      maxsbuf - offset,
+                      format,
                       static_cast<tagint> (mybuf[m]),
                       static_cast<int> (mybuf[m+1]),
                       mybuf[m+2],mybuf[m+3],mybuf[m+4],
@@ -700,7 +702,9 @@ int DumpAtom::convert_noimage(int n, double *mybuf)
       memory->grow(sbuf,maxsbuf,"dump:sbuf");
     }
 
-    offset += sprintf(&sbuf[offset],format,
+    offset += snprintf(&sbuf[offset],
+                      maxsbuf - offset,
+                      format,
                       static_cast<tagint> (mybuf[m]),
                       static_cast<int> (mybuf[m+1]),
                       mybuf[m+2],mybuf[m+3],mybuf[m+4]);

--- a/src/dump_cfg.cpp
+++ b/src/dump_cfg.cpp
@@ -166,23 +166,24 @@ int DumpCFG::convert_string(int n, double *mybuf)
       }
 
       for (j = 0; j < size_one; j++) {
+        const auto maxsize = maxsbuf - offset;
         if (j == 0) {
-          offset += sprintf(&sbuf[offset],"%f \n",mybuf[m]);
+          offset += snprintf(&sbuf[offset],maxsize,"%f \n",mybuf[m]);
         } else if (j == 1) {
-          offset += sprintf(&sbuf[offset],"%s \n",typenames[(int) mybuf[m]]);
+          offset += snprintf(&sbuf[offset],maxsize,"%s \n",typenames[(int) mybuf[m]]);
         } else if (j >= 2) {
           if (vtype[j] == Dump::INT)
-            offset += sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
+            offset += snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<int> (mybuf[m]));
           else if (vtype[j] == Dump::DOUBLE)
-            offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
+            offset += snprintf(&sbuf[offset],maxsize,vformat[j],mybuf[m]);
           else if (vtype[j] == Dump::STRING)
-            offset += sprintf(&sbuf[offset],vformat[j],typenames[(int) mybuf[m]]);
+            offset += snprintf(&sbuf[offset],maxsize,vformat[j],typenames[(int) mybuf[m]]);
           else if (vtype[j] == Dump::BIGINT)
-            offset += sprintf(&sbuf[offset],vformat[j],static_cast<bigint> (mybuf[m]));
+            offset += snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<bigint> (mybuf[m]));
         }
         m++;
       }
-      offset += sprintf(&sbuf[offset],"\n");
+      offset += snprintf(&sbuf[offset],maxsbuf-offset,"\n");
     }
 
   } else if (unwrapflag == 1) {
@@ -195,29 +196,30 @@ int DumpCFG::convert_string(int n, double *mybuf)
       }
 
       for (j = 0; j < size_one; j++) {
+        const auto maxsize = maxsbuf - offset;
         if (j == 0) {
-          offset += sprintf(&sbuf[offset],"%f \n",mybuf[m]);
+          offset += snprintf(&sbuf[offset],maxsize,"%f \n",mybuf[m]);
         } else if (j == 1) {
-          offset += sprintf(&sbuf[offset],"%s \n",typenames[(int) mybuf[m]]);
+          offset += snprintf(&sbuf[offset],maxsize,"%s \n",typenames[(int) mybuf[m]]);
         } else if (j >= 2 && j <= 4) {
           unwrap_coord = (mybuf[m] - 0.5)/UNWRAPEXPAND + 0.5;
-          offset += sprintf(&sbuf[offset],vformat[j],unwrap_coord);
+          offset += snprintf(&sbuf[offset],maxsize,vformat[j],unwrap_coord);
         } else if (j >= 5) {
           if (vtype[j] == Dump::INT)
             offset +=
-              sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
+              snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<int> (mybuf[m]));
           else if (vtype[j] == Dump::DOUBLE)
-            offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
+            offset += snprintf(&sbuf[offset],maxsize,vformat[j],mybuf[m]);
           else if (vtype[j] == Dump::STRING)
             offset +=
-              sprintf(&sbuf[offset],vformat[j],typenames[(int) mybuf[m]]);
+              snprintf(&sbuf[offset],maxsize,vformat[j],typenames[(int) mybuf[m]]);
           else if (vtype[j] == Dump::BIGINT)
             offset +=
-              sprintf(&sbuf[offset],vformat[j],static_cast<bigint> (mybuf[m]));
+              snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<bigint> (mybuf[m]));
         }
         m++;
       }
-      offset += sprintf(&sbuf[offset],"\n");
+      offset += snprintf(&sbuf[offset],maxsbuf - offset,"\n");
     }
   }
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -1358,20 +1358,21 @@ int DumpCustom::convert_string(int n, double *mybuf)
     }
 
     for (j = 0; j < nfield; j++) {
+      const auto maxsize = maxsbuf - offset;
       if (vtype[j] == Dump::INT)
-        offset += sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<int> (mybuf[m]));
       else if (vtype[j] == Dump::DOUBLE)
-        offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],mybuf[m]);
       else if (vtype[j] == Dump::STRING)
-        offset += sprintf(&sbuf[offset],vformat[j],typenames[(int) mybuf[m]]);
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],typenames[(int) mybuf[m]]);
       else if (vtype[j] == Dump::STRING2)
-        offset += sprintf(&sbuf[offset],vformat[j],atom->lmap->typelabel[(int) mybuf[m]-1].c_str());
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],atom->lmap->typelabel[(int) mybuf[m]-1].c_str());
       else if (vtype[j] == Dump::BIGINT)
-        offset += sprintf(&sbuf[offset],vformat[j],
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],
                           static_cast<bigint> (mybuf[m]));
       m++;
     }
-    offset += sprintf(&sbuf[offset],"\n");
+    offset += snprintf(&sbuf[offset],maxsbuf-offset,"\n");
   }
 
   return offset;
@@ -1909,9 +1910,9 @@ int DumpCustom::modify_param(int narg, char **arg)
       if (ptr == nullptr)
         error->all(FLERR,"Dump_modify int format does not contain d character");
       char str[8];
-      sprintf(str,"%s",BIGINT_FORMAT);
+      snprintf(str,8,"%s",BIGINT_FORMAT);
       *ptr = '\0';
-      sprintf(format_bigint_user,"%s%s%s",format_int_user,&str[1],ptr+1);
+      snprintf(format_bigint_user,n,"%s%s%s",format_int_user,&str[1],ptr+1);
       *ptr = 'd';
 
     } else if (strcmp(arg[1],"float") == 0) {

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -590,15 +590,16 @@ int DumpGrid::convert_string(int n, double *mybuf)
     }
 
     for (j = 0; j < nfield; j++) {
+      const auto maxsize = maxsbuf - offset;
       if (vtype[j] == Dump::INT)
-        offset += sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<int> (mybuf[m]));
       else if (vtype[j] == Dump::DOUBLE)
-        offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],mybuf[m]);
       else if (vtype[j] == Dump::BIGINT)
-        offset += sprintf(&sbuf[offset],vformat[j], static_cast<bigint> (mybuf[m]));
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j], static_cast<bigint> (mybuf[m]));
       m++;
     }
-    offset += sprintf(&sbuf[offset],"\n");
+    offset += snprintf(&sbuf[offset],maxsbuf-offset,"\n");
   }
 
   return offset;
@@ -776,9 +777,9 @@ int DumpGrid::modify_param(int narg, char **arg)
       if (ptr == nullptr)
         error->all(FLERR,"Dump_modify int format does not contain d character");
       char str[8];
-      sprintf(str,"%s",BIGINT_FORMAT);
+      snprintf(str,8,"%s",BIGINT_FORMAT);
       *ptr = '\0';
-      sprintf(format_bigint_user,"%s%s%s",format_int_user,&str[1],ptr+1);
+      snprintf(format_bigint_user,n,"%s%s%s",format_int_user,&str[1],ptr+1);
       *ptr = 'd';
 
     } else if (strcmp(arg[1],"float") == 0) {

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -264,9 +264,9 @@ int DumpLocal::modify_param(int narg, char **arg)
       if (ptr == nullptr)
         error->all(FLERR, "Dump_modify int format does not contain d character");
       char str[8];
-      sprintf(str,"%s",BIGINT_FORMAT);
+      snprintf(str,8,"%s",BIGINT_FORMAT);
       *ptr = '\0';
-      sprintf(format_bigint_user,"%s%s%s",format_int_user,&str[1],ptr+1);
+      snprintf(format_bigint_user,n,"%s%s%s",format_int_user,&str[1],ptr+1);
       *ptr = 'd';
 
     } else if (strcmp(arg[1],"float") == 0) {
@@ -387,17 +387,18 @@ int DumpLocal::convert_string(int n, double *mybuf)
     }
 
     for (j = 0; j < size_one; j++) {
+      const auto maxsize = maxsbuf - offset;
       if (vtype[j] == Dump::INT)
-        offset += sprintf(&sbuf[offset],vformat[j],static_cast<int> (mybuf[m]));
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<int> (mybuf[m]));
       else if (vtype[j] == Dump::DOUBLE)
-        offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],mybuf[m]);
       else if (vtype[j] == Dump::BIGINT)
-        offset += sprintf(&sbuf[offset],vformat[j],static_cast<bigint> (mybuf[m]));
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],static_cast<bigint> (mybuf[m]));
       else
-        offset += sprintf(&sbuf[offset],vformat[j],mybuf[m]);
+        offset += snprintf(&sbuf[offset],maxsize,vformat[j],mybuf[m]);
       m++;
     }
-    offset += sprintf(&sbuf[offset],"\n");
+    offset += snprintf(&sbuf[offset],maxsbuf-offset,"\n");
   }
 
   return offset;

--- a/src/dump_xyz.cpp
+++ b/src/dump_xyz.cpp
@@ -85,7 +85,7 @@ void DumpXYZ::init_style()
     typenames = new char*[ntypes+1];
     for (int itype = 1; itype <= ntypes; itype++) {
       typenames[itype] = new char[12];
-      sprintf(typenames[itype],"%d",itype);
+      snprintf(typenames[itype],12,"%d",itype);
     }
   }
 
@@ -206,7 +206,7 @@ int DumpXYZ::convert_string(int n, double *mybuf)
       memory->grow(sbuf,maxsbuf,"dump:sbuf");
     }
 
-    offset += sprintf(&sbuf[offset], format, typenames[static_cast<int> (mybuf[m+1])],
+    offset += snprintf(&sbuf[offset], maxsbuf-offset, format, typenames[static_cast<int> (mybuf[m+1])],
                       mybuf[m+2], mybuf[m+3], mybuf[m+4]);
     m += size_one;
   }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1025,7 +1025,7 @@ char *Variable::retrieve(const char *name)
       error->all(FLERR, "Variable {}: format variable {} has incompatible style",
                  names[ivar],data[ivar][0]);
     double answer = compute_equal(jvar);
-    sprintf(data[ivar][2],data[ivar][1],answer);
+    snprintf(data[ivar][2],VALUELENGTH,data[ivar][1],answer);
     str = data[ivar][2];
 
   } else if (style[ivar] == GETENV) {

--- a/unittest/fortran/wrap_extract_variable.cpp
+++ b/unittest/fortran/wrap_extract_variable.cpp
@@ -121,7 +121,7 @@ TEST_F(LAMMPS_extract_variable, loop_pad)
     char str[10];
     char *fstr;
     for (i = 1; i <= 10; i++) {
-        std::sprintf(str, "%02d", i);
+        std::snprintf(str, 10, "%02d", i);
         fstr = f_lammps_extract_variable_loop_pad();
         EXPECT_STREQ(fstr, str);
         std::free(fstr);
@@ -170,7 +170,7 @@ TEST_F(LAMMPS_extract_variable, format)
     char str[16];
     char *fstr;
     for (i = 1; i <= 10; i++) {
-        std::sprintf(str, "%.6G", std::exp(i));
+        std::snprintf(str, 16, "%.6G", std::exp(i));
         fstr = f_lammps_extract_variable_format();
         EXPECT_STREQ(fstr, str);
         std::free(fstr);
@@ -185,7 +185,7 @@ TEST_F(LAMMPS_extract_variable, format_pad)
     char str[16];
     char *fstr;
     for (i = 1; i <= 10; i++) {
-        std::sprintf(str, "%08.6G", std::exp(i));
+        std::snprintf(str, 16, "%08.6G", std::exp(i));
         fstr = f_lammps_extract_variable_format_pad();
         EXPECT_STREQ(fstr, str);
         std::free(fstr);


### PR DESCRIPTION
**Summary**

Suppresses a few more compilation warnings when compiling with Clang on MacOS. These are cases where replacing it with `fmt::sprintf` isn't possible unless you rewrite more logic.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


