### PR TITLE
Allow extended XYZ dump

### DIFF
--- a/doc/src/dump.rst
+++ b/doc/src/dump.rst
@@ -475,6 +475,16 @@ label). This option will help many visualization programs to guess bonds
 and colors. You can use the :doc:`dump_modify types labels <dump_modify>`
 option to replace numeric atom types with :doc:`type labels <Howto_type_labels>`.
 
+By passing the optional *extxyz* attribute you can write XYZ files compatible
+with the Extended XYZ (or ExtXYZ) format as defined as defined in `the libAtoms
+specification <https://github.com/libAtoms/extxyz>`_. Specifically, the following
+information will be dumped:
+
+* timestep
+* time, if enabled with :doc:`dump_modify time yes <dump_modify>`
+* simulation box lattice and pbc conditions
+* atomic velocities and forces
+
 .. versionadded:: 22Dec2022
 
 The *grid/vtk* style writes VTK files for grid data on a regular

--- a/src/dump_xyz.cpp
+++ b/src/dump_xyz.cpp
@@ -15,6 +15,7 @@
 #include "dump_xyz.h"
 
 #include "atom.h"
+#include "domain.h"
 #include "error.h"
 #include "label_map.h"
 #include "memory.h"
@@ -32,10 +33,20 @@ static constexpr int DELTA = 1048576;
 DumpXYZ::DumpXYZ(LAMMPS *lmp, int narg, char **arg) : Dump(lmp, narg, arg),
   typenames(nullptr)
 {
-  if (narg != 5) error->all(FLERR,"Illegal dump xyz command");
+  if (narg < 5) error->all(FLERR,"Illegal dump xyz command");
   if (binary || multiproc) error->all(FLERR,"Invalid dump xyz filename");
 
-  size_one = 5;
+  extxyz_flag = 0;
+
+  int iarg = 5;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"extxyz") == 0) {
+      extxyz_flag = 1;
+      iarg++;
+    } else {
+      error->all(FLERR,"Invalid attribute {} in dump xyz command",arg[iarg]);
+    }
+  }
 
   buffer_allow = 1;
   buffer_flag = 1;
@@ -44,7 +55,13 @@ DumpXYZ::DumpXYZ(LAMMPS *lmp, int narg, char **arg) : Dump(lmp, narg, arg),
 
   delete[] format_default;
 
-  format_default = utils::strdup("%s %g %g %g");
+  if (extxyz_flag) {
+    size_one = 11;
+    format_default = utils::strdup("%s %g %g %g %g %g %g %g %g %g");
+  } else {
+    size_one = 5;
+    format_default = utils::strdup("%s %g %g %g");
+  }
 
   ntypes = atom->ntypes;
   typenames = nullptr;
@@ -159,8 +176,22 @@ void DumpXYZ::write_header(bigint n)
   if (me == 0) {
     if (!fp) error->one(FLERR, "Must not use 'run pre no' after creating a new dump");
 
-    auto header = fmt::format("{}\n Atoms. Timestep: {}", n, update->ntimestep);
-    if (time_flag) header += fmt::format(" Time: {:.6f}", compute_time());
+    std::string header;
+
+    if (extxyz_flag) {
+      header = fmt::format("{}\nTimestep={}", n, update->ntimestep);
+      if (time_flag) header += fmt::format(" Time={:.6f}", compute_time());
+      header += fmt::format(" pbc=\"{} {} {}\"", domain->xperiodic ? "T" : "F",
+                            domain->yperiodic ? "T" : "F", domain->zperiodic ? "T" : "F");
+      header += fmt::format(" Lattice=\"{:g} {:g} {:g} {:g} {:g} {:g} {:g} {:g} {:g}\"",
+                            domain->xprd, 0., 0., domain->xy, domain->yprd, 0.,
+                            domain->xz, domain->yz, domain->zprd);
+      header += " Properties=species:S:1:pos:R:3:vel:R:3:forces:R:3";
+    } else {
+      header = fmt::format("{}\n Atoms. Timestep: {}", n, update->ntimestep);
+      if (time_flag) header += fmt::format(" Time: {:.6f}", compute_time());
+    }
+
     utils::print(fp, header + "\n");
   }
 }
