### PR TITLE
[COLLOID] Refactor polydisperse codes to reflect monodisperse code behaviours

### DIFF
--- a/src/COLLOID/pair_brownian.cpp
+++ b/src/COLLOID/pair_brownian.cpp
@@ -714,3 +714,17 @@ void PairBrownian::set_3_orthogonal_vectors(double p1[3], double p2[3], double p
   p3[1] = p1[2] * p2[0] - p1[0] * p2[2];
   p3[2] = p1[0] * p2[1] - p1[1] * p2[0];
 }
+
+/* ----------------------------------------------------------------------
+   check if name is recognized, return pointer to that variable
+   if name not recognized, return nullptr
+------------------------------------------------------------------------- */
+
+void *PairBrownian::extract(const char *str, int &dim)
+{
+  if (strcmp(str, "mu") == 0) {
+    dim = 0;
+    return (void *) &mu;
+  }
+  return nullptr;
+}

--- a/src/COLLOID/pair_brownian.h
+++ b/src/COLLOID/pair_brownian.h
@@ -37,6 +37,7 @@ class PairBrownian : public Pair {
   void read_restart(FILE *) override;
   void write_restart_settings(FILE *) override;
   void read_restart_settings(FILE *) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double cut_inner_global, cut_global;

--- a/src/COLLOID/pair_brownian_poly.cpp
+++ b/src/COLLOID/pair_brownian_poly.cpp
@@ -66,6 +66,7 @@ void PairBrownianPoly::compute(int eflag, int vflag)
   double *radius = atom->radius;
   int *type = atom->type;
   int nlocal = atom->nlocal;
+  int newton_pair = force->newton_pair;
 
   double vxmu2f = force->vxmu2f;
   double randr;
@@ -255,6 +256,16 @@ void PairBrownianPoly::compute(int eflag, int vflag)
         f[i][1] -= fy;
         f[i][2] -= fz;
 
+        if (newton_pair || j < nlocal) {
+          //randr = random->uniform()-0.5;
+          //fx = Fbmag*randr*delx/r;
+          //fy = Fbmag*randr*dely/r;
+          //fz = Fbmag*randr*delz/r;
+
+          f[j][0] += fx;
+          f[j][1] += fy;
+          f[j][2] += fz;
+        }
         // torque due to the Brownian Force
 
         if (flaglog) {
@@ -277,6 +288,12 @@ void PairBrownianPoly::compute(int eflag, int vflag)
           torque[i][1] -= ty;
           torque[i][2] -= tz;
 
+          if (newton_pair || j < nlocal) {
+            torque[j][0] -= tx;
+            torque[j][1] -= ty;
+            torque[j][2] -= tz;
+          }
+          
           // torque due to a_pu
 
           Fbmag = prethermostat*sqrt(a_pu);
@@ -303,7 +320,7 @@ void PairBrownianPoly::compute(int eflag, int vflag)
 
         // set j = nlocal so that only I gets tallied
 
-        if (evflag) ev_tally_xyz(i,nlocal,nlocal,0,
+        if (evflag) ev_tally_xyz(i,nlocal,nlocal,newton_pair,
                                  0.0,0.0,-fx,-fy,-fz,delx,dely,delz);
       }
     }
@@ -316,8 +333,8 @@ void PairBrownianPoly::compute(int eflag, int vflag)
 
 void PairBrownianPoly::init_style()
 {
-  if (force->newton_pair == 1)
-    error->all(FLERR,"Pair brownian/poly requires newton pair off");
+  // if (force->newton_pair == 1)
+  //   error->all(FLERR,"Pair brownian/poly requires newton pair off");
   if (!atom->radius_flag)
     error->all(FLERR,"Pair brownian/poly requires atom attribute radius");
 

--- a/src/COLLOID/pair_brownian_poly.cpp
+++ b/src/COLLOID/pair_brownian_poly.cpp
@@ -293,7 +293,7 @@ void PairBrownianPoly::compute(int eflag, int vflag)
             torque[j][1] -= ty;
             torque[j][2] -= tz;
           }
-          
+        
           // torque due to a_pu
 
           Fbmag = prethermostat*sqrt(a_pu);

--- a/src/COLLOID/pair_lubricate.cpp
+++ b/src/COLLOID/pair_lubricate.cpp
@@ -789,25 +789,15 @@ void PairLubricate::unpack_forward_comm(int n, int first, double *buf)
 }
 
 /* ----------------------------------------------------------------------
-   check if name is recognized, return integer index for that name
-   if name not recognized, return -1
-   if type pair setting, return -2 if no type pairs are set
+   check if name is recognized, return pointer to that variable
+   if name not recognized, return nullptr
 ------------------------------------------------------------------------- */
 
