### PR TITLE
Improve minimum image error messages

### DIFF
--- a/doc/src/Developer_updating.rst
+++ b/doc/src/Developer_updating.rst
@@ -635,7 +635,7 @@ Old:
    double delx2 = x[i3][0] - x[i2][0];
    double dely2 = x[i3][1] - x[i2][1];
    double delz2 = x[i3][2] - x[i2][2];
-   domain->minimum_image(delx2, dely2, delz2);
+   domain->minimum_image_big(delx2, dely2, delz2);
    double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
 New:
@@ -651,7 +651,7 @@ New:
    double delx2 = x[i3][0] - x[i2][0];
    double dely2 = x[i3][1] - x[i2][1];
    double delz2 = x[i3][2] - x[i2][2];
-   domain->minimum_image(FLERR, delx2, dely2, delz2);
+   domain->minimum_image_big(FLERR, delx2, dely2, delz2);
    double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
 This change is **required** or else the code will not compile.

--- a/doc/src/Developer_updating.rst
+++ b/doc/src/Developer_updating.rst
@@ -29,6 +29,7 @@ Available topics in mostly chronological order are:
 - `Rename of fix STORE/PERATOM to fix STORE/ATOM and change of arguments`_
 - `Use Output::get_dump_by_id() instead of Output::find_dump()`_
 - `Refactored grid communication using Grid3d/Grid2d classes instead of GridComm`_
+- `FLERR as first argument to minimum image functions in Domain class`_
 
 ----
 
@@ -608,5 +609,49 @@ KSpace solvers which use distributed FFT grids:
 - ``src/compute_property_grid.cpp``
 - ``src/EXTRA-FIX/fix_ttm_grid.cpp``
 - ``src/KSPACE/pppm.cpp``
+
+This change is **required** or else the code will not compile.
+
+FLERR as first argument to minimum image functions in Domain class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionchanged:: TBD
+
+The ``Domain::minimum_image()`` and ``Domain::minimum_image_big()``
+functions were changed to take the ``FLERR`` macros as first argument.
+This way the error message indicates *where* the function was called
+instead of pointing to the implementation of the function.  Example:
+
+Old:
+
+.. code-block:: c++
+
+   double delx1 = x[i1][0] - x[i2][0];
+   double dely1 = x[i1][1] - x[i2][1];
+   double delz1 = x[i1][2] - x[i2][2];
+   domain->minimum_image(delx1, dely1, delz1);
+   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
+
+   double delx2 = x[i3][0] - x[i2][0];
+   double dely2 = x[i3][1] - x[i2][1];
+   double delz2 = x[i3][2] - x[i2][2];
+   domain->minimum_image(delx2, dely2, delz2);
+   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
+
+New:
+
+.. code-block:: c++
+
+   double delx1 = x[i1][0] - x[i2][0];
+   double dely1 = x[i1][1] - x[i2][1];
+   double delz1 = x[i1][2] - x[i2][2];
+   domain->minimum_image(FLERR, delx1, dely1, delz1);
+   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
+
+   double delx2 = x[i3][0] - x[i2][0];
+   double dely2 = x[i3][1] - x[i2][1];
+   double delz2 = x[i3][2] - x[i2][2];
+   domain->minimum_image(FLERR, delx2, dely2, delz2);
+   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
 This change is **required** or else the code will not compile.

--- a/lib/atc/LammpsInterface.cpp
+++ b/lib/atc/LammpsInterface.cpp
@@ -561,7 +561,7 @@ bool LammpsInterface::region_bounds(const char * regionName,
 }
 
 void LammpsInterface::minimum_image(double & dx, double & dy, double & dz) const {
-  lammps_->domain->minimum_image(dx,dy,dz);
+  lammps_->domain->minimum_image(FLERR,dx,dy,dz);
 }
 
 void LammpsInterface::closest_image(const double * const xi, const double * const xj, double * const xjImage) const {

--- a/src/AMOEBA/angle_amoeba.cpp
+++ b/src/AMOEBA/angle_amoeba.cpp
@@ -834,13 +834,13 @@ double AngleAmoeba::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/BPM/bond_bpm.cpp
+++ b/src/BPM/bond_bpm.cpp
@@ -352,7 +352,7 @@ double BondBPM::equilibrium_distance(int /*i*/)
           delx = x[i][0] - x[j][0];
           dely = x[i][1] - x[j][1];
           delz = x[i][2] - x[j][2];
-          domain->minimum_image(delx, dely, delz);
+          domain->minimum_image(FLERR, delx, dely, delz);
 
           r = sqrt(delx * delx + dely * dely + delz * delz);
           if (r > r0_max_estimate) r0_max_estimate = r;

--- a/src/BPM/bond_bpm_rotational.cpp
+++ b/src/BPM/bond_bpm_rotational.cpp
@@ -177,7 +177,7 @@ void BondBPMRotational::store_data()
       }
 
       // Get closest image in case bonded with ghost
-      domain->minimum_image(delx, dely, delz);
+      domain->minimum_image(FLERR, delx, dely, delz);
       r = sqrt(delx * delx + dely * dely + delz * delz);
       rinv = 1.0 / r;
 

--- a/src/BPM/bond_bpm_spring.cpp
+++ b/src/BPM/bond_bpm_spring.cpp
@@ -140,7 +140,7 @@ void BondBPMSpring::store_data()
       delz = x[i][2] - x[j][2];
 
       // Get closest image in case bonded with ghost
-      domain->minimum_image(delx, dely, delz);
+      domain->minimum_image(FLERR, delx, dely, delz);
       r = sqrt(delx * delx + dely * dely + delz * delz);
 
       fix_bond_history->update_atom_value(i, m, 0, r);

--- a/src/BPM/bond_bpm_spring_plastic.cpp
+++ b/src/BPM/bond_bpm_spring_plastic.cpp
@@ -148,7 +148,7 @@ void BondBPMSpringPlastic::store_data()
       delz = x[i][2] - x[j][2];
 
       // Get closest image in case bonded with ghost
-      domain->minimum_image(delx, dely, delz);
+      domain->minimum_image(FLERR, delx, dely, delz);
       r = sqrt(delx * delx + dely * dely + delz * delz);
 
       fix_bond_history->update_atom_value(i, m, 0, r);

--- a/src/CG-SPICA/angle_spica.cpp
+++ b/src/CG-SPICA/angle_spica.cpp
@@ -458,13 +458,13 @@ double AngleSPICA::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;
@@ -479,7 +479,7 @@ double AngleSPICA::single(int type, int i1, int i2, int i3)
     double delx3 = x[i1][0] - x[i3][0];
     double dely3 = x[i1][1] - x[i3][1];
     double delz3 = x[i1][2] - x[i3][2];
-    domain->minimum_image(delx3,dely3,delz3);
+    domain->minimum_image(FLERR, delx3,dely3,delz3);
 
     const int type1 = atom->type[i1];
     const int type3 = atom->type[i3];

--- a/src/CLASS2/angle_class2.cpp
+++ b/src/CLASS2/angle_class2.cpp
@@ -436,13 +436,13 @@ double AngleClass2::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/COLVARS/colvarproxy_lammps.cpp
+++ b/src/COLVARS/colvarproxy_lammps.cpp
@@ -188,7 +188,7 @@ cvm::rvector colvarproxy_lammps::position_distance(cvm::atom_pos const &pos1,
   double xtmp = pos2.x - pos1.x;
   double ytmp = pos2.y - pos1.y;
   double ztmp = pos2.z - pos1.z;
-  _lmp->domain->minimum_image_big(xtmp,ytmp,ztmp);
+  _lmp->domain->minimum_image_big(FLERR, xtmp,ytmp,ztmp);
   return {xtmp, ytmp, ztmp};
 }
 

--- a/src/DIELECTRIC/fix_polarize_functional.cpp
+++ b/src/DIELECTRIC/fix_polarize_functional.cpp
@@ -652,7 +652,7 @@ void FixPolarizeFunctional::calculate_Rww_cutoff()
           double delx = xtmp - x[k][0];
           double dely = ytmp - x[k][1];
           double delz = ztmp - x[k][2];
-          domain->minimum_image(delx, dely, delz);
+          domain->minimum_image(FLERR, delx, dely, delz);
           int mk = tag2mat[tag[k]];
 
           // G1ww[mi][mk] = calculate_greens_ewald(delx, dely, delz);
@@ -861,7 +861,7 @@ void FixPolarizeFunctional::calculate_qiRqw_cutoff()
           delx = xtmp - x[k][0];
           dely = ytmp - x[k][1];
           delz = ztmp - x[k][2];
-          domain->minimum_image(delx, dely, delz);
+          domain->minimum_image(FLERR, delx, dely, delz);
           r = sqrt(delx * delx + dely * dely + delz * delz);
 
           int mk = tag2mat[tag[k]];
@@ -902,7 +902,7 @@ void FixPolarizeFunctional::calculate_qiRqw_cutoff()
           delx = x[i][0] - xtmp;
           dely = x[i][1] - ytmp;
           delz = x[i][2] - ztmp;
-          domain->minimum_image(delx, dely, delz);
+          domain->minimum_image(FLERR, delx, dely, delz);
 
           int mi = tag2mat_ions[tag[i]];    //ion_idx[i];
 

--- a/src/DIPOLE/angle_dipole.cpp
+++ b/src/DIPOLE/angle_dipole.cpp
@@ -251,7 +251,7 @@ double AngleDipole::single(int type, int iRef, int iDip, int /*iDummy*/)
   double dely = x[iRef][1] - x[iDip][1];
   double delz = x[iRef][2] - x[iDip][2];
 
-  domain->minimum_image(delx, dely, delz);
+  domain->minimum_image(FLERR, delx, dely, delz);
 
   double r = sqrt(delx * delx + dely * dely + delz * delz);
   if (r < SMALL) return 0.0;

--- a/src/EXTRA-COMPUTE/compute_born_matrix.cpp
+++ b/src/EXTRA-COMPUTE/compute_born_matrix.cpp
@@ -764,7 +764,7 @@ void ComputeBornMatrix::compute_bonds()
       dx = x[atom2][0] - x[atom1][0];
       dy = x[atom2][1] - x[atom1][1];
       dz = x[atom2][2] - x[atom1][2];
-      domain->minimum_image(dx, dy, dz);
+      domain->minimum_image(FLERR, dx, dy, dz);
       rsq = dx * dx + dy * dy + dz * dz;
       rij[0] = dx;
       rij[1] = dy;
@@ -870,7 +870,7 @@ void ComputeBornMatrix::compute_angles()
       delx1 = x[atom1][0] - x[atom2][0];
       dely1 = x[atom1][1] - x[atom2][1];
       delz1 = x[atom1][2] - x[atom2][2];
-      domain->minimum_image(delx1, dely1, delz1);
+      domain->minimum_image(FLERR, delx1, dely1, delz1);
       del1[0] = delx1;
       del1[1] = dely1;
       del1[2] = delz1;
@@ -882,7 +882,7 @@ void ComputeBornMatrix::compute_angles()
       delx2 = x[atom3][0] - x[atom2][0];
       dely2 = x[atom3][1] - x[atom2][1];
       delz2 = x[atom3][2] - x[atom2][2];
-      domain->minimum_image(delx2, dely2, delz2);
+      domain->minimum_image(FLERR, delx2, dely2, delz2);
       del2[0] = delx2;
       del2[1] = dely2;
       del2[2] = delz2;
@@ -1046,7 +1046,7 @@ void ComputeBornMatrix::compute_dihedrals()
       vb1x = x[atom2][0] - x[atom1][0];
       vb1y = x[atom2][1] - x[atom1][1];
       vb1z = x[atom2][2] - x[atom1][2];
-      domain->minimum_image(vb1x, vb1y, vb1z);
+      domain->minimum_image(FLERR, vb1x, vb1y, vb1z);
       b1[0] = vb1x;
       b1[1] = vb1y;
       b1[2] = vb1z;
@@ -1055,7 +1055,7 @@ void ComputeBornMatrix::compute_dihedrals()
       vb2x = x[atom3][0] - x[atom2][0];
       vb2y = x[atom3][1] - x[atom2][1];
       vb2z = x[atom3][2] - x[atom2][2];
-      domain->minimum_image(vb2x, vb2y, vb2z);
+      domain->minimum_image(FLERR, vb2x, vb2y, vb2z);
       b2[0] = vb2x;
       b2[1] = vb2y;
       b2[2] = vb2z;
@@ -1064,7 +1064,7 @@ void ComputeBornMatrix::compute_dihedrals()
       vb3x = x[atom4][0] - x[atom3][0];
       vb3y = x[atom4][1] - x[atom3][1];
       vb3z = x[atom4][2] - x[atom3][2];
