### PR TITLE
Single process errors in pair style kim reported using error->one

### DIFF
--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -225,7 +225,7 @@ void PairKIM::compute(int eflag, int vflag)
                              KIM_COMPUTE_ARGUMENT_NAME_particleContributing,
                              kim_particleContributing);
     if (kimerror)
-      error->all(FLERR,"Unable to set KIM particle species codes and/or contributing");
+      error->one(FLERR,"Unable to set KIM particle species codes and/or contributing");
   }
 
   // kim_particleSpecies = KIM atom species for each LAMMPS atom
@@ -250,7 +250,7 @@ void PairKIM::compute(int eflag, int vflag)
 
   // compute via KIM model
   int kimerror = KIM_Model_Compute(pkim, pargs);
-  if (kimerror) error->all(FLERR, "KIM Compute returned error {}", kimerror);
+  if (kimerror) error->one(FLERR, "KIM Compute returned error {}", kimerror);
 
   // scale results for fix adapt if needed
   if (scale_extracted) {
@@ -814,7 +814,7 @@ void PairKIM::kim_free()
   if (kim_init_ok) {
     int kimerror = KIM_Model_ComputeArgumentsDestroy(pkim, &pargs);
     if (kimerror)
-      error->all(FLERR,"Unable to destroy Compute Arguments Object");
+      error->one(FLERR,"Unable to destroy Compute Arguments Object");
 
     KIM_Model_Destroy(&pkim);
 


### PR DESCRIPTION
**Summary**

Errors during a KIM compute operation that occur on a single processor were reported using error->all, which causes LAMMPS to hang when running in parallel with more than one processor. This has been fixed by replacing error->all with error->one for those cases.

**Related Issue(s)**

None

**Author(s)**

Ellad Tadmor, University of Minnesota

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The changes do not break backwards compatibility.

**Implementation Notes**

Three instances of `error->all` were replaced with `error->one`. The code was tested against a case that generated a K compute error on a single process that caused LAMMPS to hang when running on multiple processors. With the bug fix, LAMMPS exits properly regardless of the number of processors.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

None


