### PR TITLE
Amend doc page explanations of vector outputs from the various compute temp commands

### DIFF
--- a/doc/src/compute_pressure.rst
+++ b/doc/src/compute_pressure.rst
@@ -76,8 +76,8 @@ calculated.  This includes a kinetic energy (temperature) term and the
 virial as the sum of pair, bond, angle, dihedral, improper, kspace
 (long-range), and fix contributions to the force on each atom.  If any
 extra keywords are listed, then only those components are summed to
-compute temperature or ke and/or the virial.  The *virial* keyword
-means include all terms except the kinetic energy *ke*\ .
+compute temperature or ke and/or the virial.  The *virial* keyword means
+include all terms except the kinetic energy *ke*\ .
 
 The *pair/hybrid* keyword means to only include contribution
 from a sub-style in a *hybrid* or *hybrid/overlay* pair style.
@@ -89,18 +89,18 @@ effects of periodic boundary conditions are discussed in
 
 The temperature and kinetic energy tensor are not calculated by this
 compute, but rather by the temperature compute specified with the
-command.  See the doc pages for individual compute temp variants for
-an explation of how they calculate temperature and a symmetric tensor
-(6-element vector) whose components are twice that of the traditional
-KE tensor.  That tensor is what appears in the pressure tensor formula
+command.  See the doc pages for individual compute temp variants for an
+explanation of how they calculate temperature and a symmetric tensor
+(6-element vector) whose components are twice that of the traditional KE
+tensor.  That tensor is what appears in the pressure tensor formula
 above.
 
-If the kinetic energy is not included in the pressure, than
-the temperature compute is not used and can be specified as NULL.
-Normally the temperature compute used by compute pressure should
-calculate the temperature of all atoms for consistency with the virial
-term, but any compute style that calculates temperature can be used
-(e.g., one that excludes frozen atoms or other degrees of freedom).
+If the kinetic energy is not included in the pressure, than the
+temperature compute is not used and can be specified as NULL.  Normally
+the temperature compute used by compute pressure should calculate the
+temperature of all atoms for consistency with the virial term, but any
+compute style that calculates temperature can be used (e.g., one that
+excludes frozen atoms or other degrees of freedom).
 
 Note that if desired the specified temperature compute can be one that
 subtracts off a bias to calculate a temperature using only the thermal
@@ -142,9 +142,8 @@ The ordering of values in the symmetric pressure tensor is as follows:
 :math:`p_{xx},` :math:`p_{yy},` :math:`p_{zz},` :math:`p_{xy},`
 :math:`p_{xz},` :math:`p_{yz}.`
 
-The scalar and vector values calculated by this compute are
-"intensive".  The scalar and vector values will be in pressure
-:doc:`units <units>`.
+The scalar and vector values calculated by this compute are "intensive".
+The scalar and vector values will be in pressure :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_pressure.rst
+++ b/doc/src/compute_pressure.rst
@@ -63,7 +63,7 @@ ordered :math:`xx,` :math:`yy,` :math:`zz,` :math:`xy,` :math:`xz,`
 :math:`yz.` The equation for the :math:`(I,J)` components (where
 :math:`I` and :math:`J` are :math:`x`, :math:`y`, or :math:`z`) is
 similar to the above formula, except that the first term uses
-components derived from the kinetic energy tensor and the second term
+components related to the kinetic energy tensor and the second term
 uses components of the virial tensor:
 
 .. math::

--- a/doc/src/compute_pressure.rst
+++ b/doc/src/compute_pressure.rst
@@ -59,11 +59,12 @@ may also contribute to the virial term.
 
 A symmetric pressure tensor, stored as a 6-element vector, is also
 calculated by this compute.  The six components of the vector are
-ordered :math:`xx,` :math:`yy,` :math:`zz,` :math:`xy,` :math:`xz,` :math:`yz.`
-The equation for the :math:`(I,J)` components (where :math:`I` and :math:`J`
-are :math:`x`, :math:`y`, or :math:`z`) is similar to the above formula,
-except that the first term uses components of the kinetic energy tensor and the
-second term uses components of the virial tensor:
+ordered :math:`xx,` :math:`yy,` :math:`zz,` :math:`xy,` :math:`xz,`
+:math:`yz.` The equation for the :math:`(I,J)` components (where
+:math:`I` and :math:`J` are :math:`x`, :math:`y`, or :math:`z`) is
+similar to the above formula, except that the first term uses
+components derived from the kinetic energy tensor and the second term
+uses components of the virial tensor:
 
 .. math::
 
@@ -86,9 +87,15 @@ system, including for many-body potentials and accounting for the
 effects of periodic boundary conditions are discussed in
 :ref:`(Thompson) <Thompson1>`.
 
-The temperature and kinetic energy tensor is not calculated by this
+The temperature and kinetic energy tensor are not calculated by this
 compute, but rather by the temperature compute specified with the
-command.  If the kinetic energy is not included in the pressure, than
+command.  See the doc pages for individual compute temp variants for
+an explation of how they calculate temperature and a symmetric tensor
+(6-element vector) whose components are twice that of the traditional
+KE tensor.  That tensor is what appears in the pressure tensor formula
+above.
+
+If the kinetic energy is not included in the pressure, than
 the temperature compute is not used and can be specified as NULL.
 Normally the temperature compute used by compute pressure should
 calculate the temperature of all atoms for consistency with the virial
@@ -98,14 +105,13 @@ term, but any compute style that calculates temperature can be used
 Note that if desired the specified temperature compute can be one that
 subtracts off a bias to calculate a temperature using only the thermal
 velocity of the atoms (e.g., by subtracting a background streaming
-velocity).
-See the doc pages for individual :doc:`compute commands <compute>` to determine
-which ones include a bias.
+velocity).  See the doc pages for individual :doc:`compute commands
+<compute>` to determine which ones include a bias.
 
 Also note that the :math:`N` in the first formula above is really