-      domain->minimum_image(vb3x, vb3y, vb3z);
+      domain->minimum_image(FLERR, vb3x, vb3y, vb3z);
       b3[0] = vb3x;
       b3[1] = vb3y;
       b3[2] = vb3z;

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
@@ -480,7 +480,7 @@ void ComputeStressCartesian::compute_pressure(double fpair, double xi, double yi
       tmp1[dir1] = (bin1 + 1) * bin_width1 - xi;
     else
       tmp1[dir1] = bin1 * bin_width1 - xi;
-    domain->minimum_image(tmp1[0],tmp1[1],tmp1[2]);
+    domain->minimum_image(FLERR, tmp1[0],tmp1[1],tmp1[2]);
     l1 = tmp1[dir1] / rij1;
 
     double l2;
@@ -489,7 +489,7 @@ void ComputeStressCartesian::compute_pressure(double fpair, double xi, double yi
       tmp2[dir2] = (bin2 + 1) * bin_width2 - yi;
     else
       tmp2[dir2] = bin2 * bin_width2 - yi;
-    domain->minimum_image(tmp2[0],tmp2[1],tmp2[2]);
+    domain->minimum_image(FLERR, tmp2[0],tmp2[1],tmp2[2]);
     l2 = tmp2[dir2] / rij2;
 
     if ((dims == 1 || l1 < l2 || l2 < lb + SMALL) && l1 <= 1.0 && l1 > lb) {

--- a/src/EXTRA-COMPUTE/compute_stress_mop.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_mop.cpp
@@ -82,7 +82,7 @@ ComputeStressMop::ComputeStressMop(LAMMPS *lmp, int narg, char **arg) : Compute(
     error->warning(FLERR, "The specified initial plane lies outside of the simulation box");
     double dx[3] = {0.0, 0.0, 0.0};
     dx[dir] = pos - 0.5 * (domain->boxhi[dir] + domain->boxlo[dir]);
-    domain->minimum_image(dx[0], dx[1], dx[2]);
+    domain->minimum_image(FLERR, dx[0], dx[1], dx[2]);
     pos = 0.5 * (domain->boxhi[dir] + domain->boxlo[dir]) + dx[dir];
 
     if ((pos > domain->boxhi[dir]) || (pos < domain->boxlo[dir]))
@@ -478,7 +478,7 @@ void ComputeStressMop::compute_pairs()
 
           // minimum image of xi with respect to the plane
           xi[dir] -= pos;
-          domain->minimum_image(xi[0], xi[1], xi[2]);
+          domain->minimum_image(FLERR, xi[0], xi[1], xi[2]);
           xi[dir] += pos;
 
           //velocities at t
@@ -601,7 +601,7 @@ void ComputeStressMop::compute_bonds()
       dx[1] = x[atom1][1];
       dx[2] = x[atom1][2];
       dx[dir] -= pos;
-      domain->minimum_image(dx[0], dx[1], dx[2]);
+      domain->minimum_image(FLERR, dx[0], dx[1], dx[2]);
       x_bond_1[0] = dx[0];
       x_bond_1[1] = dx[1];
       x_bond_1[2] = dx[2];
@@ -612,7 +612,7 @@ void ComputeStressMop::compute_bonds()
       dx[0] = x[atom2][0] - x_bond_1[0];
       dx[1] = x[atom2][1] - x_bond_1[1];
       dx[2] = x[atom2][2] - x_bond_1[2];
-      domain->minimum_image(dx[0], dx[1], dx[2]);
+      domain->minimum_image(FLERR, dx[0], dx[1], dx[2]);
       x_bond_2[0] = x_bond_1[0] + dx[0];
       x_bond_2[1] = x_bond_1[1] + dx[1];
       x_bond_2[2] = x_bond_1[2] + dx[2];
@@ -728,7 +728,7 @@ void ComputeStressMop::compute_angles()
       dx[1] = x[atom1][1];
       dx[2] = x[atom1][2];
       dx[dir] -= pos;
-      domain->minimum_image(dx[0], dx[1], dx[2]);
+      domain->minimum_image(FLERR, dx[0], dx[1], dx[2]);
       x_angle_left[0] = dx[0];
       x_angle_left[1] = dx[1];
       x_angle_left[2] = dx[2];
@@ -739,7 +739,7 @@ void ComputeStressMop::compute_angles()
       dx_left[0] = x[atom2][0] - x_angle_left[0];
       dx_left[1] = x[atom2][1] - x_angle_left[1];
       dx_left[2] = x[atom2][2] - x_angle_left[2];
-      domain->minimum_image(dx_left[0], dx_left[1], dx_left[2]);
+      domain->minimum_image(FLERR, dx_left[0], dx_left[1], dx_left[2]);
       x_angle_middle[0] = x_angle_left[0] + dx_left[0];
       x_angle_middle[1] = x_angle_left[1] + dx_left[1];
       x_angle_middle[2] = x_angle_left[2] + dx_left[2];
@@ -749,7 +749,7 @@ void ComputeStressMop::compute_angles()
       dx_right[0] = x[atom3][0] - x_angle_middle[0];
       dx_right[1] = x[atom3][1] - x_angle_middle[1];
       dx_right[2] = x[atom3][2] - x_angle_middle[2];
-      domain->minimum_image(dx_right[0], dx_right[1], dx_right[2]);
+      domain->minimum_image(FLERR, dx_right[0], dx_right[1], dx_right[2]);
       x_angle_right[0] = x_angle_middle[0] + dx_right[0];
       x_angle_right[1] = x_angle_middle[1] + dx_right[1];
       x_angle_right[2] = x_angle_middle[2] + dx_right[2];
@@ -920,14 +920,14 @@ void ComputeStressMop::compute_dihedrals()
       x_atom_1[1] = x[atom1][1];
       x_atom_1[2] = x[atom1][2];
       x_atom_1[dir] -= pos;
-      domain->minimum_image(x_atom_1[0], x_atom_1[1], x_atom_1[2]);
+      domain->minimum_image(FLERR, x_atom_1[0], x_atom_1[1], x_atom_1[2]);
       x_atom_1[dir] += pos;
 
       // minimum image of atom2 with respect to atom1
       diffx[0] = x[atom2][0] - x_atom_1[0];
       diffx[1] = x[atom2][1] - x_atom_1[1];
       diffx[2] = x[atom2][2] - x_atom_1[2];
-      domain->minimum_image(diffx[0], diffx[1], diffx[2]);
+      domain->minimum_image(FLERR, diffx[0], diffx[1], diffx[2]);
       x_atom_2[0] = x_atom_1[0] + diffx[0];
       x_atom_2[1] = x_atom_1[1] + diffx[1];
       x_atom_2[2] = x_atom_1[2] + diffx[2];
@@ -936,7 +936,7 @@ void ComputeStressMop::compute_dihedrals()
       diffx[0] = x[atom3][0] - x_atom_2[0];
       diffx[1] = x[atom3][1] - x_atom_2[1];
       diffx[2] = x[atom3][2] - x_atom_2[2];
-      domain->minimum_image(diffx[0], diffx[1], diffx[2]);
+      domain->minimum_image(FLERR, diffx[0], diffx[1], diffx[2]);
       x_atom_3[0] = x_atom_2[0] + diffx[0];
       x_atom_3[1] = x_atom_2[1] + diffx[1];
       x_atom_3[2] = x_atom_2[2] + diffx[2];
@@ -945,7 +945,7 @@ void ComputeStressMop::compute_dihedrals()
       diffx[0] = x[atom4][0] - x_atom_3[0];
       diffx[1] = x[atom4][1] - x_atom_3[1];
       diffx[2] = x[atom4][2] - x_atom_3[2];
-      domain->minimum_image(diffx[0], diffx[1], diffx[2]);
+      domain->minimum_image(FLERR, diffx[0], diffx[1], diffx[2]);
       x_atom_4[0] = x_atom_3[0] + diffx[0];
       x_atom_4[1] = x_atom_3[1] + diffx[1];
       x_atom_4[2] = x_atom_3[2] + diffx[2];

--- a/src/EXTRA-COMPUTE/compute_stress_mop_profile.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_mop_profile.cpp
@@ -544,7 +544,7 @@ void ComputeStressMopProfile::compute_pairs()
             xj[0] -= xi[0];
             xj[1] -= xi[1];
             xj[2] -= xi[2];
-            domain->minimum_image(FLERR, xi[0], xi[1], xi[2]);
+            domain->minimum_image(FLERR, xj[0], xj[1], xj[2]);
             xj[0] += xi[0];
             xj[1] += xi[1];
             xj[2] += xi[2];

--- a/src/EXTRA-COMPUTE/compute_stress_mop_profile.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_mop_profile.cpp
@@ -537,14 +537,14 @@ void ComputeStressMopProfile::compute_pairs()
 
             // minimum image of xi with respect to the plane
             xi[dir] -= pos;
-            domain->minimum_image(xi[0], xi[1], xi[2]);
+            domain->minimum_image(FLERR, xi[0], xi[1], xi[2]);
             xi[dir] += pos;
 
             // minimum image of xj with respect to xi
             xj[0] -= xi[0];
             xj[1] -= xi[1];
             xj[2] -= xi[2];
-            domain->minimum_image(xi[0], xi[1], xi[2]);
+            domain->minimum_image(FLERR, xi[0], xi[1], xi[2]);
             xj[0] += xi[0];
             xj[1] += xi[1];
             xj[2] += xi[2];
@@ -649,7 +649,7 @@ void ComputeStressMopProfile::compute_bonds()
         dx[1] = x[atom1][1];
         dx[2] = x[atom1][2];
         dx[dir] -= pos;
-        domain->minimum_image(dx[0], dx[1], dx[2]);
+        domain->minimum_image(FLERR, dx[0], dx[1], dx[2]);
         x_bond_1[0] = dx[0];
         x_bond_1[1] = dx[1];
         x_bond_1[2] = dx[2];
@@ -660,7 +660,7 @@ void ComputeStressMopProfile::compute_bonds()
         dx[0] = x[atom2][0] - x_bond_1[0];
         dx[1] = x[atom2][1] - x_bond_1[1];
         dx[2] = x[atom2][2] - x_bond_1[2];
-        domain->minimum_image(dx[0], dx[1], dx[2]);
+        domain->minimum_image(FLERR, dx[0], dx[1], dx[2]);
         x_bond_2[0] = x_bond_1[0] + dx[0];
         x_bond_2[1] = x_bond_1[1] + dx[1];
         x_bond_2[2] = x_bond_1[2] + dx[2];
@@ -783,7 +783,7 @@ void ComputeStressMopProfile::compute_angles()
         dx[1] = x[atom1][1];
         dx[2] = x[atom1][2];
         dx[dir] -= pos;
-        domain->minimum_image(dx[0], dx[1], dx[2]);
+        domain->minimum_image(FLERR, dx[0], dx[1], dx[2]);
         x_angle_left[0] = dx[0];
         x_angle_left[1] = dx[1];
         x_angle_left[2] = dx[2];
@@ -793,7 +793,7 @@ void ComputeStressMopProfile::compute_angles()
         dx_left[0] = x[atom2][0] - x_angle_left[0];
         dx_left[1] = x[atom2][1] - x_angle_left[1];
         dx_left[2] = x[atom2][2] - x_angle_left[2];
-        domain->minimum_image(dx_left[0], dx_left[1], dx_left[2]);
+        domain->minimum_image(FLERR, dx_left[0], dx_left[1], dx_left[2]);
         x_angle_middle[0] = x_angle_left[0] + dx_left[0];
         x_angle_middle[1] = x_angle_left[1] + dx_left[1];
         x_angle_middle[2] = x_angle_left[2] + dx_left[2];
@@ -802,7 +802,7 @@ void ComputeStressMopProfile::compute_angles()
         dx_right[0] = x[atom3][0] - x_angle_middle[0];
         dx_right[1] = x[atom3][1] - x_angle_middle[1];
         dx_right[2] = x[atom3][2] - x_angle_middle[2];
-        domain->minimum_image(dx_right[0], dx_right[1], dx_right[2]);
+        domain->minimum_image(FLERR, dx_right[0], dx_right[1], dx_right[2]);
         x_angle_right[0] = x_angle_middle[0] + dx_right[0];
         x_angle_right[1] = x_angle_middle[1] + dx_right[1];
         x_angle_right[2] = x_angle_middle[2] + dx_right[2];
@@ -971,14 +971,14 @@ void ComputeStressMopProfile::compute_dihedrals()
         x_atom_1[1] = x[atom1][1];
         x_atom_1[2] = x[atom1][2];
         x_atom_1[dir] -= pos;
-        domain->minimum_image(x_atom_1[0], x_atom_1[1], x_atom_1[2]);
+        domain->minimum_image(FLERR, x_atom_1[0], x_atom_1[1], x_atom_1[2]);
         x_atom_1[dir] += pos;
 
         // minimum image of atom2 with respect to atom1
         diffx[0] = x[atom2][0] - x_atom_1[0];
         diffx[1] = x[atom2][1] - x_atom_1[1];
         diffx[2] = x[atom2][2] - x_atom_1[2];
-        domain->minimum_image(diffx[0], diffx[1], diffx[2]);
+        domain->minimum_image(FLERR, diffx[0], diffx[1], diffx[2]);
         x_atom_2[0] = x_atom_1[0] + diffx[0];
         x_atom_2[1] = x_atom_1[1] + diffx[1];
         x_atom_2[2] = x_atom_1[2] + diffx[2];
@@ -987,7 +987,7 @@ void ComputeStressMopProfile::compute_dihedrals()
         diffx[0] = x[atom3][0] - x_atom_2[0];
         diffx[1] = x[atom3][1] - x_atom_2[1];
         diffx[2] = x[atom3][2] - x_atom_2[2];
-        domain->minimum_image(diffx[0], diffx[1], diffx[2]);
+        domain->minimum_image(FLERR, diffx[0], diffx[1], diffx[2]);
         x_atom_3[0] = x_atom_2[0] + diffx[0];
         x_atom_3[1] = x_atom_2[1] + diffx[1];
         x_atom_3[2] = x_atom_2[2] + diffx[2];
@@ -996,7 +996,7 @@ void ComputeStressMopProfile::compute_dihedrals()
         diffx[0] = x[atom4][0] - x_atom_3[0];
         diffx[1] = x[atom4][1] - x_atom_3[1];
         diffx[2] = x[atom4][2] - x_atom_3[2];
-        domain->minimum_image(diffx[0], diffx[1], diffx[2]);
+        domain->minimum_image(FLERR, diffx[0], diffx[1], diffx[2]);
         x_atom_4[0] = x_atom_3[0] + diffx[0];
         x_atom_4[1] = x_atom_3[1] + diffx[1];
         x_atom_4[2] = x_atom_3[2] + diffx[2];

--- a/src/EXTRA-FIX/fix_drag.cpp
+++ b/src/EXTRA-FIX/fix_drag.cpp
@@ -114,7 +114,7 @@ void FixDrag::post_force(int /*vflag*/)
       if (!xflag) dx = 0.0;
       if (!yflag) dy = 0.0;
       if (!zflag) dz = 0.0;
-      domain->minimum_image(dx,dy,dz);
+      domain->minimum_image(FLERR, dx,dy,dz);
       r = sqrt(dx*dx + dy*dy + dz*dz);
       if (r > delta) {
         prefactor = f_mag/r;

--- a/src/EXTRA-FIX/fix_filter_corotate.cpp
+++ b/src/EXTRA-FIX/fix_filter_corotate.cpp
@@ -547,17 +547,17 @@ void FixFilterCorotate::pre_neighbor()
           del1[0] = x[atom1][0]-x[oxy][0];
           del1[1] = x[atom1][1]-x[oxy][1];
           del1[2] = x[atom1][2]-x[oxy][2];
-          domain->minimum_image(del1);
+          domain->minimum_image(FLERR, del1);
 
           del2[0] = x[atom2][0]-x[atom1][0];
           del2[1] = x[atom2][1]-x[atom1][1];
           del2[2] = x[atom2][2]-x[atom1][2];
-          domain->minimum_image(del2);
+          domain->minimum_image(FLERR, del2);
 
           del3[0] = x[atom3][0]-x[atom1][0];
           del3[1] = x[atom3][1]-x[atom1][1];
           del3[2] = x[atom3][2]-x[atom1][2];
-          domain->minimum_image(del3);
+          domain->minimum_image(FLERR, del3);
 
           double a = (del2[1])*(del3[2]) - (del2[2])*(del3[1]);
           double b = (del2[2])*(del3[0]) - (del2[0])*(del3[2]);
@@ -620,17 +620,17 @@ void FixFilterCorotate::pre_neighbor()
         del1[0] = x[atom1][0]-x[oxy][0];
         del1[1] = x[atom1][1]-x[oxy][1];
         del1[2] = x[atom1][2]-x[oxy][2];
-        domain->minimum_image(del1);
+        domain->minimum_image(FLERR, del1);
 
         del2[0] = x[atom2][0]-x[atom1][0];
         del2[1] = x[atom2][1]-x[atom1][1];
         del2[2] = x[atom2][2]-x[atom1][2];
-        domain->minimum_image(del2);
+        domain->minimum_image(FLERR, del2);
 
         del3[0] = x[atom3][0]-x[atom1][0];
         del3[1] = x[atom3][1]-x[atom1][1];
         del3[2] = x[atom3][2]-x[atom1][2];
-        domain->minimum_image(del3);
+        domain->minimum_image(FLERR, del3);
 
         double a = (del2[1])*(del3[2]) - (del2[2])*(del3[1]);
         double b = (del2[2])*(del3[0]) - (del2[0])*(del3[2]);
@@ -1414,7 +1414,7 @@ void FixFilterCorotate::general_cluster(int index, int index_in_list)
     del[i][0] = x[list_cluster[i]][0] - x[list_cluster[0]][0];
     del[i][1] = x[list_cluster[i]][1] - x[list_cluster[0]][1];
     del[i][2] = x[list_cluster[i]][2] - x[list_cluster[0]][2];
-    domain->minimum_image(del[i]);
+    domain->minimum_image(FLERR, del[i]);
     r[i] = 1.0/sqrt(del[i][0]*del[i][0]+del[i][1]*del[i][1]+
       del[i][2]*del[i][2]);
   }

--- a/src/EXTRA-FIX/fix_pafi.cpp
+++ b/src/EXTRA-FIX/fix_pafi.cpp
@@ -261,7 +261,7 @@ void FixPAFI::post_force(int /*vflag*/)
       deviation[0] = x[i][0]-path[i][0]; // x-path
       deviation[1] = x[i][1]-path[i][1]; // x-path
       deviation[2] = x[i][2]-path[i][2]; // x-path
-      domain->minimum_image(deviation);
+      domain->minimum_image(FLERR, deviation);
 
       proj[3] += path[i][6]*deviation[0]; // (x-path).dn/nn = psi
       proj[3] += path[i][7]*deviation[1]; // (x-path).dn/nn = psi
@@ -424,7 +424,7 @@ void FixPAFI::min_post_force(int /*vflag*/)
       deviation[0] = x[i][0]-path[i][0]; // x-path
       deviation[1] = x[i][1]-path[i][1]; // x-path
       deviation[2] = x[i][2]-path[i][2]; // x-path
-      domain->minimum_image(deviation);
+      domain->minimum_image(FLERR, deviation);
 
       proj[3] += path[i][6]*deviation[0]; // (x-path).dn/nn = psi
       proj[3] += path[i][7]*deviation[1]; // (x-path).dn/nn = psi

--- a/src/EXTRA-MOLECULE/angle_cosine_delta.cpp
+++ b/src/EXTRA-MOLECULE/angle_cosine_delta.cpp
@@ -155,13 +155,13 @@ double AngleCosineDelta::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;
@@ -185,13 +185,13 @@ void AngleCosineDelta::born_matrix(int type, int i1, int i2, int i3, double &du,
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/EXTRA-MOLECULE/angle_cosine_periodic.cpp
+++ b/src/EXTRA-MOLECULE/angle_cosine_periodic.cpp
@@ -284,13 +284,13 @@ double AngleCosinePeriodic::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;
@@ -311,13 +311,13 @@ void AngleCosinePeriodic::born_matrix(int type, int i1, int i2, int i3, double &
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/EXTRA-MOLECULE/angle_cosine_shift.cpp
+++ b/src/EXTRA-MOLECULE/angle_cosine_shift.cpp
@@ -258,13 +258,13 @@ double AngleCosineShift::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/EXTRA-MOLECULE/angle_cosine_shift_exp.cpp
+++ b/src/EXTRA-MOLECULE/angle_cosine_shift_exp.cpp
@@ -297,13 +297,13 @@ double AngleCosineShiftExp::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/EXTRA-MOLECULE/angle_cosine_squared_restricted.cpp
+++ b/src/EXTRA-MOLECULE/angle_cosine_squared_restricted.cpp
@@ -242,13 +242,13 @@ double AngleCosineSquaredRestricted::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;
@@ -272,13 +272,13 @@ void AngleCosineSquaredRestricted::born_matrix(int type, int i1, int i2, int i3,
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/EXTRA-MOLECULE/angle_fourier.cpp
+++ b/src/EXTRA-MOLECULE/angle_fourier.cpp
@@ -263,13 +263,13 @@ double AngleFourier::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;
@@ -291,13 +291,13 @@ void AngleFourier::born_matrix(int type, int i1, int i2, int i3, double &du, dou
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/EXTRA-MOLECULE/angle_fourier_simple.cpp
+++ b/src/EXTRA-MOLECULE/angle_fourier_simple.cpp
@@ -269,13 +269,13 @@ double AngleFourierSimple::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;
@@ -297,13 +297,13 @@ void AngleFourierSimple::born_matrix(int type, int i1, int i2, int i3, double &d
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/EXTRA-MOLECULE/angle_gaussian.cpp
+++ b/src/EXTRA-MOLECULE/angle_gaussian.cpp
@@ -325,13 +325,13 @@ double AngleGaussian::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/EXTRA-MOLECULE/angle_mwlc.cpp
+++ b/src/EXTRA-MOLECULE/angle_mwlc.cpp
@@ -260,13 +260,13 @@ double AngleMWLC::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;
@@ -289,12 +289,12 @@ void AngleMWLC::born_matrix(int type, int i1, int i2, int i3, double &du, double
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;
   c /= sqrt((delx1 * delx1 + dely1 * dely1 + delz1 * delz1) *

--- a/src/EXTRA-MOLECULE/angle_quartic.cpp
+++ b/src/EXTRA-MOLECULE/angle_quartic.cpp
@@ -269,13 +269,13 @@ double AngleQuartic::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;
@@ -299,13 +299,13 @@ void AngleQuartic::born_matrix(int type, int i1, int i2, int i3, double &du, dou
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/EXTRA-MOLECULE/bond_harmonic_restrain.cpp
+++ b/src/EXTRA-MOLECULE/bond_harmonic_restrain.cpp
@@ -74,7 +74,7 @@ void BondHarmonicRestrain::compute(int eflag, int vflag)
     delx = x0[i1][0] - x0[i2][0];
     dely = x0[i1][1] - x0[i2][1];
     delz = x0[i1][2] - x0[i2][2];
-    domain->minimum_image(delx, dely, delz);
+    domain->minimum_image(FLERR, delx, dely, delz);
     rsq = delx * delx + dely * dely + delz * delz;
     r0 = sqrt(rsq);
 
@@ -235,7 +235,7 @@ double BondHarmonicRestrain::single(int type, double rsq, int i, int j, double &
   double delx = x0[i][0] - x0[j][0];
   double dely = x0[i][1] - x0[j][1];
   double delz = x0[i][2] - x0[j][2];
-  domain->minimum_image(delx, dely, delz);
+  domain->minimum_image(FLERR, delx, dely, delz);
   double r0 = sqrt(delx * delx + dely * dely + delz * delz);
 
   double r = sqrt(rsq);

--- a/src/EXTRA-MOLECULE/dihedral_spherical.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_spherical.cpp
@@ -110,9 +110,9 @@ static double Phi(double const *x1,    //array holding x,y,z coords atom 1
   }
 
   //Consider periodic boundary conditions:
-  domain->minimum_image(vb12[0], vb12[1], vb12[2]);
-  domain->minimum_image(vb23[0], vb23[1], vb23[2]);
-  domain->minimum_image(vb34[0], vb34[1], vb34[2]);
+  domain->minimum_image(FLERR, vb12[0], vb12[1], vb12[2]);
+  domain->minimum_image(FLERR, vb23[0], vb23[1], vb23[2]);
+  domain->minimum_image(FLERR, vb34[0], vb34[1], vb34[2]);
 
   //--- Compute the normal to the planes formed by atoms 1,2,3 and 2,3,4 ---
 

--- a/src/EXTRA-MOLECULE/improper_distance.cpp
+++ b/src/EXTRA-MOLECULE/improper_distance.cpp
@@ -94,31 +94,31 @@ void ImproperDistance::compute(int eflag, int vflag)
     xab = x[i2][0] - x[i1][0];
     yab = x[i2][1] - x[i1][1];
     zab = x[i2][2] - x[i1][2];
-    domain->minimum_image(xab,yab,zab);
+    domain->minimum_image(FLERR, xab,yab,zab);
 
     // bond 1->3
     xac = x[i3][0] - x[i1][0];
     yac = x[i3][1] - x[i1][1];
     zac = x[i3][2] - x[i1][2];
-    domain->minimum_image(xac,yac,zac);
+    domain->minimum_image(FLERR, xac,yac,zac);
 
     // bond 1->4
     xad = x[i4][0] - x[i1][0];
     yad = x[i4][1] - x[i1][1];
     zad = x[i4][2] - x[i1][2];
-    domain->minimum_image(xad,yad,zad);
+    domain->minimum_image(FLERR, xad,yad,zad);
 
     // bond 2-3
     xbc = x[i3][0] - x[i2][0];
     ybc = x[i3][1] - x[i2][1];
     zbc = x[i3][2] - x[i2][2];
-    domain->minimum_image(xbc,ybc,zbc);
+    domain->minimum_image(FLERR, xbc,ybc,zbc);
 
     // bond 2-4
     xbd = x[i4][0] - x[i2][0];
     ybd = x[i4][1] - x[i2][1];
     zbd = x[i4][2] - x[i2][2];
-    domain->minimum_image(xbd,ybd,zbd);
+    domain->minimum_image(FLERR, xbd,ybd,zbd);
 
     xna =   ybc*zbd - zbc*ybd;
     yna = -(xbc*zbd - zbc*xbd);

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -540,7 +540,7 @@ void FixPour::pre_exchange()
           delx = coords[m][0] - xnear[i][0];
           dely = coords[m][1] - xnear[i][1];
           delz = coords[m][2] - xnear[i][2];
-          domain->minimum_image(delx, dely, delz);
+          domain->minimum_image(FLERR, delx, dely, delz);
           rsq = delx * delx + dely * dely + delz * delz;
           radsum = coords[m][3] + xnear[i][3];
           if (rsq <= radsum * radsum) break;
@@ -781,7 +781,7 @@ int FixPour::overlap(int i)
       double delx = x[0] - xc;
       double dely = x[1] - yc;
       double delz = 0.0;
-      domain->minimum_image(delx, dely, delz);
+      domain->minimum_image(FLERR, delx, dely, delz);
       double rsq = delx * delx + dely * dely;
       double r = rc + delta;
       if (rsq > r * r) return 0;

--- a/src/KOKKOS/fix_minimize_kokkos.cpp
+++ b/src/KOKKOS/fix_minimize_kokkos.cpp
@@ -121,7 +121,7 @@ void FixMinimizeKokkos::reset_coords()
       double dx = dx0;
       double dy = dy0;
       double dz = dz0;
-      // domain->minimum_image(dx,dy,dz);
+      // domain->minimum_image(FLERR, dx,dy,dz);
       {
         if (triclinic == 0) {
           if (xperiodic) {
@@ -175,7 +175,7 @@ void FixMinimizeKokkos::reset_coords()
             }
           }
         }
-      } // end domain->minimum_image(dx,dy,dz);
+      } // end domain->minimum_image(FLERR, dx,dy,dz);
       if (dx != dx0) l_x0[n] = l_x(i,0) - dx;
       if (dy != dy0) l_x0[n+1] = l_x(i,1) - dy;
       if (dz != dz0) l_x0[n+2] = l_x(i,2) - dz;

--- a/src/LEPTON/angle_lepton.cpp
+++ b/src/LEPTON/angle_lepton.cpp
@@ -395,13 +395,13 @@ double AngleLepton::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/LEPTON/dihedral_lepton.cpp
+++ b/src/LEPTON/dihedral_lepton.cpp
@@ -508,9 +508,9 @@ double DihedralLepton::get_phi(double const *x1,    //array holding x,y,z coords
   }
 
   //Consider periodic boundary conditions:
-  domain->minimum_image(vb12[0], vb12[1], vb12[2]);
-  domain->minimum_image(vb23[0], vb23[1], vb23[2]);
-  domain->minimum_image(vb34[0], vb34[1], vb34[2]);
+  domain->minimum_image(FLERR, vb12[0], vb12[1], vb12[2]);
+  domain->minimum_image(FLERR, vb23[0], vb23[1], vb23[2]);
+  domain->minimum_image(FLERR, vb34[0], vb34[1], vb34[2]);
 
   //--- Compute the normal to the planes formed by atoms 1,2,3 and 2,3,4 ---
 

--- a/src/MACHDYN/pair_smd_hertz.cpp
+++ b/src/MACHDYN/pair_smd_hertz.cpp
@@ -145,7 +145,7 @@ void PairHertz::compute(int eflag, int vflag) {
                                         dely0 = x0[j][1] - x0[i][1];
                                         delz0 = x0[j][2] - x0[i][2];
                                         if (periodic) {
-                                                domain->minimum_image(delx0, dely0, delz0);
+                                                domain->minimum_image(FLERR, delx0, dely0, delz0);
                                         }
                                         rSq0 = delx0 * delx0 + dely0 * dely0 + delz0 * delz0; // initial distance
                                         sphCut = sph_radius[i] + sph_radius[j];

--- a/src/MACHDYN/pair_smd_tlsph.cpp
+++ b/src/MACHDYN/pair_smd_tlsph.cpp
@@ -220,7 +220,7 @@ void PairTlsph::PreCompute() {
         dx = xj - xi;
 
         if (periodic)
-          domain->minimum_image(dx0(0), dx0(1), dx0(2));
+          domain->minimum_image(FLERR, dx0(0), dx0(1), dx0(2));
 
         r0Sq = dx0.squaredNorm();
         h = irad + radius[j];
@@ -488,7 +488,7 @@ void PairTlsph::ComputeForces(int eflag, int vflag) {
       }
 
       if (periodic)
-        domain->minimum_image(dx0(0), dx0(1), dx0(2));
+        domain->minimum_image(FLERR, dx0(0), dx0(1), dx0(2));
 
       // check that distance between i and j (in the reference config) is less than cutoff
       dx0 = x0j - x0i;

--- a/src/MACHDYN/pair_smd_triangulated_surface.cpp
+++ b/src/MACHDYN/pair_smd_triangulated_surface.cpp
@@ -154,7 +154,7 @@ void PairTriSurf::compute(int eflag, int vflag) {
                         x4(2) = x[particle][2];
                         dx = x_center - x4; //
                         if (periodic) {
-                                domain->minimum_image(dx(0), dx(1), dx(2));
+                                domain->minimum_image(FLERR, dx(0), dx(1), dx(2));
                         }
                         rsq = dx.squaredNorm();
 

--- a/src/MC/fix_bond_swap.cpp
+++ b/src/MC/fix_bond_swap.cpp
@@ -723,7 +723,7 @@ double FixBondSwap::dist_rsq(int i, int j)
   double delx = x[i][0] - x[j][0];
   double dely = x[i][1] - x[j][1];
   double delz = x[i][2] - x[j][2];
-  domain->minimum_image(delx,dely,delz);
+  domain->minimum_image(FLERR, delx,dely,delz);
   return (delx*delx + dely*dely + delz*delz);
 }
 

--- a/src/MDI/fix_mdi_qmmm.cpp
+++ b/src/MDI/fix_mdi_qmmm.cpp
@@ -687,7 +687,7 @@ void FixMDIQMMM::pre_force(int vflag)
         double delx = xqm[i][0] - xqm[j][0];
         double dely = xqm[i][1] - xqm[j][1];
         double delz = xqm[i][2] - xqm[j][2];
-        domain->minimum_image(delx, dely, delz);
+        domain->minimum_image(FLERR, delx, dely, delz);
         rsq = delx * delx + dely * dely + delz * delz;
         qpotential_mine[i] -= qqrd2e * qqm[j] / sqrt(rsq);
       }

--- a/src/MESONT/angle_mesocnt.cpp
+++ b/src/MESONT/angle_mesocnt.cpp
@@ -371,13 +371,13 @@ double AngleMesoCNT::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/MISC/fix_ipi.cpp
+++ b/src/MISC/fix_ipi.cpp
@@ -399,7 +399,7 @@ void FixIPI::initial_integrate(int /*vflag*/)
         auto dely = x[i][1] - xhold[i][1];
         auto delz = x[i][2] - xhold[i][2];
 
-        domain->minimum_image(delx, dely, delz);
+        domain->minimum_image(FLERR, delx, dely, delz);
 
         x[i][0] = xhold[i][0] + delx;
         x[i][1] = xhold[i][1] + dely;

--- a/src/MOFFF/angle_class2_p6.cpp
+++ b/src/MOFFF/angle_class2_p6.cpp
@@ -453,13 +453,13 @@ double AngleClass2P6::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/MOFFF/angle_cosine_buck6d.cpp
+++ b/src/MOFFF/angle_cosine_buck6d.cpp
@@ -365,13 +365,13 @@ double AngleCosineBuck6d::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/MOLECULE/angle_charmm.cpp
+++ b/src/MOLECULE/angle_charmm.cpp
@@ -282,19 +282,19 @@ double AngleCharmm::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double delxUB = x[i3][0] - x[i1][0];
   double delyUB = x[i3][1] - x[i1][1];
   double delzUB = x[i3][2] - x[i1][2];
-  domain->minimum_image(delxUB, delyUB, delzUB);
+  domain->minimum_image(FLERR, delxUB, delyUB, delzUB);
   double rUB = sqrt(delxUB * delxUB + delyUB * delyUB + delzUB * delzUB);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/MOLECULE/angle_cosine.cpp
+++ b/src/MOLECULE/angle_cosine.cpp
@@ -222,13 +222,13 @@ double AngleCosine::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/MOLECULE/angle_cosine_squared.cpp
+++ b/src/MOLECULE/angle_cosine_squared.cpp
@@ -245,13 +245,13 @@ double AngleCosineSquared::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;
@@ -273,13 +273,13 @@ void AngleCosineSquared::born_matrix(int type, int i1, int i2, int i3, double &d
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/MOLECULE/angle_harmonic.cpp
+++ b/src/MOLECULE/angle_harmonic.cpp
@@ -248,13 +248,13 @@ double AngleHarmonic::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;
@@ -276,13 +276,13 @@ void AngleHarmonic::born_matrix(int type, int i1, int i2, int i3, double &du, do
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/MOLECULE/angle_table.cpp
+++ b/src/MOLECULE/angle_table.cpp
@@ -330,13 +330,13 @@ double AngleTable::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1, dely1, delz1);
+  domain->minimum_image(FLERR, delx1, dely1, delz1);
   double r1 = sqrt(delx1 * delx1 + dely1 * dely1 + delz1 * delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2, dely2, delz2);
+  domain->minimum_image(FLERR, delx2, dely2, delz2);
   double r2 = sqrt(delx2 * delx2 + dely2 * dely2 + delz2 * delz2);
 
   double c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;

--- a/src/MOLECULE/dihedral_table.cpp
+++ b/src/MOLECULE/dihedral_table.cpp
@@ -381,9 +381,9 @@ static double Phi(double const *x1, //array holding x,y,z coords atom 1
   }
 
   //Consider periodic boundary conditions:
-  domain->minimum_image(vb12[0],vb12[1],vb12[2]);
-  domain->minimum_image(vb23[0],vb23[1],vb23[2]);
-  domain->minimum_image(vb34[0],vb34[1],vb34[2]);
+  domain->minimum_image(FLERR, vb12[0],vb12[1],vb12[2]);
+  domain->minimum_image(FLERR, vb23[0],vb23[1],vb23[2]);
+  domain->minimum_image(FLERR, vb34[0],vb34[1],vb34[2]);
 
   //--- Compute the normal to the planes formed by atoms 1,2,3 and 2,3,4 ---
 

--- a/src/MOLECULE/pair_hbond_dreiding_lj.cpp
+++ b/src/MOLECULE/pair_hbond_dreiding_lj.cpp
@@ -162,14 +162,14 @@ void PairHbondDreidingLJ::compute(int eflag, int vflag)
           delr1[0] = x[i][0] - x[k][0];
           delr1[1] = x[i][1] - x[k][1];
           delr1[2] = x[i][2] - x[k][2];
-          domain->minimum_image(delr1);
+          domain->minimum_image(FLERR, delr1);
           rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
           r1 = sqrt(rsq1);
 
           delr2[0] = x[j][0] - x[k][0];
           delr2[1] = x[j][1] - x[k][1];
           delr2[2] = x[j][2] - x[k][2];
-          domain->minimum_image(delr2);
+          domain->minimum_image(FLERR, delr2);
           rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
           r2 = sqrt(rsq2);
 
@@ -540,14 +540,14 @@ double PairHbondDreidingLJ::single(int i, int j, int itype, int jtype,
     delr1[0] = x[i][0] - x[k][0];
     delr1[1] = x[i][1] - x[k][1];
     delr1[2] = x[i][2] - x[k][2];
-    domain->minimum_image(delr1);
+    domain->minimum_image(FLERR, delr1);
     rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
     r1 = sqrt(rsq1);
 
     delr2[0] = x[j][0] - x[k][0];
     delr2[1] = x[j][1] - x[k][1];
     delr2[2] = x[j][2] - x[k][2];
-    domain->minimum_image(delr2);
+    domain->minimum_image(FLERR, delr2);
     rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
     r2 = sqrt(rsq2);
 

--- a/src/MOLECULE/pair_hbond_dreiding_morse.cpp
+++ b/src/MOLECULE/pair_hbond_dreiding_morse.cpp
@@ -129,14 +129,14 @@ void PairHbondDreidingMorse::compute(int eflag, int vflag)
           delr1[0] = x[i][0] - x[k][0];
           delr1[1] = x[i][1] - x[k][1];
           delr1[2] = x[i][2] - x[k][2];
-          domain->minimum_image(delr1);
+          domain->minimum_image(FLERR, delr1);
           rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
           r1 = sqrt(rsq1);
 
           delr2[0] = x[j][0] - x[k][0];
           delr2[1] = x[j][1] - x[k][1];
           delr2[2] = x[j][2] - x[k][2];
-          domain->minimum_image(delr2);
+          domain->minimum_image(FLERR, delr2);
           rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
           r2 = sqrt(rsq2);
 
@@ -434,14 +434,14 @@ double PairHbondDreidingMorse::single(int i, int j, int itype, int jtype,
     delr1[0] = x[i][0] - x[k][0];
     delr1[1] = x[i][1] - x[k][1];
     delr1[2] = x[i][2] - x[k][2];
-    domain->minimum_image(delr1);
+    domain->minimum_image(FLERR, delr1);
     rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
     r1 = sqrt(rsq1);
 
     delr2[0] = x[j][0] - x[k][0];
     delr2[1] = x[j][1] - x[k][1];
     delr2[2] = x[j][2] - x[k][2];
-    domain->minimum_image(delr2);
+    domain->minimum_image(FLERR, delr2);
     rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
     r2 = sqrt(rsq2);
 

--- a/src/OPENMP/dihedral_table_omp.cpp
+++ b/src/OPENMP/dihedral_table_omp.cpp
@@ -64,9 +64,9 @@ static double Phi(double const *x1, //array holding x,y,z coords atom 1
   }
 
   //Consider periodic boundary conditions:
-  domain->minimum_image(vb12[0],vb12[1],vb12[2]);
-  domain->minimum_image(vb23[0],vb23[1],vb23[2]);
-  domain->minimum_image(vb34[0],vb34[1],vb34[2]);
+  domain->minimum_image(FLERR, vb12[0],vb12[1],vb12[2]);
+  domain->minimum_image(FLERR, vb23[0],vb23[1],vb23[2]);
+  domain->minimum_image(FLERR, vb34[0],vb34[1],vb34[2]);
 
   //--- Compute the normal to the planes formed by atoms 1,2,3 and 2,3,4 ---
 

--- a/src/OPENMP/pair_hbond_dreiding_lj_omp.cpp
+++ b/src/OPENMP/pair_hbond_dreiding_lj_omp.cpp
@@ -201,14 +201,14 @@ void PairHbondDreidingLJOMP::eval(int iifrom, int iito, ThrData * const thr)
           delr1[0] = xtmp - x[k].x;
           delr1[1] = ytmp - x[k].y;
           delr1[2] = ztmp - x[k].z;
-          domain->minimum_image(delr1);
+          domain->minimum_image(FLERR, delr1);
           rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
           r1 = sqrt(rsq1);
 
           delr2[0] = x[j].x - x[k].x;
           delr2[1] = x[j].y - x[k].y;
           delr2[2] = x[j].z - x[k].z;
-          domain->minimum_image(delr2);
+          domain->minimum_image(FLERR, delr2);
           rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
           r2 = sqrt(rsq2);
 

--- a/src/OPENMP/pair_hbond_dreiding_morse_omp.cpp
+++ b/src/OPENMP/pair_hbond_dreiding_morse_omp.cpp
@@ -202,14 +202,14 @@ void PairHbondDreidingMorseOMP::eval(int iifrom, int iito, ThrData * const thr)
           delr1[0] = xtmp - x[k].x;
           delr1[1] = ytmp - x[k].y;
           delr1[2] = ztmp - x[k].z;
-          domain->minimum_image(delr1);
+          domain->minimum_image(FLERR, delr1);
           rsq1 = delr1[0]*delr1[0] + delr1[1]*delr1[1] + delr1[2]*delr1[2];
           r1 = sqrt(rsq1);
 
           delr2[0] = x[j].x - x[k].x;
           delr2[1] = x[j].y - x[k].y;
           delr2[2] = x[j].z - x[k].z;
-          domain->minimum_image(delr2);
+          domain->minimum_image(FLERR, delr2);
           rsq2 = delr2[0]*delr2[0] + delr2[1]*delr2[1] + delr2[2]*delr2[2];
           r2 = sqrt(rsq2);
 

--- a/src/OPENMP/pair_peri_lps_omp.cpp
+++ b/src/OPENMP/pair_peri_lps_omp.cpp
@@ -161,7 +161,7 @@ void PairPeriLPSOMP::eval(int iifrom, int iito, ThrData * const thr)
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       rsq0 = delx0*delx0 + dely0*dely0 + delz0*delz0;
       jtype = type[j];
 
@@ -285,12 +285,12 @@ void PairPeriLPSOMP::eval(int iifrom, int iito, ThrData * const thr)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx,dely,delz);
+      if (periodic) domain->minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       jtype = type[j];
       delta = cut[itype][jtype];
       r = sqrt(rsq);

--- a/src/OPENMP/pair_peri_pmb_omp.cpp
+++ b/src/OPENMP/pair_peri_pmb_omp.cpp
@@ -156,7 +156,7 @@ void PairPeriPMBOMP::eval(int iifrom, int iito, ThrData * const thr)
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       rsq0 = delx0*delx0 + dely0*dely0 + delz0*delz0;
       jtype = type[j];
 
@@ -244,7 +244,7 @@ void PairPeriPMBOMP::eval(int iifrom, int iito, ThrData * const thr)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx,dely,delz);
+      if (periodic) domain->minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       jtype = type[j];
       delta = cut[itype][jtype];

--- a/src/PERI/pair_peri.cpp
+++ b/src/PERI/pair_peri.cpp
@@ -189,12 +189,12 @@ void PairPeri::compute_dilatation(int ifrom, int ito)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx, dely, delz);
+      if (periodic) domain->minimum_image(FLERR, delx, dely, delz);
       rsq = delx * delx + dely * dely + delz * delz;
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0, dely0, delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0, dely0, delz0);
 
       r = sqrt(rsq);
       dr = r - r0[i][jj];

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -124,7 +124,7 @@ void PairPeriEPS::compute(int eflag, int vflag)
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       rsq0 = delx0*delx0 + dely0*dely0 + delz0*delz0;
       jtype = type[j];
 
@@ -262,12 +262,12 @@ void PairPeriEPS::compute(int eflag, int vflag)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx,dely,delz);
+      if (periodic) domain->minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       jtype = type[j];
       delta = cut[itype][jtype];
       r = sqrt(rsq);
@@ -514,12 +514,12 @@ double PairPeriEPS::compute_DeviatoricForceStateNorm(int i)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx,dely,delz);
+      if (periodic) domain->minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       r = sqrt(rsq);
       dr = r - r0[i][jj];
       if (fabs(dr) < NEAR_ZERO) dr = 0.0;

--- a/src/PERI/pair_peri_lps.cpp
+++ b/src/PERI/pair_peri_lps.cpp
@@ -116,7 +116,7 @@ void PairPeriLPS::compute(int eflag, int vflag)
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       rsq0 = delx0*delx0 + dely0*dely0 + delz0*delz0;
       jtype = type[j];
 
@@ -225,12 +225,12 @@ void PairPeriLPS::compute(int eflag, int vflag)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx,dely,delz);
+      if (periodic) domain->minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       jtype = type[j];
       delta = cut[itype][jtype];
       r = sqrt(rsq);

--- a/src/PERI/pair_peri_pmb.cpp
+++ b/src/PERI/pair_peri_pmb.cpp
@@ -110,7 +110,7 @@ void PairPeriPMB::compute(int eflag, int vflag)
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       rsq0 = delx0*delx0 + dely0*dely0 + delz0*delz0;
       jtype = type[j];
 
@@ -189,7 +189,7 @@ void PairPeriPMB::compute(int eflag, int vflag)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx,dely,delz);
+      if (periodic) domain->minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       jtype = type[j];
       delta = cut[itype][jtype];
@@ -361,7 +361,7 @@ double PairPeriPMB::single(int i, int j, int itype, int jtype, double rsq,
   dely0 = x0[i][1] - x0[j][1];
   delz0 = x0[i][2] - x0[j][2];
   int periodic = domain->xperiodic || domain->yperiodic || domain->zperiodic;
-  if (periodic) domain->minimum_image(delx0,dely0,delz0);
+  if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
   rsq0 = delx0*delx0 + dely0*dely0 + delz0*delz0;
 
   d_ij = MIN(0.9*sqrt(rsq0),1.35*lc);

--- a/src/PERI/pair_peri_ves.cpp
+++ b/src/PERI/pair_peri_ves.cpp
@@ -121,7 +121,7 @@ void PairPeriVES::compute(int eflag, int vflag)
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       rsq0 = delx0*delx0 + dely0*dely0 + delz0*delz0;
       jtype = type[j];
 
@@ -233,12 +233,12 @@ void PairPeriVES::compute(int eflag, int vflag)
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      if (periodic) domain->minimum_image(delx,dely,delz);
+      if (periodic) domain->minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       delx0 = xtmp0 - x0[j][0];
       dely0 = ytmp0 - x0[j][1];
       delz0 = ztmp0 - x0[j][2];
-      if (periodic) domain->minimum_image(delx0,dely0,delz0);
+      if (periodic) domain->minimum_image(FLERR, delx0,dely0,delz0);
       jtype = type[j];
       delta = cut[itype][jtype];
       r = sqrt(rsq);

--- a/src/PHONON/fix_phonon.cpp
+++ b/src/PHONON/fix_phonon.cpp
@@ -400,7 +400,7 @@ void FixPhonon::end_of_step()
       ndim = sysdim;
       for (i = 1; i < nucell; ++i) {
         for (idim = 0; idim < sysdim; ++idim) dist2orig[idim] = Rnow[idx][ndim++] - Rnow[idx][idim];
-        domain->minimum_image_big(dist2orig);
+        domain->minimum_image_big(FLERR, dist2orig);
         for (idim = 0; idim < sysdim; ++idim) basis[i][idim] += dist2orig[idim];
       }
     }

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -1190,7 +1190,7 @@ void FixBondReact::far_partner()
       delx = xtmp - x[j][0];
       dely = ytmp - x[j][1];
       delz = ztmp - x[j][2];
-      domain->minimum_image(delx,dely,delz); // ghost location fix
+      domain->minimum_image(FLERR, delx,dely,delz); // ghost location fix
       rsq = delx*delx + dely*dely + delz*delz;
 
       if (var_flag[RMIN][rxnID]) {
@@ -1260,7 +1260,7 @@ void FixBondReact::close_partner()
       delx = x[i1][0] - x[i2][0];
       dely = x[i1][1] - x[i2][1];
       delz = x[i1][2] - x[i2][2];
-      domain->minimum_image(delx,dely,delz); // ghost location fix
+      domain->minimum_image(FLERR, delx,dely,delz); // ghost location fix
       rsq = delx*delx + dely*dely + delz*delz;
 
       if (var_flag[RMIN][rxnID]) {
@@ -1972,7 +1972,7 @@ int FixBondReact::check_constraints()
       delx = x1[0] - x2[0];
       dely = x1[1] - x2[1];
       delz = x1[2] - x2[2];
-      domain->minimum_image(delx,dely,delz); // ghost location fix
+      domain->minimum_image(FLERR, delx,dely,delz); // ghost location fix
       rsq = delx*delx + dely*dely + delz*delz;
       if (rsq < constraints[i][rxnID].par[0] || rsq > constraints[i][rxnID].par[1]) satisfied[i] = 0;
     } else if (constraints[i][rxnID].type == ANGLE) {
@@ -1984,7 +1984,7 @@ int FixBondReact::check_constraints()
       delx1 = x1[0] - x2[0];
       dely1 = x1[1] - x2[1];
       delz1 = x1[2] - x2[2];
-      domain->minimum_image(delx1,dely1,delz1); // ghost location fix
+      domain->minimum_image(FLERR, delx1,dely1,delz1); // ghost location fix
       rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
       r1 = sqrt(rsq1);
 
@@ -1992,7 +1992,7 @@ int FixBondReact::check_constraints()
       delx2 = x3[0] - x2[0];
       dely2 = x3[1] - x2[1];
       delz2 = x3[2] - x2[2];
-      domain->minimum_image(delx2,dely2,delz2); // ghost location fix
+      domain->minimum_image(FLERR, delx2,dely2,delz2); // ghost location fix
       rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
       r2 = sqrt(rsq2);
 
@@ -2012,22 +2012,22 @@ int FixBondReact::check_constraints()
       vb1x = x1[0] - x2[0];
       vb1y = x1[1] - x2[1];
       vb1z = x1[2] - x2[2];
-      domain->minimum_image(vb1x,vb1y,vb1z);
+      domain->minimum_image(FLERR, vb1x,vb1y,vb1z);
 
       vb2x = x3[0] - x2[0];
       vb2y = x3[1] - x2[1];
       vb2z = x3[2] - x2[2];
-      domain->minimum_image(vb2x,vb2y,vb2z);
+      domain->minimum_image(FLERR, vb2x,vb2y,vb2z);
 
       vb2xm = -vb2x;
       vb2ym = -vb2y;
       vb2zm = -vb2z;
-      domain->minimum_image(vb2xm,vb2ym,vb2zm);
+      domain->minimum_image(FLERR, vb2xm,vb2ym,vb2zm);
 
       vb3x = x4[0] - x3[0];
       vb3y = x4[1] - x3[1];
       vb3z = x4[2] - x3[2];
-      domain->minimum_image(vb3x,vb3y,vb3z);
+      domain->minimum_image(FLERR, vb3x,vb3y,vb3z);
 
       ax = vb1y*vb2zm - vb1z*vb2ym;
       ay = vb1z*vb2xm - vb1x*vb2zm;
@@ -3908,7 +3908,7 @@ int FixBondReact::insert_atoms_setup(tagint **my_update_mega_glove, int iupdate)
           delx = coords[m][0] - x[i][0];
           dely = coords[m][1] - x[i][1];
           delz = coords[m][2] - x[i][2];
-          domain->minimum_image(delx,dely,delz);
+          domain->minimum_image(FLERR, delx,dely,delz);
           rsq = delx*delx + dely*dely + delz*delz;
           if (rsq < overlapsq[rxnID]) {
             abortflag = 1;
@@ -3926,7 +3926,7 @@ int FixBondReact::insert_atoms_setup(tagint **my_update_mega_glove, int iupdate)
             delx = coords[m][0] - myaddatom.x[0];
             dely = coords[m][1] - myaddatom.x[1];
             delz = coords[m][2] - myaddatom.x[2];
-            domain->minimum_image(delx,dely,delz);
+            domain->minimum_image(FLERR, delx,dely,delz);
             rsq = delx*delx + dely*dely + delz*delz;
             if (rsq < overlapsq[rxnID]) {
               abortflag = 1;

--- a/src/REPLICA/bosonic_exchange.cpp
+++ b/src/REPLICA/bosonic_exchange.cpp
@@ -87,7 +87,7 @@ void BosonicExchange::diff_two_beads(const double *x1, int l1, const double *x2,
   double delx2 = x2[3 * l2 + 0] - x1[3 * l1 + 0];
   double dely2 = x2[3 * l2 + 1] - x1[3 * l1 + 1];
   double delz2 = x2[3 * l2 + 2] - x1[3 * l1 + 2];
-  if (apply_minimum_image) { domain->minimum_image(delx2, dely2, delz2); }
+  if (apply_minimum_image) { domain->minimum_image(FLERR, delx2, dely2, delz2); }
 
   diff[0] = delx2;
   diff[1] = dely2;

--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -348,7 +348,7 @@ void FixNEB::min_post_force(int /*vflag*/)
         delxp = x[i][0] - xprev[i][0];
         delyp = x[i][1] - xprev[i][1];
         delzp = x[i][2] - xprev[i][2];
-        domain->minimum_image(delxp, delyp, delzp);
+        domain->minimum_image(FLERR, delxp, delyp, delzp);
         plen += delxp * delxp + delyp * delyp + delzp * delzp;
         dottangrad += delxp * f[i][0] + delyp * f[i][1] + delzp * f[i][2];
         gradlen += f[i][0] * f[i][0] + f[i][1] * f[i][1] + f[i][2] * f[i][2];
@@ -368,7 +368,7 @@ void FixNEB::min_post_force(int /*vflag*/)
         delxn = xnext[i][0] - x[i][0];
         delyn = xnext[i][1] - x[i][1];
         delzn = xnext[i][2] - x[i][2];
-        domain->minimum_image(delxn, delyn, delzn);
+        domain->minimum_image(FLERR, delxn, delyn, delzn);
         nlen += delxn * delxn + delyn * delyn + delzn * delzn;
         gradnextlen +=
             fnext[i][0] * fnext[i][0] + fnext[i][1] * fnext[i][1] + fnext[i][2] * fnext[i][2];
@@ -396,13 +396,13 @@ void FixNEB::min_post_force(int /*vflag*/)
         delxp = x[i][0] - xprev[i][0];
         delyp = x[i][1] - xprev[i][1];
         delzp = x[i][2] - xprev[i][2];
-        domain->minimum_image(delxp, delyp, delzp);
+        domain->minimum_image(FLERR, delxp, delyp, delzp);
         plen += delxp * delxp + delyp * delyp + delzp * delzp;
 
         delxn = xnext[i][0] - x[i][0];
         delyn = xnext[i][1] - x[i][1];
         delzn = xnext[i][2] - x[i][2];
-        domain->minimum_image(delxn, delyn, delzn);
+        domain->minimum_image(FLERR, delxn, delyn, delzn);
 
         if (vnext > veng && veng > vprev) {
           tangent[i][0] = delxn;

--- a/src/REPLICA/fix_pimd_nvt.cpp
+++ b/src/REPLICA/fix_pimd_nvt.cpp
@@ -579,13 +579,13 @@ void FixPIMDNVT::spring_force()
     double dely1 = xlast[1] - x[i][1];
     double delz1 = xlast[2] - x[i][2];
     xlast += 3;
-    domain->minimum_image(delx1, dely1, delz1);
+    domain->minimum_image(FLERR, delx1, dely1, delz1);
 
     double delx2 = xnext[0] - x[i][0];
     double dely2 = xnext[1] - x[i][1];
     double delz2 = xnext[2] - x[i][2];
     xnext += 3;
-    domain->minimum_image(delx2, dely2, delz2);
+    domain->minimum_image(FLERR, delx2, dely2, delz2);
 
     double ff = fbond * _mass[type[i]];
 

--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -83,7 +83,7 @@ NEB::NEB(LAMMPS *lmp, double etol_in, double ftol_in, int n1steps_in, int n2step
     delx = buf_final[ii] - buf_init[ii];
     dely = buf_final[ii + 1] - buf_init[ii + 1];
     delz = buf_final[ii + 2] - buf_init[ii + 2];
-    domain->minimum_image(delx, dely, delz);
+    domain->minimum_image(FLERR, delx, dely, delz);
     x[i][0] = buf_init[ii] + fraction * delx;
     x[i][1] = buf_init[ii + 1] + fraction * dely;
     x[i][2] = buf_init[ii + 2] + fraction * delz;
@@ -529,7 +529,7 @@ void NEB::readfile(char *file, int flag)
           dely = values.next_double() - x[m][1];
           delz = values.next_double() - x[m][2];
 
-          domain->minimum_image(delx, dely, delz);
+          domain->minimum_image(FLERR, delx, dely, delz);
 
           if (flag == 0) {
             x[m][0] += fraction * delx;

--- a/src/RIGID/fix_ehex.cpp
+++ b/src/RIGID/fix_ehex.cpp
@@ -434,7 +434,7 @@ bool FixEHEX::check_cluster(tagint *shake_atom, int n, Region *region)
 
       // take into account pbc
 
-      domain->minimum_image_big(xtemp);
+      domain->minimum_image_big(FLERR, xtemp);
 
       for (int k = 0; k < 3; k++) xcom[k] += mi * (x[lid[0]][k] + xtemp[k]);
     }

--- a/src/RIGID/fix_rattle.cpp
+++ b/src/RIGID/fix_rattle.cpp
@@ -248,9 +248,9 @@ void FixRattle::vrattle3angle(int m)
 
   // take into account periodicity
 
-  domain->minimum_image(r01);
-  domain->minimum_image(r02);
-  domain->minimum_image(r12);
+  domain->minimum_image(FLERR, r01);
+  domain->minimum_image(FLERR, r02);
+  domain->minimum_image(FLERR, r12);
 
   // v01,v02,v12 = velocity differences
 
@@ -323,7 +323,7 @@ void FixRattle::vrattle2(int m)
   // r01 = distance vec between atoms, with PBC
 
   MathExtra::sub3(x[i1],x[i0],r01);
-  domain->minimum_image(r01);
+  domain->minimum_image(FLERR, r01);
 
   // v01 = distance vectors for velocities
 
@@ -375,8 +375,8 @@ void FixRattle::vrattle3(int m)
   MathExtra::sub3(x[i1],x[i0],r01);
   MathExtra::sub3(x[i2],x[i0],r02);
 
-  domain->minimum_image(r01);
-  domain->minimum_image(r02);
+  domain->minimum_image(FLERR, r01);
+  domain->minimum_image(FLERR, r02);
 
   // vp01,vp02 =  distance vectors between velocities
 
@@ -446,9 +446,9 @@ void FixRattle::vrattle4(int m)
   MathExtra::sub3(x[i2],x[i0],r02);
   MathExtra::sub3(x[i3],x[i0],r03);
 
-  domain->minimum_image(r01);
-  domain->minimum_image(r02);
-  domain->minimum_image(r03);
+  domain->minimum_image(FLERR, r01);
+  domain->minimum_image(FLERR, r02);
+  domain->minimum_image(FLERR, r03);
 
   // vp01,vp02,vp03 = distance vectors between velocities
 
@@ -828,7 +828,7 @@ bool FixRattle::check2(double **v, int m, bool checkr, bool checkv)
   tagint i1 = atom->map(shake_atom[m][1]);
 
   MathExtra::sub3(x[i1],x[i0],r01);
-  domain->minimum_image(r01);
+  domain->minimum_image(FLERR, r01);
   MathExtra::sub3(v[i1],v[i0],v01);
 
   stat = !checkr || (fabs(sqrt(MathExtra::dot3(r01,r01)) - bond1) <= tol);
@@ -857,8 +857,8 @@ bool FixRattle::check3(double **v, int m, bool checkr, bool checkv)
   MathExtra::sub3(x[i1],x[i0],r01);
   MathExtra::sub3(x[i2],x[i0],r02);
 
-  domain->minimum_image(r01);
-  domain->minimum_image(r02);
+  domain->minimum_image(FLERR, r01);
+  domain->minimum_image(FLERR, r02);
 
   MathExtra::sub3(v[i1],v[i0],v01);
   MathExtra::sub3(v[i2],v[i0],v02);
@@ -893,9 +893,9 @@ bool FixRattle::check4(double **v, int m, bool checkr, bool checkv)
   MathExtra::sub3(x[i2],x[i0],r02);
   MathExtra::sub3(x[i3],x[i0],r03);
 
-  domain->minimum_image(r01);
-  domain->minimum_image(r02);
-  domain->minimum_image(r03);
+  domain->minimum_image(FLERR, r01);
+  domain->minimum_image(FLERR, r02);
+  domain->minimum_image(FLERR, r03);
 
   MathExtra::sub3(v[i1],v[i0],v01);
   MathExtra::sub3(v[i2],v[i0],v02);
@@ -932,9 +932,9 @@ bool FixRattle::check3angle(double **v, int m, bool checkr, bool checkv)
   MathExtra::sub3(x[i2],x[i0],r02);
   MathExtra::sub3(x[i2],x[i1],r12);
 
-  domain->minimum_image(r01);
-  domain->minimum_image(r02);
-  domain->minimum_image(r12);
+  domain->minimum_image(FLERR, r01);
+  domain->minimum_image(FLERR, r02);
+  domain->minimum_image(FLERR, r12);
 
   MathExtra::sub3(v[i1],v[i0],v01);
   MathExtra::sub3(v[i2],v[i0],v02);

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -2180,7 +2180,7 @@ void FixRigidSmall::setup_bodies_static()
     xgc = body[ibody].xgc;
     double delta[3];
     MathExtra::sub3(xgc,xcm,delta);
-    domain->minimum_image_big(delta);
+    domain->minimum_image_big(FLERR, delta);
     MathExtra::transpose_matvec(ex,ey,ez,delta,body[ibody].xgc_body);
     MathExtra::add3(xcm,delta,xgc);
   }

--- a/src/YAFF/angle_cross.cpp
+++ b/src/YAFF/angle_cross.cpp
@@ -318,13 +318,13 @@ double AngleCross::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/YAFF/angle_mm3.cpp
+++ b/src/YAFF/angle_mm3.cpp
@@ -260,13 +260,13 @@ double AngleMM3::single(int type, int i1, int i2, int i3)
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;
@@ -297,13 +297,13 @@ void AngleMM3::born_matrix(int type, int i1, int i2, int i3, double &du, double 
   double delx1 = x[i1][0] - x[i2][0];
   double dely1 = x[i1][1] - x[i2][1];
   double delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
   double r1 = sqrt(delx1*delx1 + dely1*dely1 + delz1*delz1);
 
   double delx2 = x[i3][0] - x[i2][0];
   double dely2 = x[i3][1] - x[i2][1];
   double delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
   double r2 = sqrt(delx2*delx2 + dely2*dely2 + delz2*delz2);
 
   double c = delx1*delx2 + dely1*dely2 + delz1*delz2;

--- a/src/YAFF/improper_distharm.cpp
+++ b/src/YAFF/improper_distharm.cpp
@@ -94,37 +94,37 @@ void ImproperDistHarm::compute(int eflag, int vflag)
     xab = x[i2][0] - x[i1][0];
     yab = x[i2][1] - x[i1][1];
     zab = x[i2][2] - x[i1][2];
-    domain->minimum_image(xab,yab,zab);
+    domain->minimum_image(FLERR, xab,yab,zab);
 
     // bond 1->3
     xac = x[i3][0] - x[i1][0];
     yac = x[i3][1] - x[i1][1];
     zac = x[i3][2] - x[i1][2];
-    domain->minimum_image(xac,yac,zac);
+    domain->minimum_image(FLERR, xac,yac,zac);
 
     // bond 1->4
     xad = x[i4][0] - x[i1][0];
     yad = x[i4][1] - x[i1][1];
     zad = x[i4][2] - x[i1][2];
-    domain->minimum_image(xad,yad,zad);
+    domain->minimum_image(FLERR, xad,yad,zad);
 
     // bond 2-3
     xbc = x[i3][0] - x[i2][0];
     ybc = x[i3][1] - x[i2][1];
     zbc = x[i3][2] - x[i2][2];
-    domain->minimum_image(xbc,ybc,zbc);
+    domain->minimum_image(FLERR, xbc,ybc,zbc);
 
     // bond 2-4
     xbd = x[i4][0] - x[i2][0];
     ybd = x[i4][1] - x[i2][1];
     zbd = x[i4][2] - x[i2][2];
-    domain->minimum_image(xbd,ybd,zbd);
+    domain->minimum_image(FLERR, xbd,ybd,zbd);
 
     // bond 3-4
     xcd = x[i4][0] - x[i3][0];
     ycd = x[i4][1] - x[i3][1];
     zcd = x[i4][2] - x[i3][2];
-    domain->minimum_image(xcd,ycd,zcd);
+    domain->minimum_image(FLERR, xcd,ycd,zcd);
 
     xna =   ybc*zcd - zbc*ycd;
     yna = -(xbc*zcd - zbc*xcd);

--- a/src/YAFF/improper_sqdistharm.cpp
+++ b/src/YAFF/improper_sqdistharm.cpp
@@ -94,37 +94,37 @@ void ImproperSQDistHarm::compute(int eflag, int vflag)
     xab = x[i2][0] - x[i1][0];
     yab = x[i2][1] - x[i1][1];
     zab = x[i2][2] - x[i1][2];
-    domain->minimum_image(xab,yab,zab);
+    domain->minimum_image(FLERR, xab,yab,zab);
 
     // bond 1->3
     xac = x[i3][0] - x[i1][0];
     yac = x[i3][1] - x[i1][1];
     zac = x[i3][2] - x[i1][2];
-    domain->minimum_image(xac,yac,zac);
+    domain->minimum_image(FLERR, xac,yac,zac);
 
     // bond 1->4
     xad = x[i4][0] - x[i1][0];
     yad = x[i4][1] - x[i1][1];
     zad = x[i4][2] - x[i1][2];
-    domain->minimum_image(xad,yad,zad);
+    domain->minimum_image(FLERR, xad,yad,zad);
 
     // bond 2-3
     xbc = x[i3][0] - x[i2][0];
     ybc = x[i3][1] - x[i2][1];
     zbc = x[i3][2] - x[i2][2];
-    domain->minimum_image(xbc,ybc,zbc);
+    domain->minimum_image(FLERR, xbc,ybc,zbc);
 
     // bond 2-4
     xbd = x[i4][0] - x[i2][0];
     ybd = x[i4][1] - x[i2][1];
     zbd = x[i4][2] - x[i2][2];
-    domain->minimum_image(xbd,ybd,zbd);
+    domain->minimum_image(FLERR, xbd,ybd,zbd);
 
     // bond 3-4
     xcd = x[i4][0] - x[i3][0];
     ycd = x[i4][1] - x[i3][1];
     zcd = x[i4][2] - x[i3][2];
-    domain->minimum_image(xcd,ycd,zcd);
+    domain->minimum_image(FLERR, xcd,ycd,zcd);
 
     xna =   ybc*zcd - zbc*ycd;
     yna = -(xbc*zcd - zbc*xcd);

--- a/src/compute_angle_local.cpp
+++ b/src/compute_angle_local.cpp
@@ -263,7 +263,7 @@ int ComputeAngleLocal::compute_angles(int flag)
         delx1 = x[atom1][0] - x[atom2][0];
         dely1 = x[atom1][1] - x[atom2][1];
         delz1 = x[atom1][2] - x[atom2][2];
-        domain->minimum_image(delx1, dely1, delz1);
+        domain->minimum_image(FLERR, delx1, dely1, delz1);
 
         rsq1 = delx1 * delx1 + dely1 * dely1 + delz1 * delz1;
         r1 = sqrt(rsq1);
@@ -271,7 +271,7 @@ int ComputeAngleLocal::compute_angles(int flag)
         delx2 = x[atom3][0] - x[atom2][0];
         dely2 = x[atom3][1] - x[atom2][1];
         delz2 = x[atom3][2] - x[atom2][2];
-        domain->minimum_image(delx2, dely2, delz2);
+        domain->minimum_image(FLERR, delx2, dely2, delz2);
 
         rsq2 = delx2 * delx2 + dely2 * dely2 + delz2 * delz2;
         r2 = sqrt(rsq2);

--- a/src/compute_bond_local.cpp
+++ b/src/compute_bond_local.cpp
@@ -344,7 +344,7 @@ int ComputeBondLocal::compute_bonds(int flag)
       dx = x[atom1][0] - x[atom2][0];
       dy = x[atom1][1] - x[atom2][1];
       dz = x[atom1][2] - x[atom2][2];
-      domain->minimum_image(dx, dy, dz);
+      domain->minimum_image(FLERR, dx, dy, dz);
       rsq = dx * dx + dy * dy + dz * dz;
 
       if (btype == 0) {

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -1877,7 +1877,7 @@ void ComputeChunkAtom::atom2binsphere()
     // if requested, apply PBC to distance from sphere center
     // treat orthogonal and triclinic the same
     //   with dx,dy,dz = lengths independent of each other
-    // so do not use domain->minimum_image() which couples for triclinic
+    // so do not use domain->minimum_image(FLERR, ) which couples for triclinic
 
     if (pbcflag) {
       if (periodicity[0]) {

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -1877,7 +1877,7 @@ void ComputeChunkAtom::atom2binsphere()
     // if requested, apply PBC to distance from sphere center
     // treat orthogonal and triclinic the same
     //   with dx,dy,dz = lengths independent of each other
-    // so do not use domain->minimum_image(FLERR, ) which couples for triclinic
+    // so do not use domain->minimum_image() which couples for triclinic
 
     if (pbcflag) {
       if (periodicity[0]) {

--- a/src/compute_dihedral_local.cpp
+++ b/src/compute_dihedral_local.cpp
@@ -252,22 +252,22 @@ int ComputeDihedralLocal::compute_dihedrals(int flag)
       vb1x = x[atom1][0] - x[atom2][0];
       vb1y = x[atom1][1] - x[atom2][1];
       vb1z = x[atom1][2] - x[atom2][2];
-      domain->minimum_image(vb1x, vb1y, vb1z);
+      domain->minimum_image(FLERR, vb1x, vb1y, vb1z);
 
       vb2x = x[atom3][0] - x[atom2][0];
       vb2y = x[atom3][1] - x[atom2][1];
       vb2z = x[atom3][2] - x[atom2][2];
-      domain->minimum_image(vb2x, vb2y, vb2z);
+      domain->minimum_image(FLERR, vb2x, vb2y, vb2z);
 
       vb2xm = -vb2x;
       vb2ym = -vb2y;
       vb2zm = -vb2z;
-      domain->minimum_image(vb2xm, vb2ym, vb2zm);
+      domain->minimum_image(FLERR, vb2xm, vb2ym, vb2zm);
 
       vb3x = x[atom4][0] - x[atom3][0];
       vb3y = x[atom4][1] - x[atom3][1];
       vb3z = x[atom4][2] - x[atom3][2];
-      domain->minimum_image(vb3x, vb3y, vb3z);
+      domain->minimum_image(FLERR, vb3x, vb3y, vb3z);
 
       ax = vb1y * vb2zm - vb1z * vb2ym;
       ay = vb1z * vb2xm - vb1x * vb2zm;

--- a/src/compute_improper_local.cpp
+++ b/src/compute_improper_local.cpp
@@ -183,17 +183,17 @@ int ComputeImproperLocal::compute_impropers(int flag)
           vb1x = x[atom1][0] - x[atom2][0];
           vb1y = x[atom1][1] - x[atom2][1];
           vb1z = x[atom1][2] - x[atom2][2];
-          domain->minimum_image(vb1x, vb1y, vb1z);
+          domain->minimum_image(FLERR, vb1x, vb1y, vb1z);
 
           vb2x = x[atom3][0] - x[atom2][0];
           vb2y = x[atom3][1] - x[atom2][1];
           vb2z = x[atom3][2] - x[atom2][2];
-          domain->minimum_image(vb2x, vb2y, vb2z);
+          domain->minimum_image(FLERR, vb2x, vb2y, vb2z);
 
           vb3x = x[atom4][0] - x[atom3][0];
           vb3y = x[atom4][1] - x[atom3][1];
           vb3z = x[atom4][2] - x[atom3][2];
-          domain->minimum_image(vb3x, vb3y, vb3z);
+          domain->minimum_image(FLERR, vb3x, vb3y, vb3z);
 
           ss1 = 1.0 / (vb1x * vb1x + vb1y * vb1y + vb1z * vb1z);
           ss2 = 1.0 / (vb2x * vb2x + vb2y * vb2y + vb2z * vb2z);

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -875,7 +875,7 @@ void CreateAtoms::add_random()
             delx = xone[0] - x[i][0];
             dely = xone[1] - x[i][1];
             delz = xone[2] - x[i][2];
-            domain->minimum_image(delx, dely, delz);
+            domain->minimum_image(FLERR, delx, dely, delz);
             distsq = delx * delx + dely * dely + delz * delz;
             if (distsq < odistsq) {
               reject = 1;
@@ -891,7 +891,7 @@ void CreateAtoms::add_random()
               delx = xmol[j][0] - x[i][0];
               dely = xmol[j][1] - x[i][1];
               delz = xmol[j][2] - x[i][2];
-              domain->minimum_image(delx, dely, delz);
+              domain->minimum_image(FLERR, delx, dely, delz);
               distsq = delx * delx + dely * dely + delz * delz;
               if (distsq < odistsq) {
                 reject = 1;

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -1136,7 +1136,7 @@ void Domain::box_too_small_check()
       delx = x[i][0] - x[k][0];
       dely = x[i][1] - x[k][1];
       delz = x[i][2] - x[k][2];
-      minimum_image(delx,dely,delz);
+      minimum_image(FLERR, delx,dely,delz);
       rsq = delx*delx + dely*dely + delz*delz;
       maxbondme = MAX(maxbondme,rsq);
     }
@@ -1205,6 +1205,7 @@ void Domain::subbox_too_small_check(double thresh)
                    "could lead to lost atoms");
 }
 
+// clang-format on
 /* ----------------------------------------------------------------------
    minimum image convention in periodic dimensions
    use 1/2 of box size as test
@@ -1218,39 +1219,45 @@ void Domain::subbox_too_small_check(double thresh)
 ------------------------------------------------------------------------- */
 
 static constexpr double MAXIMGCOUNT = 16;
-
-void Domain::minimum_image(double &dx, double &dy, double &dz) const
+void Domain::minimum_image(const std::string &file, int line, double &dx, double &dy,
+                           double &dz) const
 {
   if (triclinic == 0) {
     if (xperiodic) {
       if (fabs(dx) > (MAXIMGCOUNT * xprd))
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dx);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dx);
       while (fabs(dx) > xprd_half) {
-        if (dx < 0.0) dx += xprd;
-        else dx -= xprd;
+        if (dx < 0.0)
+          dx += xprd;
+        else
+          dx -= xprd;
       }
     }
     if (yperiodic) {
       if (fabs(dy) > (MAXIMGCOUNT * yprd))
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dy);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dy);
       while (fabs(dy) > yprd_half) {
-        if (dy < 0.0) dy += yprd;
-        else dy -= yprd;
+        if (dy < 0.0)
+          dy += yprd;
+        else
+          dy -= yprd;
       }
     }
     if (zperiodic) {
       if (fabs(dz) > (MAXIMGCOUNT * zprd))
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dz);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dz);
       while (fabs(dz) > zprd_half) {
-        if (dz < 0.0) dz += zprd;
-        else dz -= zprd;
+        if (dz < 0.0)
+          dz += zprd;
+        else
+          dz -= zprd;
       }
     }
 
   } else {
     if (zperiodic) {
       if (fabs(dz) > (MAXIMGCOUNT * zprd))
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dz);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dz);
       while (fabs(dz) > zprd_half) {
         if (dz < 0.0) {
           dz += zprd;
@@ -1265,7 +1272,7 @@ void Domain::minimum_image(double &dx, double &dy, double &dz) const
     }
     if (yperiodic) {
       if (fabs(dy) > (MAXIMGCOUNT * yprd))
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dy);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dy);
       while (fabs(dy) > yprd_half) {
         if (dy < 0.0) {
           dy += yprd;
@@ -1278,10 +1285,12 @@ void Domain::minimum_image(double &dx, double &dy, double &dz) const
     }
     if (xperiodic) {
       if (fabs(dx) > (MAXIMGCOUNT * xprd))
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dx);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dx);
       while (fabs(dx) > xprd_half) {
-        if (dx < 0.0) dx += xprd;
-        else dx -= xprd;
+        if (dx < 0.0)
+          dx += xprd;
+        else
+          dx -= xprd;
       }
     }
   }
@@ -1298,61 +1307,63 @@ void Domain::minimum_image(double &dx, double &dy, double &dz) const
      this applies for example to fix rigid/small
 ------------------------------------------------------------------------- */
 
-void Domain::minimum_image_big(double &dx, double &dy, double &dz) const
+void Domain::minimum_image_big(const std::string &file, int line, double &dx, double &dy,
+                               double &dz) const
 {
   if (triclinic == 0) {
     if (xperiodic) {
-      double dfactor = dx/xprd + 0.5;
+      double dfactor = dx / xprd + 0.5;
       if (dx < 0) dfactor -= 1.0;
       if (dfactor > MAXSMALLINT)
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dx);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dx);
       dx -= xprd * static_cast<int>(dfactor);
     }
     if (yperiodic) {
-      double dfactor = dy/yprd + 0.5;
+      double dfactor = dy / yprd + 0.5;
       if (dy < 0) dfactor -= 1.0;
       if (dfactor > MAXSMALLINT)
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dy);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dy);
       dy -= yprd * static_cast<int>(dfactor);
     }
     if (zperiodic) {
-      double dfactor = dz/zprd + 0.5;
+      double dfactor = dz / zprd + 0.5;
       if (dz < 0) dfactor -= 1.0;
       if (dfactor > MAXSMALLINT)
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dz);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dz);
       dz -= zprd * static_cast<int>(dfactor);
     }
 
   } else {
     if (zperiodic) {
-      double dfactor = dz/zprd + 0.5;
+      double dfactor = dz / zprd + 0.5;
       if (dz < 0) dfactor -= 1.0;
       if (dfactor > MAXSMALLINT)
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dz);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dz);
       int factor = static_cast<int>(dfactor);
       dz -= zprd * factor;
       dy -= yz * factor;
       dx -= xz * factor;
     }
     if (yperiodic) {
-      double dfactor = dy/yprd + 0.5;
+      double dfactor = dy / yprd + 0.5;
       if (dy < 0) dfactor -= 1.0;
       if (dfactor > MAXSMALLINT)
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dy);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dy);
       int factor = static_cast<int>(dfactor);
       dy -= yprd * factor;
       dx -= xy * factor;
     }
     if (xperiodic) {
-      double dfactor = dx/xprd + 0.5;
+      double dfactor = dx / xprd + 0.5;
       if (dx < 0) dfactor -= 1.0;
       if (dfactor > MAXSMALLINT)
-        error->one(FLERR, "Atoms have moved too far apart ({}) for minimum image\n", dx);
+        error->one(file, line, "Atoms have moved too far apart ({}) for minimum image\n", dx);
       dx -= xprd * static_cast<int>(dfactor);
     }
   }
 }
 
+// clang-format off
 /* ----------------------------------------------------------------------
    return local index of atom J or any of its images that is closest to atom I
    if J is not a valid index like -1, just return it

--- a/src/domain.h
+++ b/src/domain.h
@@ -127,10 +127,16 @@ class Domain : protected Pointers {
   void image_check();
   void box_too_small_check();
   void subbox_too_small_check(double);
-  void minimum_image(double &, double &, double &) const;
-  void minimum_image(double *delta) const { minimum_image(delta[0], delta[1], delta[2]); }
-  void minimum_image_big(double &, double &, double &) const;
-  void minimum_image_big(double *delta) const { minimum_image_big(delta[0], delta[1], delta[2]); }
+  void minimum_image(const std::string &, int, double &, double &, double &) const;
+  void minimum_image(const std::string &file, int line, double *delta) const
+  {
+    minimum_image(file, line, delta[0], delta[1], delta[2]);
+  }
+  void minimum_image_big(const std::string &, int, double &, double &, double &) const;
+  void minimum_image_big(const std::string &file, int line, double *delta) const
+  {
+    minimum_image_big(file, line, delta[0], delta[1], delta[2]);
+  }
   int closest_image(int, int);
   int closest_image(const double *const, int);
   void closest_image(const double *const, const double *const, double *const);
@@ -185,7 +191,7 @@ class Domain : protected Pointers {
   //   but is a far-away image that should be treated as an unbonded neighbor
   // inline since called from neighbor build inner loop
 
-  inline int minimum_image_check(double dx, double dy, double dz)
+  inline int minimum_image_check(double dx, double dy, double dz) const
   {
     if (xperiodic && fabs(dx) > xprd_half) return 1;
     if (yperiodic && fabs(dy) > yprd_half) return 1;

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -1245,7 +1245,7 @@ void DumpImage::create_image()
         delz = x[atom2][2] - x[atom1][2];
 
         if (bcolor == ATOM || domain->minimum_image_check(delx,dely,delz)) {
-          domain->minimum_image(delx,dely,delz);
+          domain->minimum_image(FLERR, delx,dely,delz);
           xmid[0] = x[atom1][0] + 0.5*delx;
           xmid[1] = x[atom1][1] + 0.5*dely;
           xmid[2] = x[atom1][2] + 0.5*delz;

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -401,7 +401,7 @@ void FixDeposit::pre_exchange()
           delx = coord[0] - x[i][0];
           dely = coord[1] - x[i][1];
           delz = 0.0;
-          domain->minimum_image(delx,dely,delz);
+          domain->minimum_image(FLERR, delx,dely,delz);
           if (dimension == 2) rsq = delx*delx;
           else rsq = delx*delx + dely*dely;
           if (rsq > deltasq) continue;
@@ -476,7 +476,7 @@ void FixDeposit::pre_exchange()
         delx = coords[m][0] - x[i][0];
         dely = coords[m][1] - x[i][1];
         delz = coords[m][2] - x[i][2];
-        domain->minimum_image(delx,dely,delz);
+        domain->minimum_image(FLERR, delx,dely,delz);
         rsq = delx*delx + dely*dely + delz*delz;
         if (rsq < nearsq) flag = 1;
       }

--- a/src/fix_indent.cpp
+++ b/src/fix_indent.cpp
@@ -273,7 +273,7 @@ void FixIndent::post_force(int /*vflag*/)
         delx = x[i][0] - ctr[0];
         dely = x[i][1] - ctr[1];
         delz = x[i][2] - ctr[2];
