### PR TITLE
extend fix adapt to treat dihedrals

### DIFF
--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -464,6 +464,8 @@ sub-style name. The dihedral styles that currently work with fix adapt are:
 +------------------------------------------------------------------------+----------------+----------------+
 | :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`  | k,phi0         | type dihedrals |
 +------------------------------------------------------------------------+----------------+----------------+
+| :doc:`helix <dihedral_helix>`                                          | a,b,c          | type dihedrals |
++------------------------------------------------------------------------+----------------+----------------+
 | :doc:`multi/harmonic <dihedral_multi_harmonic>`                        | a1,a2,a3,a4,a5 | type dihedrals |
 +------------------------------------------------------------------------+----------------+----------------+
 | :doc:`opls <dihedral_opls>`                                            | k1,k2,k3,k4    | type dihedrals |

--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -457,21 +457,23 @@ all types from 1 to :math:`N`.  A leading asterisk means all types from
 If :doc:`dihedral_style hybrid <dihedral_hybrid>` is used, *dstyle* should be a
 sub-style name. The dihedral styles that currently work with fix adapt are:
 
-+------------------------------------------------------------------------+----------------+----------------+
-| :doc:`charmm  <dihedral_charmm>`                                       | k,n,d          | type dihedrals |
-+------------------------------------------------------------------------+----------------+----------------+
-| :doc:`charmmfsw <dihedral_charmm>`                                     | k,n,d          | type dihedrals |
-+------------------------------------------------------------------------+----------------+----------------+
-| :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`  | k,phi0         | type dihedrals |
-+------------------------------------------------------------------------+----------------+----------------+
-| :doc:`helix <dihedral_helix>`                                          | a,b,c          | type dihedrals |
-+------------------------------------------------------------------------+----------------+----------------+
-| :doc:`multi/harmonic <dihedral_multi_harmonic>`                        | a1,a2,a3,a4,a5 | type dihedrals |
-+------------------------------------------------------------------------+----------------+----------------+
-| :doc:`opls <dihedral_opls>`                                            | k1,k2,k3,k4    | type dihedrals |
-+------------------------------------------------------------------------+----------------+----------------+
-| :doc:`quadratic <dihedral_quadratic>`                                  | k,phi0         | type dihedrals |
-+------------------------------------------------------------------------+----------------+----------------+
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`charmm  <dihedral_charmm>`                                       | k,n,d                   | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`charmmfsw <dihedral_charmm>`                                     | k,n,d                   | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`class2 <dihedral_class2>`                                        | k1,k2,k3,phi1,phi2,phi3 | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`  | k,phi0                  | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`helix <dihedral_helix>`                                          | a,b,c                   | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`multi/harmonic <dihedral_multi_harmonic>`                        | a1,a2,a3,a4,a5          | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`opls <dihedral_opls>`                                            | k1,k2,k3,k4             | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
+| :doc:`quadratic <dihedral_quadratic>`                                  | k,phi0                  | type dihedrals |
++------------------------------------------------------------------------+-------------------------+----------------+
 
 Note that internally, phi0 is stored in radians, so the variable
 this fix use to reset phi0 needs to generate values in radians.

--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -457,11 +457,13 @@ all types from 1 to :math:`N`.  A leading asterisk means all types from
 If :doc:`dihedral_style hybrid <dihedral_hybrid>` is used, *dstyle* should be a
 sub-style name. The dihedral styles that currently work with fix adapt are:
 
-+---------------------------------------------------------+----------------+----------------+
-| :doc:`opls <dihedral_opls>`                             | k1,k2,k3,k4    | type dihedrals |
-+---------------------------------------------------------+----------------+----------------+
-| :doc:`quadratic <dihedral_quadratic>`                   | k,phi0         | type dihedrals |
-+---------------------------------------------------------+----------------+----------------+
++------------------------------------------------------------------------+----------------+----------------+
+| :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`  | k,phi0         | type dihedrals |
++------------------------------------------------------------------------+----------------+----------------+
+| :doc:`opls <dihedral_opls>`                                            | k1,k2,k3,k4    | type dihedrals |
++------------------------------------------------------------------------+----------------+----------------+
+| :doc:`quadratic <dihedral_quadratic>`                                  | k,phi0         | type dihedrals |
++------------------------------------------------------------------------+----------------+----------------+
 
 Note that internally, phi0 is stored in radians, so the variable
 this fix use to reset phi0 needs to generate values in radians.

--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -14,7 +14,7 @@ Syntax
 * adapt = style name of this fix command
 * N = adapt simulation settings every this many timesteps
 * one or more attribute/arg pairs may be appended
