### PR TITLE
fix the bug of pair_ylz.cpp

### DIFF
--- a/examples/ASPHERE/flat_membrane/log.3Mar25.flat_membrane.g++.1
+++ b/examples/ASPHERE/flat_membrane/log.3Mar25.flat_membrane.g++.1
@@ -1,4 +1,5 @@
-LAMMPS (15 Sep 2022)
+LAMMPS (4 Feb 2025 - Development - patch_4Feb2025-106-g5d02e140d4)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:99)
   using 1 OpenMP thread(s) per MPI task
 # flat membrane demo
 variable     r0 equal  0.97
@@ -46,7 +47,7 @@ set type 1 mass  1.0
 Setting atom values ...
   1920 settings made for mass
 
-set type 1 shape  1 1 1
+set type 1 shape  1 0.99 0.99
 Setting atom values ...
   1920 settings made for shape
 
@@ -99,7 +100,7 @@ CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE
 
 Generated 0 of 0 mixed pair_coeff terms from geometric mixing rule
 Neighbor list info ...
-  update: every = 1 steps, delay = 10 steps, check = yes
+  update: every = 1 steps, delay = 0 steps, check = yes
   max neighbors/atom: 2000, page size: 100000
   master list distance cutoff = 3.6
   ghost atom cutoff = 3.6
@@ -113,47 +114,47 @@ Neighbor list info ...
 Per MPI rank memory allocation (min/avg/max) = 5.024 | 5.024 | 5.024 Mbytes
    Step          Temp          Press           Pxx            Pyy      
          0   0.23          -0.0073508785  -0.012283389   -0.012234574  
-       200   0.20903886    -0.0010605951  -0.0011885957  -0.00198842   
-       400   0.21898026    -0.00069250685 -0.0013217981  -0.00073225707
-       600   0.22689361    -0.00057919328 -0.00076880503 -0.0010242283 
-       800   0.22983221    -0.00032145682 -0.00051928834 -0.00059337525
-      1000   0.23819392    -0.00027969126 -0.00088082301 -5.2666567e-05
-      1200   0.22053795    -0.00029571329 -0.0004446455  -0.00035529929
-      1400   0.22285021    -0.0002690371  -0.00068896571 -3.6258442e-05
-      1600   0.22687044     2.8599875e-05 -0.00032651798  0.0004056081 
-      1800   0.23356905    -2.28742e-05   -0.00027073251  0.00025081131
-      2000   0.22499821     8.8230586e-06 -7.5750159e-05  0.0001988705 
-      2200   0.23162995    -9.026855e-05  -0.00025832535  5.4904927e-05
-      2400   0.22920223     0.00016700455  3.5283125e-05  0.00034955857
-      2600   0.2260299      5.3095557e-05  0.00025691786  0.00013353467
-      2800   0.2296401      0.00043234854  0.00058344966  0.00063645193
-      3000   0.22564577     2.6423111e-05  8.9918406e-05  0.00022146229
-Loop time of 6.76659 on 1 procs for 3000 steps with 1920 atoms
+       200   0.20906916    -0.0010610794  -0.0011895359  -0.00198968   
+       400   0.21907691    -0.00068750897 -0.0013175111  -0.00072355516
+       600   0.22648739    -0.00057306694 -0.000831971   -0.00096776143
+       800   0.2368957     -0.00028517767 -0.00050638195 -0.00052670236
+      1000   0.22735705    -0.00032638104 -0.00037959812 -0.00071879257
+      1200   0.22910882    -0.00019457758 -0.00024451315 -0.00027807764
+      1400   0.22754022    -0.00033048317 -0.00010053263 -0.00075173132
+      1600   0.22503496    -7.593954e-05   5.2989168e-05 -0.00022521685
+      1800   0.22673577    -0.00017917699  1.0176667e-05 -0.00047893102
+      2000   0.22480858     9.318318e-05   0.00031024343  1.2738253e-05
+      2200   0.22387294    -6.9083174e-05 -4.6170865e-05  4.6682009e-05
+      2400   0.22686231     0.00022776785  0.00028204391  0.00030116273
+      2600   0.23055637     8.2778175e-05  0.00027137529  4.2254076e-05
+      2800   0.23126717     0.00044863024  0.00071654709  0.00057652233
+      3000   0.22234736     0.00031577792  0.00051797227  0.00039087282
+Loop time of 7.17991 on 1 procs for 3000 steps with 1920 atoms
 
