### PR TITLE
Enable large numbers of atoms per proc with the GPU package

### DIFF
--- a/lib/gpu/lal_neighbor.cpp
+++ b/lib/gpu/lal_neighbor.cpp
@@ -587,8 +587,8 @@ void Neighbor::build_nbor_list(double **x, const int inum, const int host_inum,
     const int g2x=static_cast<int>(ceil(static_cast<double>(_maxspecial)/b2x));
     const int g2y=static_cast<int>(ceil(static_cast<double>(nt)/b2y));
     // the maximum number of blocks on the device is typically 65535
-    // we can use a lower number to have more resource per block
-    const int max_num_blocks = 32768;
+    // in principle we can use a lower number to have more resource per block 32768
+    const int max_num_blocks = 65535;
     int shift = 0;
     if (g2y < max_num_blocks) {
       _shared->k_transpose.set_size(g2x,g2y,b2x,b2y);

--- a/lib/gpu/lal_neighbor.cpp
+++ b/lib/gpu/lal_neighbor.cpp
@@ -586,21 +586,24 @@ void Neighbor::build_nbor_list(double **x, const int inum, const int host_inum,
     const int b2y=_block_cell_2d;
     const int g2x=static_cast<int>(ceil(static_cast<double>(_maxspecial)/b2x));
     const int g2y=static_cast<int>(ceil(static_cast<double>(nt)/b2y));
+    // maximum number of blocks on the device
     const int max_num_blocks = 65535;
     int shift = 0;
     if (g2y < max_num_blocks) {
       _shared->k_transpose.set_size(g2x,g2y,b2x,b2y);
       _shared->k_transpose.run(&dev_special,&dev_special_t,&_maxspecial,&nt,&shift);
     } else {
-      const int num_rounds = ceil(static_cast<double>(g2y) / max_num_blocks);
+      // using a fixed number of blocks
       int g2y_m = 65534;
-      for (int i = 0; i < num_rounds; i++) {
+      // number of chunks needed for the whole transpose
+      const int num_chunks = ceil(static_cast<double>(g2y) / g2y_m);
+      for (int i = 0; i < num_chunks; i++) {
         _shared->k_transpose.set_size(g2x,g2y_m,b2x,b2y);
         _shared->k_transpose.run(&dev_special,&dev_special_t,&_maxspecial,&nt,&shift);
-        shift += g2y_m;
+        shift += g2y_m*b2y;
       }
     }
-    
+
     time_transpose.stop();
   }
 

--- a/lib/gpu/lal_neighbor.cpp
+++ b/lib/gpu/lal_neighbor.cpp
@@ -586,8 +586,21 @@ void Neighbor::build_nbor_list(double **x, const int inum, const int host_inum,
     const int b2y=_block_cell_2d;
     const int g2x=static_cast<int>(ceil(static_cast<double>(_maxspecial)/b2x));
     const int g2y=static_cast<int>(ceil(static_cast<double>(nt)/b2y));
-    _shared->k_transpose.set_size(g2x,g2y,b2x,b2y);
-    _shared->k_transpose.run(&dev_special,&dev_special_t,&_maxspecial,&nt);
+    const int max_num_blocks = 65535;
+    int shift = 0;
+    if (g2y < max_num_blocks) {
+      _shared->k_transpose.set_size(g2x,g2y,b2x,b2y);
+      _shared->k_transpose.run(&dev_special,&dev_special_t,&_maxspecial,&nt,&shift);
+    } else {
+      const int num_rounds = ceil(static_cast<double>(g2y) / max_num_blocks);
+      int g2y_m = 65534;
+      for (int i = 0; i < num_rounds; i++) {
+        _shared->k_transpose.set_size(g2x,g2y_m,b2x,b2y);
+        _shared->k_transpose.run(&dev_special,&dev_special_t,&_maxspecial,&nt,&shift);
+        shift += g2y_m;
+      }
+    }
+    
     time_transpose.stop();
   }
 

--- a/lib/gpu/lal_neighbor_gpu.cu
+++ b/lib/gpu/lal_neighbor_gpu.cu
@@ -147,7 +147,7 @@ __kernel void kernel_calc_cell_counts(const unsigned *restrict cell_id,
 
 __kernel void transpose(__global tagint *restrict out,
                         const __global tagint *restrict in,
-                        int columns_in, int rows_in)
+                        int columns_in, int rows_in, int shift)
 {
   __local tagint block[BLOCK_CELL_2D][BLOCK_CELL_2D+1];
 
@@ -158,15 +158,15 @@ __kernel void transpose(__global tagint *restrict out,
 
   unsigned i=bi*BLOCK_CELL_2D+ti;
   unsigned j=bj*BLOCK_CELL_2D+tj;
-  if ((i<columns_in) && (j<rows_in))
-    block[tj][ti]=in[j*columns_in+i];
+  if ((i<columns_in) && (j+shift<rows_in))
+    block[tj][ti]=in[(j+shift)*columns_in+i];
 
    __syncthreads();
 
   i=bj*BLOCK_CELL_2D+ti;
   j=bi*BLOCK_CELL_2D+tj;
-  if ((i<rows_in) && (j<columns_in))
-    out[j*rows_in+i] = block[ti][tj];
+  if ((i+shift<rows_in) && (j<columns_in))
+    out[j*rows_in+i+shift] = block[ti][tj];
 }
 
 #ifndef LAL_USE_OLD_NEIGHBOR


### PR DESCRIPTION
**Summary**

This PR addresses the feature request #4206 to support larger atom counts per proc with the GPU package for atom styles bond, molecular and full. The root cause is due to the fact that kernel k_transpose (when maxspecial > 0) before each nbor build is launched with a number of blocks greater than 65,535, the typical max number of blocks on the device. This PR allows multiple passes of the transpose kernel launches until the whole special matrix is completely transposed.

**Related Issue(s)**

Issue #4156
Closes #4206 

**Author(s)**

Trung Nguyen (U Chicago)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

should be maintained

**Implementation Notes**


**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->
