### PR TITLE
fix: AtomList infinite for loop

### DIFF
--- a/python/lammps/pylammps.py
+++ b/python/lammps/pylammps.py
@@ -129,6 +129,10 @@ class AtomList(object):
     :type index: int
     :rtype: Atom or Atom2D
     """
+
+    if index < 0 or index >= self.natoms:
+        raise IndexError("AtomList index out of range")
+
     if index not in self._loaded:
         if self.dimensions == 2:
             atom = Atom2D(self._pylmp, index)


### PR DESCRIPTION
**Summary**

`pylammps.AtomList` run fail by `for in`

```py
from lammps import PyLammps, lammps

pl = PyLammps(ptr=lammps())
pl.read_data("graphene.data")
for atom in pl.atoms:
    print(atom.index, atom.position)


```
![图片](https://github.com/user-attachments/assets/cad62aa7-2ac8-47ea-9427-92cfd1c3a5c4)


**Related Issue(s)**



**Author(s)**

HangYu yuhldr@qq.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


