### PR TITLE
Revert "Disallow newton on with full neigh list"

### DIFF
--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -633,22 +633,13 @@ void KokkosLMP::accelerator(int narg, char **arg)
   // set neighbor binsize, same as neigh_modify command
 
   force->newton = force->newton_pair = force->newton_bond = newtonflag;
-  newton_check();
+
+  if (neigh_thread && newtonflag)
+    error->all(FLERR,"Must use KOKKOS package option 'newton off' with 'neigh/thread on'");
 
   neighbor->binsize_user = binsize;
   if (binsize <= 0.0) neighbor->binsizeflag = 0;
   else neighbor->binsizeflag = 1;
-}
-
-/* ---------------------------------------------------------------------- */
-
-void KokkosLMP::newton_check()
-{
-  if (neighflag == FULL && force->newton)
-    error->all(FLERR,"Must use 'newton off' with KOKKOS package option 'neigh full'");
-
-  if (neigh_thread && force->newton)
-    error->all(FLERR,"Must use 'newton off' with KOKKOS package option 'neigh/thread on'");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -64,7 +64,6 @@ class KokkosLMP : protected Pointers {
   static void initialize(const Kokkos::InitializationSettings&, Error *);
   static void finalize();
   void accelerator(int, char **);
-  void newton_check();
   bigint neigh_count(int);
 
   template<class DeviceType>

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -59,7 +59,6 @@ class KokkosLMP {
   void accelerator(int, char **) {}
   int neigh_list_kokkos(int) { return 0; }
   int neigh_count(int) { return 0; }
-  void newton_check() {};
 };
 
 class AtomKokkos : public Atom {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1687,8 +1687,6 @@ void Input::newton()
 
   if (newton_pair || newton_bond) force->newton = 1;
   else force->newton = 0;
-
-  if (lmp->kokkos) lmp->kokkos->newton_check();
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
This reverts commit 27954609b8f1c2f3333064f61dd27ad971ea6132.

**Summary**

We use Kokkos for simulating many-body interactions using an in-house ML FF. We need the ability to use `newton on` as well as `neigh full` together.

I couldn't find an explanation of why this was disallowed in [the PR that recently banned this possibility](https://github.com/lammps/lammps/pull/4346). What was the rationale? 

cc @stanmoore1 @nw13slx 

<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


