### PR TITLE
compute_reduce.rst: fix variance definition

### DIFF
--- a/doc/src/compute_reduce.rst
+++ b/doc/src/compute_reduce.rst
@@ -87,7 +87,7 @@ values in the vector.  The *sumsq* option sums the square of the
 values in the vector into a global total.  The *avesq* setting does
 the same as *sumsq*, then divides the sum of squares by the number of
 values.  The last two options can be useful for calculating the
-variance of some quantity (e.g., variance = sumsq :math:`-` ave\
+variance of some quantity (e.g., variance = avesq :math:`-` ave\
 :math:`^2`).  The *sumabs* option sums the absolute values in the
 vector into a global total.  The *aveabs* setting does the same as
 *sumabs*, then divides the sum of absolute values by the number of


### PR DESCRIPTION
**Summary**

Subtracting an intensive term from an extensive term cannot be true. Not to mention the well know formula of variance which is:

![image](https://github.com/user-attachments/assets/0bba665f-d892-4a8e-a37d-9e5f50a81f90)

And `avesq` is of course ![image](https://github.com/user-attachments/assets/9c952b17-31b7-4bf2-9762-d7f5e50b4436) and this is not `sumsq`.

**Related Issue(s)**

None.

**Author(s)**

Git commit's has that info.

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Implementation Notes**

None.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

Traced back with Git blame that documentation text to this commit:

- https://github.com/lammps/lammps/commit/574e4067dcff1ed0a3e53e12b22188daf685dfe6

By @rbberger .