### PR TITLE
cmake: fix omp.h detection

### DIFF
--- a/cmake/Modules/LAMMPSUtils.cmake
+++ b/cmake/Modules/LAMMPSUtils.cmake
@@ -30,7 +30,7 @@ function(check_omp_h_include)
   if(OpenMP_CXX_FOUND)
     set(CMAKE_REQUIRED_FLAGS ${OpenMP_CXX_FLAGS})
     set(CMAKE_REQUIRED_INCLUDES ${OpenMP_CXX_INCLUDE_DIRS})
-    set(CMAKE_REQUIRED_LINK_OPTIONS ${OpenMP_CXX_FLAGS})
+    separate_arguments(CMAKE_REQUIRED_LINK_OPTIONS NATIVE_COMMAND ${OpenMP_CXX_FLAGS}) # needs to be a list
     set(CMAKE_REQUIRED_LIBRARIES ${OpenMP_CXX_LIBRARIES})
     # there are all kinds of problems with finding omp.h
     # for Clang and derived compilers so we pretend it is there.


### PR DESCRIPTION
**Summary**

`CMAKE_REQUIRED_LINK_OPTIONS` needs to be a `;`-separated list. See https://cmake.org/cmake/help/latest/module/CheckIncludeFileCXX.html.
Fixes OpenMP detection with AppleClang when libomp is manually provided.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

@rbberger 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

When telling CMake where to find `libomp`, `find_package(OpenMP)` detects OpenMP with AppleClang and sets `OpenMP_CXX_FLAGS` to `-Xclang -fopenmp`. The current custom `omp.h` header logic was passing that string directly, which turns it into a single invalid `"-Xclang -fopenmp"` command-line argument. `CMAKE_REQUIRED_LINK_OPTIONS` is documented to need to be a `;`-list to ensure the flags are passed correctly.

The alternative is to not set `CMAKE_REQUIRED_LINK_OPTIONS`, which doesn't seem to be needed for this case. However, I didn't want to verify all other platforms without it.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


