### PR TITLE
Add error checks to verlet/split for unsupported KSpace methods

### DIFF
--- a/doc/src/run_style.rst
+++ b/doc/src/run_style.rst
@@ -332,7 +332,8 @@ only if the OPENMP package was included. See the :doc:`Build package
 <Build_package>` page for more info.
 
 Run style *verlet/split* is not compatible with kspace styles from
-the INTEL package and it is not compatible with any TIP4P styles.
+the INTEL package and it is not compatible with any tip4p, dipole,
+or spin kspace styles.
 
 Whenever using rRESPA, the user should experiment with trade-offs in
 speed and accuracy for their system, and verify that they are

--- a/src/REPLICA/verlet_split.cpp
+++ b/src/REPLICA/verlet_split.cpp
@@ -221,14 +221,22 @@ void VerletSplit::init()
   if (!force->kspace && comm->me == 0)
     error->warning(FLERR,"A KSpace style must be defined with verlet/split");
 
-  if (force->kspace_match("/tip4p",0)) tip4p_flag = 1;
-  else tip4p_flag = 0;
+  // error for as-yet unsupported verlet/split KSpace options
 
-  // currently TIP4P does not work with verlet/split, so generate error
-  // see Axel email on this, also other TIP4P notes below
+  int errflag = 0;
+  if (!atom->q_flag) errflag = 1;
+  if (force->kspace->tip4pflag) errflag = 1;
+  if (force->kspace->dipoleflag) errflag = 1;
+  if (force->kspace->spinflag) errflag = 1;
 
-  if (tip4p_flag) error->all(FLERR,"Verlet/split does not yet support TIP4P");
+  if (errflag) error->all(FLERR,"Verlet/split cannot (yet) be used with this KSpace method");
 
+  // partial support for TIP4P, see where this flag is used below
+
+  tip4pflag = force->kspace->tip4pflag;
+
+  // invoke parent Verlet init
+  
   Verlet::init();
 }
 
@@ -402,7 +410,7 @@ void VerletSplit::run(int n)
 
       // TIP4P PPPM puts forces on ghost atoms, so must reverse_comm()
 
-      if (tip4p_flag && force->newton) {
+      if (tip4pflag && force->newton) {
         comm->reverse_comm();
         timer->stamp(Timer::COMM);
       }
@@ -485,7 +493,7 @@ void VerletSplit::rk_setup()
   //   could do this by calling r2k_comm() here and not again from run()
   //   except that forward_comm() in r2k_comm() is wrong
 
-  if (tip4p_flag) {
+  if (tip4pflag) {
     //r2k_comm();
     MPI_Gatherv(atom->type,n,MPI_INT,atom->type,qsize,qdisp,MPI_INT,0,block);
     MPI_Gatherv(atom->tag,n,MPI_LMP_TAGINT,
@@ -543,7 +551,7 @@ void VerletSplit::r2k_comm()
 
   // for TIP4P, Kspace partition needs to update its ghost atoms
 
-  if (tip4p_flag && !master) {
+  if (tip4pflag && !master) {
     timer->stamp();
     comm->forward_comm();
     timer->stamp(Timer::COMM);

--- a/src/REPLICA/verlet_split.cpp
+++ b/src/REPLICA/verlet_split.cpp
@@ -229,7 +229,8 @@ void VerletSplit::init()
   if (force->kspace->dipoleflag) errflag = 1;
   if (force->kspace->spinflag) errflag = 1;
 
-  if (errflag) error->all(FLERR,"Verlet/split cannot (yet) be used with this KSpace method");
+  if (errflag)
+    error->all(FLERR,"Verlet/split cannot (yet) be used with kpace style {}", force->kspace_style);
 
   // partial support for TIP4P, see where this flag is used below
 

--- a/src/REPLICA/verlet_split.h
+++ b/src/REPLICA/verlet_split.h
@@ -40,7 +40,8 @@ class VerletSplit : public Verlet {
   int ratio;                             // ratio of Rspace procs to Kspace procs
   int *qsize, *qdisp, *xsize, *xdisp;    // MPI gather/scatter params for block comm
   MPI_Comm block;                        // communicator within one block
-  int tip4p_flag;                        // 1 if PPPM/tip4p so do extra comm
+  
+  int tip4pflag;                         // 1 if Kspace method sets tip4pflag
 
   double **f_kspace;    // copy of Kspace forces on Rspace procs
   int maxatom;

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -3090,7 +3090,7 @@ void *Atom::extract(const char *name)
     return (void *) eff_plastic_strain_rate;
   if (strcmp(name, "damage") == 0) return (void *) damage;
 
-  // DPD-REACT pakage
+  // DPD-REACT package
 
   if (strcmp(name,"dpdTheta") == 0) return (void *) dpdTheta;
 


### PR DESCRIPTION
**Summary**

Verlet/split pre-dates several new KSpace methods.  It could potentially be extended to support them, but for now just add error checks to ensure it is not used with these methods.

**Related Issue(s)**

Closes #4149

**Author(s)**

Steve

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


