### PR TITLE
First pass at compressed ExtXYZ

### DIFF
--- a/doc/src/dump.rst
+++ b/doc/src/dump.rst
@@ -13,13 +13,15 @@
 .. index:: dump atom/gz
 .. index:: dump cfg/gz
 .. index:: dump custom/gz
+.. index:: dump extxyz/gz
 .. index:: dump local/gz
 .. index:: dump xyz/gz
 .. index:: dump atom/zstd
 .. index:: dump cfg/zstd
 .. index:: dump custom/zstd
-.. index:: dump xyz/zstd
+.. index:: dump extxyz/zstd
 .. index:: dump local/zstd
+.. index:: dump xyz/zstd
 
 dump command
 ============
@@ -60,7 +62,7 @@ Syntax
 
 * ID = user-assigned name for the dump
 * group-ID = ID of the group of atoms to be dumped
-* style = *atom* or *atom/adios* or *atom/gz* or *atom/zstd* or *cfg* or *cfg/gz* or *cfg/zstd* or *cfg/uef* or *custom* or *custom/gz* or *custom/zstd* or *custom/adios* or *dcd* or *extxyz* or *grid* or *grid/vtk* or *h5md* or *image* or *local* or *local/gz* or *local/zstd* or *molfile* or *movie* or *netcdf* or *netcdf/mpiio* or *vtk* or *xtc* or *xyz* or *xyz/gz* or *xyz/zstd* or *yaml*
+* style = *atom* or *atom/adios* or *atom/gz* or *atom/zstd* or *cfg* or *cfg/gz* or *cfg/zstd* or *cfg/uef* or *custom* or *custom/gz* or *custom/zstd* or *custom/adios* or *dcd* or *extxyz* or *extxyz/gz* or *extxyz/zstd* or *grid* or *grid/vtk* or *h5md* or *image* or *local* or *local/gz* or *local/zstd* or *molfile* or *movie* or *netcdf* or *netcdf/mpiio* or *vtk* or *xtc* or *xyz* or *xyz/gz* or *xyz/zstd* or *yaml*
 * N = dump on timesteps which are multiples of N
 * file = name of file to write dump info to
 * attribute1,attribute2,... = list of attributes for a particular style
@@ -79,6 +81,8 @@ Syntax
        *custom/adios* attributes = same as *custom* attributes, discussed on :doc:`dump custom/adios <dump_adios>` page
        *dcd* attributes = none
        *extxyz* attributes = none
+       *extxyz/gz* attributes = none
+       *extxyz/zstd* attributes = none
        *h5md* attributes = discussed on :doc:`dump h5md <dump_h5md>` page
        *grid* attributes = see below
        *grid/vtk* attributes = see below

