### PR TITLE
Type label support for dump image, movie 

### DIFF
--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -169,6 +169,9 @@ Examples
 
    dump_modify 1 amap min max cf 0.0 3 min green 0.5 yellow max blue boxcolor red
 
+   labelmap atom 1 C 2 H 3 O 4 N
+   dump_modify 1 acolor C gray acolor H white acolor O red acolor N blue
+
 Description
 """""""""""
 

--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -111,10 +111,10 @@ Syntax
   .. parsed-literal::
 
        *acolor* args = type color
-         type = atom type or range of types (see below)
+         type = atom type (numeric or type label) or range of numeric types (see below)
          color = name of color or color1/color2/...
        *adiam* args = type diam
-         type = atom type or range of types (see below)
+         type = atom type (numeric or type label) or range of numeric types (see below)
          diam = diameter of atoms of that type (distance units)
        *amap* args = lo hi style delta N entry1 entry2 ... entryN
          lo = number or *min* = lower bound of range of color map
@@ -739,15 +739,15 @@ The *acolor* keyword can be used with the dump image command, when its
 atom color setting is *type*, to set the color that atoms of each type
 will be drawn in the image.
 
-The specified *type* should be an integer from 1 to Ntypes = the
-number of atom types.  A wildcard asterisk can be used in place of or
-in conjunction with the *type* argument to specify a range of atom
-types.  This takes the form "\*" or "\*n" or "n\*" or "m\*n".  If N =
-the number of atom types, then an asterisk with no numeric values
-means all types from 1 to N.  A leading asterisk means all types from
-1 to n (inclusive).  A trailing asterisk means all types from n to N
-(inclusive).  A middle asterisk means all types from m to n
-(inclusive).
+The specified *type* should be a type label or integer from 1 to Ntypes
+= the number of atom types.  For numeric types, a wildcard asterisk can
+be used in place of or in conjunction with the *type* argument to
+specify a range of atom types.  This takes the form "\*" or "\*n" or
+"n\*" or "m\*n". If N = the number of atom types, then an asterisk with
+no numeric values means all types from 1 to N.  A leading asterisk
+means all types from 1 to n (inclusive).  A trailing asterisk means all
+types from n to N (inclusive).  A middle asterisk means all types from
+m to n (inclusive).
 
 The specified *color* can be a single color which is any of the 140
 pre-defined colors (see below) or a color name defined by the
@@ -761,11 +761,12 @@ fashion to each of the specified atom types.
 
 The *adiam* keyword can be used with the dump image command, when its
 atom diameter setting is *type*, to set the size that atoms of each
-type will be drawn in the image.  The specified *type* should be an
-integer from 1 to Ntypes.  As with the *acolor* keyword, a wildcard
-asterisk can be used as part of the *type* argument to specify a range
-of atom types.  The specified *diam* is the size in whatever distance
-:doc:`units <units>` the input script is using, e.g. Angstroms.
+type will be drawn in the image.  The specified *type* should be a type
+label or integer from 1 to Ntypes.  As with the *acolor* keyword, a
+wildcard asterisk can be used as part of the *type* argument to specify
+a range of numeric atom types.  The specified *diam* is the size in
+whatever distance :doc:`units <units>` the input script is using, e.g.
+Angstroms.
 
 ----------
 

--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -139,10 +139,10 @@ Syntax
        *backcolor* arg = color
          color = name of color for background
        *bcolor* args = type color
-         type = bond type or range of types (see below)
+         type = bond type (numeric or type label) or range of numeric types (see below)
          color = name of color or color1/color2/...
        *bdiam* args = type diam
-         type = bond type or range of types (see below)
+         type = bond type (numeric or type label) or range of numeric types (see below)
          diam = diameter of bonds of that type (distance units)
        *bitrate* arg = rate
          rate = target bitrate for movie in kbps
@@ -909,14 +909,15 @@ The *bcolor* keyword can be used with the dump image command, with its
 *bond* keyword, when its color setting is *type*, to set the color
 that bonds of each type will be drawn in the image.
 
-The specified *type* should be an integer from 1 to :math:`N`, where :math:`N`
-is the number of bond types.  A wildcard asterisk can be used in place of or
-in conjunction with the *type* argument to specify a range of bond
-types.  This takes the form "\*" or "\*n" or "m\*" or "m\*n".  If :math:`N`
-is the number of bond types, then an asterisk with no numerical values
-means all types from 1 to :math:`N`.  A leading asterisk means all types from
-1 to n (inclusive).  A trailing asterisk means all types from m to :math:`N`
-(inclusive).  A middle asterisk means all types from m to n
+The specified *type* should be a type label or integer from 1 to
+:math:`N`, where :math:`N` is the number of bond types.  For numeric
+types, a wildcard asterisk can be used in place of or in conjunction
+with the *type* argument to specify a range of bond types.  This takes
+the form "\*" or "\*n" or "m\*" or "m\*n".  If :math:`N` is the number
+of bond types, then an asterisk with no numerical values means all
+types from 1 to :math:`N`.  A leading asterisk means all types from 1
+to n (inclusive).  A trailing asterisk means all types from m to
+:math:`N` (inclusive).  A middle asterisk means all types from m to n
 (inclusive).
 
 The specified *color* can be a single color which is any of the 140
@@ -932,11 +933,11 @@ of the specified bond types.
 The *bdiam* keyword can be used with the dump image command, with its
 *bond* keyword, when its *diam* setting is *type*, to set the diameter
 that bonds of each type will be drawn in the image.  The specified
-*type* should be an integer from 1 to Nbondtypes.  As with the
-*bcolor* keyword, a wildcard asterisk can be used as part of the
-*type* argument to specify a range of bond types.  The specified
-*diam* is the size in whatever distance :doc:`units <units>` you are
-using (e.g., Angstroms).
+*type* should be a type label or integer from 1 to Nbondtypes.  As with
+the *bcolor* keyword, a wildcard asterisk can be used as part of the
+*type* argument to specify a range of numeric bond types.  The
+specified *diam* is the size in whatever distance :doc:`units <units>`
+you are using (e.g., Angstroms).
 
 ----------
 

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -1536,7 +1536,7 @@ int DumpImage::modify_param(int narg, char **arg)
   if (strcmp(arg[0],"acolor") == 0) {
     if (narg < 3) error->all(FLERR,"Illegal dump_modify command");
     int nlo,nhi;
-    utils::bounds(FLERR,arg[1],1,atom->ntypes,nlo,nhi,error);
+    utils::bounds_typelabel(FLERR,arg[1],1,atom->ntypes,nlo,nhi,lmp,Atom::ATOM);
 
     // get list of colors
     // assign colors in round-robin fashion to types
@@ -1557,7 +1557,7 @@ int DumpImage::modify_param(int narg, char **arg)
   if (strcmp(arg[0],"adiam") == 0) {
     if (narg < 3) error->all(FLERR,"Illegal dump_modify command");
     int nlo,nhi;
-    utils::bounds(FLERR,arg[1],1,atom->ntypes,nlo,nhi,error);
+    utils::bounds_typelabel(FLERR,arg[1],1,atom->ntypes,nlo,nhi,lmp,Atom::ATOM);
     double diam = utils::numeric(FLERR,arg[2],false,lmp);
     if (diam <= 0.0) error->all(FLERR,"Illegal dump_modify command");
     for (int i = nlo; i <= nhi; i++) diamtype[i] = diam;

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -1588,7 +1588,7 @@ int DumpImage::modify_param(int narg, char **arg)
     if (atom->nbondtypes == 0)
       error->all(FLERR,"Dump modify bcolor not allowed with no bond types");
     int nlo,nhi;
-    utils::bounds(FLERR,arg[1],1,atom->nbondtypes,nlo,nhi,error);
+    utils::bounds_typelabel(FLERR,arg[1],1,atom->nbondtypes,nlo,nhi,lmp,Atom::BOND);
 
     // process list of ncount colornames separated by '/'
     // assign colors in round-robin fashion to bond types
@@ -1611,7 +1611,7 @@ int DumpImage::modify_param(int narg, char **arg)
     if (atom->nbondtypes == 0)
       error->all(FLERR,"Dump modify bdiam not allowed with no bond types");
     int nlo,nhi;
-    utils::bounds(FLERR,arg[1],1,atom->nbondtypes,nlo,nhi,error);
+    utils::bounds_typelabel(FLERR,arg[1],1,atom->nbondtypes,nlo,nhi,lmp,Atom::BOND);
     double diam = utils::numeric(FLERR,arg[2],false,lmp);
     if (diam <= 0.0) error->all(FLERR,"Illegal dump_modify command");
     for (int i = nlo; i <= nhi; i++) bdiamtype[i] = diam;


### PR DESCRIPTION
**Summary**

Type labels for dump_modify 'acolor', 'adiam', 'bcolor', 'bdiam' keywords for dump image, movie

**Related Issue(s)**

none

**Author(s)**

Jake

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


