### PR TITLE
Fix bad value for factor_sqrt with dpd/tstat pair_style

### DIFF
--- a/src/DPD-BASIC/pair_dpd_tstat.cpp
+++ b/src/DPD-BASIC/pair_dpd_tstat.cpp
@@ -91,7 +91,7 @@ void PairDPDTstat::compute(int eflag, int vflag)
     for (jj = 0; jj < jnum; jj++) {
       j = jlist[jj];
       factor_dpd = special_lj[sbmask(j)];
-      factor_sqrt = special_sqrt[sbmask(j)];
+      factor_sqrt = sqrt(factor_dpd);
       j &= NEIGHMASK;
 
       delx = xtmp - x[j][0];


### PR DESCRIPTION
**Summary**

The temperature diverges when using the `dpd/tstat` pair style because the `factor_sqrt` variable has not the right value.

**Related Issue(s)**


**Author(s)**

Julien Devémy
Alain Dequidt

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

**Implementation Notes**

The fix consist in recomputing the sqrt in the neighbors loop, so it's not optimal but it fixes the problem.

The issue may also be present in other `dpd` pair style, like `dpd` or `dpd/gpu`...

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

Here attached a data and input file to test.

[dpd_temp_bug.tar.gz](https://github.com/user-attachments/files/18938359/dpd_temp_bug.tar.gz)

Without the fix (blue), the temperature diverges, but with the fix (orange), it converges to the target (100K):

![image](https://github.com/user-attachments/assets/f6144161-d127-4d7c-a17c-cc9dbd151b94)





