### PR TITLE
Add support to region plane for having the normal vector read from variables

### DIFF
--- a/doc/src/region.rst
+++ b/doc/src/region.rst
@@ -40,7 +40,7 @@ Syntax
        *plane* args = px py pz nx ny nz
          px,py,pz = point on the plane (distance units)
          nx,ny,nz = direction normal to plane (distance units)
-           px,py,pz can be a variable (see below)
+           px,py,pz,nx,ny,nz can be a variable (see below)
        *prism* args = xlo xhi ylo yhi zlo zhi xy xz yz
          xlo,xhi,ylo,yhi,zlo,zhi = bounds of untilted prism (distance units)
          xy = distance to tilt y in x direction (distance units)
@@ -210,9 +210,8 @@ equal-style :doc:`variable <variable>`.  Likewise, for style *sphere*
 and *ellipsoid* the x-, y-, and z- coordinates of the center of the
 sphere/ellipsoid can be specified as an equal-style variable.  And for
 style *cylinder* the two center positions c1 and c2 for the location of
-the cylinder axes can be specified as a equal-style variable.  For style
-*cone* all properties can be defined via equal-style variables.  For
-style *plane* the point can be defined via equal-style variables.
+the cylinder axes can be specified as a equal-style variable.  For styles
+*cone* and *plane* all properties can be defined via equal-style variables.
 
 If the value is a variable, it should be specified as v_name, where
 name is the variable name.  In this case, the variable will be

--- a/src/region_plane.cpp
+++ b/src/region_plane.cpp
@@ -22,13 +22,14 @@
 
 using namespace LAMMPS_NS;
 
+enum { CONSTANT, VARIABLE };
+
 /* ---------------------------------------------------------------------- */
 
-RegPlane::RegPlane(LAMMPS *lmp, int narg, char **arg) :
-    Region(lmp, narg, arg), xstr(nullptr), ystr(nullptr), zstr(nullptr)
+RegPlane::RegPlane(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg),
+    xstr(nullptr), ystr(nullptr), zstr(nullptr), nxstr(nullptr),
+    nystr(nullptr), nzstr(nullptr)
 {
-  xvar = yvar = zvar = 0.0;
-
   options(narg - 8, &arg[8]);
 
   if (utils::strmatch(arg[2], "^v_")) {
@@ -61,14 +62,40 @@ RegPlane::RegPlane(LAMMPS *lmp, int narg, char **arg) :
     zstyle = CONSTANT;
   }
 
+  if (utils::strmatch(arg[5], "^v_")) {
+    nxstr = utils::strdup(arg[5] + 2);
+    normal[0] = 0.0;
+    nxstyle = VARIABLE;
+    varshape = 1;
+  } else {
+    normal[0] = xscale * utils::numeric(FLERR, arg[5], false, lmp);
+    nxstyle = CONSTANT;
+  }
+
+  if (utils::strmatch(arg[6], "^v_")) {
+    nystr = utils::strdup(arg[6] + 2);
+    normal[1] = 0.0;
+    nystyle = VARIABLE;
+    varshape = 1;
+  } else {
+    normal[1] = yscale * utils::numeric(FLERR, arg[6], false, lmp);
+    nystyle = CONSTANT;
+  }
+
+  if (utils::strmatch(arg[7], "^v_")) {
+    nzstr = utils::strdup(arg[7] + 2);
+    normal[2] = 0.0;
+    nzstyle = VARIABLE;
+    varshape = 1;
+  } else {
+    normal[2] = zscale * utils::numeric(FLERR, arg[7], false, lmp);
+    nzstyle = CONSTANT;
+  }
+
   if (varshape) {
     variable_check();
     RegPlane::shape_update();
   }
-
-  normal[0] = xscale * utils::numeric(FLERR, arg[5], false, lmp);
-  normal[1] = yscale * utils::numeric(FLERR, arg[6], false, lmp);
-  normal[2] = zscale * utils::numeric(FLERR, arg[7], false, lmp);
 
   // enforce unit normal
 
@@ -95,6 +122,9 @@ RegPlane::~RegPlane()
   delete[] xstr;
   delete[] ystr;
   delete[] zstr;
+  delete[] nxstr;
+  delete[] nystr;
+  delete[] nzstr;
   delete[] contact;
 }
 