--- a/src/COMPRESS/dump_extxyz_gz.cpp
+++ b/src/COMPRESS/dump_extxyz_gz.cpp
@@ -1,0 +1,144 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "dump_extxyz_gz.h"
+
+#include "error.h"
+#include "file_writer.h"
+#include "update.h"
+
+#include <cstring>
+
+using namespace LAMMPS_NS;
+
+DumpExtXYZGZ::DumpExtXYZGZ(LAMMPS *lmp, int narg, char **arg) : DumpExtXYZ(lmp, narg, arg)
+{
+  if (!compressed) error->all(FLERR, "Dump extxyz/gz only writes compressed files");
+}
+
+/* ----------------------------------------------------------------------
+   generic opening of a dump file
+   ASCII or binary or compressed
+   some derived classes override this function
+------------------------------------------------------------------------- */
+
+void DumpExtXYZGZ::openfile()
+{
+  // single file, already opened, so just return
+
+  if (singlefile_opened) return;
+  if (multifile == 0) singlefile_opened = 1;
+
+  // if one file per timestep, replace '*' with current timestep
+
+  char *filecurrent = filename;
+  if (multiproc) filecurrent = multiname;
+
+  if (multifile) {
+    filecurrent = utils::strdup(utils::star_subst(filecurrent, update->ntimestep, padflag));
+    if (maxfiles > 0) {
+      if (numfiles < maxfiles) {
+        nameslist[numfiles] = utils::strdup(filecurrent);
+        ++numfiles;
+      } else {
+        if (remove(nameslist[fileidx]) != 0) {
+          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+        }
+        delete[] nameslist[fileidx];
+        nameslist[fileidx] = utils::strdup(filecurrent);
+        fileidx = (fileidx + 1) % maxfiles;
+      }
+    }
+  }
+
+  // each proc with filewriter = 1 opens a file
+
+  if (filewriter) {
+    try {
+      writer.open(filecurrent, append_flag);
+    } catch (FileWriterException &e) {
+      error->one(FLERR, e.what());
+    }
+  }
+
+  // delete string with timestep replaced
+
+  if (multifile) delete[] filecurrent;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpExtXYZGZ::write_header(bigint ndump)
+{
+  if (me == 0) {
+    auto header = header_line(ndump);
+    (void) writer.write(header.c_str(), header.length());
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpExtXYZGZ::write_data(int n, double *mybuf)
+{
+  if (buffer_flag) {
+    (void) writer.write(mybuf, n);
+  } else {
+    constexpr size_t VBUFFER_SIZE = 256;
+    char vbuffer[VBUFFER_SIZE];
+    int m = 0;
+    for (int i = 0; i < n; i++) {
+      int written =
+          DumpExtXYZ::snprintf_worker(vbuffer, VBUFFER_SIZE, format, mybuf, m);
+      if (written > 0) {
+        (void) writer.write(vbuffer, written);
+      } else if (written < 0) {
+        error->one(FLERR, "Error while writing dump extxyz/gz output");
+      }
+      m += size_one;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpExtXYZGZ::write()
+{
+  DumpExtXYZ::write();
+  if (filewriter) {
+    if (multifile) {
+      writer.close();
+    } else {
+      if (flush_flag && writer.isopen()) { writer.flush(); }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+int DumpExtXYZGZ::modify_param(int narg, char **arg)
+{
+  int consumed = DumpExtXYZ::modify_param(narg, arg);
+  if (consumed == 0) {
+    try {
+      if (strcmp(arg[0], "compression_level") == 0) {
+        if (narg < 2) error->all(FLERR, "Illegal dump_modify command");
+        int compression_level = utils::inumeric(FLERR, arg[1], false, lmp);
+        writer.setCompressionLevel(compression_level);
+        return 2;
+      }
+    } catch (FileWriterException &e) {
+      error->one(FLERR, "Illegal dump_modify command: {}", e.what());
+    }
+  }
+  return consumed;
+}

--- a/src/COMPRESS/dump_extxyz_gz.h
+++ b/src/COMPRESS/dump_extxyz_gz.h
@@ -13,40 +13,34 @@
 
 #ifdef DUMP_CLASS
 // clang-format off
-DumpStyle(extxyz,DumpExtXYZ);
+DumpStyle(extxyz/gz,DumpExtXYZGZ);
 // clang-format on
 #else
 
-#ifndef LMP_DUMP_EXTXYZ_H
-#define LMP_DUMP_EXTXYZ_H
+#ifndef LMP_DUMP_EXTXYZ_GZ_H
+#define LMP_DUMP_EXTXYZ_GZ_H
 
-#include "dump_xyz.h"
+#include "dump_extxyz.h"
+#include "gz_file_writer.h"
 
 namespace LAMMPS_NS {
-class DumpExtXYZ : public DumpXYZ {
+
+class DumpExtXYZGZ : public DumpExtXYZ {
  public:
-  DumpExtXYZ(class LAMMPS *, int, char **);
+  DumpExtXYZGZ(class LAMMPS *, int, char **);
 
  protected:
-  int with_vel;
-  int with_forces;
-  int with_mass;
-  int with_pe;
-  int with_temp;
-  int with_press;
-  char *properties_string;
+  GzFileWriter writer;
 
-  void update_properties();
-  void init_style() override;
-  std::string header_line(bigint);
+  void openfile() override;
   void write_header(bigint) override;
-  void pack(tagint *) override;
-  int convert_string(int, double *) override;
-  int modify_param(int, char **) override;
+  void write_data(int, double *) override;
+  void write() override;
 
-  int snprintf_worker(char *, int, char *, double *, int);
-  void write_lines(int, double *) override;
+  int modify_param(int, char **) override;
 };
+
 }    // namespace LAMMPS_NS
+
 #endif
 #endif

--- a/src/COMPRESS/dump_extxyz_zstd.cpp
+++ b/src/COMPRESS/dump_extxyz_zstd.cpp
@@ -1,0 +1,157 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Richard Berger (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef LAMMPS_ZSTD
+
+#include "dump_extxyz_zstd.h"
+
+#include "error.h"
+#include "file_writer.h"
+#include "update.h"
+
+#include <cstring>
+
+using namespace LAMMPS_NS;
+
+DumpExtXYZZstd::DumpExtXYZZstd(LAMMPS *lmp, int narg, char **arg) : DumpExtXYZ(lmp, narg, arg)
+{
+  if (!compressed) error->all(FLERR, "Dump extxyz/zstd only writes compressed files");
+}
+
+/* ----------------------------------------------------------------------
+   generic opening of a dump file
+   ASCII or binary or compressed
+   some derived classes override this function
+------------------------------------------------------------------------- */
+
+void DumpExtXYZZstd::openfile()
+{
+  // single file, already opened, so just return
+
+  if (singlefile_opened) return;
+  if (multifile == 0) singlefile_opened = 1;
+
+  // if one file per timestep, replace '*' with current timestep
+
+  char *filecurrent = filename;
+  if (multiproc) filecurrent = multiname;
+
+  if (multifile) {
+    filecurrent = utils::strdup(utils::star_subst(filecurrent, update->ntimestep, padflag));
+    if (maxfiles > 0) {
+      if (numfiles < maxfiles) {
+        nameslist[numfiles] = utils::strdup(filecurrent);
+        ++numfiles;
+      } else {
+        if (remove(nameslist[fileidx]) != 0) {
+          error->warning(FLERR, fmt::format("Could not delete {}", nameslist[fileidx]));
+        }
+        delete[] nameslist[fileidx];
+        nameslist[fileidx] = utils::strdup(filecurrent);
+        fileidx = (fileidx + 1) % maxfiles;
+      }
+    }
+  }
+
+  // each proc with filewriter = 1 opens a file
+
+  if (filewriter) {
+    if (append_flag) { error->one(FLERR, "dump extxyz/zstd currently doesn't support append"); }
+
+    try {
+      writer.open(filecurrent);
+    } catch (FileWriterException &e) {
+      error->one(FLERR, e.what());
+    }
+  }
+
+  // delete string with timestep replaced
+
+  if (multifile) delete[] filecurrent;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpExtXYZZstd::write_header(bigint ndump)
+{
+  if (me == 0) {
+    auto header = header_line(ndump);
+    (void) writer.write(header.c_str(), header.length());
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpExtXYZZstd::write_data(int n, double *mybuf)
+{
+  if (buffer_flag) {
+    (void) writer.write(mybuf, n);
+  } else {
+    constexpr size_t VBUFFER_SIZE = 256;
+    char vbuffer[VBUFFER_SIZE];
+    int m = 0;
+    for (int i = 0; i < n; i++) {
+      int written =
+          DumpExtXYZ::snprintf_worker(vbuffer, VBUFFER_SIZE, format, mybuf, m);
+      if (written > 0) {
+        (void) writer.write(vbuffer, written);
+      } else if (written < 0) {
+        error->one(FLERR, "Error while writing dump extxyz/zstd output");
+      }
+      m += size_one;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpExtXYZZstd::write()
+{
+  DumpExtXYZ::write();
+  if (filewriter) {
+    if (multifile) {
+      writer.close();
+    } else {
+      if (flush_flag && writer.isopen()) { writer.flush(); }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+int DumpExtXYZZstd::modify_param(int narg, char **arg)
+{
+  int consumed = DumpExtXYZ::modify_param(narg, arg);
+  if (consumed == 0) {
+    try {
+      if (strcmp(arg[0], "checksum") == 0) {
+        if (narg < 2) error->all(FLERR, "Illegal dump_modify command");
+        writer.setChecksum(utils::logical(FLERR, arg[1], false, lmp) == 1);
+        return 2;
+      } else if (strcmp(arg[0], "compression_level") == 0) {
+        if (narg < 2) error->all(FLERR, "Illegal dump_modify command");
+        writer.setCompressionLevel(utils::inumeric(FLERR, arg[1], false, lmp));
+        return 2;
+      }
+    } catch (FileWriterException &e) {
+      error->one(FLERR, "Illegal dump_modify command: {}", e.what());
+    }
+  }
+  return consumed;
+}
+
+#endif

--- a/src/COMPRESS/dump_extxyz_zstd.h
+++ b/src/COMPRESS/dump_extxyz_zstd.h
@@ -11,42 +11,43 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Contributing author: Richard Berger (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef LAMMPS_ZSTD
+
 #ifdef DUMP_CLASS
 // clang-format off
-DumpStyle(extxyz,DumpExtXYZ);
+DumpStyle(extxyz/zstd,DumpExtXYZZstd);
 // clang-format on
 #else
 
-#ifndef LMP_DUMP_EXTXYZ_H
-#define LMP_DUMP_EXTXYZ_H
+#ifndef LMP_DUMP_EXTXYZ_ZSTD_H
+#define LMP_DUMP_EXTXYZ_ZSTD_H
 
-#include "dump_xyz.h"
+#include "dump_extxyz.h"
+#include "zstd_file_writer.h"
 
 namespace LAMMPS_NS {
-class DumpExtXYZ : public DumpXYZ {
+
+class DumpExtXYZZstd : public DumpExtXYZ {
  public:
-  DumpExtXYZ(class LAMMPS *, int, char **);
+  DumpExtXYZZstd(class LAMMPS *, int, char **);
 
  protected:
-  int with_vel;
-  int with_forces;
-  int with_mass;
-  int with_pe;
-  int with_temp;
-  int with_press;
-  char *properties_string;
+  ZstdFileWriter writer;
 
-  void update_properties();
-  void init_style() override;
-  std::string header_line(bigint);
+  void openfile() override;
   void write_header(bigint) override;
-  void pack(tagint *) override;
-  int convert_string(int, double *) override;
-  int modify_param(int, char **) override;
+  void write_data(int, double *) override;
+  void write() override;
 
-  int snprintf_worker(char *, int, char *, double *, int);
-  void write_lines(int, double *) override;
+  int modify_param(int, char **) override;
 };
+
 }    // namespace LAMMPS_NS
+
+#endif
 #endif
 #endif

--- a/src/EXTRA-DUMP/dump_extxyz.cpp
+++ b/src/EXTRA-DUMP/dump_extxyz.cpp
@@ -129,39 +129,46 @@ int DumpExtXYZ::modify_param(int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
+std::string DumpExtXYZ::header_line(bigint n)
+{
+  std::string header = fmt::format("{}\nTimestep={}", n, update->ntimestep);
+  if (time_flag) header += fmt::format(" Time={:.6f}", compute_time());
+  header += fmt::format(" pbc=\"{} {} {}\"", domain->xperiodic ? "T" : "F",
+                        domain->yperiodic ? "T" : "F", domain->zperiodic ? "T" : "F");
+  header +=
+      fmt::format(" Lattice=\"{:g} {:g} {:g} {:g} {:g} {:g} {:g} {:g} {:g}\"", domain->xprd, 0.,
+                  0., domain->xy, domain->yprd, 0., domain->xz, domain->yz, domain->zprd);
+
+  if (output && output->thermo) {
+    auto *pe = output->thermo->pe;
+    if (pe) header += fmt::format(" Potential_energy={}", pe->compute_scalar());
+
+    auto *temp = output->thermo->temperature;
+    if (temp) header += fmt::format(" Temperature={}", temp->compute_scalar());
+
+    auto *press = output->thermo->pressure;
+    if (press) {
+      press->compute_vector();
+      header +=
+          fmt::format(" Stress=\"{} {} {} {} {} {} {} {} {}\"", press->vector[0],
+                      press->vector[3], press->vector[4], press->vector[3], press->vector[1],
+                      press->vector[5], press->vector[4], press->vector[5], press->vector[2]);
+    }
+  }
+
+  header += fmt::format(" Properties={}\n", properties_string);
+  return header;
+}
+
+/* ---------------------------------------------------------------------- */
+
 void DumpExtXYZ::write_header(bigint n)
 {
   if (me == 0) {
     if (!fp)
       error->one(FLERR, Error::NOLASTLINE, "Must not use 'run pre no' after creating a new dump");
 
-    std::string header = fmt::format("{}\nTimestep={}", n, update->ntimestep);
-    if (time_flag) header += fmt::format(" Time={:.6f}", compute_time());
-    header += fmt::format(" pbc=\"{} {} {}\"", domain->xperiodic ? "T" : "F",
-                          domain->yperiodic ? "T" : "F", domain->zperiodic ? "T" : "F");
-    header +=
-        fmt::format(" Lattice=\"{:g} {:g} {:g} {:g} {:g} {:g} {:g} {:g} {:g}\"", domain->xprd, 0.,
-                    0., domain->xy, domain->yprd, 0., domain->xz, domain->yz, domain->zprd);
-
-    if (output && output->thermo) {
-      auto *pe = output->thermo->pe;
-      if (pe) header += fmt::format(" Potential_energy={}", pe->compute_scalar());
-
-      auto *temp = output->thermo->temperature;
-      if (temp) header += fmt::format(" Temperature={}", temp->compute_scalar());
-
-      auto *press = output->thermo->pressure;
-      if (press) {
-        press->compute_vector();
-        header +=
-            fmt::format(" Stress=\"{} {} {} {} {} {} {} {} {}\"", press->vector[0],
-                        press->vector[3], press->vector[4], press->vector[3], press->vector[1],
-                        press->vector[5], press->vector[4], press->vector[5], press->vector[2]);
-      }
-    }
-
-    header += fmt::format(" Properties={}", properties_string);
-    utils::print(fp, header + "\n");
+    utils::print(fp, header_line(n));
   }
 }
 
@@ -211,6 +218,42 @@ void DumpExtXYZ::pack(tagint *ids)
     }
 }
 
+/* ---------------------------------------------------------------------- */
+
+int DumpExtXYZ::snprintf_worker(char *sbuf, int len, char *format, double *buf, int m)
+{
+  if (size_one == 5) {
+    return snprintf(sbuf, len, format,
+                    typenames[static_cast<int>(buf[m + 1])], buf[m + 2], buf[m + 3],
+                    buf[m + 4]);
+  } else if (size_one == 6) {
+    return snprintf(sbuf, len, format,
+                    typenames[static_cast<int>(buf[m + 1])], buf[m + 2], buf[m + 3],
+                    buf[m + 4], buf[m + 5]);
+  } else if (size_one == 8) {
+    return snprintf(sbuf, len, format,
+                    typenames[static_cast<int>(buf[m + 1])], buf[m + 2], buf[m + 3],
+                    buf[m + 4], buf[m + 5], buf[m + 6], buf[m + 7]);
+  } else if (size_one == 9) {
+    return snprintf(sbuf, len, format,
+                    typenames[static_cast<int>(buf[m + 1])], buf[m + 2], buf[m + 3],
+                    buf[m + 4], buf[m + 5], buf[m + 6], buf[m + 7], buf[m + 8]);
+  } else if (size_one == 11) {
+    return snprintf(sbuf, len, format,
+                    typenames[static_cast<int>(buf[m + 1])], buf[m + 2], buf[m + 3],
+                    buf[m + 4], buf[m + 5], buf[m + 6], buf[m + 7], buf[m + 8],
+                    buf[m + 9], buf[m + 10]);
+  } else if (size_one == 12) {
+    return snprintf(sbuf, len, format,
+                    typenames[static_cast<int>(buf[m + 1])], buf[m + 2], buf[m + 3],
+                    buf[m + 4], buf[m + 5], buf[m + 6], buf[m + 7], buf[m + 8],
+                    buf[m + 9], buf[m + 10], buf[m + 11]);
+  } else {
+    error->all(FLERR, "Invalid value of size_one for dump extxyz format.");
+    return 0;
+  }
+}
+
 /* ----------------------------------------------------------------------
    convert mybuf of doubles to one big formatted string in sbuf
    return -1 if strlen exceeds an int, since used as arg in MPI calls in Dump
@@ -227,35 +270,7 @@ int DumpExtXYZ::convert_string(int n, double *mybuf)
       memory->grow(sbuf, maxsbuf, "dump:sbuf");
     }
 
-    if (size_one == 5) {
-      offset += snprintf(&sbuf[offset], maxsbuf - offset, format,
-                         typenames[static_cast<int>(mybuf[m + 1])], mybuf[m + 2], mybuf[m + 3],
-                         mybuf[m + 4]);
-    } else if (size_one == 6) {
-      offset += snprintf(&sbuf[offset], maxsbuf - offset, format,
-                         typenames[static_cast<int>(mybuf[m + 1])], mybuf[m + 2], mybuf[m + 3],
-                         mybuf[m + 4], mybuf[m + 5]);
-    } else if (size_one == 8) {
-      offset += snprintf(&sbuf[offset], maxsbuf - offset, format,
-                         typenames[static_cast<int>(mybuf[m + 1])], mybuf[m + 2], mybuf[m + 3],
-                         mybuf[m + 4], mybuf[m + 5], mybuf[m + 6], mybuf[m + 7]);
-    } else if (size_one == 9) {
-      offset += snprintf(&sbuf[offset], maxsbuf - offset, format,
-                         typenames[static_cast<int>(mybuf[m + 1])], mybuf[m + 2], mybuf[m + 3],
-                         mybuf[m + 4], mybuf[m + 5], mybuf[m + 6], mybuf[m + 7], mybuf[m + 8]);
-    } else if (size_one == 11) {
-      offset += snprintf(&sbuf[offset], maxsbuf - offset, format,
-                         typenames[static_cast<int>(mybuf[m + 1])], mybuf[m + 2], mybuf[m + 3],
-                         mybuf[m + 4], mybuf[m + 5], mybuf[m + 6], mybuf[m + 7], mybuf[m + 8],
-                         mybuf[m + 9], mybuf[m + 10]);
-    } else if (size_one == 12) {
-      offset += snprintf(&sbuf[offset], maxsbuf - offset, format,
-                         typenames[static_cast<int>(mybuf[m + 1])], mybuf[m + 2], mybuf[m + 3],
-                         mybuf[m + 4], mybuf[m + 5], mybuf[m + 6], mybuf[m + 7], mybuf[m + 8],
-                         mybuf[m + 9], mybuf[m + 10], mybuf[m + 11]);
-    } else {
-      error->all(FLERR, "Invalid value of size_one for dump extxyz format.");
-    }
+    offset += snprintf_worker(&sbuf[offset], maxsbuf - offset, format, mybuf, m);
     m += size_one;
   }
 


### PR DESCRIPTION
**Summary**

Provide compressed versions (gz and zstd) of extended XYZ (extxyz) dump style.

**Author(s)**

François-Xavier Coudert, CNRS

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

The pull request does not break backward compatibility.

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included
