### PR TITLE
Add `type first` option to correlation fixes

### DIFF
--- a/doc/src/fix_ave_correlate.rst
+++ b/doc/src/fix_ave_correlate.rst
@@ -260,7 +260,7 @@ time.
   :math:`\{i,j\} = \{1,N\}`, so :math:`N_\text{pair} = N^2`).
 * If *type* is set to *first* then each input value is correlated with
   the first input value (i.e., :math:`C_{ij} = V_1 V_j` for
-  :math:`\{i,j\} = \{1,N\}`, so :math:`N_\text{pair} = N`).
+  :math:`\{j\} = \{1,N\}`, so :math:`N_\text{pair} = N`).
 
 The *ave* keyword determines what happens to the accumulation of correlation
 samples every :math:`N_\text{freq}` timesteps.  If the *ave* setting is *one*,

--- a/doc/src/fix_ave_correlate.rst
+++ b/doc/src/fix_ave_correlate.rst
@@ -32,13 +32,14 @@ Syntax
 
   .. parsed-literal::
 
-       *type* arg = *auto* or *upper* or *lower* or *auto/upper* or *auto/lower* or *full*
+       *type* arg = *auto* or *upper* or *lower* or *auto/upper* or *auto/lower* or *full* or *first*
          auto = correlate each value with itself
          upper = correlate each value with each succeeding value
          lower = correlate each value with each preceding value
          auto/upper = auto + upper
          auto/lower = auto + lower
          full = correlate each value with every other value, including itself = auto + upper + lower
+         first = correlate each value with the first value
        *ave* args = *one* or *running*
          one = zero the correlation accumulation every Nfreq steps
          running = accumulate correlations continuously
@@ -257,6 +258,9 @@ time.
 * If *type* is set to *full* then each input value is correlated with
   itself and every other value (i.e., :math:`C_{ij} = V_i V_j` for
   :math:`\{i,j\} = \{1,N\}`, so :math:`N_\text{pair} = N^2`).
+* If *type* is set to *first* then each input value is correlated with
+  the first input value (i.e., :math:`C_{ij} = V_1 V_j` for
+  :math:`\{i,j\} = \{1,N\}`, so :math:`N_\text{pair} = N`).
 
 The *ave* keyword determines what happens to the accumulation of correlation
 samples every :math:`N_\text{freq}` timesteps.  If the *ave* setting is *one*,
@@ -369,6 +373,8 @@ above.
 * For *type* = *full*, the :math:`N_\text{pair} = N^2` columns are ordered:
   :math:`C_{11}, C_{12}, \dotsc, C_{1N}, C_{21}, C_{22}, \dotsc, C_{2N},
   C_{31}, \dotsc, C_{3N}, \dotsc, C_{N1}, \dotsc, C_{N,N-1}, C_{NN}`
+* For *type* = *first*, the :math:`N_\text{pair} = N` columns are ordered:
+  :math:`C_{11}, C_{12}, \dotsc, C_{1N}`
 
 The array values calculated by this fix are treated as extensive.  If
 you need to divide them by the number of atoms, you must do this in a

--- a/doc/src/fix_ave_correlate_long.rst
+++ b/doc/src/fix_ave_correlate_long.rst
@@ -31,13 +31,14 @@ Syntax
 
   .. parsed-literal::
 
-       *type* arg = *auto* or *upper* or *lower* or *auto/upper* or *auto/lower* or *full*
+       *type* arg = *auto* or *upper* or *lower* or *auto/upper* or *auto/lower* or *full* or *first*
          auto = correlate each value with itself
          upper = correlate each value with each succeeding value
          lower = correlate each value with each preceding value
          auto/upper = auto + upper
          auto/lower = auto + lower
          full = correlate each value with every other value, including itself = auto + upper + lower
+         first = correlate each value with the first value
        *start* args = Nstart
          Nstart = start accumulating correlations on this time step
        *file* arg = filename

--- a/src/EXTRA-FIX/fix_ave_correlate_long.cpp
+++ b/src/EXTRA-FIX/fix_ave_correlate_long.cpp
@@ -42,7 +42,7 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 using MathSpecial::powint;
 
-enum { AUTO, UPPER, LOWER, AUTOUPPER, AUTOLOWER, FULL };
+enum { AUTO, UPPER, LOWER, AUTOUPPER, AUTOLOWER, FULL, FIRST };
 
 static const char cite_fix_ave_correlate_long[] =
     "fix ave/correlate/long command: doi:10.1063/1.3491098\n\n"
@@ -142,6 +142,8 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS *lmp, int narg, char **arg) :
         type = AUTOLOWER;
       else if (strcmp(arg[iarg + 1], "full") == 0)
         type = FULL;