-Performance: 383058.431 tau/day, 443.355 timesteps/s
-99.8% CPU use with 1 MPI tasks x 1 OpenMP threads
+Performance: 361007.348 tau/day, 417.833 timesteps/s, 802.239 katom-step/s
+99.9% CPU use with 1 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 5.7968     | 5.7968     | 5.7968     |   0.0 | 85.67
-Neigh   | 0.086077   | 0.086077   | 0.086077   |   0.0 |  1.27
-Comm    | 0.034761   | 0.034761   | 0.034761   |   0.0 |  0.51
-Output  | 0.00038014 | 0.00038014 | 0.00038014 |   0.0 |  0.01
-Modify  | 0.8268     | 0.8268     | 0.8268     |   0.0 | 12.22
-Other   |            | 0.02181    |            |       |  0.32
+Pair    | 6.2257     | 6.2257     | 6.2257     |   0.0 | 86.71
+Neigh   | 0.11392    | 0.11392    | 0.11392    |   0.0 |  1.59
+Comm    | 0.036614   | 0.036614   | 0.036614   |   0.0 |  0.51
+Output  | 0.00052672 | 0.00052672 | 0.00052672 |   0.0 |  0.01
+Modify  | 0.78577    | 0.78577    | 0.78577    |   0.0 | 10.94
+Other   |            | 0.01743    |            |       |  0.24
 
 Nlocal:           1920 ave        1920 max        1920 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Nghost:            772 ave         772 max         772 min
+Nghost:            771 ave         771 max         771 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
-Neighs:          46804 ave       46804 max       46804 min
+Neighs:          46750 ave       46750 max       46750 min
 Histogram: 1 0 0 0 0 0 0 0 0 0
 
-Total # of neighbors = 46804
-Ave neighs/atom = 24.377083
-Neighbor list builds = 99
+Total # of neighbors = 46750
+Ave neighs/atom = 24.348958
+Neighbor list builds = 98
 Dangerous builds = 0
 
 
-Total wall time: 0:00:06
+Total wall time: 0:00:07

--- a/examples/ASPHERE/flat_membrane/log.3Mar25.flat_membrane.g++.4
+++ b/examples/ASPHERE/flat_membrane/log.3Mar25.flat_membrane.g++.4
@@ -1,4 +1,5 @@
-LAMMPS (15 Sep 2022)
+LAMMPS (4 Feb 2025 - Development - patch_4Feb2025-106-g5d02e140d4)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:99)
   using 1 OpenMP thread(s) per MPI task
 # flat membrane demo
 variable     r0 equal  0.97
@@ -46,7 +47,7 @@ set type 1 mass  1.0
 Setting atom values ...
   1920 settings made for mass
 
-set type 1 shape  1 1 1
+set type 1 shape  1 0.99 0.99
 Setting atom values ...
   1920 settings made for shape
 
@@ -99,7 +100,7 @@ CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE-CITE
 
 Generated 0 of 0 mixed pair_coeff terms from geometric mixing rule
 Neighbor list info ...
-  update: every = 1 steps, delay = 10 steps, check = yes
+  update: every = 1 steps, delay = 0 steps, check = yes
   max neighbors/atom: 2000, page size: 100000
   master list distance cutoff = 3.6
   ghost atom cutoff = 3.6
@@ -113,47 +114,47 @@ Neighbor list info ...
 Per MPI rank memory allocation (min/avg/max) = 4.182 | 4.794 | 5.472 Mbytes
    Step          Temp          Press           Pxx            Pyy      
          0   0.23          -0.0073508785  -0.012283389   -0.012234574  
-       200   0.20647718    -0.0012368074  -0.0021167303  -0.0015343502 
-       400   0.21648371    -0.00085695085 -0.0015627331  -0.0011177093 
-       600   0.22929515    -0.00050218657 -0.0008332     -0.00062622609
-       800   0.22062664    -0.00049172378 -0.000611884   -0.00075089294
-      1000   0.22422425    -0.00039405068 -0.00037600355 -0.00070786572
-      1200   0.2298767     -0.00025939082 -0.00021616578 -0.00053125505
-      1400   0.2335927      5.8028332e-05  0.00017530192 -3.1675138e-05
-      1600   0.22884878    -0.0001733902  -0.0008056431   0.00014276754
-      1800   0.22813498     0.00019873459  0.00051040124  5.8860949e-05
-      2000   0.2273166     -3.3595127e-05  0.0001705632  -0.00026498213
-      2200   0.2251643     -2.4517311e-05 -4.0618888e-05  1.066658e-05 
-      2400   0.22460629    -4.5661259e-05 -0.00019144039 -1.6649099e-05
-      2600   0.23085675     0.00014029405  0.00017983536  0.00017895001
-      2800   0.22364591     4.2999164e-05 -0.00011000466  0.00024363243
-      3000   0.23421357     0.00023505702  0.00020752013  0.00053567111
-Loop time of 4.68577 on 4 procs for 3000 steps with 1920 atoms
+       200   0.21866566    -0.0011213114  -0.0017540296  -0.0017008786 
+       400   0.22409469    -0.00055137604 -0.00050366017 -0.0012846672 
+       600   0.21623646    -0.0004808564  -0.00063496522 -0.00071617302
+       800   0.22248339    -0.00066333806 -0.00093812145 -0.00099410261
+      1000   0.22367907    -0.0003439459  -0.00076259578 -0.00013354375
+      1200   0.23276206     8.5764334e-06 -0.00036165178  0.00038543803
+      1400   0.23129049    -5.1997966e-06 -0.00040514787  0.00017093646
+      1600   0.22074564    -0.0001604642  -0.00053959031  9.0463391e-05
+      1800   0.2276062     -0.00015655254 -0.00042925633  5.4938379e-05
+      2000   0.22469391    -3.6198836e-05 -1.8538296e-06 -0.00010464749
+      2200   0.22737515    -1.8967356e-05  0.0001341006  -0.00022739894
+      2400   0.22607533     0.00014650382 -2.4871789e-05  0.00058296255
+      2600   0.24044743     0.00045066449  0.00049153595  0.00078042437
+      2800   0.23346628     0.00017994019 -5.0897724e-05  0.00046011801
+      3000   0.22427206     0.00040437022  0.00049580531  0.00046259202
+Loop time of 5.04539 on 4 procs for 3000 steps with 1920 atoms
 
