### PR TITLE
Fix GPU architecture in CUDA preset for Kokkos

### DIFF
--- a/cmake/presets/kokkos-cuda.cmake
+++ b/cmake/presets/kokkos-cuda.cmake
@@ -1,9 +1,8 @@
 # preset that enables KOKKOS and selects CUDA compilation with OpenMP
-# enabled as well. The GPU architecture *must* match your hardware
+# enabled as well. The GPU architecture *must* match your hardware (If not manually set, Kokkos will try to autodetect it).
 set(PKG_KOKKOS ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_CUDA   ON CACHE BOOL "" FORCE)
-set(Kokkos_ARCH_PASCAL60 ON CACHE BOOL "" FORCE)
 set(BUILD_OMP ON CACHE BOOL "" FORCE)
 get_filename_component(NVCC_WRAPPER_CMD ${CMAKE_CURRENT_SOURCE_DIR}/../lib/kokkos/bin/nvcc_wrapper ABSOLUTE)
 set(CMAKE_CXX_COMPILER ${NVCC_WRAPPER_CMD} CACHE FILEPATH "" FORCE)


### PR DESCRIPTION
**Summary**

This pull request removes the line `set(Kokkos_ARCH_PASCAL60 ON CACHE BOOL "" FORCE)` from the `cmake/presets/kokkos-cuda.cmake` preset file. This change ensures Kokkos automatically detects and selects the appropriate GPU architecture rather than forcing a specific one.

**Related Issue(s)**

N/A

**Author(s)**

Ethan Puyaubreau - ORNL
ethan.puyaubreau@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

No changes in this pull request introduce backward incompatibility for inputs.

**Implementation Notes**

The line `set(Kokkos_ARCH_PASCAL60 ON CACHE BOOL "" FORCE)` in the `kokkos-cuda.cmake` preset file forced the Kokkos build to target the Pascal 6.0 GPU architecture. This might not be the intended behavior for a flexible CUDA preset, as users might have different GPU architectures. By removing this line, Kokkos's build system is now allowed to automatically determine and select the compatible GPU architecture for the compilation environment. 

This change was verified by successfully compiling LAMMPS using this modified preset on a system with a non-Pascal GPU (my system being a Ampere one), confirming that Kokkos correctly identified and utilized the available hardware.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

N/A