-degrees-of-freedom divided by :math:`d` = dimensionality, where the DOF value
-is calculated by the temperature compute.
-See the various :doc:`compute temperature <compute>` styles for details.
+degrees-of-freedom divided by :math:`d` = dimensionality, where the
+DOF value is calculated by the temperature compute.  See the various
+:doc:`compute temperature <compute>` styles for details.
 
 A compute of this style with the ID of thermo_press is created when
 LAMMPS starts up, as if this command were in the input script:

--- a/doc/src/compute_temp.rst
+++ b/doc/src/compute_temp.rst
@@ -48,14 +48,18 @@ the group, :math:`N_\mathrm{fix DOFs}` is the number of degrees of
 freedom removed by fix commands (see below), :math:`k_B` is the
 Boltzmann constant, and :math:`T` is the resulting computed temperature.
 
-A kinetic energy tensor, stored as a six-element vector, is also
-calculated by this compute for use in the computation of a pressure
-tensor.  The formula for the components of the tensor is the same as the
-above expression for :math:`E_\mathrm{kin}`, except that :math:`v_i^2` is
-replaced by :math:`v_{i,x} v_{i,y}` for the :math:`xy` component, and so on.
-The six components of the vector are ordered :math:`xx`, :math:`yy`,
-:math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
-
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
+      
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic* option of the
 :doc:`compute_modify <compute_modify>` command if this is not the case.