@@ -175,6 +206,8 @@ void DumpXYZ::pack(tagint *ids)
   int *type = atom->type;
   int *mask = atom->mask;
   double **x = atom->x;
+  double **v = atom->v;
+  double **f = atom->f;
   int nlocal = atom->nlocal;
 
   m = n = 0;
@@ -185,6 +218,14 @@ void DumpXYZ::pack(tagint *ids)
       buf[m++] = x[i][0];
       buf[m++] = x[i][1];
       buf[m++] = x[i][2];
+      if (extxyz_flag) {
+        buf[m++] = v[i][0];
+        buf[m++] = v[i][1];
+        buf[m++] = v[i][2];
+        buf[m++] = f[i][0];
+        buf[m++] = f[i][1];
+        buf[m++] = f[i][2];
+      }
       if (ids) ids[n++] = tag[i];
     }
 }
@@ -205,8 +246,14 @@ int DumpXYZ::convert_string(int n, double *mybuf)
       memory->grow(sbuf,maxsbuf,"dump:sbuf");
     }
 
-    offset += snprintf(&sbuf[offset], maxsbuf-offset, format, typenames[static_cast<int> (mybuf[m+1])],
-                      mybuf[m+2], mybuf[m+3], mybuf[m+4]);
+    if (extxyz_flag) {
+      offset += snprintf(&sbuf[offset], maxsbuf-offset, format, typenames[static_cast<int> (mybuf[m+1])],
+                        mybuf[m+2], mybuf[m+3], mybuf[m+4], mybuf[m+5], mybuf[m+6], mybuf[m+7],
+                        mybuf[m+8], mybuf[m+9], mybuf[m+10]);
+    } else {
+      offset += snprintf(&sbuf[offset], maxsbuf-offset, format, typenames[static_cast<int> (mybuf[m+1])],
+                        mybuf[m+2], mybuf[m+3], mybuf[m+4]);
+    }
     m += size_one;
   }
 
@@ -234,9 +281,17 @@ void DumpXYZ::write_lines(int n, double *mybuf)
 {
   int m = 0;
   for (int i = 0; i < n; i++) {
-    fprintf(fp,format,
-            typenames[static_cast<int> (mybuf[m+1])],
-            mybuf[m+2],mybuf[m+3],mybuf[m+4]);
+    if (extxyz_flag) {
+      fprintf(fp,format,
+              typenames[static_cast<int> (mybuf[m+1])],
+              mybuf[m+2],mybuf[m+3],mybuf[m+4],
+              mybuf[m+5],mybuf[m+6],mybuf[m+7],
+              mybuf[m+8],mybuf[m+9],mybuf[m+10]);
+    } else {
+      fprintf(fp,format,
+              typenames[static_cast<int> (mybuf[m+1])],
+              mybuf[m+2],mybuf[m+3],mybuf[m+4]);
+    }
     m += size_one;
   }
 }

--- a/src/dump_xyz.h
+++ b/src/dump_xyz.h
@@ -32,6 +32,7 @@ class DumpXYZ : public Dump {
  protected:
   int ntypes;
   char **typenames;
+  int extxyz_flag;    // 0 if classical XYZ Lammps format, 1 if extended XYZ
 
   void init_style() override;
   void write_header(bigint) override;


### PR DESCRIPTION
**Summary**

Allow extended XYZ (`extxyz`) as a variant of the `dump xyz` style.

**Related Issue(s)**

Fixes https://github.com/lammps/lammps/issues/4471

**Author(s)**

François-Xavier Coudert, CNRS, fxcoudert@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The pull request does not break backward compatibility.

**Implementation Notes**

This is a first version of the pull request, I would really welcome comment.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
