### PR TITLE
Last minute fixes for next feature release

### DIFF
--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -20,7 +20,7 @@ import os
 import sys
 from ctypes import CDLL, POINTER, RTLD_GLOBAL, CFUNCTYPE, py_object, byref, cast, sizeof, \
   create_string_buffer, c_int, c_int32, c_int64, c_double, c_void_p, c_char_p, c_char,    \
-  pythonapi, pointer
+  pythonapi
 from os.path import dirname, abspath, join
 from inspect import getsourcefile
 
@@ -897,9 +897,8 @@ class lammps(object):
     box_change = c_int()
 
     with ExceptionCheck(self):
-      self.lib.lammps_extract_box(self.lmp,boxlo,boxhi,
-                                  byref(xy),byref(yz),byref(xz),
-                                  periodicity,byref(box_change))
+      self.lib.lammps_extract_box(self.lmp, boxlo, boxhi, byref(xy), byref(yz), byref(xz),
+                                  periodicity, byref(box_change))
 
     boxlo = boxlo[:3]
     boxhi = boxhi[:3]
@@ -1235,7 +1234,7 @@ class lammps(object):
     """
 
     tag = self.c_tagint(id)
-    return self.lib.lammps_map_atom(self.lmp, pointer(tag))
+    return self.lib.lammps_map_atom(self.lmp, byref(tag))
 
   # -------------------------------------------------------------------------
   # extract per-atom info datatype
@@ -1607,14 +1606,14 @@ class lammps(object):
   def addstep_compute(self, nextstep):
     with ExceptionCheck(self):
       nextstep = self.c_bigint(nextstep)
-      return self.lib.lammps_addstep_compute(self.lmp, POINTER(nextstep))
+      return self.lib.lammps_addstep_compute(self.lmp, byref(nextstep))
 
   # -------------------------------------------------------------------------
 
   def addstep_compute_all(self, nextstep):
     with ExceptionCheck(self):
       nextstep = self.c_bigint(nextstep)
-      return self.lib.lammps_addstep_compute_all(self.lmp, POINTER(nextstep))
+      return self.lib.lammps_addstep_compute_all(self.lmp, byref(nextstep))
 
   # -------------------------------------------------------------------------
 
@@ -2004,7 +2003,7 @@ class lammps(object):
     """
 
     flags = (c_int*3)()
-    self.lib.lammps_decode_image_flags(image,byref(flags))
+    self.lib.lammps_decode_image_flags(image, byref(flags))
 
     return [int(i) for i in flags]
 
@@ -2699,7 +2698,8 @@ class lammps(object):
     c_iatom = c_int()
     c_numneigh = c_int()
     c_neighbors = POINTER(c_int)()
-    self.lib.lammps_neighlist_element_neighbors(self.lmp, idx, element, byref(c_iatom), byref(c_numneigh), byref(c_neighbors))
+    self.lib.lammps_neighlist_element_neighbors(self.lmp, idx, element, byref(c_iatom),
+                                                byref(c_numneigh), byref(c_neighbors))
     return c_iatom.value, c_numneigh.value, c_neighbors
 
   # -------------------------------------------------------------------------

--- a/src/fix_ave_atom.cpp
+++ b/src/fix_ave_atom.cpp
@@ -60,6 +60,8 @@ FixAveAtom::FixAveAtom(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg),
     value_t val;
     val.id = "";
     val.val.c = nullptr;
+    if (expand) val.iarg = amap[i] + ioffset;
+    else val.iarg = i + ioffset;
 
     if (strcmp(arg[i], "x") == 0) {
       val.which = ArgInfo::X;
@@ -96,8 +98,6 @@ FixAveAtom::FixAveAtom(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg),
 
       val.which = argi.get_type();
       val.argindex = argi.get_index1();
-      if (expand) val.iarg = amap[i] + ioffset;
-      else val.iarg = i + ioffset;
       val.id = argi.get_name();
 
       if ((val.which == ArgInfo::UNKNOWN) || (val.which == ArgInfo::NONE) || (argi.get_dim() > 1))

--- a/unittest/force-styles/tests/mol-pair-hbond_dreiding_lj.yaml
+++ b/unittest/force-styles/tests/mol-pair-hbond_dreiding_lj.yaml
@@ -2,7 +2,7 @@
 lammps_version: 19 Nov 2024
 tags:
 date_generated: Sat Feb  1 01:49:25 2025
-epsilon: 2e-13
+epsilon: 1e-12
 skip_tests: single
 prerequisites: ! |
   atom full

--- a/unittest/force-styles/tests/mol-pair-hbond_dreiding_lj_angleoffset.yaml
+++ b/unittest/force-styles/tests/mol-pair-hbond_dreiding_lj_angleoffset.yaml
@@ -2,7 +2,7 @@
 lammps_version: 19 Nov 2024
 tags:
 date_generated: Sat Feb  1 01:59:00 2025
-epsilon: 2e-13
+epsilon: 1e-12
 skip_tests: single
 prerequisites: ! |
   atom full

--- a/unittest/force-styles/tests/mol-pair-hbond_dreiding_morse.yaml
+++ b/unittest/force-styles/tests/mol-pair-hbond_dreiding_morse.yaml
@@ -2,7 +2,7 @@
 lammps_version: 19 Nov 2024
 tags:
 date_generated: Sat Feb  1 01:51:46 2025
-epsilon: 2e-13
+epsilon: 1e-12
 skip_tests: single
 prerequisites: ! |
   atom full

--- a/unittest/force-styles/tests/mol-pair-hbond_dreiding_morse_angleoffset.yaml
+++ b/unittest/force-styles/tests/mol-pair-hbond_dreiding_morse_angleoffset.yaml
@@ -2,7 +2,7 @@
 lammps_version: 19 Nov 2024
 tags:
 date_generated: Sat Feb  1 01:58:54 2025
-epsilon: 2e-13
+epsilon: 1e-12
 skip_tests: single
 prerequisites: ! |
   atom full


### PR DESCRIPTION
**Summary**

This pull request implements a few last minute fixes for the feature release

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following changes are included:
- fix incorrect initialization of Values struct in fix ave/atom detected by coverity scan
- relax test epsilon for pair style hbond/dreiding tests on ARM64
- use byref() instead of pointer() in library interface

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