-* attribute = *pair* or *bond* or *angle* or *improper* or *kspace* or *atom*
+* attribute = *pair* or *bond* or *angle* or *dihedral* or *improper* or *kspace* or *atom*
 
   .. parsed-literal::
 
@@ -33,6 +33,11 @@ Syntax
          aparam = parameter to adapt over time
          I = type angle to set parameter for (integer or type label)
          v_name = variable with name that calculates value of aparam
+       *dihedral* args = dstyle dparam I v_name
+         dstyle = dihedral style name (e.g., quadratic)
+         dparam = parameter to adapt over time
+         I = type dihedral to set parameter for (integer or type label)
+         v_name = variable with name that calculates value of iparam
        *improper* args = istyle iparam I v_name
          istyle = improper style name (e.g., cvff)
          iparam = parameter to adapt over time
@@ -430,6 +435,34 @@ sub-style name. The angle styles that currently work with fix adapt are:
 
 Note that internally, theta0 is stored in radians, so the variable
 this fix uses to reset theta0 needs to generate values in radians.
+
+----------
+
+.. versionadded:: TBD
+
+The *dihedral* keyword uses the specified variable to change the value of
+a dihedral coefficient over time, very similar to how the *angle* keyword
+operates. The only difference is that now a dihedral coefficient for a
+given dihedral type is adapted.
+
+A wild-card asterisk can be used in place of or in conjunction with the
+dihedral type argument to set the coefficients for multiple dihedral types.
+This takes the form "\*" or "\*n" or "m\*" or "m\*n".  If :math:`N` is
+the number of dihedral types, then an asterisk with no numeric values means
+all types from 1 to :math:`N`.  A leading asterisk means all types from
+1 to n (inclusive).  A trailing asterisk means all types from m to
+:math:`N` (inclusive).  A middle asterisk means all types from m to n
+(inclusive).
+
+If :doc:`dihedral_style hybrid <dihedral_hybrid>` is used, *dstyle* should be a
+sub-style name. The dihedral styles that currently work with fix adapt are:
+
++---------------------------------------------------------+----------------+----------------+
+| :doc:`quadratic <dihedral_quadratic>`                   | k,phi0         | type dihedrals |
++---------------------------------------------------------+----------------+----------------+
+
+Note that internally, phi0 is stored in radians, so the variable
+this fix use to reset phi0 needs to generate values in radians.
 
 ----------
 

--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -458,6 +458,10 @@ If :doc:`dihedral_style hybrid <dihedral_hybrid>` is used, *dstyle* should be a
 sub-style name. The dihedral styles that currently work with fix adapt are:
 
 +------------------------------------------------------------------------+----------------+----------------+
+| :doc:`charmm  <dihedral_charmm>`                                       | k,n,d          | type dihedrals |
++------------------------------------------------------------------------+----------------+----------------+
+| :doc:`charmmfsw <dihedral_charmm>`                                     | k,n,d          | type dihedrals |
++------------------------------------------------------------------------+----------------+----------------+
 | :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`  | k,phi0         | type dihedrals |
 +------------------------------------------------------------------------+----------------+----------------+
 | :doc:`opls <dihedral_opls>`                                            | k1,k2,k3,k4    | type dihedrals |

--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -458,6 +458,8 @@ If :doc:`dihedral_style hybrid <dihedral_hybrid>` is used, *dstyle* should be a
 sub-style name. The dihedral styles that currently work with fix adapt are:
 
 +---------------------------------------------------------+----------------+----------------+
+| :doc:`opls <dihedral_opls>`                             | k1,k2,k3,k4    | type dihedrals |
++---------------------------------------------------------+----------------+----------------+
 | :doc:`quadratic <dihedral_quadratic>`                   | k,phi0         | type dihedrals |
 +---------------------------------------------------------+----------------+----------------+
 

--- a/doc/src/fix_adapt.rst
+++ b/doc/src/fix_adapt.rst
@@ -464,6 +464,8 @@ sub-style name. The dihedral styles that currently work with fix adapt are:
 +------------------------------------------------------------------------+----------------+----------------+
 | :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`  | k,phi0         | type dihedrals |
 +------------------------------------------------------------------------+----------------+----------------+
+| :doc:`multi/harmonic <dihedral_multi_harmonic>`                        | a1,a2,a3,a4,a5 | type dihedrals |
++------------------------------------------------------------------------+----------------+----------------+
 | :doc:`opls <dihedral_opls>`                                            | k1,k2,k3,k4    | type dihedrals |
 +------------------------------------------------------------------------+----------------+----------------+
 | :doc:`quadratic <dihedral_quadratic>`                                  | k,phi0         | type dihedrals |

