### PR TITLE
Fixes to ReaxFF/Kokkos integer overflow issues for bond tables + cleanup of unused compute

### DIFF
--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -863,15 +863,6 @@ typedef tdual_ffloat_2d_dl::t_dev_um t_ffloat_2d_um_dl;
 typedef tdual_ffloat_2d_dl::t_dev_const_um t_ffloat_2d_const_um_dl;
 typedef tdual_ffloat_2d_dl::t_dev_const_randomread t_ffloat_2d_randomread_dl;
 
-// 3d F_FLOAT array n*m
-
-typedef Kokkos::DualView<F_FLOAT***, LMPDeviceType::array_layout, LMPDeviceType> tdual_ffloat_3d;
-typedef tdual_ffloat_3d::t_dev t_ffloat_3d;
-typedef tdual_ffloat_3d::t_dev_const t_ffloat_3d_const;
-typedef tdual_ffloat_3d::t_dev_um t_ffloat_3d_um;
-typedef tdual_ffloat_3d::t_dev_const_um t_ffloat_3d_const_um;
-typedef tdual_ffloat_3d::t_dev_const_randomread t_ffloat_3d_randomread;
-
 //2d F_FLOAT array n*3
 
 typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, LMPDeviceType> tdual_f_array;
@@ -1177,14 +1168,6 @@ typedef tdual_ffloat_2d_dl::t_host_const t_ffloat_2d_const_dl;
 typedef tdual_ffloat_2d_dl::t_host_um t_ffloat_2d_um_dl;
 typedef tdual_ffloat_2d_dl::t_host_const_um t_ffloat_2d_const_um_dl;
 typedef tdual_ffloat_2d_dl::t_host_const_randomread t_ffloat_2d_randomread_dl;
-
-// 3d F_FLOAT array n*m
-typedef Kokkos::DualView<F_FLOAT***, Kokkos::LayoutRight, LMPDeviceType> tdual_ffloat_3d;
-typedef tdual_ffloat_3d::t_host t_ffloat_3d;
-typedef tdual_ffloat_3d::t_host_const t_ffloat_3d_const;
-typedef tdual_ffloat_3d::t_host_um t_ffloat_3d_um;
-typedef tdual_ffloat_3d::t_host_const_um t_ffloat_3d_const_um;
-typedef tdual_ffloat_3d::t_host_const_randomread t_ffloat_3d_randomread;
 
 //2d F_FLOAT array n*3
 typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, LMPDeviceType> tdual_f_array;

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -863,6 +863,15 @@ typedef tdual_ffloat_2d_dl::t_dev_um t_ffloat_2d_um_dl;
 typedef tdual_ffloat_2d_dl::t_dev_const_um t_ffloat_2d_const_um_dl;
 typedef tdual_ffloat_2d_dl::t_dev_const_randomread t_ffloat_2d_randomread_dl;
 
+// 3d F_FLOAT array n*m
+
+typedef Kokkos::DualView<F_FLOAT***, LMPDeviceType::array_layout, LMPDeviceType> tdual_ffloat_3d;
+typedef tdual_ffloat_3d::t_dev t_ffloat_3d;
+typedef tdual_ffloat_3d::t_dev_const t_ffloat_3d_const;
+typedef tdual_ffloat_3d::t_dev_um t_ffloat_3d_um;
+typedef tdual_ffloat_3d::t_dev_const_um t_ffloat_3d_const_um;
+typedef tdual_ffloat_3d::t_dev_const_randomread t_ffloat_3d_randomread;
+
 //2d F_FLOAT array n*3
 
 typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, LMPDeviceType> tdual_f_array;
@@ -1168,6 +1177,14 @@ typedef tdual_ffloat_2d_dl::t_host_const t_ffloat_2d_const_dl;
 typedef tdual_ffloat_2d_dl::t_host_um t_ffloat_2d_um_dl;
 typedef tdual_ffloat_2d_dl::t_host_const_um t_ffloat_2d_const_um_dl;
 typedef tdual_ffloat_2d_dl::t_host_const_randomread t_ffloat_2d_randomread_dl;
+
+// 3d F_FLOAT array n*m
+typedef Kokkos::DualView<F_FLOAT***, Kokkos::LayoutRight, LMPDeviceType> tdual_ffloat_3d;
+typedef tdual_ffloat_3d::t_host t_ffloat_3d;
+typedef tdual_ffloat_3d::t_host_const t_ffloat_3d_const;
+typedef tdual_ffloat_3d::t_host_um t_ffloat_3d_um;
+typedef tdual_ffloat_3d::t_host_const_um t_ffloat_3d_const_um;
+typedef tdual_ffloat_3d::t_host_const_randomread t_ffloat_3d_randomread;
 
 //2d F_FLOAT array n*3
 typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, LMPDeviceType> tdual_f_array;

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -1604,17 +1604,10 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlocking<
   F_FLOAT dDeltap_self_i[3] = {0.0,0.0,0.0};
   F_FLOAT total_bo_i = 0.0;
 
-  const int bo_first_i = i * maxbo;
-
   int ihb = -1;
 
-  int hb_first_i;
-  if (cut_hbsq > 0.0) {
+  if (cut_hbsq > 0.0)
     ihb = paramssing(itype).p_hbond;
-    if (ihb == 1) {
-      hb_first_i = i * maxhb;
-    }
-  }
 
   int nnz;
   blocking_t selected_jj[blocksize];
@@ -1656,7 +1649,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlocking<
       const F_FLOAT rsq = delij[0]*delij[0] + delij[1]*delij[1] + delij[2]*delij[2];
 
       // hbond list
-      build_hb_list<NEIGHFLAG>(rsq, i, hb_first_i, ihb, j, jtype);
+      build_hb_list<NEIGHFLAG>(rsq, i, ihb, j, jtype);
 
       if (rsq > cut_bosq) continue;
 
@@ -1675,7 +1668,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlocking<
 
       int ii_index = -1;
       int jj_index = -1;
-      if (build_bo_list<NEIGHFLAG>(bo_first_i, i, j, ii_index, jj_index)) {
+      if (build_bo_list<NEIGHFLAG>(i, j, ii_index, jj_index)) {
 
         // from BondOrder1
 
@@ -1743,17 +1736,10 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlockingP
 
   F_FLOAT C12, C34, C56, BO_s, BO_pi, BO_pi2, BO, delij[3];
 
-  const int bo_first_i = i * maxbo;
-
   int ihb = -1;
 
-  int hb_first_i;
-  if (cut_hbsq > 0.0) {
+  if (cut_hbsq > 0.0)
     ihb = paramssing(itype).p_hbond;
-    if (ihb == 1) {
-      hb_first_i = i * maxhb;
-    }
-  }
 
   int nnz;
   blocking_t selected_jj[blocksize];
@@ -1796,7 +1782,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlockingP
       const F_FLOAT rsq = delij[0]*delij[0] + delij[1]*delij[1] + delij[2]*delij[2];
 
       // hbond list
-      build_hb_list<NEIGHFLAG>(rsq, i, hb_first_i, ihb, j, jtype);
+      build_hb_list<NEIGHFLAG>(rsq, i, ihb, j, jtype);
 
       if (rsq > cut_bosq) continue;
 
@@ -1815,7 +1801,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlockingP
 
       int ii_index = -1;
       int jj_index = -1;
-      build_bo_list<NEIGHFLAG>(bo_first_i, i, j, ii_index, jj_index);
+      build_bo_list<NEIGHFLAG>(i, j, ii_index, jj_index);
     }
   }
 }
@@ -1836,17 +1822,10 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfPreview<N
 
   F_FLOAT C12, C34, C56, BO_s, BO_pi, BO_pi2, BO, delij[3];
 
-  const int bo_first_i = i * maxbo;
-
   int ihb = -1;
 