@@ -94,16 +98,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length six (KE tensor), which can be accessed by indices
-1--6.  These values can be used by any command that uses global scalar
-or vector values from a compute as input.  See the :doc:`Howto output
-<Howto_output>` page for an overview of LAMMPS output options.
+vector of length six (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_asphere.rst
+++ b/doc/src/compute_temp_asphere.rst
@@ -90,6 +90,19 @@ for the :math:`xy` component, and the appropriate elements of the moment of
 inertia tensor are used.  The six components of the vector are ordered
 :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
 
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` and :math:`\omega^2` are replaced by :math:`v_x v_y`
+and :math:`\omega_x \omega_y` for the :math:`xy` component, and so on.
+And the appropriate elements of the moment of inertia tensor are used.
+Note that because it lacks the 1/2 factor, these tensor components are
+twice those of the traditional kinetic energy tensor.  The six
+components of the vector are ordered :math:`xx`, :math:`yy`,
+:math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic/dof* option of
 the :doc:`compute_modify <compute_modify>` command if this is not the
@@ -131,17 +144,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.
-See the :doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+vector of length 6 (symmertic tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
 output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_asphere.rst
+++ b/doc/src/compute_temp_asphere.rst
@@ -41,8 +41,8 @@ translational and rotational kinetic energy.  This differs from the
 usual :doc:`compute temp <compute_temp>` command, which assumes point
 particles with only translational kinetic energy.
 
-Only finite-size particles (aspherical or spherical) can be included
-in the group.  For 3d finite-size particles, each has six degrees of
+Only finite-size particles (aspherical or spherical) can be included in
+the group.  For 3d finite-size particles, each has six degrees of
 freedom (three translational, three rotational).  For 2d finite-size
 particles, each has three degrees of freedom (two translational, one
 rotational).
@@ -70,38 +70,39 @@ axis.  It will also be the case for biaxial ellipsoids when exactly two
 of the semiaxes have the same length and the corresponding relative well
 depths are equal.
 
-The translational kinetic energy is computed the same as is described
-by the :doc:`compute temp <compute_temp>` command.  The rotational
-kinetic energy is computed as :math:`\frac12 I \omega^2`, where :math:`I` is
-the inertia tensor for the aspherical particle and :math:`\omega` is its
+The translational kinetic energy is computed the same as is described by
+the :doc:`compute temp <compute_temp>` command.  The rotational kinetic
+energy is computed as :math:`\frac12 I \omega^2`, where :math:`I` is the
+inertia tensor for the aspherical particle and :math:`\omega` is its
 angular velocity, which is computed from its angular momentum.
 
 .. note::
 
    For :doc:`2d models <dimension>`, particles are treated as
-   ellipsoids, not ellipses, meaning their moments of inertia will be the
-   same as in 3d.
+   ellipsoids, not ellipses, meaning their moments of inertia will be
+   the same as in 3d.
 
 A kinetic energy tensor, stored as a six-element vector, is also
 calculated by this compute.  The formula for the components of the
 tensor is the same as the above formula, except that :math:`v^2` and
-:math:`\omega^2` are replaced by :math:`v_x v_y` and :math:`\omega_x \omega_y`
-for the :math:`xy` component, and the appropriate elements of the moment of
-inertia tensor are used.  The six components of the vector are ordered
-:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+:math:`\omega^2` are replaced by :math:`v_x v_y` and :math:`\omega_x
+\omega_y` for the :math:`xy` component, and the appropriate elements of
+the moment of inertia tensor are used.  The six components of the vector
+are ordered :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
 
 A symmetric tensor, stored as a six-element vector, is also calculated
 by this compute for use in the computation of a pressure tensor by the
-:doc:`compute pressue <compute_pressure>` command.  The formula for
-the components of the tensor is the same as the above expression for
+:doc:`compute pressue <compute_pressure>` command.  The formula for the
+components of the tensor is the same as the above expression for
 :math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
 the :math:`v_i^2` and :math:`\omega^2` are replaced by :math:`v_x v_y`
 and :math:`\omega_x \omega_y` for the :math:`xy` component, and so on.
 And the appropriate elements of the moment of inertia tensor are used.
 Note that because it lacks the 1/2 factor, these tensor components are
 twice those of the traditional kinetic energy tensor.  The six
-components of the vector are ordered :math:`xx`, :math:`yy`,
-:math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+components of the vector are ordered :math:`xx`, :math:`yy`, :math:`zz`,
+:math:`xy`, :math:`xz`, :math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic/dof* option of
@@ -144,14 +145,13 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (symmertic tensor), which can be accessed by
-indices 1--6.  These values can be used by any command that uses
-global scalar or vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
-output options.
+vector of length 6 (symmetric tensor), which can be accessed by indices
+1--6.  These values can be used by any command that uses global scalar
+or vector values from a compute as input.  See the :doc:`Howto output
+<Howto_output>` page for an overview of LAMMPS output options.
 
-The scalar value calculated by this compute is "intensive".  The
-vector values are "extensive".
+The scalar value calculated by this compute is "intensive".  The vector
+values are "extensive".
 
 The scalar value is in temperature :doc:`units <units>`.  The vector
 values are in energy :doc:`units <units>`.
@@ -160,11 +160,11 @@ Restrictions
 """"""""""""
 
 This compute is part of the ASPHERE package.  It is only enabled if
-LAMMPS was built with that package.  See the :doc:`Build package <Build_package>` page for more info.
+LAMMPS was built with that package.  See the :doc:`Build package
+<Build_package>` page for more info.
 
-This compute requires that atoms store angular momentum and a
-quaternion as defined by the :doc:`atom_style ellipsoid <atom_style>`
-command.
+This compute requires that atoms store angular momentum and a quaternion
+as defined by the :doc:`atom_style ellipsoid <atom_style>` command.
 
 All particles in the group must be finite-size.  They cannot be point
 particles, but they can be aspherical or spherical as defined by their

--- a/doc/src/compute_temp_body.rst
+++ b/doc/src/compute_temp_body.rst
@@ -62,12 +62,17 @@ kinetic energy is computed as :math:`\frac12 I \omega^2`, where :math:`I`
 is the moment of inertia tensor for the aspherical particle and :math:`\omega`
 is its angular velocity, which is computed from its angular momentum.
 
-A kinetic energy tensor, stored as a 6-element vector, is also calculated by
-this compute.  The formula for the components of the tensor is the same as the
-above formula, except that :math:`v^2` and :math:`\omega^2` are
-replaced by :math:`v_x v_y` and :math:`\omega_x \omega_y` for the
-math:`xy` component, and the appropriate elements of the inertia tensor are
-used.  The six components of the vector are ordered :math:`xx`, :math:`yy`,
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` and :math:`\omega^2` are replaced by :math:`v_x v_y`
+and :math:`\omega_x \omega_y` for the :math:`xy` component, and so on.
+And the appropriate elements of the moment of inertia tensor are used.
+Note that because it lacks the 1/2 factor, these tensor components are
+twice those of the traditional kinetic energy tensor.  The six
+components of the vector are ordered :math:`xx`, :math:`yy`,
 :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be
@@ -111,17 +116,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.
-See the :doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
 output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.
-The vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_chunk.rst
+++ b/doc/src/compute_temp_chunk.rst
@@ -85,12 +85,14 @@ By default, *adof* = 2 or 3 = dimensionality of system, as set via the
 :doc:`dimension <dimension>` command, and *cdof* = 0.0.
 This gives the usual formula for temperature.
 
-A kinetic energy tensor, stored as a six-element vector, is also
-calculated by this compute for use in the computation of a pressure
-tensor.  The formula for the components of the tensor is the same as
-the above formula, except that :math:`v^2` is replaced by
-:math:`v_x v_y` for the :math:`xy` component, and so on.
-The six components of the vector are ordered :math:`xx`, :math:`yy`,
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute.  The formula for the components of the tensor is the
+same as the above expression for :math:`E_\mathrm{kin}`, except that
+the 1/2 factor is NOT included and the :math:`v_i^2` is replaced by
+:math:`v_{i,x} v_{i,y}` for the :math:`xy` component, and so on.  Note
+that because it lacks the 1/2 factor, these tensor components are
+twice those of the traditional kinetic energy tensor.  The six
+components of the vector are ordered :math:`xx`, :math:`yy`,
 :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
 
 Note that the number of atoms contributing to the temperature is
@@ -227,10 +229,10 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.
-See the :doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
 output options.
 
 This compute also optionally calculates a global array, if one or more
@@ -245,9 +247,9 @@ page for an overview of LAMMPS output options.
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".  The array values are "intensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.  The array values
-will be in temperature :doc:`units <units>` for the *temp* value, and in
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.  The array values will be
+in temperature :doc:`units <units>` for the *temp* value, and in
 energy :doc:`units <units>` for the *kecom* and *internal* values.
 
 Restrictions

--- a/doc/src/compute_temp_com.rst
+++ b/doc/src/compute_temp_com.rst
@@ -44,12 +44,17 @@ where KE is the total kinetic energy of the group of atoms (sum of
 simulation, :math:`N` is number of atoms in the group, :math:`k_B` is
 the Boltzmann constant, and :math:`T` is the absolute temperature.
 
-A kinetic energy tensor, stored as a six-element vector, is also
-calculated by this compute for use in the computation of a pressure
-tensor.  The formula for the components of the tensor is the same as
-the above formula, except that :math:`v^2` is replaced by :math:`v_x v_y`
-for the :math:`xy` component, and so on.  The six components of the vector are
-ordered :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic* option of the
@@ -81,17 +86,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS output
-options.
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.
-The vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values is in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_cs.rst
+++ b/doc/src/compute_temp_cs.rst
@@ -31,27 +31,27 @@ on the center-of-mass velocity of atom pairs that are bonded to each
 other.  This compute is designed to be used with the adiabatic
 core/shell model of :ref:`(Mitchell and Fincham) <MitchellFincham1>`.
 See the :doc:`Howto coreshell <Howto_coreshell>` page for an overview of
-the model as implemented in LAMMPS.  Specifically, this compute
-enables correct temperature calculation and thermostatting of
-core/shell pairs where it is desirable for the internal degrees of
-freedom of the core/shell pairs to not be influenced by a thermostat.
-A compute of this style can be used by any command that computes a
-temperature via :doc:`fix_modify <fix_modify>`
-(e.g., :doc:`fix temp/rescale <fix_temp_rescale>`, :doc:`fix npt <fix_nh>`).
+the model as implemented in LAMMPS.  Specifically, this compute enables
+correct temperature calculation and thermostatting of core/shell pairs
+where it is desirable for the internal degrees of freedom of the
+core/shell pairs to not be influenced by a thermostat.  A compute of
+this style can be used by any command that computes a temperature via
+:doc:`fix_modify <fix_modify>` (e.g., :doc:`fix temp/rescale
+<fix_temp_rescale>`, :doc:`fix npt <fix_nh>`).
 
-Note that this compute does not require all ions to be polarized,
-hence defined as core/shell pairs.  One can mix core/shell pairs and
-ions without a satellite particle if desired. The compute will
-consider the non-polarized ions according to the physical system.
+Note that this compute does not require all ions to be polarized, hence
+defined as core/shell pairs.  One can mix core/shell pairs and ions
+without a satellite particle if desired. The compute will consider the
+non-polarized ions according to the physical system.
 
 For this compute, core and shell particles are specified by two
-respective group IDs, which can be defined using the
-:doc:`group <group>` command.  The number of atoms in the two groups
-must be the same and there should be one bond defined between a pair
-of atoms in the two groups.  Non-polarized ions which might also be
-included in the treated system should not be included into either of
-these groups, they are taken into account by the *group-ID* (second
-argument) of the compute.
+respective group IDs, which can be defined using the :doc:`group
+<group>` command.  The number of atoms in the two groups must be the
+same and there should be one bond defined between a pair of atoms in the
+two groups.  Non-polarized ions which might also be included in the
+treated system should not be included into either of these groups, they
+are taken into account by the *group-ID* (second argument) of the
+compute.
 
 The temperature is calculated by the formula
 
@@ -60,54 +60,53 @@ The temperature is calculated by the formula
    \text{KE} = \frac{\text{dim}}{2} N k_B T,
 
 where KE is the total kinetic energy of the group of atoms (sum of
-:math:`\frac12 m v^2`), dim = 2 or 3 is the dimensionality of the simulation,
-:math:`N` is the number of atoms in the group, :math:`k_B` is the Boltzmann
-constant, and :math:`T` is the absolute temperature.  Note that
-the velocity of each core or shell atom used in the KE calculation is
-the velocity of the center-of-mass (COM) of the core/shell pair the
-atom is part of.
+:math:`\frac12 m v^2`), dim = 2 or 3 is the dimensionality of the
+simulation, :math:`N` is the number of atoms in the group, :math:`k_B`
+is the Boltzmann constant, and :math:`T` is the absolute temperature.
+Note that the velocity of each core or shell atom used in the KE
+calculation is the velocity of the center-of-mass (COM) of the
+core/shell pair the atom is part of.
 
 A symmetric tensor, stored as a six-element vector, is also calculated
 by this compute for use in the computation of a pressure tensor by the
-:doc:`compute pressue <compute_pressure>` command.  The formula for
-the components of the tensor is the same as the above expression for
+:doc:`compute pressue <compute_pressure>` command.  The formula for the
+components of the tensor is the same as the above expression for
 :math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
 the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
 :math:`xy` component, and so on.  Note that because it lacks the 1/2
 factor, these tensor components are twice those of the traditional
 kinetic energy tensor.  The six components of the vector are ordered
-:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
-:math:`yz`.
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
 
 The change this fix makes to core/shell atom velocities is essentially
 computing the temperature after a "bias" has been removed from the
-velocity of the atoms.  This "bias" is the velocity of the atom
-relative to the center-of-mass velocity of the core/shell pair.  If
-this compute is used with a fix command that performs thermostatting
-then this bias will be subtracted from each atom, thermostatting of
-the remaining center-of-mass velocity will be performed, and the bias
-will be added back in.  This means the thermostatting will effectively
-be performed on the core/shell pairs, instead of on the individual
-core and shell atoms.  Thermostatting fixes that work in this way
-include :doc:`fix nvt <fix_nh>`, :doc:`fix temp/rescale
-<fix_temp_rescale>`, :doc:`fix temp/berendsen <fix_temp_berendsen>`,
-and :doc:`fix langevin <fix_langevin>`.
+velocity of the atoms.  This "bias" is the velocity of the atom relative
+to the center-of-mass velocity of the core/shell pair.  If this compute
+is used with a fix command that performs thermostatting then this bias
+will be subtracted from each atom, thermostatting of the remaining
+center-of-mass velocity will be performed, and the bias will be added
+back in.  This means the thermostatting will effectively be performed on
+the core/shell pairs, instead of on the individual core and shell atoms.
+Thermostatting fixes that work in this way include :doc:`fix nvt
+<fix_nh>`, :doc:`fix temp/rescale <fix_temp_rescale>`, :doc:`fix
+temp/berendsen <fix_temp_berendsen>`, and :doc:`fix langevin
+<fix_langevin>`.
 
 The internal energy of core/shell pairs can be calculated by the
-:doc:`compute temp/chunk <compute_temp_chunk>` command, if chunks are defined
-as core/shell pairs.  See the :doc:`Howto coreshell <Howto_coreshell>` doc
-page for more discussion on how to do this.
+:doc:`compute temp/chunk <compute_temp_chunk>` command, if chunks are
+defined as core/shell pairs.  See the :doc:`Howto coreshell
+<Howto_coreshell>` doc page for more discussion on how to do this.
 
 Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (symmertric tensor), which can be accessed by
-indices 1--6.  These values can be used by any command that uses
-global scalar or vector values from a compute as input.
+vector of length 6 (symmetric tensor), which can be accessed by indices
+1--6.  These values can be used by any command that uses global scalar
+or vector values from a compute as input.
 
-The scalar value calculated by this compute is "intensive".  The
-vector values are "extensive".
+The scalar value calculated by this compute is "intensive".  The vector
+values are "extensive".
 
 The scalar value is in temperature :doc:`units <units>`.  The vector
 values are in energy :doc:`units <units>`.

--- a/doc/src/compute_temp_cs.rst
+++ b/doc/src/compute_temp_cs.rst
@@ -67,26 +67,31 @@ the velocity of each core or shell atom used in the KE calculation is
 the velocity of the center-of-mass (COM) of the core/shell pair the
 atom is part of.
 
-A kinetic energy tensor, stored as a six-element vector, is also calculated by
-this compute for use in the computation of a pressure tensor.  The formula for
-the components of the tensor is the same as the above formula, except that
-:math:`v^2` is replaced by :math:`v_x v_y` for the :math:`xy` component, and so
-on. The six components of the vector are ordered :math:`xx`, :math:`yy`,
-:math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`. In contrast to the temperature,
-the velocity of each core or shell atom is taken individually.
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
 
 The change this fix makes to core/shell atom velocities is essentially
-computing the temperature after a "bias" has been removed from the velocity of
-the atoms.  This "bias" is the velocity of the atom relative to the
-center-of-mass velocity of the core/shell pair.  If this compute is used with a
-fix command that performs thermostatting then this bias will be subtracted from
-each atom, thermostatting of the remaining center-of-mass velocity will be
-performed, and the bias will be added back in.  This means the thermostatting
-will effectively be performed on the core/shell pairs, instead of on the
-individual core and shell atoms.  Thermostatting fixes that work in this way
-include :doc:`fix nvt <fix_nh>`, :doc:`fix temp/rescale <fix_temp_rescale>`,
-:doc:`fix temp/berendsen <fix_temp_berendsen>`, and
-:doc:`fix langevin <fix_langevin>`.
+computing the temperature after a "bias" has been removed from the
+velocity of the atoms.  This "bias" is the velocity of the atom
+relative to the center-of-mass velocity of the core/shell pair.  If
+this compute is used with a fix command that performs thermostatting
+then this bias will be subtracted from each atom, thermostatting of
+the remaining center-of-mass velocity will be performed, and the bias
+will be added back in.  This means the thermostatting will effectively
+be performed on the core/shell pairs, instead of on the individual
+core and shell atoms.  Thermostatting fixes that work in this way
+include :doc:`fix nvt <fix_nh>`, :doc:`fix temp/rescale
+<fix_temp_rescale>`, :doc:`fix temp/berendsen <fix_temp_berendsen>`,
+and :doc:`fix langevin <fix_langevin>`.
 
 The internal energy of core/shell pairs can be calculated by the
 :doc:`compute temp/chunk <compute_temp_chunk>` command, if chunks are defined
@@ -97,15 +102,15 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.
+vector of length 6 (symmertric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_deform.rst
+++ b/doc/src/compute_temp_deform.rst
@@ -73,12 +73,16 @@ simulation, :math:`N` is the number of atoms in the group, :math:`k_B`
 is the Boltzmann constant, and :math:`T` is the temperature.  Note that
 :math:`v` in the kinetic energy formula is the atom's velocity.
 
-A kinetic energy tensor, stored as a six-element vector, is also
-calculated by this compute for use in the computation of a pressure
-tensor.  The formula for the components of the tensor is the same as
-the above formula, except that :math:`v^2` is replaced by :math:`v_x v_y` for
-the :math:`xy` component, and so on. The six components of the vector are
-ordered :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
 :math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be
@@ -128,17 +132,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS output
-options.
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.
-The vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_deform_eff.rst
+++ b/doc/src/compute_temp_deform_eff.rst
@@ -29,17 +29,20 @@ model, after subtracting out a streaming velocity induced by the
 simulation box changing size and/or shape, for example in a
 non-equilibrium MD (NEMD) simulation.  The size/shape change is
 induced by use of the :doc:`fix deform <fix_deform>` command.  A
-compute of this style is created by the
-:doc:`fix nvt/sllod/eff <fix_nvt_sllod_eff>` command to compute the thermal
-temperature of atoms for thermostatting purposes.  A compute of this
-style can also be used by any command that computes a temperature
-(e.g., :doc:`thermo_modify <thermo_modify>`, :doc:`fix npt/eff <fix_nh_eff>`).
+compute of this style is created by the :doc:`fix nvt/sllod/eff
+<fix_nvt_sllod_eff>` command to compute the thermal temperature of
+atoms for thermostatting purposes.  A compute of this style can also
+be used by any command that computes a temperature (e.g.,
+:doc:`thermo_modify <thermo_modify>`, :doc:`fix npt/eff
+<fix_nh_eff>`).
 
 The calculation performed by this compute is exactly like that
 described by the :doc:`compute temp/deform <compute_temp_deform>`
-command, except that the formula for the temperature includes the
-radial electron velocity contributions, as discussed by the :doc:`compute temp/eff <compute_temp_eff>` command.  Note that only the
-translational degrees of freedom for each nuclei or electron are
+command, except that the formulas for the temperature (scalar) and
+diagonal components of the symmetric tensor (vector) include the
+radial electron velocity contributions, as discussed by the
+:doc:`compute temp/eff <compute_temp_eff>` command.  Note that only
+the translational degrees of freedom for each nuclei or electron are
 affected by the streaming velocity adjustment.  The radial velocity
 component of the electrons is not affected.
 
@@ -47,17 +50,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS output
-options.
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_partial.rst
+++ b/doc/src/compute_temp_partial.rst
@@ -44,12 +44,16 @@ constant, and :math:`T` = temperature.  The calculation of KE excludes the
 is 0.  The dim parameter is adjusted to give the correct number of
 degrees of freedom.
 
-A kinetic energy tensor, stored as a six-element vector, is also
-calculated by this compute for use in the calculation of a pressure
-tensor.  The formula for the components of the tensor is the same as
-the above formula, except that :math:`v^2` is replaced by :math:`v_x v_y` for
-the :math:`xy` component, and so on. The six components of the vector are
-ordered :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
 :math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be
@@ -88,17 +92,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.
-See the :doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
 output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_profile.rst
+++ b/doc/src/compute_temp_profile.rst
@@ -210,10 +210,10 @@ will be for most thermostats.
 Related commands
 """"""""""""""""
 
-:doc:`compute temp <compute_temp>`, :doc:`compute temp/ramp
-     <compute_temp_ramp>`, :doc:`compute temp/deform
-     <compute_temp_deform>`, :doc:`compute pressure
-     <compute_pressure>`
+:doc:`compute temp <compute_temp>`,
+:doc:`compute temp/ramp <compute_temp_ramp>`,
+:doc:`compute temp/deform <compute_temp_deform>`,
+:doc:`compute pressure <compute_pressure>`
 
 Default
 """""""

--- a/doc/src/compute_temp_profile.rst
+++ b/doc/src/compute_temp_profile.rst
@@ -97,21 +97,27 @@ center-of-mass velocity across the group in directions where streaming velocity
 is *not* subtracted. This can be altered using the *extra* option of the
 :doc:`compute_modify <compute_modify>` command.
 
-If the *out* keyword is used with a *tensor* value, which is the default,
-a kinetic energy tensor, stored as a six-element vector, is also calculated by
-this compute for use in the computation of a pressure tensor.  The formula for
-the components of the tensor is the same as the above formula, except that
-:math:`v^2` is replaced by :math:`v_x v_y` for the :math:`xy` component, and
-so on.  The six components of the vector are ordered :math:`xx`, :math:`yy`,
+If the *out* keyword is used with a *tensor* value, which is the
+default, then a symmetric tensor, stored as a six-element vector, is
+also calculated by this compute for use in the computation of a
+pressure tensor by the :doc:`compute pressue <compute_pressure>`
+command.  The formula for the components of the tensor is the same as
+the above expression for :math:`E_\mathrm{kin}`, except that the 1/2
+factor is NOT included and the :math:`v_i^2` is replaced by
+:math:`v_{i,x} v_{i,y}` for the :math:`xy` component, and so on.  Note
+that because it lacks the 1/2 factor, these tensor components are
+twice those of the traditional kinetic energy tensor.  The six
+components of the vector are ordered :math:`xx`, :math:`yy`,
 :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
 
-If the *out* keyword is used with a *bin* value, the count of atoms and
-computed temperature for each bin are stored for output, as an array of values,
-as described below.  The temperature of each bin is calculated as described
-above, where the bias velocity is subtracted and only the remaining thermal
-velocity of atoms in the bin contributes to the temperature.  See the note
-below for how the temperature is normalized by the degrees-of-freedom of atoms
-in the bin.
+If the *out* keyword is used with a *bin* value, the count of atoms
+and computed temperature for each bin are stored for output, as an
+array of values, as described below.  The temperature of each bin is
+calculated as described above, where the bias velocity is subtracted
+and only the remaining thermal velocity of atoms in the bin
+contributes to the temperature.  See the note below for how the
+temperature is normalized by the degrees-of-freedom of atoms in the
+bin.
 
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic* option of the
@@ -166,16 +172,17 @@ Output info
 This compute calculates a global scalar (the temperature).  Depending
 on the setting of the *out* keyword, it also calculates a global
 vector or array.  For *out* = *tensor*, it calculates a vector of
-length 6 (KE tensor), which can be accessed by indices 1--6.  For *out*
-= *bin* it calculates a global array which has 2 columns and :math:`N` rows,
-where :math:`N` is the number of bins.  The first column contains the number
-of atoms in that bin.  The second contains the temperature of that
-bin, calculated as described above.  The ordering of rows in the array
-is as follows.  Bins in :math:`x` vary fastest, then :math:`y`, then
-:math:`z`.  Thus for a :math:`10\times 10\times 10` 3d array of bins, there
-will be 1000 rows.  The bin with indices :math:`(i_x,i_y,i_z) = (2,3,4)` would
-map to row :math:`M = 10^2(i_z-1)  + 10(i_y-1) + i_x = 322`, where the rows are
-numbered from 1 to 1000 and the bin indices are numbered from 1 to 10 in each
+length 6 (symmetric tensor), which can be accessed by indices 1--6.
+For *out* = *bin* it calculates a global array which has 2 columns and
+:math:`N` rows, where :math:`N` is the number of bins.  The first
+column contains the number of atoms in that bin.  The second contains
+the temperature of that bin, calculated as described above.  The
+ordering of rows in the array is as follows.  Bins in :math:`x` vary
+fastest, then :math:`y`, then :math:`z`.  Thus for a :math:`10\times
+10\times 10` 3d array of bins, there will be 1000 rows.  The bin with
+indices :math:`(i_x,i_y,i_z) = (2,3,4)` would map to row :math:`M =
+10^2(i_z-1) + 10(i_y-1) + i_x = 322`, where the rows are numbered from
+1 to 1000 and the bin indices are numbered from 1 to 10 in each
 dimension.
 
 These values can be used by any command that uses global scalar or
@@ -186,9 +193,9 @@ options.
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".  The array values are "intensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.  The first column
-of array values are counts; the values in the second column will be in
+The scalar value us in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.  The first column of array
+values are counts; the values in the second column will be in
 temperature :doc:`units <units>`.
 
 Restrictions
@@ -203,7 +210,10 @@ will be for most thermostats.
 Related commands
 """"""""""""""""
 
-:doc:`compute temp <compute_temp>`, :doc:`compute temp/ramp <compute_temp_ramp>`, :doc:`compute temp/deform <compute_temp_deform>`, :doc:`compute pressure <compute_pressure>`
+:doc:`compute temp <compute_temp>`, :doc:`compute temp/ramp
+     <compute_temp_ramp>`, :doc:`compute temp/deform
+     <compute_temp_deform>`, :doc:`compute pressure
+     <compute_pressure>`
 
 Default
 """""""

--- a/doc/src/compute_temp_ramp.rst
+++ b/doc/src/compute_temp_ramp.rst
@@ -124,10 +124,10 @@ Restrictions
 Related commands
 """"""""""""""""
 
-:doc:`compute temp <compute_temp>`, :doc:`compute temp/profie
-     <compute_temp_profile>`, :doc:`compute temp/deform
-     <compute_temp_deform>`, :doc:`compute pressure
-     <compute_pressure>`
+:doc:`compute temp <compute_temp>`,
+:doc:`compute temp/profile <compute_temp_profile>`,
+:doc:`compute temp/deform <compute_temp_deform>`,
+:doc:`compute pressure <compute_pressure>`
 
 Default
 """""""

--- a/doc/src/compute_temp_ramp.rst
+++ b/doc/src/compute_temp_ramp.rst
@@ -63,12 +63,17 @@ command (e.g., :math:`\AA` for units = real or metal).  A
 velocity in lattice spacings per unit time).  The :doc:`lattice <lattice>`
 command must have been previously used to define the lattice spacing.
 
-A kinetic energy tensor, stored as a six-element vector, is also calculated by
-this compute for use in the computation of a pressure tensor.  The formula for
-the components of the tensor is the same as the above formula, except that
-:math:`v^2` is replaced by :math:`v_x v_y` for the :math:`xy` component, and
-so on.  The six components of the vector are ordered :math:`xx`, :math:`yy`,
-:math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be constant
 for the duration of the run; use the *dynamic* option of the
@@ -100,17 +105,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS output
-options.
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""
@@ -119,7 +124,10 @@ Restrictions
 Related commands
 """"""""""""""""
 
-:doc:`compute temp <compute_temp>`, :doc:`compute temp/profie <compute_temp_profile>`, :doc:`compute temp/deform <compute_temp_deform>`, :doc:`compute pressure <compute_pressure>`
+:doc:`compute temp <compute_temp>`, :doc:`compute temp/profie
+     <compute_temp_profile>`, :doc:`compute temp/deform
+     <compute_temp_deform>`, :doc:`compute pressure
+     <compute_pressure>`
 
 Default
 """""""

--- a/doc/src/compute_temp_region.rst
+++ b/doc/src/compute_temp_region.rst
@@ -49,12 +49,17 @@ where KE = is the total kinetic energy of the group of atoms (sum of
 :math:`N` is the  number of atoms in both the group and region, :math:`k_B` is
 the Boltzmann constant, and :math:`T` temperature.
 
-A kinetic energy tensor, stored as a six-element vector, is also
-calculated by this compute for use in the computation of a pressure
-tensor.  The formula for the components of the tensor is the same as
-the above formula, except that :math:`v^2` is replaced by :math:`v_x v_y`
-for the :math:`xy` component, and so on.  The six components of the vector are
-ordered :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
 
 The number of atoms contributing to the temperature is calculated each
 time the temperature is evaluated since it is assumed atoms can
@@ -78,12 +83,13 @@ will operate only on atoms that are currently in the geometric region.
 
 Unlike other compute styles that calculate temperature, this compute
 does not subtract out degrees-of-freedom due to fixes that constrain
-motion, such as :doc:`fix shake <fix_shake>` and :doc:`fix rigid <fix_rigid>`.  This is because those degrees of freedom
-(e.g., a constrained bond) could apply to sets of atoms that straddle
-the region boundary, and hence the concept is somewhat ill-defined.
-If needed the number of subtracted degrees of freedom can be set
-explicitly using the *extra* option of the
-:doc:`compute_modify <compute_modify>` command.
+motion, such as :doc:`fix shake <fix_shake>` and :doc:`fix rigid
+<fix_rigid>`.  This is because those degrees of freedom (e.g., a
+constrained bond) could apply to sets of atoms that straddle the
+region boundary, and hence the concept is somewhat ill-defined.  If
+needed the number of subtracted degrees of freedom can be set
+explicitly using the *extra* option of the :doc:`compute_modify
+<compute_modify>` command.
 
 See the :doc:`Howto thermostat <Howto_thermostat>` page for a
 discussion of different ways to compute temperature and perform
@@ -93,17 +99,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS output
-options.
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.
-The vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_region_eff.rst
+++ b/doc/src/compute_temp_region_eff.rst
@@ -38,7 +38,7 @@ contributions, as discussed by the :doc:`compute temp/eff
 <compute_temp_eff>` command.
 
 Output info
-""""""""""
+"""""""""""
 
 This compute calculates a global scalar (the temperature) and a global
 vector of length 6 (symmetric tensor), which can be accessed by

--- a/doc/src/compute_temp_region_eff.rst
+++ b/doc/src/compute_temp_region_eff.rst
@@ -32,32 +32,33 @@ temperature (e.g., :doc:`thermo_modify <thermo_modify>`).
 
 The operation of this compute is exactly like that described by the
 :doc:`compute temp/region <compute_temp_region>` command, except that
-the formula for the temperature itself includes the radial electron
-velocity contributions, as discussed by the
-:doc:`compute temp/eff <compute_temp_eff>` command.
+the formulas for the temperature (scalar) and diagonal components of
+the symmetric tensor (vector) include the radial electron velocity
+contributions, as discussed by the :doc:`compute temp/eff
+<compute_temp_eff>` command.
 
 Output info
-"""""""""""
+""""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS output
-options.
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""
 
-This compute is part of the EFF package.  It is only enabled if
-LAMMPS was built with that package.
-See the :doc:`Build package <Build_package>` page for more info.
+This compute is part of the EFF package.  It is only enabled if LAMMPS
+was built with that package.  See the :doc:`Build package
+<Build_package>` page for more info.
 
 Related commands
 """"""""""""""""

--- a/doc/src/compute_temp_rotate.rst
+++ b/doc/src/compute_temp_rotate.rst
@@ -43,12 +43,17 @@ where KE is the total kinetic energy of the group of atoms (sum of
 :math:`N` is the number of atoms in the group, :math:`k_B` is the Boltzmann
 constant, and :math:`T` is the absolute temperature.
 
-A kinetic energy tensor, stored as a six-element vector, is also calculated by
-this compute for use in the computation of a pressure tensor.  The formula for
-the components of the tensor is the same as the above formula, except that
-:math:`v^2` is replaced by :math:`v_x v_y` for the :math:`xy` component, and
-so on.  The six components of the vector are ordered :math:`xx`, :math:`yy`,
-:math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic* option of the
@@ -80,17 +85,16 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1-6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.  See the
-:doc:`Howto output <Howto_output>` page for an overview of LAMMPS output
-options.
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1-6.  These values can be used by any command that uses global
+scalar or vector values from a compute as input.  See the :doc:`Howto
+output <Howto_output>` page for an overview of LAMMPS output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_temp_sphere.rst
+++ b/doc/src/compute_temp_sphere.rst
@@ -77,6 +77,18 @@ tensor is the same as the above formulas, except that :math:`v^2` and
 vector are ordered :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`,
 :math:`xz`, :math:`yz`.
 
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` and :math:`\omega^2` are replaced by :math:`v_x v_y`
+and :math:`\omega_x \omega_y` for the :math:`xy` component, and so on.
+Note that because it lacks the 1/2 factor, these tensor components are
+twice those of the traditional kinetic energy tensor.  The six
+components of the vector are ordered :math:`xx`, :math:`yy`,
+:math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic* option of the
 :doc:`compute_modify <compute_modify>` command if this is not the case.
@@ -117,17 +129,17 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 6 (KE tensor), which can be accessed by indices 1--6.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.
-See the :doc:`Howto output <Howto_output>` page for an overview of LAMMPS
+vector of length 6 (symmetric tensor), which can be accessed by
+indices 1--6.  These values can be used by any command that uses
+global scalar or vector values from a compute as input.  See the
+:doc:`Howto output <Howto_output>` page for an overview of LAMMPS
 output options.
 
 The scalar value calculated by this compute is "intensive".  The
 vector values are "extensive".
 
-The scalar value will be in temperature :doc:`units <units>`.  The
-vector values will be in energy :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The vector
+values are in energy :doc:`units <units>`.
 
 Restrictions
 """"""""""""

--- a/doc/src/compute_viscosity_cos.rst
+++ b/doc/src/compute_viscosity_cos.rst
@@ -86,12 +86,17 @@ where KE is the total kinetic energy of the group of atoms (sum of
 :math:`N` is the number of atoms in the group, :math:`k_B` is the Boltzmann
 constant, and :math:`T` is the absolute temperature.
 
-A kinetic energy tensor, stored as a six-element vector, is also
-calculated by this compute for use in the computation of a pressure
-tensor. The formula for the components of the tensor is the same as
-the above formula, except that :math:`v^2` is replaced by :math:`v_x v_y` for
-the :math:`xy` component, and so on. The six components of the vector are
-ordered :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`, :math:`yz`.
+A symmetric tensor, stored as a six-element vector, is also calculated
+by this compute for use in the computation of a pressure tensor by the
+:doc:`compute pressue <compute_pressure>` command.  The formula for
+the components of the tensor is the same as the above expression for
+:math:`E_\mathrm{kin}`, except that the 1/2 factor is NOT included and
+the :math:`v_i^2` is replaced by :math:`v_{i,x} v_{i,y}` for the
+:math:`xy` component, and so on.  Note that because it lacks the 1/2
+factor, these tensor components are twice those of the traditional
+kinetic energy tensor.  The six components of the vector are ordered
+:math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`xz`,
+:math:`yz`.
 
 The number of atoms contributing to the temperature is assumed to be
 constant for the duration of the run; use the *dynamic* option of the
@@ -126,21 +131,21 @@ Output info
 """""""""""
 
 This compute calculates a global scalar (the temperature) and a global
-vector of length 7, which can be accessed by indices 1--7.
-The first six elements of the vector are the KE tensor,
-and the seventh is the cosine-shaped velocity amplitude :math:`V`,
-which can be used to calculate the reciprocal viscosity, as shown in the example.
-These values can be used by any command that uses global scalar or
-vector values from a compute as input.
-See the :doc:`Howto output <Howto_output>` page for an overview of LAMMPS output options.
+vector of length 7, which can be accessed by indices 1--7.  The first
+six elements of the vector are those of the symmetric tensor discussed
+above.  The seventh is the cosine-shaped velocity amplitude :math:`V`,
+which can be used to calculate the reciprocal viscosity, as shown in
+the example.  These values can be used by any command that uses global
+scalar or vector values from a compute as input.  See the :doc:`Howto
+output <Howto_output>` page for an overview of LAMMPS output options.
 
 The scalar value calculated by this compute is "intensive".  The
 first six elements of vector values are "extensive",
 and the seventh element of vector values is "intensive".
 
-The scalar value will be in temperature :doc:`units <units>`.
-The first six elements of vector values will be in energy :doc:`units <units>`.
-The seventh element of vector value will be in velocity :doc:`units <units>`.
+The scalar value is in temperature :doc:`units <units>`.  The first
+six elements of vector values are in energy :doc:`units <units>`.  The
+seventh element of vector value us in velocity :doc:`units <units>`.
 
 Restrictions
 """"""""""""


### PR DESCRIPTION
**Summary**

The doc pages for the various compute temp commands incorrectly explained their vector output.  Which is a length 6 vector representing a symmetric tensor used in computation of pressure tensors.  The doc pages said it was the kinetic energy tensor which includes a 1/2 factor in each term, e.g. 1/2 vx vy.

In reality the code drops the 1/2 factor and the components of the tensor are still energies but are twice the traditional KE tensor components.

**Related Issue(s)**

Closes #4265

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Nothing changed in the code, just in the doc pages.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


