### PR TITLE
Fix reading empty type label string in restart

### DIFF
--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -369,35 +369,35 @@ void LabelMap::read_restart(FILE *fp)
   for (int i = 0; i < natomtypes; i++) {
     charlabel = read_string(fp);
     typelabel[i] = charlabel;
-    typelabel_map[charlabel] = i + 1;
+    if (strlen(charlabel) > 0) typelabel_map[charlabel] = i + 1;
     delete[] charlabel;
   }
 
   for (int i = 0; i < nbondtypes; i++) {
     charlabel = read_string(fp);
     btypelabel[i] = charlabel;
-    btypelabel_map[charlabel] = i + 1;
+    if (strlen(charlabel) > 0) btypelabel_map[charlabel] = i + 1;
     delete[] charlabel;
   }
 
   for (int i = 0; i < nangletypes; i++) {
     charlabel = read_string(fp);
     atypelabel[i] = charlabel;
-    atypelabel_map[charlabel] = i + 1;
+    if (strlen(charlabel) > 0) atypelabel_map[charlabel] = i + 1;
     delete[] charlabel;
   }
 
   for (int i = 0; i < ndihedraltypes; i++) {
     charlabel = read_string(fp);
     dtypelabel[i] = charlabel;
-    dtypelabel_map[charlabel] = i + 1;
+    if (strlen(charlabel) > 0) dtypelabel_map[charlabel] = i + 1;
     delete[] charlabel;
   }
 
   for (int i = 0; i < nimpropertypes; i++) {
     charlabel = read_string(fp);
     itypelabel[i] = charlabel;
-    itypelabel_map[charlabel] = i + 1;
+    if (strlen(charlabel) > 0) itypelabel_map[charlabel] = i + 1;
     delete[] charlabel;
   }
 }


### PR DESCRIPTION
**Summary**

Bugfix for type labels in label_map.cpp. When reading restart files, type labels are now checked for empty strings before using as keys in the label map. This prevents invalid data file output seen in issue #4251.

**Related Issue(s)**

fixes #4251

**Author(s)**

Kieran Harris, University of Manchester

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No known issues.

**Implementation Notes**

Checks for empty strings before assigning label map entries. Tested using the example input files in issue #4251 .

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