-  int hb_first_i;
-  if (cut_hbsq > 0.0) {
+  if (cut_hbsq > 0.0)
     ihb = paramssing(itype).p_hbond;
-    if (ihb == 1) {
-      hb_first_i = i * maxhb;
-    }
-  }
 
   for (int jj = 0; jj < jnum; jj++) {
     int j = d_neighbors(i,jj);
@@ -1860,7 +1839,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfPreview<N
     const F_FLOAT rsq = delij[0]*delij[0] + delij[1]*delij[1] + delij[2]*delij[2];
 
     // hbond list
-    build_hb_list<NEIGHFLAG>(rsq, i, hb_first_i, ihb, j, jtype);
+    build_hb_list<NEIGHFLAG>(rsq, i, ihb, j, jtype);
 
     if (rsq > cut_bosq) continue;
 
@@ -1880,7 +1859,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfPreview<N
     int ii_index = -1;
     int jj_index = -1;
 
-    build_bo_list<NEIGHFLAG>(bo_first_i, i, j, ii_index, jj_index);
+    build_bo_list<NEIGHFLAG>(i, j, ii_index, jj_index);
   }
 }
 
@@ -1889,7 +1868,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfPreview<N
 template<class DeviceType>
 template<int NEIGHFLAG>
 KOKKOS_INLINE_FUNCTION
