### PR TITLE
Fixed invalid ref of coeffs

### DIFF
--- a/src/KOKKOS/mliap_model_kokkos.h
+++ b/src/KOKKOS/mliap_model_kokkos.h
@@ -35,6 +35,7 @@ template <class DeviceType> class MLIAPModelKokkos : protected Pointers {
 
   void set_k_coeffelem()
   {
+    if ( model->coeffelem == nullptr ) return; 
     double **tmp = nullptr;
     memoryKK->create_kokkos(k_coeffelem, tmp, model->nelements, model->nparams,
                             "MLIAPModelKokkos::coeffelem");

--- a/src/KOKKOS/mliap_model_kokkos.h
+++ b/src/KOKKOS/mliap_model_kokkos.h
@@ -35,7 +35,8 @@ template <class DeviceType> class MLIAPModelKokkos : protected Pointers {
 
   void set_k_coeffelem()
   {
-    if ( model->coeffelem == nullptr ) return; 
+    if ( model->coeffelem == nullptr )
+      return;
     double **tmp = nullptr;
     memoryKK->create_kokkos(k_coeffelem, tmp, model->nelements, model->nparams,
                             "MLIAPModelKokkos::coeffelem");

--- a/src/KOKKOS/mliap_model_python_kokkos.cpp
+++ b/src/KOKKOS/mliap_model_python_kokkos.cpp
@@ -76,9 +76,11 @@ MLIAPModelPythonKokkos<DeviceType>::MLIAPModelPythonKokkos(LAMMPS *lmp, char *co
     PyList_Append(py_path, PyUnicode_FromString(potentials_path));
   }
   PyGILState_Release(gstate);
-  if (coefffilename) read_coeffs(coefffilename);
+  if (coefffilename) {
+    read_coeffs(coefffilename);
+    MLIAPModelKokkos<DeviceType>::set_k_coeffelem();
+  }
 
-  if (coefffilename) MLIAPModelKokkos<DeviceType>::set_k_coeffelem();
 
   nonlinearflag = 1;
 }


### PR DESCRIPTION
**Summary**

<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->

**Related Issue(s)**
Closes #4526

Minor change, tested

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->



Before you'd see 
```
[3555c9209238:33825:0:33825] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
```
Now you get 
```
Per MPI rank memory allocation (min/avg/max) = 19.37 | 19.37 | 19.37 Mbytes
   Step          Temp          E_pair        c_energy        TotEng         Press         v_press    
         0   300           -11.85157      -11.85157      -11.813095      2717.1661     -2717.1661    
        10   296.01467     -11.851059     -11.851059     -11.813095      2697.4796     -2697.4796    
        20   284.53666     -11.849587     -11.849587     -11.813095      2289.1527     -2289.1527    
        30   266.51577     -11.847275     -11.847275     -11.813095      1851.7131     -1851.7131    
        40   243.05007     -11.844266     -11.844266     -11.813095      1570.684      -1570.684     
        50   215.51032     -11.840734     -11.840734     -11.813094      1468.1899     -1468.1899    
        60   185.48331     -11.836883     -11.836883     -11.813094      1524.8757     -1524.8757    
        70   154.6736      -11.832931     -11.832931     -11.813094      1698.3351     -1698.3351    
        80   124.79303     -11.829099     -11.829099     -11.813094      1947.0715     -1947.0715    
        90   97.448054     -11.825592     -11.825592     -11.813094      2231.9563     -2231.9563    
       100   74.035418     -11.822589     -11.822589     -11.813094      2515.8526     -2515.8526    
```


