### PR TITLE
Minor clean up to doc conventions and dev workflow files

### DIFF
--- a/doc/documentation_conventions.md
+++ b/doc/documentation_conventions.md
@@ -10,7 +10,7 @@ Last change: 2022-12-30
 
 In fall 2019, the LAMMPS documentation file format has changed from a
 home grown markup designed to generate HTML format files only, to
-[reStructuredText](https://docutils.sourceforge.io/rst.html>.  For a
+[reStructuredText](https://docutils.sourceforge.io/rst.html>).  For a
 transition period all files in the old .txt format were transparently
 converted to .rst and then processed.  The `txt2rst tool` is still
 included in the distribution to obtain an initial .rst file for legacy
@@ -64,7 +64,7 @@ Groups of shell commands or LAMMPS input script or C/C++/Python source
 code should be typeset into a `.. code-block::` section. A syntax
 highlighting extension for LAMMPS input scripts is provided, so `LAMMPS`
 can be used to indicate the language in the code block in addition to
-`bash`, `c`, `c++`, `console`, `csh`, `diff', `fortran`, `json`, `make`,
+`bash`, `c`, `c++`, `console`, `csh`, `diff`, `fortran`, `json`, `make`,
 `perl`, `powershell`, `python`, `sh`, or `tcl`, `text`, or `yaml`.  When
 no syntax style is indicated, no syntax highlighting is performed.  When
 typesetting commands executed on the shell, please do not prefix
@@ -84,7 +84,7 @@ block can be used, followed by multiple `.. tab::` blocks, one
 for each alternative. This is only used for HTML output. For other
 outputs, the `.. tabs::` directive is transparently removed and
 the individual `.. tab::` blocks will be replaced with an
-`.. admonition::`` block. Thus in PDF and ePUB output those will
+`.. admonition::` block. Thus in PDF and ePUB output those will
 be realized as sequential and plain notes.
 
 Special remarks can be highlighted with a `.. note::` block and

--- a/doc/documentation_conventions.md
+++ b/doc/documentation_conventions.md
@@ -45,8 +45,8 @@ what kind of information and sections are needed.
 
 ## Formatting conventions
 
-For headlines we try to follow the conventions posted here:
-https://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html#headings
+For headlines we try to follow the conventions posted [here]
+(https://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html#headings).
 It seems to be sufficient to have this consistent only within
 any single file and it is not (yet) enforced strictly, but making
 this globally consistent makes it easier to move sections around.

--- a/doc/documentation_conventions.md
+++ b/doc/documentation_conventions.md
@@ -45,8 +45,7 @@ what kind of information and sections are needed.
 
 ## Formatting conventions
 
-For headlines we try to follow the conventions posted [here]
-(https://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html#headings).
+For headlines we try to follow the conventions posted [here](https://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html#headings).
 It seems to be sufficient to have this consistent only within
 any single file and it is not (yet) enforced strictly, but making
 this globally consistent makes it easier to move sections around.

--- a/doc/github-development-workflow.md
+++ b/doc/github-development-workflow.md
@@ -6,7 +6,9 @@ choices the LAMMPS developers have agreed on. Git and GitHub provide the
 tools, but do not set policies, so it is up to the developers to come to
 an agreement as to how to define and interpret policies. This document
 is likely to change as our experiences and needs change, and we try to
-adapt it accordingly. Last change 2023-02-10.
+adapt it accordingly.
+
+Last change: 2023-02-10
 
 ## Table of Contents
 
@@ -72,7 +74,7 @@ be assigned to signal urgency to merge this pull request quickly.
 People can be assigned to review a pull request in two ways:
 
   * They can be assigned manually to review a pull request
-    by the submitter or a LAMMPS developer
+    by the submitter or a LAMMPS developer.
   * They can be automatically assigned, because a developer's GitHub
     handle matches a file pattern in the `.github/CODEOWNERS` file,
     which associates developers with the code they contributed and
@@ -86,9 +88,9 @@ required before merging, in addition to passing all automated
 compilation and unit tests.  Merging counts as implicit approval, so
 does submission of a pull request (by a LAMMPS developer). So the person
 doing the merge may not also submit an approving review.  The GitHub
-feature, that reviews from code owners are "hard" reviews (i.e. they
-must all approve before merging is allowed), is currently disabled.
-It is in the discretion of the merge maintainer to assess when a
+feature that reviews from code owners are "hard" reviews (i.e. they
+must all approve before merging is allowed) is currently disabled.
+It is at the discretion of the merge maintainer to assess when a
 sufficient degree of approval has been reached, especially from external
 collaborators.  Reviews may be (automatically) dismissed, when the
 reviewed code has been changed. Review may be requested a second time.
@@ -147,7 +149,8 @@ only contain bug fixes, feature additions to peripheral functionality,
 and documentation updates.  In between stable releases, bug fixes and
 infrastructure updates are back-ported from the "develop" branch to the
 "maintenance" branch and occasionally merged into "stable" and published
-as update releases.
+as update releases. Further explanation of LAMMPS versions can be found
+[in the documentation](https://docs.lammps.org/Manual_version.html).
 
 ## Project Management
 


### PR DESCRIPTION
**Summary**

Fixing a few pesky formatting errors and links in the documentation conventions.

Few punctuation fixes and an extra link (debatable) in the development workflow doc.

**Author(s)**

Joel Clemmer (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).
