### PR TITLE
Collected small fixes for LAMMPS and LAMMPS-GUI for the stable release

### DIFF
--- a/doc/src/Tools.rst
+++ b/doc/src/Tools.rst
@@ -590,19 +590,30 @@ and the LAMMPS library, via ``-D LAMMPS_SOURCE_DIR=/path/to/lammps/src``.
 CMake will try to guess a build folder with the LAMMPS library from that
 path, but it can also be set with ``-D LAMMPS_LIB_DIR=/path/to/lammps/lib``.
 
+Plugin version
+""""""""""""""
+
 Rather than linking to the LAMMPS library during compilation, it is also
-possible to compile the GUI with a plugin loader that will load
-the LAMMPS library dynamically at runtime during the start of the GUI
-from a shared library; e.g. ``liblammps.so`` or ``liblammps.dylib`` or
+possible to compile the GUI with a plugin loader that will load the
+LAMMPS library dynamically at runtime during the start of the GUI from a
+shared library; e.g. ``liblammps.so`` or ``liblammps.dylib`` or
 ``liblammps.dll`` (depending on the operating system).  This has the
 advantage that the LAMMPS library can be built from updated or modified
 LAMMPS source without having to recompile the GUI.  The ABI of the
 LAMMPS C-library interface is very stable and generally backward
-compatible.  This feature is enabled by setting
-``-D LAMMPS_GUI_USE_PLUGIN=on`` and then ``-D
+compatible.  This feature is enabled by setting ``-D
+LAMMPS_GUI_USE_PLUGIN=on`` and then ``-D
 LAMMPS_PLUGINLIB_DIR=/path/to/lammps/plugin/loader``. Typically, this
 would be the ``examples/COUPLE/plugin`` folder of the LAMMPS
 distribution.
+
+When compiling LAMMPS-GUI with plugin support, there is an additional
+command line flag (``-p <path>`` or ``--pluginpath <path>``) which
+allows to override the path to LAMMPS shared library used by the GUI.
+This is usually auto-detected on the first run and can be changed in the
+LAMMPS-GUI *Preferences* dialog.  The command line flag allows to reset
+this path to a valid value in case the original setting has become
+invalid.  An empty path ("") as argument restores the default setting.
 
 Platform notes
 ^^^^^^^^^^^^^^
@@ -670,6 +681,15 @@ pre-compiled executables (see above).  After compiling with
 folder> --target tgz`` or ``make tgz`` to build a
 ``LAMMPS-Linux-amd64.tar.gz`` file with the executables and their
 support libraries.
+
+It is also possible to build a `flatpak bundle
+<https://docs.flatpak.org/en/latest/single-file-bundles.html>`_ which is
+a way to distribute applications in a way that is compatible with most
+Linux distributions.  Use the "flatpak" target to trigger a compile
+(``cmake --build <build folder> --target flatpak`` or ``make flatpak``).
+Please note that this will not build from the local sources but from the
+repository and branch listed in the ``org.lammps.lammps-gui.yml``
+LAMMPS-GUI source folder.
 
 ----------
 

--- a/examples/COUPLE/plugin/liblammpsplugin.c
+++ b/examples/COUPLE/plugin/liblammpsplugin.c
@@ -41,7 +41,6 @@
 
 #include <stdlib.h>
 
