### PR TITLE
Doc pdf g clavier

### DIFF
--- a/doc/src/Errors_common.rst
+++ b/doc/src/Errors_common.rst
@@ -39,7 +39,8 @@ figure out your physics or numerical mistakes, like choosing too big a
 timestep, specifying erroneous force field coefficients, or putting 2
 atoms on top of each other!  If you run into errors that LAMMPS
 does not catch that you think it should flag, please send an email to
-the `developers <https://www.lammps.org/authors.html>`_.
+the `developers <https://www.lammps.org/authors.html>`_ or create an new
+topic on the dedicated `MatSci forum section <https://matsci.org/lammps/>`_.
 
 If you get an error message about an invalid command in your input
 script, you can determine what command is causing the problem by

--- a/doc/src/Errors_messages.rst
+++ b/doc/src/Errors_messages.rst
@@ -1932,7 +1932,7 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
    Self-explanatory.
 
 *Compute chunk/atom fix array is accessed out-of-range*
-   the index for the array is out of bounds.
+   The index for the array is out of bounds.
 
 *Compute chunk/atom fix does not calculate a per-atom array*
    Self-explanatory.
@@ -6073,9 +6073,9 @@ Doc page with :doc:`WARNING messages <Errors_warnings>`
 *New atom IDs exceed maximum allowed ID*
    See the setting for tagint in the src/lmptype.h file.
 
-*New bond exceeded bonds per atom in create_bonds*
-See the read_data command for info on using the "extra/bond/per/atom"
-keyword to allow for additional bonds to be formed
+*New bond exceeded bonds per atom in create\_bonds*
+   See the read_data command for info on using the "extra/bond/per/atom"
+   keyword to allow for additional bonds to be formed
 
 *New bond exceeded bonds per atom in fix bond/create*
    See the read_data command for info on using the "extra/bond/per/atom"

--- a/doc/src/Errors_warnings.rst
+++ b/doc/src/Errors_warnings.rst
@@ -233,7 +233,7 @@ Doc page with :doc:`ERROR messages <Errors_messages>`
    style.
 
 *Fix langevin gjf using random gaussians is not implemented with kokkos*
-This will most likely cause errors in kinetic fluctuations.
+   This will most likely cause errors in kinetic fluctuations.
 
 *Fix property/atom mol or charge w/out ghost communication*
    A model typically needs these properties defined for ghost atoms.

--- a/doc/src/Tools.rst
+++ b/doc/src/Tools.rst
@@ -111,7 +111,7 @@ Tool descriptions
 amber2lmp tool
 --------------------------
 
-The amber2lmp subdirectory contains two Python scripts for converting
+The amber2lmp subdirectory contains three Python scripts for converting
 files back-and-forth between the AMBER MD code and LAMMPS.  See the
 README file in amber2lmp for more information.
 

--- a/doc/src/Tools.rst
+++ b/doc/src/Tools.rst
@@ -97,6 +97,7 @@ Miscellaneous tools
    * :ref:`Offline build tool <offline>`
    * :ref:`singularity/apptainer <singularity_tool>`
    * :ref:`SWIG interface <swig>`
+   * :ref:`valgrind <valgrind>`
    * :ref:`vim <vim>`
 
 ----------
@@ -1207,6 +1208,19 @@ The ``tabulate`` folder contains Python scripts scripts to generate tabulated
 potential files for LAMMPS.  The bulk of the code is in the ``tabulate`` module
 in the ``tabulate.py`` file.  Some example files demonstrating its use are
 included.  See the README file for more information.
+
+----------
+
+.. _valgrind:
+
+valgrind tool
+-------------
+
+The ``valgrind`` folder contains additional suppressions fur LAMMPS when using
+valgrind's memcheck tool to search for memory access violation and memory
+leaks. These suppressions are automatically invoked when running tests through
+CMake "ctest -T memcheck". See the provided README file to add these
+suppressions when running LAMMPS.
 
 ----------
 

--- a/doc/src/Tools.rst
+++ b/doc/src/Tools.rst
@@ -304,7 +304,7 @@ The parameters for Cr were taken from:
 Lin Z B, Johnson R A and Zhigilei L V, Phys. Rev. B 77 214108 (2008).
 
 The Python version of the tool was authored  by Germain Clavier
-(TU Eindhoven) g.m.g.c.clavier at tue.nl or germain.clavier at gmail.com
+(Unicaen) germain.clavier at unicaen.fr
 
 .. note::
 

--- a/doc/src/Tools.rst
+++ b/doc/src/Tools.rst
@@ -58,6 +58,7 @@ Pre-processing tools
    * :ref:`polybond <polybond>`
    * :ref:`stl_bin2txt <stlconvert>`
    * :ref:`tabulate <tabulate>`
+   * :ref:`tinker <tinker>`
 
 Post-processing tools
 =====================
@@ -1208,6 +1209,20 @@ The ``tabulate`` folder contains Python scripts scripts to generate tabulated
 potential files for LAMMPS.  The bulk of the code is in the ``tabulate`` module
 in the ``tabulate.py`` file.  Some example files demonstrating its use are
 included.  See the README file for more information.
+
+----------
+
+.. _tinker:
+
+tinker tool
+--------------
+
+The ``tinker`` folder contains Python scripts scripts to convert Tinker input
+files to LAMMPS.
+
+See the README file for more information.
+
+Those scripts were written by Steve Plimpton sjplimp at gmail.com
 
 ----------
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -5450,7 +5450,7 @@ The function returns the number of atoms created or -1 on failure (e.g.,
 when called before as box has been created).
 
 Coordinates and velocities have to be given in a 1d-array in the order
-X(1),Y(1),Z(1),X(2),Y(2),Z(2),...,X(N),Y(N),Z(N).
+X(1), Y(1), Z(1), X(2), Y(2), Z(2), ..., X(N), Y(N), Z(N).
 
 \endverbatim
  *


### PR DESCRIPTION
**Summary**

Review of the pdf between p400 and 672. I went a bit above p400 in order to start at the Tools section, might overlap with @rbberger work.

Some Comments:
- Some tables are ugly. In  the pdf, see for example `lammps_extract_global` in the C API part. Centering them would help maybe? This would require going through the whole library.cpp file. I don't know if this is necessary.
- There is a weird pdf formatting issue on p625 in the FORTRAN API format (see fix_external_set_energy_global subroutine). I did not find how to fix it.

In both cases the html version if fine. Nothing more catches my eye through simple visual inspection. (I did not go through  the details of all the error and warning message and trusted the text there and focused on the format.)

**Related Issue(s)**

Issue #4274

**Author(s)**

Germain Clavier (germain.clavier@unicaen.fr)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