-Performance: 553164.568 tau/day, 640.237 timesteps/s
-95.6% CPU use with 4 MPI tasks x 1 OpenMP threads
+Performance: 513736.789 tau/day, 594.603 timesteps/s, 1.142 Matom-step/s
+99.0% CPU use with 4 MPI tasks x 1 OpenMP threads
 
 MPI task timing breakdown:
 Section |  min time  |  avg time  |  max time  |%varavg| %total
 ---------------------------------------------------------------
-Pair    | 0.00015072 | 1.6029     | 3.8573     | 131.7 | 34.21
-Neigh   | 0.00055747 | 0.025423   | 0.065858   |  17.0 |  0.54
-Comm    | 0.0052259  | 0.48173    | 1.624      |  96.5 | 10.28
-Output  | 0.0003894  | 0.023428   | 0.047223   |  15.0 |  0.50
-Modify  | 0.00037337 | 0.2141     | 0.44595    |  46.3 |  4.57
-Other   |            | 2.338      |            |       | 49.90
+Pair    | 4.1163     | 4.2634     | 4.4004     |   6.5 | 84.50
+Neigh   | 0.00088605 | 0.032793   | 0.083516   |  19.1 |  0.65
+Comm    | 0.006704   | 0.20003    | 0.40672    |  42.5 |  3.96
+Output  | 0.00033812 | 0.0012192  | 0.0020905  |   2.3 |  0.02
+Modify  | 0.00035967 | 0.20167    | 0.42535    |  45.0 |  4.00
+Other   |            | 0.3462     |            |       |  6.86
 
-Nlocal:            480 ave        1011 max           0 min
+Nlocal:            480 ave        1052 max           0 min
 Histogram: 2 0 0 0 0 0 0 0 1 1
-Nghost:            860 ave        1771 max           0 min
-Histogram: 2 0 0 0 0 0 0 0 0 2
-Neighs:        11697.8 ave       30095 max           0 min
+Nghost:          854.5 ave        1801 max           0 min
+Histogram: 2 0 0 0 0 0 0 0 1 1
+Neighs:        11684.2 ave       31145 max           0 min
 Histogram: 2 0 0 0 0 1 0 0 0 1
 
-Total # of neighbors = 46791
-Ave neighs/atom = 24.370313
-Neighbor list builds = 99
+Total # of neighbors = 46737
+Ave neighs/atom = 24.342188
+Neighbor list builds = 98
 Dangerous builds = 0
 
 
-Total wall time: 0:00:04
+Total wall time: 0:00:05

--- a/src/ASPHERE/pair_ylz.cpp
+++ b/src/ASPHERE/pair_ylz.cpp
@@ -32,7 +32,7 @@
 #include <cmath>
 
 using namespace LAMMPS_NS;
-using MathConst::MY_4PI;
+using MathConst::MY_PI;
 using MathConst::MY_PI2;
 using MathConst::MY_TWOBYSIXTH;
 
@@ -487,7 +487,7 @@ double PairYLZ::ylz_analytic(const int i, const int j, double a1[3][3], double a
 
     uA = -energy_well * t1 * cos_t;
     U = uA * phi;
-    dUdr = MY_4PI / (rcut - rmin) * (t1) *sin(t) * phi * energy_well;
+    dUdr = MY_PI * zt / (rcut - rmin) * (t1) *sin(t) * phi * energy_well;
     dUdphi = uA;
   }
 


### PR DESCRIPTION
Summary
    There is a wrong equation in the line490 of pair_ylz.cpp , MY_4PI should be MY_PI*zt. 
   


Related Issue

Author(s)

Hongyan Yuan from SUStech (yuanhy3@sustech.edu.cn);
Xin Zhang from SUStech (12432359@mail.sustech.edu.cn).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

https://doi.org/10.1103/PhysRevE.82.011905