--- a/src/CLASS2/dihedral_class2.cpp
+++ b/src/CLASS2/dihedral_class2.cpp
@@ -946,3 +946,18 @@ void DihedralClass2::write_data(FILE *fp)
             at_theta0_1[i]*180.0/MY_PI,at_theta0_2[i]*180.0/MY_PI);
 }
 
+/* ----------------------------------------------------------------------
+    return ptr to internal members upon request
+ ------------------------------------------------------------------------ */
+
+ void *DihedralClass2::extract(const char *str, int &dim)
+ {
+   dim = 1;
+   if (strcmp(str, "k1") == 0) return (void *) k1;
+   if (strcmp(str, "k2") == 0) return (void *) k2;
+   if (strcmp(str, "k3") == 0) return (void *) k3;
+   if (strcmp(str, "phi1") == 0) return (void *) phi1;
+   if (strcmp(str, "phi2") == 0) return (void *) phi2;
+   if (strcmp(str, "phi3") == 0) return (void *) phi3;
+   return nullptr;
+ }

--- a/src/CLASS2/dihedral_class2.h
+++ b/src/CLASS2/dihedral_class2.h
@@ -33,6 +33,7 @@ class DihedralClass2 : public Dihedral {
   void write_restart(FILE *) override;
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double *k1, *k2, *k3;

--- a/src/EXTRA-MOLECULE/dihedral_cosine_squared_restricted.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_cosine_squared_restricted.cpp
@@ -396,12 +396,12 @@ void DihedralCosineSquaredRestricted::born_matrix(int nd, int i1, int i2, int i3
 
 /* ----------------------------------------------------------------------
     return ptr to internal members upon request
- ------------------------------------------------------------------------ */
- 
- void *DihedralCosineSquaredRestricted::extract(const char *str, int &dim)
- {
-   dim = 1;
-   if (strcmp(str, "k") == 0) return (void *) k;
-   if (strcmp(str, "phi0") == 0) return (void *) phi0;
-   return nullptr;
- }
+------------------------------------------------------------------------ */
+
+void *DihedralCosineSquaredRestricted::extract(const char *str, int &dim)
+{
+  dim = 1;
+  if (strcmp(str, "k") == 0) return (void *) k;
+  if (strcmp(str, "phi0") == 0) return (void *) phi0;
+  return nullptr;
+}

--- a/src/EXTRA-MOLECULE/dihedral_cosine_squared_restricted.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_cosine_squared_restricted.cpp
@@ -393,3 +393,15 @@ void DihedralCosineSquaredRestricted::born_matrix(int nd, int i1, int i2, int i3
 
   du2 = 2 * k[type] * numerator / denominator;
 }
+
+/* ----------------------------------------------------------------------
+    return ptr to internal members upon request
+ ------------------------------------------------------------------------ */
+ 
+ void *DihedralCosineSquaredRestricted::extract(const char *str, int &dim)
+ {
+   dim = 1;
+   if (strcmp(str, "k") == 0) return (void *) k;
+   if (strcmp(str, "phi0") == 0) return (void *) phi0;
+   return nullptr;
+ }

--- a/src/EXTRA-MOLECULE/dihedral_cosine_squared_restricted.h
+++ b/src/EXTRA-MOLECULE/dihedral_cosine_squared_restricted.h
@@ -34,6 +34,7 @@ class DihedralCosineSquaredRestricted : public Dihedral {
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
   void born_matrix(int, int, int, int, int, double &, double &) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double *k, *phi0;

--- a/src/EXTRA-MOLECULE/dihedral_helix.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_helix.cpp
@@ -430,3 +430,16 @@ void DihedralHelix::born_matrix(int nd, int i1, int i2, int i3, int i4,
   du2 = -(9.0*bphi[type]*cos(3.0*phi) + cphi[type]*cos(phi + MY_PI4))*siinv*siinv +
           (3.0*bphi[type]*sin(3.0*phi) + cphi[type]*sin(phi + MY_PI4))*c*siinv*siinv*siinv;
 }
+
+/* ----------------------------------------------------------------------
+    return ptr to internal members upon request
+ ------------------------------------------------------------------------ */
+
+ void *DihedralHelix::extract(const char *str, int &dim)
+ {
+   dim = 1;
+   if (strcmp(str, "a") == 0) return (void *) aphi;
+   if (strcmp(str, "b") == 0) return (void *) bphi;
+   if (strcmp(str, "c") == 0) return (void *) cphi;
+   return nullptr;
+ }

--- a/src/EXTRA-MOLECULE/dihedral_helix.h
+++ b/src/EXTRA-MOLECULE/dihedral_helix.h
@@ -34,6 +34,7 @@ class DihedralHelix : public Dihedral {
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
   void born_matrix(int, int, int, int, int, double &, double &) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double *aphi, *bphi, *cphi;

--- a/src/EXTRA-MOLECULE/dihedral_quadratic.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_quadratic.cpp
@@ -435,3 +435,15 @@ void DihedralQuadratic::born_matrix(int nd, int i1, int i2, int i3, int i4,
   du = - 2.0 * k[type] * dphi * siinv;
   du2 = 2.0 * k[type] * siinv * siinv * ( 1.0 - dphi * c * siinv) ;
 }
+
+/* ----------------------------------------------------------------------
+   return ptr to internal members upon request
+------------------------------------------------------------------------ */
+
+void *DihedralQuadratic::extract(const char *str, int &dim)
+{
+  dim = 1;
+  if (strcmp(str, "k") == 0) return (void *) k0;
+  if (strcmp(str, "phi0") == 0) return (void *) phi0;
+  return nullptr;
+}

--- a/src/EXTRA-MOLECULE/dihedral_quadratic.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_quadratic.cpp
@@ -443,7 +443,7 @@ void DihedralQuadratic::born_matrix(int nd, int i1, int i2, int i3, int i4,
 void *DihedralQuadratic::extract(const char *str, int &dim)
 {
   dim = 1;
-  if (strcmp(str, "k") == 0) return (void *) k0;
+  if (strcmp(str, "k") == 0) return (void *) k;
   if (strcmp(str, "phi0") == 0) return (void *) phi0;
   return nullptr;
 }

--- a/src/EXTRA-MOLECULE/dihedral_quadratic.h
+++ b/src/EXTRA-MOLECULE/dihedral_quadratic.h
@@ -34,6 +34,7 @@ class DihedralQuadratic : public Dihedral {
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
   void born_matrix(int, int, int, int, int, double &, double &) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double *k, *phi0;

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -432,3 +432,16 @@ void DihedralCharmm::write_data(FILE *fp)
   for (int i = 1; i <= atom->ndihedraltypes; i++)
     fprintf(fp, "%d %g %d %d %g\n", i, k[i], multiplicity[i], shift[i], weight[i]);
 }
+
+ /* ----------------------------------------------------------------------
+    return ptr to internal members upon request
+ ------------------------------------------------------------------------ */
+ 
+ void *DihedralCharmm::extract(const char *str, int &dim)
+ {
+   dim = 1;
+   if (strcmp(str, "k") == 0) return (void *) k0;
+   if (strcmp(str, "n") == 0) return (void *) multiplicity;
+   if (strcmp(str, "d") == 0) return (void *) shift;
+   return nullptr;
+ }

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -433,15 +433,15 @@ void DihedralCharmm::write_data(FILE *fp)
     fprintf(fp, "%d %g %d %d %g\n", i, k[i], multiplicity[i], shift[i], weight[i]);
 }
 
- /* ----------------------------------------------------------------------
-    return ptr to internal members upon request
- ------------------------------------------------------------------------ */
- 
- void *DihedralCharmm::extract(const char *str, int &dim)
- {
-   dim = 1;
-   if (strcmp(str, "k") == 0) return (void *) k;
-   if (strcmp(str, "n") == 0) return (void *) multiplicity;
-   if (strcmp(str, "d") == 0) return (void *) shift;
-   return nullptr;
- }
+/* ----------------------------------------------------------------------
+   return ptr to internal members upon request
+------------------------------------------------------------------------ */
+
+void *DihedralCharmm::extract(const char *str, int &dim)
+{
+  dim = 1;
+  if (strcmp(str, "k") == 0) return (void *) k;
+  if (strcmp(str, "n") == 0) return (void *) multiplicity;
+  if (strcmp(str, "d") == 0) return (void *) shift;
+  return nullptr;
+}

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -440,7 +440,7 @@ void DihedralCharmm::write_data(FILE *fp)
  void *DihedralCharmm::extract(const char *str, int &dim)
  {
    dim = 1;
-   if (strcmp(str, "k") == 0) return (void *) k0;
+   if (strcmp(str, "k") == 0) return (void *) k;
    if (strcmp(str, "n") == 0) return (void *) multiplicity;
    if (strcmp(str, "d") == 0) return (void *) shift;
    return nullptr;

--- a/src/MOLECULE/dihedral_charmm.h
+++ b/src/MOLECULE/dihedral_charmm.h
@@ -34,6 +34,7 @@ class DihedralCharmm : public Dihedral {
   void write_restart(FILE *) override;
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double *k, *weight, *cos_shift, *sin_shift;

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -475,3 +475,16 @@ void DihedralCharmmfsw::write_data(FILE *fp)
   for (int i = 1; i <= atom->ndihedraltypes; i++)
     fprintf(fp, "%d %g %d %d %g\n", i, k[i], multiplicity[i], shift[i], weight[i]);
 }
+
+ /* ----------------------------------------------------------------------
+    return ptr to internal members upon request
+ ------------------------------------------------------------------------ */
+ 
+ void *DihedralCharmmfsw::extract(const char *str, int &dim)
+ {
+   dim = 1;
+   if (strcmp(str, "k") == 0) return (void *) k0;
+   if (strcmp(str, "n") == 0) return (void *) multiplicity;
+   if (strcmp(str, "d") == 0) return (void *) shift;
+   return nullptr;
+ }

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -483,7 +483,7 @@ void DihedralCharmmfsw::write_data(FILE *fp)
  void *DihedralCharmmfsw::extract(const char *str, int &dim)
  {
    dim = 1;
-   if (strcmp(str, "k") == 0) return (void *) k0;
+   if (strcmp(str, "k") == 0) return (void *) k;
    if (strcmp(str, "n") == 0) return (void *) multiplicity;
    if (strcmp(str, "d") == 0) return (void *) shift;
    return nullptr;

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -476,15 +476,15 @@ void DihedralCharmmfsw::write_data(FILE *fp)
     fprintf(fp, "%d %g %d %d %g\n", i, k[i], multiplicity[i], shift[i], weight[i]);
 }
 
- /* ----------------------------------------------------------------------
-    return ptr to internal members upon request
- ------------------------------------------------------------------------ */
- 
- void *DihedralCharmmfsw::extract(const char *str, int &dim)
- {
-   dim = 1;
-   if (strcmp(str, "k") == 0) return (void *) k;
-   if (strcmp(str, "n") == 0) return (void *) multiplicity;
-   if (strcmp(str, "d") == 0) return (void *) shift;
-   return nullptr;
- }
+/* ----------------------------------------------------------------------
+   return ptr to internal members upon request
+------------------------------------------------------------------------ */
+
+void *DihedralCharmmfsw::extract(const char *str, int &dim)
+{
+  dim = 1;
+  if (strcmp(str, "k") == 0) return (void *) k;
+  if (strcmp(str, "n") == 0) return (void *) multiplicity;
+  if (strcmp(str, "d") == 0) return (void *) shift;
+  return nullptr;
+}

--- a/src/MOLECULE/dihedral_charmmfsw.h
+++ b/src/MOLECULE/dihedral_charmmfsw.h
@@ -34,6 +34,7 @@ class DihedralCharmmfsw : public Dihedral {
   void write_restart(FILE *) override;
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
+  void *extract(const char *, int &) override;
 
  protected:
   int implicit, weightflag, dihedflag;

--- a/src/MOLECULE/dihedral_multi_harmonic.cpp
+++ b/src/MOLECULE/dihedral_multi_harmonic.cpp
@@ -409,17 +409,17 @@ void DihedralMultiHarmonic::born_matrix(int nd, int i1, int i2, int i3, int i4, 
 }
 
 
- /* ----------------------------------------------------------------------
-    return ptr to internal members upon request
- ------------------------------------------------------------------------ */
- 
- void *DihedralMultiHarmonic::extract(const char *str, int &dim)
- {
-   dim = 1;
-   if (strcmp(str, "a1") == 0) return (void *) a1;
-   if (strcmp(str, "a2") == 0) return (void *) a2;
-   if (strcmp(str, "a3") == 0) return (void *) a3;
-   if (strcmp(str, "a4") == 0) return (void *) a4;
-   if (strcmp(str, "a5") == 0) return (void *) a5;
-   return nullptr;
- }
+/* ----------------------------------------------------------------------
+   return ptr to internal members upon request
+------------------------------------------------------------------------ */
+
+void *DihedralMultiHarmonic::extract(const char *str, int &dim)
+{
+  dim = 1;
+  if (strcmp(str, "a1") == 0) return (void *) a1;
+  if (strcmp(str, "a2") == 0) return (void *) a2;
+  if (strcmp(str, "a3") == 0) return (void *) a3;
+  if (strcmp(str, "a4") == 0) return (void *) a4;
+  if (strcmp(str, "a5") == 0) return (void *) a5;
+  return nullptr;
+}

--- a/src/MOLECULE/dihedral_multi_harmonic.cpp
+++ b/src/MOLECULE/dihedral_multi_harmonic.cpp
@@ -407,3 +407,19 @@ void DihedralMultiHarmonic::born_matrix(int nd, int i1, int i2, int i3, int i4, 
   du = a2[type] + c * (2.0 * a3[type] + c * (3.0 * a4[type] + c * 4.0 * a5[type]));
   du2 = 2.0 * a3[type] + 6.0 * c * (a4[type] + 2.0 * a5[type] * c);
 }
+
+
+ /* ----------------------------------------------------------------------
+    return ptr to internal members upon request
+ ------------------------------------------------------------------------ */
+ 
+ void *DihedralMultiHarmonic::extract(const char *str, int &dim)
+ {
+   dim = 1;
+   if (strcmp(str, "a1") == 0) return (void *) a1;
+   if (strcmp(str, "a2") == 0) return (void *) a2;
+   if (strcmp(str, "a3") == 0) return (void *) a3;
+   if (strcmp(str, "a4") == 0) return (void *) a4;
+   if (strcmp(str, "a5") == 0) return (void *) a5;
+   return nullptr;
+ }

--- a/src/MOLECULE/dihedral_multi_harmonic.h
+++ b/src/MOLECULE/dihedral_multi_harmonic.h
@@ -34,6 +34,7 @@ class DihedralMultiHarmonic : public Dihedral {
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
   void born_matrix(int, int, int, int, int, double &, double &) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double *a1, *a2, *a3, *a4, *a5;

--- a/src/MOLECULE/dihedral_opls.cpp
+++ b/src/MOLECULE/dihedral_opls.cpp
@@ -433,15 +433,15 @@ void DihedralOPLS::born_matrix(int nd, int i1, int i2, int i3, int i4, double &d
 }
 
 /* ----------------------------------------------------------------------
-    return ptr to internal members upon request
- ------------------------------------------------------------------------ */
- 
- void *DihedralOPLS::extract(const char *str, int &dim)
- {
-   dim = 1;
-   if (strcmp(str, "k1") == 0) return (void *) k1;
-   if (strcmp(str, "k2") == 0) return (void *) k2;
-   if (strcmp(str, "k3") == 0) return (void *) k3;
-   if (strcmp(str, "k4") == 0) return (void *) k4;
-   return nullptr;
- }
+   return ptr to internal members upon request
+------------------------------------------------------------------------ */
+
+void *DihedralOPLS::extract(const char *str, int &dim)
+{
+  dim = 1;
+  if (strcmp(str, "k1") == 0) return (void *) k1;
+  if (strcmp(str, "k2") == 0) return (void *) k2;
+  if (strcmp(str, "k3") == 0) return (void *) k3;
+  if (strcmp(str, "k4") == 0) return (void *) k4;
+  return nullptr;
+}

--- a/src/MOLECULE/dihedral_opls.cpp
+++ b/src/MOLECULE/dihedral_opls.cpp
@@ -431,3 +431,17 @@ void DihedralOPLS::born_matrix(int nd, int i1, int i2, int i3, int i4, double &d
          16.0 * k4[type] * si * cos(4.0 * phi) - 4.0 * k4[type] * sin(4.0 * phi)) /
       (si * si * si);
 }
+
+/* ----------------------------------------------------------------------
+    return ptr to internal members upon request
+ ------------------------------------------------------------------------ */
+ 
+ void *DihedralOPLS::extract(const char *str, int &dim)
+ {
+   dim = 1;
+   if (strcmp(str, "k1") == 0) return (void *) k1;
+   if (strcmp(str, "k2") == 0) return (void *) k2;
+   if (strcmp(str, "k3") == 0) return (void *) k3;
+   if (strcmp(str, "k4") == 0) return (void *) k4;
+   return nullptr;
+ }

--- a/src/MOLECULE/dihedral_opls.h
+++ b/src/MOLECULE/dihedral_opls.h
@@ -34,6 +34,7 @@ class DihedralOPLS : public Dihedral {
   void read_restart(FILE *) override;
   void write_data(FILE *) override;
   void born_matrix(int, int, int, int, int, double &, double &) override;
+  void *extract(const char *, int &) override;
 
  protected:
   double *k1, *k2, *k3, *k4;

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -33,6 +33,7 @@ Dihedral::Dihedral(LAMMPS *_lmp) : Pointers(_lmp)
 {
   energy = 0.0;
   writedata = 0;
+  reinitflag = 1;
 
   allocated = 0;
   suffix_flag = Suffix::NONE;
@@ -427,4 +428,16 @@ double Dihedral::memory_usage()
   bytes += (double) comm->nthreads * maxvatom * 6 * sizeof(double);
   bytes += (double) comm->nthreads * maxcvatom * 9 * sizeof(double);
   return bytes;
+}
+
+/* -----------------------------------------------------------------------
+   reset all type-based dihedral params via init()
+-------------------------------------------------------------------------- */
+
+void Dihedral::reinit()
+{
+  if (!reinitflag)
+    error->all(FLERR, "Fix adapt interface to this dihedral style not supported");
+
+  init();
 }

--- a/src/dihedral.h
+++ b/src/dihedral.h
@@ -37,6 +37,9 @@ class Dihedral : protected Pointers {
                              // CENTROID_AVAIL = different and implemented
                              // CENTROID_NOTAVAIL = different, not yet implemented
 
+  int reinitflag;            // 0 if not compatible with fix adapt
+                             // extract() method may still need to be added
+
   // KOKKOS host/device flag and data masks
 
   ExecutionSpace execution_space;
@@ -62,6 +65,8 @@ class Dihedral : protected Pointers {
     du = 0.0;
     du2 = 0.0;
   }
+  virtual void *extract(const char *, int &) { return nullptr; }
+  void reinit();
 
  protected:
   int suffix_flag;    // suffix compatibility flag

--- a/src/dihedral_hybrid.cpp
+++ b/src/dihedral_hybrid.cpp
@@ -326,6 +326,14 @@ void DihedralHybrid::init_style()
     if (styles[m]) styles[m]->init_style();
 }
 
+/* ---------------------------------------------------------------------- */
+
+int DihedralHybrid::check_itype(int itype, char *substyle)
+{
+  if (strcmp(keywords[map[itype]], substyle) == 0) return 1;
+  return 0;
+}
+
 /* ----------------------------------------------------------------------
    proc 0 writes to restart file
 ------------------------------------------------------------------------- */

--- a/src/dihedral_hybrid.h
+++ b/src/dihedral_hybrid.h
@@ -40,6 +40,8 @@ class DihedralHybrid : public Dihedral {
   void read_restart(FILE *) override;
   double memory_usage() override;
 
+  int check_itype(int, char *);
+
  protected:
   int *map;    // which style each dihedral type points to
 

--- a/src/fix_adapt.h
+++ b/src/fix_adapt.h
@@ -44,7 +44,7 @@ class FixAdapt : public Fix {
 
  private:
   int nadapt, resetflag, scaleflag, massflag;
-  int anypair, anybond, anyangle, anyimproper;
+  int anypair, anybond, anyangle, anydihedral, anyimproper;
   int nlevels_respa;
   char *id_fix_diam, *id_fix_chg;
   class FixStoreAtom *fix_diam, *fix_chg;
@@ -57,9 +57,10 @@ class FixAdapt : public Fix {
     char *pstyle, *pparam;
     char *bstyle, *bparam;
     char *astyle, *aparam;
+    char *dstyle, *dparam;
     char *istyle, *iparam;
     int ilo, ihi, jlo, jhi;
-    int pdim, bdim, adim, idim;
+    int pdim, bdim, adim, ddim, idim;
     double *scalar, scalar_orig;
     double *vector, *vector_orig;
     double **array, **array_orig;
@@ -67,6 +68,7 @@ class FixAdapt : public Fix {
     class Pair *pair;
     class Bond *bond;
     class Angle *angle;
+    class Dihedral *dihedral;
     class Improper *improper;
   };
 

--- a/unittest/force-styles/test_dihedral_style.cpp
+++ b/unittest/force-styles/test_dihedral_style.cpp
@@ -746,3 +746,44 @@ TEST(DihedralStyle, numdiff)
     cleanup_lammps(lmp, test_config);
     if (!verbose) ::testing::internal::GetCapturedStdout();
 }
+
+TEST(DihedralStyle, extract)
+{
+    if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
+
+    LAMMPS::argv args = {"DihedralStyle", "-log", "none", "-echo", "screen", "-nocite"};
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    LAMMPS *lmp = nullptr;
+    try {
+        lmp = init_lammps(args, test_config, true);
+    } catch (std::exception &e) {
+        if (!verbose) ::testing::internal::GetCapturedStdout();
+        FAIL() << e.what();
+    }
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+
+    if (!lmp) {
+        std::cerr << "One or more prerequisite styles are not available "
+                     "in this LAMMPS configuration:\n";
+        for (auto prerequisite : test_config.prerequisites) {
+            std::cerr << prerequisite.first << "_style " << prerequisite.second << "\n";
+        }
+        GTEST_SKIP();
+    }
+
+    auto *dihedral = lmp->force->dihedral;
+    void *ptr   = nullptr;
+    int dim     = 0;
+    for (auto extract : test_config.extract) {
+        ptr = dihedral->extract(extract.first.c_str(), dim);
+        EXPECT_NE(ptr, nullptr);
+        EXPECT_EQ(dim, extract.second);
+    }
+    ptr = dihedral->extract("does_not_exist", dim);
+    EXPECT_EQ(ptr, nullptr);
+
+    if (!verbose) ::testing::internal::CaptureStdout();
+    cleanup_lammps(lmp, test_config);
+    if (!verbose) ::testing::internal::GetCapturedStdout();
+}

--- a/unittest/force-styles/tests/dihedral-charmm.yaml
+++ b/unittest/force-styles/tests/dihedral-charmm.yaml
@@ -19,7 +19,10 @@ dihedral_coeff: ! |
   3  56.0 0 110 0.0
   4  23.0 1 180 0.5
   5  19.0 3  90 1.0
-extract: ! ""
+extract: ! |
+  k 1
+  n 1
+  d 1
 natoms: 29
 init_energy: 1317.959844120986
 init_stress: ! |2-

--- a/unittest/force-styles/tests/dihedral-charmmfsw.yaml
+++ b/unittest/force-styles/tests/dihedral-charmmfsw.yaml
@@ -19,7 +19,10 @@ dihedral_coeff: ! |
   3  56.0 0 110 0.0
   4  23.0 1 180 0.5
   5  19.0 3  90 1.0
-extract: ! ""
+extract: ! |
+  k 1
+  n 1
+  d 1
 natoms: 29
 init_energy: 1317.959844120986
 init_stress: ! |2-

--- a/unittest/force-styles/tests/dihedral-class2.yaml
+++ b/unittest/force-styles/tests/dihedral-class2.yaml
@@ -17,7 +17,13 @@ dihedral_coeff: ! |
   *  at   75 42 31 75 42 31 120 50
   *  aat  75 120 160
   *  bb13 75 1.4 1.4
-extract: ! ""
+extract: ! |
+  k1 1
+  k2 1
+  k3 1
+  phi1 1
+  phi2 1
+  phi3 1
 natoms: 29
 init_energy: 3355.0074717375933
 init_stress: ! |2-

--- a/unittest/force-styles/tests/dihedral-cosine_squared_restricted.yaml
+++ b/unittest/force-styles/tests/dihedral-cosine_squared_restricted.yaml
@@ -16,7 +16,9 @@ dihedral_coeff: ! |
   3  15.0 -10.0
   4  12.0 0.0
   5  11.0 45.0
-extract: ! ""
+extract: ! |
+  k 1
+  phi0 1
 natoms: 29
 init_energy: 10643.96352037142
 init_stress: ! |2-

--- a/unittest/force-styles/tests/dihedral-helix.yaml
+++ b/unittest/force-styles/tests/dihedral-helix.yaml
@@ -16,7 +16,10 @@ dihedral_coeff: ! |
   3  56 10 32
   4  23 80 61
   5  19 90 13
-extract: ! ""
+extract: ! |
+  a 1
+  b 1
+  c 1
 natoms: 29
 init_energy: 4634.436545707672
 init_stress: ! |-

--- a/unittest/force-styles/tests/dihedral-multi_harmonic.yaml
+++ b/unittest/force-styles/tests/dihedral-multi_harmonic.yaml
@@ -16,7 +16,12 @@ dihedral_coeff: ! |
   3  56 10 32 84 52
   4  23 80 61 83 74
   5  19 90 13 15 58
-extract: ! ""
+extract: ! |
+  a1 1
+  a2 1
+  a3 1
+  a4 1
+  a5 1
 natoms: 29
 init_energy: 2854.9857316566695
 init_stress: ! |2-

--- a/unittest/force-styles/tests/dihedral-opls.yaml
+++ b/unittest/force-styles/tests/dihedral-opls.yaml
@@ -16,7 +16,11 @@ dihedral_coeff: ! |
   3  56 10 32 84
   4  23 80 61 83
   5  19 90 13 15
-extract: ! ""
+extract: ! |
+  k1 1
+  k2 1
+  k3 1
+  k4 1
 natoms: 29
 init_energy: 2260.6834525285753
 init_stress: ! |-

--- a/unittest/force-styles/tests/dihedral-quadratic.yaml
+++ b/unittest/force-styles/tests/dihedral-quadratic.yaml
@@ -17,7 +17,9 @@ dihedral_coeff: ! |
   3  25 100
   4  35 110
   5  85 120
-extract: ! ""
+extract: ! |
+  k 1
+  phi0 1
 natoms: 29
 init_energy: 6216.314347066598
 init_stress: ! |2-


### PR DESCRIPTION
**Summary**

Add support to fix adapt for on-the-fly adjustment of dihedral style parameters. Similar to improper and angle style params. Support for few dihedral styles was also added.

**Related Issue(s)**

closes https://github.com/lammps/lammps/issues/4350

**Author(s)**

E. Voyiatzis at NovaMechanics Ltd (email evoyiatzis@gmail.com)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

It does not break backward compatibility

**Implementation Notes**

The implementation is heavily based on PR Fix adapt improper https://github.com/lammps/lammps/pull/4467

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


