### PR TITLE
Address several issues with pair style dispersion/d3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,8 @@ src/EXTRA-COMMAND/ndx_group.*       @akohlmey
 src/EXTRA-COMPUTE/compute_stress_mop*.* @RomainVermorel
 src/EXTRA-COMPUTE/compute_born_matrix.* @Bibobu @athomps
 src/EXTRA-FIX/fix_deform_pressure.* @jtclemm
+src/EXTRA-PAIR/pair_dispersion_d3.* @soniasolomoni @arthurfl
+src/EXTRA-PAIR/d3_parameters.h      @soniasolomoni @arthurfl
 src/MISC/*_tracker.*                @jtclemm
 src/MC/fix_gcmc.*                   @athomps
 src/MC/fix_sgcmc.*                  @athomps

--- a/doc/src/pair_dispersion_d3.rst
+++ b/doc/src/pair_dispersion_d3.rst
@@ -63,7 +63,8 @@ factor, and :math:`f_n^{damp}` are damping functions.
 
 Available damping functions are the original "zero-damping" (*original*)
 :ref:`(Grimme1) <Grimme1>`, Becke-Johnson damping (*bj*) :ref:`(Grimme2)
-<Grimme2>`, and their revised forms (*bjm*) :ref:`(Sherrill) <Sherrill>`.
+<Grimme2>`, and their revised forms (*zerom* and *bjm*, respectively)
+:ref:`(Sherrill) <Sherrill>`.
 
 Available XC functional scaling factors are listed in the table below,
 and depend on the selected damping function.

--- a/doc/src/pair_dispersion_d3.rst
+++ b/doc/src/pair_dispersion_d3.rst
@@ -128,6 +128,8 @@ Style *dispersion/d3* is part of the EXTRA-PAIR package. It is only
 enabled if LAMMPS was built with that package.  See the :doc:`Build
 package <Build_package>` page for more info.
 
+The compiled in parameters require the use of :doc:`metal units <units>`.
+
 It is currently *not* possible to calculate three-body dispersion
 contributions according to, for example, the Axilrod-Teller-Muto model.
 

--- a/doc/src/pair_dispersion_d3.rst
+++ b/doc/src/pair_dispersion_d3.rst
@@ -10,7 +10,7 @@ Syntax
 
    pair_style dispersion/d3 damping functional cutoff cn_cutoff
 
-* damping = damping function: *zero*, *zerom*, *bj*, or *bjm*
+* damping = damping function: *original*, *zerom*, *bj*, or *bjm*
 * functional = XC functional form: *pbe*, *pbe0*, ... (see list below)
 * cutoff = global cutoff (distance units)
 * cn_cutoff = coordination number cutoff (distance units)
@@ -20,7 +20,7 @@ Examples
 
 .. code-block:: LAMMPS
 
-   pair_style dispersion/d3 zero pbe 30.0 20.0
+   pair_style dispersion/d3 original pbe 30.0 20.0
    pair_coeff * * C
 
 Description
@@ -55,9 +55,15 @@ factor, and :math:`f_n^{damp}` are damping functions.
    contributions, according to, for example, the Axilrod-Teller-Muto
    model.
 
-Available damping functions are the original "zero-damping"
-:ref:`(Grimme1) <Grimme1>`, Becke-Johnson damping :ref:`(Grimme2)
-<Grimme2>`, and their revised forms :ref:`(Sherrill) <Sherrill>`.
+.. versionchanged:: TBD
+
+   renamed *zero* keyword to *original* to avoid conflicts with
+   :doc:`pair style zero <pair_zero>` when used as :doc:`hybrid
+   sub-style <pair_hybrid>`.
+
+Available damping functions are the original "zero-damping" (*original*)
+:ref:`(Grimme1) <Grimme1>`, Becke-Johnson damping (*bj*) :ref:`(Grimme2)
+<Grimme2>`, and their revised forms (*bjm*) :ref:`(Sherrill) <Sherrill>`.
 
 Available XC functional scaling factors are listed in the table below,
 and depend on the selected damping function.
@@ -67,7 +73,7 @@ and depend on the selected damping function.
 +==================+================================================================================+
 | |                | | slater-dirac-exchange, b-lyp, b-p, b97-d, revpbe, pbe, pbesol, rpw86-pbe,    |
 | |                | | rpbe, tpss, b3-lyp, pbe0, hse06, revpbe38, pw6b95, tpss0, b2-plyp, pwpb95,   |
-| | zero           | | b2gp-plyp, ptpss, hf, mpwlyp, bpbe, bh-lyp, tpssh, pwb6k, b1b95, bop, o-lyp, |
+| | original       | | b2gp-plyp, ptpss, hf, mpwlyp, bpbe, bh-lyp, tpssh, pwb6k, b1b95, bop, o-lyp, |
 | |                | | o-pbe, ssb, revssb, otpss, b3pw91, revpbe0, pbe38, mpw1b95, mpwb1k, bmk,     |
 | |                | | cam-b3lyp, lc-wpbe, m05, m052x, m06l, m06, m062x, m06hf, hcth120             |
 +------------------+--------------------------------------------------------------------------------+

--- a/src/EXTRA-PAIR/pair_dispersion_d3.cpp
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.cpp
@@ -164,7 +164,7 @@ int PairDispersionD3::find_atomic_number(std::string &key)
 {
   std::transform(key.begin(), key.end(), key.begin(), ::tolower);
   if (key.length() == 1) key += " ";
-  key.resize(2);
+  if (key.length() > 2) return -1;
 
   std::vector<std::string> element_table = {
       "h ", "he", "li", "be", "b ", "c ", "n ", "o ", "f ", "ne", "na", "mg", "al", "si",
@@ -293,6 +293,8 @@ void PairDispersionD3::coeff(int narg, char **arg)
   for (int i = 0; i < ntypes; i++) {
     element = arg[i + 2];
     atomic_numbers[i] = find_atomic_number(element);
+    if (atomic_numbers[i] < 0)
+      error->all(FLERR, Error::NOLASTLINE, "Element {} not supported", element);
   }
 
   int count = 0;
@@ -967,7 +969,8 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           s8 = 1.206;
           break;
         default:
-          error->all(FLERR, "Functional name unknown");
+          error->all(FLERR, Error::NOLASTLINE,
+                     "Functional {} not supported with original damping function", functional_name);
           break;
       }
       //fprintf(stderr,"s6    : %f\n", s6);
@@ -1029,7 +1032,8 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           rs8 = 0.003160;
           break;
         default:
-          error->all(FLERR, "Functional name unknown");
+          error->all(FLERR, Error::NOLASTLINE,
+                     "Functional {} not supported with zerom damping function", functional_name);
           break;
       }
       //fprintf(stderr,"s6    : %f\n", s6);
@@ -1339,7 +1343,8 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           a2 = 4.5000;
           break;
         default:
-          error->all(FLERR, "Functional name unknown");
+          error->all(FLERR, Error::NOLASTLINE,
+                     "Functional {} not supported with bj damping function", functional_name);
           break;
       }
 
@@ -1405,7 +1410,8 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           a2 = 3.593680;
           break;
         default:
-          error->all(FLERR, "Functional name unknown");
+          error->all(FLERR, Error::NOLASTLINE,
+                     "Functional {} not supported with bjm damping function", functional_name);
           break;
       }
 
@@ -1419,7 +1425,8 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
 
     } break;
     default:
-      error->all(FLERR, "Damping type unknown");
+      // this should not happen with the error check in the init_style function
+      error->all(FLERR, Error::NOLASTLINE, "Damping code {} unknown", dampingCode);
       break;
   }
 }

--- a/src/EXTRA-PAIR/pair_dispersion_d3.cpp
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.cpp
@@ -29,6 +29,7 @@
 #include "memory.h"
 #include "neigh_list.h"
 #include "neighbor.h"
+#include "update.h"
 
 #include <algorithm>
 #include <cmath>
@@ -131,7 +132,9 @@ void PairDispersionD3::allocate()
 
 void PairDispersionD3::settings(int narg, char **arg)
 {
-  if (narg != 4) error->all(FLERR, "Pair_style dispersion/d3 needs 4 arguments");
+  if (narg != 4) error->all(FLERR, "Pair style dispersion/d3 needs 4 arguments");
+  if (strcmp("metal", update->unit_style) != 0)
+    error->all(FLERR, Error::NOLASTLINE, "Pair style dispersion/d3 requires metal units");
 
   std::string damping_type = arg[0];
   std::string functional_name = arg[1];

--- a/src/EXTRA-PAIR/pair_dispersion_d3.cpp
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.cpp
@@ -59,6 +59,7 @@ static constexpr double autoang = 0.52917725;    // atomic units (Bohr) to Angst
 static constexpr double autoev = 27.21140795;    // atomic units (Hartree) to eV
 
 #include "d3_parameters.h"
+
 /* ----------------------------------------------------------------------
    Constructor (Required)
 ------------------------------------------------------------------------- */