@@ -174,6 +204,22 @@ void RegPlane::shape_update()
   if (ystyle == VARIABLE) yp = yscale * input->variable->compute_equal(yvar);
 
   if (zstyle == VARIABLE) zp = zscale * input->variable->compute_equal(zvar);
+
+  if (nxstyle == VARIABLE) normal[0] = xscale * input->variable->compute_equal(nxvar);
+
+  if (nystyle == VARIABLE) normal[1] = yscale * input->variable->compute_equal(nyvar);
+
+  if (nzstyle == VARIABLE) normal[2] = zscale * input->variable->compute_equal(nzvar);
+
+  // enforce unit normal
+
+  double rsq = normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2];
+  if (rsq == 0.0)
+    error->all(FLERR, "Illegal region plane normal vector: {} {} {}", normal[0], normal[1],
+               normal[2]);
+  normal[0] /= sqrt(rsq);
+  normal[1] /= sqrt(rsq);
+  normal[2] /= sqrt(rsq);
 }
 
 /* ----------------------------------------------------------------------
@@ -201,5 +247,26 @@ void RegPlane::variable_check()
     if (zvar < 0) error->all(FLERR, "Variable {} for region plane does not exist", zstr);
     if (!input->variable->equalstyle(zvar))
       error->all(FLERR, "Variable {} for region plane is invalid style", zstr);
+  }
+
+  if (nxstyle == VARIABLE) {
+    nxvar = input->variable->find(nxstr);
+    if (nxvar < 0) error->all(FLERR, "Variable {} for region plane does not exist", nxstr);
+    if (!input->variable->equalstyle(nxvar))
+      error->all(FLERR, "Variable {} for region plane is invalid style", nxstr);
+  }
+
+  if (nystyle == VARIABLE) {
+    nyvar = input->variable->find(nystr);
+    if (nyvar < 0) error->all(FLERR, "Variable {} for region plane does not exist", nystr);
+    if (!input->variable->equalstyle(nyvar))
+      error->all(FLERR, "Variable {} for region plane is invalid style", nystr);
+  }
+
+  if (nzstyle == VARIABLE) {
+    nzvar = input->variable->find(nzstr);
+    if (nzvar < 0) error->all(FLERR, "Variable {} for region plane does not exist", nzstr);
+    if (!input->variable->equalstyle(nzvar))
+      error->all(FLERR, "Variable {} for region plane is invalid style", nzstr);
   }
 }

--- a/src/region_plane.cpp
+++ b/src/region_plane.cpp
@@ -30,6 +30,9 @@ RegPlane::RegPlane(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg),
     xstr(nullptr), ystr(nullptr), zstr(nullptr), nxstr(nullptr),
     nystr(nullptr), nzstr(nullptr)
 {
+  xvar = yvar = zvar = 0.0;
+  nxvar = nyvar = nzvar = 0.0;
+
   options(narg - 8, &arg[8]);
 
   if (utils::strmatch(arg[2], "^v_")) {

--- a/src/region_plane.cpp
+++ b/src/region_plane.cpp
@@ -214,6 +214,8 @@ void RegPlane::shape_update()
 
   if (nzstyle == VARIABLE) normal[2] = zscale * input->variable->compute_equal(nzvar);
 
+  if ((nxstyle == CONSTANT) && (nystyle == CONSTANT) && (nzstyle == CONSTANT)) return;
+
   // enforce unit normal
 
   double rsq = normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2];

--- a/src/region_plane.h
+++ b/src/region_plane.h
@@ -43,6 +43,11 @@ class RegPlane : public Region {
   int zstyle, zvar;
   char *xstr, *ystr, *zstr;
 
+  int nxstyle, nxvar;
+  int nystyle, nyvar;
+  int nzstyle, nzvar;
+  char *nxstr, *nystr, *nzstr;
+
   void variable_check();
 };
 


### PR DESCRIPTION
**Summary**

Add support to region plane for having the normal vector read from variables

**Related Issue(s)**

No related issue

**Author(s)**

E. Voyiatzis at NovaMechanics Ltd (email [evoyiatzis@gmail.com](mailto:evoyiatzis@gmail.com))

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

It does not break backward compatibility

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