-int PairLubricate::pre_adapt(char *name, int /*ilo*/, int /*ihi*/, int /*jlo*/, int /*jhi*/)
+void *PairLubricate::extract(const char *str, int &dim)
 {
-  if (strcmp(name,"mu") == 0) return 0;
-  return -1;
-}
-
-/* ----------------------------------------------------------------------
-   adapt parameter indexed by which
-   change all pair variables affected by the reset parameter
-   if type pair setting, set I-J and J-I coeffs
-------------------------------------------------------------------------- */
-
-void PairLubricate::adapt(int /*which*/, int /*ilo*/, int /*ihi*/, int /*jlo*/, int /*jhi*/,
-                          double value)
-{
-  mu = value;
+  if (strcmp(str, "mu") == 0) {
+    dim = 0;
+    return (void *) &mu;
+  }
+  return nullptr;
 }

--- a/src/COLLOID/pair_lubricate.h
+++ b/src/COLLOID/pair_lubricate.h
@@ -37,8 +37,7 @@ class PairLubricate : public Pair {
   void read_restart(FILE *) override;
   void write_restart_settings(FILE *) override;
   void read_restart_settings(FILE *) override;
-  int pre_adapt(char *, int, int, int, int);
-  void adapt(int, int, int, int, int, double);
+  void *extract(const char *, int &) override;
 
   int pack_forward_comm(int, int *, double *, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;

--- a/src/COLLOID/pair_lubricateU.cpp
+++ b/src/COLLOID/pair_lubricateU.cpp
@@ -2053,3 +2053,17 @@ double PairLubricateU::dot_vec_vec(int N, double *x, double *y)
   for (int i = 0; i < N; i++) dotp += x[i]*y[i];
   return dotp;
 }
+
+/* ----------------------------------------------------------------------
+   check if name is recognized, return pointer to that variable
+   if name not recognized, return nullptr
+------------------------------------------------------------------------- */
+
+void *PairLubricateU::extract(const char *str, int &dim)
+{
+  if (strcmp(str, "mu") == 0) {
+    dim = 0;
+    return (void *) &mu;
+  }
+  return nullptr;
+}

--- a/src/COLLOID/pair_lubricateU.h
+++ b/src/COLLOID/pair_lubricateU.h
@@ -39,6 +39,7 @@ class PairLubricateU : public Pair {
   void read_restart_settings(FILE *) override;
   int pack_forward_comm(int, int *, double *, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double cut_inner_global, cut_global;

--- a/src/COLLOID/pair_lubricate_poly.cpp
+++ b/src/COLLOID/pair_lubricate_poly.cpp
@@ -353,6 +353,13 @@ void PairLubricatePoly::compute(int eflag, int vflag)
         f[i][1] -= fy;
         f[i][2] -= fz;
 
+        //use Newton's third law
+
+        if (newton_pair || j<nlocal) {
+          f[j][0] += fx;
+          f[j][1] += fy;
+          f[j][2] += fz;
+        }
         // torque due to this force
 
         if (flaglog) {
@@ -363,6 +370,12 @@ void PairLubricatePoly::compute(int eflag, int vflag)
           torque[i][0] -= vxmu2f*tx;
           torque[i][1] -= vxmu2f*ty;
           torque[i][2] -= vxmu2f*tz;
+
+          if (newton_pair || j < nlocal) {
+            torque[j][0] -= vxmu2f*tx;
+            torque[j][1] -= vxmu2f*ty;
+            torque[j][2] -= vxmu2f*tz;
+          }
 
           // torque due to a_pu
 
@@ -380,11 +393,17 @@ void PairLubricatePoly::compute(int eflag, int vflag)
           torque[i][1] -= vxmu2f*ty;
           torque[i][2] -= vxmu2f*tz;
 
+          if (newton_pair || j < nlocal) {
+            torque[j][0] += vxmu2f*tx;
+            torque[j][1] += vxmu2f*ty;
+            torque[j][2] += vxmu2f*tz;
+          }
+
         }
 
         // set j = nlocal so that only I gets tallied
 
-        if (evflag) ev_tally_xyz(i,nlocal,nlocal,0,
+        if (evflag) ev_tally_xyz(i,nlocal,nlocal,newton_pair,
                                  0.0,0.0,-fx,-fy,-fz,delx,dely,delz);
       }
     }
@@ -423,8 +442,8 @@ void PairLubricatePoly::compute(int eflag, int vflag)
 
 void PairLubricatePoly::init_style()
 {
-  if (force->newton_pair == 1)
-    error->all(FLERR, "Pair lubricate/poly requires newton pair off");
+  // if (force->newton_pair == 1)
+  //   error->all(FLERR, "Pair lubricate/poly requires newton pair off");
   if (comm->ghost_velocity == 0)
     error->all(FLERR, "Pair lubricate/poly requires ghost atoms store velocity");
   if (!atom->omega_flag)


### PR DESCRIPTION

**Summary**
Implement newtonian forces to poly pair_styles -> to exhibit comparable behaviour to their monodisperse counterparts. 
Implement the extract function -> to support varying mu dynamically, as mentioned in the docs

**Author(s)**

Sourab Barath Vijayaraghavan - LRCS - sourabvbarath@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes

**Implementation Notes**

Tested using monodisperse test systems and using poly and standard pair_styles. Forces and energies were used to verify expected behaviour.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