@@ -547,6 +548,7 @@ void PairDispersionD3::compute(int eflag, int vflag)
             fpair = fpair1 + fpair2;
             fpair *= factor_lj;
           } break;
+
           case 2: {    // zerom
 
             double r0 = r0ab[type[i]][type[j]];
@@ -572,6 +574,7 @@ void PairDispersionD3::compute(int eflag, int vflag)
             fpair = fpair1 + fpair2;
             fpair *= factor_lj;
           } break;
+
           case 3: {    // bj
 
             double r0 = sqrt(C8 / C6);
@@ -592,6 +595,7 @@ void PairDispersionD3::compute(int eflag, int vflag)
             fpair = -(tmp6 + tmp8);
             fpair *= factor_lj;
           } break;
+
           case 4: {    // bjm
 
             double r0 = sqrt(C8 / C6);
@@ -619,7 +623,7 @@ void PairDispersionD3::compute(int eflag, int vflag)
           } break;
         }
 
-        if (eflag) { evdwl = -(s6 * e6 + s8 * e8) * factor_lj; }
+        if (eflag) evdwl = -(s6 * e6 + s8 * e8) * factor_lj;
 
         double rest = (s6 * e6 + s8 * e8) / C6;
 
@@ -973,11 +977,6 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
                      "Functional {} not supported with original damping function", functional_name);
           break;
       }
