### PR TITLE
Fix a bug when restarting with stored data in fix STORE/GLOBAL for global vectors or arrays

### DIFF
--- a/src/fix_store_global.cpp
+++ b/src/fix_store_global.cpp
@@ -17,6 +17,9 @@
 #include "error.h"
 #include "memory.h"
 
+// DEBUG
+#include "update.h"
+
 #include <cstring>
 
 using namespace LAMMPS_NS;
@@ -152,7 +155,8 @@ void FixStoreGlobal::restart(char *buf)
   //   means the restart file is setting size of vec or array and doing init
   //   because caller did not know size at time this fix was instantiated
   // reallocate vstore or astore accordingly
-
+  // also reset nrow,ncol to values from restart file
+  
   if (n1 != n1_restart || n2 != n2_restart) {
     memory->destroy(vstore);
     memory->destroy(astore);
@@ -165,8 +169,8 @@ void FixStoreGlobal::restart(char *buf)
       vecflag = 1;
     else
       arrayflag = 1;
-    n1 = n1_restart;
-    n2 = n2_restart;
+    nrow = n1 = n1_restart;
+    ncol = n2 = n2_restart;
     if (vecflag)
       memory->create(vstore, n1, "fix/store:vstore");
     else if (arrayflag)

--- a/src/fix_store_global.cpp
+++ b/src/fix_store_global.cpp
@@ -153,7 +153,7 @@ void FixStoreGlobal::restart(char *buf)
   //   because caller did not know size at time this fix was instantiated
   // reallocate vstore or astore accordingly
   // also reset nrow,ncol to values from restart file
-  
+
   if (n1 != n1_restart || n2 != n2_restart) {
     memory->destroy(vstore);
     memory->destroy(astore);

--- a/src/fix_store_global.cpp
+++ b/src/fix_store_global.cpp
@@ -17,9 +17,6 @@
 #include "error.h"
 #include "memory.h"
 
-// DEBUG
-#include "update.h"
-
 #include <cstring>
 
 using namespace LAMMPS_NS;


### PR DESCRIPTION
**Summary**

A couple of commands use the internal fix STORE/GLOBAL command to store a vector or array of global data.  E.g. the compute msd/chunk command does this to store the time=0 COM coords of each chunk.  When running a restarted calculation the global data is stored in the restart file.  So that in a restarted calculation, the MSD for each chunk would be continuous.

However, the restarting code in fix_store_global.cpp was not resetting the size of the global vector or array correctly, so that the global data was effectively lost.  In this case it meant the MSD was reset to zero at the beginning of the restarted run.

**Related Issue(s)**

No LAMMPS issues, but this issue was raised in the MatSci forum:
https://matsci.org/t/msd-computation-w-msd-chunk-and-restart/56657

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


