### PR TITLE
[DOC] Minor GPU build tag typo fix: `GPU_ARCH=cuda` -> `GPU_API`

### DIFF
--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -232,7 +232,7 @@ option in preparations to run on Aurora system at Argonne.
 
 .. code:: bash
 
-   # CUDA target (not recommended, use GPU_ARCH=cuda)
+   # CUDA target (not recommended, use GPU_API=cuda)
    # !!! DO NOT set CMAKE_CXX_COMPILER !!!
    export HIP_PLATFORM=nvcc
    export HIP_PATH=/path/to/HIP/install


### PR DESCRIPTION
Minor GPU build tag typo fix: `GPU_ARCH=cuda` -> `GPU_API=cuda`, in https://docs.lammps.org/Build_extras.html#cmake-build

I guess `GPU_API=cuda` should be the correct tag instead of `GPU_ARCH`:
```
-D GPU_API=value             # value = opencl (default) or cuda or hip
-D GPU_ARCH=value            # primary GPU hardware choice for GPU_API=cuda
                             # value = sm_XX (see below, default is sm_50)
```