-      //fprintf(stderr,"s6    : %f\n", s6);
-      //fprintf(stderr,"s8    : %f\n", s8);
-      //fprintf(stderr,"rs6   : %f\n", rs6);
-      //fprintf(stderr,"rs8   : %f\n", rs8);
-      //fprintf(stderr,"alpha : %f\n", alpha);
     } break;
 
     case 2: {    // zerom
@@ -1036,11 +1035,6 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
                      "Functional {} not supported with zerom damping function", functional_name);
           break;
       }
-      //fprintf(stderr,"s6    : %f\n", s6);
-      //fprintf(stderr,"s8    : %f\n", s8);
-      //fprintf(stderr,"rs6   : %f\n", rs6);
-      //fprintf(stderr,"rs8   : %f\n", rs8);
-      //fprintf(stderr,"alpha : %f\n", alpha);
 
       rs8 = rs8 / autoang;
     } break;
@@ -1348,12 +1342,6 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           break;
       }
 
-      //fprintf(stderr,"s6    : %f\n", s6);
-      //fprintf(stderr,"s8    : %f\n", s8);
-      //fprintf(stderr,"a1    : %f\n", a1);
-      //fprintf(stderr,"a2    : %f\n", a2);
-      //fprintf(stderr,"alpha : %f\n", alpha);
-
       a2 = a2 * autoang;
     } break;
 
@@ -1415,12 +1403,6 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           break;
       }
 
-      //fprintf(stderr,"s6    : %f\n", s6);
-      //fprintf(stderr,"s8    : %f\n", s8);
-      //fprintf(stderr,"a1    : %f\n", a1);
-      //fprintf(stderr,"a2    : %f\n", a2);
-      //fprintf(stderr,"alpha : %f\n", alpha);
-
       a2 = a2 * autoang;
 
     } break;
@@ -1448,8 +1430,6 @@ double PairDispersionD3::init_one(int i, int j)
 void PairDispersionD3::init_style()
 {
   if (atom->tag_enable == 0) error->all(FLERR, "Pair style D3 requires atom IDs");
-  //if (force->newton_pair == 0)
-  //  error->all(FLERR,"Pair style D3 requires newton pair on");
 
   // need an half neighbor list
   neighbor->add_request(this);

--- a/src/EXTRA-PAIR/pair_dispersion_d3.h
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.h
@@ -48,7 +48,7 @@ class PairDispersionD3 : public Pair {
   double rthr;      // R^2 distance to cutoff for D3_calculation
   double cn_thr;    // R^2 distance to cutoff for CN_calculation
 
-  std::string damping_type;              // damping function type
+  int dampingCode;
   double s6, s8, s18, rs6, rs8, rs18;    // XC parameters
   double a1, a2, alpha, alpha6, alpha8;
 


### PR DESCRIPTION
**Summary**

This pull request fixes several issues with pair style dispersion/d3

**Related Issue(s)**

Fixes #4484 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Yes.

**Implementation Notes**

The keyword "zero" cannot be used with hybrid pair styles, because there is a pair style "zero" and the list of arguments are split between sub-styles based on known pair styles. Thus the "zero" keyword is interpreted as a new sub-style.
The keyword is renamed in this pull request to "original" ("zero" remains recognized for backward compatibility, but is undocumented).

Furthermore, the detection of elements is made more thorough and errors are thrown, if needed.

Also, the pair style must require the use of "metal" units and that check is added.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