+      else if (strcmp(arg[iarg + 1], "first") == 0)
+        type = FIRST;
       else
         error->all(FLERR, iarg_orig + 1, "Unknown fix ave/correlate/long type: {}");
       iarg += 2;
@@ -262,7 +264,7 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS *lmp, int narg, char **arg) :
 
   // npair = # of correlation pairs to calculate
 
-  if (type == AUTO) npair = nvalues;
+  if (type == AUTO || type == FIRST) npair = nvalues;
   if (type == UPPER || type == LOWER) npair = nvalues * (nvalues - 1) / 2;
   if (type == AUTOUPPER || type == AUTOLOWER) npair = nvalues * (nvalues + 1) / 2;
   if (type == FULL) npair = nvalues * nvalues;
@@ -299,6 +301,9 @@ FixAveCorrelateLong::FixAveCorrelateLong(LAMMPS *lmp, int narg, char **arg) :
         for (int i = 0; i < nvalues; i++)
           for (int j = 0; j < nvalues; j++)
             fprintf(fp," %s*%s",earg[i],earg[j]);
+      else if (type == FIRST)
+        for (int i = 0; i < nvalues; i++)
+          fprintf(fp," %s*%s",earg[0],earg[i]);
       fprintf(fp,"\n");
     }
     if (ferror(fp))
@@ -612,6 +617,8 @@ void FixAveCorrelateLong::accumulate()
         if (i == j) add(ipair++,cvalues[i]);
         else add(ipair++,cvalues[i],cvalues[j]);
       }
+  } else if (type == FIRST) {
+    for (i=0; i < nvalues; i++) add(i,cvalues[0],cvalues[i]);
   }
   last_accumulated_step = update->ntimestep;
 }


### PR DESCRIPTION
**Summary**

Adds a `type first` option to `fix ave/correlate` and `fix ave/correlate/long` to correlate the first value with all values. This is useful for response theory calculations, where one value may need to be correlated with many values calculated for example by `fix ave/chunk`, but correlations between chunks are not meaningful. With existing options, many redundant columns are generated, or to avoid that, individual fixes and output files are needed for each correlation. In our use case (calculating the velocity profile across a confined LJ fluid with 100 bins and using 4 different response theory methods with `fix ave/correlate/long`) this reduces 400 output files into 4, and gives a ~4x speedup.

**Related Issue(s)**

None

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->
Stephen Sanderson (The University of Queensland) - stephen.sanderson@uq.edu.au

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
No problems expected.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
Output with `type first` tested to exactly match the first N columns when using `type full`:

```lammps
# 2-d LJ flow simulation - based on couette flow example

dimension	2
boundary	p s p

atom_style	atomic
neighbor	0.3 bin
neigh_modify	delay 5

# create geometry

lattice		hex 0.7
region		box block 0 20 0 10 -0.25 0.25
create_box	3 box
create_atoms	1 box

mass		1 1.0
mass		2 1.0
mass		3 1.0

# LJ potentials

pair_style	lj/cut 1.12246
pair_coeff	* * 1.0 1.0 1.12246

# define groups

region	     1 block INF INF INF 1.25 INF INF
group	     lower region 1
region	     2 block INF INF 8.75 INF INF INF
group	     upper region 2
group	     boundary union lower upper
group	     flow subtract all boundary

set	     group lower type 2
set	     group upper type 3

# initial velocities

compute	     mobile flow temp
velocity     flow create 1.0 482748 temp mobile
fix	     1 all nve
fix	     2 flow temp/rescale 200 1.0 1.0 0.02 1.0
fix_modify   2 temp mobile

# Couette flow

velocity     lower set 0.0 0.0 0.0
velocity     upper set 3.0 0.0 0.0
fix	     3 boundary setforce 0.0 0.0 0.0
fix	     4 all enforce2d

# Calculate velocity profile

compute cchunk all chunk/atom bin/1d y lower 0.1 units reduced
fix vprof all ave/chunk 1 1 1 cchunk vx

variable prof vector f_vprof[3]

# Correlate temperature with velocity profile - not meaningful, but works as a simple test.
# First 10 columns of "type full" should match output of "type first"

fix full_short all ave/correlate 1 100 500 c_mobile v_prof[*10] type full file full.dat
fix first_short all ave/correlate 1 100 500 c_mobile v_prof[*10] type first file first.dat

fix full all ave/correlate/long 1 500 c_mobile v_prof[*10] type full file full_long.dat
fix first all ave/correlate/long 1 500 c_mobile v_prof[*10] type first file first_long.dat

# Run

timestep	0.003
thermo		500
thermo_modify	temp mobile

run		10000
```

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