-
 liblammpsplugin_t *liblammpsplugin_load(const char *lib)
 {
   liblammpsplugin_t *lmp;

--- a/examples/COUPLE/plugin/liblammpsplugin.c
+++ b/examples/COUPLE/plugin/liblammpsplugin.c
@@ -190,6 +190,9 @@ liblammpsplugin_t *liblammpsplugin_load(const char *lib)
   ADDSYM(is_running);
   ADDSYM(force_timeout);
 
+  // symbol not present
+  if (!lmp->config_has_exceptions) return NULL;
+
   lmp->has_exceptions = lmp->config_has_exceptions();
   if (lmp->has_exceptions) {
     ADDSYM(has_error);

--- a/src/CLASS2/angle_class2.cpp
+++ b/src/CLASS2/angle_class2.cpp
@@ -18,17 +18,17 @@
 
 #include "angle_class2.h"
 
-#include <cmath>
-#include <cstring>
 #include "atom.h"
-#include "neighbor.h"
-#include "domain.h"
 #include "comm.h"
+#include "domain.h"
+#include "error.h"
 #include "force.h"
 #include "math_const.h"
 #include "memory.h"
-#include "error.h"
+#include "neighbor.h"
 
+#include <cmath>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 using namespace MathConst;

--- a/src/KOKKOS/pair_uf3_kokkos.cpp
+++ b/src/KOKKOS/pair_uf3_kokkos.cpp
@@ -1655,7 +1655,7 @@ double PairUF3Kokkos<DeviceType>::single(int /*i*/, int /*j*/, int itype, int jt
 
 namespace LAMMPS_NS {
 template class PairUF3Kokkos<LMPDeviceType>;
-#ifdef KOKKOS_ENABLE_GPU
+#ifdef LMP_KOKKOS_GPU
 template class PairUF3Kokkos<LMPHostType>;
 #endif
 }    // namespace LAMMPS_NS

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -3714,7 +3714,7 @@ int FixBondReact::insert_atoms_setup(tagint **my_update_mega_glove, int iupdate)
   tagint *molecule = atom->molecule;
   int nlocal = atom->nlocal;
 
-  tagint maxmol_all;
+  tagint maxmol_all = 0;;
   for (int i = 0; i < nlocal; i++) maxmol_all = MAX(maxmol_all,molecule[i]);
   MPI_Allreduce(MPI_IN_PLACE,&maxmol_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
 

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -3693,7 +3693,6 @@ int FixBondReact::insert_atoms_setup(tagint **my_update_mega_glove, int iupdate)
   imageint *imageflags;
   double **coords,lamda[3],rotmat[3][3];
   double *newcoord;
-  double **v = atom->v;
   double t,delx,dely,delz,rsq;
 
   memory->create(coords,twomol->natoms,3,"bond/react:coords");
@@ -3709,7 +3708,6 @@ int FixBondReact::insert_atoms_setup(tagint **my_update_mega_glove, int iupdate)
   }
 
   // find current max atom and molecule IDs
-  tagint *tag = atom->tag;
   double **x = atom->x;
   tagint *molecule = atom->molecule;
   int nlocal = atom->nlocal;

--- a/tools/lammps-gui/lammpsgui.cpp
+++ b/tools/lammps-gui/lammpsgui.cpp
@@ -76,11 +76,6 @@ LammpsGui::LammpsGui(QWidget *parent, const QString &filename) :
     prefdialog(nullptr), lammpsstatus(nullptr), varwindow(nullptr), wizard(nullptr),
     runner(nullptr), is_running(false), run_counter(0)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    // register QList<QString> only needed for Qt5
-    qRegisterMetaTypeStreamOperators<QList<QString>>("QList<QString>");
-#endif
-
     docver = "";
     ui->setupUi(this);
     this->setCentralWidget(ui->textEdit);

--- a/tools/lammps-gui/lammpsgui.cpp
+++ b/tools/lammps-gui/lammpsgui.cpp
@@ -69,7 +69,7 @@
 static const QString blank(" ");
 static constexpr int BUFLEN = 256;
 
-LammpsGui::LammpsGui(QWidget *parent, const char *filename) :
+LammpsGui::LammpsGui(QWidget *parent, const QString &filename) :
     QMainWindow(parent), ui(new Ui::LammpsGui), highlighter(nullptr), capturer(nullptr),
     status(nullptr), logwindow(nullptr), imagewindow(nullptr), chartwindow(nullptr),
     slideshow(nullptr), logupdater(nullptr), dirstatus(nullptr), progress(nullptr),
@@ -98,21 +98,21 @@ LammpsGui::LammpsGui(QWidget *parent, const char *filename) :
 
 #if defined(LAMMPS_GUI_USE_PLUGIN)
     plugin_path.clear();
-    std::string deffile = settings.value("plugin_path", "liblammps.so").toString().toStdString();
-    for (const char *libfile : {deffile.c_str(), "./liblammps.so", "liblammps.dylib",
+    QString deffile = settings.value("plugin_path", "liblammps.so").toString();
+    for (const char *libfile : {deffile.toStdString().c_str(), "./liblammps.so", "liblammps.dylib",
                                 "./liblammps.dylib", "liblammps.dll"}) {
         if (lammps.load_lib(libfile)) {
-            auto canonical = QFileInfo(libfile).canonicalFilePath();
-            plugin_path    = canonical.toStdString();
-            settings.setValue("plugin_path", canonical);
+            plugin_path = QFileInfo(libfile).canonicalFilePath();
+            settings.setValue("plugin_path", plugin_path);
             break;
         }
     }
 
-    if (plugin_path.empty()) {
+    if (plugin_path.isEmpty()) {
         // none of the plugin paths could load, remove key
         settings.remove("plugin_path");
-        QMessageBox::critical(this, "Error", "Cannot open LAMMPS shared library file");
+        QMessageBox::critical(this, "Error", "Cannot open LAMMPS shared library file.\n"
+                              "Use -p command line flag to specify a path to the library.");
         exit(1);
     }
 #endif
@@ -281,7 +281,7 @@ LammpsGui::LammpsGui(QWidget *parent, const char *filename) :
     dirstatus->show();
     ui->statusbar->addWidget(progress);
 
-    if (filename) {
+    if (filename.size() > 0) {
         open_file(filename);
     } else {
         setWindowTitle("LAMMPS-GUI - Editor - *unknown*");
@@ -505,7 +505,8 @@ void LammpsGui::start_exe()
 void LammpsGui::update_recents(const QString &filename)
 {
     QSettings settings;
-    recent = settings.value("recent").value<QList<QString>>();
+    if (settings.contains("recent"))
+        recent = settings.value("recent").value<QList<QString>>();
 
     for (int i = 0; i < recent.size(); ++i) {
         QFileInfo fi(recent[i]);
@@ -517,7 +518,8 @@ void LammpsGui::update_recents(const QString &filename)
 
     if (!filename.isEmpty() && !recent.contains(filename)) recent.prepend(filename);
     if (recent.size() > 5) recent.removeLast();
-    settings.setValue("recent", QVariant::fromValue(recent));
+    if (recent.size() > 0) settings.setValue("recent", QVariant::fromValue(recent));
+    else settings.remove("recent");
 
     ui->action_1->setVisible(false);
     if ((recent.size() > 0) && !recent[0].isEmpty()) {
@@ -1438,9 +1440,9 @@ void LammpsGui::about()
         version += " using dark theme\n";
     if (lammps.has_plugin()) {
         version += "LAMMPS library loaded as plugin";
-        if (!plugin_path.empty()) {
+        if (!plugin_path.isEmpty()) {
             version += " from file ";
-            version += plugin_path;
+            version += plugin_path.toStdString();
         }
     } else {
         version += "LAMMPS library linked to executable";

--- a/tools/lammps-gui/lammpsgui.cpp
+++ b/tools/lammps-gui/lammpsgui.cpp
@@ -97,7 +97,8 @@ LammpsGui::LammpsGui(QWidget *parent, const QString &filename) :
     QSettings settings;
 
 #if defined(LAMMPS_GUI_USE_PLUGIN)
-    plugin_path = settings.value("plugin_path", "liblammps.so").toString();
+    plugin_path =
+        QFileInfo(settings.value("plugin_path", "liblammps.so").toString()).canonicalFilePath();
     if (!lammps.load_lib(plugin_path.toStdString().c_str())) {
         // fall back to defaults
         for (const char *libfile :

--- a/tools/lammps-gui/lammpsgui.h
+++ b/tools/lammps-gui/lammpsgui.h
@@ -68,7 +68,7 @@ class LammpsGui : public QMainWindow {
     friend class Tutorial2Wizard;
 
 public:
-    LammpsGui(QWidget *parent = nullptr, const char *filename = nullptr);
+    LammpsGui(QWidget *parent = nullptr, const QString &filename = QString());
     ~LammpsGui() override;
 
 protected:
@@ -172,7 +172,7 @@ private:
     LammpsWrapper lammps;
     LammpsRunner *runner;
     QString docver;
-    std::string plugin_path;
+    QString plugin_path;
     bool is_running;
     int run_counter;
     std::vector<char *> lammps_args;

--- a/tools/lammps-gui/lammpswrapper.cpp
+++ b/tools/lammps-gui/lammpswrapper.cpp
@@ -115,7 +115,7 @@ double LammpsWrapper::extract_variable(const char *keyword)
     }
     double val = *((double *)ptr);
 #if defined(LAMMPS_GUI_USE_PLUGIN)
-    ptr = ((liblammpsplugin_t *)plugin_handle)->free(ptr);
+    ((liblammpsplugin_t *)plugin_handle)->free(ptr);
 #else
     lammps_free(ptr);
 #endif

--- a/tools/lammps-gui/main.cpp
+++ b/tools/lammps-gui/main.cpp
@@ -30,6 +30,11 @@
 int main(int argc, char *argv[])
 {
     Q_INIT_RESOURCE(lammpsgui);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // register QList<QString> only needed for Qt5
+    qRegisterMetaTypeStreamOperators<QList<QString>>("QList<QString>");
+#endif
+
     QApplication app(argc, argv);
     // enforce using the plain ASCII C locale within the GUI.
     QLocale::setDefault(QLocale::c());

--- a/tools/lammps-gui/main.cpp
+++ b/tools/lammps-gui/main.cpp
@@ -53,19 +53,22 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addPositionalArgument("file", "The LAMMPS input file to open (optional).");
-    parser.process(app); // this removes known arguments
+    parser.process(app);
 
 #if defined(LAMMPS_GUI_USE_PLUGIN)
     if (parser.isSet(plugindir)) {
-        QString pluginpath = parser.value(plugindir);
-        QSettings settings;
-        settings.setValue("plugin_path", pluginpath);
-        settings.sync();
+        QStringList pluginpath = parser.values(plugindir);
+        if (pluginpath.length() > 0) {
+            QSettings settings;
+            settings.setValue("plugin_path", QString(pluginpath.at(0)));
+            settings.sync();
+        }
     }
 #endif
 
-    const char *infile = nullptr;
-    if (argc > 1) infile = argv[1];
+    QString infile;
+    QStringList args = parser.positionalArguments();
+    if (args.size() > 0) infile = args[0];
     LammpsGui w(nullptr, infile);
     w.show();
     return app.exec();

--- a/tools/lammps-gui/main.cpp
+++ b/tools/lammps-gui/main.cpp
@@ -17,6 +17,9 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QLocale>
+#include <QSettings>
+#include <QString>
+#include <QStringList>
 
 #include <cstdio>
 #include <cstring>
@@ -40,10 +43,26 @@ int main(int argc, char *argv[])
         "\nA graphical editor for LAMMPS input files with syntax highlighting and\n"
         "auto-completion that can run LAMMPS directly. It has built-in capabilities\n"
         "for monitoring, visualization, plotting, and capturing console output.");
+#if defined(LAMMPS_GUI_USE_PLUGIN)
+    QCommandLineOption plugindir(QStringList() << "p"
+                                               << "pluginpath",
+                                 "Path to LAMMPS shared library", "path");
+    parser.addOption(plugindir);
+#endif
+
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addPositionalArgument("file", "The LAMMPS input file to open (optional).");
     parser.process(app); // this removes known arguments
+
+#if defined(LAMMPS_GUI_USE_PLUGIN)
+    if (parser.isSet(plugindir)) {
+        QString pluginpath = parser.value(plugindir);
+        QSettings settings;
+        settings.setValue("plugin_path", pluginpath);
+        settings.sync();
+    }
+#endif
 
     const char *infile = nullptr;
     if (argc > 1) infile = argv[1];


### PR DESCRIPTION
**Summary**

This is hopefully the last batch of bugfixes and updates/cleanups for the stable release.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- missing instantiation for pair style uf3/kk when compiling for GPU
- avoid segfault when loading LAMMPS as plugin if the specified library is not the LAMMPS library and symbols are missing
- silence compiler warnings about unused variables
- refactor plugin loading code in LAMMPS-GUI, add option to override setting from command line

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