-void PairReaxFFKokkos<DeviceType>::build_hb_list(F_FLOAT rsq, int i, int hb_first_i, int ihb, int j, int jtype) const {
+void PairReaxFFKokkos<DeviceType>::build_hb_list(F_FLOAT rsq, int i, int ihb, int j, int jtype) const {
 
   int i_index, j_index;
   int jhb = -1;
@@ -1897,12 +1876,12 @@ void PairReaxFFKokkos<DeviceType>::build_hb_list(F_FLOAT rsq, int i, int hb_firs
     jhb = paramssing(jtype).p_hbond;
     if (ihb == 1 && jhb == 2) {
       if (NEIGHFLAG == HALF) {
-        j_index = hb_first_i + d_hb_num[i];
+        j_index = i * maxhb + d_hb_num[i];
         d_hb_num[i]++;
       } else
-        j_index = hb_first_i + Kokkos::atomic_fetch_add(&d_hb_num[i],1);
+        j_index = i * maxhb + Kokkos::atomic_fetch_add(&d_hb_num[i],1);
 
-      const int jj_index = j_index - hb_first_i;
+      const int jj_index = j_index - i * maxhb;
 
       if (jj_index >= maxhb)
         d_resize_hb() = MAX(d_resize_hb(),jj_index+1);
@@ -1931,20 +1910,20 @@ void PairReaxFFKokkos<DeviceType>::build_hb_list(F_FLOAT rsq, int i, int hb_firs
 template<class DeviceType>
 template<int NEIGHFLAG>
 KOKKOS_INLINE_FUNCTION
-bool PairReaxFFKokkos<DeviceType>::build_bo_list(int bo_first_i, int i, int j, int& ii_index, int& jj_index) const {
+bool PairReaxFFKokkos<DeviceType>::build_bo_list(int i, int j, int& ii_index, int& jj_index) const {
    int i_index, j_index;
 
   if (NEIGHFLAG == HALF) {
-    j_index = bo_first_i + d_bo_num[i];
+    j_index = i * maxbo + d_bo_num[i];
     i_index = j * maxbo + d_bo_num[j];
     d_bo_num[i]++;
     d_bo_num[j]++;
   } else {
-    j_index = bo_first_i + Kokkos::atomic_fetch_add(&d_bo_num[i],1);
+    j_index = i * maxbo + Kokkos::atomic_fetch_add(&d_bo_num[i],1);
     i_index = j * maxbo + Kokkos::atomic_fetch_add(&d_bo_num[j],1);
   }
 
-  jj_index = j_index - bo_first_i;
+  jj_index = j_index - i * maxbo;
   ii_index = i_index - j * maxbo;
 
   bool set_dB_flag = true;

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -1503,18 +1503,10 @@ void PairReaxFFKokkos<DeviceType>::allocate_array()
 
   if (cut_hbsq > 0.0) {
     MemKK::realloc_kokkos(d_hb_num,"reaxff/kk:hb_num",nmax);
-
-    if (((bigint) nmax*maxhb) > MAXSMALLINT)
-      error->one(FLERR,"Too many hydrogen bonds in pair reaxff");
-
-    MemKK::realloc_kokkos(d_hb_list,"reaxff/kk:hb_list",nmax*maxhb);
+    MemKK::realloc_kokkos(d_hb_list,"reaxff/kk:hb_list", nmax, maxhb);
   }
   MemKK::realloc_kokkos(d_bo_num,"reaxff/kk:bo_num",nmax);
-
-  if (((bigint) nmax*maxbo) > MAXSMALLINT)
-    error->one(FLERR,"Too many bonds in pair reaxff");
-
-  MemKK::realloc_kokkos(d_bo_list,"reaxff/kk:bo_list",nmax*maxbo);
+  MemKK::realloc_kokkos(d_bo_list,"reaxff/kk:bo_list", nmax, maxbo);
 
   MemKK::realloc_kokkos(d_BO,"reaxff/kk:BO",nmax,maxbo);
   MemKK::realloc_kokkos(d_BO_s,"reaxff/kk:BO",nmax,maxbo);
@@ -1666,23 +1658,23 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlocking<
       BO = BO_s + BO_pi + BO_pi2;
       if (BO < bo_cut) continue;
 
-      int ii_index = -1;
-      int jj_index = -1;
-      if (build_bo_list<NEIGHFLAG>(i, j, ii_index, jj_index)) {
+      int i_index = -1;
+      int j_index = -1;
+      if (build_bo_list<NEIGHFLAG>(i, j, i_index, j_index)) {
 
         // from BondOrder1
 
-        d_BO(i,jj_index) = BO;
-        d_BO_s(i,jj_index) = BO_s;
+        d_BO(i,j_index) = BO;
+        d_BO_s(i,j_index) = BO_s;
 
-        d_BO(j,ii_index) = BO;
-        d_BO_s(j,ii_index) = BO_s;
+        d_BO(j,i_index) = BO;
+        d_BO_s(j,i_index) = BO_s;
 
-        d_BO_pi(j,ii_index) = BO_pi;
-        d_BO_pi2(j,ii_index) = BO_pi2;
+        d_BO_pi(j,i_index) = BO_pi;
+        d_BO_pi2(j,i_index) = BO_pi2;
 
-        d_BO_pi(i,jj_index) = BO_pi;
-        d_BO_pi2(i,jj_index) = BO_pi2;
+        d_BO_pi(i,j_index) = BO_pi;
+        d_BO_pi2(i,j_index) = BO_pi2;
 
         F_FLOAT Cln_BOp_s = p_bo2 * C12 / rij / rij;
         F_FLOAT Cln_BOp_pi = p_bo4 * C34 / rij / rij;
@@ -1695,18 +1687,18 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlocking<
         for (int d = 0; d < 3; d++) dDeltap_self_i[d] += dBOp_i[d];
         for (int d = 0; d < 3; d++) a_dDeltap_self(j,d) += -dBOp_i[d];
 
-        d_dln_BOp_pi(i,jj_index) = -(BO_pi*Cln_BOp_pi);
-        d_dln_BOp_pi(j,ii_index) = -(BO_pi*Cln_BOp_pi);
+        d_dln_BOp_pi(i,j_index) = -(BO_pi*Cln_BOp_pi);
+        d_dln_BOp_pi(j,i_index) = -(BO_pi*Cln_BOp_pi);
 
-        d_dln_BOp_pi2(i,jj_index) = -(BO_pi2*Cln_BOp_pi2);
-        d_dln_BOp_pi2(j,ii_index) = -(BO_pi2*Cln_BOp_pi2);
+        d_dln_BOp_pi2(i,j_index) = -(BO_pi2*Cln_BOp_pi2);
+        d_dln_BOp_pi2(j,i_index) = -(BO_pi2*Cln_BOp_pi2);
 
-        d_dBOp(i,jj_index) = -(BO_s*Cln_BOp_s+BO_pi*Cln_BOp_pi+BO_pi2*Cln_BOp_pi2);
-        d_dBOp(j,ii_index) = -(BO_s*Cln_BOp_s+BO_pi*Cln_BOp_pi+BO_pi2*Cln_BOp_pi2);
-        d_BO(i,jj_index) = BO - bo_cut;
-        d_BO(j,ii_index) = BO - bo_cut;
-        d_BO_s(i,jj_index) = BO_s - bo_cut;
-        d_BO_s(j,ii_index) = BO_s - bo_cut;
+        d_dBOp(i,j_index) = -(BO_s*Cln_BOp_s+BO_pi*Cln_BOp_pi+BO_pi2*Cln_BOp_pi2);
+        d_dBOp(j,i_index) = -(BO_s*Cln_BOp_s+BO_pi*Cln_BOp_pi+BO_pi2*Cln_BOp_pi2);
+        d_BO(i,j_index) = BO - bo_cut;
+        d_BO(j,i_index) = BO - bo_cut;
+        d_BO_s(i,j_index) = BO_s - bo_cut;
+        d_BO_s(j,i_index) = BO_s - bo_cut;
         total_bo_i += (BO - bo_cut);
         a_total_bo[j] += (BO - bo_cut);
       }
@@ -1799,9 +1791,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfBlockingP
       BO = BO_s + BO_pi + BO_pi2;
       if (BO < bo_cut) continue;
 
-      int ii_index = -1;
-      int jj_index = -1;
-      build_bo_list<NEIGHFLAG>(i, j, ii_index, jj_index);
+      int i_index = -1;
+      int j_index = -1;
+      build_bo_list<NEIGHFLAG>(i, j, i_index, j_index);
     }
   }
 }
@@ -1856,10 +1848,10 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsHalfPreview<N
     BO = BO_s + BO_pi + BO_pi2;
     if (BO < bo_cut) continue;
 
-    int ii_index = -1;
-    int jj_index = -1;
+    int i_index = -1;
+    int j_index = -1;
 
-    build_bo_list<NEIGHFLAG>(i, j, ii_index, jj_index);
+    build_bo_list<NEIGHFLAG>(i, j, i_index, j_index);
   }
 }
 
@@ -1876,30 +1868,26 @@ void PairReaxFFKokkos<DeviceType>::build_hb_list(F_FLOAT rsq, int i, int ihb, in
     jhb = paramssing(jtype).p_hbond;
     if (ihb == 1 && jhb == 2) {
       if (NEIGHFLAG == HALF) {
-        j_index = i * maxhb + d_hb_num[i];
+        j_index = d_hb_num[i];
         d_hb_num[i]++;
       } else
-        j_index = i * maxhb + Kokkos::atomic_fetch_add(&d_hb_num[i],1);
+        j_index = Kokkos::atomic_fetch_add(&d_hb_num[i],1);
 
-      const int jj_index = j_index - i * maxhb;
-
-      if (jj_index >= maxhb)
-        d_resize_hb() = MAX(d_resize_hb(),jj_index+1);
+      if (j_index >= maxhb)
+        d_resize_hb() = MAX(d_resize_hb(), j_index+1);
       else
-        d_hb_list[j_index] = j;
+        d_hb_list(i, j_index) = j;
     } else if (j < nlocal && ihb == 2 && jhb == 1) {
       if (NEIGHFLAG == HALF) {
-        i_index = j * maxhb + d_hb_num[j];
+        i_index = d_hb_num[j];
         d_hb_num[j]++;
       } else
-        i_index = j * maxhb + Kokkos::atomic_fetch_add(&d_hb_num[j],1);
+        i_index = Kokkos::atomic_fetch_add(&d_hb_num[j],1);
 
-      const int ii_index = i_index - j * maxhb;
-
-      if (ii_index >= maxhb)
-        d_resize_hb() = MAX(d_resize_hb(),ii_index+1);
+      if (i_index >= maxhb)
+        d_resize_hb() = MAX(d_resize_hb(), i_index+1);
       else
-        d_hb_list[i_index] = i;
+        d_hb_list(j, i_index) = i;
     }
   }
 
@@ -1910,31 +1898,27 @@ void PairReaxFFKokkos<DeviceType>::build_hb_list(F_FLOAT rsq, int i, int ihb, in
 template<class DeviceType>
 template<int NEIGHFLAG>
 KOKKOS_INLINE_FUNCTION
-bool PairReaxFFKokkos<DeviceType>::build_bo_list(int i, int j, int& ii_index, int& jj_index) const {
-   int i_index, j_index;
+bool PairReaxFFKokkos<DeviceType>::build_bo_list(int i, int j, int& i_index, int& j_index) const {
 
   if (NEIGHFLAG == HALF) {
-    j_index = i * maxbo + d_bo_num[i];
-    i_index = j * maxbo + d_bo_num[j];
+    j_index = d_bo_num[i];
+    i_index = d_bo_num[j];
     d_bo_num[i]++;
     d_bo_num[j]++;
   } else {
-    j_index = i * maxbo + Kokkos::atomic_fetch_add(&d_bo_num[i],1);
-    i_index = j * maxbo + Kokkos::atomic_fetch_add(&d_bo_num[j],1);
+    j_index = Kokkos::atomic_fetch_add(&d_bo_num[i],1);
+    i_index = Kokkos::atomic_fetch_add(&d_bo_num[j],1);
   }
-
-  jj_index = j_index - i * maxbo;
-  ii_index = i_index - j * maxbo;
 
   bool set_dB_flag = true;
 
-  if (jj_index >= maxbo || ii_index >= maxbo) {
-    const int max_val = MAX(ii_index+1,jj_index+1);
+  if (j_index >= maxbo || i_index >= maxbo) {
+    const int max_val = MAX(i_index + 1, j_index + 1);
     d_resize_bo() = MAX(d_resize_bo(),max_val);
     set_dB_flag = false;
   } else {
-    d_bo_list[j_index] = j;
-    d_bo_list[i_index] = i;
+    d_bo_list(i, j_index) = j;
+    d_bo_list(j, i_index) = i;
     set_dB_flag = true;
   }
 
@@ -1958,13 +1942,11 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBuildListsFull, const i
   F_FLOAT dDeltap_self_i[3] = {0.0,0.0,0.0};
   F_FLOAT total_bo_i = 0.0;
 
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  const int jnum = d_bo_num[i];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const int jtype = type(j);
-    const int j_index = jj - j_start;
     delij[0] = x(j,0) - xtmp;
     delij[1] = x(j,1) - ytmp;
     delij[2] = x(j,2) - ztmp;
@@ -2073,20 +2055,18 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBondOrder2, const int &
 
   const int i = d_ilist[ii];
   const int itype = type(i);
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
+  const int jnum = d_bo_num[i];
 
   const F_FLOAT val_i = paramssing(itype).valency;
 
   d_total_bo[i] = 0.0;
   F_FLOAT total_bo = 0.0;
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const int jtype = type(j);
-    const int j_index = jj - j_start;
-    const int i_index = maxbo+j_index;
+    const int i_index = maxbo + j_index; // this line seems confusing...
 
     // calculate corrected BO and total bond order
 
@@ -2242,20 +2222,18 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeMulti1, const in
   if (imass > 21.0) dfvl = 0.0;
   else dfvl = 1.0;
 
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
+  const int jnum = d_bo_num[i];
 
   F_FLOAT sum_ovun1 = 0.0;
   F_FLOAT sum_ovun2 = 0.0;
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const int jtype = type(j);
-    const int j_index = jj - j_start;
 
     sum_ovun1 += paramstwbp(itype,jtype).p_ovun1 * paramstwbp(itype,jtype).De_s * d_BO(i,j_index);
-    sum_ovun2 += (d_Delta[j] - dfvl * d_Delta_lp_temp[j]) * (d_BO_pi(i,j_index) + d_BO_pi2(i,j_index));
+    sum_ovun2 += (d_Delta[j] - dfvl * d_Delta_lp_temp[j]) * (d_BO_pi(i, j_index) + d_BO_pi2(i,j_index));
   }
   d_sum_ovun(i,1) += sum_ovun1;
   d_sum_ovun(i,2) += sum_ovun2;
@@ -2365,16 +2343,14 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeMulti2<NEIGHFLAG
   if (numbonds > 0 || enobondsflag)
     a_CdDelta[i] += CEunder3;
 
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
+  const int jnum = d_bo_num[i];
 
   F_FLOAT CdDelta_i = 0.0;
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const int jtype = type(j);
     const F_FLOAT jmass = paramssing(jtype).mass;
-    const int j_index = jj - j_start;
     const F_FLOAT De_s = paramstwbp(itype,jtype).De_s;
 
     // multibody lone pair: correction for C2
@@ -2424,24 +2400,23 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxCountAngularTorsion<POP
   const int i = d_ilist[ii];
   const int itype = type(i);
 
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
+  const int jnum = d_bo_num[i];
 
   if (POPULATE) {
     // Computes and stores SBO2, CSBO2, dSBO1, dSBO2
-    compute_angular_sbo(i, itype, j_start, j_end);
+    compute_angular_sbo(i, itype, jnum);
   }
 
   // Angular
 
   // Count buffer size for `i`
   int location_angular = 0; // dummy declaration
-  int count_angular = preprocess_angular<false>(i, itype, j_start, j_end, location_angular);
+  int count_angular = preprocess_angular<false>(i, itype, jnum, location_angular);
   location_angular = Kokkos::atomic_fetch_add(&d_count_angular_torsion(0), count_angular);
 
   if (POPULATE) {
     // Fill buffer for `i`
-    preprocess_angular<true>(i, itype, j_start, j_end, location_angular);
+    preprocess_angular<true>(i, itype, jnum, location_angular);
   }
 
   // Torsion
@@ -2453,12 +2428,12 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxCountAngularTorsion<POP
 
   // Count buffer size for `i`
   int location_torsion = 0; // dummy declaration
-  int count_torsion = preprocess_torsion<false>(i, itype, itag, xtmp, ytmp, ztmp, j_start, j_end, location_torsion);
+  int count_torsion = preprocess_torsion<false>(i, itype, itag, xtmp, ytmp, ztmp, jnum, location_torsion);
   location_torsion = Kokkos::atomic_fetch_add(&d_count_angular_torsion(1), count_torsion);
 
   if (POPULATE) {
     // Fill buffer for `i`
-    preprocess_torsion<true>(i, itype, itag, xtmp, ytmp, ztmp, j_start, j_end, location_torsion);
+    preprocess_torsion<true>(i, itype, itag, xtmp, ytmp, ztmp, jnum, location_torsion);
   }
 
 }
@@ -2467,7 +2442,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxCountAngularTorsion<POP
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairReaxFFKokkos<DeviceType>::compute_angular_sbo(int i, int itype, int j_start, int j_end) const {
+void PairReaxFFKokkos<DeviceType>::compute_angular_sbo(int i, int itype, int jnum) const {
 
   F_FLOAT SBO2, CSBO2, dSBO1, dSBO2;
 
@@ -2477,8 +2452,7 @@ void PairReaxFFKokkos<DeviceType>::compute_angular_sbo(int i, int itype, int j_s
   F_FLOAT SBOp = 0.0;
   F_FLOAT prod_SBO = 1.0;
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    const int j_index = jj - j_start;
+  for (int j_index = 0; j_index < jnum; j_index++) {
     const F_FLOAT bo_ij = d_BO(i,j_index);
 
     SBOp += (d_BO_pi(i,j_index) + d_BO_pi2(i,j_index));
@@ -2531,14 +2505,13 @@ void PairReaxFFKokkos<DeviceType>::compute_angular_sbo(int i, int itype, int j_s
 template<class DeviceType>
 template<bool POPULATE>
 KOKKOS_INLINE_FUNCTION
-int PairReaxFFKokkos<DeviceType>::preprocess_angular(int i, int itype, int j_start, int j_end, int location_angular) const {
+int PairReaxFFKokkos<DeviceType>::preprocess_angular(int i, int itype, int jnum, int location_angular) const {
 
   int count_angular = 0;
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
-    const int j_index = jj - j_start;
     const F_FLOAT bo_ij = d_BO(i,j_index);
 
     if (bo_ij <= thb_cut) continue;
@@ -2547,13 +2520,12 @@ int PairReaxFFKokkos<DeviceType>::preprocess_angular(int i, int itype, int j_sta
     const int i_index = maxbo + j_index;
     const int jtype = type(j);
 
-    for (int kk = jj+1; kk < j_end; kk++) {
+    for (int k_index = j_index + 1; k_index < jnum; k_index++) {
     //for (int kk = j_start; kk < j_end; kk++) {
-      int k = d_bo_list[kk];
+      int k = d_bo_list(i, k_index);
       k &= NEIGHMASK;
       if (k == j) continue;
 
-      const int k_index = kk - j_start;
       const F_FLOAT bo_ik = d_BO(i,k_index);
 
       if (bo_ij <= thb_cut || bo_ik <= thb_cut || bo_ij * bo_ik <= thb_cutsq) continue;
@@ -2571,14 +2543,14 @@ int PairReaxFFKokkos<DeviceType>::preprocess_angular(int i, int itype, int j_sta
         pack.i0 = i;
         pack.i1 = j;
         pack.i2 = k;
-        pack.i3 = j_start;
+        pack.i3 = jnum;
         d_angular_pack(location_angular, 0) = pack;
 
         // Second pack stores i_index, j_index, k_index, and j_end
         pack.i0 = i_index;
         pack.i1 = j_index;
         pack.i2 = k_index;
-        pack.i3 = j_end;
+        // i3 is unused
         d_angular_pack(location_angular, 1) = pack;
 
         location_angular++;
@@ -2597,17 +2569,16 @@ template<class DeviceType>
 template<bool POPULATE>
 KOKKOS_INLINE_FUNCTION
 int PairReaxFFKokkos<DeviceType>::preprocess_torsion(int i, int /*itype*/, tagint itag,
-  F_FLOAT xtmp, F_FLOAT ytmp, F_FLOAT ztmp, int j_start, int j_end, int location_torsion) const {
+  F_FLOAT xtmp, F_FLOAT ytmp, F_FLOAT ztmp, int jknum, int location_torsion) const {
 
   // in reaxff_torsion_angles: j = i, k = j, i = k;
 
   int count_torsion = 0;
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jknum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const tagint jtag = tag(j);
-    const int j_index = jj - j_start;
 
     // skip half of the interactions
     if (itag > jtag) {
@@ -2623,23 +2594,20 @@ int PairReaxFFKokkos<DeviceType>::preprocess_torsion(int i, int /*itype*/, tagin
     const F_FLOAT bo_ij = d_BO(i,j_index);
     if (bo_ij < thb_cut) continue;
 
-    const int l_start = j * maxbo;
-    const int l_end = l_start + d_bo_num[j];
+    const int lnum = d_bo_num[j];
 
-    for (int kk = j_start; kk < j_end; kk++) {
-      int k = d_bo_list[kk];
+    for (int k_index = 0; k_index < jknum; k_index++) {
+      int k = d_bo_list(i, k_index);
       k &= NEIGHMASK;
       if (k == j) continue;
-      const int k_index = kk - j_start;
 
       const F_FLOAT bo_ik = d_BO(i,k_index);
       if (bo_ik < thb_cut) continue;
 
-      for (int ll = l_start; ll < l_end; ll++) {
-        int l = d_bo_list[ll];
+      for (int l_index = 0; l_index < lnum; l_index++) {
+        int l = d_bo_list(j, l_index);
         l &= NEIGHMASK;
         if (l == i) continue;
-        const int l_index = ll - l_start;
 
         const F_FLOAT bo_jl = d_BO(j,l_index);
         if (l == k || bo_jl < thb_cut || bo_ij*bo_ik*bo_jl < thb_cut) continue;
@@ -2721,13 +2689,13 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeAngularPreproces
   const int i = pack.i0;
   const int j = pack.i1;
   const int k = pack.i2;
-  const int j_start = pack.i3;
+  const int jnum = pack.i3;
 
   pack = d_angular_pack(apack, 1);
   const int i_index = pack.i0;
   const int j_index = pack.i1;
   const int k_index = pack.i2;
-  const int j_end = pack.i3;
+  // i3 is unused
 
   const int itype = type(i);
   const X_FLOAT xtmp = x(i,0);
@@ -2885,9 +2853,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeAngularPreproces
   CdDelta_j += CEcoa4;
   a_CdDelta[k] += CEcoa5;
 
-  for (int ll = j_start; ll < j_end; ll++) {
-    const int l_index = ll - j_start;
-
+  for (int l_index = 0; l_index < jnum; l_index++) {
     temp_bo_jt = d_BO(i,l_index);
     temp = temp_bo_jt * temp_bo_jt * temp_bo_jt;
     pBOjt7 = temp * temp * temp_bo_jt;
@@ -3303,21 +3269,18 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeHydrogen<NEIGHFL
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
 
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
-  const int k_start = i * maxhb;
-  const int k_end = k_start + d_hb_num[i];
+  const int jnum = d_bo_num[i];
+  const int knum = d_hb_num[i];
 
   int top = 0;
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const int jtype = type(j);
-    const int j_index = jj - j_start;
     const F_FLOAT bo_ij = d_BO(i,j_index);
 
     if (paramssing(jtype).p_hbond == 2 && bo_ij >= HB_THRESHOLD) {
-      hblist[top] = jj;
+      hblist[top] = j_index;
       top ++;
     }
   }
@@ -3325,8 +3288,8 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeHydrogen<NEIGHFL
   F_FLOAT fitmp[3];
   for (int d = 0; d < 3; d++) fitmp[d] = 0.0;
 
-  for (int kk = k_start; kk < k_end; kk++) {
-    int k = d_hb_list[kk];
+  for (int k_index = 0; k_index < knum; k_index++) {
+    int k = d_hb_list(i, k_index);
     k &= NEIGHMASK;
     const tagint ktag = tag(k);
     const int ktype = type(k);
@@ -3338,14 +3301,13 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeHydrogen<NEIGHFL
     const F_FLOAT rik = sqrt(rsqik);
 
     for (int itr = 0; itr < top; itr++) {
-      const int jj = hblist[itr];
-      int j = d_bo_list[jj];
+      const int j_index = hblist[itr];
+      int j = d_bo_list(i, j_index);
       j &= NEIGHMASK;
       const tagint jtag = tag(j);
       if (jtag == ktag) continue;
 
       const int jtype = type(j);
-      const int j_index = jj - j_start;
       const F_FLOAT bo_ij = d_BO(i,j_index);
 
       delij[0] = x(j,0) - xtmp;
@@ -3442,11 +3404,10 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxUpdateBond<NEIGHFLAG>, 
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
   const tagint itag = tag(i);
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
+  const int jnum = d_bo_num[i];
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const tagint jtag = tag(j);
 
@@ -3464,19 +3425,16 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxUpdateBond<NEIGHFLAG>, 
 
     if (!flag) continue;
 
-    const int j_index = jj - j_start;
     const F_FLOAT Cdbo_i = d_Cdbo(i,j_index);
     const F_FLOAT Cdbopi_i = d_Cdbopi(i,j_index);
     const F_FLOAT Cdbopi2_i = d_Cdbopi2(i,j_index);
 
-    const int k_start = j * maxbo;
-    const int k_end = k_start + d_bo_num[j];
+    const int knum = d_bo_num[j];
 
-    for (int kk = k_start; kk < k_end; kk++) {
-      int k = d_bo_list[kk];
+    for (int k_index = 0; k_index < knum; k_index++) {
+      int k = d_bo_list(j, k_index);
       k &= NEIGHMASK;
       if (k != i) continue;
-      const int k_index = kk - k_start;
 
       a_Cdbo(j,k_index) += Cdbo_i;
       a_Cdbopi(j,k_index) += Cdbopi_i;
@@ -3504,13 +3462,12 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond1<NEIGHFLAG,
   const int itype = type(i);
   const tagint itag = tag(i);
   const F_FLOAT imass = paramssing(itype).mass;
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
+  const int jnum = d_bo_num[i];
 
   F_FLOAT CdDelta_i = 0.0;
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const tagint jtag = tag(j);
 
@@ -3525,7 +3482,6 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond1<NEIGHFLAG,
     }
 
     const int jtype = type(j);
-    const int j_index = jj - j_start;
     const F_FLOAT jmass = paramssing(jtype).mass;
 
     // bond energy (nlocal only)
@@ -3618,15 +3574,14 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond2<NEIGHFLAG,
   const X_FLOAT ytmp = x(i,1);
   const X_FLOAT ztmp = x(i,2);
   const tagint itag = tag(i);
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
+  const int jknum = d_bo_num[i];
 
   F_FLOAT CdDelta_i = d_CdDelta[i];
   F_FLOAT fitmp[3];
   for (int j = 0; j < 3; j++) fitmp[j] = 0.0;
 
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  for (int j_index = 0; j_index < jknum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const tagint jtag = tag(j);
 
@@ -3640,15 +3595,13 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond2<NEIGHFLAG,
       if (x(j,2) == ztmp && x(j,1) == ytmp && x(j,0) < xtmp) continue;
     }
 
-    const int j_index = jj - j_start;
     F_FLOAT CdDelta_j = d_CdDelta[j];
 
     delij[0] = x(j,0) - xtmp;
     delij[1] = x(j,1) - ytmp;
     delij[2] = x(j,2) - ztmp;
 
-    const int k_start = j * maxbo;
-    const int k_end = k_start + d_bo_num[j];
+    const int knum = d_bo_num[j];
 
     F_FLOAT coef_C1dbo, coef_C2dbo, coef_C3dbo, coef_C1dbopi, coef_C2dbopi, coef_C3dbopi, coef_C4dbopi;
     F_FLOAT coef_C1dbopi2, coef_C2dbopi2, coef_C3dbopi2, coef_C4dbopi2, coef_C1dDelta, coef_C2dDelta, coef_C3dDelta;
@@ -3732,10 +3685,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond2<NEIGHFLAG,
     }
 
     // forces on k: i neighbor
-    for (int kk = j_start; kk < j_end; kk++) {
-      int k = d_bo_list[kk];
+    for (int k_index = 0; k_index < jknum; k_index++) {
+      int k = d_bo_list(i, k_index);
       k &= NEIGHMASK;
-      const int k_index = kk - j_start;
 
       delik[0] = x(k,0) - xtmp;
       delik[1] = x(k,1) - ytmp;
@@ -3762,10 +3714,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond2<NEIGHFLAG,
     }
 
     // forces on k: j neighbor
-    for (int kk = k_start; kk < k_end; kk++) {
-      int k = d_bo_list[kk];
+    for (int k_index = 0; k_index < knum; k_index++) {
+      int k = d_bo_list(j, k_index);
       k &= NEIGHMASK;
-      const int k_index = kk - k_start;
 
       for (int d = 0; d < 3; d++) deljk[d] = x(k,d) - x(j,d);
 
@@ -4166,15 +4117,13 @@ void PairReaxFFKokkos<DeviceType>::calculate_find_bond_item(int ii, int &numbond
   int nj = 0;
 
   if (mask[i] & groupbit) {
-    const int j_start = i * maxbo;
-    const int j_end = j_start + d_bo_num[i];
-    for (int jj = j_start; jj < j_end; jj++) {
-      int j = d_bo_list[jj];
+    const int jnum = d_bo_num[i];
+    for (int j_index = 0; j_index < jnum; j_index++) {
+      int j = d_bo_list(i, j_index);
       j &= NEIGHMASK;
       if (mask[j] & groupbit) {
         const tagint jtag = tag[j];
-        const int j_index = jj - j_start;
-        double bo_tmp = d_BO(i,j_index);
+        double bo_tmp = d_BO(i, j_index);
 
         if (bo_tmp > bo_cut_bond) {
           d_neighid(i,nj) = jtag;
@@ -4372,15 +4321,13 @@ KOKKOS_INLINE_FUNCTION
 void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxFindBondSpecies, const int &i) const {
   int nj = 0;
 
-  const int j_start = i * maxbo;
-  const int j_end = j_start + d_bo_num[i];
-  for (int jj = j_start; jj < j_end; jj++) {
-    int j = d_bo_list[jj];
+  const int jnum = d_bo_num[i];
+  for (int j_index = 0; j_index < jnum; j_index++) {
+    int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     if (j < i) continue;
-    const int j_index = jj - j_start;
 
-    double bo_tmp = d_BO(i,j_index);
+    double bo_tmp = d_BO(i, j_index);
 
     if (bo_tmp >= 0.10) { // Why is this a hardcoded value?
       k_tmpid.view<DeviceType>()(i,nj) = j;

--- a/src/KOKKOS/pair_reaxff_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxff_kokkos.cpp
@@ -1537,9 +1537,9 @@ void PairReaxFFKokkos<DeviceType>::allocate_array()
   MemKK::realloc_kokkos(d_Deltap,"reaxff/kk:Deltap",nmax);
   MemKK::realloc_kokkos(d_total_bo,"reaxff/kk:total_bo",nmax);
 
-  MemKK::realloc_kokkos(d_Cdbo,"reaxff/kk:Cdbo",nmax,maxbo,3);
-  MemKK::realloc_kokkos(d_Cdbopi,"reaxff/kk:Cdbopi",nmax,maxbo,3);
-  MemKK::realloc_kokkos(d_Cdbopi2,"reaxff/kk:Cdbopi2",nmax,maxbo,3);
+  MemKK::realloc_kokkos(d_Cdbo,"reaxff/kk:Cdbo",nmax,maxbo);
+  MemKK::realloc_kokkos(d_Cdbopi,"reaxff/kk:Cdbopi",nmax,maxbo);
+  MemKK::realloc_kokkos(d_Cdbopi2,"reaxff/kk:Cdbopi2",nmax,maxbo);
 
   MemKK::realloc_kokkos(d_Delta,"reaxff/kk:Delta",nmax);
   MemKK::realloc_kokkos(d_Delta_boc,"reaxff/kk:Delta_boc",nmax);
@@ -2066,12 +2066,8 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBondOrder2, const int &
     int j = d_bo_list(i, j_index);
     j &= NEIGHMASK;
     const int jtype = type(j);
-    //const int i_index = maxbo + j_index; // this line seems confusing...
-    const int i_index = j_index; // ??
-
 
     // calculate corrected BO and total bond order
-
     const F_FLOAT val_j = paramssing(jtype).valency;
     const F_FLOAT ovc = paramstwbp(itype,jtype).ovc;
     const F_FLOAT v13cor = paramstwbp(itype,jtype).v13cor;
@@ -2163,14 +2159,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxBondOrder2, const int &
 
     total_bo += d_BO(i,j_index);
 
-    // debugging whether or not the values that go into (*,*,1) are relevant
-    d_Cdbo(i,j_index,0) = 0.0;
-    d_Cdbopi(i,j_index,0) = 0.0;
-    d_Cdbopi2(i,j_index,0) = 0.0;
-    d_Cdbo(j,i_index,1) = 0.0;
-    d_Cdbopi(j,i_index,1) = 0.0;
-    d_Cdbopi2(j,i_index,1) = 0.0;
-
+    d_Cdbo(i,j_index) = 0.0;
+    d_Cdbopi(i,j_index) = 0.0;
+    d_Cdbopi2(i,j_index) = 0.0;
     d_CdDelta[j] = 0.0;
   }
   d_CdDelta[i] = 0.0;
@@ -2364,7 +2355,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeMulti2<NEIGHFLAG
         const F_FLOAT e_lph = p_lp3 * (vov3-3.0)*(vov3-3.0);
         const F_FLOAT deahu2dbo = 2.0 * p_lp3 * (vov3 - 3.0);
         const F_FLOAT deahu2dsbo = 2.0 * p_lp3 * (vov3 - 3.0) * (-1.0 - 0.16 * pow(Di,3.0));
-        d_Cdbo(i,j_index,0) += deahu2dbo;
+        d_Cdbo(i,j_index) += deahu2dbo;
         CdDelta_i += deahu2dsbo;
 
         if (EFLAG) {
@@ -2377,9 +2368,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeMulti2<NEIGHFLAG
     // over/under coordination forces merged together
     const F_FLOAT p_ovun1 = paramstwbp(itype,jtype).p_ovun1;
     a_CdDelta[j] += (CEover4 + CEunder4) * (1.0 - dfvl * d_dDelta_lp[j]) * (d_BO_pi(i,j_index) + d_BO_pi2(i,j_index));
-    d_Cdbo(i,j_index,0) += CEover1 * p_ovun1 * De_s;
-    d_Cdbopi(i,j_index,0) += (CEover4 + CEunder4) * (d_Delta[j] - dfvl*d_Delta_lp_temp[j]);
-    d_Cdbopi2(i,j_index,0) += (CEover4 + CEunder4) * (d_Delta[j] - dfvl*d_Delta_lp_temp[j]);
+    d_Cdbo(i,j_index) += CEover1 * p_ovun1 * De_s;
+    d_Cdbopi(i,j_index) += (CEover4 + CEunder4) * (d_Delta[j] - dfvl*d_Delta_lp_temp[j]);
+    d_Cdbopi2(i,j_index) += (CEover4 + CEunder4) * (d_Delta[j] - dfvl*d_Delta_lp_temp[j]);
   }
   a_CdDelta[i] += CdDelta_i;
 
@@ -2520,8 +2511,6 @@ int PairReaxFFKokkos<DeviceType>::preprocess_angular(int i, int itype, int jnum,
     if (bo_ij <= thb_cut) continue;
     if (i >= nlocal && j >= nlocal) continue;
 
-    // const int i_index = maxbo + j_index; ??
-    const int i_index = j_index; // plus a shift?
     const int jtype = type(j);
 
     for (int k_index = j_index + 1; k_index < jnum; k_index++) {
@@ -2550,8 +2539,8 @@ int PairReaxFFKokkos<DeviceType>::preprocess_angular(int i, int itype, int jnum,
         pack.i3 = jnum;
         d_angular_pack(location_angular, 0) = pack;
 
-        // Second pack stores i_index, j_index, k_index, and j_end
-        pack.i0 = i_index;
+        // Second pack stores j_index and k_index
+        // i0 is unused because there's no i_index
         pack.i1 = j_index;
         pack.i2 = k_index;
         // i3 is unused
@@ -2651,9 +2640,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeAngularPreproces
 
   auto v_f = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_f),decltype(ndup_f)>::get(dup_f,ndup_f);
   auto a_f = v_f.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbo)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbo = d_Cdbo;
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbopi)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi = d_Cdbopi;
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbopi2)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi2 = d_Cdbopi2;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbo)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbo = d_Cdbo;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbopi)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi = d_Cdbopi;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbopi2)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi2 = d_Cdbopi2;
 
   auto v_CdDelta = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_CdDelta),decltype(ndup_CdDelta)>::get(dup_CdDelta,ndup_CdDelta);
   auto a_CdDelta = v_CdDelta.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
@@ -2696,7 +2685,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeAngularPreproces
   const int jnum = pack.i3;
 
   pack = d_angular_pack(apack, 1);
-  const int i_index = pack.i0;
+  // i0 is unused
   const int j_index = pack.i1;
   const int k_index = pack.i2;
   // i3 is unused
@@ -2848,11 +2837,8 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeAngularPreproces
 
   // Forces
 
-  // debugging whether or not the values at "1" are needed, they never seem to be read from?
-  a_Cdbo(i,j_index,0) += (CEval1 + CEpen2 + (CEcoa1 - CEcoa4));
-  a_Cdbo(j,i_index,1) += (CEval1 + CEpen2 + (CEcoa1 - CEcoa4));
-  a_Cdbo(i,k_index,0) += (CEval2 + CEpen3 + (CEcoa2 - CEcoa5));
-  a_Cdbo(k,i_index,1) += (CEval2 + CEpen3 + (CEcoa2 - CEcoa5));
+  a_Cdbo(i,j_index) += (CEval1 + CEpen2 + (CEcoa1 - CEcoa4));
+  a_Cdbo(i,k_index) += (CEval2 + CEpen3 + (CEcoa2 - CEcoa5));
 
   CdDelta_i += ((CEval3 + CEval7) + CEpen1 + CEcoa3);
   CdDelta_j += CEcoa4;
@@ -2863,9 +2849,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeAngularPreproces
     temp = temp_bo_jt * temp_bo_jt * temp_bo_jt;
     pBOjt7 = temp * temp * temp_bo_jt;
 
-    a_Cdbo(i,l_index,0) += (CEval6 * pBOjt7);
-    a_Cdbopi(i,l_index,0) += CEval5;
-    a_Cdbopi2(i,l_index,0) += CEval5;
+    a_Cdbo(i,l_index) += (CEval6 * pBOjt7);
+    a_Cdbopi(i,l_index) += CEval5;
+    a_Cdbopi2(i,l_index) += CEval5;
   }
 
   for (int d = 0; d < 3; d++) fi_tmp[d] = CEval8 * dcos_theta_di[d];
@@ -2912,8 +2898,8 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeTorsionPreproces
 
   auto v_CdDelta = ScatterViewHelper<NeedDup_v<NEIGHFLAG,DeviceType>,decltype(dup_CdDelta),decltype(ndup_CdDelta)>::get(dup_CdDelta,ndup_CdDelta);
   auto a_CdDelta = v_CdDelta.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbo)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbo = d_Cdbo;
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbopi)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi = d_Cdbopi;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbo)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbo = d_Cdbo;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbopi)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi = d_Cdbopi;
   //auto a_Cdbo = dup_Cdbo.template access<AtomicDup_v<NEIGHFLAG,DeviceType>>();
 
   // in reaxff_torsion_angles: j = i, k = j, i = k;
@@ -3156,14 +3142,14 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeTorsionPreproces
 
   // contribution to bond order
 
-  a_Cdbopi(i,j_index,0) += CEtors2;
+  a_Cdbopi(i,j_index) += CEtors2;
 
   a_CdDelta[j] += CEtors3;
   a_CdDelta[i] += CEtors3;
 
-  a_Cdbo(i,k_index,0) += CEtors4 + CEconj1;
-  a_Cdbo(i,j_index,0) += CEtors5 + CEconj2;
-  a_Cdbo(j,l_index,0) += CEtors6 + CEconj3;
+  a_Cdbo(i,k_index) += CEtors4 + CEconj1;
+  a_Cdbo(i,j_index) += CEtors5 + CEconj2;
+  a_Cdbo(j,l_index) += CEtors6 + CEconj3;
 
   const F_FLOAT coeff74 = CEtors7 + CEconj4;
   const F_FLOAT coeff85 = CEtors8 + CEconj5;
@@ -3357,7 +3343,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeHydrogen<NEIGHFL
       CEhb2 = -p_hb1/2.0 * (1.0 - exp_hb2) * exp_hb3 * cos_xhz1;
       CEhb3 = -p_hb3 * (-r0_hb/SQR(rik) + 1.0/r0_hb) * e_hb;
 
-      d_Cdbo(i,j_index,0) += CEhb1; // dbo term
+      d_Cdbo(i,j_index) += CEhb1; // dbo term
 
       // dcos terms
       for (int d = 0; d < 3; d++) fi_tmp[d] = CEhb2 * dcos_theta_di[d];
@@ -3400,9 +3386,9 @@ template<int NEIGHFLAG>
 KOKKOS_INLINE_FUNCTION
 void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxUpdateBond<NEIGHFLAG>, const int &ii) const {
 
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbo)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbo = d_Cdbo;
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbopi)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi = d_Cdbopi;
-  Kokkos::View<F_FLOAT***, typename decltype(d_Cdbopi2)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi2 = d_Cdbopi2;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbo)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbo = d_Cdbo;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbopi)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi = d_Cdbopi;
+  Kokkos::View<F_FLOAT**, typename decltype(d_Cdbopi2)::array_layout,KKDeviceType,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>> a_Cdbopi2 = d_Cdbopi2;
 
   const int i = d_ilist[ii];
   const X_FLOAT xtmp = x(i,0);
@@ -3430,9 +3416,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxUpdateBond<NEIGHFLAG>, 
 
     if (!flag) continue;
 
-    const F_FLOAT Cdbo_i = d_Cdbo(i,j_index,0);
-    const F_FLOAT Cdbopi_i = d_Cdbopi(i,j_index,0);
-    const F_FLOAT Cdbopi2_i = d_Cdbopi2(i,j_index,0);
+    const F_FLOAT Cdbo_i = d_Cdbo(i,j_index);
+    const F_FLOAT Cdbopi_i = d_Cdbopi(i,j_index);
+    const F_FLOAT Cdbopi2_i = d_Cdbopi2(i,j_index);
 
     const int knum = d_bo_num[j];
 
@@ -3441,9 +3427,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxUpdateBond<NEIGHFLAG>, 
       k &= NEIGHMASK;
       if (k != i) continue;
 
-      a_Cdbo(j,k_index,0) += Cdbo_i;
-      a_Cdbopi(j,k_index,0) += Cdbopi_i;
-      a_Cdbopi2(j,k_index,0) += Cdbopi2_i;
+      a_Cdbo(j,k_index) += Cdbo_i;
+      a_Cdbopi(j,k_index) += Cdbopi_i;
+      a_Cdbopi2(j,k_index) += Cdbopi2_i;
     }
   }
 }
@@ -3514,9 +3500,9 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond1<NEIGHFLAG,
     //if (eflag_atom) this->template e_tally<NEIGHFLAG>(ev,i,j,ebond);
 
     // calculate derivatives of Bond Orders
-    d_Cdbo(i,j_index,0) += CEbo;
-    d_Cdbopi(i,j_index,0) -= (CEbo + De_p);
-    d_Cdbopi2(i,j_index,0) -= (CEbo + De_pp);
+    d_Cdbo(i,j_index) += CEbo;
+    d_Cdbopi(i,j_index) -= (CEbo + De_p);
+    d_Cdbopi2(i,j_index) -= (CEbo + De_pp);
 
     // Stabilisation terminal triple bond
     F_FLOAT estriph = 0.0;
@@ -3542,7 +3528,7 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond1<NEIGHFLAG,
         const F_FLOAT decobdboub = -gp[10] * exphu * hulpov *
             (gp[3]*exphub1 + 25.0*gp[4]*exphuov*hulpov*(exphua1+exphub1));
 
-        d_Cdbo(i,j_index,0) += decobdbo;
+        d_Cdbo(i,j_index) += decobdbo;
         CdDelta_i += decobdboua;
         a_CdDelta[j] += decobdboub;
       }
@@ -3617,18 +3603,18 @@ void PairReaxFFKokkos<DeviceType>::operator()(TagPairReaxComputeBond2<NEIGHFLAG,
     coef_C1dDelta = coef_C2dDelta = coef_C3dDelta = 0.0;
 
     // total forces on i, j, k (nlocal + nghost, from Add_dBond_to_Forces))
-    const F_FLOAT Cdbo_ij = d_Cdbo(i,j_index,0);
+    const F_FLOAT Cdbo_ij = d_Cdbo(i,j_index);
     coef_C1dbo = d_C1dbo(i,j_index) * (Cdbo_ij);
     coef_C2dbo = d_C2dbo(i,j_index) * (Cdbo_ij);
     coef_C3dbo = d_C3dbo(i,j_index) * (Cdbo_ij);
 
-    const F_FLOAT Cdbopi_ij = d_Cdbopi(i,j_index,0);
+    const F_FLOAT Cdbopi_ij = d_Cdbopi(i,j_index);
     coef_C1dbopi = d_C1dbopi(i,j_index) * (Cdbopi_ij);
     coef_C2dbopi = d_C2dbopi(i,j_index) * (Cdbopi_ij);
     coef_C3dbopi = d_C3dbopi(i,j_index) * (Cdbopi_ij);
     coef_C4dbopi = d_C4dbopi(i,j_index) * (Cdbopi_ij);
 
-    const F_FLOAT Cdbopi2_ij = d_Cdbopi2(i,j_index,0);
+    const F_FLOAT Cdbopi2_ij = d_Cdbopi2(i,j_index);
     coef_C1dbopi2 = d_C1dbopi2(i,j_index) * (Cdbopi2_ij);
     coef_C2dbopi2 = d_C2dbopi2(i,j_index) * (Cdbopi2_ij);
     coef_C3dbopi2 = d_C3dbopi2(i,j_index) * (Cdbopi2_ij);

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -178,14 +178,14 @@ class PairReaxFFKokkos : public PairReaxFF {
   // TagPairReaxBuildListsHalfBlocking, HalfBlockingPreview, HalfPreview
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
-  void build_hb_list(F_FLOAT, int, int, int, int, int) const;
+  void build_hb_list(F_FLOAT, int, int, int, int) const;
 
   // Isolated function that builds the bond order list, reused across
   // TagPairReaxBuildListsHalfBlocking, HalfBlockingPreview, HalfPreview
   // Returns if we need to populate d_d* functions or not
   template<int NEIGHFLAG>
   KOKKOS_INLINE_FUNCTION
-  bool build_bo_list(int, int, int, int&, int&) const;
+  bool build_bo_list(int, int, int&, int&) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagPairReaxBuildListsFull, const int&) const;

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -470,7 +470,7 @@ class PairReaxFFKokkos : public PairReaxFF {
   typename AT::t_int_1d_randomread d_ilist;
   typename AT::t_int_1d_randomread d_numneigh;
 
-  typename AT::t_int_1d d_bo_first, d_bo_num, d_bo_list, d_hb_first, d_hb_num, d_hb_list;
+  typename AT::t_int_1d d_bo_num, d_bo_list, d_hb_num, d_hb_list;
 
   DAT::tdual_int_scalar k_resize_bo, k_resize_hb;
   typename AT::t_int_scalar d_resize_bo, d_resize_hb;

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -436,7 +436,8 @@ class PairReaxFFKokkos : public PairReaxFF {
   typename AT::t_ffloat_2d_dl d_C1dbo, d_C2dbo, d_C3dbo;
   typename AT::t_ffloat_2d_dl d_C1dbopi, d_C2dbopi, d_C3dbopi, d_C4dbopi;
   typename AT::t_ffloat_2d_dl d_C1dbopi2, d_C2dbopi2, d_C3dbopi2, d_C4dbopi2;
-  typename AT::t_ffloat_2d_dl d_Cdbo, d_Cdbopi, d_Cdbopi2, d_dDeltap_self;
+  typename AT::t_ffloat_2d_dl d_dDeltap_self;
+  typename AT::t_ffloat_3d d_Cdbo, d_Cdbopi, d_Cdbopi2;
 
   int need_dup;
 

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -245,17 +245,17 @@ class PairReaxFFKokkos : public PairReaxFF {
 
   // Abstraction for computing SBSO2, CSBO2, dSBO1, dsBO2
   KOKKOS_INLINE_FUNCTION
-  void compute_angular_sbo(int, int, int, int) const;
+  void compute_angular_sbo(int, int, int) const;
 
   // Abstraction for counting and populating angular intermediates
   template<bool POPULATE>
   KOKKOS_INLINE_FUNCTION
-  int preprocess_angular(int, int, int, int, int) const;
+  int preprocess_angular(int, int, int, int) const;
 
   // Abstraction for counting and populating torsion intermediated
   template<bool POPULATE>
   KOKKOS_INLINE_FUNCTION
-  int preprocess_torsion(int, int, tagint, F_FLOAT, F_FLOAT, F_FLOAT, int, int, int) const;
+  int preprocess_torsion(int, int, tagint, F_FLOAT, F_FLOAT, F_FLOAT, int, int) const;
 
   template<int NEIGHFLAG, int EVFLAG>
   KOKKOS_INLINE_FUNCTION
@@ -470,7 +470,8 @@ class PairReaxFFKokkos : public PairReaxFF {
   typename AT::t_int_1d_randomread d_ilist;
   typename AT::t_int_1d_randomread d_numneigh;
 
-  typename AT::t_int_1d d_bo_num, d_bo_list, d_hb_num, d_hb_list;
+  typename AT::t_int_1d d_bo_num, d_hb_num;
+  typename AT::t_int_2d d_bo_list, d_hb_list;
 
   DAT::tdual_int_scalar k_resize_bo, k_resize_hb;
   typename AT::t_int_scalar d_resize_bo, d_resize_hb;

--- a/src/KOKKOS/pair_reaxff_kokkos.h
+++ b/src/KOKKOS/pair_reaxff_kokkos.h
@@ -436,8 +436,7 @@ class PairReaxFFKokkos : public PairReaxFF {
   typename AT::t_ffloat_2d_dl d_C1dbo, d_C2dbo, d_C3dbo;
   typename AT::t_ffloat_2d_dl d_C1dbopi, d_C2dbopi, d_C3dbopi, d_C4dbopi;
   typename AT::t_ffloat_2d_dl d_C1dbopi2, d_C2dbopi2, d_C3dbopi2, d_C4dbopi2;
-  typename AT::t_ffloat_2d_dl d_dDeltap_self;
-  typename AT::t_ffloat_3d d_Cdbo, d_Cdbopi, d_Cdbopi2;
+  typename AT::t_ffloat_2d_dl d_dDeltap_self, d_Cdbo, d_Cdbopi, d_Cdbopi2;
 
   int need_dup;
 


### PR DESCRIPTION
**Summary**

This PR addresses the integer overflow issues in the Kokkos implementation of the ReaxFF potential initially reported in https://github.com/lammps/lammps/issues/4194#issuecomment-2192748753 . It addresses the issue by replacing the 1-d Kokkos Views d_bo_list and d_hb_list with 2-d Views, noting that those 1-d Views held flattened 2-d data all along. By unflattening this index, the risk of integer overflow goes away. This removes the need for some of the integer overflow checks introduced in https://github.com/lammps/lammps/pull/4301 . While working on this PR I noticed that some unused data was written to the data structures d_Cdbo, d_Cdbopi, and d_Cdbopi2. I cleaned this up; this was done across two commits to demonstrate how I verified the data was unused.

**Related Issue(s)**

Addresses the problem noted in https://github.com/lammps/lammps/issues/4194#issuecomment-2192748753 ; removes the need for the (hydrogen) bond size check in #4301 .

**Author(s)**

Evan Weinberg (NVIDIA). eweinberg [at] nvidia.com preferred, evansweinberg [at] gmail.com for "long-lived".

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No issues.

**Implementation Notes**

As noted above, this PR addresses one source of integer overflow in the Kokkos implementation of the ReaxFF potential calculation. It addresses this issue by replacing the 1-d Kokkos Views `d_bo_list` and `d_hb_list` with 2-d Views, noting that those 1-d Views held flattened 2-d data all along. The flattened index corresponded to (atom, bond index) pairs where "bond index" `n` corresponds to the `n`th bond neighbor (either bo or hb) of an atom `i`. The PR also removes some ancillary unnecessary calculations (more specifically: data that was computed + written but never read from afterwards).

This PR was split into as many discrete commits as possible to make reviewing/double-checking the changes as simple as possible. The steps were:

1. c05390209e9008b8166a8a0d27b58fce076845b1: Removing the data structures `d_[bo/hb]_first`, replacing them by `i * max[bo/hb]` (or other index) as appropriate within the code.
2. 8e56f37d3da8109fc2c2412305d6ab943f31af40: Removing the variables `[bo/hb]_first_i` from the utility functions `build_[bo/hb]_list` as a first step towards unflattening the bond offset indices.
3. fced73ffd779c83f1e340aa14a49672fac123206: Converted `d_[bo/hb]_list` to 2-d Views, which required refactoring away all instances of the variables `[i/j/k/l]_[start/end]` which correspond to flattened list indices, and replacing them with bond neighbor indices. The latter have no (real) risk of integer overflow.
4. 8b9e2544f03a9c05f7dc82228df7124c95c07bcc: Part 1 of verifying unnecessary data was written to `d_Cdbo`, etc: convert each View to a 3-d View and show that some of the extra indices are written to but never read from.
5. 2be54aa454c8dde56c7dd02c03029b6dfafde6cf: Part 2 of above; reverted `d_Cdbo`, etc, to 2-d Views, removed the unnecessary writes, shrank the allocations as appropriate.

I put in as much diligence as possible with code self-reviews and performing correctness checks each step of the way, running 100 iterations with the fix/qeq solve tolerance set to 1e-16... but there are nonetheless a lot of moving parts. Some of the contributions to the ReaxFF force are numerically particularly small and might get lost in +/- accumulations. I'd appreciate some additional careful code review.

This bugfix is \~perf neutral on an A100-80GB-PCIe. I saw a slight win on the CPU, likely because the newly 2-d Kokkos Views will be in a CPU-friendly data layout as opposed to before where they were hard-coded as a GPU-friendly layout... that said, these weren't runs that were particularly tuned for performance.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

No additional information.