-        domain->minimum_image(delx, dely, delz);
+        domain->minimum_image(FLERR, delx, dely, delz);
         r = sqrt(delx * delx + dely * dely + delz * delz);
         if (side == OUTSIDE) {
           dr = r - radius;
@@ -313,7 +313,7 @@ void FixIndent::post_force(int /*vflag*/)
       if (mask[i] & groupbit) {
         double del[3] = {x[i][0] - ctr[0], x[i][1] - ctr[1], x[i][2] - ctr[2]};
         del[cdim] = 0;
-        domain->minimum_image(del[0], del[1], del[2]);
+        domain->minimum_image(FLERR, del[0], del[1], del[2]);
         r = sqrt(del[0] * del[0] + del[1] * del[1] + del[2] * del[2]);
         if (side == OUTSIDE) {
           dr = r - radius;
@@ -360,7 +360,7 @@ void FixIndent::post_force(int /*vflag*/)
         delx = x[i][0] - ctr[0];
         dely = x[i][1] - ctr[1];
         delz = x[i][2] - ctr[2];
-        domain->minimum_image(delx, dely, delz);
+        domain->minimum_image(FLERR, delx, dely, delz);
 
         double x0[3] = {delx + ctr[0], dely + ctr[1], delz + ctr[2]};
         r = sqrt(delx * delx + dely * dely + delz * delz);

--- a/src/fix_minimize.cpp
+++ b/src/fix_minimize.cpp
@@ -119,7 +119,7 @@ void FixMinimize::reset_coords()
     dx = dx0 = x[i][0] - x0[n];
     dy = dy0 = x[i][1] - x0[n+1];
     dz = dz0 = x[i][2] - x0[n+2];
-    domain->minimum_image(dx,dy,dz);
+    domain->minimum_image(FLERR, dx,dy,dz);
     if (dx != dx0) x0[n] = x[i][0] - dx;
     if (dy != dy0) x0[n+1] = x[i][1] - dy;
     if (dz != dz0) x0[n+2] = x[i][2] - dz;

--- a/src/fix_restrain.cpp
+++ b/src/fix_restrain.cpp
@@ -284,7 +284,7 @@ void FixRestrain::restrain_bond(int m)
   delx = x[i1][0] - x[i2][0];
   dely = x[i1][1] - x[i2][1];
   delz = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx,dely,delz);
+  domain->minimum_image(FLERR, delx,dely,delz);
 
   rsq = delx*delx + dely*dely + delz*delz;
   r = sqrt(rsq);
@@ -357,7 +357,7 @@ void FixRestrain::restrain_lbound(int m)
   delx = x[i1][0] - x[i2][0];
   dely = x[i1][1] - x[i2][1];
   delz = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx,dely,delz);
+  domain->minimum_image(FLERR, delx,dely,delz);
 
   rsq = delx*delx + dely*dely + delz*delz;
   r = sqrt(rsq);
@@ -442,7 +442,7 @@ void FixRestrain::restrain_angle(int m)
   delx1 = x[i1][0] - x[i2][0];
   dely1 = x[i1][1] - x[i2][1];
   delz1 = x[i1][2] - x[i2][2];
-  domain->minimum_image(delx1,dely1,delz1);
+  domain->minimum_image(FLERR, delx1,dely1,delz1);
 
   rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
   r1 = sqrt(rsq1);
@@ -452,7 +452,7 @@ void FixRestrain::restrain_angle(int m)
   delx2 = x[i3][0] - x[i2][0];
   dely2 = x[i3][1] - x[i2][1];
   delz2 = x[i3][2] - x[i2][2];
-  domain->minimum_image(delx2,dely2,delz2);
+  domain->minimum_image(FLERR, delx2,dely2,delz2);
 
   rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
   r2 = sqrt(rsq2);
@@ -564,26 +564,26 @@ void FixRestrain::restrain_dihedral(int m)
   vb1x = x[i1][0] - x[i2][0];
   vb1y = x[i1][1] - x[i2][1];
   vb1z = x[i1][2] - x[i2][2];
-  domain->minimum_image(vb1x,vb1y,vb1z);
+  domain->minimum_image(FLERR, vb1x,vb1y,vb1z);
 
   // 2nd bond
 
   vb2x = x[i3][0] - x[i2][0];
   vb2y = x[i3][1] - x[i2][1];
   vb2z = x[i3][2] - x[i2][2];
-  domain->minimum_image(vb2x,vb2y,vb2z);
+  domain->minimum_image(FLERR, vb2x,vb2y,vb2z);
 
   vb2xm = -vb2x;
   vb2ym = -vb2y;
   vb2zm = -vb2z;
-  domain->minimum_image(vb2xm,vb2ym,vb2zm);
+  domain->minimum_image(FLERR, vb2xm,vb2ym,vb2zm);
 
   // 3rd bond
 
   vb3x = x[i4][0] - x[i3][0];
   vb3y = x[i4][1] - x[i3][1];
   vb3z = x[i4][2] - x[i3][2];
-  domain->minimum_image(vb3x,vb3y,vb3z);
+  domain->minimum_image(FLERR, vb3x,vb3y,vb3z);
 
   ax = vb1y*vb2zm - vb1z*vb2ym;
   ay = vb1z*vb2xm - vb1x*vb2zm;

--- a/src/ntopo.cpp
+++ b/src/ntopo.cpp
@@ -109,7 +109,7 @@ void NTopo::bond_check()
     dxstart = dx = x[i][0] - x[j][0];
     dystart = dy = x[i][1] - x[j][1];
     dzstart = dz = x[i][2] - x[j][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
   }
 
@@ -138,17 +138,17 @@ void NTopo::angle_check()
     dxstart = dx = x[i][0] - x[j][0];
     dystart = dy = x[i][1] - x[j][1];
     dzstart = dz = x[i][2] - x[j][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
     dxstart = dx = x[i][0] - x[k][0];
     dystart = dy = x[i][1] - x[k][1];
     dzstart = dz = x[i][2] - x[k][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
     dxstart = dx = x[j][0] - x[k][0];
     dystart = dy = x[j][1] - x[k][1];
     dzstart = dz = x[j][2] - x[k][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
   }
 
@@ -178,32 +178,32 @@ void NTopo::dihedral_check(int nlist, int **list)
     dxstart = dx = x[i][0] - x[j][0];
     dystart = dy = x[i][1] - x[j][1];
     dzstart = dz = x[i][2] - x[j][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
     dxstart = dx = x[i][0] - x[k][0];
     dystart = dy = x[i][1] - x[k][1];
     dzstart = dz = x[i][2] - x[k][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
     dxstart = dx = x[i][0] - x[l][0];
     dystart = dy = x[i][1] - x[l][1];
     dzstart = dz = x[i][2] - x[l][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
     dxstart = dx = x[j][0] - x[k][0];
     dystart = dy = x[j][1] - x[k][1];
     dzstart = dz = x[j][2] - x[k][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
     dxstart = dx = x[j][0] - x[l][0];
     dystart = dy = x[j][1] - x[l][1];
     dzstart = dz = x[j][2] - x[l][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
     dxstart = dx = x[k][0] - x[l][0];
     dystart = dy = x[k][1] - x[l][1];
     dzstart = dz = x[k][2] - x[l][2];
-    domain->minimum_image(dx, dy, dz);
+    domain->minimum_image(FLERR, dx, dy, dz);
     if (dx != dxstart || dy != dystart || dz != dzstart) flag = 1;
   }
 


### PR DESCRIPTION
**Summary**

This pull request adds the FLERR macro as first argument to `Domain::minimum_image()` and `Domain::minimum_image_big()` and thus improves the error messages by indicating *where* the minimum image function was called. This will help to identify the origin or the error faster.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

All internal uses of the two functions have been updated. External LAMMPS packages may need updates.

**Implementation Notes**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
